### PR TITLE
chore(gateway): cover update and setup RPCs

### DIFF
--- a/qa/scenarios/runtime/update-run-package-self-upgrade.yaml
+++ b/qa/scenarios/runtime/update-run-package-self-upgrade.yaml
@@ -6,11 +6,14 @@ scenario:
   coverage:
     primary:
       - cli.update-status-and-rpc
+      - gateway.update-and-setup-apis
     secondary:
       - cli.managed-gateway-restart
-  objective: Verify an installed OpenClaw 2026.4.26 package upgrades to the resolved latest package through the authenticated Gateway update.run RPC and returns healthy after restart.
+  objective: Verify an installed OpenClaw 2026.4.26 package exercises authenticated wizard setup RPCs, upgrades to the resolved latest package through update.run, and returns healthy after restart.
   successCriteria:
     - The package-backed Docker lane installs and verifies openclaw@2026.4.26 before invoking the authenticated Gateway update.run RPC directly.
+    - Authenticated wizard.start, wizard.status, and wizard.next return valid sanitized step projections before wizard.cancel terminates the setup flow.
+    - A second wizard.start is rejected while setup is active, and cancellation purges the session so a replacement setup can start and cancel cleanly.
     - The lane resolves openclaw@latest before the RPC and rejects a no-op or any installed version that differs from the resolved target.
     - The update RPC succeeds with source and target versions and writes the exact requested restart note into the update sentinel.
     - The restarted Gateway reports the resolved target version, passes health, readiness, and RPC status probes, and reports the QA channel account running.
@@ -22,6 +25,7 @@ scenario:
     - docs/help/testing-updates-plugins.md
   codeRefs:
     - src/gateway/server-methods/update.ts
+    - src/gateway/server-methods/wizard.ts
     - src/infra/restart.ts
     - scripts/e2e/update-run-package-self-upgrade-docker.sh
     - scripts/e2e/lib/upgrade-survivor/update-run-package-self-upgrade.sh
@@ -29,7 +33,7 @@ scenario:
   execution:
     kind: script
     path: test/e2e/qa-lab/runtime/update-run-package-self-upgrade.ts
-    summary: Runs the opt-in package-backed Docker lane for authenticated Gateway update.run self-upgrade and emits source/target, restart sentinel, Gateway health, and QA channel evidence.
+    summary: Runs the opt-in installed-package Docker lane for authenticated wizard and update RPCs, then emits sanitized setup lifecycle, source/target, restart sentinel, Gateway health, and QA channel evidence.
     allowBlockedEvidence: true
     timeoutMs: 3600000
     args:

--- a/qa/scenarios/runtime/update-run-package-self-upgrade.yaml
+++ b/qa/scenarios/runtime/update-run-package-self-upgrade.yaml
@@ -14,7 +14,7 @@ scenario:
     - The package-backed Docker lane builds an isolated production install of openclaw@2026.4.26, overlays its exact-tag private dist, preflight-imports the linked historical QA channel, and separately installs the published source Gateway before invoking update.run.
     - Authenticated wizard.start and wizard.status return valid sanitized projections, the running historical session remains usable by wizard.next, and wizard.cancel terminates the setup flow.
     - A second wizard.start is rejected while setup is active, and cancellation purges the session so a replacement setup can start and cancel cleanly.
-    - After restart, one target-package wizard session proves terminal wizard.status cleanup while an independent session proves wizard.next, duplicate-start rejection, cancellation, settlement-polled purge, and replacement setup.
+    - After restart, one target-package wizard session proves repeated wizard.status retains the running session before explicit cancellation and settlement-polled purge, while its replacement proves wizard.next, duplicate-start rejection, cancellation, settlement-polled purge, and another replacement setup.
     - The lane resolves openclaw@latest before the RPC and rejects a no-op or any installed version that differs from the resolved target.
     - The update RPC succeeds with source and target versions and writes the exact requested restart note into the update sentinel.
     - The restarted Gateway reports the resolved target version, passes health, readiness, and RPC status probes, and reports the QA channel account running.

--- a/qa/scenarios/runtime/update-run-package-self-upgrade.yaml
+++ b/qa/scenarios/runtime/update-run-package-self-upgrade.yaml
@@ -9,11 +9,12 @@ scenario:
       - gateway.update-and-setup-apis
     secondary:
       - cli.managed-gateway-restart
-  objective: Verify an installed OpenClaw 2026.4.26 package exercises authenticated wizard setup RPCs, upgrades to the resolved latest package through update.run, and returns healthy after restart.
+  objective: Verify authenticated setup RPC compatibility before and after an installed OpenClaw 2026.4.26 package upgrades to the resolved latest package through update.run and returns healthy after restart.
   successCriteria:
     - The package-backed Docker lane installs and verifies openclaw@2026.4.26 before invoking the authenticated Gateway update.run RPC directly.
     - Authenticated wizard.start, wizard.status, and wizard.next return valid sanitized step projections before wizard.cancel terminates the setup flow.
     - A second wizard.start is rejected while setup is active, and cancellation purges the session so a replacement setup can start and cancel cleanly.
+    - After restart, one target-package wizard session proves terminal wizard.status cleanup while an independent session proves wizard.next, duplicate-start rejection, cancellation, and purge behavior.
     - The lane resolves openclaw@latest before the RPC and rejects a no-op or any installed version that differs from the resolved target.
     - The update RPC succeeds with source and target versions and writes the exact requested restart note into the update sentinel.
     - The restarted Gateway reports the resolved target version, passes health, readiness, and RPC status probes, and reports the QA channel account running.
@@ -33,7 +34,7 @@ scenario:
   execution:
     kind: script
     path: test/e2e/qa-lab/runtime/update-run-package-self-upgrade.ts
-    summary: Runs the opt-in installed-package Docker lane for authenticated wizard and update RPCs, then emits sanitized setup lifecycle, source/target, restart sentinel, Gateway health, and QA channel evidence.
+    summary: Runs the opt-in installed-package Docker lane for authenticated historical and current wizard lifecycles plus update RPCs, then emits sanitized setup, source/target, restart sentinel, Gateway health, and QA channel evidence.
     allowBlockedEvidence: true
     timeoutMs: 3600000
     args:

--- a/qa/scenarios/runtime/update-run-package-self-upgrade.yaml
+++ b/qa/scenarios/runtime/update-run-package-self-upgrade.yaml
@@ -11,10 +11,10 @@ scenario:
       - cli.managed-gateway-restart
   objective: Verify authenticated setup RPC compatibility before and after an installed OpenClaw 2026.4.26 package upgrades to the resolved latest package through update.run and returns healthy after restart.
   successCriteria:
-    - The package-backed Docker lane installs and verifies openclaw@2026.4.26 before invoking the authenticated Gateway update.run RPC directly.
-    - Authenticated wizard.start, wizard.status, and wizard.next return valid sanitized step projections before wizard.cancel terminates the setup flow.
+    - The package-backed Docker lane builds an isolated production install of openclaw@2026.4.26, overlays its exact-tag private dist, preflight-imports the linked historical QA channel, and separately installs the published source Gateway before invoking update.run.
+    - Authenticated wizard.start and wizard.status return valid sanitized projections, the running historical session remains usable by wizard.next, and wizard.cancel terminates the setup flow.
     - A second wizard.start is rejected while setup is active, and cancellation purges the session so a replacement setup can start and cancel cleanly.
-    - After restart, one target-package wizard session proves terminal wizard.status cleanup while an independent session proves wizard.next, duplicate-start rejection, cancellation, and purge behavior.
+    - After restart, one target-package wizard session proves terminal wizard.status cleanup while an independent session proves wizard.next, duplicate-start rejection, cancellation, settlement-polled purge, and replacement setup.
     - The lane resolves openclaw@latest before the RPC and rejects a no-op or any installed version that differs from the resolved target.
     - The update RPC succeeds with source and target versions and writes the exact requested restart note into the update sentinel.
     - The restarted Gateway reports the resolved target version, passes health, readiness, and RPC status probes, and reports the QA channel account running.

--- a/scripts/e2e/lib/upgrade-survivor/update-run-package-self-upgrade.sh
+++ b/scripts/e2e/lib/upgrade-survivor/update-run-package-self-upgrade.sh
@@ -57,6 +57,25 @@ GATEWAY_STATUS_JSON="$ARTIFACT_DIR/gateway-status.json"
 GATEWAY_STATUS_ERR="$ARTIFACT_DIR/gateway-status.err"
 CHANNELS_STATUS_JSON="$ARTIFACT_DIR/channels-status.json"
 CHANNELS_STATUS_ERR="$ARTIFACT_DIR/channels-status.err"
+WIZARD_START_JSON="$ARTIFACT_DIR/wizard-start.json"
+WIZARD_START_ERR="$ARTIFACT_DIR/wizard-start.err"
+WIZARD_STATUS_JSON="$ARTIFACT_DIR/wizard-status.json"
+WIZARD_STATUS_ERR="$ARTIFACT_DIR/wizard-status.err"
+WIZARD_NEXT_JSON="$ARTIFACT_DIR/wizard-next.json"
+WIZARD_NEXT_ERR="$ARTIFACT_DIR/wizard-next.err"
+WIZARD_DUPLICATE_JSON="$ARTIFACT_DIR/wizard-duplicate-start.json"
+WIZARD_DUPLICATE_ERR="$ARTIFACT_DIR/wizard-duplicate-start.err"
+WIZARD_CANCEL_JSON="$ARTIFACT_DIR/wizard-cancel.json"
+WIZARD_CANCEL_ERR="$ARTIFACT_DIR/wizard-cancel.err"
+WIZARD_CANCELLED_STATUS_JSON="$ARTIFACT_DIR/wizard-cancelled-status.json"
+WIZARD_CANCELLED_STATUS_ERR="$ARTIFACT_DIR/wizard-cancelled-status.err"
+WIZARD_REPLACEMENT_START_JSON="$ARTIFACT_DIR/wizard-replacement-start.json"
+WIZARD_REPLACEMENT_START_ERR="$ARTIFACT_DIR/wizard-replacement-start.err"
+WIZARD_REPLACEMENT_CANCEL_JSON="$ARTIFACT_DIR/wizard-replacement-cancel.json"
+WIZARD_REPLACEMENT_CANCEL_ERR="$ARTIFACT_DIR/wizard-replacement-cancel.err"
+WIZARD_REPLACEMENT_STATUS_JSON="$ARTIFACT_DIR/wizard-replacement-status.json"
+WIZARD_REPLACEMENT_STATUS_ERR="$ARTIFACT_DIR/wizard-replacement-status.err"
+WIZARD_FLOW_JSON="$ARTIFACT_DIR/wizard-flow.json"
 SUMMARY_JSON="$ARTIFACT_DIR/summary.json"
 SYSTEMCTL_SHIM_LOG="$ARTIFACT_DIR/systemctl-shim.log"
 SYSTEMCTL_SHIM_SETUP_LOG="$ARTIFACT_DIR/systemctl-shim-setup.log"
@@ -86,6 +105,7 @@ rm -f \
   "$UPDATE_STATUS_JSON" \
   "$UPDATE_STATUS_ERR" \
   "$ARTIFACT_DIR/update-status.candidate.json" \
+  "$WIZARD_FLOW_JSON" \
   "$SUMMARY_JSON"
 : >"$SYSTEMCTL_SHIM_DAEMON_LOG"
 
@@ -334,6 +354,197 @@ gateway_call channels.status '{"probe":false,"timeoutMs":2000}' \
   "$ARTIFACT_DIR/channels-status-before.json" \
   "$ARTIFACT_DIR/channels-status-before.err"
 
