### PR TITLE
chore(qa): cover bundled runtime discovery

### DIFF
--- a/qa/scenarios/plugins/bundled-channel-id-discovery.yaml
+++ b/qa/scenarios/plugins/bundled-channel-id-discovery.yaml
@@ -1,0 +1,26 @@
+title: Bundled channel id discovery
+
+scenario:
+  id: bundled-channel-id-discovery
+  surface: plugins
+  category: plugins.bundled-plugins
+  coverage:
+    primary:
+      - plugins.bundled-channel-ids
+  objective: Verify bundled channel ids come from package channel metadata instead of plugin identities.
+  successCriteria:
+    - Bundled package channel metadata produces a nonempty channel id list.
+    - Bundled channel ids are returned in deterministic sorted order.
+    - Plugin ids that differ from channel ids are not substituted into the channel id list.
+  docsRefs:
+    - docs/cli/plugins.md
+    - docs/plugins/plugin-inventory.md
+    - docs/plugins/architecture-internals.md
+  codeRefs:
+    - src/channels/plugins/bundled-ids.ts
+    - src/plugins/channel-catalog-registry.ts
+    - src/channels/bundled-channel-catalog-read.test.ts
+  execution:
+    kind: vitest
+    path: src/channels/bundled-channel-catalog-read.test.ts
+    summary: Run bundled package catalog loading through the sorted channel id projection.

--- a/qa/scenarios/plugins/bundled-source-overlay-discovery.yaml
+++ b/qa/scenarios/plugins/bundled-source-overlay-discovery.yaml
@@ -1,0 +1,26 @@
+title: Bundled source overlay discovery
+
+scenario:
+  id: bundled-source-overlay-discovery
+  surface: plugins
+  category: plugins.bundled-plugins
+  coverage:
+    primary:
+      - plugins.bundled-source-overlays
+  objective: Verify mounted bundled source overlays override packaged bundles while ordinary copied source directories remain inert.
+  successCriteria:
+    - A mounted bundled source plugin is discovered before the matching packaged bundle.
+    - Discovery reports the packaged candidate shadowed by the mounted source overlay.
+    - A copied source plugin directory without mount evidence does not override the packaged bundle.
+  docsRefs:
+    - docs/cli/plugins.md
+    - docs/plugins/plugin-inventory.md
+    - docs/plugins/architecture-internals.md
+  codeRefs:
+    - src/plugins/bundled-source-overlays.ts
+    - src/plugins/discovery.ts
+    - src/plugins/discovery.test.ts
+  execution:
+    kind: vitest
+    path: src/plugins/discovery.test.ts
+    summary: Run bundled discovery coverage for mounted source overlays and inert copied source directories.

--- a/src/channels/bundled-channel-catalog-read.test.ts
+++ b/src/channels/bundled-channel-catalog-read.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanupTempDirs, makeTempRepoRoot, writeJsonFile } from "../../test/helpers/temp-repo.js";
+import type { PluginChannelCatalogEntry } from "../plugins/channel-catalog-registry.js";
 
 // Delegate to the plugin-dir resolver for candidate-order policy; mock it here
 // so these tests focus on the loader's responsibility (merge
@@ -16,10 +17,14 @@ vi.mock("../plugins/bundled-dir.js", () => ({
   resolveSourceCheckoutDependencyDiagnostic: vi.fn(() => null),
 }));
 
