### PR TITLE
chore: make responsive UI tests faster

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -1,5 +1,5 @@
 // Control UI tests cover chat responsive behavior.
-import { chromium, type Browser, type Page } from "playwright";
+import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { readStyleSheet } from "../../../../test/helpers/ui-style-fixtures.js";
 import {
@@ -21,14 +21,12 @@ const VIEWPORTS = [
   [1440, 900],
 ] as const;
 const TOUCH_TARGET_MIN_PX = 43.5;
-// Real-app cases boot through a cold Vite dev server that transforms the whole
-// Control UI module graph on first request; with 6 Vitest workers sharing an
-// 8vCPU CI runner that first render can starve well past 10s. Budget the
-// first-render waits for contention while staying inside the 60s testTimeout.
+// The shared real-app page still cold-boots Vite's full Control UI graph once;
+// under CI contention that first render can starve well past 10s.
 const APP_FIRST_RENDER_TIMEOUT_MS = 30_000;
 const FULL_APP_TEST_OPTIONS = {
-  // These cases cold-boot Vite through one shared Chromium/server pair. Keep them
-  // as a sequential barrier so concurrent layout pages cannot starve navigation.
+  // Shared-page interactions mutate viewport, pointer, and composer state. Keep
+  // each as a sequential barrier so they cannot overlap one another.
   concurrent: false,
   timeout: 60_000,
 } as const;
@@ -42,13 +40,79 @@ const describeBrowserLayout = canRunPlaywrightChromium(chromiumExecutablePath)
   : describe.skip;
 
 let sharedBrowser: Browser | null = null;
+let sharedLayoutContext: BrowserContext | null = null;
+let sharedAppPage: Page | null = null;
+let sharedAppPagePromise: Promise<Page> | null = null;
+const sharedAppPageErrors: string[] = [];
 let realChatServer: ControlUiE2eServer | null = null;
+let cachedUiCss: string | null = null;
+
+const SHARED_APP_CONTEXT_TEXT = "Context hover regression fixture.";
+const SHARED_APP_SLASH_TEXT = "Short landscape slash command keyboard regression fixture.";
+const SHARED_APP_IMAGE_URL = "https://cdn.example/render%2Epng?download=1";
+const SHARED_APP_VIDEO_URL = "https://cdn.example/clip%2Emp4?download=1";
 
 function installResponsiveChatGateway(page: Page, scenario: ControlUiMockGatewayScenario = {}) {
   return installMockGateway(page, {
     agentModel: "openai/gpt-5.5",
     ...scenario,
   });
+}
+
+async function getSharedAppPage(): Promise<Page> {
+  sharedAppPagePromise ??= createSharedAppPage();
+  return await sharedAppPagePromise;
+}
+
+async function createSharedAppPage(): Promise<Page> {
+  if (!realChatServer) {
+    throw new Error("Expected the Control UI server to be ready");
+  }
+  // The five app assertions use disjoint fixture messages and reset mutable
+  // page state, so one lazy boot preserves coverage without five graph loads.
+  const page = await openBrowserPage(1366, 900, { isolated: true });
+  try {
+    page.on("pageerror", (error) => sharedAppPageErrors.push(error.message));
+    await page.route("https://cdn.example/**", (route) => route.abort());
+    await installResponsiveChatGateway(page, {
+      assistantName: "Claw",
+      historyMessages: [
+        {
+          content: [{ text: SHARED_APP_CONTEXT_TEXT, type: "text" }],
+          model: "openai/gpt-5.5",
+          role: "assistant",
+          timestamp: Date.UTC(2026, 6, 5, 9, 51),
+          usage: { cacheRead: 2_400, input: 19_600, output: 126 },
+        },
+        {
+          content: `MEDIA:${SHARED_APP_IMAGE_URL}`,
+          role: "assistant",
+          timestamp: Date.UTC(2026, 6, 9, 10, 0),
+        },
+        {
+          content: "Encoded transcript video",
+          __openclaw: { media: [{ url: SHARED_APP_VIDEO_URL, contentType: "video/mp4" }] },
+          role: "user",
+          timestamp: Date.UTC(2026, 6, 9, 10, 1),
+        },
+        {
+          content: [{ text: SHARED_APP_SLASH_TEXT, type: "text" }],
+          role: "assistant",
+          timestamp: Date.UTC(2026, 6, 9, 10, 2),
+        },
+      ],
+    });
+    await page.goto(`${realChatServer.baseUrl}chat/main`, {
+      waitUntil: "domcontentloaded",
+      timeout: APP_FIRST_RENDER_TIMEOUT_MS,
+    });
+    await page.getByText(SHARED_APP_SLASH_TEXT).waitFor({ timeout: APP_FIRST_RENDER_TIMEOUT_MS });
+    sharedAppPage = page;
+    return page;
+  } catch (error) {
+    await closeBrowserPage(page);
+    throw error;
+  }
 }
 
 type ControlRect = {
@@ -96,6 +160,9 @@ function expectControlRect(rect: ControlRect | null, label: string): ControlRect
 }
 
 function readUiCss(): string {
+  if (cachedUiCss !== null) {
+    return cachedUiCss;
+  }
   const files = [
     "ui/src/styles/base.css",
     "ui/src/styles/layout.css",
@@ -108,7 +175,8 @@ function readUiCss(): string {
     "ui/src/styles/chat/question-card.css",
     "ui/src/styles/chat/sidebar.css",
   ];
-  return files.map((file) => readStyleSheet(file)).join("\n");
+  cachedUiCss = files.map((file) => readStyleSheet(file)).join("\n");
+  return cachedUiCss;
 }
 
 function iconSvg() {
@@ -445,12 +513,24 @@ async function openFixture(width: number, height: number, opts: ChatFixtureOptio
   }
 }
 
-async function openBrowserPage(width: number, height: number): Promise<Page> {
+async function openBrowserPage(
+  width: number,
+  height: number,
+  options: { isolated?: boolean } = {},
+): Promise<Page> {
   sharedBrowser ??= await chromium.launch({
     executablePath: chromiumExecutablePath,
     headless: true,
   });
-  return await sharedBrowser.newPage({ viewport: { width, height } });
+  if (options.isolated) {
+    return await sharedBrowser.newPage({ viewport: { width, height } });
+  }
+  // Static setContent fixtures do not mutate context-owned storage or routes,
+  // so they can share one context while their pages remain concurrent.
+  sharedLayoutContext ??= await sharedBrowser.newContext();
+  const page = await sharedLayoutContext.newPage();
+  await page.setViewportSize({ width, height });
+  return page;
 }
 
 async function closeBrowserPage(page: Page): Promise<void> {
@@ -544,12 +624,18 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       executablePath: chromiumExecutablePath,
       headless: true,
     });
+    sharedLayoutContext = await sharedBrowser.newContext();
     realChatServer = await startControlUiE2eServer();
   });
 
   afterAll(async () => {
+    await sharedAppPage?.close();
+    sharedAppPage = null;
+    sharedAppPagePromise = null;
     await realChatServer?.close();
     realChatServer = null;
+    await sharedLayoutContext?.close();
+    sharedLayoutContext = null;
     await sharedBrowser?.close();
     sharedBrowser = null;
   });
