### PR TITLE
improve(tests): avoid repeated CLI runner fixture imports

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution-cli-commentary.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-cli-commentary.test.ts
@@ -7,6 +7,7 @@ import {
   createFollowupRun,
   createMockTypingSignaler,
   getExecuteAgentTurnForTest,
+  loadActualRunCliAgentForTest,
   setupAgentRunnerExecutionTestState,
 } from "./agent-runner-execution.test-support.js";
 import type { FallbackRunnerParams } from "./agent-runner-execution.test-support.js";
@@ -82,10 +83,9 @@ function useScriptedClaudeCliBackend() {
     resolveRuntimeCliBackends: () => [backend],
   });
   state.runCliAgentMock.mockImplementationOnce(async (params: RunCliAgentParams) => {
-    if (!state.runCliAgentActual) {
-      throw new Error("real CLI runner was not initialized");
-    }
-    return await state.runCliAgentActual(params);
+    return await (
+      await loadActualRunCliAgentForTest()
+    )(params);
   });
 }
 

--- a/src/auto-reply/reply/agent-runner-execution-cli-sessions.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-cli-sessions.test.ts
@@ -1,6 +1,4 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { testing as cliBackendsTesting } from "../../agents/cli-backends.test-support.js";
-import type { RunCliAgentParams } from "../../agents/cli-runner/types.js";
 import { FailoverError } from "../../agents/failover-error.js";
 import { installSessionPlacementAdmissionProvider } from "../../agents/session-placement-admission.js";
 import type { SessionEntry } from "../../config/sessions.js";
@@ -23,52 +21,6 @@ import type { FallbackRunnerParams } from "./agent-runner-execution.test-support
 
 const state = setupAgentRunnerExecutionTestState();
 afterEach(resetGeneratedMediaTaskActivityForTests);
