### PR TITLE
fix(macos): show gateway auth failures in app status

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -31155,7 +31155,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 116,
+      "line": 120,
       "path": "apps/macos/Sources/OpenClaw/ControlChannel.swift",
       "source": "degraded: \\(message)",
       "surface": "apple",
@@ -31163,7 +31163,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 363,
+      "line": 367,
       "path": "apps/macos/Sources/OpenClaw/ControlChannel.swift",
       "source": "unknown gateway error",
       "surface": "apple",
@@ -31995,7 +31995,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 40,
+      "line": 41,
       "path": "apps/macos/Sources/OpenClaw/DashboardGatewayMenuModel.swift",
       "source": "OpenClaw Not Configured",
       "surface": "apple",
@@ -32003,15 +32003,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 42,
-      "path": "apps/macos/Sources/OpenClaw/DashboardGatewayMenuModel.swift",
-      "source": "Remote OpenClaw Active",
-      "surface": "apple",
-      "id": "native.apple.293bf9a6e721036d"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 44,
+      "line": 45,
       "path": "apps/macos/Sources/OpenClaw/DashboardGatewayMenuModel.swift",
       "source": "OpenClaw Active",
       "surface": "apple",
@@ -32019,7 +32011,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 49,
+      "line": 50,
       "path": "apps/macos/Sources/OpenClaw/DashboardGatewayMenuModel.swift",
       "source": "OpenClaw Not Configured — \\(primaryName)",
       "surface": "apple",
@@ -32027,19 +32019,59 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 51,
-      "path": "apps/macos/Sources/OpenClaw/DashboardGatewayMenuModel.swift",
-      "source": "Remote OpenClaw Active — \\(primaryName)",
-      "surface": "apple",
-      "id": "native.apple.adee4bfd71731d2d"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 53,
+      "line": 54,
       "path": "apps/macos/Sources/OpenClaw/DashboardGatewayMenuModel.swift",
       "source": "OpenClaw Active — \\(primaryName)",
       "surface": "apple",
       "id": "native.apple.2be6d3dd1a0d2699"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 64,
