### PR TITLE
test(agents): reuse attempt execution SQLite fixtures

### DIFF
--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -26,6 +26,7 @@ import {
 } from "../../state/openclaw-agent-db.js";
 import { registerGeneratedMediaTaskActivity } from "../../tasks/generated-media-task-activity.js";
 import { resetGeneratedMediaTaskActivityForTests } from "../../tasks/task-runtime.test-helpers.js";
+import { createSuiteTempRootTracker } from "../../test-helpers/temp-dir.js";
 import { captureEnv, setTestEnvValue } from "../../test-utils/env.js";
 import {
   clearRuntimeAuthProfileStoreSnapshots,
@@ -508,6 +509,7 @@ function firstEmbeddedAgentArg(callIndex = 0) {
 }
 
 describe("CLI attempt execution", () => {
+  const fixtureRoot = createSuiteTempRootTracker({ prefix: "openclaw-cli-attempt-suite-" });
   let suiteRoot: string;
   let agentDir: string;
   let tmpDir: string;
@@ -515,7 +517,7 @@ describe("CLI attempt execution", () => {
   let homeEnvSnapshot: ReturnType<typeof captureEnv> | undefined;
 
   beforeAll(async () => {
-    suiteRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-attempt-suite-"));
+    suiteRoot = await fixtureRoot.setup();
     agentDir = path.join(suiteRoot, "agents", "main", "agent");
     storePath = path.join(suiteRoot, "sessions.json");
     await fs.mkdir(agentDir, { recursive: true });
@@ -616,7 +618,7 @@ describe("CLI attempt execution", () => {
   beforeEach(async () => {
     homeEnvSnapshot = captureEnv(["HOME", "OPENCLAW_STATE_DIR"]);
     setTestEnvValue("OPENCLAW_STATE_DIR", suiteRoot);
-    tmpDir = await fs.mkdtemp(path.join(suiteRoot, "case-"));
+    tmpDir = await fixtureRoot.make();
     runCliAgentMock.mockReset();
     runEmbeddedAgentMock.mockReset();
     resetGeneratedMediaTaskActivityForTests();
@@ -719,7 +721,7 @@ describe("CLI attempt execution", () => {
         });
       }
     }
-    await fs.rm(suiteRoot, { recursive: true, force: true });
+    await fixtureRoot.cleanup();
   });
 
   it("forwards explicit local-agent timeouts while preserving the default when omitted", async () => {

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../../config/sessions.js";
 import {
   formatSqliteSessionFileMarker,
@@ -19,11 +19,18 @@ import { clearSessionStoreCacheForTest } from "../../config/sessions/store-write
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
 import { createTestUserTurnTranscriptTarget } from "../../sessions/user-turn-transcript.test-support.js";
-import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import {
+  disposeOpenClawAgentDatabaseByPath,
+  listOpenClawAgentDatabasesForTest,
+  runOpenClawAgentWriteTransaction,
+} from "../../state/openclaw-agent-db.js";
 import { registerGeneratedMediaTaskActivity } from "../../tasks/generated-media-task-activity.js";
 import { resetGeneratedMediaTaskActivityForTests } from "../../tasks/task-runtime.test-helpers.js";
 import { captureEnv, setTestEnvValue } from "../../test-utils/env.js";
-import { saveAuthProfileStore } from "../auth-profiles/store.js";
+import {
+  clearRuntimeAuthProfileStoreSnapshots,
+  saveAuthProfileStore,
+} from "../auth-profiles/store.js";
 import { testing as cliBackendsTesting } from "../cli-backends.test-support.js";
 import type { EmbeddedAgentRunResult } from "../embedded-agent.js";
 import { FailoverError } from "../failover-error.js";
@@ -501,9 +508,18 @@ function firstEmbeddedAgentArg(callIndex = 0) {
 }
 
 describe("CLI attempt execution", () => {
+  let suiteRoot: string;
+  let agentDir: string;
   let tmpDir: string;
   let storePath: string;
   let homeEnvSnapshot: ReturnType<typeof captureEnv> | undefined;
+
+  beforeAll(async () => {
+    suiteRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-attempt-suite-"));
+    agentDir = path.join(suiteRoot, "agents", "main", "agent");
+    storePath = path.join(suiteRoot, "sessions.json");
+    await fs.mkdir(agentDir, { recursive: true });
+  });
 
   async function runOpenClawEmbeddedAttemptForTest(overrides?: {
     opts?: Partial<RunAgentAttemptParams["opts"]>;
@@ -585,7 +601,7 @@ describe("CLI attempt execution", () => {
       messageChannel: "telegram",
       skillsSnapshot: undefined,
       resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
+      agentDir,
       onAgentEvent: vi.fn(),
       authProfileProvider: providerOverride,
       sessionStore,
@@ -599,8 +615,8 @@ describe("CLI attempt execution", () => {
 
   beforeEach(async () => {
     homeEnvSnapshot = captureEnv(["HOME", "OPENCLAW_STATE_DIR"]);
-    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-attempt-"));
-    storePath = path.join(tmpDir, "sessions.json");
+    setTestEnvValue("OPENCLAW_STATE_DIR", suiteRoot);
+    tmpDir = await fs.mkdtemp(path.join(suiteRoot, "case-"));
     runCliAgentMock.mockReset();
     runEmbeddedAgentMock.mockReset();
     resetGeneratedMediaTaskActivityForTests();
@@ -633,7 +649,6 @@ describe("CLI attempt execution", () => {
     for (const [sessionKey, entry] of Object.entries(sessionStore)) {
       await replaceSessionEntry({ sessionKey, storePath }, entry);
     }
-    closeOpenClawAgentDatabasesForTest();
   }
 
   function createSubagentAnnounceSessionStore(
@@ -668,10 +683,43 @@ describe("CLI attempt execution", () => {
   afterEach(async () => {
     vi.useRealTimers();
     cliBackendsTesting.resetDepsForTest();
-    closeOpenClawAgentDatabasesForTest();
+    clearRuntimeAuthProfileStoreSnapshots();
+    clearSessionStoreCacheForTest();
+    for (const database of listOpenClawAgentDatabasesForTest()) {
+      if (!database.path.startsWith(`${suiteRoot}${path.sep}`)) {
+        continue;
+      }
+      runOpenClawAgentWriteTransaction(
+        (fixture) => {
+          fixture.db.exec(`
+            DELETE FROM session_transcript_fts;
+            DELETE FROM session_nodes;
+            DELETE FROM conversations;
+            DELETE FROM auth_profile_store;
+            DELETE FROM auth_profile_state;
+            DELETE FROM cache_entries;
+            DELETE FROM state_leases;
+          `);
+        },
+        database,
+        { operationLabel: "test.attempt-execution.reset" },
+      );
+    }
+    await fs.rm(tmpDir, { recursive: true, force: true });
+    await fs.rm(storePath, { force: true });
     homeEnvSnapshot?.restore();
     homeEnvSnapshot = undefined;
-    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  afterAll(async () => {
+    for (const database of listOpenClawAgentDatabasesForTest()) {
+      if (database.path.startsWith(`${suiteRoot}${path.sep}`)) {
+        disposeOpenClawAgentDatabaseByPath(database.path, {
+          env: { OPENCLAW_STATE_DIR: suiteRoot },
+        });
+      }
+    }
+    await fs.rm(suiteRoot, { recursive: true, force: true });
   });
 
   it("forwards explicit local-agent timeouts while preserving the default when omitted", async () => {
@@ -742,7 +790,7 @@ describe("CLI attempt execution", () => {
       messageChannel: undefined,
       skillsSnapshot: undefined,
       resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
+      agentDir,
       onAgentEvent: vi.fn(),
       authProfileProvider: "claude-cli",
       sessionStore: params.sessionStore,
@@ -881,7 +929,7 @@ describe("CLI attempt execution", () => {
       messageChannel: undefined,
       skillsSnapshot: undefined,
       resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
+      agentDir,
       onAgentEvent: vi.fn(),
       authProfileProvider: "claude-cli",
       sessionStore,
@@ -1278,7 +1326,7 @@ describe("CLI attempt execution", () => {
       messageChannel: undefined,
       skillsSnapshot: undefined,
       resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
+      agentDir,
       onAgentEvent: vi.fn(),
       authProfileProvider: "claude-cli",
       sessionHasHistory: false,
@@ -1556,7 +1604,7 @@ describe("CLI attempt execution", () => {
       messageChannel: undefined,
       skillsSnapshot: undefined,
       resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
+      agentDir,
       onAgentEvent: vi.fn(),
       authProfileProvider: "openai",
       sessionStore,
@@ -1608,7 +1656,7 @@ describe("CLI attempt execution", () => {
       messageChannel: undefined,
       skillsSnapshot: undefined,
       resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
+      agentDir,
       onAgentEvent: vi.fn(),
       authProfileProvider: "openai-codex",
       sessionStore,
@@ -1641,7 +1689,7 @@ describe("CLI attempt execution", () => {
           },
         },
       },
-      tmpDir,
+      agentDir,
       { filterExternalAuthProfiles: false, syncExternalCli: false },
     );
     runCliAgentMock.mockResolvedValueOnce(makeCliResult("gemini cli response"));
@@ -1683,7 +1731,7 @@ describe("CLI attempt execution", () => {
       messageChannel: undefined,
       skillsSnapshot: undefined,
       resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
+      agentDir,
       onAgentEvent: vi.fn(),
       authProfileProvider: "google",
       sessionStore,
@@ -1716,7 +1764,7 @@ describe("CLI attempt execution", () => {
           },
         },
       },
-      tmpDir,
+      agentDir,
       { filterExternalAuthProfiles: false, syncExternalCli: false },
     );
     runCliAgentMock.mockResolvedValueOnce(makeCliResult("gemini cli api-key response"));
@@ -1753,7 +1801,7 @@ describe("CLI attempt execution", () => {
       messageChannel: undefined,
       skillsSnapshot: undefined,
       resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
+      agentDir,
       onAgentEvent: vi.fn(),
       authProfileProvider: "google",
       sessionStore,
@@ -1786,7 +1834,7 @@ describe("CLI attempt execution", () => {
           },
         },
       },
-      tmpDir,
+      agentDir,
       { filterExternalAuthProfiles: false, syncExternalCli: false },
     );
     expect(() =>
@@ -1822,7 +1870,7 @@ describe("CLI attempt execution", () => {
         messageChannel: undefined,
         skillsSnapshot: undefined,
         resolvedVerboseLevel: undefined,
-        agentDir: tmpDir,
+        agentDir,
         onAgentEvent: vi.fn(),
         authProfileProvider: "google",
         sessionStore,
@@ -1861,7 +1909,7 @@ describe("CLI attempt execution", () => {
           },
         },
       },
-      tmpDir,
+      agentDir,
       { filterExternalAuthProfiles: false, syncExternalCli: false },
     );
     runCliAgentMock.mockResolvedValueOnce(makeCliResult("gemini cli api-key response"));
@@ -1903,7 +1951,7 @@ describe("CLI attempt execution", () => {
       messageChannel: undefined,
       skillsSnapshot: undefined,
       resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
+      agentDir,
       onAgentEvent: vi.fn(),
       authProfileProvider: "google",
       sessionStore,
@@ -1934,7 +1982,7 @@ describe("CLI attempt execution", () => {
           },
         },
       },
-      tmpDir,
+      agentDir,
       { filterExternalAuthProfiles: false, syncExternalCli: false },
     );
     runCliAgentMock.mockResolvedValueOnce(makeCliResult("gemini cli api-key response"));
@@ -1976,7 +2024,7 @@ describe("CLI attempt execution", () => {
       messageChannel: undefined,
       skillsSnapshot: undefined,
       resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
+      agentDir,
       onAgentEvent: vi.fn(),
       authProfileProvider: "google",
       sessionStore,
@@ -1997,7 +2045,7 @@ describe("CLI attempt execution", () => {
       const sessionKey = `agent:main:internal-session-effects:${visibleSessionId}`;
       setTestEnvValue("HOME", tmpDir);
       setTestEnvValue("OPENCLAW_STATE_DIR", path.join(tmpDir, "state"));
-      const internalStorePath = path.join(tmpDir, "sessions.json");
+      const internalStorePath = storePath;
       const internalSessionFile = formatSqliteSessionFileMarker({
         agentId: "main",
         sessionId,
@@ -2643,7 +2691,7 @@ describe("CLI attempt execution", () => {
       messageChannel: "discord",
       skillsSnapshot: undefined,
       resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
+      agentDir,
       onAgentEvent: vi.fn(),
       authProfileProvider: "claude-cli",
       sessionStore,
@@ -2700,7 +2748,7 @@ describe("CLI attempt execution", () => {
       messageChannel: "discord",
       skillsSnapshot: undefined,
       resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
+      agentDir,
       onAgentEvent: vi.fn(),
       authProfileProvider: "claude-cli",
       sessionStore,
@@ -2752,7 +2800,7 @@ describe("CLI attempt execution", () => {
       messageChannel: undefined,
       skillsSnapshot: undefined,
       resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
+      agentDir,
       onAgentEvent: vi.fn(),
       authProfileProvider: "claude-cli",
       sessionStore,
@@ -2782,7 +2830,7 @@ describe("CLI attempt execution", () => {
           },
         },
       },
-      tmpDir,
+      agentDir,
       { filterExternalAuthProfiles: false, syncExternalCli: false },
     );
     runCliAgentMock.mockResolvedValueOnce(makeCliResult("configured claude cli"));
@@ -2835,7 +2883,7 @@ describe("CLI attempt execution", () => {
       messageChannel: undefined,
       skillsSnapshot: undefined,
       resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
+      agentDir,
       onAgentEvent: vi.fn(),
       authProfileProvider: "anthropic",
       sessionStore,
@@ -2898,7 +2946,7 @@ describe("CLI attempt execution", () => {
       messageChannel: "discord",
       skillsSnapshot: undefined,
       resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
+      agentDir,
       onAgentEvent: vi.fn(),
       authProfileProvider: "claude-cli",
       sessionStore,
@@ -2975,7 +3023,7 @@ describe("CLI attempt execution", () => {
         messageChannel: "telegram",
         skillsSnapshot: undefined,
         resolvedVerboseLevel: undefined,
-        agentDir: tmpDir,
+        agentDir,
         onAgentEvent: vi.fn(),
         authProfileProvider: "claude-cli",
         sessionStore,
@@ -3129,7 +3177,7 @@ describe("CLI attempt execution", () => {
       messageChannel: "telegram",
       skillsSnapshot: undefined,
       resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
+      agentDir,
       onAgentEvent: vi.fn(),
       authProfileProvider: "claude-cli",
       sessionStore,
@@ -3190,7 +3238,7 @@ describe("CLI attempt execution", () => {
       messageChannel: "discord",
       skillsSnapshot: undefined,
       resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
+      agentDir,
       onAgentEvent: vi.fn(),
       authProfileProvider: "claude-cli",
       sessionStore,
@@ -3251,7 +3299,7 @@ describe("CLI attempt execution", () => {
       messageChannel: "telegram",
       skillsSnapshot: undefined,
       resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
+      agentDir,
       onAgentEvent: vi.fn(),
       authProfileProvider: "anthropic",
       sessionStore,
@@ -3319,7 +3367,7 @@ describe("CLI attempt execution", () => {
       messageChannel: "telegram",
       skillsSnapshot: undefined,
       resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
+      agentDir,
       onAgentEvent: vi.fn(),
       authProfileProvider: "anthropic",
       sessionStore,
@@ -3388,7 +3436,7 @@ describe("CLI attempt execution", () => {
       messageChannel: "telegram",
       skillsSnapshot: undefined,
       resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
+      agentDir,
       onAgentEvent: vi.fn(),
       authProfileProvider: "openai",
       sessionStore,
@@ -3751,7 +3799,7 @@ describe("CLI attempt execution", () => {
           },
         },
       },
-      tmpDir,
+      agentDir,
       { filterExternalAuthProfiles: false, syncExternalCli: false },
     );
     runEmbeddedAgentMock.mockResolvedValueOnce({
@@ -3780,7 +3828,7 @@ describe("CLI attempt execution", () => {
       messageChannel: undefined,
       skillsSnapshot: undefined,
       resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
+      agentDir,
       onAgentEvent: vi.fn(),
       authProfileProvider: "fixture",
       sessionStore,
@@ -3827,7 +3875,7 @@ describe("CLI attempt execution", () => {
           },
         },
       },
-      tmpDir,
+      agentDir,
       { filterExternalAuthProfiles: false, syncExternalCli: false },
     );
     clearAgentHarnesses();
@@ -3864,7 +3912,7 @@ describe("CLI attempt execution", () => {
         messageChannel: undefined,
         skillsSnapshot: undefined,
         resolvedVerboseLevel: undefined,
-        agentDir: tmpDir,
+        agentDir,
         onAgentEvent: vi.fn(),
         authProfileProvider: "openai",
         sessionStore,
@@ -3932,7 +3980,7 @@ describe("CLI attempt execution", () => {
       messageChannel: "discord",
       skillsSnapshot: undefined,
       resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
+      agentDir,
       onAgentEvent: vi.fn(),
       authProfileProvider: "anthropic",
       sessionStore,
@@ -3996,7 +4044,7 @@ describe("CLI attempt execution", () => {
       messageChannel: "telegram",
       skillsSnapshot: undefined,
       resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
+      agentDir,
       onAgentEvent: vi.fn(),
       authProfileProvider: "openai",
       sessionStore,
@@ -4046,7 +4094,7 @@ describe("CLI attempt execution", () => {
       messageChannel: undefined,
       skillsSnapshot: undefined,
       resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
+      agentDir,
       onAgentEvent: vi.fn(),
       authProfileProvider: "claude-cli",
       sessionStore,


### PR DESCRIPTION
## Summary

- reuse suite-owned SQLite fixtures in the CLI attempt-execution tests
- keep a fresh filesystem scratch directory for every case
- reset session, transcript, auth, cache, and lease rows atomically between cases
- preserve multi-agent session-store ownership and exact final database disposal

## Why

The session seed helper inherited a close-after-write pattern from an older cache-freshness fixture. The close helper later grew into a global handle, validation, and terminal-latch reset, so this file performed roughly 192 global database closes and repeatedly rebuilt agent schemas during one run. None of its assertions cover database reopen behavior.

The replacement keeps real SQLite transactions, permission checks, auth selection, transcript persistence, session bindings, and per-case filesystem isolation. It removes only redundant fixture lifecycle work.

## Proof

- focused warm wall: 26.15s to 14.57s, 44.3% faster (11.58s saved)
- focused tests: 114 passed before and after
- agents-support warm wall: 81.05s to 58.21s, 28.2% faster (22.84s saved)
- agents-support prime wall: 68.84s to 60.91s (7.93s saved)
- agents-support counts: 141 files and 2,428 tests before and after
- warm group RSS: 6.078 GB to 5.663 GB
- post-rebase focused proof: 114 passed
- oxfmt, oxlint, and git diff check pass
- autoreview: clean, no accepted/actionable findings

The complete agents-support runs reproduced the same two pre-existing macOS remote-fs-bridge failures before and after. The changed-check wrapper could not allocate Blacksmith, AWS, Azure, or Daytona capacity, so no delegated changed-gate result is claimed.
