### PR TITLE
fix(openai): flush valid final realtime transcription audio safely

### DIFF
--- a/extensions/openai/realtime-transcription-provider.test.ts
+++ b/extensions/openai/realtime-transcription-provider.test.ts
@@ -327,7 +327,9 @@ describe("buildOpenAIRealtimeTranscriptionProvider", () => {
         },
       },
     });
+    session.sendAudio(Buffer.alloc(0));
     session.close();
+    expect(parseSent(socket).at(-1)?.type).toBe("session.update");
   });
 
   it("does not use Codex OAuth for realtime transcription", async () => {
@@ -354,8 +356,9 @@ describe("buildOpenAIRealtimeTranscriptionProvider", () => {
       response: new Response(JSON.stringify({ value: "ek-test" }), { status: 200 }),
       release: vi.fn(),
     });
-    const provider = buildOpenAIRealtimeTranscriptionProvider();
-    const session = provider.createSession({ providerConfig: {} });
+    const session = buildOpenAIRealtimeTranscriptionProvider().createSession({
+      providerConfig: {},
+    });
 
     const connecting = session.connect();
     const socket = await waitForFakeSocket();
@@ -372,9 +375,10 @@ describe("buildOpenAIRealtimeTranscriptionProvider", () => {
     session.close();
   });
 
-  it("waits for the OpenAI session update before draining audio", async () => {
-    const provider = buildOpenAIRealtimeTranscriptionProvider();
-    const session = provider.createSession({
+  it("waits for readiness, commits pending audio once on close, and delivers its final", async () => {
+    const onTranscript = vi.fn();
+    const pendingAudio = Buffer.alloc(800, 1);
+    const session = buildOpenAIRealtimeTranscriptionProvider().createSession({
       providerConfig: {
         apiKey: "sk-test", // pragma: allowlist secret
         language: "en",
@@ -383,6 +387,7 @@ describe("buildOpenAIRealtimeTranscriptionProvider", () => {
         silenceDurationMs: 900,
         vadThreshold: 0.45,
       },
+      onTranscript,
     });
 
     const connecting = session.connect();
@@ -390,209 +395,238 @@ describe("buildOpenAIRealtimeTranscriptionProvider", () => {
 
     socket.readyState = FakeWebSocket.OPEN;
     socket.emit("open");
-    session.sendAudio(Buffer.from("before-ready"));
+    session.sendAudio(pendingAudio);
 
     expect(session.isConnected()).toBe(false);
-    expect(parseSent(socket)).toEqual([
-      {
-        type: "session.update",
-        session: {
-          type: "transcription",
-          audio: {
-            input: {
-              format: { type: "audio/pcmu" },
-              transcription: {
-                model: "gpt-4o-transcribe",
-                language: "en",
-                prompt: "expect OpenClaw product names",
-              },
-              turn_detection: {
-                type: "server_vad",
-                threshold: 0.45,
-                prefix_padding_ms: 300,
-                silence_duration_ms: 900,
-              },
+    const expectedSessionUpdate = {
+      type: "session.update",
+      session: {
+        type: "transcription",
+        audio: {
+          input: {
+            format: { type: "audio/pcmu" },
+            transcription: {
+              model: "gpt-4o-transcribe",
+              language: "en",
+              prompt: "expect OpenClaw product names",
+            },
+            turn_detection: {
+              type: "server_vad",
+              threshold: 0.45,
+              prefix_padding_ms: 300,
+              silence_duration_ms: 900,
             },
           },
         },
       },
-    ]);
+    };
+    expect(parseSent(socket)).toEqual([expectedSessionUpdate]);
 
     socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
     await connecting;
 
     expect(session.isConnected()).toBe(true);
     expect(parseSent(socket)).toEqual([
-      {
-        type: "session.update",
-        session: {
-          type: "transcription",
-          audio: {
-            input: {
-              format: { type: "audio/pcmu" },
-              transcription: {
-                model: "gpt-4o-transcribe",
-                language: "en",
-                prompt: "expect OpenClaw product names",
-              },
-              turn_detection: {
-                type: "server_vad",
-                threshold: 0.45,
-                prefix_padding_ms: 300,
-                silence_duration_ms: 900,
-              },
-            },
-          },
-        },
-      },
+      expectedSessionUpdate,
       {
         type: "input_audio_buffer.append",
-        audio: Buffer.from("before-ready").toString("base64"),
+        audio: pendingAudio.toString("base64"),
       },
     ]);
     session.close();
+    session.close();
+    expect(
+      parseSent(socket).filter(({ type }) => type === "input_audio_buffer.commit"),
+    ).toHaveLength(1);
+    emitJson(socket, { type: "input_audio_buffer.committed", item_id: "final-item" });
+    emitJson(socket, {
+      type: "conversation.item.input_audio_transcription.completed",
+      item_id: "final-item",
+      transcript: "final caller sentence",
+    });
+    expect(onTranscript).toHaveBeenCalledExactlyOnceWith("final caller sentence");
+    socket.close();
   });
+
+  it("never commits audio from a previous websocket generation", async () => {
+    const session = buildOpenAIRealtimeTranscriptionProvider().createSession({
+      providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
+    });
+    const previousSocket = await connectFakeSession(session);
+    session.sendAudio(Buffer.alloc(800, 1));
+    const replacementSocket = await connectFakeSession(session, 1);
+
+    session.close();
+
+    expect(parseSent(previousSocket).at(-1)?.type).toBe("input_audio_buffer.append");
+    expect(parseSent(replacementSocket).at(-1)?.type).toBe("session.update");
+    replacementSocket.close();
+  });
+
+  it.each(["audio append", "final commit"] as const)(
+    "reports websocket backpressure during %s exactly once",
+    async (phase) => {
+      const onError = vi.fn();
+      const session = buildOpenAIRealtimeTranscriptionProvider().createSession({
+        providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
+        onError,
+      });
+      const socket = await connectFakeSession(session);
+      if (phase === "final commit") {
+        session.sendAudio(Buffer.alloc(800, 1));
+      }
+      Object.defineProperty(socket, "bufferedAmount", { value: 1024 * 1024 });
+      if (phase === "audio append") {
+        session.sendAudio(Buffer.alloc(800, 1));
+      }
+
+      session.close();
+      session.close();
+
+      expect(onError).toHaveBeenCalledOnce();
+      if (phase === "final commit") {
+        expect(onError).toHaveBeenCalledWith(
+          expect.objectContaining({ message: expect.stringContaining("final audio commit") }),
+        );
+      }
+      expect(parseSent(socket).at(-1)?.type).toBe(
+        phase === "audio append" ? "session.update" : "input_audio_buffer.append",
+      );
+    },
+  );
+
+  it.each([
+    [1, 0, false, false],
+    [799, 0, false, false],
+    [800, 1, false, false],
+    [800, 0, true, false],
+    [1599, 0, true, false],
+    [1600, 1, true, false],
+    [1600, 1, true, true],
+  ] as const)(
+    "commits eligible %i-byte audio once (%i commits, VAD stopped: %s, acknowledged: %s)",
+    async (audioBytes, expectedCommits, vadStopped, acknowledged) => {
+      const session = buildOpenAIRealtimeTranscriptionProvider().createSession({
+        providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
+      });
+      const socket = await connectFakeSession(session);
+      if (vadStopped) {
+        session.sendAudio(Buffer.alloc(800, 1));
+        session.sendAudio(Buffer.alloc(audioBytes - 800, 2));
+        emitJson(socket, {
+          type: "input_audio_buffer.speech_stopped",
+          item_id: "first-turn",
+          audio_end_ms: 100,
+        });
+        if (acknowledged) {
+          emitJson(socket, { type: "input_audio_buffer.committed", item_id: "first-turn" });
+          emitJson(socket, { type: "input_audio_buffer.committed", item_id: "first-turn" });
+        }
+      } else {
+        session.sendAudio(Buffer.alloc(audioBytes, 1));
+      }
+
+      session.close();
+
+      expect(
+        parseSent(socket).filter(({ type }) => type === "input_audio_buffer.commit"),
+      ).toHaveLength(expectedCommits);
+      socket.close();
+    },
+  );
 
   it("keeps out-of-order transcription items isolated and emits finals in commit order", async () => {
     const partials: string[] = [];
     const transcripts: string[] = [];
-    const provider = buildOpenAIRealtimeTranscriptionProvider();
-    const session = provider.createSession({
+    const session = buildOpenAIRealtimeTranscriptionProvider().createSession({
       providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
       onPartial: (partial) => partials.push(partial),
       onTranscript: (transcript) => transcripts.push(transcript),
     });
 
-    const connecting = session.connect();
-    const socket = await waitForFakeSocket();
-    socket.readyState = FakeWebSocket.OPEN;
-    socket.emit("open");
-    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
-    await connecting;
-
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          type: "input_audio_buffer.committed",
-          item_id: "item-2",
-          previous_item_id: "item-1",
-        }),
-      ),
-    );
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          type: "input_audio_buffer.committed",
-          item_id: "item-1",
-          previous_item_id: null,
-        }),
-      ),
-    );
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          type: "conversation.item.input_audio_transcription.delta",
-          item_id: "item-1",
-          delta: "first partial",
-        }),
-      ),
-    );
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          type: "conversation.item.input_audio_transcription.delta",
-          item_id: "item-2",
-          delta: "second partial",
-        }),
-      ),
-    );
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          type: "conversation.item.input_audio_transcription.completed",
-          item_id: "item-2",
-          transcript: "second final",
-        }),
-      ),
-    );
+    const socket = await connectFakeSession(session);
+    session.sendAudio(Buffer.alloc(800, 1));
+    emitJson(socket, {
+      type: "input_audio_buffer.speech_stopped",
+      item_id: "item-2",
+      audio_end_ms: 100,
+    });
+    emitJson(socket, {
+      type: "input_audio_buffer.committed",
+      item_id: "item-2",
+      previous_item_id: "item-1",
+    });
+    emitJson(socket, {
+      type: "input_audio_buffer.committed",
+      item_id: "item-1",
+      previous_item_id: null,
+    });
+    emitJson(socket, {
+      type: "conversation.item.input_audio_transcription.delta",
+      item_id: "item-1",
+      delta: "first partial",
+    });
+    emitJson(socket, {
+      type: "conversation.item.input_audio_transcription.delta",
+      item_id: "item-2",
+      delta: "second partial",
+    });
+    emitJson(socket, {
+      type: "conversation.item.input_audio_transcription.completed",
+      item_id: "item-2",
+      transcript: "second final",
+    });
 
     expect(partials).toEqual(["first partial", "second partial"]);
     expect(transcripts).toEqual([]);
 
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          type: "conversation.item.input_audio_transcription.completed",
-          item_id: "item-1",
-          transcript: "first final",
-        }),
-      ),
-    );
+    emitJson(socket, {
+      type: "conversation.item.input_audio_transcription.completed",
+      item_id: "item-1",
+      transcript: "first final",
+    });
 
     expect(transcripts).toEqual(["first final", "second final"]);
     session.close();