+echo "Exercising authenticated Gateway wizard RPC lifecycle"
+gateway_call wizard.start '{"mode":"local"}' "$WIZARD_START_JSON" "$WIZARD_START_ERR"
+wizard_session_id="$(
+  node -e '
+    const fs = require("node:fs");
+    const payload = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+    if (
+      typeof payload?.sessionId !== "string" ||
+      !payload.sessionId ||
+      payload.done !== false ||
+      payload.status !== "running" ||
+      typeof payload.step?.id !== "string"
+    ) {
+      throw new Error(`unexpected wizard.start result: ${JSON.stringify(payload)}`);
+    }
+    process.stdout.write(payload.sessionId);
+  ' "$WIZARD_START_JSON"
+)"
+wizard_step_id="$(
+  node -e '
+    const fs = require("node:fs");
+    const payload = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+    process.stdout.write(payload.step.id);
+  ' "$WIZARD_START_JSON"
+)"
+wizard_session_params="$(
+  WIZARD_SESSION_ID="$wizard_session_id" node -e '
+    process.stdout.write(JSON.stringify({ sessionId: process.env.WIZARD_SESSION_ID }));
+  '
+)"
+gateway_call wizard.status "$wizard_session_params" "$WIZARD_STATUS_JSON" "$WIZARD_STATUS_ERR"
+wizard_next_params="$(
+  WIZARD_SESSION_ID="$wizard_session_id" WIZARD_STEP_ID="$wizard_step_id" node -e '
+    process.stdout.write(
+      JSON.stringify({
+        sessionId: process.env.WIZARD_SESSION_ID,
+        answer: { stepId: process.env.WIZARD_STEP_ID, value: null },
+      }),
+    );
+  '
+)"
+gateway_call wizard.next "$wizard_next_params" "$WIZARD_NEXT_JSON" "$WIZARD_NEXT_ERR"
+
+if gateway_call wizard.start '{"mode":"local"}' \
+  "$WIZARD_DUPLICATE_JSON" "$WIZARD_DUPLICATE_ERR"; then
+  echo "wizard.start unexpectedly allowed an overlapping setup session" >&2
+  exit 1
+fi
+if ! grep -Fq "wizard already running" "$WIZARD_DUPLICATE_ERR"; then
+  echo "overlapping wizard.start failed without the expected rejection" >&2
+  openclaw_e2e_print_log "$WIZARD_DUPLICATE_ERR" >&2
+  exit 1
+fi
+
+gateway_call wizard.cancel "$wizard_session_params" "$WIZARD_CANCEL_JSON" "$WIZARD_CANCEL_ERR"
+if gateway_call wizard.status "$wizard_session_params" \
+  "$WIZARD_CANCELLED_STATUS_JSON" "$WIZARD_CANCELLED_STATUS_ERR"; then
+  echo "cancelled wizard session remained reachable" >&2
+  exit 1
+fi
+if ! grep -Fq "wizard not found" "$WIZARD_CANCELLED_STATUS_ERR"; then
+  echo "cancelled wizard cleanup failed without the expected not-found result" >&2
+  openclaw_e2e_print_log "$WIZARD_CANCELLED_STATUS_ERR" >&2
+  exit 1
+fi
+
+gateway_call wizard.start '{"mode":"local"}' \
+  "$WIZARD_REPLACEMENT_START_JSON" "$WIZARD_REPLACEMENT_START_ERR"
+replacement_session_id="$(
+  node -e '
+    const fs = require("node:fs");
+    const payload = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+    if (
+      typeof payload?.sessionId !== "string" ||
+      !payload.sessionId ||
+      payload.done !== false ||
+      payload.status !== "running"
+    ) {
+      throw new Error(`unexpected replacement wizard.start result: ${JSON.stringify(payload)}`);
+    }
+    process.stdout.write(payload.sessionId);
+  ' "$WIZARD_REPLACEMENT_START_JSON"
+)"
+replacement_session_params="$(
+  WIZARD_SESSION_ID="$replacement_session_id" node -e '
+    process.stdout.write(JSON.stringify({ sessionId: process.env.WIZARD_SESSION_ID }));
+  '
+)"
+gateway_call wizard.cancel "$replacement_session_params" \
+  "$WIZARD_REPLACEMENT_CANCEL_JSON" "$WIZARD_REPLACEMENT_CANCEL_ERR"
+if gateway_call wizard.status "$replacement_session_params" \
+  "$WIZARD_REPLACEMENT_STATUS_JSON" "$WIZARD_REPLACEMENT_STATUS_ERR"; then
+  echo "replacement wizard session remained reachable after cancellation" >&2
+  exit 1
+fi
+if ! grep -Fq "wizard not found" "$WIZARD_REPLACEMENT_STATUS_ERR"; then
+  echo "replacement wizard cleanup failed without the expected not-found result" >&2
+  openclaw_e2e_print_log "$WIZARD_REPLACEMENT_STATUS_ERR" >&2
+  exit 1
+fi
+
+WIZARD_START_JSON="$WIZARD_START_JSON" \
+  WIZARD_STATUS_JSON="$WIZARD_STATUS_JSON" \
+  WIZARD_NEXT_JSON="$WIZARD_NEXT_JSON" \
+  WIZARD_CANCEL_JSON="$WIZARD_CANCEL_JSON" \
+  WIZARD_REPLACEMENT_START_JSON="$WIZARD_REPLACEMENT_START_JSON" \
+  WIZARD_REPLACEMENT_CANCEL_JSON="$WIZARD_REPLACEMENT_CANCEL_JSON" \
+  WIZARD_FLOW_JSON="$WIZARD_FLOW_JSON" \
+  node -e '
+    const fs = require("node:fs");
+    const readJson = (file) => JSON.parse(fs.readFileSync(file, "utf8"));
+    const sanitizeStep = (step, label) => {
+      if (!step || typeof step.id !== "string" || !step.id) {
+        throw new Error(`${label} omitted its wizard step`);
+      }
+      const allowedTypes = new Set([
+        "note",
+        "select",
+        "text",
+        "confirm",
+        "multiselect",
+        "progress",
+        "action",
+      ]);
+      if (!allowedTypes.has(step.type)) {
+        throw new Error(`${label} returned unsupported step type ${String(step.type)}`);
+      }
+      if (step.sensitive === true && Object.hasOwn(step, "initialValue")) {
+        throw new Error(`${label} exposed a sensitive initial value`);
+      }
+      for (const field of ["title", "message", "placeholder"]) {
+        if (step[field] !== undefined && typeof step[field] !== "string") {
+          throw new Error(`${label} returned non-string ${field}`);
+        }
+        if (step[field]?.length > 8192) {
+          throw new Error(`${label} returned oversized ${field}`);
+        }
+      }
+      if (step.options !== undefined && !Array.isArray(step.options)) {
+        throw new Error(`${label} returned malformed options`);
+      }
+      return {
+        type: step.type,
+        executor: step.executor,
+        sensitive: step.sensitive === true,
+        initialValuePresent: Object.hasOwn(step, "initialValue"),
+        titleLength: step.title?.length ?? 0,
+        messageLength: step.message?.length ?? 0,
+        optionCount: step.options?.length ?? 0,
+      };
+    };
+    const start = readJson(process.env.WIZARD_START_JSON);
+    const status = readJson(process.env.WIZARD_STATUS_JSON);
+    const next = readJson(process.env.WIZARD_NEXT_JSON);
+    const cancel = readJson(process.env.WIZARD_CANCEL_JSON);
+    const replacementStart = readJson(process.env.WIZARD_REPLACEMENT_START_JSON);
+    const replacementCancel = readJson(process.env.WIZARD_REPLACEMENT_CANCEL_JSON);
+    if (status.status !== "running") {
+      throw new Error(`wizard.status was not running: ${JSON.stringify(status)}`);
+    }
+    if (next.done !== false || next.status !== "running") {
+      throw new Error(`wizard.next did not advance a running session: ${JSON.stringify(next)}`);
+    }
+    if (cancel.status !== "cancelled" || replacementCancel.status !== "cancelled") {
+      throw new Error("wizard.cancel did not cancel both sessions");
+    }
+    fs.writeFileSync(
+      process.env.WIZARD_FLOW_JSON,
+      `${JSON.stringify(
+        {
+          status: "passed",
+          authenticated: true,
+          start: { status: start.status, step: sanitizeStep(start.step, "wizard.start") },
+          statusPoll: status.status,
+          next: { status: next.status, step: sanitizeStep(next.step, "wizard.next") },
+          duplicateStartRejected: true,
+          cancelStatus: cancel.status,
+          cancelledSessionPurged: true,
+          replacement: {
+            status: replacementStart.status,
+            step: sanitizeStep(replacementStart.step, "replacement wizard.start"),
+            cancelStatus: replacementCancel.status,
+            purged: true,
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+  '
+
 update_params="$(
   RESTART_NOTE="$RESTART_NOTE" node -e '
     process.stdout.write(
@@ -491,6 +702,7 @@ SOURCE_VERSION="$SOURCE_VERSION" \
   POST_RESTART_OBSERVED_AT_MS="$post_restart_observed_at_ms" \
   UPDATE_RPC_JSON="$UPDATE_RPC_JSON" \
   UPDATE_STATUS_JSON="$UPDATE_STATUS_JSON" \
+  WIZARD_FLOW_JSON="$WIZARD_FLOW_JSON" \
   QA_CHANNEL_INSTALL_RECORD_JSON="$QA_CHANNEL_INSTALL_RECORD_JSON" \
   TARGET_PLUGIN_INDEX_JSON="$TARGET_PLUGIN_INDEX_JSON" \
   SOURCE_PLUGIN_INSPECT_JSON="$SOURCE_PLUGIN_INSPECT_JSON" \
@@ -533,6 +745,7 @@ SOURCE_VERSION="$SOURCE_VERSION" \
       expectedRestartNote: process.env.RESTART_NOTE,
       updateRpcCompletedAtMs: Number(process.env.UPDATE_RPC_COMPLETED_AT_MS),
       postRestartObservedAtMs: postRestartAtMs,
+      wizardFlow: readJson(process.env.WIZARD_FLOW_JSON),
       updateRpcResult: readJson(process.env.UPDATE_RPC_JSON),
       restartSentinel: updateStatus.sentinel,
       qaChannelInstallRecord: readJson(process.env.QA_CHANNEL_INSTALL_RECORD_JSON),

--- a/scripts/e2e/lib/upgrade-survivor/update-run-package-self-upgrade.sh
+++ b/scripts/e2e/lib/upgrade-survivor/update-run-package-self-upgrade.sh
@@ -76,6 +76,25 @@ WIZARD_REPLACEMENT_CANCEL_ERR="$ARTIFACT_DIR/wizard-replacement-cancel.err"
 WIZARD_REPLACEMENT_STATUS_JSON="$ARTIFACT_DIR/wizard-replacement-status.json"
 WIZARD_REPLACEMENT_STATUS_ERR="$ARTIFACT_DIR/wizard-replacement-status.err"
 WIZARD_FLOW_JSON="$ARTIFACT_DIR/wizard-flow.json"
+TARGET_WIZARD_STATUS_START_JSON="$ARTIFACT_DIR/target-wizard-status-start.json"
+TARGET_WIZARD_STATUS_START_ERR="$ARTIFACT_DIR/target-wizard-status-start.err"
+TARGET_WIZARD_STATUS_JSON="$ARTIFACT_DIR/target-wizard-status.json"
+TARGET_WIZARD_STATUS_ERR="$ARTIFACT_DIR/target-wizard-status.err"
+TARGET_WIZARD_STATUS_PURGED_JSON="$ARTIFACT_DIR/target-wizard-status-purged.json"
+TARGET_WIZARD_STATUS_PURGED_ERR="$ARTIFACT_DIR/target-wizard-status-purged.err"
+TARGET_WIZARD_ACTIVE_START_JSON="$ARTIFACT_DIR/target-wizard-active-start.json"
+TARGET_WIZARD_ACTIVE_START_ERR="$ARTIFACT_DIR/target-wizard-active-start.err"
+TARGET_WIZARD_NEXT_JSON="$ARTIFACT_DIR/target-wizard-next.json"
+TARGET_WIZARD_NEXT_ERR="$ARTIFACT_DIR/target-wizard-next.err"
+TARGET_WIZARD_DUPLICATE_JSON="$ARTIFACT_DIR/target-wizard-duplicate-start.json"
+TARGET_WIZARD_DUPLICATE_ERR="$ARTIFACT_DIR/target-wizard-duplicate-start.err"
+TARGET_WIZARD_CANCEL_JSON="$ARTIFACT_DIR/target-wizard-cancel.json"
+TARGET_WIZARD_CANCEL_ERR="$ARTIFACT_DIR/target-wizard-cancel.err"
+TARGET_WIZARD_CANCELLED_STATUS_JSON="$ARTIFACT_DIR/target-wizard-cancelled-status.json"
+TARGET_WIZARD_CANCELLED_STATUS_ERR="$ARTIFACT_DIR/target-wizard-cancelled-status.err"
+TARGET_WIZARD_PURGED_STATUS_JSON="$ARTIFACT_DIR/target-wizard-purged-status.json"
+TARGET_WIZARD_PURGED_STATUS_ERR="$ARTIFACT_DIR/target-wizard-purged-status.err"
+TARGET_WIZARD_FLOW_JSON="$ARTIFACT_DIR/target-wizard-flow.json"
 SUMMARY_JSON="$ARTIFACT_DIR/summary.json"
 SYSTEMCTL_SHIM_LOG="$ARTIFACT_DIR/systemctl-shim.log"
 SYSTEMCTL_SHIM_SETUP_LOG="$ARTIFACT_DIR/systemctl-shim-setup.log"
@@ -106,6 +125,7 @@ rm -f \
   "$UPDATE_STATUS_ERR" \
   "$ARTIFACT_DIR/update-status.candidate.json" \
   "$WIZARD_FLOW_JSON" \
+  "$TARGET_WIZARD_FLOW_JSON" \
   "$SUMMARY_JSON"
 : >"$SYSTEMCTL_SHIM_DAEMON_LOG"
 
@@ -637,6 +657,227 @@ if [ ! -f "$UPDATE_STATUS_JSON" ]; then
   exit 1
 fi
 
+echo "Exercising current target Gateway wizard RPC lifecycle"
+gateway_call wizard.start '{"mode":"local"}' \
+  "$TARGET_WIZARD_STATUS_START_JSON" "$TARGET_WIZARD_STATUS_START_ERR"
+target_status_session_id="$(
+  node -e '
+    const fs = require("node:fs");
+    const payload = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+    if (
+      typeof payload?.sessionId !== "string" ||
+      !payload.sessionId ||
+      payload.done !== false ||
+      payload.status !== "running" ||
+      typeof payload.step?.id !== "string"
+    ) {
+      throw new Error(`unexpected target wizard.start result: ${JSON.stringify(payload)}`);
+    }
+    process.stdout.write(payload.sessionId);
+  ' "$TARGET_WIZARD_STATUS_START_JSON"
+)"
+target_status_session_params="$(
+  WIZARD_SESSION_ID="$target_status_session_id" node -e '
+    process.stdout.write(JSON.stringify({ sessionId: process.env.WIZARD_SESSION_ID }));
+  '
+)"
+gateway_call wizard.status "$target_status_session_params" \
+  "$TARGET_WIZARD_STATUS_JSON" "$TARGET_WIZARD_STATUS_ERR"
+if gateway_call wizard.status "$target_status_session_params" \
+  "$TARGET_WIZARD_STATUS_PURGED_JSON" "$TARGET_WIZARD_STATUS_PURGED_ERR"; then
+  echo "target wizard.status did not terminate and purge its session" >&2
+  exit 1
+fi
+if ! grep -Fq "wizard not found" "$TARGET_WIZARD_STATUS_PURGED_ERR"; then
+  echo "target terminal wizard.status failed without the expected not-found result" >&2
+  openclaw_e2e_print_log "$TARGET_WIZARD_STATUS_PURGED_ERR" >&2
+  exit 1
+fi
+
+gateway_call wizard.start '{"mode":"local"}' \
+  "$TARGET_WIZARD_ACTIVE_START_JSON" "$TARGET_WIZARD_ACTIVE_START_ERR"
+target_active_session_id="$(
+  node -e '
+    const fs = require("node:fs");
+    const payload = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+    if (
+      typeof payload?.sessionId !== "string" ||
+      !payload.sessionId ||
+      payload.done !== false ||
+      payload.status !== "running" ||
+      typeof payload.step?.id !== "string"
+    ) {
+      throw new Error(`unexpected target active wizard.start result: ${JSON.stringify(payload)}`);
+    }
+    process.stdout.write(payload.sessionId);
+  ' "$TARGET_WIZARD_ACTIVE_START_JSON"
+)"
+target_active_step_id="$(
+  node -e '
+    const fs = require("node:fs");
+    const payload = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+    process.stdout.write(payload.step.id);
+  ' "$TARGET_WIZARD_ACTIVE_START_JSON"
+)"
+target_active_session_params="$(
+  WIZARD_SESSION_ID="$target_active_session_id" node -e '
+    process.stdout.write(JSON.stringify({ sessionId: process.env.WIZARD_SESSION_ID }));
+  '
+)"
+target_active_next_params="$(
+  WIZARD_SESSION_ID="$target_active_session_id" WIZARD_STEP_ID="$target_active_step_id" node -e '
+    process.stdout.write(
+      JSON.stringify({
+        sessionId: process.env.WIZARD_SESSION_ID,
+        answer: { stepId: process.env.WIZARD_STEP_ID, value: null },
+      }),
+    );
+  '
+)"
+gateway_call wizard.next "$target_active_next_params" \
+  "$TARGET_WIZARD_NEXT_JSON" "$TARGET_WIZARD_NEXT_ERR"
+if gateway_call wizard.start '{"mode":"local"}' \
+  "$TARGET_WIZARD_DUPLICATE_JSON" "$TARGET_WIZARD_DUPLICATE_ERR"; then
+  echo "target wizard.start unexpectedly allowed an overlapping setup session" >&2
+  exit 1
+fi
+if ! grep -Fq "wizard already running" "$TARGET_WIZARD_DUPLICATE_ERR"; then
+  echo "target overlapping wizard.start failed without the expected rejection" >&2
+  openclaw_e2e_print_log "$TARGET_WIZARD_DUPLICATE_ERR" >&2
+  exit 1
+fi
+
+gateway_call wizard.cancel "$target_active_session_params" \
+  "$TARGET_WIZARD_CANCEL_JSON" "$TARGET_WIZARD_CANCEL_ERR"
+target_cancel_status_observed="not-found"
+if gateway_call wizard.status "$target_active_session_params" \
+  "$TARGET_WIZARD_CANCELLED_STATUS_JSON" "$TARGET_WIZARD_CANCELLED_STATUS_ERR"; then
+  target_cancel_status_observed="$(
+    node -e '
+      const fs = require("node:fs");
+      const payload = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+      if (payload.status !== "cancelled") {
+        throw new Error(`unexpected target post-cancel status: ${JSON.stringify(payload)}`);
+      }
+      process.stdout.write(payload.status);
+    ' "$TARGET_WIZARD_CANCELLED_STATUS_JSON"
+  )"
+elif ! grep -Fq "wizard not found" "$TARGET_WIZARD_CANCELLED_STATUS_ERR"; then
+  echo "target cancelled wizard status failed without the expected cleanup result" >&2
+  openclaw_e2e_print_log "$TARGET_WIZARD_CANCELLED_STATUS_ERR" >&2
+  exit 1
+fi
+if gateway_call wizard.status "$target_active_session_params" \
+  "$TARGET_WIZARD_PURGED_STATUS_JSON" "$TARGET_WIZARD_PURGED_STATUS_ERR"; then
+  echo "target cancelled wizard session remained reachable" >&2
+  exit 1
+fi
+if ! grep -Fq "wizard not found" "$TARGET_WIZARD_PURGED_STATUS_ERR"; then
+  echo "target cancelled wizard cleanup failed without the expected not-found result" >&2
+  openclaw_e2e_print_log "$TARGET_WIZARD_PURGED_STATUS_ERR" >&2
+  exit 1
+fi
+
+TARGET_WIZARD_STATUS_START_JSON="$TARGET_WIZARD_STATUS_START_JSON" \
+  TARGET_WIZARD_STATUS_JSON="$TARGET_WIZARD_STATUS_JSON" \
+  TARGET_WIZARD_ACTIVE_START_JSON="$TARGET_WIZARD_ACTIVE_START_JSON" \
+  TARGET_WIZARD_NEXT_JSON="$TARGET_WIZARD_NEXT_JSON" \
+  TARGET_WIZARD_CANCEL_JSON="$TARGET_WIZARD_CANCEL_JSON" \
+  TARGET_CANCEL_STATUS_OBSERVED="$target_cancel_status_observed" \
+  TARGET_WIZARD_FLOW_JSON="$TARGET_WIZARD_FLOW_JSON" \
+  node -e '
+    const fs = require("node:fs");
+    const readJson = (file) => JSON.parse(fs.readFileSync(file, "utf8"));
+    const sanitizeStep = (step, label) => {
+      if (!step || typeof step.id !== "string" || !step.id) {
+        throw new Error(`${label} omitted its wizard step`);
+      }
+      const allowedTypes = new Set([
+        "note",
+        "select",
+        "text",
+        "confirm",
+        "multiselect",
+        "progress",
+        "action",
+      ]);
+      if (!allowedTypes.has(step.type)) {
+        throw new Error(`${label} returned unsupported step type ${String(step.type)}`);
+      }
+      if (step.sensitive === true && Object.hasOwn(step, "initialValue")) {
+        throw new Error(`${label} exposed a sensitive initial value`);
+      }
+      for (const field of ["title", "message", "placeholder"]) {
+        if (step[field] !== undefined && typeof step[field] !== "string") {
+          throw new Error(`${label} returned non-string ${field}`);
+        }
+        if (step[field]?.length > 8192) {
+          throw new Error(`${label} returned oversized ${field}`);
+        }
+      }
+      if (step.options !== undefined && !Array.isArray(step.options)) {
+        throw new Error(`${label} returned malformed options`);
+      }
+      return {
+        type: step.type,
+        executor: step.executor,
+        sensitive: step.sensitive === true,
+        initialValuePresent: Object.hasOwn(step, "initialValue"),
+        titleLength: step.title?.length ?? 0,
+        messageLength: step.message?.length ?? 0,
+        optionCount: step.options?.length ?? 0,
+      };
+    };
+    const statusStart = readJson(process.env.TARGET_WIZARD_STATUS_START_JSON);
+    const status = readJson(process.env.TARGET_WIZARD_STATUS_JSON);
+    const activeStart = readJson(process.env.TARGET_WIZARD_ACTIVE_START_JSON);
+    const next = readJson(process.env.TARGET_WIZARD_NEXT_JSON);
+    const cancel = readJson(process.env.TARGET_WIZARD_CANCEL_JSON);
+    if (status.status !== "running") {
+      throw new Error(`target wizard.status was not running: ${JSON.stringify(status)}`);
+    }
+    if (next.done !== false || next.status !== "running") {
+      throw new Error(`target wizard.next did not advance a running session: ${JSON.stringify(next)}`);
+    }
+    if (cancel.status !== "cancelled") {
+      throw new Error(`target wizard.cancel did not cancel its session: ${JSON.stringify(cancel)}`);
+    }
+    fs.writeFileSync(
+      process.env.TARGET_WIZARD_FLOW_JSON,
+      `${JSON.stringify(
+        {
+          status: "passed",
+          authenticated: true,
+          packagePhase: "target",
+          terminalStatus: {
+            start: {
+              status: statusStart.status,
+              step: sanitizeStep(statusStart.step, "target status wizard.start"),
+            },
+            observedStatus: status.status,
+            purged: true,
+          },
+          activeSession: {
+            start: {
+              status: activeStart.status,
+              step: sanitizeStep(activeStart.step, "target active wizard.start"),
+            },
+            next: {
+              status: next.status,
+              step: sanitizeStep(next.step, "target wizard.next"),
+            },
+            duplicateStartRejected: true,
+            cancelStatus: cancel.status,
+            postCancelStatus: process.env.TARGET_CANCEL_STATUS_OBSERVED,
+            purged: true,
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+  '
+
 post_restart_observed_at_ms="$(node -e 'process.stdout.write(String(Date.now()))')"
 deadline=$((SECONDS + 60))
 while [ "$SECONDS" -lt "$deadline" ]; do
@@ -703,6 +944,7 @@ SOURCE_VERSION="$SOURCE_VERSION" \
   UPDATE_RPC_JSON="$UPDATE_RPC_JSON" \
   UPDATE_STATUS_JSON="$UPDATE_STATUS_JSON" \
   WIZARD_FLOW_JSON="$WIZARD_FLOW_JSON" \
+  TARGET_WIZARD_FLOW_JSON="$TARGET_WIZARD_FLOW_JSON" \
   QA_CHANNEL_INSTALL_RECORD_JSON="$QA_CHANNEL_INSTALL_RECORD_JSON" \
   TARGET_PLUGIN_INDEX_JSON="$TARGET_PLUGIN_INDEX_JSON" \
   SOURCE_PLUGIN_INSPECT_JSON="$SOURCE_PLUGIN_INSPECT_JSON" \
@@ -746,6 +988,7 @@ SOURCE_VERSION="$SOURCE_VERSION" \
       updateRpcCompletedAtMs: Number(process.env.UPDATE_RPC_COMPLETED_AT_MS),
       postRestartObservedAtMs: postRestartAtMs,
       wizardFlow: readJson(process.env.WIZARD_FLOW_JSON),
+      targetWizardFlow: readJson(process.env.TARGET_WIZARD_FLOW_JSON),
       updateRpcResult: readJson(process.env.UPDATE_RPC_JSON),
       restartSentinel: updateStatus.sentinel,
       qaChannelInstallRecord: readJson(process.env.QA_CHANNEL_INSTALL_RECORD_JSON),

--- a/scripts/e2e/lib/upgrade-survivor/update-run-package-self-upgrade.sh
+++ b/scripts/e2e/lib/upgrade-survivor/update-run-package-self-upgrade.sh
@@ -80,6 +80,10 @@ TARGET_WIZARD_STATUS_START_JSON="$ARTIFACT_DIR/target-wizard-status-start.json"
 TARGET_WIZARD_STATUS_START_ERR="$ARTIFACT_DIR/target-wizard-status-start.err"
 TARGET_WIZARD_STATUS_JSON="$ARTIFACT_DIR/target-wizard-status.json"
 TARGET_WIZARD_STATUS_ERR="$ARTIFACT_DIR/target-wizard-status.err"
+TARGET_WIZARD_STATUS_RETAINED_JSON="$ARTIFACT_DIR/target-wizard-status-retained.json"
+TARGET_WIZARD_STATUS_RETAINED_ERR="$ARTIFACT_DIR/target-wizard-status-retained.err"
+TARGET_WIZARD_STATUS_CANCEL_JSON="$ARTIFACT_DIR/target-wizard-status-cancel.json"
+TARGET_WIZARD_STATUS_CANCEL_ERR="$ARTIFACT_DIR/target-wizard-status-cancel.err"
 TARGET_WIZARD_STATUS_PURGED_JSON="$ARTIFACT_DIR/target-wizard-status-purged.json"
 TARGET_WIZARD_STATUS_PURGED_ERR="$ARTIFACT_DIR/target-wizard-status-purged.err"
 TARGET_WIZARD_ACTIVE_START_JSON="$ARTIFACT_DIR/target-wizard-active-start.json"
@@ -661,6 +665,49 @@ if [ ! -f "$UPDATE_STATUS_JSON" ]; then
 fi
 
 echo "Exercising current target Gateway wizard RPC lifecycle"
+wait_for_target_wizard_start() {
+  local output="$1"
+  local error_output="$2"
+  local label="$3"
+  local deadline=$((SECONDS + 30))
+  local polls=0
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    polls=$((polls + 1))
+    if gateway_call wizard.start '{"mode":"local"}' "$output" "$error_output"; then
+      local session_id
+      session_id="$(
+        TARGET_START_LABEL="$label" node -e '
+          const fs = require("node:fs");
+          const payload = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+          if (
+            typeof payload?.sessionId !== "string" ||
+            !payload.sessionId ||
+            payload.done !== false ||
+            payload.status !== "running" ||
+            typeof payload.step?.id !== "string"
+          ) {
+            throw new Error(
+              `unexpected ${process.env.TARGET_START_LABEL}: ${JSON.stringify(payload)}`,
+            );
+          }
+          process.stdout.write(payload.sessionId);
+        ' "$output"
+      )"
+      printf '%s\t%s\n' "$session_id" "$polls"
+      return 0
+    fi
+    if ! grep -Fq "wizard already running" "$error_output"; then
+      echo "$label failed without the expected settlement result" >&2
+      openclaw_e2e_print_log "$error_output" >&2
+      return 1
+    fi
+    sleep 0.2
+  done
+  echo "timed out waiting for $label" >&2
+  openclaw_e2e_print_log "$error_output" >&2
+  return 1
+}
+
 gateway_call wizard.start '{"mode":"local"}' \
   "$TARGET_WIZARD_STATUS_START_JSON" "$TARGET_WIZARD_STATUS_START_ERR"
 target_status_session_id="$(
@@ -686,35 +733,31 @@ target_status_session_params="$(
 )"
 gateway_call wizard.status "$target_status_session_params" \
   "$TARGET_WIZARD_STATUS_JSON" "$TARGET_WIZARD_STATUS_ERR"
+gateway_call wizard.status "$target_status_session_params" \
+  "$TARGET_WIZARD_STATUS_RETAINED_JSON" "$TARGET_WIZARD_STATUS_RETAINED_ERR"
+gateway_call wizard.cancel "$target_status_session_params" \
+  "$TARGET_WIZARD_STATUS_CANCEL_JSON" "$TARGET_WIZARD_STATUS_CANCEL_ERR"
+
+target_active_start_result="$(
+  wait_for_target_wizard_start \
+    "$TARGET_WIZARD_ACTIVE_START_JSON" \
+    "$TARGET_WIZARD_ACTIVE_START_ERR" \
+    "target status cancellation settlement"
+)"
+IFS=$'\t' read -r target_active_session_id target_status_settlement_polls \
+  <<<"$target_active_start_result"
+
 if gateway_call wizard.status "$target_status_session_params" \
   "$TARGET_WIZARD_STATUS_PURGED_JSON" "$TARGET_WIZARD_STATUS_PURGED_ERR"; then
-  echo "target wizard.status did not terminate and purge its session" >&2
+  echo "target cancelled status-session wizard remained reachable after settlement" >&2
   exit 1
 fi
 if ! grep -Fq "wizard not found" "$TARGET_WIZARD_STATUS_PURGED_ERR"; then
-  echo "target terminal wizard.status failed without the expected not-found result" >&2
+  echo "target cancelled status-session cleanup lacked the expected not-found result" >&2
   openclaw_e2e_print_log "$TARGET_WIZARD_STATUS_PURGED_ERR" >&2
   exit 1
 fi
 
-gateway_call wizard.start '{"mode":"local"}' \
-  "$TARGET_WIZARD_ACTIVE_START_JSON" "$TARGET_WIZARD_ACTIVE_START_ERR"
-target_active_session_id="$(
-  node -e '
-    const fs = require("node:fs");
-    const payload = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
-    if (
-      typeof payload?.sessionId !== "string" ||
-      !payload.sessionId ||
-      payload.done !== false ||
-      payload.status !== "running" ||
-      typeof payload.step?.id !== "string"
-    ) {
-      throw new Error(`unexpected target active wizard.start result: ${JSON.stringify(payload)}`);
-    }
-    process.stdout.write(payload.sessionId);
-  ' "$TARGET_WIZARD_ACTIVE_START_JSON"
-)"
 target_active_step_id="$(
   node -e '
     const fs = require("node:fs");
@@ -752,43 +795,14 @@ fi
 
 gateway_call wizard.cancel "$target_active_session_params" \
   "$TARGET_WIZARD_CANCEL_JSON" "$TARGET_WIZARD_CANCEL_ERR"
-target_replacement_session_id=""
-target_cancel_settlement_polls=0
-target_cancel_deadline=$((SECONDS + 30))
-while [ "$SECONDS" -lt "$target_cancel_deadline" ]; do
-  target_cancel_settlement_polls=$((target_cancel_settlement_polls + 1))
-  if gateway_call wizard.start '{"mode":"local"}' \
-    "$TARGET_WIZARD_REPLACEMENT_START_JSON" "$TARGET_WIZARD_REPLACEMENT_START_ERR"; then
-    target_replacement_session_id="$(
-      node -e '
-        const fs = require("node:fs");
-        const payload = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
-        if (
-          typeof payload?.sessionId !== "string" ||
-          !payload.sessionId ||
-          payload.done !== false ||
-          payload.status !== "running" ||
-          typeof payload.step?.id !== "string"
-        ) {
-          throw new Error(`unexpected target replacement wizard.start: ${JSON.stringify(payload)}`);
-        }
-        process.stdout.write(payload.sessionId);
-      ' "$TARGET_WIZARD_REPLACEMENT_START_JSON"
-    )"
-    break
-  fi
-  if ! grep -Fq "wizard already running" "$TARGET_WIZARD_REPLACEMENT_START_ERR"; then
-    echo "target replacement wizard.start failed without the expected settlement result" >&2
-    openclaw_e2e_print_log "$TARGET_WIZARD_REPLACEMENT_START_ERR" >&2
-    exit 1
-  fi
-  sleep 0.2
-done
-if [ -z "$target_replacement_session_id" ]; then
-  echo "timed out waiting for target cancelled wizard settlement" >&2
-  openclaw_e2e_print_log "$TARGET_WIZARD_REPLACEMENT_START_ERR" >&2
-  exit 1
-fi
+target_replacement_start_result="$(
+  wait_for_target_wizard_start \
+    "$TARGET_WIZARD_REPLACEMENT_START_JSON" \
+    "$TARGET_WIZARD_REPLACEMENT_START_ERR" \
+    "target active cancellation settlement"
+)"
+IFS=$'\t' read -r target_replacement_session_id target_cancel_settlement_polls \
+  <<<"$target_replacement_start_result"
 
 if gateway_call wizard.status "$target_active_session_params" \
   "$TARGET_WIZARD_PURGED_STATUS_JSON" "$TARGET_WIZARD_PURGED_STATUS_ERR"; then
