### PR TITLE
fix(macos): do not synthesize approval denial on modal abort

### DIFF
--- a/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
@@ -930,10 +930,7 @@ private enum ExecHostExecutor {
                         allowAlwaysEligible: context.canPersistAllowAlways)),
                 timeoutMs: execApprovalsSocketTimeoutMs)
             else {
-                return self.errorResponse(
-                    code: "UNAVAILABLE",
-                    message: "SYSTEM_RUN_DENIED: approval prompt closed without decision",
-                    reason: "approval-cancelled")
+                return self.errorResponse(ExecHostRequestEvaluator.promptClosedError())
             }
 
             let followupDecision: ExecApprovalDecision

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
@@ -722,7 +722,7 @@ enum ExecApprovalsPromptPresenter {
         if decisions.indices.contains(selectedIndex) {
             return decisions[selectedIndex]
         }
-        return decisions.contains(.deny) ? .deny : nil
+        return nil
     }
 
     static func allowedPromptDecisions(_ request: ExecApprovalPromptRequest) -> [ExecApprovalDecision] {

--- a/apps/macos/Sources/OpenClaw/ExecHostRequestEvaluator.swift
+++ b/apps/macos/Sources/OpenClaw/ExecHostRequestEvaluator.swift
@@ -15,6 +15,13 @@ enum ExecHostPolicyDecision {
 }
 
 enum ExecHostRequestEvaluator {
+    static func promptClosedError() -> ExecHostError {
+        ExecHostError(
+            code: "UNAVAILABLE",
+            message: "SYSTEM_RUN_DENIED: approval prompt closed without decision",
+            reason: "approval-cancelled")
+    }
+
     static func validateRequest(_ request: ExecHostRequest) -> Result<ExecHostValidatedRequest, ExecHostError> {
         let approvalSource: ExecApprovalRequestSource?
         switch request.approvalSource {

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalPromptLayoutTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalPromptLayoutTests.swift
@@ -163,7 +163,7 @@ struct ExecApprovalPromptLayoutTests {
         #expect(ExecApprovalsPromptPresenter.allowedPromptDecisions(request) == [.allowOnce, .deny])
     }
 
-    @Test func `modal close does not synthesize deny when deny is unavailable`() {
+    @Test func `modal close never synthesizes an explicit decision`() {
         let closeResponse = NSApplication.ModalResponse(rawValue: 0)
 
         let withoutDeny = ExecApprovalsPromptPresenter.decision(
@@ -174,7 +174,15 @@ struct ExecApprovalPromptLayoutTests {
             decisions: [.allowOnce, .deny])
 
         #expect(withoutDeny == nil)
-        #expect(withDeny == .deny)
+        #expect(withDeny == nil)
+    }
+
+    @Test func `explicit deny button still returns deny`() {
+        let decision = ExecApprovalsPromptPresenter.decision(
+            forModalResponse: .alertSecondButtonReturn,
+            decisions: [.allowOnce, .deny])
+
+        #expect(decision == .deny)
     }
 
     @Test func `accessory view reserves nonzero alert layout space`() {

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsPromptServerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsPromptServerTests.swift
@@ -191,6 +191,30 @@ struct ExecApprovalsPromptServerTests {
     }
 
     @Test
+    func `prompt server sends no decision when presentation closes without a choice`() async throws {
+        let root = try self.makeShortSocketRoot()
+        let socketPath = root.appendingPathComponent("exec-approvals.sock").path
+        defer { try? FileManager().removeItem(at: root) }
+
+        let server = ExecApprovalsPromptServer(
+            retryDelay: .milliseconds(10),
+            resolveSocketCredentials: { (socketPath, "current-token") },
+            onPrompt: { _ in nil })
+        defer { server.stop() }
+
+        server.start()
+        #expect(await self.waitUntil { FileManager().fileExists(atPath: socketPath) })
+
+        let decision = await ExecApprovalsSocketClient.requestDecision(
+            socketPath: socketPath,
+            token: "current-token",
+            request: ExecApprovalPromptRequest(command: "echo no-decision"),
+            timeoutMs: 250)
+
+        #expect(decision == nil)
+    }
+
+    @Test
     func `prompt server restarts after its active listener stops unexpectedly`() async throws {
         let root = try self.makeShortSocketRoot()
         let socketPath = root.appendingPathComponent("exec-approvals.sock").path

--- a/apps/macos/Tests/OpenClawIPCTests/ExecHostRequestEvaluatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecHostRequestEvaluatorTests.swift
@@ -300,6 +300,15 @@ struct ExecHostRequestEvaluatorTests {
         }
     }
 
+    @Test func `closed local prompt is unavailable rather than an explicit deny`() {
+        let error = ExecHostRequestEvaluator.promptClosedError()
+
+        #expect(error.code == "UNAVAILABLE")
+        #expect(error.message == "SYSTEM_RUN_DENIED: approval prompt closed without decision")
+        #expect(error.reason == "approval-cancelled")
+        #expect(error.reason != "user-denied")
+    }
+
     @Test func `evaluate allows allow once decision on allowlist miss`() {
         let context = Self.makeContext(security: .allowlist, ask: .onMiss, allowlistSatisfied: false, skillAllow: false)
         let decision = ExecHostRequestEvaluator.evaluate(context: context, approvalDecision: .allowOnce)


### PR DESCRIPTION
Closes #118887.

## What Problem This Solves

The macOS exec-approval presenter converted any AppKit modal response outside the configured button range into .deny whenever a deny button existed. Modal abort, teardown, timeout-driven cancellation, or presentation failure could therefore be classified as if the user explicitly clicked Dont Allow.

## Why This Change Was Made

Only a response corresponding to an actual configured button produces an approval decision. Unknown and aborted responses return nil.

The two callers retain their existing fail-closed behavior:

- the approval-socket path sends no decision and closes the request, so its caller remains bounded by its existing socket/deadline behavior;
- the local Mac ExecHost path immediately returns UNAVAILABLE with reason approval-cancelled;
- a valid deny-button response still produces .deny immediately;
- allow responses are unchanged, and no failure path becomes allow.

## User Impact

Closing or losing an approval dialog is no longer reported as a deliberate user denial. Callers still fail closed, while logs and UI can distinguish an explicit Dont Allow action from an unavailable/cancelled prompt.

## Evidence

Regressions cover:

- an out-of-range modal response with and without a deny choice returns nil;
- the real second-button response still maps to .deny;
- the prompt socket sends no decision when its presenter returns nil;
- the local ExecHost cancellation contract is UNAVAILABLE / approval-cancelled and not user-denied.

Observed symptom: one real approval request was classified as denied roughly 63 ms after creation even though no usable dialog was presented. No private command, path, token, or session value is included.

The exact follow-up was not built or tested locally under the explicit machine-safety constraint; upstream macOS CI must validate this head. git diff --check passes.

## Scope

The change is limited to the AppKit response mapper, a named ExecHost cancellation error, and focused macOS tests. It does not change allow/deny policy, Gateway configuration, models, user data, workflows, signing, or packaging.

## AI Assistance

Codex helped prepare and independently review the implementation and regressions.

## Current synchronization

- Rebased candidate head: `c7ddd6ac67172d98bc1e2fd179cb4ab6b4734955`.
- Official PR base at the latest synchronization event: `6b66866fe89a1a3d35379710d42e8832de87dd56`.
- `git diff --check` passed after rebase. No local dependency install, test, or build was run; official exact-merge-head CI is authoritative.
- Official CI run 30871508590 reached Swift compilation step 1294/1347 without a compile error before GitHub canceled the macOS job. Fork authors cannot rerun official-repository jobs (`Must have admin rights`), so a maintainer rerun remains required; no no-op code commit was added merely to retrigger CI.
