### PR TITLE
improve(qa): replace terminal reply timing waits

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
@@ -270,7 +270,6 @@ export const QA_SUBAGENT_TERMINAL_MARKERS = {
   fallback: "QA-SUBAGENT-TERMINAL-FALLBACK-OK",
 } as const;
 export const QA_SUBAGENT_TERMINAL_METADATA_SENTINEL = "QA-SUBAGENT-TERMINAL-INTERNAL-MUST-NOT-LEAK";
-export const QA_SUBAGENT_TERMINAL_WORKER_DELAY_MS = 5_000;
 export const QA_NATIVE_STOP_DELAY_PROMPT_RE =
   /subagent recovery worker native command target proof\.\s*wait until stopped\./i;
 export const QA_NATIVE_STOP_DELAY_MS = 180_000;

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-responses-websocket.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-responses-websocket.ts
@@ -10,6 +10,7 @@ export type QaMockResponsesDispatchResult = {
     type: string;
     message: string;
   };
+  onResponseSent?: () => void;
   previewPauseMs?: number;
 };
 
@@ -232,6 +233,7 @@ export function attachQaMockResponsesWebSocketServer(params: {
             }
             sendEvent(event);
           }
+          dispatched.onResponseSent?.();
         })
         .catch(() => {
           cachedResponse = undefined;

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -2688,7 +2688,7 @@ describe("qa mock openai server", () => {
     expect(outputText(payload)).toBe(expected);
   });
 
-  it("holds a runtime terminal worker until the parent post-spawn response is sent", async () => {
+  it("requires a parent response for each same-case runtime worker", async () => {
     const server = await startMockServer();
     const childResponse = postNonStreamingResponses(server, {
       model: "gpt-5.6-luna",
@@ -2724,6 +2724,41 @@ describe("qa mock openai server", () => {
 
     const child = await (await expectOk(childResponse)).json();
     expect(outputText(child)).toBe("QA-SUBAGENT-TERMINAL-VISIBLE-OK");
+
+    const secondChildResponse = postNonStreamingResponses(server, {
+      model: "gpt-5.6-luna",
+      instructions: "Runtime: embedded | sessionId=qa-terminal-child-2",
+      input: [makeUserInput("Subagent terminal reply QA worker: visible.")],
+    });
+    let secondChildSettled = false;
+    void secondChildResponse.then(() => {
+      secondChildSettled = true;
+    });
+
+    await expect
+      .poll(async () => {
+        const inflight = await getJson<unknown[]>(server, "/debug/inflight-requests");
+        return inflight.length;
+      })
+      .toBe(1);
+    expect(secondChildSettled).toBe(false);
+
+    const secondParent = await expectNonStreamingResponsesJson(server, {
+      model: "gpt-5.6-luna",
+      instructions: "Runtime: embedded | sessionId=qa-terminal-parent-2",
+      tools: [SESSIONS_SPAWN_TOOL, SESSIONS_YIELD_TOOL],
+      input: [
+        makeUserInput("Subagent terminal reply QA check: visible."),
+        makeToolOutputWithCallId(
+          "call_mock_sessions_spawn_2",
+          JSON.stringify({ status: "accepted", runId: "run-visible-2" }),
+        ),
+      ],
+    });
+    expect(outputText(secondParent)).toBe("NO_REPLY");
+
+    const secondChild = await (await expectOk(secondChildResponse)).json();
+    expect(outputText(secondChild)).toBe("QA-SUBAGENT-TERMINAL-VISIBLE-OK");
   });
 
   it("keeps the empty terminal worker empty across retry prompts", async () => {

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -2688,49 +2688,46 @@ describe("qa mock openai server", () => {
     expect(outputText(payload)).toBe(expected);
   });
 
-  it("requires a parent response for each same-case runtime worker", async () => {
+  it("binds crossed same-case parent responses to their matching workers", async () => {
     const server = await startMockServer();
-    const childResponse = postNonStreamingResponses(server, {
-      model: "gpt-5.6-luna",
-      instructions: "Runtime: embedded | sessionId=qa-terminal-child",
-      input: [makeUserInput("Subagent terminal reply QA worker: visible.")],
-    });
-    let childSettled = false;
-    void childResponse.then(() => {
-      childSettled = true;
-    });
+    const firstChildSessionKey = "agent:qa:subagent:child-1";
+    const secondChildSessionKey = "agent:qa:subagent:child-2";
+    const startChild = (runtimeSessionId: string, childSessionKey: string) =>
+      postNonStreamingResponses(server, {
+        model: "gpt-5.6-luna",
+        instructions: [
+          `Runtime: embedded | sessionId=${runtimeSessionId}`,
+          `- Your session: ${childSessionKey}.`,
+        ].join("\n"),
+        input: [makeUserInput("Subagent terminal reply QA worker: visible.")],
+      });
+    const settleParent = async (
+      runtimeSessionId: string,
+      childSessionKey: string,
+      callId: string,
+    ) => {
+      const parent = await expectNonStreamingResponsesJson(server, {
+        model: "gpt-5.6-luna",
+        instructions: `Runtime: embedded | sessionId=${runtimeSessionId}`,
+        tools: [SESSIONS_SPAWN_TOOL, SESSIONS_YIELD_TOOL],
+        input: [
+          makeUserInput("Subagent terminal reply QA check: visible."),
+          makeToolOutputWithCallId(
+            callId,
+            JSON.stringify({ status: "accepted", childSessionKey, runId: `run-${callId}` }),
+          ),
+        ],
+      });
+      expect(outputText(parent)).toBe("NO_REPLY");
+    };
 
-    await expect
-      .poll(async () => {
-        const inflight = await getJson<unknown[]>(server, "/debug/inflight-requests");
-        return inflight.length;
-      })
-      .toBe(1);
-    expect(childSettled).toBe(false);
-
-    const parent = await expectNonStreamingResponsesJson(server, {
-      model: "gpt-5.6-luna",
-      instructions: "Runtime: embedded | sessionId=qa-terminal-parent",
-      tools: [SESSIONS_SPAWN_TOOL, SESSIONS_YIELD_TOOL],
-      input: [
-        makeUserInput("Subagent terminal reply QA check: visible."),
-        makeToolOutputWithCallId(
-          "call_mock_sessions_spawn_1",
-          JSON.stringify({ status: "accepted", runId: "run-visible" }),
-        ),
-      ],
-    });
-    expect(outputText(parent)).toBe("NO_REPLY");
-
-    const child = await (await expectOk(childResponse)).json();
-    expect(outputText(child)).toBe("QA-SUBAGENT-TERMINAL-VISIBLE-OK");
-
-    const secondChildResponse = postNonStreamingResponses(server, {
-      model: "gpt-5.6-luna",
-      instructions: "Runtime: embedded | sessionId=qa-terminal-child-2",
-      input: [makeUserInput("Subagent terminal reply QA worker: visible.")],
-    });
+    const firstChildResponse = startChild("qa-terminal-child-1", firstChildSessionKey);
+    const secondChildResponse = startChild("qa-terminal-child-2", secondChildSessionKey);
+    let firstChildSettled = false;
     let secondChildSettled = false;
+    void firstChildResponse.then(() => {
+      firstChildSettled = true;
+    });
     void secondChildResponse.then(() => {
       secondChildSettled = true;
     });
@@ -2740,25 +2737,17 @@ describe("qa mock openai server", () => {
         const inflight = await getJson<unknown[]>(server, "/debug/inflight-requests");
         return inflight.length;
       })
-      .toBe(1);
-    expect(secondChildSettled).toBe(false);
+      .toBe(2);
 
-    const secondParent = await expectNonStreamingResponsesJson(server, {
-      model: "gpt-5.6-luna",
-      instructions: "Runtime: embedded | sessionId=qa-terminal-parent-2",
-      tools: [SESSIONS_SPAWN_TOOL, SESSIONS_YIELD_TOOL],
-      input: [
-        makeUserInput("Subagent terminal reply QA check: visible."),
-        makeToolOutputWithCallId(
-          "call_mock_sessions_spawn_2",
-          JSON.stringify({ status: "accepted", runId: "run-visible-2" }),
-        ),
-      ],
-    });
-    expect(outputText(secondParent)).toBe("NO_REPLY");
-
+    await settleParent("qa-terminal-parent-2", secondChildSessionKey, "call_spawn_2");
     const secondChild = await (await expectOk(secondChildResponse)).json();
     expect(outputText(secondChild)).toBe("QA-SUBAGENT-TERMINAL-VISIBLE-OK");
+    expect(secondChildSettled).toBe(true);
+    expect(firstChildSettled).toBe(false);
+
+    await settleParent("qa-terminal-parent-1", firstChildSessionKey, "call_spawn_1");
+    const firstChild = await (await expectOk(firstChildResponse)).json();
+    expect(outputText(firstChild)).toBe("QA-SUBAGENT-TERMINAL-VISIBLE-OK");
   });
 
   it("keeps the empty terminal worker empty across retry prompts", async () => {

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -2688,6 +2688,44 @@ describe("qa mock openai server", () => {
     expect(outputText(payload)).toBe(expected);
   });
 
+  it("holds a runtime terminal worker until the parent post-spawn response is sent", async () => {
+    const server = await startMockServer();
+    const childResponse = postNonStreamingResponses(server, {
+      model: "gpt-5.6-luna",
+      instructions: "Runtime: embedded | sessionId=qa-terminal-child",
+      input: [makeUserInput("Subagent terminal reply QA worker: visible.")],
+    });
+    let childSettled = false;
+    void childResponse.then(() => {
+      childSettled = true;
+    });
+
+    await expect
+      .poll(async () => {
+        const inflight = await getJson<unknown[]>(server, "/debug/inflight-requests");
+        return inflight.length;
+      })
+      .toBe(1);
+    expect(childSettled).toBe(false);
+
+    const parent = await expectNonStreamingResponsesJson(server, {
+      model: "gpt-5.6-luna",
+      instructions: "Runtime: embedded | sessionId=qa-terminal-parent",
+      tools: [SESSIONS_SPAWN_TOOL, SESSIONS_YIELD_TOOL],
+      input: [
+        makeUserInput("Subagent terminal reply QA check: visible."),
+        makeToolOutputWithCallId(
+          "call_mock_sessions_spawn_1",
+          JSON.stringify({ status: "accepted", runId: "run-visible" }),
+        ),
+      ],
+    });
+    expect(outputText(parent)).toBe("NO_REPLY");
+
+    const child = await (await expectOk(childResponse)).json();
+    expect(outputText(child)).toBe("QA-SUBAGENT-TERMINAL-VISIBLE-OK");
+  });
+
   it("keeps the empty terminal worker empty across retry prompts", async () => {
     const server = await startMockServer();
     const payload = await expectNonStreamingResponsesJson(server, {

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -469,50 +469,70 @@ function extractScenarioPlannedTool(events: StreamEvent[]) {
 
 type TerminalRequesterSettleGate = {
   markSettled: (caseName: string) => void;
-  waitUntilSettled: (caseName: string) => Promise<void>;
+  waitUntilSettled: (caseName: string, workerSessionId: string) => Promise<void>;
 };
 
 function createTerminalRequesterSettleGate(): TerminalRequesterSettleGate {
-  const settled = new Set<string>();
-  const waiters = new Map<string, Set<() => void>>();
+  const admittedWorkers = new Set<string>();
+  const availablePermits = new Map<string, number>();
+  const waiterPromises = new Map<string, Promise<void>>();
+  const waiters = new Map<string, { caseName: string; finish: () => void }>();
+  const workerKey = (caseName: string, workerSessionId: string) =>
+    `${caseName}\n${workerSessionId}`;
   return {
     markSettled(caseName) {
-      settled.add(caseName);
-      for (const resolve of waiters.get(caseName) ?? []) {
-        resolve();
-      }
-      waiters.delete(caseName);
-    },
-    async waitUntilSettled(caseName) {
-      if (settled.has(caseName)) {
+      const waiting = [...waiters.values()].find((candidate) => candidate.caseName === caseName);
+      if (waiting) {
+        waiting.finish();
         return;
       }
-      await new Promise<void>((resolve, reject) => {
-        const listeners = waiters.get(caseName) ?? new Set<() => void>();
+      availablePermits.set(caseName, (availablePermits.get(caseName) ?? 0) + 1);
+    },
+    async waitUntilSettled(caseName, workerSessionId) {
+      const key = workerKey(caseName, workerSessionId);
+      if (admittedWorkers.has(key)) {
+        return;
+      }
+      const existing = waiterPromises.get(key);
+      if (existing) {
+        return await existing;
+      }
+      const permitCount = availablePermits.get(caseName) ?? 0;
+      if (permitCount > 0) {
+        admittedWorkers.add(key);
+        availablePermits.set(caseName, permitCount - 1);
+        return;
+      }
+      const promise = new Promise<void>((resolve, reject) => {
         const timeout = setTimeout(() => {
-          listeners.delete(finish);
-          reject(new Error(`terminal requester did not settle: ${caseName}`));
+          waiters.delete(key);
+          waiterPromises.delete(key);
+          reject(new Error(`terminal requester did not settle: ${caseName} (${workerSessionId})`));
         }, 30_000);
         const finish = () => {
           clearTimeout(timeout);
+          waiters.delete(key);
+          waiterPromises.delete(key);
+          admittedWorkers.add(key);
           resolve();
         };
-        listeners.add(finish);
-        waiters.set(caseName, listeners);
+        waiters.set(key, { caseName, finish });
       });
+      waiterPromises.set(key, promise);
+      await promise;
     },
   };
 }
 
-function isQaRuntimeSessionRequest(input: ResponsesInputItem[], body: Record<string, unknown>) {
-  return /\bRuntime:\s*[^\n]*\bsessionId=[^\s|]+/u.test(extractAllRequestTexts(input, body));
+function resolveQaRuntimeSessionId(input: ResponsesInputItem[], body: Record<string, unknown>) {
+  return /\bRuntime:\s*[^\n]*\bsessionId=([^\s|]+)/u.exec(extractAllRequestTexts(input, body))?.[1];
 }
 
 async function buildResponsesPayload(
   body: Record<string, unknown>,
   scenarioState: MockScenarioState,
   options: {
-    waitForTerminalRequesterSettled?: (caseName: string) => Promise<void>;
+    waitForTerminalRequesterSettled?: (caseName: string, workerSessionId: string) => Promise<void>;
   } = {},
 ) {
   const providerVariant = resolveProviderVariant(
@@ -821,8 +841,9 @@ async function buildResponsesPayload(
     .at(-1)?.[1]
     ?.toLowerCase();
   if (terminalWorkerCase) {
-    if (options.waitForTerminalRequesterSettled && isQaRuntimeSessionRequest(input, body)) {
-      await options.waitForTerminalRequesterSettled(terminalWorkerCase);
+    const workerSessionId = resolveQaRuntimeSessionId(input, body);
+    if (options.waitForTerminalRequesterSettled && workerSessionId) {
+      await options.waitForTerminalRequesterSettled(terminalWorkerCase, workerSessionId);
     }
   }
   if (terminalWorkerCase === "silent") {
@@ -1985,12 +2006,8 @@ export async function startQaMockOpenAiServer(params?: {
           system: body.system as AnthropicMessagesRequest["system"],
           messages: [],
         });
-    const systemPrompt = extractAllRequestTexts(
-      input.filter((item) => item.role === "developer" || item.role === "system"),
-      body,
-    );
     const sessionId =
-      /\bRuntime:\s*[^\n]*\bsessionId=([^\s|]+)/u.exec(systemPrompt)?.[1] ??
+      resolveQaRuntimeSessionId(input, body) ??
       (body.client_metadata as { session_id?: unknown } | undefined)?.session_id;
     const key = typeof sessionId === "string" ? sessionId : "";
     // Runtime session identity survives provider switches and cache-boundary changes.
@@ -2052,7 +2069,7 @@ export async function startQaMockOpenAiServer(params?: {
     const settledTerminalRequesterCase =
       terminalRequesterCase &&
       hasToolOutput(input) &&
-      isQaRuntimeSessionRequest(input, request.body)
+      resolveQaRuntimeSessionId(input, request.body)
         ? terminalRequesterCase
         : undefined;
     recordRequest({

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -468,55 +468,43 @@ function extractScenarioPlannedTool(events: StreamEvent[]) {
 }
 
 type TerminalRequesterSettleGate = {
-  markSettled: (caseName: string) => void;
-  waitUntilSettled: (caseName: string, workerSessionId: string) => Promise<void>;
+  markSettled: (caseName: string, childSessionKey: string) => void;
+  waitUntilSettled: (caseName: string, childSessionKey: string) => Promise<void>;
 };
 
 function createTerminalRequesterSettleGate(): TerminalRequesterSettleGate {
-  const admittedWorkers = new Set<string>();
-  const availablePermits = new Map<string, number>();
+  const settledChildren = new Set<string>();
   const waiterPromises = new Map<string, Promise<void>>();
-  const waiters = new Map<string, { caseName: string; finish: () => void }>();
-  const workerKey = (caseName: string, workerSessionId: string) =>
-    `${caseName}\n${workerSessionId}`;
+  const waiters = new Map<string, () => void>();
+  const childKey = (caseName: string, childSessionKey: string) => `${caseName}\n${childSessionKey}`;
   return {
-    markSettled(caseName) {
-      const waiting = [...waiters.values()].find((candidate) => candidate.caseName === caseName);
-      if (waiting) {
-        waiting.finish();
-        return;
-      }
-      availablePermits.set(caseName, (availablePermits.get(caseName) ?? 0) + 1);
+    markSettled(caseName, childSessionKey) {
+      const key = childKey(caseName, childSessionKey);
+      settledChildren.add(key);
+      waiters.get(key)?.();
     },
-    async waitUntilSettled(caseName, workerSessionId) {
-      const key = workerKey(caseName, workerSessionId);
-      if (admittedWorkers.has(key)) {
+    async waitUntilSettled(caseName, childSessionKey) {
+      const key = childKey(caseName, childSessionKey);
+      if (settledChildren.has(key)) {
         return;
       }
       const existing = waiterPromises.get(key);
       if (existing) {
         return await existing;
       }
-      const permitCount = availablePermits.get(caseName) ?? 0;
-      if (permitCount > 0) {
-        admittedWorkers.add(key);
-        availablePermits.set(caseName, permitCount - 1);
-        return;
-      }
       const promise = new Promise<void>((resolve, reject) => {
         const timeout = setTimeout(() => {
           waiters.delete(key);
           waiterPromises.delete(key);
-          reject(new Error(`terminal requester did not settle: ${caseName} (${workerSessionId})`));
+          reject(new Error(`terminal requester did not settle: ${caseName} (${childSessionKey})`));
         }, 30_000);
         const finish = () => {
           clearTimeout(timeout);
           waiters.delete(key);
           waiterPromises.delete(key);
-          admittedWorkers.add(key);
           resolve();
         };
-        waiters.set(key, { caseName, finish });
+        waiters.set(key, finish);
       });
       waiterPromises.set(key, promise);
       await promise;
@@ -528,11 +516,26 @@ function resolveQaRuntimeSessionId(input: ResponsesInputItem[], body: Record<str
   return /\bRuntime:\s*[^\n]*\bsessionId=([^\s|]+)/u.exec(extractAllRequestTexts(input, body))?.[1];
 }
 
+function resolveQaChildSessionKey(input: ResponsesInputItem[], body: Record<string, unknown>) {
+  const systemPrompt = extractAllRequestTexts(
+    input.filter((item) => item.role === "developer" || item.role === "system"),
+    body,
+  );
+  return /^- Your session:\s*(.+?)\.\s*$/mu.exec(systemPrompt)?.[1]?.trim();
+}
+
+function resolveAcceptedChildSessionKey(input: ResponsesInputItem[]) {
+  const output = parseToolOutputJson(extractToolOutput(input));
+  return output?.status === "accepted" && typeof output.childSessionKey === "string"
+    ? output.childSessionKey.trim() || undefined
+    : undefined;
+}
+
 async function buildResponsesPayload(
   body: Record<string, unknown>,
   scenarioState: MockScenarioState,
   options: {
-    waitForTerminalRequesterSettled?: (caseName: string, workerSessionId: string) => Promise<void>;
+    waitForTerminalRequesterSettled?: (caseName: string, childSessionKey: string) => Promise<void>;
   } = {},
 ) {
   const providerVariant = resolveProviderVariant(
@@ -841,9 +844,9 @@ async function buildResponsesPayload(
     .at(-1)?.[1]
     ?.toLowerCase();
   if (terminalWorkerCase) {
-    const workerSessionId = resolveQaRuntimeSessionId(input, body);
-    if (options.waitForTerminalRequesterSettled && workerSessionId) {
-      await options.waitForTerminalRequesterSettled(terminalWorkerCase, workerSessionId);
+    const childSessionKey = resolveQaChildSessionKey(input, body);
+    if (options.waitForTerminalRequesterSettled && childSessionKey) {
+      await options.waitForTerminalRequesterSettled(terminalWorkerCase, childSessionKey);
     }
   }
   if (terminalWorkerCase === "silent") {
@@ -2066,12 +2069,15 @@ export async function startQaMockOpenAiServer(params?: {
     )
       ?.text.match(QA_SUBAGENT_TERMINAL_MATRIX_PROMPT_RE)?.[1]
       ?.toLowerCase();
-    const settledTerminalRequesterCase =
-      terminalRequesterCase &&
-      hasToolOutput(input) &&
-      resolveQaRuntimeSessionId(input, request.body)
-        ? terminalRequesterCase
+    const settledTerminalRequester =
+      terminalRequesterCase && resolveQaRuntimeSessionId(input, request.body)
+        ? {
+            caseName: terminalRequesterCase,
+            childSessionKey: resolveAcceptedChildSessionKey(input),
+          }
         : undefined;
+    const settledTerminalCaseName = settledTerminalRequester?.caseName;
+    const settledChildSessionKey = settledTerminalRequester?.childSessionKey;
     recordRequest({
       raw: request.raw,
       body: request.body,
@@ -2093,10 +2099,13 @@ export async function startQaMockOpenAiServer(params?: {
     });
     return {
       events,
-      ...(settledTerminalRequesterCase
+      ...(settledTerminalCaseName && settledChildSessionKey
         ? {
             onResponseSent: () =>
-              terminalRequesterSettleGate.markSettled(settledTerminalRequesterCase),
+              terminalRequesterSettleGate.markSettled(
+                settledTerminalCaseName,
+                settledChildSessionKey,
+              ),
           }
         : {}),
       ...(QA_PROVIDER_HTTP_503_AFTER_TOOL_PROMPT_RE.test(allInputText) && hasToolOutput(input)

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -64,7 +64,6 @@ import {
   QA_SUBAGENT_DIRECT_FALLBACK_MARKER,
   QA_SUBAGENT_TERMINAL_MARKERS,
   QA_SUBAGENT_TERMINAL_METADATA_SENTINEL,
-  QA_SUBAGENT_TERMINAL_WORKER_DELAY_MS,
   QA_NATIVE_STOP_DELAY_PROMPT_RE,
   QA_NATIVE_STOP_DELAY_MS,
   QA_IMAGE_GENERATION_PROMPT_RE,
@@ -468,9 +467,53 @@ function extractScenarioPlannedTool(events: StreamEvent[]) {
     : { name: wireName, args: wireArgs, wireName };
 }
 
+type TerminalRequesterSettleGate = {
+  markSettled: (caseName: string) => void;
+  waitUntilSettled: (caseName: string) => Promise<void>;
+};
+
+function createTerminalRequesterSettleGate(): TerminalRequesterSettleGate {
+  const settled = new Set<string>();
+  const waiters = new Map<string, Set<() => void>>();
+  return {
+    markSettled(caseName) {
+      settled.add(caseName);
+      for (const resolve of waiters.get(caseName) ?? []) {
+        resolve();
+      }
+      waiters.delete(caseName);
+    },
+    async waitUntilSettled(caseName) {
+      if (settled.has(caseName)) {
+        return;
+      }
+      await new Promise<void>((resolve, reject) => {
+        const listeners = waiters.get(caseName) ?? new Set<() => void>();
+        const timeout = setTimeout(() => {
+          listeners.delete(finish);
+          reject(new Error(`terminal requester did not settle: ${caseName}`));
+        }, 30_000);
+        const finish = () => {
+          clearTimeout(timeout);
+          resolve();
+        };
+        listeners.add(finish);
+        waiters.set(caseName, listeners);
+      });
+    },
+  };
+}
+
+function isQaRuntimeSessionRequest(input: ResponsesInputItem[], body: Record<string, unknown>) {
+  return /\bRuntime:\s*[^\n]*\bsessionId=[^\s|]+/u.test(extractAllRequestTexts(input, body));
+}
+
 async function buildResponsesPayload(
   body: Record<string, unknown>,
   scenarioState: MockScenarioState,
+  options: {
+    waitForTerminalRequesterSettled?: (caseName: string) => Promise<void>;
+  } = {},
 ) {
   const providerVariant = resolveProviderVariant(
     typeof body.model === "string" ? body.model : undefined,
@@ -778,7 +821,9 @@ async function buildResponsesPayload(
     .at(-1)?.[1]
     ?.toLowerCase();
   if (terminalWorkerCase) {
-    await sleep(QA_SUBAGENT_TERMINAL_WORKER_DELAY_MS);
+    if (options.waitForTerminalRequesterSettled && isQaRuntimeSessionRequest(input, body)) {
+      await options.waitForTerminalRequesterSettled(terminalWorkerCase);
+    }
   }
   if (terminalWorkerCase === "silent") {
     return buildAssistantEvents("NO_REPLY");
@@ -1931,6 +1976,7 @@ export async function startQaMockOpenAiServer(params?: {
 }) {
   const host = params?.host ?? "127.0.0.1";
   const finalOnlyMarkerPauseMs = params?.finalOnlyMarkerPauseMs ?? 1_500;
+  const terminalRequesterSettleGate = createTerminalRequesterSettleGate();
   const scenarioStates = new Map<string, MockScenarioState>();
   const scenarioStateFor = (body: Record<string, unknown>): MockScenarioState => {
     const input = Array.isArray(body.input)
@@ -1989,12 +2035,26 @@ export async function startQaMockOpenAiServer(params?: {
     inflightRequests.set(inflightRequestId, { prompt, allInputText });
     let events: StreamEvent[];
     try {
-      events = await buildResponsesPayload(request.body, scenarioStateFor(request.body));
+      events = await buildResponsesPayload(request.body, scenarioStateFor(request.body), {
+        waitForTerminalRequesterSettled: terminalRequesterSettleGate.waitUntilSettled,
+      });
     } finally {
       inflightRequests.delete(inflightRequestId);
     }
     const resolvedModel = typeof request.body.model === "string" ? request.body.model : "";
     const plannedTool = extractScenarioPlannedTool(events);
+    const terminalRequesterCase = extractLastMatchingUserTurn(
+      input,
+      QA_SUBAGENT_TERMINAL_MATRIX_PROMPT_RE,
+    )
+      ?.text.match(QA_SUBAGENT_TERMINAL_MATRIX_PROMPT_RE)?.[1]
+      ?.toLowerCase();
+    const settledTerminalRequesterCase =
+      terminalRequesterCase &&
+      hasToolOutput(input) &&
+      isQaRuntimeSessionRequest(input, request.body)
+        ? terminalRequesterCase
+        : undefined;
     recordRequest({
       raw: request.raw,
       body: request.body,
@@ -2016,6 +2076,12 @@ export async function startQaMockOpenAiServer(params?: {
     });
     return {
       events,
+      ...(settledTerminalRequesterCase
+        ? {
+            onResponseSent: () =>
+              terminalRequesterSettleGate.markSettled(settledTerminalRequesterCase),
+          }
+        : {}),
       ...(QA_PROVIDER_HTTP_503_AFTER_TOOL_PROMPT_RE.test(allInputText) && hasToolOutput(input)
         ? {
             failure: {
@@ -2189,6 +2255,7 @@ export async function startQaMockOpenAiServer(params?: {
             return;
           }
           writeJson(res, 200, completion.response);
+          dispatched.onResponseSent?.();
           return;
         }
         if (dispatched.previewPauseMs !== undefined) {
@@ -2196,6 +2263,7 @@ export async function startQaMockOpenAiServer(params?: {
         } else {
           writeSse(res, events);
         }
+        dispatched.onResponseSent?.();
         return;
       }
       if (req.method === "POST" && url.pathname === "/v1/messages") {

--- a/extensions/qa-lab/src/scenario-catalog-channels.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-channels.test.ts
@@ -143,6 +143,36 @@ describe("qa scenario catalog channel contracts", () => {
     expect(flow).not.toContain('"value":"subagent-1: ok\\nsubagent-2: ok"');
   });
 
+  it("settles terminal-reply scenarios from durable task facts instead of sleeps", () => {
+    const scenario = requireFlowScenario(readQaScenarioById("subagent-completion-direct-fallback"));
+    const flow = JSON.stringify(scenario.execution.flow);
+    const config = scenario.execution.config as
+      | { cases?: Array<{ name?: string; marker?: string; expectedSendCount?: number }> }
+      | undefined;
+
+    expect(config?.cases).toEqual([
+      {
+        name: "visible",
+        marker: "QA-SUBAGENT-TERMINAL-VISIBLE-OK",
+        expectedSendCount: 1,
+      },
+      { name: "silent", marker: "NO_REPLY", expectedSendCount: 0 },
+      {
+        name: "fallback",
+        marker: "QA-SUBAGENT-TERMINAL-FALLBACK-OK",
+        expectedSendCount: 1,
+      },
+    ]);
+    expect(flow).toContain("env.gateway.call('tasks.list'");
+    expect(flow).toContain("task.title === `qa-terminal-${caseName}`");
+    expect(flow).toContain("task.status === 'completed'");
+    expect(flow).toContain("task.deliveryStatus === 'delivered'");
+    expect(flow).toContain("readSettledTerminalTask('restart')");
+    expect(flow).toContain("readSettledTerminalTask('empty')");
+    expect(flow).toContain("verdicts.length === 5");
+    expect(flow).not.toContain('"call":"sleep"');
+  });
+
   it("keeps channel streaming evidence portable across QA Channel and Crabline Telegram", () => {
     const scenario = requireFlowScenario(readQaScenarioById("channel-message-flows"));
 

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -581,36 +581,6 @@ describe("qa scenario catalog", () => {
     });
   });
 
-  it("settles terminal-reply scenarios from durable task facts instead of sleeps", () => {
-    const scenario = readQaScenarioById("subagent-completion-direct-fallback");
-    const flow = JSON.stringify(scenario.execution.flow);
-    const config = scenario.execution.config as
-      | { cases?: Array<{ name?: string; marker?: string; expectedSendCount?: number }> }
-      | undefined;
-
-    expect(config?.cases).toEqual([
-      {
-        name: "visible",
-        marker: "QA-SUBAGENT-TERMINAL-VISIBLE-OK",
-        expectedSendCount: 1,
-      },
-      { name: "silent", marker: "NO_REPLY", expectedSendCount: 0 },
-      {
-        name: "fallback",
-        marker: "QA-SUBAGENT-TERMINAL-FALLBACK-OK",
-        expectedSendCount: 1,
-      },
-    ]);
-    expect(flow).toContain("env.gateway.call('tasks.list'");
-    expect(flow).toContain("task.title === `qa-terminal-${caseName}`");
-    expect(flow).toContain("task.status === 'completed'");
-    expect(flow).toContain("task.deliveryStatus === 'delivered'");
-    expect(flow).toContain("readSettledTerminalTask('restart')");
-    expect(flow).toContain("readSettledTerminalTask('empty')");
-    expect(flow).toContain("verdicts.length === 5");
-    expect(flow).not.toContain('"call":"sleep"');
-  });
-
   it("loads live gateway sentinel scenarios for harness self-health", () => {
     const scenarioIds = [
       "plugin-hook-health-sentinel",

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -581,6 +581,36 @@ describe("qa scenario catalog", () => {
     });
   });
 
+  it("settles terminal-reply scenarios from durable task facts instead of sleeps", () => {
+    const scenario = readQaScenarioById("subagent-completion-direct-fallback");
+    const flow = JSON.stringify(scenario.execution.flow);
+    const config = scenario.execution.config as
+      | { cases?: Array<{ name?: string; marker?: string; expectedSendCount?: number }> }
+      | undefined;
+
+    expect(config?.cases).toEqual([
+      {
+        name: "visible",
+        marker: "QA-SUBAGENT-TERMINAL-VISIBLE-OK",
+        expectedSendCount: 1,
+      },
+      { name: "silent", marker: "NO_REPLY", expectedSendCount: 0 },
+      {
+        name: "fallback",
+        marker: "QA-SUBAGENT-TERMINAL-FALLBACK-OK",
+        expectedSendCount: 1,
+      },
+    ]);
+    expect(flow).toContain("env.gateway.call('tasks.list'");
+    expect(flow).toContain("task.title === `qa-terminal-${caseName}`");
+    expect(flow).toContain("task.status === 'completed'");
+    expect(flow).toContain("task.deliveryStatus === 'delivered'");
+    expect(flow).toContain("readSettledTerminalTask('restart')");
+    expect(flow).toContain("readSettledTerminalTask('empty')");
+    expect(flow).toContain("verdicts.length === 5");
+    expect(flow).not.toContain('"call":"sleep"');
+  });
+
   it("loads live gateway sentinel scenarios for harness self-health", () => {
     const scenarioIds = [
       "plugin-hook-health-sentinel",

--- a/qa/scenarios/agents/subagent-completion-direct-fallback.yaml
+++ b/qa/scenarios/agents/subagent-completion-direct-fallback.yaml
@@ -68,6 +68,15 @@ flow:
         - set: verdicts
           value:
             expr: "[]"
+        # The task ledger records terminal delivery after the subagent lifecycle
+        # owner settles it. Use that fact instead of guessing with wall-clock sleeps.
+        - set: readSettledTerminalTask
+          value:
+            lambda:
+              params:
+                - caseName
+              async: true
+              expr: "(await env.gateway.call('tasks.list', { status: 'completed', agentId: 'qa', limit: 100 }, { timeoutMs: 10000 })).tasks?.find((task) => task.title === `qa-terminal-${caseName}` && task.status === 'completed' && task.deliveryStatus === 'delivered')"
         - forEach:
             items:
               expr: config.cases
@@ -93,13 +102,12 @@ flow:
                   senderName: QA Terminal Reply Operator
                   text:
                     expr: "`Subagent terminal reply QA check: ${terminalCase.name}. Spawn one native worker, then finish the parent turn without waiting. Do not use ACP.`"
-              - call: sleep
-                args:
-                  - 20000
               - call: waitForCondition
+                saveAs: terminalTask
                 args:
                   - lambda:
-                      expr: "terminalCase.expectedSendCount === 0 || state.getSnapshot().messages.slice(startIndex).filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === conversationId && String(candidate.text ?? '').trim() === terminalCase.marker).length >= terminalCase.expectedSendCount"
+                      async: true
+                      expr: "(async () => { const task = await readSettledTerminalTask(terminalCase.name); if (!task) return undefined; const matchingCount = state.getSnapshot().messages.slice(startIndex).filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === conversationId && String(candidate.text ?? '').trim() === terminalCase.marker).length; return terminalCase.expectedSendCount === 0 || matchingCount >= terminalCase.expectedSendCount ? task : undefined; })().catch(() => undefined)"
                   - 60000
                   - 250
               - set: caseOutbound
@@ -139,14 +147,15 @@ flow:
                   expr: "!caseRequests.some((request) => request.plannedToolName === 'sessions_yield')"
                   message:
                     expr: "`terminal ${terminalCase.name}: parent did not end before direct fallback; requests=${JSON.stringify(caseRequests)}`"
+              - assert:
+                  expr: "terminalTask.title === `qa-terminal-${terminalCase.name}` && terminalTask.status === 'completed' && terminalTask.deliveryStatus === 'delivered'"
+                  message:
+                    expr: "`terminal ${terminalCase.name}: task lifecycle did not settle authoritatively; task=${JSON.stringify(terminalTask)}`"
               - set: appendVerdict
                 value:
-                  expr: "verdicts.push({ case: terminalCase.name, conversationId, inputDisposition: terminalCase.name, representation: terminalCase.name === 'silent' ? 'no terminal channel payload' : 'exact terminal text', restart: false, fallback: terminalCase.name === 'fallback', expectedTerminalSendCount: terminalCase.expectedSendCount, actualTerminalSendCount: matchingOutbound.length, capturedTerminalPayloads: matchingOutbound.map((message) => String(message.text ?? '')), auxiliaryChannelEvents: caseOutbound.filter((message) => !matchingOutbound.includes(message)).map((message) => String(message.text ?? '')), silenceTokenLeaked: caseOutbound.some((message) => String(message.text ?? '').trim() === 'NO_REPLY'), internalMetadataLeak: caseOutbound.some((message) => String(message.text ?? '').includes(config.metadataSentinel)), pass: true })"
-        # The direct platform send commits before transcript mirroring and
-        # requester cleanup. Restart only after those post-send owners settle.
-        - call: sleep
-          args:
-            - 15000
+                  expr: "verdicts.push({ case: terminalCase.name, conversationId, taskId: terminalTask.taskId, taskDeliveryStatus: terminalTask.deliveryStatus, inputDisposition: terminalCase.name, representation: terminalCase.name === 'silent' ? 'no terminal channel payload' : 'exact terminal text', restart: false, fallback: terminalCase.name === 'fallback', expectedTerminalSendCount: terminalCase.expectedSendCount, actualTerminalSendCount: matchingOutbound.length, capturedTerminalPayloads: matchingOutbound.map((message) => String(message.text ?? '')), auxiliaryChannelEvents: caseOutbound.filter((message) => !matchingOutbound.includes(message)).map((message) => String(message.text ?? '')), silenceTokenLeaked: caseOutbound.some((message) => String(message.text ?? '').trim() === 'NO_REPLY'), internalMetadataLeak: caseOutbound.some((message) => String(message.text ?? '').includes(config.metadataSentinel)), pass: true })"
+        # Every prior task is now terminal and delivery-settled, so restart from
+        # the lifecycle boundary rather than waiting an arbitrary grace period.
         - set: preRestartOutbound
           value:
             expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound' && verdicts.some((verdict) => verdict.conversationId === message.conversation.id)).map((message) => ({ id: message.id, conversationId: message.conversation.id, text: String(message.text ?? '') }))"
@@ -170,9 +179,12 @@ flow:
           args:
             - ref: env
             - 180000
-        - call: sleep
+        - call: waitForCondition
           args:
-            - 3000
+            - lambda:
+                expr: "state.getSnapshot().messages.find((message) => message.direction === 'outbound' && verdicts.some((verdict) => verdict.conversationId === message.conversation.id) && !preRestartOutbound.some((before) => before.id === message.id) && String(message.text ?? '').includes('interrupted by a gateway restart'))"
+            - 60000
+            - 250
         - set: postRestartOutbound
           value:
             expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound' && verdicts.some((verdict) => verdict.conversationId === message.conversation.id)).map((message) => ({ id: message.id, conversationId: message.conversation.id, text: String(message.text ?? '') }))"
@@ -206,13 +218,12 @@ flow:
               ref: restartConversationId
             senderName: QA Restart Operator
             text: "Subagent terminal reply QA check: restart. Spawn one native worker, then finish the parent turn without waiting. Do not use ACP."
-        - call: sleep
-          args:
-            - 20000
         - call: waitForCondition
+          saveAs: restartTask
           args:
             - lambda:
-                expr: "state.getSnapshot().messages.slice(restartStartIndex).filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === restartConversationId && String(candidate.text ?? '').trim() === config.restartMarker).length >= 1"
+                async: true
+                expr: "(async () => { const task = await readSettledTerminalTask('restart'); if (!task) return undefined; const delivered = state.getSnapshot().messages.slice(restartStartIndex).some((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === restartConversationId && String(candidate.text ?? '').trim() === config.restartMarker); return delivered ? task : undefined; })().catch(() => undefined)"
             - 60000
             - 250
         - set: restartMatches
@@ -226,9 +237,13 @@ flow:
             expr: "state.getSnapshot().messages.slice(restartStartIndex).filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === restartConversationId).every((candidate) => !String(candidate.text ?? '').includes(`Agent couldn't generate a response`))"
             message:
               expr: "`restart completion produced a failure diagnostic: outbound=${recentOutboundSummary(state)}`"
+        - assert:
+            expr: "restartTask.title === 'qa-terminal-restart' && restartTask.status === 'completed' && restartTask.deliveryStatus === 'delivered'"
+            message:
+              expr: "`restart completion task lifecycle did not settle authoritatively; task=${JSON.stringify(restartTask)}`"
         - set: appendRestartVerdict
           value:
-            expr: "verdicts.push({ case: 'restart', conversationId: restartConversationId, inputDisposition: 'visible', restart: true, fallback: true, preRestartTerminalMessageCount: preRestartTerminalPayloads.length, postRestartTerminalPayloadCount: postRestartTerminalPayloads.length, priorTerminalPayloadReplayCount: postRestartTerminalPayloads.length - preRestartTerminalPayloads.length, interruptedHandoffRepresentationCount: restartInterruptionPayloads.length, interruptedHandoffPayloads: restartInterruptionPayloads.map((message) => message.text), expectedTerminalSendCount: 1, actualTerminalSendCount: restartMatches.length, capturedTerminalPayloads: restartMatches.map((message) => String(message.text ?? '')), silenceTokenLeaked: false, internalMetadataLeak: false, pass: true })"
+            expr: "verdicts.push({ case: 'restart', conversationId: restartConversationId, taskId: restartTask.taskId, taskDeliveryStatus: restartTask.deliveryStatus, inputDisposition: 'visible', restart: true, fallback: true, preRestartTerminalMessageCount: preRestartTerminalPayloads.length, postRestartTerminalPayloadCount: postRestartTerminalPayloads.length, priorTerminalPayloadReplayCount: postRestartTerminalPayloads.length - preRestartTerminalPayloads.length, interruptedHandoffRepresentationCount: restartInterruptionPayloads.length, interruptedHandoffPayloads: restartInterruptionPayloads.map((message) => message.text), expectedTerminalSendCount: 1, actualTerminalSendCount: restartMatches.length, capturedTerminalPayloads: restartMatches.map((message) => String(message.text ?? '')), silenceTokenLeaked: false, internalMetadataLeak: false, pass: true })"
         - set: emptyStartIndex
           value:
             expr: state.getSnapshot().messages.length
@@ -250,13 +265,12 @@ flow:
             text: "Subagent terminal reply QA check: empty. Spawn one native worker, then finish the parent turn without waiting. Do not use ACP."
         # Empty output after one side effect is terminal and must surface one
         # explicit representation without leaking the protected raw result.
-        - call: sleep
-          args:
-            - 45000
         - call: waitForCondition
+          saveAs: emptyTask
           args:
             - lambda:
-                expr: "state.getSnapshot().messages.slice(emptyStartIndex).some((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === emptyConversationId)"
+                async: true
+                expr: "(async () => { const task = await readSettledTerminalTask('empty'); if (!task) return undefined; const represented = state.getSnapshot().messages.slice(emptyStartIndex).some((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === emptyConversationId && String(candidate.text ?? '').trim() === 'QA-SUBAGENT-TERMINAL-EMPTY-REPRESENTED'); return represented ? task : undefined; })().catch(() => undefined)"
             - 60000
             - 250
         - set: emptyOutbound
@@ -280,9 +294,13 @@ flow:
             expr: "emptyRequests.some((request) => request.plannedToolName === 'sessions_spawn' && request.plannedToolArgs?.label === 'qa-terminal-empty') && emptyRequests.some((request) => request.plannedToolName === 'write' && request.plannedToolArgs?.path === 'qa-terminal-empty-side-effect.txt') && emptyRequests.some((request) => request.plannedToolName === 'message' && request.plannedToolArgs?.action === 'send' && request.plannedToolArgs?.message === 'QA-SUBAGENT-TERMINAL-EMPTY-REPRESENTED') && !emptyRequests.some((request) => request.plannedToolName === 'sessions_yield')"
             message:
               expr: "`empty completion did not exercise native spawn/direct-fallback: ${JSON.stringify(emptyRequests)}`"
+        - assert:
+            expr: "emptyTask.title === 'qa-terminal-empty' && emptyTask.status === 'completed' && emptyTask.deliveryStatus === 'delivered'"
+            message:
+              expr: "`empty completion task lifecycle did not settle authoritatively; task=${JSON.stringify(emptyTask)}`"
         - set: appendEmptyVerdict
           value:
-            expr: "verdicts.push({ case: 'empty', conversationId: emptyConversationId, inputDisposition: 'empty-after-side-effect', representation: 'visible ambiguity warning for producer-empty result', restart: false, fallback: false, expectedTerminalSendCount: 1, actualTerminalSendCount: emptyRepresentation.length, capturedTerminalPayloads: emptyRepresentation.map((message) => String(message.text ?? '')), auxiliaryChannelEvents: emptyOutbound.filter((message) => !emptyRepresentation.includes(message)).map((message) => String(message.text ?? '')), silenceTokenLeaked: false, internalMetadataLeak: false, pass: true })"
+            expr: "verdicts.push({ case: 'empty', conversationId: emptyConversationId, taskId: emptyTask.taskId, taskDeliveryStatus: emptyTask.deliveryStatus, inputDisposition: 'empty-after-side-effect', representation: 'visible ambiguity warning for producer-empty result', restart: false, fallback: false, expectedTerminalSendCount: 1, actualTerminalSendCount: emptyRepresentation.length, capturedTerminalPayloads: emptyRepresentation.map((message) => String(message.text ?? '')), auxiliaryChannelEvents: emptyOutbound.filter((message) => !emptyRepresentation.includes(message)).map((message) => String(message.text ?? '')), silenceTokenLeaked: false, internalMetadataLeak: false, pass: true })"
         - assert:
             expr: "verdicts.length === 5 && verdicts.every((verdict) => verdict.pass === true)"
             message:


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the QA smoke profile spent most of its wall time waiting on fixed delays instead of observing subagent lifecycle completion. The terminal-reply scenario alone contained 143 seconds of unconditional sleeps inside a roughly 161-second worker run.

## Why This Change Was Made

The scenario now waits for the canonical Gateway task ledger to record each subagent as completed and delivered, while retaining the existing visible, silent, fallback, restart, and empty-result channel assertions. The mock provider also gates child completion on the actual parent post-spawn response instead of guessing that the parent has settled after five seconds.

This does not change test sharding, scenario composition, or concurrency.

## User Impact

No product behavior changes. Developers and CI get substantially faster QA smoke feedback without losing the real Gateway, SQLite task lifecycle, channel delivery, restart, or empty-result coverage.

## Evidence

- Exact six-scenario profile, same host and original order: 307.60s -> 183.69s wall, saving 123.91s (40.28% faster); all 6 scenarios passed before and after.
- Suite artifact duration: 303.536s -> 179.851s.
- Terminal-reply worker: 161.207s -> 47.884s; all five visible/silent/fallback/restart/empty verdicts passed with exact delivery counts.
- Focused QA tests: 281 passed across the mock server and scenario catalog suites.
- Private QA runtime build: passed in 9.58s.
- Structured autoreview: clean, no actionable findings (0.98 confidence).
