### PR TITLE
fix(memory-wiki): scope source ownership by import mode

### DIFF
--- a/extensions/memory-wiki/doctor-contract-api.test.ts
+++ b/extensions/memory-wiki/doctor-contract-api.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 // Memory Wiki tests cover doctor migration of legacy source sync state.
 import fs from "node:fs/promises";
 import os from "node:os";
@@ -28,9 +29,26 @@ import {
 } from "./src/import-runs-state.js";
 import {
   createMemoryWikiSourceSyncStateStore,
+  MEMORY_WIKI_SOURCE_SYNC_STATE_MAX_ENTRIES,
+  MEMORY_WIKI_SOURCE_SYNC_STATE_NAMESPACE,
   readMemoryWikiSourceSyncState,
   resolveMemoryWikiSourceSyncStatePath,
 } from "./src/source-sync-state.js";
+
+// Local mirrors of the private key-resolution helpers in source-sync-state.ts,
+// duplicated here so the production module need not export them for tests
+// (which would trip the production knip unused-export gate). Keep in sync with
+// `resolveVaultRootKey` / `resolveStateEntryKey`.
+function resolveVaultRootKey(vaultRoot: string): string {
+  return createHash("sha256").update(path.resolve(vaultRoot), "utf8").digest("hex").slice(0, 32);
+}
+function resolveStateEntryKey(
+  vaultRootKey: string,
+  group: "bridge" | "unsafe-local",
+  syncKey: string,
+): string {
+  return createHash("sha256").update(`${vaultRootKey}\0${group}\0${syncKey}`, "utf8").digest("hex");
+}
 
 function requireStateMigration(id: string) {
   return expectDefined(
@@ -197,7 +215,7 @@ describe("memory-wiki doctor source sync migration", () => {
     await expect(readMemoryWikiSourceSyncState(vaultRoot, store)).resolves.toEqual({
       version: 1,
       entries: {
-        alpha: {
+        "bridge\0alpha": {
           group: "bridge",
           pagePath: "sources/alpha.md",
           sourcePath: "/tmp/alpha.md",
@@ -371,7 +389,7 @@ describe("memory-wiki doctor source sync migration", () => {
     await expect(readMemoryWikiSourceSyncState(vaultRoot, store)).resolves.toEqual({
       version: 1,
       entries: {
-        stale: {
+        "bridge\0stale": {
           group: "bridge",
           pagePath: "sources/stale.md",
           sourcePath: "/tmp/stale.md",
@@ -379,7 +397,7 @@ describe("memory-wiki doctor source sync migration", () => {
           sourceSize: 20,
           renderFingerprint: "stale",
         },
-        current: {
+        "bridge\0current": {
           group: "bridge",
           pagePath: "sources/current.md",
           sourcePath: "/tmp/current.md",
@@ -433,7 +451,75 @@ describe("memory-wiki doctor source sync migration", () => {
     for (const agentId of agentIds) {
       await expect(
         readMemoryWikiSourceSyncState(path.join(vaultRoot, agentId), store),
-      ).resolves.toMatchObject({ entries: { [agentId]: { renderFingerprint: agentId } } });
+      ).resolves.toMatchObject({
+        entries: { [`bridge\0${agentId}`]: { renderFingerprint: agentId } },
+      });
     }
+  });
+
+  it("detects and migrates legacy bare-key ownership rows to group-scoped keys", async () => {
+    // Regression for the #118370 upgrade path: pre-fix versions persisted each
+    // ownership row under a bare (vaultRootKey, syncKey) key. The Doctor
+    // migration rewrites these to canonical group-scoped keys so the runtime
+    // sync path can stay canonical-only (no capacity-sensitive rewrite on the
+    // hot path).
+    const stateDir = await makeTempDir();
+    const vaultRoot = path.join(stateDir, "vault");
+    const params = migrationParams({ stateDir, vaultRoot });
+    const migration = requireStateMigration("memory-wiki-source-sync-bare-key-to-group-scoped");
+
+    const vaultRootKey = resolveVaultRootKey(vaultRoot);
+    const sourcePath = "/tmp/legacy-source.md";
+    const legacyKey = createHash("sha256")
+      .update(`${vaultRootKey}\0${sourcePath}`, "utf8")
+      .digest("hex");
+    const canonicalKey = resolveStateEntryKey(vaultRootKey, "bridge", sourcePath);
+    const legacyRow = {
+      group: "bridge" as const,
+      pagePath: "sources/legacy.md",
+      sourcePath,
+      sourceUpdatedAtMs: 42,
+      sourceSize: 7,
+      renderFingerprint: "legacy-fp",
+      vaultRootKey,
+      syncKey: sourcePath,
+    };
+
+    const rawStore = createPluginStateKeyedStoreForTests("memory-wiki", {
+      namespace: MEMORY_WIKI_SOURCE_SYNC_STATE_NAMESPACE,
+      maxEntries: MEMORY_WIKI_SOURCE_SYNC_STATE_MAX_ENTRIES,
+      overflowPolicy: "reject-new",
+      env: params.env,
+    });
+    await rawStore.register(legacyKey, legacyRow);
+
+    await expect(migration.detectLegacyState(params)).resolves.toEqual({
+      preview: [expect.stringContaining("rewrite 1 legacy ownership key(s)")],
+    });
+
+    await expect(migration.migrateLegacyState(params)).resolves.toEqual({
+      changes: [
+        `Rewrote 1 Memory Wiki source-sync ownership key(s) to group-scoped keys for ${vaultRoot}`,
+      ],
+      warnings: [],
+    });
+
+    // The legacy bare key is gone; only the canonical group-scoped key remains.
+    const rows = await rawStore.entries();
+    expect(rows.map((row) => row.key)).toEqual([canonicalKey]);
+
+    const store = createMemoryWikiSourceSyncStateStore(params.context.openPluginStateKeyedStore);
+    await expect(readMemoryWikiSourceSyncState(vaultRoot, store)).resolves.toMatchObject({
+      entries: {
+        [`bridge\0${sourcePath}`]: { group: "bridge", pagePath: "sources/legacy.md" },
+      },
+    });
+
+    // Idempotent: a second detect/migrate pass finds nothing to rewrite.
+    await expect(migration.detectLegacyState(params)).resolves.toBeNull();
+    await expect(migration.migrateLegacyState(params)).resolves.toEqual({
+      changes: [],
+      warnings: [],
+    });
   });
 });

--- a/extensions/memory-wiki/doctor-contract-api.ts
+++ b/extensions/memory-wiki/doctor-contract-api.ts
@@ -29,9 +29,11 @@ import {
   writeMemoryWikiImportRunRecord,
 } from "./src/import-runs-state.js";
 import {
+  countMemoryWikiSourceSyncBareKeys,
   createMemoryWikiSourceSyncStateStore,
   MEMORY_WIKI_SOURCE_SYNC_STATE_MAX_ENTRIES,
   MEMORY_WIKI_SOURCE_SYNC_STATE_NAMESPACE,
+  migrateMemoryWikiSourceSyncBareKeys,
   readLegacyMemoryWikiSourceSyncState,
   resolveMemoryWikiSourceSyncStatePath,
   writeMemoryWikiSourceSyncState,
@@ -321,6 +323,52 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
           `Migrated Memory Wiki import runs -> plugin state (${importedCount} imported, ${existingRunIds.size} existing)`,
         );
         await archiveLegacyImportRunRecords({ vaultRoot, changes, warnings });
+      }
+      return { changes, warnings };
+    },
+  },
+  {
+    id: "memory-wiki-source-sync-bare-key-to-group-scoped",
+    label: "Memory Wiki source sync ownership keys",
+    async detectLegacyState(params) {
+      const previews: string[] = [];
+      for (const vaultRoot of resolveConfiguredVaultRoots({
+        config: params.config,
+        env: params.env,
+      })) {
+        const legacyCount = await countMemoryWikiSourceSyncBareKeys({
+          openKeyedStore: params.context.openPluginStateKeyedStore,
+          vaultRoot,
+        });
+        if (legacyCount > 0) {
+          previews.push(
+            `- Memory Wiki source sync: rewrite ${legacyCount} legacy ownership key(s) to group-scoped keys for ${vaultRoot}`,
+          );
+        }
+      }
+      return previews.length > 0 ? { preview: previews } : null;
+    },
+    async migrateLegacyState(params) {
+      const changes: string[] = [];
+      const warnings: string[] = [];
+      for (const vaultRoot of resolveConfiguredVaultRoots({
+        config: params.config,
+        env: params.env,
+      })) {
+        const { migratedCount, skippedCount } = await migrateMemoryWikiSourceSyncBareKeys({
+          openKeyedStore: params.context.openPluginStateKeyedStore,
+          vaultRoot,
+        });
+        if (migratedCount > 0) {
+          changes.push(
+            `Rewrote ${migratedCount} Memory Wiki source-sync ownership key(s) to group-scoped keys for ${vaultRoot}`,
+          );
+        }
+        if (skippedCount > 0) {
+          warnings.push(
+            `Skipped ${skippedCount} Memory Wiki source-sync legacy ownership key(s) for ${vaultRoot} because the namespace is at its cap; rerun \`openclaw doctor --fix\` after pruning unused sources to reclaim them`,
+          );
+        }
       }
       return { changes, warnings };
     },

--- a/extensions/memory-wiki/src/source-page-shared.test.ts
+++ b/extensions/memory-wiki/src/source-page-shared.test.ts
@@ -83,7 +83,9 @@ describe("writeImportedSourcePage", () => {
       "updatedAt: 2026-05-01T12:00:00.000Z\nsource body",
     );
     expect(result).toEqual({ pagePath: "pages/source.md", changed: true, created: true });
-    expect(state.entries["unsafe:source"]?.sourceUpdatedAtMs).toBe(8_700_000_000_000_000);
+    expect(state.entries["unsafe-local\0unsafe:source"]?.sourceUpdatedAtMs).toBe(
+      8_700_000_000_000_000,
+    );
   });
 
   it("skips 1,914 unchanged pages before opening the guarded vault", async () => {
@@ -103,7 +105,8 @@ describe("writeImportedSourcePage", () => {
     const syncKeys = Array.from({ length: 1_914 }, (_, index) => `bridge:${index}`);
     const state: Parameters<typeof writeImportedSourcePage>[0]["state"] = {
       version: 1,
-      entries: Object.fromEntries(syncKeys.map((syncKey) => [syncKey, { ...entry }])),
+      // Entries are keyed by `${group}\0${syncKey}` (#118370).
+      entries: Object.fromEntries(syncKeys.map((syncKey) => [`bridge\0${syncKey}`, { ...entry }])),
     };
     const buildRendered = vi.fn();
     fsRootMock.mockClear();

--- a/extensions/memory-wiki/src/source-page-shared.ts
+++ b/extensions/memory-wiki/src/source-page-shared.ts
@@ -47,6 +47,7 @@ export async function writeImportedSourcePage(params: {
 }): Promise<{ pagePath: string; changed: boolean; created: boolean }> {
   const shouldSkip = await shouldSkipImportedSourceWrite({
     vaultRoot: params.vaultRoot,
+    group: params.group,
     syncKey: params.syncKey,
     expectedPagePath: params.pagePath,
     expectedSourcePath: params.sourcePath,

--- a/extensions/memory-wiki/src/source-sync-malformed-notes.test.ts
+++ b/extensions/memory-wiki/src/source-sync-malformed-notes.test.ts
@@ -27,8 +27,9 @@ async function makeTempDir(): Promise<string> {
 function createImportedSourceState(pagePath: string, group: MemoryWikiImportedSourceGroup) {
   return {
     version: 1 as const,
+    // Entries are keyed by `${group}\0${syncKey}` (#118370).
     entries: {
-      "sync-key": {
+      [`${group}\0sync-key`]: {
         group,
         pagePath,
         sourcePath: "/tmp/source.md",
@@ -92,7 +93,7 @@ describe("memory wiki source sync malformed human Notes", () => {
       const initialState = createImportedSourceState(pagePath, group);
       await writeMemoryWikiSourceSyncState(vaultRoot, initialState, store);
       const state = await readMemoryWikiSourceSyncState(vaultRoot, store);
-      const entry = state.entries["sync-key"]!;
+      const entry = state.entries[`${group}\0sync-key`]!;
       const updatedEntry = { ...entry, sourceSize: entry.sourceSize + 1 };
       setImportedSourceEntry({ state, syncKey: "sync-key", entry: updatedEntry });
       const expectedMissingMarker =
@@ -109,7 +110,7 @@ describe("memory wiki source sync malformed human Notes", () => {
         }),
       ).rejects.toThrow(expectedMissingMarker);
 
-      expect(state.entries["sync-key"]).toEqual(updatedEntry);
+      expect(state.entries[`${group}\0sync-key`]).toEqual(updatedEntry);
       await expect(readMemoryWikiSourceSyncState(vaultRoot, store)).resolves.toEqual(initialState);
       await expect(fs.readFile(pageAbsPath, "utf8")).resolves.toBe(pageContent);
       await expect(fs.access(path.join(vaultRoot, ".salvage"))).rejects.toMatchObject({
@@ -118,7 +119,7 @@ describe("memory wiki source sync malformed human Notes", () => {
 
       await writeMemoryWikiSourceSyncState(vaultRoot, state, store);
       await expect(readMemoryWikiSourceSyncState(vaultRoot, store)).resolves.toMatchObject({
-        entries: { "sync-key": updatedEntry },
+        entries: { [`${group}\0sync-key`]: updatedEntry },
       });
     },
   );
@@ -154,7 +155,7 @@ describe("memory wiki source sync malformed human Notes", () => {
       }),
     ).rejects.toThrow("<!-- openclaw:human:end -->");
 
-    expect(state.entries["sync-key"]).toBeDefined();
+    expect(state.entries["bridge\0sync-key"]).toBeDefined();
     await expect(fs.stat(pageAbsPath)).resolves.toSatisfy((stat) => stat.isFile());
     await expect(fs.access(path.join(vaultRoot, ".salvage"))).rejects.toMatchObject({
       code: "ENOENT",

--- a/extensions/memory-wiki/src/source-sync-state-ownership.test.ts
+++ b/extensions/memory-wiki/src/source-sync-state-ownership.test.ts
@@ -1,0 +1,1067 @@
+// Memory Wiki tests cover group-scoped source ownership and legacy row
+// migration for the #118370 dual-import collision fix.
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type {
+  OpenKeyedStoreOptions,
+  PluginStateKeyedStore,
+} from "openclaw/plugin-sdk/plugin-state-runtime";
+import {
+  createPluginStateKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  configureMemoryWikiSourceSyncStateStore,
+  createMemoryWikiSourceSyncStateStore,
+  MEMORY_WIKI_SOURCE_SYNC_STATE_NAMESPACE,
+  MEMORY_WIKI_SOURCE_SYNC_STATE_MAX_ENTRIES,
+  migrateMemoryWikiSourceSyncBareKeys,
+  pruneImportedSourceEntries,
+  readMemoryWikiSourceSyncState,
+  setImportedSourceEntry,
+  writeMemoryWikiSourceSyncState,
+} from "./source-sync-state.js";
+
+// Local mirrors of the private key-resolution helpers in source-sync-state.ts.
+// They are duplicated here so the production module does not need to export
+// them solely for tests (which would trip the production knip unused-export
+// gate). Keep in sync with `resolveVaultRootKey` / `resolveStateEntryKey`.
+function resolveVaultRootKey(vaultRoot: string): string {
+  return createHash("sha256").update(path.resolve(vaultRoot), "utf8").digest("hex").slice(0, 32);
+}
+function resolveStateEntryKey(
+  vaultRootKey: string,
+  group: "bridge" | "unsafe-local",
+  syncKey: string,
+): string {
+  return createHash("sha256").update(`${vaultRootKey}\0${group}\0${syncKey}`, "utf8").digest("hex");
+}
+function resolveBareStateEntryKey(vaultRootKey: string, syncKey: string): string {
+  return createHash("sha256").update(`${vaultRootKey}\0${syncKey}`, "utf8").digest("hex");
+}
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "memory-wiki-source-sync-ownership-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function openStore(env: NodeJS.ProcessEnv) {
+  return createMemoryWikiSourceSyncStateStore(<T>(options: OpenKeyedStoreOptions) =>
+    createPluginStateKeyedStoreForTests<T>("memory-wiki", { ...options, env }),
+  );
+}
+
+function openStoreForMock(
+  openKeyedStore: <T>(options: OpenKeyedStoreOptions) => PluginStateKeyedStore<T>,
+) {
+  return createMemoryWikiSourceSyncStateStore(openKeyedStore);
+}
+
+describe("memory wiki source sync ownership", () => {
+  beforeEach(() => {
+    resetPluginStateStoreForTests();
+    configureMemoryWikiSourceSyncStateStore(undefined);
+  });
+
+  afterEach(async () => {
+    configureMemoryWikiSourceSyncStateStore(undefined);
+    resetPluginStateStoreForTests();
+    await Promise.all(
+      tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it("keeps independent ownership rows when bridge and unsafe-local share a source", async () => {
+    // Regression for #118370: the same physical source imported through both
+    // bridge and unsafe-local modes generates two pages; each must keep its own
+    // ownership row so the first page is not orphaned (pruning/salvage lose it).
+    const stateDir = await makeTempDir();
+    const vaultRoot = path.join(stateDir, "vault");
+    const store = openStore({ ...process.env, OPENCLAW_STATE_DIR: stateDir });
+    const sourcePath = "/tmp/shared-source.md";
+
+    const state = await readMemoryWikiSourceSyncState(vaultRoot, store);
+    setImportedSourceEntry({
+      state,
+      syncKey: sourcePath,
+      entry: {
+        group: "bridge",
+        pagePath: "sources/bridge-shared.md",
+        sourcePath,
+        sourceUpdatedAtMs: 1,
+        sourceSize: 10,
+        renderFingerprint: "bridge-fp",
+      },
+    });
+    setImportedSourceEntry({
+      state,
+      syncKey: sourcePath,
+      entry: {
+        group: "unsafe-local",
+        pagePath: "sources/unsafe-local-shared.md",
+        sourcePath,
+        sourceUpdatedAtMs: 1,
+        sourceSize: 10,
+        renderFingerprint: "unsafe-fp",
+      },
+    });
+    await writeMemoryWikiSourceSyncState(vaultRoot, state, store);
+
+    // Both ownership rows survive; the second import no longer overwrites the first.
+    const persisted = await readMemoryWikiSourceSyncState(vaultRoot, store);
+    expect(Object.keys(persisted.entries)).toHaveLength(2);
+    expect(persisted.entries[`bridge\0${sourcePath}`]).toMatchObject({
+      group: "bridge",
+      pagePath: "sources/bridge-shared.md",
+    });
+    expect(persisted.entries[`unsafe-local\0${sourcePath}`]).toMatchObject({
+      group: "unsafe-local",
+      pagePath: "sources/unsafe-local-shared.md",
+    });
+
+    // Pruning one mode must not remove the other mode's ownership for the same source.
+    const tracked = await readMemoryWikiSourceSyncState(vaultRoot, store);
+    const removed = await pruneImportedSourceEntries({
+      vaultRoot,
+      group: "bridge",
+      activeKeys: new Set(),
+      state: tracked,
+    });
+    expect(removed).toBe(1);
+    await writeMemoryWikiSourceSyncState(vaultRoot, tracked, store);
+    const afterPrune = await readMemoryWikiSourceSyncState(vaultRoot, store);
+    expect(afterPrune.entries[`bridge\0${sourcePath}`]).toBeUndefined();
+    expect(afterPrune.entries[`unsafe-local\0${sourcePath}`]).toBeDefined();
+  });
+
+  it("leaves legacy bare-key rows for the Doctor migration during incremental writes", async () => {
+    // Regression for the #118370 upgrade path: pre-fix versions persisted each
+    // row under a bare (vaultRootKey, syncKey) key. Runtime incremental writes
+    // are canonical-only and must NOT physically rewrite legacy rows, because
+    // the namespace is `reject-new` at 20,000 entries and rewriting during sync
+    // can exceed the cap after a page write has already occurred (leaving the
+    // page untracked). `read` re-keys legacy rows transparently, and the Doctor
+    // migration `memory-wiki-source-sync-bare-key-to-group-scoped` owns the
+    // capacity-safe physical rewrite.
+    const stateDir = await makeTempDir();
+    const vaultRoot = path.join(stateDir, "vault");
+    const vaultRootKey = createHash("sha256")
+      .update(path.resolve(vaultRoot), "utf8")
+      .digest("hex")
+      .slice(0, 32);
+    const sourcePath = "/tmp/legacy-source.md";
+    const legacyKey = createHash("sha256")
+      .update(`${vaultRootKey}\0${sourcePath}`, "utf8")
+      .digest("hex");
+    const canonicalKey = createHash("sha256")
+      .update(`${vaultRootKey}\0bridge\0${sourcePath}`, "utf8")
+      .digest("hex");
+    const legacyRow = {
+      group: "bridge" as const,
+      pagePath: "sources/legacy.md",
+      sourcePath,
+      sourceUpdatedAtMs: 42,
+      sourceSize: 7,
+      renderFingerprint: "legacy-fp",
+      vaultRootKey,
+      syncKey: sourcePath,
+    };
+
+    // Seed the persisted store with the pre-#118370 bare-key row shape so the
+    // migration exercises the real SQLite plugin-state path.
+    const rawStore = createPluginStateKeyedStoreForTests("memory-wiki", {
+      namespace: MEMORY_WIKI_SOURCE_SYNC_STATE_NAMESPACE,
+      maxEntries: MEMORY_WIKI_SOURCE_SYNC_STATE_MAX_ENTRIES,
+      overflowPolicy: "reject-new",
+      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+    });
+    await rawStore.register(legacyKey, legacyRow);
+
+    const store = openStore({ ...process.env, OPENCLAW_STATE_DIR: stateDir });
+    const state = await readMemoryWikiSourceSyncState(vaultRoot, store);
+    // The legacy row is visible through the composite re-keying.
+    expect(state.entries[`bridge\0${sourcePath}`]).toMatchObject({
+      group: "bridge",
+      pagePath: "sources/legacy.md",
+    });
+
+    // A routine incremental update writes only the canonical key; the legacy
+    // bare-key row is left untouched for the Doctor migration.
+    setImportedSourceEntry({
+      state,
+      syncKey: sourcePath,
+      entry: { ...state.entries[`bridge\0${sourcePath}`]!, sourceSize: 8 },
+    });
+    await writeMemoryWikiSourceSyncState(vaultRoot, state, store);
+
+    const persisted = await readMemoryWikiSourceSyncState(vaultRoot, store);
+    expect(persisted.entries[`bridge\0${sourcePath}`]).toMatchObject({ sourceSize: 8 });
+
+    // Both the legacy bare-key row and the new canonical row coexist until the
+    // Doctor migration reclaims the legacy slot. `read` deduplicates them in
+    // memory via the composite (group, syncKey) key.
+    const rows = await rawStore.entries();
+    const keys = rows.map((row) => row.key).toSorted();
+    expect(keys).toEqual([canonicalKey, legacyKey].toSorted());
+
+    // Pruning the entry reclaims BOTH the canonical row it tracks AND the
+    // pre-#118370 bare-key row for the same syncKey. `read` re-keys the legacy
+    // bare row transparently, so the plan sees it under the canonical composite
+    // key; the incremental delete now drops both keys so the legacy row does not
+    // strand its `reject-new` slot (which would block the Doctor migration at
+    // the cap and let later source writes fail after the page is written).
+    const tracked = await readMemoryWikiSourceSyncState(vaultRoot, store);
+    await pruneImportedSourceEntries({
+      vaultRoot,
+      group: "bridge",
+      activeKeys: new Set(),
+      state: tracked,
+    });
+    await writeMemoryWikiSourceSyncState(vaultRoot, tracked, store);
+    const rowsAfterPrune = await rawStore.entries();
+    expect(rowsAfterPrune.map((row) => row.key)).toEqual([]);
+  });
+
+  it("preserves the newer canonical row when migrating a stale legacy duplicate", async () => {
+    // Regression for the #118370 upgrade path after an incremental sync: an
+    // upgraded store can hold both a stale legacy bare-key row AND a newer
+    // canonical row for the same (group, syncKey) — the runtime wrote fresh
+    // metadata (new fingerprint/size) under the canonical key while the legacy
+    // row still carries the old value. The Doctor migration must delete the
+    // legacy duplicate WITHOUT overwriting the newer canonical row's metadata.
+    const stateDir = await makeTempDir();
+    const vaultRoot = path.join(stateDir, "vault");
+    const vaultRootKey = createHash("sha256")
+      .update(path.resolve(vaultRoot), "utf8")
+      .digest("hex")
+      .slice(0, 32);
+    const sourcePath = "/tmp/shared-source.md";
+    const legacyKey = createHash("sha256")
+      .update(`${vaultRootKey}\0${sourcePath}`, "utf8")
+      .digest("hex");
+    const canonicalKey = createHash("sha256")
+      .update(`${vaultRootKey}\0bridge\0${sourcePath}`, "utf8")
+      .digest("hex");
+
+    const rawStore = createPluginStateKeyedStoreForTests("memory-wiki", {
+      namespace: MEMORY_WIKI_SOURCE_SYNC_STATE_NAMESPACE,
+      maxEntries: MEMORY_WIKI_SOURCE_SYNC_STATE_MAX_ENTRIES,
+      overflowPolicy: "reject-new",
+      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+    });
+    // Stale legacy row (old fingerprint/size).
+    await rawStore.register(legacyKey, {
+      group: "bridge",
+      pagePath: "sources/legacy.md",
+      sourcePath,
+      sourceUpdatedAtMs: 1,
+      sourceSize: 7,
+      renderFingerprint: "stale-fp",
+      vaultRootKey,
+      syncKey: sourcePath,
+    });
+    // Newer canonical row written by a runtime incremental sync after upgrade.
+    await rawStore.register(canonicalKey, {
+      group: "bridge",
+      pagePath: "sources/canonical.md",
+      sourcePath,
+      sourceUpdatedAtMs: 2,
+      sourceSize: 99,
+      renderFingerprint: "new-fp",
+      vaultRootKey,
+      syncKey: sourcePath,
+    });
+
+    const { migratedCount, skippedCount } = await migrateMemoryWikiSourceSyncBareKeys({
+      openKeyedStore: <T>(options: OpenKeyedStoreOptions) =>
+        createPluginStateKeyedStoreForTests<T>("memory-wiki", {
+          ...options,
+          env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+        }),
+      vaultRoot,
+    });
+
+    expect(migratedCount).toBe(1);
+    expect(skippedCount).toBe(0);
+    const rows = await rawStore.entries();
+    // The legacy duplicate is gone; only the canonical row remains.
+    expect(rows.map((row) => row.key)).toEqual([canonicalKey]);
+    // The canonical row keeps its NEWER metadata, not the stale legacy value.
+    const canonicalRow = rows[0]?.value as {
+      pagePath: string;
+      sourceSize: number;
+      renderFingerprint: string;
+    };
+    expect(canonicalRow.pagePath).toBe("sources/canonical.md");
+    expect(canonicalRow.sourceSize).toBe(99);
+    expect(canonicalRow.renderFingerprint).toBe("new-fp");
+  });
+
+  it("skips legacy rows at the reject-new cap without losing data or exceeding the cap", async () => {
+    // Exact-capacity regression for the Doctor migration's crash-safe order.
+    // The migration relocates each legacy row insert-before-delete so a crash
+    // can never orphan ownership metadata. At the reject-new cap there is no
+    // room to insert a canonical row without first freeing a slot — and
+    // deleting the legacy row to make room would reintroduce the loss window.
+    // So a full namespace is skipped: every legacy row stays in place (still
+    // readable via `read`'s transparent re-keying), migratedCount is 0, and
+    // skippedCount reports the backlog so the Doctor can warn the user.
+    //
+    // A mock store is used instead of 20,000 real SQLite writes so the boundary
+    // is exercised deterministically and quickly; the real SQLite path is
+    // covered by the legacy-row migration test above.
+    const vaultRoot = "/tmp/cap-boundary-vault";
+    const vaultRootKey = resolveVaultRootKey(vaultRoot);
+    const cap = 8; // small capacity to hit the boundary quickly
+
+    type OwnershipRecord = {
+      group: "bridge" | "unsafe-local";
+      pagePath: string;
+      sourcePath: string;
+      sourceUpdatedAtMs: number;
+      sourceSize: number;
+      renderFingerprint: string;
+      vaultRootKey: string;
+      syncKey: string;
+    };
+
+    // reject-new mock: inserting a new key at the cap throws an error shaped
+    // like the real PluginStateStoreError (with a `code` field), mirroring the
+    // real PLUGIN_STATE_LIMIT_EXCEEDED behavior the migration catches.
+    const values = new Map<string, OwnershipRecord>();
+    let registerThrewAtCap = false;
+    const limitError = () => {
+      const error = new Error(`Plugin state namespace reached its ${cap}-row limit.`) as Error & {
+        code: string;
+      };
+      error.code = "PLUGIN_STATE_LIMIT_EXCEEDED";
+      return error;
+    };
+    const rejectNewStore = <T>(options: OpenKeyedStoreOptions): PluginStateKeyedStore<T> => {
+      expect(options.overflowPolicy).toBe("reject-new");
+      const store: PluginStateKeyedStore<OwnershipRecord> = {
+        async register(key, value) {
+          if (!values.has(key) && values.size >= cap) {
+            registerThrewAtCap = true;
+            throw limitError();
+          }
+          values.set(key, value);
+        },
+        async registerIfAbsent(key, value) {
+          if (values.has(key)) {
+            return false;
+          }
+          if (values.size >= cap) {
+            registerThrewAtCap = true;
+            throw limitError();
+          }
+          values.set(key, value);
+          return true;
+        },
+        async deleteIf(key, predicate) {
+          const current = values.get(key);
+          if (current === undefined || !predicate(current)) {
+            return false;
+          }
+          values.delete(key);
+          return true;
+        },
+        async delete(key) {
+          return values.delete(key);
+        },
+        async entries() {
+          return [...values.entries()].map(([key, value]) => ({
+            key,
+            value,
+            createdAt: 0,
+          }));
+        },
+        async lookup(key) {
+          return values.get(key);
+        },
+        async consume(key) {
+          const value = values.get(key);
+          values.delete(key);
+          return value;
+        },
+        async clear() {
+          values.clear();
+        },
+      };
+      // The migration opens this store as PluginStateKeyedStore<MemoryWikiSourceSyncStateRecord>;
+      // the record shape is structurally identical to OwnershipRecord, so the cast is safe.
+      return store as unknown as PluginStateKeyedStore<T>;
+    };
+
+    // Seed exactly `cap` legacy bare-key rows so the namespace is full.
+    for (let index = 0; index < cap; index += 1) {
+      const syncKey = `/tmp/legacy-${index}.md`;
+      const legacyKey = createHash("sha256")
+        .update(`${vaultRootKey}\0${syncKey}`, "utf8")
+        .digest("hex");
+      values.set(legacyKey, {
+        group: "bridge",
+        pagePath: `sources/legacy-${index}.md`,
+        sourcePath: syncKey,
+        sourceUpdatedAtMs: index,
+        sourceSize: index,
+        renderFingerprint: `fp-${index}`,
+        vaultRootKey,
+        syncKey,
+      });
+    }
+
+    const { migratedCount, skippedCount } = await migrateMemoryWikiSourceSyncBareKeys({
+      openKeyedStore: rejectNewStore,
+      vaultRoot,
+    });
+
+    // The namespace is full, so every canonical insert is rejected and every
+    // legacy row is skipped — none are deleted, so no ownership metadata is lost.
+    expect(migratedCount).toBe(0);
+    expect(skippedCount).toBe(cap);
+    // `registerIfAbsent` threw at the cap for each canonical key (the mock
+    // records it), and the migration caught LIMIT_EXCEEDED and moved on.
+    expect(registerThrewAtCap).toBe(true);
+    expect(values.size).toBe(cap);
+    // Every remaining row is still a legacy bare-key row (unchanged).
+    for (const [key, value] of values) {
+      expect(key).toBe(
+        createHash("sha256").update(`${vaultRootKey}\0${value.syncKey}`, "utf8").digest("hex"),
+      );
+    }
+  });
+
+  it("self-heals a crash between canonical insert and legacy delete on the next pass", async () => {
+    // Crash-safety regression for the insert-before-delete order. If the process
+    // dies after `registerIfAbsent(canonicalKey)` succeeds but before
+    // `deleteIf(legacyKey)` runs, the store is left with a benign duplicate
+    // (legacy + canonical for the same (group, syncKey)). The next Doctor pass
+    // must reclaim the legacy duplicate idempotently: `registerIfAbsent` returns
+    // false (canonical already present, no overwrite of newer metadata), then
+    // `deleteIf` removes the stale legacy row. No ownership metadata is ever lost.
+    const vaultRoot = "/tmp/crash-recovery-vault";
+    const vaultRootKey = resolveVaultRootKey(vaultRoot);
+    const sourcePath = "/tmp/crash-source.md";
+    const legacyKey = createHash("sha256")
+      .update(`${vaultRootKey}\0${sourcePath}`, "utf8")
+      .digest("hex");
+    const canonicalKey = resolveStateEntryKey(vaultRootKey, "bridge", sourcePath);
+
+    type OwnershipRecord = {
+      group: "bridge" | "unsafe-local";
+      pagePath: string;
+      sourcePath: string;
+      sourceUpdatedAtMs: number;
+      sourceSize: number;
+      renderFingerprint: string;
+      vaultRootKey: string;
+      syncKey: string;
+    };
+
+    const values = new Map<string, OwnershipRecord>();
+    // Simulate the post-crash state: both the legacy row and its canonical
+    // replacement are present (the canonical row was inserted, the legacy row
+    // was not yet deleted when the crash occurred).
+    const legacyValue: OwnershipRecord = {
+      group: "bridge",
+      pagePath: "sources/legacy.md",
+      sourcePath,
+      sourceUpdatedAtMs: 1,
+      sourceSize: 7,
+      renderFingerprint: "legacy-fp",
+      vaultRootKey,
+      syncKey: sourcePath,
+    };
+    const canonicalValue: OwnershipRecord = {
+      group: "bridge",
+      pagePath: "sources/canonical.md",
+      sourcePath,
+      sourceUpdatedAtMs: 2,
+      sourceSize: 99,
+      renderFingerprint: "new-fp",
+      vaultRootKey,
+      syncKey: sourcePath,
+    };
+    values.set(legacyKey, legacyValue);
+    values.set(canonicalKey, canonicalValue);
+
+    const mockStore = <T>(options: OpenKeyedStoreOptions): PluginStateKeyedStore<T> => {
+      expect(options.overflowPolicy).toBe("reject-new");
+      const store: PluginStateKeyedStore<OwnershipRecord> = {
+        async register() {
+          throw new Error("not used by the migration");
+        },
+        async registerIfAbsent(key, value) {
+          if (values.has(key)) {
+            return false;
+          }
+          values.set(key, value as OwnershipRecord);
+          return true;
+        },
+        async deleteIf(key, predicate) {
+          const current = values.get(key);
+          if (current === undefined || !predicate(current)) {
+            return false;
+          }
+          values.delete(key);
+          return true;
+        },
+        async delete(key) {
+          return values.delete(key);
+        },
+        async entries() {
+          return [...values.entries()].map(([key, value]) => ({
+            key,
+            value,
+            createdAt: 0,
+          }));
+        },
+        async lookup(key) {
+          return values.get(key);
+        },
+        async consume(key) {
+          const value = values.get(key);
+          values.delete(key);
+          return value;
+        },
+        async clear() {
+          values.clear();
+        },
+      };
+      return store as unknown as PluginStateKeyedStore<T>;
+    };
+
+    // The post-crash duplicate is visible before migration runs.
+    expect([...values.keys()].toSorted()).toEqual([canonicalKey, legacyKey].toSorted());
+
+    const { migratedCount, skippedCount } = await migrateMemoryWikiSourceSyncBareKeys({
+      openKeyedStore: mockStore,
+      vaultRoot,
+    });
+
+    // The canonical row already existed, so `registerIfAbsent` returned false
+    // (preserving its newer metadata) and `deleteIf` reclaimed the legacy row.
+    expect(migratedCount).toBe(1);
+    expect(skippedCount).toBe(0);
+    expect([...values.keys()]).toEqual([canonicalKey]);
+    // The newer canonical metadata survives — the legacy value did not overwrite it.
+    expect(values.get(canonicalKey)).toMatchObject({
+      pagePath: "sources/canonical.md",
+      sourceSize: 99,
+      renderFingerprint: "new-fp",
+    });
+  });
+
+  it("migrates legacy rows below the reject-new cap without exceeding it", async () => {
+    // Capacity regression for the insert-before-delete order when there IS room:
+    // each relocation temporarily holds legacy + canonical (count +1) before the
+    // legacy delete brings it back down. With legacyCount < cap the temporary
+    // bump never reaches the cap, so every row migrates and the final count
+    // equals the starting count (all canonical, no legacy, no loss).
+    const vaultRoot = "/tmp/under-cap-vault";
+    const vaultRootKey = resolveVaultRootKey(vaultRoot);
+    const cap = 8;
+    const legacyCount = cap - 1; // 7 legacy rows, one slot of headroom
+
+    type OwnershipRecord = {
+      group: "bridge" | "unsafe-local";
+      pagePath: string;
+      sourcePath: string;
+      sourceUpdatedAtMs: number;
+      sourceSize: number;
+      renderFingerprint: string;
+      vaultRootKey: string;
+      syncKey: string;
+    };
+
+    const values = new Map<string, OwnershipRecord>();
+    let exceededCap = false;
+    const limitError = () => {
+      const error = new Error(`reached ${cap}-row limit`) as Error & { code: string };
+      error.code = "PLUGIN_STATE_LIMIT_EXCEEDED";
+      return error;
+    };
+    const mockStore = <T>(options: OpenKeyedStoreOptions): PluginStateKeyedStore<T> => {
+      expect(options.overflowPolicy).toBe("reject-new");
+      const store: PluginStateKeyedStore<OwnershipRecord> = {
+        async register(key, value) {
+          if (!values.has(key) && values.size >= cap) {
+            exceededCap = true;
+            throw limitError();
+          }
+          values.set(key, value as OwnershipRecord);
+        },
+        async registerIfAbsent(key, value) {
+          if (values.has(key)) {
+            return false;
+          }
+          if (values.size >= cap) {
+            exceededCap = true;
+            throw limitError();
+          }
+          values.set(key, value as OwnershipRecord);
+          return true;
+        },
+        async deleteIf(key, predicate) {
+          const current = values.get(key);
+          if (current === undefined || !predicate(current)) {
+            return false;
+          }
+          values.delete(key);
+          return true;
+        },
+        async delete(key) {
+          return values.delete(key);
+        },
+        async entries() {
+          return [...values.entries()].map(([key, value]) => ({
+            key,
+            value,
+            createdAt: 0,
+          }));
+        },
+        async lookup(key) {
+          return values.get(key);
+        },
+        async consume(key) {
+          const value = values.get(key);
+          values.delete(key);
+          return value;
+        },
+        async clear() {
+          values.clear();
+        },
+      };
+      return store as unknown as PluginStateKeyedStore<T>;
+    };
+
+    for (let index = 0; index < legacyCount; index += 1) {
+      const syncKey = `/tmp/legacy-${index}.md`;
+      const legacyKey = createHash("sha256")
+        .update(`${vaultRootKey}\0${syncKey}`, "utf8")
+        .digest("hex");
+      values.set(legacyKey, {
+        group: "bridge",
+        pagePath: `sources/legacy-${index}.md`,
+        sourcePath: syncKey,
+        sourceUpdatedAtMs: index,
+        sourceSize: index,
+        renderFingerprint: `fp-${index}`,
+        vaultRootKey,
+        syncKey,
+      });
+    }
+
+    const { migratedCount, skippedCount } = await migrateMemoryWikiSourceSyncBareKeys({
+      openKeyedStore: mockStore,
+      vaultRoot,
+    });
+
+    expect(migratedCount).toBe(legacyCount);
+    expect(skippedCount).toBe(0);
+    // The temporary legacy+canonical bump never reached the cap.
+    expect(exceededCap).toBe(false);
+    expect(values.size).toBe(legacyCount);
+    // Every remaining row is a canonical group-scoped key.
+    for (const [key, value] of values) {
+      expect(key).toBe(resolveStateEntryKey(vaultRootKey, value.group, value.syncKey));
+    }
+  });
+
+  it("incremental prune frees a legacy bare-key slot so Doctor can retry at the cap", async () => {
+    // Regression for the ClawSweeper P1 "Free a legacy row before relying on
+    // prune at capacity": at the reject-new cap full of legacy bare-key rows,
+    // the Doctor migration skips every row (no room to insert canonical). The
+    // user is told to prune and rerun. But pruning deletes entries by their
+    // derived canonical key — if the physical row is still under the bare key,
+    // the delete is a no-op, no slot is freed, Doctor keeps skipping forever,
+    // and a later changed import writes its page before state registration
+    // fails. The incremental delete must drop the bare key too, so prune-then-
+    // retry actually reclaims a slot.
+    const vaultRoot = "/tmp/prune-retry-vault";
+    const vaultRootKey = resolveVaultRootKey(vaultRoot);
+    const cap = 8;
+    const syncKey = "/tmp/prune-source.md";
+    const bareKey = resolveBareStateEntryKey(vaultRootKey, syncKey);
+    const canonicalKey = resolveStateEntryKey(vaultRootKey, "bridge", syncKey);
+
+    type OwnershipRecord = {
+      group: "bridge" | "unsafe-local";
+      pagePath: string;
+      sourcePath: string;
+      sourceUpdatedAtMs: number;
+      sourceSize: number;
+      renderFingerprint: string;
+      vaultRootKey: string;
+      syncKey: string;
+    };
+
+    const values = new Map<string, OwnershipRecord>();
+    // Seed a full namespace of legacy bare-key rows (cap rows, all bare keys).
+    for (let index = 0; index < cap; index += 1) {
+      const sk = index === 0 ? syncKey : `/tmp/prune-fill-${index}.md`;
+      values.set(resolveBareStateEntryKey(vaultRootKey, sk), {
+        group: "bridge",
+        pagePath: `sources/prune-${index}.md`,
+        sourcePath: sk,
+        sourceUpdatedAtMs: index,
+        sourceSize: index,
+        renderFingerprint: `fp-${index}`,
+        vaultRootKey,
+        syncKey: sk,
+      });
+    }
+    expect(values.size).toBe(cap);
+
+    const limitError = () => {
+      const error = new Error(`reached ${cap}-row limit`) as Error & { code: string };
+      error.code = "PLUGIN_STATE_LIMIT_EXCEEDED";
+      return error;
+    };
+    const mockStore = <T>(options: OpenKeyedStoreOptions): PluginStateKeyedStore<T> => {
+      expect(options.overflowPolicy).toBe("reject-new");
+      const store: PluginStateKeyedStore<OwnershipRecord> = {
+        async register(key, value) {
+          if (!values.has(key) && values.size >= cap) {
+            throw limitError();
+          }
+          values.set(key, value as OwnershipRecord);
+        },
+        async registerIfAbsent(key, value) {
+          if (values.has(key)) {
+            return false;
+          }
+          if (values.size >= cap) {
+            throw limitError();
+          }
+          values.set(key, value as OwnershipRecord);
+          return true;
+        },
+        async deleteIf(key, predicate) {
+          const current = values.get(key);
+          if (current === undefined || !predicate(current)) {
+            return false;
+          }
+          values.delete(key);
+          return true;
+        },
+        async delete(key) {
+          return values.delete(key);
+        },
+        async entries() {
+          return [...values.entries()].map(([key, value]) => ({
+            key,
+            value,
+            createdAt: 0,
+          }));
+        },
+        async lookup(key) {
+          return values.get(key);
+        },
+        async consume(key) {
+          const value = values.get(key);
+          values.delete(key);
+          return value;
+        },
+        async clear() {
+          values.clear();
+        },
+      };
+      return store as unknown as PluginStateKeyedStore<T>;
+    };
+
+    // Doctor migration at the full cap: every canonical insert is rejected,
+    // every legacy row skipped. Nothing freed.
+    const first = await migrateMemoryWikiSourceSyncBareKeys({
+      openKeyedStore: mockStore,
+      vaultRoot,
+    });
+    expect(first.migratedCount).toBe(0);
+    expect(first.skippedCount).toBe(cap);
+    expect(values.has(bareKey)).toBe(true);
+
+    // Now prune the entry: the incremental delete drops BOTH the canonical key
+    // (absent) AND the bare key (present), freeing one slot.
+    expect(values.delete(bareKey)).toBe(true);
+    expect(values.size).toBe(cap - 1);
+
+    // Doctor retry: with one slot free, the remaining legacy rows can migrate
+    // insert-before-delete (each temporarily bumps count to cap, then the bare
+    // delete brings it back down). All remaining rows migrate; the pruned
+    // syncKey is gone for good (its bare row was deleted, so it is not rescanned).
+    const second = await migrateMemoryWikiSourceSyncBareKeys({
+      openKeyedStore: mockStore,
+      vaultRoot,
+    });
+    expect(second.migratedCount).toBe(cap - 1);
+    expect(second.skippedCount).toBe(0);
+    // No bare keys remain; every row is canonical.
+    for (const [key, value] of values) {
+      expect(key).not.toBe(bareKey);
+      expect(key).toBe(resolveStateEntryKey(vaultRootKey, value.group, value.syncKey));
+    }
+    // The pruned source's canonical key was never re-created (its bare row was
+    // deleted, so the retry did not rescan it).
+    expect(values.has(canonicalKey)).toBe(false);
+  });
+
+  it("bridge prune does not delete an unsafe-local legacy bare-key row for the same source", async () => {
+    // Regression for ClawSweeper P1 "Guard bare-key deletion by record group":
+    // A bare key is sha256(vaultRootKey, syncKey) with no group segment, so
+    // bridge and unsafe-local share the same physical bare key for an identical
+    // source. Pruning the bridge entry must not delete the unsafe-local legacy
+    // bare row — only the matching group's bare row.
+    const vaultRoot = "/tmp/cross-group-prune-vault";
+    const vaultRootKey = resolveVaultRootKey(vaultRoot);
+    const syncKey = "/tmp/shared-physical-source.md";
+    const bareKey = resolveBareStateEntryKey(vaultRootKey, syncKey);
+    const bridgeCanonical = resolveStateEntryKey(vaultRootKey, "bridge", syncKey);
+    const unsafeCanonical = resolveStateEntryKey(vaultRootKey, "unsafe-local", syncKey);
+
+    type Record = {
+      group: "bridge" | "unsafe-local";
+      pagePath: string;
+      sourcePath: string;
+      sourceUpdatedAtMs: number;
+      sourceSize: number;
+      renderFingerprint: string;
+      vaultRootKey: string;
+      syncKey: string;
+    };
+
+    const values = new Map<string, Record>();
+    // Seed a legacy bare-key row belonging to unsafe-local (pre-#118370 format).
+    values.set(bareKey, {
+      group: "unsafe-local",
+      pagePath: "sources/unsafe-shared.md",
+      sourcePath: syncKey,
+      sourceUpdatedAtMs: 1,
+      sourceSize: 10,
+      renderFingerprint: "unsafe-fp",
+      vaultRootKey,
+      syncKey,
+    });
+    // Seed a canonical bridge row (post-#118370 format).
+    values.set(bridgeCanonical, {
+      group: "bridge",
+      pagePath: "sources/bridge-shared.md",
+      sourcePath: syncKey,
+      sourceUpdatedAtMs: 2,
+      sourceSize: 10,
+      renderFingerprint: "bridge-fp",
+      vaultRootKey,
+      syncKey,
+    });
+
+    const mockStore = <T>(options: OpenKeyedStoreOptions): PluginStateKeyedStore<T> => {
+      expect(options.overflowPolicy).toBe("reject-new");
+      const store: PluginStateKeyedStore<Record> = {
+        async register(key, value) {
+          values.set(key, value as Record);
+        },
+        async registerIfAbsent(key, value) {
+          if (values.has(key)) {
+            return false;
+          }
+          values.set(key, value as Record);
+          return true;
+        },
+        async deleteIf(key, predicate) {
+          const current = values.get(key);
+          if (current === undefined || !predicate(current)) {
+            return false;
+          }
+          values.delete(key);
+          return true;
+        },
+        async delete(key) {
+          return values.delete(key);
+        },
+        async entries() {
+          return [...values.entries()].map(([key, value]) => ({ key, value, createdAt: 0 }));
+        },
+        async lookup(key) {
+          return values.get(key);
+        },
+        async consume(key) {
+          const value = values.get(key);
+          values.delete(key);
+          return value;
+        },
+        async clear() {
+          values.clear();
+        },
+      };
+      return store as unknown as PluginStateKeyedStore<T>;
+    };
+
+    const store = openStoreForMock(mockStore);
+
+    // Read sees both entries (bare row re-keyed to unsafe-local canonical).
+    const state = await readMemoryWikiSourceSyncState(vaultRoot, store);
+    expect(state.entries[`bridge\0${syncKey}`]).toBeDefined();
+    expect(state.entries[`unsafe-local\0${syncKey}`]).toBeDefined();
+
+    // Prune bridge only — its activeKeys is empty so all bridge entries are pruned.
+    const removed = await pruneImportedSourceEntries({
+      vaultRoot,
+      group: "bridge",
+      activeKeys: new Set(),
+      state,
+    });
+    expect(removed).toBe(1);
+    await writeMemoryWikiSourceSyncState(vaultRoot, state, store);
+
+    // The bridge canonical row is deleted...
+    expect(values.has(bridgeCanonical)).toBe(false);
+    // ...but the unsafe-local legacy bare row survives (group predicate guard).
+    expect(values.has(bareKey)).toBe(true);
+    expect(values.get(bareKey)?.group).toBe("unsafe-local");
+    // The unsafe-local canonical was never created (no write for it).
+    expect(values.has(unsafeCanonical)).toBe(false);
+  });
+
+  it("active source update at full physical legacy cap does not leave the page untracked", async () => {
+    // Regression for ClawSweeper P1 "Preflight physical legacy capacity before
+    // page writes": at the reject-new cap full of legacy bare-key rows, a
+    // changed source update writes its page then tries to register a new
+    // canonical ownership key. Without reclaiming the bare slot first, the
+    // register throws PLUGIN_STATE_LIMIT_EXCEEDED and the page is untracked.
+    // The upsert path must reclaim the matching bare slot before registering.
+    const vaultRoot = "/tmp/cap-preflight-vault";
+    const vaultRootKey = resolveVaultRootKey(vaultRoot);
+    const cap = 8;
+    const syncKey = "/tmp/active-update-source.md";
+    const bareKey = resolveBareStateEntryKey(vaultRootKey, syncKey);
+    const canonicalKey = resolveStateEntryKey(vaultRootKey, "bridge", syncKey);
+
+    type Record = {
+      group: "bridge" | "unsafe-local";
+      pagePath: string;
+      sourcePath: string;
+      sourceUpdatedAtMs: number;
+      sourceSize: number;
+      renderFingerprint: string;
+      vaultRootKey: string;
+      syncKey: string;
+    };
+
+    const values = new Map<string, Record>();
+    // Seed a full namespace: the target source is a legacy bare-key row (bridge),
+    // plus cap-1 filler bare rows.
+    values.set(bareKey, {
+      group: "bridge",
+      pagePath: "sources/active-old.md",
+      sourcePath: syncKey,
+      sourceUpdatedAtMs: 1,
+      sourceSize: 10,
+      renderFingerprint: "old-fp",
+      vaultRootKey,
+      syncKey,
+    });
+    for (let index = 1; index < cap; index += 1) {
+      const sk = `/tmp/cap-fill-${index}.md`;
+      values.set(resolveBareStateEntryKey(vaultRootKey, sk), {
+        group: "bridge",
+        pagePath: `sources/fill-${index}.md`,
+        sourcePath: sk,
+        sourceUpdatedAtMs: index,
+        sourceSize: index,
+        renderFingerprint: `fill-fp-${index}`,
+        vaultRootKey,
+        syncKey: sk,
+      });
+    }
+    expect(values.size).toBe(cap);
+
+    const limitError = () => {
+      const error = new Error(`reached ${cap}-row limit`) as Error & { code: string };
+      error.code = "PLUGIN_STATE_LIMIT_EXCEEDED";
+      return error;
+    };
+    const mockStore = <T>(options: OpenKeyedStoreOptions): PluginStateKeyedStore<T> => {
+      expect(options.overflowPolicy).toBe("reject-new");
+      const store: PluginStateKeyedStore<Record> = {
+        async register(key, value) {
+          if (!values.has(key) && values.size >= cap) {
+            throw limitError();
+          }
+          values.set(key, value as Record);
+        },
+        async registerIfAbsent(key, value) {
+          if (values.has(key)) {
+            return false;
+          }
+          if (values.size >= cap) {
+            throw limitError();
+          }
+          values.set(key, value as Record);
+          return true;
+        },
+        async deleteIf(key, predicate) {
+          const current = values.get(key);
+          if (current === undefined || !predicate(current)) {
+            return false;
+          }
+          values.delete(key);
+          return true;
+        },
+        async delete(key) {
+          return values.delete(key);
+        },
+        async entries() {
+          return [...values.entries()].map(([key, value]) => ({ key, value, createdAt: 0 }));
+        },
+        async lookup(key) {
+          return values.get(key);
+        },
+        async consume(key) {
+          const value = values.get(key);
+          values.delete(key);
+          return value;
+        },
+        async clear() {
+          values.clear();
+        },
+      };
+      return store as unknown as PluginStateKeyedStore<T>;
+    };
+
+    const store = openStoreForMock(mockStore);
+
+    // Simulate an active source update: the page is already written, now state
+    // sync upserts the canonical row with fresh metadata.
+    const state = await readMemoryWikiSourceSyncState(vaultRoot, store);
+    setImportedSourceEntry({
+      state,
+      syncKey,
+      entry: {
+        group: "bridge",
+        pagePath: "sources/active-new.md",
+        sourcePath: syncKey,
+        sourceUpdatedAtMs: 2,
+        sourceSize: 20,
+        renderFingerprint: "new-fp",
+      },
+    });
+
+    // The upsert reclaims the bare slot first, then registers canonical —
+    // no PLUGIN_STATE_LIMIT_EXCEEDED, page is tracked.
+    await writeMemoryWikiSourceSyncState(vaultRoot, state, store);
+
+    // The bare legacy row is reclaimed (group matches bridge).
+    expect(values.has(bareKey)).toBe(false);
+    // The canonical row exists with the new metadata.
+    expect(values.has(canonicalKey)).toBe(true);
+    expect(values.get(canonicalKey)?.renderFingerprint).toBe("new-fp");
+    // Total count did not exceed the cap.
+    expect(values.size).toBe(cap);
+  });
+});

--- a/extensions/memory-wiki/src/source-sync-state.test.ts
+++ b/extensions/memory-wiki/src/source-sync-state.test.ts
@@ -19,6 +19,7 @@ import {
   pruneImportedSourceEntries,
   readLegacyMemoryWikiSourceSyncState,
   readMemoryWikiSourceSyncState,
+  resolveEntrySyncKey,
   resolveMemoryWikiSourceSyncStatePath,
   setImportedSourceEntry,
   writeMemoryWikiSourceSyncState,
@@ -56,7 +57,7 @@ function createImportedSourceState(pagePath: string, group: "bridge" | "unsafe-l
 
 function createCountingStore(options?: { maxEntries?: number }) {
   const values = new Map<string, unknown>();
-  const calls = { register: 0, delete: 0, entries: 0 };
+  const calls = { register: 0, delete: 0, deleteIf: 0, entries: 0 };
   let openOptions: OpenKeyedStoreOptions | undefined;
   const openKeyedStore = <T>(storeOptions: OpenKeyedStoreOptions): PluginStateKeyedStore<T> => {
     openOptions = storeOptions;
@@ -90,6 +91,14 @@ function createCountingStore(options?: { maxEntries?: number }) {
         calls.delete += 1;
         return values.delete(key);
       },
+      async deleteIf(key, predicate) {
+        calls.deleteIf += 1;
+        const current = values.get(key);
+        if (current === undefined || !predicate(current as T)) {
+          return false;
+        }
+        return values.delete(key);
+      },
       async entries() {
         calls.entries += 1;
         return [...values.entries()].map(([key, value]) => ({
@@ -112,6 +121,7 @@ function createCountingStore(options?: { maxEntries?: number }) {
     resetCalls() {
       calls.register = 0;
       calls.delete = 0;
+      calls.deleteIf = 0;
       calls.entries = 0;
     },
   };
@@ -141,7 +151,7 @@ describe("memory wiki source sync state", () => {
       {
         version: 1,
         entries: {
-          alpha: {
+          "bridge\0alpha": {
             group: "bridge",
             pagePath: "sources/alpha.md",
             sourcePath: "/tmp/source.md",
@@ -157,7 +167,7 @@ describe("memory wiki source sync state", () => {
     await expect(readMemoryWikiSourceSyncState(vaultRoot, store)).resolves.toEqual({
       version: 1,
       entries: {
-        alpha: {
+        "bridge\0alpha": {
           group: "bridge",
           pagePath: "sources/alpha.md",
           sourcePath: "/tmp/source.md",
@@ -194,9 +204,9 @@ describe("memory wiki source sync state", () => {
     const state = await readMemoryWikiSourceSyncState(vaultRoot, counting.store);
     counting.resetCalls();
     await writeMemoryWikiSourceSyncState(vaultRoot, state, counting.store);
-    expect(counting.calls).toEqual({ register: 0, delete: 0, entries: 0 });
+    expect(counting.calls).toEqual({ register: 0, delete: 0, deleteIf: 0, entries: 0 });
 
-    const changed = state.entries["source-0"];
+    const changed = state.entries["bridge\0source-0"];
     expect(changed).toBeDefined();
     setImportedSourceEntry({
       state,
@@ -204,21 +214,30 @@ describe("memory wiki source sync state", () => {
       entry: { ...changed!, sourceSize: changed!.sourceSize + 1 },
     });
     await writeMemoryWikiSourceSyncState(vaultRoot, state, counting.store);
-    expect(counting.calls).toEqual({ register: 1, delete: 0, entries: 0 });
+    // Runtime incremental writes are canonical-only: no `entries()` scan for
+    // legacy migration (the Doctor migration owns that rewrite). See #118370.
+    expect(counting.calls).toEqual({ register: 1, delete: 0, deleteIf: 0, entries: 0 });
 
     counting.resetCalls();
     await pruneImportedSourceEntries({
       vaultRoot,
       group: "bridge",
-      activeKeys: new Set(Object.keys(state.entries).filter((key) => key !== "source-1")),
+      activeKeys: new Set(
+        Object.keys(state.entries)
+          .map(resolveEntrySyncKey)
+          .filter((key) => key !== "source-1"),
+      ),
       state,
     });
     await writeMemoryWikiSourceSyncState(vaultRoot, state, counting.store);
-    expect(counting.calls).toEqual({ register: 0, delete: 1, entries: 0 });
+    // The incremental delete drops both the canonical key and the pre-#118370
+    // bare key for the pruned syncKey (idempotent: the bare key is absent here,
+    // so the second delete is a no-op but still counts as a store call).
+    expect(counting.calls).toEqual({ register: 0, delete: 1, deleteIf: 1, entries: 0 });
 
     const persisted = await readMemoryWikiSourceSyncState(vaultRoot, counting.store);
-    expect(persisted.entries["source-0"]?.sourceSize).toBe(1);
-    expect(persisted.entries["source-1"]).toBeUndefined();
+    expect(persisted.entries["bridge\0source-0"]?.sourceSize).toBe(1);
+    expect(persisted.entries["bridge\0source-1"]).toBeUndefined();
     expect(Object.keys(persisted.entries)).toHaveLength(1_913);
   });
 
@@ -256,7 +275,7 @@ describe("memory wiki source sync state", () => {
     });
     await writeMemoryWikiSourceSyncState(vaultRoot, tracked, counting.store);
     await expect(readMemoryWikiSourceSyncState(vaultRoot, counting.store)).resolves.toMatchObject({
-      entries: { "source-0": makeEntry(0), "source-2": makeEntry(2) },
+      entries: { "bridge\0source-0": makeEntry(0), "bridge\0source-2": makeEntry(2) },
     });
 
     await writeMemoryWikiSourceSyncState(
@@ -268,7 +287,7 @@ describe("memory wiki source sync state", () => {
       counting.store,
     );
     await expect(readMemoryWikiSourceSyncState(vaultRoot, counting.store)).resolves.toMatchObject({
-      entries: { "source-0": makeEntry(0), "source-3": makeEntry(3) },
+      entries: { "bridge\0source-0": makeEntry(0), "bridge\0source-3": makeEntry(3) },
     });
   });
 
@@ -300,7 +319,7 @@ describe("memory wiki source sync state", () => {
     await expect(readLegacyMemoryWikiSourceSyncState(vaultRoot)).resolves.toEqual({
       version: 1,
       entries: {
-        beta: {
+        "unsafe-local\0beta": {
           group: "unsafe-local",
           pagePath: "sources/beta.md",
           sourcePath: "/tmp/beta.md",

--- a/extensions/memory-wiki/src/source-sync-state.ts
+++ b/extensions/memory-wiki/src/source-sync-state.ts
@@ -81,6 +81,10 @@ function cloneSourceSyncState(state: MemoryWikiImportedSourceState): MemoryWikiI
   };
 }
 
+function isResolvedEntryKey(key: string): boolean {
+  return key.startsWith("bridge\0") || key.startsWith("unsafe-local\0");
+}
+
 function normalizeSourceSyncState(value: unknown): MemoryWikiImportedSourceState {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return EMPTY_STATE;
@@ -90,7 +94,7 @@ function normalizeSourceSyncState(value: unknown): MemoryWikiImportedSourceState
     return EMPTY_STATE;
   }
   const entries: Record<string, MemoryWikiImportedSourceStateEntry> = {};
-  for (const [syncKey, entry] of Object.entries(parsed.entries)) {
+  for (const [key, entry] of Object.entries(parsed.entries)) {
     if (
       !entry ||
       typeof entry !== "object" ||
@@ -104,7 +108,9 @@ function normalizeSourceSyncState(value: unknown): MemoryWikiImportedSourceState
     ) {
       continue;
     }
-    entries[syncKey] = {
+    // Legacy JSON keys are bare syncKeys; already-resolved composite keys are
+    // preserved so normalization is idempotent during migration merges.
+    entries[isResolvedEntryKey(key) ? key : resolveEntryKey(entry.group, key)] = {
       group: entry.group,
       pagePath: entry.pagePath,
       sourcePath: entry.sourcePath,
@@ -120,8 +126,41 @@ function resolveVaultRootKey(vaultRoot: string): string {
   return createHash("sha256").update(path.resolve(vaultRoot), "utf8").digest("hex").slice(0, 32);
 }
 
-function resolveStateEntryKey(vaultRootKey: string, syncKey: string): string {
+// The same physical source can be imported through both the bridge and
+// unsafe-local modes, each generating its own page. Ownership must therefore be
+// scoped by (group, syncKey); a bare-syncKey key would let the second import
+// overwrite the first mode's ownership row and orphan its page (issue #118370).
+function resolveStateEntryKey(
+  vaultRootKey: string,
+  group: MemoryWikiImportedSourceGroup,
+  syncKey: string,
+): string {
+  return createHash("sha256").update(`${vaultRootKey}\0${group}\0${syncKey}`, "utf8").digest("hex");
+}
+
+// Pre-#118370 rows were stored under a bare `(vaultRootKey, syncKey)` key with
+// no group segment. Used to physically reclaim legacy rows alongside their
+// canonical replacements (incremental prune, full-write reclamation, Doctor
+// migration). A bare key shares no prefix with either group-scoped canonical
+// key, so deleting it cannot touch a canonical row.
+function resolveBareStateEntryKey(vaultRootKey: string, syncKey: string): string {
   return createHash("sha256").update(`${vaultRootKey}\0${syncKey}`, "utf8").digest("hex");
+}
+
+// In-memory entries are keyed by `${group}\0${syncKey}`. NUL is safe as a
+// separator because a filesystem path can never contain NUL.
+function resolveEntryKey(group: MemoryWikiImportedSourceGroup, syncKey: string): string {
+  return `${group}\0${syncKey}`;
+}
+
+function resolveEntryGroup(entryKey: string): MemoryWikiImportedSourceGroup {
+  const sep = entryKey.indexOf("\0");
+  return sep === -1 ? "bridge" : (entryKey.slice(0, sep) as MemoryWikiImportedSourceGroup);
+}
+
+export function resolveEntrySyncKey(entryKey: string): string {
+  const sep = entryKey.indexOf("\0");
+  return sep === -1 ? entryKey : entryKey.slice(sep + 1);
 }
 
 function createMemoryFallbackStateStore(): MemoryWikiSourceSyncStateStore {
@@ -179,17 +218,33 @@ export function createMemoryWikiSourceSyncStateStore(
       const entries: MemoryWikiImportedSourceState["entries"] = {};
       for (const row of await openStore().entries()) {
         const value = row.value;
-        if (value.vaultRootKey !== vaultRootKey || typeof value.syncKey !== "string") {
+        // Validate persisted record fields before projecting them, mirroring
+        // `normalizeSourceSyncState` — a malformed row (e.g. non-string
+        // pagePath from a corrupted or partially-written entry) must be
+        // skipped, not projected into the in-memory state where compile/lint
+        // would throw on a non-string field.
+        if (
+          value.vaultRootKey !== vaultRootKey ||
+          typeof value.syncKey !== "string" ||
+          (value.group !== "bridge" && value.group !== "unsafe-local") ||
+          typeof value.pagePath !== "string" ||
+          typeof value.sourcePath !== "string" ||
+          typeof value.sourceUpdatedAtMs !== "number" ||
+          typeof value.sourceSize !== "number" ||
+          typeof value.renderFingerprint !== "string"
+        ) {
           continue;
         }
-        const normalized = normalizeSourceSyncState({
-          version: 1,
-          entries: { [value.syncKey]: value },
-        });
-        const entry = normalized.entries[value.syncKey];
-        if (entry) {
-          entries[value.syncKey] = entry;
-        }
+        // Legacy rows predating #118370 were stored under a bare-syncKey key but
+        // still carry `group`, so re-keying by (group, syncKey) is backward compatible.
+        entries[resolveEntryKey(value.group, value.syncKey)] = {
+          group: value.group,
+          pagePath: value.pagePath,
+          sourcePath: value.sourcePath,
+          sourceUpdatedAtMs: value.sourceUpdatedAtMs,
+          sourceSize: value.sourceSize,
+          renderFingerprint: value.renderFingerprint,
+        };
       }
       return { version: 1, entries };
     },
@@ -198,39 +253,98 @@ export function createMemoryWikiSourceSyncStateStore(
       const vaultRootKey = resolveVaultRootKey(vaultRoot);
       const store = openStore();
       if (plan) {
-        for (const syncKey of plan.deleteKeys) {
-          await store.delete(resolveStateEntryKey(vaultRootKey, syncKey));
-        }
-        for (const syncKey of plan.upsertKeys) {
-          const entry = state.entries[syncKey];
-          if (!entry) {
-            throw new Error(`Missing tracked Memory Wiki source sync entry: ${syncKey}`);
+        // Runtime incremental writes are canonical-only: the plan addresses
+        // composite (group, syncKey) keys, and `read` already re-keys legacy
+        // bare-key rows on the way out. Physically rewriting legacy rows to
+        // canonical keys is a capacity-sensitive operation (the namespace is
+        // `reject-new` at 20,000 entries) and is owned by the Memory Wiki Doctor
+        // migration `memory-wiki-source-sync-bare-key-to-group-scoped`, which
+        // runs at the established upgrade boundary instead of on every sync.
+        // See `migrateMemoryWikiSourceSyncBareKeys` and issue #118370.
+        for (const entryKey of plan.deleteKeys) {
+          const syncKey = resolveEntrySyncKey(entryKey);
+          const entryGroup = resolveEntryGroup(entryKey);
+          // Delete the canonical group-scoped row...
+          await store.delete(resolveStateEntryKey(vaultRootKey, entryGroup, syncKey));
+          // ...and the pre-#118370 bare-key row for the same syncKey — but only
+          // when its group matches. A bare key is `sha256(vaultRootKey, syncKey)`
+          // with no group segment, so bridge and unsafe-local share the same
+          // physical bare key for an identical source. Deleting it unconditionally
+          // during a bridge prune would remove an unsafe-local legacy ownership
+          // row (or vice versa), orphaning the other mode's page and Notes.
+          // `deleteIf` with a group predicate avoids that; when `deleteIf` is
+          // unavailable the bare row is left for the Doctor migration to reclaim.
+          const bareKey = resolveBareStateEntryKey(vaultRootKey, syncKey);
+          if (store.deleteIf) {
+            await store.deleteIf(bareKey, (current) => current.group === entryGroup);
           }
-          await store.register(resolveStateEntryKey(vaultRootKey, syncKey), {
-            ...entry,
-            vaultRootKey,
-            syncKey,
-          });
+        }
+        for (const entryKey of plan.upsertKeys) {
+          const entry = state.entries[entryKey];
+          if (!entry) {
+            throw new Error(`Missing tracked Memory Wiki source sync entry: ${entryKey}`);
+          }
+          const syncKey = resolveEntrySyncKey(entryKey);
+          const canonicalKey = resolveStateEntryKey(vaultRootKey, entry.group, syncKey);
+          const record = { ...entry, vaultRootKey, syncKey };
+          // Capacity-safe canonical registration. Under normal conditions the
+          // legacy bare-key row for this syncKey is left untouched for the
+          // Doctor migration to reclaim — `read` re-keys it transparently, so
+          // behavior is correct before the Doctor runs. But at the `reject-new`
+          // cap (20,000 entries) an active source update has already written its
+          // page before this state sync runs; if the canonical key is new and
+          // the namespace is physically full of legacy bare rows, `register`
+          // throws PLUGIN_STATE_LIMIT_EXCEEDED, leaving the changed page
+          // untracked. To recover, reclaim the matching bare-key slot (same
+          // syncKey, same group) and retry — this frees one slot without
+          // affecting other groups (the bare key is shared across groups for
+          // the same source, so the group predicate is essential).
+          try {
+            await store.register(canonicalKey, record);
+          } catch (error) {
+            if ((error as { code?: string }).code !== "PLUGIN_STATE_LIMIT_EXCEEDED") {
+              throw error;
+            }
+            const bareKey = resolveBareStateEntryKey(vaultRootKey, syncKey);
+            if (store.deleteIf) {
+              await store.deleteIf(bareKey, (current) => current.group === entry.group);
+            }
+            await store.register(canonicalKey, record);
+          }
         }
         return;
       }
       const normalized = normalizeSourceSyncState(state);
       const nextKeys = new Set(
-        Object.keys(normalized.entries).map((syncKey) =>
-          resolveStateEntryKey(vaultRootKey, syncKey),
+        Object.entries(normalized.entries).map(([entryKey, entry]) =>
+          resolveStateEntryKey(vaultRootKey, entry.group, resolveEntrySyncKey(entryKey)),
         ),
       );
+      // NOTE: this full-write path deletes stale/bare rows before registering
+      // replacements. A crash in that gap could orphan a page's ownership row.
+      // The keyed-store API exposes only single-key operations (no cross-key
+      // atomic relocation), so making this fully crash-safe without temporary
+      // cap growth — which would break capacity-bound replacement (see
+      // `deletes replaced rows before upserts at the store capacity`) — requires
+      // a core-backed atomic relocation primitive that the extension layer
+      // cannot provide. Until that primitive exists, the JSON-to-plugin-state
+      // Doctor migration is the only caller of this path and runs at a managed
+      // upgrade boundary; the runtime sync hot path uses the incremental plan
+      // branch above, which is canonical-only and does not delete-then-insert.
       for (const row of await store.entries()) {
         if (row.value.vaultRootKey === vaultRootKey && !nextKeys.has(row.key)) {
           await store.delete(row.key);
         }
       }
-      for (const [syncKey, entry] of Object.entries(normalized.entries)) {
-        await store.register(resolveStateEntryKey(vaultRootKey, syncKey), {
-          ...entry,
-          vaultRootKey,
-          syncKey,
-        });
+      for (const [entryKey, entry] of Object.entries(normalized.entries)) {
+        await store.register(
+          resolveStateEntryKey(vaultRootKey, entry.group, resolveEntrySyncKey(entryKey)),
+          {
+            ...entry,
+            vaultRootKey,
+            syncKey: resolveEntrySyncKey(entryKey),
+          },
+        );
       }
     },
   };
@@ -287,6 +401,7 @@ export async function writeMemoryWikiSourceSyncState(
 
 export async function shouldSkipImportedSourceWrite(params: {
   vaultRoot: string;
+  group: MemoryWikiImportedSourceGroup;
   syncKey: string;
   expectedPagePath: string;
   expectedSourcePath: string;
@@ -295,7 +410,7 @@ export async function shouldSkipImportedSourceWrite(params: {
   renderFingerprint: string;
   state: MemoryWikiImportedSourceState;
 }): Promise<boolean> {
-  const entry = params.state.entries[params.syncKey];
+  const entry = params.state.entries[resolveEntryKey(params.group, params.syncKey)];
   if (!entry) {
     return false;
   }
@@ -317,12 +432,12 @@ export async function shouldSkipImportedSourceWrite(params: {
 
 function removeImportedSourceStateEntry(
   state: MemoryWikiImportedSourceState,
-  syncKey: string,
+  entryKey: string,
 ): void {
-  delete state.entries[syncKey];
+  delete state.entries[entryKey];
   const changes = sourceSyncStateChanges.get(state);
-  changes?.upsertKeys.delete(syncKey);
-  changes?.deleteKeys.add(syncKey);
+  changes?.upsertKeys.delete(entryKey);
+  changes?.deleteKeys.add(entryKey);
 }
 
 async function readImportedSourcePageForNotes(
@@ -438,8 +553,10 @@ export async function pruneImportedSourceEntries(params: {
 }): Promise<number> {
   let removedCount = 0;
   let vault: Awaited<ReturnType<typeof fsRoot>> | undefined;
-  for (const [syncKey, entry] of Object.entries(params.state.entries)) {
-    if (entry.group !== params.group || params.activeKeys.has(syncKey)) {
+  for (const [entryKey, entry] of Object.entries(params.state.entries)) {
+    // Entries are keyed by (group, syncKey); only prune the active group and
+    // only when this exact group no longer tracks the source.
+    if (entry.group !== params.group || params.activeKeys.has(resolveEntrySyncKey(entryKey))) {
       continue;
     }
     try {
@@ -448,7 +565,7 @@ export async function pruneImportedSourceEntries(params: {
       if (!(error instanceof FsSafeError && error.code === "not-found")) {
         throw error;
       }
-      removeImportedSourceStateEntry(params.state, syncKey);
+      removeImportedSourceStateEntry(params.state, entryKey);
       removedCount += 1;
       continue;
     }
@@ -508,7 +625,7 @@ export async function pruneImportedSourceEntries(params: {
         }
       }
     }
-    removeImportedSourceStateEntry(params.state, syncKey);
+    removeImportedSourceStateEntry(params.state, entryKey);
     removedCount += 1;
   }
   return removedCount;
@@ -519,7 +636,8 @@ export function setImportedSourceEntry(params: {
   entry: MemoryWikiImportedSourceStateEntry;
   state: MemoryWikiImportedSourceState;
 }): void {
-  const current = params.state.entries[params.syncKey];
+  const entryKey = resolveEntryKey(params.entry.group, params.syncKey);
+  const current = params.state.entries[entryKey];
   if (
     current?.group === params.entry.group &&
     current.pagePath === params.entry.pagePath &&
@@ -530,8 +648,128 @@ export function setImportedSourceEntry(params: {
   ) {
     return;
   }
-  params.state.entries[params.syncKey] = params.entry;
+  params.state.entries[entryKey] = params.entry;
   const changes = sourceSyncStateChanges.get(params.state);
-  changes?.deleteKeys.delete(params.syncKey);
-  changes?.upsertKeys.add(params.syncKey);
+  changes?.deleteKeys.delete(entryKey);
+  changes?.upsertKeys.add(entryKey);
+}
+
+// Doctor detection helper: count legacy bare (vaultRootKey, syncKey) rows that
+// `migrateMemoryWikiSourceSyncBareKeys` would rewrite to canonical keys.
+export async function countMemoryWikiSourceSyncBareKeys(params: {
+  openKeyedStore: <T>(options: OpenKeyedStoreOptions) => PluginStateKeyedStore<T>;
+  vaultRoot: string;
+}): Promise<number> {
+  const vaultRootKey = resolveVaultRootKey(params.vaultRoot);
+  const store = params.openKeyedStore<MemoryWikiSourceSyncStateRecord>({
+    namespace: MEMORY_WIKI_SOURCE_SYNC_STATE_NAMESPACE,
+    maxEntries: MEMORY_WIKI_SOURCE_SYNC_STATE_MAX_ENTRIES,
+    overflowPolicy: "reject-new",
+  });
+  let legacyCount = 0;
+  for (const row of await store.entries()) {
+    const value = row.value;
+    if (
+      value.vaultRootKey !== vaultRootKey ||
+      typeof value.syncKey !== "string" ||
+      (value.group !== "bridge" && value.group !== "unsafe-local")
+    ) {
+      continue;
+    }
+    if (row.key !== resolveStateEntryKey(vaultRootKey, value.group, value.syncKey)) {
+      legacyCount += 1;
+    }
+  }
+  return legacyCount;
+}
+
+// Doctor-owned migration: rewrite pre-#118370 bare (vaultRootKey, syncKey) rows
+// to canonical group-scoped keys. The namespace is `reject-new` at
+// `MEMORY_WIKI_SOURCE_SYNC_STATE_MAX_ENTRIES` entries, and the keyed-store API
+// exposes only single-key operations (no cross-key transaction), so the
+// relocation cannot be made atomic at this layer. To eliminate the permanent
+// data-loss window, each legacy row is relocated insert-before-delete:
+//   1. `registerIfAbsent(canonicalKey, value)` — write the canonical row first.
+//      `registerIfAbsent` preserves any newer canonical row already written by a
+//      concurrent runtime incremental sync (returns false, no overwrite).
+//   2. Only after the canonical row exists, `deleteIf(legacyKey, isSameRecord)`
+//      removes the legacy duplicate.
+// A crash between steps 1 and 2 leaves legacy + canonical coexisting (a benign
+// duplicate that `read` deduplicates and the next Doctor pass reclaims) — never
+// a deleted legacy row with no canonical replacement, so page/Notes ownership is
+// never orphaned. If the namespace is at the reject-new cap, step 1 throws
+// `PLUGIN_STATE_LIMIT_EXCEEDED`; that row is skipped (legacy left intact, still
+// usable via `read`'s transparent re-keying) and reported via `skippedCount` so
+// the Doctor can warn the user to prune before rerunning. Runtime sync writes
+// stay canonical-only.
+export async function migrateMemoryWikiSourceSyncBareKeys(params: {
+  openKeyedStore: <T>(options: OpenKeyedStoreOptions) => PluginStateKeyedStore<T>;
+  vaultRoot: string;
+}): Promise<{ migratedCount: number; skippedCount: number }> {
+  const vaultRootKey = resolveVaultRootKey(params.vaultRoot);
+  const store = params.openKeyedStore<MemoryWikiSourceSyncStateRecord>({
+    namespace: MEMORY_WIKI_SOURCE_SYNC_STATE_NAMESPACE,
+    maxEntries: MEMORY_WIKI_SOURCE_SYNC_STATE_MAX_ENTRIES,
+    overflowPolicy: "reject-new",
+  });
+  let migratedCount = 0;
+  let skippedCount = 0;
+  for (const row of await store.entries()) {
+    const value = row.value;
+    if (
+      value.vaultRootKey !== vaultRootKey ||
+      typeof value.syncKey !== "string" ||
+      (value.group !== "bridge" && value.group !== "unsafe-local")
+    ) {
+      continue;
+    }
+    const canonicalKey = resolveStateEntryKey(vaultRootKey, value.group, value.syncKey);
+    if (row.key === canonicalKey) {
+      continue;
+    }
+    // Insert the canonical row BEFORE deleting the legacy row. If a concurrent
+    // runtime write already produced a newer canonical row, `registerIfAbsent`
+    // returns false and we keep that newer value (no overwrite). A crash after
+    // this point but before the delete leaves a benign duplicate that the next
+    // pass reclaims — never an orphan.
+    try {
+      await store.registerIfAbsent(canonicalKey, value);
+    } catch (error) {
+      // Namespace is at the reject-new cap: there is no room to insert the
+      // canonical row without first freeing a slot. Deleting the legacy row to
+      // make room would reintroduce the loss window, so skip this row instead —
+      // the legacy row remains and is still readable via `read`'s re-keying.
+      if ((error as { code?: string }).code === "PLUGIN_STATE_LIMIT_EXCEEDED") {
+        skippedCount += 1;
+        continue;
+      }
+      throw error;
+    }
+    // The canonical row exists now; remove the legacy duplicate. `deleteIf`
+    // removes only the exact value previously observed, so a concurrent runtime
+    // write that changed the legacy row is not clobbered (left for the next pass).
+    const removed = store.deleteIf
+      ? await store.deleteIf(row.key, (current) => isSameRecord(current, value))
+      : await store.delete(row.key);
+    if (removed) {
+      migratedCount += 1;
+    }
+  }
+  return { migratedCount, skippedCount };
+}
+
+function isSameRecord(
+  current: MemoryWikiSourceSyncStateRecord,
+  expected: MemoryWikiSourceSyncStateRecord,
+): boolean {
+  return (
+    current.vaultRootKey === expected.vaultRootKey &&
+    current.group === expected.group &&
+    current.syncKey === expected.syncKey &&
+    current.pagePath === expected.pagePath &&
+    current.sourcePath === expected.sourcePath &&
+    current.sourceUpdatedAtMs === expected.sourceUpdatedAtMs &&
+    current.sourceSize === expected.sourceSize &&
+    current.renderFingerprint === expected.renderFingerprint
+  );
 }

--- a/extensions/memory-wiki/src/unsafe-local.ts
+++ b/extensions/memory-wiki/src/unsafe-local.ts
@@ -20,6 +20,7 @@ import {
   assertMemoryWikiSourceSyncStateCapacity,
   pruneImportedSourceEntries,
   readMemoryWikiSourceSyncState,
+  resolveEntrySyncKey,
   writeMemoryWikiSourceSyncState,
 } from "./source-sync-state.js";
 import { initializeMemoryWikiVault } from "./vault.js";
@@ -236,7 +237,7 @@ export async function syncMemoryWikiUnsafeLocalSources(
   );
   const state = await readMemoryWikiSourceSyncState(config.vault.path);
   const activeKeys = new Set<string>();
-  for (const [syncKey, entry] of Object.entries(state.entries)) {
+  for (const [entryKey, entry] of Object.entries(state.entries)) {
     if (
       entry.group === "unsafe-local" &&
       unavailableConfiguredPaths.some((configuredPath) =>
@@ -245,7 +246,8 @@ export async function syncMemoryWikiUnsafeLocalSources(
     ) {
       // A configured source scope remains authoritative until it is readable again or removed
       // from config. Treating an unreadable mount as empty would permanently delete human notes.
-      activeKeys.add(syncKey);
+      // Entries are keyed by `${group}\0${syncKey}` (#118370), so recover the bare syncKey.
+      activeKeys.add(resolveEntrySyncKey(entryKey));
     }
   }
   assertMemoryWikiSourceSyncStateCapacity({


### PR DESCRIPTION
## What Problem This Solves

Importing the same physical source through both the Memory Wiki bridge and unsafe-local modes generates two source pages but records a single SQLite ownership row, permanently orphaning the first page and its handwritten Notes. Subsequent ClawSweeper reviews identified three persisted-state P1 defects in the legacy-key migration and incremental prune paths that could still orphan pages under capacity pressure or cross-group pruning.
- Problem: The source-sync ownership key is scoped to `(vaultRoot, syncKey)` without the import mode, so a second import of the same source overwrites the first mode's ownership row. The orphaned page can no longer be pruned or have its Notes salvaged. Additionally, the incremental prune unconditionally deleted the shared bare legacy key (cross-group risk), and the upsert path did not account for physical legacy occupancy at the `reject-new` cap.
- Solution: Scope the ownership key by `(vaultRoot, group, syncKey)` so each import mode keeps an independent ownership row per source. Guard bare-key deletion with a group predicate (`deleteIf`). Catch `PLUGIN_STATE_LIMIT_EXCEEDED` on canonical registration and reclaim the matching bare-key slot before retrying.
- What changed: `extensions/memory-wiki/src/source-sync-state.ts` (composite group+syncKey keys for in-memory entries and SQLite rows, idempotent normalization, group-scoped pruning with `deleteIf`-guarded bare-key deletion, cap-safe canonical retry that reclaims the bare legacy slot on `PLUGIN_STATE_LIMIT_EXCEEDED`, crash-safe Doctor migration via insert-before-delete with cap-skip, full-write boundary NOTE), `extensions/memory-wiki/src/source-page-shared.ts` (pass `group` to skip-check), `extensions/memory-wiki/src/unsafe-local.ts` (derive bare syncKey when collecting active keys), `extensions/memory-wiki/doctor-contract-api.ts` (Doctor migration `memory-wiki-source-sync-bare-key-to-group-scoped` with `skippedCount`), plus regression tests and key-format updates in existing tests.
- P2 fix: the SQLite reader now validates all persisted record fields (pagePath, sourcePath, sourceUpdatedAtMs, sourceSize, renderFingerprint) before projecting them into in-memory state, mirroring `normalizeSourceSyncState` — a malformed row from a corrupted or partially-written entry is skipped instead of causing compile/lint to throw on a non-string field.
- What did NOT change: single-mode import behavior (bridge-only or unsafe-local-only) — the composite key degenerates to the prior behavior; the page-write/render pipeline; repair of already-orphaned *pages* (separate doctor-migration concern, tracked in the issue); the full-write delete-before-insert path (requires core-backed atomic relocation primitive, documented as maintainer-scoped follow-up).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related to #118370 (prevents future orphaning; recovery of already-orphaned pages from before the fix remains a separate doctor-migration follow-up)
- Related #118375 (related Notes-protection stress fix, distinct root cause)
- [x] This PR fixes a bug or regression

## Motivation

The reported repro (`generatedPages=2, ownershipRows=1, needsMigration:true`) shows real data loss: the second import overwrites the first tracking entry, so the first page's handwritten Notes become unreachable by prune/salvage/compile/lint. Changing the configured unsafe-local root can orphan pages the same way. Each generated page must retain independent ownership. ClawSweeper's five P1 re-reviews further identified that the legacy bare-key migration and incremental prune paths had persistent-state safety gaps: (1) unconditional bare-key deletion during a bridge prune could remove an unsafe-local legacy row sharing the same syncKey; (2) at the `reject-new` cap full of legacy bare rows, an active source update could write its page then fail to register the canonical ownership key; (3) the full-write path's delete-before-insert ordering has a crash-loss window that the extension layer cannot fully resolve without a core-backed atomic relocation primitive.

## Evidence

- Behavior addressed: same physical source imported through bridge and unsafe-local modes now keeps one independent ownership row per mode, so neither page is orphaned. Cross-group bare-key pruning is guarded by a group predicate. At the `reject-new` cap, canonical registration failure triggers bare-slot reclamation and retry. Legacy pre-#118370 bare-key rows are re-keyed on read (transparent) and physically rewritten to canonical group-scoped keys by a dedicated Memory Wiki Doctor migration (`memory-wiki-source-sync-bare-key-to-group-scoped`), not on the runtime sync hot path.
- Real environment tested: Linux, Node v22.22.3, branch `fix/memory-wiki-source-ownership-118370`, real SQLite plugin-state store + real temp files. The after-fix migration proof runs the real `syncMemoryWikiBridgeSources` / `syncMemoryWikiUnsafeLocalSources` pipelines against the real SQLite plugin-state store in an isolated temp `OPENCLAW_STATE_DIR` (no production state, no live gateway network).
- Exact steps or command run after this patch:
  - `node --import tsx repro-legacy-migration.mts` (isolated real-runtime repro, script kept at `/media/vdb/code/github/contributions/pr-118714-evidence/`)
  - `node scripts/run-vitest.mjs extensions/memory-wiki/src/source-sync-state.test.ts`
  - `node scripts/run-vitest.mjs extensions/memory-wiki/src/source-sync-state-ownership.test.ts`
  - `node scripts/run-vitest.mjs extensions/memory-wiki/doctor-contract-api.test.ts`
  - `node scripts/run-vitest.mjs extensions/memory-wiki/src/source-sync-malformed-notes.test.ts extensions/memory-wiki/src/source-page-shared.test.ts`
- Evidence after fix:

```console
$ node scripts/run-vitest.mjs extensions/memory-wiki/src/source-sync-state.test.ts
 Test Files  1 passed (1)
      Tests  25 passed (25)

$ node scripts/run-vitest.mjs extensions/memory-wiki/src/source-sync-state-ownership.test.ts
 Test Files  1 passed (1)
      Tests  9 passed (9)

$ node scripts/run-vitest.mjs extensions/memory-wiki/doctor-contract-api.test.ts
 Test Files  1 passed (1)
      Tests  12 passed (12)

$ node scripts/run-vitest.mjs extensions/memory-wiki/src/source-sync-malformed-notes.test.ts \
    extensions/memory-wiki/src/source-page-shared.test.ts
 Test Files  2 passed (2)
      Tests  10 passed (10)

$ node --import tsx repro-legacy-migration.mts   # isolated real-runtime proof
--- BEFORE unsafe-local import (legacy bare key = 7554f80ebd3f…): 1 row ---
--- AFTER unsafe-local import: bridge canonical row + unsafe-local canonical row = 2 rows ---
--- AFTER Doctor migration: bare key reclaimed, 2 canonical rows remain ---
needsMigration: false
```

Matrix evidence — incremental write path behavior by scenario:

```
Scenario                                          => Result
bridge + unsafe-local same source (normal)        => 2 independent ownership rows ✓
single-mode bridge-only                           => 1 canonical row (unchanged) ✓
single-mode unsafe-local-only                     => 1 canonical row (unchanged) ✓
bridge prune, unsafe-local legacy bare row exists => bare row preserved (group guard) ✓
cap full of legacy bare rows, active update       => bare slot reclaimed, canonical registered ✓
Doctor migration at cap                           => skip with warning, retry after prune ✓
Doctor migration below cap                        => insert-before-delete, no cap exceed ✓
crash between canonical insert and legacy delete  => benign duplicate, self-heals next pass ✓
```

- Observed result after fix:
  1. Same-source dual-mode import keeps two independent ownership rows (not one).
  2. Pruning the bridge entry does not delete an unsafe-local legacy bare-key row for the same syncKey (group predicate guard via `deleteIf`).
  3. At the `reject-new` cap full of legacy bare-key rows, an active source update reclaims the matching bare slot and successfully registers the canonical ownership row (no untracked page).
  4. Legacy pre-#118370 bare-key rows are transparently re-keyed on `read`; the Doctor migration physically rewrites them via crash-safe insert-before-delete.
  5. Single-mode import behavior is unchanged (composite key degenerates to prior behavior).
- What was not tested: live networked Gateway RPC; existing orphaned-pages repair (doctor migration, separate follow-up); the full-write delete-before-insert crash-loss window (requires core-backed atomic relocation primitive, documented as maintainer-scoped follow-up).

## Root Cause

The SQLite source-sync row identity used `sha256(vaultRootKey + syncKey)` without an import-group dimension. Since `resolveArtifactKey` returns the physical `realpath` of the source, the same physical source imported through both bridge and unsafe-local modes produced the same `syncKey` and therefore the same bare ownership key — the second import overwrote the first. The bare key format (`sha256(vaultRootKey + syncKey)`) has no group segment, so it is shared across groups for the same source, which made unconditional bare-key deletion during pruning dangerous.

## Regression Test Plan

- `keeps independent ownership rows when bridge and unsafe-local share a source` — dual-import independence.
- `bridge prune does not delete an unsafe-local legacy bare-key row for the same source` — cross-group bare-key guard (P1 #1).
- `active source update at full physical legacy cap does not leave the page untracked` — cap-safe canonical retry (P1 #3).
- `leaves legacy bare-key rows for the Doctor migration during incremental writes` — runtime does not physically migrate.
- `preserves the newer canonical row when migrating a stale legacy duplicate` — canonical-wins.
- `skips legacy rows at the reject-new cap without losing data or exceeding the cap` — skip-at-cap.
- `self-heals a crash between canonical insert and legacy delete on the next pass` — crash recovery.
- `migrates legacy rows below the reject-new cap without exceeding it` — under-cap migration.
- `incremental prune frees a legacy bare-key slot so Doctor can retry at the cap` — cap-bound prune-then-retry.
- Doctor `detect`/`migrate`/idempotency regression in `doctor-contract-api.test.ts`.

## User-visible / Behavior Changes

A source imported via both bridge and unsafe-local modes now keeps two ownership rows instead of one (the intended fix). Single-mode users see no behavior change. Existing orphaned pages from before the fix require the doctor migration noted in the issue.

## Security Impact (required)

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node v22.22.3
- Model/provider: N/A (no model/provider request during source import)
- Integration/channel: memory-core public artifacts → memory-wiki bridge/unsafe-local source sync → shared SQLite plugin state

### Steps

1. Configure a Memory Wiki vault with both `bridge` and `unsafeLocal` pointing at the same physical source.
2. Import the source via `writeImportedSourcePage` with `group: "bridge"`, then with `group: "unsafe-local"` (as both gateway RPCs do).
3. Read back the source-sync state and count ownership rows.
4. Prune the bridge entry; verify the unsafe-local legacy bare-key row survives.
5. Fill the namespace to the `reject-new` cap with legacy bare-key rows; update an active source; verify the canonical row is registered.

### Expected

Two pages, two ownership rows; each mode's page prunable/salvageable independently. Cross-group bare-key pruning does not orphan the other mode. Cap-full active update does not leave a page untracked.

### Actual (pre-fix)

Two pages, one ownership row (`generatedPages=2, ownershipRows=1`), first page orphaned. Unconditional bare-key deletion could remove the other group's legacy row. Cap-full active update could fail to register canonical ownership after page write.

## Human Verification (required)

- Verified scenarios: same-source dual-mode import (ownership rows + prune independence); store round-trip; legacy row re-keying; migration of pre-fix bare-key rows through real bridge + unsafe-local sync runs (canonical row only, idempotent); idempotent normalization; cross-group bare-key prune guard; cap-safe canonical retry with bare-slot reclamation.
- Edge cases checked: single-mode behavior unchanged; capacity counting with mixed groups; malformed human-Notes markers; crash between canonical insert and legacy delete; skip-at-cap with warning.
- What you did NOT verify: live networked Gateway RPC; existing orphaned-pages repair (doctor migration, separate follow-up); full-write delete-before-insert crash-loss window (core-backed primitive needed).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- [x] Backward compatible? Yes — old SQLite rows carry `group` and are re-keyed on read; old JSON keys are normalized; full writes clean up legacy keys. Runtime incremental writes are canonical-only (no legacy rewrite on the hot path); the legacy bare-key → canonical rewrite is owned by the `memory-wiki-source-sync-bare-key-to-group-scoped` Doctor migration.
- [ ] Config/env changes? No
- [x] Migration needed? No schema bump; legacy bare-key rows are rewritten to canonical keys by the `memory-wiki-source-sync-bare-key-to-group-scoped` Doctor migration (run via `doctor --fix`). Runtime `read` already re-keys them transparently, so behavior is correct before the Doctor runs — the Doctor only reclaims the legacy slot. Repairing already-orphaned *pages* remains a separate doctor-migration follow-up tracked in the issue.

## Best-fix Verdict

- **Best fix**: Yes — the ownership key is the correct boundary: both import paths already flow through `source-sync-state.ts`; making the key group-scoped fixes the collision at its source rather than special-casing imports. The three ClawSweeper P1 fixes further harden the incremental prune (`deleteIf` group guard) and upsert (cap-safe retry) paths against persisted-state edge cases.
- **Refactor needed**: No
- **Alternative considered**: Conflict detection at import time (reject/merge when a source already has a different-mode entry) was considered and rejected: the current data model has one row per source and cannot represent two independently-tracked pages, so a group-scoped key is required to satisfy the issue's expected behavior. For P1 #2 (full-write crash-safety), a core-backed atomic relocation primitive was considered but is out of scope for the extension layer; the boundary is documented as a maintainer-scoped follow-up.

## AI Assistance

- **AI-assisted**: Yes
- **Co-Authored-By**: Maas <noreply@anthropic.com>, Claude <noreply@anthropic.com>
- **Human confirmed understanding of code changes**: Yes
- **AI prompts / session excerpts**: open-source-pr skill; root cause traced via codebase exploration; fix + regression tests implemented and validated against the full memory-wiki suite; five ClawSweeper P1 re-review cycles addressed.

## Risks and Mitigations

- **Highest-risk area**: Backward compatibility of the source-sync state key change for users with existing single-mode data, and the legacy bare-key migration paths under capacity pressure.
- **Mitigation**: Old SQLite rows store `group` in the value and are re-keyed on read; full (non-incremental) writes prune legacy bare keys. Runtime incremental writes are canonical-only — the legacy rewrite is performed by the `memory-wiki-source-sync-bare-key-to-group-scoped` Doctor migration, which relocates each legacy row via crash-safe insert-before-delete (`registerIfAbsent` canonical first, then `deleteIf` legacy with an exact-value predicate). At the `reject-new` cap the canonical insert is caught and the legacy row is skipped with a warning to rerun after pruning. The incremental prune uses `deleteIf` with a group predicate to avoid cross-group bare-key deletion. The upsert path catches `PLUGIN_STATE_LIMIT_EXCEEDED` and reclaims the matching bare slot before retrying. `deleteIf` avoids clobbering concurrent runtime writes, and normalization is idempotent so doctor migration merges stay correct. Single-mode users see no behavior change because all their rows share one group. The full-write delete-before-insert path remains a documented boundary requiring a core-backed atomic relocation primitive (maintainer-scoped follow-up).
- **Compatibility impact**: Not a breaking change. The only functional difference is that a source imported via both modes now keeps two ownership rows instead of one (the intended fix). Existing orphaned pages from before the fix require the doctor migration noted in the issue.

---

Related to #118370
