### PR TITLE
chore(tests): speed up gateway session patch coverage

### DIFF
--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -1,6 +1,6 @@
 // Session patch tests cover model/provider edits, subagent patching, provider
 // aliases, model catalog validation, and rejected invalid patch payloads.
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { SessionCreatedActor } from "../../packages/gateway-protocol/src/index.js";
 import { resetProviderAuthAliasMapCacheForTest } from "../agents/provider-auth-aliases.test-support.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -16,9 +16,18 @@ import { applySessionsPatchToStore } from "./sessions-patch.js";
 const acpSessionMetaMocks = vi.hoisted(() => ({
   readAcpSessionMetaForEntry: vi.fn(),
 }));
+const providerThinkingMocks = vi.hoisted(() => ({
+  resolveProviderThinkingProfile:
+    vi.fn<typeof import("../plugins/provider-thinking.js").resolveProviderThinkingProfile>(),
+}));
 
 vi.mock("../acp/runtime/session-meta.js", () => ({
   readAcpSessionMetaForEntry: acpSessionMetaMocks.readAcpSessionMetaForEntry,
+}));
+
+// This suite owns patch projection; provider policy artifacts have dedicated contract coverage.
+vi.mock("../plugins/provider-thinking.js", () => ({
+  resolveProviderThinkingProfile: providerThinkingMocks.resolveProviderThinkingProfile,
 }));
 
 const SUBAGENT_MODEL = "synthetic/hf:moonshotai/Kimi-K2.7-Code";
@@ -256,6 +265,32 @@ function createAllowlistedAnthropicModelCfg(): OpenClawConfig {
 }
 
 describe("gateway sessions patch", () => {
+  beforeEach(() => {
+    providerThinkingMocks.resolveProviderThinkingProfile.mockReset();
+    providerThinkingMocks.resolveProviderThinkingProfile.mockImplementation(
+      ({ provider, context }) => {
+        if (provider !== "openai") {
+          return undefined;
+        }
+        if (context.modelId === "gpt-5.5") {
+          return {
+            levels: (["off", "minimal", "low", "medium", "high", "xhigh"] as const).map((id) => ({
+              id,
+            })),
+          };
+        }
+        if (context.modelId === "gpt-5.6-luna") {
+          const levels =
+            context.agentRuntime === "openclaw"
+              ? (["off", "minimal", "low", "medium", "high", "max", "ultra"] as const)
+              : (["off", "minimal", "low", "medium", "high", "max"] as const);
+          return { levels: levels.map((id) => ({ id })) };
+        }
+        return undefined;
+      },
+    );
+  });
+
   afterEach(() => {
     acpSessionMetaMocks.readAcpSessionMetaForEntry.mockReset();
     resetProviderAuthAliasMapCacheForTest();


### PR DESCRIPTION
## What Problem This Solves

The gateway-core test group spent roughly 24 seconds loading bundled provider policy artifacts inside the session-patch projection suite. That suite validates patch behavior, while the provider policy artifact resolver already has dedicated contract coverage.

## Why This Change Was Made

The session-patch suite now supplies deterministic provider thinking profiles through its existing mocked dependency boundary. All patch cases and assertions remain intact, including OpenAI xhigh and runtime-sensitive Luna max/ultra behavior; the real bundled artifact and thinking-policy contracts remain covered by their owner suites.

## User Impact

There is no product behavior change. The gateway-core test group completes substantially faster with unchanged test coverage.

## Evidence

- Focused file, same host: 88 tests, 38.37s before to 11.43s after.
- Exact gateway-core owner group, two workers, same host: 180.65s before to 138.34s after (42.31s / 23.4% faster).
- Gateway-core count unchanged: 258 files / 4,643 tests.
- Gateway-client count unchanged: 71 files / 656 tests.
- Auto Review: clean, no accepted/actionable findings.
- Formatting: clean.
- Changed gate remote delegation was unavailable. Local core test type checking reached two unrelated current-tree failures in packages/terminal-core/src/ansi.ts and ui/src/app-session-route-paths.ts; the changed file has no type errors.
