### PR TITLE
test(gateway): prove RPC wire and agent contracts

### DIFF
--- a/qa/scenarios/runtime/gateway-agent-rpc-contracts.yaml
+++ b/qa/scenarios/runtime/gateway-agent-rpc-contracts.yaml
@@ -1,0 +1,27 @@
+title: Gateway agent RPC contracts
+
+scenario:
+  id: gateway-agent-rpc-contracts
+  surface: runtime
+  category: gateway.gateway-rpc-apis-and-events
+  coverage:
+    primary:
+      - gateway.delivery-fallback-behavior
+      - gateway.accepted-then-final-results
+      - gateway.idempotent-side-effects
+  objective: Prove real Gateway agent RPC delivery fallback, response ordering, and reconnect-safe idempotency.
+  successCriteria:
+    - Ambiguous best-effort delivery runs through webchat as a session-only agent request.
+    - One request ID receives accepted and terminal responses with the same run ID in that order.
+    - Reconnecting and repeating the idempotency key returns the cached terminal result without another agent execution.
+  docsRefs:
+    - docs/gateway/protocol.md
+    - docs/concepts/qa-e2e-automation.md
+  codeRefs:
+    - src/gateway/server-methods/agent.ts
+    - src/gateway/server-methods/agent-delivery-phase.ts
+    - src/gateway/server.agent.rpc-contracts.test.ts
+  execution:
+    kind: vitest
+    path: src/gateway/server.agent.rpc-contracts.test.ts
+    summary: Run a real Gateway agent request through session-only fallback, ordered responses, and reconnect replay.

--- a/qa/scenarios/runtime/gateway-rpc-wire-contracts.yaml
+++ b/qa/scenarios/runtime/gateway-rpc-wire-contracts.yaml
@@ -1,0 +1,30 @@
+title: Gateway RPC wire contracts
+
+scenario:
+  id: gateway-rpc-wire-contracts
+  surface: runtime
+  category: gateway.gateway-rpc-apis-and-events
+  coverage:
+    primary:
+      - gateway.request-and-event-envelopes
+      - gateway.method-discovery
+      - gateway.event-discovery
+      - gateway.event-ordering
+  objective: Prove the real Gateway WebSocket handshake, RPC envelopes, discovery catalogs, and per-client event ordering.
+  successCriteria:
+    - Two real WebSocket clients receive connect challenges and successful hello-ok response envelopes.
+    - The hello-ok payload advertises callable methods and receivable event names.
+    - A raw health request receives a successful response with the same request ID.
+    - Both clients receive two heartbeat events with strictly increasing per-client sequence numbers.
+  docsRefs:
+    - docs/gateway/protocol.md
+    - docs/concepts/qa-e2e-automation.md
+  codeRefs:
+    - src/gateway/server/ws-connection.ts
+    - src/gateway/server/ws-connection/connect-hello.ts
+    - src/gateway/server-broadcast.ts
+    - src/gateway/server.rpc-wire-contracts.test.ts
+  execution:
+    kind: vitest
+    path: src/gateway/server.rpc-wire-contracts.test.ts
+    summary: Run two real Gateway WebSocket clients through challenge, connect, health, discovery, and ordered heartbeat assertions.