+      "path": "apps/macos/Sources/OpenClaw/DashboardGatewayMenuModel.swift",
+      "source": "Remote OpenClaw Active",
+      "surface": "apple",
+      "id": "native.apple.293bf9a6e721036d"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 66,
+      "path": "apps/macos/Sources/OpenClaw/DashboardGatewayMenuModel.swift",
+      "source": "Remote OpenClaw Active — \\(name)",
+      "surface": "apple",
+      "id": "native.apple.6d4e4047b0278805"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 68,
+      "path": "apps/macos/Sources/OpenClaw/DashboardGatewayMenuModel.swift",
+      "source": "Remote OpenClaw Connecting",
+      "surface": "apple",
+      "id": "native.apple.9ca38f6a779263eb"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 70,
+      "path": "apps/macos/Sources/OpenClaw/DashboardGatewayMenuModel.swift",
+      "source": "Remote OpenClaw Connecting — \\(name)",
+      "surface": "apple",
+      "id": "native.apple.9a0da573f4e61f2f"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 72,
+      "path": "apps/macos/Sources/OpenClaw/DashboardGatewayMenuModel.swift",
+      "source": "Remote OpenClaw Needs Attention",
+      "surface": "apple",
+      "id": "native.apple.6f9a4c4e67ef0bd8"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 74,
+      "path": "apps/macos/Sources/OpenClaw/DashboardGatewayMenuModel.swift",
+      "source": "Remote OpenClaw Needs Attention — \\(name)",
+      "surface": "apple",
+      "id": "native.apple.4953d4c2dba0f324"
     },
     {
       "kind": "ui-call",
@@ -33034,6 +33066,126 @@
       "id": "native.apple.eab4dbc3ca4a9352"
     },
     {
+      "kind": "ui-localized-call",
+      "line": 21,
+      "path": "apps/macos/Sources/OpenClaw/GatewayConnectionPresentation.swift",
+      "source": "Connected",
+      "surface": "apple",
+      "id": "native.apple.1f2d7f5633608ce9"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 23,
+      "path": "apps/macos/Sources/OpenClaw/GatewayConnectionPresentation.swift",
+      "source": "Connected to your remote Gateway.",
+      "surface": "apple",
+      "id": "native.apple.575daf240b3e88c2"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 29,
+      "path": "apps/macos/Sources/OpenClaw/GatewayConnectionPresentation.swift",
+      "source": "Connecting…",
+      "surface": "apple",
+      "id": "native.apple.24bfbc7bdb1bf0a2"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 30,
+      "path": "apps/macos/Sources/OpenClaw/GatewayConnectionPresentation.swift",
+      "source": "OpenClaw connecting",
+      "surface": "apple",
+      "id": "native.apple.ace257e298e5bf46"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 31,
+      "path": "apps/macos/Sources/OpenClaw/GatewayConnectionPresentation.swift",
+      "source": "Connecting to your remote Gateway…",
+      "surface": "apple",
+      "id": "native.apple.083ea354ad2d8e22"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 37,
+      "path": "apps/macos/Sources/OpenClaw/GatewayConnectionPresentation.swift",
+      "source": "Disconnected",
+      "surface": "apple",
+      "id": "native.apple.0129bd7fc497f461"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 41,
+      "path": "apps/macos/Sources/OpenClaw/GatewayConnectionPresentation.swift",
+      "source": "Disconnected from your remote Gateway. Open Connection settings to fix it.",
+      "surface": "apple",
+      "id": "native.apple.3117686baaeec464"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 48,
+      "path": "apps/macos/Sources/OpenClaw/GatewayConnectionPresentation.swift",
+      "source": "Gateway connection failed.",
+      "surface": "apple",
+      "id": "native.apple.c5f245b99f434c79"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 49,
+      "path": "apps/macos/Sources/OpenClaw/GatewayConnectionPresentation.swift",
+      "source": "OpenClaw needs attention",
+      "surface": "apple",
+      "id": "native.apple.8a9259535246e7cf"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 50,
+      "path": "apps/macos/Sources/OpenClaw/GatewayConnectionPresentation.swift",
+      "source": "Open Connection settings to fix it.",
+      "surface": "apple",
+      "id": "native.apple.412b40dec8b94e09"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 73,
+      "path": "apps/macos/Sources/OpenClaw/GatewayConnectionPresentation.swift",
+      "source": "OpenClaw paused",
+      "surface": "apple",
+      "id": "native.apple.0bec3829fd3ff778"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 74,
+      "path": "apps/macos/Sources/OpenClaw/GatewayConnectionPresentation.swift",
+      "source": "Gateway work is paused; incoming messages will wait.",
+      "surface": "apple",
+      "id": "native.apple.af4a1c5f1eca9c8a"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 84,
+      "path": "apps/macos/Sources/OpenClaw/GatewayConnectionPresentation.swift",
+      "source": "Processing messages through the local Gateway on this Mac.",
+      "surface": "apple",
+      "id": "native.apple.682abb7a64cb3a51"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 90,
+      "path": "apps/macos/Sources/OpenClaw/GatewayConnectionPresentation.swift",
+      "source": "OpenClaw active",
+      "surface": "apple",
+      "id": "native.apple.18c46b3643479d39"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 91,
+      "path": "apps/macos/Sources/OpenClaw/GatewayConnectionPresentation.swift",
+      "source": "Ready to run after you choose a Gateway connection.",
+      "surface": "apple",
+      "id": "native.apple.448e954d678c2fff"
+    },
+    {
       "kind": "conditional-branch",
       "line": 62,
       "path": "apps/macos/Sources/OpenClaw/GatewayDiscoveryHelpers.swift",
@@ -33586,48 +33738,24 @@
       "id": "native.apple.c8c53e5345460948"
     },
     {
-      "kind": "conditional-branch",
-      "line": 232,
+      "kind": "ui-call",
+      "line": 248,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
-      "source": "OpenClaw paused",
+      "source": "Open Connection Settings",
       "surface": "apple",
-      "id": "native.apple.64e197a4a8b384ef"
+      "id": "native.apple.2dbff050b62629f4"
     },
     {
       "kind": "ui-call",
-      "line": 242,
+      "line": 255,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "OpenClaw active",
       "surface": "apple",
       "id": "native.apple.7fe6df69d8050832"
     },
     {
-      "kind": "conditional-branch",
-      "line": 261,
-      "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
-      "source": "Processing messages through the local Gateway on this Mac.",
-      "surface": "apple",
-      "id": "native.apple.2f4258fa73e04344"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 263,
-      "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
-      "source": "Connected to a remote Gateway configuration.",
-      "surface": "apple",
-      "id": "native.apple.82bbee94fd6c9afd"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 265,
-      "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
-      "source": "Ready to run after you choose a Gateway connection.",
-      "surface": "apple",
-      "id": "native.apple.57c062682e2a1b08"
-    },
-    {
       "kind": "ui-named-argument",
-      "line": 272,
+      "line": 279,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Connection",
       "surface": "apple",
@@ -33635,7 +33763,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 273,
+      "line": 280,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Choose where the Gateway runs and how this Mac app reaches it.",
       "surface": "apple",
@@ -33643,7 +33771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 367,
+      "line": 376,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "\\(Int(ping)) ms",
       "surface": "apple",
@@ -33651,7 +33779,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 401,
+      "line": 410,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Local Gateway",
       "surface": "apple",
@@ -33659,7 +33787,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 402,
+      "line": 411,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Remote Gateway direct",
       "surface": "apple",
@@ -33667,7 +33795,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 402,
+      "line": 411,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Remote Gateway via SSH",
       "surface": "apple",
@@ -33675,7 +33803,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 403,
+      "line": 412,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway not configured",
       "surface": "apple",
@@ -33683,7 +33811,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 410,
+      "line": 419,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "OpenClaw starts and monitors the Gateway on this Mac.",
       "surface": "apple",
@@ -33691,7 +33819,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 419,
+      "line": 428,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Choose local or remote before the app can attach to a Gateway.",
       "surface": "apple",
@@ -33699,7 +33827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 424,
+      "line": 433,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway",
       "surface": "apple",
@@ -33707,7 +33835,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 426,
+      "line": 435,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "OpenClaw runs",
       "surface": "apple",
@@ -33715,7 +33843,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 427,
+      "line": 436,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Pick whether this app owns a local Gateway or attaches to another host.",
       "surface": "apple",
@@ -33723,7 +33851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 430,
+      "line": 439,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway location",
       "surface": "apple",
@@ -33731,7 +33859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 431,
+      "line": 440,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Not configured",
       "surface": "apple",
@@ -33739,7 +33867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 432,
+      "line": 441,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Local (this Mac)",
       "surface": "apple",
@@ -33747,7 +33875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 433,
+      "line": 442,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Remote (another host)",
       "surface": "apple",
@@ -33755,7 +33883,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 442,
+      "line": 451,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Setup needed",
       "surface": "apple",
@@ -33763,7 +33891,7 @@
     },
     {
       "kind": "ui-named-argument-multiline",
-      "line": 443,
+      "line": 452,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Local is best for this Mac. Remote is best when the Gateway already runs on a Mac Studio or server.",
       "surface": "apple",
@@ -33771,7 +33899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 474,
+      "line": 483,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Remote Access",
       "surface": "apple",
@@ -33779,7 +33907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 486,
+      "line": 495,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Discovery & Status",
       "surface": "apple",
@@ -33787,7 +33915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 502,
+      "line": 511,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Nearby gateways",
       "surface": "apple",
@@ -33795,7 +33923,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 525,
+      "line": 534,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Remote test",
       "surface": "apple",
@@ -33803,7 +33931,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 533,
+      "line": 542,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Control channel",
       "surface": "apple",
@@ -33811,7 +33939,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 562,
+      "line": 571,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Recommended setup",
       "surface": "apple",
@@ -33819,7 +33947,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 564,
+      "line": 573,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Use Tailscale plus an SSH tunnel for stable private access.",
       "surface": "apple",
@@ -33827,7 +33955,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 565,
+      "line": 574,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
       "surface": "apple",
@@ -33835,7 +33963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 574,
+      "line": 583,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Advanced",
       "surface": "apple",
@@ -33843,7 +33971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 577,
+      "line": 586,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Identity file",
       "surface": "apple",
@@ -33851,7 +33979,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 579,
+      "line": 588,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "/Users/you/.ssh/id_ed25519",
       "surface": "apple",
@@ -33859,7 +33987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 581,
+      "line": 590,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Project root",
       "surface": "apple",
@@ -33867,7 +33995,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 583,
+      "line": 592,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "/home/you/Projects/openclaw",
       "surface": "apple",
@@ -33875,7 +34003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 585,
+      "line": 594,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "CLI path",
       "surface": "apple",
@@ -33883,7 +34011,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 587,
+      "line": 596,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "/Applications/OpenClaw.app/.../openclaw",
       "surface": "apple",
@@ -33891,7 +34019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 592,
+      "line": 601,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "SSH command details",
       "surface": "apple",
@@ -33899,7 +34027,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 612,
+      "line": 621,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Transport",
       "surface": "apple",
@@ -33907,7 +34035,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 613,
+      "line": 622,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "SSH keeps the Gateway private; direct is best for HTTPS or Tailscale Serve.",
       "surface": "apple",
@@ -33915,7 +34043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 616,
+      "line": 625,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "SSH tunnel",
       "surface": "apple",
@@ -33923,7 +34051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 617,
+      "line": 626,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Direct (ws/wss)",
       "surface": "apple",
@@ -33931,7 +34059,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 630,
+      "line": 639,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "SSH target",
       "surface": "apple",
@@ -33939,7 +34067,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 630,
+      "line": 639,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "User and host for the remote Gateway machine.",
       "surface": "apple",
@@ -33947,7 +34075,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 647,
+      "line": 656,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway URL",
       "surface": "apple",
@@ -33955,7 +34083,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 647,
+      "line": 656,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "The WebSocket URL exposed by the remote Gateway.",
       "surface": "apple",
@@ -33963,7 +34091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 650,
+      "line": 659,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "wss://gateway.example.ts.net",
       "surface": "apple",
@@ -33971,7 +34099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 656,
+      "line": 665,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Use wss:// for public hosts. ws:// is allowed for localhost, LAN, .local, and Tailnet hosts.",
       "surface": "apple",
@@ -33979,7 +34107,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 667,
+      "line": 676,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway token",
       "surface": "apple",
@@ -33987,7 +34115,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 668,
+      "line": 677,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Used when the remote gateway requires token auth.",
       "surface": "apple",
@@ -33995,7 +34123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 671,
+      "line": 680,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "remote gateway auth token (gateway.remote.token)",
       "surface": "apple",
@@ -34003,7 +34131,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 676,
+      "line": 685,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "The current gateway.remote.token value is not plain text. OpenClaw for macOS cannot use it directly; enter a plaintext token here to replace it.",
       "surface": "apple",
@@ -34011,7 +34139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 695,
+      "line": 704,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Test remote",
       "surface": "apple",
@@ -34019,7 +34147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 718,
+      "line": 722,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Testing…",
       "surface": "apple",
@@ -34027,7 +34155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 756,
+      "line": 760,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Installed: \\(gatewayVersion) · Required: \\(required)",
       "surface": "apple",
@@ -34035,7 +34163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 760,
+      "line": 764,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway \\(gatewayVersion) detected",
       "surface": "apple",
@@ -34043,7 +34171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 766,
+      "line": 770,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Node \\(node)",
       "surface": "apple",
@@ -34051,7 +34179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 778,
+      "line": 782,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Last failure: \\(failure)",
       "surface": "apple",
@@ -34059,7 +34187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 783,
+      "line": 787,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Recheck",
       "surface": "apple",
@@ -34067,7 +34195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 786,
+      "line": 790,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway auto-starts in local mode via launchd (\\(gatewayLaunchdLabel)).",
       "surface": "apple",
@@ -34075,7 +34203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 839,
+      "line": 843,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Retry now",
       "surface": "apple",
@@ -34083,7 +34211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 844,
+      "line": 848,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Open logs",
       "surface": "apple",
@@ -34355,7 +34483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 102,
+      "line": 104,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "New Gateway Window…",
       "surface": "apple",
@@ -34363,7 +34491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 107,
+      "line": 109,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "New Thread",
       "surface": "apple",
@@ -34371,7 +34499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 113,
+      "line": 115,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Settings...",
       "surface": "apple",
@@ -34379,7 +34507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 121,
+      "line": 123,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Back",
       "surface": "apple",
@@ -34387,7 +34515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 126,
+      "line": 128,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Forward",
       "surface": "apple",
@@ -34395,7 +34523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 133,
+      "line": 135,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Command Palette…",
       "surface": "apple",
@@ -34403,7 +34531,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 147,
+      "line": 149,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "OpenClaw - Voice Wake live meter active",
       "surface": "apple",
@@ -34411,7 +34539,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 148,
+      "line": 150,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "OpenClaw",
       "surface": "apple",
@@ -34419,7 +34547,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 405,
+      "line": 407,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Close Canvas",
       "surface": "apple",
@@ -34427,7 +34555,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 405,
+      "line": 407,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Open Canvas",
       "surface": "apple",
@@ -34611,7 +34739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 245,
+      "line": 246,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Debug",
       "surface": "apple",
@@ -34619,7 +34747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 249,
+      "line": 250,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Config Folder",
       "surface": "apple",
@@ -34627,7 +34755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 254,
+      "line": 255,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Run Health Check Now",
       "surface": "apple",
@@ -34635,7 +34763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 259,
+      "line": 260,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Send Test Heartbeat",
       "surface": "apple",
@@ -34643,7 +34771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 265,
+      "line": 266,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Show Pairing Panel (Demo)",
       "surface": "apple",
@@ -34651,7 +34779,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 272,
+      "line": 273,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Remote Tunnel",
       "surface": "apple",
@@ -34659,7 +34787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 275,
+      "line": 276,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Reset Remote Tunnel",
       "surface": "apple",
@@ -34667,7 +34795,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 283,
+      "line": 284,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Verbose Logging (Main): On",
       "surface": "apple",
@@ -34675,7 +34803,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 284,
+      "line": 285,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Verbose Logging (Main): Off",
       "surface": "apple",
@@ -34683,7 +34811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 288,
+      "line": 289,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Verbosity",
       "surface": "apple",
@@ -34691,7 +34819,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 296,
+      "line": 297,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "File Logging: On",
       "surface": "apple",
@@ -34699,7 +34827,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 297,
+      "line": 298,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "File Logging: Off",
       "surface": "apple",
@@ -34707,7 +34835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 301,
+      "line": 302,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "App Logging",
       "surface": "apple",
@@ -34715,7 +34843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 306,
+      "line": 307,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Session Store",
       "surface": "apple",
@@ -34723,7 +34851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 312,
+      "line": 313,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Agent Events…",
       "surface": "apple",
@@ -34731,7 +34859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 317,
+      "line": 318,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Log",
       "surface": "apple",
@@ -34739,7 +34867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 322,
+      "line": 323,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Send Debug Voice Text",
       "surface": "apple",
@@ -34747,7 +34875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 327,
+      "line": 328,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Send Test Notification",
       "surface": "apple",
@@ -34755,7 +34883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 334,
+      "line": 335,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Restart Gateway",
       "surface": "apple",
@@ -34763,7 +34891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 340,
+      "line": 341,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Restart Onboarding",
       "surface": "apple",
@@ -34771,7 +34899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 345,
+      "line": 346,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Restart App",
       "surface": "apple",
@@ -34779,7 +34907,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 391,
+      "line": 404,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Main",
       "surface": "apple",
@@ -34787,7 +34915,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 391,
+      "line": 404,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Other",
       "surface": "apple",
@@ -34795,7 +34923,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 465,
+      "line": 478,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Show pairing requests",
       "surface": "apple",
@@ -34803,7 +34931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 490,
+      "line": 503,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Refreshing microphones…",
       "surface": "apple",
@@ -34811,7 +34939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 497,
+      "line": 510,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Microphone",
       "surface": "apple",
@@ -34819,7 +34947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 522,
+      "line": 535,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Disconnected (using System default)",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/ControlChannel.swift
+++ b/apps/macos/Sources/OpenClaw/ControlChannel.swift
@@ -103,6 +103,10 @@ final class ControlChannel {
         didSet {
             CanvasManager.shared.refreshDebugStatus()
             guard oldValue != self.state else { return }
+            if self.state != .connected {
+                self.lastPingMs = nil
+                self.authSourceLabel = nil
+            }
             NotificationCenter.default.post(name: .controlChannelStateDidChange, object: nil)
             switch self.state {
             case .connected:

--- a/apps/macos/Sources/OpenClaw/CritterStatusLabel+Behavior.swift
+++ b/apps/macos/Sources/OpenClaw/CritterStatusLabel+Behavior.swift
@@ -349,14 +349,16 @@ extension CritterStatusLabel {
             connectionMode: self.connectionMode,
             controlState: self.controlChannelState,
             gatewayStatus: self.gatewayStatus,
-            isPaused: self.isPaused)
+            isPaused: self.isPaused,
+            isSleeping: self.isSleeping)
     }
 
     static func needsAttention(
         connectionMode: AppState.ConnectionMode,
         controlState: ControlChannel.ConnectionState,
         gatewayStatus: GatewayProcessManager.Status,
-        isPaused: Bool) -> Bool
+        isPaused: Bool,
+        isSleeping: Bool) -> Bool
     {
         guard !isPaused else { return false }
         switch connectionMode {
@@ -365,6 +367,7 @@ extension CritterStatusLabel {
         case .remote:
             return GatewayConnectionPresentation(state: controlState).needsAttention
         case .local:
+            guard !isSleeping else { return false }
             switch gatewayStatus {
             case .failed, .stopped:
                 return true

--- a/apps/macos/Sources/OpenClaw/CritterStatusLabel+Behavior.swift
+++ b/apps/macos/Sources/OpenClaw/CritterStatusLabel+Behavior.swift
@@ -345,20 +345,45 @@ extension CritterStatusLabel {
     }
 
     private var gatewayNeedsAttention: Bool {
-        if self.isSleeping { return false }
-        switch self.gatewayStatus {
-        case .failed, .stopped:
-            return !self.isPaused
-        case .starting, .running, .attachedExisting:
+        Self.needsAttention(
+            connectionMode: self.connectionMode,
+            controlState: self.controlChannelState,
+            gatewayStatus: self.gatewayStatus,
+            isPaused: self.isPaused)
+    }
+
+    static func needsAttention(
+        connectionMode: AppState.ConnectionMode,
+        controlState: ControlChannel.ConnectionState,
+        gatewayStatus: GatewayProcessManager.Status,
+        isPaused: Bool) -> Bool
+    {
+        guard !isPaused else { return false }
+        switch connectionMode {
+        case .unconfigured:
             return false
+        case .remote:
+            return GatewayConnectionPresentation(state: controlState).needsAttention
+        case .local:
+            switch gatewayStatus {
+            case .failed, .stopped:
+                return true
+            case .starting, .running, .attachedExisting:
+                return false
+            }
         }
     }
 
     private var gatewayBadgeColor: Color {
+        if self.connectionMode == .remote,
+           GatewayConnectionPresentation(state: self.controlChannelState).needsAttention
+        {
+            return .red
+        }
         switch self.gatewayStatus {
-        case .failed: .red
-        case .stopped: .orange
-        default: .clear
+        case .failed: return .red
+        case .stopped: return .orange
+        default: return .clear
         }
     }
 }
@@ -375,6 +400,8 @@ extension CritterStatusLabel {
             blinkTick: 1,
             sendCelebrationTick: 1,
             gatewayStatus: .running(details: nil),
+            connectionMode: .local,
+            controlChannelState: .connected,
             animationsEnabled: true,
             iconState: .workingMain(.tool(.bash)),
             voiceWakeMeterActive: true)
@@ -421,6 +448,8 @@ extension CritterStatusLabel {
             blinkTick: 0,
             sendCelebrationTick: 0,
             gatewayStatus: .failed("boom"),
+            connectionMode: .local,
+            controlChannelState: .connected,
             animationsEnabled: false,
             iconState: .idle,
             voiceWakeMeterActive: false)
@@ -435,6 +464,8 @@ extension CritterStatusLabel {
             blinkTick: 0,
             sendCelebrationTick: 0,
             gatewayStatus: .stopped,
+            connectionMode: .local,
+            controlChannelState: .connected,
             animationsEnabled: false,
             iconState: .idle,
             voiceWakeMeterActive: false)

--- a/apps/macos/Sources/OpenClaw/CritterStatusLabel.swift
+++ b/apps/macos/Sources/OpenClaw/CritterStatusLabel.swift
@@ -8,6 +8,8 @@ struct CritterStatusLabel: View {
     var blinkTick: Int
     var sendCelebrationTick: Int
     var gatewayStatus: GatewayProcessManager.Status
+    var connectionMode: AppState.ConnectionMode
+    var controlChannelState: ControlChannel.ConnectionState
     var animationsEnabled: Bool
     var iconState: IconState
     var voiceWakeMeterActive: Bool = false

--- a/apps/macos/Sources/OpenClaw/DashboardGatewayCatalog.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardGatewayCatalog.swift
@@ -97,10 +97,11 @@ enum DashboardGatewayCatalog {
 
     @MainActor
     static func primaryHealth(for state: ControlChannel.ConnectionState) -> DashboardGatewayHealth {
-        // ControlChannel currently has no failed state. Keep every representable
-        // non-connected state neutral instead of painting a speculative error.
-        if case .connected = state { return .ok }
-        return .unknown
+        switch state {
+        case .connected: .ok
+        case .degraded: .error
+        case .connecting, .disconnected: .unknown
+        }
     }
 
     @MainActor

--- a/apps/macos/Sources/OpenClaw/DashboardGatewayMenuModel.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardGatewayMenuModel.swift
@@ -30,6 +30,7 @@ enum DashboardGatewayMenuModel {
 
     static func connectionLabel(
         mode: AppState.ConnectionMode,
+        controlState: ControlChannel.ConnectionState,
         entries: [DashboardGatewayEntry]) -> String
     {
         guard entries.count >= 2,
@@ -39,7 +40,7 @@ enum DashboardGatewayMenuModel {
             case .unconfigured:
                 String(localized: "OpenClaw Not Configured")
             case .remote:
-                String(localized: "Remote OpenClaw Active")
+                self.remoteConnectionLabel(state: controlState)
             case .local:
                 String(localized: "OpenClaw Active")
             }
@@ -48,9 +49,29 @@ enum DashboardGatewayMenuModel {
         case .unconfigured:
             String(localized: "OpenClaw Not Configured — \(primaryName)")
         case .remote:
-            String(localized: "Remote OpenClaw Active — \(primaryName)")
+            self.remoteConnectionLabel(state: controlState, primaryName: primaryName)
         case .local:
             String(localized: "OpenClaw Active — \(primaryName)")
+        }
+    }
+
+    private static func remoteConnectionLabel(
+        state: ControlChannel.ConnectionState,
+        primaryName: String? = nil) -> String
+    {
+        switch (state, primaryName) {
+        case (.connected, nil):
+            String(localized: "Remote OpenClaw Active")
+        case let (.connected, .some(name)):
+            String(localized: "Remote OpenClaw Active — \(name)")
+        case (.connecting, nil):
+            String(localized: "Remote OpenClaw Connecting")
+        case let (.connecting, .some(name)):
+            String(localized: "Remote OpenClaw Connecting — \(name)")
+        case (.disconnected, nil), (.degraded, nil):
+            String(localized: "Remote OpenClaw Needs Attention")
+        case let (.disconnected, .some(name)), let (.degraded, .some(name)):
+            String(localized: "Remote OpenClaw Needs Attention — \(name)")
         }
     }
 }

--- a/apps/macos/Sources/OpenClaw/GatewayConnectionPresentation.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnectionPresentation.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+enum GatewayConnectionTone: Equatable {
+    case healthy
+    case transient
+    case attention
+}
+
+struct GatewayConnectionPresentation: Equatable {
+    let statusLine: String
+    let generalTitle: String
+    let generalSubtitle: String
+    let symbolName: String
+    let tone: GatewayConnectionTone
+    let showsConnectionAction: Bool
+    let needsAttention: Bool
+
+    init(state: ControlChannel.ConnectionState) {
+        switch state {
+        case .connected:
+            self.statusLine = String(localized: "Connected")
+            self.generalTitle = String(localized: "OpenClaw active")
+            self.generalSubtitle = String(localized: "Connected to your remote Gateway.")
+            self.symbolName = "checkmark"
+            self.tone = .healthy
+            self.showsConnectionAction = false
+            self.needsAttention = false
+        case .connecting:
+            self.statusLine = String(localized: "Connecting…")
+            self.generalTitle = String(localized: "OpenClaw connecting")
+            self.generalSubtitle = String(localized: "Connecting to your remote Gateway…")
+            self.symbolName = "arrow.trianglehead.2.clockwise.rotate.90"
+            self.tone = .transient
+            self.showsConnectionAction = false
+            self.needsAttention = false
+        case .disconnected:
+            self.statusLine = String(localized: "Disconnected")
+            self.generalTitle = String(localized: "OpenClaw needs attention")
+            self
+                .generalSubtitle =
+                String(localized: "Disconnected from your remote Gateway. Open Connection settings to fix it.")
+            self.symbolName = "exclamationmark.triangle.fill"
+            self.tone = .attention
+            self.showsConnectionAction = true
+            self.needsAttention = false
+        case let .degraded(message):
+            let reason = message.trimmingCharacters(in: .whitespacesAndNewlines)
+            self.statusLine = reason.isEmpty ? String(localized: "Gateway connection failed.") : reason
+            self.generalTitle = String(localized: "OpenClaw needs attention")
+            self.generalSubtitle = self.statusLine + " " + String(localized: "Open Connection settings to fix it.")
+            self.symbolName = "exclamationmark.triangle.fill"
+            self.tone = .attention
+            self.showsConnectionAction = true
+            self.needsAttention = true
+        }
+    }
+}
+
+struct GeneralStatusPresentation: Equatable {
+    let title: String
+    let subtitle: String
+    let symbolName: String
+    let tone: GatewayConnectionTone
+    let showsConnectionAction: Bool
+
+    static func resolve(
+        mode: AppState.ConnectionMode,
+        isPaused: Bool,
+        controlState: ControlChannel.ConnectionState) -> Self
+    {
+        if isPaused {
+            return Self(
+                title: String(localized: "OpenClaw paused"),
+                subtitle: String(localized: "Gateway work is paused; incoming messages will wait."),
+                symbolName: "pause.fill",
+                tone: .transient,
+                showsConnectionAction: false)
+        }
+
+        switch mode {
+        case .local:
+            return Self(
+                title: String(localized: "OpenClaw active"),
+                subtitle: String(localized: "Processing messages through the local Gateway on this Mac."),
+                symbolName: "checkmark",
+                tone: .healthy,
+                showsConnectionAction: false)
+        case .unconfigured:
+            return Self(
+                title: String(localized: "OpenClaw active"),
+                subtitle: String(localized: "Ready to run after you choose a Gateway connection."),
+                symbolName: "checkmark",
+                tone: .healthy,
+                showsConnectionAction: false)
+        case .remote:
+            let connection = GatewayConnectionPresentation(state: controlState)
+            return Self(
+                title: connection.generalTitle,
+                subtitle: connection.generalSubtitle,
+                symbolName: connection.symbolName,
+                tone: connection.tone,
+                showsConnectionAction: connection.showsConnectionAction)
+        }
+    }
+}

--- a/apps/macos/Sources/OpenClaw/GeneralSettings.swift
+++ b/apps/macos/Sources/OpenClaw/GeneralSettings.swift
@@ -218,26 +218,39 @@ struct GeneralSettings: View {
     }
 
     private var openClawStatusPanel: some View {
-        HStack(alignment: .center, spacing: 14) {
+        let presentation = GeneralStatusPresentation.resolve(
+            mode: self.state.connectionMode,
+            isPaused: self.state.isPaused,
+            controlState: ControlChannel.shared.state)
+
+        return HStack(alignment: .center, spacing: 14) {
             ZStack {
                 Circle()
-                    .fill(self.state.isPaused ? Color.orange.opacity(0.18) : Color.green.opacity(0.18))
-                Image(systemName: self.state.isPaused ? "pause.fill" : "checkmark")
+                    .fill(self.statusColor(presentation.tone).opacity(0.18))
+                Image(systemName: presentation.symbolName)
                     .font(.system(size: 16, weight: .bold))
-                    .foregroundStyle(self.state.isPaused ? .orange : .green)
+                    .foregroundStyle(self.statusColor(presentation.tone))
             }
             .frame(width: 42, height: 42)
 
             VStack(alignment: .leading, spacing: 4) {
-                Text(self.state.isPaused ? "OpenClaw paused" : "OpenClaw active")
+                Text(verbatim: presentation.title)
                     .font(.headline)
-                Text(self.generalStatusSubtitle)
+                Text(verbatim: presentation.subtitle)
                     .font(.footnote)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
             Spacer(minLength: 20)
+
+            if presentation.showsConnectionAction {
+                Button("Open Connection Settings") {
+                    AppNavigationActions.openSettings(tab: .connection)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
 
             Toggle("OpenClaw active", isOn: self.activeBinding)
                 .labelsHidden()
@@ -252,17 +265,11 @@ struct GeneralSettings: View {
         }
     }
 
-    private var generalStatusSubtitle: String {
-        if self.state.isPaused {
-            return "Gateway work is paused; incoming messages will wait."
-        }
-        switch self.state.connectionMode {
-        case .local:
-            return "Processing messages through the local Gateway on this Mac."
-        case .remote:
-            return "Connected to a remote Gateway configuration."
-        case .unconfigured:
-            return "Ready to run after you choose a Gateway connection."
+    private func statusColor(_ tone: GatewayConnectionTone) -> Color {
+        switch tone {
+        case .healthy: .green
+        case .transient: .orange
+        case .attention: .red
         }
     }
 
@@ -363,7 +370,9 @@ struct GeneralSettings: View {
 
             Spacer(minLength: 18)
 
-            if let ping = ControlChannel.shared.lastPingMs {
+            if ControlChannel.shared.state == .connected,
+               let ping = ControlChannel.shared.lastPingMs
+            {
                 Text("\(Int(ping)) ms")
                     .font(.caption.weight(.semibold))
                     .padding(.horizontal, 8)
@@ -701,12 +710,7 @@ struct GeneralSettings: View {
     }
 
     private var controlStatusLine: String {
-        switch ControlChannel.shared.state {
-        case .connected: "Connected"
-        case .connecting: "Connecting…"
-        case .disconnected: "Disconnected"
-        case let .degraded(msg): msg
-        }
+        GatewayConnectionPresentation(state: ControlChannel.shared.state).statusLine
     }
 
     @ViewBuilder

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -44,6 +44,8 @@ struct OpenClawApp: App {
                 blinkTick: self.state.blinkTick,
                 sendCelebrationTick: self.state.sendCelebrationTick,
                 gatewayStatus: self.gatewayManager.status,
+                connectionMode: self.state.connectionMode,
+                controlChannelState: self.controlChannel.state,
                 animationsEnabled: self.state.iconAnimationsEnabled && !self.isGatewaySleeping,
                 iconState: self.effectiveIconState,
                 voiceWakeMeterActive: self.state.voiceWakeMeterActive)

--- a/apps/macos/Sources/OpenClaw/MenuContentView.swift
+++ b/apps/macos/Sources/OpenClaw/MenuContentView.swift
@@ -207,6 +207,7 @@ struct MenuContent: View {
     private var connectionLabel: String {
         DashboardGatewayMenuModel.connectionLabel(
             mode: self.state.connectionMode,
+            controlState: self.controlChannel.state,
             entries: self.dashboardManager.gatewayEntries)
     }
 
@@ -386,6 +387,18 @@ struct MenuContent: View {
     }
 
     private var healthStatus: (label: String, color: Color) {
+        if self.state.connectionMode == .remote {
+            let live = GatewayConnectionPresentation(state: self.controlChannel.state)
+            switch live.tone {
+            case .healthy:
+                break
+            case .transient:
+                return (live.generalSubtitle, .orange)
+            case .attention:
+                return (live.generalSubtitle, .red)
+            }
+        }
+
         if let activity = self.activityStore.current {
             let color: Color = activity.role == .main ? .accentColor : .gray
             let roleLabel = activity.role == .main ? "Main" : "Other"

--- a/apps/macos/Sources/OpenClaw/Resources/Localizable.xcstrings
+++ b/apps/macos/Sources/OpenClaw/Resources/Localizable.xcstrings
@@ -29241,6 +29241,142 @@
         }
       }
     },
+    "Connected": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connected"
+          }
+        },
+        "zh-CN": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        },
+        "zh-TW": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        },
+        "ja-JP": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connected"
+          }
+        }
+      }
+    },
     "Connected Instances": {
       "localizations": {
         "en": {
@@ -29377,138 +29513,138 @@
         }
       }
     },
-    "Connected to a remote Gateway configuration.": {
+    "Connected to your remote Gateway.": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Connected to a remote Gateway configuration."
+            "value": "Connected to your remote Gateway."
           }
         },
         "zh-CN": {
           "stringUnit": {
-            "state": "translated",
-            "value": "已连接到远程 Gateway 配置。"
+            "state": "new",
+            "value": "Connected to your remote Gateway."
           }
         },
         "zh-TW": {
           "stringUnit": {
-            "state": "translated",
-            "value": "已連線至遠端 Gateway 設定。"
+            "state": "new",
+            "value": "Connected to your remote Gateway."
           }
         },
         "pt-BR": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Conectado a uma configuração de Gateway remoto."
+            "state": "new",
+            "value": "Connected to your remote Gateway."
           }
         },
         "de": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Mit einer Remote-Gateway-Konfiguration verbunden."
+            "state": "new",
+            "value": "Connected to your remote Gateway."
           }
         },
         "es": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Conectado a una configuración de Gateway remoto."
+            "state": "new",
+            "value": "Connected to your remote Gateway."
           }
         },
         "ja-JP": {
           "stringUnit": {
-            "state": "translated",
-            "value": "リモート Gateway 構成に接続されています。"
+            "state": "new",
+            "value": "Connected to your remote Gateway."
           }
         },
         "ko": {
           "stringUnit": {
-            "state": "translated",
-            "value": "원격 Gateway 구성에 연결되었습니다."
+            "state": "new",
+            "value": "Connected to your remote Gateway."
           }
         },
         "fr": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Connecté à une configuration Gateway distante."
+            "state": "new",
+            "value": "Connected to your remote Gateway."
           }
         },
         "hi": {
           "stringUnit": {
-            "state": "translated",
-            "value": "किसी रिमोट Gateway कॉन्फ़िगरेशन से कनेक्टेड।"
+            "state": "new",
+            "value": "Connected to your remote Gateway."
           }
         },
         "ar": {
           "stringUnit": {
-            "state": "translated",
-            "value": "متصل بتكوين Gateway بعيد."
+            "state": "new",
+            "value": "Connected to your remote Gateway."
           }
         },
         "it": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Connesso a una configurazione Gateway remota."
