### PR TITLE
improve(qa): cover video generation invocation

### DIFF
--- a/qa/scenarios/media/video-generation-invocation.yaml
+++ b/qa/scenarios/media/video-generation-invocation.yaml
@@ -1,0 +1,32 @@
+title: Video generation invocation
+
+scenario:
+  id: video-generation-invocation
+  surface: media
+  category: media.media-generation
+  coverage:
+    primary:
+      - media.mode-and-provider-capability-selection
+      - media.provider-option-validation
+      - media.video-generation-tool-invocation
+  objective: Verify video_generate selects a capable mode and provider, validates provider options, and persists generated video bytes.
+  successCriteria:
+    - A real temporary image reference selects image-to-video mode through the video generation tool and runtime.
+    - A primary provider whose model capabilities reject image input is skipped without invoking it, and the configured capable fallback is selected.
+    - Declared providerOptions reach the selected provider unchanged.
+    - Unknown and wrong-typed providerOptions fail before any provider generateVideo callback runs.
+    - The selected provider returns nonempty MP4 bytes that are saved through the real media store.
+  docsRefs:
+    - docs/tools/video-generation.md
+    - docs/tools/media-overview.md
+    - docs/help/testing.md
+  codeRefs:
+    - src/agents/tools/video-generate-tool.ts
+    - src/video-generation/runtime.ts
+    - src/video-generation/capability-overlays.ts
+    - src/media/store.ts
+    - test/e2e/qa-lab/media/video-generation-invocation.e2e.test.ts
+  execution:
+    kind: vitest
+    path: test/e2e/qa-lab/media/video-generation-invocation.e2e.test.ts
+    summary: Run video_generate through deterministic prepared providers, capability fallback, provider option validation, and real media persistence.

