### PR TITLE
test(security): cover gateway shared auth modes

### DIFF
--- a/qa/scenarios/security/gateway-shared-auth-modes.yaml
+++ b/qa/scenarios/security/gateway-shared-auth-modes.yaml
@@ -1,0 +1,26 @@
+title: Gateway shared auth modes
+
+scenario:
+  id: gateway-shared-auth-modes
+  surface: security
+  coverage:
+    primary:
+      - security.shared-gateway-token-password-auth
+      - security.gateway-auth-mode
+  objective: Prove the real Gateway enforces explicit token, password, and none authentication modes across WebSocket, HTTP, and startup boundaries.
+  successCriteria:
+    - WebSocket clients connect with the configured token or password and reject invalid or cross-mode credentials.
+    - The real models HTTP endpoint accepts the configured shared secret and returns 401 for an invalid secret in token and password modes.
+    - Missing active credentials and unauthenticated non-loopback exposure fail before the Gateway listens with actionable configuration guidance.
+    - Explicit none mode remains available on loopback, and existing private-ingress auth behavior remains covered without claiming adjacent Tailscale or browser trust taxonomy.
+  docsRefs:
+    - docs/gateway/authentication.md
+    - docs/gateway/security/index.md
+  codeRefs:
+    - src/gateway/auth.ts
+    - src/gateway/server-runtime-config.ts
+    - src/gateway/server.auth.modes.suite.ts
+  execution:
+    kind: vitest
+    path: src/gateway/server.auth.modes.test.ts
+    summary: Run the real Gateway auth-mode matrix across WebSocket, HTTP, loopback, private ingress, and startup validation.

--- a/src/gateway/server.auth.modes.suite.ts
+++ b/src/gateway/server.auth.modes.suite.ts
@@ -16,6 +16,14 @@ import {
   testTailscaleWhois,
 } from "./server.auth.test-helpers.js";
 
