### PR TITLE
fix(pdf): reject requested pages outside the document range

### DIFF
--- a/extensions/document-extract/document-extractor.test.ts
+++ b/extensions/document-extract/document-extractor.test.ts
@@ -176,6 +176,24 @@ describe("PDF document extractor", () => {
     );
   });
 
+  it("rejects selected pages outside the PDF page count before extraction", async () => {
+    pdfDocument.pageCount = 1;
+    pdfDocument.extract.mockResolvedValueOnce({ text: "", images: [] });
+    const extractor = createPdfDocumentExtractor();
+
+    await expect(extractor.extract(request({ pageNumbers: [2] }))).rejects.toThrow(
+      "No requested PDF pages exist in this 1-page document.",
+    );
+    expect(pdfDocument.extract).not.toHaveBeenCalled();
+    expect(pdfDocument.destroy).toHaveBeenCalledTimes(1);
+
+    await expect(extractor.extract(request({ pageNumbers: [] }))).resolves.toEqual({
+      text: "",
+      images: [],
+    });
+    expect(pdfDocument.destroy).toHaveBeenCalledTimes(2);
+  });
+
   it("reports image fallback failures and returns extracted text", async () => {
     const onImageExtractionError = vi.fn();
     const failure = new Error("render failed");

--- a/extensions/document-extract/document-extractor.ts
+++ b/extensions/document-extract/document-extractor.ts
@@ -70,6 +70,9 @@ async function extractPdfContent(
           .filter((p) => Number.isInteger(p) && p >= 1 && p <= pdf.pageCount)
           .slice(0, request.maxPages)
       : undefined;
+    if (request.pageNumbers?.length && pages?.length === 0) {
+      throw new Error(`No requested PDF pages exist in this ${pdf.pageCount}-page document.`);
+    }
     const pageSelection = pages ? { pages } : { maxPages: request.maxPages };
 
     const textResult = await pdf.extract({


### PR DESCRIPTION
## Summary
- Fail visibly when an explicitly requested nonempty PDF page selection contains no pages that actually exist.
- Prevent nonexistent pages from silently producing empty document context and triggering paid model work.
- Preserve intentionally empty selections, mixed valid/invalid selection filtering, valid blank documents, and zero-page PDFs.

## Exact real PDFium dependency and production-owner transcript
The actual installed clawpdf/PDFium dependency correctly raises `PdfPageRangeError` when page 2 is requested from a one-page document. The production owner previously erased that error by filtering the requested page list to an empty array and returning `{"text":"","images":[]}`.

Actual post-fix terminal proof using three fully in-memory genuine PDFs, the real installed PDFium renderer, and the production owner; no parser/render mocks, files, network, provider, or credentials:

```json
{
  "dependency":"clawpdf@0.3.0",
  "pdfiumRelease":"7623",
  "pdfFixtures":{"scannedBytes":677,"blankBytes":431,"zeroPageBytes":235,"allInMemory":true},
  "actualPageCount":1,
  "configuredMaxPages":20,
  "dependencyContract":{"invalidPageErrorName":"PdfPageRangeError","invalidPageErrorCode":"page_range","invalidPageErrorMessage":"Page 2 is outside 1..1","explicitEmptyPagesAccepted":true},
  "defaultSelection":{"imageCount":1,"mimeType":"image/png"},
  "validExplicitSelection":{"requestedPages":[1],"imageCount":1},
  "mixedSelection":{"requestedPages":[2,1],"validPagesRendered":1},
  "explicitEmptySelection":{"text":"","images":[]},
  "validBlankDocument":{"text":"","images":[]},
  "validZeroPageDocument":{"text":"","images":[]},
  "invalidSelection":{"requestedPages":[2],"error":"No requested PDF pages exist in this 1-page document.","imageExtractionCallbackCount":0},
  "documentLifecycle":{"opened":7,"released":7,"allReleased":true}
}
```

Exact focused owner regression output:

```text
$ node scripts/run-vitest.mjs extensions/document-extract/document-extractor.test.ts
[test] starting test/vitest/vitest.extensions.config.ts
 Test Files  1 passed (1)
      Tests  10 passed (10)
   Duration  617ms
[test] passed 1 Vitest shard in 3.35s
```

## Verification
- Deterministic red-before-green proof reproduced the original silently successful page-2-of-1 request.
- An additional compatibility review caught and preserved the upstream contract that an explicitly empty selection is legitimate.
- Real PDFium proved normal, valid explicit, mixed valid/invalid, empty, blank, zero-page, and invalid selections.
- All seven real opened documents were released.
- Independent structured review: clean, confidence 0.97.
- Production-code delta: +3 lines; no API, configuration, dependency, migration, or schema changes.