### PR TITLE
fix: CLI does not resolve SecretRef from gateway.systemd.env

### DIFF
--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -627,7 +627,7 @@ function decodeSystemdEnvironmentFileValue(rawValue: string): {
   return { value: decoded, literalDollar };
 }
 
-function parseEnvironmentFileLine(
+export function parseEnvironmentFileLine(
   rawLine: string,
 ): { key: string; value: string; literalShellReference: boolean } | null {
   const trimmedStart = rawLine.trimStart();

--- a/src/infra/dotenv-global.test.ts
+++ b/src/infra/dotenv-global.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { readDotEnvFile } from "./dotenv-global.js";
+import { loadGlobalRuntimeDotEnvFiles, readDotEnvFile } from "./dotenv-global.js";
 
 const logWarnSpy = vi.hoisted(() => vi.fn());
 
@@ -75,5 +75,74 @@ describe("readDotEnvFile", () => {
     expect(logWarnSpy).toHaveBeenCalledWith(
       expect.stringContaining("skipping oversized .env file (max"),
     );
+  });
+});
+
+describe("loadGlobalRuntimeDotEnvFiles", () => {
+  it("loads env vars from gateway.systemd.env and node.systemd.env", () => {
+    const d = tmpDir();
+    const stateEnvPath = join(d, ".env");
+    writeFileSync(stateEnvPath, "ONLY_IN_DOTENV=from-dotenv\n", "utf8");
+    writeFileSync(
+      join(d, "gateway.systemd.env"),
+      "GATEWAY_SYSTEMD_VAR=from-gateway-systemd\n",
+      "utf8",
+    );
+    writeFileSync(join(d, "node.systemd.env"), "NODE_SYSTEMD_VAR=from-node-systemd\n", "utf8");
+
+    const savedEnvKeys = new Set(["ONLY_IN_DOTENV", "GATEWAY_SYSTEMD_VAR", "NODE_SYSTEMD_VAR"]);
+    const savedEnv: Record<string, string | undefined> = {};
+    try {
+      for (const key of savedEnvKeys) {
+        savedEnv[key] = process.env[key];
+        delete process.env[key];
+      }
+
+      const result = loadGlobalRuntimeDotEnvFiles({
+        stateEnvPath,
+        quiet: true,
+      });
+
+      expect(process.env.ONLY_IN_DOTENV).toBe("from-dotenv");
+      expect(process.env.GATEWAY_SYSTEMD_VAR).toBe("from-gateway-systemd");
+      expect(process.env.NODE_SYSTEMD_VAR).toBe("from-node-systemd");
+
+      const allApplied = [...(result?.stateEnvAppliedKeys ?? [])];
+      expect(allApplied).toContain("ONLY_IN_DOTENV");
+    } finally {
+      for (const key of savedEnvKeys) {
+        if (savedEnv[key] !== undefined) {
+          process.env[key] = savedEnv[key];
+        } else {
+          delete process.env[key];
+        }
+      }
+    }
+  });
+
+  it("does not override existing env vars from systemd env files", () => {
+    const d = tmpDir();
+    const stateEnvPath = join(d, ".env");
+    writeFileSync(stateEnvPath, "", "utf8");
+    writeFileSync(join(d, "gateway.systemd.env"), "EXISTING_VAR=from-systemd\n", "utf8");
+
+    const saved = process.env.EXISTING_VAR;
+    try {
+      process.env.EXISTING_VAR = "already-set";
+
+      loadGlobalRuntimeDotEnvFiles({
+        stateEnvPath,
+        quiet: true,
+      });
+
+      // Should not override the existing value.
+      expect(process.env.EXISTING_VAR).toBe("already-set");
+    } finally {
+      if (saved !== undefined) {
+        process.env[saved] = saved;
+      } else {
+        delete process.env.EXISTING_VAR;
+      }
+    }
   });
 });

