### PR TITLE
fix(ui): surface fenced-code clipboard failures

### DIFF
--- a/ui/src/components/markdown-code-blocks.test.ts
+++ b/ui/src/components/markdown-code-blocks.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { handleMarkdownCodeBlockCopy } from "./markdown-code-blocks.ts";
+import { toSanitizedMarkdownHtml } from "./markdown.ts";
+
+const originalExecCommand = Object.getOwnPropertyDescriptor(document, "execCommand");
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  if (originalExecCommand) {
+    Object.defineProperty(document, "execCommand", originalExecCommand);
+  } else {
+    Reflect.deleteProperty(document, "execCommand");
+  }
+  document.body.innerHTML = "";
+});
+
+function renderCodeCopyButton(): HTMLButtonElement {
+  document.body.innerHTML = toSanitizedMarkdownHtml("```ts\nconst answer = 42;\n```");
+  const button = document.querySelector<HTMLButtonElement>(".code-block-copy");
+  if (!button) {
+    throw new Error("Expected Markdown code-copy button");
+  }
+  button.addEventListener("click", handleMarkdownCodeBlockCopy);
+  return button;
+}
+
+describe("Markdown code-block clipboard feedback", () => {
+  it("visibly reports both denied clipboard paths and restores the idle labels", async () => {
+    vi.useFakeTimers();
+    const writeText = vi.fn(async () => {
+      throw new DOMException("Clipboard access denied", "NotAllowedError");
+    });
+    const execCommand = vi.fn(() => false);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+    const button = renderCodeCopyButton();
+
+    button.click();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(writeText).toHaveBeenCalledWith("const answer = 42;");
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    expect(button.querySelector(".code-block-copy__idle")?.textContent).toBe("Copy failed");
+    expect(button.getAttribute("aria-label")).toBe("Copy failed");
+    expect(button.classList.contains("copied")).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(button.querySelector(".code-block-copy__idle")?.textContent).toBe("Copy");
+    expect(button.getAttribute("aria-label")).toBe("Copy code");
+  });
+
+  it("preserves successful copy feedback and restores its accessible label", async () => {
+    vi.useFakeTimers();
+    const writeText = vi.fn(async () => undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    const button = renderCodeCopyButton();
+
+    button.click();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(writeText).toHaveBeenCalledWith("const answer = 42;");
+    expect(button.classList.contains("copied")).toBe(true);
+    expect(button.getAttribute("aria-label")).toBe("Copied!");
+
+    await vi.advanceTimersByTimeAsync(1_500);
+
+    expect(button.classList.contains("copied")).toBe(false);
+    expect(button.getAttribute("aria-label")).toBe("Copy code");
+  });
+
+  it.each([
+    { name: "a previous denied copy", firstSucceeds: false, firstResetAtMs: 2_000 },
+    { name: "a previous successful copy", firstSucceeds: true, firstResetAtMs: 1_500 },
+  ])("keeps the latest denied-copy feedback after $name", async (scenario) => {
+    vi.useFakeTimers();
+    const writeText = vi
+      .fn()
+      .mockRejectedValue(new DOMException("Clipboard access denied", "NotAllowedError"));
+    if (scenario.firstSucceeds) {
+      writeText.mockResolvedValueOnce(undefined);
+    }
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: () => false,
+    });
+    const button = renderCodeCopyButton();
+
+    button.click();
+    await vi.advanceTimersByTimeAsync(1_000);
+    button.click();
+    await vi.advanceTimersByTimeAsync(scenario.firstResetAtMs - 1_000);
+
+    expect(button.querySelector(".code-block-copy__idle")?.textContent).toBe("Copy failed");
+    expect(button.getAttribute("aria-label")).toBe("Copy failed");
+
+    await vi.advanceTimersByTimeAsync(3_000 - scenario.firstResetAtMs);
+
+    expect(button.querySelector(".code-block-copy__idle")?.textContent).toBe("Copy");
+    expect(button.getAttribute("aria-label")).toBe("Copy code");
+  });
+
+  it("keeps independent reset deadlines for different code-copy buttons", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("navigator", {
+      clipboard: {
+        writeText: vi.fn().mockRejectedValue(new DOMException("Clipboard access denied")),
+      },
+    });
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: () => false,
+    });
+    const first = renderCodeCopyButton();
+    const second = first.cloneNode(true) as HTMLButtonElement;
+    second.addEventListener("click", handleMarkdownCodeBlockCopy);
+    document.body.append(second);
+
+    first.click();
+    await vi.advanceTimersByTimeAsync(500);
+    second.click();
+    await vi.advanceTimersByTimeAsync(1_500);
+
+    expect(first.getAttribute("aria-label")).toBe("Copy code");
+    expect(second.getAttribute("aria-label")).toBe("Copy failed");
+
+    second.remove();
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(second.getAttribute("aria-label")).toBe("Copy code");
+  });
+});

