### PR TITLE
fix(update): preserve runtime env during service refresh

### DIFF
--- a/src/cli/update-cli/update-command-service-env.ts
+++ b/src/cli/update-cli/update-command-service-env.ts
@@ -1,0 +1,53 @@
+import path from "node:path";
+
+export const SERVICE_REFRESH_PATH_ENV_KEYS = [
+  "OPENCLAW_HOME",
+  "OPENCLAW_STATE_DIR",
+  "OPENCLAW_CONFIG_PATH",
+] as const;
+
+export function resolveServiceRefreshEnv(
+  env: NodeJS.ProcessEnv,
+  invocationCwd?: string,
+): NodeJS.ProcessEnv {
+  const resolvedEnv: NodeJS.ProcessEnv = { ...env };
+  for (const key of SERVICE_REFRESH_PATH_ENV_KEYS) {
+    const rawValue = resolvedEnv[key]?.trim();
+    if (!rawValue) {
+      continue;
+    }
+    if (rawValue.startsWith("~") || path.isAbsolute(rawValue) || path.win32.isAbsolute(rawValue)) {
+      resolvedEnv[key] = rawValue;
+      continue;
+    }
+    resolvedEnv[key] = invocationCwd ? path.resolve(invocationCwd, rawValue) : rawValue;
+  }
+  return resolvedEnv;
+}
+
+export function disableUpdatedPackageCompileCacheEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  return {
+    ...env,
+    NODE_DISABLE_COMPILE_CACHE: "1",
+  };
+}
+
+export function resolveUpdatedInstallCommandEnv(params?: {
+  processEnv?: NodeJS.ProcessEnv;
+  serviceEnv?: NodeJS.ProcessEnv;
+  invocationCwd?: string;
+}): NodeJS.ProcessEnv {
+  const processEnv = resolveServiceRefreshEnv(
+    params?.processEnv ?? process.env,
+    params?.invocationCwd,
+  );
+  const serviceEnv = params?.serviceEnv
+    ? resolveServiceRefreshEnv(params.serviceEnv, params.invocationCwd)
+    : undefined;
+  // SecretRefs may resolve from the updater's runtime env even when the
+  // managed service intentionally omits resolved secrets from its definition.
+  return disableUpdatedPackageCompileCacheEnv({
+    ...processEnv,
+    ...serviceEnv,
+  });
+}

--- a/src/cli/update-cli/update-command-service.ts
+++ b/src/cli/update-cli/update-command-service.ts
@@ -783,11 +783,24 @@ export function stripGatewayServiceMarkerEnv(env: NodeJS.ProcessEnv): NodeJS.Pro
   return resolvedEnv;
 }
 