--- a/src/infra/dotenv-global.test.ts
+++ b/src/infra/dotenv-global.test.ts
@@ -2,7 +2,11 @@ import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { loadGlobalRuntimeDotEnvFiles, readDotEnvFile } from "./dotenv-global.js";
+import {
+  loadGlobalRuntimeDotEnvFiles,
+  readDotEnvFile,
+  readSystemdEnvironmentFile,
+} from "./dotenv-global.js";
 
 const logWarnSpy = vi.hoisted(() => vi.fn());
 
@@ -78,6 +82,57 @@ describe("readDotEnvFile", () => {
   });
 });
 
+describe("readSystemdEnvironmentFile", () => {
+  it("reads a systemd env file with unescaped values", () => {
+    const filePath = tmpFile("gateway.systemd.env", "API_KEY=secret\nOTHER_KEY=value\n");
+    const result = readSystemdEnvironmentFile({ filePath });
+    expect(result).not.toBeNull();
+    expect(result!.entries).toContainEqual({ key: "API_KEY", value: "secret" });
+    expect(result!.entries).toContainEqual({ key: "OTHER_KEY", value: "value" });
+  });
+
+  it("decodes systemd-escaped special characters", () => {
+    // The service writer escapes \, ", `, $ inside double quotes.
+    // These deserialize to the literal character.
+    const filePath = tmpFile("gateway.systemd.env", 'TOKEN="abc\\$def\\\\ghi\\"jkl\\`mno"\n');
+    const result = readSystemdEnvironmentFile({ filePath });
+    expect(result).not.toBeNull();
+    expect(result!.entries).toContainEqual({
+      key: "TOKEN",
+      value: 'abc$def\\ghi"jkl`mno',
+    });
+  });
+
+  it("decodes single-quoted values literally", () => {
+    // systemd single-quoted values are literal.
+    const filePath = tmpFile("gateway.systemd.env", "PLAIN='literal$value'\n");
+    const result = readSystemdEnvironmentFile({ filePath });
+    expect(result).not.toBeNull();
+    expect(result!.entries).toContainEqual({
+      key: "PLAIN",
+      value: "literal$value",
+    });
+  });
+
+  it("skips comments and blank lines", () => {
+    const filePath = tmpFile("gateway.systemd.env", "# comment\n; also comment\n\nKEY=value\n");
+    const result = readSystemdEnvironmentFile({ filePath });
+    expect(result).not.toBeNull();
+    expect(result!.entries).toHaveLength(1);
+    expect(result!.entries).toContainEqual({ key: "KEY", value: "value" });
+  });
+
+  it("returns null for a missing file (quiet)", () => {
+    const d = tmpDir();
+    const result = readSystemdEnvironmentFile({
+      filePath: join(d, "nonexistent.env"),
+      quiet: true,
+    });
+    expect(result).toBeNull();
+    expect(logWarnSpy).not.toHaveBeenCalled();
+  });
+});
+
 describe("loadGlobalRuntimeDotEnvFiles", () => {
   it("loads env vars from gateway.systemd.env and node.systemd.env", () => {
     const d = tmpDir();
@@ -139,9 +194,47 @@ describe("loadGlobalRuntimeDotEnvFiles", () => {
       expect(process.env.EXISTING_VAR).toBe("already-set");
     } finally {
       if (saved !== undefined) {
-        process.env[saved] = saved;
+        process.env.EXISTING_VAR = saved;
       } else {
         delete process.env.EXISTING_VAR;
+      }
+    }
+  });
+
+  it("decodes systemd-escaped token values from systemd env files", () => {
+    const d = tmpDir();
+    const stateEnvPath = join(d, ".env");
+    writeFileSync(stateEnvPath, "", "utf8");
+    // Simulate a token the service writer would produce:
+    // It escapes \, ", `, $ inside double quotes.
+    writeFileSync(
+      join(d, "gateway.systemd.env"),
+      'GATEWAY_TOKEN="abc\\$def\\\\ghi\\"jkl\\`mno"\nMISSING_FILE_TOKEN=from-gateway-systemd\n',
+      "utf8",
+    );
+    writeFileSync(join(d, "node.systemd.env"), "NODE_KEY=node-val\n", "utf8");
+
+    const savedEnvKeys = new Set(["GATEWAY_TOKEN", "MISSING_FILE_TOKEN", "NODE_KEY"]);
+    const savedEnv: Record<string, string | undefined> = {};
+    try {
+      for (const key of savedEnvKeys) {
+        savedEnv[key] = process.env[key];
+        delete process.env[key];
+      }
+
+      loadGlobalRuntimeDotEnvFiles({ stateEnvPath, quiet: true });
+
+      // The escaped token should decode to the literal characters.
+      expect(process.env.GATEWAY_TOKEN).toBe('abc$def\\ghi"jkl`mno');
+      expect(process.env.MISSING_FILE_TOKEN).toBe("from-gateway-systemd");
+      expect(process.env.NODE_KEY).toBe("node-val");
+    } finally {
+      for (const key of savedEnvKeys) {
+        if (savedEnv[key] !== undefined) {
+          process.env[key] = savedEnv[key];
+        } else {
+          delete process.env[key];
+        }
       }
     }
   });

--- a/src/infra/dotenv-global.test.ts
+++ b/src/infra/dotenv-global.test.ts
@@ -114,6 +114,25 @@ describe("readSystemdEnvironmentFile", () => {
     });
   });
 
+  it("preserves last assignment for duplicate keys within a file", () => {
+    // systemd service readers overwrite per-key; the last assignment wins.
+    // readSystemdEnvironmentFile must match that so CLI auth uses the same
+    // value the service would.
+    const filePath = tmpFile(
+      "gateway.systemd.env",
+      "TOKEN=stale_old_token\nTOKEN=current_new_token\nOTHER=val\nTOKEN=final_token\n",
+    );
+    const result = readSystemdEnvironmentFile({ filePath });
+    expect(result).not.toBeNull();
+    expect(result!.entries).toContainEqual({
+      key: "TOKEN",
+      value: "final_token",
+    });
+    expect(result!.entries).toContainEqual({ key: "OTHER", value: "val" });
+    // Only one TOKEN entry (deduplicated) plus OTHER.
+    expect(result!.entries).toHaveLength(2);
+  });
+
   it("skips comments and blank lines", () => {
     const filePath = tmpFile("gateway.systemd.env", "# comment\n; also comment\n\nKEY=value\n");
     const result = readSystemdEnvironmentFile({ filePath });

--- a/src/infra/dotenv-global.ts
+++ b/src/infra/dotenv-global.ts
@@ -163,6 +163,20 @@ export function loadGlobalRuntimeDotEnvFiles(opts?: GlobalRuntimeDotEnvOptions) 
     });
     parsedFiles.push(gatewayEnv);
   }
