### PR TITLE
fix(gateway): keep plugin model allowlists static

### DIFF
--- a/src/gateway/server-plugin-subagent-runtime.ts
+++ b/src/gateway/server-plugin-subagent-runtime.ts
@@ -1,5 +1,10 @@
 import { parseModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog-refs";
-import { normalizeModelRef, parseModelRef } from "../agents/model-selection.js";
+import {
+  normalizeBuiltInProviderModelId,
+  stripSelfProviderModelPrefix,
+} from "@openclaw/model-catalog-core/provider-model-id-normalization";
+import { normalizeModelRef } from "../agents/model-ref-shared.js";
+import { parseModelRef } from "../agents/model-selection-normalize.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
 
 export function normalizePluginSubagentAllowedModelRef(raw: string): string | null {
@@ -14,8 +19,13 @@ export function normalizePluginSubagentAllowedModelRef(raw: string): string | nu
   if (!parsed) {
     return null;
   }
-  const normalized = normalizeModelRef(parsed.provider, parsed.modelId);
-  return `${normalized.provider}/${normalized.model}`;
+  // Operator allowlists already name canonical targets; keep policy setup independent
+  // of plugin metadata and provider-runtime discovery.
+  const modelId = normalizeBuiltInProviderModelId(
+    parsed.provider,
+    stripSelfProviderModelPrefix(parsed.provider, parsed.modelId),
+  );
+  return `${parsed.provider}/${modelId}`;
 }
 
 export function resolvePluginSubagentRequestedModelRef(params: {

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -30,6 +30,7 @@ const applyPluginAutoEnable = vi.hoisted(() =>
 const primeConfiguredBindingRegistry = vi.hoisted(() =>
   vi.fn(() => ({ bindingCount: 0, channelCount: 0 })),
 );
+const normalizeProviderModelIdWithRuntime = vi.hoisted(() => vi.fn(() => undefined));
 const pluginRuntimeLoaderLogger = vi.hoisted(() => ({
   info: vi.fn(),
   warn: vi.fn(),
@@ -58,6 +59,10 @@ vi.mock("../plugins/plugin-lookup-table.js", () => ({
 
 vi.mock("../config/plugin-auto-enable.js", () => ({
   applyPluginAutoEnable,
+}));
+
+vi.mock("../agents/provider-model-normalization.runtime.js", () => ({
+  normalizeProviderModelIdWithRuntime,
 }));
 
 vi.mock("../channels/plugins/binding-registry.js", async () => {
@@ -401,6 +406,7 @@ beforeEach(() => {
     .mockReset()
     .mockImplementation(({ config }) => ({ config, changes: [], autoEnabledReasons: {} }));
   primeConfiguredBindingRegistry.mockClear().mockReturnValue({ bindingCount: 0, channelCount: 0 });
+  normalizeProviderModelIdWithRuntime.mockReset().mockReturnValue(undefined);
   pluginRuntimeLoaderLogger.info.mockClear();
   pluginRuntimeLoaderLogger.warn.mockClear();
   pluginRuntimeLoaderLogger.error.mockClear();
@@ -1612,6 +1618,7 @@ describe("loadGatewayPlugins", () => {
         },
       },
     });
+    expect(normalizeProviderModelIdWithRuntime).not.toHaveBeenCalled();
     serverPlugins.setFallbackGatewayContext(createTestContext("fallback-trusted-overrides"));
     await gatewayRequestScopeModule.withPluginRuntimePluginIdScope("voice-call", () =>
       runtime.run({
@@ -1627,6 +1634,7 @@ describe("loadGatewayPlugins", () => {
     expect(params.sessionKey).toBe("s-trusted-override");
     expect(params.provider).toBe("anthropic");
     expect(params.model).toBe("claude-haiku-4-5");
+    expect(normalizeProviderModelIdWithRuntime).toHaveBeenCalledOnce();
   });
 
   test("tags plugin fallback subagent runs with the creating plugin id", async () => {

--- a/src/plugins/runtime/runtime-llm.runtime.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.ts
@@ -1,16 +1,20 @@
 // Runtime LLM helpers adapt plugin provider hooks into the core model runtime.
 import { parseModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog-refs";
+import {
+  normalizeBuiltInProviderModelId,
+  stripSelfProviderModelPrefix,
+} from "@openclaw/model-catalog-core/provider-model-id-normalization";
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { splitTrailingAuthProfile } from "../../agents/model-ref-profile.js";
-import { modelKey } from "../../agents/model-ref-shared.js";
-import { normalizeModelRef } from "../../agents/model-selection.js";
+import { normalizeModelRef } from "../../agents/model-ref-shared.js";
 import type { NormalizedUsage, UsageLike } from "../../agents/usage.js";
 import { normalizeUsage } from "../../agents/usage.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { Api, Message } from "../../llm/types.js";
 import { getChildLogger } from "../../logging.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
+import { modelKey } from "../../shared/model-key.js";
 import { estimateUsageCost, resolveModelCostConfig } from "../../utils/usage-format.js";
 import { normalizePluginsConfig } from "../config-state.js";
 import { getPluginRuntimeGatewayRequestScope } from "./gateway-request-scope.js";
@@ -271,8 +275,13 @@ function normalizeAllowedModelRef(raw: string): string | null {
   if (!parsed) {
     return null;
   }
-  const normalized = normalizeModelRef(parsed.provider, parsed.modelId);
-  return modelKey(normalized.provider, normalized.model);
+  // Operator allowlists already name canonical targets; keep policy checks independent
+  // of plugin metadata and provider-runtime discovery.
+  const modelId = normalizeBuiltInProviderModelId(
+    parsed.provider,
+    stripSelfProviderModelPrefix(parsed.provider, parsed.modelId),
+  );
+  return modelKey(parsed.provider, modelId);
 }
 
 function normalizeModelAllowlist(params: {


### PR DESCRIPTION
Closes https://github.com/openclaw/openclaw/issues/118853

## Summary

- keep plugin subagent and runtime-LLM allowlists on built-in static model normalization
- preserve runtime/plugin normalization for actual requested and resolved models
- make the Gateway authorization test mock that request-time provider hook and assert the policy/request boundary

## Root cause

`plugins.entries.<id>.{subagent,llm}.allowedModels` is documented as canonical `provider/model` policy, but policy construction called the runtime-aware model normalizer. In source mode that performs plugin metadata discovery and can cold-load the broad provider runtime. In the non-isolated Gateway project, the explicit-config test then took 124–133 seconds and timed out at 120 seconds.

The architectural owner is the policy builder: configured canonical allowlists now use built-in static normalization, while actual requested and resolved models still use runtime-aware normalization. No config shape, schema, default, protocol, or API changes.

## Evidence

Exact candidate: `9bba996f1f8215f1910a5af00d47889f5a69bf32`, rebased onto `e110b560071de2d23b11219d013ad3c8eca4b160`.

- `node scripts/run-vitest.mjs src/gateway/server-plugins.test.ts src/plugins/runtime/runtime-llm.runtime.test.ts` — 2 files, 99 tests passed
- patch-identical cumulative Gateway prefix — 14 files, 1,163 tests passed; affected file 627 ms: https://github.com/openclaw/openclaw/actions/runs/30840125030 (`tbx_01kz4d55bcvznre66w1k0sswmy`)
- exact-content Blacksmith Testbox build and built-boundary diagnostic: https://github.com/openclaw/openclaw/actions/runs/30863916426 (`tbx_01kz50w8sew43z8tpv4cdjg1kj`)
  - all three changed files matched the candidate SHA-256 values before build
  - built `setPluginSubagentOverridePolicies` completed with 750 Node module-trace events and **0** `provider-runtime` require attempts
  - request-time `normalizeModelRef` control completed with 587 trace events and **4** `provider-runtime` require attempts
- real ephemeral Gateway diagnostic: exact files verified, build and config passed, `/readyz` reached in 12,708 ms with 14,468 module-trace events: https://github.com/openclaw/openclaw/actions/runs/30863459377 (`tbx_01kz50d438xrefyp7kj14yjvad`)
  - the exploratory whole-startup zero-import assertion was intentionally rejected after it found four unrelated request-time normalization attempts elsewhere in startup; the passing built-boundary diagnostic above isolates the changed policy owner instead of hiding that fact
- `git diff --check origin/main...HEAD` — passed
- fresh Codex autoreview — clean, no accepted/actionable findings, confidence 0.98
- public model identifier gate — PASS; no model identifiers added or changed
- exact-head hosted CI — passed: https://github.com/openclaw/openclaw/actions/runs/30865184795

The hosted full-checkout type and check lanes are green. A pre-push local fallback also passed formatting, API baselines, plugin boundaries, dependency guards, and dead-export scans; its core typecheck was not usable because Codex worktrees omit package-level `node_modules` links and resolved the root `string-width@4.2.3` types instead of `packages/terminal-core`'s declared `8.2.2`.

## Risk

Low to medium. Production delta is +26/-7 and establishes one explicit policy/runtime ownership boundary; tests add eight lines. Existing non-canonical allowlist values that depended on plugin/manifest aliases now follow the documented canonical-target contract instead of dynamic runtime policy.