--- a/ui/src/components/markdown-code-blocks.test.ts
+++ b/ui/src/components/markdown-code-blocks.test.ts
@@ -73,6 +73,41 @@ describe("Markdown code-block clipboard feedback", () => {
     expect(button.getAttribute("aria-label")).toBe("Copy code");
   });
 
+  it("ignores an older clipboard attempt that finishes after the latest denied copy", async () => {
+    vi.useFakeTimers();
+    let resolveFirstWrite!: () => void;
+    const firstWrite = new Promise<void>((resolve) => {
+      resolveFirstWrite = resolve;
+    });
+    const writeText = vi
+      .fn()
+      .mockReturnValueOnce(firstWrite)
+      .mockRejectedValueOnce(new DOMException("Clipboard access denied", "NotAllowedError"));
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: () => false,
+    });
+    const button = renderCodeCopyButton();
+
+    button.click();
+    button.click();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(button.getAttribute("aria-label")).toBe("Copy failed");
+
+    resolveFirstWrite();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(button.querySelector(".code-block-copy__idle")?.textContent).toBe("Copy failed");
+    expect(button.getAttribute("aria-label")).toBe("Copy failed");
+    expect(button.classList.contains("copied")).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(button.getAttribute("aria-label")).toBe("Copy code");
+  });
+
   it.each([
     { name: "a previous denied copy", firstSucceeds: false, firstResetAtMs: 2_000 },
     { name: "a previous successful copy", firstSucceeds: true, firstResetAtMs: 1_500 },

--- a/ui/src/components/markdown-code-blocks.ts
+++ b/ui/src/components/markdown-code-blocks.ts
@@ -20,6 +20,7 @@ import { escapeMarkdownHtml, isMarkdownBlockArtText } from "./markdown-text.ts";
 
 const blockArtCopyPayloadPrefix = "openclaw:block-art-code:";
 const blockArtCodeBlockCopyPayloadEncoding = "block-art-json";
+const codeBlockCopyAttempts = new WeakMap<HTMLElement, number>();
 const codeBlockCopyResetTimers = new WeakMap<HTMLElement, ReturnType<typeof setTimeout>>();
 
 for (const [language, definition] of Object.entries({
@@ -75,7 +76,13 @@ export function handleMarkdownCodeBlockCopy(event: Event): void {
     return;
   }
   const code = decodeCodeBlockCopyPayload(button.dataset.code ?? "", button.dataset.codeEncoding);
+  const attempt = (codeBlockCopyAttempts.get(button) ?? 0) + 1;
+  codeBlockCopyAttempts.set(button, attempt);
   void copyToClipboard(code).then((copied) => {
+    // Clipboard writes can finish out of click order; older attempts must not own feedback.
+    if (codeBlockCopyAttempts.get(button) !== attempt) {
+      return;
+    }
     const idleLabel = button.querySelector(".code-block-copy__idle");
     idleLabel?.replaceChildren(t(copied ? "common.copy" : "common.copyFailed"));
     button.classList.toggle("copied", copied);

--- a/ui/src/components/markdown-code-blocks.ts
+++ b/ui/src/components/markdown-code-blocks.ts
@@ -20,6 +20,7 @@ import { escapeMarkdownHtml, isMarkdownBlockArtText } from "./markdown-text.ts";
 
 const blockArtCopyPayloadPrefix = "openclaw:block-art-code:";
 const blockArtCodeBlockCopyPayloadEncoding = "block-art-json";
+const codeBlockCopyResetTimers = new WeakMap<HTMLElement, ReturnType<typeof setTimeout>>();
 
 for (const [language, definition] of Object.entries({
   bash,
@@ -75,11 +76,21 @@ export function handleMarkdownCodeBlockCopy(event: Event): void {
   }
   const code = decodeCodeBlockCopyPayload(button.dataset.code ?? "", button.dataset.codeEncoding);
   void copyToClipboard(code).then((copied) => {
-    if (!copied) {
-      return;
-    }
-    button.classList.add("copied");
-    setTimeout(() => button.classList.remove("copied"), 1500);
+    const idleLabel = button.querySelector(".code-block-copy__idle");
+    idleLabel?.replaceChildren(t(copied ? "common.copy" : "common.copyFailed"));
+    button.classList.toggle("copied", copied);
+    button.setAttribute("aria-label", t(copied ? "common.copied" : "common.copyFailed"));
+    clearTimeout(codeBlockCopyResetTimers.get(button));
+    const resetTimer = setTimeout(
+      () => {
+        button.classList.remove("copied");
+        idleLabel?.replaceChildren(t("common.copy"));
+        button.setAttribute("aria-label", t("common.copyCode"));
+        codeBlockCopyResetTimers.delete(button);
+      },
+      copied ? 1500 : 2000,
+    );
+    codeBlockCopyResetTimers.set(button, resetTimer);
   });
 }
 

--- a/ui/src/e2e/chat-flow.clipboard.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.clipboard.e2e.test.ts
@@ -1,9 +1,50 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
+import type { Page } from "playwright";
 import { expect, it } from "vitest";
 import { createChatFlowE2eSuite, installMockGateway } from "./chat-flow.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
+
+type ClipboardFailureProof = {
+  asyncAttempts: number;
+  legacyAttempts: number;
+  value: string;
+};
+
+async function installDeniedClipboard(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const proof = { asyncAttempts: 0, legacyAttempts: 0, value: "" };
+    Object.defineProperty(globalThis, "clipboardFailureProof", {
+      configurable: true,
+      value: proof,
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: async (text: string) => {
+          proof.asyncAttempts += 1;
+          proof.value = text;
+          throw new DOMException("Clipboard access denied", "NotAllowedError");
+        },
+      },
+    });
+    document.execCommand = ((command: string) => {
+      if (command === "copy") {
+        proof.legacyAttempts += 1;
+      }
+      return false;
+    }) as typeof document.execCommand;
+  });
+}
+
+async function readClipboardFailureProof(page: Page): Promise<ClipboardFailureProof> {
+  return page.evaluate(
+    () =>
+      (globalThis as typeof globalThis & { clipboardFailureProof: ClipboardFailureProof })
+        .clipboardFailureProof,
+  );
+}
 
 suite.define(() => {
   it.each([
@@ -18,29 +59,7 @@ suite.define(() => {
         viewport: { height: 900, width: 1280 },
       });
       const page = await context.newPage();
-      await page.addInitScript(() => {
-        const proof = { asyncAttempts: 0, legacyAttempts: 0, value: "" };
-        Object.defineProperty(globalThis, "clipboardFailureProof", {
-          configurable: true,
-          value: proof,
-        });
-        Object.defineProperty(navigator, "clipboard", {
-          configurable: true,
-          value: {
-            writeText: async (text: string) => {
-              proof.asyncAttempts += 1;
-              proof.value = text;
-              throw new DOMException("Clipboard access denied", "NotAllowedError");
-            },
-          },
-        });
-        document.execCommand = ((command: string) => {
-          if (command === "copy") {
-            proof.legacyAttempts += 1;
-          }
-          return false;
-        }) as typeof document.execCommand;
-      });
+      await installDeniedClipboard(page);
       const gateway = await installMockGateway(page, {
         workspace: "/workspace",
         workspaceGit: true,
@@ -57,20 +76,11 @@ suite.define(() => {
 
         const alert = page.getByRole("alert").filter({ hasText: "Copy failed" });
         await alert.waitFor({ state: "visible", timeout: 10_000 });
-        expect(
-          await page.evaluate(
-            () =>
-              (
-                globalThis as typeof globalThis & {
-                  clipboardFailureProof: {
-                    asyncAttempts: number;
-                    legacyAttempts: number;
-                    value: string;
-                  };
-                }
-              ).clipboardFailureProof,
-          ),
-        ).toEqual({ asyncAttempts: 1, legacyAttempts: 1, value });
+        expect(await readClipboardFailureProof(page)).toEqual({
+          asyncAttempts: 1,
+          legacyAttempts: 1,
+          value,
+        });
         expect(await gateway.getRequests("chat.send")).toHaveLength(0);
 
         const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
@@ -86,4 +96,55 @@ suite.define(() => {
       }
     },
   );
+
+  it("shows and resets a visible accessible failure when assistant code cannot be copied", async () => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    await installDeniedClipboard(page);
+    const code = "const answer = 42;";
+    const gateway = await installMockGateway(page, {
+      historyMessages: [
+        {
+          content: [{ text: `\`\`\`ts\n${code}\n\`\`\``, type: "text" }],
+          role: "assistant",
+          timestamp: Date.now(),
+        },
+      ],
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const button = page.locator(".code-block-copy");
+      await button.click();
+
+      await expect.poll(() => button.getAttribute("aria-label")).toBe("Copy failed");
+      await expect
+        .poll(() => button.locator(".code-block-copy__idle").textContent())
+        .toBe("Copy failed");
+      expect(await readClipboardFailureProof(page)).toEqual({
+        asyncAttempts: 1,
+        legacyAttempts: 1,
+        value: code,
+      });
+      expect(await gateway.getRequests("chat.send")).toHaveLength(0);
+
+      const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      if (artifactDir) {
+        await mkdir(artifactDir, { recursive: true });
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(artifactDir, "clipboard-assistant-code-failure.png"),
+        });
+      }
+
+      await expect.poll(() => button.getAttribute("aria-label")).toBe("Copy code");
+      await expect.poll(() => button.locator(".code-block-copy__idle").textContent()).toBe("Copy");
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Surface clipboard failures for Control UI path, branch, and assistant-code copy actions with visible localized feedback and accessible live announcements.
- Keep copy feedback timers owned by their individual buttons.
- Ignore stale completions when overlapping asynchronous clipboard attempts finish out of order.

## Exact-head real Chromium end-to-end proof
Reviewed head: e382aea831c40f876b106b5c2b8bd96a29cb5320.

Hosted CI executed real Chromium Control UI end-to-end tests on this exact head: all four shards succeeded in https://github.com/openclaw/openclaw/actions/runs/30802346875 (jobs 91649831700, 91649831653, 91649831716, and 91649831668).

An independent dedicated Blacksmith Testbox run on immediate parent ac70cbad also exercised the focused clipboard suite against actual /usr/bin/chromium-browser: 3 scenarios passed in 8.19 seconds. It demonstrated denied path-copy, branch-copy, and assistant fenced-code-copy actions; visible and accessible failure feedback; and the two-second recovery. Captured screenshots: clipboard-copy-path-failure.png, clipboard-copy-branch-failure.png, clipboard-assistant-code-failure.png.

The follow-up exact-head change additionally proves a deferred first clipboard write cannot overwrite a newer denied attempt when its stale completion resolves late: deterministic RED before owner fix, GREEN afterward.

## Verification
- Focused markdown, clipboard, and owner sibling tests: 137 passed.
- Four exact-head hosted real Chromium E2E shards passed.
- Independent structured review: clean, confidence 0.99.
- Maintainer decision: clipboard failures must be visible and accessible, and the newest user action owns its feedback.