### PR TITLE
fix(media): preserve bare relative attachments alongside reply captions

### DIFF
--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -36,6 +36,7 @@ describe("splitMediaFromOutput", () => {
 
   function expectAcceptedMediaPathCase(expectedPath: string, input: string) {
     expectParsedMediaOutputCase(input, { mediaUrls: [expectedPath] });
+    expect(splitMediaFromOutput(input).segments).toEqual([{ type: "media", url: expectedPath }]);
   }
 
   function expectRejectedMediaPathCase(input: string) {
@@ -94,6 +95,47 @@ describe("splitMediaFromOutput", () => {
   ] as const)("accepts supported media path variant: %s", (expectedPath, input) => {
     expectAcceptedMediaPathCase(expectedPath, input);
   });
+
+  it.each([
+    ["bare image", "Generated image\nMEDIA:image.png", ["image.png"]],
+    ["bare audio", "Generated audio\nMEDIA:voice.ogg", ["voice.ogg"]],
+    ["bare document", "Generated document\nMEDIA:report.pdf", ["report.pdf"]],
+    ["caption after bare filename", "MEDIA:image.png\nGenerated image", ["image.png"]],
+    ["quoted bare filename", 'Generated image\nMEDIA:"image.png"', ["image.png"]],
+    [
+      "quoted bare filename with spaces",
+      'Generated image\nMEDIA:"render final.png"',
+      ["render final.png"],
+    ],
+    ["unquoted bare filename with spaces", "MEDIA:render final.png", ["render final.png"]],
+    [
+      "remote followed by bare filename",
+      "MEDIA:https://example.com/remote.png\nMEDIA:image.png",
+      ["https://example.com/remote.png", "image.png"],
+    ],
+    [
+      "bare filenames surrounding remote media",
+      "MEDIA:image.png\nMEDIA:https://example.com/remote.png\nMEDIA:voice.ogg",
+      ["image.png", "https://example.com/remote.png", "voice.ogg"],
+    ],
+    ["explicit relative sibling", "MEDIA:./image.png", ["./image.png"]],
+    ["absolute sibling", "MEDIA:/tmp/image.png", ["/tmp/image.png"]],
+    [
+      "multiple paths on one directive",
+      "MEDIA:/tmp/image.png /tmp/voice.ogg",
+      ["/tmp/image.png", "/tmp/voice.ogg"],
+    ],
+  ] as const)(
+    "projects every accepted media URL into ordered segments: %s",
+    (_name, input, urls) => {
+      const result = splitMediaFromOutput(input);
+
+      expect(result.mediaUrls).toEqual(urls);
+      expect(result.segments?.filter((segment) => segment.type === "media")).toEqual(
+        urls.map((url) => ({ type: "media", url })),
+      );
+    },
+  );
 
   it.each([
     ["MEDIA:/tmp/a.png /tmp/b.png", ["/tmp/a.png", "/tmp/b.png"]],

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -647,7 +647,6 @@ export function splitMediaFromOutput(
           media.splice(mediaStartIndex, media.length - mediaStartIndex, fallback);
           hasValidMedia = true;
           foundMediaToken = true;
-          validCount = 1;
           invalidParts.length = 0;
         }
       }
@@ -658,7 +657,6 @@ export function splitMediaFromOutput(
           media.splice(mediaStartIndex, media.length - mediaStartIndex, spacedFallback);
           hasValidMedia = true;
           foundMediaToken = true;
-          validCount = 1;
           invalidParts.length = 0;
         }
       }
@@ -679,7 +677,7 @@ export function splitMediaFromOutput(
           lineSegments.push({ type: "text", text: beforeText });
         }
         pieces.length = 0;
-        for (const url of media.slice(mediaStartIndex, mediaStartIndex + validCount)) {
+        for (const url of media.slice(mediaStartIndex)) {
           lineSegments.push({ type: "media", url });
         }
         if (invalidParts.length > 0) {

--- a/ui/src/lib/chat/message-normalizer.test.ts
+++ b/ui/src/lib/chat/message-normalizer.test.ts
@@ -650,6 +650,65 @@ describe("message-normalizer", () => {
       expect(result.content).toEqual([{ type: "text", text: "MEDIA:chart.png" }]);
     });
 
+    it.each([
+      ["bare image", "Generated image\nMEDIA:image.png", "Generated image\nMEDIA:image.png"],
+      ["bare audio", "Generated audio\nMEDIA:voice.ogg", "Generated audio\nMEDIA:voice.ogg"],
+      [
+        "bare document",
+        "Generated document\nMEDIA:report.pdf",
+        "Generated document\nMEDIA:report.pdf",
+      ],
+      [
+        "caption after bare filename",
+        "MEDIA:image.png\nGenerated image",
+        "MEDIA:image.png\nGenerated image",
+      ],
+      [
+        "quoted bare filename",
+        'Generated image\nMEDIA:"image.png"',
+        "Generated image\nMEDIA:image.png",
+      ],
+      [
+        "quoted bare filename with spaces",
+        'Generated image\nMEDIA:"render final.png"',
+        "Generated image\nMEDIA:render final.png",
+      ],
+      [
+        "explicit relative sibling",
+        "Generated image\nMEDIA:./image.png",
+        "Generated image\nMEDIA:./image.png",
+      ],
+    ] as const)(
+      "preserves relative assistant media beside its caption: %s",
+      (_name, input, text) => {
+        expect(normalizeMessage({ role: "assistant", content: input }).content).toEqual([
+          { type: "text", text },
+        ]);
+      },
+    );
+
+    it("preserves bare assistant media references around a renderable attachment", () => {
+      expect(
+        normalizeMessage({
+          role: "assistant",
+          content:
+            "Generated artifacts\nMEDIA:image.png\nMEDIA:https://example.com/remote.png\nMEDIA:voice.ogg",
+        }).content,
+      ).toEqual([
+        { type: "text", text: "Generated artifacts\nMEDIA:image.png" },
+        {
+          type: "attachment",
+          attachment: {
+            url: "https://example.com/remote.png",
+            kind: "image",
+            label: "remote.png",
+            mimeType: "image/png",
+          },
+        },
+        { type: "text", text: "MEDIA:voice.ogg" },
+      ]);
+    });
+
     it("strips reply_to_current without rendering a quoted preview", () => {
       const result = normalizeMessage({
         role: "assistant",


### PR DESCRIPTION
## Summary

- Prevent generated bare relative image/audio/document paths from disappearing when a response also contains text.
- Derive ordered reply segments directly from the media actually accepted by their canonical parser owner.

## Root cause

The media parser accepted bare MEDIA:image.png, voice.ogg, and report.pdf into mediaUrls, but its fallback path did not increment a separate validCount bookkeeping field. Ordered segments therefore omitted the accepted item. The Control UI trusts ordered segments when a caption exists, silently losing the artifact; captionless fallback behavior concealed the regression.

The owner now derives the current directive's ordered suffix from its authoritative captured mediaStartIndex, and removes two obsolete bookkeeping assignments. Existing allowlisted paths, traversal rejection, quoted/spaced names, multiple directives, captions, and validCount's separate spaced-path policy remain unchanged. **Production delta: -2 lines.**

## Proof

- Nine actual parser failures plus seven UI caption/attachment failures reproduced before repair.
- **181 focused tests pass**: full parser 108/108 and Control UI normalizer 73/73, plus 42 parser-to-UI combinations.
- Type-aware type-check lint, formatting, and whitespace checks pass.
- Fresh independent structured Sol/high/P1 review: **no findings; confidence 0.91**.
