### PR TITLE
fix: preserve new-session models through startup errors

### DIFF
--- a/src/gateway/server-methods/chat-history-handler.ts
+++ b/src/gateway/server-methods/chat-history-handler.ts
@@ -26,6 +26,7 @@ import {
   measureDiagnosticsTimelineSpan,
   measureDiagnosticsTimelineSpanSync,
 } from "../../infra/diagnostics-timeline.js";
+import { formatErrorMessage } from "../../infra/errors.js";
 import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
 import { normalizeAgentId, scopeLegacySessionKeyToAgent } from "../../routing/session-key.js";
 import { listGatewayAgentsBasic } from "../agent-list.js";
@@ -124,13 +125,13 @@ async function buildChatMetadataResult(params: {
     import("./models-list-result.js"),
     import("./commands-list-result.js"),
   ]);
-  const [models, commands] = await Promise.all([
+  const [modelsResult, commandsResult] = await Promise.allSettled([
     buildModelsListResult({
       context: params.context,
       agentId: params.agentId,
       params: { view: "configured" },
     }),
-    Promise.resolve(
+    Promise.resolve().then(() =>
       buildCommandsListResult({
         cfg: params.cfg,
         agentId: params.agentId,
@@ -139,9 +140,21 @@ async function buildChatMetadataResult(params: {
       }),
     ),
   ]);
+
+  if (modelsResult.status === "rejected") {
+    throw modelsResult.reason;
+  }
+
+  if (commandsResult.status === "rejected") {
+    params.context.logGateway.warn(
+      "chat.metadata continuing without text commands: " +
+        formatErrorMessage(commandsResult.reason),
+    );
+  }
+
   return {
-    ...models,
-    ...commands,
+    ...modelsResult.value,
+    ...(commandsResult.status === "fulfilled" ? commandsResult.value : {}),
     swarmEnabled: resolveSwarmConfig(params.cfg, params.agentId).enabled,
   };
 }

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -1707,11 +1707,11 @@ describe("gateway server chat", () => {
         agents: {
           defaults: {
             model: {
-              primary: "openai/gpt-main",
+              primary: "openai/gpt-5.6-luna",
             },
             models: {
-              "openai/gpt-main": {},
-              "openai/gpt-secondary": {},
+              "openai/gpt-5.6-luna": {},
+              "openai/gpt-5.6-terra": {},
             },
           },
           entries: {
@@ -1723,8 +1723,8 @@ describe("gateway server chat", () => {
             openai: {
               baseUrl: "https://openai.example.com/v1",
               models: [
-                { id: "gpt-main", name: "GPT Main" },
-                { id: "gpt-secondary", name: "GPT Secondary" },
+                { id: "gpt-5.6-luna", name: "GPT-5.6 Luna" },
+                { id: "gpt-5.6-terra", name: "GPT-5.6 Terra" },
               ],
             },
           },
@@ -1750,8 +1750,8 @@ describe("gateway server chat", () => {
       expect(metadata.payload?.commands).toBeUndefined();
       expect(metadata.payload?.models).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ id: "gpt-main", provider: "openai" }),
-          expect.objectContaining({ id: "gpt-secondary", provider: "openai" }),
+          expect.objectContaining({ id: "gpt-5.6-luna", provider: "openai" }),
+          expect.objectContaining({ id: "gpt-5.6-terra", provider: "openai" }),
         ]),
       );
     });

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -26,6 +26,7 @@ import type { AgentModelConfig } from "../config/types.agents-shared.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { rotateAgentEventLifecycleGeneration } from "../infra/agent-events.js";
 import { onDiagnosticEvent, type DiagnosticPayloadLargeEvent } from "../infra/diagnostic-events.js";
+import { ExecApprovalsMigrationRequiredError } from "../infra/exec-approvals-migration-gate.js";
 import {
   captureCurrentPluginMetadataSnapshotState,
   restoreCurrentPluginMetadataSnapshotState,
@@ -1697,6 +1698,80 @@ describe("gateway server chat", () => {
           }),
         ]),
       );
+    });
+  });
+
+  test("chat.metadata preserves configured models when text commands require exec approvals migration", async () => {
+    await withGatewayChatHarness(async ({ ws }) => {
+      await writeGatewayConfig({
+        agents: {
+          defaults: {
+            model: {
+              primary: "openai/gpt-main",
+            },
+            models: {
+              "openai/gpt-main": {},
+              "openai/gpt-secondary": {},
+            },
+          },
+          entries: {
+            main: { default: true },
+          },
+        },
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://openai.example.com/v1",
+              models: [
+                { id: "gpt-main", name: "GPT Main" },
+                { id: "gpt-secondary", name: "GPT Secondary" },
+              ],
+            },
+          },
+        },
+      });
+      await connectOk(ws);
+
+      const legacyExecApprovalsPath = path.join(
+        autoCleanupTempDirs.make("openclaw-chat-metadata-exec-approvals-"),
+        "exec-approvals.json",
+      );
+      const commandsListResult = await import("./server-methods/commands-list-result.js");
+      vi.spyOn(commandsListResult, "buildCommandsListResult").mockImplementationOnce(() => {
+        throw new ExecApprovalsMigrationRequiredError(legacyExecApprovalsPath);
+      });
+
+      const metadata = await rpcReq<{
+        commands?: Array<{ name?: string }>;
+        models?: Array<{ id?: string; provider?: string }>;
+      }>(ws, "chat.metadata", { agentId: "main" });
+
+      expect(metadata.ok).toBe(true);
+      expect(metadata.payload?.commands).toBeUndefined();
+      expect(metadata.payload?.models).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: "gpt-main", provider: "openai" }),
+          expect.objectContaining({ id: "gpt-secondary", provider: "openai" }),
+        ]),
+      );
+    });
+  });
+
+  test("chat.metadata remains unavailable when configured models fail", async () => {
+    await withGatewayChatHarness(async ({ ws }) => {
+      await connectOk(ws);
+      const modelsListResult = await import("./server-methods/models-list-result.js");
+      vi.spyOn(modelsListResult, "buildModelsListResult").mockRejectedValueOnce(
+        new Error("configured model catalog unavailable"),
+      );
+
+      const metadata = await rpcReq(ws, "chat.metadata", { agentId: "main" });
+
+      expect(metadata.ok).toBe(false);
+      expect(metadata.error).toMatchObject({
+        code: "UNAVAILABLE",
+        message: expect.stringContaining("configured model catalog unavailable"),
+      });
     });
   });
 

