### PR TITLE
fix(agents): never persist cumulative usage as session context snapshot (#118772)

### DIFF
--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -2042,6 +2042,110 @@ describe("CLI attempt execution", () => {
     expect(sessionStore[sessionKey]?.updatedAt).toBe(persisted[sessionKey]?.updatedAt);
   });
 
+  it("stores per-call usage, not cumulative run usage, in the CLI transcript", async () => {
+    const sessionKey = "agent:main:subagent:cli-transcript-usage";
+    const sessionFile = path.join(tmpDir, "session-cli-transcript-usage.jsonl");
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-cli-usage",
+      sessionFile,
+      updatedAt: 1,
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await writeSessionStoreSeed({
+      [sessionKey]: {
+        ...sessionEntry,
+        updatedAt: 5,
+      },
+    });
+    clearSessionStoreCacheForTest();
+
+    const result = makeCliResult("usage from cli");
+    result.meta.agentMeta!.usage = { input: 12, output: 4, cacheRead: 3, cacheWrite: 0, total: 19 };
+    result.meta.agentMeta!.lastCallUsage = {
+      input: 7,
+      output: 4,
+      cacheRead: 2,
+      cacheWrite: 0,
+      total: 13,
+    };
+
+    await persistCliTranscriptEntry({
+      body: "usage prompt",
+      result,
+      sessionId: sessionEntry.sessionId,
+      sessionKey,
+      sessionEntry,
+      sessionStore,
+      storePath,
+      sessionAgentId: "main",
+      sessionCwd: tmpDir,
+      config: {},
+    });
+
+    const messages = await readSessionMessages({
+      agentId: "main",
+      sessionId: sessionEntry.sessionId,
+      sessionKey,
+      storePath,
+    });
+    const assistant = requireRecord(messages.at(-1), "assistant message");
+    expect(assistant.usage).toMatchObject({
+      input: 7,
+      output: 4,
+      cacheRead: 2,
+      cacheWrite: 0,
+      totalTokens: 13,
+    });
+  });
+
+  it("writes zero usage to the CLI transcript when only cumulative usage exists", async () => {
+    const sessionKey = "agent:main:subagent:cli-transcript-cumulative-only";
+    const sessionFile = path.join(tmpDir, "session-cli-transcript-cumulative-only.jsonl");
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-cli-cumulative-only",
+      sessionFile,
+      updatedAt: 1,
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await writeSessionStoreSeed({
+      [sessionKey]: {
+        ...sessionEntry,
+        updatedAt: 5,
+      },
+    });
+    clearSessionStoreCacheForTest();
+
+    // makeCliResult provides only cumulative `usage`; without a per-call
+    // `lastCallUsage` the transcript must not carry a nonzero prompt snapshot.
+    await persistCliTranscriptEntry({
+      body: "cumulative only",
+      result: makeCliResult("cumulative reply"),
+      sessionId: sessionEntry.sessionId,
+      sessionKey,
+      sessionEntry,
+      sessionStore,
+      storePath,
+      sessionAgentId: "main",
+      sessionCwd: tmpDir,
+      config: {},
+    });
+
+    const messages = await readSessionMessages({
+      agentId: "main",
+      sessionId: sessionEntry.sessionId,
+      sessionKey,
+      storePath,
+    });
+    const assistant = requireRecord(messages.at(-1), "assistant message");
+    expect(assistant.usage).toMatchObject({
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+    });
+  });
+
   it("mirrors only the CLI reply when the shared recorder already persisted the user turn", async () => {
     const sessionKey = "agent:main:direct:cli-recorder-owned-user";
     const sessionFile = path.join(tmpDir, "session-cli-recorder-owned-user.jsonl");

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -2098,7 +2098,7 @@ describe("CLI attempt execution", () => {
     });
   });
 
-  it("writes zero usage to the CLI transcript when only cumulative usage exists", async () => {
+  it("writes an unavailable-usage marker when only cumulative usage exists", async () => {
     const sessionKey = "agent:main:subagent:cli-transcript-cumulative-only";
     const sessionFile = path.join(tmpDir, "session-cli-transcript-cumulative-only.jsonl");
     const sessionEntry: SessionEntry = {
@@ -2116,7 +2116,8 @@ describe("CLI attempt execution", () => {
     clearSessionStoreCacheForTest();
 
     // makeCliResult provides only cumulative `usage`; without a per-call
-    // `lastCallUsage` the transcript must not carry a nonzero prompt snapshot.
+    // `lastCallUsage` the transcript must carry an explicit unavailable marker
+    // so fallback scans stop here instead of reviving older cumulative records.
     await persistCliTranscriptEntry({
       body: "cumulative only",
       result: makeCliResult("cumulative reply"),
@@ -2143,6 +2144,7 @@ describe("CLI attempt execution", () => {
       cacheRead: 0,
       cacheWrite: 0,
       totalTokens: 0,
+      contextUsage: { state: "unavailable" },
     });
   });
 

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -158,6 +158,15 @@ const ACP_TRANSCRIPT_USAGE = {
     total: 0,
   },
 } as const;
+
+const CLI_TRANSCRIPT_UNAVAILABLE_USAGE = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  total: 0,
+  contextUsage: { state: "unavailable" },
+} as const;
 function shouldSuppressEmbeddedLiveStreamOutput(params: { opts: AgentCommandOpts }): boolean {
   return params.opts.sessionEffects === "internal" && params.opts.deliver !== true;
 }
@@ -168,6 +177,11 @@ type TranscriptUsage = {
   cacheRead?: number;
   cacheWrite?: number;
   total?: number;
+  contextUsage?: {
+    state: "available" | "unavailable";
+    promptTokens?: number;
+    totalTokens?: number;
+  };
 };
 
 type PersistTextTurnTranscriptParams = {
@@ -292,13 +306,16 @@ function resolveTranscriptUsage(usage: PersistTextTurnTranscriptParams["assistan
   if (!usage) {
     return ACP_TRANSCRIPT_USAGE;
   }
-  return buildUsageWithNoCost({
+  const resolved = buildUsageWithNoCost({
     input: usage.input,
     output: usage.output,
     cacheRead: usage.cacheRead,
     cacheWrite: usage.cacheWrite,
     totalTokens: usage.total,
   });
+  return usage.contextUsage?.state === "unavailable"
+    ? { ...resolved, contextUsage: { state: "unavailable" as const } }
+    : resolved;
 }
 
 async function persistTextTurnTranscript(
@@ -481,7 +498,9 @@ export async function persistCliTurnTranscript(params: {
         // Transcript usage feeds later context reads (memory-flush fallback,
         // fork estimates). Only per-call usage is a valid prompt snapshot;
         // cumulative run usage would be promoted back as fresh context later.
-        usage: params.result.meta.agentMeta?.lastCallUsage,
+        // Without per-call usage, persist an explicit unavailable marker so
+        // the fallback scan stops here instead of reviving older records.
+        usage: params.result.meta.agentMeta?.lastCallUsage ?? CLI_TRANSCRIPT_UNAVAILABLE_USAGE,
       },
       skipAssistantTurn: params.skipAssistantTurn,
     });

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -478,7 +478,10 @@ export async function persistCliTurnTranscript(params: {
         api: "cli",
         provider,
         model,
-        usage: params.result.meta.agentMeta?.usage,
+        // Transcript usage feeds later context reads (memory-flush fallback,
+        // fork estimates). Only per-call usage is a valid prompt snapshot;
+        // cumulative run usage would be promoted back as fresh context later.
+        usage: params.result.meta.agentMeta?.lastCallUsage,
       },
       skipAssistantTurn: params.skipAssistantTurn,
     });

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -2184,6 +2184,55 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps a stale session snapshot stale when the CLI transcript carries only zero usage", async () => {
+    // persistCliTurnTranscript writes a zero-usage sentinel when a run has only
+    // cumulative usage (no per-call lastCallUsage). That must never be promoted
+    // back into a fresh context snapshot by the memory-flush fallback.
+    const sessionFile = path.join(rootDir, "memory-flush-zero-usage.jsonl");
+    await writeTestSessionTranscript({
+      rootDir,
+      events: [
+        {
+          type: "message",
+          message: {
+            role: "assistant",
+            content: "small answer",
+            usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0 },
+          },
+        },
+      ],
+    });
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokensFresh: false,
+    };
+    const sessionStore: Record<string, SessionEntry> = { main: sessionEntry };
+
+    await runMemoryFlushIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun: createTestFollowupRun({
+        sessionId: "session",
+        sessionFile,
+        sessionKey: "main",
+      }),
+      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 100_000,
+      resolvedVerboseLevel: "off",
+      sessionEntry,
+      sessionStore,
+      sessionKey: "main",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    expect(sessionStore["main"]?.totalTokens).toBeUndefined();
+    expect(sessionStore["main"]?.totalTokensFresh).toBe(false);
+    expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
+  });
+
   it("fails when required preflight compaction returns an unknown successful no-op", async () => {
     compactEmbeddedAgentSessionMock.mockResolvedValueOnce({
       ok: true,

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -2233,6 +2233,71 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
   });
 
+  it("stops the fallback scan at an unavailable CLI snapshot instead of reviving an older cumulative record", async () => {
+    // Upgrade sequence: an older assistant message carries cumulative run usage
+    // (pre-fix transcripts), followed by the explicit unavailable marker the
+    // fixed CLI writer persists when per-call usage is absent. The fallback
+    // must stop at the marker and not promote the older cumulative record.
+    const sessionFile = path.join(rootDir, "memory-flush-upgrade-sequence.jsonl");
+    await writeTestSessionTranscript({
+      rootDir,
+      events: [
+        {
+          type: "message",
+          message: {
+            role: "assistant",
+            content: "older cumulative run",
+            usage: { input: 12, output: 4, cacheRead: 3, cacheWrite: 0, totalTokens: 19 },
+          },
+        },
+        {
+          type: "message",
+          message: {
+            role: "assistant",
+            content: "after fix",
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              contextUsage: { state: "unavailable" },
+            },
+          },
+        },
+      ],
+    });
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokensFresh: false,
+    };
+    const sessionStore: Record<string, SessionEntry> = { main: sessionEntry };
+
+    await runMemoryFlushIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun: createTestFollowupRun({
+        sessionId: "session",
+        sessionFile,
+        sessionKey: "main",
+      }),
+      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 100_000,
+      resolvedVerboseLevel: "off",
+      sessionEntry,
+      sessionStore,
+      sessionKey: "main",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    expect(sessionStore["main"]?.totalTokens).toBeUndefined();
+    expect(sessionStore["main"]?.totalTokensFresh).toBe(false);
+    expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
+  });
+
   it("fails when required preflight compaction returns an unknown successful no-op", async () => {
     compactEmbeddedAgentSessionMock.mockResolvedValueOnce({
       ok: true,

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -417,6 +417,12 @@ function readLatestNonzeroUsageSnapshotFromTranscriptEvents(
         ? (record.message as { usage?: UsageLike })
         : undefined;
     const usage = normalizeUsage(message?.usage ?? record.usage);
+    if (usage?.contextUsage?.state === "unavailable") {
+      // CLI runs without per-call usage persist an explicit unavailable marker.
+      // Stop here: older transcript records predate the per-call usage policy
+      // and must not be promoted back into a fresh context snapshot.
+      return undefined;
+    }
     if (usage && hasNonzeroUsage(usage)) {
       return { usage, trailingBytes };
     }

--- a/src/auto-reply/reply/agent-runner-result-accounting.ts
+++ b/src/auto-reply/reply/agent-runner-result-accounting.ts
@@ -252,7 +252,6 @@ export async function accountAgentTurn(context: AgentTurnAccountingContext) {
     lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,
     compactionTokensAfter: runResult.meta?.agentMeta?.compactionTokensAfter,
     promptTokens,
-    usageIsContextSnapshot: usedCliProvider ? true : undefined,
     isHeartbeat,
     preserveRuntimeModel: fallbackExhausted,
     preserveUserFacingSessionModelState: preserveUserFacingSessionState,

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -4839,8 +4839,11 @@ describe("runReplyAgent typing (heartbeat)", () => {
     expect(stored.fallbackNotice).toBeUndefined();
     expect(stored.modelProvider).toBe("claude-cli");
     expect(stored.model).toBe("claude-opus-4-7");
-    expect(stored.totalTokens).toBe(36_000);
-    expect(stored.totalTokensFresh).toBe(true);
+    // The mocked run reports only cumulative usage without a per-call
+    // `lastCallUsage`; cumulative tokens must never be stored as the context
+    // snapshot (they would inflate totalTokens across multi-call turns).
+    expect(stored.totalTokens).toBeUndefined();
+    expect(stored.totalTokensFresh).toBe(false);
   });
 
   it("surfaces overflow fallback when embedded run returns empty payloads", async () => {

--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -107,7 +107,6 @@ export async function persistSessionUsageUpdate(params: {
   providerUsed?: string;
   contextTokensUsed?: number;
   promptTokens?: number;
-  usageIsContextSnapshot?: boolean;
   isHeartbeat?: boolean;
   systemPromptReport?: SessionSystemPromptReport;
   cliSessionId?: string;
@@ -133,10 +132,7 @@ export async function persistSessionUsageUpdate(params: {
     params.promptTokens > 0;
   const hasUsableLastCallUsage =
     Boolean(params.lastCallUsage) && params.lastCallUsage?.contextUsage?.state !== "unavailable";
-  const hasUsableUsageContextSnapshot =
-    params.usageIsContextSnapshot === true && params.usage?.contextUsage?.state !== "unavailable";
-  const hasFreshContextSnapshot =
-    hasUsableLastCallUsage || hasPromptTokens || hasUsableUsageContextSnapshot;
+  const hasFreshContextSnapshot = hasUsableLastCallUsage || hasPromptTokens;
   const compactionTokensAfter = resolveNonNegativeTokenCount(params.compactionTokensAfter);
   const hasCompactionSnapshot = compactionTokensAfter !== undefined;
 
@@ -161,9 +157,7 @@ export async function persistSessionUsageUpdate(params: {
           // `usage.input` sums input tokens from every API call in the run
           // (tool-use loops, compaction retries), overstating actual context.
           // `lastCallUsage` reflects only the final API call — the true context.
-          const usageForContext =
-            params.lastCallUsage ??
-            (params.usageIsContextSnapshot === true ? params.usage : undefined);
+          const usageForContext = params.lastCallUsage;
           const usageTotalTokens =
             hasFreshContextSnapshot && !preserveUserFacingRunState
               ? deriveSessionTotalTokens({

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -4549,7 +4549,6 @@ describe("persistSessionUsageUpdate", () => {
       update: {
         isHeartbeat: true,
         usage: { input: 1_200, output: 100 },
-        usageIsContextSnapshot: true,
         providerUsed: "claude-cli",
         modelUsed: "claude-sonnet-4-6",
         cliSessionBinding: {
@@ -4589,7 +4588,6 @@ describe("persistSessionUsageUpdate", () => {
       update: {
         isHeartbeat: true,
         usage: { input: 1_200, output: 100 },
-        usageIsContextSnapshot: true,
         providerUsed: "claude-cli",
         modelUsed: "claude-sonnet-4-6",
         clearCliSessionBinding: true,
@@ -4604,11 +4602,10 @@ describe("persistSessionUsageUpdate", () => {
       },
     },
     {
-      name: "treats CLI usage as a fresh context snapshot when requested",
+      name: "does not treat CLI cumulative usage as a context snapshot without last-call usage",
       seed: {},
       update: {
         usage: { input: 24_000, output: 2_000, cacheRead: 8_000 },
-        usageIsContextSnapshot: true,
         providerUsed: "claude-cli",
         cliSessionBinding: {
           sessionId: "cli-session-1",
@@ -4618,8 +4615,8 @@ describe("persistSessionUsageUpdate", () => {
         },
       },
       expected: {
-        totalTokens: 32_000,
-        totalTokensFresh: true,
+        totalTokens: undefined,
+        totalTokensFresh: false,
         cliSessionIds: { "claude-cli": "cli-session-1" },
         cliSessionBindings: {
           "claude-cli": {
@@ -4643,7 +4640,6 @@ describe("persistSessionUsageUpdate", () => {
       },
       update: {
         usage: { input: 24_000, output: 2_000, cacheRead: 8_000 },
-        usageIsContextSnapshot: true,
         providerUsed: "claude-cli",
         clearCliSessionBinding: true,
       },
@@ -4666,7 +4662,6 @@ describe("persistSessionUsageUpdate", () => {
       update: {
         usage: { input: 20, output: 10_855, cacheRead: 1_761_324, cacheWrite: 33_047 },
         lastCallUsage: { input: 20, output: 10_855, cacheRead: 1_761_324, cacheWrite: 33_047 },
-        usageIsContextSnapshot: true,
         providerUsed: "claude-cli",
         contextTokensUsed: 1_048_576,
         compactionTokensAfter: 0,
@@ -4829,6 +4824,20 @@ describe("persistSessionUsageUpdate", () => {
       seed: {},
       update: { usage: { input: 50_000, output: 5_000, total: 55_000 } },
       expected: { totalTokens: undefined, totalTokensFresh: false },
+    },
+    {
+      name: "rejects cumulative usage as a context snapshot when last-call usage is missing",
+      seed: { totalTokens: 42_000, totalTokensFresh: true },
+      update: {
+        usage: { input: 180_000, output: 10_000, cacheRead: 20_000, cacheWrite: 5_000 },
+        providerUsed: "claude-cli",
+      },
+      expected: {
+        totalTokens: 42_000,
+        totalTokensFresh: false,
+        inputTokens: 180_000,
+        outputTokens: 10_000,
+      },
     },
     {
       name: "preserves fresh post-compaction totalTokens across stale usage updates",

--- a/src/gateway/session-transcript-derived-readers.test.ts
+++ b/src/gateway/session-transcript-derived-readers.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "vitest";
+import { aggregateSqliteUsageSnapshots } from "./session-transcript-derived-readers.js";
+
+const CUMULATIVE_RUN_USAGE = {
+  input: 285_000,
+  output: 1_200,
+  cacheRead: 214_656,
+  cacheWrite: 0,
+  total: 500_856,
+} as const;
+
+const UNAVAILABLE_CONTEXT_USAGE = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  total: 0,
+  contextUsage: { state: "unavailable" },
+} as const;
+
+const PER_CALL_USAGE = {
+  input: 12_000,
+  output: 800,
+  total: 12_800,
+} as const;
+
+function assistantMessage(usage: Record<string, unknown>) {
+  return {
+    role: "assistant",
+    provider: "minimax",
+    model: "Minimax-M3",
+    usage,
+  };
+}
+
+describe("aggregateSqliteUsageSnapshots", () => {
+  test("retires an earlier cumulative total when an unavailable context marker arrives", () => {
+    const aggregate = aggregateSqliteUsageSnapshots([
+      assistantMessage(CUMULATIVE_RUN_USAGE),
+      assistantMessage(UNAVAILABLE_CONTEXT_USAGE),
+    ]);
+
+    expect(aggregate).not.toBeNull();
+    expect(aggregate?.totalTokens).toBeUndefined();
+    expect(aggregate?.totalTokensFresh).toBeUndefined();
+    expect(aggregate?.contextUsage).toEqual({ state: "unavailable" });
+  });
+
+  test("restores a fresh total when valid per-call usage follows an unavailable marker", () => {
+    const aggregate = aggregateSqliteUsageSnapshots([
+      assistantMessage(CUMULATIVE_RUN_USAGE),
+      assistantMessage(UNAVAILABLE_CONTEXT_USAGE),
+      assistantMessage(PER_CALL_USAGE),
+    ]);
+
+    expect(aggregate).toMatchObject({
+      totalTokens: 12_000,
+      totalTokensFresh: true,
+    });
+    expect(aggregate?.contextUsage).toBeUndefined();
+  });
+
+  test("keeps the latest numeric total when no unavailable marker is present", () => {
+    const aggregate = aggregateSqliteUsageSnapshots([
+      assistantMessage(CUMULATIVE_RUN_USAGE),
+      assistantMessage(PER_CALL_USAGE),
+    ]);
+
+    expect(aggregate).toMatchObject({
+      totalTokens: 12_000,
+      totalTokensFresh: true,
+    });
+  });
+});

--- a/src/gateway/session-transcript-derived-readers.ts
+++ b/src/gateway/session-transcript-derived-readers.ts
@@ -50,6 +50,9 @@ function extractSqliteUsageSnapshot(message: unknown): SessionTranscriptUsageSna
     ...(typeof normalizedUsage.cacheWrite === "number"
       ? { cacheWrite: normalizedUsage.cacheWrite }
       : {}),
+    // The unavailable-context marker must reach the aggregator; without it a
+    // later CLI turn cannot retire an earlier cumulative total (JSONL parity).
+    ...(usage?.contextUsage ? { contextUsage: usage.contextUsage } : {}),
     ...(typeof totalTokens === "number" ? { totalTokens, totalTokensFresh: true } : {}),
     ...(typeof costUsd === "number" && Number.isFinite(costUsd) ? { costUsd } : {}),
   };
@@ -98,7 +101,18 @@ export function aggregateSqliteUsageSnapshots(
       cacheWrite += snapshot.cacheWrite;
       sawCacheWrite = true;
     }
-    if (typeof snapshot.totalTokens === "number") {
+    // Mirror the JSONL aggregate reader: an unavailable context marker retires
+    // any earlier total, or a stale cumulative value resurfaces as fresh
+    // session context once the Gateway row consumes this aggregate.
+    if (snapshot.contextUsage) {
+      aggregate.contextUsage = snapshot.contextUsage;
+    } else {
+      delete aggregate.contextUsage;
+    }
+    if (snapshot.contextUsage?.state === "unavailable") {
+      delete aggregate.totalTokens;
+      delete aggregate.totalTokensFresh;
+    } else if (typeof snapshot.totalTokens === "number") {
       aggregate.totalTokens = snapshot.totalTokens;
       aggregate.totalTokensFresh = true;
     }

--- a/src/gateway/session-transcript-readers.sqlite-marker.test.ts
+++ b/src/gateway/session-transcript-readers.sqlite-marker.test.ts
@@ -1,0 +1,90 @@
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { persistSessionTranscriptTurn } from "../config/sessions/session-accessor.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import { readLatestSessionUsageFromTranscriptAsync } from "./session-transcript-readers.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("session transcript reader SQLite usage marker", () => {
+  let tempDir: string;
+  let storePath: string;
+  let envSnapshot: ReturnType<typeof captureEnv>;
+
+  beforeEach(() => {
+    envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
+    tempDir = tempDirs.make("openclaw-transcript-readers-marker-");
+    storePath = path.join(tempDir, "sessions.json");
+    setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
+  });
+
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    envSnapshot.restore();
+  });
+
+  test("retires a stale cumulative SQLite total at an unavailable context marker", async () => {
+    const sessionId = "reader-sqlite-unavailable-marker";
+    const sessionKey = `agent:main:${sessionId}`;
+    const scope = { agentId: "main", sessionId, sessionKey, storePath };
+    const assistantUsageMessage = (usage: Record<string, unknown>) => ({
+      message: {
+        role: "assistant",
+        provider: "minimax",
+        model: "Minimax-M3",
+        usage,
+      },
+    });
+
+    await persistSessionTranscriptTurn(scope, {
+      cwd: tempDir,
+      messages: [
+        assistantUsageMessage({
+          input: 285_000,
+          output: 1_200,
+          cacheRead: 214_656,
+          cacheWrite: 0,
+          total: 500_856,
+        }),
+        assistantUsageMessage({
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          total: 0,
+          contextUsage: { state: "unavailable" },
+        }),
+      ],
+      touchSessionEntry: false,
+    });
+
+    const afterMarker = await readLatestSessionUsageFromTranscriptAsync(scope);
+    expect(afterMarker).not.toBeNull();
+    expect(afterMarker?.totalTokens).toBeUndefined();
+    expect(afterMarker?.totalTokensFresh).not.toBe(true);
+    expect(afterMarker?.contextUsage).toEqual({ state: "unavailable" });
+
+    await persistSessionTranscriptTurn(scope, {
+      cwd: tempDir,
+      messages: [
+        assistantUsageMessage({
+          input: 12_000,
+          output: 800,
+          total: 12_800,
+        }),
+      ],
+      touchSessionEntry: false,
+    });
+
+    const afterValidUsage = await readLatestSessionUsageFromTranscriptAsync(scope);
+    expect(afterValidUsage).toMatchObject({
+      totalTokens: 12_000,
+      totalTokensFresh: true,
+    });
+    expect(afterValidUsage?.contextUsage).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes #118772

## Summary

`sessionEntry.totalTokens` was inflated by cumulative run usage across multi-tool-loop turns and persisted with `totalTokensFresh: true`, causing premature compaction at 4-8% of the configured context window (see #118772).

Root cause: `persistSessionUsageUpdate` accepted an `usageIsContextSnapshot` escape hatch. The only production caller (`accountAgentTurn`) set it for CLI-classified providers (`usedCliProvider ? true : undefined`). When a run's per-call `lastCallUsage` was missing, the cumulative `usage` object (sum of `input + cacheRead + cacheWrite` across every API call in the run) was stored as the context snapshot. Reproduction: a 205k cumulative run with no last-call usage persisted `totalTokens: 205000, totalTokensFresh: true` instead of keeping the previous snapshot stale.

Fix: cumulative usage can never act as the context snapshot. `totalTokens` is now derived only from `lastCallUsage` (per-call) or `promptTokens` (explicit context snapshot); runs without either persist a stale marker. `compactionTokensAfter` still wins when present and no fresh snapshot exists.

## What Problem This Solves

Sessions with long multi-call turns (tool loops, compaction retries) could have their `sessionEntry.totalTokens` written as the sum of every API call's prompt tokens instead of the current prompt size. With `totalTokensFresh: true`, the CLI compaction lifecycle and context displays treat that inflated value as the real context, so compaction fires at 4-8% of the configured window and summarizes/discards real conversation turns. This change makes cumulative run usage ineligible as a context snapshot: only the final API call's usage (`lastCallUsage`), an explicit `promptTokens` snapshot, or `compactionTokensAfter` can set `totalTokens`.

- `src/auto-reply/reply/session-usage.ts`: removed `usageIsContextSnapshot` param/branch (net -6 lines).
- `src/agents/command/attempt-execution.ts`: `persistCliTurnTranscript` now stores per-call usage on the transcript assistant message instead of cumulative run usage.

## Evidence

- Reproduction before fix: the new regression test failed with `expected 205000 to deeply equal 42000` - a cumulative 205k-token run with no `lastCallUsage` was persisted as `totalTokens: 205000, totalTokensFresh: true`. This matches the issue's reported shape exactly (`totalTokens = input + cacheRead + cacheWrite` of the accumulated run, `totalTokensFresh: true`, e.g. `330498 = 6380 + 214656 + 103462`).
- After fix: the same test passes; the entry keeps the prior snapshot (`totalTokens: 42000`) and marks it stale (`totalTokensFresh: false`).
- Existing coverage asserts the issue's suggested shape: a 180k cumulative run with a 12k final call persists `totalTokens: 12000, totalTokensFresh: true` ("uses lastCallUsage for totalTokens when provided" in `session.test.ts`).
- Focused suites all pass: `session.test.ts` 161/161, `agent-runner.misc.runreplyagent.test.ts` 75/75, `agent-runner.runreplyagent.e2e.test.ts` 123/123, `cli-compaction.test.ts` 29/29, `session-store.test.ts` 58/58.
- `pnpm tsgo:core` and `pnpm tsgo:core:test` pass; oxlint on touched files passes; `git diff --check` clean.
- Focused runs after the transcript fix: auto-reply shard (`agent-runner-memory.test.ts`, `session.test.ts`) 224/224; agents-support shard (`attempt-execution.cli.test.ts`) 116/116.

## Transcript boundary repair (P1 from review)

ClawSweeper's exact-head review found a remaining cross-turn route: `persistCliTurnTranscript` wrote cumulative `agentMeta.usage` into the CLI transcript assistant message, and the memory-flush fallback (`src/auto-reply/reply/agent-runner-memory.ts:1136`) reads the latest transcript usage and promotes its prompt total back to `totalTokensFresh: true` when the stored snapshot is stale - recreating the premature-compaction route.

Fix: the CLI transcript now persists only `agentMeta.lastCallUsage` (per-call). When a run has only cumulative usage, the transcript receives an explicit unavailable marker (`contextUsage: { state: "unavailable" }`), and the memory-flush fallback scan stops at that marker instead of reviving an older cumulative record from a pre-fix transcript. Real CLI runs are unaffected because `cli-runner` sets `usage === lastCallUsage`.

Regression coverage:
- `src/agents/command/attempt-execution.cli.test.ts`: transcript stores per-call usage (7/4/2 vs cumulative 12/4/3) and writes the unavailable marker when only cumulative usage exists.
- `src/auto-reply/reply/agent-runner-memory.test.ts`: cross-turn test - a zero-usage CLI transcript leaves `totalTokens` unset and `totalTokensFresh: false`, with no flush run.
- `src/auto-reply/reply/agent-runner-memory.test.ts`: upgrade-sequence test - an older cumulative record followed by the unavailable marker stays stale (`totalTokens` unset, `totalTokensFresh: false`, no flush), so the historical-transcript route cannot re-arm premature compaction.

Exact-head fallback proof (real `readLatestNonzeroUsageSnapshotFromTranscriptEvents` over the upgrade sequence, redacted):

```
== transcript tail (oldest -> newest) ==
{ "role": "assistant", "usage": { "input": 12, "output": 4, "cacheRead": 3, "cacheWrite": 0, "totalTokens": 19 } }  // pre-fix cumulative record
{ "role": "assistant", "usage": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0, "totalTokens": 0, "contextUsage": { "state": "unavailable" } } }  // fixed CLI writer marker

== memory-flush fallback result ==
{ "totalTokens": undefined, "totalTokensFresh": false, "flushTriggered": false }
```

Exact-head SQLite boundary proof (real `persistSessionTranscriptTurn` write + real `readLatestSessionUsageFromTranscriptAsync` read, temp state dir, redacted):

```
== persisted: cumulative usage + unavailable marker ==
== SQLite reader result ==
{
  "modelProvider": "minimax",
  "model": "Minimax-M3",
  "contextUsage": { "state": "unavailable" },
  "inputTokens": 285000,
  "outputTokens": 1200,
  "cacheRead": 214656,
  "cacheWrite": 0
}
// no totalTokens, no totalTokensFresh: the stale cumulative 500856 total is retired

== persisted: later valid per-call usage ==
== SQLite reader result ==
{
  "modelProvider": "minimax",
  "model": "Minimax-M3",
  "totalTokens": 12000,
  "totalTokensFresh": true,
  "inputTokens": 297000,
  "outputTokens": 2000,
  "cacheRead": 214656,
  "cacheWrite": 0
}
```

Evidence: `attempt-execution.cli.test.ts` 116/116, `agent-runner-memory.test.ts` 63/63, `session.test.ts` 162/162, `assistant-transcript-repair.test.ts` 7/7; `pnpm tsgo:core` and `pnpm tsgo:core:test` pass; oxlint and `git diff --check` clean.

## Duplicate repair PR

ClawSweeper's issue review flagged two competing repair PRs. This PR is the complete superset: it removes the producer escape hatch (`src/auto-reply/reply/session-usage.ts`), the caller flag, AND the transcript-boundary routes that ClawSweeper's own P1 findings required (per-call CLI transcript usage, unavailable marker, fallback scan termination), with cross-turn regressions and exact-head proof. PR #118796 removes only the caller flag and leaves the `usageIsContextSnapshot` branch and transcript route unaddressed; closing it as duplicate lands one repair.
