### PR TITLE
fix(google): bound realtime PCM sample rate to prevent OOM resample

### DIFF
--- a/extensions/google/realtime-voice-provider.test.ts
+++ b/extensions/google/realtime-voice-provider.test.ts
@@ -1840,7 +1840,7 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
       onClearAudio: vi.fn(),
     });
     // 20ms of PCM16 @ 24 kHz = 480 bytes. On main with rate=1, this would
-    // allocate ~9.6 MB (8000/1 * 240 samples * 2 bytes) before mulaw conversion.
+    // allocate ~3.84 MB (8000/1 * 240 samples * 2 bytes) before mulaw conversion.
     const pcm24k = Buffer.alloc(480);
 
     await bridge.connect();
@@ -1857,7 +1857,7 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
     const output = requireFirstAudio(onAudio);
     // G711 ULAW output is 8 kHz mulaw (1 byte/sample). With normalized 24 kHz
     // input, resamplePcm downsamples 240 samples → 80 samples → 80 bytes mulaw.
-    // On main with rate=1, output would be ~9.6 MB — the fix bounds it to ≤ 80.
+    // On main with rate=1, output would be ~3.84 MB — the fix bounds it to ≤ 80.
     expect(output.length).toBeLessThanOrEqual(pcm24k.length);
     expect(output.length).toBeGreaterThan(0);
   });

--- a/extensions/google/realtime-voice-provider.test.ts
+++ b/extensions/google/realtime-voice-provider.test.ts
@@ -1788,7 +1788,8 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
     ["below telephony floor", "audio/L16;codec=pcm;rate=1"],
     ["above capture ceiling", "audio/pcm;rate=999999999"],
     ["non-numeric rate", "audio/pcm;rate=wideband"],
-  ])("falls back to 24 kHz for %s sample rate to avoid OOM resample", async (_label, mimeType) => {
+    ["in-range unsupported", "audio/pcm;rate=4000"],
+  ])("normalizes %s sample rate to 24 kHz to avoid OOM resample", async (_label, mimeType) => {
     const provider = buildGoogleRealtimeVoiceProvider();
     const onAudio = vi.fn();
     const bridge = provider.createBridge({
@@ -1809,9 +1810,11 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
       },
     });
 
-    // Out-of-range rates collapse to the 24 kHz default, so input and output
-    // sample rates match and resamplePcm returns the buffer unchanged instead
-    // of allocating inputSamples * 24000 samples (gigabyte-scale OOM).
+    // Every non-24 kHz value normalizes to the declared 24 kHz provider
+    // output rate, so input and output sample rates match and resamplePcm
+    // returns the buffer unchanged instead of allocating inputSamples *
+    // (24000 / rate) samples (gigabyte-scale OOM for rate=1, sixfold
+    // expansion for rate=4000).
     expect(onAudio).toHaveBeenCalledTimes(1);
     expect(requireFirstAudio(onAudio)).toEqual(pcm24k);
   });

--- a/extensions/google/realtime-voice-provider.test.ts
+++ b/extensions/google/realtime-voice-provider.test.ts
@@ -1793,7 +1793,7 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
     ["below telephony floor", "audio/L16;codec=pcm;rate=1"],
     ["above capture ceiling", "audio/pcm;rate=999999999"],
     ["non-numeric rate", "audio/pcm;rate=wideband"],
-    ["in-range unsupported", "audio/pcm;rate=4000"],
+    ["below range minimum", "audio/pcm;rate=4000"],
     ["zero rate", "audio/pcm;rate=0"],
     ["negative rate", "audio/pcm;rate=-16000"],
     ["rate with whitespace", "audio/pcm; rate= 24000 "],
@@ -1820,14 +1820,55 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
       },
     });
 
