### PR TITLE
fix(gateway): route system-agent approvals off the exec channel bus

### DIFF
--- a/src/gateway/server-methods/approval-shared.test.ts
+++ b/src/gateway/server-methods/approval-shared.test.ts
@@ -6,6 +6,10 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { GATEWAY_CLIENT_IDS } from "../../../packages/gateway-protocol/src/client-info.js";
+import {
+  SYSTEM_AGENT_APPROVAL_DECISIONS,
+  type SystemAgentApprovalRequestPayload,
+} from "../../infra/system-agent-approvals.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import { ExecApprovalManager } from "../exec-approval-manager.js";
 import {
@@ -304,6 +308,7 @@ describe("handlePendingApprovalRequest", () => {
         expiresAtMs: record.expiresAtMs,
       },
       twoPhase: true,
+      approvalKind: "exec",
       deliverRequest: () => false,
     });
 
@@ -350,6 +355,7 @@ describe("handlePendingApprovalRequest", () => {
         expiresAtMs: record.expiresAtMs,
       },
       twoPhase: true,
+      approvalKind: "exec",
       deliverRequest: () => false,
     });
 
@@ -418,6 +424,74 @@ describe("handlePendingApprovalRequest", () => {
     await requestPromise;
   });
 
+  // Regression: a system-agent approval carries command AND title+description, so
+  // a channel subscriber resolving ownership off the payload rejects it. Publishing
+  // one onto the exec/plugin bus logged "does not identify exactly one owner" and
+  // left the operator with no approval binding (#118899).
+  it("keeps system-agent approvals off the channel approval bus", async () => {
+    const manager = new ExecApprovalManager<SystemAgentApprovalRequestPayload>({
+      approvalKind: "system-agent",
+    });
+    const record = manager.create(
+      {
+        // Field-for-field the payload queueDelegatedApproval builds: carrying
+        // command AND title+description is what makes the channel-side owner
+        // resolution ambiguous.
+        title: "OpenClaw change",
+        description: "Persist model default",
+        command: "Persist model default",
+        proposalHash: "proposal-hash",
+        allowedDecisions: SYSTEM_AGENT_APPROVAL_DECISIONS,
+        agentId: null,
+        sessionKey: null,
+        sessionId: "system-agent-session",
+        turnSourceChannel: null,
+        turnSourceAccountId: null,
+      },
+      60_000,
+      "system-agent-not-channel-routable",
+    );
+    const decisionPromise = manager.register(record, 60_000);
+    const publishRequested = vi.fn(() => 1);
+    const getApprovalClientConnIds = vi.fn(() => new Set<string>(["operator-ui"]));
+    const requestPromise = handlePendingApprovalRequest({
+      manager,
+      record,
+      decisionPromise,
+      respond: vi.fn(),
+      context: {
+        broadcast: vi.fn(),
+        broadcastToConnIds: vi.fn(),
+        getApprovalClientConnIds,
+        hasExecApprovalClients: () => false,
+        approvalEvents: { publishRequested, publishResolved: vi.fn() },
+      } as unknown as GatewayRequestContext,
+      requestEventName: "openclaw.approval.requested",
+      requestEvent: {
+        id: record.id,
+        request: record.request,
+        createdAtMs: record.createdAtMs,
+        expiresAtMs: record.expiresAtMs,
+      },
+      twoPhase: true,
+      approvalKind: "system-agent",
+      deliverRequest: () => false,
+      keepPendingWithoutRoute: true,
+      requireDeliveryRoute: false,
+    });
+
+    await Promise.resolve();
+    expect(publishRequested).not.toHaveBeenCalled();
+    expect(hasApprovalTurnSourceRouteMock).not.toHaveBeenCalled();
+    // Operator clients must still be selected: the fix must not silence Control UI.
+    expect(getApprovalClientConnIds).toHaveBeenCalledWith(
+      expect.objectContaining({ approvalKind: "system-agent" }),
+    );
+
+    expect(manager.resolve(record.id, "allow-once")).toBe(true);
+    await requestPromise;
+  });
+
   it("targets requested approval events to visible approval clients when available", async () => {
     const manager = new ExecApprovalManager();
     const record = manager.create(
@@ -468,6 +542,7 @@ describe("handlePendingApprovalRequest", () => {
         expiresAtMs: record.expiresAtMs,
       },
       twoPhase: true,
+      approvalKind: "exec",
       deliverRequest: () => false,
     });
 
@@ -537,6 +612,7 @@ describe("handlePendingApprovalRequest", () => {
         expiresAtMs: record.expiresAtMs,
       },
       twoPhase: true,
+      approvalKind: "exec",
       deliverRequest: () => false,
     });
 
@@ -605,6 +681,7 @@ describe("handlePendingApprovalRequest", () => {
         expiresAtMs: record.expiresAtMs,
       },
       twoPhase: true,
+      approvalKind: "exec",
       deliverRequest: () => false,
     });
 
