### PR TITLE
fix(diagnostics): report stuck sessions on lanes that keep receiving messages

### DIFF
--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -935,15 +935,23 @@ describe("stuck session diagnostics threshold", () => {
         activeWorkKind: "embedded_run",
       },
     );
+    // What the operator is told is the progress clock (>= the 60s abort
+    // threshold), not the 5s session-touch clock inbound traffic keeps resetting.
+    const stalled = requireRecord(
+      events.findLast((event) => event.type === "session.stalled"),
+      "stalled event",
+    );
+    expect(stalled.ageMs).toBeGreaterThanOrEqual(60_000);
+
     expectRecoveryCall(
       recoverStuckSession,
       { sessionId: "s1", sessionKey: "main", allowActiveAbort: true },
       ["ageMs", "stateGeneration", "queueDepth"],
     );
     const request = requireFirstMockCallArg(recoverStuckSession, "recoverStuckSession");
-    // The reported age is the progress clock (>= the 60s abort threshold), not
-    // the 5s session-touch clock the inbound traffic keeps resetting.
-    expect(request.ageMs).toBeGreaterThanOrEqual(60_000);
+    // The recovery request still carries the session clock, so the runtime's
+    // ownerless-lane release window keeps the age it has always been given.
+    expect(request.ageMs).toBeLessThan(30_000);
     expect(request.queueDepth).toBeGreaterThan(0);
   });
 

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -1025,6 +1025,27 @@ describe("stuck session diagnostics threshold", () => {
     expect(recoverStuckSession).not.toHaveBeenCalled();
   });
 
