### PR TITLE
fix(ui): clear split-pane questions after answers and cancellations

### DIFF
--- a/ui/src/app/question-prompt-client.ts
+++ b/ui/src/app/question-prompt-client.ts
@@ -1,0 +1,84 @@
+// A browser Gateway client owns authoritative question outcomes across live UI projections.
+import {
+  DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
+  type GatewayProtocolRequestOptions,
+} from "@openclaw/gateway-client/browser";
+import type { QuestionResolvedEvent } from "@openclaw/gateway-protocol";
+
+export type QuestionClient = {
+  request: (
+    method: string,
+    params?: unknown,
+    options?: GatewayProtocolRequestOptions,
+  ) => Promise<unknown>;
+};
+
+export type QuestionClientResolutionOwner = {
+  client: QuestionClient | null;
+  clientGeneration: number;
+  onQuestionResolution: (resolution: QuestionResolvedEvent) => void;
+};
+
+const resolutionOwnersByClient = new WeakMap<QuestionClient, Set<QuestionClientResolutionOwner>>();
+
+export function registerQuestionClientOwner(
+  client: QuestionClient,
+  owner: QuestionClientResolutionOwner,
+): void {
+  let owners = resolutionOwnersByClient.get(client);
+  if (!owners) {
+    owners = new Set();
+    resolutionOwnersByClient.set(client, owners);
+  }
+  owners.add(owner);
+}
+
+export function unregisterQuestionClientOwner(
+  client: QuestionClient,
+  owner: QuestionClientResolutionOwner,
+): void {
+  const owners = resolutionOwnersByClient.get(client);
+  if (!owners) {
+    return;
+  }
+  owners.delete(owner);
+  if (owners.size === 0) {
+    resolutionOwnersByClient.delete(client);
+  }
+}
+
+export function publishQuestionClientResolution(
+  client: QuestionClient,
+  resolution: QuestionResolvedEvent,
+): void {
+  const owners = resolutionOwnersByClient.get(client);
+  if (!owners) {
+    return;
+  }
+  // A listener can synchronously reconnect another pane. Snapshot its original
+  // generation so an old answer never crosses into the new connection lifecycle.
+  const publication = Array.from(owners, (owner) => ({
+    owner,
+    generation: owner.clientGeneration,
+  }));
+  for (const { owner, generation } of publication) {
+    if (owners.has(owner) && owner.client === client && owner.clientGeneration === generation) {
+      owner.onQuestionResolution(resolution);
+    }
+  }
+}
+
+export function requestQuestionGateway(
+  client: QuestionClient,
+  method: "question.list" | "question.get" | "question.resolve",
+  params: unknown,
+  expiresAtMs?: number,
+): Promise<unknown> {
+  // Browser RPCs are otherwise unbounded; decisions must also stop once their
+  // prompt can no longer be settled so its interaction never remains locked.
+  const timeoutMs =
+    expiresAtMs === undefined
+      ? DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS
+      : Math.min(DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS, Math.max(0, expiresAtMs - Date.now()));
+  return client.request(method, params, { timeoutMs });
+}

