### PR TITLE
fix(gateway): reject disconnected Apple Watch polling sockets

### DIFF
--- a/src/gateway/watch-node-http.test.ts
+++ b/src/gateway/watch-node-http.test.ts
@@ -1,4 +1,10 @@
-import { createServer, request as httpRequest, type ClientRequest, type Server } from "node:http";
+import {
+  createServer,
+  request as httpRequest,
+  type ClientRequest,
+  type Server,
+  type ServerResponse,
+} from "node:http";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -108,6 +114,7 @@ async function startRuntime(
     abortConnectResponse?: boolean;
     config?: OpenClawConfig;
     now?: () => number;
+    onPollReady?: (response: ServerResponse) => void;
   },
 ) {
   const nodeRegistry = new NodeRegistry({
@@ -152,6 +159,9 @@ async function startRuntime(
         if (!handled && !res.writableEnded) {
           res.statusCode = 404;
           res.end();
+        }
+        if (req.url === "/api/nodes/watch/poll" && !res.writableEnded) {
+          options?.onPollReady?.(res);
         }
       })
       .finally(() => {
@@ -426,6 +436,82 @@ describe("watch node HTTP transport", () => {
     runtime.close();
     expect(disconnectedNodes).toHaveLength(1);
   });
+
+  it.each([
+    { destroyTarget: "socket", delivery: "event" },
+    { destroyTarget: "socket", delivery: "raw" },
+    { destroyTarget: "response", delivery: "event" },
+  ] as const)(
+    "rejects $delivery delivery when the active watch poll $destroyTarget is destroyed",
+    async ({ destroyTarget, delivery }) => {
+      let resolvePollReady: (response: ServerResponse) => void = () => undefined;
+      const pollReady = new Promise<ServerResponse>((resolve) => {
+        resolvePollReady = resolve;
+      });
+      const { identity, issued, nodeRegistry, disconnectedNodes, runtime, baseUrl } =
+        await createWatchNodeFixture("openclaw-watch-node-destroyed-poll-", {
+          onPollReady: resolvePollReady,
+        });
+      const connectResponse = await connectWatchNode({
+        baseUrl,
+        identity,
+        bootstrapToken: issued.token,
+      });
+      expect(connectResponse.status).toBe(200);
+      const { sessionToken } = await readJson(connectResponse);
+      const authorization = `Bearer ${String(sessionToken)}`;
+      const pollFailure = new Promise<string>((resolve, reject) => {
+        const request = httpRequest(
+          `${baseUrl}/poll`,
+          { method: "POST", headers: { authorization } },
+          (response) => {
+            response.resume();
+            reject(new Error(`unexpected poll response: ${response.statusCode}`));
+          },
+        );
+        request.once("error", (error: NodeJS.ErrnoException) => {
+          resolve(error.code ?? error.message);
+        });
+        request.end();
+      });
+      try {
+        const response = await pollReady;
+        const socket = response.socket;
+        expect(socket).not.toBeNull();
+        if (destroyTarget === "socket") {
+          socket!.destroy();
+          expect(response.destroyed).toBe(false);
+        } else {
+          response.destroy();
+          expect(response.destroyed).toBe(true);
+        }
+        expect(socket!.destroyed).toBe(true);
+        expect(response.writableEnded).toBe(false);
+
+        const payload = { id: "lost" };
+        const delivered =
+          delivery === "raw"
+            ? nodeRegistry.sendEventRaw(
+                identity.deviceId,
+                "node.invoke.request",
+                serializeEventPayload(payload),
+              )
+            : nodeRegistry.sendEvent(identity.deviceId, "node.invoke.request", payload);
+        expect(delivered).toBe(false);
+        expect(nodeRegistry.get(identity.deviceId)).toBeUndefined();
+        expect(disconnectedNodes).toEqual([
+          { nodeId: identity.deviceId, reason: "event delivery failed" },
+        ]);
+        await expect(pollFailure).resolves.toBe("ECONNRESET");
+        expect(nodeRegistry.sendEvent(identity.deviceId, "node.invoke.request", payload)).toBe(
+          false,
+        );
+      } finally {
+        runtime.close();
+      }
+      expect(disconnectedNodes).toHaveLength(1);
+    },
+  );
 
   it("rejects an HTTP node session after an external reapproval changes its generation", async () => {
     const { baseDir, identity, issued, nodeRegistry, disconnectedNodes, runtime, baseUrl } =

--- a/src/gateway/watch-node-http.ts
+++ b/src/gateway/watch-node-http.ts
@@ -348,7 +348,8 @@ export function createWatchNodeHttpRuntime(options: WatchNodeHttpRuntimeOptions)
   };
 
   const sendQueuedEvent = (res: ServerResponse, queued: QueuedNodeEvent): boolean => {
-    if (res.writableEnded) {
+    // The socket can be destroyed before its response receives the close event.
+    if (res.destroyed || res.socket?.destroyed || res.writableEnded) {
       return false;
     }
     try {


### PR DESCRIPTION
## What Problem This Solves

Fixes a silent Gateway delivery failure when an authenticated Apple Watch long-poll TCP socket disconnects immediately before a node event is sent. The watch never receives the command, but the previous HTTP transport reports successful delivery, leaves the unreachable watch registered, and can strand an invocation until its timeout.

The socket-only failure is distinct from destroying the HTTP response itself: Node marks the underlying socket destroyed before its response receives the close event, so `socket.destroyed === true` while `response.destroyed === false` and `response.writableEnded === false`.

## Why This Change Was Made

The actual installed Node HTTP implementation returns `false` from `OutgoingMessage._writeRaw()` for an already-destroyed socket; `OutgoingMessage.end()` does not propagate that admission failure. The existing private watch-event owner now rejects an ended response, a destroyed response, or a destroyed underlying socket before acknowledging delivery.

Both normal and pre-serialized events already use that same owner. Its existing failure path removes the watch session, unregisters the node, and emits exactly one disconnect notification. Healthy normal and raw deliveries, signed watch pairing, authentication, queue behavior, and lifecycle ownership retain their existing paths.

Only the existing Gateway implementation and its colocated test change. Production growth is one net line, including the comment explaining the Node close-ordering contract. There is no new configuration, dependency, persistence, security policy, public API, protocol, compatibility path, or packaging surface.

## User Impact

An operator or agent receives a truthful immediate delivery failure when the Apple Watch polling socket is already disconnected. The phantom watch is removed exactly once, while healthy watch commands and existing authenticated reconnect behavior continue to work.

Release scope is precise: the direct watch HTTP transport exists on current `main` and in the locally available `v2026.7.2-beta.7` release tag; it does not exist in the locally available stable `v2026.7.1` tag. This change does not claim to repair an already-shipped stable watch transport.

## Evidence

- Exact reviewed commit: `2a32dca99ceaa5d7b450515da2b8390d4af0c931`; sole parent: `e812630f80a35da6bdd7a3612152827d29cd2b1e`; authenticated complete binary patch SHA-256: `1468c852b9d97c4672ae34dacf3d54020aef870c092fa2f9bb9ce07126b9a2a4`.
- Four distinct nonauthor hostile whole-owner reviews and a genuine official `gpt-5.6-sol` high-reasoning P0-P3 review found no actionable findings; the official review reported 0.97 confidence.
- The unchanged parent independently fails both real socket-only normal-event and raw-event delivery scenarios with a false success, a still-registered node, no disconnect notification, and an actual client `ECONNRESET`.
- The committed candidate passes five real localhost HTTP/TCP scenarios across exactly 15 localhost requests: destroyed-socket normal delivery, destroyed-socket raw delivery, destroyed-response normal delivery, healthy normal delivery, and healthy raw delivery. The scenarios use the actual signed watch challenge, bootstrap, device pairing, HTTP poll, Node `ServerResponse`, TCP socket, and `NodeRegistry`; no external requests or remote credentials are used.
- All **149 tests passed** across the complete watch transport, node registry, and shared Gateway HTTP sibling suites. Targeted formatting, targeted core lint, and `git diff --check` also passed.
- An authenticated, candidate-owned Blacksmith Testbox reproduced both unchanged-parent socket failures, verified the real installed Node HTTP/physical-socket contract, passed all five signed Watch localhost/TCP scenarios, and passed 51 Watch/HTTP sibling tests plus 27 selected NodeRegistry transport tests. Workflow: https://github.com/openclaw/openclaw/actions/runs/30800688785; lease `tbx_01kz3ehzz3pd7vz8f9kxr79tab`; authoritative `exitCode: 0`; lease stopped after completion.
- The **complete unmodified exact-two-file changed gate passed remotely**, including zero unused exports across production, full-tree, and script scans; production and test typechecking; changed-file lint and formatting; plugin/SDK, SQLite/state, pairing, webhook, and runtime-cycle guards. No dead-code skip, baseline override, or maintainer exception was used.

## Maintainer review resolution

- **Resolve merge risk:** Exact reviewed head `2a32dca99ceaa5d7b450515da2b8390d4af0c931` passed real signed Watch HTTP/TCP parent-red/candidate-green proof, healthy normal/raw controls, single-disconnect ownership, and the complete unmodified exact-two-file changed gate on the authenticated Blacksmith Testbox.
- **Complete next step:** Four independent nonauthor hostile reviews and a genuine official Sol P0-P3 review found no actionable findings; the exact-head remote behavior proof and complete changed-code gate both passed with `exitCode: 0`.

### Real behavior proof

```json
{
  "status": "PASS",
  "head": "2a32dca99ceaa5d7b450515da2b8390d4af0c931",
  "parent": "e812630f80a35da6bdd7a3612152827d29cd2b1e",
  "binaryPatchSha256": "1468c852b9d97c4672ae34dacf3d54020aef870c092fa2f9bb9ce07126b9a2a4",
  "surface": "gateway-watch-node-http",
  "parentSocketEventFalseAcknowledgement": true,
  "parentSocketRawFalseAcknowledgement": true,
  "candidateScenarios": [
    "socket-event",
    "socket-raw",
    "response-event",
    "healthy-event",
    "healthy-raw"
  ],
  "candidateLocalhostHttpRequests": 15,
  "physicalSocketDestroyedBeforeResponseClose": true,
  "failedDeliveryUnregistersExactlyOnce": true,
  "healthyNormalAndRawDeliveryPreserved": true,
  "ownerAndSiblingTestsPassed": 149,
  "externalNetworkRequests": 0,
  "remoteCredentialsUsed": false,
  "productionLinesAddedNet": 1,
  "runner": "authenticated-blacksmith-testbox",
  "blacksmithTestboxLease": "tbx_01kz3ehzz3pd7vz8f9kxr79tab",
  "blacksmithTestboxWorkflow": "https://github.com/openclaw/openclaw/actions/runs/30800688785",
  "blacksmithTestboxExitCode": 0,
  "remoteOwnerAndSiblingTestsPassed": 78,
  "deadExportScan": "PASS: zero production/full-tree/script unused exports",
  "changedGate": "PASS: complete unmodified exact-two-file repository gate",
  "availableStableContainsWatchTransport": false,
  "availableBetaContainsWatchTransport": true
}
```
