### PR TITLE
fix(agents): prevent duplicate yielded subagent fanout

### DIFF
--- a/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createEmbeddedRunReplayState,
   type EmbeddedRunReplayState,
@@ -7,7 +7,8 @@ import {
 import { dispatchEmbeddedRunAttempt } from "./run/run-attempt-dispatch.js";
 
 const mocks = vi.hoisted(() => ({
-  runAttempt: vi.fn(async () => ({ terminal: { kind: "ok" } })),
+  runAttempt: vi.fn(),
+  settleRequesterAfterSessionSpawns: vi.fn(),
 }));
 
 vi.mock("../delegation-capability.js", () => ({
@@ -30,8 +31,13 @@ vi.mock("./run/attempt-exec-approval-continuation.js", () => ({
   })),
 }));
 
-vi.mock("./run/backend.js", () => ({
-  runEmbeddedAttemptWithBackend: mocks.runAttempt,
+vi.mock("../harness/selection.js", () => ({
+  runAgentHarnessAttempt: mocks.runAttempt,
+  runAgentHarnessSettledTurnFinalization: vi.fn(),
+}));
+
+vi.mock("../subagent-registry.js", () => ({
+  settleRequesterAfterSessionSpawns: mocks.settleRequesterAfterSessionSpawns,
 }));
 
 vi.mock("./run/plugin-harness-prompt-images.js", () => ({
@@ -120,6 +126,11 @@ function makeDispatchInput(
 }
 
 describe("embedded run retry dispatch", () => {
+  beforeEach(() => {
+    mocks.runAttempt.mockReset().mockResolvedValue({ terminal: { kind: "ok" } });
+    mocks.settleRequesterAfterSessionSpawns.mockReset();
+  });
+
   it("preserves caller-owned session and unsafe replay state on the next attempt", async () => {
     const sessionManager = { owner: "caller" };
     const replayState = observeReplayMetadata(
@@ -137,5 +148,33 @@ describe("embedded run retry dispatch", () => {
     expect(replayState).toEqual({ replayInvalid: true, hadPotentialSideEffects: true });
     expect(result.preparedAttempt.initialReplayState).toBe(replayState);
     expect(mocks.runAttempt).toHaveBeenCalledWith(result.preparedAttempt);
+    expect(mocks.settleRequesterAfterSessionSpawns).not.toHaveBeenCalled();
   });
+
+  it.each([true, false])(
+    "settles accepted spawns before a late post-compaction abort (yielded: %s)",
+    async (yieldDetected) => {
+      const postCompactionAbortError = new Error("post-compaction loop detected");
+      const input = makeDispatchInput({}, createEmbeddedRunReplayState());
+      input.control.getPostCompactionAbortError = vi.fn(() => postCompactionAbortError);
+      const acceptedSessionSpawns = [
+        { runId: "child-run", childSessionKey: "agent:main:subagent:child" },
+      ];
+      mocks.runAttempt.mockResolvedValueOnce({
+        terminal: { kind: "ok" },
+        agentHarnessId: "codex",
+        yieldDetected,
+        acceptedSessionSpawns,
+      });
+
+      await expect(dispatchEmbeddedRunAttempt(input)).rejects.toBe(postCompactionAbortError);
+
+      expect(mocks.settleRequesterAfterSessionSpawns).toHaveBeenCalledWith({
+        requesterSessionKey: "agent:main:session-1",
+        requesterTurnRunId: "run-1",
+        requesterYielded: yieldDetected,
+        acceptedSessionSpawns,
+      });
+    },
+  );
 });

--- a/src/agents/embedded-agent-runner/run/backend.ts
+++ b/src/agents/embedded-agent-runner/run/backend.ts
@@ -9,6 +9,7 @@ import type {
   AgentHarness,
   AgentHarnessSettledTurnFinalizationResult,
 } from "../../harness/types.js";
+import { settleRequesterAfterSessionSpawns } from "../../subagent-registry.js";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
 
 /**
@@ -17,7 +18,22 @@ import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types
 export async function runEmbeddedAttemptWithBackend(
   params: EmbeddedRunAttemptParams,
 ): Promise<EmbeddedRunAttemptResult> {
-  return runAgentHarnessAttempt(params);
+  const result = await runAgentHarnessAttempt(params);
+  if (
+    result.agentHarnessId !== "openclaw" &&
+    params.sessionKey &&
+    result.acceptedSessionSpawns?.length
+  ) {
+    // Native harnesses return only after releasing active-run ownership.
+    // Settle before dispatch can replace the successful result with a late abort.
+    settleRequesterAfterSessionSpawns({
+      requesterSessionKey: params.sessionKey,
+      requesterTurnRunId: params.runId,
+      requesterYielded: result.yieldDetected === true,
+      acceptedSessionSpawns: result.acceptedSessionSpawns,
+    });
+  }
+  return result;
 }
 
 /** Runs one operation-specific settled-turn finalization through the selected harness. */

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -262,6 +262,7 @@ async function deliverSlackThreadAnnouncement(params: {
   sourceTool?: string;
   requesterAbandoned?: boolean;
   isSourceSessionEffectsAllowed?: () => boolean;
+  isCompletionOwnedByRequesterYield?: () => boolean;
 }) {
   // Slack thread delivery exercises all origins because direct, session, and
   // completion routing can differ after a child run outlives its requester.
@@ -296,6 +297,7 @@ async function deliverSlackThreadAnnouncement(params: {
     sourceRunId: "run-generated-media",
     sourceTool: params.sourceTool,
     isSourceSessionEffectsAllowed: params.isSourceSessionEffectsAllowed,
+    isCompletionOwnedByRequesterYield: params.isCompletionOwnedByRequesterYield,
   });
 }
 
@@ -1127,6 +1129,35 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledTimes(1);
     expect(callGateway).not.toHaveBeenCalled();
   });
+
+  it.each([true, false])(
+    "defers completion delivery when sessions_yield owns the handoff (active: %s)",
+    async (isActive) => {
+      const callGateway = createGatewayMock();
+      const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeSequenceMock([
+        "runtime_rejected",
+      ]);
+
+      const result = await deliverSlackThreadAnnouncement({
+        callGateway,
+        sessionId: "requester-session-1",
+        isActive,
+        directIdempotencyKey: `announce-yield-owned-completion-${isActive}`,
+        queueEmbeddedAgentMessageWithOutcome,
+        isCompletionOwnedByRequesterYield: () => true,
+      });
+
+      expect(result).toMatchObject({
+        delivered: false,
+        path: "none",
+        reason: "completion_handoff_pending",
+        terminal: true,
+        disposition: "intentional_non_delivery",
+      });
+      expect(queueEmbeddedAgentMessageWithOutcome).not.toHaveBeenCalled();
+      expect(callGateway).not.toHaveBeenCalled();
+    },
+  );
 
   it("keeps direct external delivery for dormant completion requesters", async () => {
     const callGateway = createGatewayMock();

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -864,6 +864,7 @@ async function sendSubagentAnnounceDirectly(params: {
   sourceChannel?: string;
   sourceTool?: string;
   isSourceSessionEffectsAllowed?: () => boolean;
+  isCompletionOwnedByRequesterYield?: () => boolean;
   requesterIsSubagent: boolean;
   onDeliveryResult?: (delivery: SubagentAnnounceDeliveryResult) => void;
   signal?: AbortSignal;
@@ -955,6 +956,17 @@ async function sendSubagentAnnounceDirectly(params: {
         path: "none",
         reason: "requester_abandoned",
         error: "requester session abandoned after timeout",
+      };
+    }
+    if (params.expectsCompletionMessage && params.isCompletionOwnedByRequesterYield?.()) {
+      // sessions_yield owns the post-turn synthesis. Starting or steering a
+      // requester turn here would replay the original fanout during handoff.
+      return {
+        delivered: false,
+        path: "none",
+        reason: "completion_handoff_pending",
+        terminal: true,
+        disposition: "intentional_non_delivery",
       };
     }
     const tryTextCompletionDirectDelivery = () =>
@@ -1318,6 +1330,7 @@ export async function deliverSubagentAnnouncement(params: {
   sourceChannel?: string;
   sourceTool?: string;
   isSourceSessionEffectsAllowed?: () => boolean;
+  isCompletionOwnedByRequesterYield?: () => boolean;
   targetRequesterSessionKey: string;
   requesterIsSubagent: boolean;
   expectsCompletionMessage: boolean;
@@ -1474,6 +1487,7 @@ export async function deliverSubagentAnnouncement(params: {
         sourceChannel: params.sourceChannel,
         sourceTool: params.sourceTool,
         isSourceSessionEffectsAllowed: params.isSourceSessionEffectsAllowed,
+        isCompletionOwnedByRequesterYield: params.isCompletionOwnedByRequesterYield,
         requesterIsSubagent: params.requesterIsSubagent,
         expectsCompletionMessage: params.expectsCompletionMessage,
         requireVisibleReply: params.requireVisibleReply,

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -309,6 +309,7 @@ export async function runSubagentAnnounceFlow(params: {
   isChildSessionEffectsAllowed?: () => boolean;
   /** Live owner check for requester delivery after awaited phases. */
   isCompletionDeliveryAllowed?: () => boolean;
+  isCompletionOwnedByRequesterYield?: () => boolean;
   signal?: AbortSignal;
   bestEffortDeliver?: boolean;
   onDeliveryResult?: (delivery: SubagentAnnounceDeliveryResult) => void;
@@ -334,11 +335,7 @@ export async function runSubagentAnnounceFlow(params: {
       typeof childSessionEntry?.sessionId === "string" && childSessionEntry.sessionId.trim()
         ? childSessionEntry.sessionId.trim()
         : undefined;
-    childSessionLifecycleRevision =
-      typeof childSessionEntry?.lifecycleRevision === "string" &&
-      childSessionEntry.lifecycleRevision.trim()
-        ? childSessionEntry.lifecycleRevision.trim()
-        : undefined;
+    childSessionLifecycleRevision = normalizeOptionalString(childSessionEntry?.lifecycleRevision);
     const settleTimeoutMs = Math.min(Math.max(params.timeoutMs, 1), 120_000);
     let reply =
       params.terminalReply?.disposition === "visible"
@@ -705,6 +702,7 @@ export async function runSubagentAnnounceFlow(params: {
       sourceChannel: INTERNAL_MESSAGE_CHANNEL,
       sourceTool: "subagent_announce",
       isSourceSessionEffectsAllowed: completionDeliveryAllowed,
+      isCompletionOwnedByRequesterYield: params.isCompletionOwnedByRequesterYield,
       targetRequesterSessionKey,
       requesterIsSubagent,
       expectsCompletionMessage,

--- a/src/agents/subagent-registry-lifecycle-cleanup.ts
+++ b/src/agents/subagent-registry-lifecycle-cleanup.ts
@@ -575,6 +575,9 @@ export function createSubagentRegistryLifecycleCleanup(
       suppressChildSessionEffects: suppressSessionEffects,
       isChildSessionEffectsAllowed: childSessionEffectsAllowed,
       isCompletionDeliveryAllowed: () => isCleanupAttemptCurrent(runId, entry, cleanupGeneration),
+      isCompletionOwnedByRequesterYield: () =>
+        entry.requesterTurnYielded === true ||
+        entry.requesterSettleWake?.requesterYieldBatch === true,
       onBeforeDeleteChildSession:
         cleanup === "delete"
           ? () => {

--- a/src/agents/subagent-registry-lifecycle-requester-wake.ts
+++ b/src/agents/subagent-registry-lifecycle-requester-wake.ts
@@ -210,6 +210,7 @@ export function createSubagentRegistryLifecycleRequesterWake(
     if (
       entry.collect ||
       !requesterSessionKey ||
+      (entry.requesterTurnRunId && entry.requesterTurnYielded === true) ||
       scheduledRequesterSettleWakeRuns.has(runId) ||
       scheduledRequesterSettleWakeTimers.has(runId)
     ) {

--- a/src/agents/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagent-registry-lifecycle.test.ts
@@ -4286,7 +4286,7 @@ describe("requester settle wake trigger", () => {
     expect(later.requesterSettleWake).toEqual({ status: "pending", attemptCount: 0 });
   });
 
-  it("preserves a yielded batch re-armed during an earlier successful wake", async () => {
+  it("keeps a yielded completion parked until its requester turn settles", async () => {
     const entry = createRunEntry({
       requesterTurnRunId: "run-requester",
       requesterTurnYielded: true,
@@ -4300,25 +4300,8 @@ describe("requester settle wake trigger", () => {
           LifecycleControllerParams["maybeWakeRequesterAfterAllChildrenSettled"]
         >[0],
       ) => {
-        const firstInvocation = settleWake.mock.calls.length === 1;
-        if (firstInvocation) {
-          controller.settleRequesterTurnAfterSessionSpawns({
-            requesterSessionKey: entry.requesterSessionKey,
-            requesterTurnRunId: "run-requester",
-            requesterYielded: true,
-            acceptedSessionSpawns: [{ runId: entry.runId, childSessionKey: entry.childSessionKey }],
-          });
-          params.transitionBatch([entry.runId], {
-            status: "dispatching",
-            attemptCount: 1,
-            batchRunIds: [entry.runId],
-          });
-        }
-        params.completeBatch(
-          [entry.runId],
-          firstInvocation ? undefined : entry.requesterSettleWake?.rearmGeneration,
-        );
-        return firstInvocation;
+        params.completeBatch([entry.runId], entry.requesterSettleWake?.rearmGeneration);
+        return true;
       },
     );
     const controller = createLifecycleController({
@@ -4333,7 +4316,17 @@ describe("requester settle wake trigger", () => {
       completedAt: 5_000,
     });
 
-    await waitForLifecycleState(() => expect(settleWake).toHaveBeenCalledTimes(2));
+    await Promise.resolve();
+    expect(settleWake).not.toHaveBeenCalled();
+
+    controller.settleRequesterTurnAfterSessionSpawns({
+      requesterSessionKey: entry.requesterSessionKey,
+      requesterTurnRunId: "run-requester",
+      requesterYielded: true,
+      acceptedSessionSpawns: [{ runId: entry.runId, childSessionKey: entry.childSessionKey }],
+    });
+
+    await waitForLifecycleState(() => expect(settleWake).toHaveBeenCalledOnce());
     expect(entry.requesterSettleWake).toBeUndefined();
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Codex-runtime sessions using `sessions_yield` fanout could replay the original child launches or never receive the final synthesized completion after the children finished.

The release-grade runtime-pair lane reproduced this as duplicate `alpha`/`beta` launches followed by a timeout.

## Why This Change Was Made

Native harness results now settle accepted child spawns immediately after the harness releases active-run ownership, before dispatch can replace the successful result with a late abort. OpenClaw keeps its existing earlier settlement boundary.

Completion delivery remains parked while the yielded requester owns the handoff, and the requester wake is re-armed only after that turn settles. This avoids both duplicate steering/direct delivery and silent completion loss.

## User Impact

Users can fan out subagents from the Codex runtime, yield for their completion, and receive one final synthesis without duplicate child launches.

## Evidence

- Reproduced in Full Release Validation at frozen SHA `8895b0c28858caf9c45f4924bc27db281f672522`: [runtime-pair failure](https://github.com/openclaw/openclaw/actions/runs/30812186274/job/91681506065) and [release verifier failure](https://github.com/openclaw/openclaw/actions/runs/30812186274/job/91686272475).
- Rebuilt conflict-free on `origin/main` `45643863d7132a2580864ac05d007dcc724a5dbf`; exact signed head `cfb7fd1b3660f3c19341a6761e5c87df12b3df9d`.
- Blacksmith Testbox `tbx_01kz5tscp2pewppczmrkfgbvky`: [workflow run](https://github.com/openclaw/openclaw/actions/runs/30887966723).
- `pnpm check:changed`: passed.
- Focused Vitest proof: 290 tests passed across registry lifecycle, announcement delivery, and native late-abort settlement.
- Private QA runtime build: passed.
- QA runtime pair `subagent-fanout-synthesis`: OpenClaw `1/1`, Codex `1/1`, validator `1/1`.
- Fresh exact-head autoreview: no accepted/actionable findings, correctness `0.94`.
- Direct Codex contract checked at `codex-rs/app-server/src/request_processors/turn_processor.rs`, `codex-rs/core/src/session/mod.rs`, `codex-rs/app-server/src/bespoke_event_handling.rs`, and `codex-rs/app-server-protocol/src/protocol/v2/turn.rs` for expected-turn steering and turn completion behavior.

Provenance: made visible by #118644, which added native accepted-spawn telemetry but did not yet settle it through the shared harness boundary.