+            "state": "new",
+            "value": "Connected to your remote Gateway."
           }
         },
         "tr": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Uzak bir Gateway yapılandırmasına bağlandı."
+            "state": "new",
+            "value": "Connected to your remote Gateway."
           }
         },
         "uk": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Підключено до віддаленої конфігурації Gateway."
+            "state": "new",
+            "value": "Connected to your remote Gateway."
           }
         },
         "id": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Terhubung ke konfigurasi Gateway jarak jauh."
+            "state": "new",
+            "value": "Connected to your remote Gateway."
           }
         },
         "pl": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Połączono ze zdalną konfiguracją Gateway."
+            "state": "new",
+            "value": "Connected to your remote Gateway."
           }
         },
         "th": {
           "stringUnit": {
-            "state": "translated",
-            "value": "เชื่อมต่อกับการกำหนดค่า Gateway ระยะไกลแล้ว"
+            "state": "new",
+            "value": "Connected to your remote Gateway."
           }
         },
         "vi": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Đã kết nối với cấu hình Gateway từ xa."
+            "state": "new",
+            "value": "Connected to your remote Gateway."
           }
         },
         "nl": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Verbonden met een externe Gateway-configuratie."
+            "state": "new",
+            "value": "Connected to your remote Gateway."
           }
         },
         "fa": {
           "stringUnit": {
-            "state": "translated",
-            "value": "به پیکربندی Gateway راه‌دور متصل شد."
+            "state": "new",
+            "value": "Connected to your remote Gateway."
           }
         },
         "ru": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Подключено к удаленной конфигурации Gateway."
