### PR TITLE
fix(ci): keep Matrix chunk tests aligned with inventory

### DIFF
--- a/test/scripts/test-extension.test.ts
+++ b/test/scripts/test-extension.test.ts
@@ -36,6 +36,7 @@ import { extensionCatchAllExcludedTestRoots } from "../vitest/vitest.extensions.
 
 const scriptPath = path.join(process.cwd(), "scripts", "test-extension.mjs");
 const posixIt = process.platform === "win32" ? it.skip : it;
+const MATRIX_TEST_PROCESS_FILE_LIMIT = 40;
 
 type RunGroupParams = VitestBatchRunParams;
 
@@ -93,6 +94,11 @@ function findExtensionWithoutTests() {
 
 function listExtensionTestFiles(extensionId: string): string[] {
   return listTrackedTestFilesForRoots([bundledPluginRoot(extensionId)]);
+}
+
+function expectedMatrixTestProcessCount() {
+  const testFileCount = listExtensionTestFilesForRoots([bundledPluginRoot("matrix")]).length;
+  return Math.max(1, Math.ceil(testFileCount / MATRIX_TEST_PROCESS_FILE_LIMIT));
 }
 
 function expectPositiveIntegerMetric(value: number) {
@@ -183,8 +189,8 @@ describe("scripts/test-extension.mjs", () => {
     const expectedFiles = listExtensionTestFilesForRoots(roots);
     const chunks = createExtensionTestProcessTargetChunks(config, roots);
 
-    expect(chunks).toHaveLength(3);
-    expect(chunks.every((chunk) => chunk.length <= 40)).toBe(true);
+    expect(chunks).toHaveLength(expectedMatrixTestProcessCount());
+    expect(chunks.every((chunk) => chunk.length <= MATRIX_TEST_PROCESS_FILE_LIMIT)).toBe(true);
     expect(Math.max(...chunks.map((chunk) => chunk.length))).toBeLessThanOrEqual(
       Math.min(...chunks.map((chunk) => chunk.length)) + 1,
     );
@@ -846,6 +852,7 @@ describe("scripts/test-extension.mjs", () => {
     const root = mkdtempSync(path.join(tmpdir(), "openclaw-test-extension-chunks-"));
     const fakePnpmPath = path.join(root, "pnpm");
     const countPath = path.join(root, "count");
+    const expectedProcessCount = expectedMatrixTestProcessCount();
 
     writeFakePnpm(fakePnpmPath);
     try {
@@ -855,13 +862,15 @@ describe("scripts/test-extension.mjs", () => {
         env: {
           ...process.env,
           OPENCLAW_FAKE_PNPM_CALL_COUNT_PATH: countPath,
-          OPENCLAW_FAKE_PNPM_EXIT_CODES: "1,0,0",
+          OPENCLAW_FAKE_PNPM_EXIT_CODES: ["1", ...Array(expectedProcessCount - 1).fill("0")].join(
+            ",",
+          ),
           npm_execpath: fakePnpmPath,
         },
       });
 
       expect(result.status).toBe(1);
-      expect(readFileSync(countPath, "utf8")).toBe("3");
+      expect(readFileSync(countPath, "utf8")).toBe(String(expectedProcessCount));
     } finally {
       rmSync(root, { force: true, recursive: true });
     }
@@ -966,9 +975,9 @@ describe("scripts/test-extension.mjs", () => {
     );
 
     expect(result).toBe(0);
-    expect(runGroup).toHaveBeenCalledTimes(3);
+    expect(runGroup).toHaveBeenCalledTimes(expectedMatrixTestProcessCount());
     const calls = runGroup.mock.calls.map(([params]) => params as RunGroupParams);
-    expect(calls.every((call) => call.targets.length <= 40)).toBe(true);
+    expect(calls.every((call) => call.targets.length <= MATRIX_TEST_PROCESS_FILE_LIMIT)).toBe(true);
     expect(calls.flatMap((call) => call.targets)).toEqual(expectedFiles);
   });
 
@@ -984,7 +993,7 @@ describe("scripts/test-extension.mjs", () => {
     );
 
     expect(result).toBe(1);
-    expect(runGroup).toHaveBeenCalledTimes(3);
+    expect(runGroup).toHaveBeenCalledTimes(expectedMatrixTestProcessCount());
   });
 
   it.each([

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -44,6 +44,7 @@ import {
 import { fullSuiteVitestShards } from "../vitest/vitest.test-shards.mjs";
 
 const normalizeRepoPath = toRepoPath;
+const MATRIX_TEST_PROCESS_FILE_LIMIT = 40;
 
 type VitestTestConfig = {
   dir?: string;
@@ -72,6 +73,11 @@ function findVitestConfigFactory(mod: Record<string, unknown>): VitestConfigFact
     }
   }
   return null;
+}
+
+function expectedMatrixTestProcessCount() {
+  const testFileCount = listExtensionTestFilesForRoots(["extensions/matrix"]).length;
+  return Math.max(1, Math.ceil(testFileCount / MATRIX_TEST_PROCESS_FILE_LIMIT));
 }
 
 async function loadRawVitestConfig(configPath: string): Promise<VitestConfig> {
@@ -3235,8 +3241,12 @@ describe("scripts/test-projects changed-target routing", () => {
           watchMode: false,
         })),
     );
-    expect(matrixPlans).toHaveLength(3);
-    expect(matrixPlans.every((plan) => (plan.includePatterns?.length ?? 0) <= 40)).toBe(true);
+    expect(matrixPlans).toHaveLength(expectedMatrixTestProcessCount());
+    expect(
+      matrixPlans.every(
+        (plan) => (plan.includePatterns?.length ?? 0) <= MATRIX_TEST_PROCESS_FILE_LIMIT,
+      ),
+    ).toBe(true);
     expect(matrixPlans.flatMap((plan) => plan.includePatterns ?? [])).toEqual(
       listExtensionTestFilesForRoots(["extensions/matrix"]),
     );
@@ -3246,11 +3256,13 @@ describe("scripts/test-projects changed-target routing", () => {
   it("bounds an explicit Matrix directory target across process lifetimes", () => {
     const plans = buildVitestRunPlans(["extensions/matrix"], process.cwd());
 
-    expect(plans).toHaveLength(3);
+    expect(plans).toHaveLength(expectedMatrixTestProcessCount());
     expect(
       plans.every((plan) => plan.config === "test/vitest/vitest.extension-matrix.config.ts"),
     ).toBe(true);
-    expect(plans.every((plan) => (plan.includePatterns?.length ?? 0) <= 40)).toBe(true);
+    expect(
+      plans.every((plan) => (plan.includePatterns?.length ?? 0) <= MATRIX_TEST_PROCESS_FILE_LIMIT),
+    ).toBe(true);
     expect(plans.flatMap((plan) => plan.includePatterns ?? [])).toEqual(
       listExtensionTestFilesForRoots(["extensions/matrix"]),
     );
@@ -3264,7 +3276,10 @@ describe("scripts/test-projects changed-target routing", () => {
 
     const plans = buildVitestRunPlans(["extensions/matrix", testFile], process.cwd());
 
-    expect(plans).toHaveLength(3);
+    expect(plans).toHaveLength(expectedMatrixTestProcessCount());
+    expect(
+      plans.every((plan) => (plan.includePatterns?.length ?? 0) <= MATRIX_TEST_PROCESS_FILE_LIMIT),
+    ).toBe(true);
     expect(plans.flatMap((plan) => plan.includePatterns ?? [])).toEqual(
       listExtensionTestFilesForRoots(["extensions/matrix"]),
     );
@@ -4652,8 +4667,10 @@ describe("scripts/test-projects full-suite sharding", () => {
     expect(toolingTargets).not.toContain("test/scripts/docker-build-helper.test.ts");
     expect(toolingTargets).not.toContain("test/scripts/openclaw-e2e-instance.test.ts");
     const matrixTargets = matrixPlans.flatMap((plan) => plan.forwardedArgs);
-    expect(matrixPlans).toHaveLength(3);
-    expect(matrixPlans.every((plan) => plan.forwardedArgs.length <= 40)).toBe(true);
+    expect(matrixPlans).toHaveLength(expectedMatrixTestProcessCount());
+    expect(
+      matrixPlans.every((plan) => plan.forwardedArgs.length <= MATRIX_TEST_PROCESS_FILE_LIMIT),
+    ).toBe(true);
     expect(matrixTargets).toEqual(listExtensionTestFilesForRoots(["extensions/matrix"]));
     expect(
       plans.filter(


### PR DESCRIPTION
Related: #118892

## What Problem This Solves

Fixes an issue where the tooling test suite fails after Matrix gains more than 120 test files because eight assertions assume the 40-file process limit always produces exactly three chunks.

## Why This Change Was Made

The extension-runner and full-suite planner tests now derive the expected Matrix process count from the current test inventory and the existing 40-file limit. Runtime chunking remains unchanged; only brittle test expectations are repaired.

## User Impact

There is no runtime user impact. Main and contributor PR CI remain green as Matrix test coverage grows.

## Evidence

- Before: the extension-runner and full-suite planner suites failed 8 assertions because 121 files produce four balanced chunks: `[31, 30, 30, 30]`.
- After: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/test-extension.test.ts test/scripts/test-projects.test.ts` passed 422/422 tests.
- `oxfmt --check`, type-aware `oxlint`, and `git diff --check` passed.
- The regression is current-main only and is not present in `v2026.7.2-beta.7` or `v2026.7.1`.
