### PR TITLE
fix(config): ModelCompatSchema drops eight keys ModelCompatConfig declares, and the drift contract cannot see it

### DIFF
--- a/src/config/schema-control-ui-contract.test.ts
+++ b/src/config/schema-control-ui-contract.test.ts
@@ -68,26 +68,43 @@ function collectMixedUnions(
   return result;
 }
 
+function schemaChildAtSegment(schema: JsonSchema, segment: string): JsonSchema | undefined {
+  let direct: JsonSchema | undefined;
+  if (segment === "*") {
+    direct = Array.isArray(schema.items)
+      ? undefined
+      : schema.items ||
+        (schema.additionalProperties && typeof schema.additionalProperties === "object"
+          ? schema.additionalProperties
+          : undefined);
+  } else if (/^\d+$/u.test(segment) && Array.isArray(schema.items)) {
+    direct = schema.items[Number(segment)];
+  } else {
+    direct = schema.properties?.[segment];
+  }
+  if (direct) {
+    return direct;
+  }
+  for (const branch of [
+    ...(schema.allOf ?? []),
+    ...(schema.anyOf ?? []),
+    ...(schema.oneOf ?? []),
+  ]) {
+    const nested = schemaChildAtSegment(branch, segment);
+    if (nested) {
+      return nested;
+    }
+  }
+  return undefined;
+}
+
 function schemaAtPath(schema: JsonSchema, path: string): JsonSchema | undefined {
   let current: JsonSchema | undefined = schema;
   for (const segment of path === "<root>" ? [] : path.split(".")) {
     if (!current) {
       return undefined;
     }
-    if (segment === "*") {
-      current = Array.isArray(current.items)
-        ? undefined
-        : current.items ||
-          (current.additionalProperties && typeof current.additionalProperties === "object"
-            ? current.additionalProperties
-            : undefined);
-      continue;
-    }
-    if (/^\d+$/u.test(segment) && Array.isArray(current.items)) {
-      current = current.items[Number(segment)];
-      continue;
-    }
-    current = current.properties?.[segment];
+    current = schemaChildAtSegment(current, segment);
   }
   return current;
 }

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -263,6 +263,67 @@ const ModelApiSchema = z.enum(MODEL_APIS, {
       : undefined,
 });
 