@@ -672,6 +749,7 @@ describe("handlePendingApprovalRequest", () => {
         expiresAtMs: record.expiresAtMs,
       },
       twoPhase: true,
+      approvalKind: "exec",
       deliverRequest: () => false,
     });
 
@@ -727,6 +805,7 @@ describe("handlePendingApprovalRequest", () => {
         expiresAtMs: record.expiresAtMs,
       },
       twoPhase: true,
+      approvalKind: "exec",
       deliverRequest: () => delivery,
     });
 
@@ -781,6 +860,7 @@ describe("handlePendingApprovalRequest", () => {
           expiresAtMs: record.expiresAtMs,
         },
         twoPhase: true,
+        approvalKind: "exec",
         deliverRequest: () => delivery,
       });
 
@@ -839,6 +919,7 @@ describe("handlePendingApprovalRequest", () => {
         expiresAtMs: record.expiresAtMs,
       },
       twoPhase: true,
+      approvalKind: "exec",
       requireDeliveryRoute: false,
       deliverRequest: () => false,
     });
@@ -1074,6 +1155,7 @@ describe("handlePendingApprovalRequest", () => {
         expiresAtMs: record.expiresAtMs,
       },
       twoPhase: true,
+      approvalKind: "exec",
       deliverRequest: () => false,
     });
 
@@ -1149,6 +1231,7 @@ describe("handlePendingApprovalRequest", () => {
         expiresAtMs: record.expiresAtMs,
       },
       twoPhase: true,
+      approvalKind: "exec",
       deliverRequest: () => false,
     });
 
@@ -1224,6 +1307,7 @@ describe("handlePendingApprovalRequest", () => {
         expiresAtMs: record.expiresAtMs,
       },
       twoPhase: true,
+      approvalKind: "exec",
       deliverRequest: () => false,
     });
 
@@ -1858,6 +1942,7 @@ describe("handlePendingApprovalRequest", () => {
           expiresAtMs: record.expiresAtMs,
         },
         twoPhase: true,
+        approvalKind: "exec",
         deliverRequest: () => false,
       });
 

--- a/src/gateway/server-methods/approval-shared.test.ts
+++ b/src/gateway/server-methods/approval-shared.test.ts
@@ -975,6 +975,7 @@ describe("handlePendingApprovalRequest", () => {
         expiresAtMs: record.expiresAtMs,
       },
       twoPhase: true,
+      approvalKind: "exec",
       suppressDelivery: true,
       deliverRequest,
     });
@@ -1028,6 +1029,7 @@ describe("handlePendingApprovalRequest", () => {
         expiresAtMs: record.expiresAtMs,
       },
       twoPhase: true,
+      approvalKind: "exec",
       deliverToApprovalClientsOnly: true,
       deliverRequest,
     });
@@ -1086,6 +1088,7 @@ describe("handlePendingApprovalRequest", () => {
         expiresAtMs: record.expiresAtMs,
       },
       twoPhase: true,
+      approvalKind: "exec",
       deliverToApprovalClientsOnly: true,
       deliverRequest,
     });

