### PR TITLE
test(qa): cover tool policy and sandbox gates

### DIFF
--- a/qa/scenarios/runtime/openclaw-tool-policy-gates.yaml
+++ b/qa/scenarios/runtime/openclaw-tool-policy-gates.yaml
@@ -1,0 +1,28 @@
+title: OpenClaw tool policy gates
+
+scenario:
+  id: openclaw-tool-policy-gates
+  surface: runtime-tools
+  coverage:
+    primary:
+      - tools.tool-policy
+      - tools.sandbox-tool-gates
+  objective: Verify OpenClaw exposes only tools permitted by every configured policy layer.
+  successCriteria:
+    - The coding profile includes filesystem and execution tools while excluding messaging tools.
+    - Global policy expands group:fs and applies explicit allow and deny entries.
+    - Provider profile, allow, and deny settings further restrict the global tool set.
+    - Agent allow and deny settings further restrict the global and provider tool set.
+    - Sandbox allow and deny settings are the final restrictive intersection, leaving read while removing write and exec.
+  docsRefs:
+    - docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
+    - docs/gateway/config-tools.md
+  codeRefs:
+    - src/agents/agent-tools.ts
+    - src/agents/conversation-tool-policy-pipeline.ts
+    - src/agents/tool-policy-pipeline.ts
+    - test/e2e/qa-lab/runtime/openclaw-tool-policy-gates.e2e.test.ts
+  execution:
+    kind: vitest
+    path: test/e2e/qa-lab/runtime/openclaw-tool-policy-gates.e2e.test.ts
+    summary: Run the production OpenClaw tool constructor through profile, global, provider, agent, and sandbox policy layers.

--- a/test/e2e/qa-lab/runtime/openclaw-tool-policy-gates.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/openclaw-tool-policy-gates.e2e.test.ts
@@ -1,0 +1,103 @@
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "vitest";
+import { createOpenClawCodingTools } from "../../../../src/agents/agent-tools.js";
+import { createAgentToolsSandboxContext } from "../../../../src/agents/test-helpers/agent-tools-sandbox-context.js";
+import { createHostSandboxFsBridge } from "../../../../src/agents/test-helpers/host-sandbox-fs-bridge.js";
+import type { OpenClawConfig } from "../../../../src/config/types.openclaw.js";
+
+type OpenClawCodingToolsOptions = NonNullable<Parameters<typeof createOpenClawCodingTools>[0]>;
+
+function toolNames(
+  config: OpenClawConfig,
+  options: Pick<OpenClawCodingToolsOptions, "sandbox"> = {},
+) {
+  return new Set(
+    createOpenClawCodingTools({
+      config,
+      sessionKey: "agent:policy:main",
+      agentId: "policy",
+      workspaceDir: path.join(os.tmpdir(), "openclaw-tool-policy-workspace"),
+      agentDir: path.join(os.tmpdir(), "openclaw-tool-policy-agent"),
+      modelProvider: "openai",
+      modelId: "gpt-5.4",
+      ...options,
+    }).map((tool) => tool.name),
+  );
+}
+
+function expectIncluded(names: Set<string>, included: string[], excluded: string[]): void {
+  for (const name of included) {
+    expect(names, `expected ${name} to pass the policy layer`).toContain(name);
+  }
+  for (const name of excluded) {
+    expect(names, `expected ${name} to be rejected by the policy layer`).not.toContain(name);
+  }
+}
+
+test("OpenClaw applies every configured tool policy as a restrictive intersection", () => {
+  const profileConfig: OpenClawConfig = {
+    tools: { profile: "coding" },
+  };
+  expectIncluded(toolNames(profileConfig), ["read", "write", "edit", "exec"], ["message"]);
+
+  const globalConfig: OpenClawConfig = {
+    tools: {
+      profile: "coding",
+      allow: ["group:fs", "exec", "process"],
+      deny: ["apply_patch"],
+    },
+  };
+  expectIncluded(
+    toolNames(globalConfig),
+    ["read", "write", "edit", "exec", "process"],
+    ["apply_patch", "message"],
+  );
+
+  const providerConfig: OpenClawConfig = {
+    tools: {
+      ...globalConfig.tools,
+      byProvider: {
+        openai: {
+          profile: "coding",
+          allow: ["read", "write", "edit", "exec", "process"],
+          deny: ["edit"],
+        },
+      },
+    },
+  };
+  expectIncluded(
+    toolNames(providerConfig),
+    ["read", "write", "exec", "process"],
+    ["apply_patch", "edit", "message"],
+  );
+
+  const agentConfig: OpenClawConfig = {
+    tools: providerConfig.tools,
+    agents: {
+      list: [
+        {
+          id: "policy",
+          tools: {
+            allow: ["read", "write", "exec", "process"],
+            deny: ["process"],
+          },
+        },
+      ],
+    },
+  };
+  expectIncluded(toolNames(agentConfig), ["read", "write", "exec"], ["edit", "process", "message"]);
+
+  const sandboxDir = path.join(os.tmpdir(), "openclaw-tool-policy-sandbox");
+  const sandbox = createAgentToolsSandboxContext({
+    workspaceDir: sandboxDir,
+    agentWorkspaceDir: path.join(os.tmpdir(), "openclaw-tool-policy-workspace"),
+    workspaceAccess: "rw",
+    fsBridge: createHostSandboxFsBridge(sandboxDir),
+    tools: {
+      allow: ["read", "write", "exec"],
+      deny: ["write", "exec"],
+    },
+  });
+  expectIncluded(toolNames(agentConfig, { sandbox }), ["read"], ["write", "edit", "exec"]);
+});


### PR DESCRIPTION
## What Problem This Solves

OpenClaw's layered tool policy and sandbox gates have focused unit coverage, but no primary QA evidence proves the production tool constructor applies every layer as a restrictive intersection.

## Why This Change Was Made

This adds one native QA Vitest scenario through `createOpenClawCodingTools`. It verifies profile filtering, `group:fs` expansion, global allow/deny, provider profile/allow/deny, agent allow/deny, and the sandbox's final restrictive intersection.

The change is test-only. It does not alter production policy, configuration, taxonomy, or QA evidence internals.

## User Impact

Operators get durable regression coverage that prevents profile, provider, agent, or sandbox policy changes from silently exposing tools denied by another layer.

## Evidence

- Focused E2E: `1` file, `1` test passed.
- Official QA Suite local fallback passed at exact head `cddc82ec27e1ba42d496381fcfb1c9a1e7f029ae`.
- `qa-evidence.json` records the exact head, source-checkout Vitest execution, and exactly two primary coverage IDs: `tools.tool-policy` and `tools.sandbox-tool-gates`.
- Path-scoped `node scripts/check-changed.mjs` local fallback passed its fail-safe all-lane plan, including full typecheck, lint, and `0` runtime import cycles. The later rebase changed only commit ancestry; the two-file diff is unchanged.
- Sol-high autoreview: clean, TruffleHog clean, no accepted/actionable findings, overall correctness `0.99`.
- Production LOC delta: `+0/-0`; test/QA metadata delta: `+131/-0`.

## Remote Fallback Note

The Blacksmith Testbox attempt failed before remote dispatch. Its task-local capture records `exitCode: -1`, empty stdout/stderr, blank Actions/run IDs, and `syncMs: 0`; it produced no QA evidence. Build-looking output initially observed during diagnosis belonged to an unrelated concurrent task and is not claimed here. Repository policy permits trusted-source local fallback when the remote backend is unavailable, which produced the evidence above.