+            "state": "new",
+            "value": "Connected to your remote Gateway."
           }
         },
         "sv": {
           "stringUnit": {
-            "state": "translated",
-            "value": "Ansluten till en fjärrkonfiguration för Gateway."
+            "state": "new",
+            "value": "Connected to your remote Gateway."
           }
         }
       }
@@ -30053,6 +30189,142 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ansluten med installationskod"
+          }
+        }
+      }
+    },
+    "Connecting to your remote Gateway…": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connecting to your remote Gateway…"
+          }
+        },
+        "zh-CN": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connecting to your remote Gateway…"
+          }
+        },
+        "zh-TW": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connecting to your remote Gateway…"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connecting to your remote Gateway…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connecting to your remote Gateway…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connecting to your remote Gateway…"
+          }
+        },
+        "ja-JP": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connecting to your remote Gateway…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connecting to your remote Gateway…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connecting to your remote Gateway…"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connecting to your remote Gateway…"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connecting to your remote Gateway…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connecting to your remote Gateway…"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connecting to your remote Gateway…"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connecting to your remote Gateway…"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connecting to your remote Gateway…"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connecting to your remote Gateway…"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connecting to your remote Gateway…"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connecting to your remote Gateway…"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connecting to your remote Gateway…"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connecting to your remote Gateway…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connecting to your remote Gateway…"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Connecting to your remote Gateway…"
           }
         }
       }
