### PR TITLE
fix: migrate redundant native Codex service tiers

### DIFF
--- a/src/agents/model-extra-params.ts
+++ b/src/agents/model-extra-params.ts
@@ -19,7 +19,7 @@ const FAST_MODE_CUTOFF_MODEL_PARAM_KEYS = new Set([
 
 // Native harnesses receive recognized values as typed run controls. Other value
 // shapes with the same keys remain authored provider request parameters.
-function isAgentRuntimeModelParam(key: string, value: unknown): boolean {
+export function isAgentRuntimeModelParam(key: string, value: unknown): boolean {
   if (key === "thinking") {
     return (
       value === false ||

--- a/src/commands/doctor/shared/codex-route-config-scan.ts
+++ b/src/commands/doctor/shared/codex-route-config-scan.ts
@@ -24,7 +24,7 @@ import {
 } from "./codex-route-model-slots.js";
 import type {
   CodexRouteHit,
-  DisabledCodexPluginRouteHit,
+  CodexRuntimeRouteHit,
   DisabledCodexPluginRouteIssue,
 } from "./codex-route-types.js";
 
@@ -216,10 +216,18 @@ export function collectConfigModelRefs(
 export function collectDisabledCodexPluginRouteHits(
   cfg: OpenClawConfig,
   env?: NodeJS.ProcessEnv,
-): DisabledCodexPluginRouteHit[] {
+): CodexRuntimeRouteHit[] {
   if (!isCodexPluginUnavailableByConfig(cfg)) {
     return [];
   }
+  return collectCodexRuntimeRouteHits(cfg, env);
+}
+
+/** Find effective configured model routes that select the Codex runtime. */
+export function collectCodexRuntimeRouteHits(
+  cfg: OpenClawConfig,
+  env?: NodeJS.ProcessEnv,
+): CodexRuntimeRouteHit[] {
   const defaults = cfg.agents?.defaults;
   const defaultRefs = collectAgentRuntimeModelRefs({
     agent: defaults,
@@ -280,7 +288,7 @@ export function collectDisabledCodexPluginRouteHits(
     }
   }
 
-  const hits: DisabledCodexPluginRouteHit[] = [];
+  const hits: CodexRuntimeRouteHit[] = [];
   const seen = new Set<string>();
   for (const ref of candidateRefs) {
     const canonicalModel = resolveRuntimeModelRef({
@@ -303,7 +311,12 @@ export function collectDisabledCodexPluginRouteHits(
       continue;
     }
     seen.add(key);
-    hits.push({ path: ref.path, modelRef: ref.modelRef, canonicalModel });
+    hits.push({
+      path: ref.path,
+      modelRef: ref.modelRef,
+      canonicalModel,
+      ...(ref.agentId ? { agentId: ref.agentId } : {}),
+    });
   }
   return hits;
 }
@@ -324,7 +337,7 @@ export function collectDisabledCodexPluginRouteIssues(
 
 export function enableCodexPluginForRequiredRoutes(params: {
   cfg: OpenClawConfig;
-  routeHits: DisabledCodexPluginRouteHit[];
+  routeHits: CodexRuntimeRouteHit[];
 }): { cfg: OpenClawConfig; changes: string[] } {
   // Explicit user opt-out wins over managed-harness repair; doctor warns instead.
   if (params.routeHits.length === 0 || codexPluginRepairIsBlocked(params.cfg)) {

--- a/src/commands/doctor/shared/codex-route-types.ts
+++ b/src/commands/doctor/shared/codex-route-types.ts
@@ -26,10 +26,11 @@ export type LegacyLosslessCompactionConfig = {
   modelValue?: string;
 };
 
-export type DisabledCodexPluginRouteHit = {
+export type CodexRuntimeRouteHit = {
   path: string;
   modelRef: string;
   canonicalModel: string;
+  agentId?: string;
 };
 
 export type DisabledCodexPluginRouteIssue = {

--- a/src/commands/doctor/shared/codex-route-warnings.test.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.test.ts
@@ -348,7 +348,7 @@ describe("collectCodexRouteWarnings", () => {
     expect(result.cfg.agents?.list?.[0]?.models?.["openai-codex/gpt-5.4"]).toBeUndefined();
   });
 
-  it("warns when Codex app-server command includes inline arguments", () => {
+  it("warns without executing a custom Codex app-server command", () => {
     const warnings = collectCodexRouteWarnings({
       plugins: {
         entries: {
@@ -371,7 +371,140 @@ describe("collectCodexRouteWarnings", () => {
         '- plugins.entries.codex.config.appServer.command: "node C:\\Users\\me\\.openclaw\\npm\\node_modules\\@openai\\codex\\bin\\codex.js" starts with "node" and embeds "C:\\Users\\me\\.openclaw\\npm\\node_modules\\@openai\\codex\\bin\\codex.js". The command field must be only the executable path.',
         "- Remove the override to use managed Codex startup, or move script/options to plugins.entries.codex.config.appServer.args.",
       ].join("\n"),
+      [
+        "- Custom Codex app-server command bypasses OpenClaw's managed exact-version binary.",
+        "- plugins.entries.codex.config.appServer.command: Doctor did not execute, inspect, or rewrite this command.",
+        "- Remove the override to use managed Codex startup, or verify the custom binary matches the Codex version bundled with this OpenClaw release.",
+      ].join("\n"),
     ]);
+  });
+
+  it("repairs only redundant native Codex service tiers and is idempotent", () => {
+    const command = "node -e process.exit(99)";
+    const original = {
+      plugins: { entries: { codex: { enabled: true, config: { appServer: { command } } } } },
+      agents: {
+        defaults: {
+          params: { temperature: 0.7 },
+          models: {
+            "openai/gpt-5.6-sol": {
+              params: { fastMode: true, serviceTier: "priority", temperature: 0.2 },
+              agentRuntime: { id: "codex" },
+            },
+            "openai/gpt-5.6-terra": {
+              params: { fast_mode: "on", service_tier: "PRIORITY" },
+              agentRuntime: { id: "codex" },
+            },
+          },
+        },
+      },
+    };
+
+    const repaired = maybeRepairCodexRoutes(original);
+
+    expect(repaired.changes).toStrictEqual([
+      "Removed redundant agents.defaults.models.openai/gpt-5.6-sol.params.serviceTier; fastMode already selects native priority.",
+      "Removed redundant agents.defaults.models.openai/gpt-5.6-terra.params.service_tier; fastMode already selects native priority.",
+    ]);
+    expect(repaired.cfg.agents?.defaults?.models).toEqual({
+      "openai/gpt-5.6-sol": {
+        params: { fastMode: true, temperature: 0.2 },
+        agentRuntime: { id: "codex" },
+      },
+      "openai/gpt-5.6-terra": {
+        params: { fast_mode: "on" },
+        agentRuntime: { id: "codex" },
+      },
+    });
+    expect(repaired.cfg.plugins?.entries?.codex?.config).toEqual({
+      appServer: { command },
+    });
+    expect(repaired.warnings.join("\n")).toContain(
+      "Custom Codex app-server command bypasses OpenClaw's managed exact-version binary.",
+    );
+    expect(repaired.warnings.join("\n")).toContain("agents.defaults.params.temperature");
+    expect(repaired.warnings.join("\n")).toContain(
+      "agents.defaults.models.openai/gpt-5.6-sol.params.temperature",
+    );
+    expect(original.agents.defaults.models["openai/gpt-5.6-sol"].params).toHaveProperty(
+      "serviceTier",
+    );
+
+    const second = maybeRepairCodexRoutes(repaired.cfg);
+    expect(second.cfg).toBe(repaired.cfg);
+    expect(second.changes).toStrictEqual([]);
+    expect(second.warnings).toStrictEqual(repaired.warnings);
+  });
+
+  it("preserves and reports authored params across effective Codex sources", () => {
+    const original = {
+      agents: {
+        defaults: {
+          model: "openai/gpt-5.6-sol",
+          params: { temperature: 0.7 },
+          models: {
+            "openai/gpt-5.6-sol": {
+              params: {
+                fastMode: true,
+                fast_mode: false,
+                serviceTier: "priority",
+                temperature: 0.2,
+              },
+              agentRuntime: { id: "codex" },
+            },
+            "openai/gpt-5.6-openclaw": {
+              params: { fastMode: true, serviceTier: "priority" },
+              agentRuntime: { id: "openclaw" },
+            },
+          },
+        },
+        entries: {
+          coder: { params: { topP: 0.8 } },
+          worker: {
+            models: {
+              "openai/gpt-5.6-sol": { agentRuntime: { id: "openclaw" } },
+            },
+          },
+        },
+      },
+    };
+
+    const result = maybeRepairCodexRoutes(original);
+
+    expect(result.cfg).toBe(original);
+    expect(result.changes).toStrictEqual([]);
+    expect(result.warnings.join("\n")).toContain(
+      "agents.defaults.models.openai/gpt-5.6-sol.params.serviceTier",
+    );
+    expect(result.warnings.join("\n")).toContain(
+      "agents.defaults.models.openai/gpt-5.6-sol.params.temperature",
+    );
+    expect(result.warnings.join("\n")).toContain("agents.defaults.params.temperature");
+    expect(result.warnings.join("\n")).toContain("agents.entries.coder.params.topP");
+    expect(result.warnings.join("\n")).not.toContain("gpt-5.6-openclaw.params.serviceTier");
+  });
+
+  it("canonicalizes and repairs a redundant legacy tier in one pass", () => {
+    const result = maybeRepairCodexRoutes({
+      agents: {
+        defaults: {
+          models: {
+            "openai-codex/gpt-5.6-sol": {
+              params: { fastMode: true, serviceTier: "priority" },
+              agentRuntime: { id: "codex" },
+            },
+          },
+        },
+      },
+    });
+
+    expect(result.cfg.agents?.defaults?.models?.["openai-codex/gpt-5.6-sol"]).toBeUndefined();
+    expect(result.cfg.agents?.defaults?.models?.["openai/gpt-5.6-sol"]?.params).toEqual({
+      fastMode: true,
+    });
+    expect(result.changes).toContain(
+      "Removed redundant agents.defaults.models.openai/gpt-5.6-sol.params.serviceTier; fastMode already selects native priority.",
+    );
   });
 
   it("warns when Codex runtime routes are configured while the Codex plugin is disabled", () => {

--- a/src/commands/doctor/shared/codex-route-warnings.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.ts
@@ -1,8 +1,17 @@
 // Doctor warnings and repairs for legacy OpenAI Codex model/provider routing.
 import { asOptionalRecord as asMutableRecord } from "@openclaw/normalization-core/record-coerce";
-import { normalizeOptionalLowercaseString as normalizeString } from "@openclaw/normalization-core/string-coerce";
+import {
+  normalizeFastMode,
+  normalizeOptionalLowercaseString as normalizeString,
+} from "@openclaw/normalization-core/string-coerce";
+import {
+  isAgentRuntimeModelParam,
+  resolveModelExtraParamSources,
+} from "../../../agents/model-extra-params.js";
+import { resolveModelRuntimePolicy } from "../../../agents/model-runtime-policy.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { detectWindowsSpawnCommandInlineArgs } from "../../../plugin-sdk/windows-spawn.js";
+import { listMutableCodexRouteAgentEntries } from "./codex-route-agent-entries.js";
 import {
   canAutoMigrateLegacyLosslessCompaction,
   collectLegacyLosslessCompactionConfigs,
@@ -18,15 +27,17 @@ import {
 } from "./codex-route-config-repair.js";
 import {
   codexPluginRepairIsBlocked,
+  collectCodexRuntimeRouteHits,
   collectConfigModelRefs,
   collectDisabledCodexPluginRouteHits,
   collectDisabledCodexPluginRouteIssues,
   enableCodexPluginForRequiredRoutes,
 } from "./codex-route-config-scan.js";
+import { parseModelRef } from "./codex-route-model-ref.js";
 import { maybeRepairCodexSessionRoutes } from "./codex-route-session-repair.js";
 import type {
   CodexRouteHit,
-  DisabledCodexPluginRouteHit,
+  CodexRuntimeRouteHit,
   LegacyLosslessCompactionConfig,
   UnsupportedCodexCompactionOverride,
 } from "./codex-route-types.js";
@@ -81,7 +92,7 @@ function formatLegacyLosslessCompactionWarning(params: {
 }
 
 function formatDisabledCodexPluginWarning(params: {
-  hits: DisabledCodexPluginRouteHit[];
+  hits: CodexRuntimeRouteHit[];
   repairBlocked: boolean;
 }): string {
   const fixHint = params.repairBlocked
@@ -103,21 +114,181 @@ function collectCodexAppServerCommandWarnings(cfg: OpenClawConfig): string[] {
   const codex = asMutableRecord(entries?.codex);
   const config = asMutableRecord(codex?.config);
   const appServer = asMutableRecord(config?.appServer);
-  const command = typeof appServer?.command === "string" ? appServer.command.trim() : "";
-  if (!command) {
+  if (typeof appServer?.command !== "string" || !appServer.command.trim()) {
     return [];
   }
+  const command = appServer.command.trim();
   const inlineArgs = detectWindowsSpawnCommandInlineArgs(command);
-  if (!inlineArgs) {
-    return [];
-  }
   return [
+    ...(inlineArgs
+      ? [
+          [
+            "- Codex app-server command override includes inline arguments.",
+            `- plugins.entries.codex.config.appServer.command: "${command}" starts with "${inlineArgs.executable}" and embeds "${inlineArgs.arguments}". The command field must be only the executable path.`,
+            "- Remove the override to use managed Codex startup, or move script/options to plugins.entries.codex.config.appServer.args.",
+          ].join("\n"),
+        ]
+      : []),
     [
-      "- Codex app-server command override includes inline arguments.",
-      `- plugins.entries.codex.config.appServer.command: "${command}" starts with "${inlineArgs.executable}" and embeds "${inlineArgs.arguments}". The command field must be only the executable path.`,
-      "- Remove the override to use managed Codex startup, or move script/options to plugins.entries.codex.config.appServer.args.",
+      "- Custom Codex app-server command bypasses OpenClaw's managed exact-version binary.",
+      "- plugins.entries.codex.config.appServer.command: Doctor did not execute, inspect, or rewrite this command.",
+      "- Remove the override to use managed Codex startup, or verify the custom binary matches the Codex version bundled with this OpenClaw release.",
     ].join("\n"),
   ];
+}
+
+const FAST_MODE_PARAM_KEYS = ["fastMode", "fast_mode"] as const;
+const SERVICE_TIER_PARAM_KEYS = ["serviceTier", "service_tier"] as const;
+
+type CodexModelParamHit = {
+  key: string;
+  modelRef: string;
+  path: string;
+  removable: boolean;
+};
+
+function ownValues(record: Record<string, unknown>, keys: readonly string[]): unknown[] {
+  return keys.filter((key) => Object.hasOwn(record, key)).map((key) => record[key]);
+}
+
+function modelUsesCodexForEveryAgent(cfg: OpenClawConfig, modelRef: string): boolean {
+  const parsed = parseModelRef(modelRef);
+  if (!parsed || parsed.modelId === "*") {
+    return false;
+  }
+  return listMutableCodexRouteAgentEntries(cfg).every(
+    ({ agentId }) =>
+      normalizeString(
+        resolveModelRuntimePolicy({
+          config: cfg,
+          provider: parsed.provider,
+          modelId: parsed.modelId,
+          agentId,
+        }).policy?.id,
+      ) === "codex",
+  );
+}
+
+function collectCodexModelParamHits(
+  cfg: OpenClawConfig,
+  env?: NodeJS.ProcessEnv,
+): CodexModelParamHit[] {
+  const hits: CodexModelParamHit[] = [];
+  const seen = new Set<string>();
+  const agentPaths = new Map(
+    listMutableCodexRouteAgentEntries(cfg).map(({ agentId, path }) => [agentId, path]),
+  );
+  for (const route of collectCodexRuntimeRouteHits(cfg, env)) {
+    const parsed = parseModelRef(route.canonicalModel);
+    if (!parsed || parsed.provider !== "openai") {
+      continue;
+    }
+    const sources = resolveModelExtraParamSources({
+      config: cfg,
+      provider: parsed.provider,
+      modelId: parsed.modelId,
+      agentId: route.agentId,
+    });
+    const modelParams = sources.modelParams;
+    const fastModes = ownValues(modelParams ?? {}, FAST_MODE_PARAM_KEYS);
+    const serviceTiers = ownValues(modelParams ?? {}, SERVICE_TIER_PARAM_KEYS);
+    const canRemoveServiceTier =
+      fastModes.length > 0 &&
+      fastModes.every((configured) => normalizeFastMode(configured) === true) &&
+      serviceTiers.length > 0 &&
+      serviceTiers.every((configured) => normalizeString(configured) === "priority") &&
+      modelUsesCodexForEveryAgent(cfg, route.canonicalModel);
+    const paramSources = [
+      { params: sources.defaultParams, path: "agents.defaults.params", modelScoped: false },
+      {
+        params: modelParams,
+        path: `agents.defaults.models.${route.canonicalModel}.params`,
+        modelScoped: true,
+      },
+      ...(route.agentId
+        ? [
+            {
+              params: sources.agentParams,
+              path: `${agentPaths.get(route.agentId) ?? `agents.entries.${route.agentId}`}.params`,
+              modelScoped: false,
+            },
+          ]
+        : []),
+    ];
+    for (const source of paramSources) {
+      for (const [key, paramValue] of Object.entries(source.params ?? {})) {
+        if (source.modelScoped && isAgentRuntimeModelParam(key, paramValue)) {
+          continue;
+        }
+        const path = `${source.path}.${key}`;
+        if (seen.has(path)) {
+          continue;
+        }
+        seen.add(path);
+        hits.push({
+          key,
+          path,
+          modelRef: route.canonicalModel,
+          removable:
+            source.modelScoped &&
+            canRemoveServiceTier &&
+            SERVICE_TIER_PARAM_KEYS.some((alias) => alias === key),
+        });
+      }
+    }
+  }
+  return hits;
+}
+
+function formatCodexModelParamWarning(hits: readonly CodexModelParamHit[]): string {
+  const fixHint = hits.some((hit) => hit.removable)
+    ? '- Run `openclaw doctor --fix` to remove only redundant priority service-tier params; remove any remaining params or set the affected route\'s agentRuntime.id to "openclaw".'
+    : '- Remove these params or set the affected route\'s agentRuntime.id to "openclaw"; Doctor cannot migrate them without changing behavior.';
+  return [
+    "- Explicit native Codex model routes cannot reproduce authored request transport parameters.",
+    ...hits.map(
+      (hit) =>
+        `- ${hit.path}: ${
+          hit.removable
+            ? "redundant because this model's fastMode already selects native priority service tier"
+            : `authored ${hit.key} cannot be migrated automatically`
+        }.`,
+    ),
+    fixHint,
+  ].join("\n");
+}
+
+function repairRedundantCodexServiceTiers(cfg: OpenClawConfig, env?: NodeJS.ProcessEnv) {
+  const removable = collectCodexModelParamHits(cfg, env).filter((hit) => hit.removable);
+  if (removable.length === 0) {
+    return { config: cfg, changes: [] };
+  }
+  const config = structuredClone(cfg);
+  const models = asMutableRecord(config.agents?.defaults?.models);
+  const changes: string[] = [];
+  for (const hit of removable) {
+    const params = asMutableRecord(asMutableRecord(models?.[hit.modelRef])?.params);
+    if (params) {
+      delete params[hit.key];
+      changes.push(
+        `Removed redundant agents.defaults.models.${hit.modelRef}.params.${hit.key}; fastMode already selects native priority.`,
+      );
+    }
+  }
+  return { config, changes };
+}
+
+/** Collect non-executing Codex runtime compatibility diagnostics for Doctor and lint. */
+export function collectCodexRuntimeCompatibilityWarnings(
+  cfg: OpenClawConfig,
+  env?: NodeJS.ProcessEnv,
+): string[] {
+  const warnings = collectCodexAppServerCommandWarnings(cfg);
+  const modelParamHits = collectCodexModelParamHits(cfg, env);
+  if (modelParamHits.length > 0) {
+    warnings.push(formatCodexModelParamWarning(modelParamHits));
+  }
+  return warnings;
 }
 
 function collectCodexComputerUseWarnings(cfg: OpenClawConfig): string[] {
@@ -208,7 +379,7 @@ export function collectCodexRouteWarnings(params: {
     });
   const warnings = [
     ...(blockedProviderPlan.warning ? [blockedProviderPlan.warning] : []),
-    ...collectCodexAppServerCommandWarnings(params.cfg),
+    ...collectCodexRuntimeCompatibilityWarnings(params.cfg, env),
     ...collectCodexComputerUseWarnings(params.cfg),
   ];
   if (hits.length > 0) {
@@ -309,14 +480,22 @@ export function maybeRepairCodexRoutes(params: {
     ignoreLegacyAgentRuntimePins,
     env,
   });
+  const hasRemovableServiceTier = collectCodexModelParamHits(params.cfg, env).some(
+    (hit) => hit.removable,
+  );
   if (
     hits.length === 0 &&
     disabledCodexPluginHits.length === 0 &&
     unsupportedCompactionOverrides.length === 0 &&
     legacyLosslessCompactionConfigs.length === 0 &&
+    !hasRemovableServiceTier &&
     !blockedProviderPlan.warning
   ) {
-    return { cfg: params.cfg, warnings: [], changes: [] };
+    return {
+      cfg: params.cfg,
+      warnings: collectCodexRouteWarnings({ cfg: params.cfg, env, blockedProviderPlan }),
+      changes: [],
+    };
   }
   if (!params.shouldRepair) {
     return {
@@ -334,9 +513,10 @@ export function maybeRepairCodexRoutes(params: {
     env,
     blockedModelIdentities,
   });
+  const serviceTierRepair = repairRedundantCodexServiceTiers(repaired.cfg, env);
   const codexPluginRepair = enableCodexPluginForRequiredRoutes({
-    cfg: repaired.cfg,
-    routeHits: collectDisabledCodexPluginRouteHits(repaired.cfg, env),
+    cfg: serviceTierRepair.config,
+    routeHits: collectDisabledCodexPluginRouteHits(serviceTierRepair.config, env),
   });
   const warnings = collectCodexRouteWarnings({
     cfg: codexPluginRepair.cfg,
@@ -360,6 +540,7 @@ export function maybeRepairCodexRoutes(params: {
       ...repaired.runtimePinChanges,
       ...repaired.unsupportedCompactionChanges,
       ...codexPluginRepair.changes,
+      ...serviceTierRepair.changes,
     ],
   };
 }

--- a/src/flows/doctor-core-checks.test.ts
+++ b/src/flows/doctor-core-checks.test.ts
@@ -628,38 +628,38 @@ describe("CORE_HEALTH_CHECKS", () => {
       createCoreHealthChecks(createDeps()),
       "core/doctor/codex-session-routes",
     );
-
+    const codex = {
+      enabled: false,
+      config: { appServer: { command: "node -e process.exit(99)" } },
+    };
     const findings = await check.detect({
       mode: "lint",
       runtime,
       cfg: {
-        plugins: {
-          entries: {
-            codex: { enabled: false },
-          },
-        },
+        plugins: { entries: { codex } },
         agents: {
           defaults: {
-            model: {
-              primary: "gpt-5.5",
-            },
+            model: "openai-codex/gpt-5.5",
+            params: { temperature: 0.7 },
           },
         },
       } as unknown as OpenClawConfig,
     });
-
-    expect(findings).toStrictEqual([
-      expect.objectContaining({
-        checkId: "core/doctor/codex-session-routes",
-        severity: "warning",
-        path: "agents.defaults.model.primary",
-        target: "openai/gpt-5.5",
-        requirement: "Codex plugin enabled for routes that use the Codex runtime.",
-        fixHint:
-          "Enable plugins.entries.codex and plugin loading, and remove codex from plugins.deny; or set the affected OpenAI models to an OpenClaw runtime policy.",
-      }),
-    ]);
-    expect(findings[0]?.message).toContain("Codex plugin is disabled by config");
+    expect(findings.map((finding) => finding.message)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("Codex plugin is disabled by config"),
+        "Codex app-server command override includes inline arguments.",
+        "Custom Codex app-server command bypasses OpenClaw's managed exact-version binary.",
+        "Explicit native Codex model routes cannot reproduce authored request transport parameters.",
+      ]),
+    );
+    expect(findings[0]).toMatchObject({
+      path: "agents.defaults.model",
+      target: "openai/gpt-5.5",
+      requirement: "Codex plugin enabled for routes that use the Codex runtime.",
+      fixHint:
+        "Enable plugins.entries.codex and plugin loading, and remove codex from plugins.deny; or set the affected OpenAI models to an OpenClaw runtime policy.",
+    });
   });
 
   it("uses the read-only model catalog for hooks.gmail.model checks", async () => {

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -28,7 +28,10 @@ import {
   uiProtocolFreshnessIssueToHealthFinding,
   uiProtocolFreshnessIssueToRepairEffects,
 } from "../commands/doctor-ui.js";
-import { collectDisabledCodexPluginRouteIssues } from "../commands/doctor/shared/codex-route-warnings.js";
+import {
+  collectCodexRuntimeCompatibilityWarnings,
+  collectDisabledCodexPluginRouteIssues,
+} from "../commands/doctor/shared/codex-route-warnings.js";
 import { isDefaultInstallIdentity } from "../config/paths.js";
 import type { ConfigValidationIssue, OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveSecretInputRef, type SecretRef } from "../config/types.secrets.js";
@@ -823,10 +826,10 @@ const legacyCronStoreCheck: SplitHealthCheckInput = {
 const codexSessionRoutesCheck: HealthCheck = {
   id: CODEX_SESSION_ROUTES_CHECK_ID,
   kind: "core",
-  description: "Codex runtime routes have a registered Codex plugin harness before sessions run.",
+  description: "Codex runtime routes are compatible with the configured plugin harness.",
   source: "doctor",
   async detect(ctx) {
-    return collectDisabledCodexPluginRouteIssues(ctx.cfg).map(
+    const disabledPluginFindings = collectDisabledCodexPluginRouteIssues(ctx.cfg, ctx.env).map(
       (issue): HealthFinding => ({
         checkId: CODEX_SESSION_ROUTES_CHECK_ID,
         severity: "warning",
@@ -848,6 +851,15 @@ const codexSessionRoutesCheck: HealthCheck = {
             ].join(" "),
       }),
     );
+    const compatibilityFindings = collectCodexRuntimeCompatibilityWarnings(ctx.cfg, ctx.env).map(
+      (text) =>
+        noteTextToFinding({
+          checkId: CODEX_SESSION_ROUTES_CHECK_ID,
+          severity: "warning",
+          text,
+        }),
+    );
+    return [...disabledPluginFindings, ...compatibilityFindings];
   },
 };
 


### PR DESCRIPTION
Closes #118528

## Problem

An explicit native Codex route rejects authored provider request parameters. The reported configuration set both `fastMode: true` and `serviceTier: "priority"`; those values select the same native Codex service tier, but the redundant authored `serviceTier` still marks the route incompatible.

The same upgrade retained a custom Codex `appServer.command`. That bypasses OpenClaw's managed exact-version binary, but Doctor previously gave no static warning before the first native turn attempted to start it.

## Fix

- `openclaw doctor --fix` removes only model-scoped `serviceTier` / `service_tier` values that are `priority` when the same effective `openai/*` route uses Codex, every authored fast-mode alias resolves to `true`, and no configured agent routes that model through OpenClaw.
- It preserves `fastMode` and every unrelated setting. Conflicting, non-priority, shared OpenClaw-route, and otherwise ambiguous values remain unchanged and produce an actionable warning.
- Doctor and `doctor --lint` inspect the same effective Codex routes and merged request-param sources (`agents.defaults.params`, per-model params, and flat per-agent params), so incompatible authored transport parameters are visible before a turn.
- A custom Codex `appServer.command` is warning-only. Doctor does not execute, inspect, or rewrite it; inline arguments retain the existing `appServer.args` guidance.

The repair remains in the existing core Codex Doctor owner. It adds no updater hook, config surface, plugin registry seam, SDK surface, or executable-probing path.

## Why the migration is lossless

OpenClaw already maps native Codex `fastMode: true` to `serviceTier: "priority"`. Removing the duplicate model-param tier therefore leaves the effective native request unchanged. Any state for which equivalence is not provable is preserved.

Direct dependency contract checks:

- Personally inspected sibling Codex `ee71c4a90f49ce52a8c8801681111e9b5a19d7aa` at `../codex/codex-rs/app-server-protocol/src/protocol/v2/thread.rs:56-73`, `turn.rs:122-133`, `core/src/session/mod.rs:843-870`, and `protocol/src/config_types.rs:471-499`.
- Matched that contract to the exact managed version pinned at `extensions/codex/src/app-server/version.ts:5`: Codex `rust-v0.146.0`, annotated-tag commit `e363b08c9175ac1cbe5893615dd2cb9ddf95043b`.
- The tagged protocol exposes nullable `serviceTier` on [`thread/start`](https://github.com/openai/codex/blob/rust-v0.146.0/codex-rs/app-server-protocol/src/protocol/v2/thread.rs#L56-L73) and [`turn/start`](https://github.com/openai/codex/blob/rust-v0.146.0/codex-rs/app-server-protocol/src/protocol/v2/turn.rs#L123-L133).
- The tagged runtime maps fast mode to `"priority"`, accepts `"fast"` and `"priority"` equivalently, and clears the tier when fast mode is disabled ([`config_types.rs:481-508`](https://github.com/openai/codex/blob/rust-v0.146.0/codex-rs/protocol/src/config_types.rs#L481-L508), [`session/mod.rs:871-883`](https://github.com/openai/codex/blob/rust-v0.146.0/codex-rs/core/src/session/mod.rs#L871-L883)).

The managed Codex version is intentionally not duplicated in core warning text: its constant is plugin-private, and creating a public SDK seam solely for diagnostics would enlarge the ownership surface. The warning instead points operators to the exact Codex version bundled with their OpenClaw release.

## Local operator-visible proof

All commands used an isolated config/state fixture. No real user config or state was modified.

- Installed `/opt/homebrew/bin/openclaw`: `OpenClaw 2026.7.2-beta.3 (d111bef)`.
- Installed Doctor left the redundant tier keys unchanged, reproducing the migration gap.
- Branch `pnpm openclaw doctor --fix --yes --non-interactive --no-workspace-suggestions` removed only both redundant tier aliases, preserved both fast-mode aliases, preserved the custom command, and did not create the command-execution sentinel.
- A second branch Doctor run left the config hash unchanged: `f1fb14e312d80b746008e927359d211a300734eedef60b158e1ae0fa42fa4242`; the sentinel remained absent.

Redacted config delta:

```diff
 "openai/gpt-5.6-sol": {
   "params": {
     "fastMode": true,
-    "serviceTier": "priority"
   },
   "agentRuntime": { "id": "codex" }
 }
 "openai/gpt-5.6-terra": {
   "params": {
     "fast_mode": "on",
-    "service_tier": "PRIORITY"
   },
   "agentRuntime": { "id": "codex" }
 }
 "plugins.entries.codex.config.appServer.command": "<redacted custom command, unchanged>"
```

## Validation

- `node scripts/run-vitest.mjs src/commands/doctor/shared/codex-route-warnings.test.ts src/flows/doctor-core-checks.test.ts` — 159 passed.
- Forced-local `node scripts/check-changed.mjs` — exit 0 across core/coreTests guards, typechecks, lint, and state/runtime checks.
- `node scripts/pre-commit/pnpm-audit-prod.mjs --audit-level=high` — no high-or-higher production advisories.
- `git diff --check origin/main...HEAD` — clean.
- Repository autoreview wrapper could not start because local TruffleHog is unavailable. Direct `codex review --base origin/main` completed with exit 0 and no actionable findings after reading the complete route/param/runtime paths and sibling Codex source.

## ClawSweeper rank-up moves

- Preserved the inline-command warning and explicit `appServer.args` remediation.
- Included redacted installed-CLI before/after, idempotency hash, and command non-execution proof in [this terminal transcript](https://github.com/openclaw/openclaw/pull/118738#issuecomment-5173154279).
- Inspected the sibling Codex protocol/runtime directly at the cited files and lines.

## Scope and Repair Doctrine closeout

- Root cause: redundant authored provider params make the forced native harness report request-transport overrides it cannot reproduce; custom commands bypass the managed exact-version binary without a pre-turn diagnostic.
- Architectural owner: existing core Codex Doctor route diagnostics and repair flow.
- Canonical fix: one effective-route scan feeds interactive Doctor, `doctor --fix`, and structured lint; only proven-redundant tier aliases migrate.
- Removed paths: no runtime fallback, dual-read, updater hook, executable probe, or new config surface.
- Sibling coverage: default/model/per-agent param sources, canonical and legacy Codex refs, per-agent OpenClaw overrides, alias spellings, conflicting values, custom-command inline args, and idempotency.
- Production: +232 / -25, net +207. The growth implements the upgrade migration, non-executing command safety diagnostic, and structured pre-turn lint contract.
- Tests: +156 / -23, net +133.
- Total: 7 files, one commit (`03b14400011`).
