### PR TITLE
fix(ui): surface sidebar clipboard failures across reconnects

### DIFF
--- a/ui/src/pages/chat/components/chat-sidebar.test.ts
+++ b/ui/src/pages/chat/components/chat-sidebar.test.ts
@@ -225,7 +225,11 @@ describe("file sidebar clipboard feedback", () => {
     { label: "Copy file contents", value: "const answer = 42;" },
   ];
 
-  type FilePanel = HTMLElement & { content: unknown; updateComplete: Promise<unknown> };
+  type FilePanel = HTMLElement & {
+    content: unknown;
+    ensureFileEditor: () => Promise<void>;
+    updateComplete: Promise<unknown>;
+  };
 
   async function mountFilePanel(): Promise<FilePanel> {
     const panel = document.createElement("openclaw-chat-detail-panel") as FilePanel;
@@ -235,10 +239,7 @@ describe("file sidebar clipboard feedback", () => {
       name: "example.ts",
       content: "const answer = 42;",
     };
-    vi.spyOn(
-      panel as HTMLElement & { ensureFileEditor: () => Promise<void> },
-      "ensureFileEditor",
-    ).mockResolvedValue();
+    vi.spyOn(panel, "ensureFileEditor").mockResolvedValue();
     document.body.append(panel);
     await panel.updateComplete;
     return panel;
@@ -270,6 +271,9 @@ describe("file sidebar clipboard feedback", () => {
         const timerIndex = schedule.mock.calls
           .map(([, timeout], callIndex) => (timeout === delay ? callIndex : -1))
           .filter((callIndex) => callIndex >= 0)[index];
+        if (timerIndex === undefined) {
+          throw new Error(`Missing sidebar clipboard reset timer after ${delay}ms`);
+        }
         const reset = schedule.mock.calls[timerIndex]?.[0];
         if (typeof reset !== "function") {
           throw new Error(`Expected sidebar clipboard reset timer after ${delay}ms`);

--- a/ui/src/pages/chat/components/chat-sidebar.test.ts
+++ b/ui/src/pages/chat/components/chat-sidebar.test.ts
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { openEditor } from "../../../lib/editor-links.ts";
 import { hasUniformLineEndings } from "./chat-sidebar.ts";
 
@@ -216,4 +216,277 @@ describe("markdown sidebar", () => {
     );
     panel.remove();
   });
+});
+
+describe("file sidebar clipboard feedback", () => {
+  const originalExecCommand = Object.getOwnPropertyDescriptor(document, "execCommand");
+  const copyActions = [
+    { label: "Copy path", value: "src/example.ts" },
+    { label: "Copy file contents", value: "const answer = 42;" },
+  ];
+
+  type FilePanel = HTMLElement & { content: unknown; updateComplete: Promise<unknown> };
+
+  async function mountFilePanel(): Promise<FilePanel> {
+    const panel = document.createElement("openclaw-chat-detail-panel") as FilePanel;
+    panel.content = {
+      kind: "file",
+      path: "src/example.ts",
+      name: "example.ts",
+      content: "const answer = 42;",
+    };
+    vi.spyOn(
+      panel as HTMLElement & { ensureFileEditor: () => Promise<void> },
+      "ensureFileEditor",
+    ).mockResolvedValue();
+    document.body.append(panel);
+    await panel.updateComplete;
+    return panel;
+  }
+
+  function findCopyButton(panel: FilePanel, label: string): HTMLButtonElement {
+    const button = Array.from(panel.querySelectorAll<HTMLButtonElement>("button")).find(
+      (candidate) => candidate.getAttribute("aria-label") === label,
+    );
+    if (!button) {
+      throw new Error(`Missing sidebar button: ${label}`);
+    }
+    return button;
+  }
+
+  function denyClipboard() {
+    const writeText = vi.fn().mockRejectedValue(new DOMException("Clipboard access denied"));
+    const execCommand = vi.fn(() => false);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    Object.defineProperty(document, "execCommand", { configurable: true, value: execCommand });
+    return { execCommand, writeText };
+  }
+
+  function captureFeedbackTimers() {
+    const schedule = vi.spyOn(globalThis, "setTimeout");
+    return {
+      schedule,
+      run(delay: number, index = 0) {
+        const timerIndex = schedule.mock.calls
+          .map(([, timeout], callIndex) => (timeout === delay ? callIndex : -1))
+          .filter((callIndex) => callIndex >= 0)[index];
+        const reset = schedule.mock.calls[timerIndex]?.[0];
+        if (typeof reset !== "function") {
+          throw new Error(`Expected sidebar clipboard reset timer after ${delay}ms`);
+        }
+        globalThis.clearTimeout(schedule.mock.results[timerIndex]?.value);
+        reset();
+      },
+    };
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    if (originalExecCommand) {
+      Object.defineProperty(document, "execCommand", originalExecCommand);
+    } else {
+      Reflect.deleteProperty(document, "execCommand");
+    }
+    document.body.replaceChildren();
+  });
+
+  it.each(copyActions)(
+    "shows and resets a visible accessible error when $label fails",
+    async ({ label, value }) => {
+      const { execCommand, writeText } = denyClipboard();
+      const panel = await mountFilePanel();
+      const button = findCopyButton(panel, label);
+      const timers = captureFeedbackTimers();
+
+      button.click();
+      await vi.waitFor(() => expect(button.getAttribute("aria-label")).toBe("Copy failed"));
+
+      expect(writeText).toHaveBeenCalledWith(value);
+      expect(execCommand).toHaveBeenCalledWith("copy");
+      expect(panel.querySelector('[role="alert"]')?.textContent).toContain("Copy failed");
+
+      timers.run(2_000);
+      await panel.updateComplete;
+
+      expect(button.getAttribute("aria-label")).toBe(label);
+      expect(panel.querySelector('[role="alert"]')).toBeNull();
+    },
+  );
+
+  it.each(copyActions)(
+    "preserves and resets successful $label feedback",
+    async ({ label, value }) => {
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      vi.stubGlobal("navigator", { clipboard: { writeText } });
+      const panel = await mountFilePanel();
+      const button = findCopyButton(panel, label);
+      const timers = captureFeedbackTimers();
+
+      button.click();
+      await vi.waitFor(() => expect(button.getAttribute("aria-label")).toBe("Copied!"));
+
+      expect(writeText).toHaveBeenCalledWith(value);
+      expect(button.classList.contains("copied")).toBe(true);
+      expect(panel.querySelector('[role="alert"]')).toBeNull();
+
+      timers.run(1_500);
+      await panel.updateComplete;
+
+      expect(button.getAttribute("aria-label")).toBe(label);
+      expect(button.classList.contains("copied")).toBe(false);
+    },
+  );
+
+  it.each(copyActions)(
+    "ignores an older successful $label attempt after a failed retry",
+    async ({ label }) => {
+      const { writeText } = denyClipboard();
+      let finishFirstCopy = () => {};
+      writeText.mockReturnValueOnce(
+        new Promise<void>((resolve) => {
+          finishFirstCopy = resolve;
+        }),
+      );
+      const panel = await mountFilePanel();
+      const button = findCopyButton(panel, label);
+
+      button.click();
+      button.click();
+      await vi.waitFor(() => expect(button.getAttribute("aria-label")).toBe("Copy failed"));
+      finishFirstCopy();
+      await Promise.resolve();
+      await Promise.resolve();
+      await panel.updateComplete;
+
+      expect(writeText).toHaveBeenCalledTimes(2);
+      expect(button.getAttribute("aria-label")).toBe("Copy failed");
+      expect(panel.querySelector('[role="alert"]')?.textContent).toContain("Copy failed");
+    },
+  );
+
+  it("keeps path and contents feedback reset timers independent", async () => {
+    denyClipboard();
+    const panel = await mountFilePanel();
+    const pathButton = findCopyButton(panel, "Copy path");
+    const contentsButton = findCopyButton(panel, "Copy file contents");
+    const timers = captureFeedbackTimers();
+
+    pathButton.click();
+    contentsButton.click();
+    await vi.waitFor(() => {
+      expect(pathButton.getAttribute("aria-label")).toBe("Copy failed");
+      expect(contentsButton.getAttribute("aria-label")).toBe("Copy failed");
+    });
+
+    timers.run(2_000);
+    await panel.updateComplete;
+    expect(pathButton.getAttribute("aria-label")).toBe("Copy path");
+    expect(contentsButton.getAttribute("aria-label")).toBe("Copy failed");
+    expect(panel.querySelector('[role="alert"]')?.textContent).toContain("Copy failed");
+
+    timers.run(2_000, 1);
+    await panel.updateComplete;
+    expect(contentsButton.getAttribute("aria-label")).toBe("Copy file contents");
+    expect(panel.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it.each(["file selection", "disconnection"])(
+    "ignores a delayed successful copy after %s changes its owner",
+    async (change) => {
+      let finishCopy = () => {};
+      const writeText = vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            finishCopy = resolve;
+          }),
+      );
+      vi.stubGlobal("navigator", { clipboard: { writeText } });
+      const panel = await mountFilePanel();
+      const button = findCopyButton(panel, "Copy file contents");
+      const timers = captureFeedbackTimers();
+
+      button.click();
+      if (change === "file selection") {
+        panel.content = {
+          kind: "file",
+          path: "src/next.ts",
+          name: "next.ts",
+          content: "const next = true;",
+        };
+        await panel.updateComplete;
+      } else {
+        panel.remove();
+      }
+      finishCopy();
+      await Promise.resolve();
+      await Promise.resolve();
+      await panel.updateComplete;
+
+      expect(timers.schedule.mock.calls.some(([, delay]) => delay === 1_500)).toBe(false);
+      expect(button.getAttribute("aria-label")).toBe("Copy file contents");
+      expect(panel.querySelector('[role="alert"]')).toBeNull();
+    },
+  );
+
+  it.each([
+    { label: "Copy path", failed: true },
+    { label: "Copy file contents", failed: false },
+  ])(
+    "restores idle $label feedback when the same sidebar reconnects",
+    async ({ label, failed }) => {
+      if (failed) {
+        denyClipboard();
+      } else {
+        vi.stubGlobal("navigator", {
+          clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+        });
+      }
+      const panel = await mountFilePanel();
+      const button = findCopyButton(panel, label);
+
+      button.click();
+      await vi.waitFor(() =>
+        expect(button.getAttribute("aria-label")).toBe(failed ? "Copy failed" : "Copied!"),
+      );
+
+      panel.remove();
+      document.body.append(panel);
+      await panel.updateComplete;
+
+      expect(findCopyButton(panel, label)).toBe(button);
+      expect(button.classList.contains("copied")).toBe(false);
+      expect(panel.querySelector('[role="alert"]')).toBeNull();
+    },
+  );
+
+  it.each(copyActions)(
+    "ignores an older $label completion after sidebar reconnection",
+    async ({ label }) => {
+      let finishCopy = () => {};
+      const writeText = vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            finishCopy = resolve;
+          }),
+      );
+      vi.stubGlobal("navigator", { clipboard: { writeText } });
+      const panel = await mountFilePanel();
+      const button = findCopyButton(panel, label);
+      const timers = captureFeedbackTimers();
+
+      button.click();
+      panel.remove();
+      document.body.append(panel);
+      await panel.updateComplete;
+      finishCopy();
+      await Promise.resolve();
+      await Promise.resolve();
+      await panel.updateComplete;
+
+      expect(button.getAttribute("aria-label")).toBe(label);
+      expect(timers.schedule.mock.calls.some(([, delay]) => delay === 1_500)).toBe(false);
+      expect(panel.querySelector('[role="alert"]')).toBeNull();
+    },
+  );
 });

