### PR TITLE
fix: attachment cards show original filenames in chat history

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -574,6 +574,7 @@ const config = {
         "src/media-source-url.ts!",
         "src/mime.ts!",
         "src/read-byte-stream-with-limit.ts!",
+        "src/stored-file-name.ts!",
       ],
       project: ["src/**/*.ts!"],
     },

--- a/packages/media-core/package.json
+++ b/packages/media-core/package.json
@@ -58,6 +58,11 @@
       "types": "./dist/read-byte-stream-with-limit.d.mts",
       "import": "./dist/read-byte-stream-with-limit.mjs",
       "default": "./dist/read-byte-stream-with-limit.mjs"
+    },
+    "./stored-file-name": {
+      "types": "./dist/stored-file-name.d.mts",
+      "import": "./dist/stored-file-name.mjs",
+      "default": "./dist/stored-file-name.mjs"
     }
   },
   "dependencies": {
@@ -65,6 +70,6 @@
     "file-type": "22.0.1"
   },
   "scripts": {
-    "build": "tsdown src/index.ts src/base64.ts src/constants.ts src/content-length.ts src/file-name.ts src/inbound-path-policy.ts src/inline-image-data-url.ts src/media-source-url.ts src/mime.ts src/read-byte-stream-with-limit.ts --no-config --platform node --format esm --dts --out-dir dist --clean"
+    "build": "tsdown src/index.ts src/base64.ts src/constants.ts src/content-length.ts src/file-name.ts src/inbound-path-policy.ts src/inline-image-data-url.ts src/media-source-url.ts src/mime.ts src/read-byte-stream-with-limit.ts src/stored-file-name.ts --no-config --platform node --format esm --dts --out-dir dist --clean"
   }
 }

--- a/packages/media-core/src/index.ts
+++ b/packages/media-core/src/index.ts
@@ -9,3 +9,4 @@ export * from "./inline-image-data-url.js";
 export * from "./media-source-url.js";
 export * from "./mime.js";
 export * from "./read-byte-stream-with-limit.js";
+export * from "./stored-file-name.js";

