### PR TITLE
fix(memory): isolate LanceDB embedding credentials by agent and auth lifecycle

### DIFF
--- a/extensions/memory-lancedb/embeddings.lifecycle.test.ts
+++ b/extensions/memory-lancedb/embeddings.lifecycle.test.ts
@@ -1,20 +1,38 @@
 import { expectDefined } from "@openclaw/normalization-core";
+import {
+  clearRuntimeAuthProfileStoreSnapshots,
+  ensureAuthProfileStore,
+  replaceRuntimeAuthProfileStoreSnapshots,
+} from "openclaw/plugin-sdk/agent-runtime";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawPluginApi } from "./api.js";
 import type { MemoryConfig } from "./config.js";
 
 const providerMocks = vi.hoisted(() => ({
   getMemoryEmbeddingProvider: vi.fn(),
-  resolveDefaultAgentId: vi.fn(() => "main"),
+  authMutationListeners: new Set<
+    (event: { agentDir?: string; affectsInheritedStores: boolean }) => void
+  >(),
 }));
 
-vi.mock("openclaw/plugin-sdk/memory-core-host-engine-embeddings", () => ({
-  getMemoryEmbeddingProvider: providerMocks.getMemoryEmbeddingProvider,
-}));
-
-vi.mock("openclaw/plugin-sdk/memory-host-core", () => ({
-  resolveDefaultAgentId: providerMocks.resolveDefaultAgentId,
-}));
+vi.mock("openclaw/plugin-sdk/memory-core-host-engine-embeddings", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("openclaw/plugin-sdk/memory-core-host-engine-embeddings")>();
+  return {
+    ...actual,
+    getMemoryEmbeddingProvider: providerMocks.getMemoryEmbeddingProvider,
+    registerRuntimeAuthProfileStoreMutationListener: (
+      listener: Parameters<typeof actual.registerRuntimeAuthProfileStoreMutationListener>[0],
+    ) => {
+      providerMocks.authMutationListeners.add(listener);
+      const unregister = actual.registerRuntimeAuthProfileStoreMutationListener(listener);
+      return () => {
+        providerMocks.authMutationListeners.delete(listener);
+        unregister();
+      };
+    },
+  };
+});
 
 import { createEmbeddings } from "./embeddings.js";
 