+    expect(parseSent(socket).at(-1)?.type).toBe("input_audio_buffer.append");
   });
 
   it("reports failed transcription items without blocking later committed turns", async () => {
     const errors: string[] = [];
     const transcripts: string[] = [];
-    const provider = buildOpenAIRealtimeTranscriptionProvider();
-    const session = provider.createSession({
+    const session = buildOpenAIRealtimeTranscriptionProvider().createSession({
       providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
       onError: (error) => errors.push(error.message),
       onTranscript: (transcript) => transcripts.push(transcript),
     });
 
-    const connecting = session.connect();
-    const socket = await waitForFakeSocket();
-    socket.readyState = FakeWebSocket.OPEN;
-    socket.emit("open");
-    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
-    await connecting;
+    const socket = await connectFakeSession(session);
 
     for (const itemId of ["item-1", "item-2"]) {
-      socket.emit(
-        "message",
-        Buffer.from(JSON.stringify({ type: "input_audio_buffer.committed", item_id: itemId })),
-      );
+      emitJson(socket, { type: "input_audio_buffer.committed", item_id: itemId });
     }
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          type: "conversation.item.input_audio_transcription.completed",
-          item_id: "item-2",
-          transcript: "second final",
-        }),
-      ),
-    );
-    socket.emit(
-      "message",
-      Buffer.from(
-        JSON.stringify({
-          type: "conversation.item.input_audio_transcription.failed",
-          item_id: "item-1",
-          error: { message: "first turn failed" },
-        }),
-      ),
-    );
+    emitJson(socket, {
+      type: "conversation.item.input_audio_transcription.completed",
+      item_id: "item-2",
+      transcript: "second final",
+    });
+    emitJson(socket, {
+      type: "conversation.item.input_audio_transcription.failed",
+      item_id: "item-1",
+      error: { message: "first turn failed" },
+    });
 
     expect(errors).toEqual(["first turn failed"]);
     expect(transcripts).toEqual(["second final"]);
