### PR TITLE
fix(doctor): refresh live SQLite session caches after durable repairs

### DIFF
--- a/src/commands/doctor-session-delivery-state.test.ts
+++ b/src/commands/doctor-session-delivery-state.test.ts
@@ -7,13 +7,18 @@ import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
   resolveOpenClawAgentSqlitePath,
+  runOpenClawAgentWriteTransaction,
 } from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { repairCanonicalSessionDeliveryStates } from "./doctor-session-delivery-state.js";
+import { writeValidatedDoctorSessionEntryJson } from "./doctor-session-entry-rewrite.js";
+import { repairReservedIncognitoSessionKeys } from "./doctor-session-incognito-key-repair.js";
 
 const tempDirs = createTempDirTracker();
 
 afterEach(() => {
   closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
   tempDirs.cleanup();
 });
 
@@ -21,13 +26,21 @@ function insertSessionRow(
   env: NodeJS.ProcessEnv,
   sessionKey: string,
   entry: Record<string, unknown>,
+  agentId = "main",
 ): void {
-  const database = openOpenClawAgentDatabase({ agentId: "main", env });
+  const database = openOpenClawAgentDatabase({ agentId, env });
   database.db
     .prepare(
-      "INSERT INTO session_nodes (session_key, current_session_id, entry_json, updated_at) VALUES (?, ?, ?, ?)",
+      "INSERT INTO session_nodes (session_key, current_session_id, entry_json, updated_at, parent_session_key, spawned_by) VALUES (?, ?, ?, ?, ?, ?)",
     )
-    .run(sessionKey, String(entry.sessionId), JSON.stringify(entry), Number(entry.updatedAt));
+    .run(
+      sessionKey,
+      String(entry.sessionId),
+      JSON.stringify(entry),
+      Number(entry.updatedAt),
+      typeof entry.parentSessionKey === "string" ? entry.parentSessionKey : null,
+      typeof entry.spawnedBy === "string" ? entry.spawnedBy : null,
+    );
   database.db
     .prepare("UPDATE session_nodes SET entry_valid = 1 WHERE session_key = ?")
     .run(sessionKey);
@@ -167,6 +180,114 @@ describe("doctor canonical session delivery state", () => {
       found: 0,
       repaired: 0,
       scannedStores: 1,
+    });
+  });
+
+  it("publishes repaired delivery accounts to the existing SQLite connection without aging sessions", () => {
+    const stateDir = fs.realpathSync(tempDirs.make("openclaw-delivery-warm-cache-"));
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    const sessionKey = "agent:main:delivery-warm-cache";
+    insertSessionRow(env, sessionKey, {
+      sessionId: "delivery-warm-cache-session",
+      updatedAt: 10,
+      channel: "slack",
+      deliveryContext: { channel: "telegram", to: "recipient", accountId: "current-bot" },
+      lastAccountId: "stale-slack-bot",
+    });
+
+    expect(listSessionEntries({ agentId: "main", env })[0]?.entry).toMatchObject({
+      updatedAt: 10,
+      lastAccountId: "stale-slack-bot",
+    });
+    expect(repairCanonicalSessionDeliveryStates({ apply: true, cfg: {}, env })).toEqual({
+      found: 1,
+      repaired: 1,
+      scannedStores: 1,
+    });
+    expect(JSON.parse(readEntryJson(env, sessionKey))).toMatchObject({
+      updatedAt: 10,
+      delivery: { context: { accountId: "current-bot" } },
+    });
+
+    const repaired = listSessionEntries({ agentId: "main", env })[0]?.entry;
+    expect(repaired).toMatchObject({
+      updatedAt: 10,
+      delivery: { context: { accountId: "current-bot" } },
+    });
+    expect(repaired).not.toHaveProperty("lastAccountId");
+  });
+
+  it("discards a Doctor session cache publication when its owner transaction rolls back", () => {
+    const stateDir = fs.realpathSync(tempDirs.make("openclaw-delivery-cache-rollback-"));
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    const sessionKey = "agent:main:delivery-cache-rollback";
+    insertSessionRow(env, sessionKey, {
+      sessionId: "delivery-cache-rollback-session",
+      updatedAt: 10,
+      label: "committed",
+    });
+    const originalJson = readEntryJson(env, sessionKey);
+    const cached = listSessionEntries({ agentId: "main", env, clone: false })[0]?.entry;
+    expect(cached?.label).toBe("committed");
+
+    expect(() =>
+      runOpenClawAgentWriteTransaction(
+        (database) => {
+          writeValidatedDoctorSessionEntryJson(
+            database,
+            {
+              current_session_id: "delivery-cache-rollback-session",
+              entry_json: originalJson,
+              session_key: sessionKey,
+              updated_at: 10,
+            },
+            JSON.stringify({ ...cached, label: "uncommitted" }),
+          );
+          throw new Error("roll back Doctor session rewrite");
+        },
+        { agentId: "main", env },
+      ),
+    ).toThrow("roll back Doctor session rewrite");
+
+    expect(readEntryJson(env, sessionKey)).toBe(originalJson);
+    expect(listSessionEntries({ agentId: "main", env, clone: false })[0]?.entry).toBe(cached);
+  });
+
+  it("publishes cross-agent incognito parent rewrites to each existing SQLite connection", () => {
+    const stateDir = fs.realpathSync(tempDirs.make("openclaw-incognito-warm-cache-"));
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    const oldParentKey = "agent:main:dashboard:incognito-warm-cache";
+    const newParentKey = "agent:main:dashboard:legacy-incognito-warm-cache";
+    const childKey = "agent:work:dashboard:child";
+    insertSessionRow(env, oldParentKey, {
+      sessionId: "incognito-parent-session",
+      updatedAt: 10,
+    });
+    insertSessionRow(
+      env,
+      childKey,
+      {
+        sessionId: "incognito-child-session",
+        updatedAt: 20,
+        parentSessionKey: oldParentKey,
+        spawnedBy: oldParentKey,
+      },
+      "work",
+    );
+
+    expect(listSessionEntries({ agentId: "work", env })[0]?.entry).toMatchObject({
+      updatedAt: 20,
+      parentSessionKey: oldParentKey,
+    });
+    expect(repairReservedIncognitoSessionKeys({ apply: true, cfg: {}, env })).toEqual({
+      found: 1,
+      repaired: 1,
+    });
+
+    expect(listSessionEntries({ agentId: "work", env })[0]?.entry).toMatchObject({
+      updatedAt: 20,
+      parentSessionKey: newParentKey,
+      spawnedBy: newParentKey,
     });
   });
 

