### PR TITLE
fix(nextcloud-talk): allow bounded parallel room deliveries

### DIFF
--- a/extensions/nextcloud-talk/src/webhook-spool.test.ts
+++ b/extensions/nextcloud-talk/src/webhook-spool.test.ts
@@ -220,6 +220,88 @@ describe("Nextcloud Talk durable ingress", () => {
     });
   });
 
+  it("drains other rooms while keeping unadopted same-room deliveries ordered", async () => {
+    await withQueue(async (queue) => {
+      let releaseRoomA!: () => void;
+      const roomADelivery = new Promise<void>((resolve) => {
+        releaseRoomA = resolve;
+      });
+      const delivered: string[] = [];
+      const spool = startSpool(queue, async (message, lifecycle) => {
+        delivered.push(message.messageId);
+        if (message.messageId === "room-a-1") {
+          await roomADelivery;
+        }
+        await lifecycle.onAdopted();
+      });
+
+      try {
+        await spool.receive(createRawEvent({ messageId: "room-a-1", roomToken: "room-a" }));
+        await vi.waitFor(() => expect(delivered).toEqual(["room-a-1"]));
+
+        await spool.receive(createRawEvent({ messageId: "room-a-2", roomToken: "room-a" }));
+        await spool.receive(createRawEvent({ messageId: "room-b-1", roomToken: "room-b" }));
+
+        await vi.waitFor(() => expect(delivered).toEqual(["room-a-1", "room-b-1"]));
+        expect(await queue.listPending()).toEqual([
+          expect.objectContaining({ id: "room-a-2", laneKey: "room:room-a" }),
+        ]);
+
+        releaseRoomA();
+        await vi.waitFor(() => expect(delivered).toEqual(["room-a-1", "room-b-1", "room-a-2"]));
+      } finally {
+        releaseRoomA();
+        await spool.stop();
+      }
+    });
+  });
+
+  it("caps active room deliveries after durable adoption across repeated pumps", async () => {
+    await withQueue(async (queue) => {
+      let releaseDeliveries!: () => void;
+      const deliveryGate = new Promise<void>((resolve) => {
+        releaseDeliveries = resolve;
+      });
+      let activeDeliveries = 0;
+      let maxActiveDeliveries = 0;
+      const deliver = vi.fn(async (_message, lifecycle) => {
+        activeDeliveries += 1;
+        maxActiveDeliveries = Math.max(maxActiveDeliveries, activeDeliveries);
+        await lifecycle.onAdopted();
+        try {
+          await deliveryGate;
+        } finally {
+          activeDeliveries -= 1;
+        }
+      });
+      const spool = startSpool(queue, deliver);
+
+      try {
+        for (let index = 0; index < 33; index += 1) {
+          await spool.receive(
+            createRawEvent({
+              messageId: `room-delivery-${index}`,
+              roomToken: `room-${index}`,
+            }),
+          );
+        }
+
+        await vi.waitFor(() => expect(deliver).toHaveBeenCalledTimes(32));
+        expect(maxActiveDeliveries).toBe(32);
+        expect(await queue.listPending()).toEqual([
+          expect.objectContaining({ id: "room-delivery-32", laneKey: "room:room-32" }),
+        ]);
+
+        releaseDeliveries();
+        await vi.waitFor(() => expect(deliver).toHaveBeenCalledTimes(33));
+        expect(maxActiveDeliveries).toBe(32);
+      } finally {
+        releaseDeliveries();
+        await spool.stop();
+      }
+    });
+  });
+
   it("stores the exact raw envelope in the room lane", async () => {
     await withQueue(async (queue) => {
       const rawEvent = createRawEvent({ messageId: "msg-raw", roomToken: "test-room-token" });

--- a/extensions/nextcloud-talk/src/webhook-spool.ts
+++ b/extensions/nextcloud-talk/src/webhook-spool.ts
@@ -179,13 +179,12 @@ export function createNextcloudTalkWebhookSpool(options: {
       await options.deliver(message, lifecycle);
     },
     pollIntervalMs: options.pollIntervalMs ?? NEXTCLOUD_TALK_INGRESS_POLL_INTERVAL_MS,
-    // Preserve Nextcloud Talk's existing one-drain-at-a-time delivery cycle.
-    waitForDeliveryIdleBeforeRepump: true,
     retention: {
       completedMaxEntries: 10_000,
       failedMaxEntries: 10_000,
     },
     drain: {
+      startLimit: 32, // Keep the shared drain's active-delivery ceiling across repumps.
       resolveNonRetryableFailure,
       ...(options.adoptionStallTimeoutMs === undefined
         ? {}


### PR DESCRIPTION
## Summary

Fixes #118649.

Nextcloud Talk durable ingress previously waited for every active delivery to become idle before pumping again. That global barrier serialized independent rooms even when their durable lane keys differed. Remove the global idle barrier while explicitly retaining the shared drain's maximum of 32 active deliveries.

- Independent rooms can deliver concurrently.
- Messages that have not yet been adopted remain FIFO within the same room.
- The 33rd room stays durably pending until one of the 32 active deliveries finishes.
- Production owner change: +1/-2 lines (**net -1**); no new config, environment variable, or public API.
- The original report affects **2026.7.2-beta.7**; this does not claim impact on an earlier stable release.

## Verification

- Real durable-SQLite owner harness: **2/2** new regressions passed: independent-room parallelism with same-room preadoption FIFO; 33-room global active-delivery cap of 32.
- Full Nextcloud ingress owner suite: **13/13** passed.
- Shared durable-queue tests: **2/2** passed.
- Full owner changed gates passed: formatting, production typecheck, test typecheck, targeted lint, plugin SDK, SQLite/database checks, and dependency-cycle checks.
- Independent authenticated high-depth review: **clean**, confidence **0.98**; secret scanner clean.
- Verification used the real durable SQLite queue/owner harness; no live external Nextcloud server or API is claimed.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted codex session transcript</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
omitted: raw tool outputs, system/developer prompts, local paths, secrets, browser/session/auth details
stats: {"agent":"codex","entries":1,"user":0,"assistant":1,"toolCalls":0,"toolOutputsDropped":0,"web":0,"redactions":0,"omittedUnsafe":0,"rawEntries":6}

[assistant]
Reused the existing remote runner to format the Nextcloud regression test; preparing the final same-runner validation pass.

Nextcloud’s room-ordering and 32-delivery-limit regressions pass; formatting is fixed and remaining remote typecheck/lint gates are running.

Nextcloud passed real queue/concurrency regressions, formatting, SDK checks, and production typechecking; test typechecking is still running.

Nextcloud fix passed all real queue tests, both typechecks, lint, formatting, and safety gates; preparing the reviewed founder PR.

Nextcloud fix is committed locally, removes one production line, and is undergoing its final independent review.

Nextcloud fix passed independent review with no findings; publishing a signed founder PR with the complete test evidence.
````

</details>
<!-- agent-transcript:end -->
