### PR TITLE
chore(clawhub): cover plugin release policy contracts

### DIFF
--- a/qa/scenarios/plugins/clawhub-release-policy-contracts.yaml
+++ b/qa/scenarios/plugins/clawhub-release-policy-contracts.yaml
@@ -1,0 +1,34 @@
+title: ClawHub release policy contracts
+
+scenario:
+  id: clawhub-release-policy-contracts
+  surface: clawhub
+  category: clawhub.publishing
+  coverage:
+    primary:
+      - clawhub.package-release-validation
+      - clawhub.version-bump-gates
+      - clawhub.npm-trusted-publishing-provenance
+      - clawhub.external-code-plugin-package-contract-required
+  objective: Verify the real OpenClaw ClawHub and npm release checks enforce publishable plugin identity, provenance, compatibility metadata, and version bumps.
+  successCriteria:
+    - Valid publishable metadata passes both release checks with the expected package name, version, and extension id.
+    - A noncanonical repository URL fails the npm trusted-publishing provenance gate.
+    - Missing plugin API compatibility or build-version metadata fails the external code plugin package contract.
+    - A committed source change without a version bump fails the ClawHub release check.
+    - The same source change passes after the package version and compatibility metadata are bumped and committed.
+  docsRefs:
+    - docs/clawhub/publishing.md
+    - docs/plugins/community.md
+    - docs/help/testing-updates-plugins.md
+  codeRefs:
+    - scripts/plugin-clawhub-release-check.ts
+    - scripts/plugin-npm-release-check.ts
+    - scripts/lib/plugin-clawhub-release.ts
+    - scripts/lib/plugin-npm-release.ts
+    - packages/plugin-package-contract/src/index.ts
+    - test/e2e/qa-lab/plugins/clawhub-release-policy-contracts.e2e.test.ts
+  execution:
+    kind: vitest
+    path: test/e2e/qa-lab/plugins/clawhub-release-policy-contracts.e2e.test.ts
+    summary: Execute the real ClawHub and npm release-check scripts against valid and invalid temporary git plugin packages.