@@ -42977,6 +43249,142 @@
         }
       }
     },
+    "Disconnected": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disconnected"
+          }
+        },
+        "zh-CN": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected"
+          }
+        },
+        "zh-TW": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected"
+          }
+        },
+        "ja-JP": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected"
+          }
+        }
+      }
+    },
     "Disconnected (using System default)": {
       "localizations": {
         "en": {
@@ -43109,6 +43517,142 @@
           "stringUnit": {
             "state": "translated",
             "value": "Frånkopplad (använder systemstandard)"
+          }
+        }
+      }
+    },
+    "Disconnected from your remote Gateway. Open Connection settings to fix it.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
+          }
+        },
+        "zh-CN": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
+          }
+        },
+        "zh-TW": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
+          }
+        },
+        "ja-JP": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
           }
         }
       }
@@ -54265,6 +54809,142 @@
         }
       }
     },
+    "Gateway connection failed.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gateway connection failed."
+          }
+        },
+        "zh-CN": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway connection failed."
+          }
+        },
+        "zh-TW": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway connection failed."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway connection failed."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway connection failed."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway connection failed."
+          }
+        },
+        "ja-JP": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway connection failed."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway connection failed."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway connection failed."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway connection failed."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway connection failed."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway connection failed."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway connection failed."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway connection failed."
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway connection failed."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway connection failed."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway connection failed."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway connection failed."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway connection failed."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway connection failed."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway connection failed."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway connection failed."
+          }
+        }
+      }
+    },
     "Gateway location": {
       "localizations": {
         "en": {
@@ -55757,6 +56437,142 @@
           "stringUnit": {
             "state": "translated",
             "value": "Gateway-varning"
+          }
+        }
+      }
+    },
+    "Gateway work is paused; incoming messages will wait.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gateway work is paused; incoming messages will wait."
+          }
+        },
+        "zh-CN": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway work is paused; incoming messages will wait."
+          }
+        },
+        "zh-TW": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway work is paused; incoming messages will wait."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway work is paused; incoming messages will wait."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway work is paused; incoming messages will wait."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway work is paused; incoming messages will wait."
+          }
+        },
+        "ja-JP": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway work is paused; incoming messages will wait."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway work is paused; incoming messages will wait."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway work is paused; incoming messages will wait."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway work is paused; incoming messages will wait."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway work is paused; incoming messages will wait."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway work is paused; incoming messages will wait."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway work is paused; incoming messages will wait."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway work is paused; incoming messages will wait."
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway work is paused; incoming messages will wait."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway work is paused; incoming messages will wait."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway work is paused; incoming messages will wait."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway work is paused; incoming messages will wait."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway work is paused; incoming messages will wait."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway work is paused; incoming messages will wait."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway work is paused; incoming messages will wait."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Gateway work is paused; incoming messages will wait."
           }
         }
       }
@@ -85273,6 +86089,278 @@
         }
       }
     },
+    "Open Connection Settings": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Connection Settings"
+          }
+        },
+        "zh-CN": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection Settings"
+          }
+        },
+        "zh-TW": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection Settings"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection Settings"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection Settings"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection Settings"
+          }
+        },
+        "ja-JP": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection Settings"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection Settings"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection Settings"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection Settings"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection Settings"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection Settings"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection Settings"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection Settings"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection Settings"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection Settings"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection Settings"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection Settings"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection Settings"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection Settings"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection Settings"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection Settings"
+          }
+        }
+      }
+    },
+    "Open Connection settings to fix it.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Connection settings to fix it."
+          }
+        },
+        "zh-CN": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection settings to fix it."
+          }
+        },
+        "zh-TW": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection settings to fix it."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection settings to fix it."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection settings to fix it."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection settings to fix it."
+          }
+        },
+        "ja-JP": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection settings to fix it."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection settings to fix it."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection settings to fix it."
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection settings to fix it."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection settings to fix it."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection settings to fix it."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection settings to fix it."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection settings to fix it."
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection settings to fix it."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection settings to fix it."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection settings to fix it."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection settings to fix it."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection settings to fix it."
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection settings to fix it."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection settings to fix it."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Open Connection settings to fix it."
+          }
+        }
+      }
+    },
     "Open Dashboard": {
       "localizations": {
         "en": {
@@ -88265,6 +89353,142 @@
         }
       }
     },
