### PR TITLE
chore(cron): cover execution diagnostics

### DIFF
--- a/qa/scenarios/scheduling/cron-execution-diagnostics.yaml
+++ b/qa/scenarios/scheduling/cron-execution-diagnostics.yaml
@@ -1,0 +1,31 @@
+title: Cron execution diagnostics
+
+scenario:
+  id: cron-execution-diagnostics
+  surface: automation
+  category: automation.cron-jobs
+  coverage:
+    primary:
+      - automation.model-provider-preflight
+      - automation.timeout-and-denial-diagnostics
+  objective: Prove isolated cron runs persist and expose provider preflight, timeout, and execution-denial diagnostics.
+  successCriteria:
+    - A real loopback transport failure is rejected by the production isolated-run model-provider preflight before agent execution.
+    - The provider-preflight skip is persisted in cron task history and emitted as an operator-visible finished event.
+    - A terminal command-lane timeout is normalized, persisted, and emitted with its canonical cron diagnostic.
+    - A fatal typed execution denial is normalized, persisted, and emitted with its tool diagnostic.
+  docsRefs:
+    - docs/automation/cron-jobs.md
+    - docs/cli/cron.md
+    - docs/gateway/protocol.md
+  codeRefs:
+    - src/cron/isolated-agent/model-preflight.runtime.ts
+    - src/cron/isolated-agent/run.ts
+    - src/cron/isolated-agent/run-finalize.ts
+    - src/cron/service/timer-execution.ts
+    - src/cron/task-run-history.ts
+    - src/cron/cron-execution-diagnostics.e2e.test.ts
+  execution:
+    kind: vitest
+    path: src/cron/cron-execution-diagnostics.e2e.test.ts
+    summary: Run real CronService jobs through isolated-run preflight and terminal diagnostic persistence boundaries.

