### PR TITLE
fix(slack,mattermost): preserve thread participation expiry across restarts

### DIFF
--- a/extensions/mattermost/src/mattermost/thread-participation.test.ts
+++ b/extensions/mattermost/src/mattermost/thread-participation.test.ts
@@ -49,6 +49,7 @@ describe("mattermost thread participation", () => {
   afterEach(() => {
     threadParticipationMemory.clear();
     resetPluginStateStoreForTests();
+    vi.restoreAllMocks();
   });
 
   it("remembers a thread the bot replied in", async () => {
@@ -85,10 +86,13 @@ describe("mattermost thread participation", () => {
     ).resolves.toBe(false);
   });
 
-  it("recovers participation from the persistent store after the in-memory cache is lost", async () => {
+  it("restores participation after a restart without extending its original expiry", async () => {
+    const repliedAt = 1_711_406_400_000;
+    const now = vi.spyOn(Date, "now").mockReturnValue(repliedAt);
     recordMattermostThreadParticipation("acct", "chan", "root-1");
     await flush();
-    // Simulate a restart: in-memory cache cleared, persistent SQLite store intact.
+    now.mockReturnValue(repliedAt + 7 * 24 * 60 * 60 * 1000 - 1000);
+    // Simulate a restart near expiry: memory is lost, but the SQLite row is still valid.
     threadParticipationMemory.clear();
     await expect(
       hasMattermostThreadParticipationWithPersistence({
@@ -97,6 +101,15 @@ describe("mattermost thread participation", () => {
         threadRootId: "root-1",
       }),
     ).resolves.toBe(true);
+
+    now.mockReturnValue(repliedAt + 7 * 24 * 60 * 60 * 1000 + 1000);
+    await expect(
+      hasMattermostThreadParticipationWithPersistence({
+        accountId: "acct",
+        channelId: "chan",
+        threadRootId: "root-1",
+      }),
+    ).resolves.toBe(false);
   });
 
   it("degrades to in-memory only when the persistent store fails", async () => {

--- a/extensions/mattermost/src/mattermost/thread-participation.ts
+++ b/extensions/mattermost/src/mattermost/thread-participation.ts
@@ -37,6 +37,8 @@ const threadParticipation = createPersistentDedupeCache<MattermostThreadParticip
       "thread-participation-state",
       "Mattermost persistent thread participation state failed",
     ),
+    // Restoring participation must not extend its original mention-bypass window.
+    readTimestamp: ({ repliedAt }) => repliedAt,
   },
 });
 

--- a/extensions/slack/src/sent-thread-cache.test.ts
+++ b/extensions/slack/src/sent-thread-cache.test.ts
@@ -93,9 +93,14 @@ describe("slack sent-thread-cache", () => {
     expect(hasSlackThreadParticipation("A1", "C123", "1700000000.005000")).toBe(true);
   });
 
-  it("writes and reads persistent thread participation when runtime state is available", async () => {
+  it("restores persistent thread participation without extending its original expiry", async () => {
+    const repliedAt = 1_711_406_400_000;
+    const ttlMs = 24 * 60 * 60 * 1000;
+    const now = vi.spyOn(Date, "now").mockReturnValue(repliedAt);
     const register = vi.fn().mockResolvedValue(undefined);
-    const lookup = vi.fn().mockResolvedValue({ repliedAt: 123 });
+    const lookup = vi
+      .fn()
+      .mockImplementation(async () => (Date.now() < repliedAt + ttlMs ? { repliedAt } : undefined));
     const openKeyedStore = vi.fn(() => ({
       register,
       lookup,
@@ -109,14 +114,14 @@ describe("slack sent-thread-cache", () => {
       logging: { getChildLogger: () => ({ warn: vi.fn() }) },
     } as never);
 
-    vi.spyOn(Date, "now").mockReturnValue(1_711_406_400_000);
     recordSlackThreadParticipation("A1", "C123", "1700000000.000002");
 
     await vi.waitFor(() => expect(register).toHaveBeenCalledTimes(1));
     expect(register).toHaveBeenCalledWith("A1:C123:1700000000.000002", {
-      repliedAt: 1_711_406_400_000,
+      repliedAt,
     });
 
+    now.mockReturnValue(repliedAt + ttlMs - 1000);
     clearSlackThreadParticipationCache();
     await expect(
       hasSlackThreadParticipationWithPersistence({
@@ -137,6 +142,16 @@ describe("slack sent-thread-cache", () => {
       }),
     ).resolves.toBe(true);
     expect(lookup).not.toHaveBeenCalled();
+
+    now.mockReturnValue(repliedAt + ttlMs + 1000);
+    await expect(
+      hasSlackThreadParticipationWithPersistence({
+        accountId: "A1",
+        channelId: "C123",
+        threadTs: "1700000000.000002",
+      }),
+    ).resolves.toBe(false);
+    expect(lookup).toHaveBeenCalledWith("A1:C123:1700000000.000002");
   });
 
   it("falls back to in-memory thread participation when persistent state cannot open", async () => {

--- a/extensions/slack/src/sent-thread-cache.ts
+++ b/extensions/slack/src/sent-thread-cache.ts
@@ -37,6 +37,8 @@ const threadParticipation = createPersistentDedupeCache<SlackThreadParticipation
       "thread-participation-state",
       "Slack persistent thread participation state failed",
     ),
+    // Restoring participation must not extend its original mention-bypass window.
+    readTimestamp: ({ repliedAt }) => repliedAt,
   },
 });
 


### PR DESCRIPTION
## What problem this solves

After a gateway restart, Mattermost and Slack restored a persisted thread-participation record using the restart time instead of the time when the bot actually last replied. A restart immediately before expiry therefore silently granted almost another seven days of Mattermost mention/onchar bypass or another 24 hours of Slack mention bypass.

Both defects are present in stable `v2026.7.1` and `v2026.7.2-beta.7`. Mattermost explicitly documents that participation lasts seven days after the bot last replied and survives gateway restarts.

## Why this change was made

Each plugin's participation owner now supplies its already-persisted `repliedAt` timestamp to the existing shared persistent-dedupe `readTimestamp` contract. This is the same contract already used by the Microsoft Teams sent-message owner; no shared SDK, storage schema, account policy, configuration, compatibility fallback, or dependency changes are needed.

SQLite already expires the durable row at the original deadline. Restoring process memory with the same original timestamp ensures its memory-first fast path cannot continue accepting an expired participation record after SQLite would reject it.

## User impact

- Mattermost thread participation expires seven days after the actual most recent visible reply, including across gateway restarts.
- Slack thread participation expires 24 hours after the actual most recent reply, including across gateway restarts.
- Existing account, channel, thread, enterprise-team, sender allowlist, control-command, and implicit-mention opt-out policies remain unchanged. Only mention/onchar activation timing changes.

## Evidence

- Exact candidate `85f74ae2ff237f268dd46cbed5fdf32012b8b7de`; sole parent `c53e594aae79690d7bc809157c904a5ecd745190`; complete approved four-file binary diff SHA-256 `622ca7b45cadc8cb05c04e9734a4d90432a2476d0bae30101359f0e0494d035c`.
- Tests first: the unchanged parent independently failed **both actual-owner/shared-SQLite physical policy proofs** and **both committed focused owner regressions**; Mattermost and Slack each incorrectly retained participation and implicit activation after the original deadline.
- Exact candidate focused verification: **16/16** existing owner tests passed across both sequential plugin shards: **5 Mattermost** and **11 Slack**.
- The complete unmodified exact-four changed-code gate, owner typechecks, formatting, lint, repository guards, and `git diff --check` passed on the immutable candidate.
- Four independently authenticated hostile P0–P3 reviews reported zero findings across SDK/SQLite, Mattermost policy, Slack enterprise/account boundaries, and CI/release/current-main ownership.
- One distinct genuine official Codex `gpt-5.6-sol` / high / P3 review reported zero findings and **0.96** confidence; checksum-authenticated native TruffleHog **3.96.0** passed.
- Two additional fresh independent complete source-only reviews authenticated the final frozen external runner, physical-owner probe, lease freshness guards, RED/GREEN orchestration, exact focused routing, and complete changed-code gate; both reported zero P0–P3 findings before the root-owned remote execution passed.
- Both defects and the existing shared timestamp contract are present in the stable and beta release trees; the unchanged Microsoft Teams sibling already consumes that contract correctly.
- Latest root-refreshed canonical `main` and `origin/main` `fe6fa891ea4ef3bb152d02df944a8def6518fdd1` leave all four changed files, all relevant scoped policies, all 31 authenticated owner/SDK/SQLite/docs/CI siblings, the frozen lockfile, and the Microsoft Teams sibling unchanged.
- Production delta: **+2 executable lines and +2 required owner-invariant comments**; test delta **+28 net lines**.

## Real behavior proof

Root-owned Blacksmith lease `tbx_01kz3knq0ywxgdtje656h3mhz8` executed the hash-authenticated original-parent and immutable-candidate proofs against the **actual production Slack and Mattermost plugin owners**, canonical persistent-dedupe SDK, real plugin runtime, and **real Kysely-backed shared `state/openclaw.sqlite` plugin-state database**:

1. Each actual plugin owner recorded its authoritative `repliedAt`; a real Kysely query authenticated the exact plugin/account/thread key and original SQLite expiry.
2. The actual shared SQLite handle physically closed at one millisecond before expiry; owner process memory cleared, the database physically reopened, and the owner restored its still-live participation.
3. At the exact original deadline, both unchanged parent owners incorrectly retained participation and both actual mention/ingress policy owners allowed the expired action: **two physical RED proofs**. Both committed focused owner regressions independently failed on the parent: **two regression RED proofs**.
4. The exact candidate correctly expired participation for both plugins and both actual policy owners rejected expired implicit activation: **two physical GREEN proofs**. Account/channel/thread isolation, Slack enterprise-team isolation, Mattermost account-specific implicit-participation opt-out, and real Slack command ingress for allowed versus denied senders all remained intact; **zero external network attempts**.
5. Both sequential focused owner shards passed: **Mattermost 5/5, Slack 11/11, total 16/16**. The complete unmodified exact-four changed-code gate also passed; the authenticated wrapper reported **exit code 0** after **445,500 ms**.

```json
{"proof":"thread-participation-real-owner-sqlite-and-full-gate","candidate":"85f74ae2ff237f268dd46cbed5fdf32012b8b7de","parent":"c53e594aae79690d7bc809157c904a5ecd745190","changedPaths":4,"parentPhysicalRed":2,"parentCommittedRegressionsRed":2,"candidatePhysicalGreen":2,"focusedTests":16,"completeChangedGate":"PASS","externalNetworkAttempts":0}
```

Complete authenticated gate:

```text
node scripts/check-changed.mjs --base c53e594aae79690d7bc809157c904a5ecd745190 --head 85f74ae2ff237f268dd46cbed5fdf32012b8b7de -- extensions/mattermost/src/mattermost/thread-participation.test.ts extensions/mattermost/src/mattermost/thread-participation.ts extensions/slack/src/sent-thread-cache.test.ts extensions/slack/src/sent-thread-cache.ts
```

## Maintainer merge-risk decision

Maintainer decision: accept the documented seven-day Mattermost and 24-hour Slack expiry correction; exact head 85f74ae2ff237f268dd46cbed5fdf32012b8b7de passed both channel-contract shards, all six changed-node shards, channel-runtime-boundary analysis, build artifacts, the complete exact-four changed gate, 16 owner tests, and real parent-RED/candidate-GREEN SQLite restart proofs.

Expired participation must not silently activate a thread after its documented deadline. This changes only activation after genuinely expired participation; account authorization, channel boundaries, the existing durable storage format, schema, and SDK remain unchanged. No database migration or schema-version change is involved.
