### PR TITLE
test(mcp): keep oversized pagination proof independent of wall-clock load

### DIFF
--- a/src/node-host/mcp.test.ts
+++ b/src/node-host/mcp.test.ts
@@ -368,32 +368,40 @@ describe("node host MCP manager", () => {
   });
 
   it("isolates an oversized multi-page catalog at the accumulated byte ceiling", async () => {
-    const largeTool = {
-      ...tool("large"),
-      inputSchema: { type: "object" as const, description: "x".repeat(6 * 1024 * 1024) },
-    };
-    const oversized = createClient({
-      list: async (params) =>
-        params?.cursor ? { tools: [largeTool] } : { tools: [largeTool], nextCursor: "next" },
-    });
-    const healthy = createClient({ tools: [tool("search")] });
-    const warn = vi.fn();
-    const manager = await startNodeHostMcpManager(
-      { oversized: { command: "oversized" }, healthy: { command: "healthy" } },
-      {
-        createClient: (serverName) => (serverName === "oversized" ? oversized : healthy),
-        resolveTransport: () => transport,
-        warn,
-      },
-    );
+    // Large-page byte counting must not spend this unrelated wall-clock deadline;
+    // the preceding case separately proves strict catalog timeout enforcement.
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    try {
+      const largeTool = {
+        ...tool("large"),
+        inputSchema: { type: "object" as const, description: "x".repeat(6 * 1024 * 1024) },
+      };
+      const oversized = createClient({
+        list: async (params) =>
+          params?.cursor ? { tools: [largeTool] } : { tools: [largeTool], nextCursor: "next" },
+      });
+      const healthy = createClient({ tools: [tool("search")] });
+      const warn = vi.fn();
+      const manager = await startNodeHostMcpManager(
+        { oversized: { command: "oversized" }, healthy: { command: "healthy" } },
+        {
+          createClient: (serverName) => (serverName === "oversized" ? oversized : healthy),
+          resolveTransport: () => transport,
+          warn,
+        },
+      );
 
-    expect(oversized.listTools).toHaveBeenCalledTimes(2);
-    expect(oversized.close).toHaveBeenCalledOnce();
-    expect(warn).toHaveBeenCalledOnce();
-    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/listing exceeded \d+ bytes/u));
-    expect(manager.descriptors.map((descriptor) => descriptor.name)).toEqual(["healthy_search"]);
+      expect(oversized.listTools).toHaveBeenCalledTimes(2);
+      expect(oversized.close).toHaveBeenCalledOnce();
+      expect(warn).toHaveBeenCalledOnce();
+      expect(warn).toHaveBeenCalledWith(expect.stringMatching(/listing exceeded \d+ bytes/u));
+      expect(manager.descriptors.map((descriptor) => descriptor.name)).toEqual(["healthy_search"]);
 
-    await manager.close();
+      await manager.close();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("isolates a listing that exceeds the retained candidate ceiling", async () => {


### PR DESCRIPTION
## Summary
- make the existing oversized multi-page MCP tool-catalog byte-limit regression independent of unrelated CPU/wall-clock scheduling under hosted CI load
- freeze time only inside that one byte-ceiling test and always restore real timers; preserve the distinct 50 ms production deadline and dedicated strict timeout regression unchanged

## Reproduced production-adjacent CI failure
The test allocates and measures a 6 MiB first catalog page while inheriting a 50 ms request deadline. Under a loaded runner, synchronous byte counting can consume the deadline before requesting page two, so the byte-ceiling assertion fails for the unrelated timeout reason. An actual owner preload advancing Date.now by 75 ms only after the 6 MiB Buffer.byteLength reproduced the exact hosted failure before the fix and passed unchanged afterward.

## Verification
- actual node-host MCP owner suite 17/17 and canonical strict pagination/deadline siblings 10/10: 27/27 passing
- targeted type-aware lint, formatting and whitespace pass
- one independent formal structured review clean, confidence 0.98
- one existing test file only; production delta zero; no increased timeout, retry, weaker assertion, or production behavior change


## Inspectable exact owner regression proof

The actual owner test was executed with an ephemeral preload that advances Date.now by 75 ms only after Buffer.byteLength measures the real 6 MiB tool page.

    BEFORE: src/node-host/mcp.test.ts:390 expected oversized.listTools calls=2, received calls=1 (deadline expired while charging first page)
    AFTER: same +75ms production-owner preload: targeted oversized byte-limit regression 1 passed
    [test] starting test/vitest/vitest.unit.config.ts
    Test Files  1 passed
    Tests       17 passed
    [test] starting test/vitest/vitest.agents-core.config.ts
    Test Files  1 passed
    Tests       10 passed
    [test] passed 2 Vitest shards in 13.73s

Production timeout/deadline behavior and the dedicated strict 50 ms pagination tests are unchanged. A currently failing hosted build-artifacts check concerns an unrelated existing TUI/Gateway PTY test and is under separate owner investigation. Moving-main drift alone is advisory under repo policy; no branch refresh is necessary unless a relevant integration conflict exists.
