### PR TITLE
fix(parallels): preserve real Windows launch outcomes after setup timeouts

### DIFF
--- a/scripts/e2e/parallels/guest-transports.ts
+++ b/scripts/e2e/parallels/guest-transports.ts
@@ -443,7 +443,9 @@ if (!(Test-Path $scriptPath)) { throw "${safeLabel} background script was not wr
   try {
     let launched = false;
     let lastLaunchStatus = 0;
-    for (let attempt = 1; attempt <= 5 && Date.now() < deadline; attempt++) {
+    // Setup can consume the active budget before the first launch; still observe
+    // its real result before using the deadline to suppress later attempts.
+    for (let attempt = 1; attempt <= 5 && (attempt === 1 || Date.now() < deadline); attempt++) {
       options.beforeLaunchAttempt?.();
       const launch = runCommand(
         "prlctl",
@@ -499,7 +501,9 @@ cmd.exe /d /s /c start "" /b powershell.exe -NoProfile -ExecutionPolicy Bypass -
     }
     if (!launched) {
       throw new Error(
-        `${options.label} background launch failed with exit code ${lastLaunchStatus}`,
+        Date.now() >= deadline
+          ? `${options.label} timed out`
+          : `${options.label} background launch failed with exit code ${lastLaunchStatus}`,
       );
     }
 

--- a/scripts/e2e/parallels/guest-transports.ts
+++ b/scripts/e2e/parallels/guest-transports.ts
@@ -501,16 +501,18 @@ cmd.exe /d /s /c start "" /b powershell.exe -NoProfile -ExecutionPolicy Bypass -
     }
     if (!launched) {
       throw new Error(
-        Date.now() >= deadline
-          ? `${options.label} timed out`
-          : `${options.label} background launch failed with exit code ${lastLaunchStatus}`,
+        `${options.label} background launch failed with exit code ${lastLaunchStatus}`,
       );
     }
 
     let completedLogDrainDeadline = 0;
     let doneFileSeen = false;
+    let completionProbeAttempted = false;
     const activeDeadline = () => (doneFileSeen ? completedLogDrainDeadline : deadline);
-    while (Date.now() < activeDeadline()) {
+    // A process can finish while setup exhausts the active budget; inspect its
+    // completion marker once before deciding whether cleanup must stop it.
+    while (!completionProbeAttempted || Date.now() < activeDeadline()) {
+      completionProbeAttempted = true;
       const doneProbe = runCommand(
         "prlctl",
         [

--- a/test/scripts/parallels-npm-update-smoke.test.ts
+++ b/test/scripts/parallels-npm-update-smoke.test.ts
@@ -839,6 +839,59 @@ exit 1
     expect(commands).not.toContain("ReadAllBytes");
   });
 
+  it.each([
+    {
+      scenario: "a successfully launched job",
+      launchStatus: 0,
+      launchOutput: "started\n",
+      expectedError: "windows setup deadline timed out",
+    },
+    {
+      scenario: "a launch that never materializes",
+      launchStatus: 0,
+      launchOutput: "",
+      expectedError: "windows setup deadline timed out",
+    },
+    {
+      scenario: "a genuine launch failure",
+      launchStatus: 17,
+      launchOutput: "",
+      expectedError: "windows setup deadline background launch failed with exit code 17",
+    },
+  ])("preserves $scenario when Windows setup exhausts its active budget", async (testCase) => {
+    let now = 1_000;
+    const clock = vi.spyOn(Date, "now").mockImplementation(() => now);
+    let launchAttempts = 0;
+    const fakeRun: typeof hostCommandRun = (_command, args, options) => {
+      if (options?.input) {
+        now += 2;
+        return { status: 0, stderr: "", stdout: "" };
+      }
+      const decoded = decodePowerShellFromArgs(args);
+      if (decoded.includes('cmd.exe /d /s /c start "" /b powershell.exe')) {
+        launchAttempts++;
+        return { status: testCase.launchStatus, stderr: "", stdout: testCase.launchOutput };
+      }
+      return { status: 0, stderr: "", stdout: "" };
+    };
+
+    try {
+      await expect(
+        runWindowsBackgroundPowerShell({
+          label: "windows setup deadline",
+          pollIntervalMs: 1,
+          runCommand: fakeRun,
+          script: "Write-Output test",
+          timeoutMs: 5,
+          vmName: "Windows Test",
+        }),
+      ).rejects.toThrow(testCase.expectedError);
+      expect(launchAttempts).toBe(1);
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
   it("does not treat Windows background log text as completion control", async () => {
     const decodedCommands: string[] = [];
     const fakeRun: typeof hostCommandRun = (_command, args) => {

--- a/test/scripts/parallels-npm-update-smoke.test.ts
+++ b/test/scripts/parallels-npm-update-smoke.test.ts
@@ -850,7 +850,7 @@ exit 1
       scenario: "a launch that never materializes",
       launchStatus: 0,
       launchOutput: "",
-      expectedError: "windows setup deadline timed out",
+      expectedError: "windows setup deadline background launch failed with exit code 0",
     },
     {
       scenario: "a genuine launch failure",
@@ -887,6 +887,57 @@ exit 1
         }),
       ).rejects.toThrow(testCase.expectedError);
       expect(launchAttempts).toBe(1);
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
+  it("drains a completed Windows job when setup exhausts the active budget", async () => {
+    let now = 1_000;
+    const clock = vi.spyOn(Date, "now").mockImplementation(() => now);
+    let completionProbes = 0;
+    let logProbes = 0;
+    const fakeRun: typeof hostCommandRun = (_command, args, options) => {
+      if (options?.input) {
+        now += 2;
+        return { status: 0, stderr: "", stdout: "" };
+      }
+      const decoded = decodePowerShellFromArgs(args);
+      if (decoded.includes('cmd.exe /d /s /c start "" /b powershell.exe')) {
+        return { status: 0, stderr: "", stdout: "started\n" };
+      }
+      if (args.includes("cmd.exe")) {
+        const command = args.at(-1) ?? "";
+        if (command.includes("__OPENCLAW_BACKGROUND_DONE__")) {
+          logProbes++;
+          const markers = extractWindowsBackgroundControlMarkers(command);
+          return {
+            status: 0,
+            stderr: "",
+            stdout: [`${markers.exitPrefix}0`, markers.done, ""].join("\n"),
+          };
+        }
+        if (command.includes("(echo done) else (echo wait)")) {
+          completionProbes++;
+          return { status: 0, stderr: "", stdout: "done\n" };
+        }
+      }
+      return { status: 0, stderr: "", stdout: "" };
+    };
+
+    try {
+      await expect(
+        runWindowsBackgroundPowerShell({
+          label: "windows completed before first poll",
+          pollIntervalMs: 1,
+          runCommand: fakeRun,
+          script: "Write-Output done",
+          timeoutMs: 5,
+          vmName: "Windows Test",
+        }),
+      ).resolves.toBeUndefined();
+      expect(completionProbes).toBe(1);
+      expect(logProbes).toBe(1);
     } finally {
       clock.mockRestore();
     }


### PR DESCRIPTION
## Summary
- fix a pre-existing Windows/Parallels background lifecycle race that currently makes unrelated hosted CI shards fail with the impossible message "background launch failed with exit code 0"
- ensure a successfully staged job receives one actual launch attempt even when setup exhausted its active phase budget; preserve genuine launch failure exit codes, timeout classification, cleanup reserve, and retry limits
- add deterministic fake-clock coverage for successful startup, unmaterialized startup, and an actual nonzero launch failure

## Root cause and observed CI impact
The active deadline started before PowerShell payload staging. Under loaded CI, the existing 5 ms owner tests exhausted that deadline before the launch loop executed; its initialized zero status was then incorrectly reported as a real failure. This exact pre-existing bug independently blocked provider/security PRs #118729 and #118745.

## Verification
- 38/38 full focused owner tests passed; the five critical original/new cases also passed across five bounded repetitions
- the three controlled-clock regressions failed before repair and pass afterward
- production delta +4 lines; no timeout increase, retry expansion, VM, network, credentials, or mocked-away failure
- exactly one independent structured formal review raised a proposed P1 claiming actual exit code 17 would be rewritten as a timeout; direct root inspection rejected it as a false positive because genuine nonzero launch statuses throw immediately INSIDE the loop before the post-loop timeout branch, and the deterministic exit-17 regression proves this exact control flow


## Final correction and ClawSweeper rank-up disposition

Exact reviewed head 3770f4b716264620a22632911b2b3f9b198a1722 additionally guarantees the first authenticated completion probe and restores the historical ambiguous-launch failure contract. Both complete Windows owner/sibling suites pass 137/137; eight critical lifecycle cases pass in five independent bounded repetitions. The previously failing hosted checks-node-compact-small-4 job now passes at https://github.com/openclaw/openclaw/actions/runs/30833860048/job/91754352583 and the full required gate passes at https://github.com/openclaw/openclaw/actions/runs/30833860048/job/91756082994. The final independent structured security review is clean, confidence 0.93.

An actual Parallels Windows guest transcript is unavailable on this host because prlctl/a runnable guest is not installed; the rank-up request is therefore explicitly skipped rather than misrepresented. Actual owner PowerShell transport, nonce/authenticated completion, successful log draining, ambiguous status-zero failures, true nonzero failures, expired setup budgets and cleanup are verified by the complete existing owner suites and the exact formerly failing hosted CI shard.
