### PR TITLE
fix(release): skip unavailable Buzz on frozen candidates

### DIFF
--- a/.github/workflows/qa-live-transports-convex.yml
+++ b/.github/workflows/qa-live-transports-convex.yml
@@ -588,7 +588,7 @@ jobs:
           if-no-files-found: error
 
       - name: Require requested Buzz QA runner
-        if: always() && steps.resolve_buzz.outcome == 'success' && steps.resolve_buzz.outputs.available != 'true'
+        if: always() && inputs.expected_sha == '' && steps.resolve_buzz.outcome == 'success' && steps.resolve_buzz.outputs.available != 'true'
         shell: bash
         run: |
           echo "::error::The selected ref does not declare the requested Buzz QA runner."

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -3175,7 +3175,7 @@ describe("package artifact reuse", () => {
     );
     const requireBuzz = workflowStep(buzzJob, "Require requested Buzz QA runner");
     expect(requireBuzz.if).toBe(
-      "always() && steps.resolve_buzz.outcome == 'success' && steps.resolve_buzz.outputs.available != 'true'",
+      "always() && inputs.expected_sha == '' && steps.resolve_buzz.outcome == 'success' && steps.resolve_buzz.outputs.available != 'true'",
     );
     expect(requireBuzz.run).toContain(
       "The selected ref does not declare the requested Buzz QA runner.",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where extended-stable release validation fails when the frozen candidate predates the Buzz QA runner. The runner is correctly absent from the candidate, but the trusted workflow currently treats that capability mismatch as a failure.

## Why This Change Was Made

The reusable Buzz workflow already writes an attested `skipped.json` result when the selected revision does not declare the runner. This change preserves a hard failure for direct/manual requests, while allowing a frozen release candidate to skip only an unavailable future capability.

## User Impact

Release operators can validate older release candidates without a newer optional QA lane becoming a false blocker. Direct Buzz QA runs still fail clearly when the requested runner is missing.

## Evidence

- Failed release validation `30789587262`: the selected `2026.6.34` candidate has no `extensions/buzz/openclaw.plugin.json`; its existing artifact records that reason before the workflow incorrectly fails.
- `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts --testNamePattern 'routes release Buzz through the QA Lab selector'` — passed (1).\n- `actionlint .github/workflows/qa-live-transports-convex.yml` — passed.\n- `./node_modules/.bin/oxfmt --check .github/workflows/qa-live-transports-convex.yml test/scripts/package-acceptance-workflow.test.ts` — passed.\n- `autoreview --mode uncommitted` — clean; no accepted/actionable findings.\n\nAI-assisted implementation and review.