### PR TITLE
fix(whatsapp): clear and migrate every Baileys credential class

### DIFF
--- a/extensions/whatsapp/setup-entry.test.ts
+++ b/extensions/whatsapp/setup-entry.test.ts
@@ -1,4 +1,7 @@
 // Whatsapp tests cover setup entry plugin behavior.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import * as legacySessionSurfaceApi from "./legacy-session-surface-api.js";
 import * as legacyStateMigrationsApi from "./legacy-state-migrations-api.js";
@@ -66,6 +69,56 @@ describe("whatsapp setup entry", () => {
     ]);
     expect(legacySessionSurface.canonicalizeLegacySessionKey).toBeTypeOf("function");
     expect(legacySessionSurface.isLegacyGroupSessionKey).toBeTypeOf("function");
+  });
+
+  it("plans migration for every Baileys auth category while preserving other shared-root files", () => {
+    const oauthDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-wa-legacy-migration-"));
+    const authFiles = [
+      "creds.json",
+      "creds.json.bak",
+      "pre-key-1.json",
+      "session-contact.json",
+      "sender-key-group.json",
+      "sender-key-memory-group.json",
+      "app-state-sync-key-contact.json",
+      "app-state-sync-version-contact.json",
+      "lid-mapping-15551234567.json",
+      "device-list-15551234567.json",
+      "tctoken-15551234567.json",
+      "identity-key-15551234567.json",
+    ];
+
+    try {
+      for (const file of [...authFiles, "oauth.json", "google-oauth.json", "notes.txt"]) {
+        fs.writeFileSync(path.join(oauthDir, file), "{}", "utf-8");
+      }
+      fs.mkdirSync(path.join(oauthDir, "nested"));
+      fs.writeFileSync(path.join(oauthDir, "nested", "session-keep.json"), "{}", "utf-8");
+      fs.symlinkSync(path.join(oauthDir, "notes.txt"), path.join(oauthDir, "session-linked.json"));
+
+      const detectLegacyStateMigrations =
+        setupEntry.loadLegacyStateMigrationDetector?.(setupEntryLoadOptions);
+      if (!detectLegacyStateMigrations) {
+        throw new Error("expected WhatsApp legacy state migration detector");
+      }
+      const migrations = detectLegacyStateMigrations({
+        cfg: {},
+        env: {},
+        oauthDir,
+        stateDir: oauthDir,
+      });
+
+      expect(migrations.map((migration) => path.basename(migration.sourcePath)).toSorted()).toEqual(
+        authFiles.toSorted(),
+      );
+      for (const migration of migrations) {
+        expect(migration.targetPath).toBe(
+          path.join(oauthDir, "whatsapp", "default", path.basename(migration.sourcePath)),
+        );
+      }
+    } finally {
+      fs.rmSync(oauthDir, { recursive: true, force: true });
+    }
   });
 
   it("loads the delegated setup wizard without importing runtime dependencies", async () => {

--- a/extensions/whatsapp/setup-entry.test.ts
+++ b/extensions/whatsapp/setup-entry.test.ts
@@ -71,7 +71,7 @@ describe("whatsapp setup entry", () => {
     expect(legacySessionSurface.isLegacyGroupSessionKey).toBeTypeOf("function");
   });
 
-  it("plans migration for every Baileys auth category while preserving other shared-root files", () => {
+  it("plans migration for every Baileys auth category while preserving other shared-root files", async () => {
     const oauthDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-wa-legacy-migration-"));
     const authFiles = [
       "creds.json",
@@ -101,12 +101,13 @@ describe("whatsapp setup entry", () => {
       if (!detectLegacyStateMigrations) {
         throw new Error("expected WhatsApp legacy state migration detector");
       }
-      const migrations = detectLegacyStateMigrations({
-        cfg: {},
-        env: {},
-        oauthDir,
-        stateDir: oauthDir,
-      });
+      const migrations =
+        (await detectLegacyStateMigrations({
+          cfg: {},
+          env: {},
+          oauthDir,
+          stateDir: oauthDir,
+        })) ?? [];
 
       expect(migrations.map((migration) => path.basename(migration.sourcePath)).toSorted()).toEqual(
         authFiles.toSorted(),

--- a/extensions/whatsapp/src/auth-store.test.ts
+++ b/extensions/whatsapp/src/auth-store.test.ts
@@ -351,6 +351,56 @@ describe("auth-store", () => {
     }
   });
 
+  it("clears every Baileys auth category from the shared legacy root without touching other files", async () => {
+    const authDir = createTempAuthDir("openclaw-wa-auth-legacy-categories");
+    const previousOAuthDir = hoisted.oauthDir;
+    const authFiles = [
+      "creds.json",
+      "creds.json.bak",
+      "pre-key-1.json",
+      "session-contact.json",
+      "sender-key-group.json",
+      "sender-key-memory-group.json",
+      "app-state-sync-key-contact.json",
+      "app-state-sync-version-contact.json",
+      "lid-mapping-15551234567.json",
+      "device-list-15551234567.json",
+      "tctoken-15551234567.json",
+      "identity-key-15551234567.json",
+    ];
+    const unrelatedFiles = ["oauth.json", "google-oauth.json", "notes.txt"];
+    const nestedAuthFile = path.join(authDir, "nested", "session-keep.json");
+    hoisted.oauthDir = authDir;
+
+    try {
+      for (const file of [...authFiles, ...unrelatedFiles]) {
+        fsSync.writeFileSync(path.join(authDir, file), "{}", "utf-8");
+      }
+      fsSync.mkdirSync(path.dirname(nestedAuthFile));
+      fsSync.writeFileSync(nestedAuthFile, "keep", "utf-8");
+      fsSync.symlinkSync(
+        path.join(authDir, "notes.txt"),
+        path.join(authDir, "session-linked.json"),
+      );
+
+      await expect(logoutWeb({ authDir, isLegacyAuthDir: true })).resolves.toBe(true);
+
+      for (const file of authFiles) {
+        expect(fsSync.existsSync(path.join(authDir, file)), file).toBe(false);
+      }
+      for (const file of unrelatedFiles) {
+        expect(fsSync.existsSync(path.join(authDir, file)), file).toBe(true);
+      }
+      expect(fsSync.readFileSync(nestedAuthFile, "utf-8")).toBe("keep");
+      expect(fsSync.lstatSync(path.join(authDir, "session-linked.json")).isSymbolicLink()).toBe(
+        true,
+      );
+    } finally {
+      hoisted.oauthDir = previousOAuthDir;
+      fsSync.rmSync(authDir, { recursive: true, force: true });
+    }
+  });
+
   it("clears auth state even when directory enumeration fails", async () => {
     await withOwnedOAuthAuthDir("openclaw-wa-auth-readdir", async (authDir) => {
       fsSync.writeFileSync(path.join(authDir, "creds.json"), "{}", "utf-8");

--- a/extensions/whatsapp/src/auth-store.ts
+++ b/extensions/whatsapp/src/auth-store.ts
@@ -10,6 +10,7 @@ import { resolveOAuthDir } from "./auth-store.runtime.js";
 import {
   assertWebCredsPathRegularFileOrMissing,
   hasWebCredsSync,
+  isWhatsAppBaileysAuthFileName,
   readWebCredsJsonRaw,
   readWebCredsJsonRawSync,
   resolveWebCredsBackupPath,
@@ -225,19 +226,6 @@ export async function readWebAuthSnapshotBestEffort(authDir: string = resolveDef
   } as const;
 }
 
-function isBaileysAuthFileName(name: string): boolean {
-  if (name === "oauth.json") {
-    return false;
-  }
-  if (name === "creds.json" || name === "creds.json.bak") {
-    return true;
-  }
-  if (!name.endsWith(".json")) {
-    return false;
-  }
-  return /^(app-state-sync|session|sender-key|pre-key)-/.test(name);
-}
-
 async function clearBaileysAuthFiles(
   authDir: string,
   beforeCredentialPersistence?: () => Promise<void>,
@@ -248,7 +236,7 @@ async function clearBaileysAuthFiles(
   }
   const entries = await fs.readdir(authDir, { withFileTypes: true });
   const credentialFiles = entries.filter(
-    (entry) => entry.isFile() && isBaileysAuthFileName(entry.name),
+    (entry) => entry.isFile() && isWhatsAppBaileysAuthFileName(entry.name),
   );
   if (credentialFiles.length === 0) {
     return;
@@ -273,7 +261,7 @@ async function shouldClearOnLogout(authDir: string, isLegacyAuthDir: boolean): P
         if (!entry.isFile()) {
           return false;
         }
-        return isBaileysAuthFileName(entry.name);
+        return isWhatsAppBaileysAuthFileName(entry.name);
       });
     }
     const credsStats = await fs.lstat(resolveWebCredsPath(authDir)).catch(() => null);

--- a/extensions/whatsapp/src/creds-files.ts
+++ b/extensions/whatsapp/src/creds-files.ts
@@ -1,5 +1,6 @@
 // Whatsapp plugin module implements creds files behavior.
 import path from "node:path";
+import type { SignalDataTypeMap } from "baileys";
 import {
   assertNoSymlinkParents,
   assertNoSymlinkParentsSync,
@@ -8,6 +9,31 @@ import {
   statRegularFile,
   statRegularFileSync,
 } from "openclaw/plugin-sdk/security-runtime";
+
+// The legacy OAuth root is shared; keep its exact WhatsApp namespaces aligned
+// with Baileys without importing the provider into setup discovery.
+const BAILEYS_SIGNAL_AUTH_CATEGORIES = {
+  "app-state-sync-key": true,
+  "app-state-sync-version": true,
+  "device-list": true,
+  "identity-key": true,
+  "lid-mapping": true,
+  "pre-key": true,
+  "sender-key": true,
+  "sender-key-memory": true,
+  session: true,
+  tctoken: true,
+} satisfies Record<keyof SignalDataTypeMap, true>;
+
+export function isWhatsAppBaileysAuthFileName(name: string): boolean {
+  if (name === "creds.json" || name === "creds.json.bak") {
+    return true;
+  }
+  return (
+    name.endsWith(".json") &&
+    Object.keys(BAILEYS_SIGNAL_AUTH_CATEGORIES).some((category) => name.startsWith(`${category}-`))
+  );
+}
 
 export function resolveWebCredsPath(authDir: string): string {
   return path.join(authDir, "creds.json");

--- a/extensions/whatsapp/src/state-migrations.ts
+++ b/extensions/whatsapp/src/state-migrations.ts
@@ -4,16 +4,7 @@ import path from "node:path";
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
 import type { ChannelLegacyStateMigrationPlan } from "openclaw/plugin-sdk/channel-contract";
 import { fileExists } from "openclaw/plugin-sdk/security-runtime";
-
-function isLegacyWhatsAppAuthFile(name: string): boolean {
-  if (name === "creds.json" || name === "creds.json.bak") {
-    return true;
-  }
-  if (!name.endsWith(".json")) {
-    return false;
-  }
-  return /^(app-state-sync|session|sender-key|pre-key)-/.test(name);
-}
+import { isWhatsAppBaileysAuthFileName } from "./creds-files.js";
 
 export function detectWhatsAppLegacyStateMigrations(params: {
   oauthDir: string;
@@ -28,7 +19,7 @@ export function detectWhatsAppLegacyStateMigrations(params: {
   })();
 
   return entries.flatMap((entry) => {
-    if (!entry.isFile() || entry.name === "oauth.json" || !isLegacyWhatsAppAuthFile(entry.name)) {
+    if (!entry.isFile() || !isWhatsAppBaileysAuthFileName(entry.name)) {
       return [];
     }
     const sourcePath = path.join(params.oauthDir, entry.name);


### PR DESCRIPTION
## Summary
- Classify WhatsApp-owned Baileys credential files once and reuse the same exhaustive ownership policy for both legacy logout and doctor state migration.
- Cover all ten actual Baileys auth namespaces plus creds.json and creds.json.bak.
- Preserve unrelated OAuth credentials, notes, nested content, and symlinks in shared credential roots.

## Exact candidate real packaged operator proof
Reviewed immutable WhatsApp source: 1255a00d20ca509b2e411b45ee09cae17730d88e. Existing trusted packaged core base: ecc49b5a870b8c35108c656ef619dc528abb149e. All eight actual bundled plugin/index/setup source blobs and the three reviewed production-file hashes were verified before loading the source plugin through the real packaged CLI.

Actual packaged `openclaw channels logout --channel whatsapp`, using an isolated disposable agent directory to exercise the genuine shared-root legacy logout owner, exited zero. Before logout, all twelve WhatsApp credential files were present alongside unrelated OAuth files, nested content, notes, and a symlink. Afterwards the shared root contained exactly:

```json
["google-oauth.json","nested/","notes.txt","oauth.json","session-linked.json@"]
```

All twelve WhatsApp credentials were removed; no canonical whatsapp/default account directory was created.

A separate actual packaged `openclaw doctor --non-interactive` exited zero. The original shared credential root afterwards contained:

```json
["google-oauth.json","nested/","notes.txt","session-linked.json@","whatsapp/"]
```

The new canonical `whatsapp/default` directory contained exactly:

```json
["app-state-sync-key-contact.json","app-state-sync-version-contact.json","creds.json","creds.json.bak","device-list-15551234567.json","identity-key-15551234567.json","lid-mapping-15551234567.json","pre-key-1.json","sender-key-group.json","sender-key-memory-group.json","session-contact.json","tctoken-15551234567.json"]
```

Nested OAuth/session files and the symlink remained untouched. Fixtures were synthetic, isolated, and removed after proof; no account, network provider, dependency installation, or real credentials were involved.

Maintainer decision: a shared credential root is never wholesale WhatsApp-owned. Logout and doctor must classify only the actual pinned Baileys auth namespaces and preserve unrelated OAuth and operator files.

## Verification
- Focused WhatsApp owner/migration tests: 26 passed.
- Required exact-head CI gate and changed production/test type checks passed.
- Actual pinned Baileys auth-store contract inspected directly: `node_modules/@whiskeysockets/baileys/lib/Types/Auth.d.ts:68-85`.
- Independent structured security autoreview: clean, confidence 0.98.
- Real packaged logout and doctor workflows both exited zero with the exact redacted file inventories above.