--- a/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
+++ b/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
@@ -409,6 +409,7 @@ async function createBrowserPage(
 ): Promise<{
   context: BrowserContext;
   evidenceStartIndex: number;
+  errors: string[];
   page: Page;
 }> {
   await mkdir(artifactDir, { recursive: true });
@@ -420,6 +421,8 @@ async function createBrowserPage(
   });
   openContexts.add(context);
   const page = await context.newPage();
+  const errors: string[] = [];
+  page.on("pageerror", (error) => errors.push(String(error)));
   page.setDefaultTimeout(15_000);
   const evidenceStartIndex = proxy.evidence.length;
   const response = await page.goto(withGatewayUrl(baseUrl, gatewayUrl), {
@@ -439,7 +442,7 @@ async function createBrowserPage(
   await expect
     .poll(() => proxy.evidence.length, { timeout: 15_000 })
     .toBeGreaterThan(evidenceStartIndex);
-  return { context, evidenceStartIndex, page };
+  return { context, errors, evidenceStartIndex, page };
 }
 
 async function warmControlUiSource(baseUrl: string): Promise<void> {
@@ -574,9 +577,24 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
   });
 
   it("connects through the trusted path and rejects the untrusted proxy path", async () => {
+    // A connected shell starts bootstrap RPCs that can outlive context teardown.
+    // Keep it last so those requests cannot starve the next browser interaction.
+    const rejected = await createBrowserPage(allowedUi.baseUrl, proxy.untrustedUrl);
+    const expectedReason = "trusted_proxy_missing_header_x-forwarded-proto";
+    await waitForVisibleFailure(rejected.page, "unauthorized");
+    const untrustedEvidence = await waitForConnectionEvidence(
+      (entry) => entry.route === "untrusted" && entry.gatewayResult?.ok === false,
+      rejected.evidenceStartIndex,
+    );
+    expect(untrustedEvidence.gatewayResult?.message).toContain("unauthorized");
+    expect(untrustedEvidence.gatewayResult?.errorReason).toBe(expectedReason);
+    expect(untrustedEvidence.identityInjected).toBe(false);
+    expect(untrustedEvidence.requiredHeaderInjected).toBe(false);
+    await captureChromiumScreenshot(rejected.page, "02-untrusted-proxy-rejected.png");
+    expect(rejected.errors).toEqual([]);
+    await closeContext(rejected.context);
+
     const connected = await createBrowserPage(allowedUi.baseUrl, proxy.trustedUrl);
-    const connectedErrors: string[] = [];
-    connected.page.on("pageerror", (error) => connectedErrors.push(String(error)));
     await connected.page
       .locator("openclaw-app-shell")
       .waitFor({ timeout: controlUiSettleTimeoutMs });
@@ -596,24 +614,8 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
     expect(trustedEvidence.identityInjected).toBe(true);
     expect(trustedEvidence.requiredHeaderInjected).toBe(true);
     await captureChromiumScreenshot(connected.page, "01-trusted-proxy-connected.png");
-    expect(connectedErrors).toEqual([]);
+    expect(connected.errors).toEqual([]);
     await closeContext(connected.context);
-
-    const rejected = await createBrowserPage(allowedUi.baseUrl, proxy.untrustedUrl);
-    const rejectedErrors: string[] = [];
-    rejected.page.on("pageerror", (error) => rejectedErrors.push(String(error)));
-    const expectedReason = "trusted_proxy_missing_header_x-forwarded-proto";
-    await waitForVisibleFailure(rejected.page, "unauthorized");
-    const untrustedEvidence = await waitForConnectionEvidence(
-      (entry) => entry.route === "untrusted" && entry.gatewayResult?.ok === false,
-      rejected.evidenceStartIndex,
-    );
-    expect(untrustedEvidence.gatewayResult?.message).toContain("unauthorized");
-    expect(untrustedEvidence.gatewayResult?.errorReason).toBe(expectedReason);
-    expect(untrustedEvidence.identityInjected).toBe(false);
-    expect(untrustedEvidence.requiredHeaderInjected).toBe(false);
-    await captureChromiumScreenshot(rejected.page, "02-untrusted-proxy-rejected.png");
-    expect(rejectedErrors).toEqual([]);
 
     await writeFile(
       path.join(artifactDir, "trusted-proxy-behavior.json"),
@@ -634,25 +636,7 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
   });
 
   it("confirms gatewayUrl, accepts the allowed origin, and rejects an unlisted origin", async () => {
-    const allowed = await createBrowserPage(allowedUi.baseUrl, proxy.trustedUrl);
-    const allowedErrors: string[] = [];
-    allowed.page.on("pageerror", (error) => allowedErrors.push(String(error)));
-    await allowed.page.locator("openclaw-app-shell").waitFor({ timeout: controlUiSettleTimeoutMs });
-    const allowedOrigin = new URL(allowedUi.baseUrl).origin;
-    const allowedEvidence = await waitForConnectionEvidence(
-      (entry) =>
-        entry.route === "trusted" &&
-        entry.browserOrigin === allowedOrigin &&
-        entry.gatewayResult?.ok === true,
-      allowed.evidenceStartIndex,
-    );
-    await captureChromiumScreenshot(allowed.page, "03-allowed-origin-connected.png");
-    expect(allowedErrors).toEqual([]);
-    await closeContext(allowed.context);
-
     const rejected = await createBrowserPage(rejectedUi.baseUrl, proxy.trustedUrl);
-    const rejectedErrors: string[] = [];
-    rejected.page.on("pageerror", (error) => rejectedErrors.push(String(error)));
     await waitForVisibleFailure(rejected.page, "origin not allowed");
     const rejectedOrigin = new URL(rejectedUi.baseUrl).origin;
     const rejectedEvidence = await waitForConnectionEvidence(
@@ -664,7 +648,22 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
       rejected.evidenceStartIndex,
     );
     await captureChromiumScreenshot(rejected.page, "04-rejected-origin-recovery.png");
-    expect(rejectedErrors).toEqual([]);
+    expect(rejected.errors).toEqual([]);
+    await closeContext(rejected.context);
+
+    const allowed = await createBrowserPage(allowedUi.baseUrl, proxy.trustedUrl);
+    await allowed.page.locator("openclaw-app-shell").waitFor({ timeout: controlUiSettleTimeoutMs });
+    const allowedOrigin = new URL(allowedUi.baseUrl).origin;
+    const allowedEvidence = await waitForConnectionEvidence(
+      (entry) =>
+        entry.route === "trusted" &&
+        entry.browserOrigin === allowedOrigin &&
+        entry.gatewayResult?.ok === true,
+      allowed.evidenceStartIndex,
+    );
+    await captureChromiumScreenshot(allowed.page, "03-allowed-origin-connected.png");
+    expect(allowed.errors).toEqual([]);
+    await closeContext(allowed.context);
 
     await writeFile(
       path.join(artifactDir, "allowed-origins-behavior.json"),

--- a/ui/src/e2e/new-session-page.catalog-reconnect.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.catalog-reconnect.e2e.test.ts
@@ -12,6 +12,61 @@ import {
 const suite = createNewSessionPageE2eSuite();
 
 suite.define(() => {
+  it("restores the model picker after startup-sidecars metadata becomes available", async () => {
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const recoveredModel = {
+      available: true,
+      id: "gpt-5.6-luna",
+      name: "Recovered GPT-5.6 Luna",
+      provider: "openai",
+      reasoning: true,
+    };
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "chat.metadata": {
+          sequence: [
+            {
+              __mockError: {
+                code: "UNAVAILABLE",
+                details: { reason: "startup-sidecars" },
+                message: "gateway startup sidecars are still initializing",
+                retryable: true,
+                retryAfterMs: 100,
+              },
+            },
+            { commands: [], models: [recoveredModel] },
+          ],
+        },
+      },
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}new`);
+      await expect.poll(async () => (await gateway.getRequests("chat.metadata")).length).toBe(2);
+
+      const modelSelect = page.locator(
+        '.new-session-page__composer [data-chat-model-select="true"]',
+      );
+      await modelSelect.click();
+      await page.locator('[data-chat-model-provider="openai"]').click();
+      await expect
+        .poll(() => page.locator('[data-chat-model-option="openai/gpt-5.6-luna"]').textContent())
+        .toContain(recoveredModel.name);
+
+      expect(await gateway.getRequests("chat.metadata")).toEqual([
+        expect.objectContaining({ params: { agentId: "main" } }),
+        expect.objectContaining({ params: { agentId: "main" } }),
+      ]);
+    } finally {
+      await context.close();
+    }
+  });
+
   it("creates a catalog-targeted draft with its advertised model", async () => {
     const context = await suite.browser.newContext({
       locale: "en-US",

--- a/ui/src/pages/new-session/model-control.test.ts
+++ b/ui/src/pages/new-session/model-control.test.ts
@@ -1,4 +1,9 @@
-import { describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
+  gatewayStartupUnavailableDetails,
+} from "@openclaw/gateway-client/browser";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GatewayRequestError } from "../../api/gateway.ts";
 import type { GatewayAgentRow, ModelCatalogEntry } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { NewSessionModelControl } from "./model-control.ts";
@@ -26,6 +31,20 @@ function contextWith(models: ModelCatalogEntry[], runtime = "openclaw") {
   } as unknown as ApplicationContext;
   return { context, request };
 }
+
+function startupUnavailableError(retryAfterMs = 250): GatewayRequestError {
+  return new GatewayRequestError({
+    code: "UNAVAILABLE",
+    message: "gateway startup sidecars are still initializing",
+    details: gatewayStartupUnavailableDetails(),
+    retryable: true,
+    retryAfterMs,
+  });
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe("new-session model runtime", () => {
   it("restores a browser preference only after the model and thinking level validate", async () => {
@@ -163,7 +182,9 @@ describe("new-session model runtime", () => {
       expect(request).toHaveBeenCalledWith(
         "chat.metadata",
         { agentId: "main" },
-        { signal: expect.any(AbortSignal) },
+        expect.objectContaining({
+          signal: expect.any(AbortSignal),
+        }),
       ),
     );
     await vi.waitFor(() => {
@@ -203,5 +224,132 @@ describe("new-session model runtime", () => {
     control.selected = "anthropic/sonnet-4.6";
 
     await vi.waitFor(() => expect(control.resolveAgentRuntimeId({ context })).toBeUndefined());
+  });
+
+  it("retries canonical startup-sidecars unavailability and restores the catalog", async () => {
+    vi.useFakeTimers();
+    const models: ModelCatalogEntry[] = [
+      {
+        id: "gpt-5.6-sol",
+        name: "GPT-5.6 Sol",
+        provider: "openai",
+        reasoning: true,
+      },
+      {
+        id: "gpt-5.6-terra",
+        name: "GPT-5.6 Terra",
+        provider: "openai",
+        reasoning: true,
+      },
+    ];
+    const { context, request } = contextWith(models);
+    request.mockReset();
+    request.mockRejectedValueOnce(startupUnavailableError(250)).mockResolvedValueOnce({ models });
+    const control = new NewSessionModelControl(() => undefined);
+
+    control.load(context, "main", true, {
+      preference: { model: "openai/gpt-5.6-terra", thinkingLevel: "high" },
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(request).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(249);
+    expect(request).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(control.selected).toBe("openai/gpt-5.6-terra");
+    expect(control.thinkingLevel).toBe("high");
+    expect(control.isRestoringPreference()).toBe(false);
+  });
+
+  it("does not retry other retryable UNAVAILABLE errors", async () => {
+    vi.useFakeTimers();
+    const { context, request } = contextWith([]);
+    request.mockReset();
+    request.mockRejectedValue(
+      new GatewayRequestError({
+        code: "UNAVAILABLE",
+        message: "database temporarily unavailable",
+        details: { reason: "database-busy" },
+        retryable: true,
+        retryAfterMs: 250,
+      }),
+    );
+    const control = new NewSessionModelControl(() => undefined);
+
+    control.load(context, "main", true);
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(request).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(request).toHaveBeenCalledOnce();
+  });
+
+  it("aborts a pending startup retry when the catalog task is invalidated", async () => {
+    vi.useFakeTimers();
+    const { context, request } = contextWith([]);
+    request.mockReset();
+    request.mockRejectedValue(startupUnavailableError(2_000));
+    const control = new NewSessionModelControl(() => undefined);
+
+    control.load(context, "main", true);
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(request).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(1);
+
+    control.invalidate();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(vi.getTimerCount()).toBe(0);
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(request).toHaveBeenCalledOnce();
+  });
+
+  it("stops startup-sidecars retries at the 60 second deadline", async () => {
+    vi.useFakeTimers();
+    const startedAt = Date.UTC(2026, 7, 2);
+    vi.setSystemTime(startedAt);
+    const { context, request } = contextWith([]);
+    const attemptTimes: number[] = [];
+    request.mockReset();
+    request.mockImplementation(() => {
+      attemptTimes.push(Date.now());
+      return Promise.reject(startupUnavailableError(2_000));
+    });
+    const control = new NewSessionModelControl(() => undefined);
+
+    control.load(context, "main", true);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(attemptTimes).toHaveLength(30);
+    expect(attemptTimes[0]).toBe(startedAt);
+    expect(attemptTimes.at(-1)).toBe(startedAt + 58_000);
+    expect(request).toHaveBeenNthCalledWith(
+      1,
+      "chat.metadata",
+      { agentId: "main" },
+      {
+        signal: expect.any(AbortSignal),
+        timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
+      },
+    );
+    expect(request).toHaveBeenLastCalledWith(
+      "chat.metadata",
+      { agentId: "main" },
+      {
+        signal: expect.any(AbortSignal),
+        timeoutMs: 2_000,
+      },
+    );
+    expect(vi.getTimerCount()).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(request).toHaveBeenCalledTimes(30);
   });
 });

--- a/ui/src/pages/new-session/model-control.ts
+++ b/ui/src/pages/new-session/model-control.ts
@@ -1,4 +1,8 @@
 import { initialState, Task, TaskStatus } from "@lit/task";
+import {
+  DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
+  resolveGatewayStartupRetryAfterMs,
+} from "@openclaw/gateway-client/browser";
 import type { ReactiveController, ReactiveControllerHost } from "lit";
 import type { GatewayAgentRow, GatewaySessionRow, ModelCatalogEntry } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
@@ -11,6 +15,90 @@ import { resolveChatThinkingSelectState } from "../../lib/chat/thinking.ts";
 import { normalizeAgentId } from "../../lib/sessions/session-key.ts";
 import { renderChatModelControls } from "../chat/components/chat-model-controls.ts";
 import type { NewSessionPreference } from "./preferences.ts";
+
+const NEW_SESSION_METADATA_RETRY_WINDOW_MS = 60_000;
+
+type NewSessionMetadataClient = NonNullable<ApplicationContext["gateway"]["snapshot"]["client"]>;
+
+function abortError(signal: AbortSignal): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new DOMException("New-session metadata retry aborted", "AbortError");
+}
+
+function waitForMetadataRetry(delayMs: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) {
+    return Promise.reject(abortError(signal));
+  }
+
+  return new Promise((resolve, reject) => {
+    let timer: ReturnType<typeof globalThis.setTimeout> | null = null;
+    const cleanup = () => {
+      if (timer !== null) {
+        globalThis.clearTimeout(timer);
+        timer = null;
+      }
+      signal.removeEventListener("abort", onAbort);
+    };
+    const onAbort = () => {
+      cleanup();
+      reject(abortError(signal));
+    };
+
+    signal.addEventListener("abort", onAbort, { once: true });
+    timer = globalThis.setTimeout(() => {
+      cleanup();
+      resolve();
+    }, delayMs);
+  });
+}
+
+async function requestNewSessionMetadata(
+  client: NewSessionMetadataClient,
+  agentId: string,
+  signal: AbortSignal,
+): Promise<{ models?: ModelCatalogEntry[] }> {
+  const deadlineAt = Date.now() + NEW_SESSION_METADATA_RETRY_WINDOW_MS;
+  let latestStartupError: unknown;
+
+  while (true) {
+    if (signal.aborted) {
+      throw abortError(signal);
+    }
+
+    const remainingMs = deadlineAt - Date.now();
+    if (remainingMs <= 0) {
+      if (latestStartupError !== undefined) {
+        throw latestStartupError;
+      }
+      throw new Error("New-session metadata retry deadline elapsed");
+    }
+
+    try {
+      return await client.request<{ models?: ModelCatalogEntry[] }>(
+        "chat.metadata",
+        { agentId },
+        {
+          signal,
+          timeoutMs: Math.min(DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS, remainingMs),
+        },
+      );
+    } catch (error) {
+      const retryAfterMs = resolveGatewayStartupRetryAfterMs(error);
+      if (retryAfterMs === null) {
+        throw error;
+      }
+
+      const retryRemainingMs = deadlineAt - Date.now();
+      if (retryRemainingMs <= 0) {
+        throw error;
+      }
+
+      latestStartupError = error;
+      await waitForMetadataRetry(Math.min(retryAfterMs, retryRemainingMs), signal);
+    }
+  }
+}
 
 type DraftModelTarget = {
   entry?: ModelCatalogEntry;
@@ -66,9 +154,7 @@ export class NewSessionModelControl implements ReactiveControllerHost {
     args: () =>
       [null as ApplicationContext["gateway"]["snapshot"]["client"], "" as string] as const,
     task: ([client, agentId], { signal }) =>
-      client
-        ? client.request<{ models?: ModelCatalogEntry[] }>("chat.metadata", { agentId }, { signal })
-        : initialState,
+      client ? requestNewSessionMetadata(client, agentId, signal) : initialState,
     onComplete: (result) => {
       this.catalog = Array.isArray(result.models) ? result.models : [];
       if (this.pendingSelectionGeneration === this.selectionGeneration) {

--- a/ui/src/pages/new-session/model-control.ts
+++ b/ui/src/pages/new-session/model-control.ts
@@ -59,7 +59,7 @@ async function requestNewSessionMetadata(
   signal: AbortSignal,
 ): Promise<{ models?: ModelCatalogEntry[] }> {
   const deadlineAt = Date.now() + NEW_SESSION_METADATA_RETRY_WINDOW_MS;
-  let latestStartupError: unknown;
+  let latestStartupError: Error | undefined;
 
   while (true) {
     if (signal.aborted) {
@@ -84,17 +84,21 @@ async function requestNewSessionMetadata(
         },
       );
     } catch (error) {
-      const retryAfterMs = resolveGatewayStartupRetryAfterMs(error);
+      const requestError =
+        error instanceof Error
+          ? error
+          : new Error("New-session metadata request failed", { cause: error });
+      const retryAfterMs = resolveGatewayStartupRetryAfterMs(requestError);
       if (retryAfterMs === null) {
-        throw error;
+        throw requestError;
       }
 
       const retryRemainingMs = deadlineAt - Date.now();
       if (retryRemainingMs <= 0) {
-        throw error;
+        throw requestError;
       }
 
-      latestStartupError = error;
+      latestStartupError = requestError;
       await waitForMetadataRetry(Math.min(retryAfterMs, retryRemainingMs), signal);
     }
   }


### PR DESCRIPTION
Closes #118891.
Closes #119105.
Related: #116118

## What Problem This Solves

Users opening New Session can lose their valid configured model catalog when optional text-command metadata fails or the first `chat.metadata` request arrives while Gateway startup sidecars are still initializing.

## Why This Change Was Made

The Gateway now treats configured models as required metadata and text commands as optional metadata. It captures synchronous command enumeration failures, logs them, and returns the valid model catalog without commands. Model discovery failures remain fatal.

The Control UI retries only the canonical retryable startup-sidecars `UNAVAILABLE` response. Retries respect the server delay, abort when the owning Lit task is invalidated, and stop after 60 seconds. Unrelated errors still fail immediately.

This does not weaken exec-approval migration checks, modify model configuration, or retry arbitrary failures. Direct inspection of `@lit/task` 1.0.3 confirmed that starting a new task aborts the previous signal and stale task results do not invoke completion/error callbacks.

The branch also repairs the unrelated current-main auth-transport E2E failure that blocked exact-head CI twice. Successful connected shells start background Gateway bootstrap RPCs that can outlive browser-context teardown; the test now exercises rejection paths first, runs the full connected shell last, closes every context explicitly, and captures page errors before navigation. No timeout was enlarged and no assertion was weakened.

## User Impact

New Session keeps the complete configured model catalog through unrelated command-metadata failures and recovers automatically from the bounded Gateway startup window. Real model-catalog failures remain visible.

## Evidence

Exact candidate head: `3675617a937a40b72a20c410fa3a713696cb8304`.

- [Blacksmith Testbox run 30874479489](https://github.com/openclaw/openclaw/actions/runs/30874479489), lease `tbx_01kz5ck73tzdghk3v3zdyn7e9s`:
  - `pnpm test ui/src/e2e/new-session-page.catalog-reconnect.e2e.test.ts ui/src/pages/new-session/model-control.test.ts src/gateway/server.chat.gateway-server-chat-b.test.ts`
  - 97 Gateway tests, 15 Control UI controller tests, and 5 Chromium New Session E2Es passed (117 total).
  - The new rendered-browser case passed in 753 ms, made exactly two `chat.metadata` requests for agent `main`, opened the picker, and found the uniquely recovered model.
  - `pnpm check:changed` passed the `core`, `coreTests`, and `ui` lanes.
  - `pnpm build` passed, including the production Control UI build, precompressed-asset validation, and performance guard.
- [Blacksmith Testbox run 30875380025](https://github.com/openclaw/openclaw/actions/runs/30875380025), lease `tbx_01kz5dnv26szt9mbwqcxvg76v5`: 97/97 Gateway tests passed after the final public-model fixture cleanup.
- Auth-transport CI repair ([issue #119105](https://github.com/openclaw/openclaw/issues/119105)):
  - [Constrained repro 30877133611](https://github.com/openclaw/openclaw/actions/runs/30877133611): the focused file failed under one CPU after the connected shell's bootstrap RPCs continued for 102–106 seconds.
  - [Constrained candidate 30877503163](https://github.com/openclaw/openclaw/actions/runs/30877503163): the same one-CPU command passed both scenarios; the first scenario fell from 115 seconds/failure to 11.4 seconds/pass.
- Full-branch AutoReview against `origin/main`: clean, no accepted/actionable findings, confidence 0.99.
- `git diff --check` and targeted `oxfmt --check` passed.
- Public-model identifier audit: all added model IDs resolve in official provider docs: [Luna](https://developers.openai.com/api/docs/models/gpt-5.6-luna), [Sol](https://developers.openai.com/api/docs/models/gpt-5.6-sol), and [Terra](https://developers.openai.com/api/docs/models/gpt-5.6-terra).
- Exact-head hosted CI: [run 30877888190](https://github.com/openclaw/openclaw/actions/runs/30877888190) completed with every job green except shard 2/4 job 91893046290, where the shared auth-transport E2E remained the sole failure. The independent starvation fix is tracked in #119084/#119103; its own exact-head shard passed 37/37 files and 104/104 tests.

```json
{
  "head": "3675617a937a40b72a20c410fa3a713696cb8304",
  "overall_behavior": "satisfies_contract",
  "overall_confidence": 0.98,
  "checks": {
    "optional_command_failure_preserves_models": "pass",
    "required_model_failure_remains_fatal": "pass",
    "canonical_startup_retry_count": 2,
    "rendered_recovered_model_visible": "pass",
    "noncanonical_error_no_retry": "pass",
    "task_invalidation_aborts_wait": "pass",
    "retry_deadline_60_seconds": "pass"
  },
  "blockers": []
}
```

## Scope and safety

Six files, +428/-48. Production is +110/-7; tests are +318/-41. The production growth pays for one explicit required-versus-optional Gateway owner boundary and one cancellable, deadline-bounded Control UI startup retry. The additional current-main CI repair is test-only and net-negative. No config, protocol, storage, dependency, workflow, version, signing, credential, or user-data surface changes.

AI-assisted: yes.
