### PR TITLE
fix(gateway): use verified proxy identity for response history

### DIFF
--- a/src/gateway/http-auth-utils.ts
+++ b/src/gateway/http-auth-utils.ts
@@ -52,6 +52,7 @@ export function getBearerToken(req: IncomingMessage): string | undefined {
 type SharedSecretGatewayAuth = Pick<ResolvedGatewayAuth, "mode">;
 export type AuthorizedGatewayHttpRequest = {
   authMethod?: GatewayAuthResult["method"];
+  user?: string;
   trustDeclaredOperatorScopes: boolean;
   controlUiPluginGrants?: ControlUiPluginTabAuthGrant[];
   controlUiPluginGrant?: ControlUiPluginTabAuthGrant;
@@ -258,6 +259,7 @@ async function checkGatewayHttpRequestAuthWith(
     ok: true,
     requestAuth: {
       authMethod: authResult.method,
+      ...(authResult.user ? { user: authResult.user } : {}),
       // Shared-secret bearer auth proves possession of the gateway secret, but it
       // does not prove a narrower per-request operator identity. HTTP endpoints
       // must opt in explicitly if they want to treat that shared-secret path as a

--- a/src/gateway/http-utils.authorize-request.test.ts
+++ b/src/gateway/http-utils.authorize-request.test.ts
@@ -88,6 +88,7 @@ describe("authorizeGatewayHttpRequestOrReply", () => {
       }),
     ).resolves.toEqual({
       authMethod: "trusted-proxy",
+      user: "operator",
       trustDeclaredOperatorScopes: true,
     });
   });

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -1866,6 +1866,56 @@ describe("OpenResponses HTTP API (e2e)", () => {
           }
 
           agentCommand.mockClear();
+          agentCommand.mockResolvedValue({ payloads: [{ text: "hello" }] } as never);
+          const forwardedHeaders = {
+            "x-forwarded-proto": "https",
+            authorization: "Bearer forwarded-untrusted",
+          };
+          const aliceResponse = await postResponses(
+            port,
+            { model: "openclaw", user: "alice", input: "private alice history" },
+            { ...forwardedHeaders, "x-forwarded-user": "Alice@example.com" },
+          );
+          expect(aliceResponse.status).toBe(200);
+          const aliceResponseId = ((await aliceResponse.json()) as { id: string }).id;
+          const aliceSessionKey = requireSessionKey(
+            firstAgentOpts().sessionKey as string | undefined,
+            "Alice trusted-proxy response",
+          );
+
+          const aliceContinuation = await postResponses(
+            port,
+            {
+              model: "openclaw",
+              user: "alice",
+              previous_response_id: aliceResponseId,
+              input: "continue alice history",
+            },
+            {
+              ...forwardedHeaders,
+              authorization: "Bearer different-forwarded-untrusted",
+              "x-forwarded-user": "Alice@example.com",
+            },
+          );
+          expect(aliceContinuation.status).toBe(200);
+          await ensureResponseConsumed(aliceContinuation);
+
+          const bobContinuation = await postResponses(
+            port,
+            {
+              model: "openclaw",
+              user: "bob",
+              previous_response_id: aliceResponseId,
+              input: "attempt alice history",
+            },
+            { ...forwardedHeaders, "x-forwarded-user": "bob@example.com" },
+          );
+          expect(bobContinuation.status).toBe(200);
+          await ensureResponseConsumed(bobContinuation);
+          expect(firstAgentOpts(2).sessionKey).not.toBe(aliceSessionKey);
+          expect(firstAgentOpts(1).sessionKey).toBe(aliceSessionKey);
+
+          agentCommand.mockClear();
           const unauthorized = await postResponses(
             port,
             { model: "openclaw", input: "hi" },

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -52,6 +52,7 @@ import {
 } from "./http-common.js";
 import { handleGatewayPostJsonEndpoint } from "./http-endpoint-helpers.js";
 import {
+  type AuthorizedGatewayHttpRequest,
   authorizeOpenAiCompatibleHttpModelOverride,
   getBearerToken,
   getHeader,
@@ -126,16 +127,15 @@ function normalizeResponseSessionScope(scope: ResponseSessionScope): ResponseSes
 function resolveResponseSessionAuthSubject(params: {
   req: IncomingMessage;
   auth: ResolvedGatewayAuth;
+  requestAuth: AuthorizedGatewayHttpRequest;
 }): string {
+  // Proxy-verified identity owns continuation; forwarded bearers are unverified.
+  if (params.requestAuth.authMethod === "trusted-proxy") {
+    return `trusted-proxy:${params.requestAuth.user}`;
+  }
   const bearer = getBearerToken(params.req);
   if (bearer) {
     return `bearer:${createHash("sha256").update(bearer).digest("hex")}`;
-  }
-  if (params.auth.mode === "trusted-proxy" && params.auth.trustedProxy?.userHeader) {
-    const user = getHeader(params.req, params.auth.trustedProxy.userHeader)?.trim();
-    if (user) {
-      return `trusted-proxy:${user}`;
-    }
   }
   return `gateway-auth:${params.auth.mode}`;
 }
@@ -143,10 +143,11 @@ function resolveResponseSessionAuthSubject(params: {
 function createResponseSessionScope(params: {
   req: IncomingMessage;
   auth: ResolvedGatewayAuth;
+  requestAuth: AuthorizedGatewayHttpRequest;
   agentId: string;
 }): ResponseSessionScope {
   return normalizeResponseSessionScope({
-    authSubject: resolveResponseSessionAuthSubject({ req: params.req, auth: params.auth }),
+    authSubject: resolveResponseSessionAuthSubject(params),
     agentId: params.agentId,
     requestedSessionKey: getHeader(params.req, "x-openclaw-session-key"),
   });
@@ -647,6 +648,7 @@ export async function handleOpenResponsesHttpRequest(
   const responseSessionScope = createResponseSessionScope({
     req,
     auth: opts.auth,
+    requestAuth: handled.requestAuth,
     agentId: resolved.agentId,
   });
   // Resolve session key: reuse previous_response_id only when it matches the


### PR DESCRIPTION
## Summary\n- Preserve the verified authenticated user at the existing Gateway HTTP authentication boundary.\n- Bind previous_response_id continuation to verified trusted-proxy identity instead of an unrelated forwarded bearer.\n- Preserve token and password authentication, local fallback, operator access, and explicit session selectors.\n\n## Verification\n- Existing real Gateway integration first reproduced two proxy identities colliding through the same incidental bearer.\n- Responses integration, auth-owner, and authentication fallback suites: 79 passed.\n- The same verified user retains continuation even when its unrelated forwarded bearer changes.\n- Independent structured security autoreview: clean, confidence 0.97.