### PR TITLE
fix(googlechat): block webhook startup without valid audience configuration

### DIFF
--- a/extensions/googlechat/src/monitor.lifecycle.test.ts
+++ b/extensions/googlechat/src/monitor.lifecycle.test.ts
@@ -27,17 +27,30 @@ vi.mock("./runtime.js", () => ({
 
 import { startGoogleChatMonitor } from "./monitor.js";
 
+const configuredAccount = {
+  accountId: "default",
+  enabled: true,
+  credentialSource: "config",
+  config: {
+    audienceType: "project-number",
+    audience: "1234567890",
+  },
+};
+
 describe("Google Chat monitor lifecycle", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.registerTarget.mockReturnValue(vi.fn());
   });
 
-  it("publishes ready after the webhook target is registered", async () => {
+  it.each([
+    { audienceType: "app-url", audience: "https://chat.example.test/googlechat" },
+    { audienceType: "project-number", audience: "1234567890" },
+  ])("publishes ready after the $audienceType webhook target is registered", async (config) => {
     const statusSink = vi.fn();
 
     const stop = await startGoogleChatMonitor({
-      account: { accountId: "default", enabled: true, credentialSource: "config", config: {} },
+      account: { ...configuredAccount, config },
       config: {},
       runtime: {},
       abortSignal: new AbortController().signal,
@@ -46,6 +59,7 @@ describe("Google Chat monitor lifecycle", () => {
     } as never);
 
     expect(mocks.registerTarget).toHaveBeenCalledOnce();
+    expect(mocks.registerTarget).toHaveBeenCalledWith(expect.objectContaining(config));
     expect(statusSink).toHaveBeenCalledWith({
       running: true,
       connected: true,
@@ -57,6 +71,54 @@ describe("Google Chat monitor lifecycle", () => {
     await stop();
   });
 
+  it.each([
+    { description: "both audience settings are missing", config: {} },
+    { description: "the audience is missing", config: { audienceType: "app-url" } },
+    {
+      description: "the audience is blank",
+      config: { audienceType: "app-url", audience: "   " },
+    },
+    {
+      description: "the audience type is missing",
+      config: { audience: "https://chat.example.test/googlechat" },
+    },
+    {
+      description: "the audience type is unsupported",
+      config: {
+        audienceType: "unsupported",
+        audience: "https://chat.example.test/googlechat",
+      },
+    },
+  ])("blocks startup when $description", async ({ config }) => {
+    const statusSink = vi.fn();
+    const runtime = { error: vi.fn() };
+
+    const stop = await startGoogleChatMonitor({
+      account: { ...configuredAccount, config },
+      config: {},
+      runtime,
+      abortSignal: new AbortController().signal,
+      webhookPath: "/googlechat",
+      statusSink,
+    } as never);
+
+    expect(mocks.ingressStart).not.toHaveBeenCalled();
+    expect(mocks.registerTarget).not.toHaveBeenCalled();
+    expect(statusSink).toHaveBeenCalledWith({
+      lifecycle: "blocked",
+      terminalDisconnect: true,
+      running: true,
+      connected: false,
+      webhookPath: undefined,
+      lastError: expect.stringContaining("channels.googlechat.audienceType"),
+    });
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("channels.googlechat.audience"),
+    );
+    await expect(stop()).resolves.toBeUndefined();
+    expect(mocks.ingressStop).not.toHaveBeenCalled();
+  });
+
   it("stops ingress and rejects startup when the webhook route cannot bind", async () => {
     const statusSink = vi.fn();
     mocks.registerTarget.mockImplementationOnce(() => {
@@ -65,7 +127,7 @@ describe("Google Chat monitor lifecycle", () => {
 
     await expect(
       startGoogleChatMonitor({
-        account: { accountId: "default", enabled: true, credentialSource: "config", config: {} },
+        account: configuredAccount,
         config: {},
         runtime: {},
         abortSignal: new AbortController().signal,

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -6,7 +6,7 @@ import {
   type ChannelBotLoopProtectionFacts,
   type ChannelInboundMediaInput,
 } from "openclaw/plugin-sdk/channel-inbound";
-import { channelReadyPatch } from "openclaw/plugin-sdk/gateway-runtime";
+import { channelBlockedPatch, channelReadyPatch } from "openclaw/plugin-sdk/gateway-runtime";
 import { mergePairLoopGuardConfig } from "openclaw/plugin-sdk/pair-loop-guard-runtime";
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { OpenClawConfig } from "../runtime-api.js";
@@ -497,6 +497,19 @@ async function monitorGoogleChatProvider(
 
   const audienceType = normalizeAudienceType(options.account.config.audienceType);
   const audience = options.account.config.audience?.trim();
+  if (!audienceType || !audience) {
+    const error =
+      "Google Chat webhook authentication requires channels.googlechat.audienceType and channels.googlechat.audience.";
+    options.runtime.error?.(`[${options.account.accountId}] ${error}`);
+    options.statusSink?.(
+      channelBlockedPatch(error, {
+        running: true,
+        connected: false,
+        webhookPath: undefined,
+      }),
+    );
+    return async () => {};
+  }
   const mediaMaxMb = options.account.config.mediaMaxMb ?? 20;
 
   warnAppPrincipalMisconfiguration({


### PR DESCRIPTION
## Summary
- Validate the effective Google Chat webhook audience and audience type before creating an inbound route.
- Publish an actionable blocked channel lifecycle instead of advertising a healthy connected account whose every webhook request must fail authentication.
- Preserve incremental setup, inherited account settings, valid app-URL/project-number audiences, and existing bind-failure cleanup.

## Real behavior proof
- Reproduced actual token-only setup, production JWT verification rejection, false-ready monitor state, and a misleading healthy gateway result.
- The repaired production monitor publishes `blocked`, clears stale webhook routing, logs actionable configuration guidance, and makes gateway health unhealthy without binding an unusable route.
- Five failing lifecycle regressions before the repair; eight complete lifecycle tests and four existing setup/inheritance scenarios now pass.
- Direct google-auth-library 10.9.1 source inspection confirms audience enforcement.
- Independent formal review: no P0/P1 findings; confidence 0.94.
- No CLI compatibility, configuration shape, schema, or public API changes.

## Inspectable production monitor, JWT, route, and gateway-health proof

Actual token-only setup and production JWT authentication before repair demonstrate the misleading healthy account even though every webhook is rejected:

```json
{"validation":null,"persistedAudience":null,"persistedAudienceType":null,"missingAudience":{"ok":false,"reason":"missing audience"},"missingAudienceType":{"ok":false,"reason":"unsupported audience type"},"health":{"healthy":true,"reason":"healthy"}}
```

After repair, the actual account resolver, JWT owner, monitor, and gateway-health evaluator produce an actionable blocked state; no HTTP route is registered:

```json
{"setupAccepted":true,"request":{"ok":false,"reason":"missing audience"},"routes":[],"snapshot":{"enabled":true,"configured":true,"lifecycle":"blocked","terminalDisconnect":true,"lastError":"Google Chat webhook authentication requires channels.googlechat.audienceType and channels.googlechat.audience.","running":true,"connected":false},"health":{"healthy":false,"reason":"blocked"},"loggedErrors":1}
```

Both supported valid audience modes still register the real plugin-owned webhook and become ready. These outputs use the actual `startGoogleChatMonitor`, `withPluginHttpRouteRegistry`, and `evaluateChannelHealth`, with an empty isolated in-memory queue; no credentials, live network, or authentication secrets:

```json
{"audienceType":"app-url","audience":"https://chat.example.invalid/googlechat","routes":[{"path":"/googlechat","pluginId":"googlechat","source":"googlechat-webhook","auth":"plugin"}],"snapshot":{"enabled":true,"configured":true,"running":true,"connected":true,"lifecycle":"ready","lastError":null},"health":{"healthy":true,"reason":"healthy"}}
{"audienceType":"project-number","audience":"123456789012","routes":[{"path":"/googlechat","pluginId":"googlechat","source":"googlechat-webhook","auth":"plugin"}],"snapshot":{"enabled":true,"configured":true,"running":true,"connected":true,"lifecycle":"ready","lastError":null},"health":{"healthy":true,"reason":"healthy"}}
```