### PR TITLE
test(qa): register external app SDK proof

### DIFF
--- a/qa/scenarios/runtime/app-sdk-gateway-conversations.yaml
+++ b/qa/scenarios/runtime/app-sdk-gateway-conversations.yaml
@@ -1,0 +1,34 @@
+title: Source-internal App SDK preview Gateway conversation evidence
+
+scenario:
+  id: app-sdk-gateway-conversations
+  surface: app-sdk
+  coverage:
+    primary:
+      - app-sdk.namespace-layout
+      - app-sdk.gateway-connect
+      - app-sdk.url-and-token-config
+      - app-sdk.agent-handles
+      - app-sdk.agent-runs
+      - app-sdk.session-creation
+      - app-sdk.session-send
+      - app-sdk.session-controls
+      - app-sdk.toolspace
+      - app-sdk.tasks
+  objective: Exercise the source-internal App SDK preview across isolated Gateway WebSocket connections, conversation handles, and the supported resource namespaces without treating the private package as published.
+  successCriteria:
+    - Explicit Gateway URLs and tokens complete the WebSocket challenge and connection handshake.
+    - Agent handles start runs, wait for completion, and cancel through Gateway RPC.
+    - Session helpers create, resolve, send, abort, patch, and compact reusable conversations.
+    - Agent, tool, and task namespaces issue the expected Gateway methods and return SDK-level results.
+  docsRefs:
+    - docs/gateway/external-apps.md
+    - docs/gateway/protocol.md
+  codeRefs:
+    - packages/sdk/src/client.ts
+    - packages/sdk/src/transport.ts
+    - packages/sdk/src/index.e2e.test.ts
+  execution:
+    kind: vitest
+    path: packages/sdk/src/index.e2e.test.ts
+    summary: Run the source-internal App SDK preview over fake and isolated Gateway WebSocket boundaries.

--- a/qa/scenarios/runtime/app-sdk-package-entrypoints.yaml
+++ b/qa/scenarios/runtime/app-sdk-package-entrypoints.yaml
@@ -1,0 +1,25 @@
+title: Source-internal App SDK preview package entrypoint evidence
+
+scenario:
+  id: app-sdk-package-entrypoints
+  surface: app-sdk
+  category: app-sdk.client-api
+  coverage:
+    primary:
+      - app-sdk.sdk-entrypoints
+  objective: Verify a clean temporary consumer can install the source-built preview @openclaw/sdk artifact and execute its root entrypoint without treating the private package as published.
+  successCriteria:
+    - The private SDK preview and its workspace dependencies build and pack as npm artifacts without workspace-only dependency references.
+    - A temporary consumer installs the source-built preview artifacts through an isolated local registry.
+    - The preview package root exports GatewayClientTransport, OpenClaw, and normalizeGatewayEvent, and event normalization executes from the installed artifact.
+  docsRefs:
+    - docs/gateway/external-apps.md
+    - docs/gateway/protocol.md
+  codeRefs:
+    - packages/sdk/package.json
+    - packages/sdk/src/index.ts
+    - packages/sdk/src/package.e2e.test.ts
+  execution:
+    kind: vitest
+    path: packages/sdk/src/package.e2e.test.ts
+    summary: Pack the source-internal App SDK preview and import its root from a clean temporary consumer.

--- a/qa/scenarios/runtime/app-sdk-unsupported-calls.yaml
+++ b/qa/scenarios/runtime/app-sdk-unsupported-calls.yaml
@@ -1,0 +1,24 @@
+title: Source-internal App SDK preview unsupported call evidence
+
+scenario:
+  id: app-sdk-unsupported-calls
+  surface: app-sdk
+  category: app-sdk.compatibility
+  coverage:
+    primary:
+      - app-sdk.unsupported-calls
+  objective: Verify the source-internal App SDK preview rejects unsupported per-run execution options before dispatching a Gateway request.
+  successCriteria:
+    - Provider-qualified model references are translated into supported provider and model request fields.
+    - Workspace, runtime, environment, and approval overrides are rejected before transport dispatch.
+    - The rejection identifies every unsupported option so callers receive an actionable result.
+  docsRefs:
+    - docs/gateway/external-apps.md
+    - docs/gateway/protocol.md
+  codeRefs:
+    - packages/sdk/src/client.ts
+    - packages/sdk/src/index.test.ts
+  execution:
+    kind: vitest
+    path: packages/sdk/src/index.test.ts
+    summary: Run the preview SDK request-shaping assertions for supported model refs and unsupported per-run options.


