### PR TITLE
fix(cli): align TaskFlow controller columns for wide text

### DIFF
--- a/src/commands/flows.test.ts
+++ b/src/commands/flows.test.ts
@@ -1,5 +1,6 @@
 // Flows command tests cover task creation, task execution, and runtime command output.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { visibleWidth } from "../../packages/terminal-core/src/ansi.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { createRunningTaskRun as createRunningTaskRunOrNull } from "../tasks/task-executor.js";
 import { createManagedTaskFlow as createManagedTaskFlowOrNull } from "../tasks/task-flow-registry.js";
@@ -225,6 +226,38 @@ describe("flows commands", () => {
         .join("\n");
       expect(output).toContain(`${"x".repeat(18)}…`);
       expect(output).not.toContain("\uD83D");
+    });
+  });
+
+  it("keeps TaskFlow columns aligned for wide controller ids", async () => {
+    await withTaskFlowCommandStateDir(async () => {
+      const controllers = [
+        { controllerId: "plain-controller", goal: "Plain controller" },
+        { controllerId: "控制器🚀", goal: "Wide controller" },
+        { controllerId: "控制器".repeat(8), goal: "Long wide controller" },
+      ];
+      for (const [index, entry] of controllers.entries()) {
+        createManagedTaskFlow({
+          ownerKey: "agent:main:main",
+          controllerId: entry.controllerId,
+          goal: entry.goal,
+          status: "running",
+          createdAt: 100 + index,
+          updatedAt: 100 + index,
+        });
+      }
+      const runtime = createRuntime();
+
+      await flowsListCommand({}, runtime);
+
+      const lines = vi.mocked(runtime.log).mock.calls.map(([line]) => String(line));
+      const countColumnWidths = controllers.map((entry) => {
+        const line = lines.find((candidate) => candidate.endsWith(entry.goal));
+        expect(line).toBeDefined();
+        return visibleWidth((line ?? "").slice(0, (line ?? "").indexOf("0 active/0 total")));
+      });
+      expect(new Set(countColumnWidths).size).toBe(1);
+      expect(lines.find((line) => line.endsWith("Long wide controller"))).toContain("…");
     });
   });
 

--- a/src/commands/flows.ts
+++ b/src/commands/flows.ts
@@ -2,6 +2,7 @@
 import { timestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { truncateToVisibleWidth, visibleWidth } from "../../packages/terminal-core/src/ansi.js";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import { formatCliCommand } from "../cli/command-format.js";
@@ -46,6 +47,12 @@ function safeFlowDisplayText(value: string | undefined, maxChars?: number): stri
     return "n/a";
   }
   return typeof maxChars === "number" ? truncate(sanitized, maxChars) : sanitized;
+}
+
+function formatFlowTableCell(value: string | undefined, width: number): string {
+  const text = safeFlowDisplayText(value);
+  const fitted = visibleWidth(text) > width ? `${truncateToVisibleWidth(text, width - 1)}…` : text;
+  return `${fitted}${" ".repeat(width - visibleWidth(fitted))}`;
 }
 
 function shortToken(value: string | undefined, maxChars = ID_PAD): string {
@@ -96,7 +103,7 @@ function formatFlowRows(flows: TaskFlowRecord[], rich: boolean) {
         flow.syncMode.padEnd(MODE_PAD),
         formatFlowStatusCell(flow.status, rich),
         String(flow.revision).padEnd(REV_PAD),
-        safeFlowDisplayText(flow.controllerId, CTRL_PAD).padEnd(CTRL_PAD),
+        formatFlowTableCell(flow.controllerId, CTRL_PAD),
         counts.padEnd(14),
         safeFlowDisplayText(flow.goal, 80),
       ].join(" "),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw tasks flow list` shifts the Tasks and Goal columns when a managed TaskFlow controller id contains CJK characters or emoji.

## Why This Change Was Made

Controller cells now truncate and pad by terminal-visible width, using the existing ANSI-aware terminal helpers. ASCII, CJK, and emoji values keep the same fixed-width table layout; JSON output and controller persistence are unchanged.

## User Impact

Operators can scan TaskFlow list output without columns moving between rows, including flows created by Unicode-capable plugins.

## Evidence

- RED live proof on the unmodified production build: real persisted TaskFlows rendered Tasks-column starts at visible columns `65`, `68`, and `84` (`aligned: false`, exit `1`).
- GREEN live proof was rerun after rebasing, from submitted head `b07b889f0782eb1773314f6e65ad20e523ba50ea`. The harness used a fresh test-only state directory, created three managed TaskFlows through the built production registry, and invoked the real `openclaw.mjs --no-color tasks flow list` entrypoint.

Redacted exact-head terminal transcript:

```text
$ git rev-parse HEAD
b07b889f0782eb1773314f6e65ad20e523ba50ea

$ node openclaw.mjs --no-color tasks flow list
TaskFlows: 3
TaskFlow pressure: 3 active · 0 blocked · 0 cancel-requested · 3 total
TaskFlow   Mode           Status     Rev    Controller           Tasks          Goal
<flow-a>-… managed        running    0      控制器控制器控制器…  0 active/0 total Long wide controller
<flow-b>-… managed        running    0      控制器🚀             0 active/0 total Wide controller
<flow-c>-… managed        running    0      plain-controller     0 active/0 total Plain controller

tasksColumn=[65,65,65]
aligned=true
longControllerTruncated=true
exitCode=0
```

- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/commands/flows.test.ts --reporter=dot` — 17 passed.
- `OPENCLAW_BUILD_ALL_NO_PNPM=1 node scripts/tsdown-build.mjs --no-clean` — passed for the exact head above.
- `oxfmt --check` and targeted `oxlint` on both changed files — passed.
- `git diff --check` — passed.
- `node scripts/check-changed.mjs ...` was attempted but blocked by the local Crabbox wrapper failing its own health check before dispatch; no product lint result was claimed.
