### PR TITLE
fix(gateway): reject explicit empty attachments instead of silently dropping them

### DIFF
--- a/src/gateway/chat-attachments.test.ts
+++ b/src/gateway/chat-attachments.test.ts
@@ -44,6 +44,7 @@ import {
   stripImageMediaMarkers,
   UnsupportedAttachmentError,
 } from "./chat-attachments.js";
+import { normalizeRpcAttachmentsToChatAttachments } from "./server-methods/attachment-normalize.js";
 
 const PNG_1x1 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
@@ -419,6 +420,39 @@ describe("parseMessageWithAttachments validation errors", () => {
     expect((caught as UnsupportedAttachmentError).name).toBe("UnsupportedAttachmentError");
     expect((caught as UnsupportedAttachmentError).reason).toBe("empty-payload");
     expect(saveMediaBufferMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { name: "an empty string", attachment: { content: "" } },
+    { name: "an empty typed array", attachment: { content: new Uint8Array(0) } },
+    { name: "an empty array buffer", attachment: { content: new ArrayBuffer(0) } },
+    {
+      name: "an empty nested base64 source",
+      attachment: { source: { type: "base64", media_type: "application/pdf", data: "" } },
+    },
+    { name: "whitespace-only content", attachment: { content: "   " } },
+  ])("rejects normalized RPC attachments with $name", async ({ attachment }) => {
+    const normalized = normalizeRpcAttachmentsToChatAttachments([
+      {
+        type: "file",
+        mimeType: "application/pdf",
+        fileName: "empty.pdf",
+        ...attachment,
+      },
+    ]);
+
+    await expectUnsupportedAttachmentReason(normalized, {}, "empty-payload");
+  });
+
+  it("continues to omit RPC attachments without recognized content", () => {
+    expect(
+      normalizeRpcAttachmentsToChatAttachments([
+        { content: undefined },
+        { content: null },
+        { mimeType: "image/png" },
+        { source: { type: "base64", media_type: "application/pdf", data: null } },
+      ]),
+    ).toEqual([]);
   });
 
   it("throws UnsupportedAttachmentError on non-image when acceptNonImage is false", async () => {

--- a/src/gateway/server-methods/attachment-normalize.ts
+++ b/src/gateway/server-methods/attachment-normalize.ts
@@ -68,6 +68,6 @@ export function normalizeRpcAttachmentsToChatAttachments(
           ...(height !== undefined ? { height } : {}),
         };
       })
-      .filter((a) => a.content) ?? []
+      .filter((a) => a.content !== undefined) ?? []
   );
 }


### PR DESCRIPTION
## Summary

- Preserve explicitly supplied empty attachments until the existing canonical attachment parser can reject them visibly.
- Keep intentionally absent, undefined, and null attachment content omitted across all Gateway entrypoints.

## Root cause and canonical owner

The shared Gateway RPC attachment normalizer filtered attachments using content truthiness. Valid protocol envelopes may explicitly contain an empty string, zero-byte Uint8Array, zero-byte ArrayBuffer, or empty Anthropic base64 source; each disappeared before the real media parser could produce its existing `empty-payload` error. This affected chat.send, agent calls, session creation, and node ingress.

The existing owner now filters only genuinely absent content and retains recognized empty payloads for canonical validation. Production delta is zero (+1/-1). Existing session-creation semantics are intentionally preserved: the public protocol supports `runError`, the Control UI displays a rejected initial message, and an existing browser E2E verifies that the created thread remains visible and retryable.

## Proof

- Twelve genuine failing normalize→parse regressions across the three Gateway projects became green.
- **250 focused Gateway/attachment tests pass**, including all four empty representations, undefined/null omission, whitespace, valid media, chat.send, and sessions.create.
- Direct type-aware type-check lint, formatting, and whitespace validation pass.
- Installed TypeBox protocol contract inspected directly.
- Fresh independent structured Sol/high/P1 review: **no findings; confidence 0.90**. The reviewer independently verified the intentional sessions.create protocol/UI/E2E contract.
