### PR TITLE
fix(pdf): surface image-render failures when documents have no text

### DIFF
--- a/extensions/document-extract/document-extractor.test.ts
+++ b/extensions/document-extract/document-extractor.test.ts
@@ -159,8 +159,9 @@ describe("PDF document extractor", () => {
       .mockResolvedValueOnce({ text: "", images: [] });
     const extractor = createPdfDocumentExtractor();
 
-    await extractor.extract(request({ pageNumbers: [3, 2, 0, 1], maxPages: 2 }));
+    const result = await extractor.extract(request({ pageNumbers: [3, 2, 0, 1], maxPages: 2 }));
 
+    expect(result).toEqual({ text: "", images: [] });
     expect(pdfDocument.extract).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({ mode: "text", pages: [2, 1] }),
@@ -187,6 +188,27 @@ describe("PDF document extractor", () => {
 
     expect(result).toEqual({ text: "short", images: [] });
     expect(onImageExtractionError).toHaveBeenCalledWith(failure);
+    expect(pdfDocument.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    { label: "empty", text: "", reportError: true },
+    { label: "whitespace-only", text: " \t\n", reportError: false },
+  ])("surfaces image fallback failures for $label PDF text", async ({ text, reportError }) => {
+    const { PdfBudgetError } = await vi.importActual<typeof import("clawpdf")>("clawpdf");
+    const onImageExtractionError = vi.fn();
+    const failure = new PdfBudgetError("renderPixels", 100);
+    pdfDocument.extract.mockResolvedValueOnce({ text, images: [] }).mockRejectedValueOnce(failure);
+    const overrides = reportError ? { onImageExtractionError } : {};
+
+    await expect(createPdfDocumentExtractor().extract(request(overrides))).rejects.toMatchObject({
+      message: "PDF image extraction failed with no extractable text.",
+      cause: failure,
+    });
+    expect(onImageExtractionError).toHaveBeenCalledTimes(reportError ? 1 : 0);
+    if (reportError) {
+      expect(onImageExtractionError).toHaveBeenCalledWith(failure);
+    }
     expect(pdfDocument.destroy).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/document-extract/document-extractor.ts
+++ b/extensions/document-extract/document-extractor.ts
@@ -116,6 +116,9 @@ async function extractPdfContent(
       return { text, images };
     } catch (err) {
       request.onImageExtractionError?.(err);
+      if (!text.trim()) {
+        throw new Error("PDF image extraction failed with no extractable text.", { cause: err });
+      }
       return { text, images: [] };
     }
   } finally {


### PR DESCRIPTION
## Summary
- Surface an actionable error when PDF image rendering fails and text extraction produced no usable document content.
- Preserve the original PDFium/clawpdf rendering error as the error cause while invoking the existing error callback exactly once.
- Preserve successful empty-document extraction and the existing nonempty-text graceful fallback.

## Exact-head inspectable real PDFium terminal transcript
Reviewed head: 5d165d4516d084b19f12bf0b73ca2ac38848044c.

Command: `node --import tsx --input-type=module -e '<in-memory scanned PDF; genuine installed clawpdf/PDFium; normal and constrained engines; patched owner callback parity>'`

Actual unmodified PDFium rendering used a valid 677-byte scanned image-XObject PDF generated entirely in memory. No renderer mocks, network, provider, credentials, fixture files, or repository mutations were used. The constrained real engine used `createEngine({maxRenderPixels:1})`.

Literal redacted stdout:

```json
{
  "head": "5d165d4516d084b19f12bf0b73ca2ac38848044c",
  "dependency": "clawpdf@0.3.0",
  "pdfiumRelease": "7623",
  "pdfBytes": 677,
  "imageOnlyText": "",
  "normalPdfiumRender": {"imageCount":1,"mimeType":"image/png","width":10,"height":10},
  "constrainedActualError": {"name":"PdfBudgetError","code":"budget","limit":"renderPixels","value":100,"message":"Rendered page has 100 pixels; limit is 1"},
  "patchedOwnerWithCallback": {"message":"PDF image extraction failed with no extractable text.","causeName":"PdfBudgetError","causeCode":"budget","causeLimit":"renderPixels","callbackCount":1,"callbackReceivedOriginalCause":true},
  "patchedOwnerWithoutCallback": {"message":"PDF image extraction failed with no extractable text.","causeName":"PdfBudgetError","sameFailClosedBehavior":true,"callbackCountUnchanged":true}
}
```

Exact-head focused owner regression transcript:

```text
$ node scripts/run-vitest.mjs extensions/document-extract/document-extractor.test.ts
[test] starting test/vitest/vitest.extensions.config.ts

 RUN  v4.1.10 <isolated exact-head checkout>

 Test Files  1 passed (1)
      Tests  9 passed (9)
   Duration  756ms (transform 434ms, setup 358ms, import 7ms, tests 289ms, environment 0ms)

[test] passed 1 Vitest shard in 4.44s
```

## Verification
- Deterministic red-before-green owner regressions reproduced both empty and whitespace-only text failures.
- Real installed clawpdf/PDFium successfully rendered the image-only document normally, then produced the actual renderer-budget failure under the constrained engine.
- Both callback-present and callback-absent production owner paths now surface the visible error; the original PdfBudgetError is preserved as cause.
- Successful empty PDFs and nonempty-text fallback remain unchanged.
- Independent structured security review: clean, confidence 0.98.
- Required exact-head CI gate: passed.
- Production-code delta: +3 lines for the concrete no-silent-empty-content invariant.