### PR TITLE
fix(auth): canonicalize provider account order and refresh running gateways

### DIFF
--- a/src/agents/auth-profiles/profiles.test.ts
+++ b/src/agents/auth-profiles/profiles.test.ts
@@ -22,6 +22,7 @@ import {
   promoteAuthProfileInOrder,
   removeAuthProfilesAcrossOwnerStores,
   removeAuthProfilesWithLock,
+  setAuthProfileOrder,
   upsertAuthProfileWithLock,
 } from "./profiles.js";
 import {
@@ -120,6 +121,119 @@ function expectOAuthCredentialFields(
   }
   return credential;
 }
+
+describe("setAuthProfileOrder", () => {
+  const primaryProfileId = "gmi:primary";
+  const backupProfileId = "gmi:backup";
+  const unrelatedProfileId = "unrelated-provider:default";
+
+  const cases: Array<{
+    label: string;
+    provider: string;
+    previousOrder: Record<string, string[]>;
+    requestedOrder: string[] | null;
+    expectedOrder: Record<string, string[]>;
+  }> = [
+    {
+      label: "canonicalizes an alias-only account order on set",
+      provider: "gmi-cloud",
+      previousOrder: { "gmi-cloud": [primaryProfileId] },
+      requestedOrder: [backupProfileId],
+      expectedOrder: { gmi: [backupProfileId] },
+    },
+    {
+      label: "removes every historical alias duplicate on set",
+      provider: "gmi",
+      previousOrder: {
+        gmi: [primaryProfileId],
+        "gmi-cloud": [primaryProfileId],
+        gmicloud: [primaryProfileId],
+      },
+      requestedOrder: [backupProfileId],
+      expectedOrder: { gmi: [backupProfileId] },
+    },
+    {
+      label: "clears an alias-only account order through the canonical provider",
+      provider: "gmi",
+      previousOrder: { "gmi-cloud": [primaryProfileId] },
+      requestedOrder: null,
+      expectedOrder: {},
+    },
+    {
+      label: "clears every canonical and historical alias duplicate atomically",
+      provider: "gmicloud",
+      previousOrder: {
+        gmi: [primaryProfileId],
+        "gmi-cloud": [primaryProfileId],
+        gmicloud: [backupProfileId],
+      },
+      requestedOrder: null,
+      expectedOrder: {},
+    },
+  ];
+
+  it.each(cases)(
+    "$label without changing unrelated state or credential ownership",
+    async (params) => {
+      await withAuthProfileTestState(
+        "openclaw-auth-order-canonical-owner-",
+        async ({ agentDir }) => {
+          fs.mkdirSync(agentDir, { recursive: true });
+          const unrelatedOrder = [unrelatedProfileId];
+          const store: AuthProfileStore = {
+            version: AUTH_STORE_VERSION,
+            profiles: {
+              [primaryProfileId]: { type: "api_key", provider: "gmi", key: "fixture-primary-key" },
+              [backupProfileId]: { type: "api_key", provider: "gmi", key: "fixture-backup-key" },
+              [unrelatedProfileId]: {
+                type: "api_key",
+                provider: "unrelated-provider",
+                key: "fixture-unrelated-key",
+              },
+            },
+            order: {
+              ...params.previousOrder,
+              "unrelated-provider": unrelatedOrder,
+            },
+            lastGood: {
+              gmi: primaryProfileId,
+              "unrelated-provider": unrelatedProfileId,
+            },
+            usageStats: {
+              [primaryProfileId]: { lastUsed: 123 },
+              [unrelatedProfileId]: { lastUsed: 456 },
+            },
+          };
+          saveAuthProfileStore(store, agentDir);
+          replaceRuntimeAuthProfileStoreSnapshots([
+            { agentDir, store: loadAuthProfileStoreForRuntime(agentDir) },
+          ]);
+          const credentialMutationToken =
+            getRuntimeAuthProfileStoreCredentialMutationToken(agentDir);
+
+          const updated = await setAuthProfileOrder({
+            agentDir,
+            provider: params.provider,
+            order: params.requestedOrder,
+          });
+
+          const expectedOrder = {
+            ...params.expectedOrder,
+            "unrelated-provider": unrelatedOrder,
+          };
+          expect(updated?.order).toEqual(expectedOrder);
+          expect(loadAuthProfileStoreForRuntime(agentDir).order).toEqual(expectedOrder);
+          expect(getRuntimeAuthProfileStoreSnapshot(agentDir)?.order).toEqual(expectedOrder);
+          expect(updated?.lastGood).toEqual(store.lastGood);
+          expect(updated?.usageStats).toEqual(store.usageStats);
+          expect(getRuntimeAuthProfileStoreCredentialMutationToken(agentDir)).toEqual(
+            credentialMutationToken,
+          );
+        },
+      );
+    },
+  );
+});
 
 describe("promoteAuthProfileInOrder", () => {
   it("refreshes inherited main selection state without advancing credential ownership", async () => {

--- a/src/agents/auth-profiles/profiles.ts
+++ b/src/agents/auth-profiles/profiles.ts
@@ -8,8 +8,9 @@ import {
   normalizeProviderId,
 } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
-import { resolveProviderIdForAuth } from "../provider-auth-aliases.js";
+import { resolveProviderAuthAliasMap, resolveProviderIdForAuth } from "../provider-auth-aliases.js";
 import { normalizeAuthProfileCredential } from "./credential-normalize.js";
 import { dedupeProfileIds, listProfilesForProvider } from "./profile-list.js";
 import {
@@ -78,10 +79,20 @@ function updateSuccessfulUsageStatsEntry(
 /** Sets or clears explicit auth profile order for a provider. */
 export async function setAuthProfileOrder(params: {
   agentDir?: string;
+  config?: OpenClawConfig;
   provider: string;
   order?: string[] | null;
 }): Promise<AuthProfileStore | null> {
-  const providerKey = normalizeProviderId(params.provider);
+  // Discover plugin-owned aliases before SQLite's synchronous commit section;
+  // otherwise canonical cleanup would perform filesystem work under its lock.
+  const providerAliases = resolveProviderAuthAliasMap(
+    params.config ? { config: params.config } : undefined,
+  );
+  const resolveProviderOwner = (provider: string): string => {
+    const normalized = normalizeProviderId(provider);
+    return providerAliases[normalized] ?? normalized;
+  };
+  const providerKey = resolveProviderOwner(params.provider);
   const sanitized =
     params.order && Array.isArray(params.order) ? normalizeStringEntries(params.order) : [];
   const deduped = dedupeProfileIds(sanitized);
@@ -90,15 +101,27 @@ export async function setAuthProfileOrder(params: {
     agentDir: params.agentDir,
     updater: (store) => {
       store.order = store.order ?? {};
+      const matchingProviderKeys = Object.keys(store.order).filter(
+        (storedProvider) => resolveProviderOwner(storedProvider) === providerKey,
+      );
       if (deduped.length === 0) {
-        if (!store.order[providerKey]) {
+        if (matchingProviderKeys.length === 0) {
           return false;
         }
-        delete store.order[providerKey];
+        for (const storedProvider of matchingProviderKeys) {
+          delete store.order[storedProvider];
+        }
         if (Object.keys(store.order).length === 0) {
           store.order = undefined;
         }
         return true;
+      }
+      // Canonical and alias keys are one owner; stale duplicates would silently
+      // resurrect an override after a later canonical clear.
+      for (const storedProvider of matchingProviderKeys) {
+        if (storedProvider !== providerKey) {
+          delete store.order[storedProvider];
+        }
       }
       store.order[providerKey] = deduped;
       return true;

--- a/src/commands/models/auth-order.test.ts
+++ b/src/commands/models/auth-order.test.ts
@@ -1,0 +1,321 @@
+/** Regression coverage for canonical provider account selection and live Gateway refresh. */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveAuthProfileOrder } from "../../agents/auth-profiles/order.js";
+import {
+  clearRuntimeAuthProfileStoreSnapshot,
+  getRuntimeAuthProfileStoreSnapshot,
+  setRuntimeAuthProfileStoreSnapshot,
+} from "../../agents/auth-profiles/runtime-snapshots.js";
+import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
+import { resetProviderAuthAliasMapCacheForTest } from "../../agents/provider-auth-aliases.test-support.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { OutputRuntimeEnv } from "../../runtime.js";
+import {
+  modelsAuthOrderClearCommand,
+  modelsAuthOrderGetCommand,
+  modelsAuthOrderSetCommand,
+} from "./auth-order.js";
+
+const agentDir = "/tmp/openclaw-auth-order-owner-main";
+const primaryProfileId = "fixture-provider:primary";
+const backupProfileId = "fixture-provider:backup";
+
+const mocks = vi.hoisted(() => {
+  const snapshot = {
+    plugins: [
+      {
+        id: "fixture-provider",
+        origin: "bundled",
+        providerAuthAliases: {
+          "fixture-provider-plan": "fixture-provider",
+          "fixture-provider-enterprise": "fixture-provider",
+        },
+      },
+    ],
+    diagnostics: [],
+  };
+  return {
+    callGateway: vi.fn(async (_params: unknown) => ({})),
+    ensureAuthProfileStore: vi.fn(),
+    externalCliDiscoveryForProviderAuth: vi.fn(() => ({ kind: "none" as const })),
+    getCurrentPluginMetadataSnapshot: vi.fn(() => snapshot),
+    loadModelsConfig: vi.fn(),
+    loadPluginMetadataSnapshot: vi.fn(() => snapshot),
+    persistedStore: { version: 1, profiles: {} } as AuthProfileStore,
+    setAuthProfileOrder: vi.fn(),
+  };
+});
+
+vi.mock("../../agents/auth-profiles.js", () => ({
+  ensureAuthProfileStore: mocks.ensureAuthProfileStore,
+  externalCliDiscoveryForProviderAuth: mocks.externalCliDiscoveryForProviderAuth,
+  resolveAuthStatePathForDisplay: (directory: string) => `${directory}/openclaw-agent.sqlite`,
+  setAuthProfileOrder: mocks.setAuthProfileOrder,
+}));
+
+vi.mock("../../gateway/call.js", () => ({
+  callGateway: mocks.callGateway,
+}));
+
+vi.mock("../../plugins/current-plugin-metadata-snapshot.js", () => ({
+  getCurrentPluginMetadataSnapshot: mocks.getCurrentPluginMetadataSnapshot,
+}));
+
+vi.mock("../../plugins/plugin-metadata-snapshot.js", () => ({
+  loadPluginMetadataSnapshot: mocks.loadPluginMetadataSnapshot,
+}));
+
+vi.mock("./load-config.js", () => ({
+  loadModelsConfig: mocks.loadModelsConfig,
+}));
+
+vi.mock("./shared.js", () => ({
+  resolveModelsTargetAgent: (_cfg: OpenClawConfig, requestedAgentId?: string) => ({
+    agentId: requestedAgentId ?? "main",
+    agentDir,
+  }),
+}));
+
+function createProfileStore(params?: {
+  credentialProvider?: string;
+  order?: string[];
+}): AuthProfileStore {
+  const credentialProvider = params?.credentialProvider ?? "fixture-provider";
+  return {
+    version: 1,
+    profiles: {
+      [primaryProfileId]: {
+        type: "api_key",
+        provider: credentialProvider,
+        key: "fixture-primary-key",
+      },
+      [backupProfileId]: {
+        type: "api_key",
+        provider: credentialProvider,
+        key: "fixture-backup-key",
+      },
+    },
+    ...(params?.order ? { order: { "fixture-provider": params.order } } : {}),
+  };
+}
+
+function createRuntime(): OutputRuntimeEnv & { logs: string[]; jsonPayloads: unknown[] } {
+  const logs: string[] = [];
+  const jsonPayloads: unknown[] = [];
+  return {
+    logs,
+    jsonPayloads,
+    log: (...values: unknown[]) => logs.push(values.map(String).join(" ")),
+    error: vi.fn(),
+    exit: vi.fn(),
+    writeStdout: vi.fn(),
+    writeJson: (value: unknown) => jsonPayloads.push(value),
+  };
+}
+
+function expectGatewayRefresh() {
+  expect(mocks.callGateway).toHaveBeenCalledWith({
+    method: "models.authStatus",
+    params: { refresh: true },
+    timeoutMs: 3000,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetProviderAuthAliasMapCacheForTest();
+  mocks.persistedStore = createProfileStore({ order: [primaryProfileId] });
+  mocks.loadModelsConfig.mockResolvedValue({} as OpenClawConfig);
+  mocks.ensureAuthProfileStore.mockImplementation(() => mocks.persistedStore);
+  mocks.callGateway.mockResolvedValue({});
+  mocks.setAuthProfileOrder.mockImplementation(
+    async (params: { provider: string; order?: string[] | null }) => {
+      const store = structuredClone(mocks.persistedStore);
+      store.order = { ...store.order };
+      if (params.order?.length) {
+        store.order[params.provider] = params.order;
+      } else {
+        delete store.order[params.provider];
+      }
+      mocks.persistedStore = store;
+      return store;
+    },
+  );
+});
+
+afterEach(() => {
+  clearRuntimeAuthProfileStoreSnapshot(agentDir);
+});
+
+describe("models auth order", () => {
+  it("reads the canonical provider account order through its manifest auth alias", async () => {
+    const runtime = createRuntime();
+
+    await modelsAuthOrderGetCommand({ provider: "fixture-provider-plan", json: true }, runtime);
+
+    expect(runtime.jsonPayloads).toEqual([
+      expect.objectContaining({
+        provider: "fixture-provider",
+        order: [primaryProfileId],
+      }),
+    ]);
+    expect(mocks.externalCliDiscoveryForProviderAuth).toHaveBeenCalledWith({
+      cfg: {},
+      provider: "fixture-provider",
+    });
+    expect(mocks.callGateway).not.toHaveBeenCalled();
+  });
+
+  it("reports an existing account order stored under a historical provider alias", async () => {
+    mocks.persistedStore.order = {
+      "fixture-provider-plan": [backupProfileId],
+      "different-provider": ["different-provider:default"],
+    };
+    const runtime = createRuntime();
+
+    await modelsAuthOrderGetCommand({ provider: "fixture-provider", json: true }, runtime);
+
+    expect(runtime.jsonPayloads).toEqual([
+      expect.objectContaining({
+        provider: "fixture-provider",
+        order: [backupProfileId],
+      }),
+    ]);
+  });
+
+  it("prefers the canonical account order when historical alias duplicates remain", async () => {
+    mocks.persistedStore.order = {
+      "fixture-provider-plan": [backupProfileId],
+      "fixture-provider-enterprise": [backupProfileId],
+      "fixture-provider": [primaryProfileId],
+    };
+    const runtime = createRuntime();
+
+    await modelsAuthOrderGetCommand({ provider: "fixture-provider-plan", json: true }, runtime);
+
+    expect(runtime.jsonPayloads).toEqual([expect.objectContaining({ order: [primaryProfileId] })]);
+  });
+
+  it.each([
+    {
+      label: "canonical credentials selected through an alias",
+      requestedProvider: "fixture-provider-plan",
+      credentialProvider: "fixture-provider",
+    },
+    {
+      label: "alias credentials selected through their canonical provider",
+      requestedProvider: "fixture-provider",
+      credentialProvider: "fixture-provider-plan",
+    },
+  ])("sets $label and refreshes the live Gateway", async (params) => {
+    mocks.persistedStore = createProfileStore({
+      credentialProvider: params.credentialProvider,
+      order: [primaryProfileId],
+    });
+
+    await modelsAuthOrderSetCommand(
+      { provider: params.requestedProvider, order: [backupProfileId] },
+      createRuntime(),
+    );
+
+    expect(mocks.setAuthProfileOrder).toHaveBeenCalledWith({
+      agentDir,
+      config: {},
+      provider: "fixture-provider",
+      order: [backupProfileId],
+    });
+    expectGatewayRefresh();
+  });
+
+  it("clears the canonical account order through its alias and refreshes the Gateway", async () => {
+    await modelsAuthOrderClearCommand({ provider: "fixture-provider-plan" }, createRuntime());
+
+    expect(mocks.setAuthProfileOrder).toHaveBeenCalledWith({
+      agentDir,
+      config: {},
+      provider: "fixture-provider",
+      order: null,
+    });
+    expectGatewayRefresh();
+  });
+
+  it.each(["set", "clear"] as const)(
+    "never refreshes the Gateway after a failed %s store write",
+    async (operation) => {
+      mocks.setAuthProfileOrder.mockResolvedValueOnce(null);
+      const runtime = createRuntime();
+      const action =
+        operation === "set"
+          ? modelsAuthOrderSetCommand(
+              { provider: "fixture-provider", order: [backupProfileId] },
+              runtime,
+            )
+          : modelsAuthOrderClearCommand({ provider: "fixture-provider" }, runtime);
+
+      await expect(action).rejects.toThrow("auth state lock may be busy");
+      expect(mocks.callGateway).not.toHaveBeenCalled();
+    },
+  );
+
+  it("never refreshes the Gateway when a profile belongs to another provider", async () => {
+    mocks.persistedStore = createProfileStore({ credentialProvider: "different-provider" });
+
+    await expect(
+      modelsAuthOrderSetCommand(
+        { provider: "fixture-provider", order: [primaryProfileId] },
+        createRuntime(),
+      ),
+    ).rejects.toThrow(`Auth profile "${primaryProfileId}" is for different-provider`);
+
+    expect(mocks.setAuthProfileOrder).not.toHaveBeenCalled();
+    expect(mocks.callGateway).not.toHaveBeenCalled();
+  });
+
+  it("applies account switching to the actual running-Gateway auth snapshot", async () => {
+    setRuntimeAuthProfileStoreSnapshot(mocks.persistedStore, agentDir);
+    const oldGatewayStore = getRuntimeAuthProfileStoreSnapshot(agentDir);
+    expect(oldGatewayStore).toBeDefined();
+    expect(
+      resolveAuthProfileOrder({
+        cfg: {},
+        store: oldGatewayStore!,
+        provider: "fixture-provider-plan",
+      }),
+    ).toEqual([primaryProfileId]);
+
+    mocks.callGateway.mockImplementationOnce(async () => {
+      setRuntimeAuthProfileStoreSnapshot(mocks.persistedStore, agentDir);
+      return {};
+    });
+
+    await modelsAuthOrderSetCommand(
+      { provider: "fixture-provider", order: [backupProfileId] },
+      createRuntime(),
+    );
+
+    const refreshedGatewayStore = getRuntimeAuthProfileStoreSnapshot(agentDir);
+    expect(refreshedGatewayStore).toBeDefined();
+    expect(
+      resolveAuthProfileOrder({
+        cfg: {},
+        store: refreshedGatewayStore!,
+        provider: "fixture-provider-plan",
+      }),
+    ).toEqual([backupProfileId]);
+    expectGatewayRefresh();
+  });
+
+  it("keeps a successful persisted account change when the Gateway is unavailable", async () => {
+    mocks.callGateway.mockRejectedValueOnce(new Error("gateway unavailable"));
+    const runtime = createRuntime();
+
+    await modelsAuthOrderSetCommand(
+      { provider: "fixture-provider", order: [backupProfileId] },
+      runtime,
+    );
+
+    expect(mocks.persistedStore.order?.["fixture-provider"]).toEqual([backupProfileId]);
+    expect(runtime.logs).toContain(`Auth profile order override: ${backupProfileId}`);
+    expectGatewayRefresh();
+  });
+});

--- a/src/commands/models/auth-order.ts
+++ b/src/commands/models/auth-order.ts
@@ -7,18 +7,24 @@ import {
   resolveAuthStatePathForDisplay,
   setAuthProfileOrder,
 } from "../../agents/auth-profiles.js";
-import { findNormalizedProviderValue, normalizeProviderId } from "../../agents/model-selection.js";
+import { findNormalizedProviderValue } from "../../agents/model-selection.js";
 import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
 import { formatCliCommand } from "../../cli/command-format.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
 import { shortenHomePath } from "../../utils.js";
+import { refreshRunningGatewayAuthState } from "./auth-refresh.js";
 import { loadModelsConfig } from "./load-config.js";
 import { resolveModelsTargetAgent } from "./shared.js";
 
-function describeOrder(store: AuthProfileStore, provider: string): string[] {
-  const providerKey = normalizeProviderId(provider);
-  const order = store.order?.[providerKey];
+function describeOrder(store: AuthProfileStore, provider: string, cfg: OpenClawConfig): string[] {
+  const providerKey = resolveProviderIdForAuth(provider, { config: cfg });
+  const order =
+    store.order?.[providerKey] ??
+    Object.entries(store.order ?? {}).find(
+      ([storedProvider]) =>
+        resolveProviderIdForAuth(storedProvider, { config: cfg }) === providerKey,
+    )?.[1];
   return Array.isArray(order) ? order : [];
 }
 
@@ -45,8 +51,9 @@ async function resolveAuthOrderContext(
       `Missing --provider. Run ${formatCliCommand("openclaw models auth list")} to see saved provider profiles.`,
     );
   }
-  const provider = normalizeProviderId(rawProvider);
   const cfg = await loadModelsConfig({ commandName: "models auth-order", runtime });
+  // Alias model providers share the canonical credential owner's account order.
+  const provider = resolveProviderIdForAuth(rawProvider, { config: cfg });
   const { agentId, agentDir } = resolveModelsTargetAgent(cfg, opts.agent);
   return { cfg, agentId, agentDir, provider };
 }
@@ -60,7 +67,7 @@ export async function modelsAuthOrderGetCommand(
   const store = ensureAuthProfileStore(agentDir, {
     externalCli: externalCliDiscoveryForProviderAuth({ cfg, provider }),
   });
-  const order = describeOrder(store, provider);
+  const order = describeOrder(store, provider, cfg);
 
   if (opts.json) {
     writeRuntimeJson(runtime, {
@@ -91,6 +98,7 @@ export async function modelsAuthOrderClearCommand(
   const { cfg, agentId, agentDir, provider } = await resolveAuthOrderContext(opts, runtime);
   const updated = await setAuthProfileOrder({
     agentDir,
+    config: cfg,
     provider,
     order: null,
   });
@@ -99,6 +107,8 @@ export async function modelsAuthOrderClearCommand(
       `Failed to update auth state; the auth state lock may be busy. Wait a moment and rerun ${formatCliCommand("openclaw models auth order clear --provider " + provider)}.`,
     );
   }
+
+  await refreshRunningGatewayAuthState();
 
   runtime.log(`Agent: ${agentId}`);
   runtime.log(`Provider: ${provider}`);
@@ -115,7 +125,6 @@ export async function modelsAuthOrderSetCommand(
   const store = ensureAuthProfileStore(agentDir, {
     externalCli: externalCliDiscoveryForProviderAuth({ cfg, provider }),
   });
-  const providerKey = provider;
   const requested = normalizeStringEntries(opts.order ?? []);
   if (requested.length === 0) {
     throw new Error(
@@ -130,13 +139,14 @@ export async function modelsAuthOrderSetCommand(
         `Auth profile "${profileId}" not found in ${shortenHomePath(agentDir)}. Run ${formatCliCommand("openclaw models auth list --provider " + provider)} to see saved profiles.`,
       );
     }
-    if (normalizeProviderId(cred.provider) !== providerKey) {
+    if (resolveProviderIdForAuth(cred.provider, { config: cfg }) !== provider) {
       throw new Error(`Auth profile "${profileId}" is for ${cred.provider}, not ${provider}.`);
     }
   }
 
   const updated = await setAuthProfileOrder({
     agentDir,
+    config: cfg,
     provider,
     order: requested,
   });
@@ -146,7 +156,9 @@ export async function modelsAuthOrderSetCommand(
     );
   }
 
+  await refreshRunningGatewayAuthState();
+
   runtime.log(`Agent: ${agentId}`);
   runtime.log(`Provider: ${provider}`);
-  runtime.log(`Auth profile order override: ${describeOrder(updated, provider).join(", ")}`);
+  runtime.log(`Auth profile order override: ${describeOrder(updated, provider, cfg).join(", ")}`);
 }


### PR DESCRIPTION
## Summary

- Treat canonical provider IDs and their plugin-owned auth aliases as one authoritative account-order owner.
- Atomically remove stale historical alias-keyed overrides and refresh an already-running Gateway after successful auth-order changes.

## Root cause and lifecycle ownership

The public `openclaw models auth order` commands normalized provider spelling without resolving plugin manifest auth aliases. Meanwhile the SQLite-backed account-order owner modified exactly one stored key, leaving historical alias-only or duplicate alias/canonical rows active after a supposed set/clear. Existing Gateway runtime snapshots also remained stale until restart.

Provider alias metadata is now prepared **before** the synchronous SQLite transaction. Inside the existing commit boundary the owner rereads authoritative state, canonicalizes the provider, removes every equivalent stale alias, and preserves unrelated account order, credentials, usage stats, last-good metadata, and credential mutation ownership. CLI get/set/clear share the canonical owner. Only a successfully persisted mutation triggers the existing best-effort Gateway auth-state refresh; offline Gateway behavior remains unchanged. No schema, schema version, configuration shape, compatibility reader, or migration path changes.

## Real owner and sibling proof

- One genuine CLI historical-alias failure plus four real SQLite/snapshot alias-only, duplicate, set, and clear failures were reproduced before repair.
- **84 focused tests pass** across commands, actual SQLite-backed auth profiles, process-local runtime snapshots, and existing siblings.
- Uses the real bundled GMI manifest aliases `gmi-cloud`/`gmicloud` and proves canonical ownership, account isolation, unchanged metadata/credentials, no failed-mutation refresh, and working live Gateway refresh.
- Type-aware typechecking/lint, formatting, and whitespace validation pass.
- Fresh independent structured Sol/high/P1 review: **no findings; confidence 0.91**.
- Production: **+48/-13 = +35 lines** in the existing public-command and SQLite ownership boundaries; remaining changes are focused regressions.
