### PR TITLE
test(tui): add reusable PTY evidence producer

### DIFF
--- a/qa/scenarios/ui/tui-pty-evidence-producer-contract.yaml
+++ b/qa/scenarios/ui/tui-pty-evidence-producer-contract.yaml
@@ -1,0 +1,33 @@
+title: TUI PTY evidence producer contract
+scenario:
+  id: tui-pty-evidence-producer-contract
+  surface: tui
+  category: tui.input-and-commands
+  coverage:
+    secondary:
+      - tui.message-composition
+  risk: low
+  objective: Run an allowlisted real TUI PTY assertion and authenticate its Vitest result as bounded QA script evidence.
+  successCriteria:
+    - The producer rejects undeclared coverage IDs and arbitrary test paths.
+    - The configured TUI PTY assertion passes in its requested test file.
+    - Fresh Vitest, proof-matrix, latest-run, and QA evidence artifacts are emitted.
+  codeRefs:
+    - test/e2e/qa-lab/tui/tui-pty-evidence-producer.ts
+    - test/e2e/qa-lab/tui/tui-pty-evidence-producer.test.ts
+    - src/tui/tui-pty-harness.e2e.test.ts
+  execution:
+    kind: script
+    path: test/e2e/qa-lab/tui/tui-pty-evidence-producer.ts
+    summary: Runs configured TUI PTY assertions through the repository Vitest wrapper and verifies the fresh JSON report before emitting evidence.
+    timeoutMs: 180000
+    args:
+      - --artifact-base
+      - ${outputDir}
+      - --scenario-id
+      - ${scenarioId}
+    config:
+      tuiPtyCases:
+        - coverageId: tui.message-composition
+          testFile: src/tui/tui-pty-harness.e2e.test.ts
+          testNamePattern: ^TUI PTY harness drives the real TUI terminal loop through typed and fragmented Unicode input$

