### PR TITLE
feat(cli): add session archive and delete commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Session lifecycle CLI:** add Gateway-backed `openclaw sessions archive <key...>` and confirmed `sessions delete <key...>` commands with multi-key results, dry-run previews, stable JSON output, and exact Control UI transcript/worktree cleanup semantics. Closes #118333.
+
 - Fixed Crabbox hydration on unprivileged cloud sandboxes by falling back to a user-writable pnpm store when the shared `/var/cache/crabbox` cache is unavailable, preserving the hardlink import mode after hydration, and making Docker an explicit routed capability instead of an implicit install requirement.
 
 - **Browser extension relay CDP compat:** answer `Target.getBrowserContexts` so Puppeteer-based clients (chrome-devtools-mcp) can drive the paired Chrome without the remote-debugging permission prompt, serve DevTools-style `/json/list` target descriptors, and add `openclaw browser extension cdp` to print the relay endpoint plus auth header for external CDP clients.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **Session lifecycle CLI:** add Gateway-backed `openclaw sessions archive <key...>` and confirmed `sessions delete <key...>` commands with multi-key results, dry-run previews, stable JSON output, and exact Control UI transcript/worktree cleanup semantics. Closes #118333.
-
 - Fixed Crabbox hydration on unprivileged cloud sandboxes by falling back to a user-writable pnpm store when the shared `/var/cache/crabbox` cache is unavailable, preserving the hardlink import mode after hydration, and making Docker an explicit routed capability instead of an implicit install requirement.
 
 - **Browser extension relay CDP compat:** answer `Target.getBrowserContexts` so Puppeteer-based clients (chrome-devtools-mcp) can drive the paired Chrome without the remote-debugging permission prompt, serve DevTools-style `/json/list` target descriptors, and add `openclaw browser extension cdp` to print the relay endpoint plus auth header for external CDP clients.

--- a/docs/cli/sessions.md
+++ b/docs/cli/sessions.md
@@ -1,7 +1,8 @@
 ---
-summary: "CLI reference for `openclaw sessions` (list stored sessions + usage)"
+summary: "CLI reference for listing, archiving, deleting, and maintaining stored sessions"
 read_when:
   - You want to list stored sessions and see recent activity
+  - You want to archive or delete sessions from a headless Gateway
 title: "Sessions"
 ---
 
