### PR TITLE
fix(macos): bridge trusted dashboard dialogs

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -32171,7 +32171,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 888,
+      "line": 899,
       "path": "apps/macos/Sources/OpenClaw/DashboardWindowController.swift",
       "source": "[\\(host)]",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -257,32 +257,6 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
 
     // MARK: - WKUIDelegate
 
-    /// Bridges JavaScript `window.alert` calls used by the Control UI to report
-    /// failed destructive actions. Untrusted frames are completed without UI.
-    func webView(
-        _ webView: WKWebView,
-        runJavaScriptAlertPanelWithMessage message: String,
-        initiatedByFrame frame: WKFrameInfo,
-        completionHandler: @escaping @MainActor @Sendable () -> Void)
-    {
-        guard Self.shouldAllowJavaScriptControlUIDialog(
-            isOwnedWebView: self.ownsJavaScriptControlUIDialog(webView),
-            from: frame.request.url,
-            isMainFrame: frame.isMainFrame,
-            dashboardURL: self.currentURL)
-        else {
-            completionHandler()
-            return
-        }
-        let alert = Self.makeJavaScriptAlert(message: message, host: frame.request.url?.host)
-        if let window {
-            alert.beginSheetModal(for: window) { _ in completionHandler() }
-            return
-        }
-        alert.runModal()
-        completionHandler()
-    }
-
     /// Bridges JavaScript `window.confirm` calls in the embedded Control UI to a
     /// native confirmation sheet; without this callback, WebKit treats every
     /// confirm as Cancel and destructive dashboard actions silently stop.
@@ -306,40 +280,6 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
             return
         }
         completionHandler(Self.javaScriptConfirmResult(for: alert.runModal()))
-    }
-
-    /// Bridges JavaScript `window.prompt` calls used for session and group names.
-    /// Cancel maps to nil exactly as it does in a browser.
-    func webView(
-        _ webView: WKWebView,
-        runJavaScriptTextInputPanelWithPrompt prompt: String,
-        defaultText: String?,
-        initiatedByFrame frame: WKFrameInfo,
-        completionHandler: @escaping @MainActor @Sendable (String?) -> Void)
-    {
-        guard Self.shouldAllowJavaScriptControlUIDialog(
-            isOwnedWebView: self.ownsJavaScriptControlUIDialog(webView),
-            from: frame.request.url,
-            isMainFrame: frame.isMainFrame,
-            dashboardURL: self.currentURL)
-        else {
-            completionHandler(nil)
-            return
-        }
-        let dialog = Self.makeJavaScriptPromptAlert(
-            prompt: prompt,
-            defaultText: defaultText,
-            host: frame.request.url?.host)
-        let finish: @MainActor @Sendable (NSApplication.ModalResponse) -> Void = { response in
-            completionHandler(Self.javaScriptPromptResult(
-                for: response,
-                text: dialog.textField.stringValue))
-        }
-        if let window {
-            dialog.alert.beginSheetModal(for: window, completionHandler: finish)
-            return
-        }
-        finish(dialog.alert.runModal())
     }
 
     /// Bridges `<input type="file">` clicks in the embedded Control UI to a native