-vi.mock("../plugins/channel-catalog-registry.js", () => ({
-  listChannelCatalogEntries: vi.fn(() => {
+const listChannelCatalogEntriesMock = vi.hoisted(() =>
+  vi.fn<() => PluginChannelCatalogEntry[]>(() => {
     throw new Error("bundled channel catalog read must not run full plugin discovery");
   }),
+);
+
+vi.mock("../plugins/channel-catalog-registry.js", () => ({
+  listChannelCatalogEntries: listChannelCatalogEntriesMock,
 }));
 
 // The channel-catalog.json fallback still walks package roots via
@@ -35,6 +40,7 @@ vi.mock("../infra/openclaw-root.js", () => ({
 import { resolveBundledPluginsDir } from "../plugins/bundled-dir.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
 import { listBundledChannelCatalogEntries } from "./bundled-channel-catalog-read.js";
+import { listBundledChannelIds } from "./plugins/bundled-ids.js";
 
 const tempDirs: string[] = [];
 const originalBundledPluginsDir = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
@@ -54,6 +60,10 @@ afterEach(() => {
   cleanupTempDirs(tempDirs);
   vi.restoreAllMocks();
   vi.mocked(resolveBundledPluginsDir).mockReset();
+  listChannelCatalogEntriesMock.mockReset();
+  listChannelCatalogEntriesMock.mockImplementation(() => {
+    throw new Error("bundled channel catalog read must not run full plugin discovery");
+  });
 });
 
 function useBundledPluginsDir(extensionsRoot: string | undefined): void {
@@ -77,6 +87,7 @@ function seedChannelPkg(
   pkgJsonPath: string,
   opts: {
     id: string;
+    pluginId?: string;
     docsPath: string;
     label?: string;
     blurb?: string;
@@ -85,8 +96,9 @@ function seedChannelPkg(
   },
 ): void {
   const pluginDir = path.dirname(pkgJsonPath);
+  const pluginId = opts.pluginId ?? opts.id;
   writeJsonFile(pkgJsonPath, {
-    name: `@openclaw/${opts.id}`,
+    name: `@openclaw/${pluginId}`,
     openclaw: {
       channel: {
         id: opts.id,
@@ -99,7 +111,7 @@ function seedChannelPkg(
     },
   });
   writeJsonFile(path.join(pluginDir, "openclaw.plugin.json"), {
-    id: opts.id,
+    id: pluginId,
     configSchema: { type: "object" },
     channels: [opts.id],
   });
@@ -151,6 +163,40 @@ describe("listBundledChannelCatalogEntries", () => {
     expect(telegram?.channel.docsPath).toBe("/channels/telegram");
     expect(telegram?.channel.label).toBe("Telegram");
     expect(telegram?.channel.approvalFlags).toEqual(["native"]);
+  });
+
+  it("lists sorted bundled channel ids without substituting plugin ids", () => {
+    const root = seedRoot("bcr-channel-ids-");
+    const extensionsRoot = path.join(root, "dist", "extensions");
+    seedChannelPkg(path.join(extensionsRoot, "vendor-beta", "package.json"), {
+      id: "beta-chat",
+      pluginId: "vendor-beta-plugin",
+      docsPath: "/channels/beta-chat",
+    });
+    seedChannelPkg(path.join(extensionsRoot, "vendor-alpha", "package.json"), {
+      id: "alpha-chat",
+      pluginId: "vendor-alpha-plugin",
+      docsPath: "/channels/alpha-chat",
+    });
+    useBundledPluginsDir(extensionsRoot);
+
+    const entries = listBundledChannelCatalogEntries().filter(
+      (entry) => entry.id === "alpha-chat" || entry.id === "beta-chat",
+    );
+    expect(entries).toHaveLength(2);
+    listChannelCatalogEntriesMock.mockReturnValue(
+      entries.map((entry) => ({
+        pluginId: entry.id === "alpha-chat" ? "vendor-alpha-plugin" : "vendor-beta-plugin",
+        origin: "bundled",
+        rootDir: extensionsRoot,
+        channel: entry.channel,
+      })),
+    );
+
+    const ids = listBundledChannelIds(process.env);
+    expect(ids).toEqual(["alpha-chat", "beta-chat"]);
+    expect(ids).not.toContain("vendor-alpha-plugin");
+    expect(ids).not.toContain("vendor-beta-plugin");
   });
 
   it("merges the generated official catalog with bundled package metadata", () => {


### PR DESCRIPTION
## What Problem This Solves

QA maturity accounting had no executable scenario ownership for bundled source-overlay discovery or bundled channel-ID discovery.

## Why This Change Was Made

Adds two narrowly owned QA scenarios backed by existing runtime tests, plus one integrated assertion that projects sorted channel IDs from bundled package metadata without substituting differing plugin IDs. Production discovery behavior is unchanged.

## User Impact

No runtime behavior changes. Maintainers gain executable coverage and durable maturity accounting for both bundled discovery contracts.

## Evidence

- Current head: `7bf95f3c99a9e8b165939979bfdee5583fa1dec6`, rebased onto `main` at `554a6f3bbf6d8173efc2f1c92e30139f88dc26d6`; the three-file patch is unchanged from the fully validated head below.
- Blacksmith Testbox `tbx_01kz4r1aygx6d9k7n4hvzcd777` on `dd38e9253e567fba14df120904dfab6af9fab909`: 152 focused tests passed across discovery, registry snapshot, package-state probes, bundled catalog read, and bundled root caches.
- Private QA build passed with `OPENCLAW_BUILD_PRIVATE_QA=1`.
- Both QA scenarios passed together and emitted full `qa-evidence.json` with the two coverage IDs as primary.
- Exact-path `pnpm check:changed` passed all fail-safe lanes in 12m37s on the unchanged patch before the final no-conflict rebase, including typecheck, core/extensions/scripts lint, import cycles, and repository guards.
- Sol/high autoreview reported no findings and rated the patch correct with 0.99 confidence.
- `pnpm format` passed for all three changed files.
- `git diff --check` passed.

ClawSweeper rank-up moves addressed:

- Rebased onto current `main`; focused Testbox validation is recorded on the unchanged pre-rebase patch, with current-head CI required before merge.
- Moved from draft only after focused, private-QA, scenario, changed-gate, and autoreview proof completed.
