### PR TITLE
improve(qa): cover PDF extraction dispatch

### DIFF
--- a/qa/scenarios/media/pdf-document-extraction-dispatch.yaml
+++ b/qa/scenarios/media/pdf-document-extraction-dispatch.yaml
@@ -1,0 +1,28 @@
+title: PDF document extraction dispatch
+
+scenario:
+  id: pdf-document-extraction-dispatch
+  surface: media
+  category: media.media-intake-and-access
+  coverage:
+    primary:
+      - media.pdf-document-extraction-dispatch
+  objective: Verify PDF intake dispatches through the bundled document extractor to real clawpdf and reports disabled extraction explicitly.
+  successCriteria:
+    - The bundled document-extract plugin supplies the PDF extractor.
+    - A parseable inline PDF yields its sentinel text through real clawpdf.
+    - The document extractor runtime tags the result with extractor pdf.
+    - Disabling document extraction produces the explicit unavailable error.
+  docsRefs:
+    - docs/plugins/reference/document-extract.md
+    - docs/tools/pdf.md
+  codeRefs:
+    - src/media/pdf-extract.ts
+    - src/media/document-extractors.runtime.ts
+    - src/plugins/document-extractors.runtime.ts
+    - extensions/document-extract/document-extractor.ts
+    - test/e2e/qa-lab/media/pdf-document-extraction-dispatch.product.test.ts
+  execution:
+    kind: vitest
+    path: test/e2e/qa-lab/media/pdf-document-extraction-dispatch.product.test.ts
+    summary: Run a parseable inline PDF through bundled extractor discovery, real clawpdf extraction, and the disabled-plugin failure path.

--- a/test/e2e/qa-lab/media/pdf-document-extraction-dispatch.product.test.ts
+++ b/test/e2e/qa-lab/media/pdf-document-extraction-dispatch.product.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { extractDocumentContent } from "../../../../src/media/document-extractors.runtime.js";
+import { extractPdfContent } from "../../../../src/media/pdf-extract.js";
+import { resolvePluginDocumentExtractors } from "../../../../src/plugins/document-extractors.runtime.js";
+
+const SENTINEL = "OPENCLAW_PDF_DISPATCH_SENTINEL";
+
+function createInlinePdf(text: string): Buffer {
+  const escapedText = text.replace(/[\\()]/gu, "\\$&");
+  const content = `BT
+/F1 18 Tf
+72 720 Td
+(${escapedText}) Tj
+ET
+`;
+  const objects = [
+    "<< /Type /Catalog /Pages 2 0 R >>",
+    "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+    "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
+    "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    `<< /Length ${Buffer.byteLength(content)} >>
+stream
+${content}endstream`,
+  ];
+
+  let pdf = "%PDF-1.4\n% OpenClaw QA fixture\n";
+  const offsets: number[] = [];
+  for (const [index, object] of objects.entries()) {
+    offsets.push(Buffer.byteLength(pdf));
+    pdf += `${index + 1} 0 obj
+${object}
+endobj
+`;
+  }
+
+  const xrefOffset = Buffer.byteLength(pdf);
+  pdf += `xref
+0 ${objects.length + 1}
+`;
+  pdf += "0000000000 65535 f \n";
+  for (const offset of offsets) {
+    pdf += `${String(offset).padStart(10, "0")} 00000 n \n`;
+  }
+  pdf += `trailer
+<< /Size ${objects.length + 1} /Root 1 0 R >>
+startxref
+${xrefOffset}
+%%EOF
+`;
+  return Buffer.from(pdf, "ascii");
+}
+
+describe("PDF document extraction dispatch", () => {
+  it("uses the bundled PDF extractor and reports disabled extraction explicitly", async () => {
+    const buffer = createInlinePdf(SENTINEL);
+    const bundledPdfExtractor = resolvePluginDocumentExtractors().find(
+      (extractor) => extractor.id === "pdf",
+    );
+
+    expect(bundledPdfExtractor).toMatchObject({
+      id: "pdf",
+      pluginId: "document-extract",
+      mimeTypes: ["application/pdf"],
+    });
+
+    const extracted = await extractDocumentContent({
+      buffer,
+      mimeType: "application/pdf",
+      maxPages: 1,
+      maxPixels: 1_000_000,
+      minTextChars: 1,
+    });
+    expect(extracted).toMatchObject({
+      extractor: "pdf",
+      text: SENTINEL,
+      images: [],
+    });
+
+    await expect(
+      extractPdfContent({
+        buffer,
+        maxPages: 1,
+        maxPixels: 1_000_000,
+        minTextChars: 1,
+      }),
+    ).resolves.toEqual({
+      text: SENTINEL,
+      images: [],
+    });
+
+    await expect(
+      extractPdfContent({
+        buffer,
+        maxPages: 1,
+        maxPixels: 1_000_000,
+        minTextChars: 1,
+        config: {
+          plugins: {
+            entries: {
+              "document-extract": { enabled: false },
+            },
+          },
+        },
+      }),
+    ).rejects.toThrow(
+      "PDF extraction disabled or unavailable: enable the document-extract plugin to process application/pdf files.",
+    );
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

PDF document extraction dispatch lacked primary QA ownership across bundled extraction and disabled/error behavior.

## Why This Change Was Made

Adds one product-level QA scenario covering:

- a valid generated PDF
- bundled PDF extraction discovery and dispatch
- sentinel text extraction
- the explicit disabled-extraction error path

Primary coverage:

- `media.pdf-document-extraction-dispatch`

## User Impact

No runtime behavior changes. PDF extraction regressions now fail at the dispatch boundary that owns them.

## Evidence

- Exact head: `c20c95f0470fa97bcc02b0bd53c51203ac05d563`
- Exact tree: `a6cf946f994f54dea071076a7baae33d58ce3757`
- Focused product test: 1/1 passed.
- Full QA suite: 1/1 passed in `full` evidence mode at the exact head.
- `git diff --check`: passed.
- Product-runtime LOC delta: 0.
- Reviewed `main` drift through `65fa1f9` is path-disjoint from this slice.
- Blacksmith Testbox was unavailable because the local client was not authenticated.
- The linked local changed gate is not accepted because it used unsupported Node 24.13 and stale shared generated dependencies.
- A frozen normal checkout at `554a6f3` passed `pnpm tsgo:all`, establishing a clean baseline for those unrelated diagnostics.
- Hosted exact-head CI must run after undraft.

Direct inspection of the pinned `clawpdf` 0.3.0 package source and types confirmed:

- `createEngine` and engine `open`
- normalized `Uint8Array` input
- document text extraction
- one-based page selection and range errors
- typed password errors
- document and engine destroy lifecycles

```json
{
  "scenario": "pdf-document-extraction-dispatch",
  "ref": "c20c95f0470fa97bcc02b0bd53c51203ac05d563",
  "tree": "a6cf946f994f54dea071076a7baae33d58ce3757",
  "evidenceMode": "full",
  "focusedPassed": 1,
  "focusedFailed": 0,
  "fullSuitePassed": 1,
  "fullSuiteFailed": 0,
  "primaryCoverage": [
    "media.pdf-document-extraction-dispatch"
  ]
}
```
