### PR TITLE
fix(plugins): enforce configured bundled-plugin execution policy

### DIFF
--- a/src/config/channel-configured-shared.ts
+++ b/src/config/channel-configured-shared.ts
@@ -1,7 +1,7 @@
 // Shares channel-configured checks across config and runtime surfaces.
 import { getChannelEnvVars } from "../secrets/channel-env-vars.js";
 import { isRecord } from "../utils.js";
-import type { OpenClawConfig } from "./config.js";
+import type { OpenClawConfig } from "./types.openclaw.js";
 
 /** Returns a channel config object when `channels.<id>` is present and object-shaped. */
 export function resolveChannelConfigRecord(

--- a/src/plugins/bundled-capability-runtime.test.ts
+++ b/src/plugins/bundled-capability-runtime.test.ts
@@ -167,6 +167,35 @@ describe("loadBundledCapabilityRuntimeRegistry", () => {
     expect(listImportedRuntimePluginIds()).toContain(target.id);
   });
 
+  it.each([
+    {
+      name: "explicitly disabled",
+      plugins: { entries: { "blocked-capability": { enabled: false } } },
+    },
+    { name: "denylisted", plugins: { deny: ["blocked-capability"] } },
+    { name: "outside the restrictive allowlist", plugins: { allow: ["allowed-capability"] } },
+    { name: "blocked by global plugin disablement", plugins: { enabled: false } },
+  ])("never imports a $name plugin through bundled capability capture", ({ plugins }) => {
+    const blocked = writePlugin({
+      id: "blocked-capability",
+      body: `module.exports = {
+        id: "blocked-capability",
+        register(api) {
+          api.registerProvider({ id: "blocked-capability", label: "Blocked", auth: [] });
+        },
+      };`,
+    });
+
+    const registry = loadBundledCapabilityRuntimeRegistry({
+      pluginIds: [blocked.id],
+      config: { plugins },
+      discovery: discoveryFor(blocked),
+    });
+
+    expect(registry.providers).toEqual([]);
+    expect(listImportedRuntimePluginIds()).not.toContain(blocked.id);
+  });
+
   it.each(["source", "built"] as const)(
     "keeps %s-first artifact preferences isolated across registry snapshots",
     (firstArtifact) => {

--- a/src/plugins/bundled-capability-runtime.ts
+++ b/src/plugins/bundled-capability-runtime.ts
@@ -48,9 +48,14 @@ function buildVitestCapabilityShimAliasMap(): Record<string, string> {
 function buildBundledCapabilityRuntimeConfig(
   pluginIds: readonly string[],
   env?: PluginLoadOptions["env"],
+  config?: PluginLoadOptions["config"],
 ): NonNullable<PluginLoadOptions["config"]> {
+  // Only the speech owner may opt into legacy global-disable compatibility before capture.
+  if (config?.plugins?.enabled === false) {
+    return config;
+  }
   const enablementCompat = withBundledPluginEnablementCompat({
-    config: undefined,
+    config,
     pluginIds,
   });
   return (
@@ -81,11 +86,12 @@ function createCapabilityRegistrationRuntime(
 export function loadBundledCapabilityRuntimeRegistry(params: {
   pluginIds: readonly string[];
   env?: PluginLoadOptions["env"];
+  config?: PluginLoadOptions["config"];
   pluginSdkResolution?: PluginSdkResolutionPreference;
   discovery?: PluginDiscoveryResult;
 }) {
   const env = params.env ?? process.env;
-  const config = buildBundledCapabilityRuntimeConfig(params.pluginIds, env);
+  const config = buildBundledCapabilityRuntimeConfig(params.pluginIds, env, params.config);
   const discovery = params.discovery ?? discoverOpenClawPlugins({ env });
   const pluginIds = new Set(params.pluginIds);
   const manifestRegistry = loadPluginManifestRegistry({

--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -43,6 +43,11 @@ const mocks = vi.hoisted(() => ({
   })),
   withBundledPluginEnablementCompat: vi.fn(({ config }) => config),
   withBundledPluginVitestCompat: vi.fn(({ config }) => config),
+  readBundledDiscoveryMode: vi.fn<() => "compat" | "allowlist" | undefined>(() => "allowlist"),
+}));
+
+vi.mock("./bundled-discovery-state.js", () => ({
+  readBundledDiscoveryMode: mocks.readBundledDiscoveryMode,
 }));
 
 vi.mock("./loader.js", () => ({
@@ -294,6 +299,7 @@ function expectBundledCompatLoadPath(params: {
 }
 
 function createCompatChainConfig() {
+  mocks.readBundledDiscoveryMode.mockReturnValue("compat");
   const cfg = { plugins: { allow: ["custom-plugin"] } } as OpenClawConfig;
   const enablementCompat = {
     plugins: {
@@ -386,6 +392,8 @@ describe("resolvePluginCapabilityProviders", () => {
     mocks.withBundledPluginEnablementCompat.mockImplementation(({ config }) => config);
     mocks.withBundledPluginVitestCompat.mockReset();
     mocks.withBundledPluginVitestCompat.mockImplementation(({ config }) => config);
+    mocks.readBundledDiscoveryMode.mockReset();
+    mocks.readBundledDiscoveryMode.mockReturnValue("allowlist");
   });
 
   afterEach(() => {
@@ -500,6 +508,163 @@ describe("resolvePluginCapabilityProviders", () => {
     expect(mocks.loadPluginManifestRegistry).not.toHaveBeenCalled();
   });
 
+  it.each([
+    {
+      name: "explicitly disabled",
+      plugins: { entries: { blocked: { enabled: false } } },
+    },
+    { name: "denylisted", plugins: { deny: ["blocked"] } },
+    { name: "outside the restrictive allowlist", plugins: { allow: ["allowed"] } },
+  ])("never prepares or executes a $name bundled capability provider", ({ plugins }) => {
+    const generateImage = vi.fn();
+    const registry = createEmptyPluginRegistry();
+    addCapabilityProvider(registry, "imageGenerationProviders", {
+      id: "blocked",
+      provider: { generateImage },
+    });
+    const prepared = prepareMediaCapabilityProviders({
+      cfg: { plugins } as OpenClawConfig,
+      registry,
+      pluginMetadataSnapshot: {
+        index: { plugins: [{ pluginId: "blocked", origin: "bundled", enabled: false }] },
+        plugins: [
+          {
+            id: "blocked",
+            origin: "bundled",
+            contracts: { imageGenerationProviders: ["blocked"] },
+          },
+        ],
+      } as never,
+    });
+
+    for (const provider of prepared.imageGenerationProviders ?? []) {
+      (provider as unknown as { generateImage: () => void }).generateImage();
+    }
+
+    expect(generateImage).not.toHaveBeenCalled();
+    expect(prepared.imageGenerationProviders).toEqual([]);
+  });
+
+  it.each([
+    {
+      name: "explicitly disabled",
+      plugins: { entries: { blocked: { enabled: false } } },
+    },
+    { name: "denylisted", plugins: { deny: ["blocked"] } },
+    { name: "outside the restrictive allowlist", plugins: { allow: ["allowed"] } },
+  ])("never selects an already-active $name bundled provider", ({ plugins }) => {
+    const active = createEmptyPluginRegistry();
+    addCapabilityProvider(active, "imageGenerationProviders", { id: "blocked" });
+    addSpeechProvider(active, "blocked");
+    mocks.resolveRuntimePluginRegistry.mockImplementation((params?: unknown) =>
+      params === undefined ? active : createEmptyPluginRegistry(),
+    );
+    setCapabilityManifestPlugins([
+      {
+        id: "blocked",
+        contracts: {
+          imageGenerationProviders: ["blocked"],
+          speechProviders: ["blocked"],
+        },
+      },
+    ]);
+    const cfg = { plugins } as OpenClawConfig;
+
+    expect(
+      resolvePluginCapabilityProvider({
+        key: "imageGenerationProviders",
+        providerId: "blocked",
+        cfg,
+      }),
+    ).toBeUndefined();
+    expect(resolvePluginCapabilityProviders({ key: "imageGenerationProviders", cfg })).toEqual([]);
+    expect(
+      resolvePluginCapabilityProvider({ key: "speechProviders", providerId: "blocked", cfg }),
+    ).toBeUndefined();
+    expect(resolvePluginCapabilityProviders({ key: "speechProviders", cfg })).toEqual([]);
+    expect(mocks.loadBundledCapabilityRuntimeRegistry).not.toHaveBeenCalled();
+  });
+
+  it("preserves restrictive-allowlist compatibility only for known bundled active owners", () => {
+    mocks.readBundledDiscoveryMode.mockReturnValue("compat");
+    const active = createEmptyPluginRegistry();
+    active.plugins.push({ id: "bundled-owner", origin: "bundled" } as never);
+    addSpeechProvider(active, "bundled-provider", { pluginId: "bundled-owner" });
+    addSpeechProvider(active, "unknown-provider", { pluginId: "unknown-owner" });
+    mocks.resolveRuntimePluginRegistry.mockImplementation((params?: unknown) =>
+      params === undefined ? active : createEmptyPluginRegistry(),
+    );
+    const cfg = { plugins: { allow: ["allowed-plugin"] } } as OpenClawConfig;
+
+    expect(
+      resolvePluginCapabilityProvider({
+        key: "speechProviders",
+        providerId: "bundled-provider",
+        cfg,
+      })?.id,
+    ).toBe("bundled-provider");
+    expect(
+      resolvePluginCapabilityProvider({
+        key: "speechProviders",
+        providerId: "unknown-provider",
+        cfg,
+      }),
+    ).toBeUndefined();
+    expect(resolvePluginCapabilityProviders({ key: "speechProviders", cfg })).toEqual([
+      expect.objectContaining({ id: "bundled-provider" }),
+    ]);
+    expect(mocks.readBundledDiscoveryMode).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([{ entries: { blocked: { enabled: false } } }, { deny: ["blocked"] }])(
+    "never lets global-disable speech compatibility override owner prohibition",
+    (plugins) => {
+      const active = createEmptyPluginRegistry();
+      addSpeechProvider(active, "blocked");
+      mocks.resolveRuntimePluginRegistry.mockImplementation((params?: unknown) =>
+        params === undefined ? active : createEmptyPluginRegistry(),
+      );
+      setCapabilityManifestPlugins([
+        { id: "blocked", contracts: { speechProviders: ["blocked"] } },
+      ]);
+      const cfg = { plugins: { enabled: false, ...plugins } } as OpenClawConfig;
+
+      expect(
+        resolvePluginCapabilityProvider({ key: "speechProviders", providerId: "blocked", cfg }),
+      ).toBeUndefined();
+      expect(resolvePluginCapabilityProviders({ key: "speechProviders", cfg })).toEqual([]);
+      expect(mocks.loadBundledCapabilityRuntimeRegistry).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    {
+      name: "explicitly disabled",
+      plugins: { entries: { blocked: { enabled: false } } },
+    },
+    { name: "denylisted", plugins: { deny: ["blocked"] } },
+    { name: "outside the restrictive allowlist", plugins: { allow: ["allowed"] } },
+  ])(
+    "never re-imports a $name bundled provider through cold compatibility capture",
+    ({ plugins }) => {
+      const captured = createEmptyPluginRegistry();
+      addCapabilityProvider(captured, "imageGenerationProviders", { id: "blocked" });
+      mocks.resolveRuntimePluginRegistry.mockReturnValue(createEmptyPluginRegistry());
+      mocks.loadBundledCapabilityRuntimeRegistry.mockReturnValue(captured);
+      setCapabilityManifestPlugins([
+        { id: "blocked", contracts: { imageGenerationProviders: ["blocked"] } },
+      ]);
+
+      expect(
+        resolvePluginCapabilityProviders({
+          key: "imageGenerationProviders",
+          cfg: { plugins } as OpenClawConfig,
+        }),
+      ).toEqual([]);
+      expect(mocks.loadBundledCapabilityRuntimeRegistry).not.toHaveBeenCalled();
+    },
+  );
+
   it("leaves a media family unresolved for loaded providers without contracts", () => {
     const loaded = createEmptyPluginRegistry();
     loaded.imageGenerationProviders.push({
@@ -532,7 +697,7 @@ describe("resolvePluginCapabilityProviders", () => {
     );
 
     const prepared = prepareMediaCapabilityProviders({
-      cfg: { plugins: { allow: ["loaded-image"] } },
+      cfg: { plugins: { allow: ["loaded-image", "lazy-image"] } },
       registry: loaded,
       pluginMetadataSnapshot: {
         index: { plugins: [] },
@@ -1211,6 +1376,7 @@ describe("resolvePluginCapabilityProviders", () => {
     expect(mocks.loadBundledCapabilityRuntimeRegistry).toHaveBeenCalledWith({
       pluginIds: ["google"],
       env: process.env,
+      config: { tts: { provider: "google" } },
       pluginSdkResolution: undefined,
     });
   });
@@ -1242,6 +1408,7 @@ describe("resolvePluginCapabilityProviders", () => {
     expect(mocks.loadBundledCapabilityRuntimeRegistry).toHaveBeenCalledWith({
       pluginIds: ["google"],
       env: process.env,
+      config: { tts: { provider: "google" } },
       pluginSdkResolution: undefined,
     });
   });
@@ -1492,6 +1659,7 @@ describe("resolvePluginCapabilityProviders", () => {
   });
 
   it("loads fallback snapshots without startup dependency repair", () => {
+    mocks.readBundledDiscoveryMode.mockReturnValue("compat");
     const cfg = { plugins: { allow: ["custom-plugin"] } } as OpenClawConfig;
     const enablementCompat = {
       plugins: {
@@ -1658,6 +1826,7 @@ describe("resolvePluginCapabilityProviders", () => {
   });
 
   it("loads only the bundled owner plugin for a targeted provider lookup", () => {
+    mocks.readBundledDiscoveryMode.mockReturnValue("compat");
     const cfg = { plugins: { allow: ["custom-plugin"] } } as OpenClawConfig;
     const enablementCompat = {
       plugins: {

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -14,6 +14,7 @@ import { resolveRuntimePluginRegistry, type PluginLoadOptions } from "./loader.j
 import {
   hasManifestContractValue,
   isManifestPluginAvailableForControlPlane,
+  isManifestPluginOwnerAllowedByControlPlanePolicy,
   loadManifestContractSnapshot,
 } from "./manifest-contract-eligibility.js";
 import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.types.js";
@@ -106,27 +107,28 @@ function resolveCapabilityPluginIds(params: {
 }): CapabilityPluginResolution {
   const contractKey = CAPABILITY_CONTRACT_KEY[params.key];
   const snapshot = loadCapabilityManifestSnapshot(params);
-  const contractPlugins = snapshot.plugins.filter((plugin) =>
-    hasManifestContractValue({
-      plugin,
-      contract: contractKey,
-      value: params.providerId,
-    }),
+  const availableContractPlugins = snapshot.plugins.filter(
+    (plugin) =>
+      hasManifestContractValue({
+        plugin,
+        contract: contractKey,
+        value: params.providerId,
+      }) &&
+      isManifestPluginAvailableForControlPlane({
+        snapshot,
+        plugin,
+        config: params.cfg,
+        // Legacy TTS remains available when the operator disables plugins globally.
+        allowRestrictiveAllowlistBypass:
+          params.key === "speechProviders" && params.cfg?.plugins?.enabled === false,
+      }),
   );
   return {
-    runtimePluginIds: sortUniqueStrings(
-      contractPlugins
-        .filter((plugin) =>
-          isManifestPluginAvailableForControlPlane({
-            snapshot,
-            plugin,
-            config: params.cfg,
-          }),
-        )
-        .map((plugin) => plugin.id),
-    ),
+    runtimePluginIds: sortUniqueStrings(availableContractPlugins.map((plugin) => plugin.id)),
     bundledCompatPluginIds: sortUniqueStrings(
-      contractPlugins.filter((plugin) => plugin.origin === "bundled").map((plugin) => plugin.id),
+      availableContractPlugins
+        .filter((plugin) => plugin.origin === "bundled")
+        .map((plugin) => plugin.id),
     ),
   };
 }
@@ -419,23 +421,54 @@ function resolveRequestedCapabilityPluginIds(params: {
     : undefined;
 }
 
+function filterPolicyAllowedCapabilityProviders<K extends CapabilityProviderRegistryKey>(params: {
+  entries: PluginRegistry[K];
+  registry?: PluginRegistry;
+  cfg?: OpenClawConfig;
+  key: K;
+  bundledPluginIds?: ReadonlySet<string>;
+}): PluginRegistry[K] {
+  if (!params.cfg?.plugins) {
+    return params.entries;
+  }
+  const origins = new Map(
+    (params.registry?.plugins ?? []).map((plugin) => [plugin.id, plugin.origin]),
+  );
+  return params.entries.filter((entry) => {
+    const origin =
+      origins.get(entry.pluginId) ??
+      (params.bundledPluginIds?.has(entry.pluginId) ? "bundled" : "global");
+    return isManifestPluginOwnerAllowedByControlPlanePolicy({
+      plugin: { id: entry.pluginId, origin },
+      config: params.cfg,
+      allowRestrictiveAllowlistBypass:
+        params.key === "speechProviders" && params.cfg?.plugins?.enabled === false,
+    });
+  }) as PluginRegistry[K];
+}
+
 function loadCapabilityProviderEntries<K extends CapabilityProviderRegistryKey>(params: {
   key: K;
   bundledCompatPluginIds: string[];
   loadOptions: PluginLoadOptions;
   requested?: Set<string>;
 }): PluginRegistry[K] {
+  const allowedPluginIds = new Set(params.loadOptions.onlyPluginIds);
+  const filterAllowedEntries = (registry: PluginRegistry | undefined): PluginRegistry[K] =>
+    (registry?.[params.key] ?? []).filter((entry) =>
+      allowedPluginIds.has(entry.pluginId),
+    ) as PluginRegistry[K];
   const loadedRegistry = getLoadedRuntimePluginRegistry({
     env: params.loadOptions.env,
     loadOptions: params.loadOptions,
     workspaceDir: params.loadOptions.workspaceDir,
     requiredPluginIds: params.loadOptions.onlyPluginIds,
   });
-  const loadedEntries = loadedRegistry?.[params.key] ?? [];
+  const loadedEntries = filterAllowedEntries(loadedRegistry);
   const coldRegistry = loadedRegistry
     ? undefined
     : resolveRuntimePluginRegistry(params.loadOptions);
-  const coldEntries = coldRegistry?.[params.key] ?? [];
+  const coldEntries = filterAllowedEntries(coldRegistry);
   const entries =
     loadedEntries.length > 0 && coldEntries.length > 0
       ? mergeCapabilityProviderEntries(loadedEntries, coldEntries)
@@ -453,11 +486,14 @@ function loadCapabilityProviderEntries<K extends CapabilityProviderRegistryKey>(
   if (params.bundledCompatPluginIds.length === 0) {
     return entries;
   }
-  const captured = loadBundledCapabilityRuntimeRegistry({
-    pluginIds: params.bundledCompatPluginIds,
-    env: process.env,
-    pluginSdkResolution: params.loadOptions.pluginSdkResolution,
-  })[params.key] as PluginRegistry[K];
+  const captured = filterAllowedEntries(
+    loadBundledCapabilityRuntimeRegistry({
+      pluginIds: params.bundledCompatPluginIds,
+      env: process.env,
+      ...(params.loadOptions.config ? { config: params.loadOptions.config } : {}),
+      pluginSdkResolution: params.loadOptions.pluginSdkResolution,
+    }),
+  );
   return entries.length > 0 ? mergeCapabilityProviderEntries(entries, captured) : captured;
 }
 
@@ -471,7 +507,13 @@ export function resolvePluginCapabilityProvider<K extends CapabilityProviderRegi
   }
 
   const activeRegistry = getLoadedRuntimePluginRegistry();
-  const activeProvider = findProviderById(activeRegistry?.[params.key] ?? [], params.providerId);
+  const activeProviders = filterPolicyAllowedCapabilityProviders({
+    entries: activeRegistry?.[params.key] ?? [],
+    registry: activeRegistry,
+    cfg: params.cfg,
+    key: params.key,
+  });
+  const activeProvider = findProviderById(activeProviders, params.providerId);
   if (activeProvider) {
     return activeProvider;
   }
@@ -513,7 +555,12 @@ export function resolvePluginCapabilityProviders<K extends CapabilityProviderReg
   }
 
   const activeRegistry = getLoadedRuntimePluginRegistry();
-  const activeProviders = activeRegistry?.[params.key] ?? [];
+  const activeProviders = filterPolicyAllowedCapabilityProviders({
+    entries: activeRegistry?.[params.key] ?? [],
+    registry: activeRegistry,
+    cfg: params.cfg,
+    key: params.key,
+  });
   const missingRequestedProviders =
     activeProviders.length > 0
       ? nonEmptyRequestedProviders(
@@ -609,19 +656,34 @@ export function prepareMediaCapabilityProviders(params: {
       cfg: params.cfg,
       pluginMetadataSnapshot: params.pluginMetadataSnapshot,
     });
-    const requiredPluginIds = sortUniqueStrings([
-      ...resolution.runtimePluginIds,
-      ...resolution.bundledCompatPluginIds,
-    ]);
+    const requiredPluginIds = resolution.runtimePluginIds;
+    if (
+      requiredPluginIds.length === 0 &&
+      params.pluginMetadataSnapshot.plugins.some((plugin) =>
+        hasManifestContractValue({
+          plugin,
+          contract: CAPABILITY_CONTRACT_KEY[key],
+        }),
+      )
+    ) {
+      return Object.freeze([]);
+    }
     if (!params.registry || !registryContainsRuntimePluginIds(params.registry, requiredPluginIds)) {
       return undefined;
     }
     const eligiblePluginIds = new Set(requiredPluginIds);
-    if (params.registry[key].some((entry) => !eligiblePluginIds.has(entry.pluginId))) {
+    const availableEntries = filterPolicyAllowedCapabilityProviders({
+      entries: params.registry[key],
+      registry: params.registry,
+      cfg: params.cfg,
+      key,
+      bundledPluginIds: new Set(resolution.bundledCompatPluginIds),
+    });
+    if (availableEntries.some((entry) => !eligiblePluginIds.has(entry.pluginId))) {
       return undefined;
     }
     return Object.freeze(
-      params.registry[key].map((entry) => entry.provider),
+      availableEntries.map((entry) => entry.provider),
     ) as readonly ProviderFor<K>[];
   };
   return Object.freeze({

--- a/src/plugins/manifest-contract-eligibility.test.ts
+++ b/src/plugins/manifest-contract-eligibility.test.ts
@@ -4,6 +4,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   loadPluginMetadataSnapshot: vi.fn(),
   resolvePluginMetadataSnapshot: vi.fn(),
+  readBundledDiscoveryMode: vi.fn<() => "compat" | "allowlist" | undefined>(() => "allowlist"),
+}));
+
+vi.mock("./bundled-discovery-state.js", () => ({
+  readBundledDiscoveryMode: mocks.readBundledDiscoveryMode,
 }));
 
 vi.mock("./plugin-metadata-snapshot.js", () => ({
@@ -11,7 +16,175 @@ vi.mock("./plugin-metadata-snapshot.js", () => ({
   resolvePluginMetadataSnapshot: mocks.resolvePluginMetadataSnapshot,
 }));
 
-import { loadManifestContractSnapshot } from "./manifest-contract-eligibility.js";
+import {
+  isManifestPluginAvailableForControlPlane,
+  listAvailableManifestContractValues,
+  loadManifestContractSnapshot,
+} from "./manifest-contract-eligibility.js";
+import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
+
+describe("bundled manifest contract availability", () => {
+  const plugin = {
+    id: "google",
+    origin: "bundled" as const,
+    contracts: { imageGenerationProviders: ["google"] },
+  };
+  const snapshot = {
+    index: { plugins: [{ pluginId: "google", origin: "bundled", enabled: false }] },
+    plugins: [plugin],
+  } as never;
+
+  beforeEach(() => {
+    clearPluginMetadataLifecycleCaches();
+    mocks.readBundledDiscoveryMode.mockReset();
+    mocks.readBundledDiscoveryMode.mockReturnValue("allowlist");
+  });
+
+  it.each([
+    {
+      name: "an explicitly disabled plugin",
+      config: { plugins: { entries: { google: { enabled: false } } } },
+    },
+    {
+      name: "a denylisted plugin",
+      config: { plugins: { deny: ["google"] } },
+    },
+    {
+      name: "a plugin outside a restrictive allowlist",
+      config: { plugins: { allow: ["another-plugin"] } },
+    },
+  ])("does not expose $name", ({ config }) => {
+    expect(isManifestPluginAvailableForControlPlane({ snapshot, plugin, config })).toBe(false);
+    expect(
+      listAvailableManifestContractValues({
+        snapshot,
+        contract: "imageGenerationProviders",
+        config,
+      }),
+    ).toEqual([]);
+  });
+
+  it("preserves bundled auto-activation when no explicit owner restriction exists", () => {
+    expect(isManifestPluginAvailableForControlPlane({ snapshot, plugin, config: {} })).toBe(true);
+    expect(mocks.readBundledDiscoveryMode).not.toHaveBeenCalled();
+  });
+
+  it.each([{ enabled: true }, { token: "configured" }])(
+    "preserves explicitly configured bundled channels outside a restrictive allowlist",
+    (channelConfig) => {
+      expect(
+        isManifestPluginAvailableForControlPlane({
+          snapshot,
+          plugin: { ...plugin, id: "discord-owner", channels: ["discord"] },
+          config: {
+            plugins: { allow: ["another-plugin"] },
+            channels: { discord: channelConfig },
+          } as never,
+        }),
+      ).toBe(true);
+      expect(mocks.readBundledDiscoveryMode).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not let disabled channel configuration bypass a restrictive allowlist", () => {
+    expect(
+      isManifestPluginAvailableForControlPlane({
+        snapshot,
+        plugin: { ...plugin, id: "discord-owner", channels: ["discord"] },
+        config: {
+          plugins: { allow: ["another-plugin"] },
+          channels: { discord: { enabled: false, token: "configured" } },
+        } as never,
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts a normalized owner explicitly included in the restrictive allowlist", () => {
+    expect(
+      isManifestPluginAvailableForControlPlane({
+        snapshot,
+        plugin,
+        config: { plugins: { allow: [" GOOGLE "] } },
+      }),
+    ).toBe(true);
+    expect(mocks.readBundledDiscoveryMode).not.toHaveBeenCalled();
+  });
+
+  it.each([{ deny: ["discord-owner"] }, { entries: { "discord-owner": { enabled: false } } }])(
+    "does not let channel configuration override explicit plugin prohibition",
+    (plugins) => {
+      expect(
+        isManifestPluginAvailableForControlPlane({
+          snapshot,
+          plugin: { ...plugin, id: "discord-owner", channels: ["discord"] },
+          config: {
+            plugins: { allow: ["another-plugin"], ...plugins },
+            channels: { discord: { token: "configured" } },
+          } as never,
+        }),
+      ).toBe(false);
+    },
+  );
+
+  it("reads machine-owned bundled compatibility once per metadata lifecycle", () => {
+    const anotherPlugin = {
+      ...plugin,
+      id: "another-google",
+      contracts: { imageGenerationProviders: ["another-google"] },
+    };
+    const config = { plugins: { allow: ["allowed-plugin"] } };
+    const restrictedSnapshot = {
+      index: { plugins: [] },
+      plugins: [plugin, anotherPlugin],
+    } as never;
+
+    expect(
+      listAvailableManifestContractValues({
+        snapshot: restrictedSnapshot,
+        contract: "imageGenerationProviders",
+        config,
+      }),
+    ).toEqual([]);
+    expect(mocks.readBundledDiscoveryMode).toHaveBeenCalledTimes(1);
+
+    clearPluginMetadataLifecycleCaches();
+    expect(isManifestPluginAvailableForControlPlane({ snapshot, plugin, config })).toBe(false);
+    expect(mocks.readBundledDiscoveryMode).toHaveBeenCalledTimes(2);
+  });
+
+  it("preserves globally disabled bundled metadata for the named speech compatibility path", () => {
+    expect(
+      isManifestPluginAvailableForControlPlane({
+        snapshot,
+        plugin,
+        config: { plugins: { enabled: false } },
+      }),
+    ).toBe(true);
+  });
+
+  it("preserves the shipped restrictive-allowlist bundled compatibility mode", () => {
+    mocks.readBundledDiscoveryMode.mockReturnValue("compat");
+
+    expect(
+      isManifestPluginAvailableForControlPlane({
+        snapshot,
+        plugin,
+        config: { plugins: { allow: ["another-plugin"] } },
+      }),
+    ).toBe(true);
+  });
+
+  it.each([{ entries: { google: { enabled: false } } }, { deny: ["google"] }])(
+    "never bypasses explicit owner prohibition in bundled compatibility mode",
+    (plugins) => {
+      mocks.readBundledDiscoveryMode.mockReturnValue("compat");
+
+      expect(
+        isManifestPluginAvailableForControlPlane({ snapshot, plugin, config: { plugins } }),
+      ).toBe(false);
+    },
+  );
+});
 
 describe("loadManifestContractSnapshot", () => {
   beforeEach(() => {

--- a/src/plugins/manifest-contract-eligibility.test.ts
+++ b/src/plugins/manifest-contract-eligibility.test.ts
@@ -69,7 +69,11 @@ describe("bundled manifest contract availability", () => {
     expect(mocks.readBundledDiscoveryMode).not.toHaveBeenCalled();
   });
 
-  it.each([{ enabled: true }, { token: "configured" }])(
+  it.each([
+    { enabled: true },
+    { token: "configured" },
+    { accounts: { primary: { token: "configured" } } },
+  ])(
     "preserves explicitly configured bundled channels outside a restrictive allowlist",
     (channelConfig) => {
       expect(
@@ -85,6 +89,20 @@ describe("bundled manifest contract availability", () => {
       expect(mocks.readBundledDiscoveryMode).not.toHaveBeenCalled();
     },
   );
+
+  it("preserves explicitly configured custom channel ids distinct from their plugin owner", () => {
+    expect(
+      isManifestPluginAvailableForControlPlane({
+        snapshot,
+        plugin: { ...plugin, id: "custom-owner", channels: ["private-channel"] },
+        config: {
+          plugins: { allow: ["another-plugin"] },
+          channels: { "private-channel": { enabled: true } },
+        } as never,
+      }),
+    ).toBe(true);
+    expect(mocks.readBundledDiscoveryMode).not.toHaveBeenCalled();
+  });
 
   it("does not let disabled channel configuration bypass a restrictive allowlist", () => {
     expect(

--- a/src/plugins/manifest-contract-eligibility.ts
+++ b/src/plugins/manifest-contract-eligibility.ts
@@ -1,8 +1,13 @@
 // Determines which manifest contracts are eligible for plugin activation.
 import { sortUniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { readBundledDiscoveryMode } from "./bundled-discovery-state.js";
+import { hasExplicitChannelConfig } from "./channel-presence-policy.js";
+import { normalizePluginsConfig } from "./config-state.js";
 import { isInstalledPluginEnabled } from "./installed-plugin-index.js";
+import { resolveManifestOwnerBasePolicyBlock } from "./manifest-owner-policy.js";
 import type { PluginManifestContractListKey, PluginManifestRecord } from "./manifest-registry.js";
+import { registerPluginMetadataProcessMemoLifecycleClear } from "./plugin-metadata-lifecycle.js";
 import { resolvePluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
 import type {
   PluginMetadataManifestView,
@@ -10,14 +15,59 @@ import type {
   PluginMetadataSnapshot,
 } from "./plugin-metadata-snapshot.types.js";
 
+let bundledDiscoveryMode: { value: ReturnType<typeof readBundledDiscoveryMode> } | undefined;
+
+registerPluginMetadataProcessMemoLifecycleClear(() => {
+  bundledDiscoveryMode = undefined;
+});
+
+/** Enforces owner-specific policy while preserving bundled speech/global compatibility. */
+export function isManifestPluginOwnerAllowedByControlPlanePolicy(params: {
+  plugin: Pick<PluginManifestRecord, "id" | "origin"> & {
+    channels?: readonly string[];
+  };
+  config?: OpenClawConfig;
+  allowRestrictiveAllowlistBypass?: boolean;
+}): boolean {
+  if (!params.config?.plugins) {
+    return true;
+  }
+  const config = params.config;
+  const normalized = normalizePluginsConfig(config.plugins);
+  // Global disable is owned by each runtime surface; bundled speech remains intentionally usable.
+  const normalizedConfig = normalized.enabled ? normalized : { ...normalized, enabled: true };
+  const block = resolveManifestOwnerBasePolicyBlock({
+    plugin: params.plugin,
+    normalizedConfig,
+    allowRestrictiveAllowlistBypass:
+      params.plugin.origin === "bundled" && params.allowRestrictiveAllowlistBypass === true,
+  });
+  if (block !== "not-in-allowlist") {
+    return block === null;
+  }
+  if (params.plugin.origin !== "bundled") {
+    return false;
+  }
+  const channelIds = params.plugin.channels ?? [params.plugin.id];
+  if (channelIds.some((channelId) => hasExplicitChannelConfig({ config, channelId }))) {
+    return true;
+  }
+  bundledDiscoveryMode ??= { value: readBundledDiscoveryMode() };
+  return bundledDiscoveryMode.value === "compat";
+}
+
 export function isManifestPluginAvailableForControlPlane(params: {
   snapshot: Pick<PluginMetadataSnapshot, "index">;
   plugin: Pick<
     PluginManifestRecord,
     "id" | "origin" | "enabledByDefault" | "enabledByDefaultOnPlatforms"
-  >;
+  > & { channels?: readonly string[] };
   config?: OpenClawConfig;
+  allowRestrictiveAllowlistBypass?: boolean;
 }): boolean {
+  if (!isManifestPluginOwnerAllowedByControlPlanePolicy(params)) {
+    return false;
+  }
   if (params.plugin.origin === "bundled") {
     return true;
   }

--- a/src/plugins/manifest-contract-eligibility.ts
+++ b/src/plugins/manifest-contract-eligibility.ts
@@ -1,8 +1,11 @@
 // Determines which manifest contracts are eligible for plugin activation.
 import { sortUniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import {
+  hasMeaningfulChannelConfigShallow,
+  resolveChannelConfigRecord,
+} from "../config/channel-configured-shared.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { readBundledDiscoveryMode } from "./bundled-discovery-state.js";
-import { hasExplicitChannelConfig } from "./channel-presence-policy.js";
 import { normalizePluginsConfig } from "./config-state.js";
 import { isInstalledPluginEnabled } from "./installed-plugin-index.js";
 import { resolveManifestOwnerBasePolicyBlock } from "./manifest-owner-policy.js";
@@ -49,7 +52,12 @@ export function isManifestPluginOwnerAllowedByControlPlanePolicy(params: {
     return false;
   }
   const channelIds = params.plugin.channels ?? [params.plugin.id];
-  if (channelIds.some((channelId) => hasExplicitChannelConfig({ config, channelId }))) {
+  if (
+    channelIds.some((channelId) => {
+      const channelConfig = resolveChannelConfigRecord(config, channelId);
+      return channelConfig?.enabled !== false && hasMeaningfulChannelConfigShallow(channelConfig);
+    })
+  ) {
     return true;
   }
   bundledDiscoveryMode ??= { value: readBundledDiscoveryMode() };


### PR DESCRIPTION
## Summary

- Prevent explicitly disabled, denied, and restrictively allowlisted bundled plugins from actually executing.
- Preserve intentionally supported speech, scoped Doctor migration, model metadata, configured channel, and installed compatibility contracts.

## Root cause and canonical owner boundaries

Bundled manifest eligibility returned true unconditionally; active capability registries and prepared providers could execute an already loaded plugin callback even when operator policy disabled it, and the cold bundled fallback reconstructed configuration without the actual deny/allow state. Actual production preparation against the real Google plugin manifest showed a disabled/denied provider callback executing.

The existing manifest-policy, active/prepared capability owner, and cold bundled runtime now share one canonical owner-aware decision. Explicit deny and disable win at every execution boundary; restrictive allowlists respect only existing intentionally scoped configured-channel or legacy compatibility semantics. Global-disable remains controlled at each runtime owner so deliberately supported speech/Doctor migration and metadata-only model catalog contracts remain intact. Restrictive compatibility state is process-lifecycle memoized; normal paths perform no state lookup.

## Actual executable proof

Before repair, the actual public provider owner returned selected `google` and executed its callback once for explicit disable, deny, and restrictive allowlist. After repair those same three states return `selected:[]`, callback executions `0`, and no imported plugin runtime.

Actual frozen global-disable proof with a genuinely preloaded Google provider:

`{"globalPluginsEnabled":false,"manifestMetadataAvailable":true,"actualPreloadedRegistryOwner":["google"],"targetedActiveProvider":null,"listedActiveProviders":[],"preparedProviders":[],"providerCallbackExecutions":0,"newlyImportedRuntimePlugins":[]}`

- Initial actual execution matrix: **17 genuine RED cases**.
- Six focused owner/active/prepared/cold/model-catalog/compat suites: **114/114 passing**.
- Type-aware/type-check lint, formatting, and lifecycle cache checks: clean.
- Production delta **+118 lines**, necessary to enforce the same security invariant across four execution boundaries while preserving shipped speech/channel/Doctor compatibility.

### Independent review disposition

One fresh structured Sol/high review proposed globally disabling the shared manifest metadata helper. This sole finding was explicitly rejected after direct complete-owner tracing and the real active-provider execution proof above: all non-speech targeted, listed, and prepared execution owners return before accessing any registry when globally disabled, and the direct cold loader preserves the disabled configuration. Applying the proposed change would break three existing verified contracts: globally disabled speech compatibility, explicitly scoped Doctor plugin migrations, and metadata-only model catalog visibility. Independent security review accepted **zero actionable P0/P1 findings**; secret scan clean, confidence **0.97**.
