### PR TITLE
fix(msteams): enforce documented AAD owner approval principals

### DIFF
--- a/extensions/msteams/src/approval-auth.ts
+++ b/extensions/msteams/src/approval-auth.ts
@@ -8,14 +8,10 @@ const MSTEAMS_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]
 
 function normalizeMSTeamsApproverId(value: string | number): string | undefined {
   const normalized = normalizeMSTeamsMessagingTarget(String(value));
-  if (!normalized?.startsWith("user:")) {
-    return undefined;
-  }
-  const id = normalizeOptionalLowercaseString(normalized.slice("user:".length));
-  if (!id) {
-    return undefined;
-  }
-  return MSTEAMS_ID_RE.test(id) ? id : undefined;
+  const id = normalizeOptionalLowercaseString(
+    normalized?.startsWith("user:") ? normalized.slice("user:".length) : normalized,
+  );
+  return id && MSTEAMS_ID_RE.test(id) ? id : undefined;
 }
 
 function resolveMSTeamsChannelConfig(cfg: OpenClawConfig) {

--- a/extensions/msteams/src/channel.test.ts
+++ b/extensions/msteams/src/channel.test.ts
@@ -253,31 +253,45 @@ describe("msteams config schema", () => {
 });
 
 describe("msTeamsApprovalAuth", () => {
-  it("authorizes stable Teams user ids and ignores display-name allowlists", () => {
-    expect(
-      msTeamsApprovalAuth.authorizeActorAction({
-        cfg: {
-          channels: {
-            msteams: {
-              allowFrom: ["user:123e4567-e89b-12d3-a456-426614174000"],
-            },
-          },
-        },
-        senderId: "123e4567-e89b-12d3-a456-426614174000",
-        action: "approve",
-        approvalKind: "exec",
-      }),
-    ).toEqual({ authorized: true });
+  const ownerId = "123e4567-e89b-12d3-a456-426614174000";
+  const otherUserId = "22222222-2222-4222-8222-222222222222";
 
-    expect(
-      msTeamsApprovalAuth.authorizeActorAction({
-        cfg: {
-          channels: { msteams: { allowFrom: ["Owner Display"] } },
-        },
-        senderId: "attacker-aad",
-        action: "approve",
-        approvalKind: "exec",
-      }),
-    ).toEqual({ authorized: true });
+  function authorizeApproval(allowFrom: string[], senderId: string) {
+    return msTeamsApprovalAuth.authorizeActorAction({
+      cfg: { channels: { msteams: { allowFrom } } },
+      senderId,
+      action: "approve",
+      approvalKind: "exec",
+    });
+  }
+
+  it.each([
+    ["bare", ownerId],
+    ["user-prefixed", `user:${ownerId}`],
+    ["provider-prefixed", `msteams:user:${ownerId}`],
+    ["provider-prefixed bare", `teams:${ownerId}`],
+    ["uppercase", `MSTEAMS:USER:${ownerId.toUpperCase()}`],
+  ])("authorizes only the configured owner for %s AAD object IDs", (_label, allowFrom) => {
+    expect(authorizeApproval([allowFrom], ownerId)).toEqual({ authorized: true });
+    expect(authorizeApproval([allowFrom], otherUserId)).toMatchObject({ authorized: false });
+  });
+
+  it.each([
+    ["conversation", `conversation:${otherUserId}`],
+    ["provider-prefixed conversation", `msteams:conversation:${otherUserId}`],
+    ["chat", `chat:${otherUserId}`],
+    ["email", "owner@example.com"],
+    ["display name", "Owner Display"],
+    ["access group", "accessGroup:operators"],
+    ["wildcard", "*"],
+    ["braced UUID", `{${otherUserId}}`],
+  ])("does not treat %s entries as stable approval principals", (_label, invalidPrincipal) => {
+    expect(authorizeApproval([ownerId, invalidPrincipal], otherUserId)).toMatchObject({
+      authorized: false,
+    });
+  });
+
+  it("preserves implicit same-chat fallback for display-name-only allowlists", () => {
+    expect(authorizeApproval(["Owner Display"], "attacker-aad")).toEqual({ authorized: true });
   });
 });


### PR DESCRIPTION
## Summary
- Normalize documented bare Microsoft Entra/AAD owner object IDs at the Teams approval authorization boundary.
- Reject conversation, chat, display-name, wildcard, and other non-user approval principals while preserving supported user/provider-prefixed IDs and existing private fallback semantics.
- Prevent an authorized group participant from approving another owner's pending execution request.

## Security proof
- Reproduced a real pending ExecApprovalManager request resolved through the production Teams `/approve` handler and `exec.approval.resolve` gateway call before the fix.
- After the fix, the attacker receives an authorization denial with zero gateway calls; the documented bare-GUID owner successfully resolves the same real approval.
- 10 regression failures before the repair; 32 complete Teams channel tests pass afterward.
- Independent 26-case live principal/owner/fallback matrix and direct Microsoft SDK contract inspection.
- Independent formal review: zero P0/P1 findings, confidence 0.94.
- Production code decreases by four lines; no public API/config changes.

## Inspectable real approval-handler and gateway proof

Configuration uses public synthetic fixture GUIDs only: documented bare owner `11111111-1111-4111-8111-111111111111`; legitimate group participant `22222222-2222-4222-8222-222222222222` is **not** an approval owner. The harness executes the actual Teams `msTeamsApprovalAuth`, registered channel plugin, production `handleApproveCommandFromContext`, real pending `ExecApprovalManager.create/register/resolve`, and `withGatewayNativeApprovalRuntime`.

Before the fix, the group participant incorrectly resolves a real pending execution approval:

```json
{"phase":"RED","reply":"✅ Approval allow-once submitted for qa-pending.","pendingDecision":"allow-once","gatewayCalls":[{"method":"exec.approval.resolve","id":"qa-pending","decision":"allow-once"}]}
```

After the fix, the same participant is denied and makes **zero gateway resolution calls**, while the documented bare-GUID owner successfully resolves the request:

```json
{"phase":"GREEN","case":"unauthorized_group_member","reply":"❌ You are not authorized to approve exec requests on Microsoft Teams.","pendingDecision":"deny","gatewayCalls":[]}
{"phase":"GREEN","case":"configured_owner","reply":"✅ Approval allow-once submitted for qa-configured_owner-pending.","pendingDecision":"allow-once","gatewayCalls":[{"method":"exec.approval.resolve","id":"qa-configured_owner-pending","decision":"allow-once"}]}
```

The unauthorized case remains unresolved after denial; `pendingDecision:"deny"` is explicit test-harness cleanup performed **after** proving that no gateway approval was issued. Full plugin owner suite: `32 passed`.