### PR TITLE
fix(whatsapp): stop reconnecting after terminal retry exhaustion

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor-state.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor-state.test.ts
@@ -155,6 +155,8 @@ describe("createWebChannelStatusController", () => {
     {
       healthState: "logged-out",
       statusCode: 401,
+      error: "WhatsApp session logged out",
+      reconnectAttempts: 0,
       lifecycle: "blocked",
       finalHealthState: "logged-out",
       finalLifecycle: "blocked",
@@ -163,14 +165,28 @@ describe("createWebChannelStatusController", () => {
     {
       healthState: "conflict",
       statusCode: 440,
+      error: "WhatsApp session conflict",
+      reconnectAttempts: 0,
       lifecycle: "blocked",
       finalHealthState: "conflict",
       finalLifecycle: "blocked",
       terminalDisconnect: true,
     },
     {
+      healthState: "stopped",
+      statusCode: 408,
+      error: "WhatsApp reconnect attempts exhausted after a timeout",
+      reconnectAttempts: 12,
+      lifecycle: "blocked",
+      finalHealthState: "stopped",
+      finalLifecycle: "blocked",
+      terminalDisconnect: true,
+    },
+    {
       healthState: "reconnecting",
       statusCode: 408,
+      error: "WhatsApp connection timed out",
+      reconnectAttempts: 1,
       lifecycle: "recovering",
       finalHealthState: "stopped",
       finalLifecycle: "stopped",
@@ -181,6 +197,8 @@ describe("createWebChannelStatusController", () => {
     ({
       healthState,
       statusCode,
+      error,
+      reconnectAttempts,
       lifecycle,
       finalHealthState,
       finalLifecycle,
@@ -193,41 +211,80 @@ describe("createWebChannelStatusController", () => {
       controller.noteClose({
         at: 2000,
         statusCode,
-        error: healthState,
-        reconnectAttempts: healthState === "reconnecting" ? 1 : 0,
+        error,
+        reconnectAttempts,
         healthState,
       });
       expect(patches.at(-1)!.healthState).toBe(healthState);
       expect(patches.at(-1)!.lifecycle).toBe(lifecycle);
 
-      controller.markStopped(2100);
+      const stoppedStatus = {
+        healthState: finalHealthState,
+        lifecycle: finalLifecycle,
+        terminalDisconnect,
+        lastError: error,
+        reconnectAttempts,
+        lastDisconnect: {
+          at: 2000,
+          status: statusCode,
+          error,
+        },
+      };
 
-      expect(patches.at(-1)!.healthState).toBe(finalHealthState);
-      expect(patches.at(-1)!.lifecycle).toBe(finalLifecycle);
-      expect(patches.at(-1)!.terminalDisconnect).toBe(terminalDisconnect);
+      controller.markStopped(2100);
+      expect(patches.at(-1)).toMatchObject(stoppedStatus);
+
+      controller.markStopped(2200);
+      expect(patches.at(-1)).toMatchObject(stoppedStatus);
     },
   );
 
-  it("clears terminalDisconnect on noteConnected after a terminal stop", () => {
-    const patches: Record<string, unknown>[] = [];
-    const controller = createWebChannelStatusController((s) => patches.push({ ...s }));
+  it.each([
+    { healthState: "logged-out", statusCode: 401, reconnectAttempts: 0 },
+    { healthState: "conflict", statusCode: 440, reconnectAttempts: 0 },
+    { healthState: "stopped", statusCode: 408, reconnectAttempts: 12 },
+  ] as const)(
+    "clears terminalDisconnect on reconnect after a $healthState stop",
+    ({ healthState, statusCode, reconnectAttempts }) => {
+      const patches: Record<string, unknown>[] = [];
+      const controller = createWebChannelStatusController((s) => patches.push({ ...s }));
 
-    controller.noteConnected(1000);
-    controller.noteClose({
-      at: 2000,
-      statusCode: 401,
-      error: "logged out",
-      reconnectAttempts: 0,
-      healthState: "logged-out",
-    });
-    controller.markStopped(2100);
-    expect(patches.at(-1)!.terminalDisconnect).toBe(true);
+      controller.noteConnected(1000);
+      controller.noteClose({
+        at: 2000,
+        statusCode,
+        error: healthState,
+        reconnectAttempts,
+        healthState,
+      });
+      controller.markStopped(2100);
+      expect(patches.at(-1)!.terminalDisconnect).toBe(true);
+      expect(patches.at(-1)!.lifecycle).toBe("blocked");
 
-    controller.noteConnected(3000);
-    expect(patches.at(-1)!.terminalDisconnect).toBeUndefined();
-    expect(patches.at(-1)!.healthState).toBe("healthy");
-    expect(patches.at(-1)!.lifecycle).toBe("ready");
-  });
+      controller.markStopped(2200);
+      expect(patches.at(-1)!.terminalDisconnect).toBe(true);
+      expect(patches.at(-1)!.lifecycle).toBe("blocked");
+
+      controller.noteConnected(3000);
+      expect(patches.at(-1)!.terminalDisconnect).toBeUndefined();
+      expect(patches.at(-1)!.healthState).toBe("healthy");
+      expect(patches.at(-1)!.lifecycle).toBe("ready");
+
+      controller.markStopped(3100);
+      expect(patches.at(-1)).toMatchObject({
+        healthState: "stopped",
+        lifecycle: "stopped",
+        terminalDisconnect: false,
+      });
+
+      controller.markStopped(3200);
+      expect(patches.at(-1)).toMatchObject({
+        healthState: "stopped",
+        lifecycle: "stopped",
+        terminalDisconnect: false,
+      });
+    },
+  );
 
   it("publishes stopped lifecycle without changing the shipped health label", () => {
     const patches: Record<string, unknown>[] = [];
@@ -241,6 +298,14 @@ describe("createWebChannelStatusController", () => {
       connected: false,
       healthState: "stopped",
       lifecycle: "stopped",
+      terminalDisconnect: false,
+    });
+
+    controller.markStopped(3000);
+    expect(patches.at(-1)).toMatchObject({
+      healthState: "stopped",
+      lifecycle: "stopped",
+      terminalDisconnect: false,
     });
   });
 });

--- a/extensions/whatsapp/src/auto-reply/monitor-state.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor-state.ts
@@ -12,7 +12,7 @@ const LIFECYCLE_BY_HEALTH_STATE = {
   reconnecting: "recovering",
   conflict: "blocked",
   "logged-out": "blocked",
-  stopped: "stopped",
+  stopped: "blocked", // Retry exhaustion is terminal; manual stops bypass this mapping.
 } satisfies Record<WebChannelHealthState, NonNullable<WebChannelStatus["lifecycle"]>>;
 
 function cloneStatus(status: WebChannelStatus): WebChannelStatus {
@@ -136,8 +136,7 @@ export function createWebChannelStatusController(statusSink?: (status: WebChanne
       status.running = false;
       status.connected = false;
       status.lastEventAt = at;
-      status.terminalDisconnect =
-        status.healthState === "logged-out" || status.healthState === "conflict";
+      status.terminalDisconnect = status.lifecycle === "blocked";
       if (!isTerminalHealthState(status.healthState)) {
         status.healthState = "stopped";
         status.lifecycle = "stopped";


### PR DESCRIPTION
## What Problem This Solves

After WhatsApp exhausted its bounded reconnect budget, its connection owner stopped correctly but the separate status owner did not record a terminal lifecycle. The production Gateway interpreted that clean exit as restartable, began another retry cycle, and could replace the original useful error with a generic disconnect.

## Why This Change Was Made

The canonical terminal fact already belongs to the WhatsApp lifecycle owner. Map retry exhaustion to its existing `blocked` lifecycle and derive `terminalDisconnect` from that authoritative fact instead of separately guessing from legacy health labels. Ordinary repeated shutdown and recovery remain nonterminal. The production refactor removes one net line and introduces no Gateway/core, credential, config/default, dependency, SDK, schema, or protocol changes.

## User Impact

Operators no longer get an endless WhatsApp reconnect storm after the configured retry budget is exhausted. Real `openclaw channels status` retains the original upstream failure and existing actionable `openclaw doctor` guidance; intentional stops and manual recovery keep working.

Existing shared Gateway terminal cleanup resets its generic reconnect-attempt projection to zero. The actual WhatsApp owner still exhausts all 12 attempts; this unchanged projection is not represented as retaining the owner count.

## Evidence

- Genuine owner-level regressions failed first: five failed before the canonical lifecycle repair.
- WhatsApp owner, connection-controller, channel-status, and status-issue suites: **56 passed**.
- Gateway health-policy, channel lifecycle, channel server, and status-RPC suites: **141 passed**.
- Existing WhatsApp reconnect-exhaustion E2E: **passed**.
- Complete exact-two-path remote repository gate: **passed**, including all three dead-export scans, extension and extension-test typechecking, formatting, lint, ownership/dependency guards, and runtime import-cycle checks; **359.358 seconds**.
- Four distinct complete hostile code reviews: **no P0–P3 findings**.
- Separate genuine `gpt-5.6-sol` / high / P3 / no-web autoreview: **clean**, confidence **0.94**; pinned TruffleHog 3.96.0: **clean**.

## Real behavior proof

An actual authenticated loopback production Gateway, its real `channels.status` WebSocket RPC, and the public Commander CLI exercised the full owner-to-operator path on exact commit `2f5222eb6e2dd51d6660734a73d17af7727683cb`:

- The WhatsApp owner exhausted **12** attempts; the channel started exactly **once**.
- Gateway recorded `lifecycle: blocked`, `terminalDisconnect: true`, and the original `whatsapp-proof-2f522: upstream websocket timed out` error.
- Real public CLI output included the original failure and `openclaw doctor` remediation.
- Repeated ordinary stops and recovered-account stops remained nonterminal.
- The isolated, credential-free runtime observed **zero** external network attempts or connections on the exercised standard product paths. This is an observed runtime boundary, not an adversarial native-network or host-wide sandbox claim.

## Maintainer decision

- Maintainer accepts the low-risk WhatsApp-owner-only canonical lifecycle refactor after exact-head real Gateway/CLI proof, focused coverage, complete remote gate, and five independent clean reviews.
- Maintainer authorizes repository-native landing of exact reviewed head `2f5222eb6e2dd51d6660734a73d17af7727683cb` after all hosted checks and the completed ClawSweeper review pass.
- Maintainer accepts the clean current-main merge result after confirming the required `openclaw/ci-gate` passed and authorizes the repository-native preparation and landing workflow.
