### PR TITLE
fix: abort in-flight gateway runs on shutdown (Ctrl+C / SIGINT)

### DIFF
--- a/src/acp/translator.lifecycle.test.ts
+++ b/src/acp/translator.lifecycle.test.ts
@@ -525,3 +525,43 @@ describe("acp translator stable lifecycle handlers", () => {
     sessionStore.clearAllSessionsForTest();
   });
 });
+
+describe("shutdown aborts in-flight runs", () => {
+  it("sends chat.abort for all pending prompts when shutdown() is called (SIGINT path)", async () => {
+    const sentRunIds: string[] = [];
+    const request = vi.fn(async (_method: string, params: Record<string, unknown>) => {
+      if (_method === "chat.send") {
+        const runId = params.idempotencyKey as string;
+        sentRunIds.push(runId);
+        // never resolve — simulates an in-flight run
+        await new Promise<void>(() => {});
+      }
+      return { ok: true };
+    }) as GatewayClient["request"];
+
+    const sessionStore = createInMemorySessionStore();
+    sessionStore.createSession({
+      sessionId: "session-sigint",
+      sessionKey: "agent:main:work",
+      cwd: "/tmp/openclaw",
+    });
+    const agent = new AcpGatewayAgent(createAcpConnection(), createAcpGateway(request), {
+      sessionStore,
+    });
+
+    const pending = await startPendingPrompt({ agent, sentRunIds, sessionId: "session-sigint" });
+
+    // Simulate Ctrl+C / SIGINT triggering shutdown
+    agent.shutdown();
+
+    // The translator must have fired chat.abort for the in-flight run
+    await vi.waitFor(() => {
+      expect(request).toHaveBeenCalledWith(
+        "chat.abort",
+        expect.objectContaining({ runId: pending.runId }),
+      );
+    });
+
+    sessionStore.clearAllSessionsForTest();
+  });
+});

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -301,6 +301,17 @@ export class AcpGatewayAgent implements Agent {
   }
 
   shutdown(): void {
+    // Abort any in-flight gateway runs so the daemon does not continue
+    // processing after the CLI process disconnects (e.g. Ctrl+C).
+    if (this.pendingPrompts.size > 0) {
+      const toCancel = Array.from(this.pendingPrompts.values());
+      for (const pending of toCancel) {
+        const session = this.sessionStore.getSession(pending.sessionId);
+        if (session) {
+          void this.cancelSessionWork(session).catch(() => {});
+        }
+      }
+    }
     this.sessionUpdates.stop();
     this.activeDisconnectContext = null;
     this.clearDisconnectTimer();


### PR DESCRIPTION
## Summary

When the CLI receives SIGINT (Ctrl+C / stop button), `shutdown()` was called on `AcpGatewayAgent` but it never fired `chat.abort` to the gateway. The active run kept processing in the background, and the response would arrive in the next session causing confusing duplicate or stale output.

## Root cause

`AcpGatewayAgent.shutdown()` in `src/acp/translator.ts` only stopped session updates and cleared the disconnect timer — it never iterated `pendingPrompts` to cancel them.

The `cancelSessionWork()` private method already does the right thing (fires `chat.abort` + resolves the pending promise with `stopReason=cancelled`), but it was never called from `shutdown()`.

## Changes

- **`src/acp/translator.ts`**: iterate `pendingPrompts` on `shutdown()` and call `cancelSessionWork()` for each, firing `chat.abort` to the gateway before teardown.
- **`src/acp/translator.lifecycle.test.ts`**: adds a test verifying that `shutdown()` sends `chat.abort` for any in-flight run.

## Testing

New unit test: `shutdown aborts in-flight runs › sends chat.abort for all pending prompts when shutdown() is called (SIGINT path)`

Fixes #118929