### PR TITLE
fix(agents): prevent hosted tools during conversation compaction

### DIFF
--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -919,6 +919,8 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       expectRecordFields(mockCallArg(applyExtraParamsToAgentMock, 0, 11), {
         nativeWebSearchPolicyContext: {
           sessionKey: undefined,
+          webSearchEnabled: false,
+          runtimeToolAllowlist: [],
           sandboxToolPolicy: undefined,
           messageProvider: undefined,
           agentAccountId: undefined,

--- a/src/agents/embedded-agent-runner/compaction-session-agent.ts
+++ b/src/agents/embedded-agent-runner/compaction-session-agent.ts
@@ -42,7 +42,6 @@ export async function prepareCompactionSessionAgent(params: {
   senderName?: string | null;
   senderUsername?: string | null;
   senderE164?: string | null;
-  webSearchEnabled?: boolean;
 }) {
   const authStorage =
     params.authStorage &&
@@ -107,10 +106,11 @@ export async function prepareCompactionSessionAgent(params: {
     {
       ...(preparedRuntimeExtraParams ? { preparedExtraParams: preparedRuntimeExtraParams } : {}),
       nativeWebSearchPolicyContext: {
-        // Compaction rebuilds the stream wrapper, so preserve the session policy
-        // inputs that can suppress provider-native search.
+        // Summaries have no tool loop; provider-hosted tools must not inherit
+        // the originating conversation's broader web-search authority.
         sessionKey: params.sessionKey,
-        webSearchEnabled: params.webSearchEnabled,
+        webSearchEnabled: false,
+        runtimeToolAllowlist: [],
         sandboxToolPolicy: params.sandboxToolPolicy,
         messageProvider: params.messageProvider,
         agentAccountId: params.agentAccountId,

--- a/src/agents/embedded-agent-runner/compaction-session-execution.ts
+++ b/src/agents/embedded-agent-runner/compaction-session-execution.ts
@@ -284,7 +284,6 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
             senderName: params.senderName,
             senderUsername: params.senderUsername,
             senderE164: params.senderE164,
-            webSearchEnabled: params.toolOverrides?.webSearch !== false,
           });
           session.agent.streamFn = wrapStreamFnWithDiagnosticModelCallEvents(
             session.agent.streamFn,


### PR DESCRIPTION
## Summary
- Explicitly prohibit provider-hosted tools while generating inherently tool-free conversation compaction summaries.
- Prevent native OpenAI web search from being injected into background compaction when no tools were authorized.
- Remove the obsolete compaction web-search passthrough while preserving authorized foreground web search.

## Exact-head real SDK request proof
Reviewed head: f89a4c943e4aaa061c5731bd4f78221d066aa5ea.

Actual installed OpenAI SDK request serialization against an in-memory recording transport, with no external requests or credentials:

```json
{"actualSdkPath":["/v1/responses","/v1/responses","/v1/responses"],"requestedContextTools":[],"foregroundDeniedTools":[],"foregroundAllowedTools":[{"type":"web_search"}],"compactionTools":[],"fakeFetchCalls":3,"externalRequests":0,"toolFreeCompactionEnforced":true}
```

The same real OpenAI provider permits foreground web search when explicitly authorized, denies foreground search without permission, and sends no hosted search tool during compaction.

Installed dependency source inspected directly: node_modules/openai/resources/responses/responses.mjs:15-21 and node_modules/openai/resources/responses/responses.d.mts:6880-6908.

The sibling Codex-source gate is not applicable: this change touches ordinary OpenAI Platform Responses provider-native tools and the installed OpenAI SDK, not Codex CLI/app-server protocol, runtime, harness, or provider behavior.

## Verification
- Focused compaction and provider-runtime suites: 133 passed.
- Independent structured security autoreview: clean, confidence 0.99.
- Maintainer decision: compaction is inherently tool-free and must never initiate hosted network tools.
- Separate branch-summary behavior is outside this owner-scoped fix and requires its own follow-up.
- Production-code delta: -1 line.