### PR TITLE
fix(parallels): keep provider keys out of POSIX job logs

### DIFF
--- a/scripts/e2e/parallels/npm-update-scripts.ts
+++ b/scripts/e2e/parallels/npm-update-scripts.ts
@@ -30,6 +30,20 @@ const macosGuestPath =
   "/opt/homebrew/bin:/opt/homebrew/opt/node/bin:/usr/local/bin:/usr/local/sbin:/opt/homebrew/sbin:/usr/bin:/bin:/usr/sbin:/sbin";
 const macosOpenClawCommand = '"$OPENCLAW_BIN"';
 
+function posixProviderApiKeyFunction(auth: ProviderAuth): string {
+  return `with_provider_api_key() {
+  # Killed background jobs print their command; keep the secret inside the function body.
+  export ${auth.apiKeyEnv}=${shellQuote(auth.apiKeyValue)}
+  if "$@"; then
+    provider_command_status=0
+  else
+    provider_command_status=$?
+  fi
+  unset ${auth.apiKeyEnv}
+  return "$provider_command_status"
+}`;
+}
+
 function posixNpmRegistryEnv(registry: string | undefined): string {
   if (!registry) {
     return "";
@@ -98,7 +112,7 @@ for attempt in 1 2; do
   rm -f "$HOME/.openclaw/agents/main/sessions/$session_id.jsonl"
   output_file="$(mktemp)"
   set +e
-  OPENCLAW_ALLOW_ROOT="\${OPENCLAW_ALLOW_ROOT:-}" ${input.auth.apiKeyEnv}=${shellQuote(input.auth.apiKeyValue)} ${command} agent --local --agent main --session-id "$session_id" --message 'Reply with exact ASCII text OK only.' --thinking off --timeout ${resolveParallelsModelTimeoutSeconds(platform)} --json >"$output_file" 2>&1
+  OPENCLAW_ALLOW_ROOT="\${OPENCLAW_ALLOW_ROOT:-}" with_provider_api_key ${command} agent --local --agent main --session-id "$session_id" --message 'Reply with exact ASCII text OK only.' --thinking off --timeout ${resolveParallelsModelTimeoutSeconds(platform)} --json >"$output_file" 2>&1
   rc=$?
   set -e
   print_log_tail "$output_file"
@@ -199,6 +213,7 @@ if (-not $agentOk) { throw 'openclaw agent finished without OK response' }`;
 export function macosUpdateScript(input: NpmUpdateScriptInput): string {
   return String.raw`set -euo pipefail
 export PATH=${macosGuestPath}
+${posixProviderApiKeyFunction(input.auth)}
 ${posixPrintLogTailFunction()}
 resolve_required_command() {
   command -v "$1" || {
@@ -248,9 +263,7 @@ start_openclaw_gateway() {
   stop_openclaw_gateway_processes
   rm -f /tmp/openclaw-parallels-macos-gateway.log
   trap '' HUP
-  /usr/bin/env OPENCLAW_HOME="$HOME" OPENCLAW_STATE_DIR="$HOME/.openclaw" OPENCLAW_CONFIG_PATH="$HOME/.openclaw/openclaw.json" ${input.auth.apiKeyEnv}=${shellQuote(
-    input.auth.apiKeyValue,
-  )} "$OPENCLAW_BIN" gateway run --bind loopback --port 18789 --force >/tmp/openclaw-parallels-macos-gateway.log 2>&1 </dev/null &
+  with_provider_api_key /usr/bin/env OPENCLAW_HOME="$HOME" OPENCLAW_STATE_DIR="$HOME/.openclaw" OPENCLAW_CONFIG_PATH="$HOME/.openclaw/openclaw.json" "$OPENCLAW_BIN" gateway run --bind loopback --port 18789 --force >/tmp/openclaw-parallels-macos-gateway.log 2>&1 </dev/null &
   sleep 1
 }
 wait_for_gateway() {
@@ -363,6 +376,7 @@ export function linuxUpdateScript(input: NpmUpdateScriptInput): string {
   return String.raw`set -euo pipefail
 export PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/snap/bin
 export OPENCLAW_ALLOW_ROOT=1
+${posixProviderApiKeyFunction(input.auth)}
 ${posixPrintLogTailFunction()}
 scrub_future_plugin_entries() {
   node - <<'JS'
@@ -392,10 +406,8 @@ stop_openclaw_gateway_processes() {
 start_openclaw_gateway() {
   pkill -f "openclaw gateway run" >/dev/null 2>&1 || true
   rm -f /tmp/openclaw-parallels-linux-gateway.log
-  setsid sh -lc ${shellQuote(
-    `exec env OPENCLAW_HOME=/root OPENCLAW_STATE_DIR=/root/.openclaw OPENCLAW_CONFIG_PATH=/root/.openclaw/openclaw.json OPENCLAW_DISABLE_BONJOUR=1 OPENCLAW_ALLOW_ROOT=1 ${input.auth.apiKeyEnv}=${shellQuote(
-      input.auth.apiKeyValue,
-    )} openclaw gateway run --bind loopback --port 18789 --force >/tmp/openclaw-parallels-linux-gateway.log 2>&1`,
+  with_provider_api_key setsid sh -lc ${shellQuote(
+    "exec env OPENCLAW_HOME=/root OPENCLAW_STATE_DIR=/root/.openclaw OPENCLAW_CONFIG_PATH=/root/.openclaw/openclaw.json OPENCLAW_DISABLE_BONJOUR=1 OPENCLAW_ALLOW_ROOT=1 openclaw gateway run --bind loopback --port 18789 --force >/tmp/openclaw-parallels-linux-gateway.log 2>&1",
   )} >/dev/null 2>&1 < /dev/null &
 }
 wait_for_gateway() {

--- a/test/scripts/parallels-npm-update-smoke.test.ts
+++ b/test/scripts/parallels-npm-update-smoke.test.ts
@@ -392,6 +392,27 @@ exit 1
     }
   });
 
+  it("keeps POSIX provider secrets out of executable command lines", () => {
+    const input = {
+      auth: TEST_AUTH,
+      expectedNeedle: "2026.7.2-beta.5",
+      updateTarget: "2026.7.2-beta.5",
+    };
+    const exportLine = `  export ${TEST_AUTH.apiKeyEnv}='${TEST_AUTH.apiKeyValue}'`;
+
+    for (const script of [macosUpdateScript(input), linuxUpdateScript(input)]) {
+      expect(script.split("\n").filter((line) => line.includes(TEST_AUTH.apiKeyValue))).toEqual([
+        exportLine,
+      ]);
+      expect(script).toMatch(/with_provider_api_key [^\n]*gateway run/u);
+      expect(script).toMatch(/with_provider_api_key [^\n]*agent --local/u);
+      expect(script).toContain(`unset ${TEST_AUTH.apiKeyEnv}`);
+      expect(script.split("\n").find((line) => line.includes(" update --tag "))).not.toContain(
+        "with_provider_api_key",
+      );
+    }
+  });
+
   it("does not recreate retired workspace setup state in release smoke scripts", () => {
     const input = {
       auth: TEST_AUTH,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Parallels npm-update validation could write a provider API key into a captured macOS or Linux phase log when a background gateway was killed and the POSIX shell printed its job command.

## Why This Change Was Made

The POSIX update-script generator now keeps the provider key inside a scoped shell function and invokes both the gateway and live agent through that function. The updater, version checks, and config commands do not inherit the credential, and background job notifications no longer contain the key.

Windows is unchanged because its update payload already assigns the credential inside the guest PowerShell script rather than the launched command.

## User Impact

Maintainers can run the macOS and Linux npm-update Parallels lanes without provider credentials being serialized into phase logs by gateway retry cleanup.

## Evidence

- Native Parallels validation from frozen `origin/main` `dc1412c145e858a8a244b0f7ba434f4db2d276bb`:
  - fresh macOS: install, onboarding, gateway RPC, dashboard, and live OpenAI agent passed
  - fresh Windows: install, onboarding, gateway restart/status, and live OpenAI agent passed
  - Windows same-guest update passed
  - macOS same-guest update reproduced the credential in shell job-status output; the run was stopped and local artifacts were redacted
- `node scripts/run-vitest.mjs test/scripts/parallels-npm-update-smoke.test.ts`: 36 passed on the complete focused file before the final assertion-only strengthening
- `node scripts/run-vitest.mjs test/scripts/parallels-npm-update-smoke.test.ts -t "keeps POSIX provider secrets out of executable command lines"`: passed on the final diff
- Blacksmith Testbox `tbx_01kz4cx5j24fspgdfdhysgjm12`: `pnpm check:changed` passed on the final diff
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/30839795093
- Fresh autoreview: clean, no accepted/actionable findings; TruffleHog clean
- `git diff --check`

Known proof gap: the credential-dependent macOS update rerun was intentionally bypassed after the exposed credential was retired. No release was published.
