### PR TITLE
fix(google): accept standard Google API key for web search

### DIFF
--- a/docs/reference/api-usage-costs.md
+++ b/docs/reference/api-usage-costs.md
@@ -77,7 +77,7 @@ See [Memory](/concepts/memory).
 
 ### Web search tool
 
-`web_search` can incur usage charges depending on the selected provider. Providers read keys from environment variables or `plugins.entries.<id>.config.webSearch.apiKey`; exact precedence varies by provider:
+`web_search` can incur usage charges depending on the selected provider. Providers read keys from environment variables or `plugins.entries.<id>.config.webSearch.apiKey`; exact precedence varies by provider. Gemini keeps an explicitly configured Google model provider key ahead of `GOOGLE_API_KEY`:
 
 | Provider               | Env var(s)                                                                                                                                                             |
 | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/reference/api-usage-costs.md
+++ b/docs/reference/api-usage-costs.md
@@ -77,7 +77,7 @@ See [Memory](/concepts/memory).
 
 ### Web search tool
 
-`web_search` can incur usage charges depending on the selected provider. Each provider reads its key from an env var first, then `plugins.entries.<id>.config.webSearch.apiKey`:
+`web_search` can incur usage charges depending on the selected provider. Providers read keys from environment variables or `plugins.entries.<id>.config.webSearch.apiKey`; exact precedence varies by provider:
 
 | Provider               | Env var(s)                                                                                                                                                             |
 | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -85,7 +85,7 @@ See [Memory](/concepts/memory).
 | DuckDuckGo             | key-free; unofficial, HTML-based, no billing                                                                                                                           |
 | Exa                    | `EXA_API_KEY`                                                                                                                                                          |
 | Firecrawl              | `FIRECRAWL_API_KEY`                                                                                                                                                    |
-| Gemini (Google Search) | `GEMINI_API_KEY`                                                                                                                                                       |
+| Gemini (Google Search) | `GEMINI_API_KEY` or `GOOGLE_API_KEY`                                                                                                                                   |
 | Grok (xAI)             | xAI OAuth profile or `XAI_API_KEY`                                                                                                                                     |
 | Kimi (Moonshot)        | `KIMI_API_KEY` or `MOONSHOT_API_KEY`                                                                                                                                   |
 | MiniMax Search         | `MINIMAX_CODE_PLAN_KEY`, `MINIMAX_CODING_API_KEY`, `MINIMAX_OAUTH_TOKEN`, or `MINIMAX_API_KEY`                                                                         |

--- a/docs/tools/gemini-search.md
+++ b/docs/tools/gemini-search.md
@@ -2,7 +2,7 @@
 summary: "Gemini web search with Google Search grounding"
 read_when:
   - You want to use Gemini for web_search
-  - You need a GEMINI_API_KEY or models.providers.google.apiKey
+  - You need a GEMINI_API_KEY, GOOGLE_API_KEY, or models.providers.google.apiKey
   - You want Google Search grounding
   - Your Gemini gateway requires request headers
 title: "Gemini search"
@@ -21,7 +21,7 @@ citations.
     API key.
   </Step>
   <Step title="Store the key">
