### PR TITLE
fix(gateway): retain agent model override provenance

### DIFF
--- a/src/gateway/server-methods/sessions-mutations.sticky-model.test.ts
+++ b/src/gateway/server-methods/sessions-mutations.sticky-model.test.ts
@@ -3,6 +3,7 @@ import { loadSessionEntry, upsertSessionEntry } from "../../config/sessions/sess
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { withAgentSessionModelPatchOrigin } from "../session-model-patch-origin.js";
 import type { GatewayClient, GatewayRequestContext, RespondFn } from "./types.js";
 
 const effects = vi.hoisted(() => ({
@@ -151,6 +152,38 @@ describe("sessions.patch sticky model persistence", () => {
         modelOverride: "gpt-5.6-sol",
       });
       expect(effects.mutateConfigFileWithRetry).not.toHaveBeenCalled();
+    });
+  });
+
+  it("persists model and profile provenance from the Gateway caller boundary", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const userSessionKey = "agent:main:dm:user-model-patch";
+      const agentSessionKey = "agent:main:dm:agent-model-patch";
+      for (const sessionKey of [userSessionKey, agentSessionKey]) {
+        await upsertSessionEntry(
+          { agentId: "main", sessionKey },
+          { sessionId: `session-${sessionKey}`, updatedAt: 1 },
+        );
+      }
+
+      const model = "anthropic/claude-sonnet-4-6@work";
+      const userResponse = await patchSession({ key: userSessionKey, model }, ["operator.write"]);
+      const agentResponse = await withAgentSessionModelPatchOrigin(
+        async () => await patchSession({ key: agentSessionKey, model }, ["operator.write"]),
+      );
+
+      expect(userResponse[0]).toBe(true);
+      expect(agentResponse[0]).toBe(true);
+      expect(loadSessionEntry({ agentId: "main", sessionKey: userSessionKey })).toMatchObject({
+        modelOverrideSource: "user",
+        authProfileOverride: "work",
+        authProfileOverrideSource: "user",
+      });
+      expect(loadSessionEntry({ agentId: "main", sessionKey: agentSessionKey })).toMatchObject({
+        modelOverrideSource: "auto",
+        authProfileOverride: "work",
+        authProfileOverrideSource: "auto",
+      });
     });
   });
 

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -980,7 +980,7 @@ describe("gateway sessions patch", () => {
         await applyMainModelPatch({
           store,
           cfg: createAllowlistedAnthropicModelCfg(),
-          model: ANTHROPIC_SONNET_MODEL,
+          model: `${ANTHROPIC_SONNET_MODEL}@agent-profile`,
           catalogRefs: [OPENAI_GPT_MODEL, ANTHROPIC_SONNET_MODEL],
         }),
     );
@@ -995,6 +995,8 @@ describe("gateway sessions patch", () => {
       prevThinkingLevel: "high",
       source: "agent-patch",
     });
+    expect(entry.modelOverrideSource).toBe("auto");
+    expectAuthOverride(entry, { profile: "agent-profile", source: "auto" });
   });
 
   test("keeps the last validated model across consecutive agent patches", async () => {

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -611,6 +611,7 @@ export async function projectSessionsPatchEntry(params: {
       if (!resolved.ok) {
         return invalid(resolved.error);
       }
+      const overrideSource = isAgentSessionModelPatchOrigin() ? "auto" : "user";
       applyModelOverrideWithAuthProfileCompatibility({
         cfg,
         agentDir: resolveAgentDir(cfg, sessionAgentId),
@@ -622,6 +623,8 @@ export async function projectSessionsPatchEntry(params: {
           isDefault: resolved.isDefault,
         },
         profileOverride: resolved.profile,
+        profileOverrideSource: overrideSource,
+        selectionSource: overrideSource,
         ...(params.providerAuthMetadataSnapshot
           ? { metadataSnapshot: params.providerAuthMetadataSnapshot }
           : {}),

--- a/test/sessions-tool-model-provenance.e2e.test.ts
+++ b/test/sessions-tool-model-provenance.e2e.test.ts
@@ -1,0 +1,213 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveStorePath } from "../src/config/sessions/paths.js";
+import { loadSessionEntry } from "../src/config/sessions/session-accessor.js";
+import {
+  disconnectGatewayClient,
+  startGatewayWithClient,
+} from "../src/gateway/test-helpers.e2e.js";
+import { closeOpenClawAgentDatabasesForTest } from "../src/state/openclaw-agent-db.js";
+import { captureEnv, setTestEnvValue } from "../src/test-utils/env.js";
+import { useAutoCleanupTempDirTracker } from "./helpers/temp-dir.js";
+
+const TEST_TIMEOUT_MS = 30_000;
+const TARGET_MODEL = "fixture/selected@work";
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const ENV_KEYS = [
+  "HOME",
+  "USERPROFILE",
+  "OPENCLAW_STATE_DIR",
+  "OPENCLAW_CONFIG_PATH",
+  "OPENCLAW_SKIP_CHANNELS",
+  "OPENCLAW_SKIP_GMAIL_WATCHER",
+  "OPENCLAW_SKIP_CRON",
+  "OPENCLAW_SKIP_CANVAS_HOST",
+  "OPENCLAW_SKIP_BROWSER_CONTROL_SERVER",
+  "OPENCLAW_SKIP_PROVIDERS",
+  "OPENCLAW_TEST_MINIMAL_GATEWAY",
+  "OPENCLAW_BUNDLED_PLUGINS_DIR",
+  "OPENCLAW_DISABLE_BUNDLED_PLUGINS",
+] as const;
+
+async function setupTempHome() {
+  const env = captureEnv([...ENV_KEYS]);
+  const home = tempDirs.make("openclaw-sessions-tool-provenance-");
+  const stateDir = path.join(home, ".openclaw");
+  const workspace = path.join(home, "workspace");
+  const bundledPlugins = path.join(home, "empty-bundled-plugins");
+  await Promise.all([
+    fs.mkdir(stateDir, { recursive: true }),
+    fs.mkdir(workspace, { recursive: true }),
+    fs.mkdir(bundledPlugins, { recursive: true }),
+  ]);
+  setTestEnvValue("HOME", home);
+  setTestEnvValue("USERPROFILE", home);
+  setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+  setTestEnvValue("OPENCLAW_SKIP_CHANNELS", "1");
+  setTestEnvValue("OPENCLAW_SKIP_GMAIL_WATCHER", "1");
+  setTestEnvValue("OPENCLAW_SKIP_CRON", "1");
+  setTestEnvValue("OPENCLAW_SKIP_CANVAS_HOST", "1");
+  setTestEnvValue("OPENCLAW_SKIP_BROWSER_CONTROL_SERVER", "1");
+  setTestEnvValue("OPENCLAW_BUNDLED_PLUGINS_DIR", bundledPlugins);
+  setTestEnvValue("OPENCLAW_DISABLE_BUNDLED_PLUGINS", "1");
+  delete process.env.OPENCLAW_CONFIG_PATH;
+  delete process.env.OPENCLAW_SKIP_PROVIDERS;
+  delete process.env.OPENCLAW_TEST_MINIMAL_GATEWAY;
+  return {
+    configPath: path.join(stateDir, "openclaw.json"),
+    env,
+    workspace,
+  };
+}
+
+type CreatedSession = {
+  key: string;
+  sessionId: string;
+};
+
+type ToolInvokeResult = {
+  ok: boolean;
+  error?: { message?: string };
+};
+
+describe("Sessions tool model provenance product proof", () => {
+  it(
+    "persists agent tool patches as automatic and external patches as user-owned",
+    { timeout: TEST_TIMEOUT_MS },
+    async () => {
+      const temp = await setupTempHome();
+      const token = `sessions-tool-provenance-${process.pid}`;
+      const cfg = {
+        agents: {
+          defaults: {
+            workspace: temp.workspace,
+            model: { primary: "fixture/default" },
+            models: {
+              "fixture/default": {},
+              "fixture/selected": {},
+            },
+          },
+        },
+        gateway: { auth: { mode: "token", token } },
+        models: {
+          mode: "replace",
+          providers: {
+            fixture: {
+              apiKey: "fixture-secret",
+              baseUrl: "http://127.0.0.1:9/v1",
+              models: [
+                { id: "default", name: "Default", contextWindow: 8192 },
+                { id: "selected", name: "Selected", contextWindow: 8192 },
+              ],
+            },
+          },
+        },
+      };
+      let started: Awaited<ReturnType<typeof startGatewayWithClient>> | undefined;
+      let agentSession: CreatedSession | undefined;
+      let userSession: CreatedSession | undefined;
+
+      try {
+        try {
+          started = await startGatewayWithClient({
+            cfg,
+            configPath: temp.configPath,
+            token,
+            clientDisplayName: "sessions-tool-provenance-proof",
+          });
+          agentSession = (await started.client.request("sessions.create", {
+            agentId: "main",
+            label: "Agent provenance proof",
+          })) as CreatedSession;
+          userSession = (await started.client.request("sessions.create", {
+            agentId: "main",
+            label: "User provenance proof",
+          })) as CreatedSession;
+
+          const toolResult = (await started.client.request("tools.invoke", {
+            name: "sessions",
+            sessionKey: agentSession.key,
+            args: { action: "patch", model: TARGET_MODEL },
+          })) as ToolInvokeResult;
+          expect(toolResult).toMatchObject({ ok: true });
+
+          await expect(
+            started.client.request("sessions.patch", {
+              key: userSession.key,
+              model: TARGET_MODEL,
+              modelOverrideSource: "auto",
+            }),
+          ).rejects.toThrow(/invalid sessions\.patch params/i);
+          await started.client.request("sessions.patch", {
+            key: userSession.key,
+            model: TARGET_MODEL,
+          });
+        } finally {
+          try {
+            if (started) {
+              await disconnectGatewayClient(started.client).catch(() => undefined);
+              await started.server.close({ reason: "Sessions tool provenance proof complete" });
+            }
+          } finally {
+            closeOpenClawAgentDatabasesForTest();
+          }
+        }
+
+        if (!agentSession || !userSession) {
+          throw new Error("Gateway proof did not create both sessions");
+        }
+        const storePath = resolveStorePath(undefined, { agentId: "main" });
+        const agentEntry = loadSessionEntry({
+          agentId: "main",
+          sessionKey: agentSession.key,
+          storePath,
+        });
+        const userEntry = loadSessionEntry({
+          agentId: "main",
+          sessionKey: userSession.key,
+          storePath,
+        });
+
+        expect(agentEntry).toMatchObject({
+          providerOverride: "fixture",
+          modelOverride: "selected",
+          modelOverrideSource: "auto",
+          authProfileOverride: "work",
+          authProfileOverrideSource: "auto",
+        });
+        expect(userEntry).toMatchObject({
+          providerOverride: "fixture",
+          modelOverride: "selected",
+          modelOverrideSource: "user",
+          authProfileOverride: "work",
+          authProfileOverrideSource: "user",
+        });
+
+        console.info(
+          `[sessions-tool-provenance-proof] ${JSON.stringify({
+            head: process.env.OPENCLAW_PROOF_HEAD ?? "not-specified",
+            gateway: "loopback-token-auth",
+            agentOrigin: {
+              entrypoint: "tools.invoke:sessions",
+              dispatch: "in-process",
+              modelOverrideSource: agentEntry?.modelOverrideSource,
+              authProfileOverride: agentEntry?.authProfileOverride,
+              authProfileOverrideSource: agentEntry?.authProfileOverrideSource,
+            },
+            directUser: {
+              entrypoint: "sessions.patch",
+              modelOverrideSource: userEntry?.modelOverrideSource,
+              authProfileOverride: userEntry?.authProfileOverride,
+              authProfileOverrideSource: userEntry?.authProfileOverrideSource,
+            },
+            publicRpcAllowsCallerProvenance: false,
+          })}`,
+        );
+      } finally {
+        closeOpenClawAgentDatabasesForTest();
+        temp.env.restore();
+      }
+    },
+  );
+});


### PR DESCRIPTION
Closes #118705

## What Problem This Solves

Fixes an issue where agent-initiated `sessions.patch` model changes were persisted as user-selected overrides. For model references with an explicit `@profile`, the model and auth-profile provenance could also diverge, leaving an automatic model paired with a durable user-owned profile.

## Why This Change Was Made

The Gateway now derives both model-selection and explicit auth-profile provenance from the existing trusted in-process agent origin. Agent tool calls persist both sources as `"auto"`; ordinary Gateway model patches persist both as `"user"`.

This uses the current auth-profile compatibility wrapper and does not add a caller-controlled provenance field to the public RPC schema.

## User Impact

Model and profile changes made through the agent Sessions tool remain automatic state, so reset, fallback, and recovery policies can manage them together. Direct user and Control UI selections remain user-owned pins.

## Evidence

- Exact head: `6ef1a43e9c1ee9e49e44cdcc5e0391cdf60b5a2a`
- Real Sessions-tool-to-Gateway product proof:

  ```text
  OPENCLAW_E2E_VERBOSE=1 \
  OPENCLAW_PROOF_HEAD=6ef1a43e9c1ee9e49e44cdcc5e0391cdf60b5a2a \
  node scripts/run-vitest.mjs run \
    --config test/vitest/vitest.e2e.config.ts \
    test/sessions-tool-model-provenance.e2e.test.ts
  ```

  This starts a real loopback Gateway with token authentication and an isolated
  SQLite state directory. An authenticated WebSocket client invokes the real
  built-in Sessions tool through `tools.invoke`; the tool resolves through the
  production tool factory and dispatches `sessions.patch` through the live
  in-process Gateway context. A second session is patched through ordinary
  external Gateway RPC. The test then closes the client, Gateway, and database
  handles before reopening SQLite and reading both persisted entries.

  ```text
  [sessions-tool-provenance-proof] {"head":"6ef1a43e9c1ee9e49e44cdcc5e0391cdf60b5a2a","gateway":"loopback-token-auth","agentOrigin":{"entrypoint":"tools.invoke:sessions","dispatch":"in-process","modelOverrideSource":"auto","authProfileOverride":"work","authProfileOverrideSource":"auto"},"directUser":{"entrypoint":"sessions.patch","modelOverrideSource":"user","authProfileOverride":"work","authProfileOverrideSource":"user"},"publicRpcAllowsCallerProvenance":false}
  ```

  The same E2E also verifies that an external `sessions.patch` request carrying
  `modelOverrideSource: "auto"` is rejected by the closed RPC schema.
- `node scripts/run-vitest.mjs src/gateway/sessions-patch.test.ts src/gateway/server-methods/sessions-mutations.sticky-model.test.ts`
  - 96 tests passed.
- The focused Gateway regressions persist the same `model@profile` selection through both caller paths:
  - ordinary operator patch: `modelOverrideSource=user`, `authProfileOverrideSource=user`
  - trusted agent-origin patch: `modelOverrideSource=auto`, `authProfileOverrideSource=auto`
- `pnpm tsgo:core:test`
- Targeted `oxfmt` and `oxlint` on all four changed files
- `git diff origin/main...HEAD --check`

Production delta is +3 lines. Tests add the focused projection/Gateway coverage
and one real product-boundary E2E (`+249/-1` test lines).

AI-assisted: investigation, implementation, validation, and review were performed with an AI coding assistant; the contributor reviewed and understands the change.