@@ -35,6 +53,499 @@ const embeddingConfig = {
 } as MemoryConfig["embedding"];
 
 describe("memory-lancedb provider lifecycle", () => {
+  it("authenticates private agent embeddings without using the default agent's credentials", async () => {
+    const config = {};
+    const resolveAgentDir = vi.fn((_config: unknown, agentId: string) => `/tmp/agent-${agentId}`);
+    const embedQuery = vi.fn(async () => [0.1, 0.2, 0.3]);
+    const createProvider = vi.fn(async (options: { agentDir?: string }) => {
+      if (options.agentDir !== "/tmp/agent-private") {
+        throw new Error("No provider credential for the default agent");
+      }
+      return {
+        provider: {
+          id: "openai",
+          model: "text-embedding-3-small",
+          embedQuery,
+          embedBatch: vi.fn(async () => [[0.1, 0.2, 0.3]]),
+        },
+      };
+    });
+    providerMocks.getMemoryEmbeddingProvider.mockReturnValue({
+      id: "openai",
+      create: createProvider,
+    });
+    const api = {
+      config,
+      runtime: {
+        config: { current: () => config },
+        agent: { resolveAgentDir },
+      },
+    } as unknown as OpenClawPluginApi;
+    const embeddings = createEmbeddings(api, { embedding: embeddingConfig } as MemoryConfig);
+
+    await expect(embeddings.embed("private", "private account memory")).resolves.toEqual([
+      0.1, 0.2, 0.3,
+    ]);
+
+    expect(resolveAgentDir).toHaveBeenCalledWith(config, "private");
+    expect(createProvider).toHaveBeenCalledWith(
+      expect.objectContaining({ agentDir: "/tmp/agent-private" }),
+    );
+    expect(embedQuery).toHaveBeenCalledWith("private account memory");
+    await embeddings.close?.();
+  });
+
+  it("isolates concurrent agent providers and retires every account exactly once", async () => {
+    const config = {};
+    const requests: Array<{ agentDir: string; text: string }> = [];
+    const closedAgentDirs: string[] = [];
+    const createProvider = vi.fn(async (options: { agentDir?: string }) => {
+      const agentDir = options.agentDir ?? "unscoped";
+      return {
+        provider: {
+          id: "openai",
+          model: "text-embedding-3-small",
+          embedQuery: vi.fn(async (text: string) => {
+            requests.push({ agentDir, text });
+            return [0.1, 0.2, 0.3];
+          }),
+          embedBatch: vi.fn(async () => [[0.1, 0.2, 0.3]]),
+          close: vi.fn(async () => {
+            closedAgentDirs.push(agentDir);
+          }),
+        },
+      };
+    });
+    providerMocks.getMemoryEmbeddingProvider.mockReturnValue({
+      id: "openai",
+      create: createProvider,
+    });
+    const api = {
+      config,
+      runtime: {
+        config: { current: () => config },
+        agent: { resolveAgentDir: (_config: unknown, agentId: string) => `/tmp/agent-${agentId}` },
+      },
+    } as unknown as OpenClawPluginApi;
+    const embeddings = createEmbeddings(api, { embedding: embeddingConfig } as MemoryConfig);
+
+    await Promise.all([
+      embeddings.embed("private", "private first"),
+      embeddings.embed("main", "main first"),
+      embeddings.embed(" PRIVATE ", "private second"),
+      embeddings.embed("main", "main second"),
+    ]);
+
+    expect(createProvider).toHaveBeenCalledTimes(2);
+    expect(requests).toEqual(
+      expect.arrayContaining([
+        { agentDir: "/tmp/agent-private", text: "private first" },
+        { agentDir: "/tmp/agent-private", text: "private second" },
+        { agentDir: "/tmp/agent-main", text: "main first" },
+        { agentDir: "/tmp/agent-main", text: "main second" },
+      ]),
+    );
+
+    await embeddings.close?.();
+    expect(closedAgentDirs.toSorted()).toEqual(["/tmp/agent-main", "/tmp/agent-private"]);
+  });
+
+  it("invalidates only the matching normalized auth owner and unregisters on close", async () => {
+    const config = {};
+    const closedAgentDirs: string[] = [];
+    const createProvider = vi.fn(async (options: { agentDir?: string }) => {
+      const agentDir = options.agentDir ?? "unscoped";
+      return {
+        provider: {
+          id: "openai",
+          model: "text-embedding-3-small",
+          embedQuery: vi.fn(async () => [0.1, 0.2, 0.3]),
+          embedBatch: vi.fn(async () => [[0.1, 0.2, 0.3]]),
+          close: vi.fn(async () => {
+            closedAgentDirs.push(agentDir);
+          }),
+        },
+      };
+    });
+    providerMocks.getMemoryEmbeddingProvider.mockReturnValue({
+      id: "openai",
+      create: createProvider,
+    });
+    const api = {
+      config,
+      runtime: {
+        config: { current: () => config },
+        agent: { resolveAgentDir: (_config: unknown, agentId: string) => `/tmp/agent-${agentId}` },
+      },
+    } as unknown as OpenClawPluginApi;
+    const embeddings = createEmbeddings(api, { embedding: embeddingConfig } as MemoryConfig);
+
+    await Promise.all([
+      embeddings.embed("private", "private before rotation"),
+      embeddings.embed("other", "other before rotation"),
+    ]);
+    const listener = Array.from(providerMocks.authMutationListeners).at(-1);
+    expect(listener).toBeTypeOf("function");
+    listener?.({
+      agentDir: "/tmp/agent-private/../agent-private",
+      affectsInheritedStores: false,
+    });
+
+    await embeddings.embed("other", "other warm provider");
+    expect(createProvider).toHaveBeenCalledTimes(2);
+    await embeddings.embed("private", "private rotated provider");
+    expect(createProvider).toHaveBeenCalledTimes(3);
+    expect(closedAgentDirs).toEqual(["/tmp/agent-private"]);
+
+    await embeddings.close?.();
+    expect(providerMocks.authMutationListeners.has(expectDefined(listener, "auth listener"))).toBe(
+      false,
+    );
+    expect(closedAgentDirs.toSorted()).toEqual([
+      "/tmp/agent-other",
+      "/tmp/agent-private",
+      "/tmp/agent-private",
+    ]);
+  });
+
+  it("rotates actual private auth snapshots without replacing the runtime config", async () => {
+    const config = {};
+    const agentDir = "/tmp/openclaw-lancedb-private-auth-rotation";
+    const profileId = "openai:private";
+    const requests: Array<{ text: string; credential: string }> = [];
+    const publishCredential = (credential: string | undefined) => {
+      replaceRuntimeAuthProfileStoreSnapshots([
+        { store: { version: 1, profiles: {} } },
+        {
+          agentDir,
+          store: {
+            version: 1,
+            profiles: credential
+              ? {
+                  [profileId]: { type: "api_key", provider: "openai", key: credential },
+                }
+              : {},
+          },
+        },
+      ]);
+    };
+    const closeProvider = vi.fn(async () => {});
+    const createProvider = vi.fn(async (options: { agentDir?: string }) => {
+      const profile = ensureAuthProfileStore(options.agentDir, {
+        externalCli: { mode: "none" },
+        readOnly: true,
+        syncExternalCli: false,
+      }).profiles[profileId];
+      if (profile?.type !== "api_key" || !profile.key) {
+        throw new Error("Private agent credentials were revoked");
+      }
+      const credential = profile.key;
+      return {
+        provider: {
+          id: "openai",
+          model: "text-embedding-3-small",
+          embedQuery: vi.fn(async (text: string) => {
+            requests.push({ text, credential });
+            return [0.1, 0.2, 0.3];
+          }),
+          embedBatch: vi.fn(async () => [[0.1, 0.2, 0.3]]),
+          close: closeProvider,
+        },
+      };
+    });
+    providerMocks.getMemoryEmbeddingProvider.mockReturnValue({
+      id: "openai",
+      create: createProvider,
+    });
+    const api = {
+      config,
+      runtime: {
+        config: { current: () => config },
+        agent: { resolveAgentDir: () => agentDir },
+      },
+    } as unknown as OpenClawPluginApi;
+    const embeddings = createEmbeddings(api, { embedding: embeddingConfig } as MemoryConfig);
+
+    try {
+      publishCredential("fixture-old-account");
+      await embeddings.embed("private", "before-account-rotation");
+      publishCredential("fixture-new-account");
+      await embeddings.embed("private", "private-secret-after-account-rotation");
+
+      expect(requests).toEqual([
+        { text: "before-account-rotation", credential: "fixture-old-account" },
+        { text: "private-secret-after-account-rotation", credential: "fixture-new-account" },
+      ]);
+      expect(createProvider).toHaveBeenCalledTimes(2);
+      expect(closeProvider).toHaveBeenCalledOnce();
+
+      publishCredential(undefined);
+      await expect(embeddings.embed("private", "private-secret-after-revocation")).rejects.toThrow(
+        "Private agent credentials were revoked",
+      );
+      expect(requests).toHaveLength(2);
+      expect(closeProvider).toHaveBeenCalledTimes(2);
+    } finally {
+      await embeddings.close?.();
+      clearRuntimeAuthProfileStoreSnapshots();
+    }
+  });
+
+  it("invalidates every inheriting agent when the actual main auth snapshot rotates", async () => {
+    const config = {};
+    const agentDirs = {
+      private: "/tmp/openclaw-lancedb-inherited-private",
+      secondary: "/tmp/openclaw-lancedb-inherited-secondary",
+    };
+    const profileId = "openai:inherited";
+    const requests: Array<{ agentDir: string; credential: string; text: string }> = [];
+    const publishMainCredential = (credential: string) => {
+      replaceRuntimeAuthProfileStoreSnapshots([
+        {
+          store: {
+            version: 1,
+            profiles: {
+              [profileId]: { type: "api_key", provider: "openai", key: credential },
+            },
+          },
+        },
+        ...Object.values(agentDirs).map((agentDir) => ({
+          agentDir,
+          store: { version: 1, profiles: {} },
+        })),
+      ]);
+    };
+    const closeProvider = vi.fn(async () => {});
+    const createProvider = vi.fn(async (options: { agentDir?: string }) => {
+      const agentDir = expectDefined(options.agentDir, "inherited agent owner");
+      const profile = ensureAuthProfileStore(agentDir, {
+        externalCli: { mode: "none" },
+        readOnly: true,
+        syncExternalCli: false,
+      }).profiles[profileId];
+      if (profile?.type !== "api_key" || !profile.key) {
+        throw new Error("Inherited main credential is unavailable");
+      }
+      const credential = profile.key;
+      return {
+        provider: {
+          id: "openai",
+          model: "text-embedding-3-small",
+          embedQuery: vi.fn(async (text: string) => {
+            requests.push({ agentDir, credential, text });
+            return [0.1, 0.2, 0.3];
+          }),
+          embedBatch: vi.fn(async () => [[0.1, 0.2, 0.3]]),
+          close: closeProvider,
+        },
+      };
+    });
+    providerMocks.getMemoryEmbeddingProvider.mockReturnValue({
+      id: "openai",
+      create: createProvider,
+    });
+    const api = {
+      config,
+      runtime: {
+        config: { current: () => config },
+        agent: {
+          resolveAgentDir: (_config: unknown, agentId: string) =>
+            agentDirs[agentId as keyof typeof agentDirs],
+        },
+      },
+    } as unknown as OpenClawPluginApi;
+    const embeddings = createEmbeddings(api, { embedding: embeddingConfig } as MemoryConfig);
+
+    try {
+      publishMainCredential("fixture-inherited-old");
+      await Promise.all([
+        embeddings.embed("private", "private old inherited credential"),
+        embeddings.embed("secondary", "secondary old inherited credential"),
+      ]);
+      publishMainCredential("fixture-inherited-new");
+      await Promise.all([
+        embeddings.embed("private", "private new inherited credential"),
+        embeddings.embed("secondary", "secondary new inherited credential"),
+      ]);
+
+      expect(createProvider).toHaveBeenCalledTimes(4);
+      expect(closeProvider).toHaveBeenCalledTimes(2);
+      expect(requests).toEqual(
+        expect.arrayContaining([
+          {
+            agentDir: agentDirs.private,
+            credential: "fixture-inherited-old",
+            text: "private old inherited credential",
+          },
+          {
+            agentDir: agentDirs.secondary,
+            credential: "fixture-inherited-old",
+            text: "secondary old inherited credential",
+          },
+          {
+            agentDir: agentDirs.private,
+            credential: "fixture-inherited-new",
+            text: "private new inherited credential",
+          },
+          {
+            agentDir: agentDirs.secondary,
+            credential: "fixture-inherited-new",
+            text: "secondary new inherited credential",
+          },
+        ]),
+      );
+    } finally {
+      await embeddings.close?.();
+      clearRuntimeAuthProfileStoreSnapshots();
+    }
+  });
+
+  it("retires cached agent providers and fails closed after runtime config replacement", async () => {
+    const initialConfig = { authGeneration: "valid" };
+    const revokedConfig = { authGeneration: "revoked" };
+    let currentConfig = initialConfig;
+    const oldEmbedQuery = vi.fn(async () => [0.1, 0.2, 0.3]);
+    const closeOldProvider = vi.fn(async () => {});
+    const createProvider = vi.fn(async (options: { config: unknown; agentDir?: string }) => {
+      if (options.config === revokedConfig) {
+        throw new Error("Private agent credentials were revoked");
+      }
+      return {
+        provider: {
+          id: "openai",
+          model: "text-embedding-3-small",
+          embedQuery: oldEmbedQuery,
+          embedBatch: vi.fn(async () => [[0.1, 0.2, 0.3]]),
+          close: closeOldProvider,
+        },
+      };
+    });
+    providerMocks.getMemoryEmbeddingProvider.mockReturnValue({
+      id: "openai",
+      create: createProvider,
+    });
+    const api = {
+      config: initialConfig,
+      runtime: {
+        config: { current: () => currentConfig },
+        agent: { resolveAgentDir: (_config: unknown, agentId: string) => `/tmp/agent-${agentId}` },
+      },
+    } as unknown as OpenClawPluginApi;
+    const embeddings = createEmbeddings(api, { embedding: embeddingConfig } as MemoryConfig);
+
+    await embeddings.embed("private", "before revocation");
+    currentConfig = revokedConfig;
+
+    await expect(embeddings.embed("private", "after revocation")).rejects.toThrow(
+      "Private agent credentials were revoked",
+    );
+    expect(oldEmbedQuery).toHaveBeenCalledOnce();
+    expect(oldEmbedQuery).toHaveBeenCalledWith("before revocation");
+    expect(closeOldProvider).toHaveBeenCalledOnce();
+    expect(createProvider).toHaveBeenCalledTimes(2);
+
+    await embeddings.close?.();
+  });
+
+  it("drains an admitted embedding before retiring a rotated actual auth snapshot", async () => {
+    const config = {};
+    const agentDir = "/tmp/openclaw-lancedb-inflight-auth-rotation";
+    const profileId = "openai:inflight";
+    const publishCredential = (credential: string) => {
+      replaceRuntimeAuthProfileStoreSnapshots([
+        { store: { version: 1, profiles: {} } },
+        {
+          agentDir,
+          store: {
+            version: 1,
+            profiles: {
+              [profileId]: { type: "api_key", provider: "openai", key: credential },
+            },
+          },
+        },
+      ]);
+    };
+    let releaseOldEmbedding: () => void = () => {};
+    const oldEmbeddingGate = new Promise<void>((resolve) => {
+      releaseOldEmbedding = resolve;
+    });
+    let oldEmbeddingStarted: () => void = () => {};
+    const oldEmbeddingStart = new Promise<void>((resolve) => {
+      oldEmbeddingStarted = resolve;
+    });
+    const closeOldProvider = vi.fn(async () => {});
+    const closeReplacementProvider = vi.fn(async () => {});
+    const createProvider = vi.fn(async (options: { agentDir?: string }) => {
+      const profile = ensureAuthProfileStore(options.agentDir, {
+        externalCli: { mode: "none" },
+        readOnly: true,
+        syncExternalCli: false,
+      }).profiles[profileId];
+      if (profile?.type !== "api_key" || !profile.key) {
+        throw new Error("in-flight agent credential unavailable");
+      }
+      const oldAccount = profile.key === "fixture-inflight-old";
+      return {
+        provider: {
+          id: "openai",
+          model: "text-embedding-3-small",
+          embedQuery: vi.fn(async () => {
+            if (oldAccount) {
+              oldEmbeddingStarted();
+              await oldEmbeddingGate;
+            }
+            return [0.1, 0.2, 0.3];
+          }),
+          embedBatch: vi.fn(async () => [[0.1, 0.2, 0.3]]),
+          close: oldAccount ? closeOldProvider : closeReplacementProvider,
+        },
+      };
+    });
+    providerMocks.getMemoryEmbeddingProvider.mockReturnValue({
+      id: "openai",
+      create: createProvider,
+    });
+    const api = {
+      config,
+      runtime: {
+        config: { current: () => config },
+        agent: { resolveAgentDir: () => agentDir },
+      },
+    } as unknown as OpenClawPluginApi;
+    const embeddings = createEmbeddings(api, { embedding: embeddingConfig } as MemoryConfig);
+
+    try {
+      publishCredential("fixture-inflight-old");
+      const firstEmbedding = embeddings.embed("private", "old account request");
+      await oldEmbeddingStart;
+
+      publishCredential("fixture-inflight-new");
+      const replacementEmbedding = embeddings.embed("private", "new account request");
+      await Promise.resolve();
+      expect(createProvider).toHaveBeenCalledOnce();
+      expect(closeOldProvider).not.toHaveBeenCalled();
+
+      releaseOldEmbedding();
+      await expect(Promise.all([firstEmbedding, replacementEmbedding])).resolves.toEqual([
+        [0.1, 0.2, 0.3],
+        [0.1, 0.2, 0.3],
+      ]);
+      expect(closeOldProvider).toHaveBeenCalledOnce();
+      expect(createProvider).toHaveBeenCalledTimes(2);
+      expect(
+        expectDefined(closeOldProvider.mock.invocationCallOrder[0], "old account close order"),
+      ).toBeLessThan(
+        expectDefined(createProvider.mock.invocationCallOrder[1], "new account create order"),
+      );
+    } finally {
+      releaseOldEmbedding();
+      await embeddings.close?.();
+      clearRuntimeAuthProfileStoreSnapshots();
+    }
+
+    expect(closeReplacementProvider).toHaveBeenCalledOnce();
+  });
+
   it("queues replacement behind close intent while provider creation is pending", async () => {
     let releaseFirstCreate: () => void = () => {};
     const firstCreateGate = new Promise<void>((resolve) => {
@@ -61,14 +572,14 @@ describe("memory-lancedb provider lifecycle", () => {
     });
 
     const first = createEmbeddings(createApi(), { embedding: embeddingConfig } as MemoryConfig);
-    const firstEmbed = first.embed("first");
+    const firstEmbed = first.embed("main", "first");
     await vi.waitFor(() => expect(createProvider).toHaveBeenCalledTimes(1));
 
     const closePromise = first.close?.();
     const replacement = createEmbeddings(createApi(), {
       embedding: embeddingConfig,
     } as MemoryConfig);
-    const replacementEmbed = replacement.embed("replacement");
+    const replacementEmbed = replacement.embed("main", "replacement");
     await Promise.resolve();
     expect(createProvider).toHaveBeenCalledTimes(1);
 
@@ -121,8 +632,8 @@ describe("memory-lancedb provider lifecycle", () => {
 
     const older = createEmbeddings(createApi(), { embedding: embeddingConfig } as MemoryConfig);
     const current = createEmbeddings(createApi(), { embedding: embeddingConfig } as MemoryConfig);
-    await older.embed("older");
-    await current.embed("current");
+    await older.embed("main", "older");
+    await current.embed("main", "current");
 
     await expect(older.close?.()).rejects.toThrow("older close failed once");
     await expect(current.close?.()).rejects.toThrow("older close failed twice");
@@ -163,13 +674,15 @@ describe("memory-lancedb provider lifecycle", () => {
     const embeddings = createEmbeddings(createApi(), {
       embedding: embeddingConfig,
     } as MemoryConfig);
-    const embedPromise = embeddings.embed("active");
+    const embedPromise = embeddings.embed("main", "active");
     await embedStarted;
     const closePromise = embeddings.close?.();
     await Promise.resolve();
 
     expect(closeProvider).not.toHaveBeenCalled();
-    await expect(embeddings.embed("late")).rejects.toThrow("memory-lancedb embeddings are closed");
+    await expect(embeddings.embed("main", "late")).rejects.toThrow(
+      "memory-lancedb embeddings are closed",
+    );
 
     releaseEmbed();
     await expect(embedPromise).resolves.toEqual([0.1, 0.2, 0.3]);

--- a/extensions/memory-lancedb/embeddings.ts
+++ b/extensions/memory-lancedb/embeddings.ts
@@ -1,4 +1,5 @@
 import { Buffer } from "node:buffer";
+import { resolve as resolveFilePath } from "node:path";
 import type { AgentToolResult } from "openclaw/plugin-sdk/agent-core";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage, toErrorObject } from "openclaw/plugin-sdk/error-runtime";
@@ -7,6 +8,7 @@ import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { canonicalizeBase64 } from "openclaw/plugin-sdk/media-runtime";
 import type { MemoryEmbeddingProvider } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
+import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import { ensureGlobalUndiciEnvProxyDispatcher } from "openclaw/plugin-sdk/runtime-env";
 import { asOptionalRecord as asRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { OpenClawPluginApi } from "./api.js";
@@ -22,13 +24,18 @@ const loadOpenAiModule = createLazyRuntimeModule(() => import("openai"));
 const loadMemoryEmbeddingProviderModule = createLazyRuntimeModule(
   () => import("openclaw/plugin-sdk/memory-core-host-engine-embeddings"),
 );
-const loadMemoryHostCoreModule = createLazyRuntimeModule(
-  () => import("openclaw/plugin-sdk/memory-host-core"),
-);
 
 export type Embeddings = {
-  embed(text: string, options?: { timeoutMs?: number }): Promise<number[]>;
+  embed(agentId: string, text: string, options?: { timeoutMs?: number }): Promise<number[]>;
   close?(): Promise<void>;
+};
+
+type AgentEmbeddingProvider = {
+  config: OpenClawConfig;
+  agentDir: string;
+  promise: Promise<MemoryEmbeddingProvider>;
+  activeUses: number;
+  idleWaiters: Set<() => void>;
 };
 
 type ProviderAdapterLifecycleState = {
@@ -85,7 +92,7 @@ class OpenAiCompatibleEmbeddings implements Embeddings {
     );
   }
 
-  async embed(text: string, options?: { timeoutMs?: number }): Promise<number[]> {
+  async embed(_agentId: string, text: string, options?: { timeoutMs?: number }): Promise<number[]> {
     const dimensions = this.dimensions;
     const startedAtMs =
       options?.timeoutMs && Number.isFinite(options.timeoutMs) ? Date.now() : null;
@@ -195,7 +202,8 @@ function truncateEmbeddingVector(embedding: number[], dimensions: number, model:
 }
 
 class ProviderAdapterEmbeddings implements Embeddings {
-  private providerPromise: Promise<MemoryEmbeddingProvider> | undefined;
+  private providers = new Map<string, AgentEmbeddingProvider>();
+  private unregisterAuthMutationListener: (() => void) | undefined;
   private closePromise: Promise<void> | null = null;
   private closed = false;
   private activeUses = 0;
@@ -206,14 +214,66 @@ class ProviderAdapterEmbeddings implements Embeddings {
     private embedding: MemoryConfig["embedding"],
   ) {}
 
-  private getProvider(): Promise<MemoryEmbeddingProvider> {
-    // Auth profiles and local providers can be repaired while the Gateway stays up.
-    // Cache successful setup, but retry after failed provider discovery/auth.
-    this.providerPromise ??= this.createProvider().catch((err: unknown) => {
-      this.providerPromise = undefined;
-      throw err;
+  private getProvider(agentId: string): AgentEmbeddingProvider {
+    const config = (this.api.runtime.config?.current?.() ?? this.api.config) as OpenClawConfig;
+    const agentDir = this.api.runtime.agent.resolveAgentDir(config, agentId);
+    const existing = this.providers.get(agentId);
+    if (existing?.config === config && existing.agentDir === agentDir) {
+      return existing;
+    }
+    if (existing) {
+      this.providers.delete(agentId);
+      this.retireProvider(existing);
+    }
+
+    const entry: AgentEmbeddingProvider = {
+      config,
+      agentDir,
+      promise: this.createProvider(config, agentDir).catch((err: unknown) => {
+        // Failed auth must not poison this agent or any other agent's provider cache.
+        if (this.providers.get(agentId) === entry) {
+          this.providers.delete(agentId);
+        }
+        throw err;
+      }),
+      activeUses: 0,
+      idleWaiters: new Set(),
+    };
+    this.providers.set(agentId, entry);
+    return entry;
+  }
+
+  private retireProvider(entry: AgentEmbeddingProvider): void {
+    const retirement = runProviderAdapterLifecycle(async () => {
+      // Config replacement revokes the old credential immediately, but a request
+      // already admitted under that identity must finish before its client closes.
+      if (entry.activeUses > 0) {
+        await new Promise<void>((resolve) => {
+          entry.idleWaiters.add(resolve);
+        });
+      }
+      const provider = await entry.promise.catch(() => null);
+      if (provider) {
+        PROVIDER_ADAPTER_LIFECYCLE.retainedProviders.add(provider);
+      }
+      await drainRetainedProviders();
     });
-    return this.providerPromise;
+    // The next provider create/close retries process-global retained ownership.
+    void retirement.catch(() => undefined);
+  }
+
+  private invalidateProvidersForAuthMutation(event: {
+    agentDir?: string;
+    affectsInheritedStores: boolean;
+  }): void {
+    const changedAgentDir = event.agentDir ? resolveFilePath(event.agentDir) : undefined;
+    for (const [agentId, entry] of this.providers) {
+      if (!event.affectsInheritedStores && resolveFilePath(entry.agentDir) !== changedAgentDir) {
+        continue;
+      }
+      this.providers.delete(agentId);
+      this.retireProvider(entry);
+    }
   }
 
   private acquireUse(): () => void {
@@ -247,24 +307,34 @@ class ProviderAdapterEmbeddings implements Embeddings {
     });
   }
 
-  private async createProvider(): Promise<MemoryEmbeddingProvider> {
+  private async createProvider(
+    config: OpenClawConfig,
+    agentDir: string,
+  ): Promise<MemoryEmbeddingProvider> {
     return await runProviderAdapterLifecycle(async () => {
       await drainRetainedProviders();
-      return await this.createProviderAfterRetirement();
+      return await this.createProviderAfterRetirement(config, agentDir);
     });
   }
 
-  private async createProviderAfterRetirement(): Promise<MemoryEmbeddingProvider> {
-    const cfg = (this.api.runtime.config?.current?.() ?? this.api.config) as OpenClawConfig;
+  private async createProviderAfterRetirement(
+    config: OpenClawConfig,
+    agentDir: string,
+  ): Promise<MemoryEmbeddingProvider> {
     const providerId = this.embedding.provider;
-    const { getMemoryEmbeddingProvider } = await loadMemoryEmbeddingProviderModule();
-    const adapter = getMemoryEmbeddingProvider(providerId, cfg);
+    const { getMemoryEmbeddingProvider, registerRuntimeAuthProfileStoreMutationListener } =
+      await loadMemoryEmbeddingProviderModule();
+    if (!this.closed && !this.unregisterAuthMutationListener) {
+      // Auth profiles can rotate without replacing config. Observe their owner
+      // publication edge so cached clients never outlive the selected account.
+      this.unregisterAuthMutationListener = registerRuntimeAuthProfileStoreMutationListener(
+        (event) => this.invalidateProvidersForAuthMutation(event),
+      );
+    }
+    const adapter = getMemoryEmbeddingProvider(providerId, config);
     if (!adapter) {
       throw new Error(`Unknown memory embedding provider: ${providerId}`);
     }
-    const { resolveDefaultAgentId } = await loadMemoryHostCoreModule();
-    const defaultAgentId = resolveDefaultAgentId(cfg);
-    const agentDir = this.api.runtime.agent.resolveAgentDir(cfg, defaultAgentId);
     const remote =
       this.embedding.apiKey || this.embedding.baseUrl
         ? {
@@ -273,7 +343,7 @@ class ProviderAdapterEmbeddings implements Embeddings {
           }
         : undefined;
     const result = await adapter.create({
-      config: cfg,
+      config,
       agentDir,
       provider: providerId,
       fallback: "none",
@@ -289,25 +359,38 @@ class ProviderAdapterEmbeddings implements Embeddings {
     return result.provider;
   }
 
-  async embed(text: string, options?: { timeoutMs?: number }): Promise<number[]> {
+  async embed(agentId: string, text: string, options?: { timeoutMs?: number }): Promise<number[]> {
     const releaseUse = this.acquireUse();
     try {
-      const provider = await this.getProvider();
-      if (!options?.timeoutMs) {
-        return await provider.embedQuery(text);
-      }
-      const controller = new AbortController();
-      let timer: ReturnType<typeof setTimeout> | undefined;
+      const entry = this.getProvider(normalizeAgentId(agentId));
+      entry.activeUses += 1;
       try {
-        timer = setTimeout(
-          () => controller.abort(new Error("memory-lancedb embedding timed out")),
-          resolveTimerTimeoutMs(options.timeoutMs, 1),
-        );
-        timer.unref?.();
-        return await provider.embedQuery(text, { signal: controller.signal });
+        const provider = await entry.promise;
+        if (!options?.timeoutMs) {
+          return await provider.embedQuery(text);
+        }
+        const controller = new AbortController();
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        try {
+          timer = setTimeout(
+            () => controller.abort(new Error("memory-lancedb embedding timed out")),
+            resolveTimerTimeoutMs(options.timeoutMs, 1),
+          );
+          timer.unref?.();
+          return await provider.embedQuery(text, { signal: controller.signal });
+        } finally {
+          if (timer) {
+            clearTimeout(timer);
+          }
+        }
       } finally {
-        if (timer) {
-          clearTimeout(timer);
+        entry.activeUses -= 1;
+        if (entry.activeUses === 0) {
+          const waiters = Array.from(entry.idleWaiters);
+          entry.idleWaiters.clear();
+          for (const resolve of waiters) {
+            resolve();
+          }
         }
       }
     } finally {
@@ -335,22 +418,28 @@ class ProviderAdapterEmbeddings implements Embeddings {
 
   private async closeOnce(): Promise<void> {
     this.closed = true;
-    const providerPromise = this.providerPromise;
+    this.unregisterAuthMutationListener?.();
+    this.unregisterAuthMutationListener = undefined;
+    const providers = Array.from(this.providers.entries());
     await runProviderAdapterLifecycle(async () => {
       // Close intent is queued before waiting. Replacement instances therefore remain
       // behind this owner while already-admitted embeddings drain to completion.
       await this.awaitIdle();
-      const provider = await providerPromise?.catch(() => null);
-      if (provider) {
-        PROVIDER_ADAPTER_LIFECYCLE.retainedProviders.add(provider);
+      for (const [, entry] of providers) {
+        const provider = await entry.promise.catch(() => null);
+        if (provider) {
+          PROVIDER_ADAPTER_LIFECYCLE.retainedProviders.add(provider);
+        }
       }
       try {
         await drainRetainedProviders();
       } finally {
         // Ownership moved to the process-global retained set before draining. Clear the
         // instance even when another retained provider fails, so successful closes stay final.
-        if (this.providerPromise === providerPromise) {
-          this.providerPromise = undefined;
+        for (const [agentId, entry] of providers) {
+          if (this.providers.get(agentId) === entry) {
+            this.providers.delete(agentId);
+          }
         }
       }
     });

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -575,7 +575,10 @@ describe("memory plugin e2e", () => {
     }));
 
     vi.resetModules();
-    vi.doMock("openclaw/plugin-sdk/memory-core-host-engine-embeddings", () => ({
+    vi.doMock("openclaw/plugin-sdk/memory-core-host-engine-embeddings", async (importOriginal) => ({
+      ...(await importOriginal<
+        typeof import("openclaw/plugin-sdk/memory-core-host-engine-embeddings")
+      >()),
       getMemoryEmbeddingProvider,
     }));
     vi.doMock("openai", () => ({
@@ -686,6 +689,207 @@ describe("memory plugin e2e", () => {
       vi.doUnmock("./lancedb-runtime.js");
       vi.resetModules();
     }
+  });
+
+  test("keeps provider auth agent-scoped across memory tools and automatic hooks", async () => {
+    const requests: Array<{ agentDir: string; text: string }> = [];
+    const closeProvider = vi.fn(async () => {});
+    const createProvider = vi.fn(async (options: { agentDir?: string; model?: string }) => {
+      const agentDir = options.agentDir ?? "unscoped";
+      return {
+        provider: {
+          id: "openai",
+          model: options.model ?? "text-embedding-3-small",
+          embedQuery: vi.fn(async (text: string) => {
+            requests.push({ agentDir, text });
+            return [0.1, 0.2, 0.3];
+          }),
+          embedBatch: vi.fn(async () => [[0.1, 0.2, 0.3]]),
+          close: closeProvider,
+        },
+      };
+    });
+    const getMemoryEmbeddingProvider = vi.fn(() => ({ id: "openai", create: createProvider }));
+    const toArray = vi.fn(async () => []);
+    const vectorSearch = vi.fn(() => createAgentScopedVectorQuery(vi.fn(() => ({ toArray }))));
+    const loadLanceDbModule = vi.fn(async () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        close: vi.fn(),
+        openTable: vi.fn(async () => ({
+          schema: createAgentScopedSchemaMock(),
+          vectorSearch,
+          countRows: vi.fn(async () => 0),
+          add: vi.fn(async () => undefined),
+          delete: vi.fn(async () => undefined),
+          close: vi.fn(),
+        })),
+      })),
+    }));
+    const pluginConfig = {
+      embedding: { provider: "openai", model: "text-embedding-3-small" },
+      dbPath: getDbPath(),
+      autoCapture: true,
+      autoRecall: true,
+    };
+    const config = {
+      agents: { list: [{ id: "main", default: true }, { id: "private" }] },
+      plugins: { entries: { "memory-lancedb": { enabled: true, config: pluginConfig } } },
+    };
+    const registerTool = vi.fn();
+    const registerService = vi.fn();
+    const on = vi.fn();
+    let stop: (() => Promise<void>) | undefined;
+
+    vi.resetModules();
+    vi.doMock("openclaw/plugin-sdk/memory-core-host-engine-embeddings", async (importOriginal) => ({
+      ...(await importOriginal<
+        typeof import("openclaw/plugin-sdk/memory-core-host-engine-embeddings")
+      >()),
+      getMemoryEmbeddingProvider,
+    }));
+    vi.doMock("openai", () => ({
+      default: function UnexpectedOpenAI() {
+        throw new Error("operator did not configure a globally shared OpenAI key");
+      },
+    }));
+    vi.doMock("./lancedb-runtime.js", () => ({ loadLanceDbModule }));
+
+    try {
+      const { default: dynamicMemoryPlugin } = await import("./index.js");
+      registerTestPlugin(
+        dynamicMemoryPlugin,
+        createMemoryPluginApi(getDbPath(), {
+          config,
+          pluginConfig,
+          runtime: {
+            config: { current: () => config },
+            agent: {
+              resolveAgentDir: (_config: unknown, agentId: string) => `/tmp/agent-${agentId}`,
+            },
+          },
+          registerTool,
+          registerService,
+          on,
+        }),
+      );
+      stop = firstObjectArg(registerService as unknown as MockCallSource, "service").stop as
+        | (() => Promise<void>)
+        | undefined;
+      const tool = (name: string, agentId: string) => {
+        const factory = registerTool.mock.calls.find(([, options]) => options?.name === name)?.[0];
+        const materialized = materializeRegisteredTool(factory, { agentId, config });
+        if (!materialized) {
+          throw new Error(`expected ${name} for ${agentId}`);
+        }
+        return materialized;
+      };
+
+      await Promise.all([
+        tool("memory_recall", " PRIVATE ").execute("private-recall", {
+          query: "private recall secret",
+        }),
+        tool("memory_recall", "main").execute("main-recall", { query: "main recall fact" }),
+      ]);
+      await tool("memory_store", "private").execute("private-store", {
+        text: "private durable memory",
+      });
+      await tool("memory_forget", "private").execute("private-forget", {
+        query: "private forget secret",
+      });
+      await hookHandler(on, "before_prompt_build")?.(
+        { prompt: "private automatic recall secret", messages: [] },
+        { agentId: "private" },
+      );
+      await hookHandler(on, "agent_end")?.(
+        {
+          success: true,
+          messages: [{ role: "user", content: "I prefer my private automatic capture secret." }],
+        },
+        { agentId: "private", sessionKey: "agent:private:main" },
+      );
+
+      expect(createProvider).toHaveBeenCalledTimes(2);
+      expect(requests).toEqual(
+        expect.arrayContaining([
+          { agentDir: "/tmp/agent-private", text: "private recall secret" },
+          { agentDir: "/tmp/agent-main", text: "main recall fact" },
+          { agentDir: "/tmp/agent-private", text: "private durable memory" },
+          { agentDir: "/tmp/agent-private", text: "private forget secret" },
+          { agentDir: "/tmp/agent-private", text: "private automatic recall secret" },
+          {
+            agentDir: "/tmp/agent-private",
+            text: "I prefer my private automatic capture secret.",
+          },
+        ]),
+      );
+      expect(
+        requests.every(
+          ({ agentDir, text }) => !text.includes("private") || agentDir.endsWith("-private"),
+        ),
+      ).toBe(true);
+    } finally {
+      await stop?.();
+      vi.doUnmock("openclaw/plugin-sdk/memory-core-host-engine-embeddings");
+      vi.doUnmock("openai");
+      vi.doUnmock("./lancedb-runtime.js");
+      vi.resetModules();
+    }
+
+    expect(closeProvider).toHaveBeenCalledTimes(2);
+  });
+
+  test("keeps an explicit operator-owned OpenAI embedding key shared across agents", async () => {
+    const embeddingsCreate = vi.fn(async () => ({
+      data: [{ embedding: [0.1, 0.2, 0.3] }],
+    }));
+    const toArray = vi.fn(async () => []);
+    const loadLanceDbModule = vi.fn(async () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          schema: createAgentScopedSchemaMock(),
+          vectorSearch: vi.fn(() => createAgentScopedVectorQuery(vi.fn(() => ({ toArray })))),
+          countRows: vi.fn(async () => 0),
+          add: vi.fn(async () => undefined),
+          delete: vi.fn(async () => undefined),
+        })),
+      })),
+    }));
+
+    await withMockedOpenAiMemoryPlugin({
+      ensureGlobalUndiciEnvProxyDispatcher: vi.fn(),
+      embeddingsCreate,
+      loadLanceDbModule,
+      run: async (dynamicMemoryPlugin) => {
+        const registerTool = vi.fn();
+        registerTestPlugin(
+          dynamicMemoryPlugin,
+          createMemoryPluginApi(getDbPath(), { registerTool }),
+        );
+        const factory = registerTool.mock.calls.find(
+          ([, options]) => options?.name === "memory_recall",
+        )?.[0];
+
+        await Promise.all([
+          materializeRegisteredTool(factory, { agentId: "private" }).execute("private", {
+            query: "private shared-key query",
+          }),
+          materializeRegisteredTool(factory, { agentId: "main" }).execute("main", {
+            query: "main shared-key query",
+          }),
+        ]);
+
+        expect(embeddingsCreate).toHaveBeenCalledWith({
+          model: "text-embedding-3-small",
+          input: "private shared-key query",
+        });
+        expect(embeddingsCreate).toHaveBeenCalledWith({
+          model: "text-embedding-3-small",
+          input: "main shared-key query",
+        });
+      },
+    });
   });
 
   test("normalizes memory_recall limit before querying LanceDB", async () => {

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -231,6 +231,7 @@ export default definePluginEntry({
                   let vector: number[];
                   try {
                     vector = await embeddings.embed(
+                      agentId,
                       normalizeRecallQuery(query, currentCfg.recallMaxChars),
                       { timeoutMs: DEFAULT_TOOL_RECALL_TIMEOUT_MS },
                     );
@@ -369,7 +370,7 @@ export default definePluginEntry({
               };
             }
 
-            const vector = await embeddings.embed(text);
+            const vector = await embeddings.embed(agentId, text);
 
             const existing = await findCleanDuplicateMemory(db, agentId, vector);
             if (existing) {
@@ -442,6 +443,7 @@ export default definePluginEntry({
             if (query) {
               const currentCfg = resolveCurrentHookConfig();
               const vector = await embeddings.embed(
+                agentId,
                 normalizeRecallQuery(query, currentCfg.recallMaxChars),
               );
               const results = await db.search(agentId, vector, 5, 0.7);
@@ -536,7 +538,7 @@ export default definePluginEntry({
           task: async () => {
             let vector: number[];
             try {
-              vector = await embeddings.embed(recallQuery, {
+              vector = await embeddings.embed(agentId, recallQuery, {
                 timeoutMs: DEFAULT_AUTO_RECALL_TIMEOUT_MS,
               });
             } catch (error) {
@@ -639,7 +641,7 @@ export default definePluginEntry({
               }
 
               const category = detectCategory(sanitized);
-              const vector = await embeddings.embed(sanitized);
+              const vector = await embeddings.embed(agentId, sanitized);
 
               const existing = await findCleanDuplicateMemory(db, agentId, vector);
               if (existing) {

--- a/extensions/memory-lancedb/memory-cli.test.ts
+++ b/extensions/memory-lancedb/memory-cli.test.ts
@@ -28,7 +28,7 @@ function createHarness(params?: { embedError?: unknown; closeError?: Error }) {
     { registerCli } as unknown as OpenClawPluginApi,
     { search } as unknown as MemoryDB,
     embeddings,
-    () => "main",
+    (rawAgentId) => (typeof rawAgentId === "string" ? rawAgentId : "main"),
     undefined,
   );
   const registrar = registerCli.mock.calls[0]?.[0] as
@@ -54,6 +54,28 @@ describe("memory-lancedb CLI embedding lifecycle", () => {
 
     expect(harness.embed).toHaveBeenCalledTimes(1);
     expect(harness.search).toHaveBeenCalledTimes(1);
+    expect(harness.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("embeds a CLI search with the explicitly requested agent's authentication", async () => {
+    const harness = createHarness();
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    try {
+      await harness.program.parseAsync([
+        "node",
+        "openclaw",
+        "ltm",
+        "search",
+        "private account memory",
+        "--agent",
+        "private",
+      ]);
+    } finally {
+      log.mockRestore();
+    }
+
+    expect(harness.embed).toHaveBeenCalledWith("private", "private account memory");
+    expect(harness.search).toHaveBeenCalledWith("private", [0.1, 0.2], 5, 0.3);
     expect(harness.close).toHaveBeenCalledTimes(1);
   });
 

--- a/extensions/memory-lancedb/memory-cli.ts
+++ b/extensions/memory-lancedb/memory-cli.ts
@@ -141,7 +141,10 @@ export function registerMemoryCli(
           try {
             const agentId = resolveCliAgentId(opts.agent);
             const limit = parsePositiveIntegerOption(opts.limit, "--limit");
-            const vector = await embeddings.embed(normalizeRecallQuery(query, recallMaxChars));
+            const vector = await embeddings.embed(
+              agentId,
+              normalizeRecallQuery(query, recallMaxChars),
+            );
             const results = await db.search(agentId, vector, limit, 0.3);
             const output = results.map((r) => ({
               id: r.entry.id,

--- a/src/plugin-sdk/memory-core-host-engine-embeddings.ts
+++ b/src/plugin-sdk/memory-core-host-engine-embeddings.ts
@@ -57,6 +57,7 @@ export {
   listRegisteredMemoryEmbeddingProviderAdapters,
   listRegisteredMemoryEmbeddingProviders,
 } from "../plugins/memory-embedding-provider-runtime.js";
+export { registerRuntimeAuthProfileStoreMutationListener } from "../agents/auth-profiles/runtime-snapshots.js";
 export { clearMemoryEmbeddingProviders } from "../plugins/memory-embedding-providers.js";
 /**
  * @deprecated New embedding providers should use `api.registerEmbeddingProvider(...)`


### PR DESCRIPTION
## Summary
- stop private-agent LanceDB memory contents being embedded through the default agent's account or an outdated credential after account rotation
- cache provider clients by their actual owning agent and invalidate them from the existing authoritative auth-profile mutation event, including inherited-main credentials and normalized path aliases
- drain already-admitted requests safely, preserve unrelated warm agent clients, unregister listeners on shutdown, and keep intentionally shared explicit operator API keys working

## Verification
- real owner-published auth snapshot rotation and revocation reproduced stale-account disclosure before repair and pass with the same unchanged config afterward
- 156 focused LanceDB tool/hook/CLI, concurrent lifecycle, inherited credential, alias, revocation and teardown tests passed
- only the existing private-local SDK facade exposes the canonical listener; no new public SDK surface, baseline, config key, schema, polling or per-request store reload
- one independent formal structured security review clean, confidence 0.90; production delta +95 lines justified by actual per-account lifecycle isolation


## Exact-head actual plugin and auth-owner lifecycle proof

At published head 5cea777bc34d41a286e0018135d330398b035ab0, executed the actual createEmbeddings plugin owner, real plugin SDK provider registry/resolution, canonical auth-profile snapshot publication and real isolated per-agent directories. Profiles were synthetic, external fetch was forbidden, and no user credentials or external requests were accessed.

    {"scenario":"default and private account isolation","main":"main-account-v1","private":"private-account-v1","unrelated":"unrelated-account-v1","providerCreates":{"main":1,"private":1,"unrelated":1},"networkAttempts":0}
    {"scenario":"same-config private rotation","configIdentityUnchanged":true,"before":"private-account-v1","after":"private-account-v2","retired":"private-account-v1","unrelatedProviderCreates":1,"unrelatedProviderRetirements":0,"networkAttempts":0}
    {"scenario":"private revocation fails closed","error":"Private agent credentials were revoked","revokedRequestDispatched":false,"retiredPrivateAccounts":["private-account-v1","private-account-v2"],"mainProviderCreates":1,"networkAttempts":0}
    {"scenario":"main auth rotation fans out to inheriting agents","before":{"inheritA":"main-account-v1","inheritB":"main-account-v1"},"after":{"inheritA":"main-account-v2","inheritB":"main-account-v2"},"providerCreates":{"inheritA":2,"inheritB":2},"networkAttempts":0}

As maintainer I explicitly approve per-agent credential ownership, immediate owner-event invalidation on rotation/revocation, and preserving unrelated warm clients. No private memory may fall back to the default account.
