### PR TITLE
test(qa): prove gateway catalog RPCs

### DIFF
--- a/qa/scenarios/runtime/gateway-rpc-identity-presence.yaml
+++ b/qa/scenarios/runtime/gateway-rpc-identity-presence.yaml
@@ -1,0 +1,24 @@
+title: Gateway RPC identity and presence
+
+scenario:
+  id: gateway-rpc-identity-presence
+  surface: runtime
+  coverage:
+    primary:
+      - gateway.identity-and-presence-apis
+  objective: Prove Gateway identity, host information, presence, system-event, and heartbeat RPCs through real WebSocket clients.
+  successCriteria:
+    - Two authenticated clients observe the same stable Gateway process identity.
+    - The system information RPC returns real host and process resource data.
+    - A system event updates the presence snapshot and broadcasts the new presence to another client.
+    - Heartbeat state can be read and toggled, and the test restores heartbeats before shutdown.
+  docsRefs:
+    - docs/gateway/index.md
+  codeRefs:
+    - src/gateway/server-methods/system.ts
+    - src/infra/system-presence.ts
+    - test/e2e/qa-lab/runtime/gateway-rpc-identity-presence.e2e.test.ts
+  execution:
+    kind: vitest
+    path: test/e2e/qa-lab/runtime/gateway-rpc-identity-presence.e2e.test.ts
+    summary: Start a real token-authenticated Gateway and exercise identity, system information, presence, system-event, and heartbeat RPCs with two WebSocket clients.

--- a/qa/scenarios/runtime/gateway-rpc-models.yaml
+++ b/qa/scenarios/runtime/gateway-rpc-models.yaml
@@ -1,0 +1,25 @@
+title: Gateway RPC model catalog
+
+scenario:
+  id: gateway-rpc-models
+  surface: runtime
+  coverage:
+    primary:
+      - gateway.model-apis
+  objective: Prove the models.list Gateway RPC returns the configured public model catalog without provider secrets or runtime-only fields.
+  successCriteria:
+    - A real authenticated Gateway WebSocket request returns the configured provider and model row.
+    - Public model metadata includes the configured alias and capabilities.
+    - Provider credentials, endpoints, and runtime-only fields are absent from the response.
+    - Invalid request parameters are rejected by the runtime method validator.
+  docsRefs:
+    - docs/concepts/models.md
+    - docs/gateway/index.md
+  codeRefs:
+    - src/gateway/server-methods/models.ts
+    - src/gateway/server-methods/models-list-result.ts
+    - test/e2e/qa-lab/runtime/gateway-rpc-models.e2e.test.ts
+  execution:
+    kind: vitest
+    path: test/e2e/qa-lab/runtime/gateway-rpc-models.e2e.test.ts
+    summary: Start a real Gateway with a synthetic configured provider and inspect models.list over WebSocket.

--- a/qa/scenarios/runtime/gateway-rpc-tools-skills.yaml
+++ b/qa/scenarios/runtime/gateway-rpc-tools-skills.yaml
@@ -1,0 +1,26 @@
+title: Gateway RPC tool and skill catalogs
+
+scenario:
+  id: gateway-rpc-tools-skills
+  surface: runtime
+  coverage:
+    primary:
+      - gateway.tool-and-skill-apis
+  objective: Prove representative command, tool, and local skill catalog RPCs through a real Gateway WebSocket.
+  successCriteria:
+    - commands.list exposes a built-in native command.
+    - tools.catalog exposes a core tool without requiring plugin discovery.
+    - skills.status discovers a temporary workspace skill and its local Skill Card metadata.
+    - skills.skillCard reads the exact local Skill Card content through the Gateway RPC.
+  docsRefs:
+    - docs/tools/index.md
+    - docs/tools/skills.md
+  codeRefs:
+    - src/gateway/server-methods/commands.ts
+    - src/gateway/server-methods/tools-catalog.ts
+    - src/gateway/server-methods/skills.ts
+    - test/e2e/qa-lab/runtime/gateway-rpc-tools-skills.e2e.test.ts
+  execution:
+    kind: vitest
+    path: test/e2e/qa-lab/runtime/gateway-rpc-tools-skills.e2e.test.ts
+    summary: Start a real Gateway with a temporary workspace skill, then read command, tool, skill status, and Skill Card RPC results.

