### PR TITLE
fix(cron): keep auto-disable notifications behind durable writes

### DIFF
--- a/src/cron/service/auto-disable.ts
+++ b/src/cron/service/auto-disable.ts
@@ -78,6 +78,8 @@ export function autoDisableCronJob(params: {
   if (params.deferredNotifications) {
     params.deferredNotifications.push(notify);
   } else {
+    // Production mutations always supply a post-persist queue; this fallback
+    // remains only for direct unit callers that have no durable owner.
     notify();
   }
   return true;

--- a/src/cron/service/ops-lifecycle.ts
+++ b/src/cron/service/ops-lifecycle.ts
@@ -90,17 +90,12 @@ export async function start(state: CronServiceState) {
       state.store.jobs = jobs.filter((job) => !completedJobIdsToDelete.has(job.id));
     }
     if (repairedAnyStartupRun || jobs.length > 0) {
-      const persisted = await persist(
-        state,
-        repairedAnyStartupRun ? undefined : { stateOnly: true },
-      );
       // Recovery notifications describe repaired durable rows, so never
       // publish them until the startup write has committed successfully.
-      if (persisted) {
-        for (const notify of postPersistNotifications) {
-          notify();
-        }
-      }
+      await persist(state, {
+        ...(repairedAnyStartupRun ? {} : { stateOnly: true }),
+        postPersistNotifications,
+      });
     }
   });
 
