### PR TITLE
fix(sessions): include category in session search

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatModels.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatModels.kt
@@ -366,7 +366,7 @@ fun filterSessionEntries(
   val query = search.trim().lowercase()
   if (query.isEmpty()) return sessions
   return sessions.filter { session ->
-    listOfNotNull(session.displayName, session.label, session.key)
+    listOfNotNull(session.displayName, session.label, session.category, session.key)
       .any { it.lowercase().contains(query) }
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerSessionSearchTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerSessionSearchTest.kt
@@ -49,17 +49,18 @@ class ChatControllerSessionSearchTest {
       ?.content
 
   @Test
-  fun filterSessionEntriesMatchesDisplayNameLabelAndKey() {
+  fun filterSessionEntriesMatchesDisplayNameLabelCategoryAndKey() {
     val sessions =
       listOf(
         ChatSessionEntry(key = "agent:main:topic-a", updatedAtMs = 2, displayName = "Trip planning"),
-        ChatSessionEntry(key = "agent:main:topic-b", updatedAtMs = 1, displayName = "Groceries"),
+        ChatSessionEntry(key = "agent:main:topic-b", updatedAtMs = 1, displayName = "Groceries", category = "Team Planning"),
         ChatSessionEntry(key = "agent:main:trip-notes", updatedAtMs = 3, displayName = "Notes"),
       )
     assertEquals(
       listOf("agent:main:topic-a", "agent:main:trip-notes"),
       filterSessionEntries(sessions, "TRIP").map { it.key },
     )
+    assertEquals(listOf("agent:main:topic-b"), filterSessionEntries(sessions, "TEAM PLANNING").map { it.key })
     assertEquals(sessions, filterSessionEntries(sessions, "  "))
   }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessions.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessions.swift
@@ -587,12 +587,8 @@ public enum OpenClawChatSessionListOrganizer {
         let query = search.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard !query.isEmpty else { return sessions }
         return sessions.filter { session in
-            for field in [session.displayName, session.label, session.subject, session.sessionId, session.key] {
-                if let field, field.lowercased().contains(query) {
-                    return true
-                }
-            }
-            return false
+            [session.displayName, session.label, session.subject, session.sessionId, session.category, session.key]
+                .contains { $0?.lowercased().contains(query) == true }
         }
     }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessions.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessions.swift
@@ -568,7 +568,14 @@ public enum OpenClawChatSessionListOrganizer {
         let query = search.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard !query.isEmpty else { return sessions }
         return sessions.filter { session in
-            for field in [session.displayName, session.label, session.subject, session.sessionId, session.key] {
+            for field in [
+                session.displayName,
+                session.label,
+                session.subject,
+                session.sessionId,
+                session.category,
+                session.key,
+            ] {
                 if let field, field.lowercased().contains(query) {
                     return true
                 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatSessionSidebarModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatSessionSidebarModelTests.swift
@@ -307,7 +307,7 @@ struct ChatSessionSidebarModelTests {
         #expect(sections.flatMap(\.nodes).map(\.session.key) == ["agent:main:research"])
     }
 
-    @Test(arguments: ["holiday", "KYOTO", "session-123", "  HoLiDaY  "])
+    @Test(arguments: ["holiday", "KYOTO", "session-123", "team planning", "  HoLiDaY  "])
     func `sidebar search matches every canonical gateway session field`(_ query: String) {
         let matching = self.entry(
             key: "agent:main:roadmap",
@@ -315,7 +315,8 @@ struct ChatSessionSidebarModelTests {
             label: "Summer holiday",
             subject: "Kyoto itinerary",
             sessionId: "session-123",
-            updatedAt: 200)
+            updatedAt: 200,
+            category: "Team Planning")
         let other = self.entry(
             key: "agent:main:other",
             displayName: "Unrelated",

--- a/src/gateway/session-utils-list.ts
+++ b/src/gateway/session-utils-list.ts
@@ -280,6 +280,7 @@ function filterSessionEntries(params: {
         entry.label,
         entry.subject,
         entry.sessionId,
+        entry.category,
         key,
       ];
       appendStoredSessionModelSearchFields(cheapFields, entry);

--- a/src/gateway/session-utils-list.ts
+++ b/src/gateway/session-utils-list.ts
@@ -284,6 +284,7 @@ function filterSessionEntries(params: {
         entry.label,
         entry.subject,
         entry.sessionId,
+        entry.category,
         key,
       ];
       appendStoredSessionModelSearchFields(cheapFields, entry);

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -629,6 +629,33 @@ describe("gateway session utils", () => {
     expect(listed.hasMore).toBe(true);
   });
 
+  test("session list search includes the session group name", () => {
+    const cfg = { agents: { list: [{ id: "main", default: true }] } } as OpenClawConfig;
+    const store: Record<string, SessionEntry> = {
+      "agent:main:roadmap": {
+        sessionId: "roadmap",
+        displayName: "Quarterly roadmap",
+        category: "Team Planning",
+        updatedAt: 2,
+      },
+      "agent:main:other": {
+        sessionId: "other",
+        displayName: "Unrelated",
+        category: "Personal",
+        updatedAt: 1,
+      },
+    };
+
+    const listed = listSessionsFromStore({
+      cfg,
+      storePath: "",
+      store,
+      opts: { search: "team planning" },
+    });
+
+    expect(listed.sessions.map((session) => session.key)).toEqual(["agent:main:roadmap"]);
+  });
+
   test("session list search includes direct-session origin display labels", () => {
     const cfg = { agents: { list: [{ id: "main", default: true }] } } as OpenClawConfig;
     const store: Record<string, SessionEntry> = {

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -498,6 +498,33 @@ describe("gateway session utils", () => {
     expect(listed.sessions[0]?.displayName).toBe("openclaw-tui");
   });
 
+  test("session list search includes the session group name", () => {
+    const cfg = { agents: { list: [{ id: "main", default: true }] } } as OpenClawConfig;
+    const store: Record<string, SessionEntry> = {
+      "agent:main:roadmap": {
+        sessionId: "roadmap",
+        displayName: "Quarterly roadmap",
+        category: "Team Planning",
+        updatedAt: 2,
+      },
+      "agent:main:other": {
+        sessionId: "other",
+        displayName: "Unrelated",
+        category: "Personal",
+        updatedAt: 1,
+      },
+    };
+
+    const listed = listSessionsFromStore({
+      cfg,
+      storePath: "",
+      store,
+      opts: { search: "team planning" },
+    });
+
+    expect(listed.sessions.map((session) => session.key)).toEqual(["agent:main:roadmap"]);
+  });
+
   test("session lists mark the final offset page without hasMore", () => {
     const cfg = createModelDefaultsConfig({ primary: "openai/gpt-5.4" });
     const store = Object.fromEntries(


### PR DESCRIPTION
## Summary

Closes #118910.

Session search did not include the visible session category, so searching only by a group or category name returned no results even though the category was already available to each search owner. This repairs the invariant at all three existing owners:

- Gateway session-list search now includes each stored session category.
- Shared Apple session search now includes the category while simplifying its existing case-insensitive substring matcher.
- Android session search now includes the category alongside its existing searchable fields.

The original contributor fix covered the Gateway and Apple paths. A maintainer update completes the equivalent Android path and preserves @ZYV5ge's contributor credit.

Production LOC: +4/-7 (net -3). Tests: +33/-4.

## Validation

Each category-only regression was first observed failing independently on unfixed main, then passing after the owner-boundary repair:

- Gateway: `node scripts/run-vitest.mjs run src/gateway/session-utils.test.ts` — 195 tests passed.
- Apple: `swift test --package-path apps/shared/OpenClawKit --filter ChatSessionSidebarModelTests` — 39 tests passed.
- Android: `./gradlew :app:testPlayDebugUnitTest --tests 'ai.openclaw.app.chat.ChatControllerSessionSearchTest' --console=plain` — 7 tests passed.
- Android formatting: `./gradlew :app:ktlintCheck --console=plain` — passed.
- Independent review reported no actionable findings.
- The complete changed-files gate passed repository policy, formatting, boundaries, dependencies, duplicate detection, and all three Knip scans before reaching unrelated existing local dependency/typecheck drift; fresh exact-head hosted CI is required for the clean-environment typecheck.

No schema, configuration, protocol, session visibility, authorization, or ranking behavior changes.
