### PR TITLE
docs(mxc): isolate test setup and cleanup

### DIFF
--- a/extensions/mxc/README.md
+++ b/extensions/mxc/README.md
@@ -86,11 +86,10 @@ help stay in sync with plugin runtime validation.
 - OpenClaw passes per-run command, environment, and filesystem config to the
   plugin's Node launcher through a short-lived local payload file, and deletes
   that file and its temp directory when the launcher or run finishes.
-- `@microsoft/mxc-sdk@0.7.0` passes the full base64 request envelope to native
-  `wxc-exec` as the `--config-base64` process argument. A host user with
-  process-inspection rights can observe the command, environment, and policy
-  data while the process is running. Do not put secrets in MXC command arguments
-  or environment values
+- `@microsoft/mxc-sdk@0.7.0` then carries the full base64 request envelope on
+  the native `wxc-exec` process argv. A host user with process-inspection rights
+  can observe that command, environment, and policy data while the process is
+  running. Do not put secrets in MXC command arguments or environment values
   until the SDK provides a non-argv transport
   ([microsoft/mxc#626](https://github.com/microsoft/mxc/issues/626)).
 
@@ -104,37 +103,34 @@ help stay in sync with plugin runtime validation.
 
 ## Test setup
 
-Create a dedicated `mxc-test` agent so MXC testing does not change the default
-agent. `openclaw agents add` preserves existing agents. Then use
+Use an already configured OpenClaw installation with MXC installed and enabled
+on a supported Windows host. These commands create a uniquely named test agent
+and a new temporary workspace, leaving existing agents and workspaces alone.
 [`openclaw config patch --stdin`](https://docs.openclaw.ai/cli/config#config-patch)
-to add the MXC sandbox settings and plugin configuration with one validated
-config write.
+applies sandbox settings only to that agent. Installation-wide MXC settings
+and policy files remain unchanged; review them before testing because they
+apply to the test agent too.
+
+Run setup, testing, and cleanup in the same PowerShell session. Finish cleanup
+before running setup again. Stop if any command fails.
 
 ```powershell
-$mxcPolicyPath = Join-Path $env:TEMP "openclaw-mxc-policy.json"
-@'
-{
-  "filesystem": {
-    "restrictToProjectDir": true,
-    "additionalReadonlyPaths": [],
-    "additionalReadwritePaths": []
-  },
-  "process": {
-    "timeoutSeconds": 120
-  }
-}
-'@ | Set-Content -Path $mxcPolicyPath -Encoding utf8
+$mxcAgentCreated = $false
+$mxcAgent = "mxc-test-" + [guid]::NewGuid().ToString("N")
+$mxcWorkspace = Join-Path ([System.IO.Path]::GetTempPath()) $mxcAgent
+New-Item -ItemType Directory -Path $mxcWorkspace -ErrorAction Stop | Out-Null
 
-openclaw agents add mxc-test `
-  --workspace ~/.openclaw/workspace-mxc-test `
+openclaw agents add $mxcAgent `
+  --workspace $mxcWorkspace `
   --non-interactive
+if ($LASTEXITCODE -ne 0) { throw "Agent creation failed; stop without patching or deleting an existing agent." }
+$mxcAgentCreated = $true
 
-$mxcPolicyPathLiteral = ConvertTo-Json $mxcPolicyPath -Compress
 $mxcConfigPatch = @"
 {
   agents: {
     entries: {
-      "mxc-test": {
+      "$mxcAgent": {
         sandbox: {
           mode: "all",
           backend: "mxc",
@@ -144,23 +140,13 @@ $mxcConfigPatch = @"
       },
     },
   },
-  plugins: {
-    entries: {
-      mxc: {
-        enabled: true,
-        config: {
-          containment: "process",
-          network: "none",
-          mxcPolicyPaths: [$mxcPolicyPathLiteral],
-        },
-      },
-    },
-  },
 }
 "@
 
 $mxcConfigPatch | openclaw config patch --stdin --dry-run
+if ($LASTEXITCODE -ne 0) { throw "Sandbox validation failed; use Cleanup to remove the new test agent." }
 $mxcConfigPatch | openclaw config patch --stdin
+if ($LASTEXITCODE -ne 0) { throw "Sandbox setup failed; use Cleanup to remove the new test agent." }
 ```
 
 ## Sandbox policy files
@@ -242,37 +228,32 @@ ProcessContainer cannot safely enforce the nested read-only grant.
 Run the TUI as that agent:
 
 ```powershell
-openclaw tui --session agent:mxc-test:main
+openclaw tui --session "agent:${mxcAgent}:main"
 ```
 
 For local embedded testing without a Gateway:
 
 ```powershell
-openclaw tui --local --session agent:mxc-test:main
+openclaw tui --local --session "agent:${mxcAgent}:main"
 ```
 
 ## Cleanup
 
-If you used the exact sample above, remove the test agent and MXC plugin
-configuration:
+In the same PowerShell session, remove only the agent created by setup:
 
 ```powershell
-openclaw agents delete mxc-test --force
-
-$mxcCleanupPatch = @'
-{
-  plugins: {
-    entries: {
-      mxc: null,
-    },
-  },
+if (-not $mxcAgentCreated) {
+  throw "No successfully created test agent in this session; do not delete an existing agent."
 }
-'@
-
-$mxcCleanupPatch | openclaw config patch --stdin --dry-run
-$mxcCleanupPatch | openclaw config patch --stdin
-Remove-Item -Path $mxcPolicyPath -ErrorAction SilentlyContinue
+openclaw agents delete $mxcAgent --force
+if ($LASTEXITCODE -ne 0) { throw "Agent cleanup failed; inspect the error before retrying." }
+$mxcAgentCreated = $false
 ```
+
+The delete command removes the test agent's configuration and attempts to move
+its workspace and state to Trash. Check its output for any manual-cleanup
+warning. Do not remove the MXC plugin entry or shared policy files: other
+agents may still use them.
 
 ## Host readiness
 

--- a/extensions/mxc/README.md
+++ b/extensions/mxc/README.md
@@ -46,14 +46,14 @@ readiness behavior to change as MXC host support matures.
 and out-of-range values fail plugin activation with an actionable error
 (`Invalid mxc plugin config: <reason>`) instead of falling back silently.
 
-| Field            | Type                              | Default                        | Notes                                                                                                                                                         |
-| ---------------- | --------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `mxcBinaryPath`  | `string`                          | unset                          | Non-empty override for the `wxc-exec.exe` executor path; see [SDK-only executor discovery](#supported).                                                       |
-| `containment`    | `"process" \| "processcontainer"` | `"process"`                    | Both currently resolve to Windows ProcessContainer.                                                                                                           |
-| `network`        | `"none" \| "default"`             | `"none"`                       | `"default"` allows outbound network via the `internetClient` capability.                                                                                      |
-| `timeoutSeconds` | `number`                          | `120`                          | Must be `>= 1` and `<= 2147000` (the largest Node-safe `setTimeout` delay in whole seconds). Capped to the sandbox policy baseline timeout when both are set. |
-| `debug`          | `boolean`                         | `false`                        | Forwards debug output from the MXC SDK launcher.                                                                                                              |
-| `mxcPolicyPaths` | `string[]`                        | unset (built-in baseline only) | Every entry must be a non-empty absolute path. See [Sandbox policy files](#sandbox-policy-files).                                                             |
+| Field            | Type                              | Default                                | Notes                                                                                                                                                         |
+| ---------------- | --------------------------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mxcBinaryPath`  | `string`                          | unset                                  | Non-empty override for the `wxc-exec.exe` executor path; see [SDK-only executor discovery](#supported).                                                       |
+| `containment`    | `"process" \| "processcontainer"` | `"process"`                            | Both currently resolve to Windows ProcessContainer.                                                                                                           |
+| `network`        | `"none" \| "default"`             | `"none"`                               | `"default"` allows outbound network via the `internetClient` capability.                                                                                      |
+| `timeoutSeconds` | `number`                          | unset (baseline default `300` applies) | Must be `>= 1` and `<= 2147000` (the largest Node-safe `setTimeout` delay in whole seconds). Capped to the sandbox policy baseline timeout when both are set. |
+| `debug`          | `boolean`                         | `false`                                | Forwards debug output from the MXC SDK launcher.                                                                                                              |
+| `mxcPolicyPaths` | `string[]`                        | unset (built-in baseline only)         | Every entry must be a non-empty absolute path. See [Sandbox policy files](#sandbox-policy-files).                                                             |
 
 Any other key is rejected. `openclaw.plugin.json` publishes the same schema
 (enums, `minimum`/`maximum` bounds) so `openclaw config` validation and CLI

--- a/extensions/mxc/README.md
+++ b/extensions/mxc/README.md
@@ -254,19 +254,13 @@ openclaw tui --local --session agent:mxc-test:main
 ## Cleanup
 
 If you used the exact sample above, remove the test agent and MXC plugin
-configuration by patching the config back to the default-only shape:
+configuration:
 
 ```powershell
+openclaw agents delete mxc-test --force
+
 $mxcCleanupPatch = @'
 {
-  agents: {
-    list: [
-      {
-        id: "main",
-        workspace: "~/.openclaw/workspace",
-      },
-    ],
-  },
   plugins: {
     entries: {
       mxc: null,

--- a/extensions/mxc/README.md
+++ b/extensions/mxc/README.md
@@ -46,14 +46,14 @@ readiness behavior to change as MXC host support matures.
 and out-of-range values fail plugin activation with an actionable error
 (`Invalid mxc plugin config: <reason>`) instead of falling back silently.
 
-| Field            | Type                              | Default                                | Notes                                                                                                                                                         |
-| ---------------- | --------------------------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `mxcBinaryPath`  | `string`                          | unset                                  | Non-empty override for the `wxc-exec.exe` executor path; see [SDK-only executor discovery](#supported).                                                       |
-| `containment`    | `"process" \| "processcontainer"` | `"process"`                            | Both currently resolve to Windows ProcessContainer.                                                                                                           |
-| `network`        | `"none" \| "default"`             | `"none"`                               | `"default"` allows outbound network via the `internetClient` capability.                                                                                      |
-| `timeoutSeconds` | `number`                          | unset (baseline default `300` applies) | Must be `>= 1` and `<= 2147000` (the largest Node-safe `setTimeout` delay in whole seconds). Capped to the sandbox policy baseline timeout when both are set. |
-| `debug`          | `boolean`                         | `false`                                | Forwards debug output from the MXC SDK launcher.                                                                                                              |
-| `mxcPolicyPaths` | `string[]`                        | unset (built-in baseline only)         | Every entry must be a non-empty absolute path. See [Sandbox policy files](#sandbox-policy-files).                                                             |
+| Field            | Type                              | Default                        | Notes                                                                                                                                                         |
+| ---------------- | --------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mxcBinaryPath`  | `string`                          | unset                          | Non-empty override for the `wxc-exec.exe` executor path; see [SDK-only executor discovery](#supported).                                                       |
+| `containment`    | `"process" \| "processcontainer"` | `"process"`                    | Both currently resolve to Windows ProcessContainer.                                                                                                           |
+| `network`        | `"none" \| "default"`             | `"none"`                       | `"default"` allows outbound network via the `internetClient` capability.                                                                                      |
+| `timeoutSeconds` | `number`                          | `120`                          | Must be `>= 1` and `<= 2147000` (the largest Node-safe `setTimeout` delay in whole seconds). Capped to the sandbox policy baseline timeout when both are set. |
+| `debug`          | `boolean`                         | `false`                        | Forwards debug output from the MXC SDK launcher.                                                                                                              |
+| `mxcPolicyPaths` | `string[]`                        | unset (built-in baseline only) | Every entry must be a non-empty absolute path. See [Sandbox policy files](#sandbox-policy-files).                                                             |
 
 Any other key is rejected. `openclaw.plugin.json` publishes the same schema
 (enums, `minimum`/`maximum` bounds) so `openclaw config` validation and CLI

--- a/extensions/mxc/README.md
+++ b/extensions/mxc/README.md
@@ -86,10 +86,11 @@ help stay in sync with plugin runtime validation.
 - OpenClaw passes per-run command, environment, and filesystem config to the
   plugin's Node launcher through a short-lived local payload file, and deletes
   that file and its temp directory when the launcher or run finishes.
-- `@microsoft/mxc-sdk@0.7.0` then carries the full base64 request envelope on
-  the native `wxc-exec` process argv. A host user with process-inspection rights
-  can observe that command, environment, and policy data while the process is
-  running. Do not put secrets in MXC command arguments or environment values
+- `@microsoft/mxc-sdk@0.7.0` passes the full base64 request envelope to native
+  `wxc-exec` as the `--config-base64` process argument. A host user with
+  process-inspection rights can observe the command, environment, and policy
+  data while the process is running. Do not put secrets in MXC command arguments
+  or environment values
   until the SDK provides a non-argv transport
   ([microsoft/mxc#626](https://github.com/microsoft/mxc/issues/626)).
 
@@ -101,16 +102,13 @@ help stay in sync with plugin runtime validation.
 - Windows filesystem-deny and host-list network policy knobs are not exposed by
   this plugin until MXC can enforce them on ProcessContainer.
 
-## Test setup with `openclaw config`
+## Test setup
 
-This patch creates a default `main` agent, then adds a dedicated `mxc-test`
-agent so MXC testing does not change the default agent. It uses
+Create a dedicated `mxc-test` agent so MXC testing does not change the default
+agent. `openclaw agents add` preserves existing agents. Then use
 [`openclaw config patch --stdin`](https://docs.openclaw.ai/cli/config#config-patch)
-so setup is one validated config write instead of several path-based
-`config set` commands.
-
-If you already have `agents.list` entries, copy them into the patch before
-`mxc-test` instead of replacing the list.
+to add the MXC sandbox settings and plugin configuration with one validated
+config write.
 
 ```powershell
 $mxcPolicyPath = Join-Path $env:TEMP "openclaw-mxc-policy.json"
@@ -127,18 +125,16 @@ $mxcPolicyPath = Join-Path $env:TEMP "openclaw-mxc-policy.json"
 }
 '@ | Set-Content -Path $mxcPolicyPath -Encoding utf8
 
+openclaw agents add mxc-test `
+  --workspace ~/.openclaw/workspace-mxc-test `
+  --non-interactive
+
 $mxcPolicyPathLiteral = ConvertTo-Json $mxcPolicyPath -Compress
 $mxcConfigPatch = @"
 {
   agents: {
-    list: [
-      {
-        id: "main",
-        workspace: "~/.openclaw/workspace",
-      },
-      {
-        id: "mxc-test",
-        workspace: "~/.openclaw/workspace-mxc-test",
+    entries: {
+      "mxc-test": {
         sandbox: {
           mode: "all",
           backend: "mxc",
@@ -146,7 +142,7 @@ $mxcConfigPatch = @"
           workspaceAccess: "none",
         },
       },
-    ],
+    },
   },
   plugins: {
     entries: {
@@ -165,43 +161,6 @@ $mxcConfigPatch = @"
 
 $mxcConfigPatch | openclaw config patch --stdin --dry-run
 $mxcConfigPatch | openclaw config patch --stdin
-```
-
-Resulting config shape:
-
-```jsonc
-{
-  "agents": {
-    "list": [
-      {
-        "id": "main",
-        "workspace": "~/.openclaw/workspace",
-      },
-      {
-        "id": "mxc-test",
-        "workspace": "~/.openclaw/workspace-mxc-test",
-        "sandbox": {
-          "mode": "all",
-          "backend": "mxc",
-          "scope": "agent",
-          "workspaceAccess": "none",
-        },
-      },
-    ],
-  },
-  "plugins": {
-    "entries": {
-      "mxc": {
-        "enabled": true,
-        "config": {
-          "containment": "process",
-          "network": "none",
-          "mxcPolicyPaths": ["C:\\Users\\you\\AppData\\Local\\Temp\\openclaw-mxc-policy.json"],
-        },
-      },
-    },
-  },
-}
 ```
 
 ## Sandbox policy files
@@ -342,7 +301,7 @@ wxc-host-prep prepare-system-drive
 pnpm test:extension mxc
 ```
 
-`pnpm test extensions/mxc` is equivalent and also works.
+`pnpm test extensions/mxc` is also supported for the bundled extension test lane.
 
 For policy-only edits, the focused coverage is in:
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators following the MXC test guide could modify an existing test agent or shared plugin settings instead of isolating their test. The proposed fixed-name `agents add` could fail and PowerShell would continue into the patch; cleanup could then delete that existing agent. Both the old guide and the initial PR also overwrite installation-wide policy and remove the whole MXC plugin entry during cleanup.

Current-main qualification: on `9bd50c803cce88f2ab387ddaf6cc29b4ef004005`, the old `agents.list` patch is accepted but leaves an existing canonical `agents.entries` roster unchanged, including the requested sandbox settings. The original claim of current-main roster destruction is not supported by this reproduction. The guide is still broken, and the failed-create/shared-policy hazards remain real.

## Why This Change Was Made

Keep Paul Campbell's dedicated-agent approach, but give the example a generated agent ID and reserve a fresh workspace before creating it. Check each native exit immediately, patch only that agent's sandbox settings, and permit cleanup only after successful creation in the same PowerShell session. Use the canonical agent-delete command; do not remove shared plugin configuration or policy files.

The example requires an existing configured installation with MXC already installed and enabled. It deliberately inherits the installation's existing policy. This avoids a second test-specific plugin configuration or profile that would lose the operator's existing setup. Cleanup documents partial filesystem failures instead of promising that a successful configuration deletion removed every directory.

The effective unset timeout remains the existing 300-second baseline. The SDK transport note is unchanged from main. The test-command wording no longer claims two different runners are equivalent.

## User Impact

Operators can set up and remove a temporary MXC test agent without altering other agents, reusing an existing workspace, or changing policy for other MXC users. No runtime code, schema, config option, timeout, or sandbox permission changes.

Release-note context: MXC test setup now uses a uniquely owned agent and workspace, stops on failed commands, and preserves existing agents and shared plugin policy. Thanks @paulcam206.

## Evidence

Reviewed README SHA-256: `82dceb0b965f0790c5ac85a7c77deda8885f7db031720d84a24549f2de63e970` (head `7a5cc00480262a2c5ece2951d685d298556c0712`).

Real before/after observations:

```text
BEFORE: Agent "mxc-test" already exists.
UNGUARDED_NATIVE_FAILURE=continued
PREEXISTING_AGENT=modified_despite_failed_add

AFTER: Dry run successful: 4 update(s) validated.
Applied 4 config update(s).
Moved to Trash: <fixture>/tmp/<new-test-agent>
Deleted agent: <new-test-agent>
CASE=after SETUP_EXPECTATION=pass CLEANUP_EXPECTATION=pass SESSION_INTERPOLATION=pass
CASE=duplicate SETUP_EXPECTATION=pass CLEANUP_EXPECTATION=pass SESSION_INTERPOLATION=pass
CASE=workspace SETUP_EXPECTATION=pass CLEANUP_EXPECTATION=pass SESSION_INTERPOLATION=pass
CASE=dry-failure SETUP_EXPECTATION=pass CLEANUP_EXPECTATION=pass SESSION_INTERPOLATION=pass
CASE=apply-failure SETUP_EXPECTATION=pass CLEANUP_EXPECTATION=pass SESSION_INTERPOLATION=pass
EXISTING_AGENTS=preserved BINDINGS=preserved TEMP_AGENT=removed_or_not_created
EXISTING_WORKSPACES=preserved SHARED_MXC_CONFIG=preserved
```

All five revised-flow cases completed successfully, including invalid dry-run and failed application after a successful dry-run. Both failure paths left the new agent unconfigured and permitted scoped cleanup while preserving existing state. Exact-head [CI run 33078686540](https://github.com/openclaw/openclaw/actions/runs/33078686540) completed successfully, including `check-docs` and `openclaw/ci-gate`.

Independent source review and isolated Codex autoreview found no actionable findings. `git diff --check` and standalone `oxfmt --check extensions/mxc/README.md` passed. The dependency-less PR worktree's formatting hook refused to run; the commit used the separately verified trusted formatter result. CI and native landing gates remain required. No dependency install or contributor executable was used for the behavior proof.

Proof scope: real PowerShell 7.6.3 and the built trusted-main CLI on macOS, with isolated configuration/state, an unused loopback port, multiple existing agents, a routing binding, workspace sentinels, and nondefault MXC configuration. The final README blocks are extracted and executed directly for the success case. Failure cases change only the collision input or inject an invalid sandbox mode before validation/application; native CLI commands are not mocked.

This proves shell control flow and configuration/cleanup ownership, not Windows ProcessContainer execution. MXC is disabled in the proof fixture because the host is macOS; no inference, provider calls, real Gateway, or operator state is used. The no-Gateway fixture prints a cron-cleanup warning (it contains no scheduled jobs); this is not presented as verified cron cleanup. Windows backend execution is outside this documentation-only repair. One earlier multi-command harness run timed out under heavy host load and is excluded from passing evidence; completed multi-command runs use a proportionate harness allowance without changing any product timeout.

Source map: CLI registration and agent add/delete commands; `src/agents/agent-create.ts` duplicate ownership; `src/agents/agent-scope-config.ts` roster precedence; `src/commands/agents.config.ts` scoped pruning; workspace creation and deletion safety; config patch operations and writer roster guards; MXC plugin registration, backend factory, timeout resolution, and policy ownership. The generic legacy roster-patch acceptance behavior is a named follow-up, not a runtime change in this PR.

Production LOC: +0/-0. Tests: +0/-0. Documentation: +37/-103. No synthetic README-string test was added: the executable PowerShell scenarios exercise the operator-visible contract directly.

Both latest ClawSweeper rank-up moves are addressed by fail-fast handling and the before/after preservation proof. The added SDK-argument wording was dropped, so the dependency-specific addition is no longer part of the patch.