--- a/test/e2e/qa-lab/plugins/clawhub-release-policy-contracts.e2e.test.ts
+++ b/test/e2e/qa-lab/plugins/clawhub-release-policy-contracts.e2e.test.ts
@@ -1,0 +1,231 @@
+// ClawHub release policy tests execute the real npm and ClawHub release checks.
+import { spawnSync } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanupTempDirs, makeTempRepoRoot, writeJsonFile } from "../../../helpers/temp-repo.js";
+
+const CLAWHUB_CHECK = resolve("scripts/plugin-clawhub-release-check.ts");
+const NPM_CHECK = resolve("scripts/plugin-npm-release-check.ts");
+const REPOSITORY_URL = "https://github.com/openclaw/openclaw";
+const PACKAGE_NAME = "@openclaw/demo-plugin";
+const INITIAL_VERSION = "2026.8.3";
+const tsxImport = import.meta.resolve("tsx");
+const tempDirs: string[] = [];
+
+type FixtureOptions = {
+  includeBuildVersion?: boolean;
+  includePluginApi?: boolean;
+  repositoryUrl?: string;
+  version?: string;
+};
+
+afterEach(() => cleanupTempDirs(tempDirs));
+
+function git(cwd: string, args: string[]) {
+  const result = spawnSync("git", ["-C", cwd, ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  expect(result.status, result.stderr).toBe(0);
+  return result.stdout.trim();
+}
+
+function packageManifest(options: FixtureOptions = {}) {
+  const version = options.version ?? INITIAL_VERSION;
+  return {
+    name: PACKAGE_NAME,
+    version,
+    type: "module",
+    repository: {
+      type: "git",
+      url: options.repositoryUrl ?? REPOSITORY_URL,
+    },
+    openclaw: {
+      extensions: ["./index.ts"],
+      ...(options.includePluginApi === false
+        ? {}
+        : {
+            compat: {
+              pluginApi: `>=${version}`,
+            },
+          }),
+      ...(options.includeBuildVersion === false
+        ? {}
+        : {
+            build: {
+              openclawVersion: version,
+            },
+          }),
+      install: {
+        npmSpec: PACKAGE_NAME,
+      },
+      release: {
+        publishToClawHub: true,
+        publishToNpm: true,
+      },
+    },
+  };
+}
+
+function createPluginRepo(options: FixtureOptions = {}) {
+  const repoDir = makeTempRepoRoot(tempDirs, "openclaw-clawhub-policy-");
+  const packageDir = join(repoDir, "extensions", "demo-plugin");
+  mkdirSync(packageDir, { recursive: true });
+  writeJsonFile(join(repoDir, "package.json"), {
+    name: "openclaw-release-policy-fixture",
+    private: true,
+  });
+  writeFileSync(join(repoDir, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n", "utf8");
+  writeJsonFile(join(packageDir, "package.json"), packageManifest(options));
+  writeFileSync(join(packageDir, "index.ts"), "export const demo = 1;\n", "utf8");
+  writeFileSync(join(packageDir, "README.md"), "# Demo plugin\n", "utf8");
+
+  git(repoDir, ["init", "-b", "main"]);
+  git(repoDir, ["add", "."]);
+  git(repoDir, [
+    "-c",
+    "user.name=OpenClaw Test",
+    "-c",
+    "user.email=test@example.invalid",
+    "commit",
+    "-m",
+    "initial plugin",
+  ]);
+  return repoDir;
+}
+
+function commitFixture(repoDir: string, message: string) {
+  git(repoDir, ["add", "."]);
+  git(repoDir, [
+    "-c",
+    "user.name=OpenClaw Test",
+    "-c",
+    "user.email=test@example.invalid",
+    "commit",
+    "-m",
+    message,
+  ]);
+  return git(repoDir, ["rev-parse", "HEAD"]);
+}
+
+function runCheck(scriptPath: string, cwd: string, args: string[] = []) {
+  return spawnSync(process.execPath, ["--import", tsxImport, scriptPath, ...args], {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      NO_COLOR: "1",
+    },
+  });
+}
+
+function expectValidPackage(result: ReturnType<typeof runCheck>, command: string, version: string) {
+  expect(result.status, result.stderr).toBe(0);
+  expect(result.stderr).toBe("");
+  expect(result.stdout).toContain(`${command}: publishable plugin metadata looks OK.`);
+  expect(result.stdout).toContain(`- ${PACKAGE_NAME}@${version} (stable, demo-plugin)`);
+}
+
+describe("ClawHub release policy contracts", () => {
+  it("validates package identity, version, and extension metadata through both release checks", () => {
+    const repoDir = createPluginRepo();
+
+    expectValidPackage(
+      runCheck(CLAWHUB_CHECK, repoDir),
+      "plugin-clawhub-release-check",
+      INITIAL_VERSION,
+    );
+    expectValidPackage(runCheck(NPM_CHECK, repoDir), "plugin-npm-release-check", INITIAL_VERSION);
+  });
+
+  it("requires the canonical repository provenance for ClawHub and npm publishing", () => {
+    const repoDir = createPluginRepo({
+      repositoryUrl: "https://example.invalid/not-openclaw",
+    });
+    const expected = `package.json repository.url must be "${REPOSITORY_URL}" so npm provenance can validate GitHub trusted publishing`;
+
+    for (const scriptPath of [CLAWHUB_CHECK, NPM_CHECK]) {
+      const result = runCheck(scriptPath, repoDir);
+      expect(result.status).toBe(1);
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toContain(expected);
+    }
+  });
+
+  it("requires the external code plugin compatibility and build contract", () => {
+    const repoDir = createPluginRepo({
+      includeBuildVersion: false,
+      includePluginApi: false,
+    });
+
+    for (const scriptPath of [CLAWHUB_CHECK, NPM_CHECK]) {
+      const result = runCheck(scriptPath, repoDir);
+      expect(result.status).toBe(1);
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toContain(
+        "openclaw.compat.pluginApi is required for external code plugin packages.",
+      );
+      expect(result.stderr).toContain(
+        "openclaw.build.openclawVersion is required for external code plugin packages.",
+      );
+    }
+  });
+
+  it("rejects a changed publishable plugin whose committed version did not change", () => {
+    const repoDir = createPluginRepo();
+    const baseRef = git(repoDir, ["rev-parse", "HEAD"]);
+    writeFileSync(
+      join(repoDir, "extensions", "demo-plugin", "index.ts"),
+      "export const demo = 2;\n",
+      "utf8",
+    );
+    const headRef = commitFixture(repoDir, "change plugin source");
+
+    const result = runCheck(CLAWHUB_CHECK, repoDir, ["--base-ref", baseRef, "--head-ref", headRef]);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("version bumps required before ClawHub publish");
+    expect(result.stderr).toContain(
+      `${PACKAGE_NAME}@${INITIAL_VERSION}: changed publishable plugin still has the same version in package.json.`,
+    );
+  });
+
+  it("accepts a source change with a committed package version bump", () => {
+    const repoDir = createPluginRepo();
+    const baseRef = git(repoDir, ["rev-parse", "HEAD"]);
+    const nextVersion = "2026.8.4";
+    writeFileSync(
+      join(repoDir, "extensions", "demo-plugin", "index.ts"),
+      "export const demo = 2;\n",
+      "utf8",
+    );
+    const manifestPath = join(repoDir, "extensions", "demo-plugin", "package.json");
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as ReturnType<
+      typeof packageManifest
+    >;
+    writeJsonFile(manifestPath, {
+      ...manifest,
+      version: nextVersion,
+      openclaw: {
+        ...manifest.openclaw,
+        compat: {
+          pluginApi: `>=${nextVersion}`,
+        },
+        build: {
+          openclawVersion: nextVersion,
+        },
+      },
+    });
+    const headRef = commitFixture(repoDir, "bump plugin version");
+    const args = ["--base-ref", baseRef, "--head-ref", headRef];
+
+    expectValidPackage(
+      runCheck(CLAWHUB_CHECK, repoDir, args),
+      "plugin-clawhub-release-check",
+      nextVersion,
+    );
+    expectValidPackage(runCheck(NPM_CHECK, repoDir, args), "plugin-npm-release-check", nextVersion);
+  });
+});

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -1908,7 +1908,10 @@ describe("scripts/test-projects changed-target routing", () => {
       ],
       "scripts/plugin-clawhub-release-check.ts": ["test/scripts/release-wrapper-scripts.test.ts"],
       "scripts/plugin-clawhub-release-plan.ts": ["test/scripts/release-wrapper-scripts.test.ts"],
-      "scripts/plugin-npm-release-check.ts": ["test/scripts/release-wrapper-scripts.test.ts"],
+      "scripts/plugin-npm-release-check.ts": [
+        "test/e2e/qa-lab/plugins/clawhub-release-policy-contracts.e2e.test.ts",
+        "test/scripts/release-wrapper-scripts.test.ts",
+      ],
       "scripts/plugin-npm-release-plan.ts": ["test/scripts/release-wrapper-scripts.test.ts"],
       "scripts/plugin-release-pretag-pack-check.ts": [
         "test/scripts/plugin-release-pretag-pack-check.test.ts",


### PR DESCRIPTION
## What Problem This Solves

ClawHub package-release policy had no executable QA Lab owner for four release-critical contracts:

- `clawhub.package-release-validation`
- `clawhub.version-bump-gates`
- `clawhub.npm-trusted-publishing-provenance`
- `clawhub.external-code-plugin-package-contract-required`

That left identity, provenance, compatibility metadata, and version-bump regressions outside the coverage ledger.

## Why This Change Was Made

Adds one QA Lab scenario backed by a Vitest E2E fixture that creates temporary Git plugin packages and invokes the real `plugin-clawhub-release-check.ts` and `plugin-npm-release-check.ts` entrypoints through Node + tsx.

The test covers the canonical valid package, bad repository provenance, missing external-code compatibility/build metadata, an unchanged version after a committed source change, and the corresponding passing version bump. It does not change release scripts, workflows, package contracts, or production behavior.

## User Impact

No runtime behavior changes. Maintainers now get executable QA coverage if ClawHub or npm plugin release policy drifts across either release-check entrypoint.

## Evidence

- Focused resolver + E2E proof: `test-projects` 261/261 and ClawHub release policy 5/5 passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30854581152
- QA coverage: the scenario resolves all four exact coverage IDs.
- Mock-provider QA suite: scenario evidence passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30850897612
- `pnpm check:changed`: all policy guards, formatting, all-project typecheck, lint, and import-cycle checks passed on the final three-file diff: https://github.com/openclaw/openclaw/actions/runs/30854843166
- Sol/high autoreview: clean, no accepted or actionable findings. The post-review companion change only updates the mandatory changed-target expectation for the new E2E test.
- Diff accounting: 0 production lines; 235 test lines added, 1 test line removed, and 34 QA scenario lines added.

## Repair Notes

- Root cause: the release-policy contracts had no executable QA coverage owner.
- Owner boundary: QA Lab scenario metadata and its E2E test.
- Canonical fix: exercise both real release-check entrypoints from one temporary-Git fixture.
- Removed paths: none.
- Sibling coverage: both ClawHub and npm release validation are asserted where their contracts overlap.
- CI routing: release-check source changes now include this E2E fixture alongside the existing release-wrapper owner test.

## AI Assistance

Implementation, validation, and review were performed with Codex under maintainer direction.
