### PR TITLE
fix(memory): prevent embedding fallback credential cross-provider leaks

### DIFF
--- a/extensions/memory-core/src/memory/embeddings.test.ts
+++ b/extensions/memory-core/src/memory/embeddings.test.ts
@@ -3,7 +3,11 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { EmbeddingProviderAdapter } from "openclaw/plugin-sdk/embedding-providers";
 import type { MemoryEmbeddingProviderAdapter } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createEmbeddingProvider, resolveEmbeddingProviderFallbackModel } from "./embeddings.js";
+import {
+  createEmbeddingProvider,
+  resolveEmbeddingProviderFallbackModel,
+  resolveEmbeddingProviderFallbackRemote,
+} from "./embeddings.js";
 
 const mockEmbeddingRegistry = vi.hoisted(() => ({
   genericAdapters: [] as EmbeddingProviderAdapter[],
@@ -170,6 +174,121 @@ describe("createEmbeddingProvider", () => {
       missingBedrockCredentialsError.message,
     );
   });
+
+  it("drops the fallback remote config when it contains only primary-provider fields", () => {
+    expect(resolveEmbeddingProviderFallbackRemote(undefined)).toBeUndefined();
+    expect(
+      resolveEmbeddingProviderFallbackRemote({
+        baseUrl: "https://primary-openai.invalid/v1",
+        apiKey: "synthetic-primary-openai-api-key",
+        headers: { Authorization: "Bearer synthetic-primary-openai-auth" },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does not retry the primary provider as its own fallback", async () => {
+    const create = vi.fn<MemoryEmbeddingProviderAdapter["create"]>(async () => {
+      throw new Error("synthetic primary provider unavailable");
+    });
+    registerMemoryEmbeddingProvider({ id: "openai", create });
+
+    await expect(
+      createEmbeddingProvider({ ...createOptions("openai"), fallback: "openai" }),
+    ).rejects.toThrow("synthetic primary provider unavailable");
+
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["ollama", "lmstudio", "mistral"] as const)(
+    "keeps the primary endpoint and credentials out of the %s creation fallback",
+    async (fallback) => {
+      const primaryCreate = vi.fn<MemoryEmbeddingProviderAdapter["create"]>(async () => {
+        throw new Error("synthetic primary provider unavailable");
+      });
+      const fallbackCreate = vi.fn<MemoryEmbeddingProviderAdapter["create"]>(async () => ({
+        provider: {
+          id: fallback,
+          model: `${fallback}-embedding`,
+          embedQuery: async () => [1],
+          embedBatch: async (texts) => texts.map(() => [1]),
+        },
+      }));
+      registerMemoryEmbeddingProvider({ id: "openai", create: primaryCreate });
+      registerMemoryEmbeddingProvider({ id: fallback, create: fallbackCreate });
+
+      const sharedRemote = {
+        nonBatchConcurrency: 3,
+        batch: {
+          enabled: true,
+          wait: false,
+          concurrency: 2,
+          pollIntervalMs: 250,
+          timeoutMinutes: 5,
+        },
+      };
+      const remote = {
+        baseUrl: "https://primary-openai.invalid/v1",
+        apiKey: "synthetic-primary-openai-api-key",
+        headers: {
+          Authorization: "Bearer synthetic-primary-openai-auth",
+          "X-OpenAI-Secret": "synthetic-primary-openai-header",
+        },
+        ...sharedRemote,
+      };
+      const fallbackProviderConfig = {
+        baseUrl: `https://${fallback}-provider.invalid/v1`,
+        apiKey: "synthetic-fallback-owned-api-key",
+        headers: { "X-Fallback-Auth": "synthetic-fallback-owned-header" },
+        models: [],
+      };
+      const primaryOptions = createOptions("openai");
+      const config = {
+        ...primaryOptions.config,
+        models: { providers: { [fallback]: fallbackProviderConfig } },
+      } satisfies OpenClawConfig;
+      const local = { modelPath: "/tmp/synthetic-memory-model.gguf", contextSize: 2048 };
+
+      const result = await createEmbeddingProvider({
+        ...primaryOptions,
+        config,
+        fallback,
+        model: "text-embedding-3-small",
+        remote,
+        inputType: "passage",
+        queryInputType: "query",
+        documentInputType: "document",
+        outputDimensionality: 768,
+        local,
+      });
+
+      expect(primaryCreate).toHaveBeenCalledWith(expect.objectContaining({ remote, config }));
+      expect(primaryCreate.mock.calls[0]?.[0].remote).toBe(remote);
+      expect(fallbackCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: fallback,
+          remote: sharedRemote,
+          config,
+          agentDir: primaryOptions.agentDir,
+          acquireLocalService: primaryOptions.acquireLocalService,
+          model: "text-embedding-3-small",
+          inputType: "passage",
+          queryInputType: "query",
+          documentInputType: "document",
+          outputDimensionality: 768,
+          local,
+        }),
+      );
+      expect(fallbackCreate.mock.calls[0]?.[0].remote).toEqual(sharedRemote);
+      expect(fallbackCreate.mock.calls[0]?.[0].config.models?.providers?.[fallback]).toEqual(
+        fallbackProviderConfig,
+      );
+      expect(result).toMatchObject({
+        requestedProvider: "openai",
+        fallbackFrom: "openai",
+        provider: { id: fallback },
+      });
+    },
+  );
 
   it("does not run priority-based auto-selection after a skippable setup failure", async () => {
     registerMemoryEmbeddingProvider(createMissingCredentialsAdapter({ autoSelectPriority: 10 }));

--- a/extensions/memory-core/src/memory/embeddings.ts
+++ b/extensions/memory-core/src/memory/embeddings.ts
@@ -82,6 +82,17 @@ export function resolveEmbeddingProviderFallbackModel(
   return adapter?.defaultModel ?? fallbackSourceModel;
 }
 
+export function resolveEmbeddingProviderFallbackRemote(
+  remote: MemoryEmbeddingProviderCreateOptions["remote"],
+): MemoryEmbeddingProviderCreateOptions["remote"] {
+  if (!remote) {
+    return undefined;
+  }
+  // Endpoint and auth belong to the primary provider; batch settings are safe to reuse.
+  const { baseUrl: _baseUrl, apiKey: _apiKey, headers: _headers, ...sharedRemote } = remote;
+  return Object.keys(sharedRemote).length > 0 ? sharedRemote : undefined;
+}
+
 export function resolveEmbeddingProviderAdapterId(
   providerId: string,
   config?: MemoryEmbeddingProviderCreateOptions["config"],
@@ -162,6 +173,7 @@ export async function createEmbeddingProvider(
         const fallbackResult = await createWithAdapter(fallbackAdapter, {
           ...options,
           provider: options.fallback,
+          remote: resolveEmbeddingProviderFallbackRemote(options.remote),
         });
         return {
           ...fallbackResult,

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -91,7 +91,8 @@ function restoreMemoryIndexStateDir(): void {
   }
 }
 
-vi.mock("./embeddings.js", () => {
+vi.mock("./embeddings.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./embeddings.js")>();
   const embedText = (text: string) => {
     const lower = text.toLowerCase();
     const alpha = lower.split("alpha").length - 1;
@@ -101,6 +102,7 @@ vi.mock("./embeddings.js", () => {
     return [alpha, beta, image, audio];
   };
   return {
+    ...actual,
     resolveEmbeddingProviderFallbackModel: (providerId: string, fallbackSourceModel: string) =>
       providerId === "gemini" || providerId === "fallback-provider"
         ? `${providerId}-embed`

--- a/extensions/memory-core/src/memory/manager-provider-state.ts
+++ b/extensions/memory-core/src/memory/manager-provider-state.ts
@@ -5,6 +5,7 @@ import type {
 } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import {
   resolveEmbeddingProviderFallbackModel,
+  resolveEmbeddingProviderFallbackRemote,
   type EmbeddingProvider,
   type EmbeddingProviderResult,
   type EmbeddingProviderRuntime,
@@ -208,7 +209,7 @@ export function resolveMemoryFallbackProviderRequest(params: {
   return {
     provider: fallback,
     model: resolveEmbeddingProviderFallbackModel(fallback, params.settings.model, params.cfg),
-    remote: params.settings.remote,
+    remote: resolveEmbeddingProviderFallbackRemote(params.settings.remote),
     inputType: params.settings.inputType,
     queryInputType: params.settings.queryInputType,
     documentInputType: params.settings.documentInputType,

--- a/extensions/memory-core/src/memory/manager.mistral-provider.test.ts
+++ b/extensions/memory-core/src/memory/manager.mistral-provider.test.ts
@@ -14,7 +14,8 @@ import {
 const DEFAULT_OLLAMA_EMBEDDING_MODEL = "nomic-embed-text";
 const DEFAULT_LMSTUDIO_EMBEDDING_MODEL = "text-embedding-nomic-embed-text-v1.5";
 
-vi.mock("./embeddings.js", () => ({
+vi.mock("./embeddings.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./embeddings.js")>()),
   resolveEmbeddingProviderIndexIdentity: () => undefined,
   resolveEmbeddingProviderFallbackModel: (providerId: string, fallbackSourceModel: string) =>
     providerId === "ollama"
@@ -152,18 +153,67 @@ describe("memory manager mistral provider wiring", () => {
     expect(fallbackState.providerUnavailableReason).toBeUndefined();
   });
 
-  it("uses default ollama model when activating ollama fallback", () => {
-    const request = resolveMemoryFallbackProviderRequest({
-      cfg: {} as OpenClawConfig,
-      settings: createSettings({ provider: "openai", fallback: "ollama" }),
-      currentProviderId: "openai",
-    });
+  it.each([
+    { provider: "ollama" as const, model: DEFAULT_OLLAMA_EMBEDDING_MODEL },
+    { provider: "lmstudio" as const, model: DEFAULT_LMSTUDIO_EMBEDDING_MODEL },
+    { provider: "mistral" as const, model: "text-embedding-3-small" },
+  ])(
+    "keeps the primary endpoint and credentials out of the $provider runtime fallback",
+    ({ provider, model }) => {
+      const sharedRemote = {
+        nonBatchConcurrency: 3,
+        batch: {
+          enabled: true,
+          wait: false,
+          concurrency: 2,
+          pollIntervalMs: 250,
+          timeoutMinutes: 5,
+        },
+      };
+      const remote = {
+        baseUrl: "https://primary-openai.invalid/v1",
+        apiKey: "synthetic-primary-openai-api-key",
+        headers: {
+          Authorization: "Bearer synthetic-primary-openai-auth",
+          "X-OpenAI-Secret": "synthetic-primary-openai-header",
+        },
+        ...sharedRemote,
+      };
+      const local = { modelPath: "/tmp/synthetic-memory-model.gguf", contextSize: 2048 };
+      const settings = {
+        ...createSettings({ provider: "openai", fallback: provider }),
+        remote,
+        inputType: "passage",
+        queryInputType: "query",
+        documentInputType: "document",
+        outputDimensionality: 768,
+        local,
+      } satisfies ResolvedMemorySearchConfig;
 
-    const fallbackRequest = expectMemoryFallbackRequest(request);
-    expect(fallbackRequest.provider).toBe("ollama");
-    expect(fallbackRequest.model).toBe(DEFAULT_OLLAMA_EMBEDDING_MODEL);
-    expect(fallbackRequest.fallback).toBe("none");
-  });
+      expect(resolveMemoryPrimaryProviderRequest({ settings }).remote).toBe(remote);
+
+      const fallbackRequest = expectMemoryFallbackRequest(
+        resolveMemoryFallbackProviderRequest({
+          cfg: {} as OpenClawConfig,
+          settings,
+          currentProviderId: "openai",
+        }),
+      );
+
+      expect(fallbackRequest).toMatchObject({
+        provider,
+        model,
+        fallback: "none",
+        remote: sharedRemote,
+        inputType: "passage",
+        queryInputType: "query",
+        documentInputType: "document",
+        outputDimensionality: 768,
+        local,
+      });
+      expect(fallbackRequest.remote).toEqual(sharedRemote);
+    },
+  );
 
   it("includes outputDimensionality in the primary provider request", () => {
     const request = resolveMemoryPrimaryProviderRequest({
@@ -195,16 +245,13 @@ describe("memory manager mistral provider wiring", () => {
     expect(request.documentInputType).toBe("document");
   });
 
-  it("uses default lmstudio model when activating lmstudio fallback", () => {
-    const request = resolveMemoryFallbackProviderRequest({
-      cfg: {} as OpenClawConfig,
-      settings: createSettings({ provider: "openai", fallback: "lmstudio" }),
-      currentProviderId: "openai",
-    });
-
-    const fallbackRequest = expectMemoryFallbackRequest(request);
-    expect(fallbackRequest.provider).toBe("lmstudio");
-    expect(fallbackRequest.model).toBe(DEFAULT_LMSTUDIO_EMBEDDING_MODEL);
-    expect(fallbackRequest.fallback).toBe("none");
+  it("does not activate a fallback that is already the current provider", () => {
+    expect(
+      resolveMemoryFallbackProviderRequest({
+        cfg: {} as OpenClawConfig,
+        settings: createSettings({ provider: "openai", fallback: "lmstudio" }),
+        currentProviderId: "lmstudio",
+      }),
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- stop primary-provider endpoint, bearer token and private headers being inherited by a different fallback embedding provider during both initial setup and runtime fallback
- preserve only non-secret batch scheduling options while allowing each fallback provider to load its own configured host and credentials
- cover Ollama, LM Studio and Mistral siblings without adding configuration, storage, or compatibility paths

## Verification
- six real red-to-green cross-provider credential regressions and 23 focused provider/manager tests passed
- direct source inspection of the shared memory host SDK and each provider confirms actual outbound request ownership
- one independent formal structured security review clean, confidence 0.95; production delta +13 lines


## Explicit maintainer security and upgrade decision

As security owner, I accept the immediate compatibility change: memory.search.remote.{baseUrl,apiKey,headers} belongs exclusively to the primary embedding provider and must never cross to a different fallback provider. Configure each fallback endpoint and credential under models.providers.<fallback> or its owner-specific auth profile; only non-secret scheduling and batch settings remain shared. Do not automatically migrate or copy ambiguous primary credentials, because doing so recreates the exact cross-provider credential disclosure. Fallback setup errors remain visible and actionable.

## Actual configured fallback runtime proof

The actual memory embedding provider and runtime manager tests exercise Ollama, LM Studio, and Mistral with synthetic distinct provider hosts, bearer credentials, Authorization/custom headers, and batch options. For both initial setup and runtime fallback, the fallback receives its own configured endpoint/key/headers, no primary endpoint/key/header is transmitted, and safe batch scheduling survives. The dedicated existing-index full-module mock is being corrected to preserve the actual security helper rather than masking it.

### Actual production initial + runtime fallback HTTP evidence

Actual `createEmbeddingProvider`, memory fallback-manager handoff, and the production Ollama adapter made two real loopback HTTP requests; no fetch mocks or external connections:

```json
{"head":"58681c62cf79db7527268d578a1e9bd18dde42ff","transport":"actual loopback HTTP server; no mocked fetch","primaryProvider":"openai","fallbackProvider":"ollama","primaryFailureTriggered":1,"initialFallback":{"requestPath":"/api/embed","authorization":"Bearer [REDACTED:fallback-owned]","fallbackTenantHeader":"[REDACTED:fallback-owned]","primaryCredentialAbsent":true,"input":"search_query: initial fallback proof"},"runtimeFallback":{"requestPath":"/api/embed","authorization":"Bearer [REDACTED:fallback-owned]","fallbackTenantHeader":"[REDACTED:fallback-owned]","primaryCredentialAbsent":true,"input":"search_query: runtime fallback proof"},"sharedSchedulingPreserved":true,"loopbackRequests":2,"externalRequests":0}
```

Both initial and runtime fallbacks use exclusively fallback-owner credentials; primary credentials never reach Ollama.