@@ -811,11 +825,14 @@ gateway_call wizard.cancel "$target_replacement_session_params" \
 
 TARGET_WIZARD_STATUS_START_JSON="$TARGET_WIZARD_STATUS_START_JSON" \
   TARGET_WIZARD_STATUS_JSON="$TARGET_WIZARD_STATUS_JSON" \
+  TARGET_WIZARD_STATUS_RETAINED_JSON="$TARGET_WIZARD_STATUS_RETAINED_JSON" \
+  TARGET_WIZARD_STATUS_CANCEL_JSON="$TARGET_WIZARD_STATUS_CANCEL_JSON" \
   TARGET_WIZARD_ACTIVE_START_JSON="$TARGET_WIZARD_ACTIVE_START_JSON" \
   TARGET_WIZARD_NEXT_JSON="$TARGET_WIZARD_NEXT_JSON" \
   TARGET_WIZARD_CANCEL_JSON="$TARGET_WIZARD_CANCEL_JSON" \
   TARGET_WIZARD_REPLACEMENT_START_JSON="$TARGET_WIZARD_REPLACEMENT_START_JSON" \
   TARGET_WIZARD_REPLACEMENT_CANCEL_JSON="$TARGET_WIZARD_REPLACEMENT_CANCEL_JSON" \