--- a/packages/media-core/src/stored-file-name.ts
+++ b/packages/media-core/src/stored-file-name.ts
@@ -1,0 +1,24 @@
+// Media Core module implements stored file name behavior.
+
+const EMBEDDED_MEDIA_ID_RE =
+  /^(.+)---[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
+
+function storedFileBasename(filePath: string): string {
+  const normalized = filePath.replaceAll("\\", "/").replace(/\/+$/u, "");
+  return normalized.slice(normalized.lastIndexOf("/") + 1);
+}
+
+/** Restores the caller-facing filename from media-store paths with embedded UUID suffixes. */
+export function extractOriginalFilename(filePath: string): string {
+  const basename = storedFileBasename(filePath);
+  if (!basename) {
+    return "file.bin";
+  }
+
+  const extensionIndex = basename.lastIndexOf(".");
+  const hasExtension = extensionIndex > 0;
+  const extension = hasExtension ? basename.slice(extensionIndex) : "";
+  const nameWithoutExtension = hasExtension ? basename.slice(0, extensionIndex) : basename;
+  const match = nameWithoutExtension.match(EMBEDDED_MEDIA_ID_RE);
+  return match?.[1] ? `${match[1]}${extension}` : basename;
+}

--- a/scripts/lib/extension-package-boundary.ts
+++ b/scripts/lib/extension-package-boundary.ts
@@ -177,6 +177,9 @@ export const EXTENSION_PACKAGE_BOUNDARY_BASE_PATHS = {
   "@openclaw/media-core/read-byte-stream-with-limit": [
     "../dist/plugin-sdk/packages/media-core/src/read-byte-stream-with-limit.d.ts",
   ],
+  "@openclaw/media-core/stored-file-name": [
+    "../dist/plugin-sdk/packages/media-core/src/stored-file-name.d.ts",
+  ],
   "@openclaw/media-core/*": ["../dist/plugin-sdk/packages/media-core/src/*.d.ts"],
   "@openclaw/normalization-core/record-coerce": [
     "../dist/plugin-sdk/packages/normalization-core/src/record-coerce.d.ts",

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -3,11 +3,7 @@ import "../infra/fs-safe-defaults.js";
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import {
-  basenameFromAnyPath,
-  extnameFromAnyPath,
-  nameFromAnyPath,
-} from "@openclaw/media-core/file-name";
+import { extnameFromAnyPath, nameFromAnyPath } from "@openclaw/media-core/file-name";
 import {
   detectMime,
   extensionForMime,
@@ -123,25 +119,7 @@ function sanitizeFilename(name: string): string {
   return truncateUtf16Safe(sanitized.replace(/_+/g, "_").replace(/^_|_$/g, ""), 60);
 }
 
-/** Restores the caller-facing filename from media-store paths with embedded UUID suffixes. */
-export function extractOriginalFilename(filePath: string): string {
-  const basename = basenameFromAnyPath(filePath);
-  if (!basename) {
-    return "file.bin";
-  }
-
-  const ext = extnameFromAnyPath(basename);
-  const nameWithoutExt = path.basename(basename, ext);
-
-  const match = nameWithoutExt.match(
-    /^(.+)---[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i,
-  );
-  if (match?.[1]) {
-    return `${match[1]}${ext}`;
-  }
-
-  return basename;
-}
+export { extractOriginalFilename } from "@openclaw/media-core/stored-file-name";
 
 /** Returns the configured absolute media-store root without creating it. */
 export function getMediaDir() {

--- a/src/plugins/plugin-sdk-native-resolver.ts
+++ b/src/plugins/plugin-sdk-native-resolver.ts
@@ -104,6 +104,7 @@ const INTERNAL_CORE_PACKAGE_ALIASES = [
       ["media-source-url", "media-source-url.ts"],
       ["mime", "mime.ts"],
       ["read-byte-stream-with-limit", "read-byte-stream-with-limit.ts"],
+      ["stored-file-name", "stored-file-name.ts"],
     ],
   },
   {

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -530,6 +530,7 @@ const WORKSPACE_PACKAGE_ALIAS_SUBPATHS = [
       "media-source-url",
       "mime",
       "read-byte-stream-with-limit",
+      "stored-file-name",
     ],
   ],
   ["retry", [""]],

--- a/test/vitest/vitest.shared.config.ts
+++ b/test/vitest/vitest.shared.config.ts
@@ -542,6 +542,7 @@ export const sharedVitestConfig = {
       sourcePackageAlias("media-core", "media-source-url"),
       sourcePackageAlias("media-core", "mime"),
       sourcePackageAlias("media-core", "read-byte-stream-with-limit"),
+      sourcePackageAlias("media-core", "stored-file-name"),
       sourcePackageAlias("media-core"),
       sourcePackageAlias("retry"),
       sourcePackageAlias("session-url-contract", "parse"),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -122,6 +122,9 @@
       "@openclaw/media-core/read-byte-stream-with-limit": [
         "./packages/media-core/src/read-byte-stream-with-limit.ts"
       ],
+      "@openclaw/media-core/stored-file-name": [
+        "./packages/media-core/src/stored-file-name.ts"
+      ],
       "@openclaw/media-core/*": ["./packages/media-core/src/*"],
       "@openclaw/media-understanding-common/*": [
         "./packages/media-understanding-common/src/*"

--- a/ui/src/lib/chat/message-extract.test.ts
+++ b/ui/src/lib/chat/message-extract.test.ts
@@ -6,6 +6,7 @@ import {
   extractText,
   extractTextCached,
   extractThinkingCached,
+  readTranscriptMediaEntries,
 } from "./message-extract.ts";
 
 describe("extractTextCached", () => {
@@ -153,5 +154,29 @@ describe("nullish messages", () => {
       expect(extractRawText(message)).toBeNull();
       expect(extractThinkingCached(message)).toBeNull();
     }
+  });
+});
+
+describe("readTranscriptMediaEntries", () => {
+  it("preserves the authoritative persisted filename", () => {
+    expect(
+      readTranscriptMediaEntries({
+        __openclaw: {
+          media: [
+            {
+              path: "media://inbound/report---a1b2c3d4-e5f6-7890-abcd-ef1234567890.pdf",
+              contentType: "application/pdf",
+              fileName: "report.pdf",
+            },
+          ],
+        },
+      }),
+    ).toEqual([
+      {
+        path: "media://inbound/report---a1b2c3d4-e5f6-7890-abcd-ef1234567890.pdf",
+        mediaType: "application/pdf",
+        fileName: "report.pdf",
+      },
+    ]);
   });
 });

--- a/ui/src/lib/chat/message-extract.ts
+++ b/ui/src/lib/chat/message-extract.ts
@@ -134,13 +134,22 @@ function hasTranscriptMediaFacts(message: unknown): boolean {
 export function readTranscriptMediaEntries(message: unknown): Array<{
   path: string;
   mediaType: string | undefined;
+  fileName?: string;
 }> {
   if (!message || typeof message !== "object") {
     return [];
   }
   return (readPersistedMediaFacts(message) ?? []).flatMap((fact) => {
     const path = fact.path ?? fact.url;
-    return path ? [{ path, mediaType: fact.contentType ?? fact.kind }] : [];
+    return path
+      ? [
+          {
+            path,
+            mediaType: fact.contentType ?? fact.kind,
+            ...(fact.fileName ? { fileName: fact.fileName } : {}),
+          },
+        ]
+      : [];
   });
 }
 

--- a/ui/src/pages/chat/components/chat-message-local-media.ts
+++ b/ui/src/pages/chat/components/chat-message-local-media.ts
@@ -12,7 +12,7 @@ export function isLocalAssistantAttachmentSource(source: string): boolean {
   );
 }
 
-function isCanonicalInboundMediaSource(source: string): boolean {
+export function isCanonicalInboundMediaSource(source: string): boolean {
   // Match the raw one-segment form first; URL parsing would erase dot segments.
   const match = /^media:\/\/inbound\/([^/?#]+)$/i.exec(source.trim());
   if (!match?.[1]) {

--- a/ui/src/pages/chat/components/chat-message-media.test.ts
+++ b/ui/src/pages/chat/components/chat-message-media.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mediaPath = "media://inbound/report---a1b2c3d4-e5f6-7890-abcd-ef1234567890.pdf";
+const readTranscriptMediaEntries = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../lib/chat/message-extract.ts", () => ({
+  readTranscriptMediaEntries,
+}));
+vi.mock("../../../lib/media-file-extension.ts", () => ({
+  getMediaFileExtension: () => "pdf",
+  hasVideoMediaFileExtension: () => false,
+}));
+
+import { extractTranscriptAttachments } from "./chat-message-media.ts";
+
+describe("extractTranscriptAttachments", () => {
+  beforeEach(() => {
+    readTranscriptMediaEntries.mockReturnValue([{ path: mediaPath, mediaType: "application/pdf" }]);
+  });
+
+  it("restores the original label from a managed media-store path", () => {
+    expect(
+      extractTranscriptAttachments({
+        role: "user",
+        __openclaw: {
+          media: [{ path: mediaPath, contentType: "application/pdf" }],
+        },
+      }),
+    ).toEqual([
+      {
+        type: "attachment",
+        attachment: {
+          url: mediaPath,
+          kind: "document",
+          label: "report.pdf",
+          mimeType: "application/pdf",
+        },
+      },
+    ]);
+  });
+
+  it("prefers the authoritative filename without changing the managed URI", () => {
+    readTranscriptMediaEntries.mockReturnValue([
+      { path: mediaPath, mediaType: "application/pdf", fileName: "Quarterly report.pdf" },
+    ]);
+
+    expect(extractTranscriptAttachments({ role: "user" })).toEqual([
+      {
+        type: "attachment",
+        attachment: {
+          url: mediaPath,
+          kind: "document",
+          label: "Quarterly report.pdf",
+          mimeType: "application/pdf",
+        },
+      },
+    ]);
+  });
+
+  it("restores the original label for a canonical uppercase media URI", () => {
+    const path = `MEDIA://inbound/report---a1b2c3d4-e5f6-7890-abcd-ef1234567890.pdf`;
+    readTranscriptMediaEntries.mockReturnValue([{ path, mediaType: "application/pdf" }]);
+
+    const [block] = extractTranscriptAttachments({ role: "user" });
+
+    expect(block?.attachment).toMatchObject({ url: path, label: "report.pdf" });
+  });
+
+  it.each([
+    `media://inbound/nested/report---a1b2c3d4-e5f6-7890-abcd-ef1234567890.pdf`,
+    `media://inbound/nested%2Freport---a1b2c3d4-e5f6-7890-abcd-ef1234567890.pdf`,
+    `/tmp/report---a1b2c3d4-e5f6-7890-abcd-ef1234567890.pdf`,
+  ])("does not rewrite a noncanonical inbound source: %s", (path) => {
+    readTranscriptMediaEntries.mockReturnValue([{ path, mediaType: "application/pdf" }]);
+
+    const [block] = extractTranscriptAttachments({ role: "user" });
+
+    expect(block?.attachment.label).toContain("---a1b2c3d4-e5f6-7890-abcd-ef1234567890.pdf");
+  });
+});

--- a/ui/src/pages/chat/components/chat-message-media.ts
+++ b/ui/src/pages/chat/components/chat-message-media.ts
@@ -1,3 +1,4 @@
+import { extractOriginalFilename } from "@openclaw/media-core/stored-file-name";
 import type { ImageLightboxItem } from "../../../components/image-lightbox.ts";
 import { t } from "../../../i18n/index.ts";
 import type { MessageContentItem } from "../../../lib/chat/chat-types.ts";
@@ -6,6 +7,7 @@ import {
   getMediaFileExtension,
   hasVideoMediaFileExtension,
 } from "../../../lib/media-file-extension.ts";
+import { isCanonicalInboundMediaSource } from "./chat-message-local-media.ts";
 
 export type PairingQrExpiryNotice = {
   title: string;
@@ -368,7 +370,8 @@ function labelForMediaPath(mediaPath: string): string {
       return parsed.pathname.split("/").pop()?.trim() || parsed.hostname || trimmed;
     }
   } catch {}
-  return trimmed.split(/[\\/]/).pop()?.trim() || trimmed;
+  const label = trimmed.split(/[\\/]/).pop()?.trim() || trimmed;
+  return isCanonicalInboundMediaSource(trimmed) ? extractOriginalFilename(label) : label;
 }
 
 export function extractImages(message: unknown): ImageBlock[] {
@@ -556,7 +559,7 @@ export function schedulePairingQrExpiryRefresh(
 
 export function extractTranscriptAttachments(message: unknown): AttachmentItem[] {
   const attachments: AttachmentItem[] = [];
-  for (const { path: mediaPath, mediaType } of readTranscriptMediaEntries(message)) {
+  for (const { path: mediaPath, mediaType, fileName } of readTranscriptMediaEntries(message)) {
     if (isImageTranscriptMediaPath(mediaPath, mediaType)) {
       continue;
     }
@@ -570,7 +573,7 @@ export function extractTranscriptAttachments(message: unknown): AttachmentItem[]
       attachment: {
         url: mediaPath,
         kind,
-        label: labelForMediaPath(mediaPath),
+        label: fileName?.trim() || labelForMediaPath(mediaPath),
         ...(typeof mediaType === "string" ? { mimeType: mediaType } : {}),
       },
     });


### PR DESCRIPTION
# Pull request draft

## Title

fix: attachment cards show original filenames in chat history

## Body

Closes #118621

## What Problem This Solves

Fixes an issue where users viewing uploaded files in Control UI chat history would see collision-safe managed names such as `report---<uuid>.pdf` instead of the original upload filename.

## Why This Change Was Made

Transcript media extraction now preserves the canonical persisted `fileName`, and attachment rendering prefers that authoritative label. For shipped path-only history, a browser-safe media-core helper restores only an exact final managed UUID suffix from canonical `media://inbound/` labels; stored IDs, URIs, provider input, and attachment resolution remain unchanged.

## User Impact

Uploaded document, audio, and video cards in chat history display familiar original filenames. Existing path-only history also receives a clean display label when its managed basename matches the exact `name---UUID.ext` contract.

## Evidence

Before:

`media://inbound/report---a1b2c3d4-e5f6-7890-abcd-ef1234567890.pdf` rendered as `report---a1b2c3d4-e5f6-7890-abcd-ef1234567890.pdf`.

After:

The same managed URI renders as `report.pdf`; an authoritative persisted `fileName` takes precedence. The URL remains byte-for-byte unchanged.

Validation:

- Control UI focused tests: 31 passed, including canonical uppercase plus nested, encoded, and local noncanonical URI regressions.
- Existing media-store tests: 49 passed.
- Core and Control UI typechecks: passed.
- Control UI production build: passed.
- `@openclaw/media-core` build: passed.
- Package resolver/tooling tests: 197 passed; two `sdk-alias` memoization assertions fail identically on clean `upstream/main`.
- Dead-export audits: passed with zero entries.
- Changed-file formatting and `git diff --check`: passed.
- Independent review blockers resolved: fallback stripping now reuses the canonical one-segment inbound predicate, and the new media-core subpath is registered in every explicit package-resolution mirror.
- Full aggregate `pnpm run check` exceeded the local 10-minute tool limit without a source diagnostic; a separate scripts typecheck was stopped after 15 minutes without a diagnostic. The targeted changed-surface gates above passed.

No generated Control UI bundle or stored media path is changed by this patch.