-    Set `GEMINI_API_KEY` in the Gateway environment, reuse
+    Set `GEMINI_API_KEY` or `GOOGLE_API_KEY` in the Gateway environment, reuse
     `models.providers.google.apiKey`, or configure a dedicated web-search key via:
 
     ```bash
@@ -40,7 +40,7 @@ citations.
       google: {
         config: {
           webSearch: {
-            apiKey: "AIza...", // optional if GEMINI_API_KEY or models.providers.google.apiKey is set
+            apiKey: "AIza...", // optional if GEMINI_API_KEY, GOOGLE_API_KEY, or models.providers.google.apiKey is set
             baseUrl: "https://generativelanguage.googleapis.com/v1beta", // optional; falls back to models.providers.google.baseUrl
             headers: {
               "X-Routing-Target": "staging",
@@ -68,7 +68,7 @@ citations.
 
 **Credential precedence:** Gemini web search uses
 `plugins.entries.google.config.webSearch.apiKey` first, then `GEMINI_API_KEY`,
-then `models.providers.google.apiKey`. For base URLs, the dedicated
+then `GOOGLE_API_KEY`, and finally `models.providers.google.apiKey`. For base URLs, the dedicated
 `plugins.entries.google.config.webSearch.baseUrl` wins before
 `models.providers.google.baseUrl`.
 

--- a/docs/tools/gemini-search.md
+++ b/docs/tools/gemini-search.md
@@ -2,7 +2,7 @@
 summary: "Gemini web search with Google Search grounding"
 read_when:
   - You want to use Gemini for web_search
-  - You need a GEMINI_API_KEY, GOOGLE_API_KEY, or models.providers.google.apiKey
+  - You need a GEMINI_API_KEY, models.providers.google.apiKey, or GOOGLE_API_KEY
   - You want Google Search grounding
   - Your Gemini gateway requires request headers
 title: "Gemini search"
@@ -21,12 +21,14 @@ citations.
     API key.
   </Step>
   <Step title="Store the key">
-    Set `GEMINI_API_KEY` or `GOOGLE_API_KEY` in the Gateway environment, reuse
-    `models.providers.google.apiKey`, or configure a dedicated web-search key via:
+    Configure a dedicated web-search key via:
 
     ```bash
     openclaw configure --section web
     ```
+
+    Alternatively, set `GEMINI_API_KEY` in the Gateway environment, reuse
+    `models.providers.google.apiKey`, or set `GOOGLE_API_KEY` as a fallback.
 
   </Step>
 </Steps>
@@ -40,7 +42,7 @@ citations.
       google: {
         config: {
           webSearch: {
-            apiKey: "AIza...", // optional if GEMINI_API_KEY, GOOGLE_API_KEY, or models.providers.google.apiKey is set
+            apiKey: "AIza...", // optional if GEMINI_API_KEY, models.providers.google.apiKey, or GOOGLE_API_KEY is set
             baseUrl: "https://generativelanguage.googleapis.com/v1beta", // optional; falls back to models.providers.google.baseUrl
             headers: {
               "X-Routing-Target": "staging",
@@ -68,7 +70,7 @@ citations.
 
 **Credential precedence:** Gemini web search uses
 `plugins.entries.google.config.webSearch.apiKey` first, then `GEMINI_API_KEY`,
-then `GOOGLE_API_KEY`, and finally `models.providers.google.apiKey`. For base URLs, the dedicated
+then `models.providers.google.apiKey`, and finally `GOOGLE_API_KEY`. For base URLs, the dedicated
 `plugins.entries.google.config.webSearch.baseUrl` wins before
 `models.providers.google.baseUrl`.
 

--- a/extensions/google/openclaw.plugin.json
+++ b/extensions/google/openclaw.plugin.json
@@ -707,7 +707,7 @@
   "uiHints": {
     "webSearch.apiKey": {
       "label": "Gemini Search API Key",
-      "help": "Gemini API key for Google Search grounding (fallback: GEMINI_API_KEY env var).",
+      "help": "Gemini API key for Google Search grounding (fallback: GEMINI_API_KEY or GOOGLE_API_KEY env var).",
       "sensitive": true,
       "placeholder": "AIza..."
     },

--- a/extensions/google/openclaw.plugin.json
+++ b/extensions/google/openclaw.plugin.json
@@ -707,7 +707,7 @@
   "uiHints": {
     "webSearch.apiKey": {
       "label": "Gemini Search API Key",
-      "help": "Gemini API key for Google Search grounding (fallback: GEMINI_API_KEY or GOOGLE_API_KEY env var).",
+      "help": "Gemini API key for Google Search grounding (fallback: GEMINI_API_KEY, configured Google provider key, or GOOGLE_API_KEY).",
       "sensitive": true,
       "placeholder": "AIza..."
     },

--- a/extensions/google/src/gemini-web-search-provider.runtime.ts
+++ b/extensions/google/src/gemini-web-search-provider.runtime.ts
@@ -194,13 +194,12 @@ function resolveGeminiTimeRangeFilter(
   };
 }
 
-function resolveGeminiRuntimeApiKey(gemini?: GeminiConfig): string | undefined {
-  return (
-    readConfiguredSecretString(gemini?.apiKey, "plugins.entries.google.config.webSearch.apiKey") ??
-    readProviderEnvValue(["GEMINI_API_KEY", "GOOGLE_API_KEY"]) ??
-    readConfiguredSecretString(gemini?.providerApiKey, "models.providers.google.apiKey")
-  );
-}
+// Keep configured provider accounts ahead of the newly recognized ambient alias.
+const resolveGeminiRuntimeApiKey = (gemini?: GeminiConfig): string | undefined =>
+  readConfiguredSecretString(gemini?.apiKey, "plugins.entries.google.config.webSearch.apiKey") ??
+  readProviderEnvValue(["GEMINI_API_KEY"]) ??
+  readConfiguredSecretString(gemini?.providerApiKey, "models.providers.google.apiKey") ??
+  readProviderEnvValue(["GOOGLE_API_KEY"]);
 
 function resolveGeminiWebSearchHeaders(gemini?: GeminiConfig): Record<string, string> | undefined {
   if (!isRecord(gemini?.headers)) {
@@ -406,7 +405,7 @@ export async function executeGeminiSearch(
     return {
       error: "missing_gemini_api_key",
       message:
-        "web_search (gemini) needs an API key. Set GEMINI_API_KEY or GOOGLE_API_KEY in the Gateway environment, configure plugins.entries.google.config.webSearch.apiKey, or reuse models.providers.google.apiKey. If you do not want to configure a search API key, use web_fetch for a specific URL or the browser tool for interactive pages.",
+        "web_search (gemini) needs an API key. Configure plugins.entries.google.config.webSearch.apiKey, set GEMINI_API_KEY in the Gateway environment, reuse models.providers.google.apiKey, or set GOOGLE_API_KEY as a fallback. If you do not want to configure a search API key, use web_fetch for a specific URL or the browser tool for interactive pages.",
       docs: "https://docs.openclaw.ai/tools/web",
     };
   }

--- a/extensions/google/src/gemini-web-search-provider.runtime.ts
+++ b/extensions/google/src/gemini-web-search-provider.runtime.ts
@@ -197,7 +197,7 @@ function resolveGeminiTimeRangeFilter(
 function resolveGeminiRuntimeApiKey(gemini?: GeminiConfig): string | undefined {
   return (
     readConfiguredSecretString(gemini?.apiKey, "plugins.entries.google.config.webSearch.apiKey") ??
-    readProviderEnvValue(["GEMINI_API_KEY"]) ??
+    readProviderEnvValue(["GEMINI_API_KEY", "GOOGLE_API_KEY"]) ??
     readConfiguredSecretString(gemini?.providerApiKey, "models.providers.google.apiKey")
   );
 }
@@ -406,7 +406,7 @@ export async function executeGeminiSearch(
     return {
       error: "missing_gemini_api_key",
       message:
-        "web_search (gemini) needs an API key. Set GEMINI_API_KEY in the Gateway environment, configure plugins.entries.google.config.webSearch.apiKey, or reuse models.providers.google.apiKey. If you do not want to configure a search API key, use web_fetch for a specific URL or the browser tool for interactive pages.",
+        "web_search (gemini) needs an API key. Set GEMINI_API_KEY or GOOGLE_API_KEY in the Gateway environment, configure plugins.entries.google.config.webSearch.apiKey, or reuse models.providers.google.apiKey. If you do not want to configure a search API key, use web_fetch for a specific URL or the browser tool for interactive pages.",
       docs: "https://docs.openclaw.ai/tools/web",
     };
   }

--- a/extensions/google/src/gemini-web-search-provider.ts
+++ b/extensions/google/src/gemini-web-search-provider.ts
@@ -121,7 +121,7 @@ export function createGeminiWebSearchProvider(): WebSearchProviderPlugin {
     hint: "Requires Google Gemini API key · Google Search grounding",
     onboardingScopes: ["text-inference"],
     credentialLabel: "Google Gemini API key",
-    envVars: ["GEMINI_API_KEY"],
+    envVars: ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
     placeholder: "AIza...",
     signupUrl: "https://aistudio.google.com/apikey",
     docsUrl: "https://docs.openclaw.ai/tools/web",

--- a/extensions/google/web-search-provider.test.ts
+++ b/extensions/google/web-search-provider.test.ts
@@ -107,8 +107,12 @@ afterEach(() => {
 });
 
 describe("google web search provider", () => {
+  it("advertises both supported Google API key environment variables", () => {
+    expect(createGeminiWebSearchProvider().envVars).toEqual(["GEMINI_API_KEY", "GOOGLE_API_KEY"]);
+  });
+
   it("points missing-key users to fetch/browser alternatives", async () => {
-    await withEnvAsync({ GEMINI_API_KEY: undefined }, async () => {
+    await withEnvAsync({ GEMINI_API_KEY: undefined, GOOGLE_API_KEY: undefined }, async () => {
       const provider = createGeminiWebSearchProvider();
       const tool = provider.createTool({ config: {}, searchConfig: {} });
       if (!tool) {
@@ -119,7 +123,7 @@ describe("google web search provider", () => {
         docs: "https://docs.openclaw.ai/tools/web",
         error: "missing_gemini_api_key",
         message:
-          "web_search (gemini) needs an API key. Set GEMINI_API_KEY in the Gateway environment, configure plugins.entries.google.config.webSearch.apiKey, or reuse models.providers.google.apiKey. If you do not want to configure a search API key, use web_fetch for a specific URL or the browser tool for interactive pages.",
+          "web_search (gemini) needs an API key. Set GEMINI_API_KEY or GOOGLE_API_KEY in the Gateway environment, configure plugins.entries.google.config.webSearch.apiKey, or reuse models.providers.google.apiKey. If you do not want to configure a search API key, use web_fetch for a specific URL or the browser tool for interactive pages.",
       });
     });
   });
@@ -451,7 +455,7 @@ describe("google web search provider", () => {
   });
 
   it("reuses the Google model provider key when no web search key or env key is set", async () => {
-    await withEnvAsync({ GEMINI_API_KEY: undefined }, async () => {
+    await withEnvAsync({ GEMINI_API_KEY: undefined, GOOGLE_API_KEY: undefined }, async () => {
       const mockFetch = installGeminiFetch();
       const provider = createGeminiWebSearchProvider();
       const tool = provider.createTool({
@@ -474,8 +478,52 @@ describe("google web search provider", () => {
     });
   });
 
+  it.each([
+    {
+      label: "accepts GOOGLE_API_KEY without another configured credential",
+      geminiApiKey: undefined,
+      googleApiKey: "AIza-google-env-test",
+      providerApiKey: undefined,
+      expectedApiKey: "AIza-google-env-test",
+    },
+    {
+      label: "keeps GEMINI_API_KEY ahead of GOOGLE_API_KEY",
+      geminiApiKey: "AIza-gemini-env-test",
+      googleApiKey: "AIza-google-env-test",
+      providerApiKey: "AIza-provider-test",
+      expectedApiKey: "AIza-gemini-env-test",
+    },
+    {
+      label: "keeps GOOGLE_API_KEY ahead of the model provider credential",
+      geminiApiKey: undefined,
+      googleApiKey: "AIza-google-env-test",
+      providerApiKey: "AIza-provider-test",
+      expectedApiKey: "AIza-google-env-test",
+    },
+  ])("$label", async ({ label, geminiApiKey, googleApiKey, providerApiKey, expectedApiKey }) => {
+    await withEnvAsync({ GEMINI_API_KEY: geminiApiKey, GOOGLE_API_KEY: googleApiKey }, async () => {
+      const mockFetch = installGeminiFetch();
+      const provider = createGeminiWebSearchProvider();
+      const config: OpenClawConfig = providerApiKey
+        ? {
+            models: {
+              providers: {
+                google: createGoogleModelProviderConfig({ apiKey: providerApiKey }),
+              },
+            },
+          }
+        : {};
+      const tool = provider.createTool({ config, searchConfig: { provider: "gemini" } });
+
+      await tool?.execute({ query: `OpenClaw ${label}` });
+
+      expect(getFetchHeaders(mockFetch)["x-goog-api-key"]).toBe(expectedApiKey);
+    });
+  });
+
   it("keeps plugin web search keys ahead of env and provider keys", async () => {
-    await withEnvAsync({ GEMINI_API_KEY: "AIza-env-test" }, async () => {
+    const envKeys = { GEMINI_API_KEY: "AIza-env-test", GOOGLE_API_KEY: "AIza-google-env-test" };
+    await withEnvAsync(envKeys, async () => {
       const mockFetch = installGeminiFetch();
       const provider = createGeminiWebSearchProvider();
       const tool = provider.createTool({

--- a/extensions/google/web-search-provider.test.ts
+++ b/extensions/google/web-search-provider.test.ts
@@ -123,7 +123,7 @@ describe("google web search provider", () => {
         docs: "https://docs.openclaw.ai/tools/web",
         error: "missing_gemini_api_key",
         message:
-          "web_search (gemini) needs an API key. Set GEMINI_API_KEY or GOOGLE_API_KEY in the Gateway environment, configure plugins.entries.google.config.webSearch.apiKey, or reuse models.providers.google.apiKey. If you do not want to configure a search API key, use web_fetch for a specific URL or the browser tool for interactive pages.",
+          "web_search (gemini) needs an API key. Configure plugins.entries.google.config.webSearch.apiKey, set GEMINI_API_KEY in the Gateway environment, reuse models.providers.google.apiKey, or set GOOGLE_API_KEY as a fallback. If you do not want to configure a search API key, use web_fetch for a specific URL or the browser tool for interactive pages.",
       });
     });
   });
@@ -494,11 +494,11 @@ describe("google web search provider", () => {
       expectedApiKey: "AIza-gemini-env-test",
     },
     {
-      label: "keeps GOOGLE_API_KEY ahead of the model provider credential",
+      label: "preserves an explicit model provider credential over ambient GOOGLE_API_KEY",
       geminiApiKey: undefined,
       googleApiKey: "AIza-google-env-test",
       providerApiKey: "AIza-provider-test",
-      expectedApiKey: "AIza-google-env-test",
+      expectedApiKey: "AIza-provider-test",
     },
   ])("$label", async ({ label, geminiApiKey, googleApiKey, providerApiKey, expectedApiKey }) => {
     await withEnvAsync({ GEMINI_API_KEY: geminiApiKey, GOOGLE_API_KEY: googleApiKey }, async () => {


### PR DESCRIPTION


## Corrected account-preserving credential precedence and actual production-owner proof

Exact reviewed head: `8117aa614d4127cdc7b0863c1144306c16042886`.

ClawSweeper correctly identified that introducing the new ambient alias before an existing explicitly configured Google model-provider credential could silently change the operator's account and billing. This finding is fully repaired: dedicated Google web-search credential → previously supported `GEMINI_API_KEY` → previously supported configured Google model-provider credential → newly supported ambient `GOOGLE_API_KEY`. Every pre-existing credential decision remains unchanged; the new alias is selected only when no prior credential source exists. The dedicated setup, diagnostic, manifest, and cost documentation describe the same contract.

An independent operator proof imported the actual published plugin owner, created the actual `web_search` tool, executed its production request builder and grounded-response parser, and inspected the emitted authentication header. The transport was an in-memory supported fetch mock; all credentials were synthetic, no external Google API was contacted, and no real credential was accessed.

```json
{"result":"PASS","surface":"actual Google web_search provider","provider":"gemini","googleOnly":true,"httpRequests":1,"authHeaderMatchesFixture":true,"groundedRequest":true,"groundedResponse":true,"transport":"in-memory mock"}
{"result":"PASS","surface":"actual Google web_search provider","provider":"gemini","configuredProviderCredentialPresent":true,"ambientGoogleAliasPresent":true,"configuredCredentialRetained":true,"ambientAliasNotSelected":true,"httpRequests":1,"groundedRequest":true,"groundedResponse":true,"transport":"in-memory mock"}
```

The corrected owner suite passes 39/39 normally and 39/39 with both synthetic aliases set; the fresh independent structured Sol/high review returned clean, confidence 0.98. The accepted account/billing finding and corresponding rank-up move are addressed on this exact head.