@@ -558,122 +644,98 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     "does not replay a consumed session rail open generation after round trips or remounts",
     FULL_APP_TEST_OPTIONS,
     async () => {
-      if (!realChatServer) {
-        throw new Error("Expected the Control UI server to be ready");
-      }
-      const page = await openBrowserPage(900, 700);
-      try {
-        await page.goto(realChatServer.baseUrl, {
-          waitUntil: "domcontentloaded",
-          timeout: APP_FIRST_RENDER_TIMEOUT_MS,
-        });
-        await page.evaluate(
-          () =>
-            new Promise<void>((resolve, reject) => {
-              const script = document.createElement("script");
-              script.type = "module";
-              script.src = "/src/pages/chat/components/chat-session-rail.ts";
-              script.addEventListener("load", () => resolve(), { once: true });
-              script.addEventListener(
-                "error",
-                () => reject(new Error("Session rail module failed")),
-                {
-                  once: true,
-                },
-              );
-              document.head.append(script);
-            }),
-        );
-        const result = await page.evaluate(async () => {
-          localStorage.setItem("openclaw.chat.observerHud.display", "pill");
-          type Rail = HTMLElement & {
-            companion: {
-              exchanges: [];
-              pendingQuestion: null;
-              failedQuestion: null;
-              hint: null;
-              draft: string;
-            };
-            connected: boolean;
-            consumedOpenRequest: number;
-            onOpenRequestConsumed: (openRequest: number) => void;
-            onVisibilityChange: (visible: boolean) => void;
-            openRequest: number;
-            sessionKey: string;
-            updateComplete: Promise<boolean>;
+      const page = await getSharedAppPage();
+      const result = await page.evaluate(async () => {
+        await customElements.whenDefined("openclaw-chat-session-rail");
+        localStorage.setItem("openclaw.chat.observerHud.display", "pill");
+        type Rail = HTMLElement & {
+          companion: {
+            exchanges: [];
+            pendingQuestion: null;
+            failedQuestion: null;
+            hint: null;
+            draft: string;
           };
-          const createRail = () => document.createElement("openclaw-chat-session-rail") as Rail;
-          let rail = createRail();
-          let consumedOpenRequest = 0;
-          let visibleReports = 0;
-          const configureRail = (nextRail: Rail) => {
-            nextRail.companion = {
-              exchanges: [],
-              pendingQuestion: null,
-              failedQuestion: null,
-              hint: null,
-              draft: "What changed?",
-            };
-            nextRail.connected = true;
-            nextRail.consumedOpenRequest = consumedOpenRequest;
-            nextRail.onOpenRequestConsumed = (openRequest) => {
-              consumedOpenRequest = openRequest;
-            };
-            nextRail.onVisibilityChange = (visible) => {
-              if (visible) {
-                visibleReports += 1;
-              }
-            };
+          connected: boolean;
+          consumedOpenRequest: number;
+          onOpenRequestConsumed: (openRequest: number) => void;
+          onVisibilityChange: (visible: boolean) => void;
+          openRequest: number;
+          sessionKey: string;
+          updateComplete: Promise<boolean>;
+        };
+        const createRail = () => document.createElement("openclaw-chat-session-rail") as Rail;
+        let rail = createRail();
+        let consumedOpenRequest = 0;
+        let visibleReports = 0;
+        const configureRail = (nextRail: Rail) => {
+          nextRail.companion = {
+            exchanges: [],
+            pendingQuestion: null,
+            failedQuestion: null,
+            hint: null,
+            draft: "What changed?",
           };
-          configureRail(rail);
-          rail.sessionKey = "agent:main:a";
-          document.body.replaceChildren(rail);
+          nextRail.connected = true;
+          nextRail.consumedOpenRequest = consumedOpenRequest;
+          nextRail.onOpenRequestConsumed = (openRequest) => {
+            consumedOpenRequest = openRequest;
+          };
+          nextRail.onVisibilityChange = (visible) => {
+            if (visible) {
+              visibleReports += 1;
+            }
+          };
+        };
+        configureRail(rail);
+        rail.sessionKey = "agent:main:a";
+        document.body.append(rail);
+        await rail.updateComplete;
+        const mode = () =>
+          rail.querySelector(".chat-session-rail--expanded") ? "expanded" : "pill";
+        const update = async (sessionKey: string, openRequest: number) => {
+          rail.sessionKey = sessionKey;
+          rail.openRequest = openRequest;
+          rail.consumedOpenRequest = consumedOpenRequest;
           await rail.updateComplete;
-          const mode = () =>
-            rail.querySelector(".chat-session-rail--expanded") ? "expanded" : "pill";
-          const update = async (sessionKey: string, openRequest: number) => {
-            rail.sessionKey = sessionKey;
-            rail.openRequest = openRequest;
-            rail.consumedOpenRequest = consumedOpenRequest;
-            await rail.updateComplete;
-            return mode();
-          };
+          return mode();
+        };
 
-          const sameElementModes = [
-            await update("agent:main:a", 1),
-            await update("agent:main:b", 0),
-            await update("agent:main:a", 1),
-            await update("agent:main:a", 2),
-          ];
-          rail.remove();
-          rail = createRail();
-          configureRail(rail);
-          rail.sessionKey = "agent:main:a";
-          rail.openRequest = 2;
-          document.body.append(rail);
-          await rail.updateComplete;
-          const remountMode = mode();
-          const nextGenerationMode = await update("agent:main:a", 3);
+        const sameElementModes = [
+          await update("agent:main:a", 1),
+          await update("agent:main:b", 0),
+          await update("agent:main:a", 1),
+          await update("agent:main:a", 2),
+        ];
+        rail.remove();
+        rail = createRail();
+        configureRail(rail);
+        rail.sessionKey = "agent:main:a";
+        rail.openRequest = 2;
+        document.body.append(rail);
+        await rail.updateComplete;
+        const remountMode = mode();
+        const nextGenerationMode = await update("agent:main:a", 3);
 
-          return {
-            sameElementModes,
-            remountMode,
-            nextGenerationMode,
-            storedPreference: localStorage.getItem("openclaw.chat.observerHud.display"),
-            visibleReports,
-          };
-        });
+        const snapshot = {
+          sameElementModes,
+          remountMode,
+          nextGenerationMode,
+          storedPreference: localStorage.getItem("openclaw.chat.observerHud.display"),
+          visibleReports,
+        };
+        rail.remove();
+        localStorage.removeItem("openclaw.chat.observerHud.display");
+        return snapshot;
+      });
 
-        expect(result).toEqual({
-          sameElementModes: ["expanded", "pill", "pill", "expanded"],
-          remountMode: "pill",
-          nextGenerationMode: "expanded",
-          storedPreference: "pill",
-          visibleReports: 3,
-        });
-      } finally {
-        await closeBrowserPage(page);
-      }
+      expect(result).toEqual({
+        sameElementModes: ["expanded", "pill", "pill", "expanded"],
+        remountMode: "pill",
+        nextGenerationMode: "expanded",
+        storedPreference: "pill",
+        visibleReports: 3,
+      });
     },
   );
 
@@ -1104,18 +1166,10 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     "remeasures a populated composer when the viewport width changes",
     FULL_APP_TEST_OPTIONS,
     async () => {
-      if (!realChatServer) {
-        throw new Error("Expected the Control UI server to be ready");
-      }
-      const page = await openBrowserPage(900, 800);
-      const pageErrors: string[] = [];
-      page.on("pageerror", (error) => pageErrors.push(error.message));
+      const page = await getSharedAppPage();
+      const errorStart = sharedAppPageErrors.length;
       try {
-        await installResponsiveChatGateway(page);
-        await page.goto(`${realChatServer.baseUrl}chat/main`, {
-          waitUntil: "domcontentloaded",
-          timeout: APP_FIRST_RENDER_TIMEOUT_MS,
-        });
+        await page.setViewportSize({ width: 900, height: 800 });
         const textarea = page.locator(".agent-chat__composer-combobox > textarea");
         await textarea.waitFor({ timeout: APP_FIRST_RENDER_TIMEOUT_MS });
         await textarea.fill(
@@ -1143,9 +1197,14 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           );
           return element !== null && element.getBoundingClientRect().height < previousHeight - 1;
         }, narrowHeight);
-        expect(pageErrors.filter((message) => message.includes("ResizeObserver loop"))).toEqual([]);
+        expect(
+          sharedAppPageErrors
+            .slice(errorStart)
+            .filter((message) => message.includes("ResizeObserver loop")),
+        ).toEqual([]);
       } finally {
-        await closeBrowserPage(page);
+        await page.locator(".agent-chat__composer-combobox > textarea").fill("");
+        await page.setViewportSize({ width: 1366, height: 900 });
       }
     },
   );
