### PR TITLE
fix(gateway): preserve final speech during transcription shutdown

### DIFF
--- a/src/gateway/talk-transcription-relay.test.ts
+++ b/src/gateway/talk-transcription-relay.test.ts
@@ -122,6 +122,7 @@ describe("talk transcription gateway relay", () => {
   });
 
   it("bridges browser audio into a transcription-only Talk event stream", async () => {
+    vi.useFakeTimers();
     let sttRequest: RealtimeTranscriptionSessionCreateRequest | undefined;
     const sttSession = createSttSessionMock(async () => {
       sttRequest?.onSpeechStart?.();
@@ -154,10 +155,14 @@ describe("talk transcription gateway relay", () => {
       connId: "conn-1",
       audioBase64: Buffer.from("audio-in").toString("base64"),
     });
+    sttSession.close.mockImplementationOnce(() => {
+      sttRequest?.onTranscript?.("final audio");
+    });
     stopTalkTranscriptionRelaySession({
       transcriptionSessionId: session.transcriptionSessionId,
       connId: "conn-1",
     });
+    await vi.advanceTimersByTimeAsync(5_000);
 
     expect(sttSession.sendAudio).toHaveBeenCalledWith(Buffer.from("audio-in"));
     expect(sttSession.close).toHaveBeenCalledOnce();
@@ -233,6 +238,302 @@ describe("talk transcription gateway relay", () => {
         dropIfSlow: type === "partial" || type === "inputAudio",
       });
     }
+  });
+
+  it.each(["synchronous", "asynchronous"] as const)(
+    "delivers a %s provider final before gracefully closing an active transcription turn",
+    async (delivery) => {
+      vi.useFakeTimers();
+      let request: RealtimeTranscriptionSessionCreateRequest | undefined;
+      const sttSession = createSttSessionMock();
+      sttSession.close.mockImplementation(() => {
+        const deliverFirst = () => request?.onTranscript?.("first provider transcript");
+        const deliverSecond = () => request?.onTranscript?.("second provider transcript");
+        if (delivery === "synchronous") {
+          deliverFirst();
+          deliverSecond();
+        } else {
+          queueMicrotask(deliverFirst);
+          setTimeout(deliverSecond, 1_000);
+        }
+      });
+      const { events, session } = await createStartedRelaySession(sttSession, {}, (value) => {
+        request = value;
+      });
+
+      sendTalkTranscriptionRelayAudio({
+        transcriptionSessionId: session.transcriptionSessionId,
+        connId: "conn-1",
+        audioBase64: "AQI=",
+      });
+      stopTalkTranscriptionRelaySession({
+        transcriptionSessionId: session.transcriptionSessionId,
+        connId: "conn-1",
+      });
+      expect(
+        events.some((event) => isRecord(event.payload) && event.payload.type === "close"),
+      ).toBe(false);
+      expect(() =>
+        sendTalkTranscriptionRelayAudio({
+          transcriptionSessionId: session.transcriptionSessionId,
+          connId: "conn-1",
+          audioBase64: "AQI=",
+        }),
+      ).toThrow("Unknown transcription Talk session");
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      const transcripts = events
+        .map((event) => requireRecord(event.payload, "transcription relay event"))
+        .filter(
+          (payload) => isRecord(payload.talkEvent) && payload.talkEvent.type === "transcript.done",
+        );
+      expect(transcripts.map((payload) => payload.text)).toEqual([
+        "first provider transcript",
+        "second provider transcript",
+      ]);
+      expect(
+        events.some((event) => isRecord(event.payload) && event.payload.type === "close"),
+      ).toBe(false);
+      await vi.advanceTimersByTimeAsync(4_000);
+      const terminalEvents = events
+        .map((event) => {
+          const payload = requireRecord(event.payload, "transcription relay event");
+          return isRecord(payload.talkEvent) ? payload.talkEvent.type : undefined;
+        })
+        .filter((type) =>
+          ["input.audio.committed", "transcript.done", "turn.ended", "session.closed"].includes(
+            String(type),
+          ),
+        );
+      expect(terminalEvents).toEqual([
+        "input.audio.committed",
+        "transcript.done",
+        "turn.ended",
+        "transcript.done",
+        "turn.ended",
+        "session.closed",
+      ]);
+      expect(sttSession.close).toHaveBeenCalledOnce();
+
+      const eventCount = events.length;
+      request?.onTranscript?.("late provider transcript");
+      expect(events).toHaveLength(eventCount);
+    },
+  );
+
+  it("drains later provider finals after an earlier transcript already ended its turn", async () => {
+    vi.useFakeTimers();
+    let request: RealtimeTranscriptionSessionCreateRequest | undefined;
+    const sttSession = createSttSessionMock();
+    sttSession.close.mockImplementationOnce(() => {
+      request?.onTranscript?.("second provider transcript");
+    });
+    const { events, session } = await createStartedRelaySession(sttSession, {}, (value) => {
+      request = value;
+    });
+
+    sendTalkTranscriptionRelayAudio({
+      transcriptionSessionId: session.transcriptionSessionId,
+      connId: "conn-1",
+      audioBase64: "AQI=",
+    });
+    request?.onTranscript?.("first provider transcript");
+    stopTalkTranscriptionRelaySession({
+      transcriptionSessionId: session.transcriptionSessionId,
+      connId: "conn-1",
+    });
+
+    const transcripts = events
+      .map((event) => requireRecord(event.payload, "transcription relay event"))
+      .filter(
+        (payload) => isRecord(payload.talkEvent) && payload.talkEvent.type === "transcript.done",
+      );
+    expect(transcripts.map((payload) => payload.text)).toEqual([
+      "first provider transcript",
+      "second provider transcript",
+    ]);
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(findPayloadByType(events, "close").reason).toBe("completed");
+  });
+
+  it("closes a provider immediately when its transcription session never received audio", async () => {
+    const sttSession = createSttSessionMock();
+    const { events, session } = await createStartedRelaySession(sttSession, {});
+
+    stopTalkTranscriptionRelaySession({
+      transcriptionSessionId: session.transcriptionSessionId,
+      connId: "conn-1",
+    });
+
+    expect(findPayloadByType(events, "close").reason).toBe("completed");
+    expect(sttSession.close).toHaveBeenCalledOnce();
+  });
+
+  it("bounds graceful provider draining when no final transcript arrives", async () => {
+    vi.useFakeTimers();
+    const sttSession = createSttSessionMock();
+    const { events, session } = await createStartedRelaySession(sttSession, {});
+
+    sendTalkTranscriptionRelayAudio({
+      transcriptionSessionId: session.transcriptionSessionId,
+      connId: "conn-1",
+      audioBase64: "AQI=",
+    });
+    stopTalkTranscriptionRelaySession({
+      transcriptionSessionId: session.transcriptionSessionId,
+      connId: "conn-1",
+    });
+
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(events.some((event) => isRecord(event.payload) && event.payload.type === "close")).toBe(
+      false,
+    );
+    await vi.advanceTimersByTimeAsync(1);
+
+    const close = findPayloadByType(events, "close");
+    expect(close.reason).toBe("completed");
+    expect(sttSession.close).toHaveBeenCalledOnce();
+  });
+
+  it("preserves partial activity between provider finals while graceful draining continues", async () => {
+    vi.useFakeTimers();
+    let request: RealtimeTranscriptionSessionCreateRequest | undefined;
+    const sttSession = createSttSessionMock();
+    const { events, session } = await createStartedRelaySession(sttSession, {}, (value) => {
+      request = value;
+    });
+
+    sendTalkTranscriptionRelayAudio({
+      transcriptionSessionId: session.transcriptionSessionId,
+      connId: "conn-1",
+      audioBase64: "AQI=",
+    });
+    stopTalkTranscriptionRelaySession({
+      transcriptionSessionId: session.transcriptionSessionId,
+      connId: "conn-1",
+    });
+    request?.onTranscript?.("first final");
+    await vi.advanceTimersByTimeAsync(1_400);
+    request?.onPartial?.("second draft");
+    await vi.advanceTimersByTimeAsync(200);
+    request?.onTranscript?.("second final");
+
+    const updates = events
+      .map((event) => requireRecord(event.payload, "transcription relay event"))
+      .filter((payload) => typeof payload.text === "string" && payload.text)
+      .map((payload) => ({ type: payload.type, text: payload.text }));
+    expect(updates).toEqual([
+      { type: "transcript", text: "first final" },
+      { type: "partial", text: "second draft" },
+      { type: "transcript", text: "second final" },
+    ]);
+    expect(events.some((event) => isRecord(event.payload) && event.payload.type === "close")).toBe(
+      false,
+    );
+    await vi.advanceTimersByTimeAsync(3_400);
+    expect(findPayloadByType(events, "close").reason).toBe("completed");
+  });
+
+  it("does not report a provider ready after graceful draining has started", async () => {
+    vi.useFakeTimers();
+    let request: RealtimeTranscriptionSessionCreateRequest | undefined;
+    let resolveConnection: (() => void) | undefined;
+    const sttSession = createSttSessionMock(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveConnection = resolve;
+        }),
+    );
+    const { events, session } = await createStartedRelaySession(sttSession, {}, (value) => {
+      request = value;
+    });
+
+    sendTalkTranscriptionRelayAudio({
+      transcriptionSessionId: session.transcriptionSessionId,
+      connId: "conn-1",
+      audioBase64: "AQI=",
+    });
+    stopTalkTranscriptionRelaySession({
+      transcriptionSessionId: session.transcriptionSessionId,
+      connId: "conn-1",
+    });
+    resolveConnection?.();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(events.some((event) => isRecord(event.payload) && event.payload.type === "ready")).toBe(
+      false,
+    );
+    request?.onTranscript?.("final provider transcript");
+    expect(findPayloadByTalkEventType(events, "transcript.done").text).toBe(
+      "final provider transcript",
+    );
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(findPayloadByType(events, "close").reason).toBe("completed");
+  });
+
+  it("closes a draining provider immediately when its browser owner disconnects", async () => {
+    let request: RealtimeTranscriptionSessionCreateRequest | undefined;
+    const sttSession = createSttSessionMock();
+    sttSession.close.mockImplementationOnce(() => {
+      queueMicrotask(() => request?.onTranscript?.("disconnected provider transcript"));
+    });
+    const { events, session } = await createStartedRelaySession(sttSession, {}, (value) => {
+      request = value;
+    });
+
+    sendTalkTranscriptionRelayAudio({
+      transcriptionSessionId: session.transcriptionSessionId,
+      connId: "conn-1",
+      audioBase64: "AQI=",
+    });
+    stopTalkTranscriptionRelaySession({
+      transcriptionSessionId: session.transcriptionSessionId,
+      connId: "conn-1",
+    });
+    closeTalkTranscriptionRelaySessionsForConnection("conn-1");
+    await Promise.resolve();
+
+    expect(
+      events.filter((event) => isRecord(event.payload) && event.payload.type === "close"),
+    ).toHaveLength(1);
+    expect(
+      events.some(
+        (event) =>
+          isRecord(event.payload) && event.payload.text === "disconnected provider transcript",
+      ),
+    ).toBe(false);
+    expect(sttSession.close).toHaveBeenCalledOnce();
+  });
+
+  it("terminates graceful draining immediately when the provider reports an error", async () => {
+    let request: RealtimeTranscriptionSessionCreateRequest | undefined;
+    const sttSession = createSttSessionMock();
+    const { events, session } = await createStartedRelaySession(sttSession, {}, (value) => {
+      request = value;
+    });
+
+    sendTalkTranscriptionRelayAudio({
+      transcriptionSessionId: session.transcriptionSessionId,
+      connId: "conn-1",
+      audioBase64: "AQI=",
+    });
+    stopTalkTranscriptionRelaySession({
+      transcriptionSessionId: session.transcriptionSessionId,
+      connId: "conn-1",
+    });
+    request?.onError?.(new Error("provider finalization failed"));
+    request?.onTranscript?.("transcript after provider error");
+
+    expect(findPayloadByType(events, "error").message).toBe("provider finalization failed");
+    expect(findPayloadByType(events, "close").reason).toBe("error");
+    expect(
+      events.some(
+        (event) =>
+          isRecord(event.payload) && event.payload.text === "transcript after provider error",
+      ),
+    ).toBe(false);
+    expect(sttSession.close).toHaveBeenCalledOnce();
   });
 
   it("keeps provider errors and terminal close events durable", async () => {
@@ -477,6 +778,9 @@ describe("talk transcription gateway relay", () => {
     const { events, session } = await createStartedRelaySession(sttSession, {}, (req) => {
       sttRequest = req;
     });
+    sttSession.close.mockImplementationOnce(() => {
+      sttRequest?.onTranscript?.("cancelled provider transcript");
+    });
 
     cancelTalkTranscriptionRelayTurn({
       transcriptionSessionId: session.transcriptionSessionId,
@@ -502,5 +806,11 @@ describe("talk transcription gateway relay", () => {
       type: "close",
       reason: "completed",
     });
+    expect(
+      events.some(
+        (event) =>
+          isRecord(event.payload) && event.payload.text === "cancelled provider transcript",
+      ),
+    ).toBe(false);
   });
 });

--- a/src/gateway/talk-transcription-relay.ts
+++ b/src/gateway/talk-transcription-relay.ts
@@ -32,6 +32,9 @@ import { forgetUnifiedTalkSession } from "./talk-session-registry.js";
  * events for the same connection.
  */
 const TRANSCRIPTION_SESSION_TTL_MS = 30 * 60 * 1000;
+// Realtime transcription websocket owners retain provider sockets for this
+// bounded interval so a graceful close can still deliver its final transcript.
+const TRANSCRIPTION_PROVIDER_FINAL_DRAIN_MS = 5_000;
 const MAX_AUDIO_BASE64_BYTES = 512 * 1024;
 const MAX_TRANSCRIPTION_SESSIONS_PER_CONN = 2;
 const MAX_TRANSCRIPTION_SESSIONS_GLOBAL = 64;
@@ -61,6 +64,8 @@ type TranscriptionRelaySession = {
   talk: TalkSessionController;
   expiresAtMs: number;
   cleanupTimer: ReturnType<typeof setTimeout>;
+  receivedAudio: boolean;
+  draining: boolean;
   closed: boolean;
 };
 
@@ -189,7 +194,9 @@ function closeTranscriptionSession(
   forgetUnifiedTalkSession(session.id);
   clearTimeout(session.cleanupTimer);
   try {
-    session.sttSession.close();
+    if (!session.draining) {
+      session.sttSession.close();
+    }
   } finally {
     // Provider teardown may throw, but the owner-visible terminal event must
     // still complete so disconnect cleanup cannot leave ambiguous state.
@@ -285,7 +292,7 @@ export function createTalkTranscriptionRelaySession(
     providerConfig: params.providerConfig,
     onSpeechStart: () => {
       const relay = getActiveRelay();
-      if (!relay) {
+      if (!relay || relay.draining) {
         return;
       }
       ensureTranscriptionTurn(relay);
@@ -361,6 +368,8 @@ export function createTalkTranscriptionRelaySession(
         closeTranscriptionSession(active, "completed");
       }
     }, TRANSCRIPTION_SESSION_TTL_MS),
+    receivedAudio: false,
+    draining: false,
     closed: false,
   };
   relayRef.current = relay;
@@ -369,7 +378,7 @@ export function createTalkTranscriptionRelaySession(
   sttSession
     .connect()
     .then(() => {
-      if (transcriptionSessions.get(transcriptionSessionId) !== relay) {
+      if (transcriptionSessions.get(transcriptionSessionId) !== relay || relay.draining) {
         return;
       }
       emit({ transcriptionSessionId, type: "ready" }, { type: "session.ready", payload: null });
@@ -411,13 +420,17 @@ function getTranscriptionSession(
   transcriptionSessionId: string,
   connId: string,
 ): TranscriptionRelaySession {
-  return requireActiveTalkRelaySession({
+  const relay = requireActiveTalkRelaySession({
     sessions: transcriptionSessions,
     sessionId: transcriptionSessionId,
     connId,
     closeSession: (session) => closeTranscriptionSession(session, "completed"),
     unknownSessionMessage: "Unknown transcription Talk session",
   });
+  if (relay.draining) {
+    throw new Error("Unknown transcription Talk session");
+  }
+  return relay;
 }
 
 /** Streams one base64-encoded audio frame into the owning transcription relay. */
@@ -433,6 +446,7 @@ export function sendTalkTranscriptionRelayAudio(params: {
   const audio = decodeTalkRelayAudioBase64(params.audioBase64, "Transcription Talk");
   const turnId = ensureTranscriptionTurn(session);
   session.sttSession.sendAudio(audio);
+  session.receivedAudio = true;
   broadcastToOwner(session.context, session.connId, {
     transcriptionSessionId: session.id,
     type: "inputAudio",
@@ -451,7 +465,12 @@ export function stopTalkTranscriptionRelaySession(params: {
   connId: string;
 }): void {
   const session = getTranscriptionSession(params.transcriptionSessionId, params.connId);
-  if (session.talk.activeTurnId) {
+  const turnId = session.talk.activeTurnId;
+  if (!turnId && !session.receivedAudio) {
+    closeTranscriptionSession(session, "completed");
+    return;
+  }
+  if (turnId) {
     broadcastToOwner(session.context, session.connId, {
       transcriptionSessionId: session.id,
       type: "transcript",
@@ -459,13 +478,28 @@ export function stopTalkTranscriptionRelaySession(params: {
       final: true,
       talkEvent: session.talk.emit({
         type: "input.audio.committed",
-        turnId: session.talk.activeTurnId,
+        turnId,
         payload: {},
         final: true,
       }),
     });
   }
-  closeTranscriptionSession(session, "completed");
+  session.draining = true;
+  clearTimeout(session.cleanupTimer);
+  session.cleanupTimer = setTimeout(() => {
+    if (transcriptionSessions.get(session.id) === session) {
+      closeTranscriptionSession(session, "completed");
+    }
+  }, TRANSCRIPTION_PROVIDER_FINAL_DRAIN_MS);
+  session.cleanupTimer.unref?.();
+  try {
+    // Providers can flush several finals across asynchronous frames; keep this
+    // exact owner registered throughout its bounded provider shutdown window.
+    session.sttSession.close();
+  } catch (error) {
+    closeTranscriptionSession(session, "completed");
+    throw error;
+  }
 }
 
 /** Cancels the active transcription turn and closes the relay. */


### PR DESCRIPTION
## Summary

- Deliver all final and partial provider speech transcripts emitted while a Talk session closes.
- Preserve strict connection ownership, immediate cancellation/disconnect, resource limits, and bounded teardown.

## Root cause and architectural owner

The Talk Gateway removed its exact session owner before calling the transcription provider's graceful close. Deepgram, ElevenLabs, Mistral, and other providers emit their final transcript only during close; the shared websocket owner intentionally retains its socket for five seconds, but the Gateway had already rejected every callback. Users lost their final spoken words without any visible error.

The Gateway now keeps the same authenticated relay owner for the existing bounded five-second provider finalization window. It accepts all final and partial callbacks for already-received audio, including multiple distinct finals; new browser audio and stale ready/foreign-generation callbacks remain rejected. Empty sessions, cancellation, disconnect, provider errors, and expiry retain their immediate terminal behavior.

## Actual consumer/owner proof

- Actual production relay reproduced zero final events before repair despite both synchronous and asynchronous provider flush callbacks.
- Accepted independent adversarial cases additionally proved and repaired stale ready after close, multiple late final utterances, intervening partial updates required by the real Control UI quiet timer, and prior completed turns with new buffered audio.
- Actual Gateway owner plus real UI dictation consumer: **35/35 passing**.
- One provider close and one terminal event; no post-cancel transcript; connection/global limits remain enforced throughout the existing bounded interval.
- Type-aware lint, formatting, and diff checks: clean.
- Fresh independent structured Sol/high review: **no findings, confidence 0.91**.
- Production delta: **+34 lines**, required to own graceful drain and session identity.