@@ -74,6 +75,81 @@ skipped.
   "sessions": [
     { "agentId": "main", "key": "agent:main:main", "model": "openai/gpt-5.6-sol" },
     { "agentId": "work", "key": "agent:work:main", "model": "anthropic/claude-sonnet-4-6" }
+  ]
+}
+```
+
+## Archive sessions
+
+Archive one or more sessions through the running Gateway:
+
+```bash
+openclaw sessions archive "agent:main:scratch-1"
+openclaw sessions archive "agent:main:scratch-1" "agent:main:scratch-2"
+openclaw sessions archive "agent:work:scratch-1" --agent work
+openclaw sessions archive "agent:main:scratch-1" --dry-run
+openclaw sessions archive "agent:main:scratch-1" --json
+```
+
+Archive uses the same `sessions.patch` lifecycle operation as the Control UI.
+It keeps the transcript, marks the session archived, and removes the session
+from the default active list. Already archived sessions are successful no-ops.
+Use `--dry-run` to validate every key and preview the result without changing
+session state.
+
+## Delete sessions
+
+Delete one or more sessions through the running Gateway:
+
+```bash
+openclaw sessions delete "agent:main:scratch-1"
+openclaw sessions delete "agent:main:scratch-1" "agent:main:scratch-2" --yes
+openclaw sessions delete "agent:work:scratch-1" --agent work --yes
+openclaw sessions delete "agent:main:scratch-1" --dry-run
+openclaw sessions delete "agent:main:scratch-1" --yes --json
+```
+
+<Warning>
+  Delete is destructive. In an interactive terminal it asks once before
+  deleting the valid keys. Non-interactive and `--json` deletion requires
+  `--yes`. Use `--dry-run` first when scripting a bulk cleanup.
+</Warning>
+
+Delete uses the same `sessions.delete` lifecycle operation as the Control UI,
+with transcript cleanup enabled. The Gateway removes the live session row,
+transcript generations, session-owned runtime state, bindings, boards, and
+other lifecycle artifacts. For ordinary sessions it retains the transcript as
+a verified `.jsonl.deleted.<timestamp>` archive; incognito transcripts are
+removed without an archive. If a managed worktree cannot be removed safely,
+the command reports the preserved branch and path for manual cleanup.
+
+Both lifecycle commands:
+
+- accept multiple keys and report one ordered result per key;
+- use `--agent <id>` to select the owning agent, which is required for a
+  `global` key outside the default agent;
+- support `--url`, `--token`, `--password`, and `--timeout <ms>` Gateway
+  connection overrides;
+- return a non-zero exit when any key is unknown or any operation fails, while
+  still processing the other valid keys;
+- emit one stable JSON envelope with `ok`, `operation`, `dryRun`, and `results`
+  when `--json` is set.
+
+Example mixed-result JSON:
+
+```json
+{
+  "ok": false,
+  "operation": "archive",
+  "dryRun": false,
+  "results": [
+    { "key": "agent:main:scratch-1", "ok": true, "status": "archived" },
+    {
+      "key": "agent:main:missing",
+      "ok": false,
+      "status": "not_found",
+      "error": "Session not found. Run openclaw sessions list --json to choose a valid key."
+    }
   ]
 }
 ```

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ overrides:
   request: npm:@cypress/request@4.0.1
   request-promise: npm:@cypress/request-promise@5.0.0
   basic-ftp: 6.0.2
-  brace-expansion: 5.0.8
+  brace-expansion: 5.0.9
   file-type: 22.0.1
   form-data: 4.0.6
   werift-ice@0.2.2>ip: npm:neoip@3.1.0
@@ -5994,8 +5994,8 @@ packages:
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -13138,7 +13138,7 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -15210,7 +15210,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,7 +20,7 @@ minimumReleaseAgeExclude:
   - "axios"
   - "basic-ftp"
   - "baileys@7.0.0-rc13"
-  - "brace-expansion@5.0.8"
+  - "brace-expansion@5.0.9"
   - "hono"
   - "libopus-wasm@0.2.0"
   - "libsignal@6.0.0"
@@ -134,7 +134,7 @@ overrides:
   request: "npm:@cypress/request@4.0.1"
   request-promise: "npm:@cypress/request-promise@5.0.0"
   basic-ftp: 6.0.2
-  brace-expansion: 5.0.8
+  brace-expansion: 5.0.9
   file-type: 22.0.1
   form-data: 4.0.6
   "werift-ice@0.2.2>ip": "npm:neoip@3.1.0"

--- a/src/cli/program/register.status-health-sessions.test.ts
+++ b/src/cli/program/register.status-health-sessions.test.ts
@@ -10,6 +10,8 @@ const mocks = vi.hoisted(() => ({
   sessionsCleanupCommand: vi.fn(),
   sessionsTailCommand: vi.fn(),
   sessionsCompactCommand: vi.fn(),
+  sessionsArchiveCommand: vi.fn(),
+  sessionsDeleteCommand: vi.fn(),
   exportTrajectoryCommand: vi.fn(),
   commitmentsListCommand: vi.fn(),
   commitmentsDismissCommand: vi.fn(),
@@ -36,6 +38,8 @@ const sessionsCommand = mocks.sessionsCommand;
 const sessionsCleanupCommand = mocks.sessionsCleanupCommand;
 const sessionsTailCommand = mocks.sessionsTailCommand;
 const sessionsCompactCommand = mocks.sessionsCompactCommand;
+const sessionsArchiveCommand = mocks.sessionsArchiveCommand;
+const sessionsDeleteCommand = mocks.sessionsDeleteCommand;
 const exportTrajectoryCommand = mocks.exportTrajectoryCommand;
 const commitmentsListCommand = mocks.commitmentsListCommand;
 const commitmentsDismissCommand = mocks.commitmentsDismissCommand;
@@ -101,6 +105,11 @@ vi.mock("../../commands/sessions-compact.js", () => ({
   sessionsCompactCommand: mocks.sessionsCompactCommand,
 }));
 
+vi.mock("../../commands/sessions-lifecycle.js", () => ({
+  sessionsArchiveCommand: mocks.sessionsArchiveCommand,
+  sessionsDeleteCommand: mocks.sessionsDeleteCommand,
+}));
+
 vi.mock("../../commands/export-trajectory.js", () => ({
   exportTrajectoryCommand: mocks.exportTrajectoryCommand,
 }));
@@ -149,6 +158,8 @@ describe("registerStatusHealthSessionsCommands", () => {
     sessionsCleanupCommand.mockResolvedValue(undefined);
     sessionsTailCommand.mockResolvedValue(undefined);
     sessionsCompactCommand.mockResolvedValue(undefined);
+    sessionsArchiveCommand.mockResolvedValue(undefined);
+    sessionsDeleteCommand.mockResolvedValue(undefined);
     exportTrajectoryCommand.mockResolvedValue(undefined);
     commitmentsListCommand.mockResolvedValue(undefined);
     commitmentsDismissCommand.mockResolvedValue(undefined);
@@ -346,6 +357,87 @@ describe("registerStatusHealthSessionsCommands", () => {
     expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("--verbose"));
     expect(runtime.exit).toHaveBeenCalledWith(1);
     expect(sessionsCompactCommand).not.toHaveBeenCalled();
+  });
+
+  it("forwards multi-key archive options and inherits parent sessions output options", async () => {
+    await runCli([
+      "sessions",
+      "--agent",
+      "work",
+      "--json",
+      "archive",
+      "agent:work:scratch-1",
+      "agent:work:scratch-2",
+      "--dry-run",
+      "--url",
+      "ws://gateway.test",
+      "--token",
+      "test-token",
+      "--password",
+      "test-password",
+      "--timeout",
+      "45000",
+    ]);
+
+    expectCommandOptions(sessionsArchiveCommand, {
+      keys: ["agent:work:scratch-1", "agent:work:scratch-2"],
+      agent: "work",
+      dryRun: true,
+      url: "ws://gateway.test",
+      token: "test-token",
+      password: "test-password",
+      timeout: "45000",
+      json: true,
+    });
+  });
+
+  it("forwards multi-key delete options and prefers the subcommand agent", async () => {
+    await runCli([
+      "sessions",
+      "--agent",
+      "main",
+      "delete",
+      "agent:work:scratch-1",
+      "agent:work:scratch-2",
+      "--agent",
+      "work",
+      "--yes",
+      "--json",
+    ]);
+
+    expectCommandOptions(sessionsDeleteCommand, {
+      keys: ["agent:work:scratch-1", "agent:work:scratch-2"],
+      agent: "work",
+      dryRun: false,
+      yes: true,
+      json: true,
+    });
+  });
+
+  it("rejects inherited session-list filters for lifecycle mutations", async () => {
+    await runCli([
+      "sessions",
+      "--store",
+      "/tmp/other-sessions.json",
+      "--all-agents",
+      "archive",
+      "agent:main:scratch-1",
+    ]);
+
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("--store"));
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("--all-agents"));
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(sessionsArchiveCommand).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid lifecycle RPC timeouts", async () => {
+    await runCli(["sessions", "delete", "agent:main:scratch-1", "--timeout", "0", "--yes"]);
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      "--timeout must be a positive integer (milliseconds).",
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(sessionsDeleteCommand).not.toHaveBeenCalled();
   });
 
   it("forwards sessions list-side options", async () => {

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -75,6 +75,16 @@ function addSessionsListOptions(command: Command): Command {
     .option("--limit <count>", 'Max sessions to show (default: 100; use "all" for full output)');
 }
 
+function addSessionsGatewayOptions(command: Command): Command {
+  return command
+    .option("--agent <id>", "Agent id that owns the session (required for global keys)")
+    .option("--url <url>", "Gateway WebSocket URL (defaults to gateway.remote.url when configured)")
+    .option("--token <token>", "Gateway token (if required)")
+    .option("--password <password>", "Gateway password (password auth)")
+    .option("--timeout <ms>", "RPC timeout in milliseconds")
+    .option("--json", "Output JSON", false);
+}
+
 function mergeSessionsListOptions(
   opts: SessionsListCliOptions,
   parentOpts?: SessionsListCliOptions,
@@ -104,6 +114,98 @@ async function runSessionsListCli(opts: SessionsListCliOptions): Promise<void> {
     },
     defaultRuntime,
   );
+}
+
+function registerSessionsLifecycleCommand(
+  sessionsCmd: Command,
+  operation: "archive" | "delete",
+): void {
+  const destructive = operation === "delete";
+  const examples: Array<[string, string]> = destructive
+    ? [
+        ['openclaw sessions delete "agent:main:scratch-1"', "Delete with confirmation."],
+        [
+          'openclaw sessions delete "agent:main:scratch-1" "agent:main:scratch-2" --yes',
+          "Delete several sessions non-interactively.",
+        ],
+        [
+          'openclaw sessions delete "agent:work:scratch-1" --agent work --dry-run',
+          "Preview an agent-scoped delete.",
+        ],
+      ]
+    : [
+        ['openclaw sessions archive "agent:main:scratch-1"', "Archive one session."],
+        [
+          'openclaw sessions archive "agent:main:scratch-1" "agent:main:scratch-2"',
+          "Archive several sessions.",
+        ],
+        [
+          'openclaw sessions archive "agent:work:scratch-1" --agent work --dry-run',
+          "Preview an agent-scoped archive.",
+        ],
+      ];
+  const command = sessionsCmd
+    .command(`${operation} <keys...>`)
+    .description(
+      destructive
+        ? "Delete stored sessions and their live artifacts via the running gateway"
+        : "Archive stored sessions via the running gateway",
+    )
+    .option(`--dry-run`, `Preview ${operation} actions without writing`, false);
+  if (destructive) {
+    command.option("--yes", "Skip the destructive confirmation prompt", false);
+  }
+  addSessionsGatewayOptions(command)
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.heading("Examples:")}\n${formatHelpExamples(examples)}${
+          destructive
+            ? `\n\n${theme.muted(
+                "Deletion uses the Control UI lifecycle operation, including transcript archival and runtime cleanup.",
+              )}`
+            : ""
+        }`,
+    )
+    .action(async (keys: string[], opts, actionCommand) => {
+      const parentOpts = actionCommand.parent?.opts() as SessionsListCliOptions | undefined;
+      if (
+        rejectUnsupportedSessionsParentOptions(
+          operation,
+          parentOpts,
+          ["store", "allAgents", "active", "limit", "verbose"],
+          "the gateway resolves target stores from each key and --agent",
+        )
+      ) {
+        return;
+      }
+      const timeoutMs = parseStrictPositiveIntOrUndefined(opts.timeout);
+      if (opts.timeout !== undefined && timeoutMs === undefined) {
+        defaultRuntime.error("--timeout must be a positive integer (milliseconds).");
+        defaultRuntime.exit(1);
+        return;
+      }
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        const lifecycleCommands = await import("../../commands/sessions-lifecycle.js");
+        const handler = destructive
+          ? lifecycleCommands.sessionsDeleteCommand
+          : lifecycleCommands.sessionsArchiveCommand;
+        await handler(
+          {
+            keys,
+            agent: (opts.agent as string | undefined) ?? parentOpts?.agent,
+            dryRun: Boolean(opts.dryRun),
+            ...(destructive ? { yes: Boolean(opts.yes) } : {}),
+            timeout: timeoutMs !== undefined ? String(timeoutMs) : undefined,
+            url: opts.url as string | undefined,
+            token: opts.token as string | undefined,
+            password: opts.password as string | undefined,
+            json: Boolean(opts.json || parentOpts?.json),
+          },
+          defaultRuntime,
+        );
+      });
+    });
 }
 
 function parseTimeoutMs(timeout: unknown): number | null | undefined {
@@ -400,19 +502,15 @@ export function registerStatusHealthSessionsCommands(program: Command) {
       });
     });
 