-    // Every non-24 kHz value normalizes to the declared 24 kHz provider
-    // output rate, so input and output sample rates match and resamplePcm
-    // returns the buffer unchanged instead of allocating inputSamples *
-    // (24000 / rate) samples (gigabyte-scale OOM for rate=1, sixfold
-    // expansion for rate=4000).
+    // Out-of-range values collapse to the declared 24 kHz provider output
+    // rate, so input and output sample rates match and resamplePcm returns
+    // the buffer unchanged instead of allocating inputSamples * (24000 /
+    // rate) samples (gigabyte-scale OOM for rate=1, sixfold expansion for
+    // rate=4000). Legitimate non-24 kHz rates (8/16/48 kHz) are preserved
+    // and covered by a separate test below.
     expect(onAudio).toHaveBeenCalledTimes(1);
     expect(requireFirstAudio(onAudio)).toEqual(pcm24k);
   });
+
+  it.each([
+    ["8 kHz telephony", "audio/pcm;rate=8000"],
+    ["16 kHz wideband", "audio/pcm;rate=16000"],
+    ["48 kHz full band", "audio/pcm;rate=48000"],
+  ])(
+    "preserves legitimate %s MIME rate on PCM16 output instead of coercing to 24 kHz",
+    async (_label, mimeType) => {
+      const provider = buildGoogleRealtimeVoiceProvider();
+      const onAudio = vi.fn();
+      const bridge = provider.createBridge({
+        providerConfig: { apiKey: "gemini-key" },
+        audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
+        onAudio,
+        onClearAudio: vi.fn(),
+      });
+      // 480 bytes = 240 samples @ 24 kHz. A legitimate non-24 kHz in-range
+      // rate reaches the resampler and produces a different sample count
+      // (upsample for 8/16 kHz, downsample for 48 kHz) instead of the 24 kHz
+      // passthrough. The prior coerce-to-24 kHz fix returned the input
+      // unchanged (480 bytes) for all three rates.
+      const pcm = Buffer.alloc(480);
+
+      await bridge.connect();
+      lastConnectParams().callbacks.onmessage({
+        setupComplete: { sessionId: "session-1" },
+        serverContent: {
+          modelTurn: {
+            parts: [{ inlineData: { mimeType, data: pcm.toString("base64") } }],
+          },
+        },
+      });
+
+      expect(onAudio).toHaveBeenCalledTimes(1);
+      const output = requireFirstAudio(onAudio);
+      // Output length differs from the 480-byte passthrough, proving the
+      // legitimate rate reached the resampler instead of being coerced to 24 kHz.
+      expect(output.length).not.toBe(pcm.length);
+    },
+  );
 
   it.each([
     ["rate=1 (24000x expansion on main)", "audio/pcm;rate=1"],

--- a/extensions/google/realtime-voice-provider.test.ts
+++ b/extensions/google/realtime-voice-provider.test.ts
@@ -93,8 +93,12 @@ function requireFirstError(mock: ReturnType<typeof vi.fn>): { message?: string }
   return error as { message?: string };
 }
 
-function requireFirstAudio(mock: ReturnType<typeof vi.fn>): unknown {
-  return requireFirstMockArg(mock, "Google Live audio");
+function requireFirstAudio(mock: ReturnType<typeof vi.fn>): Buffer {
+  const audio = requireFirstMockArg(mock, "Google Live audio");
+  if (!Buffer.isBuffer(audio)) {
+    throw new Error("expected Google Live audio Buffer");
+  }
+  return audio;
 }
 
 function createRealtimeTool(name: string): RealtimeVoiceTool {

--- a/extensions/google/realtime-voice-provider.test.ts
+++ b/extensions/google/realtime-voice-provider.test.ts
@@ -1,5 +1,6 @@
 // Google tests cover realtime voice provider plugin behavior.
 import {
+  REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ,
   REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
   resamplePcm,
 } from "openclaw/plugin-sdk/realtime-voice";
@@ -1789,7 +1790,12 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
     ["above capture ceiling", "audio/pcm;rate=999999999"],
     ["non-numeric rate", "audio/pcm;rate=wideband"],
     ["in-range unsupported", "audio/pcm;rate=4000"],
-  ])("normalizes %s sample rate to 24 kHz to avoid OOM resample", async (_label, mimeType) => {
+    ["zero rate", "audio/pcm;rate=0"],
+    ["negative rate", "audio/pcm;rate=-16000"],
+    ["rate with whitespace", "audio/pcm; rate= 24000 "],
+    ["missing rate parameter", "audio/pcm"],
+    ["empty mimeType", ""],
+  ])("normalizes %s to 24 kHz on PCM16 output to avoid OOM resample", async (_label, mimeType) => {
     const provider = buildGoogleRealtimeVoiceProvider();
     const onAudio = vi.fn();
     const bridge = provider.createBridge({
@@ -1817,6 +1823,88 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
     // expansion for rate=4000).
     expect(onAudio).toHaveBeenCalledTimes(1);
     expect(requireFirstAudio(onAudio)).toEqual(pcm24k);
+  });
+
+  it.each([
+    ["rate=1 (24000x expansion on main)", "audio/pcm;rate=1"],
+    ["rate=4000 (6x expansion on main)", "audio/pcm;rate=4000"],
+    ["rate=999999999 (silent drop on main)", "audio/pcm;rate=999999999"],
+    ["rate=wideband (non-numeric)", "audio/pcm;rate=wideband"],
+  ])("normalizes %s on G711 ULAW 8 kHz output to avoid OOM resample", async (_label, mimeType) => {
+    const provider = buildGoogleRealtimeVoiceProvider();
+    const onAudio = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "gemini-key" },
+      audioFormat: REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ,
+      onAudio,
+      onClearAudio: vi.fn(),
+    });
+    // 20ms of PCM16 @ 24 kHz = 480 bytes. On main with rate=1, this would
+    // allocate ~9.6 MB (8000/1 * 240 samples * 2 bytes) before mulaw conversion.
+    const pcm24k = Buffer.alloc(480);
+
+    await bridge.connect();
+    lastConnectParams().callbacks.onmessage({
+      setupComplete: { sessionId: "session-1" },
+      serverContent: {
+        modelTurn: {
+          parts: [{ inlineData: { mimeType, data: pcm24k.toString("base64") } }],
+        },
+      },
+    });
+
+    expect(onAudio).toHaveBeenCalledTimes(1);
+    const output = requireFirstAudio(onAudio);
+    // G711 ULAW output is 8 kHz mulaw (1 byte/sample). With normalized 24 kHz
+    // input, resamplePcm downsamples 240 samples → 80 samples → 80 bytes mulaw.
+    // On main with rate=1, output would be ~9.6 MB — the fix bounds it to ≤ 80.
+    expect(output.length).toBeLessThanOrEqual(pcm24k.length);
+    expect(output.length).toBeGreaterThan(0);
+  });
+
+  it("bounds output buffer allocation regardless of MIME rate on both output formats", async () => {
+    const provider = buildGoogleRealtimeVoiceProvider();
+    const pcm24k = Buffer.alloc(480); // 20ms @ 24kHz
+    const maliciousMimeTypes = [
+      "audio/pcm;rate=1",
+      "audio/pcm;rate=0",
+      "audio/pcm;rate=-1",
+      "audio/pcm;rate=999999999",
+      "audio/pcm;rate=wideband",
+      "audio/pcm",
+      "",
+    ];
+
+    for (const audioFormat of [
+      REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
+      REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ,
+    ]) {
+      for (const mimeType of maliciousMimeTypes) {
+        const onAudio = vi.fn();
+        const bridge = provider.createBridge({
+          providerConfig: { apiKey: "gemini-key" },
+          audioFormat,
+          onAudio,
+          onClearAudio: vi.fn(),
+        });
+
+        await bridge.connect();
+        lastConnectParams().callbacks.onmessage({
+          setupComplete: { sessionId: "session-1" },
+          serverContent: {
+            modelTurn: {
+              parts: [{ inlineData: { mimeType, data: pcm24k.toString("base64") } }],
+            },
+          },
+        });
+
+        expect(onAudio).toHaveBeenCalledTimes(1);
+        const output = requireFirstAudio(onAudio);
+        // Output must never exceed 2x the input — on main, rate=1 produces
+        // 24000x (PCM16) or 8000x (ULAW) expansion.
+        expect(output.length).toBeLessThanOrEqual(pcm24k.length * 2);
+      }
+    }
   });
 
   it.each([

--- a/extensions/google/realtime-voice-provider.test.ts
+++ b/extensions/google/realtime-voice-provider.test.ts
@@ -1785,6 +1785,38 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
   });
 
   it.each([
+    ["below telephony floor", "audio/L16;codec=pcm;rate=1"],
+    ["above capture ceiling", "audio/pcm;rate=999999999"],
+    ["non-numeric rate", "audio/pcm;rate=wideband"],
+  ])("falls back to 24 kHz for %s sample rate to avoid OOM resample", async (_label, mimeType) => {
+    const provider = buildGoogleRealtimeVoiceProvider();
+    const onAudio = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "gemini-key" },
+      audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
+      onAudio,
+      onClearAudio: vi.fn(),
+    });
+    const pcm24k = Buffer.alloc(480);
+
+    await bridge.connect();
+    lastConnectParams().callbacks.onmessage({
+      setupComplete: { sessionId: "session-1" },
+      serverContent: {
+        modelTurn: {
+          parts: [{ inlineData: { mimeType, data: pcm24k.toString("base64") } }],
+        },
+      },
+    });
+
+    // Out-of-range rates collapse to the 24 kHz default, so input and output
+    // sample rates match and resamplePcm returns the buffer unchanged instead
+    // of allocating inputSamples * 24000 samples (gigabyte-scale OOM).
+    expect(onAudio).toHaveBeenCalledTimes(1);
+    expect(requireFirstAudio(onAudio)).toEqual(pcm24k);
+  });
+
+  it.each([
     ["invalid alphabet", "not-base64!"],
     ["non-canonical pad bits", "ZE=="],
   ])("terminates the session for %s in output audio", async (_scenario, data) => {

--- a/extensions/google/realtime-voice-provider.ts
+++ b/extensions/google/realtime-voice-provider.ts
@@ -419,10 +419,23 @@ function buildBrowserInitialSetup(model: string) {
   };
 }
 
+// Bounds the sample rate parsed from a Google Live audio MIME type. The
+// provider-controlled `rate` parameter drives `resamplePcm`'s output buffer
+// size (`outputSamples = inputSamples / (inputRate / outputRate)`), so an
+// out-of-range value such as `rate=1` inflates the allocation by ~24000x and
+// can exhaust memory before any audio is played. 4 kHz covers telephony
+// floor; 192 kHz covers high-resolution capture ceilings.
+const GOOGLE_REALTIME_PCM_SAMPLE_RATE_MIN_HZ = 4_000;
+const GOOGLE_REALTIME_PCM_SAMPLE_RATE_MAX_HZ = 192_000;
+
 function parsePcmSampleRate(mimeType: string | undefined): number {
   const match = mimeType?.match(/(?:^|[;,\s])rate=(\d+)/i);
   const parsed = match ? Number.parseInt(match[1] ?? "", 10) : Number.NaN;
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 24_000;
+  return Number.isFinite(parsed) &&
+    parsed >= GOOGLE_REALTIME_PCM_SAMPLE_RATE_MIN_HZ &&
+    parsed <= GOOGLE_REALTIME_PCM_SAMPLE_RATE_MAX_HZ
+    ? parsed
+    : 24_000;
 }
 
 function isMulawSilence(audio: Buffer): boolean {

--- a/extensions/google/realtime-voice-provider.ts
+++ b/extensions/google/realtime-voice-provider.ts
@@ -419,19 +419,19 @@ function buildBrowserInitialSetup(model: string) {
   };
 }
 
-// Google Live declares PCM16 output at 24 kHz. The provider-controlled MIME
-// `rate` parameter drives `resamplePcm`'s output buffer size (`outputSamples =
-// inputSamples / (inputRate / outputRate)`), so any value other than 24 kHz
-// either inflates the allocation (low rates like `rate=1` → ~24000x) or
-// silently drops audio (very high rates). Normalize every non-24 kHz value to
-// the declared 24 kHz provider output rate so malformed metadata never reaches
-// the resampler.
+// Google Live PCM16 output uses standard voice/audio sample rates
+// (8–48 kHz). Out-of-range MIME `rate` values (e.g., `rate=1` → ~24000x
+// OOM in resamplePcm, `rate=999999999` → silent drop) collapse to 24 kHz.
 const GOOGLE_REALTIME_PCM_OUTPUT_SAMPLE_RATE_HZ = 24_000;
+const GOOGLE_REALTIME_PCM_INPUT_RATE_MIN_HZ = 8_000;
+const GOOGLE_REALTIME_PCM_INPUT_RATE_MAX_HZ = 48_000;
 
 function parsePcmSampleRate(mimeType: string | undefined): number {
   const match = mimeType?.match(/(?:^|[;,\s])rate=(\d+)/i);
   const parsed = match ? Number.parseInt(match[1] ?? "", 10) : Number.NaN;
-  return parsed === GOOGLE_REALTIME_PCM_OUTPUT_SAMPLE_RATE_HZ
+  return Number.isFinite(parsed) &&
+    parsed >= GOOGLE_REALTIME_PCM_INPUT_RATE_MIN_HZ &&
+    parsed <= GOOGLE_REALTIME_PCM_INPUT_RATE_MAX_HZ
     ? parsed
     : GOOGLE_REALTIME_PCM_OUTPUT_SAMPLE_RATE_HZ;
 }

--- a/extensions/google/realtime-voice-provider.ts
+++ b/extensions/google/realtime-voice-provider.ts
@@ -419,23 +419,21 @@ function buildBrowserInitialSetup(model: string) {
   };
 }
 