+    "OpenClaw connecting": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OpenClaw connecting"
+          }
+        },
+        "zh-CN": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw connecting"
+          }
+        },
+        "zh-TW": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw connecting"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw connecting"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw connecting"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw connecting"
+          }
+        },
+        "ja-JP": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw connecting"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw connecting"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw connecting"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw connecting"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw connecting"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw connecting"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw connecting"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw connecting"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw connecting"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw connecting"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw connecting"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw connecting"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw connecting"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw connecting"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw connecting"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw connecting"
+          }
+        }
+      }
+    },
     "OpenClaw could not confirm the agent notification. It will not retry, to avoid a duplicate welcome.": {
       "localizations": {
         "en": {
@@ -90029,6 +91253,142 @@
           "stringUnit": {
             "state": "translated",
             "value": "OpenClaw arbetar…"
+          }
+        }
+      }
+    },
+    "OpenClaw needs attention": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OpenClaw needs attention"
+          }
+        },
+        "zh-CN": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw needs attention"
+          }
+        },
+        "zh-TW": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw needs attention"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw needs attention"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw needs attention"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw needs attention"
+          }
+        },
+        "ja-JP": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw needs attention"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw needs attention"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw needs attention"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw needs attention"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw needs attention"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw needs attention"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw needs attention"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw needs attention"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw needs attention"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw needs attention"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw needs attention"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw needs attention"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw needs attention"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw needs attention"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw needs attention"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "new",
+            "value": "OpenClaw needs attention"
           }
         }
       }
@@ -105805,6 +107165,278 @@
           "stringUnit": {
             "state": "translated",
             "value": "Fjärr-OpenClaw aktivt"
+          }
+        }
+      }
+    },
+    "Remote OpenClaw Connecting": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remote OpenClaw Connecting"
+          }
+        },
+        "zh-CN": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Connecting"
+          }
+        },
+        "zh-TW": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Connecting"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Connecting"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Connecting"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Connecting"
+          }
+        },
+        "ja-JP": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Connecting"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Connecting"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Connecting"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Connecting"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Connecting"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Connecting"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Connecting"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Connecting"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Connecting"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Connecting"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Connecting"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Connecting"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Connecting"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Connecting"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Connecting"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Connecting"
+          }
+        }
+      }
+    },
+    "Remote OpenClaw Needs Attention": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remote OpenClaw Needs Attention"
+          }
+        },
+        "zh-CN": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Needs Attention"
+          }
+        },
+        "zh-TW": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Needs Attention"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Needs Attention"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Needs Attention"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Needs Attention"
+          }
+        },
+        "ja-JP": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Needs Attention"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Needs Attention"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Needs Attention"
+          }
+        },
+        "hi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Needs Attention"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Needs Attention"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Needs Attention"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Needs Attention"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Needs Attention"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Needs Attention"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Needs Attention"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Needs Attention"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Needs Attention"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Needs Attention"
+          }
+        },
+        "fa": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Needs Attention"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Needs Attention"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Remote OpenClaw Needs Attention"
           }
         }
       }

--- a/apps/macos/Sources/OpenClaw/Resources/Localizable.xcstrings
+++ b/apps/macos/Sources/OpenClaw/Resources/Localizable.xcstrings
@@ -29241,142 +29241,6 @@
         }
       }
     },
-    "Connected": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connected"
-          }
-        },
-        "zh-CN": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connected"
-          }
-        },
-        "zh-TW": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connected"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connected"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connected"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connected"
-          }
-        },
-        "ja-JP": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connected"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connected"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connected"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connected"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connected"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connected"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connected"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connected"
-          }
-        },
-        "id": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connected"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connected"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connected"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connected"
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connected"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connected"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connected"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connected"
-          }
-        }
-      }
-    },
     "Connected Instances": {
       "localizations": {
         "en": {
@@ -29513,138 +29377,138 @@
         }
       }
     },
-    "Connected to your remote Gateway.": {
+    "Connected to a remote Gateway configuration.": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Connected to your remote Gateway."
+            "value": "Connected to a remote Gateway configuration."
           }
         },
         "zh-CN": {
           "stringUnit": {
-            "state": "new",
-            "value": "Connected to your remote Gateway."
+            "state": "translated",
+            "value": "已连接到远程 Gateway 配置。"
           }
         },
         "zh-TW": {
           "stringUnit": {
-            "state": "new",
-            "value": "Connected to your remote Gateway."
+            "state": "translated",
+            "value": "已連線至遠端 Gateway 設定。"
           }
         },
         "pt-BR": {
           "stringUnit": {
-            "state": "new",
-            "value": "Connected to your remote Gateway."
+            "state": "translated",
+            "value": "Conectado a uma configuração de Gateway remoto."
           }
         },
         "de": {
           "stringUnit": {
-            "state": "new",
-            "value": "Connected to your remote Gateway."
+            "state": "translated",
+            "value": "Mit einer Remote-Gateway-Konfiguration verbunden."
           }
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": "Connected to your remote Gateway."
+            "state": "translated",
+            "value": "Conectado a una configuración de Gateway remoto."
           }
         },
         "ja-JP": {
           "stringUnit": {
-            "state": "new",
-            "value": "Connected to your remote Gateway."
+            "state": "translated",
+            "value": "リモート Gateway 構成に接続されています。"
           }
         },
         "ko": {
           "stringUnit": {
-            "state": "new",
-            "value": "Connected to your remote Gateway."
+            "state": "translated",
+            "value": "원격 Gateway 구성에 연결되었습니다."
           }
         },
         "fr": {
           "stringUnit": {
-            "state": "new",
-            "value": "Connected to your remote Gateway."
+            "state": "translated",
+            "value": "Connecté à une configuration Gateway distante."
           }
         },
         "hi": {
           "stringUnit": {
-            "state": "new",
-            "value": "Connected to your remote Gateway."
+            "state": "translated",
+            "value": "किसी रिमोट Gateway कॉन्फ़िगरेशन से कनेक्टेड।"
           }
         },
         "ar": {
           "stringUnit": {
-            "state": "new",
-            "value": "Connected to your remote Gateway."
+            "state": "translated",
+            "value": "متصل بتكوين Gateway بعيد."
           }
         },
         "it": {
           "stringUnit": {
-            "state": "new",
-            "value": "Connected to your remote Gateway."
+            "state": "translated",
+            "value": "Connesso a una configurazione Gateway remota."
           }
         },
         "tr": {
           "stringUnit": {
-            "state": "new",
-            "value": "Connected to your remote Gateway."
+            "state": "translated",
+            "value": "Uzak bir Gateway yapılandırmasına bağlandı."
           }
         },
         "uk": {
           "stringUnit": {
-            "state": "new",
-            "value": "Connected to your remote Gateway."
+            "state": "translated",
+            "value": "Підключено до віддаленої конфігурації Gateway."
           }
         },
         "id": {
           "stringUnit": {
-            "state": "new",
-            "value": "Connected to your remote Gateway."
+            "state": "translated",
+            "value": "Terhubung ke konfigurasi Gateway jarak jauh."
           }
         },
         "pl": {
           "stringUnit": {
-            "state": "new",
-            "value": "Connected to your remote Gateway."
+            "state": "translated",
+            "value": "Połączono ze zdalną konfiguracją Gateway."
           }
         },
         "th": {
           "stringUnit": {
-            "state": "new",
-            "value": "Connected to your remote Gateway."
+            "state": "translated",
+            "value": "เชื่อมต่อกับการกำหนดค่า Gateway ระยะไกลแล้ว"
           }
         },
         "vi": {
           "stringUnit": {
-            "state": "new",
-            "value": "Connected to your remote Gateway."
+            "state": "translated",
+            "value": "Đã kết nối với cấu hình Gateway từ xa."
           }
         },
         "nl": {
           "stringUnit": {
-            "state": "new",
-            "value": "Connected to your remote Gateway."
+            "state": "translated",
+            "value": "Verbonden met een externe Gateway-configuratie."
           }
         },
         "fa": {
           "stringUnit": {
-            "state": "new",
-            "value": "Connected to your remote Gateway."
+            "state": "translated",
+            "value": "به پیکربندی Gateway راه‌دور متصل شد."
           }
         },
         "ru": {
           "stringUnit": {
-            "state": "new",
-            "value": "Connected to your remote Gateway."
+            "state": "translated",
+            "value": "Подключено к удаленной конфигурации Gateway."
           }
         },
         "sv": {
           "stringUnit": {
-            "state": "new",
-            "value": "Connected to your remote Gateway."
+            "state": "translated",
+            "value": "Ansluten till en fjärrkonfiguration för Gateway."
           }
         }
       }
@@ -30189,142 +30053,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ansluten med installationskod"
-          }
-        }
-      }
-    },
-    "Connecting to your remote Gateway…": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connecting to your remote Gateway…"
-          }
-        },
-        "zh-CN": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connecting to your remote Gateway…"
-          }
-        },
-        "zh-TW": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connecting to your remote Gateway…"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connecting to your remote Gateway…"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connecting to your remote Gateway…"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connecting to your remote Gateway…"
-          }
-        },
-        "ja-JP": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connecting to your remote Gateway…"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connecting to your remote Gateway…"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connecting to your remote Gateway…"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connecting to your remote Gateway…"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connecting to your remote Gateway…"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connecting to your remote Gateway…"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connecting to your remote Gateway…"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connecting to your remote Gateway…"
-          }
-        },
-        "id": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connecting to your remote Gateway…"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connecting to your remote Gateway…"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connecting to your remote Gateway…"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connecting to your remote Gateway…"
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connecting to your remote Gateway…"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connecting to your remote Gateway…"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connecting to your remote Gateway…"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Connecting to your remote Gateway…"
           }
         }
       }
@@ -43249,142 +42977,6 @@
         }
       }
     },
