### PR TITLE
fix(cron): show saved automation descriptions in dashboard

### DIFF
--- a/ui/src/e2e/cron-descriptions.e2e.test.ts
+++ b/ui/src/e2e/cron-descriptions.e2e.test.ts
@@ -1,0 +1,120 @@
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI cron saved descriptions E2E",
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed or cannot start at ${executablePath}.`,
+});
+
+function cronJob(id: string, name: string) {
+  return {
+    id,
+    name,
+    enabled: true,
+    createdAtMs: Date.parse("2026-05-29T08:00:00.000Z"),
+    updatedAtMs: Date.parse("2026-05-29T08:05:00.000Z"),
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "main",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "systemEvent", text: `${name} fired` },
+    state: {},
+  };
+}
+
+suite.define(() => {
+  it("shows saved descriptions in compact rows and task details for every payload kind", async () => {
+    const jobs = [
+      {
+        ...cronJob("described-event", "System reminder"),
+        description: "  Explain the system reminder without opening advanced settings  ",
+        payload: { kind: "systemEvent", text: "Run the system reminder" },
+      },
+      {
+        ...cronJob("described-agent", "Agent digest"),
+        description: "Summarize the overnight activity",
+        payload: { kind: "agentTurn", message: "List overnight deployment activity" },
+      },
+      {
+        ...cronJob("described-command", "Command check"),
+        description: "Run the infrastructure health check",
+        payload: { kind: "command", argv: ["echo", "healthy"] },
+      },
+      {
+        ...cronJob("described-script", "Script check"),
+        description: "Inspect the scripted health check",
+        payload: { kind: "script", script: "return 'healthy'" },
+      },
+      {
+        ...cronJob("described-heartbeat", "Heartbeat check"),
+        description: "Explain the system-owned heartbeat",
+        payload: { kind: "heartbeat" },
+      },
+    ] as const;
+    const undescribedJob = cronJob("without-description", "Plain task");
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1_280 },
+    });
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      methodResponses: {
+        "cron.list": {
+          jobs: [...jobs, undescribedJob],
+          total: jobs.length + 1,
+          offset: 0,
+          limit: 50,
+          hasMore: false,
+          nextOffset: null,
+        },
+        "cron.runs": { entries: [], total: 0, offset: 0, hasMore: false },
+        "cron.status": { enabled: true, jobs: jobs.length + 1, nextWakeAtMs: null },
+      },
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}cron`);
+      await page.locator(`[data-test-id="cron-row-${jobs[0].id}"]`).waitFor({ timeout: 10_000 });
+
+      for (const job of jobs) {
+        const description = page.locator(`[data-test-id="cron-row-description-${job.id}"]`);
+        expect((await description.textContent())?.trim()).toBe(`· ${job.description.trim()}`);
+        expect(await description.getAttribute("title")).toBe(
+          `Description: ${job.description.trim()}`,
+        );
+      }
+      expect(
+        await page.locator(`[data-test-id="cron-row-description-${undescribedJob.id}"]`).count(),
+      ).toBe(0);
+
+      const describedRow = await page
+        .locator(`[data-test-id="cron-row-${jobs[1].id}"]`)
+        .boundingBox();
+      const undescribedRow = await page
+        .locator(`[data-test-id="cron-row-${undescribedJob.id}"]`)
+        .boundingBox();
+      expect(describedRow?.height).toBe(undescribedRow?.height);
+
+      for (const job of jobs) {
+        const row = page.locator(`[data-test-id="cron-row-${job.id}"]`);
+        await row.locator(".cron-table__name-text").click();
+        const detailDescription = page.locator('[data-test-id="cron-detail-description"]');
+        await detailDescription.waitFor({ state: "visible" });
+        expect((await detailDescription.textContent())?.replace(/\s+/g, " ").trim()).toBe(
+          `Description: ${job.description.trim()}`,
+        );
+
+        await page.locator('[data-test-id="cron-detail-tab-history"]').click();
+        expect((await detailDescription.textContent())?.replace(/\s+/g, " ").trim()).toBe(
+          `Description: ${job.description.trim()}`,
+        );
+        await page.locator('[data-test-id="cron-back"]').click();
+        await row.waitFor({ timeout: 10_000 });
+      }
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+});