--- a/src/gateway/server.agent.rpc-contracts.test.ts
+++ b/src/gateway/server.agent.rpc-contracts.test.ts
@@ -1,0 +1,142 @@
+// Real Gateway WebSocket proof for agent delivery fallback, response ordering, and idempotency.
+import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import type { WebSocket } from "ws";
+import { createDeferred } from "../shared/deferred.js";
+import { startGatewayServerHarness, type GatewayServerHarness } from "./server.e2e-ws-harness.js";
+import { agentCommand, installGatewayTestHooks, onceMessage } from "./test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+type AgentResponse = {
+  type?: string;
+  id?: string;
+  ok?: boolean;
+  payload?: {
+    runId?: string;
+    status?: string;
+  };
+};
+
+let harness: GatewayServerHarness;
+
+beforeAll(async () => {
+  harness = await startGatewayServerHarness();
+});
+
+beforeEach(() => {
+  vi.mocked(agentCommand).mockReset();
+});
+
+afterAll(async () => {
+  await harness.close();
+});
+
+function sendAgentRequest(params: {
+  ws: WebSocket;
+  id: string;
+  idempotencyKey: string;
+  message: string;
+}): void {
+  params.ws.send(
+    JSON.stringify({
+      type: "req",
+      id: params.id,
+      method: "agent",
+      params: {
+        message: params.message,
+        sessionKey: "main",
+        deliver: true,
+        bestEffortDeliver: true,
+        idempotencyKey: params.idempotencyKey,
+      },
+    }),
+  );
+}
+
+describe("gateway agent RPC contracts", () => {
+  test("downgrades ambiguous delivery and replays one ordered run across reconnect", async () => {
+    const runCompletion = createDeferred<void>();
+    vi.mocked(agentCommand).mockImplementationOnce(async () => {
+      await runCompletion.promise;
+    });
+
+    const idempotencyKey = "gateway-agent-rpc-contract";
+    const first = await harness.openClient();
+    const acceptedPromise = onceMessage<AgentResponse>(
+      first.ws,
+      (frame) =>
+        frame.type === "res" &&
+        frame.id === "agent-contract" &&
+        frame.payload?.status === "accepted",
+    );
+    const terminalPromise = onceMessage<AgentResponse>(
+      first.ws,
+      (frame) =>
+        frame.type === "res" &&
+        frame.id === "agent-contract" &&
+        frame.payload?.status !== "accepted",
+    );
+
+    sendAgentRequest({
+      ws: first.ws,
+      id: "agent-contract",
+      idempotencyKey,
+      message: "prove the gateway agent RPC contract",
+    });
+
+    const accepted = await acceptedPromise;
+    await vi.waitFor(() => expect(agentCommand).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(agentCommand).mock.calls[0]?.[0]).toMatchObject({
+      runId: idempotencyKey,
+      channel: "webchat",
+      messageChannel: "webchat",
+      deliver: false,
+      bestEffortDeliver: true,
+    });
+
+    runCompletion.resolve();
+    const terminal = await terminalPromise;
+    expect(accepted).toMatchObject({
+      type: "res",
+      id: "agent-contract",
+      ok: true,
+      payload: {
+        runId: idempotencyKey,
+        status: "accepted",
+      },
+    });
+    expect(terminal).toMatchObject({
+      type: "res",
+      id: "agent-contract",
+      ok: true,
+      payload: {
+        runId: idempotencyKey,
+        status: "ok",
+      },
+    });
+
+    first.ws.close();
+    await new Promise<void>((resolve) => first.ws.once("close", () => resolve()));
+
+    const second = await harness.openClient();
+    try {
+      const replayPromise = onceMessage<AgentResponse>(
+        second.ws,
+        (frame) => frame.type === "res" && frame.id === "agent-contract-replay",
+      );
+      sendAgentRequest({
+        ws: second.ws,
+        id: "agent-contract-replay",
+        idempotencyKey,
+        message: "this duplicate must not execute",
+      });
+
+      const replay = await replayPromise;
+      expect(replay.payload).toEqual(terminal.payload);
+      expect(replay.payload?.status).toBe("ok");
+      expect(agentCommand).toHaveBeenCalledTimes(1);
+    } finally {
+      second.ws.close();
+    }
+  });
+});

--- a/src/gateway/server.agent.rpc-contracts.test.ts
+++ b/src/gateway/server.agent.rpc-contracts.test.ts
@@ -1,6 +1,7 @@
 // Real Gateway WebSocket proof for agent delivery fallback, response ordering, and idempotency.
 import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