@@ -126,12 +121,9 @@ export async function start(state: CronServiceState) {
       deferredNotifications: postPersistMaintenanceNotifications,
     });
     if (changed) {
-      const persisted = await persist(state);
-      if (persisted) {
-        for (const notify of postPersistMaintenanceNotifications) {
-          notify();
-        }
-      }
+      await persist(state, {
+        postPersistNotifications: postPersistMaintenanceNotifications,
+      });
     }
     for (const interrupted of interruptedRuns) {
       const job = state.store?.jobs.find((entry) => entry.id === interrupted.jobId);

--- a/src/cron/service/ops.test.ts
+++ b/src/cron/service/ops.test.ts
@@ -562,6 +562,49 @@ describe("cron service ops seam coverage", () => {
     stop(state);
   });
 
+  it("start persists an interrupted-run auto-disable before notifying", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.parse("2026-03-23T12:00:00.000Z");
+    const job = createInterruptedMainJob(now);
+    job.state.consecutiveErrors = 9;
+    await writeCronStoreSnapshot({ storePath, jobs: [job] });
+
+    const order: string[] = [];
+    const enqueueSystemEvent = vi.fn(() => {
+      expect(order.at(-1)).toBe("persist");
+      order.push("notify");
+    });
+    const requestHeartbeat = vi.fn(() => {
+      expect(order.at(-1)).toBe("notify");
+      order.push("heartbeat");
+    });
+    const saveCronJobsStore = cronStoreModule.saveCronJobsStore;
+    vi.spyOn(cronStoreModule, "saveCronJobsStore").mockImplementation(async (...args) => {
+      await saveCronJobsStore(...args);
+      order.push("persist");
+    });
+    const state = createCronServiceState({
+      storePath,
+      cronEnabled: true,
+      log: logger,
+      nowMs: () => now,
+      enqueueSystemEvent,
+      requestHeartbeat,
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await start(state);
+
+    expect(order.slice(0, 3)).toEqual(["persist", "notify", "heartbeat"]);
+    expect((await loadCronStore(storePath)).jobs[0]).toMatchObject({
+      enabled: false,
+      state: {
+        autoDisabled: { reason: "consecutive-failures", consecutiveErrors: 10 },
+      },
+    });
+    stop(state);
+  });
+
   it.each([
     { identity: "canonical", reservationOffsetMs: undefined },
     { identity: "shipped reservation-keyed", reservationOffsetMs: 250 },
@@ -1704,48 +1747,71 @@ describe("cron service ops persist rollback", () => {
     expect(loaded.jobs.map((entry) => entry.id)).toEqual([job.id]);
   });
 
-  it("notifies about schedule auto-disable only after the mutation persists", async () => {
-    const { storePath } = await makeStorePath();
-    const now = Date.parse("2026-06-09T00:00:00.000Z");
-    const state = createOkIsolatedCronState({ storePath, now });
+  it.each(["mutation", "read maintenance"] as const)(
+    "notifies about schedule auto-disable only after %s persists",
+    async (triggerPath) => {
+      const { storePath } = await makeStorePath();
+      const now = Date.parse("2026-06-09T00:00:00.000Z");
+      const state = createOkIsolatedCronState({ storePath, now });
 
-    const malformed = await add(state, {
-      ...makeCreateInput("malformed sibling"),
-      schedule: { kind: "cron", expr: "0 1 * * *" },
-    });
-    if (state.timer) {
-      clearTimeout(state.timer);
-    }
-    malformed.state.nextRunAtMs = undefined;
-    malformed.state.scheduleErrorCount = 2;
-    const enqueueSystemEvent = vi.mocked(state.deps.enqueueSystemEvent);
-    const requestHeartbeat = vi.mocked(state.deps.requestHeartbeat);
-    enqueueSystemEvent.mockClear();
-    requestHeartbeat.mockClear();
-    const computeNextRunAtMs = cronSchedule.computeNextRunAtMs;
-    vi.spyOn(cronSchedule, "computeNextRunAtMs").mockImplementation((schedule, nowMs) => {
-      if (schedule.kind === "cron" && schedule.expr === "0 1 * * *") {
-        throw new Error("simulated schedule failure");
+      const malformed = await add(state, {
+        ...makeCreateInput("malformed sibling"),
+        schedule: { kind: "cron", expr: "0 1 * * *" },
+      });
+      if (state.timer) {
+        clearTimeout(state.timer);
       }
-      return computeNextRunAtMs(schedule, nowMs);
-    });
+      malformed.state.nextRunAtMs = undefined;
+      malformed.state.scheduleErrorCount = 2;
+      const enqueueSystemEvent = vi.mocked(state.deps.enqueueSystemEvent);
+      const requestHeartbeat = vi.mocked(state.deps.requestHeartbeat);
+      const order: string[] = [];
+      enqueueSystemEvent.mockClear();
+      requestHeartbeat.mockClear();
+      enqueueSystemEvent.mockImplementation(() => {
+        order.push("notify");
+      });
+      requestHeartbeat.mockImplementation(() => {
+        order.push("heartbeat");
+      });
+      const computeNextRunAtMs = cronSchedule.computeNextRunAtMs;
+      vi.spyOn(cronSchedule, "computeNextRunAtMs").mockImplementation((schedule, nowMs) => {
+        if (schedule.kind === "cron" && schedule.expr === "0 1 * * *") {
+          throw new Error("simulated schedule failure");
+        }
+        return computeNextRunAtMs(schedule, nowMs);
+      });
 
-    vi.spyOn(cronStoreModule, "saveCronJobsStore").mockRejectedValueOnce(new Error("disk full"));
-    await expect(add(state, makeCreateInput("failed mutation"))).rejects.toThrow("disk full");
+      const saveCronJobsStore = cronStoreModule.saveCronJobsStore;
+      vi.spyOn(cronStoreModule, "saveCronJobsStore")
+        .mockRejectedValueOnce(new Error("disk full"))
+        .mockImplementationOnce(async (...args) => {
+          expect(enqueueSystemEvent).not.toHaveBeenCalled();
+          expect(requestHeartbeat).not.toHaveBeenCalled();
+          await saveCronJobsStore(...args);
+          order.push("persist");
+        });
+      const trigger = () =>
+        triggerPath === "mutation"
+          ? add(state, makeCreateInput("trigger mutation"))
+          : list(state, { includeDisabled: true });
+      await expect(trigger()).rejects.toThrow("disk full");
 
-    expect(state.store?.jobs.find((job) => job.id === malformed.id)?.enabled).toBe(true);
-    expect(enqueueSystemEvent).not.toHaveBeenCalled();
-    expect(requestHeartbeat).not.toHaveBeenCalled();
+      expect(state.store?.jobs.find((job) => job.id === malformed.id)?.enabled).toBe(true);
+      expect(enqueueSystemEvent).not.toHaveBeenCalled();
+      expect(requestHeartbeat).not.toHaveBeenCalled();
 
-    await add(state, makeCreateInput("successful mutation"));
-    if (state.timer) {
-      clearTimeout(state.timer);
-    }
+      await trigger();
+      if (state.timer) {
+        clearTimeout(state.timer);
+      }
 
-    expect(state.store?.jobs.find((job) => job.id === malformed.id)?.enabled).toBe(false);
-    expect(enqueueSystemEvent).toHaveBeenCalledTimes(1);
-    expect(requestHeartbeat).toHaveBeenCalledTimes(1);
-  });
+      expect(state.store?.jobs.find((job) => job.id === malformed.id)?.enabled).toBe(false);
+      expect(order).toEqual(["persist", "notify", "heartbeat"]);
+      expect(enqueueSystemEvent).toHaveBeenCalledTimes(1);
+      expect(requestHeartbeat).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it.each(["failed", "committed", "uncertain"] as const)(
     "publishes agent-removal auto-disable notifications only after a %s roster outcome",
@@ -1831,6 +1897,10 @@ describe("cron service ops persist rollback", () => {
     }
     job.state.nextRunAtMs = undefined;
     job.state.scheduleErrorCount = 2;
+    const before = structuredClone(job);
+    const persistedBefore = structuredClone(
+      (await loadCronStore(storePath)).jobs.find((entry) => entry.id === job.id),
+    );
     const enqueueSystemEvent = vi.mocked(state.deps.enqueueSystemEvent);
     const requestHeartbeat = vi.mocked(state.deps.requestHeartbeat);
     enqueueSystemEvent.mockClear();
@@ -1845,8 +1915,10 @@ describe("cron service ops persist rollback", () => {
         ran: false,
         reason: "not-due",
       });
-      expect(job.enabled).toBe(true);
-      expect(job.state.scheduleErrorCount).toBe(2);
+      expect(job).toEqual(before);
+      expect((await loadCronStore(storePath)).jobs.find((entry) => entry.id === job.id)).toEqual(
+        persistedBefore,
+      );
       expect(enqueueSystemEvent).not.toHaveBeenCalled();
       expect(requestHeartbeat).not.toHaveBeenCalled();
     } finally {

--- a/src/cron/service/store.test.ts
+++ b/src/cron/service/store.test.ts
@@ -8,7 +8,7 @@ import { loadCronStore, saveCronStore } from "../store.js";
 import type { CronJob } from "../types.js";
 import { findJobOrThrow } from "./jobs.js";
 import { createCronServiceState } from "./state.js";
-import { ensureLoaded, persist } from "./store.js";
+import { ensureLoaded, persist, persistOrRestore, snapshotStoreForRollback } from "./store.js";
 
 const { logger, makeStorePath } = setupCronServiceSuite({
   prefix: "cron-service-store-seam",
@@ -62,6 +62,16 @@ function createReloadCronJob(params?: Partial<CronJob>): CronJob {
 describe("cron service store seam coverage", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it("does not drain post-persist notifications when there is no store to write", async () => {
+    const { storePath } = await makeStorePath();
+    const state = createStoreTestState(storePath);
+    const notify = vi.fn();
+
+    await expect(persist(state, { postPersistNotifications: [notify] })).resolves.toBe(false);
+
+    expect(notify).not.toHaveBeenCalled();
   });
 
   it("loads stored jobs, recomputes next runs, and does not rewrite the store on load", async () => {
@@ -192,6 +202,59 @@ describe("cron service store seam coverage", () => {
     );
     expect(state.durableNextRunAtMsByJobId.has(job.id)).toBe(true);
     expect(state.durableNextRunAtMsByJobId.get(job.id)).toBeUndefined();
+  });
+
+  it("drains post-persist notifications only after a successful state-only write", async () => {
+    const { storePath } = await makeStorePath();
+    await writeSingleJobStore(storePath, createReloadCronJob());
+    const state = createStoreTestState(storePath);
+    await ensureLoaded(state, { skipRecompute: true });
+    const notify = vi.fn();
+    const order: string[] = [];
+    const saveCronJobsStore = cronStoreModule.saveCronJobsStore;
+    vi.spyOn(cronStoreModule, "saveCronJobsStore")
+      .mockRejectedValueOnce(new Error("disk full"))
+      .mockImplementationOnce(async (...args) => {
+        expect(notify).not.toHaveBeenCalled();
+        await saveCronJobsStore(...args);
+        order.push("persist");
+      });
+    notify.mockImplementation(() => order.push("notify"));
+    const postPersistNotifications = [notify];
+
+    await expect(persist(state, { stateOnly: true, postPersistNotifications })).rejects.toThrow(
+      "disk full",
+    );
+    expect(notify).not.toHaveBeenCalled();
+
+    await persist(state, { stateOnly: true, postPersistNotifications });
+
+    expect(order).toEqual(["persist", "notify"]);
+    expect(notify).toHaveBeenCalledOnce();
+  });
+
+  it("does not restore speculative state after a post-persist notification throws", async () => {
+    const { storePath } = await makeStorePath();
+    const nextRunAtMs = STORE_TEST_NOW + 120_000;
+    await writeSingleJobStore(storePath, createReloadCronJob());
+    const state = createStoreTestState(storePath);
+    await ensureLoaded(state, { skipRecompute: true });
+    const snapshot = snapshotStoreForRollback(state);
+    const job = findJobOrThrow(state, "reload-cron-expr-job");
+    job.state.nextRunAtMs = nextRunAtMs;
+
+    await expect(
+      persistOrRestore(state, snapshot, {
+        postPersistNotifications: [
+          () => {
+            throw new Error("notification failed");
+          },
+        ],
+      }),
+    ).rejects.toThrow("notification failed");
+
+    expect(job.state.nextRunAtMs).toBe(nextRunAtMs);
+    expect((await loadCronStore(storePath)).jobs[0]?.state.nextRunAtMs).toBe(nextRunAtMs);
   });
 
   it("advances durable wake state while suppressing duplicate scheduled delivery", async () => {
@@ -355,16 +418,19 @@ describe("cron service store seam coverage", () => {
     const saveStore = vi
       .spyOn(cronStoreModule, "saveCronJobsStore")
       .mockRejectedValueOnce(new Error("quarantine unavailable"));
+    const notify = vi.fn();
+    const postPersistNotifications = [notify];
 
-    await persist(state, { stateOnly: true });
+    await persist(state, { stateOnly: true, postPersistNotifications });
 
     expect(saveStore).toHaveBeenCalledTimes(1);
     expect(onEvent).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalled();
     expect(state.pendingQuarantineConfigJobs).toHaveLength(1);
     expect(state.durableNextRunAtMsByJobId.get(job.id)).toBe(initialNextRunAtMs);
     expect((await loadCronStore(storePath)).jobs[0]?.state.nextRunAtMs).toBe(initialNextRunAtMs);
 
-    await persist(state, { stateOnly: true });
+    await persist(state, { stateOnly: true, postPersistNotifications });
 
     expect(saveStore).toHaveBeenLastCalledWith(
       storePath,
@@ -376,6 +442,7 @@ describe("cron service store seam coverage", () => {
       }),
     );
     expect(state.pendingQuarantineConfigJobs).toEqual([]);
+    expect(notify).toHaveBeenCalledOnce();
     expect(cronStoreModule.loadCronQuarantinedJobs(storePath)).toEqual([
       expect.objectContaining({ reason: "invalid-schedule" }),
     ]);

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -19,6 +19,7 @@ const loadedCronStoreRevisions = new WeakMap<CronServiceState, number>();
 type PersistOptions = {
   stateOnly?: boolean;
   suppressScheduledJobId?: string;
+  postPersistNotifications?: DeferredCronNotifications;
 };
 
 export type CronRollbackSnapshot = {
@@ -293,6 +294,9 @@ export async function persist(state: CronServiceState, opts?: PersistOptions) {
     stateOnly,
     suppressScheduledJobId: opts?.suppressScheduledJobId,
   });
+  for (const notify of opts?.postPersistNotifications ?? []) {
+    notify();
+  }
   return true;
 }
 
@@ -309,29 +313,27 @@ export function snapshotStoreForRollback(state: CronServiceState): CronRollbackS
 export async function persistOrRestore(
   state: CronServiceState,
   snapshot: CronRollbackSnapshot,
-  opts: {
-    postPersistNotifications?: DeferredCronNotifications;
-    suppressScheduledJobId?: string;
-  } = {},
+  opts: Omit<PersistOptions, "stateOnly"> = {},
 ) {
+  let writeCompleted = false;
+  const postPersistNotifications = opts.postPersistNotifications?.map((notify) => () => {
+    // Notification failures happen after commit and must not restore the
+    // speculative snapshot over rows that are already durable.
+    writeCompleted = true;
+    notify();
+  });
   try {
-    const persisted = await persist(
-      state,
-      opts.suppressScheduledJobId === undefined
-        ? undefined
-        : { suppressScheduledJobId: opts.suppressScheduledJobId },
-    );
+    const persisted = await persist(state, { ...opts, postPersistNotifications });
     if (!persisted) {
       throw new Error("cron: durable store write did not complete");
     }
+    writeCompleted = true;
   } catch (err) {
+    if (writeCompleted) {
+      throw err;
+    }
     state.store = snapshot.store;
     state.durableNextRunAtMsByJobId = snapshot.durableNextRunAtMsByJobId;
     throw err;
-  }
-  // Queued notifications must not describe speculative cron state that a
-  // failed write rolls back before the service lock is released.
-  for (const notify of opts.postPersistNotifications ?? []) {
-    notify();
   }
 }

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -2819,6 +2819,74 @@ describe("cron service timer regressions", () => {
     },
   );
 
+  it.each(["timer maintenance", "startup catch-up"] as const)(
+    "persists schedule auto-disable before notifying during %s",
+    async (path) => {
+      const store = timerRegressionFixtures.makeStorePath();
+      const now = Date.parse("2026-08-01T11:00:00.000Z");
+      const malformed = createIsolatedRegressionJob({
+        id: `malformed-${path}`,
+        name: `malformed ${path}`,
+        scheduledAt: now,
+        schedule: { kind: "cron", expr: "0 1 * * *" },
+        payload: { kind: "agentTurn", message: "malformed" },
+        state: { scheduleErrorCount: 2 },
+      });
+      const jobs =
+        path === "startup catch-up"
+          ? [
+              createDueIsolatedJob({ id: "due-startup-catch-up", nowMs: now, nextRunAtMs: now }),
+              malformed,
+            ]
+          : [malformed];
+      await saveCronStore(store.storePath, { version: 1, jobs });
+
+      const order: string[] = [];
+      const enqueueSystemEvent = vi.fn(() => {
+        expect(order.at(-1)).toBe("persist");
+        order.push("notify");
+      });
+      const requestHeartbeat = vi.fn(() => {
+        expect(order.at(-1)).toBe("notify");
+        order.push("heartbeat");
+      });
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => now,
+        enqueueSystemEvent,
+        requestHeartbeat,
+        runIsolatedAgentJob: createDefaultIsolatedRunner(),
+      });
+      const computeNextRunAtMs = schedule.computeNextRunAtMs;
+      vi.spyOn(schedule, "computeNextRunAtMs").mockImplementation((cronSchedule, nowMs) => {
+        if (cronSchedule.kind === "cron" && cronSchedule.expr === "0 1 * * *") {
+          throw new Error("simulated schedule failure");
+        }
+        return computeNextRunAtMs(cronSchedule, nowMs);
+      });
+      const saveCronJobsStore = cronStoreModule.saveCronJobsStore;
+      vi.spyOn(cronStoreModule, "saveCronJobsStore").mockImplementation(async (...args) => {
+        await saveCronJobsStore(...args);
+        order.push("persist");
+      });
+
+      if (path === "startup catch-up") {
+        await runMissedJobs(state);
+      } else {
+        await onTimer(state);
+      }
+
+      const notifyAt = order.indexOf("notify");
+      expect(order.slice(notifyAt - 1, notifyAt + 2)).toEqual(["persist", "notify", "heartbeat"]);
+      expect(state.store?.jobs.find((job) => job.id === malformed.id)?.enabled).toBe(false);
+      expect(
+        (await loadCronStore(store.storePath)).jobs.find((job) => job.id === malformed.id),
+      ).toMatchObject({ enabled: false });
+    },
+  );
+
   it("auto-disables a recurring job on its tenth consecutive run failure", () => {
     const startedAt = Date.parse("2026-08-01T12:00:00.000Z");
     const deferredNotifications: Array<() => void> = [];


### PR DESCRIPTION
Fixes #118345

AI-assisted: implemented and reviewed with Codex.

## What Problem This Solves

Fixes an issue where cron auto-disable notifications could escape from persistence call sites that each had to remember to drain a deferred queue. A missed drain or future unthreaded caller could describe an auto-disable transition before the matching state was durable.

The issue was closed by #118384 while this work was being prepared. That PR threaded the known production callers and made manual-run preflight suppress schedule-error side effects, but it did not move ordinary draining into the persistence owner or remove the duplicate startup drain loops requested by the issue.

## Why This Change Was Made

`persist(state, opts)` now owns ordinary post-persist draining and only drains after a successful write, including state-only writes. `persistOrRestore` delegates to it while preserving rollback semantics; a notification failure after commit cannot restore speculative in-memory state over already-durable rows. The two startup loops now pass their queues to `persist` instead of draining by hand.

Agent-roster deletion intentionally remains the exception: its auto-disable notification waits for the later roster commit (or an uncertain commit result), not merely the cron-store write.

The deferred parameters remain optional because making the full recompute/result family required would mechanically change 52 direct recompute test callers plus the separate failure-alert result-call family. All current production callers were verified to pass a real queue or use the advisory preflight suppression added by #118384; the immediate fallback now carries a why-comment that it is only for direct unit callers without a durable owner.

Manual-run preflight remains advisory: a schedule-computation throw does not increment the stored error count, disable the job, persist a transition, or notify. The regression now compares the complete in-memory and reloaded persisted job before and after the check.

Production LOC: 26 additions, 30 deletions (net -4). Test LOC: 248 additions, 41 deletions.

## User Impact

Operators can rely on cron auto-disable notifications representing state that has already committed. Failed writes do not publish false transitions, startup repair uses the same persistence-owned ordering, and manual eligibility checks remain side-effect-free for schedule-computation failures.

## Evidence

- `pnpm install` — passed.
- `node scripts/run-vitest.mjs src/cron/service/store.test.ts src/cron/service/ops.test.ts src/cron/service/timer.batch-finalization.test.ts src/cron/service/startup-run-repair.auto-disable.test.ts src/cron/service/jobs.schedule-error-isolation.test.ts src/cron/service.failure-alert.test.ts src/cron/service/timer.regression.test.ts` — 7 files passed, 202 tests passed.
- `node scripts/check-changed.mjs` — remote routing was unavailable because the configured Crabbox backends were not ready; the trusted-source local fallback below ran the same changed gate.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs` — passed, including production/test typechecks, lint, import cycles, storage, dependency, boundary, and dead-code guards.
- `./node_modules/.bin/oxfmt --check src/cron/service/auto-disable.ts src/cron/service/ops-lifecycle.ts src/cron/service/store.ts src/cron/service/store.test.ts src/cron/service/ops.test.ts src/cron/service/timer.regression.test.ts` — passed.
- `git diff --check origin/main...HEAD` — passed after rebase.
- Post-rebase sanity: `node scripts/run-vitest.mjs src/cron/service/store.test.ts` — 20 tests passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --engine codex` — clean; no accepted/actionable findings.
- Source-blind CLI validation used a fresh isolated gateway and state directory. Public validation rejected malformed cron expressions and invalid timezones before a threshold fixture could be created, and exposed no safe write-failure injector, so the four threshold-specific clauses were correctly reported `blocked_source_required`; no behavioral failure was observed and the isolated gateway/state were cleaned up.


---

## Maintainer live proof (dist build, ephemeral gateway :19876, isolated state dir, loopback alert webhook)

Config: `cron.failureAlert {enabled, after: 1, cooldownMs: 0, mode: webhook}` to a timestamped loopback listener (via `cron.webhookSsrfPolicy.dangerouslyAllowPrivateNetwork`).

**Committed-before-notification (normal path):** failing command job → run finalizes, then the alert webhook arrives at the listener (timestamped receipt); run record durably carries the outcome the alert describes. One alert pair per failed run, exactly once, cooldown honored.

**Forced write denial (adversarial path):** held `BEGIN EXCLUSIVE` on the state DB from a second connection, then triggered a manual run. Result: **nothing observable escaped** — the run was never admitted (admission itself requires the durable write), no run record, no execution, and **zero alert lines** during the lock or after release. No phantom notification ever appeared for that job.

**Honest scope note:** a mid-run persist failure cannot be forced externally against a live gateway — `chmod` does not affect an already-open SQLite fd (verified: writes continued), and an exclusive lock blocks at admission before execution. The mid-run write-failure ⇒ rollback-without-notification case is therefore owned by the fault-injection unit tests added in this PR (`store.test.ts`: persist failure ⇒ no delivery + snapshot restored; notification throw after commit ⇒ durable rows NOT restored over — the `writeCompleted` guard).
