### PR TITLE
fix(plugins): reject external public-artifact hardlinks

### DIFF
--- a/src/plugins/provider-public-artifacts.test.ts
+++ b/src/plugins/provider-public-artifacts.test.ts
@@ -232,6 +232,46 @@ describe("provider public artifacts", () => {
     }
   });
 
+  it.runIf(process.platform !== "win32")(
+    "rejects trusted official provider policy artifacts hardlinked outside the installed root",
+    () => {
+      const tempRoot = fs.realpathSync(
+        fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-provider-policy-hardlink-")),
+      );
+      const pluginRoot = path.join(tempRoot, "installed-provider");
+      const outsidePath = path.join(tempRoot, "outside-policy.js");
+      fs.mkdirSync(pluginRoot, { recursive: true });
+      fs.writeFileSync(
+        outsidePath,
+        'export function resolveThinkingProfile() { return { defaultLevel: "escaped" }; }\n',
+        "utf8",
+      );
+      fs.linkSync(outsidePath, path.join(pluginRoot, "provider-policy-api.js"));
+
+      try {
+        const pluginId = "hardlinked-provider";
+        expect(() =>
+          resolveProviderPolicySurface(pluginId, {
+            manifestRegistry: {
+              plugins: [
+                {
+                  id: pluginId,
+                  origin: "global",
+                  trustedOfficialInstall: true,
+                  rootDir: pluginRoot,
+                  providers: [pluginId],
+                  cliBackends: [],
+                } as never,
+              ],
+            },
+          }),
+        ).toThrow("Unable to open plugin public surface provider-policy-api.js");
+      } finally {
+        fs.rmSync(tempRoot, { recursive: true, force: true });
+      }
+    },
+  );
+
   it("resolves namespaced provider policies from their trusted external plugin root", () => {
     const bundledPluginsDir = fs.mkdtempSync(
       path.join(os.tmpdir(), "openclaw-empty-bundled-plugins-"),

--- a/src/plugins/public-surface-loader.test.ts
+++ b/src/plugins/public-surface-loader.test.ts
@@ -329,6 +329,35 @@ describe("bundled plugin public surface loader", () => {
     },
   );
 
+  it
+    .runIf(process.platform !== "win32")
+    .each(["provider-policy-api.js", "api.js", "runtime-api.js"])(
+    "rejects installed plugin public artifact %s hardlinked outside its root",
+    async (artifact) => {
+      const publicSurfaceLoader = await importFreshModule<
+        typeof import("./public-surface-loader.js")
+      >(
+        import.meta.url,
+        `./public-surface-loader.js?scope=installed-hardlink-${artifact.replace(".js", "")}`,
+      );
+      const tempRoot = fs.realpathSync(createTempDir());
+      const pluginRoot = path.join(tempRoot, "installed-plugin");
+      const outsidePath = path.join(tempRoot, "outside.js");
+      const artifactPath = path.join(pluginRoot, artifact);
+      fs.mkdirSync(pluginRoot, { recursive: true });
+      fs.writeFileSync(outsidePath, 'export const marker = "outside-plugin-root";\n', "utf8");
+      fs.linkSync(outsidePath, artifactPath);
+
+      expect(fs.statSync(artifactPath).nlink).toBeGreaterThan(1);
+      expect(() =>
+        publicSurfaceLoader.loadPluginPublicArtifactModuleSync({
+          pluginRoot,
+          artifactBasename: artifact,
+        }),
+      ).toThrow(`Unable to open plugin public surface ${artifact}`);
+    },
+  );
+
   it("does not cache missing public artifact locations", async () => {
     vi.doMock("./native-module-require.js", () => ({
       tryNativeRequireJavaScriptModule: (modulePath: string) => ({

--- a/src/plugins/public-surface-loader.ts
+++ b/src/plugins/public-surface-loader.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import { openRootFileSync } from "../infra/boundary-file-read.js";
 import { sameFileIdentity } from "../infra/fs-safe-advanced.js";
 import { resolveBundledPluginsDir } from "./bundled-dir.js";
+import { shouldRejectHardlinkedPluginFiles } from "./hardlink-policy.js";
 import { registerPluginMetadataProcessMemoLifecycleClear } from "./plugin-metadata-lifecycle.js";
 import {
   createPluginModuleLoaderCache,
@@ -127,17 +128,23 @@ function loadValidatedPublicSurfaceModule(params: {
   boundaryRoot: string;
   boundaryLabel: string;
   surfaceLabel: string;
+  origin: "bundled" | "global";
 }): object {
   const cached = publicSurfaceModuleCache.get(params.modulePath);
   if (cached) {
     return cached as object;
   }
 
+  // Official install trust does not make mutable plugin roots immutable;
+  // the shared policy preserves bundled and immutable Nix-store exceptions.
   const opened = openRootFileSync({
     absolutePath: params.modulePath,
     rootPath: params.boundaryRoot,
     boundaryLabel: params.boundaryLabel,
-    rejectHardlinks: false,
+    rejectHardlinks: shouldRejectHardlinkedPluginFiles({
+      origin: params.origin,
+      rootDir: params.boundaryRoot,
+    }),
   });
   if (!opened.ok) {
     throw new Error(`Unable to open ${params.surfaceLabel}`, { cause: opened.error });
@@ -182,6 +189,7 @@ export function loadBundledPluginPublicArtifactModuleSync<T extends object>(para
     boundaryLabel:
       location.boundaryRoot === OPENCLAW_PACKAGE_ROOT ? "OpenClaw package root" : "plugin root",
     surfaceLabel: `bundled plugin public surface ${params.dirName}/${params.artifactBasename}`,
+    origin: "bundled",
   }) as T;
 }
 
@@ -201,6 +209,7 @@ export function loadPluginPublicArtifactModuleSync<T extends object>(params: {
     boundaryRoot: path.resolve(params.pluginRoot),
     boundaryLabel: "plugin root",
     surfaceLabel: `plugin public surface ${params.artifactBasename}`,
+    origin: "global",
   }) as T;
 }
 


### PR DESCRIPTION


## Maintainer compatibility decision

Maintainer explicitly accepts the intentional upgrade-time fail-closed behavior: an externally installed plugin whose mutable public artifact is hardlinked outside its plugin root must be repaired or reinstalled before it loads. The installed discovery/runtime/SDK-facade owners already enforce this same security invariant; allowing the public surface to remain an exception would preserve arbitrary outside-root code execution. Legitimate bundled plugins and immutable Nix-store hardlinks remain supported, and the regression suite proves both. No migration, unsafe compatibility alias, or credentialed fallback is appropriate for this boundary.

ClawSweeper rank-up disposition: this compatibility tradeoff is accepted and documented; exact-head required checks must finish before landing. Merely being behind current main is not itself a reason to rebase; the native maintainer merge workflow will verify the actual merge result and current required checks.