### PR TITLE
chore(agents): add real process-control roundtrip coverage

### DIFF
--- a/qa/scenarios/runtime/process-control-roundtrip.yaml
+++ b/qa/scenarios/runtime/process-control-roundtrip.yaml
@@ -1,0 +1,31 @@
+title: Background process control roundtrip
+
+scenario:
+  id: process-control-roundtrip
+  surface: automation
+  category: automation.polling-controls
+  coverage:
+    primary:
+      - automation.process-poll
+      - automation.process-log
+      - automation.background-process-status
+      - automation.process-input-controls
+  objective: Prove the production exec and process tools control one real interactive background child through its complete lifecycle.
+  successCriteria:
+    - Exec starts a real PTY-backed child and returns a running process session.
+    - Process list reports the live session and writable input state.
+    - Process log and poll expose real child output without inventing channel or message polling proof.
+    - Process write plus submit delivers one input line to the child.
+    - Process send-keys delivers literal, Enter, and control-key input.
+    - Process poll observes the child exit successfully and completed logs remain readable.
+  docsRefs:
+    - docs/gateway/background-process.md
+    - docs/help/testing.md
+  codeRefs:
+    - src/agents/bash-tools.exec-run.ts
+    - src/agents/bash-tools.process.ts
+    - src/agents/bash-tools.process.e2e.test.ts
+  execution:
+    kind: vitest
+    path: src/agents/bash-tools.process.e2e.test.ts
+    summary: Run one real interactive background child through exec, process status, log, poll, input, and control boundaries.