+// OpenRouter provider routing preferences (`compat.openRouterRouting`); mirrors the
+// `OpenRouterRouting` interface in packages/llm-core/src/types.ts.
+const OpenRouterRoutingPercentileCutoffsSchema = z
+  .object({
+    p50: z.number().optional(),
+    p75: z.number().optional(),
+    p90: z.number().optional(),
+    p99: z.number().optional(),
+  })
+  .strict();
+
+const OpenRouterRoutingSchema = z
+  .object({
+    allow_fallbacks: z.boolean().optional(),
+    require_parameters: z.boolean().optional(),
+    data_collection: z.union([z.literal("deny"), z.literal("allow")]).optional(),
+    zdr: z.boolean().optional(),
+    enforce_distillable_text: z.boolean().optional(),
+    order: z.array(z.string()).optional(),
+    only: z.array(z.string()).optional(),
+    ignore: z.array(z.string()).optional(),
+    quantizations: z.array(z.string()).optional(),
+    sort: z
+      .union([
+        z.string(),
+        z
+          .object({
+            by: z.string().optional(),
+            partition: z.union([z.string(), z.null()]).optional(),
+          })
+          .strict(),
+      ])
+      .optional(),
+    max_price: z
+      .object({
+        prompt: z.union([z.number(), z.string()]).optional(),
+        completion: z.union([z.number(), z.string()]).optional(),
+        image: z.union([z.number(), z.string()]).optional(),
+        audio: z.union([z.number(), z.string()]).optional(),
+        request: z.union([z.number(), z.string()]).optional(),
+      })
+      .strict()
+      .optional(),
+    preferred_min_throughput: z
+      .union([z.number(), OpenRouterRoutingPercentileCutoffsSchema])
+      .optional(),
+    preferred_max_latency: z
+      .union([z.number(), OpenRouterRoutingPercentileCutoffsSchema])
+      .optional(),
+  })
+  .strict();
+
+// Vercel AI Gateway routing preferences (`compat.vercelGatewayRouting`); mirrors the
+// `VercelGatewayRouting` interface in packages/llm-core/src/types.ts.
+const VercelGatewayRoutingSchema = z
+  .object({
+    only: z.array(z.string()).optional(),
+    order: z.array(z.string()).optional(),
+  })
+  .strict();
+
 const ModelCompatSchema = z
   .object({
     supportsStore: z.boolean().optional(),
@@ -293,6 +354,14 @@ const ModelCompatSchema = z
     unsupportedToolSchemaKeywords: z.array(z.string().min(1)).optional(),
     toolCallArgumentsEncoding: z.string().optional(),
     requiresOpenAiAnthropicToolPayload: z.boolean().optional(),
+    openRouterRouting: OpenRouterRoutingSchema.optional(),
+    vercelGatewayRouting: VercelGatewayRoutingSchema.optional(),
+    zaiToolStream: z.boolean().optional(),
+    cacheControlFormat: z.literal("anthropic").optional(),
+    sendSessionAffinityHeaders: z.boolean().optional(),
+    sendSessionIdHeader: z.boolean().optional(),
+    supportsEagerToolInputStreaming: z.boolean().optional(),
+    supportsLongCacheRetention: z.boolean().optional(),
   })
   .strict()
   .optional();

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -370,6 +370,29 @@ const modelCompatSchemaContract: [
   AssertAssignable<z.infer<typeof ModelCompatSchema>, ModelCompatConfig | undefined>,
   AssertAssignable<ModelCompatConfig | undefined, z.infer<typeof ModelCompatSchema>>,
 ] = [] as never;
+
+// The assignability contract above cannot see a key that the schema is *missing*:
+// TypeScript's structural assignability lets a type with extra optional properties
+// be assigned to one without them (excess-property checking only applies to object
+// literals), so both directions hold even while the schema drops keys the type
+// declares. Compare key sets instead — this fails to compile the moment either side
+// gains a key the other lacks.
+type AssertNever<_T extends never> = true;
+const modelCompatKeyContract: [
+  AssertNever<
+    Exclude<
+      keyof NonNullable<ModelCompatConfig>,
+      keyof NonNullable<z.infer<typeof ModelCompatSchema>>
+    >
+  >,
+  AssertNever<
+    Exclude<
+      keyof NonNullable<z.infer<typeof ModelCompatSchema>>,
+      keyof NonNullable<ModelCompatConfig>
+    >
+  >,
+] = [] as never;
+void modelCompatKeyContract;
 void modelCompatSchemaContract;
 const ConfiguredProviderRequestTlsSchema = z
   .object({

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { z } from "zod";
 import { isSafeExecutableValue } from "../infra/exec-safety.js";
+import type { OpenRouterRouting, VercelGatewayRouting } from "../llm/types.js";
 import { normalizeExactAllowedHost } from "../secrets/exact-hostname.js";
 import {
   formatExecSecretRefIdValidationMessage,
@@ -263,9 +264,7 @@ const ModelApiSchema = z.enum(MODEL_APIS, {
       : undefined,
 });
 
-// OpenRouter provider routing preferences (`compat.openRouterRouting`); mirrors the
-// `OpenRouterRouting` interface in packages/llm-core/src/types.ts.
-const OpenRouterRoutingPercentileCutoffsSchema = z
+const RoutingPercentileCutoffsSchema = z
   .object({
     p50: z.number().optional(),
     p75: z.number().optional(),
@@ -278,7 +277,7 @@ const OpenRouterRoutingSchema = z
   .object({
     allow_fallbacks: z.boolean().optional(),
     require_parameters: z.boolean().optional(),
-    data_collection: z.union([z.literal("deny"), z.literal("allow")]).optional(),
+    data_collection: z.enum(["deny", "allow"]).optional(),
     zdr: z.boolean().optional(),
     enforce_distillable_text: z.boolean().optional(),
     order: z.array(z.string()).optional(),
@@ -291,7 +290,7 @@ const OpenRouterRoutingSchema = z
         z
           .object({
             by: z.string().optional(),
-            partition: z.union([z.string(), z.null()]).optional(),
+            partition: z.string().nullable().optional(),
           })
           .strict(),
       ])
@@ -306,22 +305,16 @@ const OpenRouterRoutingSchema = z
       })
       .strict()
       .optional(),
-    preferred_min_throughput: z
-      .union([z.number(), OpenRouterRoutingPercentileCutoffsSchema])
-      .optional(),
-    preferred_max_latency: z
-      .union([z.number(), OpenRouterRoutingPercentileCutoffsSchema])
-      .optional(),
-  })
+    preferred_min_throughput: z.union([z.number(), RoutingPercentileCutoffsSchema]).optional(),
+    preferred_max_latency: z.union([z.number(), RoutingPercentileCutoffsSchema]).optional(),
+  } satisfies Record<keyof OpenRouterRouting, z.ZodType>)
   .strict();
 
