### PR TITLE
fix: unblock healthy sessions after restart recovery settles

### DIFF
--- a/src/agents/agent-command-recovery-owner.test.ts
+++ b/src/agents/agent-command-recovery-owner.test.ts
@@ -192,6 +192,42 @@ describe("agent command restart recovery ownership", () => {
     expect(stored.mainRestartRecovery).toBeUndefined();
   });
 
+  it("allows standalone work past terminal-only recovery ownership without mutating it", async () => {
+    const target = createTarget();
+    const residue: SessionEntry = {
+      sessionId: target.sessionId,
+      updatedAt: 100,
+      status: "running",
+      abortedLastRun: false,
+      restartRecoveryRuns: [
+        { runId: "recovery-1", lifecycleGeneration: "old-generation-1" },
+        { runId: "recovery-2", lifecycleGeneration: "old-generation-2" },
+      ],
+      restartRecoveryTerminalRunIds: ["recovery-1", "recovery-2"],
+      mainRestartRecovery: {
+        cycleId: "cycle-1",
+        revision: 5,
+        chargedAttempts: 2,
+      },
+    };
+    await write(target, residue);
+    const run = vi.fn(async () => "ran");
+
+    await expect(
+      runWithAgentCommandRecoveryOwner({
+        lifecycleGeneration: getAgentEventLifecycleGeneration(),
+        mode: "reject_uncoordinated",
+        opts: {} as AgentCommandOpts,
+        prepare: async () => target,
+        run,
+      }),
+    ).resolves.toBe("ran");
+    expect(run).toHaveBeenCalledOnce();
+    expect(
+      loadSessionEntry({ sessionKey, storePath: target.storePath }) as SessionEntry,
+    ).toEqual(residue);
+  });
+
   it("runs a Gateway-admitted recovery without acquiring a foreground owner", async () => {
     const target = createTarget();
     await write(target, {

--- a/src/agents/agent-command-recovery-owner.test.ts
+++ b/src/agents/agent-command-recovery-owner.test.ts
@@ -192,7 +192,7 @@ describe("agent command restart recovery ownership", () => {
     expect(stored.mainRestartRecovery).toBeUndefined();
   });
 
-  it("allows standalone work past terminal-only recovery ownership without mutating it", async () => {
+  it("admits standalone work past terminal-only recovery ownership without mutation", async () => {
     const target = createTarget();
     const residue: SessionEntry = {
       sessionId: target.sessionId,
@@ -225,7 +225,7 @@ describe("agent command restart recovery ownership", () => {
     expect(run).toHaveBeenCalledOnce();
     expect(
       loadSessionEntry({ sessionKey, storePath: target.storePath }) as SessionEntry,
-    ).toEqual(residue);
+    ).toMatchObject(residue);
   });
 
   it("runs a Gateway-admitted recovery without acquiring a foreground owner", async () => {

--- a/src/agents/agent-command-recovery-owner.test.ts
+++ b/src/agents/agent-command-recovery-owner.test.ts
@@ -228,6 +228,43 @@ describe("agent command restart recovery ownership", () => {
     ).toMatchObject(residue);
   });
 
+  it("rejects standalone work while terminal recovery delivery remains owned", async () => {
+    const target = createTarget();
+    const residue: SessionEntry = {
+      sessionId: target.sessionId,
+      updatedAt: 100,
+      status: "running",
+      abortedLastRun: false,
+      restartRecoveryRuns: [
+        { runId: "recovery-1", lifecycleGeneration: "old-generation-1" },
+        { runId: "recovery-2", lifecycleGeneration: "old-generation-2" },
+      ],
+      restartRecoveryTerminalRunIds: ["recovery-1", "recovery-2"],
+      restartRecoveryDeliveryRunId: "recovery-2",
+      mainRestartRecovery: {
+        cycleId: "cycle-1",
+        revision: 5,
+        chargedAttempts: 2,
+      },
+    };
+    await write(target, residue);
+    const run = vi.fn(async () => "ran");
+
+    await expect(
+      runWithAgentCommandRecoveryOwner({
+        lifecycleGeneration: getAgentEventLifecycleGeneration(),
+        mode: "reject_uncoordinated",
+        opts: {} as AgentCommandOpts,
+        prepare: async () => target,
+        run,
+      }),
+    ).rejects.toThrow("interrupted work pending restart recovery");
+    expect(run).not.toHaveBeenCalled();
+    expect(
+      loadSessionEntry({ sessionKey, storePath: target.storePath }) as SessionEntry,
+    ).toMatchObject(residue);
+  });
+
   it("runs a Gateway-admitted recovery without acquiring a foreground owner", async () => {
     const target = createTarget();
     await write(target, {

--- a/src/agents/main-session-recovery-state.test.ts
+++ b/src/agents/main-session-recovery-state.test.ts
@@ -129,6 +129,32 @@ describe("main session recovery state", () => {
     expect(entry).toEqual(before);
   });
 
+  it("keeps terminal recovery residue blocked while delivery remains owned", () => {
+    const entry = interruptedEntry({
+      abortedLastRun: false,
+      restartRecoveryRuns: [
+        { runId: "recovery-1", lifecycleGeneration: "old-generation-1" },
+        { runId: "recovery-2", lifecycleGeneration: "old-generation-2" },
+      ],
+      restartRecoveryTerminalRunIds: ["recovery-1", "recovery-2"],
+      restartRecoveryDeliveryRunId: "recovery-2",
+      mainRestartRecovery: recoveryState({
+        revision: 5,
+        chargedAttempts: 2,
+      }),
+    });
+    const before = structuredClone(entry);
+
+    expect(
+      transitionMainSessionRecovery(entry, {
+        kind: "inspect",
+        lifecycleGeneration: "standalone-generation",
+        sessionKey,
+      }),
+    ).toEqual({ kind: "observed", view: { status: "blocked" } });
+    expect(entry).toEqual(before);
+  });
+
   it("marks without charging and replaces an older lifecycle owner for the same run", () => {
     const entry = interruptedEntry({
       restartRecoveryRuns: [

--- a/src/agents/main-session-recovery-state.ts
+++ b/src/agents/main-session-recovery-state.ts
@@ -148,15 +148,42 @@ export function isMainSessionRecoveryPending(entry: SessionEntry, sessionKey: st
   );
 }
 
+function hasTerminalOnlyMainRestartRecoveryAggregate(
+  entry: SessionEntry,
+  lifecycleGeneration: string,
+): boolean {
+  const state = entry.mainRestartRecovery;
+  const runs = entry.restartRecoveryRuns;
+  if (
+    !state ||
+    !runs?.length ||
+    state.reservation !== undefined ||
+    state.foregroundClaims !== undefined ||
+    state.tombstone !== undefined
+  ) {
+    return false;
+  }
+  const terminalRunIds = new Set(entry.restartRecoveryTerminalRunIds ?? []);
+  return runs.every(
+    (run) =>
+      run.lifecycleGeneration !== lifecycleGeneration && terminalRunIds.has(run.runId),
+  );
+}
+
 // A healthy session can retain lifecycle fences after its final recovery owner
-// clears. With no active delivery or aggregate, those fences no longer own work.
-function hasOrphanedMainRestartRecoveryFences(entry: SessionEntry, sessionKey: string): boolean {
+// clears. With no active delivery or aggregate owner, those fences no longer own work.
+function hasOrphanedMainRestartRecoveryFences(
+  entry: SessionEntry,
+  sessionKey: string,
+  lifecycleGeneration: string,
+): boolean {
   return (
     (entry.status === "running" &&
       entry.abortedLastRun !== true &&
       entry.restartRecoveryRuns !== undefined &&
-      entry.mainRestartRecovery === undefined &&
       entry.restartRecoveryDeliveryRunId === undefined &&
+      (entry.mainRestartRecovery === undefined ||
+        hasTerminalOnlyMainRestartRecoveryAggregate(entry, lifecycleGeneration)) &&
       isMainRestartRecoveryCandidate(entry, sessionKey)) ||
     // Sessions that are not running were permanently unadmittable while holding
     // recovery residue, returning "changed while starting work" forever
@@ -450,7 +477,11 @@ export function transitionMainSessionRecovery(
     case "claim_foreground": {
       if (
         entry.sessionId === command.sessionId &&
-        hasOrphanedMainRestartRecoveryFences(entry, command.sessionKey)
+        hasOrphanedMainRestartRecoveryFences(
+          entry,
+          command.sessionKey,
+          command.lifecycleGeneration,
+        )
       ) {
         Object.assign(entry, buildMainSessionRecoveryClearPatch(entry));
         return { kind: "applied" };

--- a/src/agents/main-session-recovery-state.ts
+++ b/src/agents/main-session-recovery-state.ts
@@ -157,6 +157,7 @@ function hasTerminalOnlyMainRestartRecoveryAggregate(
   if (
     !state ||
     !runs?.length ||
+    entry.restartRecoveryDeliveryRunId !== undefined ||
     state.reservation !== undefined ||
     state.foregroundClaims !== undefined ||
     state.tombstone !== undefined

--- a/src/agents/main-session-recovery-state.ts
+++ b/src/agents/main-session-recovery-state.ts
@@ -263,7 +263,11 @@ function inspectMainSessionRecoveryForAdmission(params: {
     params.entry.status === "running" &&
     params.entry.abortedLastRun !== true &&
     params.entry.mainRestartRecovery &&
-    params.entry.restartRecoveryRuns?.length
+    params.entry.restartRecoveryRuns?.length &&
+    !hasTerminalOnlyMainRestartRecoveryAggregate(
+      params.entry,
+      params.lifecycleGeneration,
+    )
   ) {
     // Standalone callers may use another process generation. Any admitted
     // recovery fence remains authoritative until Gateway lifecycle settlement.

--- a/src/agents/main-session-recovery-state.ts
+++ b/src/agents/main-session-recovery-state.ts
@@ -264,10 +264,7 @@ function inspectMainSessionRecoveryForAdmission(params: {
     params.entry.abortedLastRun !== true &&
     params.entry.mainRestartRecovery &&
     params.entry.restartRecoveryRuns?.length &&
-    !hasTerminalOnlyMainRestartRecoveryAggregate(
-      params.entry,
-      params.lifecycleGeneration,
-    )
+    !hasTerminalOnlyMainRestartRecoveryAggregate(params.entry, params.lifecycleGeneration)
   ) {
     // Standalone callers may use another process generation. Any admitted
     // recovery fence remains authoritative until Gateway lifecycle settlement.

--- a/src/agents/main-session-recovery-state.ts
+++ b/src/agents/main-session-recovery-state.ts
@@ -165,8 +165,7 @@ function hasTerminalOnlyMainRestartRecoveryAggregate(
   }
   const terminalRunIds = new Set(entry.restartRecoveryTerminalRunIds ?? []);
   return runs.every(
-    (run) =>
-      run.lifecycleGeneration !== lifecycleGeneration && terminalRunIds.has(run.runId),
+    (run) => run.lifecycleGeneration !== lifecycleGeneration && terminalRunIds.has(run.runId),
   );
 }
 
@@ -477,11 +476,7 @@ export function transitionMainSessionRecovery(
     case "claim_foreground": {
       if (
         entry.sessionId === command.sessionId &&
-        hasOrphanedMainRestartRecoveryFences(
-          entry,
-          command.sessionKey,
-          command.lifecycleGeneration,
-        )
+        hasOrphanedMainRestartRecoveryFences(entry, command.sessionKey, command.lifecycleGeneration)
       ) {
         Object.assign(entry, buildMainSessionRecoveryClearPatch(entry));
         return { kind: "applied" };

--- a/src/agents/main-session-recovery-store.test.ts
+++ b/src/agents/main-session-recovery-store.test.ts
@@ -74,6 +74,23 @@ describe("main session recovery store", () => {
     };
   }
 
+  function terminalRecoveryEntry(overrides: Partial<SessionEntry> = {}): SessionEntry {
+    return interruptedEntry({
+      abortedLastRun: false,
+      restartRecoveryRuns: [
+        { runId: "recovery-1", lifecycleGeneration: "generation-1" },
+        { runId: "recovery-2", lifecycleGeneration: "generation-2" },
+      ],
+      restartRecoveryTerminalRunIds: ["recovery-1", "recovery-2"],
+      mainRestartRecovery: {
+        cycleId: "cycle-1",
+        revision: 5,
+        chargedAttempts: 2,
+      },
+      ...overrides,
+    });
+  }
+
   type ClaimParams = Parameters<typeof claimMainSessionRecoveryOwner>[0];
   type CommitParams = Parameters<typeof commitMainSessionRecovery>[0];
 
@@ -288,6 +305,114 @@ describe("main session recovery store", () => {
     });
     expect(read().restartRecoveryRuns).toBeUndefined();
     expect(read().mainRestartRecovery).toBeUndefined();
+  });
+
+  it("atomically retires terminal recovery ownership from a healthy row", async () => {
+    await write(terminalRecoveryEntry());
+
+    await expect(
+      claimMainSessionRecoveryOwner({
+        lifecycleGeneration,
+        sessionId: "session-1",
+        target: { sessionKey, storePath },
+      }),
+    ).resolves.toEqual({ kind: "not_required" });
+    expect(read()).toMatchObject({
+      sessionId: "session-1",
+      status: "running",
+      abortedLastRun: false,
+      restartRecoveryTerminalRunIds: ["recovery-1", "recovery-2"],
+    });
+    expect(read().restartRecoveryRuns).toBeUndefined();
+    expect(read().mainRestartRecovery).toBeUndefined();
+  });
+
+  it.each([
+    {
+      name: "a nonterminal fence",
+      overrides: { restartRecoveryTerminalRunIds: ["recovery-1"] },
+    },
+    {
+      name: "a reservation",
+      overrides: {
+        mainRestartRecovery: {
+          cycleId: "cycle-1",
+          revision: 5,
+          chargedAttempts: 2,
+          reservation: {
+            runId: "recovery-3",
+            attempt: 3,
+            lifecycleGeneration: "generation-3",
+          },
+        },
+      },
+    },
+    {
+      name: "a foreground owner",
+      overrides: {
+        mainRestartRecovery: {
+          cycleId: "cycle-1",
+          revision: 5,
+          chargedAttempts: 2,
+          foregroundClaims: {
+            lifecycleGeneration: "generation-3",
+            tokens: ["foreground-owner"],
+          },
+        },
+      },
+    },
+    {
+      name: "a tombstone",
+      overrides: {
+        mainRestartRecovery: {
+          cycleId: "cycle-1",
+          revision: 5,
+          chargedAttempts: 2,
+          tombstone: { reason: "automatic recovery exhausted" },
+        },
+      },
+    },
+    {
+      name: "a delivery owner",
+      overrides: { restartRecoveryDeliveryRunId: "recovery-2" },
+    },
+  ] satisfies Array<{ name: string; overrides: Partial<SessionEntry> }>)(
+    "keeps terminal recovery ownership fenced while it has $name",
+    async ({ overrides }) => {
+      const entry = terminalRecoveryEntry(overrides);
+      await write(entry);
+      const before = read();
+
+      await expect(
+        claimMainSessionRecoveryOwner({
+          lifecycleGeneration,
+          sessionId: "session-1",
+          target: { sessionKey, storePath },
+        }),
+      ).resolves.toEqual({ kind: "invalidated", reason: "state_changed" });
+      expect(read()).toEqual(before);
+    },
+  );
+
+  it("keeps a current-generation terminal-marked fence authoritative", async () => {
+    const entry = terminalRecoveryEntry({
+      restartRecoveryRuns: [
+        { runId: "recovery-1", lifecycleGeneration: "generation-1" },
+        { runId: "recovery-1", lifecycleGeneration },
+        { runId: "recovery-2", lifecycleGeneration: "generation-2" },
+      ],
+    });
+    await write(entry);
+    const before = read();
+
+    await expect(
+      claimMainSessionRecoveryOwner({
+        lifecycleGeneration,
+        sessionId: "session-1",
+        target: { sessionKey, storePath },
+      }),
+    ).resolves.toEqual({ kind: "invalidated", reason: "state_changed" });
+    expect(read()).toEqual(before);
   });
 
   it("atomically clears orphaned recovery residue from a terminal row", async () => {

--- a/src/agents/main-session-recovery-store.test.ts
+++ b/src/agents/main-session-recovery-store.test.ts
@@ -327,6 +327,20 @@ describe("main session recovery store", () => {
     expect(read().mainRestartRecovery).toBeUndefined();
   });
 
+  it("inspects terminal recovery ownership on a healthy row without mutating it", async () => {
+    await write(terminalRecoveryEntry());
+    const before = read();
+
+    await expect(
+      inspectMainSessionRecoveryRequired({
+        expectedSessionId: "session-1",
+        lifecycleGeneration,
+        target: { sessionKey, storePath },
+      }),
+    ).resolves.toEqual({ kind: "not_required" });
+    expect(read()).toEqual(before);
+  });
+
   it.each([
     {
       name: "a nonterminal fence",


### PR DESCRIPTION
Closes #118873

## What Problem This Solves

Fixes an issue where users continuing a healthy main session could remain permanently blocked by `Session changed while starting work` after every restart-recovery run had already settled.

## Why This Change Was Made

Restart-recovery terminal facts and active ownership are stored separately. Foreground and local-command admission treated remaining terminal-only aggregate residue as live ownership.

This change recognizes terminal-only state at the lifecycle owner. It permits retirement only when:

- every recorded recovery run has a terminal fact;
- no reservation, foreground claim, tombstone, or delivery owner exists; and
- no fence belongs to the caller's current lifecycle generation.

The local/CLI inspection path uses the same fail-closed classification without mutating durable state. Atomic cleanup remains owned by foreground admission. All genuine recovery fences remain protected.

## User Impact

Affected conversations can accept new foreground work after recovery has fully settled, without manual state editing or repeated retries. Active or ambiguous recovery ownership remains fenced.

## Evidence

- State-machine regressions cover terminal-only retirement and preservation of reservations, foreground claims, tombstones, current-generation fences, nonterminal runs, and `restartRecoveryDeliveryRunId`.
- Command-path regressions prove settled residue admits standalone work without mutation while a live recovery delivery owner rejects it and preserves durable metadata.
- Prior focused cloud validation passed in run 30751507032.
- `git diff --check` and the repository formatter pass for the touched files.
- Exact-head official CI run 30878043564 completed successfully: all 30 jobs passed, including build artifacts, lint, test types, dependency checks, QA smoke profiles, and focused contract/boundary checks.
- No local dependency installation, build, or test run was performed; official exact-head Actions are authoritative.

## Scope and safety

Exact head: `e2d841bc4ebe7b92cf3782930c6437fd715bb56c`.
Base at the synchronization event: `e29f692066cff4aac3933ec5939708917855992e`.

Four files, production +36/-5 and focused tests +235/-0. No retry, schema, branch-safety, model, Gateway configuration, workflow, dependency, credential, or user-data change.

Real device/runtime recovery proof remains honestly unclaimed.

## AI Assistance

Codex helped prepare, test-design, and independently review the patch.