### PR TITLE
improve(ui): cut E2E shard runtime by reusing the bundle

### DIFF
--- a/config/knip.all-exports.config.ts
+++ b/config/knip.all-exports.config.ts
@@ -44,6 +44,8 @@ const ROOT_TEST_ENTRY_GLOBS = [
   "test/non-isolated-runner.ts!",
   "test/vitest/*-runtime.ts!",
   "test/vitest/vitest*.config.ts!",
+  "test/vitest/vitest*.setup.ts!",
+  "test/vitest/vitest*.global-setup.ts!",
   // Test drivers and Docker fixtures are executed by path from package scripts
   // and the test-project registry.
   "test/e2e/qa-lab/runtime/agent-bundle-mcp-tools-docker-client.ts!",

--- a/test/vitest/vitest.ui-e2e.config.ts
+++ b/test/vitest/vitest.ui-e2e.config.ts
@@ -31,12 +31,13 @@ function createUiE2eVitestConfig(
       // failure latency, not coverage.
       expect: { poll: { interval: 100, timeout: 15_000 } },
       fileParallelism: false,
+      globalSetup: ["test/vitest/vitest.ui-e2e.global-setup.ts"],
       include,
       isolate: true,
       name: "ui-e2e",
       pool: "forks",
       runner: undefined,
-      setupFiles: [],
+      setupFiles: ["test/vitest/vitest.ui-e2e.setup.ts"],
     },
   });
 }

--- a/test/vitest/vitest.ui-e2e.global-setup.ts
+++ b/test/vitest/vitest.ui-e2e.global-setup.ts
@@ -1,0 +1,28 @@
+// Vitest global setup builds and serves the shipped UI once per serial E2E shard.
+import { chromium } from "playwright";
+import type { TestProject } from "vitest/node";
+import {
+  canRunPlaywrightChromium,
+  resolvePlaywrightChromiumExecutablePath,
+  startBundledControlUiE2eServer,
+} from "../../ui/src/test-helpers/control-ui-e2e.ts";
+
+declare module "vitest" {
+  export interface ProvidedContext {
+    controlUiE2eServerBaseUrl: string | null;
+  }
+}
+
+export default async function setup(project: TestProject) {
+  const executablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+  if (!canRunPlaywrightChromium(executablePath)) {
+    project.provide("controlUiE2eServerBaseUrl", null);
+    return;
+  }
+
+  const server = await startBundledControlUiE2eServer();
+  project.provide("controlUiE2eServerBaseUrl", server.baseUrl);
+  return async () => {
+    await server.close();
+  };
+}

--- a/test/vitest/vitest.ui-e2e.global-setup.ts
+++ b/test/vitest/vitest.ui-e2e.global-setup.ts
@@ -1,7 +1,4 @@
 // Vitest global setup builds and serves the shipped UI once per serial E2E shard.