-import type { WebSocket } from "ws";
+import type { RawData, WebSocket } from "ws";
+import { rawDataToString } from "../infra/ws.js";
 import { createDeferred } from "../shared/deferred.js";
 import { startGatewayServerHarness, type GatewayServerHarness } from "./server.e2e-ws-harness.js";
 import { agentCommand, installGatewayTestHooks, onceMessage } from "./test-helpers.js";
@@ -62,6 +63,14 @@ describe("gateway agent RPC contracts", () => {
 
     const idempotencyKey = "gateway-agent-rpc-contract";
     const first = await harness.openClient();
+    const orderedResponses: AgentResponse[] = [];
+    const recordResponse = (data: RawData) => {
+      const frame = JSON.parse(rawDataToString(data)) as AgentResponse;
+      if (frame.type === "res" && frame.id === "agent-contract") {
+        orderedResponses.push(frame);
+      }
+    };
+    first.ws.on("message", recordResponse);
     const acceptedPromise = onceMessage<AgentResponse>(
       first.ws,
       (frame) =>
@@ -84,7 +93,7 @@ describe("gateway agent RPC contracts", () => {
       message: "prove the gateway agent RPC contract",
     });
 
-    const accepted = await acceptedPromise;
+    await acceptedPromise;
     await vi.waitFor(() => expect(agentCommand).toHaveBeenCalledTimes(1));
     expect(vi.mocked(agentCommand).mock.calls[0]?.[0]).toMatchObject({
       runId: idempotencyKey,
@@ -96,6 +105,9 @@ describe("gateway agent RPC contracts", () => {
 
     runCompletion.resolve();
     const terminal = await terminalPromise;
+    first.ws.off("message", recordResponse);
+    expect(orderedResponses.map((frame) => frame.payload?.status)).toEqual(["accepted", "ok"]);
+    const accepted = orderedResponses[0];
     expect(accepted).toMatchObject({
       type: "res",
       id: "agent-contract",

--- a/src/gateway/server.agent.rpc-contracts.test.ts
+++ b/src/gateway/server.agent.rpc-contracts.test.ts
@@ -55,7 +55,7 @@ function sendAgentRequest(params: {
 
 describe("gateway agent RPC contracts", () => {
   test("downgrades ambiguous delivery and replays one ordered run across reconnect", async () => {
-    const runCompletion = createDeferred<void>();
+    const runCompletion = createDeferred();
     vi.mocked(agentCommand).mockImplementationOnce(async () => {
       await runCompletion.promise;
     });
@@ -116,7 +116,9 @@ describe("gateway agent RPC contracts", () => {
     });
 
     first.ws.close();
-    await new Promise<void>((resolve) => first.ws.once("close", () => resolve()));
+    await new Promise<void>((resolve) => {
+      first.ws.once("close", () => resolve());
+    });
 
     const second = await harness.openClient();
     try {

--- a/src/gateway/server.rpc-wire-contracts.test.ts
+++ b/src/gateway/server.rpc-wire-contracts.test.ts
@@ -137,9 +137,11 @@ describe("gateway RPC wire contracts", () => {
       emitHeartbeatEvent({ status: "skipped", reason: "qa-wire-ordering" });
       const secondHeartbeats = await Promise.all(secondHeartbeatPromises);
 
-      for (let index = 0; index < clients.length; index += 1) {
-        const first = firstHeartbeats[index];
+      for (const [index, first] of firstHeartbeats.entries()) {
         const second = secondHeartbeats[index];
+        if (!second) {
+          throw new Error(`missing second heartbeat for client ${index}`);
+        }
         expect(first).toMatchObject({
           type: "event",
           event: "heartbeat",

--- a/src/gateway/server.rpc-wire-contracts.test.ts
+++ b/src/gateway/server.rpc-wire-contracts.test.ts
@@ -1,0 +1,163 @@
+// Real Gateway WebSocket proof for RPC envelopes, discovery, and event ordering.
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { WebSocket } from "ws";
+import { emitHeartbeatEvent } from "../infra/heartbeat-events.js";
+import { startGatewayServerHarness, type GatewayServerHarness } from "./server.e2e-ws-harness.js";
+import {
+  connectReq,
+  installGatewayTestHooks,
+  onceMessage,
+  trackConnectChallengeNonce,
+} from "./test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+type WireFrame = {
+  type?: string;
+  id?: string;
+  ok?: boolean;
+  event?: string;
+  payload?: Record<string, unknown> | null;
+  seq?: number;
+};
+
+type ConnectedWireClient = {
+  ws: WebSocket;
+  challenge: WireFrame;
+  connectResponse: WireFrame;
+};
+
+let harness: GatewayServerHarness;
+
+beforeAll(async () => {
+  harness = await startGatewayServerHarness();
+});
+
+afterAll(async () => {
+  await harness.close();
+});
+
+async function openWireClient(): Promise<ConnectedWireClient> {
+  const ws = new WebSocket(`ws://127.0.0.1:${harness.port}`);
+  trackConnectChallengeNonce(ws);
+  const challengePromise = onceMessage<WireFrame>(
+    ws,
+    (frame) => frame.type === "event" && frame.event === "connect.challenge",
+  );
+  await new Promise<void>((resolve, reject) => {
+    ws.once("open", resolve);
+    ws.once("error", reject);
+  });
+  const challenge = await challengePromise;
+  const connectResponse = await connectReq(ws);
+  return { ws, challenge, connectResponse };
+}
+
+function expectChallenge(frame: WireFrame): void {
+  expect(frame).toMatchObject({
+    type: "event",
+    event: "connect.challenge",
+    payload: {
+      nonce: expect.any(String),
+      ts: expect.any(Number),
+    },
+  });
+  expect(frame).not.toHaveProperty("id");
+}
+
+function expectConnectResponse(frame: WireFrame): void {
+  expect(frame).toMatchObject({
+    type: "res",
+    id: expect.any(String),
+    ok: true,
+    payload: {
+      type: "hello-ok",
+      protocol: expect.any(Number),
+      server: {
+        version: expect.any(String),
+        connId: expect.any(String),
+      },
+      features: {
+        methods: expect.arrayContaining(["health", "agent"]),
+        events: expect.arrayContaining(["connect.challenge", "heartbeat"]),
+      },
+    },
+  });
+}
+
+describe("gateway RPC wire contracts", () => {
+  test("publishes canonical envelopes, discovery catalogs, and ordered events", async () => {
+    const clients = await Promise.all([openWireClient(), openWireClient()]);
+
+    try {
+      for (const client of clients) {
+        expectChallenge(client.challenge);
+        expectConnectResponse(client.connectResponse);
+      }
+
+      const healthResponsePromise = onceMessage<WireFrame>(
+        clients[0].ws,
+        (frame) => frame.type === "res" && frame.id === "wire-health",
+      );
+      clients[0].ws.send(
+        JSON.stringify({
+          type: "req",
+          id: "wire-health",
+          method: "health",
+        }),
+      );
+      expect(await healthResponsePromise).toMatchObject({
+        type: "res",
+        id: "wire-health",
+        ok: true,
+        payload: expect.any(Object),
+      });
+
+      const firstHeartbeatPromises = clients.map((client) =>
+        onceMessage<WireFrame>(
+          client.ws,
+          (frame) =>
+            frame.type === "event" &&
+            frame.event === "heartbeat" &&
+            frame.payload?.status === "sent",
+        ),
+      );
+      emitHeartbeatEvent({ status: "sent", to: "qa-wire", preview: "first" });
+      const firstHeartbeats = await Promise.all(firstHeartbeatPromises);
+
+      const secondHeartbeatPromises = clients.map((client) =>
+        onceMessage<WireFrame>(
+          client.ws,
+          (frame) =>
+            frame.type === "event" &&
+            frame.event === "heartbeat" &&
+            frame.payload?.status === "skipped",
+        ),
+      );
+      emitHeartbeatEvent({ status: "skipped", reason: "qa-wire-ordering" });
+      const secondHeartbeats = await Promise.all(secondHeartbeatPromises);
+
+      for (let index = 0; index < clients.length; index += 1) {
+        const first = firstHeartbeats[index];
+        const second = secondHeartbeats[index];
+        expect(first).toMatchObject({
+          type: "event",
+          event: "heartbeat",
+          payload: { status: "sent" },
+          seq: expect.any(Number),
+        });
+        expect(second).toMatchObject({
+          type: "event",
+          event: "heartbeat",
+          payload: { status: "skipped" },
+          seq: expect.any(Number),
+        });
+        expect(second.seq).toBeGreaterThan(first.seq ?? Number.NEGATIVE_INFINITY);
+      }
+    } finally {
+      for (const client of clients) {
+        client.ws.close();
+      }
+    }
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Gateway QA coverage did not directly exercise seven RPC/event contracts at the
real WebSocket boundary: frame envelopes, method/event discovery, per-client
event ordering, delivery fallback, accepted/final responses, and idempotent
replay.

## Why This Change Was Made

This adds two focused real-Gateway WebSocket scenarios. The wire scenario uses
two clients to validate handshake and health envelopes, hello discovery
metadata, and monotonic heartbeat sequences. The agent scenario validates
session-only fallback, accepted/final ordering, and reconnect replay while
mocking only the downstream provider command.

No production code, taxonomy, QA internals, or existing broad tests are changed.

## User Impact

No runtime behavior changes. Maintainers gain executable primary evidence for
seven existing Gateway maturity targets.

## Review Disposition

- Applied the response-ordering finding: one raw receive log now proves the
  exact `accepted`, then `ok` frame order for the request ID.
- Retained the focused agent scenario. This is the approved cohesive QA
  evidence owner for three exact maturity IDs: one real Gateway lifecycle
  proves fallback, ordered responses, and reconnect replay while mocking only
  downstream `agentCommand`. Existing broad tests cover those behaviors
  separately; they do not provide this single catalog evidence unit.

## Repair Doctrine

- Root cause: the Gateway QA catalog lacked direct, executable real-WebSocket
  evidence for these seven existing contracts.
- Architectural owner: Gateway server contract tests plus QA runtime scenario
  metadata.
- Canonical fix: two focused real-Gateway tests, split between wire-level and
  agent-lifecycle ownership.
- Removed paths: none; this is additive test evidence only.
- Production LOC delta: `+0`.
- Test and QA metadata delta: `+378` lines across two tests and two scenarios.
- Sibling coverage: two raw clients prove independent event sequences; the
  agent path proves fallback, ordered terminal results, reconnect replay, and
  one downstream side effect.

## Evidence

- Rebased once onto frozen `origin/main`
  `682f60ce56b37c5cd3205fdcbbf25b21d48708f2`, which contains security
  prerequisite `25aa29d7a15ed6402543fe48680853d7637f2b36`.
- Exact PR head: `25b820c3b46e2ac952439783a8a731ca3a78f673`.
- Trusted AWS Crabbox focused proof:
  - lease `cbx_19fb48ce19cd`
  - run `run_e8f0c2496053`
  - `src/gateway/server.rpc-wire-contracts.test.ts`: passed
  - `src/gateway/server.agent.rpc-contracts.test.ts`: passed
  - total: 2 files, 2 tests passed
- Scoped changed gate passed on Blacksmith Testbox
  `tbx_01kz4pdhhq8dss6x0znyj4e8p5`: formatting, repository guards, full
  `tsgo` typecheck, full lint, and runtime import-cycle checks all passed.
- QA suite source runs passed at the exact PR head:
  - `gateway-rpc-wire-contracts`: four exact primary IDs
  - `gateway-agent-rpc-contracts`: three exact primary IDs
- Each of the seven coverage IDs occurs in exactly one intended runtime
  scenario.
- `git diff --check`: passed.
- Exact touched-file oxlint: passed.
- Full branch autoreview: clean, no accepted/actionable findings; correctness
  score `0.99`.
