### PR TITLE
fix(delivery): renew stable producer leases

### DIFF
--- a/src/gateway/server-import-boundary.test.ts
+++ b/src/gateway/server-import-boundary.test.ts
@@ -154,12 +154,18 @@ describe("gateway startup import boundaries", () => {
     expect(serverImpl.slice(markHelperStart, markHelperEnd)).toContain(
       "cronReconciliation.invalidate();",
     );
+    expect(serverImpl.slice(markHelperStart, markHelperEnd)).toContain(
+      "void stopOutboundDeliveryRecoveryForClose();",
+    );
     expect(beginHelperStart).toBeGreaterThan(-1);
     expect(serverImpl.slice(beginHelperStart, beginHelperEnd)).toContain(
       "markClosePreludeStarted();",
     );
     expect(serverImpl.slice(beginHelperStart, beginHelperEnd)).toContain(
-      "await stopConfigReloaderForClose()",
+      "stopConfigReloaderForClose().catch",
+    );
+    expect(serverImpl.slice(beginHelperStart, beginHelperEnd)).toContain(
+      "stopOutboundDeliveryRecoveryForClose(),",
     );
     expect(postReadyStart).toBeGreaterThan(-1);
     expect(postReadyBlock).toContain("isClosing: () => lifecycle.closePreludeStarted");

--- a/src/gateway/server-lifecycle.ts
+++ b/src/gateway/server-lifecycle.ts
@@ -297,8 +297,16 @@ export async function prepareGatewayLifecycle(params: {
     clearTimeout(postReadyState.maintenanceTimer);
     postReadyState.maintenanceTimer = null;
   };
+  let outboundDeliveryRecoveryStopPromise: Promise<void> | null = null;
+  const stopOutboundDeliveryRecoveryForClose = () => {
+    outboundDeliveryRecoveryStopPromise ??= runtimeState.stopOutboundDeliveryRecovery();
+    return outboundDeliveryRecoveryStopPromise;
+  };
   const markClosePreludeStarted = () => {
     lifecycle.closePreludeStarted = true;
+    // Fence outbound recovery before any awaited close step can tear down the
+    // plugin/channel runtime it needs for reconciliation.
+    void stopOutboundDeliveryRecoveryForClose();
     runtimeState.controlUiSessionPullRequests?.stop();
     runtimeState.sessionViewerPresence?.stop();
     unsubscribeEffectiveOperatorPairing();
@@ -317,9 +325,12 @@ export async function prepareGatewayLifecycle(params: {
   const beginClosePrelude = async () => {
     clearSessionSuspensionTimers();
     markClosePreludeStarted();
-    // Join the last reload before any owner it can publish into is torn down.
-    // The close handler re-awaits this same promise to retain warning reporting.
-    await stopConfigReloaderForClose().catch(() => {});
+    // Both owners are fenced synchronously above. Join them before any runtime
+    // they can publish into is torn down.
+    await Promise.all([
+      stopOutboundDeliveryRecoveryForClose(),
+      stopConfigReloaderForClose().catch(() => {}),
+    ]);
   };
   const runClosePrelude = async () => {
     await beginClosePrelude();

--- a/src/gateway/server-runtime-handles.ts
+++ b/src/gateway/server-runtime-handles.ts
@@ -27,6 +27,7 @@ export type GatewayServerMutableState = {
   worktreeCleanup: ReturnType<typeof setInterval> | null;
   skillCuratorCleanup: () => void;
   heartbeatRunner: HeartbeatRunner;
+  stopOutboundDeliveryRecovery: () => Promise<void>;
   stopGatewayUpdateCheck: () => void;
   tailscaleCleanup: (() => Promise<void>) | null;
   postReadySidecars: GatewayPostReadySidecarHandle[];
@@ -65,6 +66,7 @@ export function createGatewayServerMutableState(): GatewayServerMutableState {
       stop: () => {},
       updateConfig: (_cfg: OpenClawConfig) => {},
     } satisfies HeartbeatRunner,
+    stopOutboundDeliveryRecovery: async () => {},
     stopGatewayUpdateCheck: () => {},
     tailscaleCleanup: null as (() => Promise<void>) | null,
     postReadySidecars: [],

--- a/src/gateway/server-runtime-services.test.ts
+++ b/src/gateway/server-runtime-services.test.ts
@@ -20,6 +20,8 @@ type StartSessionDeliveryRuntime =
   typeof import("../infra/session-delivery-queue-runtime.js").startSessionDeliveryRuntime;
 type DrainPendingDeliveries =
   typeof import("../infra/outbound/delivery-queue.js").drainPendingDeliveries;
+type RecoverPendingDeliveries =
+  typeof import("../infra/outbound/delivery-queue.js").recoverPendingDeliveries;
 
 const hoisted = vi.hoisted(() => {
   const heartbeatRunner = {
@@ -43,7 +45,7 @@ const hoisted = vi.hoisted(() => {
     ),
     schedulePendingSessionDeliveries: vi.fn(async () => undefined),
     startSessionUpstreamMonitor: vi.fn(() => ({ stop: stopSessionUpstreamMonitor })),
-    recoverPendingDeliveries: vi.fn(async () => ({
+    recoverPendingDeliveries: vi.fn<RecoverPendingDeliveries>(async () => ({
       recovered: 0,
       failed: 0,
       skippedMaxRetries: 0,
@@ -125,7 +127,13 @@ describe("server-runtime-services", () => {
     hoisted.stopSessionDeliveryRuntime.mockClear();
     hoisted.startSessionDeliveryRuntime.mockClear();
     hoisted.schedulePendingSessionDeliveries.mockClear();
-    hoisted.recoverPendingDeliveries.mockClear();
+    hoisted.recoverPendingDeliveries.mockReset();
+    hoisted.recoverPendingDeliveries.mockResolvedValue({
+      recovered: 0,
+      failed: 0,
+      skippedMaxRetries: 0,
+      deferredBackoff: 0,
+    });
     hoisted.drainPendingDeliveries.mockReset();
     hoisted.drainPendingDeliveries.mockResolvedValue(undefined);
     hoisted.recoverPendingRestartContinuationDeliveries.mockClear();
@@ -377,6 +385,73 @@ describe("server-runtime-services", () => {
       "recovered",
     );
     expect(hoisted.schedulePendingSessionDeliveries).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for an active outbound recovery before its stop handle settles", async () => {
+    vi.useFakeTimers();
+    let resolveDrain: (() => void) | undefined;
+    hoisted.drainPendingDeliveries.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveDrain = resolve;
+        }),
+    );
+
+    const { services } = activateScheduledServicesForTest();
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(hoisted.recoverPendingDeliveries).toHaveBeenCalledOnce();
+    expect(hoisted.drainPendingDeliveries).toHaveBeenCalledOnce();
+
+    let stopped = false;
+    const stopPromise = services.stopOutboundDeliveryRecovery().then(() => {
+      stopped = true;
+    });
+    await Promise.resolve();
+    expect(stopped).toBe(false);
+
+    if (!resolveDrain) {
+      throw new Error("Expected outbound retry drain resolver to be initialized");
+    }
+    resolveDrain();
+    await stopPromise;
+    expect(stopped).toBe(true);
+    services.heartbeatRunner.stop();
+  });
+
+  it("bounds outbound recovery shutdown handoff without rearming", async () => {
+    vi.useFakeTimers();
+    hoisted.drainPendingDeliveries.mockImplementationOnce(() => new Promise(() => {}));
+    const log = createLog();
+    const { services } = activateScheduledServicesForTest({ log });
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(hoisted.recoverPendingDeliveries).toHaveBeenCalledOnce();
+    expect(hoisted.drainPendingDeliveries).toHaveBeenCalledOnce();
+
+    let firstStopped = false;
+    let secondStopped = false;
+    const firstStop = services.stopOutboundDeliveryRecovery().then(() => {
+      firstStopped = true;
+    });
+    const secondStop = services.stopOutboundDeliveryRecovery().then(() => {
+      secondStopped = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(firstStopped).toBe(false);
+    expect(secondStopped).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    await Promise.all([firstStop, secondStop]);
+    expect(firstStopped).toBe(true);
+    expect(secondStopped).toBe(true);
+    expect(log.child.mock.results[0]?.value.warn).toHaveBeenCalledOnce();
+    expect(log.child.mock.results[0]?.value.warn).toHaveBeenCalledWith(
+      "delivery recovery shutdown handoff exceeded 5000ms; continuing shutdown",
+    );
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(hoisted.recoverPendingDeliveries).toHaveBeenCalledOnce();
+    expect(hoisted.drainPendingDeliveries).toHaveBeenCalledOnce();
+    services.heartbeatRunner.stop();
   });
 
   it("schedules pending session deliveries when startup recovery fails", async () => {
@@ -818,9 +893,10 @@ function activateScheduledServicesForTest(
   const cronState = createTestCronState(cron);
   const cronStart = cron.start;
   const log = overrides.log ?? createLog();
+  const cfgAtStart = overrides.cfgAtStart ?? ({} as never);
   const services = activateGatewayScheduledServices({
     minimalTestGateway: false,
-    cfgAtStart: {} as never,
+    cfgAtStart,
     deps: {} as never,
     sessionDeliveryRecoveryMaxEnqueuedAt: 123,
     cronReconciliation: createTestCronReconciliation(),

--- a/src/gateway/server-runtime-services.test.ts
+++ b/src/gateway/server-runtime-services.test.ts
@@ -387,7 +387,45 @@ describe("server-runtime-services", () => {
     expect(hoisted.schedulePendingSessionDeliveries).toHaveBeenCalledTimes(1);
   });
 
-  it("waits for an active outbound recovery before its stop handle settles", async () => {
+  it("waits for active startup recovery before its stop handle settles", async () => {
+    vi.useFakeTimers();
+    let resolveRecovery: (() => void) | undefined;
+    hoisted.recoverPendingDeliveries.mockImplementationOnce(async () => {
+      await new Promise<void>((resolve) => {
+        resolveRecovery = resolve;
+      });
+      return {
+        recovered: 0,
+        failed: 0,
+        skippedMaxRetries: 0,
+        deferredBackoff: 0,
+      };
+    });
+
+    const { services } = activateScheduledServicesForTest();
+    await vi.dynamicImportSettled();
+    expect(hoisted.recoverPendingDeliveries).toHaveBeenCalledOnce();
+    expect(hoisted.drainPendingDeliveries).not.toHaveBeenCalled();
+
+    let stopped = false;
+    const stopPromise = services.stopOutboundDeliveryRecovery().then(() => {
+      stopped = true;
+    });
+    await Promise.resolve();
+    expect(stopped).toBe(false);
+    expect(getActiveGatewayRootWorkCount()).toBe(1);
+
+    if (!resolveRecovery) {
+      throw new Error("Expected outbound startup recovery resolver to be initialized");
+    }
+    resolveRecovery();
+    await stopPromise;
+    expect(stopped).toBe(true);
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
+    services.heartbeatRunner.stop();
+  });
+
+  it("warns but holds shutdown until outbound recovery settles", async () => {
     vi.useFakeTimers();
     let resolveDrain: (() => void) | undefined;
     hoisted.drainPendingDeliveries.mockImplementationOnce(
@@ -396,31 +434,6 @@ describe("server-runtime-services", () => {
           resolveDrain = resolve;
         }),
     );
-
-    const { services } = activateScheduledServicesForTest();
-    await vi.advanceTimersByTimeAsync(5_000);
-    expect(hoisted.recoverPendingDeliveries).toHaveBeenCalledOnce();
-    expect(hoisted.drainPendingDeliveries).toHaveBeenCalledOnce();
-
-    let stopped = false;
-    const stopPromise = services.stopOutboundDeliveryRecovery().then(() => {
-      stopped = true;
-    });
-    await Promise.resolve();
-    expect(stopped).toBe(false);
-
-    if (!resolveDrain) {
-      throw new Error("Expected outbound retry drain resolver to be initialized");
-    }
-    resolveDrain();
-    await stopPromise;
-    expect(stopped).toBe(true);
-    services.heartbeatRunner.stop();
-  });
-
-  it("bounds outbound recovery shutdown handoff without rearming", async () => {
-    vi.useFakeTimers();
-    hoisted.drainPendingDeliveries.mockImplementationOnce(() => new Promise(() => {}));
     const log = createLog();
     const { services } = activateScheduledServicesForTest({ log });
     await vi.advanceTimersByTimeAsync(5_000);
@@ -436,21 +449,30 @@ describe("server-runtime-services", () => {
       secondStopped = true;
     });
 
-    await vi.advanceTimersByTimeAsync(4_999);
+    await vi.advanceTimersByTimeAsync(5_000);
     expect(firstStopped).toBe(false);
     expect(secondStopped).toBe(false);
-    await vi.advanceTimersByTimeAsync(1);
-    await Promise.all([firstStop, secondStop]);
-    expect(firstStopped).toBe(true);
-    expect(secondStopped).toBe(true);
+    expect(getActiveGatewayRootWorkCount()).toBe(1);
     expect(log.child.mock.results[0]?.value.warn).toHaveBeenCalledOnce();
     expect(log.child.mock.results[0]?.value.warn).toHaveBeenCalledWith(
-      "delivery recovery shutdown handoff exceeded 5000ms; continuing shutdown",
+      "delivery recovery is still pending after 5000ms; waiting before runtime teardown",
     );
 
     await vi.advanceTimersByTimeAsync(15_000);
     expect(hoisted.recoverPendingDeliveries).toHaveBeenCalledOnce();
     expect(hoisted.drainPendingDeliveries).toHaveBeenCalledOnce();
+    expect(firstStopped).toBe(false);
+    expect(secondStopped).toBe(false);
+    expect(log.child.mock.results[0]?.value.warn).toHaveBeenCalledOnce();
+
+    if (!resolveDrain) {
+      throw new Error("Expected outbound retry drain resolver to be initialized");
+    }
+    resolveDrain();
+    await Promise.all([firstStop, secondStop]);
+    expect(firstStopped).toBe(true);
+    expect(secondStopped).toBe(true);
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
     services.heartbeatRunner.stop();
   });
 

--- a/src/gateway/server-runtime-services.ts
+++ b/src/gateway/server-runtime-services.ts
@@ -182,20 +182,25 @@ export function scheduleGatewayPostReadyMaintenance(params: {
   return timer;
 }
 
-function recoverPendingOutboundDeliveries(params: {
+const RECOVERY_SHUTDOWN_HANDOFF_TIMEOUT_MS = 5_000;
+
+function startPendingOutboundDeliveryRecovery(params: {
   cfg: OpenClawConfig;
   log: GatewayRuntimeServiceLogger;
-}): () => void {
+}): () => Promise<void> {
   let stopped = false;
-  let recoveryInFlight = false;
+  let inFlight: Promise<void> | null = null;
+  let stopPromise: Promise<void> | null = null;
   let logRecovery: ReturnType<GatewayRuntimeServiceLogger["child"]> | undefined;
 
   const recover = (startup: boolean): void => {
-    if (stopped || recoveryInFlight || isGatewayWorkAdmissionClosed()) {
+    if (stopped || inFlight || isGatewayWorkAdmissionClosed()) {
       return;
     }
-    recoveryInFlight = true;
-    void runWithGatewayIndependentRootWorkAdmission(async () => {
+    const recovery = runWithGatewayIndependentRootWorkAdmission(async () => {
+      if (stopped) {
+        return;
+      }
       const { drainPendingDeliveries, recoverPendingDeliveries } =
         await import("../infra/outbound/delivery-queue.js");
       const { deliverOutboundPayloadsInternal } = await import("../infra/outbound/deliver.js");
@@ -221,11 +226,13 @@ function recoverPendingOutboundDeliveries(params: {
         deliver: deliverOutboundPayloadsInternal,
         selectEntry: () => ({ match: true, bypassBackoff: false }),
       });
-    })
-      .catch((err: unknown) => params.log.error(`Delivery recovery failed: ${String(err)}`))
-      .finally(() => {
-        recoveryInFlight = false;
-      });
+    }).catch((err: unknown) => params.log.error(`Delivery recovery failed: ${String(err)}`));
+    const settled: Promise<void> = recovery.finally(() => {
+      if (inFlight === settled) {
+        inFlight = null;
+      }
+    });
+    inFlight = settled;
   };
 
   // Match the queue's first backoff window without holding admission between
@@ -236,6 +243,34 @@ function recoverPendingOutboundDeliveries(params: {
   return () => {
     stopped = true;
     clearInterval(retryTimer);
+    if (stopPromise) {
+      return stopPromise;
+    }
+    const recovery = inFlight;
+    if (!recovery) {
+      stopPromise = Promise.resolve();
+      return stopPromise;
+    }
+    stopPromise = new Promise<void>((resolve) => {
+      let settled = false;
+      const finish = () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timeout);
+        resolve();
+      };
+      const timeout = setTimeout(() => {
+        (logRecovery ??= params.log.child("delivery-recovery")).warn(
+          `delivery recovery shutdown handoff exceeded ${RECOVERY_SHUTDOWN_HANDOFF_TIMEOUT_MS}ms; continuing shutdown`,
+        );
+        finish();
+      }, RECOVERY_SHUTDOWN_HANDOFF_TIMEOUT_MS);
+      timeout.unref?.();
+      void recovery.then(finish);
+    });
+    return stopPromise;
   };
 }
 
@@ -304,12 +339,13 @@ export function activateGatewayScheduledServices(params: {
   startCron?: boolean;
   logCron: { error: (message: string) => void };
   log: GatewayRuntimeServiceLogger;
-}): { heartbeatRunner: HeartbeatRunner } {
+}): { heartbeatRunner: HeartbeatRunner; stopOutboundDeliveryRecovery: () => Promise<void> } {
   if (params.minimalTestGateway) {
     // Minimal gateways keep handles callable but inert so tests can share shutdown paths with
     // production starts without launching background loops.
     return {
       heartbeatRunner: createNoopHeartbeatRunner(),
+      stopOutboundDeliveryRecovery: async () => {},
     };
   }
   if (
@@ -343,19 +379,21 @@ export function activateGatewayScheduledServices(params: {
       logCron: params.logCron,
     });
   }
-  const stopOutboundDeliveryRecovery = recoverPendingOutboundDeliveries({
+  const stopOutboundDeliveryRecovery = startPendingOutboundDeliveryRecovery({
     cfg: params.cfgAtStart,
     log: params.log,
   });
-  return {
-    heartbeatRunner: {
-      updateConfig: heartbeatRunner.updateConfig,
-      stop: () => {
-        stopOutboundDeliveryRecovery();
-        stopSessionDeliveryRuntime();
-        sessionUpstreamMonitor.stop();
-        heartbeatRunner.stop();
-      },
+  const heartbeatRunnerWithUpstreamMonitor: HeartbeatRunner = {
+    updateConfig: heartbeatRunner.updateConfig,
+    stop: () => {
+      void stopOutboundDeliveryRecovery();
+      stopSessionDeliveryRuntime();
+      sessionUpstreamMonitor.stop();
+      heartbeatRunner.stop();
     },
+  };
+  return {
+    heartbeatRunner: heartbeatRunnerWithUpstreamMonitor,
+    stopOutboundDeliveryRecovery,
   };
 }

--- a/src/gateway/server-runtime-services.ts
+++ b/src/gateway/server-runtime-services.ts
@@ -182,7 +182,7 @@ export function scheduleGatewayPostReadyMaintenance(params: {
   return timer;
 }
 
-const RECOVERY_SHUTDOWN_HANDOFF_TIMEOUT_MS = 5_000;
+const RECOVERY_SHUTDOWN_STILL_PENDING_WARN_MS = 5_000;
 
 function startPendingOutboundDeliveryRecovery(params: {
   cfg: OpenClawConfig;
@@ -251,24 +251,16 @@ function startPendingOutboundDeliveryRecovery(params: {
       stopPromise = Promise.resolve();
       return stopPromise;
     }
-    stopPromise = new Promise<void>((resolve) => {
-      let settled = false;
-      const finish = () => {
-        if (settled) {
-          return;
-        }
-        settled = true;
-        clearTimeout(timeout);
-        resolve();
-      };
-      const timeout = setTimeout(() => {
-        (logRecovery ??= params.log.child("delivery-recovery")).warn(
-          `delivery recovery shutdown handoff exceeded ${RECOVERY_SHUTDOWN_HANDOFF_TIMEOUT_MS}ms; continuing shutdown`,
-        );
-        finish();
-      }, RECOVERY_SHUTDOWN_HANDOFF_TIMEOUT_MS);
-      timeout.unref?.();
-      void recovery.then(finish);
+    const stillPendingTimer = setTimeout(() => {
+      (logRecovery ??= params.log.child("delivery-recovery")).warn(
+        `delivery recovery is still pending after ${RECOVERY_SHUTDOWN_STILL_PENDING_WARN_MS}ms; waiting before runtime teardown`,
+      );
+    }, RECOVERY_SHUTDOWN_STILL_PENDING_WARN_MS);
+    stillPendingTimer.unref?.();
+    // Provider dispatch is not generically cancellable. Keep its runtime alive
+    // until the admitted recovery settles; the process watchdog owns forced exit.
+    stopPromise = recovery.finally(() => {
+      clearTimeout(stillPendingTimer);
     });
     return stopPromise;
   };

--- a/src/gateway/server-startup-finish.ts
+++ b/src/gateway/server-startup-finish.ts
@@ -398,6 +398,7 @@ export async function finishGatewayStartup(params: {
         log,
       });
       runtimeState.heartbeatRunner = activated.heartbeatRunner;
+      runtimeState.stopOutboundDeliveryRecovery = activated.stopOutboundDeliveryRecovery;
     });
   };
   ({

--- a/src/infra/delivery-queue-sqlite-claim.ts
+++ b/src/infra/delivery-queue-sqlite-claim.ts
@@ -11,11 +11,12 @@ type PlatformClaimParams = {
   queueName: string;
   id: string;
   stateDir?: string;
+  requiresProducerClaim?: boolean;
   reconciledPlatformSendAttemptId?: string;
   reconciledPlatformSendStartedAt?: number;
 };
 
-const PLATFORM_SEND_OWNER_LEASE_MS = 30_000;
+export const PLATFORM_SEND_OWNER_LEASE_MS = 30_000;
 
 /** Runs an existing queue mutation only while its exact platform owner survives. */
 export function transitionOwnedDeliveryQueueEntry(
@@ -119,6 +120,7 @@ export function claimDeliveryQueueEntryPlatformSend(
     }
     return {
       ...entry,
+      ...(params.requiresProducerClaim === true ? { requiresProducerClaim: true } : {}),
       availableAt: now + PLATFORM_SEND_OWNER_LEASE_MS,
       producerClaimId: claimId,
       platformSendAttemptId: undefined,
@@ -128,6 +130,52 @@ export function claimDeliveryQueueEntryPlatformSend(
   })
     ? claimId
     : undefined;
+}
+
+/** Renew only the exact unexpired reusable producer that already owns the row. */
+export function renewDeliveryQueueEntryPlatformSendLease(
+  params: Pick<PlatformClaimParams, "queueName" | "id" | "stateDir"> & {
+    claimId: string;
+  },
+): number | undefined {
+  const database = openOpenClawStateDatabase({
+    env: params.stateDir ? { ...process.env, OPENCLAW_STATE_DIR: params.stateDir } : process.env,
+  });
+  return runSqliteImmediateTransactionSync(
+    database.db,
+    () => {
+      const entry = loadDeliveryQueueEntry(params.queueName, params.id, params.stateDir);
+      const now = Date.now();
+      const exactOwner =
+        entry?.recoveryState === "producer_claimed"
+          ? entry.producerClaimId === params.claimId
+          : (entry?.recoveryState === "send_attempt_started" ||
+              entry?.recoveryState === "unknown_after_send") &&
+            entry.platformSendAttemptId === params.claimId;
+      if (
+        !entry ||
+        entry.requiresProducerClaim !== true ||
+        !exactOwner ||
+        typeof entry.availableAt !== "number" ||
+        entry.availableAt <= now
+      ) {
+        return undefined;
+      }
+      const expiresAt = now + PLATFORM_SEND_OWNER_LEASE_MS;
+      return upsertDeliveryQueueEntry({
+        queueName: params.queueName,
+        entry: { ...entry, availableAt: expiresAt },
+        stateDir: params.stateDir,
+        updatePendingOnly: true,
+      })
+        ? expiresAt
+        : undefined;
+    },
+    {
+      databaseLabel: "openclaw-state",
+      operationLabel: `renew ${params.queueName} delivery platform send`,
+    },
+  );
 }
 
 /** Atomically fence the exact unexpired owner at the real provider boundary. */

--- a/src/infra/delivery-queue-sqlite.test.ts
+++ b/src/infra/delivery-queue-sqlite.test.ts
@@ -6,6 +6,7 @@ import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
 import {
   claimDeliveryQueueEntryPlatformSend,
   promoteDeliveryQueueEntryPlatformSend,
+  renewDeliveryQueueEntryPlatformSendLease,
 } from "./delivery-queue-sqlite-claim.js";
 import { commitStagedDeliveryQueueEntryOnceAcrossNamespaces } from "./delivery-queue-sqlite-namespace.js";
 import {
@@ -597,6 +598,35 @@ describe("delivery-queue-sqlite corrupt JSON resilience", () => {
       expect(loadDeliveryQueueEntry(QUEUE, id, stateDir)?.platformSendStartedAt).toBeUndefined();
     });
 
+    it("atomically upgrades a legacy live reuse claim to renewable ownership", () => {
+      const id = `${boundedCronRetention.idPrefix}upgrade-reusable-claim`;
+      upsertDeliveryQueueEntry({
+        queueName: QUEUE,
+        entry: {
+          id,
+          enqueuedAt: Date.now(),
+          retryCount: 0,
+          completionRetention: boundedCronRetention,
+        },
+        stateDir,
+      });
+
+      const claimId = claimDeliveryQueueEntryPlatformSend({
+        queueName: QUEUE,
+        id,
+        stateDir,
+        requiresProducerClaim: true,
+      });
+
+      expect(claimId).toEqual(expect.any(String));
+      expect(loadDeliveryQueueEntry(QUEUE, id, stateDir)).toMatchObject({
+        recoveryState: "producer_claimed",
+        producerClaimId: claimId,
+        requiresProducerClaim: true,
+        availableAt: expect.any(Number),
+      });
+    });
+
     it("recovers an expired pre-provider producer lease without claiming platform delivery", () => {
       vi.useFakeTimers();
       try {
@@ -669,6 +699,116 @@ describe("delivery-queue-sqlite corrupt JSON resilience", () => {
           platformSendStartedAt: expect.any(Number),
         });
         expect(loadDeliveryQueueEntry(QUEUE, id, stateDir)?.producerClaimId).toBeUndefined();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it.each(["producer_claimed", "send_attempt_started", "unknown_after_send"] as const)(
+      "renews the exact unexpired explicit owner in %s",
+      (recoveryState) => {
+        vi.useFakeTimers();
+        try {
+          vi.setSystemTime(new Date("2026-08-02T10:00:00.000Z"));
+          const id = `${boundedCronRetention.idPrefix}renew-${recoveryState}`;
+          const claimId = `claim-${recoveryState}`;
+          upsertDeliveryQueueEntry({
+            queueName: QUEUE,
+            entry: {
+              id,
+              enqueuedAt: Date.now(),
+              retryCount: 0,
+              requiresProducerClaim: true,
+              availableAt: Date.now() + 5_000,
+              ...(recoveryState === "producer_claimed"
+                ? { producerClaimId: claimId }
+                : {
+                    platformSendAttemptId: claimId,
+                    platformSendStartedAt: Date.now(),
+                  }),
+              recoveryState,
+            },
+            stateDir,
+          });
+          vi.setSystemTime(Date.now() + 1_000);
+
+          expect(
+            renewDeliveryQueueEntryPlatformSendLease({
+              queueName: QUEUE,
+              id,
+              claimId,
+              stateDir,
+            }),
+          ).toBe(Date.now() + 30_000);
+          expect(loadDeliveryQueueEntry(QUEUE, id, stateDir)).toMatchObject({
+            recoveryState,
+            availableAt: Date.now() + 30_000,
+            ...(recoveryState === "producer_claimed"
+              ? { producerClaimId: claimId }
+              : { platformSendAttemptId: claimId }),
+          });
+        } finally {
+          vi.useRealTimers();
+        }
+      },
+    );
+
+    it("refuses to renew expired, mismatched, and non-explicit owners", () => {
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(new Date("2026-08-02T10:00:00.000Z"));
+        const cases = [
+          {
+            id: `${boundedCronRetention.idPrefix}renew-expired`,
+            requiresProducerClaim: true,
+            producerClaimId: "expired-owner",
+            availableAt: Date.now(),
+            claimId: "expired-owner",
+          },
+          {
+            id: `${boundedCronRetention.idPrefix}renew-wrong-owner`,
+            requiresProducerClaim: true,
+            producerClaimId: "current-owner",
+            availableAt: Date.now() + 5_000,
+            claimId: "stale-owner",
+          },
+          {
+            id: `${boundedCronRetention.idPrefix}renew-legacy-owner`,
+            requiresProducerClaim: false,
+            producerClaimId: "legacy-owner",
+            availableAt: Date.now() + 5_000,
+            claimId: "legacy-owner",
+          },
+        ] as const;
+        for (const entry of cases) {
+          upsertDeliveryQueueEntry({
+            queueName: QUEUE,
+            entry: {
+              id: entry.id,
+              enqueuedAt: Date.now(),
+              retryCount: 0,
+              ...(entry.requiresProducerClaim
+                ? { requiresProducerClaim: entry.requiresProducerClaim }
+                : {}),
+              producerClaimId: entry.producerClaimId,
+              availableAt: entry.availableAt,
+              recoveryState: "producer_claimed",
+            },
+            stateDir,
+          });
+
+          expect(
+            renewDeliveryQueueEntryPlatformSendLease({
+              queueName: QUEUE,
+              id: entry.id,
+              claimId: entry.claimId,
+              stateDir,
+            }),
+          ).toBeUndefined();
+          expect(loadDeliveryQueueEntry(QUEUE, entry.id, stateDir)?.availableAt).toBe(
+            entry.availableAt,
+          );
+        }
       } finally {
         vi.useRealTimers();
       }

--- a/src/infra/outbound/deliver-contracts.ts
+++ b/src/infra/outbound/deliver-contracts.ts
@@ -212,6 +212,8 @@ export type DeliverOutboundPayloadsParams = DeliverOutboundPayloadsCoreParams & 
   skipQueue?: boolean;
   /** @internal Fence recovery ownership at the same provider boundary as live sends. */
   deliveryProducerClaimId?: string;
+  /** @internal Keep an explicitly reusable producer claim alive during platform preparation. */
+  deliveryProducerLeaseRequired?: boolean;
   /** @internal Recovery already ran provider admission after its pending-row re-read. */
   deferredDeliveryAdmissionPassed?: true;
   /** @internal State directory that owns the existing recovery queue entry. */

--- a/src/infra/outbound/deliver-queue-execute.ts
+++ b/src/infra/outbound/deliver-queue-execute.ts
@@ -51,7 +51,15 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
   queueId: string | null,
   auditStartedAt: number,
   producerClaimId?: string,
+  producerLeaseSignal?: AbortSignal,
 ): Promise<OutboundDeliveryResult[]> {
+  // Lease loss revokes queue mutation authority. Caller cancellation still
+  // follows the normal abort cleanup path through the combined signal.
+  const throwIfProducerLeaseLost = (): void => {
+    if (producerLeaseSignal?.aborted) {
+      throw producerLeaseSignal.reason;
+    }
+  };
   const payloadCount = params.preparedBatch?.sourcePayloadCount ?? params.payloads.length;
   // Wrap onError to detect partial failures under bestEffort mode.
   // When bestEffort is true, per-payload errors are caught and passed to onError
@@ -118,6 +126,7 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
       })
     : undefined;
   const ackOwnedQueue = (options?: { suppressCompletionReceipt?: boolean }) => {
+    throwIfProducerLeaseLost();
     if (!queueOwner) {
       throw new Error("Queued delivery acknowledgement requires a queue id");
     }
@@ -127,12 +136,14 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
     record: typeof failDelivery | typeof failDeliveryAfterPlatformSend,
     error: string,
   ) => {
+    throwIfProducerLeaseLost();
     if (!queueOwner) {
       throw new Error("Queued delivery failure requires a queue id");
     }
     return queueOwner.fail(record, error);
   };
   const persistOwnedPostSendState = () => {
+    throwIfProducerLeaseLost();
     if (!queueId) {
       throw new Error("Queued delivery post-send state requires a queue id");
     }
@@ -174,6 +185,7 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
       : { deliveryQueueId: undefined }),
     requiredUnknownSendReconciliation: exactReconciliationRequired,
     onPlatformSendStart: async (route) => {
+      params.abortSignal?.throwIfAborted();
       platformSendRoute = route;
       if (platformQueueId && !exactReconciliationRequired && queuedPreSendState === undefined) {
         queuedPreSendState = await persistQueuedPreSendState({
@@ -190,9 +202,12 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
           queuedPostSendState = "acked";
         }
       }
+      params.abortSignal?.throwIfAborted();
       await params.onPlatformSendStart?.(route);
+      params.abortSignal?.throwIfAborted();
     },
     onPlatformSendDispatch: async () => {
+      params.abortSignal?.throwIfAborted();
       if (platformQueueId && queuedPreSendState !== "acked") {
         try {
           if (producerClaimId) {
@@ -219,9 +234,12 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
           );
         }
       }
+      params.abortSignal?.throwIfAborted();
       await params.onPlatformSendDispatch?.();
+      params.abortSignal?.throwIfAborted();
     },
     onError: (err: unknown, payload: NormalizedOutboundPayload) => {
+      throwIfProducerLeaseLost();
       hadPartialFailure = true;
       lastPayloadError = err;
       partialFailuresAreProvenNotSent &&= isProvenDeliveryNotSentError(err);
@@ -251,9 +269,11 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
   let platformResultsReturned = false;
 
   try {
+    throwIfProducerLeaseLost();
     const results = await deliverOutboundPayloadsCore(wrappedParams);
     // Core reconciles adapter progress objects with hook-bearing final results.
     deliveredResults = results;
+    throwIfProducerLeaseLost();
     platformResultsReturned = true;
     if (
       queueId &&
@@ -421,6 +441,7 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
     }
     return results;
   } catch (err) {
+    throwIfProducerLeaseLost();
     if (err instanceof OutboundDeliveryError && err.results.length > 0) {
       deliveredResults = err.results;
     }

--- a/src/infra/outbound/deliver-queue.lease-integration.test.ts
+++ b/src/infra/outbound/deliver-queue.lease-integration.test.ts
@@ -1,0 +1,465 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { onTrustedMessageAuditEvent } from "../../audit/message-audit-events.js";
+import { createMessageReceiptFromOutboundResults } from "../../channels/message/receipt.js";
+import type { ChannelMessageSendTextContext } from "../../channels/message/types.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
+import { getDeliveryQueueEntryStatus } from "../delivery-queue-sqlite.js";
+import {
+  boundedCronCompletionRetention,
+  matrixOutboundForQueueTest,
+} from "./deliver.queue-integration.test-support.js";
+import { OUTBOUND_DELIVERY_QUEUE_NAME } from "./delivery-queue-media-staging.js";
+import { claimDeliveryPlatformSendAttempt } from "./delivery-queue-storage.js";
+import { enqueueDeliveryOnce } from "./delivery-queue.js";
+import {
+  installDeliveryQueueTmpDirHooks,
+  readQueuedEntry,
+  setQueuedEntryState,
+} from "./delivery-queue.test-helpers.js";
+
+let deliverOutboundPayloads: typeof import("./deliver.js").deliverOutboundPayloads;
+
+function createDeferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+async function startBlockedStableDelivery(params: {
+  tmpDir: string;
+  deliveryIntentId: string;
+  requiresProducerClaim: boolean;
+}) {
+  process.env.OPENCLAW_STATE_DIR = params.tmpDir;
+  const preparationEntered = createDeferred();
+  const releasePreparation = createDeferred();
+  const messageId = `${params.deliveryIntentId}-message`;
+  const sendText = vi.fn(async (ctx: ChannelMessageSendTextContext) => {
+    await ctx.onPlatformSendDispatch?.();
+    return {
+      messageId,
+      receipt: createMessageReceiptFromOutboundResults({
+        results: [{ channel: "matrix", messageId }],
+        kind: "text",
+      }),
+    };
+  });
+  setActivePluginRegistry(
+    createTestRegistry([
+      {
+        pluginId: "matrix",
+        source: "test",
+        plugin: {
+          ...createOutboundTestPlugin({ id: "matrix", outbound: matrixOutboundForQueueTest }),
+          message: {
+            id: "matrix",
+            durableFinal: { capabilities: { text: true } },
+            send: {
+              lifecycle: {
+                beforeSendAttempt: async () => {
+                  preparationEntered.resolve();
+                  await releasePreparation.promise;
+                },
+              },
+              text: sendText,
+            },
+          },
+        },
+      },
+    ]),
+  );
+  await enqueueDeliveryOnce(
+    {
+      channel: "matrix",
+      to: "!room:example",
+      payloads: [{ text: "queue-owned stable content" }],
+      queuePolicy: "required",
+      completionRetention: boundedCronCompletionRetention,
+      ...(params.requiresProducerClaim ? { requiresProducerClaim: true } : {}),
+    },
+    params.deliveryIntentId,
+    params.tmpDir,
+  );
+  const delivery = deliverOutboundPayloads({
+    cfg: {} as OpenClawConfig,
+    channel: "matrix",
+    to: "!room:example",
+    payloads: [{ text: "regenerated content must not replace queue custody" }],
+    queuePolicy: "required",
+    deliveryIntentId: params.deliveryIntentId,
+    completionRetention: boundedCronCompletionRetention,
+    reusePendingDeliveryIntent: true,
+  });
+  await preparationEntered.promise;
+  return { delivery, messageId, releasePreparation: releasePreparation.resolve, sendText };
+}
+
+async function startBlockedRenderedStableDelivery(params: {
+  tmpDir: string;
+  deliveryIntentId: string;
+}) {
+  process.env.OPENCLAW_STATE_DIR = params.tmpDir;
+  const renderEntered = createDeferred();
+  const releaseRender = createDeferred();
+  const messageId = `${params.deliveryIntentId}-message`;
+  const renderPresentation = vi.fn(async ({ payload }) => {
+    renderEntered.resolve();
+    await releaseRender.promise;
+    return payload;
+  });
+  const sendText = vi.fn(async (ctx: ChannelMessageSendTextContext) => {
+    await ctx.onPlatformSendDispatch?.();
+    return {
+      messageId,
+      receipt: createMessageReceiptFromOutboundResults({
+        results: [{ channel: "matrix", messageId }],
+        kind: "text",
+      }),
+    };
+  });
+  setActivePluginRegistry(
+    createTestRegistry([
+      {
+        pluginId: "matrix",
+        source: "test",
+        plugin: {
+          ...createOutboundTestPlugin({
+            id: "matrix",
+            outbound: {
+              ...matrixOutboundForQueueTest,
+              presentationCapabilities: { supported: true },
+              renderPresentation,
+            },
+          }),
+          message: {
+            id: "matrix",
+            durableFinal: { capabilities: { text: true } },
+            send: { text: sendText },
+          },
+        },
+      },
+    ]),
+  );
+  await enqueueDeliveryOnce(
+    {
+      channel: "matrix",
+      to: "!room:example",
+      payloads: [
+        {
+          text: "queue-owned stable content",
+          presentation: { blocks: [{ type: "text", text: "rendered stable content" }] },
+        },
+      ],
+      queuePolicy: "required",
+      completionRetention: boundedCronCompletionRetention,
+      requiresProducerClaim: true,
+    },
+    params.deliveryIntentId,
+    params.tmpDir,
+  );
+  const delivery = deliverOutboundPayloads({
+    cfg: {} as OpenClawConfig,
+    channel: "matrix",
+    to: "!room:example",
+    payloads: [{ text: "regenerated content must not replace queue custody" }],
+    queuePolicy: "required",
+    deliveryIntentId: params.deliveryIntentId,
+    completionRetention: boundedCronCompletionRetention,
+    reusePendingDeliveryIntent: true,
+  });
+  await renderEntered.promise;
+  return { delivery, releaseRender: releaseRender.resolve, renderPresentation, sendText };
+}
+
+async function startBlockedProviderStableDelivery(params: {
+  tmpDir: string;
+  deliveryIntentId: string;
+}) {
+  process.env.OPENCLAW_STATE_DIR = params.tmpDir;
+  const providerEntered = createDeferred();
+  const releaseProvider = createDeferred();
+  const messageId = `${params.deliveryIntentId}-message`;
+  const onDeliveryResult = vi.fn();
+  const sendText = vi.fn(async (ctx: ChannelMessageSendTextContext) => {
+    await ctx.onPlatformSendDispatch?.();
+    providerEntered.resolve();
+    await releaseProvider.promise;
+    return {
+      messageId,
+      receipt: createMessageReceiptFromOutboundResults({
+        results: [{ channel: "matrix", messageId }],
+        kind: "text",
+      }),
+    };
+  });
+  setActivePluginRegistry(
+    createTestRegistry([
+      {
+        pluginId: "matrix",
+        source: "test",
+        plugin: {
+          ...createOutboundTestPlugin({ id: "matrix", outbound: matrixOutboundForQueueTest }),
+          message: {
+            id: "matrix",
+            durableFinal: { capabilities: { text: true } },
+            send: { text: sendText },
+          },
+        },
+      },
+    ]),
+  );
+  await enqueueDeliveryOnce(
+    {
+      channel: "matrix",
+      to: "!room:example",
+      payloads: [{ text: "queue-owned stable content" }],
+      queuePolicy: "required",
+      completionRetention: boundedCronCompletionRetention,
+      requiresProducerClaim: true,
+    },
+    params.deliveryIntentId,
+    params.tmpDir,
+  );
+  const delivery = deliverOutboundPayloads({
+    cfg: {} as OpenClawConfig,
+    channel: "matrix",
+    to: "!room:example",
+    payloads: [{ text: "regenerated content must not replace queue custody" }],
+    queuePolicy: "required",
+    deliveryIntentId: params.deliveryIntentId,
+    completionRetention: boundedCronCompletionRetention,
+    reusePendingDeliveryIntent: true,
+    onDeliveryResult,
+  });
+  await providerEntered.promise;
+  return { delivery, onDeliveryResult, releaseProvider: releaseProvider.resolve, sendText };
+}
+
+describe("stable delivery producer lease integration", () => {
+  const fixtures = installDeliveryQueueTmpDirHooks();
+
+  beforeAll(async () => {
+    ({ deliverOutboundPayloads } = await import("./deliver.js"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    resetPluginRuntimeStateForTest();
+    setActivePluginRegistry(createEmptyPluginRegistry());
+  });
+
+  it("upgrades and renews a legacy reused intent through long channel preparation", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-02T10:00:00.000Z"));
+    const tmpDir = fixtures.tmpDir();
+    const deliveryIntentId = "cron-direct-delivery:v1:renew-long-channel-preparation";
+    let blocked: Awaited<ReturnType<typeof startBlockedStableDelivery>> | undefined;
+    try {
+      blocked = await startBlockedStableDelivery({
+        tmpDir,
+        deliveryIntentId,
+        requiresProducerClaim: false,
+      });
+      await vi.advanceTimersByTimeAsync(35_000);
+
+      expect(await claimDeliveryPlatformSendAttempt(deliveryIntentId, tmpDir)).toBeUndefined();
+      expect(readQueuedEntry(tmpDir, deliveryIntentId)).toMatchObject({
+        recoveryState: "producer_claimed",
+        requiresProducerClaim: true,
+        availableAt: expect.any(Number),
+      });
+      expect(readQueuedEntry(tmpDir, deliveryIntentId).availableAt as number).toBeGreaterThan(
+        Date.now(),
+      );
+
+      blocked.releasePreparation();
+      await expect(blocked.delivery).resolves.toMatchObject([{ messageId: blocked.messageId }]);
+      expect(blocked.sendText).toHaveBeenCalledOnce();
+      expect(
+        getDeliveryQueueEntryStatus(OUTBOUND_DELIVERY_QUEUE_NAME, deliveryIntentId, tmpDir),
+      ).toBe("completed");
+    } finally {
+      blocked?.releasePreparation();
+      await blocked?.delivery.catch(() => undefined);
+    }
+  });
+
+  it("stops before provider I/O when the exact owner is replaced", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-02T10:00:00.000Z"));
+    const tmpDir = fixtures.tmpDir();
+    const deliveryIntentId = "cron-direct-delivery:v1:lose-owner-before-provider";
+    let blocked: Awaited<ReturnType<typeof startBlockedStableDelivery>> | undefined;
+    try {
+      blocked = await startBlockedStableDelivery({
+        tmpDir,
+        deliveryIntentId,
+        requiresProducerClaim: true,
+      });
+      expect(readQueuedEntry(tmpDir, deliveryIntentId).producerClaimId).toEqual(expect.any(String));
+      setQueuedEntryState(tmpDir, deliveryIntentId, {
+        retryCount: 0,
+        producerClaimId: "replacement-owner",
+      });
+      await vi.advanceTimersByTimeAsync(10_001);
+
+      const rejected = expect(blocked.delivery).rejects.toThrow(
+        `Stable delivery platform claim was lost: ${deliveryIntentId}`,
+      );
+      blocked.releasePreparation();
+      await rejected;
+
+      expect(blocked.sendText).not.toHaveBeenCalled();
+      expect(readQueuedEntry(tmpDir, deliveryIntentId)).toMatchObject({
+        recoveryState: "producer_claimed",
+        producerClaimId: "replacement-owner",
+        retryCount: 0,
+      });
+    } finally {
+      blocked?.releasePreparation();
+      await blocked?.delivery.catch(() => undefined);
+    }
+  });
+
+  it("retains retryable custody when the owner expires before provider I/O", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-02T10:00:00.000Z"));
+    const tmpDir = fixtures.tmpDir();
+    const deliveryIntentId = "cron-direct-delivery:v1:expire-owner-before-provider";
+    let blocked: Awaited<ReturnType<typeof startBlockedStableDelivery>> | undefined;
+    try {
+      blocked = await startBlockedStableDelivery({
+        tmpDir,
+        deliveryIntentId,
+        requiresProducerClaim: true,
+      });
+      const producerClaimId = readQueuedEntry(tmpDir, deliveryIntentId).producerClaimId;
+      expect(producerClaimId).toEqual(expect.any(String));
+      setQueuedEntryState(tmpDir, deliveryIntentId, {
+        retryCount: 0,
+        availableAt: Date.now() - 1,
+      });
+      await vi.advanceTimersByTimeAsync(10_001);
+
+      const rejected = expect(blocked.delivery).rejects.toThrow(
+        `Stable delivery platform claim was lost: ${deliveryIntentId}`,
+      );
+      blocked.releasePreparation();
+      await rejected;
+
+      expect(blocked.sendText).not.toHaveBeenCalled();
+      expect(
+        getDeliveryQueueEntryStatus(OUTBOUND_DELIVERY_QUEUE_NAME, deliveryIntentId, tmpDir),
+      ).toBe("pending");
+      expect(readQueuedEntry(tmpDir, deliveryIntentId)).toMatchObject({
+        recoveryState: "producer_claimed",
+        producerClaimId,
+        retryCount: 0,
+      });
+      expect(readQueuedEntry(tmpDir, deliveryIntentId)).not.toHaveProperty("lastError");
+      const replacementClaimId = await claimDeliveryPlatformSendAttempt(deliveryIntentId, tmpDir);
+      expect(replacementClaimId).toEqual(expect.any(String));
+      expect(replacementClaimId).not.toBe(producerClaimId);
+    } finally {
+      blocked?.releasePreparation();
+      await blocked?.delivery.catch(() => undefined);
+    }
+  });
+
+  it("preserves lease loss through presentation preparation before provider I/O", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-02T10:00:00.000Z"));
+    const tmpDir = fixtures.tmpDir();
+    const deliveryIntentId = "cron-direct-delivery:v1:expire-owner-during-presentation";
+    let blocked: Awaited<ReturnType<typeof startBlockedRenderedStableDelivery>> | undefined;
+    try {
+      blocked = await startBlockedRenderedStableDelivery({ tmpDir, deliveryIntentId });
+      const producerClaimId = readQueuedEntry(tmpDir, deliveryIntentId).producerClaimId;
+      expect(producerClaimId).toEqual(expect.any(String));
+      setQueuedEntryState(tmpDir, deliveryIntentId, {
+        retryCount: 0,
+        availableAt: Date.now() - 1,
+      });
+      await vi.advanceTimersByTimeAsync(10_001);
+
+      const rejected = expect(blocked.delivery).rejects.toThrow(
+        `Stable delivery platform claim was lost: ${deliveryIntentId}`,
+      );
+      blocked.releaseRender();
+      await rejected;
+
+      expect(blocked.renderPresentation).toHaveBeenCalledOnce();
+      expect(blocked.sendText).not.toHaveBeenCalled();
+      expect(
+        getDeliveryQueueEntryStatus(OUTBOUND_DELIVERY_QUEUE_NAME, deliveryIntentId, tmpDir),
+      ).toBe("pending");
+      expect(readQueuedEntry(tmpDir, deliveryIntentId)).toMatchObject({
+        recoveryState: "producer_claimed",
+        producerClaimId,
+        retryCount: 0,
+      });
+      expect(readQueuedEntry(tmpDir, deliveryIntentId)).not.toHaveProperty("lastError");
+      const replacementClaimId = await claimDeliveryPlatformSendAttempt(deliveryIntentId, tmpDir);
+      expect(replacementClaimId).toEqual(expect.any(String));
+      expect(replacementClaimId).not.toBe(producerClaimId);
+    } finally {
+      blocked?.releaseRender();
+      await blocked?.delivery.catch(() => undefined);
+    }
+  });
+
+  it("does not settle a queue row when the lease expires after provider dispatch", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-02T10:00:00.000Z"));
+    const tmpDir = fixtures.tmpDir();
+    const deliveryIntentId = "cron-direct-delivery:v1:expire-owner-after-dispatch";
+    const auditEvents: unknown[] = [];
+    const unsubscribe = onTrustedMessageAuditEvent((event) => auditEvents.push(event));
+    let blocked: Awaited<ReturnType<typeof startBlockedProviderStableDelivery>> | undefined;
+    try {
+      blocked = await startBlockedProviderStableDelivery({ tmpDir, deliveryIntentId });
+      const dispatched = readQueuedEntry(tmpDir, deliveryIntentId);
+      const platformSendAttemptId = dispatched.platformSendAttemptId;
+      expect(dispatched).toMatchObject({
+        recoveryState: "send_attempt_started",
+        platformSendAttemptId: expect.any(String),
+        retryCount: 0,
+      });
+      setQueuedEntryState(tmpDir, deliveryIntentId, {
+        retryCount: 0,
+        recoveryState: "send_attempt_started",
+        platformSendStartedAt: dispatched.platformSendStartedAt as number,
+        availableAt: Date.now() - 1,
+      });
+      await vi.advanceTimersByTimeAsync(10_001);
+
+      const rejected = expect(blocked.delivery).rejects.toThrow(
+        `Stable delivery platform claim was lost: ${deliveryIntentId}`,
+      );
+      blocked.releaseProvider();
+      await rejected;
+
+      expect(blocked.sendText).toHaveBeenCalledOnce();
+      expect(blocked.onDeliveryResult).not.toHaveBeenCalled();
+      expect(auditEvents).toEqual([]);
+      expect(
+        getDeliveryQueueEntryStatus(OUTBOUND_DELIVERY_QUEUE_NAME, deliveryIntentId, tmpDir),
+      ).toBe("pending");
+      expect(readQueuedEntry(tmpDir, deliveryIntentId)).toMatchObject({
+        recoveryState: "send_attempt_started",
+        platformSendAttemptId,
+        retryCount: 0,
+      });
+      expect(readQueuedEntry(tmpDir, deliveryIntentId)).not.toHaveProperty("lastError");
+    } finally {
+      unsubscribe();
+      blocked?.releaseProvider();
+      await blocked?.delivery.catch(() => undefined);
+    }
+  });
+});

--- a/src/infra/outbound/deliver-queue.ts
+++ b/src/infra/outbound/deliver-queue.ts
@@ -15,13 +15,18 @@ import {
 } from "./deliver-queue-admission.js";
 import { deliverOutboundPayloadsWithQueueCleanup } from "./deliver-queue-execute.js";
 import type { OutboundDeliveryResult } from "./deliver-types.js";
+import { startDeliveryProducerLease } from "./delivery-queue-lease.js";
 import {
   StableDeliveryPreparationLostError,
   withStableDeliveryPreparation,
   type StableDeliveryPreparationOwner,
 } from "./delivery-queue-preparation.js";
 import { findDeliveryIntentOwner, loadPendingDelivery } from "./delivery-queue-storage.js";
-import { claimDeliveryPlatformSendAttempt, withActiveDeliveryClaim } from "./delivery-queue.js";
+import {
+  claimReusableDeliveryPlatformSendAttempt,
+  renewDeliveryPlatformSendLease,
+  withActiveDeliveryClaim,
+} from "./delivery-queue.js";
 import { createMessageSentEmitter } from "./message-sent-hook.js";
 import { emitOutboundAuditTerminals, uniformOutboundAuditTerminals } from "./outbound-audit.js";
 import { acceptedPreparedOutboundEntries } from "./prepared-batch.js";
@@ -58,6 +63,46 @@ export async function runOutboundDeliveryInternal(
     throw new Error(`Stable delivery intent is already queued: ${stableIntentId}`);
   }
   return await runOutboundDeliveryWithQueue(params, false);
+}
+
+async function deliverWithProducerLease(
+  params: DeliverOutboundPayloadsParams,
+  queueId: string | null,
+  auditStartedAt: number,
+  producerClaimId?: string,
+): Promise<OutboundDeliveryResult[]> {
+  if (params.deliveryProducerLeaseRequired !== true) {
+    return await deliverOutboundPayloadsWithQueueCleanup(
+      params,
+      queueId,
+      auditStartedAt,
+      producerClaimId,
+    );
+  }
+  const platformQueueId = queueId ?? params.deliveryQueueId;
+  if (!platformQueueId || !producerClaimId) {
+    throw new Error("Stable delivery producer lease requires an exact queue owner");
+  }
+  const stateDir = queueId ? undefined : params.deliveryQueueStateDir;
+  const lease = await startDeliveryProducerLease({
+    id: platformQueueId,
+    renew: async () =>
+      await renewDeliveryPlatformSendLease(platformQueueId, stateDir, producerClaimId),
+  });
+  const abortSignal = params.abortSignal
+    ? AbortSignal.any([params.abortSignal, lease.signal])
+    : lease.signal;
+  try {
+    return await deliverOutboundPayloadsWithQueueCleanup(
+      { ...params, abortSignal },
+      queueId,
+      auditStartedAt,
+      producerClaimId,
+      lease.signal,
+    );
+  } finally {
+    lease.stop();
+  }
 }
 
 async function runOutboundDeliveryWithQueue(
@@ -239,7 +284,7 @@ async function runOutboundDeliveryWithQueue(
   }
 
   if (!queueId) {
-    return await deliverOutboundPayloadsWithQueueCleanup(
+    return await deliverWithProducerLease(
       deliveryParams,
       null,
       auditStartedAt,
@@ -252,20 +297,27 @@ async function runOutboundDeliveryWithQueue(
   }
   const deliverClaimedIntent = async (): Promise<OutboundDeliveryResult[]> => {
     const producerClaimId = params.reusePendingDeliveryIntent
-      ? await claimDeliveryPlatformSendAttempt(queueId)
+      ? await claimReusableDeliveryPlatformSendAttempt(queueId)
       : undefined;
     if (params.reusePendingDeliveryIntent && !producerClaimId) {
       throw new Error(`Stable delivery intent is already queued: ${queueId}`);
     }
-    let claimedDeliveryParams = deliveryParams;
+    let claimedDeliveryParams: DeliverOutboundPayloadsParams =
+      params.reusePendingDeliveryIntent && queued?.created === true
+        ? { ...deliveryParams, deliveryProducerLeaseRequired: true }
+        : deliveryParams;
     if (queued?.created !== true) {
       const queuedEntry = await loadPendingDelivery(queueId);
       if (!queuedEntry || queuedEntry.producerClaimId !== producerClaimId) {
         throw new Error(`Stable delivery platform claim was lost: ${queueId}`);
       }
-      claimedDeliveryParams = restoreQueuedDeliveryCustody(deliveryParams, queuedEntry);
+      const restoredDeliveryParams = restoreQueuedDeliveryCustody(deliveryParams, queuedEntry);
+      claimedDeliveryParams =
+        queuedEntry.requiresProducerClaim === true
+          ? { ...restoredDeliveryParams, deliveryProducerLeaseRequired: true }
+          : restoredDeliveryParams;
     }
-    return deliverOutboundPayloadsWithQueueCleanup(
+    return deliverWithProducerLease(
       claimedDeliveryParams,
       queueId,
       auditStartedAt,

--- a/src/infra/outbound/deliver.queue-integration.test.ts
+++ b/src/infra/outbound/deliver.queue-integration.test.ts
@@ -17,13 +17,12 @@ import {
 } from "./deliver.queue-integration.test-support.js";
 import { collectEntrySpoolPaths, stageQueuePayloadMedia } from "./delivery-queue-media-spool.js";
 import { OUTBOUND_DELIVERY_QUEUE_NAME } from "./delivery-queue-media-staging.js";
-import { loadPendingDeliveries, reserveDeliveryAttempt } from "./delivery-queue-storage.js";
 import {
   claimDeliveryPlatformSendAttempt,
-  enqueueDeliveryOnce,
-  recoverPendingDeliveries,
-  type DeliverFn,
-} from "./delivery-queue.js";
+  loadPendingDeliveries,
+  reserveDeliveryAttempt,
+} from "./delivery-queue-storage.js";
+import { enqueueDeliveryOnce, recoverPendingDeliveries, type DeliverFn } from "./delivery-queue.js";
 import {
   createRecoveryLog,
   installDeliveryQueueTmpDirHooks,

--- a/src/infra/outbound/delivery-queue-lease.test.ts
+++ b/src/infra/outbound/delivery-queue-lease.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { startDeliveryProducerLease } from "./delivery-queue-lease.js";
+
+describe("delivery producer lease", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renews immediately and keeps the exact owner alive until stopped", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const renew = vi.fn(async () => Date.now() + 30_000);
+
+    const lease = await startDeliveryProducerLease({ id: "stable-1", renew });
+    expect(renew).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(35_000);
+    expect(renew).toHaveBeenCalledTimes(4);
+    expect(lease.signal.aborted).toBe(false);
+
+    lease.stop();
+    lease.stop();
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(renew).toHaveBeenCalledTimes(4);
+  });
+
+  it("aborts with the stable claim error when renewal definitively loses ownership", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const renew = vi
+      .fn<() => Promise<number | undefined>>()
+      .mockResolvedValueOnce(Date.now() + 30_000)
+      .mockResolvedValueOnce(undefined);
+
+    const lease = await startDeliveryProducerLease({ id: "stable-lost", renew });
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(lease.signal.aborted).toBe(true);
+    expect(lease.signal.reason).toMatchObject({
+      name: "StableDeliveryProducerLeaseLostError",
+      message: "Stable delivery platform claim was lost: stable-lost",
+    });
+  });
+
+  it("retries transient renewal failures while the last confirmed lease remains valid", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const renew = vi
+      .fn<() => Promise<number | undefined>>()
+      .mockResolvedValueOnce(Date.now() + 30_000)
+      .mockRejectedValueOnce(new Error("database busy"))
+      .mockImplementation(async () => Date.now() + 30_000);
+
+    const lease = await startDeliveryProducerLease({ id: "stable-retry", renew });
+    await vi.advanceTimersByTimeAsync(35_000);
+
+    expect(renew).toHaveBeenCalledTimes(4);
+    expect(lease.signal.aborted).toBe(false);
+    lease.stop();
+  });
+
+  it("aborts when transient renewal failures outlive the last confirmed lease", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const renew = vi
+      .fn<() => Promise<number | undefined>>()
+      .mockResolvedValueOnce(Date.now() + 30_000)
+      .mockRejectedValue(new Error("database unavailable"));
+
+    const lease = await startDeliveryProducerLease({ id: "stable-expired", renew });
+    await vi.advanceTimersByTimeAsync(30_001);
+
+    expect(lease.signal.aborted).toBe(true);
+    expect(lease.signal.reason).toMatchObject({
+      name: "StableDeliveryProducerLeaseLostError",
+      message: "Stable delivery platform claim was lost: stable-expired",
+    });
+  });
+
+  it("refuses to start without a confirmed unexpired owner", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+
+    await expect(
+      startDeliveryProducerLease({
+        id: "stable-missing",
+        renew: async () => undefined,
+      }),
+    ).rejects.toMatchObject({
+      name: "StableDeliveryProducerLeaseLostError",
+      message: "Stable delivery platform claim was lost: stable-missing",
+    });
+    await expect(
+      startDeliveryProducerLease({
+        id: "stable-storage-error",
+        renew: async () => {
+          throw new Error("database unavailable");
+        },
+      }),
+    ).rejects.toMatchObject({
+      name: "StableDeliveryProducerLeaseLostError",
+      message: "Stable delivery platform claim was lost: stable-storage-error",
+    });
+  });
+});

--- a/src/infra/outbound/delivery-queue-lease.ts
+++ b/src/infra/outbound/delivery-queue-lease.ts
@@ -1,0 +1,100 @@
+import { PLATFORM_SEND_OWNER_LEASE_MS } from "../delivery-queue-sqlite-claim.js";
+
+const PLATFORM_SEND_OWNER_HEARTBEAT_MS = Math.floor(PLATFORM_SEND_OWNER_LEASE_MS / 3);
+
+type DeliveryProducerLease = {
+  signal: AbortSignal;
+  stop: () => void;
+};
+
+class StableDeliveryProducerLeaseLostError extends Error {
+  override name = "StableDeliveryProducerLeaseLostError";
+}
+
+function lostProducerLeaseError(id: string, cause?: unknown): Error {
+  return new StableDeliveryProducerLeaseLostError(
+    `Stable delivery platform claim was lost: ${id}`,
+    { cause },
+  );
+}
+
+/** Maintains one already-acquired stable producer claim during fallible preparation and send. */
+export async function startDeliveryProducerLease(params: {
+  id: string;
+  renew: () => Promise<number | undefined>;
+}): Promise<DeliveryProducerLease> {
+  let confirmedExpiresAt: number;
+  try {
+    const initialExpiry = await params.renew();
+    if (initialExpiry === undefined || initialExpiry <= Date.now()) {
+      throw lostProducerLeaseError(params.id);
+    }
+    confirmedExpiresAt = initialExpiry;
+  } catch (error) {
+    if (error instanceof StableDeliveryProducerLeaseLostError) {
+      throw error;
+    }
+    throw lostProducerLeaseError(params.id, error);
+  }
+
+  const lost = new AbortController();
+  let stopped = false;
+  let renewing = false;
+  let expiryTimer: ReturnType<typeof setTimeout> | undefined;
+  const abortLost = (cause?: unknown): void => {
+    if (!stopped && !lost.signal.aborted) {
+      lost.abort(lostProducerLeaseError(params.id, cause));
+    }
+  };
+  const scheduleExpiry = (): void => {
+    if (expiryTimer) {
+      clearTimeout(expiryTimer);
+    }
+    expiryTimer = setTimeout(() => abortLost(), Math.max(1, confirmedExpiresAt - Date.now()));
+    expiryTimer.unref?.();
+  };
+  const renew = async (): Promise<void> => {
+    if (stopped || renewing || lost.signal.aborted) {
+      return;
+    }
+    renewing = true;
+    try {
+      const expiresAt = await params.renew();
+      if (stopped) {
+        return;
+      }
+      if (expiresAt === undefined) {
+        abortLost();
+        return;
+      }
+      confirmedExpiresAt = expiresAt;
+      scheduleExpiry();
+    } catch (error) {
+      // A transient storage failure does not revoke the last confirmed lease.
+      // Its expiry timer remains authoritative while later heartbeats retry.
+      if (!stopped && Date.now() >= confirmedExpiresAt) {
+        abortLost(error);
+      }
+    } finally {
+      renewing = false;
+    }
+  };
+
+  scheduleExpiry();
+  const heartbeat = setInterval(() => void renew(), PLATFORM_SEND_OWNER_HEARTBEAT_MS);
+  heartbeat.unref?.();
+
+  return {
+    signal: lost.signal,
+    stop: () => {
+      if (stopped) {
+        return;
+      }
+      stopped = true;
+      clearInterval(heartbeat);
+      if (expiryTimer) {
+        clearTimeout(expiryTimer);
+      }
+    },
+  };
+}

--- a/src/infra/outbound/delivery-queue-platform-lease.ts
+++ b/src/infra/outbound/delivery-queue-platform-lease.ts
@@ -1,0 +1,32 @@
+import {
+  claimDeliveryQueueEntryPlatformSend,
+  renewDeliveryQueueEntryPlatformSendLease,
+} from "../delivery-queue-sqlite-claim.js";
+import { OUTBOUND_DELIVERY_QUEUE_NAME } from "./delivery-queue-media-staging.js";
+
+/** Claim and atomically upgrade a live reusable producer to renewable ownership. */
+export async function claimReusableDeliveryPlatformSendAttempt(
+  id: string,
+  stateDir?: string,
+): Promise<string | undefined> {
+  return claimDeliveryQueueEntryPlatformSend({
+    queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
+    id,
+    stateDir,
+    requiresProducerClaim: true,
+  });
+}
+
+/** Extend the exact active reusable producer lease without changing ownership. */
+export async function renewDeliveryPlatformSendLease(
+  id: string,
+  stateDir: string | undefined,
+  claimId: string,
+): Promise<number | undefined> {
+  return renewDeliveryQueueEntryPlatformSendLease({
+    queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
+    id,
+    stateDir,
+    claimId,
+  });
+}

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -83,6 +83,7 @@ export type DeliverFn = (
       deliveryQueueId?: string;
       deliveryQueueStateDir?: string;
       deliveryProducerClaimId?: string;
+      deliveryProducerLeaseRequired?: boolean;
       skipQueue?: boolean;
       deferredDeliveryAdmissionPassed?: true;
       deferCommitHooks?: boolean;
@@ -260,7 +261,9 @@ function hasActiveStableDeliveryOwner(entry: QueuedDelivery, now: number): boole
       entry.completionRetention === "permanent" ||
       entry.requiresProducerClaim === true) &&
     (entry.recoveryState === "producer_claimed" ||
-      (entry.recoveryState === "send_attempt_started" && entry.requiresProducerClaim === true)) &&
+      ((entry.recoveryState === "send_attempt_started" ||
+        entry.recoveryState === "unknown_after_send") &&
+        entry.requiresProducerClaim === true)) &&
     typeof entry.availableAt === "number" &&
     entry.availableAt > now
   );
@@ -328,6 +331,7 @@ function buildRecoveryDeliverParams(
     deliveryQueueId: entry.id,
     deliveryQueueStateDir: stateDir,
     ...(producerClaimId ? { deliveryProducerClaimId: producerClaimId } : {}),
+    ...(entry.requiresProducerClaim === true ? { deliveryProducerLeaseRequired: true } : {}),
     skipQueue: true, // Prevent re-enqueueing during recovery.
     deferredDeliveryAdmissionPassed: true,
     deferCommitHooks: true,

--- a/src/infra/outbound/delivery-queue-storage.ts
+++ b/src/infra/outbound/delivery-queue-storage.ts
@@ -599,7 +599,14 @@ export async function markDeliveryPlatformOutcomeUnknown(
     stateDir,
     (entry) => ({
       ...entry,
-      availableAt: undefined,
+      // An explicit stable producer keeps its exact lease through the
+      // ambiguous outcome so recovery cannot race its remaining cleanup.
+      availableAt:
+        expectedPlatformSendAttemptId &&
+        entry.requiresProducerClaim === true &&
+        entry.platformSendAttemptId === expectedPlatformSendAttemptId
+          ? entry.availableAt
+          : undefined,
       producerClaimId: undefined,
       platformSendStartedAt: entry.platformSendStartedAt ?? Date.now(),
       recoveryState: "unknown_after_send",

--- a/src/infra/outbound/delivery-queue.recovery.test.ts
+++ b/src/infra/outbound/delivery-queue.recovery.test.ts
@@ -846,6 +846,90 @@ describe("delivery-queue recovery", () => {
       platformSendAttemptId: producerClaimId,
       availableAt: expect.any(Number),
     });
+
+    await markDeliveryPlatformOutcomeUnknown(id, tmpDir(), producerClaimId);
+    const unknownResult = await runRecovery({ deliver });
+
+    expect(unknownResult.result).toMatchObject({ recovered: 0, failed: 0 });
+    expect(reconcileUnknownSend).not.toHaveBeenCalled();
+    expect(deliver).not.toHaveBeenCalled();
+    expect((await loadPendingDeliveries(tmpDir()))[0]).toMatchObject({
+      id,
+      recoveryState: "unknown_after_send",
+      platformSendAttemptId: producerClaimId,
+      availableAt: expect.any(Number),
+    });
+  });
+
+  it("reconciles an unknown stable send after restart recovery waits for its lease expiry", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-02T10:00:00.000Z"));
+    try {
+      const id = "cron-direct-delivery:v1:restart-before-producer-lease-expiry";
+      await enqueueDeliveryOnce(
+        {
+          channel: "demo-channel-a",
+          to: "+1",
+          payloads: [{ text: "reconcile after the crashed producer lease expires" }],
+          queuePolicy: "required",
+          completionRetention: {
+            idPrefix: "cron-direct-delivery:v1:",
+            maxAgeMs: 24 * 60 * 60_000,
+            maxEntries: 2_000,
+          },
+          requiresProducerClaim: true,
+        },
+        id,
+        tmpDir(),
+      );
+      const originalClaimId = await claimDeliveryPlatformSendAttempt(id, tmpDir());
+      if (!originalClaimId) {
+        throw new Error("test invariant: the crashed producer must own a stable claim");
+      }
+      await markDeliveryPlatformSendAttemptStarted(id, tmpDir(), undefined, originalClaimId);
+      await markDeliveryPlatformOutcomeUnknown(id, tmpDir(), originalClaimId);
+      const leaseExpiry = (await loadPendingDeliveries(tmpDir()))[0]?.availableAt;
+      if (leaseExpiry === undefined) {
+        throw new Error("test invariant: the stable producer claim must have an expiry");
+      }
+
+      const reconcileUnknownSend = vi.fn().mockResolvedValue({
+        status: "sent",
+        messageId: "reconciled-after-expiry",
+        receipt: {
+          primaryPlatformMessageId: "reconciled-after-expiry",
+          platformMessageIds: ["reconciled-after-expiry"],
+          parts: [{ platformMessageId: "reconciled-after-expiry", kind: "text", index: 0 }],
+          sentAt: leaseExpiry,
+        },
+      });
+      resolveOutboundChannelMessageAdapterMock.mockReturnValue({
+        durableFinal: {
+          capabilities: { reconcileUnknownSend: true },
+          reconcileUnknownSend,
+        },
+      });
+      const deliver = vi.fn();
+
+      const firstRun = await runRecovery({ deliver });
+      expect(firstRun.result).toMatchObject({
+        recovered: 0,
+        failed: 0,
+      });
+      expect(reconcileUnknownSend).not.toHaveBeenCalled();
+      expect(deliver).not.toHaveBeenCalled();
+
+      vi.setSystemTime(leaseExpiry + 1);
+      const secondRun = await runRecovery({ deliver });
+
+      expect(secondRun.result).toMatchObject({ recovered: 1, failed: 0 });
+      expect(reconcileUnknownSend).toHaveBeenCalledOnce();
+      expect(deliver).not.toHaveBeenCalled();
+      expect(readOutboundQueueStatus(tmpDir(), id)).toBe("completed");
+      expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
   it("atomically fences stable recovery after an adapter proves an ambiguous send was not sent", async () => {
     const id = "cron-direct-delivery:v1:reconciled-stable-recovery";
@@ -887,6 +971,10 @@ describe("delivery-queue recovery", () => {
       requiresProducerClaim: true,
     });
     await markDeliveryPlatformOutcomeUnknown(id, tmpDir(), platformSendAttemptId);
+    setQueuedEntryState(tmpDir(), id, {
+      retryCount: 0,
+      availableAt: Date.now() - 1,
+    });
     const reconcileUnknownSend = vi
       .fn()
       .mockResolvedValue(reconciledSent("reconciled-permanent-message"));

--- a/src/infra/outbound/delivery-queue.storage.test.ts
+++ b/src/infra/outbound/delivery-queue.storage.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { openOpenClawStateDatabase } from "../../state/openclaw-state-db.js";
 import { OUTBOUND_DELIVERY_QUEUE_NAME } from "./delivery-queue-media-staging.js";
+import { renewDeliveryPlatformSendLease } from "./delivery-queue-platform-lease.js";
 import {
   ackDelivery,
   claimDeliveryPlatformSendAttempt,
@@ -473,6 +474,52 @@ describe("delivery-queue storage", () => {
       expect((entry.platformSendStartedAt as number) > 0).toBe(true);
       expect(entry.recoveryState).toBe("unknown_after_send");
       expect(entry.retryCount).toBe(0);
+    });
+
+    it("preserves and renews the exact explicit owner after an ambiguous platform outcome", async () => {
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(new Date("2026-08-02T10:00:00.000Z"));
+        const stateDir = tmpDir();
+        const id = "cron-direct-delivery:v1:unknown-owner-lease";
+        await enqueueDeliveryOnce(
+          {
+            channel: "forum",
+            to: "123",
+            payloads: [{ text: "test" }],
+            completionRetention: {
+              idPrefix: "cron-direct-delivery:v1:",
+              maxAgeMs: 24 * 60 * 60_000,
+              maxEntries: 2_000,
+            },
+            requiresProducerClaim: true,
+          },
+          id,
+          stateDir,
+        );
+        const claimId = await claimDeliveryPlatformSendAttempt(id, stateDir);
+        if (!claimId) {
+          throw new Error("test invariant: explicit producer must own the stable row");
+        }
+        await markDeliveryPlatformSendAttemptStarted(id, stateDir, undefined, claimId);
+        const started = readQueuedEntry(stateDir, id);
+        const originalExpiry = started.availableAt;
+        vi.setSystemTime(Date.now() + 1_000);
+
+        await markDeliveryPlatformOutcomeUnknown(id, stateDir, claimId);
+
+        expect(readQueuedEntry(stateDir, id)).toMatchObject({
+          recoveryState: "unknown_after_send",
+          platformSendAttemptId: claimId,
+          availableAt: originalExpiry,
+        });
+        await expect(renewDeliveryPlatformSendLease(id, stateDir, claimId)).resolves.toBe(
+          Date.now() + 30_000,
+        );
+        expect(readQueuedEntry(stateDir, id).availableAt).toBe(Date.now() + 30_000);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("refreshes the attempt timestamp immediately before provider I/O", async () => {

--- a/src/infra/outbound/delivery-queue.test-helpers.ts
+++ b/src/infra/outbound/delivery-queue.test-helpers.ts
@@ -84,6 +84,8 @@ export function setQueuedEntryState(
     enqueuedAt?: number;
     platformSendStartedAt?: number;
     recoveryState?: "send_attempt_started" | "unknown_after_send";
+    producerClaimId?: string;
+    availableAt?: number;
   },
 ): void {
   const entry = readQueuedEntry(tmpDir, id);
@@ -106,6 +108,12 @@ export function setQueuedEntryState(
   }
   if (state.recoveryState !== undefined) {
     entry.recoveryState = state.recoveryState;
+  }
+  if (state.producerClaimId !== undefined) {
+    entry.producerClaimId = state.producerClaimId;
+  }
+  if (state.availableAt !== undefined) {
+    entry.availableAt = state.availableAt;
   }
   const { db } = openOpenClawStateDatabase({ env: { ...process.env, OPENCLAW_STATE_DIR: tmpDir } });
   db.prepare(

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -1,7 +1,6 @@
 // Public outbound delivery queue facade for storage and recovery operations.
 export {
   ackDelivery,
-  claimDeliveryPlatformSendAttempt,
   enqueueDelivery,
   enqueueDeliveryOnce,
   enqueuePreparedDeliveryOnce,
@@ -10,6 +9,10 @@ export {
   failDeliveryBeforePlatformSend,
   markDeliveryPlatformSendDispatched,
 } from "./delivery-queue-storage.js";
+export {
+  claimReusableDeliveryPlatformSendAttempt,
+  renewDeliveryPlatformSendLease,
+} from "./delivery-queue-platform-lease.js";
 export type { QueuedReplyPayloadSendingHook } from "./delivery-queue-storage.js";
 export {
   drainPendingDeliveries,


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/118044

## What Problem This Solves

Resolves a delivery race where a reusable stable outbound intent could outlive its producer claim while channel preparation or the provider send was still running. Recovery could then acquire the same intent and begin a second provider send before the first producer had a definitive result.

## Why This Change Was Made

- Upgrade a reused stable send to one exact renewable SQLite owner before channel preparation.
- Renew that same claim through preparation and provider execution; abort before further provider or queue mutation when ownership is definitively lost.
- Keep `producer_claimed`, `send_attempt_started`, and explicit `unknown_after_send` rows fenced while the stable lease is live.
- Use the existing Gateway-owned five-second retry loop as the only recovery scheduler. Startup migration still runs once, periodic drains use fresh runtime config, and expired leases are picked up by the next tick.
- Fence recovery synchronously during Gateway close and await actual in-flight settlement before plugin/channel teardown.
- Warn after five seconds if recovery is still pending; the process-level shutdown watchdog remains the forced-exit owner.

This integrates with the single recovery owner landed in https://github.com/openclaw/openclaw/pull/118694. It deliberately removes the stacked branch's duplicate exact-expiry timer and `nextRecoveryAt` contract.

No SQLite schema version, DDL, or migration is added. `requiresProducerClaim` remains metadata in the existing queue entry JSON.

## User Impact

Long-running outbound sends no longer become eligible for concurrent recovery while their original producer still owns the attempt. This reduces duplicate real-world sends and keeps restart recovery conservative when the platform outcome is unknown.

Recovery may begin up to five seconds after an expired lease. That bounded delay is intentional: one lifecycle-owned scheduler is safer than competing interval and exact-expiry timers.

Shutdown now keeps plugin/channel runtime alive until any admitted recovery settles. Providers do not expose a universal acknowledged-cancellation contract, so a local timeout cannot safely prove that delivery work has stopped.

## Evidence

- Exact-head focused proof: 189/189 tests passed across eight files.
- Gateway lifecycle/import-boundary proof: 32/32 passed.
- Lease, SQLite, storage, recovery, and delivery integration proof: 157/157 passed.
- Covered behavior includes active-lease skip, post-expiry recovery, renewal through long preparation, exact-owner replacement, lease loss before and after dispatch, `unknown_after_send` retention, fresh-config retries, non-overlap, suspended admission, idempotent stop, startup-recovery join, and warning-only shutdown wait.
- `git diff --check` passed.
- Targeted `oxfmt` passed.
- Exact-head autoreview passed with no accepted/actionable findings (`patch is correct`, confidence 0.91).
- Production delta: +348/-35. Test delta: +965/-9. Total: 22 files.

No `CHANGELOG.md` edit: release generation owns changelog entries for normal PRs.
