### PR TITLE
test(system-agent): reuse setup fixtures

### DIFF
--- a/src/system-agent/assistant.configured.test.ts
+++ b/src/system-agent/assistant.configured.test.ts
@@ -1,6 +1,5 @@
 // Configured OpenClaw assistant tests cover route-owned, tool-free planning.
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
-import { testing as cliBackendsTesting } from "../agents/cli-backends.test-support.js";
 import type { RunCliAgentParams } from "../agents/cli-runner/types.js";
 import { fingerprintResolvedProviderAuth } from "../agents/execution-auth-binding.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -8,7 +7,10 @@ import { planSystemAgentCommandWithConfiguredModel } from "./assistant.js";
 import { SystemAgentInferenceUnavailableError } from "./inference-error.js";
 import { resolveSystemAgentConfiguredRouteFromConfig } from "./inference-route.js";
 import type { SystemAgentOverview } from "./overview.js";
-import { createSystemAgentVerifiedInferenceTestFixture } from "./system-agent.test-helpers.js";
+import {
+  createSystemAgentVerifiedInferenceTestFixture,
+  installSystemAgentClaudeCliBackendTestFixture,
+} from "./system-agent.test-helpers.js";
 import {
   createSystemAgentVerifiedInferenceBinding,
   type SystemAgentVerifiedInferenceBinding,
@@ -55,26 +57,14 @@ function useFastVerifiedInference(
   return binding;
 }
 
+let restoreCliBackendFixture: (() => void) | undefined;
+
 beforeAll(() => {
-  cliBackendsTesting.setDepsForTest({
-    resolvePluginSetupCliBackend: () => undefined,
-    resolvePluginSetupRegistry: () => ({ cliBackends: [] }) as never,
-    resolveRuntimeCliBackends: () => [
-      {
-        id: "claude-cli",
-        pluginId: "anthropic",
-        modelProvider: "anthropic",
-        bundleMcp: true,
-        bundleMcpMode: "claude-config-file",
-        config: { command: "claude" },
-        sideQuestionToolMode: "disabled",
-      },
-    ],
-  });
+  restoreCliBackendFixture = installSystemAgentClaudeCliBackendTestFixture();
 });
 
 afterAll(() => {
-  cliBackendsTesting.resetDepsForTest();
+  restoreCliBackendFixture?.();
 });
 
 function overview(defaultModel?: string): SystemAgentOverview {

--- a/src/system-agent/operations.setup.test.ts
+++ b/src/system-agent/operations.setup.test.ts
@@ -1,7 +1,7 @@
 // OpenClaw operation tests cover rescue operation planning and execution.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { listAgentEntries } from "../agents/agent-scope-config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -13,6 +13,7 @@ import {
   createSystemAgentTestRuntime,
   expectSystemAgentAuditRecord as expectAuditRecord,
   expectTestRecordFields as expectRecordFields,
+  installSystemAgentClaudeCliBackendTestFixture,
   readLastSystemAgentAuditEntry as readLastAuditEntry,
   requireTestRecord as requireRecord,
 } from "./system-agent.test-helpers.js";
@@ -146,6 +147,15 @@ vi.mock("../state/local-onboarding-state.js", () => ({
 }));
 
 const opTempDirs = useAutoCleanupTempDirTracker(afterEach);
+let restoreCliBackendFixture: (() => void) | undefined;
+
+beforeAll(() => {
+  restoreCliBackendFixture = installSystemAgentClaudeCliBackendTestFixture();
+});
+
+afterAll(() => {
+  restoreCliBackendFixture?.();
+});
 
 describe("parseSystemAgentOperation", () => {
   let stateDirSnapshot: ReturnType<typeof captureEnv> | undefined;

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -133,11 +133,16 @@ const suiteTempRootTracker = createSuiteTempRootTracker({
   prefix: "setup-inference-test-",
 });
 let pluginMetadataSnapshot: SystemAgentPluginMetadataTestSnapshot | undefined;
+let preparedPluginMetadataSnapshot: ReturnType<typeof resolvePluginMetadataSnapshot> | undefined;
 
 beforeAll(async () => {
   pluginMetadataSnapshot = installSystemAgentPluginMetadataTestSnapshot(
     materializedMainRuntimeConfig,
   );
+  preparedPluginMetadataSnapshot = resolvePluginMetadataSnapshot({
+    config: materializedMainRuntimeConfig,
+    env: process.env,
+  });
   cliBackendsTesting.setDepsForTest({
     resolvePluginSetupCliBackend: () => undefined,
     resolvePluginSetupRegistry: () => ({ cliBackends: [] }) as never,
@@ -461,6 +466,13 @@ function mockCodexRuntimeInstall(installRecord?: PluginInstallRecord) {
   })) as never;
 }
 
+function requirePreparedPluginMetadataSnapshot() {
+  if (!preparedPluginMetadataSnapshot) {
+    throw new Error("setup inference plugin metadata fixture was not initialized");
+  }
+  return preparedPluginMetadataSnapshot;
+}
+
 function activateCodexSetup(params: Omit<TestSetupInferenceActivationParams, "kind">) {
   return activateSetupInference({
     kind: "codex-cli",
@@ -469,6 +481,7 @@ function activateCodexSetup(params: Omit<TestSetupInferenceActivationParams, "ki
       ensureCodexRuntimePlugin: mockCodexRuntimeInstall(),
       runEmbeddedAgent: vi.fn(successfulRunner("openai", "gpt-5.6-sol")) as never,
       refreshPluginRegistryAfterConfigMutation: vi.fn(async () => {}) as never,
+      resolvePluginMetadataSnapshot: requirePreparedPluginMetadataSnapshot,
       ...params.deps,
     },
   });

--- a/src/system-agent/verified-inference.test.ts
+++ b/src/system-agent/verified-inference.test.ts
@@ -14,6 +14,7 @@ import type { PluginOrigin } from "../plugins/types.js";
 import { resolveSystemAgentConfiguredRouteFromConfig } from "./inference-route.js";
 import { resolvePersistentApplyInference } from "./setup-inference.js";
 import {
+  installSystemAgentClaudeCliBackendTestFixture,
   installSystemAgentPluginMetadataTestSnapshot,
   type SystemAgentPluginMetadataTestSnapshot,
 } from "./system-agent.test-helpers.js";
@@ -81,12 +82,15 @@ const profile = {
 
 const runtime = { log: () => {}, error: () => {}, exit: () => {} } as never;
 let pluginMetadataSnapshot: SystemAgentPluginMetadataTestSnapshot | undefined;
+let restoreCliBackendFixture: (() => void) | undefined;
 
 beforeAll(() => {
   pluginMetadataSnapshot = installSystemAgentPluginMetadataTestSnapshot(config());
+  restoreCliBackendFixture = installSystemAgentClaudeCliBackendTestFixture();
 });
 
 afterAll(() => {
+  restoreCliBackendFixture?.();
   pluginMetadataSnapshot?.restore();
 });
 


### PR DESCRIPTION
## What Problem This Solves

System-agent unit tests repeatedly performed real CLI backend discovery and plugin metadata scans while exercising mocked routing and persistence behavior. This kept the compact large-8 test job on the critical path despite the tests not owning backend discovery.

## Why This Change Was Made

The affected suites now reuse the existing contract-level Claude CLI fixture. Ordinary mocked Codex activations also reuse the suite's frozen plugin metadata snapshot, while the dedicated plugin-lifecycle test continues to inject the real resolver and prove the forced refresh path.

## User Impact

No user-visible behavior changes. Maintainers get faster system-agent test feedback without changing test counts, workers, sharding, or lifecycle coverage.

## Evidence

- Focused proof: 7/7 isolated tests and 180/180 unit tests passed.
- Same-host warm unit-src baseline: 339 files, 4,142 tests, 118.69 seconds.
- Same-host warm unit-src after: 339 files, 4,142 tests, 109.28 seconds.
- Improvement: 9.41 seconds (7.9%) with identical test membership and worker count.
- Autoreview: clean, no accepted/actionable findings.
