### PR TITLE
fix(anthropic): fail over on Claude CLI session limits

### DIFF
--- a/extensions/anthropic/provider-failover.test.ts
+++ b/extensions/anthropic/provider-failover.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { classifyAnthropicFailoverReason } from "./provider-failover.js";
+
+describe("classifyAnthropicFailoverReason", () => {
+  it.each([
+    "You've hit your session limit \u00b7 resets 1:50pm (America/Buenos_Aires)",
+    "You've hit your limit \u00b7 resets 9:40pm (Europe/Madrid)",
+  ])("classifies Claude CLI subscription exhaustion as rate_limit: %s", (errorMessage) => {
+    expect(
+      classifyAnthropicFailoverReason({
+        provider: "claude-cli",
+        errorMessage,
+      }),
+    ).toBe("rate_limit");
+  });
+
+  it.each([undefined, "anthropic", "openai"])(
+    "does not share Claude CLI prose with provider %s",
+    (provider) => {
+      expect(
+        classifyAnthropicFailoverReason({
+          provider,
+          errorMessage: "You've hit your session limit \u00b7 resets 1:50pm (America/Buenos_Aires)",
+        }),
+      ).toBeUndefined();
+    },
+  );
+
+  it("does not classify unrelated Claude CLI session limits", () => {
+    expect(
+      classifyAnthropicFailoverReason({
+        provider: "claude-cli",
+        errorMessage: "terminal session limit reached (50)",
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/extensions/anthropic/provider-failover.ts
+++ b/extensions/anthropic/provider-failover.ts
@@ -1,0 +1,38 @@
+import type { ProviderFailoverErrorContext } from "openclaw/plugin-sdk/plugin-entry";
+import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { CLAUDE_CLI_BACKEND_ID } from "./cli-constants.js";
+
+const CLAUDE_CLI_USAGE_LIMIT_RE = /\byou(?:['\u2019]ve| have) hit your (?:session )?limit\b/i;
+
+function classifyAnthropicFailoverDescriptor(value: string | undefined) {
+  switch (value?.trim().toUpperCase()) {
+    case "RATE_LIMIT_ERROR":
+      return "rate_limit" as const;
+    case "API_ERROR":
+      return "server_error" as const;
+    default:
+      return undefined;
+  }
+}
+
+export function classifyAnthropicFailoverReason({
+  provider,
+  errorMessage,
+  code,
+  errorType,
+}: ProviderFailoverErrorContext) {
+  const descriptorReason =
+    classifyAnthropicFailoverDescriptor(errorType) ?? classifyAnthropicFailoverDescriptor(code);
+  if (descriptorReason) {
+    return descriptorReason;
+  }
+  // Claude CLI reports subscription exhaustion as prose rather than an API descriptor.
+  // Keep this provider-gated so unrelated session-limit errors retain their meaning.
+  if (
+    normalizeLowercaseStringOrEmpty(provider) === CLAUDE_CLI_BACKEND_ID &&
+    CLAUDE_CLI_USAGE_LIMIT_RE.test(errorMessage)
+  ) {
+    return "rate_limit" as const;
+  }
+  return undefined;
+}

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -66,6 +66,7 @@ import { acceptsAnthropicLiveModelContract } from "./live-model-contract-gate.js
 import { anthropicMediaUnderstandingProvider } from "./media-understanding-provider.js";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 import { resolveClaudeCliSyntheticAuth } from "./provider-discovery.js";
+import { classifyAnthropicFailoverReason } from "./provider-failover.js";
 import { createClaudeSessionNodeInvokePolicies } from "./session-catalog-node-commands.js";
 import { registerClaudeSessionDiscovery } from "./session-catalog-registration.js";
 import { isAnthropicOAuthApiKey, wrapAnthropicProviderStream } from "./stream-wrappers.js";
@@ -77,17 +78,6 @@ type ProviderAuthMethodNonInteractiveValidationContext = Parameters<
 
 const PROVIDER_ID = "anthropic";
 
-// Anthropic-native error descriptors stay with the Anthropic provider hook.
-function classifyAnthropicFailoverDescriptor(value: string | undefined) {
-  switch (value?.trim().toUpperCase()) {
-    case "RATE_LIMIT_ERROR":
-      return "rate_limit" as const;
-    case "API_ERROR":
-      return "server_error" as const;
-    default:
-      return undefined;
-  }
-}
 type UpsertAuthProfileParams = Parameters<typeof upsertAuthProfileWithLock>[0];
 const DEFAULT_ANTHROPIC_MODEL = "anthropic/claude-opus-5";
 const ANTHROPIC_OPUS_48_MODEL_ID = "claude-opus-4-8";
@@ -1132,8 +1122,7 @@ export function buildAnthropicProvider(): ProviderPlugin {
       (!isAnthropicMandatoryClaude5Model(modelId) ||
         normalizeLowercaseStringOrEmpty(provider) === PROVIDER_ID),
     resolveReasoningOutputMode: () => "native",
-    classifyFailoverReason: ({ code, errorType }) =>
-      classifyAnthropicFailoverDescriptor(errorType) ?? classifyAnthropicFailoverDescriptor(code),
+    classifyFailoverReason: classifyAnthropicFailoverReason,
     resolveThinkingProfile: ({ provider, modelId, params }) => {
       const contractModelId = resolveClaudeModelIdentity({ id: modelId, params });
       return isAnthropicMythos5Model(contractModelId) &&

--- a/scripts/test-built-plugin-singleton.mjs
+++ b/scripts/test-built-plugin-singleton.mjs
@@ -12,12 +12,29 @@ installProcessWarningFilter();
 
 const repoRoot = resolveRepoRoot(import.meta.url);
 const smokeEntryPath = path.join(repoRoot, "dist", "plugins", "build-smoke-entry.js");
+const providerRuntimeEntryPath = path.join(repoRoot, "dist", "plugins", "provider-runtime.js");
 assert.ok(fs.existsSync(smokeEntryPath), `missing build output: ${smokeEntryPath}`);
+assert.ok(
+  fs.existsSync(providerRuntimeEntryPath),
+  `missing provider runtime output: ${providerRuntimeEntryPath}`,
+);
 
-const { clearPluginCommands, getPluginCommandSpecs, loadOpenClawPlugins, matchPluginCommand } =
-  await import(pathToFileURL(smokeEntryPath).href);
+const {
+  classifyFailoverReason,
+  clearPluginCommands,
+  getPluginCommandSpecs,
+  loadOpenClawPlugins,
+  matchPluginCommand,
+} = await import(pathToFileURL(smokeEntryPath).href);
+const providerRuntime = await import(pathToFileURL(providerRuntimeEntryPath).href);
 
 assert.equal(typeof loadOpenClawPlugins, "function", "built loader export missing");
+assert.equal(typeof classifyFailoverReason, "function", "failover classifier export missing");
+assert.equal(
+  typeof providerRuntime.classifyProviderFailoverReasonWithPlugin,
+  "function",
+  "provider failover runtime export missing",
+);
 assert.equal(typeof clearPluginCommands, "function", "clearPluginCommands missing");
 assert.equal(typeof getPluginCommandSpecs, "function", "getPluginCommandSpecs missing");
 assert.equal(typeof matchPluginCommand, "function", "matchPluginCommand missing");
@@ -85,6 +102,17 @@ fs.writeFileSync(
     `  id: ${JSON.stringify(pluginId)},`,
     "  configSchema: emptyPluginConfigSchema(),",
     "  register(api) {",
+    "    api.registerProvider({",
+    "      id: 'build-smoke-provider',",
+    "      label: 'Build Smoke Provider',",
+    "      hookAliases: ['build-smoke-cli'],",
+    "      auth: [],",
+    "      classifyFailoverReason({ provider, errorMessage }) {",
+    "        return provider === 'build-smoke-cli' && errorMessage === 'smoke usage limit'",
+    "          ? 'rate_limit'",
+    "          : undefined;",
+    "      },",
+    "    });",
     "    api.registerCommand({",
     "      name: 'pair',",
     "      description: 'Pair a device',",
@@ -145,5 +173,10 @@ assert.ok(match, "canonical built command registry did not receive the command")
 assert.equal(match.args, "now");
 const result = await match.command.handler({ args: match.args });
 assert.deepEqual(result, { text: "paired:now" });
+assert.equal(
+  classifyFailoverReason("smoke usage limit", { provider: "build-smoke-cli" }),
+  "rate_limit",
+  "built failover classifier did not resolve the provider runtime hook",
+);
 
 process.stdout.write("[build-smoke] built plugin singleton smoke passed\n");

--- a/src/agents/cli-runner/output-error.test.ts
+++ b/src/agents/cli-runner/output-error.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import { withPluginRuntimeRegistryScope } from "../../plugins/runtime/gateway-request-scope.js";
+import type { ProviderFailoverErrorContext } from "../../plugins/types.js";
+import { createCliOutputFailoverError } from "./output-error.js";
+
+describe("createCliOutputFailoverError", () => {
+  it("classifies CLI prose through a provider hook alias", () => {
+    const errorMessage = "You've hit your session limit \u00b7 resets 1:50pm";
+    const classifyFailoverReason = vi.fn(
+      ({ provider, errorMessage: message }: ProviderFailoverErrorContext) =>
+        provider === "claude-cli" && message === errorMessage ? "rate_limit" : undefined,
+    );
+    const unrelatedHook = vi.fn(() => "billing" as const);
+    const registry = createEmptyPluginRegistry();
+    registry.providers.push(
+      {
+        pluginId: "other",
+        provider: {
+          id: "other",
+          label: "Other",
+          auth: [],
+          classifyFailoverReason: unrelatedHook,
+        },
+        source: "test",
+      },
+      {
+        pluginId: "anthropic",
+        provider: {
+          id: "anthropic",
+          label: "Anthropic",
+          hookAliases: ["claude-cli"],
+          auth: [],
+          classifyFailoverReason,
+        },
+        source: "test",
+      },
+    );
+
+    const error = withPluginRuntimeRegistryScope(registry, () =>
+      createCliOutputFailoverError({
+        output: { text: "", errorText: errorMessage },
+        provider: "claude-cli",
+        model: "claude-sonnet-4-6",
+      }),
+    );
+
+    expect(error).toMatchObject({
+      reason: "rate_limit",
+      status: 429,
+      provider: "claude-cli",
+      model: "claude-sonnet-4-6",
+      rawError: errorMessage,
+    });
+    expect(classifyFailoverReason).toHaveBeenCalledWith({
+      provider: "claude-cli",
+      errorMessage,
+    });
+    expect(classifyFailoverReason).toHaveBeenCalledTimes(1);
+    expect(unrelatedHook).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/embedded-agent-helpers/provider-error-patterns.ts
+++ b/src/agents/embedded-agent-helpers/provider-error-patterns.ts
@@ -7,6 +7,7 @@
  */
 
 import { resolveNodeRequireFromMeta } from "../../logging/node-require.js";
+import { classifyLoadedProviderFailoverReason } from "../../plugins/provider-error-runtime.js";
 import type { FailoverReason } from "./types.js";
 
 type ProviderErrorPattern = {
@@ -86,6 +87,14 @@ type ProviderRuntimeHooks = {
 };
 
 const requireProviderRuntime = resolveNodeRequireFromMeta(import.meta.url);
+const isSourceProviderErrorModule = new URL(import.meta.url).pathname.endsWith(
+  "/src/agents/embedded-agent-helpers/provider-error-patterns.ts",
+);
+// Bundled code must only probe the package-internal stable entry. Falling
+// through to ../../ from dist/ could load an unrelated file outside the package.
+const PROVIDER_RUNTIME_SPECIFIER = isSourceProviderErrorModule
+  ? "../../plugins/provider-runtime.js"
+  : "./plugins/provider-runtime.js";
 let cachedProviderRuntimeHooks: ProviderRuntimeHooks | null | undefined;
 
 const PROVIDER_CONTEXT_OVERFLOW_SIGNAL_RE =
@@ -103,7 +112,7 @@ function resolveProviderRuntimeHooks(): ProviderRuntimeHooks | null {
   }
   try {
     const loaded = requireProviderRuntime(
-      "../../plugins/provider-runtime.js",
+      PROVIDER_RUNTIME_SPECIFIER,
     ) as unknown as ProviderRuntimeHooks;
     cachedProviderRuntimeHooks = {
       classifyProviderFailoverReasonWithPlugin: ({ provider, context }) =>
@@ -150,10 +159,11 @@ export function matchesProviderContextOverflow(errorMessage: string): boolean {
   if (!looksLikeProviderContextOverflowCandidate(errorMessage)) {
     return false;
   }
+  const context = { errorMessage };
   const runtimeHooks = resolveProviderRuntimeHooks();
   return (
     runtimeHooks?.matchesProviderContextOverflowWithPlugin({
-      context: { errorMessage },
+      context,
     }) === true || PROVIDER_CONTEXT_OVERFLOW_PATTERNS.some((pattern) => pattern.test(errorMessage))
   );
 }
@@ -162,6 +172,15 @@ export function classifyProviderPluginError(
   input: string | ProviderSpecificErrorContext,
 ): FailoverReason | null {
   const context = normalizeProviderSpecificErrorContext(input);
+  if (context.provider) {
+    const loaded = classifyLoadedProviderFailoverReason({
+      provider: context.provider,
+      context,
+    });
+    if (loaded.matched) {
+      return loaded.reason;
+    }
+  }
   const runtimeHooks = resolveProviderRuntimeHooks();
   return (
     runtimeHooks?.classifyProviderFailoverReasonWithPlugin({

--- a/src/infra/tsdown-config.test.ts
+++ b/src/infra/tsdown-config.test.ts
@@ -166,6 +166,7 @@ describe("tsdown config", () => {
       "provider-dispatcher.runtime",
       "plugins/hook-runner-global",
       "plugins/provider-discovery.runtime",
+      "plugins/provider-runtime",
       "plugins/provider-runtime.runtime",
       "plugins/runtime/index",
       "plugins/synthetic-auth.runtime",

--- a/src/plugins/build-smoke-entry.ts
+++ b/src/plugins/build-smoke-entry.ts
@@ -1,4 +1,5 @@
 // Re-exports plugin modules used by build smoke checks.
+export { classifyFailoverReason } from "../agents/embedded-agent-helpers.js";
 export { clearPluginCommands, executePluginCommand, matchPluginCommand } from "./commands.js";
 export { getPluginCommandSpecs } from "./command-specs.js";
 export { loadOpenClawPlugins, loadPluginRegistryHandle } from "./loader.js";

--- a/src/plugins/provider-error-runtime.ts
+++ b/src/plugins/provider-error-runtime.ts
@@ -1,0 +1,61 @@
+// Reads only already-loaded provider hooks through process-global registry slots.
+// Keep this leaf free of gateway and plugin barrels so agent error paths stay acyclic.
+import type { FailoverReason } from "../agents/embedded-agent-helpers/types.js";
+import type {
+  ProviderFailoverErrorContext,
+  ProviderFailoverHook,
+} from "./provider-failover.types.js";
+import { matchesProviderPluginRef } from "./provider-registry-shared.js";
+import { PLUGIN_REGISTRY_STATE } from "./runtime-state-key.js";
+import { PLUGIN_RUNTIME_GATEWAY_REQUEST_SCOPE_KEY } from "./runtime/gateway-request-scope-key.js";
+
+type ProviderRegistryView = {
+  providers: Array<{ provider: ProviderFailoverHook }>;
+};
+
+type GatewayRequestScopeStorage = {
+  getStore: () => { pluginRegistry?: ProviderRegistryView } | undefined;
+};
+
+type LoadedProviderPlugins = {
+  matched: boolean;
+  plugins: ProviderFailoverHook[];
+};
+
+function readGlobalSlot(key: symbol): unknown {
+  return (globalThis as Record<PropertyKey, unknown>)[key];
+}
+
+function resolveLoadedProviderPlugins(provider: string): LoadedProviderPlugins {
+  const requestRegistry = (
+    readGlobalSlot(PLUGIN_RUNTIME_GATEWAY_REQUEST_SCOPE_KEY) as
+      | GatewayRequestScopeStorage
+      | undefined
+  )?.getStore()?.pluginRegistry;
+  const activeRegistry = (
+    readGlobalSlot(PLUGIN_REGISTRY_STATE) as
+      | { activeRegistry?: ProviderRegistryView | null }
+      | undefined
+  )?.activeRegistry;
+  const providers = (requestRegistry ?? activeRegistry)?.providers.map((entry) => entry.provider);
+  if (!providers) {
+    return { matched: false, plugins: [] };
+  }
+  const matched = providers.find((candidate) => matchesProviderPluginRef(candidate, provider));
+  return matched ? { matched: true, plugins: [matched] } : { matched: false, plugins: [] };
+}
+
+/** Classifies through an explicitly matched provider hook already owned by this runtime. */
+export function classifyLoadedProviderFailoverReason(params: {
+  provider: string;
+  context: ProviderFailoverErrorContext;
+}): { matched: boolean; reason: FailoverReason | null } {
+  const loaded = resolveLoadedProviderPlugins(params.provider);
+  for (const plugin of loaded.plugins) {
+    const reason = plugin.classifyFailoverReason?.(params.context);
+    if (reason) {
+      return { matched: true, reason };
+    }
+  }
+  return { matched: loaded.matched, reason: null };
+}

--- a/src/plugins/provider-failover.types.ts
+++ b/src/plugins/provider-failover.types.ts
@@ -1,0 +1,21 @@
+import type { FailoverReason } from "../agents/embedded-agent-helpers/types.js";
+
+/** Provider-owned failover error classification input. */
+export type ProviderFailoverErrorContext = {
+  provider?: string;
+  modelId?: string;
+  errorMessage: string;
+  status?: number;
+  code?: string;
+  errorType?: string;
+};
+
+/** Leaf view of the provider fields needed by synchronous error dispatch. */
+export type ProviderFailoverHook = {
+  id: string;
+  aliases?: readonly string[];
+  hookAliases?: readonly string[];
+  classifyFailoverReason?: (
+    context: ProviderFailoverErrorContext,
+  ) => FailoverReason | null | undefined;
+};

--- a/src/plugins/provider-transport.types.ts
+++ b/src/plugins/provider-transport.types.ts
@@ -1,5 +1,6 @@
 import type { StreamFn } from "../agents/runtime/index.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+export type { ProviderFailoverErrorContext } from "./provider-failover.types.js";
 import type { ProviderRuntimeModel } from "./provider-runtime-model.types.js";
 import type { ProviderPrepareExtraParamsContext } from "./provider-runtime.types.js";
 
@@ -80,21 +81,6 @@ export type ProviderResolveWebSocketSessionPolicyContext = {
   modelId: string;
   model?: ProviderRuntimeModel;
   sessionId?: string;
-};
-
-/**
- * Provider-owned failover error classification input.
- *
- * Use this when provider-specific transport or API errors need classification
- * hints that generic string matching cannot express safely.
- */
-export type ProviderFailoverErrorContext = {
-  provider?: string;
-  modelId?: string;
-  errorMessage: string;
-  status?: number;
-  code?: string;
-  errorType?: string;
 };
 
 /**

--- a/src/plugins/runtime/gateway-request-scope-key.ts
+++ b/src/plugins/runtime/gateway-request-scope-key.ts
@@ -1,0 +1,4 @@
+/** Process-global key shared by lightweight request-scope readers. */
+export const PLUGIN_RUNTIME_GATEWAY_REQUEST_SCOPE_KEY: unique symbol = Symbol.for(
+  "openclaw.pluginRuntimeGatewayRequestScope",
+);

--- a/src/plugins/runtime/gateway-request-scope.ts
+++ b/src/plugins/runtime/gateway-request-scope.ts
@@ -7,6 +7,7 @@ import type {
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
 import type { PluginOrigin } from "../plugin-origin.types.js";
 import type { PluginRegistry } from "../registry-types.js";
+import { PLUGIN_RUNTIME_GATEWAY_REQUEST_SCOPE_KEY } from "./gateway-request-scope-key.js";
 
 type PluginRuntimeGatewayRequestScope = {
   context?: GatewayRequestContext;
@@ -26,10 +27,6 @@ type PluginRuntimePluginScope = {
   pluginOrigin?: PluginOrigin;
   pluginTrustedOfficialInstall?: boolean;
 };
-
-const PLUGIN_RUNTIME_GATEWAY_REQUEST_SCOPE_KEY: unique symbol = Symbol.for(
-  "openclaw.pluginRuntimeGatewayRequestScope",
-);
 
 const pluginRuntimeGatewayRequestScope = resolveGlobalSingleton<
   AsyncLocalStorage<PluginRuntimeGatewayRequestScope>

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -311,6 +311,9 @@ function buildCoreDistEntries(): Record<string, string> {
     "commands/status.summary.runtime": "src/status/summary.runtime.ts",
     "infra/boundary-file-read": "src/infra/boundary-file-read.ts",
     "plugins/provider-discovery.runtime": "src/plugins/provider-discovery.runtime.ts",
+    // Provider error classification is synchronous and loaded only on demand.
+    // Keep a stable built entry for the source/dist bridge in provider-error-patterns.
+    "plugins/provider-runtime": "src/plugins/provider-runtime.ts",
     "plugins/provider-runtime.runtime": "src/plugins/provider-runtime.runtime.ts",
     "web-fetch/runtime": "src/web-fetch/runtime.ts",
     "plugins/public-surface-runtime": "src/plugins/public-surface-runtime.ts",


### PR DESCRIPTION
Closes #118793

Credit to @germankovacevic-lab for the report and exact error text.

## What Problem This Solves

Fixes an issue where users relying on a configured model fallback chain would get a terminal `surface_error` instead of trying the next model when Claude CLI reported that the account or session usage limit had been reached.

## Why This Change Was Made

The Anthropic provider now maps the observed Claude CLI usage-limit prose to the existing `rate_limit` failover reason while preserving the current structured Anthropic error mappings. The prose matcher is gated to the `claude-cli` backend so unrelated providers and unrelated session-limit errors retain their existing behavior.

The shared classifier now dispatches directly to an already-loaded, explicitly matched provider hook through leaf process-global registry slots and retains full provider discovery as the fallback. The build also exposes the existing full provider runtime at a stable package-internal entry, so the lazy source/dist bridge no longer resolves outside the package after bundling. The leaf scope-key and failover-context contracts keep this synchronous path out of gateway/plugin import cycles.

## User Impact

Claude CLI subscription exhaustion can now advance through the configured model fallback chain instead of stopping the run immediately.

## Evidence

- Controlled process-level replay on exact final head `1c1725ed277b3d210fd6843fc2b5102d063ae3a9`: [`reason=rate_limit`, `status=429`, fallback succeeds](https://github.com/openclaw/openclaw/pull/118835#issuecomment-5171471700).
- Added focused regression coverage for the reporter's exact `You've hit your session limit` message and Anthropic's current `You've hit your limit` wording, plus negative coverage for other providers and unrelated Claude CLI session limits.
- Added unmocked CLI-output-to-provider-hook wiring coverage and a built-bundle singleton smoke that resolves a hook alias through the production classifier.
- Focused Vitest: 4 shards, 6 files, 125 tests passed; after the final lint-only cleanup, the 2 directly affected shards were rerun with 7/7 passing.
- Exact final-head architecture gate: `Madge import cycle check: 0 cycle(s)`.
- Exact final-head unified production build and built plugin singleton smoke: passed.
- Targeted `oxlint`, `oxfmt --check`, and `git diff --check` on the final change: passed.
- Mandatory external Codex autoreview against the exact final Git tree: clean, no accepted/actionable findings (`patch is correct`, confidence `0.98`).
- TruffleHog scan of the review bundle: clean.
- Upstream wording contract: https://github.com/anthropics/claude-code/issues/54750