--- a/src/cron/cron-execution-diagnostics.e2e.test.ts
+++ b/src/cron/cron-execution-diagnostics.e2e.test.ts
@@ -1,0 +1,262 @@
+import { createServer, type Server } from "node:net";
+import type { AddressInfo } from "node:net";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { resetTaskRegistryForTests } from "../tasks/task-runtime.test-helpers.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import {
+  loadRunCronIsolatedAgentTurn,
+  mockRunCronFallbackPassthrough,
+  resetRunCronIsolatedAgentTurnHarness,
+  resolveAllowedModelRefMock,
+  resolveConfiguredModelRefMock,
+  runEmbeddedAgentMock,
+  runWithModelFallbackMock,
+} from "./isolated-agent/run.test-harness.js";
+import { CronService, type CronEvent } from "./service.js";
+import { createNoopLogger } from "./service.test-harness.js";
+import { cronStoreKey } from "./store/key.js";
+import { readCronTaskRunHistoryPage } from "./task-run-history.js";
+
+vi.doUnmock("./isolated-agent/model-preflight.runtime.js");
+
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+const { resetCronModelProviderPreflightCacheForTest } =
+  await import("./isolated-agent/model-preflight.runtime.js");
+
+type ModelRef = { provider: string; model: string };
+
+function makeCommandLaneTaskTimeoutError(lane: string, timeoutMs: number): Error {
+  const error = new Error(`Command lane "${lane}" task timed out after ${timeoutMs}ms`);
+  error.name = "CommandLaneTaskTimeoutError";
+  return error;
+}
+
+async function listenForBrokenHttpConnections(): Promise<{
+  baseUrl: string;
+  server: Server;
+}> {
+  const server = createServer((socket) => socket.destroy());
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address() as AddressInfo;
+  return { baseUrl: `http://127.0.0.1:${address.port}`, server };
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function configFor(modelRef: ModelRef, localBaseUrl?: string): OpenClawConfig {
+  return {
+    agents: {
+      defaults: {
+        model: `${modelRef.provider}/${modelRef.model}`,
+      },
+    },
+    ...(localBaseUrl
+      ? {
+          models: {
+            providers: {
+              [modelRef.provider]: {
+                api: "ollama",
+                baseUrl: localBaseUrl,
+                models: [],
+              },
+            },
+          },
+        }
+      : {}),
+  };
+}
+
+async function runPersistedDiagnosticCase(params: {
+  cfg: OpenClawConfig;
+  modelRef: ModelRef;
+  name: string;
+}) {
+  return await withOpenClawTestState(
+    { layout: "state-only", prefix: "openclaw-cron-execution-diagnostics-" },
+    async (state) => {
+      resetTaskRegistryForTests();
+      const events: CronEvent[] = [];
+      const storePath = state.path("cron", "jobs.json");
+      const cron = new CronService({
+        storePath,
+        cronEnabled: true,
+        cronConfig: { triggers: { enabled: true } },
+        log: createNoopLogger(),
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        onEvent: (event) => events.push(structuredClone(event)),
+        runIsolatedAgentJob: async (runParams) =>
+          await runCronIsolatedAgentTurn({
+            ...runParams,
+            cfg: params.cfg,
+            deps: {},
+            sessionKey: `cron:${runParams.job.id}`,
+          }),
+      });
+      try {
+        await cron.start();
+        const job = await cron.add({
+          name: params.name,
+          enabled: true,
+          schedule: { kind: "every", everyMs: 60_000 },
+          sessionTarget: "isolated",
+          wakeMode: "next-heartbeat",
+          payload: {
+            kind: "agentTurn",
+            message: `run ${params.name}`,
+            model: `${params.modelRef.provider}/${params.modelRef.model}`,
+          },
+          delivery: { mode: "none" },
+        });
+        await expect(cron.run(job.id, "force")).resolves.toEqual({ ok: true, ran: true });
+
+        const finished = events.find(
+          (event) => event.action === "finished" && event.jobId === job.id,
+        );
+        const history = readCronTaskRunHistoryPage({
+          storeKey: cronStoreKey(storePath),
+          jobId: job.id,
+          limit: 1,
+        }).entries[0];
+        expect(finished).toBeDefined();
+        expect(history).toBeDefined();
+        return { finished: finished!, history: history! };
+      } finally {
+        cron.stop();
+        resetTaskRegistryForTests({ persist: false });
+      }
+    },
+  );
+}
+
+describe.sequential("cron execution diagnostics", () => {
+  const servers: Server[] = [];
+
+  beforeEach(() => {
+    resetRunCronIsolatedAgentTurnHarness();
+    resetCronModelProviderPreflightCacheForTest();
+  });
+
+  afterAll(async () => {
+    await Promise.all(servers.map(closeServer));
+  });
+
+  it("persists and emits a real isolated-run local-provider preflight failure", async () => {
+    const endpoint = await listenForBrokenHttpConnections();
+    servers.push(endpoint.server);
+    const modelRef = { provider: "ollama", model: "diagnostic-model" };
+    resolveConfiguredModelRefMock.mockReturnValue(modelRef);
+    resolveAllowedModelRefMock.mockReturnValue({ ref: modelRef });
+
+    const { finished, history } = await runPersistedDiagnosticCase({
+      cfg: configFor(modelRef, endpoint.baseUrl),
+      modelRef,
+      name: "unreachable provider",
+    });
+
+    expect(runWithModelFallbackMock).not.toHaveBeenCalled();
+    expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
+    for (const outcome of [finished, history]) {
+      expect(outcome).toMatchObject({
+        status: "skipped",
+        provider: "ollama",
+        model: "diagnostic-model",
+        error: expect.stringContaining("unavailable"),
+        diagnostics: {
+          entries: expect.arrayContaining([
+            expect.objectContaining({
+              source: "model-preflight",
+              severity: "warn",
+              message: expect.stringContaining("unavailable"),
+            }),
+          ]),
+        },
+      });
+    }
+  });
+
+  it("persists and emits the canonical terminal timeout diagnostic", async () => {
+    const modelRef = { provider: "openai", model: "gpt-5.4" };
+    resolveConfiguredModelRefMock.mockReturnValue(modelRef);
+    runWithModelFallbackMock.mockRejectedValueOnce(
+      makeCommandLaneTaskTimeoutError("cron-nested", 330_000),
+    );
+
+    const { finished, history } = await runPersistedDiagnosticCase({
+      cfg: configFor(modelRef),
+      modelRef,
+      name: "nested lane timeout",
+    });
+
+    for (const outcome of [finished, history]) {
+      expect(outcome).toMatchObject({
+        status: "error",
+        provider: "openai",
+        model: "gpt-5.4",
+        error: "cron: job execution timed out",
+        diagnostics: {
+          entries: expect.arrayContaining([
+            expect.objectContaining({
+              source: "cron-setup",
+              severity: "error",
+              message: "cron: job execution timed out",
+            }),
+          ]),
+        },
+      });
+    }
+  });
+
+  it("persists and emits a fatal execution-denial diagnostic", async () => {
+    const modelRef = { provider: "openai", model: "gpt-5.4" };
+    resolveConfiguredModelRefMock.mockReturnValue(modelRef);
+    mockRunCronFallbackPassthrough();
+    runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      meta: {
+        agentMeta: {},
+        failureSignal: {
+          kind: "execution_denied",
+          source: "tool",
+          toolName: "exec",
+          code: "SYSTEM_RUN_DENIED",
+          message: "SYSTEM_RUN_DENIED: approval required",
+          fatalForCron: true,
+        },
+      },
+    });
+
+    const { finished, history } = await runPersistedDiagnosticCase({
+      cfg: configFor(modelRef),
+      modelRef,
+      name: "execution denied",
+    });
+
+    for (const outcome of [finished, history]) {
+      expect(outcome).toMatchObject({
+        status: "error",
+        provider: "openai",
+        model: "gpt-5.4",
+        error: "SYSTEM_RUN_DENIED: approval required",
+        summary: "SYSTEM_RUN_DENIED: approval required",
+        diagnostics: {
+          entries: expect.arrayContaining([
+            expect.objectContaining({
+              source: "tool",
+              severity: "error",
+              message: "SYSTEM_RUN_DENIED: approval required",
+            }),
+          ]),
+        },
+      });
+    }
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Cron QA coverage did not prove that isolated-run provider admission failures or terminal timeout and execution-denial outcomes survive through the operator-visible event and persisted run-history boundaries.

## Why This Change Was Made

Adds a test-only QA scenario that executes production `CronService` jobs through the isolated-agent orchestration path. The preflight case uses a real broken loopback transport, while timeout and denial are injected at the external agent boundary so production normalization, diagnostics, event emission, and SQLite persistence remain under test.

## User Impact

No runtime behavior changes. Maintainers gain regression proof for:

- `automation.model-provider-preflight`
- `automation.timeout-and-denial-diagnostics`

## Evidence

- Exact reviewed head: `810f42dd82007f30e275bb29cca222a005594521`
- `node scripts/run-vitest.mjs src/cron/cron-execution-diagnostics.e2e.test.ts`
  - 1 file passed
  - 3 tests passed
- Both exact QA coverage IDs resolve uniquely to `cron-execution-diagnostics`
- Hosted exact-target CI: https://github.com/openclaw/openclaw/actions/runs/30853306497
  - private-QA build artifacts and all four QA Smoke profiles passed
  - focused cron isolated-agent, cron service, cron core, and test-types lanes passed
- Fresh autoreview found no actionable issue (`correct: 0.99`)
- ClawSweeper reviewed this exact head and found no patch defect
- `git diff --check`
- Production LOC delta: `0`

## Collision Disposition

As of August 3, 2026, #117340, #117425, #102116, #115933, and #117884 remain open at unchanged heads. No owner-path change has landed on `main`, so the optional ClawSweeper refresh is explicitly deferred. This exact head remains frozen against unrelated `main` drift.
