### PR TITLE
fix(gateway): reset terminal verdict on manual channel restart

### DIFF
--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -927,6 +927,81 @@ describe("server-channels auto restart", () => {
     expect(lifecycleAtHandoff).toEqual(["starting", "starting"]);
   });
 
+  it("recovers a manually restarted channel from a transient failure after terminal disconnect", async () => {
+    const handoffStates: ChannelAccountSnapshot[] = [];
+    const handoffSignals: AbortSignal[] = [];
+    const startAccount = vi.fn(async (ctx: ChannelGatewayContext<TestAccount>) => {
+      handoffStates.push({ ...ctx.getStatus() });
+      handoffSignals.push(ctx.abortSignal);
+      if (handoffStates.length === 1) {
+        ctx.setStatus({
+          accountId: ctx.accountId,
+          terminalDisconnect: true,
+          lifecycle: "blocked",
+          lastError: "relink required",
+        });
+        return;
+      }
+      if (handoffStates.length === 2) {
+        throw new Error("transient reconnect failure");
+      }
+      ctx.setStatus({ accountId: ctx.accountId, connected: true });
+      await new Promise<void>((resolve) => {
+        ctx.abortSignal.addEventListener("abort", () => resolve(), { once: true });
+      });
+    });
+    installTestRegistry(createTestPlugin({ startAccount }));
+    const manager = createManager();
+    const readAccount = () =>
+      manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+
+    await manager.startChannels();
+    await vi.advanceTimersByTimeAsync(20);
+
+    expect(startAccount).toHaveBeenCalledTimes(1);
+    expect(readAccount()).toMatchObject({
+      terminalDisconnect: true,
+      running: false,
+      lifecycle: "blocked",
+      lastError: "relink required",
+      restartPending: false,
+    });
+    expect(healthOf(readAccount()).reason).toBe("terminal-disconnect");
+    expect(hoisted.sleepWithAbort).not.toHaveBeenCalled();
+
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID, { manual: true });
+    await advanceTimersUntil(
+      () => startAccount.mock.calls.length === 3,
+      "expected a transient failure after manual restart to recover automatically",
+      { stepMs: 10, maxMs: 100 },
+    );
+    await flushMicrotasks();
+
+    expect(handoffStates.map(({ lifecycle }) => lifecycle)).toEqual([
+      "starting",
+      "starting",
+      "starting",
+    ]);
+    expect(handoffStates[1]?.terminalDisconnect).toBeUndefined();
+    expect(handoffStates[2]?.terminalDisconnect).toBeUndefined();
+    expect(handoffSignals[0]?.aborted).toBe(true);
+    expect(handoffSignals[1]?.aborted).toBe(true);
+    expect(handoffSignals[2]?.aborted).toBe(false);
+    expect(hoisted.sleepWithAbort).toHaveBeenCalledTimes(1);
+    expect(hoisted.sleepWithAbort.mock.calls[0]?.[0]).toBe(10);
+    expect(manager.isManuallyStopped("discord", DEFAULT_ACCOUNT_ID)).toBe(false);
+    expect(readAccount()).toMatchObject({
+      connected: true,
+      running: true,
+      lifecycle: "ready",
+      restartPending: false,
+      lastError: null,
+      reconnectAttempts: 1,
+    });
+    expect(readAccount()?.terminalDisconnect).toBeUndefined();
+    expect(healthOf(readAccount()).reason).not.toBe("terminal-disconnect");
+  });
+
   it("consumes rejected stop tasks during manual abort", async () => {
     const unhandledRejection = vi.fn();
     process.on("unhandledRejection", unhandledRejection);

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -728,10 +728,10 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             restartPending: false,
             lastStartAt: Date.now(),
             lastError: null,
-            // Runtime rows are patch-merged, so a dead-ingress verdict from the
-            // previous lifecycle would outlive the condition it described. Every
-            // start re-proves ingress, so every start must clear it first.
+            // Runtime rows are patch-merged; prior ingress or terminal verdicts
+            // must not poison a new lifecycle before its plugin reports status.
             ingressUnavailable: undefined,
+            terminalDisconnect: undefined,
             reconnectAttempts: preserveRestartAttempts ? (restarts.get(rKey)?.attempts ?? 0) : 0,
           });
           const task = Promise.resolve().then(async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators who manually restarted a channel after resolving a terminal disconnect could still lose that channel permanently when its first reconnection attempt hit an ordinary temporary error. The Gateway incorrectly treated the new connection attempt as if the previous terminal failure were still current, so both automatic channel recovery and health-monitor recovery remained disabled.

The underlying Gateway lifecycle bug is present in stable `v2026.7.1`, where WhatsApp is the affected bundled channel; current `main` also exposes the shared failure to additional channel plugins that report terminal disconnects.

## Why This Change Was Made

Clear lifecycle-owned terminal and ingress verdicts together at the Gateway's existing authoritative new-channel-start transition. This leaves genuine terminal failures blocked for their own lifecycle and preserves administrator authorization, plugin readiness, link/configuration admission, manual-stop decisions, abort ordering, and the existing retry policy.

## User Impact

After an operator explicitly starts a channel again, ordinary transient reconnect errors recover automatically instead of leaving the bot silently and permanently offline. A genuine terminal disconnect still requires operator action; no channel credentials, public configuration, plugin contracts, or Gateway protocol behavior change.

## Evidence

- Exact reviewed commit: `2222b46d3f164766367142c6b79a61f3b25483bf`; sole parent: `fe6fa891ea4ef3bb152d02df944a8def6518fdd1`.
- Exact committed two-file binary-diff SHA-256: `8e0e5268b171601f2302fc271baece596332366b6076f35bde3cd5c67bd6f387`.
- Tests-first RED through the actual Gateway channel manager and plugin registry: the first terminal failure correctly blocks automatic retries; an explicit `{ manual: true }` restart then fails before readiness, and the expected third automatic recovery never occurs. The focused regression failed with `expected a transient failure after manual restart to recover automatically`.
- Final focused GREEN through the same real manager boundary proves three distinct lifecycle generations, stale-terminal clearing before plugin handoff, the original terminal block, one ordinary 10 ms backoff retry, correct old/current abort-signal ownership, a healthy connected account, and preserved manual-stop state.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/gateway/server-channels.test.ts` — **85/85 passing**, including existing same-lifecycle terminal-disconnect, manual-stop, stop-timeout, aborted-task, and retry-supervisor safety cases.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/gateway/channel-health-policy.test.ts src/gateway/channel-health-monitor.test.ts` — **94/94 passing**.
- Exact two-file formatting and committed `git diff --check` passed. Production delta: **3 additions, 3 deletions; zero net lines**.
- Four separate independent hostile source reviews found **zero P0–P3 issues**. A fifth distinct reviewer ran exactly one genuine `gpt-5.6-sol` / high-reasoning / P3 / no-web autoreview: **clean, confidence 0.94**. Checksum-authenticated TruffleHog 3.96.0 found no secrets.

- Final root-owned Testbox proof authenticated the exact commit, parent, tree, two source blobs, dependency inputs, and binary patch before starting an actual isolated Gateway and driving real loopback WebSocket RPC. The unchanged parent failed the real administrator restart/recovery scenario; the reviewed candidate recovered successfully after the genuine production retry delay (5,180 ms).
- Real wrong-token authentication was rejected; a read-only operator was denied `channels.start` and both `channels.stop` variants; genuine terminal disconnects and manually stopped sibling accounts remained blocked while the recovered account became healthy.
- The same exact-head remote run passed **85 Gateway lifecycle tests plus 94 health-policy/health-monitor sibling tests**, followed by the complete exact-two-path changed gate: core/core-test typechecks, lint, Knip, architecture/boundary checks, schema/state guards, and import-cycle checks.
- The Gateway/provider Node-process network guard independently passed real loopback HTTP, WebSocket, socket, Unix IPC, malformed lookup, symlink, and non-owner-path checks. One background hosted-catalog DNS attempt was blocked; **zero external network connections occurred**. This guard is scoped to Gateway/provider Node transports and is not presented as an operating-system-wide subprocess firewall.

### Actual authenticated Gateway proof

```json
{"status":"PASS","ready_to_publish":true,"head":"2222b46d3f164766367142c6b79a61f3b25483bf","base":"fe6fa891ea4ef3bb152d02df944a8def6518fdd1","binaryDiffSha256":"8e0e5268b171601f2302fc271baece596332366b6076f35bde3cd5c67bd6f387","rootCauses":1,"productionLocDelta":0,"ownerTests":85,"healthSiblingTests":94,"independentHostileReviews":4,"officialReview":"CLEAN","officialReviewConfidence":0.94,"secretScan":"CLEAN","gatewayTransport":"actual-loopback-websocket","parentAuthenticatedAdminRecovery":"RED","candidateAuthenticatedAdminRecovery":"GREEN","productionRetryElapsedMs":5180,"wrongTokenRejected":true,"readerDeniedMethods":3,"genuineTerminalPreserved":true,"manuallyStoppedSiblingPreserved":true,"guardedGatewayNodeExternalNetworkAttempts":1,"guardedGatewayNodeExternalNetworkConnections":0,"completeExactTwoPathChangedGate":"PASS"}
```

## Maintainer Review Resolution

- All required exact-head GitHub checks for commit `2222b46d3f164766367142c6b79a61f3b25483bf` are green; the independently authenticated loopback Gateway parent RED/candidate GREEN proof and complete remote changed-code gate both passed.
- The repository owner explicitly delegated autonomous maintainer review and native landing for this campaign; four independent hostile Gateway reviews and the exact-head genuine Sol review are complete.
- **Maintainer decision:** Approve the existing lifecycle-owner reset and three-generation regression test, retain genuine-terminal and manual-stop protection, and land the reviewed exact head through the repository's normal native maintainer workflow.
