### PR TITLE
fix(skills): reconcile manually created proposal targets

### DIFF
--- a/src/gateway/server-methods/skills.proposals.test.ts
+++ b/src/gateway/server-methods/skills.proposals.test.ts
@@ -212,6 +212,43 @@ describe("skills proposal gateway handlers", () => {
     ).resolves.toContain("Use current weather");
   });
 
+  it("marks manually created create targets stale before list and inspect responses", async () => {
+    const create = await callHandler("skills.proposals.create", {
+      name: "Manual Gateway Skill",
+      description: "Installed before its proposal was applied.",
+      content: "# Manual Gateway Skill\n",
+    });
+    expect(create.ok).toBe(true);
+    const created = create.response as {
+      record: { id: string; target: { skillFile: string } };
+    };
+    await fs.mkdir(path.dirname(created.record.target.skillFile), { recursive: true });
+    await fs.writeFile(
+      created.record.target.skillFile,
+      "# Manual Gateway Skill\n\nAlready installed.\n",
+      "utf8",
+    );
+
+    const list = await callHandler("skills.proposals.list", {});
+    expect(list.ok).toBe(true);
+    expect(
+      (list.response as { proposals: Array<{ id: string; status: string }> }).proposals,
+    ).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: created.record.id, status: "stale" })]),
+    );
+
+    const inspect = await callHandler("skills.proposals.inspect", {
+      proposalId: created.record.id,
+    });
+    expect(inspect.ok).toBe(true);
+    expect(
+      (inspect.response as { record: { status: string; statusReason?: string } }).record,
+    ).toMatchObject({
+      status: "stale",
+      statusReason: "Target skill was created after proposal creation.",
+    });
+  });
+
   it("keeps list and inspect bound to the agent after its workspace changes", async () => {
     const firstWorkspaceDir = mocks.workspaceDir;
     const first = await callHandler("skills.proposals.create", {

--- a/src/skills/workshop/apply-transition.ts
+++ b/src/skills/workshop/apply-transition.ts
@@ -448,12 +448,11 @@ export async function assertSkillProposalSupportTargetUnchanged(params: {
   }
 }
 
-export async function markSkillProposalStale(params: {
+export function transitionPendingSkillProposalToStale(params: {
   record: SkillProposalRecord;
   reason: string;
-  message: string;
   input: SkillProposalTransitionInput;
-}): Promise<never> {
+}): { record: SkillProposalRecord; event: SkillProposalEvent } {
   const now = new Date().toISOString();
   const stale: SkillProposalRecord = {
     ...params.record,
@@ -478,7 +477,17 @@ export async function markSkillProposalStale(params: {
   if (commit.state !== "committed" || !commit.event) {
     throw new Error("Failed to record stale Skill Workshop proposal.");
   }
-  throw new SkillProposalLifecycleError(params.message, stale, commit.event);
+  return { record: stale, event: commit.event };
+}
+
+export async function markSkillProposalStale(params: {
+  record: SkillProposalRecord;
+  reason: string;
+  message: string;
+  input: SkillProposalTransitionInput;
+}): Promise<never> {
+  const transition = transitionPendingSkillProposalToStale(params);
+  throw new SkillProposalLifecycleError(params.message, transition.record, transition.event);
 }
 
 function createSkillProposalRollback(params: {

--- a/src/skills/workshop/collection-reconcile.test.ts
+++ b/src/skills/workshop/collection-reconcile.test.ts
@@ -709,6 +709,51 @@ describe("skill collection reconciliation", () => {
     await expect(fs.access(proposal.record.target.skillFile)).rejects.toThrow();
   });
 
+  it("surfaces proposal reads that exceed the collection lease wait", async () => {
+    const proposal = await proposeCreateSkill({
+      workspaceDir,
+      env: testState.env,
+      name: "Contended Candidate",
+      description: "Surface collection lock contention.",
+      content: "# Contended Candidate\n",
+    });
+    let releaseLock: (() => void) | undefined;
+    let markAcquired: (() => void) | undefined;
+    const acquired = new Promise<void>((resolve) => {
+      markAcquired = resolve;
+    });
+    const heldLock = withSkillCollectionLock(
+      workspaceDir,
+      async () => {
+        markAcquired?.();
+        await new Promise<void>((resolve) => {
+          releaseLock = resolve;
+        });
+      },
+      { env: testState.env },
+    );
+    await acquired;
+
+    try {
+      await Promise.all([
+        expect(listSkillProposals({ workspaceDir, env: testState.env })).rejects.toMatchObject({
+          code: "OPENCLAW_STATE_LEASE_TIMEOUT",
+        }),
+        expect(
+          inspectSkillProposal(proposal.record.id, {
+            workspaceDir,
+            env: testState.env,
+          }),
+        ).rejects.toMatchObject({
+          code: "OPENCLAW_STATE_LEASE_TIMEOUT",
+        }),
+      ]);
+    } finally {
+      releaseLock?.();
+      await heldLock;
+    }
+  }, 15_000);
+
   it("restores a staged drop when backup commit fails", async () => {
     await writeWorkspaceSkills(workspaceDir, [
       { name: "obsolete", description: "Obsolete procedure", body: "# Original\n" },

--- a/src/skills/workshop/collection-reconcile.test.ts
+++ b/src/skills/workshop/collection-reconcile.test.ts
@@ -18,6 +18,7 @@ import {
 } from "./collection-reconcile.js";
 import { getArchivedSkillFiles } from "./curator.js";
 import { readSkillProposalTargetTreeSha256 } from "./proposal-bundle.js";
+import { inspectSkillProposal, listSkillProposals, proposeCreateSkill } from "./service.js";
 import { withSkillCollectionLock } from "./target-lock.js";
 
 type CopyDirectoryHook = (
@@ -631,6 +632,81 @@ describe("skill collection reconciliation", () => {
 
     expect(getArchivedSkillFiles({ env: testState.env })).toEqual(new Set([skillFile]));
     await expect(fs.readFile(skillFile, "utf8")).resolves.toContain("# Original");
+  });
+
+  it("keeps proposal reads behind a failed collection create rollback", async () => {
+    const proposal = await proposeCreateSkill({
+      workspaceDir,
+      env: testState.env,
+      name: "Collection Candidate",
+      description: "Remain pending if collection creation rolls back.",
+      content: "# Collection Candidate\n\nCreated by collection reconciliation.\n",
+    });
+    const receipt = await readCollectionReceipt();
+    const originalRename = fs.rename.bind(fs);
+    let releaseCommit: (() => void) | undefined;
+    let markCommitAttempted: (() => void) | undefined;
+    const commitAttempted = new Promise<void>((resolve) => {
+      markCommitAttempted = resolve;
+    });
+    const renameSpy = vi.spyOn(fs, "rename").mockImplementation(async (oldPath, newPath) => {
+      if (String(oldPath).includes(`${path.sep}.pending-`)) {
+        markCommitAttempted?.();
+        await new Promise<void>((resolve) => {
+          releaseCommit = resolve;
+        });
+        throw new Error("forced backup commit failure");
+      }
+      await originalRename(oldPath, newPath);
+    });
+
+    const reconciliation = reconcileSkillCollection({
+      workspaceDir,
+      env: testState.env,
+      ...receipt,
+      plan: [
+        {
+          action: "write",
+          name: proposal.record.target.skillKey,
+          description: "Created during a collection mutation.",
+          content: "# Collection Candidate\n\nTransient collection content.\n",
+        },
+      ],
+    });
+    try {
+      await commitAttempted;
+      let listSettled = false;
+      let inspectSettled = false;
+      const listing = listSkillProposals({ workspaceDir, env: testState.env }).finally(() => {
+        listSettled = true;
+      });
+      const inspection = inspectSkillProposal(proposal.record.id, {
+        workspaceDir,
+        env: testState.env,
+      }).finally(() => {
+        inspectSettled = true;
+      });
+
+      await new Promise((resolve) => {
+        setTimeout(resolve, 50);
+      });
+      expect(listSettled).toBe(false);
+      expect(inspectSettled).toBe(false);
+
+      releaseCommit?.();
+      await expect(reconciliation).rejects.toThrow("forced backup commit failure");
+      await expect(listing).resolves.toMatchObject({
+        proposals: [expect.objectContaining({ id: proposal.record.id, status: "pending" })],
+      });
+      await expect(inspection).resolves.toMatchObject({
+        record: { id: proposal.record.id, status: "pending" },
+      });
+    } finally {
+      releaseCommit?.();
+      renameSpy.mockRestore();
+    }
+
+    await expect(fs.access(proposal.record.target.skillFile)).rejects.toThrow();
   });
 
   it("restores a staged drop when backup commit fails", async () => {

--- a/src/skills/workshop/service-lifecycle-hooks.test.ts
+++ b/src/skills/workshop/service-lifecycle-hooks.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../shared/deferred.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
@@ -29,6 +30,7 @@ import {
   listSkillProposalEvents,
   proposeCreateSkill,
   proposeUpdateSkill,
+  rejectSkillProposal,
 } from "./service.js";
 
 const tempDirs = createTrackedTempDirs();
@@ -181,6 +183,57 @@ describe("Skill Workshop lifecycle hooks", () => {
       }),
       { workspaceDir, agentId: "main" },
     );
+  });
+
+  it("releases the target lease before dispatching a reconciliation hook", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-skill-lifecycle-reconcile-lock-");
+    const first = await proposeCreateSkill({
+      workspaceDir,
+      agentId: "main",
+      name: "Reconcile Lock",
+      description: "First proposal sharing the target.",
+      content: "# Reconcile Lock\n",
+    });
+    const second = await proposeCreateSkill({
+      workspaceDir,
+      agentId: "main",
+      name: "Reconcile Lock",
+      description: "Second proposal sharing the target.",
+      content: "# Reconcile Lock\n",
+    });
+    await writeSkill({
+      dir: first.record.target.skillDir,
+      name: "reconcile-lock",
+      description: "Created elsewhere",
+      body: "# Created Elsewhere\n",
+    });
+    const hookEntered = createDeferred();
+    const releaseHook = createDeferred();
+    hookMocks.proposalChanged.mockImplementation(async (event) => {
+      if (event.action === "stale" && event.proposal.id === first.record.id) {
+        hookEntered.resolve();
+        await releaseHook.promise;
+      }
+    });
+
+    const inspection = inspectSkillProposal(first.record.id, { workspaceDir });
+    await hookEntered.promise;
+    try {
+      const rejected = await rejectSkillProposal({
+        workspaceDir,
+        agentId: "main",
+        proposalId: second.record.id,
+      });
+      expect(rejected.status).toBe("rejected");
+    } finally {
+      releaseHook.resolve();
+    }
+    await expect(inspection).resolves.toMatchObject({ record: { status: "stale" } });
+    expect(
+      listSkillProposalEvents({ workspaceDir, proposalId: first.record.id }).events.map(
+        (event) => event.type,
+      ),
+    ).toEqual(["created", "stale"]);
   });
 
   it("rejects apply when an untouched target asset changes after evaluation", async () => {

--- a/src/skills/workshop/service-lifecycle-hooks.test.ts
+++ b/src/skills/workshop/service-lifecycle-hooks.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createDeferred } from "../../shared/deferred.js";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,

--- a/src/skills/workshop/service-query.ts
+++ b/src/skills/workshop/service-query.ts
@@ -7,7 +7,6 @@ import {
   readWorkspaceSkillFile,
 } from "../lifecycle/workspace-skill-write.js";
 import { transitionPendingSkillProposalToStale } from "./apply-transition.js";
-import { stripProposalFrontmatterForSkill } from "./frontmatter.js";
 import { dispatchSkillProposalChanged } from "./plugin-hooks.js";
 import { hashSkillProposalRevision } from "./revision-hash.js";
 import {
@@ -206,10 +205,6 @@ async function reconcilePendingCreateProposal(
           () => null,
         );
         if (targetContent === null) {
-          return current;
-        }
-        const proposalTargetContent = stripProposalFrontmatterForSkill(current.content);
-        if (targetContent === proposalTargetContent) {
           return current;
         }
         const transition = transitionPendingSkillProposalToStale({

--- a/src/skills/workshop/service-query.ts
+++ b/src/skills/workshop/service-query.ts
@@ -3,11 +3,21 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { normalizeSkillIndexName } from "../discovery/skill-index.js";
 import {
+  assertInsideWorkspace,
+  readWorkspaceSkillFile,
+} from "../lifecycle/workspace-skill-write.js";
+import { transitionPendingSkillProposalToStale } from "./apply-transition.js";
+import { stripProposalFrontmatterForSkill } from "./frontmatter.js";
+import { dispatchSkillProposalChanged } from "./plugin-hooks.js";
+import { hashSkillProposalRevision } from "./revision-hash.js";
+import {
   readProposalSupportFiles,
   readSkillProposal,
   readSkillProposalManifest,
   readSkillProposalRecord,
+  readSkillProposalRollback,
 } from "./store.js";
+import { withSkillProposalTargetLock } from "./target-lock.js";
 import type { SkillProposalManifest, SkillProposalReadResult } from "./types.js";
 
 type SkillProposalScopeOptions = {
@@ -25,13 +35,30 @@ function storeOptions(env?: NodeJS.ProcessEnv) {
   return env ? { env } : {};
 }
 
+function proposalScope(options: SkillProposalScopeOptions) {
+  return {
+    ...(options.agentId ? { agentId: options.agentId } : {}),
+    ...(options.workspaceDir ? { workspaceDir: options.workspaceDir } : {}),
+  };
+}
+
 export async function listSkillProposals(
   options: SkillProposalScopeOptions = {},
 ): Promise<SkillProposalManifest> {
-  return await readSkillProposalManifest(storeOptions(options.env), {
-    ...(options.agentId ? { agentId: options.agentId } : {}),
-    ...(options.workspaceDir ? { workspaceDir: options.workspaceDir } : {}),
-  });
+  const store = storeOptions(options.env);
+  const scope = proposalScope(options);
+  const manifest = await readSkillProposalManifest(store, scope);
+  await Promise.all(
+    manifest.proposals
+      .filter((proposal) => proposal.kind === "create" && proposal.status === "pending")
+      .map(async (proposal) => {
+        const read = await readSkillProposal(proposal.id, store, scope);
+        if (read) {
+          await reconcilePendingCreateProposal(read, options);
+        }
+      }),
+  );
+  return await readSkillProposalManifest(store, scope);
 }
 
 export async function getSkillProposalRunProgress(
@@ -58,11 +85,18 @@ export async function inspectSkillProposal(
   proposalId: string,
   options: SkillProposalScopeOptions = {},
 ): Promise<SkillProposalReadResult | null> {
-  const read = await readSkillProposal(proposalId, storeOptions(options.env), options);
+  const read = await readSkillProposal(
+    proposalId,
+    storeOptions(options.env),
+    proposalScope(options),
+  );
   if (!read) {
     return null;
   }
-  return await hydrateProposalSupportFiles(read, options.env);
+  return await hydrateProposalSupportFiles(
+    await reconcilePendingCreateProposal(read, options),
+    options.env,
+  );
 }
 
 export async function resolvePendingSkillProposal(input: {
@@ -142,7 +176,74 @@ export async function readRequiredProposal(
   if (!read) {
     throw new Error(`Skill proposal not found: ${proposalId}`);
   }
-  return read;
+  return readOptions.reconcile === false
+    ? read
+    : await reconcilePendingCreateProposal(read, {
+        ...(agentId ? { agentId } : {}),
+        ...(env ? { env } : {}),
+        ...(workspaceDir ? { workspaceDir } : {}),
+      });
+}
+
+async function reconcilePendingCreateProposal(
+  read: SkillProposalReadResult,
+  options: SkillProposalScopeOptions,
+): Promise<SkillProposalReadResult> {
+  const workspaceDir = options.workspaceDir;
+  if (!workspaceDir || read.record.kind !== "create" || read.record.status !== "pending") {
+    return read;
+  }
+  const store = storeOptions(options.env);
+  const scope = proposalScope(options);
+  try {
+    return await withSkillProposalTargetLock(
+      read.record,
+      async () => {
+        const current = await readSkillProposal(read.record.id, store, scope, { reconcile: false });
+        if (!current || current.record.kind !== "create" || current.record.status !== "pending") {
+          return current ?? read;
+        }
+        assertInsideWorkspace(workspaceDir, current.record.target.skillFile, "skill file");
+        if (await readSkillProposalRollback(current.record.id, store)) {
+          return current;
+        }
+        const targetContent = await readWorkspaceSkillFile(current.record.target.skillFile).catch(
+          () => null,
+        );
+        if (targetContent === null) {
+          return current;
+        }
+        const proposalTargetContent = stripProposalFrontmatterForSkill(current.content);
+        if (targetContent === proposalTargetContent) {
+          return current;
+        }
+        const transition = transitionPendingSkillProposalToStale({
+          record: current.record,
+          reason: "Target skill was created after proposal creation.",
+          input: {
+            workspaceDir,
+            ...(options.agentId ? { agentId: options.agentId } : {}),
+            eventActor: { type: "system" },
+            ...(options.env ? { env: options.env } : {}),
+          },
+        });
+        await dispatchSkillProposalChanged({
+          event: transition.event,
+          record: transition.record,
+          workspaceDir,
+          ...(options.agentId ? { agentId: options.agentId } : {}),
+        });
+        return {
+          ...current,
+          record: transition.record,
+          revisionHash: hashSkillProposalRevision(transition.record),
+        };
+      },
+      store,
+    );
+  } catch {
+    return read;
+  }
 }
 
 async function hydrateProposalSupportFiles(

--- a/src/skills/workshop/service-query.ts
+++ b/src/skills/workshop/service-query.ts
@@ -108,11 +108,9 @@ export async function resolvePendingSkillProposal(input: {
 }): Promise<SkillProposalReadResult> {
   const proposalId = normalizeOptionalString(input.proposalId);
   if (proposalId) {
-    const direct = await readRequiredProposal(
-      proposalId,
-      input.workspaceDir,
-      input.env,
-      input.agentId,
+    const direct = await reconcilePendingCreateProposal(
+      await readRequiredProposal(proposalId, input.workspaceDir, input.env, input.agentId),
+      input,
     );
     if (direct.record.status !== "pending") {
       throw new Error(
@@ -143,11 +141,14 @@ export async function resolvePendingSkillProposal(input: {
       .join(", ");
     throw new Error(`Multiple pending skill proposals matched ${name}: ${candidates}`);
   }
-  const matched = await readRequiredProposal(
-    expectDefined(matches[0], "matches capture group 0").id,
-    input.workspaceDir,
-    input.env,
-    input.agentId,
+  const matched = await reconcilePendingCreateProposal(
+    await readRequiredProposal(
+      expectDefined(matches[0], "matches capture group 0").id,
+      input.workspaceDir,
+      input.env,
+      input.agentId,
+    ),
+    input,
   );
   if (matched.record.status !== "pending") {
     throw new Error(
@@ -176,13 +177,7 @@ export async function readRequiredProposal(
   if (!read) {
     throw new Error(`Skill proposal not found: ${proposalId}`);
   }
-  return readOptions.reconcile === false
-    ? read
-    : await reconcilePendingCreateProposal(read, {
-        ...(agentId ? { agentId } : {}),
-        ...(env ? { env } : {}),
-        ...(workspaceDir ? { workspaceDir } : {}),
-      });
+  return read;
 }
 
 async function reconcilePendingCreateProposal(

--- a/src/skills/workshop/service-query.ts
+++ b/src/skills/workshop/service-query.ts
@@ -189,23 +189,29 @@ async function reconcilePendingCreateProposal(
   }
   const store = storeOptions(options.env);
   const scope = proposalScope(options);
+  let reconciled:
+    | {
+        read: SkillProposalReadResult;
+        transition?: ReturnType<typeof transitionPendingSkillProposalToStale>;
+      }
+    | undefined;
   try {
-    return await withSkillProposalTargetLock(
+    reconciled = await withSkillProposalTargetLock(
       read.record,
       async () => {
         const current = await readSkillProposal(read.record.id, store, scope, { reconcile: false });
         if (!current || current.record.kind !== "create" || current.record.status !== "pending") {
-          return current ?? read;
+          return { read: current ?? read };
         }
         assertInsideWorkspace(workspaceDir, current.record.target.skillFile, "skill file");
         if (await readSkillProposalRollback(current.record.id, store)) {
-          return current;
+          return { read: current };
         }
         const targetContent = await readWorkspaceSkillFile(current.record.target.skillFile).catch(
           () => null,
         );
         if (targetContent === null) {
-          return current;
+          return { read: current };
         }
         const transition = transitionPendingSkillProposalToStale({
           record: current.record,
@@ -217,16 +223,13 @@ async function reconcilePendingCreateProposal(
             ...(options.env ? { env: options.env } : {}),
           },
         });
-        await dispatchSkillProposalChanged({
-          event: transition.event,
-          record: transition.record,
-          workspaceDir,
-          ...(options.agentId ? { agentId: options.agentId } : {}),
-        });
         return {
-          ...current,
-          record: transition.record,
-          revisionHash: hashSkillProposalRevision(transition.record),
+          read: {
+            ...current,
+            record: transition.record,
+            revisionHash: hashSkillProposalRevision(transition.record),
+          },
+          transition,
         };
       },
       store,
@@ -234,6 +237,15 @@ async function reconcilePendingCreateProposal(
   } catch {
     return read;
   }
+  if (reconciled.transition) {
+    await dispatchSkillProposalChanged({
+      event: reconciled.transition.event,
+      record: reconciled.transition.record,
+      workspaceDir,
+      ...(options.agentId ? { agentId: options.agentId } : {}),
+    });
+  }
+  return reconciled.read;
 }
 
 async function hydrateProposalSupportFiles(

--- a/src/skills/workshop/service-query.ts
+++ b/src/skills/workshop/service-query.ts
@@ -16,7 +16,7 @@ import {
   readSkillProposalRecord,
   readSkillProposalRollback,
 } from "./store.js";
-import { withSkillProposalTargetLock } from "./target-lock.js";
+import { withSkillProposalCommitLock } from "./target-lock.js";
 import type { SkillProposalManifest, SkillProposalReadResult } from "./types.js";
 
 type SkillProposalScopeOptions = {
@@ -196,7 +196,8 @@ async function reconcilePendingCreateProposal(
       }
     | undefined;
   try {
-    reconciled = await withSkillProposalTargetLock(
+    reconciled = await withSkillProposalCommitLock(
+      workspaceDir,
       read.record,
       async () => {
         const current = await readSkillProposal(read.record.id, store, scope, { reconcile: false });

--- a/src/skills/workshop/service-query.ts
+++ b/src/skills/workshop/service-query.ts
@@ -1,6 +1,8 @@
+import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { isPathInside } from "../../infra/path-safety.js";
 import { normalizeSkillIndexName } from "../discovery/skill-index.js";
 import {
   assertInsideWorkspace,
@@ -187,57 +189,56 @@ async function reconcilePendingCreateProposal(
   if (!workspaceDir || read.record.kind !== "create" || read.record.status !== "pending") {
     return read;
   }
-  const store = storeOptions(options.env);
-  const scope = proposalScope(options);
-  let reconciled:
-    | {
-        read: SkillProposalReadResult;
-        transition?: ReturnType<typeof transitionPendingSkillProposalToStale>;
-      }
-    | undefined;
-  try {
-    reconciled = await withSkillProposalCommitLock(
-      workspaceDir,
-      read.record,
-      async () => {
-        const current = await readSkillProposal(read.record.id, store, scope, { reconcile: false });
-        if (!current || current.record.kind !== "create" || current.record.status !== "pending") {
-          return { read: current ?? read };
-        }
-        assertInsideWorkspace(workspaceDir, current.record.target.skillFile, "skill file");
-        if (await readSkillProposalRollback(current.record.id, store)) {
-          return { read: current };
-        }
-        const targetContent = await readWorkspaceSkillFile(current.record.target.skillFile).catch(
-          () => null,
-        );
-        if (targetContent === null) {
-          return { read: current };
-        }
-        const transition = transitionPendingSkillProposalToStale({
-          record: current.record,
-          reason: "Target skill was created after proposal creation.",
-          input: {
-            workspaceDir,
-            ...(options.agentId ? { agentId: options.agentId } : {}),
-            eventActor: { type: "system" },
-            ...(options.env ? { env: options.env } : {}),
-          },
-        });
-        return {
-          read: {
-            ...current,
-            record: transition.record,
-            revisionHash: hashSkillProposalRevision(transition.record),
-          },
-          transition,
-        };
-      },
-      store,
-    );
-  } catch {
+  const resolvedWorkspaceDir = path.resolve(workspaceDir);
+  const resolvedTarget = path.resolve(read.record.target.skillFile);
+  // Agent-scoped reads intentionally include proposals bound to earlier workspaces.
+  // Only reconcile a target against the workspace that owns it.
+  if (
+    options.agentId &&
+    resolvedTarget !== resolvedWorkspaceDir &&
+    !isPathInside(resolvedWorkspaceDir, resolvedTarget)
+  ) {
     return read;
   }
+  const store = storeOptions(options.env);
+  const scope = proposalScope(options);
+  const reconciled = await withSkillProposalCommitLock(
+    workspaceDir,
+    read.record,
+    async () => {
+      const current = await readSkillProposal(read.record.id, store, scope, { reconcile: false });
+      if (!current || current.record.kind !== "create" || current.record.status !== "pending") {
+        return { read: current ?? read };
+      }
+      assertInsideWorkspace(workspaceDir, current.record.target.skillFile, "skill file");
+      if (await readSkillProposalRollback(current.record.id, store)) {
+        return { read: current };
+      }
+      const targetContent = await readWorkspaceSkillFile(current.record.target.skillFile);
+      if (targetContent === null) {
+        return { read: current };
+      }
+      const transition = transitionPendingSkillProposalToStale({
+        record: current.record,
+        reason: "Target skill was created after proposal creation.",
+        input: {
+          workspaceDir,
+          ...(options.agentId ? { agentId: options.agentId } : {}),
+          eventActor: { type: "system" },
+          ...(options.env ? { env: options.env } : {}),
+        },
+      });
+      return {
+        read: {
+          ...current,
+          record: transition.record,
+          revisionHash: hashSkillProposalRevision(transition.record),
+        },
+        transition,
+      };
+    },
+    store,
+  );
   if (reconciled.transition) {
     await dispatchSkillProposalChanged({
       event: reconciled.transition.event,

--- a/src/skills/workshop/service.test.ts
+++ b/src/skills/workshop/service.test.ts
@@ -474,12 +474,12 @@ describe("skill workshop proposals", () => {
       description: "Becomes stale before proposal inspection.",
       content: "# Inspected Manual Skill\n",
     });
-    await writeSkill({
-      dir: listed.record.target.skillDir,
-      name: "listed-manual-skill",
-      description: "Installed without the proposal.",
-      body: "# Listed Manual Skill\n\nAlready active.\n",
-    });
+    await fs.mkdir(listed.record.target.skillDir, { recursive: true });
+    await fs.writeFile(
+      listed.record.target.skillFile,
+      stripProposalFrontmatterForSkill(listed.content),
+      "utf8",
+    );
     await writeSkill({
       dir: inspected.record.target.skillDir,
       name: "inspected-manual-skill",
@@ -1029,7 +1029,7 @@ describe("skill workshop proposals", () => {
     expect(manifest.proposals).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ id: proposal.record.id, status: "applied" }),
-        expect.objectContaining({ id: sibling.record.id, status: "pending" }),
+        expect.objectContaining({ id: sibling.record.id, status: "stale" }),
       ]),
     );
     await expect(

--- a/src/skills/workshop/service.test.ts
+++ b/src/skills/workshop/service.test.ts
@@ -460,6 +460,58 @@ describe("skill workshop proposals", () => {
     ).rejects.toThrow("Skill already exists");
   });
 
+  it("reconciles pending create proposals when their target skills are created manually", async () => {
+    const workspaceDir = await makeWorkspace();
+    const listed = await proposeCreateSkill({
+      workspaceDir,
+      name: "Listed Manual Skill",
+      description: "Becomes stale before proposal listing.",
+      content: "# Listed Manual Skill\n",
+    });
+    const inspected = await proposeCreateSkill({
+      workspaceDir,
+      name: "Inspected Manual Skill",
+      description: "Becomes stale before proposal inspection.",
+      content: "# Inspected Manual Skill\n",
+    });
+    await writeSkill({
+      dir: listed.record.target.skillDir,
+      name: "listed-manual-skill",
+      description: "Installed without the proposal.",
+      body: "# Listed Manual Skill\n\nAlready active.\n",
+    });
+    await writeSkill({
+      dir: inspected.record.target.skillDir,
+      name: "inspected-manual-skill",
+      description: "Installed without the proposal.",
+      body: "# Inspected Manual Skill\n\nAlready active.\n",
+    });
+
+    await expect(listSkillProposals({ workspaceDir })).resolves.toMatchObject({
+      proposals: expect.arrayContaining([
+        expect.objectContaining({
+          id: listed.record.id,
+          status: "stale",
+        }),
+      ]),
+    });
+    await expect(
+      inspectSkillProposal(inspected.record.id, { workspaceDir }),
+    ).resolves.toMatchObject({
+      record: {
+        id: inspected.record.id,
+        status: "stale",
+        statusReason: "Target skill was created after proposal creation.",
+      },
+    });
+    await expect(
+      resolvePendingSkillProposal({
+        name: listed.record.target.skillKey,
+        workspaceDir,
+      }),
+    ).rejects.toThrow("No pending skill proposal matched");
+  });
+
   it("revises pending proposals in place before approval", async () => {
     const workspaceDir = await makeWorkspace();
     const proposal = await proposeCreateSkill({

--- a/test/skills-proposal-manual-target.e2e.test.ts
+++ b/test/skills-proposal-manual-target.e2e.test.ts
@@ -1,0 +1,193 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  disconnectGatewayClient,
+  startGatewayWithClient,
+} from "../src/gateway/test-helpers.e2e.js";
+import { captureEnv, setTestEnvValue } from "../src/test-utils/env.js";
+import { useAutoCleanupTempDirTracker } from "./helpers/temp-dir.js";
+
+const TEST_TIMEOUT_MS = 30_000;
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const ENV_KEYS = [
+  "HOME",
+  "USERPROFILE",
+  "OPENCLAW_STATE_DIR",
+  "OPENCLAW_CONFIG_PATH",
+  "OPENCLAW_SKIP_CHANNELS",
+  "OPENCLAW_SKIP_GMAIL_WATCHER",
+  "OPENCLAW_SKIP_CRON",
+  "OPENCLAW_SKIP_CANVAS_HOST",
+  "OPENCLAW_SKIP_BROWSER_CONTROL_SERVER",
+  "OPENCLAW_SKIP_PROVIDERS",
+  "OPENCLAW_TEST_MINIMAL_GATEWAY",
+  "OPENCLAW_BUNDLED_PLUGINS_DIR",
+  "OPENCLAW_DISABLE_BUNDLED_PLUGINS",
+] as const;
+
+async function setupTempHome() {
+  const env = captureEnv([...ENV_KEYS]);
+  const home = tempDirs.make("openclaw-skill-proposal-proof-");
+  const stateDir = path.join(home, ".openclaw");
+  const workspace = path.join(home, "workspace");
+  const bundledPlugins = path.join(home, "empty-bundled-plugins");
+  await Promise.all([
+    fs.mkdir(stateDir, { recursive: true }),
+    fs.mkdir(workspace, { recursive: true }),
+    fs.mkdir(bundledPlugins, { recursive: true }),
+  ]);
+  setTestEnvValue("HOME", home);
+  setTestEnvValue("USERPROFILE", home);
+  setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+  setTestEnvValue("OPENCLAW_SKIP_CHANNELS", "1");
+  setTestEnvValue("OPENCLAW_SKIP_GMAIL_WATCHER", "1");
+  setTestEnvValue("OPENCLAW_SKIP_CRON", "1");
+  setTestEnvValue("OPENCLAW_SKIP_CANVAS_HOST", "1");
+  setTestEnvValue("OPENCLAW_SKIP_BROWSER_CONTROL_SERVER", "1");
+  setTestEnvValue("OPENCLAW_SKIP_PROVIDERS", "1");
+  setTestEnvValue("OPENCLAW_BUNDLED_PLUGINS_DIR", bundledPlugins);
+  setTestEnvValue("OPENCLAW_DISABLE_BUNDLED_PLUGINS", "1");
+  delete process.env.OPENCLAW_CONFIG_PATH;
+  delete process.env.OPENCLAW_TEST_MINIMAL_GATEWAY;
+  return {
+    configPath: path.join(stateDir, "openclaw.json"),
+    env,
+    workspace,
+  };
+}
+
+type ProposalRecord = {
+  id: string;
+  kind: "create";
+  status: string;
+  statusReason?: string;
+  staleAt?: string;
+  target: {
+    skillKey: string;
+    skillFile: string;
+  };
+};
+
+describe("Skill proposal manual-target product proof", () => {
+  it(
+    "persists stale state and rejects apply after a target is installed manually",
+    { timeout: TEST_TIMEOUT_MS },
+    async () => {
+      const temp = await setupTempHome();
+      const token = `skill-proposal-proof-${process.pid}`;
+      let started: Awaited<ReturnType<typeof startGatewayWithClient>> | undefined;
+
+      try {
+        started = await startGatewayWithClient({
+          cfg: {
+            agents: { defaults: { workspace: temp.workspace } },
+            gateway: { auth: { mode: "token", token } },
+          },
+          configPath: temp.configPath,
+          token,
+          clientDisplayName: "skill-proposal-manual-target-proof",
+        });
+
+        const created = (await started.client.request("skills.proposals.create", {
+          agentId: "main",
+          name: "Manual Gateway Proof",
+          description: "Proof for a manually installed proposal target.",
+          content: "# Manual Gateway Proof\n\nProposal draft.\n",
+        })) as { record: ProposalRecord };
+        expect(created.record).toMatchObject({
+          kind: "create",
+          status: "pending",
+          target: {
+            skillKey: "manual-gateway-proof",
+            skillFile: path.join(temp.workspace, "skills", "manual-gateway-proof", "SKILL.md"),
+          },
+        });
+
+        await fs.mkdir(path.dirname(created.record.target.skillFile), { recursive: true });
+        await fs.writeFile(
+          created.record.target.skillFile,
+          "# Manual Gateway Proof\n\nInstalled manually.\n",
+          "utf8",
+        );
+
+        const listed = (await started.client.request("skills.proposals.list", {
+          agentId: "main",
+        })) as { proposals: ProposalRecord[] };
+        const listedRecord = listed.proposals.find((proposal) => proposal.id === created.record.id);
+        expect(listedRecord).toMatchObject({ kind: "create", status: "stale" });
+
+        const inspected = (await started.client.request("skills.proposals.inspect", {
+          agentId: "main",
+          proposalId: created.record.id,
+        })) as { record: ProposalRecord };
+        expect(inspected.record).toMatchObject({
+          id: created.record.id,
+          status: "stale",
+          statusReason: "Target skill was created after proposal creation.",
+          staleAt: expect.any(String),
+        });
+
+        const events = (await started.client.request("skills.proposals.events.list", {
+          agentId: "main",
+          proposalId: created.record.id,
+        })) as {
+          events: Array<{
+            actor: { type: string };
+            proposalId: string;
+            type: string;
+          }>;
+        };
+        expect(events.events.map((event) => event.type)).toEqual(["created", "stale"]);
+        expect(events.events.at(-1)).toMatchObject({
+          actor: { type: "system" },
+          proposalId: created.record.id,
+          type: "stale",
+        });
+
+        let applyError: unknown;
+        try {
+          await started.client.request("skills.proposals.apply", {
+            agentId: "main",
+            proposalId: created.record.id,
+          });
+        } catch (error) {
+          applyError = error;
+        }
+        expect(applyError).toMatchObject({
+          gatewayCode: "INVALID_REQUEST",
+          message: "Only pending proposals can be applied. Current status: stale.",
+        });
+
+        console.info(
+          `[skill-proposal-manual-target-proof] ${JSON.stringify({
+            head: process.env.OPENCLAW_PROOF_HEAD ?? "not-specified",
+            transport: "loopback-token-auth-websocket",
+            workspaceIsolated: true,
+            createdStatus: created.record.status,
+            listStatus: listedRecord?.status,
+            inspectStatus: inspected.record.status,
+            statusReason: inspected.record.statusReason,
+            durableEvents: events.events.map((event) => event.type),
+            staleActor: events.events.at(-1)?.actor.type,
+            applyRejected: applyError !== undefined,
+            applyErrorCode:
+              applyError && typeof applyError === "object" && "gatewayCode" in applyError
+                ? applyError.gatewayCode
+                : undefined,
+            verdict: "PASS",
+          })}`,
+        );
+      } finally {
+        try {
+          if (started) {
+            await disconnectGatewayClient(started.client).catch(() => undefined);
+            await started.server.close({ reason: "Skill proposal proof complete" });
+          }
+        } finally {
+          temp.env.restore();
+        }
+      }
+    },
+  );
+});

--- a/ui/src/pages/skill-workshop/route.ts
+++ b/ui/src/pages/skill-workshop/route.ts
@@ -18,7 +18,7 @@ export const page = definePage({
     const [{ loadSkillWorkshopPageData }, { createSkillWorkshopState, skillWorkshopRouteData }] =
       await Promise.all([import("./history-scan-page-controller.ts"), import("./proposals.ts")]);
     const state = createSkillWorkshopState();
-    await loadSkillWorkshopPageData({ state, context, force: false });
+    await loadSkillWorkshopPageData({ state, context, force: true });
     return skillWorkshopRouteData(state);
   },
 });

--- a/ui/src/pages/skill-workshop/skill-workshop-page.test.ts
+++ b/ui/src/pages/skill-workshop/skill-workshop-page.test.ts
@@ -1,3 +1,4 @@
+import type { RouteLoaderOptions } from "@openclaw/uirouter";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { SessionsListResult } from "../../api/types.ts";
@@ -5,6 +6,7 @@ import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/c
 import type { SkillWorkshopProposal } from "../../lib/skill-workshop/index.ts";
 import { createSkillWorkshopState, skillWorkshopRouteData } from "./proposals.ts";
 import type { SkillWorkshopRouteData, SkillWorkshopState } from "./proposals.ts";
+import { page as skillWorkshopRoute } from "./route.ts";
 import "./skill-workshop-page.ts";
 
 type SkillWorkshopPageTestElement = HTMLElement & {
@@ -217,6 +219,96 @@ describe("SkillWorkshopPage lifecycle", () => {
         agentId: "research",
       }),
     );
+  });
+
+  it("reloads proposals on route activation and removes Apply after reconciliation", async () => {
+    let activation = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "skills.proposals.list") {
+        activation += 1;
+        return {
+          schema: "openclaw.skill-workshop.proposals-manifest.v1",
+          updatedAt: "2026-08-12T00:00:00.000Z",
+          proposals: [
+            {
+              id: "proposal-route-refresh",
+              kind: "create",
+              status: activation === 1 ? "pending" : "stale",
+              title: "Route Refresh",
+              description: "Refresh stale proposal state on route activation.",
+              skillName: "Route Refresh",
+              skillKey: "route-refresh",
+              createdAt: "2026-08-12T00:00:00.000Z",
+              updatedAt: "2026-08-12T00:00:00.000Z",
+              scanState: "clean",
+            },
+          ],
+        };
+      }
+      if (method === "skills.proposals.inspect") {
+        const status = activation === 1 ? "pending" : "stale";
+        return {
+          record: {
+            id: "proposal-route-refresh",
+            kind: "create",
+            status,
+            title: "Route Refresh",
+            description: "Refresh stale proposal state on route activation.",
+            createdAt: "2026-08-12T00:00:00.000Z",
+            updatedAt: "2026-08-12T00:00:00.000Z",
+            proposedVersion: "v1",
+            draftHash: "a".repeat(64),
+            target: {
+              skillName: "Route Refresh",
+              skillKey: "route-refresh",
+            },
+          },
+          revisionHash: "b".repeat(64),
+          content: "# Route Refresh\n",
+          supportFiles: [],
+        };
+      }
+      if (method === "skills.proposals.historyStatus") {
+        return {
+          schema: "openclaw.skill-workshop.history-scan.v1",
+          hasScanned: false,
+          reviewedSessions: 0,
+          ideasFound: 0,
+          hasMore: false,
+          lastScanReviewed: 0,
+          lastScanIdeas: 0,
+        };
+      }
+      return {};
+    });
+    const context = createContext(request);
+    const options = {
+      signal: new AbortController().signal,
+      shouldRun: () => true,
+      revalidating: false,
+      location: { pathname: "/skill-workshop", search: "", hash: "" },
+      deps: "",
+      cause: "navigation",
+    } satisfies RouteLoaderOptions;
+    if (!skillWorkshopRoute.loader) {
+      throw new Error("skill workshop route has no loader");
+    }
+
+    const first = (await skillWorkshopRoute.loader(context, options)) as SkillWorkshopRouteData;
+    const second = (await skillWorkshopRoute.loader(context, options)) as SkillWorkshopRouteData;
+    expect(callsFor(request, "skills.proposals.list")).toHaveLength(2);
+    expect(first.skillWorkshopProposals[0]?.status).toBe("pending");
+    expect(second.skillWorkshopProposals[0]?.status).toBe("stale");
+
+    const secondPage = document.createElement(
+      "openclaw-skill-workshop-page",
+    ) as SkillWorkshopPageTestElement;
+    secondPage.data = second;
+    secondPage.context = context;
+    document.body.append(secondPage);
+    await secondPage.updateComplete;
+
+    expect(secondPage.querySelector(".sw-action-bar .sw-btn--primary")).toBeNull();
   });
 
   it("does not issue duplicate list requests while a load is in flight", async () => {


### PR DESCRIPTION
Closes #90388

## What Problem This Solves

A pending Skill Workshop create proposal could remain actionable after its target `SKILL.md` had been installed manually. List and inspect APIs returned the stale pending record, so Workshop could continue to offer Apply.

## Root Cause And Owner

Proposal query reconciliation owned the missing stale transition, but it originally serialized only on the proposal target. Current collection reconciliation owns a broader collection commit lock and can create a target transiently before rolling it back. A target-only reader could observe that intermediate file and permanently mark the proposal stale.

The architectural owner is the Skill Workshop proposal commit boundary: collection lock first, target lock second, followed by an authoritative proposal reread and one atomic state/event commit.

## Canonical Repair

- Reconcile pending create proposals under `withSkillProposalCommitLock(workspaceDir, record, ...)`, the same collection-plus-target lock used by proposal apply.
- Preserve the authoritative reread, rollback-journal skip, workspace containment check, and atomic stale record/event transition.
- Propagate lock, validation, target-read, and transition-commit failures instead of returning an actionable pending proposal.
- Preserve agent-scoped proposals bound to an earlier workspace as an intentional non-reconciliation case.
- Dispatch `skill_proposal_changed` only after both locks are released.
- Force a fresh Workshop proposal load on route activation so a reconciled stale proposal no longer renders Apply.
- Keep list, inspect, proposal-id, and name resolution on the same canonical reconciliation path.

No polling, same-page event stream, config, protocol, schema, or migration surface was added.

## User Impact

Skill Workshop list, inspect, and pending lookup now agree that a manually installed target makes its create proposal non-actionable. Concurrent collection creation and rollback cannot leak a transient target into durable proposal state. Lock or storage failures remain visible instead of silently restoring Apply.

## ClawSweeper Feedback

- Applied: reconciliation failures now propagate through the existing error path.
- Applied: list and inspect both have a real over-timeout collection-lease regression.
- Applied: the exact-head loopback Gateway proof below covers the repaired lock behavior.
- Not extracted: the apply conflict path is post-failure compensation under its target lifecycle, while query reconciliation is a pre-response collection-plus-target commit. Combining them would change lock ordering and widen lifecycle ownership beyond this issue; both already share the canonical stale transition helper and status reason.

## Scope And Size

- Rebased onto `654fc632cd8289538458d66a308f92d0eb82928c`.
- Production delta: `+135/-21` (`+114` net).
- Test delta: `+549/-1` (`+548` net).
- Contributor commits and authorship are preserved on the editable PR branch.

## Evidence

- Exact head: `d4b4f4dc79d2b0250c2ee44a7376bc161674f6fb`
- Rebase base: `654fc632cd8289538458d66a308f92d0eb82928c`
- Sanitized AWS Crabbox: `cbx_c7fe8a3afcd2`
- Final exact-head matrix: `run_11473661e9c3`
  - Focused unit/UI/Gateway methods: 100 passed.
  - Real loopback token-auth Gateway E2E: 1 passed; stale state persisted and Apply was rejected after manual target installation.
  - Over-timeout list/inspect contention regression: passed after the real five-second collection lease wait.
  - Touched-file `oxfmt --check`: passed.
  - Touched-file oxlint: 0 warnings, 0 errors.
  - `tsgo:core`, `tsgo:test:src`, `tsgo:ui`, `tsgo:test:ui`: passed.
  - Path-scoped `CI=1 pnpm check:changed -- <touched paths>`: passed.
- GitHub exact-head CI: green.
- Local isolated autoreview, max priority P1: clean; no accepted/actionable findings.

The focused coverage includes manual target reconciliation through list, inspect, and name resolution; list/inspect blocking behind a collection mutation; failed collection creation rollback preserving a pending proposal; visible timeout failures; hook dispatch after lock release; Workshop route reactivation refreshing stale state and removing Apply; and the real Gateway product path.
