### PR TITLE
fix(diagnostic): stop aborting healthy agent turns that wait on a background subagent

### DIFF
--- a/docs/plugins/cli-backend-plugins.md
+++ b/docs/plugins/cli-backend-plugins.md
@@ -257,11 +257,15 @@ available to `resolveExecutionArgs(ctx)` for native CLI flags.
 backend owns a vendor-supported SDK for the installed CLI. The transport
 receives the exact prepared command, arguments, environment, prompt, session,
 and tool availability; it yields the backend's existing structured stream
-records. Native tool actions must use the provided, run-bound
-`requestToolPermission` callback rather than creating independent approval
-authority. OpenClaw retains cancellation, watchdogs, session policy, and MCP
-grant ownership. Explicit credential forwarding, paired-node execution, and
-manual compaction continue through the existing host-managed process path.
+records. When the backend's runtime knows that vendor-native work retains the
+parent turn, report that plugin-owned fact through
+`executionContext.reportBackgroundWorkLiveness({ outstanding })`; classify
+vendor records in the plugin, not in core. Native tool actions must use the
+provided, run-bound `requestToolPermission` callback rather than creating
+independent approval authority. OpenClaw retains cancellation, watchdogs,
+session policy, diagnostic recording, and MCP grant ownership. Explicit
+credential forwarding, paired-node execution, and manual compaction continue
+through the existing host-managed process path.
 
 `runtimeArtifact` is plugin-owned. It is consulted
 only when a live inference turn mints or revalidates verified setup authority;