--- a/src/agents/bash-tools.process.e2e.test.ts
+++ b/src/agents/bash-tools.process.e2e.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, expect, test } from "vitest";
+import { getSession } from "./bash-process-registry.js";
+import { resetProcessRegistryForTests } from "./bash-process-registry.test-support.js";
+import { createExecTool } from "./bash-tools.exec-run.js";
+import { createProcessTool } from "./bash-tools.process.js";
+
+afterEach(() => {
+  resetProcessRegistryForTests();
+});
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", process.platform === "win32" ? "''" : "'\\''")}'`;
+}
+
+function currentNodeEvalCommand(source: string): string {
+  const node = shellQuote(process.execPath);
+  const script = shellQuote(source);
+  return process.platform === "win32" ? `& ${node} -e ${script}` : `${node} -e ${script}`;
+}
+
+function textContent(result: { content: Array<{ type: string; text?: string }> }): string {
+  return result.content.find((part) => part.type === "text")?.text ?? "";
+}
+
+test.skipIf(process.platform === "win32")(
+  "controls one real interactive background child through exec and process tools",
+  async () => {
+    const scopeKey = "agent:main:process-control-roundtrip";
+    const execTool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      allowBackground: true,
+      backgroundMs: 0,
+      timeoutSec: 10,
+      notifyOnExit: false,
+      scopeKey,
+    });
+    const processTool = createProcessTool({ scopeKey });
+    const command = currentNodeEvalCommand(
+      [
+        'process.stdin.setEncoding("utf8");',
+        "process.stdin.setRawMode?.(true);",
+        'let pending = "";',
+        "let lineCount = 0;",
+        'process.stdout.write("READY\\n");',
+        'process.stdin.on("data", (chunk) => {',
+        "  for (const char of chunk) {",
+        '    if (char === "\\u0003") {',
+        "      process.stdout.write(`CONTROL:CTRL-C:${lineCount}\\n`);",
+        "      setTimeout(() => process.exit(lineCount === 2 ? 0 : 3), 10);",
+        "      continue;",
+        "    }",
+        '    if (char !== "\\r" && char !== "\\n") {',
+        "      pending += char;",
+        "      continue;",
+        "    }",
+        "    if (!pending) continue;",
+        "    lineCount += 1;",
+        "    process.stdout.write(`LINE:${pending}\\n`);",
+        '    pending = "";',
+        "  }",
+        "});",
+        "setInterval(() => {}, 1_000);",
+      ].join("\n"),
+    );
+
+    let sessionId: string | undefined;
+    try {
+      const started = await execTool.execute("process-control-start", {
+        command,
+        background: true,
+        pty: true,
+      });
+      expect(started.details).toMatchObject({ status: "running" });
+      sessionId = (started.details as { sessionId?: string }).sessionId;
+      expect(sessionId).toEqual(expect.any(String));
+      if (!sessionId) {
+        throw new Error("exec did not return a background session id");
+      }
+
+      const listed = await processTool.execute("process-control-list", { action: "list" });
+      expect(listed.details).toMatchObject({
+        status: "completed",
+        sessions: expect.arrayContaining([
+          expect.objectContaining({
+            sessionId,
+            status: "running",
+            stdinWritable: true,
+          }),
+        ]),
+      });
+
+      await expect
+        .poll(
+          async () => {
+            const log = await processTool.execute("process-control-ready-log", {
+              action: "log",
+              sessionId,
+            });
+            return textContent(log);
+          },
+          { timeout: 5_000, interval: 25 },
+        )
+        .toContain("READY");
+
+      const readyPoll = await processTool.execute("process-control-ready-poll", {
+        action: "poll",
+        sessionId,
+        timeout: 1_000,
+      });
+      expect(readyPoll.details).toMatchObject({
+        status: "running",
+        sessionId,
+        aggregated: expect.stringContaining("READY"),
+      });
+
+      const write = await processTool.execute("process-control-write", {
+        action: "write",
+        sessionId,
+        data: "alpha",
+      });
+      expect(write.details).toMatchObject({ status: "running", sessionId });
+      expect(textContent(write)).toContain("Wrote 5 bytes");
+
+      const beforeSubmit = await processTool.execute("process-control-before-submit", {
+        action: "log",
+        sessionId,
+      });
+      expect(textContent(beforeSubmit)).not.toContain("LINE:alpha");
+
+      const submit = await processTool.execute("process-control-submit", {
+        action: "submit",
+        sessionId,
+      });
+      expect(submit.details).toMatchObject({ status: "running", sessionId });
+      expect(textContent(submit)).toContain("Submitted");
+
+      await expect
+        .poll(
+          async () => {
+            const poll = await processTool.execute("process-control-alpha-poll", {
+              action: "poll",
+              sessionId,
+              timeout: 250,
+            });
+            return (poll.details as { aggregated?: string }).aggregated ?? "";
+          },
+          { timeout: 5_000, interval: 25 },
+        )
+        .toContain("LINE:alpha");
+
+      const literal = await processTool.execute("process-control-send-literal", {
+        action: "send-keys",
+        sessionId,
+        literal: "beta",
+      });
+      expect(literal.details).toMatchObject({ status: "running", sessionId });
+      expect(textContent(literal)).toContain("Sent 4 bytes");
+
+      const enter = await processTool.execute("process-control-send-enter", {
+        action: "send-keys",
+        sessionId,
+        keys: ["Enter"],
+      });
+      expect(enter.details).toMatchObject({ status: "running", sessionId });
+
+      await expect
+        .poll(
+          async () => {
+            const poll = await processTool.execute("process-control-beta-poll", {
+              action: "poll",
+              sessionId,
+              timeout: 250,
+            });
+            return (poll.details as { aggregated?: string }).aggregated ?? "";
+          },
+          { timeout: 5_000, interval: 25 },
+        )
+        .toContain("LINE:beta");
+
+      const interrupt = await processTool.execute("process-control-send-interrupt", {
+        action: "send-keys",
+        sessionId,
+        keys: ["C-c"],
+      });
+      expect(interrupt.details).toMatchObject({ status: "running", sessionId });
+
+      await expect
+        .poll(
+          async () => {
+            const poll = await processTool.execute("process-control-final-poll", {
+              action: "poll",
+              sessionId,
+              timeout: 250,
+            });
+            const details = poll.details as {
+              status?: string;
+              exitCode?: number;
+              aggregated?: string;
+            };
+            return {
+              status: details.status,
+              exitCode: details.exitCode,
+              aggregated: details.aggregated ?? "",
+            };
+          },
+          { timeout: 5_000, interval: 25 },
+        )
+        .toEqual({
+          status: "completed",
+          exitCode: 0,
+          aggregated: expect.stringContaining("CONTROL:CTRL-C:2"),
+        });
+
+      const completedLog = await processTool.execute("process-control-completed-log", {
+        action: "log",
+        sessionId,
+      });
+      expect(completedLog.details).toMatchObject({ status: "completed", sessionId });
+      expect(textContent(completedLog)).toContain("LINE:alpha");
+      expect(textContent(completedLog)).toContain("LINE:beta");
+      expect(textContent(completedLog)).toContain("CONTROL:CTRL-C:2");
+    } finally {
+      if (sessionId && getSession(sessionId)) {
+        await processTool.execute("process-control-cleanup", {
+          action: "kill",
+          sessionId,
+        });
+      }
+    }
+  },
+  20_000,
+);


### PR DESCRIPTION
## What Problem This Solves

OpenClaw lacked durable primary QA coverage for the real background-process control lifecycle across:

- `automation.process-poll`
- `automation.process-log`
- `automation.background-process-status`
- `automation.process-input-controls`

## Why This Change Was Made

This adds one PTY-backed child lifecycle that executes the production `createExecTool` and `createProcessTool` boundaries, proving list/status, log, poll, write/submit, literal and Enter input, control-key input, completion, and retained logs. It adds no production code and does not claim channel or message polling behavior.

https://github.com/openclaw/openclaw/pull/113860 remains open and dirty at head `23eca9a8cf8c54da5424e5a6cba6601a59e9f8a4`. Its production liveness changes overlap the exercised contract, but its tracked files are distinct; this branch was rechecked against that unchanged head immediately before push.

AI-assisted.

## User Impact

No runtime behavior changes. Maintainers gain executable regression coverage and canonical QA evidence for the four process-control taxonomy IDs.

## Evidence

- Refreshed current-main canonical QA proof:
  - `OPENCLAW_QA_REF="$GITHUB_SHA" pnpm dev qa suite --scenario process-control-roundtrip --output-dir .artifacts/qa-e2e/process-control-roundtrip`
  - AWS Crabbox run: `run_dfa66fede576`
  - Evidence: `.artifacts/qa-e2e/process-control-roundtrip/qa-evidence.json`
  - Vitest log: `.artifacts/qa-e2e/process-control-roundtrip/vitest/process-control-roundtrip.log`
  - Result: `pass`; environment ref `b097d4607167c8379b9ea5cd15bef51d42869823`; primary coverage is exactly the four IDs listed above.
- Earlier focused proof:
  - `node scripts/run-vitest.mjs src/agents/bash-tools.process.e2e.test.ts`
  - Result: 1 file passed, 1 test passed.
- Changed gate on AWS Crabbox:
  - `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE=1 CI=1 pnpm check:changed`
  - Run: `run_870731117a5b`
  - Result: passed, including typecheck, lint, formatting, policy guards, and runtime import-cycle checks.
  - The unskipped run `run_c2082bcf1135` failed only the repository-wide dead-export scan on pre-existing unused exports under untouched `src/config/**`; all preceding lanes passed.
- Latest local hygiene:
  - `oxfmt --check` passed for both changed files.
  - `git diff --check` passed.
  - `git diff --numstat origin/main...HEAD`: 31 scenario lines plus 234 test lines; zero production LOC.
  - Privacy scrub passed.
  - `node scripts/check-changed.mjs -- <touched files>` reached remote delegation and stopped before lane execution because no managed provider was ready; the earlier remote changed gate and exact-head required CI remain the heavy proof.
- ClawSweeper:
  - An exact-head lease expired without a verdict; recovery used exactly one `@clawsweeper review` command.
  - Durable review on prior head `521d92943e167c0c7c27e942985487b1adff102a` found no actionable defects and required a current-main rebase plus refreshed QA evidence.
  - Both rank-up moves are reflected here: the branch is rebased and this body carries the refreshed exact-head QA artifact reference.
  - The branch is now frozen at the exact-head-proven commit below. Future behind-main text is dispositioned as unrelated unless current main changes the two tracked files, the exercised process-control contract, or a required CI failure identifies a concrete branch defect.
- Required CI baseline:
  - The first `security-fast` failure was reproduced on the matching main SHA and came from newly published advisories for shared lockfile versions.
  - Current base `682f60ce56b37c5cd3205fdcbbf25b21d48708f2` contains the landed lockfile upgrades to `fast-uri 4.1.2` and `undici 7.29.0`; main's `security-fast` passed on that base.
- Head: `b097d4607167c8379b9ea5cd15bef51d42869823`
- Base: `682f60ce56b37c5cd3205fdcbbf25b21d48708f2`
