### PR TITLE
fix(bedrock): preserve private embedding endpoints and AWS routing policy

### DIFF
--- a/extensions/amazon-bedrock/embedding-provider.test.ts
+++ b/extensions/amazon-bedrock/embedding-provider.test.ts
@@ -1,9 +1,11 @@
 // Amazon Bedrock tests cover embedding provider plugin behavior.
+import { BedrockRuntimeClient } from "@aws-sdk/client-bedrock-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createBedrockEmbeddingProvider, hasAwsCredentials } from "./embedding-provider.js";
 import { embeddingTesting as testing } from "./test-support.js";
 
 afterEach(() => {
+  vi.restoreAllMocks();
   vi.unstubAllEnvs();
 });
 
@@ -37,6 +39,146 @@ describe("bedrock embedding region resolution", () => {
     });
 
     expect(client.region).toBe(expected);
+  });
+});
+
+describe("bedrock embedding endpoint routing", () => {
+  it.each([
+    {
+      name: "memory PrivateLink endpoint ahead of the provider endpoint",
+      remoteBaseUrl: "https://vpce-memory.bedrock-runtime.eu-west-1.vpce.amazonaws.com",
+      providerBaseUrl: "https://vpce-provider.bedrock-runtime.us-east-1.vpce.amazonaws.com",
+      hostname: "vpce-memory.bedrock-runtime.eu-west-1.vpce.amazonaws.com",
+      signingRegion: "eu-west-1",
+      sdkEndpoint: "https://vpce-environment.bedrock-runtime.us-east-1.vpce.amazonaws.com",
+    },
+    {
+      name: "provider PrivateLink endpoint when memory has no override",
+      remoteBaseUrl: undefined,
+      providerBaseUrl: "https://vpce-provider.bedrock-runtime.us-east-1.vpce.amazonaws.com",
+      hostname: "vpce-provider.bedrock-runtime.us-east-1.vpce.amazonaws.com",
+      signingRegion: "us-east-1",
+    },
+    {
+      name: "SDK regional endpoint when no override is configured",
+      remoteBaseUrl: undefined,
+      providerBaseUrl: undefined,
+      hostname: "bedrock-runtime.us-east-1.amazonaws.com",
+      signingRegion: "us-east-1",
+    },
+    {
+      name: "SDK FIPS endpoint for a canonical regional provider URL",
+      remoteBaseUrl: undefined,
+      providerBaseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+      hostname: "bedrock-runtime-fips.us-east-1.amazonaws.com",
+      signingRegion: "us-east-1",
+      fips: true,
+      customEndpoint: false,
+    },
+    {
+      name: "SDK dual-stack endpoint for a canonical regional provider URL",
+      remoteBaseUrl: undefined,
+      providerBaseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+      hostname: "bedrock-runtime.us-east-1.api.aws",
+      signingRegion: "us-east-1",
+      dualstack: true,
+      customEndpoint: false,
+    },
+    {
+      name: "SDK PrivateLink override for a canonical regional provider URL",
+      remoteBaseUrl: undefined,
+      providerBaseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+      hostname: "vpce-environment.bedrock-runtime.us-east-1.vpce.amazonaws.com",
+      signingRegion: "us-east-1",
+      sdkEndpoint: "https://vpce-environment.bedrock-runtime.us-east-1.vpce.amazonaws.com",
+      customEndpoint: false,
+    },
+    {
+      name: "explicit PrivateLink endpoint that correctly rejects FIPS mode",
+      remoteBaseUrl: "https://vpce-memory.bedrock-runtime.us-east-1.vpce.amazonaws.com",
+      providerBaseUrl: undefined,
+      hostname: "vpce-memory.bedrock-runtime.us-east-1.vpce.amazonaws.com",
+      signingRegion: "us-east-1",
+      fips: true,
+      expectedError: "Invalid Configuration: FIPS and custom endpoint are not supported",
+    },
+  ])("sends signed requests to the $name", async (testCase) => {
+    const { remoteBaseUrl, providerBaseUrl, hostname, signingRegion } = testCase;
+    const sdkEndpoint = "sdkEndpoint" in testCase ? testCase.sdkEndpoint : undefined;
+    const fips = "fips" in testCase && testCase.fips;
+    const dualstack = "dualstack" in testCase && testCase.dualstack;
+    vi.stubEnv("AWS_REGION", "us-east-1");
+    vi.stubEnv("AWS_DEFAULT_REGION", undefined);
+    vi.stubEnv("AWS_PROFILE", undefined);
+    vi.stubEnv("AWS_ACCESS_KEY_ID", "BEDROCK_QA_FIXTURE_ACCESS");
+    vi.stubEnv("AWS_SECRET_ACCESS_KEY", "bedrock-qa-fixture-secret");
+    vi.stubEnv("AWS_SESSION_TOKEN", undefined);
+    vi.stubEnv("AWS_BEARER_TOKEN_BEDROCK", undefined);
+    vi.stubEnv("AWS_ENDPOINT_URL", undefined);
+    vi.stubEnv("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", sdkEndpoint);
+    vi.stubEnv("AWS_USE_FIPS_ENDPOINT", fips ? "true" : undefined);
+    vi.stubEnv("AWS_USE_DUALSTACK_ENDPOINT", dualstack ? "true" : undefined);
+
+    const observedRequests: Array<{ hostname: string; authorization: string | undefined }> = [];
+    const originalSend = BedrockRuntimeClient.prototype.send;
+    vi.spyOn(BedrockRuntimeClient.prototype, "send").mockImplementation(
+      function (command, options) {
+        this.config.requestHandler = {
+          handle: async (request) => {
+            observedRequests.push({
+              hostname: request.hostname,
+              authorization: request.headers.authorization,
+            });
+            return {
+              response: {
+                statusCode: 200,
+                headers: { "content-type": "application/json" },
+                body: Buffer.from(JSON.stringify({ embedding: [3, 4] })),
+              },
+            };
+          },
+          destroy() {},
+        };
+        return originalSend.call(this, command, options);
+      },
+    );
+
+    const { provider, client } = await createBedrockEmbeddingProvider({
+      config: providerBaseUrl
+        ? {
+            models: {
+              providers: {
+                "amazon-bedrock": { baseUrl: providerBaseUrl, models: [] },
+              },
+            },
+          }
+        : {},
+      ...(remoteBaseUrl ? { remote: { baseUrl: remoteBaseUrl } } : {}),
+      model: "amazon.titan-embed-text-v2:0",
+    });
+
+    if ("expectedError" in testCase) {
+      await expect(provider.embedQuery("private memory")).rejects.toThrow(testCase.expectedError);
+      expect(observedRequests).toEqual([]);
+      return;
+    }
+
+    await expect(provider.embedQuery("private memory")).resolves.toEqual([0.6, 0.8]);
+    expect(observedRequests).toEqual([
+      {
+        hostname,
+        authorization: expect.stringMatching(
+          /^AWS4-HMAC-SHA256 Credential=BEDROCK_QA_FIXTURE_ACCESS\//,
+        ),
+      },
+    ]);
+    expect(observedRequests[0]?.authorization).toContain(`/${signingRegion}/bedrock/aws4_request`);
+    expect(client.region).toBe(signingRegion);
+    if ("customEndpoint" in testCase ? testCase.customEndpoint : remoteBaseUrl || providerBaseUrl) {
+      expect(client).toHaveProperty("endpoint", remoteBaseUrl ?? providerBaseUrl);
+    } else {
+      expect(client).not.toHaveProperty("endpoint");
+    }
   });
 });
 