+
+  // Also load systemd env files from the state directory so CLI commands (e.g. status)
+  // can resolve env-based SecretRefs when the gateway is not reachable locally.
+  const stateEnvDir = path.dirname(stateEnvPath);
+  for (const filename of ["gateway.systemd.env", "node.systemd.env"]) {
+    const systemdEnv = readDotEnvFile({
+      entryFilter: opts?.entryFilter,
+      filePath: path.join(stateEnvDir, filename),
+      quiet,
+    });
+    if (systemdEnv) {
+      parsedFiles.push(systemdEnv);
+    }
+  }
   const parsed = parsedFiles.filter((file): file is LoadedDotEnvFile => file !== null);
   const appliedKeysByFile = loadParsedDotEnvFiles(parsed);
   return {

--- a/src/infra/dotenv-global.ts
+++ b/src/infra/dotenv-global.ts
@@ -114,7 +114,12 @@ export function readSystemdEnvironmentFile(params: {
     return null;
   }
 
-  const entries: DotEnvEntry[] = [];
+  // Collect entries last-wins per key to match the service's runtime
+  // semantics (environment[parsed.key] = parsed.value).  A repeated key
+  // inside the same EnvironmentFile must resolve to the final assignment;
+  // the cross-file merge that follows is first-wins, so per-file last-wins
+  // avoids the CLI picking a stale token when the service uses a newer one.
+  const entryMap = new Map<string, string>();
   for (const line of content.split(/\r?\n/)) {
     const parsed = parseEnvironmentFileLine(line);
     if (!parsed) {
@@ -122,8 +127,12 @@ export function readSystemdEnvironmentFile(params: {
     }
     const key = normalizeEnvVarKey(parsed.key, { portable: true });
     if (key && (params.entryFilter?.(key, parsed.value) ?? true)) {
-      entries.push({ key, value: parsed.value });
+      entryMap.set(key, parsed.value);
     }
+  }
+  const entries: DotEnvEntry[] = [];
+  for (const [key, value] of entryMap) {
+    entries.push({ key, value });
   }
   return { filePath: params.filePath, entries };
 }

--- a/src/infra/dotenv-global.ts
+++ b/src/infra/dotenv-global.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { parse as parseDotEnv } from "dotenv";
+import { parseEnvironmentFileLine } from "../daemon/systemd.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveConfigDir } from "../utils.js";
 import { resolveRequiredHomeDir } from "./home-dir.js";
@@ -71,6 +72,57 @@ export function readDotEnvFile(params: {
     const key = normalizeEnvVarKey(rawKey, { portable: true });
     if (key && (params.entryFilter?.(key, value) ?? true)) {
       entries.push({ key, value });
+    }
+  }
+  return { filePath: params.filePath, entries };
+}
+
+/**
+ * Read a systemd EnvironmentFile using the canonical systemd grammar.
+ *
+ * Unlike dotenv files, systemd EnvironmentFiles use their own escaping rules:
+ * double-quoted values unescape only \", \\, \`, and \$; single-quoted
+ * values are literal except for the closing quote; backslash outside quotes
+ * escapes the following character.
+ */
+export function readSystemdEnvironmentFile(params: {
+  entryFilter?: (key: string, value: string) => boolean;
+  filePath: string;
+  quiet?: boolean;
+}): LoadedDotEnvFile | null {
+  let content: string;
+  try {
+    const resolved = fs.realpathSync(params.filePath);
+    const { buffer } = readRegularFileSync({
+      filePath: resolved,
+      maxBytes: MAX_DOTENV_FILE_BYTES,
+    });
+    content = buffer.toString("utf8");
+  } catch (error) {
+    if (!params.quiet) {
+      const code =
+        error && typeof error === "object" && "code" in error ? String(error.code) : undefined;
+      if (code !== "ENOENT") {
+        logger.warn(`Failed to read ${params.filePath}: ${String(error)}`, { error });
+      }
+      if (error instanceof Error && error.message?.startsWith("File exceeds")) {
+        logger.warn(
+          `skipping oversized systemd env file (max ${MAX_DOTENV_FILE_BYTES} bytes): ${params.filePath}`,
+        );
+      }
+    }
+    return null;
+  }
+
+  const entries: DotEnvEntry[] = [];
+  for (const line of content.split(/\r?\n/)) {
+    const parsed = parseEnvironmentFileLine(line);
+    if (!parsed) {
+      continue;
+    }
+    const key = normalizeEnvVarKey(parsed.key, { portable: true });
+    if (key && (params.entryFilter?.(key, parsed.value) ?? true)) {
+      entries.push({ key, value: parsed.value });
     }
   }
   return { filePath: params.filePath, entries };
@@ -166,9 +218,11 @@ export function loadGlobalRuntimeDotEnvFiles(opts?: GlobalRuntimeDotEnvOptions) 
 
   // Also load systemd env files from the state directory so CLI commands (e.g. status)
   // can resolve env-based SecretRefs when the gateway is not reachable locally.
+  // These use the canonical systemd EnvironmentFile grammar, not dotenv parsing,
+  // because the service writer escapes $, \, `, and " using systemd-specific rules.
   const stateEnvDir = path.dirname(stateEnvPath);
   for (const filename of ["gateway.systemd.env", "node.systemd.env"]) {
-    const systemdEnv = readDotEnvFile({
+    const systemdEnv = readSystemdEnvironmentFile({
       entryFilter: opts?.entryFilter,
       filePath: path.join(stateEnvDir, filename),
       quiet,


### PR DESCRIPTION
Closes #118733

## What Problem This Solves

Addresses #118733: CLI does not resolve SecretRef from gateway.systemd.env

## Why This Change Was Made

The implementation is intentionally scoped to the reported failure and its regression coverage.

## User Impact

The behavior described in the linked issue is corrected without unrelated changes.

## Evidence

```text
pnpm vitest run src/infra/dotenv-global.test.ts --reporter=verbose
RUN  v4.1.10 /workspace

 ✓  infra  ../../src/infra/dotenv-global.test.ts > readDotEnvFile > reads a small .env file 822ms
 ✓  infra  ../../src/infra/dotenv-global.test.ts > readDotEnvFile > reads a symlinked .env file 1ms
 ✓  infra  ../../src/infra/dotenv-global.test.ts > readDotEnvFile > returns null for a missing file (quiet) 1ms
 ✓  infra  ../../src/infra/dotenv-global.test.ts > readDotEnvFile > warns when an oversized .env file is skipped 4ms
 ✓  infra  ../../src/infra/dotenv-global.test.ts > readSystemdEnvironmentFile > reads a systemd env file with unescaped values 1ms
 ✓  infra  ../../src/infra/dotenv-global.test.ts > readSystemdEnvironmentFile > decodes systemd-escaped special characters 1ms
 ✓  infra  ../../src/infra/dotenv-global.test.ts > readSystemdEnvironmentFile > decodes single-quoted values literally 1ms
 ✓  infra  ../../src/infra/dotenv-global.test.ts > readSystemdEnvironmentFile > preserves last assignment for duplicate keys within a file 1ms
 ✓  infra  ../../src/infra/dotenv-global.test.ts > readSystemdEnvironmentFile > skips comments and blank lines 1ms
 ✓  infra  ../../src/infra/dotenv-global.test.ts > readSystemdEnvironmentFile > returns null for a missing file (quiet) 1ms
 ✓  infra  ../../src/infra/dotenv-global.test.ts > loadGlobalRuntimeDotEnvFiles > loads env vars from gateway.systemd.env and node.systemd.env 2ms
 ✓  infra  ../../src/infra/dotenv-global.test.ts > loadGlobalRuntimeDotEnvFiles > does not override existing env vars from systemd env files 1ms
 ✓  infra  ../../src/infra/dotenv-global.test.ts > loadGlobalRuntimeDotEnvFiles > decodes systemd-escaped token values from systemd env files 1ms

 Test Files  1 passed (1)
      Tests  13 passed (13)
   Start at  20:13:48
   Duration  2.44s (transform 1.78s, setup 1.11s, import 356ms, tests 841ms, environment 0ms)

[PLUGIN_TIMINGS] Your build spent significant time in plugin `inject-file-scope-variables`. See https://rolldown.rs/reference/InputOptions.checks#plugintimings for more details.


Checking formatting...

All matched files use the correct format.
Finished in 20ms on 3 files using 2 threads.

Found 0 warnings and 0 errors.
Finished in 16ms on 3 files with 212 rules using 2 threads.
```

## AI-assisted development

This change was implemented with an OpenClaw coding agent and published through a guarded human-approval workflow. The exact diff and focused validation evidence were verified before publication.

Artifact SHA-256: `657bdf57c3a4aff69a9a5343892402797e1a36754cf2c81d4e5cd6b26f152229`