### PR DESCRIPTION
Related: #118785

## What Problem This Solves

The QA catalog lacked executable primary proof for the source-internal TypeScript App SDK preview. The first registration also overclaimed four taxonomy IDs and cited the Gateway clients guide in a way that could imply `@openclaw/sdk` is already a published package.

## Why This Change Was Made

This registers three existing Vitest boundaries for 12 honest A1 claims: 10 Gateway conversation/resource claims, one preview package-entrypoint claim, and one unsupported-call claim. Event stream/envelope proof moves to A2, while models and ergonomic wrappers remain blocked pending public contracts. The scenarios describe the private `0.0.0-private` package as a source-internal preview and cite the current external-app and protocol docs only.

No SDK production code, SDK tests, Swift code, or transport/event behavior owned by #116904 changes here.

## User Impact

Maintainers can discover and execute accurate QA proof for the current App SDK preview without treating incomplete event, models, wrapper, or package-publication contracts as complete. There is no user-visible runtime behavior change.

## Evidence

- Frozen base: `05dc73bb35fd6ef1dc56ec82f0e913476d438412`
- Corrected head: `67801b7b6a25ce17f2372b41b9d0fb8d62d58620`
- Coverage ownership: exactly 12 primary IDs, split `10/1/1` across `app-sdk-gateway-conversations`, `app-sdk-package-entrypoints`, and `app-sdk-unsupported-calls`.
- Removed from A1: `app-sdk.event-stream`, `app-sdk.event-envelope`, `app-sdk.models`, and `app-sdk.ergonomic-wrappers`.
- Trusted AWS Crabbox proof: https://crabbox.openclaw.ai/portal/runs/run_2b4cc4bd599b
  - `packages/sdk/src/index.test.ts`: 38 passed.
  - SDK E2E: 6 passed, 1 intentional live test skipped.
  - QA catalog, coverage, and routing: 69 passed.
  - QA Suite: 3 passed, 0 failed, 0 skipped.
  - Fresh `qa-evidence.json` references the corrected head and contains exactly the 12 retained primary claims.
  - `node scripts/check-changed.mjs -- <three scenario files>` passed the fail-safe all-lanes gate, including typecheck, lint, and import-cycle checks.
- Exact coverage, formatting, diff checks, and private-path scrub passed.
- Autoreview: clean, no accepted or actionable findings.
- Blacksmith Testbox was unavailable because its CLI was not authenticated; trusted AWS Crabbox provided the required remote proof.
- AI-assisted: yes. The final diff, source contracts, and evidence were reviewed directly.

## Rank-up Decision

The optional rebase and QA rerun are intentionally skipped. Intervening `main` changes through `cd42cb77033265b3cc63846e2391f77366f356eb` do not overlap these three QA YAMLs or their reviewed App SDK, QA runner, and external-app/protocol documentation boundaries. Exact-head AWS Crabbox run `run_2b4cc4bd599b` is green. Root repository policy rejects rebasing solely for unrelated drift, so the reviewed head remains frozen at `67801b7b6a25ce17f2372b41b9d0fb8d62d58620`.

## Maintainer Acceptance

Maintainer decision: accept source-built private-preview evidence as primary QA evidence for exactly these 12 current-behavior A1 IDs. This bounded acceptance does not establish a published or public package contract. `app-sdk.event-stream` and `app-sdk.event-envelope` remain A2 pending explicit event-contract proof; `app-sdk.models` and `app-sdk.ergonomic-wrappers` remain blocked. Publication, additional event, model, and wrapper claims remain excluded from this A1 decision.
