### PR TITLE
test(qa): prove ClawHub catalog discovery

### DIFF
--- a/qa/scenarios/plugins/clawhub-catalog-discovery.yaml
+++ b/qa/scenarios/plugins/clawhub-catalog-discovery.yaml
@@ -1,0 +1,31 @@
+title: ClawHub catalog discovery
+
+scenario:
+  id: clawhub-catalog-discovery
+  surface: clawhub
+  category: clawhub.catalog-discovery
+  coverage:
+    primary:
+      - clawhub.plugin-catalog-search
+      - clawhub.plugin-and-skill-search-separation
+      - clawhub.catalog-lookup-failure
+  objective: Verify plugin catalog search uses the real ClawHub HTTP boundary, stays separate from skill search, and reports empty or failed lookups.
+  successCriteria:
+    - Plugin search queries both installable plugin family endpoints and keeps the highest-scoring duplicate package.
+    - Plugin terminal and JSON output preserve an installable package identity, and terminal output includes the matching install command.
+    - Skill search uses its separate endpoint and skill-only results never appear in plugin output.
+    - Empty plugin results are visible without failure.
+    - A controlled ClawHub service failure is visible and exits nonzero.
+  docsRefs:
+    - docs/cli/plugins.md
+    - docs/cli/skills.md
+  codeRefs:
+    - src/cli/plugins-search-command.ts
+    - src/plugins/catalog-search.ts
+    - src/infra/clawhub.ts
+    - scripts/e2e/lib/clawhub-fixture-server.cjs
+    - src/cli/plugins-search-command.clawhub.e2e.test.ts
+  execution:
+    kind: vitest
+    path: src/cli/plugins-search-command.clawhub.e2e.test.ts
+    summary: Run real ClawHub HTTP plugin and skill catalog discovery through the CLI search boundary.

--- a/scripts/e2e/lib/clawhub-fixture-server.cjs
+++ b/scripts/e2e/lib/clawhub-fixture-server.cjs
@@ -359,9 +359,90 @@ export default definePluginEntry({
   },
 };
 
+profiles["catalog-search"] = {
+  ...profiles.plugins,
+  catalogSearch: {
+    packages: {
+      "code-plugin": [
+        {
+          score: 4,
+          package: {
+            name: "@acme/calendar",
+            displayName: "Calendar",
+            family: "code-plugin",
+            channel: "community",
+            isOfficial: false,
+            summary: "Calendar integration",
+            createdAt: 1,
+            updatedAt: 2,
+            latestVersion: "1.2.3",
+          },
+        },
+        {
+          score: 8,
+          package: {
+            name: "@acme/calendar-code",
+            displayName: "Calendar Code Plugin",
+            family: "code-plugin",
+            channel: "community",
+            isOfficial: false,
+            summary: "Code-only calendar integration",
+            createdAt: 1,
+            updatedAt: 2,
+            latestVersion: "2.0.0",
+          },
+        },
+      ],
+      "bundle-plugin": [
+        {
+          score: 12,
+          package: {
+            name: "@acme/calendar",
+            displayName: "Calendar Bundle",
+            family: "bundle-plugin",
+            channel: "official",
+            isOfficial: true,
+            summary: "Official calendar bundle",
+            createdAt: 1,
+            updatedAt: 3,
+            latestVersion: "3.0.0",
+          },
+        },
+        {
+          score: 6,
+          package: {
+            name: "@acme/calendar-bundle",
+            displayName: "Calendar Bundle Plugin",
+            family: "bundle-plugin",
+            channel: "community",
+            isOfficial: false,
+            summary: "Community calendar bundle",
+            createdAt: 1,
+            updatedAt: 2,
+            latestVersion: "1.0.0",
+          },
+        },
+      ],
+    },
+    skills: [
+      {
+        score: 99,
+        slug: "calendar-skill",
+        ownerHandle: "acme",
+        displayName: "Calendar Skill",
+        summary: "Skill-only calendar result",
+        version: "4.0.0",
+        updatedAt: 4,
+      },
+    ],
+  },
+};
+
 const fixture = profiles[profile];
 if (!fixture || !portFile) {
-  console.error("usage: clawhub-fixture-server.cjs <kitchen-sink-plugin|plugins> <port-file>");
+  console.error(
+    "usage: clawhub-fixture-server.cjs <catalog-search|kitchen-sink-plugin|plugins> <port-file>",
+  );
   process.exit(1);
 }
 