+  TARGET_STATUS_SETTLEMENT_POLLS="$target_status_settlement_polls" \
   TARGET_CANCEL_SETTLEMENT_POLLS="$target_cancel_settlement_polls" \
   TARGET_WIZARD_FLOW_JSON="$TARGET_WIZARD_FLOW_JSON" \
   node -e '
@@ -863,19 +880,30 @@ TARGET_WIZARD_STATUS_START_JSON="$TARGET_WIZARD_STATUS_START_JSON" \
     };
     const statusStart = readJson(process.env.TARGET_WIZARD_STATUS_START_JSON);
     const status = readJson(process.env.TARGET_WIZARD_STATUS_JSON);
+    const retainedStatus = readJson(process.env.TARGET_WIZARD_STATUS_RETAINED_JSON);
+    const statusCancel = readJson(process.env.TARGET_WIZARD_STATUS_CANCEL_JSON);
     const activeStart = readJson(process.env.TARGET_WIZARD_ACTIVE_START_JSON);
     const next = readJson(process.env.TARGET_WIZARD_NEXT_JSON);
     const cancel = readJson(process.env.TARGET_WIZARD_CANCEL_JSON);
     const replacementStart = readJson(process.env.TARGET_WIZARD_REPLACEMENT_START_JSON);
     const replacementCancel = readJson(process.env.TARGET_WIZARD_REPLACEMENT_CANCEL_JSON);
