### PR TITLE
test(agents): avoid provider fixture fallback delays

### DIFF
--- a/src/agents/model-runtime-aliases.test.ts
+++ b/src/agents/model-runtime-aliases.test.ts
@@ -64,6 +64,7 @@ function createAnthropicAuthConfig(params: {
 describe("resolveCliRuntimeExecutionProvider", () => {
   beforeEach(() => {
     cliBackendsTesting.setDepsForTest({
+      resolvePluginSetupCliBackend: () => undefined,
       resolvePluginSetupRegistry: () => ({
         providers: [],
         cliBackends: [],

--- a/src/agents/provider-http-errors.test.ts
+++ b/src/agents/provider-http-errors.test.ts
@@ -421,19 +421,29 @@ describe("provider error utils", () => {
   });
 
   it("rejects stalled non-2xx error body read after chunk idle timeout", async () => {
-    const stream = new ReadableStream<Uint8Array>({
-      start(controller) {
-        controller.enqueue(new TextEncoder().encode('{"error": {"message": "par'));
-      },
-    });
-    const response = new Response(stream, {
-      status: 502,
-      headers: { "content-type": "application/json" },
-    });
+    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    try {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('{"error": {"message": "par'));
+        },
+      });
+      const response = new Response(stream, {
+        status: 502,
+        headers: { "content-type": "application/json" },
+      });
 
-    await expect(assertOkOrThrowProviderError(response, "stalled-error")).rejects.toThrow(
-      "stalled-error (502)",
-    );
+      const assertion = expect(
+        assertOkOrThrowProviderError(response, "stalled-error"),
+      ).rejects.toThrow("stalled-error (502)");
+      await vi.advanceTimersByTimeAsync(0);
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 10_000);
+      await vi.advanceTimersByTimeAsync(10_000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("proves idle timeout with a real TCP server that stalls mid-JSON-body", async () => {


### PR DESCRIPTION
## Summary

- keep the incompatible CLI runtime-alias test on its explicit empty setup fixture instead of falling through to real plugin metadata discovery
- advance the stalled provider error-body test with fake timers while asserting the production 10,000 ms idle timeout exactly
- preserve all test cases and production timeout/runtime behavior

## Proof

- focused: 2 files, 34 tests passed in 1.88s on the final base
- exact models group: 50 files, 1,195 tests passed in 74.17s on the final pre-PR base
- three alternating exact-group pairs saved 16.945s, 8.029s, and 15.683s; median saving 15.683s
- target test bodies dropped from approximately 27.6s combined to approximately 0.2s combined
- oxfmt and direct oxlint passed; git diff --check passed
- autoreview clean with no accepted/actionable findings

The delegated changed-file gate could not acquire a Crabbox/Testbox backend. Its trusted-source local fallback exposed an unrelated existing packages/terminal-core declaration error before linting these files; direct targeted linting passed.
