### PR TITLE
fix(codex): avoid duplicate subagents after yielded fanout

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -444,6 +444,51 @@ describe("createCodexDynamicToolBridge", () => {
     expect(onAgentToolResult).toHaveBeenCalledWith(
       expect.objectContaining({ toolName: "sessions_spawn", isError: false }),
     );
+    expect(bridge.telemetry.acceptedSessionSpawns).toEqual([
+      { runId: "run_5f3a9c", childSessionKey: "child-7b21" },
+    ]);
+  });
+
+  it("preserves an accepted sessions_spawn after result middleware strips its details", async () => {
+    const registry = createEmptyPluginRegistry();
+    const handler = vi.fn(async (event: { result: AgentToolResult<unknown> }) => ({
+      result: {
+        ...event.result,
+        content: [{ type: "text" as const, text: "Child launch recorded." }],
+        details: {},
+      },
+    }));
+    registry.agentToolResultMiddlewares.push({
+      pluginId: "result-compactor",
+      pluginName: "Result Compactor",
+      rawHandler: handler,
+      handler,
+      runtimes: ["codex"],
+      source: "test",
+    });
+    setActivePluginRegistry(registry);
+    const bridge = createBridgeWithToolResult(
+      "sessions_spawn",
+      textToolResult("Accepted: launching child session.", {
+        status: "accepted",
+        runId: "run_compacted",
+        childSessionKey: "child-compacted",
+      }),
+    );
+
+    const result = await bridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-compacted",
+      namespace: null,
+      tool: "sessions_spawn",
+      arguments: { task: "scan logs" },
+    });
+
+    expect(result).toEqual(expectInputText("Child launch recorded."));
+    expect(bridge.telemetry.acceptedSessionSpawns).toEqual([
+      { runId: "run_compacted", childSessionKey: "child-compacted" },
+    ]);
   });
 
   it("retains only MCP App preview details for OpenClaw transcript projection", async () => {
@@ -500,6 +545,7 @@ describe("createCodexDynamicToolBridge", () => {
     });
 
     expect(result.success).toBe(false);
+    expect(bridge.telemetry.acceptedSessionSpawns).toEqual([]);
   });
 
   it("treats accepted goal tool statuses (created / updated) as successful dynamic tool calls", async () => {

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -45,7 +45,11 @@ import { emitTrustedDiagnosticEvent } from "openclaw/plugin-sdk/diagnostic-runti
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import type { ImageContent, TextContent } from "openclaw/plugin-sdk/llm";
 import { normalizeOpenAIToolSchemas } from "openclaw/plugin-sdk/provider-tools";
-import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  asOptionalRecord,
+  isRecord,
+  normalizeOptionalString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS,
   estimateToolResultTextChars,
@@ -381,9 +385,23 @@ export type CodexDynamicToolBridge = {
     toolMediaUrls: string[];
     toolAudioAsVoice: boolean;
     successfulCronAdds?: number;
+    acceptedSessionSpawns: Array<{ runId: string; childSessionKey: string }>;
     quarantinedTools: CodexDynamicToolSchemaQuarantine[];
   };
 };
+
+function normalizeAcceptedSessionSpawn(result: unknown): {
+  runId: string;
+  childSessionKey: string;
+} | null {
+  const details = asOptionalRecord(asOptionalRecord(result)?.details);
+  if (!details || details.status !== "accepted") {
+    return null;
+  }
+  const runId = normalizeOptionalString(details.runId);
+  const childSessionKey = normalizeOptionalString(details.childSessionKey);
+  return runId && childSessionKey ? { runId, childSessionKey } : null;
+}
 
 /** Namespace attached to OpenClaw-owned dynamic tools exposed to Codex. */
 const CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE = "openclaw";
@@ -490,6 +508,7 @@ export function createCodexDynamicToolBridge(params: {
     messagingToolSourceReplyPayloads: [],
     toolMediaUrls: [],
     toolAudioAsVoice: false,
+    acceptedSessionSpawns: [],
     quarantinedTools,
   };
   const middlewareRunner = createAgentToolResultMiddlewareRunner({
@@ -654,6 +673,14 @@ export function createCodexDynamicToolBridge(params: {
           result: middlewareResult,
         });
         const resultIsError = rawIsError || isToolResultError(result);
+        // A successful spawn is durable before presentation middleware can rewrite details.
+        const acceptedSessionSpawn =
+          toolName === "sessions_spawn" && !rawIsError
+            ? normalizeAcceptedSessionSpawn(telemetryRawResult)
+            : null;
+        if (acceptedSessionSpawn) {
+          telemetry.acceptedSessionSpawns.push(acceptedSessionSpawn);
+        }
         const finalResultFailureKind = resolveToolResultFailureKind(result);
         const resultFailureKind = rawResultFailureKind ?? finalResultFailureKind;
         const observerResult =

--- a/extensions/codex/src/app-server/event-projector.commentary.test.ts
+++ b/extensions/codex/src/app-server/event-projector.commentary.test.ts
@@ -647,7 +647,7 @@ describe("CodexAppServerEventProjector commentary projection", () => {
     expect(result.lastAssistant).toBeUndefined();
   });
 
-  it("preserves sessions_yield detection in attempt results", () => {
+  it("preserves accepted session spawns as yield continuation evidence", () => {
     const projector = new CodexAppServerEventProjector(
       {
         prompt: "hello",
@@ -664,8 +664,20 @@ describe("CodexAppServerEventProjector commentary projection", () => {
       TURN_ID,
     );
 
-    const result = projector.buildResult(buildEmptyToolTelemetry(), { yieldDetected: true });
+    const result = projector.buildResult(
+      {
+        ...buildEmptyToolTelemetry(),
+        acceptedSessionSpawns: [
+          { runId: "child-run", childSessionKey: "agent:main:subagent:child" },
+        ],
+      },
+      { yieldDetected: true },
+    );
 
     expect(result.yieldDetected).toBe(true);
+    expect(result.acceptedSessionSpawns).toEqual([
+      { runId: "child-run", childSessionKey: "agent:main:subagent:child" },
+    ]);
+    expect(result.replayMetadata).toEqual({ hadPotentialSideEffects: true, replaySafe: false });
   });
 });

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -73,7 +73,7 @@ type CodexAppServerToolTelemetry = {
   toolMediaUrls?: string[];
   toolAudioAsVoice?: boolean;
   successfulCronAdds?: number;
-};
+} & Pick<EmbeddedRunAttemptResult, "acceptedSessionSpawns">;
 
 export class CodexAppServerEventProjector {
   private readonly assistantProjection: CodexAssistantProjection;
@@ -403,7 +403,7 @@ export class CodexAppServerEventProjector {
     const toolMetas = this.toolProgressProjection.toolMetas;
     const hadPotentialSideEffects =
       toolTelemetry.didSendViaMessagingTool ||
-      (toolTelemetry.successfulCronAdds ?? 0) > 0 ||
+      Boolean(toolTelemetry.successfulCronAdds || toolTelemetry.acceptedSessionSpawns?.length) ||
       this.generatedMediaProjection.hasGeneratedMedia() ||
       this.toolProgressProjection.hasPotentialSideEffects;
     return {
@@ -439,6 +439,7 @@ export class CodexAppServerEventProjector {
       hostOwnedToolMediaUrls: this.generatedMediaProjection.buildHostOwnedMediaUrls(toolTelemetry),
       toolAudioAsVoice: toolTelemetry.toolAudioAsVoice,
       successfulCronAdds: toolTelemetry.successfulCronAdds,
+      acceptedSessionSpawns: toolTelemetry.acceptedSessionSpawns,
       cloudCodeAssistFormatError: false,
       attemptUsage: projectedUsage,
       ...(this.completedCompactionCount > 0


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Codex app-server users could launch duplicate subagents and time out when a turn spawned children and yielded for their completion.

The accepted child launches were visible in the tool result, but result middleware could remove those structured details before the run attempt recorded continuation evidence. The yielded turn was then treated as replay-safe and the parent prompt ran again.

## Why This Change Was Made

Record accepted `sessions_spawn` evidence from the sanitized execution result before presentation middleware runs, then carry it through the Codex event projector into the normal subagent continuation and replay-safety paths.

This keeps the fix inside the Codex app-server bridge while matching the existing embedded-agent runtime contract.

## User Impact

Codex turns that yield after spawning subagents now wait for the accepted children and resume with their results instead of replaying the parent prompt and launching duplicates.

## Evidence

- Before: the exact `subagent-fanout-synthesis` Codex cell timed out after 90 seconds with six tool calls and duplicate alpha/beta launches.
- After: Blacksmith Testbox `tbx_01kz3nngvx2st4cjwdd7ks9ggy`, run https://github.com/openclaw/openclaw/actions/runs/30809157173:
  - targeted Codex lint passed
  - 149 focused Codex tests passed
  - OpenClaw and Codex runtime-pair fanout cells both passed
  - `pnpm check:changed` passed for `extensions`, `extensionTests`, and `docs`
- Fresh autoreview: no accepted/actionable findings; overall correctness 0.98.
- Direct Codex contract checked: `turn/steer` accepts input only for the matching active turn, so OpenClaw must preserve accepted child-launch evidence and wait rather than replaying the parent prompt.

- [x] AI-assisted; I reviewed and understand the implementation and proof.