-    if (status.status !== "running") {
-      throw new Error(`target wizard.status was not running: ${JSON.stringify(status)}`);
+    if (status.status !== "running" || retainedStatus.status !== "running") {
+      throw new Error(
+        `target wizard.status did not retain its running session: ${JSON.stringify({
+          status,
+          retainedStatus,
+        })}`,
+      );
     }
     if (next.done !== false || next.status !== "running") {
       throw new Error(`target wizard.next did not advance a running session: ${JSON.stringify(next)}`);
     }
-    if (cancel.status !== "cancelled" || replacementCancel.status !== "cancelled") {
-      throw new Error("target wizard.cancel did not cancel both sessions");
+    if (
+      statusCancel.status !== "cancelled" ||
+      cancel.status !== "cancelled" ||
+      replacementCancel.status !== "cancelled"
+    ) {
+      throw new Error("target wizard.cancel did not cancel every target session");
     }
     fs.writeFileSync(
       process.env.TARGET_WIZARD_FLOW_JSON,
@@ -884,12 +912,15 @@ TARGET_WIZARD_STATUS_START_JSON="$TARGET_WIZARD_STATUS_START_JSON" \
           status: "passed",
           authenticated: true,
           packagePhase: "target",
-          terminalStatus: {
+          statusSession: {
             start: {
               status: statusStart.status,
               step: sanitizeStep(statusStart.step, "target status wizard.start"),
             },
-            observedStatus: status.status,
+            observedStatuses: [status.status, retainedStatus.status],
+            runningStatusRetained: true,
+            cancelStatus: statusCancel.status,
+            settlementPolls: Number(process.env.TARGET_STATUS_SETTLEMENT_POLLS),
             purged: true,
           },
           activeSession: {

--- a/scripts/e2e/lib/upgrade-survivor/update-run-package-self-upgrade.sh
+++ b/scripts/e2e/lib/upgrade-survivor/update-run-package-self-upgrade.sh
@@ -376,6 +376,43 @@ gateway_call() {
     >"$output" 2>"$error_output"
 }
 
+assert_gateway_call_error_message() {
+  local output="$1"
+  local error_output="$2"
+  local expected="$3"
+  local label="$4"
+  local allow_stderr_fallback="${5:-0}"
+  if EXPECTED_GATEWAY_ERROR="$expected" node -e '
+    const fs = require("node:fs");
+    const file = process.argv[1];
+    const raw = fs.existsSync(file) ? fs.readFileSync(file, "utf8").trim() : "";
+    if (!raw) {
+      process.exit(1);
+    }
+    try {
+      const payload = JSON.parse(raw);
+      process.exit(
+        payload?.ok === false &&
+          payload?.error?.type === "gateway_request_error" &&
+          payload.error.message === process.env.EXPECTED_GATEWAY_ERROR
+          ? 0
+          : 1,
+      );
+    } catch {
+      process.exit(1);
+    }
+  ' "$output"; then
+    return 0
+  fi
+  if [ "$allow_stderr_fallback" = "1" ] && grep -Fq "$expected" "$error_output"; then
+    return 0
+  fi
+  echo "$label failed without the expected '$expected' result" >&2
+  openclaw_e2e_print_log "$output" >&2
+  openclaw_e2e_print_log "$error_output" >&2
+  exit 1
+}
+
 gateway_call channels.status '{"probe":false,"timeoutMs":2000}' \
   "$ARTIFACT_DIR/channels-status-before.json" \
   "$ARTIFACT_DIR/channels-status-before.err"
@@ -428,11 +465,12 @@ if gateway_call wizard.start '{"mode":"local"}' \
   echo "wizard.start unexpectedly allowed an overlapping setup session" >&2
   exit 1
 fi
-if ! grep -Fq "wizard already running" "$WIZARD_DUPLICATE_ERR"; then
-  echo "overlapping wizard.start failed without the expected rejection" >&2
-  openclaw_e2e_print_log "$WIZARD_DUPLICATE_ERR" >&2
-  exit 1
-fi
+assert_gateway_call_error_message \
+  "$WIZARD_DUPLICATE_JSON" \
+  "$WIZARD_DUPLICATE_ERR" \
+  "wizard already running" \
+  "overlapping wizard.start" \
+  1
 
 gateway_call wizard.cancel "$wizard_session_params" "$WIZARD_CANCEL_JSON" "$WIZARD_CANCEL_ERR"
 if gateway_call wizard.status "$wizard_session_params" \
@@ -440,11 +478,12 @@ if gateway_call wizard.status "$wizard_session_params" \
   echo "cancelled wizard session remained reachable" >&2
   exit 1
 fi
-if ! grep -Fq "wizard not found" "$WIZARD_CANCELLED_STATUS_ERR"; then
-  echo "cancelled wizard cleanup failed without the expected not-found result" >&2
-  openclaw_e2e_print_log "$WIZARD_CANCELLED_STATUS_ERR" >&2
-  exit 1
-fi
+assert_gateway_call_error_message \
+  "$WIZARD_CANCELLED_STATUS_JSON" \
+  "$WIZARD_CANCELLED_STATUS_ERR" \
+  "wizard not found" \
+  "cancelled wizard cleanup" \
+  1
 
 gateway_call wizard.start '{"mode":"local"}' \
   "$WIZARD_REPLACEMENT_START_JSON" "$WIZARD_REPLACEMENT_START_ERR"
@@ -475,11 +514,12 @@ if gateway_call wizard.status "$replacement_session_params" \
   echo "replacement wizard session remained reachable after cancellation" >&2
   exit 1
 fi
-if ! grep -Fq "wizard not found" "$WIZARD_REPLACEMENT_STATUS_ERR"; then
-  echo "replacement wizard cleanup failed without the expected not-found result" >&2
-  openclaw_e2e_print_log "$WIZARD_REPLACEMENT_STATUS_ERR" >&2
-  exit 1
-fi
+assert_gateway_call_error_message \
+  "$WIZARD_REPLACEMENT_STATUS_JSON" \
+  "$WIZARD_REPLACEMENT_STATUS_ERR" \
+  "wizard not found" \
+  "replacement wizard cleanup" \
+  1
 
 WIZARD_START_JSON="$WIZARD_START_JSON" \
   WIZARD_STATUS_JSON="$WIZARD_STATUS_JSON" \
@@ -696,11 +736,8 @@ wait_for_target_wizard_start() {
       printf '%s\t%s\n' "$session_id" "$polls"
       return 0
     fi
-    if ! grep -Fq "wizard already running" "$error_output"; then
-      echo "$label failed without the expected settlement result" >&2
-      openclaw_e2e_print_log "$error_output" >&2
-      return 1
-    fi
+    assert_gateway_call_error_message \
+      "$output" "$error_output" "wizard already running" "$label"
     sleep 0.2
   done
   echo "timed out waiting for $label" >&2
@@ -752,11 +789,11 @@ if gateway_call wizard.status "$target_status_session_params" \
   echo "target cancelled status-session wizard remained reachable after settlement" >&2
   exit 1
 fi
-if ! grep -Fq "wizard not found" "$TARGET_WIZARD_STATUS_PURGED_ERR"; then
-  echo "target cancelled status-session cleanup lacked the expected not-found result" >&2
-  openclaw_e2e_print_log "$TARGET_WIZARD_STATUS_PURGED_ERR" >&2
-  exit 1
-fi
+assert_gateway_call_error_message \
+  "$TARGET_WIZARD_STATUS_PURGED_JSON" \
+  "$TARGET_WIZARD_STATUS_PURGED_ERR" \
+  "wizard not found" \
+  "target cancelled status-session cleanup"
 
 target_active_step_id="$(
   node -e '
@@ -787,11 +824,11 @@ if gateway_call wizard.start '{"mode":"local"}' \
   echo "target wizard.start unexpectedly allowed an overlapping setup session" >&2
   exit 1
 fi
-if ! grep -Fq "wizard already running" "$TARGET_WIZARD_DUPLICATE_ERR"; then
-  echo "target overlapping wizard.start failed without the expected rejection" >&2
-  openclaw_e2e_print_log "$TARGET_WIZARD_DUPLICATE_ERR" >&2
-  exit 1
-fi
+assert_gateway_call_error_message \
+  "$TARGET_WIZARD_DUPLICATE_JSON" \
+  "$TARGET_WIZARD_DUPLICATE_ERR" \
+  "wizard already running" \
+  "target overlapping wizard.start"
 
 gateway_call wizard.cancel "$target_active_session_params" \
   "$TARGET_WIZARD_CANCEL_JSON" "$TARGET_WIZARD_CANCEL_ERR"
@@ -809,11 +846,11 @@ if gateway_call wizard.status "$target_active_session_params" \
   echo "target cancelled wizard session remained reachable" >&2
   exit 1
 fi
-if ! grep -Fq "wizard not found" "$TARGET_WIZARD_PURGED_STATUS_ERR"; then
-  echo "target cancelled wizard cleanup failed without the expected not-found result" >&2
-  openclaw_e2e_print_log "$TARGET_WIZARD_PURGED_STATUS_ERR" >&2
-  exit 1
-fi
+assert_gateway_call_error_message \
+  "$TARGET_WIZARD_PURGED_STATUS_JSON" \
+  "$TARGET_WIZARD_PURGED_STATUS_ERR" \
+  "wizard not found" \
+  "target cancelled wizard cleanup"
 
 target_replacement_session_params="$(
   WIZARD_SESSION_ID="$target_replacement_session_id" node -e '

--- a/scripts/e2e/lib/upgrade-survivor/update-run-package-self-upgrade.sh
+++ b/scripts/e2e/lib/upgrade-survivor/update-run-package-self-upgrade.sh
@@ -90,8 +90,10 @@ TARGET_WIZARD_DUPLICATE_JSON="$ARTIFACT_DIR/target-wizard-duplicate-start.json"
 TARGET_WIZARD_DUPLICATE_ERR="$ARTIFACT_DIR/target-wizard-duplicate-start.err"
 TARGET_WIZARD_CANCEL_JSON="$ARTIFACT_DIR/target-wizard-cancel.json"
 TARGET_WIZARD_CANCEL_ERR="$ARTIFACT_DIR/target-wizard-cancel.err"
-TARGET_WIZARD_CANCELLED_STATUS_JSON="$ARTIFACT_DIR/target-wizard-cancelled-status.json"
-TARGET_WIZARD_CANCELLED_STATUS_ERR="$ARTIFACT_DIR/target-wizard-cancelled-status.err"
+TARGET_WIZARD_REPLACEMENT_START_JSON="$ARTIFACT_DIR/target-wizard-replacement-start.json"
+TARGET_WIZARD_REPLACEMENT_START_ERR="$ARTIFACT_DIR/target-wizard-replacement-start.err"
+TARGET_WIZARD_REPLACEMENT_CANCEL_JSON="$ARTIFACT_DIR/target-wizard-replacement-cancel.json"
+TARGET_WIZARD_REPLACEMENT_CANCEL_ERR="$ARTIFACT_DIR/target-wizard-replacement-cancel.err"
 TARGET_WIZARD_PURGED_STATUS_JSON="$ARTIFACT_DIR/target-wizard-purged-status.json"
 TARGET_WIZARD_PURGED_STATUS_ERR="$ARTIFACT_DIR/target-wizard-purged-status.err"
 TARGET_WIZARD_FLOW_JSON="$ARTIFACT_DIR/target-wizard-flow.json"
@@ -548,6 +550,7 @@ WIZARD_START_JSON="$WIZARD_START_JSON" \
           authenticated: true,
           start: { status: start.status, step: sanitizeStep(start.step, "wizard.start") },
           statusPoll: status.status,
+          runningStatusRetained: true,
           next: { status: next.status, step: sanitizeStep(next.step, "wizard.next") },
           duplicateStartRejected: true,
           cancelStatus: cancel.status,
@@ -749,24 +752,44 @@ fi
 
 gateway_call wizard.cancel "$target_active_session_params" \
   "$TARGET_WIZARD_CANCEL_JSON" "$TARGET_WIZARD_CANCEL_ERR"
-target_cancel_status_observed="not-found"
-if gateway_call wizard.status "$target_active_session_params" \
-  "$TARGET_WIZARD_CANCELLED_STATUS_JSON" "$TARGET_WIZARD_CANCELLED_STATUS_ERR"; then
-  target_cancel_status_observed="$(
-    node -e '
-      const fs = require("node:fs");
-      const payload = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
-      if (payload.status !== "cancelled") {
-        throw new Error(`unexpected target post-cancel status: ${JSON.stringify(payload)}`);
-      }
-      process.stdout.write(payload.status);
-    ' "$TARGET_WIZARD_CANCELLED_STATUS_JSON"
-  )"
-elif ! grep -Fq "wizard not found" "$TARGET_WIZARD_CANCELLED_STATUS_ERR"; then
-  echo "target cancelled wizard status failed without the expected cleanup result" >&2
-  openclaw_e2e_print_log "$TARGET_WIZARD_CANCELLED_STATUS_ERR" >&2
+target_replacement_session_id=""
+target_cancel_settlement_polls=0
+target_cancel_deadline=$((SECONDS + 30))
+while [ "$SECONDS" -lt "$target_cancel_deadline" ]; do
+  target_cancel_settlement_polls=$((target_cancel_settlement_polls + 1))
+  if gateway_call wizard.start '{"mode":"local"}' \
+    "$TARGET_WIZARD_REPLACEMENT_START_JSON" "$TARGET_WIZARD_REPLACEMENT_START_ERR"; then
+    target_replacement_session_id="$(
+      node -e '
+        const fs = require("node:fs");
+        const payload = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+        if (
+          typeof payload?.sessionId !== "string" ||
+          !payload.sessionId ||
+          payload.done !== false ||
+          payload.status !== "running" ||
+          typeof payload.step?.id !== "string"
+        ) {
+          throw new Error(`unexpected target replacement wizard.start: ${JSON.stringify(payload)}`);
+        }
+        process.stdout.write(payload.sessionId);
+      ' "$TARGET_WIZARD_REPLACEMENT_START_JSON"
+    )"
+    break
+  fi
+  if ! grep -Fq "wizard already running" "$TARGET_WIZARD_REPLACEMENT_START_ERR"; then
+    echo "target replacement wizard.start failed without the expected settlement result" >&2
+    openclaw_e2e_print_log "$TARGET_WIZARD_REPLACEMENT_START_ERR" >&2
+    exit 1
+  fi
+  sleep 0.2
+done
+if [ -z "$target_replacement_session_id" ]; then
+  echo "timed out waiting for target cancelled wizard settlement" >&2
+  openclaw_e2e_print_log "$TARGET_WIZARD_REPLACEMENT_START_ERR" >&2
   exit 1
 fi
+
 if gateway_call wizard.status "$target_active_session_params" \
   "$TARGET_WIZARD_PURGED_STATUS_JSON" "$TARGET_WIZARD_PURGED_STATUS_ERR"; then
   echo "target cancelled wizard session remained reachable" >&2
@@ -778,12 +801,22 @@ if ! grep -Fq "wizard not found" "$TARGET_WIZARD_PURGED_STATUS_ERR"; then
   exit 1
 fi
 
+target_replacement_session_params="$(
+  WIZARD_SESSION_ID="$target_replacement_session_id" node -e '
+    process.stdout.write(JSON.stringify({ sessionId: process.env.WIZARD_SESSION_ID }));
+  '
+)"
+gateway_call wizard.cancel "$target_replacement_session_params" \
+  "$TARGET_WIZARD_REPLACEMENT_CANCEL_JSON" "$TARGET_WIZARD_REPLACEMENT_CANCEL_ERR"
+
 TARGET_WIZARD_STATUS_START_JSON="$TARGET_WIZARD_STATUS_START_JSON" \
   TARGET_WIZARD_STATUS_JSON="$TARGET_WIZARD_STATUS_JSON" \
   TARGET_WIZARD_ACTIVE_START_JSON="$TARGET_WIZARD_ACTIVE_START_JSON" \
   TARGET_WIZARD_NEXT_JSON="$TARGET_WIZARD_NEXT_JSON" \
   TARGET_WIZARD_CANCEL_JSON="$TARGET_WIZARD_CANCEL_JSON" \
-  TARGET_CANCEL_STATUS_OBSERVED="$target_cancel_status_observed" \
+  TARGET_WIZARD_REPLACEMENT_START_JSON="$TARGET_WIZARD_REPLACEMENT_START_JSON" \
+  TARGET_WIZARD_REPLACEMENT_CANCEL_JSON="$TARGET_WIZARD_REPLACEMENT_CANCEL_JSON" \
+  TARGET_CANCEL_SETTLEMENT_POLLS="$target_cancel_settlement_polls" \
   TARGET_WIZARD_FLOW_JSON="$TARGET_WIZARD_FLOW_JSON" \
   node -e '
     const fs = require("node:fs");
@@ -833,14 +866,16 @@ TARGET_WIZARD_STATUS_START_JSON="$TARGET_WIZARD_STATUS_START_JSON" \
     const activeStart = readJson(process.env.TARGET_WIZARD_ACTIVE_START_JSON);
     const next = readJson(process.env.TARGET_WIZARD_NEXT_JSON);
     const cancel = readJson(process.env.TARGET_WIZARD_CANCEL_JSON);
+    const replacementStart = readJson(process.env.TARGET_WIZARD_REPLACEMENT_START_JSON);
+    const replacementCancel = readJson(process.env.TARGET_WIZARD_REPLACEMENT_CANCEL_JSON);
     if (status.status !== "running") {
       throw new Error(`target wizard.status was not running: ${JSON.stringify(status)}`);
     }
     if (next.done !== false || next.status !== "running") {
       throw new Error(`target wizard.next did not advance a running session: ${JSON.stringify(next)}`);
     }
-    if (cancel.status !== "cancelled") {
-      throw new Error(`target wizard.cancel did not cancel its session: ${JSON.stringify(cancel)}`);
+    if (cancel.status !== "cancelled" || replacementCancel.status !== "cancelled") {
+      throw new Error("target wizard.cancel did not cancel both sessions");
     }
     fs.writeFileSync(
       process.env.TARGET_WIZARD_FLOW_JSON,
@@ -868,8 +903,13 @@ TARGET_WIZARD_STATUS_START_JSON="$TARGET_WIZARD_STATUS_START_JSON" \
             },
             duplicateStartRejected: true,
             cancelStatus: cancel.status,
-            postCancelStatus: process.env.TARGET_CANCEL_STATUS_OBSERVED,
+            settlementPolls: Number(process.env.TARGET_CANCEL_SETTLEMENT_POLLS),
             purged: true,
+            replacement: {
+              status: replacementStart.status,
+              step: sanitizeStep(replacementStart.step, "target replacement wizard.start"),
+              cancelStatus: replacementCancel.status,
+            },
           },
         },
         null,

--- a/scripts/e2e/update-run-package-self-upgrade-docker.sh
+++ b/scripts/e2e/update-run-package-self-upgrade-docker.sh
@@ -25,6 +25,7 @@ SKIP_BUILD="${OPENCLAW_UPDATE_RUN_SELF_UPGRADE_E2E_SKIP_BUILD:-0}"
 DOCKER_RUN_TIMEOUT="${OPENCLAW_UPDATE_RUN_SELF_UPGRADE_DOCKER_RUN_TIMEOUT:-1800s}"
 ARTIFACT_DIR="${OPENCLAW_UPDATE_RUN_SELF_UPGRADE_ARTIFACT_DIR:-$ROOT_DIR/.artifacts/update-run-package-self-upgrade}"
 QA_CHANNEL_FIXTURE_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/openclaw-update-run-qa-channel.XXXXXX")"
+QA_CHANNEL_FIXTURE_ARCHIVE="$QA_CHANNEL_FIXTURE_ROOT/qa-channel.tar"
 
 cleanup() {
   rm -rf "$QA_CHANNEL_FIXTURE_ROOT"
@@ -102,6 +103,7 @@ prepare_qa_channel_fixture() {
       return 1
     fi
   done
+  tar -C "$checkout_root" -cf "$QA_CHANNEL_FIXTURE_ARCHIVE" dist/extensions/qa-channel
 }
 
 mkdir -p "$ARTIFACT_DIR"
@@ -123,7 +125,9 @@ docker_e2e_run_with_harness \
   -e OPENCLAW_UPDATE_RUN_SELF_UPGRADE_ARTIFACT_DIR=/tmp/openclaw-update-run-artifacts \
   -e OPENCLAW_UPDATE_RUN_SELF_UPGRADE_SOURCE_VERSION="$SOURCE_VERSION" \
   -v "$ARTIFACT_DIR:/tmp/openclaw-update-run-artifacts" \
-  -v "$QA_CHANNEL_FIXTURE_ROOT/checkout:/tmp/openclaw-update-run-build:ro" \
+  -v "$QA_CHANNEL_FIXTURE_ARCHIVE:/tmp/openclaw-update-run-qa-channel.tar:ro" \
   "$IMAGE_NAME" \
   timeout --kill-after=30s "$DOCKER_RUN_TIMEOUT" \
-  bash scripts/e2e/lib/upgrade-survivor/update-run-package-self-upgrade.sh
+  bash -lc 'mkdir -p /tmp/openclaw-update-run-build
+tar --no-same-owner -xf /tmp/openclaw-update-run-qa-channel.tar -C /tmp/openclaw-update-run-build
+exec bash scripts/e2e/lib/upgrade-survivor/update-run-package-self-upgrade.sh'

--- a/scripts/e2e/update-run-package-self-upgrade-docker.sh
+++ b/scripts/e2e/update-run-package-self-upgrade-docker.sh
@@ -25,7 +25,7 @@ SKIP_BUILD="${OPENCLAW_UPDATE_RUN_SELF_UPGRADE_E2E_SKIP_BUILD:-0}"
 DOCKER_RUN_TIMEOUT="${OPENCLAW_UPDATE_RUN_SELF_UPGRADE_DOCKER_RUN_TIMEOUT:-1800s}"
 ARTIFACT_DIR="${OPENCLAW_UPDATE_RUN_SELF_UPGRADE_ARTIFACT_DIR:-$ROOT_DIR/.artifacts/update-run-package-self-upgrade}"
 QA_CHANNEL_FIXTURE_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/openclaw-update-run-qa-channel.XXXXXX")"
-QA_CHANNEL_FIXTURE_ARCHIVE="$QA_CHANNEL_FIXTURE_ROOT/qa-channel.tar"
+QA_CHANNEL_FIXTURE_ARCHIVE="$QA_CHANNEL_FIXTURE_ROOT/historical-dist.tar"
 
 cleanup() {
   rm -rf "$QA_CHANNEL_FIXTURE_ROOT"
@@ -103,7 +103,7 @@ prepare_qa_channel_fixture() {
       return 1
     fi
   done
-  tar -C "$checkout_root" -cf "$QA_CHANNEL_FIXTURE_ARCHIVE" dist/extensions/qa-channel
+  tar -C "$checkout_root" -cf "$QA_CHANNEL_FIXTURE_ARCHIVE" dist
 }
 
 mkdir -p "$ARTIFACT_DIR"
@@ -125,9 +125,9 @@ docker_e2e_run_with_harness \
   -e OPENCLAW_UPDATE_RUN_SELF_UPGRADE_ARTIFACT_DIR=/tmp/openclaw-update-run-artifacts \
   -e OPENCLAW_UPDATE_RUN_SELF_UPGRADE_SOURCE_VERSION="$SOURCE_VERSION" \
   -v "$ARTIFACT_DIR:/tmp/openclaw-update-run-artifacts" \
-  -v "$QA_CHANNEL_FIXTURE_ARCHIVE:/tmp/openclaw-update-run-qa-channel.tar:ro" \
+  -v "$QA_CHANNEL_FIXTURE_ARCHIVE:/tmp/openclaw-update-run-historical-dist.tar:ro" \
   "$IMAGE_NAME" \
   timeout --kill-after=30s "$DOCKER_RUN_TIMEOUT" \
   bash -lc 'mkdir -p /tmp/openclaw-update-run-build
-tar --no-same-owner -xf /tmp/openclaw-update-run-qa-channel.tar -C /tmp/openclaw-update-run-build
+tar --no-same-owner -xf /tmp/openclaw-update-run-historical-dist.tar -C /tmp/openclaw-update-run-build
 exec bash scripts/e2e/lib/upgrade-survivor/update-run-package-self-upgrade.sh'

--- a/scripts/e2e/update-run-package-self-upgrade-docker.sh
+++ b/scripts/e2e/update-run-package-self-upgrade-docker.sh
@@ -25,7 +25,7 @@ SKIP_BUILD="${OPENCLAW_UPDATE_RUN_SELF_UPGRADE_E2E_SKIP_BUILD:-0}"
 DOCKER_RUN_TIMEOUT="${OPENCLAW_UPDATE_RUN_SELF_UPGRADE_DOCKER_RUN_TIMEOUT:-1800s}"
 ARTIFACT_DIR="${OPENCLAW_UPDATE_RUN_SELF_UPGRADE_ARTIFACT_DIR:-$ROOT_DIR/.artifacts/update-run-package-self-upgrade}"
 QA_CHANNEL_FIXTURE_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/openclaw-update-run-qa-channel.XXXXXX")"
-QA_CHANNEL_FIXTURE_ARCHIVE="$QA_CHANNEL_FIXTURE_ROOT/historical-dist.tar"
+HISTORICAL_DIST_ARCHIVE="$QA_CHANNEL_FIXTURE_ROOT/historical-dist.tar"
 
 cleanup() {
   rm -rf "$QA_CHANNEL_FIXTURE_ROOT"
@@ -73,6 +73,8 @@ prepare_qa_channel_fixture() {
           tagObject: process.env.TAG_OBJECT,
           commit: process.env.SOURCE_COMMIT,
           buildCommand: "OPENCLAW_BUILD_PRIVATE_QA=1 corepack pnpm build:docker",
+          runtimeInstall: `npm install --prefix <isolated-root> --omit=dev openclaw@${process.env.SOURCE_TAG.slice(1)}`,
+          privateDistOverlay: true,
         }, null, 2)}\n`,
       );
     ' "$ARTIFACT_DIR/qa-channel-fixture-provenance.json"
@@ -103,7 +105,7 @@ prepare_qa_channel_fixture() {
       return 1
     fi
   done
-  tar -C "$checkout_root" -cf "$QA_CHANNEL_FIXTURE_ARCHIVE" dist
+  tar -C "$checkout_root" -cf "$HISTORICAL_DIST_ARCHIVE" dist
 }
 
 mkdir -p "$ARTIFACT_DIR"
@@ -125,9 +127,47 @@ docker_e2e_run_with_harness \
   -e OPENCLAW_UPDATE_RUN_SELF_UPGRADE_ARTIFACT_DIR=/tmp/openclaw-update-run-artifacts \
   -e OPENCLAW_UPDATE_RUN_SELF_UPGRADE_SOURCE_VERSION="$SOURCE_VERSION" \
   -v "$ARTIFACT_DIR:/tmp/openclaw-update-run-artifacts" \
-  -v "$QA_CHANNEL_FIXTURE_ARCHIVE:/tmp/openclaw-update-run-historical-dist.tar:ro" \
+  -v "$HISTORICAL_DIST_ARCHIVE:/tmp/openclaw-update-run-historical-dist.tar:ro" \
   "$IMAGE_NAME" \
   timeout --kill-after=30s "$DOCKER_RUN_TIMEOUT" \
-  bash -lc 'mkdir -p /tmp/openclaw-update-run-build
-tar --no-same-owner -xf /tmp/openclaw-update-run-historical-dist.tar -C /tmp/openclaw-update-run-build
+  bash -lc 'set -euo pipefail
+historical_install_root=/tmp/openclaw-update-run-historical-install
+historical_package_root="$historical_install_root/node_modules/openclaw"
+qa_plugin_link=/tmp/openclaw-update-run-build/dist/extensions/qa-channel
+npm install \
+  --prefix "$historical_install_root" \
+  --omit=dev \
+  --no-fund \
+  --no-audit \
+  "openclaw@$OPENCLAW_UPDATE_RUN_SELF_UPGRADE_SOURCE_VERSION" \
+  2>&1 | tee /tmp/openclaw-update-run-artifacts/historical-package-install.log
+tar --no-same-owner \
+  -xf /tmp/openclaw-update-run-historical-dist.tar \
+  -C "$historical_package_root"
+mkdir -p "$(dirname "$qa_plugin_link")"
+ln -s "$historical_package_root/dist/extensions/qa-channel" "$qa_plugin_link"
+HISTORICAL_PACKAGE_ROOT="$historical_package_root" \
+  HISTORICAL_PLUGIN_ENTRY="$historical_package_root/dist/extensions/qa-channel/index.js" \
+  HISTORICAL_PREFLIGHT_OUT=/tmp/openclaw-update-run-artifacts/historical-package-preflight.json \
+  node --input-type=module <<NODE
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+const packageRoot = process.env.HISTORICAL_PACKAGE_ROOT;
+const pluginEntry = process.env.HISTORICAL_PLUGIN_ENTRY;
+const packageVersion = JSON.parse(
+  fs.readFileSync(path.join(packageRoot, "package.json"), "utf8"),
+).version;
+const pluginVersion = JSON.parse(
+  fs.readFileSync(path.join(path.dirname(pluginEntry), "package.json"), "utf8"),
+).version;
+if (packageVersion !== process.env.OPENCLAW_UPDATE_RUN_SELF_UPGRADE_SOURCE_VERSION) {
+  throw new Error("isolated historical package version mismatch: " + packageVersion);
+}
+await import(pathToFileURL(pluginEntry).href);
+fs.writeFileSync(
+  process.env.HISTORICAL_PREFLIGHT_OUT,
+  JSON.stringify({ packageVersion, pluginVersion, pluginEntryImported: true }, null, 2) + "\n",
+);
+NODE
 exec bash scripts/e2e/lib/upgrade-survivor/update-run-package-self-upgrade.sh'

--- a/test/e2e/qa-lab/runtime/update-run-package-self-upgrade.test.ts
+++ b/test/e2e/qa-lab/runtime/update-run-package-self-upgrade.test.ts
@@ -72,6 +72,35 @@ describe("update.run package self-upgrade producer", () => {
     );
   });
 
+  it("proves the authenticated setup lifecycle before updating", async () => {
+    const script = await fs.readFile(
+      path.join(
+        process.cwd(),
+        "scripts/e2e/lib/upgrade-survivor/update-run-package-self-upgrade.sh",
+      ),
+      "utf8",
+    );
+
+    expect(script).toContain(
+      'gateway_call wizard.start \'{"mode":"local"}\' "$WIZARD_START_JSON" "$WIZARD_START_ERR"',
+    );
+    expect(script).toContain(
+      'gateway_call wizard.status "$wizard_session_params" "$WIZARD_STATUS_JSON" "$WIZARD_STATUS_ERR"',
+    );
+    expect(script).toContain(
+      'gateway_call wizard.next "$wizard_next_params" "$WIZARD_NEXT_JSON" "$WIZARD_NEXT_ERR"',
+    );
+    expect(script).toContain('grep -Fq "wizard already running" "$WIZARD_DUPLICATE_ERR"');
+    expect(script).toContain(
+      'gateway_call wizard.cancel "$wizard_session_params" "$WIZARD_CANCEL_JSON" "$WIZARD_CANCEL_ERR"',
+    );
+    expect(script).toContain('grep -Fq "wizard not found" "$WIZARD_CANCELLED_STATUS_ERR"');
+    expect(script).toContain('step.sensitive === true && Object.hasOwn(step, "initialValue")');
+    expect(script.indexOf("Exercising authenticated Gateway wizard RPC lifecycle")).toBeLessThan(
+      script.indexOf("Invoking authenticated Gateway RPC update.run"),
+    );
+  });
+
   it("falls back to the exact tag clone when commit or tag objects are missing", async () => {
     const script = await fs.readFile(
       path.join(process.cwd(), "scripts/e2e/update-run-package-self-upgrade-docker.sh"),
@@ -92,13 +121,19 @@ describe("update.run package self-upgrade producer", () => {
         installedVersion: "2026.7.2",
         source: { version: "2026.4.26" },
         target: { resolvedVersion: "2026.7.2", tag: "latest" },
+        wizardFlow: {
+          authenticated: true,
+          cancelledSessionPurged: true,
+          duplicateStartRejected: true,
+          status: "passed",
+        },
         restartSentinel: {
           message: "QA-UPDATE-RUN-PACKAGE-SELF-UPGRADE",
           status: "ok",
         },
       }),
     ).toBe(
-      "source=2026.4.26; target=latest:2026.7.2; installed=2026.7.2; sentinel=ok:QA-UPDATE-RUN-PACKAGE-SELF-UPGRADE",
+      "wizard=passed:authenticated:exclusive:purged; source=2026.4.26; target=latest:2026.7.2; installed=2026.7.2; sentinel=ok:QA-UPDATE-RUN-PACKAGE-SELF-UPGRADE",
     );
   });
 });

--- a/test/e2e/qa-lab/runtime/update-run-package-self-upgrade.test.ts
+++ b/test/e2e/qa-lab/runtime/update-run-package-self-upgrade.test.ts
@@ -91,11 +91,20 @@ describe("update.run package self-upgrade producer", () => {
       'gateway_call wizard.next "$wizard_next_params" "$WIZARD_NEXT_JSON" "$WIZARD_NEXT_ERR"',
     );
     expect(script).toContain("runningStatusRetained: true");
-    expect(script).toContain('grep -Fq "wizard already running" "$WIZARD_DUPLICATE_ERR"');
+    expect(script).toContain("assert_gateway_call_error_message()");
+    expect(script).toContain(
+      '"$WIZARD_DUPLICATE_JSON" \\\n  "$WIZARD_DUPLICATE_ERR" \\\n  "wizard already running"',
+    );
+    expect(script).toContain('local allow_stderr_fallback="${5:-0}"');
+    expect(script).toContain(
+      '[ "$allow_stderr_fallback" = "1" ] && grep -Fq "$expected" "$error_output"',
+    );
     expect(script).toContain(
       'gateway_call wizard.cancel "$wizard_session_params" "$WIZARD_CANCEL_JSON" "$WIZARD_CANCEL_ERR"',
     );
-    expect(script).toContain('grep -Fq "wizard not found" "$WIZARD_CANCELLED_STATUS_ERR"');
+    expect(script).toContain(
+      '"$WIZARD_CANCELLED_STATUS_JSON" \\\n  "$WIZARD_CANCELLED_STATUS_ERR" \\\n  "wizard not found"',
+    );
     expect(script).toContain('step.sensitive === true && Object.hasOwn(step, "initialValue")');
     expect(script.indexOf("Exercising authenticated Gateway wizard RPC lifecycle")).toBeLessThan(
       script.indexOf("Invoking authenticated Gateway RPC update.run"),
@@ -124,7 +133,9 @@ describe("update.run package self-upgrade producer", () => {
     expect(script).toContain(
       'gateway_call wizard.next "$target_active_next_params" \\\n  "$TARGET_WIZARD_NEXT_JSON" "$TARGET_WIZARD_NEXT_ERR"',
     );
-    expect(script).toContain('grep -Fq "wizard already running" "$TARGET_WIZARD_DUPLICATE_ERR"');
+    expect(script).toContain(
+      '"$TARGET_WIZARD_DUPLICATE_JSON" \\\n  "$TARGET_WIZARD_DUPLICATE_ERR" \\\n  "wizard already running"',
+    );
     expect(script).toContain(
       'gateway_call wizard.cancel "$target_active_session_params" \\\n  "$TARGET_WIZARD_CANCEL_JSON" "$TARGET_WIZARD_CANCEL_ERR"',
     );
@@ -139,7 +150,9 @@ describe("update.run package self-upgrade producer", () => {
         'gateway_call wizard.status "$target_status_session_params" \\\n  "$TARGET_WIZARD_STATUS_PURGED_JSON"',
       ),
     );
-    expect(script).toContain('grep -Fq "wizard not found" "$TARGET_WIZARD_PURGED_STATUS_ERR"');
+    expect(script).toContain(
+      '"$TARGET_WIZARD_PURGED_STATUS_JSON" \\\n  "$TARGET_WIZARD_PURGED_STATUS_ERR" \\\n  "wizard not found"',
+    );
     expect(script.indexOf("target_replacement_start_result=")).toBeLessThan(
       script.indexOf(
         'gateway_call wizard.status "$target_active_session_params" \\\n  "$TARGET_WIZARD_PURGED_STATUS_JSON"',

--- a/test/e2e/qa-lab/runtime/update-run-package-self-upgrade.test.ts
+++ b/test/e2e/qa-lab/runtime/update-run-package-self-upgrade.test.ts
@@ -116,18 +116,31 @@ describe("update.run package self-upgrade producer", () => {
       'gateway_call wizard.status "$target_status_session_params" \\\n  "$TARGET_WIZARD_STATUS_JSON" "$TARGET_WIZARD_STATUS_ERR"',
     );
     expect(script).toContain(
+      'gateway_call wizard.status "$target_status_session_params" \\\n  "$TARGET_WIZARD_STATUS_RETAINED_JSON" "$TARGET_WIZARD_STATUS_RETAINED_ERR"',
+    );
+    expect(script).toContain(
+      'gateway_call wizard.cancel "$target_status_session_params" \\\n  "$TARGET_WIZARD_STATUS_CANCEL_JSON" "$TARGET_WIZARD_STATUS_CANCEL_ERR"',
+    );
+    expect(script).toContain(
       'gateway_call wizard.next "$target_active_next_params" \\\n  "$TARGET_WIZARD_NEXT_JSON" "$TARGET_WIZARD_NEXT_ERR"',
     );
     expect(script).toContain('grep -Fq "wizard already running" "$TARGET_WIZARD_DUPLICATE_ERR"');
     expect(script).toContain(
       'gateway_call wizard.cancel "$target_active_session_params" \\\n  "$TARGET_WIZARD_CANCEL_JSON" "$TARGET_WIZARD_CANCEL_ERR"',
     );
-    expect(script).toContain('while [ "$SECONDS" -lt "$target_cancel_deadline" ]');
+    expect(script).toContain("wait_for_target_wizard_start()");
+    expect(script).toContain("target_status_settlement_polls");
+    expect(script).toContain("target_cancel_settlement_polls");
     expect(script).toContain(
-      '"$TARGET_WIZARD_REPLACEMENT_START_JSON" "$TARGET_WIZARD_REPLACEMENT_START_ERR"',
+      '"$TARGET_WIZARD_REPLACEMENT_START_JSON" \\\n    "$TARGET_WIZARD_REPLACEMENT_START_ERR"',
+    );
+    expect(script.indexOf("target_active_start_result=")).toBeLessThan(
+      script.indexOf(
+        'gateway_call wizard.status "$target_status_session_params" \\\n  "$TARGET_WIZARD_STATUS_PURGED_JSON"',
+      ),
     );
     expect(script).toContain('grep -Fq "wizard not found" "$TARGET_WIZARD_PURGED_STATUS_ERR"');
-    expect(script.indexOf('while [ "$SECONDS" -lt "$target_cancel_deadline" ]')).toBeLessThan(
+    expect(script.indexOf("target_replacement_start_result=")).toBeLessThan(
       script.indexOf(
         'gateway_call wizard.status "$target_active_session_params" \\\n  "$TARGET_WIZARD_PURGED_STATUS_JSON"',
       ),
@@ -189,7 +202,10 @@ describe("update.run package self-upgrade producer", () => {
           },
           authenticated: true,
           status: "passed",
-          terminalStatus: { purged: true },
+          statusSession: {
+            purged: true,
+            runningStatusRetained: true,
+          },
         },
         restartSentinel: {
           message: "QA-UPDATE-RUN-PACKAGE-SELF-UPGRADE",
@@ -197,7 +213,7 @@ describe("update.run package self-upgrade producer", () => {
         },
       }),
     ).toBe(
-      "wizard=passed:authenticated:status-retained:exclusive:purged; target-wizard=passed:authenticated:terminal-status:exclusive:purged; source=2026.4.26; target=latest:2026.7.2; installed=2026.7.2; sentinel=ok:QA-UPDATE-RUN-PACKAGE-SELF-UPGRADE",
+      "wizard=passed:authenticated:status-retained:exclusive:purged; target-wizard=passed:authenticated:status-retained:status-purged:exclusive:purged; source=2026.4.26; target=latest:2026.7.2; installed=2026.7.2; sentinel=ok:QA-UPDATE-RUN-PACKAGE-SELF-UPGRADE",
     );
   });
 });

--- a/test/e2e/qa-lab/runtime/update-run-package-self-upgrade.test.ts
+++ b/test/e2e/qa-lab/runtime/update-run-package-self-upgrade.test.ts
@@ -90,6 +90,7 @@ describe("update.run package self-upgrade producer", () => {
     expect(script).toContain(
       'gateway_call wizard.next "$wizard_next_params" "$WIZARD_NEXT_JSON" "$WIZARD_NEXT_ERR"',
     );
+    expect(script).toContain("runningStatusRetained: true");
     expect(script).toContain('grep -Fq "wizard already running" "$WIZARD_DUPLICATE_ERR"');
     expect(script).toContain(
       'gateway_call wizard.cancel "$wizard_session_params" "$WIZARD_CANCEL_JSON" "$WIZARD_CANCEL_ERR"',
@@ -121,7 +122,16 @@ describe("update.run package self-upgrade producer", () => {
     expect(script).toContain(
       'gateway_call wizard.cancel "$target_active_session_params" \\\n  "$TARGET_WIZARD_CANCEL_JSON" "$TARGET_WIZARD_CANCEL_ERR"',
     );
+    expect(script).toContain('while [ "$SECONDS" -lt "$target_cancel_deadline" ]');
+    expect(script).toContain(
+      '"$TARGET_WIZARD_REPLACEMENT_START_JSON" "$TARGET_WIZARD_REPLACEMENT_START_ERR"',
+    );
     expect(script).toContain('grep -Fq "wizard not found" "$TARGET_WIZARD_PURGED_STATUS_ERR"');
+    expect(script.indexOf('while [ "$SECONDS" -lt "$target_cancel_deadline" ]')).toBeLessThan(
+      script.indexOf(
+        'gateway_call wizard.status "$target_active_session_params" \\\n  "$TARGET_WIZARD_PURGED_STATUS_JSON"',
+      ),
+    );
     expect(script.indexOf("Invoking authenticated Gateway RPC update.run")).toBeLessThan(
       script.indexOf("Exercising current target Gateway wizard RPC lifecycle"),
     );
@@ -142,13 +152,21 @@ describe("update.run package self-upgrade producer", () => {
     expect(script).toContain(
       '! git -C "$source_repo" cat-file -e "$SOURCE_TAG^{commit}" 2>/dev/null',
     );
-    expect(script).toContain('tar -C "$checkout_root" -cf "$QA_CHANNEL_FIXTURE_ARCHIVE" dist');
+    expect(script).toContain('tar -C "$checkout_root" -cf "$HISTORICAL_DIST_ARCHIVE" dist');
     expect(script).toContain(
-      "tar --no-same-owner -xf /tmp/openclaw-update-run-historical-dist.tar -C /tmp/openclaw-update-run-build",
+      'npm install \\\n  --prefix "$historical_install_root" \\\n  --omit=dev',
     );
+    expect(script).toContain(
+      'tar --no-same-owner \\\n  -xf /tmp/openclaw-update-run-historical-dist.tar \\\n  -C "$historical_package_root"',
+    );
+    expect(script).toContain(
+      'ln -s "$historical_package_root/dist/extensions/qa-channel" "$qa_plugin_link"',
+    );
+    expect(script).toContain("await import(pathToFileURL(pluginEntry).href)");
     expect(script).not.toContain(
       '-v "$QA_CHANNEL_FIXTURE_ROOT/checkout:/tmp/openclaw-update-run-build:ro"',
     );
+    expect(script).not.toContain("NODE_PATH");
   });
 
   it("formats the proven version transition and sentinel", () => {
@@ -161,6 +179,7 @@ describe("update.run package self-upgrade producer", () => {
           authenticated: true,
           cancelledSessionPurged: true,
           duplicateStartRejected: true,
+          runningStatusRetained: true,
           status: "passed",
         },
         targetWizardFlow: {
@@ -178,7 +197,7 @@ describe("update.run package self-upgrade producer", () => {
         },
       }),
     ).toBe(
-      "wizard=passed:authenticated:exclusive:purged; target-wizard=passed:authenticated:terminal-status:exclusive:purged; source=2026.4.26; target=latest:2026.7.2; installed=2026.7.2; sentinel=ok:QA-UPDATE-RUN-PACKAGE-SELF-UPGRADE",
+      "wizard=passed:authenticated:status-retained:exclusive:purged; target-wizard=passed:authenticated:terminal-status:exclusive:purged; source=2026.4.26; target=latest:2026.7.2; installed=2026.7.2; sentinel=ok:QA-UPDATE-RUN-PACKAGE-SELF-UPGRADE",
     );
   });
 });

--- a/test/e2e/qa-lab/runtime/update-run-package-self-upgrade.test.ts
+++ b/test/e2e/qa-lab/runtime/update-run-package-self-upgrade.test.ts
@@ -142,6 +142,15 @@ describe("update.run package self-upgrade producer", () => {
     expect(script).toContain(
       '! git -C "$source_repo" cat-file -e "$SOURCE_TAG^{commit}" 2>/dev/null',
     );
+    expect(script).toContain(
+      'tar -C "$checkout_root" -cf "$QA_CHANNEL_FIXTURE_ARCHIVE" dist/extensions/qa-channel',
+    );
+    expect(script).toContain(
+      "tar --no-same-owner -xf /tmp/openclaw-update-run-qa-channel.tar -C /tmp/openclaw-update-run-build",
+    );
+    expect(script).not.toContain(
+      '-v "$QA_CHANNEL_FIXTURE_ROOT/checkout:/tmp/openclaw-update-run-build:ro"',
+    );
   });
 
   it("formats the proven version transition and sentinel", () => {

--- a/test/e2e/qa-lab/runtime/update-run-package-self-upgrade.test.ts
+++ b/test/e2e/qa-lab/runtime/update-run-package-self-upgrade.test.ts
@@ -101,6 +101,35 @@ describe("update.run package self-upgrade producer", () => {
     );
   });
 
+  it("proves the current target setup lifecycle after updating", async () => {
+    const script = await fs.readFile(
+      path.join(
+        process.cwd(),
+        "scripts/e2e/lib/upgrade-survivor/update-run-package-self-upgrade.sh",
+      ),
+      "utf8",
+    );
+
+    expect(script).toContain("Exercising current target Gateway wizard RPC lifecycle");
+    expect(script).toContain(
+      'gateway_call wizard.status "$target_status_session_params" \\\n  "$TARGET_WIZARD_STATUS_JSON" "$TARGET_WIZARD_STATUS_ERR"',
+    );
+    expect(script).toContain(
+      'gateway_call wizard.next "$target_active_next_params" \\\n  "$TARGET_WIZARD_NEXT_JSON" "$TARGET_WIZARD_NEXT_ERR"',
+    );
+    expect(script).toContain('grep -Fq "wizard already running" "$TARGET_WIZARD_DUPLICATE_ERR"');
+    expect(script).toContain(
+      'gateway_call wizard.cancel "$target_active_session_params" \\\n  "$TARGET_WIZARD_CANCEL_JSON" "$TARGET_WIZARD_CANCEL_ERR"',
+    );
+    expect(script).toContain('grep -Fq "wizard not found" "$TARGET_WIZARD_PURGED_STATUS_ERR"');
+    expect(script.indexOf("Invoking authenticated Gateway RPC update.run")).toBeLessThan(
+      script.indexOf("Exercising current target Gateway wizard RPC lifecycle"),
+    );
+    expect(script.indexOf("Exercising current target Gateway wizard RPC lifecycle")).toBeLessThan(
+      script.indexOf("post_restart_observed_at_ms="),
+    );
+  });
+
   it("falls back to the exact tag clone when commit or tag objects are missing", async () => {
     const script = await fs.readFile(
       path.join(process.cwd(), "scripts/e2e/update-run-package-self-upgrade-docker.sh"),
@@ -127,13 +156,22 @@ describe("update.run package self-upgrade producer", () => {
           duplicateStartRejected: true,
           status: "passed",
         },
+        targetWizardFlow: {
+          activeSession: {
+            duplicateStartRejected: true,
+            purged: true,
+          },
+          authenticated: true,
+          status: "passed",
+          terminalStatus: { purged: true },
+        },
         restartSentinel: {
           message: "QA-UPDATE-RUN-PACKAGE-SELF-UPGRADE",
           status: "ok",
         },
       }),
     ).toBe(
-      "wizard=passed:authenticated:exclusive:purged; source=2026.4.26; target=latest:2026.7.2; installed=2026.7.2; sentinel=ok:QA-UPDATE-RUN-PACKAGE-SELF-UPGRADE",
+      "wizard=passed:authenticated:exclusive:purged; target-wizard=passed:authenticated:terminal-status:exclusive:purged; source=2026.4.26; target=latest:2026.7.2; installed=2026.7.2; sentinel=ok:QA-UPDATE-RUN-PACKAGE-SELF-UPGRADE",
     );
   });
 });

--- a/test/e2e/qa-lab/runtime/update-run-package-self-upgrade.test.ts
+++ b/test/e2e/qa-lab/runtime/update-run-package-self-upgrade.test.ts
@@ -142,11 +142,9 @@ describe("update.run package self-upgrade producer", () => {
     expect(script).toContain(
       '! git -C "$source_repo" cat-file -e "$SOURCE_TAG^{commit}" 2>/dev/null',
     );
+    expect(script).toContain('tar -C "$checkout_root" -cf "$QA_CHANNEL_FIXTURE_ARCHIVE" dist');
     expect(script).toContain(
-      'tar -C "$checkout_root" -cf "$QA_CHANNEL_FIXTURE_ARCHIVE" dist/extensions/qa-channel',
-    );
-    expect(script).toContain(
-      "tar --no-same-owner -xf /tmp/openclaw-update-run-qa-channel.tar -C /tmp/openclaw-update-run-build",
+      "tar --no-same-owner -xf /tmp/openclaw-update-run-historical-dist.tar -C /tmp/openclaw-update-run-build",
     );
     expect(script).not.toContain(
       '-v "$QA_CHANNEL_FIXTURE_ROOT/checkout:/tmp/openclaw-update-run-build:ro"',

--- a/test/e2e/qa-lab/runtime/update-run-package-self-upgrade.ts
+++ b/test/e2e/qa-lab/runtime/update-run-package-self-upgrade.ts
@@ -23,6 +23,12 @@ type UpdateRunSelfUpgradeSummary = {
   source?: { version?: string };
   target?: { resolvedVersion?: string; tag?: string };
   restartSentinel?: { message?: string; status?: string };
+  wizardFlow?: {
+    authenticated?: boolean;
+    duplicateStartRejected?: boolean;
+    cancelledSessionPurged?: boolean;
+    status?: string;
+  };
 };
 
 function formatErrorMessage(error: unknown) {
@@ -63,6 +69,7 @@ export function resolveUpdateRunSelfUpgradePermission(
 
 export function formatUpdateRunSelfUpgradeDetails(summary: UpdateRunSelfUpgradeSummary) {
   return [
+    `wizard=${summary.wizardFlow?.status ?? "unknown"}:${summary.wizardFlow?.authenticated === true ? "authenticated" : "unauthenticated"}:${summary.wizardFlow?.duplicateStartRejected === true ? "exclusive" : "overlap-unknown"}:${summary.wizardFlow?.cancelledSessionPurged === true ? "purged" : "cleanup-unknown"}`,
     `source=${summary.source?.version ?? "unknown"}`,
     `target=${summary.target?.tag ?? "unknown"}:${summary.target?.resolvedVersion ?? "unknown"}`,
     `installed=${summary.installedVersion ?? "unknown"}`,
@@ -111,7 +118,7 @@ async function runProducer(options: ProducerOptions): Promise<QaEvidenceSummaryJ
   const writer = createQaScriptEvidenceWriter({
     artifactBase: options.artifactBase,
     logFileName: "update-run-package-self-upgrade.log",
-    primaryModel: "gateway/update.run",
+    primaryModel: "gateway/update-and-setup",
     providerMode: "mock-openai",
     repoRoot: options.repoRoot,
     target: {
@@ -122,6 +129,7 @@ async function runProducer(options: ProducerOptions): Promise<QaEvidenceSummaryJ
         "scripts/e2e/lib/upgrade-survivor/assertions.mjs",
         "scripts/lib/docker-e2e-scenarios.mjs",
         "src/gateway/server-methods/update.ts",
+        "src/gateway/server-methods/wizard.ts",
       ],
       docsRefs: [
         "docs/cli/update.md",
@@ -159,6 +167,7 @@ async function runProducer(options: ProducerOptions): Promise<QaEvidenceSummaryJ
     return await writer.write({
       artifacts: [
         { kind: "summary", filePath: path.join("lane", "summary.json") },
+        { kind: "rpc", filePath: path.join("lane", "wizard-flow.json") },
         { kind: "rpc", filePath: path.join("lane", "update-rpc.json") },
         { kind: "sentinel", filePath: path.join("lane", "update-status.json") },
         {

--- a/test/e2e/qa-lab/runtime/update-run-package-self-upgrade.ts
+++ b/test/e2e/qa-lab/runtime/update-run-package-self-upgrade.ts
@@ -29,6 +29,15 @@ type UpdateRunSelfUpgradeSummary = {
     cancelledSessionPurged?: boolean;
     status?: string;
   };
+  targetWizardFlow?: {
+    activeSession?: {
+      duplicateStartRejected?: boolean;
+      purged?: boolean;
+    };
+    authenticated?: boolean;
+    status?: string;
+    terminalStatus?: { purged?: boolean };
+  };
 };
 
 function formatErrorMessage(error: unknown) {
@@ -70,6 +79,7 @@ export function resolveUpdateRunSelfUpgradePermission(
 export function formatUpdateRunSelfUpgradeDetails(summary: UpdateRunSelfUpgradeSummary) {
   return [
     `wizard=${summary.wizardFlow?.status ?? "unknown"}:${summary.wizardFlow?.authenticated === true ? "authenticated" : "unauthenticated"}:${summary.wizardFlow?.duplicateStartRejected === true ? "exclusive" : "overlap-unknown"}:${summary.wizardFlow?.cancelledSessionPurged === true ? "purged" : "cleanup-unknown"}`,
+    `target-wizard=${summary.targetWizardFlow?.status ?? "unknown"}:${summary.targetWizardFlow?.authenticated === true ? "authenticated" : "unauthenticated"}:${summary.targetWizardFlow?.terminalStatus?.purged === true ? "terminal-status" : "status-unknown"}:${summary.targetWizardFlow?.activeSession?.duplicateStartRejected === true ? "exclusive" : "overlap-unknown"}:${summary.targetWizardFlow?.activeSession?.purged === true ? "purged" : "cleanup-unknown"}`,
     `source=${summary.source?.version ?? "unknown"}`,
     `target=${summary.target?.tag ?? "unknown"}:${summary.target?.resolvedVersion ?? "unknown"}`,
     `installed=${summary.installedVersion ?? "unknown"}`,
@@ -168,6 +178,7 @@ async function runProducer(options: ProducerOptions): Promise<QaEvidenceSummaryJ
       artifacts: [
         { kind: "summary", filePath: path.join("lane", "summary.json") },
         { kind: "rpc", filePath: path.join("lane", "wizard-flow.json") },
+        { kind: "rpc", filePath: path.join("lane", "target-wizard-flow.json") },
         { kind: "rpc", filePath: path.join("lane", "update-rpc.json") },
         { kind: "sentinel", filePath: path.join("lane", "update-status.json") },
         {

--- a/test/e2e/qa-lab/runtime/update-run-package-self-upgrade.ts
+++ b/test/e2e/qa-lab/runtime/update-run-package-self-upgrade.ts
@@ -27,6 +27,7 @@ type UpdateRunSelfUpgradeSummary = {
     authenticated?: boolean;
     duplicateStartRejected?: boolean;
     cancelledSessionPurged?: boolean;
+    runningStatusRetained?: boolean;
     status?: string;
   };
   targetWizardFlow?: {
@@ -78,7 +79,7 @@ export function resolveUpdateRunSelfUpgradePermission(
 
 export function formatUpdateRunSelfUpgradeDetails(summary: UpdateRunSelfUpgradeSummary) {
   return [
-    `wizard=${summary.wizardFlow?.status ?? "unknown"}:${summary.wizardFlow?.authenticated === true ? "authenticated" : "unauthenticated"}:${summary.wizardFlow?.duplicateStartRejected === true ? "exclusive" : "overlap-unknown"}:${summary.wizardFlow?.cancelledSessionPurged === true ? "purged" : "cleanup-unknown"}`,
+    `wizard=${summary.wizardFlow?.status ?? "unknown"}:${summary.wizardFlow?.authenticated === true ? "authenticated" : "unauthenticated"}:${summary.wizardFlow?.runningStatusRetained === true ? "status-retained" : "status-unknown"}:${summary.wizardFlow?.duplicateStartRejected === true ? "exclusive" : "overlap-unknown"}:${summary.wizardFlow?.cancelledSessionPurged === true ? "purged" : "cleanup-unknown"}`,
     `target-wizard=${summary.targetWizardFlow?.status ?? "unknown"}:${summary.targetWizardFlow?.authenticated === true ? "authenticated" : "unauthenticated"}:${summary.targetWizardFlow?.terminalStatus?.purged === true ? "terminal-status" : "status-unknown"}:${summary.targetWizardFlow?.activeSession?.duplicateStartRejected === true ? "exclusive" : "overlap-unknown"}:${summary.targetWizardFlow?.activeSession?.purged === true ? "purged" : "cleanup-unknown"}`,
     `source=${summary.source?.version ?? "unknown"}`,
     `target=${summary.target?.tag ?? "unknown"}:${summary.target?.resolvedVersion ?? "unknown"}`,
@@ -189,6 +190,11 @@ async function runProducer(options: ProducerOptions): Promise<QaEvidenceSummaryJ
         { kind: "summary", filePath: path.join("lane", "source-plugin-inspect.json") },
         { kind: "summary", filePath: path.join("lane", "target-plugin-index.json") },
         { kind: "log", filePath: path.join("lane", "historical-qa-channel-build.log") },
+        { kind: "log", filePath: path.join("lane", "historical-package-install.log") },
+        {
+          kind: "summary",
+          filePath: path.join("lane", "historical-package-preflight.json"),
+        },
         {
           kind: "summary",
           filePath: path.join("lane", "qa-channel-fixture-provenance.json"),

--- a/test/e2e/qa-lab/runtime/update-run-package-self-upgrade.ts
+++ b/test/e2e/qa-lab/runtime/update-run-package-self-upgrade.ts
@@ -37,7 +37,10 @@ type UpdateRunSelfUpgradeSummary = {
     };
     authenticated?: boolean;
     status?: string;
-    terminalStatus?: { purged?: boolean };
+    statusSession?: {
+      purged?: boolean;
+      runningStatusRetained?: boolean;
+    };
   };
 };
 
@@ -80,7 +83,7 @@ export function resolveUpdateRunSelfUpgradePermission(
 export function formatUpdateRunSelfUpgradeDetails(summary: UpdateRunSelfUpgradeSummary) {
   return [
     `wizard=${summary.wizardFlow?.status ?? "unknown"}:${summary.wizardFlow?.authenticated === true ? "authenticated" : "unauthenticated"}:${summary.wizardFlow?.runningStatusRetained === true ? "status-retained" : "status-unknown"}:${summary.wizardFlow?.duplicateStartRejected === true ? "exclusive" : "overlap-unknown"}:${summary.wizardFlow?.cancelledSessionPurged === true ? "purged" : "cleanup-unknown"}`,
-    `target-wizard=${summary.targetWizardFlow?.status ?? "unknown"}:${summary.targetWizardFlow?.authenticated === true ? "authenticated" : "unauthenticated"}:${summary.targetWizardFlow?.terminalStatus?.purged === true ? "terminal-status" : "status-unknown"}:${summary.targetWizardFlow?.activeSession?.duplicateStartRejected === true ? "exclusive" : "overlap-unknown"}:${summary.targetWizardFlow?.activeSession?.purged === true ? "purged" : "cleanup-unknown"}`,
+    `target-wizard=${summary.targetWizardFlow?.status ?? "unknown"}:${summary.targetWizardFlow?.authenticated === true ? "authenticated" : "unauthenticated"}:${summary.targetWizardFlow?.statusSession?.runningStatusRetained === true ? "status-retained" : "status-unknown"}:${summary.targetWizardFlow?.statusSession?.purged === true ? "status-purged" : "status-cleanup-unknown"}:${summary.targetWizardFlow?.activeSession?.duplicateStartRejected === true ? "exclusive" : "overlap-unknown"}:${summary.targetWizardFlow?.activeSession?.purged === true ? "purged" : "cleanup-unknown"}`,
     `source=${summary.source?.version ?? "unknown"}`,
     `target=${summary.target?.tag ?? "unknown"}:${summary.target?.resolvedVersion ?? "unknown"}`,
     `installed=${summary.installedVersion ?? "unknown"}`,


### PR DESCRIPTION
## What Problem This Solves

Gateway QA had real installed-package proof for `update.run`, but no primary
scenario covered the adjacent authenticated `wizard.*` setup lifecycle. Drift
in setup-session exclusivity, live-status retention, settlement cleanup, or
error projection could therefore escape the Gateway coverage portfolio.

## Why This Change Was Made

The package self-upgrade scenario now exercises `wizard.start`,
`wizard.status`, `wizard.next`, and `wizard.cancel` against both the installed
historical `openclaw@2026.4.26` Gateway and the updated target Gateway.

The target flow follows the current lifecycle contract: a running wizard
remains reachable through repeated status calls; cancellation cleanup waits
for settlement; replacement sessions prove the old session was purged; and
current JSON-mode RPC errors are read from the structured stdout envelope.
The historical CLI keeps a narrowly scoped stderr fallback because that is its
published contract.

No production code, taxonomy, QA internals, or existing CLI primary ownership
changes.

## User Impact

No runtime behavior changes. Maintainers gain installed-package regression
proof for Gateway setup and update RPCs in one destructive acceptance lane.

## Evidence

Frozen head: `e93a97bcbdaafe2a22956314c4021c1552ccb2bd`.

- Focused Vitest: 8/8 passed.
- `bash -n` passed for both shell producers.
- Changed-file formatting and `git diff --check` passed.
- Explicit structured-error parser smoke passed.
- QA coverage resolves `gateway.update-and-setup-apis` to exactly
  `update-run-package-self-upgrade` as a primary owner.
- Autoreview: clean, no accepted/actionable findings, correctness 0.99;
  TruffleHog clean.
- Hosted CI at the frozen head: `openclaw/ci-gate` and all required checks
  passed.
- Exact-head AWS changed gate `run_fb59247f25e5`: passed with exit 0 after
  verifying the exact five-path diff and all five frozen-head blob hashes.
  Fail-safe lanes included full tsgo, type-aware core/extensions/scripts lint,
  formatting, dependency and policy guards, SDK/database guards, and runtime
  import-cycle checks.
- Exact-head AWS package acceptance:
  - `run_c4b02f20dcd9`: the destructive workload returned 0 and emitted the
    suite report, evidence, and summary paths. The outer broker failed while
    appending its event after the workload completed.
  - `run_ff76bee26cf2`: the destructive workload returned 0 again. Under
    `set -e`, exact evidence assertions and every lane lifecycle assertion
    completed before the post-run validator failed.
  - The validator failure was a wrapper bug, not a suite failure: it asserted
    a nonexistent top-level `.status` in `qa-suite-summary.json`.
    `extensions/qa-lab/src/suite-summary.ts` defines `scenarios`, `counts`,
    optional metrics/evidence, and `run`; future validation uses
    `.counts.total == 1 and .counts.failed == 0 and .counts.passed == 1`.
  - Exact evidence ref: `e93a97bcbdaafe2a22956314c4021c1552ccb2bd`.
  - Lifecycle assertions passed: authenticated historical and target calls,
    duplicate-start rejection, live-status retention, cancellation settlement,
    old-session purge, replacement exclusivity, installed target version,
    restart sentinel, health, readiness, and Gateway status.

## ClawSweeper Rank-up Moves

- **Keep live wizard status reachable: satisfied.** Repeated target
  `wizard.status` calls retain the running session.
- **Wait for cancellation settlement before requiring purge: satisfied.**
  Replacement start/status polling establishes settlement before old-session
  absence is asserted.
- **Obtain exact repaired-head packaged proof: satisfied.** The destructive
  workload returned 0 twice at `e93a97b`; the second capture completed all
  exact evidence and lane lifecycle assertions before the documented
  suite-summary wrapper mistake.
- **Attach redacted post-fix RPC evidence: satisfied.** The evidence is bounded
  to lifecycle outcomes and exact frozen-head metadata; no credentials or
  private infrastructure details are included.
- **Current re-review: infrastructure-blocked, disposition preserved.**
  ClawSweeper exact-head runs `30866590403` and `30867392655` failed in its
  Codex execution before publishing an artifact. The repaired moves above are
  applied and independently covered by exact-head autoreview, package
  acceptance, changed gate, and hosted CI.

## Repair Summary

- Root cause: the QA producer treated status polling as cleanup, raced
  cancellation settlement, and expected current JSON-mode RPC errors on
  stderr.
- Architectural owner: the destructive package-upgrade QA producer and its
  fixture assertions.
- Canonical fix: model the real wizard lifecycle in the producer, poll the
  owner boundary for settlement, and parse the current structured error
  envelope.
- Removed paths: immediate-purge assertions and unconditional stderr matching.
- Sibling coverage: historical published CLI behavior and current target CLI
  behavior are both exercised in the same installed-package run.

## Scope

- Production LOC: +0/-0.
- QA/test/scripts only: +777/-7.
- Existing CLI primary `cli.update-status-and-rpc` remains primary.
- Added primary coverage: `gateway.update-and-setup-apis`.
