### PR TITLE
fix(test): keep ui-e2e global setup lint-clean

### DIFF
--- a/test/vitest/vitest.ui-e2e.global-setup.ts
+++ b/test/vitest/vitest.ui-e2e.global-setup.ts
@@ -18,14 +18,15 @@ export default async function setup(project: TestProject) {
   const executablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
   if (!canRunPlaywrightChromium(executablePath)) {
     project.provide("controlUiE2eServerBaseUrl", null);
-    return;
+    // No-op teardown keeps both paths value-returning for Vitest's setup contract.
+    return () => {};
   }
 
   // Local full-suite runs can fan shards into separate processes in one checkout.
   // Keep every build out of canonical dist so those processes cannot clobber it.
   const tempDirs = createTempDirTracker();
   const outDir = tempDirs.make("openclaw-ui-e2e-");
-  const server = await startBundledControlUiE2eServer(outDir).catch(async (error) => {
+  const server = await startBundledControlUiE2eServer(outDir).catch(async (error: unknown) => {
     try {
       tempDirs.cleanup();
     } catch {}


### PR DESCRIPTION
## What Problem This Solves

`pnpm lint:all` regressed to nonzero within hours of becoming a zero-noise gate (#118256): commit 73535e4ede7 (#118697) introduced two violations in `test/vitest/vitest.ui-e2e.global-setup.ts` — a `consistent-return` (one path returned bare, the other returned a teardown) and a non-`unknown` catch callback variable.

## Why This Change Was Made

The skip path now returns a no-op teardown so both paths are value-returning under Vitest's global-setup contract, and the catch callback is typed `unknown`. Behavior is unchanged.

## User Impact

None — test infrastructure only; the lint gate is zero-noise again.

## Evidence

- `node scripts/run-oxlint.mjs test/vitest/vitest.ui-e2e.global-setup.ts`: clean
- `pnpm tsgo:test`: clean; formatting clean
- Structured autoreview: clean (0.99)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