--- a/src/commands/doctor-session-delivery-state.ts
+++ b/src/commands/doctor-session-delivery-state.ts
@@ -11,6 +11,7 @@ import type { DB as OpenClawAgentKyselyDatabase } from "../state/openclaw-agent-
 import {
   closeOpenClawAgentDatabaseByPath,
   isOpenClawAgentDatabaseOpen,
+  type OpenClawAgentDatabase,
   runOpenClawAgentWriteTransaction,
 } from "../state/openclaw-agent-db.js";
 import {
@@ -68,7 +69,7 @@ export function repairCanonicalSessionDeliveryStates(params: {
     const wasOpen = isOpenClawAgentDatabaseOpen(target.sqlitePath);
     try {
       repaired += runOpenClawAgentWriteTransaction(
-        (database) => applyDeliveryRewrites(database.db),
+        (database) => applyDeliveryRewrites(database),
         { agentId: target.agentId, env: params.env, path: target.sqlitePath },
         { operationLabel: "doctor.canonicalize-session-delivery-state" },
       );
@@ -127,13 +128,13 @@ function collectDeliveryRewrites(database: DatabaseSync): DeliveryRewrite[] {
   });
 }
 
-function applyDeliveryRewrites(database: DatabaseSync): number {
-  const db = getNodeSqliteKysely<OpenClawAgentKyselyDatabase>(database);
-  const rewrites = collectDeliveryRewrites(database);
+function applyDeliveryRewrites(database: OpenClawAgentDatabase): number {
+  const db = getNodeSqliteKysely<OpenClawAgentKyselyDatabase>(database.db);
+  const rewrites = collectDeliveryRewrites(database.db);
   for (const rewrite of rewrites) {
     writeValidatedDoctorSessionEntryJson(database, rewrite.row, rewrite.entryJson);
     executeSqliteQuerySync(
-      database,
+      database.db,
       db
         .updateTable("session_windows")
         .set({ account_id: rewrite.accountId, channel: rewrite.channel })

--- a/src/commands/doctor-session-entry-rewrite.ts
+++ b/src/commands/doctor-session-entry-rewrite.ts
@@ -1,7 +1,8 @@
-import type { DatabaseSync } from "node:sqlite";
+import { publishSqliteSessionEntryCacheInvalidation } from "../config/sessions/session-accessor.sqlite-entry-cache.js";
 import { parseSqliteSessionEntryRecord } from "../config/sessions/session-entry-json.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../state/openclaw-agent-db.generated.js";
+import type { OpenClawAgentDatabase } from "../state/openclaw-agent-db.js";
 
 export type DoctorSessionEntryRow = {
   current_session_id: string;
@@ -12,16 +13,16 @@ export type DoctorSessionEntryRow = {
 
 /** Persist a doctor-proven entry rewrite and settle the schema-owned validity projection. */
 export function writeValidatedDoctorSessionEntryJson(
-  database: DatabaseSync,
+  database: OpenClawAgentDatabase,
   row: DoctorSessionEntryRow,
   entryJson: string,
 ): void {
   if (!parseSqliteSessionEntryRecord({ ...row, entry_json: entryJson })) {
     throw new Error(`Refusing invalid SQLite session entry rewrite for ${row.session_key}`);
   }
-  const db = getNodeSqliteKysely<OpenClawAgentKyselyDatabase>(database);
+  const db = getNodeSqliteKysely<OpenClawAgentKyselyDatabase>(database.db);
   executeSqliteQuerySync(
-    database,
+    database.db,
     db
       .updateTable("session_nodes")
       .set({ entry_json: entryJson })
@@ -30,10 +31,13 @@ export function writeValidatedDoctorSessionEntryJson(
   // The entry_json trigger marks every rewrite pending, including a value already validated
   // above. Settle it separately so the next strict reader does not reject doctor's output.
   executeSqliteQuerySync(
-    database,
+    database.db,
     db
       .updateTable("session_nodes")
       .set({ entry_valid: 1 })
       .where("session_key", "=", row.session_key),
   );
+  // The transaction owner defers this row publication until commit; rollback must never
+  // expose repaired JSON through a warm connection-local session cache.
+  publishSqliteSessionEntryCacheInvalidation(database, { ...row, entry_json: entryJson });
 }

--- a/src/commands/doctor-session-incognito-key-repair.ts
+++ b/src/commands/doctor-session-incognito-key-repair.ts
@@ -9,6 +9,7 @@ import type { DB as OpenClawAgentKyselyDatabase } from "../state/openclaw-agent-
 import {
   closeOpenClawAgentDatabaseByPath,
   isOpenClawAgentDatabaseOpen,
+  type OpenClawAgentDatabase,
   runOpenClawAgentWriteTransaction,
 } from "../state/openclaw-agent-db.js";
 import {
@@ -106,7 +107,7 @@ export function repairReservedIncognitoSessionKeys(params: {
     const options = { agentId: target.agentId, env: params.env, path: target.sqlitePath };
     try {
       runOpenClawAgentWriteTransaction(
-        (database) => applyReservedIncognitoKeyRenames(database.db, renames),
+        (database) => applyReservedIncognitoKeyRenames(database, renames),
         options,
         { operationLabel: "doctor.rename-reserved-incognito-session-keys" },
       );
@@ -163,16 +164,16 @@ function planReservedIncognitoKeyRenames(
 }
 
 function applyReservedIncognitoKeyRenames(
-  database: DatabaseSync,
+  database: OpenClawAgentDatabase,
   renames: readonly ReservedKeyRename[],
 ): void {
   if (renames.length === 0) {
     return;
   }
   // Board widget foreign keys are immediate; defer them so every key-bearing row renames atomically.
-  database.exec("PRAGMA defer_foreign_keys = ON;"); // sqlite-allow-raw -- transaction-local FK deferral.
+  database.db.exec("PRAGMA defer_foreign_keys = ON;"); // sqlite-allow-raw -- transaction-local FK deferral.
   for (const rename of renames) {
-    updateSessionKeyColumns(database, rename);
+    updateSessionKeyColumns(database.db, rename);
   }
   rewriteSessionEntryJsonReferences(database, new Map(renames.map((item) => [item.from, item.to])));
 }
@@ -352,12 +353,12 @@ function updateSessionKeyColumns(database: DatabaseSync, rename: ReservedKeyRena
 }
 
 function rewriteSessionEntryJsonReferences(
-  database: DatabaseSync,
+  database: OpenClawAgentDatabase,
   renames: ReadonlyMap<string, string>,
 ): void {
-  const db = getNodeSqliteKysely<OpenClawAgentKyselyDatabase>(database);
+  const db = getNodeSqliteKysely<OpenClawAgentKyselyDatabase>(database.db);
   const rows = executeSqliteQuerySync(
-    database,
+    database.db,
     db
       .selectFrom("session_nodes")
       .select(["session_key", "current_session_id", "entry_json", "updated_at"]),


### PR DESCRIPTION
## Summary
- publish the existing canonical session-cache invalidation only after Doctor's SQLite repairs actually commit
- preserve historical updated_at / entry_json.updatedAt values while propagating the actual owning agent database through delivery-account and incognito-parent rewrite paths
- prevent warm same-connection readers from permanently retaining stale delivery accounts, parent session keys or spawnedBy references

## Verification
- two deterministic production DatabaseSync/Kysely regressions failed before repair and pass afterward
- 31 focused Doctor, incognito, transaction/cache and rollback tests pass, including cross-agent owner isolation
- actual rollback preserves both durable JSON and warm-cache object identity; no schema change, SQL fallback or Node-version-specific API
- independent formal structured review clean, confidence 0.93; production delta +6 lines