### PR TITLE
improve(tests): reuse prepared plugin metadata

### DIFF
--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -2,7 +2,7 @@
 import crypto from "node:crypto";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TranscriptNotContinuableError } from "../../packages/agent-core/src/errors.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { createAgentRunStaleLifecycleError } from "../infra/agent-lifecycle-error.js";
@@ -13,9 +13,6 @@ import {
 } from "../infra/diagnostic-events.js";
 import { resetLogger, setLoggerOverride } from "../logging/logger.js";
 import { createWarnLogCapture } from "../logging/test-helpers/warn-log-capture.js";
-import { setCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
-import { clearCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-state.js";
-import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { GatewayDrainingError } from "../process/gateway-work-admission.js";
 import { AgentRunTerminalOutcomeError } from "./agent-run-terminal-error.js";
 import { AUTH_STORE_VERSION } from "./auth-profiles/constants.js";
@@ -50,13 +47,19 @@ import { resolveSessionSuspensionReason } from "./session-suspension.js";
 import { SessionWriteLockTimeoutError } from "./session-write-lock-error.js";
 import { makeModelFallbackCfg } from "./test-helpers/model-fallback-config-fixture.js";
 
+const emptyManifestPlugins = [] as const;
+
+function resolveFallbackCandidateRoutes(params: Parameters<typeof resolveModelCandidateChain>[0]) {
+  return resolveModelCandidateChain({ manifestPlugins: emptyManifestPlugins, ...params });
+}
+
 function resolveFallbackCandidateRefs(params: Parameters<typeof resolveModelCandidateChain>[0]) {
-  return resolveModelCandidateChain(params).map(({ provider, model }) => ({ provider, model }));
+  return resolveFallbackCandidateRoutes(params).map(({ provider, model }) => ({ provider, model }));
 }
 
 const testing = {
   resolveFallbackCandidates: resolveFallbackCandidateRefs,
-  resolveFallbackCandidateRoutes: resolveModelCandidateChain,
+  resolveFallbackCandidateRoutes,
   resolveSessionSuspensionReason,
   shouldDiscardDeferredSessionSuspension,
 };
@@ -215,7 +218,6 @@ vi.mock("./auth-profiles.runtime.js", () => authRuntimeMock.runtime);
 const makeCfg = makeModelFallbackCfg;
 let authTempRoot = "";
 let authTempCounter = 0;
-const emptyManifestPlugins = [] as const;
 
 function registerFallbackHarness(id: string): void {
   registerAgentHarness(
@@ -242,14 +244,6 @@ function createHarnessScopedPreflightError(harnessId: string): AgentHarnessPrefl
 const runWithModelFallback: typeof runWithModelFallbackBase = (params) =>
   runWithModelFallbackBase({ manifestPlugins: emptyManifestPlugins, ...params });
 
-beforeAll(() => {
-  setDefaultPluginMetadataSnapshot();
-});
-
-afterAll(() => {
-  clearCurrentPluginMetadataSnapshot();
-});
-
 function resetModelFallbackTestState(): void {
   // Fallback state has process-level caches for skip markers, harnesses, auth,
   // and plugin normalization. Reset every surface between tests.
@@ -263,13 +257,6 @@ function resetModelFallbackTestState(): void {
     .mockReset()
     .mockReturnValue(undefined);
   resetDiagnosticEventsForTest();
-}
-
-function setDefaultPluginMetadataSnapshot(): void {
-  setCurrentPluginMetadataSnapshot(loadPluginMetadataSnapshot({ config: {}, env: process.env }), {
-    config: {},
-    env: process.env,
-  });
 }
 
 afterEach(() => {

--- a/src/agents/model-runtime-aliases.test.ts
+++ b/src/agents/model-runtime-aliases.test.ts
@@ -9,8 +9,35 @@ import {
 import {
   areRuntimeModelRefsEquivalent,
   isCliRuntimeProvider,
-  resolveCliRuntimeExecutionProvider,
+  resolveCliRuntimeExecutionProvider as resolveCliRuntimeExecutionProviderBase,
 } from "./model-runtime-aliases.js";
+
+const anthropicAuthAliasMetadata = {
+  plugins: [
+    {
+      id: "anthropic",
+      origin: "bundled",
+      providerAuthChoices: [
+        {
+          provider: "anthropic",
+          method: "cli",
+          choiceId: "anthropic-cli",
+          deprecatedChoiceIds: ["claude-cli"],
+          choiceLabel: "Anthropic Claude CLI",
+        },
+      ],
+    },
+  ],
+} as never;
+
+function resolveCliRuntimeExecutionProvider(
+  params: Omit<Parameters<typeof resolveCliRuntimeExecutionProviderBase>[0], "metadataSnapshot">,
+) {
+  return resolveCliRuntimeExecutionProviderBase({
+    ...params,
+    metadataSnapshot: anthropicAuthAliasMetadata,
+  });
+}
 
 function createAnthropicAuthConfig(params: {
   order?: string[];
@@ -103,22 +130,13 @@ describe("resolveCliRuntimeExecutionProvider", () => {
     ).toBe("claude-cli");
   });
 
-  it("uses caller-provided plugin auth aliases without metadata discovery", () => {
+  it("uses prepared Anthropic auth choice aliases without metadata discovery", () => {
     expect(
       resolveCliRuntimeExecutionProvider({
         authProfileId: "anthropic:claude-cli",
         cfg: createAnthropicAuthConfig({ order: ["anthropic:api"] }),
         provider: "anthropic",
         modelId: "opus-4.7",
-        metadataSnapshot: {
-          plugins: [
-            {
-              id: "anthropic",
-              origin: "bundled",
-              providerAuthAliases: { "claude-cli": "anthropic" },
-            },
-          ],
-        } as never,
       }),
     ).toBe("claude-cli");
   });


### PR DESCRIPTION
## What Problem This Solves

The compact-large-5 test job regressed to 319 seconds in main run 30799534554. Its serial agents-core models group was repeatedly building complete plugin metadata even though these unit tests already control the manifest facts they need.

## Why This Change Was Made

The model fallback suite now carries its existing prepared empty manifest list through its direct candidate helpers and removes a stale suite metadata scan left behind after the cache-invalidation regression was deleted. The runtime-alias suite shares one prepared Anthropic auth-choice fixture across its routing cases instead of rediscovering the same manifest alias.

This is test-only. It does not change sharding, workers, scheduling, timeouts, or production behavior.

## User Impact

No user-visible behavior changes. Maintainers get a faster compact-large-5 models group with the same assertions and lower peak memory.

## Evidence

- Exact source run: https://github.com/openclaw/openclaw/actions/runs/30799534554
- Exact job: https://github.com/openclaw/openclaw/actions/runs/30799534554/job/91641240487
- Same-host exact 50-file group before: 50 files, 1,195 tests, 95.33s Vitest / 95.91s wall, 2.811 GB peak RSS
- Same-host exact 50-file group after: 50 files, 1,195 tests, 76.89s Vitest / 77.44s wall, 2.385 GB peak RSS
- Saving: 18.47s wall (19.3%) and about 426 MB peak RSS
- Post-rebase focused proof: 2 files, 160 tests passed in 26.36s
- Formatting, targeted Oxlint, diff check, and Codex autoreview are clean
- Delta: production +0/-0; tests +38/-33