--- a/test/e2e/qa-lab/runtime/gateway-rpc-identity-presence.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-rpc-identity-presence.e2e.test.ts
@@ -1,0 +1,132 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  startGatewayServerHarness,
+  type GatewayServerHarness,
+} from "../../../../src/gateway/server.e2e-ws-harness.js";
+import {
+  installGatewayTestHooks,
+  onceMessage,
+  rpcReq,
+} from "../../../../src/gateway/test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+let harness: GatewayServerHarness;
+
+beforeAll(async () => {
+  harness = await startGatewayServerHarness();
+});
+
+afterAll(async () => {
+  await harness.close();
+});
+
+describe("gateway RPC identity and presence", () => {
+  it("exposes stable identity, host information, presence broadcasts, and heartbeat controls", async () => {
+    const writer = await harness.openClient();
+    const observer = await harness.openClient();
+
+    const writerIdentity = await rpcReq<{
+      deviceId: string;
+      publicKey: string;
+    }>(writer.ws, "gateway.identity.get");
+    const observerIdentity = await rpcReq<{
+      deviceId: string;
+      publicKey: string;
+    }>(observer.ws, "gateway.identity.get");
+    expect(writerIdentity).toMatchObject({ ok: true });
+    expect(observerIdentity.payload).toEqual(writerIdentity.payload);
+    expect(writerIdentity.payload).toEqual({
+      deviceId: expect.any(String),
+      publicKey: expect.any(String),
+    });
+
+    const systemInfo = await rpcReq<{
+      arch: string;
+      cpuCount: number;
+      hostname: string;
+      memoryTotalBytes: number;
+      nodeVersion: string;
+      platform: string;
+      processInstanceId: string;
+    }>(writer.ws, "system.info");
+    expect(systemInfo).toMatchObject({
+      ok: true,
+      payload: {
+        arch: expect.any(String),
+        cpuCount: expect.any(Number),
+        hostname: expect.any(String),
+        memoryTotalBytes: expect.any(Number),
+        nodeVersion: expect.any(String),
+        platform: expect.any(String),
+        processInstanceId: expect.any(String),
+      },
+    });
+    expect(systemInfo.payload?.cpuCount).toBeGreaterThan(0);
+    expect(systemInfo.payload?.memoryTotalBytes).toBeGreaterThan(0);
+
+    const before = await rpcReq<{ length: number }>(observer.ws, "system-presence");
+    expect(before.ok).toBe(true);
+    expect(Array.isArray(before.payload)).toBe(true);
+
+    const presenceEvent = onceMessage(
+      observer.ws,
+      (frame) =>
+        frame.type === "event" &&
+        frame.event === "presence" &&
+        Array.isArray(frame.payload?.presence) &&
+        frame.payload.presence.some(
+          (entry: { deviceId?: string }) => entry.deviceId === "rpc-catalog-device",
+        ),
+    );
+    const systemEvent = await rpcReq<{ ok: boolean }>(writer.ws, "system-event", {
+      text: "Node: rpc-catalog-host (127.0.0.2) · app 1.0.0 · last input 2s ago · mode qa · reason catalog-proof",
+      deviceId: "rpc-catalog-device",
+      instanceId: "rpc-catalog-instance",
+      host: "rpc-catalog-host",
+      ip: "127.0.0.2",
+      mode: "qa",
+      reason: "catalog-proof",
+      version: "1.0.0",
+    });
+    expect(systemEvent).toMatchObject({ ok: true, payload: { ok: true } });
+    expect(await presenceEvent).toMatchObject({
+      event: "presence",
+      stateVersion: { presence: expect.any(Number) },
+      type: "event",
+    });
+
+    const after = await rpcReq<{
+      find: unknown;
+    }>(observer.ws, "system-presence");
+    expect(after.ok).toBe(true);
+    expect(after.payload).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          deviceId: "rpc-catalog-device",
+          host: "rpc-catalog-host",
+          mode: "qa",
+          reason: "catalog-proof",
+        }),
+      ]),
+    );
+
+    const lastHeartbeat = await rpcReq<Record<string, unknown>>(writer.ws, "last-heartbeat");
+    expect(lastHeartbeat.ok).toBe(true);
+    expect(lastHeartbeat.payload === null || typeof lastHeartbeat.payload === "object").toBe(true);
+
+    try {
+      expect(await rpcReq(writer.ws, "set-heartbeats", { enabled: false })).toMatchObject({
+        ok: true,
+        payload: { enabled: false, ok: true },
+      });
+    } finally {
+      expect(await rpcReq(writer.ws, "set-heartbeats", { enabled: true })).toMatchObject({
+        ok: true,
+        payload: { enabled: true, ok: true },
+      });
+      writer.ws.close();
+      observer.ws.close();
+    }
+  });
+});

