### PR TITLE
improve(qa): cover vision channel offload

### DIFF
--- a/extensions/qa-lab/src/gateway-child.test.ts
+++ b/extensions/qa-lab/src/gateway-child.test.ts
@@ -468,6 +468,34 @@ describe("buildQaRuntimeEnv", () => {
     expect(env.OPENCLAW_COMPATIBILITY_HOST_VERSION).toBe("2026.4.8");
   });
 
+  it("isolates gateway children from Vitest without removing QA controls or non-test NODE_ENV", () => {
+    const testEnv = buildQaRuntimeEnv({
+      ...createParams({
+        NODE_ENV: "test",
+        VITEST: "true",
+        VITEST_POOL_ID: "base-pool",
+        VITEST_WORKER_ID: "base-worker",
+      }),
+      runtimeEnvPatch: {
+        VITEST: "patched",
+        VITEST_POOL_ID: "patched-pool",
+        VITEST_WORKER_ID: "patched-worker",
+      },
+    });
+
+    expect(testEnv.NODE_ENV).toBeUndefined();
+    expect(testEnv.VITEST).toBeUndefined();
+    expect(testEnv.VITEST_POOL_ID).toBeUndefined();
+    expect(testEnv.VITEST_WORKER_ID).toBeUndefined();
+    expect(testEnv.OPENCLAW_TEST_FAST).toBe("1");
+    expect(testEnv.OPENCLAW_ALLOW_SLOW_REPLY_TESTS).toBe("1");
+
+    const developmentEnv = buildQaRuntimeEnv({
+      ...createParams({ NODE_ENV: "development" }),
+    });
+    expect(developmentEnv.NODE_ENV).toBe("development");
+  });
+
   it("maps live frontier key aliases into provider env vars", () => {
     const env = buildQaRuntimeEnv({
       ...createParams({

--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -136,6 +136,18 @@ function scrubQaGatewayChildSecretEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv
   return env;
 }
 
+function scrubQaGatewayChildTestRunnerEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  // The Gateway is a product child, not a nested Vitest worker. Leaking runner
+  // markers makes the dist launcher select test-only startup behavior.
+  delete env.VITEST;
+  delete env.VITEST_POOL_ID;
+  delete env.VITEST_WORKER_ID;
+  if (env.NODE_ENV === "test") {
+    delete env.NODE_ENV;
+  }
+  return env;
+}
+
 function createQaGatewayEmptyTransport() {
   return {
     requiredPluginIds: [] as const,
@@ -446,7 +458,7 @@ export function buildQaRuntimeEnv(params: {
   normalizedEnv.OPENCLAW_BUILD_PRIVATE_QA = "1";
   delete normalizedEnv[QA_LIVE_ANTHROPIC_SETUP_TOKEN_ENV];
   delete normalizedEnv[QA_LIVE_SETUP_TOKEN_VALUE_ENV];
-  return scrubQaGatewayChildSecretEnv(normalizedEnv);
+  return scrubQaGatewayChildSecretEnv(scrubQaGatewayChildTestRunnerEnv(normalizedEnv));
 }
 
 async function stageQaCodexMockModelCatalog(params: {

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-assistant-text.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-assistant-text.ts
@@ -38,7 +38,7 @@ import {
   extractSlackMpimRetainedBotNonce,
   extractAllUserTexts,
   extractAllRequestTexts,
-  extractLatestImageUserTurn,
+  extractCurrentImageRequest,
   parseToolOutputJson,
 } from "./mock-openai-input.js";
 import {
@@ -167,7 +167,7 @@ export function buildAssistantText(input: ResponsesInputItem[], body: Record<str
   const userExactMarkerDirective =
     promptExactMarkerDirective ?? extractExactMarkerDirective(allUserText);
   const exactReplyDirective = promptExactReplyDirective ?? extractExactReplyDirective(allInputText);
-  const latestImageUserTurn = extractLatestImageUserTurn(input);
+  const currentImageRequest = extractCurrentImageRequest(input, body);
   const whatsAppLocationMarker = shouldUseWhatsAppLocationMarker(prompt)
     ? extractWhatsAppLocationMarkerDirective(allInputText)
     : "";
@@ -218,14 +218,14 @@ export function buildAssistantText(input: ResponsesInputItem[], body: Record<str
     return "HEARTBEAT_OK";
   }
   if (
-    /roundtrip image inspection check/i.test(latestImageUserTurn.text) &&
-    latestImageUserTurn.imageInputCount > 0
+    /roundtrip image inspection check/i.test(currentImageRequest.text) &&
+    currentImageRequest.imageInputCount > 0
   ) {
     return "Protocol note: the generated attachment shows the same QA lighthouse scene from the previous step.";
   }
   if (
-    /image understanding check/i.test(latestImageUserTurn.text) &&
-    latestImageUserTurn.imageInputCount > 0
+    /image understanding check/i.test(currentImageRequest.text) &&
+    currentImageRequest.imageInputCount > 0
   ) {
     return "Protocol note: the attached image is split horizontally, with red on top and blue on the bottom.";
   }

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-input.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-input.ts
@@ -404,7 +404,7 @@ export function countImageInputs(value: unknown): number {
   return count;
 }
 
-export function extractLatestImageUserTurn(input: ResponsesInputItem[]) {
+function extractLatestImageUserTurn(input: ResponsesInputItem[]) {
   const latestUserIndex = findLastUserIndex(input);
   if (latestUserIndex < 0) {
     return { text: "", imageInputCount: 0 };
@@ -426,6 +426,28 @@ export function extractLatestImageUserTurn(input: ResponsesInputItem[]) {
       .filter(Boolean)
       .join("\n"),
     imageInputCount,
+  };
+}
+
+export function extractCurrentImageRequest(
+  input: ResponsesInputItem[],
+  body: Record<string, unknown>,
+) {
+  // Match only the current request. Historical image prompts must not override
+  // a later non-image turn just because they remain in transcript context.
+  const imageUserTurn = extractLatestImageUserTurn(input);
+  if (imageUserTurn.imageInputCount === 0) {
+    return imageUserTurn;
+  }
+  const developerInstructions = input
+    .filter((item) => item.role === "developer" && Array.isArray(item.content))
+    .map((item) => extractInputText(item.content as unknown[]))
+    .filter(Boolean);
+  return {
+    text: [extractInstructionsText(body), ...developerInstructions, imageUserTurn.text]
+      .filter(Boolean)
+      .join("\n"),
+    imageInputCount: imageUserTurn.imageInputCount,
   };
 }
 

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -5214,6 +5214,39 @@ describe("qa mock openai server", () => {
     expect(requireRecord(requestLog[0], "debug request 0").imageInputCount).toBe(1);
   });
 
+  it("uses current request instructions for image descriptions", async () => {
+    const server = await startMockServer();
+
+    const payload = (await expectNonStreamingResponsesJson(server, {
+      model: "mock-openai/gpt-5.6-luna",
+      input: [
+        makeDeveloperInput("Image understanding check: describe the top and bottom colors."),
+        {
+          role: "user",
+          content: [
+            {
+              type: "input_image",
+              source: {
+                type: "base64",
+                mime_type: "image/png",
+                data: QA_IMAGE_PNG_BASE64,
+              },
+            },
+            {
+              type: "input_text",
+              text: "[media attached: media://inbound/red-top-blue-bottom.png (image/png)]",
+            },
+          ],
+        },
+      ],
+    })) as {
+      output?: Array<{ content?: Array<{ text?: string }> }>;
+    };
+    const text = payload.output?.[0]?.content?.[0]?.text ?? "";
+    expect(text.toLowerCase()).toContain("red");
+    expect(text.toLowerCase()).toContain("blue");
+  });
+
   it("recognizes OpenAI-compatible image_url parts as image inputs", async () => {
     const server = await startMockServer();
 

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -152,7 +152,7 @@ import {
   buildWhatsAppGroupDispatchReply,
   buildWhatsAppBatchedReply,
   countImageInputs,
-  extractLatestImageUserTurn,
+  extractCurrentImageRequest,
   parseToolOutputJson,
 } from "./mock-openai-input.js";
 import {
@@ -600,7 +600,7 @@ async function buildResponsesPayload(
   const exactReplyDirective = promptExactReplyDirective ?? extractExactReplyDirective(allInputText);
   const exactMarkerDirective =
     promptExactMarkerDirective ?? extractExactMarkerDirective(allInputText);
-  const latestImageUserTurn = extractLatestImageUserTurn(input);
+  const currentImageRequest = extractCurrentImageRequest(input, body);
   const whatsAppLocationMarker = shouldUseWhatsAppLocationMarker(prompt)
     ? extractWhatsAppLocationMarkerDirective(allInputText)
     : "";
@@ -958,16 +958,16 @@ async function buildResponsesPayload(
     return buildAssistantEvents("BETA-OK");
   }
   if (
-    /roundtrip image inspection check/i.test(latestImageUserTurn.text) &&
-    latestImageUserTurn.imageInputCount > 0
+    /roundtrip image inspection check/i.test(currentImageRequest.text) &&
+    currentImageRequest.imageInputCount > 0
   ) {
     return buildAssistantEvents(
       "Protocol note: the generated attachment shows the same QA lighthouse scene from the previous step.",
     );
   }
   if (
-    /image understanding check/i.test(latestImageUserTurn.text) &&
-    latestImageUserTurn.imageInputCount > 0
+    /image understanding check/i.test(currentImageRequest.text) &&
+    currentImageRequest.imageInputCount > 0
   ) {
     return buildAssistantEvents(
       "Protocol note: the attached image is split horizontally, with red on top and blue on the bottom.",

--- a/qa/scenarios/media/vision-channel-offload.yaml
+++ b/qa/scenarios/media/vision-channel-offload.yaml
@@ -1,0 +1,30 @@
+title: QA-channel vision offload
+
+scenario:
+  id: vision-channel-offload
+  surface: media
+  category: media.media-understanding
+  coverage:
+    primary:
+      - media.image-summary-qa-channel
+      - media.text-only-model-media-offload
+  objective: Verify QA-channel image ingress is summarized by a configured vision model before the text-only active model emits one visible reply.
+  successCriteria:
+    - QA-channel ingests an inline PNG through the real bundled channel and gateway flow.
+    - The configured image model receives at least one image input.
+    - The active text-only model receives zero image inputs and the provider summary in its text context.
+    - QA-channel emits exactly one visible final outbound reply.
+  docsRefs:
+    - docs/channels/qa-channel.md
+    - docs/nodes/media-understanding.md
+    - docs/concepts/qa-e2e-automation.md
+  codeRefs:
+    - extensions/qa-channel/src/inbound.ts
+    - src/auto-reply/reply/get-reply.ts
+    - src/media-understanding/apply.ts
+    - src/media-understanding/runner.ts
+    - test/e2e/qa-lab/media/vision-channel-offload.product.test.ts
+  execution:
+    kind: vitest
+    path: test/e2e/qa-lab/media/vision-channel-offload.product.test.ts
+    summary: Send an image through QA-channel, prove the configured image model summarizes it, and prove the text-only active model receives only the summary before one visible reply.

--- a/qa/scenarios/media/vision-channel-offload.yaml
+++ b/qa/scenarios/media/vision-channel-offload.yaml
@@ -23,8 +23,8 @@ scenario:
     - src/auto-reply/reply/get-reply.ts
     - src/media-understanding/apply.ts
     - src/media-understanding/runner.ts
-    - test/e2e/qa-lab/media/vision-channel-offload.product.test.ts
+    - test/e2e/qa-lab/media/vision-channel-offload.e2e.test.ts
   execution:
     kind: vitest
-    path: test/e2e/qa-lab/media/vision-channel-offload.product.test.ts
+    path: test/e2e/qa-lab/media/vision-channel-offload.e2e.test.ts
     summary: Send an image through QA-channel, prove the configured image model summarizes it, and prove the text-only active model receives only the summary before one visible reply.

--- a/test/e2e/qa-lab/media/vision-channel-offload.e2e.test.ts
+++ b/test/e2e/qa-lab/media/vision-channel-offload.e2e.test.ts
@@ -1,12 +1,14 @@
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { afterEach, describe, expect, it } from "vitest";
-import { startQaBusServer } from "../../../../extensions/qa-lab/src/bus-server.js";
-import { createQaBusState } from "../../../../extensions/qa-lab/src/bus-state.js";
-import { startQaGatewayChild } from "../../../../extensions/qa-lab/src/gateway-child.js";
-import type { MockOpenAiRequestSnapshot } from "../../../../extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.js";
-import { startQaMockOpenAiServer } from "../../../../extensions/qa-lab/src/providers/mock-openai/server.js";
-import { createQaChannelTransport } from "../../../../extensions/qa-lab/src/qa-channel-transport.js";
+import {
+  createQaBusState,
+  createQaChannelTransport,
+  type MockOpenAiRequestSnapshot,
+  startQaBusServer,
+  startQaGatewayChild,
+  startQaMockOpenAiServer,
+} from "../../../../extensions/qa-lab/api.js";
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "../../../..");
 const ACTIVE_MODEL_ID = "gpt-5.6-luna";
@@ -33,7 +35,7 @@ function configureVisionOffload(config: OpenClawConfig): OpenClawConfig {
       return model;
     }
     foundActiveModel = true;
-    return { ...model, input: ["text"] as const };
+    return { ...model, input: ["text" as const] };
   });
   if (!foundActiveModel) {
     throw new Error(`active QA model is missing from provider catalog: ${ACTIVE_MODEL_ID}`);
@@ -81,12 +83,40 @@ async function readMockRequests(baseUrl: string, after: number) {
   return (await response.json()) as MockOpenAiRequestSnapshot[];
 }
 
+function compactRequestShapes(requests: MockOpenAiRequestSnapshot[]) {
+  return requests.map((request) => ({
+    cursor: request.cursor,
+    model: request.model,
+    imageInputCount: request.imageInputCount,
+    inputRoles: readInputRoles(request),
+    instructions: request.instructions?.slice(0, 240),
+    allInputTextTail: request.allInputText.slice(-400),
+  }));
+}
+
+function readInputRoles(request: MockOpenAiRequestSnapshot) {
+  const input = Array.isArray(request.body.input) ? request.body.input : [];
+  return input.flatMap((item) =>
+    item && typeof item === "object" && typeof (item as { role?: unknown }).role === "string"
+      ? [(item as { role: string }).role]
+      : [],
+  );
+}
+
 describe("QA-channel vision offload", () => {
   const cleanups: Array<() => Promise<void>> = [];
 
   afterEach(async () => {
+    const errors: unknown[] = [];
     for (const cleanup of cleanups.splice(0).toReversed()) {
-      await cleanup();
+      try {
+        await cleanup();
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    if (errors.length > 0) {
+      throw new AggregateError(errors, "vision channel offload cleanup failed");
     }
   });
 
@@ -157,20 +187,26 @@ describe("QA-channel vision offload", () => {
     const scenarioRequests = (await readMockRequests(mock.baseUrl, requestCursor)).filter(
       (request) => request.allInputText.includes(SCENARIO_MARKER),
     );
-    expect(scenarioRequests).toHaveLength(2);
+    const requestDiagnostics = `requests=${JSON.stringify(compactRequestShapes(scenarioRequests))}`;
+    expect(scenarioRequests, requestDiagnostics).toHaveLength(2);
 
     const [imageRequest, activeModelRequest] = scenarioRequests;
-    expect(imageRequest).toMatchObject({
-      model: IMAGE_MODEL_ID,
-      imageInputCount: expect.any(Number),
-    });
-    expect(imageRequest.imageInputCount).toBeGreaterThanOrEqual(1);
-    expect(activeModelRequest).toMatchObject({
-      model: ACTIVE_MODEL_ID,
-      imageInputCount: 0,
-    });
-    expect(activeModelRequest.cursor).toBeGreaterThan(imageRequest.cursor);
-    expect(activeModelRequest.allInputText).toContain(PROVIDER_SUMMARY);
+    if (!imageRequest || !activeModelRequest) {
+      throw new Error(requestDiagnostics);
+    }
+    expect(imageRequest.model, requestDiagnostics).toBe(IMAGE_MODEL_ID);
+    expect(imageRequest.imageInputCount, requestDiagnostics).toBe(1);
+    expect(readInputRoles(imageRequest), requestDiagnostics).toEqual(["developer", "user"]);
+    expect(activeModelRequest.model, requestDiagnostics).toBe(ACTIVE_MODEL_ID);
+    expect(activeModelRequest.imageInputCount, requestDiagnostics).toBe(0);
+    expect(readInputRoles(activeModelRequest), requestDiagnostics).toEqual([
+      "system",
+      "user",
+      "user",
+    ]);
+    expect(imageRequest.cursor, requestDiagnostics).toBeLessThan(activeModelRequest.cursor);
+    expect(imageRequest.allInputText, requestDiagnostics).toContain(IMAGE_PROMPT);
+    expect(activeModelRequest.allInputText, requestDiagnostics).toContain(PROVIDER_SUMMARY);
 
     const visibleOutbound = state
       .getSnapshot()

--- a/test/e2e/qa-lab/media/vision-channel-offload.product.test.ts
+++ b/test/e2e/qa-lab/media/vision-channel-offload.product.test.ts
@@ -1,0 +1,191 @@
+import path from "node:path";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { afterEach, describe, expect, it } from "vitest";
+import { startQaBusServer } from "../../../../extensions/qa-lab/src/bus-server.js";
+import { createQaBusState } from "../../../../extensions/qa-lab/src/bus-state.js";
+import { startQaGatewayChild } from "../../../../extensions/qa-lab/src/gateway-child.js";
+import type { MockOpenAiRequestSnapshot } from "../../../../extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.js";
+import { startQaMockOpenAiServer } from "../../../../extensions/qa-lab/src/providers/mock-openai/server.js";
+import { createQaChannelTransport } from "../../../../extensions/qa-lab/src/qa-channel-transport.js";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "../../../..");
+const ACTIVE_MODEL_ID = "gpt-5.6-luna";
+const ACTIVE_MODEL_REF = `mock-openai/${ACTIVE_MODEL_ID}`;
+const IMAGE_MODEL_ID = "gpt-5.6-luna-alt";
+const IMAGE_MODEL_REF = `mock-openai/${IMAGE_MODEL_ID}`;
+const SCENARIO_MARKER = "VISION_CHANNEL_OFFLOAD";
+const FINAL_REPLY = "QA_VISION_CHANNEL_OFFLOAD_OK";
+const PROVIDER_SUMMARY =
+  "Protocol note: the attached image is split horizontally, with red on top and blue on the bottom.";
+const IMAGE_PROMPT = `Image understanding check ${SCENARIO_MARKER}: describe the top and bottom colors.`;
+const SPLIT_COLOR_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAHElEQVR4nGP4z8DwnxLMMGrAsDCAQv2jBgwPAwAxtf4Q24P5oAAAAABJRU5ErkJggg==";
+const CONVERSATION = { id: "vision-channel-offload", kind: "direct" as const };
+
+function configureVisionOffload(config: OpenClawConfig): OpenClawConfig {
+  const provider = config.models?.providers?.["mock-openai"];
+  if (!provider) {
+    throw new Error("mock-openai provider is missing from QA gateway config");
+  }
+  let foundActiveModel = false;
+  const models = provider.models.map((model) => {
+    if (model.id !== ACTIVE_MODEL_ID) {
+      return model;
+    }
+    foundActiveModel = true;
+    return { ...model, input: ["text"] as const };
+  });
+  if (!foundActiveModel) {
+    throw new Error(`active QA model is missing from provider catalog: ${ACTIVE_MODEL_ID}`);
+  }
+
+  return {
+    ...config,
+    agents: {
+      ...config.agents,
+      defaults: {
+        ...config.agents?.defaults,
+        imageModel: { primary: IMAGE_MODEL_REF },
+      },
+    },
+    models: {
+      ...config.models,
+      providers: {
+        ...config.models?.providers,
+        "mock-openai": {
+          ...provider,
+          models,
+        },
+      },
+    },
+    tools: {
+      ...config.tools,
+      media: {
+        ...config.tools?.media,
+        image: {
+          ...config.tools?.media?.image,
+          prompt: IMAGE_PROMPT,
+        },
+      },
+    },
+  };
+}
+
+async function readMockRequests(baseUrl: string, after: number) {
+  const response = await fetch(`${baseUrl}/debug/requests?after=${after}`);
+  if (!response.ok) {
+    throw new Error(
+      `mock request log failed with HTTP ${response.status}: ${await response.text()}`,
+    );
+  }
+  return (await response.json()) as MockOpenAiRequestSnapshot[];
+}
+
+describe("QA-channel vision offload", () => {
+  const cleanups: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    for (const cleanup of cleanups.splice(0).toReversed()) {
+      await cleanup();
+    }
+  });
+
+  it("summarizes an image before the text-only active model replies once", async () => {
+    const state = createQaBusState();
+    const transport = createQaChannelTransport(state);
+    const bus = await startQaBusServer({ state });
+    cleanups.push(() => bus.stop());
+
+    const mock = await startQaMockOpenAiServer();
+    cleanups.push(() => mock.stop());
+
+    const gateway = await startQaGatewayChild({
+      repoRoot: REPO_ROOT,
+      useRepoCli: true,
+      providerBaseUrl: `${mock.baseUrl}/v1`,
+      providerMode: "mock-openai",
+      primaryModel: ACTIVE_MODEL_REF,
+      alternateModel: IMAGE_MODEL_REF,
+      transport,
+      transportBaseUrl: bus.baseUrl,
+      controlUiEnabled: false,
+      mutateConfig: configureVisionOffload,
+    });
+    cleanups.push(() => gateway.stop());
+    await transport.waitReady({ gateway });
+
+    const cursorResponse = await fetch(`${mock.baseUrl}/debug/request-cursor`);
+    const cursorBody = (await cursorResponse.json()) as { cursor?: unknown };
+    expect(cursorResponse.ok).toBe(true);
+    expect(typeof cursorBody.cursor).toBe("number");
+    const requestCursor = cursorBody.cursor as number;
+
+    await transport.sendInbound({
+      accountId: "default",
+      conversation: CONVERSATION,
+      senderId: CONVERSATION.id,
+      text: `${SCENARIO_MARKER}: use the image description and reply exactly ${FINAL_REPLY}.`,
+      attachments: [
+        {
+          id: "split-color-image",
+          kind: "image",
+          mimeType: "image/png",
+          fileName: "red-top-blue-bottom.png",
+          contentBase64: SPLIT_COLOR_PNG_BASE64,
+        },
+      ],
+    });
+
+    let finalOutbound;
+    try {
+      finalOutbound = await transport.waitForOutbound({
+        conversation: CONVERSATION,
+        textIncludes: FINAL_REPLY,
+        timeoutMs: 90_000,
+      });
+    } catch (error) {
+      throw new Error(
+        [
+          error instanceof Error ? error.message : String(error),
+          `bus=${JSON.stringify(state.getSnapshot())}`,
+          `gateway=${gateway.logs()}`,
+        ].join("\n"),
+        { cause: error },
+      );
+    }
+
+    const scenarioRequests = (await readMockRequests(mock.baseUrl, requestCursor)).filter(
+      (request) => request.allInputText.includes(SCENARIO_MARKER),
+    );
+    expect(scenarioRequests).toHaveLength(2);
+
+    const [imageRequest, activeModelRequest] = scenarioRequests;
+    expect(imageRequest).toMatchObject({
+      model: IMAGE_MODEL_ID,
+      imageInputCount: expect.any(Number),
+    });
+    expect(imageRequest.imageInputCount).toBeGreaterThanOrEqual(1);
+    expect(activeModelRequest).toMatchObject({
+      model: ACTIVE_MODEL_ID,
+      imageInputCount: 0,
+    });
+    expect(activeModelRequest.cursor).toBeGreaterThan(imageRequest.cursor);
+    expect(activeModelRequest.allInputText).toContain(PROVIDER_SUMMARY);
+
+    const visibleOutbound = state
+      .getSnapshot()
+      .messages.filter(
+        (message) =>
+          message.direction === "outbound" &&
+          message.accountId === "default" &&
+          message.conversation.id === CONVERSATION.id &&
+          message.conversation.kind === CONVERSATION.kind &&
+          !message.deleted,
+      );
+    expect(visibleOutbound).toHaveLength(1);
+    expect(visibleOutbound[0]).toMatchObject({
+      id: finalOutbound.id,
+      text: FINAL_REPLY,
+    });
+  }, 180_000);
+});


### PR DESCRIPTION
## What Problem This Solves

QA-channel image summarization and text-only model offload lacked primary end-to-end ownership through the real gateway/channel path.

## Why This Change Was Made

Adds one QA scenario using the real QA bus, gateway, and QA-channel flow. It also fixes the QA harness ownership gaps exposed by that path:

- gateway children no longer inherit Vitest worker markers or `NODE_ENV=test`
- mock image understanding reads only current request instructions plus the latest image user turn, not stale transcript text
- the scenario test uses the `.e2e.test.ts` suffix required for the QA runner to select `test/vitest/vitest.e2e.config.ts`
- the latest-image-turn helper remains module-private; only the shared current-request extractor is exported

The scenario verifies:

- one image-capable summarizer request with one image
- one later text-only active-model request with zero images
- semantic red-top/blue-bottom summary insertion
- exactly one visible outbound QA-channel reply

Primary coverage:

- `media.image-summary-qa-channel`
- `media.text-only-model-media-offload`

## User Impact

No product runtime behavior changes. QA-channel media offload now has deterministic full-stack regression coverage, and QA gateway children run with a production-like process environment.

## Evidence

- Exact head: `ace1a1f4e826e80d2be0e5bb366e0cef63c910f0`
- Gateway child: `89/89` passed
- Mock provider: `234/234` passed
- Knip unused exports: production, full-tree, and script scans passed with zero entries
- QA suite: `1/1` passed
- Suite log records `--config test/vitest/vitest.e2e.config.ts`
- Formatting, repo lint wrapper, `git diff --check`, privacy scan, and exact scenario refs passed
- Evidence: `.artifacts/qa-e2e/vision-channel-offload-exact-ace1a1f-20260803/qa-evidence.json`
- LOC: production `+48/-14` (net `+34`); tests/scenario `+318/-0`

The positive production delta is the narrow owner-boundary fix: child-process test-runner isolation plus one shared current-image-request extractor used by both mock response paths.

```json
{
  "scenario": "vision-channel-offload",
  "ref": "ace1a1f4e826e80d2be0e5bb366e0cef63c910f0",
  "primaryCoverage": [
    "media.image-summary-qa-channel",
    "media.text-only-model-media-offload"
  ],
  "fullSuiteStatus": "passed"
}
```
