### PR TITLE
chore(tui): stabilize queued-turn admission in Gateway PTY test

### DIFF
--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -1327,7 +1327,7 @@ describe("TUI PTY real backends", () => {
         queueClient.onConnected = () => {
           queueClientConnected = true;
         };
-        // Queue admission emits chat/final before its chat.send ACK may arrive.
+        // Retain admission events that arrive before both chat.send ACKs settle.
         queueClient.onEvent = ({ event, payload }) => {
           if (event !== "chat" || !payload || typeof payload !== "object") {
             return;

--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -1323,8 +1323,23 @@ describe("TUI PTY real backends", () => {
       });
       try {
         let queueClientConnected = false;
+        const admittedRunIds = new Set<string>();
         queueClient.onConnected = () => {
           queueClientConnected = true;
+        };
+        // Queue admission emits chat/final before its chat.send ACK may arrive.
+        queueClient.onEvent = ({ event, payload }) => {
+          if (event !== "chat" || !payload || typeof payload !== "object") {
+            return;
+          }
+          const chatEvent = payload as { runId?: unknown; sessionKey?: unknown; state?: unknown };
+          if (
+            chatEvent.state === "final" &&
+            chatEvent.sessionKey === fixture.sessionKey &&
+            typeof chatEvent.runId === "string"
+          ) {
+            admittedRunIds.add(chatEvent.runId);
+          }
         };
         queueClient.start();
         await waitFor({
@@ -1332,6 +1347,7 @@ describe("TUI PTY real backends", () => {
           read: () => (queueClientConnected ? true : null),
           onTimeout: () => new Error("TUI Gateway client did not connect"),
         });
+        await queueClient.subscribeSessionEvents();
         await fixture.run.write("/queue collect debounce:250ms\r", { delay: false });
         await fixture.waitForOutput("Queue mode set to collect.");
         await fixture.run.write("slow collect parent\r");
@@ -1345,16 +1361,23 @@ describe("TUI PTY real backends", () => {
           sessionKey: fixture.sessionKey,
           message: "collect prompt alpha",
         });
-        await sleep(50);
         const betaSend = queueClient.sendChat({
           sessionKey: fixture.sessionKey,
           message: "collect prompt beta",
         });
         const sendResults = await Promise.all([alphaSend, betaSend]);
         expect(sendResults.map((result) => result.status)).toEqual(["started", "started"]);
-        // Let both Gateway submissions reach the active-turn queue before the
-        // parent response opens the collect debounce window.
-        await sleep(1_000);
+        const expectedRunIds = sendResults.map(({ runId }) => runId);
+        await waitFor({
+          timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
+          read: () => (expectedRunIds.every((runId) => admittedRunIds.has(runId)) ? true : null),
+          onTimeout: () =>
+            new Error(
+              `queued prompts were not admitted: expected ${expectedRunIds.join(", ")}; ` +
+                `observed ${[...admittedRunIds].join(", ")}\n${fixture.gateway.logs()}\n` +
+                fixture.run.output(),
+            ),
+        });
         fixture.mockModel.releaseFirstResponse();
         await waitFor({
           timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,


### PR DESCRIPTION
## What Problem This Solves

The real Gateway-and-PTY queued-turn integration test can release a blocked parent turn before the follow-up prompt has actually been admitted. Busy four-CPU runners can then miss that prompt, causing unrelated contributor pull requests such as #117992 to fail despite correct production behavior.

## Why This Change Was Made

Wait for the existing queued-turn admission signal before releasing the parent turn. The change modifies one existing integration test only and changes no production code, configuration, or API.

## User Impact

No production or user-facing behavior changes. Contributors and maintainers get stable CI coverage for queued Gateway turns and fewer unrelated pull-request failures.

## Evidence

- Real Gateway plus PTY end-to-end: 4/4 runs passed, including three runs on four-CPU workers.
- Focused Gateway owner integration: 1/1 passed.
- Changed-file verification gates: 16/16 passed.
- Independent high-effort review: clean; production files changed: 0.
- Related contributor pull request: #117992.
