### PR TITLE
fix(cua-computer): load ESM driver asynchronously

### DIFF
--- a/docs/nodes/computer-use.md
+++ b/docs/nodes/computer-use.md
@@ -47,6 +47,18 @@ The bundled `cua-computer` plugin provides an experimental fulfiller for Windows
 
 2. Start `openclaw node run` from the interactive desktop session. The plugin creates its configured SDK runtime lazily, then creates one OpenClaw-owned trusted session for the node-host command execution. It closes that session and shuts down the runtime when the command host stops or restarts.
 
+3. Add `computer.act` to the Gateway allowlist. This plugin registers `computer.act` as a dangerous plugin node command, so enabling the plugin alone is not enough; the operator must opt in explicitly:
+
+   ```json5
+   {
+     gateway: {
+       nodes: { commands: { allow: ["computer.act"] } },
+     },
+   }
+   ```
+
+   Without this entry, `node.invoke` rejects `computer.act` even though the node advertises it.
+
 This fulfiller currently controls only the primary display. `hold_key`, `left_mouse_down`, and `left_mouse_up` are unavailable because the CUA Driver SDK has no desktop-scope held-input contract. Modifier-held clicks, scrolling, and dragging are rejected because the typed desktop methods do not accept modifiers. The `key` action accepts named keys, letters, and modifier combos (for example `cmd+c` or `Return`); digit and punctuation keys are rejected because the driver drops their layout-dependent shift state, so send that text through the `type` action instead. Cancellation is passed to the SDK for each node invocation.
 
 The plugin calls `CuaDriver.createConfigured`, never bare `create()`. Its authorization ceiling, trusted session identifier, TTLs, and desktop scope are fixed by OpenClaw; model-facing `screen.snapshot` and `computer.act` inputs cannot select a session or widen that authority. Because the driver reports no stable display identity, frame authorization binds to the trusted session generation plus live primary-display geometry. A new session invalidates outstanding frames, but a same-geometry primary-display substitution inside one session cannot be detected; prefer a stable single-display session for this fulfiller.
