### PR TITLE
fix(agents): preserve network-tainted memory provenance in provider bridges

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -3,12 +3,18 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
+import { createOpenClawCodingTools } from "openclaw/plugin-sdk/agent-harness";
 import {
   embeddedAgentLog,
   isToolWrappedWithBeforeToolCallHook,
   type EmbeddedRunAttemptParams,
   wrapToolWithBeforeToolCallHook,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  clearMemoryPluginState,
+  type MemoryFlushPlan,
+  registerMemoryCapability,
+} from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { dynamicToolBuildState } from "./dynamic-tool-build-state.js";
 import {
@@ -1401,6 +1407,125 @@ describe("Codex app-server dynamic tool build", () => {
       onToolOutcome,
       allocateToolOutcomeOrdinal,
     });
+  });
+
+  it("quarantines exposed Codex memory writes and edits after a network tool", async () => {
+    vi.stubEnv("OPENCLAW_BUILD_PRIVATE_QA", "1");
+    vi.stubEnv("OPENCLAW_QA_FORCE_RUNTIME", "codex");
+    const workspaceDir = path.join(tempDir, "workspace");
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    const recordWriteProvenance = vi.fn<NonNullable<MemoryFlushPlan["recordWriteProvenance"]>>(
+      async () => undefined,
+    );
+    registerMemoryCapability("memory-core", {
+      flushPlanResolver: () => ({
+        softThresholdTokens: 1,
+        forceFlushTranscriptBytes: 1,
+        reserveTokensFloor: 1,
+        prompt: "flush",
+        systemPrompt: "flush",
+        relativePath: "memory/day.md",
+        recordWriteProvenance,
+      }),
+    });
+
+    try {
+      let turnTainted = false;
+      const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+      params.config = { tools: { fs: { workspaceOnly: true } } };
+      params.disableTools = false;
+      params.provider = "openai";
+      params.model = createCodexTestModel("openai");
+      params.runtimePlan = createCodexRuntimePlanFixture();
+      params.senderIsOwner = true;
+      params.onToolOutcome = vi.fn((outcome) => {
+        if (!outcome.presentationOnly && outcome.resultContentSource === "network") {
+          turnTainted = true;
+        }
+      });
+      params.isTurnTainted = () => turnTainted;
+      setOpenClawCodingToolsFactoryForTests((options) => {
+        const filesystemTools = createOpenClawCodingTools(options).filter((tool) =>
+          ["write", "edit"].includes(tool.name),
+        );
+        const networkTool = wrapToolWithBeforeToolCallHook(
+          { ...createRuntimeDynamicTool("web_fetch"), resultContentSource: "network" },
+          {
+            agentId: "main",
+            sessionKey: options?.sessionKey,
+            sessionId: options?.sessionId,
+            runId: options?.runId,
+            onToolOutcome: options?.onToolOutcome,
+          },
+          { emitDiagnostics: false },
+        );
+        return [...filesystemTools, networkTool];
+      });
+
+      const tools = await buildDynamicToolsForTest(params, workspaceDir, {
+        sandbox: null as never,
+      });
+      const tool = (name: string) =>
+        expectDefined(
+          tools.find((candidate) => candidate.name === name),
+          `Codex ${name} dynamic tool`,
+        );
+      await tool("write").execute("codex-trusted-write", {
+        path: "memory/trusted.md",
+        content: "owner note\n",
+      });
+      await tool("web_fetch").execute("codex-network-call", {});
+      expect(params.onToolOutcome).toHaveBeenCalledWith(
+        expect.objectContaining({ toolName: "web_fetch", resultContentSource: "network" }),
+      );
+      expect(params.isTurnTainted()).toBe(true);
+
+      await tool("write").execute("codex-network-write", {
+        path: "memory/network.md",
+        content: "network note\n",
+      });
+      await tool("edit").execute("codex-network-edit", {
+        path: "memory/trusted.md",
+        edits: [{ oldText: "owner note", newText: "network edit" }],
+      });
+
+      const freshParams = createParams(path.join(tempDir, "fresh-session.jsonl"), workspaceDir);
+      freshParams.config = params.config;
+      freshParams.disableTools = false;
+      freshParams.provider = "openai";
+      freshParams.model = createCodexTestModel("openai");
+      freshParams.runtimePlan = createCodexRuntimePlanFixture();
+      freshParams.runId = "codex-fresh-run";
+      freshParams.senderIsOwner = true;
+      freshParams.sessionId = "codex-fresh-session";
+      freshParams.sessionKey = "agent:main:codex-fresh-session";
+      freshParams.isTurnTainted = () => false;
+      const freshTools = await buildDynamicToolsForTest(freshParams, workspaceDir, {
+        sandbox: null as never,
+      });
+      await expectDefined(
+        freshTools.find((candidate) => candidate.name === "write"),
+        "fresh Codex write tool",
+      ).execute("codex-fresh-write", {
+        path: "memory/fresh.md",
+        content: "fresh owner note\n",
+      });
+
+      expect(recordWriteProvenance.mock.calls.map(([entry]) => entry.originClass)).toEqual([
+        "agent",
+        "untrusted",
+        "untrusted",
+        "agent",
+      ]);
+      await expect(fs.readFile(path.join(workspaceDir, "memory/trusted.md"), "utf8")).resolves.toBe(
+        "network edit\n",
+      );
+      await expect(fs.readFile(path.join(workspaceDir, "memory/network.md"), "utf8")).resolves.toBe(
+        "network note\n",
+      );
+    } finally {
+      clearMemoryPluginState();
+    }
   });
 
   it("preserves before-tool wrapping through Codex runtime normalization", async () => {

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -335,6 +335,7 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
       toolBuildStages.mark(name);
     },
     onToolOutcome: params.onToolOutcome,
+    isTurnTainted: params.isTurnTainted,
     allocateToolOutcomeOrdinal: params.allocateToolOutcomeOrdinal,
   });
   const codexScopedTools = addCodexMessageToolOnlyFinalControl(

--- a/extensions/copilot/src/tool-bridge.test.ts
+++ b/extensions/copilot/src/tool-bridge.test.ts
@@ -1,7 +1,20 @@
 // Copilot tests cover tool bridge plugin behavior.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import type { Tool as SdkTool, ToolInvocation, ToolResultObject } from "@github/copilot-sdk";
 import { expectDefined } from "@openclaw/normalization-core";
-import type { AnyAgentTool, SandboxContext } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { createOpenClawCodingTools as createRealOpenClawCodingTools } from "openclaw/plugin-sdk/agent-harness";
+import {
+  type AnyAgentTool,
+  type SandboxContext,
+  wrapToolWithBeforeToolCallHook,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  clearMemoryPluginState,
+  type MemoryFlushPlan,
+  registerMemoryCapability,
+} from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createCopilotToolBridge } from "./tool-bridge.js";
 