+async function requestModels(port: number, secret: string): Promise<Response> {
+  return await fetch(`http://127.0.0.1:${port}/v1/models`, {
+    headers: {
+      authorization: `Bearer ${secret}`,
+    },
+  });
+}
+
 export function registerAuthModesSuite(): void {
   describe("password auth", () => {
     let server: Awaited<ReturnType<typeof startGatewayServer>>;
@@ -24,7 +32,7 @@ export function registerAuthModesSuite(): void {
     beforeAll(async () => {
       testState.gatewayAuth = { mode: "password", password: "secret" }; // pragma: allowlist secret
       port = await getFreePort();
-      server = await startGatewayServer(port);
+      server = await startGatewayServer(port, { openAiChatCompletionsEnabled: true });
     });
 
     beforeEach(() => {
@@ -49,6 +57,27 @@ export function registerAuthModesSuite(): void {
       expect(res.error?.message ?? "").toContain("unauthorized");
       ws.close();
     });
+
+    test("rejects token credentials in password mode", async () => {
+      const ws = await openWs(port);
+      const res = await connectReq(ws, {
+        skipDefaultAuth: true,
+        token: "secret",
+      });
+      expect(res.ok).toBe(false);
+      expect(res.error?.message ?? "").toContain("unauthorized");
+      ws.close();
+    });
+
+    test("authorizes the models HTTP endpoint with only the configured password", async () => {
+      const authorized = await requestModels(port, "secret");
+      expect(authorized.status).toBe(200);
+      await authorized.body?.cancel();
+
+      const unauthorized = await requestModels(port, "wrong");
+      expect(unauthorized.status).toBe(401);
+      await unauthorized.body?.cancel();
+    });
   });
 
   describe("token auth", () => {
@@ -61,7 +90,7 @@ export function registerAuthModesSuite(): void {
       process.env.OPENCLAW_GATEWAY_TOKEN = "secret";
       testState.gatewayAuth = { mode: "token", token: "secret" };
       port = await getFreePort();
-      server = await startGatewayServer(port);
+      server = await startGatewayServer(port, { openAiChatCompletionsEnabled: true });
     });
 
     beforeEach(() => {
@@ -74,12 +103,40 @@ export function registerAuthModesSuite(): void {
       restoreGatewayToken(prevToken);
     });
 
+    test("accepts token auth when configured", async () => {
+      const ws = await openWs(port);
+      const res = await connectReq(ws, { token: "secret" });
+      expect(res.ok).toBe(true);
+      ws.close();
+    });
+
     test("rejects invalid token", async () => {
       const ws = await openWs(port);
       const res = await connectReq(ws, { token: "wrong" });
       expect(res.ok).toBe(false);
       expect(res.error?.message ?? "").toContain("unauthorized");
       ws.close();
+    });
+
+    test("rejects password credentials in token mode", async () => {
+      const ws = await openWs(port);
+      const res = await connectReq(ws, {
+        skipDefaultAuth: true,
+        password: "secret", // pragma: allowlist secret
+      });
+      expect(res.ok).toBe(false);
+      expect(res.error?.message ?? "").toContain("unauthorized");
+      ws.close();
+    });
+
+    test("authorizes the models HTTP endpoint with only the configured token", async () => {
+      const authorized = await requestModels(port, "secret");
+      expect(authorized.status).toBe(200);
+      await authorized.body?.cancel();
+
+      const unauthorized = await requestModels(port, "wrong");
+      expect(unauthorized.status).toBe(401);
+      await unauthorized.body?.cancel();
     });
 
     test("returns control ui hint when token is missing", async () => {
@@ -141,6 +198,59 @@ export function registerAuthModesSuite(): void {
       const res = await connectReq(ws, { skipDefaultAuth: true });
       expect(res.ok).toBe(true);
       ws.close();
+    });
+  });
+
+  describe("startup auth validation", () => {
+    test.each([
+      {
+        mode: "token" as const,
+        envKey: "OPENCLAW_GATEWAY_TOKEN" as const,
+        expected:
+          "gateway auth mode is token, but no token was configured (set gateway.auth.token or OPENCLAW_GATEWAY_TOKEN)",
+      },
+      {
+        mode: "password" as const,
+        envKey: "OPENCLAW_GATEWAY_PASSWORD" as const,
+        expected: "gateway auth mode is password, but no password was configured",
+      },
+    ])("rejects $mode mode before startup when its credential is missing", async (testCase) => {
+      const previous = process.env[testCase.envKey];
+      delete process.env[testCase.envKey];
+      // Use an explicit empty override so suite-level credentials cannot satisfy
+      // the mode under test before runtime validation runs.
+      const auth =
+        testCase.mode === "token"
+          ? { mode: "token" as const, token: "", allowTailscale: false }
+          : { mode: "password" as const, password: "", allowTailscale: false };
+      testState.gatewayAuth = auth;
+      const port = await getFreePort();
+
+      try {
+        await expect(startGatewayServer(port, { auth })).rejects.toThrow(testCase.expected);
+      } finally {
+        if (previous === undefined) {
+          delete process.env[testCase.envKey];
+        } else {
+          process.env[testCase.envKey] = previous;
+        }
+      }
+    });
+
+    test("rejects non-loopback exposure without effective auth before listening", async () => {
+      testState.gatewayAuth = { mode: "none" };
+      const port = await getFreePort();
+
+      await expect(
+        startGatewayServer(port, {
+          bind: "lan",
+          host: "0.0.0.0",
+          auth: { mode: "none" },
+          controlUiEnabled: false,
+        }),
+      ).rejects.toThrow(
+        "without auth (set gateway.auth.token/password, or set OPENCLAW_GATEWAY_TOKEN/OPENCLAW_GATEWAY_PASSWORD",
+      );
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

Two security taxonomy IDs had no primary executable QA proof:

- `security.shared-gateway-token-password-auth`
- `security.gateway-auth-mode`

## Why This Change Was Made

This keeps ownership in the existing real Gateway authentication-mode suite and adds the matching QA scenario metadata.

The suite now proves:

- WebSocket token and password success, invalid-secret rejection, and cross-mode credential rejection.
- Real HTTP `/v1/models` Bearer success under token and password modes, with invalid shared secrets returning `401`.
- Missing active token or password credentials prevent startup with actionable operator guidance.
- Explicit token, password, and none modes remain authoritative.
- Loopback none mode succeeds, while unauthenticated non-loopback exposure fails before listening with token/password remedies.

Existing private-ingress and Tailscale coverage remains intact, but this change does not claim broad WebSocket handshake, origin, trusted-proxy, Tailscale, browser/device, or remote-access taxonomy IDs.

## User Impact

There is no production runtime behavior change. Maintainers gain durable primary evidence for the two Gateway shared-auth taxonomy IDs through the established test owner and QA inventory.

No production code or changelog is changed. Production LOC delta is `0`.

## Evidence

Exact-head validation completed against:

- Head: `61894881701e114834ec19b4d3f36b919cdd8bf5`
- Base: `780d6bf7b80d187b1b5feabe320a1bb34cb08a81`
- Runtime: Node `24.18.0`, pnpm `11.15.1`

Results:

- Focused Gateway auth-mode suite: `17/17` tests passed.
- Full changed gate: passed in `925.55s`.
  - Typecheck: `540.75s`
  - Lint: `254.37s`
  - Runtime import cycles: `11.61s`
- Private QA build: passed in `279.49s`.
- `corepack pnpm openclaw qa coverage --match security.shared-gateway-token-password-auth --json`: passed and matched `gateway-shared-auth-modes`.
- `corepack pnpm openclaw qa coverage --match security.gateway-auth-mode --json`: passed and matched `gateway-shared-auth-modes`.
- Fresh `mock-openai` QA suite: passed in `29.74s`.
- `git diff --check`, direct formatting, focused lint, and diff privacy review: passed.

```json
{
  "head": "61894881701e114834ec19b4d3f36b919cdd8bf5",
  "scenario": "gateway-shared-auth-modes",
  "providerMode": "mock-openai",
  "entries": 1,
  "status": "pass",
  "primaryIds": [
    "security.gateway-auth-mode",
    "security.shared-gateway-token-password-auth"
  ],
  "runner": "vitest",
  "scenarioWallTimeMs": 22311
}
```

Proof routing: Blacksmith Testbox and AWS were unavailable, and Daytona capacity was exhausted. Trusted-source local fallback therefore ran in a disposable clean clone pinned to the exact head and base above.