--- a/test/e2e/qa-lab/tui/tui-pty-evidence-producer.test.ts
+++ b/test/e2e/qa-lab/tui/tui-pty-evidence-producer.test.ts
@@ -1,0 +1,333 @@
+// TUI PTY evidence producer tests cover validation, command routing, and reports.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  validateQaEvidenceSummaryJson,
+  type QaSeedScenarioWithSource,
+} from "../../../../extensions/qa-lab/api.js";
+import { useAutoCleanupTempDirTracker } from "../../../helpers/temp-dir.js";
+import {
+  buildTuiPtyVitestCommand,
+  parseTuiPtyProducerOptions,
+  runTuiPtyEvidenceProducer,
+  validateTuiPtyScenario,
+  verifyTuiPtyVitestReport,
+  type TuiPtyCase,
+} from "./tui-pty-evidence-producer.js";
+
+const SOURCE_PATH = "test/e2e/qa-lab/tui/tui-pty-evidence-producer.ts";
+const HARNESS_FILE = "src/tui/tui-pty-harness.e2e.test.ts";
+const LOCAL_FILE = "src/tui/tui-pty-local.e2e.test.ts";
+const RESET_FILE = "src/tui/tui-reset-transition-pty.e2e.test.ts";
+const COVERAGE_ID = "tui.message-composition";
+const TEST_NAME = "TUI PTY harness drives the real TUI terminal loop";
+const TEST_PATTERN = `^${TEST_NAME}$`;
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(() => vi.unstubAllEnvs());
+
+function makeScenario(
+  params: {
+    cases?: unknown[];
+    primary?: string[];
+    secondary?: string[];
+    executionKind?: "script" | "vitest";
+    executionPath?: string;
+  } = {},
+): QaSeedScenarioWithSource {
+  const execution =
+    params.executionKind === "vitest"
+      ? {
+          kind: "vitest" as const,
+          path: params.executionPath ?? SOURCE_PATH,
+          config: { tuiPtyCases: params.cases ?? [makeCase()] },
+        }
+      : {
+          kind: "script" as const,
+          path: params.executionPath ?? SOURCE_PATH,
+          config: { tuiPtyCases: params.cases ?? [makeCase()] },
+        };
+  return {
+    id: "tui-pty-producer-test",
+    title: "TUI PTY producer test",
+    surface: "tui",
+    objective: "Prove the TUI PTY evidence producer contract.",
+    successCriteria: ["The configured PTY assertion passes."],
+    sourcePath: "qa/scenarios/ui/tui-pty-producer-test.yaml",
+    coverage: {
+      primary: params.primary ?? [],
+      ...(params.secondary ? { secondary: params.secondary } : { secondary: [COVERAGE_ID] }),
+    },
+    execution,
+  };
+}
+
+function makeCase(overrides: Partial<TuiPtyCase> = {}): TuiPtyCase {
+  return {
+    coverageId: COVERAGE_ID,
+    testFile: HARNESS_FILE,
+    testNamePattern: TEST_PATTERN,
+    ...overrides,
+  };
+}
+
+async function makeTempRepo() {
+  const repoRoot = tempDirs.make("openclaw-tui-pty-producer-");
+  for (const testFile of [HARNESS_FILE, LOCAL_FILE, RESET_FILE]) {
+    const absolutePath = path.join(repoRoot, testFile);
+    await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+    await fs.writeFile(absolutePath, "// fixture\n", "utf8");
+  }
+  return repoRoot;
+}
+
+async function writeReport(
+  reportPath: string,
+  params: {
+    assertionName?: string;
+    failed?: number;
+    passed?: number;
+    testFile?: string;
+  } = {},
+) {
+  const assertionName = params.assertionName ?? TEST_NAME;
+  await fs.mkdir(path.dirname(reportPath), { recursive: true });
+  await fs.writeFile(
+    reportPath,
+    `${JSON.stringify({
+      numFailedTests: params.failed ?? 0,
+      numPassedTests: params.passed ?? 1,
+      success: (params.failed ?? 0) === 0,
+      testResults: [
+        {
+          name: params.testFile ?? HARNESS_FILE,
+          assertionResults:
+            (params.passed ?? 1) > 0
+              ? [{ fullName: assertionName, status: "passed", title: assertionName }]
+              : [],
+        },
+      ],
+    })}\n`,
+    "utf8",
+  );
+}
+
+describe("TUI PTY evidence producer", () => {
+  it("accepts only the two required CLI arguments exactly once", () => {
+    expect(
+      parseTuiPtyProducerOptions(
+        ["--artifact-base", ".artifacts/pty", "--scenario-id", "scenario-id"],
+        "/repo",
+      ),
+    ).toEqual({
+      artifactBase: path.resolve("/repo/.artifacts/pty"),
+      repoRoot: path.resolve("/repo"),
+      scenarioId: "scenario-id",
+    });
+    expect(() => parseTuiPtyProducerOptions([], "/repo")).toThrow("--artifact-base is required");
+    expect(() =>
+      parseTuiPtyProducerOptions(["--artifact-base", "out", "--extra", "value"], "/repo"),
+    ).toThrow("unsupported TUI PTY evidence producer argument");
+    expect(() =>
+      parseTuiPtyProducerOptions(
+        ["--artifact-base", "one", "--artifact-base", "two", "--scenario-id", "id"],
+        "/repo",
+      ),
+    ).toThrow("--artifact-base was provided more than once");
+  });
+
+  it("rejects arbitrary paths, traversal, malformed cases, and invalid patterns", () => {
+    expect(() =>
+      validateTuiPtyScenario(
+        makeScenario({
+          cases: [makeCase({ testFile: "../outside.test.ts" as typeof HARNESS_FILE })],
+        }),
+      ),
+    ).toThrow("testFile is not allowlisted");
+    expect(() =>
+      validateTuiPtyScenario(
+        makeScenario({
+          cases: [makeCase({ testFile: "src/tui/other.e2e.test.ts" as typeof HARNESS_FILE })],
+        }),
+      ),
+    ).toThrow("testFile is not allowlisted");
+    expect(() =>
+      validateTuiPtyScenario(makeScenario({ cases: [{ ...makeCase(), extra: true }] })),
+    ).toThrow("contains unsupported key extra");
+    expect(() =>
+      validateTuiPtyScenario(makeScenario({ cases: [makeCase({ testNamePattern: "[" })] })),
+    ).toThrow("testNamePattern is invalid");
+  });
+
+  it("requires declared coverage, every primary ID, unique cases, and the producer path", () => {
+    expect(() =>
+      validateTuiPtyScenario(
+        makeScenario({ cases: [makeCase({ coverageId: "tui.output-safety" })] }),
+      ),
+    ).toThrow("coverage ID not owned by scenario");
+    expect(() =>
+      validateTuiPtyScenario(
+        makeScenario({
+          primary: [COVERAGE_ID, "tui.output-safety"],
+          cases: [makeCase()],
+        }),
+      ),
+    ).toThrow("primary coverage IDs without TUI PTY cases: tui.output-safety");
+    expect(() => validateTuiPtyScenario(makeScenario({ cases: [makeCase(), makeCase()] }))).toThrow(
+      "duplicate TUI PTY case",
+    );
+    expect(() => validateTuiPtyScenario(makeScenario({ executionKind: "vitest" }))).toThrow(
+      "execution.kind=script",
+    );
+    expect(() => validateTuiPtyScenario(makeScenario({ executionPath: "test/other.ts" }))).toThrow(
+      `must execute ${SOURCE_PATH}`,
+    );
+  });
+
+  it("builds fake and local PTY commands with the required environment", () => {
+    vi.stubEnv("OPENCLAW_TUI_PTY_INCLUDE_LOCAL", "1");
+    const fake = buildTuiPtyVitestCommand({
+      cases: [makeCase()],
+      repoRoot: "/repo",
+      reportPath: "/artifacts/report.json",
+    });
+    expect(fake.args).toEqual(
+      expect.arrayContaining([
+        "scripts/run-vitest.mjs",
+        "run",
+        "--config",
+        "test/vitest/vitest.tui-pty.config.ts",
+        HARNESS_FILE,
+        "--reporter=json",
+        "--outputFile.json=/artifacts/report.json",
+      ]),
+    );
+    expect(fake.env.OPENCLAW_BEHAVIOR_EVIDENCE).toBe("1");
+    expect(fake.env.OPENCLAW_TUI_PTY_INCLUDE_LOCAL).toBeUndefined();
+
+    const local = buildTuiPtyVitestCommand({
+      cases: [makeCase({ testFile: LOCAL_FILE })],
+      repoRoot: "/repo",
+      reportPath: "/artifacts/report.json",
+    });
+    expect(local.args).toContain(LOCAL_FILE);
+    expect(local.env.OPENCLAW_TUI_PTY_INCLUDE_LOCAL).toBe("1");
+  });
+
+  it("rejects wrong-file and unmatched-pattern reports", async () => {
+    const repoRoot = await makeTempRepo();
+    await expect(
+      verifyTuiPtyVitestReport({
+        cases: [makeCase()],
+        repoRoot,
+        report: {
+          success: true,
+          numFailedTests: 0,
+          numPassedTests: 1,
+          testResults: [
+            {
+              name: RESET_FILE,
+              assertionResults: [{ fullName: TEST_NAME, status: "passed" }],
+            },
+          ],
+        },
+      }),
+    ).rejects.toThrow(`no result for configured test file ${HARNESS_FILE}`);
+    await expect(
+      verifyTuiPtyVitestReport({
+        cases: [makeCase()],
+        repoRoot,
+        report: {
+          success: true,
+          numFailedTests: 0,
+          numPassedTests: 1,
+          testResults: [
+            {
+              name: HARNESS_FILE,
+              assertionResults: [{ fullName: "another assertion", status: "passed" }],
+            },
+          ],
+        },
+      }),
+    ).rejects.toThrow("no passed assertion");
+  });
+
+  it("fails when the child writes no fresh report or writes a stale report", async () => {
+    const repoRoot = await makeTempRepo();
+    const artifactBase = path.join(repoRoot, ".artifacts", "missing-report");
+    const scenario = makeScenario();
+    const missing = await runTuiPtyEvidenceProducer(
+      { artifactBase, repoRoot, scenarioId: scenario.id },
+      {
+        loadScenario: () => scenario,
+        runCommand: async () => ({ exitCode: 0, signal: null }),
+      },
+    );
+    expect(missing.entries[0]?.result).toMatchObject({
+      status: "fail",
+      failure: { reason: expect.stringContaining("did not write vitest-report.json") },
+    });
+
+    const staleBase = path.join(repoRoot, ".artifacts", "stale-report");
+    const stale = await runTuiPtyEvidenceProducer(
+      { artifactBase: staleBase, repoRoot, scenarioId: scenario.id },
+      {
+        loadScenario: () => scenario,
+        now: () => 10_000,
+        runCommand: async (command) => {
+          const reportPath = command.args
+            .find((arg) => arg.startsWith("--outputFile.json="))
+            ?.slice("--outputFile.json=".length);
+          await writeReport(reportPath ?? "");
+          await fs.utimes(reportPath ?? "", new Date(0), new Date(0));
+          return { exitCode: 0, signal: null };
+        },
+      },
+    );
+    expect(stale.entries[0]?.result).toMatchObject({
+      status: "fail",
+      failure: { reason: expect.stringContaining("report is stale") },
+    });
+  });
+
+  it("writes a sanitized proof matrix and passing QA evidence", async () => {
+    const repoRoot = await makeTempRepo();
+    const artifactBase = path.join(repoRoot, ".artifacts", "passing-report");
+    const scenario = makeScenario();
+    const evidence = await runTuiPtyEvidenceProducer(
+      { artifactBase, repoRoot, scenarioId: scenario.id },
+      {
+        loadScenario: () => scenario,
+        runCommand: async (command) => {
+          const reportPath = command.args
+            .find((arg) => arg.startsWith("--outputFile.json="))
+            ?.slice("--outputFile.json=".length);
+          await writeReport(reportPath ?? "", {
+            testFile: path.join(repoRoot, HARNESS_FILE),
+          });
+          return { exitCode: 0, signal: null };
+        },
+      },
+    );
+
+    expect(validateQaEvidenceSummaryJson(evidence)).toEqual(evidence);
+    expect(evidence.entries[0]).toMatchObject({
+      coverage: [{ id: COVERAGE_ID, role: "secondary" }],
+      result: { status: "pass" },
+    });
+    const proofMatrix = JSON.parse(
+      await fs.readFile(path.join(artifactBase, "proof-matrix.json"), "utf8"),
+    ) as { cases: Array<{ coverageId: string; matchedAssertions: string[] }> };
+    expect(proofMatrix.cases).toEqual([
+      expect.objectContaining({
+        coverageId: COVERAGE_ID,
+        matchedAssertions: [TEST_NAME],
+      }),
+    ]);
+    const reportText = await fs.readFile(path.join(artifactBase, "vitest-report.json"), "utf8");
+    expect(reportText).toContain(`"name": "${HARNESS_FILE}"`);
+    expect(reportText).not.toContain(repoRoot);
+    await expect(fs.access(path.join(artifactBase, "latest-run.json"))).resolves.toBeUndefined();
+    await expect(fs.access(path.join(artifactBase, "qa-evidence.json"))).resolves.toBeUndefined();
+  });
+});

