### PR TITLE
improve(qa): verify plugin tool ownership in gateway flow

### DIFF
--- a/extensions/qa-lab/src/tool-search-gateway.fixture.test.ts
+++ b/extensions/qa-lab/src/tool-search-gateway.fixture.test.ts
@@ -257,12 +257,25 @@ describe("tool search gateway e2e lane result", () => {
         ]),
       );
     vi.stubGlobal("fetch", fetchMock);
+    const gatewayCall = vi.fn(async () => ({
+      groups: [
+        {
+          tools: [
+            {
+              id: "fake_plugin_tool_17",
+              source: "plugin",
+              pluginId: "tool-search-e2e-fixture",
+            },
+          ],
+        },
+      ],
+    }));
     const env: QaSuiteRuntimeEnv = {
       alternateModel: "openai/gpt-5.6-luna",
       cfg: {},
       gateway: {
         baseUrl: "http://gateway.test",
-        call: async () => undefined,
+        call: gatewayCall,
         restartAfterStateMutation: async (mutateState) => {
           await mutateState({
             configPath,
@@ -293,7 +306,16 @@ describe("tool search gateway e2e lane result", () => {
       expect(result.providerInputSnippet).toBe(inputPrefix);
       expect(result.providerToolOutputSnippet).toBe(toolOutputPrefix);
       expect(result.providerDirectoryContainsTarget).toBe(true);
+      expect(result.targetToolIdentity).toEqual({
+        source: "plugin",
+        pluginId: "tool-search-e2e-fixture",
+      });
       expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(gatewayCall).toHaveBeenCalledWith(
+        "tools.effective",
+        { sessionKey: "tool-search-gateway-code" },
+        { timeoutMs: expect.any(Number) },
+      );
       const laneConfig = JSON.parse(await fs.readFile(configPath, "utf8")) as {
         memory?: { search?: Record<string, unknown> };
       };
@@ -334,6 +356,10 @@ describe("qa fixture response helpers", () => {
 
 describe("tool search gateway e2e lane assertions", () => {
   const targetTool = "fake_plugin_tool_17";
+  const targetToolIdentity = {
+    source: "plugin",
+    pluginId: "tool-search-e2e-fixture",
+  };
   const normal = {
     gatewayOutputText: `FAKE_PLUGIN_OK ${targetTool}`,
     providerDeclaredToolCount: 36,
@@ -343,6 +369,7 @@ describe("tool search gateway e2e lane assertions", () => {
     sessionLogToolMentions: {
       [targetTool]: 1,
     },
+    targetToolIdentity,
   };
 
   it("accepts code lane proof only when the target plugin tool output is present", () => {
@@ -351,6 +378,7 @@ describe("tool search gateway e2e lane assertions", () => {
         normal,
         targetTool,
         code: {
+          targetToolIdentity,
           gatewayOutputText: `FAKE_PLUGIN_OK ${targetTool}`,
           providerDeclaredToolCount: 1,
           providerDirectoryContainsTarget: true,
@@ -377,6 +405,7 @@ describe("tool search gateway e2e lane assertions", () => {
           gatewayOutputText: `${normalOutput}😀tail`,
         },
         code: {
+          targetToolIdentity,
           gatewayOutputText: `${codeOutput}😀tail`,
           providerDeclaredToolCount: 1,
           providerDirectoryContainsTarget: true,
@@ -399,6 +428,7 @@ describe("tool search gateway e2e lane assertions", () => {
         normal,
         targetTool,
         code: {
+          targetToolIdentity,
           gatewayOutputText: targetTool,
           providerDeclaredToolCount: 1,
           providerDirectoryContainsTarget: true,
@@ -419,6 +449,7 @@ describe("tool search gateway e2e lane assertions", () => {
         normal,
         targetTool,
         code: {
+          targetToolIdentity,
           gatewayOutputText: `FAKE_PLUGIN_OK ${targetTool}`,
           providerDeclaredToolCount: 2,
           providerDirectoryContainsTarget: true,
@@ -444,6 +475,7 @@ describe("tool search gateway e2e lane assertions", () => {
           },
         },
         code: {
+          targetToolIdentity,
           gatewayOutputText: `FAKE_PLUGIN_OK ${targetTool}`,
           providerDeclaredToolCount: 1,
           providerDirectoryContainsTarget: true,
@@ -471,6 +503,7 @@ describe("tool search gateway e2e lane assertions", () => {
           },
         },
         code: {
+          targetToolIdentity,
           gatewayOutputText: `FAKE_PLUGIN_OK ${targetTool}`,
           providerDeclaredToolCount: 1,
           providerDirectoryContainsTarget: true,
@@ -491,6 +524,7 @@ describe("tool search gateway e2e lane assertions", () => {
         normal,
         targetTool,
         code: {
+          targetToolIdentity,
           gatewayOutputText: `FAKE_PLUGIN_OK ${targetTool}`,
           providerDeclaredToolCount: 1,
           providerDirectoryContainsTarget: false,
@@ -511,6 +545,7 @@ describe("tool search gateway e2e lane assertions", () => {
         normal: { ...normal, providerDirectoryContainsTarget: true },
         targetTool,
         code: {
+          targetToolIdentity,
           gatewayOutputText: `FAKE_PLUGIN_OK ${targetTool}`,
           providerDeclaredToolCount: 1,
           providerDirectoryContainsTarget: true,
@@ -523,5 +558,29 @@ describe("tool search gateway e2e lane assertions", () => {
         },
       }),
     ).toThrow("normal lane unexpectedly advertised a Tool Search capability directory");
+  });
+
+  it("rejects tools.effective ownership that does not identify the fixture plugin", () => {
+    expect(() =>
+      assertToolSearchLaneResults({
+        normal: {
+          ...normal,
+          targetToolIdentity: { source: "core", pluginId: "" },
+        },
+        targetTool,
+        code: {
+          targetToolIdentity,
+          gatewayOutputText: `FAKE_PLUGIN_OK ${targetTool}`,
+          providerDeclaredToolCount: 1,
+          providerDirectoryContainsTarget: true,
+          providerPlannedTools: ["tool_search_code"],
+          providerRawBytes: 4_000,
+          sessionLogToolMentions: {
+            tool_search_code: 1,
+            [targetTool]: 1,
+          },
+        },
+      }),
+    ).toThrow(`tools.effective did not attribute ${targetTool} to plugin tool-search-e2e-fixture`);
   });
 });

--- a/extensions/qa-lab/src/tool-search-gateway.fixture.ts
+++ b/extensions/qa-lab/src/tool-search-gateway.fixture.ts
@@ -38,6 +38,10 @@ type LaneResult = {
   gatewayOutputToolNames: string[];
   gatewayOutputText: string;
   sessionLogToolMentions: Record<string, number>;
+  targetToolIdentity: {
+    source: string;
+    pluginId: string;
+  };
 };
 
 type LaneResultSummary = Pick<
@@ -48,6 +52,7 @@ type LaneResultSummary = Pick<
   | "providerRawBytes"
   | "gatewayOutputText"
   | "sessionLogToolMentions"
+  | "targetToolIdentity"
 > & {
   providerInputSnippet?: string;
   providerToolOutputSnippet?: string;
@@ -332,6 +337,33 @@ async function configureLane(params: {
   });
 }
 
+async function readTargetToolIdentity(params: {
+  env: QaSuiteRuntimeEnv;
+  sessionKey: string;
+  targetTool: string;
+}) {
+  const payload = (await params.env.gateway.call(
+    "tools.effective",
+    { sessionKey: params.sessionKey },
+    { timeoutMs: liveTurnTimeoutMs(params.env, 90_000) },
+  )) as {
+    groups?: Array<{
+      tools?: Array<{ id?: string; source?: string; pluginId?: string }>;
+    }>;
+  };
+  for (const group of payload.groups ?? []) {
+    for (const tool of group.tools ?? []) {
+      if (tool.id === params.targetTool) {
+        return {
+          source: tool.source?.trim() ?? "",
+          pluginId: tool.pluginId?.trim() ?? "",
+        };
+      }
+    }
+  }
+  throw new Error(`tools.effective did not report ${params.targetTool}`);
+}
+
 export async function stageToolSearchGatewayFixture(params: {
   env: QaSuiteRuntimeEnv;
   targetTool?: string;
@@ -366,6 +398,7 @@ export async function runToolSearchGatewayLane(params: {
   const requestCursorBefore = readQaMockRequestCursor(
     await fetchJson(qaMockRequestCursorUrl(providerBaseUrl)),
   );
+  const sessionKey = `tool-search-gateway-${params.lane}`;
   const response = await fetchJson(
     `${params.env.gateway.baseUrl}/v1/responses`,
     {
@@ -375,7 +408,7 @@ export async function runToolSearchGatewayLane(params: {
         "content-type": "application/json",
         "x-openclaw-scopes": "operator.write",
         "x-openclaw-agent": "qa",
-        "x-openclaw-session-key": `tool-search-gateway-${params.lane}`,
+        "x-openclaw-session-key": sessionKey,
       },
       body: JSON.stringify({
         model: "openclaw/qa",
@@ -415,6 +448,11 @@ export async function runToolSearchGatewayLane(params: {
     .filter((value): value is string => typeof value === "string")
     .join("\n");
   const responseStatus = (response as { status?: unknown }).status;
+  const targetToolIdentity = await readTargetToolIdentity({
+    env: params.env,
+    sessionKey,
+    targetTool: params.fixture.targetTool,
+  });
   const mentionCountsAfter = await countToolSearchSessionLogMentions({
     stateDir,
     targetTool: params.fixture.targetTool,
@@ -442,6 +480,7 @@ export async function runToolSearchGatewayLane(params: {
     gatewayOutputToolNames: outputToolNames(response),
     gatewayOutputText: outputText(response),
     sessionLogToolMentions: subtractMentionCounts(mentionCountsAfter, mentionCountsBefore),
+    targetToolIdentity,
   };
 }
 
@@ -519,4 +558,11 @@ export function assertToolSearchLaneResults(params: {
     !normal.providerPlannedTools.includes("tool_search_code"),
     "normal lane unexpectedly used Tool Search bridge",
   );
+  for (const lane of [normal, code]) {
+    assert(
+      lane.targetToolIdentity.source === "plugin" &&
+        lane.targetToolIdentity.pluginId === FAKE_PLUGIN_ID,
+      `tools.effective did not attribute ${targetTool} to plugin ${FAKE_PLUGIN_ID}: ${laneDebug()}`,
+    );
+  }
 }

--- a/qa/scenarios/runtime/tool-search-gateway-e2e.yaml
+++ b/qa/scenarios/runtime/tool-search-gateway-e2e.yaml
@@ -6,12 +6,13 @@ scenario:
   coverage:
     primary:
       - agent-runtime.hosted-tool-use
-    secondary:
       - plugins.plugin-tools
+    secondary:
       - plugins.tool-plugin-invocation
   objective: Verify the Tool Search gateway QA Lab flow keeps a large plugin-owned tool catalog behind the compact bridge while still invoking the selected plugin tool.
   successCriteria:
     - Direct mode exposes the fake plugin tool schemas and calls the selected plugin tool.
+    - Both lanes report the selected tool through tools.effective with source=plugin and pluginId=tool-search-e2e-fixture.
     - Tool Search code mode exposes only the compact bridge to the provider.
     - Tool Search code mode automatically advertises the selected tool in its bounded system-prompt directory.
     - The compact bridge calls the same selected plugin tool and records bridge plus target tool mentions in session logs.
@@ -94,4 +95,6 @@ flow:
           compactPlannedTools: codeLane.providerPlannedTools,
           directMentions: normalLane.sessionLogToolMentions,
           compactMentions: codeLane.sessionLogToolMentions,
+          directEffectiveTool: normalLane.targetToolIdentity,
+          compactEffectiveTool: codeLane.targetToolIdentity,
         })


### PR DESCRIPTION
## What Problem This Solves

The QA portfolio classified `plugins.plugin-tools` only as secondary coverage, even though the existing Tool Search gateway scenario exercises a staged external plugin with a large tool catalog.

## Why This Change Was Made

The scenario now reads the real `tools.effective` inventory after both direct and compact Tool Search lanes and requires the selected tool to be attributed to `source=plugin` and `pluginId=tool-search-e2e-fixture`. With that ownership proof in the artifact, the scenario becomes the primary owner for `plugins.plugin-tools`.

The change is confined to QA Lab fixture code, its focused tests, and scenario metadata. Production LOC delta is zero.

## User Impact

No runtime behavior changes. Maintainers get stronger regression evidence that plugin-owned tools remain correctly attributed through both gateway execution modes.

## Evidence

- `node scripts/run-vitest.mjs extensions/qa-lab/src/tool-search-gateway.fixture.test.ts` - 19 tests passed.
- Blacksmith Testbox private-QA build - passed on `tbx_01kz4me39bmfj9zmvjb047tdc1`.
- Exact `tool-search-gateway-e2e` scenario - passed 1/1 with mock OpenAI and qa-channel.
- `qa-evidence.json` records `plugins.plugin-tools` as primary.
- Scenario report records both direct and compact identities as `source=plugin`, `pluginId=tool-search-e2e-fixture`.
- Blacksmith Testbox `pnpm check:changed` - passed in 14m22s, including project typecheck, all lint shards, and import-cycle checks.
- Sol/high branch autoreview - clean, correctness 0.99.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/30849615040