--- a/ui/src/e2e/cron-filters.e2e.test.ts
+++ b/ui/src/e2e/cron-filters.e2e.test.ts
@@ -299,12 +299,15 @@ describeControlUiE2e("Control UI cron mocked Gateway E2E", () => {
   });
 
   it("keeps read-only operators on Cron browse and history surfaces", async () => {
-    const readOnlyJob = cronJob(
-      "read-only-job",
-      "Read-only nightly digest",
-      { kind: "cron", expr: "0 1 * * *", tz: "UTC" },
-      { lastRunStatus: "ok", lastRunAtMs: Date.parse("2026-05-29T08:10:00.000Z") },
-    );
+    const readOnlyJob = {
+      ...cronJob(
+        "read-only-job",
+        "Read-only nightly digest",
+        { kind: "cron", expr: "0 1 * * *", tz: "UTC" },
+        { lastRunStatus: "ok", lastRunAtMs: Date.parse("2026-05-29T08:10:00.000Z") },
+      ),
+      description: "Explain the nightly digest without granting write access",
+    };
     const context = await browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -332,6 +335,9 @@ describeControlUiE2e("Control UI cron mocked Gateway E2E", () => {
       await page.goto(`${server.baseUrl}cron`);
       await jobTitle(page, readOnlyJob.name).waitFor({ timeout: 10_000 });
       await page.getByRole("note").filter({ hasText: "Browsing only" }).waitFor();
+      expect(
+        await page.locator(`[data-test-id="cron-row-description-${readOnlyJob.id}"]`).textContent(),
+      ).toContain(readOnlyJob.description);
 
       await expect.poll(() => page.locator('[data-test-id="cron-new-task"]').count()).toBe(0);
       await expect
@@ -346,12 +352,18 @@ describeControlUiE2e("Control UI cron mocked Gateway E2E", () => {
 
       await jobTitle(page, readOnlyJob.name).click();
       await page.locator("fieldset.cron-editor:disabled").waitFor();
+      expect(
+        await page.locator('[data-test-id="cron-detail-description"]').textContent(),
+      ).toContain(readOnlyJob.description);
       await expect.poll(() => page.locator('[data-test-id="cron-run-now"]').count()).toBe(0);
       await expect.poll(() => page.locator('[data-test-id="cron-submit"]').count()).toBe(0);
       await expect.poll(() => page.locator(".cron-editor-actions").count()).toBe(0);
 
       await page.locator('[data-test-id="cron-detail-tab-history"]').click();
       await page.getByText("Read-only history remains available", { exact: true }).waitFor();
+      expect(
+        await page.locator('[data-test-id="cron-detail-description"]').textContent(),
+      ).toContain(readOnlyJob.description);
 
       const mutationMethods = new Set(["cron.add", "cron.remove", "cron.run", "cron.update"]);
       expect(

--- a/ui/src/pages/cron/cron-page.test.ts
+++ b/ui/src/pages/cron/cron-page.test.ts
@@ -169,6 +169,7 @@ describe("CronPage editor state sync", () => {
     const job: CronJob = {
       id: "access-job",
       name: "Readably scheduled task",
+      description: "Inspect this task without changing its permissions",
       enabled: true,
       createdAtMs: 0,
       updatedAtMs: 0,
@@ -205,6 +206,9 @@ describe("CronPage editor state sync", () => {
     await waitForCronPage(() =>
       expect(page.querySelector('[data-test-id="cron-row-access-job"]')).not.toBeNull(),
     );
+    expect(
+      page.querySelector('[data-test-id="cron-row-description-access-job"]')?.textContent,
+    ).toContain(job.description);
     expect(Boolean(page.querySelector('[data-test-id="cron-new-task"]'))).toBe(canManage);
     expect(Boolean(page.querySelector('[data-test-id="cron-row-run-access-job"]'))).toBe(canManage);
     expect(Boolean(page.querySelector('[data-test-id="cron-row-toggle-access-job"]'))).toBe(
@@ -215,6 +219,9 @@ describe("CronPage editor state sync", () => {
     (page.querySelector('[data-test-id="cron-row-access-job"]') as HTMLElement).click();
     await waitForCronPage(() =>
       expect(page.querySelector('[data-test-id="cron-detail-tab-history"]')).not.toBeNull(),
+    );
+    expect(page.querySelector('[data-test-id="cron-detail-description"]')?.textContent).toContain(
+      job.description,
     );
     expect(Boolean(page.querySelector('[data-test-id="cron-run-now"]'))).toBe(canManage);
     expect(Boolean(page.querySelector('[data-test-id="cron-toggle-enabled"]'))).toBe(canManage);

--- a/ui/src/pages/cron/view-description.test.ts
+++ b/ui/src/pages/cron/view-description.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CronJob } from "../../api/types.ts";
+import { DEFAULT_CRON_FORM } from "../../test-helpers/cron.ts";
+import { createCronViewJob, renderCronView } from "./view.test-support.ts";
+
+const payloadCases = [
+  { kind: "systemEvent", payload: { kind: "systemEvent", text: "check status" } },
+  { kind: "agentTurn", payload: { kind: "agentTurn", message: "Summarize updates" } },
+  { kind: "command", payload: { kind: "command", argv: ["echo", "ready"] } },
+  { kind: "script", payload: { kind: "script", script: "return 'ready'" } },
+  { kind: "heartbeat", payload: { kind: "heartbeat" } },
+] satisfies Array<{ kind: CronJob["payload"]["kind"]; payload: CronJob["payload"] }>;
+
+describe("cron view saved descriptions", () => {
+  it.each(payloadCases)(
+    "shows the saved description inline for $kind tasks without changing row selection",
+    ({ kind, payload }) => {
+      const onSelectJob = vi.fn();
+      const job = createCronViewJob(`described-${kind}`, {
+        description: "  Summarize overnight deployment activity  ",
+        payload,
+      });
+      const container = renderCronView({ jobs: [job], onSelectJob });
+      const description = container.querySelector<HTMLSpanElement>(
+        `[data-test-id="cron-row-description-${job.id}"]`,
+      );
+
+      expect(description).toBeInstanceOf(HTMLSpanElement);
+      expect(description?.textContent?.trim()).toBe("· Summarize overnight deployment activity");
+      expect(description?.title).toBe("Description: Summarize overnight deployment activity");
+      description?.click();
+      expect(onSelectJob).toHaveBeenCalledWith(job);
+    },
+  );
+
+  it.each([undefined, "", "  \n\t  "])(
+    "omits the inline description when the saved description is %j",
+    (description) => {
+      const job = createCronViewJob("without-description", { description });
+      const container = renderCronView({ jobs: [job] });
+
+      expect(container.querySelector(".cron-table__description")).toBeNull();
+    },
+  );
+
+  it("renders saved descriptions as escaped text", () => {
+    const description = '<img src="x" onerror="alert(1)"> & <script>alert(1)</script>';
+    const job = createCronViewJob("escaped-description", { description });
+    const container = renderCronView({ jobs: [job] });
+
+    expect(container.querySelector(".cron-table__description")?.textContent).toContain(description);
+    expect(container.querySelector(".cron-table__name img")).toBeNull();
+    expect(container.querySelector(".cron-table__name script")).toBeNull();
+  });
+
+  it.each(payloadCases)(
+    "shows the saved $kind task description instead of unsaved form edits",
+    ({ kind, payload }) => {
+      const job = createCronViewJob(`saved-${kind}`, {
+        description: "  Saved description for the selected task  ",
+        payload,
+      });
+      const container = renderCronView({
+        jobs: [job],
+        editingJobId: job.id,
+        form: { ...DEFAULT_CRON_FORM, description: "Unsaved description edit" },
+      });
+      const description = container.querySelector('[data-test-id="cron-detail-description"]');
+
+      expect(description).toBeInstanceOf(HTMLDivElement);
+      expect(description?.textContent?.replace(/\s+/g, " ").trim()).toBe(
+        "Description: Saved description for the selected task",
+      );
+      expect(description?.textContent).not.toContain("Unsaved description edit");
+    },
+  );
+
+  it.each([undefined, "", "  \n\t  "])(
+    "omits the detail description when the saved description is %j",
+    (description) => {
+      const job = createCronViewJob("without-description", { description });
+      const container = renderCronView({ jobs: [job], editingJobId: job.id });
+
+      expect(container.querySelector('[data-test-id="cron-detail-description"]')).toBeNull();
+    },
+  );
+});

--- a/ui/src/pages/cron/view.test-support.ts
+++ b/ui/src/pages/cron/view.test-support.ts
@@ -1,0 +1,95 @@
+import { render } from "lit";
+import type { CronJob } from "../../api/types.ts";
+import { DEFAULT_CRON_FORM } from "../../test-helpers/cron.ts";
+import { renderCron } from "./view.ts";
+
+type CronProps = Parameters<typeof renderCron>[0];
+
+export function createCronViewJob(id: string, overrides: Partial<CronJob> = {}): CronJob {
+  return {
+    id,
+    name: "Daily ping",
+    enabled: true,
+    createdAtMs: 0,
+    updatedAtMs: 0,
+    schedule: { kind: "cron", expr: "0 9 * * *" },
+    sessionTarget: "main",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "systemEvent", text: "ping" },
+    ...overrides,
+  } as CronJob;
+}
+
+function createCronViewProps(overrides: Partial<CronProps> = {}): CronProps {
+  return {
+    basePath: "",
+    agentId: "main",
+    loading: false,
+    canManage: true,
+    jobsLoadingMore: false,
+    status: null,
+    failingCount: null,
+    agentScoped: false,
+    scopedTotal: null,
+    scopedNextWakeAtMs: null,
+    jobs: [],
+    jobsTotal: 0,
+    jobsHasMore: false,
+    jobsQuery: "",
+    jobsEnabledFilter: "all",
+    jobsScheduleKindFilter: "all",
+    jobsLastStatusFilter: "all",
+    jobsSortBy: "nextRunAtMs",
+    jobsSortDir: "asc",
+    error: null,
+    busy: false,
+    form: { ...DEFAULT_CRON_FORM },
+    fieldErrors: {},
+    canSubmit: true,
+    editingJobId: null,
+    createOpen: false,
+    listTab: "tasks",
+    detailTab: "settings",
+    channels: [],
+    channelLabels: {},
+    runs: [],
+    runsTotal: 0,
+    runsHasMore: false,
+    runsLoadingMore: false,
+    runsStatuses: [],
+    runsDeliveryStatuses: [],
+    runsQuery: "",
+    runsSortDir: "desc",
+    agentSuggestions: [],
+    modelSuggestions: [],
+    thinkingSuggestions: [],
+    timezoneSuggestions: [],
+    deliveryToSuggestions: [],
+    accountSuggestions: [],
+    onListTabChange: () => undefined,
+    onDetailTabChange: () => undefined,
+    onFormChange: () => undefined,
+    onRefresh: () => undefined,
+    onSubmit: () => undefined,
+    onSubmitRunNow: () => undefined,
+    onSelectJob: () => undefined,
+    onOpenCreate: () => undefined,
+    onClosePanel: () => undefined,
+    onClone: () => undefined,
+    onToggle: () => undefined,
+    onRun: () => undefined,
+    onRemove: () => undefined,
+    onLoadMoreJobs: () => undefined,
+    onJobsFiltersChange: () => undefined,
+    onJobsFiltersReset: () => undefined,
+    onLoadMoreRuns: () => undefined,
+    onRunsFiltersChange: () => undefined,
+    ...overrides,
+  };
+}
+
+export function renderCronView(overrides: Partial<CronProps> = {}) {
+  const container = document.createElement("div");
+  render(renderCron(createCronViewProps(overrides)), container);
+  return container;
+}

--- a/ui/src/pages/cron/view.test.ts
+++ b/ui/src/pages/cron/view.test.ts
@@ -1,100 +1,10 @@
 // Control UI tests cover the Automations (cron) view behavior.
-import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
-import type { CronJob } from "../../api/types.ts";
 import { DEFAULT_CRON_FORM } from "../../test-helpers/cron.ts";
-import { renderCron } from "./view.ts";
-
-type CronProps = Parameters<typeof renderCron>[0];
-
-function createJob(id: string, overrides: Partial<CronJob> = {}): CronJob {
-  return {
-    id,
-    name: "Daily ping",
-    enabled: true,
-    createdAtMs: 0,
-    updatedAtMs: 0,
-    schedule: { kind: "cron", expr: "0 9 * * *" },
-    sessionTarget: "main",
-    wakeMode: "next-heartbeat",
-    payload: { kind: "systemEvent", text: "ping" },
-    ...overrides,
-  } as CronJob;
-}
-
-function createProps(overrides: Partial<CronProps> = {}): CronProps {
-  return {
-    basePath: "",
-    agentId: "main",
-    loading: false,
-    canManage: true,
-    jobsLoadingMore: false,
-    status: null,
-    failingCount: null,
-    agentScoped: false,
-    scopedTotal: null,
-    scopedNextWakeAtMs: null,
-    jobs: [],
-    jobsTotal: 0,
-    jobsHasMore: false,
-    jobsQuery: "",
-    jobsEnabledFilter: "all",
-    jobsScheduleKindFilter: "all",
-    jobsLastStatusFilter: "all",
-    jobsSortBy: "nextRunAtMs",
-    jobsSortDir: "asc",
-    error: null,
-    busy: false,
-    form: { ...DEFAULT_CRON_FORM },
-    fieldErrors: {},
-    canSubmit: true,
-    editingJobId: null,
-    createOpen: false,
-    listTab: "tasks",
-    detailTab: "settings",
-    channels: [],
-    channelLabels: {},
-    runs: [],
-    runsTotal: 0,
-    runsHasMore: false,
-    runsLoadingMore: false,
-    runsStatuses: [],
-    runsDeliveryStatuses: [],
-    runsQuery: "",
-    runsSortDir: "desc",
-    agentSuggestions: [],
-    modelSuggestions: [],
-    thinkingSuggestions: [],
-    timezoneSuggestions: [],
-    deliveryToSuggestions: [],
-    accountSuggestions: [],
-    onListTabChange: () => undefined,
-    onDetailTabChange: () => undefined,
-    onFormChange: () => undefined,
-    onRefresh: () => undefined,
-    onSubmit: () => undefined,
-    onSubmitRunNow: () => undefined,
-    onSelectJob: () => undefined,
-    onOpenCreate: () => undefined,
-    onClosePanel: () => undefined,
-    onClone: () => undefined,
-    onToggle: () => undefined,
-    onRun: () => undefined,
-    onRemove: () => undefined,
-    onLoadMoreJobs: () => undefined,
-    onJobsFiltersChange: () => undefined,
-    onJobsFiltersReset: () => undefined,
-    onLoadMoreRuns: () => undefined,
-    onRunsFiltersChange: () => undefined,
-    ...overrides,
-  };
-}
-
-function renderView(overrides: Partial<CronProps> = {}) {
-  const container = document.createElement("div");
-  render(renderCron(createProps(overrides)), container);
-  return container;
-}
+import {
+  createCronViewJob as createJob,
+  renderCronView as renderView,
+} from "./view.test-support.ts";
 
 function getButtonByText(container: Element, text: string): HTMLButtonElement {
   const button = Array.from(container.querySelectorAll("button")).find(
@@ -1025,7 +935,10 @@ describe("cron view editor", () => {
 
   it("keeps read-only operators on browse surfaces without mutation controls", () => {
     const onSelectJob = vi.fn();
-    const job = createJob("job-1", { name: "Nightly digest" });
+    const job = createJob("job-1", {
+      name: "Nightly digest",
+      description: "Read-only operators can inspect this task",
+    });
     const list = renderView({ canManage: false, jobs: [job], jobsTotal: 1, onSelectJob });
 
     expect(list.textContent).toContain("Browsing only");
@@ -1034,6 +947,7 @@ describe("cron view editor", () => {
     expect(list.querySelector('[data-test-id="cron-row-toggle-job-1"]')).toBeNull();
     expect(list.querySelector("wa-dropdown.cron-job-menu")).toBeNull();
     expect(list.querySelector("[data-suggestion]")).toBeNull();
+    expect(list.querySelector(".cron-table__description")?.textContent).toContain(job.description);
 
     getElement(list, '[data-test-id="cron-row-job-1"]', HTMLDivElement).click();
     expect(onSelectJob).toHaveBeenCalledWith(job);
@@ -1047,6 +961,9 @@ describe("cron view editor", () => {
     expect(detail.querySelector(".cron-editor-actions")).toBeNull();
     expect(getElement(detail, ".cron-editor", HTMLFieldSetElement).disabled).toBe(true);
     expect(detail.querySelector('[data-test-id="cron-detail-tab-history"]')).not.toBeNull();
+    expect(detail.querySelector('[data-test-id="cron-detail-description"]')?.textContent).toContain(
+      job.description,
+    );
   });
 
   it("locks the editor and back navigation while a save is pending", () => {
@@ -1067,7 +984,10 @@ describe("cron view editor", () => {
   });
 
   it("shows run history instead of the editor on the history tab", () => {
-    const job = createJob("job-1", { name: "Nightly digest" });
+    const job = createJob("job-1", {
+      name: "Nightly digest",
+      description: "Saved description stays visible in history",
+    });
     const container = renderView({
       jobs: [job],
       editingJobId: "job-1",
@@ -1076,6 +996,9 @@ describe("cron view editor", () => {
     });
     expect(container.querySelector(".cron-run-entry")).not.toBeNull();
     expect(container.querySelector(".cron-editor")).toBeNull();
+    expect(
+      container.querySelector('[data-test-id="cron-detail-description"]')?.textContent,
+    ).toContain(job.description);
   });
 
   it("shows the paused switch state for disabled jobs", () => {

--- a/ui/src/pages/cron/view.ts
+++ b/ui/src/pages/cron/view.ts
@@ -705,6 +705,7 @@ function renderJobsTable(props: CronProps, hasAnyJobsFilters: boolean) {
 }
 
 function renderJobRow(job: CronJob, props: CronProps) {
+  const description = job.description?.trim();
   const nextRunAtMs = job.state?.nextRunAtMs;
   const hasNextRun = typeof nextRunAtMs === "number" && Number.isFinite(nextRunAtMs);
   const dotVariant = isCronJobActiveFailure(job)
@@ -729,6 +730,16 @@ function renderJobRow(job: CronJob, props: CronProps) {
       <span class="cron-table__name">
         <span class="cron-table__dot ${dotVariant}" aria-hidden="true"></span>
         <span class="cron-table__name-text">${job.name}</span>
+        ${description
+          ? html`
+              <span
+                class="cron-table__description"
+                data-test-id=${`cron-row-description-${job.id}`}
+                title=${`${t("cron.form.description")}: ${description}`}
+                >· ${description}</span
+              >
+            `
+          : nothing}
         ${job.enabled
           ? nothing
           : html`<span class="muted cron-table__paused-note">${t("cron.list.paused")}</span>`}
@@ -918,6 +929,7 @@ function renderDetailView(props: CronProps, mode: CronPanelMode) {
 
 function renderDetailHeader(props: CronProps, mode: CronPanelMode, selectedJob?: CronJob) {
   const title = mode === "job" ? (selectedJob?.name ?? props.form.name) : t("cron.detail.newTitle");
+  const description = mode === "job" ? selectedJob?.description?.trim() : undefined;
   // Header describes the SAVED job (schedule + next run); the form's live
   // summary describes unsaved edits, so the two never contradict each other.
   const nextRunAtMs = selectedJob?.state?.nextRunAtMs;
@@ -933,6 +945,12 @@ function renderDetailHeader(props: CronProps, mode: CronPanelMode, selectedJob?:
     <div class="cron-detail-header">
       <div class="cron-detail-header__copy">
         <div class="cron-detail-title">${title}</div>
+        ${description
+          ? html`<div class="cron-detail-description" data-test-id="cron-detail-description">
+              <span class="cron-detail-description__label">${t("cron.form.description")}:</span>
+              ${description}
+            </div>`
+          : nothing}
         <div class="cron-detail-meta">
           ${mode === "job" && selectedJob && props.canManage
             ? renderEnabledSwitch(props, selectedJob)

--- a/ui/src/styles/cron.css
+++ b/ui/src/styles/cron.css
@@ -346,6 +346,17 @@
   white-space: nowrap;
 }
 
+.cron-table__description {
+  flex: 1 1 0;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--muted);
+  font-size: var(--control-ui-text-xs);
+  font-weight: 400;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .cron-table__paused-note {
   flex: 0 0 auto;
   font-size: var(--control-ui-text-xs);
@@ -499,6 +510,19 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.cron-detail-description {
+  max-width: 72ch;
+  color: var(--text);
+  font-size: var(--control-ui-text-sm);
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.cron-detail-description__label {
+  color: var(--muted);
+  font-weight: 600;
 }
 
 .cron-detail-meta {


### PR DESCRIPTION
Closes #13479

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users managing scheduled automations in the Control UI could not see their saved human-readable descriptions in the Cron dashboard, making similarly named jobs difficult to distinguish without opening the collapsed advanced editor.

Reported by @vokaplok in #13479. This builds on the original implementation proposed by @mvanhorn in #86674; Matt Van Horn is credited as a commit coauthor.

## Why This Change Was Made

Show each existing saved description inline beside its automation name and, when selected, in the shared detail header across Settings and History. The description remains safely escaped, whitespace-trimmed, localized through existing labels, truncated only in compact rows, and absent when blank; no storage, configuration, transport, or permission contract changes.

## User Impact

Operators can immediately distinguish scheduled automations by their human-readable descriptions, inspect the complete description without opening or editing advanced settings, and retain that context across History and read-only views. Existing prompts, row height, and all five scheduled payload types remain intact.

## Evidence

- **Real user-path proof:** created a scheduled automation through the normal CLI with the description `Summarize overnight deployments and flag failed releases`, verified the exact value in the CLI listing and `state/openclaw.sqlite` `cron_jobs.description`, started the real Gateway with freshly built Control UI assets, completed the normal authenticated dashboard bootstrap, and verified the actual Chromium-rendered Cron row, Settings detail, History detail, and existing prompt. Proof run: https://github.com/openclaw/openclaw/actions/runs/30793733943. The captured screenshot `live-gateway.png` has SHA-256 `ceb6c6f42bcfa18f351b7a0a9b81aa64b6d3b9cbb4c83ed9f7f77791a11c5cbd`.
- **Before:** the scheduled automation row showed only its name; the saved description was hidden inside collapsed Advanced settings.
- **After:** the same compact row shows `· Summarize overnight deployments and flag failed releases`; both Settings and History show `Description: Summarize overnight deployments and flag failed releases`, while the existing prompt remains visible.
- **Exact final branch, official real Chromium:** 13/13 scenarios across the dedicated description suite and existing Cron browser suite, including all five payload types, blank descriptions, unchanged row height, Settings/History transitions, and read-only behavior.
- **Focused Cron owner tests:** 76/76 passing across three suites.
- **Static checks:** all seven changed TypeScript files pass targeted oxlint; the Cron stylesheet passes stylelint; all eight changed files pass oxfmt; `git diff --check` is clean.
- **TypeScript transparency:** strict full UI and core-test project analysis passes with declaration emission disabled. The normal declaration-emitting UI command currently reports the *same three pre-existing diagnostics* (`TS2883`, `TS4058`, `TS7056`) at untouched `ui/src/e2e/new-session-page.test-support.ts:68` on both this patch and independently verified clean `main` commit `0cad02313a9cbc6d1e60dfcb1d44b1bde523e3fb`; none of the changed Cron files produces diagnostics. Declaration-disabled analysis is supplemental, not a replacement: normal hosted CI must pass before landing.
- **Independent and AI-assisted review:** independent reviewer clean; fresh full-patch Codex autoreview at `xhigh` found zero actionable issues (0.99 confidence), with a clean secret scan. This PR was prepared with AI assistance and human contributor credit preserved.