--- a/src/gateway/server-methods/approval-shared.ts
+++ b/src/gateway/server-methods/approval-shared.ts
@@ -8,6 +8,7 @@ import type {
   ValidationError,
 } from "../../../packages/gateway-protocol/src/index.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { GatewayApprovalEventKind } from "../../infra/approval-gateway-runtime.types.js";
 import { hasApprovalTurnSourceRoute } from "../../infra/approval-turn-source.js";
 import type { ChannelApprovalKind } from "../../infra/approval-types.js";
 import type {
@@ -292,7 +293,7 @@ export async function handlePendingApprovalRequest<
   requestEventName: string;
   requestEvent: RequestedApprovalEvent<TPayload>;
   twoPhase: boolean;
-  approvalKind?: ChannelApprovalKind;
+  approvalKind: ChannelApprovalKind | "system-agent";
   deliverRequest: () => boolean | Promise<boolean>;
   afterDecision?: (
     decision: ExecApprovalDecision | null,
@@ -314,10 +315,18 @@ export async function handlePendingApprovalRequest<
     // per-occurrence spam #128031 removed, while an approval client can end
     // the recurrence with one allow-always (standing grant).
     const approvalClientsOnly = !suppressDelivery && params.deliverToApprovalClientsOnly === true;
+    // Only exec/plugin approvals have a channel-native payload and a turn source.
+    // Publishing operator-owned system-agent approvals here makes channel subscribers
+    // reject the payload and silently drops the operator's binding. Allowlist, so a
+    // new kind stays non-routable until deliberately added.
+    const channelApprovalKind: GatewayApprovalEventKind | null =
+      params.approvalKind === "exec" || params.approvalKind === "plugin"
+        ? params.approvalKind
+        : null;
     const approvalClientConnIds = suppressDelivery
       ? null
       : resolveApprovalRequestRecipientConnIds({
-          approvalKind: params.approvalKind ?? "exec",
+          approvalKind: params.approvalKind,
           context: params.context,
           record: params.record,
           excludeConnId: params.clientConnId,
@@ -338,13 +347,10 @@ export async function handlePendingApprovalRequest<
         });
       }
     }
-    const internalApprovalSubscriberCount =
-      suppressDelivery || approvalClientsOnly
-        ? 0
-        : (params.context.approvalEvents?.publishRequested(
-            params.approvalKind ?? "exec",
-            params.requestEvent,
-          ) ?? 0);
+    const channelBusKind = suppressDelivery || approvalClientsOnly ? null : channelApprovalKind;
+    const internalApprovalSubscriberCount = channelBusKind
+      ? (params.context.approvalEvents?.publishRequested(channelBusKind, params.requestEvent) ?? 0)
+      : 0;
 
     const hasApprovalClients = suppressDelivery
       ? false
@@ -362,10 +368,11 @@ export async function handlePendingApprovalRequest<
       !approvalClientsOnly &&
       !hasApprovalClients &&
       !delivered &&
+      channelApprovalKind !== null &&
       hasApprovalTurnSourceRoute({
         turnSourceChannel: params.record.request.turnSourceChannel,
         turnSourceAccountId: params.record.request.turnSourceAccountId,
-        approvalKind: params.approvalKind ?? "exec",
+        approvalKind: channelApprovalKind,
       });
     const deliveryRoute: ApprovalRequestDeliveryRoute = delivered
       ? "forwarder"

