### PR TITLE
chore(hooks): add durable internal lifecycle QA

### DIFF
--- a/qa/scenarios/runtime/hook-lifecycle-contracts.yaml
+++ b/qa/scenarios/runtime/hook-lifecycle-contracts.yaml
@@ -1,0 +1,34 @@
+title: Internal hook lifecycle contracts
+
+scenario:
+  id: hook-lifecycle-contracts
+  surface: automation
+  category: automation.automation-hooks
+  coverage:
+    primary:
+      - automation.hook-md-authoring
+      - automation.hook-discovery
+      - automation.hook-cli-management
+      - automation.hook-packs
+      - automation.lifecycle-event-dispatch
+  objective: Verify an authored internal hook pack crosses archive installation, discovery, CLI management, and lifecycle dispatch boundaries.
+  successCriteria:
+    - A local hook-pack archive containing a real HOOK.md installs into isolated managed state.
+    - Production discovery reads the authored metadata and resolves the managed hook.
+    - The real hooks CLI disables and enables the discovered hook in isolated config.
+    - A disabled hook does not register or receive the Gateway startup lifecycle event.
+    - The enabled discovered hook receives the Gateway startup event and records its marker.
+  docsRefs:
+    - docs/automation/hooks.md
+    - docs/cli/hooks.md
+  codeRefs:
+    - src/hooks/install.ts
+    - src/hooks/workspace.ts
+    - src/cli/hooks-cli.ts
+    - src/hooks/loader.ts
+    - src/hooks/internal-hooks.ts
+    - src/hooks/hooks-lifecycle.e2e.test.ts
+  execution:
+    kind: vitest
+    path: src/hooks/hooks-lifecycle.e2e.test.ts
+    summary: Run the isolated archive-to-discovery-to-CLI-to-Gateway-startup internal hook lifecycle.

