### PR TITLE
fix(media): fall back when providers return empty output

### DIFF
--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -782,7 +782,7 @@ async function runAttachmentEntries(params: {
               config: params.config,
               secretOwnerId: candidate.secretOwnerId,
             });
-      if (result) {
+      if (result?.text) {
         const decision = buildModelDecision({ entry, entryType, outcome: "success" });
         if (result.provider) {
           decision.provider = result.provider;

--- a/src/media-understanding/runner.video.test.ts
+++ b/src/media-understanding/runner.video.test.ts
@@ -481,7 +481,8 @@ describe("runCapability provider output decisions", () => {
       (output.text.trim() ? [true] : [true, false]).map((configureFallback) => ({
         capability,
         configureFallback,
-        ...output,
+        label: output.label,
+        text: output.text,
       })),
     ),
   );

--- a/src/media-understanding/runner.video.test.ts
+++ b/src/media-understanding/runner.video.test.ts
@@ -1,6 +1,10 @@
 // Video runner tests cover provider request wiring, auth/config precedence, and
 // provider output handling for video attachments.
 import { describe, expect, it, vi } from "vitest";
+import {
+  formatAudioTranscripts,
+  formatMediaUnderstandingBody,
+} from "../../packages/media-understanding-common/src/format.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import { withEnvAsync } from "../test-utils/env.js";
@@ -464,4 +468,124 @@ describe("runCapability video provider wiring", () => {
     expect(firstCall?.provider).toBe("openai");
     expect(firstCall?.modelApi).toBeUndefined();
   });
+});
+
+describe("runCapability provider output decisions", () => {
+  const outputs = [
+    { label: "empty", text: "" },
+    { label: "whitespace", text: " \t\n" },
+    { label: "usable", text: "  usable primary output  " },
+  ] as const;
+  const cases = (["audio", "video", "image"] as const).flatMap((capability) =>
+    outputs.flatMap((output) =>
+      (output.text.trim() ? [true] : [true, false]).map((configureFallback) => ({
+        capability,
+        configureFallback,
+        ...output,
+      })),
+    ),
+  );
+
+  it.each(cases)(
+    "handles $label $capability provider output with fallback=$configureFallback",
+    async ({ capability, configureFallback, text }) => {
+      const extension = capability === "image" ? "png" : capability === "video" ? "mp4" : "wav";
+      const mime = `${capability}/${extension}`;
+      const buffer =
+        capability === "image"
+          ? Buffer.from(
+              "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8Xw8AAuMBg4n8tLwAAAAASUVORK5CYII=",
+              "base64",
+            )
+          : Buffer.alloc(2048, 1);
+      const primary = vi.fn(async () => ({ text, model: "primary-model" }));
+      const fallback = vi.fn(async () => ({
+        text: "usable fallback output",
+        model: "fallback-model",
+      }));
+      const createProvider = (
+        id: string,
+        run: () => Promise<{ text: string; model: string }>,
+      ): MediaUnderstandingProvider => ({
+        id,
+        capabilities: [capability],
+        ...(capability === "audio"
+          ? { transcribeAudio: run }
+          : capability === "video"
+            ? { describeVideo: run }
+            : { describeImage: run }),
+      });
+      const providerIds = ["qa-primary", ...(configureFallback ? ["qa-fallback"] : [])];
+      const cfg = {
+        models: {
+          providers: Object.fromEntries(
+            providerIds.map((provider) => [provider, { apiKey: "test-key", models: [] }]),
+          ),
+        },
+        tools: {
+          media: {
+            models: providerIds.map((provider) => ({
+              provider,
+              model: provider === "qa-primary" ? "primary-model" : "fallback-model",
+              capabilities: [capability],
+            })),
+            [capability]: { enabled: true },
+          },
+        },
+      } as unknown as OpenClawConfig;
+
+      const result = await runCapability({
+        capability,
+        cfg,
+        ctx: { Body: "" },
+        attachments: {
+          getBuffer: async () => ({
+            buffer,
+            mime,
+            fileName: `fixture.${extension}`,
+            size: buffer.length,
+          }),
+        } as Parameters<typeof runCapability>[0]["attachments"],
+        media: [{ index: 0, kind: capability, mime }],
+        agentDir: "/tmp/openclaw-media-provider-output-test",
+        providerRegistry: new Map<string, MediaUnderstandingProvider>([
+          ["qa-primary", createProvider("qa-primary", primary)],
+          ["qa-fallback", createProvider("qa-fallback", fallback)],
+        ]),
+      });
+
+      const usablePrimary = text.trim();
+      const expectedText = usablePrimary || (configureFallback ? "usable fallback output" : "");
+      const expectedFallbackCalls = !usablePrimary && configureFallback ? 1 : 0;
+      expect(primary).toHaveBeenCalledOnce();
+      expect(fallback).toHaveBeenCalledTimes(expectedFallbackCalls);
+      expect(result.outputs.map((output) => output.text)).toEqual(
+        expectedText ? [expectedText] : [],
+      );
+      expect(result.decision.outcome).toBe(expectedText ? "success" : "skipped");
+
+      const attempts = result.decision.attachments[0]?.attempts.map(
+        ({ provider, outcome, reason }) => ({
+          provider,
+          outcome,
+          ...(reason ? { reason } : {}),
+        }),
+      );
+      expect(attempts).toEqual([
+        usablePrimary
+          ? { provider: "qa-primary", outcome: "success" }
+          : { provider: "qa-primary", outcome: "skipped", reason: "empty output" },
+        ...(expectedFallbackCalls ? [{ provider: "qa-fallback", outcome: "success" }] : []),
+      ]);
+
+      if (capability === "audio") {
+        expect(formatMediaUnderstandingBody({ outputs: result.outputs })).toBe(
+          expectedText ? `[Audio]\nTranscript:\n${expectedText}` : "",
+        );
+        if (expectedText) {
+          expect(formatAudioTranscripts(result.outputs)).toBe(expectedText);
+        }
+      }
+    },
+  );
 });

--- a/src/media-understanding/runner.video.test.ts
+++ b/src/media-understanding/runner.video.test.ts
@@ -545,7 +545,7 @@ describe("runCapability provider output decisions", () => {
             fileName: `fixture.${extension}`,
             size: buffer.length,
           }),
-        } as Parameters<typeof runCapability>[0]["attachments"],
+        } as unknown as Parameters<typeof runCapability>[0]["attachments"],
         media: [{ index: 0, kind: capability, mime }],
         agentDir: "/tmp/openclaw-media-provider-output-test",
         providerRegistry: new Map<string, MediaUnderstandingProvider>([


### PR DESCRIPTION
## Summary

- Treat empty or whitespace-only audio transcription, video description, and image description provider output as the existing `empty output` skip outcome.
- Continue to the operator's already-configured fallback provider instead of incorrectly reporting success and silently dropping the media result.
- Preserve all legitimate nonempty results, actual public audio transcript/body formatting, provider failure handling, and the existing single canonical normalization boundary.

## Root cause and owner

All three provider paths already trim their returned text in `src/media-understanding/runner.entries.ts`; however, the shared `runAttachmentEntries` arbiter accepted any truthy result object, including `{ text: "" }`, as success. That suppressed configured fallback providers and could leave an operator-visible audio transcript/body empty while reporting a successful capability decision. The canonical one-token owner repair is `if (result?.text)`, reusing text that was already normalized; CLI-backed entries already reject empty output.

Direct dependency contract inspected: installed `openai@6.49.0` transcription responses promise only `text: string`, not nonempty content, and the real SDK passes JSON strings through unchanged. A real installed SDK request using an in-memory synthetic fetch returned whitespace and reproduced the actual provider → runtime → empty-transcript failure without external network.

## Proof

- Before fix: **12 failing regression combinations** across audio/video/image × empty/whitespace × configured fallback/no fallback; 10 existing/nonempty controls passed.
- After fix: `node scripts/run-vitest.mjs src/media-understanding/runner.video.test.ts src/media-understanding/runner.auto-audio.test.ts src/media-understanding/runner.cli-audio.test.ts` → **66/66 passed**.
- Actual installed OpenAI SDK plus fake HTTP response: blank transcription now records `empty output`, invokes the configured recovery provider exactly once, and produces the expected visible transcript.
- Tests assert successful fallback, no-fallback skipped state, existing decision/attempt diagnostics, usable padded text, and actual public audio body/transcript formatters.
- Direct formatting and `git diff --check` passed; production LOC delta **0** (+1/-1), tests +124.
- One independent structured Sol/high review and complete owner/dependency inspection found **zero accepted findings**. Its single automated warning claimed whitespace might reach the arbiter; this was explicitly rejected with direct source proof: `trimOutput` calls `text.trim()` and every image/audio/video producer calls it before the arbiter, with all whitespace regression cases passing. Adding another trim would duplicate the existing canonical producer normalization.

No credentials, external provider calls, config changes, new fallback paths, or dependency changes.