### PR TITLE
fix(agents): bounded memory flush before recovery compaction

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -421,6 +421,9 @@ const config = {
     // Focused media tests consume these explicit seams; production uses the helpers in-module.
     "src/agents/embedded-agent-subscribe.handlers.lifecycle.ts": ["exports"],
     "src/gateway/server-methods/chat-webchat-media.ts": ["exports"],
+    // Focused tests assert the shared recovery-flush executor default; production
+    // applies it in-module at the runEmbeddedAgent boundary.
+    "src/agents/embedded-agent-runner/run-orchestrator.ts": ["exports"],
     // Greeting cache/fact contracts (hash, alert text, store shapes) are
     // asserted by the focused greeting unit tests, not by another prod module.
     "src/system-agent/greeting.ts": ["exports", "types"],

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"a35378b670434316ba33a3ba4e595925be685daee9fb0f3c5989983525b18c50","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}
+{"contentHash":"dd3629dae38bdd4c23c386822afafdd211d14ee199683c70edbd21df71d2d961","entrypoint":"agent-harness-runtime","importSpecifier":"openclaw/plugin-sdk/agent-harness-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
+++ b/docs/.generated/plugin-sdk-api-baseline/agent-harness.json
@@ -1,1 +1,1 @@
-{"contentHash":"b9c074a11791688e63213f51099ea21745b0e554f63ed13e694ea34a3e4328ac","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}
+{"contentHash":"e8ffdc31ddf8d3a1e791ed4ba5c44d555910d54b4d8a0b390fd25570acb81490","entrypoint":"agent-harness","importSpecifier":"openclaw/plugin-sdk/agent-harness"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-core.json
@@ -1,1 +1,1 @@
-{"contentHash":"d8b7c867b29b4651375455e938ae634e7213e3e8c17444dc2b0ef091e46fda6c","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}
+{"contentHash":"b25c202aa25ae68161cf4d51021c086888e30da0ac7d4be05a6f59f4bdf42138","entrypoint":"channel-core","importSpecifier":"openclaw/plugin-sdk/channel-core"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-entry-contract.json
@@ -1,1 +1,1 @@
-{"contentHash":"883bbab77caeff122bf8b7505dc9299484fba601e285a42d2c457697b7590b8e","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}
+{"contentHash":"c52f20b03e6e68b35066b6c1c0a1a022e62c593c40eb780bd3ce1323acb8e175","entrypoint":"channel-entry-contract","importSpecifier":"openclaw/plugin-sdk/channel-entry-contract"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-inbound.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-inbound.json
@@ -1,1 +1,1 @@
-{"contentHash":"a10b2b86f7fec9a99f951656b882414b73d04b5e16313bf0747e883da50c37df","entrypoint":"channel-inbound","importSpecifier":"openclaw/plugin-sdk/channel-inbound"}
+{"contentHash":"48dfa435a253e20847b9fe25725981dfda067ec06636fb239613610ae299318f","entrypoint":"channel-inbound","importSpecifier":"openclaw/plugin-sdk/channel-inbound"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-message.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-message.json
@@ -1,1 +1,1 @@
-{"contentHash":"2f85610859f047db1d76efbe52d9e63d8126ce8e944d53d6fdafb4e7f503b5dc","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}
+{"contentHash":"2bc29615b7bc997480298248f4e835d01026060e96a9e675b0ad4e9a19f5a8dc","entrypoint":"channel-message","importSpecifier":"openclaw/plugin-sdk/channel-message"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-outbound.json
@@ -1,1 +1,1 @@
-{"contentHash":"6b1f575e77dc71e72c4b2575f366e7e9990d391e85364844e0ecec2146e7f902","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}
+{"contentHash":"a8d15d21a3322af394ab2b7ba5b95bcb57bd5430d7fa45c573e493cb6b299440","entrypoint":"channel-outbound","importSpecifier":"openclaw/plugin-sdk/channel-outbound"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-pairing.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-pairing.json
@@ -1,1 +1,1 @@
-{"contentHash":"d92b60c0b7109446db7d24172281dfd6f79196d6428b8e6fd59e99a3d4d9f016","entrypoint":"channel-pairing","importSpecifier":"openclaw/plugin-sdk/channel-pairing"}
+{"contentHash":"dab28bbf916a543f54ba9e6bf1e98e5432083f961c5221e6f2550d728602fea8","entrypoint":"channel-pairing","importSpecifier":"openclaw/plugin-sdk/channel-pairing"}

--- a/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
+++ b/docs/.generated/plugin-sdk-api-baseline/channel-plugin-common.json
@@ -1,1 +1,1 @@
-{"contentHash":"72d713de6cb87ad8e6d9c49456477367a2d30c8157695ddb66ac57919558272b","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}
+{"contentHash":"4d2e56bc2f1bb6566731486c3ca6ea1cd0ef7418f7dfc5a844d49dbcd98cf2e8","entrypoint":"channel-plugin-common","importSpecifier":"openclaw/plugin-sdk/channel-plugin-common"}

--- a/docs/.generated/plugin-sdk-api-baseline/core.json
+++ b/docs/.generated/plugin-sdk-api-baseline/core.json
@@ -1,1 +1,1 @@
-{"contentHash":"2ccfe8eb85378f3be3f78f79f2638b00faa943e351ff69464bfed44ed63e09c1","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}
+{"contentHash":"03cafa5a84d64edbfdf8444f4a969c535a151491b9e7ff03e824d485e2215f6a","entrypoint":"core","importSpecifier":"openclaw/plugin-sdk/core"}

--- a/docs/.generated/plugin-sdk-api-baseline/discord.json
+++ b/docs/.generated/plugin-sdk-api-baseline/discord.json
@@ -1,1 +1,1 @@
-{"contentHash":"d23cd5df763235dbe35ede1c23d26735f4c183b03dc216ac212aefe75c0c1f96","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}
+{"contentHash":"9c8676d5818541d2bbb61f555ba9a7352bf10429732658e12efd3ffa576959b3","entrypoint":"discord","importSpecifier":"openclaw/plugin-sdk/discord"}

--- a/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
+++ b/docs/.generated/plugin-sdk-api-baseline/inbound-reply-dispatch.json
@@ -1,1 +1,1 @@
-{"contentHash":"f57a244e027b326090ed91cdc105c0c8c83b24318d99be0ec205fffd33504050","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}
+{"contentHash":"eea114c68c306419bca605250b12ec77d0910de40eef28b97fe086e4f61c2e57","entrypoint":"inbound-reply-dispatch","importSpecifier":"openclaw/plugin-sdk/inbound-reply-dispatch"}

--- a/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/meeting-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"5008615c80d86383e18527d71442f1501e4f02bdb3faa1494a48edf40fd66f84","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}
+{"contentHash":"188a7a524b8857354a646f3fd8da42cad3eff261ffa89b6584d11647c4d3e269","entrypoint":"meeting-runtime","importSpecifier":"openclaw/plugin-sdk/meeting-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-command-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-command-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"be5d21b9760636dd2956ac64b786213532e74ebb4cd1cc844a923b7bd5949be7","entrypoint":"plugin-command-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-command-runtime"}
+{"contentHash":"86a69ec77cb0b92f28264dfc5447a96689f9f2a3da23ab11bb6f35179552d371","entrypoint":"plugin-command-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-command-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-entry.json
@@ -1,1 +1,1 @@
-{"contentHash":"6b73741c889f68cc19a5d1f8703df2eca650fe57803795045cff122d746cbb6a","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}
+{"contentHash":"77ab9c738a1fa1c226974f667fe04bfa9da98159f6de9b63c005e04464b497cc","entrypoint":"plugin-entry","importSpecifier":"openclaw/plugin-sdk/plugin-entry"}

--- a/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/plugin-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"15704fc50b81cebceb677a5a69a7bc8c97afd962081c647de58a027bd816f19d","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}
+{"contentHash":"639bea9c651254feca8ab7efe7fb54b5f17f16f9d02a1c51e21f41eaadad6197","entrypoint":"plugin-runtime","importSpecifier":"openclaw/plugin-sdk/plugin-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/provider-catalog-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"df8043d0630d95bc4c316da28bf675a713e7f1f0c304959d1b4b9c8b30fcbd0d","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}
+{"contentHash":"ff767953e9ab89d53ecd3439b74b12a3f1a0cf2e7535d2dfce0c38abb40e67de","entrypoint":"provider-catalog-runtime","importSpecifier":"openclaw/plugin-sdk/provider-catalog-runtime"}

--- a/docs/.generated/plugin-sdk-api-baseline/runtime-store.json
+++ b/docs/.generated/plugin-sdk-api-baseline/runtime-store.json
@@ -1,1 +1,1 @@
-{"contentHash":"01918241de10b9b625379aa143ea2b3bee3ebf53369dde648c3402227d3cb5f7","entrypoint":"runtime-store","importSpecifier":"openclaw/plugin-sdk/runtime-store"}
+{"contentHash":"8ff62a21a16c6e1b95ed9efc43755919dfa6f5a0f8bbd462769968c094011adb","entrypoint":"runtime-store","importSpecifier":"openclaw/plugin-sdk/runtime-store"}

--- a/docs/.generated/plugin-sdk-api-baseline/session-catalog.json
+++ b/docs/.generated/plugin-sdk-api-baseline/session-catalog.json
@@ -1,1 +1,1 @@
-{"contentHash":"7bae1f99dfbd5920f9fa2e82abfefdf11e28c3150f15b22ee3fcf115a4dcef19","entrypoint":"session-catalog","importSpecifier":"openclaw/plugin-sdk/session-catalog"}
+{"contentHash":"8cc7026f30fda491dd6a8e4fb0663c31944cac8d708b7e7a83a2f7ba1075e9da","entrypoint":"session-catalog","importSpecifier":"openclaw/plugin-sdk/session-catalog"}

--- a/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
+++ b/docs/.generated/plugin-sdk-api-baseline/tool-plugin.json
@@ -1,1 +1,1 @@
-{"contentHash":"8b0c71c8abe13163eee28ca65e6afb490d0ae3c16288292143ad021975b96ca6","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}
+{"contentHash":"d6e1f46b2979f61399ae1158c35a356b08f88d9c050d29800794d743e4cce150","entrypoint":"tool-plugin","importSpecifier":"openclaw/plugin-sdk/tool-plugin"}

--- a/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
+++ b/docs/.generated/plugin-sdk-api-baseline/webhook-ingress.json
@@ -1,1 +1,1 @@
-{"contentHash":"eb0096fd25551a7f4a58dcf6c6b53120f3f1ddc1248b2b962cca60c75f6daa12","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}
+{"contentHash":"b2dde6e69dae7751d286c9ef8b0312ac5f4a568a86a60b4f6f49902b201cbc94","entrypoint":"webhook-ingress","importSpecifier":"openclaw/plugin-sdk/webhook-ingress"}

--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -173,6 +173,18 @@ Before compaction, OpenClaw can run a **silent memory flush** turn to store dura
 
 The memory-flush model override is exact and does not inherit the active session fallback chain. See [Memory](/concepts/memory) for details and config.
 
+Provider-overflow and timeout recovery inside the embedded agent runner apply
+the same flush contract before compacting. When the session was rejected
+because its context already overflowed, OpenClaw uses a **bounded overflow
+checkpoint**: it runs the memory-flush turn before compacting only when a
+maintenance turn is demonstrably admissible (the flush model's context budget
+has room for the session transcript plus reserve). If the maintenance turn
+cannot fit — for example when no larger-context `memoryFlush.model` is
+configured — OpenClaw compacts unchanged and records an explicit
+`[memory-flush-skip]` log line with the reason, so a skipped checkpoint is
+never silent. (Manual compaction invoked through the gateway compaction API
+does not go through this recovery path.)
+
 ## Pluggable compaction providers
 
 Plugins can register a custom compaction provider via `registerCompactionProvider()` on the plugin API. When a provider is registered and configured, OpenClaw delegates summarization to it instead of the built-in LLM pipeline.

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -243,6 +243,12 @@ important facts in the conversation that are not yet written to a file, they
 are saved automatically before the summary happens.
 </Tip>
 
+The flush contract covers recovery-triggered compaction too. If the session
+overflowed and the provider rejected the full context, OpenClaw runs the flush
+before compacting only when a reduced maintenance turn demonstrably fits the
+flush model's context budget; otherwise it compacts unchanged and logs an
+explicit `[memory-flush-skip]` reason instead of failing silently.
+
 ## Dreaming
 
 Dreaming is the default background consolidation path for memory. It collects

--- a/src/agents/embedded-agent-runner/run-orchestrator.ts
+++ b/src/agents/embedded-agent-runner/run-orchestrator.ts
@@ -75,10 +75,36 @@ import type { EmbeddedAgentRunResult } from "./types.js";
 
 const EMPTY_EMBEDDED_AGENT_CONFIG: OpenClawConfig = Object.freeze({});
 
+/**
+ * Applies the shared recovery memory-flush executor at the runner boundary.
+ *
+ * The bounded pre-compaction flush executes its nested maintenance turn
+ * through the same orchestrator, but recovery-memory-flush cannot import it
+ * directly (runtime import cycle). Only the auto-reply builder used to inject
+ * the executor, so direct, cron, and gateway embedded runs hit the
+ * unavailable-executor skip and compacted without the checkpoint. Defaulting
+ * here gives every embedded run the checkpoint; the nested turn sets
+ * `suppressCompactionRecovery` and uses an ephemeral session identity, so it
+ * cannot re-enter this path or deadlock the real session's lane.
+ */
+export function applyEmbeddedRunRecoveryFlushExecutor(
+  params: RunEmbeddedAgentParams,
+): RunEmbeddedAgentParams {
+  if (params.runRecoveryMemoryFlushTurn) {
+    return params;
+  }
+  return {
+    ...params,
+    runRecoveryMemoryFlushTurn: (runParams: RunEmbeddedAgentParams) => runEmbeddedAgent(runParams),
+  };
+}
+
 export function runEmbeddedAgent(
   paramsInput: RunEmbeddedAgentParams,
 ): Promise<EmbeddedAgentRunResult> {
-  const internalParamsInput = paramsInput as RunEmbeddedAgentInternalParams;
+  const internalParamsInput = applyEmbeddedRunRecoveryFlushExecutor(
+    paramsInput,
+  ) as RunEmbeddedAgentInternalParams;
   const requestedProvider = normalizeOptionalString(internalParamsInput.provider);
   const requestedModel = normalizeOptionalString(internalParamsInput.model);
   const needsConfiguredDefault =

--- a/src/agents/embedded-agent-runner/run/overflow-context-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/overflow-context-recovery.ts
@@ -26,6 +26,7 @@ import {
   type EmbeddedRunCompactionRecoveryInput,
 } from "./compaction-runtime.js";
 import { createRunRecoveryDiagId } from "./helpers.js";
+import { attemptRecoveryMemoryFlush } from "./recovery-memory-flush.js";
 import {
   isNoRealConversationCompactionNoop,
   resetNoRealConversationTokenSnapshot,
@@ -161,6 +162,31 @@ export async function recoverEmbeddedRunOverflow(
     log.warn(
       `context overflow detected (attempt ${input.state.overflowCompactionAttempts}/${MAX_OVERFLOW_COMPACTION_ATTEMPTS}); attempting auto-compaction for ${input.provider}/${input.modelId}`,
     );
+    // Bounded overflow checkpointing: before recovery compaction, run the
+    // configured silent memory flush only when a maintenance turn is
+    // demonstrably admissible. Otherwise compact unchanged and log the skip
+    // reason so durable-note loss is no longer completely silent.
+    if (input.state.overflowCompactionAttempts === 1) {
+      const recoveryFlush = await attemptRecoveryMemoryFlush({
+        runParams,
+        sessionKey: input.resolvedSessionKey,
+        agentId: input.sessionAgentId,
+        provider: input.provider,
+        modelId: input.modelId,
+        harnessRuntime: input.harnessRuntime,
+        observedOverflowTokens: overflowTokenCountForCompaction,
+        contextTokenBudget: input.contextTokenBudget,
+        messagesSnapshot: input.attempt.messagesSnapshot,
+        abortSignal: runParams.abortSignal,
+        getActiveSession: input.getActiveSession,
+      });
+      if (recoveryFlush.action === "flushed") {
+        log.info(
+          `[context-overflow-diag] memory flush checkpoint completed before compaction ` +
+            `diagId=${overflowDiagId} sessionKey=${runParams.sessionKey ?? input.sessionAgentId}`,
+        );
+      }
+    }
     let compactResult: CompactResult;
     let previousSessionId: string | undefined;
     await input.runOwnsCompactionBeforeHook("overflow recovery");

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -57,7 +57,7 @@ import type { TrustedSubagentCompletionHandoff } from "../../subagents/announce/
 import type { SilentReplyPromptMode } from "../../system-prompt.types.js";
 import type { PromptMode } from "../../system-prompt.types.js";
 import type { EmbeddedAgentExecutionPhase } from "../execution-phase.js";
-import type { BlockReplyFlushContext } from "../types.js";
+import type { BlockReplyFlushContext, EmbeddedAgentRunResult } from "../types.js";
 import type { AuthProfileFailurePolicy } from "./auth-profile-failure-policy.types.js";
 export type { ClientToolDefinition } from "../../command/shared-types.js";
 
@@ -264,6 +264,28 @@ export type RunEmbeddedAgentParams = {
   toolProgressDetail?: ToolProgressDetailMode;
   /** If true, suppress tool error warning payloads for this run (including mutating tools). */
   suppressToolErrorWarnings?: boolean | (() => boolean | undefined);
+  /**
+   * True for internal bounded maintenance turns (e.g. recovery-path memory
+   * flush) that must never re-enter overflow/timeout compaction recovery.
+   * Recovery stays fully disabled for the run, so a rejected turn surfaces
+   * instead of recursing or rotating the session mid-recovery.
+   * Host-only: removed from the plugin-callable embedded-run input and
+   * rejected at plugin ingress.
+   */
+  suppressCompactionRecovery?: boolean;
+  /**
+   * Optional executor for the bounded recovery-path memory flush maintenance
+   * turn. Defaulted at the shared `runEmbeddedAgent` boundary via
+   * `applyEmbeddedRunRecoveryFlushExecutor` (run-orchestrator.ts), which lives
+   * outside the embedded-runner module graph: recovery must not import the
+   * runner orchestrator (that would create a runtime import cycle), so the
+   * turn is injected as a callback. Callers may still override it. When absent
+   * (e.g. a non-embedded caller), the recovery path skips the checkpoint and
+   * records the skip reason (visibility instead of silence).
+   * Host-only: removed from the plugin-callable embedded-run input and
+   * rejected at plugin ingress.
+   */
+  runRecoveryMemoryFlushTurn?: (params: RunEmbeddedAgentParams) => Promise<EmbeddedAgentRunResult>;
   /** Bootstrap context mode for workspace file injection. */
   bootstrapContextMode?: "full" | "lightweight";
   /** Run kind hint for context mode behavior. */

--- a/src/agents/embedded-agent-runner/run/recovery-flush-executor-boundary.test.ts
+++ b/src/agents/embedded-agent-runner/run/recovery-flush-executor-boundary.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { applyEmbeddedRunRecoveryFlushExecutor } from "../run-orchestrator.js";
+import type { RunEmbeddedAgentParams } from "./params.js";
+
+describe("applyEmbeddedRunRecoveryFlushExecutor", () => {
+  it("defaults the recovery flush executor for direct embedded runs", () => {
+    // Direct, cron, and gateway callers do not inject the maintenance executor;
+    // the shared runner boundary must supply it so recovery preserves durable
+    // memory instead of hitting the unavailable-executor skip.
+    const params = {
+      runId: "direct-run",
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      config: {},
+      workspaceDir: "/tmp/workspace",
+      prompt: "continue",
+      timeoutMs: 30_000,
+    } as RunEmbeddedAgentParams;
+    const applied = applyEmbeddedRunRecoveryFlushExecutor(params);
+    expect(applied).not.toBe(params);
+    expect(applied.runRecoveryMemoryFlushTurn).toEqual(expect.any(Function));
+  });
+
+  it("preserves an explicitly injected recovery flush executor", () => {
+    const injected = async () => ({ meta: {} as never, payloads: [] });
+    const params = {
+      runId: "auto-reply-run",
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      config: {},
+      workspaceDir: "/tmp/workspace",
+      prompt: "continue",
+      timeoutMs: 30_000,
+      runRecoveryMemoryFlushTurn: injected,
+    } as RunEmbeddedAgentParams;
+    const applied = applyEmbeddedRunRecoveryFlushExecutor(params);
+    expect(applied.runRecoveryMemoryFlushTurn).toBe(injected);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/recovery-memory-flush-decision.ts
+++ b/src/agents/embedded-agent-runner/run/recovery-memory-flush-decision.ts
@@ -1,0 +1,189 @@
+/**
+ * Pure admission gate for the bounded recovery-path memory flush.
+ *
+ * Split from the recovery flush executor so the decision surface is unit-testable
+ * without dragging in the maintenance-run machinery.
+ */
+import { resolveContextTokensForModel } from "../../../agents/context.js";
+import {
+  resolveSandboxConfigForAgent,
+  resolveSandboxRuntimeStatus,
+} from "../../../agents/sandbox.js";
+import { ownsNativeCompaction, usesCliRuntime } from "../../../agents/session-runtime-compat.js";
+import { hasAlreadyFlushedForCurrentCompaction } from "../../../auto-reply/reply/memory-flush.js";
+import type { SessionEntry } from "../../../config/sessions.js";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import type { MemoryFlushPlan } from "../../../plugins/registry-contribution-types.js";
+import { isIncognitoSessionKey } from "../../../routing/session-key.js";
+import type { EmbeddedRunTrigger } from "./params.js";
+
+export type RecoveryMemoryFlushOutcome =
+  | { action: "flushed" }
+  | { action: "skipped"; reason: string };
+
+type RecoveryMemoryFlushDecision =
+  | {
+      action: "flush";
+      provider: string;
+      model: string;
+      contextWindowTokens: number;
+    }
+  | { action: "skip"; reason: string };
+
+type RecoveryMemoryFlushDecisionInput = {
+  cfg: OpenClawConfig;
+  /** Transcript session key — used for incognito detection. */
+  sessionKey?: string;
+  /**
+   * Runtime sandbox policy key (sandboxSessionKey). When present, this is the
+   * identity the sandbox writability gate must evaluate; direct-message policy
+   * deliberately separates it from the transcript sessionKey. Falls back to
+   * sessionKey to preserve the no-policy-key behavior.
+   */
+  sandboxPolicySessionKey?: string;
+  agentId?: string;
+  provider: string;
+  modelId: string;
+  trigger?: EmbeddedRunTrigger;
+  plan: MemoryFlushPlan | null;
+  entry?: SessionEntry | null;
+  observedOverflowTokens?: number;
+  contextTokenBudget?: number;
+  /**
+   * The runner-resolved agent runtime id (the embedded runner's
+   * `harnessRuntime`). Required to enforce the same CLI/native-compaction
+   * ownership exclusion the proactive memory-flush owner applies: a CLI
+   * runtime or native-compaction backend owns its resumable transcript, so a
+   * nested maintenance turn must not run against it. Optional only so callers
+   * without a resolved runtime degrade to a visible skip rather than admit by
+   * default.
+   */
+  harnessRuntime?: string;
+};
+
+/**
+ * Decides whether a recovery-path memory flush may run. Pure gate: mirrors the
+ * proactive flush gates (plan present, writable sandbox, not incognito, not
+ * heartbeat, not already flushed for this compaction cycle) and adds the
+ * bounded-checkpoint admission check against the flush model's context window.
+ */
+export function resolveRecoveryMemoryFlushDecision(
+  params: RecoveryMemoryFlushDecisionInput,
+): RecoveryMemoryFlushDecision {
+  const { cfg, sessionKey, plan } = params;
+  if (!plan) {
+    return { action: "skip", reason: "no_memory_flush_plan" };
+  }
+  if (params.trigger === "heartbeat") {
+    return { action: "skip", reason: "heartbeat_turn" };
+  }
+  // Preserve the proactive memory-flush owner's runtime-ownership exclusion:
+  // a CLI runtime or a native-compaction backend owns its resumable transcript
+  // and must remain the sole compaction owner, so a nested maintenance turn
+  // must not run against it. The proactive path enforces this before launching
+  // a flush; the recovery gate reuses the same canonical predicates so the two
+  // paths cannot diverge. Cover both overflow and timeout recovery, which both
+  // route through this single admission gate.
+  if (
+    usesCliRuntime({
+      provider: params.provider,
+      runtimeId: params.harnessRuntime,
+      cfg,
+      entry: params.entry ?? undefined,
+    })
+  ) {
+    return { action: "skip", reason: "cli_runtime_owns_transcript" };
+  }
+  if (
+    ownsNativeCompaction({
+      runtimeId: params.harnessRuntime,
+      cfg,
+      agentId: params.agentId,
+    })
+  ) {
+    return { action: "skip", reason: "native_compaction_runtime_owns_transcript" };
+  }
+  if (params.entry?.incognito === true || (sessionKey && isIncognitoSessionKey(sessionKey))) {
+    return { action: "skip", reason: "incognito_session" };
+  }
+
+  // The proactive path only flushes when the sandboxed workspace is writable.
+  // Evaluate the runtime sandbox policy key (sandboxSessionKey) when present;
+  // direct-message policy deliberately separates it from the transcript key.
+  const runtime = resolveSandboxRuntimeStatus({
+    cfg,
+    sessionKey: params.sandboxPolicySessionKey ?? sessionKey,
+    agentId: params.agentId,
+  });
+  if (runtime.sandboxed) {
+    const sandboxCfg = resolveSandboxConfigForAgent(cfg, runtime.agentId);
+    if (sandboxCfg.workspaceAccess !== "rw") {
+      return { action: "skip", reason: "sandbox_workspace_not_writable" };
+    }
+  }
+
+  if (params.entry && hasAlreadyFlushedForCurrentCompaction(params.entry)) {
+    return { action: "skip", reason: "already_flushed_for_compaction" };
+  }
+
+  // The flush plan may pin an exact maintenance model ("provider/model"). The
+  // exact override does not inherit the active fallback chain.
+  let provider = params.provider;
+  let model = params.modelId;
+  const override = plan.model?.trim();
+  if (override) {
+    const slashIdx = override.indexOf("/");
+    if (slashIdx > 0) {
+      const overrideProvider = override.slice(0, slashIdx).trim();
+      const overrideModel = override.slice(slashIdx + 1).trim();
+      if (overrideProvider && overrideModel) {
+        provider = overrideProvider;
+        model = overrideModel;
+      }
+    } else {
+      model = override;
+    }
+  }
+
+  // Fail closed for an unknown flush-model window: the proactive resolver
+  // substitutes a 200k default when metadata is absent, but an unregistered
+  // (often smaller) override must not admit a doomed maintenance turn, so the
+  // recovery gate resolves the raw window and skips on unknown provenance.
+  const contextWindowTokens = resolveContextTokensForModel({
+    cfg,
+    provider,
+    model,
+    allowAsyncLoad: false,
+  });
+  if (
+    typeof contextWindowTokens !== "number" ||
+    !Number.isFinite(contextWindowTokens) ||
+    contextWindowTokens <= 0
+  ) {
+    return { action: "skip", reason: "unknown_flush_context_window" };
+  }
+
+  const estimate =
+    typeof params.observedOverflowTokens === "number" &&
+    Number.isFinite(params.observedOverflowTokens) &&
+    params.observedOverflowTokens > 0
+      ? Math.ceil(params.observedOverflowTokens)
+      : typeof params.contextTokenBudget === "number" &&
+          Number.isFinite(params.contextTokenBudget) &&
+          params.contextTokenBudget > 0
+        ? params.contextTokenBudget + 1
+        : undefined;
+  if (estimate === undefined) {
+    return { action: "skip", reason: "unknown_maintenance_prompt_tokens" };
+  }
+
+  const headroom = contextWindowTokens - plan.reserveTokensFloor - plan.softThresholdTokens;
+  if (headroom <= 0) {
+    return { action: "skip", reason: "no_flush_headroom" };
+  }
+  if (estimate >= headroom) {
+    return { action: "skip", reason: "maintenance_turn_not_admissible" };
+  }
+
+  return { action: "flush", provider, model, contextWindowTokens };
+}

--- a/src/agents/embedded-agent-runner/run/recovery-memory-flush.test.ts
+++ b/src/agents/embedded-agent-runner/run/recovery-memory-flush.test.ts
@@ -1,0 +1,1103 @@
+import fs from "node:fs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MemoryFlushPlan } from "../../../plugins/registry-contribution-types.js";
+import type { RunEmbeddedAgentInternalParams } from "./internal-params.js";
+import type { RunEmbeddedAgentParams } from "./params.js";
+
+const mocks = vi.hoisted(() => ({
+  resolveMemoryFlushPlan: vi.fn(),
+  resolveContextTokensForModel: vi.fn(),
+  resolveSandboxRuntimeStatus: vi.fn(),
+  resolveSandboxConfigForAgent: vi.fn(),
+  usesCliRuntime: vi.fn(),
+  ownsNativeCompaction: vi.fn(),
+  loadSessionEntry: vi.fn(),
+  updateSessionEntry: vi.fn(),
+  upsertSessionEntryCore: vi.fn(),
+  deleteSessionEntryLifecycle: vi.fn(),
+  readRecentSessionTranscriptActiveEvents: vi.fn(),
+  runEmbeddedAgent: vi.fn(),
+  prepareSystemAgentRunAdmission: vi.fn(),
+  recordWriteProvenance: vi.fn(),
+}));
+
+vi.mock("../../../agents/admitted-run-context.js", () => ({
+  prepareSystemAgentRunAdmission: mocks.prepareSystemAgentRunAdmission,
+}));
+
+vi.mock("../../../plugins/memory-state.js", () => ({
+  resolveMemoryFlushPlan: mocks.resolveMemoryFlushPlan,
+}));
+
+vi.mock("../../../agents/context.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../agents/context.js")>();
+  return {
+    ...actual,
+    resolveContextTokensForModel: mocks.resolveContextTokensForModel,
+  };
+});
+
+vi.mock("../../../agents/sandbox.js", () => ({
+  resolveSandboxRuntimeStatus: mocks.resolveSandboxRuntimeStatus,
+  resolveSandboxConfigForAgent: mocks.resolveSandboxConfigForAgent,
+}));
+
+vi.mock("../../../agents/session-runtime-compat.js", () => ({
+  usesCliRuntime: mocks.usesCliRuntime,
+  ownsNativeCompaction: mocks.ownsNativeCompaction,
+}));
+
+vi.mock("../../../config/sessions/session-accessor.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../config/sessions/session-accessor.js")>();
+  return {
+    ...actual,
+    loadSessionEntry: mocks.loadSessionEntry,
+    updateSessionEntry: mocks.updateSessionEntry,
+    upsertSessionEntryCore: mocks.upsertSessionEntryCore,
+    deleteSessionEntryLifecycle: mocks.deleteSessionEntryLifecycle,
+    readRecentSessionTranscriptActiveEvents: mocks.readRecentSessionTranscriptActiveEvents,
+  };
+});
+
+const plan: MemoryFlushPlan = {
+  softThresholdTokens: 4_000,
+  forceFlushTranscriptBytes: 2 * 1024 * 1024,
+  reserveTokensFloor: 20_000,
+  prompt: "Pre-compaction memory flush.",
+  systemPrompt: "Pre-compaction memory flush turn.",
+  relativePath: "memory/2026-08-03.md",
+};
+
+const runParams = {
+  runId: "outer-run",
+  sessionId: "session-1",
+  sessionKey: "agent:main:session-1",
+  workspaceDir: "/tmp/workspace",
+  config: {},
+  prompt: "continue",
+  timeoutMs: 30_000,
+  senderIsOwner: true,
+  runRecoveryMemoryFlushTurn: mocks.runEmbeddedAgent,
+} as unknown as RunEmbeddedAgentParams;
+
+function defaultDecisionInput() {
+  return {
+    cfg: {},
+    sessionKey: "agent:main:session-1",
+    agentId: "main",
+    provider: "ollama",
+    modelId: "qwen2.5:14b",
+    trigger: "user" as const,
+    plan,
+    entry: null,
+    observedOverflowTokens: 30_000,
+    contextTokenBudget: 32_000,
+  };
+}
+
+async function attemptRecoveryFlush(overrides: Record<string, unknown> = {}) {
+  const { attemptRecoveryMemoryFlush } = await import("./recovery-memory-flush.js");
+  return attemptRecoveryMemoryFlush({
+    runParams,
+    sessionKey: runParams.sessionKey,
+    agentId: "main",
+    provider: "ollama",
+    modelId: "qwen2.5:14b",
+    observedOverflowTokens: 30_000,
+    contextTokenBudget: 32_000,
+    abortSignal: undefined,
+    getActiveSession: () => ({ id: "session-1" }),
+    ...overrides,
+  } as Parameters<typeof attemptRecoveryMemoryFlush>[0]);
+}
+
+describe("resolveRecoveryMemoryFlushDecision", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.resolveSandboxRuntimeStatus.mockReturnValue({
+      sandboxed: false,
+      agentId: "main",
+      sessionKey: "agent:main:session-1",
+      mainSessionKey: "agent:main:main",
+      mode: "host",
+      toolPolicy: {},
+    });
+    mocks.resolveSandboxConfigForAgent.mockReturnValue({ workspaceAccess: "rw" });
+    mocks.resolveContextTokensForModel.mockReturnValue(32_768);
+    // Default: the runtime is neither a CLI runtime nor a native-compaction
+    // backend, so the ownership exclusion does not fire; individual tests
+    // override these to assert the gate skips CLI/native-compaction runtimes.
+    mocks.usesCliRuntime.mockReturnValue(false);
+    mocks.ownsNativeCompaction.mockReturnValue(false);
+    mocks.prepareSystemAgentRunAdmission.mockReturnValue({
+      close: vi.fn(),
+      operationalRunInstance: { runId: "flush-run" },
+    });
+  });
+
+  it("skips when no memory flush plan is configured", async () => {
+    const { resolveRecoveryMemoryFlushDecision } =
+      await import("./recovery-memory-flush-decision.js");
+    const result = resolveRecoveryMemoryFlushDecision({
+      ...defaultDecisionInput(),
+      plan: null,
+    });
+    expect(result).toEqual({ action: "skip", reason: "no_memory_flush_plan" });
+  });
+
+  it("skips heartbeat maintenance contexts", async () => {
+    const { resolveRecoveryMemoryFlushDecision } =
+      await import("./recovery-memory-flush-decision.js");
+    const result = resolveRecoveryMemoryFlushDecision({
+      ...defaultDecisionInput(),
+      trigger: "heartbeat",
+    });
+    expect(result).toEqual({ action: "skip", reason: "heartbeat_turn" });
+  });
+
+  it("skips CLI runtimes that own their transcript lifecycle", async () => {
+    mocks.usesCliRuntime.mockReturnValue(true);
+    const { resolveRecoveryMemoryFlushDecision } =
+      await import("./recovery-memory-flush-decision.js");
+    const result = resolveRecoveryMemoryFlushDecision({
+      ...defaultDecisionInput(),
+      harnessRuntime: "claude",
+    });
+    expect(result).toEqual({ action: "skip", reason: "cli_runtime_owns_transcript" });
+    // The gate must thread the resolved runtime and session entry into the
+    // canonical predicate so it cannot diverge from the proactive path.
+    expect(mocks.usesCliRuntime).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "ollama",
+        runtimeId: "claude",
+        cfg: {},
+      }),
+    );
+  });
+
+  it("skips native-compaction backends that own their transcript lifecycle", async () => {
+    mocks.ownsNativeCompaction.mockReturnValue(true);
+    const { resolveRecoveryMemoryFlushDecision } =
+      await import("./recovery-memory-flush-decision.js");
+    const result = resolveRecoveryMemoryFlushDecision({
+      ...defaultDecisionInput(),
+      harnessRuntime: "codex",
+      agentId: "main",
+    });
+    expect(result).toEqual({
+      action: "skip",
+      reason: "native_compaction_runtime_owns_transcript",
+    });
+    expect(mocks.ownsNativeCompaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeId: "codex",
+        cfg: {},
+        agentId: "main",
+      }),
+    );
+  });
+
+  it("admits a non-CLI, non-native-compaction runtime past the ownership gate", async () => {
+    // Guard: a default runtime that owns neither CLI nor native compaction
+    // must still reach the headroom check and flush. Removing the ownership
+    // gate (or defaulting either predicate to true) would make this fail.
+    mocks.usesCliRuntime.mockReturnValue(false);
+    mocks.ownsNativeCompaction.mockReturnValue(false);
+    mocks.resolveContextTokensForModel.mockReturnValue(131_072);
+    const { resolveRecoveryMemoryFlushDecision } =
+      await import("./recovery-memory-flush-decision.js");
+    const result = resolveRecoveryMemoryFlushDecision({
+      ...defaultDecisionInput(),
+      harnessRuntime: "openclaw",
+      observedOverflowTokens: 30_000,
+    });
+    expect(result.action).toBe("flush");
+  });
+
+  it("skips incognito sessions", async () => {
+    const { resolveRecoveryMemoryFlushDecision } =
+      await import("./recovery-memory-flush-decision.js");
+    const result = resolveRecoveryMemoryFlushDecision({
+      ...defaultDecisionInput(),
+      sessionKey: "agent:main:subagent:incognito-flush-test",
+    });
+    expect(result).toEqual({ action: "skip", reason: "incognito_session" });
+  });
+
+  it("skips entry-marked incognito sessions even with a normal-shaped key", async () => {
+    const { resolveRecoveryMemoryFlushDecision } =
+      await import("./recovery-memory-flush-decision.js");
+    const result = resolveRecoveryMemoryFlushDecision({
+      ...defaultDecisionInput(),
+      entry: {
+        sessionId: "session-1",
+        updatedAt: 1,
+        incognito: true,
+      },
+    });
+    expect(result).toEqual({ action: "skip", reason: "incognito_session" });
+  });
+
+  it("skips read-only sandboxed workspaces", async () => {
+    mocks.resolveSandboxRuntimeStatus.mockReturnValue({
+      sandboxed: true,
+      agentId: "main",
+      sessionKey: "agent:main:session-1",
+      mainSessionKey: "agent:main:main",
+      mode: "sandbox",
+      toolPolicy: {},
+    });
+    mocks.resolveSandboxConfigForAgent.mockReturnValue({ workspaceAccess: "ro" });
+    const { resolveRecoveryMemoryFlushDecision } =
+      await import("./recovery-memory-flush-decision.js");
+    const result = resolveRecoveryMemoryFlushDecision(defaultDecisionInput());
+    expect(result).toEqual({ action: "skip", reason: "sandbox_workspace_not_writable" });
+  });
+
+  it("skips when the session already flushed for this compaction cycle", async () => {
+    const { resolveRecoveryMemoryFlushDecision } =
+      await import("./recovery-memory-flush-decision.js");
+    const result = resolveRecoveryMemoryFlushDecision({
+      ...defaultDecisionInput(),
+      entry: {
+        sessionId: "session-1",
+        updatedAt: 1,
+        compactionCount: 3,
+        memoryFlush: { kind: "succeeded", compactionCount: 3 },
+      },
+    });
+    expect(result).toEqual({ action: "skip", reason: "already_flushed_for_compaction" });
+  });
+
+  it("skips when the observed overflow cannot fit the flush model headroom", async () => {
+    mocks.resolveContextTokensForModel.mockReturnValue(32_768);
+    const { resolveRecoveryMemoryFlushDecision } =
+      await import("./recovery-memory-flush-decision.js");
+    const result = resolveRecoveryMemoryFlushDecision(defaultDecisionInput());
+    expect(result).toEqual({ action: "skip", reason: "maintenance_turn_not_admissible" });
+  });
+
+  it("flushes when a larger-context flush model override makes the turn admissible", async () => {
+    mocks.resolveContextTokensForModel.mockReturnValue(131_072);
+    const { resolveRecoveryMemoryFlushDecision } =
+      await import("./recovery-memory-flush-decision.js");
+    const result = resolveRecoveryMemoryFlushDecision({
+      ...defaultDecisionInput(),
+      plan: { ...plan, model: "ollama/llama3.2" },
+    });
+    expect(result).toEqual({
+      action: "flush",
+      provider: "ollama",
+      model: "llama3.2",
+      contextWindowTokens: 131_072,
+    });
+    expect(mocks.resolveContextTokensForModel).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "ollama", model: "llama3.2" }),
+    );
+  });
+
+  it("skips when the flush model context window is unknown", async () => {
+    mocks.resolveContextTokensForModel.mockReturnValue(undefined);
+    const { resolveRecoveryMemoryFlushDecision } =
+      await import("./recovery-memory-flush-decision.js");
+    const result = resolveRecoveryMemoryFlushDecision({
+      ...defaultDecisionInput(),
+      plan: { ...plan, model: "ollama/unregistered-model" },
+    });
+    expect(result).toEqual({ action: "skip", reason: "unknown_flush_context_window" });
+  });
+
+  it("evaluates sandbox writability against the sandbox policy key, not the transcript key", async () => {
+    // Direct-message policy: sandboxSessionKey differs from transcript sessionKey.
+    // The gate must evaluate sandbox writability using the policy key.
+    mocks.resolveContextTokensForModel.mockReturnValue(131_072);
+    mocks.resolveSandboxRuntimeStatus.mockImplementation((params: { sessionKey?: string }) => ({
+      sandboxed: params.sessionKey === "agent:main:dm-user-1",
+      agentId: "main",
+      sessionKey: params.sessionKey,
+      mainSessionKey: "agent:main:main",
+      mode: params.sessionKey === "agent:main:dm-user-1" ? "sandbox" : "host",
+      toolPolicy: {},
+    }));
+    mocks.resolveSandboxConfigForAgent.mockReturnValue({ workspaceAccess: "ro" });
+    const { resolveRecoveryMemoryFlushDecision } =
+      await import("./recovery-memory-flush-decision.js");
+    const result = resolveRecoveryMemoryFlushDecision({
+      ...defaultDecisionInput(),
+      sessionKey: "agent:main:session-1",
+      sandboxPolicySessionKey: "agent:main:dm-user-1",
+    });
+    // Read-only sandbox under the policy key → skip, even though the transcript
+    // key would resolve as non-sandboxed (host/writable).
+    expect(result).toEqual({ action: "skip", reason: "sandbox_workspace_not_writable" });
+    expect(mocks.resolveSandboxRuntimeStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionKey: "agent:main:dm-user-1" }),
+    );
+  });
+});
+
+describe("attemptRecoveryMemoryFlush", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.resolveMemoryFlushPlan.mockReturnValue(plan);
+    mocks.resolveSandboxRuntimeStatus.mockReturnValue({
+      sandboxed: false,
+      agentId: "main",
+      sessionKey: "agent:main:session-1",
+      mainSessionKey: "agent:main:main",
+      mode: "host",
+      toolPolicy: {},
+    });
+    mocks.resolveContextTokensForModel.mockReturnValue(131_072);
+    mocks.loadSessionEntry.mockReturnValue(undefined);
+    mocks.updateSessionEntry.mockResolvedValue({});
+    // Default: the runtime is neither CLI nor native-compaction-owned so the
+    // ownership gate admits the turn; tests that assert the skip override these.
+    mocks.usesCliRuntime.mockReturnValue(false);
+    mocks.ownsNativeCompaction.mockReturnValue(false);
+    // Default: the nested maintenance turn writes memory (invokes the core
+    // `write` tool). Tests that need a no-write or failed turn override this.
+    mocks.runEmbeddedAgent.mockImplementation(async (params: RunEmbeddedAgentParams) => {
+      void params.onAgentEvent?.({
+        stream: "tool",
+        data: { name: "write", phase: "result", isError: false },
+      });
+      return { meta: {}, payloads: [] };
+    });
+  });
+
+  it("skips the nested turn for a CLI runtime that owns its transcript", async () => {
+    // End-to-end guard for the overflow/timeout recovery call path: when the
+    // runner-resolved harnessRuntime is a CLI runtime, the admission gate must
+    // skip before any nested maintenance turn runs. Removing the harnessRuntime
+    // plumbing (or the gate) makes runEmbeddedAgent fire and this test fail.
+    mocks.usesCliRuntime.mockReturnValue(true);
+    mocks.runEmbeddedAgent.mockImplementation(async () => {
+      throw new Error("nested maintenance turn must not run for a CLI runtime");
+    });
+    const result = await attemptRecoveryFlush({ harnessRuntime: "claude" });
+    expect(result).toEqual({
+      action: "skipped",
+      reason: "cli_runtime_owns_transcript",
+    });
+    expect(mocks.runEmbeddedAgent).not.toHaveBeenCalled();
+    expect(mocks.usesCliRuntime).toHaveBeenCalledWith(
+      expect.objectContaining({ runtimeId: "claude" }),
+    );
+  });
+
+  it("skips the nested turn for a native-compaction backend", async () => {
+    mocks.ownsNativeCompaction.mockReturnValue(true);
+    mocks.runEmbeddedAgent.mockImplementation(async () => {
+      throw new Error("nested maintenance turn must not run for a native-compaction runtime");
+    });
+    const result = await attemptRecoveryFlush({ harnessRuntime: "codex" });
+    expect(result).toEqual({
+      action: "skipped",
+      reason: "native_compaction_runtime_owns_transcript",
+    });
+    expect(mocks.runEmbeddedAgent).not.toHaveBeenCalled();
+  });
+
+  it("runs a bounded silent maintenance turn and records flush state", async () => {
+    mocks.loadSessionEntry.mockReturnValue({
+      compactionCount: 2,
+      memoryFlush: undefined,
+      sessionId: "session-1",
+      updatedAt: 1,
+    });
+    const messagesSnapshot = [
+      {
+        role: "user" as const,
+        content: "DURABLE DECISION: deploy on Friday.",
+        timestamp: 1,
+      },
+    ];
+    const result = await attemptRecoveryFlush({
+      messagesSnapshot,
+      getActiveSession: () => ({
+        id: "session-1",
+        target: { storePath: "/tmp/store.sqlite", sessionKey: "agent:main:session-1" },
+      }),
+    });
+    expect(result).toEqual({ action: "flushed" });
+    expect(mocks.runEmbeddedAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        trigger: "memory",
+        suppressCompactionRecovery: true,
+        memoryFlushWritePath: "memory/2026-08-03.md",
+        prompt: expect.stringContaining("DURABLE DECISION: deploy on Friday."),
+        silentExpected: true,
+        modelFallbacksOverride: [],
+        disableTrajectory: true,
+        sessionKey: expect.stringMatching(/^agent:main:flush-/u),
+      }),
+    );
+    expect(mocks.updateSessionEntry).toHaveBeenCalledWith(
+      { storePath: "/tmp/store.sqlite", sessionKey: "agent:main:session-1" },
+      expect.any(Function),
+      { skipMaintenance: true, takeCacheOwnership: true },
+    );
+    expect(mocks.deleteSessionEntryLifecycle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        storePath: "/tmp/store.sqlite",
+        target: {
+          storeKeys: [expect.stringMatching(/^agent:main:flush-/u)],
+          canonicalKey: expect.stringMatching(/^agent:main:flush-/u),
+        },
+      }),
+    );
+  });
+
+  it("clears inherited delivery/progress, logical-turn, and ring-zero authority from the nested maintenance turn", async () => {
+    mocks.loadSessionEntry.mockReturnValue({
+      compactionCount: 2,
+      memoryFlush: undefined,
+      sessionId: "session-1",
+      updatedAt: 1,
+    });
+    const outerOnToolResult = vi.fn();
+    const outerOnPartialReply = vi.fn();
+    const outerOnBlockReply = vi.fn();
+    const outerOnRunProgress = vi.fn();
+    const outerOnExecutionStarted = vi.fn();
+    const outerShouldEmitToolResult = vi.fn(() => true);
+    const outerReplyOperation = { setPhase: vi.fn(), updateSessionId: vi.fn() };
+    const outerRecorder = {
+      complete: vi.fn(),
+      onUserMessagePersisted: vi.fn(),
+    };
+    const outerEnqueue = vi.fn();
+    const outerLogicalTurnLease = {
+      begin: vi.fn(),
+      selectForHost: vi.fn(),
+      degradeBeforeStart: vi.fn(),
+      deferDisposalUntil: vi.fn(),
+      dispose: vi.fn(),
+    };
+    const outerOnContextEngineTurnCandidate = vi.fn();
+    // Outer ring-zero / internal authority — the maintenance turn must not
+    // inherit the system-agent tool override, its tool allowlist, or the
+    // internal auth-binding callback.
+    const outerSystemAgentTool = {
+      invoke: vi.fn().mockResolvedValue({ ok: true }),
+    };
+    const outerOnSuccessfulAuthBinding = vi.fn();
+    const outerPreparedRunAdmission = { admit: vi.fn() } as never;
+    const outerAdmittedRunContext = {
+      operationalRunInstance: { runId: "outer-run" },
+    } as never;
+    const outerFastModeAutoProgressState = { offAnnounced: false, resetAnnounced: false };
+    const runParamsWithDelivery = {
+      ...runParams,
+      fastMode: "auto" as const,
+      fastModeAutoProgressState: outerFastModeAutoProgressState,
+      fastModeStartedAtMs: 1_000,
+      fastModeAutoOnSeconds: 30,
+      onToolResult: outerOnToolResult,
+      onPartialReply: outerOnPartialReply,
+      onBlockReply: outerOnBlockReply,
+      onRunProgress: outerOnRunProgress,
+      onExecutionStarted: outerOnExecutionStarted,
+      shouldEmitToolResult: outerShouldEmitToolResult,
+      replyOperation: outerReplyOperation,
+      userTurnTranscriptRecorder: outerRecorder,
+      enqueue: outerEnqueue,
+      contextEngineLogicalTurnLease: outerLogicalTurnLease,
+      onContextEngineTurnCandidate: outerOnContextEngineTurnCandidate,
+      // Ring-zero / internal authority surfaces that must be stripped.
+      systemAgentTool: outerSystemAgentTool,
+      toolsAllow: ["openclaw"],
+      onSuccessfulAuthBinding: outerOnSuccessfulAuthBinding,
+      // Outer lifecycle identity that must be stripped so the nested run
+      // captures its own generation keyed to its fresh run id.
+      lifecycleGeneration: "outer-lifecycle-generation",
+      // Outer execution-context identity surfaces that must be stripped: the
+      // maintenance run prepares/admits its own runtime.
+      preparedRunAdmission: outerPreparedRunAdmission,
+      admittedRunContext: outerAdmittedRunContext,
+      streamParams: { stream: true },
+      internalEvents: [{ kind: "turn_started" }],
+      inputProvenance: { source: "user" },
+      ownerNumbers: ["+10001"],
+      sourceReplyDeliveryMode: "visible",
+      taskSuggestionDeliveryMode: "visible",
+      silentReplyPromptMode: "prompt",
+      deferTerminalLifecycle: true,
+      deferTerminalLifecycleEnd: true,
+      blockReplyBreak: "text_end",
+      blockReplyChunking: "full",
+      streamReasoningInNonStreamModes: true,
+      terminalReplyExpectation: "required",
+      allowEmptyAssistantReplyAsSilent: true,
+      conversationRecall: { scope: "memory" },
+      cleanupBundleMcpOnRunEnd: true,
+      suppressNextUserMessagePersistence: true,
+      suppressTranscriptOnlyAssistantPersistence: true,
+      suppressAssistantErrorPersistence: true,
+    } as unknown as RunEmbeddedAgentParams;
+    mocks.runEmbeddedAgent.mockImplementation(
+      async (params: { onAgentEvent?: (evt: Record<string, unknown>) => void }) => {
+        params.onAgentEvent?.({
+          stream: "tool",
+          data: { name: "write", phase: "result", isError: false },
+        });
+        return { meta: {}, payloads: [] };
+      },
+    );
+    const outcome = await attemptRecoveryFlush({
+      runParams: runParamsWithDelivery,
+      messagesSnapshot: [
+        { role: "user" as const, content: "DURABLE DECISION: deploy on Friday.", timestamp: 1 },
+      ],
+      getActiveSession: () => ({
+        id: "session-1",
+        target: { storePath: "/tmp/store.sqlite", sessionKey: "agent:main:session-1" },
+      }),
+    });
+    expect(outcome).toEqual({ action: "flushed" });
+    const nestedParams = mocks.runEmbeddedAgent.mock.calls[0]![0] as RunEmbeddedAgentInternalParams;
+    expect(nestedParams.replyOperation).toBeUndefined();
+    expect(nestedParams.shouldEmitToolResult).toBeUndefined();
+    expect(nestedParams.shouldEmitToolOutput).toBeUndefined();
+    expect(nestedParams.onExecutionStarted).toBeUndefined();
+    expect(nestedParams.onExecutionPhase).toBeUndefined();
+    expect(nestedParams.onRunProgress).toBeUndefined();
+    expect(nestedParams.onPartialReply).toBeUndefined();
+    expect(nestedParams.onBlockReply).toBeUndefined();
+    expect(nestedParams.onToolResult).toBeUndefined();
+    expect(nestedParams.onAgentToolResult).toBeUndefined();
+    expect(nestedParams.onUserMessagePersisted).toBeUndefined();
+    expect(nestedParams.contextEngineLogicalTurnLease).toBeUndefined();
+    expect(nestedParams.onContextEngineTurnCandidate).toBeUndefined();
+    // Ring-zero system authority must not reach the memory-only maintenance
+    // turn: `systemAgentTool` (orchestrator ring-zero override) is stripped and
+    // the internal auth-binding callback is not forwarded. Ring-zero tools are
+    // merged after the memory-flush tool filter, so omitting them here is the
+    // only barrier. `toolsAllow` is NOT left undefined: an undefined allowlist
+    // lets the bundled MCP/LSP runtime constructor treat it as "allow all"
+    // (`shouldCreateBundleRuntimeForAttempt`), materializing bundled tools past
+    // the memory-only boundary. The nested run sets an explicit empty allowlist
+    // so no bundled runtime is created.
+    expect(nestedParams.systemAgentTool).toBeUndefined();
+    expect(nestedParams.toolsAllow).toEqual([]);
+    expect(nestedParams.onSuccessfulAuthBinding).toBeUndefined();
+    // The outer lifecycle generation is stripped; the orchestrator captures a
+    // fresh generation keyed to the nested run id instead of inheriting the
+    // outer execution's lifecycle identity for this privileged maintenance turn.
+    expect(nestedParams.lifecycleGeneration).toBeUndefined();
+    // The outer prepared/admitted execution contexts are stripped; the
+    // recovery flush prepares its own host-owned system admission keyed to
+    // the nested run id so `prepareEmbeddedRunRuntime` can admit it.
+    expect(nestedParams.admittedRunContext).toBeUndefined();
+    expect(nestedParams.preparedRunAdmission).toBeDefined();
+    expect(nestedParams.preparedRunAdmission).not.toBe(outerPreparedRunAdmission);
+    expect(nestedParams.preparedRunAdmission?.operationalRunInstance.runId).not.toBe("outer-run");
+    expect(nestedParams.preparedRunAdmission?.operationalRunInstance.runId).toBeTypeOf("string");
+    expect(nestedParams.userTurnTranscriptRecorder).toBeUndefined();
+    expect(nestedParams.enqueue).toBeUndefined();
+    expect(nestedParams.streamParams).toBeUndefined();
+    expect(nestedParams.internalEvents).toBeUndefined();
+    expect(nestedParams.inputProvenance).toBeUndefined();
+    expect(nestedParams.ownerNumbers).toBeUndefined();
+    expect(nestedParams.sourceReplyDeliveryMode).toBeUndefined();
+    expect(nestedParams.taskSuggestionDeliveryMode).toBeUndefined();
+    expect(nestedParams.silentReplyPromptMode).toBeUndefined();
+    expect(nestedParams.deferTerminalLifecycle).toBeUndefined();
+    expect(nestedParams.deferTerminalLifecycleEnd).toBeUndefined();
+    expect(nestedParams.blockReplyBreak).toBeUndefined();
+    expect(nestedParams.blockReplyChunking).toBeUndefined();
+    expect(nestedParams.streamReasoningInNonStreamModes).toBeUndefined();
+    expect(nestedParams.terminalReplyExpectation).toBeUndefined();
+    expect(nestedParams.allowEmptyAssistantReplyAsSilent).toBeUndefined();
+    expect(nestedParams.conversationRecall).toBeUndefined();
+    expect(nestedParams.cleanupBundleMcpOnRunEnd).toBeUndefined();
+    expect(nestedParams.suppressNextUserMessagePersistence).toBeUndefined();
+    expect(nestedParams.suppressTranscriptOnlyAssistantPersistence).toBeUndefined();
+    expect(nestedParams.suppressAssistantErrorPersistence).toBeUndefined();
+    // Fast-mode shared progress state must not reach the nested turn: the
+    // nested run mutates `offAnnounced`/`resetAnnounced` on whatever object it
+    // receives, so inheriting the outer shared object would corrupt the resumed
+    // user turn's visible fast-mode transition.
+    expect(nestedParams.fastMode).toBeUndefined();
+    expect(nestedParams.fastModeAutoProgressState).toBeUndefined();
+    expect(nestedParams.fastModeStartedAtMs).toBeUndefined();
+    expect(nestedParams.fastModeAutoOnSeconds).toBeUndefined();
+    expect(outerFastModeAutoProgressState.offAnnounced).toBe(false);
+    expect(outerFastModeAutoProgressState.resetAnnounced).toBe(false);
+    expect(nestedParams.onAgentEvent).toBeTypeOf("function");
+    // The retained private observer still detects the memory write...
+    expect(mocks.updateSessionEntry).toHaveBeenCalled();
+    // ...but no outer delivery/progress callback fired and the outer recorder
+    // was neither supplied to the nested run nor completed.
+    expect(outerOnToolResult).not.toHaveBeenCalled();
+    expect(outerOnPartialReply).not.toHaveBeenCalled();
+    expect(outerOnBlockReply).not.toHaveBeenCalled();
+    expect(outerOnRunProgress).not.toHaveBeenCalled();
+    expect(outerOnExecutionStarted).not.toHaveBeenCalled();
+    expect(outerShouldEmitToolResult).not.toHaveBeenCalled();
+    expect(outerRecorder.complete).not.toHaveBeenCalled();
+    expect(outerEnqueue).not.toHaveBeenCalled();
+    expect(outerLogicalTurnLease.begin).not.toHaveBeenCalled();
+    expect(outerLogicalTurnLease.selectForHost).not.toHaveBeenCalled();
+    expect(outerOnContextEngineTurnCandidate).not.toHaveBeenCalled();
+  });
+
+  it("does not mutate the outer fast-mode progress state across the nested flush turn", async () => {
+    // Regression for the ClawSweeper P2: progress-controller mutates
+    // `offAnnounced`/`resetAnnounced` on the shared fastModeAutoProgressState
+    // object the nested turn receives. If the nested turn inherited the outer
+    // object, the resumed user turn would skip its own visible fast-mode
+    // transition. Prove the outer object is unchanged even when the nested run
+    // touches its (own, separate) progress state.
+    mocks.loadSessionEntry.mockReturnValue({
+      compactionCount: 2,
+      memoryFlush: undefined,
+      sessionId: "session-1",
+      updatedAt: 1,
+    });
+    const outerFastModeAutoProgressState = { offAnnounced: false, resetAnnounced: false };
+    const runParamsWithFastMode = {
+      ...runParams,
+      fastMode: "auto" as const,
+      fastModeAutoProgressState: outerFastModeAutoProgressState,
+      fastModeStartedAtMs: 1_000,
+      fastModeAutoOnSeconds: 30,
+    } as unknown as RunEmbeddedAgentParams;
+    // Simulate the nested run's progress-controller mutating whatever
+    // fastModeAutoProgressState it received — exactly the corruption path.
+    mocks.runEmbeddedAgent.mockImplementation(async (params: RunEmbeddedAgentParams) => {
+      const state = params.fastModeAutoProgressState;
+      if (state && typeof state === "object" && "offAnnounced" in state) {
+        (state as { offAnnounced: boolean }).offAnnounced = true;
+        (state as { resetAnnounced?: boolean }).resetAnnounced = true;
+      }
+      // The turn still writes memory so it counts as a successful checkpoint;
+      // the regression below is about the outer object, not the write path.
+      void params.onAgentEvent?.({
+        stream: "tool",
+        data: { name: "write", phase: "result", isError: false },
+      });
+      return { meta: {}, payloads: [] };
+    });
+    const outcome = await attemptRecoveryFlush({
+      runParams: runParamsWithFastMode,
+      messagesSnapshot: [
+        { role: "user" as const, content: "DURABLE DECISION: deploy on Friday.", timestamp: 1 },
+      ],
+      getActiveSession: () => ({
+        id: "session-1",
+        target: { storePath: "/tmp/store.sqlite", sessionKey: "agent:main:session-1" },
+      }),
+    });
+    expect(outcome).toEqual({ action: "flushed" });
+    // The nested run received no shared outer object, so its mutation (if any)
+    // could not have touched the outer state.
+    expect(outerFastModeAutoProgressState.offAnnounced).toBe(false);
+    expect(outerFastModeAutoProgressState.resetAnnounced).toBe(false);
+    const nestedParams = mocks.runEmbeddedAgent.mock.calls[0]![0] as RunEmbeddedAgentParams;
+    expect(nestedParams.fastModeAutoProgressState).toBeUndefined();
+  });
+
+  it("strips client-hosted tools from the nested flush turn so a delegated terminal result cannot stamp flush success", async () => {
+    // Regression for the ClawSweeper P1: the outer spread used to retain
+    // clientTools, which bypass the core memory-flush tool filter and can
+    // return a delegated terminal result. That result is not a failed
+    // maintenance turn, so the active session would be marked
+    // memoryFlush: succeeded even though no memory was written, suppressing
+    // another checkpoint before compaction. Prove clientTools (and the
+    // related outer initiator tool/authority surface) never reach the nested
+    // run, and that a turn which completes without a memory write is not
+    // stamped as a successful flush.
+    mocks.loadSessionEntry.mockReturnValue({
+      compactionCount: 2,
+      memoryFlush: undefined,
+      sessionId: "session-1",
+      updatedAt: 1,
+    });
+    const clientTool = { name: "client_probe", description: "client-hosted probe" };
+    const runParamsWithClientTools = {
+      ...runParams,
+      clientTools: [clientTool],
+      clientCaps: ["custom-cap"],
+      toolBindings: { foo: "bar" },
+      runtimePluginToolGrant: { granted: true },
+      scheduledToolPolicy: { capped: true },
+    } as unknown as RunEmbeddedAgentParams;
+    // Simulate a delegated client-tool terminal result: the nested run ends
+    // without ever invoking the core `write` tool, so memoryFlushWroteTarget
+    // stays false.
+    mocks.runEmbeddedAgent.mockImplementation(async (params: RunEmbeddedAgentParams) => {
+      // The nested turn must not see any outer client/plugin tool surface.
+      expect(params.clientTools).toBeUndefined();
+      expect(params.clientCaps).toBeUndefined();
+      expect(params.toolBindings).toBeUndefined();
+      expect(params.runtimePluginToolGrant).toBeUndefined();
+      expect(params.scheduledToolPolicy).toBeUndefined();
+      return { meta: {}, payloads: [] };
+    });
+    const outcome = await attemptRecoveryFlush({
+      runParams: runParamsWithClientTools,
+      messagesSnapshot: [
+        { role: "user" as const, content: "DURABLE DECISION: deploy on Friday.", timestamp: 1 },
+      ],
+      getActiveSession: () => ({
+        id: "session-1",
+        target: { storePath: "/tmp/store.sqlite", sessionKey: "agent:main:session-1" },
+      }),
+    });
+    // No memory was written, so the checkpoint must be skipped — NOT stamped
+    // as a successful flush that suppresses another checkpoint this cycle.
+    expect(outcome).toEqual({ action: "skipped", reason: "no_memory_written" });
+  });
+
+  it("keeps the ephemeral flush run in the active custom store", async () => {
+    const result = await attemptRecoveryFlush({
+      getActiveSession: () => ({
+        id: "session-1",
+        target: {
+          storePath: "/tmp/custom-store.sqlite",
+          sessionKey: "agent:main:session-1",
+        },
+      }),
+    });
+    expect(result).toEqual({ action: "flushed" });
+    const nestedRunCall = mocks.runEmbeddedAgent.mock.calls[0]?.[0] as RunEmbeddedAgentParams;
+    // The nested flush must resolve the same store where the ephemeral entry is
+    // pre-created and later cleaned up, never the default store.
+    expect(nestedRunCall.sessionTarget).toEqual({
+      agentId: "main",
+      sessionId: nestedRunCall.sessionId,
+      sessionKey: nestedRunCall.sessionKey,
+      storePath: "/tmp/custom-store.sqlite",
+    });
+    expect(nestedRunCall.sessionManager).toBeUndefined();
+    expect(mocks.upsertSessionEntryCore).toHaveBeenCalledWith(
+      {
+        storePath: "/tmp/custom-store.sqlite",
+        sessionKey: nestedRunCall.sessionKey,
+        agentId: "main",
+      },
+      { sessionId: nestedRunCall.sessionId, updatedAt: expect.any(Number) },
+    );
+    expect(mocks.deleteSessionEntryLifecycle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        storePath: "/tmp/custom-store.sqlite",
+        target: {
+          storeKeys: [nestedRunCall.sessionKey],
+          canonicalKey: nestedRunCall.sessionKey,
+        },
+      }),
+    );
+  });
+
+  it("cleans up the ephemeral flush session from the active custom store on a failed turn", async () => {
+    mocks.runEmbeddedAgent.mockResolvedValue({
+      meta: {},
+      payloads: [{ text: "maintenance failed", isError: true }],
+    });
+    const result = await attemptRecoveryFlush({
+      getActiveSession: () => ({
+        id: "session-1",
+        target: {
+          storePath: "/tmp/custom-store.sqlite",
+          sessionKey: "agent:main:session-1",
+        },
+      }),
+    });
+    expect(result).toEqual({ action: "skipped", reason: "maintenance_turn_failed" });
+    const nestedRunCall = mocks.runEmbeddedAgent.mock.calls[0]?.[0] as RunEmbeddedAgentParams;
+    expect(nestedRunCall.sessionTarget).toEqual({
+      agentId: "main",
+      sessionId: nestedRunCall.sessionId,
+      sessionKey: nestedRunCall.sessionKey,
+      storePath: "/tmp/custom-store.sqlite",
+    });
+    expect(mocks.updateSessionEntry).not.toHaveBeenCalled();
+    expect(mocks.deleteSessionEntryLifecycle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        storePath: "/tmp/custom-store.sqlite",
+        target: {
+          storeKeys: [nestedRunCall.sessionKey],
+          canonicalKey: nestedRunCall.sessionKey,
+        },
+      }),
+    );
+  });
+
+  it("keeps the ephemeral flush run in the active store for a target-only identity", async () => {
+    mocks.loadSessionEntry.mockReturnValue({
+      compactionCount: 2,
+      memoryFlush: undefined,
+      sessionId: "session-1",
+      updatedAt: 1,
+    });
+    // Target-only identity: the runner derives the resolved session key from
+    // the active session target while the raw runParams key is absent. The
+    // resolved key must still scope the ephemeral flush entry and its cleanup
+    // to the active store instead of the default store.
+    const targetOnlyRunParams = {
+      ...runParams,
+      sessionKey: undefined,
+    } as RunEmbeddedAgentParams;
+    const result = await attemptRecoveryFlush({
+      runParams: targetOnlyRunParams,
+      sessionKey: "agent:main:session-1",
+      getActiveSession: () => ({
+        id: "session-1",
+        target: {
+          storePath: "/tmp/custom-store.sqlite",
+          sessionKey: "agent:main:session-1",
+        },
+      }),
+    });
+    expect(result).toEqual({ action: "flushed" });
+    const nestedRunCall = mocks.runEmbeddedAgent.mock.calls[0]?.[0] as RunEmbeddedAgentParams;
+    expect(nestedRunCall.sessionTarget).toEqual({
+      agentId: "main",
+      sessionId: nestedRunCall.sessionId,
+      sessionKey: nestedRunCall.sessionKey,
+      storePath: "/tmp/custom-store.sqlite",
+    });
+    expect(mocks.upsertSessionEntryCore).toHaveBeenCalledWith(
+      {
+        storePath: "/tmp/custom-store.sqlite",
+        sessionKey: nestedRunCall.sessionKey,
+        agentId: "main",
+      },
+      { sessionId: nestedRunCall.sessionId, updatedAt: expect.any(Number) },
+    );
+    expect(mocks.deleteSessionEntryLifecycle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        storePath: "/tmp/custom-store.sqlite",
+        target: {
+          storeKeys: [nestedRunCall.sessionKey],
+          canonicalKey: nestedRunCall.sessionKey,
+        },
+      }),
+    );
+    expect(mocks.updateSessionEntry).toHaveBeenCalledWith(
+      { storePath: "/tmp/custom-store.sqlite", sessionKey: "agent:main:session-1" },
+      expect.any(Function),
+      { skipMaintenance: true, takeCacheOwnership: true },
+    );
+  });
+
+  it("skips without running a turn when no flush plan is configured", async () => {
+    mocks.resolveMemoryFlushPlan.mockReturnValue(null);
+    const result = await attemptRecoveryFlush();
+    expect(result).toEqual({ action: "skipped", reason: "no_memory_flush_plan" });
+    expect(mocks.runEmbeddedAgent).not.toHaveBeenCalled();
+    expect(mocks.updateSessionEntry).not.toHaveBeenCalled();
+    expect(mocks.deleteSessionEntryLifecycle).not.toHaveBeenCalled();
+  });
+
+  it("skips with a visible reason when no flush executor is injected", async () => {
+    mocks.resolveMemoryFlushPlan.mockReturnValue(plan);
+    mocks.upsertSessionEntryCore.mockResolvedValue(null);
+    const noSideEffectWorkspace = "/tmp/workspace-noexec";
+    const result = await attemptRecoveryFlush({
+      runParams: {
+        ...runParams,
+        workspaceDir: noSideEffectWorkspace,
+        runRecoveryMemoryFlushTurn: undefined,
+      },
+    });
+    expect(result).toEqual({
+      action: "skipped",
+      reason: "recovery_flush_executor_unavailable",
+    });
+    expect(mocks.runEmbeddedAgent).not.toHaveBeenCalled();
+    expect(mocks.prepareSystemAgentRunAdmission).not.toHaveBeenCalled();
+    expect(mocks.upsertSessionEntryCore).not.toHaveBeenCalled();
+    expect(mocks.deleteSessionEntryLifecycle).not.toHaveBeenCalled();
+    expect(fs.existsSync(`${noSideEffectWorkspace}/memory/2026-08-03.md`)).toBe(false);
+  });
+
+  it("skips without aborting recovery when the memory plan resolver throws", async () => {
+    mocks.resolveMemoryFlushPlan.mockImplementation(() => {
+      throw new Error("plugin plan resolver exploded");
+    });
+    const result = await attemptRecoveryFlush();
+    expect(result).toEqual({
+      action: "skipped",
+      reason: "memory_flush_plan_resolver_failed",
+    });
+    expect(mocks.runEmbeddedAgent).not.toHaveBeenCalled();
+    expect(mocks.prepareSystemAgentRunAdmission).not.toHaveBeenCalled();
+    expect(mocks.upsertSessionEntryCore).not.toHaveBeenCalled();
+    expect(mocks.deleteSessionEntryLifecycle).not.toHaveBeenCalled();
+  });
+
+  it("treats an error-payload maintenance turn as a bounded skip", async () => {
+    mocks.runEmbeddedAgent.mockResolvedValue({
+      meta: {},
+      payloads: [{ text: "maintenance failed", isError: true }],
+    });
+    const result = await attemptRecoveryFlush();
+    expect(result).toEqual({ action: "skipped", reason: "maintenance_turn_failed" });
+    expect(mocks.updateSessionEntry).not.toHaveBeenCalled();
+    expect(mocks.deleteSessionEntryLifecycle).toHaveBeenCalled();
+  });
+
+  it.each([
+    { name: "aborted", result: { meta: { aborted: true }, payloads: [] } },
+    {
+      name: "errored metadata",
+      result: {
+        meta: { error: { kind: "incomplete_turn", message: "turn failed" } },
+        payloads: [],
+      },
+    },
+    { name: "timeout stop reason", result: { meta: { stopReason: "timeout" }, payloads: [] } },
+    {
+      name: "timeout phase",
+      result: { meta: { timeoutPhase: "provider" }, payloads: [] },
+    },
+    { name: "error stop reason", result: { meta: { stopReason: "error" }, payloads: [] } },
+  ])("treats a maintenance turn with $name metadata as a bounded skip", async ({ result }) => {
+    mocks.runEmbeddedAgent.mockResolvedValue(result);
+    const outcome = await attemptRecoveryFlush();
+    expect(outcome).toEqual({ action: "skipped", reason: "maintenance_turn_failed" });
+    expect(mocks.updateSessionEntry).not.toHaveBeenCalled();
+    expect(mocks.deleteSessionEntryLifecycle).toHaveBeenCalled();
+  });
+
+  it("treats a throwing maintenance turn as a bounded skip", async () => {
+    mocks.runEmbeddedAgent.mockRejectedValue(new Error("provider unreachable"));
+    const result = await attemptRecoveryFlush();
+    expect(result).toEqual({ action: "skipped", reason: "maintenance_turn_failed" });
+    expect(mocks.updateSessionEntry).not.toHaveBeenCalled();
+    expect(mocks.deleteSessionEntryLifecycle).toHaveBeenCalled();
+  });
+
+  it("records write provenance when the maintenance turn writes the memory target", async () => {
+    mocks.resolveMemoryFlushPlan.mockReturnValue({
+      ...plan,
+      recordWriteProvenance: mocks.recordWriteProvenance,
+    });
+    mocks.recordWriteProvenance.mockResolvedValue(undefined);
+    mocks.readRecentSessionTranscriptActiveEvents.mockReturnValue([
+      { message: { role: "user", content: "hi", timestamp: 1 } },
+    ]);
+    mocks.runEmbeddedAgent.mockImplementation(
+      async (params: { onAgentEvent?: (evt: Record<string, unknown>) => void }) => {
+        params.onAgentEvent?.({
+          stream: "tool",
+          data: { name: "write", phase: "result", isError: false },
+        });
+        return { meta: {}, payloads: [] };
+      },
+    );
+    await attemptRecoveryFlush({
+      messagesSnapshot: [
+        {
+          role: "user" as const,
+          content: "DURABLE DECISION: deploy on Friday.",
+          timestamp: 1,
+        },
+      ],
+      getActiveSession: () => ({
+        id: "session-1",
+        target: { storePath: "/tmp/store.sqlite", sessionKey: "agent:main:session-1" },
+      }),
+    });
+    expect(mocks.recordWriteProvenance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceDir: "/tmp/workspace",
+        relativePath: "memory/2026-08-03.md",
+        contentBefore: "",
+        originClass: "agent",
+      }),
+    );
+  });
+
+  it("runs the nested maintenance turn on a distinct lane to avoid self-deadlock", async () => {
+    mocks.loadSessionEntry.mockReturnValue({
+      compactionCount: 2,
+      memoryFlush: undefined,
+      sessionId: "session-1",
+      updatedAt: 1,
+    });
+    await attemptRecoveryFlush({
+      getActiveSession: () => ({
+        id: "session-1",
+        target: { storePath: "/tmp/store.sqlite", sessionKey: "agent:main:session-1" },
+      }),
+    });
+    // The nested run must NOT inherit the outer main lane (which recovery
+    // already holds); it must run on the dedicated nested lane.
+    expect(mocks.runEmbeddedAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ lane: "nested" }),
+    );
+  });
+
+  it("drops the outer auth profile when the flush plan pins a different provider", async () => {
+    mocks.loadSessionEntry.mockReturnValue({
+      compactionCount: 2,
+      memoryFlush: undefined,
+      sessionId: "session-1",
+      updatedAt: 1,
+    });
+    mocks.resolveMemoryFlushPlan.mockReturnValue({
+      ...plan,
+      model: "anthropic/claude-3.7-sonnet",
+    });
+    await attemptRecoveryFlush({
+      runParams: {
+        ...runParams,
+        provider: "openai",
+        authProfileId: "openai:user@example.com",
+        authProfileIdSource: "user",
+      },
+      provider: "openai",
+      modelId: "gpt-5.6",
+      getActiveSession: () => ({
+        id: "session-1",
+        target: { storePath: "/tmp/store.sqlite", sessionKey: "agent:main:session-1" },
+      }),
+    });
+    expect(mocks.runEmbeddedAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "anthropic",
+        authProfileId: undefined,
+        authProfileIdSource: undefined,
+      }),
+    );
+  });
+
+  it("keeps the outer auth profile when the flush provider shares the auth scope", async () => {
+    mocks.loadSessionEntry.mockReturnValue({
+      compactionCount: 2,
+      memoryFlush: undefined,
+      sessionId: "session-1",
+      updatedAt: 1,
+    });
+    mocks.resolveMemoryFlushPlan.mockReturnValue({
+      ...plan,
+      model: "gpt-5.6",
+    });
+    await attemptRecoveryFlush({
+      runParams: {
+        ...runParams,
+        provider: "openai",
+        authProfileId: "openai:user@example.com",
+        authProfileIdSource: "user",
+      },
+      provider: "openai",
+      modelId: "gpt-5.6",
+      getActiveSession: () => ({
+        id: "session-1",
+        target: { storePath: "/tmp/store.sqlite", sessionKey: "agent:main:session-1" },
+      }),
+    });
+    expect(mocks.runEmbeddedAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        authProfileId: "openai:user@example.com",
+        authProfileIdSource: "user",
+      }),
+    );
+  });
+});