--- a/src/hooks/hooks-lifecycle.e2e.test.ts
+++ b/src/hooks/hooks-lifecycle.e2e.test.ts
@@ -1,0 +1,215 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import JSON5 from "json5";
+import * as tar from "tar";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { installHooksFromPath } from "./install.js";
+import {
+  clearInternalHooks,
+  createInternalHookEvent,
+  triggerInternalHook,
+} from "./internal-hooks.js";
+import { loadInternalHooks } from "./loader.js";
+import { loadWorkspaceHookEntries } from "./workspace.js";
+
+const execFileAsync = promisify(execFile);
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const hookName = "qa-lifecycle-recorder";
+const hookMarker = "QA_HOOK_LIFECYCLE_OK";
+
+afterEach(() => {
+  clearInternalHooks();
+});
+
+async function runHooksCli(args: string[], env: NodeJS.ProcessEnv) {
+  try {
+    const result = await execFileAsync(
+      process.execPath,
+      ["--import", "tsx", "src/entry.ts", "hooks", ...args],
+      {
+        cwd: process.cwd(),
+        env,
+        encoding: "utf8",
+        maxBuffer: 1024 * 1024,
+        timeout: 90_000,
+      },
+    );
+    return { stdout: result.stdout, stderr: result.stderr };
+  } catch (error) {
+    const failed = error as Error & { stdout?: string; stderr?: string };
+    throw new Error(
+      `${failed.message}\nstdout:\n${failed.stdout ?? ""}\nstderr:\n${failed.stderr ?? ""}`,
+      { cause: error },
+    );
+  }
+}
+
+async function readConfig(configPath: string): Promise<OpenClawConfig> {
+  return JSON5.parse(await fs.readFile(configPath, "utf8")) as OpenClawConfig;
+}
+
+async function createHookPackFixture() {
+  const rootDir = tempDirs.make("openclaw-hooks-lifecycle-e2e-");
+  const homeDir = path.join(rootDir, "home");
+  const stateDir = path.join(rootDir, "state");
+  const workspaceDir = path.join(rootDir, "workspace");
+  const managedHooksDir = path.join(stateDir, "hooks");
+  const bundledHooksDir = path.join(rootDir, "bundled-hooks");
+  const packageRoot = path.join(rootDir, "archive-root");
+  const packageDir = path.join(packageRoot, "package");
+  const hookDir = path.join(packageDir, "hooks", hookName);
+  const archivePath = path.join(rootDir, "qa-lifecycle-hooks.tgz");
+  const configPath = path.join(stateDir, "openclaw.json");
+
+  await Promise.all([
+    fs.mkdir(homeDir, { recursive: true }),
+    fs.mkdir(stateDir, { recursive: true }),
+    fs.mkdir(workspaceDir, { recursive: true }),
+    fs.mkdir(bundledHooksDir, { recursive: true }),
+    fs.mkdir(hookDir, { recursive: true }),
+  ]);
+
+  const initialConfig: OpenClawConfig = {
+    agents: { defaults: { workspace: workspaceDir } },
+    hooks: { internal: { enabled: true } },
+  };
+  await fs.writeFile(configPath, `${JSON.stringify(initialConfig, null, 2)}\n`, "utf8");
+  await fs.writeFile(
+    path.join(packageDir, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "@openclaw/qa-lifecycle-hooks",
+        version: "1.0.0",
+        openclaw: { hooks: [`./hooks/${hookName}`] },
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+  await fs.writeFile(
+    path.join(hookDir, "HOOK.md"),
+    [
+      "---",
+      `name: ${hookName}`,
+      "description: Records a Gateway startup lifecycle event",
+      'metadata: {"openclaw":{"events":["gateway:startup"]}}',
+      "---",
+      "",
+      "# QA lifecycle recorder",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await fs.writeFile(
+    path.join(hookDir, "handler.js"),
+    `export default async function recordLifecycle(event) { event.messages.push("${hookMarker}"); }\n`,
+    "utf8",
+  );
+  await tar.c({ cwd: packageRoot, file: archivePath, gzip: true }, ["package"]);
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    HOME: homeDir,
+    USERPROFILE: homeDir,
+    OPENCLAW_CONFIG_PATH: configPath,
+    OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+    OPENCLAW_HOME: homeDir,
+    OPENCLAW_STATE_DIR: stateDir,
+    OPENCLAW_TEST_FAST: "1",
+    VITEST: "",
+  };
+
+  return {
+    archivePath,
+    bundledHooksDir,
+    configPath,
+    env,
+    initialConfig,
+    managedHooksDir,
+    workspaceDir,
+  };
+}
+
+describe("internal hook lifecycle", () => {
+  it("installs, discovers, toggles, and dispatches an authored hook pack", async () => {
+    const fixture = await createHookPackFixture();
+    const install = await installHooksFromPath({
+      config: fixture.initialConfig,
+      hooksDir: fixture.managedHooksDir,
+      path: fixture.archivePath,
+    });
+    expect(install).toMatchObject({
+      ok: true,
+      hookPackId: "qa-lifecycle-hooks",
+      hooks: [hookName],
+      packageKind: "hook-only",
+    });
+    if (!install.ok) {
+      throw new Error(install.error);
+    }
+
+    await expect(
+      fs.readFile(path.join(install.targetDir, "hooks", hookName, "HOOK.md"), "utf8"),
+    ).resolves.toContain("gateway:startup");
+
+    const discovered = loadWorkspaceHookEntries(fixture.workspaceDir, {
+      bundledHooksDir: fixture.bundledHooksDir,
+      config: fixture.initialConfig,
+      managedHooksDir: fixture.managedHooksDir,
+    });
+    expect(discovered).toEqual([
+      expect.objectContaining({
+        hook: expect.objectContaining({
+          name: hookName,
+          source: "openclaw-managed",
+        }),
+        metadata: expect.objectContaining({
+          events: ["gateway:startup"],
+        }),
+      }),
+    ]);
+
+    const disabled = await runHooksCli(["disable", hookName], fixture.env);
+    expect(disabled.stdout).toContain(hookName);
+    const disabledConfig = await readConfig(fixture.configPath);
+    expect(disabledConfig.hooks?.internal?.entries?.[hookName]?.enabled).toBe(false);
+
+    clearInternalHooks();
+    expect(
+      await loadInternalHooks(disabledConfig, fixture.workspaceDir, {
+        bundledHooksDir: fixture.bundledHooksDir,
+        managedHooksDir: fixture.managedHooksDir,
+      }),
+    ).toBe(0);
+    const disabledEvent = createInternalHookEvent("gateway", "startup", "gateway:startup", {
+      cfg: disabledConfig,
+      workspaceDir: fixture.workspaceDir,
+    });
+    await triggerInternalHook(disabledEvent);
+    expect(disabledEvent.messages).not.toContain(hookMarker);
+
+    const enabled = await runHooksCli(["enable", hookName], fixture.env);
+    expect(enabled.stdout).toContain(hookName);
+    const enabledConfig = await readConfig(fixture.configPath);
+    expect(enabledConfig.hooks?.internal?.entries?.[hookName]?.enabled).toBe(true);
+
+    clearInternalHooks();
+    expect(
+      await loadInternalHooks(enabledConfig, fixture.workspaceDir, {
+        bundledHooksDir: fixture.bundledHooksDir,
+        managedHooksDir: fixture.managedHooksDir,
+      }),
+    ).toBe(1);
+    const event = createInternalHookEvent("gateway", "startup", "gateway:startup", {
+      cfg: enabledConfig,
+      workspaceDir: fixture.workspaceDir,
+    });
+    await triggerInternalHook(event);
+    expect(event.messages).toContain(hookMarker);
+  }, 180_000);
+});


### PR DESCRIPTION
## What Problem This Solves

Internal hook authoring, archive installation, discovery, CLI management, and lifecycle dispatch lacked one durable composed QA contract.

## Why This Change Was Made

Adds a production-boundary Vitest scenario that creates a real `HOOK.md`, installs a local hook-pack archive into isolated managed state, discovers it, toggles it through the real hooks CLI, and dispatches a real Gateway startup event. This stays entirely in test and QA scenario metadata; plugin hook APIs are intentionally excluded.

## User Impact

No runtime behavior changes. Maintainers gain durable regression evidence for the complete internal hook lifecycle.

## Evidence

- `node scripts/run-vitest.mjs src/hooks/hooks-lifecycle.e2e.test.ts`
  - passed: 1 file, 1 test
  - refreshed exact head `26e60a7fa4650d5295611707c67b6f1d7fb5438f`: passed in 18.39s
- `NO_COLOR=1 node scripts/run-node.mjs qa coverage --match hook-lifecycle-contracts`
  - resolves one scenario with exactly the five approved primary IDs
- `node_modules/.bin/oxfmt --write --threads=1 ...`
  - clean on both changed files
- `git diff --check`
  - clean
- autoreview
  - clean, no accepted/actionable findings; overall correct at 0.99
- production LOC delta: 0
- clean AWS Crabbox lease `cbx_22518611a3ce`, run `run_2d8eed2a31f9`
  - `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build`: passed in 4m39.5s
  - QA Suite: passed in 12.475s
  - `qa-evidence.json`: schema v2, full evidence mode, pre-rebase head `3f4adf756309f7264e2952a911e5a1d0d36d4cc6`, all five IDs emitted as primary
  - the test/QA diff is unchanged after the collision-free rebase onto `origin/main@cd42cb77033265b3cc63846e2391f77366f356eb`
- changed gate infrastructure
  - Blacksmith Testbox lease creation is unavailable because the local `blacksmith` CLI is not authenticated
  - AWS fallback runs `run_3b0f89de07e3` and `run_4b71f814ca91` could not execute the gate because the changed-gate overlay had no dependency graph; the prescribed pinned install then failed postinstall on missing `typescript`
  - hosted exact-head CI is the remaining fallback gate

## ClawSweeper Rank-up Moves

- Rebased onto current `main`; refreshed head and complete blobs are available at `26e60a7fa4650d5295611707c67b6f1d7fb5438f`.
- Complete source review confirms isolation of HOME, USERPROFILE, OpenClaw home/state/config, workspace, bundled-hook discovery, and the internal-hook registry.
- Existing hook tests cover archive installation, loading, CLI policy, and dispatch in separate focused units. This test adds the missing composed production-boundary contract: archive install -> discovery -> actual CLI disable/enable -> disabled non-registration -> enabled Gateway startup dispatch.

AI-assisted: yes
