### PR TITLE
test(gateway): avoid async facade mock race

### DIFF
--- a/src/gateway/server-methods/__mocks__/tools-effective.runtime.ts
+++ b/src/gateway/server-methods/__mocks__/tools-effective.runtime.ts
@@ -1,0 +1,68 @@
+import { vi } from "vitest";
+
+export {
+  listAgentIds,
+  resolveAgentDir,
+  resolveAgentWorkspaceDir,
+  resolveSessionAgentId,
+} from "../../../agents/agent-scope.js";
+export { getRegisteredAgentHarness } from "../../../agents/harness/registry.js";
+export { resolveReplyToMode } from "../../../auto-reply/reply/reply-threading.js";
+export { resolveRuntimeConfigCacheKey } from "../../../config/config.js";
+export { deliveryContextFromSession } from "../../../utils/delivery-context.shared.js";
+export { loadSessionEntryReadOnly, resolveSessionModelRef } from "../../session-utils.js";
+
+export const toolsEffectiveGlobalAgentRuntimeMocks = {
+  resolveEffectiveToolInventory: vi.fn(
+    (params: { agentId: string; modelProvider?: string; modelId?: string }) => ({
+      agentId: params.agentId,
+      profile: "coding",
+      groups: [
+        {
+          id: "core",
+          label: "Built-in tools",
+          source: "core",
+          tools: [
+            {
+              id: "exec",
+              label: "Exec",
+              description: "Run shell commands",
+              source: "core",
+            },
+          ],
+        },
+      ],
+      modelProvider: params.modelProvider,
+      modelId: params.modelId,
+    }),
+  ),
+  resolveEffectiveToolInventoryRuntimeModelContext: vi.fn((_params?: unknown) => ({
+    modelApi: "openai-responses",
+    runtimeModel: {
+      id: "work-model",
+      name: "Work model",
+      provider: "openai",
+      api: "openai-responses",
+      baseUrl: "https://api.openai.com/v1",
+    },
+  })),
+  resolveEffectiveToolInventoryRuntimeModelContextAsync: vi.fn(async (params: unknown) =>
+    toolsEffectiveGlobalAgentRuntimeMocks.resolveEffectiveToolInventoryRuntimeModelContext(params),
+  ),
+};
+
+export const resolveEffectiveToolInventory =
+  toolsEffectiveGlobalAgentRuntimeMocks.resolveEffectiveToolInventory;
+export const resolveEffectiveToolInventoryRuntimeModelContextAsync =
+  toolsEffectiveGlobalAgentRuntimeMocks.resolveEffectiveToolInventoryRuntimeModelContextAsync;
+export const peekSessionMcpRuntime = vi.fn(() => undefined);
+export const resolveSessionMcpConfigSummary = vi.fn(() => ({
+  fingerprint: "mcp:0",
+  serverNames: [] as string[],
+}));
+export const buildBundleMcpToolsFromCatalog = vi.fn(() => []);
+export const applyFinalEffectiveToolPolicy = vi.fn(
+  (params: { bundledTools: unknown[] }) => params.bundledTools,
+);
+export const getActivePluginRegistryVersion = vi.fn(() => 1);
+export const getActivePluginChannelRegistryVersion = vi.fn(() => 1);

--- a/src/gateway/server-methods/tools-effective.global-agent.integration.test.ts
+++ b/src/gateway/server-methods/tools-effective.global-agent.integration.test.ts
@@ -4,66 +4,10 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { installGatewayTestHooks, testState, writeSessionStore } from "../test-helpers.js";
 import { getGatewayConfigModule, sessionStoreEntry } from "../test/server-sessions.test-helpers.js";
+import { toolsEffectiveGlobalAgentRuntimeMocks as inventoryMocks } from "./__mocks__/tools-effective.runtime.js";
 import { testing, toolsEffectiveHandlers } from "./tools-effective.js";
 
