### PR TITLE
fix: Custodian wizard loses pending control after reload

### DIFF
--- a/ui/src/e2e/custodian-event-nudge.e2e.test.ts
+++ b/ui/src/e2e/custodian-event-nudge.e2e.test.ts
@@ -1,9 +1,9 @@
 // Control UI tests cover event-reactive custodian presence against a mocked Gateway.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
+import { GATEWAY_SERVER_CAPS } from "@openclaw/gateway-protocol";
 import type { Page } from "playwright";
 import { expect, it } from "vitest";
-import { GATEWAY_SERVER_CAPS } from "../../../packages/gateway-protocol/src/index.js";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -586,6 +586,115 @@ suite.define(() => {
         expect(await page.locator(".agent-chat__composer-shell").count()).toBe(1);
       },
     );
+  });
+
+  it("restores a sensitive wizard blank and cancels it directly", async () => {
+    if (captureUiProofEnabled) {
+      await mkdir(uiProofArtifactDir, { recursive: true });
+    }
+    const context = await suite.newBrowserContext({
+      colorScheme: "dark",
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      featureCapabilities: [
+        GATEWAY_SERVER_CAPS.SYSTEM_AGENT_WIZARD_CANCEL,
+        GATEWAY_SERVER_CAPS.SYSTEM_AGENT_CHAT_HISTORY_SESSION_RECOVERY,
+      ],
+      featureMethods: ["chat.metadata", "chat.startup", "openclaw.chat", "openclaw.chat.history"],
+      methodResponses: {
+        "openclaw.chat.history": { turns: [] },
+        "openclaw.chat": {
+          sessionId: "e2e-reload-wizard",
+          reply: "Enter the secret.",
+          action: "none",
+          sensitive: true,
+          wizardInputPending: true,
+          step: {
+            id: "secret",
+            type: "text",
+            message: "Twitch client secret",
+            sensitive: true,
+          },
+        },
+      },
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}custodian?onboarding=1`);
+      const secretInput = page.getByRole("textbox", { name: "Twitch client secret" });
+      await secretInput.waitFor();
+      await secretInput.fill("not-persisted");
+      expect(await page.getByRole("button", { name: "Cancel", exact: true }).count()).toBe(1);
+      expect(await page.getByRole("button", { name: "Exit setup", exact: true }).count()).toBe(1);
+
+      if (captureUiProofEnabled) {
+        await page.screenshot({
+          animations: "disabled",
+          path: path.join(uiProofArtifactDir, "03-sensitive-wizard-before-reload-desktop.png"),
+        });
+      }
+
+      await gateway.setMethodResponse("openclaw.chat.history", {
+        turns: [
+          { role: "user", text: "connect twitch", at: 1 },
+          { role: "assistant", text: "Enter the secret.", at: 2 },
+        ],
+        activeWizard: {
+          sessionId: "e2e-reload-wizard",
+          step: {
+            id: "secret",
+            type: "text",
+            message: "Twitch client secret",
+            sensitive: true,
+          },
+        },
+      });
+      await page.reload();
+
+      const recoveredInput = page.getByRole("textbox", { name: "Twitch client secret" });
+      await recoveredInput.waitFor();
+      expect(await recoveredInput.inputValue()).toBe("");
+      expect(await recoveredInput.getAttribute("type")).toBe("password");
+      expect(await gateway.getRequests("openclaw.chat")).toHaveLength(1);
+      expect(await page.getByRole("button", { name: "Cancel", exact: true }).count()).toBe(1);
+      expect(await page.getByRole("button", { name: "Exit setup", exact: true }).count()).toBe(1);
+
+      if (captureUiProofEnabled) {
+        await page.screenshot({
+          animations: "disabled",
+          path: path.join(uiProofArtifactDir, "04-sensitive-wizard-recovered-desktop.png"),
+        });
+        await page.setViewportSize({ height: 812, width: 375 });
+        await page.screenshot({
+          animations: "disabled",
+          path: path.join(uiProofArtifactDir, "05-sensitive-wizard-recovered-mobile.png"),
+        });
+        await page.setViewportSize({ height: 900, width: 1280 });
+      }
+
+      await gateway.setMethodResponse("openclaw.chat", {
+        sessionId: "e2e-reload-wizard",
+        reply: "Twitch setup cancelled.",
+        action: "none",
+      });
+      await page.getByRole("button", { name: "Cancel", exact: true }).click();
+      await page.getByText("Twitch setup cancelled.").waitFor();
+
+      const requests = await gateway.getRequests("openclaw.chat");
+      expect(requests).toHaveLength(2);
+      expect(requests[1]?.params).toMatchObject({
+        sessionId: "e2e-reload-wizard",
+        wizardCancel: { stepId: "secret" },
+      });
+      expect(requests[1]?.params).not.toHaveProperty("message");
+      expect(await page.locator(".custodian__wizard-step").count()).toBe(0);
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
   });
 
   it("stays silent during onboarding", async () => {

--- a/ui/src/pages/custodian/custodian-page-agent-create.test.ts
+++ b/ui/src/pages/custodian/custodian-page-agent-create.test.ts
@@ -20,7 +20,11 @@ type TestCustodianPage = HTMLElement & {
 };
 
 function createContext(request: ReturnType<typeof vi.fn>) {
-  const client = { request } as unknown as GatewayBrowserClient;
+  const client = {
+    request,
+    recoveryScope: "",
+    recoveryScopeReady: true,
+  } as unknown as GatewayBrowserClient;
   const snapshot: ApplicationGatewaySnapshot = {
     client,
     phase: "connected",

--- a/ui/src/pages/custodian/custodian-page.reload-recovery.test.ts
+++ b/ui/src/pages/custodian/custodian-page.reload-recovery.test.ts
@@ -1,0 +1,481 @@
+/* @vitest-environment jsdom */
+
+import { GATEWAY_SERVER_CAPS } from "@openclaw/gateway-protocol";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
+import { createContext, mountPage } from "./custodian-page.test-harness.ts";
+import {
+  readCustodianRecoveryForClient,
+  reconcileCustodianRecoveryForScope,
+} from "./custodian-recovery.ts";
+
+const gatewayUrl = "ws://gateway.test/control";
+const recoveryScope = "principal-a";
+const recoveryOwner = { gatewayUrl, recoveryScope };
+const recoveryClient = { recoveryScope, recoveryScopeReady: true } as never;
+const recoveryCapabilities = [
+  GATEWAY_SERVER_CAPS.SYSTEM_AGENT_WIZARD_CANCEL,
+  GATEWAY_SERVER_CAPS.SYSTEM_AGENT_CHAT_HISTORY_SESSION_RECOVERY,
+];
+
+describe("Custodian wizard reload recovery", () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+    sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("restores the sanitized active step and continues the same live session", async () => {
+    let cancelled = false;
+    let freshChatCount = 0;
+    const request = vi.fn(async (method: string, params: Record<string, unknown>) => {
+      if (method === "openclaw.chat.history") {
+        if (params.sessionId === "live-wizard" && !cancelled) {
+          return {
+            turns: [
+              { role: "user", text: "connect twitch", at: 1 },
+              { role: "assistant", text: "Enter the secret.", at: 2 },
+            ],
+            activeWizard: {
+              sessionId: "live-wizard",
+              step: {
+                id: "secret",
+                type: "text",
+                message: "Twitch client secret",
+                sensitive: true,
+              },
+            },
+          };
+        }
+        return { turns: [] };
+      }
+      if (method !== "openclaw.chat") {
+        throw new Error(`unexpected method ${method}`);
+      }
+      if (params.wizardCancel) {
+        cancelled = true;
+        return {
+          sessionId: "live-wizard",
+          reply: "Twitch setup cancelled.",
+          action: "none",
+        };
+      }
+      freshChatCount += 1;
+      return freshChatCount === 1
+        ? {
+            sessionId: "live-wizard",
+            reply: "Enter the secret.",
+            action: "none",
+            sensitive: true,
+            wizardInputPending: true,
+            step: {
+              id: "secret",
+              type: "text",
+              message: "Twitch client secret",
+              sensitive: true,
+            },
+          }
+        : { sessionId: "fresh-session", reply: "Fresh session ready.", action: "none" };
+    });
+    const { context } = createContext(request, ["openclaw.chat", "openclaw.chat.history"], {
+      gatewayCapabilities: recoveryCapabilities,
+      recoveryScope,
+    });
+    const first = await mountPage(context);
+    await waitForFast(() =>
+      expect(first.page.querySelector(".custodian__wizard-step")).not.toBeNull(),
+    );
+    expect(readCustodianRecoveryForClient(recoveryClient, gatewayUrl)).toBe("live-wizard");
+
+    first.provider.remove();
+    const second = await mountPage(context);
+    const recoveredInput = await waitForFast(() => {
+      const input = second.page.querySelector<HTMLInputElement>(
+        '.custodian__wizard-step input[type="password"]',
+      );
+      expect(input).not.toBeNull();
+      return input!;
+    });
+    expect(recoveredInput.value).toBe("");
+    expect(second.page.textContent).toContain("Enter the secret.");
+    expect(request.mock.calls.filter(([method]) => method === "openclaw.chat")).toHaveLength(1);
+
+    second.page.querySelector<HTMLButtonElement>(".custodian__wizard-cancel")!.click();
+    await waitForFast(() => expect(second.page.textContent).toContain("Twitch setup cancelled."));
+    expect(request.mock.calls.at(-1)?.[1]).toMatchObject({
+      sessionId: "live-wizard",
+      wizardCancel: { stepId: "secret" },
+    });
+    expect(readCustodianRecoveryForClient(recoveryClient, gatewayUrl)).toBeNull();
+
+    second.provider.remove();
+    const third = await mountPage(context);
+    await waitForFast(() => expect(third.page.textContent).toContain("Fresh session ready."));
+    expect(third.page.querySelector(".custodian__wizard-step")).toBeNull();
+  });
+
+  it("waits for the authenticated recovery scope before starting a fresh session", async () => {
+    reconcileCustodianRecoveryForScope(
+      recoveryOwner,
+      {
+        sessionId: "delayed-scope-wizard",
+        reply: "Enter the secret.",
+        action: "none",
+        wizardInputPending: true,
+        step: {
+          id: "secret",
+          type: "text",
+          message: "Twitch client secret",
+          sensitive: true,
+        },
+      },
+      "delayed-scope-wizard",
+    );
+    const request = vi.fn(async (method: string, params: Record<string, unknown>) => {
+      if (method === "openclaw.chat.history") {
+        expect(params.sessionId).toBe("delayed-scope-wizard");
+        return {
+          turns: [{ role: "assistant", text: "Enter the secret.", at: 1 }],
+          activeWizard: {
+            sessionId: "delayed-scope-wizard",
+            step: {
+              id: "secret",
+              type: "text",
+              message: "Twitch client secret",
+              sensitive: true,
+            },
+          },
+        };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+    const harness = createContext(request, ["openclaw.chat", "openclaw.chat.history"], {
+      gatewayCapabilities: recoveryCapabilities,
+      recoveryScope,
+      recoveryScopeReady: false,
+    });
+    const mounted = await mountPage(harness.context);
+    await Promise.resolve();
+    expect(request).not.toHaveBeenCalled();
+    expect(mounted.page.store.chatAvailable).toBe(false);
+
+    harness.setRecoveryScopeReady(true);
+    const recoveredInput = await waitForFast(() => {
+      const input = mounted.page.querySelector<HTMLInputElement>(
+        '.custodian__wizard-step input[type="password"]',
+      );
+      expect(input).not.toBeNull();
+      return input!;
+    });
+    expect(recoveredInput.value).toBe("");
+    expect(request.mock.calls.map(([method]) => method)).toEqual(["openclaw.chat.history"]);
+  });
+
+  it("keeps a live recovery handle when its history lookup is temporarily unavailable", async () => {
+    reconcileCustodianRecoveryForScope(
+      recoveryOwner,
+      {
+        sessionId: "retryable-wizard",
+        reply: "Enter the secret.",
+        action: "none",
+        wizardInputPending: true,
+        step: {
+          id: "secret",
+          type: "text",
+          message: "Twitch client secret",
+          sensitive: true,
+        },
+      },
+      "retryable-wizard",
+    );
+    const request = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("temporary history failure"))
+      .mockResolvedValueOnce({
+        turns: [{ role: "assistant", text: "Enter the secret.", at: 1 }],
+        activeWizard: {
+          sessionId: "retryable-wizard",
+          step: {
+            id: "secret",
+            type: "text",
+            message: "Twitch client secret",
+            sensitive: true,
+          },
+        },
+      });
+    const { context } = createContext(request, ["openclaw.chat", "openclaw.chat.history"], {
+      gatewayCapabilities: recoveryCapabilities,
+      recoveryScope,
+    });
+    const { page } = await mountPage(context);
+
+    const retry = await waitForFast(() => {
+      const button = page.querySelector<HTMLButtonElement>('[role="alert"] button');
+      expect(button).not.toBeNull();
+      return button!;
+    });
+    expect(request.mock.calls.map(([method]) => method)).toEqual(["openclaw.chat.history"]);
+    expect(readCustodianRecoveryForClient(recoveryClient, gatewayUrl)).toBe("retryable-wizard");
+
+    retry.click();
+    await waitForFast(() =>
+      expect(page.querySelector('.custodian__wizard-step input[type="password"]')).not.toBeNull(),
+    );
+    expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "openclaw.chat.history",
+      "openclaw.chat.history",
+    ]);
+  });
+
+  it("recovers a pending wizard after a same-scope client replacement", async () => {
+    const request = vi.fn(async (method: string) =>
+      method === "openclaw.chat.history"
+        ? { turns: [] }
+        : {
+            sessionId: "replacement-source-wizard",
+            reply: "Enter the secret.",
+            action: "none",
+            wizardInputPending: true,
+            step: {
+              id: "secret",
+              type: "text",
+              message: "Twitch client secret",
+              sensitive: true,
+            },
+          },
+    );
+    const replacementRequest = vi.fn(async (method: string, params: Record<string, unknown>) => {
+      expect(method).toBe("openclaw.chat.history");
+      expect(params.sessionId).toBe("replacement-source-wizard");
+      return {
+        turns: [{ role: "assistant", text: "Enter the secret.", at: 1 }],
+        activeWizard: {
+          sessionId: "replacement-source-wizard",
+          step: {
+            id: "secret",
+            type: "text",
+            message: "Twitch client secret",
+            sensitive: true,
+          },
+        },
+      };
+    });
+    const replacementClient = {
+      request: replacementRequest,
+      recoveryScope,
+      recoveryScopeReady: false,
+    };
+    const harness = createContext(request, ["openclaw.chat", "openclaw.chat.history"], {
+      gatewayCapabilities: recoveryCapabilities,
+      recoveryScope,
+    });
+    const { page } = await mountPage(harness.context);
+    await waitForFast(() => expect(request).toHaveBeenCalled());
+    await waitForFast(() =>
+      expect(readCustodianRecoveryForClient(recoveryClient, gatewayUrl)).toBe(
+        "replacement-source-wizard",
+      ),
+    );
+
+    harness.setGatewaySnapshot({ client: replacementClient as unknown as GatewayBrowserClient });
+    await Promise.resolve();
+    expect(replacementRequest).not.toHaveBeenCalled();
+
+    replacementClient.recoveryScopeReady = true;
+    harness.setGatewaySnapshot({ client: replacementClient as unknown as GatewayBrowserClient });
+    await waitForFast(() => expect(page.querySelector(".custodian__wizard-step")).not.toBeNull());
+    expect(page.textContent).toContain("Enter the secret.");
+    expect(replacementRequest.mock.calls.map(([method]) => method)).toEqual([
+      "openclaw.chat.history",
+    ]);
+    expect(readCustodianRecoveryForClient(recoveryClient, gatewayUrl)).toBe(
+      "replacement-source-wizard",
+    );
+  });
+
+  it("clears the writing scope when the same client changes recovery identity", async () => {
+    let chatCount = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "openclaw.chat.history") {
+        return { turns: [] };
+      }
+      chatCount += 1;
+      return chatCount === 1
+        ? {
+            sessionId: "original-scope-wizard",
+            reply: "Enter the secret.",
+            action: "none",
+            wizardInputPending: true,
+            step: {
+              id: "secret",
+              type: "text",
+              message: "Twitch client secret",
+              sensitive: true,
+            },
+          }
+        : {
+            sessionId: "rotated-scope-session",
+            reply: "Rotated scope ready.",
+            action: "none",
+          };
+    });
+    const harness = createContext(request, ["openclaw.chat", "openclaw.chat.history"], {
+      gatewayCapabilities: recoveryCapabilities,
+      recoveryScope,
+    });
+    const { page } = await mountPage(harness.context);
+    await waitForFast(() =>
+      expect(readCustodianRecoveryForClient(recoveryClient, gatewayUrl)).toBe(
+        "original-scope-wizard",
+      ),
+    );
+
+    harness.setRecoveryScopeReady(false);
+    harness.setRecoveryScope("principal-b");
+    harness.setRecoveryScopeReady(true);
+
+    await waitForFast(() => expect(page.textContent).toContain("Rotated scope ready."));
+    expect(page.textContent).not.toContain("Enter the secret.");
+    expect(page.querySelector(".custodian__wizard-step")).toBeNull();
+    expect(readCustodianRecoveryForClient(recoveryClient, gatewayUrl)).toBeNull();
+    expect(
+      readCustodianRecoveryForClient(
+        { recoveryScope: "principal-b", recoveryScopeReady: true } as never,
+        gatewayUrl,
+      ),
+    ).toBeNull();
+  });
+
+  it("keeps the live session when credentials rotate within the same recovery scope", async () => {
+    const request = vi.fn(async (method: string) =>
+      method === "openclaw.chat.history"
+        ? { turns: [] }
+        : {
+            sessionId: "same-owner-wizard",
+            reply: "Enter the secret.",
+            action: "none",
+            wizardInputPending: true,
+            step: {
+              id: "secret",
+              type: "text",
+              message: "Twitch client secret",
+              sensitive: true,
+            },
+          },
+    );
+    const harness = createContext(request, ["openclaw.chat", "openclaw.chat.history"], {
+      gatewayCapabilities: recoveryCapabilities,
+      recoveryScope,
+    });
+    const { page } = await mountPage(harness.context);
+    await waitForFast(() =>
+      expect(readCustodianRecoveryForClient(recoveryClient, gatewayUrl)).toBe("same-owner-wizard"),
+    );
+
+    harness.setRecoveryScopeReady(false);
+    harness.setGatewayToken("rotated-token");
+    const hello = harness.context.gateway.snapshot.hello!;
+    harness.setGatewaySnapshot({
+      hello: {
+        ...hello,
+        auth: { ...hello.auth!, deviceToken: "rotated-device-token" },
+      },
+    });
+    harness.setRecoveryScopeReady(true);
+
+    await waitForFast(() => expect(page.querySelector(".custodian__wizard-step")).not.toBeNull());
+    expect(page.textContent).toContain("Enter the secret.");
+    expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "openclaw.chat.history",
+      "openclaw.chat",
+    ]);
+    expect(readCustodianRecoveryForClient(recoveryClient, gatewayUrl)).toBe("same-owner-wizard");
+  });
+
+  it("clears the old gateway recovery key when the connection URL changes", async () => {
+    const request = vi.fn(async (method: string) =>
+      method === "openclaw.chat.history"
+        ? { turns: [] }
+        : {
+            sessionId: "old-gateway-wizard",
+            reply: "Enter the secret.",
+            action: "none",
+            wizardInputPending: true,
+            step: {
+              id: "secret",
+              type: "text",
+              message: "Twitch client secret",
+              sensitive: true,
+            },
+          },
+    );
+    const replacementRequest = vi.fn(async (method: string) =>
+      method === "openclaw.chat.history"
+        ? { turns: [] }
+        : { sessionId: "new-gateway-session", reply: "New gateway ready.", action: "none" },
+    );
+    const harness = createContext(request, ["openclaw.chat", "openclaw.chat.history"], {
+      gatewayCapabilities: recoveryCapabilities,
+      recoveryScope,
+    });
+    await mountPage(harness.context);
+    await waitForFast(() =>
+      expect(readCustodianRecoveryForClient(recoveryClient, gatewayUrl)).toBe("old-gateway-wizard"),
+    );
+
+    harness.setGatewayUrl("ws://other-gateway.test/control");
+    harness.setGatewaySnapshot({
+      client: {
+        request: replacementRequest,
+        recoveryScope,
+        recoveryScopeReady: true,
+      } as unknown as GatewayBrowserClient,
+    });
+    await waitForFast(() => expect(replacementRequest).toHaveBeenCalledTimes(2));
+
+    expect(readCustodianRecoveryForClient(recoveryClient, gatewayUrl)).toBeNull();
+  });
+
+  it("starts fresh without sending sessionId to a legacy history method", async () => {
+    reconcileCustodianRecoveryForScope(
+      recoveryOwner,
+      {
+        sessionId: "legacy-wizard",
+        reply: "Enter the secret.",
+        action: "none",
+        wizardInputPending: true,
+        step: {
+          id: "secret",
+          type: "text",
+          message: "Twitch client secret",
+          sensitive: true,
+        },
+      },
+      "legacy-wizard",
+    );
+    const request = vi.fn(async (method: string, params: Record<string, unknown>) => {
+      if (method === "openclaw.chat.history") {
+        expect(params).not.toHaveProperty("sessionId");
+        return { turns: [] };
+      }
+      if (method === "openclaw.chat") {
+        return { sessionId: "legacy-fresh", reply: "Fresh session ready.", action: "none" };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+    const { context } = createContext(request, ["openclaw.chat", "openclaw.chat.history"], {
+      gatewayCapabilities: [],
+      recoveryScope,
+    });
+    const { page } = await mountPage(context);
+
+    await waitForFast(() => expect(page.textContent).toContain("Fresh session ready."));
+    expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "openclaw.chat.history",
+      "openclaw.chat",
+    ]);
+    expect(request.mock.calls[1]?.[1].sessionId).not.toBe("legacy-wizard");
+    expect(readCustodianRecoveryForClient(recoveryClient, gatewayUrl)).toBeNull();
+  });
+});

--- a/ui/src/pages/custodian/custodian-page.test-harness.ts
+++ b/ui/src/pages/custodian/custodian-page.test-harness.ts
@@ -27,6 +27,9 @@ type TestCustodianPage = HTMLElement & {
 type ContextHarness = {
   context: ApplicationContext;
   setGatewaySnapshot: (patch: Partial<ApplicationGatewaySnapshot>) => void;
+  setRecoveryScope: (scope: string) => void;
+  setRecoveryScopeReady: (ready: boolean) => void;
+  setGatewayUrl: (gatewayUrl: string) => void;
   setGatewayToken: (token: string) => void;
   setChannelsConnected: (connected: boolean) => void;
   setChannelsSnapshot: (snapshot: ChannelsStatusSnapshot | null) => void;
@@ -40,9 +43,16 @@ export function createContext(
     agentsList?: ApplicationContext["agents"]["state"]["agentsList"];
     channelsSnapshot?: ChannelsStatusSnapshot | null;
     gatewayCapabilities?: string[];
+    recoveryScope?: string;
+    recoveryScopeReady?: boolean;
   } = {},
 ): ContextHarness {
-  const client = { request } as unknown as GatewayBrowserClient;
+  const clientState = {
+    request,
+    recoveryScope: options.recoveryScope ?? "",
+    recoveryScopeReady: options.recoveryScopeReady ?? true,
+  };
+  const client = clientState as unknown as GatewayBrowserClient;
   let snapshot: ApplicationGatewaySnapshot = {
     client,
     phase: "connected",
@@ -141,10 +151,30 @@ export function createContext(
   return {
     context,
     setGatewaySnapshot: (patch) => {
+      if (patch.client && patch.client.recoveryScopeReady === undefined) {
+        Object.assign(patch.client, { recoveryScope: "", recoveryScopeReady: true });
+      }
       snapshot = { ...snapshot, ...patch };
       for (const listener of listeners) {
         listener(snapshot);
       }
+    },
+    setRecoveryScopeReady: (ready) => {
+      clientState.recoveryScopeReady = ready;
+      snapshot = { ...snapshot };
+      for (const listener of listeners) {
+        listener(snapshot);
+      }
+    },
+    setRecoveryScope: (scope) => {
+      clientState.recoveryScope = scope;
+      snapshot = { ...snapshot };
+      for (const listener of listeners) {
+        listener(snapshot);
+      }
+    },
+    setGatewayUrl: (gatewayUrl) => {
+      connection.gatewayUrl = gatewayUrl;
     },
     setGatewayToken: (value) => {
       const credentials = { token: value };

--- a/ui/src/pages/custodian/custodian-page.test.ts
+++ b/ui/src/pages/custodian/custodian-page.test.ts
@@ -399,7 +399,7 @@ describe("custodian page", () => {
     ]);
   });
 
-  it("keeps rows for a same-ownership client replacement and requests a fresh welcome", async () => {
+  it("recovers rows for a same-ownership client replacement before a fresh welcome", async () => {
     let chatCalls = 0;
     const request = vi.fn(async (method: string, _params?: unknown) => {
       if (method === "openclaw.chat.history") {
@@ -423,15 +423,16 @@ describe("custodian page", () => {
     await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
 
     setGatewaySnapshot({ client: { request } as unknown as GatewayBrowserClient });
-    await waitForFast(() => expect(request).toHaveBeenCalledTimes(3));
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(4));
     await waitForFast(() => expect(page.textContent).toContain("Fresh session welcome"));
 
     expect(request.mock.calls.map(([method]) => method)).toEqual([
       "openclaw.chat.history",
       "openclaw.chat",
+      "openclaw.chat.history",
       "openclaw.chat",
     ]);
-    expect(request.mock.calls[2]?.[1]).toMatchObject({
+    expect(request.mock.calls[3]?.[1]).toMatchObject({
       sessionId: expect.stringMatching(/^control-ui-onboarding-/),
     });
     expect(page.textContent).toContain("Earlier state");

--- a/ui/src/pages/custodian/custodian-recovery.test.ts
+++ b/ui/src/pages/custodian/custodian-recovery.test.ts
@@ -1,0 +1,107 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  clearCustodianRecoveryForScope,
+  readCustodianRecoveryForClient,
+  reconcileCustodianRecoveryForScope,
+} from "./custodian-recovery.ts";
+
+const gatewayUrl = "ws://127.0.0.1:18789";
+const recoveryScope = "principal-a";
+const recoveryOwner = { gatewayUrl, recoveryScope };
+const client = { recoveryScope, recoveryScopeReady: true } as never;
+
+function remember(sessionId: string): void {
+  reconcileCustodianRecoveryForScope(
+    recoveryOwner,
+    {
+      sessionId,
+      reply: "Enter a secret",
+      action: "none",
+      wizardInputPending: true,
+      step: { id: "secret", type: "text", message: "Secret", sensitive: true },
+    },
+    sessionId,
+  );
+}
+
+describe("Custodian wizard reload recovery", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    sessionStorage.clear();
+  });
+
+  it("stores only the active session handle in tab-scoped storage", () => {
+    remember("custodian-live");
+    expect(readCustodianRecoveryForClient(client, gatewayUrl)).toBe("custodian-live");
+    expect([...Array(sessionStorage.length)].map((_, index) => sessionStorage.key(index))).toEqual([
+      `openclaw.custodian.recovery.v1:${gatewayUrl.length}:${gatewayUrl}:${recoveryScope.length}:${recoveryScope}`,
+    ]);
+    expect(sessionStorage.getItem(sessionStorage.key(0)!)).toBe("custodian-live");
+  });
+
+  it("rejects malformed state and clears only the expected session", () => {
+    sessionStorage.setItem(
+      `openclaw.custodian.recovery.v1:${gatewayUrl.length}:${gatewayUrl}:${recoveryScope.length}:${recoveryScope}`,
+      "   ",
+    );
+    expect(readCustodianRecoveryForClient(client, gatewayUrl)).toBeNull();
+    expect(sessionStorage.length).toBe(0);
+
+    remember("custodian-live");
+    clearCustodianRecoveryForScope(recoveryOwner, "different-session");
+    expect(readCustodianRecoveryForClient(client, gatewayUrl)).not.toBeNull();
+    clearCustodianRecoveryForScope(recoveryOwner, "custodian-live");
+    expect(readCustodianRecoveryForClient(client, gatewayUrl)).toBeNull();
+  });
+
+  it("keeps colliding unframed gateway and scope tuples independent", () => {
+    const first = { gatewayUrl: "ws://gateway.test:18789", recoveryScope: "principal-a" };
+    const second = { gatewayUrl: "ws://gateway.test", recoveryScope: "18789:principal-a" };
+    const result = {
+      reply: "Enter a secret",
+      action: "none" as const,
+      wizardInputPending: true,
+      step: { id: "secret", type: "text" as const, message: "Secret", sensitive: true },
+    };
+
+    reconcileCustodianRecoveryForScope(first, { ...result, sessionId: "first" }, "first");
+    reconcileCustodianRecoveryForScope(second, { ...result, sessionId: "second" }, "second");
+
+    expect(
+      readCustodianRecoveryForClient(
+        { recoveryScope: first.recoveryScope, recoveryScopeReady: true } as never,
+        first.gatewayUrl,
+      ),
+    ).toBe("first");
+    expect(
+      readCustodianRecoveryForClient(
+        { recoveryScope: second.recoveryScope, recoveryScopeReady: true } as never,
+        second.gatewayUrl,
+      ),
+    ).toBe("second");
+
+    clearCustodianRecoveryForScope(first, "first");
+    expect(
+      readCustodianRecoveryForClient(
+        { recoveryScope: second.recoveryScope, recoveryScopeReady: true } as never,
+        second.gatewayUrl,
+      ),
+    ).toBe("second");
+  });
+
+  it("degrades cleanly when session storage access is denied", () => {
+    const getItem = vi.fn(() => {
+      throw new Error("storage denied");
+    });
+    const removeItem = vi.fn(() => {
+      throw new Error("storage denied");
+    });
+    vi.stubGlobal("sessionStorage", { getItem, removeItem });
+
+    expect(() => readCustodianRecoveryForClient(client, gatewayUrl)).not.toThrow();
+    expect(getItem).toHaveBeenCalledOnce();
+  });
+});

--- a/ui/src/pages/custodian/custodian-recovery.ts
+++ b/ui/src/pages/custodian/custodian-recovery.ts
@@ -1,0 +1,97 @@
+import type { SystemAgentChatResult } from "@openclaw/gateway-protocol";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+
+const STORAGE_PREFIX = "openclaw.custodian.recovery.v1:";
+
+export type CustodianRecoveryScope = {
+  gatewayUrl: string;
+  recoveryScope: string;
+};
+
+// Web Storage keys are JS strings, so frame UTF-16 code units directly.
+// This keeps variable gateway and identity components unambiguous.
+function frameStorageKeyPart(value: string): string {
+  return `${value.length}:${value}`;
+}
+
+function storageKey(scope: CustodianRecoveryScope): string {
+  return `${STORAGE_PREFIX}${frameStorageKeyPart(scope.gatewayUrl)}:${frameStorageKeyPart(scope.recoveryScope)}`;
+}
+
+export function captureCustodianRecoveryScope(
+  client: GatewayBrowserClient,
+  gatewayUrl: string,
+): CustodianRecoveryScope | null {
+  const normalizedGatewayUrl = gatewayUrl.trim();
+  const recoveryScope = client.recoveryScopeReady ? (client.recoveryScope?.trim() ?? "") : "";
+  return normalizedGatewayUrl && recoveryScope
+    ? { gatewayUrl: normalizedGatewayUrl, recoveryScope }
+    : null;
+}
+
+export function readCustodianRecoveryForClient(
+  client: GatewayBrowserClient,
+  gatewayUrl: string,
+): string | null {
+  const scope = captureCustodianRecoveryScope(client, gatewayUrl);
+  return scope ? readCustodianRecovery(scope) : null;
+}
+
+export function reconcileCustodianRecoveryForScope(
+  scope: CustodianRecoveryScope,
+  result: SystemAgentChatResult,
+  requestSessionId: string,
+): void {
+  if (result.wizardInputPending === true && result.step) {
+    writeCustodianRecovery(scope, result.sessionId);
+    return;
+  }
+  clearCustodianRecoveryForScope(scope, requestSessionId);
+}
+
+function readCustodianRecovery(scope: CustodianRecoveryScope): string | null {
+  const key = storageKey(scope);
+  try {
+    const sessionId = globalThis.sessionStorage?.getItem(key);
+    if (sessionId === null || sessionId === undefined) {
+      return null;
+    }
+    if (!sessionId.trim()) {
+      globalThis.sessionStorage?.removeItem(key);
+      return null;
+    }
+    return sessionId;
+  } catch {
+    // Storage access can be denied entirely, including cleanup attempts.
+    return null;
+  }
+}
+
+function writeCustodianRecovery(scope: CustodianRecoveryScope, sessionId: string): void {
+  if (!sessionId.trim()) {
+    return;
+  }
+  try {
+    globalThis.sessionStorage?.setItem(storageKey(scope), sessionId);
+  } catch {
+    // Recovery state is best-effort when browser storage is unavailable.
+  }
+}
+
+export function clearCustodianRecoveryForScope(
+  scope: CustodianRecoveryScope,
+  expectedSessionId?: string,
+): void {
+  try {
+    const storage = globalThis.sessionStorage;
+    const key = storageKey(scope);
+    if (expectedSessionId) {
+      if (storage?.getItem(key) !== expectedSessionId) {
+        return;
+      }
+    }
+    storage?.removeItem(key);
+  } catch {
+    // Recovery state is best-effort to remove after a wizard leaves its active step.
+  }
+}

--- a/ui/src/pages/custodian/custodian-session-store.ts
+++ b/ui/src/pages/custodian/custodian-session-store.ts
@@ -5,7 +5,6 @@ import {
   type SystemAgentChatResult,
 } from "@openclaw/gateway-protocol";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import type { WizardStep } from "../../api/types.ts";
 import { selectApplicationSession } from "../../app/agent-selection.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { t } from "../../i18n/index.ts";
@@ -16,6 +15,11 @@ import {
 } from "../../lib/gateway-methods.ts";
 import { buildAgentMainSessionKey, normalizeAgentId } from "../../lib/sessions/session-key.ts";
 import { pathForCustodianAgentHandoff } from "./custodian-navigation.ts";
+import { readCustodianRecoveryForClient } from "./custodian-recovery.ts";
+import {
+  CustodianTranscriptState,
+  type CustodianTranscriptHistoryOutcome,
+} from "./custodian-transcript-state.ts";
 import { custodianWizardSubmission, initialCustodianWizardValue } from "./custodian-wizard-step.ts";
 import * as eventNudgeState from "./event-nudge.ts";
 import {
@@ -23,13 +27,11 @@ import {
   isCustodianSessionInvalidatedError,
   type CustodianSessionVariant,
 } from "./session-lifecycle.ts";
-import { parseCustodianQuestion, type CustodianStructuredQuestion } from "./structured-question.ts";
+import { parseCustodianQuestion } from "./structured-question.ts";
 import {
   createCustodianSessionId,
-  createCustodianTranscriptMessages,
   custodianErrorMessage,
   hasUnresolvedCustodianQuestion,
-  readCustodianTranscript,
   retireCustodianQuestions,
   type CustodianMessage,
 } from "./transcript.ts";
@@ -50,39 +52,27 @@ type ConfiguredInferenceState = "unresolved" | "required" | "ready";
 type CustodianSetupIssue = "missing" | "unavailable";
 
 /** One process-local conversation owner shared by the full page and dock surface. */
-export class CustodianSessionStore {
-  messages: CustodianMessage[] = [];
+export class CustodianSessionStore extends CustodianTranscriptState {
   input = "";
   sending = false;
-  sensitive = false;
-  wizardInputPending = false;
-  wizardValue: unknown;
-  wizardSecretVisible = false;
-  questionReplyUncertain = false;
   error: string | null = null;
   setupIssue: CustodianSetupIssue | null = null;
   dismissedQuestions = new Set<string>();
   answeredQuestions = new Set<string>();
-  activeClient: GatewayBrowserClient | null = null;
   chatAvailable = false;
   eventNudge: eventNudgeState.CustodianEventNudge | null = null;
   eventNudgePending: eventNudgeState.CustodianEventNudge | null = null;
   channelOnboardingNudgeClosed = false;
-  earlierBoundaryAfterId: number | null = null;
   abandonedTurnOutcomeUnknown = false;
 
   private context: ApplicationContext | null = null;
   private variant: CustodianSessionVariant = "caretaker";
   private sessionVariant: CustodianSessionVariant | null = null;
-  private sessionId = createCustodianSessionId();
-  private requestEpoch = 0;
   private requestAbort: AbortController | null = null;
-  private nextMessageId = 1;
   private retryParams: SystemAgentChatParams | null = null;
-  private sessionClient: GatewayBrowserClient | null = null;
   private sessionOwnershipKey: string | null = null;
   private sessionStarted = false;
-  private lastHelloDeviceToken = "";
+  private recoveryScopeReady = false;
   private configuredInferenceState: ConfiguredInferenceState = "unresolved";
   private eventNudgeClosed = false;
   private gatewayCleanup: (() => void) | null = null;
@@ -185,7 +175,10 @@ export class CustodianSessionStore {
     const client = this.activeClient;
     const params = this.retryParams;
     if (client && params && !hasCustodianUserInput(params) && this.chatAvailable && !this.sending) {
-      void this.initializeSession(client, params);
+      const gatewayUrl = this.context?.gateway.connection.gatewayUrl ?? "";
+      const recoveryPending =
+        readCustodianRecoveryForClient(client, gatewayUrl) === params.sessionId;
+      void this.initializeSession(client, params, true, recoveryPending);
     }
   }
 
@@ -380,23 +373,10 @@ export class CustodianSessionStore {
     this.context?.navigate("model-setup");
   }
 
-  private emit(): void {
+  protected emit(): void {
     for (const listener of this.listeners) {
       listener();
     }
-  }
-
-  private currentSessionOwnershipKey(): string {
-    const context = this.context;
-    if (!context) {
-      return "";
-    }
-    const { gatewayUrl, token, password, bootstrapToken } = context.gateway.connection;
-    const auth = context.gateway.snapshot.hello?.auth;
-    if (auth) {
-      this.lastHelloDeviceToken = auth.deviceToken ?? "";
-    }
-    return JSON.stringify([gatewayUrl, token, password, bootstrapToken, this.lastHelloDeviceToken]);
   }
 
   private startSession(
@@ -404,15 +384,18 @@ export class CustodianSessionStore {
     variant: CustodianSessionVariant,
     loadTranscript: boolean,
   ): void {
-    this.sessionId = createCustodianSessionId();
+    const gatewayUrl = this.context?.gateway.connection.gatewayUrl ?? "";
+    const recovery = loadTranscript ? readCustodianRecoveryForClient(client, gatewayUrl) : null;
+    this.sessionId = recovery ?? createCustodianSessionId();
     this.sessionVariant = variant;
-    this.sessionClient = client;
-    this.sessionOwnershipKey = this.currentSessionOwnershipKey();
+    this.bindSessionRecovery(client, gatewayUrl);
+    this.sessionOwnershipKey = this.currentSessionOwnershipKey(this.context);
     this.sessionStarted = true;
     void this.initializeSession(
       client,
       { sessionId: this.sessionId, ...custodianChatParams(variant) },
       loadTranscript,
+      recovery !== null,
     );
   }
 
@@ -429,6 +412,7 @@ export class CustodianSessionStore {
     client: GatewayBrowserClient,
     variant: CustodianSessionVariant,
   ): void {
+    this.clearSessionRecovery();
     this.answeredQuestions = retireCustodianQuestions(this.messages, this.answeredQuestions);
     this.retryParams = null;
     this.input = "";
@@ -448,14 +432,18 @@ export class CustodianSessionStore {
     }
     const snapshot = context.gateway.snapshot;
     const client = snapshot.phase === "connected" ? snapshot.client : null;
+    const recoveryScopeReady = client?.recoveryScopeReady === true;
+    const recoveryScopeReadinessChanged = recoveryScopeReady !== this.recoveryScopeReady;
     const chatSupported =
       client !== null && canCallGatewayMethod(snapshot, "openclaw.chat", "operator.admin");
     const chatUnsupported = isGatewayMethodAdvertised(snapshot, "openclaw.chat") === false;
     const configuredInferenceState = this.resolveConfiguredInferenceState();
+    const shouldEnableChat =
+      chatSupported && configuredInferenceState !== "unresolved" && recoveryScopeReady;
     const inferenceStateChanged = configuredInferenceState !== this.configuredInferenceState;
     this.configuredInferenceState = configuredInferenceState;
     const variantChanged = this.sessionStarted && this.sessionVariant !== this.variant;
-    const ownershipKey = this.currentSessionOwnershipKey();
+    const ownershipKey = this.currentSessionOwnershipKey(this.context);
     const clientReplaced =
       this.sessionStarted &&
       client !== null &&
@@ -468,14 +456,16 @@ export class CustodianSessionStore {
       !variantChanged &&
       !clientReplaced &&
       !ownershipChanged &&
-      this.chatAvailable === (chatSupported && configuredInferenceState !== "unresolved") &&
-      !inferenceStateChanged
+      this.chatAvailable === shouldEnableChat &&
+      !inferenceStateChanged &&
+      !recoveryScopeReadinessChanged
     ) {
       return;
     }
     const requestWasPending = this.sending && this.retryParams !== null;
     const pendingParams = requestWasPending ? this.retryParams : null;
     this.activeClient = client;
+    this.recoveryScopeReady = recoveryScopeReady;
     this.requestEpoch += 1;
     this.sending = false;
     this.chatAvailable = false;
@@ -484,9 +474,14 @@ export class CustodianSessionStore {
       [this.eventNudge, this.eventNudgePending] = [null, null];
       this.eventNudgeClosed = false;
       this.abandonedTurnOutcomeUnknown = false;
+      this.clearSessionRecovery();
       this.sessionStarted = false;
       this.clearConversation();
     } else if (client && clientReplaced) {
+      if (!recoveryScopeReady) {
+        this.abandonPendingUserTurn(pendingParams);
+        return;
+      }
       if (!chatSupported) {
         this.sessionStarted = false;
         this.abandonPendingUserTurn(pendingParams);
@@ -495,7 +490,7 @@ export class CustodianSessionStore {
       }
       this.chatAvailable = true;
       this.abandonPendingUserTurn(pendingParams);
-      this.rotateVolatileSession(client, this.currentSessionVariant());
+      this.startSession(client, this.currentSessionVariant(), true);
       return;
     } else if (requestWasPending) {
       if (pendingParams?.message === undefined) {
@@ -513,8 +508,12 @@ export class CustodianSessionStore {
     if (configuredInferenceState === "unresolved") {
       return;
     }
+    if (!recoveryScopeReady) {
+      return;
+    }
     this.chatAvailable = true;
     if (configuredInferenceState === "required") {
+      this.clearSessionRecovery();
       this.sessionStarted = false;
       this.clearConversation();
       this.setupIssue = "missing";
@@ -562,41 +561,54 @@ export class CustodianSessionStore {
     client: GatewayBrowserClient,
     params: SystemAgentChatParams,
     loadTranscript = true,
+    recoveryPending = false,
   ): Promise<void> {
     const epoch = ++this.requestEpoch;
     this.sending = true;
     this.error = null;
     this.retryParams = params;
     this.emit();
+    let historyOutcome: CustodianTranscriptHistoryOutcome = "inactive";
     if (loadTranscript) {
-      await this.refreshTranscriptHistory(client, epoch);
+      const gatewaySnapshot = this.context?.gateway.snapshot;
+      historyOutcome = await this.refreshTranscriptHistory(
+        client,
+        epoch,
+        gatewaySnapshot !== undefined &&
+          isGatewayMethodAdvertised(gatewaySnapshot, "openclaw.chat.history") === true,
+        recoveryPending &&
+          gatewaySnapshot !== undefined &&
+          isGatewayCapabilityAdvertised(
+            gatewaySnapshot,
+            GATEWAY_SERVER_CAPS.SYSTEM_AGENT_CHAT_HISTORY_SESSION_RECOVERY,
+          ) === true
+          ? params.sessionId
+          : undefined,
+      );
     }
     if (epoch !== this.requestEpoch || client !== this.activeClient) {
       return;
     }
-    await this.requestReply(client, params);
-  }
-
-  private async refreshTranscriptHistory(
-    client: GatewayBrowserClient,
-    epoch: number,
-  ): Promise<void> {
-    const context = this.context;
-    if (
-      !context ||
-      isGatewayMethodAdvertised(context.gateway.snapshot, "openclaw.chat.history") !== true
-    ) {
+    if (historyOutcome === "recovered") {
+      this.sending = false;
+      this.retryParams = null;
+      this.emit();
       return;
     }
-    const turns = await readCustodianTranscript(client);
-    if (turns === null || epoch !== this.requestEpoch || client !== this.activeClient) {
+    if (recoveryPending && historyOutcome === "unavailable") {
+      this.sending = false;
+      this.error = t("custodian.requestFailed");
+      this.emit();
       return;
     }
-    const transcript = createCustodianTranscriptMessages(turns, this.nextMessageId);
-    this.messages = transcript.messages;
-    this.nextMessageId = transcript.nextMessageId;
-    this.earlierBoundaryAfterId = this.messages.at(-1)?.id ?? null;
-    this.emit();
+    let requestParams = params;
+    if (recoveryPending) {
+      this.clearSessionRecovery(params.sessionId);
+      this.sessionId = createCustodianSessionId();
+      requestParams = { ...params, sessionId: this.sessionId };
+      this.retryParams = requestParams;
+    }
+    await this.requestReply(client, requestParams);
   }
 
   private clearConversation(): void {
@@ -611,24 +623,6 @@ export class CustodianSessionStore {
     this.wizardSecretVisible = false;
     this.sensitive = this.wizardInputPending = this.questionReplyUncertain = false;
     this.earlierBoundaryAfterId = null;
-  }
-
-  private appendAssistant(
-    reply: string,
-    question: CustodianStructuredQuestion | null,
-    step: WizardStep | null,
-  ): void {
-    this.messages = [
-      ...this.messages,
-      {
-        id: this.nextMessageId++,
-        role: "assistant",
-        text: reply,
-        at: Date.now(),
-        question,
-        step,
-      },
-    ];
   }
 
   private async requestReply(
@@ -674,6 +668,7 @@ export class CustodianSessionStore {
       this.retryParams = null;
       this.setupIssue = null;
       const step = result.step ?? null;
+      this.reconcileSessionRecovery(result, params.sessionId);
       const question = step ? null : parseCustodianQuestion(result.question);
       this.wizardValue = step ? initialCustodianWizardValue(step) : undefined;
       this.wizardSecretVisible = false;

--- a/ui/src/pages/custodian/custodian-transcript-state.ts
+++ b/ui/src/pages/custodian/custodian-transcript-state.ts
@@ -1,0 +1,145 @@
+import type { SystemAgentChatResult } from "@openclaw/gateway-protocol";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { WizardStep } from "../../api/types.ts";
+import type { ApplicationContext } from "../../app/context.ts";
+import {
+  captureCustodianRecoveryScope,
+  clearCustodianRecoveryForScope,
+  type CustodianRecoveryScope,
+  reconcileCustodianRecoveryForScope,
+} from "./custodian-recovery.ts";
+import { initialCustodianWizardValue } from "./custodian-wizard-step.ts";
+import type { CustodianStructuredQuestion } from "./structured-question.ts";
+import {
+  createCustodianSessionId,
+  loadCustodianTranscriptSnapshot,
+  type CustodianMessage,
+  type CustodianTranscriptSnapshot,
+} from "./transcript.ts";
+
+export type CustodianTranscriptHistoryOutcome = "recovered" | "inactive" | "unavailable";
+
+/** Transcript-owned state shared by live turns and reload recovery. */
+export abstract class CustodianTranscriptState {
+  messages: CustodianMessage[] = [];
+  sensitive = false;
+  wizardInputPending = false;
+  wizardValue: unknown;
+  wizardSecretVisible = false;
+  questionReplyUncertain = false;
+  earlierBoundaryAfterId: number | null = null;
+  activeClient: GatewayBrowserClient | null = null;
+
+  protected sessionId = createCustodianSessionId();
+  protected nextMessageId = 1;
+  protected requestEpoch = 0;
+  protected sessionClient: GatewayBrowserClient | null = null;
+  // Reconnect mutates the client's scope; cleanup must keep targeting the identity that wrote the handle.
+  private sessionRecoveryScope: CustodianRecoveryScope | null = null;
+  private lastHelloDeviceToken = "";
+
+  protected abstract emit(): void;
+
+  protected bindSessionRecovery(client: GatewayBrowserClient, gatewayUrl: string): void {
+    this.sessionClient = client;
+    this.sessionRecoveryScope = captureCustodianRecoveryScope(client, gatewayUrl);
+  }
+
+  protected currentSessionOwnershipKey(context: ApplicationContext | null): string {
+    if (!context) {
+      return "";
+    }
+    const { gatewayUrl, token, password, bootstrapToken } = context.gateway.connection;
+    const auth = context.gateway.snapshot.hello?.auth;
+    if (auth) {
+      this.lastHelloDeviceToken = auth.deviceToken ?? "";
+    }
+    const client = context.gateway.snapshot.client;
+    const recoveryScope = client?.recoveryScopeReady
+      ? (client.recoveryScope?.trim() ?? "")
+      : (this.sessionRecoveryScope?.recoveryScope ?? "");
+    if (recoveryScope) {
+      // The Gateway derives this scope from the authenticated owner. Credential and
+      // device-token rotation must not discard that owner's live setup session.
+      return JSON.stringify([gatewayUrl, recoveryScope]);
+    }
+    return JSON.stringify([gatewayUrl, token, password, bootstrapToken, this.lastHelloDeviceToken]);
+  }
+
+  protected clearSessionRecovery(expectedSessionId = this.sessionId): void {
+    if (!this.sessionRecoveryScope) {
+      return;
+    }
+    clearCustodianRecoveryForScope(this.sessionRecoveryScope, expectedSessionId);
+  }
+
+  protected reconcileSessionRecovery(
+    result: SystemAgentChatResult,
+    requestSessionId: string,
+  ): void {
+    if (!this.sessionRecoveryScope) {
+      return;
+    }
+    reconcileCustodianRecoveryForScope(this.sessionRecoveryScope, result, requestSessionId);
+  }
+
+  protected async refreshTranscriptHistory(
+    client: GatewayBrowserClient,
+    epoch: number,
+    historySupported: boolean,
+    sessionId?: string,
+  ): Promise<CustodianTranscriptHistoryOutcome> {
+    if (!historySupported) {
+      return "inactive";
+    }
+    let transcript;
+    try {
+      transcript = await loadCustodianTranscriptSnapshot(client, this.nextMessageId, sessionId);
+    } catch {
+      return "unavailable";
+    }
+    if (epoch !== this.requestEpoch || client !== this.activeClient) {
+      return "inactive";
+    }
+    const recovered = this.applyTranscriptSnapshot(transcript, sessionId);
+    this.emit();
+    return recovered ? "recovered" : "inactive";
+  }
+
+  protected appendAssistant(
+    reply: string,
+    question: CustodianStructuredQuestion | null,
+    step: WizardStep | null,
+  ): void {
+    this.messages = [
+      ...this.messages,
+      {
+        id: this.nextMessageId++,
+        role: "assistant",
+        text: reply,
+        at: Date.now(),
+        question,
+        step,
+      },
+    ];
+  }
+
+  protected applyTranscriptSnapshot(
+    transcript: CustodianTranscriptSnapshot,
+    recoveredSessionId?: string,
+  ): boolean {
+    this.messages = transcript.messages;
+    this.nextMessageId = transcript.nextMessageId;
+    this.earlierBoundaryAfterId = transcript.earlierBoundaryAfterId;
+    const step = transcript.recoveredStep;
+    if (recoveredSessionId) {
+      this.sessionId = recoveredSessionId;
+      this.sensitive = step?.sensitive === true;
+      this.wizardInputPending = step !== undefined;
+      this.wizardValue = step ? initialCustodianWizardValue(step) : undefined;
+      this.wizardSecretVisible = false;
+      this.questionReplyUncertain = false;
+    }
+    return step !== undefined;
+  }
+}

--- a/ui/src/pages/custodian/transcript.ts
+++ b/ui/src/pages/custodian/transcript.ts
@@ -84,22 +84,17 @@ function toCustodianMessageGroup(message: CustodianMessage): MessageGroup {
   };
 }
 
-export async function readCustodianTranscript(
+async function readCustodianTranscript(
   client: GatewayBrowserClient,
-): Promise<SystemAgentChatHistoryResult["turns"] | null> {
-  try {
-    return (
-      await client.request<SystemAgentChatHistoryResult>(
-        "openclaw.chat.history",
-        {},
-        {
-          timeoutMs: CUSTODIAN_TRANSCRIPT_TIMEOUT_MS,
-        },
-      )
-    ).turns;
-  } catch {
-    return null;
-  }
+  sessionId?: string,
+): Promise<SystemAgentChatHistoryResult> {
+  return await client.request<SystemAgentChatHistoryResult>(
+    "openclaw.chat.history",
+    sessionId ? { sessionId } : {},
+    {
+      timeoutMs: CUSTODIAN_TRANSCRIPT_TIMEOUT_MS,
+    },
+  );
 }
 
 /**
@@ -110,7 +105,7 @@ export async function readCustodianTranscript(
  */
 const SERVER_SENSITIVE_MASK = "<redacted secret>";
 
-export function createCustodianTranscriptMessages(
+function createCustodianTranscriptMessages(
   turns: readonly SystemAgentChatHistoryTurn[],
   firstMessageId: number,
 ): { messages: CustodianMessage[]; nextMessageId: number } {
@@ -127,6 +122,41 @@ export function createCustodianTranscriptMessages(
     step: null,
   }));
   return { messages, nextMessageId };
+}
+
+export type CustodianTranscriptSnapshot = {
+  messages: CustodianMessage[];
+  nextMessageId: number;
+  earlierBoundaryAfterId: number | null;
+  recoveredStep?: WizardStep;
+};
+
+export async function loadCustodianTranscriptSnapshot(
+  client: GatewayBrowserClient,
+  firstMessageId: number,
+  sessionId?: string,
+): Promise<CustodianTranscriptSnapshot> {
+  const history = await readCustodianTranscript(client, sessionId);
+  const transcript = createCustodianTranscriptMessages(history.turns, firstMessageId);
+  const earlierBoundaryAfterId = transcript.messages.at(-1)?.id ?? null;
+  const activeWizard = history.activeWizard;
+  const recoveredStep =
+    sessionId && activeWizard?.sessionId === sessionId ? activeWizard.step : null;
+  if (recoveredStep) {
+    transcript.messages.push({
+      id: transcript.nextMessageId++,
+      role: "assistant",
+      text: "",
+      at: Date.now(),
+      question: null,
+      step: recoveredStep,
+    });
+  }
+  return {
+    ...transcript,
+    earlierBoundaryAfterId,
+    ...(recoveredStep ? { recoveredStep } : {}),
+  };
 }
 
 function renderCustodianEarlierDivider(message: CustodianMessage, boundaryAfterId: number | null) {


### PR DESCRIPTION
## New behavior

Reloading Custodian during hosted setup restores the same owner-bound live session instead of losing the pending control.

- The tab stores only an opaque session id under the current Gateway and authenticated recovery scope.
- After reload, the Gateway supplies the authoritative transcript and sanitized active step.
- Sensitive input is never restored: the recovered secret field is blank and masked.
- Gateway URL or recovery-scope changes discard the old handle and start fresh.
- Cancel remains a negotiated typed action on the recovered step.

## Stack context

Layer 2 of 3. Depends on #121560 and is followed by #121562.

- Exact head: `e9a1b0a2f27c3fe7870d203488d8309622c32f50`
- Direct-base diff: 10 files, +1,099/-100
- Production delta: +360/-93; the rest is lifecycle, identity-fence, storage-collision, reload, and browser proof.

## Rendered UI proof

### Desktop recovery

<img width="1280" height="900" alt="Custodian after reload with restored transcript and a blank masked Twitch client secret control" src="https://github.com/user-attachments/assets/c8a20057-f147-4e5f-9aef-0432f03cab07" />

The prior transcript and pending secret step return after reload. The field is blank and masked; Cancel and Submit remain available.

### Mobile recovery

<img width="375" height="812" alt="Custodian recovered secret step at mobile width without horizontal overflow" src="https://github.com/user-attachments/assets/c12128bc-78ab-4f67-81be-9cc1984a38a1" />

The same recovered state fits a 375×812 viewport without horizontal overflow.

Both captures use `/custodian?onboarding=1`, dark mode, and the repository's mocked Gateway fixture. No real credential appears. The current amendment changes only the ownership fence and its regression, not this rendered state.

## Verification

- Exact-head recovery tests: 15/15 passed locally on Node 24.15, including same-scope credential rotation and storage-key isolation.
- The UI recovery layer passed 115 focused protocol, Gateway, engine, recovery, and Control UI tests locally on Node 24.15; the current parent owner delta passed 37/37 focused tests.
- Rendered Control UI E2E: 8/8 scenarios passed on the exact final stack tree, including desktop/mobile recovery, blank sensitive input, typed cancellation, and receipt states.
- Blacksmith Testbox shut down two fresh leases before either executed repository code, so the repository's trusted-source local fallback was used. The prior stack head passed 136 focused tests on Testbox ([run 31612490852](https://github.com/openclaw/openclaw/actions/runs/31612490852)).
- Scope-only identity rotation clears the old transcript, control, and handle; length-framed storage keys keep colliding Gateway/scope tuples isolated.
- Prerequisite #121560 exact head `6e02bb4e67358ad50955945378741fe0858c6e69` uses the canonical linked-login profile for ownership, rebinds live sessions when profiles merge, and still rejects a foreign profile before returning live wizard state.
- Local trusted-source fallback passed formatting, core/UI `tsgo`, full core oxlint, and `git diff --check`.

## Implementation note

Session storage contains the raw opaque session id only. The immutable `(gateway URL, recovery scope)` captured when the session starts owns subsequent write and compare-and-clear operations; the Gateway remains the sole owner of live wizard state.
