### PR TITLE
improve(qa): cover guarded media fetch boundaries

### DIFF
--- a/qa/scenarios/media/media-fetch-boundaries.yaml
+++ b/qa/scenarios/media/media-fetch-boundaries.yaml
@@ -1,0 +1,30 @@
+title: Media guarded fetch boundaries
+
+scenario:
+  id: media-fetch-boundaries
+  surface: media
+  category: media.media-intake-and-access
+  coverage:
+    primary:
+      - media.safe-remote-fetch
+      - media.size-caps-and-bounded-reads
+  objective: Prove remote media intake enforces SSRF, redirect, header, and bounded-write policy before publishing media-store artifacts.
+  successCriteria:
+    - A private loopback target is rejected before any network request or media-store publication.
+    - Redirect targets are revalidated against exact-origin policy.
+    - Cross-origin redirects preserve safe headers while stripping authorization, cookie, and API-key material.
+    - Declared content-length and chunked streaming overflows fail at the configured byte cap.
+    - Failed guarded fetches leave no final or temporary media-store artifact.
+  docsRefs:
+    - docs/tools/media-overview.md
+    - docs/gateway/security/secure-file-operations.md
+    - docs/help/testing.md
+  codeRefs:
+    - src/infra/net/fetch-guard.ts
+    - src/media/fetch.ts
+    - src/media/store.ts
+    - test/e2e/qa-lab/media/media-fetch-boundaries.e2e.test.ts
+  execution:
+    kind: vitest
+    path: test/e2e/qa-lab/media/media-fetch-boundaries.e2e.test.ts
+    summary: Runs real loopback HTTP redirects and bounded streams through canonical guarded media fetch and atomic store publication.

