### PR TITLE
fix(memory): prevent wiki test plugin discovery stalls

### DIFF
--- a/extensions/memory-wiki/src/agent-vault-isolation.test.ts
+++ b/extensions/memory-wiki/src/agent-vault-isolation.test.ts
@@ -82,6 +82,8 @@ describe("agent-scoped memory-wiki tools", () => {
   it("keeps apply, search, and get behavior isolated by configured agent", async () => {
     const vaultParent = await createTempDir("memory-wiki-agent-vaults-");
     const appConfig = {
+      // This suite registers memory-core directly; runtime discovery would load unrelated plugins.
+      plugins: { enabled: false },
       agents: {
         list: [{ id: "support", default: true }, { id: "marketing" }],
       },

--- a/extensions/memory-wiki/src/corpus-supplement.visibility.test.ts
+++ b/extensions/memory-wiki/src/corpus-supplement.visibility.test.ts
@@ -18,6 +18,8 @@ import { createMemoryWikiTestHarness } from "./test-helpers.js";
 const { createVault } = createMemoryWikiTestHarness();
 
 const appConfig = {
+  // This suite registers memory-core directly; runtime discovery would load unrelated plugins.
+  plugins: { enabled: false },
   agents: { list: [{ id: "main", default: true }, { id: "secondary" }] },
 } as OpenClawConfig;
 


### PR DESCRIPTION
Closes #118653

## What Problem This Solves

Fixes an issue where maintainers running two memory-wiki integration tests would wait almost four minutes per one-test file because the fixtures cold-loaded the runtime plugin registry after already registering memory-core directly.

## Why This Change Was Made

Both manually assembled integration configs now explicitly disable implicit plugin discovery. The tests still exercise the registered memory-core/memory-wiki tool boundary, but unrelated plugins are no longer loaded by the fixture.

## User Impact

There is no production runtime behavior change. Focused memory-wiki integration proof completes in seconds, and the full memory project no longer pays several minutes of unrelated plugin-loading work for these two files.

AI-assisted: yes. The root cause, shared bug-class decision, diff, and proof were reviewed directly.

## Evidence

- Reproduced on base `757d22020362db03b73924a0ab85159ca1297948`:
  - `corpus-supplement.visibility.test.ts`: 1/1 passed, but 226.93s in the test body and 229.32s total;
  - `agent-vault-isolation.test.ts`: 1/1 passed, but 226.75s in the test body and 228.38s total.
- Focused green after the fix:
  - corpus visibility: 2.13s test body;
  - agent-vault isolation: 2.66s test body.
- Focused stress: 10/10 fresh-process rounds of both files passed (20/20 total); corpus 1.83–2.02s and agent-vault 2.52–2.72s.
- Blacksmith Testbox `tbx_01kz3qcvk6k6w8c8jh92q6yky2`: [run 30811141324](https://github.com/openclaw/openclaw/actions/runs/30811141324)
  - full memory project: 134/134 files and 1,939/1,939 tests passed;
  - corpus visibility: 1.203s, down from the prior hosted 168.001s;
  - agent-vault isolation: 1.944s, down from the prior hosted 174.747s;
  - aggregate Vitest duration: 84.32s, down from 235.73s in the preceding full-memory run;
  - repo-native changed gate passed, including extension-test typecheck and focused lint.
- `git diff --check` and targeted oxfmt check passed.
- Fresh autoreview: clean, no accepted/actionable findings.
- Diff: two test files, +4/-0; production LOC delta 0.

No external live-product boundary applies to this fixture-isolation change; both exact focused reproductions and the full hosted memory workflow cover the affected behavior.
