### PR TITLE
test(qa): prove real yielded-child completion and channel delivery

### DIFF
--- a/extensions/qa-lab/src/live-scenario-timeouts.test.ts
+++ b/extensions/qa-lab/src/live-scenario-timeouts.test.ts
@@ -1,13 +1,351 @@
 import { describe, expect, it } from "vitest";
+import { createQaBusState } from "./bus-state.js";
 import { resolveQaLiveTurnTimeoutMs } from "./live-timeout.js";
 import { readQaScenarioById } from "./scenario-catalog.js";
 import { requireFlowScenario } from "./scenario-catalog.test-utils.js";
+import { runLoadedScenarioFlow } from "./scenario-flow-runner.test-support.js";
+
+const completionParentSessionKey = "agent:qa:qa-channel:direct:alice";
+const completionChildSessionKey = "agent:qa:subagent:completion-child";
+const completionAttemptStartedAt = 1_000;
+const completionChildEndedAt = completionAttemptStartedAt + 10;
+const completionParentTranscriptCursor = 7;
+const completionProofMarker = "ISSUE109025_COMPLETION_EXEC_OK:fixture-marker";
+const completionSpawnToolCallId = "completion-spawn";
+const completionYieldToolCallId = "completion-yield";
+const completionExecToolCallId = "completion-exec";
+
+type CompletionSuccessfulToolEvent = {
+  name: string;
+  timestamp: number;
+  toolCallId: string;
+};
+
+type CompletionTaskFixture = {
+  childSessionKey?: string;
+  createdAt: number;
+  deliveryStatus: "delivered" | "pending";
+  endedAt?: number;
+  label: string;
+  requesterSessionKey: string;
+  status: "running" | "succeeded";
+};
+
+type CompletionParentReplyFixture = {
+  includeExecToolCall?: boolean;
+  mirror?: "delivery" | "delivery-marker" | "gateway-injected" | "message-tool";
+  phase?: "commentary" | "final_answer";
+  providerIdentity?: boolean;
+  role?: "assistant" | "toolResult";
+  text: string;
+};
+
+type CompletionParentOutboundFixture = {
+  accountId?: string;
+  conversationId?: string;
+  text?: string;
+};
+
+const deliveredCompletionTask: CompletionTaskFixture = {
+  childSessionKey: completionChildSessionKey,
+  createdAt: completionAttemptStartedAt + 1,
+  deliveryStatus: "delivered",
+  endedAt: completionChildEndedAt,
+  label: "issue-109025-completion-child-00000000",
+  requesterSessionKey: completionParentSessionKey,
+  status: "succeeded",
+};
+
+function runCompletionPolicyFlow(
+  params: {
+    childFinalText?: string;
+    delayedParentReplyHistoryReads?: number;
+    parentExecCompletedAt?: number;
+    parentExecCommand?: string;
+    parentExecToolCallId?: string;
+    parentOutbound?: CompletionParentOutboundFixture | null;
+    parentReply?: CompletionParentReplyFixture | null;
+    parentSpawnCompletedAt?: number;
+    parentToolCalls?: Record<string, number>;
+    parentYieldCompletedAt?: number;
+    priorSuccessfulParentToolCalls?: Record<string, number>;
+    priorParentOutbound?: CompletionParentOutboundFixture;
+    priorRequesterInbound?: boolean;
+    proofCompletionText?: string;
+    proofModifiedAt?: number;
+    successfulChildReads?: number;
+    successfulParentToolEvents?: CompletionSuccessfulToolEvent[];
+    successfulParentToolCalls?: Record<string, number>;
+    taskLookupError?: Error;
+    tasks?: CompletionTaskFixture[];
+  } = {},
+) {
+  const state = createQaBusState();
+  const gatewayCalls: Array<{ method: string; request: { sessionKey?: string } }> = [];
+  const taskCommands: unknown[] = [];
+  const transcriptSessionKeys: string[] = [];
+  const transcriptReadOptions: unknown[] = [];
+  const workspaceWrites: Array<{ content: string; filePath: string }> = [];
+  let generatedUuidCount = 0;
+  const parentToolCalls = params.parentToolCalls ?? {
+    sessions_spawn: 1,
+    sessions_yield: 1,
+    exec: 1,
+  };
+  const successfulParentToolCalls = params.successfulParentToolCalls ?? parentToolCalls;
+  const successfulParentToolEvents = params.successfulParentToolEvents ?? [
+    {
+      name: "sessions_spawn",
+      timestamp: params.parentSpawnCompletedAt ?? completionAttemptStartedAt + 1,
+      toolCallId: completionSpawnToolCallId,
+    },
+    {
+      name: "sessions_yield",
+      timestamp: params.parentYieldCompletedAt ?? completionChildEndedAt - 1,
+      toolCallId: completionYieldToolCallId,
+    },
+    {
+      name: "exec",
+      timestamp: params.parentExecCompletedAt ?? completionChildEndedAt + 1,
+      toolCallId: completionExecToolCallId,
+    },
+  ];
+  const successfulChildReads = params.successfulChildReads ?? 4;
+  const parentReply =
+    params.parentReply === undefined
+      ? { phase: "final_answer" as const, text: completionProofMarker }
+      : params.parentReply;
+
+  const result = runLoadedScenarioFlow("issue-109025-completion-policy-live", {
+    state,
+    onWaitForOutboundMessage: ({ state: currentState }) => {
+      if (
+        params.parentOutbound === null ||
+        !parentReply ||
+        parentReply.role === "toolResult" ||
+        parentReply.phase === "commentary" ||
+        parentReply.mirror ||
+        parentReply.includeExecToolCall
+      ) {
+        return;
+      }
+      currentState.addOutboundMessage({
+        accountId: params.parentOutbound?.accountId ?? "qa-channel",
+        to: `dm:${params.parentOutbound?.conversationId ?? "issue-109025-completion"}`,
+        text: params.parentOutbound?.text ?? parentReply.text,
+      });
+    },
+    api: {
+      Date: { now: () => completionAttemptStartedAt },
+      env: {
+        providerMode: "live-frontier",
+        cfg: { session: {} },
+        gateway: {
+          workspaceDir: "/qa",
+          call: async (method: string, request: { sessionKey?: string }) => {
+            gatewayCalls.push({ method, request });
+            if (method !== "chat.history" || request.sessionKey !== completionParentSessionKey) {
+              throw new Error(`unexpected completion gateway call: ${method}`);
+            }
+            const inboundText =
+              state
+                .getSnapshot()
+                .messages.findLast(
+                  (message) =>
+                    message.direction === "inbound" &&
+                    message.conversation.id === "issue-109025-completion",
+                )?.text ?? "";
+            const commandTemplate = inboundText.match(/run this exact command: ([^\n]+)/u)?.[1];
+            const childMarker = workspaceWrites.at(-1)?.content.trim();
+            if (!commandTemplate || !childMarker) {
+              throw new Error("completion fixture is missing its command or child marker");
+            }
+            const execToolCall = {
+              type: "toolCall",
+              id: params.parentExecToolCallId ?? completionExecToolCallId,
+              name: "exec",
+              arguments: {
+                command:
+                  params.parentExecCommand ??
+                  commandTemplate.replace("__CHILD_COMPLETION_TOKEN__", childMarker),
+              },
+            };
+            const parentReplyIsVisible =
+              parentReply && gatewayCalls.length > (params.delayedParentReplyHistoryReads ?? 0);
+            return {
+              messages: [
+                {
+                  role: "assistant",
+                  content: [execToolCall],
+                },
+                ...(parentReplyIsVisible
+                  ? [
+                      {
+                        role: parentReply.role ?? "assistant",
+                        ...(parentReply.phase ? { phase: parentReply.phase } : {}),
+                        ...(parentReply.mirror === "delivery"
+                          ? { model: "delivery-mirror", provider: "openclaw" }
+                          : {}),
+                        ...(parentReply.mirror === "delivery-marker"
+                          ? { openclawDeliveryMirror: { kind: "channel-final" } }
+                          : {}),
+                        ...(parentReply.mirror === "gateway-injected"
+                          ? { model: "gateway-injected", provider: "openclaw" }
+                          : {}),
+                        ...(parentReply.mirror === "message-tool"
+                          ? { openclawMessageToolMirror: { toolName: "message" } }
+                          : {}),
+                        ...(parentReply.providerIdentity
+                          ? {
+                              __openclaw: { mirrorIdentity: "completion:assistant" },
+                              model: "gpt-5.4",
+                              provider: "openai",
+                            }
+                          : {}),
+                        content: [
+                          {
+                            type: "text",
+                            text: parentReply.text,
+                            ...(parentReply.phase
+                              ? {
+                                  textSignature: JSON.stringify({
+                                    v: 1,
+                                    id: "completion-reply",
+                                    phase: parentReply.phase,
+                                  }),
+                                }
+                              : {}),
+                          },
+                          ...(parentReply.includeExecToolCall ? [execToolCall] : []),
+                        ],
+                      },
+                    ]
+                  : []),
+              ],
+            };
+          },
+        },
+      },
+      buildAgentSessionKey: () => completionParentSessionKey,
+      path: { join: (...parts: string[]) => parts.join("/") },
+      randomUUID: () => {
+        const uuid = `00000000-0000-4000-8000-${String(generatedUuidCount).padStart(12, "0")}`;
+        generatedUuidCount += 1;
+        return uuid;
+      },
+      fs: {
+        readFile: async () => {
+          const childMarker = workspaceWrites.at(-1)?.content.trim() ?? "";
+          const completionText =
+            params.proofCompletionText === undefined ||
+            params.proofCompletionText === "__DELIVERED_CHILD_TOKEN__"
+              ? childMarker
+              : params.proofCompletionText;
+          return `${completionProofMarker}\n${completionText}\n`;
+        },
+        stat: async () => ({ mtimeMs: params.proofModifiedAt ?? completionChildEndedAt + 1 }),
+        writeFile: async (filePath: string, content: string) => {
+          workspaceWrites.push({ content, filePath });
+        },
+      },
+      readGatewayLogs: () =>
+        `${state
+          .getSnapshot()
+          .messages.map((message) => message.text)
+          .join("\n")}\n${completionProofMarker}`,
+      readSessionTranscriptSummary: async (
+        _env: unknown,
+        sessionKey: string,
+        options?: { afterEventCursor?: number; allowEmpty?: boolean },
+      ) => {
+        transcriptSessionKeys.push(sessionKey);
+        transcriptReadOptions.push(options);
+        if (sessionKey === completionParentSessionKey) {
+          if (options?.allowEmpty) {
+            if (params.priorRequesterInbound) {
+              state.addInboundMessage({
+                accountId: "qa-channel",
+                conversation: { id: "previous-requester", kind: "direct" },
+                senderId: "previous-requester",
+                senderName: "Previous requester",
+                text: "old inbound turn",
+              });
+            }
+            if (params.priorParentOutbound) {
+              state.addOutboundMessage({
+                accountId: params.priorParentOutbound.accountId ?? "qa-channel",
+                to: `dm:${params.priorParentOutbound.conversationId ?? "issue-109025-completion"}`,
+                text: params.priorParentOutbound.text ?? completionProofMarker,
+              });
+            }
+            return {
+              assistantToolCallCounts: params.priorSuccessfulParentToolCalls ?? {},
+              eventCursor: completionParentTranscriptCursor,
+              successfulToolCallCounts: params.priorSuccessfulParentToolCalls ?? {},
+            };
+          }
+          return {
+            assistantToolCallCounts: parentToolCalls,
+            finalText: parentReply?.role !== "toolResult" ? (parentReply?.text ?? "") : "",
+            successfulToolCallCounts:
+              options?.afterEventCursor === completionParentTranscriptCursor
+                ? successfulParentToolCalls
+                : { ...params.priorSuccessfulParentToolCalls, ...successfulParentToolCalls },
+            successfulToolCallEvents: successfulParentToolEvents,
+          };
+        }
+        if (sessionKey === completionChildSessionKey) {
+          const terminalFileContents = workspaceWrites.at(-1)?.content.trim();
+          return {
+            assistantToolCallCounts: { read: successfulChildReads },
+            successfulToolCallCounts: { read: successfulChildReads },
+            finalText:
+              params.childFinalText ??
+              (terminalFileContents?.startsWith("CHILD_DONE:")
+                ? terminalFileContents
+                : "CHILD_DONE"),
+          };
+        }
+        throw new Error(`unexpected completion transcript session: ${sessionKey}`);
+      },
+      runQaCli: async (_env: unknown, command: unknown) => {
+        taskCommands.push(command);
+        if (params.taskLookupError) {
+          throw params.taskLookupError;
+        }
+        return { tasks: params.tasks ?? [deliveredCompletionTask] };
+      },
+    },
+  });
+
+  return {
+    gatewayCalls,
+    result,
+    state,
+    taskCommands,
+    transcriptReadOptions,
+    transcriptSessionKeys,
+    workspaceWrites,
+  };
+}
 
 describe("live subagent scenario timeouts", () => {
   it.each([
     {
       id: "issue-109025-completion-policy-live",
       savedEvidence: "expectedFinalMarker",
+    },
+    {
+      id: "issue-109025-completion-policy-live",
+      savedEvidence: "completedChild",
+    },
+    {
+      id: "issue-109025-completion-policy-live",
+      savedEvidence: "parentTranscript",
+    },
+    {
+      id: "issue-109025-completion-policy-live",
+      savedEvidence: "parentHistory",
     },
     {
       id: "issue-109025-sender-policy-live",
@@ -36,6 +374,41 @@ describe("live subagent scenario timeouts", () => {
     });
   });
 
+  it("checkpoints outbound-only history before waiting for the current requester delivery", () => {
+    const scenario = requireFlowScenario(readQaScenarioById("issue-109025-completion-policy-live"));
+    const actions = scenario.execution.flow?.steps.flatMap((step) => step.actions) ?? [];
+    const checkpoint = actions.find(
+      (action) =>
+        typeof action === "object" &&
+        action !== null &&
+        "set" in action &&
+        action.set === "outboundStartIndex",
+    );
+    const deliveryWait = actions.find(
+      (action) =>
+        typeof action === "object" &&
+        action !== null &&
+        "call" in action &&
+        action.call === "waitForOutboundMessage" &&
+        "saveAs" in action &&
+        action.saveAs === "parentOutbound",
+    );
+
+    expect(checkpoint).toMatchObject({
+      value: {
+        expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length",
+      },
+    });
+    expect(deliveryWait).toMatchObject({
+      args: [
+        { ref: "state" },
+        expect.any(Object),
+        { expr: "liveTurnTimeoutMs(env, 60000)" },
+        { sinceIndex: { ref: "outboundStartIndex" } },
+      ],
+    });
+  });
+
   it("applies the GPT-5 live floor without extending the mock fallback", () => {
     expect(
       resolveQaLiveTurnTimeoutMs(
@@ -57,5 +430,466 @@ describe("live subagent scenario timeouts", () => {
         60_000,
       ),
     ).toBe(60_000);
+  });
+
+  it("rejects echoed completion text when no child was actually spawned", async () => {
+    const { result, state } = runCompletionPolicyFlow({
+      parentToolCalls: { sessions_yield: 1, exec: 1 },
+      tasks: [],
+    });
+
+    await expect(result).rejects.toThrow("parent did not spawn a subagent");
+    expect(state.getSnapshot().messages[0]?.text).toContain("CHILD_DONE");
+  });
+
+  it.each([
+    { reason: "missing child task", tasks: [] },
+    {
+      reason: "stale child task",
+      tasks: [{ ...deliveredCompletionTask, createdAt: completionAttemptStartedAt - 1 }],
+    },
+    {
+      reason: "different child label",
+      tasks: [{ ...deliveredCompletionTask, label: "another-child" }],
+    },
+    {
+      reason: "different requester session",
+      tasks: [{ ...deliveredCompletionTask, requesterSessionKey: "agent:qa:someone-else" }],
+    },
+    {
+      reason: "unfinished child task",
+      tasks: [{ ...deliveredCompletionTask, status: "running" as const }],
+    },
+    {
+      reason: "undelivered child completion",
+      tasks: [{ ...deliveredCompletionTask, deliveryStatus: "pending" as const }],
+    },
+    {
+      reason: "missing child session identity",
+      tasks: [{ ...deliveredCompletionTask, childSessionKey: undefined }],
+    },
+    {
+      reason: "missing child completion timestamp",
+      tasks: [{ ...deliveredCompletionTask, endedAt: undefined }],
+    },
+  ])("rejects a $reason despite matching Gateway completion text", async ({ tasks }) => {
+    await expect(runCompletionPolicyFlow({ tasks }).result).rejects.toThrow(
+      "test condition was not met",
+    );
+  });
+
+  it.each<{
+    failure: string;
+    parentToolCalls: Record<string, number>;
+    tool: string;
+  }>([
+    {
+      tool: "sessions_spawn",
+      parentToolCalls: { sessions_yield: 1, exec: 1 },
+      failure: "parent did not spawn a subagent",
+    },
+    {
+      tool: "sessions_yield",
+      parentToolCalls: { sessions_spawn: 1, exec: 1 },
+      failure: "parent did not yield before completion",
+    },
+    {
+      tool: "exec",
+      parentToolCalls: { sessions_spawn: 1, sessions_yield: 1 },
+      failure: "parent did not execute the completion command",
+    },
+  ])(
+    "rejects completion without a real parent $tool call",
+    async ({ failure, parentToolCalls }) => {
+      await expect(runCompletionPolicyFlow({ parentToolCalls }).result).rejects.toThrow(failure);
+    },
+  );
+
+  it.each<{
+    failure: string;
+    successfulParentToolCalls: Record<string, number>;
+    tool: string;
+  }>([
+    {
+      tool: "sessions_spawn",
+      successfulParentToolCalls: { sessions_yield: 1, exec: 1 },
+      failure: "parent did not spawn a subagent",
+    },
+    {
+      tool: "sessions_yield",
+      successfulParentToolCalls: { sessions_spawn: 1, exec: 1 },
+      failure: "parent did not yield before completion",
+    },
+    {
+      tool: "exec",
+      successfulParentToolCalls: { sessions_spawn: 1, sessions_yield: 1 },
+      failure: "parent did not execute the completion command",
+    },
+  ])("rejects an attempted but unsuccessful parent $tool", async (fixture) => {
+    await expect(runCompletionPolicyFlow(fixture).result).rejects.toThrow(fixture.failure);
+  });
+
+  it.each<{
+    parentReply: CompletionParentReplyFixture | null;
+    reason: string;
+  }>([
+    { reason: "no final requester reply", parentReply: null },
+    {
+      reason: "only the exec tool result",
+      parentReply: { role: "toolResult", text: completionProofMarker },
+    },
+    {
+      reason: "commentary instead of a final answer",
+      parentReply: { phase: "commentary", text: completionProofMarker },
+    },
+    {
+      reason: "commentary attached to another exec tool call",
+      parentReply: {
+        includeExecToolCall: true,
+        phase: "commentary",
+        text: completionProofMarker,
+      },
+    },
+    {
+      reason: "a final answer with the wrong marker",
+      parentReply: { phase: "final_answer", text: `${completionProofMarker}-wrong` },
+    },
+    {
+      reason: "a delivery-mirror bookkeeping row",
+      parentReply: { mirror: "delivery", phase: "final_answer", text: completionProofMarker },
+    },
+    {
+      reason: "a delivery-mirror marker without provider provenance",
+      parentReply: {
+        mirror: "delivery-marker",
+        phase: "final_answer",
+        text: completionProofMarker,
+      },
+    },
+    {
+      reason: "a gateway-injected bookkeeping row",
+      parentReply: {
+        mirror: "gateway-injected",
+        phase: "final_answer",
+        text: completionProofMarker,
+      },
+    },
+    {
+      reason: "a message-tool mirror",
+      parentReply: { mirror: "message-tool", phase: "final_answer", text: completionProofMarker },
+    },
+  ])("rejects exec output with $reason", async ({ parentReply }) => {
+    await expect(runCompletionPolicyFlow({ parentReply }).result).rejects.toThrow(
+      "test condition was not met",
+    );
+  });
+
+  it.each<{
+    parentOutbound: CompletionParentOutboundFixture | null;
+    reason: string;
+  }>([
+    { reason: "no outbound message", parentOutbound: null },
+    {
+      reason: "the wrong requester conversation",
+      parentOutbound: { conversationId: "someone-else" },
+    },
+    {
+      reason: "a different final marker",
+      parentOutbound: { text: `${completionProofMarker}-wrong` },
+    },
+    {
+      reason: "the wrong QA channel account",
+      parentOutbound: { accountId: "another-account" },
+    },
+  ])("rejects a real final requester reply with $reason", async ({ parentOutbound }) => {
+    await expect(runCompletionPolicyFlow({ parentOutbound }).result).rejects.toThrow(
+      "waiting for outbound marker",
+    );
+  });
+
+  it("does not reuse a matching outbound reply from before the current inbound turn", async () => {
+    await expect(
+      runCompletionPolicyFlow({ parentOutbound: null, priorParentOutbound: {} }).result,
+    ).rejects.toThrow("waiting for outbound marker");
+  });
+
+  it("does not borrow successful tools from a previous requester turn", async () => {
+    const { result } = runCompletionPolicyFlow({
+      priorSuccessfulParentToolCalls: { sessions_yield: 1, exec: 1 },
+      successfulParentToolCalls: { sessions_spawn: 1 },
+    });
+
+    await expect(result).rejects.toThrow("parent did not yield before completion");
+  });
+
+  it("rejects an exec proof written before the child actually completed", async () => {
+    await expect(
+      runCompletionPolicyFlow({ proofModifiedAt: completionChildEndedAt - 1 }).result,
+    ).rejects.toThrow("completion command ran before the child finished");
+  });
+
+  it("rejects a parent that yielded only after the child had already completed", async () => {
+    await expect(
+      runCompletionPolicyFlow({ parentYieldCompletedAt: completionChildEndedAt + 1 }).result,
+    ).rejects.toThrow("parent did not successfully yield before child completion");
+  });
+
+  it("rejects a yield result that predates the successful spawn", async () => {
+    await expect(
+      runCompletionPolicyFlow({
+        parentSpawnCompletedAt: completionChildEndedAt - 1,
+        parentYieldCompletedAt: completionChildEndedAt - 2,
+      }).result,
+    ).rejects.toThrow("parent successful tool timeline was not chronological");
+  });
+
+  it("rejects an exec result that predates child completion", async () => {
+    await expect(
+      runCompletionPolicyFlow({ parentExecCompletedAt: completionChildEndedAt - 1 }).result,
+    ).rejects.toThrow("parent successful tool timeline was not chronological");
+  });
+
+  it("rejects a missing authenticated successful yield timestamp", async () => {
+    await expect(
+      runCompletionPolicyFlow({
+        successfulParentToolEvents: [
+          {
+            name: "sessions_spawn",
+            timestamp: completionAttemptStartedAt + 1,
+            toolCallId: completionSpawnToolCallId,
+          },
+          {
+            name: "exec",
+            timestamp: completionChildEndedAt + 1,
+            toolCallId: completionExecToolCallId,
+          },
+        ],
+      }).result,
+    ).rejects.toThrow("parent successful tool timeline was incomplete");
+  });
+
+  it("rejects a non-finite authenticated successful yield timestamp", async () => {
+    await expect(
+      runCompletionPolicyFlow({ parentYieldCompletedAt: Number.NaN }).result,
+    ).rejects.toThrow("parent successful tool timeline was incomplete");
+  });
+
+  it("rejects successful parent results persisted outside spawn-yield-exec order", async () => {
+    await expect(
+      runCompletionPolicyFlow({
+        successfulParentToolEvents: [
+          {
+            name: "sessions_spawn",
+            timestamp: completionAttemptStartedAt + 1,
+            toolCallId: completionSpawnToolCallId,
+          },
+          {
+            name: "exec",
+            timestamp: completionChildEndedAt + 1,
+            toolCallId: completionExecToolCallId,
+          },
+          {
+            name: "sessions_yield",
+            timestamp: completionChildEndedAt - 1,
+            toolCallId: completionYieldToolCallId,
+          },
+        ],
+      }).result,
+    ).rejects.toThrow("parent successful tool timeline was incomplete");
+  });
+
+  it("rejects a visible exec tool call that does not match the successful result identity", async () => {
+    await expect(
+      runCompletionPolicyFlow({ parentExecToolCallId: "another-exec-call" }).result,
+    ).rejects.toThrow("parent exec did not use the exact delivered-completion command");
+  });
+
+  it.each([
+    { reason: "missing", proofCompletionText: "" },
+    { reason: "guessed", proofCompletionText: "CHILD_DONE:guessed-before-delivery" },
+  ])(
+    "rejects premature parent exec when its proof contains a $reason completion token",
+    async ({ proofCompletionText }) => {
+      await expect(runCompletionPolicyFlow({ proofCompletionText }).result).rejects.toThrow(
+        "completion proof did not contain the delivered child marker",
+      );
+    },
+  );
+
+  it("rejects inline filesystem discovery even when the exec proof forges the child marker", async () => {
+    await expect(
+      runCompletionPolicyFlow({
+        parentExecCommand: `node -e 'require("node:fs").readFileSync("guessed-chain")'`,
+        proofCompletionText: "__DELIVERED_CHILD_TOKEN__",
+      }).result,
+    ).rejects.toThrow("parent exec did not use the exact delivered-completion command");
+  });
+
+  it.each(["read", "sessions_history"])(
+    "rejects an alternate parent %s tool that could discover the child marker",
+    async (tool) => {
+      await expect(
+        runCompletionPolicyFlow({
+          successfulParentToolCalls: { sessions_spawn: 1, sessions_yield: 1, exec: 1, [tool]: 1 },
+        }).result,
+      ).rejects.toThrow("parent used an unexpected successful tool");
+    },
+  );
+
+  it.each(["sessions_yield", "exec"])(
+    "rejects repeated successful parent %s calls",
+    async (tool) => {
+      await expect(
+        runCompletionPolicyFlow({
+          successfulParentToolCalls: { sessions_spawn: 1, sessions_yield: 1, exec: 1, [tool]: 2 },
+        }).result,
+      ).rejects.toThrow(`parent did not call ${tool} exactly once`);
+    },
+  );
+
+  it("surfaces task snapshot failures without converting them into retry timeouts", async () => {
+    await expect(
+      runCompletionPolicyFlow({ taskLookupError: new Error("durable task snapshot unavailable") })
+        .result,
+    ).rejects.toThrow("durable task snapshot unavailable");
+  });
+
+  it.each([
+    {
+      reason: "wrong child final reply",
+      childFinalText: "CHILD_DONE but not the required exact reply",
+      failure: "child did not finish with the exact completion reply",
+    },
+    {
+      reason: "incomplete successful read chain",
+      successfulChildReads: 3,
+      failure: "child did not successfully read the complete chain",
+    },
+    {
+      reason: "four repeated reads and a guessed completion marker",
+      successfulChildReads: 4,
+      childFinalText: "CHILD_DONE",
+      failure: "child did not finish with the exact completion reply",
+    },
+    {
+      reason: "completion marker guessed from the first chain filename",
+      successfulChildReads: 4,
+      childFinalText: "CHILD_DONE:00000000-0000-4000-8000-000000000001",
+      failure: "child did not finish with the exact completion reply",
+    },
+  ])("rejects a delivered task with the $reason", async (fixture) => {
+    await expect(runCompletionPolicyFlow(fixture).result).rejects.toThrow(fixture.failure);
+  });
+
+  it("accepts a current requester-owned delivered child with complete transcript proof", async () => {
+    const {
+      gatewayCalls,
+      result,
+      state,
+      taskCommands,
+      transcriptReadOptions,
+      transcriptSessionKeys,
+    } = runCompletionPolicyFlow();
+
+    await expect(result).resolves.toMatchObject({ status: "pass" });
+    expect(gatewayCalls).toEqual([
+      {
+        method: "chat.history",
+        request: { sessionKey: completionParentSessionKey, limit: 100, maxChars: 131_072 },
+      },
+    ]);
+    expect(taskCommands).toEqual([["tasks", "list", "--json", "--runtime", "subagent"]]);
+    expect(transcriptSessionKeys).toEqual([
+      completionParentSessionKey,
+      completionParentSessionKey,
+      completionChildSessionKey,
+    ]);
+    expect(transcriptReadOptions).toEqual([
+      { allowEmpty: true },
+      { afterEventCursor: completionParentTranscriptCursor },
+      undefined,
+    ]);
+    expect(state.getSnapshot().messages[0]?.text).toContain("CHILD_DONE");
+    expect(state.getSnapshot().messages[1]).toMatchObject({
+      accountId: "qa-channel",
+      conversation: { id: "issue-109025-completion", kind: "direct" },
+      direction: "outbound",
+      text: completionProofMarker,
+    });
+  });
+
+  it("waits until the exact final requester reply is visible after the exec result", async () => {
+    const { gatewayCalls, result } = runCompletionPolicyFlow({ delayedParentReplyHistoryReads: 2 });
+
+    await expect(result).resolves.toMatchObject({ status: "pass" });
+    expect(gatewayCalls).toHaveLength(3);
+  });
+
+  it("accepts a genuine OpenAI final reply with provider mirror-correlation metadata", async () => {
+    await expect(
+      runCompletionPolicyFlow({
+        parentReply: {
+          phase: "final_answer",
+          providerIdentity: true,
+          text: completionProofMarker,
+        },
+      }).result,
+    ).resolves.toMatchObject({ status: "pass" });
+  });
+
+  it("delivers the current reply after mixed prior inbound and outbound history", async () => {
+    await expect(
+      runCompletionPolicyFlow({
+        priorParentOutbound: { text: "prior requester reply" },
+        priorRequesterInbound: true,
+      }).result,
+    ).resolves.toMatchObject({ status: "pass" });
+  });
+
+  it("keeps each chain hop independent and its terminal answer outside the prompt", async () => {
+    const { result, state, workspaceWrites } = runCompletionPolicyFlow();
+
+    await expect(result).resolves.toMatchObject({ status: "pass" });
+    expect(workspaceWrites).toHaveLength(4);
+
+    const chainFileNames = workspaceWrites.map(({ filePath }) => filePath.split("/").at(-1));
+    const chainUuids = chainFileNames.map(
+      (fileName) =>
+        fileName?.match(
+          /[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/u,
+        )?.[0],
+    );
+    expect(chainUuids.every((uuid) => uuid !== undefined)).toBe(true);
+    expect(new Set(chainUuids).size).toBe(4);
+    expect(workspaceWrites.slice(0, -1).map(({ content }) => content.trim())).toEqual(
+      chainFileNames.slice(1),
+    );
+
+    const terminalMarker = workspaceWrites.at(-1)?.content.trim();
+    expect(terminalMarker).toMatch(/^CHILD_DONE:[0-9a-f-]+$/u);
+    const inboundText = state.getSnapshot().messages[0]?.text ?? "";
+    expect(inboundText).toContain(chainFileNames[0]);
+    expect(inboundText).toContain("__CHILD_COMPLETION_TOKEN__");
+    for (const chainFileName of chainFileNames.slice(1)) {
+      expect(inboundText).not.toContain(chainFileName);
+    }
+    expect(inboundText).not.toContain(terminalMarker);
+  });
+
+  it("accepts an exec proof created in the same millisecond the child completed", async () => {
+    await expect(
+      runCompletionPolicyFlow({ proofModifiedAt: completionChildEndedAt }).result,
+    ).resolves.toMatchObject({ status: "pass" });
+  });
+
+  it("accepts authenticated spawn, yield, completion, and exec in the same millisecond", async () => {
+    await expect(
+      runCompletionPolicyFlow({
+        parentExecCompletedAt: completionChildEndedAt,
+        parentSpawnCompletedAt: completionChildEndedAt,
+        parentYieldCompletedAt: completionChildEndedAt,
+        proofModifiedAt: completionChildEndedAt,
+      }).result,
+    ).resolves.toMatchObject({ status: "pass" });
   });
 });

--- a/extensions/qa-lab/src/suite-runtime-agent-session.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-session.test.ts
@@ -515,6 +515,7 @@ describe("qa suite runtime agent session helpers", () => {
         toolName: "update_plan",
         content: [{ type: "text", text: "Plan updated" }],
         isError: false,
+        timestamp: 100,
       },
       {
         role: "toolResult",
@@ -522,6 +523,7 @@ describe("qa suite runtime agent session helpers", () => {
         toolName: "update_plan",
         content: [{ type: "text", text: "duplicate" }],
         isError: false,
+        timestamp: 200,
       },
       {
         role: "toolResult",
@@ -529,6 +531,7 @@ describe("qa suite runtime agent session helpers", () => {
         toolName: "update_plan",
         content: [{ type: "text", text: "failed" }],
         isError: true,
+        timestamp: 300,
       },
       {
         role: "toolResult",
@@ -536,6 +539,7 @@ describe("qa suite runtime agent session helpers", () => {
         toolName: "exec",
         content: [{ type: "text", text: "wrong tool" }],
         isError: false,
+        timestamp: 400,
       },
     ]) {
       await appendQaTranscriptMessage({
@@ -557,6 +561,108 @@ describe("qa suite runtime agent session helpers", () => {
       assistantToolCallCounts: { update_plan: 2, write: 1 },
       completedToolCallCounts: { update_plan: 2 },
       successfulToolCallCounts: { update_plan: 1 },
+      successfulToolCallEvents: [{ name: "update_plan", timestamp: 100, toolCallId: "plan-ok" }],
+    });
+  });
+
+  it("only exposes authenticated successful tool results with finite owner timestamps", async () => {
+    const tempRoot = await makeTempDir("qa-session-transcript-tool-event-timestamps-");
+    const sessionKey = "agent:qa:tool-event-timestamps";
+    const sessionId = "session-tool-event-timestamps";
+    await seedQaSession({ tempRoot, sessionKey, sessionId });
+    await appendQaTranscriptMessage({
+      tempRoot,
+      sessionKey,
+      sessionId,
+      message: {
+        role: "assistant",
+        content: ["missing", "invalid", "valid"].map((id) => ({
+          type: "toolCall",
+          id,
+          name: "exec",
+          arguments: {},
+        })),
+      },
+    });
+
+    for (const [toolCallId, timestamp] of [
+      ["missing", undefined],
+      ["invalid", "not-a-number"],
+      ["valid", 300],
+    ] as const) {
+      await appendQaTranscriptMessage({
+        tempRoot,
+        sessionKey,
+        sessionId,
+        message: {
+          role: "toolResult",
+          toolCallId,
+          toolName: "exec",
+          isError: false,
+          ...(timestamp === undefined ? {} : { timestamp }),
+        },
+      });
+    }
+
+    await expect(
+      readSessionTranscriptSummary({ gateway: { tempRoot } } as never, sessionKey),
+    ).resolves.toMatchObject({
+      successfulToolCallCounts: { exec: 3 },
+      successfulToolCallEvents: [{ name: "exec", timestamp: 300, toolCallId: "valid" }],
+    });
+  });
+
+  it("bounds authenticated successful tool results to the latest 64 events", async () => {
+    const tempRoot = await makeTempDir("qa-session-transcript-tool-event-bound-");
+    const sessionKey = "agent:qa:tool-event-bound";
+    const sessionId = "session-tool-event-bound";
+    await seedQaSession({ tempRoot, sessionKey, sessionId });
+    await appendQaTranscriptMessage({
+      tempRoot,
+      sessionKey,
+      sessionId,
+      message: {
+        role: "assistant",
+        content: Array.from({ length: 65 }, (_, index) => ({
+          type: "toolCall",
+          id: `call-${index}`,
+          name: "exec",
+          arguments: {},
+        })),
+      },
+    });
+
+    for (let index = 0; index < 65; index += 1) {
+      await appendQaTranscriptMessage({
+        tempRoot,
+        sessionKey,
+        sessionId,
+        message: {
+          role: "toolResult",
+          toolCallId: `call-${index}`,
+          toolName: "exec",
+          isError: false,
+          timestamp: index,
+        },
+      });
+    }
+
+    const summary = await readSessionTranscriptSummary(
+      { gateway: { tempRoot } } as never,
+      sessionKey,
+    );
+
+    expect(summary.successfulToolCallCounts).toEqual({ exec: 65 });
+    expect(summary.successfulToolCallEvents).toHaveLength(64);
+    expect(summary.successfulToolCallEvents?.[0]).toEqual({
+      name: "exec",
+      timestamp: 1,
+      toolCallId: "call-1",
+    });
+    expect(summary.successfulToolCallEvents?.at(-1)).toEqual({
+      name: "exec",
+      timestamp: 64,
+      toolCallId: "call-64",
     });
   });
 
@@ -576,6 +682,7 @@ describe("qa suite runtime agent session helpers", () => {
         toolName: "update_plan",
         content: [{ type: "text", text: "Plan updated" }],
         isError: false,
+        timestamp: 100,
       },
       {
         role: "assistant",
@@ -589,6 +696,9 @@ describe("qa suite runtime agent session helpers", () => {
       { gateway: { tempRoot } } as never,
       sessionKey,
     );
+    expect(checkpoint.successfulToolCallEvents).toEqual([
+      { name: "update_plan", timestamp: 100, toolCallId: "old-plan" },
+    ]);
     await appendQaTranscriptMessage({
       tempRoot,
       sessionKey,
@@ -600,16 +710,19 @@ describe("qa suite runtime agent session helpers", () => {
       },
     });
 
-    await expect(
-      readSessionTranscriptSummary({ gateway: { tempRoot } } as never, sessionKey, {
-        afterEventCursor: checkpoint.eventCursor,
-      }),
-    ).resolves.toMatchObject({
+    const summary = await readSessionTranscriptSummary(
+      { gateway: { tempRoot } } as never,
+      sessionKey,
+      { afterEventCursor: checkpoint.eventCursor },
+    );
+
+    expect(summary).toMatchObject({
       assistantMirrors: [{ identity: "current-turn:assistant", text: "same visible reply" }],
       assistantToolCallCounts: {},
       eventCursor: 5,
       successfulToolCallCounts: {},
     });
+    expect(summary.successfulToolCallEvents).toBeUndefined();
   });
 
   it("returns an empty checkpoint before the session exists", async () => {

--- a/extensions/qa-lab/src/suite-runtime-agent-session.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-session.ts
@@ -43,6 +43,7 @@ type QaSessionTranscriptSeedParams = {
 
 const SESSION_STORE_LOCK_RETRY_DELAYS_MS = [1_000, 3_000, 5_000] as const;
 const SESSION_STORE_FTS_SETTLE_RETRY_DELAYS_MS = [100, 250, 500, 1_000, 2_000] as const;
+const MAX_SUCCESSFUL_TOOL_CALL_EVENTS = 64;
 
 type QaSessionTranscriptSummary = {
   assistantMirrors?: Array<{ identity: string; text: string }>;
@@ -51,6 +52,7 @@ type QaSessionTranscriptSummary = {
   eventCursor: number;
   userMessageCount: number;
   successfulToolCallCounts: Record<string, number>;
+  successfulToolCallEvents?: Array<{ name: string; timestamp: number; toolCallId: string }>;
   finalText: string;
   hasDirectReplySelfMessage: boolean;
   lastAssistantContentTypes?: string[];
@@ -120,6 +122,9 @@ function summarizeSessionTranscriptEvents(
   const assistantToolCallCounts: Record<string, number> = {};
   const completedToolCallCounts: Record<string, number> = {};
   const successfulToolCallCounts: Record<string, number> = {};
+  const successfulToolCallEvents: NonNullable<
+    QaSessionTranscriptSummary["successfulToolCallEvents"]
+  > = [];
   const assistantToolNamesByCallId = new Map<string, string>();
   const completedToolCallIds = new Set<string>();
   const successfulToolCallIds = new Set<string>();
@@ -162,6 +167,17 @@ function summarizeSessionTranscriptEvents(
       ) {
         successfulToolCallIds.add(toolCallId);
         successfulToolCallCounts[toolName] = (successfulToolCallCounts[toolName] ?? 0) + 1;
+        if (typeof message.timestamp === "number" && Number.isFinite(message.timestamp)) {
+          // Keep owner-authenticated result chronology bounded for long-lived QA sessions.
+          if (successfulToolCallEvents.length === MAX_SUCCESSFUL_TOOL_CALL_EVENTS) {
+            successfulToolCallEvents.shift();
+          }
+          successfulToolCallEvents.push({
+            name: toolName,
+            timestamp: message.timestamp,
+            toolCallId,
+          });
+        }
       }
       continue;
     }
@@ -207,6 +223,7 @@ function summarizeSessionTranscriptEvents(
     eventCursor,
     userMessageCount,
     successfulToolCallCounts,
+    ...(successfulToolCallEvents.length > 0 ? { successfulToolCallEvents } : {}),
     finalText,
     hasDirectReplySelfMessage: scanner.findings().length > 0,
     ...(lastAssistantContentTypes.length > 0 ? { lastAssistantContentTypes } : {}),

--- a/qa/scenarios/agents/issue-109025-completion-policy-live.yaml
+++ b/qa/scenarios/agents/issue-109025-completion-policy-live.yaml
@@ -29,7 +29,8 @@ scenario:
     - The child follows a serial filesystem-read chain that remains allowed by the wildcard policy.
     - The child completion wakes the requester agent without a new external sender turn.
     - The requester-agent continuation uses exec, which the wildcard policy denies, to generate a fresh marker while write remains denied.
-    - The QA runner reads the exec-created proof file and finds the exact same unpredictable marker in Gateway output.
+    - The exec-created proof file binds its fresh output marker to the child-only completion token without exposing that token in the original prompt.
+    - The requester sends a genuine visible final assistant reply containing exactly the exec-created marker.
   docsRefs:
     - docs/gateway/config-tools.md
     - docs/tools/subagents.md
@@ -71,12 +72,12 @@ flow:
         - set: childLabel
           value:
             expr: "`${config.childLabelPrefix}-${randomUUID().slice(0, 8)}`"
-        - set: chainNonce
-          value:
-            expr: randomUUID().slice(0, 8)
         - set: chainFiles
           value:
-            expr: "[1, 2, 3, 4].map((index) => `${config.chainFilePrefix}-${chainNonce}-${index}.txt`)"
+            expr: "[1, 2, 3, 4].map(() => `${config.chainFilePrefix}-${randomUUID()}.txt`)"
+        - set: childTerminalMarker
+          value:
+            expr: "`CHILD_DONE:${randomUUID()}`"
         - set: proofFile
           value:
             expr: "`issue-109025-exec-proof-${randomUUID()}.txt`"
@@ -86,7 +87,7 @@ flow:
         - set: execCommand
           value:
             expr: |-
-              `node -e ${JSON.stringify(`const fs=require("node:fs");const crypto=require("node:crypto");const marker="${config.completionPrefix}:"+crypto.randomUUID();fs.writeFileSync(${JSON.stringify(proofFile)},marker+"\n");process.stdout.write(marker+"\n");`)}`
+              `node -e ${JSON.stringify(`const fs=require("node:fs");const crypto=require("node:crypto");const completion=process.argv[1];if(!completion.startsWith("CHILD_DONE:"))throw new Error("missing delivered completion");const marker="${config.completionPrefix}:"+crypto.randomUUID();fs.writeFileSync(${JSON.stringify(proofFile)},marker+"\n"+completion+"\n");process.stdout.write(marker+"\n");`)} __CHILD_COMPLETION_TOKEN__`
         - call: fs.writeFile
           args:
             - expr: path.join(env.gateway.workspaceDir, chainFiles[0])
@@ -105,8 +106,21 @@ flow:
         - call: fs.writeFile
           args:
             - expr: path.join(env.gateway.workspaceDir, chainFiles[3])
-            - CHILD_READY
+            - expr: "`${childTerminalMarker}\n`"
             - utf8
+        - set: attemptStartedAt
+          value:
+            expr: Date.now()
+        - call: readSessionTranscriptSummary
+          saveAs: parentTranscriptBefore
+          args:
+            - ref: env
+            - ref: parentSessionKey
+            - allowEmpty: true
+        # The transport waiter slices outbound rows, not the mixed inbound/outbound bus.
+        - set: outboundStartIndex
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
         - sendInbound:
             conversation:
               id: issue-109025-completion
@@ -116,35 +130,138 @@ flow:
             text:
               expr: |-
                 `Issue 109025 dormant completion probe. Follow these steps exactly.
-                1. Call sessions_spawn exactly once with runtime subagent, label ${childLabel}, and this task: "Use only the filesystem read tool. Start by reading ${chainFiles[0]}. Its trimmed contents name the next workspace file to read. Continue following one filename at a time until a file contains CHILD_READY. You must perform each read serially because later filenames are not in this task. Then reply exactly CHILD_DONE and nothing else. Do not use exec or process."
+                1. Call sessions_spawn exactly once with runtime subagent, label ${childLabel}, and this task: "Use only the filesystem read tool. Start by reading ${chainFiles[0]}. Its trimmed contents name the next workspace file to read. Continue following one filename at a time until a file's trimmed contents start with CHILD_DONE:. You must perform each read serially because later filenames are not in this task. Reply with the exact terminal file contents and nothing else. Do not use exec or process."
                 2. Immediately after sessions_spawn succeeds, call sessions_yield. Do not wait for the child and do not send a normal final reply.
-                3. When the CHILD_DONE completion event later resumes you, use the exec tool to run this exact command: ${execCommand}
+                3. When the child's CHILD_DONE: completion event later resumes you, use the exec tool exactly once to run this exact command: ${execCommand}
+                Replace only __CHILD_COMPLETION_TOKEN__ with the exact CHILD_DONE: completion text you received from the child. Do not otherwise change the command or inspect the workspace.
                 Do not use read or write for this step. Then reply with exactly the command's trimmed stdout.`
         - call: waitForCondition
           saveAs: expectedFinalMarker
           args:
             - lambda:
                 async: true
-                expr: "fs.readFile(proofPath, 'utf8').then((text) => { const marker = text.trim(); return marker.startsWith(`${config.completionPrefix}:`) && readGatewayLogs().includes(marker) ? marker : undefined; }).catch(() => undefined)"
+                expr: "fs.readFile(proofPath, 'utf8').then((text) => { const marker = text.split('\\n')[0]?.trim() ?? ''; return marker.startsWith(`${config.completionPrefix}:`) && readGatewayLogs().includes(marker) ? marker : undefined; }).catch(() => undefined)"
             - expr: liveTurnTimeoutMs(env, 60000)
             - 250
-        - call: readSessionTranscriptSummary
+        - call: waitForCondition
           saveAs: parentTranscript
           args:
+            - lambda:
+                async: true
+                expr: "readSessionTranscriptSummary(env, parentSessionKey, { afterEventCursor: parentTranscriptBefore.eventCursor }).then((summary) => String(summary.finalText ?? '').trim() === expectedFinalMarker ? summary : undefined)"
+            - expr: liveTurnTimeoutMs(env, 60000)
+            - 250
+        - assert:
+            expr: "(parentTranscript.successfulToolCallCounts.sessions_spawn ?? 0) === 1"
+            message:
+              expr: "`parent did not spawn a subagent; successfulTools=${JSON.stringify(parentTranscript.successfulToolCallCounts ?? {})}`"
+        - assert:
+            expr: "(parentTranscript.successfulToolCallCounts.sessions_yield ?? 0) >= 1"
+            message:
+              expr: "`parent did not yield before completion; successfulTools=${JSON.stringify(parentTranscript.successfulToolCallCounts ?? {})}`"
+        - assert:
+            expr: "(parentTranscript.successfulToolCallCounts.sessions_yield ?? 0) === 1"
+            message: parent did not call sessions_yield exactly once
+        - assert:
+            expr: "(parentTranscript.successfulToolCallCounts.exec ?? 0) >= 1"
+            message:
+              expr: "`parent did not execute the completion command; successfulTools=${JSON.stringify(parentTranscript.successfulToolCallCounts ?? {})}`"
+        - assert:
+            expr: "(parentTranscript.successfulToolCallCounts.exec ?? 0) === 1"
+            message: parent did not call exec exactly once
+        - assert:
+            expr: "Object.entries(parentTranscript.successfulToolCallCounts ?? {}).every(([name, count]) => count === 0 || ['sessions_spawn', 'sessions_yield', 'exec'].includes(name))"
+            message:
+              expr: "`parent used an unexpected successful tool; successfulTools=${JSON.stringify(parentTranscript.successfulToolCallCounts ?? {})}`"
+        # Transport reset preserves durable task state; match this attempt's requester and child.
+        - call: waitForCondition
+          saveAs: completedChild
+          args:
+            - lambda:
+                async: true
+                expr: "(async () => { const payload = await runQaCli(env, ['tasks', 'list', '--json', '--runtime', 'subagent'], { timeoutMs: liveTurnTimeoutMs(env, 60000), json: true }); return (payload.tasks ?? []).find((task) => task.label === childLabel && task.requesterSessionKey === parentSessionKey && task.createdAt >= attemptStartedAt && typeof task.childSessionKey === 'string' && task.childSessionKey.length > 0 && typeof task.endedAt === 'number' && Number.isFinite(task.endedAt) && task.status === 'succeeded' && task.deliveryStatus === 'delivered'); })()"
+            - expr: liveTurnTimeoutMs(env, 60000)
+            - 250
+        # Raw transcript results retain authenticated tool ids/timestamps that
+        # public chat.history intentionally omits from its visible projection.
+        - set: parentSuccessfulToolEvents
+          value:
+            expr: parentTranscript.successfulToolCallEvents ?? []
+        - assert:
+            expr: "parentSuccessfulToolEvents.length === 3 && ['sessions_spawn', 'sessions_yield', 'exec'].every((name, index) => parentSuccessfulToolEvents[index]?.name === name && typeof parentSuccessfulToolEvents[index]?.toolCallId === 'string' && parentSuccessfulToolEvents[index].toolCallId.length > 0 && typeof parentSuccessfulToolEvents[index]?.timestamp === 'number' && Number.isFinite(parentSuccessfulToolEvents[index].timestamp)) && new Set(parentSuccessfulToolEvents.map((event) => event.toolCallId)).size === 3"
+            message: parent successful tool timeline was incomplete
+        - assert:
+            expr: "parentSuccessfulToolEvents[1].timestamp <= completedChild.endedAt"
+            message: parent did not successfully yield before child completion
+        - assert:
+            expr: "parentSuccessfulToolEvents[0].timestamp >= attemptStartedAt && parentSuccessfulToolEvents[0].timestamp <= parentSuccessfulToolEvents[1].timestamp && completedChild.endedAt <= parentSuccessfulToolEvents[2].timestamp"
+            message: parent successful tool timeline was not chronological
+        - call: fs.stat
+          saveAs: execProofStat
+          args:
+            - ref: proofPath
+        - assert:
+            expr: execProofStat.mtimeMs >= completedChild.endedAt
+            message:
+              expr: "`completion command ran before the child finished; proofModifiedAt=${String(execProofStat.mtimeMs)} childEndedAt=${String(completedChild.endedAt)}`"
+        - call: readSessionTranscriptSummary
+          saveAs: childTranscript
+          args:
             - ref: env
-            - ref: parentSessionKey
+            - expr: completedChild.childSessionKey
+        - assert:
+            expr: "String(childTranscript.finalText ?? '').trim() === childTerminalMarker"
+            message: child did not finish with the exact completion reply
+        - assert:
+            expr: "(childTranscript.successfulToolCallCounts.read ?? 0) >= chainFiles.length"
+            message:
+              expr: "`child did not successfully read the complete chain; childTools=${JSON.stringify(childTranscript.successfulToolCallCounts ?? {})}`"
+        # The hidden child-only token proves exec consumed the delivered completion,
+        # while requester history rejects commands that discover it from the workspace.
+        - set: execProofContents
+          value:
+            expr: "(await fs.readFile(proofPath, 'utf8')).trim().split('\\n')"
+        - assert:
+            expr: "execProofContents.length === 2 && execProofContents[0] === expectedFinalMarker && execProofContents[1] === childTerminalMarker"
+            message: completion proof did not contain the delivered child marker
+        # Raw transcript finalText also includes commentary and mirror bookkeeping;
+        # only projected history proves a separate requester-visible final reply.
+        - call: waitForCondition
+          saveAs: parentHistory
+          args:
+            - lambda:
+                async: true
+                expr: |-
+                  (async () => {
+                    const history = await env.gateway.call('chat.history', { sessionKey: parentSessionKey, limit: 100, maxChars: 131072 }, { timeoutMs: liveTurnTimeoutMs(env, 15000) });
+                    const messages = history.messages ?? [];
+                    const execIndex = messages.findLastIndex((message) => message?.role === 'assistant' && Array.isArray(message.content) && message.content.some((item) => (item?.type === 'toolCall' || item?.type === 'toolUse') && (item?.name ?? item?.toolName) === 'exec'));
+                    if (execIndex < 0) return undefined;
+                    const finalReply = messages.slice(execIndex + 1).findLast((message) => message?.role === 'assistant' && message.phase !== 'commentary' && !message.openclawMessageToolMirror && !message.openclawDeliveryMirror && !(message.provider === 'openclaw' && ['delivery-mirror', 'gateway-injected'].includes(message.model)) && (!Array.isArray(message.content) || !message.content.some((item) => ['toolCall', 'toolUse', 'tool_use', 'toolResult', 'tool_result'].includes(item?.type))));
+                    if (!finalReply) return undefined;
+                    const replyText = typeof finalReply.content === 'string' ? finalReply.content : Array.isArray(finalReply.content) ? finalReply.content.filter((item) => ['text', 'input_text', 'output_text'].includes(item?.type)).map((item) => item.text ?? '').join('\n') : finalReply.text ?? '';
+                    return replyText.trim() === expectedFinalMarker ? history : undefined;
+                  })()
+            - expr: liveTurnTimeoutMs(env, 60000)
+            - 250
+        - assert:
+            expr: "(parentHistory.messages ?? []).some((message) => message?.role === 'assistant' && Array.isArray(message.content) && message.content.some((item) => (item?.type === 'toolCall' || item?.type === 'toolUse') && (item?.name ?? item?.toolName) === 'exec' && item?.id === parentSuccessfulToolEvents[2].toolCallId && (item?.arguments ?? item?.input)?.command === execCommand.replace('__CHILD_COMPLETION_TOKEN__', childTerminalMarker)))"
+            message: parent exec did not use the exact delivered-completion command
+        - call: waitForOutboundMessage
+          saveAs: parentOutbound
+          args:
+            - ref: state
+            - lambda:
+                params: [candidate]
+                expr: "candidate.direction === 'outbound' && candidate.accountId === transport.accountId && candidate.conversation.id === 'issue-109025-completion' && candidate.conversation.kind === 'direct' && String(candidate.text ?? '').trim() === expectedFinalMarker"
+            - expr: liveTurnTimeoutMs(env, 60000)
+            - sinceIndex:
+                ref: outboundStartIndex
         - set: gatewayLogs
           value:
             expr: readGatewayLogs()
         - assert:
-            expr: "(parentTranscript.assistantToolCallCounts.sessions_yield ?? 0) >= 1"
-            message:
-              expr: "`parent did not yield before completion; parentTools=${JSON.stringify(parentTranscript.assistantToolCallCounts ?? {})}`"
-        - assert:
             expr: gatewayLogs.includes(expectedFinalMarker)
             message:
               expr: "`completion continuation did not produce the exec-created marker; marker=${String(expectedFinalMarker ?? '')}`"
-        - assert:
-            expr: "gatewayLogs.indexOf('CHILD_DONE') >= 0 && gatewayLogs.indexOf(expectedFinalMarker) > gatewayLogs.indexOf('CHILD_DONE')"
-            message: child completion did not precede the exec-created continuation marker
-      detailsExpr: "`parentSession=${parentSessionKey} parentTools=${JSON.stringify(parentTranscript.assistantToolCallCounts ?? {})} execMarker=${String(expectedFinalMarker ?? '')}`"
+      detailsExpr: "`parentSession=${parentSessionKey} childSession=${completedChild.childSessionKey} successfulParentTools=${JSON.stringify(parentTranscript.successfulToolCallCounts ?? {})} successfulChildTools=${JSON.stringify(childTranscript.successfulToolCallCounts ?? {})} execMarker=${String(expectedFinalMarker ?? '')}`"


### PR DESCRIPTION
## Summary

- Eliminate false-positive passes from the existing live yielded-subagent completion-policy scenario.
- Prove actual authenticated tool chronology, child delivery, requester continuation, visible final reply, and real QA-channel outbound delivery.

## Root cause and canonical QA evidence ownership

The existing so-called live proof could pass because a completion phrase or exec marker appeared in its own initial prompt, logs, or tool stdout; neither a successful child, an actually yielded parent, a resumed final answer, nor a delivered outbound reply was required. Public Gateway history intentionally omits raw tool results, so visible-history timestamps cannot prove successful tool completion.

The existing QA transcript owner now exposes an optional bounded latest-64 list of authenticated successful tool-call identities/timestamps, matched to their actual assistant tool calls; existing summaries remain byte-compatible when timing evidence is unavailable. The scenario uses a child-only unpredictable token, exact current requester/task generation, authenticated spawn→yield→child completion→exec ordering, an immutable non-reading exec command, an actual projected non-mirror parent final, and a post-checkpoint real QA-channel outbound event for the correct account/conversation.

## Adversarial proof

Genuine failing fixtures covered prompt/tool-output spoofing, attempted versus successful calls, premature parent execution, delayed child completion, reused task generations, unauthorized filesystem discovery, late parent yields, missing final replies, commentary-only replies, synthetic delivery mirrors, false rejection of legitimate provider mirror identities, stale outbound events, wrong accounts/conversations, and silently dropped channel delivery.

- Final real YAML loading + actual SQLite transcript owner suites: **86/86 passing**.
- Exact hosted type-aware/type-check targeted test lint, formatting, and diff checks: clean.
- Production delta **+17 QA-only lines** for bounded authenticated existing-owner evidence; no Gateway protocol, public API, config, or state schema changes.
- Final fresh independent structured Sol/high review after all accepted adversarial findings: **no actionable findings, confidence 0.86**.
