### PR TITLE
fix(gateway): resume durable outbound delivery retries

### DIFF
--- a/src/gateway/server-runtime-services.test.ts
+++ b/src/gateway/server-runtime-services.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getActiveGatewayRootWorkCount,
   resetGatewayWorkAdmission,
+  tryBeginGatewaySuspendAdmission,
   tryBeginGatewayRootWorkAdmission,
 } from "../process/gateway-work-admission.js";
 
@@ -17,6 +18,8 @@ function waitForFast<T>(
 
 type StartSessionDeliveryRuntime =
   typeof import("../infra/session-delivery-queue-runtime.js").startSessionDeliveryRuntime;
+type DrainPendingDeliveries =
+  typeof import("../infra/outbound/delivery-queue.js").drainPendingDeliveries;
 
 const hoisted = vi.hoisted(() => {
   const heartbeatRunner = {
@@ -40,7 +43,13 @@ const hoisted = vi.hoisted(() => {
     ),
     schedulePendingSessionDeliveries: vi.fn(async () => undefined),
     startSessionUpstreamMonitor: vi.fn(() => ({ stop: stopSessionUpstreamMonitor })),
-    recoverPendingDeliveries: vi.fn(async () => undefined),
+    recoverPendingDeliveries: vi.fn(async () => ({
+      recovered: 0,
+      failed: 0,
+      skippedMaxRetries: 0,
+      deferredBackoff: 0,
+    })),
+    drainPendingDeliveries: vi.fn<DrainPendingDeliveries>(async () => undefined),
     recoverPendingRestartContinuationDeliveries: vi.fn(async () => undefined),
     deliverQueuedSessionDelivery: vi.fn(async () => undefined),
     settleQueuedSessionDelivery: vi.fn(async () => undefined),
@@ -71,6 +80,7 @@ vi.mock("../infra/outbound/deliver.js", () => ({
 
 vi.mock("../infra/outbound/delivery-queue.js", () => ({
   recoverPendingDeliveries: hoisted.recoverPendingDeliveries,
+  drainPendingDeliveries: hoisted.drainPendingDeliveries,
 }));
 
 vi.mock("../infra/session-delivery-queue-runtime.js", () => ({
@@ -116,6 +126,8 @@ describe("server-runtime-services", () => {
     hoisted.startSessionDeliveryRuntime.mockClear();
     hoisted.schedulePendingSessionDeliveries.mockClear();
     hoisted.recoverPendingDeliveries.mockClear();
+    hoisted.drainPendingDeliveries.mockReset();
+    hoisted.drainPendingDeliveries.mockResolvedValue(undefined);
     hoisted.recoverPendingRestartContinuationDeliveries.mockClear();
     hoisted.deliverQueuedSessionDelivery.mockClear();
     hoisted.settleQueuedSessionDelivery.mockClear();
@@ -408,6 +420,139 @@ describe("server-runtime-services", () => {
     await vi.advanceTimersByTimeAsync(1_250);
     await vi.dynamicImportSettled();
     expect(hoisted.recoverPendingDeliveries).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    {
+      name: "startup recovery deferred an existing delivery for backoff",
+      deferredBackoff: 1,
+    },
+    {
+      name: "a new delivery failed after an empty startup scan",
+      deferredBackoff: 0,
+    },
+  ])("retries outbound deliveries when $name", async ({ deferredBackoff }) => {
+    vi.useFakeTimers();
+    hoisted.recoverPendingDeliveries.mockResolvedValueOnce({
+      recovered: 0,
+      failed: 0,
+      skippedMaxRetries: 0,
+      deferredBackoff,
+    });
+    const { services } = activateScheduledServicesForTest({ startCron: false });
+
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(hoisted.recoverPendingDeliveries).toHaveBeenCalledOnce();
+    expect(hoisted.drainPendingDeliveries).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(hoisted.drainPendingDeliveries).toHaveBeenCalledOnce();
+    const [drain] = hoisted.drainPendingDeliveries.mock.calls[0] ?? [];
+    expect(drain).toMatchObject({
+      drainKey: "gateway:outbound",
+      deliver: hoisted.deliverOutboundPayloads,
+    });
+    expect(drain?.selectEntry({ channel: "discord" } as never, Date.now())).toEqual({
+      match: true,
+      bypassBackoff: false,
+    });
+    services.heartbeatRunner.stop();
+  });
+
+  it("uses the current runtime config when retrying queued outbound deliveries", async () => {
+    vi.useFakeTimers();
+    const configModule = await import("../config/config.js");
+    const reloadedConfig = { channels: { discord: { enabled: false } } };
+    const runtimeConfig = vi
+      .spyOn(configModule, "getRuntimeConfig")
+      .mockReturnValue(reloadedConfig as never);
+    const { services } = activateScheduledServicesForTest({
+      startCron: false,
+      cfgAtStart: { channels: { discord: { enabled: true } } } as never,
+    });
+
+    try {
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      expect(hoisted.drainPendingDeliveries).toHaveBeenCalledWith(
+        expect.objectContaining({ cfg: reloadedConfig }),
+      );
+      expect(runtimeConfig).toHaveBeenCalledOnce();
+    } finally {
+      services.heartbeatRunner.stop();
+      runtimeConfig.mockRestore();
+    }
+  });
+
+  it("never overlaps outbound retry drains or admits work between timer firings", async () => {
+    vi.useFakeTimers();
+    let finishDrain: (() => void) | undefined;
+    hoisted.drainPendingDeliveries.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishDrain = resolve;
+        }),
+    );
+    const { services } = activateScheduledServicesForTest({ startCron: false });
+
+    await vi.advanceTimersByTimeAsync(1_250);
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(3_750);
+    expect(hoisted.drainPendingDeliveries).toHaveBeenCalledOnce();
+    expect(getActiveGatewayRootWorkCount()).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(hoisted.drainPendingDeliveries).toHaveBeenCalledOnce();
+    expect(getActiveGatewayRootWorkCount()).toBe(1);
+
+    if (!finishDrain) {
+      throw new Error("Expected the outbound retry drain to be pending");
+    }
+    finishDrain();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(hoisted.drainPendingDeliveries).toHaveBeenCalledTimes(2);
+    services.heartbeatRunner.stop();
+  });
+
+  it("stops outbound delivery retry timers with the gateway lifecycle", async () => {
+    vi.useFakeTimers();
+    const { services } = activateScheduledServicesForTest({ startCron: false });
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(hoisted.drainPendingDeliveries).toHaveBeenCalledOnce();
+
+    services.heartbeatRunner.stop();
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    expect(hoisted.drainPendingDeliveries).toHaveBeenCalledOnce();
+    expect(hoisted.heartbeatRunner.stop).toHaveBeenCalledOnce();
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
+  });
+
+  it("skips outbound retry ticks while gateway work admission is suspended", async () => {
+    vi.useFakeTimers();
+    const { services } = activateScheduledServicesForTest({ startCron: false });
+    await vi.advanceTimersByTimeAsync(1_250);
+
+    const suspension = tryBeginGatewaySuspendAdmission(() => {});
+    if (!suspension?.commit()) {
+      throw new Error("Expected gateway suspension admission to be acquired");
+    }
+    await vi.advanceTimersByTimeAsync(13_750);
+
+    expect(hoisted.drainPendingDeliveries).not.toHaveBeenCalled();
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
+
+    suspension.release();
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(hoisted.drainPendingDeliveries).toHaveBeenCalledOnce();
+    services.heartbeatRunner.stop();
   });
 
   it("starts cron and records memory when post-ready maintenance fails", async () => {

--- a/src/gateway/server-runtime-services.ts
+++ b/src/gateway/server-runtime-services.ts
@@ -2,6 +2,7 @@
 // Starts delayed maintenance, cron, heartbeat, recovery, and pricing refresh work.
 import { getRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { computeBackoffMs } from "../infra/delivery-recovery.shared.js";
 import {
   resolveHeartbeatAgents,
   startHeartbeatRunner,
@@ -12,7 +13,10 @@ import {
   schedulePendingSessionDeliveries,
   startSessionDeliveryRuntime,
 } from "../infra/session-delivery-queue-runtime.js";
-import { runWithGatewayIndependentRootWorkAdmission } from "../process/gateway-work-admission.js";
+import {
+  isGatewayWorkAdmissionClosed,
+  runWithGatewayIndependentRootWorkAdmission,
+} from "../process/gateway-work-admission.js";
 import { startSessionUpstreamMonitor } from "../sessions/session-upstream-monitor.js";
 import type { GatewayCronReconciliation } from "./server-cron-reconciled.js";
 import type { GatewayCronState } from "./server-cron.js";
@@ -181,19 +185,58 @@ export function scheduleGatewayPostReadyMaintenance(params: {
 function recoverPendingOutboundDeliveries(params: {
   cfg: OpenClawConfig;
   log: GatewayRuntimeServiceLogger;
-}): void {
-  // Recovery is best-effort background work; startup must continue even if outbound modules fail
-  // to import or queued delivery replay fails.
-  void runWithGatewayIndependentRootWorkAdmission(async () => {
-    const { recoverPendingDeliveries } = await import("../infra/outbound/delivery-queue.js");
-    const { deliverOutboundPayloadsInternal } = await import("../infra/outbound/deliver.js");
-    const logRecovery = params.log.child("delivery-recovery");
-    await recoverPendingDeliveries({
-      deliver: deliverOutboundPayloadsInternal,
-      log: logRecovery,
-      cfg: params.cfg,
-    });
-  }).catch((err: unknown) => params.log.error(`Delivery recovery failed: ${String(err)}`));
+}): () => void {
+  let stopped = false;
+  let recoveryInFlight = false;
+  let logRecovery: ReturnType<GatewayRuntimeServiceLogger["child"]> | undefined;
+
+  const recover = (startup: boolean): void => {
+    if (stopped || recoveryInFlight || isGatewayWorkAdmissionClosed()) {
+      return;
+    }
+    recoveryInFlight = true;
+    void runWithGatewayIndependentRootWorkAdmission(async () => {
+      const { drainPendingDeliveries, recoverPendingDeliveries } =
+        await import("../infra/outbound/delivery-queue.js");
+      const { deliverOutboundPayloadsInternal } = await import("../infra/outbound/deliver.js");
+      if (stopped) {
+        return;
+      }
+      logRecovery ??= params.log.child("delivery-recovery");
+      if (startup) {
+        await recoverPendingDeliveries({
+          deliver: deliverOutboundPayloadsInternal,
+          log: logRecovery,
+          cfg: params.cfg,
+        });
+        return;
+      }
+      // Startup migration runs once. Normal retries use fresh config so revoked
+      // accounts cannot inherit the authority captured at gateway startup.
+      await drainPendingDeliveries({
+        drainKey: "gateway:outbound",
+        logLabel: "Outbound delivery retry",
+        cfg: getRuntimeConfig(),
+        log: logRecovery,
+        deliver: deliverOutboundPayloadsInternal,
+        selectEntry: () => ({ match: true, bypassBackoff: false }),
+      });
+    })
+      .catch((err: unknown) => params.log.error(`Delivery recovery failed: ${String(err)}`))
+      .finally(() => {
+        recoveryInFlight = false;
+      });
+  };
+
+  // Match the queue's first backoff window without holding admission between
+  // ticks; otherwise suspended/restarting gateways retain invisible work.
+  const retryTimer = setInterval(() => recover(false), computeBackoffMs(1));
+  retryTimer.unref?.();
+  recover(true);
+  return () => {
+    stopped = true;
+    clearInterval(retryTimer);
+  };
 }
 
 function startPendingSessionDeliveryRuntime(params: {
@@ -291,14 +334,6 @@ export function activateGatewayScheduledServices(params: {
     log: params.log,
     maxEnqueuedAt: params.sessionDeliveryRecoveryMaxEnqueuedAt,
   });
-  const heartbeatRunnerWithUpstreamMonitor: HeartbeatRunner = {
-    updateConfig: heartbeatRunner.updateConfig,
-    stop: () => {
-      stopSessionDeliveryRuntime();
-      sessionUpstreamMonitor.stop();
-      heartbeatRunner.stop();
-    },
-  };
   if (params.startCron !== false) {
     startGatewayCronWithLogging({
       cronState: params.cronState,
@@ -308,11 +343,19 @@ export function activateGatewayScheduledServices(params: {
       logCron: params.logCron,
     });
   }
-  recoverPendingOutboundDeliveries({
+  const stopOutboundDeliveryRecovery = recoverPendingOutboundDeliveries({
     cfg: params.cfgAtStart,
     log: params.log,
   });
   return {
-    heartbeatRunner: heartbeatRunnerWithUpstreamMonitor,
+    heartbeatRunner: {
+      updateConfig: heartbeatRunner.updateConfig,
+      stop: () => {
+        stopOutboundDeliveryRecovery();
+        stopSessionDeliveryRuntime();
+        sessionUpstreamMonitor.stop();
+        heartbeatRunner.stop();
+      },
+    },
   };
 }

--- a/src/infra/outbound/delivery-queue.reconnect-drain.test.ts
+++ b/src/infra/outbound/delivery-queue.reconnect-drain.test.ts
@@ -185,6 +185,106 @@ describe("drainPendingDeliveries for reconnect", () => {
     expect(deliver).not.toHaveBeenCalled();
   });
 
+  it("retries deferred rows for every channel through the gateway-wide drain", async () => {
+    const channels = ["discord", "slack", "signal"] as const;
+    const deliveryIds: string[] = [];
+    for (const channel of channels) {
+      const id = await enqueueDelivery(
+        {
+          channel,
+          to: `${channel}:recipient`,
+          payloads: [{ text: `retry ${channel}` }],
+        },
+        tmpDir,
+      );
+      await failDelivery(id, "temporary connection failure", tmpDir);
+      deliveryIds.push(id);
+    }
+    const deliver = vi.fn<DeliverFn>(async (entry) => [
+      { channel: entry.channel, messageId: `${entry.channel}-delivered` },
+    ]);
+    const drain = () =>
+      drainPendingDeliveries({
+        drainKey: "gateway:outbound",
+        logLabel: "Outbound delivery retry",
+        cfg: stubCfg,
+        log: createRecoveryLog(),
+        stateDir: tmpDir,
+        deliver,
+        selectEntry: () => ({ match: true, bypassBackoff: false }),
+      });
+
+    await expect(
+      recoverPendingDeliveries({
+        cfg: stubCfg,
+        log: createRecoveryLog(),
+        stateDir: tmpDir,
+        deliver,
+      }),
+    ).resolves.toMatchObject({ recovered: 0, deferredBackoff: channels.length });
+
+    await drain();
+    expect(deliver).not.toHaveBeenCalled();
+    expect(await loadPendingDeliveries(tmpDir)).toHaveLength(channels.length);
+
+    for (const id of deliveryIds) {
+      setQueuedEntryState(tmpDir, id, {
+        retryCount: 1,
+        lastAttemptAt: Date.now() - 5_000,
+        lastError: "temporary connection failure",
+      });
+    }
+    await drain();
+
+    expect(deliver.mock.calls.map(([entry]) => entry.channel).toSorted()).toEqual(
+      channels.toSorted(),
+    );
+    expect(await loadPendingDeliveries(tmpDir)).toEqual([]);
+
+    await drain();
+    expect(deliver).toHaveBeenCalledTimes(channels.length);
+  });
+
+  it("rejects recovered delivery when the current channel config disables its account", async () => {
+    const id = await enqueueDelivery(
+      {
+        channel: "discord",
+        to: "discord:recipient",
+        payloads: [{ text: "do not send after account revocation" }],
+      },
+      tmpDir,
+    );
+    await failDelivery(id, "temporary connection failure", tmpDir);
+    setQueuedEntryState(tmpDir, id, {
+      retryCount: 1,
+      lastAttemptAt: Date.now() - 5_000,
+    });
+    const cfg: OpenClawConfig = { channels: { discord: { enabled: false } } };
+    const admitDeferredDelivery = vi.fn(({ cfg: currentConfig }: { cfg: OpenClawConfig }) =>
+      currentConfig.channels?.discord?.enabled === false
+        ? { status: "permanent_rejection" as const, reason: "Discord account disabled" }
+        : { status: "allowed" as const },
+    );
+    resolveOutboundChannelMessageAdapterMock.mockReturnValue({
+      durableFinal: { admitDeferredDelivery },
+    });
+    const deliver = vi.fn<DeliverFn>(async () => []);
+
+    await drainPendingDeliveries({
+      drainKey: "gateway:outbound",
+      logLabel: "Outbound delivery retry",
+      cfg,
+      log: createRecoveryLog(),
+      stateDir: tmpDir,
+      deliver,
+      selectEntry: () => ({ match: true, bypassBackoff: false }),
+    });
+
+    expect(admitDeferredDelivery).toHaveBeenCalledWith(expect.objectContaining({ cfg }));
+    expect(deliver).not.toHaveBeenCalled();
+    expect(readOutboundQueueStatus(tmpDir, id)).toBe("failed");
+  });
+
   it("retries immediately without resetting retry history", async () => {
     const log = createRecoveryLog();
     const deliver = createTransientFailureDeliver();


### PR DESCRIPTION
## Summary

- Automatically retry persisted failed outbound messages instead of abandoning them until Gateway restart.
- Preserve existing backoff, atomic delivery claims, current channel authorization, and Gateway suspension/shutdown ownership.

## Root cause and canonical lifecycle owner

The generic Gateway called `recoverPendingDeliveries` exactly once at startup. A persisted row whose backoff had not elapsed—or any new Slack/Discord/Signal/etc. transport failure after startup—had no future generic drain, leaving the user's message stranded indefinitely; only a few channels implemented their own polling. The existing per-channel durable queue, coordinator, and retry policy already support correct recovery.

The Gateway runtime now owns a bounded unref timer matching the existing five-second first backoff. Startup legacy migration still executes exactly once; normal ticks use the existing atomic generic drain/coordinator, fresh `getRuntimeConfig()`, nonoverlapping work admission, and canonical backoff. No admitted root is retained between ticks, suspended Gateways are skipped, and the timer stops with the existing runtime lifecycle.

## Actual durable operator proof

Real SQLite queue rows for Discord, Slack, and Signal fail once, are all deferred by the real startup owner, then the canonical retry owner delivers each exactly once after backoff; a repeat drain delivers none. A real revoked channel account is dead-lettered without invoking its send callback, proving current authorization replaces stale startup configuration.

- Five actual Gateway lifecycle failures reproduced before repair.
- Existing Gateway lifecycle + real SQLite delivery suites: **46/46 passing**.
- Covers initially empty startup then later failure, startup-deferred rows, hot channel disable, overlap, suspension/no idle admitted waiter, and shutdown cleanup.
- Type-aware/type-check lint and formatting: clean.
- Fresh independent structured Sol/high review: **no findings, confidence 0.91**.
- Production delta: **+43 lines** for the previously missing lifecycle owner; no schema, configuration, or retry-policy changes.
