### PR TITLE
fix: send fallback for empty visible channel turns

### DIFF
--- a/src/channels/turn/kernel.test.ts
+++ b/src/channels/turn/kernel.test.ts
@@ -696,6 +696,49 @@ describe("channel turn kernel", () => {
     expect(delivered.visibleReplySent).toBe(true);
   });
 
+  it("sends a visible fallback when an assembled dispatch returns no visible reply", async () => {
+    const dispatchReplyWithBufferedBlockDispatcher = vi.fn(async () => ({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+      noVisibleReplyFallbackEligible: true,
+    })) as unknown as DispatchReplyWithBufferedBlockDispatcher;
+    const deliver = vi.fn(async () => ({ visibleReplySent: true }));
+
+    const result = await dispatchAssembledChannelTurn({
+      cfg,
+      channel: "slack",
+      accountId: "acct",
+      agentId: "main",
+      routeSessionKey: "agent:main:slack:channel:thread",
+      storePath: "/tmp/sessions.json",
+      ctxPayload: createCtx({
+        Provider: "slack",
+        Surface: "slack",
+        ChatType: "channel",
+      }),
+      recordInboundSession: createRecordInboundSession(),
+      dispatchReplyWithBufferedBlockDispatcher,
+      delivery: { deliver },
+    });
+
+    expect(deliver).toHaveBeenCalledTimes(1);
+    expect(deliver).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: expect.stringContaining("internal runtime issue"),
+        isError: true,
+        isStatusNotice: true,
+      }),
+      { kind: "final" },
+    );
+    expectDispatched(result);
+    expect(result.dispatchResult).toMatchObject({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+      noVisibleReplyFallbackEligible: true,
+      observedReplyDelivery: true,
+    });
+  });
+
   it("maps durable hook cancellation to typed routed suppression", async () => {
     sendDurableMessageBatch.mockResolvedValueOnce({
       status: "suppressed",

--- a/src/channels/turn/lifecycle.ts
+++ b/src/channels/turn/lifecycle.ts
@@ -20,6 +20,10 @@ import { createChannelReplyPipeline } from "../message/reply-pipeline.js";
 import { recordInboundSession } from "../session.js";
 import { isChannelPartialDeliveryError } from "./delivery-result.js";
 import {
+  hasVisibleChannelTurnDispatch,
+  type ChannelTurnDispatchResultLike,
+} from "./dispatch-result.js";
+import {
   deliverInboundReplyWithMessageSendContext,
   isDurableInboundReplyDeliveryHandled,
   throwIfDurableInboundReplyDeliveryFailed,
@@ -358,6 +362,124 @@ function createObserveOnlyDeliveryAdapter(): ChannelEventDeliveryAdapter {
   };
 }
 
+function shouldSendNoVisibleReplyFallback(params: {
+  admission: DispatchableChannelTurn["admission"];
+  result: ChannelTurnResult;
+}): boolean {
+  if (!params.result.dispatched || params.admission?.kind === "observeOnly") {
+    return false;
+  }
+  const dispatchResult = params.result.dispatchResult as ChannelTurnDispatchResultLike & {
+    noVisibleReplyFallbackEligible?: unknown;
+  };
+  return (
+    dispatchResult?.noVisibleReplyFallbackEligible === true &&
+    !hasVisibleChannelTurnDispatch(dispatchResult)
+  );
+}
+
+function markFallbackReplyObserved(result: ChannelTurnResult): ChannelTurnResult {
+  if (!result.dispatched) {
+    return result;
+  }
+  return {
+    ...result,
+    dispatchResult: {
+      ...(result.dispatchResult as Record<string, unknown>),
+      observedReplyDelivery: true,
+    } as typeof result.dispatchResult,
+  };
+}
+
+async function deliverNoVisibleReplyFallback(params: {
+  cfg: DispatchableChannelTurn["cfg"];
+  channel: string;
+  accountId: string | undefined;
+  agentId: string;
+  ctxPayload: DispatchableChannelTurn["ctxPayload"];
+  delivery: AnyChannelDeliveryAdapter;
+}): Promise<ChannelDeliveryResult | void> {
+  const payload: ReplyPayload = {
+    text: "⚠️ I hit an internal runtime issue before I could send the answer. Please try again, or use /new if this thread keeps failing.",
+    isError: true,
+    isStatusNotice: true,
+  };
+  const info: ChannelDeliveryInfo = { kind: "final" };
+  const preparedPayload = params.delivery.preparePayload
+    ? await params.delivery.preparePayload(payload, info)
+    : payload;
+  if (preparedPayload === null) {
+    const suppression = createSuppressedChannelDeliveryResult({ reason: "no_visible_payload" });
+    await runChannelDeliveryObserver({
+      onDelivered: params.delivery.onDelivered,
+      payload,
+      info,
+      result: suppression,
+    });
+    return suppression;
+  }
+
+  const durable = "durable" in params.delivery ? params.delivery.durable : undefined;
+  const durableOptions =
+    typeof durable === "function" ? await durable(preparedPayload, info) : durable;
+  if (durableOptions) {
+    const durableResult = await deliverInboundReplyWithMessageSendContext({
+      cfg: params.cfg,
+      channel: params.channel,
+      accountId: params.accountId,
+      agentId: params.agentId,
+      ctxPayload: params.ctxPayload,
+      payload: preparedPayload,
+      info,
+      ...durableOptions,
+    });
+    throwIfDurableInboundReplyDeliveryFailed(durableResult);
+    if (isDurableInboundReplyDeliveryHandled(durableResult)) {
+      await runChannelDeliveryObserver({
+        onDelivered: params.delivery.onDelivered,
+        payload: preparedPayload,
+        info,
+        result: durableResult.delivery,
+      });
+      return durableResult.delivery;
+    }
+  }
+
+  const result =
+    "deliverWithProviderMessageSending" in params.delivery &&
+    params.delivery.deliverWithProviderMessageSending
+      ? await params.delivery.deliverWithProviderMessageSending(preparedPayload, info)
+      : "deliver" in params.delivery && params.delivery.deliver
+        ? await params.delivery.deliver(preparedPayload, info)
+        : undefined;
+  await runChannelDeliveryObserver({
+    onDelivered: params.delivery.onDelivered,
+    payload: preparedPayload,
+    info,
+    result,
+  });
+  return result;
+}
+
+async function maybeDeliverNoVisibleReplyFallback(params: {
+  cfg: DispatchableChannelTurn["cfg"];
+  channel: string;
+  accountId: string | undefined;
+  agentId: string;
+  ctxPayload: DispatchableChannelTurn["ctxPayload"];
+  admission: DispatchableChannelTurn["admission"];
+  delivery: AnyChannelDeliveryAdapter;
+  result: ChannelTurnResult;
+}): Promise<ChannelTurnResult> {
+  if (!shouldSendNoVisibleReplyFallback(params)) {
+    return params.result;
+  }
+  const fallback = await deliverNoVisibleReplyFallback(params);
+  return isExplicitlyNonVisibleChannelDelivery(fallback)
+    ? params.result
+    : markFallbackReplyObserved(params.result);
+}
+
 async function dispatchChannelTurnWithDeliveryOwner(
   ...args:
     | [params: AssembledChannelTurn, ownership: "legacy-dispatcher"]
@@ -415,7 +537,7 @@ async function dispatchChannelTurnWithDeliveryOwner(
     });
     return messageSentEmitter;
   };
-  return await runPreparedChannelTurnCore(
+  const result = await runPreparedChannelTurnCore(
     {
       channel: params.channel,
       accountId: params.accountId,
@@ -641,6 +763,16 @@ async function dispatchChannelTurnWithDeliveryOwner(
     },
     { suppressObserveOnlyDispatch: false },
   );
+  return await maybeDeliverNoVisibleReplyFallback({
+    cfg: params.cfg,
+    channel: params.channel,
+    accountId: params.accountId,
+    agentId: params.agentId,
+    ctxPayload: params.ctxPayload,
+    admission: params.admission,
+    delivery,
+    result,
+  });
 }
 
 export async function dispatchAssembledChannelTurn(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users in visible Slack channel threads could see no reply when a channel turn was aborted or finalized after no visible reply payload was queued. In a private production bot incident, the agent started work, gateway logs reported a visible channel turn with no queued reply payloads, and the Slack thread was left silent.

## Why This Change Was Made

The runtime should never leave a visible channel turn silent after it knows there was no visible dispatch. This change sends a short fallback only for eligible visible channel turns and preserves silent behavior for observe-only turns.

## User Impact

Users get a clear retryable runtime notice instead of silence when this edge case occurs. Operators also get finalization state that reflects a visible reply was delivered.

## Evidence

- Ran oxfmt on src/channels/turn/lifecycle.ts and src/channels/turn/kernel.test.ts.
- Ran core typecheck: node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental false --pretty false.
- Ran targeted regression suite: ./node_modules/.bin/vitest run src/channels/turn/kernel.test.ts, passing 62 tests.
- Rebased onto current origin/main and confirmed PR is mergeable.
- Validated equivalent fallback behavior on a private production bot runtime with healthy gateway, connected Slack provider, no restart pending, and clean task audit.