-// Vercel AI Gateway routing preferences (`compat.vercelGatewayRouting`); mirrors the
-// `VercelGatewayRouting` interface in packages/llm-core/src/types.ts.
 const VercelGatewayRoutingSchema = z
   .object({
     only: z.array(z.string()).optional(),
     order: z.array(z.string()).optional(),
-  })
+  } satisfies Record<keyof VercelGatewayRouting, z.ZodType>)
   .strict();
 
 const ModelCompatSchema = z
@@ -362,7 +355,7 @@ const ModelCompatSchema = z
     sendSessionIdHeader: z.boolean().optional(),
     supportsEagerToolInputStreaming: z.boolean().optional(),
     supportsLongCacheRetention: z.boolean().optional(),
-  })
+  } satisfies Record<keyof ModelCompatConfig, z.ZodType>)
   .strict()
   .optional();
 type AssertAssignable<_Left extends _Right, _Right> = true;
@@ -370,29 +363,6 @@ const modelCompatSchemaContract: [
   AssertAssignable<z.infer<typeof ModelCompatSchema>, ModelCompatConfig | undefined>,
   AssertAssignable<ModelCompatConfig | undefined, z.infer<typeof ModelCompatSchema>>,
 ] = [] as never;
-
-// The assignability contract above cannot see a key that the schema is *missing*:
-// TypeScript's structural assignability lets a type with extra optional properties
-// be assigned to one without them (excess-property checking only applies to object
-// literals), so both directions hold even while the schema drops keys the type
-// declares. Compare key sets instead — this fails to compile the moment either side
-// gains a key the other lacks.
-type AssertNever<_T extends never> = true;
-const modelCompatKeyContract: [
-  AssertNever<
-    Exclude<
-      keyof NonNullable<ModelCompatConfig>,
-      keyof NonNullable<z.infer<typeof ModelCompatSchema>>
-    >
-  >,
-  AssertNever<
-    Exclude<
-      keyof NonNullable<z.infer<typeof ModelCompatSchema>>,
-      keyof NonNullable<ModelCompatConfig>
-    >
-  >,
-] = [] as never;
-void modelCompatKeyContract;
 void modelCompatSchemaContract;
 const ConfiguredProviderRequestTlsSchema = z
   .object({

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -211,6 +211,67 @@ const ModelApiSchema = z.enum(MODEL_APIS, {
       : undefined,
 });
 
+// OpenRouter provider routing preferences (`compat.openRouterRouting`); mirrors the
+// `OpenRouterRouting` interface in packages/llm-core/src/types.ts.
+const OpenRouterRoutingPercentileCutoffsSchema = z
+  .object({
+    p50: z.number().optional(),
+    p75: z.number().optional(),
+    p90: z.number().optional(),
+    p99: z.number().optional(),
+  })
+  .strict();
+
+const OpenRouterRoutingSchema = z
+  .object({
+    allow_fallbacks: z.boolean().optional(),
+    require_parameters: z.boolean().optional(),
+    data_collection: z.union([z.literal("deny"), z.literal("allow")]).optional(),
+    zdr: z.boolean().optional(),
+    enforce_distillable_text: z.boolean().optional(),
+    order: z.array(z.string()).optional(),
+    only: z.array(z.string()).optional(),
+    ignore: z.array(z.string()).optional(),
+    quantizations: z.array(z.string()).optional(),
+    sort: z
+      .union([
+        z.string(),
+        z
+          .object({
+            by: z.string().optional(),
+            partition: z.union([z.string(), z.null()]).optional(),
+          })
+          .strict(),
+      ])
+      .optional(),
+    max_price: z
+      .object({
+        prompt: z.union([z.number(), z.string()]).optional(),
+        completion: z.union([z.number(), z.string()]).optional(),
+        image: z.union([z.number(), z.string()]).optional(),
+        audio: z.union([z.number(), z.string()]).optional(),
+        request: z.union([z.number(), z.string()]).optional(),
+      })
+      .strict()
+      .optional(),
+    preferred_min_throughput: z
+      .union([z.number(), OpenRouterRoutingPercentileCutoffsSchema])
+      .optional(),
+    preferred_max_latency: z
+      .union([z.number(), OpenRouterRoutingPercentileCutoffsSchema])
+      .optional(),
+  })
+  .strict();
+
+// Vercel AI Gateway routing preferences (`compat.vercelGatewayRouting`); mirrors the
+// `VercelGatewayRouting` interface in packages/llm-core/src/types.ts.
+const VercelGatewayRoutingSchema = z
+  .object({
+    only: z.array(z.string()).optional(),
+    order: z.array(z.string()).optional(),
+  })
+  .strict();
+
 const ModelCompatSchema = z
   .object({
     supportsStore: z.boolean().optional(),
@@ -240,6 +301,14 @@ const ModelCompatSchema = z
     unsupportedToolSchemaKeywords: z.array(z.string().min(1)).optional(),
     toolCallArgumentsEncoding: z.string().optional(),
     requiresOpenAiAnthropicToolPayload: z.boolean().optional(),
+    openRouterRouting: OpenRouterRoutingSchema.optional(),
+    vercelGatewayRouting: VercelGatewayRoutingSchema.optional(),
+    zaiToolStream: z.boolean().optional(),
+    cacheControlFormat: z.literal("anthropic").optional(),
+    sendSessionAffinityHeaders: z.boolean().optional(),
+    sendSessionIdHeader: z.boolean().optional(),
+    supportsEagerToolInputStreaming: z.boolean().optional(),
+    supportsLongCacheRetention: z.boolean().optional(),
   })
   .strict()
   .optional();

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -317,6 +317,29 @@ const modelCompatSchemaContract: [
   AssertAssignable<z.infer<typeof ModelCompatSchema>, ModelCompatConfig | undefined>,
   AssertAssignable<ModelCompatConfig | undefined, z.infer<typeof ModelCompatSchema>>,
 ] = [] as never;
+
+// The assignability contract above cannot see a key that the schema is *missing*:
+// TypeScript's structural assignability lets a type with extra optional properties
+// be assigned to one without them (excess-property checking only applies to object
+// literals), so both directions hold even while the schema drops keys the type
+// declares. Compare key sets instead — this fails to compile the moment either side
+// gains a key the other lacks.
+type AssertNever<_T extends never> = true;
+const modelCompatKeyContract: [
+  AssertNever<
+    Exclude<
+      keyof NonNullable<ModelCompatConfig>,
+      keyof NonNullable<z.infer<typeof ModelCompatSchema>>
+    >
+  >,
+  AssertNever<
+    Exclude<
+      keyof NonNullable<z.infer<typeof ModelCompatSchema>>,
+      keyof NonNullable<ModelCompatConfig>
+    >
+  >,
+] = [] as never;
+void modelCompatKeyContract;
 void modelCompatSchemaContract;
 const ConfiguredProviderRequestTlsSchema = z
   .object({

--- a/src/config/zod-schema.models.test.ts
+++ b/src/config/zod-schema.models.test.ts
@@ -114,6 +114,46 @@ describe("ModelsConfigSchema", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts and preserves declared model compatibility settings", () => {
+    const compat = {
+      openRouterRouting: {
+        allow_fallbacks: false,
+        require_parameters: true,
+        data_collection: "deny",
+        zdr: true,
+        enforce_distillable_text: true,
+        order: ["anthropic", "openai"],
+        only: ["anthropic"],
+        ignore: ["openai"],
+        quantizations: ["fp16"],
+        sort: { by: "latency", partition: null },
+        max_price: { prompt: "0.5", completion: 1, image: 2, audio: 3, request: 4 },
+        preferred_min_throughput: { p50: 10, p75: 20, p90: 30, p99: 40 },
+        preferred_max_latency: 5,
+      },
+      vercelGatewayRouting: {
+        only: ["anthropic"],
+        order: ["anthropic", "openai"],
+      },
+      zaiToolStream: true,
+      cacheControlFormat: "anthropic",
+      sendSessionAffinityHeaders: true,
+      sendSessionIdHeader: true,
+      supportsEagerToolInputStreaming: true,
+      supportsLongCacheRetention: true,
+    };
+    const parsed = ModelsConfigSchema.parse({
+      providers: {
+        "my-proxy": {
+          baseUrl: "https://my-proxy.example.com/v1",
+          models: [{ id: "custom-model", name: "Custom Model", compat }],
+        },
+      },
+    });
+
+    expect(parsed?.providers?.["my-proxy"]?.models?.[0]?.compat).toEqual(compat);
+  });
+
   it("accepts catalog-declared temperature compatibility", () => {
     const result = ModelsConfigSchema.safeParse({
       providers: {


### PR DESCRIPTION
Fixes #118667.

## What Problem This Solves

OpenClaw declares eight model compatibility settings and uses them in provider requests. The strict root config schema omitted them, so `openclaw config validate` rejected every config that set one.

The rejected settings cover OpenRouter and Vercel routing, Z.AI tool streaming, Anthropic cache control, session affinity, session IDs, eager tool streaming, and long cache retention.

## Why This Change Was Made

`ModelCompatConfig` is the TypeScript contract for these settings. `ModelCompatSchema` is the runtime validation owner.

This change adds strict runtime schemas for every declared field. Each schema shape uses the owning TypeScript keys, so a later missing or extra key fails the type check. The existing bidirectional assignability check still verifies value types.

The separate agent `models.json` TypeBox parser remains out of scope. It permits and preserves extra compatibility keys, so it does not reproduce this strict root-config rejection.

## User Impact

Operators can set all eight existing compatibility options in `openclaw.json`. Validation preserves the supplied values for the provider request builders.

This adds no config option or default. It makes already declared options reachable through the root config path.

## Evidence

- Exact current `main` `b30cef73edae8daec41c0ba36bfbe24f02701325`: source CLI config validation exits 1 and reports all eight keys as unrecognized.
- The new owner-boundary regression on the same revision fails for those eight keys while 24 existing tests pass.
- Exact head `e207b5dd1c83ce98477f691c8d28f208a391b682`: the model schema and generated Control UI contract suites pass all 27 tests on a secretless clean Linux checkout.
- The exported root `OpenClawSchema` accepts the same config on the exact head and returns every supplied scalar and nested routing value unchanged.
- Exact head `pnpm check:changed` passes formatting, repository ratchets, core and test type checks, Oxlint, dependency and architecture guards, and import-cycle checks.
