### PR TITLE
fix(discord): preserve privacy after interaction acknowledgments

### DIFF
--- a/extensions/discord/src/monitor/agent-components.plugin-interactive.ts
+++ b/extensions/discord/src/monitor/agent-components.plugin-interactive.ts
@@ -66,10 +66,11 @@ export async function dispatchPluginDiscordInteractiveEvent(params: {
     },
     reply: async ({ text, ephemeral = true }: { text: string; ephemeral?: boolean }) => {
       responded = true;
-      await params.interaction.reply({
-        content: text,
-        ephemeral,
-      });
+      const payload = { content: text, ephemeral };
+      // Deferred component replies edit the public source; follow-ups preserve reply visibility.
+      await (acknowledged
+        ? params.interaction.followUp(payload)
+        : params.interaction.reply(payload));
     },
     followUp: async ({ text, ephemeral = true }: { text: string; ephemeral?: boolean }) => {
       responded = true;

--- a/extensions/discord/src/monitor/monitor.test.ts
+++ b/extensions/discord/src/monitor/monitor.test.ts
@@ -919,6 +919,48 @@ describe("discord component interactions", () => {
     expect(dispatchReplyMock).not.toHaveBeenCalled();
   });
 
+  it.each([
+    { visibility: "private", ephemeral: true },
+    { visibility: "public", ephemeral: false },
+    { visibility: "default-private", ephemeral: undefined },
+  ])(
+    "sends $visibility plugin replies as new messages after component acknowledgment",
+    async ({ ephemeral }) => {
+      registerDiscordComponentEntries({
+        entries: [createButtonEntry({ callbackData: "codex:approve" })],
+        modals: [],
+      });
+      dispatchPluginInteractiveHandlerMock.mockImplementation(async (params: unknown) => {
+        const typedParams = params as {
+          onMatched: () => Promise<void>;
+          respond: { reply: (payload: { text: string; ephemeral?: boolean }) => Promise<void> };
+        };
+        await typedParams.onMatched();
+        await typedParams.respond.reply({
+          text: "Plugin result",
+          ...(ephemeral === undefined ? {} : { ephemeral }),
+        });
+        return { matched: true, handled: true, duplicate: false };
+      });
+
+      const acknowledge = vi.fn().mockResolvedValue(undefined);
+      const followUp = vi.fn().mockResolvedValue(undefined);
+      const reply = vi.fn().mockResolvedValue(undefined);
+      const button = createDiscordComponentButton(createComponentContext());
+      const { interaction } = createComponentButtonInteraction({ acknowledge, followUp, reply });
+
+      await button.run(interaction, { cid: "btn_1" } as ComponentData);
+
+      expect(acknowledge).toHaveBeenCalledTimes(1);
+      expect(followUp).toHaveBeenCalledWith({
+        content: "Plugin result",
+        ephemeral: ephemeral ?? true,
+      });
+      expect(reply).not.toHaveBeenCalled();
+      expect(dispatchReplyMock).not.toHaveBeenCalled();
+    },
+  );
+
   it("lets plugin Discord interactions clear components after acknowledging", async () => {
     registerDiscordComponentEntries({
       entries: [createButtonEntry({ callbackData: "codex:approve" })],


### PR DESCRIPTION
## Summary
- Send replies to already acknowledged Discord plugin interactions as new follow-up messages.
- Prevent an intended ephemeral response from editing the existing public component message.
- Preserve explicit public replies, initial unacknowledged responses, and intentional source-message edits.

## Exact-head real Discord HTTP proof
Immutable PR head e953bb407282c5cb0b5fcb8295662927c42f04a4, actual OpenClaw plugin registry, Discord Client and ButtonInteraction, and a real local HTTP recording server:

private: POST /api/v10/interactions/interaction-private/[fixture-token]/callback {"type":6} -> POST /api/v10/webhooks/fixture-app/[fixture-token] {"content":"proof-private","flags":64}
public: POST /api/v10/interactions/interaction-public/[fixture-token]/callback {"type":6} -> POST /api/v10/webhooks/fixture-app/[fixture-token] {"content":"proof-public"}
default-private: POST /api/v10/interactions/interaction-default-private/[fixture-token]/callback {"type":6} -> POST /api/v10/webhooks/fixture-app/[fixture-token] {"content":"proof-default-private","flags":64}
PASS scenarios=3 actual_http_requests=6 public_source_PATCH_requests=0

This proof executes the actual changed owner and actual Discord HTTP request serialization without using external credentials; it does not claim full Gateway Discord ingress.

## Verification
- Focused Discord interaction and transport suites: 62 passed.
- Installed Discord API type-6 acknowledgement and ephemeral message flag contracts inspected directly.
- Independent structured P1 security autoreview: clean, confidence 0.98.
- Exact-head required openclaw/ci-gate: SUCCESS.

## Maintainer ownership decision
Accepted: acknowledged plugin replies must create a private or public follow-up according to their explicit/default ephemeral setting. Only intentional editMessage and clearComponents actions may mutate the original public source message.