### PR TITLE
perf(memory-wiki): avoid redundant publication hash

### DIFF
--- a/extensions/memory-wiki/src/compile.test.ts
+++ b/extensions/memory-wiki/src/compile.test.ts
@@ -115,6 +115,56 @@ describe("compileMemoryWikiVault", () => {
     expect(claims.map((claim) => claim.text)).toContain("Alpha is the canonical source page.");
   });
 
+  it("hashes each source only twice while publishing a successful compile", async () => {
+    const { rootDir, config } = await createVault({
+      rootDir: nextCaseRoot(),
+      initialize: true,
+    });
+    const sourcePath = path.join(rootDir, "sources", "hash-count.md");
+    const claimText = "The successful publication keeps its verified source snapshot.";
+
+    await fs.writeFile(
+      sourcePath,
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.hash-count",
+          title: "Hash Count",
+          claims: [{ text: claimText, status: "supported" }],
+        },
+        body: "# Hash Count\n",
+      }),
+      "utf8",
+    );
+
+    const originalReadFile = fs.readFile.bind(fs);
+    let sourceHashReads = 0;
+    const readFileSpy = vi
+      .spyOn(fs, "readFile")
+      .mockImplementation(async (...args: Parameters<typeof fs.readFile>) => {
+        const [target, options] = args;
+        if (
+          typeof target === "string" &&
+          path.resolve(target) === sourcePath &&
+          typeof options === "object" &&
+          options !== null &&
+          !("encoding" in options)
+        ) {
+          sourceHashReads += 1;
+        }
+        return await originalReadFile(...args);
+      });
+
+    try {
+      await compileMemoryWikiVault(config);
+    } finally {
+      readFileSpy.mockRestore();
+    }
+
+    expect((await expectCompiledCache(config)).claims[0]?.text).toBe(claimText);
+    expect(sourceHashReads).toBe(2);
+  });
+
   it("preserves source page bytes while rebuilding derived artifacts", async () => {
     const { rootDir, config } = await createVault({
       rootDir: nextCaseRoot(),

--- a/extensions/memory-wiki/src/compile.ts
+++ b/extensions/memory-wiki/src/compile.ts
@@ -37,7 +37,6 @@ import {
 import type { ResolvedMemoryWikiConfig } from "./config.js";
 import {
   appendMemoryWikiLog,
-  loadMemoryWikiValidatedVaultIdentity,
   loadMemoryWikiVaultIdentity,
   resolveMemoryWikiVaultSourceGeneration,
 } from "./log.js";
@@ -1370,7 +1369,7 @@ async function compileMemoryWikiVaultUnlocked(
         },
       });
     },
-    () => loadMemoryWikiValidatedVaultIdentity(rootDir),
+    () => loadMemoryWikiVaultIdentity(rootDir),
   );
   await appendMemoryWikiLog(rootDir, {
     type: "compile",

--- a/extensions/memory-wiki/src/compiled-cache.integration.test.ts
+++ b/extensions/memory-wiki/src/compiled-cache.integration.test.ts
@@ -221,6 +221,41 @@ describe("Memory Wiki compiled cache lifecycle", () => {
     );
   });
 
+  it("rejects a published snapshot after source edits on lifecycle refresh", async () => {
+    const { rootDir, config } = await createPersistentVault({ initialize: true });
+    const sourcePath = path.join(rootDir, "entities", "lifecycle-edit.md");
+    const renderSource = (claimText: string) =>
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "entity",
+          id: "entity.lifecycle-edit",
+          title: "Lifecycle Edit",
+          claims: [{ text: claimText, status: "supported" }],
+        },
+        body: "# Lifecycle Edit\n",
+      });
+
+    await fs.writeFile(sourcePath, renderSource("Claim before the source edit."), "utf8");
+    await compileMemoryWikiVault(config);
+
+    expect((await loadMemoryWikiCompiledCache(config))?.claims[0]?.text).toBe(
+      "Claim before the source edit.",
+    );
+
+    await fs.writeFile(sourcePath, renderSource("Claim after the source edit."), "utf8");
+
+    // Prompt preparation intentionally does not poll source files. The next lifecycle
+    // refresh performs the validated source-generation check and rejects this stale row.
+    expect((await loadMemoryWikiCompiledCache(config))?.claims[0]?.text).toBe(
+      "Claim before the source edit.",
+    );
+    configureMemoryWikiCompiledCacheStore(undefined);
+    configureMemoryWikiCompiledCacheStore(createCacheStore());
+    await activateVault(config);
+
+    await expect(loadMemoryWikiCompiledCache(config)).resolves.toBeNull();
+  });
+
   it("ignores legacy files and rebuilds only on compile", async () => {
     const { rootDir, config } = await createPersistentVault({
       initialize: true,


### PR DESCRIPTION
Closes #118904.

## What Problem This Solves

A successful Memory Wiki compile already computes and publishes a source-generation proof, then immediately asks the owner-reconciliation callback to load a *validated* identity. That validation walks and hashes the same unchanged vault again inside the same locked publication flow.

## Why This Change Was Made

The post-publication callback now reads the just-written vault identity/log metadata without recomputing the full source generation. Later lifecycle activation continues to use validated identity loading, so edits after publication still invalidate stale compiled cache.

Reservation, publication ownership, locking, and crash-recovery behavior are unchanged.

## Evidence

Regressions assert:

- one successful compile performs only the expected two source reads rather than an extra full hash read;
- after publication, editing a source page and starting the next lifecycle refresh still rejects the stale compiled cache.

The equivalent Memory Wiki implementation passed the focused cloud suite in [Actions run 30751511103](https://github.com/ZYV5ge/openclaw/actions/runs/30751511103). This latest-main extraction was not run locally under the machine-safety constraint; upstream CI should validate the exact head.

## Scope

Based on official `main` at `7741cbdaa752472610619b94d27a3a631a682bac`. Three Memory Wiki files, with a one-line production-path substitution plus regressions. No visibility, authorization, ranking, model, Gateway configuration, workflow, version, package, or user-data change.

AI-assisted: yes.