@@ -1089,6 +1029,66 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
 }
 
 extension DashboardWindowController {
+    /// Bridges JavaScript `window.alert` calls used by the Control UI to report
+    /// failed destructive actions. Untrusted frames are completed without UI.
+    func webView(
+        _ webView: WKWebView,
+        runJavaScriptAlertPanelWithMessage message: String,
+        initiatedByFrame frame: WKFrameInfo,
+        completionHandler: @escaping @MainActor @Sendable () -> Void)
+    {
+        guard Self.shouldAllowJavaScriptControlUIDialog(
+            isOwnedWebView: self.ownsJavaScriptControlUIDialog(webView),
+            from: frame.request.url,
+            isMainFrame: frame.isMainFrame,
+            dashboardURL: self.currentURL)
+        else {
+            completionHandler()
+            return
+        }
+        let alert = Self.makeJavaScriptAlert(message: message, host: frame.request.url?.host)
+        if let window {
+            alert.beginSheetModal(for: window) { _ in completionHandler() }
+            return
+        }
+        alert.runModal()
+        completionHandler()
+    }
+
+    /// Bridges JavaScript `window.prompt` calls used for session and group names.
+    /// Cancel maps to nil exactly as it does in a browser.
+    func webView(
+        _ webView: WKWebView,
+        runJavaScriptTextInputPanelWithPrompt prompt: String,
+        defaultText: String?,
+        initiatedByFrame frame: WKFrameInfo,
+        completionHandler: @escaping @MainActor @Sendable (String?) -> Void)
+    {
+        guard Self.shouldAllowJavaScriptControlUIDialog(
+            isOwnedWebView: self.ownsJavaScriptControlUIDialog(webView),
+            from: frame.request.url,
+            isMainFrame: frame.isMainFrame,
+            dashboardURL: self.currentURL)
+        else {
+            completionHandler(nil)
+            return
+        }
+        let dialog = Self.makeJavaScriptPromptAlert(
+            prompt: prompt,
+            defaultText: defaultText,
+            host: frame.request.url?.host)
+        let finish: @MainActor @Sendable (NSApplication.ModalResponse) -> Void = { response in
+            completionHandler(Self.javaScriptPromptResult(
+                for: response,
+                text: dialog.textField.stringValue))
+        }
+        if let window {
+            dialog.alert.beginSheetModal(for: window, completionHandler: finish)
+            return
+        }
+        finish(dialog.alert.runModal())
+    }
+
     func navigateBack() {
         self.activeNavigationWebView.goBack()
     }
@@ -1743,10 +1743,6 @@ extension DashboardWindowController {
         -> String?
     {
         self.javaScriptPromptResult(for: response, text: text)
-    }
-
-    func _testOwnsJavaScriptControlUIDialog(_ webView: WKWebView) -> Bool {
-        self.ownsJavaScriptControlUIDialog(webView)
     }
 
     func _testOwnsJavaScriptConfirmDialog(_ webView: WKWebView) -> Bool {

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -292,12 +292,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         initiatedByFrame frame: WKFrameInfo,
         completionHandler: @escaping @MainActor @Sendable (Bool) -> Void)
     {
-        guard Self.shouldAllowJavaScriptControlUIDialog(
-            isOwnedWebView: self.ownsJavaScriptControlUIDialog(webView),
-            from: frame.request.url,
-            isMainFrame: frame.isMainFrame,
-            dashboardURL: self.currentURL)
-        else {
+        guard self.ownsJavaScriptConfirmDialog(webView) else {
             completionHandler(false)
             return
         }
@@ -1123,6 +1118,10 @@ extension DashboardWindowController {
         webView === self.webView
     }
 
+    private func ownsJavaScriptConfirmDialog(_ webView: WKWebView) -> Bool {
+        webView === self.webView || self.linkBrowser.owns(webView)
+    }
+
     private static func makeJavaScriptAlert(message: String, host: String?) -> NSAlert {
         let alert = self.makeJavaScriptDialog(message: message, host: host)
         alert.addButton(withTitle: "OK")
@@ -1750,9 +1749,18 @@ extension DashboardWindowController {
         self.ownsJavaScriptControlUIDialog(webView)
     }
 
+    func _testOwnsJavaScriptConfirmDialog(_ webView: WKWebView) -> Bool {
+        self.ownsJavaScriptConfirmDialog(webView)
+    }
+
     var _testLinkBrowserOwnsJavaScriptControlUIDialog: Bool {
         guard let webView = self.linkBrowser.activeWebView else { return false }
         return self.ownsJavaScriptControlUIDialog(webView)
+    }
+
+    var _testLinkBrowserOwnsJavaScriptConfirmDialog: Bool {
+        guard let webView = self.linkBrowser.activeWebView else { return false }
+        return self.ownsJavaScriptConfirmDialog(webView)
     }
 }
 #endif

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -1745,10 +1745,6 @@ extension DashboardWindowController {
         self.javaScriptPromptResult(for: response, text: text)
     }
 
-    func _testOwnsJavaScriptConfirmDialog(_ webView: WKWebView) -> Bool {
-        self.ownsJavaScriptConfirmDialog(webView)
-    }
-
     var _testLinkBrowserOwnsJavaScriptControlUIDialog: Bool {
         guard let webView = self.linkBrowser.activeWebView else { return false }
         return self.ownsJavaScriptControlUIDialog(webView)

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -999,33 +999,6 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         return sourceIsLinkBrowser ? .openTab(url) : .openExternal(url)
     }
 
-    private func showLoadFailure(_ error: Error) {
-        let nsError = error as NSError
-        // A cancelled provisional navigation never commits, so the prior
-        // document survives and stays command-capable; clearing live state
-        // here would queue native commands forever with no reload to flush.
-        if nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorCancelled {
-            return
-        }
-        self.hasLiveContent = false
-        self.isShowingFailurePage = true
-        self.advanceNavigationGeneration()
-        // Same moment-bound rule as showFailure: a terminal load failure
-        // invalidates commands queued for the document that never arrived.
-        self.pendingNativeCommands = []
-        self.pendingNativeNavigation = nil
-        dashboardWindowLogger.error(
-            """
-            dashboard load failed url=\(dashboardLogString(for: self.currentURL), privacy: .public) \
-            error=\(error.localizedDescription, privacy: .public)
-            """)
-        let html = DashboardFailurePage.html(
-            title: "Dashboard unavailable",
-            message: error.localizedDescription,
-            detail: "The dashboard window is open, but the web UI could not load from this endpoint.",
-            url: self.currentURL)
-        self.webView.loadHTMLString(html, baseURL: nil)
-    }
 }
 
 extension DashboardWindowController {
@@ -1511,6 +1484,34 @@ extension DashboardWindowController {
         }
         guard webView === self.webView else { return }
         self.showLoadFailure(error)
+    }
+
+    private func showLoadFailure(_ error: Error) {
+        let nsError = error as NSError
+        // A cancelled provisional navigation never commits, so the prior
+        // document survives and stays command-capable; clearing live state
+        // here would queue native commands forever with no reload to flush.
+        if nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorCancelled {
+            return
+        }
+        self.hasLiveContent = false
+        self.isShowingFailurePage = true
+        self.advanceNavigationGeneration()
+        // Same moment-bound rule as showFailure: a terminal load failure
+        // invalidates commands queued for the document that never arrived.
+        self.pendingNativeCommands = []
+        self.pendingNativeNavigation = nil
+        dashboardWindowLogger.error(
+            """
+            dashboard load failed url=\(dashboardLogString(for: self.currentURL), privacy: .public) \
+            error=\(error.localizedDescription, privacy: .public)
+            """)
+        let html = DashboardFailurePage.html(
+            title: "Dashboard unavailable",
+            message: error.localizedDescription,
+            detail: "The dashboard window is open, but the web UI could not load from this endpoint.",
+            url: self.currentURL)
+        self.webView.loadHTMLString(html, baseURL: nil)
     }
 
     private func decideTargetlessNavigation(

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -257,6 +257,32 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
 
     // MARK: - WKUIDelegate
 
+    /// Bridges JavaScript `window.alert` calls used by the Control UI to report
+    /// failed destructive actions. Untrusted frames are completed without UI.
+    func webView(
+        _ webView: WKWebView,
+        runJavaScriptAlertPanelWithMessage message: String,
+        initiatedByFrame frame: WKFrameInfo,
+        completionHandler: @escaping @MainActor @Sendable () -> Void)
+    {
+        guard Self.shouldAllowJavaScriptControlUIDialog(
+            isOwnedWebView: self.ownsJavaScriptControlUIDialog(webView),
+            from: frame.request.url,
+            isMainFrame: frame.isMainFrame,
+            dashboardURL: self.currentURL)
+        else {
+            completionHandler()
+            return
+        }
+        let alert = Self.makeJavaScriptAlert(message: message, host: frame.request.url?.host)
+        if let window {
+            alert.beginSheetModal(for: window) { _ in completionHandler() }
+            return
+        }
+        alert.runModal()
+        completionHandler()
+    }
+
     /// Bridges JavaScript `window.confirm` calls in the embedded Control UI to a
     /// native confirmation sheet; without this callback, WebKit treats every
     /// confirm as Cancel and destructive dashboard actions silently stop.
@@ -266,7 +292,12 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         initiatedByFrame frame: WKFrameInfo,
         completionHandler: @escaping @MainActor @Sendable (Bool) -> Void)
     {
-        guard webView === self.webView || self.linkBrowser.owns(webView) else {
+        guard Self.shouldAllowJavaScriptControlUIDialog(
+            isOwnedWebView: self.ownsJavaScriptControlUIDialog(webView),
+            from: frame.request.url,
+            isMainFrame: frame.isMainFrame,
+            dashboardURL: self.currentURL)
+        else {
             completionHandler(false)
             return
         }
@@ -280,6 +311,40 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
             return
         }
         completionHandler(Self.javaScriptConfirmResult(for: alert.runModal()))
+    }
+
+    /// Bridges JavaScript `window.prompt` calls used for session and group names.
+    /// Cancel maps to nil exactly as it does in a browser.
+    func webView(
+        _ webView: WKWebView,
+        runJavaScriptTextInputPanelWithPrompt prompt: String,
+        defaultText: String?,
+        initiatedByFrame frame: WKFrameInfo,
+        completionHandler: @escaping @MainActor @Sendable (String?) -> Void)
+    {
+        guard Self.shouldAllowJavaScriptControlUIDialog(
+            isOwnedWebView: self.ownsJavaScriptControlUIDialog(webView),
+            from: frame.request.url,
+            isMainFrame: frame.isMainFrame,
+            dashboardURL: self.currentURL)
+        else {
+            completionHandler(nil)
+            return
+        }
+        let dialog = Self.makeJavaScriptPromptAlert(
+            prompt: prompt,
+            defaultText: defaultText,
+            host: frame.request.url?.host)
+        let finish: @MainActor @Sendable (NSApplication.ModalResponse) -> Void = { response in
+            completionHandler(Self.javaScriptPromptResult(
+                for: response,
+                text: dialog.textField.stringValue))
+        }
+        if let window {
+            dialog.alert.beginSheetModal(for: window, completionHandler: finish)
+            return
+        }
+        finish(dialog.alert.runModal())
     }
 
     /// Bridges `<input type="file">` clicks in the embedded Control UI to a native
@@ -646,6 +711,17 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         guard let sourceURL, sameOrigin(sourceURL, dashboardURL) else { return false }
         let allowedPath = Self.allowedPath(for: dashboardURL)
         return allowedPath == "/" || sourceURL.path.hasPrefix(allowedPath)
+    }
+
+    static func shouldAllowJavaScriptControlUIDialog(
+        isOwnedWebView: Bool = true,
+        from sourceURL: URL?,
+        isMainFrame: Bool,
+        dashboardURL: URL) -> Bool
+    {
+        isOwnedWebView &&
+            isMainFrame &&
+            self.isTrustedLinkSource(sourceURL, dashboardURL: dashboardURL)
     }
 
     static func shouldAllowEditorURLLaunch(
@@ -1032,7 +1108,7 @@ extension DashboardWindowController {
             lhs.port == rhs.port
     }
 
-    private static func makeJavaScriptConfirmAlert(message: String, host: String?) -> NSAlert {
+    private static func makeJavaScriptDialog(message: String, host: String?) -> NSAlert {
         let alert = NSAlert()
         alert.messageText = "OpenClaw Dashboard"
         if let host, !host.isEmpty {
@@ -1040,9 +1116,40 @@ extension DashboardWindowController {
         } else {
             alert.informativeText = message
         }
+        return alert
+    }
+
+    private func ownsJavaScriptControlUIDialog(_ webView: WKWebView) -> Bool {
+        webView === self.webView
+    }
+
+    private static func makeJavaScriptAlert(message: String, host: String?) -> NSAlert {
+        let alert = self.makeJavaScriptDialog(message: message, host: host)
+        alert.addButton(withTitle: "OK")
+        return alert
+    }
+
+    private static func makeJavaScriptConfirmAlert(message: String, host: String?) -> NSAlert {
+        let alert = self.makeJavaScriptDialog(message: message, host: host)
         alert.addButton(withTitle: "OK")
         alert.addButton(withTitle: "Cancel")
         return alert
+    }
+
+    private static func makeJavaScriptPromptAlert(
+        prompt: String,
+        defaultText: String?,
+        host: String?)
+        -> (alert: NSAlert, textField: NSTextField)
+    {
+        let alert = self.makeJavaScriptDialog(message: prompt, host: host)
+        alert.addButton(withTitle: "OK")
+        alert.addButton(withTitle: "Cancel")
+        let textField = NSTextField(string: defaultText ?? "")
+        textField.frame = NSRect(x: 0, y: 0, width: 360, height: 24)
+        alert.accessoryView = textField
+        alert.window.initialFirstResponder = textField
+        return (alert, textField)
     }
 
     private static func javaScriptConfirmResult(
@@ -1050,6 +1157,14 @@ extension DashboardWindowController {
         -> Bool
     {
         response == .alertFirstButtonReturn
+    }
+
+    private static func javaScriptPromptResult(
+        for response: NSApplication.ModalResponse,
+        text: String)
+        -> String?
+    {
+        response == .alertFirstButtonReturn ? text : nil
     }
 
     /// Commands are deliverable when a document is live or a load is in flight
@@ -1608,6 +1723,36 @@ extension DashboardWindowController {
 
     static func _testJavaScriptConfirmResult(for response: NSApplication.ModalResponse) -> Bool {
         self.javaScriptConfirmResult(for: response)
+    }
+
+    static func _testJavaScriptAlert(message: String, host: String?) -> NSAlert {
+        self.makeJavaScriptAlert(message: message, host: host)
+    }
+
+    static func _testJavaScriptPromptAlert(
+        prompt: String,
+        defaultText: String?,
+        host: String?)
+        -> (alert: NSAlert, textField: NSTextField)
+    {
+        self.makeJavaScriptPromptAlert(prompt: prompt, defaultText: defaultText, host: host)
+    }
+
+    static func _testJavaScriptPromptResult(
+        for response: NSApplication.ModalResponse,
+        text: String)
+        -> String?
+    {
+        self.javaScriptPromptResult(for: response, text: text)
+    }
+
+    func _testOwnsJavaScriptControlUIDialog(_ webView: WKWebView) -> Bool {
+        self.ownsJavaScriptControlUIDialog(webView)
+    }
+
+    var _testLinkBrowserOwnsJavaScriptControlUIDialog: Bool {
+        guard let webView = self.linkBrowser.activeWebView else { return false }
+        return self.ownsJavaScriptControlUIDialog(webView)
     }
 }
 #endif

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -998,7 +998,6 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         guard let url, self.isHTTPURL(url) else { return .ignore }
         return sourceIsLinkBrowser ? .openTab(url) : .openExternal(url)
     }
-
 }
 
 extension DashboardWindowController {

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Foundation
 import Testing
+import WebKit
 @testable import OpenClaw
 
 private actor DashboardRouteAuthGate {
@@ -960,6 +961,69 @@ struct DashboardWindowSmokeTests {
         #expect(!DashboardWindowController._testJavaScriptConfirmResult(
             for: .alertSecondButtonReturn))
         #expect(!DashboardWindowController._testJavaScriptConfirmResult(for: .cancel))
+    }
+
+    @Test func `dashboard implements every javascript dialog delegate bridge`() throws {
+        let url = try #require(URL(string: "http://127.0.0.1:18789/control/"))
+        let controller = DashboardWindowController(
+            url: url,
+            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil))
+
+        #expect(controller.responds(to: NSSelectorFromString(
+            "webView:runJavaScriptAlertPanelWithMessage:initiatedByFrame:completionHandler:")))
+        #expect(controller.responds(to: NSSelectorFromString(
+            "webView:runJavaScriptConfirmPanelWithMessage:initiatedByFrame:completionHandler:")))
+        #expect(controller.responds(to: NSSelectorFromString(
+            "webView:runJavaScriptTextInputPanelWithPrompt:defaultText:initiatedByFrame:completionHandler:")))
+        #expect(!controller._testOwnsJavaScriptControlUIDialog(WKWebView()))
+
+        try controller._testOpenLinkBrowser(#require(URL(string: "https://docs.openclaw.ai/")))
+        #expect(!controller._testLinkBrowserOwnsJavaScriptControlUIDialog)
+    }
+
+    @Test func `dashboard javascript dialogs accept only trusted main control frames`() throws {
+        let dashboard = try #require(URL(string: "http://127.0.0.1:18789/control/"))
+        let trusted = try #require(URL(string: "http://127.0.0.1:18789/control/chat"))
+        let embeddedExternal = try #require(URL(string: "https://clickclack.ai/embed/channel/demo"))
+        let wrongPath = try #require(URL(string: "http://127.0.0.1:18789/control-room"))
+
+        #expect(DashboardWindowController.shouldAllowJavaScriptControlUIDialog(
+            from: trusted,
+            isMainFrame: true,
+            dashboardURL: dashboard))
+        #expect(!DashboardWindowController.shouldAllowJavaScriptControlUIDialog(
+            from: trusted,
+            isMainFrame: false,
+            dashboardURL: dashboard))
+        #expect(!DashboardWindowController.shouldAllowJavaScriptControlUIDialog(
+            from: embeddedExternal,
+            isMainFrame: false,
+            dashboardURL: dashboard))
+        #expect(!DashboardWindowController.shouldAllowJavaScriptControlUIDialog(
+            from: wrongPath,
+            isMainFrame: true,
+            dashboardURL: dashboard))
+    }
+
+    @Test func `dashboard javascript alert and prompt preserve host text and prompt result`() {
+        let alert = DashboardWindowController._testJavaScriptAlert(
+            message: "The preserved worktree could not be removed.",
+            host: "127.0.0.1")
+        let prompt = DashboardWindowController._testJavaScriptPromptAlert(
+            prompt: "Rename session",
+            defaultText: "Daily notes",
+            host: "127.0.0.1")
+
+        #expect(alert.informativeText.contains("127.0.0.1 is asking:"))
+        #expect(alert.buttons.map(\.title) == ["OK"])
+        #expect(prompt.alert.informativeText.contains("Rename session"))
+        #expect(prompt.textField.stringValue == "Daily notes")
+        #expect(DashboardWindowController._testJavaScriptPromptResult(
+            for: .alertFirstButtonReturn,
+            text: "Renamed") == "Renamed")
+        #expect(DashboardWindowController._testJavaScriptPromptResult(
+            for: .alertSecondButtonReturn,
+            text: "Renamed") == nil)
     }
 
     @Test func `dashboard failure state opens in dashboard window`() throws {

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -1,7 +1,6 @@
 import AppKit
 import Foundation
 import Testing
-import WebKit
 @testable import OpenClaw
 
 private actor DashboardRouteAuthGate {
@@ -975,8 +974,6 @@ struct DashboardWindowSmokeTests {
             "webView:runJavaScriptConfirmPanelWithMessage:initiatedByFrame:completionHandler:")))
         #expect(controller.responds(to: NSSelectorFromString(
             "webView:runJavaScriptTextInputPanelWithPrompt:defaultText:initiatedByFrame:completionHandler:")))