-import { mkdtemp, rm } from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
 import { chromium } from "playwright";
 import type { TestProject } from "vitest/node";
 import {
@@ -9,6 +6,7 @@ import {
   resolvePlaywrightChromiumExecutablePath,
   startBundledControlUiE2eServer,
 } from "../../ui/src/test-helpers/control-ui-e2e.ts";
+import { createTempDirTracker } from "../helpers/temp-dir.ts";
 
 declare module "vitest" {
   export interface ProvidedContext {
@@ -25,9 +23,12 @@ export default async function setup(project: TestProject) {
 
   // Local full-suite runs can fan shards into separate processes in one checkout.
   // Keep every build out of canonical dist so those processes cannot clobber it.
-  const outDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-ui-e2e-"));
+  const tempDirs = createTempDirTracker();
+  const outDir = tempDirs.make("openclaw-ui-e2e-");
   const server = await startBundledControlUiE2eServer(outDir).catch(async (error) => {
-    await rm(outDir, { force: true, recursive: true }).catch(() => {});
+    try {
+      tempDirs.cleanup();
+    } catch {}
     throw error;
   });
   try {
@@ -36,12 +37,14 @@ export default async function setup(project: TestProject) {
       try {
         await server.close();
       } finally {
-        await rm(outDir, { force: true, recursive: true });
+        tempDirs.cleanup();
       }
     };
   } catch (error) {
     await server.close().catch(() => {});
-    await rm(outDir, { force: true, recursive: true }).catch(() => {});
+    try {
+      tempDirs.cleanup();
+    } catch {}
     throw error;
   }
 }

--- a/test/vitest/vitest.ui-e2e.global-setup.ts
+++ b/test/vitest/vitest.ui-e2e.global-setup.ts
@@ -1,4 +1,7 @@
 // Vitest global setup builds and serves the shipped UI once per serial E2E shard.
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { chromium } from "playwright";
 import type { TestProject } from "vitest/node";
 import {
@@ -20,9 +23,25 @@ export default async function setup(project: TestProject) {
     return;
   }
 
-  const server = await startBundledControlUiE2eServer();
-  project.provide("controlUiE2eServerBaseUrl", server.baseUrl);
-  return async () => {
-    await server.close();
-  };
+  // Local full-suite runs can fan shards into separate processes in one checkout.
+  // Keep every build out of canonical dist so those processes cannot clobber it.
+  const outDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-ui-e2e-"));
+  const server = await startBundledControlUiE2eServer(outDir).catch(async (error) => {
+    await rm(outDir, { force: true, recursive: true }).catch(() => {});
+    throw error;
+  });
+  try {
+    project.provide("controlUiE2eServerBaseUrl", server.baseUrl);
+    return async () => {
+      try {
+        await server.close();
+      } finally {
+        await rm(outDir, { force: true, recursive: true });
+      }
+    };
+  } catch (error) {
+    await server.close().catch(() => {});
+    await rm(outDir, { force: true, recursive: true }).catch(() => {});
+    throw error;
+  }
 }

--- a/test/vitest/vitest.ui-e2e.setup.ts
+++ b/test/vitest/vitest.ui-e2e.setup.ts
@@ -1,0 +1,14 @@
+// Per-file setup leases the shard-scoped production bundle through the test helper.
+import { inject } from "vitest";
+import { setSharedControlUiE2eServerBaseUrl } from "../../ui/src/test-helpers/control-ui-e2e.ts";
+
+declare module "vitest" {
+  export interface ProvidedContext {
+    controlUiE2eServerBaseUrl: string | null;
+  }
+}
+
+const serverBaseUrl = inject("controlUiE2eServerBaseUrl");
+if (serverBaseUrl) {
+  setSharedControlUiE2eServerBaseUrl(serverBaseUrl);
+}

--- a/ui/src/e2e/appearance-settings-defaults.e2e.test.ts
+++ b/ui/src/e2e/appearance-settings-defaults.e2e.test.ts
@@ -6,6 +6,8 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { importCustomThemeFromUrl } from "../app/custom-theme.ts";
 import {
   canRunPlaywrightChromium,
+  controlUiBundledGatewayUrl,
+  controlUiBundledSettingsStorageKey,
   installMockGateway,
   resolvePlaywrightChromiumExecutablePath,
   startControlUiE2eServer,
@@ -27,10 +29,12 @@ const uiProofArtifactDir = path.join(
   "control-ui-e2e",
   "appearance-settings-defaults",
 );
-const settingsStorageKey = "openclaw.control.settings.v1:ws://127.0.0.1:18789";
-
 let browser: Browser;
 let server: ControlUiE2eServer;
+
+function settingsStorageKey(): string {
+  return controlUiBundledSettingsStorageKey(server.baseUrl);
+}
 
 function configResponse(prefs: Record<string, unknown>, hash: string) {
   const config = { ui: { prefs } };
@@ -110,7 +114,7 @@ async function readPersistedSettings(page: Page): Promise<Record<string, unknown
   return page.evaluate((key) => {
     const raw = localStorage.getItem(key);
     return raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
-  }, settingsStorageKey);
+  }, settingsStorageKey());
 }
 
 async function readThemeImportRaceState(page: Page) {
@@ -169,20 +173,23 @@ describeControlUiE2e("Control UI Appearance defaults mocked Gateway E2E", () => 
       serviceWorkers: "block",
       viewport: { height: 1000, width: 1440 },
     });
-    await context.addInitScript((key) => {
-      const seedKey = "openclaw.control-ui-e2e.appearance-defaults-seeded";
-      if (sessionStorage.getItem(seedKey) === "1") {
-        return;
-      }
-      sessionStorage.setItem(seedKey, "1");
-      localStorage.setItem(
-        key,
-        JSON.stringify({
-          gatewayUrl: "ws://127.0.0.1:18789",
-          textScale: 110,
-        }),
-      );
-    }, settingsStorageKey);
+    await context.addInitScript(
+      ({ gatewayUrl, key }) => {
+        const seedKey = "openclaw.control-ui-e2e.appearance-defaults-seeded";
+        if (sessionStorage.getItem(seedKey) === "1") {
+          return;
+        }
+        sessionStorage.setItem(seedKey, "1");
+        localStorage.setItem(
+          key,
+          JSON.stringify({
+            gatewayUrl,
+            textScale: 110,
+          }),
+        );
+      },
+      { gatewayUrl: controlUiBundledGatewayUrl(server.baseUrl), key: settingsStorageKey() },
+    );
     const page = await context.newPage();
     const initialPrefs: Record<string, unknown> = {
       chatSendShortcut: "modifier-enter",
@@ -501,17 +508,21 @@ describeControlUiE2e("Control UI Appearance defaults mocked Gateway E2E", () => 
       viewport: { height: 1000, width: 1440 },
     });
     await context.addInitScript(
-      ({ key, theme }) => {
+      ({ gatewayUrl, key, theme }) => {
         localStorage.setItem(
           key,
           JSON.stringify({
             customTheme: theme,
-            gatewayUrl: "ws://127.0.0.1:18789",
+            gatewayUrl,
             theme: "custom",
           }),
         );
       },
-      { key: settingsStorageKey, theme: existingTheme },
+      {
+        gatewayUrl: controlUiBundledGatewayUrl(server.baseUrl),
+        key: settingsStorageKey(),
+        theme: existingTheme,
+      },
     );
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {

--- a/ui/src/e2e/approval-page.e2e.test.ts
+++ b/ui/src/e2e/approval-page.e2e.test.ts
@@ -431,7 +431,7 @@ describeControlUiE2e("Control UI standalone approval page", () => {
     const appUrl = new URL(server?.baseUrl ?? "http://127.0.0.1/");
     const pageGatewayScope = `ws://${appUrl.host}`;
     const selectionKey = `openclaw.control.currentGateway.v1:${pageGatewayScope}`;
-    const pageGateway = `ws://${appUrl.hostname}:18789`;
+    const pageGateway = pageGatewayScope;
     const pageSettingsKey = `openclaw.control.settings.v1:${pageGateway}`;
     const pageSettings = JSON.stringify({
       gatewayUrl: pageGateway,

--- a/ui/src/e2e/board-mcp-app.e2e.test.ts
+++ b/ui/src/e2e/board-mcp-app.e2e.test.ts
@@ -6,6 +6,7 @@ import { createSandboxHostHttpServer } from "../../../src/gateway/mcp-app-sandbo
 import { getFreeGatewayPort } from "../../../src/gateway/test-helpers.e2e.js";
 import {
   canRunPlaywrightChromium,
+  controlUiBundledSettingsStorageKey,
   installMockGateway,
   resolvePlaywrightChromiumExecutablePath,
   startControlUiE2eServer,
@@ -49,15 +50,18 @@ function boardSnapshot(count: number) {
 }
 
 async function openDashboard(page: Page): Promise<void> {
-  await page.addInitScript((key) => {
-    const settingsKey = "openclaw.control.settings.v1:ws://127.0.0.1:18789";
-    const settings = JSON.parse(localStorage.getItem(settingsKey) ?? "{}") as Record<
-      string,
-      unknown
-    >;
-    settings.boardSessionViews = { [key]: { activeTabId: "main" } };
-    localStorage.setItem(settingsKey, JSON.stringify(settings));
-  }, sessionKey);
+  const settingsKey = controlUiBundledSettingsStorageKey(controlUi.baseUrl);
+  await page.addInitScript(
+    ({ key, storageKey }) => {
+      const settings = JSON.parse(localStorage.getItem(storageKey) ?? "{}") as Record<
+        string,
+        unknown
+      >;
+      settings.boardSessionViews = { [key]: { activeTabId: "main" } };
+      localStorage.setItem(storageKey, JSON.stringify(settings));
+    },
+    { key: sessionKey, storageKey: settingsKey },
+  );
   await page.goto(`${controlUi.baseUrl}dashboard`);
   await page.locator(".board-session-surface").waitFor();
 }

--- a/ui/src/e2e/chat-flow.navigation-presentation.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.navigation-presentation.e2e.test.ts
@@ -1,4 +1,5 @@
 import { expect, it } from "vitest";
+import { controlUiBundledSettingsStorageKey } from "../test-helpers/control-ui-e2e.ts";
 import {
   SESSION_DRAG_MIME,
   captureSessionAccessibilityProof,
@@ -22,9 +23,9 @@ suite.define(() => {
       serviceWorkers: "block",
       viewport: { height: 900, width: 1440 },
     });
-    await context.addInitScript(() => {
+    await context.addInitScript((settingsKey) => {
       localStorage.setItem(
-        "openclaw.control.settings.v1:ws://127.0.0.1:18789",
+        settingsKey,
         JSON.stringify({
           chatSplitLayout: {
             activePaneId: "p1",
@@ -44,7 +45,7 @@ suite.define(() => {
           },
         }),
       );
-    });
+    }, controlUiBundledSettingsStorageKey(suite.server.baseUrl));
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       deferredMethods: ["chat.startup", "chat.startup"],

--- a/ui/src/e2e/initial-connect-splash.e2e.test.ts
+++ b/ui/src/e2e/initial-connect-splash.e2e.test.ts
@@ -52,7 +52,7 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
         `Playwright Chromium is not installed or cannot start at ${chromiumExecutablePath}.`,
       );
     }
-    server = await startControlUiE2eServer();
+    server = await startControlUiE2eServer(undefined, { source: true });
     browser = await chromium.launch({ executablePath: chromiumExecutablePath });
   });
 

--- a/ui/src/e2e/locale-offline-retry.e2e.test.ts
+++ b/ui/src/e2e/locale-offline-retry.e2e.test.ts
@@ -62,7 +62,7 @@ describeControlUiE2e("Control UI offline locale retry", () => {
         `Playwright Chromium is not available at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
       );
     }
-    server = await startControlUiE2eServer();
+    server = await startControlUiE2eServer(undefined, { source: true });
     browser = await chromium.launch({ executablePath: chromiumExecutablePath });
   });
 

--- a/ui/src/e2e/logs-layout.e2e.test.ts
+++ b/ui/src/e2e/logs-layout.e2e.test.ts
@@ -4,6 +4,7 @@ import { chromium, type Browser } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   canRunPlaywrightChromium,
+  controlUiBundledSettingsStorageKey,
   installMockGateway,
   resolvePlaywrightChromiumExecutablePath,
   startControlUiE2eServer,
@@ -58,11 +59,8 @@ describeControlUiE2e("Control UI logs native app layout E2E", () => {
         : {}),
     });
     const page = await context.newPage();
-    await page.addInitScript(() => {
-      localStorage.setItem(
-        "openclaw.control.settings.v1:ws://127.0.0.1:18789",
-        JSON.stringify({ textScale: 125, themeMode: "dark" }),
-      );
+    await page.addInitScript((settingsKey) => {
+      localStorage.setItem(settingsKey, JSON.stringify({ textScale: 125, themeMode: "dark" }));
       const nativeWindow = window as Window & {
         __OPENCLAW_NATIVE_WEB_CHROME__?: boolean;
         __OPENCLAW_NATIVE_HISTORY__?: { canGoBack: boolean; canGoForward: boolean };
@@ -82,7 +80,7 @@ describeControlUiE2e("Control UI logs native app layout E2E", () => {
       } else {
         document.addEventListener("DOMContentLoaded", stamp);
       }
-    });
+    }, controlUiBundledSettingsStorageKey(server.baseUrl));
     await installMockGateway(page, {
       methodResponses: {
         "logs.tail": {

--- a/ui/src/e2e/mcp-app-conformance.e2e.test.ts
+++ b/ui/src/e2e/mcp-app-conformance.e2e.test.ts
@@ -421,7 +421,7 @@ describeConformance("MCP App Control UI and standalone host conformance", () => 
     const configPath = path.join(stateDir, "openclaw.json");
     const fixturePath = path.join(tempRoot, "fixture-server.mjs");
     await fs.mkdir(path.join(tempRoot, "empty-plugins"), { recursive: true });
-    controlUiServer = await startControlUiE2eServer();
+    controlUiServer = await startControlUiE2eServer(undefined, { source: true });
     const appEntryPath = require.resolve("@modelcontextprotocol/ext-apps/app-with-deps");
     const appModuleSource = await fs.readFile(appEntryPath, "utf8");
     const appAssetPort = await getFreeGatewayPort();

--- a/ui/src/e2e/mount-recovery.e2e.test.ts
+++ b/ui/src/e2e/mount-recovery.e2e.test.ts
@@ -22,7 +22,7 @@ describeControlUiE2e("Control UI mount recovery E2E", () => {
     if (!chromiumAvailable) {
       throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
     }
-    server = await startControlUiE2eServer();
+    server = await startControlUiE2eServer(undefined, { source: true });
     browser = await chromium.launch({ executablePath: chromiumExecutablePath });
   });
 

--- a/ui/src/e2e/session-dashboard.e2e.test.ts
+++ b/ui/src/e2e/session-dashboard.e2e.test.ts
@@ -9,6 +9,7 @@ import { SANDBOX_HOST_PATH } from "../../../src/agents/sandbox-host.js";
 import { createSandboxHostHttpServer } from "../../../src/gateway/mcp-app-sandbox-http.js";
 import {
   canRunPlaywrightChromium,
+  controlUiBundledSettingsStorageKey,
   installMockGateway,
   resolvePlaywrightChromiumExecutablePath,
   startControlUiE2eServer,
@@ -139,26 +140,29 @@ const pluginWidgetBoardSnapshot = {
 };
 
 async function showDashboard(page: Page): Promise<void> {
-  await page.addInitScript((key) => {
-    const settingsKey = "openclaw.control.settings.v1:ws://127.0.0.1:18789";
-    const settings = JSON.parse(localStorage.getItem(settingsKey) ?? "{}") as Record<
-      string,
-      unknown
-    >;
-    const boardSessionViews =
-      settings.boardSessionViews && typeof settings.boardSessionViews === "object"
-        ? (settings.boardSessionViews as Record<string, unknown>)
-        : {};
-    const savedView = boardSessionViews[key];
-    settings.boardSessionViews = {
-      ...boardSessionViews,
-      [key]: {
-        activeTabId: "main",
-        ...(savedView && typeof savedView === "object" ? savedView : {}),
-      },
-    };
-    localStorage.setItem(settingsKey, JSON.stringify(settings));
-  }, sessionKey);
+  const settingsKey = controlUiBundledSettingsStorageKey(server.baseUrl);
+  await page.addInitScript(
+    ({ key, storageKey }) => {
+      const settings = JSON.parse(localStorage.getItem(storageKey) ?? "{}") as Record<
+        string,
+        unknown
+      >;
+      const boardSessionViews =
+        settings.boardSessionViews && typeof settings.boardSessionViews === "object"
+          ? (settings.boardSessionViews as Record<string, unknown>)
+          : {};
+      const savedView = boardSessionViews[key];
+      settings.boardSessionViews = {
+        ...boardSessionViews,
+        [key]: {
+          activeTabId: "main",
+          ...(savedView && typeof savedView === "object" ? savedView : {}),
+        },
+      };
+      localStorage.setItem(storageKey, JSON.stringify(settings));
+    },
+    { key: sessionKey, storageKey: settingsKey },
+  );
 }
 
 function workboardConfigSnapshot(enabled = true) {

--- a/ui/src/e2e/terminal-runtime.e2e.test.ts
+++ b/ui/src/e2e/terminal-runtime.e2e.test.ts
@@ -39,7 +39,7 @@ describeControlUiE2e("Control UI terminal runtime isolation", () => {
         `Playwright Chromium is not installed or cannot start at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
       );
     }
-    server = await startControlUiE2eServer();
+    server = await startControlUiE2eServer(undefined, { source: true });
     browser = await chromium.launch({ executablePath: chromiumExecutablePath });
   });
 

--- a/ui/src/e2e/theme-muted-contrast.e2e.test.ts
+++ b/ui/src/e2e/theme-muted-contrast.e2e.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
-import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { controlUiBundledGatewayUrl, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
@@ -142,14 +142,17 @@ suite.define(() => {
       });
       const initialFamily = family === "claw" ? "knot" : "claw";
       await context.addInitScript(
-        ({ initialMode, initialTheme }) => {
-          const gatewayUrl = "ws://127.0.0.1:18789";
+        ({ gatewayUrl, initialMode, initialTheme }) => {
           localStorage.setItem(
             `openclaw.control.settings.v1:${gatewayUrl}`,
             JSON.stringify({ gatewayUrl, theme: initialTheme, themeMode: initialMode }),
           );
         },
-        { initialMode: mode, initialTheme: initialFamily },
+        {
+          gatewayUrl: controlUiBundledGatewayUrl(suite.server.baseUrl),
+          initialMode: mode,
+          initialTheme: initialFamily,
+        },
       );
 
       const page = await context.newPage();

--- a/ui/src/e2e/theme-muted-contrast.e2e.test.ts
+++ b/ui/src/e2e/theme-muted-contrast.e2e.test.ts
@@ -53,9 +53,12 @@ type RenderedColor = {
 
 function parseRenderedColor(color: string): RenderedColor {
   const trimmed = color.trim();
-  const hex = /^#([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/iu.exec(trimmed);
+  const shortHex = /^#([a-f\d])([a-f\d])([a-f\d])$/iu.exec(trimmed);
+  const hex = shortHex ?? /^#([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/iu.exec(trimmed);
   if (hex) {
-    const channels = hex.slice(1).map((channel) => Number.parseInt(channel, 16));
+    const channels = hex
+      .slice(1)
+      .map((channel) => Number.parseInt(shortHex ? channel.repeat(2) : channel, 16));
     const [red, green, blue] = channels;
     if (red !== undefined && green !== undefined && blue !== undefined) {
       return { alpha: 1, blue, green, red };
@@ -81,7 +84,7 @@ function parseRenderedColor(color: string): RenderedColor {
     }
   }
 
-  throw new Error(`Expected a browser-rendered RGB or six-digit theme color, received ${color}`);
+  throw new Error(`Expected a browser-rendered RGB or theme hex color, received ${color}`);
 }
 
 function compositeColor(foreground: RenderedColor, background: RenderedColor): RenderedColor {

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -7,7 +7,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { buildControlUiSessionPath } from "@openclaw/session-url-contract";
 import type { Locator, Page } from "playwright";
-import type { ViteDevServer } from "vite";
+import type { Plugin, PreviewServer, ViteDevServer } from "vite";
 import { PROTOCOL_VERSION } from "../../../packages/gateway-protocol/src/version.js";
 import { CONTROL_UI_BOOTSTRAP_CONFIG_PATH } from "../../../src/gateway/control-ui-contract.js";
 import type { ControlUiBuildInfo } from "../build-info.ts";
@@ -248,6 +248,27 @@ export type ControlUiE2eServer = {
   close: () => Promise<void>;
 };
 
+type ControlUiE2eServerOptions = {
+  source?: boolean;
+};
+
+const DEFAULT_CONTROL_UI_E2E_BUILD_INFO: ControlUiBuildInfo = {
+  version: "2026.7.10",
+  commit: "0123456789abcdef0123456789abcdef01234567",
+  commitAt: "2026-07-10T11:22:33.000Z",
+  builtAt: "2026-07-10T12:34:56.000Z",
+  branch: null,
+  dirty: false,
+  release: false,
+  buildId: "e2e",
+};
+
+let sharedControlUiE2eServerBaseUrl: string | null = null;
+
+export function setSharedControlUiE2eServerBaseUrl(baseUrl: string | null): void {
+  sharedControlUiE2eServerBaseUrl = baseUrl;
+}
+
 export type MockGatewayControls = {
   closeLatest: (code?: number, reason?: string) => Promise<void>;
   deliverLatest: (frame: unknown) => Promise<void>;
@@ -322,17 +343,22 @@ export async function pauseVirtualClock(page: Page): Promise<void> {
 }
 
 export async function startControlUiE2eServer(
-  buildInfo: ControlUiBuildInfo = {
-    version: "2026.7.10",
-    commit: "0123456789abcdef0123456789abcdef01234567",
-    commitAt: "2026-07-10T11:22:33.000Z",
-    builtAt: "2026-07-10T12:34:56.000Z",
-    branch: null,
-    dirty: false,
-    release: false,
-    buildId: "e2e",
-  },
+  buildInfo?: ControlUiBuildInfo,
+  options: ControlUiE2eServerOptions = {},
 ): Promise<ControlUiE2eServer> {
+  // Ordinary E2E files exercise the shipped bundle. Source-module and custom
+  // build-info tests retain a private Vite server through the same lease API.
+  if (
+    sharedControlUiE2eServerBaseUrl !== null &&
+    buildInfo === undefined &&
+    options.source !== true
+  ) {
+    return {
+      baseUrl: sharedControlUiE2eServerBaseUrl,
+      close: async () => {},
+    };
+  }
+  const resolvedBuildInfo = buildInfo ?? DEFAULT_CONTROL_UI_E2E_BUILD_INFO;
   // Shared browser fixtures import this helper; load filesystem-bound Vite
   // configuration only when its Node-owned development server actually starts.
   const [
@@ -358,7 +384,7 @@ export async function startControlUiE2eServer(
     clearScreen: false,
     configFile: false,
     define: {
-      "globalThis.OPENCLAW_CONTROL_UI_BUILD_INFO": JSON.stringify(buildInfo),
+      "globalThis.OPENCLAW_CONTROL_UI_BUILD_INFO": JSON.stringify(resolvedBuildInfo),
     },
     logLevel: "error",
     optimizeDeps: {
@@ -393,6 +419,66 @@ export async function startControlUiE2eServer(
   };
 }
 
+function controlUiE2ePreviewConfigPlugin(): Plugin {
+  return {
+    name: "control-ui-e2e-preview-config",
+    configurePreviewServer(server) {
+      server.middlewares.use(CONTROL_UI_BOOTSTRAP_CONFIG_PATH, (_req, res) => {
+        res.setHeader("Content-Type", "application/json");
+        res.end(
+          JSON.stringify({
+            basePath: "/",
+            assistantName: "",
+            assistantAvatar: "",
+          }),
+        );
+      });
+    },
+  };
+}
+
+export async function startBundledControlUiE2eServer(): Promise<ControlUiE2eServer> {
+  const [{ build, preview }, { default: controlUiViteConfig }] = await Promise.all([
+    import("vite"),
+    import("../../vite.config.ts"),
+  ]);
+  const port = await resolveAvailableLoopbackPort();
+  const config = controlUiViteConfig();
+  const uiRoot = path.join(resolveRepoRoot(), "ui");
+  const sharedConfig = {
+    ...config,
+    base: "/",
+    configFile: false,
+    define: {
+      ...config.define,
+      "globalThis.OPENCLAW_CONTROL_UI_BUILD_INFO": JSON.stringify(
+        DEFAULT_CONTROL_UI_E2E_BUILD_INFO,
+      ),
+    },
+    logLevel: "error" as const,
+    root: uiRoot,
+  };
+  await build(sharedConfig);
+  const server = await preview({
+    ...sharedConfig,
+    plugins: [...(sharedConfig.plugins ?? []), controlUiE2ePreviewConfigPlugin()],
+    preview: {
+      host: "127.0.0.1",
+      port,
+      strictPort: true,
+    },
+  });
+  try {
+    return {
+      baseUrl: resolveServerBaseUrl(server),
+      close: () => server.close(),
+    };
+  } catch (error) {
+    await server.close().catch(() => {});
+    throw error;
+  }
+}
+
 async function resolveAvailableLoopbackPort(): Promise<number> {
   return new Promise((resolve, reject) => {
     const probe = createNetServer();
@@ -414,7 +500,7 @@ async function resolveAvailableLoopbackPort(): Promise<number> {
   });
 }
 
-function resolveServerBaseUrl(server: ViteDevServer): string {
+function resolveServerBaseUrl(server: ViteDevServer | PreviewServer): string {
   const address = server.httpServer?.address();
   if (!address || typeof address === "string") {
     throw new Error("Control UI E2E server did not expose a TCP port");

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -7,7 +7,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { buildControlUiSessionPath } from "@openclaw/session-url-contract";
 import type { Locator, Page } from "playwright";
-import type { Plugin, PreviewServer, ViteDevServer } from "vite";
+import type { InlineConfig, Plugin, PreviewServer, ViteDevServer } from "vite";
 import { PROTOCOL_VERSION } from "../../../packages/gateway-protocol/src/version.js";
 import { CONTROL_UI_BOOTSTRAP_CONFIG_PATH } from "../../../src/gateway/control-ui-contract.js";
 import type { ControlUiBuildInfo } from "../build-info.ts";
@@ -443,15 +443,11 @@ export async function startBundledControlUiE2eServer(outDir: string): Promise<Co
     import("../../vite.config.ts"),
   ]);
   const port = await resolveAvailableLoopbackPort();
-  const config = controlUiViteConfig();
+  const config = controlUiViteConfig({ outDir });
   const uiRoot = path.join(resolveRepoRoot(), "ui");
-  const sharedConfig = {
+  const sharedConfig: InlineConfig = {
     ...config,
     base: "/",
-    build: {
-      ...config.build,
-      outDir,
-    },
     configFile: false,
     define: {
       ...config.define,

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -437,7 +437,7 @@ function controlUiE2ePreviewConfigPlugin(): Plugin {
   };
 }
 
-export async function startBundledControlUiE2eServer(): Promise<ControlUiE2eServer> {
+export async function startBundledControlUiE2eServer(outDir: string): Promise<ControlUiE2eServer> {
   const [{ build, preview }, { default: controlUiViteConfig }] = await Promise.all([
     import("vite"),
     import("../../vite.config.ts"),
@@ -448,6 +448,10 @@ export async function startBundledControlUiE2eServer(): Promise<ControlUiE2eServ
   const sharedConfig = {
     ...config,
     base: "/",
+    build: {
+      ...config.build,
+      outDir,
+    },
     configFile: false,
     define: {
       ...config.define,

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -31,6 +31,16 @@ export function controlUiSessionUrl(baseUrl: string, sessionKey: string): string
   return url.toString();
 }
 
+export function controlUiBundledGatewayUrl(baseUrl: string): string {
+  const url = new URL(baseUrl);
+  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+  return url.origin;
+}
+
+export function controlUiBundledSettingsStorageKey(baseUrl: string): string {
+  return `openclaw.control.settings.v1:${controlUiBundledGatewayUrl(baseUrl)}`;
+}
+
 type ControlUiRouteTarget = {
   hash?: string;
   pathname?: string;

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -383,12 +383,12 @@ export function controlUiBrowserOnlySharedModuleAliases(): Plugin {
   };
 }
 
-function controlUiServiceWorkerBuildIdPlugin(buildId: string): Plugin {
+function controlUiServiceWorkerBuildIdPlugin(buildId: string, buildOutDir: string): Plugin {
   return {
     name: "control-ui-service-worker-build-id",
     apply: "build",
     closeBundle() {
-      const swPath = path.join(outDir, "sw.js");
+      const swPath = path.join(buildOutDir, "sw.js");
       const publicSwPath = path.join(here, "public/sw.js");
       const source = fs.readFileSync(publicSwPath, "utf8");
       const placeholder = '"__OPENCLAW_CONTROL_UI_BUILD_ID__"';
@@ -396,13 +396,13 @@ function controlUiServiceWorkerBuildIdPlugin(buildId: string): Plugin {
       if (updated === source) {
         throw new Error(`Control UI service worker build id placeholder missing in ${swPath}`);
       }
-      fs.mkdirSync(outDir, { recursive: true });
+      fs.mkdirSync(buildOutDir, { recursive: true });
       fs.writeFileSync(swPath, updated);
     },
   };
 }
 
-function controlUiPrecompressedAssetsPlugin(): Plugin {
+function controlUiPrecompressedAssetsPlugin(buildOutDir: string): Plugin {
   return {
     name: "control-ui-precompressed-assets",
     apply: "build",
@@ -411,21 +411,22 @@ function controlUiPrecompressedAssetsPlugin(): Plugin {
         // Vite's post-build import analysis rewrites lazy preload markers in a
         // later generateBundle hook. Read from disk here so sidecars always
         // encode the exact final bytes that the identity response serves.
-        const source = fs.readFileSync(path.join(outDir, output.fileName));
+        const source = fs.readFileSync(path.join(buildOutDir, output.fileName));
         for (const variant of createControlUiPrecompressedAssetVariants(output.fileName, source)) {
-          fs.writeFileSync(path.join(outDir, variant.fileName), variant.source);
+          fs.writeFileSync(path.join(buildOutDir, variant.fileName), variant.source);
         }
       }
     },
   };
 }
 
-export default function controlUiViteConfig(): UserConfig {
+export default function controlUiViteConfig(options: { outDir?: string } = {}): UserConfig {
   const envBase = process.env.OPENCLAW_CONTROL_UI_BASE_PATH?.trim();
   const base = envBase ? normalizeBase(envBase) : "./";
   const bootstrapConfigPath =
     base === "./" ? "/control-ui-config.json" : `${base}control-ui-config.json`;
   const buildInfo = resolveControlUiBuildInfo();
+  const buildOutDir = options.outDir ?? outDir;
   return {
     base,
     define: {
@@ -449,7 +450,7 @@ export default function controlUiViteConfig(): UserConfig {
       ],
     },
     build: {
-      outDir,
+      outDir: buildOutDir,
       emptyOutDir: true,
       sourcemap: true,
       rolldownOptions: {
@@ -472,8 +473,8 @@ export default function controlUiViteConfig(): UserConfig {
     plugins: [
       controlUiLocaleModulesPlugin(),
       controlUiBrowserOnlySharedModuleAliases(),
-      controlUiPrecompressedAssetsPlugin(),
-      controlUiServiceWorkerBuildIdPlugin(buildInfo.buildId),
+      controlUiPrecompressedAssetsPlugin(buildOutDir),
+      controlUiServiceWorkerBuildIdPlugin(buildInfo.buildId, buildOutDir),
       {
         name: "control-ui-dev-stubs",
         configureServer(server) {


### PR DESCRIPTION
## What Problem This Solves

Control UI E2E shards repeatedly started and transformed the same Vite development app for every test file. On the measured shard, that duplicated setup dominated the run: 35 files and 139 tests took 358.21 seconds even though each file still needed only fresh browser and Gateway state.

## Why This Change Was Made

Build and serve the production Control UI bundle once per serial Vitest shard, while preserving fresh browsers, contexts, pages, mock Gateways, file isolation, sharding, workers, concurrency, and timeouts. The three suites that inspect or intercept source modules keep private Vite development servers, and custom build-info tests automatically bypass the shared bundle.

## User Impact

No product behavior changes. Maintainers get materially faster Control UI E2E feedback without removing tests or weakening assertions.

## Evidence

- Direct AWS Crabbox `c7a.8xlarge`, exact same lease and shard 1: 358.21s baseline -> 189.59s candidate, saving 168.62s (47.1%). All 35 files and 139 tests passed.
- Post-rebase focused proof: 5 files and 15 tests passed, covering the bundled path, source-module recovery/interception, custom build info, MCP conformance, and minified theme colors.
- Shard 2 broad rerun: 32/35 files and 100/103 tests passed in 178.37s; the only three failures occurred before app assertions because the reused runner no longer had Playwright's ffmpeg helper. The affected source-interception suite passed all 5 tests, and an earlier targeted AWS rerun passed the same 5/5.
- `oxfmt --check`, direct Oxlint, and `git diff --check` passed.
- Autoreview (Codex, GPT-5.6 Sol, high): no accepted/actionable findings.