+    session.sendAudio(Buffer.alloc(800, 1));
     session.close();
+    expect(parseSent(socket).at(-1)?.type).toBe("input_audio_buffer.commit");
   });
 
   it("releases settled turns from the unresolved item budget", async () => {
     const transcripts: string[] = [];
     const onError = vi.fn();
-    const provider = buildOpenAIRealtimeTranscriptionProvider();
-    const session = provider.createSession({
+    const session = buildOpenAIRealtimeTranscriptionProvider().createSession({
       providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
       onError,
       onTranscript: (transcript) => transcripts.push(transcript),
@@ -643,8 +677,7 @@ describe("buildOpenAIRealtimeTranscriptionProvider", () => {
   it("fails once when unresolved item correlation exceeds its session bound", async () => {
     const onError = vi.fn();
     const onTranscript = vi.fn();
-    const provider = buildOpenAIRealtimeTranscriptionProvider();
-    const session = provider.createSession({
+    const session = buildOpenAIRealtimeTranscriptionProvider().createSession({
       providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
       onError,
       onTranscript,
@@ -677,12 +710,7 @@ describe("buildOpenAIRealtimeTranscriptionProvider", () => {
     expect(onTranscript).not.toHaveBeenCalled();
     expect(session.isConnected()).toBe(false);
 
-    const reconnecting = session.connect();
-    const replacementSocket = await waitForFakeSocket(1);
-    replacementSocket.readyState = FakeWebSocket.OPEN;
-    replacementSocket.emit("open");
-    emitJson(replacementSocket, { type: "session.updated" });
-    await reconnecting;
+    const replacementSocket = await connectFakeSession(session, 1);
     emitJson(replacementSocket, {
       type: "input_audio_buffer.committed",
       item_id: "replacement-item",
@@ -704,8 +732,7 @@ describe("buildOpenAIRealtimeTranscriptionProvider", () => {
     const onError = vi.fn();
     const onPartial = vi.fn();
     const onTranscript = vi.fn();
-    const provider = buildOpenAIRealtimeTranscriptionProvider();
-    const session = provider.createSession({
+    const session = buildOpenAIRealtimeTranscriptionProvider().createSession({
       providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
       onError,
       onPartial,
@@ -744,8 +771,7 @@ describe("buildOpenAIRealtimeTranscriptionProvider", () => {
   it("accounts for UTF-8 surrogate pairs split across delta frames", async () => {
     const onError = vi.fn();
     const onPartial = vi.fn();
-    const provider = buildOpenAIRealtimeTranscriptionProvider();
-    const session = provider.createSession({
+    const session = buildOpenAIRealtimeTranscriptionProvider().createSession({
       providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
       onError,
       onPartial,
@@ -779,8 +805,7 @@ describe("buildOpenAIRealtimeTranscriptionProvider", () => {
     const onError = vi.fn();
     const onPartial = vi.fn();
     const transcripts: string[] = [];
-    const provider = buildOpenAIRealtimeTranscriptionProvider();
-    const session = provider.createSession({
+    const session = buildOpenAIRealtimeTranscriptionProvider().createSession({
       providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
       onError,
       onPartial,
@@ -835,12 +860,7 @@ describe("buildOpenAIRealtimeTranscriptionProvider", () => {
     expect(onError).not.toHaveBeenCalled();
     expect(session.isConnected()).toBe(true);
 
-    const reconnecting = session.connect();
-    const replacementSocket = await waitForFakeSocket(1);
-    replacementSocket.readyState = FakeWebSocket.OPEN;
-    replacementSocket.emit("open");
-    emitJson(replacementSocket, { type: "session.updated" });
-    await reconnecting;
+    const replacementSocket = await connectFakeSession(session, 1);
     emitJson(replacementSocket, {
       type: "input_audio_buffer.committed",
       item_id: "item-2",
@@ -860,8 +880,7 @@ describe("buildOpenAIRealtimeTranscriptionProvider", () => {
     const errors: string[] = [];
     const partials: string[] = [];
     const transcripts: string[] = [];
-    const provider = buildOpenAIRealtimeTranscriptionProvider();
-    const session = provider.createSession({
+    const session = buildOpenAIRealtimeTranscriptionProvider().createSession({
       providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
       onError: (error) => errors.push(error.message),
       onPartial: (partial) => partials.push(partial),
@@ -930,8 +949,7 @@ describe("buildOpenAIRealtimeTranscriptionProvider", () => {
 
   it("keeps active predecessor satisfaction as terminal history grows", async () => {
     const transcripts: string[] = [];
-    const provider = buildOpenAIRealtimeTranscriptionProvider();
-    const session = provider.createSession({
+    const session = buildOpenAIRealtimeTranscriptionProvider().createSession({
       providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
       onTranscript: (transcript) => transcripts.push(transcript),
     });
@@ -973,8 +991,7 @@ describe("buildOpenAIRealtimeTranscriptionProvider", () => {
   it("keeps the first failed terminal outcome when completion arrives late", async () => {
     const errors: string[] = [];
     const transcripts: string[] = [];
-    const provider = buildOpenAIRealtimeTranscriptionProvider();
-    const session = provider.createSession({
+    const session = buildOpenAIRealtimeTranscriptionProvider().createSession({
       providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
       onError: (error) => errors.push(error.message),
       onTranscript: (transcript) => transcripts.push(transcript),
@@ -1016,14 +1033,14 @@ describe("buildOpenAIRealtimeTranscriptionProvider", () => {
   it("fails before retaining oversized correlation identities", async () => {
     const onError = vi.fn();
     const onTranscript = vi.fn();
-    const provider = buildOpenAIRealtimeTranscriptionProvider();
-    const session = provider.createSession({
+    const session = buildOpenAIRealtimeTranscriptionProvider().createSession({
       providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
       onError,
       onTranscript,
     });
     const socket = await connectFakeSession(session);
 
+    session.sendAudio(Buffer.alloc(800, 1));
     emitJson(socket, {
       type: "conversation.item.input_audio_transcription.failed",
       item_id: "i".repeat(1025),
@@ -1037,6 +1054,10 @@ describe("buildOpenAIRealtimeTranscriptionProvider", () => {
     );
     expect(onTranscript).not.toHaveBeenCalled();
     expect(session.isConnected()).toBe(false);
+    expect(parseSent(socket).map((event) => event.type)).toEqual([
+      "session.update",
+      "input_audio_buffer.append",
+    ]);
     session.close();
   });
 

--- a/extensions/openai/realtime-transcription-provider.ts
+++ b/extensions/openai/realtime-transcription-provider.ts
@@ -47,6 +47,7 @@ type RealtimeEvent = {
   transcript?: string;
   item_id?: string;
   previous_item_id?: string | null;
+  audio_end_ms?: number;
   error?: unknown;
 };
 
@@ -74,6 +75,8 @@ const OPENAI_REALTIME_TRANSCRIPTION_URL = "wss://api.openai.com/v1/realtime?inte
 const OPENAI_REALTIME_TRANSCRIPTION_CONNECT_TIMEOUT_MS = 10_000;
 const OPENAI_REALTIME_TRANSCRIPTION_MAX_RECONNECT_ATTEMPTS = 5;
 const OPENAI_REALTIME_TRANSCRIPTION_RECONNECT_DELAY_MS = 1000;
+const OPENAI_REALTIME_TRANSCRIPTION_AUDIO_BYTES_PER_MS = 8;
+const OPENAI_REALTIME_TRANSCRIPTION_MIN_COMMIT_DURATION_MS = 100;
 const OPENAI_REALTIME_TRANSCRIPTION_DEFAULT_MODEL = "gpt-4o-transcribe";
 const OPENAI_REALTIME_TRANSCRIPTION_MAX_UNRESOLVED_ITEMS = 64;
 const OPENAI_REALTIME_TRANSCRIPTION_MAX_ITEM_ID_BYTES = 1024;
@@ -209,6 +212,9 @@ function createOpenAIRealtimeTranscriptionSession(
   const unkeyedTranscript = "__openclaw_unkeyed_transcript__";
   let retainedTranscriptBytes = 0;
   let settledItemIdBytes = 0;
+  let appendedAudioBytes = 0;
+  let committedAudioBytes = 0;
+  let lastVadBoundary: { itemId: string; audioEndBytes: number } | undefined;
 
   const resetTranscriptionState = () => {
     pendingTranscripts.clear();
@@ -219,6 +225,9 @@ function createOpenAIRealtimeTranscriptionSession(
     settledItemIds.clear();
     retainedTranscriptBytes = 0;
     settledItemIdBytes = 0;
+    appendedAudioBytes = 0;
+    committedAudioBytes = 0;
+    lastVadBoundary = undefined;
   };
 
   const failTerminal = (error: Error, transport: RealtimeTranscriptionWebSocketTransport) => {
@@ -412,8 +421,39 @@ function createOpenAIRealtimeTranscriptionSession(
         return;
 
       case "input_audio_buffer.committed":
+        if (
+          event.item_id &&
+          (committedItems.has(event.item_id) || settledItemIds.has(event.item_id)) &&
+          lastVadBoundary?.itemId !== event.item_id
+        ) {
+          return;
+        }
+        committedAudioBytes =
+          event.item_id && lastVadBoundary?.itemId === event.item_id
+            ? Math.max(
+                committedAudioBytes,
+                Math.min(appendedAudioBytes, lastVadBoundary.audioEndBytes),
+              )
+            : appendedAudioBytes;
+        if (event.item_id === lastVadBoundary?.itemId) {
+          lastVadBoundary = undefined;
+        }
         if (event.item_id) {
           commitItem(event.item_id, event.previous_item_id, transport);
+        }
+        return;
+
+      case "input_audio_buffer.speech_stopped":
+        if (
+          event.item_id &&
+          typeof event.audio_end_ms === "number" &&
+          Number.isFinite(event.audio_end_ms) &&
+          event.audio_end_ms >= 0
+        ) {
+          lastVadBoundary = {
+            itemId: event.item_id,
+            audioEndBytes: event.audio_end_ms * OPENAI_REALTIME_TRANSCRIPTION_AUDIO_BYTES_PER_MS,
+          };
         }
         return;
 
@@ -512,10 +552,33 @@ function createOpenAIRealtimeTranscriptionSession(
     connectClosedBeforeReadyMessage: "OpenAI realtime transcription connection closed before ready",
     reconnectLimitMessage: "OpenAI realtime transcription reconnect limit reached",
     sendAudio: (audio, transport) => {
-      transport.sendJson({
+      const sent = transport.sendJson({
         type: "input_audio_buffer.append",
         audio: audio.toString("base64"),
       });
+      if (sent) {
+        appendedAudioBytes += audio.byteLength;
+      }
+    },
+    onClose: (transport) => {
+      // Server VAD owns stopped audio before its ack; shorter manual commits are rejected.
+      const ownedAudioBytes = Math.max(committedAudioBytes, lastVadBoundary?.audioEndBytes ?? 0);
+      if (
+        appendedAudioBytes - ownedAudioBytes >=
+        OPENAI_REALTIME_TRANSCRIPTION_MIN_COMMIT_DURATION_MS *
+          OPENAI_REALTIME_TRANSCRIPTION_AUDIO_BYTES_PER_MS
+      ) {
+        if (!transport.sendJson({ type: "input_audio_buffer.commit" })) {
+          failTerminal(
+            new Error(
+              "OpenAI realtime transcription could not send its final audio commit; check the provider connection",
+            ),
+            transport,
+          );
+          return;
+        }
+        committedAudioBytes = appendedAudioBytes;
+      }
     },
     onOpen: (transport: RealtimeTranscriptionWebSocketTransport) => {
       // A reconnect starts a new provider session. Retaining outstanding item


### PR DESCRIPTION
## Summary
- flush eligible final OpenAI realtime transcription audio without dropping last words when a microphone session closes
- honor actual Server VAD ownership before its committed acknowledgment and avoid duplicate manual commits
- enforce the provider's real 100 ms minimum for the negotiated 8 kHz G.711 μlaw format (800 bytes), preserve delayed/duplicate ACK handling, and surface actual final-send failures once

## Dependency and lifecycle proof
Personally inspected the installed official OpenAI realtime SDK: realtime.ts:841-849 documents automatic Server VAD commits, :950-965 documents the stopped/item lifecycle, :1311-1349 defines PCM versus μlaw formats, and :1802-1807 documents recoverable realtime error events. The actual Gateway relay fixes G.711 μlaw at 8 kHz.

- Four genuine owner regressions reproduced before repair: 1-byte/799-byte invalid commits, an already VAD-owned 800-byte turn before ACK, and a VAD-owned turn with only a 799-byte tail.
- 36 focused provider/bounds tests pass; 15 actual production-provider + shared WebSocket lifecycle cases pass with zero external network.
- One formal reviewer proposed that an unavoidable cross-direction VAD timing race would lose the final transcript. Root personally inspected the official recoverable-error contract and the actual shared close/failConnect lifecycle, then rejected that finding using this real owner sequence:

    {"outboundEvents":["session.update","input_audio_buffer.append","input_audio_buffer.commit"],"inboundEvents":["error:invalid_request_error/input_audio_buffer_commit_empty","input_audio_buffer.speech_stopped","input_audio_buffer.committed","conversation.item.input_audio_transcription.completed"],"socketRemainedOpenAfterRecoverableError":true,"onErrorCalls":0,"onTranscriptCalls":1,"finalTranscript":"server-owned final transcript","externalNetworkRequests":0}

The documented recoverable error does not close the already-settled socket and the final transcript is delivered exactly once. No hidden fallback, broader timeout, external provider call, or real credential was used. Production delta +63 lines reflects canonical VAD/audio shutdown ownership.

### Maintainer disposition: explicit bounded live-provider proof gap

The PR author is the project owner/administrator. Latest review found no actionable code or security issue and explicitly permits accepting the remaining mock-only provider timing risk. A real external OpenAI Realtime call could not be performed because the mandatory approved stable 1Password executable is unavailable; its safety policy prohibits substituting the versioned Homebrew binary or triggering credential-access prompts. No credential was accessed.

The actual production provider owner and shared WebSocket owner were executed together across 36 focused regressions plus 15 lifecycle/boundary scenarios, including the real cross-direction close/final race. The official installed OpenAI SDK source directly confirms append/commit, VAD, µ-law buffering, empty-buffer behavior, and recoverable realtime errors. This establishes actual owner behavior and dependency contracts but is **not** a live external-provider call. The project-owner-authored repair accepts that narrowly disclosed residual external timing risk; no live-proof claim is made.