### PR TITLE
fix(gateway): stop caching time-expired session list results

### DIFF
--- a/src/gateway/server-methods/sessions-list-cache.ts
+++ b/src/gateway/server-methods/sessions-list-cache.ts
@@ -91,7 +91,10 @@ export async function respondWithCachedSessionList(params: {
   // Every input that can change a projected row must fence reuse. Store mutations and
   // live-run transitions have separate owners, so their monotonic counters stay separate.
   const fence = readSessionListFence(params.context);
-  const completed = state.completed.get(workKey);
+  // Activity windows and child retention expire without mutations; hidden paginated rows
+  // prevent deriving a safe deadline, so only concurrent temporal requests share work.
+  const cacheCompleted = params.request.activeMinutes === undefined && !params.request.spawnedBy;
+  const completed = cacheCompleted ? state.completed.get(workKey) : undefined;
   if (completed && matchesSessionListFence(completed, fence)) {
     params.respond(true, completed.result, undefined);
     return;
@@ -107,7 +110,7 @@ export async function respondWithCachedSessionList(params: {
   const promise = Promise.resolve()
     .then(params.run)
     .then((result) => {
-      if (matchesSessionListFence(readSessionListFence(params.context), fence)) {
+      if (cacheCompleted && matchesSessionListFence(readSessionListFence(params.context), fence)) {
         rememberCompletedSessionList(state, workKey, { ...fence, result });
       }
       return result;

--- a/src/gateway/server-methods/sessions-read-cache.test.ts
+++ b/src/gateway/server-methods/sessions-read-cache.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionsListParams } from "../../../packages/gateway-protocol/src/index.js";
-import { upsertSessionEntry } from "../../config/sessions/session-accessor.js";
+import {
+  loadSessionEntry,
+  replaceSessionEntry,
+  upsertSessionEntry,
+} from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resetAgentEventsForTest } from "../../infra/agent-events.js";
 import { clearAgentRunContext, registerAgentRunContext } from "../../infra/agent-run-registry.js";
@@ -87,6 +91,7 @@ async function listSessions(params: {
     count: number;
     nextOffset: number | null;
     sessions: Array<{ hasActiveRun?: boolean; key: string }>;
+    totalCount: number;
   };
 }
 
@@ -132,6 +137,25 @@ async function seedSessions(): Promise<OpenClawConfig> {
     },
   );
   return config;
+}
+
+async function seedSessionsWithActivityTimes() {
+  const clock = vi.spyOn(Date, "now").mockReturnValue(400);
+  const config = await seedSessions();
+  for (const [name, updatedAt] of [
+    ["active", 400],
+    ["draft", 300],
+    ["archived", 200],
+  ] as const) {
+    const scope = { agentId: "main", sessionKey: `agent:main:${name}` };
+    const entry = loadSessionEntry(scope);
+    if (!entry) {
+      throw new Error(`Missing seeded session ${scope.sessionKey}`);
+    }
+    await replaceSessionEntry(scope, { ...entry, updatedAt });
+    expect(loadSessionEntry(scope)?.updatedAt).toBe(updatedAt);
+  }
+  return { clock, config };
 }
 
 beforeEach(() => {
@@ -197,8 +221,10 @@ describe("sessions.list single-flight", () => {
       const context = requestContext(config);
       const client = identifiedClient("owner@example.com");
       const request = { archived: "all" as const, limit: 100 };
+      const clock = vi.spyOn(Date, "now").mockReturnValue(60_400);
 
       const first = await listSessions({ client, context, request });
+      clock.mockReturnValue(60_401);
       const cached = await listSessions({ client, context, request });
       expect(cached).toBe(first);
       expect(loader.calls).toHaveBeenCalledTimes(1);
@@ -206,6 +232,117 @@ describe("sessions.list single-flight", () => {
       emitSessionsChanged(context, { reason: "test", sessionKey: "agent:main:active" });
       await listSessions({ client, context, request });
       expect(loader.calls).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it.each([
+    {
+      description: "the last visible row crosses the inclusive activity cutoff",
+      now: 60_400,
+      limit: 100,
+      before: { keys: ["agent:main:active"], totalCount: 1 },
+      after: { keys: [], totalCount: 0 },
+    },
+    {
+      description: "an older row outside the current page expires",
+      now: 60_200,
+      limit: 1,
+      before: { keys: ["agent:main:active"], totalCount: 3 },
+      after: { keys: ["agent:main:active"], totalCount: 2 },
+    },
+  ])("refreshes activity-filtered results when $description", async (scenario) => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const { clock, config } = await seedSessionsWithActivityTimes();
+      const context = requestContext(config);
+      const client = identifiedClient("owner@example.com");
+      clock.mockReturnValue(scenario.now);
+      const request = {
+        activeMinutes: 1,
+        agentId: "main",
+        archived: "all" as const,
+        limit: scenario.limit,
+      };
+
+      const before = await listSessions({ client, context, request });
+      expect(before.sessions.map((session) => session.key)).toEqual(scenario.before.keys);
+      expect(before.totalCount).toBe(scenario.before.totalCount);
+
+      clock.mockReturnValue(scenario.now + 1);
+      const after = await listSessions({ client, context, request });
+      expect(after.sessions.map((session) => session.key)).toEqual(scenario.after.keys);
+      expect(after.totalCount).toBe(scenario.after.totalCount);
+      expect(loader.calls).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("collapses concurrent activity-filtered requests into one projection", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const { clock, config } = await seedSessionsWithActivityTimes();
+      const context = requestContext(config);
+      const client = identifiedClient("owner@example.com");
+      clock.mockReturnValue(60_400);
+      const request = { activeMinutes: 1, agentId: "main", limit: 100 };
+
+      const results = await Promise.all(
+        Array.from({ length: 8 }, () => listSessions({ client, context, request })),
+      );
+
+      expect(results[0]?.sessions.map((session) => session.key)).toEqual(["agent:main:active"]);
+      expect(results.every((result) => result === results[0])).toBe(true);
+      expect(loader.calls).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("expires completed children from parent-filtered listings at the retention boundary", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const { clock, config } = await seedSessionsWithActivityTimes();
+      const parentSessionKey = "agent:main:active";
+      const childSessionKey = "agent:main:child";
+      await upsertSessionEntry(
+        { agentId: "main", sessionKey: childSessionKey },
+        {
+          sessionId: "completed-child",
+          endedAt: 400,
+          parentSessionKey,
+          spawnedBy: parentSessionKey,
+          status: "done",
+          updatedAt: 400,
+          visibility: "shared",
+        },
+      );
+      const context = requestContext(config);
+      const client = identifiedClient("owner@example.com");
+      const request = { agentId: "main", limit: 100, spawnedBy: parentSessionKey };
+
+      clock.mockReturnValue(1_800_400);
+      const retained = await listSessions({ client, context, request });
+      expect(retained.sessions.map((session) => session.key)).toEqual([childSessionKey]);
+
+      clock.mockReturnValue(1_800_401);
+      const expired = await listSessions({ client, context, request });
+      expect(expired.sessions).toEqual([]);
+      expect(loader.calls).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("rejects a zero-minute activity window without loading the session store", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const config = await seedSessions();
+      const respond = vi.fn();
+
+      await sessionReadHandlers["sessions.list"]?.({
+        params: { activeMinutes: 0 },
+        client: identifiedClient("owner@example.com"),
+        context: requestContext(config),
+        respond,
+      } as never);
+
+      expect(respond).toHaveBeenCalledWith(
+        false,
+        undefined,
+        expect.objectContaining({ code: "INVALID_REQUEST" }),
+      );
+      expect(loader.calls).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary
- stop Gateway sessions.list from indefinitely reusing projections whose activeMinutes or spawnedBy visibility changes as wall-clock time advances
- retain concurrent request single-flight and all ordinary non-temporal projection caching; avoid unsafe guessed expirations when pagination hides the row that will expire
- respect terminal child retention boundaries, visible active-session cutoffs, paginated total counts, active runs and existing invalidation fences

## Verification
- three deterministic actual Gateway owner failures reproduced before repair and pass afterward: +1ms activity cutoff, invisible paginated row expiration, +1ms completed-child retention
- 22 focused Gateway cache, connection reuse and store materialization tests passed
- eight simultaneous temporal requests still share one in-flight projection; non-temporal completed caching remains unchanged
- one independent formal structured review clean, confidence 0.96; production delta +3 lines


## Exact-head actual Gateway sessions.list RPC proof

At published head b3e6b18d5bfa79f5ef9c1cd77ffbb62e8f7cdcb2, invoked the actual production sessions.list Gateway handler and real isolated SQLite-backed session projection with a deterministic clock. No mocked projection, external network, user data, or credential was used.

    {"scenario":"activeMinutes boundary","before":{"nowMs":60400,"count":1,"totalCount":1},"after":{"nowMs":60401,"count":0,"totalCount":0},"projectionStarts":2}
    {"scenario":"hidden paginated row expiration","request":{"activeMinutes":1,"limit":1},"before":{"nowMs":60200,"count":1,"totalCount":3,"nextOffset":1},"after":{"nowMs":60201,"count":1,"totalCount":2,"nextOffset":1},"projectionStarts":2}
    {"scenario":"concurrent temporal single-flight","concurrentCalls":8,"projectionStarts":1,"identicalResponseObject":true,"count":1}
    {"scenario":"non-temporal completed cache retained","beforeNowMs":60400,"afterNowMs":60401,"projectionStarts":1,"identicalResponseObject":true,"count":3}
    {"scenario":"spawnedBy completed-child retention boundary","before":{"nowMs":1800400,"count":1},"after":{"nowMs":1800401,"count":0},"projectionStarts":2}

As maintainer I accept the narrowly scoped load tradeoff: temporal filters retain in-flight request coalescing but must not reuse completed wall-clock-dependent projections; ordinary requests retain the existing completed projection cache. Guessing expiry from visible rows would be incorrect because pagination can hide the row changing totalCount.
