### PR TITLE
fix(matrix): prevent tests from sharing host state

### DIFF
--- a/extensions/matrix/src/test-runtime.test.ts
+++ b/extensions/matrix/src/test-runtime.test.ts
@@ -1,0 +1,35 @@
+// Matrix tests cover isolated runtime state fixtures.
+import fs from "node:fs";
+import path from "node:path";
+import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
+import { describe, expect, it } from "vitest";
+import { getMatrixRuntime } from "./runtime.js";
+import { installMatrixTestRuntime } from "./test-runtime.js";
+
+describe("installMatrixTestRuntime", () => {
+  it("uses a canonical isolated state directory by default", () => {
+    installMatrixTestRuntime();
+
+    const runtime = getMatrixRuntime();
+    const stateDir = runtime.state.resolveStateDir(process.env);
+    const tempRoot = fs.realpathSync(resolvePreferredOpenClawTmpDir());
+
+    expect(stateDir).toBe(fs.realpathSync(stateDir));
+    expect(path.dirname(stateDir)).toBe(tempRoot);
+    expect(path.basename(stateDir)).toMatch(/^openclaw-matrix-test-state-/u);
+
+    const store = runtime.state.openSyncKeyedStore<string>({
+      namespace: "test-runtime",
+      maxEntries: 1,
+    });
+    store.register("state", "isolated");
+    expect(store.lookup("state")).toBe("isolated");
+  });
+
+  it("preserves an explicit state directory override", () => {
+    const stateDir = path.join(resolvePreferredOpenClawTmpDir(), "matrix-explicit-state");
+    installMatrixTestRuntime({ stateDir });
+
+    expect(getMatrixRuntime().state.resolveStateDir(process.env)).toBe(stateDir);
+  });
+});

--- a/extensions/matrix/src/test-runtime.ts
+++ b/extensions/matrix/src/test-runtime.ts
@@ -1,4 +1,6 @@
 // Matrix plugin module implements test runtime behavior.
+import fs from "node:fs";
+import path from "node:path";
 import {
   implicitMentionKindWhen,
   resolveInboundMentionDecision,
@@ -11,10 +13,26 @@ import {
   createPluginBlobStoreForTests,
   createPluginStateKeyedStoreForTests,
   createPluginStateSyncKeyedStoreForTests,
+  resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import { vi } from "vitest";
+import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
+import { afterAll, vi } from "vitest";
 import type { PluginRuntime } from "./runtime-api.js";
 import { setMatrixRuntime } from "./runtime.js";
+
+const defaultStateDir = fs.realpathSync(
+  fs.mkdtempSync(path.join(resolvePreferredOpenClawTmpDir(), "openclaw-matrix-test-state-")),
+);
+
+afterAll(() => {
+  resetPluginStateStoreForTests();
+  fs.rmSync(defaultStateDir, {
+    recursive: true,
+    force: true,
+    maxRetries: 5,
+    retryDelay: 20,
+  });
+});
 
 type MatrixTestRuntimeOptions = {
   cfg?: Record<string, unknown>;
@@ -59,16 +77,15 @@ function createMatrixRuntimeMediaMock(
 }
 
 export function installMatrixTestRuntime(options: MatrixTestRuntimeOptions = {}): void {
-  const osHomedirForTest = () => "/tmp";
+  const stateDir = options.stateDir ?? defaultStateDir;
   const defaultStateDirResolver: NonNullable<PluginRuntime["state"]>["resolveStateDir"] = (
     _env,
-    homeDir,
-  ) => options.stateDir ?? (homeDir ?? (() => "/tmp"))();
+    _homeDir,
+  ) => stateDir;
   const resolvePluginStateEnv = (storeOptions: OpenKeyedStoreOptions): NodeJS.ProcessEnv => ({
     ...(storeOptions.env ?? process.env),
     OPENCLAW_STATE_DIR:
-      storeOptions.env?.OPENCLAW_STATE_DIR?.trim() ||
-      defaultStateDirResolver(storeOptions.env, osHomedirForTest),
+      storeOptions.env?.OPENCLAW_STATE_DIR?.trim() || defaultStateDirResolver(storeOptions.env),
   });
   const getRuntimeConfig = () => options.cfg ?? {};
   const logging: PluginRuntime["logging"] | undefined = options.logging
@@ -96,7 +113,7 @@ export function installMatrixTestRuntime(options: MatrixTestRuntimeOptions = {})
       openBlobStore: (<T>(storeOptions: OpenBlobStoreOptions) =>
         createPluginBlobStoreForTests<T>("matrix", storeOptions, {
           ...process.env,
-          OPENCLAW_STATE_DIR: defaultStateDirResolver(process.env, osHomedirForTest),
+          OPENCLAW_STATE_DIR: defaultStateDirResolver(process.env),
         })) as PluginRuntime["state"]["openBlobStore"],
       openKeyedStore: (<T>(storeOptions: OpenKeyedStoreOptions) =>
         createPluginStateKeyedStoreForTests<T>("matrix", {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Matrix extension test suite could fail when another process had left a newer-schema `openclaw.sqlite` under `/tmp/state`.

## Why This Change Was Made

The Matrix test runtime now creates one canonical, realpath-resolved temporary state directory per evaluated fixture module and removes it after the file's tests finish. Explicit state-directory overrides remain unchanged, while the default runtime can no longer share `/tmp/state` across processes or test runs.

## User Impact

There is no runtime user impact. Matrix contributors and CI get deterministic, isolation-safe tests even when the host temporary directory contains unrelated OpenClaw state.

## Evidence

- Seeded `/tmp/state/openclaw.sqlite` with schema version 16 plus a sentinel file before running the suite.
- Ran `CI=1 OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test extensions/matrix -- --isolate=false` in an isolated Node 24 container.
- Result: 121 test files passed; 1,894 tests passed.
- Verified both seeded files were byte-for-byte unchanged after the suite.
- Verified no `openclaw-matrix-test-state-*` directories remained after the suite.
- `git diff --check` passed.
- Required autoreview reported no actionable findings (0.98 confidence).

The repository's changed-check router could not acquire Blacksmith Testbox or brokered AWS, so the policy-approved trusted-source fallback used a local container. Hosted PR CI remains the final independent proof before merge.

No changelog entry: test infrastructure only.
