### PR TITLE
fix(channels): deny unauthorized Discord and Telegram binding access

### DIFF
--- a/extensions/discord/src/interactive-dispatch.ts
+++ b/extensions/discord/src/interactive-dispatch.ts
@@ -91,7 +91,14 @@ export async function dispatchDiscordPluginInteractiveHandler(params: {
         },
         respond: params.respond,
         ...createInteractiveConversationBindingHelpers({
-          registration,
+          // Untrusted callbacks may reach their plugin, but never inherit conversation-binding authority.
+          registration:
+            params.ctx.auth?.isAuthorizedSender &&
+            params.ctx.senderId?.trim() &&
+            params.ctx.accountId?.trim() &&
+            params.ctx.conversationId?.trim()
+              ? registration
+              : { ...registration, pluginRoot: undefined },
           senderId: params.ctx.senderId,
           conversation: {
             channel: "discord",

--- a/extensions/discord/src/monitor/monitor.test.ts
+++ b/extensions/discord/src/monitor/monitor.test.ts
@@ -245,10 +245,7 @@ describe("discord component interactions", () => {
   });
 
   const createGuildComponentContext = (allowFrom: string[]) =>
-    createComponentContext({
-      cfg: { ...createCfg(), commands: { useAccessGroups: true } },
-      allowFrom,
-    });
+    createComponentContext({ cfg: createCfg(), allowFrom });
   const createGuildPluginButton = (allowFrom: string[]) =>
     createDiscordComponentButton(createGuildComponentContext(allowFrom));
 

--- a/extensions/discord/src/monitor/monitor.test.ts
+++ b/extensions/discord/src/monitor/monitor.test.ts
@@ -1,10 +1,19 @@
 // Discord tests cover monitor plugin behavior.
 import { ChannelType } from "discord-api-types/v10";
 import type { DiscordAccountConfig, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { buildPluginBindingApprovalCustomId } from "openclaw/plugin-sdk/conversation-runtime";
+import {
+  buildPluginBindingApprovalCustomId,
+  registerSessionBindingAdapter,
+  type SessionBindingAdapter,
+  type SessionBindingRecord,
+  unregisterSessionBindingAdapter,
+} from "openclaw/plugin-sdk/conversation-runtime";
+import { registerPluginInteractiveHandler } from "openclaw/plugin-sdk/plugin-runtime";
+import { getActivePluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { clearDiscordComponentEntriesForTest } from "../components-registry.test-support.js";
 import type { DiscordComponentEntry, DiscordModalEntry } from "../components.js";
+import type { DiscordInteractiveHandlerContext } from "../interactive-dispatch.js";
 import type {
   ButtonInteraction,
   ComponentData,
@@ -83,13 +92,6 @@ function getLastPluginDispatchCtx(): Record<string, unknown> | undefined {
     "dispatchPluginInteractiveHandler",
   ) as { ctx?: Record<string, unknown> };
   return params?.ctx;
-}
-
-function requireRecord(value: unknown, label: string): Record<string, unknown> {
-  if (!value || typeof value !== "object") {
-    throw new Error(`expected ${label} to be an object`);
-  }
-  return value as Record<string, unknown>;
 }
 
 function firstMockCall(mock: MockWithCalls, label: string): unknown[] {
@@ -242,16 +244,13 @@ describe("discord component interactions", () => {
     ...overrides,
   });
 
+  const createGuildComponentContext = (allowFrom: string[]) =>
+    createComponentContext({
+      cfg: { ...createCfg(), commands: { useAccessGroups: true } },
+      allowFrom,
+    });
   const createGuildPluginButton = (allowFrom: string[]) =>
-    createDiscordComponentButton(
-      createComponentContext({
-        cfg: {
-          commands: { useAccessGroups: true },
-          channels: { discord: { replyToMode: "first" } },
-        } as OpenClawConfig,
-        allowFrom,
-      }),
-    );
+    createDiscordComponentButton(createGuildComponentContext(allowFrom));
 
   const createGuildPluginButtonInteraction = (interactionId: string) =>
     createComponentButtonInteraction({
@@ -264,30 +263,99 @@ describe("discord component interactions", () => {
       guild: { id: "guild-1", name: "Test Guild" } as unknown as ButtonInteraction["guild"],
     });
 
-  async function expectPluginGuildInteractionAuth(params: {
-    allowFrom: string[];
-    interactionId: string;
-    isAuthorizedSender: boolean;
-  }) {
-    registerDiscordComponentEntries({
-      entries: [createButtonEntry({ callbackData: "codex:approve" })],
-      modals: [],
-    });
-    dispatchPluginInteractiveHandlerMock.mockResolvedValue({
-      matched: true,
-      handled: true,
-      duplicate: false,
-    });
+  async function expectPluginGuildInteractionAuth(isAuthorizedSender: boolean) {
+    const pluginId = "qa-discord-interactive-binding";
+    const pluginRoot = "/plugins/qa-discord-interactive-binding";
+    const conversationId = "channel:guild-channel";
+    let binding: SessionBindingRecord | null = {
+      bindingId: pluginId,
+      targetSessionKey: "agent:qa:discord:interactive-binding",
+      targetKind: "session",
+      conversation: { channel: "discord", accountId: "default", conversationId },
+      status: "active",
+      boundAt: 1,
+      metadata: { pluginBindingOwner: "plugin", pluginId, pluginRoot },
+    };
+    const adapter = {
+      channel: "discord",
+      accountId: "default",
+      bind: vi.fn<NonNullable<SessionBindingAdapter["bind"]>>(async (input) => {
+        binding = { ...input, bindingId: pluginId, status: "active", boundAt: 1 };
+        return binding;
+      }),
+      listBySession: () => [],
+      resolveByConversation: vi.fn<SessionBindingAdapter["resolveByConversation"]>((ref) =>
+        binding?.conversation.conversationId === ref.conversationId ? binding : null,
+      ),
+      unbind: vi.fn<NonNullable<SessionBindingAdapter["unbind"]>>(async ({ bindingId }) => {
+        const removed = binding;
+        if (!removed || removed.bindingId !== bindingId) {
+          return [];
+        }
+        binding = null;
+        return [removed];
+      }),
+    } satisfies SessionBindingAdapter;
+    const registry = getActivePluginRegistry();
+    if (!registry) {
+      throw new Error("expected active plugin registry");
+    }
+    registerSessionBindingAdapter(adapter);
+    try {
+      const handler = vi.fn(async (context: DiscordInteractiveHandlerContext) => {
+        expect([
+          context.auth.isAuthorizedSender,
+          (await context.requestConversationBinding()).status,
+          (await context.getCurrentConversationBinding())?.conversationId ?? null,
+          (await context.detachConversationBinding()).removed,
+        ]).toEqual([
+          isAuthorizedSender,
+          isAuthorizedSender ? "bound" : "error",
+          isAuthorizedSender ? conversationId : null,
+          isAuthorizedSender,
+        ]);
+        return { handled: true };
+      });
+      expect(
+        registerPluginInteractiveHandler(
+          pluginId,
+          { channel: "discord", namespace: "qabind", handler: handler as never },
+          { pluginRoot },
+        ).ok,
+      ).toBe(true);
+      registerDiscordComponentEntries({
+        entries: [createButtonEntry({ callbackData: "qabind:refresh" })],
+        modals: [],
+      });
+      dispatchPluginInteractiveHandlerMock.mockImplementation(async (input) => {
+        const actual = await vi.importActual<typeof import("../interactive-dispatch.js")>(
+          "../interactive-dispatch.js",
+        );
+        return await actual.dispatchDiscordPluginInteractiveHandler(input as never);
+      });
 
-    const button = createGuildPluginButton(params.allowFrom);
-    const { interaction } = createGuildPluginButtonInteraction(params.interactionId);
+      const button = createGuildPluginButton(isAuthorizedSender ? ["123456789"] : ["owner-1"]);
+      const { interaction } = createGuildPluginButtonInteraction(
+        `interaction-guild-plugin-${isAuthorizedSender}`,
+      );
 
-    await button.run(interaction, { cid: "btn_1" } as ComponentData);
+      await button.run(interaction, { cid: "btn_1" } as ComponentData);
 
-    expect(dispatchPluginInteractiveHandlerMock).toHaveBeenCalledTimes(1);
-    const auth = requireRecord(getLastPluginDispatchCtx()?.auth, "plugin dispatch auth");
-    expect(auth.isAuthorizedSender).toBe(params.isAuthorizedSender);
-    expect(dispatchReplyMock).not.toHaveBeenCalled();
+      expect(dispatchPluginInteractiveHandlerMock).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledOnce();
+      expect(adapter.bind).toHaveBeenCalledTimes(Number(isAuthorizedSender));
+      expect(adapter.resolveByConversation).toHaveBeenCalledTimes(isAuthorizedSender ? 3 : 0);
+      expect(adapter.unbind).toHaveBeenCalledTimes(Number(isAuthorizedSender));
+      expect(dispatchReplyMock).not.toHaveBeenCalled();
+    } finally {
+      const registrationIndex = registry.interactiveHandlers.findIndex(
+        (entry) => entry.pluginId === pluginId && entry.channel === "discord",
+      );
+      if (registrationIndex >= 0) {
+        registry.interactiveHandlers.splice(registrationIndex, 1);
+      }
+      unregisterSessionBindingAdapter({ channel: "discord", accountId: "default", adapter });
+    }
   }
 
   beforeAll(async () => {
@@ -698,15 +766,7 @@ describe("discord component interactions", () => {
       modals: [createModalEntry()],
     });
 
-    const modal = createDiscordComponentModal(
-      createComponentContext({
-        cfg: {
-          commands: { useAccessGroups: true },
-          channels: { discord: { replyToMode: "first" } },
-        } as OpenClawConfig,
-        allowFrom: params.allowFrom,
-      }),
-    );
+    const modal = createDiscordComponentModal(createGuildComponentContext(params.allowFrom));
     const { interaction, acknowledge } = createModalInteraction({
       rawData: {
         channel_id: "guild-channel",
@@ -766,19 +826,11 @@ describe("discord component interactions", () => {
   });
 
   it("passes false auth to plugin Discord interactions for non-allowlisted guild users", async () => {
-    await expectPluginGuildInteractionAuth({
-      allowFrom: ["owner-1"],
-      interactionId: "interaction-guild-plugin-1",
-      isAuthorizedSender: false,
-    });
+    await expectPluginGuildInteractionAuth(false);
   });
 
   it("passes true auth to plugin Discord interactions for allowlisted guild users", async () => {
-    await expectPluginGuildInteractionAuth({
-      allowFrom: ["123456789"],
-      interactionId: "interaction-guild-plugin-2",
-      isAuthorizedSender: true,
-    });
+    await expectPluginGuildInteractionAuth(true);
   });
 
   it("routes plugin Discord interactions in group DMs by channel id instead of sender id", async () => {

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -19,6 +19,12 @@ import {
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { mockPinnedHostnameResolution } from "openclaw/plugin-sdk/test-env";
 import { createOpenClawTestState, type OpenClawTestState } from "openclaw/plugin-sdk/test-state";
+import {
+  registerSessionBindingAdapter,
+  type SessionBindingAdapter,
+  type SessionBindingRecord,
+  unregisterSessionBindingAdapter,
+} from "openclaw/plugin-sdk/thread-bindings-runtime";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildTelegramApprovalCallbackData } from "./approval-callback-data.js";
 import type { TelegramBotDeps } from "./bot-deps.js";
@@ -224,13 +230,18 @@ function createTelegramPluginCallbackHandler(params: {
   handler: TelegramInteractiveHandlerRegistration["handler"];
   namespace?: string;
   pluginId?: string;
+  pluginRoot?: string;
   config?: NonNullable<Parameters<typeof createTelegramBot>[0]["config"]>;
 }) {
-  registerPluginInteractiveHandler(params.pluginId ?? "codex-plugin", {
-    channel: "telegram",
-    namespace: params.namespace ?? "codexapp",
-    handler: params.handler as never,
-  });
+  registerPluginInteractiveHandler(
+    params.pluginId ?? "codex-plugin",
+    {
+      channel: "telegram",
+      namespace: params.namespace ?? "codexapp",
+      handler: params.handler as never,
+    },
+    params.pluginRoot ? { pluginRoot: params.pluginRoot } : undefined,
+  );
   createTelegramBot({
     token: "tok",
     config: params.config ?? {
@@ -5213,9 +5224,63 @@ describe("createTelegramBot", () => {
       expectedAuth: true,
     },
   ])("$name", async ({ sender, messageId, expectedAuth }) => {
-    let observedAuth: TelegramInteractiveHandlerContext["auth"] | undefined;
-    const handler = vi.fn(async ({ auth }: TelegramInteractiveHandlerContext) => {
-      observedAuth = auth;
+    const pluginId = "qa-telegram-interactive-binding";
+    const pluginRoot = "/plugins/qa-telegram-interactive-binding";
+    const conversationId = "-100999:topic:99";
+    let binding: SessionBindingRecord | null = null;
+    const bind = vi.fn<NonNullable<SessionBindingAdapter["bind"]>>(async (input) => {
+      binding = {
+        bindingId: "qa-telegram-interactive-binding",
+        targetSessionKey: input.targetSessionKey,
+        targetKind: input.targetKind,
+        conversation: input.conversation,
+        status: "active",
+        boundAt: 1,
+        ...(input.metadata ? { metadata: input.metadata } : {}),
+      };
+      return binding;
+    });
+    const resolveByConversation = vi.fn<SessionBindingAdapter["resolveByConversation"]>((ref) =>
+      binding?.conversation.conversationId === ref.conversationId ? binding : null,
+    );
+    const unbind = vi.fn<NonNullable<SessionBindingAdapter["unbind"]>>(async (input) => {
+      if (!binding || input.bindingId !== binding.bindingId) {
+        return [];
+      }
+      const removed = binding;
+      binding = null;
+      return [removed];
+    });
+    const adapter: SessionBindingAdapter = {
+      channel: "telegram",
+      accountId: "default",
+      capabilities: { bindSupported: true, unbindSupported: true, placements: ["current"] },
+      bind,
+      listBySession: () => [],
+      resolveByConversation,
+      unbind,
+    };
+    let observed:
+      | {
+          auth: TelegramInteractiveHandlerContext["auth"];
+          request: Awaited<
+            ReturnType<TelegramInteractiveHandlerContext["requestConversationBinding"]>
+          >;
+          current: Awaited<
+            ReturnType<TelegramInteractiveHandlerContext["getCurrentConversationBinding"]>
+          >;
+          detach: Awaited<
+            ReturnType<TelegramInteractiveHandlerContext["detachConversationBinding"]>
+          >;
+        }
+      | undefined;
+    const handler = vi.fn(async (context: TelegramInteractiveHandlerContext) => {
+      observed = {
+        auth: context.auth,
+        request: await context.requestConversationBinding({ summary: "Refresh this topic" }),
+        current: await context.getCurrentConversationBinding(),
+        detach: await context.detachConversationBinding(),
+      };
       return { handled: true };
     });
 
@@ -5239,23 +5304,64 @@ describe("createTelegramBot", () => {
     const callbackHandler = createTelegramPluginCallbackHandler({
       handler: handler as never,
       config,
+      pluginId,
+      pluginRoot,
     });
-
-    await callbackHandler(
-      createTelegramCallbackContext({
-        id: `cbq-plugin-auth-${expectedAuth}`,
-        data: "codexapp:resume:thread-1",
-        from: sender,
-        message: {
-          chat: { id: -100999, type: "supergroup", title: "Test Group" },
-          message_id: messageId,
-          text: "Select a thread",
+    registerSessionBindingAdapter(adapter);
+    try {
+      await bind({
+        targetSessionKey: "agent:qa:telegram:interactive-binding",
+        targetKind: "session",
+        conversation: {
+          channel: "telegram",
+          accountId: "default",
+          conversationId,
+          parentConversationId: "-100999",
         },
-      }),
-    );
+        metadata: { pluginBindingOwner: "plugin", pluginId, pluginRoot },
+      });
+      bind.mockClear();
+      resolveByConversation.mockClear();
+      unbind.mockClear();
 
-    expect(handler).toHaveBeenCalledOnce();
-    expect(observedAuth?.isAuthorizedSender).toBe(expectedAuth);
+      await callbackHandler(
+        createTelegramCallbackContext({
+          id: `cbq-plugin-auth-${expectedAuth}`,
+          data: "codexapp:resume:thread-1",
+          from: sender,
+          message: {
+            chat: { id: -100999, type: "supergroup", title: "Test Group", is_forum: true },
+            message_id: messageId,
+            message_thread_id: 99,
+            is_topic_message: true,
+            text: "Select a thread",
+          },
+        }),
+      );
+
+      expect(handler).toHaveBeenCalledOnce();
+      expect(observed?.auth.isAuthorizedSender).toBe(expectedAuth);
+      if (expectedAuth) {
+        expect(observed?.request).toMatchObject({
+          status: "bound",
+          binding: { conversationId, threadId: 99 },
+        });
+        expect(observed?.current).toMatchObject({ conversationId, threadId: 99 });
+        expect(observed?.detach).toEqual({ removed: true });
+        expect(bind).toHaveBeenCalledOnce();
+        expect(resolveByConversation).toHaveBeenCalled();
+        expect(unbind).toHaveBeenCalledOnce();
+      } else {
+        expect(observed?.request).toMatchObject({ status: "error" });
+        expect(observed?.current).toBeNull();
+        expect(observed?.detach).toEqual({ removed: false });
+        expect(bind).not.toHaveBeenCalled();
+        expect(resolveByConversation).not.toHaveBeenCalled();
+        expect(unbind).not.toHaveBeenCalled();
+      }
+    } finally {
+      unregisterSessionBindingAdapter({ channel: "telegram", accountId: "default", adapter });
+    }
   });
 
   it("passes true command auth to Telegram plugin callbacks for access-group DM senders", async () => {

--- a/extensions/telegram/src/interactive-dispatch.ts
+++ b/extensions/telegram/src/interactive-dispatch.ts
@@ -117,7 +117,14 @@ export async function dispatchTelegramPluginInteractiveHandler(params: {
         },
         respond: params.respond,
         ...createInteractiveConversationBindingHelpers({
-          registration,
+          // Untrusted callbacks may reach their plugin, but never inherit conversation-binding authority.
+          registration:
+            handlerContext.auth?.isAuthorizedSender &&
+            handlerContext.senderId?.trim() &&
+            handlerContext.accountId?.trim() &&
+            handlerContext.conversationId?.trim()
+              ? registration
+              : { ...registration, pluginRoot: undefined },
           senderId: handlerContext.senderId,
           conversation: {
             channel: "telegram",


### PR DESCRIPTION
## Summary

- Prevent unauthorized Discord and Telegram interactive callbacks from creating, reading, or detaching privileged conversation bindings.
- Preserve ordinary plugin callback execution, all existing public plugin SDK contracts, and authenticated guild/forum/DM behavior.

## Root cause and transport ownership

Both transports deliberately dispatch registered plugin callbacks even when `isAuthorizedSender=false`; existing channel integrations rely on this behavior. However, both transport owners also passed the privileged plugin registration root to the shipped generic conversation-binding helper. An unapproved Discord guild member or Telegram group user could therefore request an automatically approved binding, inspect it, and detach it despite being unauthorized.

Each existing transport owner now withholds only privileged binding authority unless its own authenticated sender, account, and conversation identity are present. The public callback, response behavior, shared external plugin SDK helper, channel routing, and Telegram topic identity remain unchanged. This exactly matches the already-landed Slack owner repair in #118662.

## Actual registered-handler proof

Before repair, real registered Discord and Telegram handlers reached the actual shared binding owner and produced `{"authorized":false,"handlerInvoked":true,"requestStatus":"bound","readReturnedBinding":true,"detachRemoved":true}`.

After repair, both unauthorized transports still invoke their ordinary plugin handler but return request error/read null/detach false with **zero privileged adapter reads or writes**. Authorized Discord guild and Telegram forum/DM controls continue to bind/read/detach with their real canonical identities.

- Existing actual registered ingress → dispatcher → generic helper → real binding owner → in-memory adapter: **5/5 passing**, covering both false/true guild/group cases plus authorized DM.
- Formatting, targeted lint, effective 1,000-line test limit, and `git diff --check`: clean.
- Fresh independent structured Sol/high security review: **no findings, confidence 0.94**.
- Production delta **+14 lines**, split equally across the two authoritative transport owners; no public SDK/config/schema changes.


## Maintainer proof decision and exact-head coverage disclosure

The immediately preceding commit `4d359710d677953d2f9cafe679abadfb730567ed` executed five actual registered Discord/Telegram interaction regressions: four authorized/unauthorized conversation-binding owner paths and one separate Telegram direct-message authorization case. Reviewed head `d97e86833207c15cef3c2cd8f88f732c293edcf5` is its direct child and changes only the Discord test fixture (+1/-4) to remove a retired configuration key. The Telegram production-dispatch Git blob remains exactly `00b8162c517e8cfa397307c074511a31dc3c9e83`; its test blob remains exactly `297c6e61efa2c5b5382ee2a350e674aecb62e4e4`. The Discord production-dispatch blob also remains unchanged, and both Discord authorization-owner cases passed again on the reviewed head.

Exact-head hosted CI and Telegram help/tools/context/status smoke are green. Important coverage caveat: the compact hosted Node planner excludes extension projects, so those CI jobs do **not** execute Telegram callback/binding owner regressions. Attempts to rerun the Telegram suite in the isolated linked worktree failed during setup/collection before any case executed (121 pending; two suite setup/cleanup errors); no live Telegram channel was contacted. The installed-worktree alias points to a missing linked-worktree dependency; its attempted in-memory resolver adjustment did not make collection succeed. This is not represented as an exact-head Telegram pass.

**Explicit maintainer decision:** accept the actual parent-commit Telegram owner proof because the reviewed child contains byte-identical Telegram production and test objects, combined with exact-head Discord owner proof, green general Telegram smoke, full hosted guards/types/security checks, and the candid isolated-environment/live-channel limitations above.