@@ -417,12 +498,34 @@ async function main() {
       stale: false,
     },
   };
+  const requestLog = [];
 
   const server = http.createServer((request, response) => {
     const url = new URL(request.url, "http://127.0.0.1");
     if (request.method !== "GET") {
       response.writeHead(405);
       response.end("method not allowed");
+      return;
+    }
+    if (url.pathname === "/__fixture__/requests") {
+      json(response, { requests: requestLog });
+      return;
+    }
+    requestLog.push(`${request.method} ${url.pathname}${url.search}`);
+    if (fixture.catalogSearch && url.pathname === "/api/v1/packages/search") {
+      if (url.searchParams.get("q") === "unavailable") {
+        json(response, { error: "catalog unavailable" }, 503);
+        return;
+      }
+      const family = url.searchParams.get("family");
+      const results =
+        url.searchParams.get("q") === "empty" ? [] : (fixture.catalogSearch.packages[family] ?? []);
+      json(response, { results });
+      return;
+    }
+    if (fixture.catalogSearch && url.pathname === "/api/v1/search") {
+      const results = url.searchParams.get("q") === "empty" ? [] : fixture.catalogSearch.skills;
+      json(response, { results });
       return;
     }
     if (url.pathname === `/api/v1/packages/${encodeURIComponent(packageName)}`) {

--- a/src/cli/plugins-search-command.clawhub.e2e.test.ts
+++ b/src/cli/plugins-search-command.clawhub.e2e.test.ts
@@ -1,0 +1,186 @@
+import { spawn, type ChildProcessByStdio } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { Readable } from "node:stream";
+import { setTimeout as delay } from "node:timers/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import type { RuntimeEnv } from "../runtime.js";
+import { searchSkillsFromClawHub } from "../skills/lifecycle/clawhub.js";
+import { runPluginsSearchCommand } from "./plugins-search-command.js";
+
+const SCRIPT_PATH = "scripts/e2e/lib/clawhub-fixture-server.cjs";
+const servers: Array<ChildProcessByStdio<null, Readable, Readable>> = [];
+const tempDirs: string[] = [];
+const previousClawHubUrl = process.env.OPENCLAW_CLAWHUB_URL;
+const previousClawHubConfigPath = process.env.CLAWHUB_CONFIG_PATH;
+const previousClawHubToken = process.env.CLAWHUB_TOKEN;
+const previousClawHubAuthToken = process.env.CLAWHUB_AUTH_TOKEN;
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map(stopServer));
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  if (previousClawHubUrl === undefined) {
+    delete process.env.OPENCLAW_CLAWHUB_URL;
+  } else {
+    process.env.OPENCLAW_CLAWHUB_URL = previousClawHubUrl;
+  }
+  if (previousClawHubConfigPath === undefined) {
+    delete process.env.CLAWHUB_CONFIG_PATH;
+  } else {
+    process.env.CLAWHUB_CONFIG_PATH = previousClawHubConfigPath;
+  }
+  if (previousClawHubToken === undefined) {
+    delete process.env.CLAWHUB_TOKEN;
+  } else {
+    process.env.CLAWHUB_TOKEN = previousClawHubToken;
+  }
+  if (previousClawHubAuthToken === undefined) {
+    delete process.env.CLAWHUB_AUTH_TOKEN;
+  } else {
+    process.env.CLAWHUB_AUTH_TOKEN = previousClawHubAuthToken;
+  }
+});
+
+async function stopServer(child: ChildProcessByStdio<null, Readable, Readable>) {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+  const exited = new Promise<void>((resolve) => {
+    child.once("exit", () => resolve());
+  });
+  child.kill("SIGTERM");
+  await Promise.race([exited, delay(1_000, undefined, { ref: false })]);
+  if (child.exitCode === null && child.signalCode === null) {
+    child.kill("SIGKILL");
+    await exited;
+  }
+}
+
+async function startFixtureServer() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "clawhub-search-e2e-"));
+  tempDirs.push(root);
+  const portFile = path.join(root, "port");
+  const child = spawn(process.execPath, [SCRIPT_PATH, "catalog-search", portFile], {
+    cwd: process.cwd(),
+    env: { ...process.env },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  servers.push(child);
+  let stderr = "";
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+
+  for (let attempt = 0; attempt < 500; attempt += 1) {
+    if (existsSync(portFile)) {
+      const port = Number(readFileSync(portFile, "utf8"));
+      if (Number.isInteger(port) && port > 0) {
+        return `http://127.0.0.1:${port}`;
+      }
+    }
+    if (child.exitCode !== null) {
+      throw new Error(`fixture server exited early: ${stderr}`);
+    }
+    await delay(5);
+  }
+  throw new Error(`fixture server did not write a port: ${stderr}`);
+}
+
+function createRuntime() {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  let exitCode: number | undefined;
+  const runtime: RuntimeEnv = {
+    log: (...args) => logs.push(args.map(String).join(" ")),
+    error: (...args) => errors.push(args.map(String).join(" ")),
+    exit: (code) => {
+      exitCode = code;
+    },
+  };
+  return {
+    runtime,
+    logs,
+    errors,
+    get exitCode() {
+      return exitCode;
+    },
+  };
+}
+
+async function readRequestLog(baseUrl: string): Promise<string[]> {
+  const response = await fetch(`${baseUrl}/__fixture__/requests`);
+  expect(response.status).toBe(200);
+  const body = (await response.json()) as { requests: string[] };
+  return body.requests;
+}
+
+describe("openclaw plugins search ClawHub E2E", () => {
+  it("keeps plugin discovery separate from skills and surfaces empty and failed lookups", async () => {
+    const baseUrl = await startFixtureServer();
+    process.env.OPENCLAW_CLAWHUB_URL = baseUrl;
+    process.env.CLAWHUB_CONFIG_PATH = path.join(tempDirs[0] ?? os.tmpdir(), "missing-config.json");
+    delete process.env.CLAWHUB_TOKEN;
+    delete process.env.CLAWHUB_AUTH_TOKEN;
+
+    const terminal = createRuntime();
+    await runPluginsSearchCommand("calendar", { limit: 5 }, terminal.runtime);
+    const terminalOutput = terminal.logs.join("\n");
+    expect(terminal.exitCode).toBeUndefined();
+    expect(
+      terminalOutput.split("\n").filter((line) => line.startsWith("@acme/calendar  ")),
+    ).toHaveLength(1);
+    expect(terminalOutput).toContain("bundle-plugin | official | v3.0.0");
+    expect(terminalOutput).toContain("Install: openclaw plugins install clawhub:@acme/calendar");
+    expect(terminalOutput).not.toContain("calendar-skill");
+
+    const json = createRuntime();
+    await runPluginsSearchCommand("calendar", { json: true, limit: 5 }, json.runtime);
+    const jsonOutput = JSON.parse(json.logs.join("\n")) as {
+      results: Array<{ score: number; package: { name: string; family: string } }>;
+    };
+    expect(jsonOutput.results[0]).toMatchObject({
+      score: 12,
+      package: {
+        name: "@acme/calendar",
+        family: "bundle-plugin",
+      },
+    });
+    expect(
+      jsonOutput.results.filter((entry) => entry.package.name === "@acme/calendar"),
+    ).toHaveLength(1);
+
+    const skills = await searchSkillsFromClawHub({
+      query: "calendar",
+      limit: 5,
+      baseUrl,
+    });
+    expect(skills).toEqual([
+      expect.objectContaining({
+        score: 99,
+        slug: "calendar-skill",
+      }),
+    ]);
+
+    const empty = createRuntime();
+    await runPluginsSearchCommand("empty", { limit: 5 }, empty.runtime);
+    expect(empty.exitCode).toBeUndefined();
+    expect(empty.logs).toEqual(["No ClawHub plugins found."]);
+
+    const unavailable = createRuntime();
+    await runPluginsSearchCommand("unavailable", { limit: 5 }, unavailable.runtime);
+    expect(unavailable.exitCode).toBe(1);
+    expect(unavailable.errors.join("\n")).toContain("catalog unavailable");
+
+    const requests = await readRequestLog(baseUrl);
+    expect(requests).toEqual(
+      expect.arrayContaining([
+        "GET /api/v1/packages/search?q=calendar&family=code-plugin&limit=5",
+        "GET /api/v1/packages/search?q=calendar&family=bundle-plugin&limit=5",
+        "GET /api/v1/search?q=calendar&limit=5",
+      ]),
+    );
+  }, 30_000);
+});

--- a/src/cli/plugins-search-command.clawhub.e2e.test.ts
+++ b/src/cli/plugins-search-command.clawhub.e2e.test.ts
@@ -1,18 +1,17 @@
 import { spawn, type ChildProcessByStdio } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
-import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import type { Readable } from "node:stream";
 import { setTimeout as delay } from "node:timers/promises";
 import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { searchSkillsFromClawHub } from "../skills/lifecycle/clawhub.js";
 import { runPluginsSearchCommand } from "./plugins-search-command.js";
 
 const SCRIPT_PATH = "scripts/e2e/lib/clawhub-fixture-server.cjs";
 const servers: Array<ChildProcessByStdio<null, Readable, Readable>> = [];
-const tempDirs: string[] = [];
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const previousClawHubUrl = process.env.OPENCLAW_CLAWHUB_URL;
 const previousClawHubConfigPath = process.env.CLAWHUB_CONFIG_PATH;
 const previousClawHubToken = process.env.CLAWHUB_TOKEN;
@@ -20,7 +19,6 @@ const previousClawHubAuthToken = process.env.CLAWHUB_AUTH_TOKEN;
 
 afterEach(async () => {
   await Promise.all(servers.splice(0).map(stopServer));
-  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
   if (previousClawHubUrl === undefined) {
     delete process.env.OPENCLAW_CLAWHUB_URL;
   } else {
@@ -59,8 +57,7 @@ async function stopServer(child: ChildProcessByStdio<null, Readable, Readable>) 
 }
 
 async function startFixtureServer() {
-  const root = await fs.mkdtemp(path.join(os.tmpdir(), "clawhub-search-e2e-"));
-  tempDirs.push(root);
+  const root = tempDirs.make("clawhub-search-e2e-");
   const portFile = path.join(root, "port");
   const child = spawn(process.execPath, [SCRIPT_PATH, "catalog-search", portFile], {
     cwd: process.cwd(),
@@ -78,7 +75,7 @@ async function startFixtureServer() {
     if (existsSync(portFile)) {
       const port = Number(readFileSync(portFile, "utf8"));
       if (Number.isInteger(port) && port > 0) {
-        return `http://127.0.0.1:${port}`;
+        return { baseUrl: `http://127.0.0.1:${port}`, root };
       }
     }
     if (child.exitCode !== null) {
@@ -119,9 +116,9 @@ async function readRequestLog(baseUrl: string): Promise<string[]> {
 
 describe("openclaw plugins search ClawHub E2E", () => {
   it("keeps plugin discovery separate from skills and surfaces empty and failed lookups", async () => {
-    const baseUrl = await startFixtureServer();
+    const { baseUrl, root } = await startFixtureServer();
     process.env.OPENCLAW_CLAWHUB_URL = baseUrl;
-    process.env.CLAWHUB_CONFIG_PATH = path.join(tempDirs[0] ?? os.tmpdir(), "missing-config.json");
+    process.env.CLAWHUB_CONFIG_PATH = path.join(root, "missing-config.json");
     delete process.env.CLAWHUB_TOKEN;
     delete process.env.CLAWHUB_AUTH_TOKEN;
 

--- a/test/scripts/clawhub-fixture-server.test.ts
+++ b/test/scripts/clawhub-fixture-server.test.ts
@@ -122,7 +122,63 @@ describe("ClawHub fixture server", () => {
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain(
-      "usage: clawhub-fixture-server.cjs <kitchen-sink-plugin|plugins> <port-file>",
+      "usage: clawhub-fixture-server.cjs <catalog-search|kitchen-sink-plugin|plugins> <port-file>",
     );
+  });
+
+  it("serves separate plugin-family and skill search fixtures", async () => {
+    const { baseUrl } = await startFixtureServer("catalog-search");
+
+    const codePlugins = await fetchJson(
+      baseUrl,
+      "/api/v1/packages/search?q=calendar&family=code-plugin&limit=5",
+    );
+    expect(codePlugins.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          score: 4,
+          package: expect.objectContaining({
+            name: "@acme/calendar",
+            family: "code-plugin",
+          }),
+        }),
+      ]),
+    );
+
+    const bundlePlugins = await fetchJson(
+      baseUrl,
+      "/api/v1/packages/search?q=calendar&family=bundle-plugin&limit=5",
+    );
+    expect(bundlePlugins.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          score: 12,
+          package: expect.objectContaining({
+            name: "@acme/calendar",
+            family: "bundle-plugin",
+          }),
+        }),
+      ]),
+    );
+
+    const skills = await fetchJson(baseUrl, "/api/v1/search?q=calendar&limit=5");
+    expect(skills.results).toEqual([
+      expect.objectContaining({
+        score: 99,
+        slug: "calendar-skill",
+      }),
+    ]);
+
+    const empty = await fetchJson(
+      baseUrl,
+      "/api/v1/packages/search?q=empty&family=code-plugin&limit=5",
+    );
+    expect(empty).toEqual({ results: [] });
+
+    const unavailable = await fetch(
+      `${baseUrl}/api/v1/packages/search?q=unavailable&family=code-plugin&limit=5`,
+    );
+    expect(unavailable.status).toBe(503);
+    await expect(unavailable.json()).resolves.toEqual({ error: "catalog unavailable" });
   });
 });


### PR DESCRIPTION
## What Problem This Solves

ClawHub plugin catalog discovery had no primary QA proof through the real HTTP and CLI command boundary. Existing tests mocked the catalog client, so regressions could silently mix plugin and skill results, lose duplicate-score selection, or hide empty and failed lookups.

## Why This Change Was Made

Adds a deterministic ClawHub catalog-search fixture profile and an end-to-end command test. The test exercises both installable plugin families, best-score duplicate merging, the separate skill endpoint, empty results, JSON and terminal identity, install guidance, and a controlled HTTP 503.

The scenario claims:

- `clawhub.plugin-catalog-search`
- `clawhub.plugin-and-skill-search-separation`
- `clawhub.catalog-lookup-failure`

Production code is unchanged. Production LOC delta: `+0/-0`.

## User Impact

No runtime behavior changes. Release QA can now detect catalog discovery regressions at the operator-visible command boundary.

## Evidence

Reviewed branch head: `98979d2ab07f5964362e2db0291316fc8b91797a`.

- Focused proof on the reviewed head:
  - fixture server: 3/3 passed
  - real command E2E: 1/1 passed
- Blacksmith Testbox `tbx_01kz52v075r30yzbrezsdfncxx`:
  - Actions run: https://github.com/openclaw/openclaw/actions/runs/30865770241
  - exact tree `9451f03ee43340291485eb58b9268cd4ec7d72f5` matched the reviewed branch
  - private QA runtime build passed
  - canonical `qa suite --scenario clawhub-catalog-discovery` passed
  - schema-v2 `qa-evidence.json` recorded status `pass` and exactly the three claimed primary IDs
  - path-scoped changed gate passed full typecheck, lint, dead-code, import-cycle, and repository guard lanes
- Targeted `oxfmt --check`: passed
- `git diff --check`: passed
- Sol/high autoreview: clean, with no accepted or actionable findings
- ClawSweeper reviewed the exact head with no findings; its focused-test rank-up move is satisfied

- Exact-head hosted CI run https://github.com/openclaw/openclaw/actions/runs/30866763426 passed at `98979d2ab07f5964362e2db0291316fc8b91797a`
  - final PR checks: 79 passed, 42 intentionally skipped, 0 failed or pending
  - two unrelated flaky shards passed on failed-job-only retry; `openclaw/ci-gate` finished green
