### PR TITLE
fix(slack): scope interactive conversation bindings safely

### DIFF
--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -862,6 +862,12 @@ describe("slackPlugin messaging targets", () => {
     expect(messaging?.resolveDeliveryTarget?.({ conversationId: "c08gqh53ejm" })).toEqual({
       to: "channel:c08gqh53ejm",
     });
+    expect(messaging?.resolveDeliveryTarget?.({ conversationId: "G08GQH53EJM" })).toEqual({
+      to: "channel:g08gqh53ejm",
+    });
+    expect(messaging?.resolveDeliveryTarget?.({ conversationId: "user:U08GQH53EJM" })).toEqual({
+      to: "user:u08gqh53ejm",
+    });
     expect(
       messaging?.resolveDeliveryTarget?.({
         conversationId: "1712345678.123456",
@@ -870,6 +876,24 @@ describe("slackPlugin messaging targets", () => {
     ).toEqual({
       to: "channel:c08gqh53ejm",
       threadId: "1712345678.123456",
+    });
+    expect(
+      messaging?.resolveDeliveryTarget?.({
+        conversationId: "1712345678.654321",
+        parentConversationId: "user:U08GQH53EJM",
+      }),
+    ).toEqual({
+      to: "user:u08gqh53ejm",
+      threadId: "1712345678.654321",
+    });
+    expect(
+      messaging?.resolveDeliveryTarget?.({
+        conversationId: "1712345678.777777",
+        parentConversationId: "G08GQH53EJM",
+      }),
+    ).toEqual({
+      to: "channel:g08gqh53ejm",
+      threadId: "1712345678.777777",
     });
     expect(messaging?.resolveSessionTarget?.({ kind: "channel", id: "C08GQH53EJM" })).toBe(
       "channel:c08gqh53ejm",

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -664,8 +664,8 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount, SlackProbe> = crea
         const parent = parentConversationId?.trim();
         const child = conversationId.trim();
         return parent && parent !== child
-          ? { to: normalizeSlackMessagingTarget(`channel:${parent}`), threadId: child }
-          : { to: normalizeSlackMessagingTarget(`channel:${child}`) };
+          ? { to: normalizeSlackMessagingTarget(parent), threadId: child }
+          : { to: normalizeSlackMessagingTarget(child) };
       },
       resolveSessionTarget: ({ id }) => {
         // Session identities stay folded; send.ts restores unambiguous IDs at the API boundary.

--- a/extensions/slack/src/interactive-dispatch.ts
+++ b/extensions/slack/src/interactive-dispatch.ts
@@ -103,10 +103,20 @@ type SlackInteractiveDispatchContext = Omit<
 export async function dispatchSlackPluginInteractiveHandler(params: {
   data: string;
   interactionId: string;
+  channelType?: "im" | "mpim" | "channel" | "group";
   ctx: SlackInteractiveDispatchContext;
   respond: SlackInteractiveHandlerContext["respond"];
   onMatched?: () => Promise<void> | void;
 }) {
+  const senderId = params.ctx.senderId?.trim();
+  const baseConversationId =
+    params.channelType === "im"
+      ? senderId
+        ? `user:${senderId}`
+        : ""
+      : params.ctx.conversationId.trim();
+  const threadId = params.ctx.threadId?.trim() || undefined;
+
   return await dispatchPluginInteractiveHandler<SlackInteractiveHandlerRegistration>({
     channel: "slack",
     data: params.data,
@@ -124,14 +134,20 @@ export async function dispatchSlackPluginInteractiveHandler(params: {
         },
         respond: params.respond,
         ...createInteractiveConversationBindingHelpers({
-          registration,
+          // The shared helpers fail closed without owner authority; never expose it to unauthenticated actions.
+          registration:
+            params.ctx.auth.isAuthorizedSender === true && baseConversationId
+              ? registration
+              : { ...registration, pluginRoot: undefined },
           senderId: params.ctx.senderId,
           conversation: {
             channel: "slack",
             accountId: params.ctx.accountId,
-            conversationId: params.ctx.conversationId,
-            parentConversationId: params.ctx.parentConversationId,
-            threadId: params.ctx.threadId,
+            conversationId: threadId ?? baseConversationId,
+            parentConversationId: threadId
+              ? (params.ctx.parentConversationId ?? baseConversationId)
+              : params.ctx.parentConversationId,
+            threadId,
           },
         }),
       }),

--- a/extensions/slack/src/interactive-dispatch.ts
+++ b/extensions/slack/src/interactive-dispatch.ts
@@ -136,7 +136,7 @@ export async function dispatchSlackPluginInteractiveHandler(params: {
         ...createInteractiveConversationBindingHelpers({
           // The shared helpers fail closed without owner authority; never expose it to unauthenticated actions.
           registration:
-            params.ctx.auth.isAuthorizedSender === true && baseConversationId
+            params.ctx.auth.isAuthorizedSender && baseConversationId
               ? registration
               : { ...registration, pluginRoot: undefined },
           senderId: params.ctx.senderId,

--- a/extensions/slack/src/monitor/events/interactions.block-actions.ts
+++ b/extensions/slack/src/monitor/events/interactions.block-actions.ts
@@ -770,6 +770,7 @@ async function dispatchSlackPluginInteraction(params: {
   parsed: ParsedSlackBlockAction;
   pluginInteractionData: string;
   auth: { isAuthorizedSender: boolean };
+  channelType?: Parameters<typeof dispatchSlackPluginInteractiveHandler>[0]["channelType"];
   respond?: SlackBlockActionRespond;
 }): Promise<boolean> {
   const pluginInteractionId = buildSlackPluginInteractionId({
@@ -793,6 +794,7 @@ async function dispatchSlackPluginInteraction(params: {
   const pluginResult = await dispatchSlackPluginInteractiveHandler({
     data: params.pluginInteractionData,
     interactionId: pluginInteractionId,
+    channelType: params.channelType,
     ctx: {
       accountId: params.ctx.accountId,
       interactionId: pluginInteractionId,
@@ -1138,6 +1140,7 @@ async function handleSlackBlockAction(params: {
       auth: {
         isAuthorizedSender,
       },
+      channelType: auth.channelType,
       respond,
     });
     if (handled) {

--- a/extensions/slack/src/monitor/events/interactions.modal.ts
+++ b/extensions/slack/src/monitor/events/interactions.modal.ts
@@ -222,6 +222,7 @@ async function dispatchSlackModalPluginInteractiveHandler(params: {
   interactionType: SlackModalInteractionKind;
   data: string | undefined;
   auth: { isAuthorizedSender: boolean };
+  channelType?: Parameters<typeof dispatchSlackPluginInteractiveHandler>[0]["channelType"];
   payload: SlackModalEventBase["payload"];
   stateValues?: unknown;
   sessionRouting: SlackModalEventBase["sessionRouting"];
@@ -248,6 +249,7 @@ async function dispatchSlackModalPluginInteractiveHandler(params: {
   const result = await dispatchSlackPluginInteractiveHandler({
     data: params.data,
     interactionId,
+    channelType: params.channelType,
     ctx: {
       accountId: params.ctx.accountId,
       interactionId,
@@ -377,6 +379,7 @@ async function emitSlackModalLifecycleEvent(params: {
       interactionType: params.interactionType,
       data: pluginInteractiveData,
       auth: { isAuthorizedSender: auth.allowed },
+      channelType: auth.channelType,
       payload,
       stateValues,
       sessionRouting,

--- a/extensions/slack/src/monitor/events/interactions.test.ts
+++ b/extensions/slack/src/monitor/events/interactions.test.ts
@@ -17,6 +17,35 @@ const dispatchPluginInteractiveHandlerMock = vi.hoisted(() =>
     duplicate: false,
   })),
 );
+const privilegedInteractiveBindingOperationMock = vi.hoisted(() =>
+  vi.fn((operation: "request" | "detach" | "get", conversation: Record<string, unknown>) => {
+    if (operation === "request") {
+      return { status: "bound" as const, binding: conversation };
+    }
+    return operation === "detach" ? { removed: true } : conversation;
+  }),
+);
+const createInteractiveConversationBindingHelpersMock = vi.hoisted(() =>
+  vi.fn(
+    (params: { registration: { pluginRoot?: string }; conversation: Record<string, unknown> }) => ({
+      requestConversationBinding: async () =>
+        params.registration.pluginRoot
+          ? privilegedInteractiveBindingOperationMock("request", params.conversation)
+          : {
+              status: "error" as const,
+              message: "This interaction cannot bind the current conversation.",
+            },
+      detachConversationBinding: async () =>
+        params.registration.pluginRoot
+          ? privilegedInteractiveBindingOperationMock("detach", params.conversation)
+          : { removed: false },
+      getCurrentConversationBinding: async () =>
+        params.registration.pluginRoot
+          ? privilegedInteractiveBindingOperationMock("get", params.conversation)
+          : null,
+    }),
+  ),
+);
 const resolvePluginConversationBindingApprovalMock = vi.hoisted(() => vi.fn());
 const buildPluginBindingResolvedTextMock = vi.hoisted(() => vi.fn(() => "Binding updated."));
 type ApprovalResolveMockResult = {
@@ -68,43 +97,12 @@ vi.mock("openclaw/plugin-sdk/question-gateway-runtime", () => ({
   },
 }));
 
-vi.mock("../../interactive-dispatch.js", () => ({
-  dispatchSlackPluginInteractiveHandler: (params: {
-    data: string;
-    interactionId: string;
-    ctx: {
-      interaction?: Record<string, unknown>;
-    } & Record<string, unknown>;
-    respond: unknown;
-  }) =>
-    (dispatchPluginInteractiveHandlerMock as (arg: unknown) => Promise<unknown>)({
-      channel: "slack",
-      data: params.data,
-      dedupeId: params.interactionId,
-      invoke: async ({
-        registration,
-        namespace,
-        payload,
-      }: {
-        registration: { handler: (ctx: unknown) => unknown };
-        namespace: string;
-        payload: string;
-      }) =>
-        registration.handler({
-          ...params.ctx,
-          channel: "slack",
-          interaction: {
-            ...params.ctx.interaction,
-            data: params.data,
-            namespace,
-            payload,
-          },
-          respond: params.respond,
-          requestConversationBinding: vi.fn(),
-          detachConversationBinding: vi.fn(),
-          getCurrentConversationBinding: vi.fn(),
-        }),
-    }),
+vi.mock("openclaw/plugin-sdk/plugin-runtime", () => ({
+  dispatchPluginInteractiveHandler: (arg: unknown) => dispatchPluginInteractiveHandlerMock(arg),
+  createInteractiveConversationBindingHelpers: (params: {
+    registration: { pluginRoot?: string };
+    conversation: Record<string, unknown>;
+  }) => createInteractiveConversationBindingHelpersMock(params),
 }));
 
 vi.mock("../conversation.runtime.js", () => {
@@ -372,6 +370,50 @@ function expectRecordFields(
   }
 }
 
+async function invokeSlackPluginBindingHandler(
+  dispatchCall: unknown,
+  params: { namespace?: string; payload?: string } = {},
+) {
+  const invoke = requireRecord(dispatchCall, "plugin interactive dispatch").invoke;
+  if (typeof invoke !== "function") {
+    throw new Error("Expected plugin interactive handler invocation");
+  }
+
+  let context: Record<string, unknown> | undefined;
+  let operations: { request: unknown; current: unknown; detach: unknown } | undefined;
+  await invoke({
+    registration: {
+      pluginId: "qa-interactive-plugin",
+      pluginRoot: "/plugins/qa-interactive-plugin",
+      handler: async (value: unknown) => {
+        context = requireRecord(value, "plugin interactive handler context");
+        const request = context.requestConversationBinding;
+        const current = context.getCurrentConversationBinding;
+        const detach = context.detachConversationBinding;
+        if (
+          typeof request !== "function" ||
+          typeof current !== "function" ||
+          typeof detach !== "function"
+        ) {
+          throw new Error("Expected plugin conversation binding helpers");
+        }
+        operations = {
+          request: await request({ summary: "Bind this conversation" }),
+          current: await current(),
+          detach: await detach(),
+        };
+      },
+    },
+    namespace: params.namespace ?? "qa",
+    payload: params.payload ?? "bind",
+  });
+
+  if (!context || !operations) {
+    throw new Error("Expected plugin interactive handler to complete");
+  }
+  return { context, ...operations };
+}
+
 function slackInteractionPayload(callIndex = 0): Record<string, unknown> {
   const eventText = mockCallArg(enqueueSystemEventMock, callIndex, "enqueueSystemEvent");
   if (typeof eventText !== "string") {
@@ -416,6 +458,8 @@ describe("registerSlackInteractionEvents", () => {
     enqueueSystemEventMock.mockReturnValue(true);
     requestHeartbeatMock.mockClear();
     dispatchPluginInteractiveHandlerMock.mockClear();
+    createInteractiveConversationBindingHelpersMock.mockClear();
+    privilegedInteractiveBindingOperationMock.mockClear();
     resolvePluginConversationBindingApprovalMock.mockClear();
     resolvePluginConversationBindingApprovalMock.mockResolvedValue({ status: "expired" });
     buildPluginBindingResolvedTextMock.mockClear();
@@ -825,6 +869,98 @@ describe("registerSlackInteractionEvents", () => {
     expect(app.client.chat.update).not.toHaveBeenCalled();
   });
 
+  it.each([
+    {
+      name: "channel root",
+      channelId: "C123",
+      channelType: "channel" as const,
+      conversationId: "C123",
+    },
+    {
+      name: "channel thread",
+      channelId: "C123",
+      channelType: "channel" as const,
+      threadId: "100.100",
+      conversationId: "100.100",
+      parentConversationId: "C123",
+    },
+    {
+      name: "private channel root",
+      channelId: "G123",
+      channelType: "group" as const,
+      conversationId: "G123",
+    },
+    {
+      name: "group direct-message root",
+      channelId: "G456",
+      channelType: "mpim" as const,
+      conversationId: "G456",
+    },
+    {
+      name: "direct-message root",
+      channelId: "D123",
+      channelType: "im" as const,
+      conversationId: "user:U_BINDER",
+    },
+    {
+      name: "direct-message thread",
+      channelId: "D123",
+      channelType: "im" as const,
+      threadId: "200.200",
+      conversationId: "200.200",
+      parentConversationId: "user:U_BINDER",
+    },
+  ])(
+    "binds the canonical $name conversation without changing public action context",
+    async (testCase) => {
+      dispatchPluginInteractiveHandlerMock.mockResolvedValueOnce({
+        matched: true,
+        handled: true,
+        duplicate: false,
+      });
+      const { ctx, getHandler } = createContext({
+        allowFrom: ["U_BINDER"],
+        resolveChannelName: async () => ({ type: testCase.channelType }),
+      });
+      registerSlackInteractionEvents({ ctx: ctx as never });
+
+      await getHandler()({
+        ack: vi.fn().mockResolvedValue(undefined),
+        body: {
+          user: { id: "U_BINDER" },
+          channel: { id: testCase.channelId },
+          container: {
+            channel_id: testCase.channelId,
+            message_ts: "300.300",
+            thread_ts: testCase.threadId,
+          },
+          message: { ts: "300.300" },
+        },
+        action: { type: "button", action_id: "qa", value: "bind" },
+      });
+
+      const { context, request, current, detach } = await invokeSlackPluginBindingHandler(
+        mockCallArg(dispatchPluginInteractiveHandlerMock, 0, "plugin interactive dispatcher"),
+      );
+      const expectedConversation = {
+        channel: "slack",
+        accountId: "default",
+        conversationId: testCase.conversationId,
+        parentConversationId: testCase.parentConversationId,
+        threadId: testCase.threadId,
+      };
+
+      expect(context.conversationId).toBe(testCase.channelId);
+      expect(context.parentConversationId).toBeUndefined();
+      expect(context.threadId).toBe(testCase.threadId);
+      expect(requireRecord(context.auth, "registration auth").isAuthorizedSender).toBe(true);
+      expect(request).toEqual({ status: "bound", binding: expectedConversation });
+      expect(current).toEqual(expectedConversation);
+      expect(detach).toEqual({ removed: true });
+      expect(privilegedInteractiveBindingOperationMock).toHaveBeenCalledTimes(3);
+    },
+  );
+
   it("passes false command auth to Slack plugin interactions for non-allowlisted senders", async () => {
     dispatchPluginInteractiveHandlerMock.mockResolvedValueOnce({
       matched: true,
@@ -896,6 +1032,16 @@ describe("registerSlackInteractionEvents", () => {
       "registration handler ctx",
     );
     expect(requireRecord(registrationCtx.auth, "registration auth").isAuthorizedSender).toBe(false);
+
+    const denied = await invokeSlackPluginBindingHandler(dispatchCall, {
+      namespace: "codex",
+      payload: "approve:thread-1",
+    });
+    expect(denied.context.conversationId).toBe("C1");
+    expect(denied.request).toMatchObject({ status: "error" });
+    expect(denied.current).toBeNull();
+    expect(denied.detach).toEqual({ removed: false });
+    expect(privilegedInteractiveBindingOperationMock).not.toHaveBeenCalled();
   });
 
   it("passes true command auth to Slack plugin interactions for allowlisted senders", async () => {
@@ -3263,6 +3409,22 @@ describe("registerSlackInteractionEvents", () => {
       senderId: "U777",
     });
     expect(requireRecord(registrationCtx.auth, "registration auth").isAuthorizedSender).toBe(true);
+
+    const binding = await invokeSlackPluginBindingHandler(dispatchCall, {
+      namespace: "dean.contract",
+      payload: "confirm_hearing",
+    });
+    expect(binding.context.conversationId).toBe("D777");
+    expect(binding.request).toEqual({
+      status: "bound",
+      binding: {
+        channel: "slack",
+        accountId: "default",
+        conversationId: "user:U777",
+        parentConversationId: undefined,
+        threadId: undefined,
+      },
+    });
     const interaction = requireRecord(registrationCtx.interaction, "registration interaction") as {
       inputs?: unknown[];
       stateValues?: unknown;
@@ -3367,6 +3529,16 @@ describe("registerSlackInteractionEvents", () => {
       "registration handler ctx",
     );
     expect(requireRecord(registrationCtx.auth, "registration auth").isAuthorizedSender).toBe(false);
+
+    const denied = await invokeSlackPluginBindingHandler(dispatchCall, {
+      namespace: "dean.contract",
+      payload: "confirm_hearing",
+    });
+    expect(denied.context.conversationId).toBe("");
+    expect(denied.request).toMatchObject({ status: "error" });
+    expect(denied.current).toBeNull();
+    expect(denied.detach).toEqual({ removed: false });
+    expect(privilegedInteractiveBindingOperationMock).not.toHaveBeenCalled();
     expectRecordFields(requireRecord(registrationCtx.interaction, "registration interaction"), {
       kind: "view_submission",
       data: "dean.contract:confirm_hearing",
@@ -3476,6 +3648,11 @@ describe("registerSlackInteractionEvents", () => {
 
   it("keeps no-channel modal events open when allowFrom is unset", async () => {
     enqueueSystemEventMock.mockClear();
+    dispatchPluginInteractiveHandlerMock.mockResolvedValueOnce({
+      matched: true,
+      handled: true,
+      duplicate: false,
+    });
     const { ctx, getViewHandler } = createContext({ allowFrom: [] });
     registerSlackInteractionEvents({ ctx: ctx as never });
     const viewHandler = getViewHandler();
@@ -3510,6 +3687,16 @@ describe("registerSlackInteractionEvents", () => {
     );
     expect(deliveryContext).not.toHaveProperty("to");
     expect(requestHeartbeatMock).toHaveBeenCalledOnce();
+
+    const denied = await invokeSlackPluginBindingHandler(
+      mockCallArg(dispatchPluginInteractiveHandlerMock, 0, "plugin interactive dispatcher"),
+    );
+    expect(requireRecord(denied.context.auth, "registration auth").isAuthorizedSender).toBe(true);
+    expect(denied.context.conversationId).toBe("");
+    expect(denied.request).toMatchObject({ status: "error" });
+    expect(denied.current).toBeNull();
+    expect(denied.detach).toEqual({ removed: false });
+    expect(privilegedInteractiveBindingOperationMock).not.toHaveBeenCalled();
   });
 
   it("captures modal input labels and picker values across block types", async () => {


### PR DESCRIPTION
## Summary

- Bind Slack button/select/modal interactions to the same exact channel-thread or `user:<sender>` DM identity used by normal authenticated Slack inbound routing.
- Preserve correct end-to-end delivery targets for channel threads, direct messages, and threaded direct messages.
- Fail closed for all privileged conversation-binding request/lookup/detach helpers when the sender is unauthorized, the direct-message actor is missing, or no trustworthy conversation exists; still invoke the public plugin handler with its unchanged context.

## Root cause and security impact

Slack interactive producers supplied transport channel IDs plus a separate `threadId` to the shared plugin helper, but the generic binding owner discards thread identity unless a channel supplies a resolver. Slack did not supply one. An authenticated action from one thread therefore claimed the entire channel, causing cross-thread capture/privacy failures; DM and modal actions claimed a transport `D…` channel instead of canonical `user:<sender>`, so normal inbound messages missed the binding. Its delivery owner also forcibly prepended `channel:` to valid DM identities.

Separately, Slack passed callbacks with `auth.isAuthorizedSender=false` into plugin handlers while handing them privileged binding helpers. The generic binding owner can refresh existing bindings or bind immediately under persistent account approval, so an unauthorized callback could actually mutate/read/detach conversation state. The fix preserves handler invocation and its existing public transport context, canonicalizes only the private Slack-owned helper tuple, and withholds plugin ownership metadata so the existing generic helpers return their established fail-closed result shapes. No generic core/SDK/public API, config, schema, or other-channel changes.

Canonical private identities now follow the already-shipped Slack inbound owner:

- channel root: channel ID;
- channel/MPIM thread: thread timestamp + parent channel ID;
- DM root: `user:<authenticated sender>`;
- DM thread: thread timestamp + `user:<authenticated sender>` parent.

The existing target normalizer now receives the actual channel/user identity instead of an unconditionally prefixed `channel:` identity.

## Proof

- Original real-production zero-network reproduction: thread action captured the entire channel, DM actions bound raw `D…` transport IDs, and an unauthorized callback actually mutated the real generic binding owner/in-memory adapter.
- `node scripts/run-vitest.mjs extensions/slack/src/monitor/events/interactions.test.ts extensions/slack/src/channel.test.ts` → **134/134 passed**.
- Actual production registry → real Slack dispatcher → real shared binding helpers/core → in-memory session-binding adapter → real Slack delivery owner: **13/13 passed**, including channel root/thread, nested parent, MPIM, DM root/thread/modal, secondary account, unauthorized sender, missing conversation, and missing DM actor.
- Denied callbacks performed **zero privileged adapter reads/writes** while the public plugin handler still executed.
- Directly inspected installed `@slack/bolt@5.0.0` / `@slack/types@3.0.0` interaction and modal contracts, canonical Slack inbound owner, generic binding owner, route projection, and outbound delivery.
- Six-file formatting and `git diff --check` passed; production **+22 LOC**, required to carry authenticated channel classification, canonicalize private tuples, and enforce an existing security boundary; tests +211.
- Fresh independent structured Sol/high security review: **clean, confidence 0.93**; secret scan clean.

No network calls, actual Slack tokens, provider credentials, account mutations, or database schema changes.