### PR TITLE
test: speed up setup inference fixtures

### DIFF
--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -3,12 +3,10 @@ import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { listAgentEntries, resolveAgentDir } from "../agents/agent-scope-config.js";
-import {
-  readAuthProfileStoreForTest,
-  removeOAuthTestTempRoot,
-} from "../agents/auth-profiles/oauth-test-utils.js";
+import { readAuthProfileStoreForTest } from "../agents/auth-profiles/oauth-test-utils.js";
 import { upsertAuthProfileWithLock } from "../agents/auth-profiles/profiles.js";
-import { updateAuthProfileStoreWithLock } from "../agents/auth-profiles/store.js";
+import type { updateAuthProfileStoreWithLock } from "../agents/auth-profiles/store.js";
+import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import { testing as cliBackendsTesting } from "../agents/cli-backends.test-support.js";
 import {
   fingerprintAuthProfileCredential,
@@ -19,8 +17,11 @@ import { detectInferenceBackends } from "../commands/onboard-inference.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
+import { setCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
+import { resolveInstalledPluginIndexPolicyHash } from "../plugins/installed-plugin-index-policy.js";
 import { withoutPluginInstallRecords } from "../plugins/installed-plugin-index-records.js";
 import { hasRetainedManagedNpmInstallMarker } from "../plugins/managed-npm-retention.js";
+import { resolvePluginControlPlaneFingerprint } from "../plugins/plugin-control-plane-context.js";
 import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import type { ProviderAuthChoiceMetadata } from "../plugins/provider-auth-choices.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
@@ -33,7 +34,10 @@ import {
 } from "../plugins/runtime.js";
 import { ensurePluginRegistryLoaded } from "../plugins/runtime/runtime-registry-loader.js";
 import type { ProviderPlugin } from "../plugins/types.js";
-import { disposeOpenClawAgentDatabaseByPath } from "../state/openclaw-agent-db.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  disposeOpenClawAgentDatabaseByPath,
+} from "../state/openclaw-agent-db.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { cleanupSystemAgentSession, createSystemAgentSession } from "./agent-turn.js";
 import { runSystemAgentTurnWithDeps } from "./agent-turn.test-support.js";
@@ -134,6 +138,7 @@ const suiteTempRootTracker = createSuiteTempRootTracker({
 });
 let pluginMetadataSnapshot: SystemAgentPluginMetadataTestSnapshot | undefined;
 let preparedPluginMetadataSnapshot: ReturnType<typeof resolvePluginMetadataSnapshot> | undefined;
+let inMemoryAuthProfileStores = new Map<string, AuthProfileStore>();
 
 beforeAll(async () => {
   pluginMetadataSnapshot = installSystemAgentPluginMetadataTestSnapshot(
@@ -171,7 +176,11 @@ beforeAll(async () => {
 
 afterAll(async () => {
   try {
-    await suiteTempRootTracker.cleanup();
+    try {
+      closeOpenClawAgentDatabasesForTest();
+    } finally {
+      await suiteTempRootTracker.cleanup();
+    }
   } finally {
     cliBackendsTesting.resetDepsForTest();
     pluginMetadataSnapshot?.restore();
@@ -179,6 +188,7 @@ afterAll(async () => {
 });
 
 beforeEach(() => {
+  inMemoryAuthProfileStores = new Map();
   pluginMetadataSnapshot?.rebindForCurrentEnv();
 });
 
@@ -245,9 +255,39 @@ function materializeRuntimeAgentListForTest(config: OpenClawConfig): OpenClawCon
   return next;
 }
 
-function withSuiteTempDirs<
+function readInMemoryAuthProfileStore(agentDir?: string): AuthProfileStore {
+  return structuredClone(
+    inMemoryAuthProfileStores.get(agentDir ?? "default") ?? { version: 1, profiles: {} },
+  );
+}
+
+function loadInMemoryPersistedAuthProfileStore(agentDir?: string): AuthProfileStore | null {
+  const store = inMemoryAuthProfileStores.get(agentDir ?? "default");
+  return store ? structuredClone(store) : null;
+}
+
+function seedInMemoryAuthProfileStore(agentDir: string, store: AuthProfileStore): void {
+  inMemoryAuthProfileStores.set(agentDir, structuredClone(store));
+}
+
+// Every case already has a unique child path. Close their cached databases and
+// remove the shared root once in afterAll instead of recursively deleting each child.
+const removeOAuthTestTempRoot = async (_tempRoot: string) => {};
+
+async function updateInMemoryAuthProfileStoreWithLock(
+  params: Parameters<typeof updateAuthProfileStoreWithLock>[0],
+): ReturnType<typeof updateAuthProfileStoreWithLock> {
+  const key = params.agentDir ?? "default";
+  const store = readInMemoryAuthProfileStore(params.agentDir);
+  if (params.updater(store)) {
+    inMemoryAuthProfileStores.set(key, structuredClone(store));
+  }
+  return structuredClone(store);
+}
+
+function withSuiteFixtures<
   T extends NonNullable<Parameters<typeof activateSetupInferenceImpl>[0]["deps"]>,
->(input: T | undefined): T {
+>(input: T | undefined, useRealAuthProfileStore = false): T {
   // Keep operation dirs real and unique; only their routine cleanup moves to suite teardown.
   const deps = Object.create(
     Object.getPrototypeOf(input ?? {}),
@@ -262,6 +302,24 @@ function withSuiteTempDirs<
   if (!deps.readCodexCliActiveApiKey) {
     deps.readCodexCliActiveApiKey = () => null;
   }
+  deps.resolvePluginMetadataSnapshot ??= bindPreparedPluginMetadataSnapshot;
+  if (!useRealAuthProfileStore) {
+    deps.updateAuthProfileStoreWithLock ??= updateInMemoryAuthProfileStoreWithLock;
+    deps.loadPersistedAuthProfileStore ??= loadInMemoryPersistedAuthProfileStore;
+    deps.loadAuthProfileStoreForRuntime ??= readInMemoryAuthProfileStore as never;
+    deps.ensureAuthProfileStore ??= readInMemoryAuthProfileStore as never;
+  }
+  if (deps.readConfigFileSnapshot) {
+    const readConfigFileSnapshot = deps.readConfigFileSnapshot;
+    deps.readConfigFileSnapshot = (async (...args: Parameters<typeof readConfigFileSnapshot>) => {
+      const snapshot = await readConfigFileSnapshot(...args);
+      bindPreparedPluginMetadataSnapshot({
+        config: snapshot.runtimeConfig ?? snapshot.config,
+        env: process.env,
+      });
+      return snapshot;
+    }) as typeof deps.readConfigFileSnapshot;
+  }
   return deps;
 }
 
@@ -270,15 +328,18 @@ type TestSetupInferenceActivationParams = Omit<
   SetupInferenceActivationParams,
   "runtime" | "surface"
 > &
-  Partial<Pick<SetupInferenceActivationParams, "runtime" | "surface">>;
+  Partial<Pick<SetupInferenceActivationParams, "runtime" | "surface">> & {
+    useRealAuthProfileStore?: boolean;
+  };
 
 async function activateSetupInference(
   params: TestSetupInferenceActivationParams,
 ): ReturnType<typeof activateSetupInferenceImpl> {
-  const deps = withSuiteTempDirs(params.deps);
+  const { useRealAuthProfileStore = false, ...activationParams } = params;
+  const deps = withSuiteFixtures(activationParams.deps, useRealAuthProfileStore);
   const ownerPluginArtifacts = { ownerPluginIds: [], ownerPluginArtifacts: [] } as const;
   const usesRealOwnerBinding =
-    params.deps?.createSystemAgentVerifiedInferenceBinding ===
+    activationParams.deps?.createSystemAgentVerifiedInferenceBinding ===
     createSystemAgentVerifiedInferenceBinding;
   if (!deps.captureSystemAgentOwnerPluginArtifacts && !usesRealOwnerBinding) {
     deps.captureSystemAgentOwnerPluginArtifacts = () => ownerPluginArtifacts;
@@ -300,13 +361,14 @@ async function activateSetupInference(
       const snapshot = await readConfigFileSnapshot(...args);
       const sourceConfig = snapshot.sourceConfig ?? snapshot.config;
       const runtimeConfig = snapshot.runtimeConfig ?? snapshot.config;
+      const materializedRuntimeConfig = runtimeConfig
+        ? materializeRuntimeAgentListForTest(runtimeConfig)
+        : undefined;
       return {
         ...snapshot,
         ...(snapshot.config ? { config: materializeRuntimeAgentListForTest(snapshot.config) } : {}),
         ...(sourceConfig ? { sourceConfig: canonicalizeAgentEntriesForTest(sourceConfig) } : {}),
-        ...(runtimeConfig
-          ? { runtimeConfig: materializeRuntimeAgentListForTest(runtimeConfig) }
-          : {}),
+        ...(materializedRuntimeConfig ? { runtimeConfig: materializedRuntimeConfig } : {}),
       };
     }) as typeof deps.readConfigFileSnapshot;
   }
@@ -339,7 +401,7 @@ async function activateSetupInference(
   return activateSetupInferenceImpl({
     runtime,
     surface: "gateway",
-    ...params,
+    ...activationParams,
     // Most activation tests isolate commit mechanics from the verified-owner
     // implementation. Owner-CAS regressions opt back into the real helper.
     deps,
@@ -349,7 +411,10 @@ async function activateSetupInference(
 type TestVerifySetupInferenceParams = Omit<
   Parameters<typeof verifySetupInferenceImpl>[0],
   "bindSession" | "runtime"
-> & { runtime?: Parameters<typeof verifySetupInferenceImpl>[0]["runtime"] };
+> & {
+  runtime?: Parameters<typeof verifySetupInferenceImpl>[0]["runtime"];
+  useRealAuthProfileStore?: boolean;
+};
 
 function verifySetupInference(
   params: TestVerifySetupInferenceParams & { bindSession: true },
@@ -360,22 +425,26 @@ function verifySetupInference(
 function verifySetupInference(
   params: TestVerifySetupInferenceParams & { bindSession?: boolean },
 ): Promise<VerifySetupInferenceResult | BoundVerifySetupInferenceResult> {
+  const { useRealAuthProfileStore = false, ...verifyParams } = params;
   return verifySetupInferenceImpl({
     runtime,
-    ...params,
-    deps: withSuiteTempDirs(params.deps),
+    ...verifyParams,
+    deps: withSuiteFixtures(verifyParams.deps, useRealAuthProfileStore),
   } as never);
 }
 
 async function verifySetupInferenceConfig(
   params: Omit<Parameters<typeof verifySetupInferenceConfigImpl>[0], "runtime"> & {
     runtime?: Parameters<typeof verifySetupInferenceConfigImpl>[0]["runtime"];
+    useRealAuthProfileStore?: boolean;
   },
 ): ReturnType<typeof verifySetupInferenceConfigImpl> {
+  const { useRealAuthProfileStore = false, ...verifyParams } = params;
+  bindPreparedPluginMetadataSnapshot({ config: verifyParams.config, env: process.env });
   return verifySetupInferenceConfigImpl({
     runtime,
-    ...params,
-    deps: withSuiteTempDirs(params.deps),
+    ...verifyParams,
+    deps: withSuiteFixtures(verifyParams.deps, useRealAuthProfileStore),
   });
 }
 
@@ -473,6 +542,34 @@ function requirePreparedPluginMetadataSnapshot() {
   return preparedPluginMetadataSnapshot;
 }
 
+function bindPreparedPluginMetadataSnapshot(
+  params: Parameters<typeof resolvePluginMetadataSnapshot>[0],
+) {
+  const prepared = requirePreparedPluginMetadataSnapshot();
+  const policyHash = resolveInstalledPluginIndexPolicyHash(params.config);
+  const index =
+    prepared.index.policyHash === policyHash ? prepared.index : { ...prepared.index, policyHash };
+  const snapshot = {
+    ...prepared,
+    index,
+    policyHash,
+    configFingerprint: resolvePluginControlPlaneFingerprint({
+      config: params.config,
+      env: params.env,
+      index,
+      policyHash,
+      workspaceDir: params.workspaceDir,
+    }),
+    ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+  };
+  setCurrentPluginMetadataSnapshot(snapshot, {
+    config: params.config,
+    env: params.env,
+    workspaceDir: params.workspaceDir,
+  });
+  return snapshot;
+}
+
 function activateCodexSetup(params: Omit<TestSetupInferenceActivationParams, "kind">) {
   return activateSetupInference({
     kind: "codex-cli",
@@ -481,7 +578,6 @@ function activateCodexSetup(params: Omit<TestSetupInferenceActivationParams, "ki
       ensureCodexRuntimePlugin: mockCodexRuntimeInstall(),
       runEmbeddedAgent: vi.fn(successfulRunner("openai", "gpt-5.6-sol")) as never,
       refreshPluginRegistryAfterConfigMutation: vi.fn(async () => {}) as never,
-      resolvePluginMetadataSnapshot: requirePreparedPluginMetadataSnapshot,
       ...params.deps,
     },
   });
@@ -1524,6 +1620,7 @@ describe("activateSetupInference", () => {
 
     const result = await activateGroqSetup({
       apiKey: "temporary-plaintext-key",
+      useRealAuthProfileStore: true,
       deps: {
         runEmbeddedAgent: vi.fn(async () => {
           throw new Error("401 invalid_api_key");
@@ -2497,6 +2594,7 @@ describe("activateSetupInference", () => {
       const result = await activateSetupInference({
         kind: "provider-auth",
         authChoice: "openai",
+        useRealAuthProfileStore: true,
         workspace: "/tmp/openclaw-workspace",
         prompter: { note: vi.fn(async () => {}) } as never,
         deps: {
@@ -2591,20 +2689,15 @@ describe("activateSetupInference", () => {
       // Custom agent directories must be bound to their configured owner before
       // the shared per-agent database is created.
       resolveAgentDir(initialConfig, "main");
-      await upsertAuthProfileWithLock({
-        profileId: "groq:legacy",
-        credential:
-          credentialType === "api_key"
-            ? { type: "api_key", provider: "groq", key: "legacy-key" }
-            : { type: "token", provider: "groq", token: "legacy-key" },
-        agentDir,
-      });
-      await updateAuthProfileStoreWithLock({
-        agentDir,
-        updater: (store) => {
-          store.order = { groq: ["groq:legacy"] };
-          return true;
+      seedInMemoryAuthProfileStore(agentDir, {
+        version: 1,
+        profiles: {
+          "groq:legacy":
+            credentialType === "api_key"
+              ? { type: "api_key", provider: "groq", key: "legacy-key" }
+              : { type: "token", provider: "groq", token: "legacy-key" },
         },
+        order: { groq: ["groq:legacy"] },
       });
       const runAuth = vi.fn(async (ctx: { opts?: { token?: string } }) => ({
         profiles: [
@@ -2706,12 +2799,12 @@ describe("activateSetupInference", () => {
             },
           },
         });
-        expect(readAuthProfileStoreForTest(agentDir).profiles[activatedProfileId]).toMatchObject(
+        expect(readInMemoryAuthProfileStore(agentDir).profiles[activatedProfileId]).toMatchObject(
           credentialType === "api_key"
             ? { type: "api_key", provider: "groq", key: "test-groq-key" }
             : { type: "token", provider: "groq", token: "test-groq-key" },
         );
-        expect(readAuthProfileStoreForTest(agentDir).order?.groq).toEqual(["groq:legacy"]);
+        expect(readInMemoryAuthProfileStore(agentDir).order?.groq).toEqual(["groq:legacy"]);
         expect(
           (await resolveSystemAgentConfiguredRouteFromConfig(configHarness.current()))
             ?.authProfileId,
@@ -2755,7 +2848,7 @@ describe("activateSetupInference", () => {
         error: expect.stringContaining('used profile "groq:fallback"'),
       });
       expect(transformConfig).not.toHaveBeenCalled();
-      expect(readAuthProfileStoreForTest(agentDir).profiles).toEqual({});
+      expect(readInMemoryAuthProfileStore(agentDir).profiles).toEqual({});
     } finally {
       await removeOAuthTestTempRoot(stateDir);
     }
@@ -2931,7 +3024,7 @@ describe("activateSetupInference", () => {
       );
       expect(setupProfileIds).toHaveLength(1);
       expect(setupProfileIds[0]).toMatch(/^groq:setup-/);
-      expect(Object.keys(readAuthProfileStoreForTest(agentDir).profiles)).toEqual(setupProfileIds);
+      expect(Object.keys(readInMemoryAuthProfileStore(agentDir).profiles)).toEqual(setupProfileIds);
     } finally {
       await removeOAuthTestTempRoot(stateDir);
     }
@@ -2997,7 +3090,7 @@ describe("activateSetupInference", () => {
       });
       expect(configHarness.current()).toEqual(canonicalizeAgentEntriesForTest(initialConfig));
       expect(
-        Object.keys(readAuthProfileStoreForTest(agentDir).profiles).filter((id) =>
+        Object.keys(readInMemoryAuthProfileStore(agentDir).profiles).filter((id) =>
           id.startsWith("groq:setup-"),
         ),
       ).toEqual([]);
@@ -3014,10 +3107,11 @@ describe("activateSetupInference", () => {
       auth: { profiles: { "groq:default": { provider: "groq", mode: "api_key" } } },
     } satisfies OpenClawConfig;
     resolveAgentDir(initialConfig, "main");
-    await upsertAuthProfileWithLock({
-      profileId: "groq:default",
-      credential: { type: "api_key", provider: "groq", key: "existing-key" },
-      agentDir,
+    seedInMemoryAuthProfileStore(agentDir, {
+      version: 1,
+      profiles: {
+        "groq:default": { type: "api_key", provider: "groq", key: "existing-key" },
+      },
     });
     const transformConfig = vi.fn(async (params: { transform: Function }) => {
       await params.transform(initialConfig, {
@@ -3039,7 +3133,7 @@ describe("activateSetupInference", () => {
         }),
       ).rejects.toThrow("simulated config commit failure");
 
-      const store = readAuthProfileStoreForTest(agentDir);
+      const store = readInMemoryAuthProfileStore(agentDir);
       expect(store.profiles["groq:default"]).toMatchObject({ key: "existing-key" });
       expect(Object.keys(store.profiles).filter((id) => id.startsWith("groq:setup-"))).toEqual([]);
     } finally {
@@ -3080,7 +3174,7 @@ describe("activateSetupInference", () => {
     const updateAuthProfileStore = vi.fn(
       async (params: Parameters<typeof updateAuthProfileStoreWithLock>[0]) => {
         if (params.agentDir !== agentDir) {
-          return await updateAuthProfileStoreWithLock(params);
+          return await updateInMemoryAuthProfileStoreWithLock(params);
         }
         realStoreUpdates += 1;
         params.updater(preexistingStore);
@@ -3102,7 +3196,7 @@ describe("activateSetupInference", () => {
               const resolvedAgentDir = candidateAgentDir ?? resolveAgentDir(initialConfig, "main");
               return resolvedAgentDir === agentDir
                 ? preexistingStore
-                : readAuthProfileStoreForTest(resolvedAgentDir);
+                : loadInMemoryPersistedAuthProfileStore(resolvedAgentDir);
             }) as never,
             transformConfigWithPendingPluginInstalls: transformConfig as never,
           },
@@ -3164,7 +3258,7 @@ describe("activateSetupInference", () => {
 
       expect(readConfigFileSnapshot).toHaveBeenCalledOnce();
       expect(
-        Object.keys(readAuthProfileStoreForTest(agentDir).profiles).filter((id) =>
+        Object.keys(readInMemoryAuthProfileStore(agentDir).profiles).filter((id) =>
           id.startsWith("groq:setup-"),
         ),
       ).toEqual([]);
@@ -3218,7 +3312,7 @@ describe("activateSetupInference", () => {
         }),
       ).rejects.toThrow("credential was retained because the current config may reference it");
 
-      const profileId = Object.keys(readAuthProfileStoreForTest(agentDir).profiles).find((id) =>
+      const profileId = Object.keys(readInMemoryAuthProfileStore(agentDir).profiles).find((id) =>
         id.startsWith("groq:setup-"),
       );
       expect(profileId).toBeDefined();
@@ -3256,7 +3350,7 @@ describe("activateSetupInference", () => {
       ).rejects.toThrow("simulated config commit failure");
 
       expect(
-        Object.keys(readAuthProfileStoreForTest(agentDir).profiles).filter((id) =>
+        Object.keys(readInMemoryAuthProfileStore(agentDir).profiles).filter((id) =>
           id.startsWith("groq:setup-"),
         ),
       ).toEqual([]);
@@ -3289,7 +3383,7 @@ describe("activateSetupInference", () => {
           return null;
         }
       }
-      return await updateAuthProfileStoreWithLock(params);
+      return await updateInMemoryAuthProfileStoreWithLock(params);
     });
     const transformConfig = vi.fn(async (params: { transform: Function }) => {
       await params.transform(concurrentConfig, {
@@ -3323,7 +3417,7 @@ describe("activateSetupInference", () => {
         message: expect.stringContaining("could not confirm removal"),
       });
       expect(
-        Object.keys(readAuthProfileStoreForTest(agentDir).profiles).filter((id) =>
+        Object.keys(readInMemoryAuthProfileStore(agentDir).profiles).filter((id) =>
           id.startsWith("groq:setup-"),
         ),
       ).toHaveLength(1);
@@ -3338,7 +3432,7 @@ describe("activateSetupInference", () => {
     const transformConfig = vi.fn();
     let realStoreUpdates = 0;
     const updateAuthProfileStore = vi.fn(async (params) => {
-      const updated = await updateAuthProfileStoreWithLock(params);
+      const updated = await updateInMemoryAuthProfileStoreWithLock(params);
       if (params.agentDir !== agentDir) {
         return updated;
       }
@@ -3374,7 +3468,7 @@ describe("activateSetupInference", () => {
       expect(transformConfig).not.toHaveBeenCalled();
       expect(realStoreUpdates).toBe(4);
       expect(
-        Object.keys(readAuthProfileStoreForTest(agentDir).profiles).filter((id) =>
+        Object.keys(readInMemoryAuthProfileStore(agentDir).profiles).filter((id) =>
           id.startsWith("groq:setup-"),
         ),
       ).toHaveLength(0);
@@ -3435,7 +3529,7 @@ describe("activateSetupInference", () => {
         /^groq\/llama-3\.3-70b-versatile@groq:setup-/,
       );
       expect(
-        Object.keys(readAuthProfileStoreForTest(agentDir).profiles).filter((id) =>
+        Object.keys(readInMemoryAuthProfileStore(agentDir).profiles).filter((id) =>
           id.startsWith("groq:setup-"),
         ),
       ).toHaveLength(1);
@@ -3460,7 +3554,7 @@ describe("activateSetupInference", () => {
       runEmbeddedAgent: vi.fn(successfulRunner("groq", "llama-3.3-70b-versatile")) as never,
       updateAuthProfileStoreWithLock: vi.fn(async (params) => {
         authWriteDirs.push(params.agentDir ?? "");
-        return await updateAuthProfileStoreWithLock(params);
+        return await updateInMemoryAuthProfileStoreWithLock(params);
       }),
     };
     Object.defineProperty(deps, "transformConfigWithPendingPluginInstalls", {
@@ -3480,7 +3574,7 @@ describe("activateSetupInference", () => {
       ).rejects.toThrow("simulated transformer resolution failure");
 
       expect(authWriteDirs).not.toContain(agentDir);
-      expect(readAuthProfileStoreForTest(agentDir).profiles).toEqual({});
+      expect(readInMemoryAuthProfileStore(agentDir).profiles).toEqual({});
     } finally {
       await removeOAuthTestTempRoot(stateDir);
     }
@@ -3618,7 +3712,7 @@ describe("activateSetupInference", () => {
           model: "claude-sonnet-4.5",
         }),
       );
-      expect(readAuthProfileStoreForTest(agentDir).profiles[activatedProfileId]).toMatchObject({
+      expect(readInMemoryAuthProfileStore(agentDir).profiles[activatedProfileId]).toMatchObject({
         type: "token",
         provider: "github-copilot",
         token: "github-token",
@@ -3634,17 +3728,19 @@ describe("activateSetupInference", () => {
   });
 
   it("does not persist a provider key after a failed live test", async () => {
-    const stateDir = await makeTempDir();
-    const agentDir = path.join(stateDir, "agent");
+    const { stateDir, agentDir, initialConfig } = await createMainAgentFixture();
+    const transformConfig = vi.fn();
 
     try {
       const result = await activateGroqSetup({
         apiKey: "bad-groq-key",
         workspace: "/tmp/openclaw-workspace",
         deps: {
+          readConfigFileSnapshot: mockConfigSnapshot(initialConfig),
           runEmbeddedAgent: vi.fn(async () => {
             throw new Error("401 rejected credential bad-groq-key");
           }) as never,
+          transformConfigWithPendingPluginInstalls: transformConfig as never,
         },
       });
 
@@ -3653,7 +3749,8 @@ describe("activateSetupInference", () => {
         expect(result.error).toContain("401 rejected credential [redacted]");
         expect(result.error).not.toContain("bad-groq-key");
       }
-      expect(readAuthProfileStoreForTest(agentDir).profiles["groq:default"]).toBeUndefined();
+      expect(readInMemoryAuthProfileStore(agentDir).profiles).toEqual({});
+      expect(transformConfig).not.toHaveBeenCalled();
     } finally {
       await removeOAuthTestTempRoot(stateDir);
     }
@@ -3665,7 +3762,7 @@ describe("activateSetupInference", () => {
     const runEmbeddedAgent = vi.fn(async (params: SuccessfulRunParams & { agentDir?: string }) => {
       const profileId = params.authProfileId;
       expect(profileId).toMatch(/^openai:setup-/);
-      expect(readAuthProfileStoreForTest(params.agentDir!).profiles[profileId!]).toMatchObject({
+      expect(readInMemoryAuthProfileStore(params.agentDir!).profiles[profileId!]).toMatchObject({
         type: "api_key",
         provider: "openai",
         key: "codex-api-key",
@@ -3690,7 +3787,7 @@ describe("activateSetupInference", () => {
       expect(result).toMatchObject({ ok: true, modelRef: "openai/gpt-5.6-sol" });
       const profileId = runEmbeddedAgent.mock.calls[0]?.[0].authProfileId;
       expect(profileId).toMatch(/^openai:setup-/);
-      expect(readAuthProfileStoreForTest(agentDir).profiles[profileId!]).toMatchObject({
+      expect(readInMemoryAuthProfileStore(agentDir).profiles[profileId!]).toMatchObject({
         type: "api_key",
         provider: "openai",
         key: "codex-api-key",
@@ -3753,7 +3850,7 @@ describe("activateSetupInference", () => {
         expect(result.error).toContain("401 rejected [redacted]");
         expect(result.error).not.toContain("rejected-codex-key");
       }
-      expect(readAuthProfileStoreForTest(agentDir).profiles).toEqual({});
+      expect(readInMemoryAuthProfileStore(agentDir).profiles).toEqual({});
     } finally {
       await removeOAuthTestTempRoot(stateDir);
     }
@@ -5494,10 +5591,9 @@ describe("verifySetupInference", () => {
     const stateDir = await makeTempDir();
     const agentDir = path.join(stateDir, "configured-agent");
     const profileId = "openai:default";
-    await upsertAuthProfileWithLock({
-      profileId,
-      credential: openAiOAuthCredential("dummy"),
-      agentDir,
+    seedInMemoryAuthProfileStore(agentDir, {
+      version: 1,
+      profiles: { [profileId]: openAiOAuthCredential("dummy") },
     });
     const runEmbeddedAgent = vi.fn(
       async (params: {
@@ -5506,14 +5602,14 @@ describe("verifySetupInference", () => {
       }) => {
         expect(params.agentDir).toBeDefined();
         expect(params.agentDir).not.toBe(agentDir);
-        expect(readAuthProfileStoreForTest(params.agentDir!).profiles[profileId]).toEqual({
+        expect(readInMemoryAuthProfileStore(params.agentDir!).profiles[profileId]).toEqual({
           type: "oauth",
           provider: "openai",
           access: "fake",
           refresh: "fake",
           expires: expect.any(Number),
         });
-        await updateAuthProfileStoreWithLock({
+        await updateInMemoryAuthProfileStoreWithLock({
           agentDir: params.agentDir!,
           updater: ({ profiles }) => {
             profiles[profileId] = openAiOAuthCredential("sample", 7_200_000);
@@ -5572,7 +5668,7 @@ describe("verifySetupInference", () => {
           },
         ],
       });
-      expect(readAuthProfileStoreForTest(agentDir).profiles[profileId]).toEqual({
+      expect(readInMemoryAuthProfileStore(agentDir).profiles[profileId]).toEqual({
         type: "oauth",
         provider: "openai",
         access: "dummy",
@@ -5588,7 +5684,7 @@ describe("verifySetupInference", () => {
     const profileId = "openai:default";
     const runEmbeddedAgent = vi.fn(async (params: { agentDir?: string }) => {
       expect(params.agentDir).toBeDefined();
-      await updateAuthProfileStoreWithLock({
+      await updateInMemoryAuthProfileStoreWithLock({
         agentDir: params.agentDir!,
         updater: ({ profiles }) => {
           profiles[profileId] = openAiOAuthCredential("sample", 7_200_000);
@@ -5903,14 +5999,15 @@ describe("verifySetupInference", () => {
       },
     };
     resolveAgentDir(config, "ops");
-    await upsertAuthProfileWithLock({
-      profileId: testCase.profileId,
-      credential: testCase.credential,
-      agentDir,
+    seedInMemoryAuthProfileStore(agentDir, {
+      version: 1,
+      profiles: { [testCase.profileId]: testCase.credential },
     });
 
     try {
-      const route = await resolveSystemAgentConfiguredRouteFromConfig(config);
+      const route = await resolveSystemAgentConfiguredRouteFromConfig(config, undefined, {
+        loadAuthProfileStoreForRuntime: readInMemoryAuthProfileStore as never,
+      });
       expect(route).toMatchObject({
         runner: "cli",
         provider: "google-gemini-cli",


### PR DESCRIPTION
## Summary

- Reuse one prepared, config-bound plugin metadata snapshot across setup-inference fixture paths instead of rediscovering the plugin inventory.
- Exercise auth persistence orchestration through a per-test in-memory implementation of the existing injected store contract.
- Retain real SQLite integration coverage for successful provider OAuth persistence and dispose-before-remove behavior, while closing remaining cached databases once at suite teardown.

No production code, sharding, workers, scheduling, timeouts, or configuration changed. All test cases remain.

## Performance

Paired on the same AWS Crabbox host with four Vitest workers and separate fresh module caches:

| Measure | Baseline | Patched | Change |
| --- | ---: | ---: | ---: |
| setup-inference test file | 36.344s | 17.701s | -51.3% |
| unit-src Vitest group | 91.09s | 83.32s | -7.77s |
| unit-src wrapper | 95.65s | 87.68s | -7.97s |

Counts were identical: 338 passing and 2 skipped files; 4,148 passing and 12 skipped tests.

## Test plan

- Current-main focused run: 123/123 passing, 18.48s total and 16.05s test time.
- Paired full unit-src run: 4,148 passing and 12 skipped tests before and after.
- Codex autoreview: clean, no accepted or actionable findings.
