### PR TITLE
fix(slack): isolate GovSlack media trust and delivery

### DIFF
--- a/extensions/slack/src/actions.download-file.test.ts
+++ b/extensions/slack/src/actions.download-file.test.ts
@@ -53,7 +53,7 @@ function expectNoMediaDownload(result: Awaited<ReturnType<typeof downloadSlackFi
   expect(resolveSlackMedia).not.toHaveBeenCalled();
 }
 
-function expectResolveSlackMediaCalledWithDefaults() {
+function expectResolveSlackMediaCalledWithDefaults(client: ReturnType<typeof createClient>) {
   expect(resolveSlackMedia).toHaveBeenCalledWith({
     files: [
       {
@@ -64,6 +64,7 @@ function expectResolveSlackMediaCalledWithDefaults() {
         url_private_download: "https://files.slack.com/files-pri/T1-F123/image.png",
       },
     ],
+    client,
     token: "xoxb-test",
     maxBytes: 1024,
   });
@@ -116,8 +117,26 @@ describe("downloadSlackFile", () => {
     });
 
     expect(client.files.info).toHaveBeenCalledWith({ file: "F123" });
-    expectResolveSlackMediaCalledWithDefaults();
+    expectResolveSlackMediaCalledWithDefaults(client);
     expect(result).toEqual(makeResolvedSlackMedia());
+  });
+
+  it("passes the prepared GovSlack client to the media trust boundary", async () => {
+    const client = Object.assign(createClient(), { slackApiUrl: "https://slack-gov.com/api/" });
+    client.files.info.mockResolvedValueOnce({
+      file: makeSlackFileInfo({
+        url_private_download: "https://files.slack-gov.com/files-pri/T1-F123/image.png",
+      }),
+    });
+    resolveSlackMedia.mockResolvedValueOnce([makeResolvedSlackMedia()]);
+
+    await downloadSlackFile("F123", {
+      client,
+      token: "xoxb-test",
+      maxBytes: 1024,
+    });
+
+    expect(resolveSlackMedia).toHaveBeenCalledWith(expect.objectContaining({ client }));
   });
 
   it("preserves non-image download metadata", async () => {
@@ -153,6 +172,7 @@ describe("downloadSlackFile", () => {
           url_private_download: "https://files.slack.com/files-pri/T1-F123/report.pdf",
         },
       ],
+      client,
       token: "xoxb-test",
       maxBytes: 1024,
     });
@@ -218,7 +238,7 @@ describe("downloadSlackFile", () => {
 
     expect(result).toEqual(makeResolvedSlackMedia());
     expect(resolveSlackMedia).toHaveBeenCalledTimes(1);
-    expectResolveSlackMediaCalledWithDefaults();
+    expectResolveSlackMediaCalledWithDefaults(client);
   });
 
   it("resolves the bot token from cfg when no explicit token or client is provided", async () => {
@@ -258,6 +278,7 @@ describe("downloadSlackFile", () => {
           url_private_download: "https://files.slack.com/files-pri/T1-F123/image.png",
         },
       ],
+      client,
       token: "xoxb-from-cfg",
       maxBytes: 1024,
     });

--- a/extensions/slack/src/actions.ts
+++ b/extensions/slack/src/actions.ts
@@ -732,6 +732,7 @@ export async function downloadSlackFile(
         url_private_download: file.url_private_download,
       },
     ],
+    client,
     token,
     maxBytes: opts.maxBytes,
   });

--- a/extensions/slack/src/monitor/media.test.ts
+++ b/extensions/slack/src/monitor/media.test.ts
@@ -2,6 +2,11 @@ import { expectDefined } from "@openclaw/normalization-core";
 // Slack tests cover media plugin behavior.
 import type { WebClient } from "@slack/web-api";
 import type { FetchLike, SavedMedia } from "openclaw/plugin-sdk/media-runtime";
+import {
+  fetchWithSsrFGuard,
+  type LookupFn,
+  type SsrFPolicy,
+} from "openclaw/plugin-sdk/ssrf-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   resolveSlackAttachmentContent,
@@ -297,6 +302,195 @@ describe("resolveSlackMedia", () => {
       secondAuthorization: null,
     });
   });