-
-const expiredClaudeSessionProgram = String.raw`
-let input = "";
-process.stdin.setEncoding("utf8");
-process.stdin.on("data", (chunk) => { input += chunk; });
-process.stdin.on("end", () => {
-  if (!input.trim()) process.exit(2);
-  process.stdout.write(JSON.stringify({
-    type: "result",
-    subtype: "error_during_execution",
-    is_error: true,
-    session_id: "stale-cli-session",
-    result: "No conversation found with session ID stale-cli-session",
-  }) + "\n");
-});
-`;
-
-function useScriptedExpiredClaudeBackend() {
-  const backend = {
-    id: "claude-cli",
-    modelProvider: "anthropic",
-    pluginId: "anthropic",
-    bundleMcp: false,
-    config: {
-      command: process.execPath,
-      args: ["-e", expiredClaudeSessionProgram],
-      resumeArgs: ["-e", expiredClaudeSessionProgram, "--resume", "{sessionId}"],
-      input: "stdin" as const,
-      output: "jsonl" as const,
-      jsonlDialect: "claude-stream-json" as const,
-      sessionMode: "existing" as const,
-      systemPromptWhen: "never" as const,
-    },
-  };
-  cliBackendsTesting.setDepsForTest({
-    resolvePluginSetupCliBackend: ({ backend: id }) =>
-      id === backend.id ? { pluginId: backend.pluginId, backend } : undefined,
-    resolveRuntimeCliBackends: () => [backend],
-  });
-  state.runCliAgentMock.mockImplementationOnce((params: RunCliAgentParams) => {
-    if (!state.runCliAgentActual) {
-      throw new Error("real CLI runner was not initialized");
-    }
-    return state.runCliAgentActual(params);
-  });
-}
 
 describe("executeAgentTurn: CLI session routing", () => {
   it("forwards the static extra system prompt to CLI backends", async () => {
@@ -668,7 +620,7 @@ describe("executeAgentTurn: CLI session routing", () => {
     }
   });
 
-  it("clears a reused binding after a real CLI subprocess reports an expired session", async () => {
+  it("clears a reused binding after the CLI reports an expired session", async () => {
     state.isCliProviderMock.mockReturnValue(true);
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
       result: await params.run("claude-cli", "claude-opus-4-8"),
@@ -676,7 +628,13 @@ describe("executeAgentTurn: CLI session routing", () => {
       model: "claude-opus-4-8",
       attempts: [],
     }));
-    useScriptedExpiredClaudeBackend();
+    state.runCliAgentMock.mockRejectedValueOnce(
+      new FailoverError("No conversation found with session ID stale-cli-session", {
+        reason: "session_expired",
+        provider: "claude-cli",
+        model: "claude-opus-4-8",
+      }),
+    );
 
     const followupRun = createFollowupRun();
     followupRun.run.provider = "claude-cli";

--- a/src/auto-reply/reply/agent-runner-execution.test-support.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test-support.ts
@@ -32,7 +32,6 @@ const state = vi.hoisted(() => ({
   runEmbeddedAgentMock: vi.fn(),
   runEmbeddedAgentEntryMock: vi.fn(),
   runCliAgentMock: vi.fn(),
-  runCliAgentActual: undefined as RunCliAgent | undefined,
   runWithModelFallbackMock: vi.fn(),
   isCliProviderMock: vi.fn((_: unknown) => false),
   isInternalMessageChannelMock: vi.fn((_: unknown) => false),
@@ -79,16 +78,9 @@ vi.mock("../../agents/agent-bundle-mcp-manager-api.js", () => ({
   peekSessionMcpRuntime: (params: unknown) => state.peekSessionMcpRuntimeMock(params),
 }));
 
-vi.mock("../../agents/cli-runner.js", async () => {
-  const actual = await vi.importActual<typeof import("../../agents/cli-runner.js")>(
-    "../../agents/cli-runner.js",
-  );
-  state.runCliAgentActual = actual.runCliAgent;
-  return {
-    ...actual,
-    runCliAgent: (params: unknown) => state.runCliAgentMock(params),
-  };
-});
+vi.mock("../../agents/cli-runner.js", () => ({
+  runCliAgent: (params: unknown) => state.runCliAgentMock(params),
+}));
 
 vi.mock("../../agents/model-fallback-runner.js", () => ({
   runWithModelFallback: (params: unknown) => state.runWithModelFallbackMock(params),
@@ -309,6 +301,12 @@ export async function getExecuteAgentTurnForTest() {
     }
     return { kind: "final" as const, payload: { text: "NO_REPLY" } };
   };
+}
+
+export async function loadActualRunCliAgentForTest(): Promise<RunCliAgent> {
+  return (
+    await vi.importActual<typeof import("../../agents/cli-runner.js")>("../../agents/cli-runner.js")
+  ).runCliAgent;
 }
 
 export type FallbackRunnerParams = {


### PR DESCRIPTION
## What Problem This Solves

The isolated reply-execution suites eagerly imported the complete real CLI runner through their shared fixture even though only one test needs its subprocess behavior. That repeated module-graph setup across 18 suites and made the compact large-8 group about 17–20 seconds slower.

## Why This Change Was Made

Keep the shared fixture as a thin synchronous `runCliAgent` mock and lazy-load the actual runner only for the commentary JSONL subprocess test. The session-binding cleanup test now injects the typed `session_expired` failure owned by that orchestration boundary; exact error classification and real CLI session-expiry behavior remain covered in their dedicated owner suites.

## User Impact

No product behavior changes. Maintainers get faster isolated test feedback without changing sharding, workers, scheduling, retries, timeouts, test counts, or assertions at the owning boundaries.

## Evidence

- Direct AWS Crabbox `c7a.8xlarge`, exact same lease and source snapshot:
  - baseline `run_b303a2f08866`: 91.42s
  - candidate `run_e26b3c037180`: 73.94s
  - saving: 17.48s (19.1%)
- Earlier same-lease pair: 92.28s → 72.57s, saving 19.71s (21.4%).
- Counts remained exact in every run: 96 isolated files with 1,297 passed and 24 skipped; 10 fake-timer files with 213 passed.
- Post-rebase full-group proof `run_baedd8e94d01`: all counts passed in 74.31s.
- Production LOC: zero. Test diff: +21/-65.
- `oxfmt`, `git diff --check`, and Codex autoreview passed with no accepted/actionable findings.
