### PR TITLE
fix(codex): preserve native routing for catalog sessions

### DIFF
--- a/extensions/codex/src/app-server/session-history-import.ts
+++ b/extensions/codex/src/app-server/session-history-import.ts
@@ -7,6 +7,10 @@ import { importCodexThreadHistoryToTranscript } from "./transcript-mirror.js";
 type CreatedCodexImportedSession = Awaited<
   ReturnType<PluginRuntime["agent"]["session"]["createSessionEntry"]>
 >;
+type CodexImportedSessionInitialEntry = Extract<
+  Parameters<PluginRuntime["agent"]["session"]["createSessionEntry"]>[0]["initialEntry"],
+  { agentHarnessId: string }
+>;
 
 /** Creates a session whose transcript is derived from one verified Codex thread snapshot. */
 export async function createImportedCodexSession(params: {
@@ -17,11 +21,7 @@ export async function createImportedCodexSession(params: {
   thread: CodexThread;
   throughTurnId: string | null;
   recoverMatchingInitialEntry?: true;
-  initialEntry: {
-    agentHarnessId: string;
-    modelSelectionLocked?: true;
-    pluginExtensions?: CreatedCodexImportedSession["entry"]["pluginExtensions"];
-  };
+  initialEntry: CodexImportedSessionInitialEntry;
   afterImport: (
     created: CreatedCodexImportedSession,
   ) => Promise<{ pluginExtensions: CreatedCodexImportedSession["entry"]["pluginExtensions"] }>;

--- a/extensions/codex/src/session-catalog.test.ts
+++ b/extensions/codex/src/session-catalog.test.ts
@@ -1990,6 +1990,8 @@ describe("Codex supervision actions", () => {
         afterCreate: expect.any(Function),
         initialEntry: {
           agentHarnessId: "codex",
+          providerOverride: "codex",
+          modelOverride: "codex-native",
           modelSelectionLocked: true,
           pluginExtensions: {
             codex: {

--- a/extensions/codex/src/session-catalog.ts
+++ b/extensions/codex/src/session-catalog.ts
@@ -1086,6 +1086,10 @@ async function createOrReuseAdoptedSession(params: {
       recoverMatchingInitialEntry: true,
       initialEntry: {
         agentHarnessId: "codex",
+        // thread/read cannot attest the native model; this virtual route reaches
+        // the Codex harness until its first fork returns the authoritative pair.
+        providerOverride: "codex",
+        modelOverride: "codex-native",
         modelSelectionLocked: true,
         pluginExtensions: {
           codex: {

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -1153,6 +1153,8 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       sessionId: "session-1",
       updatedAt: 1,
       agentHarnessId: "codex",
+      providerOverride: "codex",
+      modelOverride: "codex-native",
       modelSelectionLocked: true,
       pluginExtensions: {
         codex: {
@@ -1175,11 +1177,13 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     );
     expect(fallbackParams.fallbacksOverride).toEqual([]);
     expectRecordFields(mockCallArg(state.runAgentAttemptMock), {
-      providerOverride: "anthropic",
-      modelOverride: "claude",
+      providerOverride: "codex",
+      modelOverride: "codex-native",
       agentHarnessRuntimeOverride: "codex",
       sessionEntry: expect.objectContaining({
         agentHarnessId: "codex",
+        providerOverride: "codex",
+        modelOverride: "codex-native",
         modelSelectionLocked: true,
       }),
     });

--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -403,6 +403,34 @@ export async function createGatewaySession(params: {
     params.initialEntry?.pluginOwnerId &&
     params.authorizedPluginId === params.initialEntry.pluginOwnerId,
   );
+  const authorizedInitialModelRoute = authorizedHarnessCreation || authorizedPluginCreation;
+  const initialModelRoute = params.initialEntry
+    ? {
+        provider: normalizeOptionalString(params.initialEntry.providerOverride),
+        model: normalizeOptionalString(params.initialEntry.modelOverride),
+        resolution: params.initialEntry.modelOverrideRouteResolution,
+      }
+    : undefined;
+  const hasInitialModelRoute = Boolean(
+    params.initialEntry?.providerOverride ||
+    params.initialEntry?.modelOverride ||
+    params.initialEntry?.modelOverrideRouteResolution,
+  );
+  if (
+    hasInitialModelRoute &&
+    (!authorizedInitialModelRoute ||
+      !initialModelRoute?.provider ||
+      !initialModelRoute?.model ||
+      initialModelRoute?.resolution !== "resolved")
+  ) {
+    return {
+      ok: false,
+      error: errorShape(
+        ErrorCodes.INVALID_REQUEST,
+        "trusted initial model route requires an authorized resolved provider and model",
+      ),
+    };
+  }
   if (params.initialEntry?.pluginOwnerId && !authorizedPluginCreation) {
     return {
       ok: false,
@@ -981,13 +1009,13 @@ export async function createGatewaySession(params: {
           ...(createdNewEntry && params.authorizedPluginId && !params.catalogTarget
             ? { pluginOwnerId: params.authorizedPluginId }
             : {}),
-          ...(authorizedPluginCreation && params.initialEntry?.providerOverride
+          ...(authorizedInitialModelRoute && params.initialEntry?.providerOverride
             ? { providerOverride: params.initialEntry.providerOverride }
             : {}),
-          ...(authorizedPluginCreation && params.initialEntry?.modelOverride
+          ...(authorizedInitialModelRoute && params.initialEntry?.modelOverride
             ? { modelOverride: params.initialEntry.modelOverride }
             : {}),
-          ...(authorizedPluginCreation && params.initialEntry?.modelOverrideRouteResolution
+          ...(authorizedInitialModelRoute && params.initialEntry?.modelOverrideRouteResolution
             ? { modelOverrideRouteResolution: params.initialEntry.modelOverrideRouteResolution }
             : {}),
           // Seeded CLI bindings ride only the plugin-authorized creation path;

--- a/src/plugins/runtime/runtime-agent.test.ts
+++ b/src/plugins/runtime/runtime-agent.test.ts
@@ -64,6 +64,8 @@ describe("plugin runtime session creation", () => {
         label: "Native Codex thread",
         initialEntry: {
           agentHarnessId: "codex",
+          providerOverride: "codex",
+          modelOverride: "codex-native",
           modelSelectionLocked: true,
           pluginExtensions: initialPluginExtensions,
         },
@@ -85,6 +87,9 @@ describe("plugin runtime session creation", () => {
         entry: {
           agentHarnessId: "codex",
           delivery: { kind: "none" },
+          providerOverride: "codex",
+          modelOverride: "codex-native",
+          modelOverrideRouteResolution: "resolved",
           modelSelectionLocked: true,
           label: "Native Codex thread",
           pluginExtensions: {

--- a/src/plugins/runtime/runtime-agent.ts
+++ b/src/plugins/runtime/runtime-agent.ts
@@ -193,6 +193,20 @@ async function createSessionEntry(
   const acpInitial = "acpSessionBinding" in params.initialEntry ? params.initialEntry : undefined;
   const harnessInitial = "agentHarnessId" in params.initialEntry ? params.initialEntry : undefined;
   const pluginInitial = cliInitial ?? acpInitial;
+  const initialHarnessRoute =
+    harnessInitial?.providerOverride && harnessInitial.modelOverride
+      ? {
+          providerOverride: harnessInitial.providerOverride,
+          modelOverride: harnessInitial.modelOverride,
+          modelOverrideRouteResolution: "resolved" as const,
+        }
+      : undefined;
+  if (
+    (harnessInitial?.providerOverride || harnessInitial?.modelOverride) &&
+    (!initialHarnessRoute || harnessInitial.modelSelectionLocked !== true)
+  ) {
+    throw new Error("initial harness model route requires a locked provider and model");
+  }
   const acpBackendId = acpInitial?.acpBackendId.trim();
   const acpAgentId = acpInitial?.acpSessionBinding.acpAgentId.trim();
   const agentSessionId = acpInitial?.acpSessionBinding.agentSessionId.trim();
@@ -323,6 +337,10 @@ async function createSessionEntry(
             matchingEntry.agentHarnessId === harnessInitial?.agentHarnessId &&
             matchingEntry.pluginOwnerId === pluginInitial?.pluginOwnerId &&
             matchingEntry.modelSelectionLocked === params.initialEntry.modelSelectionLocked &&
+            matchingEntry.providerOverride === initialHarnessRoute?.providerOverride &&
+            matchingEntry.modelOverride === initialHarnessRoute?.modelOverride &&
+            matchingEntry.modelOverrideRouteResolution ===
+              initialHarnessRoute?.modelOverrideRouteResolution &&
             (!cliInitial ||
               (matchingEntry.providerOverride === cliInitial.cliBackendId &&
                 matchingEntry.modelOverride === cliInitial.model &&
@@ -366,6 +384,7 @@ async function createSessionEntry(
             ...(params.execCwd !== undefined ? { execCwd: params.execCwd } : {}),
             initialEntry: {
               ...(harnessInitial ? { agentHarnessId: harnessInitial.agentHarnessId } : {}),
+              ...initialHarnessRoute,
               ...(cliInitial
                 ? {
                     pluginOwnerId: cliInitial.pluginOwnerId,

--- a/src/plugins/runtime/runtime-agent.ts
+++ b/src/plugins/runtime/runtime-agent.ts
@@ -203,7 +203,7 @@ async function createSessionEntry(
       : undefined;
   if (
     (harnessInitial?.providerOverride || harnessInitial?.modelOverride) &&
-    (!initialHarnessRoute || harnessInitial.modelSelectionLocked !== true)
+    (!initialHarnessRoute || !harnessInitial.modelSelectionLocked)
   ) {
     throw new Error("initial harness model route requires a locked provider and model");
   }

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -89,6 +89,21 @@ type RuntimeCreateSessionEntryResult = {
 type RuntimeCreateSessionEntryFinalPatch = {
   pluginExtensions: RuntimeSessionPluginExtensions;
 };
+type RuntimeHarnessSessionInitialEntry =
+  | {
+      agentHarnessId: string;
+      modelSelectionLocked?: true;
+      pluginExtensions?: RuntimeSessionPluginExtensions;
+      providerOverride?: never;
+      modelOverride?: never;
+    }
+  | {
+      agentHarnessId: string;
+      providerOverride: string;
+      modelOverride: string;
+      modelSelectionLocked: true;
+      pluginExtensions?: RuntimeSessionPluginExtensions;
+    };
 type RuntimeCreateSessionEntryBaseParams = {
   cfg: import("../../config/types.openclaw.js").OpenClawConfig;
   key: string;
@@ -100,11 +115,7 @@ type RuntimeCreateSessionEntryBaseParams = {
   /** Working directory interpreted only by execNode. */
   execCwd?: string;
   initialEntry:
-    | {
-        agentHarnessId: string;
-        modelSelectionLocked?: true;
-        pluginExtensions?: RuntimeSessionPluginExtensions;
-      }
+    | RuntimeHarnessSessionInitialEntry
     | {
         cliBackendId: string;
         model: string;


### PR DESCRIPTION
Closes #118642

## What Problem This Solves

Catalog-adopted Codex sessions are locked to the Codex harness but previously lacked a persisted initial provider/model route. The first turn could therefore inherit an unsupported outer default, such as `openrouter/...`, and fail before Codex could execute its supervision fork.

## Why This Approach

The catalog importer now persists the virtual `codex/codex-native` bootstrap route through a trusted locked-harness initialization contract. This reaches the Codex harness without claiming that `codex-native` is the snapshot's native model and without issuing a fork during import. The existing first-turn supervision flow still obtains the authoritative model/provider pair from `thread/fork` and starts the canonical thread with that exact pair.

The gateway accepts an initial model route only for an already-authorized harness or plugin creation request, and only when it supplies both fields with canonical `resolved` provenance.

## User Impact

Opening a locked Codex catalog session no longer lets the agent's configured default model override the pending native Codex route. The first turn can materialize the actual native selection as designed.

## Evidence

- `node scripts/run-vitest.mjs extensions/codex/src/session-catalog.test.ts src/plugins/runtime/runtime-agent.test.ts src/agents/agent-command.live-model-switch.test.ts` (235 passed)
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/thread-lifecycle.test.ts` (141 passed)
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-118642.tsbuildinfo`
- `./node_modules/.bin/oxfmt --check` and `./node_modules/.bin/oxlint` on all changed files
- `git diff --check`

`node scripts/check-changed.mjs` could not run because the local Crabbox binary failed its startup sanity check. The broader extension type lane is also unavailable locally after the workspace dependency installer stalled on cross-platform optional packages; CI will run the canonical clean-environment checks.
