### PR TITLE
fix(deps): remediate fast-uri and undici advisories

### DIFF
--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -15,7 +15,7 @@
     "get-east-asian-width": "1.6.0",
     "p-map": "7.0.6",
     "typebox": "1.3.6",
-    "undici": "7.28.0",
+    "undici": "7.29.0",
     "ws": "8.21.1",
     "zod": "4.4.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ overrides:
   hono: 4.12.32
   '@hono/node-server': 2.0.12
   axios: 1.18.1
-  fast-uri: 4.1.1
+  fast-uri: 4.1.2
   follow-redirects: 1.16.0
   defu: 6.1.7
   fast-xml-parser: 5.10.1
@@ -1776,10 +1776,10 @@ importers:
     dependencies:
       '@slack/bolt':
         specifier: 5.0.0
-        version: 5.0.0(@types/express@5.0.6)(supports-color@10.2.2)(undici@7.28.0)
+        version: 5.0.0(@types/express@5.0.6)(supports-color@10.2.2)(undici@7.29.0)
       '@slack/socket-mode':
         specifier: 3.0.0
-        version: 3.0.0(undici@7.28.0)
+        version: 3.0.0(undici@7.29.0)
       '@slack/types':
         specifier: 3.0.0
         version: 3.0.0
@@ -1796,8 +1796,8 @@ importers:
         specifier: 1.3.6
         version: 1.3.6
       undici:
-        specifier: 7.28.0
-        version: 7.28.0
+        specifier: 7.29.0
+        version: 7.29.0
       ws:
         specifier: 8.21.1
         version: 8.21.1
@@ -6614,8 +6614,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@4.1.1:
-    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
+  fast-uri@4.1.2:
+    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -9031,8 +9031,8 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   undici@8.9.0:
@@ -12120,11 +12120,11 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@slack/bolt@5.0.0(@types/express@5.0.6)(supports-color@10.2.2)(undici@7.28.0)':
+  '@slack/bolt@5.0.0(@types/express@5.0.6)(supports-color@10.2.2)(undici@7.29.0)':
     dependencies:
       '@slack/logger': 5.0.0
       '@slack/oauth': 4.0.0
-      '@slack/socket-mode': 3.0.0(undici@7.28.0)
+      '@slack/socket-mode': 3.0.0(undici@7.29.0)
       '@slack/types': 3.0.0
       '@slack/web-api': 8.0.0
       '@types/express': 5.0.6
@@ -12148,13 +12148,13 @@ snapshots:
       '@types/node': 26.1.1
       jsonwebtoken: 9.0.3
 
-  '@slack/socket-mode@3.0.0(undici@7.28.0)':
+  '@slack/socket-mode@3.0.0(undici@7.29.0)':
     dependencies:
       '@slack/logger': 5.0.0
       '@slack/web-api': 8.0.0
       '@types/node': 26.1.1
       eventemitter3: 5.0.4
-      undici: 7.28.0
+      undici: 7.29.0
 
   '@slack/types@3.0.0': {}
 
@@ -12930,7 +12930,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.1
+      fast-uri: 4.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -13784,7 +13784,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@4.1.1: {}
+  fast-uri@4.1.2: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -14439,7 +14439,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 5.1.2
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -16720,7 +16720,7 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   undici@8.9.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -127,7 +127,7 @@ overrides:
   hono: 4.12.32
   "@hono/node-server": 2.0.12
   axios: 1.18.1
-  fast-uri: 4.1.1
+  fast-uri: 4.1.2
   follow-redirects: 1.16.0
   defu: 6.1.7
   fast-xml-parser: 5.10.1


### PR DESCRIPTION
## What Problem This Solves

Resolves production dependency advisories in `fast-uri@4.1.1` and the Slack-owned `undici@7.28.0` graph. These advisories block security validation for affected work, including https://github.com/openclaw/openclaw/pull/118856.

## Why This Change Was Made

Pins the workspace `fast-uri` override to `4.1.2`, updates Slack's owned Undici dependency to `7.29.0`, and regenerates only the corresponding `pnpm-lock.yaml` entries. The root `undici@8.9.0` pin and `.github/release/clawhub-cli/package-lock.json` are intentionally unchanged.

## User Impact

Source installs and CI no longer resolve the affected package versions. No OpenClaw API or product behavior changes are intended.

## Evidence

- Frozen base: `bac7d6bd5d8f88d6b7cd1f41461f49b5b273208d`
- Signed head: `32b0381d0e2a8cde2bb3ed1396f0c0cce7043262`
- `pnpm install --frozen-lockfile`
- Lock scan: no `fast-uri@4.1.1` or `undici@7.28.0`; `pnpm why` resolves `fast-uri@4.1.2` and Slack-owned `undici@7.29.0`
- Runtime smoke: malformed URI authorities rejected, valid URIs preserved; Slack resolves Undici 7.29.0 `fetch` and `EnvHttpProxyAgent`
- `pnpm test:extension slack` - 129 files, 2,160 tests passed
- `pnpm deps:npm-lock:check:changed` - 95 affected package locks passed
- `node scripts/pre-commit/pnpm-audit-prod.mjs --audit-level=high` - no high-or-higher production advisories
- `node scripts/dependency-vulnerability-gate.mjs` - 1,616 versions checked, 0 advisories
- `pnpm deps:pins:check`
- `pnpm format:check --no-error-on-unmatched-pattern -- extensions/slack/package.json pnpm-lock.yaml pnpm-workspace.yaml`
- `git diff HEAD^ --check`
- Repository autoreview: clean, confidence 0.99; TruffleHog clean

AI-assisted: yes. The exact diff and upstream package source were inspected before validation.
