### PR TITLE
fix(media): clean empty host staging directories

### DIFF
--- a/src/auto-reply/reply.block-streaming.test.ts
+++ b/src/auto-reply/reply.block-streaming.test.ts
@@ -68,6 +68,7 @@ vi.mock("./reply/session-reset-model.runtime.js", () => ({
 }));
 vi.mock("./reply/stage-sandbox-media.runtime.js", () => ({
   cleanupEmptyHostWorkspaceStagingDir: vi.fn(async () => undefined),
+  cleanupHostWorkspaceStagingFiles: vi.fn(async () => undefined),
   stageSandboxMedia: vi.fn(async () => ({ staged: new Map() })),
 }));
 vi.mock("./reply/typing.js", () => ({

--- a/src/auto-reply/reply.block-streaming.test.ts
+++ b/src/auto-reply/reply.block-streaming.test.ts
@@ -67,7 +67,8 @@ vi.mock("./reply/session-reset-model.runtime.js", () => ({
   applyResetModelOverride: vi.fn(async () => undefined),
 }));
 vi.mock("./reply/stage-sandbox-media.runtime.js", () => ({
-  stageSandboxMedia: vi.fn(async () => undefined),
+  cleanupEmptyHostWorkspaceStagingDir: vi.fn(async () => undefined),
+  stageSandboxMedia: vi.fn(async () => ({ staged: new Map() })),
 }));
 vi.mock("./reply/typing.js", () => ({
   createTypingController: vi.fn(() => createMockTypingController()),

--- a/src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts
@@ -4,7 +4,10 @@ import path, { basename, dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MEDIA_MAX_BYTES } from "../media/store.js";
-import { stageSandboxMedia } from "./reply/stage-sandbox-media.js";
+import {
+  cleanupEmptyHostWorkspaceStagingDir,
+  stageSandboxMedia,
+} from "./reply/stage-sandbox-media.js";
 import {
   createSandboxMediaContexts,
   createSandboxMediaStageConfig,
@@ -224,15 +227,27 @@ describe("stageSandboxMedia", () => {
 
       const stagedPath = ctx.media?.[0]?.path ?? "";
       const stagedRelativePath = path.relative(workspaceDir, stagedPath);
+      const hostWorkspaceStagingDir = result.hostWorkspaceStagingDir;
       expect(stagedRelativePath).toMatch(
         new RegExp(`^media/inbound/openclaw-staged-[0-9a-f-]+/${fileName}$`),
       );
       expect(result.staged.get(0)).toBe(stagedPath);
+      expect(hostWorkspaceStagingDir).toBe(dirname(stagedPath));
+      if (!hostWorkspaceStagingDir) {
+        throw new Error("expected host workspace staging directory");
+      }
       expect(sessionCtx.media?.[0]?.path).toBe(stagedPath);
       expect(ctx.media?.[0]).toMatchObject({ path: stagedPath, workspaceDir });
       expect(sessionCtx.media?.[0]).toMatchObject({ path: stagedPath, workspaceDir });
       await expect(fs.readFile(stagedPath, "utf8")).resolves.toBe("host-image-bytes");
       await expect(fs.readFile(existingProjectFile, "utf8")).resolves.toBe("project-file");
+      await cleanupEmptyHostWorkspaceStagingDir(hostWorkspaceStagingDir);
+      await expect(fs.readFile(stagedPath, "utf8")).resolves.toBe("host-image-bytes");
+      await fs.unlink(stagedPath);
+      await cleanupEmptyHostWorkspaceStagingDir(hostWorkspaceStagingDir);
+      await expect(fs.lstat(hostWorkspaceStagingDir)).rejects.toMatchObject({
+        code: "ENOENT",
+      });
 
       const blockedPath = join(home, "blocked-host.png");
       await fs.writeFile(blockedPath, "blocked");

--- a/src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MEDIA_MAX_BYTES } from "../media/store.js";
 import {
   cleanupEmptyHostWorkspaceStagingDir,
+  cleanupHostWorkspaceStagingFiles,
   stageSandboxMedia,
 } from "./reply/stage-sandbox-media.js";
 import {
@@ -243,7 +244,15 @@ describe("stageSandboxMedia", () => {
       await expect(fs.readFile(existingProjectFile, "utf8")).resolves.toBe("project-file");
       await cleanupEmptyHostWorkspaceStagingDir(hostWorkspaceStagingDir);
       await expect(fs.readFile(stagedPath, "utf8")).resolves.toBe("host-image-bytes");
-      await fs.unlink(stagedPath);
+      const unrelatedPath = join(hostWorkspaceStagingDir, "agent-output.txt");
+      await fs.writeFile(unrelatedPath, "keep");
+      await cleanupHostWorkspaceStagingFiles({
+        stagingDir: hostWorkspaceStagingDir,
+        stagedFiles: result.staged.values(),
+      });
+      await expect(fs.lstat(stagedPath)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.readFile(unrelatedPath, "utf8")).resolves.toBe("keep");
+      await fs.unlink(unrelatedPath);
       await cleanupEmptyHostWorkspaceStagingDir(hostWorkspaceStagingDir);
       await expect(fs.lstat(hostWorkspaceStagingDir)).rejects.toMatchObject({
         code: "ENOENT",

--- a/src/auto-reply/reply/agent-runner-core.ts
+++ b/src/auto-reply/reply/agent-runner-core.ts
@@ -530,6 +530,7 @@ export type RunReplyAgentParams = {
   queueAdmissionState?: "empty" | "steering" | "ready";
   isActive: boolean;
   isRunActive?: () => boolean;
+  onHostStagingOwnershipTransferred?: (settlement?: PromiseLike<void>) => void;
   opts?: InternalGetReplyOptions;
   typing: TypingController;
   sessionEntry?: SessionEntry;

--- a/src/auto-reply/reply/agent-runner-run.ts
+++ b/src/auto-reply/reply/agent-runner-run.ts
@@ -226,6 +226,7 @@ export async function runReplyAgent(
     replyRunState.bindQueueDispositionToRunState(followupRun, replyOperationRunState);
     await runActiveReplySteer({
       followupRun,
+      onHostStagingOwnershipTransferred: params.onHostStagingOwnershipTransferred,
       opts,
       providedReplyOperation,
       queueKey,
@@ -275,6 +276,7 @@ export async function runReplyAgent(
       typing.cleanup();
       return undefined;
     }
+    params.onHostStagingOwnershipTransferred?.();
     if (replyOperationRunState) {
       replyOperationRunState.admission = { status: "accepted", mode: "followup" };
     }

--- a/src/auto-reply/reply/agent-runner-steer-adoption.ts
+++ b/src/auto-reply/reply/agent-runner-steer-adoption.ts
@@ -25,6 +25,7 @@ import type { TypingSignaler } from "./typing-mode.js";
 
 type ActiveReplySteerParams = {
   followupRun: RunReplyAgentParams["followupRun"];
+  onHostStagingOwnershipTransferred: RunReplyAgentParams["onHostStagingOwnershipTransferred"];
   opts: RunReplyAgentParams["opts"];
   providedReplyOperation: ReplyOperation | undefined;
   queueKey: string;
@@ -138,6 +139,24 @@ export async function runActiveReplySteer(params: ActiveReplySteerParams): Promi
     params.providedReplyOperation?.key === sessionKey
       ? params.providedReplyOperation
       : (registeredReplyOperation ?? params.providedReplyOperation);
+  const activeOwnerSettlement = params.onHostStagingOwnershipTransferred
+    ? expectDefined(activeReplyOperation?.ownerSettlement, "active reply owner settlement")
+    : undefined;
+  let stagingOwnershipTransferred = false;
+  const transferStagingToQueue = () => {
+    if (stagingOwnershipTransferred) {
+      return;
+    }
+    stagingOwnershipTransferred = true;
+    params.onHostStagingOwnershipTransferred?.();
+  };
+  const transferStagingToActiveRun = () => {
+    if (stagingOwnershipTransferred || !activeOwnerSettlement) {
+      return;
+    }
+    stagingOwnershipTransferred = true;
+    params.onHostStagingOwnershipTransferred?.(activeOwnerSettlement);
+  };
   const steerSessionId = activeReplyOperation?.sessionId ?? followupRun.run.sessionId;
   const parked = parkSteerCandidate(queueKey, followupRun, resolvedQueue, runFollowup);
   if (!parked) {
@@ -167,6 +186,7 @@ export async function runActiveReplySteer(params: ActiveReplySteerParams): Promi
       return "handled";
     }
     if (admission === "fallback") {
+      transferStagingToQueue();
       parked.fallback();
       if (replyOperationRunState) {
         replyOperationRunState.admission = { status: "accepted", mode: "followup" };
@@ -201,6 +221,7 @@ export async function runActiveReplySteer(params: ActiveReplySteerParams): Promi
       },
     );
     if (!steerOutcome.queued) {
+      transferStagingToQueue();
       parked.fallback();
       if (replyOperationRunState) {
         replyOperationRunState.admission = { status: "accepted", mode: "followup" };
@@ -211,6 +232,7 @@ export async function runActiveReplySteer(params: ActiveReplySteerParams): Promi
       typing.cleanup();
       return "handled";
     }
+    transferStagingToActiveRun();
     const adoptionDisposition = await finalizeAcceptedSteer({
       activeReplyOperation,
       abortKey: sessionKey ?? queueKey,
@@ -240,6 +262,7 @@ export async function runActiveReplySteer(params: ActiveReplySteerParams): Promi
     if (resolveFollowupAbortSignal(followupRun)?.aborted) {
       parked.consume();
     } else {
+      transferStagingToQueue();
       parked.fallback();
     }
     throw error;
@@ -248,6 +271,7 @@ export async function runActiveReplySteer(params: ActiveReplySteerParams): Promi
       if (resolveFollowupAbortSignal(followupRun)?.aborted) {
         parked.consume();
       } else {
+        transferStagingToQueue();
         parked.fallback();
       }
     }

--- a/src/auto-reply/reply/agent-runner-steer-adoption.ts
+++ b/src/auto-reply/reply/agent-runner-steer-adoption.ts
@@ -139,9 +139,7 @@ export async function runActiveReplySteer(params: ActiveReplySteerParams): Promi
     params.providedReplyOperation?.key === sessionKey
       ? params.providedReplyOperation
       : (registeredReplyOperation ?? params.providedReplyOperation);
-  const activeOwnerSettlement = params.onHostStagingOwnershipTransferred
-    ? expectDefined(activeReplyOperation?.ownerSettlement, "active reply owner settlement")
-    : undefined;
+  const activeOwnerSettlement = activeReplyOperation?.ownerSettlement;
   let stagingOwnershipTransferred = false;
   const transferStagingToQueue = () => {
     if (stagingOwnershipTransferred) {
@@ -151,7 +149,11 @@ export async function runActiveReplySteer(params: ActiveReplySteerParams): Promi
     params.onHostStagingOwnershipTransferred?.();
   };
   const transferStagingToActiveRun = () => {
-    if (stagingOwnershipTransferred || !activeOwnerSettlement) {
+    if (stagingOwnershipTransferred) {
+      return;
+    }
+    if (!activeOwnerSettlement) {
+      transferStagingToQueue();
       return;
     }
     stagingOwnershipTransferred = true;

--- a/src/auto-reply/reply/agent-runner.media-paths.test.ts
+++ b/src/auto-reply/reply/agent-runner.media-paths.test.ts
@@ -580,6 +580,7 @@ describe("runReplyAgent media path normalization", () => {
       resetTriggered: false,
     });
     operation.setPhase("running");
+    const onHostStagingOwnershipTransferred = vi.fn();
     expect(operation.acceptedSteeredInboundAudio).toBe(false);
     queueEmbeddedAgentMessageWithOutcomeAsyncMock.mockImplementation(async (sessionId: string) => ({
       queued: true,
@@ -591,6 +592,7 @@ describe("runReplyAgent media path normalization", () => {
     await runReplyAgent(
       makeRunReplyAgentParams({
         replyOperation: operation,
+        onHostStagingOwnershipTransferred,
         sessionKey: "agent:main:whatsapp:direct:chat-1",
         resolvedQueue: { mode: "steer" } as QueueSettings,
         shouldSteer: true,
@@ -618,13 +620,18 @@ describe("runReplyAgent media path normalization", () => {
       },
     );
     expect(enqueueFollowupRunMock).not.toHaveBeenCalled();
+    expect(onHostStagingOwnershipTransferred).toHaveBeenCalledOnce();
+    expect(onHostStagingOwnershipTransferred).toHaveBeenCalledWith(operation.ownerSettlement);
     expect(parkedSteerConsumeMock).toHaveBeenCalledOnce();
     expect(parkedSteerFallbackMock).not.toHaveBeenCalled();
   });
 
   it("queues active prompts in followup mode without steering", async () => {
+    const onHostStagingOwnershipTransferred = vi.fn();
+    enqueueFollowupRunMock.mockReturnValueOnce(true);
     await runReplyAgent(
       makeRunReplyAgentParams({
+        onHostStagingOwnershipTransferred,
         resolvedQueue: { mode: "followup" } as QueueSettings,
         shouldSteer: false,
         shouldFollowup: true,
@@ -637,9 +644,36 @@ describe("runReplyAgent media path normalization", () => {
     expect(parkSteerCandidateMock).not.toHaveBeenCalled();
     expect(enqueueFollowupRunMock).toHaveBeenCalledOnce();
     expect(enqueueFollowupRunMock.mock.calls[0]?.[1].prompt).toBe("generate chart");
+    expect(onHostStagingOwnershipTransferred).toHaveBeenCalledOnce();
+    expect(onHostStagingOwnershipTransferred).toHaveBeenCalledWith();
+  });
+
+  it("keeps host staging with the caller when followup enqueue rejects", async () => {
+    const onHostStagingOwnershipTransferred = vi.fn();
+    enqueueFollowupRunMock.mockReturnValueOnce(false);
+
+    await runReplyAgent(
+      makeRunReplyAgentParams({
+        onHostStagingOwnershipTransferred,
+        resolvedQueue: { mode: "followup" } as QueueSettings,
+        shouldSteer: false,
+        shouldFollowup: true,
+        isActive: true,
+      }),
+    );
+
+    expect(enqueueFollowupRunMock).toHaveBeenCalledOnce();
+    expect(onHostStagingOwnershipTransferred).not.toHaveBeenCalled();
   });
 
   it("falls back to a queued followup when active steering is rejected", async () => {
+    const operation = createRegisteredReplyOperation({
+      sessionKey: "main",
+      sessionId: "session",
+      resetTriggered: false,
+    });
+    operation.setPhase("running");
+    const onHostStagingOwnershipTransferred = vi.fn();
     queueEmbeddedAgentMessageWithOutcomeAsyncMock.mockImplementation(async (sessionId: string) => ({
       queued: false,
       sessionId,
@@ -650,6 +684,8 @@ describe("runReplyAgent media path normalization", () => {
 
     await runReplyAgent(
       makeRunReplyAgentParams({
+        replyOperation: operation,
+        onHostStagingOwnershipTransferred,
         resolvedQueue: { mode: "steer" } as QueueSettings,
         shouldSteer: true,
         shouldFollowup: true,
@@ -667,6 +703,8 @@ describe("runReplyAgent media path normalization", () => {
     expect(parkedSteerFallbackMock).toHaveBeenCalledOnce();
     expect(parkedSteerConsumeMock).not.toHaveBeenCalled();
     expect(enqueueFollowupRunMock).not.toHaveBeenCalled();
+    expect(onHostStagingOwnershipTransferred).toHaveBeenCalledOnce();
+    expect(onHostStagingOwnershipTransferred).toHaveBeenCalledWith();
   });
 
   it("shares one media cache between block accumulation and final payload delivery", async () => {

--- a/src/auto-reply/reply/agent-runner.media-paths.test.ts
+++ b/src/auto-reply/reply/agent-runner.media-paths.test.ts
@@ -494,6 +494,7 @@ describe("runReplyAgent media path normalization", () => {
   });
 
   it("steers ordered current-turn images with the active prompt", async () => {
+    const onHostStagingOwnershipTransferred = vi.fn();
     queueEmbeddedAgentMessageWithOutcomeAsyncMock.mockImplementation(async (sessionId: string) => ({
       queued: true,
       sessionId,
@@ -513,6 +514,7 @@ describe("runReplyAgent media path normalization", () => {
 
     await runReplyAgent(
       makeRunReplyAgentParams({
+        onHostStagingOwnershipTransferred,
         resolvedQueue: { mode: "steer" } as QueueSettings,
         shouldSteer: true,
         shouldFollowup: true,
@@ -537,6 +539,8 @@ describe("runReplyAgent media path normalization", () => {
       },
     );
     expect(enqueueFollowupRunMock).not.toHaveBeenCalled();
+    expect(onHostStagingOwnershipTransferred).toHaveBeenCalledOnce();
+    expect(onHostStagingOwnershipTransferred).toHaveBeenCalledWith();
     expect(parkedSteerConsumeMock).toHaveBeenCalledOnce();
     expect(parkedSteerFallbackMock).not.toHaveBeenCalled();
   });

--- a/src/auto-reply/reply/get-reply-run-execute.ts
+++ b/src/auto-reply/reply/get-reply-run-execute.ts
@@ -308,6 +308,7 @@ export async function executePreparedReplyRun(state: PreparedReplyRunAdmission) 
     ...(queuedFollowupAbortSignal ? { abortSignal: queuedFollowupAbortSignal } : {}),
     deliveryCorrelations: opts?.queuedDeliveryCorrelations,
     turnAdoptionLifecycle: opts?.turnAdoptionLifecycle,
+    onQueueSettled: params.onQueuedFollowupSettled,
     onReplyAdmissionWaitChange: opts?.onReplyAdmissionWaitChange,
     ...(opts?.onFollowupQueueDisposition
       ? { onQueueDisposition: opts.onFollowupQueueDisposition }

--- a/src/auto-reply/reply/get-reply-run-execute.ts
+++ b/src/auto-reply/reply/get-reply-run-execute.ts
@@ -456,6 +456,7 @@ export async function executePreparedReplyRun(state: PreparedReplyRunAdmission) 
     shouldFollowup,
     queueAdmissionState,
     isActive,
+    onHostStagingOwnershipTransferred: params.onHostStagingOwnershipTransferred,
     isRunActive: () => {
       const latestSessionState = resolvePreparedSessionState();
       const latestActiveSessionId =

--- a/src/auto-reply/reply/get-reply-run.types.ts
+++ b/src/auto-reply/reply/get-reply-run.types.ts
@@ -87,6 +87,8 @@ export type RunPreparedReplyParams = {
   };
   typing: TypingController;
   opts?: InternalGetReplyOptions;
+  /** Retries host staging cleanup after a queued consumer leaves the queue lifecycle. */
+  onQueuedFollowupSettled?: () => void;
   defaultModel: string;
   timeoutMs: number;
   isNewSession: boolean;

--- a/src/auto-reply/reply/get-reply-run.types.ts
+++ b/src/auto-reply/reply/get-reply-run.types.ts
@@ -89,6 +89,8 @@ export type RunPreparedReplyParams = {
   opts?: InternalGetReplyOptions;
   /** Retries host staging cleanup after a queued consumer leaves the queue lifecycle. */
   onQueuedFollowupSettled?: () => void;
+  /** Transfers host staging cleanup to the lifecycle that will finish consuming it. */
+  onHostStagingOwnershipTransferred?: (settlement?: PromiseLike<void>) => void;
   defaultModel: string;
   timeoutMs: number;
   isNewSession: boolean;

--- a/src/auto-reply/reply/get-reply.message-hooks.test.ts
+++ b/src/auto-reply/reply/get-reply.message-hooks.test.ts
@@ -55,6 +55,7 @@ let getReplyFromConfig: typeof import("./get-reply.js").getReplyFromConfig;
 let resolveDefaultModelMock: typeof import("./directive-handling.defaults.js").resolveDefaultModel;
 let runPreparedReplyMock: typeof import("./get-reply-run.js").runPreparedReply;
 let cleanupEmptyHostWorkspaceStagingDirMock: typeof import("./stage-sandbox-media.runtime.js").cleanupEmptyHostWorkspaceStagingDir;
+let cleanupHostWorkspaceStagingFilesMock: typeof import("./stage-sandbox-media.runtime.js").cleanupHostWorkspaceStagingFiles;
 let stageSandboxMediaMock: typeof import("./stage-sandbox-media.runtime.js").stageSandboxMedia;
 
 async function loadGetReplyRuntimeForTest() {
@@ -64,6 +65,7 @@ async function loadGetReplyRuntimeForTest() {
   ({ runPreparedReply: runPreparedReplyMock } = await import("./get-reply-run.js"));
   ({
     cleanupEmptyHostWorkspaceStagingDir: cleanupEmptyHostWorkspaceStagingDirMock,
+    cleanupHostWorkspaceStagingFiles: cleanupHostWorkspaceStagingFilesMock,
     stageSandboxMedia: stageSandboxMediaMock,
   } = await import("./stage-sandbox-media.runtime.js"));
 }
@@ -136,6 +138,7 @@ async function resetMessageHookTestState() {
   vi.mocked(resolveDefaultModelMock).mockReset();
   vi.mocked(runPreparedReplyMock).mockReset();
   vi.mocked(cleanupEmptyHostWorkspaceStagingDirMock).mockReset();
+  vi.mocked(cleanupHostWorkspaceStagingFilesMock).mockReset();
   vi.mocked(stageSandboxMediaMock).mockReset();
   vi.mocked(logVerbose).mockReset();
 
@@ -178,6 +181,7 @@ async function resetMessageHookTestState() {
   });
   vi.mocked(runPreparedReplyMock).mockResolvedValue({ text: "ok" });
   vi.mocked(cleanupEmptyHostWorkspaceStagingDirMock).mockResolvedValue(undefined);
+  vi.mocked(cleanupHostWorkspaceStagingFilesMock).mockResolvedValue(undefined);
   vi.mocked(stageSandboxMediaMock).mockResolvedValue({ staged: new Map() });
   mocks.resolveReplySessionPreprocessingState.mockReturnValue({
     sessionEntry: undefined,
@@ -712,10 +716,9 @@ describe("getReplyFromConfig message hooks", () => {
     );
   });
 
-  it("cleans an empty host staging directory after the prepared reply settles", async () => {
+  it("releases exact host staging files when no deferred owner accepts them", async () => {
     const hostWorkspaceStagingDir = "/tmp/openclaw-staged-media";
-    const order: string[] = [];
-    let onQueuedFollowupSettled: (() => void) | undefined;
+    const stagedFile = `${hostWorkspaceStagingDir}/voice.ogg`;
     mocks.resolveReplyDirectives.mockResolvedValueOnce(
       createGetReplyContinueDirectivesResult({
         body: "voice transcript",
@@ -729,20 +732,12 @@ describe("getReplyFromConfig message hooks", () => {
       }),
     );
     vi.mocked(stageSandboxMediaMock).mockImplementationOnce(async () => {
-      order.push("stage");
       return {
-        staged: new Map([[0, `${hostWorkspaceStagingDir}/voice.ogg`]]),
+        staged: new Map([[0, stagedFile]]),
         hostWorkspaceStagingDir,
       };
     });
-    vi.mocked(runPreparedReplyMock).mockImplementationOnce(async (params) => {
-      order.push("run");
-      onQueuedFollowupSettled = params.onQueuedFollowupSettled;
-      return { text: "ok" };
-    });
-    vi.mocked(cleanupEmptyHostWorkspaceStagingDirMock).mockImplementation(async (dir) => {
-      order.push(`cleanup:${dir}`);
-    });
+    vi.mocked(runPreparedReplyMock).mockResolvedValueOnce({ text: "ok" });
 
     await expect(
       getReplyFromConfig(buildCtx(), undefined, withFastReplyConfig({})),
@@ -750,19 +745,86 @@ describe("getReplyFromConfig message hooks", () => {
       text: "ok",
     });
 
-    expect(order).toEqual(["stage", "run", `cleanup:${hostWorkspaceStagingDir}`]);
-    expect(onQueuedFollowupSettled).toBeTypeOf("function");
+    expect(cleanupHostWorkspaceStagingFilesMock).toHaveBeenCalledOnce();
+    expect(cleanupHostWorkspaceStagingFilesMock).toHaveBeenCalledWith({
+      stagingDir: hostWorkspaceStagingDir,
+      stagedFiles: [stagedFile],
+    });
+    expect(cleanupEmptyHostWorkspaceStagingDirMock).not.toHaveBeenCalled();
+  });
 
+  it("defers exact host staging cleanup to the queued source lifecycle", async () => {
+    const hostWorkspaceStagingDir = "/tmp/openclaw-staged-media";
+    const stagedFile = `${hostWorkspaceStagingDir}/voice.ogg`;
+    let onQueuedFollowupSettled: (() => void) | undefined;
+    mocks.resolveReplyDirectives.mockResolvedValueOnce(
+      createGetReplyContinueDirectivesResult({
+        body: "voice transcript",
+        abortKey: "telegram:-100123",
+        from: "telegram:user:42",
+        to: "telegram:-100123",
+        senderId: "telegram:user:42",
+        commandSource: "text",
+        senderIsOwner: true,
+        resetHookTriggered: false,
+      }),
+    );
+    vi.mocked(stageSandboxMediaMock).mockResolvedValueOnce({
+      staged: new Map([[0, stagedFile]]),
+      hostWorkspaceStagingDir,
+    });
+    vi.mocked(runPreparedReplyMock).mockImplementationOnce(async (params) => {
+      params.onHostStagingOwnershipTransferred?.();
+      onQueuedFollowupSettled = params.onQueuedFollowupSettled;
+      return { text: "ok" };
+    });
+
+    await getReplyFromConfig(buildCtx(), undefined, withFastReplyConfig({}));
+
+    expect(cleanupEmptyHostWorkspaceStagingDirMock).toHaveBeenCalledWith(hostWorkspaceStagingDir);
+    expect(cleanupHostWorkspaceStagingFilesMock).not.toHaveBeenCalled();
     onQueuedFollowupSettled?.();
     await vi.waitFor(() => {
-      expect(cleanupEmptyHostWorkspaceStagingDirMock).toHaveBeenCalledTimes(2);
+      expect(cleanupHostWorkspaceStagingFilesMock).toHaveBeenCalledOnce();
     });
-    expect(order).toEqual([
-      "stage",
-      "run",
-      `cleanup:${hostWorkspaceStagingDir}`,
-      `cleanup:${hostWorkspaceStagingDir}`,
-    ]);
+  });
+
+  it("keeps accepted-steer staging until the active operation settles", async () => {
+    const hostWorkspaceStagingDir = "/tmp/openclaw-staged-media";
+    const stagedFile = `${hostWorkspaceStagingDir}/voice.ogg`;
+    let settleOperation: (() => void) | undefined;
+    const ownerSettlement = new Promise<void>((resolve) => {
+      settleOperation = resolve;
+    });
+    mocks.resolveReplyDirectives.mockResolvedValueOnce(
+      createGetReplyContinueDirectivesResult({
+        body: "voice transcript",
+        abortKey: "telegram:-100123",
+        from: "telegram:user:42",
+        to: "telegram:-100123",
+        senderId: "telegram:user:42",
+        commandSource: "text",
+        senderIsOwner: true,
+        resetHookTriggered: false,
+      }),
+    );
+    vi.mocked(stageSandboxMediaMock).mockResolvedValueOnce({
+      staged: new Map([[0, stagedFile]]),
+      hostWorkspaceStagingDir,
+    });
+    vi.mocked(runPreparedReplyMock).mockImplementationOnce(async (params) => {
+      params.onHostStagingOwnershipTransferred?.(ownerSettlement);
+      params.onQueuedFollowupSettled?.();
+      return { text: "ok" };
+    });
+
+    await getReplyFromConfig(buildCtx(), undefined, withFastReplyConfig({}));
+
+    expect(cleanupHostWorkspaceStagingFilesMock).not.toHaveBeenCalled();
+    settleOperation?.();
+    await vi.waitFor(() => {
+      expect(cleanupHostWorkspaceStagingFilesMock).toHaveBeenCalledOnce();
+    });
   });
 
   it("emits only preprocessed when no transcript is produced", async () => {

--- a/src/auto-reply/reply/get-reply.message-hooks.test.ts
+++ b/src/auto-reply/reply/get-reply.message-hooks.test.ts
@@ -715,6 +715,7 @@ describe("getReplyFromConfig message hooks", () => {
   it("cleans an empty host staging directory after the prepared reply settles", async () => {
     const hostWorkspaceStagingDir = "/tmp/openclaw-staged-media";
     const order: string[] = [];
+    let onQueuedFollowupSettled: (() => void) | undefined;
     mocks.resolveReplyDirectives.mockResolvedValueOnce(
       createGetReplyContinueDirectivesResult({
         body: "voice transcript",
@@ -734,11 +735,12 @@ describe("getReplyFromConfig message hooks", () => {
         hostWorkspaceStagingDir,
       };
     });
-    vi.mocked(runPreparedReplyMock).mockImplementationOnce(async () => {
+    vi.mocked(runPreparedReplyMock).mockImplementationOnce(async (params) => {
       order.push("run");
+      onQueuedFollowupSettled = params.onQueuedFollowupSettled;
       return { text: "ok" };
     });
-    vi.mocked(cleanupEmptyHostWorkspaceStagingDirMock).mockImplementationOnce(async (dir) => {
+    vi.mocked(cleanupEmptyHostWorkspaceStagingDirMock).mockImplementation(async (dir) => {
       order.push(`cleanup:${dir}`);
     });
 
@@ -749,6 +751,18 @@ describe("getReplyFromConfig message hooks", () => {
     });
 
     expect(order).toEqual(["stage", "run", `cleanup:${hostWorkspaceStagingDir}`]);
+    expect(onQueuedFollowupSettled).toBeTypeOf("function");
+
+    onQueuedFollowupSettled?.();
+    await vi.waitFor(() => {
+      expect(cleanupEmptyHostWorkspaceStagingDirMock).toHaveBeenCalledTimes(2);
+    });
+    expect(order).toEqual([
+      "stage",
+      "run",
+      `cleanup:${hostWorkspaceStagingDir}`,
+      `cleanup:${hostWorkspaceStagingDir}`,
+    ]);
   });
 
   it("emits only preprocessed when no transcript is produced", async () => {

--- a/src/auto-reply/reply/get-reply.message-hooks.test.ts
+++ b/src/auto-reply/reply/get-reply.message-hooks.test.ts
@@ -54,6 +54,7 @@ registerGetReplyRuntimeOverrides(mocks);
 let getReplyFromConfig: typeof import("./get-reply.js").getReplyFromConfig;
 let resolveDefaultModelMock: typeof import("./directive-handling.defaults.js").resolveDefaultModel;
 let runPreparedReplyMock: typeof import("./get-reply-run.js").runPreparedReply;
+let cleanupEmptyHostWorkspaceStagingDirMock: typeof import("./stage-sandbox-media.runtime.js").cleanupEmptyHostWorkspaceStagingDir;
 let stageSandboxMediaMock: typeof import("./stage-sandbox-media.runtime.js").stageSandboxMedia;
 
 async function loadGetReplyRuntimeForTest() {
@@ -61,7 +62,10 @@ async function loadGetReplyRuntimeForTest() {
   ({ resolveDefaultModel: resolveDefaultModelMock } =
     await import("./directive-handling.defaults.js"));
   ({ runPreparedReply: runPreparedReplyMock } = await import("./get-reply-run.js"));
-  ({ stageSandboxMedia: stageSandboxMediaMock } = await import("./stage-sandbox-media.runtime.js"));
+  ({
+    cleanupEmptyHostWorkspaceStagingDir: cleanupEmptyHostWorkspaceStagingDirMock,
+    stageSandboxMedia: stageSandboxMediaMock,
+  } = await import("./stage-sandbox-media.runtime.js"));
 }
 
 function emptyAliasIndex() {
@@ -131,6 +135,7 @@ async function resetMessageHookTestState() {
   mocks.resolveReplySessionPreprocessingState.mockReset();
   vi.mocked(resolveDefaultModelMock).mockReset();
   vi.mocked(runPreparedReplyMock).mockReset();
+  vi.mocked(cleanupEmptyHostWorkspaceStagingDirMock).mockReset();
   vi.mocked(stageSandboxMediaMock).mockReset();
   vi.mocked(logVerbose).mockReset();
 
@@ -172,6 +177,7 @@ async function resetMessageHookTestState() {
     aliasIndex: emptyAliasIndex(),
   });
   vi.mocked(runPreparedReplyMock).mockResolvedValue({ text: "ok" });
+  vi.mocked(cleanupEmptyHostWorkspaceStagingDirMock).mockResolvedValue(undefined);
   vi.mocked(stageSandboxMediaMock).mockResolvedValue({ staged: new Map() });
   mocks.resolveReplySessionPreprocessingState.mockReturnValue({
     sessionEntry: undefined,
@@ -704,6 +710,45 @@ describe("getReplyFromConfig message hooks", () => {
         workspaceDir: "/tmp/workspace",
       }),
     );
+  });
+
+  it("cleans an empty host staging directory after the prepared reply settles", async () => {
+    const hostWorkspaceStagingDir = "/tmp/openclaw-staged-media";
+    const order: string[] = [];
+    mocks.resolveReplyDirectives.mockResolvedValueOnce(
+      createGetReplyContinueDirectivesResult({
+        body: "voice transcript",
+        abortKey: "telegram:-100123",
+        from: "telegram:user:42",
+        to: "telegram:-100123",
+        senderId: "telegram:user:42",
+        commandSource: "text",
+        senderIsOwner: true,
+        resetHookTriggered: false,
+      }),
+    );
+    vi.mocked(stageSandboxMediaMock).mockImplementationOnce(async () => {
+      order.push("stage");
+      return {
+        staged: new Map([[0, `${hostWorkspaceStagingDir}/voice.ogg`]]),
+        hostWorkspaceStagingDir,
+      };
+    });
+    vi.mocked(runPreparedReplyMock).mockImplementationOnce(async () => {
+      order.push("run");
+      return { text: "ok" };
+    });
+    vi.mocked(cleanupEmptyHostWorkspaceStagingDirMock).mockImplementationOnce(async (dir) => {
+      order.push(`cleanup:${dir}`);
+    });
+
+    await expect(
+      getReplyFromConfig(buildCtx(), undefined, withFastReplyConfig({})),
+    ).resolves.toEqual({
+      text: "ok",
+    });
+
+    expect(order).toEqual(["stage", "run", `cleanup:${hostWorkspaceStagingDir}`]);
   });
 
   it("emits only preprocessed when no transcript is produced", async () => {

--- a/src/auto-reply/reply/get-reply.test-mocks.ts
+++ b/src/auto-reply/reply/get-reply.test-mocks.ts
@@ -78,7 +78,8 @@ vi.mock("./session-reset-model.runtime.js", () => ({
 }));
 
 vi.mock("./stage-sandbox-media.runtime.js", () => ({
-  stageSandboxMedia: vi.fn(async () => undefined),
+  cleanupEmptyHostWorkspaceStagingDir: vi.fn(async () => undefined),
+  stageSandboxMedia: vi.fn(async () => ({ staged: new Map() })),
 }));
 
 vi.mock("./typing.js", () => ({

--- a/src/auto-reply/reply/get-reply.test-mocks.ts
+++ b/src/auto-reply/reply/get-reply.test-mocks.ts
@@ -79,6 +79,7 @@ vi.mock("./session-reset-model.runtime.js", () => ({
 
 vi.mock("./stage-sandbox-media.runtime.js", () => ({
   cleanupEmptyHostWorkspaceStagingDir: vi.fn(async () => undefined),
+  cleanupHostWorkspaceStagingFiles: vi.fn(async () => undefined),
   stageSandboxMedia: vi.fn(async () => ({ staged: new Map() })),
 }));
 

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -1144,6 +1144,13 @@ export async function getReplyFromConfig(
         perMessageQueueOptions,
         typing,
         opts: withExtractedFileImages(resolvedOpts, extractedFileImages),
+        ...(hostWorkspaceStagingDir && cleanupEmptyHostWorkspaceStagingDir
+          ? {
+              onQueuedFollowupSettled: () => {
+                void cleanupEmptyHostWorkspaceStagingDir(hostWorkspaceStagingDir);
+              },
+            }
+          : {}),
         defaultModel,
         timeoutMs,
         isNewSession,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -1078,7 +1078,13 @@ export async function getReplyFromConfig(
   }
 
   let hostWorkspaceStagingDir: string | undefined;
+  let hostWorkspaceStagedFiles: string[] = [];
   let cleanupEmptyHostWorkspaceStagingDir: ((stagingDir?: string) => Promise<void>) | undefined;
+  let cleanupHostWorkspaceStagingFiles:
+    | ((params: { stagingDir?: string; stagedFiles: Iterable<string> }) => Promise<void>)
+    | undefined;
+  let hostStagingOwner: "caller" | "queue" | "operation" = "caller";
+  let hostStagingCleanup: Promise<void> | undefined;
   // Already-staged facts or SDK projections must remain a single-stage contract.
   if (
     !useFastTestBootstrap &&
@@ -1087,8 +1093,11 @@ export async function getReplyFromConfig(
     !hasStagedMediaFacts(ctx.media) &&
     hasInboundMedia(ctx)
   ) {
-    const { cleanupEmptyHostWorkspaceStagingDir: cleanupStagingDir, stageSandboxMedia } =
-      await loadStageSandboxMediaRuntime();
+    const {
+      cleanupEmptyHostWorkspaceStagingDir: cleanupStagingDir,
+      cleanupHostWorkspaceStagingFiles: cleanupStagingFiles,
+      stageSandboxMedia,
+    } = await loadStageSandboxMediaRuntime();
     const stageResult = await traceGetReplyPhase("reply.stage_media", () =>
       stageSandboxMedia({
         ctx,
@@ -1099,8 +1108,16 @@ export async function getReplyFromConfig(
       }),
     );
     hostWorkspaceStagingDir = stageResult.hostWorkspaceStagingDir;
+    hostWorkspaceStagedFiles = [...stageResult.staged.values()];
     cleanupEmptyHostWorkspaceStagingDir = cleanupStagingDir;
+    cleanupHostWorkspaceStagingFiles = cleanupStagingFiles;
   }
+  const releaseHostStaging = () =>
+    (hostStagingCleanup ??=
+      cleanupHostWorkspaceStagingFiles?.({
+        stagingDir: hostWorkspaceStagingDir,
+        stagedFiles: hostWorkspaceStagedFiles,
+      }) ?? Promise.resolve());
 
   logResolverTiming("milestone", "before_run_prepared_reply");
   let replyResult: ReplyPayload | ReplyPayload[] | undefined;
@@ -1144,10 +1161,20 @@ export async function getReplyFromConfig(
         perMessageQueueOptions,
         typing,
         opts: withExtractedFileImages(resolvedOpts, extractedFileImages),
-        ...(hostWorkspaceStagingDir && cleanupEmptyHostWorkspaceStagingDir
+        ...(hostWorkspaceStagingDir &&
+        cleanupEmptyHostWorkspaceStagingDir &&
+        cleanupHostWorkspaceStagingFiles
           ? {
+              onHostStagingOwnershipTransferred: (settlement?: PromiseLike<void>) => {
+                hostStagingOwner = settlement ? "operation" : "queue";
+                if (settlement) {
+                  void Promise.resolve(settlement).then(releaseHostStaging, releaseHostStaging);
+                }
+              },
               onQueuedFollowupSettled: () => {
-                void cleanupEmptyHostWorkspaceStagingDir(hostWorkspaceStagingDir);
+                if (hostStagingOwner === "queue") {
+                  void releaseHostStaging();
+                }
               },
             }
           : {}),
@@ -1168,7 +1195,11 @@ export async function getReplyFromConfig(
     );
   } finally {
     if (hostWorkspaceStagingDir) {
-      await cleanupEmptyHostWorkspaceStagingDir?.(hostWorkspaceStagingDir);
+      if (hostStagingOwner === "caller") {
+        await releaseHostStaging();
+      } else {
+        await cleanupEmptyHostWorkspaceStagingDir?.(hostWorkspaceStagingDir);
+      }
     }
   }
   logResolverTiming("completed", "prepared_reply");

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -1077,6 +1077,8 @@ export async function getReplyFromConfig(
     }
   }
 
+  let hostWorkspaceStagingDir: string | undefined;
+  let cleanupEmptyHostWorkspaceStagingDir: ((stagingDir?: string) => Promise<void>) | undefined;
   // Already-staged facts or SDK projections must remain a single-stage contract.
   if (
     !useFastTestBootstrap &&
@@ -1085,8 +1087,9 @@ export async function getReplyFromConfig(
     !hasStagedMediaFacts(ctx.media) &&
     hasInboundMedia(ctx)
   ) {
-    const { stageSandboxMedia } = await loadStageSandboxMediaRuntime();
-    await traceGetReplyPhase("reply.stage_media", () =>
+    const { cleanupEmptyHostWorkspaceStagingDir: cleanupStagingDir, stageSandboxMedia } =
+      await loadStageSandboxMediaRuntime();
+    const stageResult = await traceGetReplyPhase("reply.stage_media", () =>
       stageSandboxMedia({
         ctx,
         sessionCtx,
@@ -1095,63 +1098,72 @@ export async function getReplyFromConfig(
         workspaceDir,
       }),
     );
+    hostWorkspaceStagingDir = stageResult.hostWorkspaceStagingDir;
+    cleanupEmptyHostWorkspaceStagingDir = cleanupStagingDir;
   }
 
   logResolverTiming("milestone", "before_run_prepared_reply");
-  const replyResult = await traceGetReplyPhase("reply.run_prepared_reply", () =>
-    runPreparedReply({
-      ctx,
-      sessionCtx,
-      cfg,
-      agentId,
-      agentDir,
-      agentCfg,
-      sessionCfg,
-      commandAuthorized,
-      command,
-      commandSource,
-      allowTextCommands,
-      directives,
-      defaultActivation,
-      resolvedThinkLevel,
-      resolvedFastMode,
-      resolvedFastModeAutoOnSeconds,
-      resolvedFastModeOverride,
-      resolvedFastModeAutoOnSecondsOverride,
-      resolvedVerboseLevel,
-      resolvedReasoningLevel,
-      resolvedElevatedLevel,
-      execOverrides,
-      elevatedEnabled,
-      elevatedAllowed,
-      blockStreamingEnabled,
-      blockReplyChunking,
-      resolvedBlockStreamingBreak,
-      modelState: runModelState,
-      provider: runProvider,
-      model: runModel,
-      requestedRouteResolution: runAutoFallbackPrimaryProbe
-        ? runModelState.requestedRouteResolution
-        : requestedRouteResolution,
-      perMessageQueueMode,
-      perMessageQueueOptions,
-      typing,
-      opts: withExtractedFileImages(resolvedOpts, extractedFileImages),
-      defaultModel,
-      timeoutMs,
-      isNewSession,
-      resetTriggered,
-      systemSent,
-      sessionEntry,
-      sessionStore,
-      sessionKey,
-      sessionId,
-      storePath,
-      workspaceDir,
-      abortedLastRun,
-      autoFallbackPrimaryProbe: runAutoFallbackPrimaryProbe,
-    }),
-  );
+  let replyResult: ReplyPayload | ReplyPayload[] | undefined;
+  try {
+    replyResult = await traceGetReplyPhase("reply.run_prepared_reply", () =>
+      runPreparedReply({
+        ctx,
+        sessionCtx,
+        cfg,
+        agentId,
+        agentDir,
+        agentCfg,
+        sessionCfg,
+        commandAuthorized,
+        command,
+        commandSource,
+        allowTextCommands,
+        directives,
+        defaultActivation,
+        resolvedThinkLevel,
+        resolvedFastMode,
+        resolvedFastModeAutoOnSeconds,
+        resolvedFastModeOverride,
+        resolvedFastModeAutoOnSecondsOverride,
+        resolvedVerboseLevel,
+        resolvedReasoningLevel,
+        resolvedElevatedLevel,
+        execOverrides,
+        elevatedEnabled,
+        elevatedAllowed,
+        blockStreamingEnabled,
+        blockReplyChunking,
+        resolvedBlockStreamingBreak,
+        modelState: runModelState,
+        provider: runProvider,
+        model: runModel,
+        requestedRouteResolution: runAutoFallbackPrimaryProbe
+          ? runModelState.requestedRouteResolution
+          : requestedRouteResolution,
+        perMessageQueueMode,
+        perMessageQueueOptions,
+        typing,
+        opts: withExtractedFileImages(resolvedOpts, extractedFileImages),
+        defaultModel,
+        timeoutMs,
+        isNewSession,
+        resetTriggered,
+        systemSent,
+        sessionEntry,
+        sessionStore,
+        sessionKey,
+        sessionId,
+        storePath,
+        workspaceDir,
+        abortedLastRun,
+        autoFallbackPrimaryProbe: runAutoFallbackPrimaryProbe,
+      }),
+    );
+  } finally {
+    if (hostWorkspaceStagingDir) {
+      await cleanupEmptyHostWorkspaceStagingDir?.(hostWorkspaceStagingDir);
+    }
+  }
   logResolverTiming("completed", "prepared_reply");
   return replyResult;
 }

--- a/src/auto-reply/reply/queue.dedupe.test.ts
+++ b/src/auto-reply/reply/queue.dedupe.test.ts
@@ -1,4 +1,7 @@
 // Tests follow-up queue message-id dedupe and drain scheduling behavior.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { FollowupRun, QueueSettings } from "./queue.js";
@@ -15,6 +18,7 @@ import {
   installQueueRuntimeErrorSilencer,
 } from "./queue.test-helpers.js";
 import { resetRecentQueuedMessageIdDedupe } from "./queue/enqueue.test-support.js";
+import { cleanupEmptyHostWorkspaceStagingDir } from "./stage-sandbox-media.js";
 
 installQueueRuntimeErrorSilencer();
 
@@ -546,6 +550,47 @@ describe("followup queue deduplication", () => {
       originatingTo: "group:G1",
     });
     expect(enqueueFollowupRun(key, redelivery, collectSettings)).toBe(false);
+  });
+
+  it("runs queue settlement cleanup once when a source lifecycle completes", () => {
+    const onQueueSettled = vi.fn();
+    const run = createRun({ prompt: "cleanup after consumer" });
+    run.onQueueSettled = onQueueSettled;
+
+    completeFollowupRunLifecycle(run);
+    completeFollowupRunLifecycle(run);
+
+    expect(onQueueSettled).toHaveBeenCalledOnce();
+  });
+
+  it("removes host staging after the queued consumer releases its media", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-queue-staging-"));
+    const stagingDir = path.join(root, "media", "inbound", "queued-run");
+    const stagedFile = path.join(stagingDir, "voice.ogg");
+    const cleanupDone = createDeferred<void>();
+    try {
+      await fs.mkdir(stagingDir, { recursive: true });
+      await fs.writeFile(stagedFile, "queued media");
+
+      await cleanupEmptyHostWorkspaceStagingDir(stagingDir);
+      await expect(fs.lstat(stagingDir)).resolves.toBeDefined();
+
+      await fs.rm(stagedFile);
+      const run = createRun({ prompt: "consume staged media" });
+      run.onQueueSettled = () => {
+        void cleanupEmptyHostWorkspaceStagingDir(stagingDir).then(
+          () => cleanupDone.resolve(),
+          (error: unknown) => cleanupDone.reject(error),
+        );
+      };
+
+      completeFollowupRunLifecycle(run);
+      await cleanupDone.promise;
+
+      await expect(fs.lstat(stagingDir)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await fs.rm(root, { force: true, recursive: true });
+    }
   });
 
   it("can opt-in to prompt-based dedupe when message id is absent", () => {

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -916,6 +916,7 @@ export function createOverflowSummaryRetrySource(source: FollowupRun): FollowupR
     originatingChatType: source.originatingChatType,
     abortSignal: source.abortSignal,
     turnAdoptionLifecycle: source.turnAdoptionLifecycle,
+    onQueueSettled: source.onQueueSettled,
     onReplyAdmissionWaitChange: source.onReplyAdmissionWaitChange,
     ...(source.currentInboundEventKind === "room_event"
       ? { currentInboundEventKind: "room_event" }

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -89,6 +89,8 @@ export type FollowupRun = {
   deliveryCorrelations?: QueuedReplyDeliveryCorrelation[];
   /** Canonical ownership lifecycle for durable ingress / reply-lane transfer. */
   turnAdoptionLifecycle?: TurnAdoptionLifecycle;
+  /** Best-effort cleanup that runs when this source leaves the follow-up queue lifecycle. */
+  onQueueSettled?: () => void;
   /** Dispatch-scoped freshness owner for a queued delivery-barrier wait. */
   onReplyAdmissionWaitChange?: (waiting: boolean) => void;
   /** Records terminal queue-cap outcomes at the queue owner before lifecycle cleanup. */
@@ -231,14 +233,18 @@ export function resolveFollowupAbortSignal(
   return signals.length > 1 ? AbortSignal.any(signals) : signals[0];
 }
 
+type FollowupLifecycleRun = Pick<
+  FollowupRun,
+  "onQueueSettled" | "steerPending" | "turnAdoptionLifecycle"
+>;
+
 const enqueuedTurnAdoptionLifecycles = new WeakSet<TurnAdoptionLifecycle>();
 const admittedTurnAdoptionLifecycles = new WeakSet<TurnAdoptionLifecycle>();
 const admittingTurnAdoptionLifecycles = new WeakMap<TurnAdoptionLifecycle, Promise<void>>();
 const retiredTurnAdoptionCancellationLifecycles = new WeakSet<TurnAdoptionLifecycle>();
 const completedTurnAdoptionLifecycles = new WeakSet<TurnAdoptionLifecycle>();
 const completedTurnAdoptionLifecycleCallbacks = new WeakSet<TurnAdoptionLifecycle>();
-
-type FollowupLifecycleRun = Pick<FollowupRun, "steerPending" | "turnAdoptionLifecycle">;
+const completedQueueSettlementCallbacks = new WeakSet<FollowupLifecycleRun>();
 
 export function markFollowupRunEnqueued(run: FollowupLifecycleRun): boolean {
   const lifecycle = run.turnAdoptionLifecycle;
@@ -294,22 +300,28 @@ export function completeFollowupRunLifecycle(run: FollowupLifecycleRun): void {
   const lifecycle = run.turnAdoptionLifecycle;
 
   const finish = () => {
-    if (!lifecycle || completedTurnAdoptionLifecycleCallbacks.has(lifecycle)) {
-      return;
-    }
-    completedTurnAdoptionLifecycleCallbacks.add(lifecycle);
-    // Async onAbandoned work must contain its own rejections; core guarantees a
-    // non-rejecting promise. onSettled must still run after a synchronous throw.
     try {
-      if (!admittedTurnAdoptionLifecycles.has(lifecycle)) {
-        // The queue is relinquishing an un-admitted message: free its dedupe
-        // identity so the abandonment-triggered ingress retry can re-enqueue
-        // instead of being rejected as a recent duplicate and falsely completed.
-        releaseRecentQueueMessageId(run);
-        lifecycle.onAbandoned?.();
+      if (lifecycle && !completedTurnAdoptionLifecycleCallbacks.has(lifecycle)) {
+        completedTurnAdoptionLifecycleCallbacks.add(lifecycle);
+        // Async onAbandoned work must contain its own rejections; core guarantees a
+        // non-rejecting promise. onSettled must still run after a synchronous throw.
+        try {
+          if (!admittedTurnAdoptionLifecycles.has(lifecycle)) {
+            // The queue is relinquishing an un-admitted message: free its dedupe
+            // identity so the abandonment-triggered ingress retry can re-enqueue
+            // instead of being rejected as a recent duplicate and falsely completed.
+            releaseRecentQueueMessageId(run);
+            lifecycle.onAbandoned?.();
+          }
+        } finally {
+          lifecycle.onSettled?.();
+        }
       }
     } finally {
-      lifecycle.onSettled?.();
+      if (!completedQueueSettlementCallbacks.has(run)) {
+        completedQueueSettlementCallbacks.add(run);
+        run.onQueueSettled?.();
+      }
     }
   };
 

--- a/src/auto-reply/reply/stage-sandbox-media.runtime.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.runtime.ts
@@ -1,2 +1,6 @@
 /** Runtime facade for staging media into sandbox-accessible paths. */
-export { cleanupEmptyHostWorkspaceStagingDir, stageSandboxMedia } from "./stage-sandbox-media.js";
+export {
+  cleanupEmptyHostWorkspaceStagingDir,
+  cleanupHostWorkspaceStagingFiles,
+  stageSandboxMedia,
+} from "./stage-sandbox-media.js";

--- a/src/auto-reply/reply/stage-sandbox-media.runtime.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.runtime.ts
@@ -1,2 +1,2 @@
 /** Runtime facade for staging media into sandbox-accessible paths. */
-export { stageSandboxMedia } from "./stage-sandbox-media.js";
+export { cleanupEmptyHostWorkspaceStagingDir, stageSandboxMedia } from "./stage-sandbox-media.js";

--- a/src/auto-reply/reply/stage-sandbox-media.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.ts
@@ -205,6 +205,35 @@ export async function cleanupEmptyHostWorkspaceStagingDir(stagingDir?: string): 
   });
 }
 
+export async function cleanupHostWorkspaceStagingFiles(params: {
+  stagingDir?: string;
+  stagedFiles: Iterable<string>;
+}): Promise<void> {
+  const stagingDir = params.stagingDir;
+  if (!stagingDir) {
+    return;
+  }
+  const normalizedStagingDir = path.resolve(stagingDir);
+  const ownedFiles = [
+    ...new Set(
+      [...params.stagedFiles]
+        .map((filePath) => path.resolve(filePath))
+        .filter((filePath) => path.dirname(filePath) === normalizedStagingDir),
+    ),
+  ];
+  await Promise.all(
+    ownedFiles.map(async (filePath) => {
+      await fs.unlink(filePath).catch((error: unknown) => {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+          return;
+        }
+        logVerbose(`Failed to clean staged host media file ${filePath}: ${String(error)}`);
+      });
+    }),
+  );
+  await cleanupEmptyHostWorkspaceStagingDir(stagingDir);
+}
+
 async function isUrlAliasForStagedSource(params: {
   url?: string;
   sourcePath: string;

--- a/src/auto-reply/reply/stage-sandbox-media.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.ts
@@ -29,6 +29,8 @@ const SCP_STDERR_TAIL_CHARS = 16_384;
 // partial failures without matching rewritten strings back to source paths.
 export type StageSandboxMediaResult = {
   staged: ReadonlyMap<number, string>;
+  /** Host-only directory eligible for non-recursive cleanup after the reply settles. */
+  hostWorkspaceStagingDir?: string;
 };
 
 const EMPTY_STAGE_RESULT: StageSandboxMediaResult = { staged: new Map() };
@@ -88,6 +90,9 @@ export async function stageSandboxMedia(params: {
     !sandbox && !ctx.MediaRemoteHost
       ? path.join("media", "inbound", `openclaw-staged-${crypto.randomUUID()}`)
       : undefined;
+  const hostWorkspaceStagingPath = hostWorkspaceStagingDir
+    ? path.join(effectiveWorkspaceDir, hostWorkspaceStagingDir)
+    : undefined;
 
   for (const entry of pathEntries) {
     const source = await resolveStageableMediaSource(entry.path);
@@ -158,6 +163,7 @@ export async function stageSandboxMedia(params: {
   }
 
   if (staged.size === 0) {
+    await cleanupEmptyHostWorkspaceStagingDir(hostWorkspaceStagingPath);
     return { staged };
   }
 
@@ -178,7 +184,25 @@ export async function stageSandboxMedia(params: {
     applyStagedMediaContext(sessionCtx, nextMedia);
   }
 
-  return { staged };
+  return {
+    staged,
+    ...(hostWorkspaceStagingPath ? { hostWorkspaceStagingDir: hostWorkspaceStagingPath } : {}),
+  };
+}
+
+export async function cleanupEmptyHostWorkspaceStagingDir(stagingDir?: string): Promise<void> {
+  if (!stagingDir) {
+    return;
+  }
+  await fs.rmdir(stagingDir).catch((error: unknown) => {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ENOTEMPTY" || code === "EEXIST") {
+      return;
+    }
+    logVerbose(
+      `Failed to clean empty host media staging directory ${stagingDir}: ${String(error)}`,
+    );
+  });
 }
 
 async function isUrlAliasForStagedSource(params: {


### PR DESCRIPTION
Closes #104358

## What Problem This Solves

Host-mode inbound-media staging creates a UUID-scoped `media/inbound/openclaw-staged-*` directory but previously discarded its identity before the reply lifecycle ran. Empty directories could therefore accumulate in agent workspaces, including after delayed queued follow-ups.

## Why This Approach

The staging result now carries the absolute host-only directory path and the exact files created by that staging operation. Cleanup unlinks only those producer-owned copies, then attempts a non-recursive directory removal. Unknown files in the same directory are preserved.

`getReplyFromConfig` initially owns cleanup and transfers it only when another lifecycle accepts the media:

- direct runs and rejected queue admission remain caller-owned;
- normal follow-ups and steer fallbacks wait for the original queue source terminal lifecycle;
- accepted steers wait for `ReplyOperation.ownerSettlement` when that owner exists; embedded-only active steers remain queue-owned.

Collect batching and overflow-summary retries preserve the source callback. Sandbox staging, remote-cache staging, and Gateway attachment prestaging are unchanged.

## User Impact

Completed and rejected host-mode replies no longer leave producer-owned media copies or empty `openclaw-staged-*` directories behind. Queued and steered consumers retain the files until their actual owner settles, and unrelated files are not deleted.

## Evidence

- Exact head: `c43eba3d8c49b51475d769fd79b6711b5cd8c1e2`
- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner.media-paths.test.ts src/auto-reply/reply/get-reply.message-hooks.test.ts src/auto-reply/reply/queue.dedupe.test.ts` (52 passed)
- `/opt/homebrew/bin/pnpm tsgo:core:test`
- changed-file `oxfmt` and `oxlint`: passed
- `git diff --check`: passed

### Host-mode filesystem proof

The original exact-head proof ran production `stageSandboxMedia` and `cleanupEmptyHostWorkspaceStagingDir` with sandbox mode disabled, an isolated `OPENCLAW_STATE_DIR`, managed inbound media, and an isolated agent workspace:

```text
[host-staging-proof] {"head":"fcd2544b7bede8f529ecadeac5daaa721e0c5805","hostMode":true,"retainedWhileNonEmpty":true,"removedAfterEmpty":true}
```

Exact head `c43eba3d8c4` adds filesystem and ownership regressions:

- the production helper removes the exact staged copy but preserves an unknown file in the same UUID directory;
- direct/rejected ownership releases exact files in the caller `finally`;
- normal queue ownership delays exact cleanup until queue source settlement;
- queue settlement after an accepted steer does not clean the file; active-operation settlement does;
- embedded-only active steers with no `ReplyOperation` do not throw and retain queue-owned cleanup;
- follow-up enqueue rejection never transfers ownership.

No recursive deletion is introduced.

AI-assisted: investigation, implementation, validation, and review were performed with an AI coding assistant; the contributor reviewed and understands the change.