--- a/ui/src/pages/chat/components/chat-sidebar.ts
+++ b/ui/src/pages/chat/components/chat-sidebar.ts
@@ -245,8 +245,12 @@ function absoluteFilePath(content: FileSidebarContent): string | null {
   return `${content.root.replace(/[\\/]+$/, "")}/${content.path.replace(/^[\\/]+/, "")}`;
 }
 
+type FileCopyAction = "path" | "contents";
+type FileCopyFeedback = Partial<Record<FileCopyAction, "copied" | "failed">>;
+const noFileCopyFeedback: FileCopyFeedback = {};
+
 type FileViewControls = {
-  copied: boolean;
+  copyFeedback: FileCopyFeedback;
   currentMatchIndex: number;
   dirty: boolean;
   editorMenuOpen: boolean;
@@ -258,7 +262,7 @@ type FileViewControls = {
   saveNotice: { kind: "conflict" } | { kind: "error"; message: string } | null;
   saving: boolean;
   searchOpen: boolean;
-  onCopyContents: () => void;
+  onCopy: (action: FileCopyAction) => void;
   onDiscard: () => void;
   onEdit: () => void;
   onNextMatch: () => void;
@@ -274,6 +278,31 @@ type FileViewControls = {
   onToggleSearch: () => void;
 };
 
+function renderFileCopyButton(action: FileCopyAction, controls?: FileViewControls) {
+  const feedback = controls?.copyFeedback[action];
+  const label = t(
+    feedback === "failed"
+      ? "common.copyFailed"
+      : feedback === "copied"
+        ? "common.copied"
+        : action === "path"
+          ? "chat.detailPanel.copyPath"
+          : "chat.detailPanel.copyContents",
+  );
+  return html`
+    <openclaw-tooltip .content=${label}>
+      <button
+        class="btn btn--sm sidebar-file-view__action ${feedback === "copied" ? "copied" : ""}"
+        type="button"
+        aria-label=${label}
+        @click=${() => controls?.onCopy(action)}
+      >
+        ${feedback === "copied" ? icons.check : icons.copy}
+      </button>
+    </openclaw-tooltip>
+  `;
+}
+
 function renderFileSidebarContent(
   content: FileSidebarContent,
   onViewRawText: () => void,
@@ -286,16 +315,7 @@ function renderFileSidebarContent(
       <div class="sidebar-file-view__path-bar">
         <div class="sidebar-file-view__path-field">
           <span class="sidebar-file-view__path" title=${content.path}>${content.path}</span>
-          <openclaw-tooltip .content=${t("chat.detailPanel.copyPath")}>
-            <button
-              class="btn btn--sm sidebar-file-view__action"
-              type="button"
-              aria-label=${t("chat.detailPanel.copyPath")}
-              @click=${() => void copyToClipboard(content.path)}
-            >
-              ${icons.copy}
-            </button>
-          </openclaw-tooltip>
+          ${renderFileCopyButton("path", controls)}
         </div>
         ${controls
           ? html`
@@ -366,25 +386,15 @@ function renderFileSidebarContent(
                         onOpenChange: controls.onEditorMenuOpenChange,
                         onOpenEditor: controls.onOpenEditor,
                       })}
-                      <openclaw-tooltip .content=${t("chat.detailPanel.copyContents")}>
-                        <button
-                          class="btn btn--sm sidebar-file-view__action ${controls.copied
-                            ? "copied"
-                            : ""}"
-                          type="button"
-                          aria-label=${controls.copied
-                            ? t("common.copied")
-                            : t("chat.detailPanel.copyContents")}
-                          @click=${controls.onCopyContents}
-                        >
-                          ${controls.copied ? icons.check : icons.copy}
-                        </button>
-                      </openclaw-tooltip>
+                      ${renderFileCopyButton("contents", controls)}
                     `}
               </div>
             `
           : nothing}
       </div>
+      ${Object.values(controls?.copyFeedback ?? {}).includes("failed")
+        ? html`<div class="file-view__save-notice" role="alert">${t("common.copyFailed")}</div>`
+        : nothing}
       ${controls?.searchOpen
         ? html`
             <div class="file-view__search">
@@ -696,7 +706,7 @@ class ChatDetailPanel extends OpenClawLightDomElement {
   @state() private fileSearchQuery = "";
   @state() private fileSearchMatchIndex = 0;
   @state() private fileEditorMenuOpen = false;
-  @state() private fileContentsCopied = false;
+  @state() private fileCopyFeedback = noFileCopyFeedback;
   @state() private fileEditorLoading = false;
   @state() private fileEditing = false;
   @state() private fileDirty = false;
@@ -715,20 +725,22 @@ class ChatDetailPanel extends OpenClawLightDomElement {
   private fileDraftContent: string | null = null;
   private fileSavedContent = "";
   private fileHash = "";
-  private copyFeedbackTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
+  private readonly copyAttempts = new Map<FileCopyAction, number>();
+  private readonly copyFeedbackTimers = new Map<
+    FileCopyAction,
+    ReturnType<typeof globalThis.setTimeout>
+  >();
 
   override connectedCallback() {
     super.connectedCallback();
+    this.fileCopyFeedback = noFileCopyFeedback;
     document.addEventListener("pointerdown", this.handleDocumentPointerDown);
   }
 
   override disconnectedCallback() {
     document.removeEventListener("pointerdown", this.handleDocumentPointerDown);
     this.destroyFileEditor();
-    if (this.copyFeedbackTimer) {
-      globalThis.clearTimeout(this.copyFeedbackTimer);
-      this.copyFeedbackTimer = null;
-    }
+    this.clearFileCopyFeedback();
     super.disconnectedCallback();
   }
 
@@ -744,7 +756,8 @@ class ChatDetailPanel extends OpenClawLightDomElement {
     this.fileSearchQuery = "";
     this.fileSearchMatchIndex = 0;
     this.fileEditorMenuOpen = false;
-    this.fileContentsCopied = false;
+    this.clearFileCopyFeedback();
+    this.fileCopyFeedback = noFileCopyFeedback;
     this.fileOperationVersion += 1;
     this.fileEditing = false;
     this.fileDirty = false;
@@ -771,9 +784,16 @@ class ChatDetailPanel extends OpenClawLightDomElement {
     this.fileDirty = Boolean(restoredDraft);
     this.fileEditorLoading = this.content?.kind === "file";
     this.destroyFileEditor();
-    if (this.copyFeedbackTimer) {
-      globalThis.clearTimeout(this.copyFeedbackTimer);
-      this.copyFeedbackTimer = null;
+  }
+
+  private clearFileCopyFeedback() {
+    for (const timer of this.copyFeedbackTimers.values()) {
+      globalThis.clearTimeout(timer);
+    }
+    this.copyFeedbackTimers.clear();
+    // Keep attempt tokens monotonic so old work cannot become current after reconnection.
+    for (const [action, attempt] of this.copyAttempts) {
+      this.copyAttempts.set(action, attempt + 1);
     }
   }
 
@@ -977,23 +997,37 @@ class ChatDetailPanel extends OpenClawLightDomElement {
     openEditor(editor, absPath, content.line);
   };
 
-  private readonly copyFileContents = () => {
+  private readonly copyFileValue = (action: FileCopyAction) => {
     const content = this.visibleContent;
     if (content?.kind !== "file") {
       return;
     }
-    void copyToClipboard(content.content).then((copied) => {
-      if (!copied) {
+    const attempt = (this.copyAttempts.get(action) ?? 0) + 1;
+    this.copyAttempts.set(action, attempt);
+    void copyToClipboard(action === "path" ? content.path : content.content).then((copied) => {
+      // A newer copy or file selection owns feedback; stale completions must stay invisible.
+      if (
+        this.copyAttempts.get(action) !== attempt ||
+        this.visibleContent !== content ||
+        !this.isConnected
+      ) {
         return;
       }
-      this.fileContentsCopied = true;
-      if (this.copyFeedbackTimer) {
-        globalThis.clearTimeout(this.copyFeedbackTimer);
-      }
-      this.copyFeedbackTimer = globalThis.setTimeout(() => {
-        this.copyFeedbackTimer = null;
-        this.fileContentsCopied = false;
-      }, 1500);
+      this.fileCopyFeedback = {
+        ...this.fileCopyFeedback,
+        [action]: copied ? "copied" : "failed",
+      };
+      globalThis.clearTimeout(this.copyFeedbackTimers.get(action));
+      this.copyFeedbackTimers.set(
+        action,
+        globalThis.setTimeout(
+          () => {
+            this.copyFeedbackTimers.delete(action);
+            this.fileCopyFeedback = { ...this.fileCopyFeedback, [action]: undefined };
+          },
+          copied ? 1500 : 2000,
+        ),
+      );
     });
   };
 
@@ -1312,7 +1346,7 @@ class ChatDetailPanel extends OpenClawLightDomElement {
           content: this.visibleContent,
           error: this.error,
           fileView: {
-            copied: this.fileContentsCopied,
+            copyFeedback: this.fileCopyFeedback,
             currentMatchIndex,
             dirty: this.fileDirty,
             editorMenuOpen: this.fileEditorMenuOpen,
@@ -1324,7 +1358,7 @@ class ChatDetailPanel extends OpenClawLightDomElement {
             saveNotice: this.fileSaveNotice,
             saving: this.fileSaving,
             searchOpen: this.fileSearchOpen,
-            onCopyContents: this.copyFileContents,
+            onCopy: this.copyFileValue,
             onDiscard: this.discardFileEdits,
             onEdit: this.editFile,
             onNextMatch: () => this.moveFileSearch(1),


### PR DESCRIPTION
## Summary
- Make the default chat file sidebar show visible, localized, accessible feedback when copying either a file path or file contents fails.
- Give each action independent latest-attempt and feedback-timer ownership.
- Correctly invalidate old clipboard attempts and feedback across sidebar disconnection, reconnection, and file changes.

## Actual user-visible owner behavior
The real sidebar custom element and actual clipboard helper previously ignored failures from both navigator.clipboard and document.execCommand. Both `Copy path` and `Copy file contents` silently remained at their idle icon/accessible label.

The repaired owner displays a localized visible `role=alert` failure and matching accessible button feedback for both actions, preserves successful copies, and restores the correct idle labels independently.

A fresh security/lifecycle review additionally identified that detaching and reconnecting the same custom element could preserve obsolete success/failure feedback or allow a pre-detach clipboard promise to publish into a new connection. Four actual custom-element regressions reproduced those failures before the owner fix. Connection-scoped monotonic action generations now invalidate every obsolete completion without resetting counters or triggering reactive updates from disconnected lifecycle cleanup.

The tests run the real custom element, real clipboard helper, real user-visible DOM and accessibility attributes; only the unrelated browser-only CodeMirror editor initialization is replaced on the individual test instance because it cannot run in jsdom.

## Verification
- Initial red-before-green default-path proof: path-copy and contents-copy failures reproduced.
- Four additional detach/reconnect stale-feedback and stale-completion regressions reproduced before repair.
- Complete existing sidebar owner suite: 26 passed.
- Coverage includes denied Clipboard API and legacy fallback, visible alerts, accessible labels, successful copy, out-of-order completions, independent per-action timers, changed file selection, disconnect, and same-instance reconnect.
- Focused formatting/lint/diff checks passed.
- Fresh independent structured security/lifecycle review: clean, confidence 0.98.
- Production-code delta: +34 lines for canonical visible user outcomes, independent async ownership, and safe lifecycle invalidation.

## Exact-head actual Chromium after-fix proof
Reviewed head: bfc701cbd42bbf6f6ad63c5f250ea00a3fb49818. A real headless Chromium browser loaded the actual reviewed Control UI through the actual Vite source server and a local mock Gateway. Both changed file-sidebar buttons were clicked, both real browser clipboard mechanisms were denied, visible alert and accessible feedback were observed, each action reset, and the exact same custom element was disconnected/reconnected while an older promise completed. No provider calls or external traffic.

```json
{"result":"PASS","head":"bfc701cbd42bbf6f6ad63c5f250ea00a3fb49818","browser":"chromium","actualBrowser":true,"actualViteSourceUi":true,"mockGateway":"local","actions":[{"action":"path","modernClipboardDenied":true,"legacyCopyDenied":true,"visibleAlert":"Copy failed","failedAriaLabel":"Copy failed","idleAriaLabel":"Copy path","resetAlertCleared":true},{"action":"contents","modernClipboardDenied":true,"legacyCopyDenied":true,"visibleAlert":"Copy failed","failedAriaLabel":"Copy failed","idleAriaLabel":"Copy file contents","resetAlertCleared":true}],"reconnect":{"sameElement":true,"connected":true,"staleCompletionIgnored":true,"idleAriaLabel":"Copy file contents","alertAbsent":true},"fileRequests":1,"providerCalls":0,"screenshots":["sidebar-path-denied.png","sidebar-contents-denied.png","sidebar-reconnect-stale-completion.png"]}
```

Browser and Vite server shut down cleanly; both reviewed source overlays were restored. Actual browser run exited zero in 8.81 seconds. All four exact-head hosted Chromium shards and the required CI gate also passed.