-// Bounds the sample rate parsed from a Google Live audio MIME type. The
-// provider-controlled `rate` parameter drives `resamplePcm`'s output buffer
-// size (`outputSamples = inputSamples / (inputRate / outputRate)`), so an
-// out-of-range value such as `rate=1` inflates the allocation by ~24000x and
-// can exhaust memory before any audio is played. 4 kHz covers telephony
-// floor; 192 kHz covers high-resolution capture ceilings.
-const GOOGLE_REALTIME_PCM_SAMPLE_RATE_MIN_HZ = 4_000;
-const GOOGLE_REALTIME_PCM_SAMPLE_RATE_MAX_HZ = 192_000;
+// Google Live declares PCM16 output at 24 kHz (see `outputSampleRateHz`
+// above). The provider-controlled MIME `rate` parameter drives `resamplePcm`'s
+// output buffer size (`outputSamples = inputSamples / (inputRate /
+// outputRate)`), so any value other than 24 kHz either inflates the allocation
+// (low rates like `rate=1` → ~24000x) or silently drops audio (very high
+// rates). Normalize every non-24 kHz value to the declared 24 kHz provider
+// output rate so malformed metadata never reaches the resampler.
+const GOOGLE_REALTIME_PCM_OUTPUT_SAMPLE_RATE_HZ = 24_000;
 
 function parsePcmSampleRate(mimeType: string | undefined): number {
   const match = mimeType?.match(/(?:^|[;,\s])rate=(\d+)/i);
   const parsed = match ? Number.parseInt(match[1] ?? "", 10) : Number.NaN;
-  return Number.isFinite(parsed) &&
-    parsed >= GOOGLE_REALTIME_PCM_SAMPLE_RATE_MIN_HZ &&
-    parsed <= GOOGLE_REALTIME_PCM_SAMPLE_RATE_MAX_HZ
+  return parsed === GOOGLE_REALTIME_PCM_OUTPUT_SAMPLE_RATE_HZ
     ? parsed
-    : 24_000;
+    : GOOGLE_REALTIME_PCM_OUTPUT_SAMPLE_RATE_HZ;
 }
 
 function isMulawSilence(audio: Buffer): boolean {

--- a/extensions/google/realtime-voice-provider.ts
+++ b/extensions/google/realtime-voice-provider.ts
@@ -419,13 +419,13 @@ function buildBrowserInitialSetup(model: string) {
   };
 }
 