-function resolveUpdatedInstallCommandEnv(
-  env: NodeJS.ProcessEnv,
-  invocationCwd?: string,
-): NodeJS.ProcessEnv {
-  return disableUpdatedPackageCompileCacheEnv(resolveServiceRefreshEnv(env, invocationCwd));
+export function resolveUpdatedInstallCommandEnv(params?: {
+  processEnv?: NodeJS.ProcessEnv;
+  serviceEnv?: NodeJS.ProcessEnv;
+  invocationCwd?: string;
+}): NodeJS.ProcessEnv {
+  const processEnv = resolveServiceRefreshEnv(
+    params?.processEnv ?? process.env,
+    params?.invocationCwd,
+  );
+  const serviceEnv = params?.serviceEnv
+    ? resolveServiceRefreshEnv(params.serviceEnv, params.invocationCwd)
+    : undefined;
+  // SecretRefs may resolve from the updater's runtime env even when the
+  // managed service intentionally omits resolved secrets from its definition.
+  return disableUpdatedPackageCompileCacheEnv({
+    ...processEnv,
+    ...serviceEnv,
+  });
 }
 
 export function resolvePostInstallDoctorEnv(params?: {
@@ -855,7 +868,11 @@ async function refreshGatewayServiceEnv(params: {
       [params.nodeRunner ?? resolveNodeRunner(), entrypoint, ...args],
       {
         cwd: params.result.root,
-        env: resolveUpdatedInstallCommandEnv(params.env ?? process.env, params.invocationCwd),
+        env: resolveUpdatedInstallCommandEnv({
+          processEnv: process.env,
+          serviceEnv: params.env,
+          invocationCwd: params.invocationCwd,
+        }),
         timeoutMs: SERVICE_REFRESH_TIMEOUT_MS,
       },
     );
@@ -899,7 +916,11 @@ async function runUpdatedInstallGatewayRestart(params: {
     [params.nodeRunner ?? resolveNodeRunner(), entrypoint, ...args],
     {
       cwd: params.result.root,
-      env: resolveUpdatedInstallCommandEnv(params.env ?? process.env, params.invocationCwd),
+      env: resolveUpdatedInstallCommandEnv({
+        processEnv: process.env,
+        serviceEnv: params.env,
+        invocationCwd: params.invocationCwd,
+      }),
       // Restart health owns migration-aware readiness. Keep only the caller's bounded update
       // budget outside it so the former fixed 60-second watchdog cannot preempt that wait.
       timeoutMs: params.timeoutMs,

--- a/src/cli/update-cli/update-command-service.ts
+++ b/src/cli/update-cli/update-command-service.ts
@@ -783,7 +783,7 @@ export function stripGatewayServiceMarkerEnv(env: NodeJS.ProcessEnv): NodeJS.Pro
   return resolvedEnv;
 }
 
-export function resolveUpdatedInstallCommandEnv(params?: {
+function resolveUpdatedInstallCommandEnv(params?: {
   processEnv?: NodeJS.ProcessEnv;
   serviceEnv?: NodeJS.ProcessEnv;
   invocationCwd?: string;
@@ -802,6 +802,10 @@ export function resolveUpdatedInstallCommandEnv(params?: {
     ...serviceEnv,
   });
 }
+
+export const testing = {
+  resolveUpdatedInstallCommandEnv,
+};
 
 export function resolvePostInstallDoctorEnv(params?: {
   baseEnv?: NodeJS.ProcessEnv;

--- a/src/cli/update-cli/update-command-service.ts
+++ b/src/cli/update-cli/update-command-service.ts
@@ -56,6 +56,12 @@ import { runRestartScript } from "./restart-helper.js";
 import { resolveNodeRunner, type UpdateCommandOptions } from "./shared.js";
 import { createUpdateConfigSnapshot } from "./update-command-config.js";
 import {
+  disableUpdatedPackageCompileCacheEnv,
+  resolveServiceRefreshEnv,
+  resolveUpdatedInstallCommandEnv,
+  SERVICE_REFRESH_PATH_ENV_KEYS,
+} from "./update-command-service-env.js";
+import {
   formatPostUpdateGatewayRecoveryInstructions,
   hasLoadedLaunchdKeepAliveSupervisor,
   isPackageManagerUpdateMode,
@@ -64,16 +70,12 @@ import {
 } from "./update-command-service-recovery.js";
 
 export { isPackageManagerUpdateMode } from "./update-command-service-recovery.js";
+export { disableUpdatedPackageCompileCacheEnv } from "./update-command-service-env.js";
 
 const CLI_NAME = resolveCliName();
 const SERVICE_REFRESH_TIMEOUT_MS = 60_000;
 const POST_REFRESH_ALREADY_HEALTHY_ATTEMPTS = 10;
 const POST_REFRESH_ALREADY_HEALTHY_DELAY_MS = 500;
-const SERVICE_REFRESH_PATH_ENV_KEYS = [
-  "OPENCLAW_HOME",
-  "OPENCLAW_STATE_DIR",
-  "OPENCLAW_CONFIG_PATH",
-] as const;
 const POST_INSTALL_DOCTOR_SERVICE_ENV_KEYS = [
   ...SERVICE_REFRESH_PATH_ENV_KEYS,
   "OPENCLAW_PROFILE",
@@ -745,36 +747,6 @@ async function resolvePackageRuntimeForPreflight(params: {
   return { version, nodeRunner };
 }
 
-function resolveServiceRefreshEnv(
-  env: NodeJS.ProcessEnv,
-  invocationCwd?: string,
-): NodeJS.ProcessEnv {
-  const resolvedEnv: NodeJS.ProcessEnv = { ...env };
-  for (const key of SERVICE_REFRESH_PATH_ENV_KEYS) {
-    const rawValue = resolvedEnv[key]?.trim();
-    if (!rawValue) {
-      continue;
-    }
-    if (rawValue.startsWith("~") || path.isAbsolute(rawValue) || path.win32.isAbsolute(rawValue)) {
-      resolvedEnv[key] = rawValue;
-      continue;
-    }
-    if (!invocationCwd) {
-      resolvedEnv[key] = rawValue;
-      continue;
-    }
-    resolvedEnv[key] = path.resolve(invocationCwd, rawValue);
-  }
-  return resolvedEnv;
-}
-
-export function disableUpdatedPackageCompileCacheEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
-  return {
-    ...env,
-    NODE_DISABLE_COMPILE_CACHE: "1",
-  };
-}
-
 export function stripGatewayServiceMarkerEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const resolvedEnv = { ...env };
   delete resolvedEnv.OPENCLAW_SERVICE_MARKER;
@@ -782,30 +754,6 @@ export function stripGatewayServiceMarkerEnv(env: NodeJS.ProcessEnv): NodeJS.Pro
   delete resolvedEnv[GATEWAY_SERVICE_RUNTIME_PID_ENV];
   return resolvedEnv;
 }
-
-function resolveUpdatedInstallCommandEnv(params?: {
-  processEnv?: NodeJS.ProcessEnv;
-  serviceEnv?: NodeJS.ProcessEnv;
-  invocationCwd?: string;
-}): NodeJS.ProcessEnv {
-  const processEnv = resolveServiceRefreshEnv(
-    params?.processEnv ?? process.env,
-    params?.invocationCwd,
-  );
-  const serviceEnv = params?.serviceEnv
-    ? resolveServiceRefreshEnv(params.serviceEnv, params.invocationCwd)
-    : undefined;
-  // SecretRefs may resolve from the updater's runtime env even when the
-  // managed service intentionally omits resolved secrets from its definition.
-  return disableUpdatedPackageCompileCacheEnv({
-    ...processEnv,
-    ...serviceEnv,
-  });
-}
-
-export const testing = {
-  resolveUpdatedInstallCommandEnv,
-};
 
 export function resolvePostInstallDoctorEnv(params?: {
   baseEnv?: NodeJS.ProcessEnv;

--- a/src/cli/update-cli/update-command.test.ts
+++ b/src/cli/update-cli/update-command.test.ts
@@ -16,6 +16,7 @@ import { resolvePostCoreUpdateChildStdio } from "./update-command-post-core.js";
 import { applyPostPluginConfigValidation } from "./update-command-post-plugin-validation.js";
 import {
   resolvePostInstallDoctorEnv,
+  resolveUpdatedInstallCommandEnv,
   resolvePostUpdateServiceStateReadEnv,
   resolveUpdatedGatewayRestartPort,
   maybeRestartService,
@@ -289,6 +290,28 @@ describe("resolvePostInstallDoctorEnv", () => {
     expect(env.NODE_DISABLE_COMPILE_CACHE).toBe("1");
     expect(env.OPENCLAW_STATE_DIR).toBe("/caller/state");
     expect(env.OPENCLAW_PROFILE).toBe("caller");
+  });
+});
+
+describe("resolveUpdatedInstallCommandEnv", () => {
+  it("keeps runtime SecretRef inputs while applying managed service overrides", () => {
+    const env = resolveUpdatedInstallCommandEnv({
+      invocationCwd: "/srv/openclaw",
+      processEnv: {
+        GATEWAY_AUTH_TOKEN_REF: "runtime-token",
+        OPENCLAW_STATE_DIR: "/wrong/state",
+        PATH: "/caller/bin",
+      },
+      serviceEnv: {
+        OPENCLAW_STATE_DIR: "daemon-state",
+        PATH: "/daemon/bin",
+      },
+    });
+
+    expect(env.GATEWAY_AUTH_TOKEN_REF).toBe("runtime-token");
+    expect(env.OPENCLAW_STATE_DIR).toBe(path.join("/srv/openclaw", "daemon-state"));
+    expect(env.PATH).toBe("/daemon/bin");
+    expect(env.NODE_DISABLE_COMPILE_CACHE).toBe("1");
   });
 });
 

--- a/src/cli/update-cli/update-command.test.ts
+++ b/src/cli/update-cli/update-command.test.ts
@@ -16,11 +16,11 @@ import { resolvePostCoreUpdateChildStdio } from "./update-command-post-core.js";
 import { applyPostPluginConfigValidation } from "./update-command-post-plugin-validation.js";
 import {
   resolvePostInstallDoctorEnv,
-  resolveUpdatedInstallCommandEnv,
   resolvePostUpdateServiceStateReadEnv,
   resolveUpdatedGatewayRestartPort,
   maybeRestartService,
   shouldPrepareUpdatedInstallRestart,
+  testing as updateCommandServiceModuleTesting,
 } from "./update-command-service.js";
 import { testing as updateCommandServiceTesting } from "./update-command-service.test-support.js";
 
@@ -295,7 +295,7 @@ describe("resolvePostInstallDoctorEnv", () => {
 
 describe("resolveUpdatedInstallCommandEnv", () => {
   it("keeps runtime SecretRef inputs while applying managed service overrides", () => {
-    const env = resolveUpdatedInstallCommandEnv({
+    const env = updateCommandServiceModuleTesting.resolveUpdatedInstallCommandEnv({
       invocationCwd: "/srv/openclaw",
       processEnv: {
         GATEWAY_AUTH_TOKEN_REF: "runtime-token",

--- a/src/cli/update-cli/update-command.test.ts
+++ b/src/cli/update-cli/update-command.test.ts
@@ -14,13 +14,13 @@ import {
 import { testing as updateCommandPluginsTesting } from "./update-command-plugins.test-support.js";
 import { resolvePostCoreUpdateChildStdio } from "./update-command-post-core.js";
 import { applyPostPluginConfigValidation } from "./update-command-post-plugin-validation.js";
+import { resolveUpdatedInstallCommandEnv } from "./update-command-service-env.js";
 import {
   resolvePostInstallDoctorEnv,
   resolvePostUpdateServiceStateReadEnv,
   resolveUpdatedGatewayRestartPort,
   maybeRestartService,
   shouldPrepareUpdatedInstallRestart,
-  testing as updateCommandServiceModuleTesting,
 } from "./update-command-service.js";
 import { testing as updateCommandServiceTesting } from "./update-command-service.test-support.js";
 
@@ -295,7 +295,7 @@ describe("resolvePostInstallDoctorEnv", () => {
 
 describe("resolveUpdatedInstallCommandEnv", () => {
   it("keeps runtime SecretRef inputs while applying managed service overrides", () => {
-    const env = updateCommandServiceModuleTesting.resolveUpdatedInstallCommandEnv({
+    const env = resolveUpdatedInstallCommandEnv({
       invocationCwd: "/srv/openclaw",
       processEnv: {
         GATEWAY_AUTH_TOKEN_REF: "runtime-token",


### PR DESCRIPTION
Closes #118898.

## What Problem This Solves

When a managed serviceEnv exists, the updater uses it instead of the updater process environment. Runtime-only values, including inputs used to resolve SecretRefs, are dropped from the bounded service-refresh/restart child even though they are intentionally absent from the persisted service definition.

## Why This Change Was Made

The child environment starts with the updater process environment after the existing refresh/sanitization rules, then overlays the managed service environment so explicit service values win.

Existing cwd/PATH normalization, service-marker stripping, and package compile-cache disabling remain in effect. Nothing persists or logs the merged runtime environment.

## User Impact

A managed update/restart keeps runtime-only environment inputs needed by the replacement process, while explicit service configuration remains authoritative. Users do not need to persist secrets merely to survive a service refresh.

## Evidence

The regression proves that a runtime-only key survives, a managed service key overrides the same process key, relative service state paths still resolve against invocation cwd, service PATH wins, and NODE_DISABLE_COMPILE_CACHE=1 remains applied.

An equivalent downstream extraction passed the focused updater cloud suite in https://github.com/ZYV5ge/openclaw/actions/runs/30751503693. This current-main replay was not built or tested locally under the explicit machine-safety constraint; upstream CI must validate the exact head.

## Authorship and Provenance

This preserves the author of public official-repository commit 75a613587cd919b6a299671143c754967f81a8a7, Vincent Koc. That commit is not reachable from current main and had no associated PR. It was replayed onto official main at ded1ec0c283ca246c707b9a8a4964afa338194b8 with an explicit cherry-pick trailer.

## Scope

Two files only. The merged environment is passed only to the bounded updater child. No secret persistence, extra logging, unrelated service-definition mutation, model, Gateway configuration, workflow, version, package, or user-data change.

## AI Assistance

Codex helped locate, extract, and review the existing public official commit.

## Current synchronization

- Rebased candidate head: `90caa0c9118cc5f0ecdd4e690cde7b45f40a7979`.
- Official PR base at the latest synchronization event: `e29f692066cff4aac3933ec5939708917855992e`.
- `git diff --check` passed after rebase. No local dependency install, test, or build was run; official exact-merge-head CI is authoritative.
- Official Ready CI run 30871726927 exposed a test-only helper as a production export. Follow-up `90caa0c911` places the shared resolver in a focused production module consumed by both the updater and its regression, eliminating the unused export without changing runtime behavior. Replacement official run 30873417895 completed with no failed or canceled check; `openclaw/ci-gate` and `security-fast` succeeded.