--- a/test/e2e/qa-lab/tui/tui-pty-evidence-producer.ts
+++ b/test/e2e/qa-lab/tui/tui-pty-evidence-producer.ts
@@ -1,0 +1,493 @@
+// Runs allowlisted TUI PTY cases and emits authenticated QA script evidence.
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import {
+  QA_EVIDENCE_FILENAME,
+  readQaScenarioById,
+  type QaEvidenceSummaryJson,
+  type QaSeedScenarioWithSource,
+} from "../../../../extensions/qa-lab/api.js";
+import { createQaScriptEvidenceWriter } from "../runtime/script-evidence.js";
+
+const SOURCE_PATH = "test/e2e/qa-lab/tui/tui-pty-evidence-producer.ts";
+const VITEST_CONFIG_PATH = "test/vitest/vitest.tui-pty.config.ts";
+const LOCAL_PTY_TEST_FILE = "src/tui/tui-pty-local.e2e.test.ts";
+const REPORT_FILENAME = "vitest-report.json";
+const PROOF_MATRIX_FILENAME = "proof-matrix.json";
+const REPORT_FRESHNESS_TOLERANCE_MS = 2_000;
+const MAX_PATTERN_LENGTH = 1_024;
+
+export const TUI_PTY_TEST_FILE_ALLOWLIST = [
+  "src/tui/tui-pty-harness.e2e.test.ts",
+  LOCAL_PTY_TEST_FILE,
+  "src/tui/tui-reset-transition-pty.e2e.test.ts",
+] as const;
+
+type AllowedTuiPtyTestFile = (typeof TUI_PTY_TEST_FILE_ALLOWLIST)[number];
+
+export type TuiPtyCase = {
+  coverageId: string;
+  testFile: AllowedTuiPtyTestFile;
+  testNamePattern: string;
+};
+
+export type TuiPtyProducerOptions = {
+  artifactBase: string;
+  repoRoot: string;
+  scenarioId: string;
+};
+
+type VitestAssertionResult = {
+  fullName?: unknown;
+  status?: unknown;
+  title?: unknown;
+};
+
+type VitestTestResult = {
+  assertionResults?: unknown;
+  name?: unknown;
+};
+
+type VitestJsonReport = {
+  numFailedTests?: unknown;
+  numPassedTests?: unknown;
+  success?: unknown;
+  testResults?: unknown;
+};
+
+type ProducerCommand = {
+  args: string[];
+  command: string;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+};
+
+type CommandResult = {
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+};
+
+type ProducerDependencies = {
+  loadScenario?: (scenarioId: string) => QaSeedScenarioWithSource;
+  now?: () => number;
+  runCommand?: (
+    command: ProducerCommand,
+    appendLog: (chunk: unknown) => void,
+  ) => Promise<CommandResult>;
+};
+
+type ProofMatrixCase = TuiPtyCase & {
+  matchedAssertions: string[];
+};
+
+function formatErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function readOptionValue(argv: readonly string[], index: number, option: string) {
+  const value = argv[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${option} requires a value`);
+  }
+  return value;
+}
+
+export function parseTuiPtyProducerOptions(
+  argv: readonly string[],
+  repoRoot = process.cwd(),
+): TuiPtyProducerOptions {
+  let artifactBase = "";
+  let scenarioId = "";
+  const seen = new Set<string>();
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const option = argv[index];
+    if (option !== "--artifact-base" && option !== "--scenario-id") {
+      throw new Error(`unsupported TUI PTY evidence producer argument: ${option}`);
+    }
+    if (seen.has(option)) {
+      throw new Error(`${option} was provided more than once`);
+    }
+    seen.add(option);
+    const value = readOptionValue(argv, index, option);
+    index += 1;
+    if (option === "--artifact-base") {
+      artifactBase = value;
+    } else {
+      scenarioId = value;
+    }
+  }
+
+  if (!artifactBase.trim()) {
+    throw new Error("--artifact-base is required");
+  }
+  if (!scenarioId.trim()) {
+    throw new Error("--scenario-id is required");
+  }
+  return {
+    artifactBase: path.resolve(repoRoot, artifactBase),
+    repoRoot: path.resolve(repoRoot),
+    scenarioId: scenarioId.trim(),
+  };
+}
+
+function isAllowedTestFile(value: string): value is AllowedTuiPtyTestFile {
+  return (TUI_PTY_TEST_FILE_ALLOWLIST as readonly string[]).includes(value);
+}
+
+function readTuiPtyCase(value: unknown, index: number): TuiPtyCase {
+  if (!isRecord(value)) {
+    throw new Error(`execution.config.tuiPtyCases[${index}] must be an object`);
+  }
+  const allowedKeys = new Set(["coverageId", "testFile", "testNamePattern"]);
+  const unexpectedKey = Object.keys(value).find((key) => !allowedKeys.has(key));
+  if (unexpectedKey) {
+    throw new Error(
+      `execution.config.tuiPtyCases[${index}] contains unsupported key ${unexpectedKey}`,
+    );
+  }
+  const coverageId = typeof value.coverageId === "string" ? value.coverageId.trim() : "";
+  const testFile = typeof value.testFile === "string" ? value.testFile.trim() : "";
+  const testNamePattern =
+    typeof value.testNamePattern === "string" ? value.testNamePattern.trim() : "";
+  if (!coverageId) {
+    throw new Error(`execution.config.tuiPtyCases[${index}].coverageId is required`);
+  }
+  if (!isAllowedTestFile(testFile)) {
+    throw new Error(
+      `execution.config.tuiPtyCases[${index}].testFile is not allowlisted: ${testFile || "<empty>"}`,
+    );
+  }
+  if (!testNamePattern) {
+    throw new Error(`execution.config.tuiPtyCases[${index}].testNamePattern is required`);
+  }
+  if (testNamePattern.length > MAX_PATTERN_LENGTH) {
+    throw new Error(
+      `execution.config.tuiPtyCases[${index}].testNamePattern exceeds ${MAX_PATTERN_LENGTH} characters`,
+    );
+  }
+  try {
+    new RegExp(testNamePattern);
+  } catch (error) {
+    throw new Error(
+      `execution.config.tuiPtyCases[${index}].testNamePattern is invalid: ${formatErrorMessage(error)}`,
+    );
+  }
+  return { coverageId, testFile, testNamePattern };
+}
+
+export function validateTuiPtyScenario(scenario: QaSeedScenarioWithSource): TuiPtyCase[] {
+  if (scenario.execution.kind !== "script") {
+    throw new Error(`scenario ${scenario.id} must use execution.kind=script`);
+  }
+  if (scenario.execution.path !== SOURCE_PATH) {
+    throw new Error(`scenario ${scenario.id} must execute ${SOURCE_PATH}`);
+  }
+  const rawCases = scenario.execution.config?.tuiPtyCases;
+  if (!Array.isArray(rawCases) || rawCases.length === 0) {
+    throw new Error(`scenario ${scenario.id} must configure a non-empty tuiPtyCases array`);
+  }
+
+  const cases = rawCases.map(readTuiPtyCase);
+  const declaredCoverage = new Set([
+    ...(scenario.coverage?.primary ?? []),
+    ...(scenario.coverage?.secondary ?? []),
+  ]);
+  const seenCases = new Set<string>();
+  for (const configuredCase of cases) {
+    if (!declaredCoverage.has(configuredCase.coverageId)) {
+      throw new Error(
+        `TUI PTY case declares coverage ID not owned by scenario ${scenario.id}: ${configuredCase.coverageId}`,
+      );
+    }
+    const caseKey = [
+      configuredCase.coverageId,
+      configuredCase.testFile,
+      configuredCase.testNamePattern,
+    ].join("\u0000");
+    if (seenCases.has(caseKey)) {
+      throw new Error(
+        `scenario ${scenario.id} contains a duplicate TUI PTY case for ${configuredCase.coverageId}`,
+      );
+    }
+    seenCases.add(caseKey);
+  }
+
+  const representedCoverage = new Set(cases.map((configuredCase) => configuredCase.coverageId));
+  const missingPrimary = (scenario.coverage?.primary ?? []).filter(
+    (coverageId) => !representedCoverage.has(coverageId),
+  );
+  if (missingPrimary.length > 0) {
+    throw new Error(
+      `scenario ${scenario.id} has primary coverage IDs without TUI PTY cases: ${missingPrimary.join(", ")}`,
+    );
+  }
+  return cases;
+}
+
+export function buildTuiPtyVitestCommand(params: {
+  cases: readonly TuiPtyCase[];
+  repoRoot: string;
+  reportPath: string;
+}): ProducerCommand {
+  const testFiles = [
+    ...new Set(params.cases.map((configuredCase) => configuredCase.testFile)),
+  ].toSorted((left, right) => left.localeCompare(right));
+  const testNamePattern = params.cases
+    .map((configuredCase) => `(?:${configuredCase.testNamePattern})`)
+    .join("|");
+  const usesLocalPty = testFiles.includes(LOCAL_PTY_TEST_FILE);
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    OPENCLAW_BEHAVIOR_EVIDENCE: "1",
+  };
+  if (usesLocalPty) {
+    env.OPENCLAW_TUI_PTY_INCLUDE_LOCAL = "1";
+  } else {
+    delete env.OPENCLAW_TUI_PTY_INCLUDE_LOCAL;
+  }
+  return {
+    command: process.execPath,
+    cwd: params.repoRoot,
+    args: [
+      "scripts/run-vitest.mjs",
+      "run",
+      "--config",
+      VITEST_CONFIG_PATH,
+      ...testFiles,
+      "--testNamePattern",
+      testNamePattern,
+      "--reporter=verbose",
+      "--reporter=json",
+      `--outputFile.json=${params.reportPath}`,
+    ],
+    env,
+  };
+}
+
+async function runProducerCommand(
+  command: ProducerCommand,
+  appendLog: (chunk: unknown) => void,
+): Promise<CommandResult> {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(command.command, command.args, {
+      cwd: command.cwd,
+      env: command.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    child.stdout.on("data", appendLog);
+    child.stderr.on("data", appendLog);
+    child.on("error", reject);
+    child.on("close", (exitCode, signal) => resolve({ exitCode, signal }));
+  });
+}
+
+function assertionName(assertion: VitestAssertionResult) {
+  if (typeof assertion.fullName === "string") {
+    return assertion.fullName;
+  }
+  return typeof assertion.title === "string" ? assertion.title : undefined;
+}
+
+async function canonicalizeReportedTestPath(repoRoot: string, reportedPath: string) {
+  const absolutePath = path.resolve(repoRoot, reportedPath);
+  return await fs.realpath(absolutePath).catch(() => absolutePath);
+}
+
+export async function verifyTuiPtyVitestReport(params: {
+  cases: readonly TuiPtyCase[];
+  report: VitestJsonReport;
+  repoRoot: string;
+}): Promise<ProofMatrixCase[]> {
+  if (
+    params.report.success !== true ||
+    params.report.numFailedTests !== 0 ||
+    typeof params.report.numPassedTests !== "number" ||
+    !Number.isSafeInteger(params.report.numPassedTests) ||
+    params.report.numPassedTests < 1 ||
+    !Array.isArray(params.report.testResults)
+  ) {
+    throw new Error("Vitest report does not describe a successful test run");
+  }
+
+  const testResults = params.report.testResults.filter(isRecord) as VitestTestResult[];
+  const resultPaths = await Promise.all(
+    testResults.map(async (result) => {
+      const name = typeof result.name === "string" ? result.name : "";
+      return name ? await canonicalizeReportedTestPath(params.repoRoot, name) : "";
+    }),
+  );
+
+  const proofCases: ProofMatrixCase[] = [];
+  for (const configuredCase of params.cases) {
+    const expectedPath = await fs.realpath(path.resolve(params.repoRoot, configuredCase.testFile));
+    const resultIndex = resultPaths.indexOf(expectedPath);
+    if (resultIndex < 0) {
+      throw new Error(
+        `Vitest report has no result for configured test file ${configuredCase.testFile}`,
+      );
+    }
+    const assertionResults = testResults[resultIndex]?.assertionResults;
+    const passedAssertions = Array.isArray(assertionResults)
+      ? assertionResults
+          .filter(isRecord)
+          .filter((assertion) => assertion.status === "passed")
+          .map(assertionName)
+          .filter((name): name is string => Boolean(name))
+      : [];
+    const pattern = new RegExp(configuredCase.testNamePattern);
+    const matchedAssertions = passedAssertions.filter((name) => {
+      pattern.lastIndex = 0;
+      return pattern.test(name);
+    });
+    if (matchedAssertions.length === 0) {
+      throw new Error(
+        `Vitest report has no passed assertion for ${configuredCase.testFile} matching ${JSON.stringify(configuredCase.testNamePattern)}`,
+      );
+    }
+    proofCases.push({ ...configuredCase, matchedAssertions });
+  }
+  return proofCases;
+}
+
+async function writeJson(filePath: string, value: unknown) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function sanitizeVitestReport(report: VitestJsonReport, proofCases: readonly ProofMatrixCase[]) {
+  const allowedFiles = new Set(proofCases.map((configuredCase) => configuredCase.testFile));
+  const testResults = Array.isArray(report.testResults)
+    ? report.testResults.map((result) => {
+        if (!isRecord(result) || typeof result.name !== "string") {
+          return result;
+        }
+        const resultName = result.name;
+        const matchingFile = [...allowedFiles].find((file) => resultName.endsWith(file));
+        return { ...result, name: matchingFile ?? "<unrecognized-test-file>" };
+      })
+    : report.testResults;
+  return { ...report, testResults };
+}
+
+export async function runTuiPtyEvidenceProducer(
+  options: TuiPtyProducerOptions,
+  dependencies: ProducerDependencies = {},
+): Promise<QaEvidenceSummaryJson> {
+  const scenario = (dependencies.loadScenario ?? readQaScenarioById)(options.scenarioId);
+  if (scenario.id !== options.scenarioId) {
+    throw new Error(
+      `loaded scenario ${scenario.id} does not match requested scenario ${options.scenarioId}`,
+    );
+  }
+  const cases = validateTuiPtyScenario(scenario);
+  const reportPath = path.join(options.artifactBase, REPORT_FILENAME);
+  const proofMatrixPath = path.join(options.artifactBase, PROOF_MATRIX_FILENAME);
+  const target = {
+    codeRefs: scenario.codeRefs,
+    docsRefs: scenario.docsRefs,
+    id: scenario.id,
+    primaryCoverageIds: scenario.coverage?.primary ?? [],
+    secondaryCoverageIds: scenario.coverage?.secondary ?? [],
+    sourcePath: SOURCE_PATH,
+    title: scenario.title,
+  };
+  const writer = createQaScriptEvidenceWriter({
+    artifactBase: options.artifactBase,
+    logFileName: "tui-pty-evidence-producer.log",
+    primaryModel: "mock-openai/tui-pty",
+    providerMode: "mock-openai",
+    repoRoot: options.repoRoot,
+    target,
+  });
+  const startedAt = (dependencies.now ?? Date.now)();
+  await fs.mkdir(options.artifactBase, { recursive: true });
+  await Promise.all([fs.rm(reportPath, { force: true }), fs.rm(proofMatrixPath, { force: true })]);
+
+  try {
+    const command = buildTuiPtyVitestCommand({
+      cases,
+      reportPath,
+      repoRoot: options.repoRoot,
+    });
+    writer.appendLog(
+      `$ ${path.basename(command.command)} ${command.args
+        .map((arg) =>
+          JSON.stringify(
+            arg.startsWith("--outputFile.json=") ? `--outputFile.json=${REPORT_FILENAME}` : arg,
+          ),
+        )
+        .join(" ")}\n`,
+    );
+    const result = await (dependencies.runCommand ?? runProducerCommand)(command, (chunk) =>
+      writer.appendLog(chunk),
+    );
+    if (result.exitCode !== 0 || result.signal) {
+      throw new Error(
+        result.signal
+          ? `TUI PTY Vitest terminated by ${result.signal}`
+          : `TUI PTY Vitest exited with ${String(result.exitCode)}`,
+      );
+    }
+
+    const reportStat = await fs.stat(reportPath).catch(() => undefined);
+    if (!reportStat) {
+      throw new Error(`TUI PTY Vitest did not write ${REPORT_FILENAME}`);
+    }
+    if (reportStat.mtimeMs < startedAt - REPORT_FRESHNESS_TOLERANCE_MS) {
+      throw new Error(`TUI PTY Vitest report is stale: ${REPORT_FILENAME}`);
+    }
+    const report = JSON.parse(await fs.readFile(reportPath, "utf8")) as VitestJsonReport;
+    const proofCases = await verifyTuiPtyVitestReport({
+      cases,
+      report,
+      repoRoot: options.repoRoot,
+    });
+    await writeJson(reportPath, sanitizeVitestReport(report, proofCases));
+    await writeJson(proofMatrixPath, {
+      schemaVersion: 1,
+      scenarioId: scenario.id,
+      generatedAt: new Date().toISOString(),
+      cases: proofCases,
+    });
+    return await writer.write({
+      artifacts: [
+        { kind: "vitest-report", filePath: REPORT_FILENAME },
+        { kind: "proof-matrix", filePath: PROOF_MATRIX_FILENAME },
+      ],
+      details: `Authenticated ${proofCases.length} TUI PTY coverage case(s).`,
+      durationMs: Math.max(1, (dependencies.now ?? Date.now)() - startedAt),
+      status: "pass",
+    });
+  } catch (error) {
+    const details = formatErrorMessage(error);
+    writer.appendLog(`\nfail: ${details}\n`);
+    return await writer.write({
+      details,
+      durationMs: Math.max(1, (dependencies.now ?? Date.now)() - startedAt),
+      status: "fail",
+    });
+  }
+}
+
+async function main(argv: readonly string[]) {
+  const evidence = await runTuiPtyEvidenceProducer(parseTuiPtyProducerOptions(argv));
+  const status = evidence.entries[0]?.result.status;
+  console.log(`TUI PTY evidence: ${QA_EVIDENCE_FILENAME}`);
+  console.log(`TUI PTY status: ${status}`);
+  return status === "pass" ? 0 : 1;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  main(process.argv.slice(2))
+    .then((exitCode) => {
+      process.exitCode = exitCode;
+    })
+    .catch((error: unknown) => {
+      console.error(formatErrorMessage(error));
+      process.exitCode = 1;
+    });
+}


### PR DESCRIPTION
## What Problem This Solves

QA coverage slices that rely on the TUI PTY tests lacked a reusable producer that authenticates exact Vitest file and assertion results and emits QA Lab evidence.

## Why This Change Was Made

Adds a strict script evidence producer over existing public QA seams and a secondary-only contract scenario. The producer accepts only the two documented CLI arguments, allowlists exactly the three existing PTY test files, validates scenario coverage-to-case ownership, requires a fresh successful Vitest JSON report, and emits bounded redacted evidence artifacts.

No production code, dependency, lockfile, plugin SDK, protocol, channel, taxonomy, or TUI runtime files change.

## User Impact

No direct user-facing behavior changes. QA scenario authors can reuse authenticated PTY evidence without claiming primary product coverage in this infrastructure slice.

## Evidence

- Exact pushed head: `8d5c1a86803468d470b19d51c879749647afcc6b`
- Focused producer tests: 1 file, 7 tests passed.
- Root test typecheck: passed.
- Private-QA build: passed, including all 149 public plugin SDK subpaths and Control UI performance checks.
- QA Suite `tui-pty-evidence-producer-contract`: passed at exact head after rebuilding private-QA CLI artifacts.
- Fresh evidence: one passed configured assertion in `src/tui/tui-pty-harness.e2e.test.ts`, secondary-only `tui.message-composition`, with `vitest-report.json`, `proof-matrix.json`, `latest-run.json`, and `qa-evidence.json`.
- Formatting, diff check, import-cycle check, dependency pins, plugin boundaries, script declarations, storage guards, and privacy scrub passed.
- Fresh Sol high autoreview: clean, patch correctness 0.87; TruffleHog clean.
- ClawSweeper's canonical record-guard move is applied; command construction also explicitly clears the local-PTY opt-in for non-local cases.
- Blacksmith Testbox was unavailable because local authentication is missing; AWS Crabbox was unavailable because broker login is missing. Trusted-source heavy proof used the repository-approved local fallback.
- `pnpm-lock.yaml` was restored after a sparse-checkout install artifact and has no final diff; no dependency change is required.

AI-assisted implementation and review.
