### PR TITLE
fix(agents): apply per-agent context caps to embedded runs

### DIFF
--- a/src/agents/context-window-guard.test.ts
+++ b/src/agents/context-window-guard.test.ts
@@ -395,7 +395,7 @@ describe("context-window-guard", () => {
     ).toContain("This looks like a local model endpoint.");
   });
 
-  it("points config-backed block remediation at agents.defaults.contextTokens", () => {
+  it("uses neutral remediation for an agent context cap", () => {
     const guard = evaluateContextWindowGuard({
       info: { tokens: 8_000, source: "agentContextTokens" },
     });
@@ -405,8 +405,26 @@ describe("context-window-guard", () => {
       runtimeBaseUrl: "http://127.0.0.1:11434/v1",
     });
 
-    expect(message).toContain("OpenClaw is capped by agents.defaults.contextTokens.");
+    expect(message).toContain("OpenClaw is capped by an agent contextTokens setting.");
+    expect(message).toContain("Raise that setting.");
+    expect(message).not.toContain("agents.defaults.contextTokens");
     expect(message).not.toContain("choose a larger model");
+  });
+
+  it("uses neutral remediation for an agent context cap in warnings", () => {
+    const guard = evaluateContextWindowGuard({
+      info: { tokens: 6_000, source: "agentContextTokens" },
+    });
+
+    const message = formatContextWindowWarningMessage({
+      provider: "lmstudio",
+      modelId: "qwen3",
+      guard,
+      runtimeBaseUrl: "http://127.0.0.1:1234/v1",
+    });
+
+    expect(message).toContain("OpenClaw is capped by an agent contextTokens setting");
+    expect(message).not.toContain("agents.defaults.contextTokens");
   });
 
   it("points model config block remediation at contextWindow/contextTokens", () => {

--- a/src/agents/context-window-guard.ts
+++ b/src/agents/context-window-guard.ts
@@ -158,7 +158,7 @@ export function formatContextWindowWarningMessage(params: {
   }
   if (params.guard.source === "agentContextTokens") {
     return (
-      `${base}; OpenClaw is capped by agents.defaults.contextTokens, so raise that cap ` +
+      `${base}; OpenClaw is capped by an agent contextTokens setting, so raise that setting ` +
       `if you want to use more of the model context window`
     );
   }
@@ -187,7 +187,7 @@ export function formatContextWindowBlockMessage(params: {
     return base;
   }
   if (params.guard.source === "agentContextTokens") {
-    return `${base} OpenClaw is capped by agents.defaults.contextTokens. Raise that cap.`;
+    return `${base} OpenClaw is capped by an agent contextTokens setting. Raise that setting.`;
   }
   if (params.guard.source === "modelsConfig") {
     return (

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -4590,6 +4590,37 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     );
   });
 
+  it("preserves the session agent for queued sandbox budget resolution", async () => {
+    resolveSessionAgentIdsMock.mockReturnValue({
+      defaultAgentId: "main",
+      sessionAgentId: "work",
+    });
+
+    await compactEmbeddedAgentSession(
+      wrappedCompactionArgs({
+        agentId: "work",
+        config: {
+          agents: {
+            defaults: { contextTokens: 128_000 },
+            list: [{ id: "work", contextTokens: 200_000 }],
+          },
+        },
+        sandboxSessionKey: "agent:work:telegram:default:direct:12345",
+        sessionKey: "agent:work:main",
+        sessionTarget: {
+          agentId: "work",
+          sessionId: TEST_SESSION_ID,
+          sessionKey: "agent:work:main",
+          storePath: "/tmp/work-sessions.json",
+        },
+      }),
+    );
+
+    expect(resolveContextWindowInfoMock).toHaveBeenCalledWith(
+      expect.objectContaining({ agentContextTokens: 200_000 }),
+    );
+  });
+
   it("keeps a delegated result that echoes the current transcript on the active transcript", async () => {
     const maintain = vi.fn(async (_params?: unknown) => ({
       changed: false,

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -362,6 +362,7 @@ async function compactEmbeddedAgentSessionImpl(
         agentDir,
         resolvedWorkspaceDir,
         lease.snapshot,
+        agentIds.sessionAgentId,
         () => {
           disposeContextEngineOnExit = false;
         },
@@ -385,6 +386,7 @@ async function compactResolvedContextEngine(
   agentDir: string,
   resolvedWorkspaceDir: string,
   preparedModelRuntime: PreparedModelRuntimeSnapshot,
+  sessionAgentId: string,
   releaseContextEngineOwnership: () => void,
 ): Promise<EmbeddedAgentCompactResult> {
   const runtimeTarget = await resolveAgentRunSessionTarget(params);
@@ -526,7 +528,7 @@ async function compactResolvedContextEngine(
   }
   const contextTokenBudget = resolveCompactionContextTokenBudget({
     config: params.config,
-    agentId: runtimePolicyAgentId,
+    agentId: sessionAgentId,
     provider: ceContextConfigProvider,
     modelId: ceModelId,
     model: effectiveRuntimeModel,

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -526,6 +526,7 @@ async function compactResolvedContextEngine(
   }
   const contextTokenBudget = resolveCompactionContextTokenBudget({
     config: params.config,
+    agentId: runtimePolicyAgentId,
     provider: ceContextConfigProvider,
     modelId: ceModelId,
     model: effectiveRuntimeModel,

--- a/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
@@ -9,6 +9,7 @@ import { createProcessSessionFixture } from "../bash-process-registry.test-helpe
 import { resetProcessRegistryForTests } from "../bash-process-registry.test-support.js";
 import {
   buildEmbeddedCompactionRuntimeContext,
+  resolveCompactionContextTokenBudget,
   resolveCompactionHarnessRuntime,
   resolveEmbeddedCompactionThinkingLevel,
   resolveEmbeddedCompactionTarget,
@@ -760,6 +761,26 @@ describe("buildEmbeddedCompactionRuntimeContext", () => {
       defaultModel: "claude-opus-4-5",
     });
     expect(result.provider).toBe("anthropic");
+  });
+});
+
+describe("resolveCompactionContextTokenBudget", () => {
+  it("keeps the selected agent cap for prepared and queued compaction", () => {
+    expect(
+      resolveCompactionContextTokenBudget({
+        config: {
+          agents: {
+            defaults: { contextTokens: 128_000 },
+            list: [{ id: "work", contextTokens: 200_000 }],
+          },
+        } as unknown as OpenClawConfig,
+        agentId: "work",
+        provider: "openai",
+        modelId: "gpt-5.5",
+        model: { contextWindow: 272_000 },
+        requestedTokenBudget: 200_000,
+      }),
+    ).toBe(200_000);
   });
 });
 

--- a/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { formatSqliteSessionFileMarker } from "../../config/sessions/legacy-sqlite-marker.js";
+import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import { addSession } from "../bash-process-registry.js";
 import { createProcessSessionFixture } from "../bash-process-registry.test-helpers.js";
 import { resetProcessRegistryForTests } from "../bash-process-registry.test-support.js";
@@ -777,7 +778,18 @@ describe("resolveCompactionContextTokenBudget", () => {
         agentId: "work",
         provider: "openai",
         modelId: "gpt-5.5",
-        model: { contextWindow: 272_000 },
+        model: {
+          id: "gpt-5.5",
+          name: "GPT-5.5",
+          api: "openai-responses",
+          provider: "openai",
+          baseUrl: "https://example.com",
+          reasoning: true,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 272_000,
+          maxTokens: 4096,
+        } satisfies ProviderRuntimeModel,
         requestedTokenBudget: 200_000,
       }),
     ).toBe(200_000);

--- a/src/agents/embedded-agent-runner/compaction-runtime-context.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-context.ts
@@ -6,6 +6,7 @@ import type { ChatType } from "../../channels/chat-type.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import { isDefaultAgentRuntimeId, normalizeOptionalAgentRuntimeId } from "../agent-runtime-id.js";
+import { resolveAgentConfig } from "../agent-scope-config.js";
 import {
   listActiveProcessSessionReferences,
   type ActiveProcessSessionReference,
@@ -304,6 +305,7 @@ export function resolveCompactionHarnessRuntime(params: {
 /** Resolves the shared policy, target, and harness ownership for either compaction entry point. */
 export function resolveCompactionContextTokenBudget(params: {
   config?: OpenClawConfig;
+  agentId?: string;
   provider: string;
   modelId: string;
   model?: ProviderRuntimeModel;
@@ -318,6 +320,9 @@ export function resolveCompactionContextTokenBudget(params: {
         modelId: params.modelId,
         modelContextTokens: readAgentModelContextTokens(params.model),
         modelContextWindow: params.model?.contextWindow,
+        agentContextTokens: params.agentId
+          ? resolveAgentConfig(params.config ?? {}, params.agentId)?.contextTokens
+          : undefined,
         defaultTokens: DEFAULT_CONTEXT_TOKENS,
       }).tokens,
     ) ?? DEFAULT_CONTEXT_TOKENS;

--- a/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
+++ b/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
@@ -202,6 +202,7 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
     const runtimeModelWithContext = runtimeModel as ProviderRuntimeModel;
     const contextTokenBudget = resolveCompactionContextTokenBudget({
       config: params.config,
+      agentId: effectiveSkillAgentId,
       provider: contextConfigProvider,
       modelId,
       model: runtimeModelWithContext,

--- a/src/agents/embedded-agent-runner/run/model-harness.ts
+++ b/src/agents/embedded-agent-runner/run/model-harness.ts
@@ -1,4 +1,5 @@
 import type { Model } from "../../../llm/types.js";
+import { resolveAgentConfig } from "../../agent-scope-config.js";
 import {
   selectAgentHarness,
   selectAgentHarnessForPreparedModelProviders,
@@ -41,6 +42,9 @@ export function resolveEmbeddedRunEffectiveModel(
     }),
     modelId: params.modelId,
     runtimeModel: params.runtimeModel,
+    agentContextTokens: params.runParams.agentId
+      ? resolveAgentConfig(params.runParams.config ?? {}, params.runParams.agentId)?.contextTokens
+      : undefined,
     nativeModelOwned: params.nativeModelOwned,
   });
 }

--- a/src/agents/embedded-agent-runner/run/setup.test.ts
+++ b/src/agents/embedded-agent-runner/run/setup.test.ts
@@ -6,6 +6,8 @@ import type { ModelDefinitionConfig } from "../../../config/types.models.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { ProviderRuntimeModel } from "../../../plugins/provider-runtime-model.types.js";
 import { AGENT_HARNESS_SESSION_ID_LOCKED_MESSAGE } from "../../../sessions/agent-harness-session-key.js";
+import { resolveEmbeddedRunEffectiveModel } from "./model-harness.js";
+import type { RunEmbeddedAgentParams } from "./params.js";
 import {
   buildBeforeModelResolveAttachments,
   resolveAgentHarnessRunAdmissionError,
@@ -295,6 +297,43 @@ describe("resolveEmbeddedRuntimeModelPolicy", () => {
       tokens: 272_000,
     });
     expect(result.effectiveModel.contextWindow).toBe(272_000);
+  });
+
+  it("applies the selected agent context cap before the model limit", () => {
+    const result = resolveEmbeddedRuntimeModelPolicy({
+      cfg: undefined,
+      provider: "openai",
+      modelId: "gpt-5.5",
+      runtimeModel: createRuntimeModel(),
+      agentContextTokens: 128_000,
+      nativeModelOwned: false,
+    });
+
+    expect(result.contextWindowInfo).toEqual({
+      source: "agentContextTokens",
+      referenceTokens: 272_000,
+      tokens: 128_000,
+    });
+    expect(result.contextTokenBudget).toBe(128_000);
+    expect(result.effectiveModel.contextWindow).toBe(128_000);
+  });
+
+  it("passes the selected agent context cap through embedded model preparation", () => {
+    const result = resolveEmbeddedRunEffectiveModel({
+      runParams: {
+        agentId: "work",
+        config: { agents: { list: [{ id: "work", contextTokens: 128_000 }] } },
+      } as RunEmbeddedAgentParams,
+      provider: "openai",
+      modelConfigProvider: "openai",
+      modelId: "gpt-5.5",
+      agentHarnessId: "openclaw",
+      runtimeModel: createRuntimeModel(),
+      nativeModelOwned: false,
+    });
+
+    expect(result.contextTokenBudget).toBe(128_000);
+    expect(result.effectiveModel.contextWindow).toBe(128_000);
   });
 });
 

--- a/src/agents/embedded-agent-runner/run/setup.ts
+++ b/src/agents/embedded-agent-runner/run/setup.ts
@@ -210,6 +210,7 @@ function resolveEffectiveRuntimeModel(params: {
   contextConfigProvider?: string;
   modelId: string;
   runtimeModel: ProviderRuntimeModel;
+  agentContextTokens?: number;
 }): {
   ctxInfo: ContextWindowInfo;
   effectiveModel: ProviderRuntimeModel;
@@ -220,6 +221,7 @@ function resolveEffectiveRuntimeModel(params: {
     modelId: params.modelId,
     modelContextTokens: readAgentModelContextTokens(params.runtimeModel),
     modelContextWindow: params.runtimeModel.contextWindow,
+    agentContextTokens: params.agentContextTokens,
     defaultTokens: DEFAULT_CONTEXT_TOKENS,
   });
 
@@ -272,6 +274,7 @@ export function resolveEmbeddedRuntimeModelPolicy(params: {
   contextConfigProvider?: string;
   modelId: string;
   runtimeModel: ProviderRuntimeModel;
+  agentContextTokens?: number;
   nativeModelOwned: boolean;
 }): {
   contextWindowInfo?: ContextWindowInfo;


### PR DESCRIPTION
Related: #118678

## What Problem This Solves

Fixes an issue where users with a per-agent `contextTokens` limit could have embedded turns prechecked against the model's larger default context window, causing a tool-heavy turn to stop before its final response.

## Why This Change Was Made

The embedded runtime now resolves the selected agent's merged context cap before applying the shared context-window policy. The resulting budget is also applied to the effective model used for compaction and prechecks; native model-owned harnesses remain unchanged.

## User Impact

Per-agent context limits now consistently control embedded-run prechecks, compaction, and model context metadata, so users get the configured budget instead of a silently different limit.

## Evidence

- Current-head queued embedded compaction proof: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/compact.hooks.test.ts -t "preserves the session agent for queued sandbox budget resolution"` passed with `Test Files 2 passed` and `Tests 2 passed | 248 skipped`.
- Inspectable queued-path result: with `sandboxSessionKey=agent:work:telegram:default:direct:12345`, default context `128000`, and selected agent `work` configured for `200000`, the assertion observed `agentContextTokens: 200000` during queued compaction.
- Selected-agent budget regression: default `128000`, selected agent `200000`, model `272000`; the resolver returns `200000` for the selected agent path.
- Supporting checks passed: targeted formatting, `git diff --check`, and the focused queued-compaction regression.
- Proof boundary: this validates the embedded runtime's selected-agent cap through queued sandbox-key compaction and the selected-agent budget helper; native model-owned harnesses remain outside this proof.
- Exact head: `f3a55cd7244e9482528e3b7a11f36c977f419b74`.
