### PR TITLE
fix(exec): recover after doctor migration without gateway restart

### DIFF
--- a/src/infra/exec-approvals-migration-gate.ts
+++ b/src/infra/exec-approvals-migration-gate.ts
@@ -4,7 +4,9 @@ import path from "node:path";
 import { resolveExecApprovalsPath } from "./exec-approvals-config.js";
 
 const DOCTOR_CLAIM_SUFFIX = ".doctor-importing";
-const legacyPresenceCache = new Map<string, boolean>();
+// Doctor usually runs in another process, so cache only the steady-state absence;
+// a present verdict must be re-probed on the next attempt after Doctor finishes.
+const legacyAbsenceCache = new Set<string>();
 
 /**
  * Doctor repairs whichever state directory its own environment resolves to, so a bare
@@ -42,26 +44,20 @@ export function assertNoPendingLegacyExecApprovals(
   options: { pathMayExist?: (filePath: string) => boolean } = {},
 ): void {
   const sourcePath = resolveExecApprovalsPath();
-  let hasLegacy = legacyPresenceCache.get(sourcePath);
-  if (hasLegacy === undefined) {
-    const probe = options.pathMayExist ?? pathMayExist;
-    // Bound both Doctor rename directions: source -> claim and claim -> source.
-    const sourceBefore = probe(sourcePath);
-    const claim = probe(`${sourcePath}${DOCTOR_CLAIM_SUFFIX}`);
-    const sourceAfter = probe(sourcePath);
-    hasLegacy = sourceBefore || claim || sourceAfter;
-    legacyPresenceCache.set(sourcePath, hasLegacy);
+  if (legacyAbsenceCache.has(sourcePath)) {
+    return;
   }
-  if (hasLegacy) {
+  const probe = options.pathMayExist ?? pathMayExist;
+  // Bound both Doctor rename directions: source -> claim and claim -> source.
+  const sourceBefore = probe(sourcePath);
+  const claim = probe(`${sourcePath}${DOCTOR_CLAIM_SUFFIX}`);
+  const sourceAfter = probe(sourcePath);
+  if (sourceBefore || claim || sourceAfter) {
     throw new ExecApprovalsMigrationRequiredError(sourcePath);
   }
-}
-
-/** Forget one process-local legacy probe after Doctor resolves the source. */
-export function resetLegacyExecApprovalsPresenceCache(env: NodeJS.ProcessEnv = process.env): void {
-  legacyPresenceCache.delete(resolveExecApprovalsPath(env));
+  legacyAbsenceCache.add(sourcePath);
 }
 
 export function resetExecApprovalsMigrationGateForTest(): void {
-  legacyPresenceCache.clear();
+  legacyAbsenceCache.clear();
 }

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -382,19 +382,36 @@ describe("exec approvals SQLite store", () => {
     }
   });
 