@@ -96,7 +108,7 @@ Once the node-local control is enabled and the pairing update is approved, `comp
 
 On macOS, default-on means a paired gateway can drive pointer and keyboard input as soon as the required macOS grants exist. There is no per-action confirmation. Turn off **Allow Computer Control** before pairing, or at any later time, to stop advertising and accepting `computer.act`.
 
-`gateway.nodes.commands.deny` remains an explicit global revocation and always wins. `computer.act` does not need a `gateway.nodes.commands.allow` entry. An authenticated operator with `operator.write` can invoke an enabled, paired command through `node.invoke`; there is no per-action admin check.
+`gateway.nodes.commands.deny` remains an explicit global revocation and always wins. For the macOS fulfiller, `computer.act` does not need a `gateway.nodes.commands.allow` entry. The experimental `cua-computer` plugin registers `computer.act` as a dangerous plugin node command, so once that plugin is enabled the operator must add it to `gateway.nodes.commands.allow` (see the Windows/Linux setup above); the plugin registration excludes it from the default allowlist regardless of platform. An authenticated operator with `operator.write` can invoke an enabled, paired command through `node.invoke`; there is no per-action admin check.
 
 ## Safety
 

--- a/extensions/cua-computer/index.test.ts
+++ b/extensions/cua-computer/index.test.ts
@@ -1,21 +1,48 @@
 import type {
   OpenClawPluginApi,
   OpenClawPluginNodeHostCommand,
+  OpenClawPluginNodeInvokePolicy,
+  OpenClawPluginNodeInvokePolicyContext,
 } from "openclaw/plugin-sdk/plugin-entry";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import plugin from "./index.js";
 
 describe("cua-computer plugin registration", () => {
   it("registers the screen and dangerous computer node-host commands", () => {
     const commands: OpenClawPluginNodeHostCommand[] = [];
+    const policies: OpenClawPluginNodeInvokePolicy[] = [];
     plugin.register({
       pluginConfig: {},
       registerNodeHostCommand: (command: OpenClawPluginNodeHostCommand) => commands.push(command),
+      registerNodeInvokePolicy: (policy: OpenClawPluginNodeInvokePolicy) => policies.push(policy),
     } as unknown as OpenClawPluginApi);
 
     expect(commands.map(({ command, cap, dangerous }) => ({ command, cap, dangerous }))).toEqual([
       { command: "screen.snapshot", cap: "screen", dangerous: false },
       { command: "computer.act", cap: "computer", dangerous: true },
     ]);
+    expect(policies).toHaveLength(1);
+    expect(policies[0]).toMatchObject({ commands: ["computer.act"], dangerous: true });
+    expect(policies[0]?.defaultPlatforms).toBeUndefined();
+  });
+
+  it("forwards an explicitly armed computer action and preserves node refusals", async () => {
+    const policies: OpenClawPluginNodeInvokePolicy[] = [];
+    plugin.register({
+      pluginConfig: {},
+      registerNodeHostCommand: () => {},
+      registerNodeInvokePolicy: (policy: OpenClawPluginNodeInvokePolicy) => policies.push(policy),
+    } as unknown as OpenClawPluginApi);
+    const refusal = {
+      ok: false as const,
+      code: "INVALID_REQUEST",
+      message: "COMPUTER_STALE_FRAME: take a new screenshot",
+    };
+    const invokeNode = vi.fn(async () => refusal);
+
+    await expect(
+      policies[0]!.handle({ invokeNode } as unknown as OpenClawPluginNodeInvokePolicyContext),
+    ).resolves.toEqual(refusal);
+    expect(invokeNode).toHaveBeenCalledOnce();
   });
 });

--- a/extensions/cua-computer/index.ts
+++ b/extensions/cua-computer/index.ts
@@ -23,5 +23,14 @@ export default definePluginEntry({
     for (const command of createCuaComputerCommands()) {
       api.registerNodeHostCommand(command);
     }
+    // computer.act is dangerous-by-default and therefore also requires the
+    // operator's explicit gateway.nodes.commands.allow entry. The plugin
+    // policy is the final Gateway guard and the only path that may forward the
+    // already-allowlisted invocation to the paired node.
+    api.registerNodeInvokePolicy({
+      commands: ["computer.act"],
+      dangerous: true,
+      handle: async (ctx) => await ctx.invokeNode(),
+    });
   },
 });

--- a/extensions/cua-computer/src/commands.test.ts
+++ b/extensions/cua-computer/src/commands.test.ts
@@ -187,6 +187,28 @@ describe("cua-computer direct SDK commands", () => {
     ).rejects.toThrow("COMPUTER_REFUSED_desktop_unavailable");
   });
 
+  it("rejects a mismatched reference width before desktop input", async () => {
+    const { session, click } = driver();
+    const [snapshot, act] = commands(session);
+    const screen = JSON.parse(await snapshot!.handle('{"format":"png","maxWidth":100}')) as {
+      displayFrameId: string;
+      width: number;
+    };
+
+    await expect(
+      act!.handle(
+        JSON.stringify({
+          action: "left_click",
+          displayFrameId: screen.displayFrameId,
+          refWidth: screen.width + 1,
+          x: 10,
+          y: 20,
+        }),
+      ),
+    ).rejects.toThrow("COMPUTER_STALE_FRAME: the coordinate reference width changed");
+    expect(click).not.toHaveBeenCalled();
+  });
+
   it("lazily owns one session and closes it when node-host availability stops", async () => {
     const { session, dispose } = driver();
     const createDriver = vi.fn(() => session);

--- a/extensions/cua-computer/src/driver-client.test.ts
+++ b/extensions/cua-computer/src/driver-client.test.ts
@@ -111,4 +111,48 @@ describe("CUA Driver direct session", () => {
     expect(loadSdk).toHaveBeenCalledTimes(2);
     await driver.dispose();
   });
+
+  it("loads an ESM driver asynchronously and exposes it on a later availability probe", async () => {
+    let resolveSdk: ((value: typeof sdk) => void) | undefined;
+    const sdkPromise = new Promise<typeof sdk>((resolve) => {
+      resolveSdk = resolve;
+    });
+    const loadSdk = vi.fn(() => sdkPromise as never);
+    const driver = createCuaDriver({ loadSdk });
+
+    expect(driver.isAvailable()).toBe(false);
+    expect(loadSdk).toHaveBeenCalledOnce();
+
+    resolveSdk?.(sdk);
+    await vi.waitFor(() => expect(driver.isAvailable()).toBe(true));
+    await driver.getDesktopState();
+
+    expect(loadSdk).toHaveBeenCalledOnce();
+    expect(mocks.createConfigured).toHaveBeenCalledOnce();
+    expect(mocks.getDesktopState).toHaveBeenCalledOnce();
+    await driver.dispose();
+  });
+
+  it("retries an asynchronous ESM import failure after the availability cache resets", async () => {
+    let attempt = 0;
+    const loadSdk = vi.fn(() => {
+      attempt += 1;
+      return attempt === 1
+        ? Promise.reject(new Error("native module is temporarily unavailable"))
+        : Promise.resolve(sdk as never);
+    });
+    const driver = createCuaDriver({ loadSdk });
+
+    expect(driver.isAvailable()).toBe(false);
+    await expect(driver.getDesktopState()).rejects.toThrow(
+      "COMPUTER_DRIVER_UNAVAILABLE: failed to load CUA Driver SDK: native module is temporarily unavailable",
+    );
+
+    driver.resetAvailabilityCache();
+    expect(driver.isAvailable()).toBe(false);
+    await vi.waitFor(() => expect(driver.isAvailable()).toBe(true));
+
+    expect(loadSdk).toHaveBeenCalledTimes(2);
+    await driver.dispose();
+  });
 });

--- a/extensions/cua-computer/src/driver-client.ts
+++ b/extensions/cua-computer/src/driver-client.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import { createRequire } from "node:module";
 
 type DriverClickButton = import("@trycua/cua-driver").ClickButton;
 type CuaDriverLike = import("@trycua/cua-driver").CuaDriverLike;
@@ -241,10 +240,8 @@ class DirectCuaDriverSession implements CuaDriverSession {
   }
 }
 
-const require = createRequire(import.meta.url);
-
-function loadCuaDriverSdk(): CuaDriverSdk {
-  return require("@trycua/cua-driver") as CuaDriverSdk;
+async function loadCuaDriverSdk(): Promise<CuaDriverSdk> {
+  return (await import("@trycua/cua-driver")) as CuaDriverSdk;
 }
 
 function unavailableError(failure: unknown): Error {
@@ -254,28 +251,58 @@ function unavailableError(failure: unknown): Error {
   });
 }
 
+function isPromise<T>(value: T | Promise<T>): value is Promise<T> {
+  return typeof (value as Promise<T>).then === "function";
+}
+
 class LazyCuaDriverSession implements CuaDriverSession {
   private readonly unloadedGeneration = randomUUID();
   private runtime: DirectCuaDriverSession | undefined;
+  private loadPromise: Promise<DirectCuaDriverSession> | undefined;
   private loadFailure: unknown;
   private hasLoadFailure = false;
   private disposed = false;
 
-  constructor(private readonly loadSdk: () => CuaDriverSdk) {}
+  constructor(private readonly loadSdk: () => CuaDriverSdk | Promise<CuaDriverSdk>) {}
 
   get generation(): string {
     return this.runtime?.generation ?? this.unloadedGeneration;
   }
 
   private resolveRuntime(): DirectCuaDriverSession | undefined {
-    if (this.disposed || this.hasLoadFailure) {
+    if (this.disposed || this.hasLoadFailure || this.loadPromise) {
       return undefined;
     }
     if (this.runtime) {
       return this.runtime;
     }
     try {
-      this.runtime = new DirectCuaDriverSession(this.loadSdk());
+      const loadedSdk = this.loadSdk();
+      if (!isPromise(loadedSdk)) {
+        this.runtime = new DirectCuaDriverSession(loadedSdk);
+        return this.runtime;
+      }
+
+      const loadPromise = loadedSdk
+        .then((sdk) => new DirectCuaDriverSession(sdk))
+        .then((runtime) => {
+          this.runtime = runtime;
+          return runtime;
+        })
+        .catch((error: unknown) => {
+          this.loadFailure = error;
+          this.hasLoadFailure = true;
+          throw error;
+        })
+        .finally(() => {
+          if (this.loadPromise === loadPromise) {
+            this.loadPromise = undefined;
+          }
+        });
+      this.loadPromise = loadPromise;
+      // Availability is synchronous, so the first probe starts the ESM import
+      // and reports unavailable until a later probe observes the loaded SDK.
+      void loadPromise.catch(() => {});
       return this.runtime;
     } catch (error) {
       this.loadFailure = error;
@@ -284,10 +311,17 @@ class LazyCuaDriverSession implements CuaDriverSession {
     }
   }
 
-  private requireRuntime(): DirectCuaDriverSession {
+  private async requireRuntime(): Promise<DirectCuaDriverSession> {
     const runtime = this.resolveRuntime();
     if (runtime) {
       return runtime;
+    }
+    if (this.loadPromise) {
+      try {
+        return await this.loadPromise;
+      } catch (error) {
+        throw unavailableError(this.loadFailure ?? error);
+      }
     }
     throw unavailableError(
       this.disposed ? new Error("cua-computer is stopping") : this.loadFailure,
@@ -301,44 +335,44 @@ class LazyCuaDriverSession implements CuaDriverSession {
   resetAvailabilityCache(): void {
     if (this.runtime) {
       this.runtime.resetAvailabilityCache();
-    } else if (!this.disposed) {
+    } else if (!this.disposed && !this.loadPromise) {
       this.loadFailure = undefined;
       this.hasLoadFailure = false;
     }
   }
 
   async getDesktopState(signal?: AbortSignal) {
-    return await this.requireRuntime().getDesktopState(signal);
+    return await (await this.requireRuntime()).getDesktopState(signal);
   }
   async getScreenSize(signal?: AbortSignal) {
-    return await this.requireRuntime().getScreenSize(signal);
+    return await (await this.requireRuntime()).getScreenSize(signal);
   }
   async click(
     input: { x: number; y: number; button: ClickButton; count: number },
     signal?: AbortSignal,
   ) {
-    return await this.requireRuntime().click(input, signal);
+    return await (await this.requireRuntime()).click(input, signal);
   }
   async drag(
     input: { fromX: number; fromY: number; toX: number; toY: number; durationMs?: bigint },
     signal?: AbortSignal,
   ) {
-    return await this.requireRuntime().drag(input, signal);
+    return await (await this.requireRuntime()).drag(input, signal);
   }
   async moveCursor(input: { x: number; y: number }, signal?: AbortSignal) {
-    return await this.requireRuntime().moveCursor(input, signal);
+    return await (await this.requireRuntime()).moveCursor(input, signal);
   }
   async scroll(
     input: { x: number; y: number; direction: ScrollDirection; amount: bigint },
     signal?: AbortSignal,
   ) {
-    return await this.requireRuntime().scroll(input, signal);
+    return await (await this.requireRuntime()).scroll(input, signal);
   }
   async typeText(text: string, signal?: AbortSignal) {
-    return await this.requireRuntime().typeText(text, signal);
+    return await (await this.requireRuntime()).typeText(text, signal);
   }
   async pressKey(input: { key: string; modifiers: string[] }, signal?: AbortSignal) {
-    return await this.requireRuntime().pressKey(input, signal);
+    return await (await this.requireRuntime()).pressKey(input, signal);
   }
 
   async dispose(): Promise<void> {
@@ -346,10 +380,17 @@ class LazyCuaDriverSession implements CuaDriverSession {
       return;
     }
     this.disposed = true;
+    try {
+      await this.loadPromise;
+    } catch {
+      // A failed load has no native resources to release.
+    }
     await this.runtime?.dispose();
   }
 }
 
-export function createCuaDriver(options: { loadSdk?: () => CuaDriverSdk } = {}): CuaDriverSession {
+export function createCuaDriver(
+  options: { loadSdk?: () => CuaDriverSdk | Promise<CuaDriverSdk> } = {},
+): CuaDriverSession {
   return new LazyCuaDriverSession(options.loadSdk ?? loadCuaDriverSdk);
 }


### PR DESCRIPTION
## Summary

- load the bundled `@trycua/cua-driver` through its public ESM export
- preserve synchronous node-host availability while the lazy import is pending, including retry and teardown behavior
- register the mandatory dangerous-command forwarding policy for `computer.act`
- cover asynchronous SDK loading, retry after an import failure, policy forwarding, and stale-frame rejection

## What Problem This Solves

`@trycua/cua-driver@0.14.1` exposes `import` but no `require` condition. The bundled `cua-computer` integration used `createRequire()`, so Node raised `ERR_PACKAGE_PATH_NOT_EXPORTED` before the native driver loaded. Windows and Linux node hosts consequently never advertised `screen.snapshot` or `computer.act`.

After switching to the public ESM export, `computer.act` also needs an explicit node-invoke policy because it is intentionally registered as a dangerous command. Without that policy the Gateway rejects dispatch with `PLUGIN_POLICY_MISSING`.

This change keeps the topology embedded: OpenClaw loads its lockfile-selected SDK directly; no separate CUA Driver daemon or MCP server is introduced.

## Evidence

- 18 focused Vitest tests across the `cua-computer` extension
- extension lint and full project typecheck (`node scripts/check.mjs --include-test-types --timed`)
- direct public ESM import and create/shutdown of the lockfile-selected `@trycua/cua-driver@0.14.1`
- disposable Windows Server 2022 interactive Session 1 proof through public `openclaw nodes invoke`: fresh screenshots, cursor move, click, type, hotkey, scroll, drag, stale-frame rejection, and external GUI/Win32 oracles
- Windows process audit confirmed the embedded topology and no standalone CUA daemon or MCP server

Managed Fleet certification remains pending because the test environment did not create a VM during the bounded readiness window; the same pre-VM symptom reproduced with its established control image. The disposable pool and namespace were removed and absence was verified. This PR remains unmerged while that environment-level validation is pending.