--- a/test/e2e/qa-lab/runtime/gateway-rpc-identity-presence.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-rpc-identity-presence.e2e.test.ts
@@ -1,8 +1,10 @@
+import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { openAuthenticatedGatewayWs } from "../../../../src/gateway/shared-auth.test-helpers.js";
 import {
-  startGatewayServerHarness,
-  type GatewayServerHarness,
-} from "../../../../src/gateway/server.e2e-ws-harness.js";
+  disconnectGatewayClient,
+  startGatewayWithClient,
+} from "../../../../src/gateway/test-helpers.e2e.js";
 import {
   installGatewayTestHooks,
   onceMessage,
@@ -11,122 +13,144 @@ import {
 
 installGatewayTestHooks({ scope: "suite" });
 
-let harness: GatewayServerHarness;
+const TOKEN = `rpc-identity-presence-${process.pid}`;
+let started: Awaited<ReturnType<typeof startGatewayWithClient>> | undefined;
 
 beforeAll(async () => {
-  harness = await startGatewayServerHarness();
+  const stateDir = process.env.OPENCLAW_STATE_DIR;
+  if (!stateDir) {
+    throw new Error("OPENCLAW_STATE_DIR is required");
+  }
+  started = await startGatewayWithClient({
+    cfg: { gateway: { auth: { mode: "token", token: TOKEN } } },
+    configPath: path.join(stateDir, "openclaw.json"),
+    token: TOKEN,
+    clientDisplayName: "rpc-identity-presence-bootstrap",
+  });
 });
 
 afterAll(async () => {
-  await harness.close();
+  if (!started) {
+    return;
+  }
+  await disconnectGatewayClient(started.client).catch(() => undefined);
+  await started.server.close({ reason: "gateway RPC identity and presence proof complete" });
 });
 
 describe("gateway RPC identity and presence", () => {
   it("exposes stable identity, host information, presence broadcasts, and heartbeat controls", async () => {
-    const writer = await harness.openClient();
-    const observer = await harness.openClient();
-
-    const writerIdentity = await rpcReq<{
-      deviceId: string;
-      publicKey: string;
-    }>(writer.ws, "gateway.identity.get");
-    const observerIdentity = await rpcReq<{
-      deviceId: string;
-      publicKey: string;
-    }>(observer.ws, "gateway.identity.get");
-    expect(writerIdentity).toMatchObject({ ok: true });
-    expect(observerIdentity.payload).toEqual(writerIdentity.payload);
-    expect(writerIdentity.payload).toEqual({
-      deviceId: expect.any(String),
-      publicKey: expect.any(String),
-    });
-
-    const systemInfo = await rpcReq<{
-      arch: string;
-      cpuCount: number;
-      hostname: string;
-      memoryTotalBytes: number;
-      nodeVersion: string;
-      platform: string;
-      processInstanceId: string;
-    }>(writer.ws, "system.info");
-    expect(systemInfo).toMatchObject({
-      ok: true,
-      payload: {
-        arch: expect.any(String),
-        cpuCount: expect.any(Number),
-        hostname: expect.any(String),
-        memoryTotalBytes: expect.any(Number),
-        nodeVersion: expect.any(String),
-        platform: expect.any(String),
-        processInstanceId: expect.any(String),
-      },
-    });
-    expect(systemInfo.payload?.cpuCount).toBeGreaterThan(0);
-    expect(systemInfo.payload?.memoryTotalBytes).toBeGreaterThan(0);
-
-    const before = await rpcReq<{ length: number }>(observer.ws, "system-presence");
-    expect(before.ok).toBe(true);
-    expect(Array.isArray(before.payload)).toBe(true);
-
-    const presenceEvent = onceMessage(
-      observer.ws,
-      (frame) =>
-        frame.type === "event" &&
-        frame.event === "presence" &&
-        Array.isArray(frame.payload?.presence) &&
-        frame.payload.presence.some(
-          (entry: { deviceId?: string }) => entry.deviceId === "rpc-catalog-device",
-        ),
-    );
-    const systemEvent = await rpcReq<{ ok: boolean }>(writer.ws, "system-event", {
-      text: "Node: rpc-catalog-host (127.0.0.2) · app 1.0.0 · last input 2s ago · mode qa · reason catalog-proof",
-      deviceId: "rpc-catalog-device",
-      instanceId: "rpc-catalog-instance",
-      host: "rpc-catalog-host",
-      ip: "127.0.0.2",
-      mode: "qa",
-      reason: "catalog-proof",
-      version: "1.0.0",
-    });
-    expect(systemEvent).toMatchObject({ ok: true, payload: { ok: true } });
-    expect(await presenceEvent).toMatchObject({
-      event: "presence",
-      stateVersion: { presence: expect.any(Number) },
-      type: "event",
-    });
-
-    const after = await rpcReq<{
-      find: unknown;
-    }>(observer.ws, "system-presence");
-    expect(after.ok).toBe(true);
-    expect(after.payload).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          deviceId: "rpc-catalog-device",
-          host: "rpc-catalog-host",
-          mode: "qa",
-          reason: "catalog-proof",
-        }),
-      ]),
-    );
-
-    const lastHeartbeat = await rpcReq<Record<string, unknown>>(writer.ws, "last-heartbeat");
-    expect(lastHeartbeat.ok).toBe(true);
-    expect(lastHeartbeat.payload === null || typeof lastHeartbeat.payload === "object").toBe(true);
+    if (!started) {
+      throw new Error("Gateway did not start");
+    }
+    const writer = await openAuthenticatedGatewayWs(started.port, TOKEN);
+    const observer = await openAuthenticatedGatewayWs(started.port, TOKEN);
 
     try {
-      expect(await rpcReq(writer.ws, "set-heartbeats", { enabled: false })).toMatchObject({
-        ok: true,
-        payload: { enabled: false, ok: true },
+      const writerIdentity = await rpcReq<{
+        deviceId: string;
+        publicKey: string;
+      }>(writer, "gateway.identity.get");
+      const observerIdentity = await rpcReq<{
+        deviceId: string;
+        publicKey: string;
+      }>(observer, "gateway.identity.get");
+      expect(writerIdentity).toMatchObject({ ok: true });
+      expect(observerIdentity.payload).toEqual(writerIdentity.payload);
+      expect(writerIdentity.payload).toEqual({
+        deviceId: expect.any(String),
+        publicKey: expect.any(String),
       });
+
+      const systemInfo = await rpcReq<{
+        arch: string;
+        cpuCount: number;
+        hostname: string;
+        memoryTotalBytes: number;
+        nodeVersion: string;
+        platform: string;
+        processInstanceId: string;
+      }>(writer, "system.info");
+      expect(systemInfo).toMatchObject({
+        ok: true,
+        payload: {
+          arch: expect.any(String),
+          cpuCount: expect.any(Number),
+          hostname: expect.any(String),
+          memoryTotalBytes: expect.any(Number),
+          nodeVersion: expect.any(String),
+          platform: expect.any(String),
+          processInstanceId: expect.any(String),
+        },
+      });
+      expect(systemInfo.payload?.cpuCount).toBeGreaterThan(0);
+      expect(systemInfo.payload?.memoryTotalBytes).toBeGreaterThan(0);
+
+      const before = await rpcReq<{ length: number }>(observer, "system-presence");
+      expect(before.ok).toBe(true);
+      expect(Array.isArray(before.payload)).toBe(true);
+
+      const presenceEvent = onceMessage(
+        observer,
+        (frame) =>
+          frame.type === "event" &&
+          frame.event === "presence" &&
+          Array.isArray(frame.payload?.presence) &&
+          frame.payload.presence.some(
+            (entry: { deviceId?: string }) => entry.deviceId === "rpc-catalog-device",
+          ),
+      );
+      const systemEvent = await rpcReq<{ ok: boolean }>(writer, "system-event", {
+        text: "Node: rpc-catalog-host (127.0.0.2) · app 1.0.0 · last input 2s ago · mode qa · reason catalog-proof",
+        deviceId: "rpc-catalog-device",
+        instanceId: "rpc-catalog-instance",
+        host: "rpc-catalog-host",
+        ip: "127.0.0.2",
+        mode: "qa",
+        reason: "catalog-proof",
+        version: "1.0.0",
+      });
+      expect(systemEvent).toMatchObject({ ok: true, payload: { ok: true } });
+      expect(await presenceEvent).toMatchObject({
+        event: "presence",
+        stateVersion: { presence: expect.any(Number) },
+        type: "event",
+      });
+
+      const after = await rpcReq<{
+        find: unknown;
+      }>(observer, "system-presence");
+      expect(after.ok).toBe(true);
+      expect(after.payload).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            deviceId: "rpc-catalog-device",
+            host: "rpc-catalog-host",
+            mode: "qa",
+            reason: "catalog-proof",
+          }),
+        ]),
+      );
+
+      const lastHeartbeat = await rpcReq<Record<string, unknown>>(writer, "last-heartbeat");
+      expect(lastHeartbeat.ok).toBe(true);
+      expect(lastHeartbeat.payload === null || typeof lastHeartbeat.payload === "object").toBe(
+        true,
+      );
+
+      try {
+        expect(await rpcReq(writer, "set-heartbeats", { enabled: false })).toMatchObject({
+          ok: true,
+          payload: { enabled: false, ok: true },
+        });
+      } finally {
+        expect(await rpcReq(writer, "set-heartbeats", { enabled: true })).toMatchObject({
+          ok: true,
+          payload: { enabled: true, ok: true },
+        });
+      }
     } finally {
-      expect(await rpcReq(writer.ws, "set-heartbeats", { enabled: true })).toMatchObject({
-        ok: true,
-        payload: { enabled: true, ok: true },
-      });
-      writer.ws.close();
-      observer.ws.close();
+      writer.close();
+      observer.close();
     }
   });
 });