--- a/test/e2e/qa-lab/media/media-fetch-boundaries.e2e.test.ts
+++ b/test/e2e/qa-lab/media/media-fetch-boundaries.e2e.test.ts
@@ -1,0 +1,247 @@
+import fs from "node:fs/promises";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { MediaFetchError, saveRemoteMedia } from "../../../../src/media/fetch.js";
+import { withEnvAsync } from "../../../../src/test-utils/env.js";
+import { useAutoCleanupTempDirTracker } from "../../../helpers/temp-dir.js";
+
+type SeenRequest = {
+  headers: IncomingMessage["headers"];
+  url: string;
+};
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const sourceRequests: SeenRequest[] = [];
+const targetRequests: SeenRequest[] = [];
+
+let sourceServer: Server;
+let sourceOrigin: string;
+let targetServer: Server;
+let targetOrigin: string;
+
+async function listenOnLoopback(server: Server): Promise<string> {
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error) => {
+      server.off("error", onError);
+      reject(error);
+    };
+    server.once("error", onError);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", onError);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("loopback media server did not expose a TCP port");
+  }
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function closeLoopbackServer(server: Server): Promise<void> {
+  const closed = new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+  server.closeAllConnections();
+  await closed;
+}
+
+function recordRequest(request: IncomingMessage, requests: SeenRequest[]): void {
+  requests.push({
+    headers: request.headers,
+    url: request.url ?? "/",
+  });
+}
+
+function handleSourceRequest(request: IncomingMessage, response: ServerResponse): void {
+  recordRequest(request, sourceRequests);
+  switch (request.url) {
+    case "/private":
+      response.writeHead(200, { "content-type": "text/plain" });
+      response.end("private media");
+      return;
+    case "/redirect":
+      response.writeHead(302, { location: `${targetOrigin}/payload` });
+      response.end();
+      return;
+    case "/oversized-file":
+      response.writeHead(200, {
+        "content-length": "128",
+        "content-type": "application/octet-stream",
+      });
+      response.end("declared oversized file");
+      return;
+    case "/oversized-stream":
+      response.writeHead(200, { "content-type": "application/octet-stream" });
+      response.write(Buffer.alloc(12, 0x61));
+      response.end(Buffer.alloc(12, 0x62));
+      return;
+    default:
+      response.writeHead(404);
+      response.end();
+  }
+}
+
+function handleTargetRequest(request: IncomingMessage, response: ServerResponse): void {
+  recordRequest(request, targetRequests);
+  if (request.url !== "/payload") {
+    response.writeHead(404);
+    response.end();
+    return;
+  }
+  response.writeHead(200, { "content-type": "text/plain" });
+  response.end("redirected media");
+}
+
+async function expectNoPublishedMediaFiles(stateDir: string): Promise<void> {
+  const mediaDir = path.join(stateDir, "media");
+  const files: string[] = [];
+
+  const visit = async (directory: string): Promise<void> => {
+    const entries = await fs
+      .readdir(directory, { withFileTypes: true })
+      .catch((error: NodeJS.ErrnoException) => {
+        if (error.code === "ENOENT") {
+          return [];
+        }
+        throw error;
+      });
+    for (const entry of entries) {
+      const entryPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        await visit(entryPath);
+      } else {
+        files.push(path.relative(mediaDir, entryPath));
+      }
+    }
+  };
+
+  await visit(mediaDir);
+  expect(files.toSorted()).toStrictEqual([]);
+}
+
+describe("media guarded fetch product boundaries", () => {
+  beforeAll(async () => {
+    targetServer = createServer(handleTargetRequest);
+    targetOrigin = await listenOnLoopback(targetServer);
+    sourceServer = createServer(handleSourceRequest);
+    sourceOrigin = await listenOnLoopback(sourceServer);
+  });
+
+  beforeEach(() => {
+    sourceRequests.length = 0;
+    targetRequests.length = 0;
+  });
+
+  afterAll(async () => {
+    await Promise.all([closeLoopbackServer(sourceServer), closeLoopbackServer(targetServer)]);
+  });
+
+  it("rejects private targets before the network or media store is reached", async () => {
+    const stateDir = tempDirs.make("openclaw-media-private-fetch-");
+
+    await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+      const error = await saveRemoteMedia({
+        url: `${sourceOrigin}/private`,
+        maxBytes: 64,
+        subdir: "private-target",
+      }).catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(MediaFetchError);
+      expect(error).toMatchObject({
+        code: "fetch_failed",
+        cause: { name: "SsrFBlockedError" },
+      });
+      expect(sourceRequests).toHaveLength(0);
+      await expectNoPublishedMediaFiles(stateDir);
+    });
+  });
+
+  it("revalidates redirect targets and strips sensitive cross-origin headers", async () => {
+    const stateDir = tempDirs.make("openclaw-media-safe-redirect-");
+
+    await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+      const blocked = await saveRemoteMedia({
+        url: `${sourceOrigin}/redirect`,
+        requestInit: {
+          headers: {
+            Accept: "text/plain",
+            Authorization: "Bearer private-token",
+            Cookie: "session=private",
+            "X-Api-Key": "private-key",
+          },
+        },
+        maxBytes: 64,
+        subdir: "blocked-redirect",
+        ssrfPolicy: { allowedOrigins: [sourceOrigin] },
+      }).catch((caught: unknown) => caught);
+
+      expect(blocked).toBeInstanceOf(MediaFetchError);
+      expect(blocked).toMatchObject({
+        code: "fetch_failed",
+        cause: { name: "SsrFBlockedError" },
+      });
+      expect(sourceRequests).toHaveLength(1);
+      expect(targetRequests).toHaveLength(0);
+      await expectNoPublishedMediaFiles(stateDir);
+
+      sourceRequests.length = 0;
+      const saved = await saveRemoteMedia({
+        url: `${sourceOrigin}/redirect`,
+        requestInit: {
+          headers: {
+            Accept: "text/plain",
+            Authorization: "Bearer private-token",
+            Cookie: "session=private",
+            "X-Api-Key": "private-key",
+          },
+        },
+        maxBytes: 64,
+        subdir: "safe-redirect",
+        ssrfPolicy: { allowedOrigins: [sourceOrigin, targetOrigin] },
+      });
+
+      expect(sourceRequests[0]?.headers.authorization).toBe("Bearer private-token");
+      expect(targetRequests).toHaveLength(1);
+      expect(targetRequests[0]?.headers.accept).toBe("text/plain");
+      expect(targetRequests[0]?.headers.authorization).toBeUndefined();
+      expect(targetRequests[0]?.headers.cookie).toBeUndefined();
+      expect(targetRequests[0]?.headers["x-api-key"]).toBeUndefined();
+      await expect(fs.readFile(saved.path, "utf8")).resolves.toBe("redirected media");
+    });
+  });
+
+  it("rejects declared and streamed overflows without publishing store artifacts", async () => {
+    const stateDir = tempDirs.make("openclaw-media-bounded-fetch-");
+    const allowedOrigins = [sourceOrigin];
+
+    await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+      await expect(
+        saveRemoteMedia({
+          url: `${sourceOrigin}/oversized-file`,
+          maxBytes: 16,
+          subdir: "oversized-file",
+          ssrfPolicy: { allowedOrigins },
+        }),
+      ).rejects.toMatchObject({
+        name: "MediaFetchError",
+        code: "max_bytes",
+      });
+      await expectNoPublishedMediaFiles(stateDir);
+
+      await expect(
+        saveRemoteMedia({
+          url: `${sourceOrigin}/oversized-stream`,
+          maxBytes: 16,
+          subdir: "oversized-stream",
+          ssrfPolicy: { allowedOrigins },
+        }),
+      ).rejects.toMatchObject({
+        name: "MediaFetchError",
+        code: "max_bytes",
+      });
+      await expectNoPublishedMediaFiles(stateDir);
+    });
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Guarded remote media fetch behavior had no primary QA ownership for private-network rejection, redirect revalidation, bounded reads, and whole-store failed-write cleanup.

