### PR TITLE
chore(qa): cover plugin tools activation

### DIFF
--- a/qa/scenarios/plugins/mcp-plugin-tools-call.yaml
+++ b/qa/scenarios/plugins/mcp-plugin-tools-call.yaml
@@ -5,6 +5,7 @@ scenario:
   surface: mcp
   coverage:
     primary:
+      - plugins.activation-plugin-tools
       - plugins.tool-plugin-mcp-tools
       - plugins.tool-plugin-invocation
   objective: Verify OpenClaw can expose plugin tools over MCP and a real MCP client can call one successfully.


### PR DESCRIPTION
## What Problem This Solves

The QA taxonomy had no primary owner for plugin-tools runtime activation even though the existing script evidence exercises it over real MCP stdio.

## Why This Change Was Made

Registers `plugins.activation-plugin-tools` on the existing `mcp-plugin-tools-call` scenario. No producer, source, or test behavior changes.

## User Impact

No runtime behavior change. QA scorecards now recognize the existing real plugin activation proof.

## Evidence

- focused producer test: 4/4 passed
- private QA build and exact scenario: passed on [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/30850764046)
- `qa-evidence.json`: `mcp-plugin-tools-call` passed at `c6d1d063188371f2dc5d0845119f8d45106f5eb9` with `plugins.activation-plugin-tools` as primary coverage
- changed gate on the same Testbox: passed
- `git diff --check`, targeted `oxfmt`, and Sol/high autoreview: clean
- production LOC: 0; test LOC: 0; metadata: +1

AI-assisted: yes.