-    "Disconnected": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Disconnected"
-          }
-        },
-        "zh-CN": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected"
-          }
-        },
-        "zh-TW": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected"
-          }
-        },
-        "ja-JP": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected"
-          }
-        },
-        "id": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected"
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected"
-          }
-        }
-      }
-    },
     "Disconnected (using System default)": {
       "localizations": {
         "en": {
@@ -43517,142 +43109,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Frånkopplad (använder systemstandard)"
-          }
-        }
-      }
-    },
-    "Disconnected from your remote Gateway. Open Connection settings to fix it.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
-          }
-        },
-        "zh-CN": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
-          }
-        },
-        "zh-TW": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
-          }
-        },
-        "ja-JP": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
-          }
-        },
-        "id": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Disconnected from your remote Gateway. Open Connection settings to fix it."
           }
         }
       }
@@ -54809,142 +54265,6 @@
         }
       }
     },
-    "Gateway connection failed.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gateway connection failed."
-          }
-        },
-        "zh-CN": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway connection failed."
-          }
-        },
-        "zh-TW": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway connection failed."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway connection failed."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway connection failed."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway connection failed."
-          }
-        },
-        "ja-JP": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway connection failed."
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway connection failed."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway connection failed."
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway connection failed."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway connection failed."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway connection failed."
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway connection failed."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway connection failed."
-          }
-        },
-        "id": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway connection failed."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway connection failed."
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway connection failed."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway connection failed."
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway connection failed."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway connection failed."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway connection failed."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway connection failed."
-          }
-        }
-      }
-    },
     "Gateway location": {
       "localizations": {
         "en": {
@@ -56437,142 +55757,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Gateway-varning"
-          }
-        }
-      }
-    },
-    "Gateway work is paused; incoming messages will wait.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gateway work is paused; incoming messages will wait."
-          }
-        },
-        "zh-CN": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway work is paused; incoming messages will wait."
-          }
-        },
-        "zh-TW": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway work is paused; incoming messages will wait."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway work is paused; incoming messages will wait."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway work is paused; incoming messages will wait."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway work is paused; incoming messages will wait."
-          }
-        },
-        "ja-JP": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway work is paused; incoming messages will wait."
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway work is paused; incoming messages will wait."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway work is paused; incoming messages will wait."
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway work is paused; incoming messages will wait."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway work is paused; incoming messages will wait."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway work is paused; incoming messages will wait."
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway work is paused; incoming messages will wait."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway work is paused; incoming messages will wait."
-          }
-        },
-        "id": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway work is paused; incoming messages will wait."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway work is paused; incoming messages will wait."
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway work is paused; incoming messages will wait."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway work is paused; incoming messages will wait."
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway work is paused; incoming messages will wait."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway work is paused; incoming messages will wait."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway work is paused; incoming messages will wait."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Gateway work is paused; incoming messages will wait."
           }
         }
       }
@@ -86089,278 +85273,6 @@
         }
       }
     },
-    "Open Connection Settings": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open Connection Settings"
-          }
-        },
-        "zh-CN": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection Settings"
-          }
-        },
-        "zh-TW": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection Settings"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection Settings"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection Settings"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection Settings"
-          }
-        },
-        "ja-JP": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection Settings"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection Settings"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection Settings"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection Settings"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection Settings"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection Settings"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection Settings"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection Settings"
-          }
-        },
-        "id": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection Settings"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection Settings"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection Settings"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection Settings"
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection Settings"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection Settings"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection Settings"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection Settings"
-          }
-        }
-      }
-    },
-    "Open Connection settings to fix it.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open Connection settings to fix it."
-          }
-        },
-        "zh-CN": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection settings to fix it."
-          }
-        },
-        "zh-TW": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection settings to fix it."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection settings to fix it."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection settings to fix it."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection settings to fix it."
-          }
-        },
-        "ja-JP": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection settings to fix it."
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection settings to fix it."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection settings to fix it."
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection settings to fix it."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection settings to fix it."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection settings to fix it."
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection settings to fix it."
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection settings to fix it."
-          }
-        },
-        "id": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection settings to fix it."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection settings to fix it."
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection settings to fix it."
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection settings to fix it."
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection settings to fix it."
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection settings to fix it."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection settings to fix it."
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Open Connection settings to fix it."
-          }
-        }
-      }
-    },
     "Open Dashboard": {
       "localizations": {
         "en": {
@@ -89353,142 +88265,6 @@
         }
       }
     },
-    "OpenClaw connecting": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OpenClaw connecting"
-          }
-        },
-        "zh-CN": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw connecting"
-          }
-        },
-        "zh-TW": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw connecting"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw connecting"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw connecting"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw connecting"
-          }
-        },
-        "ja-JP": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw connecting"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw connecting"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw connecting"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw connecting"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw connecting"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw connecting"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw connecting"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw connecting"
-          }
-        },
-        "id": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw connecting"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw connecting"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw connecting"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw connecting"
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw connecting"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw connecting"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw connecting"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw connecting"
-          }
-        }
-      }
-    },
     "OpenClaw could not confirm the agent notification. It will not retry, to avoid a duplicate welcome.": {
       "localizations": {
         "en": {
@@ -91253,142 +90029,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "OpenClaw arbetar…"
-          }
-        }
-      }
-    },
-    "OpenClaw needs attention": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OpenClaw needs attention"
-          }
-        },
-        "zh-CN": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw needs attention"
-          }
-        },
-        "zh-TW": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw needs attention"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw needs attention"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw needs attention"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw needs attention"
-          }
-        },
-        "ja-JP": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw needs attention"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw needs attention"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw needs attention"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw needs attention"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw needs attention"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw needs attention"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw needs attention"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw needs attention"
-          }
-        },
-        "id": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw needs attention"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw needs attention"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw needs attention"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw needs attention"
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw needs attention"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw needs attention"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw needs attention"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "new",
-            "value": "OpenClaw needs attention"
           }
         }
       }
@@ -107165,278 +105805,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Fjärr-OpenClaw aktivt"
-          }
-        }
-      }
-    },
-    "Remote OpenClaw Connecting": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Remote OpenClaw Connecting"
-          }
-        },
-        "zh-CN": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Connecting"
-          }
-        },
-        "zh-TW": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Connecting"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Connecting"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Connecting"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Connecting"
-          }
-        },
-        "ja-JP": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Connecting"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Connecting"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Connecting"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Connecting"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Connecting"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Connecting"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Connecting"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Connecting"
-          }
-        },
-        "id": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Connecting"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Connecting"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Connecting"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Connecting"
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Connecting"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Connecting"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Connecting"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Connecting"
-          }
-        }
-      }
-    },
-    "Remote OpenClaw Needs Attention": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Remote OpenClaw Needs Attention"
-          }
-        },
-        "zh-CN": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Needs Attention"
-          }
-        },
-        "zh-TW": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Needs Attention"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Needs Attention"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Needs Attention"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Needs Attention"
-          }
-        },
-        "ja-JP": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Needs Attention"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Needs Attention"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Needs Attention"
-          }
-        },
-        "hi": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Needs Attention"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Needs Attention"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Needs Attention"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Needs Attention"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Needs Attention"
-          }
-        },
-        "id": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Needs Attention"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Needs Attention"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Needs Attention"
-          }
-        },
-        "vi": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Needs Attention"
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Needs Attention"
-          }
-        },
-        "fa": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Needs Attention"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Needs Attention"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Remote OpenClaw Needs Attention"
           }
         }
       }

--- a/apps/macos/Tests/OpenClawIPCTests/CritterStatusBeatsTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CritterStatusBeatsTests.swift
@@ -81,4 +81,38 @@ struct CritterStatusBeatsTests {
             endedAt: startedAt.addingTimeInterval(10),
             minimumDuration: 10))
     }
+
+    @Test func `remote authentication failure raises attention and recovery clears it`() {
+        let gatewayStatus = GatewayProcessManager.Status.stopped
+        let authFailure = RemoteGatewayAuthIssue.tokenMismatch.statusMessage
+
+        #expect(CritterStatusLabel.needsAttention(
+            connectionMode: .remote,
+            controlState: .degraded(authFailure),
+            gatewayStatus: gatewayStatus,
+            isPaused: false))
+        #expect(!CritterStatusLabel.needsAttention(
+            connectionMode: .remote,
+            controlState: .connected,
+            gatewayStatus: gatewayStatus,
+            isPaused: false))
+    }
+
+    @Test func `attention follows the configured owner`() {
+        #expect(CritterStatusLabel.needsAttention(
+            connectionMode: .local,
+            controlState: .connected,
+            gatewayStatus: .failed("boom"),
+            isPaused: false))
+        #expect(!CritterStatusLabel.needsAttention(
+            connectionMode: .unconfigured,
+            controlState: .degraded("ignored"),
+            gatewayStatus: .stopped,
+            isPaused: false))
+        #expect(!CritterStatusLabel.needsAttention(
+            connectionMode: .remote,
+            controlState: .degraded("auth failed"),
+            gatewayStatus: .stopped,
+            isPaused: true))
+    }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/CritterStatusBeatsTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CritterStatusBeatsTests.swift
@@ -90,12 +90,14 @@ struct CritterStatusBeatsTests {
             connectionMode: .remote,
             controlState: .degraded(authFailure),
             gatewayStatus: gatewayStatus,
-            isPaused: false))
+            isPaused: false,
+            isSleeping: true))
         #expect(!CritterStatusLabel.needsAttention(
             connectionMode: .remote,
             controlState: .connected,
             gatewayStatus: gatewayStatus,