+
+  it.each(["https://slack-gov.com/api/", "https://slack-gov.com./api/"])(
+    "downloads GovSlack files only for their prepared official API client %s",
+    async (slackApiUrl) => {
+      const client = { slackApiUrl } as WebClient;
+      mockFetch.mockResolvedValueOnce(
+        new Response(Buffer.from("government image"), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+      );
+
+      const result = await resolveSlackMedia({
+        files: [{ url_private_download: "https://files.slack-gov.com/direct.png" }],
+        client,
+        token: "xoxb-test-token",
+        maxBytes: 1024,
+      });
+
+      expectSlackMediaResult(result);
+      expectFetchCalledWithUrl(mockFetch, "https://files.slack-gov.com/direct.png");
+      expect(getRequestHeader(0, "Authorization")).toBe("Bearer xoxb-test-token");
+    },
+  );
+
+  it("keeps the GovSlack trust boundary when refreshing a private file URL", async () => {
+    const client = {
+      slackApiUrl: "https://slack-gov.com/api/",
+      files: {
+        info: vi.fn(async () => ({
+          file: { url_private_download: "https://files.slack-gov.com/refreshed.png" },
+        })),
+      },
+    } as unknown as WebClient;
+    mockFetch.mockResolvedValueOnce(new Response("expired", { status: 403 })).mockResolvedValueOnce(
+      new Response(Buffer.from("refreshed government image"), {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      }),
+    );
+
+    const result = await resolveSlackMedia({
+      files: [
+        {
+          id: "FGOV123",
+          url_private_download: "https://files.slack-gov.com/expired.png",
+        },
+      ],
+      client,
+      token: "xoxb-test-token",
+      maxBytes: 1024,
+    });
+
+    expectSlackMediaResult(result);
+    expect(client.files.info).toHaveBeenCalledWith({ file: "FGOV123" });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(requireMockCall(mockFetch, 1, "fetch")[0]).toBe(
+      "https://files.slack-gov.com/refreshed.png",
+    );
+  });
+
+  it("downloads GovSlack files discovered only through files.info metadata", async () => {
+    const client = {
+      slackApiUrl: "https://slack-gov.com/api/",
+      files: {
+        info: vi.fn(async () => ({
+          file: { url_private_download: "https://files.slack-gov.com/metadata-only.png" },
+        })),
+      },
+    } as unknown as WebClient;
+    mockFetch.mockResolvedValueOnce(
+      new Response(Buffer.from("government image"), {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      }),
+    );
+
+    const result = await resolveSlackMedia({
+      files: [{ id: "FGOV123" }],
+      client,
+      token: "xoxb-test-token",
+      maxBytes: 1024,
+    });
+
+    expectSlackMediaResult(result);
+    expect(client.files.info).toHaveBeenCalledWith({ file: "FGOV123" });
+    expectFetchCalledWithUrl(mockFetch, "https://files.slack-gov.com/metadata-only.png");
+  });
+
+  it("rejects files.info refresh URLs that escape the GovSlack trust plane", async () => {
+    const client = {
+      slackApiUrl: "https://slack-gov.com/api/",
+      files: {
+        info: vi.fn(async () => ({
+          file: { url_private_download: "https://files.slack.com/cross-plane.png" },
+        })),
+      },
+    } as unknown as WebClient;
+    mockFetch.mockResolvedValueOnce(new Response("expired", { status: 403 }));
+
+    const result = await resolveSlackMedia({
+      files: [{ id: "FGOV123", url_private_download: "https://files.slack-gov.com/expired.png" }],
+      client,
+      token: "xoxb-test-token",
+      maxBytes: 1024,
+    });
+
+    expect(result).toBeNull();
+    expect(client.files.info).toHaveBeenCalledWith({ file: "FGOV123" });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(getRequestHeader(0, "Authorization")).toBe("Bearer xoxb-test-token");
+  });
+
+  it.each([
+    ["commercial client to GovSlack", "https://slack.com/api/", "files.slack-gov.com"],
+    ["GovSlack client to commercial Slack", "https://slack-gov.com/api/", "files.slack.com"],
+    ["GovSlack client to commercial CDN", "https://slack-gov.com/api/", "downloads.slack-edge.com"],
+    [
+      "undocumented GovSlack subdomain",
+      "https://slack-gov.com/api/",
+      "future-upload.slack-gov.com",
+    ],
+    ["nested GovSlack file hostname", "https://slack-gov.com/api/", "nested.files.slack-gov.com"],
+    [
+      "GovSlack hostname suffix lookalike",
+      "https://slack-gov.com/api/",
+      "files.slack-gov.com.evil.example",
+    ],
+    [
+      "lookalike GovSlack API root",
+      "https://slack-gov.com.evil.example/api/",
+      "files.slack-gov.com",
+    ],
+    ["plaintext GovSlack API root", "http://slack-gov.com/api/", "files.slack-gov.com"],
+    ["nondefault GovSlack API port", "https://slack-gov.com:444/api/", "files.slack-gov.com"],
+  ])("rejects %s before exposing its bearer token", async (_label, slackApiUrl, hostname) => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(Buffer.from("must not fetch"), {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      }),
+    );
+
+    const result = await resolveSlackMedia({
+      files: [{ url_private_download: `https://${hostname}/image.png` }],
+      client: { slackApiUrl } as WebClient,
+      token: "xoxb-test-token",
+      maxBytes: 1024,
+    });
+
+    expect(result).toBeNull();
+    expect(saveRemoteMediaMock).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      "commercial redirect to GovSlack",
+      "https://slack.com/api/",
+      "https://files.slack.com/direct.png",
+      "https://files.slack-gov.com/escaped.png",
+    ],
+    [
+      "GovSlack redirect to commercial Slack",
+      "https://slack-gov.com/api/",
+      "https://files.slack-gov.com/direct.png",
+      "https://downloads.slack-edge.com/escaped.png",
+    ],
+  ])(
+    "rejects %s before a cross-plane fetch",
+    async (_label, slackApiUrl, sourceUrl, redirectUrl) => {
+      mockFetch
+        .mockResolvedValueOnce(
+          new Response(null, { status: 302, headers: { location: redirectUrl } }),
+        )
+        .mockResolvedValueOnce(new Response("must not fetch", { status: 200 }));
+
+      const result = await resolveSlackMedia({
+        files: [{ url_private_download: sourceUrl }],
+        client: { slackApiUrl } as WebClient,
+        token: "xoxb-test-token",
+        maxBytes: 1024,
+      });
+
+      expect(result).toBeNull();
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(getRequestHeader(0, "Authorization")).toBe("Bearer xoxb-test-token");
+    },
+  );
 
   it("returns null when download fails", async () => {
     // Simulate a network error
@@ -810,6 +1004,130 @@ describe("Slack media SSRF policy", () => {
     );
     expect(policy.allowRfc2544BenchmarkRange).toBe(true);
   });
+
+  it("restricts GovSlack media SSRF policy to its exact official file hostname", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(Buffer.from("government image"), {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      }),
+    );
+
+    await resolveSlackMedia({
+      files: [{ url_private_download: "https://files.slack-gov.com/direct.png" }],
+      client: { slackApiUrl: "https://slack-gov.com/api/" } as WebClient,
+      token: "xoxb-test-token",
+      maxBytes: 1024,
+    });
+
+    const policy = requireRecord(
+      requireRecord(
+        requireMockCall(readRemoteMediaBufferMock, 0, "readRemoteMediaBuffer")[0],
+        "readRemoteMediaBuffer params",
+      ).ssrfPolicy,
+      "ssrfPolicy",
+    );
+    expect(policy).not.toHaveProperty("allowedHostnames");
+    expect(policy.hostnameAllowlist).toEqual(["files.slack-gov.com"]);
+    expect(policy.allowRfc2544BenchmarkRange).toBe(true);
+  });
+
+  it.each([
+    {
+      label: "blocks GovSlack RFC1918 class A DNS rebinding",
+      slackApiUrl: "https://slack-gov.com/api/",
+      fileHostname: "files.slack-gov.com",
+      address: "10.23.45.67",
+      allowed: false,
+    },
+    {
+      label: "blocks GovSlack RFC1918 class C DNS rebinding",
+      slackApiUrl: "https://slack-gov.com/api/",
+      fileHostname: "files.slack-gov.com",
+      address: "192.168.1.50",
+      allowed: false,
+    },
+    {
+      label: "allows a public GovSlack file destination",
+      slackApiUrl: "https://slack-gov.com/api/",
+      fileHostname: "files.slack-gov.com",
+      address: "93.184.216.34",
+      allowed: true,
+    },
+    {
+      label: "preserves GovSlack RFC2544 fake-IP proxy support",
+      slackApiUrl: "https://slack-gov.com/api/",
+      fileHostname: "files.slack-gov.com",
+      address: "198.18.0.1",
+      allowed: true,
+    },
+    {
+      label: "preserves commercial Slack private-address protection",
+      slackApiUrl: "https://slack.com/api/",
+      fileHostname: "files.slack.com",
+      address: "10.23.45.67",
+      allowed: false,
+    },
+    {
+      label: "preserves commercial Slack public-address downloads",
+      slackApiUrl: "https://slack.com/api/",
+      fileHostname: "files.slack.com",
+      address: "93.184.216.34",
+      allowed: true,
+    },
+  ])(
+    "$label through the actual guarded fetch",
+    async ({ slackApiUrl, fileHostname, address, allowed }) => {
+      const networkFetch = vi.fn(
+        async () =>
+          new Response(Buffer.from("guarded image"), {
+            status: 200,
+            headers: { "content-type": "image/png" },
+          }),
+      );
+      const lookupFn = vi.fn(async () => [{ address, family: 4 }]) as unknown as LookupFn;
+      saveRemoteMediaMock.mockImplementationOnce(async (params) => {
+        const guarded = await fetchWithSsrFGuard({
+          url: params.url,
+          fetchImpl: networkFetch,
+          init: params.requestInit,
+          policy: params.ssrfPolicy as SsrFPolicy,
+          lookupFn,
+        });
+        try {
+          const buffer = Buffer.from(await guarded.response.arrayBuffer());
+          return {
+            ...(await saveMediaBufferMock(
+              buffer,
+              guarded.response.headers.get("content-type") ?? undefined,
+              "inbound",
+              params.maxBytes,
+              params.filePathHint,
+            )),
+            fileName: params.filePathHint,
+          };
+        } finally {
+          await guarded.release();
+        }
+      });
+
+      const result = await resolveSlackMedia({
+        files: [{ url_private_download: `https://${fileHostname}/guarded.png` }],
+        client: { slackApiUrl } as WebClient,
+        token: "xoxb-test-token",
+        maxBytes: 1024,
+      });
+
+      if (allowed) {
+        expectSlackMediaResult(result);
+        expect(networkFetch).toHaveBeenCalledOnce();
+      } else {
+        expect(result).toBeNull();
+        expect(networkFetch).not.toHaveBeenCalled();
+      }
+      expect(lookupFn).toHaveBeenCalledWith(fileHostname, { all: true });
+    },
+  );
 });
 
 describe("resolveSlackAttachmentContent", () => {
@@ -903,6 +1221,52 @@ describe("resolveSlackAttachmentContent", () => {
     const firstInit = requireRecord(firstCall[1], "fetch init") as RequestInit;
     expect(firstInit.redirect).toBe("manual");
     expect(new Headers(firstInit.headers).get("Authorization")).toBe("Bearer xoxb-test-token");
+  });
+
+  it.each([
+    {
+      label: "forwarded image",
+      attachment: { is_share: true, image_url: "https://files.slack-gov.com/forwarded.png" },
+    },
+    {
+      label: "forwarded file",
+      attachment: {
+        is_share: true,
+        files: [{ url_private_download: "https://files.slack-gov.com/forwarded.png" }],
+      },
+    },
+  ])("downloads a GovSlack $label using the prepared listener client", async ({ attachment }) => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(Buffer.from("forwarded government image"), {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      }),
+    );
+
+    const result = await resolveSlackAttachmentContent({
+      attachments: [attachment],
+      client: { slackApiUrl: "https://slack-gov.com/api/" } as WebClient,
+      token: "xoxb-test-token",
+      maxBytes: 1024,
+    });
+
+    expect(result?.media).toHaveLength(1);
+    expectFetchCalledWithUrl(mockFetch, "https://files.slack-gov.com/forwarded.png");
+  });
+
+  it("rejects commercial forwarded images before sending a GovSlack bearer token", async () => {
+    mockFetch.mockResolvedValueOnce(new Response("must not fetch", { status: 200 }));
+
+    const result = await resolveSlackAttachmentContent({
+      attachments: [{ is_share: true, image_url: "https://files.slack.com/forwarded.png" }],
+      client: { slackApiUrl: "https://slack-gov.com/api/" } as WebClient,
+      token: "xoxb-test-token",
+      maxBytes: 1024,
+    });
+
+    expect(result).toBeNull();
+    expect(saveRemoteMediaMock).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 });
 