+  it("does not recover a session whose only progress signal is markDiagnosticSessionProgress", () => {
+    const recoverStuckSession = vi.fn();
+
+    // An earlier embedded turn leaves an activity row behind: recordRunCompleted
+    // clears the active sets but activityByRef is never pruned.
+    logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+    markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+    markDiagnosticEmbeddedRunEnded({ sessionId: "s1", sessionKey: "main" });
+
+    startDiagnosticHeartbeat({ diagnostics: { enabled: true } }, { recoverStuckSession });
+
+    // ACP turn in progress: dispatch-acp.ts:447 refreshes only state.lastActivity.
+    for (let i = 0; i < 8; i += 1) {
+      vi.advanceTimersByTime(25_000);
+      markDiagnosticSessionProgress({ sessionKey: "main" });
+      vi.advanceTimersByTime(5_000);
+    }
+
+    expect(recoverStuckSession).not.toHaveBeenCalled();
+  });
+
   it("recovers stale native tool calls through the active-run abort path", async () => {
     const events: DiagnosticEventPayload[] = [];
     const recoverStuckSession = vi.fn();

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -901,6 +901,130 @@ describe("stuck session diagnostics threshold", () => {
     );
   });
 
+  it("still observes a wedged processing lane whose inbound traffic keeps refreshing session activity", () => {
+    const events: DiagnosticEventPayload[] = [];
+    const recoverStuckSession = vi.fn();
+    const unsubscribe = onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+    try {
+      startDiagnosticHeartbeat({ diagnostics: { enabled: true } }, { recoverStuckSession });
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+      markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+
+      // Inbound every 25s against a 30s heartbeat and a 30s warn threshold, so
+      // `state.lastActivity` is only ever 5s old at tick time while run progress
+      // has been frozen since the run started.
+      for (let i = 0; i < 6; i += 1) {
+        vi.advanceTimersByTime(25_000);
+        logMessageQueued({ sessionId: "s1", sessionKey: "main", source: `inbound-${i}` });
+        vi.advanceTimersByTime(5_000);
+      }
+    } finally {
+      unsubscribe();
+    }
+
+    expectRecordFields(
+      requireRecord(
+        events.findLast((event) => event.type === "session.stalled"),
+        "stalled event",
+      ),
+      {
+        classification: "stalled_agent_run",
+        reason: "active_work_without_progress",
+        activeWorkKind: "embedded_run",
+      },
+    );
+    expectRecoveryCall(
+      recoverStuckSession,
+      { sessionId: "s1", sessionKey: "main", allowActiveAbort: true },
+      ["ageMs", "stateGeneration", "queueDepth"],
+    );
+    const request = requireFirstMockCallArg(recoverStuckSession, "recoverStuckSession");
+    // The reported age is the progress clock (>= the 60s abort threshold), not
+    // the 5s session-touch clock the inbound traffic keeps resetting.
+    expect(request.ageMs).toBeGreaterThanOrEqual(60_000);
+    expect(request.queueDepth).toBeGreaterThan(0);
+  });
+
+  it("stays silent on a busy processing lane whose run progress is genuinely fresh", () => {
+    const events: DiagnosticEventPayload[] = [];
+    const recoverStuckSession = vi.fn();
+    const unsubscribe = onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+    try {
+      startDiagnosticHeartbeat({ diagnostics: { enabled: true } }, { recoverStuckSession });
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+      markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+
+      for (let i = 0; i < 6; i += 1) {
+        vi.advanceTimersByTime(25_000);
+        logMessageQueued({ sessionId: "s1", sessionKey: "main", source: `inbound-${i}` });
+        markDiagnosticRunProgressForTest({
+          sessionId: "s1",
+          sessionKey: "main",
+          reason: "embedded_run:progress",
+        });
+        vi.advanceTimersByTime(5_000);
+      }
+    } finally {
+      unsubscribe();
+    }
+
+    expect(recoverStuckSession).not.toHaveBeenCalled();
+    expect(
+      events.filter(
+        (event) =>
+          event.type === "session.stuck" ||
+          event.type === "session.stalled" ||
+          event.type === "session.long_running",
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("does not make a blocked tool call newly abortable once the progress clock opens the gate", () => {
+    const events: DiagnosticEventPayload[] = [];
+    const recoverStuckSession = vi.fn();
+    const unsubscribe = onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+    try {
+      startDiagnosticHeartbeat({ diagnostics: { enabled: true } }, { recoverStuckSession });
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+      markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+      markDiagnosticToolStartedForTest({
+        sessionId: "s1",
+        sessionKey: "main",
+        runId: "run-1",
+        toolName: "bash",
+        toolCallId: "cmd-1",
+      });
+
+      // 180s of stale progress is far below BLOCKED_TOOL_CALL_ABORT_FLOOR_MS.
+      for (let i = 0; i < 6; i += 1) {
+        vi.advanceTimersByTime(25_000);
+        logMessageQueued({ sessionId: "s1", sessionKey: "main", source: `inbound-${i}` });
+        vi.advanceTimersByTime(5_000);
+      }
+    } finally {
+      unsubscribe();
+    }
+
+    expectRecordFields(
+      requireRecord(
+        events.findLast((event) => event.type === "session.stalled"),
+        "stalled event",
+      ),
+      {
+        classification: "blocked_tool_call",
+        reason: "blocked_tool_call",
+        activeWorkKind: "tool_call",
+      },
+    );
+    expect(recoverStuckSession).not.toHaveBeenCalled();
+  });
+
   it("recovers stale native tool calls through the active-run abort path", async () => {
     const events: DiagnosticEventPayload[] = [];
     const recoverStuckSession = vi.fn();

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -1046,6 +1046,48 @@ describe("stuck session diagnostics threshold", () => {
     expect(recoverStuckSession).not.toHaveBeenCalled();
   });
 
+  it("reports the progress clock, not the older session clock, for idle-queued stalls", () => {
+    const recoverStuckSession = vi.fn();
+
+    logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+    markDiagnosticToolStartedForTest({
+      sessionId: "s1",
+      sessionKey: "main",
+      runId: "run-1",
+      toolName: "bash",
+      toolCallId: "cmd-1",
+    });
+    logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "q1" });
+    logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "q2" });
+    logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "q3" });
+    // Last touch of state.lastActivity. Run progress keeps arriving after it, so
+    // the session clock ends up OLDER than the progress clock.
+    logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "idle" });
+
+    startDiagnosticHeartbeat({ diagnostics: { enabled: true } }, { recoverStuckSession });
+
+    for (let i = 0; i < 3; i += 1) {
+      vi.advanceTimersByTime(25_000);
+      markDiagnosticRunProgressForTest({
+        sessionId: "s1",
+        sessionKey: "main",
+        reason: "tool_call:progress",
+      });
+      vi.advanceTimersByTime(5_000);
+    }
+    expect(recoverStuckSession).not.toHaveBeenCalled();
+
+    // Progress stops at t=85s; the tick at t=120s sees progressAge=35s against a
+    // session clock of 120s.
+    vi.advanceTimersByTime(30_000);
+
+    const params = requireFirstMockCallArg(recoverStuckSession, "recoverStuckSession");
+    // The ownerless-lane release window in the recovery runtime is measured from
+    // this age, so it must stay the progress clock.
+    expect(params.ageMs).toBeGreaterThanOrEqual(30_000);
+    expect(params.ageMs).toBeLessThan(60_000);
+  });
+
   it("recovers stale native tool calls through the active-run abort path", async () => {
     const events: DiagnosticEventPayload[] = [];
     const recoverStuckSession = vi.fn();

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -1042,6 +1042,16 @@ describe("stuck session diagnostics threshold", () => {
     markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
     markDiagnosticEmbeddedRunEnded({ sessionId: "s1", sessionKey: "main" });
 
+    // Precondition: the row survives with no active work left on it. That is the
+    // state the activeWorkKind guard has to recognise.
+    expectRecordFields(
+      getDiagnosticSessionActivitySnapshot({ sessionId: "s1", sessionKey: "main" }),
+      {
+        activeWorkKind: undefined,
+        lastProgressReason: "embedded_run:ended",
+      },
+    );
+
     startDiagnosticHeartbeat({ diagnostics: { enabled: true } }, { recoverStuckSession });
 
     // ACP turn in progress: dispatch-acp.ts:447 refreshes only state.lastActivity.

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -1311,10 +1311,13 @@ export function startDiagnosticHeartbeat(
       // `state.lastActivity` is refreshed by every inbound message, so it dates the
       // arrival of new work rather than progress on existing work: a wedged lane
       // receiving messages faster than the threshold can never age into observation.
-      // Reconcile on run-progress age, and keep the session clock as a lower bound so
-      // an orphaned session with no activity row is still observed exactly as before.
+      // Reconcile on run-progress age instead, but only while run activity is
+      // registered — `markDiagnosticSessionProgress` (the ACP dispatcher's progress
+      // signal) refreshes the session clock alone, and `activityByRef` entries outlive
+      // the run that created them, so a finished run's row would otherwise make a
+      // healthy ACP turn read as stale forever.
       const progressAgeMs = activity.lastProgressAgeMs ?? ageMs;
-      const attentionAgeMs = Math.max(ageMs, progressAgeMs);
+      const attentionAgeMs = activity.activeWorkKind ? Math.max(ageMs, progressAgeMs) : ageMs;
       if (
         (state.state === "processing" && attentionAgeMs > stuckSessionWarnMs) ||
         idleQueuedRecoverableStall

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -1327,6 +1327,13 @@ export function startDiagnosticHeartbeat(
         // value, so letting an older session clock win there would release a lane
         // before its no-progress safety window and re-run work still in flight.
         const attentionAgeMs = idleQueuedRecoverableStall ? progressAgeMs : observedAgeMs;
+        // Recovery keeps receiving the session clock. Only what the operator is
+        // told changes here; the runtime's ownerless-lane release window
+        // (diagnostic-stuck-session-recovery.runtime.ts) stays on the age it has
+        // always been given, so this widening cannot shorten it. Abort eligibility
+        // is unaffected either way: that path reads activity.lastProgressAgeMs
+        // directly whenever a run-activity row exists.
+        const recoveryAgeMs = idleQueuedRecoverableStall ? progressAgeMs : ageMs;
         const classification = logSessionAttention({
           sessionId: state.sessionId,
           sessionKey: state.sessionKey,
@@ -1355,7 +1362,7 @@ export function startDiagnosticHeartbeat(
             sessionId: state.sessionId,
             sessionKey: state.sessionKey,
             sessionFile: state.sessionFile,
-            ageMs: attentionAgeMs,
+            ageMs: recoveryAgeMs,
             queueDepth: resolveDiagnosticQueuedBacklog(state),
             expectedState: state.state,
             stateGeneration: state.generation,

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -1317,11 +1317,16 @@ export function startDiagnosticHeartbeat(
       // the run that created them, so a finished run's row would otherwise make a
       // healthy ACP turn read as stale forever.
       const progressAgeMs = activity.lastProgressAgeMs ?? ageMs;
-      const attentionAgeMs = activity.activeWorkKind ? Math.max(ageMs, progressAgeMs) : ageMs;
+      const observedAgeMs = activity.activeWorkKind ? Math.max(ageMs, progressAgeMs) : ageMs;
       if (
-        (state.state === "processing" && attentionAgeMs > stuckSessionWarnMs) ||
+        (state.state === "processing" && observedAgeMs > stuckSessionWarnMs) ||
         idleQueuedRecoverableStall
       ) {
+        // The idle-queued branch keeps reporting the progress clock alone: the
+        // recovery runtime measures its ownerless-lane release window from this
+        // value, so letting an older session clock win there would release a lane
+        // before its no-progress safety window and re-run work still in flight.
+        const attentionAgeMs = idleQueuedRecoverableStall ? progressAgeMs : observedAgeMs;
         const classification = logSessionAttention({
           sessionId: state.sessionId,
           sessionKey: state.sessionKey,

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -1308,13 +1308,17 @@ export function startDiagnosticHeartbeat(
         activity,
         staleMs: stuckSessionWarnMs,
       });
+      // `state.lastActivity` is refreshed by every inbound message, so it dates the
+      // arrival of new work rather than progress on existing work: a wedged lane
+      // receiving messages faster than the threshold can never age into observation.
+      // Reconcile on run-progress age, and keep the session clock as a lower bound so
+      // an orphaned session with no activity row is still observed exactly as before.
+      const progressAgeMs = activity.lastProgressAgeMs ?? ageMs;
+      const attentionAgeMs = Math.max(ageMs, progressAgeMs);
       if (
-        (state.state === "processing" && ageMs > stuckSessionWarnMs) ||
+        (state.state === "processing" && attentionAgeMs > stuckSessionWarnMs) ||
         idleQueuedRecoverableStall
       ) {
-        const attentionAgeMs = idleQueuedRecoverableStall
-          ? (activity.lastProgressAgeMs ?? ageMs)
-          : ageMs;
         const classification = logSessionAttention({
           sessionId: state.sessionId,
           sessionKey: state.sessionKey,


### PR DESCRIPTION
Related: #103690
Related: #96834

<!--
Linked as context, not as fixes. Both carry `no-new-fix-pr` and
`needs-product-decision`; their open question is a product call about when a lane
should be released, which this PR neither answers nor changes.
-->

## What Problem This Solves

Fixes an issue where a reply lane that has wedged mid-turn produces no operator
signal, and no recovery request, for as long as users keep messaging it.

The heartbeat's stuck-session check gates on `Date.now() - state.lastActivity`.
`logMessageQueuedWithBacklogPolicy` rewrites `state.lastActivity`
(`src/logging/diagnostic-runtime.ts:48`) for every arriving inbound message,
before reply admission is attempted. The clock meant to notice that nothing is
progressing is reset by the arrival of new work, so the more a user is ignored,
the quieter the system gets.

Suppressed with it, on that lane: the `stuck session` / `stalled session`
warnings and the `session.stuck` / `session.stalled` events emitted from
`logSessionAttention`, and the heartbeat's recovery request. On `d5887c110e5`, `resetCommandLane` has
two production call sites, both inside `recoverStuckDiagnosticSession`
(`diagnostic-stuck-session-recovery.runtime.ts:298` and `:340`), and both are reached only through this gate.

Measured at default timings: a lane holds 10 queued messages for 7 minutes and
emits zero warnings, zero events, zero recovery requests. The identical wedge with
nobody typing is warned about 10 times.

## Why This Change Was Made

`activity.lastProgressAgeMs` is refreshed only by run-activity lifecycle events
(`touchSessionActivity` in `src/logging/diagnostic-run-activity.ts`), not by
message arrival, and the sibling `idle` branch of this same `if` already uses it.

```ts
const progressAgeMs = activity.lastProgressAgeMs ?? ageMs;
const observedAgeMs = activity.activeWorkKind ? Math.max(ageMs, progressAgeMs) : ageMs;
if ((state.state === "processing" && observedAgeMs > stuckSessionWarnMs) || idleQueuedRecoverableStall) {
  const attentionAgeMs = idleQueuedRecoverableStall ? progressAgeMs : observedAgeMs;
  const recoveryAgeMs = idleQueuedRecoverableStall ? progressAgeMs : ageMs;
```

Three clocks, one per consumer:

| value | drives | changed? |
|---|---|---|
| `observedAgeMs` | whether the processing branch opens the gate | **yes** — the fix |
| `attentionAgeMs` | the age in the warning and the emitted event | **yes**, for processing lanes |
| `recoveryAgeMs` | the age handed to `requestStuckSessionRecovery` | **no** — each branch keeps the value it passes today |

Why each guard is there:

- `Math.max` keeps the session clock as a lower bound, so the gate does not close
  anywhere it currently opens.
- The `activeWorkKind` guard matters because `activityByRef` entries outlive the
  run that created them, while `markDiagnosticSessionProgress` writes
  `state.lastActivity` only. On `d5887c110e5` that writer has three production
  callers, all on the ACP dispatch path: `dispatch-acp.ts:447` and
  `dispatch-from-config.gather.ts:240` / `:242`. Without the guard, a session that
  once ran an embedded turn keeps a stale activity row and a healthy ACP turn is
  treated as wedged — see the regression test below, which fails without it.
- Recovery keeps the age each branch already passes: the processing branch hands
  it `ageMs` (the session clock) and the idle-queued branch hands it
  `progressAgeMs`, both exactly as upstream does. That leaves the ownerless-lane
  release window which reads it (`resolveStaleActiveLaneTaskReleaseMs` /
  `...recovery.runtime.ts:297`) unchanged on both branches. Abort eligibility is
  unaffected either way — `isActiveRunProgressStale` (`:78`) prefers
  `activity.lastProgressAgeMs` whenever a run-activity row exists.

Eligibility itself is untouched: `classifySessionAttention` and
`isActiveAbortRecoveryEligible` decide from the activity snapshot, so crossing the
gate does not make a session abortable. A test pins that a newly observable
blocked tool call is still not recovered.

## User Impact

On a wedged lane still receiving traffic — the case that previously emitted
nothing — operators get the `stuck session` / `stalled session` warning and the
matching diagnostic events. Lanes genuinely making progress stay quiet.

The heartbeat also reaches its recovery call, which it previously never did on
such a lane. That is where the evidence stops: the harness substitutes the
documented `opts.recoverStuckSession` seam and counts invocations, so what is
demonstrated is that the call is now issued — not that
`abortAndDrainEmbeddedAgentRun` or `resetCommandLane` then succeed. This PR makes
no claim that a wedge clears or that a restart becomes unnecessary; establishing
that needs an integration-level proof and is left to the follow-up that restores
the ownerless-lane release.

## Fix summary

- **Root cause**: the staleness gate reads a field that inbound arrival rewrites.
- **Fix**: open the processing-state gate on the run-progress clock (guarded on
  registered run activity) and report that age; hand recovery the same age as
  before.
- **Diff** (`d5887c110e5..ed699913b2a`): two files — `src/logging/diagnostic.ts`
  `+24 / -5` production, most of the added lines being comments recording why each
  guard exists, and `src/logging/diagnostic.test.ts` `+205 / -0`.
- **Tests**: five cases in the existing heartbeat suite, plus a 430s no-mock A/B
  at default timings.
- **Scope**: this PR is limited to the observation gate in
  `startDiagnosticHeartbeat`. `recoveryAgeMs` in the diff keeps the age upstream
  already passes, so the ownerless-lane release guarded at
  `src/logging/diagnostic-stuck-session-recovery.runtime.ts:297` behaves as it does
  today. Restoring it on busy lanes is out of scope here: it needs its own proof
  and is left to a follow-up.

## Evidence

### Real behavior proof

Behavior addressed: a wedged reply lane that keeps receiving inbound emits no
stuck/stalled warning, no `session.stuck` / `session.stalled` event, and no
recovery request.

Real environment tested: Linux, Node 24, the real `src/logging` diagnostic modules
imported directly (`startDiagnosticHeartbeat`, `createDiagnosticMessageLifecycle`,
`logSessionStateChange`, `markDiagnosticEmbeddedRunStarted`,
`markDiagnosticRunProgress`) with **no `vi.mock`, no vitest and no fake timers**,
at default timings (`stuckSessionWarnMs` unset → 120000, abort → 360000). The only
injected seam is the documented `opts.recoverStuckSession`, used to count
invocations. Captured at head `ed699913b2a`, merge base `d5887c110e5`.

Exact steps or command run after this patch: the harness (`wedge-gate-ab.mts`) is
a proof artifact and is not part of this diff; its full source is at the end of
this body. Each arm runs in its own scratch worktree so nothing is mutated in
place:

```sh
# one scratch worktree per arm, inside the repo so the node_modules link resolves
git worktree add worktrees/ab-after ed699913b2a
git worktree add worktrees/ab-before d5887c110e5
cp wedge-gate-ab.mts worktrees/ab-after/
cp wedge-gate-ab.mts worktrees/ab-before/
ln -sfn ../../node_modules worktrees/ab-after/node_modules
ln -sfn ../../node_modules worktrees/ab-before/node_modules
cd worktrees/ab-after && ./node_modules/.bin/tsx wedge-gate-ab.mts after
cd worktrees/ab-before && ./node_modules/.bin/tsx wedge-gate-ab.mts before
```

Both arms build an identical wedge — one embedded run started, its terminal
`run:completed` progress frame recorded, the session left pinned in `processing`.
Two variables are crossed: the code revision (base vs this PR) and, within each
revision, inbound cadence only — none, versus one message every 45s for 430s.

Before evidence:

Busy lane, base:

```json
{
  "variant": "before",
  "arm": "before_busy_lane",
  "stuckSessionWarnMs": "production default (120000)",
  "stuckSessionAbortMs": "production default (360000)",
  "inboundEveryMs": 45000,
  "observedSeconds": 430,
  "recoveryRequests": 0,
  "recoveryCalls": [],
  "attentionEvents": 0,
  "warnings": 0,
  "warningSample": [],
  "finalSessionState": "processing",
  "finalQueueDepth": 10,
  "finalAgeMsSinceLastActivity": 25000
}
```

Evidence after fix:

Busy lane, this PR:

```json
{
  "variant": "after",
  "arm": "after_busy_lane",
  "inboundEveryMs": 45000,
  "observedSeconds": 430,
  "recoveryRequests": 3,
  "recoveryCalls": [
    { "atSec": 360, "ageSec": 0, "queueDepth": 8 },
    { "atSec": 390, "ageSec": 30, "queueDepth": 8 },
    { "atSec": 420, "ageSec": 15, "queueDepth": 9 }
  ],
  "attentionEvents": 10,
  "warnings": 10,
  "warningSample": [
    "t=150s stalled session: sessionId=wedged-session-1 state=processing age=150s queueDepth=3 reason=queued_behind_terminal_active_work classification=stalled_agent_run activeWorkKind=embedded_run lastProgress=run:completed lastProgressAge=150s terminalProgressStale=true recovery=none",
    "t=180s stalled session: sessionId=wedged-session-1 state=processing age=180s queueDepth=4 reason=queued_behind_terminal_active_work classification=stalled_agent_run activeWorkKind=embedded_run lastProgress=run:completed lastProgressAge=180s terminalProgressStale=true recovery=none"
  ],
  "finalSessionState": "processing",
  "finalQueueDepth": 10,
  "finalAgeMsSinceLastActivity": 24998
}
```

Observed result after fix: same wedge, same 10 queued messages, same 25s since the
last inbound. Before: zero warnings, zero events, zero recovery requests across
the full 7 minutes. After: 10 warnings, and 3 recovery calls observed at the seam. Their `queueDepth`
values in the `recoveryCalls` array above rise 8 → 8 → 9 because each entry's
`atSec` samples the backlog while inbound is still arriving; `finalQueueDepth` is
the raw counter at the end of the arm and reads 10 in both arms.

The split is visible in the same capture. In `warningSample` the reported `age=`
tracks `lastProgressAge=` and climbs with it, while every entry in `recoveryCalls`
carries an `ageSec` far below its own `atSec` — that is the session clock, kept
small because inbound keeps resetting it. Observation moved; the age handed to the
recovery runtime did not.

### Secondary, timing-dependent: the quiet-lane control

Nobody typing after the wedge. The warning count is 10 in every run on both sides.
Recovery begins at the first tick whose measured progress age has crossed the
existing 360s threshold — t=360s or t=390s depending on sub-second process phase,
so the raw count over a 430s arm is 2 or 3 rather than a stable number. Three runs
per side:

```
### AFTER quiet rep1
{"variant":"after","quietRecoveryRequests":3,"quietRecoveryFirstAtSec":360,"quietWarnings":10}
### AFTER quiet rep2
{"variant":"after","quietRecoveryRequests":2,"quietRecoveryFirstAtSec":390,"quietWarnings":10}
### BEFORE quiet rep1
{"variant":"before","quietRecoveryRequests":3,"quietRecoveryFirstAtSec":360,"quietWarnings":10}
### BEFORE quiet rep2
{"variant":"before","quietRecoveryRequests":3,"quietRecoveryFirstAtSec":360,"quietWarnings":10}
```

The third run per side is the quiet arm of the 4-cell run above (before: 3 at
t=360s, after: 2 at t=390s). The 390s outcome
occurs on both sides across runs. The expression that decides it,
`isStalledEmbeddedRunRecoveryEligible`, compares `activity.lastProgressAgeMs`
against `stuckSessionAbortMs`; this patch touches neither.

### Regression tests

All five cases extend the existing `stuck session diagnostics threshold` suite in
`src/logging/diagnostic.test.ts`, alongside the code they cover. No new test file:

1. `still observes a wedged processing lane whose inbound traffic keeps refreshing
   session activity` — emits `session.stalled` and calls `recoverStuckSession`;
   asserts the emitted event carries the progress clock (>= the abort threshold)
   **and** that the recovery request still carries the session clock (< 30s),
   pinning both halves of the split;
2. `stays silent on a busy processing lane whose run progress is genuinely fresh`
   — no recovery, no attention event;
3. `does not make a blocked tool call newly abortable once the progress clock
   opens the gate` — observed, not recovered;
4. `does not recover a session whose only progress signal is
   markDiagnosticSessionProgress` — the ACP shape;
5. `reports the progress clock, not the older session clock, for idle-queued
   stalls`.

```
$ node scripts/run-vitest.mjs src/logging/diagnostic.test.ts
 Test Files  1 passed (1)
      Tests  84 passed (84)
```

`oxfmt --check` and `oxlint` are clean on both changed files. `tsgo --noEmit`
reports two errors, in `packages/terminal-core/src/ansi.ts` and
`ui/src/app-session-route-paths.ts`; both reproduce identically with this patch
stashed, so they are pre-existing and untouched by this diff. The full suite was
not run locally — the changed surface is one heartbeat branch covered by the file
above, and CI runs the rest.

With `src/logging/diagnostic.ts` restored to the base:

```
 × still observes a wedged processing lane whose inbound traffic keeps refreshing session activity
 × does not make a blocked tool call newly abortable once the progress clock opens the gate
 Test Files  1 failed (1)
      Tests  2 failed | 82 passed (84)
```

Cases 2, 4 and 5 stay green in both directions by design; case 5 fails with
`expected 120000 to be less than 60000` if the idle-branch guard is dropped.

What was not tested:

- The harness is process-local. It drives the real diagnostic modules at real
  default timings, but it is not a live channel trace; the field reports in
  #103690 and #96834 are corroboration, not this proof.
- Recovery is counted at the injected seam. `abortAndDrainEmbeddedAgentRun` and
  `resetCommandLane` never execute, so nothing downstream of the request is
  demonstrated.
- Only the `embedded_run` wedge shape gets a live arm; `tool_call` and
  `model_call` are covered by the unit cases.
- No arm reaches `!activeSessionId && sessionLane`, so the ownerless-lane release
  window is not exercised. It is also not modified — the age it reads is passed
  through unchanged, which case 1 asserts directly.

Proof limitations or environment constraints: the harness uses the real system
clock with no time mocking, so counts that straddle the 360000ms abort boundary
vary by one tick between runs — which is why the quiet control is reported over
three runs per side and labelled secondary. Nothing else in the measurement is
timing-sensitive at that resolution.

### Harness (`wedge-gate-ab.mts`, proof artifact — not part of this diff)

Included so the 430s measurement is reproducible; skip it unless you want to rerun
the arms.

```ts
// Real-behavior A/B for the diagnostic heartbeat stuck-session observation gate.
//
// Imports the production modules directly (no vi.mock, no vitest, no fake timers)
// and builds an IDENTICAL wedged reply lane in both arms. The only independent
// variable is inbound cadence: arm "quiet" receives nothing after the wedge, arm
// "busy" receives one inbound every 45s -- a user chasing an unresponsive bot.
//
// Run once with src/logging/diagnostic.ts at upstream/main (BEFORE) and once with
// the patch applied (AFTER). Timings are the PRODUCTION defaults: no testTimings,
// so stuckSessionWarnMs = 120_000 (src/logging/diagnostic.ts:84) and the abort
// threshold = max(5min, warn*3) = 360_000 (src/logging/diagnostic.ts:506-511).
//
//   ./node_modules/.bin/tsx wedge-gate-ab.mts <before|after>
import { onDiagnosticEvent, setDiagnosticsEnabledForProcess } from "./src/infra/diagnostic-events.js";
import {
  markDiagnosticEmbeddedRunStarted,
  markDiagnosticRunProgress,
} from "./src/logging/diagnostic-run-activity.js";
import { getDiagnosticSessionState } from "./src/logging/diagnostic-session-state.js";
import {
  diagnosticLogger,
  logSessionStateChange,
  resetDiagnosticStateForTest,
  startDiagnosticHeartbeat,
  stopDiagnosticHeartbeat,
} from "./src/logging/diagnostic.js";
import { createDiagnosticMessageLifecycle } from "./src/logging/message-lifecycle.js";

const VARIANT = process.argv[2] === "before" ? "before" : "after";
const SESSION_KEY = "agent:main:whatsapp:direct:+15550000000";
const SESSION_ID = "wedged-session-1";
const RUN_SECONDS = Number(process.env.AB_RUN_SECONDS ?? 430);
const INBOUND_EVERY_MS = 45_000;
const config = { diagnostics: { enabled: true } } as never;

function inbound() {
  createDiagnosticMessageLifecycle({
    enabled: true,
    channel: "whatsapp",
    sessionKey: SESSION_KEY,
    sessionId: SESSION_ID,
    source: "dispatch",
    processingReason: "message_start",
    trackSessionState: true,
  }).markProcessing();
}

async function runArm(label: string, busy: boolean) {
  resetDiagnosticStateForTest();
  setDiagnosticsEnabledForProcess(true);

  const recoveryCalls: { atSec: number; ageSec: number; queueDepth?: number }[] = [];
  const attentionEvents: { atSec: number; type: string; reason?: string; ageSec?: number }[] = [];
  const warnLines: string[] = [];

  const realWarn = diagnosticLogger.warn.bind(diagnosticLogger);
  const startedAt = Date.now();
  const sec = () => Math.round((Date.now() - startedAt) / 1000);

  diagnosticLogger.warn = (message: string, ...rest: unknown[]) => {
    if (/stuck session|stalled session|long-running session/i.test(message)) {
      warnLines.push(`t=${sec()}s ${message}`);
    }
    return realWarn(message, ...rest);
  };
  const unsubscribe = onDiagnosticEvent((event) => {
    if (
      event.type === "session.stuck" ||
      event.type === "session.stalled" ||
      event.type === "session.long_running"
    ) {
      const record = event as unknown as { reason?: string; ageMs?: number };
      attentionEvents.push({
        atSec: sec(),
        type: event.type,
        reason: record.reason,
        ageSec: typeof record.ageMs === "number" ? Math.round(record.ageMs / 1000) : undefined,
      });
    }
  });

  startDiagnosticHeartbeat(config, {
    getConfig: () => config,
    // No testTimings -> production resolveStuckSessionWarnMs() default of 120_000.
    recoverStuckSession: (params) => {
      recoveryCalls.push({
        atSec: sec(),
        ageSec: Math.round(params.ageMs / 1000),
        queueDepth: params.queueDepth,
      });
      return { status: "skipped", action: "observe_only", reason: "already_in_flight" } as never;
    },
  });

  // Identical wedge in both arms: a run that started, reported its terminal
  // progress frame, and left the session pinned in `processing` forever.
  inbound();
  markDiagnosticEmbeddedRunStarted({ sessionId: SESSION_ID, sessionKey: SESSION_KEY });
  markDiagnosticRunProgress({
    sessionId: SESSION_ID,
    sessionKey: SESSION_KEY,
    reason: "run:completed",
  });
  logSessionStateChange({
    sessionId: SESSION_ID,
    sessionKey: SESSION_KEY,
    state: "processing",
    reason: "wedged",
  });

  const timer = busy ? setInterval(inbound, INBOUND_EVERY_MS) : undefined;
  await new Promise((r) => setTimeout(r, RUN_SECONDS * 1_000));
  if (timer) {
    clearInterval(timer);
  }

  const state = getDiagnosticSessionState({ sessionId: SESSION_ID, sessionKey: SESSION_KEY });
  const result = {
    variant: VARIANT,
    arm: label,
    busyLane: busy,
    stuckSessionWarnMs: "production default (120000)",
    stuckSessionAbortMs: "production default (360000)",
    inboundEveryMs: busy ? INBOUND_EVERY_MS : null,
    observedSeconds: RUN_SECONDS,
    recoveryRequests: recoveryCalls.length,
    recoveryCalls,
    attentionEvents: attentionEvents.length,
    attentionEventSample: attentionEvents.slice(0, 4),
    warnings: warnLines.length,
    warningSample: warnLines.slice(0, 3),
    finalSessionState: state.state,
    finalQueueDepth: state.queueDepth,
    finalAgeMsSinceLastActivity: Date.now() - state.lastActivity,
  };

  stopDiagnosticHeartbeat();
  unsubscribe();
  diagnosticLogger.warn = realWarn;
  console.log(JSON.stringify(result, null, 2));
  return result;
}

const ARMS = process.env.AB_ARMS ?? "quiet,busy";
const summary: Record<string, unknown> = { variant: VARIANT };
if (ARMS.includes("quiet")) {
  const quiet = await runArm(`${VARIANT}_quiet_lane`, false);
  summary.quietRecoveryRequests = quiet.recoveryRequests;
  summary.quietRecoveryFirstAtSec = quiet.recoveryCalls[0]?.atSec ?? null;
  summary.quietWarnings = quiet.warnings;
}
if (ARMS.includes("busy")) {
  const busy = await runArm(`${VARIANT}_busy_lane`, true);
  summary.busyRecoveryRequests = busy.recoveryRequests;
  summary.busyWarnings = busy.warnings;
  summary.busyFinalQueueDepth = busy.finalQueueDepth;
}
console.log(JSON.stringify(summary));
process.exit(0);
```
