### PR TITLE
docs: show canonical SQLite paths in sessions JSON example

### DIFF
--- a/docs/cli/sessions.md
+++ b/docs/cli/sessions.md
@@ -62,8 +62,8 @@ skipped.
 {
   "path": null,
   "stores": [
-    { "agentId": "main", "path": "/home/user/.openclaw/agents/main/sessions/sessions.json" },
-    { "agentId": "work", "path": "/home/user/.openclaw/agents/work/sessions/sessions.json" }
+    { "agentId": "main", "path": "/home/user/.openclaw/agents/main/agent/openclaw-agent.sqlite" },
+    { "agentId": "work", "path": "/home/user/.openclaw/agents/work/agent/openclaw-agent.sqlite" }
   ],
   "allAgents": true,
   "count": 2,


### PR DESCRIPTION
## Summary

- update the `openclaw sessions --all-agents --json` example to show the canonical per-agent SQLite database paths
- align the docs with the current CLI path resolver and existing sessions command tests

## Testing

- `pnpm check:docs`
- `git diff --check`
- `pnpm exec oxfmt --check docs/cli/sessions.md`