### PR TITLE
fix(agents): retain completions after session takeover

### DIFF
--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -3425,6 +3425,8 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       sessionId: "requester-session-lock-race-evidence",
       isActive: true,
       directIdempotencyKey: "announce-permanent-lock-error-evidence",
+      sourceTool: "subagent_announce",
+      internalEvents: taskCompletionEvents({ childSessionId: "child-session-id" }),
     });
 
     expect(result.delivered).toBe(false);
@@ -3433,6 +3435,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(result.phases?.map((phase) => phase.phase)).toEqual(["direct-primary"]);
     expect(callGateway).toHaveBeenCalledTimes(1);
     expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledTimes(1);
+    expect(sessionDeliveryQueueMocks.enqueueClaimedSessionDelivery).not.toHaveBeenCalled();
   });
 
   it("does not fallback-steer after wrapped prompt-lock takeover with send evidence", async () => {
@@ -3498,6 +3501,102 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(result.delivered).toBe(true);
     expect(result.path).toBe("direct");
     expect(callGatewaySpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("queues a no-send completion after session-file retries are exhausted", async () => {
+    const callGateway = vi.fn(async () => {
+      throw new Error("session file changed while embedded prompt lock was released");
+    }) as unknown as typeof runtimeCallGateway;
+    const result = await deliverSlackThreadAnnouncement({
+      callGateway,
+      directIdempotencyKey: "announce-durable-session-takeover",
+      sourceTool: "subagent_announce",
+      internalEvents: taskCompletionEvents({
+        childSessionId: "child-session-id",
+        taskLabel: "durable takeover completion",
+      }),
+    });
+
+    expect(result).toMatchObject({
+      delivered: false,
+      path: "queued",
+      disposition: "session_queued",
+      phases: [{ phase: "direct-primary", delivered: false, path: "queued" }],
+    });
+    expect(callGateway).toHaveBeenCalledTimes(4);
+    expect(sessionDeliveryQueueMocks.enqueueClaimedSessionDelivery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "agentTurn",
+        inputProvenance: expect.objectContaining({ sourceTool: "subagent_announce" }),
+        expectedMediaUrls: [],
+        idempotencyKey: "announce-durable-session-takeover:agent-loop",
+      }),
+      expect.any(Number),
+    );
+    expect(sessionDeliveryQueueMocks.scheduleSessionDelivery).toHaveBeenCalledWith(
+      "session-delivery-media",
+    );
+  });
+
+  it("queues a wrapped no-send session-file takeover after retries are exhausted", async () => {
+    const takeover = new Error("session file changed while embedded prompt lock was released");
+    const callGateway = vi.fn(async () => {
+      throw new Error("agent command failed", { cause: takeover });
+    }) as unknown as typeof runtimeCallGateway;
+    const result = await deliverSlackThreadAnnouncement({
+      callGateway,
+      directIdempotencyKey: "announce-durable-wrapped-session-takeover",
+      sourceTool: "subagent_announce",
+      internalEvents: taskCompletionEvents({
+        childSessionId: "child-session-id",
+        taskLabel: "wrapped durable takeover completion",
+      }),
+    });
+
+    expect(result).toMatchObject({
+      delivered: false,
+      path: "queued",
+      disposition: "session_queued",
+      phases: [{ phase: "direct-primary", delivered: false, path: "queued" }],
+    });
+    expect(callGateway).toHaveBeenCalledTimes(4);
+    expect(sessionDeliveryQueueMocks.enqueueClaimedSessionDelivery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        idempotencyKey: "announce-durable-wrapped-session-takeover:agent-loop",
+      }),
+      expect.any(Number),
+    );
+  });
+
+  it("does not queue a completion after its source owner changes on the final retry", async () => {
+    let sourceEffectsAllowed = true;
+    let attempts = 0;
+    const callGateway = vi.fn(async () => {
+      attempts += 1;
+      if (attempts === 4) {
+        sourceEffectsAllowed = false;
+      }
+      throw new Error("session file changed while embedded prompt lock was released");
+    }) as unknown as typeof runtimeCallGateway;
+    const result = await deliverSlackThreadAnnouncement({
+      callGateway,
+      directIdempotencyKey: "announce-stale-durable-session-takeover",
+      sourceTool: "subagent_announce",
+      isSourceSessionEffectsAllowed: () => sourceEffectsAllowed,
+      internalEvents: taskCompletionEvents({
+        childSessionId: "child-session-id",
+        taskLabel: "stale durable takeover completion",
+      }),
+    });
+
+    expect(result).toMatchObject({
+      delivered: false,
+      path: "none",
+      reason: "source_owner_changed",
+      terminal: true,
+    });
+    expect(callGateway).toHaveBeenCalledTimes(4);
+    expect(sessionDeliveryQueueMocks.enqueueClaimedSessionDelivery).not.toHaveBeenCalled();
   });
 
   it("stops a direct Gateway retry when source ownership changes after the first attempt", async () => {

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -260,6 +260,7 @@ async function deliverSlackThreadAnnouncement(params: {
   sendMessage?: typeof runtimeSendMessage;
   internalEvents?: AgentInternalEvent[];
   sourceTool?: string;
+  includeSourceRunId?: boolean;
   requesterAbandoned?: boolean;
   isSourceSessionEffectsAllowed?: () => boolean;
 }) {
@@ -293,7 +294,7 @@ async function deliverSlackThreadAnnouncement(params: {
     bestEffortDeliver: true,
     directIdempotencyKey: params.directIdempotencyKey,
     internalEvents: params.internalEvents,
-    sourceRunId: "run-generated-media",
+    ...(params.includeSourceRunId === false ? {} : { sourceRunId: "run-generated-media" }),
     sourceTool: params.sourceTool,
     isSourceSessionEffectsAllowed: params.isSourceSessionEffectsAllowed,
   });
@@ -3530,6 +3531,41 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
         inputProvenance: expect.objectContaining({ sourceTool: "subagent_announce" }),
         expectedMediaUrls: [],
         idempotencyKey: "announce-durable-session-takeover:agent-loop",
+      }),
+      expect.any(Number),
+    );
+    expect(sessionDeliveryQueueMocks.scheduleSessionDelivery).toHaveBeenCalledWith(
+      "session-delivery-media",
+    );
+  });
+
+  it("queues a no-send agent harness completion without a run id after session-file retries", async () => {
+    const callGateway = vi.fn(async () => {
+      throw new Error("session file changed while embedded prompt lock was released");
+    }) as unknown as typeof runtimeCallGateway;
+    const result = await deliverSlackThreadAnnouncement({
+      callGateway,
+      directIdempotencyKey: "announce-harness-durable-session-takeover",
+      sourceTool: "agent_harness_task",
+      includeSourceRunId: false,
+      internalEvents: taskCompletionEvents({
+        childSessionId: "harness-child-session-id",
+        taskLabel: "durable harness takeover completion",
+      }),
+    });
+
+    expect(result).toMatchObject({
+      delivered: false,
+      path: "queued",
+      disposition: "session_queued",
+      phases: [{ phase: "direct-primary", delivered: false, path: "queued" }],
+    });
+    expect(callGateway).toHaveBeenCalledTimes(4);
+    expect(sessionDeliveryQueueMocks.enqueueClaimedSessionDelivery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "agentTurn",
+        inputProvenance: expect.objectContaining({ sourceTool: "agent_harness_task" }),
+        idempotencyKey: "announce-harness-durable-session-takeover:agent-loop",
       }),
       expect.any(Number),
     );

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -1485,7 +1485,7 @@ export async function deliverSubagentAnnouncement(params: {
         params.expectsCompletionMessage &&
         normalizeOptionalLowercaseString(params.sourceTool) === "subagent_announce" &&
         params.sourceRunId &&
-        direct.delivered === false &&
+        !direct.delivered &&
         direct.disposition === "permanent_failure" &&
         direct.reason === "session_file_changed"
       ) {

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -80,7 +80,7 @@ import type { SubagentCompletionToolHandoffRegistration } from "./subagent-annou
 import {
   inferDeliveryTargetChatType,
   resolveCompletionDeliveryOrigins,
-  resolveGeneratedMediaSessionDeliveryRoute,
+  resolveCompletionSessionDeliveryRoute,
   type DeliveryContext,
 } from "./subagent-announce-origin.js";
 import { admitCorrelatedSubagentSessionDelivery } from "./subagent-completion-delivery.js";
@@ -1296,6 +1296,7 @@ async function sendSubagentAnnounceDirectly(params: {
     return {
       delivered: false,
       path: "direct",
+      ...(hasSessionFileChangedAnnounceError(err) ? { reason: "session_file_changed" } : {}),
       error: summarizeDeliveryError(err),
       disposition,
     };
@@ -1332,17 +1333,14 @@ export async function deliverSubagentAnnouncement(params: {
   if (sourceOwnerChanged()) {
     return sourceOwnerChangedResult();
   }
-  const durableGeneratedMediaHandoff =
-    params.expectsCompletionMessage &&
-    isAgentMediatedCompletionSourceTool(params.sourceTool) &&
-    hasGeneratedMediaCompletionEvent(params.internalEvents);
-  let durableQueueId: string | undefined;
-  let durableQueueClaimed = false;
-  if (durableGeneratedMediaHandoff) {
+  const queueDurableCompletionHandoff = async (): Promise<SubagentAnnounceDeliveryResult> => {
+    if (sourceOwnerChanged()) {
+      return sourceOwnerChangedResult();
+    }
     try {
       const cfg = subagentAnnounceDeliveryDeps.getRuntimeConfig();
       const canonicalSessionKey = resolveRequesterStoreKey(cfg, params.targetRequesterSessionKey);
-      const queuedRoute = resolveGeneratedMediaSessionDeliveryRoute({
+      const queuedRoute = resolveCompletionSessionDeliveryRoute({
         sessionKey: canonicalSessionKey,
         completionDirectOrigin: params.completionDirectOrigin,
         directOrigin: params.directOrigin,
@@ -1400,43 +1398,45 @@ export async function deliverSubagentAnnouncement(params: {
           delivered: false,
           path: "queued",
           reason: "completion_handoff_unavailable",
-          error: "generated media session handoff was already dead-lettered",
+          error: "completion session handoff was already dead-lettered",
           disposition: "permanent_failure",
         };
       }
       if (queued.status === "completed") {
         return { delivered: true, path: "queued", disposition: "delivered" };
       }
-      durableQueueId = queued.id;
-      durableQueueClaimed = queued.claimed;
+      if (queued.claimed) {
+        await releaseSessionDeliveryClaim(queued.id).catch((error: unknown) => {
+          defaultRuntime.log(
+            `[warn] Completion session handoff lease release failed; durable recovery remains pending: ${summarizeDeliveryError(error)}`,
+          );
+        });
+      }
+      await scheduleSessionDelivery(queued.id).catch((error: unknown) => {
+        defaultRuntime.log(
+          `[warn] Completion session handoff retry scheduling failed; durable recovery remains pending: ${summarizeDeliveryError(error)}`,
+        );
+      });
+      return { delivered: false, path: "queued", disposition: "session_queued" };
     } catch (error) {
       defaultRuntime.log(
-        `[warn] Generated media session handoff could not be persisted; refusing ambiguous fallback: ${summarizeDeliveryError(error)}`,
+        `[warn] Completion session handoff could not be persisted; refusing ambiguous fallback: ${summarizeDeliveryError(error)}`,
       );
       return {
         delivered: false,
         path: "queued",
         reason: "completion_handoff_unavailable",
-        error: "generated media session handoff could not be persisted",
+        error: "completion session handoff could not be persisted",
         disposition: "retryable",
       };
     }
-  }
-
-  if (durableQueueId) {
-    if (durableQueueClaimed) {
-      await releaseSessionDeliveryClaim(durableQueueId).catch((error: unknown) => {
-        defaultRuntime.log(
-          `[warn] Generated media session handoff lease release failed; durable recovery remains pending: ${summarizeDeliveryError(error)}`,
-        );
-      });
-    }
-    await scheduleSessionDelivery(durableQueueId).catch((error: unknown) => {
-      defaultRuntime.log(
-        `[warn] Generated media session handoff retry scheduling failed; durable recovery remains pending: ${summarizeDeliveryError(error)}`,
-      );
-    });
-    return { delivered: false, path: "queued", disposition: "session_queued" };
+  };
+  const durableGeneratedMediaHandoff =
+    params.expectsCompletionMessage &&
+    isAgentMediatedCompletionSourceTool(params.sourceTool) &&
+    hasGeneratedMediaCompletionEvent(params.internalEvents);
+  if (durableGeneratedMediaHandoff) {
+    return await queueDurableCompletionHandoff();
   }
 
   return await runSubagentAnnounceDispatch({
@@ -1461,7 +1461,7 @@ export async function deliverSubagentAnnouncement(params: {
       if (sourceOwnerChanged()) {
         return sourceOwnerChangedResult();
       }
-      return await sendSubagentAnnounceDirectly({
+      const direct = await sendSubagentAnnounceDirectly({
         requesterSessionKey: params.requesterSessionKey,
         targetRequesterSessionKey: params.targetRequesterSessionKey,
         triggerMessage: params.triggerMessage,
@@ -1481,6 +1481,17 @@ export async function deliverSubagentAnnouncement(params: {
         signal: params.signal,
         bestEffortDeliver: params.bestEffortDeliver,
       });
+      if (
+        params.expectsCompletionMessage &&
+        normalizeOptionalLowercaseString(params.sourceTool) === "subagent_announce" &&
+        params.sourceRunId &&
+        direct.delivered === false &&
+        direct.disposition === "permanent_failure" &&
+        direct.reason === "session_file_changed"
+      ) {
+        return await queueDurableCompletionHandoff();
+      }
+      return direct;
     },
   });
 }

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -1483,8 +1483,8 @@ export async function deliverSubagentAnnouncement(params: {
       });
       if (
         params.expectsCompletionMessage &&
-        normalizeOptionalLowercaseString(params.sourceTool) === "subagent_announce" &&
-        params.sourceRunId &&
+        (normalizeOptionalLowercaseString(params.sourceTool) === "subagent_announce" ||
+          isAgentMediatedCompletionSourceTool(params.sourceTool)) &&
         !direct.delivered &&
         direct.disposition === "permanent_failure" &&
         direct.reason === "session_file_changed"

--- a/src/agents/subagent-announce-dispatch.ts
+++ b/src/agents/subagent-announce-dispatch.ts
@@ -19,6 +19,7 @@ type SubagentAnnounceDeliveryFailureReason =
   | "generated_media_missing"
   | "message_tool_delivery_missing"
   | "requester_abandoned"
+  | "session_file_changed"
   | "source_owner_changed"
   | "visible_reply_missing";
 

--- a/src/agents/subagent-announce-origin.ts
+++ b/src/agents/subagent-announce-origin.ts
@@ -281,8 +281,8 @@ export function inferDeliveryTargetChatType(target: {
     : undefined;
 }
 
-/** Resolve the durable generated-media handoff route from the canonical completion origin. */
-export function resolveGeneratedMediaSessionDeliveryRoute(params: {
+/** Resolve a durable completion handoff route from the canonical completion origin. */
+export function resolveCompletionSessionDeliveryRoute(params: {
   sessionKey: string;
   completionDirectOrigin?: DeliveryContext;
   directOrigin?: DeliveryContext;


### PR DESCRIPTION
Closes #118408

## What Problem This Solves

Fixes an issue where concurrent subagent completion announcements could exhaust their direct retry budget after an `EmbeddedAttemptSessionTakeoverError`, then lose a completed result even though no channel delivery had occurred.

## Why This Change Was Made

The direct completion path still retries first. If a `subagent_announce` or agent-mediated completion remains blocked by a session-file takeover with no delivery evidence, it now enters the existing session-delivery queue. Correlated admission remains in use when the caller supplies a run ID; the agent-harness completion caller safely uses the queue's normal idempotent admission when it does not. Errors with send evidence and source-lifecycle changes remain non-replayable.

## User Impact

Parallel subagent work that completes during requester-session contention is retained for durable delivery instead of ending as a generic failed completion. Confirmed sends are not duplicated.

## Evidence

- `node scripts/run-vitest.mjs src/agents/subagent-announce-delivery.test.ts src/agents/subagent-announce-dispatch.test.ts src/agents/subagent-completion-admission.store.test.ts src/infra/session-delivery-queue.recovery.test.ts src/gateway/server-restart-sentinel.test.ts`
  - Passed: 273 focused tests across agent, harness, queue recovery, persistence, and Gateway recovery surfaces.
- The durable-takeover regression covers the production `agent_harness_task` source without a `sourceRunId`: after four no-send session-file-takeover retries it uses normal session-queue admission and retains the completion.
- `./node_modules/.bin/oxfmt --check ...`
- `./node_modules/.bin/oxlint ...`
- `git diff --check`
- Local `node scripts/run-tsgo.mjs -p tsconfig.core.json` was terminated by the environment with exit 137 before producing diagnostics; hosted CI remains the typecheck authority.
