### PR TITLE
test(qa): cover Plugin SDK import topology

### DIFF
--- a/qa/scenarios/plugins/plugin-public-entrypoint-contracts.yaml
+++ b/qa/scenarios/plugins/plugin-public-entrypoint-contracts.yaml
@@ -6,9 +6,15 @@ scenario:
   category: plugins.authoring-and-packaging-plugins
   coverage:
     primary:
+      - plugins.root-sdk-entrypoint
+      - plugins.focused-sdk-imports
       - plugins.entrypoint-discovery
-  objective: Verify plugin authors can discover public SDK entrypoints and support status from the maintained catalog and documentation.
+      - plugins.migration-shims
+  objective: Verify plugin authors can discover and import the supported root, focused, and migration Plugin SDK entrypoints.
   successCriteria:
+    - The supported top-level contract resolves through `openclaw/plugin-sdk/core`.
+    - Focused Plugin SDK subpaths resolve through their published package exports.
+    - Deprecated public subpaths remain importable while plugin authors migrate.
     - Every public SDK catalog entry has a published package export.
     - Private-local SDK entries stay out of published package exports.
     - Deprecated entries remain public while their support status is maintained separately.
@@ -25,4 +31,4 @@ scenario:
   execution:
     kind: vitest
     path: src/plugins/contracts/plugin-sdk-subpaths.test.ts
-    summary: Run the public SDK catalog, package export, and documentation classification contract.
+    summary: Run the Plugin SDK import topology, package export, and documentation classification contract.

--- a/src/plugins/contracts/plugin-sdk-subpaths.test.ts
+++ b/src/plugins/contracts/plugin-sdk-subpaths.test.ts
@@ -1363,8 +1363,17 @@ describe("plugin-sdk subpath exports", () => {
     >();
   });
 
-  it("keeps runtime entry subpaths importable", async () => {
+  it("keeps the supported root SDK contract importable through core", async () => {
     const coreSdk = await importResolvedPluginSdkSubpath("openclaw/plugin-sdk/core");
+
+    expect(coreSdk.definePluginEntry).toBe(coreDirectSdk.definePluginEntry);
+    expect(coreSdk.optionalStringEnum).toBe(coreDirectSdk.optionalStringEnum);
+    expect(coreSdk.prepareMemorySystemPromptAddition).toBe(
+      coreDirectSdk.prepareMemorySystemPromptAddition,
+    );
+  });
+
+  it("keeps focused SDK subpaths importable", async () => {
     const channelActionsSdk = await importResolvedPluginSdkSubpath(
       "openclaw/plugin-sdk/channel-actions",
     );
@@ -1383,11 +1392,7 @@ describe("plugin-sdk subpath exports", () => {
       representativeModules.push(await importResolvedPluginSdkSubpath(`openclaw/plugin-sdk/${id}`));
     }
 
-    expect(coreSdk.definePluginEntry).toBe(pluginEntrySdk.definePluginEntry);
-    expect(coreSdk.optionalStringEnum).toBe(coreDirectSdk.optionalStringEnum);
-    expect(coreSdk.prepareMemorySystemPromptAddition).toBe(
-      coreDirectSdk.prepareMemorySystemPromptAddition,
-    );
+    expect(pluginEntrySdk.definePluginEntry).toBe(coreDirectSdk.definePluginEntry);
     expect(channelActionsSdk.optionalStringEnum).toBe(channelActionsDirectSdk.optionalStringEnum);
     expect(channelActionsSdk.stringEnum).toBe(channelActionsDirectSdk.stringEnum);
     expectSourceMentions("error-runtime", [
@@ -1450,6 +1455,15 @@ describe("plugin-sdk subpath exports", () => {
       const mod = representativeModules[index];
       expect(typeof mod).toBe("object");
       expect(Object.keys(mod as object).length, `subpath ${id} should resolve`).toBeGreaterThan(0);
+    }
+  });
+
+  it("keeps deprecated public SDK shims importable during migrations", async () => {
+    expect(deprecatedPublicPluginSdkEntrypoints.length).toBeGreaterThan(0);
+
+    for (const subpath of deprecatedPublicPluginSdkEntrypoints) {
+      const mod = await importResolvedPluginSdkSubpath(`openclaw/plugin-sdk/${subpath}`);
+      expect(typeof mod, `deprecated subpath ${subpath} should resolve`).toBe("object");
     }
   });
 


### PR DESCRIPTION
## What Problem This Solves

Plugin SDK import topology had one broad runtime-import assertion, leaving the supported root contract, focused subpaths, and deprecated migration shims without distinct QA coverage ownership.

## Why This Change Was Made

Split the existing contract into explicit root/core, focused-subpath, and deprecated-shim assertions. Extend the existing public-entrypoint QA scenario to own the three matching taxonomy IDs without changing production exports or compatibility behavior.

## User Impact

No runtime behavior changes. Plugin authors gain durable regression coverage for the documented import paths and migration shims.

## Evidence

- `node scripts/run-vitest.mjs src/plugins/contracts/plugin-sdk-subpaths.test.ts` (`18/18` passed)
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm plugin-sdk:surface:check` (passed)
- Blacksmith Testbox `tbx_01kz4fkn5gdd9ab543ebf24feg`: private QA build plus the single `plugin-public-entrypoint-contracts` scenario passed on `e6f47f2c8a785abd1b4d7e18d5a753335eb3c3e5`; full `qa-evidence.json` records all four scenario coverage IDs as primary (18,981 ms)
- Same Blacksmith lease: exact two-path `pnpm check:changed` expanded to the fail-safe all-lanes gate and passed, including typecheck, lint, and runtime import cycles (847,614 ms)
- Testbox workflow: https://github.com/openclaw/openclaw/actions/runs/30842965021
- Fresh Sol/high autoreview: clean, zero findings, `patch is correct` (0.99)
- fresh coverage queries resolve one primary scenario for each claimed ID
- `git diff --check` (passed)

## Repair Summary

- Root cause: one broad runtime-import assertion obscured three distinct public contract classes.
- Architectural owner: the existing Plugin SDK public-entrypoint contract test and its QA scenario.
- Canonical fix: explicit assertions for supported `openclaw/plugin-sdk/core`, focused subpaths, and deprecated migration shims.
- Removed path: the broad catch-all assertion; no production, export, alias, or compatibility path changed.
- Sibling coverage: entrypoint discovery remains primary in the same scenario; the removed bare `openclaw/plugin-sdk` root remains unsupported and untested.
- Observed behavior: supported imports and migration shims resolve from the built private-QA distribution.

## Scope

- tests and QA scenario metadata only
- production LOC delta: `0`
- no package exports, SDK implementation, compatibility aliases, or taxonomy changes