-  sessionsCmd
-    .command("compact <key>")
+  registerSessionsLifecycleCommand(sessionsCmd, "archive");
+  registerSessionsLifecycleCommand(sessionsCmd, "delete");
+
+  addSessionsGatewayOptions(sessionsCmd.command("compact <key>"))
     .description("Compact a stored session transcript via the running gateway")
-    .option("--agent <id>", "Agent id that owns the session (required for global keys)")
     .option(
       "--max-lines <count>",
       "Truncate to the last N transcript lines instead of LLM summarization",
     )
-    .option("--url <url>", "Gateway WebSocket URL (defaults to gateway.remote.url when configured)")
-    .option("--token <token>", "Gateway token (if required)")
-    .option("--password <password>", "Gateway password (password auth)")
-    .option("--timeout <ms>", "RPC timeout in milliseconds (defaults to no client deadline)")
-    .option("--json", "Output JSON", false)
     .addHelpText(
       "after",
       () =>

--- a/src/commands/sessions-lifecycle.test.ts
+++ b/src/commands/sessions-lifecycle.test.ts
@@ -1,0 +1,365 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { sessionsArchiveCommand, sessionsDeleteCommand } from "./sessions-lifecycle.js";
+
+const mocks = vi.hoisted(() => ({
+  callGateway: vi.fn(),
+  confirm: vi.fn(),
+}));
+
+vi.mock("../cli/gateway-rpc.js", () => ({
+  callGatewayFromCliWithTransport: mocks.callGateway,
+}));
+
+vi.mock("../wizard/clack-prompter.js", () => ({
+  createClackPrompter: () => ({ confirm: mocks.confirm }),
+}));
+
+function createRuntime() {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+    writeStdout: vi.fn(),
+    writeJson: vi.fn(),
+  };
+}
+
+function listResult(
+  sessions: Array<{ key: string; sessionId?: string; archived?: boolean }>,
+  pagination: { hasMore?: boolean; nextOffset?: number | null } = {},
+) {
+  return { sessions, hasMore: false, nextOffset: null, ...pagination };
+}
+
+describe("sessions lifecycle commands", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.confirm.mockResolvedValue(true);
+  });
+
+  it("archives through sessions.patch and emits the stable JSON envelope", async () => {
+    mocks.callGateway
+      .mockResolvedValueOnce(listResult([{ key: "agent:work:scratch-1", sessionId: "session-1" }]))
+      .mockResolvedValueOnce({
+        ok: true,
+        key: "agent:work:scratch-1",
+        entry: { archivedAt: 123 },
+      });
+    const runtime = createRuntime();
+
+    await sessionsArchiveCommand(
+      {
+        keys: ["agent:work:scratch-1"],
+        agent: "work",
+        url: "ws://gateway.test",
+        token: "test-token",
+        password: "test-password",
+        timeout: "45000",
+        json: true,
+      },
+      runtime,
+    );
+
+    expect(mocks.callGateway).toHaveBeenNthCalledWith(
+      1,
+      "sessions.list",
+      {
+        url: "ws://gateway.test",
+        token: "test-token",
+        password: "test-password",
+        timeout: "45000",
+        json: true,
+      },
+      {
+        limit: 200,
+        archived: "all",
+        includeGlobal: true,
+        includeUnknown: true,
+        configuredAgentsOnly: true,
+        agentId: "work",
+      },
+      { defaultTimeoutMs: 30_000 },
+    );
+    expect(mocks.callGateway).toHaveBeenNthCalledWith(
+      2,
+      "sessions.patch",
+      expect.any(Object),
+      {
+        key: "agent:work:scratch-1",
+        agentId: "work",
+        expectedSessionId: "session-1",
+        archived: true,
+      },
+      { defaultTimeoutMs: 30_000 },
+    );
+    expect(runtime.writeJson).toHaveBeenCalledWith(
+      {
+        ok: true,
+        operation: "archive",
+        dryRun: false,
+        results: [{ key: "agent:work:scratch-1", ok: true, status: "archived" }],
+      },
+      2,
+    );
+    expect(runtime.exit).not.toHaveBeenCalled();
+  });
+
+  it("uses sessions.list archived state for a mutation-free archive dry run", async () => {
+    mocks.callGateway.mockResolvedValueOnce(
+      listResult([
+        { key: "agent:main:active", sessionId: "active-session" },
+        { key: "agent:main:archived", sessionId: "archived-session", archived: true },
+      ]),
+    );
+    const runtime = createRuntime();
+
+    await sessionsArchiveCommand(
+      {
+        keys: ["agent:main:active", "agent:main:archived"],
+        dryRun: true,
+        json: true,
+      },
+      runtime,
+    );
+
+    expect(mocks.callGateway).toHaveBeenCalledTimes(1);
+    expect(runtime.writeJson).toHaveBeenCalledWith(
+      {
+        ok: true,
+        operation: "archive",
+        dryRun: true,
+        results: [
+          { key: "agent:main:active", ok: true, status: "would_archive" },
+          { key: "agent:main:archived", ok: true, status: "already_archived" },
+        ],
+      },
+      2,
+    );
+  });
+
+  it("deletes archived sessions with the same gated artifact contract as Control UI", async () => {
+    mocks.callGateway
+      .mockResolvedValueOnce(
+        listResult([{ key: "agent:main:archived", sessionId: "session-1", archived: true }]),
+      )
+      .mockResolvedValueOnce({
+        ok: true,
+        key: "agent:main:archived",
+        deleted: true,
+        archived: ["/state/session-1.jsonl.deleted.123"],
+        worktreePreserved: { id: "wt-1", branch: "scratch", path: "/worktree" },
+      });
+    const runtime = createRuntime();
+
+    await sessionsDeleteCommand({ keys: ["agent:main:archived"], yes: true, json: true }, runtime);
+
+    expect(mocks.callGateway).toHaveBeenNthCalledWith(
+      2,
+      "sessions.delete",
+      expect.any(Object),
+      {
+        key: "agent:main:archived",
+        expectedSessionId: "session-1",
+        deleteTranscript: true,
+        archivedOnly: true,
+      },
+      { defaultTimeoutMs: 30_000 },
+    );
+    expect(runtime.writeJson).toHaveBeenCalledWith(
+      {
+        ok: true,
+        operation: "delete",
+        dryRun: false,
+        results: [
+          {
+            key: "agent:main:archived",
+            ok: true,
+            status: "deleted",
+            archived: ["/state/session-1.jsonl.deleted.123"],
+            worktreePreserved: { id: "wt-1", branch: "scratch", path: "/worktree" },
+          },
+        ],
+      },
+      2,
+    );
+  });
+
+  it("deletes active sessions without the archive-only scope restriction", async () => {
+    mocks.callGateway
+      .mockResolvedValueOnce(listResult([{ key: "agent:main:active", sessionId: "session-1" }]))
+      .mockResolvedValueOnce({
+        ok: true,
+        key: "agent:main:active",
+        deleted: true,
+        archived: [],
+      });
+    const runtime = createRuntime();
+
+    await sessionsDeleteCommand({ keys: ["agent:main:active"], yes: true }, runtime);
+
+    const deleteParams = mocks.callGateway.mock.calls[1]?.[2];
+    expect(deleteParams).toEqual({
+      key: "agent:main:active",
+      expectedSessionId: "session-1",
+      deleteTranscript: true,
+    });
+    expect(deleteParams).not.toHaveProperty("archivedOnly");
+  });
+
+  it("keeps delete dry runs read-only and does not require --yes", async () => {
+    mocks.callGateway.mockResolvedValueOnce(
+      listResult([{ key: "agent:main:active", sessionId: "session-1" }]),
+    );
+    const runtime = createRuntime();
+
+    await sessionsDeleteCommand({ keys: ["agent:main:active"], dryRun: true, json: true }, runtime);
+
+    expect(mocks.callGateway).toHaveBeenCalledTimes(1);
+    expect(mocks.confirm).not.toHaveBeenCalled();
+    expect(runtime.writeJson).toHaveBeenCalledWith(
+      {
+        ok: true,
+        operation: "delete",
+        dryRun: true,
+        results: [{ key: "agent:main:active", ok: true, status: "would_delete" }],
+      },
+      2,
+    );
+  });
+
+  it("refuses non-interactive deletion without --yes", async () => {
+    mocks.callGateway.mockResolvedValueOnce(
+      listResult([{ key: "agent:main:active", sessionId: "session-1" }]),
+    );
+    const runtime = createRuntime();
+    const originalIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: false });
+    try {
+      await sessionsDeleteCommand({ keys: ["agent:main:active"] }, runtime);
+    } finally {
+      Object.defineProperty(process.stdin, "isTTY", {
+        configurable: true,
+        value: originalIsTTY,
+      });
+    }
+
+    expect(mocks.callGateway).toHaveBeenCalledTimes(1);
+    expect(mocks.callGateway.mock.calls[0]?.[0]).toBe("sessions.list");
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("Pass --yes to delete non-interactively"),
+    );
+    expect(runtime.writeJson).not.toHaveBeenCalled();
+  });
+
+  it("reports mixed valid and invalid keys in order and exits non-zero after continuing", async () => {
+    mocks.callGateway
+      .mockResolvedValueOnce(
+        listResult([
+          { key: "agent:main:first", sessionId: "session-1" },
+          { key: "agent:main:last", sessionId: "session-2" },
+        ]),
+      )
+      .mockResolvedValueOnce({
+        ok: true,
+        key: "agent:main:first",
+        deleted: true,
+        archived: ["/state/session-1.jsonl.deleted.123"],
+      })
+      .mockRejectedValueOnce(new Error("session is still active"));
+    const runtime = createRuntime();
+
+    await sessionsDeleteCommand(
+      {
+        keys: ["agent:main:first", "agent:main:missing", "agent:main:last"],
+        yes: true,
+        json: true,
+      },
+      runtime,
+    );
+
+    expect(mocks.callGateway).toHaveBeenCalledTimes(3);
+    expect(runtime.writeJson).toHaveBeenCalledWith(
+      {
+        ok: false,
+        operation: "delete",
+        dryRun: false,
+        results: [
+          {
+            key: "agent:main:first",
+            ok: true,
+            status: "deleted",
+            archived: ["/state/session-1.jsonl.deleted.123"],
+          },
+          {
+            key: "agent:main:missing",
+            ok: false,
+            status: "not_found",
+            error: expect.stringContaining("openclaw sessions list --json"),
+          },
+          {
+            key: "agent:main:last",
+            ok: false,
+            status: "failed",
+            error: "session is still active",
+          },
+        ],
+      },
+      2,
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("treats a delete race that reports deleted:false as not found", async () => {
+    mocks.callGateway
+      .mockResolvedValueOnce(listResult([{ key: "agent:main:vanished", sessionId: "session-1" }]))
+      .mockResolvedValueOnce({ ok: true, key: "agent:main:vanished", deleted: false });
+    const runtime = createRuntime();
+
+    await sessionsDeleteCommand({ keys: ["agent:main:vanished"], yes: true, json: true }, runtime);
+
+    expect(runtime.writeJson).toHaveBeenCalledWith(
+      {
+        ok: false,
+        operation: "delete",
+        dryRun: false,
+        results: [
+          {
+            key: "agent:main:vanished",
+            ok: false,
+            status: "not_found",
+            error: expect.stringContaining("choose a valid key"),
+          },
+        ],
+      },
+      2,
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("paginates the UI list surface before declaring a key unknown", async () => {
+    mocks.callGateway
+      .mockResolvedValueOnce(listResult([], { hasMore: true, nextOffset: 200 }))
+      .mockResolvedValueOnce(listResult([{ key: "agent:main:later", sessionId: "session-2" }]));
+    const runtime = createRuntime();
+
+    await sessionsArchiveCommand({ keys: ["agent:main:later"], dryRun: true, json: true }, runtime);
+
+    expect(mocks.callGateway).toHaveBeenNthCalledWith(
+      2,
+      "sessions.list",
+      expect.any(Object),
+      expect.objectContaining({ offset: 200 }),
+      { defaultTimeoutMs: 30_000 },
+    );
+    expect(runtime.writeJson).toHaveBeenCalledWith(
+      {
+        ok: true,
+        operation: "archive",
+        dryRun: true,
+        results: [{ key: "agent:main:later", ok: true, status: "would_archive" }],
+      },
+      2,
+    );
+  });
+});

--- a/src/commands/sessions-lifecycle.ts
+++ b/src/commands/sessions-lifecycle.ts
@@ -1,0 +1,333 @@
+/** Gateway-backed archive and delete commands for stored sessions. */
+import { formatCliCommand } from "../cli/command-format.js";
+import { callGatewayFromCliWithTransport } from "../cli/gateway-rpc.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
+import { createClackPrompter } from "../wizard/clack-prompter.js";
+
+type SessionsLifecycleCliOptions = {
+  keys: string[];
+  agent?: string;
+  dryRun?: boolean;
+  yes?: boolean;
+  timeout?: string;
+  url?: string;
+  token?: string;
+  password?: string;
+  json?: boolean;
+};
+
+type SessionsLifecycleOperation = "archive" | "delete";
+
+type SessionsLifecycleStatus =
+  | "archived"
+  | "already_archived"
+  | "deleted"
+  | "would_archive"
+  | "would_delete"
+  | "not_found"
+  | "failed";
+
+type SessionsLifecycleResult = {
+  key: string;
+  ok: boolean;
+  status: SessionsLifecycleStatus;
+  error?: string;
+  archived?: string[];
+  worktreePreserved?: { id: string; branch: string; path: string };
+};
+
+type SessionsListRow = {
+  key: string;
+  sessionId?: string;
+  archived?: boolean;
+};
+
+type SessionsListResult = {
+  sessions?: SessionsListRow[];
+  hasMore?: boolean;
+  nextOffset?: number | null;
+};
+
+type SessionsPatchResult = {
+  ok?: boolean;
+  key?: string;
+  entry?: { archivedAt?: number };
+};
+
+type SessionsDeleteResult = {
+  ok?: boolean;
+  key?: string;
+  deleted?: boolean;
+  archived?: string[];
+  worktreePreserved?: { id: string; branch: string; path: string };
+};
+
+type SessionsLifecycleRpcOptions = Parameters<typeof callGatewayFromCliWithTransport>[1];
+
+// Keep each read bounded while exhausting pagination when an invalid key must
+// be distinguished from a session outside the first Gateway list page.
+const SESSION_TARGET_PAGE_SIZE = 200;
+
+function listHint(agent?: string): string {
+  const agentFlag = agent ? ` --agent ${agent}` : "";
+  return formatCliCommand(`openclaw sessions list${agentFlag} --json`);
+}
+
+function notFoundResult(key: string, agent?: string): SessionsLifecycleResult {
+  return {
+    key,
+    ok: false,
+    status: "not_found",
+    error: `Session not found. Run ${listHint(agent)} to choose a valid key.`,
+  };
+}
+
+async function listRequestedSessions(
+  keys: readonly string[],
+  agent: string | undefined,
+  rpcOptions: SessionsLifecycleRpcOptions,
+): Promise<Map<string, SessionsListRow>> {
+  const wanted = new Set(keys);
+  const found = new Map<string, SessionsListRow>();
+  let offset = 0;
+
+  while (wanted.size > found.size) {
+    const page = (await callGatewayFromCliWithTransport(
+      "sessions.list",
+      rpcOptions,
+      {
+        limit: SESSION_TARGET_PAGE_SIZE,
+        ...(offset > 0 ? { offset } : {}),
+        archived: "all",
+        includeGlobal: true,
+        includeUnknown: true,
+        configuredAgentsOnly: true,
+        ...(agent ? { agentId: agent } : {}),
+      },
+      { defaultTimeoutMs: 30_000 },
+    )) as SessionsListResult;
+    if (!page || !Array.isArray(page.sessions)) {
+      throw new Error("Gateway returned an invalid sessions.list response.");
+    }
+    for (const row of page.sessions) {
+      if (wanted.has(row.key) && !found.has(row.key)) {
+        found.set(row.key, row);
+      }
+    }
+    if (found.size === wanted.size || page.hasMore !== true) {
+      break;
+    }
+    const nextOffset = page.nextOffset;
+    if (typeof nextOffset !== "number" || nextOffset <= offset) {
+      throw new Error("Gateway returned invalid sessions.list pagination.");
+    }
+    offset = nextOffset;
+  }
+
+  return found;
+}
+
+function outputLifecycleResults(
+  operation: SessionsLifecycleOperation,
+  dryRun: boolean,
+  results: SessionsLifecycleResult[],
+  runtime: RuntimeEnv,
+  json: boolean,
+): void {
+  const ok = results.every((result) => result.ok);
+  if (json) {
+    writeRuntimeJson(runtime, { ok, operation, dryRun, results });
+  } else {
+    for (const result of results) {
+      switch (result.status) {
+        case "archived":
+          runtime.log(`Archived session ${result.key}.`);
+          break;
+        case "already_archived":
+          runtime.log(`Session ${result.key} is already archived.`);
+          break;
+        case "deleted":
+          runtime.log(`Deleted session ${result.key}.`);
+          for (const archived of result.archived ?? []) {
+            runtime.log(`Archived transcript: ${archived}`);
+          }
+          if (result.worktreePreserved) {
+            runtime.error(
+              `Preserved worktree ${result.worktreePreserved.branch} at ${result.worktreePreserved.path}; remove it manually after preserving any changes.`,
+            );
+          }
+          break;
+        case "would_archive":
+          runtime.log(`[dry-run] archive session ${result.key}`);
+          break;
+        case "would_delete":
+          runtime.log(`[dry-run] delete session ${result.key} and its live transcript state`);
+          break;
+        case "not_found":
+        case "failed":
+          runtime.error(`${operation} ${result.key}: ${result.error ?? "Unknown failure."}`);
+          break;
+      }
+    }
+  }
+  if (!ok) {
+    runtime.exit(1);
+  }
+}
+
+async function runSessionsLifecycleCommand(
+  operation: SessionsLifecycleOperation,
+  opts: SessionsLifecycleCliOptions,
+  runtime: RuntimeEnv,
+): Promise<void> {
+  const keys = opts.keys.map((key) => key.trim());
+  const rpcOptions: SessionsLifecycleRpcOptions = {
+    url: opts.url,
+    token: opts.token,
+    password: opts.password,
+    timeout: opts.timeout,
+    json: opts.json,
+  };
+  let sessions: Map<string, SessionsListRow>;
+  try {
+    sessions = await listRequestedSessions(keys.filter(Boolean), opts.agent, rpcOptions);
+  } catch (error) {
+    const message = formatErrorMessage(error);
+    outputLifecycleResults(
+      operation,
+      Boolean(opts.dryRun),
+      keys.map((key) => ({ key, ok: false, status: "failed", error: message })),
+      runtime,
+      Boolean(opts.json),
+    );
+    return;
+  }
+
+  const results = keys.map((key): SessionsLifecycleResult | undefined =>
+    key && sessions.has(key) ? undefined : notFoundResult(key, opts.agent),
+  );
+  const validTargets = keys.flatMap((key, index) => {
+    const session = sessions.get(key);
+    return session ? [{ index, session }] : [];
+  });
+
+  if (operation === "delete" && !opts.dryRun && !opts.yes && validTargets.length > 0) {
+    if (opts.json || !process.stdin.isTTY) {
+      const error = "Deletion requires confirmation. Pass --yes to delete non-interactively.";
+      for (const { index, session } of validTargets) {
+        results[index] = { key: session.key, ok: false, status: "failed", error };
+      }
+      outputLifecycleResults(
+        operation,
+        false,
+        results.filter((result) => result !== undefined),
+        runtime,
+        Boolean(opts.json),
+      );
+      return;
+    }
+    const confirmed = await createClackPrompter().confirm({
+      message: `Delete ${validTargets.length} session${validTargets.length === 1 ? "" : "s"} and remove live transcript state?`,
+      initialValue: false,
+    });
+    if (!confirmed) {
+      runtime.log("Cancelled.");
+      return;
+    }
+  }
+
+  for (const { index, session } of validTargets) {
+    if (opts.dryRun) {
+      results[index] = {
+        key: session.key,
+        ok: true,
+        status:
+          operation === "archive"
+            ? session.archived === true
+              ? "already_archived"
+              : "would_archive"
+            : "would_delete",
+      };
+      continue;
+    }
+    if (operation === "archive" && session.archived === true) {
+      results[index] = { key: session.key, ok: true, status: "already_archived" };
+      continue;
+    }
+    try {
+      if (operation === "archive") {
+        const response = (await callGatewayFromCliWithTransport(
+          "sessions.patch",
+          rpcOptions,
+          {
+            key: session.key,
+            ...(opts.agent ? { agentId: opts.agent } : {}),
+            ...(session.sessionId ? { expectedSessionId: session.sessionId } : {}),
+            archived: true,
+          },
+          { defaultTimeoutMs: 30_000 },
+        )) as SessionsPatchResult;
+        if (response?.ok !== true || response.entry?.archivedAt === undefined) {
+          throw new Error("Gateway did not confirm that the session was archived.");
+        }
+        results[index] = { key: response.key ?? session.key, ok: true, status: "archived" };
+      } else {
+        const response = (await callGatewayFromCliWithTransport(
+          "sessions.delete",
+          rpcOptions,
+          {
+            key: session.key,
+            ...(opts.agent ? { agentId: opts.agent } : {}),
+            ...(session.sessionId ? { expectedSessionId: session.sessionId } : {}),
+            deleteTranscript: true,
+            ...(session.archived === true ? { archivedOnly: true } : {}),
+          },
+          { defaultTimeoutMs: 30_000 },
+        )) as SessionsDeleteResult;
+        if (response?.ok !== true || response.deleted !== true) {
+          results[index] = notFoundResult(session.key, opts.agent);
+          continue;
+        }
+        results[index] = {
+          key: response.key ?? session.key,
+          ok: true,
+          status: "deleted",
+          archived: response.archived ?? [],
+          ...(response.worktreePreserved ? { worktreePreserved: response.worktreePreserved } : {}),
+        };
+      }
+    } catch (error) {
+      results[index] = {
+        key: session.key,
+        ok: false,
+        status: "failed",
+        error: formatErrorMessage(error),
+      };
+    }
+  }
+
+  outputLifecycleResults(
+    operation,
+    Boolean(opts.dryRun),
+    results.filter((result) => result !== undefined),
+    runtime,
+    Boolean(opts.json),
+  );
+}
+
+/** Archive one or more stored sessions through the same Gateway patch used by Control UI. */
+export async function sessionsArchiveCommand(
+  opts: SessionsLifecycleCliOptions,
+  runtime: RuntimeEnv,
+): Promise<void> {
+  await runSessionsLifecycleCommand("archive", opts, runtime);
+}
+
+/** Delete one or more stored sessions through the same Gateway lifecycle owner used by Control UI. */
+export async function sessionsDeleteCommand(
+  opts: SessionsLifecycleCliOptions,
+  runtime: RuntimeEnv,
+): Promise<void> {
+  await runSessionsLifecycleCommand("delete", opts, runtime);
+}


### PR DESCRIPTION
Closes #118333

## What Problem This Solves

OpenClaw could create and inspect sessions from headless or remote CLI workflows, but archiving and deleting an individual session required the Control UI. Scripted load tests, CI jobs, and SSH operators therefore had no supported way to retire exact session keys.

## Why This Change Was Made

Adds `openclaw sessions archive <key...>` and `openclaw sessions delete <key...>` as thin Gateway-backed commands. Archive reuses `sessions.patch` with `archived: true`; delete reuses `sessions.delete` with `deleteTranscript: true` and the Control UI's state-aware `archivedOnly` gate. The CLI never edits SQLite or duplicates lifecycle cleanup.

Keys are preflighted through the same `sessions.list` projection used by the UI, including archived rows, so an unknown archive cannot accidentally materialize a new session. Mutations stay sequential and carry the listed session id as an existing lifecycle race guard.

## User Impact

Operators can now:

- archive or delete several exact session keys in one invocation;
- scope `global` keys with `--agent <id>` and override Gateway connection settings;
- preview either operation with `--dry-run`;
- consume one stable ordered result envelope with `--json`;
- continue valid keys in mixed-validity runs while receiving a non-zero exit;
- confirm destructive deletion interactively or use `--yes` for automation.

Delete matches the Control UI lifecycle contract: it removes live session/transcript/runtime artifacts, reports retained transcript archives, and surfaces preserved managed worktrees for manual cleanup.

## Evidence

- `node scripts/run-vitest.mjs src/commands/sessions-lifecycle.test.ts src/cli/program/register.status-health-sessions.test.ts` — 48 tests passed.
- `node scripts/run-vitest.mjs src/gateway/server.sessions.store-rpc.test.ts src/gateway/server.sessions.delete-lifecycle.test.ts` — 30 tests passed, including archived-list visibility and transcript archive/removal.
- `node scripts/check-changed.mjs -- <touched files>` — Blacksmith routing was unavailable before dispatch; the trusted-source local fallback passed core production/test typecheck, lint, formatting, database-first, import-cycle, SDK surface, and guard lanes.
- `pnpm docs:check-mdx` — 767 files passed.
- `pnpm docs:check-links` — 6,490 internal links checked, 0 broken.
- Dist-backed CLI help/build passed for both new subcommands.
- Source-blind live behavior validation passed 5/5 clauses against an isolated Gateway: archive/delete dry-runs were mutation-free, mixed archive preserved ordered partial success with exit 1, delete refused without `--yes`, and confirmed multi-delete removed one archived plus one active fixture while retaining the unrelated session.
- Codex autoreview (`gpt-5.6-sol`, high) reported no accepted/actionable findings.
- Initial CI exposed unrelated current-main advisory drift in the production `brace-expansion@5.0.8` pin (GHSA-rgw5-rvv9-x895). This PR updates the existing central override to upstream 5.0.9; the exact audit command is clean, dependency-fix CI run `30837271439` passed, and final exact-head CI run `30838326158` passed after applying the release-owned changelog policy.