--- a/test/e2e/qa-lab/media/video-generation-invocation.e2e.test.ts
+++ b/test/e2e/qa-lab/media/video-generation-invocation.e2e.test.ts
@@ -1,0 +1,235 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { PreparedModelRuntimeSnapshot } from "../../../../src/agents/prepared-model-runtime.js";
+import { createVideoGenerateTool } from "../../../../src/agents/tools/video-generate-tool.js";
+import type { OpenClawConfig } from "../../../../src/config/types.js";
+import { withEnvAsync } from "../../../../src/test-utils/env.js";
+import { resolveVideoGenerationMode } from "../../../../src/video-generation/capabilities.js";
+import type {
+  VideoGenerationProvider,
+  VideoGenerationRequest,
+} from "../../../../src/video-generation/types.js";
+import { createSolidPngBuffer } from "../../../helpers/image-fixtures.js";
+import { useAutoCleanupTempDirTracker } from "../../../helpers/temp-dir.js";
+
+function createMp4Fixture(): Buffer {
+  return Buffer.from([
+    0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d, 0x00, 0x00, 0x02, 0x00,
+    0x69, 0x73, 0x6f, 0x6d, 0x6d, 0x70, 0x34, 0x31,
+  ]);
+}
+
+function createPreparedRuntime(providers: VideoGenerationProvider[]): PreparedModelRuntimeSnapshot {
+  return {
+    mediaCapabilityProviders: {
+      videoGenerationProviders: providers,
+    },
+  } as unknown as PreparedModelRuntimeSnapshot;
+}
+
+function createConfig(primary: string, fallbacks: string[]): OpenClawConfig {
+  return {
+    agents: {
+      defaults: {
+        mediaModels: {
+          video: { primary, fallbacks },
+        },
+      },
+    },
+  };
+}
+
+function requireVideoTool(tool: ReturnType<typeof createVideoGenerateTool>) {
+  if (!tool) {
+    throw new Error("expected video_generate tool");
+  }
+  return tool;
+}
+
+function requireDetails(result: { details?: unknown }): Record<string, unknown> {
+  if (!result.details || typeof result.details !== "object") {
+    throw new Error("expected video generation result details");
+  }
+  return result.details as Record<string, unknown>;
+}
+
+describe("video generation invocation QA", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+  it("selects image-to-video fallback, forwards declared options, and persists video bytes", async () => {
+    const root = await fs.realpath(tempDirs.make("openclaw-qa-video-invocation-"));
+    const referenceBytes = createSolidPngBuffer(2, 2, { r: 32, g: 112, b: 224 });
+    const referencePath = path.join(root, "reference.png");
+    await fs.writeFile(referencePath, referenceBytes);
+
+    const generatedVideo = createMp4Fixture();
+    let primaryGenerateCalls = 0;
+    let fallbackRequest: VideoGenerationRequest | undefined;
+    const primaryProvider: VideoGenerationProvider = {
+      id: "qa-limited-video",
+      defaultModel: "limited-v1",
+      models: ["limited-v1"],
+      isConfigured: () => true,
+      capabilities: {
+        imageToVideo: {
+          enabled: true,
+          maxInputImages: 1,
+          providerOptions: { seed: "number", draft: "boolean" },
+        },
+      },
+      resolveModelCapabilities: async () => ({
+        imageToVideo: {
+          enabled: false,
+        },
+      }),
+      generateVideo: async () => {
+        primaryGenerateCalls += 1;
+        throw new Error("unsupported provider must be skipped before forwarding");
+      },
+    };
+    const fallbackProvider: VideoGenerationProvider = {
+      id: "qa-capable-video",
+      defaultModel: "capable-v1",
+      models: ["capable-v1"],
+      isConfigured: () => true,
+      capabilities: {
+        imageToVideo: {
+          enabled: true,
+          maxInputImages: 1,
+          providerOptions: { seed: "number", draft: "boolean" },
+        },
+      },
+      generateVideo: async (request) => {
+        fallbackRequest = request;
+        return {
+          model: request.model,
+          videos: [
+            {
+              buffer: generatedVideo,
+              mimeType: "video/mp4",
+              fileName: "provider-result.mp4",
+            },
+          ],
+        };
+      },
+    };
+    const providers = [primaryProvider, fallbackProvider];
+    const config = createConfig("qa-limited-video/limited-v1", ["qa-capable-video/capable-v1"]);
+    const providerOptions = { seed: 17, draft: true };
+
+    await withEnvAsync({ OPENCLAW_STATE_DIR: path.join(root, "state") }, async () => {
+      const tool = requireVideoTool(
+        createVideoGenerateTool({
+          config,
+          agentDir: path.join(root, "agent"),
+          workspaceDir: root,
+          preparedModelRuntime: createPreparedRuntime(providers),
+        }),
+      );
+      const result = await tool.execute("qa-video-invocation", {
+        prompt: "Animate the reference image into a short QA clip.",
+        image: referencePath,
+        imageRoles: ["first_frame"],
+        providerOptions,
+        filename: "qa-selected-video.mp4",
+      });
+      const details = requireDetails(result);
+
+      expect(primaryGenerateCalls).toBe(0);
+      expect(fallbackRequest).toMatchObject({
+        provider: "qa-capable-video",
+        model: "capable-v1",
+        providerOptions,
+      });
+      expect(
+        resolveVideoGenerationMode({
+          inputImageCount: fallbackRequest?.inputImages?.length,
+          inputVideoCount: fallbackRequest?.inputVideos?.length,
+        }),
+      ).toBe("imageToVideo");
+      expect(fallbackRequest?.inputImages).toEqual([
+        {
+          buffer: referenceBytes,
+          mimeType: "image/png",
+          fileName: "reference.png",
+          role: "first_frame",
+        },
+      ]);
+      expect(details.provider).toBe("qa-capable-video");
+      expect(details.model).toBe("capable-v1");
+      expect(details.count).toBe(1);
+      expect(details.attempts).toEqual([
+        {
+          provider: "qa-limited-video",
+          model: "limited-v1",
+          error: expect.stringContaining(
+            "does not support reference image inputs; skipping to avoid silent reference drop",
+          ),
+        },
+      ]);
+
+      const savedPaths = details.paths as string[];
+      expect(savedPaths).toHaveLength(1);
+      const savedPath = savedPaths[0];
+      if (!savedPath) {
+        throw new Error("expected saved video path");
+      }
+      const savedStat = await fs.stat(savedPath);
+      expect(savedStat.isFile()).toBe(true);
+      expect(savedStat.size).toBe(generatedVideo.byteLength);
+      await expect(fs.readFile(savedPath)).resolves.toEqual(generatedVideo);
+      expect(details.attachments).toEqual([
+        expect.objectContaining({
+          type: "video",
+          path: savedPath,
+          mimeType: "video/mp4",
+          sizeBytes: generatedVideo.byteLength,
+        }),
+      ]);
+    });
+  });
+
+  it("rejects unknown and wrong-typed provider options before provider invocation", async () => {
+    let providerCalls = 0;
+    const createProvider = (id: string, model: string): VideoGenerationProvider => ({
+      id,
+      defaultModel: model,
+      models: [model],
+      isConfigured: () => true,
+      capabilities: {
+        providerOptions: { seed: "number", draft: "boolean" },
+      },
+      generateVideo: async () => {
+        providerCalls += 1;
+        return {
+          videos: [{ buffer: createMp4Fixture(), mimeType: "video/mp4" }],
+        };
+      },
+    });
+    const providers = [
+      createProvider("qa-options-primary", "primary-v1"),
+      createProvider("qa-options-fallback", "fallback-v1"),
+    ];
+    const tool = requireVideoTool(
+      createVideoGenerateTool({
+        config: createConfig("qa-options-primary/primary-v1", ["qa-options-fallback/fallback-v1"]),
+        preparedModelRuntime: createPreparedRuntime(providers),
+      }),
+    );
+
+    await expect(
+      tool.execute("qa-video-options-unknown", {
+        prompt: "Generate a QA clip.",
+        providerOptions: { seed: 21, unknown_option: true },
+      }),
+    ).rejects.toThrow(/does not accept providerOptions keys: unknown_option/);
+    await expect(
+      tool.execute("qa-video-options-type", {
+        prompt: "Generate another QA clip.",
+        providerOptions: { seed: "twenty-one" },
+      }),
+    ).rejects.toThrow(/expects providerOptions\.seed to be a finite number, got string/);
+    expect(providerCalls).toBe(0);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Video generation mode selection, provider-option validation, and tool invocation lacked primary product-level QA ownership.

## Why This Change Was Made

Adds one scenario through the real video-generation tool/runtime path, using deterministic prepared providers and real temporary persistence, to verify:

- generation mode selection
- unsupported-capability skip and fallback
- accepted provider options reach the selected provider
- unknown and wrong-type options fail before provider invocation
- a nonempty generated video is persisted

Primary coverage:

- `media.mode-and-provider-capability-selection`
- `media.provider-option-validation`
- `media.video-generation-tool-invocation`

## User Impact

No runtime behavior changes. Provider-routing and option-contract regressions now have direct owned coverage before they reach users.

## Evidence

- Exact head: `d3cc8939ec685422931a88027c4b957c5d64786e`.
- Exact tree: `45ebb37c70f902f2f4a18226de32149fb411904f`.
- Focused product tests: 2/2 passed.
- Full QA suite: 1/1 passed in `full` evidence mode.
- All three primary coverage registrations: passed.
- `git diff --check`: passed.
- Product-runtime LOC delta: 0.
- Blacksmith Testbox: blocked locally because it is not authenticated.
- Linked local changed gate: not accepted because Node 24.13 and shared generated dependencies were stale.
- Frozen normal checkout at `554a6f3bbf6d8173efc2f1c92e30139f88dc26d6`: `pnpm tsgo:all` passed.
- Current main through `65fa1f9` is path-disjoint from this slice.
- Hosted exact-head CI must run after undraft.

```json
{
  "scenario": "video-generation-invocation",
  "ref": "d3cc8939ec685422931a88027c4b957c5d64786e",
  "tree": "45ebb37c70f902f2f4a18226de32149fb411904f",
  "primaryCoverage": [
    "media.mode-and-provider-capability-selection",
    "media.provider-option-validation",
    "media.video-generation-tool-invocation"
  ],
  "focusedPassed": 2,
  "fullSuiteStatus": "pass",
  "fullSuitePassed": 1,
  "productRuntimeLocDelta": 0,
  "hostedExactHeadCi": "pending-after-undraft"
}
```
