### PR TITLE
fix(otel): fail closed when configured TLS material is invalid

### DIFF
--- a/extensions/diagnostics-otel/src/service-exporter.ts
+++ b/extensions/diagnostics-otel/src/service-exporter.ts
@@ -10,7 +10,6 @@ import {
 import type {
   OtelHttpAgentFactory,
   OtelHttpAgentOptions,
-  OtelLogger,
   OtelSignalIdentifier,
 } from "./service-types.js";
 
@@ -75,8 +74,7 @@ function readOtelEnvFile(params: {
   signalIdentifier: OtelSignalIdentifier;
   signalSuffix: "CERTIFICATE" | "CLIENT_CERTIFICATE" | "CLIENT_KEY";
   sharedEnvName: string;
-  logger: OtelLogger;
-  warning: string;
+  label: string;
 }): Buffer | undefined {
   const signalEnvName = `OTEL_EXPORTER_OTLP_${params.signalIdentifier}_${params.signalSuffix}`;
   const filePath =
@@ -86,48 +84,53 @@ function readOtelEnvFile(params: {
     return undefined;
   }
   try {
-    return readFileSync(nodePath.resolve(process.cwd(), filePath));
+    const material = readFileSync(nodePath.resolve(process.cwd(), filePath));
+    if (material.length > 0) {
+      return material;
+    }
   } catch {
-    params.logger.warn(`diagnostics-otel: ${params.warning}`);
-    return undefined;
+    // Never expose certificate paths or silently downgrade to system trust.
   }
+  throw new Error(
+    `Configured OpenTelemetry ${params.label} file is missing, empty, or unreadable; refusing insecure export`,
+  );
 }
 
 function normalizeOtelEnvValue(value: string | undefined): string | undefined {
-  const trimmed = value?.trim();
-  return trimmed ? trimmed : undefined;
+  return value?.trim() ? value : undefined;
 }
 
 export function resolveOtelHttpAgentOptions(params: {
   url: string | undefined;
   signalIdentifier: OtelSignalIdentifier;
-  logger: OtelLogger;
-}): OtelHttpAgentFactory | undefined {
-  const { url, signalIdentifier, logger } = params;
-  if (!url) {
-    return undefined;
-  }
+}): OtelHttpAgentFactory | OtelHttpAgentOptions | undefined {
+  const { url, signalIdentifier } = params;
   const ca = readOtelEnvFile({
     signalIdentifier,
     signalSuffix: "CERTIFICATE",
     sharedEnvName: OTEL_EXPORTER_OTLP_CERTIFICATE_ENV,
-    logger,
-    warning: "failed to read root certificate file",
+    label: "TLS root certificate",
   });
   const cert = readOtelEnvFile({
     signalIdentifier,
     signalSuffix: "CLIENT_CERTIFICATE",
     sharedEnvName: OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE_ENV,
-    logger,
-    warning: "failed to read client certificate chain file",
+    label: "mTLS client certificate",
   });
   const key = readOtelEnvFile({
     signalIdentifier,
     signalSuffix: "CLIENT_KEY",
     sharedEnvName: OTEL_EXPORTER_OTLP_CLIENT_KEY_ENV,
-    logger,
-    warning: "failed to read client certificate private key file",
+    label: "mTLS client private key",
   });
+  if ((cert === undefined) !== (key === undefined)) {
+    throw new Error(
+      "Configured OpenTelemetry mTLS requires both a client certificate and private key; refusing insecure export",
+    );
+  }
+  if (!url) {
+    return undefined;
+  }
   const agentOptions: OtelHttpAgentOptions = {
     keepAlive: true,
     ...(ca !== undefined ? { ca } : {}),
@@ -136,10 +139,13 @@ export function resolveOtelHttpAgentOptions(params: {
   };
   try {
     const agent = createNodeProxyAgent({ mode: "env", targetUrl: url, agentOptions });
-    return agent ? () => agent : undefined;
+    if (agent) {
+      return () => agent;
+    }
   } catch {
     throw new Error("Configured telemetry proxy is invalid or unsupported; refusing direct export");
   }
+  return (ca || cert || key) && new URL(url).protocol === "https:" ? agentOptions : undefined;
 }
 
 export function resolveSampleRate(value: number | undefined): number | undefined {

--- a/extensions/diagnostics-otel/src/service-logs.ts
+++ b/extensions/diagnostics-otel/src/service-logs.ts
@@ -20,7 +20,7 @@ import {
   normalizeOtelLogString,
   type OtelContentCapturePolicy,
 } from "./service-content-normalization.js";
-import { errorCategory, formatError, resolveOtelHttpAgentOptions } from "./service-exporter.js";
+import { errorCategory, formatError } from "./service-exporter.js";
 import {
   addTraceAttributes,
   contextForTrustedTraceContext,
@@ -28,6 +28,8 @@ import {
 } from "./service-trace-context.js";
 import type {
   BuiltOtelLogRecord,
+  OtelHttpAgentFactory,
+  OtelHttpAgentOptions,
   OtelLogger,
   TelemetryExporterDiagnosticEvent,
 } from "./service-types.js";
@@ -50,6 +52,7 @@ export function createDiagnosticsLogExporter(params: {
   logsEnabled: boolean;
   logsToOtlp: boolean;
   logsToStdout: boolean;
+  logHttpAgentOptions?: OtelHttpAgentFactory | OtelHttpAgentOptions;
   logUrl?: string;
   resource: Resource;
   serviceName: string;
@@ -63,6 +66,7 @@ export function createDiagnosticsLogExporter(params: {
     logsEnabled,
     logsToOtlp,
     logsToStdout,
+    logHttpAgentOptions,
     logUrl,
     resource,
     serviceName,
@@ -86,11 +90,6 @@ export function createDiagnosticsLogExporter(params: {
 
     let otelLogger: { emit: (logRecord: LogRecord) => void } | undefined;
     if (logsToOtlp) {
-      const logHttpAgentOptions = resolveOtelHttpAgentOptions({
-        url: logUrl,
-        signalIdentifier: "LOGS",
-        logger,
-      });
       const logExporter = new OTLPLogExporter({
         ...(logUrl ? { url: logUrl } : {}),
         ...(headers ? { headers } : {}),

--- a/extensions/diagnostics-otel/src/service.otlp-export.test.ts
+++ b/extensions/diagnostics-otel/src/service.otlp-export.test.ts
@@ -8,6 +8,9 @@
 // Trace cases use the OPENCLAW_OTEL_PRELOADED seam to retain this file's tracer provider.
 // Collector-boundary cases start the real NodeSDK, so teardown restores every global SDK
 // registration; otherwise a shutdown provider would poison later real-SDK cases.
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { context, diag, DiagLogLevel, metrics, propagation, trace } from "@opentelemetry/api";
 import { logs } from "@opentelemetry/api-logs";
 import {
@@ -37,6 +40,18 @@ const ENDPOINT_ENV_KEYS = [
   "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
   "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
   "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+  "OTEL_EXPORTER_OTLP_CERTIFICATE",
+  "OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE",
+  "OTEL_EXPORTER_OTLP_CLIENT_KEY",
+  "OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE",
+  "OTEL_EXPORTER_OTLP_TRACES_CLIENT_CERTIFICATE",
+  "OTEL_EXPORTER_OTLP_TRACES_CLIENT_KEY",
+  "OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE",
+  "OTEL_EXPORTER_OTLP_METRICS_CLIENT_CERTIFICATE",
+  "OTEL_EXPORTER_OTLP_METRICS_CLIENT_KEY",
+  "OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE",
+  "OTEL_EXPORTER_OTLP_LOGS_CLIENT_CERTIFICATE",
+  "OTEL_EXPORTER_OTLP_LOGS_CLIENT_KEY",
   "OTEL_LOG_LEVEL",
 ] as const;
 const OTEL_GLOBAL_API_KEY = Symbol.for("opentelemetry.js.api.1");
@@ -466,6 +481,147 @@ test.each([
     try {
       await service.start(ctx);
       expect(diagnostics.join("\n")).not.toContain(credential);
+    } finally {
+      await service.stop?.(ctx);
+    }
+  },
+);
+
+const OTEL_TLS_MATERIAL_CASES = [
+  { suffix: "CERTIFICATE", label: "TLS root certificate" },
+  { suffix: "CLIENT_CERTIFICATE", label: "mTLS client certificate" },
+  { suffix: "CLIENT_KEY", label: "mTLS client private key" },
+] as const;
+
+const OTEL_TLS_FILE_SECURITY_CASES = OTEL_ENDPOINT_SIGNAL_CASES.flatMap((signal) =>
+  OTEL_TLS_MATERIAL_CASES.flatMap((material) =>
+    (["shared", "signal"] as const).map((scope) => Object.assign({ scope }, signal, material)),
+  ),
+);
+
+test.each(OTEL_TLS_FILE_SECURITY_CASES)(
+  "refuses the real $signal exporter when its $scope $label file cannot be read",
+  async ({ signal, suffix, label, scope, flags }) => {
+    process.env[PRELOAD_ENV] = "0";
+    const pathSentinel = `qa-otel-${signal}-${suffix.toLowerCase()}-file-sentinel`;
+    const missingPath = `/definitely-missing/${pathSentinel}.pem`;
+    const envKey =
+      scope === "shared"
+        ? `OTEL_EXPORTER_OTLP_${suffix}`
+        : `OTEL_EXPORTER_OTLP_${signal.toUpperCase()}_${suffix}`;
+    process.env[envKey] = missingPath;
+
+    const diagnostics = captureOtelDiagnostics();
+    const ctx = createOtelContext("https://collector.example.com/otlp", flags);
+    ctx.internalDiagnostics!.emit = () => {};
+    const service = createDiagnosticsOtelService();
+    let failure: unknown;
+    try {
+      await service.start(ctx);
+    } catch (error) {
+      failure = error;
+    } finally {
+      await service.stop?.(ctx);
+    }
+
+    expect(failure).toBeInstanceOf(Error);
+    const startupError = failure as Error;
+    expect(startupError.message).toBe(
+      `Configured OpenTelemetry ${label} file is missing, empty, or unreadable; refusing insecure export`,
+    );
+    expect(startupError.stack).not.toContain(pathSentinel);
+    expect(startupError).not.toHaveProperty("cause");
+    expect(diagnostics.join("\n")).not.toContain(pathSentinel);
+    expect(JSON.stringify(vi.mocked(ctx.logger.error).mock.calls)).not.toContain(pathSentinel);
+    expect(JSON.stringify(vi.mocked(ctx.logger.warn).mock.calls)).not.toContain(pathSentinel);
+  },
+);
+
+test.each(OTEL_ENDPOINT_SIGNAL_CASES)(
+  "refuses invalid TLS material before the real default $signal exporter is constructed",
+  async ({ signal, flags }) => {
+    process.env[PRELOAD_ENV] = "0";
+    process.env[`OTEL_EXPORTER_OTLP_${signal.toUpperCase()}_CERTIFICATE`] =
+      "/definitely-missing/qa-otel-default-root.pem";
+    const ctx = createOtelContext("", flags);
+    ctx.internalDiagnostics!.emit = () => {};
+    const service = createDiagnosticsOtelService();
+
+    try {
+      await expect(service.start(ctx)).rejects.toThrow(
+        "Configured OpenTelemetry TLS root certificate file is missing, empty, or unreadable; refusing insecure export",
+      );
+    } finally {
+      await service.stop?.(ctx);
+    }
+  },
+);
+
+test.each(
+  OTEL_ENDPOINT_SIGNAL_CASES.flatMap((signal) =>
+    OTEL_TLS_MATERIAL_CASES.map((material) => Object.assign({}, signal, material)),
+  ),
+)(
+  "rejects an empty $signal $label file before the SDK can silently downgrade trust",
+  async ({ signal, suffix, label, flags }) => {
+    process.env[PRELOAD_ENV] = "0";
+    const certDir = mkdtempSync(path.join(tmpdir(), "openclaw-otel-empty-tls-"));
+    const emptyMaterialPath = path.join(certDir, "empty.pem");
+    writeFileSync(emptyMaterialPath, "");
+    process.env[`OTEL_EXPORTER_OTLP_${signal.toUpperCase()}_${suffix}`] = emptyMaterialPath;
+    const ctx = createOtelContext("https://collector.example.com/otlp", flags);
+    ctx.internalDiagnostics!.emit = () => {};
+    const service = createDiagnosticsOtelService();
+
+    try {
+      await expect(service.start(ctx)).rejects.toThrow(
+        `Configured OpenTelemetry ${label} file is missing, empty, or unreadable; refusing insecure export`,
+      );
+    } finally {
+      await service.stop?.(ctx);
+      rmSync(certDir, { force: true, recursive: true });
+    }
+  },
+);
+
+test.each(OTEL_ENDPOINT_SIGNAL_CASES)(
+  "rejects the raw whitespace-padded $signal TLS certificate path the SDK cannot read",
+  async ({ signal, flags }) => {
+    process.env[PRELOAD_ENV] = "0";
+    process.env[`OTEL_EXPORTER_OTLP_${signal.toUpperCase()}_CERTIFICATE`] = ` ${process.execPath} `;
+    const ctx = createOtelContext("https://collector.example.com/otlp", flags);
+    ctx.internalDiagnostics!.emit = () => {};
+    const service = createDiagnosticsOtelService();
+
+    try {
+      await expect(service.start(ctx)).rejects.toThrow(
+        "Configured OpenTelemetry TLS root certificate file is missing, empty, or unreadable; refusing insecure export",
+      );
+    } finally {
+      await service.stop?.(ctx);
+    }
+  },
+);
+
+test.each(
+  OTEL_ENDPOINT_SIGNAL_CASES.flatMap((signal) =>
+    (["CLIENT_CERTIFICATE", "CLIENT_KEY"] as const).map((suffix) =>
+      Object.assign({ suffix }, signal),
+    ),
+  ),
+)(
+  "rejects the real $signal exporter when only $suffix mTLS material is configured",
+  async ({ signal, suffix, flags }) => {
+    process.env[PRELOAD_ENV] = "0";
+    process.env[`OTEL_EXPORTER_OTLP_${signal.toUpperCase()}_${suffix}`] = process.execPath;
+    const ctx = createOtelContext("https://collector.example.com/otlp", flags);
+    ctx.internalDiagnostics!.emit = () => {};
+    const service = createDiagnosticsOtelService();
+
+    try {
+      await expect(service.start(ctx)).rejects.toThrow(
+        "Configured OpenTelemetry mTLS requires both a client certificate and private key; refusing insecure export",
+      );
     } finally {
       await service.stop?.(ctx);
     }

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -1928,11 +1928,14 @@ describe("diagnostics-otel service", () => {
     try {
       const rootCertificatePath = path.join(certDir, "root.pem");
       const clientCertificatePath = path.join(certDir, "client.pem");
+      const sharedClientCertificatePath = path.join(certDir, "shared-client.pem");
       const clientKeyPath = path.join(certDir, "client-key.pem");
       writeFileSync(rootCertificatePath, "root-certificate");
       writeFileSync(clientCertificatePath, "trace-client-certificate");
+      writeFileSync(sharedClientCertificatePath, "shared-client-certificate");
       writeFileSync(clientKeyPath, "client-key");
       process.env.OTEL_EXPORTER_OTLP_CERTIFICATE = rootCertificatePath;
+      process.env.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE = sharedClientCertificatePath;
       process.env.OTEL_EXPORTER_OTLP_TRACES_CLIENT_CERTIFICATE = clientCertificatePath;
       process.env.OTEL_EXPORTER_OTLP_CLIENT_KEY = clientKeyPath;
       createNodeProxyAgentMock.mockReturnValue(nodeProxyAgent);
@@ -1959,6 +1962,7 @@ describe("diagnostics-otel service", () => {
       expect(metricCall.agentOptions).toEqual({
         keepAlive: true,
         ca: Buffer.from("root-certificate"),
+        cert: Buffer.from("shared-client-certificate"),
         key: Buffer.from("client-key"),
       });
     } finally {
@@ -1990,6 +1994,131 @@ describe("diagnostics-otel service", () => {
     } finally {
       rmSync(certDir, { force: true, recursive: true });
     }
+  });
+
+  test("pins validated collector TLS material on direct HTTPS exporter agents", async () => {
+    const certDir = mkdtempSync(path.join(tmpdir(), "openclaw-otel-direct-tls-"));
+    try {
+      const rootCertificatePath = path.join(certDir, "root.pem");
+      writeFileSync(rootCertificatePath, "explicit-root-certificate");
+      process.env.OTEL_EXPORTER_OTLP_CERTIFICATE = rootCertificatePath;
+
+      await startOtelService({
+        endpoint: "https://collector.example.com/otlp",
+        traces: true,
+      });
+
+      expect(firstExporterOptions(traceExporterCtor).httpAgentOptions).toEqual({
+        keepAlive: true,
+        ca: Buffer.from("explicit-root-certificate"),
+      });
+    } finally {
+      rmSync(certDir, { force: true, recursive: true });
+    }
+  });
+
+  test("validates log TLS before constructing any trace, metric, or SDK owner", async () => {
+    process.env.OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE =
+      "/definitely-missing/qa-otel-log-root-atomic.pem";
+
+    await expect(
+      startOtelService({
+        endpoint: "https://collector.example.com/otlp",
+        traces: true,
+        metrics: true,
+        logs: true,
+      }),
+    ).rejects.toThrow(
+      "Configured OpenTelemetry TLS root certificate file is missing, empty, or unreadable; refusing insecure export",
+    );
+
+    expect(traceExporterCtor).not.toHaveBeenCalled();
+    expect(metricExporterCtor).not.toHaveBeenCalled();
+    expect(logExporterCtor).not.toHaveBeenCalled();
+    expect(sdkCtor).not.toHaveBeenCalled();
+    expect(sdkStart).not.toHaveBeenCalled();
+  });
+
+  test("never falls back from an unreadable signal TLS file to readable shared trust", async () => {
+    process.env.OTEL_EXPORTER_OTLP_CERTIFICATE = process.execPath;
+    process.env.OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE =
+      "/definitely-missing/qa-otel-signal-override.pem";
+
+    await expect(startOtelService({ traces: true })).rejects.toThrow(
+      "Configured OpenTelemetry TLS root certificate file is missing, empty, or unreadable; refusing insecure export",
+    );
+    expect(traceExporterCtor).not.toHaveBeenCalled();
+  });
+
+  test("lets a readable signal TLS file shadow an unreadable shared trust file", async () => {
+    process.env.OTEL_EXPORTER_OTLP_CERTIFICATE =
+      "/definitely-missing/qa-otel-shadowed-shared-root.pem";
+    process.env.OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE = process.execPath;
+
+    await startOtelService({ traces: true });
+
+    expect(traceExporterCtor).toHaveBeenCalledTimes(1);
+  });
+
+  test("keeps valid ambient TLS material compatible with plain HTTP collectors", async () => {
+    process.env.OTEL_EXPORTER_OTLP_CERTIFICATE = process.execPath;
+
+    await startOtelService({ endpoint: "http://collector.example.com/otlp", traces: true });
+
+    expect(traceExporterCtor).toHaveBeenCalledTimes(1);
+    expect(firstExporterOptions(traceExporterCtor).httpAgentOptions).toBeUndefined();
+  });
+
+  test("does not validate TLS material owned by a preloaded SDK", async () => {
+    process.env.OPENCLAW_OTEL_PRELOADED = "1";
+    process.env.OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE =
+      "/definitely-missing/qa-otel-preloaded-traces-root.pem";
+    process.env.OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE =
+      "/definitely-missing/qa-otel-preloaded-metrics-root.pem";
+
+    await startOtelService({ traces: true, metrics: true, logs: false });
+
+    expect(sdkCtor).not.toHaveBeenCalled();
+  });
+
+  test("still validates plugin-owned OTLP logs when a trace SDK is preloaded", async () => {
+    process.env.OPENCLAW_OTEL_PRELOADED = "1";
+    process.env.OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE =
+      "/definitely-missing/qa-otel-preloaded-log-root.pem";
+
+    await expect(startOtelService({ traces: true, logs: true })).rejects.toThrow(
+      "Configured OpenTelemetry TLS root certificate file is missing, empty, or unreadable; refusing insecure export",
+    );
+    expect(logExporterCtor).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    {
+      signal: "disabled traces",
+      envKey: "OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE",
+      flags: { traces: false, metrics: true, logs: false },
+    },
+    {
+      signal: "disabled metrics",
+      envKey: "OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE",
+      flags: { traces: true, metrics: false, logs: false },
+    },
+    {
+      signal: "disabled logs",
+      envKey: "OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE",
+      flags: { traces: true, metrics: false, logs: false },
+    },
+    {
+      signal: "stdout-only logs",
+      envKey: "OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE",
+      flags: { traces: true, metrics: false, logs: true, logsExporter: "stdout" },
+    },
+  ] as const)("does not read TLS files for $signal", async ({ envKey, flags }) => {
+    process.env[envKey] = "/definitely-missing/qa-otel-inactive-signal-root.pem";
+
+    await startOtelService(flags);
+
+    expect(sdkCtor).toHaveBeenCalledTimes(1);
   });
 
   test.each([

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -163,8 +163,8 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
             path: "v1/logs",
           })
         : undefined;
-      if (!sdkPreloaded && (tracesEnabled || metricsEnabled)) {
-        const traceUrl = tracesEnabled
+      const traceUrl =
+        !sdkPreloaded && tracesEnabled
           ? resolveSignalOtelUrl({
               signalEndpoint: otel.tracesEndpoint,
               signalEnvEndpoint: process.env[OTEL_EXPORTER_OTLP_TRACES_ENDPOINT_ENV],
@@ -173,7 +173,8 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
               path: "v1/traces",
             })
           : undefined;
-        const metricUrl = metricsEnabled
+      const metricUrl =
+        !sdkPreloaded && metricsEnabled
           ? resolveSignalOtelUrl({
               signalEndpoint: otel.metricsEndpoint,
               signalEnvEndpoint: process.env[OTEL_EXPORTER_OTLP_METRICS_ENDPOINT_ENV],
@@ -182,16 +183,19 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
               path: "v1/metrics",
             })
           : undefined;
-        const traceHttpAgentOptions = resolveOtelHttpAgentOptions({
-          url: traceUrl,
-          signalIdentifier: "TRACES",
-          logger: ctx.logger,
-        });
-        const metricHttpAgentOptions = resolveOtelHttpAgentOptions({
-          url: metricUrl,
-          signalIdentifier: "METRICS",
-          logger: ctx.logger,
-        });
+      // Validate every owned signal before any SDK can export with downgraded TLS trust.
+      const logHttpAgentOptions = logsToOtlp
+        ? resolveOtelHttpAgentOptions({ url: logUrl, signalIdentifier: "LOGS" })
+        : undefined;
+      const traceHttpAgentOptions =
+        !sdkPreloaded && tracesEnabled
+          ? resolveOtelHttpAgentOptions({ url: traceUrl, signalIdentifier: "TRACES" })
+          : undefined;
+      const metricHttpAgentOptions =
+        !sdkPreloaded && metricsEnabled
+          ? resolveOtelHttpAgentOptions({ url: metricUrl, signalIdentifier: "METRICS" })
+          : undefined;
+      if (!sdkPreloaded && (tracesEnabled || metricsEnabled)) {
         const traceExporter = tracesEnabled
           ? new OTLPTraceExporter({
               ...(traceUrl ? { url: traceUrl } : {}),
@@ -281,6 +285,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         logsEnabled,
         logsToOtlp,
         logsToStdout,
+        logHttpAgentOptions,
         logUrl,
         resource,
         serviceName,


### PR DESCRIPTION
## Summary
- Fail closed when an explicitly configured OpenTelemetry TLS root CA, client certificate, or private key is missing, empty, unreadable, or incompletely paired.
- Preserve exact SDK raw-path and per-signal/shared precedence rather than silently falling back to system trust roots.
- Validate all enabled signal TLS material—including logs—before any telemetry exporter or SDK can start.

## Exact actual HTTPS/mTLS collector exploit and repair proof
Real loopback HTTPS and mutually authenticated TLS collectors were started using disposable locally generated roots and client credentials. The actual installed OTLP trace/metric/log exporters emitted real protobuf data; no external network, existing user certificates, provider credentials, or real secrets were involved.

Actual observed redacted runtime result:

```json
{"actualCollector":"localhost HTTPS + mTLS","baselineDowngradedDelivery":true,"missingRootBlockedBeforeRequest":true,"verifiedDirectDelivery":true,"mutualTlsDelivery":true,"incompletePairBlocked":true,"totalRequests":3,"actualProtobufBytes":798,"noExternalNetwork":true}
```

Before the repair, an unreadable explicitly configured private trust root allowed the actual SDK to construct an HTTPS exporter using default/system trust and successfully deliver sensitive telemetry. After the repair, that misconfiguration fails visibly before any collector request; verified custom-root and complete mutual-TLS paths continue to deliver, and an incomplete certificate/key pair fails closed.

The owner validates the exact raw nonblank file paths consumed by upstream, treats zero-byte CA/cert/key files as invalid, preserves valid per-signal override of shared settings, supplies verified bytes directly to HTTPS/proxy agent options, and atomically preflights all enabled signals before starting any SDK or exporting data. Disabled, preloaded, stdout-only, valid HTTP collector, proxy, NO_PROXY, and valid mTLS configurations retain their documented behavior.

## Verification
- Deterministic red-before-green: 43 real installed-SDK security failures reproduced across signal/shared scopes, missing/empty/padded files, default endpoints, and incomplete certificate pairs.
- Both complete diagnostics owner suites: 215 tests passed; repeated independently with a fresh module cache: 215 passed again.
- Independent real-dependency fuzz: 750 shared/per-signal CA+cert+key combinations; 8 legitimate verified-agent admissions, 742 safe failures, zero precedence mismatches, zero certificate-path disclosures.
- Actual localhost HTTPS and mutual-TLS collectors exchanged 798 real OTLP protobuf bytes and proved both the baseline trust downgrade and repaired fail-closed behavior.
- Secret scanner, focused lint/format/diff checks clean.
- Independent structured security review: clean, confidence 0.97.
- Production-code delta: +10 lines for explicit TLS trust ownership and atomic signal preflight.

## Maintainer upgrade decision
The maintainer explicitly accepts the intended compatibility change: an unreadable, empty, or incompletely paired TLS file that previously only emitted a warning while silently falling back to public/system trust will now stop diagnostics-OTel startup with a sanitized actionable error. Continuing telemetry with weakened trust is a security regression, not a supported upgrade contract. Valid signal-specific/shared TLS, valid HTTP collector compatibility, disabled/stdout-only/preloaded signals, and correctly configured custom-CA/mTLS paths remain supported.