### PR TITLE
fix(slack): unify slash command registration ownership

### DIFF
--- a/extensions/slack/src/monitor/slash.test.ts
+++ b/extensions/slack/src/monitor/slash.test.ts
@@ -839,14 +839,33 @@ describe("Slack native command argument menus", () => {
         slashCommand: { enabled: boolean };
       }
     ).slashCommand.enabled = true;
-    await registerCommands(configuredHarness.ctx, configuredHarness.account);
+    const registration = await registerCommands(configuredHarness.ctx, configuredHarness.account);
 
+    expect(registration).toEqual({ mode: "single", name: "openclaw" });
     expect(
       [...configuredHarness.commands.keys()].some(
         (command) => command instanceof RegExp && command.test("/openclaw"),
       ),
     ).toBe(true);
     expect(configuredHarness.commands.has("/usage")).toBe(false);
+  });
+
+  it("does not register native argument handlers for a configured slash command", async () => {
+    const configuredHarness = createArgMenusHarness();
+    const slashCommand = (
+      configuredHarness.ctx as {
+        slashCommand: { enabled: boolean; name: string };
+      }
+    ).slashCommand;
+    slashCommand.enabled = true;
+    slashCommand.name = "acme";
+
+    await expect(
+      registerCommands(configuredHarness.ctx, configuredHarness.account),
+    ).resolves.toEqual({ mode: "single", name: "acme" });
+
+    expect(configuredHarness.actions.size).toBe(0);
+    expect(configuredHarness.options.size).toBe(0);
   });
 
   it("registers options handlers without losing app receiver binding", async () => {

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -387,6 +387,11 @@ export async function registerSlackMonitorSlashCommands(params: {
   const slashCommand = resolveSlackSlashCommandConfig(
     ctx.slashCommand ?? account.config.slashCommand,
   );
+  // App Home and argument handlers must share the registered command mode;
+  // explicit single-command mode also avoids loading inactive native runtimes.
+  let registration: SlackCommandRegistration = slashCommand.enabled
+    ? { mode: "single", name: slashCommand.name }
+    : { mode: "disabled" };
 
   const handleSlashCommand = async (p: {
     command: SlackCommandMiddlewareArgs["command"];
@@ -872,22 +877,22 @@ export async function registerSlackMonitorSlashCommands(params: {
     }
   };
 
-  const nativeEnabled = resolveNativeCommandsEnabled({
-    providerId: "slack",
-    providerSetting: account.config.commands?.native,
-    globalSetting: startupCfg.commands?.native,
-  });
-  const nativeSkillsEnabled = resolveNativeSkillsEnabled({
-    providerId: "slack",
-    providerSetting: account.config.commands?.nativeSkills,
-    globalSetting: startupCfg.commands?.nativeSkills,
-  });
-
   let nativeCommands: Array<{ name: string }> = [];
   let slashCommandsRuntime: typeof import("./slash-commands.runtime.js") | null = null;
-  if (nativeEnabled) {
+  if (
+    registration.mode === "disabled" &&
+    resolveNativeCommandsEnabled({
+      providerId: "slack",
+      providerSetting: account.config.commands?.native,
+      globalSetting: startupCfg.commands?.native,
+    })
+  ) {
     slashCommandsRuntime = await loadSlashCommandsRuntime();
-    const skillCommands = nativeSkillsEnabled
+    const skillCommands = resolveNativeSkillsEnabled({
+      providerId: "slack",
+      providerSetting: account.config.commands?.nativeSkills,
+      globalSetting: startupCfg.commands?.nativeSkills,
+    })
       ? (await loadSlashSkillCommandsRuntime()).listSkillCommandsForAgents({ cfg: startupCfg })
       : [];
     nativeCommands = slashCommandsRuntime.listNativeCommandSpecsForConfig(startupCfg, {
@@ -906,11 +911,12 @@ export async function registerSlackMonitorSlashCommands(params: {
       existingNativeNames.add(normalizedName);
       nativeCommands.push(pluginCommand);
     }
+    registration = nativeCommands.length > 0 ? { mode: "native" } : { mode: "disabled" };
   }
 
-  if (slashCommand.enabled) {
+  if (registration.mode === "single") {
     ctx.app.command(
-      buildSlackSlashCommandMatcher(slashCommand.name),
+      buildSlackSlashCommandMatcher(registration.name),
       async ({ command, ack, respond, body }: SlackCommandMiddlewareArgs) => {
         await handleSlashCommand({
           command,
@@ -921,7 +927,7 @@ export async function registerSlackMonitorSlashCommands(params: {
         });
       },
     );
-  } else if (nativeCommands.length > 0) {
+  } else if (registration.mode === "native") {
     if (!slashCommandsRuntime) {
       throw new Error("Missing commands runtime for native Slack commands.");
     }
@@ -960,14 +966,7 @@ export async function registerSlackMonitorSlashCommands(params: {
     logVerbose("slack: slash commands disabled");
   }
 
-  const registration: SlackCommandRegistration =
-    nativeCommands.length > 0
-      ? { mode: "native" }
-      : slashCommand.enabled
-        ? { mode: "single", name: slashCommand.name }
-        : { mode: "disabled" };
-
-  if (nativeCommands.length === 0 || !supportsInteractiveArgMenus) {
+  if (registration.mode !== "native" || !supportsInteractiveArgMenus) {
     return registration;
   }
 


### PR DESCRIPTION
## What Problem This Solves

When a Slack account enables both a configured single slash command and native commands, the actual configured slash-command handler is correctly registered, but the same owner incorrectly reports native mode and registers native argument/action listeners that no command owns. As a result, Slack App Home omits the configured command hint and orphan interactive listeners remain installed.

## Why This Change Was Made

Resolve the authoritative command-registration mode once at the Slack owner, then use that same decision for actual handler registration, returned App Home metadata, optional native-runtime loading, and native argument listeners. The currently shipped beta's existing configured-single-command precedence is preserved; inactive native runtimes no longer load.

## User Impact

Configured Slack slash commands appear correctly in App Home, use their actual custom command names, and no longer install unusable native argument handlers. Native-only commands, plugin/skill commands, account/global settings, disabled commands, and Bolt receiver binding preserve their existing behavior; no configuration or public API changes.

## Evidence

- Exact reviewed commit: `850f48b92d3a2797c8b33312b353ac3bcc8cbe42`; parent: `73535e4ede7eaa51cd4f97f4087657b05814e3d4`; exact two-file binary patch SHA-256: `705f3cb7fcf54b7fd540d0e8ef531df7348641521aec8e619739741fd250cbd7`.
- Authentic tests-first RED: the configured handler returned the wrong `native` mode and installed an orphan native interaction listener; the reviewed owner returns the actual configured `single` mode and registers zero orphan action/options handlers.
- **61/61 focused Slack slash-command and App Home sibling tests passed**; exact-file formatter, configured lint, maximum-line ratchet, and committed diff checks passed. Production code shrinks by one line.
- Direct inspection of installed `@slack/bolt@5.0.0` confirms command, action, and options handlers are independent listeners. Current `main` and shipped `v2026.7.2-beta.7` already register the configured single handler first; the earlier stable-to-beta precedence change is pre-existing and this patch does not change it.
- Four independently scoped hostile owner, SDK/lifecycle, release-history, and type/test reviews found no P0–P3 issues. Exactly one genuine `gpt-5.6-sol` high-reasoning/no-web autoreview was clean with confidence **0.98**; checksum-verified TruffleHog found no secrets.
- **Exact-head required CI openclaw/ci-gate: SUCCESS (850f48b92d3a).** The complete exact-head required GitHub Actions gate passed before this evidence update.
- **Actual Bolt 5.0.0 / Web API 8.0.0 wire verdict: PASS.** The maintainer independently reran the actual production command-registration owner and actual App Home event owner through a real installed Bolt `app.processEvent`, followed by a real installed Slack Web API HTTP `POST /api/views.publish` to a guarded loopback provider. Both global and account native commands were enabled alongside configured `/acme`. The production owner registered the real `/acme` listener, returned `{ "mode": "single", "name": "acme" }`, registered **zero** native action/options listeners, acknowledged the real Bolt event exactly once, and published the actual App Home wire payload containing `` `/acme` ``. The equivalent parent registered the same `/acme` command but incorrectly returned `native`, added one orphan action plus one orphan options listener, and published an App Home payload without `/acme`.
- **Installed Bolt source and shipped beta precedence directly verified.** Installed `@slack/bolt@5.0.0` `dist/App.js:332-362` and `dist/App.d.ts` show separately registered action/command/options listeners; `v2026.7.2-beta.7:extensions/slack/src/monitor/slash.ts` proves the configured single command already takes precedence over native command registration. The earlier reviewer could not access these sources, but they were personally verified against installed dependencies and the actual shipped tag.
- **Maintainer-authorized behavior-proof gate satisfied without live-tenant claims.** The captured diagnostic below is an actual production-owner / installed-Bolt / installed-Web-API / real-loopback-HTTP integration, not a mocked command-registration unit assertion; it uses no live Slack workspace, no user credentials, and no external network. Root `AGENTS.md` explicitly accepts channel-visible mock-provider harness verdict JSON when it covers the changed path. Production LOC delta: **-1**; there is no configuration, public SDK, authentication, or security-contract change.

```json
{
  "proof": "actual-bolt-and-web-api-loopback-provider-event",
  "exactHead": "850f48b92d3a2797c8b33312b353ac3bcc8cbe42",
  "packages": { "bolt": "5.0.0", "slackWebApi": "8.0.0" },
  "configuredCommand": "/acme",
  "accountNativeEnabled": true,
  "globalNativeEnabled": true,
  "parent": {
    "registration": "native",
    "nativeActionListeners": 1,
    "nativeOptionsListeners": 1,
    "appHomeContainsConfiguredCommand": false
  },
  "candidate": {
    "registration": { "mode": "single", "name": "acme" },
    "nativeActionListeners": 0,
    "nativeOptionsListeners": 0,
    "boltEventAcknowledgements": 1,
    "actualHttp": "POST /api/views.publish",
    "appHomeText": "Send a DM, mention OpenClaw in a channel, or use `/acme` to start a session."
  },
  "liveSlackWorkspace": false,
  "userCredentialsUsed": false,
  "externalNetworkUsed": false,
  "verdict": "PASS"
}
```