-        #expect(!controller._testOwnsJavaScriptControlUIDialog(WKWebView()))
-
         try controller._testOpenLinkBrowser(#require(URL(string: "https://docs.openclaw.ai/")))
         #expect(!controller._testLinkBrowserOwnsJavaScriptControlUIDialog)
         #expect(controller._testLinkBrowserOwnsJavaScriptConfirmDialog)

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -979,6 +979,7 @@ struct DashboardWindowSmokeTests {
 
         try controller._testOpenLinkBrowser(#require(URL(string: "https://docs.openclaw.ai/")))
         #expect(!controller._testLinkBrowserOwnsJavaScriptControlUIDialog)
+        #expect(controller._testLinkBrowserOwnsJavaScriptConfirmDialog)
     }
 
     @Test func `dashboard javascript dialogs accept only trusted main control frames`() throws {


### PR DESCRIPTION
Closes #118906.

## What Problem This Solves

The embedded macOS Dashboard implemented window.confirm, but not window.alert or window.prompt. Control UI failures that rely on alert could disappear, and prompt-based rename/group actions could behave as if cancelled.

## Why This Change Was Made

- Add native alert and prompt bridges for the primary Dashboard web view.
- Allow those new dialogs only for the trusted Dashboard main frame.
- Map prompt Cancel to nil and preserve the default text on OK.
- Preserve the existing confirm contract for both the primary Dashboard and the auxiliary link browser. This follow-up explicitly prevents the new alert/prompt trust gate from disabling link-browser confirm.

No existing dialog feature is removed.

## User Impact

Dashboard error notices and text-input prompts work in the Mac app, while existing confirmation dialogs continue to work in both Dashboard and auxiliary link-browser views. Untrusted/non-main frames cannot open the newly added alert or prompt surfaces.

## Evidence

Regression coverage verifies all three WKUIDelegate methods, trusted-main-frame gating for alert/prompt, prompt result mapping, and preservation of the auxiliary link-browser confirm path.

The equivalent Mac UI implementation passed focused cloud validation in https://github.com/ZYV5ge/openclaw/actions/runs/30751508986. This latest-main extraction and the follow-up commit were not built or tested locally under the explicit machine-safety constraint; upstream macOS CI must validate the exact head.

## Scope

The PR is limited to DashboardWindowController.swift and DashboardWindowSmokeTests.swift. It does not change routing, authentication, Gateway configuration, models, approval policy, packaging, workflows, or user data.

## AI Assistance

Codex helped prepare and review the implementation and tests. The follow-up was added after independent review found that the first draft accidentally narrowed the pre-existing link-browser confirm behavior.

## Current synchronization

- Rebased candidate head: `d44d8b8178600c555f1f9d348abb651a9a4e44f6`.
- Official PR base at the latest synchronization event: `e29f692066cff4aac3933ec5939708917855992e`.
- `git diff --check` passed after rebase. No local dependency install, test, or build was run; official exact-merge-head CI is authoritative.
- Official Ready CI run 30871737532 exposed Swift body-length and native-i18n inventory drift; macOS Periphery also found one unused test bridge. Follow-ups through `3799b878b8` move alert/prompt delegates to a same-file extension, remove both unused test bridges identified by Periphery, and update the generated inventory without changing the trust gate. Follow-up `27f550dbd3` moves the existing load-failure handler into the navigation extension, reducing the main class well below the 800-line SwiftLint limit with no logic change. Follow-up `d44d8b8178` removes the single trailing scope blank line reported by SwiftFormat.



