### PR TITLE
test(plugins): align tool fixtures with owner policy

### DIFF
--- a/src/plugins/manifest-contract-eligibility.test.ts
+++ b/src/plugins/manifest-contract-eligibility.test.ts
@@ -1,5 +1,5 @@
 // Covers manifest contract eligibility decisions.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   loadPluginMetadataSnapshot: vi.fn(),
@@ -16,12 +16,22 @@ vi.mock("./plugin-metadata-snapshot.js", () => ({
   resolvePluginMetadataSnapshot: mocks.resolvePluginMetadataSnapshot,
 }));
 
-import {
-  isManifestPluginAvailableForControlPlane,
-  listAvailableManifestContractValues,
-  loadManifestContractSnapshot,
-} from "./manifest-contract-eligibility.js";
-import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
+let isManifestPluginAvailableForControlPlane: typeof import("./manifest-contract-eligibility.js").isManifestPluginAvailableForControlPlane;
+let listAvailableManifestContractValues: typeof import("./manifest-contract-eligibility.js").listAvailableManifestContractValues;
+let loadManifestContractSnapshot: typeof import("./manifest-contract-eligibility.js").loadManifestContractSnapshot;
+let clearPluginMetadataLifecycleCaches: typeof import("./plugin-metadata-lifecycle.js").clearPluginMetadataLifecycleCaches;
+
+beforeAll(async () => {
+  // The plugins project shares module state across files. Rebind this module graph
+  // after the hoisted mocks so an earlier production import cannot bypass them.
+  vi.resetModules();
+  ({
+    isManifestPluginAvailableForControlPlane,
+    listAvailableManifestContractValues,
+    loadManifestContractSnapshot,
+  } = await import("./manifest-contract-eligibility.js"));
+  ({ clearPluginMetadataLifecycleCaches } = await import("./plugin-metadata-lifecycle.js"));
+});
 
 describe("bundled manifest contract availability", () => {
   const plugin = {

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -2,6 +2,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY } from "../agents/tool-policy.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resetLogger, setLoggerOverride } from "../logging/logger.js";
 import { loggingState } from "../logging/state.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
@@ -108,17 +109,31 @@ function createToolManifest(
   };
 }
 
-function createContext() {
+function createContext(): { config: OpenClawConfig; workspaceDir: string } {
   return {
     config: {
       plugins: {
         enabled: true,
-        allow: ["optional-demo", "message", "multi", "feishu"],
         load: { paths: ["/tmp/plugin.js"] },
         slots: { memory: "none" },
       },
     },
     workspaceDir: "/tmp",
+  };
+}
+
+function createConfiguredFeishuToolContext<T extends string>(conversationReadOrigin: T) {
+  const context = createContext();
+  return {
+    ...context,
+    config: {
+      ...context.config,
+      plugins: {
+        ...context.config.plugins,
+        allow: ["feishu"],
+      },
+    },
+    conversationReadOrigin,
   };
 }
 
@@ -166,12 +181,15 @@ function createToolRegistry(entries: MockRegistryToolEntry[]) {
   };
 }
 
-function setRegistry(entries: MockRegistryToolEntry[]) {
+function setRegistry(
+  entries: MockRegistryToolEntry[],
+  config: ReturnType<typeof createContext>["config"] = createContext().config,
+) {
   const registry = createToolRegistry(entries);
   loadOpenClawPluginsMock.mockReturnValue(registry);
   setActivePluginRegistry?.(registry as never, "test-tool-registry", "gateway-bindable", "/tmp");
   installToolManifestSnapshots({
-    config: createContext().config,
+    config,
     plugins: entries
       .map((entry) => ({
         id: entry.pluginId,
@@ -193,6 +211,27 @@ function setRegistry(entries: MockRegistryToolEntry[]) {
       .filter((plugin) => plugin.contracts.tools.length > 0),
   });
   return registry;
+}
+
+function setFeishuConversationToolRegistry(params: {
+  config: ReturnType<typeof createContext>["config"];
+  factory: MockRegistryToolEntry["factory"];
+  origin?: MockRegistryToolEntry["origin"] | "unknown";
+  source?: string;
+}) {
+  return setRegistry(
+    [
+      {
+        pluginId: "feishu",
+        optional: false,
+        ...(params.origin ? { origin: params.origin as never } : {}),
+        source: params.source ?? "/tmp/feishu.js",
+        names: ["feishu_chat"],
+        factory: params.factory,
+      },
+    ],
+    params.config,
+  );
 }
 
 function setMultiToolRegistry() {
@@ -801,7 +840,7 @@ describe("resolvePluginTools optional tools", () => {
       ...context.config,
       plugins: {
         ...context.config.plugins,
-        allow: [...context.config.plugins.allow, "feishu"],
+        allow: [...(context.config.plugins?.allow ?? []), "feishu"],
       },
       channels: {
         feishu: {
@@ -851,7 +890,7 @@ describe("resolvePluginTools optional tools", () => {
       ...context.config,
       plugins: {
         ...context.config.plugins,
-        allow: [...context.config.plugins.allow, "account-demo"],
+        allow: [...(context.config.plugins?.allow ?? []), "account-demo"],
         entries: {
           "account-demo": {
             config: {
@@ -925,7 +964,7 @@ describe("resolvePluginTools optional tools", () => {
       ...context.config,
       plugins: {
         ...context.config.plugins,
-        allow: [...context.config.plugins.allow, "feishu"],
+        allow: [...(context.config.plugins?.allow ?? []), "feishu"],
       },
       channels: {
         feishu: {
@@ -2511,24 +2550,13 @@ describe("resolvePluginTools optional tools", () => {
   );
 
   it("hides a non-bundled conversation-read tool from delegated resolution before factory execution", () => {
+    const context = createConfiguredFeishuToolContext("delegated");
     const factory = vi.fn(() => makeTool("feishu_chat"));
-    setRegistry([
-      {
-        pluginId: "feishu",
-        optional: false,
-        origin: "workspace",
-        source: "/tmp/feishu.js",
-        names: ["feishu_chat"],
-        factory,
-      },
-    ]);
+    setFeishuConversationToolRegistry({ config: context.config, factory, origin: "workspace" });
 
     const tools = resolvePluginTools(
       createResolveToolsParams({
-        context: {
-          ...createContext(),
-          conversationReadOrigin: "delegated",
-        },
+        context,
       }),
     );
 
@@ -2537,24 +2565,13 @@ describe("resolvePluginTools optional tools", () => {
   });
 
   it("keeps a non-bundled conversation-read tool available to direct operators", () => {
+    const context = createConfiguredFeishuToolContext("direct-operator");
     const factory = vi.fn(() => makeTool("feishu_chat"));
-    setRegistry([
-      {
-        pluginId: "feishu",
-        optional: false,
-        origin: "workspace",
-        source: "/tmp/feishu.js",
-        names: ["feishu_chat"],
-        factory,
-      },
-    ]);
+    setFeishuConversationToolRegistry({ config: context.config, factory, origin: "workspace" });
 
     const tools = resolvePluginTools(
       createResolveToolsParams({
-        context: {
-          ...createContext(),
-          conversationReadOrigin: "direct-operator",
-        },
+        context,
       }),
     );
 
@@ -2563,24 +2580,13 @@ describe("resolvePluginTools optional tools", () => {
   });
 
   it("keeps the bundled Feishu conversation-read tool available to delegated calls", () => {
+    const context = createConfiguredFeishuToolContext("delegated");
     const factory = vi.fn(() => makeTool("feishu_chat"));
-    setRegistry([
-      {
-        pluginId: "feishu",
-        optional: false,
-        origin: "bundled",
-        source: "/tmp/feishu.js",
-        names: ["feishu_chat"],
-        factory,
-      },
-    ]);
+    setFeishuConversationToolRegistry({ config: context.config, factory, origin: "bundled" });
 
     const tools = resolvePluginTools(
       createResolveToolsParams({
-        context: {
-          ...createContext(),
-          conversationReadOrigin: "delegated",
-        },
+        context,
       }),
     );
 
@@ -2591,24 +2597,13 @@ describe("resolvePluginTools optional tools", () => {
   it.each([undefined, "unknown"] as const)(
     "fails closed for %s conversation-read tool registration provenance",
     (origin) => {
+      const context = createConfiguredFeishuToolContext("delegated");
       const factory = vi.fn(() => makeTool("feishu_chat"));
-      setRegistry([
-        {
-          pluginId: "feishu",
-          optional: false,
-          ...(origin ? { origin: origin as never } : {}),
-          source: "/tmp/feishu.js",
-          names: ["feishu_chat"],
-          factory,
-        },
-      ]);
+      setFeishuConversationToolRegistry({ config: context.config, factory, origin });
 
       const tools = resolvePluginTools(
         createResolveToolsParams({
-          context: {
-            ...createContext(),
-            conversationReadOrigin: "delegated",
-          },
+          context,
         }),
       );
 
@@ -2618,24 +2613,18 @@ describe("resolvePluginTools optional tools", () => {
   );
 
   it("does not let an external override inherit bundled Feishu provenance", () => {
+    const context = createConfiguredFeishuToolContext("delegated");
     const factory = vi.fn(() => makeTool("feishu_chat"));
-    setRegistry([
-      {
-        pluginId: "feishu",
-        optional: false,
-        origin: "config",
-        source: "/tmp/external-feishu.js",
-        names: ["feishu_chat"],
-        factory,
-      },
-    ]);
+    setFeishuConversationToolRegistry({
+      config: context.config,
+      factory,
+      origin: "config",
+      source: "/tmp/external-feishu.js",
+    });
 
     const tools = resolvePluginTools(
       createResolveToolsParams({
-        context: {
-          ...createContext(),
-          conversationReadOrigin: "delegated",
-        },
+        context,
       }),
     );
 
@@ -2644,19 +2633,16 @@ describe("resolvePluginTools optional tools", () => {
   });
 
   it("rejects a stale bundled registration when the current manifest owner is external", () => {
+    const context = createConfiguredFeishuToolContext("delegated");
     const factory = vi.fn(() => makeTool("feishu_chat"));
-    setRegistry([
-      {
-        pluginId: "feishu",
-        optional: false,
-        origin: "bundled",
-        source: "/tmp/bundled-feishu.js",
-        names: ["feishu_chat"],
-        factory,
-      },
-    ]);
+    setFeishuConversationToolRegistry({
+      config: context.config,
+      factory,
+      origin: "bundled",
+      source: "/tmp/bundled-feishu.js",
+    });
     installToolManifestSnapshot({
-      config: createContext().config,
+      config: context.config,
       plugin: {
         id: "feishu",
         origin: "config",
@@ -2669,10 +2655,7 @@ describe("resolvePluginTools optional tools", () => {
 
     const tools = resolvePluginTools(
       createResolveToolsParams({
-        context: {
-          ...createContext(),
-          conversationReadOrigin: "delegated",
-        },
+        context,
       }),
     );
 
@@ -2686,32 +2669,23 @@ describe("resolvePluginTools optional tools", () => {
   ] as const)(
     "does not leak a non-bundled conversation-read tool through cached %s then %s resolution",
     (firstOrigin, secondOrigin, firstNames, secondNames) => {
+      const firstContext = createConfiguredFeishuToolContext(firstOrigin);
+      const secondContext = createConfiguredFeishuToolContext(secondOrigin);
       const factory = vi.fn(() => makeTool("feishu_chat"));
-      setRegistry([
-        {
-          pluginId: "feishu",
-          optional: false,
-          origin: "workspace",
-          source: "/tmp/feishu.js",
-          names: ["feishu_chat"],
-          factory,
-        },
-      ]);
+      setFeishuConversationToolRegistry({
+        config: firstContext.config,
+        factory,
+        origin: "workspace",
+      });
 
       const first = resolvePluginTools(
         createResolveToolsParams({
-          context: {
-            ...createContext(),
-            conversationReadOrigin: firstOrigin,
-          },
+          context: firstContext,
         }),
       );
       const second = resolvePluginTools(
         createResolveToolsParams({
-          context: {
-            ...createContext(),
-            conversationReadOrigin: secondOrigin,
-          },
+          context: secondContext,
         }),
       );
 
@@ -2722,36 +2696,27 @@ describe("resolvePluginTools optional tools", () => {
   );
 
   it("keeps concurrent direct and delegated non-bundled resolutions isolated", async () => {
+    const directContext = createConfiguredFeishuToolContext("direct-operator");
+    const delegatedContext = createConfiguredFeishuToolContext("delegated");
     const factory = vi.fn(() => makeTool("feishu_chat"));
-    setRegistry([
-      {
-        pluginId: "feishu",
-        optional: false,
-        origin: "workspace",
-        source: "/tmp/feishu.js",
-        names: ["feishu_chat"],
-        factory,
-      },
-    ]);
+    setFeishuConversationToolRegistry({
+      config: directContext.config,
+      factory,
+      origin: "workspace",
+    });
 
     const [direct, delegated] = await Promise.all([
       Promise.resolve().then(() =>
         resolvePluginTools(
           createResolveToolsParams({
-            context: {
-              ...createContext(),
-              conversationReadOrigin: "direct-operator",
-            },
+            context: directContext,
           }),
         ),
       ),
       Promise.resolve().then(() =>
         resolvePluginTools(
           createResolveToolsParams({
-            context: {
-              ...createContext(),
-              conversationReadOrigin: "delegated",
-            },
+            context: delegatedContext,
           }),
         ),
       ),
@@ -2763,21 +2728,14 @@ describe("resolvePluginTools optional tools", () => {
   });
 
   it("does not retain bundled authority in a cached executable after owner replacement", async () => {
+    const context = createConfiguredFeishuToolContext("delegated");
     const bundledFactory = vi.fn(() => makeTool("feishu_chat"));
-    setRegistry([
-      {
-        pluginId: "feishu",
-        optional: false,
-        origin: "bundled",
-        source: "/tmp/bundled-feishu.js",
-        names: ["feishu_chat"],
-        factory: bundledFactory,
-      },
-    ]);
-    const context = {
-      ...createContext(),
-      conversationReadOrigin: "delegated" as const,
-    };
+    setFeishuConversationToolRegistry({
+      config: context.config,
+      factory: bundledFactory,
+      origin: "bundled",
+      source: "/tmp/bundled-feishu.js",
+    });
     resolvePluginTools(createResolveToolsParams({ context }));
     const [cachedTool] = resolvePluginTools(createResolveToolsParams({ context }));
     expect(cachedTool?.name).toBe("feishu_chat");
@@ -2801,7 +2759,7 @@ describe("resolvePluginTools optional tools", () => {
       "/tmp",
     );
     installToolManifestSnapshot({
-      config: createContext().config,
+      config: context.config,
       plugin: {
         id: "feishu",
         origin: "config",
@@ -3336,7 +3294,7 @@ describe("resolvePluginTools optional tools", () => {
       onlyPluginIds?: string[];
       toolDiscovery?: unknown;
     };
-    expect(loaderParams.onlyPluginIds).toEqual(["optional-demo", "tavily"]);
+    expect(loaderParams.onlyPluginIds).toEqual(["tavily"]);
     expect(loaderParams.toolDiscovery).toBe(true);
   });
 


### PR DESCRIPTION
Closes https://github.com/openclaw/openclaw/issues/118957

## Summary

- make the default plugin-tool test context unrestricted so owner-policy enforcement does not silently exclude arbitrary fixture owners
- give external Feishu fixtures an explicit owner allowlist and share their registry setup
- update the restrictive-allowlist expectation to exclude an active plugin outside the allowlist
- rebind manifest eligibility imports after hoisted mocks in the non-isolated Plugins project

## Root cause

Bundled owner-policy enforcement made `plugins.allow` authoritative for tool owners. The old default fixture carried a restrictive allowlist while dynamically creating many unrelated plugin ids, so 20 assertions correctly received no tools. Separately, `manifest-contract-eligibility.test.ts` could reuse a production module graph evaluated by an earlier file, bypassing its mocks and producing six order-dependent failures.

The repair stays at the test owner boundary: default fixtures no longer smuggle restrictive policy into unrelated cases, tests that need external Feishu ownership configure it explicitly, and the non-isolated suite rebinds its mocked module graph. Production policy is unchanged.

## Evidence

Exact candidate: `3f0a5d43ffc4c8f1428afa349f27f6273e3bf178`, rebased onto current `main` at `c83dcc2bc089ca22db9ba19bb602694a66e19337`.

- `node scripts/run-vitest.mjs src/plugins/tools.optional.test.ts src/plugins/manifest-contract-eligibility.test.ts` — 2 files, 107 tests passed
- `OPENCLAW_VITEST_FS_MODULE_CACHE=0 node scripts/run-vitest.mjs --config test/vitest/vitest.plugins.config.ts` — 222 files, 3,369 tests passed, one skipped on Blacksmith Testbox `tbx_01kz4wwsrjezd0ar8wgztd6bmb`: https://github.com/openclaw/openclaw/actions/runs/30859893741
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` — clean, no accepted/actionable findings, confidence 0.99
- `git diff --check origin/main...HEAD` — passed
- public model identifier gate — PASS; no model identifiers added or changed

An earlier full-suite prepare attempt failed only three unrelated Gateway image-capability assertions in `src/gateway/server.agent.gateway-server-agent-a.test.ts`; the Plugins project was green in that run. The exact-current-main Plugins run above closes the ClawSweeper shared-module-lifecycle concern without weakening the unrelated Gateway test.

## Risk

Low. This is test-only, removes 32 net lines, and leaves production policy unchanged. Restrictive allowlist behavior remains covered explicitly instead of leaking through the default fixture.