-            isPaused: false))
+            isPaused: false,
+            isSleeping: false))
     }
 
     @Test func `attention follows the configured owner`() {
@@ -103,16 +105,25 @@ struct CritterStatusBeatsTests {
             connectionMode: .local,
             controlState: .connected,
             gatewayStatus: .failed("boom"),
-            isPaused: false))
+            isPaused: false,
+            isSleeping: false))
+        #expect(!CritterStatusLabel.needsAttention(
+            connectionMode: .local,
+            controlState: .connected,
+            gatewayStatus: .stopped,
+            isPaused: false,
+            isSleeping: true))
         #expect(!CritterStatusLabel.needsAttention(
             connectionMode: .unconfigured,
             controlState: .degraded("ignored"),
             gatewayStatus: .stopped,
-            isPaused: false))
+            isPaused: false,
+            isSleeping: false))
         #expect(!CritterStatusLabel.needsAttention(
             connectionMode: .remote,
             controlState: .degraded("auth failed"),
             gatewayStatus: .stopped,
-            isPaused: true))
+            isPaused: true,
+            isSleeping: true))
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardGatewayMenuTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardGatewayMenuTests.swift
@@ -6,17 +6,23 @@ struct DashboardGatewayMenuTests {
     @Test func `connection label names primary only for multiple gateways`() {
         let primary = Self.entry(id: "primary", name: "Mac Studio", isPrimary: true, health: .ok)
         let profile = Self.entry(id: "profile:travel", name: "Travel", canPromote: true)
-        let cases: [(AppState.ConnectionMode, [DashboardGatewayEntry], String)] = [
-            (.unconfigured, [primary], "OpenClaw Not Configured"),
-            (.unconfigured, [primary, profile], "OpenClaw Not Configured — Mac Studio"),
-            (.local, [primary], "OpenClaw Active"),
-            (.local, [primary, profile], "OpenClaw Active — Mac Studio"),
-            (.remote, [primary], "Remote OpenClaw Active"),
-            (.remote, [primary, profile], "Remote OpenClaw Active — Mac Studio"),
+        let cases: [(AppState.ConnectionMode, ControlChannel.ConnectionState, [DashboardGatewayEntry], String)] = [
+            (.unconfigured, .degraded("ignored"), [primary], "OpenClaw Not Configured"),
+            (.unconfigured, .degraded("ignored"), [primary, profile], "OpenClaw Not Configured — Mac Studio"),
+            (.local, .degraded("ignored"), [primary], "OpenClaw Active"),
+            (.local, .degraded("ignored"), [primary, profile], "OpenClaw Active — Mac Studio"),
+            (.remote, .connected, [primary], "Remote OpenClaw Active"),
+            (.remote, .connected, [primary, profile], "Remote OpenClaw Active — Mac Studio"),
+            (.remote, .connecting, [primary], "Remote OpenClaw Connecting"),
+            (.remote, .degraded("auth failed"), [primary], "Remote OpenClaw Needs Attention"),
+            (.remote, .degraded("auth failed"), [primary, profile], "Remote OpenClaw Needs Attention — Mac Studio"),
         ]
 
-        for (mode, entries, expected) in cases {
-            #expect(DashboardGatewayMenuModel.connectionLabel(mode: mode, entries: entries) == expected)
+        for (mode, controlState, entries, expected) in cases {
+            #expect(DashboardGatewayMenuModel.connectionLabel(
+                mode: mode,
+                controlState: controlState,
+                entries: entries) == expected)
         }
     }
 

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardGatewaysTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardGatewaysTests.swift
@@ -70,11 +70,11 @@ struct DashboardGatewayCatalogTests {
         #expect(entries[0].name == "127.0.0.1")
     }
 
-    @Test @MainActor func `catalog maps only connected control state to healthy`() {
+    @Test @MainActor func `catalog maps live control health`() {
         #expect(DashboardGatewayCatalog.primaryHealth(for: .connected) == .ok)
         #expect(DashboardGatewayCatalog.primaryHealth(for: .disconnected) == .unknown)
         #expect(DashboardGatewayCatalog.primaryHealth(for: .connecting) == .unknown)
-        #expect(DashboardGatewayCatalog.primaryHealth(for: .degraded("offline")) == .unknown)
+        #expect(DashboardGatewayCatalog.primaryHealth(for: .degraded("offline")) == .error)
     }
 
     @Test func `local catalog does not deduplicate a retained remote profile`() throws {

--- a/apps/macos/Tests/OpenClawIPCTests/GeneralSettingsStatusTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GeneralSettingsStatusTests.swift
@@ -1,0 +1,59 @@
+import Testing
+@testable import OpenClaw
+
+@MainActor
+struct GeneralSettingsStatusTests {
+    @Test func `connected remote gateway is healthy`() {
+        let status = GeneralStatusPresentation.resolve(
+            mode: .remote,
+            isPaused: false,
+            controlState: .connected)
+
+        #expect(status.title == "OpenClaw active")
+        #expect(status.subtitle == "Connected to your remote Gateway.")
+        #expect(status.tone == .healthy)
+        #expect(!status.showsConnectionAction)
+    }
+
+    @Test func `remote authentication failure is actionable`() {
+        let reason = RemoteGatewayAuthIssue.tokenMismatch.statusMessage
+        let status = GeneralStatusPresentation.resolve(
+            mode: .remote,
+            isPaused: false,
+            controlState: .degraded(reason))
+
+        #expect(status.title == "OpenClaw needs attention")
+        #expect(status.subtitle.contains(reason))
+        #expect(status.subtitle.contains("Open Connection settings"))
+        #expect(status.tone == .attention)
+        #expect(status.showsConnectionAction)
+    }
+
+    @Test func `remote connection attempt is transient`() {
+        let status = GeneralStatusPresentation.resolve(
+            mode: .remote,
+            isPaused: false,
+            controlState: .connecting)
+
+        #expect(status.title == "OpenClaw connecting")
+        #expect(status.subtitle == "Connecting to your remote Gateway…")
+        #expect(status.tone == .transient)
+        #expect(!status.showsConnectionAction)
+    }
+
+    @Test func `local and unconfigured copy stay independent of remote health`() {
+        let local = GeneralStatusPresentation.resolve(
+            mode: .local,
+            isPaused: false,
+            controlState: .degraded("ignored"))
+        let unconfigured = GeneralStatusPresentation.resolve(
+            mode: .unconfigured,
+            isPaused: false,
+            controlState: .degraded("ignored"))
+
+        #expect(local.subtitle == "Processing messages through the local Gateway on this Mac.")
+        #expect(local.tone == .healthy)
+        #expect(unconfigured.subtitle == "Ready to run after you choose a Gateway connection.")
+        #expect(unconfigured.tone == .healthy)
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/SettingsViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/SettingsViewSmokeTests.swift
@@ -155,6 +155,12 @@ struct SettingsViewSmokeTests {
         _ = view.body
     }
 
+    @Test func `connection settings builds body`() {
+        let state = AppState(preview: true)
+        let view = GeneralSettings(state: state, page: .connection)
+        _ = view.body
+    }
+
     @Test func `general settings renders the keyboard shortcut recorder`() {
         let state = AppState(preview: true)
         let hosting = NSHostingView(rootView: GeneralSettings(state: state))


### PR DESCRIPTION
Closes #118035

## What Problem This Solves

Fixes an issue where remote-mode macOS users saw a green “OpenClaw active” status and “Connected to a remote Gateway configuration” even while the live Gateway control channel was rejected for a missing or mismatched token. The same failure was absent from the menu-bar status surface, leaving the app in a silent degraded state.

## Why This Change Was Made

The General pane, Connection pane, menu heading/status, Gateway catalog, and menu-bar attention badge now project the existing `ControlChannel.ConnectionState` instead of treating configuration as connection health. Remote authentication failures preserve the control channel’s actionable reason, link directly to Connection settings, and raise the existing menu-bar attention dot; a healthy connection clears that state. Local and unconfigured behavior are unchanged.

Connection-scoped ping and auth-source facts are also cleared when the control channel leaves the connected state, preventing stale green latency from appearing beside a failure.

The source localization inventory is updated in this PR. The repository’s isolated Native App Locale Refresh workflow owns the generated `Localizable.xcstrings` update; mixing that generated catalog with Swift source is rejected by CI.

## User Impact

Before: `OpenClaw active — Connected to a remote Gateway configuration.`

After, healthy: `OpenClaw active — Connected to your remote Gateway.`

After, connecting: `OpenClaw connecting — Connecting to your remote Gateway…`

After, authentication failure: `OpenClaw needs attention — Gateway token mismatch… Open Connection settings to fix it.` The panel includes an **Open Connection Settings** action, the menu heading/status reflects the failure, and the menu-bar icon shows its existing red attention dot.

## Evidence

- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift build --package-path apps/macos` — passed.
- Focused Swift test targets compile. Local execution then hits the known host limitation loading `Sparkle.framework` into `OpenClawIPCTests.xctest`; the `macos-swift` CI lane is the execution proof.
- `pnpm native:i18n:verify` — passed.
- `pnpm apple:i18n:check` — passed.
- Codex autoreview — clean; no accepted/actionable findings.

Screenshots are omitted because reproducing the before/after state requires a deliberately mis-authenticated remote Gateway. The state-to-copy mapping, auth-failure attention transition, recovery clearing, and sibling menu states are covered by focused unit tests and CI.