@@ -1154,60 +1213,40 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     "reveals, pins, and dismisses message context from the timestamp",
     FULL_APP_TEST_OPTIONS,
     async () => {
-      if (!realChatServer) {
-        throw new Error("Expected the Control UI server to be ready");
-      }
-      const page = await openBrowserPage(1366, 900);
+      const page = await getSharedAppPage();
       try {
-        await installResponsiveChatGateway(page, {
-          assistantName: "Claw",
-          historyMessages: [
-            {
-              content: [{ text: "Context hover regression fixture.", type: "text" }],
-              model: "openai/gpt-5.5",
-              role: "assistant",
-              timestamp: Date.UTC(2026, 6, 5, 9, 51),
-              usage: { cacheRead: 2_400, input: 19_600, output: 126 },
-            },
-          ],
-        });
-        await page.goto(`${realChatServer.baseUrl}chat/main`, {
-          waitUntil: "domcontentloaded",
-          timeout: APP_FIRST_RENDER_TIMEOUT_MS,
-        });
-        await page
-          .getByText("Context hover regression fixture.")
-          .waitFor({ timeout: APP_FIRST_RENDER_TIMEOUT_MS });
-
-        const details = page.locator("details.msg-meta");
-        const context = page.locator(".msg-meta__details");
-        const initialLayout = await page.evaluate(() => {
-          const footer = document.querySelector<HTMLElement>(".chat-group-footer")!;
-          const group = document.querySelector<HTMLElement>(".chat-group")!;
+        await page.setViewportSize({ width: 1366, height: 900 });
+        const group = page.locator(".chat-group").filter({ hasText: SHARED_APP_CONTEXT_TEXT });
+        const details = group.locator("details.msg-meta");
+        const context = details.locator(".msg-meta__details");
+        const summary = details.locator(".msg-meta__summary");
+        const messageText = group.locator(".chat-text").first();
+        await messageText.waitFor({ timeout: APP_FIRST_RENDER_TIMEOUT_MS });
+        const initialLayout = await group.evaluate((node) => {
+          const footer = node.querySelector<HTMLElement>(".chat-group-footer")!;
           return {
             footerHeight: footer.getBoundingClientRect().height,
-            groupHeight: group.getBoundingClientRect().height,
+            groupHeight: (node as HTMLElement).getBoundingClientRect().height,
           };
         });
         expect(await context.isVisible()).toBe(false);
 
         // Travel like a real pointer: the footer overlay is pointer-gated until
         // the group is hovered, so enter through the message body first.
-        await page.locator(".chat-text").first().hover();
-        await page.locator(".msg-meta__summary").hover();
+        await messageText.hover();
+        await summary.hover();
         // The reveal is state-driven, so the re-render can lag the hover event
         // under CPU contention; poll instead of a one-shot visibility read.
         await context.waitFor({ state: "visible", timeout: 10_000 });
-        const hoverLayout = await page.evaluate(() => {
-          const footer = document.querySelector<HTMLElement>(".chat-group-footer")!;
-          const group = document.querySelector<HTMLElement>(".chat-group")!;
-          const summary = document.querySelector<HTMLElement>(".msg-meta__summary")!;
-          const detailsOverlay = document.querySelector<HTMLElement>(".msg-meta__details")!;
+        const hoverLayout = await group.evaluate((node) => {
+          const footer = node.querySelector<HTMLElement>(".chat-group-footer")!;
+          const summaryNode = node.querySelector<HTMLElement>(".msg-meta__summary")!;
+          const detailsOverlay = node.querySelector<HTMLElement>(".msg-meta__details")!;
           return {
             contextBottom: detailsOverlay.getBoundingClientRect().bottom,
             footerHeight: footer.getBoundingClientRect().height,
-            groupHeight: group.getBoundingClientRect().height,
-            summaryTop: summary.getBoundingClientRect().top,
+            groupHeight: (node as HTMLElement).getBoundingClientRect().height,
+            summaryTop: summaryNode.getBoundingClientRect().top,
           };
         });
         expect(hoverLayout.footerHeight).toBeCloseTo(initialLayout.footerHeight, 2);
@@ -1217,12 +1256,12 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         await page.mouse.move(0, 0);
         await context.waitFor({ state: "hidden", timeout: 10_000 });
 
-        await page.locator(".chat-text").first().hover();
-        await page.locator(".msg-meta__summary").hover();
+        await messageText.hover();
+        await summary.hover();
         // Escape only owns pinned disclosures; it must not corrupt an active
         // hover preview before the click converts that preview into a pin.
         await page.keyboard.press("Escape");
-        await page.locator(".msg-meta__summary").click();
+        await summary.click();
         await page.mouse.move(0, 0);
         // Click-to-open must survive the pointer leaving the message group.
         await context.waitFor({ state: "visible", timeout: 10_000 });
@@ -1232,14 +1271,15 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         await context.waitFor({ state: "hidden", timeout: 10_000 });
         expect(await details.getAttribute("open")).toBeNull();
 
-        await page.locator(".chat-text").first().hover();
-        await page.locator(".msg-meta__summary").click();
+        await messageText.hover();
+        await summary.click();
         await context.waitFor({ state: "visible", timeout: 10_000 });
         await page.keyboard.press("Escape");
         await context.waitFor({ state: "hidden", timeout: 10_000 });
         expect(await details.getAttribute("open")).toBeNull();
       } finally {
-        await closeBrowserPage(page);
+        await page.keyboard.press("Escape");
+        await page.mouse.move(0, 0);
       }
     },
   );
@@ -1248,45 +1288,13 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     "renders encoded media extensions from assistant output and transcript fields",
     FULL_APP_TEST_OPTIONS,
     async () => {
-      if (!realChatServer) {
-        throw new Error("Expected the Control UI server to be ready");
-      }
-      const imageUrl = "https://cdn.example/render%2Epng?download=1";
-      const videoUrl = "https://cdn.example/clip%2Emp4?download=1";
-      const page = await openBrowserPage(1366, 900);
-      try {
-        await page.route("https://cdn.example/**", (route) => route.abort());
-        await installResponsiveChatGateway(page, {
-          historyMessages: [
-            {
-              content: `MEDIA:${imageUrl}`,
-              role: "assistant",
-              timestamp: Date.UTC(2026, 6, 9, 10, 0),
-            },
-            {
-              content: "Encoded transcript video",
-              __openclaw: { media: [{ url: videoUrl, contentType: "video/mp4" }] },
-              role: "user",
-              timestamp: Date.UTC(2026, 6, 9, 10, 1),
-            },
-          ],
-        });
-        await page.goto(`${realChatServer.baseUrl}chat/main`, {
-          waitUntil: "domcontentloaded",
-          timeout: APP_FIRST_RENDER_TIMEOUT_MS,
-        });
-
-        const image = page.locator("img.chat-message-image");
-        const video = page.locator("video");
-        // First wait absorbs the cold-app render; both elements land in the same
-        // history render pass. Video stays behind its placeholder until metadata loads.
-        await image.waitFor({ timeout: APP_FIRST_RENDER_TIMEOUT_MS });
-        await video.waitFor({ state: "attached", timeout: 10_000 });
-        expect(await image.getAttribute("src")).toBe(imageUrl);
-        expect(await video.getAttribute("src")).toBe(videoUrl);
-      } finally {
-        await closeBrowserPage(page);
-      }
+      const page = await getSharedAppPage();
+      const image = page.locator(`img.chat-message-image[src="${SHARED_APP_IMAGE_URL}"]`);
+      const video = page.locator(`video[src="${SHARED_APP_VIDEO_URL}"]`);
+      await image.waitFor({ timeout: APP_FIRST_RENDER_TIMEOUT_MS });
+      await video.waitFor({ state: "attached", timeout: 10_000 });
+      expect(await image.getAttribute("src")).toBe(SHARED_APP_IMAGE_URL);
+      expect(await video.getAttribute("src")).toBe(SHARED_APP_VIDEO_URL);
     },
   );
 
@@ -2449,38 +2457,17 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     let page: Page;
 
     beforeAll(async () => {
-      if (!realChatServer) {
-        throw new Error("Expected the Control UI server to be ready");
-      }
-      page = await openBrowserPage(568, 320);
-      await installResponsiveChatGateway(page, {
-        historyMessages: [
-          {
-            content: [
-              {
-                text: "Short landscape slash command keyboard regression fixture.",
-                type: "text",
-              },
-            ],
-            role: "assistant",
-            timestamp: Date.now(),
-          },
-        ],
-      });
-      await page.goto(`${realChatServer.baseUrl}chat/main`, {
-        waitUntil: "domcontentloaded",
-        timeout: APP_FIRST_RENDER_TIMEOUT_MS,
-      });
-      await page
-        .getByText("Short landscape slash command keyboard regression fixture.")
-        .waitFor({ timeout: APP_FIRST_RENDER_TIMEOUT_MS });
+      page = await getSharedAppPage();
+      await page.setViewportSize({ width: 568, height: 320 });
+      await page.getByText(SHARED_APP_SLASH_TEXT).waitFor({ timeout: APP_FIRST_RENDER_TIMEOUT_MS });
       const textarea = page.locator(".agent-chat__composer-combobox > textarea");
       await textarea.fill("/");
       await textarea.focus();
     });
 
     afterAll(async () => {
-      await closeBrowserPage(page);
+      await page.locator(".agent-chat__composer-combobox > textarea").fill("");
+      await page.setViewportSize({ width: 1366, height: 900 });
     });
 
     it("scrolls the keyboard-active slash option into view in short landscape", async () => {


### PR DESCRIPTION
## What Problem This Solves

The responsive chat browser suite repeatedly created Chromium contexts, reread a 500 KB CSS bundle, and booted the complete Control UI five times. The 73-case file took 18.19 seconds in a focused local baseline and 23.41 seconds in the latest measured Linux UI shard.

## Why This Change Was Made

Static `setContent` layout fixtures now share one BrowserContext and a cached stylesheet string while retaining separate concurrent pages. The five stateful real-app checks keep one isolated, lazily booted page with disjoint fixture messages and explicit state cleanup between assertions. Test count, responsive assertions, worker settings, sharding, timeouts, and test-level concurrency settings are unchanged.

## User Impact

There is no user-visible product change. Maintainers get the same responsive UI coverage with materially less test wall time and browser setup work.

## Evidence

- Focused baseline: 18.19 seconds, 73 tests.
- Three warm after runs: 10.03, 10.00, and 10.01 seconds, preserving all 73 tests. This saves 8.16–8.19 seconds (about 45%).
- Consolidated real-app checks: 5 passed, 68 skipped in 3.19 seconds.
- Direct Oxlint, Oxfmt, and `git diff --check`: clean.
- Autoreview: clean, no accepted/actionable findings (0.99 correctness confidence).
- The full local `core-runtime-media-ui` fallback could not produce a comparison because current `main` stalled during the complete UI config teardown and hit the unchanged 300-second no-output watchdog. Hosted PR CI remains the owning Linux group proof.
- A pre-existing macOS-only gateway-picker computed-style assertion fails identically before and after this patch; the latest Linux `main` shard is green.