## Why This Change Was Made

Adds one E2E QA scenario covering the canonical guarded fetch path:

- private destination rejection
- redirect target revalidation
- sensitive-header stripping across origins
- declared and streamed size limits
- failure without a persisted media-store artifact anywhere in the fresh media tree

The executable test uses the `.e2e.test.ts` suffix required for QA Lab to select `test/vitest/vitest.e2e.config.ts` and load OpenClaw runtime setup.

After every failed fetch, the helper recursively scans the complete `stateDir/media` tree. ENOENT and empty directories are accepted; any file in any subdirectory fails the assertion.

Primary coverage:

- `media.safe-remote-fetch`
- `media.size-caps-and-bounded-reads`

## User Impact

No runtime behavior changes. Security, size-boundary, and failed-write cleanup regressions now fail visibly in the QA portfolio.

## Evidence

- Exact head: `72f670911e8ed0a248df0b4ee6030ad3557c84b6`
- Exact tree: `f9ba2c60227d8729b85ae59fdbbd5338cd83231e`
- Focused E2E test: 3/3 passed under `test/vitest/vitest.e2e.config.ts`.
- Full QA suite: 1/1 passed in `full` evidence mode.
- Evidence: `.artifacts/qa-e2e/media-fetch-boundaries-exact-72f6709-20260803/qa-evidence.json`
- Exact evidence source/ref validation: passed.
- Targeted `oxfmt`, touched-file `oxlint`, `git diff --check`, and privacy scan: passed.
- Product-runtime LOC delta: 0.
- Repair delta from the prior reviewed head: test-only +28/-12, net +16 LOC.
- Hosted exact-head CI is attached and pending.

```json
{
  "scenario": "media-fetch-boundaries",
  "ref": "72f670911e8ed0a248df0b4ee6030ad3557c84b6",
  "tree": "f9ba2c60227d8729b85ae59fdbbd5338cd83231e",
  "providerMode": "mock-openai",
  "evidenceMode": "full",
  "focusedPassed": 3,
  "focusedFailed": 0,
  "fullSuitePassed": 1,
  "fullSuiteFailed": 0,
  "primaryCoverage": [
    "media.safe-remote-fetch",
    "media.size-caps-and-bounded-reads"
  ]
}
```