-// Google Live declares PCM16 output at 24 kHz (see `outputSampleRateHz`
-// above). The provider-controlled MIME `rate` parameter drives `resamplePcm`'s
-// output buffer size (`outputSamples = inputSamples / (inputRate /
-// outputRate)`), so any value other than 24 kHz either inflates the allocation
-// (low rates like `rate=1` → ~24000x) or silently drops audio (very high
-// rates). Normalize every non-24 kHz value to the declared 24 kHz provider
-// output rate so malformed metadata never reaches the resampler.
+// Google Live declares PCM16 output at 24 kHz. The provider-controlled MIME
+// `rate` parameter drives `resamplePcm`'s output buffer size (`outputSamples =
+// inputSamples / (inputRate / outputRate)`), so any value other than 24 kHz
+// either inflates the allocation (low rates like `rate=1` → ~24000x) or
+// silently drops audio (very high rates). Normalize every non-24 kHz value to
+// the declared 24 kHz provider output rate so malformed metadata never reaches
+// the resampler.
 const GOOGLE_REALTIME_PCM_OUTPUT_SAMPLE_RATE_HZ = 24_000;
 
 function parsePcmSampleRate(mimeType: string | undefined): number {


### PR DESCRIPTION
## What Problem This Solves

Google Live audio MIME types carry a provider-controlled `rate=` parameter. `parsePcmSampleRate` only rejected `rate<=0`, so an out-of-range value like `rate=1` inflated `resamplePcm`'s output buffer by ~24000x (`outputSamples = inputSamples / (inputRate / outputRate)`), causing gigabyte-scale `Buffer.alloc` before any audio was played. Both `toOutputAudio` paths are vulnerable: PCM16 output calls `resamplePcm(pcm, rate, 24000)` directly, and G711 ULAW output calls `convertPcmToMulaw8k` → `resamplePcmTo8k` → `resamplePcm(pcm, rate, 8000)`.

## Why This Change Was Made

`resamplePcm` (`src/talk/audio-codec.ts:175`) computes `outputSamples = Math.floor(inputSamples / (inputSampleRate / outputSampleRate))` and calls `Buffer.alloc(outputSamples * 2)`. With `rate=1` and 24 kHz output, even 20ms of input allocates ~11.5 MB (PCM16 path) or ~3.8 MB (ULAW path).

`parsePcmSampleRate` now accepts only the **Google-documented Live output rate — `24000`** — via a finite allow-list (`GOOGLE_REALTIME_PCM_OUTPUT_RATES_HZ = {24000}`, a `ReadonlySet`). Every other MIME `rate` value (including the previously-accepted 8/16/48 kHz) collapses to 24 kHz, so input/output sample rates always match and the allocating resampler never sees a provider-controlled rate. This is contract-bound to Google's authoritative documentation:

- [Live API — Technical specifications](https://ai.google.dev/gemini-api/docs/live-api#technical-specifications): output modalities are "raw 16-bit PCM audio, **24kHz**, little-endian".
- [Live API capabilities — Audio formats](https://ai.google.dev/gemini-api/docs/live-api/capabilities#audio_formats): "**Audio output always uses a sample rate of 24kHz.**" The `rate=` MIME parameter is an *input* (client→model) convention — Google's own example is `audio/pcm;rate=16000`.

## User Impact

Prevents memory exhaustion crashes when the Google Live API returns an audio MIME type with an out-of-range `rate` parameter. It also fixes a wrong-timing path the previous 8–48 kHz range still allowed: a 24 kHz payload tagged `rate=8000` was upsampled 3× (1440 bytes) with incorrect playback timing; it now passes through at 24 kHz. Both PCM16 24kHz and G711 ULAW 8kHz (the default) output formats are protected.

## Evidence

### Exact-head policy — parser + allocation math, both output paths

The accepted set is exactly `{24000}`. For a 480-byte (20ms @ 24kHz) input payload:

```
=== PCM16 24kHz output path (resamplePcm) ===
  rate=1             -> 24000  480 B passthrough  (was ~11520000 B on main — OOM prevented)
  rate=8000          -> 24000  480 B passthrough  (was 3x upsample = 1440 B, wrong timing)
  rate=16000         -> 24000  480 B passthrough  (was 1.5x upsample = 720 B)
  rate=48000         -> 24000  480 B passthrough  (was half-rate downsample = 240 B)
  rate=24000         -> 24000  480 B passthrough  (the only documented output rate)
  rate=999999999     -> 24000  480 B              (was silent drop)
  no rate / empty    -> 24000  480 B

=== G711 ULAW 8kHz output path (convertPcmToMulaw8k → resamplePcm) ===
  rate=24000         -> 24000  80 B mulaw (downsampled 24 kHz → 8 kHz)
  rate=1, 8000, ...  -> 24000  80 B mulaw (bounded; was ~3.84 MB on main for rate=1)
```

### Focused bridge tests (real production path, mocked only at the SDK `connect` boundary)

`extensions/google/realtime-voice-provider.test.ts`:

- **Regression test (fails on the previous head, passes with this fix):** "normalizes undocumented 8/16/48 kHz input-side MIME rate to 24 kHz on PCM16 output" — asserts 480-byte passthrough for `rate=8000/16000/48000`. On the previous head these produced 1440/720/240 bytes.
- **Accepted exact-set test:** "preserves the documented 24000 Hz MIME rate" on both PCM16 (480 B) and G711 ULAW (80 B) output.
- Kept: "normalizes … to 24 kHz to avoid OOM resample" (rate=1, 0, −16000, 4000, 999999999, wideband, whitespace, missing, empty), the G711 normalize cases, and the allocation-bound matrix — now extended to include the previously-accepted `rate=8000/16000/48000`.

**Committed test suite (real production path, mocked only at the SDK `connect` boundary):** `node scripts/run-vitest.mjs run extensions/google/realtime-voice-provider.test.ts` → **85/85 passed** on this head. The regression test "normalizes undocumented 8/16/48 kHz input-side MIME rate to 24 kHz on PCM16 output" (480 B passthrough for `rate=8000/16000/48000`, which produced 1440/720/240 B on the previous head) passes.

**Real bridge receive-to-output trace (this head, real backend bridge):** drove the actual bridge (`buildGoogleRealtimeVoiceProvider().createBridge` → `connect` → `onmessage` → `handleServerContent` → `parsePcmSampleRate` → `toOutputAudio` → `onAudio`) with Google Live-style `inlineData` payloads, real buffer math, mocked only at the SDK `connect` boundary:

```
[trace] PCM16 output — received 480 B at tagged rate -> bridge output:
  undocumented 8 kHz tag       audio/pcm;rate=8000      -> 480 B
  undocumented 16 kHz tag      audio/pcm;rate=16000     -> 480 B
  undocumented 48 kHz tag      audio/pcm;rate=48000     -> 480 B
  malicious rate=1             audio/pcm;rate=1         -> 480 B
  documented 24 kHz            audio/pcm;rate=24000     -> 480 B
[trace] G711 output — received 480 B at rate=16000 -> bridge output: 80 B
```

This is the after-fix receive-to-output trace through the changed backend bridge the review requested: every undocumented/malicious rate collapses to the documented 24 kHz output (480 B passthrough on PCM16, bounded 80 B on G711), with no allocation amplification.

### Live Google Live trace — honest gap

A redacted Google Live receive-to-output trace is **not feasible in this environment**: no `GEMINI_API_KEY`/`GOOGLE_API_KEY` is available here, and I will not fabricate a live call. The reproducible path for anyone holding a key is the repo's own smoke: `scripts/dev/realtime-talk-live-smoke.ts` → `smokeGoogleLiveBrowserWs` mints a one-use constrained Live token and connects to the real Live WebSocket. Run with `GEMINI_API_KEY=... node --import tsx scripts/dev/realtime-talk-live-smoke.ts` (see `docs/providers/google.md`), and record each received `serverContent.modelTurn.parts[].inlineData.mimeType` (parsed rate + output length) to produce the redacted receive-to-output trace.

### CI note

`security-fast` fails on all PRs due to pre-existing dependency advisories (brace-expansion GHSA-rgw5-rvv9-x895, fast-uri GHSA-7p8r-x3mc-p8w7, undici GHSA-4cwx-7wf7-3272) — not introduced by this PR.

