### PR TITLE
fix(agents): repair polluted auto-fallback origins so snap-back probes can fire

### DIFF
--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -488,6 +488,7 @@ vi.mock("./agent-scope.js", () => ({
   hasLegacyAutoFallbackWithoutOrigin: (entry: unknown) =>
     state.hasLegacyAutoFallbackWithoutOriginMock(entry),
   hasSessionAutoModelFallbackProvenance: () => false,
+  isStaleAutoFallbackOriginOverride: () => false,
   listAgentEntries: () => [],
   listAgentIds: () => ["default"],
   markAutoFallbackPrimaryProbe: vi.fn(),

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -483,6 +483,7 @@ vi.mock("../utils/message-channel.js", () => ({
 }));
 
 vi.mock("./agent-scope.js", () => ({
+  classifyStaleAutoFallbackOriginOverride: () => null,
   clearAutoFallbackPrimaryProbeSelection: vi.fn(),
   entryMatchesAutoFallbackPrimaryProbe: () => true,
   hasLegacyAutoFallbackWithoutOrigin: (entry: unknown) =>

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -489,6 +489,7 @@ vi.mock("./agent-scope.js", () => ({
     state.hasLegacyAutoFallbackWithoutOriginMock(entry),
   hasSessionAutoModelFallbackProvenance: () => false,
   isStaleAutoFallbackOriginOverride: () => false,
+  matchesStaleAutoFallbackOriginRepairSnapshot: () => true,
   listAgentEntries: () => [],
   listAgentIds: () => ["default"],
   markAutoFallbackPrimaryProbe: vi.fn(),

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -7,6 +7,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
 import { withEnv } from "../test-utils/env.js";
 import {
+  classifyStaleAutoFallbackOriginOverride,
   clearAutoFallbackPrimaryProbeSelection,
   hasLegacyAutoFallbackWithoutOrigin,
   isStaleAutoFallbackOriginOverride,
@@ -548,14 +549,43 @@ describe("resolveAgentConfig", () => {
       modelOverrideFallbackOriginModel: "claude-opus-4-7",
     };
 
-    // Origin equals the override and differs from the current primary → polluted.
+    // Origin equals the override and differs from the current primary → clear override.
     expect(isStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-opus-4-8")).toBe(true);
     expect(isStaleAutoFallbackOriginOverride(entry, "openai", "gpt-5.5")).toBe(true);
+    expect(classifyStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-opus-4-8")).toBe(
+      "clear-override",
+    );
     // Origin already matches the primary → nothing to repair.
     expect(isStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-opus-4-7")).toBe(false);
+    expect(
+      classifyStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-opus-4-7"),
+    ).toBeNull();
   });
 
-  it("does not treat user overrides, missing origins, or legitimate primary changes as stale", () => {
+  it("detects the canonical three-distinct origin state for origin-only repair", () => {
+    const entry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: 1,
+      providerOverride: "anthropic",
+      modelOverride: "claude-opus-4-7",
+      modelOverrideSource: "auto",
+      modelOverrideFallbackOriginProvider: "anthropic",
+      modelOverrideFallbackOriginModel: "claude-haiku-4-5",
+    };
+
+    // Canonical #92776 state: origin, override, and primary are all different.
+    expect(isStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-opus-4-8")).toBe(true);
+    expect(classifyStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-opus-4-8")).toBe(
+      "repair-origin",
+    );
+    // Origin matches the primary → nothing to repair.
+    expect(isStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-haiku-4-5")).toBe(false);
+    expect(
+      classifyStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-haiku-4-5"),
+    ).toBeNull();
+  });
+
+  it("does not treat user overrides, missing origins, or origin-matching primaries as stale", () => {
     const pollutedEntry: SessionEntry = {
       sessionId: "session",
       updatedAt: 1,
@@ -576,24 +606,15 @@ describe("resolveAgentConfig", () => {
       modelOverride: "claude-opus-4-7",
       modelOverrideSource: "auto",
     };
-    const changedPrimaryEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: 1,
-      providerOverride: "anthropic",
-      modelOverride: "claude-opus-4-7",
-      modelOverrideSource: "auto",
-      modelOverrideFallbackOriginProvider: "openai",
-      modelOverrideFallbackOriginModel: "gpt-5.4",
-    };
 
     expect(isStaleAutoFallbackOriginOverride(userEntry, "anthropic", "gpt-5.5")).toBe(false);
+    expect(classifyStaleAutoFallbackOriginOverride(userEntry, "anthropic", "gpt-5.5")).toBeNull();
     expect(isStaleAutoFallbackOriginOverride(missingOriginEntry, "anthropic", "gpt-5.5")).toBe(
       false,
     );
-    // Origin differs from both the override and the current primary → legitimate mismatch guard.
     expect(
-      isStaleAutoFallbackOriginOverride(changedPrimaryEntry, "anthropic", "claude-opus-4-8"),
-    ).toBe(false);
+      classifyStaleAutoFallbackOriginOverride(missingOriginEntry, "anthropic", "gpt-5.5"),
+    ).toBeNull();
   });
 
   it("prunes stale and excess primary probe throttle entries", () => {

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -538,28 +538,52 @@ describe("resolveAgentConfig", () => {
     ).toMatchObject({ provider: "anthropic", model: "claude-sonnet-4-6" });
   });
 
-  it("detects provably polluted auto-fallback origins that equal the override", () => {
+  it("does not repair genuine auto-fallback origins without durable provenance", () => {
+    const entry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: 1,
+      providerOverride: "google",
+      modelOverride: "gemini-3-pro",
+      modelOverrideSource: "auto",
+      // Origin differs from override: a genuine provider fallback occurred.
+      modelOverrideFallbackOriginProvider: "anthropic",
+      modelOverrideFallbackOriginModel: "claude-opus-4-7",
+    };
+
+    // Origin ≠ override (genuine fallback) and origin ≠ primary. Without durable
+    // provenance this is indistinguishable from a legitimate primary change.
+    expect(isStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-opus-4-8")).toBe(false);
+    expect(
+      classifyStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-opus-4-8"),
+    ).toBeNull();
+    expect(isStaleAutoFallbackOriginOverride(entry, "openai", "gpt-5.5")).toBe(false);
+    expect(classifyStaleAutoFallbackOriginOverride(entry, "openai", "gpt-5.5")).toBeNull();
+    // Origin already matches the primary → nothing to repair.
+    expect(isStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-opus-4-7")).toBe(false);
+    expect(
+      classifyStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-opus-4-7"),
+    ).toBeNull();
+  });
+
+  it("does not repair self-referential origins (preserves configured selections)", () => {
     const entry: SessionEntry = {
       sessionId: "session",
       updatedAt: 1,
       providerOverride: "anthropic",
       modelOverride: "claude-opus-4-7",
       modelOverrideSource: "auto",
+      // Self-referential: origin equals override. Configured subagent selections use this
+      // pattern deliberately; the hasSessionActiveAutoModelFallback contract preserves them.
       modelOverrideFallbackOriginProvider: "anthropic",
       modelOverrideFallbackOriginModel: "claude-opus-4-7",
     };
 
-    // Origin equals the override and differs from the current primary → clear override.
-    expect(isStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-opus-4-8")).toBe(true);
-    expect(isStaleAutoFallbackOriginOverride(entry, "openai", "gpt-5.5")).toBe(true);
-    expect(classifyStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-opus-4-8")).toBe(
-      "clear-override",
-    );
-    // Origin already matches the primary → nothing to repair.
-    expect(isStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-opus-4-7")).toBe(false);
+    expect(isStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-opus-4-8")).toBe(false);
     expect(
-      classifyStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-opus-4-7"),
+      classifyStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-opus-4-8"),
     ).toBeNull();
+    expect(isStaleAutoFallbackOriginOverride(entry, "openai", "gpt-5.5")).toBe(false);
+    expect(classifyStaleAutoFallbackOriginOverride(entry, "openai", "gpt-5.5")).toBeNull();
   });
 
   it("does not repair the canonical three-distinct origin state without provenance", () => {
@@ -587,18 +611,19 @@ describe("resolveAgentConfig", () => {
     ).toBeNull();
   });
 
-  it("does not treat user overrides, missing origins, or origin-matching primaries as stale", () => {
-    const pollutedEntry: SessionEntry = {
+  it("does not treat user overrides, missing origins, self-referential origins, or origin-matching primaries as stale", () => {
+    const selfReferentialEntry: SessionEntry = {
       sessionId: "session",
       updatedAt: 1,
       providerOverride: "anthropic",
       modelOverride: "claude-opus-4-7",
       modelOverrideSource: "auto",
+      // Origin equals override → configured selection, not a fallback.
       modelOverrideFallbackOriginProvider: "anthropic",
       modelOverrideFallbackOriginModel: "claude-opus-4-7",
     };
     const userEntry: SessionEntry = {
-      ...pollutedEntry,
+      ...selfReferentialEntry,
       modelOverrideSource: "user",
     };
     const missingOriginEntry: SessionEntry = {
@@ -616,6 +641,13 @@ describe("resolveAgentConfig", () => {
     );
     expect(
       classifyStaleAutoFallbackOriginOverride(missingOriginEntry, "anthropic", "gpt-5.5"),
+    ).toBeNull();
+    // Self-referential origin is not a genuine fallback → not stale.
+    expect(isStaleAutoFallbackOriginOverride(selfReferentialEntry, "openai", "gpt-5.5")).toBe(
+      false,
+    );
+    expect(
+      classifyStaleAutoFallbackOriginOverride(selfReferentialEntry, "openai", "gpt-5.5"),
     ).toBeNull();
   });
 

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -9,6 +9,7 @@ import { withEnv } from "../test-utils/env.js";
 import {
   clearAutoFallbackPrimaryProbeSelection,
   hasLegacyAutoFallbackWithoutOrigin,
+  isStaleAutoFallbackOriginOverride,
   markAutoFallbackPrimaryProbe,
   hasConfiguredModelFallbacks,
   resolveAgentConfig,
@@ -534,6 +535,52 @@ describe("resolveAgentConfig", () => {
         probeState,
       }),
     ).toMatchObject({ provider: "anthropic", model: "claude-sonnet-4-6" });
+  });
+
+  it("detects polluted auto-fallback origins that no longer match the primary", () => {
+    const entry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: 1,
+      providerOverride: "anthropic",
+      modelOverride: "claude-opus-4-7",
+      modelOverrideSource: "auto",
+      modelOverrideFallbackOriginProvider: "anthropic",
+      modelOverrideFallbackOriginModel: "claude-haiku-4-5",
+    };
+
+    expect(isStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-opus-4-8")).toBe(true);
+    expect(isStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-opus-4-7")).toBe(true);
+    expect(isStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-haiku-4-5")).toBe(false);
+    expect(isStaleAutoFallbackOriginOverride(entry, "openai", "claude-haiku-4-5")).toBe(true);
+  });
+
+  it("does not treat user overrides or missing origins as stale origins", () => {
+    const autoEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: 1,
+      providerOverride: "anthropic",
+      modelOverride: "claude-opus-4-7",
+      modelOverrideSource: "auto",
+      modelOverrideFallbackOriginProvider: "anthropic",
+      modelOverrideFallbackOriginModel: "claude-opus-4-8",
+    };
+    const userEntry: SessionEntry = {
+      ...autoEntry,
+      modelOverrideSource: "user",
+    };
+    const missingOriginEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: 1,
+      providerOverride: "anthropic",
+      modelOverride: "claude-opus-4-7",
+      modelOverrideSource: "auto",
+    };
+
+    expect(isStaleAutoFallbackOriginOverride(autoEntry, "anthropic", "gpt-5.5")).toBe(true);
+    expect(isStaleAutoFallbackOriginOverride(userEntry, "anthropic", "gpt-5.5")).toBe(false);
+    expect(isStaleAutoFallbackOriginOverride(missingOriginEntry, "anthropic", "gpt-5.5")).toBe(
+      false,
+    );
   });
 
   it("prunes stale and excess primary probe throttle entries", () => {

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -538,7 +538,7 @@ describe("resolveAgentConfig", () => {
     ).toMatchObject({ provider: "anthropic", model: "claude-sonnet-4-6" });
   });
 
-  it("does not repair genuine auto-fallback origins without durable provenance", () => {
+  it("repairs genuine auto-fallback origins whose origin differs from primary", () => {
     const entry: SessionEntry = {
       sessionId: "session",
       updatedAt: 1,
@@ -551,13 +551,16 @@ describe("resolveAgentConfig", () => {
     };
 
     // Origin ≠ override (genuine fallback) and origin ≠ primary. Without durable
-    // provenance this is indistinguishable from a legitimate primary change.
-    expect(isStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-opus-4-8")).toBe(false);
-    expect(
-      classifyStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-opus-4-8"),
-    ).toBeNull();
-    expect(isStaleAutoFallbackOriginOverride(entry, "openai", "gpt-5.5")).toBe(false);
-    expect(classifyStaleAutoFallbackOriginOverride(entry, "openai", "gpt-5.5")).toBeNull();
+    // provenance we cannot distinguish a polluted fallback from a legitimate primary
+    // change, but the stale override is cleared so this turn retries the primary.
+    expect(isStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-opus-4-8")).toBe(true);
+    expect(classifyStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-opus-4-8")).toBe(
+      "clear-override",
+    );
+    expect(isStaleAutoFallbackOriginOverride(entry, "openai", "gpt-5.5")).toBe(true);
+    expect(classifyStaleAutoFallbackOriginOverride(entry, "openai", "gpt-5.5")).toBe(
+      "clear-override",
+    );
     // Origin already matches the primary → nothing to repair.
     expect(isStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-opus-4-7")).toBe(false);
     expect(
@@ -586,7 +589,7 @@ describe("resolveAgentConfig", () => {
     expect(classifyStaleAutoFallbackOriginOverride(entry, "openai", "gpt-5.5")).toBeNull();
   });
 
-  it("does not repair the canonical three-distinct origin state without provenance", () => {
+  it("repairs the canonical three-distinct origin state", () => {
     const entry: SessionEntry = {
       sessionId: "session",
       updatedAt: 1,
@@ -597,13 +600,13 @@ describe("resolveAgentConfig", () => {
       modelOverrideFallbackOriginModel: "claude-haiku-4-5",
     };
 
-    // Canonical #92776 state: origin, override, and primary are all different. Without a
-    // provenance/migration contract this is indistinguishable from a legitimate primary-model
-    // change, so the changed-primary guard must be preserved.
-    expect(isStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-opus-4-8")).toBe(false);
-    expect(
-      classifyStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-opus-4-8"),
-    ).toBeNull();
+    // Canonical #92776 state: origin, override, and primary are all different. Without
+    // durable provenance we cannot distinguish a polluted fallback from a legitimate
+    // primary-model change, but the stale override is cleared to retry the primary.
+    expect(isStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-opus-4-8")).toBe(true);
+    expect(classifyStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-opus-4-8")).toBe(
+      "clear-override",
+    );
     // Origin matches the primary → nothing to repair.
     expect(isStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-haiku-4-5")).toBe(false);
     expect(

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -537,7 +537,7 @@ describe("resolveAgentConfig", () => {
     ).toMatchObject({ provider: "anthropic", model: "claude-sonnet-4-6" });
   });
 
-  it("detects polluted auto-fallback origins that no longer match the primary", () => {
+  it("detects provably polluted auto-fallback origins that equal the override", () => {
     const entry: SessionEntry = {
       sessionId: "session",
       updatedAt: 1,
@@ -545,27 +545,28 @@ describe("resolveAgentConfig", () => {
       modelOverride: "claude-opus-4-7",
       modelOverrideSource: "auto",
       modelOverrideFallbackOriginProvider: "anthropic",
-      modelOverrideFallbackOriginModel: "claude-haiku-4-5",
+      modelOverrideFallbackOriginModel: "claude-opus-4-7",
     };
 
+    // Origin equals the override and differs from the current primary → polluted.
     expect(isStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-opus-4-8")).toBe(true);
-    expect(isStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-opus-4-7")).toBe(true);
-    expect(isStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-haiku-4-5")).toBe(false);
-    expect(isStaleAutoFallbackOriginOverride(entry, "openai", "claude-haiku-4-5")).toBe(true);
+    expect(isStaleAutoFallbackOriginOverride(entry, "openai", "gpt-5.5")).toBe(true);
+    // Origin already matches the primary → nothing to repair.
+    expect(isStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-opus-4-7")).toBe(false);
   });
 
-  it("does not treat user overrides or missing origins as stale origins", () => {
-    const autoEntry: SessionEntry = {
+  it("does not treat user overrides, missing origins, or legitimate primary changes as stale", () => {
+    const pollutedEntry: SessionEntry = {
       sessionId: "session",
       updatedAt: 1,
       providerOverride: "anthropic",
       modelOverride: "claude-opus-4-7",
       modelOverrideSource: "auto",
       modelOverrideFallbackOriginProvider: "anthropic",
-      modelOverrideFallbackOriginModel: "claude-opus-4-8",
+      modelOverrideFallbackOriginModel: "claude-opus-4-7",
     };
     const userEntry: SessionEntry = {
-      ...autoEntry,
+      ...pollutedEntry,
       modelOverrideSource: "user",
     };
     const missingOriginEntry: SessionEntry = {
@@ -575,12 +576,24 @@ describe("resolveAgentConfig", () => {
       modelOverride: "claude-opus-4-7",
       modelOverrideSource: "auto",
     };
+    const changedPrimaryEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: 1,
+      providerOverride: "anthropic",
+      modelOverride: "claude-opus-4-7",
+      modelOverrideSource: "auto",
+      modelOverrideFallbackOriginProvider: "openai",
+      modelOverrideFallbackOriginModel: "gpt-5.4",
+    };
 
-    expect(isStaleAutoFallbackOriginOverride(autoEntry, "anthropic", "gpt-5.5")).toBe(true);
     expect(isStaleAutoFallbackOriginOverride(userEntry, "anthropic", "gpt-5.5")).toBe(false);
     expect(isStaleAutoFallbackOriginOverride(missingOriginEntry, "anthropic", "gpt-5.5")).toBe(
       false,
     );
+    // Origin differs from both the override and the current primary → legitimate mismatch guard.
+    expect(
+      isStaleAutoFallbackOriginOverride(changedPrimaryEntry, "anthropic", "claude-opus-4-8"),
+    ).toBe(false);
   });
 
   it("prunes stale and excess primary probe throttle entries", () => {

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -562,7 +562,7 @@ describe("resolveAgentConfig", () => {
     ).toBeNull();
   });
 
-  it("detects the canonical three-distinct origin state for origin-only repair", () => {
+  it("does not repair the canonical three-distinct origin state without provenance", () => {
     const entry: SessionEntry = {
       sessionId: "session",
       updatedAt: 1,
@@ -573,11 +573,13 @@ describe("resolveAgentConfig", () => {
       modelOverrideFallbackOriginModel: "claude-haiku-4-5",
     };
 
-    // Canonical #92776 state: origin, override, and primary are all different.
-    expect(isStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-opus-4-8")).toBe(true);
-    expect(classifyStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-opus-4-8")).toBe(
-      "repair-origin",
-    );
+    // Canonical #92776 state: origin, override, and primary are all different. Without a
+    // provenance/migration contract this is indistinguishable from a legitimate primary-model
+    // change, so the changed-primary guard must be preserved.
+    expect(isStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-opus-4-8")).toBe(false);
+    expect(
+      classifyStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-opus-4-8"),
+    ).toBeNull();
     // Origin matches the primary → nothing to repair.
     expect(isStaleAutoFallbackOriginOverride(entry, "anthropic", "claude-haiku-4-5")).toBe(false);
     expect(

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -133,8 +133,9 @@ export function hasLegacyAutoFallbackWithoutOrigin(
  *  Only genuine fallbacks (origin differs from override per hasSessionActiveAutoModelFallback)
  *  whose recorded origin no longer matches the current primary are repaired. Self-referential
  *  origins (origin == override) are preserved because configured subagent selections use the
- *  same pattern. The canonical #92776 three-distinct state remains untouched until a
- *  provenance/migration contract can distinguish it from a legitimate primary-model change. */
+ *  same pattern. Without durable provenance we cannot distinguish a polluted fallback from a
+ *  legitimate primary-model change, but the stale override is cleared so this turn retries the
+ *  configured primary. */
 export type StaleAutoFallbackOriginRepairKind = "clear-override";
 
 /** Classifies an auto-fallback override origin for repair.
@@ -142,8 +143,7 @@ export type StaleAutoFallbackOriginRepairKind = "clear-override";
  *    longer matches the current primary. The override is cleared so this turn retries
  *    the configured primary.
  *  - `null`: no repair needed (user override, missing origin, origin already matches primary,
- *    self-referential origin that could be a configured subagent selection, or the origin
- *    differs from primary because the primary legitimately changed). */
+ *    or self-referential origin that could be a configured subagent selection). */
 export function classifyStaleAutoFallbackOriginOverride(
   entry:
     | Pick<
@@ -194,20 +194,17 @@ export function classifyStaleAutoFallbackOriginOverride(
   if (originMatchesPrimary) {
     return null;
   }
-  // Genuine fallback whose recorded origin differs from the current primary. The origin
-  // could be stale (primary changed → snap-back should fire) or the primary could have
-  // legitimately changed since this fallback was created — the two are indistinguishable
-  // without durable provenance. Return null to preserve the existing changed-primary guard
-  // until a provenance/migration contract can distinguish them.
-  return null;
+  // Genuine fallback whose recorded origin differs from the current primary. Without
+  // durable provenance we cannot distinguish a polluted fallback origin from a legitimate
+  // primary-model change, but the stale override is cleared so this turn retries the
+  // configured primary.
+  return "clear-override";
 }
 
 /** Detects auto-fallback overrides whose recorded origin needs repair.
  *  Returns true only for genuine fallbacks (origin differs from override per
  *  hasSessionActiveAutoModelFallback) whose recorded origin no longer matches the current
- *  primary. Self-referential origins are preserved to protect configured subagent selections;
- *  the canonical #92776 three-distinct state is intentionally not treated as stale until a
- *  provenance/migration contract can distinguish it from a legitimate primary change. */
+ *  primary. Self-referential origins are preserved to protect configured subagent selections. */
 export function isStaleAutoFallbackOriginOverride(
   entry:
     | Pick<

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -123,18 +123,20 @@ export function hasLegacyAutoFallbackWithoutOrigin(
   );
 }
 
-/** Kinds of stale auto-fallback origin repair. */
-export type StaleAutoFallbackOriginRepairKind = "clear-override" | "repair-origin";
+/** Kinds of stale auto-fallback origin repair.
+ *  Only self-referential origins are repaired now; the canonical #92776 three-distinct state is
+ *  indistinguishable from a legitimate primary-model change without a provenance/migration
+ *  contract, so it is left untouched to preserve the changed-primary guard. */
+export type StaleAutoFallbackOriginRepairKind = "clear-override";
 
 /** Classifies an auto-fallback override origin for repair.
  *  - `"clear-override"`: the recorded origin equals the current fallback override itself, which
- *    is provably polluted (a fallback can never originate from the model it fell back to).
- *  - `"repair-origin"`: the recorded origin differs from both the current primary and the current
- *    fallback override. This covers the canonical #92776 three-distinct state where the writer
- *    recorded a failed chain model as the origin; we conservatively update the origin to the
- *    current primary so the snap-back probe can fire, while preserving the fallback override.
+ *    is provably polluted (a fallback can never originate from the model it fell back to). The
+ *    override is cleared so this turn retries the configured primary.
  *  - `null`: no repair needed (user override, missing origin, origin already matches primary,
- *    or origin differs from primary only because the primary legitimately changed). */
+ *    or the origin differs from primary because the primary legitimately changed). The latter
+ *    case deliberately preserves the existing changed-primary mismatch guard; a migration or
+ *    provenance contract is required before rewriting three-distinct origins. */
 export function classifyStaleAutoFallbackOriginOverride(
   entry:
     | Pick<
@@ -181,12 +183,13 @@ export function classifyStaleAutoFallbackOriginOverride(
   if (originProvider === overrideProvider && originModel === overrideModel) {
     return "clear-override";
   }
-  return "repair-origin";
+  return null;
 }
 
 /** Detects auto-fallback overrides whose recorded origin needs repair.
- *  Returns true for both provably polluted origins (origin equals the fallback override) and the
- *  canonical #92776 three-distinct state (origin differs from both primary and override). */
+ *  Returns true only for provably polluted self-referential origins (origin equals the fallback
+ *  override itself). The canonical #92776 three-distinct state is intentionally not treated as
+ *  stale until a provenance/migration contract can distinguish it from a legitimate primary change. */
 export function isStaleAutoFallbackOriginOverride(
   entry:
     | Pick<

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -2,8 +2,14 @@
 import fs from "node:fs";
 import path from "node:path";
 import { resolveAgentModelFallbackValues } from "../config/model-input.js";
-import { hasSessionAutoModelFallbackProvenance } from "../config/sessions/model-override-provenance.js";
-export { hasSessionAutoModelFallbackProvenance } from "../config/sessions/model-override-provenance.js";
+import {
+  hasSessionActiveAutoModelFallback,
+  hasSessionAutoModelFallbackProvenance,
+} from "../config/sessions/model-override-provenance.js";
+export {
+  hasSessionActiveAutoModelFallback,
+  hasSessionAutoModelFallbackProvenance,
+} from "../config/sessions/model-override-provenance.js";
 import {
   lowercasePreservingWhitespace,
   normalizeLowercaseStringOrEmpty,
@@ -124,19 +130,20 @@ export function hasLegacyAutoFallbackWithoutOrigin(
 }
 
 /** Kinds of stale auto-fallback origin repair.
- *  Only self-referential origins are repaired now; the canonical #92776 three-distinct state is
- *  indistinguishable from a legitimate primary-model change without a provenance/migration
- *  contract, so it is left untouched to preserve the changed-primary guard. */
+ *  Only genuine fallbacks (origin differs from override per hasSessionActiveAutoModelFallback)
+ *  whose recorded origin no longer matches the current primary are repaired. Self-referential
+ *  origins (origin == override) are preserved because configured subagent selections use the
+ *  same pattern. The canonical #92776 three-distinct state remains untouched until a
+ *  provenance/migration contract can distinguish it from a legitimate primary-model change. */
 export type StaleAutoFallbackOriginRepairKind = "clear-override";
 
 /** Classifies an auto-fallback override origin for repair.
- *  - `"clear-override"`: the recorded origin equals the current fallback override itself, which
- *    is provably polluted (a fallback can never originate from the model it fell back to). The
- *    override is cleared so this turn retries the configured primary.
+ *  - `"clear-override"`: a genuine fallback (origin differs from override) whose origin no
+ *    longer matches the current primary. The override is cleared so this turn retries
+ *    the configured primary.
  *  - `null`: no repair needed (user override, missing origin, origin already matches primary,
- *    or the origin differs from primary because the primary legitimately changed). The latter
- *    case deliberately preserves the existing changed-primary mismatch guard; a migration or
- *    provenance contract is required before rewriting three-distinct origins. */
+ *    self-referential origin that could be a configured subagent selection, or the origin
+ *    differs from primary because the primary legitimately changed). */
 export function classifyStaleAutoFallbackOriginOverride(
   entry:
     | Pick<
@@ -175,21 +182,32 @@ export function classifyStaleAutoFallbackOriginOverride(
   if (!normalizedPrimaryProvider || !normalizedPrimaryModel) {
     return null;
   }
+  // Only repair genuine fallbacks (origin differs from override). Self-referential
+  // origins (origin == override) are preserved because configured subagent selections
+  // deliberately use the same pattern to prevent cleanup from discarding them.
+  // The existing hasSessionActiveAutoModelFallback contract explicitly documents this.
+  if (!hasSessionActiveAutoModelFallback(entry)) {
+    return null;
+  }
   const originMatchesPrimary =
     originProvider === normalizedPrimaryProvider && originModel === normalizedPrimaryModel;
   if (originMatchesPrimary) {
     return null;
   }
-  if (originProvider === overrideProvider && originModel === overrideModel) {
-    return "clear-override";
-  }
+  // Genuine fallback whose recorded origin differs from the current primary. The origin
+  // could be stale (primary changed → snap-back should fire) or the primary could have
+  // legitimately changed since this fallback was created — the two are indistinguishable
+  // without durable provenance. Return null to preserve the existing changed-primary guard
+  // until a provenance/migration contract can distinguish them.
   return null;
 }
 
 /** Detects auto-fallback overrides whose recorded origin needs repair.
- *  Returns true only for provably polluted self-referential origins (origin equals the fallback
- *  override itself). The canonical #92776 three-distinct state is intentionally not treated as
- *  stale until a provenance/migration contract can distinguish it from a legitimate primary change. */
+ *  Returns true only for genuine fallbacks (origin differs from override per
+ *  hasSessionActiveAutoModelFallback) whose recorded origin no longer matches the current
+ *  primary. Self-referential origins are preserved to protect configured subagent selections;
+ *  the canonical #92776 three-distinct state is intentionally not treated as stale until a
+ *  provenance/migration contract can distinguish it from a legitimate primary change. */
 export function isStaleAutoFallbackOriginOverride(
   entry:
     | Pick<

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -162,6 +162,53 @@ export function isStaleAutoFallbackOriginOverride(
   return originProvider !== normalizedPrimaryProvider || originModel !== normalizedPrimaryModel;
 }
 
+/** Verifies a persisted session entry still matches the automatic-fallback snapshot this turn
+ *  observed before repairing its origin. Without this guard a concurrent reset, user selection,
+ *  or newer automatic fallback could keep the same sessionId while changing the selection state,
+ *  causing the repair to attach stale origin metadata to newer state. */
+export function matchesStaleAutoFallbackOriginRepairSnapshot(
+  persisted: SessionEntry | null | undefined,
+  observed: SessionEntry | null | undefined,
+): boolean {
+  if (!persisted || !observed) {
+    return false;
+  }
+  if (persisted.sessionId !== observed.sessionId) {
+    return false;
+  }
+  if (persisted.updatedAt !== observed.updatedAt) {
+    return false;
+  }
+  if (persisted.modelOverrideSource !== observed.modelOverrideSource) {
+    return false;
+  }
+  if (
+    normalizeOptionalString(persisted.providerOverride) !==
+    normalizeOptionalString(observed.providerOverride)
+  ) {
+    return false;
+  }
+  if (
+    normalizeOptionalString(persisted.modelOverride) !==
+    normalizeOptionalString(observed.modelOverride)
+  ) {
+    return false;
+  }
+  if (
+    normalizeOptionalString(persisted.modelOverrideFallbackOriginProvider) !==
+    normalizeOptionalString(observed.modelOverrideFallbackOriginProvider)
+  ) {
+    return false;
+  }
+  if (
+    normalizeOptionalString(persisted.modelOverrideFallbackOriginModel) !==
+    normalizeOptionalString(observed.modelOverrideFallbackOriginModel)
+  ) {
+    return false;
+  }
+  return true;
+}
+
 export function resolveAutoFallbackPrimaryProbe(params: {
   entry:
     | Pick<

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -123,6 +123,45 @@ export function hasLegacyAutoFallbackWithoutOrigin(
   );
 }
 
+/** Detects auto-fallback overrides whose recorded origin no longer matches the current primary.
+ *  A polluted origin (e.g. the chain's terminal failed model) prevents the snap-back probe from
+ *  firing, so this predicate lets model-selection paths treat the pin as stale and reset it. */
+export function isStaleAutoFallbackOriginOverride(
+  entry:
+    | Pick<
+        SessionEntry,
+        | "modelOverrideSource"
+        | "modelOverrideFallbackOriginProvider"
+        | "modelOverrideFallbackOriginModel"
+        | "providerOverride"
+        | "modelOverride"
+      >
+    | null
+    | undefined,
+  primaryProvider: string,
+  primaryModel: string,
+): boolean {
+  if (!entry) {
+    return false;
+  }
+  const recoveredAutoFallbackOverride =
+    entry.modelOverrideSource === undefined && hasSessionAutoModelFallbackProvenance(entry);
+  if (entry.modelOverrideSource !== "auto" && !recoveredAutoFallbackOverride) {
+    return false;
+  }
+  const originProvider = normalizeOptionalString(entry.modelOverrideFallbackOriginProvider);
+  const originModel = normalizeOptionalString(entry.modelOverrideFallbackOriginModel);
+  if (!originProvider || !originModel) {
+    return false;
+  }
+  const normalizedPrimaryProvider = normalizeOptionalString(primaryProvider);
+  const normalizedPrimaryModel = normalizeOptionalString(primaryModel);
+  if (!normalizedPrimaryProvider || !normalizedPrimaryModel) {
+    return false;
+  }
+  return originProvider !== normalizedPrimaryProvider || originModel !== normalizedPrimaryModel;
+}
+
 export function resolveAutoFallbackPrimaryProbe(params: {
   entry:
     | Pick<

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -123,9 +123,11 @@ export function hasLegacyAutoFallbackWithoutOrigin(
   );
 }
 
-/** Detects auto-fallback overrides whose recorded origin no longer matches the current primary.
- *  A polluted origin (e.g. the chain's terminal failed model) prevents the snap-back probe from
- *  firing, so this predicate lets model-selection paths treat the pin as stale and reset it. */
+/** Detects auto-fallback overrides whose recorded origin is provably polluted.
+ *  A legitimate origin records the primary model that was active when the fallback pin was
+ *  created; it is allowed to differ from the current primary when the primary has since changed.
+ *  The only safe proof of pollution is when the recorded origin equals the current fallback
+ *  override itself — a fallback can never originate from the model it fell back to. */
 export function isStaleAutoFallbackOriginOverride(
   entry:
     | Pick<
@@ -154,12 +156,22 @@ export function isStaleAutoFallbackOriginOverride(
   if (!originProvider || !originModel) {
     return false;
   }
+  const overrideProvider = normalizeOptionalString(entry.providerOverride);
+  const overrideModel = normalizeOptionalString(entry.modelOverride);
+  if (!overrideProvider || !overrideModel) {
+    return false;
+  }
   const normalizedPrimaryProvider = normalizeOptionalString(primaryProvider);
   const normalizedPrimaryModel = normalizeOptionalString(primaryModel);
   if (!normalizedPrimaryProvider || !normalizedPrimaryModel) {
     return false;
   }
-  return originProvider !== normalizedPrimaryProvider || originModel !== normalizedPrimaryModel;
+  const originMatchesPrimary =
+    originProvider === normalizedPrimaryProvider && originModel === normalizedPrimaryModel;
+  if (originMatchesPrimary) {
+    return false;
+  }
+  return originProvider === overrideProvider && originModel === overrideModel;
 }
 
 /** Verifies a persisted session entry still matches the automatic-fallback snapshot this turn

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -123,11 +123,70 @@ export function hasLegacyAutoFallbackWithoutOrigin(
   );
 }
 
-/** Detects auto-fallback overrides whose recorded origin is provably polluted.
- *  A legitimate origin records the primary model that was active when the fallback pin was
- *  created; it is allowed to differ from the current primary when the primary has since changed.
- *  The only safe proof of pollution is when the recorded origin equals the current fallback
- *  override itself — a fallback can never originate from the model it fell back to. */
+/** Kinds of stale auto-fallback origin repair. */
+export type StaleAutoFallbackOriginRepairKind = "clear-override" | "repair-origin";
+
+/** Classifies an auto-fallback override origin for repair.
+ *  - `"clear-override"`: the recorded origin equals the current fallback override itself, which
+ *    is provably polluted (a fallback can never originate from the model it fell back to).
+ *  - `"repair-origin"`: the recorded origin differs from both the current primary and the current
+ *    fallback override. This covers the canonical #92776 three-distinct state where the writer
+ *    recorded a failed chain model as the origin; we conservatively update the origin to the
+ *    current primary so the snap-back probe can fire, while preserving the fallback override.
+ *  - `null`: no repair needed (user override, missing origin, origin already matches primary,
+ *    or origin differs from primary only because the primary legitimately changed). */
+export function classifyStaleAutoFallbackOriginOverride(
+  entry:
+    | Pick<
+        SessionEntry,
+        | "modelOverrideSource"
+        | "modelOverrideFallbackOriginProvider"
+        | "modelOverrideFallbackOriginModel"
+        | "providerOverride"
+        | "modelOverride"
+      >
+    | null
+    | undefined,
+  primaryProvider: string,
+  primaryModel: string,
+): StaleAutoFallbackOriginRepairKind | null {
+  if (!entry) {
+    return null;
+  }
+  const recoveredAutoFallbackOverride =
+    entry.modelOverrideSource === undefined && hasSessionAutoModelFallbackProvenance(entry);
+  if (entry.modelOverrideSource !== "auto" && !recoveredAutoFallbackOverride) {
+    return null;
+  }
+  const originProvider = normalizeOptionalString(entry.modelOverrideFallbackOriginProvider);
+  const originModel = normalizeOptionalString(entry.modelOverrideFallbackOriginModel);
+  if (!originProvider || !originModel) {
+    return null;
+  }
+  const overrideProvider = normalizeOptionalString(entry.providerOverride);
+  const overrideModel = normalizeOptionalString(entry.modelOverride);
+  if (!overrideProvider || !overrideModel) {
+    return null;
+  }
+  const normalizedPrimaryProvider = normalizeOptionalString(primaryProvider);
+  const normalizedPrimaryModel = normalizeOptionalString(primaryModel);
+  if (!normalizedPrimaryProvider || !normalizedPrimaryModel) {
+    return null;
+  }
+  const originMatchesPrimary =
+    originProvider === normalizedPrimaryProvider && originModel === normalizedPrimaryModel;
+  if (originMatchesPrimary) {
+    return null;
+  }
+  if (originProvider === overrideProvider && originModel === overrideModel) {
+    return "clear-override";
+  }
+  return "repair-origin";
+}
+
+/** Detects auto-fallback overrides whose recorded origin needs repair.
+ *  Returns true for both provably polluted origins (origin equals the fallback override) and the
+ *  canonical #92776 three-distinct state (origin differs from both primary and override). */
 export function isStaleAutoFallbackOriginOverride(
   entry:
     | Pick<
@@ -143,35 +202,7 @@ export function isStaleAutoFallbackOriginOverride(
   primaryProvider: string,
   primaryModel: string,
 ): boolean {
-  if (!entry) {
-    return false;
-  }
-  const recoveredAutoFallbackOverride =
-    entry.modelOverrideSource === undefined && hasSessionAutoModelFallbackProvenance(entry);
-  if (entry.modelOverrideSource !== "auto" && !recoveredAutoFallbackOverride) {
-    return false;
-  }
-  const originProvider = normalizeOptionalString(entry.modelOverrideFallbackOriginProvider);
-  const originModel = normalizeOptionalString(entry.modelOverrideFallbackOriginModel);
-  if (!originProvider || !originModel) {
-    return false;
-  }
-  const overrideProvider = normalizeOptionalString(entry.providerOverride);
-  const overrideModel = normalizeOptionalString(entry.modelOverride);
-  if (!overrideProvider || !overrideModel) {
-    return false;
-  }
-  const normalizedPrimaryProvider = normalizeOptionalString(primaryProvider);
-  const normalizedPrimaryModel = normalizeOptionalString(primaryModel);
-  if (!normalizedPrimaryProvider || !normalizedPrimaryModel) {
-    return false;
-  }
-  const originMatchesPrimary =
-    originProvider === normalizedPrimaryProvider && originModel === normalizedPrimaryModel;
-  if (originMatchesPrimary) {
-    return false;
-  }
-  return originProvider === overrideProvider && originModel === overrideModel;
+  return classifyStaleAutoFallbackOriginOverride(entry, primaryProvider, primaryModel) !== null;
 }
 
 /** Verifies a persisted session entry still matches the automatic-fallback snapshot this turn

--- a/src/agents/command/model-selection.ts
+++ b/src/agents/command/model-selection.ts
@@ -282,9 +282,10 @@ export async function resolveEmbeddedModelSelection(params: {
     : null;
   const primaryProvider = normalizedChannelOverride?.provider ?? defaultProvider;
   const primaryModel = normalizedChannelOverride?.model ?? defaultModel;
-  // A polluted fallback origin (recorded as the chain's failed model instead of the
-  // configured primary) prevents the snap-back probe from firing. Clear it so this
-  // attempt can retry the primary and, if needed, recreate a clean auto-fallback pin.
+  // A provably polluted fallback origin (recorded as the fallback override itself
+  // instead of the configured primary) prevents the snap-back probe from firing.
+  // Clear it so this attempt can retry the primary and, if needed, recreate a clean
+  // auto-fallback pin.
   // The write is guarded by the exact observed automatic-fallback snapshot so a
   // concurrent reset, user selection, or newer automatic fallback does not receive
   // stale origin-clear metadata.

--- a/src/agents/command/model-selection.ts
+++ b/src/agents/command/model-selection.ts
@@ -282,13 +282,14 @@ export async function resolveEmbeddedModelSelection(params: {
     : null;
   const primaryProvider = normalizedChannelOverride?.provider ?? defaultProvider;
   const primaryModel = normalizedChannelOverride?.model ?? defaultModel;
-  // A provably polluted fallback origin (recorded as the fallback override itself
-  // instead of the configured primary) prevents the snap-back probe from firing.
-  // Clear it so this attempt can retry the primary and, if needed, recreate a clean
+  // A stale fallback origin (provably polluted when it equals the override, or the
+  // canonical #92776 three-distinct state) prevents the snap-back probe from firing.
+  // Repair it so this attempt can retry the primary and, if needed, recreate a clean
   // auto-fallback pin.
   // The write is guarded by the exact observed automatic-fallback snapshot so a
   // concurrent reset, user selection, or newer automatic fallback does not receive
-  // stale origin-clear metadata.
+  // stale repair metadata. Locked sessions and commit-edge conflicts are handled
+  // inside the repair helper.
   if (
     sessionEntry &&
     params.sessionStore &&

--- a/src/agents/command/model-selection.ts
+++ b/src/agents/command/model-selection.ts
@@ -27,6 +27,7 @@ import {
   clearAutoFallbackPrimaryProbeSelection,
   hasLegacyAutoFallbackWithoutOrigin,
   hasSessionAutoModelFallbackProvenance,
+  isStaleAutoFallbackOriginOverride,
   resolveAutoFallbackPrimaryProbe,
   resolveAgentConfig,
   resolveAgentEffectiveModelPrimary,
@@ -246,12 +247,6 @@ export async function resolveEmbeddedModelSelection(params: {
     hasLegacyAutoFallbackOverrideWithoutOrigin = false;
   }
 
-  const storedProviderOverride = hasLegacyAutoFallbackOverrideWithoutOrigin
-    ? undefined
-    : sessionEntry?.providerOverride?.trim();
-  const storedModelOverride = hasLegacyAutoFallbackOverrideWithoutOrigin
-    ? undefined
-    : sessionEntry?.modelOverride?.trim();
   const currentRunModelChannel = [
     params.runContext.messageChannel,
     params.opts.replyChannel,
@@ -287,6 +282,51 @@ export async function resolveEmbeddedModelSelection(params: {
     : null;
   const primaryProvider = normalizedChannelOverride?.provider ?? defaultProvider;
   const primaryModel = normalizedChannelOverride?.model ?? defaultModel;
+  // A polluted fallback origin (recorded as the chain's failed model instead of the
+  // configured primary) prevents the snap-back probe from firing. Clear it so this
+  // attempt can retry the primary and, if needed, recreate a clean auto-fallback pin.
+  if (
+    sessionEntry &&
+    params.sessionStore &&
+    params.sessionKey &&
+    !params.suppressVisibleSessionEffects &&
+    isStaleAutoFallbackOriginOverride(sessionEntry, primaryProvider, primaryModel)
+  ) {
+    const initialEntry = sessionEntry;
+    const entry = { ...sessionEntry };
+    const { updated } = applyModelOverrideToSessionEntry({
+      entry,
+      selection: { provider: primaryProvider, model: primaryModel, isDefault: true },
+    });
+    if (updated) {
+      sessionEntry = await persistSessionEntry({
+        sessionStore: params.sessionStore,
+        sessionKey: params.sessionKey,
+        storePath: params.storePath,
+        initialEntry,
+        entry,
+      });
+      const adoptedHasStoredOverride = Boolean(
+        sessionEntry?.modelOverride || sessionEntry?.providerOverride,
+      );
+      storedModelOverrideSource = adoptedHasStoredOverride
+        ? sessionEntry?.modelOverrideSource
+        : undefined;
+      storedModelOverrideRouteResolution = adoptedHasStoredOverride
+        ? resolveSessionModelOverrideRouteResolution(sessionEntry)
+        : undefined;
+      hasStoredAutoFallbackProvenance =
+        adoptedHasStoredOverride && hasSessionAutoModelFallbackProvenance(sessionEntry);
+      hasLegacyAutoFallbackOverrideWithoutOrigin =
+        adoptedHasStoredOverride && hasLegacyAutoFallbackWithoutOrigin(sessionEntry);
+    }
+  }
+  const storedProviderOverride = hasLegacyAutoFallbackOverrideWithoutOrigin
+    ? undefined
+    : sessionEntry?.providerOverride?.trim();
+  const storedModelOverride = hasLegacyAutoFallbackOverrideWithoutOrigin
+    ? undefined
+    : sessionEntry?.modelOverride?.trim();
   const hasEffectiveStoredOverride = Boolean(storedProviderOverride || storedModelOverride);
   if (normalizedChannelOverride && !hasEffectiveStoredOverride) {
     provider = normalizedChannelOverride.provider;

--- a/src/agents/command/model-selection.ts
+++ b/src/agents/command/model-selection.ts
@@ -282,14 +282,13 @@ export async function resolveEmbeddedModelSelection(params: {
     : null;
   const primaryProvider = normalizedChannelOverride?.provider ?? defaultProvider;
   const primaryModel = normalizedChannelOverride?.model ?? defaultModel;
-  // A stale fallback origin (provably polluted when it equals the override, or the
-  // canonical #92776 three-distinct state) prevents the snap-back probe from firing.
-  // Repair it so this attempt can retry the primary and, if needed, recreate a clean
-  // auto-fallback pin.
-  // The write is guarded by the exact observed automatic-fallback snapshot so a
-  // concurrent reset, user selection, or newer automatic fallback does not receive
-  // stale repair metadata. Locked sessions and commit-edge conflicts are handled
-  // inside the repair helper.
+  // A provably polluted self-referential fallback origin (origin equals the override itself)
+  // prevents the snap-back probe from firing. Repair it so this attempt can retry the primary.
+  // The canonical #92776 three-distinct state is not repaired here because it is
+  // indistinguishable from a legitimate primary-model change without a migration or provenance
+  // contract. The write is guarded by the exact observed automatic-fallback snapshot so a
+  // concurrent reset, user selection, or newer automatic fallback does not receive stale repair
+  // metadata. Locked sessions and commit-edge conflicts are handled inside the repair helper.
   if (
     sessionEntry &&
     params.sessionStore &&

--- a/src/agents/command/model-selection.ts
+++ b/src/agents/command/model-selection.ts
@@ -27,7 +27,6 @@ import {
   clearAutoFallbackPrimaryProbeSelection,
   hasLegacyAutoFallbackWithoutOrigin,
   hasSessionAutoModelFallbackProvenance,
-  isStaleAutoFallbackOriginOverride,
   resolveAutoFallbackPrimaryProbe,
   resolveAgentConfig,
   resolveAgentEffectiveModelPrimary,
@@ -69,6 +68,7 @@ import { normalizeExplicitOverrideInput } from "./prepare.js";
 import type { resolveAgentRunContext } from "./run-context.js";
 import { loadTranscriptResolveRuntime } from "./runtime-loaders.js";
 import { persistSessionEntry } from "./session-helpers.js";
+import { repairStaleAutoFallbackOriginOverride } from "./stale-auto-fallback-origin-repair.js";
 import type { AgentCommandOpts } from "./types.js";
 
 type AgentRunContext = ReturnType<typeof resolveAgentRunContext>;
@@ -285,40 +285,31 @@ export async function resolveEmbeddedModelSelection(params: {
   // A polluted fallback origin (recorded as the chain's failed model instead of the
   // configured primary) prevents the snap-back probe from firing. Clear it so this
   // attempt can retry the primary and, if needed, recreate a clean auto-fallback pin.
+  // The write is guarded by the exact observed automatic-fallback snapshot so a
+  // concurrent reset, user selection, or newer automatic fallback does not receive
+  // stale origin-clear metadata.
   if (
     sessionEntry &&
     params.sessionStore &&
     params.sessionKey &&
-    !params.suppressVisibleSessionEffects &&
-    isStaleAutoFallbackOriginOverride(sessionEntry, primaryProvider, primaryModel)
+    !params.suppressVisibleSessionEffects
   ) {
-    const initialEntry = sessionEntry;
-    const entry = { ...sessionEntry };
-    const { updated } = applyModelOverrideToSessionEntry({
-      entry,
-      selection: { provider: primaryProvider, model: primaryModel, isDefault: true },
+    const repair = await repairStaleAutoFallbackOriginOverride({
+      sessionEntry,
+      sessionStore: params.sessionStore,
+      sessionKey: params.sessionKey,
+      storePath: params.storePath,
+      primaryProvider,
+      primaryModel,
     });
-    if (updated) {
-      sessionEntry = await persistSessionEntry({
-        sessionStore: params.sessionStore,
-        sessionKey: params.sessionKey,
-        storePath: params.storePath,
-        initialEntry,
-        entry,
-      });
-      const adoptedHasStoredOverride = Boolean(
-        sessionEntry?.modelOverride || sessionEntry?.providerOverride,
-      );
-      storedModelOverrideSource = adoptedHasStoredOverride
-        ? sessionEntry?.modelOverrideSource
-        : undefined;
-      storedModelOverrideRouteResolution = adoptedHasStoredOverride
-        ? resolveSessionModelOverrideRouteResolution(sessionEntry)
-        : undefined;
-      hasStoredAutoFallbackProvenance =
-        adoptedHasStoredOverride && hasSessionAutoModelFallbackProvenance(sessionEntry);
+    if (repair.entry !== sessionEntry) {
+      sessionEntry = repair.entry;
+      params.sessionStore[params.sessionKey] = sessionEntry;
+      storedModelOverrideSource = repair.storedModelOverrideSource;
+      storedModelOverrideRouteResolution = repair.storedModelOverrideRouteResolution;
+      hasStoredAutoFallbackProvenance = repair.hasStoredAutoFallbackProvenance;
       hasLegacyAutoFallbackOverrideWithoutOrigin =
-        adoptedHasStoredOverride && hasLegacyAutoFallbackWithoutOrigin(sessionEntry);
+        repair.hasLegacyAutoFallbackOverrideWithoutOrigin;
     }
   }
   const storedProviderOverride = hasLegacyAutoFallbackOverrideWithoutOrigin

--- a/src/agents/command/stale-auto-fallback-origin-repair.test.ts
+++ b/src/agents/command/stale-auto-fallback-origin-repair.test.ts
@@ -57,18 +57,16 @@ describe("repairStaleAutoFallbackOriginOverride", () => {
     expect(result.hasStoredOverride).toBe(false);
   });
 
-  it("repairs the canonical three-distinct state by updating the origin only", async () => {
+  it("does not repair the canonical three-distinct state without provenance", async () => {
     const sessionKey = "agent:main:telegram:123";
     const sessionStore: Record<string, SessionEntry> = {};
     const storePath = path.join(tempDirs.make("repair-store"), "sessions.json");
-    replaceSessionEntrySync(
-      { storePath, sessionKey },
-      makeSessionEntry({
-        modelOverride: "claude-opus-4-7",
-        modelOverrideFallbackOriginProvider: "anthropic",
-        modelOverrideFallbackOriginModel: "claude-haiku-4-5",
-      }),
-    );
+    const originEntry = makeSessionEntry({
+      modelOverride: "claude-opus-4-7",
+      modelOverrideFallbackOriginProvider: "anthropic",
+      modelOverrideFallbackOriginModel: "claude-haiku-4-5",
+    });
+    replaceSessionEntrySync({ storePath, sessionKey }, originEntry);
     const sessionEntry = loadSessionEntryReadOnly({ storePath, sessionKey });
     if (!sessionEntry) {
       throw new Error("session entry not loaded");
@@ -84,13 +82,13 @@ describe("repairStaleAutoFallbackOriginOverride", () => {
       primaryModel: "claude-opus-4-8",
     });
 
-    // Override is preserved; origin is rewritten to the current primary so the
-    // snap-back probe can fire on the next interval.
+    // Without a provenance/migration contract, three-distinct origins are indistinguishable
+    // from a legitimate primary-model change, so the override and origin are left untouched.
     expect(result.entry.providerOverride).toBe("anthropic");
     expect(result.entry.modelOverride).toBe("claude-opus-4-7");
     expect(result.entry.modelOverrideSource).toBe("auto");
     expect(result.entry.modelOverrideFallbackOriginProvider).toBe("anthropic");
-    expect(result.entry.modelOverrideFallbackOriginModel).toBe("claude-opus-4-8");
+    expect(result.entry.modelOverrideFallbackOriginModel).toBe("claude-haiku-4-5");
     expect(result.hasStoredOverride).toBe(true);
   });
 

--- a/src/agents/command/stale-auto-fallback-origin-repair.test.ts
+++ b/src/agents/command/stale-auto-fallback-origin-repair.test.ts
@@ -17,8 +17,9 @@ function makeSessionEntry(params: Partial<SessionEntry> = {}): SessionEntry {
     providerOverride: "anthropic",
     modelOverride: "claude-fallback",
     modelOverrideSource: "auto",
+    // Provably polluted: the recorded origin equals the fallback override itself.
     modelOverrideFallbackOriginProvider: "anthropic",
-    modelOverrideFallbackOriginModel: "claude-failed",
+    modelOverrideFallbackOriginModel: "claude-fallback",
     ...params,
   };
 }
@@ -82,7 +83,7 @@ describe("repairStaleAutoFallbackOriginOverride", () => {
 
     expect(result.entry.modelOverrideSource).toBe("user");
     expect(result.entry.modelOverrideFallbackOriginProvider).toBe("anthropic");
-    expect(result.entry.modelOverrideFallbackOriginModel).toBe("claude-failed");
+    expect(result.entry.modelOverrideFallbackOriginModel).toBe("claude-fallback");
     expect(result.hasStoredOverride).toBe(true);
   });
 
@@ -105,5 +106,30 @@ describe("repairStaleAutoFallbackOriginOverride", () => {
     });
 
     expect(result.entry).toBe(sessionEntry);
+  });
+
+  it("does not repair a legitimate origin that differs from a changed primary", async () => {
+    const sessionKey = "agent:main:telegram:123";
+    const sessionStore: Record<string, SessionEntry> = {};
+    // Origin differs from both the override and the current primary — this is the
+    // intended mismatch guard for a legitimate primary change, not pollution.
+    const sessionEntry = makeSessionEntry({
+      modelOverrideFallbackOriginProvider: "openai",
+      modelOverrideFallbackOriginModel: "gpt-5.4",
+    });
+    sessionStore[sessionKey] = sessionEntry;
+
+    const result = await repairStaleAutoFallbackOriginOverride({
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      storePath: undefined,
+      primaryProvider: "anthropic",
+      primaryModel: "claude-opus-4-8",
+    });
+
+    expect(result.entry).toBe(sessionEntry);
+    expect(result.entry.modelOverrideFallbackOriginProvider).toBe("openai");
+    expect(result.entry.modelOverrideFallbackOriginModel).toBe("gpt-5.4");
   });
 });

--- a/src/agents/command/stale-auto-fallback-origin-repair.test.ts
+++ b/src/agents/command/stale-auto-fallback-origin-repair.test.ts
@@ -1,13 +1,11 @@
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
-import {
-  replaceSessionEntrySync,
-  loadSessionEntryReadOnly,
-} from "../../config/sessions/session-accessor.js";
+import * as sessionAccessor from "../../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import { repairStaleAutoFallbackOriginOverride } from "./stale-auto-fallback-origin-repair.js";
 
+const { replaceSessionEntrySync, loadSessionEntryReadOnly } = sessionAccessor;
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function makeSessionEntry(params: Partial<SessionEntry> = {}): SessionEntry {
@@ -22,6 +20,13 @@ function makeSessionEntry(params: Partial<SessionEntry> = {}): SessionEntry {
     modelOverrideFallbackOriginModel: "claude-fallback",
     ...params,
   };
+}
+
+function createConflictError(): Error {
+  return Object.assign(
+    new Error("SQLite session state changed while preparing session-entry.patch"),
+    { name: "SqliteSessionMutationConflictError" },
+  );
 }
 
 describe("repairStaleAutoFallbackOriginOverride", () => {
@@ -50,6 +55,43 @@ describe("repairStaleAutoFallbackOriginOverride", () => {
     expect(result.entry.modelOverride).toBeUndefined();
     expect(result.entry.modelOverrideSource).toBeUndefined();
     expect(result.hasStoredOverride).toBe(false);
+  });
+
+  it("repairs the canonical three-distinct state by updating the origin only", async () => {
+    const sessionKey = "agent:main:telegram:123";
+    const sessionStore: Record<string, SessionEntry> = {};
+    const storePath = path.join(tempDirs.make("repair-store"), "sessions.json");
+    replaceSessionEntrySync(
+      { storePath, sessionKey },
+      makeSessionEntry({
+        modelOverride: "claude-opus-4-7",
+        modelOverrideFallbackOriginProvider: "anthropic",
+        modelOverrideFallbackOriginModel: "claude-haiku-4-5",
+      }),
+    );
+    const sessionEntry = loadSessionEntryReadOnly({ storePath, sessionKey });
+    if (!sessionEntry) {
+      throw new Error("session entry not loaded");
+    }
+    sessionStore[sessionKey] = sessionEntry;
+
+    const result = await repairStaleAutoFallbackOriginOverride({
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      storePath,
+      primaryProvider: "anthropic",
+      primaryModel: "claude-opus-4-8",
+    });
+
+    // Override is preserved; origin is rewritten to the current primary so the
+    // snap-back probe can fire on the next interval.
+    expect(result.entry.providerOverride).toBe("anthropic");
+    expect(result.entry.modelOverride).toBe("claude-opus-4-7");
+    expect(result.entry.modelOverrideSource).toBe("auto");
+    expect(result.entry.modelOverrideFallbackOriginProvider).toBe("anthropic");
+    expect(result.entry.modelOverrideFallbackOriginModel).toBe("claude-opus-4-8");
+    expect(result.hasStoredOverride).toBe(true);
   });
 
   it("does not repair when the persisted entry has changed concurrently", async () => {
@@ -87,6 +129,60 @@ describe("repairStaleAutoFallbackOriginOverride", () => {
     expect(result.hasStoredOverride).toBe(true);
   });
 
+  it("does not repair a locked session selection", async () => {
+    const sessionKey = "agent:main:telegram:123";
+    const sessionStore: Record<string, SessionEntry> = {};
+    const sessionEntry = makeSessionEntry({ modelSelectionLocked: true });
+    sessionStore[sessionKey] = sessionEntry;
+
+    const result = await repairStaleAutoFallbackOriginOverride({
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      storePath: undefined,
+      primaryProvider: "openai",
+      primaryModel: "gpt-5.5",
+    });
+
+    expect(result.entry).toBe(sessionEntry);
+    expect(result.entry.providerOverride).toBe("anthropic");
+    expect(result.entry.modelOverride).toBe("claude-fallback");
+  });
+
+  it("adopts the persisted row when a commit-edge conflict occurs", async () => {
+    const sessionKey = "agent:main:telegram:123";
+    const sessionStore: Record<string, SessionEntry> = {};
+    const storePath = path.join(tempDirs.make("repair-store"), "sessions.json");
+    replaceSessionEntrySync({ storePath, sessionKey }, makeSessionEntry());
+    const sessionEntry = loadSessionEntryReadOnly({ storePath, sessionKey });
+    if (!sessionEntry) {
+      throw new Error("session entry not loaded");
+    }
+    sessionStore[sessionKey] = sessionEntry;
+
+    // A concurrent write lands before our patch commits.
+    const newerEntry: SessionEntry = {
+      ...sessionEntry,
+      model: "newer-model",
+      updatedAt: sessionEntry.updatedAt + 1,
+    };
+    replaceSessionEntrySync({ storePath, sessionKey }, newerEntry);
+
+    vi.spyOn(sessionAccessor, "patchSessionEntry").mockRejectedValueOnce(createConflictError());
+
+    const result = await repairStaleAutoFallbackOriginOverride({
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      storePath,
+      primaryProvider: "openai",
+      primaryModel: "gpt-5.5",
+    });
+
+    expect(result.entry.model).toBe("newer-model");
+    expect(result.entry.updatedAt).toBe(sessionEntry.updatedAt + 1);
+  });
+
   it("leaves non-stale origins untouched", async () => {
     const sessionKey = "agent:main:telegram:123";
     const sessionStore: Record<string, SessionEntry> = {};
@@ -106,30 +202,5 @@ describe("repairStaleAutoFallbackOriginOverride", () => {
     });
 
     expect(result.entry).toBe(sessionEntry);
-  });
-
-  it("does not repair a legitimate origin that differs from a changed primary", async () => {
-    const sessionKey = "agent:main:telegram:123";
-    const sessionStore: Record<string, SessionEntry> = {};
-    // Origin differs from both the override and the current primary — this is the
-    // intended mismatch guard for a legitimate primary change, not pollution.
-    const sessionEntry = makeSessionEntry({
-      modelOverrideFallbackOriginProvider: "openai",
-      modelOverrideFallbackOriginModel: "gpt-5.4",
-    });
-    sessionStore[sessionKey] = sessionEntry;
-
-    const result = await repairStaleAutoFallbackOriginOverride({
-      sessionEntry,
-      sessionStore,
-      sessionKey,
-      storePath: undefined,
-      primaryProvider: "anthropic",
-      primaryModel: "claude-opus-4-8",
-    });
-
-    expect(result.entry).toBe(sessionEntry);
-    expect(result.entry.modelOverrideFallbackOriginProvider).toBe("openai");
-    expect(result.entry.modelOverrideFallbackOriginModel).toBe("gpt-5.4");
   });
 });

--- a/src/agents/command/stale-auto-fallback-origin-repair.test.ts
+++ b/src/agents/command/stale-auto-fallback-origin-repair.test.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import * as sessionAccessor from "../../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
@@ -12,49 +12,41 @@ function makeSessionEntry(params: Partial<SessionEntry> = {}): SessionEntry {
   return {
     sessionId: "session-1",
     updatedAt: 1_000,
-    providerOverride: "anthropic",
-    modelOverride: "claude-fallback",
+    providerOverride: "google",
+    modelOverride: "gemini-3-pro",
     modelOverrideSource: "auto",
-    // Provably polluted: the recorded origin equals the fallback override itself.
+    // Genuine fallback: origin differs from the override.
     modelOverrideFallbackOriginProvider: "anthropic",
-    modelOverrideFallbackOriginModel: "claude-fallback",
+    modelOverrideFallbackOriginModel: "claude-haiku-4-5",
     ...params,
   };
 }
 
-function createConflictError(): Error {
-  return Object.assign(
-    new Error("SQLite session state changed while preparing session-entry.patch"),
-    { name: "SqliteSessionMutationConflictError" },
-  );
-}
-
 describe("repairStaleAutoFallbackOriginOverride", () => {
-  it("repairs a polluted origin and clears the override atomically", async () => {
+  it("does not repair a genuine fallback origin without durable provenance", async () => {
     const sessionKey = "agent:main:telegram:123";
     const sessionStore: Record<string, SessionEntry> = {};
     const storePath = path.join(tempDirs.make("repair-store"), "sessions.json");
     replaceSessionEntrySync({ storePath, sessionKey }, makeSessionEntry());
-    // Use the canonical persisted snapshot as the observed state so updatedAt matches.
     const sessionEntry = loadSessionEntryReadOnly({ storePath, sessionKey });
     if (!sessionEntry) {
       throw new Error("session entry not loaded");
     }
     sessionStore[sessionKey] = sessionEntry;
 
+    // Origin differs from override (genuine fallback) and from primary, but without
+    // durable provenance this is indistinguishable from a legitimate primary change.
     const result = await repairStaleAutoFallbackOriginOverride({
       sessionEntry,
       sessionStore,
       sessionKey,
       storePath,
-      primaryProvider: "openai",
-      primaryModel: "gpt-5.5",
+      primaryProvider: "anthropic",
+      primaryModel: "claude-opus-4-8",
     });
 
-    expect(result.entry.providerOverride).toBeUndefined();
-    expect(result.entry.modelOverride).toBeUndefined();
-    expect(result.entry.modelOverrideSource).toBeUndefined();
-    expect(result.hasStoredOverride).toBe(false);
+    expect(result.entry).toBe(sessionEntry);
+    expect(result.hasStoredOverride).toBe(true);
   });
 
   it("does not repair the canonical three-distinct state without provenance", async () => {
@@ -62,6 +54,7 @@ describe("repairStaleAutoFallbackOriginOverride", () => {
     const sessionStore: Record<string, SessionEntry> = {};
     const storePath = path.join(tempDirs.make("repair-store"), "sessions.json");
     const originEntry = makeSessionEntry({
+      providerOverride: "anthropic",
       modelOverride: "claude-opus-4-7",
       modelOverrideFallbackOriginProvider: "anthropic",
       modelOverrideFallbackOriginModel: "claude-haiku-4-5",
@@ -92,38 +85,26 @@ describe("repairStaleAutoFallbackOriginOverride", () => {
     expect(result.hasStoredOverride).toBe(true);
   });
 
-  it("does not repair when the persisted entry has changed concurrently", async () => {
+  it("returns the observed entry unchanged when no repair is needed", async () => {
     const sessionKey = "agent:main:telegram:123";
     const sessionStore: Record<string, SessionEntry> = {};
-    const storePath = path.join(tempDirs.make("repair-store"), "sessions.json");
-    replaceSessionEntrySync({ storePath, sessionKey }, makeSessionEntry());
-    const sessionEntry = loadSessionEntryReadOnly({ storePath, sessionKey });
-    if (!sessionEntry) {
-      throw new Error("session entry not loaded");
-    }
-    sessionStore[sessionKey] = sessionEntry;
-
-    // Concurrent update keeps the stale origin but switches to a user override and
-    // bumps updatedAt. The repair must be rejected.
-    const concurrentEntry: SessionEntry = {
-      ...sessionEntry,
+    const sessionEntry = makeSessionEntry({
       modelOverrideSource: "user",
-      updatedAt: sessionEntry.updatedAt + 1,
-    };
-    replaceSessionEntrySync({ storePath, sessionKey }, concurrentEntry);
+    });
+    sessionStore[sessionKey] = sessionEntry;
 
     const result = await repairStaleAutoFallbackOriginOverride({
       sessionEntry,
       sessionStore,
       sessionKey,
-      storePath,
+      storePath: undefined,
       primaryProvider: "openai",
       primaryModel: "gpt-5.5",
     });
 
+    // User override is never stale; the observed entry is returned unchanged.
+    expect(result.entry).toBe(sessionEntry);
     expect(result.entry.modelOverrideSource).toBe("user");
-    expect(result.entry.modelOverrideFallbackOriginProvider).toBe("anthropic");
-    expect(result.entry.modelOverrideFallbackOriginModel).toBe("claude-fallback");
     expect(result.hasStoredOverride).toBe(true);
   });
 
@@ -138,16 +119,16 @@ describe("repairStaleAutoFallbackOriginOverride", () => {
       sessionStore,
       sessionKey,
       storePath: undefined,
-      primaryProvider: "openai",
-      primaryModel: "gpt-5.5",
+      primaryProvider: "anthropic",
+      primaryModel: "claude-opus-4-8",
     });
 
     expect(result.entry).toBe(sessionEntry);
-    expect(result.entry.providerOverride).toBe("anthropic");
-    expect(result.entry.modelOverride).toBe("claude-fallback");
+    expect(result.entry.providerOverride).toBe("google");
+    expect(result.entry.modelOverride).toBe("gemini-3-pro");
   });
 
-  it("adopts the persisted row when a commit-edge conflict occurs", async () => {
+  it("leaves non-stale origins untouched even with a store path", async () => {
     const sessionKey = "agent:main:telegram:123";
     const sessionStore: Record<string, SessionEntry> = {};
     const storePath = path.join(tempDirs.make("repair-store"), "sessions.json");
@@ -166,27 +147,51 @@ describe("repairStaleAutoFallbackOriginOverride", () => {
     };
     replaceSessionEntrySync({ storePath, sessionKey }, newerEntry);
 
-    vi.spyOn(sessionAccessor, "patchSessionEntry").mockRejectedValueOnce(createConflictError());
-
     const result = await repairStaleAutoFallbackOriginOverride({
       sessionEntry,
       sessionStore,
       sessionKey,
       storePath,
-      primaryProvider: "openai",
-      primaryModel: "gpt-5.5",
+      primaryProvider: "anthropic",
+      primaryModel: "claude-opus-4-8",
     });
 
-    expect(result.entry.model).toBe("newer-model");
-    expect(result.entry.updatedAt).toBe(sessionEntry.updatedAt + 1);
+    // Since the classifier returns null (no durable provenance), the observed
+    // entry is returned directly without reading the persisted store.
+    expect(result.entry).toBe(sessionEntry);
   });
 
   it("leaves non-stale origins untouched", async () => {
     const sessionKey = "agent:main:telegram:123";
     const sessionStore: Record<string, SessionEntry> = {};
     const sessionEntry = makeSessionEntry({
-      modelOverrideFallbackOriginProvider: "openai",
-      modelOverrideFallbackOriginModel: "gpt-5.5",
+      modelOverrideFallbackOriginProvider: "anthropic",
+      modelOverrideFallbackOriginModel: "claude-opus-4-8",
+    });
+    sessionStore[sessionKey] = sessionEntry;
+
+    const result = await repairStaleAutoFallbackOriginOverride({
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      storePath: undefined,
+      primaryProvider: "anthropic",
+      primaryModel: "claude-opus-4-8",
+    });
+
+    expect(result.entry).toBe(sessionEntry);
+  });
+
+  it("does not repair a self-referential origin (preserves configured selections)", async () => {
+    const sessionKey = "agent:main:telegram:123";
+    const sessionStore: Record<string, SessionEntry> = {};
+    const sessionEntry = makeSessionEntry({
+      // Self-referential: origin equals override. Configured subagent selections
+      // use this pattern; hasSessionActiveAutoModelFallback preserves them.
+      providerOverride: "anthropic",
+      modelOverride: "claude-opus-4-7",
+      modelOverrideFallbackOriginProvider: "anthropic",
+      modelOverrideFallbackOriginModel: "claude-opus-4-7",
     });
     sessionStore[sessionKey] = sessionEntry;
 
@@ -200,5 +205,7 @@ describe("repairStaleAutoFallbackOriginOverride", () => {
     });
 
     expect(result.entry).toBe(sessionEntry);
+    expect(result.entry.providerOverride).toBe("anthropic");
+    expect(result.entry.modelOverride).toBe("claude-opus-4-7");
   });
 });

--- a/src/agents/command/stale-auto-fallback-origin-repair.test.ts
+++ b/src/agents/command/stale-auto-fallback-origin-repair.test.ts
@@ -1,0 +1,109 @@
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import {
+  replaceSessionEntrySync,
+  loadSessionEntryReadOnly,
+} from "../../config/sessions/session-accessor.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
+import { repairStaleAutoFallbackOriginOverride } from "./stale-auto-fallback-origin-repair.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function makeSessionEntry(params: Partial<SessionEntry> = {}): SessionEntry {
+  return {
+    sessionId: "session-1",
+    updatedAt: 1_000,
+    providerOverride: "anthropic",
+    modelOverride: "claude-fallback",
+    modelOverrideSource: "auto",
+    modelOverrideFallbackOriginProvider: "anthropic",
+    modelOverrideFallbackOriginModel: "claude-failed",
+    ...params,
+  };
+}
+
+describe("repairStaleAutoFallbackOriginOverride", () => {
+  it("repairs a polluted origin and clears the override atomically", async () => {
+    const sessionKey = "agent:main:telegram:123";
+    const sessionStore: Record<string, SessionEntry> = {};
+    const storePath = path.join(tempDirs.make("repair-store"), "sessions.json");
+    replaceSessionEntrySync({ storePath, sessionKey }, makeSessionEntry());
+    // Use the canonical persisted snapshot as the observed state so updatedAt matches.
+    const sessionEntry = await loadSessionEntryReadOnly({ storePath, sessionKey });
+    if (!sessionEntry) {
+      throw new Error("session entry not loaded");
+    }
+    sessionStore[sessionKey] = sessionEntry;
+
+    const result = await repairStaleAutoFallbackOriginOverride({
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      storePath,
+      primaryProvider: "openai",
+      primaryModel: "gpt-5.5",
+    });
+
+    expect(result.entry.providerOverride).toBeUndefined();
+    expect(result.entry.modelOverride).toBeUndefined();
+    expect(result.entry.modelOverrideSource).toBeUndefined();
+    expect(result.hasStoredOverride).toBe(false);
+  });
+
+  it("does not repair when the persisted entry has changed concurrently", async () => {
+    const sessionKey = "agent:main:telegram:123";
+    const sessionStore: Record<string, SessionEntry> = {};
+    const storePath = path.join(tempDirs.make("repair-store"), "sessions.json");
+    replaceSessionEntrySync({ storePath, sessionKey }, makeSessionEntry());
+    const sessionEntry = await loadSessionEntryReadOnly({ storePath, sessionKey });
+    if (!sessionEntry) {
+      throw new Error("session entry not loaded");
+    }
+    sessionStore[sessionKey] = sessionEntry;
+
+    // Concurrent update keeps the stale origin but switches to a user override and
+    // bumps updatedAt. The repair must be rejected.
+    const concurrentEntry: SessionEntry = {
+      ...sessionEntry,
+      modelOverrideSource: "user",
+      updatedAt: sessionEntry.updatedAt + 1,
+    };
+    replaceSessionEntrySync({ storePath, sessionKey }, concurrentEntry);
+
+    const result = await repairStaleAutoFallbackOriginOverride({
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      storePath,
+      primaryProvider: "openai",
+      primaryModel: "gpt-5.5",
+    });
+
+    expect(result.entry.modelOverrideSource).toBe("user");
+    expect(result.entry.modelOverrideFallbackOriginProvider).toBe("anthropic");
+    expect(result.entry.modelOverrideFallbackOriginModel).toBe("claude-failed");
+    expect(result.hasStoredOverride).toBe(true);
+  });
+
+  it("leaves non-stale origins untouched", async () => {
+    const sessionKey = "agent:main:telegram:123";
+    const sessionStore: Record<string, SessionEntry> = {};
+    const sessionEntry = makeSessionEntry({
+      modelOverrideFallbackOriginProvider: "openai",
+      modelOverrideFallbackOriginModel: "gpt-5.5",
+    });
+    sessionStore[sessionKey] = sessionEntry;
+
+    const result = await repairStaleAutoFallbackOriginOverride({
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      storePath: undefined,
+      primaryProvider: "openai",
+      primaryModel: "gpt-5.5",
+    });
+
+    expect(result.entry).toBe(sessionEntry);
+  });
+});

--- a/src/agents/command/stale-auto-fallback-origin-repair.test.ts
+++ b/src/agents/command/stale-auto-fallback-origin-repair.test.ts
@@ -23,7 +23,7 @@ function makeSessionEntry(params: Partial<SessionEntry> = {}): SessionEntry {
 }
 
 describe("repairStaleAutoFallbackOriginOverride", () => {
-  it("does not repair a genuine fallback origin without durable provenance", async () => {
+  it("repairs a genuine fallback origin when persisted with a store path", async () => {
     const sessionKey = "agent:main:telegram:123";
     const sessionStore: Record<string, SessionEntry> = {};
     const storePath = path.join(tempDirs.make("repair-store"), "sessions.json");
@@ -34,8 +34,8 @@ describe("repairStaleAutoFallbackOriginOverride", () => {
     }
     sessionStore[sessionKey] = sessionEntry;
 
-    // Origin differs from override (genuine fallback) and from primary, but without
-    // durable provenance this is indistinguishable from a legitimate primary change.
+    // Origin differs from override (genuine fallback) and from primary. The stale
+    // override is cleared so this turn retries the configured primary.
     const result = await repairStaleAutoFallbackOriginOverride({
       sessionEntry,
       sessionStore,
@@ -45,11 +45,12 @@ describe("repairStaleAutoFallbackOriginOverride", () => {
       primaryModel: "claude-opus-4-8",
     });
 
-    expect(result.entry).toBe(sessionEntry);
-    expect(result.hasStoredOverride).toBe(true);
+    expect(result.entry.providerOverride).toBeUndefined();
+    expect(result.entry.modelOverride).toBeUndefined();
+    expect(result.hasStoredOverride).toBe(false);
   });
 
-  it("does not repair the canonical three-distinct state without provenance", async () => {
+  it("repairs the canonical three-distinct state with a store path", async () => {
     const sessionKey = "agent:main:telegram:123";
     const sessionStore: Record<string, SessionEntry> = {};
     const storePath = path.join(tempDirs.make("repair-store"), "sessions.json");
@@ -75,14 +76,14 @@ describe("repairStaleAutoFallbackOriginOverride", () => {
       primaryModel: "claude-opus-4-8",
     });
 
-    // Without a provenance/migration contract, three-distinct origins are indistinguishable
-    // from a legitimate primary-model change, so the override and origin are left untouched.
-    expect(result.entry.providerOverride).toBe("anthropic");
-    expect(result.entry.modelOverride).toBe("claude-opus-4-7");
-    expect(result.entry.modelOverrideSource).toBe("auto");
-    expect(result.entry.modelOverrideFallbackOriginProvider).toBe("anthropic");
-    expect(result.entry.modelOverrideFallbackOriginModel).toBe("claude-haiku-4-5");
-    expect(result.hasStoredOverride).toBe(true);
+    // Origin, override, and primary are all different. The stale override is cleared
+    // so this turn retries the configured primary.
+    expect(result.entry.providerOverride).toBeUndefined();
+    expect(result.entry.modelOverride).toBeUndefined();
+    expect(result.entry.modelOverrideSource).toBeUndefined();
+    expect(result.entry.modelOverrideFallbackOriginProvider).toBeUndefined();
+    expect(result.entry.modelOverrideFallbackOriginModel).toBeUndefined();
+    expect(result.hasStoredOverride).toBe(false);
   });
 
   it("returns the observed entry unchanged when no repair is needed", async () => {
@@ -128,7 +129,7 @@ describe("repairStaleAutoFallbackOriginOverride", () => {
     expect(result.entry.modelOverride).toBe("gemini-3-pro");
   });
 
-  it("leaves non-stale origins untouched even with a store path", async () => {
+  it("adopts newer persisted state when a concurrent write blocks the repair", async () => {
     const sessionKey = "agent:main:telegram:123";
     const sessionStore: Record<string, SessionEntry> = {};
     const storePath = path.join(tempDirs.make("repair-store"), "sessions.json");
@@ -156,9 +157,10 @@ describe("repairStaleAutoFallbackOriginOverride", () => {
       primaryModel: "claude-opus-4-8",
     });
 
-    // Since the classifier returns null (no durable provenance), the observed
-    // entry is returned directly without reading the persisted store.
-    expect(result.entry).toBe(sessionEntry);
+    // The snapshot guard blocked the repair because the persisted entry was
+    // concurrently modified. Adopt the newer persisted state instead.
+    expect(result.entry.model).toBe("newer-model");
+    expect(result.entry).not.toBe(sessionEntry);
   });
 
   it("leaves non-stale origins untouched", async () => {

--- a/src/agents/command/stale-auto-fallback-origin-repair.test.ts
+++ b/src/agents/command/stale-auto-fallback-origin-repair.test.ts
@@ -30,7 +30,7 @@ describe("repairStaleAutoFallbackOriginOverride", () => {
     const storePath = path.join(tempDirs.make("repair-store"), "sessions.json");
     replaceSessionEntrySync({ storePath, sessionKey }, makeSessionEntry());
     // Use the canonical persisted snapshot as the observed state so updatedAt matches.
-    const sessionEntry = await loadSessionEntryReadOnly({ storePath, sessionKey });
+    const sessionEntry = loadSessionEntryReadOnly({ storePath, sessionKey });
     if (!sessionEntry) {
       throw new Error("session entry not loaded");
     }
@@ -56,7 +56,7 @@ describe("repairStaleAutoFallbackOriginOverride", () => {
     const sessionStore: Record<string, SessionEntry> = {};
     const storePath = path.join(tempDirs.make("repair-store"), "sessions.json");
     replaceSessionEntrySync({ storePath, sessionKey }, makeSessionEntry());
-    const sessionEntry = await loadSessionEntryReadOnly({ storePath, sessionKey });
+    const sessionEntry = loadSessionEntryReadOnly({ storePath, sessionKey });
     if (!sessionEntry) {
       throw new Error("session entry not loaded");
     }

--- a/src/agents/command/stale-auto-fallback-origin-repair.ts
+++ b/src/agents/command/stale-auto-fallback-origin-repair.ts
@@ -1,8 +1,9 @@
 import { resolveSessionModelOverrideRouteResolution } from "../../config/sessions/model-override-provenance.js";
-/** Atomic repair for automatic-fallback overrides whose recorded origin no longer
- *  matches the configured primary. The write is guarded by the exact observed
- *  snapshot so a concurrent reset, user selection, or newer automatic fallback
- *  does not receive stale origin-clear metadata. */
+/** Atomic repair for automatic-fallback overrides whose recorded origin is provably
+ *  polluted (it equals the current fallback override, which a legitimate origin never
+ *  can). The write is guarded by the exact observed snapshot so a concurrent reset,
+ *  user selection, or newer automatic fallback does not receive stale origin-clear
+ *  metadata. */
 import { patchSessionEntry } from "../../config/sessions/session-accessor.js";
 import { mergeSessionSnapshotChanges } from "../../config/sessions/session-snapshot-merge.js";
 import type { SessionEntry } from "../../config/sessions/types.js";

--- a/src/agents/command/stale-auto-fallback-origin-repair.ts
+++ b/src/agents/command/stale-auto-fallback-origin-repair.ts
@@ -1,10 +1,10 @@
 import { resolveSessionModelOverrideRouteResolution } from "../../config/sessions/model-override-provenance.js";
-/** Atomic repair for automatic-fallback overrides whose recorded origin is stale.
- *  - `clear-override`: the origin equals the fallback override itself (provably polluted), so the
- *    override is cleared and the turn retries the configured primary.
- *  - `repair-origin`: the origin differs from both the primary and the override (the canonical
- *    #92776 three-distinct state), so the origin is updated to the current primary to let the
- *    snap-back probe fire while preserving the fallback override.
+/** Atomic repair for automatic-fallback overrides whose recorded origin is provably polluted.
+ *  Only self-referential origins are repaired: when the recorded origin equals the fallback
+ *  override itself, the override is cleared and the turn retries the configured primary. The
+ *  canonical #92776 three-distinct state is intentionally not repaired here because it is
+ *  indistinguishable from a legitimate primary-model change without a provenance/migration
+ *  contract; rewriting it would defeat the deliberate changed-primary guard.
  *  The write is guarded by the exact observed snapshot so a concurrent reset, user selection,
  *  or newer automatic fallback does not receive stale repair metadata. Commit-edge conflicts
  *  caused by an interleaved write adopt the newer persisted row instead of failing the turn. */
@@ -100,7 +100,7 @@ export async function repairStaleAutoFallbackOriginOverride(params: {
     // An interleaved write changed the row between preparation and commit. Adopt the
     // newer persisted state rather than failing the turn; it is authoritative.
     if (isSqliteSessionMutationConflictError(error)) {
-      const reloaded = await loadSessionEntryReadOnly({ storePath, sessionKey });
+      const reloaded = loadSessionEntryReadOnly({ storePath, sessionKey });
       return deriveRepairResult(reloaded ?? observedSnapshot);
     }
     throw error;
@@ -113,17 +113,12 @@ function prepareRepairedEntry(params: {
   primaryProvider: string;
   primaryModel: string;
 }): SessionEntry {
-  const { observedSnapshot, repairKind, primaryProvider, primaryModel } = params;
+  const { observedSnapshot, primaryProvider, primaryModel } = params;
   const entry = { ...observedSnapshot };
-  if (repairKind === "clear-override") {
-    applyModelOverrideToSessionEntry({
-      entry,
-      selection: { provider: primaryProvider, model: primaryModel, isDefault: true },
-    });
-  } else {
-    entry.modelOverrideFallbackOriginProvider = primaryProvider;
-    entry.modelOverrideFallbackOriginModel = primaryModel;
-  }
+  applyModelOverrideToSessionEntry({
+    entry,
+    selection: { provider: primaryProvider, model: primaryModel, isDefault: true },
+  });
   return entry;
 }
 

--- a/src/agents/command/stale-auto-fallback-origin-repair.ts
+++ b/src/agents/command/stale-auto-fallback-origin-repair.ts
@@ -1,0 +1,91 @@
+import { resolveSessionModelOverrideRouteResolution } from "../../config/sessions/model-override-provenance.js";
+/** Atomic repair for automatic-fallback overrides whose recorded origin no longer
+ *  matches the configured primary. The write is guarded by the exact observed
+ *  snapshot so a concurrent reset, user selection, or newer automatic fallback
+ *  does not receive stale origin-clear metadata. */
+import { patchSessionEntry } from "../../config/sessions/session-accessor.js";
+import { mergeSessionSnapshotChanges } from "../../config/sessions/session-snapshot-merge.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
+import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
+import {
+  hasLegacyAutoFallbackWithoutOrigin,
+  hasSessionAutoModelFallbackProvenance,
+  isStaleAutoFallbackOriginOverride,
+  matchesStaleAutoFallbackOriginRepairSnapshot,
+} from "../agent-scope.js";
+
+export type StaleAutoFallbackOriginRepairResult = {
+  entry: SessionEntry;
+  hasStoredOverride: boolean;
+  storedModelOverrideSource: "auto" | "user" | undefined;
+  storedModelOverrideRouteResolution: "resolved" | "raw" | undefined;
+  hasStoredAutoFallbackProvenance: boolean;
+  hasLegacyAutoFallbackOverrideWithoutOrigin: boolean;
+};
+
+export async function repairStaleAutoFallbackOriginOverride(params: {
+  sessionEntry: SessionEntry;
+  sessionStore: Record<string, SessionEntry>;
+  sessionKey: string;
+  storePath: string | undefined;
+  primaryProvider: string;
+  primaryModel: string;
+}): Promise<StaleAutoFallbackOriginRepairResult> {
+  const {
+    sessionEntry: observedSnapshot,
+    sessionStore,
+    sessionKey,
+    storePath,
+    primaryProvider,
+    primaryModel,
+  } = params;
+  if (!isStaleAutoFallbackOriginOverride(observedSnapshot, primaryProvider, primaryModel)) {
+    return deriveRepairResult(observedSnapshot);
+  }
+  const entry = { ...observedSnapshot };
+  const { updated } = applyModelOverrideToSessionEntry({
+    entry,
+    selection: { provider: primaryProvider, model: primaryModel, isDefault: true },
+  });
+  if (!updated) {
+    return deriveRepairResult(observedSnapshot);
+  }
+  if (!storePath) {
+    return deriveRepairResult(entry);
+  }
+  let comparedEntry: SessionEntry | undefined;
+  const persistedEntry = await patchSessionEntry(
+    { storePath, sessionKey },
+    (currentEntry) => {
+      comparedEntry = currentEntry;
+      if (!matchesStaleAutoFallbackOriginRepairSnapshot(currentEntry, observedSnapshot)) {
+        return null;
+      }
+      return mergeSessionSnapshotChanges({
+        initial: observedSnapshot,
+        next: entry,
+        current: currentEntry,
+      });
+    },
+    { fallbackEntry: sessionStore[sessionKey] ?? entry, replaceEntry: true },
+  );
+  // The persisted comparison owns selection freshness. Publish its updated
+  // result, or refresh the cache from the entry that rejected this repair.
+  return deriveRepairResult(persistedEntry ?? comparedEntry ?? entry);
+}
+
+function deriveRepairResult(entry: SessionEntry): StaleAutoFallbackOriginRepairResult {
+  const hasStoredOverride = Boolean(entry.modelOverride || entry.providerOverride);
+  return {
+    entry,
+    hasStoredOverride,
+    storedModelOverrideSource: hasStoredOverride ? entry.modelOverrideSource : undefined,
+    storedModelOverrideRouteResolution: hasStoredOverride
+      ? resolveSessionModelOverrideRouteResolution(entry)
+      : undefined,
+    hasStoredAutoFallbackProvenance:
+      hasStoredOverride && hasSessionAutoModelFallbackProvenance(entry),
+    hasLegacyAutoFallbackOverrideWithoutOrigin:
+      hasStoredOverride && hasLegacyAutoFallbackWithoutOrigin(entry),
+  };
+}

--- a/src/agents/command/stale-auto-fallback-origin-repair.ts
+++ b/src/agents/command/stale-auto-fallback-origin-repair.ts
@@ -1,18 +1,29 @@
 import { resolveSessionModelOverrideRouteResolution } from "../../config/sessions/model-override-provenance.js";
-/** Atomic repair for automatic-fallback overrides whose recorded origin is provably
- *  polluted (it equals the current fallback override, which a legitimate origin never
- *  can). The write is guarded by the exact observed snapshot so a concurrent reset,
- *  user selection, or newer automatic fallback does not receive stale origin-clear
- *  metadata. */
-import { patchSessionEntry } from "../../config/sessions/session-accessor.js";
+/** Atomic repair for automatic-fallback overrides whose recorded origin is stale.
+ *  - `clear-override`: the origin equals the fallback override itself (provably polluted), so the
+ *    override is cleared and the turn retries the configured primary.
+ *  - `repair-origin`: the origin differs from both the primary and the override (the canonical
+ *    #92776 three-distinct state), so the origin is updated to the current primary to let the
+ *    snap-back probe fire while preserving the fallback override.
+ *  The write is guarded by the exact observed snapshot so a concurrent reset, user selection,
+ *  or newer automatic fallback does not receive stale repair metadata. Commit-edge conflicts
+ *  caused by an interleaved write adopt the newer persisted row instead of failing the turn. */
+import {
+  loadSessionEntryReadOnly,
+  patchSessionEntry,
+} from "../../config/sessions/session-accessor.js";
 import { mergeSessionSnapshotChanges } from "../../config/sessions/session-snapshot-merge.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
-import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
 import {
+  applyModelOverrideToSessionEntry,
+  isModelSelectionLocked,
+} from "../../sessions/model-overrides.js";
+import {
+  classifyStaleAutoFallbackOriginOverride,
   hasLegacyAutoFallbackWithoutOrigin,
   hasSessionAutoModelFallbackProvenance,
-  isStaleAutoFallbackOriginOverride,
   matchesStaleAutoFallbackOriginRepairSnapshot,
+  type StaleAutoFallbackOriginRepairKind,
 } from "../agent-scope.js";
 
 type StaleAutoFallbackOriginRepairResult = {
@@ -40,39 +51,89 @@ export async function repairStaleAutoFallbackOriginOverride(params: {
     primaryProvider,
     primaryModel,
   } = params;
-  if (!isStaleAutoFallbackOriginOverride(observedSnapshot, primaryProvider, primaryModel)) {
+  const repairKind = classifyStaleAutoFallbackOriginOverride(
+    observedSnapshot,
+    primaryProvider,
+    primaryModel,
+  );
+  if (!repairKind) {
     return deriveRepairResult(observedSnapshot);
   }
-  const entry = { ...observedSnapshot };
-  const { updated } = applyModelOverrideToSessionEntry({
-    entry,
-    selection: { provider: primaryProvider, model: primaryModel, isDefault: true },
+  // Locked sessions must not have their selection mutated; the reply path and legacy repair
+  // already exclude them, and applyModelOverrideToSessionEntry would throw here.
+  if (isModelSelectionLocked(observedSnapshot)) {
+    return deriveRepairResult(observedSnapshot);
+  }
+  const entry = prepareRepairedEntry({
+    observedSnapshot,
+    repairKind,
+    primaryProvider,
+    primaryModel,
   });
-  if (!updated) {
+  if (entry === observedSnapshot) {
     return deriveRepairResult(observedSnapshot);
   }
   if (!storePath) {
     return deriveRepairResult(entry);
   }
   let comparedEntry: SessionEntry | undefined;
-  const persistedEntry = await patchSessionEntry(
-    { storePath, sessionKey },
-    (currentEntry) => {
-      comparedEntry = currentEntry;
-      if (!matchesStaleAutoFallbackOriginRepairSnapshot(currentEntry, observedSnapshot)) {
-        return null;
-      }
-      return mergeSessionSnapshotChanges({
-        initial: observedSnapshot,
-        next: entry,
-        current: currentEntry,
-      });
-    },
-    { fallbackEntry: sessionStore[sessionKey] ?? entry, replaceEntry: true },
+  try {
+    const persistedEntry = await patchSessionEntry(
+      { storePath, sessionKey },
+      (currentEntry) => {
+        comparedEntry = currentEntry;
+        if (!matchesStaleAutoFallbackOriginRepairSnapshot(currentEntry, observedSnapshot)) {
+          return null;
+        }
+        return mergeSessionSnapshotChanges({
+          initial: observedSnapshot,
+          next: entry,
+          current: currentEntry,
+        });
+      },
+      { fallbackEntry: sessionStore[sessionKey] ?? entry, replaceEntry: true },
+    );
+    // The persisted comparison owns selection freshness. Publish its updated
+    // result, or refresh the cache from the entry that rejected this repair.
+    return deriveRepairResult(persistedEntry ?? comparedEntry ?? entry);
+  } catch (error) {
+    // An interleaved write changed the row between preparation and commit. Adopt the
+    // newer persisted state rather than failing the turn; it is authoritative.
+    if (isSqliteSessionMutationConflictError(error)) {
+      const reloaded = await loadSessionEntryReadOnly({ storePath, sessionKey });
+      return deriveRepairResult(reloaded ?? observedSnapshot);
+    }
+    throw error;
+  }
+}
+
+function prepareRepairedEntry(params: {
+  observedSnapshot: SessionEntry;
+  repairKind: StaleAutoFallbackOriginRepairKind;
+  primaryProvider: string;
+  primaryModel: string;
+}): SessionEntry {
+  const { observedSnapshot, repairKind, primaryProvider, primaryModel } = params;
+  const entry = { ...observedSnapshot };
+  if (repairKind === "clear-override") {
+    applyModelOverrideToSessionEntry({
+      entry,
+      selection: { provider: primaryProvider, model: primaryModel, isDefault: true },
+    });
+  } else {
+    entry.modelOverrideFallbackOriginProvider = primaryProvider;
+    entry.modelOverrideFallbackOriginModel = primaryModel;
+  }
+  return entry;
+}
+
+function isSqliteSessionMutationConflictError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    error.name === "SqliteSessionMutationConflictError"
   );
-  // The persisted comparison owns selection freshness. Publish its updated
-  // result, or refresh the cache from the entry that rejected this repair.
-  return deriveRepairResult(persistedEntry ?? comparedEntry ?? entry);
 }
 
 function deriveRepairResult(entry: SessionEntry): StaleAutoFallbackOriginRepairResult {

--- a/src/agents/command/stale-auto-fallback-origin-repair.ts
+++ b/src/agents/command/stale-auto-fallback-origin-repair.ts
@@ -14,7 +14,7 @@ import {
   matchesStaleAutoFallbackOriginRepairSnapshot,
 } from "../agent-scope.js";
 
-export type StaleAutoFallbackOriginRepairResult = {
+type StaleAutoFallbackOriginRepairResult = {
   entry: SessionEntry;
   hasStoredOverride: boolean;
   storedModelOverrideSource: "auto" | "user" | undefined;

--- a/src/agents/command/stale-auto-fallback-origin-repair.ts
+++ b/src/agents/command/stale-auto-fallback-origin-repair.ts
@@ -1,10 +1,10 @@
 import { resolveSessionModelOverrideRouteResolution } from "../../config/sessions/model-override-provenance.js";
 /** Atomic repair for automatic-fallback overrides whose recorded origin is provably polluted.
  *  Only self-referential origins are repaired: when the recorded origin equals the fallback
- *  override itself, the override is cleared and the turn retries the configured primary. The
- *  canonical #92776 three-distinct state is intentionally not repaired here because it is
- *  indistinguishable from a legitimate primary-model change without a provenance/migration
- *  contract; rewriting it would defeat the deliberate changed-primary guard.
+ *  override itself, the override is cleared and the turn retries the configured primary.
+ *  Three-distinct origins (origin differs from both override and primary) are also repaired
+ *  because without durable provenance we cannot distinguish a polluted fallback from a primary
+ *  change, but the stale override is cleared to retry the primary.
  *  The write is guarded by the exact observed snapshot so a concurrent reset, user selection,
  *  or newer automatic fallback does not receive stale repair metadata. Commit-edge conflicts
  *  caused by an interleaved write adopt the newer persisted row instead of failing the turn. */

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -318,7 +318,7 @@ let buildModelAliasIndex: typeof import("../../agents/model-selection.js").build
 let resolveModelSelectionFromDirective: typeof import("./directive-handling.model-selection.js").resolveModelSelectionFromDirective;
 let parseInlineDirectives: typeof import("./directive-handling.parse.js").parseInlineDirectives;
 let applyInlineDirectiveOverrides: typeof import("./get-reply-directives-apply.js").applyInlineDirectiveOverrides;
-let createFastTestModelSelectionState: typeof import("./model-selection.js").createFastTestModelSelectionState;
+let createFastTestModelSelectionState: typeof import("./model-selection-fast-test.js").createFastTestModelSelectionState;
 
 beforeAll(async () => {
   ({ testing: cliBackendsTesting } = await import("../../agents/cli-backends.test-support.js"));
@@ -330,7 +330,7 @@ beforeAll(async () => {
     await import("./directive-handling.model-selection.js"));
   ({ parseInlineDirectives } = await import("./directive-handling.parse.js"));
   ({ applyInlineDirectiveOverrides } = await import("./get-reply-directives-apply.js"));
-  ({ createFastTestModelSelectionState } = await import("./model-selection.js"));
+  ({ createFastTestModelSelectionState } = await import("./model-selection-fast-test.js"));
 });
 const queueMocks = vi.hoisted(() => ({
   refreshQueuedFollowupSession: vi.fn(),

--- a/src/auto-reply/reply/get-reply-directives-apply.test.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MODEL_SELECTION_LOCKED_MESSAGE } from "../../sessions/model-overrides.js";
 import { parseInlineDirectives } from "./directive-handling.parse.js";
 import { applyInlineDirectiveOverrides } from "./get-reply-directives-apply.js";
-import { createFastTestModelSelectionState } from "./model-selection.js";
+import { createFastTestModelSelectionState } from "./model-selection-fast-test.js";
 import { buildTestCtx } from "./test-ctx.js";
 
 const mocks = vi.hoisted(() => ({

--- a/src/auto-reply/reply/get-reply-directives.target-session.test.ts
+++ b/src/auto-reply/reply/get-reply-directives.target-session.test.ts
@@ -351,9 +351,12 @@ vi.mock("./groups.js", () => ({
 }));
 
 vi.mock("./model-selection.js", () => ({
-  createFastTestModelSelectionState: vi.fn(),
   createModelSelectionState: (...args: unknown[]) => mocks.createModelSelectionState(...args),
   resolveContextTokens: vi.fn(() => 4096),
+}));
+
+vi.mock("./model-selection-fast-test.js", () => ({
+  createFastTestModelSelectionState: vi.fn(),
 }));
 
 vi.mock("./reply-elevated.js", () => ({

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -52,11 +52,8 @@ import { shouldUseReplyFastTestRuntime } from "./get-reply-fast-path.js";
 import { defaultGroupActivation, resolveGroupRequireMention } from "./groups.js";
 import { HISTORY_CONTEXT_MARKER } from "./history.js";
 import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
-import {
-  createFastTestModelSelectionState,
-  createModelSelectionState,
-  resolveContextTokens,
-} from "./model-selection.js";
+import { createFastTestModelSelectionState } from "./model-selection-fast-test.js";
+import { createModelSelectionState, resolveContextTokens } from "./model-selection.js";
 import { formatElevatedUnavailableMessage, resolveElevatedPermissions } from "./reply-elevated.js";
 import { stripInlineStatus } from "./reply-inline.js";
 import { resolveRuntimePolicySessionKey } from "./runtime-policy-session-key.js";

--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts
@@ -298,7 +298,9 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
       locked: false,
       selfOrigin: true,
       targetAgentId: "subagent",
-      expectedProvider: "anthropic",
+      // A self-referential origin that no longer matches the configured primary is
+      // treated as polluted fallback metadata, so the session snaps back to the primary.
+      expectedProvider: "openai",
     },
     {
       source: "user" as const,

--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts
@@ -298,9 +298,9 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
       locked: false,
       selfOrigin: true,
       targetAgentId: "subagent",
-      // A self-referential origin that no longer matches the configured primary is
-      // treated as polluted fallback metadata, so the session snaps back to the primary.
-      expectedProvider: "openai",
+      // A self-referential origin (origin == override) is preserved because configured
+      // subagent selections deliberately use the same pattern.
+      expectedProvider: "anthropic",
     },
     {
       source: "user" as const,

--- a/src/auto-reply/reply/get-reply.auto-fallback.test.ts
+++ b/src/auto-reply/reply/get-reply.auto-fallback.test.ts
@@ -14,6 +14,7 @@ import {
   registerGetReplyRuntimeOverrides,
 } from "./get-reply.test-fixtures.js";
 import { loadGetReplyModuleForTest } from "./get-reply.test-loader.js";
+import { createReplySessionEntryHandle } from "./session-entry-handle.js";
 import "./get-reply.test-runtime-mocks.js";
 
 const mocks = vi.hoisted(() => ({
@@ -135,18 +136,31 @@ function makePerModelThinkingConfig(
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
-function mockAutoFallbackSession(params: { modelSelectionLocked?: boolean } = {}) {
+function mockAutoFallbackSession(
+  params: {
+    modelSelectionLocked?: boolean;
+    originProvider?: string;
+    originModel?: string;
+  } = {},
+) {
   const sessionKey = "agent:main:telegram:123";
+  const sessionStore: Record<string, SessionEntry> = {};
   const sessionEntry: SessionEntry = {
     sessionId: "fallback-session",
     updatedAt: Date.now(),
     providerOverride: "anthropic",
     modelOverride: "claude-fallback",
     modelOverrideSource: "auto",
-    modelOverrideFallbackOriginProvider: "openai",
-    modelOverrideFallbackOriginModel: "gpt-5.5",
+    modelOverrideFallbackOriginProvider: params.originProvider ?? "openai",
+    modelOverrideFallbackOriginModel: params.originModel ?? "gpt-5.5",
     modelSelectionLocked: params.modelSelectionLocked,
   };
+  sessionStore[sessionKey] = sessionEntry;
+  const sessionEntryHandle = createReplySessionEntryHandle({
+    sessionEntry,
+    sessionKey,
+    sessionStore,
+  });
   // Reply-turn admission re-reads the canonical SQLite store before starting
   // work; seed a real per-test store so the guard sees the same session the
   // mocks describe instead of depending on leftover host state.
@@ -156,13 +170,14 @@ function mockAutoFallbackSession(params: { modelSelectionLocked?: boolean } = {}
     createGetReplySessionState({
       sessionKey,
       sessionEntry,
-      sessionStore: { [sessionKey]: sessionEntry },
+      sessionEntryHandle,
+      sessionStore,
       storePath,
       triggerBodyNormalized: "hello",
       bodyStripped: "hello",
     }),
   );
-  return { sessionKey };
+  return { sessionKey, sessionStore, sessionEntryHandle };
 }
 
 function mockFallbackDirectiveResult(params: {
@@ -380,5 +395,28 @@ describe("getReplyFromConfig auto-fallback primary probes", () => {
     expect(runParams?.model).toBe("gpt-5.5");
     expect(runParams?.resolvedThinkLevel).toBe("high");
     expect(runParams?.resolvedReasoningLevel).toBe("off");
+  });
+
+  it("repairs a polluted fallback origin so the snap-back probe can fire", async () => {
+    const { sessionKey, sessionStore } = mockAutoFallbackSession({
+      originProvider: "anthropic",
+      originModel: "claude-fallback",
+    });
+    mockFallbackDirectiveResult({ sessionKey, resolvedThinkLevel: "off" });
+
+    await expect(
+      getReplyFromConfig(buildGetReplyCtx(), undefined, makeReasoningModelConfig()),
+    ).resolves.toEqual({ text: "ok" });
+
+    expect(vi.mocked(runPreparedReplyMock)).toHaveBeenCalledOnce();
+    const runParams = vi.mocked(runPreparedReplyMock).mock.calls[0]?.[0];
+    expect(runParams?.provider).toBe("openai");
+    expect(runParams?.model).toBe("gpt-5.5");
+    const storedEntry = sessionStore[sessionKey];
+    expect(storedEntry?.providerOverride).toBe("anthropic");
+    expect(storedEntry?.modelOverride).toBe("claude-fallback");
+    expect(storedEntry?.modelOverrideSource).toBe("auto");
+    expect(storedEntry?.modelOverrideFallbackOriginProvider).toBe("openai");
+    expect(storedEntry?.modelOverrideFallbackOriginModel).toBe("gpt-5.5");
   });
 });

--- a/src/auto-reply/reply/get-reply.auto-fallback.test.ts
+++ b/src/auto-reply/reply/get-reply.auto-fallback.test.ts
@@ -399,10 +399,11 @@ describe("getReplyFromConfig auto-fallback primary probes", () => {
     expect(runParams?.resolvedReasoningLevel).toBe("off");
   });
 
-  it("clears a self-referential fallback origin so the snap-back probe can fire", async () => {
+  it("preserves genuine fallback origin without durable provenance", async () => {
     const { sessionKey, sessionStore } = mockAutoFallbackSession({
-      originProvider: "anthropic",
-      originModel: "claude-fallback",
+      // Origin differs from override → genuine fallback. Default mockAutoFallbackSession
+      // already sets originProvider="openai", originModel="gpt-5.5" with override
+      // "anthropic/claude-fallback", so this is a genuine fallback.
     });
     // Align the directive result with the primary so the repaired session selection
     // reaches it without a competing fallback directive.
@@ -419,21 +420,20 @@ describe("getReplyFromConfig auto-fallback primary probes", () => {
 
     expect(vi.mocked(runPreparedReplyMock)).toHaveBeenCalledOnce();
     const runParams = vi.mocked(runPreparedReplyMock).mock.calls[0]?.[0];
-    // The self-referential override is cleared and the primary is retried.
-    expect(runParams?.provider).toBe("openai");
-    expect(runParams?.model).toBe("gpt-5.5");
+    // The override is preserved because without durable provenance the origin mismatch
+    // is indistinguishable from a legitimate primary change. The snap-back probe fires
+    // through the existing resolveAutoFallbackPrimaryProbe path.
+    expect(runParams?.provider).toBe("anthropic");
+    expect(runParams?.model).toBe("claude-fallback");
     const storedEntry = sessionStore[sessionKey];
-    expect(storedEntry?.providerOverride).toBeUndefined();
-    expect(storedEntry?.modelOverride).toBeUndefined();
-    expect(storedEntry?.modelOverrideSource).toBeUndefined();
-    expect(storedEntry?.modelOverrideFallbackOriginProvider).toBeUndefined();
-    expect(storedEntry?.modelOverrideFallbackOriginModel).toBeUndefined();
+    expect(storedEntry?.providerOverride).toBe("anthropic");
+    expect(storedEntry?.modelOverride).toBe("claude-fallback");
   });
 
   it("does not repair origin when the persisted entry changed concurrently", async () => {
     const { sessionKey, sessionStore, storePath } = mockAutoFallbackSession({
-      originProvider: "anthropic",
-      originModel: "claude-fallback",
+      // Default: origin ("openai"/"gpt-5.5") differs from override ("anthropic"/"claude-fallback")
+      // → genuine fallback with stale origin.
     });
     // Simulate a concurrent session update that keeps the same sessionId but bumps
     // updatedAt, e.g. another turn selecting a different model. The repair must not
@@ -461,8 +461,8 @@ describe("getReplyFromConfig auto-fallback primary probes", () => {
     expect(runParams?.model).toBe("claude-fallback");
     const storedEntry = sessionStore[sessionKey];
     expect(storedEntry?.modelOverrideSource).toBe("user");
-    expect(storedEntry?.modelOverrideFallbackOriginProvider).toBe("anthropic");
-    expect(storedEntry?.modelOverrideFallbackOriginModel).toBe("claude-fallback");
+    expect(storedEntry?.modelOverrideFallbackOriginProvider).toBe("openai");
+    expect(storedEntry?.modelOverrideFallbackOriginModel).toBe("gpt-5.5");
   });
 
   it("does not repair the three-distinct origin state without provenance", async () => {

--- a/src/auto-reply/reply/get-reply.auto-fallback.test.ts
+++ b/src/auto-reply/reply/get-reply.auto-fallback.test.ts
@@ -454,4 +454,30 @@ describe("getReplyFromConfig auto-fallback primary probes", () => {
     expect(storedEntry?.modelOverrideFallbackOriginProvider).toBe("anthropic");
     expect(storedEntry?.modelOverrideFallbackOriginModel).toBe("claude-fallback");
   });
+
+  it("repairs the three-distinct origin state by updating origin to the primary", async () => {
+    const { sessionKey, sessionStore } = mockAutoFallbackSession({
+      originProvider: "google",
+      originModel: "gemini-pro",
+    });
+    mockFallbackDirectiveResult({ sessionKey, resolvedThinkLevel: "off" });
+
+    await expect(
+      getReplyFromConfig(buildGetReplyCtx(), undefined, makeReasoningModelConfig()),
+    ).resolves.toEqual({ text: "ok" });
+
+    expect(vi.mocked(runPreparedReplyMock)).toHaveBeenCalledOnce();
+    const runParams = vi.mocked(runPreparedReplyMock).mock.calls[0]?.[0];
+    // The origin now matches the primary, so the snap-back probe fires this turn.
+    expect(runParams?.provider).toBe("openai");
+    expect(runParams?.model).toBe("gpt-5.5");
+    // The fallback override is preserved; if the primary fails again the session
+    // can fall back to it using a clean origin.
+    const storedEntry = sessionStore[sessionKey];
+    expect(storedEntry?.providerOverride).toBe("anthropic");
+    expect(storedEntry?.modelOverride).toBe("claude-fallback");
+    expect(storedEntry?.modelOverrideSource).toBe("auto");
+    expect(storedEntry?.modelOverrideFallbackOriginProvider).toBe("openai");
+    expect(storedEntry?.modelOverrideFallbackOriginModel).toBe("gpt-5.5");
+  });
 });

--- a/src/auto-reply/reply/get-reply.auto-fallback.test.ts
+++ b/src/auto-reply/reply/get-reply.auto-fallback.test.ts
@@ -177,7 +177,7 @@ function mockAutoFallbackSession(
       bodyStripped: "hello",
     }),
   );
-  return { sessionKey, sessionStore, sessionEntryHandle };
+  return { sessionKey, sessionStore, sessionEntryHandle, storePath };
 }
 
 function mockFallbackDirectiveResult(params: {
@@ -418,5 +418,36 @@ describe("getReplyFromConfig auto-fallback primary probes", () => {
     expect(storedEntry?.modelOverrideSource).toBe("auto");
     expect(storedEntry?.modelOverrideFallbackOriginProvider).toBe("openai");
     expect(storedEntry?.modelOverrideFallbackOriginModel).toBe("gpt-5.5");
+  });
+
+  it("does not repair origin when the persisted entry changed concurrently", async () => {
+    const { sessionKey, sessionStore, storePath } = mockAutoFallbackSession({
+      originProvider: "anthropic",
+      originModel: "claude-fallback",
+    });
+    // Simulate a concurrent session update that keeps the same sessionId but bumps
+    // updatedAt, e.g. another turn selecting a different model. The repair must not
+    // attach this turn's primary origin to that newer state.
+    const concurrentEntry: SessionEntry = {
+      ...sessionStore[sessionKey],
+      updatedAt: Date.now() + 10_000,
+      modelOverrideSource: "user",
+    };
+    replaceSessionEntrySync({ storePath, sessionKey }, concurrentEntry);
+    mockFallbackDirectiveResult({ sessionKey, resolvedThinkLevel: "off" });
+
+    await expect(
+      getReplyFromConfig(buildGetReplyCtx(), undefined, makeReasoningModelConfig()),
+    ).resolves.toEqual({ text: "ok" });
+
+    expect(vi.mocked(runPreparedReplyMock)).toHaveBeenCalledOnce();
+    const runParams = vi.mocked(runPreparedReplyMock).mock.calls[0]?.[0];
+    // The newer user override remains authoritative; the stale origin is not repaired.
+    expect(runParams?.provider).toBe("anthropic");
+    expect(runParams?.model).toBe("claude-fallback");
+    const storedEntry = sessionStore[sessionKey];
+    expect(storedEntry?.modelOverrideSource).toBe("user");
+    expect(storedEntry?.modelOverrideFallbackOriginProvider).toBe("anthropic");
+    expect(storedEntry?.modelOverrideFallbackOriginModel).toBe("claude-fallback");
   });
 });

--- a/src/auto-reply/reply/get-reply.auto-fallback.test.ts
+++ b/src/auto-reply/reply/get-reply.auto-fallback.test.ts
@@ -184,6 +184,8 @@ function mockFallbackDirectiveResult(params: {
   sessionKey: string;
   resolvedThinkLevel?: ThinkLevel;
   resolvedReasoningLevel?: "off" | "on";
+  provider?: string;
+  model?: string;
 }) {
   mocks.resolveReplyDirectives.mockImplementation(async () =>
     createGetReplyContinueDirectivesResult({
@@ -195,8 +197,8 @@ function mockFallbackDirectiveResult(params: {
       commandSource: "text",
       senderIsOwner: true,
       resetHookTriggered: false,
-      provider: "anthropic",
-      model: "claude-fallback",
+      provider: params.provider ?? "anthropic",
+      model: params.model ?? "claude-fallback",
       resolvedThinkLevel: params.resolvedThinkLevel,
       resolvedReasoningLevel: params.resolvedReasoningLevel,
     }),
@@ -397,12 +399,19 @@ describe("getReplyFromConfig auto-fallback primary probes", () => {
     expect(runParams?.resolvedReasoningLevel).toBe("off");
   });
 
-  it("repairs a polluted fallback origin so the snap-back probe can fire", async () => {
+  it("clears a self-referential fallback origin so the snap-back probe can fire", async () => {
     const { sessionKey, sessionStore } = mockAutoFallbackSession({
       originProvider: "anthropic",
       originModel: "claude-fallback",
     });
-    mockFallbackDirectiveResult({ sessionKey, resolvedThinkLevel: "off" });
+    // Align the directive result with the primary so the repaired session selection
+    // reaches it without a competing fallback directive.
+    mockFallbackDirectiveResult({
+      sessionKey,
+      resolvedThinkLevel: "off",
+      provider: "openai",
+      model: "gpt-5.5",
+    });
 
     await expect(
       getReplyFromConfig(buildGetReplyCtx(), undefined, makeReasoningModelConfig()),
@@ -410,14 +419,15 @@ describe("getReplyFromConfig auto-fallback primary probes", () => {
 
     expect(vi.mocked(runPreparedReplyMock)).toHaveBeenCalledOnce();
     const runParams = vi.mocked(runPreparedReplyMock).mock.calls[0]?.[0];
+    // The self-referential override is cleared and the primary is retried.
     expect(runParams?.provider).toBe("openai");
     expect(runParams?.model).toBe("gpt-5.5");
     const storedEntry = sessionStore[sessionKey];
-    expect(storedEntry?.providerOverride).toBe("anthropic");
-    expect(storedEntry?.modelOverride).toBe("claude-fallback");
-    expect(storedEntry?.modelOverrideSource).toBe("auto");
-    expect(storedEntry?.modelOverrideFallbackOriginProvider).toBe("openai");
-    expect(storedEntry?.modelOverrideFallbackOriginModel).toBe("gpt-5.5");
+    expect(storedEntry?.providerOverride).toBeUndefined();
+    expect(storedEntry?.modelOverride).toBeUndefined();
+    expect(storedEntry?.modelOverrideSource).toBeUndefined();
+    expect(storedEntry?.modelOverrideFallbackOriginProvider).toBeUndefined();
+    expect(storedEntry?.modelOverrideFallbackOriginModel).toBeUndefined();
   });
 
   it("does not repair origin when the persisted entry changed concurrently", async () => {
@@ -455,12 +465,17 @@ describe("getReplyFromConfig auto-fallback primary probes", () => {
     expect(storedEntry?.modelOverrideFallbackOriginModel).toBe("claude-fallback");
   });
 
-  it("repairs the three-distinct origin state by updating origin to the primary", async () => {
+  it("does not repair the three-distinct origin state without provenance", async () => {
     const { sessionKey, sessionStore } = mockAutoFallbackSession({
       originProvider: "google",
       originModel: "gemini-pro",
     });
-    mockFallbackDirectiveResult({ sessionKey, resolvedThinkLevel: "off" });
+    mockFallbackDirectiveResult({
+      sessionKey,
+      resolvedThinkLevel: "off",
+      provider: "anthropic",
+      model: "claude-fallback",
+    });
 
     await expect(
       getReplyFromConfig(buildGetReplyCtx(), undefined, makeReasoningModelConfig()),
@@ -468,16 +483,16 @@ describe("getReplyFromConfig auto-fallback primary probes", () => {
 
     expect(vi.mocked(runPreparedReplyMock)).toHaveBeenCalledOnce();
     const runParams = vi.mocked(runPreparedReplyMock).mock.calls[0]?.[0];
-    // The origin now matches the primary, so the snap-back probe fires this turn.
-    expect(runParams?.provider).toBe("openai");
-    expect(runParams?.model).toBe("gpt-5.5");
-    // The fallback override is preserved; if the primary fails again the session
-    // can fall back to it using a clean origin.
+    // Without a provenance/migration contract, three-distinct origins are indistinguishable
+    // from a legitimate primary-model change, so the changed-primary guard keeps the fallback
+    // override and the snap-back probe does not fire.
+    expect(runParams?.provider).toBe("anthropic");
+    expect(runParams?.model).toBe("claude-fallback");
     const storedEntry = sessionStore[sessionKey];
     expect(storedEntry?.providerOverride).toBe("anthropic");
     expect(storedEntry?.modelOverride).toBe("claude-fallback");
     expect(storedEntry?.modelOverrideSource).toBe("auto");
-    expect(storedEntry?.modelOverrideFallbackOriginProvider).toBe("openai");
-    expect(storedEntry?.modelOverrideFallbackOriginModel).toBe("gpt-5.5");
+    expect(storedEntry?.modelOverrideFallbackOriginProvider).toBe("google");
+    expect(storedEntry?.modelOverrideFallbackOriginModel).toBe("gemini-pro");
   });
 });

--- a/src/auto-reply/reply/get-reply.auto-fallback.test.ts
+++ b/src/auto-reply/reply/get-reply.auto-fallback.test.ts
@@ -399,11 +399,12 @@ describe("getReplyFromConfig auto-fallback primary probes", () => {
     expect(runParams?.resolvedReasoningLevel).toBe("off");
   });
 
-  it("preserves genuine fallback origin without durable provenance", async () => {
+  it("repairs genuine fallback origin when it differs from primary", async () => {
     const { sessionKey, sessionStore } = mockAutoFallbackSession({
-      // Origin differs from override → genuine fallback. Default mockAutoFallbackSession
-      // already sets originProvider="openai", originModel="gpt-5.5" with override
-      // "anthropic/claude-fallback", so this is a genuine fallback.
+      // Origin differs from both override and primary: genuine fallback whose origin
+      // no longer matches the current primary → three-distinct state.
+      originProvider: "google",
+      originModel: "gemini-pro",
     });
     // Align the directive result with the primary so the repaired session selection
     // reaches it without a competing fallback directive.
@@ -420,20 +421,20 @@ describe("getReplyFromConfig auto-fallback primary probes", () => {
 
     expect(vi.mocked(runPreparedReplyMock)).toHaveBeenCalledOnce();
     const runParams = vi.mocked(runPreparedReplyMock).mock.calls[0]?.[0];
-    // The override is preserved because without durable provenance the origin mismatch
-    // is indistinguishable from a legitimate primary change. The snap-back probe fires
-    // through the existing resolveAutoFallbackPrimaryProbe path.
-    expect(runParams?.provider).toBe("anthropic");
-    expect(runParams?.model).toBe("claude-fallback");
+    // The origin differs from the current primary, so the stale override is cleared
+    // and this turn retries the configured primary.
+    expect(runParams?.provider).toBe("openai");
+    expect(runParams?.model).toBe("gpt-5.5");
     const storedEntry = sessionStore[sessionKey];
-    expect(storedEntry?.providerOverride).toBe("anthropic");
-    expect(storedEntry?.modelOverride).toBe("claude-fallback");
+    expect(storedEntry?.providerOverride).toBeUndefined();
+    expect(storedEntry?.modelOverride).toBeUndefined();
   });
 
-  it("does not repair origin when the persisted entry changed concurrently", async () => {
+  it("adopts the newer persisted user selection when a concurrent write blocks repair", async () => {
     const { sessionKey, sessionStore, storePath } = mockAutoFallbackSession({
-      // Default: origin ("openai"/"gpt-5.5") differs from override ("anthropic"/"claude-fallback")
-      // → genuine fallback with stale origin.
+      // Origin differs from both override and primary → three-distinct state.
+      originProvider: "google",
+      originModel: "gemini-pro",
     });
     // Simulate a concurrent session update that keeps the same sessionId but bumps
     // updatedAt, e.g. another turn selecting a different model. The repair must not
@@ -461,11 +462,11 @@ describe("getReplyFromConfig auto-fallback primary probes", () => {
     expect(runParams?.model).toBe("claude-fallback");
     const storedEntry = sessionStore[sessionKey];
     expect(storedEntry?.modelOverrideSource).toBe("user");
-    expect(storedEntry?.modelOverrideFallbackOriginProvider).toBe("openai");
-    expect(storedEntry?.modelOverrideFallbackOriginModel).toBe("gpt-5.5");
+    expect(storedEntry?.modelOverrideFallbackOriginProvider).toBe("google");
+    expect(storedEntry?.modelOverrideFallbackOriginModel).toBe("gemini-pro");
   });
 
-  it("does not repair the three-distinct origin state without provenance", async () => {
+  it("repairs the three-distinct origin state so the primary retries", async () => {
     const { sessionKey, sessionStore } = mockAutoFallbackSession({
       originProvider: "google",
       originModel: "gemini-pro",
@@ -473,8 +474,8 @@ describe("getReplyFromConfig auto-fallback primary probes", () => {
     mockFallbackDirectiveResult({
       sessionKey,
       resolvedThinkLevel: "off",
-      provider: "anthropic",
-      model: "claude-fallback",
+      provider: "openai",
+      model: "gpt-5.5",
     });
 
     await expect(
@@ -483,16 +484,15 @@ describe("getReplyFromConfig auto-fallback primary probes", () => {
 
     expect(vi.mocked(runPreparedReplyMock)).toHaveBeenCalledOnce();
     const runParams = vi.mocked(runPreparedReplyMock).mock.calls[0]?.[0];
-    // Without a provenance/migration contract, three-distinct origins are indistinguishable
-    // from a legitimate primary-model change, so the changed-primary guard keeps the fallback
-    // override and the snap-back probe does not fire.
-    expect(runParams?.provider).toBe("anthropic");
-    expect(runParams?.model).toBe("claude-fallback");
+    // The origin differs from both override and primary, so the stale override is
+    // cleared and this turn retries the configured primary.
+    expect(runParams?.provider).toBe("openai");
+    expect(runParams?.model).toBe("gpt-5.5");
     const storedEntry = sessionStore[sessionKey];
-    expect(storedEntry?.providerOverride).toBe("anthropic");
-    expect(storedEntry?.modelOverride).toBe("claude-fallback");
-    expect(storedEntry?.modelOverrideSource).toBe("auto");
-    expect(storedEntry?.modelOverrideFallbackOriginProvider).toBe("google");
-    expect(storedEntry?.modelOverrideFallbackOriginModel).toBe("gemini-pro");
+    expect(storedEntry?.providerOverride).toBeUndefined();
+    expect(storedEntry?.modelOverride).toBeUndefined();
+    expect(storedEntry?.modelOverrideSource).toBeUndefined();
+    expect(storedEntry?.modelOverrideFallbackOriginProvider).toBeUndefined();
+    expect(storedEntry?.modelOverrideFallbackOriginModel).toBeUndefined();
   });
 });

--- a/src/auto-reply/reply/get-reply.auto-fallback.test.ts
+++ b/src/auto-reply/reply/get-reply.auto-fallback.test.ts
@@ -428,8 +428,12 @@ describe("getReplyFromConfig auto-fallback primary probes", () => {
     // Simulate a concurrent session update that keeps the same sessionId but bumps
     // updatedAt, e.g. another turn selecting a different model. The repair must not
     // attach this turn's primary origin to that newer state.
+    const baseEntry = sessionStore[sessionKey];
+    if (!baseEntry) {
+      throw new Error("concurrent-update base session entry missing");
+    }
     const concurrentEntry: SessionEntry = {
-      ...sessionStore[sessionKey],
+      ...baseEntry,
       updatedAt: Date.now() + 10_000,
       modelOverrideSource: "user",
     };

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -73,7 +73,8 @@ import {
   hasInboundMediaForUnderstanding,
 } from "./inbound-media.js";
 import { emitPreAgentMessageHooks } from "./message-preprocess-hooks.js";
-import { createFastTestModelSelectionState, createModelSelectionState } from "./model-selection.js";
+import { createFastTestModelSelectionState } from "./model-selection-fast-test.js";
+import { createModelSelectionState } from "./model-selection.js";
 import {
   PENDING_FINAL_DELIVERY_CLEAR_PATCH,
   sanitizePendingFinalDeliveryText,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -705,9 +705,9 @@ export async function getReplyFromConfig(
   const primaryModel = resolvedChannelModelOverride?.ref.model ?? defaultModel;
   // A provably polluted self-referential fallback origin (origin equals the override itself)
   // prevents the snap-back probe from firing. Repair it in place before the probe check so this
-  // turn can retry the primary. The canonical #92776 three-distinct state is not repaired here
-  // because it is indistinguishable from a legitimate primary-model change without a migration or
-  // provenance contract.
+  // turn can retry the primary. Three-distinct origins (origin differs from primary) are also
+  // repaired here because without durable provenance we cannot distinguish a polluted fallback
+  // from a primary-model change, but the stale override is cleared to retry the primary.
   const staleAutoFallbackOriginRepairKind = classifyStaleAutoFallbackOriginOverride(
     sessionEntry,
     primaryProvider,
@@ -1235,6 +1235,8 @@ function prepareRepairedReplySessionEntry(): Partial<SessionEntry> {
     modelOverrideFallbackOriginProvider: undefined,
     modelOverrideFallbackOriginModel: undefined,
     authProfileOverride: undefined,
+    authProfileOverrideSource: undefined,
+    authProfileOverrideCompactionCount: undefined,
   };
 }
 

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -2,8 +2,8 @@
 import fs from "node:fs/promises";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
+  classifyStaleAutoFallbackOriginOverride,
   hasLegacyAutoFallbackWithoutOrigin,
-  isStaleAutoFallbackOriginOverride,
   matchesStaleAutoFallbackOriginRepairSnapshot,
   resolveAutoFallbackPrimaryProbe,
   resolveAgentConfig,
@@ -703,39 +703,57 @@ export async function getReplyFromConfig(
       : null;
   const primaryProvider = resolvedChannelModelOverride?.ref.provider ?? defaultProvider;
   const primaryModel = resolvedChannelModelOverride?.ref.model ?? defaultModel;
-  // A provably polluted fallback origin (recorded as the fallback override itself
-  // instead of the configured primary) prevents the snap-back probe from firing.
+  // A stale fallback origin (provably polluted when it equals the override, or the
+  // canonical #92776 three-distinct state) prevents the snap-back probe from firing.
   // Repair it in place before the probe check so this turn can retry the primary.
+  const staleAutoFallbackOriginRepairKind = classifyStaleAutoFallbackOriginOverride(
+    sessionEntry,
+    primaryProvider,
+    primaryModel,
+  );
   if (
     sessionEntry &&
     sessionStore &&
     sessionKey &&
     sessionEntryHandle &&
     !sessionModelSelectionLocked &&
-    isStaleAutoFallbackOriginOverride(sessionEntry, primaryProvider, primaryModel)
+    staleAutoFallbackOriginRepairKind
   ) {
-    const { updateSessionEntry } = await import("../../config/sessions/session-accessor.js");
-    const originPatch = {
-      modelOverrideFallbackOriginProvider: primaryProvider,
-      modelOverrideFallbackOriginModel: primaryModel,
-    };
+    const { loadSessionEntryReadOnly, updateSessionEntry } =
+      await import("../../config/sessions/session-accessor.js");
+    const originPatch = prepareRepairedReplySessionEntry({
+      primaryProvider,
+      primaryModel,
+    });
     const nextEntry = { ...sessionEntry, ...originPatch };
     if (storePath) {
       const observedSnapshot = sessionEntry;
       let comparedEntry: SessionEntry | undefined;
-      const persistedEntry = await updateSessionEntry(
-        { storePath, sessionKey },
-        (entry) => {
-          comparedEntry = entry;
-          return matchesStaleAutoFallbackOriginRepairSnapshot(entry, observedSnapshot)
-            ? originPatch
-            : null;
-        },
-        { skipMaintenance: true, takeCacheOwnership: true },
-      );
-      // The persisted comparison owns selection freshness. Publish its updated
-      // result, or refresh the cache from the entry that rejected this repair.
-      sessionEntry = persistedEntry ?? comparedEntry ?? nextEntry;
+      try {
+        const persistedEntry = await updateSessionEntry(
+          { storePath, sessionKey },
+          (entry) => {
+            comparedEntry = entry;
+            if (!matchesStaleAutoFallbackOriginRepairSnapshot(entry, observedSnapshot)) {
+              return null;
+            }
+            return originPatch;
+          },
+          { skipMaintenance: true, takeCacheOwnership: true },
+        );
+        // The persisted comparison owns selection freshness. Publish its updated
+        // result, or refresh the cache from the entry that rejected this repair.
+        sessionEntry = persistedEntry ?? comparedEntry ?? nextEntry;
+      } catch (error) {
+        // An interleaved write changed the row between preparation and commit. Adopt
+        // the newer persisted state rather than failing the turn; it is authoritative.
+        if (isSqliteSessionMutationConflictError(error)) {
+          const reloaded = await loadSessionEntryReadOnly({ storePath, sessionKey });
+          sessionEntry = reloaded ?? nextEntry;
+        } else {
+          throw error;
+        }
+      }
     } else {
       sessionEntry = nextEntry;
     }
@@ -1198,4 +1216,27 @@ export async function getReplyFromConfig(
   logResolverTiming("completed", "prepared_reply");
   return replyResult;
 }
+
+function prepareRepairedReplySessionEntry(params: {
+  primaryProvider: string;
+  primaryModel: string;
+}): Partial<SessionEntry> {
+  // The reply path conservatively repairs only the origin metadata. Clearing the
+  // override here would fight the existing primary-probe scheduling; updating the
+  // origin lets the probe fire on this turn while preserving the fallback pin.
+  return {
+    modelOverrideFallbackOriginProvider: params.primaryProvider,
+    modelOverrideFallbackOriginModel: params.primaryModel,
+  };
+}
+
+function isSqliteSessionMutationConflictError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    error.name === "SqliteSessionMutationConflictError"
+  );
+}
+
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -703,9 +703,9 @@ export async function getReplyFromConfig(
       : null;
   const primaryProvider = resolvedChannelModelOverride?.ref.provider ?? defaultProvider;
   const primaryModel = resolvedChannelModelOverride?.ref.model ?? defaultModel;
-  // A polluted fallback origin (recorded as the chain's failed model instead of the
-  // configured primary) prevents the snap-back probe from firing. Repair it in place
-  // before the probe check so this turn can retry the primary.
+  // A provably polluted fallback origin (recorded as the fallback override itself
+  // instead of the configured primary) prevents the snap-back probe from firing.
+  // Repair it in place before the probe check so this turn can retry the primary.
   if (
     sessionEntry &&
     sessionStore &&

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -1222,8 +1222,9 @@ export async function getReplyFromConfig(
 }
 
 function prepareRepairedReplySessionEntry(): Partial<SessionEntry> {
-  // The only repair shape we apply in the reply path is a self-referential (provably
-  // polluted) origin, which is fixed by clearing the override and retrying the primary.
+  // The only repair shape we apply in the reply path is a genuine fallback (origin differs
+  // from override) whose recorded origin no longer matches the current primary. The override,
+  // origin metadata, and automatic auth state are cleared so this turn retries the primary.
   // Fields must be explicitly set to undefined (not deleted) because the reply path uses
   // a non-replacing merge that would otherwise keep the existing override values.
   return {
@@ -1233,6 +1234,7 @@ function prepareRepairedReplySessionEntry(): Partial<SessionEntry> {
     modelOverrideRouteResolution: undefined,
     modelOverrideFallbackOriginProvider: undefined,
     modelOverrideFallbackOriginModel: undefined,
+    authProfileOverride: undefined,
   };
 }
 

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   hasLegacyAutoFallbackWithoutOrigin,
+  isStaleAutoFallbackOriginOverride,
   resolveAutoFallbackPrimaryProbe,
   resolveAgentConfig,
   resolveAgentDir,
@@ -552,7 +553,6 @@ export async function getReplyFromConfig(
   }
   const {
     sessionCtx,
-    sessionEntry,
     initialSessionEntry,
     sessionEntryHandle,
     previousSessionEntry,
@@ -569,6 +569,7 @@ export async function getReplyFromConfig(
     triggerBodyNormalized,
     bodyStripped,
   } = sessionState;
+  let sessionEntry = sessionState.sessionEntry;
   const sessionModelSelectionLocked = isModelSelectionLocked(sessionEntry);
   if (sessionModelSelectionLocked && hasResolvedHeartbeatModelOverride) {
     // Heartbeat routing is turn-local. A native harness lock owns the durable
@@ -699,6 +700,36 @@ export async function getReplyFromConfig(
       : null;
   const primaryProvider = resolvedChannelModelOverride?.ref.provider ?? defaultProvider;
   const primaryModel = resolvedChannelModelOverride?.ref.model ?? defaultModel;
+  // A polluted fallback origin (recorded as the chain's failed model instead of the
+  // configured primary) prevents the snap-back probe from firing. Repair it in place
+  // before the probe check so this turn can retry the primary.
+  if (
+    sessionEntry &&
+    sessionStore &&
+    sessionKey &&
+    sessionEntryHandle &&
+    !sessionModelSelectionLocked &&
+    isStaleAutoFallbackOriginOverride(sessionEntry, primaryProvider, primaryModel)
+  ) {
+    const { updateSessionEntry } = await import("../../config/sessions/session-accessor.js");
+    const originPatch = {
+      modelOverrideFallbackOriginProvider: primaryProvider,
+      modelOverrideFallbackOriginModel: primaryModel,
+    };
+    const nextEntry = { ...sessionEntry, ...originPatch };
+    if (storePath) {
+      const persistedEntry = await updateSessionEntry(
+        { storePath, sessionKey },
+        (entry) => (entry.sessionId === nextEntry.sessionId ? originPatch : null),
+        { skipMaintenance: true, takeCacheOwnership: true },
+      );
+      sessionEntry = persistedEntry ?? nextEntry;
+    } else {
+      sessionEntry = nextEntry;
+    }
+    sessionEntryHandle.replaceCurrent(sessionEntry);
+    sessionStore[sessionKey] = sessionEntry;
+  }
   const hasSessionModelOverride = Boolean(
     normalizeOptionalString(sessionEntry.modelOverride) ||
     normalizeOptionalString(sessionEntry.providerOverride),

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -573,7 +573,7 @@ export async function getReplyFromConfig(
     bodyStripped,
   } = sessionState;
   let sessionEntry = sessionState.sessionEntry;
-  const sessionModelSelectionLocked = isModelSelectionLocked(sessionEntry);
+  let sessionModelSelectionLocked = isModelSelectionLocked(sessionEntry);
   if (sessionModelSelectionLocked && hasResolvedHeartbeatModelOverride) {
     // Heartbeat routing is turn-local. A native harness lock owns the durable
     // model selection, so heartbeat.model must not retarget its AppServer turn.
@@ -703,9 +703,11 @@ export async function getReplyFromConfig(
       : null;
   const primaryProvider = resolvedChannelModelOverride?.ref.provider ?? defaultProvider;
   const primaryModel = resolvedChannelModelOverride?.ref.model ?? defaultModel;
-  // A stale fallback origin (provably polluted when it equals the override, or the
-  // canonical #92776 three-distinct state) prevents the snap-back probe from firing.
-  // Repair it in place before the probe check so this turn can retry the primary.
+  // A provably polluted self-referential fallback origin (origin equals the override itself)
+  // prevents the snap-back probe from firing. Repair it in place before the probe check so this
+  // turn can retry the primary. The canonical #92776 three-distinct state is not repaired here
+  // because it is indistinguishable from a legitimate primary-model change without a migration or
+  // provenance contract.
   const staleAutoFallbackOriginRepairKind = classifyStaleAutoFallbackOriginOverride(
     sessionEntry,
     primaryProvider,
@@ -721,10 +723,7 @@ export async function getReplyFromConfig(
   ) {
     const { loadSessionEntryReadOnly, updateSessionEntry } =
       await import("../../config/sessions/session-accessor.js");
-    const originPatch = prepareRepairedReplySessionEntry({
-      primaryProvider,
-      primaryModel,
-    });
+    const originPatch = prepareRepairedReplySessionEntry();
     const nextEntry = { ...sessionEntry, ...originPatch };
     if (storePath) {
       const observedSnapshot = sessionEntry;
@@ -748,7 +747,7 @@ export async function getReplyFromConfig(
         // An interleaved write changed the row between preparation and commit. Adopt
         // the newer persisted state rather than failing the turn; it is authoritative.
         if (isSqliteSessionMutationConflictError(error)) {
-          const reloaded = await loadSessionEntryReadOnly({ storePath, sessionKey });
+          const reloaded = loadSessionEntryReadOnly({ storePath, sessionKey });
           sessionEntry = reloaded ?? nextEntry;
         } else {
           throw error;
@@ -756,6 +755,11 @@ export async function getReplyFromConfig(
       }
     } else {
       sessionEntry = nextEntry;
+    }
+    // A concurrent update may have locked the session after we captured the initial lock flag.
+    // Re-evaluate the durable lock on the adopted entry before allowing the primary probe below.
+    if (isModelSelectionLocked(sessionEntry)) {
+      sessionModelSelectionLocked = true;
     }
     sessionEntryHandle.replaceCurrent(sessionEntry);
     sessionStore[sessionKey] = sessionEntry;
@@ -1217,16 +1221,18 @@ export async function getReplyFromConfig(
   return replyResult;
 }
 
-function prepareRepairedReplySessionEntry(params: {
-  primaryProvider: string;
-  primaryModel: string;
-}): Partial<SessionEntry> {
-  // The reply path conservatively repairs only the origin metadata. Clearing the
-  // override here would fight the existing primary-probe scheduling; updating the
-  // origin lets the probe fire on this turn while preserving the fallback pin.
+function prepareRepairedReplySessionEntry(): Partial<SessionEntry> {
+  // The only repair shape we apply in the reply path is a self-referential (provably
+  // polluted) origin, which is fixed by clearing the override and retrying the primary.
+  // Fields must be explicitly set to undefined (not deleted) because the reply path uses
+  // a non-replacing merge that would otherwise keep the existing override values.
   return {
-    modelOverrideFallbackOriginProvider: params.primaryProvider,
-    modelOverrideFallbackOriginModel: params.primaryModel,
+    providerOverride: undefined,
+    modelOverride: undefined,
+    modelOverrideSource: undefined,
+    modelOverrideRouteResolution: undefined,
+    modelOverrideFallbackOriginProvider: undefined,
+    modelOverrideFallbackOriginModel: undefined,
   };
 }
 

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -4,6 +4,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import {
   hasLegacyAutoFallbackWithoutOrigin,
   isStaleAutoFallbackOriginOverride,
+  matchesStaleAutoFallbackOriginRepairSnapshot,
   resolveAutoFallbackPrimaryProbe,
   resolveAgentConfig,
   resolveAgentDir,
@@ -19,6 +20,7 @@ import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../../agents/
 import { resolveChannelModelOverride } from "../../channels/model-overrides.js";
 import { type OpenClawConfig, getRuntimeConfig } from "../../config/config.js";
 import { isSessionWorkStartInvalidatedError } from "../../config/sessions/lifecycle.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
 import { logVerbose } from "../../globals.js";
 import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
 import { isFastTestRuntimeEnv } from "../../infra/env.js";
@@ -718,12 +720,21 @@ export async function getReplyFromConfig(
     };
     const nextEntry = { ...sessionEntry, ...originPatch };
     if (storePath) {
+      const observedSnapshot = sessionEntry;
+      let comparedEntry: SessionEntry | undefined;
       const persistedEntry = await updateSessionEntry(
         { storePath, sessionKey },
-        (entry) => (entry.sessionId === nextEntry.sessionId ? originPatch : null),
+        (entry) => {
+          comparedEntry = entry;
+          return matchesStaleAutoFallbackOriginRepairSnapshot(entry, observedSnapshot)
+            ? originPatch
+            : null;
+        },
         { skipMaintenance: true, takeCacheOwnership: true },
       );
-      sessionEntry = persistedEntry ?? nextEntry;
+      // The persisted comparison owns selection freshness. Publish its updated
+      // result, or refresh the cache from the entry that rejected this repair.
+      sessionEntry = persistedEntry ?? comparedEntry ?? nextEntry;
     } else {
       sessionEntry = nextEntry;
     }

--- a/src/auto-reply/reply/model-selection-fast-test.ts
+++ b/src/auto-reply/reply/model-selection-fast-test.ts
@@ -1,0 +1,64 @@
+/** Fast-test model-selection state factory, split out to keep model-selection.ts under budget. */
+import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
+import type { ModelFallbackRouteResolution } from "../../agents/model-fallback.types.js";
+import type { ModelAliasIndex } from "../../agents/model-selection.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { ThinkLevel } from "../thinking.shared.js";
+
+type ModelCatalog = ModelCatalogEntry[];
+
+export type ThinkingDefaultSelection = {
+  provider: string;
+  model: string;
+  agentRuntime?: string | null;
+};
+
+export type ModelSelectionState = {
+  provider: string;
+  model: string;
+  requestedRouteResolution: ModelFallbackRouteResolution;
+  allowedModelKeys: Set<string>;
+  allowedModelCatalog: ModelCatalog;
+  policyAliasIndex: ModelAliasIndex;
+  resetModelOverride: boolean;
+  resetModelOverrideRef?: string;
+  resetModelOverrideReason?: "disallowed" | "stale" | "temporarily-unavailable";
+  modelPolicyConfigPath?: string;
+  modelPolicyRepairConfigPath?: string;
+  resolveThinkingCatalog: () => Promise<ModelCatalog | undefined>;
+  resolveDefaultThinkingLevel: (selection?: ThinkingDefaultSelection) => Promise<ThinkLevel>;
+  hasConfiguredThinkingDefault?: boolean;
+  /** Default reasoning level from model capability: "on" if model has reasoning, else "off". */
+  resolveDefaultReasoningLevel: () => Promise<"on" | "off">;
+  needsModelCatalog: boolean;
+  modelContextWindow?: number;
+  modelContextTokens?: number;
+};
+
+/** Creates minimal model-selection state for fast test mode. */
+export function createFastTestModelSelectionState(params: {
+  agentCfg: NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]> | undefined;
+  provider: string;
+  model: string;
+}): ModelSelectionState {
+  return {
+    provider: params.provider,
+    model: params.model,
+    requestedRouteResolution: "resolved",
+    allowedModelKeys: new Set<string>(),
+    allowedModelCatalog: [],
+    policyAliasIndex: { byAlias: new Map(), byKey: new Map() },
+    resetModelOverride: false,
+    resetModelOverrideRef: undefined,
+    resetModelOverrideReason: undefined,
+    modelPolicyConfigPath: undefined,
+    modelPolicyRepairConfigPath: undefined,
+    resolveThinkingCatalog: async () => [],
+    resolveDefaultThinkingLevel: async () => params.agentCfg?.thinkingDefault as ThinkLevel,
+    hasConfiguredThinkingDefault: params.agentCfg?.thinkingDefault !== undefined,
+    resolveDefaultReasoningLevel: async () => "off",
+    needsModelCatalog: false,
+    modelContextWindow: undefined,
+    modelContextTokens: undefined,
+  };
+}

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -2090,7 +2090,7 @@ describe("createModelSelectionState auto-failover overrides", () => {
     expect(state.resetModelOverride).toBe(false);
   });
 
-  it("preserves auto-failover override on normal turn when the origin mismatches a changed primary", async () => {
+  it("repairs auto-failover override on normal turn when the origin mismatches a changed primary", async () => {
     const { state, sessionStore } = await resolveStateWithOverride({
       providerOverride: "openrouter",
       modelOverride: "minimax/minimax-m2.7",
@@ -2102,21 +2102,23 @@ describe("createModelSelectionState auto-failover overrides", () => {
     });
 
     // Origin differs from both the current primary and the override (three-distinct
-    // state). The repair kind is "repair-origin", not "clear-override", so the
-    // fallback override is preserved here and the origin is repaired elsewhere.
-    expect(state.provider).toBe("openrouter");
-    expect(state.model).toBe("minimax/minimax-m2.7");
-    expect(state.resetModelOverride).toBe(false);
-    expect(sessionStore[sessionKey]?.providerOverride).toBe("openrouter");
-    expect(sessionStore[sessionKey]?.modelOverride).toBe("minimax/minimax-m2.7");
-    expect(sessionStore[sessionKey]?.modelOverrideSource).toBe("auto");
-    expect(sessionStore[sessionKey]?.modelOverrideFallbackOriginProvider).toBe("openai");
-    expect(sessionStore[sessionKey]?.modelOverrideFallbackOriginModel).toBe("gpt-5.3");
+    // state). Without durable provenance we cannot distinguish a polluted fallback
+    // from a legitimate primary change, but the stale override is cleared to retry
+    // the configured primary.
+    expect(state.provider).toBe(defaultProvider);
+    expect(state.model).toBe(defaultModel);
+    expect(state.resetModelOverride).toBe(true);
+    expect(state.resetModelOverrideRef).toBe("openrouter/minimax/minimax-m2.7");
+    expect(sessionStore[sessionKey]?.providerOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverrideSource).toBeUndefined();
   });
 
-  it("preserves a genuine auto-failover override without durable provenance", async () => {
-    // Origin differs from override (genuine fallback) and from current primary, but
-    // without durable provenance this is indistinguishable from a legitimate primary change.
+  it("repairs a genuine auto-failover override when origin differs from primary", async () => {
+    // Origin differs from override (genuine fallback) and from current primary.
+    // Without durable provenance we cannot distinguish a polluted fallback from a
+    // legitimate primary change, but the stale override is cleared to retry the
+    // configured primary.
     const { state, sessionStore } = await resolveStateWithOverride({
       providerOverride: "openrouter",
       modelOverride: "minimax/minimax-m2.7",
@@ -2127,13 +2129,12 @@ describe("createModelSelectionState auto-failover overrides", () => {
       model: "minimax/minimax-m2.7",
     });
 
-    // Override is preserved; the snap-back probe fires through the existing
-    // resolveAutoFallbackPrimaryProbe path.
-    expect(state.provider).toBe("openrouter");
-    expect(state.model).toBe("minimax/minimax-m2.7");
-    expect(state.resetModelOverride).toBe(false);
-    expect(sessionStore[sessionKey]?.providerOverride).toBe("openrouter");
-    expect(sessionStore[sessionKey]?.modelOverride).toBe("minimax/minimax-m2.7");
+    expect(state.provider).toBe(defaultProvider);
+    expect(state.model).toBe(defaultModel);
+    expect(state.resetModelOverride).toBe(true);
+    expect(state.resetModelOverrideRef).toBe("openrouter/minimax/minimax-m2.7");
+    expect(sessionStore[sessionKey]?.providerOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverride).toBeUndefined();
   });
 
   it("preserves a user override on normal turn even when its origin looks stale", async () => {

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -2090,13 +2090,36 @@ describe("createModelSelectionState auto-failover overrides", () => {
     expect(state.resetModelOverride).toBe(false);
   });
 
-  it("clears stale auto-failover override on normal turn when fallback origin changed", async () => {
+  it("preserves auto-failover override on normal turn when the origin mismatches a changed primary", async () => {
     const { state, sessionStore } = await resolveStateWithOverride({
       providerOverride: "openrouter",
       modelOverride: "minimax/minimax-m2.7",
       modelOverrideSource: "auto",
       modelOverrideFallbackOriginProvider: "openai",
       modelOverrideFallbackOriginModel: "gpt-5.3",
+      provider: "openrouter",
+      model: "minimax/minimax-m2.7",
+    });
+
+    // Origin differs from the current primary but also differs from the override,
+    // so this is a legitimate changed-primary mismatch guard, not pollution.
+    expect(state.provider).toBe("openrouter");
+    expect(state.model).toBe("minimax/minimax-m2.7");
+    expect(state.resetModelOverride).toBe(false);
+    expect(sessionStore[sessionKey]?.providerOverride).toBe("openrouter");
+    expect(sessionStore[sessionKey]?.modelOverride).toBe("minimax/minimax-m2.7");
+    expect(sessionStore[sessionKey]?.modelOverrideSource).toBe("auto");
+    expect(sessionStore[sessionKey]?.modelOverrideFallbackOriginProvider).toBe("openai");
+    expect(sessionStore[sessionKey]?.modelOverrideFallbackOriginModel).toBe("gpt-5.3");
+  });
+
+  it("clears provably polluted auto-failover override when origin equals the override", async () => {
+    const { state, sessionStore } = await resolveStateWithOverride({
+      providerOverride: "openrouter",
+      modelOverride: "minimax/minimax-m2.7",
+      modelOverrideSource: "auto",
+      modelOverrideFallbackOriginProvider: "openrouter",
+      modelOverrideFallbackOriginModel: "minimax/minimax-m2.7",
       provider: "openrouter",
       model: "minimax/minimax-m2.7",
     });

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -2114,26 +2114,26 @@ describe("createModelSelectionState auto-failover overrides", () => {
     expect(sessionStore[sessionKey]?.modelOverrideFallbackOriginModel).toBe("gpt-5.3");
   });
 
-  it("clears provably polluted auto-failover override when origin equals the override", async () => {
+  it("preserves a genuine auto-failover override without durable provenance", async () => {
+    // Origin differs from override (genuine fallback) and from current primary, but
+    // without durable provenance this is indistinguishable from a legitimate primary change.
     const { state, sessionStore } = await resolveStateWithOverride({
       providerOverride: "openrouter",
       modelOverride: "minimax/minimax-m2.7",
       modelOverrideSource: "auto",
-      modelOverrideFallbackOriginProvider: "openrouter",
-      modelOverrideFallbackOriginModel: "minimax/minimax-m2.7",
+      modelOverrideFallbackOriginProvider: "openai",
+      modelOverrideFallbackOriginModel: "gpt-5.3",
       provider: "openrouter",
       model: "minimax/minimax-m2.7",
     });
 
-    expect(state.provider).toBe(defaultProvider);
-    expect(state.model).toBe(defaultModel);
-    expect(state.resetModelOverride).toBe(true);
-    expect(state.resetModelOverrideReason).toBe("stale");
-    expect(sessionStore[sessionKey]?.providerOverride).toBeUndefined();
-    expect(sessionStore[sessionKey]?.modelOverride).toBeUndefined();
-    expect(sessionStore[sessionKey]?.modelOverrideSource).toBeUndefined();
-    expect(sessionStore[sessionKey]?.modelOverrideFallbackOriginProvider).toBeUndefined();
-    expect(sessionStore[sessionKey]?.modelOverrideFallbackOriginModel).toBeUndefined();
+    // Override is preserved; the snap-back probe fires through the existing
+    // resolveAutoFallbackPrimaryProbe path.
+    expect(state.provider).toBe("openrouter");
+    expect(state.model).toBe("minimax/minimax-m2.7");
+    expect(state.resetModelOverride).toBe(false);
+    expect(sessionStore[sessionKey]?.providerOverride).toBe("openrouter");
+    expect(sessionStore[sessionKey]?.modelOverride).toBe("minimax/minimax-m2.7");
   });
 
   it("preserves a user override on normal turn even when its origin looks stale", async () => {

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -2090,6 +2090,46 @@ describe("createModelSelectionState auto-failover overrides", () => {
     expect(state.resetModelOverride).toBe(false);
   });
 
+  it("clears stale auto-failover override on normal turn when fallback origin changed", async () => {
+    const { state, sessionStore } = await resolveStateWithOverride({
+      providerOverride: "openrouter",
+      modelOverride: "minimax/minimax-m2.7",
+      modelOverrideSource: "auto",
+      modelOverrideFallbackOriginProvider: "openai",
+      modelOverrideFallbackOriginModel: "gpt-5.3",
+      provider: "openrouter",
+      model: "minimax/minimax-m2.7",
+    });
+
+    expect(state.provider).toBe(defaultProvider);
+    expect(state.model).toBe(defaultModel);
+    expect(state.resetModelOverride).toBe(true);
+    expect(state.resetModelOverrideReason).toBe("stale");
+    expect(sessionStore[sessionKey]?.providerOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverrideSource).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverrideFallbackOriginProvider).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverrideFallbackOriginModel).toBeUndefined();
+  });
+
+  it("preserves a user override on normal turn even when its origin looks stale", async () => {
+    const { state, sessionStore } = await resolveStateWithOverride({
+      providerOverride: "openrouter",
+      modelOverride: "minimax/minimax-m2.7",
+      modelOverrideSource: "user",
+      modelOverrideFallbackOriginProvider: "openai",
+      modelOverrideFallbackOriginModel: "gpt-5.3",
+      provider: "openrouter",
+      model: "minimax/minimax-m2.7",
+    });
+
+    expect(state.provider).toBe("openrouter");
+    expect(state.model).toBe("minimax/minimax-m2.7");
+    expect(state.resetModelOverride).toBe(false);
+    expect(sessionStore[sessionKey]?.providerOverride).toBe("openrouter");
+    expect(sessionStore[sessionKey]?.modelOverride).toBe("minimax/minimax-m2.7");
+  });
+
   it("preserves a legacy override with no modelOverrideSource (treated as user)", async () => {
     // Sessions persisted before modelOverrideSource was introduced lack the field.
     // Backward-compat rule: missing source + present override = user selection.

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -2101,8 +2101,9 @@ describe("createModelSelectionState auto-failover overrides", () => {
       model: "minimax/minimax-m2.7",
     });
 
-    // Origin differs from the current primary but also differs from the override,
-    // so this is a legitimate changed-primary mismatch guard, not pollution.
+    // Origin differs from both the current primary and the override (three-distinct
+    // state). The repair kind is "repair-origin", not "clear-override", so the
+    // fallback override is preserved here and the origin is repaired elsewhere.
     expect(state.provider).toBe("openrouter");
     expect(state.model).toBe("minimax/minimax-m2.7");
     expect(state.resetModelOverride).toBe(false);

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -1,7 +1,7 @@
 /** Model selection state for reply runs, including catalog and override handling. */
 import {
+  classifyStaleAutoFallbackOriginOverride,
   hasLegacyAutoFallbackWithoutOrigin,
-  isStaleAutoFallbackOriginOverride,
   resolveAgentConfig,
   resolveAgentDir,
   resolveDefaultAgentId,
@@ -244,7 +244,8 @@ export async function createModelSelectionState(params: {
       modelKey(normalizedDirectOverride.provider, normalizedDirectOverride.model);
   const staleAutoFallbackOriginOverride =
     directStoredModelOverride?.source === "session" &&
-    isStaleAutoFallbackOriginOverride(sessionEntry, primaryProvider, primaryModel);
+    classifyStaleAutoFallbackOriginOverride(sessionEntry, primaryProvider, primaryModel) ===
+      "clear-override";
   const staleDirectStoredOverride =
     staleHeartbeatAutoFallbackOverride ||
     staleLegacyOpenAICodexAutoOverride ||

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -1,6 +1,7 @@
 /** Model selection state for reply runs, including catalog and override handling. */
 import {
   hasLegacyAutoFallbackWithoutOrigin,
+  isStaleAutoFallbackOriginOverride,
   resolveAgentConfig,
   resolveAgentDir,
   resolveDefaultAgentId,
@@ -297,10 +298,14 @@ export async function createModelSelectionState(params: {
     normalizedDirectOverride !== null &&
     modelKey(normalizedCurrentSelection.provider, normalizedCurrentSelection.model) !==
       modelKey(normalizedDirectOverride.provider, normalizedDirectOverride.model);
+  const staleAutoFallbackOriginOverride =
+    directStoredModelOverride?.source === "session" &&
+    isStaleAutoFallbackOriginOverride(sessionEntry, primaryProvider, primaryModel);
   const staleDirectStoredOverride =
     staleHeartbeatAutoFallbackOverride ||
     staleLegacyOpenAICodexAutoOverride ||
-    staleLegacyAutoFallbackWithoutOrigin;
+    staleLegacyAutoFallbackWithoutOrigin ||
+    staleAutoFallbackOriginOverride;
 
   if (needsModelCatalog) {
     const catalogSnapshot = await loadRuntimeCatalogSnapshot();
@@ -434,7 +439,8 @@ export async function createModelSelectionState(params: {
   // Skip stored session model override only when an explicit heartbeat.model
   // was resolved. Heartbeats without heartbeat.model still inherit normal
   // overrides unless a direct auto fallback override is stale for the current
-  // configured default.
+  // configured default. Polluted fallback-origin metadata is also treated as
+  // stale so the snap-back probe can fire on subsequent turns.
   const skipStoredOverride =
     params.skipStoredModelOverride === true ||
     hasOneTurnModelOverride ||

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -13,7 +13,6 @@ import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
 import type { ModelCatalogSnapshot } from "../../agents/model-catalog.types.js";
 import type { ModelFallbackRouteResolution } from "../../agents/model-fallback.types.js";
 import {
-  type ModelAliasIndex,
   buildConfiguredModelCatalog,
   legacyModelKey,
   modelKey,
@@ -48,6 +47,7 @@ export {
 } from "./model-selection-directive.js";
 export { resolveContextTokens } from "./model-selection-context.js";
 import { normalizeRuntimeRef, resolveRuntimeNormalization } from "./model-runtime-normalization.js";
+import type { ModelSelectionState, ThinkingDefaultSelection } from "./model-selection-fast-test.js";
 import {
   isStaleHeartbeatAutoFallbackOverride,
   normalizeStoredRuntimeModelRef,
@@ -57,67 +57,11 @@ import {
 
 type ModelCatalog = ModelCatalogEntry[];
 
-type ThinkingDefaultSelection = {
-  provider: string;
-  model: string;
-  agentRuntime?: string | null;
-};
-
-type ModelSelectionState = {
-  provider: string;
-  model: string;
-  requestedRouteResolution: ModelFallbackRouteResolution;
-  allowedModelKeys: Set<string>;
-  allowedModelCatalog: ModelCatalog;
-  policyAliasIndex: ModelAliasIndex;
-  resetModelOverride: boolean;
-  resetModelOverrideRef?: string;
-  resetModelOverrideReason?: "disallowed" | "stale" | "temporarily-unavailable";
-  modelPolicyConfigPath?: string;
-  modelPolicyRepairConfigPath?: string;
-  resolveThinkingCatalog: () => Promise<ModelCatalog | undefined>;
-  resolveDefaultThinkingLevel: (selection?: ThinkingDefaultSelection) => Promise<ThinkLevel>;
-  hasConfiguredThinkingDefault?: boolean;
-  /** Default reasoning level from model capability: "on" if model has reasoning, else "off". */
-  resolveDefaultReasoningLevel: () => Promise<"on" | "off">;
-  needsModelCatalog: boolean;
-  modelContextWindow?: number;
-  modelContextTokens?: number;
-};
-
 function resolveConfiguredModelThinkingDefault(raw: unknown): ThinkLevel | undefined {
   if (raw === false || raw === "disabled" || raw === "none") {
     return "off";
   }
   return typeof raw === "string" ? normalizeThinkLevel(raw) : undefined;
-}
-
-/** Creates minimal model-selection state for fast test mode. */
-export function createFastTestModelSelectionState(params: {
-  agentCfg: NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]> | undefined;
-  provider: string;
-  model: string;
-}): ModelSelectionState {
-  return {
-    provider: params.provider,
-    model: params.model,
-    requestedRouteResolution: "resolved",
-    allowedModelKeys: new Set<string>(),
-    allowedModelCatalog: [],
-    policyAliasIndex: { byAlias: new Map(), byKey: new Map() },
-    resetModelOverride: false,
-    resetModelOverrideRef: undefined,
-    resetModelOverrideReason: undefined,
-    modelPolicyConfigPath: undefined,
-    modelPolicyRepairConfigPath: undefined,
-    resolveThinkingCatalog: async () => [],
-    resolveDefaultThinkingLevel: async () => params.agentCfg?.thinkingDefault as ThinkLevel,
-    hasConfiguredThinkingDefault: params.agentCfg?.thinkingDefault !== undefined,
-    resolveDefaultReasoningLevel: async () => "off",
-    needsModelCatalog: false,
-    modelContextWindow: undefined,
-    modelContextTokens: undefined,
-  };
 }
 
 const modelCatalogRuntimeLoader = createLazyImportLoader(

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -383,8 +383,9 @@ export async function createModelSelectionState(params: {
   // Skip stored session model override only when an explicit heartbeat.model
   // was resolved. Heartbeats without heartbeat.model still inherit normal
   // overrides unless a direct auto fallback override is stale for the current
-  // configured default. Polluted fallback-origin metadata is also treated as
-  // stale so the snap-back probe can fire on subsequent turns.
+  // configured default. Provably polluted fallback-origin metadata (origin equal
+  // to the override itself) is also treated as stale so the snap-back probe can
+  // fire on subsequent turns.
   const skipStoredOverride =
     params.skipStoredModelOverride === true ||
     hasOneTurnModelOverride ||


### PR DESCRIPTION
<!--
Related: #92776
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where sessions that fell back to a degraded model could stay pinned to that fallback model indefinitely. The snap-back primary probe introduced in #82676 could not fire when the session's recorded fallback origin had been polluted, because the three-distinct state (origin ≠ override ≠ primary) was incorrectly classified as requiring durable provenance before any repair could fire.

## Why This Change Was Made

Adds a classifier and repair framework for auto-fallback origin overrides. The classifier now returns `"clear-override"` for genuine fallbacks whose recorded origin differs from the current primary — the three-distinct state reported in #92776. Self-referential origins (origin == override) are preserved because configured subagent selections deliberately use the same pattern to prevent cleanup from discarding them.

The reply-path repair also clears all automatic auth-profile metadata (source and compaction counter) alongside model/origin fields, not just the profile override value.

## User Impact

Sessions that experienced automatic model fallback under one primary model and later had their primary changed will now retry the current configured primary instead of staying permanently pinned to the fallback model. Self-origin metadata used by configured subagent selections is preserved.

## Evidence

### Tests

```
node scripts/run-vitest.mjs src/agents/agent-scope.test.ts
→ 44 passed
```

```
node scripts/run-vitest.mjs src/agents/command/stale-auto-fallback-origin-repair.test.ts
→ 7 passed
```

```
node scripts/run-vitest.mjs src/auto-reply/reply/get-reply.auto-fallback.test.ts
→ 14 passed
```

```
node scripts/run-vitest.mjs src/auto-reply/reply/model-selection.test.ts
→ 75 passed
```

```
node scripts/run-vitest.mjs src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts -t "uses only user-selected"
→ 14 passed (self-origin subagent case preserves anthropic)
```

Format: clean across all 8 changed files (`oxfmt --check` passes).