--- a/ui/src/app/question-prompt.shared-state.test.ts
+++ b/ui/src/app/question-prompt.shared-state.test.ts
@@ -60,7 +60,7 @@ function requestQuestion(
 
 function connectQuestionState(
   client: QuestionClient,
-  onChange = vi.fn(),
+  onChange: () => void = vi.fn(),
   expiresAtMs?: number,
 ): QuestionState {
   const state = createQuestionPromptState(onChange);
@@ -278,6 +278,46 @@ describe("Gateway-client question outcome ownership", () => {
     expect(onPeerChange).not.toHaveBeenCalled();
   });
 
+  it.each(resolutionCases)(
+    "publishes a committed $action to surviving peers after the submitting pane is disposed",
+    async ({ resolve, status }) => {
+      let finishRequest: ((result: QuestionResolveResult) => void) | undefined;
+      const client: QuestionClient = {
+        request: vi.fn(
+          () =>
+            new Promise<QuestionResolveResult>((complete) => {
+              finishRequest = complete;
+            }),
+        ),
+      };
+      const onSubmitterChange = vi.fn();
+      const submitter = connectQuestionState(client, onSubmitterChange);
+      const peer = connectQuestionState(client);
+      const sidebar = connectQuestionState(client);
+      const submission = resolve(submitter);
+      onSubmitterChange.mockClear();
+      disposeQuestionPromptState(submitter);
+      const result: QuestionResolveResult =
+        status === "answered"
+          ? { status, answers: { answers: { format: ["Compact"] } } }
+          : { status };
+      finishRequest?.(result);
+
+      await submission;
+
+      expect(submitter.prompts.get("question-1")?.status).toBe("pending");
+      expect(onSubmitterChange).not.toHaveBeenCalled();
+      for (const projection of [peer, sidebar]) {
+        expect(projection.prompts.get("question-1")).toMatchObject({
+          status,
+          answeredElsewhere: status === "answered",
+          localResolutionConfirmed: false,
+          submitting: false,
+        });
+      }
+    },
+  );
+
   it("does not deliver an old client result to a peer rebound to another Gateway", async () => {
     const firstClient = createQuestionClient();
     const submitter = connectQuestionState(firstClient);
@@ -421,22 +461,25 @@ describe("Gateway-client question outcome ownership", () => {
     expect(remounted.prompts.has("stale-before-remount")).toBe(false);
   });
 
-  it("does not publish a retired same-client request after its sender reconnects", async () => {
-    let finishRequest: ((result: QuestionResolveResult) => void) | undefined;
+  it("does not publish an old request rejected when its Gateway reconnects", async () => {
+    let rejectRequest: ((error: Error) => void) | undefined;
     const client: QuestionClient = {
       request: vi.fn(
         () =>
-          new Promise<QuestionResolveResult>((resolve) => {
-            finishRequest = resolve;
+          new Promise<QuestionResolveResult>((_resolve, reject) => {
+            rejectRequest = reject;
           }),
       ),
     };
     const submitter = connectQuestionState(client);
     const peer = connectQuestionState(client);
     const submission = cancelQuestionPrompt(submitter, "question-1");
-    setQuestionPromptClient(submitter, null);
-    setQuestionPromptClient(submitter, client);
-    finishRequest?.({ status: "cancelled" });
+    // The protocol rejects pending requests before its reconnect lifecycle.
+    rejectRequest?.(new Error("gateway closed"));
+    for (const projection of [submitter, peer]) {
+      setQuestionPromptClient(projection, null);
+      setQuestionPromptClient(projection, client);
+    }
 
     await submission;
 

--- a/ui/src/app/question-prompt.shared-state.test.ts
+++ b/ui/src/app/question-prompt.shared-state.test.ts
@@ -1,0 +1,467 @@
+// @vitest-environment node
+// One Gateway client owns question outcomes across chat panes and sidebar projections.
+import type { QuestionResolveResult } from "@openclaw/gateway-protocol";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  cancelQuestionPrompt,
+  createQuestionPromptState,
+  disposeQuestionPromptState,
+  handleQuestionPromptEvent,
+  refreshPendingQuestionsWithRetry,
+  setQuestionPromptClient,
+  submitQuestionPrompt,
+} from "./question-prompt.ts";
+
+type QuestionState = ReturnType<typeof createQuestionPromptState>;
+type QuestionClient = {
+  request: (method: string, params?: unknown) => Promise<unknown>;
+};
+
+const states: QuestionState[] = [];
+
+function createQuestionClient(): QuestionClient {
+  return {
+    request: vi.fn(async (_method: string, params?: unknown) =>
+      (params as { cancel?: boolean } | undefined)?.cancel
+        ? ({ status: "cancelled" } satisfies QuestionResolveResult)
+        : ({
+            status: "answered",
+            answers: { answers: { format: ["Compact"] } },
+          } satisfies QuestionResolveResult),
+    ),
+  };
+}
+
+function requestQuestion(
+  state: QuestionState,
+  id = "question-1",
+  expiresAtMs = Date.now() + 60_000,
+): void {
+  handleQuestionPromptEvent(state, {
+    event: "question.requested",
+    payload: {
+      id,
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      questions: [
+        {
+          questionId: "format",
+          header: "Format",
+          question: "Which format should I use?",
+          options: [{ label: "Compact" }, { label: "Detailed" }],
+        },
+      ],
+      createdAtMs: 1_000,
+      expiresAtMs,
+      status: "pending",
+    },
+  });
+}
+
+function connectQuestionState(
+  client: QuestionClient,
+  onChange = vi.fn(),
+  expiresAtMs?: number,
+): QuestionState {
+  const state = createQuestionPromptState(onChange);
+  states.push(state);
+  setQuestionPromptClient(state, client);
+  requestQuestion(state, "question-1", expiresAtMs);
+  return state;
+}
+
+const resolutionCases = [
+  {
+    action: "answer",
+    status: "answered",
+    resolve: (state: QuestionState) =>
+      submitQuestionPrompt(state, "question-1", { format: [" Compact "] }),
+  },
+  {
+    action: "cancellation",
+    status: "cancelled",
+    resolve: (state: QuestionState) => cancelQuestionPrompt(state, "question-1"),
+  },
+] as const;
+
+afterEach(() => {
+  for (const state of states.splice(0)) {
+    disposeQuestionPromptState(state);
+  }
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("Gateway-client question outcome ownership", () => {
+  it.each(resolutionCases)(
+    "publishes an authoritative $action to every same-client pane and sidebar owner",
+    async ({ resolve, status }) => {
+      const client = createQuestionClient();
+      const submitter = connectQuestionState(client);
+      const splitPane = connectQuestionState(client);
+      const sidebar = connectQuestionState(client);
+
+      await resolve(submitter);
+
+      expect(submitter.prompts.get("question-1")).toMatchObject({
+        status,
+        localResolutionConfirmed: true,
+        answeredElsewhere: false,
+        submitting: false,
+      });
+      for (const peer of [splitPane, sidebar]) {
+        expect(peer.prompts.get("question-1")).toMatchObject({
+          status,
+          localResolutionConfirmed: false,
+          answeredElsewhere: status === "answered",
+          submitting: false,
+        });
+      }
+      if (status === "answered") {
+        expect(splitPane.prompts.get("question-1")?.answers).toEqual({
+          answers: { format: ["Compact"] },
+        });
+      }
+      expect(client.request).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each(resolutionCases)(
+    "retains an authoritative $action until a same-client projection finishes hydration",
+    async ({ resolve, status }) => {
+      let finishList: ((result: unknown) => void) | undefined;
+      const resolver = createQuestionClient();
+      const client: QuestionClient = {
+        request: vi.fn((method, params) =>
+          method === "question.list"
+            ? new Promise<unknown>((complete) => {
+                finishList = complete;
+              })
+            : resolver.request(method, params),
+        ),
+      };
+      const submitter = connectQuestionState(client);
+      const stalePending = { ...submitter.prompts.get("question-1"), status: "pending" };
+      const hydrating = createQuestionPromptState(vi.fn());
+      states.push(hydrating);
+      setQuestionPromptClient(hydrating, client);
+      refreshPendingQuestionsWithRetry(hydrating, client);
+
+      await resolve(submitter);
+
+      expect(hydrating.unmatchedResolutions.get("question-1")).toMatchObject({
+        id: "question-1",
+        status,
+      });
+      finishList?.({ questions: [stalePending] });
+      await vi.waitFor(() =>
+        expect(hydrating.prompts.get("question-1")).toMatchObject({
+          status,
+          answeredElsewhere: status === "answered",
+          localResolutionConfirmed: false,
+        }),
+      );
+      expect(hydrating.unmatchedResolutions.size).toBe(0);
+    },
+  );
+
+  it.each(resolutionCases)(
+    "recovers a committed $action when a peer mounts before its ordered RPC response",
+    async ({ resolve, status }) => {
+      let finishResolution: ((result: QuestionResolveResult) => void) | undefined;
+      let finishList: ((result: { questions: unknown[] }) => void) | undefined;
+      const client: QuestionClient = {
+        request: vi.fn((method) => {
+          if (method === "question.resolve") {
+            return new Promise<QuestionResolveResult>((complete) => {
+              finishResolution = complete;
+            });
+          }
+          if (method === "question.list") {
+            return new Promise<{ questions: unknown[] }>((complete) => {
+              finishList = complete;
+            });
+          }
+          return Promise.resolve({ question: terminalRecord });
+        }),
+      };
+      const submitter = connectQuestionState(client);
+      const answers = { answers: { format: ["Compact"] } };
+      const terminalRecord = {
+        ...submitter.prompts.get("question-1"),
+        status,
+        ...(status === "answered" ? { answers } : {}),
+      };
+      const submission = resolve(submitter);
+      const hydrating = createQuestionPromptState(vi.fn());
+      states.push(hydrating);
+      setQuestionPromptClient(hydrating, client);
+      refreshPendingQuestionsWithRetry(hydrating, client);
+      expect(vi.mocked(client.request).mock.calls.map(([method]) => method)).toEqual([
+        "question.resolve",
+        "question.list",
+      ]);
+
+      finishResolution?.(status === "answered" ? { status, answers } : { status });
+      await submission;
+      expect(hydrating.unmatchedResolutions.has("question-1")).toBe(true);
+      finishList?.({ questions: [] });
+
+      await vi.waitFor(() =>
+        expect(hydrating.prompts.get("question-1")).toMatchObject({
+          status,
+          answeredElsewhere: status === "answered",
+          localResolutionConfirmed: false,
+        }),
+      );
+      expect(vi.mocked(client.request).mock.calls.map(([method]) => method)).toEqual([
+        "question.resolve",
+        "question.list",
+        "question.get",
+      ]);
+      expect(hydrating.unmatchedResolutions.size).toBe(0);
+    },
+  );
+
+  it.each(resolutionCases)(
+    "does not leak a same-id $action into another Gateway client",
+    async ({ resolve }) => {
+      const submitter = connectQuestionState(createQuestionClient());
+      const otherGateway = connectQuestionState(createQuestionClient());
+
+      await resolve(submitter);
+
+      expect(otherGateway.prompts.get("question-1")).toMatchObject({
+        status: "pending",
+        localResolutionConfirmed: false,
+      });
+    },
+  );
+
+  it("does not settle an unrelated same-client session question", async () => {
+    const client = createQuestionClient();
+    const submitter = connectQuestionState(client);
+    const otherSession = createQuestionPromptState(vi.fn());
+    states.push(otherSession);
+    setQuestionPromptClient(otherSession, client);
+    requestQuestion(otherSession, "other-session-question");
+
+    await cancelQuestionPrompt(submitter, "question-1");
+
+    expect(otherSession.prompts.get("other-session-question")?.status).toBe("pending");
+  });
+
+  it("unregisters a disconnected peer without discarding its reconnectable prompt", async () => {
+    const client = createQuestionClient();
+    const submitter = connectQuestionState(client);
+    const disconnected = connectQuestionState(client);
+    setQuestionPromptClient(disconnected, null);
+
+    await cancelQuestionPrompt(submitter, "question-1");
+
+    expect(disconnected.prompts.get("question-1")?.status).toBe("pending");
+    setQuestionPromptClient(disconnected, client);
+    expect(disconnected.prompts.get("question-1")?.status).toBe("pending");
+  });
+
+  it("unregisters a disposed peer before a sibling receives its RPC result", async () => {
+    const client = createQuestionClient();
+    const submitter = connectQuestionState(client);
+    const onPeerChange = vi.fn();
+    const disposed = connectQuestionState(client, onPeerChange);
+    onPeerChange.mockClear();
+    disposeQuestionPromptState(disposed);
+
+    await cancelQuestionPrompt(submitter, "question-1");
+
+    expect(disposed.prompts.get("question-1")?.status).toBe("pending");
+    expect(onPeerChange).not.toHaveBeenCalled();
+  });
+
+  it("does not deliver an old client result to a peer rebound to another Gateway", async () => {
+    const firstClient = createQuestionClient();
+    const submitter = connectQuestionState(firstClient);
+    const migrated = connectQuestionState(firstClient);
+    setQuestionPromptClient(migrated, createQuestionClient());
+    requestQuestion(migrated);
+
+    await cancelQuestionPrompt(submitter, "question-1");
+
+    expect(migrated.prompts.get("question-1")?.status).toBe("pending");
+  });
+
+  it.each(["pending", "answered"] as const)(
+    "purges a disposed $status question and unmatched private outcome before attaching another Gateway",
+    (status) => {
+      const firstClient = createQuestionClient();
+      const reused = connectQuestionState(firstClient);
+      if (status === "answered") {
+        handleQuestionPromptEvent(reused, {
+          event: "question.resolved",
+          payload: {
+            id: "question-1",
+            status,
+            answers: { answers: { format: ["Private account answer"] } },
+          },
+        });
+      }
+      handleQuestionPromptEvent(reused, {
+        event: "question.resolved",
+        payload: { id: "private-unmatched-question", status: "cancelled" },
+      });
+      disposeQuestionPromptState(reused);
+
+      setQuestionPromptClient(reused, createQuestionClient());
+
+      expect(reused.prompts.size).toBe(0);
+      expect(reused.unmatchedResolutions.size).toBe(0);
+    },
+  );
+
+  it("keeps and reconnects a disposed question projection on its original Gateway", async () => {
+    const client = createQuestionClient();
+    const submitter = connectQuestionState(client);
+    const remounted = connectQuestionState(client);
+    handleQuestionPromptEvent(remounted, {
+      event: "question.resolved",
+      payload: { id: "same-gateway-unmatched-question", status: "cancelled" },
+    });
+    disposeQuestionPromptState(remounted);
+    setQuestionPromptClient(remounted, client);
+
+    expect(remounted.prompts.get("question-1")?.status).toBe("pending");
+    expect(remounted.unmatchedResolutions.has("same-gateway-unmatched-question")).toBe(true);
+    await cancelQuestionPrompt(submitter, "question-1");
+    expect(remounted.prompts.get("question-1")?.status).toBe("cancelled");
+  });
+
+  it("publishes and expires a pending question recovered only from question.list", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-17T00:00:00.000Z"));
+    const client: QuestionClient = {
+      request: vi.fn(async () => ({ questions: [pending] })),
+    };
+    const existing = connectQuestionState(client, vi.fn(), Date.now() + 1_000);
+    const pending = { ...existing.prompts.get("question-1"), status: "pending" };
+    const onChange = vi.fn();
+    const hydrated = createQuestionPromptState(onChange);
+    states.push(hydrated);
+    setQuestionPromptClient(hydrated, client);
+
+    refreshPendingQuestionsWithRetry(hydrated, client);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(hydrated.prompts.get("question-1")?.status).toBe("pending");
+    expect(hydrated.tickTimer).not.toBeNull();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(hydrated.prompts.get("question-1")).toMatchObject({
+      status: "expired",
+      locallyExpired: true,
+    });
+  });
+
+  it("expires remounted pane and sidebar questions while their Gateway hydration remains stalled", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-17T00:00:00.000Z"));
+    const stalledList = new Promise<never>(() => {});
+    const client: QuestionClient = { request: vi.fn(() => stalledList) };
+    const expiresAtMs = Date.now() + 1_000;
+    const pane = connectQuestionState(client, vi.fn(), expiresAtMs);
+    const sidebar = connectQuestionState(client, vi.fn(), expiresAtMs);
+    for (const projection of [pane, sidebar]) {
+      disposeQuestionPromptState(projection);
+      setQuestionPromptClient(projection, client);
+      refreshPendingQuestionsWithRetry(projection, client);
+    }
+    expect(client.request).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    for (const projection of [pane, sidebar]) {
+      expect(projection.prompts.get("question-1")).toMatchObject({
+        status: "expired",
+        locallyExpired: true,
+        submitting: false,
+      });
+    }
+  });
+
+  it("rejects a stale same-client hydration result after the sidebar remounts", async () => {
+    const pendingLists: Array<(value: unknown) => void> = [];
+    const client: QuestionClient = {
+      request: vi.fn(
+        (method: string) =>
+          new Promise<unknown>((resolve) => {
+            if (method === "question.list") {
+              pendingLists.push(resolve);
+            }
+          }),
+      ),
+    };
+    const remounted = connectQuestionState(client);
+    refreshPendingQuestionsWithRetry(remounted, client);
+    disposeQuestionPromptState(remounted);
+    setQuestionPromptClient(remounted, client);
+    refreshPendingQuestionsWithRetry(remounted, client);
+    expect(pendingLists).toHaveLength(2);
+
+    pendingLists[0]?.({
+      questions: [
+        {
+          ...remounted.prompts.get("question-1"),
+          id: "stale-before-remount",
+          status: "pending",
+        },
+      ],
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(remounted.prompts.has("stale-before-remount")).toBe(false);
+  });
+
+  it("does not publish a retired same-client request after its sender reconnects", async () => {
+    let finishRequest: ((result: QuestionResolveResult) => void) | undefined;
+    const client: QuestionClient = {
+      request: vi.fn(
+        () =>
+          new Promise<QuestionResolveResult>((resolve) => {
+            finishRequest = resolve;
+          }),
+      ),
+    };
+    const submitter = connectQuestionState(client);
+    const peer = connectQuestionState(client);
+    const submission = cancelQuestionPrompt(submitter, "question-1");
+    setQuestionPromptClient(submitter, null);
+    setQuestionPromptClient(submitter, client);
+    finishRequest?.({ status: "cancelled" });
+
+    await submission;
+
+    expect(submitter.prompts.get("question-1")?.status).toBe("pending");
+    expect(peer.prompts.get("question-1")?.status).toBe("pending");
+  });
+
+  it("skips a peer rebound to a newer generation during reentrant publication", async () => {
+    const client = createQuestionClient();
+    const submitter = connectQuestionState(client);
+    let publishStarted = false;
+    const reentrant = connectQuestionState(client, () => {
+      if (!publishStarted) {
+        return;
+      }
+      publishStarted = false;
+      setQuestionPromptClient(rebound, null);
+      setQuestionPromptClient(rebound, client);
+    });
+    const rebound = connectQuestionState(client);
+    publishStarted = true;
+
+    await cancelQuestionPrompt(submitter, "question-1");
+
+    expect(reentrant.prompts.get("question-1")?.status).toBe("cancelled");
+    expect(rebound.prompts.get("question-1")?.status).toBe("pending");
+  });
+});

--- a/ui/src/app/question-prompt.test.ts
+++ b/ui/src/app/question-prompt.test.ts
@@ -553,7 +553,7 @@ describe("question resolution connection ownership", () => {
   );
 
   it.each(questionResolutionCases)(
-    "retires an old $action when the same gateway client reconnects",
+    "rejects an old $action when the same gateway transport reconnects",
     async ({ resolve }) => {
       const stale = createDeferredQuestionRequest();
       const current = createDeferredQuestionRequest();
@@ -569,12 +569,13 @@ describe("question resolution connection ownership", () => {
       const { state } = createConnectedState(client, requestedPayload());
 
       const staleResolution = resolve(state);
+      // Socket closure rejects its pending requests before reconnect callbacks.
+      stale.reject();
       setQuestionPromptClient(state, null);
       expect(state.prompts.get("question-1")?.submitting).toBe(false);
       setQuestionPromptClient(state, client);
 
       const currentResolution = resolve(state);
-      stale.resolve();
       await staleResolution;
 
       expect(state.prompts.get("question-1")).toMatchObject({

--- a/ui/src/app/question-prompt.test.ts
+++ b/ui/src/app/question-prompt.test.ts
@@ -1,5 +1,10 @@
 // @vitest-environment node
 // Control UI tests cover operator question parsing and lifecycle state.
+import {
+  DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
+  type GatewayProtocolRequestOptions,
+} from "@openclaw/gateway-client/browser";
+import type { QuestionAnswers, QuestionResolveResult } from "@openclaw/gateway-protocol";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { GatewayRequestError } from "../api/gateway.ts";
 import { i18n } from "../i18n/index.ts";
@@ -14,10 +19,15 @@ import {
   submitQuestionPrompt,
 } from "./question-prompt.ts";
 
-type RequestFn = (method: string, params?: unknown) => Promise<unknown>;
+type RequestFn = (
+  method: string,
+  params?: unknown,
+  options?: GatewayProtocolRequestOptions,
+) => Promise<unknown>;
 type QuestionPromptState = ReturnType<typeof createQuestionPromptState>;
 
 const states: QuestionPromptState[] = [];
+const defaultRequestDeadline = { timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS };
 
 function createState(onChange = vi.fn()) {
   const state = createQuestionPromptState(onChange);
@@ -47,11 +57,58 @@ function requestedPayload(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function requestQuestion(state: QuestionPromptState, overrides: Record<string, unknown> = {}) {
+  return handleQuestionPromptEvent(state, {
+    event: "question.requested",
+    payload: requestedPayload(overrides),
+  });
+}
+
+function recordQuestionResolution(state: QuestionPromptState, payload: unknown) {
+  return handleQuestionPromptEvent(state, { event: "question.resolved", payload });
+}
+
+function resolvedQuestion(params?: unknown): QuestionResolveResult {
+  const request = params as { answers?: QuestionAnswers; cancel?: true } | undefined;
+  return request?.cancel
+    ? { status: "cancelled" }
+    : {
+        status: "answered",
+        answers: request?.answers ?? { answers: { format: ["Compact"] } },
+      };
+}
+
+function createQuestionResolver() {
+  return vi.fn<RequestFn>(async (_method, params) => resolvedQuestion(params));
+}
+
+function createConnectedState(request: RequestFn | { request: RequestFn }, payload?: unknown) {
+  const state = createState();
+  const client = typeof request === "function" ? { request } : request;
+  setQuestionPromptClient(state, client);
+  if (payload !== undefined) {
+    handleQuestionPromptEvent(state, { event: "question.requested", payload });
+  }
+  return { state, client };
+}
+
 function questionNotFoundError() {
   return new GatewayRequestError({
     code: "INVALID_REQUEST",
     message: "question was not found",
     details: { reason: "QUESTION_NOT_FOUND" },
+  });
+}
+
+function rejectAfterRequestDeadline(options?: GatewayProtocolRequestOptions): Promise<never> {
+  return new Promise((_resolve, reject) => {
+    const timeoutMs = options?.timeoutMs;
+    if (typeof timeoutMs === "number") {
+      setTimeout(
+        () => reject(new Error(`gateway request timed out after ${timeoutMs}ms`)),
+        timeoutMs,
+      );
+    }
   });
 }
 
@@ -67,7 +124,7 @@ function createDeferredQuestionRequest() {
   );
   return {
     request,
-    resolve: () => finishRequest({ status: "answered" }),
+    resolve: () => finishRequest(resolvedQuestion(request.mock.calls.at(-1)?.[1])),
     reject: () => failRequest(new Error("stale gateway unavailable")),
   };
 }
@@ -95,12 +152,7 @@ afterEach(() => {
 describe("question event parsing", () => {
   it("round-trips requested and resolved event payloads", () => {
     const state = createState();
-    expect(
-      handleQuestionPromptEvent(state, {
-        event: "question.requested",
-        payload: requestedPayload(),
-      }),
-    ).toBe(true);
+    expect(requestQuestion(state)).toBe(true);
     expect(state.prompts.get("question-1")).toMatchObject({
       id: "question-1",
       runId: "run-question",
@@ -109,13 +161,10 @@ describe("question event parsing", () => {
       questions: [{ questionId: "format", options: [{ label: "Compact" }, { label: "Detailed" }] }],
     });
     expect(
-      handleQuestionPromptEvent(state, {
-        event: "question.resolved",
-        payload: {
-          id: "question-1",
-          status: "answered",
-          answers: { answers: { format: ["Compact"] } },
-        },
+      recordQuestionResolution(state, {
+        id: "question-1",
+        status: "answered",
+        answers: { answers: { format: ["Compact"] } },
       }),
     ).toBe(true);
     expect(state.prompts.get("question-1")).toMatchObject({
@@ -145,12 +194,7 @@ describe("question event parsing", () => {
 
   it("rejects malformed records and answer maps", () => {
     const state = createState();
-    expect(
-      handleQuestionPromptEvent(state, {
-        event: "question.requested",
-        payload: requestedPayload({ id: "" }),
-      }),
-    ).toBe(false);
+    expect(requestQuestion(state, { id: "" })).toBe(false);
     expect(
       handleQuestionPromptEvent(state, {
         event: "question.requested",
@@ -160,13 +204,10 @@ describe("question event parsing", () => {
       }),
     ).toBe(false);
     expect(
-      handleQuestionPromptEvent(state, {
-        event: "question.resolved",
-        payload: {
-          id: "question-1",
-          status: "answered",
-          answers: { answers: { format: "Compact" } },
-        },
+      recordQuestionResolution(state, {
+        id: "question-1",
+        status: "answered",
+        answers: { answers: { format: "Compact" } },
       }),
     ).toBe(false);
   });
@@ -175,34 +216,20 @@ describe("question event parsing", () => {
 describe("question prompt state", () => {
   it.each(["cancelled", "expired"] as const)("transitions requested to %s", (status) => {
     const state = createState();
-    expect(
-      handleQuestionPromptEvent(state, {
-        event: "question.requested",
-        payload: requestedPayload(),
-      }),
-    ).toBe(true);
+    expect(requestQuestion(state)).toBe(true);
 
-    handleQuestionPromptEvent(state, {
-      event: "question.resolved",
-      payload: { id: "question-1", status },
-    });
+    recordQuestionResolution(state, { id: "question-1", status });
 
     expect(state.prompts.get("question-1")?.status).toBe(status);
   });
 
   it("marks answers from another surface", () => {
     const state = createState();
-    handleQuestionPromptEvent(state, {
-      event: "question.requested",
-      payload: requestedPayload(),
-    });
-    handleQuestionPromptEvent(state, {
-      event: "question.resolved",
-      payload: {
-        id: "question-1",
-        status: "answered",
-        answers: { answers: { format: ["Detailed"] } },
-      },
+    requestQuestion(state);
+    recordQuestionResolution(state, {
+      id: "question-1",
+      status: "answered",
+      answers: { answers: { format: ["Detailed"] } },
     });
 
     expect(state.prompts.get("question-1")).toMatchObject({
@@ -217,24 +244,16 @@ describe("question prompt state", () => {
     const request = vi.fn<RequestFn>(
       () =>
         new Promise((resolve) => {
-          releaseRequest = () => resolve({ status: "answered" });
+          releaseRequest = () => resolve(resolvedQuestion());
         }),
     );
-    const state = createState();
-    setQuestionPromptClient(state, { request });
-    handleQuestionPromptEvent(state, {
-      event: "question.requested",
-      payload: requestedPayload(),
-    });
+    const { state } = createConnectedState(request, requestedPayload());
 
     const submitting = submitQuestionPrompt(state, "question-1", { format: ["Compact"] });
-    handleQuestionPromptEvent(state, {
-      event: "question.resolved",
-      payload: {
-        id: "question-1",
-        status: "answered",
-        answers: { answers: { format: ["Compact"] } },
-      },
+    recordQuestionResolution(state, {
+      id: "question-1",
+      status: "answered",
+      answers: { answers: { format: ["Compact"] } },
     });
     releaseRequest();
     await submitting;
@@ -255,21 +274,13 @@ describe("question prompt state", () => {
           rejectRequest = reject;
         }),
     );
-    const state = createState();
-    setQuestionPromptClient(state, { request });
-    handleQuestionPromptEvent(state, {
-      event: "question.requested",
-      payload: requestedPayload(),
-    });
+    const { state } = createConnectedState(request, requestedPayload());
 
     const submitting = submitQuestionPrompt(state, "question-1", { format: ["Compact"] });
-    handleQuestionPromptEvent(state, {
-      event: "question.resolved",
-      payload: {
-        id: "question-1",
-        status: "answered",
-        answers: { answers: { format: ["Detailed"] } },
-      },
+    recordQuestionResolution(state, {
+      id: "question-1",
+      status: "answered",
+      answers: { answers: { format: ["Detailed"] } },
     });
     rejectRequest(new Error("question already resolved"));
     await submitting;
@@ -291,21 +302,13 @@ describe("question prompt state", () => {
           rejectRequest = reject;
         }),
     );
-    const state = createState();
-    setQuestionPromptClient(state, { request });
-    handleQuestionPromptEvent(state, {
-      event: "question.requested",
-      payload: requestedPayload(),
-    });
+    const { state } = createConnectedState(request, requestedPayload());
 
     const submitting = submitQuestionPrompt(state, "question-1", { format: ["Compact"] });
-    handleQuestionPromptEvent(state, {
-      event: "question.resolved",
-      payload: {
-        id: "question-1",
-        status: "answered",
-        answers: { answers: { format: ["Compact"] } },
-      },
+    recordQuestionResolution(state, {
+      id: "question-1",
+      status: "answered",
+      answers: { answers: { format: ["Compact"] } },
     });
     rejectRequest(new Error("connection closed"));
     await submitting;
@@ -322,10 +325,7 @@ describe("question prompt state", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-17T00:00:00.000Z"));
     const state = createState();
-    handleQuestionPromptEvent(state, {
-      event: "question.requested",
-      payload: requestedPayload({ expiresAtMs: Date.now() + 1_000 }),
-    });
+    requestQuestion(state, { expiresAtMs: Date.now() + 1_000 });
 
     vi.advanceTimersByTime(1_000);
 
@@ -336,12 +336,7 @@ describe("question prompt state", () => {
     const request = vi.fn<RequestFn>(async () => {
       throw new Error("gateway unavailable");
     });
-    const state = createState();
-    setQuestionPromptClient(state, { request });
-    handleQuestionPromptEvent(state, {
-      event: "question.requested",
-      payload: requestedPayload(),
-    });
+    const { state } = createConnectedState(request, requestedPayload());
 
     await submitQuestionPrompt(state, "question-1", { format: ["Compact"] });
 
@@ -359,10 +354,7 @@ describe("question prompt state", () => {
         key === "chat.questions.disconnected" ? "Localized reconnect guidance" : key,
       );
     const state = createState();
-    handleQuestionPromptEvent(state, {
-      event: "question.requested",
-      payload: requestedPayload(),
-    });
+    requestQuestion(state);
 
     await submitQuestionPrompt(state, "question-1", { format: ["Compact"] });
 
@@ -377,13 +369,25 @@ describe("question prompt state", () => {
 
 describe("question RPC helpers", () => {
   it("sends option labels, free text, and multi-select arrays in the frozen answer shape", async () => {
-    const request = vi.fn<RequestFn>(async () => ({}));
-    const state = createState();
-    setQuestionPromptClient(state, { request });
-    handleQuestionPromptEvent(state, {
-      event: "question.requested",
-      payload: requestedPayload(),
-    });
+    const request = createQuestionResolver();
+    const questions = [
+      ...requestedPayload().questions,
+      {
+        questionId: "destination",
+        header: "Destination",
+        question: "Where should I send it?",
+        options: [],
+        isOther: true,
+      },
+      {
+        questionId: "extras",
+        header: "Extras",
+        question: "What should I include?",
+        options: [{ label: "Tests" }, { label: "Docs" }],
+        multiSelect: true,
+      },
+    ];
+    const { state } = createConnectedState(request, requestedPayload({ questions }));
 
     await submitQuestionPrompt(state, "question-1", {
       format: ["Compact"],
@@ -391,34 +395,102 @@ describe("question RPC helpers", () => {
       extras: ["Tests", "Docs"],
     });
 
-    expect(request).toHaveBeenCalledWith("question.resolve", {
-      id: "question-1",
-      answers: {
+    expect(request).toHaveBeenCalledWith(
+      "question.resolve",
+      {
+        id: "question-1",
         answers: {
-          format: ["Compact"],
-          destination: ["My own target"],
-          extras: ["Tests", "Docs"],
+          answers: {
+            format: ["Compact"],
+            destination: ["My own target"],
+            extras: ["Tests", "Docs"],
+          },
         },
       },
+      defaultRequestDeadline,
+    );
+    expect(state.prompts.get("question-1")).toMatchObject({
+      status: "answered",
+      localResolutionConfirmed: true,
+      answeredElsewhere: false,
+      submitting: false,
     });
   });
 
   it("cancels a pending question when the docked panel is skipped", async () => {
-    const request = vi.fn<RequestFn>(async () => ({}));
-    const state = createState();
-    setQuestionPromptClient(state, { request });
-    handleQuestionPromptEvent(state, {
-      event: "question.requested",
-      payload: requestedPayload(),
-    });
+    const request = createQuestionResolver();
+    const { state } = createConnectedState(request, requestedPayload());
 
     await cancelQuestionPrompt(state, "question-1");
 
-    expect(request).toHaveBeenCalledWith("question.resolve", {
-      id: "question-1",
-      cancel: true,
+    expect(request).toHaveBeenCalledWith(
+      "question.resolve",
+      { id: "question-1", cancel: true },
+      defaultRequestDeadline,
+    );
+    expect(state.prompts.get("question-1")).toMatchObject({
+      status: "cancelled",
+      localResolutionConfirmed: true,
+      submitting: false,
     });
   });
+
+  it.each([{}, { status: "answered" }, { status: "cancelled" }])(
+    "keeps an invalid successful answer response retryable: %o",
+    async (result) => {
+      const request = vi.fn<RequestFn>(async () => result);
+      const { state } = createConnectedState(request, requestedPayload());
+
+      await submitQuestionPrompt(state, "question-1", { format: ["Compact"] });
+
+      expect(state.prompts.get("question-1")).toMatchObject({
+        status: "pending",
+        submitting: false,
+        error: "invalid question.resolve response",
+      });
+    },
+  );
+
+  it.each(questionResolutionCases)(
+    "re-enables a stalled $action when its gateway request reaches the owner deadline",
+    async ({ resolve }) => {
+      vi.useFakeTimers();
+      const request = vi.fn<RequestFn>((_method, _params, options) =>
+        rejectAfterRequestDeadline(options),
+      );
+      const { state } = createConnectedState(request, requestedPayload());
+
+      const pending = resolve(state);
+      expect(state.prompts.get("question-1")?.submitting).toBe(true);
+      await vi.advanceTimersByTimeAsync(DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS);
+
+      expect(state.prompts.get("question-1")).toMatchObject({
+        status: "pending",
+        submitting: false,
+        error: `gateway request timed out after ${DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS}ms`,
+      });
+      await pending;
+    },
+  );
+
+  it.each(questionResolutionCases)(
+    "clips a $action request to the remaining question lifetime",
+    async ({ resolve }) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-07-17T00:00:00.000Z"));
+      const request = createQuestionResolver();
+      const { state } = createConnectedState(
+        request,
+        requestedPayload({ expiresAtMs: Date.now() + 1_250 }),
+      );
+
+      await resolve(state);
+
+      expect(request).toHaveBeenCalledWith("question.resolve", expect.any(Object), {
+        timeoutMs: 1_250,
+      });
+    },
+  );
 });
 
 describe("question resolution connection ownership", () => {
@@ -427,20 +499,12 @@ describe("question resolution connection ownership", () => {
     async ({ resolve }) => {
       const stale = createDeferredQuestionRequest();
       const current = createDeferredQuestionRequest();
-      const state = createState();
-      setQuestionPromptClient(state, { request: stale.request });
-      handleQuestionPromptEvent(state, {
-        event: "question.requested",
-        payload: requestedPayload(),
-      });
+      const { state } = createConnectedState(stale.request, requestedPayload());
 
       const staleResolution = resolve(state);
       setQuestionPromptClient(state, { request: current.request });
       expect(state.prompts.has("question-1")).toBe(false);
-      handleQuestionPromptEvent(state, {
-        event: "question.requested",
-        payload: requestedPayload(),
-      });
+      requestQuestion(state);
 
       const currentResolution = resolve(state);
       stale.resolve();
@@ -464,20 +528,12 @@ describe("question resolution connection ownership", () => {
     async ({ resolve }) => {
       const stale = createDeferredQuestionRequest();
       const current = createDeferredQuestionRequest();
-      const state = createState();
-      setQuestionPromptClient(state, { request: stale.request });
-      handleQuestionPromptEvent(state, {
-        event: "question.requested",
-        payload: requestedPayload(),
-      });
+      const { state } = createConnectedState(stale.request, requestedPayload());
 
       const staleResolution = resolve(state);
       setQuestionPromptClient(state, { request: current.request });
       expect(state.prompts.has("question-1")).toBe(false);
-      handleQuestionPromptEvent(state, {
-        event: "question.requested",
-        payload: requestedPayload(),
-      });
+      requestQuestion(state);
 
       const currentResolution = resolve(state);
       stale.reject();
@@ -510,12 +566,7 @@ describe("question resolution connection ownership", () => {
             : current.request(method, params);
         }),
       };
-      const state = createState();
-      setQuestionPromptClient(state, client);
-      handleQuestionPromptEvent(state, {
-        event: "question.requested",
-        payload: requestedPayload(),
-      });
+      const { state } = createConnectedState(client, requestedPayload());
 
       const staleResolution = resolve(state);
       setQuestionPromptClient(state, null);
@@ -541,20 +592,14 @@ describe("question resolution connection ownership", () => {
 
   it.each(questionResolutionCases)(
     "keeps a current $action after same-connection prompt hydration",
-    async ({ resolve }) => {
+    async ({ action, resolve }) => {
       const pending = createDeferredQuestionRequest();
       const request = vi.fn<RequestFn>((method, params) =>
         method === "question.list"
           ? Promise.resolve({ questions: [requestedPayload()] })
           : pending.request(method, params),
       );
-      const state = createState();
-      const client = { request };
-      setQuestionPromptClient(state, client);
-      handleQuestionPromptEvent(state, {
-        event: "question.requested",
-        payload: requestedPayload(),
-      });
+      const { state, client } = createConnectedState(request, requestedPayload());
 
       const resolution = resolve(state);
       const original = state.prompts.get("question-1");
@@ -565,8 +610,9 @@ describe("question resolution connection ownership", () => {
       await resolution;
 
       expect(state.prompts.get("question-1")).toMatchObject({
-        status: "pending",
+        status: action === "answer" ? "answered" : "cancelled",
         localResolutionConfirmed: true,
+        submitting: false,
         error: null,
       });
     },
@@ -575,14 +621,9 @@ describe("question resolution connection ownership", () => {
   it.each(["pending", "answered", "cancelled", "expired"] as const)(
     "does not carry a %s question into a replacement gateway",
     (status) => {
-      const firstClient = { request: vi.fn<RequestFn>(async () => ({})) };
-      const secondClient = { request: vi.fn<RequestFn>(async () => ({})) };
-      const state = createState();
-      setQuestionPromptClient(state, firstClient);
-      handleQuestionPromptEvent(state, {
-        event: "question.requested",
-        payload: requestedPayload(),
-      });
+      const firstClient = { request: createQuestionResolver() };
+      const secondClient = { request: createQuestionResolver() };
+      const { state } = createConnectedState(firstClient, requestedPayload());
       if (status !== "pending") {
         handleQuestionPromptEvent(state, {
           event: "question.resolved",
@@ -596,10 +637,7 @@ describe("question resolution connection ownership", () => {
               : { id: "question-1", status },
         });
       }
-      handleQuestionPromptEvent(state, {
-        event: "question.resolved",
-        payload: { id: "unmatched-first-gateway", status: "cancelled" },
-      });
+      recordQuestionResolution(state, { id: "unmatched-first-gateway", status: "cancelled" });
       setQuestionPromptClient(state, null);
 
       setQuestionPromptClient(state, secondClient);
@@ -610,25 +648,14 @@ describe("question resolution connection ownership", () => {
   );
 
   it("preserves authoritative question records when the same gateway reconnects", () => {
-    const client = { request: vi.fn<RequestFn>(async () => ({})) };
-    const state = createState();
-    setQuestionPromptClient(state, client);
-    handleQuestionPromptEvent(state, {
-      event: "question.requested",
-      payload: requestedPayload(),
+    const client = { request: createQuestionResolver() };
+    const { state } = createConnectedState(client, requestedPayload());
+    recordQuestionResolution(state, {
+      id: "question-1",
+      status: "answered",
+      answers: { answers: { format: ["Detailed"] } },
     });
-    handleQuestionPromptEvent(state, {
-      event: "question.resolved",
-      payload: {
-        id: "question-1",
-        status: "answered",
-        answers: { answers: { format: ["Detailed"] } },
-      },
-    });
-    handleQuestionPromptEvent(state, {
-      event: "question.resolved",
-      payload: { id: "unmatched-same-gateway", status: "cancelled" },
-    });
+    recordQuestionResolution(state, { id: "unmatched-same-gateway", status: "cancelled" });
 
     setQuestionPromptClient(state, null);
     setQuestionPromptClient(state, client);
@@ -644,14 +671,32 @@ describe("question resolution connection ownership", () => {
 describe("refreshPendingQuestions", () => {
   it("hydrates pending questions after connect", async () => {
     const request = vi.fn<RequestFn>(async () => ({ questions: [requestedPayload()] }));
-    const state = createState();
-    const client = { request };
-    setQuestionPromptClient(state, client);
+    const { state, client } = createConnectedState(request);
 
     refreshPendingQuestionsWithRetry(state, client);
     await waitForFast(() => expect(state.prompts.get("question-1")?.status).toBe("pending"));
 
-    expect(request).toHaveBeenCalledWith("question.list", {});
+    expect(request).toHaveBeenCalledWith("question.list", {}, defaultRequestDeadline);
+    expect(state.prompts.get("question-1")?.status).toBe("pending");
+  });
+
+  it("retries question hydration when the gateway leaves question.list unresolved", async () => {
+    vi.useFakeTimers();
+    let attempts = 0;
+    const request = vi.fn<RequestFn>((_method, _params, options) => {
+      attempts += 1;
+      return attempts === 1
+        ? rejectAfterRequestDeadline(options)
+        : Promise.resolve({ questions: [requestedPayload()] });
+    });
+    const { state, client } = createConnectedState(request);
+
+    refreshPendingQuestionsWithRetry(state, client);
+    await vi.advanceTimersByTimeAsync(DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS);
+    expect(request).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(request).toHaveBeenCalledTimes(2);
     expect(state.prompts.get("question-1")?.status).toBe("pending");
   });
 
@@ -665,9 +710,7 @@ describe("refreshPendingQuestions", () => {
       }
       return { questions: [requestedPayload()] };
     });
-    const state = createState();
-    const client = { request };
-    setQuestionPromptClient(state, client);
+    const { state, client } = createConnectedState(request);
 
     refreshPendingQuestionsWithRetry(state, client);
     await vi.advanceTimersByTimeAsync(1_000);
@@ -687,22 +730,13 @@ describe("refreshPendingQuestions", () => {
           finishList = resolve;
         }),
     );
-    const state = createState();
-    const client = { request };
-    setQuestionPromptClient(state, client);
-    handleQuestionPromptEvent(state, {
-      event: "question.requested",
-      payload: requestedPayload(),
-    });
+    const { state, client } = createConnectedState(request, requestedPayload());
 
     refreshPendingQuestionsWithRetry(state, client);
-    handleQuestionPromptEvent(state, {
-      event: "question.resolved",
-      payload: {
-        id: "question-1",
-        status: "answered",
-        answers: { answers: { format: ["Detailed"] } },
-      },
+    recordQuestionResolution(state, {
+      id: "question-1",
+      status: "answered",
+      answers: { answers: { format: ["Detailed"] } },
     });
     finishList({ questions: [requestedPayload()] });
     await waitForFast(() => expect(state.prompts.get("question-1")?.status).toBe("answered"));
@@ -724,23 +758,22 @@ describe("refreshPendingQuestions", () => {
             }),
           }),
     );
-    const state = createState();
-    const client = { request };
-    setQuestionPromptClient(state, client);
+    const { state, client } = createConnectedState(request);
 
     refreshPendingQuestionsWithRetry(state, client);
-    handleQuestionPromptEvent(state, {
-      event: "question.resolved",
-      payload: {
-        id: "question-1",
-        status: "answered",
-        answers: { answers: { format: ["Detailed"] } },
-      },
+    recordQuestionResolution(state, {
+      id: "question-1",
+      status: "answered",
+      answers: { answers: { format: ["Detailed"] } },
     });
     finishList({ questions: [] });
     await waitForFast(() => expect(state.prompts.get("question-1")?.status).toBe("answered"));
 
-    expect(request).toHaveBeenCalledWith("question.get", { id: "question-1" });
+    expect(request).toHaveBeenCalledWith(
+      "question.get",
+      { id: "question-1" },
+      defaultRequestDeadline,
+    );
     expect(state.prompts.get("question-1")).toMatchObject({
       status: "answered",
       answeredElsewhere: true,
@@ -761,18 +794,16 @@ describe("refreshPendingQuestions", () => {
         }),
       };
     });
-    const state = createState();
-    const client = { request };
-    setQuestionPromptClient(state, client);
-    handleQuestionPromptEvent(state, {
-      event: "question.requested",
-      payload: requestedPayload(),
-    });
+    const { state, client } = createConnectedState(request, requestedPayload());
 
     refreshPendingQuestionsWithRetry(state, client);
     await waitForFast(() => expect(state.prompts.get("question-1")?.status).toBe("answered"));
 
-    expect(request).toHaveBeenCalledWith("question.get", { id: "question-1" });
+    expect(request).toHaveBeenCalledWith(
+      "question.get",
+      { id: "question-1" },
+      defaultRequestDeadline,
+    );
     expect(state.prompts.get("question-1")).toMatchObject({
       status: "answered",
       answeredElsewhere: true,
@@ -797,13 +828,7 @@ describe("refreshPendingQuestions", () => {
         }),
       };
     });
-    const state = createState();
-    const client = { request };
-    setQuestionPromptClient(state, client);
-    handleQuestionPromptEvent(state, {
-      event: "question.requested",
-      payload: requestedPayload(),
-    });
+    const { state, client } = createConnectedState(request, requestedPayload());
 
     refreshPendingQuestionsWithRetry(state, client);
     await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
@@ -825,13 +850,7 @@ describe("refreshPendingQuestions", () => {
       }
       throw questionNotFoundError();
     });
-    const state = createState();
-    const client = { request };
-    setQuestionPromptClient(state, client);
-    handleQuestionPromptEvent(state, {
-      event: "question.requested",
-      payload: requestedPayload(),
-    });
+    const { state, client } = createConnectedState(request, requestedPayload());
 
     refreshPendingQuestionsWithRetry(state, client);
     await waitForFast(() => expect(state.prompts.get("question-1")?.status).toBe("unavailable"));
@@ -843,6 +862,101 @@ describe("refreshPendingQuestions", () => {
       submitting: false,
       error: null,
     });
+  });
+
+  it("stops retrying an unmatched resolution after its gateway tombstone ages out", async () => {
+    vi.useFakeTimers();
+    const request = vi.fn<RequestFn>(async (method) => {
+      if (method === "question.list") {
+        return { questions: [] };
+      }
+      throw questionNotFoundError();
+    });
+    const { state, client } = createConnectedState(request);
+    recordQuestionResolution(state, { id: "forgotten-question", status: "cancelled" });
+    setQuestionPromptClient(state, null);
+    await vi.advanceTimersByTimeAsync(15_000);
+    setQuestionPromptClient(state, client);
+
+    refreshPendingQuestionsWithRetry(state, client);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(state.unmatchedResolutions.has("forgotten-question")).toBe(false);
+    expect(state.refreshRetryTimer).toBeNull();
+    expect(request).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(12_000);
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps an unmatched resolution recoverable after a transient question.get failure", async () => {
+    vi.useFakeTimers();
+    let getAttempts = 0;
+    const request = vi.fn<RequestFn>(async (method) => {
+      if (method === "question.list") {
+        return { questions: [] };
+      }
+      getAttempts += 1;
+      if (getAttempts === 1) {
+        throw new Error("gateway unavailable");
+      }
+      return {
+        question: requestedPayload({
+          status: "answered",
+          answers: { answers: { format: ["Detailed"] } },
+        }),
+      };
+    });
+    const { state, client } = createConnectedState(request);
+    recordQuestionResolution(state, {
+      id: "question-1",
+      status: "answered",
+      answers: { answers: { format: ["Detailed"] } },
+    });
+
+    refreshPendingQuestionsWithRetry(state, client);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(state.unmatchedResolutions.has("question-1")).toBe(true);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(state.prompts.get("question-1")).toMatchObject({
+      status: "answered",
+      answeredElsewhere: true,
+      answers: { answers: { format: ["Detailed"] } },
+    });
+    expect(state.unmatchedResolutions.size).toBe(0);
+  });
+
+  it("recovers a sibling question when another question.get never responds", async () => {
+    vi.useFakeTimers();
+    const request = vi.fn<RequestFn>((method, params, options) => {
+      if (method === "question.list") {
+        return Promise.resolve({ questions: [] });
+      }
+      if ((params as { id: string }).id === "question-1") {
+        return rejectAfterRequestDeadline(options);
+      }
+      return Promise.resolve({
+        question: requestedPayload({
+          id: "question-2",
+          status: "answered",
+          answers: { answers: { format: ["Detailed"] } },
+        }),
+      });
+    });
+    const { state, client } = createConnectedState(request);
+    for (const id of ["question-1", "question-2"]) {
+      requestQuestion(state, { id });
+    }
+
+    refreshPendingQuestionsWithRetry(state, client);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(state.prompts.get("question-2")).toMatchObject({
+      status: "answered",
+      answers: { answers: { format: ["Detailed"] } },
+    });
+    expect(state.prompts.get("question-1")?.status).toBe("pending");
+    await vi.advanceTimersByTimeAsync(DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS);
+    expect(state.prompts.get("question-1")?.status).toBe("pending");
   });
 
   it("reconciles a locally expired prompt with the authoritative record", async () => {
@@ -858,13 +972,10 @@ describe("refreshPendingQuestions", () => {
             }),
           },
     );
-    const state = createState();
-    const client = { request };
-    setQuestionPromptClient(state, client);
-    handleQuestionPromptEvent(state, {
-      event: "question.requested",
-      payload: requestedPayload({ expiresAtMs: Date.now() + 1_000 }),
-    });
+    const { state, client } = createConnectedState(
+      request,
+      requestedPayload({ expiresAtMs: Date.now() + 1_000 }),
+    );
     vi.advanceTimersByTime(1_000);
     expect(state.prompts.get("question-1")).toMatchObject({
       status: "expired",
@@ -894,17 +1005,18 @@ describe("refreshPendingQuestions", () => {
         finishGet = resolve;
       });
     });
-    const state = createState();
-    const client = { request };
-    setQuestionPromptClient(state, client);
-    handleQuestionPromptEvent(state, {
-      event: "question.requested",
-      payload: requestedPayload({ expiresAtMs: Date.now() + 1_000 }),
-    });
+    const { state, client } = createConnectedState(
+      request,
+      requestedPayload({ expiresAtMs: Date.now() + 1_000 }),
+    );
 
     refreshPendingQuestionsWithRetry(state, client);
     await waitForFast(() =>
-      expect(request).toHaveBeenCalledWith("question.get", { id: "question-1" }),
+      expect(request).toHaveBeenCalledWith(
+        "question.get",
+        { id: "question-1" },
+        defaultRequestDeadline,
+      ),
     );
     await vi.advanceTimersByTimeAsync(1_000);
     expect(state.prompts.get("question-1")?.locallyExpired).toBe(true);
@@ -940,20 +1052,21 @@ describe("refreshPendingQuestions", () => {
         }),
       });
     });
-    const state = createState();
-    const client = { request };
-    setQuestionPromptClient(state, client);
-    handleQuestionPromptEvent(state, {
-      event: "question.requested",
-      payload: requestedPayload({ expiresAtMs: Date.now() + 1_000 }),
-    });
+    const { state, client } = createConnectedState(
+      request,
+      requestedPayload({ expiresAtMs: Date.now() + 1_000 }),
+    );
 
     refreshPendingQuestionsWithRetry(state, client);
     await vi.advanceTimersByTimeAsync(1_000);
     finishList({ questions: [] });
 
     await waitForFast(() => expect(state.prompts.get("question-1")?.status).toBe("answered"));
-    expect(request).toHaveBeenCalledWith("question.get", { id: "question-1" });
+    expect(request).toHaveBeenCalledWith(
+      "question.get",
+      { id: "question-1" },
+      defaultRequestDeadline,
+    );
     expect(state.prompts.get("question-1")).toMatchObject({
       status: "answered",
       locallyExpired: false,
@@ -977,15 +1090,16 @@ describe("refreshPendingQuestions", () => {
     const state = createState(onChange);
     const client = { request };
     setQuestionPromptClient(state, client);
-    handleQuestionPromptEvent(state, {
-      event: "question.requested",
-      payload: requestedPayload(),
-    });
+    requestQuestion(state);
     onChange.mockClear();
 
     refreshPendingQuestionsWithRetry(state, client);
     await waitForFast(() =>
-      expect(request).toHaveBeenCalledWith("question.get", { id: "question-1" }),
+      expect(request).toHaveBeenCalledWith(
+        "question.get",
+        { id: "question-1" },
+        defaultRequestDeadline,
+      ),
     );
 
     expect(state.prompts.get("question-2")?.status).toBe("pending");

--- a/ui/src/app/question-prompt.ts
+++ b/ui/src/app/question-prompt.ts
@@ -4,14 +4,19 @@ import type {
   Question,
   QuestionAnswers,
   QuestionRecord,
+  QuestionResolveResult,
   QuestionResolvedEvent,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { GatewayRequestError, type GatewayEventFrame } from "../api/gateway.ts";
 import { t } from "../i18n/index.ts";
-
-type QuestionClient = {
-  request: (method: string, params?: unknown) => Promise<unknown>;
-};
+import {
+  publishQuestionClientResolution,
+  registerQuestionClientOwner,
+  requestQuestionGateway,
+  unregisterQuestionClientOwner,
+  type QuestionClient,
+  type QuestionClientResolutionOwner,
+} from "./question-prompt-client.ts";
 
 type QuestionDraft = {
   selected: Set<string>;
@@ -40,10 +45,8 @@ export type QuestionPrompt = {
   revision: number;
 };
 
-type QuestionPromptState = {
-  client: QuestionClient | null;
+type QuestionPromptState = QuestionClientResolutionOwner & {
   ownerClient: QuestionClient | null;
-  clientGeneration: number;
   prompts: Map<string, QuestionPrompt>;
   unmatchedResolutions: Map<string, QuestionResolvedEvent>;
   revision: number;
@@ -247,8 +250,19 @@ function parseQuestionResolvedEvent(payload: unknown): QuestionResolvedEvent | n
   return null;
 }
 
+function parseQuestionResolveResult(payload: unknown): QuestionResolveResult | null {
+  if (!isRecord(payload)) {
+    return null;
+  }
+  if (payload.status === "cancelled") {
+    return { status: "cancelled" };
+  }
+  const answers = parseQuestionAnswers(payload.answers);
+  return payload.status === "answered" && answers ? { status: "answered", answers } : null;
+}
+
 export function createQuestionPromptState(onChange: () => void): QuestionPromptState {
-  return {
+  const state: QuestionPromptState = {
     client: null,
     ownerClient: null,
     clientGeneration: 0,
@@ -258,7 +272,9 @@ export function createQuestionPromptState(onChange: () => void): QuestionPromptS
     tickTimer: null,
     refreshRetryTimer: null,
     onChange,
+    onQuestionResolution: (resolution) => recordQuestionResolution(state, resolution),
   };
+  return state;
 }
 
 function scheduleTick(state: QuestionPromptState): void {
@@ -346,6 +362,23 @@ function applyQuestionResolution(
   prompt.revision = ++state.revision;
 }
 
+function recordQuestionResolution(
+  state: QuestionPromptState,
+  resolved: QuestionResolvedEvent,
+): void {
+  const prompt = state.prompts.get(resolved.id);
+  if (prompt) {
+    applyQuestionResolution(state, prompt, resolved);
+  } else {
+    // Broadcasts and same-client results own one fact. Gateway list/resolve are
+    // synchronous; WebSocket FIFO delivers it before any later empty list response,
+    // so existing hydration consumes this tombstone without a parallel recovery.
+    state.unmatchedResolutions.set(resolved.id, resolved);
+    state.revision += 1;
+  }
+  state.onChange();
+}
+
 export function handleQuestionPromptEvent(
   state: QuestionPromptState,
   event: Pick<GatewayEventFrame, "event" | "payload">,
@@ -374,18 +407,10 @@ export function handleQuestionPromptEvent(
     return false;
   }
   const resolved = parseQuestionResolvedEvent(event.payload);
-  const prompt = resolved ? state.prompts.get(resolved.id) : undefined;
   if (!resolved) {
     return false;
   }
-  if (!prompt) {
-    state.unmatchedResolutions.set(resolved.id, resolved);
-    state.revision += 1;
-    state.onChange();
-    return true;
-  }
-  applyQuestionResolution(state, prompt, resolved);
-  state.onChange();
+  recordQuestionResolution(state, resolved);
   return true;
 }
 
@@ -428,7 +453,7 @@ async function refreshPendingQuestions(
   isCurrentClient: () => boolean = () => state.client === client,
 ): Promise<boolean> {
   const startedAtRevision = state.revision;
-  const listResult = await client.request("question.list", {});
+  const listResult = await requestQuestionGateway(client, "question.list", {});
   const records = parseQuestionListResult(listResult);
   if (!records || !isCurrentClient()) {
     return false;
@@ -467,42 +492,48 @@ async function refreshPendingQuestions(
       missingIds.add(id);
     }
   }
-  const missingResults = await Promise.allSettled(
-    missing.map((candidate) => client.request("question.get", { id: candidate.id })),
-  );
-  if (!isCurrentClient()) {
-    return false;
-  }
-  let complete = true;
-  for (const [index, candidate] of missing.entries()) {
-    const current = state.prompts.get(candidate.id);
-    if (candidate.prompt && current !== candidate.prompt) {
-      if (!current || current.status === "pending" || current.locallyExpired) {
-        complete = false;
+  const recovered = await Promise.all(
+    missing.map(async (candidate) => {
+      const result = await requestQuestionGateway(client, "question.get", {
+        id: candidate.id,
+      }).then(
+        (value) => ({ ok: true as const, value }),
+        (error: unknown) => ({ ok: false as const, error }),
+      );
+      if (!isCurrentClient()) {
+        return false;
       }
-      continue;
-    }
-    if (candidate.prompt && current?.revision !== candidate.revision && !current?.locallyExpired) {
-      if (current?.status === "pending") {
-        complete = false;
+      const current = state.prompts.get(candidate.id);
+      if (candidate.prompt && current !== candidate.prompt) {
+        return Boolean(current && current.status !== "pending" && !current.locallyExpired);
       }
-      continue;
-    }
-    if (!candidate.prompt && !state.unmatchedResolutions.has(candidate.id)) {
-      continue;
-    }
-    const missingResult = missingResults[index];
-    if (
-      current &&
-      missingResult?.status === "rejected" &&
-      isQuestionNotFoundError(missingResult.reason)
-    ) {
-      markRecoveryUnavailable(state, current);
-      continue;
-    }
-    const record =
-      missingResult?.status === "fulfilled" ? parseQuestionGetResult(missingResult.value) : null;
-    if (record) {
+      if (
+        candidate.prompt &&
+        current?.revision !== candidate.revision &&
+        !current?.locallyExpired
+      ) {
+        return current?.status !== "pending";
+      }
+      if (!candidate.prompt && !state.unmatchedResolutions.has(candidate.id)) {
+        return true;
+      }
+      if (!result.ok) {
+        if (!isQuestionNotFoundError(result.error)) {
+          return false;
+        }
+        if (current) {
+          markRecoveryUnavailable(state, current);
+        }
+        // An aged-out tombstone cannot hydrate an unmatched resolution;
+        // retaining it would retry an already-final reconnect forever.
+        state.unmatchedResolutions.delete(candidate.id);
+        state.onChange();
+        return true;
+      }
+      const record = parseQuestionGetResult(result.value);
+      if (!record) {
+        return false;
+      }
       const prompt = promptFromRecord(state, record, current);
       const unmatched = state.unmatchedResolutions.get(candidate.id);
       if (unmatched) {
@@ -510,13 +541,14 @@ async function refreshPendingQuestions(
         applyQuestionResolution(state, prompt, unmatched);
       }
       state.prompts.set(candidate.id, prompt);
-      continue;
-    }
-    complete = false;
-  }
-  scheduleTick(state);
-  state.onChange();
-  return complete;
+      scheduleTick(state);
+      // Publish each settled recovery immediately; a hung sibling must never
+      // withhold an already-authoritative answer until its own deadline.
+      state.onChange();
+      return true;
+    }),
+  );
+  return isCurrentClient() && recovered.every(Boolean);
 }
 
 export function refreshPendingQuestionsWithRetry(
@@ -524,18 +556,21 @@ export function refreshPendingQuestionsWithRetry(
   client: QuestionClient,
   isCurrentClient: () => boolean = () => state.client === client,
 ): void {
+  const clientGeneration = state.clientGeneration;
+  const refreshIsCurrent = () =>
+    state.client === client && state.clientGeneration === clientGeneration && isCurrentClient();
   let retryIndex = 0;
   const run = async () => {
-    if (!isCurrentClient()) {
+    if (!refreshIsCurrent()) {
       return;
     }
     let complete: boolean;
     try {
-      complete = await refreshPendingQuestions(state, client, isCurrentClient);
+      complete = await refreshPendingQuestions(state, client, refreshIsCurrent);
     } catch {
       complete = false;
     }
-    if (complete || !isCurrentClient()) {
+    if (complete || !refreshIsCurrent()) {
       return;
     }
     const delayMs = REFRESH_RETRY_DELAYS_MS[retryIndex];
@@ -560,12 +595,16 @@ export function setQuestionPromptClient(
     return;
   }
 
+  if (state.client) {
+    unregisterQuestionClientOwner(state.client, state);
+  }
   state.clientGeneration += 1;
   const ownerChanged =
     client !== null && state.ownerClient !== null && state.ownerClient !== client;
   state.client = client;
   if (client !== null) {
     state.ownerClient = client;
+    registerQuestionClientOwner(client, state);
   }
 
   if (ownerChanged) {
@@ -583,6 +622,11 @@ export function setQuestionPromptClient(
     return;
   }
 
+  if (client) {
+    // Disposal stops the projection clock; same-owner remount must restart it
+    // before async hydration so an expired question cannot strand the surface.
+    scheduleTick(state);
+  }
   let changed = false;
   for (const prompt of state.prompts.values()) {
     if (!prompt.submitting) {
@@ -600,6 +644,9 @@ export function setQuestionPromptClient(
 }
 
 export function disposeQuestionPromptState(state: QuestionPromptState): void {
+  if (state.client) {
+    unregisterQuestionClientOwner(state.client, state);
+  }
   if (state.tickTimer) {
     globalThis.clearTimeout(state.tickTimer);
     state.tickTimer = null;
@@ -609,8 +656,9 @@ export function disposeQuestionPromptState(state: QuestionPromptState): void {
     state.refreshRetryTimer = null;
   }
   state.clientGeneration += 1;
+  // Retained records belong to the previous client: remount on it may recover
+  // them, while a different Gateway must still recognize and purge its state.
   state.client = null;
-  state.ownerClient = null;
 }
 
 function buildAnswers(values: QuestionAnswerValues): QuestionAnswers {
@@ -643,9 +691,11 @@ async function resolveQuestionPrompt(
   prompt.revision = ++state.revision;
   state.onChange();
   try {
-    await client.request(
+    const result = await requestQuestionGateway(
+      client,
       "question.resolve",
       submittedAnswers ? { id, answers: submittedAnswers } : { id, cancel: true },
+      prompt.expiresAtMs,
     );
     if (state.client !== client || state.clientGeneration !== clientGeneration) {
       return;
@@ -654,13 +704,14 @@ async function resolveQuestionPrompt(
     if (!current) {
       return;
     }
-    current.localResolutionConfirmed = true;
-    if (current.status !== "pending") {
-      current.answeredElsewhere = false;
-      current.submitting = false;
+    const resolved = parseQuestionResolveResult(result);
+    if (!resolved || resolved.status !== (submittedAnswers ? "answered" : "cancelled")) {
+      throw new Error("invalid question.resolve response");
     }
-    current.revision = ++state.revision;
-    state.onChange();
+    current.localResolutionConfirmed = true;
+    // The committed RPC result owns every same-client projection even when
+    // server event fanout fails; it is not a synthetic Gateway broadcast.
+    publishQuestionClientResolution(client, { ...resolved, id });
   } catch (error) {
     if (state.client !== client || state.clientGeneration !== clientGeneration) {
       return;

--- a/ui/src/app/question-prompt.ts
+++ b/ui/src/app/question-prompt.ts
@@ -697,20 +697,18 @@ async function resolveQuestionPrompt(
       submittedAnswers ? { id, answers: submittedAnswers } : { id, cancel: true },
       prompt.expiresAtMs,
     );
-    if (state.client !== client || state.clientGeneration !== clientGeneration) {
-      return;
-    }
-    const current = state.prompts.get(id);
-    if (!current) {
-      return;
-    }
     const resolved = parseQuestionResolveResult(result);
     if (!resolved || resolved.status !== (submittedAnswers ? "answered" : "cancelled")) {
       throw new Error("invalid question.resolve response");
     }
-    current.localResolutionConfirmed = true;
+    if (state.client === client && state.clientGeneration === clientGeneration) {
+      const current = state.prompts.get(id);
+      if (current) {
+        current.localResolutionConfirmed = true;
+      }
+    }
     // The committed RPC result owns every same-client projection even when
-    // server event fanout fails; it is not a synthetic Gateway broadcast.
+    // fanout fails or its submitting pane unmounts before the response.
     publishQuestionClientResolution(client, { ...resolved, id });
   } catch (error) {
     if (state.client !== client || state.clientGeneration !== clientGeneration) {

--- a/ui/src/e2e/question-flow.e2e.test.ts
+++ b/ui/src/e2e/question-flow.e2e.test.ts
@@ -356,11 +356,21 @@ describeControlUiE2e("Control UI Gateway question flow", () => {
   });
 
   it.each([
-    { action: "answer", status: "answered" as const },
-    { action: "cancellation", status: "cancelled" as const },
+    { action: "answer", status: "answered" as const, closeSubmittingPane: false },
+    { action: "cancellation", status: "cancelled" as const, closeSubmittingPane: false },
+    {
+      action: "answer after its submitting pane closes",
+      status: "answered" as const,
+      closeSubmittingPane: true,
+    },
+    {
+      action: "cancellation after its submitting pane closes",
+      status: "cancelled" as const,
+      closeSubmittingPane: true,
+    },
   ])(
-    "updates both split panes and sidebar from an authoritative $action without a resolution event",
-    async ({ action, status }) => {
+    "updates current panes and sidebar from an authoritative $action without a resolution event",
+    async ({ status, closeSubmittingPane }) => {
       const { gateway, page } = await openQuestionPage();
       await page.getByRole("button", { name: "Open split view" }).click();
       const panes = page.locator("openclaw-chat-pane.chat-split-view__pane");
@@ -369,7 +379,7 @@ describeControlUiE2e("Control UI Gateway question flow", () => {
         .poll(async () => (await gateway.getRequests("question.list")).length)
         .toBeGreaterThanOrEqual(3);
 
-      const request = questionRecord(`question-split-${action}`, [
+      const request = questionRecord(`question-split-${status}-${closeSubmittingPane}`, [
         {
           questionId: "deploy_target",
           header: "Deploy",
@@ -385,8 +395,14 @@ describeControlUiE2e("Control UI Gateway question flow", () => {
       const answers = { answers: { deploy_target: ["Staging"] } };
       const result: QuestionResolveResult =
         status === "answered" ? { status, answers } : { status };
-      await gateway.setMethodResponse("question.resolve", result);
-      const submittingPanel = panels.first();
+      if (closeSubmittingPane) {
+        await gateway.deferNext("question.resolve");
+      } else {
+        await gateway.setMethodResponse("question.resolve", result);
+      }
+      const submittingIndex = closeSubmittingPane ? 1 : 0;
+      const submittingPane = panes.nth(submittingIndex);
+      const submittingPanel = panels.nth(submittingIndex);
       if (status === "answered") {
         await submittingPanel.getByRole("radio", { name: /Staging/ }).click();
       }
@@ -398,11 +414,19 @@ describeControlUiE2e("Control UI Gateway question flow", () => {
         status === "answered" ? { id: request.id, answers } : { id: request.id, cancel: true },
       );
       expect(await gateway.getRequests("question.resolve")).toHaveLength(1);
+      const remainingPanes = page.locator("openclaw-chat-pane");
+      if (closeSubmittingPane) {
+        await submittingPane.getByRole("button", { name: "Close pane", exact: true }).click();
+        await expect.poll(() => remainingPanes.count()).toBe(1);
+        await expectQuestionAttention(page, true);
+        await gateway.resolveDeferred("question.resolve", result);
+      }
+      const remainingCount = closeSubmittingPane ? 1 : 2;
 
       await expect.poll(() => panels.count()).toBe(0);
       await expect
-        .poll(() => panes.locator(".agent-chat__composer-combobox textarea").count())
-        .toBe(2);
+        .poll(() => remainingPanes.locator(".agent-chat__composer-combobox textarea").count())
+        .toBe(remainingCount);
       await expect
         .poll(() =>
           page
@@ -410,7 +434,7 @@ describeControlUiE2e("Control UI Gateway question flow", () => {
             .filter({ hasText: status === "answered" ? "Staging" : "Skipped" })
             .count(),
         )
-        .toBe(2);
+        .toBe(remainingCount);
       await expectQuestionAttention(page, false);
     },
   );

--- a/ui/src/e2e/question-flow.e2e.test.ts
+++ b/ui/src/e2e/question-flow.e2e.test.ts
@@ -1,10 +1,13 @@
 // Control UI E2E tests cover composer-replacing Gateway questions through the mocked WebSocket.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
+import type { QuestionResolveResult } from "@openclaw/gateway-protocol";
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import type { SessionsListResult } from "../api/types.ts";
 import {
   canRunPlaywrightChromium,
+  controlUiSessionUrl,
   installMockGateway,
   resolvePlaywrightChromiumExecutablePath,
   startControlUiE2eServer,
@@ -18,6 +21,8 @@ const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM 
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "question-flow");
+const mainSessionKey = "agent:main:main";
+const questionSessionKey = "agent:main:question-proof";
 
 let browser: Browser;
 let context: BrowserContext | undefined;
@@ -39,7 +44,7 @@ function questionRecord(
     id,
     questions,
     agentId: "main",
-    sessionKey: "main",
+    sessionKey: questionSessionKey,
     createdAtMs,
     expiresAtMs: createdAtMs + 15 * 60_000,
     status: "pending" as const,
@@ -82,19 +87,69 @@ async function openQuestionPage() {
   });
   const page = await context.newPage();
   const gateway = await installMockGateway(page, {
+    featureMethods: [
+      "chat.abort",
+      "chat.metadata",
+      "chat.startup",
+      "question.get",
+      "question.list",
+      "question.resolve",
+      "sessions.create",
+      "sessions.patch",
+    ],
     historyMessages: historyMessages(),
     methodResponses: {
       "question.list": { questions: [] },
+      "sessions.list": {
+        ts: Date.now(),
+        path: "",
+        count: 2,
+        defaults: { modelProvider: "openai", model: "gpt-5.5", contextTokens: null },
+        sessions: [
+          {
+            key: mainSessionKey,
+            kind: "direct",
+            label: "Home",
+            updatedAt: Date.now() - 1_000,
+          },
+          {
+            key: questionSessionKey,
+            kind: "direct",
+            label: "Question proof",
+            updatedAt: Date.now(),
+          },
+        ],
+      } satisfies SessionsListResult,
     },
-    sessionKey: "main",
+    // The handshake must advertise the genuine canonical main; the question
+    // lives in its own existing thread so the real sidebar can render its row.
+    sessionKey: mainSessionKey,
   });
-  await page.goto(`${server.baseUrl}chat`);
-  await gateway.waitForRequest("question.list");
+  await page.goto(controlUiSessionUrl(server.baseUrl, questionSessionKey));
+  // Chat and sidebar each own a projection; both must bind to the advertised
+  // real client before a lost-broadcast test can prove cross-surface delivery.
+  await expect
+    .poll(async () => (await gateway.getRequests("question.list")).length)
+    .toBeGreaterThanOrEqual(2);
+  const startup = await gateway.waitForRequest("chat.startup");
+  expect(startup.params).toEqual(expect.objectContaining({ sessionKey: questionSessionKey }));
+  await page.locator(`[data-session-key="${questionSessionKey}"]`).first().waitFor();
   return { gateway, page };
 }
 
 function panelFor(page: Page, prompt: string) {
   return page.locator("openclaw-chat-question-panel").filter({ hasText: prompt });
+}
+
+async function expectQuestionAttention(page: Page, present: boolean): Promise<void> {
+  const session = page.locator(`[data-session-key="${questionSessionKey}"]`).first();
+  const expectedCount = present ? 1 : 0;
+  await expect
+    .poll(() => session.locator('[data-session-attention="question"]').count())
+    .toBe(expectedCount);
+  await expect
+    .poll(() => session.getByText("Waiting for your answer", { exact: true }).count())
+    .toBe(expectedCount);
 }
 
 async function emitRequested(
@@ -123,7 +178,7 @@ describeControlUiE2e("Control UI Gateway question flow", () => {
     await server?.close();
   });
 
-  it("replaces the composer, restores it on collapse, and preserves its draft through resolution", async () => {
+  it("restores the composer and its draft from an authoritative answer without a resolution event", async () => {
     const { gateway, page } = await openQuestionPage();
     const composer = page.locator(".agent-chat__composer-combobox textarea");
     await composer.fill("Keep this release note draft");
@@ -149,6 +204,7 @@ describeControlUiE2e("Control UI Gateway question flow", () => {
     await emitRequested(gateway, request);
     const panel = panelFor(page, "Where should I deploy?");
     await panel.waitFor();
+    await expectQuestionAttention(page, true);
     await expect
       .poll(() => page.locator(".chat-thread openclaw-chat-question-panel").count())
       .toBe(0);
@@ -204,28 +260,18 @@ describeControlUiE2e("Control UI Gateway question flow", () => {
       )
       .toBe(true);
 
+    const answers = { answers: { deploy_target: ["Staging (Recommended)"] } };
+    await gateway.setMethodResponse("question.resolve", {
+      status: "answered",
+      answers,
+    } satisfies QuestionResolveResult);
     await panel.getByRole("radio", { name: /Staging \(Recommended\)/ }).click();
     await panel.getByRole("button", { name: "Submit", exact: true }).click();
     const resolveRequest = await gateway.waitForRequest("question.resolve");
-    expect(resolveRequest.params).toEqual({
-      id: request.id,
-      answers: {
-        answers: {
-          deploy_target: ["Staging (Recommended)"],
-        },
-      },
-    });
+    expect(resolveRequest.params).toEqual({ id: request.id, answers });
 
-    await gateway.emitGatewayEvent("question.resolved", {
-      id: request.id,
-      status: "answered",
-      answers: {
-        answers: {
-          deploy_target: ["Staging (Recommended)"],
-        },
-      },
-    });
     await expect.poll(() => panel.count()).toBe(0);
+    await expectQuestionAttention(page, false);
     const summary = page.locator(".chat-question-summary").filter({ hasText: "Deploy:" });
     await summary.waitFor();
     await expect
@@ -269,17 +315,105 @@ describeControlUiE2e("Control UI Gateway question flow", () => {
       .toBe("true");
     await screenshot(page, "03-question-multiselect.png");
 
+    const answers = { answers: { release_checks: ["Tests", "Metrics"] } };
+    await gateway.setMethodResponse("question.resolve", {
+      status: "answered",
+      answers,
+    } satisfies QuestionResolveResult);
     await panel.getByRole("button", { name: "Submit", exact: true }).click();
     const resolveRequest = await gateway.waitForRequest("question.resolve");
-    expect(resolveRequest.params).toEqual({
-      id: request.id,
-      answers: {
-        answers: {
-          release_checks: ["Tests", "Metrics"],
-        },
-      },
-    });
+    expect(resolveRequest.params).toEqual({ id: request.id, answers });
+    await expect.poll(() => panel.count()).toBe(0);
   });
+
+  it("restores the composer from an authoritative cancellation without a resolution event", async () => {
+    const { gateway, page } = await openQuestionPage();
+    const request = questionRecord("question-skip-without-broadcast", [
+      {
+        questionId: "deploy_target",
+        header: "Deploy",
+        question: "Should I continue the deployment?",
+        options: [{ label: "Staging" }, { label: "Production" }],
+      },
+    ]);
+    await emitRequested(gateway, request);
+    const panel = panelFor(page, "Should I continue the deployment?");
+    await panel.waitFor();
+    await expectQuestionAttention(page, true);
+    await gateway.setMethodResponse("question.resolve", {
+      status: "cancelled",
+    } satisfies QuestionResolveResult);
+
+    await panel.getByRole("button", { name: "Skip", exact: true }).click();
+    const resolveRequest = await gateway.waitForRequest("question.resolve");
+    expect(resolveRequest.params).toEqual({ id: request.id, cancel: true });
+    await expect.poll(() => panel.count()).toBe(0);
+    await expectQuestionAttention(page, false);
+    await page.locator(".agent-chat__composer-combobox textarea").waitFor();
+    await expect
+      .poll(() => page.locator(".chat-question-summary").filter({ hasText: "Skipped" }).count())
+      .toBe(1);
+  });
+
+  it.each([
+    { action: "answer", status: "answered" as const },
+    { action: "cancellation", status: "cancelled" as const },
+  ])(
+    "updates both split panes and sidebar from an authoritative $action without a resolution event",
+    async ({ action, status }) => {
+      const { gateway, page } = await openQuestionPage();
+      await page.getByRole("button", { name: "Open split view" }).click();
+      const panes = page.locator("openclaw-chat-pane.chat-split-view__pane");
+      await expect.poll(() => panes.count()).toBe(2);
+      await expect
+        .poll(async () => (await gateway.getRequests("question.list")).length)
+        .toBeGreaterThanOrEqual(3);
+
+      const request = questionRecord(`question-split-${action}`, [
+        {
+          questionId: "deploy_target",
+          header: "Deploy",
+          question: "Where should both panes deploy?",
+          options: [{ label: "Staging" }, { label: "Production" }],
+        },
+      ]);
+      await emitRequested(gateway, request);
+      const panels = panelFor(page, "Where should both panes deploy?");
+      await expect.poll(() => panels.count()).toBe(2);
+      await expectQuestionAttention(page, true);
+
+      const answers = { answers: { deploy_target: ["Staging"] } };
+      const result: QuestionResolveResult =
+        status === "answered" ? { status, answers } : { status };
+      await gateway.setMethodResponse("question.resolve", result);
+      const submittingPanel = panels.first();
+      if (status === "answered") {
+        await submittingPanel.getByRole("radio", { name: /Staging/ }).click();
+      }
+      await submittingPanel
+        .getByRole("button", { name: status === "answered" ? "Submit" : "Skip", exact: true })
+        .click();
+      const resolveRequest = await gateway.waitForRequest("question.resolve");
+      expect(resolveRequest.params).toEqual(
+        status === "answered" ? { id: request.id, answers } : { id: request.id, cancel: true },
+      );
+      expect(await gateway.getRequests("question.resolve")).toHaveLength(1);
+
+      await expect.poll(() => panels.count()).toBe(0);
+      await expect
+        .poll(() => panes.locator(".agent-chat__composer-combobox textarea").count())
+        .toBe(2);
+      await expect
+        .poll(() =>
+          page
+            .locator(".chat-question-summary")
+            .filter({ hasText: status === "answered" ? "Staging" : "Skipped" })
+            .count(),
+        )
+        .toBe(2);
+      await expectQuestionAttention(page, false);
+    },
+  );
 
   it("restores the composer when reconnect recovery cannot find an old question", async () => {
     const { gateway, page } = await openQuestionPage();
@@ -294,20 +428,26 @@ describeControlUiE2e("Control UI Gateway question flow", () => {
     await emitRequested(gateway, request);
     const panel = panelFor(page, "Where should I deploy after reconnecting?");
     await panel.waitFor();
+    await expectQuestionAttention(page, true);
 
+    await gateway.deferNext("question.get");
     await gateway.deferNext("question.get");
     await gateway.closeLatest();
     const recovery = await gateway.waitForRequest("question.get");
     expect(recovery.params).toEqual({ id: request.id });
-    await gateway.rejectDeferred("question.get", {
+    await expect.poll(async () => (await gateway.getRequests("question.get")).length).toBe(2);
+    const notFound = {
       code: "INVALID_REQUEST",
       message: "question was not found",
       details: { reason: "QUESTION_NOT_FOUND" },
-    });
+    };
+    await gateway.rejectDeferred("question.get", notFound);
+    await gateway.rejectDeferred("question.get", notFound);
 
     await expect.poll(() => panel.count()).toBe(0);
+    await expectQuestionAttention(page, false);
     await page.locator(".agent-chat__composer-combobox textarea").waitFor();
-    expect(await gateway.getRequests("question.get")).toHaveLength(1);
+    expect(await gateway.getRequests("question.get")).toHaveLength(2);
   });
 
   it("shows a 1/2 stepper with answered and expired summaries", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users answering or cancelling a Control UI question could remain stuck with waiting indicators and disabled chat panes when the Gateway committed the response without a broadcast. Closing the submitting split pane while its request was in flight also discarded the authoritative result for every surviving pane and the sidebar.

## Why This Change Was Made

A single Gateway-client-keyed question lifecycle owner now fans authoritative responses out to every still-current projection. Recipient generation checks preserve account/socket isolation, while valid committed results survive disposal of only the submitting view; actual Gateway transport disconnection already rejects outstanding requests, so stale fabricated reconnect-success tests were replaced with the real dependency contract.

## User Impact

Answer and cancel actions now clear all split chat panes, re-enable the remaining composer, and remove the sidebar waiting indicator even if the original submitting pane closes before the RPC response. Existing reconnection, expiration, privacy/account isolation, hydration, and automatic recovery behavior remain intact; there are no Gateway protocol, authentication, or public API changes.

## Evidence

- Exact reviewed commit: `133257985327eade58ba20a0ef07fc4f11990eeb`; immutable comparison base: `3b6cad7e31e1c2ede4727ac9e27044d609e0c206`; exact five-file binary patch SHA-256: `388e8f90e8dfb978b2ce166e5971ea23f558a5ae56b51e451124092be809e55e`.
- Genuine tests-first reproductions failed for both delayed answer and delayed cancellation after disposing the submitting owner; all **71 focused canonical owner and sibling tests** subsequently passed.
- Production delta: **+133 lines**, justified by the previously missing shared Gateway-client lifecycle owner and generation-fenced fanout; regression and real-browser tests are counted separately (**+789 lines**). The owner replaces independent per-pane resolution decisions rather than introducing a second transport or compatibility path.
- Four wholly fresh independent reviewers audited real Gateway RPC/transport ordering, the browser fixture and surviving-pane identity, generation/privacy isolation, installed Vitest types, live sidebar ownership, and all touched code; no actionable findings remained.
- The first high-reasoning Sol autoreview raised two suspected issues that were conclusively disproved: the actual installed strict native TypeScript compiler accepted the exact callback expression, and existing source plus its direct regression already scheduled list-only hydration. A second genuinely fresh full-branch `gpt-5.6-sol` high-reasoning P3/no-web autoreview independently returned **clean, confidence 0.92**; checksum-verified TruffleHog was clean.
- Final exact-head Blacksmith Testbox `tbx_01kz49nw7ptgchqgqw69p9sffs` succeeded: **9/9 actual Chromium question-flow scenarios**, including delayed answer/cancellation after disposing the submitting split pane; **71/71 focused lifecycle tests**; and the complete exact-five-path changed gate, including strict native core/UI TypeScript, formatting, lint, duplicate/dependency guards, Control UI i18n, and dead-export checks. The authenticated remote patch remained `388e8f90e8dfb978b2ce166e5971ea23f558a5ae56b51e451124092be809e55e`; the lease was stopped after its successful timing JSON.
- **ClawSweeper merge-drift resolution:** the last independently inspected current-main snapshot changed none of the five reviewed files; the repository-native maintainer landing workflow will revalidate the exact reviewed head, current clean mergeability, and required green checks immediately before merge. Root repository policy treats moving-main drift as advisory rather than requiring repeated speculative rebases.
- **ClawSweeper exact-head gate resolution:** the only failed refreshed UI E2E case was an unchanged, separately introduced `config-safe-write.e2e.test.ts` timeout; the identical fourth shard passed on the exact same main base in job `92178886463`. Only the failed jobs were retried, and the repository-native landing workflow refuses to merge until the exact reviewed head is mergeable and every required check is green.
- **Protected maintainer decision:** the repository owner explicitly authorized autonomous maintainer review and landing; four fresh independent reviewers, a clean high-reasoning Sol review, exact-head Chromium proof, and the native guarded maintainer workflow supply the required human-delegated decision.
- **ClawSweeper rank-up resolution:** the native maintainer workflow revalidates the exact reviewed head, clean current mergeability, and all required hosted checks immediately before landing.
- **Stored-data classifier resolution:** the flagged path is a browser E2E test fixture, not vector storage or an embedding schema; all five changed files are Control UI code or tests, with no persistent data-model, protocol, configuration, or migration change.
- The earlier unrelated `brace-expansion` advisory has already been remediated on current main; this PR changes no dependencies and no failing security or CI gate will be bypassed.
- A separately pre-existing server-issued question-ID reuse/tombstone edge case was recorded as a named follow-up; it is not introduced by this owner refactor.
