### PR TITLE
fix(agents): use 'unclassified' instead of 'unknown' for uncategorized fallback reasons

### DIFF
--- a/src/agents/embedded-agent-runner/run/failover-policy.test.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.test.ts
@@ -95,6 +95,26 @@ describe("resolveRunFailoverDecision", () => {
     });
   });
 
+  it("falls back with 'unclassified' instead of 'unknown' when no reason was classified (#117366)", () => {
+    // A transient stream disconnect that the message classifier could not tag
+    // must not read as "unknown" in the user-visible fallback notice: that
+    // wrongly implies the selected model itself is unrecognized/unavailable.
+    expect(
+      resolveRunFailoverDecision({
+        stage: "prompt",
+        aborted: false,
+        externalAbort: false,
+        fallbackConfigured: true,
+        failoverFailure: true,
+        failoverReason: null,
+        profileRotated: true,
+      }),
+    ).toEqual({
+      action: "fallback_model",
+      reason: "unclassified",
+    });
+  });
+
   it("sends prompt TLS certificate failures directly to model fallback", () => {
     expect(
       resolveRunFailoverDecision({
@@ -265,6 +285,22 @@ describe("resolveRunFailoverDecision", () => {
     ).toEqual({
       action: "fallback_model",
       reason: "rate_limit",
+    });
+  });
+
+  it("falls back with 'unclassified' instead of 'unknown' for an unclassified assistant failure (#117366)", () => {
+    expect(
+      resolveRunFailoverDecision({
+        stage: "assistant",
+        terminal: { kind: "ok" },
+        fallbackConfigured: true,
+        failoverFailure: true,
+        failoverReason: null,
+        profileRotated: true,
+      }),
+    ).toEqual({
+      action: "fallback_model",
+      reason: "unclassified",
     });
   });
 

--- a/src/agents/embedded-agent-runner/run/failover-policy.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.ts
@@ -142,7 +142,7 @@ function assistantFallbackReason(params: AssistantDecisionParams): FailoverReaso
   if (params.failoverFailure && failoverReason && failoverReason !== "timeout") {
     return failoverReason;
   }
-  return isAssistantTimeoutFailure(params) ? "timeout" : (failoverReason ?? "unknown");
+  return isAssistantTimeoutFailure(params) ? "timeout" : (failoverReason ?? "unclassified");
 }
 
 /** Preserves an existing retry reason unless the current attempt produced a stronger signal. */
@@ -169,7 +169,7 @@ export function resolveRunFailoverDecision(
 export function resolveRunFailoverDecision(params: RunFailoverDecisionParams): RunFailoverDecision {
   if (params.stage === "retry_limit") {
     if (params.fallbackConfigured && shouldEscalateRetryLimit(params.failoverReason)) {
-      const fallbackReason = params.failoverReason ?? "unknown";
+      const fallbackReason = params.failoverReason ?? "unclassified";
       return {
         action: "fallback_model",
         reason: fallbackReason,
@@ -224,7 +224,7 @@ export function resolveRunFailoverDecision(params: RunFailoverDecisionParams): R
     if (params.fallbackConfigured && params.failoverFailure && !isTerminalFormatFailure(params)) {
       return {
         action: "fallback_model",
-        reason: params.failoverReason ?? "unknown",
+        reason: params.failoverReason ?? "unclassified",
       };
     }
     return {

--- a/src/agents/embedded-agent-runner/run/prompt-failure.ts
+++ b/src/agents/embedded-agent-runner/run/prompt-failure.ts
@@ -250,7 +250,7 @@ export async function handleEmbeddedPromptFailure(input: {
     };
   }
   if (failoverDecision.action === "fallback_model") {
-    const fallbackReason = failoverDecision.reason ?? "unknown";
+    const fallbackReason = failoverDecision.reason ?? "unclassified";
     const status = resolveFailoverStatus(fallbackReason);
     input.traceAttempts.push({
       provider: input.provider,


### PR DESCRIPTION
## What Problem This Solves

A transient/uncategorized failure (e.g. a stream disconnect mid-response) that reaches model fallback shows up in the user-visible fallback notice as `; unknown)`, e.g.:

`Model Fallback: openai/gpt-5.5 (selected openai/gpt-5.6-sol; unknown)`

This misleadingly suggests the selected model itself is unrecognized or unavailable, even though the underlying error was already correctly classified elsewhere in the same run as `unclassified` (a distinct, transient-safe category).

## Why This Change Was Made

`resolveRunFailoverDecision` in `src/agents/embedded-agent-runner/run/failover-policy.ts` defaults a `null` `failoverReason` to the literal string `"unknown"` at three sibling call sites when escalating to `fallback_model`:
- the `prompt` stage (line ~227) — the exact site named in the issue
- the `assistant` stage, via `assistantFallbackReason` (line ~145)
- the `retry_limit` stage (line ~172)

`"unclassified"` is already a valid `FailoverReason` member and already renders safely in the fallback notice: `src/auto-reply/fallback-state.ts`'s `TRANSIENT_FALLBACK_REASONS` set already includes `"unclassified"` and treats it as transient-safe. It just was never being passed there — the reason was downgraded to `"unknown"` first. This PR swaps the default at all three sites for consistency, not just the one reported, since they share the identical pattern.

`prompt-failure.ts`'s own `?? "unknown"` fallback (which is unreachable in practice, since `failoverDecision.reason` is typed non-nullable for the `fallback_model` action) is also updated to `"unclassified"` for consistency/defense in depth.

## User Impact

An uncategorized fallback failure now reads as `; unclassified)` in the visible notice instead of `; unknown)`, matching the minimum bar the issue itself calls out as acceptable, without changing behavior for any already-classified reason (`rate_limit`, `timeout`, `tls_certificate`, etc.).

## Evidence

- Root cause confirmed by reading `failover-policy.ts` end-to-end: the three `?? "unknown"` sites are the actual origin; `prompt-failure.ts`'s own fallback is dead code given the non-nullable `fallback_model` reason type.
- Added two regression tests in `failover-policy.test.ts` covering the exact reported scenario (prompt stage) plus the sibling assistant-stage case: `failoverReason: null` reaching `fallback_model` now resolves to `reason: "unclassified"`.
- Full existing `failover-policy.test.ts` suite passes: 48/48 (including the two new tests), verified with `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/failover-policy.test.ts`.
- Formatted with `node_modules/.bin/oxfmt`.

Fixes #117366