-  it("blocks runtime reads while the retired JSON or claim exists", () => {
-    closeOpenClawStateDatabaseForTest();
-    const stateDir = process.env.OPENCLAW_STATE_DIR;
-    if (!stateDir) {
-      throw new Error("missing test state dir");
-    }
-    fs.writeFileSync(
-      path.join(stateDir, "exec-approvals.json"),
-      serializeExecApprovals({ version: 1, agents: {} }),
-    );
-    execApprovalsStoreTesting.reset();
-    expect(() => loadExecApprovals()).toThrow(ExecApprovalsMigrationRequiredError);
-  });
+  it.each([
+    ["source", ""],
+    ["Doctor claim", ".doctor-importing"],
+  ])(
+    "blocks runtime reads while the retired %s exists, then rechecks after removal",
+    (_, suffix) => {
+      closeOpenClawStateDatabaseForTest();
+      const stateDir = process.env.OPENCLAW_STATE_DIR;
+      if (!stateDir) {
+        throw new Error("missing test state dir");
+      }
+      const sourcePath = path.join(stateDir, "exec-approvals.json");
+      const legacyPath = `${sourcePath}${suffix}`;
+      fs.writeFileSync(legacyPath, serializeExecApprovals({ version: 1, agents: {} }));
+      execApprovalsStoreTesting.reset();
+      let caught: unknown;
+      try {
+        loadExecApprovals();
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(ExecApprovalsMigrationRequiredError);
+      expect(caught).toMatchObject({
+        message: `Legacy exec approvals exist at ${sourcePath}. Run \`openclaw doctor --fix\` with OPENCLAW_STATE_DIR set to ${stateDir} before using exec approvals.`,
+      });
+
+      fs.rmSync(legacyPath);
+      expect(loadExecApprovals()).toMatchObject({ version: 1, agents: {} });
+    },
+  );
 
   it("scopes the doctor command to the blocked state directory", () => {
     // A bare `openclaw doctor --fix` repairs the default root, leaving a scoped

--- a/src/infra/state-migrations.exec-approvals.ts
+++ b/src/infra/state-migrations.exec-approvals.ts
@@ -6,7 +6,6 @@ import {
   resolveExecApprovalsPath,
   tryParsePersistedExecApprovals,
 } from "./exec-approvals-config.js";
-import { resetLegacyExecApprovalsPresenceCache } from "./exec-approvals-migration-gate.js";
 import {
   readExecApprovalsConfigRow,
   serializeExecApprovals,
@@ -321,7 +320,6 @@ async function migrateWithExclusiveStateOwnership(params: {
       `Legacy exec approvals were removed, but their receipt could not be finalized: ${String(error)}`,
     );
   }
-  resetLegacyExecApprovalsPresenceCache(params.env);
   return {
     changes: [decisionMessage(result.decision, result.removeSource)],
     warnings,


### PR DESCRIPTION
Closes #118762

## What Problem This Solves

Fixes an issue where agents using exec could remain blocked by a legacy-approvals migration error after an operator had successfully run `openclaw doctor --fix`. Because the running Gateway retained the refusal until restart, repeating the prescribed repair did not restore exec.

## Why This Change Was Made

The migration gate cached both absence and presence for the process lifetime. A Gateway that observed the retired JSON or Doctor's temporary claim therefore kept treating that observation as current even when a separate Doctor CLI process removed the state.

The gate now caches only the steady-state absence. A real source or `.doctor-importing` claim still fails closed with the same typed, actionable error, but that positive observation is re-probed on the next attempt. This keeps the normal path free of repeated filesystem work and makes a completed separate-process Doctor migration visible without cross-process signaling.

The existing source-claim-source probe already bounds Doctor's rename window. A settle timer or retry delay would add timing policy without improving the required invariant: if an attempt overlaps the rename/removal window, it may fail closed once, then the next attempt re-probes. The obsolete same-process cache-reset hook was removed so correctness no longer depends on which process runs Doctor.

## User Impact

After Doctor migrates and removes retired exec-approval state, the next exec attempt can proceed without restarting the Gateway. Exec remains blocked while either the legacy source or Doctor claim genuinely exists.

## Evidence

Observed before the repair on maintainer build `39c506b`: the Gateway continued returning `ExecApprovalsMigrationRequiredError` after a separate `doctor --fix` completed, and recovered only after restart.

Focused gate/store/Doctor proof:

```text
$ node scripts/run-vitest.mjs src/infra/exec-approvals-store.test.ts src/infra/state-migrations.exec-approvals.test.ts
Test Files  2 passed (2)
Tests  33 passed (33)
[test] passed 1 Vitest shard in 7.27s
```

The regression runs the real filesystem order for both `exec-approvals.json` and `.doctor-importing`: present -> same typed/actionable error -> remove without reset -> next store call succeeds.

Exec and node-host caller proof:

```text
$ node scripts/run-vitest.mjs src/agents/bash-tools.exec.security-floor.test.ts src/node-host/invoke-system-run.test.ts
Test Files  1 passed (1) / Tests  81 passed (81)
Test Files  1 passed (1) / Tests  15 passed (15)
[test] passed 2 Vitest shards in 16.17s
```

Touched-file gate:

```text
$ node scripts/check-changed.mjs -- src/infra/exec-approvals-migration-gate.ts src/infra/exec-approvals-store.test.ts src/infra/state-migrations.exec-approvals.ts
exit 0
```

This covered formatting, production/test typechecks, targeted lint, Plugin SDK and dependency guards, dead exports, native schema v6, database-first legacy-store rules, runtime import cycles, and the remaining core architecture guards.

Codex autoreview: clean, no accepted/actionable findings (`gpt-5.6-sol`, high reasoning, 0.98 confidence).

LOC: production `+13/-19` (net `-6`); tests `+30/-13` (net `+17`). No config, schema, protocol, or public API changes.
