### PR TITLE
fix(google): stop advertising unsupported Gemini filters

### DIFF
--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -170,6 +170,7 @@ See [Plugins](/tools/plugin) for the full plugin system guide, and [Capability m
 | `imageGenerationProviderMetadata`    | No       | `Record<string, object>`     | Cheap image-generation auth metadata for provider ids declared in `contracts.imageGenerationProviders`, including provider-owned auth aliases and base-url guards.                                                                                                                             |
 | `videoGenerationProviderMetadata`    | No       | `Record<string, object>`     | Cheap video-generation auth metadata for provider ids declared in `contracts.videoGenerationProviders`, including provider-owned auth aliases and base-url guards.                                                                                                                             |
 | `musicGenerationProviderMetadata`    | No       | `Record<string, object>`     | Cheap music-generation auth metadata for provider ids declared in `contracts.musicGenerationProviders`, including provider-owned auth aliases and base-url guards.                                                                                                                             |
+| `webSearchProviderMetadata`          | No       | `Record<string, object>`     | Cheap web-search auth/config metadata for provider ids declared in `contracts.webSearchProviders`. It can describe provider-owned credential fallbacks without importing provider runtime.                                                                                                     |
 | `toolMetadata`                       | No       | `Record<string, object>`     | Cheap availability metadata for plugin-owned tools declared in `contracts.tools`. Use it when a tool should not load runtime unless config, env, or auth evidence exists.                                                                                                                      |
 | `channelConfigs`                     | No       | `Record<string, object>`     | Manifest-owned channel config metadata merged into discovery and validation surfaces before runtime loads.                                                                                                                                                                                     |
 | `skills`                             | No       | `string[]`                   | Skill directories to load, relative to the plugin root.                                                                                                                                                                                                                                        |
@@ -250,11 +251,11 @@ The manifest ids are plugin-local. Widget grants use `<plugin-id>.<id>`, such as
 | `featured` | `boolean` | Whether catalog surfaces should feature this plugin.                       |
 | `order`    | `number`  | Ascending display hint among curated plugins; lower values appear earlier. |
 
-## Generation provider metadata reference
+## Capability provider metadata reference
 
-The generation provider metadata fields describe static auth signals for providers declared in the matching `contracts.*GenerationProviders` list. OpenClaw reads these fields before provider runtime loads so core tools can decide whether a generation provider is available without importing every provider plugin.
+The image, video, music, and web-search provider metadata fields describe static auth/config signals for providers declared in the matching `contracts.*Providers` list. OpenClaw reads these fields before provider runtime loads so core tools can decide whether a capability provider is available without importing every provider plugin.
 
-Use these fields only for cheap, declarative facts. Transport, request transforms, token refresh, credential validation, and actual generation behavior stay in the plugin runtime.
+Use these fields only for cheap, declarative facts. Transport, request transforms, token refresh, credential validation, and actual capability behavior stay in the plugin runtime. Metadata never bypasses the owning plugin's enablement, allowlist, denylist, or installed-plugin policy.
 
 ```json
 {
@@ -289,6 +290,28 @@ Use these fields only for cheap, declarative facts. Transport, request transform
             "defaultBaseUrl": "https://api.example.com/v1",
             "allowedBaseUrls": ["https://api.example.com/v1"]
           }
+        }
+      ]
+    }
+  }
+}
+```
+
+Web-search providers use the same `configSignals` shape. For example, a provider
+that can reuse a configured model-provider API key can declare that fallback
+without making core load or special-case its runtime:
+
+```json
+{
+  "contracts": {
+    "webSearchProviders": ["example-search"]
+  },
+  "webSearchProviderMetadata": {
+    "example-search": {
+      "configSignals": [
+        {
+          "rootPath": "models.providers.example",
+          "required": ["apiKey"]
         }
       ]
     }

--- a/extensions/google/openclaw.plugin.json
+++ b/extensions/google/openclaw.plugin.json
@@ -757,6 +757,16 @@
       "nativeDocumentInputs": ["pdf"]
     }
   },
+  "webSearchProviderMetadata": {
+    "gemini": {
+      "configSignals": [
+        {
+          "rootPath": "models.providers.google",
+          "required": ["apiKey"]
+        }
+      ]
+    }
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/extensions/google/src/gemini-web-search-provider.ts
+++ b/extensions/google/src/gemini-web-search-provider.ts
@@ -27,8 +27,6 @@ const GEMINI_TOOL_PARAMETERS = {
       minimum: 1,
       maximum: 10,
     },
-    country: { type: "string", description: "Not supported by Gemini." },
-    language: { type: "string", description: "Not supported by Gemini." },
     freshness: {
       type: "string",
       description:

--- a/extensions/google/src/gemini-web-search-provider.ts
+++ b/extensions/google/src/gemini-web-search-provider.ts
@@ -117,7 +117,6 @@ export function createGeminiWebSearchProvider(): WebSearchProviderPlugin {
     id: "gemini",
     label: "Gemini (Google Search)",
     hint: "Requires Google Gemini API key · Google Search grounding",
-    modelParameters: GEMINI_TOOL_PARAMETERS,
     onboardingScopes: ["text-inference"],
     credentialLabel: "Google Gemini API key",
     envVars: ["GEMINI_API_KEY"],

--- a/extensions/google/src/gemini-web-search-provider.ts
+++ b/extensions/google/src/gemini-web-search-provider.ts
@@ -117,6 +117,7 @@ export function createGeminiWebSearchProvider(): WebSearchProviderPlugin {
     id: "gemini",
     label: "Gemini (Google Search)",
     hint: "Requires Google Gemini API key · Google Search grounding",
+    modelParameters: GEMINI_TOOL_PARAMETERS,
     onboardingScopes: ["text-inference"],
     credentialLabel: "Google Gemini API key",
     envVars: ["GEMINI_API_KEY"],

--- a/extensions/google/web-search-provider.test.ts
+++ b/extensions/google/web-search-provider.test.ts
@@ -108,7 +108,8 @@ afterEach(() => {
 
 describe("google web search provider", () => {
   it("does not advertise Gemini filters that the provider cannot execute", () => {
-    const tool = createGeminiWebSearchProvider().createTool({
+    const provider = createGeminiWebSearchProvider();
+    const tool = provider.createTool({
       config: {},
       searchConfig: { provider: "gemini" },
     });
@@ -122,6 +123,7 @@ describe("google web search provider", () => {
     expect(parameters.properties).toBeDefined();
     expect(parameters.properties).not.toHaveProperty("country");
     expect(parameters.properties).not.toHaveProperty("language");
+    expect(provider.modelParameters).toBe(tool.parameters);
   });
 
   it.each([

--- a/extensions/google/web-search-provider.test.ts
+++ b/extensions/google/web-search-provider.test.ts
@@ -107,6 +107,52 @@ afterEach(() => {
 });
 
 describe("google web search provider", () => {
+  it("does not advertise Gemini filters that the provider cannot execute", () => {
+    const tool = createGeminiWebSearchProvider().createTool({
+      config: {},
+      searchConfig: { provider: "gemini" },
+    });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    const parameters = tool.parameters as {
+      properties?: Record<string, unknown>;
+    };
+    expect(parameters.properties).toBeDefined();
+    expect(parameters.properties).not.toHaveProperty("country");
+    expect(parameters.properties).not.toHaveProperty("language");
+  });
+
+  it.each([
+    ["country", "us", "unsupported_country"],
+    ["language", "en", "unsupported_language"],
+  ])("keeps crafted unsupported %s filters rejected at runtime", async (filter, value, error) => {
+    const mockFetch = installGeminiFetch();
+    const tool = createGeminiWebSearchProvider().createTool({
+      config: {
+        plugins: {
+          entries: {
+            google: {
+              config: {
+                webSearch: { apiKey: "AIza-plugin-test" },
+              },
+            },
+          },
+        },
+      },
+      searchConfig: { provider: "gemini" },
+    });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    await expect(tool.execute({ query: "OpenClaw docs", [filter]: value })).resolves.toMatchObject({
+      error,
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it("points missing-key users to fetch/browser alternatives", async () => {
     await withEnvAsync({ GEMINI_API_KEY: undefined }, async () => {
       const provider = createGeminiWebSearchProvider();

--- a/extensions/google/web-search-provider.test.ts
+++ b/extensions/google/web-search-provider.test.ts
@@ -123,7 +123,6 @@ describe("google web search provider", () => {
     expect(parameters.properties).toBeDefined();
     expect(parameters.properties).not.toHaveProperty("country");
     expect(parameters.properties).not.toHaveProperty("language");
-    expect(provider.modelParameters).toBe(tool.parameters);
   });
 
   it.each([

--- a/src/agents/agent-tool-metadata.ts
+++ b/src/agents/agent-tool-metadata.ts
@@ -5,6 +5,27 @@ import { copyChannelAgentToolMeta } from "./channel-tool-metadata.js";
 import { copyCodeModeControlToolIdentity } from "./code-mode-control-tools.js";
 import { copyToolTerminalPresentation } from "./tool-terminal-presentation.js";
 
+/** Preserve a live parameter-schema accessor across wrappers that spread a tool. */
+export function copyAgentToolParameterAccessor<T extends AnyAgentTool>(
+  source: AnyAgentTool,
+  target: T,
+): T {
+  const sourceDescriptor = Object.getOwnPropertyDescriptor(source, "parameters");
+  if (!sourceDescriptor?.get) {
+    return target;
+  }
+  const targetDescriptor = Object.getOwnPropertyDescriptor(target, "parameters");
+  if (targetDescriptor?.get || targetDescriptor?.set) {
+    return target;
+  }
+  Object.defineProperty(target, "parameters", {
+    configurable: true,
+    enumerable: sourceDescriptor.enumerable,
+    get: () => source.parameters,
+  });
+  return target;
+}
+
 /**
  * Preserve identity-backed tool metadata that object spread cannot carry.
  * Losing it detaches policy, hooks, presentation, and control-flow ownership.
@@ -18,5 +39,5 @@ export function copyAgentToolMetadata<T extends AnyAgentTool>(source: AnyAgentTo
   copyBeforeToolCallHookMarker(source, target);
   copyToolTerminalPresentation(source, target);
   copyCodeModeControlToolIdentity(source, target);
-  return target;
+  return copyAgentToolParameterAccessor(source, target);
 }

--- a/src/agents/agent-tools.before-tool-call.wrapper.ts
+++ b/src/agents/agent-tools.before-tool-call.wrapper.ts
@@ -14,6 +14,7 @@ import {
 } from "../infra/diagnostic-trace-context.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
 import { copyPluginToolMeta, getPluginToolMeta } from "../plugins/tools.js";
+import { copyAgentToolParameterAccessor } from "./agent-tool-metadata.js";
 import {
   buildToolContentPrivateData,
   emitSkillUsedDiagnostic,
@@ -604,6 +605,7 @@ export function wrapToolWithBeforeToolCallHook(
   copyPluginToolMeta(tool, wrappedTool);
   copyChannelAgentToolMeta(tool as never, wrappedTool as never);
   copyToolTerminalPresentation(tool, wrappedTool);
+  copyAgentToolParameterAccessor(tool, wrappedTool);
   Object.defineProperty(wrappedTool, BEFORE_TOOL_CALL_WRAPPED, {
     value: true,
     enumerable: true,
@@ -645,6 +647,7 @@ export function rewrapToolWithBeforeToolCallHook(
     ...tool,
     execute: sourceTool.execute,
   };
+  copyAgentToolParameterAccessor(tool, rewrapSource);
   delete (rewrapSource as unknown as Record<symbol, unknown>)[BEFORE_TOOL_CALL_WRAPPED];
   copyPluginToolMeta(tool, rewrapSource);
   copyChannelAgentToolMeta(tool as never, rewrapSource as never);

--- a/src/agents/agent-tools.schema.test.ts
+++ b/src/agents/agent-tools.schema.test.ts
@@ -886,6 +886,25 @@ describe("normalizeToolParameters", () => {
     expect(tagged[beforeToolCallTesting.BEFORE_TOOL_CALL_HOOK_CONTEXT]).toBe(hookContext);
   });
 
+  it("preserves accessor-backed schemas instead of snapshotting them", () => {
+    let currentParameters: TSchema = Type.Object({ stale: Type.String() });
+    const tool: AnyAgentTool = {
+      name: "dynamic_tool",
+      label: "Dynamic Tool",
+      description: "test",
+      get parameters() {
+        return currentParameters;
+      },
+      execute: vi.fn(),
+    };
+
+    const normalized = normalizeToolParameters(tool);
+    expect(normalized.parameters).toEqual(Type.Object({ stale: Type.String() }));
+
+    currentParameters = Type.Object({ fresh: Type.String() });
+    expect(normalized.parameters).toEqual(Type.Object({ fresh: Type.String() }));
+  });
+
   it("normalizes truly empty schemas to type:object with properties:{} (MCP parameter-free tools)", () => {
     const tool: AnyAgentTool = {
       name: "get_flux_instance",

--- a/src/agents/agent-tools.schema.ts
+++ b/src/agents/agent-tools.schema.ts
@@ -73,6 +73,28 @@ export function normalizeToolParameters(
   if (!schema) {
     return tool;
   }
+  const parameterDescriptor = Object.getOwnPropertyDescriptor(tool, "parameters");
+  if (parameterDescriptor?.get || parameterDescriptor?.set) {
+    const readNormalizedParameters = () => {
+      const current = tool.parameters;
+      return current && typeof current === "object"
+        ? normalizeToolParameterSchema(current as Record<string, unknown>, options)
+        : current;
+    };
+    return copyAgentToolMetadata(tool, {
+      ...tool,
+      prepareArguments: (args: unknown) => {
+        const prepared = tool.prepareArguments ? tool.prepareArguments(args) : args;
+        return isObjectSchemaWithNoRequiredParams(readNormalizedParameters()) &&
+          (prepared === null || prepared === undefined)
+          ? {}
+          : prepared;
+      },
+      get parameters() {
+        return readNormalizedParameters();
+      },
+    });
+  }
   const parameters = normalizeToolParameterSchema(schema, options);
   return copyAgentToolMetadata(tool, {
     ...tool,

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -4,6 +4,7 @@
  * Runs the configured runtime provider and returns normalized cached search results.
  */
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { getActivePluginRegistry } from "../../plugins/runtime.js";
 import { assertSecretOwnerAvailable } from "../../secrets/runtime-degraded-state.js";
 import { runtimeWebSecretOwnerId } from "../../secrets/runtime-web-secret-owner.js";
 import type { RuntimeWebSearchMetadata } from "../../secrets/runtime-web-tools.types.js";
@@ -90,15 +91,53 @@ function isWebSearchDisabled(config?: OpenClawConfig): boolean {
   return Boolean(search && typeof search === "object" && search.enabled === false);
 }
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function hasConfiguredWebSearchProviderSignal(config?: OpenClawConfig): boolean {
+  const pluginEntries = config?.plugins?.entries ?? {};
+  const hasPluginSearchConfig = Object.values(pluginEntries).some((entry) => {
+    const pluginConfig = asRecord(entry?.config);
+    return asRecord(pluginConfig?.webSearch) !== null;
+  });
+  if (hasPluginSearchConfig) {
+    return true;
+  }
+
+  // Gemini web search explicitly accepts the Google model provider API key as
+  // a credential fallback, even when plugin-owned web-search config is absent.
+  return asRecord(config?.models?.providers?.google)?.apiKey !== undefined;
+}
+
+function shouldResolveWebSearchModelParameters(params: {
+  config?: OpenClawConfig;
+  providerSelectionId: string;
+}): boolean {
+  return Boolean(
+    params.providerSelectionId.trim() ||
+    getActivePluginRegistry()?.webSearchProviders.length ||
+    hasConfiguredWebSearchProviderSignal(params.config),
+  );
+}
+
 function resolveWebSearchModelParameters(
   options: WebSearchToolOptions | undefined,
 ): AnyAgentTool["parameters"] {
-  const { config, preferRuntimeProviders, runtimeWebSearch } =
+  const { config, preferRuntimeProviders, providerSelectionId, runtimeWebSearch } =
     resolveWebSearchToolRuntimeContext({
       config: options?.config,
       lateBindRuntimeConfig: options?.lateBindRuntimeConfig,
       runtimeWebSearch: options?.runtimeWebSearch,
     });
+  // A generic schema read must not trigger an unscoped plugin source load. A
+  // selected, registered, or config-backed provider still resolves through the
+  // same candidate path as execution so metadata-free auto-detection works.
+  if (!shouldResolveWebSearchModelParameters({ config, providerSelectionId })) {
+    return WebSearchSchema;
+  }
   return (
     resolveWebSearchDefinition({
       config,

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -5,6 +5,7 @@
  */
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { getActivePluginRegistry } from "../../plugins/runtime.js";
+import { hasConfiguredWebSearchCredential } from "../../plugins/web-search-credential-presence.js";
 import { assertSecretOwnerAvailable } from "../../secrets/runtime-degraded-state.js";
 import { runtimeWebSecretOwnerId } from "../../secrets/runtime-web-secret-owner.js";
 import type { RuntimeWebSearchMetadata } from "../../secrets/runtime-web-tools.types.js";
@@ -98,18 +99,19 @@ function asRecord(value: unknown): Record<string, unknown> | null {
 }
 
 function hasConfiguredWebSearchProviderSignal(config?: OpenClawConfig): boolean {
-  const pluginEntries = config?.plugins?.entries ?? {};
-  const hasPluginSearchConfig = Object.values(pluginEntries).some((entry) => {
-    const pluginConfig = asRecord(entry?.config);
-    return asRecord(pluginConfig?.webSearch) !== null;
-  });
-  if (hasPluginSearchConfig) {
+  const resolvedConfig = config ?? {};
+  if (
+    hasConfiguredWebSearchCredential({
+      config: resolvedConfig,
+      env: process.env,
+    })
+  ) {
     return true;
   }
 
   // Gemini web search explicitly accepts the Google model provider API key as
   // a credential fallback, even when plugin-owned web-search config is absent.
-  return asRecord(config?.models?.providers?.google)?.apiKey !== undefined;
+  return asRecord(resolvedConfig.models?.providers?.google)?.apiKey !== undefined;
 }
 
 function shouldResolveWebSearchModelParameters(params: {

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -4,7 +4,6 @@
  * Runs the configured runtime provider and returns normalized cached search results.
  */
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { getActivePluginRegistry } from "../../plugins/runtime.js";
 import { assertSecretOwnerAvailable } from "../../secrets/runtime-degraded-state.js";
 import { runtimeWebSecretOwnerId } from "../../secrets/runtime-web-secret-owner.js";
 import type { RuntimeWebSearchMetadata } from "../../secrets/runtime-web-tools.types.js";
@@ -12,7 +11,7 @@ import {
   truncateSanitizedExternalContent,
   wrapWebContent,
 } from "../../security/external-content.js";
-import { runWebSearch } from "../../web-search/runtime.js";
+import { resolveWebSearchDefinition, runWebSearch } from "../../web-search/runtime.js";
 import type { AnyAgentTool } from "./common.js";
 import { asToolParamsRecord, jsonResult, textResult } from "./common.js";
 import { normalizeWebSearchOutput, WebSearchOutputSchema } from "./web-search-output.js";
@@ -94,19 +93,24 @@ function isWebSearchDisabled(config?: OpenClawConfig): boolean {
 function resolveWebSearchModelParameters(
   options: WebSearchToolOptions | undefined,
 ): AnyAgentTool["parameters"] {
-  const { providerSelectionId } = resolveWebSearchToolRuntimeContext({
-    config: options?.config,
-    lateBindRuntimeConfig: options?.lateBindRuntimeConfig,
-    runtimeWebSearch: options?.runtimeWebSearch,
-  });
-  const providerId = providerSelectionId.trim().toLowerCase();
-  if (!providerId) {
+  const { config, preferRuntimeProviders, providerSelectionId, runtimeWebSearch } =
+    resolveWebSearchToolRuntimeContext({
+      config: options?.config,
+      lateBindRuntimeConfig: options?.lateBindRuntimeConfig,
+      runtimeWebSearch: options?.runtimeWebSearch,
+    });
+  if (!providerSelectionId.trim()) {
     return WebSearchSchema;
   }
-  const selectedProvider = getActivePluginRegistry()?.webSearchProviders.find(
-    (entry) => entry.provider.id.trim().toLowerCase() === providerId,
-  )?.provider;
-  return selectedProvider?.modelParameters ?? WebSearchSchema;
+  return (
+    resolveWebSearchDefinition({
+      config,
+      agentDir: options?.agentDir,
+      sandboxed: options?.sandboxed,
+      runtimeWebSearch,
+      preferRuntimeProviders,
+    })?.definition.parameters ?? WebSearchSchema
+  );
 }
 
 /** Creates the `web_search` tool, or `null` when web search is disabled by config. */

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -93,15 +93,12 @@ function isWebSearchDisabled(config?: OpenClawConfig): boolean {
 function resolveWebSearchModelParameters(
   options: WebSearchToolOptions | undefined,
 ): AnyAgentTool["parameters"] {
-  const { config, preferRuntimeProviders, providerSelectionId, runtimeWebSearch } =
+  const { config, preferRuntimeProviders, runtimeWebSearch } =
     resolveWebSearchToolRuntimeContext({
       config: options?.config,
       lateBindRuntimeConfig: options?.lateBindRuntimeConfig,
       runtimeWebSearch: options?.runtimeWebSearch,
     });
-  if (!providerSelectionId.trim()) {
-    return WebSearchSchema;
-  }
   return (
     resolveWebSearchDefinition({
       config,
@@ -124,7 +121,7 @@ export function createWebSearchTool(options?: WebSearchToolOptions): AnyAgentToo
     name: "web_search",
     resultContentSource: "network",
     description:
-      "Search current web; normalized provider results. Supports freshness and date-range filters (freshness, date_after/date_before) and domain filtering (domain_filter).",
+      "Search current web and return normalized provider results. Available filters depend on the active provider.",
     get parameters() {
       return resolveWebSearchModelParameters(options);
     },

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -4,6 +4,7 @@
  * Runs the configured runtime provider and returns normalized cached search results.
  */
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { getActivePluginRegistry } from "../../plugins/runtime.js";
 import { assertSecretOwnerAvailable } from "../../secrets/runtime-degraded-state.js";
 import { runtimeWebSecretOwnerId } from "../../secrets/runtime-web-secret-owner.js";
 import type { RuntimeWebSearchMetadata } from "../../secrets/runtime-web-tools.types.js";
@@ -76,20 +77,40 @@ const WebSearchSchema = {
   },
 } satisfies Record<string, unknown>;
 
-function isWebSearchDisabled(config?: OpenClawConfig): boolean {
-  const search = config?.tools?.web?.search;
-  return Boolean(search && typeof search === "object" && search.enabled === false);
-}
-
-/** Creates the `web_search` tool, or `null` when web search is disabled by config. */
-export function createWebSearchTool(options?: {
+type WebSearchToolOptions = {
   config?: OpenClawConfig;
   enabled?: boolean;
   agentDir?: string;
   sandboxed?: boolean;
   runtimeWebSearch?: RuntimeWebSearchMetadata;
   lateBindRuntimeConfig?: boolean;
-}): AnyAgentTool | null {
+};
+
+function isWebSearchDisabled(config?: OpenClawConfig): boolean {
+  const search = config?.tools?.web?.search;
+  return Boolean(search && typeof search === "object" && search.enabled === false);
+}
+
+function resolveWebSearchModelParameters(
+  options: WebSearchToolOptions | undefined,
+): AnyAgentTool["parameters"] {
+  const { providerSelectionId } = resolveWebSearchToolRuntimeContext({
+    config: options?.config,
+    lateBindRuntimeConfig: options?.lateBindRuntimeConfig,
+    runtimeWebSearch: options?.runtimeWebSearch,
+  });
+  const providerId = providerSelectionId.trim().toLowerCase();
+  if (!providerId) {
+    return WebSearchSchema;
+  }
+  const selectedProvider = getActivePluginRegistry()?.webSearchProviders.find(
+    (entry) => entry.provider.id.trim().toLowerCase() === providerId,
+  )?.provider;
+  return selectedProvider?.modelParameters ?? WebSearchSchema;
+}
+
+/** Creates the `web_search` tool, or `null` when web search is disabled by config. */
+export function createWebSearchTool(options?: WebSearchToolOptions): AnyAgentTool | null {
   if (options?.enabled === false || isWebSearchDisabled(options?.config)) {
     return null;
   }
@@ -100,7 +121,9 @@ export function createWebSearchTool(options?: {
     resultContentSource: "network",
     description:
       "Search current web; normalized provider results. Supports freshness and date-range filters (freshness, date_after/date_before) and domain filtering (domain_filter).",
-    parameters: WebSearchSchema,
+    get parameters() {
+      return resolveWebSearchModelParameters(options);
+    },
     outputSchema: WebSearchOutputSchema,
     execute: async (_toolCallId, args, signal) => {
       // Late binding lets long-lived agents pick up runtime web-search credentials/config without

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -92,26 +92,12 @@ function isWebSearchDisabled(config?: OpenClawConfig): boolean {
   return Boolean(search && typeof search === "object" && search.enabled === false);
 }
 
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return value !== null && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
-
 function hasConfiguredWebSearchProviderSignal(config?: OpenClawConfig): boolean {
   const resolvedConfig = config ?? {};
-  if (
-    hasConfiguredWebSearchCredential({
-      config: resolvedConfig,
-      env: process.env,
-    })
-  ) {
-    return true;
-  }
-
-  // Gemini web search explicitly accepts the Google model provider API key as
-  // a credential fallback, even when plugin-owned web-search config is absent.
-  return asRecord(resolvedConfig.models?.providers?.google)?.apiKey !== undefined;
+  return hasConfiguredWebSearchCredential({
+    config: resolvedConfig,
+    env: process.env,
+  });
 }
 
 function shouldResolveWebSearchModelParameters(params: {

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -230,6 +230,79 @@ describe("web tools defaults", () => {
     expect(createTool).toHaveBeenCalledOnce();
   });
 
+  it("resolves an auto-detected provider schema when runtime metadata is absent", () => {
+    const registry = createEmptyPluginRegistry();
+    const braveParameters = {
+      type: "object",
+      required: ["query"],
+      properties: {
+        query: { type: "string" },
+        country: { type: "string" },
+      },
+    };
+    const braveCreateTool = vi.fn(() => ({
+      description: "Brave runtime tool",
+      parameters: braveParameters,
+      execute: async () => ({ query: "openclaw", results: [] }),
+    }));
+    const fallbackCreateTool = vi.fn(() => ({
+      description: "Fallback runtime tool",
+      parameters: {
+        type: "object",
+        required: ["query"],
+        properties: { query: { type: "string" } },
+      },
+      execute: async () => ({ query: "openclaw", results: [] }),
+    }));
+    registry.webSearchProviders.push(
+      {
+        pluginId: "brave",
+        pluginName: "Brave Search",
+        source: "test",
+        provider: {
+          id: "brave",
+          label: "Brave Search",
+          hint: "Runtime provider",
+          envVars: [],
+          placeholder: "brave-...",
+          signupUrl: "https://example.com/brave",
+          autoDetectOrder: 1,
+          credentialPath: "tools.web.search.brave.apiKey",
+          getCredentialValue: () => "configured",
+          getConfiguredCredentialValue: () => "configured",
+          setCredentialValue: () => {},
+          createTool: braveCreateTool,
+        },
+      },
+      {
+        pluginId: "google",
+        pluginName: "Gemini Search",
+        source: "test",
+        provider: {
+          id: "gemini",
+          label: "Gemini Search",
+          hint: "Runtime provider",
+          envVars: [],
+          placeholder: "gemini-...",
+          signupUrl: "https://example.com/gemini",
+          autoDetectOrder: 2,
+          credentialPath: "tools.web.search.gemini.apiKey",
+          getCredentialValue: () => "configured",
+          getConfiguredCredentialValue: () => "configured",
+          setCredentialValue: () => {},
+          createTool: fallbackCreateTool,
+        },
+      },
+    );
+    setActivePluginRegistry(registry);
+
+    const tool = createWebSearchTool({ config: {} });
+
+    expect(tool?.parameters).toBe(braveParameters);
+    expect(braveCreateTool).toHaveBeenCalledOnce();
+    expect(fallbackCreateTool).not.toHaveBeenCalled();
+  });
+
   it("late-binds the model schema to the current selected provider", () => {
     const registry = createEmptyPluginRegistry();
     const staleParameters = { type: "object", properties: { stale: { type: "string" } } };

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -20,8 +20,12 @@ const runWebSearchCalls = vi.hoisted(
       runtimeWebSearch?: unknown;
     }>,
 );
-const resolveWebSearchDefinitionCalls = vi.hoisted(() => [] as Array<{ config?: unknown }>);
-const configuredWebSearchCredentialSignal = vi.hoisted(() => ({ current: false }));
+const resolveWebSearchDefinitionCalls = vi.hoisted(
+  () => [] as Array<{ config?: unknown }>,
+);
+const configuredWebSearchCredentialSignal = vi.hoisted(() => ({
+  current: false,
+}));
 const activeSecretsRuntimeSnapshot = vi.hoisted(() => ({
   current: null as null | { config: unknown },
 }));
@@ -47,11 +51,13 @@ function readConfiguredSearchProvider(config: unknown): string | undefined {
 }
 
 vi.mock("../../secrets/runtime-state.js", () => ({
-  getActiveSecretsRuntimeConfigSnapshot: () => activeSecretsRuntimeSnapshot.current,
+  getActiveSecretsRuntimeConfigSnapshot: () =>
+    activeSecretsRuntimeSnapshot.current,
 }));
 
 vi.mock("../../plugins/web-search-credential-presence.js", () => ({
-  hasConfiguredWebSearchCredential: () => configuredWebSearchCredentialSignal.current,
+  hasConfiguredWebSearchCredential: () =>
+    configuredWebSearchCredentialSignal.current,
 }));
 
 vi.mock("../../web-search/runtime.js", async () => {
@@ -60,7 +66,10 @@ vi.mock("../../web-search/runtime.js", async () => {
     await import("../../secrets/runtime-web-tools-state.js");
   const resolveRuntimeDefinition = (options?: {
     config?: unknown;
-    runtimeWebSearch?: { selectedProvider?: string; providerConfigured?: string };
+    runtimeWebSearch?: {
+      selectedProvider?: string;
+      providerConfigured?: string;
+    };
   }) => {
     // The mock mirrors production provider resolution order closely enough to
     // catch stale construction-time metadata in late-bound tool instances.
@@ -81,8 +90,9 @@ vi.mock("../../web-search/runtime.js", async () => {
           )
           .find((entry) =>
             Boolean(
-              entry.provider.getConfiguredCredentialValue?.(options?.config as never) ??
-                entry.provider.getCredentialValue(),
+              entry.provider.getConfiguredCredentialValue?.(
+                options?.config as never,
+              ) ?? entry.provider.getCredentialValue(),
             ),
           );
     const definition = registration?.provider.createTool({
@@ -218,7 +228,9 @@ describe("web tools defaults", () => {
       },
     });
 
-    const result = await tool?.execute?.("call-runtime-provider", { query: "openclaw" });
+    const result = await tool?.execute?.("call-runtime-provider", {
+      query: "openclaw",
+    });
 
     expect(tool?.description).toContain("Search current web");
     expect(result?.details).toMatchObject({
@@ -349,8 +361,14 @@ describe("web tools defaults", () => {
 
   it("late-binds the model schema to the current selected provider", () => {
     const registry = createEmptyPluginRegistry();
-    const staleParameters = { type: "object", properties: { stale: { type: "string" } } };
-    const freshParameters = { type: "object", properties: { fresh: { type: "string" } } };
+    const staleParameters = {
+      type: "object",
+      properties: { stale: { type: "string" } },
+    };
+    const freshParameters = {
+      type: "object",
+      properties: { fresh: { type: "string" } },
+    };
     for (const [id, modelParameters] of [
       ["stale", staleParameters],
       ["fresh", freshParameters],
@@ -407,8 +425,14 @@ describe("web tools defaults", () => {
 
   it("keeps the selected provider schema live through agent tool assembly", () => {
     const registry = createEmptyPluginRegistry();
-    const staleParameters = { type: "object", properties: { stale: { type: "string" } } };
-    const freshParameters = { type: "object", properties: { fresh: { type: "string" } } };
+    const staleParameters = {
+      type: "object",
+      properties: { stale: { type: "string" } },
+    };
+    const freshParameters = {
+      type: "object",
+      properties: { fresh: { type: "string" } },
+    };
     for (const [id, modelParameters] of [
       ["stale", staleParameters],
       ["fresh", freshParameters],
@@ -507,11 +531,16 @@ describe("web tools defaults", () => {
       sandboxed: true,
     });
 
-    const result = await tool?.execute?.("call-runtime-provider-without-metadata", {
-      query: "openclaw",
-    });
+    const result = await tool?.execute?.(
+      "call-runtime-provider-without-metadata",
+      {
+        query: "openclaw",
+      },
+    );
 
-    expect((result?.details as { provider?: string } | undefined)?.provider).toBe("custom");
+    expect(
+      (result?.details as { provider?: string } | undefined)?.provider,
+    ).toBe("custom");
     expect(runWebSearchCalls).toHaveLength(1);
     expect(runWebSearchCalls[0]?.preferRuntimeProviders).toBe(true);
   });
@@ -582,7 +611,11 @@ describe("web tools defaults", () => {
       diagnostics: [],
     });
     const runtimeConfig = {
-      tools: { web: { search: { provider: "fresh", fresh: { apiKey: "runtime-key" } } } },
+      tools: {
+        web: {
+          search: { provider: "fresh", fresh: { apiKey: "runtime-key" } },
+        },
+      },
     };
     activeSecretsRuntimeSnapshot.current = { config: runtimeConfig };
 
@@ -599,14 +632,20 @@ describe("web tools defaults", () => {
       lateBindRuntimeConfig: true,
     });
 
-    const result = await tool?.execute?.("call-runtime-provider", { query: "openclaw" });
+    const result = await tool?.execute?.("call-runtime-provider", {
+      query: "openclaw",
+    });
 
-    expect((result?.details as { provider?: string } | undefined)?.provider).toBe("fresh");
+    expect(
+      (result?.details as { provider?: string } | undefined)?.provider,
+    ).toBe("fresh");
     expect(runWebSearchCalls).toHaveLength(1);
     expect(runWebSearchCalls[0]?.config).toBe(runtimeConfig);
     expect(
-      (runWebSearchCalls[0]?.runtimeWebSearch as { selectedProvider?: string } | undefined)
-        ?.selectedProvider,
+      (
+        runWebSearchCalls[0]?.runtimeWebSearch as
+          { selectedProvider?: string } | undefined
+      )?.selectedProvider,
     ).toBe("fresh");
   });
 });

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -7,6 +7,9 @@ import {
   clearActiveRuntimeWebToolsMetadata,
   setActiveRuntimeWebToolsMetadata,
 } from "../../secrets/runtime-web-tools-state.js";
+import { toToolDefinitions } from "../agent-tool-definition-adapter.js";
+import { wrapToolWithBeforeToolCallHook } from "../agent-tools.before-tool-call.js";
+import { normalizeToolParameters } from "../agent-tools.schema.js";
 import { createWebFetchTool, createWebSearchTool } from "./web-tools.js";
 
 const runWebSearchCalls = vi.hoisted(
@@ -285,6 +288,70 @@ describe("web tools defaults", () => {
       diagnostics: [],
     });
     expect(tool?.parameters).toBe(freshParameters);
+  });
+
+  it("keeps the selected provider schema live through agent tool assembly", () => {
+    const registry = createEmptyPluginRegistry();
+    const staleParameters = { type: "object", properties: { stale: { type: "string" } } };
+    const freshParameters = { type: "object", properties: { fresh: { type: "string" } } };
+    for (const [id, modelParameters] of [
+      ["stale", staleParameters],
+      ["fresh", freshParameters],
+    ] as const) {
+      registry.webSearchProviders.push({
+        pluginId: `${id}-search`,
+        pluginName: `${id} Search`,
+        source: "test",
+        provider: {
+          id,
+          label: `${id} Search`,
+          hint: "Runtime provider",
+          envVars: [],
+          placeholder: `${id}-...`,
+          signupUrl: `https://example.com/${id}`,
+          credentialPath: `tools.web.search.${id}.apiKey`,
+          getCredentialValue: () => "configured",
+          setCredentialValue: () => {},
+          modelParameters,
+          createTool: () => ({
+            description: `${id} runtime tool`,
+            parameters: modelParameters,
+            execute: async () => ({ query: "openclaw", results: [] }),
+          }),
+        },
+      });
+    }
+    setActivePluginRegistry(registry);
+    setActiveRuntimeWebToolsMetadata({
+      search: {
+        providerSource: "configured",
+        selectedProvider: "stale",
+        selectedProviderKeySource: "config",
+        diagnostics: [],
+      },
+      fetch: { providerSource: "none", diagnostics: [] },
+      diagnostics: [],
+    });
+    const tool = createWebSearchTool({ lateBindRuntimeConfig: true });
+    if (!tool) {
+      throw new Error("expected web_search tool");
+    }
+    const normalized = normalizeToolParameters(tool);
+    const wrapped = wrapToolWithBeforeToolCallHook(normalized);
+
+    setActiveRuntimeWebToolsMetadata({
+      search: {
+        providerSource: "configured",
+        selectedProvider: "fresh",
+        selectedProviderKeySource: "config",
+        diagnostics: [],
+      },
+      fetch: { providerSource: "none", diagnostics: [] },
+      diagnostics: [],
+    });
+    const definition = toToolDefinitions([wrapped])[0];
+
+    expect(definition?.parameters).toEqual(freshParameters);
   });
 
   it("keeps runtime provider discovery enabled when runtime web_search metadata is missing", async () => {

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -20,9 +20,7 @@ const runWebSearchCalls = vi.hoisted(
       runtimeWebSearch?: unknown;
     }>,
 );
-const resolveWebSearchDefinitionCalls = vi.hoisted(
-  () => [] as Array<{ config?: unknown }>,
-);
+const resolveWebSearchDefinitionCalls = vi.hoisted(() => [] as Array<{ config?: unknown }>);
 const configuredWebSearchCredentialSignal = vi.hoisted(() => ({
   current: false,
 }));
@@ -51,13 +49,11 @@ function readConfiguredSearchProvider(config: unknown): string | undefined {
 }
 
 vi.mock("../../secrets/runtime-state.js", () => ({
-  getActiveSecretsRuntimeConfigSnapshot: () =>
-    activeSecretsRuntimeSnapshot.current,
+  getActiveSecretsRuntimeConfigSnapshot: () => activeSecretsRuntimeSnapshot.current,
 }));
 
 vi.mock("../../plugins/web-search-credential-presence.js", () => ({
-  hasConfiguredWebSearchCredential: () =>
-    configuredWebSearchCredentialSignal.current,
+  hasConfiguredWebSearchCredential: () => configuredWebSearchCredentialSignal.current,
 }));
 
 vi.mock("../../web-search/runtime.js", async () => {
@@ -66,10 +62,7 @@ vi.mock("../../web-search/runtime.js", async () => {
     await import("../../secrets/runtime-web-tools-state.js");
   const resolveRuntimeDefinition = (options?: {
     config?: unknown;
-    runtimeWebSearch?: {
-      selectedProvider?: string;
-      providerConfigured?: string;
-    };
+    runtimeWebSearch?: { selectedProvider?: string; providerConfigured?: string };
   }) => {
     // The mock mirrors production provider resolution order closely enough to
     // catch stale construction-time metadata in late-bound tool instances.
@@ -228,9 +221,7 @@ describe("web tools defaults", () => {
       },
     });
 
-    const result = await tool?.execute?.("call-runtime-provider", {
-      query: "openclaw",
-    });
+    const result = await tool?.execute?.("call-runtime-provider", { query: "openclaw" });
 
     expect(tool?.description).toContain("Search current web");
     expect(result?.details).toMatchObject({
@@ -531,16 +522,11 @@ describe("web tools defaults", () => {
       sandboxed: true,
     });
 
-    const result = await tool?.execute?.(
-      "call-runtime-provider-without-metadata",
-      {
-        query: "openclaw",
-      },
-    );
+    const result = await tool?.execute?.("call-runtime-provider-without-metadata", {
+      query: "openclaw",
+    });
 
-    expect(
-      (result?.details as { provider?: string } | undefined)?.provider,
-    ).toBe("custom");
+    expect((result?.details as { provider?: string } | undefined)?.provider).toBe("custom");
     expect(runWebSearchCalls).toHaveLength(1);
     expect(runWebSearchCalls[0]?.preferRuntimeProviders).toBe(true);
   });
@@ -632,20 +618,14 @@ describe("web tools defaults", () => {
       lateBindRuntimeConfig: true,
     });
 
-    const result = await tool?.execute?.("call-runtime-provider", {
-      query: "openclaw",
-    });
+    const result = await tool?.execute?.("call-runtime-provider", { query: "openclaw" });
 
-    expect(
-      (result?.details as { provider?: string } | undefined)?.provider,
-    ).toBe("fresh");
+    expect((result?.details as { provider?: string } | undefined)?.provider).toBe("fresh");
     expect(runWebSearchCalls).toHaveLength(1);
     expect(runWebSearchCalls[0]?.config).toBe(runtimeConfig);
     expect(
-      (
-        runWebSearchCalls[0]?.runtimeWebSearch as
-          { selectedProvider?: string } | undefined
-      )?.selectedProvider,
+      (runWebSearchCalls[0]?.runtimeWebSearch as { selectedProvider?: string } | undefined)
+        ?.selectedProvider,
     ).toBe("fresh");
   });
 });

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -21,6 +21,7 @@ const runWebSearchCalls = vi.hoisted(
     }>,
 );
 const resolveWebSearchDefinitionCalls = vi.hoisted(() => [] as Array<{ config?: unknown }>);
