### PR TITLE
fix(plugins): remove stale load paths during uninstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Plugin uninstall cleanup:** remove exact recorded install paths from `plugins.load.paths` for marketplace, npm, and other managed installs while preserving parent, child, prefix, and unrelated paths.
 - Fixed Crabbox hydration on unprivileged cloud sandboxes by falling back to a user-writable pnpm store when the shared `/var/cache/crabbox` cache is unavailable, preserving the hardlink import mode after hydration, and making Docker an explicit routed capability instead of an implicit install requirement.
 
 - **Browser extension relay CDP compat:** answer `Target.getBrowserContexts` so Puppeteer-based clients (chrome-devtools-mcp) can drive the paired Chrome without the remote-debugging permission prompt, serve DevTools-style `/json/list` target descriptors, and add `openclaw browser extension cdp` to print the relay endpoint plus auth header for external CDP clients.

--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -49,6 +49,7 @@ const repositoryScriptEntries = [
   "scripts/e2e/lib/plugin-lifecycle-matrix/measure.mjs!",
   "scripts/e2e/lib/plugin-update/registry-server.mjs!",
   "scripts/e2e/lib/plugins/npm-registry-server.mjs!",
+  "scripts/e2e/lib/release-plugin-marketplace/lifecycle-assertions.mjs!",
   "scripts/e2e/lib/release-scenarios/write-cli-plugin.mjs!",
   "scripts/e2e/lib/release-scenarios/write-marketplace.mjs!",
   "scripts/e2e/lib/release-user-journey/clickclack-fixture.mjs!",

--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -420,7 +420,7 @@ openclaw plugins uninstall <id> --keep-files
 openclaw plugins uninstall <id> --force
 ```
 
-`uninstall` removes plugin records from `plugins.entries`, the persisted plugin index, plugin allow/deny list entries, and linked `plugins.load.paths` entries when applicable. Unless `--keep-files` is set, uninstall also removes the tracked managed install directory, but only when it resolves inside OpenClaw's plugin extensions root. If the plugin currently owns the `memory` or `contextEngine` slot, that slot resets to its default (`memory-core` for memory, `legacy` for context engine).
+`uninstall` removes plugin records from `plugins.entries`, the persisted plugin index, plugin allow/deny list entries, and any `plugins.load.paths` entry that exactly resolves to the recorded install path. Linked path installs also remove an exact entry for their recorded source path. Parent directories, child paths, prefix matches, and unrelated load paths are preserved. Unless `--keep-files` is set, uninstall also removes the tracked managed install directory, but only when it resolves inside OpenClaw's plugin extensions root. If the plugin currently owns the `memory` or `contextEngine` slot, that slot resets to its default (`memory-core` for memory, `legacy` for context engine).
 
 `uninstall` prints a preview of what will be removed, then prompts `Uninstall plugin "<id>"?` before making changes. Pass `--force` to skip the confirmation prompt (useful for scripts and non-interactive runs); without it, uninstall requires an interactive TTY. `--dry-run` prints the same preview and exits without prompting or changing anything.
 

--- a/qa/scenarios/plugins/clawhub-marketplace-list.yaml
+++ b/qa/scenarios/plugins/clawhub-marketplace-list.yaml
@@ -8,7 +8,6 @@ scenario:
     primary:
       - clawhub.marketplace-list
       - clawhub.update-by-plugin-id
-    secondary:
       - clawhub.uninstall-config-index-policy-file-cleanup
   objective: Verify package-installed marketplace listing, install, update, and uninstall behavior through the release plugin marketplace lane.
   successCriteria:
@@ -16,7 +15,7 @@ scenario:
     - The package-installed CLI lists the fixture marketplace as JSON and includes the expected plugin.
     - The marketplace plugin installs into the managed directory with canonical marketplace metadata and a SQLite install/index record.
     - A plugin-ID dry run reports 0.0.1 to 0.0.2 without mutating the record or CLI, then the real update persists 0.0.2 and exposes the v2 CLI output.
-    - Uninstall removes the plugin CLI and install metadata.
+    - Uninstall removes the config entry, SQLite install/index metadata, allow/deny policy entries, exact managed load path, managed directory, and plugin CLI while preserving unrelated policy and load-path sentinels.
   docsRefs:
     - docs/help/testing.md
     - docs/concepts/qa-e2e-automation.md

--- a/qa/scenarios/plugins/clawhub-marketplace-list.yaml
+++ b/qa/scenarios/plugins/clawhub-marketplace-list.yaml
@@ -7,14 +7,15 @@ scenario:
   coverage:
     primary:
       - clawhub.marketplace-list
-    secondary:
       - clawhub.update-by-plugin-id
+    secondary:
       - clawhub.uninstall-config-index-policy-file-cleanup
   objective: Verify package-installed marketplace listing, install, update, and uninstall behavior through the release plugin marketplace lane.
   successCriteria:
     - A fixture marketplace is written into the package-installed home.
     - The package-installed CLI lists the fixture marketplace as JSON and includes the expected plugin.
-    - The marketplace plugin installs by marketplace shortcut, exposes its CLI, updates by plugin id, and exposes the updated CLI output.
+    - The marketplace plugin installs into the managed directory with canonical marketplace metadata and a SQLite install/index record.
+    - A plugin-ID dry run reports 0.0.1 to 0.0.2 without mutating the record or CLI, then the real update persists 0.0.2 and exposes the v2 CLI output.
     - Uninstall removes the plugin CLI and install metadata.
   docsRefs:
     - docs/help/testing.md
@@ -22,6 +23,7 @@ scenario:
   codeRefs:
     - scripts/e2e/release-plugin-marketplace-docker.sh
     - scripts/e2e/lib/release-plugin-marketplace/scenario.sh
+    - scripts/e2e/lib/release-plugin-marketplace/lifecycle-assertions.mjs
     - scripts/e2e/lib/release-scenarios/write-marketplace.mjs
   execution:
     kind: script

--- a/scripts/e2e/lib/release-plugin-marketplace/lifecycle-assertions.mjs
+++ b/scripts/e2e/lib/release-plugin-marketplace/lifecycle-assertions.mjs
@@ -30,12 +30,29 @@ function resolveRecordedPath(value) {
   return path.resolve(value);
 }
 
+function resolveComparablePath(value) {
+  const resolved = resolveRecordedPath(value);
+  try {
+    return fs.realpathSync(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
 function assertPathInside(parent, child, label) {
   const relative = path.relative(fs.realpathSync(parent), fs.realpathSync(child));
   assert(
     relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative),
     `${label} escaped ${parent}: ${child}`,
   );
+}
+
+function samePath(left, right) {
+  return resolveComparablePath(left) === resolveComparablePath(right);
+}
+
+function appendUnique(values, additions) {
+  return [...new Set([...(values ?? []), ...additions])];
 }
 
 function assertMarketplaceState() {
@@ -106,6 +123,83 @@ function assertMarketplaceState() {
   }
 }
 
+function seedMarketplaceUninstallState() {
+  const pluginId = process.argv[3];
+  const sentinelPluginId = process.argv[4];
+  const sentinelPath = process.argv[5];
+  const installPathFile = process.argv[6];
+  assert(pluginId, "missing plugin id");
+  assert(sentinelPluginId, "missing sentinel plugin id");
+  assert(sentinelPath, "missing sentinel path");
+  assert(installPathFile, "missing install path file");
+
+  const index = readPluginInstallIndex({ stateDir: stateDir(), configPath: configPath() });
+  const installPath = index.installRecords?.[pluginId]?.installPath;
+  assert(installPath, `install path missing for ${pluginId}`);
+  assert(
+    fs.existsSync(installPath),
+    `managed install path missing before uninstall: ${installPath}`,
+  );
+  assert(fs.existsSync(sentinelPath), `sentinel path missing before uninstall: ${sentinelPath}`);
+
+  const config = readJson(configPath());
+  const plugins = config.plugins ?? {};
+  config.plugins = {
+    ...plugins,
+    allow: appendUnique(plugins.allow, [pluginId, sentinelPluginId]),
+    deny: appendUnique(plugins.deny, [pluginId, sentinelPluginId]),
+    load: {
+      ...plugins.load,
+      paths: appendUnique(plugins.load?.paths, [installPath, sentinelPath]),
+    },
+  };
+  fs.writeFileSync(configPath(), `${JSON.stringify(config, null, 2)}\n`, "utf8");
+  fs.writeFileSync(installPathFile, `${installPath}\n`, "utf8");
+}
+
+function assertMarketplaceUninstalled() {
+  const pluginId = process.argv[3];
+  const sentinelPluginId = process.argv[4];
+  const sentinelPath = process.argv[5];
+  const installPathFile = process.argv[6];
+  assert(pluginId, "missing plugin id");
+  assert(sentinelPluginId, "missing sentinel plugin id");
+  assert(sentinelPath, "missing sentinel path");
+  assert(installPathFile, "missing install path file");
+
+  const installPath = fs.readFileSync(installPathFile, "utf8").trim();
+  const index = readPluginInstallIndex({ stateDir: stateDir(), configPath: configPath() });
+  const config = readJson(configPath());
+  const loadPaths = config.plugins?.load?.paths ?? [];
+
+  assert(!index.installRecords?.[pluginId], `install record still present for ${pluginId}`);
+  assert(
+    !(index.plugins ?? []).some((entry) => entry.pluginId === pluginId),
+    `installed plugin index still includes ${pluginId}`,
+  );
+  assert(!config.plugins?.entries?.[pluginId], `plugin config entry still present for ${pluginId}`);
+  assert(!config.plugins?.allow?.includes(pluginId), `allowlist still includes ${pluginId}`);
+  assert(!config.plugins?.deny?.includes(pluginId), `denylist still includes ${pluginId}`);
+  assert(
+    config.plugins?.allow?.includes(sentinelPluginId),
+    `allowlist lost sentinel ${sentinelPluginId}`,
+  );
+  assert(
+    config.plugins?.deny?.includes(sentinelPluginId),
+    `denylist lost sentinel ${sentinelPluginId}`,
+  );
+  assert(
+    !loadPaths.some((candidate) => samePath(candidate, installPath)),
+    `load paths still include managed install path ${installPath}`,
+  );
+  assert(
+    loadPaths.some((candidate) => samePath(candidate, sentinelPath)),
+    `load paths lost sentinel path ${sentinelPath}`,
+  );
+  assert(!fs.existsSync(installPath), `managed install path still exists: ${installPath}`);
+  assert(fs.existsSync(sentinelPath), `sentinel path was removed: ${sentinelPath}`);
+}
+
 function assertUpdateLog() {
   const logPath = process.argv[3];
   const expected = process.argv[4];
@@ -117,6 +211,8 @@ function assertUpdateLog() {
 
 const commands = {
   "assert-marketplace-state": assertMarketplaceState,
+  "seed-marketplace-uninstall-state": seedMarketplaceUninstallState,
+  "assert-marketplace-uninstalled": assertMarketplaceUninstalled,
   "assert-update-log": assertUpdateLog,
 };
 

--- a/scripts/e2e/lib/release-plugin-marketplace/lifecycle-assertions.mjs
+++ b/scripts/e2e/lib/release-plugin-marketplace/lifecycle-assertions.mjs
@@ -1,0 +1,128 @@
+import fs from "node:fs";
+import path from "node:path";
+import { readPluginInstallIndex } from "../plugin-index-sqlite.mjs";
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function stateDir() {
+  return process.env.OPENCLAW_STATE_DIR || path.join(process.env.HOME ?? "", ".openclaw");
+}
+
+function configPath() {
+  return process.env.OPENCLAW_CONFIG_PATH || path.join(stateDir(), "openclaw.json");
+}
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+function resolveRecordedPath(value) {
+  if (value === "~") {
+    return process.env.HOME ?? "";
+  }
+  if (value.startsWith("~/")) {
+    return path.join(process.env.HOME ?? "", value.slice(2));
+  }
+  return path.resolve(value);
+}
+
+function assertPathInside(parent, child, label) {
+  const relative = path.relative(fs.realpathSync(parent), fs.realpathSync(child));
+  assert(
+    relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative),
+    `${label} escaped ${parent}: ${child}`,
+  );
+}
+
+function assertMarketplaceState() {
+  const pluginId = process.argv[3];
+  const expectedVersion = process.argv[4];
+  const expectedMarketplaceSource = process.argv[5];
+  const expectedMarketplacePlugin = process.argv[6];
+  const installPathFile = process.argv[7];
+  assert(pluginId, "missing plugin id");
+  assert(expectedVersion, "missing expected version");
+  assert(expectedMarketplaceSource, "missing expected marketplace source");
+  assert(expectedMarketplacePlugin, "missing expected marketplace plugin");
+  assert(installPathFile, "missing install path file");
+
+  const databasePath = path.join(stateDir(), "state", "openclaw.sqlite");
+  assert(fs.existsSync(databasePath), `canonical plugin index database missing: ${databasePath}`);
+  const index = readPluginInstallIndex({ stateDir: stateDir(), configPath: configPath() });
+  const record = index.installRecords?.[pluginId];
+  assert(record, `missing install record for ${pluginId}`);
+  assert(record.source === "marketplace", `expected marketplace source, got ${record.source}`);
+  assert(
+    record.marketplaceSource === expectedMarketplaceSource,
+    `expected marketplace source ${expectedMarketplaceSource}, got ${record.marketplaceSource}`,
+  );
+  assert(
+    record.marketplacePlugin === expectedMarketplacePlugin,
+    `expected marketplace plugin ${expectedMarketplacePlugin}, got ${record.marketplacePlugin}`,
+  );
+  assert(
+    record.version === expectedVersion,
+    `expected install record version ${expectedVersion}, got ${record.version}`,
+  );
+
+  const indexedPlugin = (index.plugins ?? []).find((entry) => entry.pluginId === pluginId);
+  assert(indexedPlugin, `installed plugin index omitted ${pluginId}`);
+  assert(
+    indexedPlugin.packageVersion === expectedVersion,
+    `expected indexed package version ${expectedVersion}, got ${indexedPlugin.packageVersion}`,
+  );
+
+  const config = readJson(configPath());
+  assert(
+    config.plugins?.entries?.[pluginId]?.enabled === true,
+    `plugin config entry is not enabled for ${pluginId}`,
+  );
+
+  assert(record.installPath, `install path missing for ${pluginId}`);
+  const installPath = resolveRecordedPath(record.installPath);
+  assert(
+    fs.existsSync(installPath),
+    `managed install path missing for ${pluginId}: ${installPath}`,
+  );
+  assertPathInside(path.join(stateDir(), "extensions"), installPath, "managed install path");
+  const packageJson = readJson(path.join(installPath, "package.json"));
+  assert(
+    packageJson.version === expectedVersion,
+    `expected installed package version ${expectedVersion}, got ${packageJson.version}`,
+  );
+
+  if (fs.existsSync(installPathFile)) {
+    const previousInstallPath = fs.readFileSync(installPathFile, "utf8").trim();
+    assert(
+      previousInstallPath === installPath,
+      `plugin update moved the managed install path: ${previousInstallPath} -> ${installPath}`,
+    );
+  } else {
+    fs.writeFileSync(installPathFile, `${installPath}\n`, "utf8");
+  }
+}
+
+function assertUpdateLog() {
+  const logPath = process.argv[3];
+  const expected = process.argv[4];
+  assert(logPath, "missing update log path");
+  assert(expected, "missing expected update log text");
+  const output = fs.readFileSync(logPath, "utf8");
+  assert(output.includes(expected), `${logPath} did not contain ${expected}`);
+}
+
+const commands = {
+  "assert-marketplace-state": assertMarketplaceState,
+  "assert-update-log": assertUpdateLog,
+};
+
+const command = process.argv[2];
+const fn = commands[command];
+if (!fn) {
+  throw new Error(`unknown marketplace lifecycle assertion command: ${command ?? "<missing>"}`);
+}
+fn();

--- a/scripts/e2e/lib/release-plugin-marketplace/scenario.sh
+++ b/scripts/e2e/lib/release-plugin-marketplace/scenario.sh
@@ -25,6 +25,7 @@ dump_debug_logs() {
     /tmp/openclaw-release-plugin-marketplace-install-plugin.log \
     /tmp/openclaw-release-plugin-marketplace-cli-v1.log \
     /tmp/openclaw-release-plugin-marketplace-update-dry-run.log \
+    /tmp/openclaw-release-plugin-marketplace-cli-after-dry-run.log \
     /tmp/openclaw-release-plugin-marketplace-update.log \
     /tmp/openclaw-release-plugin-marketplace-cli-v2.log \
     /tmp/openclaw-release-plugin-marketplace-uninstall.log \
@@ -49,6 +50,8 @@ openclaw onboard \
   --skip-health >/tmp/openclaw-release-plugin-marketplace-onboard.log 2>&1
 
 marketplace_root="$HOME/.claude/plugins/marketplaces/release-fixture-marketplace"
+marketplace_assertions="scripts/e2e/lib/release-plugin-marketplace/lifecycle-assertions.mjs"
+install_path_file="/tmp/openclaw-release-plugin-marketplace-install-path.txt"
 mkdir -p "$HOME/.claude/plugins" "$marketplace_root/.claude-plugin"
 node scripts/e2e/lib/release-scenarios/write-cli-plugin.mjs \
   "$marketplace_root/plugins/release-marketplace-plugin" \
@@ -76,6 +79,13 @@ openclaw plugins marketplace list release-fixtures --json >/tmp/openclaw-release
 node scripts/e2e/lib/release-scenarios/assertions.mjs assert-file-contains /tmp/openclaw-release-plugin-marketplace-list.json release-marketplace-plugin
 
 openclaw plugins install release-marketplace-plugin@release-fixtures --force >/tmp/openclaw-release-plugin-marketplace-install-plugin.log 2>&1
+node "$marketplace_assertions" \
+  assert-marketplace-state \
+  release-marketplace-plugin \
+  0.0.1 \
+  release-fixtures \
+  release-marketplace-plugin \
+  "$install_path_file"
 openclaw release-market ping >/tmp/openclaw-release-plugin-marketplace-cli-v1.log 2>&1
 node scripts/e2e/lib/release-scenarios/assertions.mjs assert-file-contains /tmp/openclaw-release-plugin-marketplace-cli-v1.log "release-marketplace-plugin:v1"
 
@@ -88,7 +98,31 @@ node scripts/e2e/lib/release-scenarios/write-cli-plugin.mjs \
   release-market \
   "release-marketplace-plugin:v2"
 openclaw plugins update release-marketplace-plugin --dry-run >/tmp/openclaw-release-plugin-marketplace-update-dry-run.log 2>&1
+node "$marketplace_assertions" \
+  assert-update-log \
+  /tmp/openclaw-release-plugin-marketplace-update-dry-run.log \
+  "Would update release-marketplace-plugin: 0.0.1 -> 0.0.2."
+node "$marketplace_assertions" \
+  assert-marketplace-state \
+  release-marketplace-plugin \
+  0.0.1 \
+  release-fixtures \
+  release-marketplace-plugin \
+  "$install_path_file"
+openclaw release-market ping >/tmp/openclaw-release-plugin-marketplace-cli-after-dry-run.log 2>&1
+node scripts/e2e/lib/release-scenarios/assertions.mjs assert-file-contains /tmp/openclaw-release-plugin-marketplace-cli-after-dry-run.log "release-marketplace-plugin:v1"
 openclaw plugins update release-marketplace-plugin >/tmp/openclaw-release-plugin-marketplace-update.log 2>&1
+node "$marketplace_assertions" \
+  assert-update-log \
+  /tmp/openclaw-release-plugin-marketplace-update.log \
+  "Updated release-marketplace-plugin: 0.0.1 -> 0.0.2."
+node "$marketplace_assertions" \
+  assert-marketplace-state \
+  release-marketplace-plugin \
+  0.0.2 \
+  release-fixtures \
+  release-marketplace-plugin \
+  "$install_path_file"
 openclaw release-market ping >/tmp/openclaw-release-plugin-marketplace-cli-v2.log 2>&1
 node scripts/e2e/lib/release-scenarios/assertions.mjs assert-file-contains /tmp/openclaw-release-plugin-marketplace-cli-v2.log "release-marketplace-plugin:v2"
 

--- a/scripts/e2e/lib/release-plugin-marketplace/scenario.sh
+++ b/scripts/e2e/lib/release-plugin-marketplace/scenario.sh
@@ -126,11 +126,29 @@ node "$marketplace_assertions" \
 openclaw release-market ping >/tmp/openclaw-release-plugin-marketplace-cli-v2.log 2>&1
 node scripts/e2e/lib/release-scenarios/assertions.mjs assert-file-contains /tmp/openclaw-release-plugin-marketplace-cli-v2.log "release-marketplace-plugin:v2"
 
+sentinel_plugin_id="release-marketplace-other"
+sentinel_path="$marketplace_root/plugins/$sentinel_plugin_id"
+node "$marketplace_assertions" \
+  seed-marketplace-uninstall-state \
+  release-marketplace-plugin \
+  "$sentinel_plugin_id" \
+  "$sentinel_path" \
+  "$install_path_file"
 openclaw plugins uninstall release-marketplace-plugin --force >/tmp/openclaw-release-plugin-marketplace-uninstall.log 2>&1
+node "$marketplace_assertions" \
+  assert-update-log \
+  /tmp/openclaw-release-plugin-marketplace-uninstall.log \
+  "Removed: config entry, install record, allowlist entry, denylist entry, load path, directory."
 if openclaw release-market ping >/tmp/openclaw-release-plugin-marketplace-cli-after-uninstall.log 2>&1; then
   echo "release-market CLI should be gone after uninstall" >&2
   exit 1
 fi
+node "$marketplace_assertions" \
+  assert-marketplace-uninstalled \
+  release-marketplace-plugin \
+  "$sentinel_plugin_id" \
+  "$sentinel_path" \
+  "$install_path_file"
 node scripts/e2e/lib/release-scenarios/assertions.mjs assert-plugin-uninstalled release-marketplace-plugin release-market
 
 echo "Release plugin marketplace scenario passed."

--- a/src/plugins/uninstall.test.ts
+++ b/src/plugins/uninstall.test.ts
@@ -148,6 +148,15 @@ function createGitInstallRecord(pluginId = "my-plugin", installPath?: string): P
   };
 }
 
+function createMarketplaceInstallRecord(installPath: string): PluginInstallRecord {
+  return {
+    source: "marketplace",
+    installPath,
+    marketplaceSource: "release-fixtures",
+    marketplacePlugin: "my-plugin",
+  };
+}
+
 function createPathInstallRecord(
   installPath = "/path/to/plugin",
   sourcePath = installPath,
@@ -382,6 +391,76 @@ describe("removePluginFromConfig", () => {
 
     expect(result.plugins?.load?.paths).toEqual(expectedPaths);
     expect(actions.loadPath).toBe(true);
+  });
+
+  it.each([
+    {
+      name: "marketplace install path",
+      installRecord: createMarketplaceInstallRecord("/managed/my-plugin"),
+      loadPaths: ["/managed/my-plugin", "/managed/my-plugin/child", "/other/path"],
+      expectedPaths: ["/managed/my-plugin/child", "/other/path"],
+      expectedChanged: true,
+    },
+    {
+      name: "npm install path",
+      installRecord: createNpmInstallRecord("my-plugin", "/managed/my-plugin"),
+      loadPaths: ["/managed/my-plugin", "/managed/my-plugin/child", "/other/path"],
+      expectedPaths: ["/managed/my-plugin/child", "/other/path"],
+      expectedChanged: true,
+    },
+    {
+      name: "absent load paths",
+      installRecord: createMarketplaceInstallRecord("/managed/my-plugin"),
+      loadPaths: undefined,
+      expectedPaths: undefined,
+      expectedChanged: false,
+    },
+    {
+      name: "mismatched and child paths",
+      installRecord: createNpmInstallRecord("my-plugin", "/managed/my-plugin"),
+      loadPaths: ["/managed/my-plugin-other", "/managed/my-plugin/child"],
+      expectedPaths: ["/managed/my-plugin-other", "/managed/my-plugin/child"],
+      expectedChanged: false,
+    },
+  ])(
+    "cleans only the exact $name from load.paths",
+    ({ installRecord, loadPaths, expectedPaths, expectedChanged }) => {
+      const config = createPluginConfig({
+        installs: { "my-plugin": installRecord },
+        loadPaths,
+      });
+
+      const { config: result, actions } = removePluginFromConfig(config, "my-plugin");
+
+      expect(result.plugins?.load?.paths).toEqual(expectedPaths);
+      expect(actions.loadPath).toBe(expectedChanged);
+    },
+  );
+
+  it("removes a canonical marketplace install path without removing siblings", async () => {
+    const tempRoot = path.join(process.cwd(), ".tmp");
+    await fs.mkdir(tempRoot, { recursive: true });
+    const tempDir = await fs.mkdtemp(path.join(tempRoot, "openclaw-uninstall-marketplace-path-"));
+    try {
+      const installPath = path.join(tempDir, "managed", "my-plugin");
+      const linkedPath = path.join(tempDir, "my-plugin-link");
+      const siblingPath = path.join(tempDir, "managed", "my-plugin-other");
+      await fs.mkdir(installPath, { recursive: true });
+      await fs.symlink(installPath, linkedPath, "dir");
+      const config = createPluginConfig({
+        installs: {
+          "my-plugin": createMarketplaceInstallRecord(installPath),
+        },
+        loadPaths: [linkedPath, siblingPath],
+      });
+
+      const { config: result, actions } = removePluginFromConfig(config, "my-plugin");
+
+      expect(result.plugins?.load?.paths).toEqual([siblingPath]);
+      expect(actions.loadPath).toBe(true);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("removes absolute load path for a workspace-relative install source path", async () => {

--- a/src/plugins/uninstall.ts
+++ b/src/plugins/uninstall.ts
@@ -361,11 +361,11 @@ export function resolveUninstallChannelConfigKeys(
   return keys;
 }
 
-function loadPathMatchesInstallSourcePath(loadPath: string, sourcePath: string): boolean {
-  if (loadPath === sourcePath) {
+function loadPathMatchesInstallPath(loadPath: string, installPath: string): boolean {
+  if (loadPath === installPath) {
     return true;
   }
-  return resolveComparablePath(loadPath) === resolveComparablePath(sourcePath);
+  return resolveComparablePath(loadPath) === resolveComparablePath(installPath);
 }
 
 function resolveComparablePath(value: string): string {
@@ -435,17 +435,23 @@ export function removePluginFromConfig(
     actions.denylist = true;
   }
 
-  // Remove linked path from load.paths (for source === "path" plugins)
+  // Remove exact tracked install paths without consuming parent, child, or prefix matches.
   let load = pluginsConfig.load;
-  if (installRecord?.source === "path" && installRecord.sourcePath) {
-    const sourcePath = installRecord.sourcePath;
+  const trackedInstallPaths = [
+    installRecord?.installPath,
+    installRecord?.source === "path" ? installRecord.sourcePath : undefined,
+  ].filter((value): value is string => Boolean(value));
+  if (trackedInstallPaths.length > 0) {
     const loadPaths = load?.paths;
     if (
       Array.isArray(loadPaths) &&
-      loadPaths.some((p) => loadPathMatchesInstallSourcePath(p, sourcePath))
+      loadPaths.some((p) =>
+        trackedInstallPaths.some((installPath) => loadPathMatchesInstallPath(p, installPath)),
+      )
     ) {
       const nextLoadPaths = loadPaths.filter(
-        (p) => !loadPathMatchesInstallSourcePath(p, sourcePath),
+        (p) =>
+          !trackedInstallPaths.some((installPath) => loadPathMatchesInstallPath(p, installPath)),
       );
       load = nextLoadPaths.length > 0 ? { ...load, paths: nextLoadPaths } : undefined;
       actions.loadPath = true;

--- a/test/scripts/release-plugin-marketplace-lifecycle.test.ts
+++ b/test/scripts/release-plugin-marketplace-lifecycle.test.ts
@@ -1,0 +1,179 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../helpers/temp-dir.js";
+
+const HELPER = path.resolve("scripts/e2e/lib/release-plugin-marketplace/lifecycle-assertions.mjs");
+const tempDirs = new Set<string>();
+
+afterEach(() => {
+  cleanupTempDirs(tempDirs);
+});
+
+function writeIndex(
+  stateDir: string,
+  pluginId: string,
+  record: Record<string, unknown>,
+  packageVersion: string,
+) {
+  const databasePath = path.join(stateDir, "state", "openclaw.sqlite");
+  fs.mkdirSync(path.dirname(databasePath), { recursive: true });
+  const db = new DatabaseSync(databasePath);
+  try {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS installed_plugin_index (
+        index_key TEXT NOT NULL PRIMARY KEY,
+        version INTEGER NOT NULL,
+        host_contract_version TEXT NOT NULL,
+        compat_registry_version TEXT NOT NULL,
+        migration_version INTEGER NOT NULL,
+        policy_hash TEXT NOT NULL,
+        generated_at_ms INTEGER NOT NULL,
+        refresh_reason TEXT,
+        install_records_json TEXT NOT NULL,
+        plugins_json TEXT NOT NULL,
+        diagnostics_json TEXT NOT NULL,
+        warning TEXT,
+        updated_at_ms INTEGER NOT NULL
+      );
+    `);
+    const now = Date.now();
+    db.prepare(
+      `
+        INSERT OR REPLACE INTO installed_plugin_index (
+          index_key, version, host_contract_version, compat_registry_version,
+          migration_version, policy_hash, generated_at_ms, refresh_reason,
+          install_records_json, plugins_json, diagnostics_json, warning, updated_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+    ).run(
+      "installed-plugin-index",
+      1,
+      "test",
+      "test",
+      1,
+      "test",
+      now,
+      "source-changed",
+      JSON.stringify({ [pluginId]: record }),
+      JSON.stringify([{ pluginId, packageVersion }]),
+      "[]",
+      null,
+      now,
+    );
+  } finally {
+    db.close();
+  }
+}
+
+function runHelper(home: string, args: string[]) {
+  const stateDir = path.join(home, ".openclaw");
+  return spawnSync(process.execPath, [HELPER, ...args], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      HOME: home,
+      OPENCLAW_CONFIG_PATH: path.join(stateDir, "openclaw.json"),
+      OPENCLAW_STATE_DIR: stateDir,
+    },
+  });
+}
+
+function writeMarketplaceState(home: string, version: string) {
+  const pluginId = "release-marketplace-plugin";
+  const stateDir = path.join(home, ".openclaw");
+  const installPath = path.join(stateDir, "extensions", pluginId);
+  fs.mkdirSync(installPath, { recursive: true });
+  fs.writeFileSync(
+    path.join(installPath, "package.json"),
+    `${JSON.stringify({ name: `@openclaw/${pluginId}`, version })}\n`,
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(stateDir, "openclaw.json"),
+    `${JSON.stringify({
+      plugins: { entries: { [pluginId]: { enabled: true } } },
+    })}\n`,
+    "utf8",
+  );
+  writeIndex(
+    stateDir,
+    pluginId,
+    {
+      source: "marketplace",
+      installPath,
+      version,
+      marketplaceName: "Release Fixture Marketplace",
+      marketplaceSource: "release-fixtures",
+      marketplacePlugin: pluginId,
+    },
+    version,
+  );
+  return { installPath, pluginId };
+}
+
+describe("release plugin marketplace lifecycle assertions", () => {
+  it("checks canonical marketplace metadata and stable managed install paths", () => {
+    const home = makeTempDir(tempDirs, "openclaw-marketplace-lifecycle-");
+    const { installPath, pluginId } = writeMarketplaceState(home, "0.0.1");
+    const installPathFile = path.join(home, "install-path.txt");
+
+    const initial = runHelper(home, [
+      "assert-marketplace-state",
+      pluginId,
+      "0.0.1",
+      "release-fixtures",
+      pluginId,
+      installPathFile,
+    ]);
+    expect(initial.stderr).toBe("");
+    expect(initial.status).toBe(0);
+    expect(fs.readFileSync(installPathFile, "utf8").trim()).toBe(installPath);
+
+    writeMarketplaceState(home, "0.0.2");
+    const updated = runHelper(home, [
+      "assert-marketplace-state",
+      pluginId,
+      "0.0.2",
+      "release-fixtures",
+      pluginId,
+      installPathFile,
+    ]);
+    expect(updated.stderr).toBe("");
+    expect(updated.status).toBe(0);
+  });
+
+  it("rejects marketplace state with the wrong persisted version", () => {
+    const home = makeTempDir(tempDirs, "openclaw-marketplace-lifecycle-");
+    const { pluginId } = writeMarketplaceState(home, "0.0.1");
+
+    const result = runHelper(home, [
+      "assert-marketplace-state",
+      pluginId,
+      "0.0.2",
+      "release-fixtures",
+      pluginId,
+      path.join(home, "install-path.txt"),
+    ]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("expected install record version 0.0.2, got 0.0.1");
+  });
+
+  it("checks the exact dry-run and update outcome text", () => {
+    const home = makeTempDir(tempDirs, "openclaw-marketplace-lifecycle-");
+    const logPath = path.join(home, "update.log");
+    fs.writeFileSync(logPath, "Would update release-marketplace-plugin: 0.0.1 -> 0.0.2.\n", "utf8");
+
+    const result = runHelper(home, [
+      "assert-update-log",
+      logPath,
+      "Would update release-marketplace-plugin: 0.0.1 -> 0.0.2.",
+    ]);
+
+    expect(result.stderr).toBe("");
+    expect(result.status).toBe(0);
+  });
+});

--- a/test/scripts/release-plugin-marketplace-lifecycle.test.ts
+++ b/test/scripts/release-plugin-marketplace-lifecycle.test.ts
@@ -114,6 +114,24 @@ function writeMarketplaceState(home: string, version: string) {
   return { installPath, pluginId };
 }
 
+function clearMarketplaceIndex(home: string) {
+  const databasePath = path.join(home, ".openclaw", "state", "openclaw.sqlite");
+  const db = new DatabaseSync(databasePath);
+  try {
+    db.prepare(
+      `
+        UPDATE installed_plugin_index
+           SET install_records_json = ?,
+               plugins_json = ?,
+               updated_at_ms = ?
+         WHERE index_key = ?
+      `,
+    ).run("{}", "[]", Date.now(), "installed-plugin-index");
+  } finally {
+    db.close();
+  }
+}
+
 describe("release plugin marketplace lifecycle assertions", () => {
   it("checks canonical marketplace metadata and stable managed install paths", () => {
     const home = makeTempDir(tempDirs, "openclaw-marketplace-lifecycle-");
@@ -160,6 +178,49 @@ describe("release plugin marketplace lifecycle assertions", () => {
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("expected install record version 0.0.2, got 0.0.1");
+  });
+
+  it("seeds uninstall state and verifies complete cleanup with sentinels preserved", () => {
+    const home = makeTempDir(tempDirs, "openclaw-marketplace-lifecycle-");
+    const { installPath, pluginId } = writeMarketplaceState(home, "0.0.2");
+    const sentinelPluginId = "release-marketplace-other";
+    const sentinelPath = path.join(home, "marketplace", sentinelPluginId);
+    const installPathFile = path.join(home, "install-path.txt");
+    fs.mkdirSync(sentinelPath, { recursive: true });
+
+    const seeded = runHelper(home, [
+      "seed-marketplace-uninstall-state",
+      pluginId,
+      sentinelPluginId,
+      sentinelPath,
+      installPathFile,
+    ]);
+    expect(seeded.stderr).toBe("");
+    expect(seeded.status).toBe(0);
+
+    const configPath = path.join(home, ".openclaw", "openclaw.json");
+    const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    expect(config.plugins.allow).toEqual([pluginId, sentinelPluginId]);
+    expect(config.plugins.deny).toEqual([pluginId, sentinelPluginId]);
+    expect(config.plugins.load.paths).toEqual([installPath, sentinelPath]);
+
+    delete config.plugins.entries[pluginId];
+    config.plugins.allow = [sentinelPluginId];
+    config.plugins.deny = [sentinelPluginId];
+    config.plugins.load.paths = [sentinelPath];
+    fs.writeFileSync(configPath, `${JSON.stringify(config)}\n`, "utf8");
+    fs.rmSync(installPath, { recursive: true });
+    clearMarketplaceIndex(home);
+
+    const verified = runHelper(home, [
+      "assert-marketplace-uninstalled",
+      pluginId,
+      sentinelPluginId,
+      sentinelPath,
+      installPathFile,
+    ]);
+    expect(verified.stderr).toBe("");
+    expect(verified.status).toBe(0);
   });
 
   it("checks the exact dry-run and update outcome text", () => {

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -481,6 +481,9 @@ describe("scripts/test-projects changed-target routing", () => {
         "test/scripts/release-scenarios-assertions.test.ts",
         "test/scripts/release-user-journey-assertions.test.ts",
       ],
+      "scripts/e2e/lib/release-plugin-marketplace/lifecycle-assertions.mjs": [
+        "test/scripts/release-plugin-marketplace-lifecycle.test.ts",
+      ],
       "scripts/e2e/lib/openai-chat-tools/write-config.mjs": [
         "test/e2e/qa-lab/runtime/openai-compatible-chat-tools.e2e.test.ts",
       ],


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where uninstalling a marketplace, npm, or other managed plugin could delete its managed directory but leave an exact matching `plugins.load.paths` entry behind. The stale config could keep pointing plugin discovery at a path that no longer exists.

## Why This Change Was Made

Uninstall already owns the canonical install record, so load-path cleanup now matches that record's `installPath` for every install source and retains the existing linked-path `sourcePath` cleanup. Matching is exact or realpath-equivalent only; parent directories, child paths, prefixes, and unrelated operator paths are preserved.

The package-installed marketplace scenario now proves the full lifecycle: v1 install state, non-mutating plugin-ID dry run, persisted v2 update, then uninstall cleanup across config, SQLite index/install records, allow/deny policy, the exact load path, managed files, and CLI registration while unrelated sentinels remain.

## User Impact

Operators no longer retain a stale exact load path after uninstalling a managed plugin. Explicit non-exact paths remain untouched.

## Maintainer Decision

Accepted: uninstall owns cleanup of an exact or realpath-equivalent load path recorded as the managed plugin's `installPath`. This is intentional persisted-config behavior; non-exact operator paths remain preserved.

## Evidence

- `node scripts/run-vitest.mjs src/plugins/uninstall.test.ts test/scripts/release-plugin-marketplace-lifecycle.test.ts` (65 uninstall tests and 4 lifecycle-helper tests passed)
- `node scripts/run-node.mjs qa coverage --match clawhub.update-by-plugin-id` (one primary scenario match)
- `node scripts/run-node.mjs qa coverage --match clawhub.uninstall-config-index-policy-file-cleanup` (one primary scenario match)
- `bash -n scripts/e2e/lib/release-plugin-marketplace/scenario.sh`
- `./node_modules/.bin/oxfmt --check` on all touched formatted files
- `git diff --check`
- Blacksmith Testbox baseline Docker lane passed on pre-fix commit `5d30ff9e5a7` (lease `tbx_01kz4mqbxszrpndpm4dym0askf`, run https://github.com/openclaw/openclaw/actions/runs/30849990176)
- Blacksmith Testbox release marketplace Docker E2E passed on runtime head `4af47fffb8527738288d5931556c7ca0f6f326ff` (lease `tbx_01kz4n7g0s48q81pjx74fsspnc`)
- Blacksmith Testbox private QA suite passed on runtime head `4af47fffb8527738288d5931556c7ca0f6f326ff` for `clawhub-marketplace-list`; schema-v2 evidence recorded one passing entry at `.artifacts/qa-e2e/clawhub-marketplace-lifecycle-4af47ff-1785790175/qa-evidence.json`
- Blacksmith Testbox `pnpm check:changed` passed on runtime head `4af47fffb8527738288d5931556c7ca0f6f326ff`, including typecheck, lint, and runtime import-cycle checks
- Final head `2d46f7cb77d` adds only the Knip executable-root declaration and owner-test routing required by the initial ready-for-review CI run
- Final-head `pnpm deadcode:dependencies` and `pnpm deadcode:unused-files` passed with zero entries
- Final-head focused owner routing, lifecycle-helper, and uninstall tests passed
- Final-head Sol autoreview passed with no actionable findings; patch correctness confidence 0.99

Production delta: `src/plugins/uninstall.ts` is +14/-8, net +6 lines.
