### PR TITLE
fix(scripts): honor last repeated CLI flag value

### DIFF
--- a/scripts/lib/arg-utils.mjs
+++ b/scripts/lib/arg-utils.mjs
@@ -7,7 +7,7 @@ function failFlagParse(message) {
  * @internal Shared repository-script contract.
  */
 export function readFlagValue(args, name) {
-  for (let index = 0; index < args.length; index += 1) {
+  for (let index = args.length - 1; index >= 0; index -= 1) {
     const arg = args[index];
     if (arg === name) {
       return args[index + 1];

--- a/test/scripts/arg-utils.test.ts
+++ b/test/scripts/arg-utils.test.ts
@@ -4,11 +4,22 @@ import {
   booleanFlag,
   intFlag,
   parseFlagArgs,
+  readFlagValue,
   stringFlag,
   stringListFlag,
 } from "../../scripts/lib/arg-utils.mjs";
 
 describe("scripts/lib/arg-utils parseFlagArgs", () => {
+  it("uses the last value when a flag is repeated", () => {
+    expect(readFlagValue(["-p", "first.json", "-p", "second.json"], "-p")).toBe("second.json");
+    expect(
+      readFlagValue(
+        ["--tsBuildInfoFile=first.tsbuildinfo", "--tsBuildInfoFile", "second.tsbuildinfo"],
+        "--tsBuildInfoFile",
+      ),
+    ).toBe("second.tsbuildinfo");
+  });
+
   it("ignores the conventional option separator by default", () => {
     const parsed = parseFlagArgs(["--", "--limit", "30"], { limit: 10 }, [
       intFlag("--limit", "limit", { min: 1 }),


### PR DESCRIPTION
AI-assisted.

## What Problem This Solves

Fixes an issue where repository tsgo wrappers could inspect the first occurrence of a repeated `-p` or `--tsBuildInfoFile` option while tsgo used the last occurrence. Sparse-checkout guards and build-info directory preparation could therefore target a different project or path than the compiler actually used.

## Why This Change Was Made

`readFlagValue` now scans repeated options from the end, matching tsgo's effective last-value behavior. The shared helper test covers both split and inline option forms; this change does not alter single-value or list-flag parsing.

## User Impact

Developers and CI workflows that pass repeated tsgo options now receive guard diagnostics and build-info preparation for the same project and path that tsgo compiles.

## Evidence

- Final runtime proof: `node scripts/run-tsgo.mjs --showConfig -p tsconfig.scripts.json -p tsconfig.core.json` selected `tsconfig.core.json` (8,262 files), the final repeated project option.
- Sparse guard proof: a controlled repeated-`-p` runtime probe reached the `tsconfig.core.json` sparse-checkout guard rather than treating the earlier scripts project as effective.
- Focused Vitest: `test/scripts/arg-utils.test.ts` — 12 passed.
- Supporting checks: targeted oxlint passed, oxfmt check passed, and `git diff --check` passed.
- Autoreview returned clean with no actionable findings.
- Proof boundary: no broad typecheck was run; this PR is limited to shared script argument selection and its focused regression coverage.
- Exact head: `39f9b4a0f54ac273d8e31b3f0bf8eae3bbe59679`.