--- a/extensions/slack/src/monitor/media.ts
+++ b/extensions/slack/src/monitor/media.ts
@@ -21,10 +21,31 @@ export {
   resolveSlackThreadStarter,
 } from "./thread.js";
 
-function isSlackHostname(hostname: string): boolean {
+function isGovSlackClient(client?: SlackWebClient): boolean {
+  if (!client?.slackApiUrl) {
+    return false;
+  }
+  try {
+    const apiUrl = new URL(client.slackApiUrl);
+    return (
+      apiUrl.protocol === "https:" &&
+      !apiUrl.port &&
+      normalizeHostname(apiUrl.hostname) === "slack-gov.com"
+    );
+  } catch {
+    return false;
+  }
+}
+
+function isSlackHostname(hostname: string, govSlack: boolean): boolean {
   const normalized = normalizeHostname(hostname);
   if (!normalized) {
     return false;
+  }
+  // GovSlack is a separate compliance plane; its token must never follow
+  // commercial Slack/CDN URLs or undocumented government subdomains.
+  if (govSlack) {
+    return normalized === "files.slack-gov.com";
   }
   // Slack-hosted files typically come from *.slack.com and redirect to Slack CDN domains.
   // Include a small allowlist of known Slack domains to avoid leaking tokens if a file URL
@@ -35,7 +56,7 @@ function isSlackHostname(hostname: string): boolean {
   );
 }
 
-function assertSlackFileUrl(rawUrl: string): URL {
+function assertSlackFileUrl(rawUrl: string, govSlack: boolean): URL {
   let parsed: URL;
   try {
     parsed = new URL(rawUrl);
@@ -45,7 +66,7 @@ function assertSlackFileUrl(rawUrl: string): URL {
   if (parsed.protocol !== "https:") {
     throw new Error(`Refusing Slack file URL with non-HTTPS protocol: ${parsed.protocol}`);
   }
-  if (!isSlackHostname(parsed.hostname)) {
+  if (!isSlackHostname(parsed.hostname, govSlack)) {
     throw new Error(
       `Refusing to send Slack token to non-Slack host "${parsed.hostname}" (url: ${rawUrl})`,
     );
@@ -60,11 +81,12 @@ function createSlackAuthHeaders(token: string): HeadersInit {
 function createSlackMediaRequest(
   url: string,
   token: string,
+  govSlack: boolean,
 ): {
   url: string;
   requestInit: RequestInit;
 } {
-  const parsed = assertSlackFileUrl(url);
+  const parsed = assertSlackFileUrl(url, govSlack);
   return {
     url: parsed.href,
     // Let the shared guarded-fetch redirect logic preserve auth on same-origin
@@ -84,13 +106,13 @@ function isMockedFetch(fetchImpl: typeof fetch | undefined): boolean {
   return candidate.mock !== undefined || candidate["_isMockFunction"] === true;
 }
 
-function createSlackMediaFetch(): FetchLike {
+function createSlackMediaFetch(govSlack: boolean): FetchLike {
   return async (input, init) => {
     const url = resolveRequestUrl(input);
     if (!url) {
       throw new Error("Unsupported fetch input: expected string, URL, or Request");
     }
-    const parsed = assertSlackFileUrl(url);
+    const parsed = assertSlackFileUrl(url, govSlack);
     const fetchImpl =
       "dispatcher" in (init ?? {}) && !isMockedFetch(globalThis.fetch)
         ? fetchWithRuntimeDispatcher
@@ -102,6 +124,10 @@ function createSlackMediaFetch(): FetchLike {
 const SLACK_MEDIA_SSRF_POLICY = {
   allowedHostnames: ["*.slack.com", "*.slack-edge.com", "*.slack-files.com"],
   hostnameAllowlist: ["*.slack.com", "*.slack-edge.com", "*.slack-files.com"],
+  allowRfc2544BenchmarkRange: true,
+};
+const SLACK_GOV_MEDIA_SSRF_POLICY = {
+  hostnameAllowlist: ["files.slack-gov.com"],
   allowRfc2544BenchmarkRange: true,
 };
 export const SLACK_MEDIA_READ_IDLE_TIMEOUT_MS = 60_000;
@@ -236,9 +262,14 @@ async function downloadSlackMediaFile(params: {
   readIdleTimeoutMs?: number;
   totalTimeoutMs?: number;
   abortSignal?: AbortSignal;
+  govSlack: boolean;
 }): Promise<SlackMediaResult | null> {
-  const { url: slackUrl, requestInit } = createSlackMediaRequest(params.url, params.token);
-  const fetchImpl = createSlackMediaFetch();
+  const { url: slackUrl, requestInit } = createSlackMediaRequest(
+    params.url,
+    params.token,
+    params.govSlack,
+  );
+  const fetchImpl = createSlackMediaFetch(params.govSlack);
   const saved = await saveSlackMedia({
     options: {
       url: slackUrl,
@@ -247,7 +278,7 @@ async function downloadSlackMediaFile(params: {
       filePathHint: params.file.name,
       fallbackContentType: resolveSlackMediaMimetype(params.file, params.file.mimetype),
       maxBytes: params.maxBytes,
-      ssrfPolicy: SLACK_MEDIA_SSRF_POLICY,
+      ssrfPolicy: params.govSlack ? SLACK_GOV_MEDIA_SSRF_POLICY : SLACK_MEDIA_SSRF_POLICY,
     },
     readIdleTimeoutMs: params.readIdleTimeoutMs,
     totalTimeoutMs: params.totalTimeoutMs ?? SLACK_MEDIA_TOTAL_TIMEOUT_MS,
@@ -283,14 +314,17 @@ function isForwardedSlackAttachment(attachment: SlackAttachment): boolean {
   return attachment.is_share === true;
 }
 
-function resolveForwardedAttachmentImageUrl(attachment: SlackAttachment): string | null {
+function resolveForwardedAttachmentImageUrl(
+  attachment: SlackAttachment,
+  govSlack: boolean,
+): string | null {
   const rawUrl = attachment.image_url?.trim();
   if (!rawUrl) {
     return null;
   }
   try {
     const parsed = new URL(rawUrl);
-    if (parsed.protocol !== "https:" || !isSlackHostname(parsed.hostname)) {
+    if (parsed.protocol !== "https:" || !isSlackHostname(parsed.hostname, govSlack)) {
       return null;
     }
     return parsed.toString();
@@ -313,6 +347,7 @@ export async function resolveSlackMedia(params: {
   abortSignal?: AbortSignal;
   preloadedMedia?: ReadonlyMap<SlackFile, SlackMediaResult>;
 }): Promise<SlackMediaResult[] | null> {
+  const govSlack = isGovSlackClient(params.client);
   const files = params.files ?? [];
   const limitedFiles =
     files.length > MAX_SLACK_MEDIA_FILES ? files.slice(0, MAX_SLACK_MEDIA_FILES) : files;
@@ -339,6 +374,7 @@ export async function resolveSlackMedia(params: {
         readIdleTimeoutMs: params.readIdleTimeoutMs,
         totalTimeoutMs: params.totalTimeoutMs,
         abortSignal: params.abortSignal,
+        govSlack,
       }).catch(() => null);
       if (result || !eventUrl) {
         return result ?? pMapSkip;
@@ -356,6 +392,7 @@ export async function resolveSlackMedia(params: {
         readIdleTimeoutMs: params.readIdleTimeoutMs,
         totalTimeoutMs: params.totalTimeoutMs,
         abortSignal: params.abortSignal,
+        govSlack,
       }).catch(() => null);
       return retryResult ?? pMapSkip;
     },
@@ -389,6 +426,7 @@ export async function resolveSlackAttachmentContent(params: {
 
   const textBlocks: string[] = [];
   const allMedia: SlackMediaResult[] = [];
+  const govSlack = isGovSlackClient(params.client);
 
   for (const att of forwardedAttachments) {
     const text = att.text?.trim() || att.fallback?.trim();
@@ -398,18 +436,22 @@ export async function resolveSlackAttachmentContent(params: {
       textBlocks.push(`${heading}\n${text}`);
     }
 
-    const imageUrl = resolveForwardedAttachmentImageUrl(att);
+    const imageUrl = resolveForwardedAttachmentImageUrl(att, govSlack);
     if (imageUrl) {
       try {
-        const { url: slackUrl, requestInit } = createSlackMediaRequest(imageUrl, params.token);
-        const fetchImpl = createSlackMediaFetch();
+        const { url: slackUrl, requestInit } = createSlackMediaRequest(
+          imageUrl,
+          params.token,
+          govSlack,
+        );
+        const fetchImpl = createSlackMediaFetch(govSlack);
         const saved = await saveSlackMedia({
           options: {
             url: slackUrl,
             fetchImpl,
             requestInit,
             maxBytes: params.maxBytes,
-            ssrfPolicy: SLACK_MEDIA_SSRF_POLICY,
+            ssrfPolicy: govSlack ? SLACK_GOV_MEDIA_SSRF_POLICY : SLACK_MEDIA_SSRF_POLICY,
           },
           readIdleTimeoutMs: params.readIdleTimeoutMs,
           totalTimeoutMs: params.totalTimeoutMs ?? SLACK_MEDIA_TOTAL_TIMEOUT_MS,


### PR DESCRIPTION
## Summary

- Restore GovSlack inbound, forwarded, refreshed, and explicitly downloaded media.
- Keep government and commercial Slack credential/DNS trust planes completely isolated.

## Root cause and security ownership

The Slack media owner recognized only commercial Slack/CDN domains, so configured GovSlack clients silently dropped all authenticated attachments; the explicit download action additionally failed to forward its already prepared WebClient. The actual installed Slack WebClient preserves its trusted configured `slackApiUrl`, and the official GovSlack contract uses a separate `slack-gov.com` plane. The plugin-owned media policy now derives the trust plane once from that existing prepared client: only HTTPS `files.slack-gov.com` is allowed for the official government API, while commercial installations retain their original domains. The download action forwards its existing client; no new setting, credential, fallback, or dependency is introduced.

An initial independent audit caught a genuine RFC1918 DNS-rebinding issue: exact `allowedHostnames` bypasses private-IP checks in the shared SSRF owner. The final candidate deliberately uses the same safe hostname-allowlist policy as the existing government upload owner; real guarded-fetch mocked DNS proves private IPv4/IPv6/metadata addresses are rejected before any request.

## Actual owner proof

- Ten original source-backed failures plus three genuine guarded-fetch DNS rebinding failures became GREEN.
- Actual guarded fetch rejects `10.x`, `192.168.x`, link-local, IPv6 private/link-local, and IPv4-mapped private addresses; public addresses and intentional RFC2544 fixtures remain valid.
- Direct files, metadata refresh, malicious refreshed URLs, forwarded images/files, explicit downloads, thread/audio siblings, cross-plane redirects, lookalikes/subdomains, plaintext/ports, and trailing-dot clients are covered.
- Four focused actual Slack owner suites: **103/103 passing**.
- Fresh independent structured Sol/high security review: **no findings, confidence 0.94**.
- Production delta: **+43 lines**, necessary to own both credential-plane and DNS security boundaries.


## Exact-head configured GovSlack production-runtime proof

The actual candidate Slack plugin `createSlackBoltApp` constructed the real installed Bolt app and its real `@slack/web-api` WebClient configured with the official GovSlack API base. The official Undici `MockAgent` had `disableNetConnect()` enabled: the real SDK executed `files.info`, then the production media owner downloaded direct, refreshed, forwarded, and explicitly requested GovSlack attachments, while the commercial sibling remained functional. Cross-plane downloads and forwarded attachments were rejected in both directions; a government-to-commercial redirect, lookalike/nested/plain-HTTP hosts, malicious API configuration, and private-address DNS rebinding were blocked before credentials could cross planes. This is the actual configured plugin/SDK/guarded-fetch runtime with an in-memory official HTTP transport, not a claim of an external GovSlack account/API call.

```json
{"phase":"govslack-configured-proof-pass","pr":118695,"candidate":"fa4cae9c415f","realPluginOwner":true,"realBoltApp":true,"realWebClient":true,"officialUndiciIntercept":true,"externalRequests":0,"apiCalls":1,"mediaRequests":5,"dnsQueries":6,"crossPlaneAuthorizationAttempts":0}
```

Dependency contracts directly inspected: installed `@slack/web-api/dist/WebClient.js:123-129`, installed `@slack/bolt/dist/App.js:115-127,514-538`, and production `extensions/slack/src/monitor/provider-support.ts:323`.