--- a/src/gateway/server-methods/approval-shared.ts
+++ b/src/gateway/server-methods/approval-shared.ts
@@ -8,7 +8,6 @@ import type {
   ValidationError,
 } from "../../../packages/gateway-protocol/src/index.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import type { GatewayApprovalEventKind } from "../../infra/approval-gateway-runtime.types.js";
 import { hasApprovalTurnSourceRoute } from "../../infra/approval-turn-source.js";
 import type { ChannelApprovalKind } from "../../infra/approval-types.js";
 import type {
@@ -319,7 +318,7 @@ export async function handlePendingApprovalRequest<
     // Publishing operator-owned system-agent approvals here makes channel subscribers
     // reject the payload and silently drops the operator's binding. Allowlist, so a
     // new kind stays non-routable until deliberately added.
-    const channelApprovalKind: GatewayApprovalEventKind | null =
+    const channelApprovalKind: ChannelApprovalKind | null =
       params.approvalKind === "exec" || params.approvalKind === "plugin"
         ? params.approvalKind
         : null;

--- a/src/gateway/server-methods/system-agent.ts
+++ b/src/gateway/server-methods/system-agent.ts
@@ -209,6 +209,7 @@ function queueDelegatedApproval(params: {
     requestEventName: "openclaw.approval.requested",
     requestEvent,
     twoPhase: true,
+    approvalKind: "system-agent",
     deliverRequest: () => false,
     keepPendingWithoutRoute: true,
     requireDeliveryRoute: false,

--- a/src/gateway/server-request-context.test.ts
+++ b/src/gateway/server-request-context.test.ts
@@ -566,6 +566,12 @@ describe("createGatewayRequestContext", () => {
         scopes: ["operator.admin"],
       }),
       makeGatewayClient({
+        connId: "macos",
+        clientId: GATEWAY_CLIENT_IDS.MACOS_APP,
+        mode: GATEWAY_CLIENT_MODES.UI,
+        scopes: ["operator.admin"],
+      }),
+      makeGatewayClient({
         connId: "bridge",
         clientId: GATEWAY_CLIENT_IDS.CLI,
         scopes: ["operator.approvals"],
@@ -610,13 +616,15 @@ describe("createGatewayRequestContext", () => {
 
     expect(context.hasExecApprovalClients?.()).toBe(true);
     expect(context.getApprovalClientConnIds?.()).toEqual(
-      new Set(["control-ui", "ios", "bridge", "acp", "runtime"]),
+      new Set(["control-ui", "ios", "macos", "bridge", "acp", "runtime"]),
     );
     expect(context.getApprovalClientConnIds?.({ approvalKind: "plugin" })).toEqual(
       new Set(["control-ui", "bridge", "tui", "plugin-bridge", "runtime"]),
     );
+    // macOS is the only native app that presents openclaw.approval.requested; it
+    // must keep receiving these once they are routed under their true kind.
     expect(context.getApprovalClientConnIds?.({ approvalKind: "system-agent" })).toEqual(
-      new Set(["control-ui", "bridge", "runtime"]),
+      new Set(["control-ui", "macos", "bridge", "runtime"]),
     );
     expect(context.hasExecApprovalClients?.("control-ui")).toBe(true);
     expect(

--- a/src/gateway/server-request-context.ts
+++ b/src/gateway/server-request-context.ts
@@ -133,6 +133,15 @@ const EXEC_APPROVAL_CLIENT_IDS: ReadonlySet<GatewayClientId> = new Set([
 
 const PLUGIN_APPROVAL_CLIENT_IDS: ReadonlySet<GatewayClientId> = new Set([GATEWAY_CLIENT_IDS.TUI]);
 
+// The macOS app has presented `openclaw.approval.requested` and resolved it as
+// `system-agent` since the delegation feature shipped, but advertises no approvals
+// cap — it reached these requests only while they were mislabeled `exec`. Routing
+// them under their true kind makes this list the one thing keeping that prompt
+// alive. iOS/Android declare no handler for the event, so they stay exec-only.
+const SYSTEM_AGENT_APPROVAL_CLIENT_IDS: ReadonlySet<GatewayClientId> = new Set([
+  GATEWAY_CLIENT_IDS.MACOS_APP,
+]);
+
 function canDeliverApprovals(
   gatewayClient: GatewayRequestContextClient,
   approvalKind: "exec" | "plugin" | "system-agent",
@@ -157,7 +166,9 @@ function canDeliverApprovals(
         hasGatewayClientCap(gatewayClient.connect.caps, GATEWAY_CLIENT_CAPS.EXEC_APPROVALS))) ||
     (approvalKind === "plugin" &&
       (PLUGIN_APPROVAL_CLIENT_IDS.has(gatewayClient.connect.client.id) ||
-        hasGatewayClientCap(gatewayClient.connect.caps, GATEWAY_CLIENT_CAPS.PLUGIN_APPROVALS)))
+        hasGatewayClientCap(gatewayClient.connect.caps, GATEWAY_CLIENT_CAPS.PLUGIN_APPROVALS))) ||
+    (approvalKind === "system-agent" &&
+      SYSTEM_AGENT_APPROVAL_CLIENT_IDS.has(gatewayClient.connect.client.id))
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

Closes #118899.

A delegated `system-agent` approval is published to internal channel subscribers as `exec`. Channel approval runtimes resolve ownership from the payload shape, and the system-agent payload carries `command` **and** `title`+`description`, so both discriminators match and `resolveApprovalRequestKind` throws. The gateway swallows it into a log line:

```text
[gateway] internal approval subscriber failed: Error: approval request payload does not identify exactly one owner
```

The approval stays pending but no channel approval-reaction binding is ever created, so the operator cannot resolve it from the channel that raised it.

The chain on `main` (`c218c539ab7`):

1. `queueDelegatedApproval` builds a payload with `title`, `description`, and `command` — [`src/gateway/server-methods/system-agent.ts:216`](https://github.com/openclaw/openclaw/blob/c218c539ab7/src/gateway/server-methods/system-agent.ts#L216)
2. it calls `handlePendingApprovalRequest` with **no `approvalKind`** — [`system-agent.ts:237`](https://github.com/openclaw/openclaw/blob/c218c539ab7/src/gateway/server-methods/system-agent.ts#L237)
3. the shared handler publishes it as `params.approvalKind ?? "exec"` — [`approval-shared.ts:504`](https://github.com/openclaw/openclaw/blob/c218c539ab7/src/gateway/server-methods/approval-shared.ts#L504)
4. `publish` fans out to every subscriber registered for `"exec"` — [`server-instance-runtime.ts:125`](https://github.com/openclaw/openclaw/blob/c218c539ab7/src/gateway/server-instance-runtime.ts#L125)
5. `resolveApprovalRequestKind` sees both owners and throws — [`src/infra/approval-types.ts:6`](https://github.com/openclaw/openclaw/blob/c218c539ab7/src/infra/approval-types.ts#L6)

## Why This Change Was Made

`GatewayApprovalRequest` is `ExecApprovalRequest | PluginApprovalRequest`: the internal channel bus is typed for exec and plugin only, and `SystemAgentApprovalRequestPayload` was never a member. Publishing onto it is a type-level lie that only the `?? "exec"` sentinel and the `as GatewayApprovalRequest` cast made possible.

The surrounding infrastructure already anticipated the third kind — `OperatorApprovalKind`, `canDeliverApprovals`, `resolveApprovalRequestRecipientConnIds`, and `broadcastApprovalResolvedEvent` all accept `"system-agent"`. Only the requested-path parameter stayed narrow.

So the fix records the fact at the producer instead of compensating downstream:

- `approvalKind` becomes **required** and widens to `OperatorApprovalKind`. The other three callers (`exec-approval.ts`, `plugin-approval.ts`, `node-invoke-plugin-policy.ts`) already passed it explicitly, so this costs them nothing and makes the omission a compile error rather than a silent mislabel.
- the channel bus and turn-source route are gated behind an allowlist of channel-native kinds, so a future kind is non-routable until deliberately added.
- three `?? "exec"` sentinels are deleted.

This restores symmetry with the sibling **resolved** path, which already gets it right: [`approval-publication.ts:90`](https://github.com/openclaw/openclaw/blob/c218c539ab7/src/gateway/server-methods/approval-publication.ts#L90) allowlists `exec`/`plugin` off the authoritative `record.kind` before publishing to the channel bus. The requested path was the one that defaulted instead of checking — that asymmetry is the bug.

**Rejected alternative:** passing `suppressDelivery: true` at the call site is a one-liner, but it also skips the operator broadcast at [`approval-shared.ts:489`](https://github.com/openclaw/openclaw/blob/c218c539ab7/src/gateway/server-methods/approval-shared.ts#L489) — silencing the Control UI for an approval that exists specifically to be armed by a human operator there. That converts a logged error into a silent dead end.

Net production change: **+20 LOC** across 3 files (11 of them comment), 3 sentinels removed. `git diff --numstat` production-only: `+30/-10`; tests `+95/-2`.

## User Impact

Delegated system-agent approvals no longer emit an internal subscriber error, and channel-native approval runtimes (WhatsApp, Discord, Slack) are no longer handed a payload they cannot classify. Exec and plugin approval routing is unchanged.

Audience selection now runs under the true kind, so `canDeliverApprovals` applies the system-agent policy rather than the exec one.

### The macOS prompt — ClawSweeper P1, fixed here

**The finding is real, and this PR now preserves that delivery path.** Verified end to end: a connected Mac receives `openclaw.approval.requested` today only because the request is mislabeled `exec`, so fixing the label alone would have taken the prompt away. `canDeliverApprovals` now admits `openclaw-macos` for `system-agent`, next to the existing exec/plugin client-id lists — one clause and one named set.

Why that set is exactly `{openclaw-macos}`:

- `ExecApprovalsGatewayPrompter.swift:43` presents `openclaw.approval.requested` and resolves it with `"kind": "system-agent"`. That is a purpose-built handler, not an accident of event naming.
- The app advertises only `agent-kind` and `inline-widgets` ([`GatewayConnection.swift:17`](https://github.com/openclaw/openclaw/blob/c218c539ab7/apps/macos/Sources/OpenClaw/GatewayConnection.swift#L17)), so no `approvals` cap route exists for it. The stable client id is the only thing that can reach it.
- iOS and Android declare **no** handler for the event — `NodeRuntime.kt:5377` switches on `exec.approval.requested` only, and iOS has no listener at all. Admitting them would deliver an event nothing consumes, so they stay exec-only.

Sibling surface checked: `broadcastApprovalResolvedEvent` resolves recipients through the same `canDeliverApprovals`, off the authoritative `record.kind` ([`approval-publication.ts:82`](https://github.com/openclaw/openclaw/blob/c218c539ab7/src/gateway/server-methods/approval-publication.ts#L82)), so macOS joins that audience too. No behaviour rides on it — the app subscribes to no `*.approval.resolved` event today, exec included — but the two directions now agree instead of splitting. `hasExecApprovalClients` is hardcoded to `exec` and is untouched.

**One correction to the review's history evidence.** The comment attributes both the recipient policy and the macOS handler to `0758316883f5`; that commit is `feat(sms): track Twilio delivery status (#118665)` and touches neither file. `git log -S` gives the provenance: the macOS handler came with the system-agent delegation feature in `b1f4aac349f` (2026-07-14), and the recipient policy came two days later in `68694599af6` / #108935 (2026-07-16). The ordering is what makes this preservation rather than invention.

**Why this is preservation, not a new contract.** #108935 gave `canDeliverApprovals` a `system-agent` branch, but nothing ever reached it from the requested path: `system-agent.ts` passed no kind, so `approval-shared.ts` defaulted every request to `exec`. The `{control-ui, bridge, runtime}` audience at `server-request-context.test.ts:299` was therefore an un-exercised default, not a shipped decision to exclude macOS — and its fixture had an `ios` client but no `macos` one, which is why the gap went uncaught. This PR is the first change that makes that audience binding for requests, which is precisely why the exclusion had to be repaired inside it.

### Still not decided here — the permanent contract

*Rank-up move "Decide and implement the macOS system-agent recipient contract or explicitly retire it": **skipped**, deliberately.*

This PR restores the operator-visible behaviour that shipped. It does not settle the forward-looking question: whether macOS should be a first-class system-agent surface advertising the `approvals` cap instead of riding a stable-id list, whether iOS/Android should grow handlers and join it, or whether the Swift handler should be retired and the route dropped on purpose. Defining or retiring a public native-client contract is an owner call. Name the direction and I will follow up in either — including deleting this clause if retirement is the answer.

## Evidence

**Real-behavior proof harness** driving the real `handlePendingApprovalRequest`, the real `createGatewayInstanceRuntime` publish/subscriber fan-out, a real `ExecApprovalManager`, and the real `resolveApprovalRequestKind` that channel runtimes use ([`approval-handler-runtime.ts:461`](https://github.com/openclaw/openclaw/blob/c218c539ab7/src/infra/approval-handler-runtime.ts#L461)). Only the websocket transport is mocked. The RED case reproduces main's actual call site by **omitting** `approvalKind`, rather than hand-feeding the fixed argument.

Negative control on unfixed `main` (`c218c539ab7`):

```text
=== issue #118899 — system-agent approval must not reach the channel bus ===

  [FAIL] call site omitting approvalKind does not mislabel as exec (got: internal approval
         subscriber failed: Error: approval request payload does not identify exactly one owner)
  [PASS] exec/plugin channel subscriber NOT invoked for a system-agent approval
  [PASS] operator approval broadcast still fired (Control UI keeps receiving it)
  [PASS] explicit system-agent kind also stays off the channel bus
  [PASS] audience selected for the true kind (asked: system-agent)
  [PASS] exec approval STILL reaches the channel subscriber (no routing regression)
  [PASS] exec approval produced no subscriber error

PROOF FAIL — 6/7 checks
```

Same harness on this branch:

```text
  [PASS] call site omitting approvalKind does not mislabel as exec (got: no error)
  [PASS] exec/plugin channel subscriber NOT invoked for a system-agent approval
  [PASS] operator approval broadcast still fired (Control UI keeps receiving it)
  [PASS] explicit system-agent kind also stays off the channel bus
  [PASS] audience selected for the true kind (asked: system-agent)
  [PASS] exec approval STILL reaches the channel subscriber (no routing regression)
  [PASS] exec approval produced no subscriber error

PROOF PASS — 7/7 checks
```

The RED line is the reporter's log message verbatim.

**Second negative control — the macOS recipient regression (ClawSweeper P1).** The recipient-policy fixture had an `ios` client but no `macos` one, so nothing covered this. It now has one. Reverting *only* `src/gateway/server-request-context.ts` to the pre-fix head `adfa208992a` and rerunning the same test reproduces exactly the loss the review predicted:

```text
AssertionError: expected Set{ 'control-ui', 'bridge', 'runtime' }
              to deeply equal Set{ 'control-ui', 'macos', …(2) }

  Set {
    "bridge",
    "control-ui",
-   "macos",
    "runtime",
  }
 ❯ src/gateway/server-request-context.test.ts:307

 Test Files  1 failed (1) | Tests  1 failed | 7 passed (8)
```

With the fix restored, the same assertion passes and macOS stays in the system-agent audience while remaining absent from the plugin one.

**Focused test command:**

```bash
node scripts/run-vitest.mjs src/gateway/server-request-context.test.ts src/gateway/server-methods/approval.test.ts src/gateway/server-methods/approval-shared.test.ts src/gateway/server-methods/system-agent.test.ts
```

`Test Files 4 passed (4) | Tests 109 passed (109)` — covering the new regression `keeps system-agent approvals off the channel approval bus` (asserts `publishRequested` is never called, no turn-source lookup happens, and operator clients are still selected with `approvalKind: "system-agent"`), plus the widened recipient-policy expectation above.

Also run: `tsgo -p tsconfig.core.json` clean, `tsgo -p test/tsconfig/tsconfig.core.test.json` clean, `run-oxlint.mjs src/gateway` clean, `oxfmt` applied.

**What was not tested:** no live WhatsApp roundtrip — I have no linked WhatsApp account, so the final channel-side reaction binding is proven at the gateway publish boundary rather than on-device.

---

🤖 AI-assisted (Claude Opus 5). Root cause, fix, harness, and tests reviewed by a human before opening.





P.S. — you should hire me. 115+ contributions to open source: https://github.com/harjothkhara