-const inventoryMocks = vi.hoisted(() => ({
-  resolveEffectiveToolInventory: vi.fn(
-    (params: { agentId: string; modelProvider?: string; modelId?: string }) => ({
-      agentId: params.agentId,
-      profile: "coding",
-      groups: [
-        {
-          id: "core",
-          label: "Built-in tools",
-          source: "core",
-          tools: [
-            {
-              id: "exec",
-              label: "Exec",
-              description: "Run shell commands",
-              source: "core",
-            },
-          ],
-        },
-      ],
-      modelProvider: params.modelProvider,
-      modelId: params.modelId,
-    }),
-  ),
-  resolveEffectiveToolInventoryRuntimeModelContext: vi.fn((_params?: unknown) => ({
-    modelApi: "openai-responses",
-    runtimeModel: {
-      id: "work-model",
-      name: "Work model",
-      provider: "openai",
-      api: "openai-responses",
-      baseUrl: "https://api.openai.com/v1",
-    },
-  })),
-  resolveEffectiveToolInventoryRuntimeModelContextAsync: vi.fn(async (params: unknown) =>
-    inventoryMocks.resolveEffectiveToolInventoryRuntimeModelContext(params),
-  ),
-}));
-
-vi.mock("./tools-effective.runtime.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./tools-effective.runtime.js")>();
-  return {
-    ...actual,
-    resolveEffectiveToolInventory: inventoryMocks.resolveEffectiveToolInventory,
-    resolveEffectiveToolInventoryRuntimeModelContext:
-      inventoryMocks.resolveEffectiveToolInventoryRuntimeModelContext,
-    resolveEffectiveToolInventoryRuntimeModelContextAsync:
-      inventoryMocks.resolveEffectiveToolInventoryRuntimeModelContextAsync,
-    peekSessionMcpRuntime: vi.fn(() => undefined),
-    resolveSessionMcpConfigSummary: vi.fn(() => ({ fingerprint: "mcp:0", serverNames: [] })),
-    buildBundleMcpToolsFromCatalog: vi.fn(() => []),
-    applyFinalEffectiveToolPolicy: vi.fn(
-      (params: { bundledTools: unknown[] }) => params.bundledTools,
-    ),
-    getActivePluginRegistryVersion: vi.fn(() => 1),
-    getActivePluginChannelRegistryVersion: vi.fn(() => 1),
-  };
-});
+vi.mock("./tools-effective.runtime.js");
 
 installGatewayTestHooks();
 


### PR DESCRIPTION
## Summary

- replace the gateway tools integration test's async partial same-facade mock with a synchronous complete manual mock
- keep the real agent, session-store, config-cache, model-reference, delivery, and hot-reload owners in the integration path
- continue mocking only inventory, MCP, policy, and registry-version work that is outside these three assertions

## Root cause

In CI run 30818181352, the first gateway-methods attempt reported 144 of 145 files and 2,846 tests, then remained silent until the 300-second watchdog killed it. The sole missing file was tools-effective.global-agent.integration.test.ts. The automatic retry passed all 145 files and 2,849 tests in 59.13 seconds, producing a 439.91-second wrapper wall.

The missing file was the only gateway-methods test with an async importOriginal partial mock of tools-effective.runtime.js. That factory crossed the shared non-isolated worker's mock-resolution boundary after another file had completed. The replacement facade is synchronous and complete, so it cannot re-enter resolution of the module it is mocking.

## Proof

- Direct AWS Crabbox run_433fbc2be087:
  - five consecutive agent.test.ts -> tools-effective.global-agent.integration.test.ts runs
  - all five passed 2 files / 273 tests in the required order
- Direct AWS Crabbox run_1a0255aada9a:
  - exact compact-large-6 leading order, retry disabled: auth -> CLI runner -> gateway methods
  - auth: 39 files / 579 tests
  - CLI runner: 1 file / 119 tests
  - gateway methods: 145 files / 2,849 tests, 85.85-second wrapper, no stall or retry
- Post-rebase focused run_1a39c8d59c15:
  - 1 file / 3 tests passed in 7.21 seconds
- git diff --check
- autoreview clean: no accepted/actionable findings

No sharding, worker, concurrency, timeout, retry, production, docs, or coverage behavior changes.
