### PR TITLE
fix(slack): clean up partially started native streams

### DIFF
--- a/extensions/slack/src/streaming.test.ts
+++ b/extensions/slack/src/streaming.test.ts
@@ -370,6 +370,64 @@ describe("stopSlackStream finalize error handling", () => {
     expect(alreadyDelivered.stopped).toBe(false);
   });
 
+  it("finalizes a stream started during failed stop after fallback delivery", async () => {
+    const streamTs = "1700000000.500300";
+    const startStream = vi.fn(async () => ({ ok: true, ts: streamTs }));
+    const stopStream = vi
+      .fn()
+      .mockRejectedValueOnce(slackApiError("user_not_found"))
+      .mockResolvedValueOnce({ ok: true, ts: streamTs });
+    const client = {
+      chat: {
+        startStream,
+        appendStream: vi.fn(async () => ({ ok: true })),
+        stopStream,
+      },
+    };
+    const streamer = new ChatStreamer(
+      client as never,
+      { debug: vi.fn() } as never,
+      {
+        channel: "C123",
+        thread_ts: "1700000000.000100",
+      },
+      { buffer_size: 256 },
+    );
+    const session: SlackStreamSession = {
+      streamer,
+      channel: "C123",
+      threadTs: "1700000000.000100",
+      stopped: false,
+      delivered: false,
+      pendingText: "",
+    };
+    const metadata = { event_type: "openclaw.reply", event_payload: { turn: "qa" } };
+
+    await appendSlackStream({ session, text: "short buffered reply" });
+    await expect(stopSlackStream({ session, metadata })).rejects.toBeInstanceOf(
+      SlackStreamNotDeliveredError,
+    );
+    expect(streamer.ts).toBe(streamTs);
+    expect(session.delivered).toBe(false);
+
+    markSlackStreamFallbackDelivered(session);
+    expect(session.stopped).toBe(false);
+    await expect(stopSlackStream({ session, metadata })).resolves.toEqual({ messageId: streamTs });
+
+    expect(startStream).toHaveBeenCalledOnce();
+    expect(stopStream).toHaveBeenCalledTimes(2);
+    expect(stopStream).toHaveBeenNthCalledWith(2, {
+      token: undefined,
+      channel: "C123",
+      ts: streamTs,
+      chunks: [],
+      metadata,
+    });
+    expect(session.stopped).toBe(true);
+    expect(session.delivered).toBe(true);
+    expect(session.pendingText).toBe("");
+  });
+
   it("clears the SDK buffer before finalizing an already-visible fallback stream", async () => {
     const startStream = vi.fn(async () => ({ ok: true, ts: "1700000000.500300" }));
     const stopStream = vi.fn(async () => ({ ok: true, ts: "1700000000.500300" }));

--- a/extensions/slack/src/streaming.ts
+++ b/extensions/slack/src/streaming.ts
@@ -371,7 +371,7 @@ function extractSlackErrorCode(err: unknown): string | undefined {
 }
 
 export function markSlackStreamFallbackDelivered(session: SlackStreamSession): void {
-  const nativeStreamWasStarted = session.delivered;
+  const nativeStreamWasStarted = session.delivered || Boolean(session.streamer.ts);
   session.pendingText = "";
   // @slack/web-api 7.16.0 retains its private buffer after a failed flush.
   // Clear fallback-owned text before retrying stop(), or the SDK resends it.


### PR DESCRIPTION
## Summary\n- Recognize an already allocated native Slack stream even when its first stop request fails before delivery bookkeeping.\n- Retry stream cleanup after the normal fallback without duplicating text or losing metadata.\n- Preserve streams that never started and existing fallback behavior without increasing production lines.\n\n## Verification\n- Actual installed Slack Web API ChatStreamer first reproduced one allocated stream and a failed stop with no cleanup.\n- After the fix the same stream receives a safe second stop with no duplicate chunks and no orphan.\n- Complete focused Slack streaming suite: 24 passed.\n- Independent structured autoreview: clean, confidence 0.99.