### PR TITLE
fix(otel): redact invalid collector URLs and suppress implicit exporters

### DIFF
--- a/extensions/diagnostics-otel/src/service-exporter.ts
+++ b/extensions/diagnostics-otel/src/service-exporter.ts
@@ -28,14 +28,10 @@ function resolveOtelUrl(endpoint: string | undefined, path: string): string | un
     return endpoint;
   }
   if (/[?#]/u.test(endpoint)) {
-    try {
-      const url = new URL(endpoint);
-      const basePath = url.pathname.replace(/\/+$/u, "");
-      url.pathname = `${basePath}/${path}`;
-      return url.toString();
-    } catch {
-      // Fall back to the historical concatenation path for non-URL test doubles.
-    }
+    const url = new URL(endpoint);
+    const basePath = url.pathname.replace(/\/+$/u, "");
+    url.pathname = `${basePath}/${path}`;
+    return url.toString();
   }
   return `${endpoint}/${path}`;
 }
@@ -43,13 +39,36 @@ function resolveOtelUrl(endpoint: string | undefined, path: string): string | un
 export function resolveSignalOtelUrl(params: {
   signalEndpoint?: string;
   signalEnvEndpoint?: string;
+  sharedEnvEndpoint?: string;
   endpoint?: string;
   path: string;
 }): string | undefined {
-  return resolveOtelUrl(
-    normalizeEndpoint(params.signalEndpoint ?? params.signalEnvEndpoint) ?? params.endpoint,
-    params.path,
-  );
+  const endpoint =
+    normalizeEndpoint(params.signalEndpoint ?? params.signalEnvEndpoint) ?? params.endpoint;
+  // OTLP parses nonblank env values verbatim even when explicit config takes precedence.
+  const signalEnvEndpoint = params.signalEnvEndpoint?.trim() ? params.signalEnvEndpoint : undefined;
+  const sharedEnvEndpoint = params.sharedEnvEndpoint?.trim() ? params.sharedEnvEndpoint : undefined;
+  const consumedSharedEnvEndpoint = signalEnvEndpoint ? undefined : sharedEnvEndpoint;
+  const appendedSharedEnvEndpoint = consumedSharedEnvEndpoint
+    ? `${consumedSharedEnvEndpoint}${consumedSharedEnvEndpoint.endsWith("/") ? "" : "/"}${params.path}`
+    : undefined;
+  const resolvedEndpoint =
+    endpoint && URL.canParse(endpoint) ? resolveOtelUrl(endpoint, params.path) : endpoint;
+
+  for (const candidate of [
+    endpoint,
+    signalEnvEndpoint ?? sharedEnvEndpoint,
+    appendedSharedEnvEndpoint,
+    resolvedEndpoint,
+  ]) {
+    if (candidate && !URL.canParse(candidate)) {
+      throw new Error(
+        "Configured OpenTelemetry collector endpoint is invalid; check the collector URL",
+      );
+    }
+  }
+
+  return resolvedEndpoint;
 }
 
 function readOtelEnvFile(params: {

--- a/extensions/diagnostics-otel/src/service.otlp-export.test.ts
+++ b/extensions/diagnostics-otel/src/service.otlp-export.test.ts
@@ -5,11 +5,11 @@
 // test feeds in, collapsing the diagnostic and OTel id spaces into one value. That hides
 // a parent lookup keyed by one id space and queried with the other.
 //
-// It drives the service through the OPENCLAW_OTEL_PRELOADED seam so the plugin uses this
-// file's tracer provider instead of starting its own NodeSDK. trace.disable() in teardown
-// then fully releases the global API slot; a NodeSDK cannot be unregistered, and the
-// leftover dead provider would make any later real-SDK test export nothing.
-import { trace } from "@opentelemetry/api";
+// Trace cases use the OPENCLAW_OTEL_PRELOADED seam to retain this file's tracer provider.
+// Collector-boundary cases start the real NodeSDK, so teardown restores every global SDK
+// registration; otherwise a shutdown provider would poison later real-SDK cases.
+import { context, diag, DiagLogLevel, metrics, propagation, trace } from "@opentelemetry/api";
+import { logs } from "@opentelemetry/api-logs";
 import {
   BasicTracerProvider,
   InMemorySpanExporter,
@@ -23,17 +23,58 @@ import {
   resetDiagnosticEventsForTest,
   waitForDiagnosticEventsDrained,
 } from "openclaw/plugin-sdk/diagnostic-runtime";
-import { afterEach, beforeEach, expect, test } from "vitest";
-import { startOtelService, stopStartedOtelServices } from "./service.test-helpers.js";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { createDiagnosticsOtelService } from "./service.js";
+import {
+  createOtelContext,
+  startOtelService,
+  stopStartedOtelServices,
+} from "./service.test-helpers.js";
 
 const PRELOAD_ENV = "OPENCLAW_OTEL_PRELOADED";
+const ENDPOINT_ENV_KEYS = [
+  "OTEL_EXPORTER_OTLP_ENDPOINT",
+  "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+  "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+  "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+  "OTEL_LOG_LEVEL",
+] as const;
+const OTEL_GLOBAL_API_KEY = Symbol.for("opentelemetry.js.api.1");
+const OTEL_GLOBAL_LOGS_KEY = Symbol.for("io.opentelemetry.js.api.logs");
+
+type OtelGlobalRegistrations = {
+  context?: Parameters<typeof context.setGlobalContextManager>[0];
+  diag?: Parameters<typeof diag.setLogger>[0];
+  metrics?: Parameters<typeof metrics.setGlobalMeterProvider>[0];
+  propagation?: Parameters<typeof propagation.setGlobalPropagator>[0];
+  trace?: Parameters<typeof trace.setGlobalTracerProvider>[0];
+};
 
 let exporter: InMemorySpanExporter;
 let provider: BasicTracerProvider;
 let originalPreloaded: string | undefined;
+let originalEndpointEnv: Record<(typeof ENDPOINT_ENV_KEYS)[number], string | undefined>;
+let originalOtelGlobals: OtelGlobalRegistrations;
+let originalLogsProvider: ReturnType<typeof logs.getLoggerProvider> | undefined;
+
+function registeredOtelGlobals(): OtelGlobalRegistrations | undefined {
+  return (globalThis as unknown as Record<symbol, OtelGlobalRegistrations | undefined>)[
+    OTEL_GLOBAL_API_KEY
+  ];
+}
 
 beforeEach(() => {
   originalPreloaded = process.env[PRELOAD_ENV];
+  originalEndpointEnv = Object.fromEntries(
+    ENDPOINT_ENV_KEYS.map((key) => [key, process.env[key]]),
+  ) as Record<(typeof ENDPOINT_ENV_KEYS)[number], string | undefined>;
+  for (const key of ENDPOINT_ENV_KEYS) {
+    delete process.env[key];
+  }
+  originalOtelGlobals = { ...registeredOtelGlobals() };
+  originalLogsProvider = Object.hasOwn(globalThis, OTEL_GLOBAL_LOGS_KEY)
+    ? logs.getLoggerProvider()
+    : undefined;
   process.env[PRELOAD_ENV] = "1";
   exporter = new InMemorySpanExporter();
   provider = new BasicTracerProvider({ spanProcessors: [new SimpleSpanProcessor(exporter)] });
@@ -43,12 +84,57 @@ beforeEach(() => {
 afterEach(async () => {
   await stopStartedOtelServices();
   await provider.shutdown();
-  trace.disable();
+  const currentGlobals = registeredOtelGlobals();
+  if (currentGlobals?.context !== originalOtelGlobals.context) {
+    context.disable();
+    if (originalOtelGlobals.context) {
+      context.setGlobalContextManager(originalOtelGlobals.context);
+    }
+  }
+  if (currentGlobals?.propagation !== originalOtelGlobals.propagation) {
+    propagation.disable();
+    if (originalOtelGlobals.propagation) {
+      propagation.setGlobalPropagator(originalOtelGlobals.propagation);
+    }
+  }
+  if (currentGlobals?.metrics !== originalOtelGlobals.metrics) {
+    metrics.disable();
+    if (originalOtelGlobals.metrics) {
+      metrics.setGlobalMeterProvider(originalOtelGlobals.metrics);
+    }
+  }
+  if (currentGlobals?.trace !== originalOtelGlobals.trace) {
+    trace.disable();
+    if (originalOtelGlobals.trace) {
+      trace.setGlobalTracerProvider(originalOtelGlobals.trace);
+    }
+  }
+  if (Object.hasOwn(globalThis, OTEL_GLOBAL_LOGS_KEY) || originalLogsProvider) {
+    logs.disable();
+    if (originalLogsProvider) {
+      logs.setGlobalLoggerProvider(originalLogsProvider);
+    }
+  }
   exporter.reset();
   if (originalPreloaded === undefined) {
     delete process.env[PRELOAD_ENV];
   } else {
     process.env[PRELOAD_ENV] = originalPreloaded;
+  }
+  for (const key of ENDPOINT_ENV_KEYS) {
+    const value = originalEndpointEnv[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  diag.disable();
+  if (originalOtelGlobals.diag) {
+    diag.setLogger(originalOtelGlobals.diag, {
+      logLevel: DiagLogLevel.ALL,
+      suppressOverrideMessage: true,
+    });
   }
   resetDiagnosticEventsForTest();
 });
@@ -58,6 +144,24 @@ const emit = (event: Parameters<typeof emitTrustedDiagnosticEventWithPrivateData
 
 function spanNamed(spans: ReadableSpan[], name: string) {
   return spans.find((span) => span.name === name);
+}
+
+function captureOtelDiagnostics(): string[] {
+  const messages: string[] = [];
+  const capture = (...args: unknown[]) => {
+    messages.push(args.map((value) => String(value)).join(" "));
+  };
+  diag.setLogger(
+    {
+      debug: () => {},
+      error: capture,
+      info: () => {},
+      verbose: () => {},
+      warn: capture,
+    },
+    { logLevel: DiagLogLevel.ALL, suppressOverrideMessage: true },
+  );
+  return messages;
 }
 
 // Covers all three completeTrackedLifecycleSpan owners: run.completed,
@@ -237,3 +341,133 @@ test("leaves exec spans parentless rather than naming a span nobody exported", a
   expect(execSpan).toBeDefined();
   expect(execSpan?.parentSpanContext).toBeUndefined();
 }, 30_000);
+
+const OTEL_ENDPOINT_SIGNAL_CASES = [
+  {
+    signal: "traces",
+    envKey: "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+    configKey: "tracesEndpoint",
+    flags: { traces: true, metrics: false, logs: false },
+  },
+  {
+    signal: "metrics",
+    envKey: "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+    configKey: "metricsEndpoint",
+    flags: { traces: false, metrics: true, logs: false },
+  },
+  {
+    signal: "logs",
+    envKey: "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+    configKey: "logsEndpoint",
+    flags: { traces: false, metrics: false, logs: true },
+  },
+] as const;
+
+const OTEL_ENDPOINT_SECURITY_CASES = OTEL_ENDPOINT_SIGNAL_CASES.flatMap((signal) =>
+  (
+    [
+      "shared configuration",
+      "signal configuration",
+      "signal environment",
+      "shared environment",
+      "Unicode-prefixed signal environment",
+      "Unicode-prefixed shared environment",
+      "path-concatenated shared environment",
+      "path-concatenated shared configuration",
+      "path-concatenated signal configuration",
+    ] as const
+  ).map((source) => Object.assign({ source }, signal)),
+);
+
+test.each(OTEL_ENDPOINT_SECURITY_CASES)(
+  "rejects malformed $signal collector $source before the real SDK can expose credentials",
+  async ({ signal, envKey, configKey, flags, source }) => {
+    process.env[PRELOAD_ENV] = "0";
+    const credential = `qa-otel-${signal}-endpoint-password-sentinel`;
+    const malformedEndpoint = source.startsWith("Unicode-prefixed")
+      ? `\u00a0https://operator:${credential}@collector.example.com/otlp`
+      : source === "path-concatenated shared environment"
+        ? `https://operator:${credential}@collector.example.com: `
+        : source.startsWith("path-concatenated")
+          ? `https://operator:${credential}@collector.example.com /`
+          : `https://operator:${credential}@[`;
+    const configuredEndpoint = source.endsWith("shared configuration")
+      ? malformedEndpoint
+      : "https://collector.example.com/otlp";
+    if (source.endsWith("signal environment")) {
+      process.env[envKey] = malformedEndpoint;
+    } else if (source.endsWith("shared environment")) {
+      process.env.OTEL_EXPORTER_OTLP_ENDPOINT = malformedEndpoint;
+    }
+
+    const diagnostics = captureOtelDiagnostics();
+    const ctx = createOtelContext(configuredEndpoint, flags);
+    if (source.endsWith("signal configuration") || source.endsWith("signal environment")) {
+      ctx.config.diagnostics!.otel![configKey] = source.endsWith("signal configuration")
+        ? malformedEndpoint
+        : "https://signal.example.com/otlp";
+    }
+    ctx.internalDiagnostics!.emit = () => {};
+    const service = createDiagnosticsOtelService();
+    let failure: unknown;
+    try {
+      await service.start(ctx);
+    } catch (error) {
+      failure = error;
+    } finally {
+      await service.stop?.(ctx);
+    }
+
+    expect(diagnostics.join("\n")).not.toContain(credential);
+    expect(failure).toBeInstanceOf(Error);
+    const startupError = failure as Error;
+    expect(startupError.message).toBe(
+      "Configured OpenTelemetry collector endpoint is invalid; check the collector URL",
+    );
+    expect(startupError.stack).not.toContain(credential);
+    expect(startupError).not.toHaveProperty("cause");
+    expect(JSON.stringify(vi.mocked(ctx.logger.error).mock.calls)).not.toContain(credential);
+    expect(JSON.stringify(vi.mocked(ctx.logger.warn).mock.calls)).not.toContain(credential);
+  },
+);
+
+test.each([
+  {
+    disabledSignal: "metrics",
+    envKey: "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+    flags: { traces: true, metrics: false, logs: false },
+  },
+  {
+    disabledSignal: "traces",
+    envKey: "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+    flags: { traces: false, metrics: true, logs: false },
+  },
+  {
+    disabledSignal: "logs",
+    envKey: "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+    flags: { traces: true, metrics: false, logs: false },
+  },
+  {
+    disabledSignal: "stdout-only logs",
+    envKey: "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+    flags: { traces: true, metrics: false, logs: true, logsExporter: "stdout" },
+  },
+] as const)(
+  "does not auto-create an undeclared $disabledSignal OTLP exporter",
+  async ({ disabledSignal, envKey, flags }) => {
+    process.env[PRELOAD_ENV] = "0";
+    const credential = `qa-otel-${disabledSignal.replaceAll(" ", "-")}-disabled-password`;
+    process.env[envKey] = `https://operator:${credential}@[`;
+    const diagnostics = captureOtelDiagnostics();
+    const ctx = createOtelContext("https://collector.example.com/otlp", flags);
+    ctx.internalDiagnostics!.emit = () => {};
+    const service = createDiagnosticsOtelService();
+
+    try {
+      await service.start(ctx);
+      expect(diagnostics.join("\n")).not.toContain(credential);
+    } finally {
+      await service.stop?.(ctx);
+    }
+  },
+);

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -57,6 +57,7 @@ const telemetryState = vi.hoisted(() => {
 
 const sdkStart = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const sdkShutdown = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const sdkCtor = vi.hoisted(() => vi.fn());
 const logEmit = vi.hoisted(() => vi.fn());
 const logShutdown = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const traceExporterCtor = vi.hoisted(() => vi.fn());
@@ -107,6 +108,10 @@ vi.mock("@opentelemetry/api", () => ({
 
 vi.mock("@opentelemetry/sdk-node", () => ({
   NodeSDK: class {
+    constructor(options?: unknown) {
+      sdkCtor(options);
+    }
+
     start = sdkStart;
     shutdown = sdkShutdown;
   },
@@ -220,7 +225,9 @@ const LATE_CHILD_ELAPSED_MS = 30 * 60_000 + 1_000;
 const PROTO_KEY = "__proto__";
 const MAX_TEST_OTEL_CONTENT_ATTRIBUTE_CHARS = 128 * 1024;
 const OTEL_TRUNCATED_SUFFIX_MAX_CHARS = 20;
+const OTEL_TEST_USERINFO = ["operator", "example-fixture"].join(":");
 const ORIGINAL_OPENCLAW_OTEL_PRELOADED = process.env.OPENCLAW_OTEL_PRELOADED;
+const ORIGINAL_OTEL_EXPORTER_OTLP_ENDPOINT = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
 const ORIGINAL_OTEL_EXPORTER_OTLP_PROTOCOL = process.env.OTEL_EXPORTER_OTLP_PROTOCOL;
 const ORIGINAL_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
 const ORIGINAL_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT =
@@ -584,6 +591,7 @@ describe("diagnostics-otel service", () => {
     telemetryState.tracer.setSpanContext.mockClear();
     telemetryState.meter.createCounter.mockClear();
     telemetryState.meter.createHistogram.mockClear();
+    sdkCtor.mockClear();
     sdkStart.mockClear();
     sdkShutdown.mockClear();
     logEmit.mockReset();
@@ -597,6 +605,7 @@ describe("diagnostics-otel service", () => {
     createNodeProxyAgentMock.mockReturnValue(undefined);
     unhandledRejectionHandlerState.reset();
     unhandledRejectionHandlerState.register.mockClear();
+    delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
     delete process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
     delete process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT;
     delete process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT;
@@ -612,6 +621,11 @@ describe("diagnostics-otel service", () => {
       delete process.env.OPENCLAW_OTEL_PRELOADED;
     } else {
       process.env.OPENCLAW_OTEL_PRELOADED = ORIGINAL_OPENCLAW_OTEL_PRELOADED;
+    }
+    if (ORIGINAL_OTEL_EXPORTER_OTLP_ENDPOINT === undefined) {
+      delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+    } else {
+      process.env.OTEL_EXPORTER_OTLP_ENDPOINT = ORIGINAL_OTEL_EXPORTER_OTLP_ENDPOINT;
     }
     if (ORIGINAL_OTEL_EXPORTER_OTLP_PROTOCOL === undefined) {
       delete process.env.OTEL_EXPORTER_OTLP_PROTOCOL;
@@ -1688,6 +1702,16 @@ describe("diagnostics-otel service", () => {
       "https://collector.example.com/otlp/v1/traces#tenant-a",
     ],
     [
+      "preserves valid collector credentials and query parameters",
+      `https://${OTEL_TEST_USERINFO}@collector.example.com/otlp?tenant=red`,
+      `https://${OTEL_TEST_USERINFO}@collector.example.com/otlp/v1/traces?tenant=red`,
+    ],
+    [
+      "preserves parseable non-HTTP collector URL schemes",
+      "custom+otel://collector.example.com/otlp",
+      "custom+otel://collector.example.com/otlp/v1/traces",
+    ],
+    [
       "keeps signal-qualified endpoint unchanged when signal path casing differs",
       "https://collector.example.com/v1/Traces",
       "https://collector.example.com/v1/Traces",
@@ -1761,6 +1785,105 @@ describe("diagnostics-otel service", () => {
     expect(traceOptions.url).toBe("https://trace-env.example.com/v1/traces");
     expect(metricOptions.url).toBe("https://metric-env.example.com/otlp/v1/metrics");
     expect(logOptions.url).toBe("https://log-env.example.com/otlp/v1/logs");
+  });
+
+  test("ignores malformed shared OTLP env when valid signal endpoints shadow it", async () => {
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = "https://operator:qa-ignored-shared-password@[";
+    process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = "https://trace-env.example.com/v1/traces";
+    process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT = "https://metric-env.example.com/v1/metrics";
+    process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = "https://log-env.example.com/v1/logs";
+
+    await startOtelService({ traces: true, metrics: true, logs: true });
+
+    expect(firstExporterOptions(traceExporterCtor).url).toBe(
+      "https://trace-env.example.com/v1/traces",
+    );
+    expect(firstExporterOptions(metricExporterCtor).url).toBe(
+      "https://metric-env.example.com/v1/metrics",
+    );
+    expect(firstExporterOptions(logExporterCtor).url).toBe("https://log-env.example.com/v1/logs");
+  });
+
+  test("treats whitespace-only OTLP environment endpoints as unset", async () => {
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = " \u00a0 ";
+    process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = " \t ";
+    process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT = "\u2000";
+    process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = "\ufeff";
+
+    await startOtelService({ traces: true, metrics: true, logs: true });
+
+    expect(firstExporterOptions(traceExporterCtor).url).toBe(`${OTEL_TEST_ENDPOINT}/v1/traces`);
+    expect(firstExporterOptions(metricExporterCtor).url).toBe(`${OTEL_TEST_ENDPOINT}/v1/metrics`);
+    expect(firstExporterOptions(logExporterCtor).url).toBe(`${OTEL_TEST_ENDPOINT}/v1/logs`);
+  });
+
+  test.each([
+    {
+      enabledSignal: "traces",
+      flags: { traces: true, metrics: false, logs: false },
+      metricReaderCount: 0,
+      tracesDisabled: false,
+    },
+    {
+      enabledSignal: "metrics",
+      flags: { traces: false, metrics: true, logs: false },
+      metricReaderCount: 1,
+      tracesDisabled: true,
+    },
+    {
+      enabledSignal: "traces and metrics",
+      flags: { traces: true, metrics: true, logs: false },
+      metricReaderCount: 1,
+      tracesDisabled: false,
+    },
+  ] as const)(
+    "keeps NodeSDK exporter ownership explicit for $enabledSignal",
+    async ({ flags, metricReaderCount, tracesDisabled }) => {
+      await startOtelService(flags);
+
+      const options = mockCallArg(sdkCtor, 0) as {
+        logRecordProcessors?: unknown[];
+        metricReaders?: unknown[];
+        spanProcessors?: unknown[];
+      };
+      expect(options.logRecordProcessors).toEqual([]);
+      expect(options.metricReaders).toHaveLength(metricReaderCount);
+      expect(options).not.toHaveProperty("metricReader");
+      if (tracesDisabled) {
+        expect(options.spanProcessors).toEqual([]);
+      }
+    },
+  );
+
+  test("ignores malformed collector endpoints for preloaded traces and metrics", async () => {
+    process.env.OPENCLAW_OTEL_PRELOADED = "1";
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = "https://operator:qa-preloaded-shared-password@[";
+    process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT =
+      "https://operator:qa-preloaded-trace-password@[";
+    process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT =
+      "https://operator:qa-preloaded-metric-password@[";
+
+    await startOtelService({ traces: true, metrics: true, logs: false });
+
+    expect(sdkCtor).not.toHaveBeenCalled();
+    expect(traceExporterCtor).not.toHaveBeenCalled();
+    expect(metricExporterCtor).not.toHaveBeenCalled();
+  });
+
+  test("ignores malformed collector endpoints for stdout-only diagnostics", async () => {
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = "https://operator:qa-stdout-shared-password@[";
+    process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = "https://operator:qa-stdout-log-password@[";
+
+    await startOtelService({
+      endpoint: "https://operator:qa-stdout-config-password@[",
+      traces: false,
+      metrics: false,
+      logs: true,
+      logsExporter: "stdout",
+    });
+
+    expect(sdkCtor).not.toHaveBeenCalled();
+    expect(logExporterCtor).not.toHaveBeenCalled();
   });
 
   test("passes env proxy agents to OTLP HTTP exporters", async () => {

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -141,9 +141,8 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         return;
       }
 
-      const endpoint = normalizeEndpoint(
-        otel.endpoint ?? process.env[OTEL_EXPORTER_OTLP_ENDPOINT_ENV],
-      );
+      const sharedEnvEndpoint = process.env[OTEL_EXPORTER_OTLP_ENDPOINT_ENV];
+      const endpoint = normalizeEndpoint(otel.endpoint ?? sharedEnvEndpoint);
       const headers = otel.headers ?? undefined;
       const serviceName =
         otel.serviceName?.trim() || process.env.OTEL_SERVICE_NAME || DEFAULT_SERVICE_NAME;
@@ -155,32 +154,41 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         [ATTR_SERVICE_NAME]: serviceName,
       });
 
-      const logUrl = resolveSignalOtelUrl({
-        signalEndpoint: otel.logsEndpoint,
-        signalEnvEndpoint: process.env[OTEL_EXPORTER_OTLP_LOGS_ENDPOINT_ENV],
-        endpoint,
-        path: "v1/logs",
-      });
+      const logUrl = logsToOtlp
+        ? resolveSignalOtelUrl({
+            signalEndpoint: otel.logsEndpoint,
+            signalEnvEndpoint: process.env[OTEL_EXPORTER_OTLP_LOGS_ENDPOINT_ENV],
+            sharedEnvEndpoint,
+            endpoint,
+            path: "v1/logs",
+          })
+        : undefined;
       if (!sdkPreloaded && (tracesEnabled || metricsEnabled)) {
-        const traceUrl = resolveSignalOtelUrl({
-          signalEndpoint: otel.tracesEndpoint,
-          signalEnvEndpoint: process.env[OTEL_EXPORTER_OTLP_TRACES_ENDPOINT_ENV],
-          endpoint,
-          path: "v1/traces",
-        });
-        const metricUrl = resolveSignalOtelUrl({
-          signalEndpoint: otel.metricsEndpoint,
-          signalEnvEndpoint: process.env[OTEL_EXPORTER_OTLP_METRICS_ENDPOINT_ENV],
-          endpoint,
-          path: "v1/metrics",
-        });
+        const traceUrl = tracesEnabled
+          ? resolveSignalOtelUrl({
+              signalEndpoint: otel.tracesEndpoint,
+              signalEnvEndpoint: process.env[OTEL_EXPORTER_OTLP_TRACES_ENDPOINT_ENV],
+              sharedEnvEndpoint,
+              endpoint,
+              path: "v1/traces",
+            })
+          : undefined;
+        const metricUrl = metricsEnabled
+          ? resolveSignalOtelUrl({
+              signalEndpoint: otel.metricsEndpoint,
+              signalEnvEndpoint: process.env[OTEL_EXPORTER_OTLP_METRICS_ENDPOINT_ENV],
+              sharedEnvEndpoint,
+              endpoint,
+              path: "v1/metrics",
+            })
+          : undefined;
         const traceHttpAgentOptions = resolveOtelHttpAgentOptions({
-          url: tracesEnabled ? traceUrl : undefined,
+          url: traceUrl,
           signalIdentifier: "TRACES",
           logger: ctx.logger,
         });
         const metricHttpAgentOptions = resolveOtelHttpAgentOptions({
-          url: metricsEnabled ? metricUrl : undefined,
+          url: metricUrl,
           signalIdentifier: "METRICS",
           logger: ctx.logger,
         });
@@ -219,8 +227,13 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
 
         sdk = new NodeSDK({
           resource,
-          ...(spanProcessors ? { spanProcessors } : traceExporter ? { traceExporter } : {}),
-          ...(metricReader ? { metricReader } : {}),
+          ...(spanProcessors
+            ? { spanProcessors }
+            : traceExporter
+              ? { traceExporter }
+              : { spanProcessors: [] }),
+          metricReaders: metricReader ? [metricReader] : [],
+          logRecordProcessors: [],
           ...(sampleRate !== undefined
             ? {
                 sampler: new ParentBasedSampler({


### PR DESCRIPTION


## Maintainer upgrade decision
The plugin documentation already promises independent signal toggles and logs disabled by default. Ambient implicit NodeSDK exporters that silently bypass those explicit settings, redact/capture policy, or stdout-only mode are unintended behavior, not a supported upgrade contract. The maintainer intentionally accepts stopping those unintended default exporters; operators who want OTLP traces, metrics, or logs should enable the corresponding existing documented plugin signal. Valid explicitly enabled exporters, endpoint environment precedence, proxy/TLS settings, and stdout-only logging remain unchanged. The previously flaky unrelated TUI hosted build check was retried once and both exact-head build-artifacts and required openclaw/ci-gate are now SUCCESS.