--- a/extensions/anthropic/agent-sdk.runtime.test.ts
+++ b/extensions/anthropic/agent-sdk.runtime.test.ts
@@ -592,10 +592,23 @@ describe("Anthropic Agent SDK runtime ownership", () => {
     const live = useLiveSdkStreams();
     const capability = createLiveCapability();
     const controller = new AbortController();
+    const reportBackgroundWorkLiveness = vi.fn();
     const running = collect(
-      createContext({ abortSignal: controller.signal, liveSession: capability }),
+      createContext({
+        abortSignal: controller.signal,
+        liveSession: capability,
+        reportBackgroundWorkLiveness,
+      }),
     );
     await vi.waitFor(() => expect(queryMock).toHaveBeenCalledOnce());
+    live.streams[0]?.write({
+      type: "system",
+      subtype: "background_tasks_changed",
+      tasks: [{ task_id: "background-agent", task_type: "local_agent" }],
+    });
+    await vi.waitFor(() =>
+      expect(reportBackgroundWorkLiveness).toHaveBeenLastCalledWith({ outstanding: true }),
+    );
     const canUseTool = sdkNativeTool(sdkOptions());
     const reason = new Error("OpenClaw cancelled the active warm turn.");
 
@@ -604,6 +617,7 @@ describe("Anthropic Agent SDK runtime ownership", () => {
     await expect(running).rejects.toBe(reason);
     expect(live.closes[0]).toHaveBeenCalledOnce();
     expect(capability.current()).toBeUndefined();
+    expect(reportBackgroundWorkLiveness).toHaveBeenLastCalledWith({ outstanding: false });
     await expect(
       canUseTool(
         "Bash",
@@ -709,13 +723,36 @@ describe("Anthropic Agent SDK runtime ownership", () => {
     });
   });
 
-  it("holds provisional synthetic results until the real background-agent answer arrives", async () => {
+  it.each([
+    { taskId: " ", taskType: "local_agent" },
+    { taskId: "background-workflow", taskType: "local_workflow" },
+  ])("reports $taskType liveness through the plugin seam", async ({ taskId, taskType }) => {
+    const reportBackgroundWorkLiveness = vi.fn();
+    useSdkMessages([
+      {
+        type: "system",
+        subtype: "background_tasks_changed",
+        tasks: [{ task_id: taskId, task_type: taskType }],
+      },
+      SUCCESS_RESULT,
+    ]);
+
+    await collect(createContext({ reportBackgroundWorkLiveness }));
+
+    expect(reportBackgroundWorkLiveness).toHaveBeenNthCalledWith(1, { outstanding: true });
+    expect(reportBackgroundWorkLiveness).toHaveBeenLastCalledWith({ outstanding: false });
+  });
+
+  it("reports Agent SDK task liveness while holding a provisional result", async () => {
     const live = useLiveSdkStreams();
     const capability = createLiveCapability();
+    const reportBackgroundWorkLiveness = vi.fn();
     const observed: Record<string, unknown>[] = [];
     let settled = false;
     const result = (async () => {
-      for await (const event of executeClaudeAgentSdk(createContext({ liveSession: capability }))) {
+      for await (const event of executeClaudeAgentSdk(
+        createContext({ liveSession: capability, reportBackgroundWorkLiveness }),
+      )) {
         observed.push(event);
       }
       settled = true;
@@ -740,6 +777,7 @@ describe("Anthropic Agent SDK runtime ownership", () => {
     stream?.write({ ...SUCCESS_RESULT, result: "" });
     await vi.waitFor(() => expect(observed).toHaveLength(3));
     expect(settled).toBe(false);
+    expect(reportBackgroundWorkLiveness).toHaveBeenCalledExactlyOnceWith({ outstanding: true });
 
     stream?.write({ type: "system", subtype: "background_tasks_changed", tasks: [] });
     stream?.write({ ...SUCCESS_RESULT, result: "background answer" });
@@ -750,6 +788,7 @@ describe("Anthropic Agent SDK runtime ownership", () => {
       ]),
     );
     expect(observed.at(-1)).toEqual(expect.objectContaining({ result: "background answer" }));
+    expect(reportBackgroundWorkLiveness).toHaveBeenLastCalledWith({ outstanding: false });
     expect(live.closes[0]).not.toHaveBeenCalled();
   });
 

--- a/extensions/anthropic/agent-sdk.runtime.ts
+++ b/extensions/anthropic/agent-sdk.runtime.ts
@@ -450,6 +450,25 @@ function resolveClaudeAgentSdkOptions(
   return options;
 }
 
+function reportClaudeAgentSdkBackgroundWorkLiveness(
+  context: CliBackendExecuteContext,
+  message: Record<string, unknown>,
+): boolean | undefined {
+  if (message.type !== "system" || message.subtype !== "background_tasks_changed") {
+    return undefined;
+  }
+  const outstanding = (Array.isArray(message.tasks) ? message.tasks : []).some(
+    (task) =>
+      isRecord(task) &&
+      typeof task.task_type === "string" &&
+      RESULT_HOLDING_BACKGROUND_TASK_TYPES.has(task.task_type) &&
+      typeof task.task_id === "string" &&
+      task.task_id.length > 0,
+  );
+  context.reportBackgroundWorkLiveness?.({ outstanding });
+  return outstanding;
+}
+
 function closeClaudeAgentSdkSession(
   session: ClaudeAgentSdkSession,
   _reason: CliBackendLiveSessionCloseReason,
@@ -465,6 +484,7 @@ function closeClaudeAgentSdkSession(
   const turn = session.currentTurn;
   session.currentTurn = undefined;
   if (turn) {
+    turn.context.reportBackgroundWorkLiveness?.({ outstanding: false });
     turn.error =
       error instanceof Error ? error : new Error("Claude Agent SDK live session closed.");
     turn.controller.abort();
@@ -500,17 +520,12 @@ function acceptClaudeAgentSdkMessage(
   if (!turn) {
     return;
   }
-  if (message.type === "system" && message.subtype === "background_tasks_changed") {
-    session.hasResultHoldingBackgroundTasks = (
-      Array.isArray(message.tasks) ? message.tasks : []
-    ).some(
-      (task) =>
-        isRecord(task) &&
-        typeof task.task_type === "string" &&
-        RESULT_HOLDING_BACKGROUND_TASK_TYPES.has(task.task_type) &&
-        typeof task.task_id === "string" &&
-        task.task_id.length > 0,
-    );
+  const hasResultHoldingBackgroundTasks = reportClaudeAgentSdkBackgroundWorkLiveness(
+    turn.context,
+    message,
+  );
+  if (hasResultHoldingBackgroundTasks !== undefined) {
+    session.hasResultHoldingBackgroundTasks = hasResultHoldingBackgroundTasks;
   }
   turn.events.write(message);
   if (message.type === "result") {
@@ -682,15 +697,18 @@ export async function* executeClaudeAgentSdk(
       secretInput,
     );
     for await (const message of query({ prompt: context.prompt, options })) {
-      if (message.type === "result") {
+      const record = { ...message };
+      reportClaudeAgentSdkBackgroundWorkLiveness(context, record);
+      if (record.type === "result") {
         sawTerminalResult = true;
       }
-      yield { ...message };
+      yield record;
     }
     if (!sawTerminalResult && !controller.signal.aborted) {
       throw new Error("Claude Agent SDK exited without a terminal result.");
     }
   } finally {
+    context.reportBackgroundWorkLiveness?.({ outstanding: false });
     activeTurn = undefined;
     if (!controller.signal.aborted) {
       controller.abort();

--- a/src/agents/cli-runner/execute-plugin.test.ts
+++ b/src/agents/cli-runner/execute-plugin.test.ts
@@ -874,48 +874,19 @@ describe("plugin-owned CLI execution host boundary", () => {
     approval.resolve({ id: "late-approval", decision: "allow-once" });
   });
 
-  it("reports result-holding background work to diagnostic activity", async () => {
-    const { context } = await createExecution({ runId: "plugin-diagnostic-background" });
-    const backgroundObserved = createDeferred();
-    const backgroundFinished = createDeferred();
-    const run = runPlugin(
-      context,
-      async function* () {
-        yield {
-          type: "system",
-          subtype: "background_tasks_changed",
-          tasks: [{ task_id: "background-agent", task_type: "local_agent" }],
-        };
-        await backgroundFinished.promise;
-        yield { type: "system", subtype: "background_tasks_changed", tasks: [] };
-        yield SUCCESS_RESULT;
-      },
-      { consumeStdout: () => backgroundObserved.resolve() },
-    );
-
-    try {
-      await backgroundObserved.promise;
-      expect(diagnosticActivity(context)).toMatchObject({ hasOutstandingBackgroundWork: true });
-    } finally {
-      backgroundFinished.resolve();
-    }
-
-    await expect(run).resolves.toMatchObject({ reason: "exit", timedOut: false });
-    expect(diagnosticActivity(context)).not.toHaveProperty("hasOutstandingBackgroundWork");
-  });
-
-  it("releases diagnostic background work after a terminal plugin result", async () => {
+  it("records only plugin-reported liveness and fences it after a terminal result", async () => {
     const { context } = await createExecution({ runId: "plugin-diagnostic-terminal" });
+    let retainedFact: CliBackendExecuteContext["reportBackgroundWorkLiveness"];
     const backgroundObserved = createDeferred();
     const allowTerminalResult = createDeferred();
     const run = runPlugin(
       context,
-      async function* () {
-        yield {
-          type: "system",
-          subtype: "background_tasks_changed",
-          tasks: [{ task_id: "background-agent", task_type: "local_agent" }],
-        };
+      async function* (execution) {
+        retainedFact = execution.reportBackgroundWorkLiveness;
+        retainedFact?.({ outstanding: true });
+        // The opaque stream record disagrees intentionally: only the plugin-owned
+        // fact may decide whether diagnostic recovery retains this turn.
+        yield { type: "system", subtype: "background_tasks_changed", tasks: [] };
         await allowTerminalResult.promise;
         yield {
           type: "result",
@@ -936,6 +907,7 @@ describe("plugin-owned CLI execution host boundary", () => {
     }
 
     await expect(run).resolves.toMatchObject({ reason: "exit", timedOut: false });
+    retainedFact?.({ outstanding: true });
     expect(diagnosticActivity(context)).not.toHaveProperty("hasOutstandingBackgroundWork");
   });
 

--- a/src/agents/cli-runner/execute-plugin.test.ts
+++ b/src/agents/cli-runner/execute-plugin.test.ts
@@ -2,6 +2,10 @@ import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "@openclaw/ai/internal/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  getDiagnosticSessionActivitySnapshot,
+  resetDiagnosticRunActivityForTest,
+} from "../../logging/diagnostic-run-activity.js";
 import type {
   CliBackendExecute,
   CliBackendExecuteContext,
@@ -11,10 +15,6 @@ import type {
 import { prepareSystemAgentRunAdmission } from "../admitted-run-context.js";
 import { buildPreparedCliRunContext } from "../cli-runner.test-helpers.js";
 import { callGatewayTool } from "../tools/gateway.js";
-import {
-  getDiagnosticSessionActivitySnapshot,
-  resetDiagnosticRunActivityForTest,
-} from "../../logging/diagnostic-run-activity.js";
 import {
   closeCliLiveSession,
   createCliLiveSessionCapability,
@@ -125,6 +125,13 @@ function runPlugin(
     ...(options.onInterrupted ? { onInterrupted: options.onInterrupted } : {}),
     noOutputTimeoutMs: options.noOutputTimeoutMs ?? 2_000,
     consumeStdout: options.consumeStdout ?? (() => {}),
+  });
+}
+
+function diagnosticActivity(context: PreparedCliRunContext) {
+  return getDiagnosticSessionActivitySnapshot({
+    sessionId: context.params.sessionId,
+    sessionKey: context.params.sessionKey,
   });
 }
 
@@ -869,8 +876,8 @@ describe("plugin-owned CLI execution host boundary", () => {
 
   it("reports result-holding background work to diagnostic activity", async () => {
     const { context } = await createExecution({ runId: "plugin-diagnostic-background" });
-    const backgroundObserved = createDeferred<void>();
-    const backgroundFinished = createDeferred<void>();
+    const backgroundObserved = createDeferred();
+    const backgroundFinished = createDeferred();
     const run = runPlugin(
       context,
       async function* () {
@@ -888,29 +895,19 @@ describe("plugin-owned CLI execution host boundary", () => {
 
     try {
       await backgroundObserved.promise;
-      expect(
-        getDiagnosticSessionActivitySnapshot({
-          sessionId: context.params.sessionId,
-          sessionKey: context.params.sessionKey,
-        }),
-      ).toMatchObject({ hasOutstandingBackgroundWork: true });
+      expect(diagnosticActivity(context)).toMatchObject({ hasOutstandingBackgroundWork: true });
     } finally {
       backgroundFinished.resolve();
     }
 
     await expect(run).resolves.toMatchObject({ reason: "exit", timedOut: false });
-    expect(
-      getDiagnosticSessionActivitySnapshot({
-        sessionId: context.params.sessionId,
-        sessionKey: context.params.sessionKey,
-      }),
-    ).not.toHaveProperty("hasOutstandingBackgroundWork");
+    expect(diagnosticActivity(context)).not.toHaveProperty("hasOutstandingBackgroundWork");
   });
 
   it("releases diagnostic background work after a terminal plugin result", async () => {
     const { context } = await createExecution({ runId: "plugin-diagnostic-terminal" });
-    const backgroundObserved = createDeferred<void>();
-    const allowTerminalResult = createDeferred<void>();
+    const backgroundObserved = createDeferred();
+    const allowTerminalResult = createDeferred();
     const run = runPlugin(
       context,
       async function* () {
@@ -933,23 +930,13 @@ describe("plugin-owned CLI execution host boundary", () => {
 
     try {
       await backgroundObserved.promise;
-      expect(
-        getDiagnosticSessionActivitySnapshot({
-          sessionId: context.params.sessionId,
-          sessionKey: context.params.sessionKey,
-        }),
-      ).toMatchObject({ hasOutstandingBackgroundWork: true });
+      expect(diagnosticActivity(context)).toMatchObject({ hasOutstandingBackgroundWork: true });
     } finally {
       allowTerminalResult.resolve();
     }
 
     await expect(run).resolves.toMatchObject({ reason: "exit", timedOut: false });
-    expect(
-      getDiagnosticSessionActivitySnapshot({
-        sessionId: context.params.sessionId,
-        sessionKey: context.params.sessionKey,
-      }),
-    ).not.toHaveProperty("hasOutstandingBackgroundWork");
+    expect(diagnosticActivity(context)).not.toHaveProperty("hasOutstandingBackgroundWork");
   });
 
   it("keeps tracked background work alive beyond the ordinary no-output watchdog", async () => {

--- a/src/agents/cli-runner/execute-plugin.test.ts
+++ b/src/agents/cli-runner/execute-plugin.test.ts
@@ -907,6 +907,51 @@ describe("plugin-owned CLI execution host boundary", () => {
     ).not.toHaveProperty("hasOutstandingBackgroundWork");
   });
 
+  it("releases diagnostic background work after a terminal plugin result", async () => {
+    const { context } = await createExecution({ runId: "plugin-diagnostic-terminal" });
+    const backgroundObserved = createDeferred<void>();
+    const allowTerminalResult = createDeferred<void>();
+    const run = runPlugin(
+      context,
+      async function* () {
+        yield {
+          type: "system",
+          subtype: "background_tasks_changed",
+          tasks: [{ task_id: "background-agent", task_type: "local_agent" }],
+        };
+        await allowTerminalResult.promise;
+        yield {
+          type: "result",
+          subtype: "error_during_execution",
+          is_error: true,
+          result: "background agent failed",
+          session_id: "sdk-session",
+        };
+      },
+      { consumeStdout: () => backgroundObserved.resolve() },
+    );
+
+    try {
+      await backgroundObserved.promise;
+      expect(
+        getDiagnosticSessionActivitySnapshot({
+          sessionId: context.params.sessionId,
+          sessionKey: context.params.sessionKey,
+        }),
+      ).toMatchObject({ hasOutstandingBackgroundWork: true });
+    } finally {
+      allowTerminalResult.resolve();
+    }
+
+    await expect(run).resolves.toMatchObject({ reason: "exit", timedOut: false });
+    expect(
+      getDiagnosticSessionActivitySnapshot({
+        sessionId: context.params.sessionId,
+        sessionKey: context.params.sessionKey,
+      }),
+    ).not.toHaveProperty("hasOutstandingBackgroundWork");
+  });
+
   it("keeps tracked background work alive beyond the ordinary no-output watchdog", async () => {
     vi.useFakeTimers();
     const { context } = await createExecution();

--- a/src/agents/cli-runner/execute-plugin.test.ts
+++ b/src/agents/cli-runner/execute-plugin.test.ts
@@ -12,6 +12,10 @@ import { prepareSystemAgentRunAdmission } from "../admitted-run-context.js";
 import { buildPreparedCliRunContext } from "../cli-runner.test-helpers.js";
 import { callGatewayTool } from "../tools/gateway.js";
 import {
+  getDiagnosticSessionActivitySnapshot,
+  resetDiagnosticRunActivityForTest,
+} from "../../logging/diagnostic-run-activity.js";
+import {
   closeCliLiveSession,
   createCliLiveSessionCapability,
 } from "./cli-live-session-registry.js";
@@ -184,6 +188,7 @@ afterEach(() => {
     admission.close();
   }
   mockCallGatewayTool.mockReset();
+  resetDiagnosticRunActivityForTest();
   vi.restoreAllMocks();
   vi.useRealTimers();
 });
@@ -860,6 +865,46 @@ describe("plugin-owned CLI execution host boundary", () => {
     });
     expect(approvalSignal?.aborted).toBe(true);
     approval.resolve({ id: "late-approval", decision: "allow-once" });
+  });
+
+  it("reports result-holding background work to diagnostic activity", async () => {
+    const { context } = await createExecution({ runId: "plugin-diagnostic-background" });
+    const backgroundObserved = createDeferred<void>();
+    const backgroundFinished = createDeferred<void>();
+    const run = runPlugin(
+      context,
+      async function* () {
+        yield {
+          type: "system",
+          subtype: "background_tasks_changed",
+          tasks: [{ task_id: "background-agent", task_type: "local_agent" }],
+        };
+        await backgroundFinished.promise;
+        yield { type: "system", subtype: "background_tasks_changed", tasks: [] };
+        yield SUCCESS_RESULT;
+      },
+      { consumeStdout: () => backgroundObserved.resolve() },
+    );
+
+    try {
+      await backgroundObserved.promise;
+      expect(
+        getDiagnosticSessionActivitySnapshot({
+          sessionId: context.params.sessionId,
+          sessionKey: context.params.sessionKey,
+        }),
+      ).toMatchObject({ hasOutstandingBackgroundWork: true });
+    } finally {
+      backgroundFinished.resolve();
+    }
+
+    await expect(run).resolves.toMatchObject({ reason: "exit", timedOut: false });
+    expect(
+      getDiagnosticSessionActivitySnapshot({
+        sessionId: context.params.sessionId,
+        sessionKey: context.params.sessionKey,
+      }),
+    ).not.toHaveProperty("hasOutstandingBackgroundWork");
   });
 
   it("keeps tracked background work alive beyond the ordinary no-output watchdog", async () => {

--- a/src/agents/cli-runner/execute-plugin.ts
+++ b/src/agents/cli-runner/execute-plugin.ts
@@ -3,7 +3,10 @@ import { clampPositiveTimerTimeoutMs } from "@openclaw/normalization-core/number
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { toErrorObject } from "../../infra/errors.js";
 import { resolveExecutablePath } from "../../infra/executable-path.js";
-import { BLOCKED_TOOL_CALL_ABORT_FLOOR_MS } from "../../logging/diagnostic-run-activity.js";
+import {
+  BLOCKED_TOOL_CALL_ABORT_FLOOR_MS,
+  markDiagnosticOutstandingBackgroundWork,
+} from "../../logging/diagnostic-run-activity.js";
 import type {
   CliBackendExecute,
   CliBackendToolPermissionRequest,
@@ -33,6 +36,18 @@ import { resolveCliNoOutputTimeoutDecision } from "./no-output-timeout-policy.js
 import type { PreparedCliRunContext } from "./types.js";
 
 const PLUGIN_ITERATOR_CLOSE_TIMEOUT_MS = 5_000;
+const RESULT_HOLDING_BACKGROUND_TASK_TYPES = new Set(["local_agent", "local_workflow"]);
+
+function hasResultHoldingBackgroundTasks(tasks: unknown[]): boolean {
+  return tasks.some(
+    (task) =>
+      isRecord(task) &&
+      typeof task.task_type === "string" &&
+      RESULT_HOLDING_BACKGROUND_TASK_TYPES.has(task.task_type) &&
+      typeof task.task_id === "string" &&
+      task.task_id.trim().length > 0,
+  );
+}
 
 function denyTool(message: string): CliBackendToolPermissionResult {
   return { behavior: "deny", message };
@@ -460,6 +475,13 @@ export async function executePluginOwnedProcess(params: {
         Array.isArray(next.value.tasks)
       ) {
         outstanding.background = next.value.tasks.filter(isRecord).length;
+        // The CLI's task list is authoritative while a child owns the quiet turn.
+        markDiagnosticOutstandingBackgroundWork({
+          runId: run.runId,
+          sessionId: run.sessionId,
+          sessionKey: run.sessionKey,
+          outstanding: hasResultHoldingBackgroundTasks(next.value.tasks),
+        });
       }
       params.consumeStdout(`${JSON.stringify(next.value)}\n`);
       outstanding.observed = true;

--- a/src/agents/cli-runner/execute-plugin.ts
+++ b/src/agents/cli-runner/execute-plugin.ts
@@ -514,6 +514,14 @@ export async function executePluginOwnedProcess(params: {
   } finally {
     clearTimeout(overallTimer);
     clearTimeout(noOutputTimer);
+    // A terminal result, iterator error, cancellation, or timeout can arrive
+    // before the plugin sends an empty task list; do not leak its liveness floor.
+    markDiagnosticOutstandingBackgroundWork({
+      runId: run.runId,
+      sessionId: run.sessionId,
+      sessionKey: run.sessionKey,
+      outstanding: false,
+    });
     // Permission callbacks can be retained by the plugin or its subprocess.
     // Closing the turn fences those capabilities before any outer cleanup runs.
     if (!controller.signal.aborted) {

--- a/src/agents/cli-runner/execute-plugin.ts
+++ b/src/agents/cli-runner/execute-plugin.ts
@@ -36,18 +36,6 @@ import { resolveCliNoOutputTimeoutDecision } from "./no-output-timeout-policy.js
 import type { PreparedCliRunContext } from "./types.js";
 
 const PLUGIN_ITERATOR_CLOSE_TIMEOUT_MS = 5_000;
-const RESULT_HOLDING_BACKGROUND_TASK_TYPES = new Set(["local_agent", "local_workflow"]);
-
-function hasResultHoldingBackgroundTasks(tasks: unknown[]): boolean {
-  return tasks.some(
-    (task) =>
-      isRecord(task) &&
-      typeof task.task_type === "string" &&
-      RESULT_HOLDING_BACKGROUND_TASK_TYPES.has(task.task_type) &&
-      typeof task.task_id === "string" &&
-      task.task_id.trim().length > 0,
-  );
-}
 
 function denyTool(message: string): CliBackendToolPermissionResult {
   return { behavior: "deny", message };
@@ -393,6 +381,7 @@ export async function executePluginOwnedProcess(params: {
   let iterator: AsyncIterator<Record<string, unknown>> | undefined;
   let terminalResultSeen = false;
   let terminalErrorSeen = false;
+  let acceptsBackgroundWorkLiveness = true;
   try {
     resetNoOutputTimer();
     if (
@@ -438,6 +427,19 @@ export async function executePluginOwnedProcess(params: {
             }),
           }
         : {}),
+      reportBackgroundWorkLiveness: ({ outstanding: hasOutstandingBackgroundWork }) => {
+        // Plugins may retain callbacks after their iterator closes. A late fact
+        // must not recreate the diagnostic floor after this turn has released it.
+        if (!acceptsBackgroundWorkLiveness) {
+          return;
+        }
+        markDiagnosticOutstandingBackgroundWork({
+          runId: run.runId,
+          sessionId: run.sessionId,
+          sessionKey: run.sessionKey,
+          outstanding: hasOutstandingBackgroundWork,
+        });
+      },
       requestToolPermission: createPluginToolPermissionHandler({
         context: params.context,
         abortSignal: signal,
@@ -475,13 +477,6 @@ export async function executePluginOwnedProcess(params: {
         Array.isArray(next.value.tasks)
       ) {
         outstanding.background = next.value.tasks.filter(isRecord).length;
-        // The CLI's task list is authoritative while a child owns the quiet turn.
-        markDiagnosticOutstandingBackgroundWork({
-          runId: run.runId,
-          sessionId: run.sessionId,
-          sessionKey: run.sessionKey,
-          outstanding: hasResultHoldingBackgroundTasks(next.value.tasks),
-        });
       }
       params.consumeStdout(`${JSON.stringify(next.value)}\n`);
       outstanding.observed = true;
@@ -512,10 +507,11 @@ export async function executePluginOwnedProcess(params: {
       throw error;
     }
   } finally {
+    acceptsBackgroundWorkLiveness = false;
     clearTimeout(overallTimer);
     clearTimeout(noOutputTimer);
     // A terminal result, iterator error, cancellation, or timeout can arrive
-    // before the plugin sends an empty task list; do not leak its liveness floor.
+    // before the plugin reports its final fact; do not leak its liveness floor.
     markDiagnosticOutstandingBackgroundWork({
       runId: run.runId,
       sessionId: run.sessionId,

--- a/src/auto-reply/reply/reply-run-registry.test.ts
+++ b/src/auto-reply/reply/reply-run-registry.test.ts
@@ -7,6 +7,7 @@ import { attachToolAllowlistIntersection } from "../../agents/tool-policy.js";
 import {
   getDiagnosticSessionActivitySnapshot,
   markDiagnosticEmbeddedRunStarted,
+  markDiagnosticOutstandingBackgroundWork,
   resetDiagnosticRunActivityForTest,
   RUN_STALE_TAKEOVER_MS,
 } from "../../logging/diagnostic-run-activity.js";
@@ -407,6 +408,33 @@ describe("reply run registry", () => {
           sessionKey: operation.key,
         }).lastProgressReason,
       ).toBe("global_lane:wait_ended");
+    } finally {
+      operation.complete();
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps a healthy CLI background child from stale takeover", () => {
+    vi.useFakeTimers();
+    const operation = createTestReplyOperation({
+      sessionKey: "agent:main:telegram:direct:background",
+      sessionId: "session-background",
+    });
+    const refs = {
+      sessionId: operation.sessionId,
+      sessionKey: operation.key,
+      runId: "background-run",
+    };
+    try {
+      operation.setPhase("running");
+      markDiagnosticModelStartedForTest({ ...refs, provider: "claude-cli", model: "sonnet" });
+      markDiagnosticOutstandingBackgroundWork({ ...refs, outstanding: true });
+
+      vi.advanceTimersByTime(RUN_STALE_TAKEOVER_MS + 1);
+      expect(isReplyRunEvidenceStale(operation)).toBe(false);
+
+      markDiagnosticOutstandingBackgroundWork({ ...refs, outstanding: false });
+      expect(isReplyRunEvidenceStale(operation)).toBe(true);
     } finally {
       operation.complete();
       vi.useRealTimers();

--- a/src/logging/diagnostic-activity-keys.ts
+++ b/src/logging/diagnostic-activity-keys.ts
@@ -1,0 +1,39 @@
+export function diagnosticToolKey(event: {
+  runId?: string;
+  sessionId?: string;
+  sessionKey?: string;
+  toolCallId?: string;
+  toolName: string;
+}): string {
+  return `${event.runId ?? event.sessionId ?? event.sessionKey ?? "unknown"}:${
+    event.toolCallId ?? event.toolName
+  }`;
+}
+
+export function diagnosticModelCallKey(event: {
+  runId?: string;
+  provider?: string;
+  model?: string;
+}): string {
+  return `${event.runId ?? "unknown"}:${event.provider ?? "provider"}:${event.model ?? "model"}`;
+}
+
+export function resolveEmbeddedRunWorkKey(params: { sessionId: string; workKey?: string }): string {
+  return params.workKey ?? params.sessionId;
+}
+
+export function diagnosticSessionActivityRefs(params: {
+  sessionId?: string;
+  sessionKey?: string;
+}): string[] {
+  const refs: string[] = [];
+  const sessionId = params.sessionId?.trim();
+  const sessionKey = params.sessionKey?.trim();
+  if (sessionId) {
+    refs.push(`id:${sessionId}`);
+  }
+  if (sessionKey) {
+    refs.push(`key:${sessionKey}`);
+  }
+  return refs;
+}

--- a/src/logging/diagnostic-background-work.ts
+++ b/src/logging/diagnostic-background-work.ts
@@ -1,0 +1,31 @@
+type DiagnosticBackgroundWorkParams = {
+  runId: string;
+  sessionId: string;
+  sessionKey?: string;
+  outstanding: boolean;
+};
+
+type DiagnosticBackgroundWorkActivity = {
+  outstandingBackgroundWorkRunId?: string;
+};
+
+export function recordDiagnosticOutstandingBackgroundWork(
+  params: DiagnosticBackgroundWorkParams,
+  resolveActivity: (
+    params: DiagnosticBackgroundWorkParams,
+  ) => DiagnosticBackgroundWorkActivity | undefined,
+): void {
+  const runId = params.runId.trim();
+  if (!runId) {
+    return;
+  }
+  const activity = resolveActivity({ ...params, runId });
+  if (!activity) {
+    return;
+  }
+  if (params.outstanding) {
+    activity.outstandingBackgroundWorkRunId = runId;
+  } else if (activity.outstandingBackgroundWorkRunId === runId) {
+    activity.outstandingBackgroundWorkRunId = undefined;
+  }
+}

--- a/src/logging/diagnostic-run-activity-snapshot.ts
+++ b/src/logging/diagnostic-run-activity-snapshot.ts
@@ -73,9 +73,7 @@ export function buildDiagnosticSessionActivitySnapshot(
   return {
     activeWorkKind,
     ...(activity.activeEmbeddedRuns.size > 0 ? { hasActiveEmbeddedRun: true } : {}),
-    ...(activity.outstandingBackgroundWorkRunId
-      ? { hasOutstandingBackgroundWork: true }
-      : {}),
+    ...(activity.outstandingBackgroundWorkRunId ? { hasOutstandingBackgroundWork: true } : {}),
     activeToolName: activeTool?.toolName,
     activeToolCallId: activeTool?.toolCallId,
     activeToolAgeMs: activeTool ? Math.max(0, now - activeTool.startedAt) : undefined,

--- a/src/logging/diagnostic-run-activity-snapshot.ts
+++ b/src/logging/diagnostic-run-activity-snapshot.ts
@@ -11,6 +11,7 @@ import {
 export type DiagnosticSessionActivitySnapshot = {
   activeWorkKind?: DiagnosticSessionActiveWorkKind;
   hasActiveEmbeddedRun?: boolean;
+  hasOutstandingBackgroundWork?: boolean;
   activeToolName?: string;
   activeToolCallId?: string;
   activeToolAgeMs?: number;
@@ -27,6 +28,7 @@ type SnapshotActivity = DiagnosticArgumentChurnActivity &
     activeModelCalls: ReadonlyMap<string, unknown>;
     activeCoreModelCalls: ReadonlyMap<object, ReadonlyMap<string, { requestTimeoutMs?: number }>>;
     activeTools: ReadonlyMap<string, SnapshotTool>;
+    outstandingBackgroundWorkRunId?: string;
     lastProgressAt: number;
     lastProgressReason?: string;
   };
@@ -71,6 +73,9 @@ export function buildDiagnosticSessionActivitySnapshot(
   return {
     activeWorkKind,
     ...(activity.activeEmbeddedRuns.size > 0 ? { hasActiveEmbeddedRun: true } : {}),
+    ...(activity.outstandingBackgroundWorkRunId
+      ? { hasOutstandingBackgroundWork: true }
+      : {}),
     activeToolName: activeTool?.toolName,
     activeToolCallId: activeTool?.toolCallId,
     activeToolAgeMs: activeTool ? Math.max(0, now - activeTool.startedAt) : undefined,

--- a/src/logging/diagnostic-run-activity.test.ts
+++ b/src/logging/diagnostic-run-activity.test.ts
@@ -27,6 +27,7 @@ import {
   markDiagnosticArgumentChurnObservation,
   markDiagnosticEmbeddedRunEnded,
   markDiagnosticEmbeddedRunStarted,
+  markDiagnosticOutstandingBackgroundWork,
   markDiagnosticRunProgress,
   resetDiagnosticRunActivityForTest,
   resolveRunStaleThresholdMs,
@@ -1032,6 +1033,27 @@ describe("repeated request liveness", () => {
   });
 });
 
+describe("outstanding CLI background work", () => {
+  it("is owned by its run and cleared only by that run", () => {
+    const ref = { sessionId: "background-session", sessionKey: "agent:main:background" };
+    markDiagnosticOutstandingBackgroundWork({ ...ref, runId: "background-run", outstanding: true });
+
+    expect(getDiagnosticSessionActivitySnapshot(ref)).toMatchObject({
+      hasOutstandingBackgroundWork: true,
+    });
+
+    markDiagnosticOutstandingBackgroundWork({ ...ref, runId: "replacement-run", outstanding: false });
+    expect(getDiagnosticSessionActivitySnapshot(ref)).toMatchObject({
+      hasOutstandingBackgroundWork: true,
+    });
+
+    markDiagnosticOutstandingBackgroundWork({ ...ref, runId: "background-run", outstanding: false });
+    expect(getDiagnosticSessionActivitySnapshot(ref)).not.toHaveProperty(
+      "hasOutstandingBackgroundWork",
+    );
+  });
+});
+
 describe("resolveRunStaleThresholdMs", () => {
   it.each([
     {
@@ -1052,6 +1074,11 @@ describe("resolveRunStaleThresholdMs", () => {
     {
       name: "blocked-tool floor for tool_call",
       activity: { activeWorkKind: "tool_call" as const },
+      expected: Math.max(RUN_STALE_TAKEOVER_MS, BLOCKED_TOOL_CALL_ABORT_FLOOR_MS),
+    },
+    {
+      name: "blocked-tool floor for CLI background work",
+      activity: { activeWorkKind: "model_call" as const, hasOutstandingBackgroundWork: true },
       expected: Math.max(RUN_STALE_TAKEOVER_MS, BLOCKED_TOOL_CALL_ABORT_FLOOR_MS),
     },
   ])("$name", ({ activity, expected }) => {

--- a/src/logging/diagnostic-run-activity.test.ts
+++ b/src/logging/diagnostic-run-activity.test.ts
@@ -1042,12 +1042,20 @@ describe("outstanding CLI background work", () => {
       hasOutstandingBackgroundWork: true,
     });
 
-    markDiagnosticOutstandingBackgroundWork({ ...ref, runId: "replacement-run", outstanding: false });
+    markDiagnosticOutstandingBackgroundWork({
+      ...ref,
+      runId: "replacement-run",
+      outstanding: false,
+    });
     expect(getDiagnosticSessionActivitySnapshot(ref)).toMatchObject({
       hasOutstandingBackgroundWork: true,
     });
 
-    markDiagnosticOutstandingBackgroundWork({ ...ref, runId: "background-run", outstanding: false });
+    markDiagnosticOutstandingBackgroundWork({
+      ...ref,
+      runId: "background-run",
+      outstanding: false,
+    });
     expect(getDiagnosticSessionActivitySnapshot(ref)).not.toHaveProperty(
       "hasOutstandingBackgroundWork",
     );

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -62,6 +62,7 @@ type SessionActivity = DiagnosticArgumentChurnActivity &
       CoreModelRequestOwnerGeneration,
       Map<string, DiagnosticRecoveryModelCall>
     >;
+    outstandingBackgroundWorkRunId?: string;
     recoveredOwnerStartEventCutoffs: Map<string, number>;
     lastProgressAt: number;
     lastProgressReason?: string;
@@ -91,12 +92,15 @@ export const BLOCKED_TOOL_CALL_ABORT_FLOOR_MS = 15 * 60_000;
 // Default quiet-run reclaim window for steer/takeover. Evidence clocks stay local.
 export const RUN_STALE_TAKEOVER_MS = 10 * 60_000;
 
-// Quiet-but-alive tool phases get the blocked-tool floor so a human message
-// cannot reclaim a healthy long tool that stuck recovery would not touch yet.
+// Quiet-but-alive tool phases and CLI-owned background work get the blocked-tool
+// floor so a human message cannot reclaim work that recovery would not touch yet.
 export function resolveRunStaleThresholdMs(
-  activity: Pick<DiagnosticSessionActivitySnapshot, "activeWorkKind">,
+  activity: Pick<
+    DiagnosticSessionActivitySnapshot,
+    "activeWorkKind" | "hasOutstandingBackgroundWork"
+  >,
 ): number {
-  return activity.activeWorkKind === "tool_call"
+  return activity.activeWorkKind === "tool_call" || activity.hasOutstandingBackgroundWork === true
     ? Math.max(RUN_STALE_TAKEOVER_MS, BLOCKED_TOOL_CALL_ABORT_FLOOR_MS)
     : RUN_STALE_TAKEOVER_MS;
 }
@@ -154,6 +158,7 @@ function replaceSessionActivityReferences(source: SessionActivity, target: Sessi
 function mergeSessionActivity(target: SessionActivity, source: SessionActivity): void {
   target.sessionId ??= source.sessionId;
   target.sessionKey ??= source.sessionKey;
+  target.outstandingBackgroundWorkRunId ??= source.outstandingBackgroundWorkRunId;
   for (const [key, embeddedRun] of source.activeEmbeddedRuns) {
     const existing = target.activeEmbeddedRuns.get(key);
     if (existing && existing.runId !== embeddedRun.runId) {
@@ -413,6 +418,28 @@ export function markDiagnosticArgumentChurnObservation(
 
 export const markDiagnosticRunProgress: (params: RunProgressEvent) => void = applyRunProgress;
 
+/** Records CLI-owned background work in the canonical run activity state. */
+export function markDiagnosticOutstandingBackgroundWork(params: {
+  runId: string;
+  sessionId: string;
+  sessionKey?: string;
+  outstanding: boolean;
+}): void {
+  const runId = params.runId.trim();
+  if (!runId) {
+    return;
+  }
+  const activity = resolveSessionActivity({ ...params, runId, create: params.outstanding });
+  if (!activity) {
+    return;
+  }
+  if (params.outstanding) {
+    activity.outstandingBackgroundWorkRunId = runId;
+  } else if (activity.outstandingBackgroundWorkRunId === runId) {
+    activity.outstandingBackgroundWorkRunId = undefined;
+  }
+}
+
 function applyRunProgress(params: RunProgressEvent, semantic = false): void {
   const runId = params.runId?.trim() || undefined;
   const activity = resolveSessionActivity({ ...params, runId, create: true });
@@ -442,6 +469,9 @@ function recordRunCompleted(
   );
   if (hasCoreOwner) {
     return;
+  }
+  if (activity.outstandingBackgroundWorkRunId === event.runId) {
+    activity.outstandingBackgroundWorkRunId = undefined;
   }
   activityByRunId.delete(event.runId);
   if (activity.repeatedRequestOwnerRunId === event.runId) {
@@ -484,6 +514,10 @@ export function markDiagnosticEmbeddedRunStarted(params: {
   // New owners must not inherit the prior owner's semantic-stall clock.
   if (activity.repeatedRequestOwnerRunId !== ownerRunId) {
     clearRepeatedRequestActivity(activity);
+  }
+  // A replacement run must not inherit a prior CLI child's liveness floor.
+  if (activity.outstandingBackgroundWorkRunId !== ownerRunId) {
+    activity.outstandingBackgroundWorkRunId = undefined;
   }
   if (activity.argumentChurnStartedAt !== undefined) {
     clearArgumentChurnActivity(activity, { runId: ownerRunId });
@@ -611,7 +645,8 @@ export function clearDiagnosticEmbeddedRunActivityForSession(params: {
     activity.activeEmbeddedRuns.size === 0 &&
     activity.activeTools.size === 0 &&
     activity.activeModelCalls.size === 0 &&
-    countActiveCoreModelCalls(activity) === 0
+    countActiveCoreModelCalls(activity) === 0 &&
+    activity.outstandingBackgroundWorkRunId === undefined
   ) {
     const clearedChurn = clearArgumentChurnActivity(activity, {
       runId: params.activeSessionId,
@@ -652,6 +687,7 @@ export function clearDiagnosticEmbeddedRunActivityForSession(params: {
   activity.activeTools.clear();
   activity.activeModelCalls.clear();
   activity.activeCoreModelCalls.clear();
+  activity.outstandingBackgroundWorkRunId = undefined;
   clearArgumentChurnActivity(activity, { runId: params.activeSessionId });
   clearArgumentChurnPolicyWaits(activity, { runId: params.activeSessionId });
   clearRepeatedRequestActivity(activity);

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -12,6 +12,12 @@ import type {
 import { resolveCoreModelRequestLifecycleDiagnosticMetadata } from "../infra/diagnostic-model-request.js";
 import { isCoreSemanticRunProgressDiagnosticMetadata } from "../infra/diagnostic-semantic-run-progress.js";
 import {
+  diagnosticModelCallKey,
+  diagnosticSessionActivityRefs,
+  diagnosticToolKey,
+  resolveEmbeddedRunWorkKey,
+} from "./diagnostic-activity-keys.js";
+import {
   applyArgumentChurnObservation,
   clearArgumentChurnActivity,
   clearArgumentChurnPolicyWaits,
@@ -20,6 +26,7 @@ import {
   mergeArgumentChurnActivity,
   recordDiagnosticActivityProgress,
 } from "./diagnostic-argument-churn-activity.js";
+import { recordDiagnosticOutstandingBackgroundWork } from "./diagnostic-background-work.js";
 import { createDiagnosticEmbeddedRunIndex } from "./diagnostic-embedded-run-index.js";
 import {
   clearRepeatedRequestActivity,
@@ -83,27 +90,11 @@ type RunProgressEvent = Pick<
   "runId" | "sessionId" | "sessionKey" | "reason"
 > & { progressKind?: "semantic" | "liveness" };
 
-// Quiet-but-alive tools are normal agent behavior; the CLI byte watchdog kills
-// truly silent children within its own deadline. This floor bounds every
-// staleness consumer (diagnostic recovery aborts, reply-run stale takeover,
-// steer gates): lowering it reopens #88870, removing it reopens #96168.
-export const BLOCKED_TOOL_CALL_ABORT_FLOOR_MS = 15 * 60_000;
-
-// Default quiet-run reclaim window for steer/takeover. Evidence clocks stay local.
-export const RUN_STALE_TAKEOVER_MS = 10 * 60_000;
-
-// Quiet-but-alive tool phases and CLI-owned background work get the blocked-tool
-// floor so a human message cannot reclaim work that recovery would not touch yet.
-export function resolveRunStaleThresholdMs(
-  activity: Pick<
-    DiagnosticSessionActivitySnapshot,
-    "activeWorkKind" | "hasOutstandingBackgroundWork"
-  >,
-): number {
-  return activity.activeWorkKind === "tool_call" || activity.hasOutstandingBackgroundWork === true
-    ? Math.max(RUN_STALE_TAKEOVER_MS, BLOCKED_TOOL_CALL_ABORT_FLOOR_MS)
-    : RUN_STALE_TAKEOVER_MS;
-}
+export {
+  BLOCKED_TOOL_CALL_ABORT_FLOOR_MS,
+  resolveRunStaleThresholdMs,
+  RUN_STALE_TAKEOVER_MS,
+} from "./diagnostic-run-stale-threshold.js";
 
 const activityByRef = new Map<string, SessionActivity>();
 const activityByRunId = new Map<string, SessionActivity>();
@@ -115,26 +106,13 @@ const activeDiagnosticOwners = new Map<
 const closedDiagnosticOwnerGenerations = new WeakSet<CoreModelRequestOwnerGeneration>();
 let embeddedRunSequence = 0;
 
-function sessionRefs(params: { sessionId?: string; sessionKey?: string }): string[] {
-  const refs: string[] = [];
-  const sessionId = params.sessionId?.trim();
-  const sessionKey = params.sessionKey?.trim();
-  if (sessionId) {
-    refs.push(`id:${sessionId}`);
-  }
-  if (sessionKey) {
-    refs.push(`key:${sessionKey}`);
-  }
-  return refs;
-}
-
 function registerSessionActivityRefs(
   activity: SessionActivity,
   params: { sessionId?: string; sessionKey?: string; runId?: string },
 ): void {
   activity.sessionId ??= params.sessionId;
   activity.sessionKey ??= params.sessionKey;
-  for (const ref of sessionRefs(params)) {
+  for (const ref of diagnosticSessionActivityRefs(params)) {
     activityByRef.set(ref, activity);
   }
   if (params.runId) {
@@ -215,7 +193,7 @@ function resolveSessionActivity(params: {
     }
   }
 
-  for (const ref of sessionRefs(params)) {
+  for (const ref of diagnosticSessionActivityRefs(params)) {
     const byRef = activityByRef.get(ref);
     if (!byRef) {
       continue;
@@ -265,29 +243,13 @@ function touchSemanticSessionActivity(
   touchSessionActivity(activity, reason, params.now);
 }
 
-function toolKey(event: {
-  runId?: string;
-  sessionId?: string;
-  sessionKey?: string;
-  toolCallId?: string;
-  toolName: string;
-}): string {
-  return `${event.runId ?? event.sessionId ?? event.sessionKey ?? "unknown"}:${
-    event.toolCallId ?? event.toolName
-  }`;
-}
-
-function modelCallKey(event: { runId?: string; provider?: string; model?: string }): string {
-  return `${event.runId ?? "unknown"}:${event.provider ?? "provider"}:${event.model ?? "model"}`;
-}
-
 function recordToolStarted(event: DiagnosticToolStartedActivityEvent): void {
   const activity = resolveSessionActivity({ ...event, create: true });
   if (!activity || shouldIgnoreRecoveredOwnerStartEvent(activity, event)) {
     return;
   }
   const now = Date.now();
-  activity.activeTools.set(toolKey(event), {
+  activity.activeTools.set(diagnosticToolKey(event), {
     runId: event.runId,
     sessionId: event.sessionId,
     sessionKey: event.sessionKey,
@@ -310,7 +272,7 @@ function recordToolEnded(
   if (!activity) {
     return;
   }
-  activity.activeTools.delete(toolKey(event));
+  activity.activeTools.delete(diagnosticToolKey(event));
   touchSessionActivity(activity, `tool:${event.toolName}:ended`);
 }
 
@@ -362,7 +324,7 @@ function recordModelStarted(
   if (coreRequestForTest) {
     recordRepeatedRequestObservation(activity, activity.activeEmbeddedRuns.values(), event);
   }
-  activity.activeModelCalls.set(modelCallKey(event), {
+  activity.activeModelCalls.set(diagnosticModelCallKey(event), {
     runId: event.runId,
     sessionId: event.sessionId,
     sessionKey: event.sessionKey,
@@ -389,7 +351,7 @@ function recordModelEnded(
       Object.is(ownerActivity, activity),
     )
   ) {
-    activity.activeModelCalls.delete(modelCallKey(event));
+    activity.activeModelCalls.delete(diagnosticModelCallKey(event));
     return;
   }
   if (provenance?.phase === "ended" && registration) {
@@ -403,7 +365,7 @@ function recordModelEnded(
     touchSessionActivity(activity, "model_call:ended");
     return;
   }
-  activity.activeModelCalls.delete(modelCallKey(event));
+  activity.activeModelCalls.delete(diagnosticModelCallKey(event));
   touchSessionActivity(activity, "model_call:ended");
 }
 
@@ -425,19 +387,11 @@ export function markDiagnosticOutstandingBackgroundWork(params: {
   sessionKey?: string;
   outstanding: boolean;
 }): void {
-  const runId = params.runId.trim();
-  if (!runId) {
-    return;
-  }
-  const activity = resolveSessionActivity({ ...params, runId, create: params.outstanding });
-  if (!activity) {
-    return;
-  }
-  if (params.outstanding) {
-    activity.outstandingBackgroundWorkRunId = runId;
-  } else if (activity.outstandingBackgroundWorkRunId === runId) {
-    activity.outstandingBackgroundWorkRunId = undefined;
-  }
+  recordDiagnosticOutstandingBackgroundWork(
+    params,
+    ({ runId, sessionId, sessionKey, outstanding }) =>
+      resolveSessionActivity({ runId, sessionId, sessionKey, create: outstanding }),
+  );
 }
 
 function applyRunProgress(params: RunProgressEvent, semantic = false): void {
@@ -598,10 +552,6 @@ export function markDiagnosticEmbeddedRunEnded(params: {
     clearArgumentChurnPolicyWaits(activity);
   }
   touchSessionActivity(activity, "embedded_run:ended"); // Retained retry evidence is inert here.
-}
-
-function resolveEmbeddedRunWorkKey(params: { sessionId: string; workKey?: string }): string {
-  return params.workKey ?? params.sessionId;
 }
 
 // Reconciles a session's terminal embedded-run activity at once. Used when an

--- a/src/logging/diagnostic-run-stale-threshold.ts
+++ b/src/logging/diagnostic-run-stale-threshold.ts
@@ -1,0 +1,23 @@
+import type { DiagnosticSessionActivitySnapshot } from "./diagnostic-run-activity-snapshot.js";
+
+// Quiet-but-alive tools are normal agent behavior; the CLI byte watchdog kills
+// truly silent children within its own deadline. This floor bounds every
+// staleness consumer (diagnostic recovery aborts, reply-run stale takeover,
+// steer gates): lowering it reopens #88870, removing it reopens #96168.
+export const BLOCKED_TOOL_CALL_ABORT_FLOOR_MS = 15 * 60_000;
+
+// Default quiet-run reclaim window for steer/takeover. Evidence clocks stay local.
+export const RUN_STALE_TAKEOVER_MS = 10 * 60_000;
+
+// Quiet-but-alive tool phases and CLI-owned background work get the blocked-tool
+// floor so a human message cannot reclaim work that recovery would not touch yet.
+export function resolveRunStaleThresholdMs(
+  activity: Pick<
+    DiagnosticSessionActivitySnapshot,
+    "activeWorkKind" | "hasOutstandingBackgroundWork"
+  >,
+): number {
+  return activity.activeWorkKind === "tool_call" || activity.hasOutstandingBackgroundWork === true
+    ? Math.max(RUN_STALE_TAKEOVER_MS, BLOCKED_TOOL_CALL_ABORT_FLOOR_MS)
+    : RUN_STALE_TAKEOVER_MS;
+}

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -1213,11 +1213,17 @@ describe("stuck session diagnostics threshold", () => {
       "ageMs",
       "stateGeneration",
     ]);
+  });
+
   it("keeps a quiet model call alive while its CLI background child is outstanding", () => {
     const recoverStuckSession = vi.fn();
     const refs = { sessionId: "s1", sessionKey: "main", runId: "background-run" };
     startDiagnosticHeartbeat({ diagnostics: { enabled: true } }, { recoverStuckSession });
-    logSessionStateChange({ sessionId: refs.sessionId, sessionKey: refs.sessionKey, state: "processing" });
+    logSessionStateChange({
+      sessionId: refs.sessionId,
+      sessionKey: refs.sessionKey,
+      state: "processing",
+    });
     markDiagnosticEmbeddedRunStarted(refs);
     markDiagnosticModelStartedForTest({
       ...refs,
@@ -1239,7 +1245,12 @@ describe("stuck session diagnostics threshold", () => {
 
     expectRecoveryCall(
       recoverStuckSession,
-      { sessionId: refs.sessionId, sessionKey: refs.sessionKey, queueDepth: 0, allowActiveAbort: true },
+      {
+        sessionId: refs.sessionId,
+        sessionKey: refs.sessionKey,
+        queueDepth: 0,
+        allowActiveAbort: true,
+      },
       ["ageMs", "stateGeneration"],
     );
   });

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -21,6 +21,7 @@ import {
   createDiagnosticEmbeddedRunOwner,
   markDiagnosticEmbeddedRunEnded,
   markDiagnosticEmbeddedRunStarted,
+  markDiagnosticOutstandingBackgroundWork,
   resetDiagnosticRunActivityForTest,
   startDiagnosticRunActivityTracking,
 } from "./diagnostic-run-activity.js";
@@ -1212,6 +1213,35 @@ describe("stuck session diagnostics threshold", () => {
       "ageMs",
       "stateGeneration",
     ]);
+  it("keeps a quiet model call alive while its CLI background child is outstanding", () => {
+    const recoverStuckSession = vi.fn();
+    const refs = { sessionId: "s1", sessionKey: "main", runId: "background-run" };
+    startDiagnosticHeartbeat({ diagnostics: { enabled: true } }, { recoverStuckSession });
+    logSessionStateChange({ sessionId: refs.sessionId, sessionKey: refs.sessionKey, state: "processing" });
+    markDiagnosticEmbeddedRunStarted(refs);
+    markDiagnosticModelStartedForTest({
+      ...refs,
+      provider: "anthropic",
+      model: "claude-opus-5",
+    });
+    markDiagnosticOutstandingBackgroundWork({ ...refs, outstanding: true });
+
+    vi.advanceTimersByTime(60_000);
+
+    expect(recoverStuckSession).not.toHaveBeenCalled();
+    expect(getDiagnosticSessionActivitySnapshot(refs)).toMatchObject({
+      activeWorkKind: "model_call",
+      hasOutstandingBackgroundWork: true,
+    });
+
+    markDiagnosticOutstandingBackgroundWork({ ...refs, outstanding: false });
+    vi.advanceTimersByTime(30_000);
+
+    expectRecoveryCall(
+      recoverStuckSession,
+      { sessionId: refs.sessionId, sessionKey: refs.sessionKey, queueDepth: 0, allowActiveAbort: true },
+      ["ageMs", "stateGeneration"],
+    );
   });
 
   it("recovers stale model calls without active embedded-run ownership", async () => {

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -526,10 +526,13 @@ function isStalledModelCallRecoveryEligible(params: {
   const effectiveAbortMs = Math.max(
     params.stuckSessionAbortMs,
     params.activity?.activeModelCallRequestTimeoutMs ?? 0,
+    params.activity?.hasOutstandingBackgroundWork ? BLOCKED_TOOL_CALL_ABORT_FLOOR_MS : 0,
   );
   // Local providers are not blanket-exempt from recovery. Streaming model
   // chunks refresh run activity while emitted progress events are throttled, so
   // active streams stay fresh and silent/non-streaming calls can be recovered.
+  // A CLI-owned child is the exception: its parent stays quiet while the child
+  // works, so preserve the same floor used by stale-takeover consumers.
   return (
     params.classification?.eventType === "session.stalled" &&
     params.classification.classification === "stalled_agent_run" &&

--- a/src/plugin-sdk/cli-backend.ts
+++ b/src/plugin-sdk/cli-backend.ts
@@ -3,6 +3,7 @@
  */
 export type {
   CliBackendAuthEpochMode,
+  CliBackendBackgroundWorkLiveness,
   CliBackendConfig,
   CliBackendExecute,
   CliBackendExecuteContext,

--- a/src/plugins/cli-backend.types.ts
+++ b/src/plugins/cli-backend.types.ts
@@ -225,6 +225,11 @@ export type CliBackendLiveSessionCapability = {
   remove(handle: CliBackendLiveSessionHandle): void;
 };
 
+/** Plugin-owned fact about whether backend-native work retains the admitted turn. */
+export type CliBackendBackgroundWorkLiveness = Readonly<{
+  outstanding: boolean;
+}>;
+
 /** Exact prepared local process facts consumed by a plugin-owned execution transport. */
 export type CliBackendExecuteContext = {
   command: string;
@@ -242,6 +247,8 @@ export type CliBackendExecuteContext = {
   toolAvailability?: CliBackendToolAvailability;
   /** Exact host-owned reusable process lifecycle and current-turn admission. */
   liveSession?: CliBackendLiveSessionCapability;
+  /** Reports plugin-owned background-work liveness; the host records this fact without parsing vendor events. */
+  reportBackgroundWorkLiveness?: (fact: CliBackendBackgroundWorkLiveness) => void;
   /** Closure-bound approval capability; retained copies fail after the run closes. */
   requestToolPermission: (
     request: CliBackendToolPermissionRequest,


### PR DESCRIPTION
Fixes #118386

## What Problem This Solves

A healthy Claude CLI parent can be quiet while a `local_agent` or `local_workflow` child is still producing its answer. Before this PR, diagnostic recovery could treat that parent as stalled at the configured timeout and abort the whole turn, losing completed child work.

## Why This Change Was Made

The Agent SDK already owns the vendor-specific decision about which
`background_tasks_changed` records retain a turn. Core had duplicated that
classifier, including a different task-id normalization, so the two paths could
disagree.

This revision adds one typed, generic `reportBackgroundWorkLiveness({
 outstanding })` callback to the existing CLI-backend execution context.
`extensions/anthropic/agent-sdk.runtime.ts` emits its already-owned result-
holding state through that callback. `executePluginOwnedProcess` records only
the generic fact for the admitted diagnostic run, fences retained callbacks at
terminal teardown, and clears the run-owned fact on every terminal path. Core
still counts opaque task records only for its existing no-output watchdog; it
no longer interprets Anthropic task types or ids for diagnostic recovery.

The existing 15-minute `BLOCKED_TOOL_CALL_ABORT_FLOOR_MS` policy is unchanged:
it applies only while the plugin reports outstanding work. Ordinary quiet model
calls still recover at their configured `stuckSessionAbortMs`.

## User Impact

Claude turns waiting on a result-holding background child keep the existing
15-minute recovery floor. Equivalent ordinary quiet turns remain recoverable at
the configured timeout, and terminal/cancelled turns cannot leak that floor
into a later run.

## Evidence

Verified on exact head [`1496eea30d0bc853cdc6e9d3d8f24f32e5a877ef`](https://github.com/MoerAI/openclaw/commit/1496eea30d0bc853cdc6e9d3d8f24f32e5a877ef).

### Typed-seam RED -> GREEN

The new host regression was red before the seam: a plugin-reported `outstanding:
true` fact plus an opaque empty task list left diagnostic activity empty. The
same focused test is green after the host records only the typed fact. A second
RED case showed a retained callback could recreate liveness after terminal
cleanup; the final host callback is now closure-fenced and its regression is
green.

### Redacted exact-head runtime trace

The current Agent SDK runtime executes these real production transitions with a
controlled SDK message stream (all task ids and model text redacted):

```text
system.background_tasks_changed [{ task_type: local_agent, task_id: <redacted> }]
  -> Anthropic runtime reports { outstanding: true }
result (provisional) -> live turn remains open
system.background_tasks_changed []
  -> Anthropic runtime reports { outstanding: false }
result (background answer) -> turn completes
abort while outstanding -> Anthropic runtime reports { outstanding: false }
```

`extensions/anthropic/agent-sdk.runtime.test.ts` covers both `local_agent`
(including the SDK's non-trimmed task-id contract) and `local_workflow`,
provisional-result retention, empty-list recovery, and abort cleanup.

A separate exact-head plain-Node trace ran the real
`executePluginOwnedProcess` and real 30-second diagnostic heartbeat. It
recorded a plugin fact for `trace-protected` and left an otherwise identical
`trace-ordinary` turn quiet:

```json
{
  "pluginReportedOutstanding": true,
  "firstRealHeartbeatRecovered": ["trace-ordinary"],
  "protectedRecovered": false,
  "terminalSnapshotHasOutstandingBackgroundWork": false
}
```

This proves the complete host record -> diagnostic recovery -> terminal cleanup
path without relying on a stale Claude-live producer. One configured exact-head
Agent SDK run was attempted through `openclaw agent exec --isolated
--no-auth-env-only --model claude-cli/claude-sonnet-4-6`: the production host
logged `cli live session start`, then the configured Claude OAuth route failed
before any background-child event with `Failed to authenticate: OAuth session
expired and could not be refreshed`. No live background-child proof is claimed
while that credential condition persists; the deterministic Agent SDK stream
and the real host/heartbeat trace above remain the available exact-head proof.

### Validation

- Focused Claude/host/diagnostic/reply tests: 257 passed across 4 Vitest shards.
- Historical failing Codex shard: 412/412 passed across 11 files, including `preserves post-tool budget for native tool completion buffered during turn start`.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 pnpm check:changed --base upstream/main --head HEAD --timed -- $(git diff --name-only upstream/main...HEAD)`: passed core, core-test, extension, extension-test, and docs lanes, including typechecks, changed-file lint/format, SDK export/surface checks, dead exports, import cycles, and policy guards.
- `pnpm build`: passed.
- `node scripts/check-cli-startup-memory.mjs`: passed; `plugins list --json` median max RSS 242.6 MB (500 MB limit).
- Fresh Codex autoreview against `upstream/main`: no accepted/actionable findings.

Diff audit against frozen `upstream/main`: production `+210/-73` (net `+137`); tests `+195/-3`; docs `+9/-5`. The corrective commit itself is production `+55/-33` (net `+22`), tests `+51/-40`, and docs `+9/-5`; that net production growth is the documented public CLI-backend liveness contract and removal of the duplicate Anthropic classifier from core.

AI-assisted; reviewed line-by-line.
