### PR TITLE
fix(kilocode): model discovery overstates the usable context window

### DIFF
--- a/extensions/kilocode/provider-models.test.ts
+++ b/extensions/kilocode/provider-models.test.ts
@@ -281,6 +281,59 @@ describe("discoverKilocodeModels (fetch path)", () => {
     });
   });
 
+  it("prefers the primary provider context window over the catalog-wide value", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      jsonResponse({
+        data: [
+          makeGatewayModel({
+            id: "minimax/minimax-m3",
+            context_length: 1048576,
+            top_provider: {
+              is_moderated: false,
+              context_length: 524288,
+              max_completion_tokens: 512000,
+            },
+          }),
+        ],
+      }),
+    );
+
+    await withFetchPathTest(mockFetch, async () => {
+      const models = await discoverKilocodeModels();
+
+      expect(requireModelById(models, "minimax/minimax-m3")).toMatchObject({
+        contextWindow: 524288,
+        maxTokens: 512000,
+      });
+    });
+  });
+
+  it("falls back to the catalog window when the provider window is unusable", async () => {
+    const unusable: unknown[] = [0, -1, 4096.5, Number.POSITIVE_INFINITY, null, "131072"];
+    const mockFetch = vi.fn().mockResolvedValue(
+      jsonResponse({
+        data: unusable.map((context_length, index) =>
+          makeGatewayModel({
+            id: `some/provider-window-${index}`,
+            context_length: 200000,
+            top_provider: { is_moderated: false, context_length, max_completion_tokens: 8192 },
+          }),
+        ),
+      }),
+    );
+
+    await withFetchPathTest(mockFetch, async () => {
+      const models = await discoverKilocodeModels();
+
+      for (let index = 0; index < unusable.length; index++) {
+        expect(requireModelById(models, `some/provider-window-${index}`)).toMatchObject({
+          contextWindow: 200000,
+          maxTokens: 8192,
+        });
+      }
+    });
+  });
+
   it("ensures kilo-auto/balanced is present even when API doesn't return it", async () => {
     const mockFetch = vi.fn().mockResolvedValue(
       jsonResponse({

--- a/extensions/kilocode/provider-models.ts
+++ b/extensions/kilocode/provider-models.ts
@@ -63,6 +63,7 @@ interface GatewayModelEntry {
     output_modalities?: string[];
   };
   top_provider?: {
+    context_length?: number | null;
     max_completion_tokens?: number | null;
   };
   pricing: GatewayModelPricing;
@@ -111,7 +112,11 @@ function toModelDefinition(entry: GatewayModelEntry): ModelDefinitionConfig {
       cacheRead: toPricePerMillion(entry.pricing.input_cache_read),
       cacheWrite: toPricePerMillion(entry.pricing.input_cache_write),
     },
-    contextWindow: asPositiveSafeInteger(entry.context_length) ?? KILOCODE_DEFAULT_CONTEXT_WINDOW,
+    // The primary provider window bounds real requests; the catalog-wide value can be larger.
+    contextWindow:
+      asPositiveSafeInteger(entry.top_provider?.context_length) ??
+      asPositiveSafeInteger(entry.context_length) ??
+      KILOCODE_DEFAULT_CONTEXT_WINDOW,
     maxTokens:
       asPositiveSafeInteger(entry.top_provider?.max_completion_tokens) ??
       KILOCODE_DEFAULT_MAX_TOKENS,


### PR DESCRIPTION
AI-assisted.

## What Problem This Solves

Fixes an issue where users on the Kilocode provider would get model context
windows larger than the model can actually accept, whenever the primary
provider serving that model publishes a smaller window than the catalog-wide
ceiling.

Kilocode's gateway returns an OpenRouter-shaped catalog. In it, `context_length`
is the catalog-wide ceiling across all routing candidates, while
`top_provider.context_length` describes the primary provider that actually
serves the request. Model discovery read only the catalog-wide value.

On the live public catalog this affects 33 of the 335 discovered models. The
overstatement is up to 3.8x, for example:

```
model                              catalog     primary provider
nvidia/nemotron-3-super-120b-a12b  1000000     262144
minimax/minimax-m3                 1048576     524288
thinkingmachines/inkling           1048576     524288
qwen/qwen3.6-27b                    262144     131072
z-ai/glm-5.1                        204800     200000
```

## Why This Change Was Made

Discovery now prefers `top_provider.context_length` and falls back to the
catalog-wide `context_length`, then to the existing default. This is the same
precedence already owned by `extensions/openrouter/provider-catalog.ts:197-200`,
so the two OpenRouter-shaped catalogs agree.

The same normalization was applied to `src/agents/model-scan.ts` in
`8fa1b82e42a35447482f2722df75128916d0c059` (#110855). The Kilocode reader was
not covered there; this completes it.

Completion-token handling is deliberately left unchanged. The live Kilocode
catalog exposes no top-level `max_completion_tokens` or `max_output_tokens`
field at all, so the existing `top_provider.max_completion_tokens` read is
already the only available source and adding a fallback chain would encode a
field the data never carries.

No config, Plugin SDK, protocol, persistence, migration, or feature surface
changes.

## User Impact

Kilocode models are registered with the context window the serving provider
actually offers, so context budgeting and model metadata stop overstating what
a request can use on the 33 affected models. Models whose primary provider
matches the catalog value are unchanged.

## Evidence

Live public catalog, no key and no inference call:
`curl -H "Accept: application/json" https://api.kilo.ai/api/gateway/models`
returned 346 rows; 340 carry `top_provider.context_length`.

The real catalog response was then fed through the actual
`discoverKilocodeModels()` implementation, changing only the production file
between the two runs. `registered` is the `contextWindow` discovery assigns:

Before (current `main`):

```
ROWS=346 MODELS=335 DIVERGENT=33
minimax/minimax-m3       catalog=1048576  provider=524288  registered=1048576
thinkingmachines/inkling catalog=1048576  provider=524288  registered=1048576
stepfun/step-3.7-flash   catalog=262144   provider=256000  registered=262144
qwen/qwen3.6-27b         catalog=262144   provider=131072  registered=262144
z-ai/glm-5.1             catalog=204800   provider=200000  registered=204800
```

After (this branch):

```
ROWS=346 MODELS=335 DIVERGENT=33
minimax/minimax-m3       catalog=1048576  provider=524288  registered=524288
thinkingmachines/inkling catalog=1048576  provider=524288  registered=524288
stepfun/step-3.7-flash   catalog=262144   provider=256000  registered=256000
qwen/qwen3.6-27b         catalog=262144   provider=131072  registered=131072
z-ai/glm-5.1             catalog=204800   provider=200000  registered=200000
```

Tests, run on Node 24.18.1:

- `extensions/kilocode/provider-models.test.ts`: 13/13 pass.
- Whole `extensions/kilocode/` folder: 35/35 pass across 4 files.
- Control run: with the production file reverted to `main` and the new tests
  kept, the precedence test fails with `contextWindow` 1048576 instead of
  524288, so the added coverage is load-bearing rather than self-confirming.

Regression coverage added: primary-provider precedence, and independent
fallback to the catalog-wide value when the provider value is zero, negative,
fractional, non-finite, null, or a string.

`oxfmt --check`, direct `oxlint` on both touched files, and `git diff --check`
are clean.

## Scope

Production delta: `+6/-1` in `extensions/kilocode/provider-models.ts`. Tests add
53 lines. Changelog not required: this corrects existing internal catalog
normalization without changing commands or configuration.