@@ -602,6 +615,156 @@ describe("createCopilotToolBridge", () => {
       expect(opts.config).toBe(config);
       expect(opts.onToolOutcome).toBe(onToolOutcome);
       expect(opts.messageActionTurnCapability).toBe("turn-capability-1");
+    });
+
+    it("quarantines owner memory writes, edits, and patches after a network tool", async () => {
+      const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-copilot-memory-"));
+      await fs.mkdir(path.join(workspaceDir, "memory"));
+      const recordWriteProvenance = vi.fn<NonNullable<MemoryFlushPlan["recordWriteProvenance"]>>(
+        async () => undefined,
+      );
+      registerMemoryCapability("memory-core", {
+        flushPlanResolver: () => ({
+          softThresholdTokens: 1,
+          forceFlushTranscriptBytes: 1,
+          reserveTokensFloor: 1,
+          prompt: "flush",
+          systemPrompt: "flush",
+          relativePath: "memory/day.md",
+          recordWriteProvenance,
+        }),
+      });
+
+      try {
+        let turnTainted = false;
+        const onToolOutcome = vi.fn<
+          NonNullable<NonNullable<CopilotToolBridgeInput["attemptParams"]>["onToolOutcome"]>
+        >((outcome) => {
+          if (!outcome.presentationOnly && outcome.resultContentSource === "network") {
+            turnTainted = true;
+          }
+        });
+        const createTools = (rawOptions: unknown) => {
+          const options = rawOptions as NonNullable<
+            Parameters<typeof createRealOpenClawCodingTools>[0]
+          >;
+          const filesystemTools = createRealOpenClawCodingTools(options).filter((tool) =>
+            ["write", "edit", "apply_patch"].includes(tool.name),
+          );
+          const networkTool = wrapToolWithBeforeToolCallHook(
+            makeTool({ name: "web_fetch", resultContentSource: "network" }),
+            {
+              agentId: "main",
+              sessionKey: options.sessionKey,
+              sessionId: options.sessionId,
+              runId: options.runId,
+              onToolOutcome: options.onToolOutcome,
+            },
+            { emitDiagnostics: false },
+          );
+          return [...filesystemTools, networkTool];
+        };
+        const sessionKey = "agent:main:copilot-memory-session";
+        const bridge = await createCopilotToolBridge({
+          agentId: "main",
+          attemptParams: {
+            config: { tools: { fs: { workspaceOnly: true } } },
+            onToolOutcome,
+            isTurnTainted: () => turnTainted,
+            runId: "copilot-memory-run",
+            senderIsOwner: true,
+            sessionKey,
+            workspaceDir,
+          },
+          createOpenClawCodingTools: createTools,
+          modelId: "gpt-4o",
+          modelProvider: "github-copilot",
+          sessionId: "copilot-memory-session",
+          sessionKey,
+          workspaceDir,
+        });
+        const tool = (name: string) =>
+          expectDefined(
+            bridge.sdkTools.find((candidate) => candidate.name === name),
+            `Copilot ${name} tool`,
+          );
+        await runSdkTool(tool("write"), {
+          path: "memory/trusted.md",
+          content: "owner note\n",
+        });
+        await runSdkTool(
+          tool("web_fetch"),
+          {},
+          makeInvocation({
+            sessionId: "copilot-memory-session",
+            toolCallId: "copilot-network-call",
+            toolName: "web_fetch",
+          }),
+        );
+        expect(onToolOutcome).toHaveBeenCalledWith(
+          expect.objectContaining({ toolName: "web_fetch", resultContentSource: "network" }),
+        );
+        expect(turnTainted).toBe(true);
+
+        await runSdkTool(tool("write"), {
+          path: "memory/network.md",
+          content: "network note\n",
+        });
+        await runSdkTool(tool("edit"), {
+          path: "memory/trusted.md",
+          edits: [{ oldText: "owner note", newText: "network edit" }],
+        });
+        await runSdkTool(tool("apply_patch"), {
+          input: [
+            "*** Begin Patch",
+            "*** Add File: memory/patched.md",
+            "+network patch",
+            "*** End Patch",
+          ].join("\n"),
+        });
+
+        const freshBridge = await createCopilotToolBridge({
+          agentId: "main",
+          attemptParams: {
+            config: { tools: { fs: { workspaceOnly: true } } },
+            isTurnTainted: () => false,
+            runId: "copilot-fresh-run",
+            senderIsOwner: true,
+            sessionKey: "agent:main:copilot-fresh-session",
+            workspaceDir,
+          },
+          createOpenClawCodingTools: createTools,
+          modelId: "gpt-4o",
+          modelProvider: "github-copilot",
+          sessionId: "copilot-fresh-session",
+          sessionKey: "agent:main:copilot-fresh-session",
+          workspaceDir,
+        });
+        await runSdkTool(
+          expectDefined(
+            freshBridge.sdkTools.find((candidate) => candidate.name === "write"),
+            "fresh Copilot write tool",
+          ),
+          { path: "memory/fresh.md", content: "fresh owner note\n" },
+        );
+
+        expect(recordWriteProvenance.mock.calls.map(([entry]) => entry.originClass)).toEqual([
+          "agent",
+          "untrusted",
+          "untrusted",
+          "untrusted",
+          "agent",
+        ]);
+        await expect(
+          fs.readFile(path.join(workspaceDir, "memory/trusted.md"), "utf8"),
+        ).resolves.toBe("network edit\n");
+        await expect(
+          fs.readFile(path.join(workspaceDir, "memory/patched.md"), "utf8"),
+        ).resolves.toBe("network patch\n");
+      } finally {
+        clearMemoryPluginState();
+        await fs.rm(workspaceDir, { recursive: true, force: true });
+      }
     });
 
     it("prefers the unscoped toolAuthProfileStore when building OpenClaw tools", async () => {

--- a/extensions/copilot/src/tool-bridge.ts
+++ b/extensions/copilot/src/tool-bridge.ts
@@ -446,6 +446,7 @@ function buildOpenClawCodingToolsOptions(
     // recordToolPrepStage intentionally omitted: copilot does not
     // surface attempt-stage telemetry yet. Codex omits this too.
     onToolOutcome: a.onToolOutcome,
+    isTurnTainted: a.isTurnTainted,
     onYield: (message) => {
       // Notify the caller first so the final attempt result can carry
       // yieldDetected even if the abort below races a concurrent


### PR DESCRIPTION
## Summary
- propagate the existing live network-taint callback through Copilot's canonical filesystem tool bridge and Codex's explicitly exposed dynamic filesystem tool builder
- ensure network-observed memory writes, edits and Copilot apply_patch are recorded as untrusted while operator-authored writes before observation and fresh turns remain trusted
- preserve both providers' SDK contracts, raw tool outputs and session boundaries with only two production-line changes

## Mandatory upstream dependency proof
Personally inspected the sibling Codex source at ../codex/codex-rs/protocol/src/dynamic_tools.rs:58, ../codex/codex-rs/core/src/tools/handlers/dynamic.rs:150, ../codex/codex-rs/app-server/src/dynamic_tools.rs:37, and ../codex/codex-rs/core/src/tools/spec_plan.rs:636. Copilot's actual installed SDK override behavior was also verified.

## Explicit coverage boundary
Default Copilot write/edit/apply_patch and the explicitly QA-exposed Codex write/edit bridge are fixed. Ordinary native Codex shell/native filesystem operations and generic shell-mediated writes do not cross this dynamic-tool owner and remain separate architectural gaps; this PR does not claim otherwise.

## Verification
- 137 focused provider, bridge, turn-taint and persistent-memory provenance tests passed
- independently reproduced trusted-before-network -> untrusted-after-network -> trusted-fresh-turn transitions
- one independent formal structured security review clean, confidence 0.96; production delta **+2 lines**


## Inspectable exact-head actual provider runtime proof

Exact published head 5182c5b0af638c234f110ba8499937e62de88856 executed both actual production provider bridges and real temporary filesystem owners in hosted CI; network tool outcomes were synthetic and no real provider credentials or requests were used.

- Codex exact owner job: https://github.com/openclaw/openclaw/actions/runs/30832464156/job/91749679419 — "quarantines exposed Codex memory writes and edits after a network tool"; 58/58 passed. Actual sequence write trusted -> web_fetch(network) -> write network -> edit trusted -> fresh-turn write; recorded provenance [agent, untrusted, untrusted, agent].
- Copilot exact owner job: https://github.com/openclaw/openclaw/actions/runs/30832464156/job/91749679389 — "quarantines owner memory writes, edits, and patches after a network tool"; 79/79 passed. Actual sequence write trusted -> web_fetch(network) -> write network -> edit trusted -> apply_patch -> fresh-turn write; recorded provenance [agent, untrusted, untrusted, untrusted, agent].
- Combined actual provider-owner coverage: 137/137 passing. Exact-head required CI gate: https://github.com/openclaw/openclaw/actions/runs/30832464156/job/91750927842.
- The independent reviewer personally inspected ../codex/codex-rs/protocol/src/dynamic_tools.rs:45-62, ../codex/codex-rs/app-server-protocol/src/protocol/common.rs:1535-1538, ../codex/codex-rs/core/src/tools/handlers/dynamic.rs:113-160, and ../codex/codex-rs/core/src/tools/spec_plan.rs:636-644; installed Copilot SDK override/skipPermission behavior was also inspected directly.
- Ordinary native Codex shell/filesystem operations remain explicitly outside this dynamic bridge, as documented above.
