### PR TITLE
fix(xai): classify exhausted credits as billing

### DIFF
--- a/extensions/xai/index.test.ts
+++ b/extensions/xai/index.test.ts
@@ -471,6 +471,31 @@ describe("xai provider plugin", () => {
     ).toBeUndefined();
   });
 
+  it("classifies exhausted Grok credits and subscription requirements as billing", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+
+    expect(
+      provider.classifyFailoverReason?.({
+        errorMessage: '403 {"error":"You have run out of credits"}',
+      }),
+    ).toBe("billing");
+    expect(
+      provider.classifyFailoverReason?.({
+        errorMessage: '403 {"error":"You need a Grok subscription"}',
+      }),
+    ).toBe("billing");
+    expect(
+      provider.classifyFailoverReason?.({
+        errorMessage: "403 Forbidden",
+      }),
+    ).toBeUndefined();
+    expect(
+      provider.classifyFailoverReason?.({
+        errorMessage: "429 Too Many Requests",
+      }),
+    ).toBe("rate_limit");
+  });
+
   it("registers xAI speech providers for batch and streaming STT", async () => {
     const { mediaProviders, realtimeTranscriptionProviders } = await registerProviderPlugin({
       plugin,

--- a/extensions/xai/index.ts
+++ b/extensions/xai/index.ts
@@ -57,7 +57,7 @@ import {
 const PROVIDER_ID = "xai";
 
 const XAI_CREDIT_OR_SPENDING_LIMIT_RE =
-  /\b(?:used all available credits|monthly spending limit|purchase more credits|raise your spending limit)\b/i;
+  /\b(?:used all available credits|run out of credits|monthly spending limit|purchase more credits|raise your spending limit|need a Grok subscription)\b/i;
 const XAI_RATE_LIMIT_RE = /\b(?:rate limit exceeded|too many requests)\b/i;
 
 const loadCodeExecutionModule = createLazyRuntimeModule(() => import("./code-execution.js"));

--- a/src/agents/embedded-agent-helpers/errors-provider-structured-signals.test.ts
+++ b/src/agents/embedded-agent-helpers/errors-provider-structured-signals.test.ts
@@ -69,6 +69,27 @@ describe("provider failover hook structured signals", () => {
     ).toEqual({ kind: "reason", reason: "auth" });
   });
 
+  it("lets provider billing text override a leading 403 in assistant failures", () => {
+    providerRuntimeMocks.classifyProviderPluginError.mockImplementation((context) => {
+      return context.provider === "demo-provider" &&
+        context.errorMessage.includes("quota exhausted")
+        ? "billing"
+        : undefined;
+    });
+
+    const errorMessage = '403 {"error":"Account quota exhausted"}';
+    expect(
+      classifyAssistantFailoverReason(
+        makeAssistantMessageFixture({ provider: "demo-provider", errorMessage }),
+      ),
+    ).toBe("billing");
+    expect(
+      classifyAssistantFailoverReason(
+        makeAssistantMessageFixture({ provider: "other-provider", errorMessage }),
+      ),
+    ).toBe("auth");
+  });
+
   it("does not call the direct provider hook for unstructured classified messages", () => {
     // Plain message classifiers run first; provider hooks only see structured
     // descriptors where a plugin can make a reliable decision.


### PR DESCRIPTION
Closes #115853

## What Problem This Solves

Fixes an issue where users of xAI models could have exhausted-credit and missing-subscription responses reported as authentication failures when the response began with HTTP 403.

## Why This Change Was Made

Extends the xAI provider's billing matcher for the two observed response phrases while preserving the generic core classification of ordinary 403 responses as authentication failures. Regression coverage exercises both the provider hook directly and its precedence in the structured assistant failure path.

## User Impact

Users now receive a billing classification for xAI responses that say they have run out of credits or need a Grok subscription, while unrelated xAI and non-xAI 403 responses keep their existing classifications.

## Evidence

Before the production change, the new xAI regression failed because the provider hook returned `undefined` instead of `billing` for `403 {"error":"You have run out of credits"}`.

After the change, 212 focused and adjacent tests pass across the xAI plugin matcher, structured provider signals, and model fallback classification:

```text
node scripts/run-vitest.mjs extensions/xai/index.test.ts src/agents/embedded-agent-helpers/errors-provider-structured-signals.test.ts src/agents/model-fallback.test.ts
```

Additional validation:

```text
node_modules/.bin/oxfmt --check extensions/xai/index.ts extensions/xai/index.test.ts src/agents/embedded-agent-helpers/errors-provider-structured-signals.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/xai/index.ts extensions/xai/index.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/embedded-agent-helpers/errors-provider-structured-signals.test.ts
node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo
git diff --check
```

The full production and core-test typecheck lanes were also started locally but produced no diagnostics while remaining CPU-bound for more than 20 and 15 minutes respectively, so they were stopped; CI remains the broad typecheck authority.

Disclosure: AI was used to understand the codebase and review the fix.
