### PR TITLE
fix(deps): bump brace-expansion override to 5.0.9 for HIGH advisory 1130705

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ overrides:
   request: npm:@cypress/request@4.0.1
   request-promise: npm:@cypress/request-promise@5.0.0
   basic-ftp: 6.0.2
-  brace-expansion: 5.0.8
+  brace-expansion: 5.0.9
   file-type: 22.0.1
   form-data: 4.0.6
   werift-ice@0.2.2>ip: npm:neoip@3.1.0
@@ -5994,8 +5994,8 @@ packages:
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -13138,7 +13138,7 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -15210,7 +15210,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,7 +20,7 @@ minimumReleaseAgeExclude:
   - "axios"
   - "basic-ftp"
   - "baileys@7.0.0-rc13"
-  - "brace-expansion@5.0.8"
+  - "brace-expansion@5.0.9"
   - "hono"
   - "libopus-wasm@0.2.0"
   - "libsignal@6.0.0"
@@ -134,7 +134,7 @@ overrides:
   request: "npm:@cypress/request@4.0.1"
   request-promise: "npm:@cypress/request-promise@5.0.0"
   basic-ftp: 6.0.2
-  brace-expansion: 5.0.8
+  brace-expansion: 5.0.9
   file-type: 22.0.1
   form-data: 4.0.6
   "werift-ice@0.2.2>ip": "npm:neoip@3.1.0"

--- a/src/node-host/mcp.test.ts
+++ b/src/node-host/mcp.test.ts
@@ -368,32 +368,40 @@ describe("node host MCP manager", () => {
   });
 
   it("isolates an oversized multi-page catalog at the accumulated byte ceiling", async () => {
-    const largeTool = {
-      ...tool("large"),
-      inputSchema: { type: "object" as const, description: "x".repeat(6 * 1024 * 1024) },
-    };
-    const oversized = createClient({
-      list: async (params) =>
-        params?.cursor ? { tools: [largeTool] } : { tools: [largeTool], nextCursor: "next" },
-    });
-    const healthy = createClient({ tools: [tool("search")] });
-    const warn = vi.fn();
-    const manager = await startNodeHostMcpManager(
-      { oversized: { command: "oversized" }, healthy: { command: "healthy" } },
-      {
-        createClient: (serverName) => (serverName === "oversized" ? oversized : healthy),
-        resolveTransport: () => transport,
-        warn,
-      },
-    );
+    // Large-page byte counting must not spend this unrelated wall-clock deadline;
+    // the preceding case separately proves strict catalog timeout enforcement.
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    try {
+      const largeTool = {
+        ...tool("large"),
+        inputSchema: { type: "object" as const, description: "x".repeat(6 * 1024 * 1024) },
+      };
+      const oversized = createClient({
+        list: async (params) =>
+          params?.cursor ? { tools: [largeTool] } : { tools: [largeTool], nextCursor: "next" },
+      });
+      const healthy = createClient({ tools: [tool("search")] });
+      const warn = vi.fn();
+      const manager = await startNodeHostMcpManager(
+        { oversized: { command: "oversized" }, healthy: { command: "healthy" } },
+        {
+          createClient: (serverName) => (serverName === "oversized" ? oversized : healthy),
+          resolveTransport: () => transport,
+          warn,
+        },
+      );
 
-    expect(oversized.listTools).toHaveBeenCalledTimes(2);
-    expect(oversized.close).toHaveBeenCalledOnce();
-    expect(warn).toHaveBeenCalledOnce();
-    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/listing exceeded \d+ bytes/u));
-    expect(manager.descriptors.map((descriptor) => descriptor.name)).toEqual(["healthy_search"]);
+      expect(oversized.listTools).toHaveBeenCalledTimes(2);
+      expect(oversized.close).toHaveBeenCalledOnce();
+      expect(warn).toHaveBeenCalledOnce();
+      expect(warn).toHaveBeenCalledWith(expect.stringMatching(/listing exceeded \d+ bytes/u));
+      expect(manager.descriptors.map((descriptor) => descriptor.name)).toEqual(["healthy_search"]);
 
-    await manager.close();
+      await manager.close();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("isolates a listing that exceeds the retained candidate ceiling", async () => {


### PR DESCRIPTION
## What Problem This Solves

The `security-fast` gate is red on every PR (and will be on main) since GitHub advisory 1130705 published: HIGH severity DoS in `brace-expansion` `>=4.0.0 <5.0.9` (unbounded intermediate arrays bypassing the CVE-2026-14257 mitigation). The repo pins `brace-expansion` at exactly 5.0.8 via the existing workspace override, which is inside the vulnerable range.

## Why This Change Was Made

Bumps the existing exact-version override 5.0.8 → 5.0.9 (the patched release, published 2026-07-30) in both `pnpm-workspace.yaml` spots (override + minimum-release-age exclusion) and regenerates the lockfile. This is remediation of an already-established override, not a new override; exact-versions-only is preserved. Flagging per repo policy since it touches the workspace override surface — the alternative (leaving the gate red) blocks all landings.

## User Impact

None functional; removes a HIGH DoS advisory from production dependencies.

## Evidence

- `pnpm-lock.yaml` resolves only `brace-expansion@5.0.9`
- Named-export surface unchanged (`expand`, `EXPANSION_MAX`, `EXPANSION_MAX_LENGTH`); runtime smoke: `expand("a{1,2}")` → `["a1","a2"]`
- Focused consumer suite (`src/infra/exec-allowlist-pattern.test.ts`) passes
- Structured autoreview: clean (0.99) — bundle consistency across override, exclusion, and lockfile verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Canonical CI-owner repair included

The first exact-head dependency workflow proved the security fix immediately: `node scripts/pre-commit/pnpm-audit-prod.mjs --audit-level=high` reported no high-or-higher advisories. Its sole remaining CI failure exposed the already diagnosed independent MCP 6-MiB pagination regression: synchronous page sizing exhausted a real 50-ms wall-clock deadline under runner load, so an otherwise valid second page was never requested.

To break the dependency ↔ MCP ↔ TUI CI cycle, this PR now also contains the already independently reviewed, project-owner-authored one-file MCP test repair from #118779. It freezes time only for the byte-budget regression and restores real timers in `finally`; production timeout behavior and independent timeout tests remain unchanged. The actual owner test passed 17/17 on the combined commit; previous formal reviews were clean (dependency 0.99; MCP test 0.98). Production-code delta from the MCP repair is zero.