--- a/extensions/amazon-bedrock/embedding-provider.test.ts
+++ b/extensions/amazon-bedrock/embedding-provider.test.ts
@@ -1,10 +1,14 @@
 // Amazon Bedrock tests cover embedding provider plugin behavior.
-import { BedrockRuntimeClient } from "@aws-sdk/client-bedrock-runtime";
+import * as bedrockRuntimeSdk from "@aws-sdk/client-bedrock-runtime";
+import { NodeHttp2Handler } from "@smithy/node-http-handler";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createBedrockEmbeddingProvider, hasAwsCredentials } from "./embedding-provider.js";
 import { embeddingTesting as testing } from "./test-support.js";
 
+vi.mock("@aws-sdk/client-bedrock-runtime", { spy: true });
+
 afterEach(() => {
+  vi.mocked(bedrockRuntimeSdk.BedrockRuntimeClient).mockReset();
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
 });
@@ -85,6 +89,110 @@ describe("bedrock embedding endpoint routing", () => {
       customEndpoint: false,
     },
     {
+      name: "configured canonical FIPS endpoint in its own signing region",
+      remoteBaseUrl: undefined,
+      providerBaseUrl: "https://bedrock-runtime-fips.us-west-2.amazonaws.com",
+      hostname: "bedrock-runtime-fips.us-west-2.amazonaws.com",
+      signingRegion: "us-west-2",
+      customEndpoint: false,
+    },
+    {
+      name: "configured canonical FIPS endpoint with SDK FIPS mode",
+      remoteBaseUrl: undefined,
+      providerBaseUrl: "https://bedrock-runtime-fips.us-west-2.amazonaws.com",
+      hostname: "bedrock-runtime-fips.us-west-2.amazonaws.com",
+      signingRegion: "us-west-2",
+      fips: true,
+      customEndpoint: false,
+    },
+    {
+      name: "configured canonical dual-stack endpoint",
+      remoteBaseUrl: undefined,
+      providerBaseUrl: "https://bedrock-runtime.us-west-2.api.aws",
+      hostname: "bedrock-runtime.us-west-2.api.aws",
+      signingRegion: "us-west-2",
+      customEndpoint: false,
+    },
+    {
+      name: "configured canonical dual-stack endpoint with SDK dual-stack mode",
+      remoteBaseUrl: undefined,
+      providerBaseUrl: "https://bedrock-runtime.us-west-2.api.aws",
+      hostname: "bedrock-runtime.us-west-2.api.aws",
+      signingRegion: "us-west-2",
+      dualstack: true,
+      customEndpoint: false,
+    },
+    {
+      name: "configured canonical combined FIPS and dual-stack endpoint",
+      remoteBaseUrl: undefined,
+      providerBaseUrl: "https://bedrock-runtime-fips.us-west-2.api.aws",
+      hostname: "bedrock-runtime-fips.us-west-2.api.aws",
+      signingRegion: "us-west-2",
+      customEndpoint: false,
+    },
+    {
+      name: "configured canonical combined FIPS and dual-stack endpoint with SDK modes",
+      remoteBaseUrl: undefined,
+      providerBaseUrl: "https://bedrock-runtime-fips.us-west-2.api.aws",
+      hostname: "bedrock-runtime-fips.us-west-2.api.aws",
+      signingRegion: "us-west-2",
+      fips: true,
+      dualstack: true,
+      customEndpoint: false,
+    },
+    {
+      name: "configured FIPS endpoint upgraded by SDK dual-stack mode",
+      remoteBaseUrl: undefined,
+      providerBaseUrl: "https://bedrock-runtime-fips.us-west-2.amazonaws.com",
+      hostname: "bedrock-runtime-fips.us-west-2.api.aws",
+      signingRegion: "us-west-2",
+      dualstack: true,
+      customEndpoint: false,
+    },
+    {
+      name: "configured dual-stack endpoint upgraded by SDK FIPS mode",
+      remoteBaseUrl: undefined,
+      providerBaseUrl: "https://bedrock-runtime.us-west-2.api.aws",
+      hostname: "bedrock-runtime-fips.us-west-2.api.aws",
+      signingRegion: "us-west-2",
+      fips: true,
+      customEndpoint: false,
+    },
+    {
+      name: "configured GovCloud FIPS endpoint with partition-aware signing",
+      remoteBaseUrl: undefined,
+      providerBaseUrl: "https://bedrock-runtime-fips.us-gov-west-1.amazonaws.com",
+      hostname: "bedrock-runtime-fips.us-gov-west-1.amazonaws.com",
+      signingRegion: "us-gov-west-1",
+      customEndpoint: false,
+    },
+    {
+      name: "configured China FIPS dual-stack endpoint with its partition DNS suffix",
+      remoteBaseUrl: undefined,
+      providerBaseUrl: "https://bedrock-runtime-fips.cn-north-1.api.amazonwebservices.com.cn",
+      hostname: "bedrock-runtime-fips.cn-north-1.api.amazonwebservices.com.cn",
+      signingRegion: "cn-north-1",
+      customEndpoint: false,
+    },
+    {
+      name: "ISO PrivateLink endpoint when speculative security modes are unsupported",
+      remoteBaseUrl: "https://vpce-memory.bedrock-runtime.us-iso-east-1.c2s.ic.gov",
+      providerBaseUrl: undefined,
+      hostname: "vpce-memory.bedrock-runtime.us-iso-east-1.c2s.ic.gov",
+      signingRegion: "us-iso-east-1",
+      unsupportedPartitionModes: true,
+    },
+    {
+      name: "ISO regional endpoint that correctly rejects an explicitly requested unsupported mode",
+      remoteBaseUrl: undefined,
+      providerBaseUrl: "https://bedrock-runtime.us-iso-east-1.c2s.ic.gov",
+      hostname: "bedrock-runtime.us-iso-east-1.c2s.ic.gov",
+      signingRegion: "us-iso-east-1",
+      dualstack: true,
+      unsupportedPartitionModes: true,
+      expectedError: "DualStack is enabled but this partition does not support DualStack",
+    },
+    {
       name: "SDK PrivateLink override for a canonical regional provider URL",
       remoteBaseUrl: undefined,
       providerBaseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -101,6 +209,15 @@ describe("bedrock embedding endpoint routing", () => {
       signingRegion: "us-east-1",
       fips: true,
       expectedError: "Invalid Configuration: FIPS and custom endpoint are not supported",
+    },
+    {
+      name: "explicit PrivateLink endpoint that correctly rejects dual-stack mode",
+      remoteBaseUrl: "https://vpce-memory.bedrock-runtime.us-east-1.vpce.amazonaws.com",
+      providerBaseUrl: undefined,
+      hostname: "vpce-memory.bedrock-runtime.us-east-1.vpce.amazonaws.com",
+      signingRegion: "us-east-1",
+      dualstack: true,
+      expectedError: "Invalid Configuration: Dualstack and custom endpoint are not supported",
     },
   ])("sends signed requests to the $name", async (testCase) => {
     const { remoteBaseUrl, providerBaseUrl, hostname, signingRegion } = testCase;
@@ -119,29 +236,51 @@ describe("bedrock embedding endpoint routing", () => {
     vi.stubEnv("AWS_USE_FIPS_ENDPOINT", fips ? "true" : undefined);
     vi.stubEnv("AWS_USE_DUALSTACK_ENDPOINT", dualstack ? "true" : undefined);
 
-    const observedRequests: Array<{ hostname: string; authorization: string | undefined }> = [];
-    const originalSend = BedrockRuntimeClient.prototype.send;
-    vi.spyOn(BedrockRuntimeClient.prototype, "send").mockImplementation(
-      function (command, options) {
-        this.config.requestHandler = {
-          handle: async (request) => {
-            observedRequests.push({
-              hostname: request.hostname,
-              authorization: request.headers.authorization,
+    if ("unsupportedPartitionModes" in testCase) {
+      const { BedrockRuntimeClient: ActualBedrockRuntimeClient } = await vi.importActual<
+        typeof import("@aws-sdk/client-bedrock-runtime")
+      >("@aws-sdk/client-bedrock-runtime");
+      vi.mocked(bedrockRuntimeSdk.BedrockRuntimeClient).mockImplementation(
+        class extends ActualBedrockRuntimeClient {
+          constructor(...args: ConstructorParameters<typeof ActualBedrockRuntimeClient>) {
+            super(...args);
+            const endpointProvider = this.config.endpointProvider.bind(this.config);
+            vi.spyOn(this.config, "endpointProvider").mockImplementation((parameters, context) => {
+              if (
+                parameters.Region === "us-iso-east-1" &&
+                !parameters.Endpoint &&
+                (parameters.UseFIPS || parameters.UseDualStack)
+              ) {
+                const unsupportedMode = parameters.UseFIPS ? "FIPS" : "DualStack";
+                throw new Error(
+                  `${unsupportedMode} is enabled but this partition does not support ${unsupportedMode}`,
+                );
+              }
+              return endpointProvider(parameters, context);
             });
-            return {
-              response: {
-                statusCode: 200,
-                headers: { "content-type": "application/json" },
-                body: Buffer.from(JSON.stringify({ embedding: [3, 4] })),
-              },
-            };
+          }
+        },
+      );
+    }
+
+    const observedRequests: Array<{ hostname: string; authorization: string | undefined }> = [];
+    vi.spyOn(NodeHttp2Handler, "create").mockImplementation(() => {
+      const requestHandler = new NodeHttp2Handler();
+      vi.spyOn(requestHandler, "handle").mockImplementation(async (request) => {
+        observedRequests.push({
+          hostname: request.hostname,
+          authorization: request.headers.authorization,
+        });
+        return {
+          response: {
+            statusCode: 200,
+            headers: { "content-type": "application/json" },
+            body: Buffer.from(JSON.stringify({ embedding: [3, 4] })),
           },
-          destroy() {},
         };
-        return originalSend.call(this, command, options);
-      },
-    );
+      });
+      return requestHandler;
+    });
 
     const { provider, client } = await createBedrockEmbeddingProvider({
       config: providerBaseUrl

--- a/extensions/amazon-bedrock/embedding-provider.ts
+++ b/extensions/amazon-bedrock/embedding-provider.ts
@@ -23,6 +23,7 @@ type BedrockEmbeddingClient = {
   region: string;
   model: string;
   dimensions?: number;
+  endpoint?: string;
 };
 
 /** Default Bedrock embedding model used when no explicit model is configured. */
@@ -306,8 +307,8 @@ if (process.env.VITEST === "true") {
 export async function createBedrockEmbeddingProvider(
   options: MemoryEmbeddingProviderCreateOptions,
 ): Promise<{ provider: MemoryEmbeddingProvider; client: BedrockEmbeddingClient }> {
-  const client = resolveBedrockEmbeddingClient(options);
   const { BedrockRuntimeClient, InvokeModelCommand } = await loadSdk();
+  const client = resolveBedrockEmbeddingClient(options, BedrockRuntimeClient);
   const spec = resolveSpec(client.model);
   const family = spec?.family ?? inferFamily(client.model);
 
@@ -320,7 +321,7 @@ export async function createBedrockEmbeddingProvider(
 
   const invoke = async (body: string, signal?: AbortSignal): Promise<string> => {
     await refreshAwsSharedConfigCacheForBedrock();
-    const sdk = new BedrockRuntimeClient({ region: client.region });
+    const sdk = new BedrockRuntimeClient({ region: client.region, endpoint: client.endpoint });
     try {
       const res = await sdk.send(
         new InvokeModelCommand({
@@ -399,10 +400,14 @@ export async function createBedrockEmbeddingProvider(
 
 function resolveBedrockEmbeddingClient(
   options: MemoryEmbeddingProviderCreateOptions,
+  BedrockRuntimeClient: AwsSdk["BedrockRuntimeClient"],
 ): BedrockEmbeddingClient {
   const model = normalizeBedrockEmbeddingModel(options.model);
   const spec = resolveSpec(model);
   const providerConfig = options.config.models?.providers?.["amazon-bedrock"];
+  let endpoint =
+    normalizeOptionalString(options.remote?.baseUrl) ??
+    normalizeOptionalString(providerConfig?.baseUrl);
 
   const region =
     regionFromUrl(options.remote?.baseUrl) ??
@@ -410,6 +415,18 @@ function resolveBedrockEmbeddingClient(
     normalizeOptionalString(process.env.AWS_REGION) ??
     normalizeOptionalString(process.env.AWS_DEFAULT_REGION) ??
     "us-east-1";
+
+  if (endpoint) {
+    const sdk = new BedrockRuntimeClient({ region });
+    try {
+      const endpointModes = { Region: region, UseFIPS: false, UseDualStack: false };
+      const regionalEndpoint = sdk.config.endpointProvider(endpointModes).url.href;
+      // Pinning regional metadata would defeat SDK-owned FIPS and private endpoint overrides.
+      endpoint = new URL(endpoint).href === regionalEndpoint ? undefined : endpoint;
+    } finally {
+      sdk.destroy();
+    }
+  }
 
   let dimensions: number | undefined;
   if (options.outputDimensionality != null) {
@@ -423,7 +440,7 @@ function resolveBedrockEmbeddingClient(
     dimensions = spec?.dims;
   }
 
-  return { region, model, dimensions };
+  return { region, model, dimensions, ...(endpoint ? { endpoint } : {}) };
 }
 
 // ---------------------------------------------------------------------------

--- a/extensions/amazon-bedrock/embedding-provider.ts
+++ b/extensions/amazon-bedrock/embedding-provider.ts
@@ -24,6 +24,8 @@ type BedrockEmbeddingClient = {
   model: string;
   dimensions?: number;
   endpoint?: string;
+  useFipsEndpoint?: true;
+  useDualstackEndpoint?: true;
 };
 
 /** Default Bedrock embedding model used when no explicit model is configured. */
@@ -150,7 +152,7 @@ function loadDefaultCredentialProvider(): Promise<AwsCredentialProvider | null> 
 // ---------------------------------------------------------------------------
 
 const MODEL_PREFIX_RE = /^(?:bedrock|amazon-bedrock|aws)\//;
-const REGION_RE = /bedrock-runtime\.([a-z0-9-]+)\./;
+const REGION_RE = /bedrock-runtime(?:-fips)?\.([a-z0-9-]+)\./;
 
 function normalizeBedrockEmbeddingModel(model: string): string {
   const trimmed = model.trim();
@@ -321,7 +323,12 @@ export async function createBedrockEmbeddingProvider(
 
   const invoke = async (body: string, signal?: AbortSignal): Promise<string> => {
     await refreshAwsSharedConfigCacheForBedrock();
-    const sdk = new BedrockRuntimeClient({ region: client.region, endpoint: client.endpoint });
+    const sdk = new BedrockRuntimeClient({
+      region: client.region,
+      endpoint: client.endpoint,
+      useFipsEndpoint: client.useFipsEndpoint,
+      useDualstackEndpoint: client.useDualstackEndpoint,
+    });
     try {
       const res = await sdk.send(
         new InvokeModelCommand({
@@ -408,6 +415,8 @@ function resolveBedrockEmbeddingClient(
   let endpoint =
     normalizeOptionalString(options.remote?.baseUrl) ??
     normalizeOptionalString(providerConfig?.baseUrl);
+  let useFipsEndpoint: true | undefined;
+  let useDualstackEndpoint: true | undefined;
 
   const region =
     regionFromUrl(options.remote?.baseUrl) ??
@@ -419,10 +428,28 @@ function resolveBedrockEmbeddingClient(
   if (endpoint) {
     const sdk = new BedrockRuntimeClient({ region });
     try {
-      const endpointModes = { Region: region, UseFIPS: false, UseDualStack: false };
-      const regionalEndpoint = sdk.config.endpointProvider(endpointModes).url.href;
-      // Pinning regional metadata would defeat SDK-owned FIPS and private endpoint overrides.
-      endpoint = new URL(endpoint).href === regionalEndpoint ? undefined : endpoint;
+      const normalizedEndpoint = new URL(endpoint).href;
+      for (const fips of [false, true]) {
+        for (const dualstack of [false, true]) {
+          const endpointModes = { Region: region, UseFIPS: fips, UseDualStack: dualstack };
+          try {
+            if (sdk.config.endpointProvider(endpointModes).url.href !== normalizedEndpoint) {
+              continue;
+            }
+          } catch {
+            // Unsupported hypothetical modes must not reject a valid custom endpoint.
+            continue;
+          }
+          // SDK-owned endpoints must retain their security modes and environment overrides.
+          endpoint = undefined;
+          useFipsEndpoint = fips || undefined;
+          useDualstackEndpoint = dualstack || undefined;
+          break;
+        }
+        if (!endpoint) {
+          break;
+        }
+      }
     } finally {
       sdk.destroy();
     }
@@ -440,7 +467,14 @@ function resolveBedrockEmbeddingClient(
     dimensions = spec?.dims;
   }
 
-  return { region, model, dimensions, ...(endpoint ? { endpoint } : {}) };
+  return {
+    region,
+    model,
+    dimensions,
+    ...(endpoint ? { endpoint } : {}),
+    ...(useFipsEndpoint ? { useFipsEndpoint } : {}),
+    ...(useDualstackEndpoint ? { useDualstackEndpoint } : {}),
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/extensions/amazon-bedrock/memory-embedding-adapter.test.ts
+++ b/extensions/amazon-bedrock/memory-embedding-adapter.test.ts
@@ -23,7 +23,12 @@ function defaultCreateOptions() {
   };
 }
 
-function stubCreate(client: { region: string; model: string; dimensions?: number }) {
+function stubCreate(client: {
+  region: string;
+  model: string;
+  dimensions?: number;
+  endpoint?: string;
+}) {
   createBedrockEmbeddingProviderMock.mockResolvedValue({
     provider: {
       id: "bedrock",
@@ -43,6 +48,7 @@ describe("bedrockMemoryEmbeddingProviderAdapter", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
   });
 
   afterAll(() => {
@@ -88,6 +94,64 @@ describe("bedrockMemoryEmbeddingProviderAdapter", () => {
       },
     });
     expect(createBedrockEmbeddingProviderMock).toHaveBeenCalledOnce();
+  });
+
+  it("invalidates cached embeddings when the configured PrivateLink endpoint changes", async () => {
+    hasAwsCredentialsMock.mockResolvedValue(true);
+    const firstEndpoint = "https://vpce-first.bedrock-runtime.us-east-1.vpce.amazonaws.com";
+    const secondEndpoint = "https://vpce-second.bedrock-runtime.us-east-1.vpce.amazonaws.com";
+
+    stubCreate({
+      region: "us-east-1",
+      model: "amazon.titan-embed-text-v2:0",
+      dimensions: 1024,
+      endpoint: firstEndpoint,
+    });
+    const first = await bedrockMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
+
+    stubCreate({
+      region: "us-east-1",
+      model: "amazon.titan-embed-text-v2:0",
+      dimensions: 1024,
+      endpoint: secondEndpoint,
+    });
+    const second = await bedrockMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
+
+    expect(first.runtime?.cacheKeyData).toMatchObject({ endpoint: firstEndpoint });
+    expect(second.runtime?.cacheKeyData).toMatchObject({ endpoint: secondEndpoint });
+    expect(first.runtime?.cacheKeyData).not.toEqual(second.runtime?.cacheKeyData);
+  });
+
+  it("preserves existing cache identity for canonical AWS regional provider URLs", async () => {
+    hasAwsCredentialsMock.mockResolvedValue(true);
+    const actual =
+      await vi.importActual<typeof import("./embedding-provider.js")>("./embedding-provider.js");
+    createBedrockEmbeddingProviderMock.mockImplementation(actual.createBedrockEmbeddingProvider);
+    vi.stubEnv("AWS_REGION", "us-east-1");
+    vi.stubEnv("AWS_DEFAULT_REGION", undefined);
+    vi.stubEnv("AWS_ENDPOINT_URL", undefined);
+    vi.stubEnv("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", undefined);
+
+    const result = await bedrockMemoryEmbeddingProviderAdapter.create({
+      ...defaultCreateOptions(),
+      config: {
+        models: {
+          providers: {
+            "amazon-bedrock": {
+              baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+              models: [],
+            },
+          },
+        },
+      },
+    });
+
+    expect(result.runtime?.cacheKeyData).toEqual({
+      provider: "bedrock",
+      region: "us-east-1",
+      model: "amazon.titan-embed-text-v2:0",
+      dimensions: 1024,
+    });
   });
 
   it("lets the auto-select loop skip bedrock when credentials are unavailable", async () => {

--- a/extensions/amazon-bedrock/memory-embedding-adapter.ts
+++ b/extensions/amazon-bedrock/memory-embedding-adapter.ts
@@ -45,6 +45,7 @@ export const bedrockMemoryEmbeddingProviderAdapter: MemoryEmbeddingProviderAdapt
           region: client.region,
           model: client.model,
           dimensions: client.dimensions,
+          ...(client.endpoint ? { endpoint: client.endpoint } : {}),
         },
       },
     };


### PR DESCRIPTION
## Summary

- Route Bedrock embeddings to explicitly configured PrivateLink/custom endpoints instead of silently sending private memory to public AWS.
- Keep ordinary AWS regional endpoints under official SDK ownership, preserving FIPS, dualstack, and service-specific environment endpoint overrides.
- Include genuine custom endpoints in embedding cache identity without changing the historic default identity.

## Root cause and canonical owner

The Bedrock embedding owner used configured endpoint URLs only to infer the region, then constructed the official BedrockRuntimeClient with region alone. Private/custom endpoint intent was discarded. Conversely, blindly forwarding every configured URL as an SDK custom endpoint overrides service-specific PrivateLink environment routing and makes legitimate FIPS/dualstack regional configuration fail.

The canonical owner compares configured URLs against the official AWS SDK's own partition-aware regional endpoint provider. Genuine custom/PrivateLink URLs are forwarded; normal canonical regional URLs remain SDK-managed. The existing memory embedding adapter includes only genuine custom endpoints in cache identity. Explicit custom endpoint plus explicit FIPS/dualstack continues to fail closed exactly as required by the AWS SDK; no security mode is disabled.

## Actual official SDK proof

- Three original genuine destination/cache failures and four subsequent FIPS/dualstack/PrivateLink-override regressions were reproduced before repair.
- **37 focused tests pass** using the real installed AWS Bedrock SDK, synthetic credentials, actual SigV4 signing, and an official in-memory request handler; **zero AWS calls/network requests**.
- Actual signed request targets verify remote PrivateLink > configured provider endpoint > SDK regional defaults, canonical regional URLs preserve FIPS/dualstack, `AWS_ENDPOINT_URL_BEDROCK_RUNTIME` remains authoritative, correct eu-west signing region, and custom cache identity changes while default identity remains stable.
- Installed SDK endpoint rules and current shipped Bedrock stream sibling inspected directly.
- Fresh independent structured Sol/high/P1 security review: **no findings; confidence 0.89**.
- Production **+18 lines** across the two existing Bedrock embedding owners.

### Maintainer disposition: installed AWS SDK signed transport proof

50 focused owner regressions pass against the actual installed AWS SDK 3.1095 endpoint resolver and actual SigV4-signed in-memory transport. Coverage includes custom/PrivateLink endpoint routing and signing, standard commercial/GovCloud/China partitions, FIPS, dual-stack, and fail-closed handling of unsupported requested endpoint security modes. Direct installed dependency source/types and canonical provider owner were inspected. This demonstrates actual endpoint resolution and signed HTTP request generation without external AWS credentials; live PrivateLink/AWS calls are intentionally unavailable and the additional live capture is optional, not a correctness finding.