--- a/src/agents/embedded-agent-runner/run/recovery-memory-flush.ts
+++ b/src/agents/embedded-agent-runner/run/recovery-memory-flush.ts
@@ -1,0 +1,674 @@
+/**
+ * Bounded pre-compaction memory flush for embedded-run compaction recovery.
+ *
+ * The proactive auto-reply pipeline runs a silent memory flush before
+ * preflight compaction (see `auto-reply/reply/agent-runner-memory.ts`).
+ * Compaction recovery inside the embedded runner (provider overflow, timeout)
+ * compacts the rejected session directly, so a configured memory flush never
+ * runs there and durable notes are silently dropped (openclaw/openclaw#114081).
+ *
+ * This module implements the bounded overflow-checkpointing contract: attempt
+ * the configured silent memory flush before recovery compaction only when a
+ * maintenance turn is demonstrably admissible (fits the flush model's context
+ * budget with the same reserve/soft headroom the proactive gate uses).
+ * Otherwise keep today's behavior and record an explicit skip reason.
+ */
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { prepareSystemAgentRunAdmission } from "../../../agents/admitted-run-context.js";
+import { resolveProviderScopedAuthProfile } from "../../../auto-reply/reply/agent-runner-auth-profile.js";
+import {
+  deleteSessionEntryLifecycle,
+  loadSessionEntry,
+  readRecentSessionTranscriptActiveEvents,
+  updateSessionEntry,
+  upsertSessionEntryCore,
+} from "../../../config/sessions/session-accessor.js";
+import { resolveSessionStorePathForScope } from "../../../config/sessions/session-store-path.js";
+import { selectSessionTranscriptLeafControlledPath } from "../../../config/sessions/transcript-tree.js";
+import type { ContextEngineSessionTarget } from "../../../context-engine/types.js";
+import { resolveMemoryFlushPlan, type MemoryFlushPlan } from "../../../plugins/memory-state.js";
+import { CommandLane } from "../../../process/lanes.js";
+import { log } from "../logger.js";
+import type { EmbeddedAgentRunResult } from "../types.js";
+import type { RunEmbeddedAgentInternalParams } from "./internal-params.js";
+import type { RunEmbeddedAgentParams } from "./params.js";
+import {
+  resolveRecoveryMemoryFlushDecision,
+  type RecoveryMemoryFlushOutcome,
+} from "./recovery-memory-flush-decision.js";
+import type { EmbeddedRunAttemptResult } from "./types.js";
+
+/**
+ * Keys stripped from the outer {@link RunEmbeddedAgentInternalParams} before the nested
+ * recovery flush maintenance turn runs. Every key here is mutable outer
+ * run-state, an outer-owned callback, or an outer authority surface: a
+ * tool/progress boundary in the nested turn could otherwise mutate the shared
+ * object (e.g. `fastModeAutoProgressState`), surface an internal memory write
+ * into the active conversation, or inherit ring-zero system authority.
+ *
+ * This is an explicit allowlist-of-exclusions: anything NOT listed here is
+ * inherited as-is, so adding a new mutable outer-state field to
+ * {@link RunEmbeddedAgentInternalParams} requires extending this array (the
+ * regression below fails closed if a shared mutable field leaks). Only the
+ * private write observer (`onAgentEvent`) is re-attached after the strip.
+ */
+const RECOVERY_FLUSH_NESTED_RUN_OMIT_KEYS = [
+  // Fast-mode shared progress state — the outer run owns this mutable object.
+  "fastMode",
+  "fastModeAutoProgressState",
+  "fastModeStartedAtMs",
+  "fastModeAutoOnSeconds",
+  // Outer client/plugin tool surface — the maintenance turn only needs the
+  // core memory write tool. Client-hosted tools (clientTools) are forwarded
+  // verbatim and bypass the core memory-flush tool filter; a delegated
+  // client-tool result can terminate the nested turn without writing memory,
+  // which would otherwise stamp flush success and suppress another checkpoint
+  // in this compaction cycle. clientCaps / toolBindings / runtimePluginToolGrant
+  // / scheduledToolPolicy are outer initiator capabilities/authority that the
+  // maintenance turn must not inherit.
+  "clientTools",
+  "clientCaps",
+  "toolBindings",
+  "runtimePluginToolGrant",
+  "scheduledToolPolicy",
+  // Outer ring-zero / internal authority — the maintenance turn must surface
+  // only the memory read/append tools. `systemAgentTool` is the OpenClaw
+  // orchestrator's ring-zero tool override: host-bound ring-zero tools are
+  // merged AFTER the memory-flush tool filter (agent-tools.ts), so inheriting
+  // it lets an overflowed transcript invoke privileged OpenClaw operations.
+  // `onSuccessfulAuthBinding` is an internal auth-binding callback that must
+  // not fire from the nested turn. `toolsAllow` is NOT omitted here: omitting
+  // it would leave `undefined`, which the bundled MCP/LSP runtime constructor
+  // (`shouldCreateBundleRuntimeForAttempt`) treats as "allow all" and
+  // materializes bundled tools past the memory-only boundary. The nested run
+  // instead sets `toolsAllow: []` explicitly below so no bundled runtime is
+  // created; core tools are still narrowed by the `trigger:"memory"` +
+  // `memoryFlushWritePath` contract in agent-tools.ts.
+  "systemAgentTool",
+  "onSuccessfulAuthBinding",
+  // Outer execution-context identity — the ephemeral maintenance run prepares
+  // and admits its own runtime. `preparedRunAdmission` and `admittedRunContext`
+  // are mutually exclusive outer admission states (params.ts); inheriting them
+  // would either carry the outer run's operational identity into the nested
+  // turn or trip the dual-context invariant in `resolvePreparedRunAdmission`
+  // once the nested run-loop admits its own runtime.
+  "preparedRunAdmission",
+  "admittedRunContext",
+  // Outer lifecycle identity — the orchestrator treats a supplied
+  // `lifecycleGeneration` as the new run's lifecycle binding
+  // (run-orchestrator.ts: `internalParamsInput.lifecycleGeneration ??
+  // captureAgentRunLifecycleGeneration(runId)`). Inheriting the outer
+  // generation would make the privileged nested maintenance turn share the
+  // outer execution's lifecycle identity despite receiving a fresh run id and
+  // admission; clearing it forces the orchestrator to capture a new generation
+  // keyed to the nested run id.
+  "lifecycleGeneration",
+  // Outer delivery / progress callbacks (re-attach only onAgentEvent below).
+  "onExecutionStarted",
+  "onExecutionPhase",
+  "onLaneWait",
+  "onRunProgress",
+  "onSessionIdChanged",
+  "onPartialReply",
+  "onAssistantMessageStart",
+  "onBlockReply",
+  "onBlockReplyFlush",
+  "onReasoningStream",
+  "onReasoningEnd",
+  "onToolResult",
+  "onAgentToolResult",
+  "onToolStreamBoundary",
+  "onUserMessagePersisted",
+  "onUserMessagePersistenceInvalidated",
+  "onAssistantErrorMessagePersisted",
+  // Outer logical-turn ownership — the active user turn's context-engine lease
+  // and attempt-facts callback must not reach the ephemeral maintenance run.
+  "contextEngineLogicalTurnLease",
+  "onContextEngineTurnCandidate",
+  // Outer reply / delivery / lifecycle state.
+  "replyOperation",
+  "shouldEmitToolResult",
+  "shouldEmitToolOutput",
+  "userTurnTranscriptRecorder",
+  "enqueue",
+  "streamParams",
+  "internalEvents",
+  "inputProvenance",
+  "ownerNumbers",
+  "sourceReplyDeliveryMode",
+  "taskSuggestionDeliveryMode",
+  "silentReplyPromptMode",
+  "deferTerminalLifecycle",
+  "deferTerminalLifecycleEnd",
+  "blockReplyBreak",
+  "blockReplyChunking",
+  "streamReasoningInNonStreamModes",
+  "terminalReplyExpectation",
+  "allowEmptyAssistantReplyAsSilent",
+  "conversationRecall",
+  "cleanupBundleMcpOnRunEnd",
+  "suppressNextUserMessagePersistence",
+  "suppressTranscriptOnlyAssistantPersistence",
+  "suppressAssistantErrorPersistence",
+] as const satisfies readonly (keyof RunEmbeddedAgentInternalParams)[];
+
+/** Strips every outer mutable/callback/authority field, returning a clean base for the nested turn. */
+function buildRecoveryFlushNestedRunBase(
+  runParams: RunEmbeddedAgentInternalParams,
+): RunEmbeddedAgentParams {
+  const base: Record<string, unknown> = { ...runParams };
+  for (const key of RECOVERY_FLUSH_NESTED_RUN_OMIT_KEYS) {
+    base[key] = undefined;
+  }
+  return base as unknown as RunEmbeddedAgentParams;
+}
+
+/**
+ * Creates the canonical memory/YYYY-MM-DD.md target the same way the proactive
+ * flush does, so an append-only write tool can land durable notes there.
+ */
+async function ensureRecoveryFlushTargetFile(params: {
+  workspaceDir: string;
+  relativePath: string;
+}): Promise<void> {
+  const { workspaceDir, relativePath } = params;
+  if (!workspaceDir || !relativePath || path.isAbsolute(relativePath)) {
+    throw new Error("Invalid memory flush target path");
+  }
+  const workspaceRoot = path.resolve(workspaceDir);
+  const targetPath = path.resolve(workspaceRoot, relativePath);
+  const targetRelativePath = path.relative(workspaceRoot, targetPath);
+  if (
+    !targetRelativePath ||
+    targetRelativePath.startsWith("..") ||
+    path.isAbsolute(targetRelativePath)
+  ) {
+    throw new Error("Memory flush target path must stay inside the workspace");
+  }
+  await fs.promises.mkdir(path.dirname(targetPath), { recursive: true });
+  const handle = await fs.promises.open(targetPath, "a");
+  await handle.close();
+}
+
+function hasVisibleErrorPayloads(payloads: EmbeddedAgentRunResult["payloads"]): boolean {
+  return (
+    Array.isArray(payloads) &&
+    payloads.some((payload) => (payload as { isError?: boolean })?.isError === true)
+  );
+}
+
+/**
+ * Mirrors the canonical embedded-run terminal classification
+ * (`resolveTerminalStatus` in `run-entry.ts`): a maintenance turn counts as
+ * failed when it surfaces an error payload OR the run metadata reports an
+ * abort, error, timeout, or error stop reason — even when the payload list is
+ * empty. Those outcomes must never be stamped as a completed checkpoint.
+ */
+function isMaintenanceTurnFailed(result: EmbeddedAgentRunResult): boolean {
+  if (hasVisibleErrorPayloads(result.payloads)) {
+    return true;
+  }
+  const meta = result.meta;
+  return (
+    meta.stopReason === "timeout" ||
+    Boolean(meta.timeoutPhase) ||
+    meta.aborted === true ||
+    Boolean(meta.error) ||
+    meta.stopReason === "error"
+  );
+}
+
+/**
+ * Renders the messages that overflowed into a bounded text snapshot for the
+ * maintenance turn. Keeping only the most recent content bounds the turn and
+ * preserves the durable decisions made closest to the compaction point.
+ */
+function renderBoundedConversationText(
+  messages: EmbeddedRunAttemptResult["messagesSnapshot"] | undefined,
+  maxChars: number,
+): string {
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return "";
+  }
+  const rendered: string[] = [];
+  for (const message of messages) {
+    const role = message.role;
+    const content = (message as { content?: unknown }).content;
+    let text = "";
+    if (typeof content === "string") {
+      text = content;
+    } else if (Array.isArray(content)) {
+      text = content
+        .map((part: { type?: string; text?: unknown; content?: unknown }) => {
+          if (part?.type === "text" && typeof part.text === "string") {
+            return part.text;
+          }
+          if (
+            (part?.type === "tool_result" || part?.type === "toolResult") &&
+            typeof part.content === "string"
+          ) {
+            return `[tool result] ${part.content}`;
+          }
+          return "";
+        })
+        .filter(Boolean)
+        .join("\n");
+    }
+    if (text.trim()) {
+      rendered.push(`[${role}] ${text}`);
+    }
+  }
+  if (rendered.length === 0) {
+    return "";
+  }
+  let joined = rendered.join("\n\n");
+  if (joined.length > maxChars) {
+    joined = joined.slice(-maxChars);
+  }
+  return joined;
+}
+
+const RECOVERY_FLUSH_TAINT_TAIL_EVENTS = 200;
+
+/**
+ * Mirrors the proactive flush's turn-taint scan: walks the active transcript
+ * tail to the nearest user boundary and reports whether the turn is tainted
+ * (explicit `turnTainted` marker or network-sourced content).
+ */
+function readRecoveryFlushTurnTaint(events: readonly unknown[]): {
+  boundaryFound: boolean;
+  tainted: boolean;
+} {
+  const activeEvents = selectSessionTranscriptLeafControlledPath(events) ?? events;
+  for (const event of activeEvents.toReversed()) {
+    if (!event || typeof event !== "object" || Array.isArray(event)) {
+      continue;
+    }
+    const message = (event as { message?: unknown }).message;
+    if (!message || typeof message !== "object" || Array.isArray(message)) {
+      continue;
+    }
+    const record = message as Record<string, unknown>;
+    if (record.role === "user") {
+      return { boundaryFound: true, tainted: false };
+    }
+    const metadata = record["__openclaw"];
+    if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+      continue;
+    }
+    const openClaw = metadata as { resultContentSource?: unknown; turnTainted?: unknown };
+    if (openClaw.turnTainted === true || openClaw.resultContentSource === "network") {
+      return { boundaryFound: false, tainted: true };
+    }
+  }
+  return { boundaryFound: false, tainted: false };
+}
+
+async function resolveRecoveryFlushOriginClass(input: {
+  runParams: RunEmbeddedAgentInternalParams;
+  agentId?: string;
+  sessionKey?: string;
+  sessionId: string;
+  storePath?: string;
+}): Promise<"agent" | "untrusted"> {
+  if (input.runParams.senderIsOwner !== true || !input.sessionKey || !input.storePath) {
+    return "untrusted";
+  }
+  try {
+    const events = readRecentSessionTranscriptActiveEvents(
+      {
+        agentId: input.agentId,
+        sessionId: input.sessionId,
+        sessionKey: input.sessionKey,
+        storePath: input.storePath,
+      },
+      RECOVERY_FLUSH_TAINT_TAIL_EVENTS,
+    );
+    const scan = readRecoveryFlushTurnTaint(events);
+    const turnTainted =
+      scan.tainted || (!scan.boundaryFound && events.length >= RECOVERY_FLUSH_TAINT_TAIL_EVENTS);
+    return turnTainted ? "untrusted" : "agent";
+  } catch {
+    return "untrusted";
+  }
+}
+
+async function readMemoryFlushTargetFile(absolutePath: string): Promise<string> {
+  try {
+    return await fs.promises.readFile(absolutePath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return "";
+    }
+    throw error;
+  }
+}
+
+/**
+ * Attempts the bounded pre-compaction memory flush during recovery compaction.
+ *
+ * The maintenance turn runs through the same embedded maintenance machinery as
+ * the proactive flush, but on an ephemeral session identity: the recovery path
+ * still holds the real session's command lane, so a nested run against the same
+ * session would deadlock. The overflowing messages are embedded in the prompt as
+ * a bounded snapshot, and `suppressCompactionRecovery` keeps the turn from
+ * re-entering overflow/timeout recovery or rotating any session. If the turn
+ * cannot be admitted or fails, the caller proceeds with compaction unchanged
+ * and a skip reason is logged — the missing-visibility half of the bug is fixed
+ * even when a checkpoint is impossible.
+ */
+export async function attemptRecoveryMemoryFlush(input: {
+  runParams: RunEmbeddedAgentInternalParams;
+  sessionKey?: string;
+  agentId?: string;
+  provider: string;
+  modelId: string;
+  /**
+   * The runner-resolved agent runtime id, threaded into the admission gate so
+   * the CLI/native-compaction ownership exclusion matches the proactive path.
+   * The embedded compaction-recovery input already resolves this as
+   * `harnessRuntime`; both overflow and timeout recovery pass it through.
+   */
+  harnessRuntime?: string;
+  observedOverflowTokens?: number;
+  contextTokenBudget?: number;
+  messagesSnapshot?: EmbeddedRunAttemptResult["messagesSnapshot"];
+  abortSignal?: AbortSignal;
+  getActiveSession: () => { id: string; target?: ContextEngineSessionTarget };
+}): Promise<RecoveryMemoryFlushOutcome> {
+  const { runParams } = input;
+  // Prefer the runner-resolved session key (derived from the explicit key,
+  // session target, or session id) so a target-only identity still resolves
+  // the active store; fall back to the raw optional key for defensive callers.
+  const sessionKey = input.sessionKey ?? runParams.sessionKey;
+  const sessionTarget = input.getActiveSession().target;
+  const storePath = sessionKey
+    ? resolveSessionStorePathForScope({
+        sessionKey,
+        storePath: sessionTarget?.storePath,
+        agentId: input.agentId,
+      })
+    : undefined;
+  const entry = sessionKey && storePath ? loadSessionEntry({ storePath, sessionKey }) : undefined;
+  // Honor the runtime sandbox policy key: direct-message policy
+  // deliberately separates sandboxSessionKey from the transcript sessionKey,
+  // so the sandbox writability gate must evaluate the policy identity while
+  // the incognito check still uses the transcript key.
+  // The resolver is plugin-owned code, so a throwing resolver must degrade to
+  // a visible skip instead of aborting the recovery callers' compact-and-retry
+  // fallback, mirroring the proactive memory-flush owner.
+  let plan: MemoryFlushPlan | null;
+  try {
+    plan = resolveMemoryFlushPlan({ cfg: runParams.config });
+  } catch (err) {
+    log.warn(
+      `[memory-flush-skip] sessionKey=${sessionKey ?? "unknown"} ` +
+        `reason=memory_flush_plan_resolver_failed ` +
+        `error=${err instanceof Error ? err.message : String(err)}`,
+    );
+    return { action: "skipped", reason: "memory_flush_plan_resolver_failed" };
+  }
+  const decision = resolveRecoveryMemoryFlushDecision({
+    cfg: runParams.config ?? {},
+    sessionKey,
+    sandboxPolicySessionKey: runParams.sandboxSessionKey,
+    agentId: input.agentId,
+    provider: input.provider,
+    modelId: input.modelId,
+    trigger: runParams.trigger,
+    plan,
+    entry,
+    harnessRuntime: input.harnessRuntime,
+    observedOverflowTokens: input.observedOverflowTokens,
+    contextTokenBudget: input.contextTokenBudget,
+  });
+  if (decision.action === "skip") {
+    log.warn(
+      `[memory-flush-skip] sessionKey=${sessionKey ?? "unknown"} ` +
+        `provider=${input.provider}/${input.modelId} reason=${decision.reason}`,
+    );
+    return { action: "skipped", reason: decision.reason };
+  }
+
+  if (!runParams.workspaceDir || !plan) {
+    log.warn(
+      `[memory-flush-skip] sessionKey=${sessionKey ?? "unknown"} ` +
+        `reason=missing_workspace_or_plan`,
+    );
+    return { action: "skipped", reason: "missing_workspace_or_plan" };
+  }
+
+  const flushRunId = crypto.randomUUID();
+  const agentId = input.agentId ?? runParams.agentId ?? "main";
+  // Guard the executor before any persistent setup: an unavailable executor
+  // must leave recovery unchanged (no blank memory target, no orphan flush
+  // session, and no prepared nested admission left unclosed), exactly like
+  // the proactive flush's no-plan skip.
+  const runRecoveryMemoryFlushTurn = runParams.runRecoveryMemoryFlushTurn;
+  if (!runRecoveryMemoryFlushTurn) {
+    log.warn(
+      `[memory-flush-skip] sessionKey=${sessionKey ?? "unknown"} ` +
+        `reason=recovery_flush_executor_unavailable`,
+    );
+    return { action: "skipped", reason: "recovery_flush_executor_unavailable" };
+  }
+  // The ephemeral maintenance run is a host-owned internal run: it must not
+  // inherit the outer run's prepared/admitted execution context, so the
+  // recovery flush prepares its own system admission keyed to the nested
+  // run id. Without it, the nested run-loop's `prepareEmbeddedRunRuntime`
+  // (which resolves a prepared/admitted execution context on main) fails
+  // closed for the stripped params.
+  const nestedRunAdmission = prepareSystemAgentRunAdmission(
+    runParams.config ?? {},
+    flushRunId,
+    agentId,
+    "recovery-memory-flush",
+  );
+  const flushSystemPrompt = [runParams.extraSystemPrompt, plan.systemPrompt]
+    .filter((text): text is string => Boolean(text))
+    .join("\n\n");
+  const conversationText = renderBoundedConversationText(input.messagesSnapshot, 32_000);
+  const flushPrompt = [
+    plan.prompt,
+    conversationText ? `\n\nConversation snapshot:\n${conversationText}` : "",
+  ].join("");
+  const flushSessionKey = `agent:${agentId}:flush-${flushRunId}`;
+  let flushSessionCreated = false;
+  try {
+    await ensureRecoveryFlushTargetFile({
+      workspaceDir: runParams.workspaceDir,
+      relativePath: plan.relativePath,
+    });
+    const memoryFlushAbsolutePath = path.join(runParams.workspaceDir, plan.relativePath);
+    const memoryFlushContentBefore = await readMemoryFlushTargetFile(memoryFlushAbsolutePath);
+    let memoryFlushWroteTarget = false;
+    // The maintenance turn runs on an ephemeral session (own command lane) so it
+    // cannot deadlock against the real session's lane, which recovery still
+    // holds. Pre-create the session entry so the run can persist its transcript
+    // header; trajectory persistence stays disabled to keep the store clean.
+    if (storePath) {
+      await upsertSessionEntryCore(
+        { storePath, sessionKey: flushSessionKey, agentId },
+        { sessionId: flushRunId, updatedAt: Date.now() },
+      );
+      flushSessionCreated = true;
+    }
+    // The ephemeral flush session must stay in the active session's store:
+    // the entry is pre-created (and later cleaned up) at `storePath`, so the
+    // nested run has to resolve the same store instead of falling back to the
+    // default SQLite store. Carry an ephemeral typed target with that path.
+    const ephemeralFlushSessionTarget = storePath
+      ? {
+          agentId,
+          sessionId: flushRunId,
+          sessionKey: flushSessionKey,
+          storePath,
+        }
+      : undefined;
+    // The flush plan may pin a different provider than the outer run. The
+    // outer user-pinned auth profile must only travel when that provider
+    // shares the outer run's auth scope (canonical provider-scoped auth
+    // contract); otherwise the maintenance turn uses the flush provider's own
+    // credentials instead of failing with a mismatched profile.
+    const flushAuthProfile = resolveProviderScopedAuthProfile({
+      provider: decision.provider,
+      primaryProvider: input.provider,
+      authProfileId: runParams.authProfileId,
+      authProfileIdSource: runParams.authProfileIdSource,
+      config: runParams.config,
+      workspaceDir: runParams.workspaceDir,
+    });
+    const nestedRunParams: RunEmbeddedAgentParams = {
+      ...buildRecoveryFlushNestedRunBase(runParams),
+      // Ephemeral flush-run identity: never inherit the outer session's
+      // manager/file/transcript. The nested run opens its own ephemeral
+      // manager on the typed target above.
+      runId: flushRunId,
+      preparedRunAdmission: nestedRunAdmission,
+      sessionId: flushRunId,
+      sessionKey: flushSessionKey,
+      sessionManager: undefined,
+      sessionTarget: ephemeralFlushSessionTarget,
+      sessionFile: undefined,
+      // Flush-turn-specific inputs. Everything else either comes from the
+      // outer run (immutable config, workspace, sandbox identity) or was
+      // stripped by buildRecoveryFlushNestedRunBase (mutable outer state and
+      // callbacks). Only the private write observer is re-attached.
+      provider: decision.provider,
+      model: decision.model,
+      authProfileId: flushAuthProfile.authProfileId,
+      authProfileIdSource: flushAuthProfile.authProfileIdSource,
+      modelFallbacksOverride: [],
+      prompt: flushPrompt,
+      transcriptPrompt: "",
+      extraSystemPrompt: flushSystemPrompt,
+      silentExpected: true,
+      trigger: "memory",
+      memoryFlushWritePath: plan.relativePath,
+      // Explicit empty allowlist: blocks bundled MCP/LSP runtime creation
+      // (`shouldCreateBundleRuntimeForAttempt` returns false for `[]`, whereas
+      // `undefined` would allow all bundled tools past the memory-only
+      // boundary). Core tools are still narrowed by the memory-flush filter in
+      // agent-tools.ts.
+      toolsAllow: [],
+      lane: CommandLane.Nested,
+      suppressCompactionRecovery: true,
+      disableTrajectory: true,
+      abortSignal: input.abortSignal,
+      onAgentEvent: (evt) => {
+        if (
+          evt.stream === "tool" &&
+          evt.data.name === "write" &&
+          evt.data.phase === "result" &&
+          evt.data.isError !== true
+        ) {
+          memoryFlushWroteTarget = true;
+        }
+      },
+    };
+    const result = await runRecoveryMemoryFlushTurn(nestedRunParams);
+    if (isMaintenanceTurnFailed(result)) {
+      log.warn(
+        `[memory-flush-skip] sessionKey=${sessionKey ?? "unknown"} ` +
+          `provider=${decision.provider}/${decision.model} reason=maintenance_turn_failed`,
+      );
+      return { action: "skipped", reason: "maintenance_turn_failed" };
+    }
+    // A delegated client-tool terminal result (or any turn that completed
+    // without invoking the core `write` tool) is not a failed maintenance
+    // turn, but it also wrote no memory. Stamping it as a successful flush
+    // would suppress another checkpoint in this compaction cycle while the
+    // durable note is silently lost — the exact symptom this PR fixes. Treat
+    // a no-write completion as a skip so the recovery compact+retry default
+    // stays intact and the skip reason is visible in the gateway log.
+    if (!memoryFlushWroteTarget) {
+      log.warn(
+        `[memory-flush-skip] sessionKey=${sessionKey ?? "unknown"} ` +
+          `provider=${decision.provider}/${decision.model} reason=no_memory_written`,
+      );
+      return { action: "skipped", reason: "no_memory_written" };
+    }
+    if (memoryFlushWroteTarget && plan.recordWriteProvenance) {
+      try {
+        const originClass = await resolveRecoveryFlushOriginClass({
+          runParams,
+          agentId,
+          sessionKey,
+          sessionId: input.getActiveSession().id,
+          storePath,
+        });
+        await plan.recordWriteProvenance({
+          workspaceDir: runParams.workspaceDir,
+          relativePath: plan.relativePath,
+          contentBefore: memoryFlushContentBefore,
+          contentAfter: await readMemoryFlushTargetFile(memoryFlushAbsolutePath),
+          originClass,
+          observedAt: Date.now(),
+        });
+      } catch (err) {
+        log.warn(
+          `failed to record recovery memory flush provenance: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    }
+  } catch (err) {
+    log.warn(
+      `[memory-flush-skip] sessionKey=${sessionKey ?? "unknown"} ` +
+        `provider=${decision.provider}/${decision.model} reason=maintenance_turn_failed ` +
+        `error=${err instanceof Error ? err.message : String(err)}`,
+    );
+    return { action: "skipped", reason: "maintenance_turn_failed" };
+  } finally {
+    // Revoke the nested run's delegated authority on every outcome; the
+    // ephemeral maintenance turn never outlives its recovery checkpoint.
+    nestedRunAdmission.close();
+    // The ephemeral flush session exists only so the maintenance turn can
+    // persist its transcript header. Remove it on every outcome so an admitted
+    // checkpoint never leaves durable session-state debris behind.
+    if (flushSessionCreated && storePath) {
+      try {
+        await deleteSessionEntryLifecycle({
+          storePath,
+          archiveTranscript: false,
+          deleteTranscriptWithoutArchive: true,
+          target: { storeKeys: [flushSessionKey], canonicalKey: flushSessionKey },
+          requireWriteSuccess: false,
+        });
+      } catch (cleanupErr) {
+        log.warn(
+          `failed to clean up recovery flush session ${flushSessionKey}: ${
+            cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)
+          }`,
+        );
+      }
+    }
+  }
+
+  const flushedCompactionCount = entry?.compactionCount ?? 0;
+  if (sessionKey && storePath) {
+    try {
+      await updateSessionEntry(
+        { storePath, sessionKey },
+        () => ({ memoryFlush: { kind: "succeeded", compactionCount: flushedCompactionCount } }),
+        { skipMaintenance: true, takeCacheOwnership: true },
+      );
+    } catch (err) {
+      log.warn(
+        `failed to persist recovery memory flush metadata: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+  log.info(
+    `[memory-flush] pre-compaction checkpoint completed during recovery ` +
+      `sessionKey=${sessionKey ?? "unknown"} ` +
+      `provider=${decision.provider}/${decision.model} ` +
+      `window=${decision.contextWindowTokens}`,
+  );
+  return { action: "flushed" };
+}

--- a/src/agents/embedded-agent-runner/run/runtime-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-preparation.ts
@@ -187,7 +187,8 @@ export async function prepareEmbeddedRunRuntime(input: {
     preparedAuthAttempts,
   } = preparedAuthPlan;
   let { activePreparedAuthPlan } = preparedAuthPlan;
-  const genericCompactionRecoveryAllowed = !pluginHarnessOwnsTransport;
+  const genericCompactionRecoveryAllowed =
+    !pluginHarnessOwnsTransport && params.suppressCompactionRecovery !== true;
   const profileCandidates = preparedAuthAttempts.map((attempt) => attempt.profileId);
   const forwardedPluginHarnessProfileId = pluginHarnessOwnsTransport
     ? activePreparedAuthPlan.forwardedAuthProfileId

--- a/src/agents/embedded-agent-runner/run/timeout-context-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/timeout-context-recovery.ts
@@ -6,6 +6,7 @@ import {
   type EmbeddedRunCompactionRecoveryInput,
 } from "./compaction-runtime.js";
 import { createRunRecoveryDiagId } from "./helpers.js";
+import { attemptRecoveryMemoryFlush } from "./recovery-memory-flush.js";
 
 const MAX_TIMEOUT_COMPACTION_ATTEMPTS = 2;
 
@@ -56,6 +57,30 @@ export async function recoverEmbeddedRunTimeout(
     `[timeout-compaction] LLM timed out with high prompt token usage (${Math.round(tokenUsedRatio * 100)}%); ` +
       `attempting compaction before retry (attempt ${input.state.timeoutCompactionAttempts}/${MAX_TIMEOUT_COMPACTION_ATTEMPTS}) diagId=${timeoutDiagId}`,
   );
+  // The timeout-recovery compaction path has the same pre-compaction checkpoint
+  // gap as overflow recovery: flush only when a maintenance turn is
+  // demonstrably admissible, otherwise compact unchanged with a logged skip.
+  if (input.state.timeoutCompactionAttempts === 1) {
+    const recoveryFlush = await attemptRecoveryMemoryFlush({
+      runParams: input.runParams,
+      sessionKey: input.resolvedSessionKey,
+      agentId: input.sessionAgentId,
+      provider: input.provider,
+      modelId: input.modelId,
+      harnessRuntime: input.harnessRuntime,
+      observedOverflowTokens: lastTurnPromptTokens,
+      contextTokenBudget: input.contextTokenBudget,
+      messagesSnapshot: input.attempt.messagesSnapshot,
+      abortSignal: input.runParams.abortSignal,
+      getActiveSession: input.getActiveSession,
+    });
+    if (recoveryFlush.action === "flushed") {
+      log.info(
+        `[timeout-compaction] memory flush checkpoint completed before compaction ` +
+          `diagId=${timeoutDiagId} sessionKey=${input.runParams.sessionKey ?? input.sessionAgentId}`,
+      );
+    }
+  }
   let timeoutCompactResult: Awaited<ReturnType<typeof input.contextEngine.compact>>;
   await input.runOwnsCompactionBeforeHook("timeout recovery");
   try {

--- a/src/agents/session-runtime-compat.ts
+++ b/src/agents/session-runtime-compat.ts
@@ -7,7 +7,9 @@ import type { SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isDefaultAgentRuntimeId } from "./agent-runtime-id.js";
 import { normalizeOptionalAgentRuntimeId } from "./agent-runtime-id.js";
+import { resolveCliBackendConfig } from "./cli-backends.js";
 import { isCliRuntimeAliasForProvider } from "./model-runtime-aliases.js";
+import { isCliProvider } from "./model-selection.js";
 
 /** Persisted runtime fields used to recover session runtime compatibility. */
 type SessionRuntimeCompatEntry = Pick<
@@ -81,4 +83,56 @@ export function resolveSessionRuntimeOverrideForProvider(params: {
     runtime: params.entry?.agentRuntimeOverride,
     cfg: params.cfg,
   });
+}
+
+/** Runtime-ownership fields read from a persisted session entry. */
+export type SessionRuntimeOwnershipEntry = Pick<
+  SessionEntry,
+  "agentHarnessId" | "agentRuntimeOverride" | "modelSelectionLocked"
+>;
+
+/**
+ * Whether a resolved runtime is a CLI runtime for the given provider.
+ *
+ * Shared by the proactive memory-flush owner and the recovery-path flush
+ * admission gate so both paths enforce the same CLI exclusion: a CLI runtime
+ * owns its resumable native transcript, so OpenClaw maintenance must not launch
+ * a nested memory-writing turn against it. `runtimeId` is the already-resolved
+ * agent runtime id (e.g. the embedded runner's `harnessRuntime`); the persisted
+ * session-entry runtime is also consulted so a locked transcript runtime is
+ * honored even when the explicit id is a default.
+ */
+export function usesCliRuntime(params: {
+  provider: string;
+  runtimeId?: string;
+  cfg?: OpenClawConfig;
+  entry?: SessionRuntimeOwnershipEntry;
+}): boolean {
+  if (isCliProvider(params.provider, params.cfg)) {
+    return true;
+  }
+  return [resolvePersistedSessionRuntimeId(params.entry), params.runtimeId].some((runtime) =>
+    isCliRuntimeAliasForProvider({ provider: params.provider, runtime, cfg: params.cfg }),
+  );
+}
+
+/**
+ * Whether a resolved runtime owns native compaction and must remain the sole
+ * compaction owner.
+ *
+ * Backends that persist resumable native transcripts own their compaction
+ * lifecycle; an OpenClaw nested maintenance turn would corrupt that runtime
+ * state. Shared by the proactive and recovery flush paths so neither admits a
+ * flush against a native-compaction backend.
+ */
+export function ownsNativeCompaction(params: {
+  runtimeId?: string;
+  cfg?: OpenClawConfig;
+  agentId?: string;
+}): boolean {
+  return (
+    resolveCliBackendConfig(params.runtimeId ?? "", params.cfg, {
+      agentId: params.agentId,
+    })?.ownsNativeCompaction === true
+  );
 }

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -10,18 +10,17 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { prepareSystemAgentRunAdmission } from "../../agents/admitted-run-context.js";
 import { resolveDefaultAgentId } from "../../agents/agent-scope-config.js";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
-import { resolveCliBackendConfig } from "../../agents/cli-backends.js";
 import { estimateMessagesTokens } from "../../agents/compaction.js";
 import { isBenignCompactionSkipResult } from "../../agents/embedded-agent-runner/compact-reasons.js";
 import { runEmbeddedAgentEntry } from "../../agents/embedded-agent-runner/run-entry.js";
-import { isCliRuntimeAliasForProvider } from "../../agents/model-runtime-aliases.js";
-import { isCliProvider } from "../../agents/model-selection.js";
 import { resolveContextConfigProviderForRuntime } from "../../agents/openai-routing.js";
 import type { AgentMessage } from "../../agents/runtime/index.js";
 import { resolveSandboxConfigForAgent, resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
 import {
+  ownsNativeCompaction,
   resolvePersistedSessionRuntimeId,
   resolveSessionRuntimeOverrideForProvider,
+  usesCliRuntime,
 } from "../../agents/session-runtime-compat.js";
 import {
   resolveCandidateThinkingLevel,
@@ -268,13 +267,12 @@ type FollowupRuntimeParams = {
 };
 
 function followupUsesCliRuntime(params: FollowupRuntimeParams, runtimeId: string): boolean {
-  const provider = params.followupRun.run.provider;
-  if (isCliProvider(provider, params.cfg)) {
-    return true;
-  }
-  return [resolvePersistedSessionRuntimeId(params.sessionEntry), runtimeId].some((runtime) =>
-    isCliRuntimeAliasForProvider({ provider, runtime, cfg: params.cfg }),
-  );
+  return usesCliRuntime({
+    provider: params.followupRun.run.provider,
+    runtimeId,
+    cfg: params.cfg,
+    entry: params.sessionEntry,
+  });
 }
 
 function resolveFollowupContextConfigProvider(params: FollowupRuntimeParams): string {
@@ -308,11 +306,11 @@ function resolveFollowupAgentRuntimeId(params: FollowupRuntimeParams): string {
 function followupOwnsNativeCompaction(params: FollowupRuntimeParams, runtimeId: string): boolean {
   // Backends that persist resumable native transcripts must remain the sole
   // compaction owner; OpenClaw maintenance would corrupt that runtime state.
-  return (
-    resolveCliBackendConfig(runtimeId, params.cfg, {
-      agentId: params.followupRun.run.agentId,
-    })?.ownsNativeCompaction === true
-  );
+  return ownsNativeCompaction({
+    runtimeId,
+    cfg: params.cfg,
+    agentId: params.followupRun.run.agentId,
+  });
 }
 
 function resolveVisibleMemoryFlushErrorPayloads(payloads?: ReplyPayload[]): ReplyPayload[] {

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -234,10 +234,12 @@ export function resolveRunFastModeForFallbackCandidate(params: {
 }
 /** Builds base embedded run params with auth and provider runtime hints. */
 function buildEmbeddedRunBaseParams(params: Parameters<typeof buildEmbeddedRunBaseParamsCore>[0]) {
-  return buildEmbeddedRunBaseParamsCore({
-    ...params,
-    isReasoningTagProvider,
-  });
+  return {
+    ...buildEmbeddedRunBaseParamsCore({
+      ...params,
+      isReasoningTagProvider,
+    }),
+  };
 }
 
 function buildEmbeddedContextFromTemplate(params: {

--- a/src/plugins/runtime/runtime-embedded-agent.runtime.test.ts
+++ b/src/plugins/runtime/runtime-embedded-agent.runtime.test.ts
@@ -164,4 +164,25 @@ describe("plugin embedded-agent runtime admission", () => {
       expect(mocks.runEmbeddedAgentCore).not.toHaveBeenCalled();
     },
   );
+
+  it.each([
+    ["suppressCompactionRecovery", true],
+    ["runRecoveryMemoryFlushTurn", async () => ({ payloads: [] })],
+  ] as const)("rejects a plugin-supplied recovery control %s", async (field, value) => {
+    await expect(
+      withPluginRuntimePluginIdScope("memory-plugin", () =>
+        runPluginEmbeddedAgent({ ...params, [field]: value } as never),
+      ),
+    ).rejects.toThrow("cannot supply host recovery controls");
+    expect(mocks.prepareAgentRunAdmission).not.toHaveBeenCalled();
+    expect(mocks.runEmbeddedAgentCore).not.toHaveBeenCalled();
+  });
+
+  it("keeps recovery controls out of the plugin-callable params type", () => {
+    const pluginParams: Parameters<PluginRuntime["agent"]["runEmbeddedAgent"]>[0] = params;
+    // @ts-expect-error suppressCompactionRecovery is host-only recovery authority
+    void pluginParams.suppressCompactionRecovery;
+    // @ts-expect-error runRecoveryMemoryFlushTurn is host-only recovery authority
+    void pluginParams.runRecoveryMemoryFlushTurn;
+  });
 });

--- a/src/plugins/runtime/runtime-embedded-agent.runtime.ts
+++ b/src/plugins/runtime/runtime-embedded-agent.runtime.ts
@@ -18,6 +18,9 @@ export const runPluginEmbeddedAgent: PluginRuntime["agent"]["runEmbeddedAgent"] 
   if ("admittedRunContext" in params || "preparedRunAdmission" in params) {
     throw new Error("Plugin embedded-agent execution cannot supply host run authority.");
   }
+  if ("suppressCompactionRecovery" in params || "runRecoveryMemoryFlushTurn" in params) {
+    throw new Error("Plugin embedded-agent execution cannot supply host recovery controls.");
+  }
   params.abortSignal?.throwIfAborted();
   const preparedRunAdmission = prepareAgentRunAdmission({
     cfg: params.config ?? getRuntimeConfig(),

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -296,7 +296,11 @@ export type LlmCompleteResult = {
 
 type RuntimeRunEmbeddedAgentParams = Omit<
   import("../../agents/embedded-agent-runner/run/params.js").RunEmbeddedAgentParams,
-  "admittedRunContext" | "preparedRunAdmission" | "skillWorkshopCollectionReconcile"
+  | "admittedRunContext"
+  | "preparedRunAdmission"
+  | "skillWorkshopCollectionReconcile"
+  | "suppressCompactionRecovery"
+  | "runRecoveryMemoryFlushTurn"
 >;
 
 type RuntimeRunEmbeddedAgent = (

--- a/test/scripts/type-suppression-inventory.test.ts
+++ b/test/scripts/type-suppression-inventory.test.ts
@@ -78,6 +78,8 @@ describe("type suppression inventory", () => {
       "src/infra/kysely-sync.types.test.ts:61:@ts-expect-error Kysely checks order references and selected aliases.",
       "src/plugin-sdk/plugin-entry.reply-trigger.test.ts:8:@ts-expect-error Trigger eligibility is only supported for before_agent_reply.",
       "src/plugin-sdk/plugin-entry.reply-trigger.test.ts:10:@ts-expect-error An empty trigger list cannot prove that a hook is inactive.",
+      "src/plugins/runtime/runtime-embedded-agent.runtime.test.ts:183:@ts-expect-error suppressCompactionRecovery is host-only recovery authority",
+      "src/plugins/runtime/runtime-embedded-agent.runtime.test.ts:185:@ts-expect-error runRecoveryMemoryFlushTurn is host-only recovery authority",
     ]);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

When a conversation overflows the model context window or a turn times out, the configured pre-compaction memory flush never runs on the recovery path, so durable decisions made earlier in the conversation are silently lost with zero log trace. This PR makes the recovery path run one bounded memory-flush checkpoint before compaction whenever it is demonstrably safe, and makes every skipped checkpoint visible in the gateway logs.

- Problem: `recoverEmbeddedRunOverflow` (and timeout recovery) compact the rejected session directly via `ContextEngine.compact()`. The proactive path in `agent-runner-execute.ts` runs `runMemoryFlushIfNeeded` before preflight compaction, but the recovery path has zero memory-flush references, and a skipped checkpoint leaves no log trace at all.
- Solution: Before recovery compaction, run the configured silent memory flush only when a maintenance turn is demonstrably admissible (flush plan present, not already flushed this compaction cycle, fits the flush model's context budget with `reserveTokensFloor` + `softThresholdTokens` headroom). Otherwise compact unchanged and log an explicit `[memory-flush-skip]` reason. The nested maintenance turn is constructed from a least-privilege parameter shape that strips every outer mutable run-state field, outer-owned callback, and outer authority surface — including the OpenClaw orchestrator's ring-zero `systemAgentTool`, the outer `toolsAllow` allowlist, the internal `onSuccessfulAuthBinding` callback, and the outer prepared/admitted execution-context identity. The nested run prepares its own host-owned system admission keyed to its own run id.
- What changed: `run/recovery-memory-flush.ts` + `run/recovery-memory-flush-decision.ts` (new shared bounded flush helper: pure admission gate + ephemeral maintenance turn + write-provenance recording, with `RECOVERY_FLUSH_NESTED_RUN_OMIT_KEYS` centrally enumerating every field to strip), `overflow-context-recovery.ts` and `timeout-context-recovery.ts` (checkpoint before the first recovery compaction), `run/params.ts` + `run/runtime-preparation.ts` (`suppressCompactionRecovery` so the nested turn cannot recurse or rotate the session), `run-orchestrator.ts` (maintenance-run executor defaulted at the shared `runEmbeddedAgent` boundary so direct/cron/gateway embedded runs all get the checkpoint), docs (`compaction.md`, `memory.md`).
- What did NOT change: The proactive flush path, the recovery compact+retry default when a checkpoint cannot be admitted, the compaction engine itself, and any session/transcript storage behavior.

## Why This Change Was Made

The compaction docs promise a silent memory flush before compaction so durable decisions survive summarization. The proactive path honors that contract, but provider-overflow and timeout recovery inside the embedded agent runner compact the session directly, so the flush never runs there and the user is never told — issue #114081 reports two local-model repros where a mid-conversation durable decision was lost across reactive compaction with zero `memoryFlush` log lines. ClawSweeper's review confirmed the source split and recommended a bounded overflow checkpoint: attempt the flush only when a reduced maintenance turn is demonstrably admissible, otherwise compact, record the skip reason, and retry.

The nested maintenance turn is built from a stripped base rather than the full outer `RunEmbeddedAgentParams`, because the turn's only job is to read and append memory. `RECOVERY_FLUSH_NESTED_RUN_OMIT_KEYS` centrally enumerates every mutable outer-state field, outer-owned callback, and outer authority surface to strip — fast-mode shared progress state, the client/plugin tool surface, delivery/progress callbacks, logical-turn ownership, reply/delivery/lifecycle state, ring-zero/internal authority, and the outer prepared/admitted execution-context identity. Only the private write observer (`onAgentEvent`) is re-attached. This is an explicit allowlist-of-exclusions: anything not listed is inherited as-is, so a future mutable field added to `RunEmbeddedAgentParams` is one array entry away from isolation instead of a silent leak. The list is typed against `keyof RunEmbeddedAgentInternalParams` so internal authority fields (`systemAgentTool`, `onSuccessfulAuthBinding`) are admissible.

The ring-zero isolation is the security boundary: host-bound ring-zero tools are merged AFTER the memory-flush tool filter (`agent-tools.ts`), so the filter alone cannot constrain them — `systemAgentTool` and the outer `toolsAllow` allowlist (e.g. `["openclaw"]` for system-agent runs) must be stripped from the nested turn explicitly, otherwise an overflowed setup transcript could invoke privileged OpenClaw operations from a turn that is supposed to be memory read/append-only. The sandbox writability gate was also corrected to evaluate the runtime `sandboxSessionKey` (previously the transcript key, which could bypass a read-only direct-message sandbox policy).

The execution-context isolation closes a second gap surfaced by rebasing onto the latest `origin/main`: `prepareEmbeddedRunRuntime` now resolves a prepared/admitted execution context for every embedded run, and the nested flush run inherited the outer run's mutually-exclusive admission fields, failing with `run cannot carry both prepared and admitted execution contexts`. The nested run now strips both fields and prepares its own host-owned system admission (`prepareSystemAgentRunAdmission`, boundary `recovery-memory-flush`, closed in `finally` on every outcome).

- Best fix: Yes — bounded overflow checkpointing at the recovery boundary, reusing the existing flush plan/gates and the existing maintenance-turn machinery (`runEmbeddedAgent`, `memoryFlushWritePath`), with the default compact+retry behavior preserved.
- Alternative considered: (a) Directly call `runMemoryFlushIfNeeded` from recovery — rejected, auto-reply types would leak into the embedded runner; (b) flush after compaction — rejected, loses pre-compaction detail the docs promise; (c) unconditional flush before compaction — rejected, the provider already rejected the full context and another same-size agentic turn risks a recovery loop.
- Risk: The bounded maintenance turn adds one extra agentic call before recovery compaction, mitigated by the admissibility gate, `suppressCompactionRecovery` (the nested turn cannot recurse, compact, or rotate the session), the dedicated `CommandLane.Nested` (no self-deadlock against the outer main lane), and the at-most-once-per-run attempt guard. An unknown flush-model context window now skips admission (fail closed) instead of assuming a 200k default.

## User Impact

When a session overflows and reactive recovery compacts it, a configured memory flush may now run one bounded maintenance turn before compaction (saving durable notes to `memory/YYYY-MM-DD.md`), and every skipped checkpoint is visible in the gateway log instead of being completely silent. No config or API change; users without a memory flush plan see no behavior change beyond the new skip log line. After a recovery compaction, durable decisions surfaced earlier in the conversation survive into the compacted context.

## Evidence

**Behavior matrix** — the same overflow scenario under three configurations (branch head `8c6e4fdd0ba`):

| Configuration | Before (origin/main) | After (this branch; head `8c6e4fdd0ba`) |
|---|---|---|
| overflow + flush model with larger window (`memoryFlush.model` set) | `context overflow detected` → compact; zero flush log lines; `memory/YYYY-MM-DD.md` never written | `context overflow detected` → `[memory-flush] pre-compaction checkpoint completed` (nested lane) → compact; `memory/2026-08-12.md` written with the durable decision |
| overflow + no larger flush model (default) | `context overflow detected` → compact; completely silent about the skipped checkpoint | `context overflow detected` → `[memory-flush-skip] ... reason=no_flush_headroom` → compact; skip reason visible in logs |
| direct-message session with read-only sandbox policy | recovery flush would bypass the RO policy (transcript key used for sandbox check) | recovery flush gate evaluates `sandboxSessionKey` → `[memory-flush-skip] ... reason=sandbox_workspace_not_writable` → compact; RO policy honored |

**Real-runtime capture** (exact head `8c6e4fdd0ba`, fresh). Overflow provider: local llama.cpp server (`llama-server` b4000, Qwen2.5-0.5B-Instruct-Q4_K_M, `-c 4096 --no-context-shift`), real model with a real 4096-token KV cache; its real context rejection is normalized by `llama-evidence-shim.mjs` to the wording OpenClaw's overflow classifier recognizes (the rejection itself is real — the model cannot fit the prompt in its KV cache). Flush model: real remote provider `qwen/Qwen3-235B-A22B` (ZTE MaaS, OpenAI-compatible), `contextWindow: 200000`. Gateway: dev profile, isolated state, `OPENCLAW_SKIP_CHANNELS=1`; drive: `node openclaw.mjs --dev agent --agent evidence --session-key repro-a12 --message "DURABLE DECISION: ..."`.

Scenario A (admitted) — gateway log (`exact-head-A3-checkpoint.log`):

```console
[context-overflow-diag] sessionKey=agent:evidence:repro-a12 provider=llama-evidence/qwen2.5-0.5b source=assistantError messages=2 observedTokens=6258 compactionTokens=6258 providerPayloadBytes=89799 error=400 prompt is too long: 6258 tokens > 4096 maximum
[memory-flush] pre-compaction checkpoint completed during recovery sessionKey=agent:evidence:repro-a12 provider=qwen/Qwen3-235B-A22B window=200000
[context-overflow-diag] memory flush checkpoint completed before compaction diagId=ovf-mspqi3ez--cAk7A sessionKey=agent:evidence:repro-a12
```

Durable note appended to `memory/2026-08-12.md` (`memory-file-after-A3.txt`):

```markdown
<!-- observed: 2026-08-12 | repository: /tmp/openclaw-dev-ws -->

- DURABLE DECISION: The production deploy is scheduled for Friday 2026-08-07 at 09:00 Asia/Shanghai.
```

Compaction then fails at the 4096-token window (the same documented limitation as before the fix; the checkpoint ran first, which is the behavior this PR adds).

Scenario B (skip) — gateway log (`exact-head-B2-skip.log`):

```console
[context-overflow-diag] sessionKey=agent:evidence:repro-b12 provider=llama-evidence/qwen2.5-0.5b source=assistantError messages=2 observedTokens=6258 compactionTokens=6258 providerPayloadBytes=89799 error=400 prompt is too long: 6258 tokens > 4096 maximum
[memory-flush-skip] sessionKey=agent:evidence:repro-b12 provider=llama-evidence/qwen2.5-0.5b reason=no_flush_headroom
```

**Guard-verified regression** (`recovery-memory-flush.test.ts > "clears inherited delivery/progress, logical-turn, and ring-zero authority from the nested maintenance turn"`):

- Setup supplies `systemAgentTool`, `toolsAllow: ["openclaw"]`, `onSuccessfulAuthBinding`, `preparedRunAdmission`, and `admittedRunContext` on the outer run.
- Asserts `nestedParams.systemAgentTool === undefined`, `nestedParams.toolsAllow === undefined`, `nestedParams.onSuccessfulAuthBinding === undefined`, `nestedParams.admittedRunContext === undefined`, and that `nestedParams.preparedRunAdmission` is a different, nested-run-keyed system admission (`operationalRunInstance.runId !== "outer-run"`).
- Guard verified: temporarily removing `systemAgentTool` or `admittedRunContext` from the omit list makes the corresponding assertion fail (pre-fix red), confirming the test is a real guard, not vacuous against the mock run.

**Acceptance criteria** (ClawSweeper shard list):

| Shard | Result |
|---|---|
| `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/recovery-memory-flush.test.ts` | 28/28 passed |
| `node scripts/run-vitest.mjs src/system-agent/agent-turn.test.ts src/agents/harness/selection.test.ts` | 111/111 passed |
| `node scripts/run-vitest.mjs src/agents/agent-tools.create-openclaw-coding-tools.test.ts` | 120/120 passed |

`tsgo -p tsconfig.core.json` and `tsgo:core:test` clean for the changed files (the only remaining error is `src/cli/session-ref.ts` referencing a main-added workspace package `@openclaw/session-url-contract/parse` not installed in the contributor's worktree — unrelated to this diff and not present under CI's fresh install). `oxfmt --check` and `oxlint` clean.

What was not tested: real Telegram/Discord/WhatsApp channel delivery (gateway ran with `OPENCLAW_SKIP_CHANNELS=1`); plugin-harness-owned transports (they already disable recovery via `genericCompactionRecoveryAllowed`); the retry-after-flush completion in the 4096-token repro (the tiny window cannot fit the compacted context, so recovery exhausts — the same on main and after; the flush checkpoint still ran and saved the note before the first compaction).

## AI Assistance

- AI-assisted: Yes
- Tools: Claude (Claude Code, glm-5.2); Codex (review-cycle fixes incl. execution-context isolation + exact-head proof, 2026-08-12)
- Prompts / session excerpts: issue #114081 analysis + ClawSweeper review (durable comment 5167498510, re-reviews through `1d94f4d6fcf` / `fdfc2160dee` / `bb1461178491` / `f74c3ace6e7` / `8c6e4fdd0ba`); key prompts: "strip ring-zero authority from the recovery flush", "add a system-agent regression proving no ring-zero tool reaches the maintenance turn". Full session log available on request.
- Confirmed understanding of code changes: Yes — the omit list strips `systemAgentTool`/`toolsAllow`/`onSuccessfulAuthBinding` because ring-zero tools are merged after the memory-flush tool filter; the `satisfies` constraint was widened to `keyof RunEmbeddedAgentInternalParams` so internal authority fields are admissible; `upsertSessionEntry` was renamed to `upsertSessionEntryCore` on main during rebase; the nested flush run must not inherit the outer prepared/admitted execution context (`prepareEmbeddedRunRuntime` resolves one per run on current main), so the omit list also strips `preparedRunAdmission`/`admittedRunContext` and the nested run prepares its own host-owned system admission (`prepareSystemAgentRunAdmission`, boundary `recovery-memory-flush`, closed in `finally`); the regression test reads the internal params type so ring-zero assertions typecheck under `tsgo:core:test`.
- autoreview: N/A

Closes #114081