+const configuredWebSearchCredentialSignal = vi.hoisted(() => ({ current: false }));
 const activeSecretsRuntimeSnapshot = vi.hoisted(() => ({
   current: null as null | { config: unknown },
 }));
@@ -47,6 +48,10 @@ function readConfiguredSearchProvider(config: unknown): string | undefined {
 
 vi.mock("../../secrets/runtime-state.js", () => ({
   getActiveSecretsRuntimeConfigSnapshot: () => activeSecretsRuntimeSnapshot.current,
+}));
+
+vi.mock("../../plugins/web-search-credential-presence.js", () => ({
+  hasConfiguredWebSearchCredential: () => configuredWebSearchCredentialSignal.current,
 }));
 
 vi.mock("../../web-search/runtime.js", async () => {
@@ -127,6 +132,7 @@ beforeEach(() => {
   setActivePluginRegistry(createEmptyPluginRegistry());
   clearActiveRuntimeWebToolsMetadata();
   activeSecretsRuntimeSnapshot.current = null;
+  configuredWebSearchCredentialSignal.current = false;
   runWebSearchCalls.length = 0;
   resolveWebSearchDefinitionCalls.length = 0;
 });
@@ -135,6 +141,7 @@ afterEach(() => {
   setActivePluginRegistry(createEmptyPluginRegistry());
   clearActiveRuntimeWebToolsMetadata();
   activeSecretsRuntimeSnapshot.current = null;
+  configuredWebSearchCredentialSignal.current = false;
 });
 
 describe("web tools defaults", () => {
@@ -155,6 +162,15 @@ describe("web tools defaults", () => {
       properties: { query: { type: "string" } },
     });
     expect(resolveWebSearchDefinitionCalls).toHaveLength(0);
+  });
+
+  it("resolves metadata-free credential candidates without an active registration", () => {
+    configuredWebSearchCredentialSignal.current = true;
+    const tool = createWebSearchTool({ config: {} });
+
+    void tool?.parameters;
+
+    expect(resolveWebSearchDefinitionCalls).toHaveLength(1);
   });
 
   it("disables web_fetch when explicitly disabled", () => {

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -83,9 +83,8 @@ vi.mock("../../web-search/runtime.js", async () => {
           )
           .find((entry) =>
             Boolean(
-              entry.provider.getConfiguredCredentialValue?.(
-                options?.config as never,
-              ) ?? entry.provider.getCredentialValue(),
+              entry.provider.getConfiguredCredentialValue?.(options?.config as never) ??
+              entry.provider.getCredentialValue(),
             ),
           );
     const definition = registration?.provider.createTool({

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -20,6 +20,7 @@ const runWebSearchCalls = vi.hoisted(
       runtimeWebSearch?: unknown;
     }>,
 );
+const resolveWebSearchDefinitionCalls = vi.hoisted(() => [] as Array<{ config?: unknown }>);
 const activeSecretsRuntimeSnapshot = vi.hoisted(() => ({
   current: null as null | { config: unknown },
 }));
@@ -64,9 +65,21 @@ vi.mock("../../web-search/runtime.js", async () => {
       getActiveRuntimeWebToolsMetadata()?.search?.selectedProvider ??
       getActiveRuntimeWebToolsMetadata()?.search?.providerConfigured ??
       readConfiguredSearchProvider(options?.config);
-    const registration = getActivePluginRegistry()?.webSearchProviders.find(
-      (entry) => entry.provider.id === providerId,
-    );
+    const registrations = getActivePluginRegistry()?.webSearchProviders ?? [];
+    const registration = providerId
+      ? registrations.find((entry) => entry.provider.id === providerId)
+      : registrations
+          .toSorted(
+            (left, right) =>
+              (left.provider.autoDetectOrder ?? Number.MAX_SAFE_INTEGER) -
+              (right.provider.autoDetectOrder ?? Number.MAX_SAFE_INTEGER),
+          )
+          .find((entry) =>
+            Boolean(
+              entry.provider.getConfiguredCredentialValue?.(options?.config as never) ??
+                entry.provider.getCredentialValue(),
+            ),
+          );
     const definition = registration?.provider.createTool({
       config: options?.config as never,
       runtimeMetadata: options?.runtimeWebSearch as never,
@@ -82,7 +95,10 @@ vi.mock("../../web-search/runtime.js", async () => {
       : null;
   };
   return {
-    resolveWebSearchDefinition: resolveRuntimeDefinition,
+    resolveWebSearchDefinition: (options?: { config?: unknown }) => {
+      resolveWebSearchDefinitionCalls.push({ config: options?.config });
+      return resolveRuntimeDefinition(options);
+    },
     resolveWebSearchProviderId: () => "",
     runWebSearch: async (options: {
       config?: unknown;
@@ -112,6 +128,7 @@ beforeEach(() => {
   clearActiveRuntimeWebToolsMetadata();
   activeSecretsRuntimeSnapshot.current = null;
   runWebSearchCalls.length = 0;
+  resolveWebSearchDefinitionCalls.length = 0;
 });
 
 afterEach(() => {
@@ -127,6 +144,17 @@ describe("web tools defaults", () => {
     expect(fetchTool?.name).toBe("web_fetch");
     expect(fetchTool?.resultContentSource).toBe("network");
     expect(searchTool?.resultContentSource).toBe("network");
+  });
+
+  it("keeps the generic web_search schema fast when no provider signal exists", () => {
+    const tool = createWebSearchTool({ config: {} });
+
+    expect(tool?.parameters).toMatchObject({
+      type: "object",
+      required: ["query"],
+      properties: { query: { type: "string" } },
+    });
+    expect(resolveWebSearchDefinitionCalls).toHaveLength(0);
   });
 
   it("disables web_fetch when explicitly disabled", () => {

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -186,7 +186,7 @@ describe("web tools defaults", () => {
     });
   });
 
-  it("uses the selected provider model schema without constructing its runtime tool", () => {
+  it("uses the selected provider tool schema through runtime-compatible resolution", () => {
     const registry = createEmptyPluginRegistry();
     const modelParameters = {
       type: "object",
@@ -212,7 +212,6 @@ describe("web tools defaults", () => {
         credentialPath: "tools.web.search.custom.apiKey",
         getCredentialValue: () => "configured",
         setCredentialValue: () => {},
-        modelParameters,
         createTool,
       },
     });
@@ -228,7 +227,7 @@ describe("web tools defaults", () => {
     });
 
     expect(tool?.parameters).toBe(modelParameters);
-    expect(createTool).not.toHaveBeenCalled();
+    expect(createTool).toHaveBeenCalledOnce();
   });
 
   it("late-binds the model schema to the current selected provider", () => {
@@ -253,7 +252,6 @@ describe("web tools defaults", () => {
           credentialPath: `tools.web.search.${id}.apiKey`,
           getCredentialValue: () => "configured",
           setCredentialValue: () => {},
-          modelParameters,
           createTool: () => ({
             description: `${id} runtime tool`,
             parameters: modelParameters,
@@ -312,7 +310,6 @@ describe("web tools defaults", () => {
           credentialPath: `tools.web.search.${id}.apiKey`,
           getCredentialValue: () => "configured",
           setCredentialValue: () => {},
-          modelParameters,
           createTool: () => ({
             description: `${id} runtime tool`,
             parameters: modelParameters,

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -183,6 +183,110 @@ describe("web tools defaults", () => {
     });
   });
 
+  it("uses the selected provider model schema without constructing its runtime tool", () => {
+    const registry = createEmptyPluginRegistry();
+    const modelParameters = {
+      type: "object",
+      required: ["query"],
+      properties: { query: { type: "string" } },
+    };
+    const createTool = vi.fn(() => ({
+      description: "custom runtime tool",
+      parameters: modelParameters,
+      execute: async () => ({ query: "openclaw", results: [] }),
+    }));
+    registry.webSearchProviders.push({
+      pluginId: "custom-search",
+      pluginName: "Custom Search",
+      source: "test",
+      provider: {
+        id: "custom",
+        label: "Custom Search",
+        hint: "Custom runtime provider",
+        envVars: [],
+        placeholder: "custom-...",
+        signupUrl: "https://example.com/signup",
+        credentialPath: "tools.web.search.custom.apiKey",
+        getCredentialValue: () => "configured",
+        setCredentialValue: () => {},
+        modelParameters,
+        createTool,
+      },
+    });
+    setActivePluginRegistry(registry);
+
+    const tool = createWebSearchTool({
+      runtimeWebSearch: {
+        providerSource: "configured",
+        selectedProvider: "custom",
+        selectedProviderKeySource: "config",
+        diagnostics: [],
+      },
+    });
+
+    expect(tool?.parameters).toBe(modelParameters);
+    expect(createTool).not.toHaveBeenCalled();
+  });
+
+  it("late-binds the model schema to the current selected provider", () => {
+    const registry = createEmptyPluginRegistry();
+    const staleParameters = { type: "object", properties: { stale: { type: "string" } } };
+    const freshParameters = { type: "object", properties: { fresh: { type: "string" } } };
+    for (const [id, modelParameters] of [
+      ["stale", staleParameters],
+      ["fresh", freshParameters],
+    ] as const) {
+      registry.webSearchProviders.push({
+        pluginId: `${id}-search`,
+        pluginName: `${id} Search`,
+        source: "test",
+        provider: {
+          id,
+          label: `${id} Search`,
+          hint: "Runtime provider",
+          envVars: [],
+          placeholder: `${id}-...`,
+          signupUrl: `https://example.com/${id}`,
+          credentialPath: `tools.web.search.${id}.apiKey`,
+          getCredentialValue: () => "configured",
+          setCredentialValue: () => {},
+          modelParameters,
+          createTool: () => ({
+            description: `${id} runtime tool`,
+            parameters: modelParameters,
+            execute: async () => ({ query: "openclaw", results: [] }),
+          }),
+        },
+      });
+    }
+    setActivePluginRegistry(registry);
+    setActiveRuntimeWebToolsMetadata({
+      search: {
+        providerSource: "configured",
+        selectedProvider: "stale",
+        selectedProviderKeySource: "config",
+        diagnostics: [],
+      },
+      fetch: { providerSource: "none", diagnostics: [] },
+      diagnostics: [],
+    });
+    const tool = createWebSearchTool({ lateBindRuntimeConfig: true });
+
+    expect(tool?.parameters).toBe(staleParameters);
+
+    setActiveRuntimeWebToolsMetadata({
+      search: {
+        providerSource: "configured",
+        selectedProvider: "fresh",
+        selectedProviderKeySource: "config",
+        diagnostics: [],
+      },
+      fetch: { providerSource: "none", diagnostics: [] },
+      diagnostics: [],
+    });
+    expect(tool?.parameters).toBe(freshParameters);
+  });
+
   it("keeps runtime provider discovery enabled when runtime web_search metadata is missing", async () => {
     const registry = createEmptyPluginRegistry();
     registry.webSearchProviders.push({

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -2360,6 +2360,16 @@ describe("loadPluginManifestRegistry", () => {
           ],
         },
       },
+      webSearchProviderMetadata: {
+        search: {
+          configSignals: [
+            {
+              rootPath: "models.providers.acme",
+              required: ["apiKey"],
+            },
+          ],
+        },
+      },
       mediaUnderstandingProviderMetadata: {
         openai: {
           capabilities: ["image", "audio", "unknown"],
@@ -2441,6 +2451,16 @@ describe("loadPluginManifestRegistry", () => {
             },
             requiredAny: ["workflow", "workflowPath"],
             required: ["promptNodeId"],
+          },
+        ],
+      },
+    });
+    expect(registry.plugins[0]?.webSearchProviderMetadata).toEqual({
+      search: {
+        configSignals: [
+          {
+            rootPath: "models.providers.acme",
+            required: ["apiKey"],
           },
         ],
       },

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -276,6 +276,7 @@ export type PluginManifestRecord = {
   imageGenerationProviderMetadata?: Record<string, PluginManifestCapabilityProviderMetadata>;
   videoGenerationProviderMetadata?: Record<string, PluginManifestCapabilityProviderMetadata>;
   musicGenerationProviderMetadata?: Record<string, PluginManifestCapabilityProviderMetadata>;
+  webSearchProviderMetadata?: Record<string, PluginManifestCapabilityProviderMetadata>;
   toolMetadata?: Record<string, PluginManifestToolMetadata>;
   configContracts?: PluginManifestConfigContracts;
   channelConfigs?: Record<string, PluginManifestChannelConfig>;
@@ -629,6 +630,7 @@ function buildRecord(params: {
     imageGenerationProviderMetadata: params.manifest.imageGenerationProviderMetadata,
     videoGenerationProviderMetadata: params.manifest.videoGenerationProviderMetadata,
     musicGenerationProviderMetadata: params.manifest.musicGenerationProviderMetadata,
+    webSearchProviderMetadata: params.manifest.webSearchProviderMetadata,
     toolMetadata: params.manifest.toolMetadata,
     configContracts: params.manifest.configContracts,
     channelConfigs,

--- a/src/plugins/manifest-types.ts
+++ b/src/plugins/manifest-types.ts
@@ -416,6 +416,8 @@ export type PluginManifest = {
   videoGenerationProviderMetadata?: Record<string, PluginManifestCapabilityProviderMetadata>;
   /** Cheap music-generation provider auth metadata without importing plugin runtime. */
   musicGenerationProviderMetadata?: Record<string, PluginManifestCapabilityProviderMetadata>;
+  /** Cheap web-search provider auth metadata without importing plugin runtime. */
+  webSearchProviderMetadata?: Record<string, PluginManifestCapabilityProviderMetadata>;
   /** Cheap plugin-tool availability metadata without importing plugin runtime. */
   toolMetadata?: Record<string, PluginManifestToolMetadata>;
   /** Manifest-owned config behavior consumed by generic core helpers. */

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -292,6 +292,9 @@ export function loadPluginManifest(
       musicGenerationProviderMetadata: capabilityNormalizers.normalizeCapabilityProviderMetadata(
         raw.musicGenerationProviderMetadata,
       ),
+      webSearchProviderMetadata: capabilityNormalizers.normalizeCapabilityProviderMetadata(
+        raw.webSearchProviderMetadata,
+      ),
       toolMetadata: capabilityNormalizers.normalizePluginToolMetadata(raw.toolMetadata),
       configContracts: capabilityNormalizers.normalizeManifestConfigContracts(raw.configContracts),
       channelConfigs: setupNormalizers.normalizeChannelConfigs(raw.channelConfigs),

--- a/src/plugins/web-provider-types.ts
+++ b/src/plugins/web-provider-types.ts
@@ -92,6 +92,8 @@ export type WebSearchProviderPlugin = {
   id: WebSearchProviderId;
   label: string;
   hint: string;
+  /** Provider-specific schema to expose to models when this provider is selected. */
+  modelParameters?: TSchema;
   onboardingScopes?: readonly "text-inference"[];
   requiresCredential?: boolean;
   credentialLabel?: string;

--- a/src/plugins/web-provider-types.ts
+++ b/src/plugins/web-provider-types.ts
@@ -92,8 +92,6 @@ export type WebSearchProviderPlugin = {
   id: WebSearchProviderId;
   label: string;
   hint: string;
-  /** Provider-specific schema to expose to models when this provider is selected. */
-  modelParameters?: TSchema;
   onboardingScopes?: readonly "text-inference"[];
   requiresCredential?: boolean;
   credentialLabel?: string;

--- a/src/plugins/web-search-credential-presence.test.ts
+++ b/src/plugins/web-search-credential-presence.test.ts
@@ -9,6 +9,21 @@ const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
 
 let hasConfiguredWebSearchCredential: typeof import("./web-search-credential-presence.js").hasConfiguredWebSearchCredential;
 
+function googleModelCredentialConfig(plugins?: OpenClawConfig["plugins"]): OpenClawConfig {
+  return {
+    models: {
+      providers: {
+        google: {
+          baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+          apiKey: "google-model-key",
+          models: [],
+        },
+      },
+    },
+    ...(plugins ? { plugins } : {}),
+  };
+}
+
 beforeAll(async () => {
   ({ hasConfiguredWebSearchCredential } = await import("./web-search-credential-presence.js"));
 });
@@ -49,20 +64,33 @@ describe("hasConfiguredWebSearchCredential", () => {
   it("detects manifest-declared model credential fallbacks without provider-specific core logic", () => {
     expect(
       hasConfiguredWebSearchCredential({
-        config: {
-          models: {
-            providers: {
-              google: {
-                baseUrl: "https://generativelanguage.googleapis.com/v1beta",
-                apiKey: "google-model-key",
-                models: [],
-              },
-            },
-          },
-        } as OpenClawConfig,
+        config: googleModelCredentialConfig(),
         env: {},
         origin: "bundled",
       }),
     ).toBe(true);
+  });
+
+  it.each([
+    {
+      name: "an explicitly disabled plugin",
+      plugins: { entries: { google: { enabled: false } } },
+    },
+    {
+      name: "a denylisted plugin",
+      plugins: { deny: ["google"] },
+    },
+    {
+      name: "a plugin outside a restrictive allowlist",
+      plugins: { allow: ["another-plugin"] },
+    },
+  ])("does not accept manifest credentials from $name", ({ plugins }) => {
+    expect(
+      hasConfiguredWebSearchCredential({
+        config: googleModelCredentialConfig(plugins),
+        env: {},
+        origin: "bundled",
+      }),
+    ).toBe(false);
   });
 });

--- a/src/plugins/web-search-credential-presence.test.ts
+++ b/src/plugins/web-search-credential-presence.test.ts
@@ -52,7 +52,11 @@ describe("hasConfiguredWebSearchCredential", () => {
         config: {
           models: {
             providers: {
-              google: { apiKey: "google-model-key", models: [] },
+              google: {
+                baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+                apiKey: "google-model-key",
+                models: [],
+              },
             },
           },
         } as OpenClawConfig,

--- a/src/plugins/web-search-credential-presence.test.ts
+++ b/src/plugins/web-search-credential-presence.test.ts
@@ -45,4 +45,20 @@ describe("hasConfiguredWebSearchCredential", () => {
       }),
     ).toBe(true);
   });
+
+  it("detects manifest-declared model credential fallbacks without provider-specific core logic", () => {
+    expect(
+      hasConfiguredWebSearchCredential({
+        config: {
+          models: {
+            providers: {
+              google: { apiKey: "google-model-key", models: [] },
+            },
+          },
+        } as OpenClawConfig,
+        env: {},
+        origin: "bundled",
+      }),
+    ).toBe(true);
+  });
 });

--- a/src/plugins/web-search-credential-presence.ts
+++ b/src/plugins/web-search-credential-presence.ts
@@ -32,9 +32,7 @@ function hasConfiguredPluginWebSearchCandidate(config: OpenClawConfig): boolean 
   }
   return Object.values(entries).some((entry) => {
     const pluginConfig = asOptionalObjectRecord(entry)?.config;
-    return hasConfiguredSearchCredentialCandidate(
-      asOptionalObjectRecord(pluginConfig)?.webSearch,
-    );
+    return hasConfiguredSearchCredentialCandidate(asOptionalObjectRecord(pluginConfig)?.webSearch);
   });
 }
 
@@ -66,13 +64,12 @@ function hasManifestWebSearchCredentialCandidate(params: {
     }
     if (
       providerIds.some((providerId) =>
-        plugin.webSearchProviderMetadata?.[providerId]?.configSignals?.some(
-          (signal) =>
-            manifestConfigSignalPasses({
-              config: params.config,
-              env: params.env ?? process.env,
-              signal,
-            }),
+        plugin.webSearchProviderMetadata?.[providerId]?.configSignals?.some((signal) =>
+          manifestConfigSignalPasses({
+            config: params.config,
+            env: params.env ?? process.env,
+            signal,
+          }),
         ),
       )
     ) {

--- a/src/plugins/web-search-credential-presence.ts
+++ b/src/plugins/web-search-credential-presence.ts
@@ -3,6 +3,7 @@ import { asOptionalObjectRecord } from "@openclaw/normalization-core/record-coer
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { loadManifestMetadataSnapshot } from "./manifest-contract-eligibility.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
+import { manifestConfigSignalPasses } from "./manifest-tool-availability.js";
 
 function hasConfiguredCredentialValue(value: unknown): boolean {
   if (typeof value === "string") {
@@ -11,7 +12,9 @@ function hasConfiguredCredentialValue(value: unknown): boolean {
   return value !== undefined && value !== null;
 }
 
-function hasConfiguredSearchCredentialCandidate(searchConfig: unknown): boolean {
+function hasConfiguredSearchCredentialCandidate(
+  searchConfig: unknown,
+): boolean {
   const record = asOptionalObjectRecord(searchConfig);
   if (!record) {
     return false;
@@ -21,38 +24,60 @@ function hasConfiguredSearchCredentialCandidate(searchConfig: unknown): boolean 
   );
 }
 
-function hasConfiguredPluginWebSearchCandidate(config: OpenClawConfig): boolean {
+function hasConfiguredPluginWebSearchCandidate(
+  config: OpenClawConfig,
+): boolean {
   const entries = asOptionalObjectRecord(config.plugins?.entries);
   if (!entries) {
     return false;
   }
   return Object.values(entries).some((entry) => {
     const pluginConfig = asOptionalObjectRecord(entry)?.config;
-    return hasConfiguredSearchCredentialCandidate(asOptionalObjectRecord(pluginConfig)?.webSearch);
+    return hasConfiguredSearchCredentialCandidate(
+      asOptionalObjectRecord(pluginConfig)?.webSearch,
+    );
   });
 }
 
-function hasManifestWebSearchEnvCredentialCandidate(params: {
+function hasManifestWebSearchCredentialCandidate(params: {
   config: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   origin?: PluginManifestRecord["origin"];
 }): boolean {
-  const env = params.env;
-  if (!env) {
-    return false;
-  }
   return loadManifestMetadataSnapshot({
     config: params.config,
-    env,
+    env: params.env,
   }).plugins.some((plugin) => {
     if (params.origin && plugin.origin !== params.origin) {
       return false;
     }
-    if ((plugin.contracts?.webSearchProviders?.length ?? 0) === 0) {
+    const providerIds = plugin.contracts?.webSearchProviders ?? [];
+    if (providerIds.length === 0) {
       return false;
     }
-    const envVars = (plugin.setup?.providers ?? []).flatMap((provider) => provider.envVars ?? []);
-    return envVars.some((envVar) => hasConfiguredCredentialValue(env[envVar]));
+    if (
+      providerIds.some((providerId) =>
+        plugin.webSearchProviderMetadata?.[providerId]?.configSignals?.some(
+          (signal) =>
+            manifestConfigSignalPasses({
+              config: params.config,
+              env: params.env ?? process.env,
+              signal,
+            }),
+        ),
+      )
+    ) {
+      return true;
+    }
+    if (!params.env) {
+      return false;
+    }
+    const envVars = (plugin.setup?.providers ?? []).flatMap(
+      (provider) => provider.envVars ?? [],
+    );
+    return envVars.some((envVar) =>
+      hasConfiguredCredentialValue(params.env?.[envVar]),
+    );
   });
 }
 
@@ -68,7 +93,7 @@ export function hasConfiguredWebSearchCredential(params: {
   return (
     hasConfiguredSearchCredentialCandidate(searchConfig) ||
     hasConfiguredPluginWebSearchCandidate(params.config) ||
-    hasManifestWebSearchEnvCredentialCandidate({
+    hasManifestWebSearchCredentialCandidate({
       config: params.config,
       env: params.env,
       origin: params.origin,

--- a/src/plugins/web-search-credential-presence.ts
+++ b/src/plugins/web-search-credential-presence.ts
@@ -15,9 +15,7 @@ function hasConfiguredCredentialValue(value: unknown): boolean {
   return value !== undefined && value !== null;
 }
 
-function hasConfiguredSearchCredentialCandidate(
-  searchConfig: unknown,
-): boolean {
+function hasConfiguredSearchCredentialCandidate(searchConfig: unknown): boolean {
   const record = asOptionalObjectRecord(searchConfig);
   if (!record) {
     return false;
@@ -27,9 +25,7 @@ function hasConfiguredSearchCredentialCandidate(
   );
 }
 
-function hasConfiguredPluginWebSearchCandidate(
-  config: OpenClawConfig,
-): boolean {
+function hasConfiguredPluginWebSearchCandidate(config: OpenClawConfig): boolean {
   const entries = asOptionalObjectRecord(config.plugins?.entries);
   if (!entries) {
     return false;
@@ -85,12 +81,8 @@ function hasManifestWebSearchCredentialCandidate(params: {
     if (!params.env) {
       return false;
     }
-    const envVars = (plugin.setup?.providers ?? []).flatMap(
-      (provider) => provider.envVars ?? [],
-    );
-    return envVars.some((envVar) =>
-      hasConfiguredCredentialValue(params.env?.[envVar]),
-    );
+    const envVars = (plugin.setup?.providers ?? []).flatMap((provider) => provider.envVars ?? []);
+    return envVars.some((envVar) => hasConfiguredCredentialValue(params.env?.[envVar]));
   });
 }
 

--- a/src/plugins/web-search-credential-presence.ts
+++ b/src/plugins/web-search-credential-presence.ts
@@ -1,7 +1,10 @@
 // Checks web-search credential presence from config and plugin metadata.
 import { asOptionalObjectRecord } from "@openclaw/normalization-core/record-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { loadManifestMetadataSnapshot } from "./manifest-contract-eligibility.js";
+import {
+  isManifestPluginAvailableForControlPlane,
+  loadManifestMetadataSnapshot,
+} from "./manifest-contract-eligibility.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import { manifestConfigSignalPasses } from "./manifest-tool-availability.js";
 
@@ -44,11 +47,21 @@ function hasManifestWebSearchCredentialCandidate(params: {
   env?: NodeJS.ProcessEnv;
   origin?: PluginManifestRecord["origin"];
 }): boolean {
-  return loadManifestMetadataSnapshot({
+  const snapshot = loadManifestMetadataSnapshot({
     config: params.config,
     env: params.env,
-  }).plugins.some((plugin) => {
+  });
+  return snapshot.plugins.some((plugin) => {
     if (params.origin && plugin.origin !== params.origin) {
+      return false;
+    }
+    if (
+      !isManifestPluginAvailableForControlPlane({
+        snapshot,
+        plugin,
+        config: params.config,
+      })
+    ) {
       return false;
     }
     const providerIds = plugin.contracts?.webSearchProviders ?? [];

--- a/src/web-search/runtime-execution.ts
+++ b/src/web-search/runtime-execution.ts
@@ -23,13 +23,31 @@ function isStructuredAvailabilityError(result: unknown): result is { error: stri
   return typeof error === "string" && /^missing_[a-z0-9_]*api_key$/i.test(error);
 }
 
+function asSchemaRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function resolveUnsupportedFallbackArguments(
+  parameters: unknown,
+  args: Record<string, unknown>,
+): string[] {
+  const schema = asSchemaRecord(parameters);
+  const properties = asSchemaRecord(schema?.properties);
+  if (schema?.type !== "object" || !properties) {
+    return [];
+  }
+  return Object.keys(args).filter((name) => !Object.hasOwn(properties, name));
+}
+
 export async function executeWebSearchCandidates(
   params: ExecuteWebSearchCandidatesParams,
 ): Promise<RunWebSearchResult> {
   let lastError: unknown;
   let sawUnavailableProvider = false;
 
-  for (const candidate of params.candidates) {
+  for (const [candidateIndex, candidate] of params.candidates.entries()) {
     params.signal?.throwIfAborted();
     try {
       const definition = candidate.createTool({
@@ -44,6 +62,17 @@ export async function executeWebSearchCandidates(
         }
         sawUnavailableProvider = true;
         continue;
+      }
+      if (params.allowFallback && candidateIndex > 0) {
+        const unsupportedArguments = resolveUnsupportedFallbackArguments(
+          definition.parameters,
+          params.args,
+        );
+        if (unsupportedArguments.length > 0) {
+          throw new Error(
+            `web_search fallback provider "${candidate.id}" does not accept provider-specific arguments: ${unsupportedArguments.join(", ")}. Retry without those arguments or explicitly select a compatible provider.`,
+          );
+        }
       }
       const executed = await definition.execute(params.args, { signal: params.signal });
       // Cancellation wins races with provider completion or cleanup failures. Otherwise an

--- a/src/web-search/runtime-execution.ts
+++ b/src/web-search/runtime-execution.ts
@@ -15,6 +15,8 @@ type ExecuteWebSearchCandidatesParams = {
   allowFallback: boolean;
 };
 
+const CLI_FALLBACK_ARGUMENT_ALIASES = new Set(["limit"]);
+
 function isStructuredAvailabilityError(result: unknown): result is { error: string } {
   if (!result || typeof result !== "object" || !("error" in result)) {
     return false;
@@ -41,6 +43,28 @@ function resolveUnsupportedFallbackArguments(
   return Object.keys(args).filter((name) => !Object.hasOwn(properties, name));
 }
 
+function normalizeFallbackArguments(
+  parameters: unknown,
+  args: Record<string, unknown>,
+): Record<string, unknown> {
+  const schema = asSchemaRecord(parameters);
+  const properties = asSchemaRecord(schema?.properties);
+  if (schema?.type !== "object" || !properties) {
+    return args;
+  }
+  const hasUnsupportedCliAlias = Object.keys(args).some(
+    (name) => CLI_FALLBACK_ARGUMENT_ALIASES.has(name) && !Object.hasOwn(properties, name),
+  );
+  if (!hasUnsupportedCliAlias) {
+    return args;
+  }
+  return Object.fromEntries(
+    Object.entries(args).filter(
+      ([name]) => !CLI_FALLBACK_ARGUMENT_ALIASES.has(name) || Object.hasOwn(properties, name),
+    ),
+  );
+}
+
 export async function executeWebSearchCandidates(
   params: ExecuteWebSearchCandidatesParams,
 ): Promise<RunWebSearchResult> {
@@ -63,10 +87,12 @@ export async function executeWebSearchCandidates(
         sawUnavailableProvider = true;
         continue;
       }
+      let executionArgs = params.args;
       if (params.allowFallback && candidateIndex > 0) {
+        executionArgs = normalizeFallbackArguments(definition.parameters, params.args);
         const unsupportedArguments = resolveUnsupportedFallbackArguments(
           definition.parameters,
-          params.args,
+          executionArgs,
         );
         if (unsupportedArguments.length > 0) {
           throw new Error(
@@ -74,7 +100,7 @@ export async function executeWebSearchCandidates(
           );
         }
       }
-      const executed = await definition.execute(params.args, { signal: params.signal });
+      const executed = await definition.execute(executionArgs, { signal: params.signal });
       // Cancellation wins races with provider completion or cleanup failures. Otherwise an
       // ignored signal could return stale work or trigger another provider fallback.
       params.signal?.throwIfAborted();

--- a/src/web-search/runtime-execution.ts
+++ b/src/web-search/runtime-execution.ts
@@ -52,15 +52,19 @@ function normalizeFallbackArguments(
   if (schema?.type !== "object" || !properties) {
     return args;
   }
-  const hasUnsupportedCliAlias = Object.keys(args).some(
-    (name) => CLI_FALLBACK_ARGUMENT_ALIASES.has(name) && !Object.hasOwn(properties, name),
+  const hasOmittedOrUnsupportedCliArgument = Object.entries(args).some(
+    ([name, value]) =>
+      value === undefined ||
+      (CLI_FALLBACK_ARGUMENT_ALIASES.has(name) && !Object.hasOwn(properties, name)),
   );
-  if (!hasUnsupportedCliAlias) {
+  if (!hasOmittedOrUnsupportedCliArgument) {
     return args;
   }
   return Object.fromEntries(
     Object.entries(args).filter(
-      ([name]) => !CLI_FALLBACK_ARGUMENT_ALIASES.has(name) || Object.hasOwn(properties, name),
+      ([name, value]) =>
+        value !== undefined &&
+        (!CLI_FALLBACK_ARGUMENT_ALIASES.has(name) || Object.hasOwn(properties, name)),
     ),
   );
 }

--- a/src/web-search/runtime.test.ts
+++ b/src/web-search/runtime.test.ts
@@ -262,6 +262,131 @@ describe("web search runtime", () => {
     expect(createTool).toHaveBeenCalledOnce();
   });
 
+  it("projects auto-detected parameters across every executable fallback candidate", async () => {
+    const braveExecute = vi.fn(async () => {
+      throw new Error("brave unavailable");
+    });
+    const geminiExecute = vi.fn(async (args: Record<string, unknown>) => ({
+      ...args,
+      provider: "gemini",
+    }));
+    const providers = [
+      createCustomSearchProvider({
+        pluginId: "brave",
+        id: "brave",
+        autoDetectOrder: 1,
+        getConfiguredCredentialValue: () => "brave-configured",
+        getCredentialValue: () => "brave-configured",
+        createTool: () => ({
+          description: "Brave search",
+          parameters: {
+            type: "object",
+            properties: {
+              query: { type: "string" },
+              count: { type: "integer", minimum: 1, maximum: 10 },
+              country: { type: "string" },
+            },
+            required: ["query"],
+          },
+          execute: braveExecute,
+        }),
+      }),
+      createCustomSearchProvider({
+        pluginId: "google",
+        id: "gemini",
+        autoDetectOrder: 2,
+        getConfiguredCredentialValue: () => "gemini-configured",
+        getCredentialValue: () => "gemini-configured",
+        createTool: () => ({
+          description: "Gemini search",
+          parameters: {
+            type: "object",
+            properties: {
+              query: { type: "string" },
+              count: { type: "integer", minimum: 1, maximum: 10 },
+              freshness: { type: "string" },
+            },
+            required: ["query"],
+          },
+          execute: geminiExecute,
+        }),
+      }),
+    ];
+    resolveRuntimeWebSearchProvidersMock.mockReturnValue(providers);
+    const runtimeWebSearch = {
+      providerSource: "auto-detect" as const,
+      selectedProvider: "brave",
+      selectedProviderKeySource: "config" as const,
+      diagnostics: [],
+    };
+
+    const resolved = resolveWebSearchDefinition({
+      config: {},
+      preferRuntimeProviders: true,
+      runtimeWebSearch,
+    });
+    const parameters = requireRecord(resolved?.definition.parameters);
+    const properties = requireRecord(parameters.properties);
+
+    expect(resolved?.provider.id).toBe("brave");
+    expect(Object.keys(properties)).toEqual(["query", "count"]);
+    expect(properties.country).toBeUndefined();
+    expect(properties.freshness).toBeUndefined();
+    expect(parameters.required).toEqual(["query"]);
+    expect(parameters.additionalProperties).toBe(false);
+
+    await expect(
+      runWebSearch({
+        config: {},
+        runtimeWebSearch,
+        args: { query: "fallback" },
+      }),
+    ).resolves.toEqual({
+      provider: "gemini",
+      result: { query: "fallback", provider: "gemini" },
+    });
+    expect(braveExecute).toHaveBeenCalledOnce();
+    expect(geminiExecute).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the full selected-provider schema when fallback is disabled", () => {
+    const braveParameters = {
+      type: "object",
+      properties: {
+        query: { type: "string" },
+        country: { type: "string" },
+      },
+      required: ["query"],
+    };
+    resolveRuntimeWebSearchProvidersMock.mockReturnValue([
+      createCustomSearchProvider({
+        pluginId: "brave",
+        id: "brave",
+        getConfiguredCredentialValue: () => "brave-configured",
+        getCredentialValue: () => "brave-configured",
+        createTool: () => ({
+          description: "Brave search",
+          parameters: braveParameters,
+          execute: async () => ({ ok: true }),
+        }),
+      }),
+      createCustomSearchProvider({
+        pluginId: "google",
+        id: "gemini",
+        getConfiguredCredentialValue: () => "gemini-configured",
+        getCredentialValue: () => "gemini-configured",
+      }),
+    ]);
+
+    const resolved = resolveWebSearchDefinition({
+      config: { tools: { web: { search: { provider: "brave" } } } },
+      preferRuntimeProviders: true,
+    });
+
+    expect(resolved?.provider.id).toBe("brave");
+    expect(resolved?.definition.parameters).toBe(braveParameters);
+  });
+
   it("accepts the prepared provider selection without rediscovering providers", () => {
     expect(
       hasUsableWebSearchProvider({

--- a/src/web-search/runtime.test.ts
+++ b/src/web-search/runtime.test.ts
@@ -426,6 +426,58 @@ describe("web search runtime", () => {
     );
   });
 
+  it("drops omitted CLI options before validating a query-only fallback", async () => {
+    const geminiExecute = vi.fn(async (args: Record<string, unknown>) => ({
+      ...args,
+      provider: "gemini",
+    }));
+    resolveRuntimeWebSearchProvidersMock.mockReturnValue([
+      createCustomSearchProvider({
+        pluginId: "brave",
+        id: "brave",
+        autoDetectOrder: 1,
+        getConfiguredCredentialValue: () => "brave-configured",
+        getCredentialValue: () => "brave-configured",
+        createTool: () => ({
+          description: "Brave search",
+          parameters: {
+            type: "object",
+            properties: { query: { type: "string" }, count: { type: "integer" } },
+          },
+          execute: async () => {
+            throw new Error("brave unavailable");
+          },
+        }),
+      }),
+      createCustomSearchProvider({
+        pluginId: "google",
+        id: "gemini",
+        autoDetectOrder: 2,
+        getConfiguredCredentialValue: () => "gemini-configured",
+        getCredentialValue: () => "gemini-configured",
+        createTool: () => ({
+          description: "Gemini search",
+          parameters: {
+            type: "object",
+            properties: { query: { type: "string" } },
+          },
+          execute: geminiExecute,
+        }),
+      }),
+    ]);
+
+    await expect(
+      runWebSearch({
+        config: {},
+        args: { query: "fallback", count: undefined, limit: undefined },
+      }),
+    ).resolves.toEqual({
+      provider: "gemini",
+      result: { query: "fallback", provider: "gemini" },
+    });
+    expect(geminiExecute).toHaveBeenCalledWith({ query: "fallback" }, { signal: undefined });
+  });
+
   it("does not pass provider-specific arguments to an incompatible fallback", async () => {
     const geminiExecute = vi.fn(async () => ({ ok: true }));
     resolveRuntimeWebSearchProvidersMock.mockReturnValue([

--- a/src/web-search/runtime.test.ts
+++ b/src/web-search/runtime.test.ts
@@ -262,7 +262,61 @@ describe("web search runtime", () => {
     expect(createTool).toHaveBeenCalledOnce();
   });
 
-  it("projects auto-detected parameters across every executable fallback candidate", async () => {
+  it("resolves metadata-free auto-detect without prebuilding fallback tools", () => {
+    const braveParameters = {
+      type: "object",
+      properties: {
+        query: { type: "string" },
+        count: { type: "integer", minimum: 1, maximum: 10 },
+        country: { type: "string" },
+      },
+      required: ["query"],
+    };
+    const braveCreateTool = vi.fn(() => ({
+      description: "Brave search",
+      parameters: braveParameters,
+      execute: async () => ({ ok: true }),
+    }));
+    const geminiCreateTool = vi.fn(() => ({
+      description: "Gemini search",
+      parameters: {
+        type: "object",
+        properties: { query: { type: "string" } },
+        required: ["query"],
+      },
+      execute: async () => ({ ok: true }),
+    }));
+    resolveRuntimeWebSearchProvidersMock.mockReturnValue([
+      createCustomSearchProvider({
+        pluginId: "brave",
+        id: "brave",
+        autoDetectOrder: 1,
+        getConfiguredCredentialValue: () => "brave-configured",
+        getCredentialValue: () => "brave-configured",
+        createTool: braveCreateTool,
+      }),
+      createCustomSearchProvider({
+        pluginId: "google",
+        id: "gemini",
+        autoDetectOrder: 2,
+        getConfiguredCredentialValue: () => "gemini-configured",
+        getCredentialValue: () => "gemini-configured",
+        createTool: geminiCreateTool,
+      }),
+    ]);
+
+    const resolved = resolveWebSearchDefinition({
+      config: {},
+      preferRuntimeProviders: true,
+    });
+
+    expect(resolved?.provider.id).toBe("brave");
+    expect(resolved?.definition.parameters).toBe(braveParameters);
+    expect(braveCreateTool).toHaveBeenCalledOnce();
+    expect(geminiCreateTool).not.toHaveBeenCalled();
+  });
+
+  it("uses a compatible fallback only after the selected provider fails", async () => {
     const braveExecute = vi.fn(async () => {
       throw new Error("brave unavailable");
     });
@@ -270,7 +324,7 @@ describe("web search runtime", () => {
       ...args,
       provider: "gemini",
     }));
-    const providers = [
+    resolveRuntimeWebSearchProvidersMock.mockReturnValue([
       createCustomSearchProvider({
         pluginId: "brave",
         id: "brave",
@@ -281,12 +335,7 @@ describe("web search runtime", () => {
           description: "Brave search",
           parameters: {
             type: "object",
-            properties: {
-              query: { type: "string" },
-              count: { type: "integer", minimum: 1, maximum: 10 },
-              country: { type: "string" },
-            },
-            required: ["query"],
+            properties: { query: { type: "string" }, country: { type: "string" } },
           },
           execute: braveExecute,
         }),
@@ -301,44 +350,16 @@ describe("web search runtime", () => {
           description: "Gemini search",
           parameters: {
             type: "object",
-            properties: {
-              query: { type: "string" },
-              count: { type: "integer", minimum: 1, maximum: 10 },
-              freshness: { type: "string" },
-            },
-            required: ["query"],
+            properties: { query: { type: "string" }, count: { type: "integer" } },
           },
           execute: geminiExecute,
         }),
       }),
-    ];
-    resolveRuntimeWebSearchProvidersMock.mockReturnValue(providers);
-    const runtimeWebSearch = {
-      providerSource: "auto-detect" as const,
-      selectedProvider: "brave",
-      selectedProviderKeySource: "config" as const,
-      diagnostics: [],
-    };
-
-    const resolved = resolveWebSearchDefinition({
-      config: {},
-      preferRuntimeProviders: true,
-      runtimeWebSearch,
-    });
-    const parameters = requireRecord(resolved?.definition.parameters);
-    const properties = requireRecord(parameters.properties);
-
-    expect(resolved?.provider.id).toBe("brave");
-    expect(Object.keys(properties)).toEqual(["query", "count"]);
-    expect(properties.country).toBeUndefined();
-    expect(properties.freshness).toBeUndefined();
-    expect(parameters.required).toEqual(["query"]);
-    expect(parameters.additionalProperties).toBe(false);
+    ]);
 
     await expect(
       runWebSearch({
         config: {},
-        runtimeWebSearch,
         args: { query: "fallback" },
       }),
     ).resolves.toEqual({
@@ -347,6 +368,54 @@ describe("web search runtime", () => {
     });
     expect(braveExecute).toHaveBeenCalledOnce();
     expect(geminiExecute).toHaveBeenCalledOnce();
+  });
+
+  it("does not pass provider-specific arguments to an incompatible fallback", async () => {
+    const geminiExecute = vi.fn(async () => ({ ok: true }));
+    resolveRuntimeWebSearchProvidersMock.mockReturnValue([
+      createCustomSearchProvider({
+        pluginId: "brave",
+        id: "brave",
+        autoDetectOrder: 1,
+        getConfiguredCredentialValue: () => "brave-configured",
+        getCredentialValue: () => "brave-configured",
+        createTool: () => ({
+          description: "Brave search",
+          parameters: {
+            type: "object",
+            properties: { query: { type: "string" }, country: { type: "string" } },
+          },
+          execute: async () => {
+            throw new Error("brave unavailable");
+          },
+        }),
+      }),
+      createCustomSearchProvider({
+        pluginId: "google",
+        id: "gemini",
+        autoDetectOrder: 2,
+        getConfiguredCredentialValue: () => "gemini-configured",
+        getCredentialValue: () => "gemini-configured",
+        createTool: () => ({
+          description: "Gemini search",
+          parameters: {
+            type: "object",
+            properties: { query: { type: "string" }, count: { type: "integer" } },
+          },
+          execute: geminiExecute,
+        }),
+      }),
+    ]);
+
+    await expect(
+      runWebSearch({
+        config: {},
+        args: { query: "fallback", country: "US" },
+      }),
+    ).rejects.toThrow(
+      'web_search fallback provider "gemini" does not accept provider-specific arguments: country',
+    );
+    expect(geminiExecute).not.toHaveBeenCalled();
   });
 
   it("keeps the full selected-provider schema when fallback is disabled", () => {

--- a/src/web-search/runtime.test.ts
+++ b/src/web-search/runtime.test.ts
@@ -166,6 +166,7 @@ function createDuckDuckGoSearchProvider(
 
 describe("web search runtime", () => {
   let hasUsableWebSearchProvider: typeof import("./runtime.js").hasUsableWebSearchProvider;
+  let resolveWebSearchDefinition: typeof import("./runtime.js").resolveWebSearchDefinition;
   let runWebSearch: typeof import("./runtime.js").runWebSearch;
   let activateSecretsRuntimeSnapshot: typeof import("../secrets/runtime.js").activateSecretsRuntimeSnapshot;
   let clearSecretsRuntimeSnapshot: typeof import("../secrets/runtime.js").clearSecretsRuntimeSnapshot;
@@ -174,7 +175,8 @@ describe("web search runtime", () => {
   const tempDirs: string[] = [];
 
   beforeAll(async () => {
-    ({ hasUsableWebSearchProvider, runWebSearch } = await import("./runtime.js"));
+    ({ hasUsableWebSearchProvider, resolveWebSearchDefinition, runWebSearch } =
+      await import("./runtime.js"));
     ({ activateSecretsRuntimeSnapshot, clearSecretsRuntimeSnapshot } =
       await import("../secrets/runtime.js"));
     ({ clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } =
@@ -225,6 +227,39 @@ describe("web search runtime", () => {
       provider: "custom",
       result: { query: "hello", ok: true },
     });
+  });
+
+  it("resolves model parameters through a scoped runtime provider load", () => {
+    const parameters = {
+      type: "object",
+      required: ["query"],
+      properties: { query: { type: "string" } },
+    };
+    const createTool = vi.fn(() => ({
+      description: "Gemini search",
+      parameters,
+      execute: async () => ({ ok: true }),
+    }));
+    const provider = createCustomSearchProvider({
+      pluginId: "google",
+      id: "gemini",
+      createTool,
+    });
+    resolveManifestContractOwnerPluginIdMock.mockReturnValue("google");
+    resolveRuntimeWebSearchProvidersMock.mockReturnValue([provider]);
+
+    const resolved = resolveWebSearchDefinition({
+      config: { tools: { web: { search: { provider: "gemini" } } } },
+      preferRuntimeProviders: true,
+      providerId: "gemini",
+    });
+
+    expect(resolved?.provider.id).toBe("gemini");
+    expect(resolved?.definition.parameters).toBe(parameters);
+    expect(resolveRuntimeWebSearchProvidersMock).toHaveBeenCalledWith(
+      expect.objectContaining({ onlyPluginIds: ["google"] }),
+    );
+    expect(createTool).toHaveBeenCalledOnce();
   });
 
   it("accepts the prepared provider selection without rediscovering providers", () => {

--- a/src/web-search/runtime.test.ts
+++ b/src/web-search/runtime.test.ts
@@ -370,6 +370,62 @@ describe("web search runtime", () => {
     expect(geminiExecute).toHaveBeenCalledOnce();
   });
 
+  it("strips the CLI-only limit alias before executing a compatible fallback", async () => {
+    const geminiExecute = vi.fn(async (args: Record<string, unknown>) => ({
+      ...args,
+      provider: "gemini",
+    }));
+    resolveRuntimeWebSearchProvidersMock.mockReturnValue([
+      createCustomSearchProvider({
+        pluginId: "brave",
+        id: "brave",
+        autoDetectOrder: 1,
+        getConfiguredCredentialValue: () => "brave-configured",
+        getCredentialValue: () => "brave-configured",
+        createTool: () => ({
+          description: "Brave search",
+          parameters: {
+            type: "object",
+            properties: { query: { type: "string" }, count: { type: "integer" } },
+          },
+          execute: async () => {
+            throw new Error("brave unavailable");
+          },
+        }),
+      }),
+      createCustomSearchProvider({
+        pluginId: "google",
+        id: "gemini",
+        autoDetectOrder: 2,
+        getConfiguredCredentialValue: () => "gemini-configured",
+        getCredentialValue: () => "gemini-configured",
+        createTool: () => ({
+          description: "Gemini search",
+          parameters: {
+            type: "object",
+            properties: { query: { type: "string" }, count: { type: "integer" } },
+          },
+          execute: geminiExecute,
+        }),
+      }),
+    ]);
+
+    await expect(
+      runWebSearch({
+        config: {},
+        args: { query: "fallback", count: 3, limit: 3 },
+      }),
+    ).resolves.toEqual({
+      provider: "gemini",
+      result: { query: "fallback", count: 3, provider: "gemini" },
+    });
+    expect(geminiExecute).toHaveBeenCalledOnce();
+    expect(geminiExecute).toHaveBeenCalledWith(
+      { query: "fallback", count: 3 },
+      { signal: undefined },
+    );
+  });
+
   it("does not pass provider-specific arguments to an incompatible fallback", async () => {
     const geminiExecute = vi.fn(async () => ({ ok: true }));
     resolveRuntimeWebSearchProvidersMock.mockReturnValue([

--- a/src/web-search/runtime.ts
+++ b/src/web-search/runtime.ts
@@ -432,7 +432,11 @@ function resolveSharedWebSearchParameters(
   }
 
   const concretePropertyMaps = propertyMaps as Record<string, unknown>[];
-  const sharedPropertyNames = Object.keys(concretePropertyMaps[0]).filter((name) =>
+  const selectedPropertyMap = concretePropertyMaps[0];
+  if (!selectedPropertyMap) {
+    throw new Error("Automatic web_search fallback has no parameter properties.");
+  }
+  const sharedPropertyNames = Object.keys(selectedPropertyMap).filter((name) =>
     concretePropertyMaps.every((properties) =>
       Object.prototype.hasOwnProperty.call(properties, name),
     ),

--- a/src/web-search/runtime.ts
+++ b/src/web-search/runtime.ts
@@ -407,79 +407,7 @@ function resolveWebSearchCandidates(
   return orderedProviders;
 }
 
-function asParameterSchemaRecord(value: unknown): Record<string, unknown> | null {
-  return value !== null && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
-
-function resolveSharedWebSearchParameters(
-  definitions: readonly WebSearchProviderToolDefinition[],
-): WebSearchProviderToolDefinition["parameters"] {
-  const selectedDefinition = definitions[0];
-  if (!selectedDefinition) {
-    throw new Error("Automatic web_search fallback has no provider definition.");
-  }
-  const selectedParameters = selectedDefinition.parameters;
-  if (definitions.length === 1) {
-    return selectedParameters;
-  }
-
-  const schemas = definitions.map((definition) => asParameterSchemaRecord(definition.parameters));
-  const propertyMaps = schemas.map((schema) => asParameterSchemaRecord(schema?.properties));
-  if (schemas.some((schema) => schema?.type !== "object") || propertyMaps.some((map) => !map)) {
-    throw new Error("Automatic web_search fallback requires object parameter schemas.");
-  }
-
-  const concretePropertyMaps = propertyMaps as Record<string, unknown>[];
-  const selectedPropertyMap = concretePropertyMaps[0];
-  if (!selectedPropertyMap) {
-    throw new Error("Automatic web_search fallback has no parameter properties.");
-  }
-  const sharedPropertyNames = Object.keys(selectedPropertyMap).filter((name) =>
-    concretePropertyMaps.every((properties) =>
-      Object.prototype.hasOwnProperty.call(properties, name),
-    ),
-  );
-  const sharedPropertyNameSet = new Set(sharedPropertyNames);
-  const requiredPropertyNames = uniqueStrings(
-    schemas.flatMap((schema) =>
-      Array.isArray(schema?.required)
-        ? schema.required.filter((name): name is string => typeof name === "string")
-        : [],
-    ),
-  );
-  const unsharedRequiredPropertyNames = requiredPropertyNames.filter(
-    (name) => !sharedPropertyNameSet.has(name),
-  );
-  if (unsharedRequiredPropertyNames.length > 0) {
-    throw new Error(
-      `Automatic web_search fallback has incompatible required parameters: ${unsharedRequiredPropertyNames.join(", ")}.`,
-    );
-  }
-
-  const properties = Object.fromEntries(
-    sharedPropertyNames.map((name) => {
-      const variants = concretePropertyMaps.map((propertyMap) => propertyMap[name]);
-      const firstVariantJson = JSON.stringify(variants[0]);
-      const parameterSchema = variants.every(
-        (variant) => JSON.stringify(variant) === firstVariantJson,
-      )
-        ? variants[0]
-        : { allOf: variants };
-      return [name, parameterSchema];
-    }),
-  );
-
-  return {
-    type: "object",
-    properties,
-    ...(requiredPropertyNames.length > 0 ? { required: requiredPropertyNames } : {}),
-    additionalProperties: false,
-  };
-}
-
-/** Resolves model parameters through the same provider candidates used by execution. */
+/** Resolves the selected provider definition without constructing fallback tools. */
 export function resolveWebSearchDefinition(options?: ResolveWebSearchDefinitionParams): {
   provider: PluginWebSearchProviderEntry;
   definition: WebSearchProviderToolDefinition;
@@ -494,45 +422,13 @@ export function resolveWebSearchDefinition(options?: ResolveWebSearchDefinitionP
   if (!provider) {
     return null;
   }
-  const providerContext = {
+  const definition = provider.createTool({
     config,
     agentDir: options?.agentDir,
     searchConfig: search as Record<string, unknown> | undefined,
     runtimeMetadata: runtimeWebSearch,
-  };
-  const definition = provider.createTool(providerContext);
-  if (!definition) {
-    return null;
-  }
-  if (
-    hasExplicitWebSearchSelection({
-      search,
-      runtimeWebSearch,
-      providerId: options?.providerId,
-      providers,
-    })
-  ) {
-    return { provider, definition };
-  }
-
-  const fallbackDefinitions = providers.slice(1).flatMap((candidate) => {
-    try {
-      const candidateDefinition = candidate.createTool(providerContext);
-      return candidateDefinition ? [candidateDefinition] : [];
-    } catch (error) {
-      logVerbose(
-        `web_search provider "${candidate.id}" schema resolution failed during fallback projection: ${String(error)}`,
-      );
-      return [];
-    }
   });
-  return {
-    provider,
-    definition: {
-      ...definition,
-      parameters: resolveSharedWebSearchParameters([definition, ...fallbackDefinitions]),
-    },
-  };
+  return definition ? { provider, definition } : null;
 }
 
 /** Reports whether web_search can use the prepared selection or resolve an agent-scoped provider. */

--- a/src/web-search/runtime.ts
+++ b/src/web-search/runtime.ts
@@ -14,7 +14,10 @@ import {
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { logVerbose } from "../globals.js";
 import { resolveManifestContractOwnerPluginId } from "../plugins/plugin-registry-contributions.js";
-import type { PluginWebSearchProviderEntry } from "../plugins/types.js";
+import type {
+  PluginWebSearchProviderEntry,
+  WebSearchProviderToolDefinition,
+} from "../plugins/types.js";
 import {
   resolvePluginWebSearchProviders,
   resolveRuntimeWebSearchProviders,
@@ -402,6 +405,29 @@ function resolveWebSearchCandidates(
     ...fallbackProviders.filter((entry) => !preferredIds.includes(entry.id)),
   ];
   return orderedProviders;
+}
+
+/** Resolves the selected provider's public tool definition through the execution load path. */
+export function resolveWebSearchDefinition(options?: ResolveWebSearchDefinitionParams): {
+  provider: PluginWebSearchProviderEntry;
+  definition: WebSearchProviderToolDefinition;
+} | null {
+  const { config, search, runtimeWebSearch } = resolveWebSearchRequestContext(options);
+  const provider = resolveWebSearchCandidates({
+    ...options,
+    config,
+    runtimeWebSearch,
+  })[0];
+  if (!provider) {
+    return null;
+  }
+  const definition = provider.createTool({
+    config,
+    agentDir: options?.agentDir,
+    searchConfig: search as Record<string, unknown> | undefined,
+    runtimeMetadata: runtimeWebSearch,
+  });
+  return definition ? { provider, definition } : null;
 }
 
 /** Reports whether web_search can use the prepared selection or resolve an agent-scoped provider. */

--- a/src/web-search/runtime.ts
+++ b/src/web-search/runtime.ts
@@ -407,27 +407,128 @@ function resolveWebSearchCandidates(
   return orderedProviders;
 }
 
-/** Resolves the selected provider's public tool definition through the execution load path. */
+function asParameterSchemaRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function resolveSharedWebSearchParameters(
+  definitions: readonly WebSearchProviderToolDefinition[],
+): WebSearchProviderToolDefinition["parameters"] {
+  const selectedDefinition = definitions[0];
+  if (!selectedDefinition) {
+    throw new Error("Automatic web_search fallback has no provider definition.");
+  }
+  const selectedParameters = selectedDefinition.parameters;
+  if (definitions.length === 1) {
+    return selectedParameters;
+  }
+
+  const schemas = definitions.map((definition) => asParameterSchemaRecord(definition.parameters));
+  const propertyMaps = schemas.map((schema) => asParameterSchemaRecord(schema?.properties));
+  if (schemas.some((schema) => schema?.type !== "object") || propertyMaps.some((map) => !map)) {
+    throw new Error("Automatic web_search fallback requires object parameter schemas.");
+  }
+
+  const concretePropertyMaps = propertyMaps as Record<string, unknown>[];
+  const sharedPropertyNames = Object.keys(concretePropertyMaps[0]).filter((name) =>
+    concretePropertyMaps.every((properties) =>
+      Object.prototype.hasOwnProperty.call(properties, name),
+    ),
+  );
+  const sharedPropertyNameSet = new Set(sharedPropertyNames);
+  const requiredPropertyNames = uniqueStrings(
+    schemas.flatMap((schema) =>
+      Array.isArray(schema?.required)
+        ? schema.required.filter((name): name is string => typeof name === "string")
+        : [],
+    ),
+  );
+  const unsharedRequiredPropertyNames = requiredPropertyNames.filter(
+    (name) => !sharedPropertyNameSet.has(name),
+  );
+  if (unsharedRequiredPropertyNames.length > 0) {
+    throw new Error(
+      `Automatic web_search fallback has incompatible required parameters: ${unsharedRequiredPropertyNames.join(", ")}.`,
+    );
+  }
+
+  const properties = Object.fromEntries(
+    sharedPropertyNames.map((name) => {
+      const variants = concretePropertyMaps.map((propertyMap) => propertyMap[name]);
+      const firstVariantJson = JSON.stringify(variants[0]);
+      const parameterSchema = variants.every(
+        (variant) => JSON.stringify(variant) === firstVariantJson,
+      )
+        ? variants[0]
+        : { allOf: variants };
+      return [name, parameterSchema];
+    }),
+  );
+
+  return {
+    type: "object",
+    properties,
+    ...(requiredPropertyNames.length > 0 ? { required: requiredPropertyNames } : {}),
+    additionalProperties: false,
+  };
+}
+
+/** Resolves model parameters through the same provider candidates used by execution. */
 export function resolveWebSearchDefinition(options?: ResolveWebSearchDefinitionParams): {
   provider: PluginWebSearchProviderEntry;
   definition: WebSearchProviderToolDefinition;
 } | null {
   const { config, search, runtimeWebSearch } = resolveWebSearchRequestContext(options);
-  const provider = resolveWebSearchCandidates({
+  const providers = resolveWebSearchCandidates({
     ...options,
     config,
     runtimeWebSearch,
-  })[0];
+  });
+  const provider = providers[0];
   if (!provider) {
     return null;
   }
-  const definition = provider.createTool({
+  const providerContext = {
     config,
     agentDir: options?.agentDir,
     searchConfig: search as Record<string, unknown> | undefined,
     runtimeMetadata: runtimeWebSearch,
+  };
+  const definition = provider.createTool(providerContext);
+  if (!definition) {
+    return null;
+  }
+  if (
+    hasExplicitWebSearchSelection({
+      search,
+      runtimeWebSearch,
+      providerId: options?.providerId,
+      providers,
+    })
+  ) {
+    return { provider, definition };
+  }
+
+  const fallbackDefinitions = providers.slice(1).flatMap((candidate) => {
+    try {
+      const candidateDefinition = candidate.createTool(providerContext);
+      return candidateDefinition ? [candidateDefinition] : [];
+    } catch (error) {
+      logVerbose(
+        `web_search provider "${candidate.id}" schema resolution failed during fallback projection: ${String(error)}`,
+      );
+      return [];
+    }
   });
-  return definition ? { provider, definition } : null;
+  return {
+    provider,
+    definition: {
+      ...definition,
+      parameters: resolveSharedWebSearchParameters([definition, ...fallbackDefinitions]),
+    },
+  };
 }
 
 /** Reports whether web_search can use the prepared selection or resolve an agent-scoped provider. */

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -1532,7 +1532,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Search current web; normalized provider results. Supports freshness and date-range filters (freshness, date_after/date_before) and domain filtering (domain_filter).",
+        "description": "Search current web and return normalized provider results. Available filters depend on the active provider.",
         "inputSchema": {
           "properties": {
             "count": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -221,8 +221,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 61490,
-    "roughTokens": 15373
+    "chars": 61433,
+    "roughTokens": 15359
   },
   "openClawDeveloperInstructions": {
     "chars": 3811,
@@ -233,8 +233,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 7049
   },
   "totalWithDynamicToolsJson": {
-    "chars": 89686,
-    "roughTokens": 22422
+    "chars": 89629,
+    "roughTokens": 22408
   },
   "userInputText": {
     "chars": 1300,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -221,8 +221,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 61182,
-    "roughTokens": 15296
+    "chars": 61125,
+    "roughTokens": 15282
   },
   "openClawDeveloperInstructions": {
     "chars": 2702,
@@ -233,8 +233,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6679
   },
   "totalWithDynamicToolsJson": {
-    "chars": 87898,
-    "roughTokens": 21975
+    "chars": 87841,
+    "roughTokens": 21961
   },
   "userInputText": {
     "chars": 929,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -222,8 +222,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 62716,
-    "roughTokens": 15679
+    "chars": 62659,
+    "roughTokens": 15665
   },
   "openClawDeveloperInstructions": {
     "chars": 2702,
@@ -234,8 +234,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6783
   },
   "totalWithDynamicToolsJson": {
-    "chars": 89848,
-    "roughTokens": 22462
+    "chars": 89791,
+    "roughTokens": 22448
   },
   "userInputText": {
     "chars": 1271,


### PR DESCRIPTION
Closes #118894.

## What Problem This Solves

Gemini Web Search exposed `country` and `language` in its model-facing schema even though its runtime rejects both arguments. The schema also crosses lazy plugin loading, agent normalization/hook wrappers, metadata-free credential auto-detection, and automatic provider fallback, so removing two fields only at one call site is not sufficient.

## What This Changes

- Gemini's provider-owned schema omits unsupported `country` and `language`; crafted, stale, or legacy calls are still rejected before provider fetch.
- Core resolves the selected provider schema through the execution-compatible scoped provider loader and preserves the late-bound accessor through normalization, metadata, `before_tool_call`, and tool-definition wrappers.
- Schema publication constructs only the selected provider definition. Fallback runtimes stay lazy until the selected provider actually fails.
- Automatic fallback validates supplied arguments against each candidate's published schema. It immutably drops only undefined CLI options and the unsupported CLI-only `limit` alias; defined canonical arguments remain, and genuine provider-specific arguments are still rejected instead of being forwarded incorrectly.
- Metadata-free credential discovery remains runtime-lazy. A new optional `webSearchProviderMetadata` manifest family lets a web-search provider declare cheap `configSignals`, parallel to the existing image/video/music capability metadata, without provider-specific core code.
- Manifest credential signals now pass through the existing control-plane plugin-availability policy before they can enable schema resolution or security-audit exposure.
- Explicit provider selection keeps its provider's complete schema and continues to disable fallback. Unknown/unresolved selection retains the existing generic schema.

No web-search feature or supported provider argument is disabled.

## Maintainer Decision Requested

This PR proposes adopting `webSearchProviderMetadata` as a documented optional plugin-manifest contract for static web-search credential/config signals. The field is normalized, preserved in registry records, documented beside the parallel capability metadata families, and covered by compatibility tests.

Recommended decision: adopt the generic manifest field. It keeps external providers provider-neutral and runtime-lazy. If maintainers do not want this public contract, the alternative is to reject the field and request a narrower supported seam; this PR does not claim contributor-side approval on the maintainers' behalf.

## Regression Evidence

Focused regressions cover:

- Gemini's generated schema omits `country` and `language`, while crafted unsupported calls still fail before fetch;
- selected schema resolution uses the execution-compatible scoped loader and does not eagerly construct fallback tools;
- provider schema access remains late-bound through agent normalization and hook wrappers;
- query-only fallback succeeds for the CLI-shaped `{ query, count: undefined, limit: undefined }` input and executes with `{ query }`;
- defined canonical `count` is preserved, while actual provider-specific arguments cannot cross into an incompatible fallback;
- model-provider credential fallback is discovered from static manifest metadata without importing provider runtime;
- explicitly disabled, denylisted, and restrictive-allowlist-excluded plugins cannot enable manifest credential discovery;
- manifest normalization and registry persistence retain the new optional metadata family.

Official exact-head Actions run [30943248594](https://github.com/openclaw/openclaw/actions/runs/30943248594) is the verification authority. Exact-head documentation/formatting, lint, production types, test types, prompt snapshots, plugin contracts, security, static analysis, and the other completed Node shards passed. Three nondeterministic lanes need a maintainer rerun: a Doctor test timed out at 120 seconds, the `agents-core` Vitest process was terminated after 300 seconds without output, and an unrelated TUI/PTTY shared Gateway fixture closed with WebSocket 1006 before eight dependent tests. The exact job evidence and passing counts are recorded in [this CI triage comment](https://github.com/openclaw/openclaw/pull/118896#issuecomment-5183816840). GitHub rejected the contributor-side native failed-job rerun with `Must have admin rights to Repository`; no permissions were bypassed and no replacement workflow was created.

The repository's pinned `oxfmt@0.60.0` output for the two previously listed files was obtained in a temporary read-only fork workflow and applied exactly: [formatter run 30943092912](https://github.com/ZYV5ge/openclaw/actions/runs/30943092912). The temporary branch and workflow were deleted after the patch was retrieved.

`git diff --check` and plugin-manifest JSON parsing pass. No local dependency installation, test, or build was performed. A live credentialed Gemini provider call remains honestly unclaimed.

## Scope and Safety

- Exact head: `5b87cceb6972b815830506e163d6d8b77830326c`
- Frozen upstream base: `832459d2ae76a08f17dfdb95dad78a5db4599762`
- Surface: 23 files, +1073/-51

The change is limited to Gemini's existing provider schema, internal web-search schema/candidate handling, manifest-owned static credential metadata, preservation of a dynamic parameter accessor through existing agent-tool wrappers, documentation, prompt snapshots, and focused tests. It does not change credentials, models, Gateway configuration, workflows, dependencies, versions, or user data.

## AI Assistance

AI assistance was used to trace the schema lifecycle, prepare tests and implementation, inspect exact-head review findings, and draft this description. All behavior and evidence claims are limited to the exact diff and linked official Actions.