--- a/test/e2e/qa-lab/runtime/gateway-rpc-models.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-rpc-models.e2e.test.ts
@@ -1,0 +1,146 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  disconnectGatewayClient,
+  startGatewayWithClient,
+} from "../../../../src/gateway/test-helpers.e2e.js";
+import { captureEnv, setTestEnvValue } from "../../../../src/test-utils/env.js";
+
+const TEST_TIMEOUT_MS = 30_000;
+const ENV_KEYS = [
+  "HOME",
+  "USERPROFILE",
+  "OPENCLAW_STATE_DIR",
+  "OPENCLAW_CONFIG_PATH",
+  "OPENCLAW_SKIP_CHANNELS",
+  "OPENCLAW_SKIP_GMAIL_WATCHER",
+  "OPENCLAW_SKIP_CRON",
+  "OPENCLAW_SKIP_CANVAS_HOST",
+  "OPENCLAW_SKIP_BROWSER_CONTROL_SERVER",
+  "OPENCLAW_SKIP_PROVIDERS",
+  "OPENCLAW_TEST_MINIMAL_GATEWAY",
+  "OPENCLAW_BUNDLED_PLUGINS_DIR",
+  "OPENCLAW_DISABLE_BUNDLED_PLUGINS",
+] as const;
+
+async function setupTempHome() {
+  const env = captureEnv([...ENV_KEYS]);
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-rpc-models-"));
+  const stateDir = path.join(home, ".openclaw");
+  const workspace = path.join(home, "workspace");
+  const bundledPlugins = path.join(home, "empty-bundled-plugins");
+  await Promise.all([
+    fs.mkdir(stateDir, { recursive: true }),
+    fs.mkdir(workspace, { recursive: true }),
+    fs.mkdir(bundledPlugins, { recursive: true }),
+  ]);
+  setTestEnvValue("HOME", home);
+  setTestEnvValue("USERPROFILE", home);
+  setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+  setTestEnvValue("OPENCLAW_SKIP_CHANNELS", "1");
+  setTestEnvValue("OPENCLAW_SKIP_GMAIL_WATCHER", "1");
+  setTestEnvValue("OPENCLAW_SKIP_CRON", "1");
+  setTestEnvValue("OPENCLAW_SKIP_CANVAS_HOST", "1");
+  setTestEnvValue("OPENCLAW_SKIP_BROWSER_CONTROL_SERVER", "1");
+  setTestEnvValue("OPENCLAW_BUNDLED_PLUGINS_DIR", bundledPlugins);
+  setTestEnvValue("OPENCLAW_DISABLE_BUNDLED_PLUGINS", "1");
+  delete process.env.OPENCLAW_CONFIG_PATH;
+  delete process.env.OPENCLAW_SKIP_PROVIDERS;
+  delete process.env.OPENCLAW_TEST_MINIMAL_GATEWAY;
+  return {
+    configPath: path.join(stateDir, "openclaw.json"),
+    env,
+    home,
+    workspace,
+  };
+}
+
+describe("gateway RPC model catalog", () => {
+  it(
+    "returns configured public model metadata without provider internals",
+    { timeout: TEST_TIMEOUT_MS },
+    async () => {
+      const temp = await setupTempHome();
+      const token = `rpc-models-${process.pid}`;
+      const modelRef = "fixture/catalog-model";
+      let started: Awaited<ReturnType<typeof startGatewayWithClient>> | undefined;
+
+      try {
+        started = await startGatewayWithClient({
+          cfg: {
+            agents: {
+              defaults: {
+                workspace: temp.workspace,
+                model: { primary: modelRef },
+                models: { [modelRef]: { alias: "Catalog Alias" } },
+              },
+            },
+            gateway: { auth: { mode: "token", token } },
+            models: {
+              mode: "replace",
+              providers: {
+                fixture: {
+                  apiKey: "rpc-model-secret",
+                  baseUrl: "http://127.0.0.1:9/v1",
+                  models: [
+                    {
+                      id: "catalog-model",
+                      name: "Catalog Model",
+                      contextWindow: 8192,
+                      reasoning: true,
+                      compat: { supportsTools: true },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+          configPath: temp.configPath,
+          token,
+          clientDisplayName: "rpc-models-reader",
+        });
+
+        const payload = (await started.client.request("models.list", {
+          view: "configured",
+        })) as {
+          models: Array<Record<string, unknown>>;
+        };
+        expect(payload.models).toEqual([
+          expect.objectContaining({
+            alias: "Catalog Alias",
+            contextWindow: 8192,
+            id: "catalog-model",
+            name: "Catalog Model",
+            provider: "fixture",
+            reasoning: true,
+            supportsTools: true,
+          }),
+        ]);
+        const model = payload.models[0] ?? {};
+        expect(model).not.toHaveProperty("agentRuntime");
+        expect(model).not.toHaveProperty("apiKey");
+        expect(model).not.toHaveProperty("baseUrl");
+        expect(JSON.stringify(payload)).not.toContain("rpc-model-secret");
+
+        await expect(started.client.request("models.list", { unexpected: true })).rejects.toThrow(
+          /invalid models\.list params/i,
+        );
+      } finally {
+        try {
+          if (started) {
+            await disconnectGatewayClient(started.client).catch(() => undefined);
+            await started.server.close({ reason: "gateway RPC model catalog proof complete" });
+          }
+        } finally {
+          try {
+            await fs.rm(temp.home, { force: true, recursive: true });
+          } finally {
+            temp.env.restore();
+          }
+        }
+      }
+    },
+  );
+});

--- a/test/e2e/qa-lab/runtime/gateway-rpc-models.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-rpc-models.e2e.test.ts
@@ -1,14 +1,15 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   disconnectGatewayClient,
   startGatewayWithClient,
 } from "../../../../src/gateway/test-helpers.e2e.js";
 import { captureEnv, setTestEnvValue } from "../../../../src/test-utils/env.js";
+import { useAutoCleanupTempDirTracker } from "../../../helpers/temp-dir.js";
 
 const TEST_TIMEOUT_MS = 30_000;
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const ENV_KEYS = [
   "HOME",
   "USERPROFILE",
@@ -27,7 +28,7 @@ const ENV_KEYS = [
 
 async function setupTempHome() {
   const env = captureEnv([...ENV_KEYS]);
-  const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-rpc-models-"));
+  const home = tempDirs.make("openclaw-rpc-models-");
   const stateDir = path.join(home, ".openclaw");
   const workspace = path.join(home, "workspace");
   const bundledPlugins = path.join(home, "empty-bundled-plugins");
@@ -134,11 +135,7 @@ describe("gateway RPC model catalog", () => {
             await started.server.close({ reason: "gateway RPC model catalog proof complete" });
           }
         } finally {
-          try {
-            await fs.rm(temp.home, { force: true, recursive: true });
-          } finally {
-            temp.env.restore();
-          }
+          temp.env.restore();
         }
       }
     },

--- a/test/e2e/qa-lab/runtime/gateway-rpc-tools-skills.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-rpc-tools-skills.e2e.test.ts
@@ -1,0 +1,166 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  disconnectGatewayClient,
+  startGatewayWithClient,
+} from "../../../../src/gateway/test-helpers.e2e.js";
+import { captureEnv, setTestEnvValue } from "../../../../src/test-utils/env.js";
+
+const TEST_TIMEOUT_MS = 30_000;
+const SKILL_CARD = "# Catalog Proof\n\nLocal Gateway skill-card evidence.\n";
+const ENV_KEYS = [
+  "HOME",
+  "USERPROFILE",
+  "OPENCLAW_STATE_DIR",
+  "OPENCLAW_CONFIG_PATH",
+  "OPENCLAW_SKIP_CHANNELS",
+  "OPENCLAW_SKIP_GMAIL_WATCHER",
+  "OPENCLAW_SKIP_CRON",
+  "OPENCLAW_SKIP_CANVAS_HOST",
+  "OPENCLAW_SKIP_BROWSER_CONTROL_SERVER",
+  "OPENCLAW_SKIP_PROVIDERS",
+  "OPENCLAW_TEST_MINIMAL_GATEWAY",
+  "OPENCLAW_BUNDLED_PLUGINS_DIR",
+  "OPENCLAW_DISABLE_BUNDLED_PLUGINS",
+] as const;
+
+async function setupTempHome() {
+  const env = captureEnv([...ENV_KEYS]);
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-rpc-tools-skills-"));
+  const stateDir = path.join(home, ".openclaw");
+  const workspace = path.join(home, "workspace");
+  const bundledPlugins = path.join(home, "empty-bundled-plugins");
+  const skillDir = path.join(workspace, "skills", "catalog-proof");
+  await Promise.all([
+    fs.mkdir(stateDir, { recursive: true }),
+    fs.mkdir(skillDir, { recursive: true }),
+    fs.mkdir(bundledPlugins, { recursive: true }),
+  ]);
+  await fs.writeFile(
+    path.join(skillDir, "SKILL.md"),
+    [
+      "---",
+      "name: catalog-proof",
+      "description: Fixture skill for Gateway catalog proof.",
+      "---",
+      "",
+      "# Catalog Proof",
+      "",
+      "Use this fixture only for local QA evidence.",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await fs.writeFile(path.join(skillDir, "skill-card.md"), SKILL_CARD, "utf8");
+  setTestEnvValue("HOME", home);
+  setTestEnvValue("USERPROFILE", home);
+  setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+  setTestEnvValue("OPENCLAW_SKIP_CHANNELS", "1");
+  setTestEnvValue("OPENCLAW_SKIP_GMAIL_WATCHER", "1");
+  setTestEnvValue("OPENCLAW_SKIP_CRON", "1");
+  setTestEnvValue("OPENCLAW_SKIP_CANVAS_HOST", "1");
+  setTestEnvValue("OPENCLAW_SKIP_BROWSER_CONTROL_SERVER", "1");
+  setTestEnvValue("OPENCLAW_SKIP_PROVIDERS", "1");
+  setTestEnvValue("OPENCLAW_BUNDLED_PLUGINS_DIR", bundledPlugins);
+  setTestEnvValue("OPENCLAW_DISABLE_BUNDLED_PLUGINS", "1");
+  delete process.env.OPENCLAW_CONFIG_PATH;
+  delete process.env.OPENCLAW_TEST_MINIMAL_GATEWAY;
+  return {
+    configPath: path.join(stateDir, "openclaw.json"),
+    env,
+    home,
+    skillDir,
+    workspace,
+  };
+}
+
+describe("gateway RPC tool and skill catalogs", () => {
+  it(
+    "returns built-in commands, core tools, and a readable workspace skill card",
+    { timeout: TEST_TIMEOUT_MS },
+    async () => {
+      const temp = await setupTempHome();
+      const token = `rpc-tools-skills-${process.pid}`;
+      let started: Awaited<ReturnType<typeof startGatewayWithClient>> | undefined;
+
+      try {
+        started = await startGatewayWithClient({
+          cfg: {
+            agents: { defaults: { workspace: temp.workspace } },
+            gateway: { auth: { mode: "token", token } },
+          },
+          configPath: temp.configPath,
+          token,
+          clientDisplayName: "rpc-tools-skills-reader",
+        });
+
+        const commands = (await started.client.request("commands.list", {})) as {
+          commands: Array<{ name: string; source: string }>;
+        };
+        expect(commands.commands).toEqual(
+          expect.arrayContaining([expect.objectContaining({ name: "model", source: "native" })]),
+        );
+
+        const tools = (await started.client.request("tools.catalog", {
+          includePlugins: false,
+        })) as {
+          groups: Array<{ source: string; tools: Array<{ id: string; source: string }> }>;
+        };
+        expect(tools.groups.flatMap((group) => group.tools)).toEqual(
+          expect.arrayContaining([expect.objectContaining({ id: "tts", source: "core" })]),
+        );
+        expect(tools.groups.some((group) => group.source === "plugin")).toBe(false);
+
+        const status = (await started.client.request("skills.status", {})) as {
+          workspaceDir: string;
+          skills: Array<{
+            name: string;
+            skillKey: string;
+            skillCard?: { path: string; sizeBytes: number };
+          }>;
+        };
+        expect(status.workspaceDir).toBe(temp.workspace);
+        const fixture = status.skills.find((skill) => skill.name === "catalog-proof");
+        expect(fixture).toEqual(
+          expect.objectContaining({
+            name: "catalog-proof",
+            skillKey: "catalog-proof",
+            skillCard: {
+              path: path.join(temp.skillDir, "skill-card.md"),
+              present: true,
+              sizeBytes: Buffer.byteLength(SKILL_CARD),
+            },
+          }),
+        );
+
+        const card = await started.client.request("skills.skillCard", {
+          skillKey: "catalog-proof",
+        });
+        expect(card).toEqual({
+          schema: "openclaw.skills.skill-card.v1",
+          skillKey: "catalog-proof",
+          path: path.join(temp.skillDir, "skill-card.md"),
+          sizeBytes: Buffer.byteLength(SKILL_CARD),
+          content: SKILL_CARD,
+        });
+      } finally {
+        try {
+          if (started) {
+            await disconnectGatewayClient(started.client).catch(() => undefined);
+            await started.server.close({
+              reason: "gateway RPC tool/skill catalog proof complete",
+            });
+          }
+        } finally {
+          try {
+            await fs.rm(temp.home, { force: true, recursive: true });
+          } finally {
+            temp.env.restore();
+          }
+        }
+      }
+    },
+  );
+});

--- a/test/e2e/qa-lab/runtime/gateway-rpc-tools-skills.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-rpc-tools-skills.e2e.test.ts
@@ -1,15 +1,16 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   disconnectGatewayClient,
   startGatewayWithClient,
 } from "../../../../src/gateway/test-helpers.e2e.js";
 import { captureEnv, setTestEnvValue } from "../../../../src/test-utils/env.js";
+import { useAutoCleanupTempDirTracker } from "../../../helpers/temp-dir.js";
 
 const TEST_TIMEOUT_MS = 30_000;
 const SKILL_CARD = "# Catalog Proof\n\nLocal Gateway skill-card evidence.\n";
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const ENV_KEYS = [
   "HOME",
   "USERPROFILE",
@@ -28,7 +29,7 @@ const ENV_KEYS = [
 
 async function setupTempHome() {
   const env = captureEnv([...ENV_KEYS]);
-  const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-rpc-tools-skills-"));
+  const home = tempDirs.make("openclaw-rpc-tools-skills-");
   const stateDir = path.join(home, ".openclaw");
   const workspace = path.join(home, "workspace");
   const bundledPlugins = path.join(home, "empty-bundled-plugins");
@@ -118,7 +119,7 @@ describe("gateway RPC tool and skill catalogs", () => {
           skills: Array<{
             name: string;
             skillKey: string;
-            skillCard?: { path: string; sizeBytes: number };
+            skillCard?: { path: string; present: boolean; sizeBytes: number };
           }>;
         };
         expect(status.workspaceDir).toBe(temp.workspace);
@@ -154,11 +155,7 @@ describe("gateway RPC tool and skill catalogs", () => {
             });
           }
         } finally {
-          try {
-            await fs.rm(temp.home, { force: true, recursive: true });
-          } finally {
-            temp.env.restore();
-          }
+          temp.env.restore();
         }
       }
     },


### PR DESCRIPTION
## What Problem This Solves

Gateway read and catalog RPCs had focused unit coverage but no executed QA
scenarios proving their public WebSocket behavior at the real server boundary.

## Why This Change Was Made

Adds three isolated native QA scenario/test pairs:

- `gateway.identity-and-presence-apis`
- `gateway.model-apis`
- `gateway.tool-and-skill-apis`

The identity scenario starts a token-authenticated Gateway and authenticates
both WebSocket clients. The model and tool/skill scenarios use deterministic
local fixtures. Skill proof is limited to `skills.status` and
`skills.skillCard`; it does not use ClawHub or network access.

## User Impact

No runtime behavior changes. Maintainers gain durable primary evidence for
three Gateway taxonomy targets.

## Evidence

- Frozen head: `792d406fe0bf2196d383fa2d76bbba4be3fb4544`
- Blacksmith Testbox:
  `tbx_01kz4nqg9skehp224pk7zrarcp`
  ([run](https://github.com/openclaw/openclaw/actions/runs/30851317559))
- Private-QA build: passed
- Focused real-Gateway Vitest: 3 files passed, 3 tests passed
- QA Suite: 3 selected scenarios, 3 passing evidence entries
- `pnpm check:changed -- <six QA files>`: passed, including `tsgo`, lint,
  import cycles, formatting, and repository guards
- Autoreview: clean, no findings
  (`019fc962-b117-70f3-bdc9-ddebda5228fb`)
- Previous ClawSweeper authentication finding addressed by authenticating both
  identity/presence clients; fresh review requested on the frozen head

Production LOC delta: 0. The diff contains exactly three scenario YAML files
and three E2E test files.
