### PR TITLE
fix(googlechat): align doctor policy ownership with canonical account configuration

### DIFF
--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -55,7 +55,7 @@
       "systemImage": "message.badge",
       "markdownCapable": true,
       "doctorCapabilities": {
-        "dmAllowFromMode": "nestedOnly",
+        "dmAllowFromMode": "topOnly",
         "groupModel": "route",
         "groupAllowFromFallbackToAllowFrom": false,
         "warnOnEmptyGroupSenderAllowlist": false

--- a/extensions/googlechat/src/doctor-contract.test.ts
+++ b/extensions/googlechat/src/doctor-contract.test.ts
@@ -2,8 +2,88 @@
 import { describe, expect, it } from "vitest";
 import { resolveGoogleChatAccount } from "./accounts.js";
 import { legacyConfigRules, normalizeCompatibilityConfig } from "./doctor-contract.js";
+import { collectGoogleChatMutableAllowlistWarnings } from "./doctor.js";
 
 describe("googlechat doctor contract", () => {
+  it.each([
+    {
+      label: "root sender",
+      config: { allowFrom: ["alice@example.com"] },
+      expectedPath: "channels.googlechat.allowFrom: alice@example.com",
+    },
+    {
+      label: "named-account sender",
+      config: { accounts: { work: { allowFrom: ["bob@example.com"] } } },
+      expectedPath: "channels.googlechat.accounts.work.allowFrom: bob@example.com",
+    },
+    {
+      label: "space sender",
+      config: { groups: { "spaces/team": { users: ["carol@example.com"] } } },
+      expectedPath: "channels.googlechat.groups.spaces/team.users: carol@example.com",
+    },
+    {
+      label: "named-account dangerous-name override",
+      config: {
+        dangerouslyAllowNameMatching: true,
+        accounts: {
+          work: {
+            allowFrom: ["dave@example.com"],
+            dangerouslyAllowNameMatching: false,
+          },
+        },
+      },
+      expectedPath: "channels.googlechat.accounts.work.allowFrom: dave@example.com",
+    },
+  ])("warns for mutable $label allowlist entries", ({ config, expectedPath }) => {
+    const warnings = collectGoogleChatMutableAllowlistWarnings({
+      cfg: { channels: { googlechat: config } },
+    });
+
+    expect(warnings).toContain(`- ${expectedPath}`);
+  });
+
+  it.each([
+    {
+      label: "stable sender IDs",
+      config: {
+        allowFrom: ["users/123", "*"],
+        accounts: { work: { allowFrom: ["users/456"] } },
+      },
+    },
+    {
+      label: "explicit dangerous-name opt-in",
+      config: {
+        dangerouslyAllowNameMatching: true,
+        allowFrom: ["alice@example.com"],
+      },
+    },
+    {
+      label: "inherited dangerous-name opt-in",
+      config: {
+        dangerouslyAllowNameMatching: true,
+        accounts: { work: { allowFrom: ["bob@example.com"] } },
+      },
+    },
+  ])("does not warn for $label", ({ config }) => {
+    expect(
+      collectGoogleChatMutableAllowlistWarnings({
+        cfg: { channels: { googlechat: config } },
+      }),
+    ).toEqual([]);
+  });
+
+  it("does not inspect retired nested DM allowlists", () => {
+    expect(
+      collectGoogleChatMutableAllowlistWarnings({
+        cfg: {
+          channels: {
+            googlechat: { dm: { allowFrom: ["retired@example.com"] } },
+          },
+        } as never,
+      }),
+    ).toEqual([]);
+  });
+
   it("removes retired reaction flags", () => {
     const result = normalizeCompatibilityConfig({
       cfg: {

--- a/extensions/googlechat/src/doctor.ts
+++ b/extensions/googlechat/src/doctor.ts
@@ -16,8 +16,6 @@ export const collectGoogleChatMutableAllowlistWarnings =
     detector: isGoogleChatMutableAllowEntry,
     collectLists: (scope) =>
       collectStandardAllowlistLists(scope, {
-        includeAllowFrom: false,
-        includeDm: true,
         includeGroups: true,
         groupField: "users",
       }),

--- a/scripts/lib/official-external-channel-catalog.json
+++ b/scripts/lib/official-external-channel-catalog.json
@@ -673,7 +673,7 @@
           "systemImage": "message.badge",
           "markdownCapable": true,
           "doctorCapabilities": {
-            "dmAllowFromMode": "nestedOnly",
+            "dmAllowFromMode": "topOnly",
             "groupModel": "route",
             "groupAllowFromFallbackToAllowFrom": false,
             "warnOnEmptyGroupSenderAllowlist": false

--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -769,7 +769,7 @@ vi.mock("./doctor/shared/stale-oauth-profile-shadows.js", () => ({
 vi.mock("./doctor/channel-capabilities.js", () => {
   const byChannel = {
     googlechat: {
-      dmAllowFromMode: "nestedOnly",
+      dmAllowFromMode: "topOnly",
       groupModel: "route",
       groupAllowFromFallbackToAllowFrom: false,
       warnOnEmptyGroupSenderAllowlist: false,
@@ -3089,9 +3089,7 @@ describe("doctor config flow", () => {
           googlechat: {
             accounts: {
               work: {
-                dm: {
-                  policy: "open",
-                },
+                dmPolicy: "open",
               },
             },
           },
@@ -3106,11 +3104,9 @@ describe("doctor config flow", () => {
         googlechat: {
           accounts: {
             work: {
-              dm: {
-                policy: string;
-                allowFrom: string[];
-              };
-              allowFrom?: string[];
+              dmPolicy: string;
+              allowFrom: string[];
+              dm?: unknown;
             };
           };
         };
@@ -3118,8 +3114,9 @@ describe("doctor config flow", () => {
     };
     expect(cfg.channels.discord.allowFrom).toEqual(["*"]);
     expect(cfg.channels.discord.dmPolicy).toBe("open");
-    expect(cfg.channels.googlechat.accounts.work.dm.allowFrom).toEqual(["*"]);
-    expect(cfg.channels.googlechat.accounts.work.allowFrom).toBeUndefined();
+    expect(cfg.channels.googlechat.accounts.work.dmPolicy).toBe("open");
+    expect(cfg.channels.googlechat.accounts.work.allowFrom).toEqual(["*"]);
+    expect(cfg.channels.googlechat.accounts.work.dm).toBeUndefined();
   });
 
   it('repairs dmPolicy="allowlist" by restoring allowFrom from pairing store on repair', async () => {
@@ -3469,16 +3466,14 @@ describe("doctor config flow", () => {
     }
   });
 
-  it("recovers from stale googlechat top-level allowFrom by repairing dm.allowFrom", async () => {
+  it("preserves valid googlechat top-level DM policy and allowFrom", async () => {
     const result = await runDoctorConfigWithInput({
       repair: true,
       config: {
         channels: {
           googlechat: {
+            dmPolicy: "open",
             allowFrom: ["*"],
-            dm: {
-              policy: "open",
-            },
           },
         },
       },
@@ -3487,13 +3482,15 @@ describe("doctor config flow", () => {
     const cfg = result.cfg as {
       channels: {
         googlechat: {
-          dm: { allowFrom: string[] };
-          allowFrom?: string[];
+          dmPolicy: string;
+          allowFrom: string[];
+          dm?: unknown;
         };
       };
     };
-    expect(cfg.channels.googlechat.dm.allowFrom).toEqual(["*"]);
-    expect(cfg.channels.googlechat.allowFrom).toBeUndefined();
+    expect(cfg.channels.googlechat.dmPolicy).toBe("open");
+    expect(cfg.channels.googlechat.allowFrom).toEqual(["*"]);
+    expect(cfg.channels.googlechat.dm).toBeUndefined();
   });
 
   it("does not report repeat talk provider normalization on consecutive repair runs", async () => {

--- a/src/commands/doctor/channel-capabilities.test.ts
+++ b/src/commands/doctor/channel-capabilities.test.ts
@@ -1,5 +1,6 @@
 // Doctor channel capability tests cover channel capability inspection and diagnostics.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { collectChannelDmPolicyDependencyWarnings } from "../../config/validation-channel-rules.js";
 import {
   getDoctorChannelCapabilities,
   resolveDoctorChannelAccountIds,
@@ -24,13 +25,39 @@ describe("doctor channel capabilities", () => {
     channelPluginMocks.getChannelPlugin.mockReset().mockReturnValue(undefined);
   });
 
-  it("returns nested route semantics from googlechat plugin metadata", () => {
+  it("returns canonical top-level route semantics from googlechat plugin metadata", () => {
     expect(getDoctorChannelCapabilities("googlechat")).toEqual({
-      dmAllowFromMode: "nestedOnly",
+      dmAllowFromMode: "topOnly",
       groupModel: "route",
       groupAllowFromFallbackToAllowFrom: false,
       warnOnEmptyGroupSenderAllowlist: false,
     });
+  });
+
+  it("retains root and account Google Chat DM-policy safety warnings", () => {
+    const dmAllowFromMode = getDoctorChannelCapabilities("googlechat").dmAllowFromMode;
+    const warnings = collectChannelDmPolicyDependencyWarnings(
+      {
+        channels: {
+          googlechat: {
+            dmPolicy: "open",
+            allowFrom: ["users/123"],
+            accounts: {
+              work: {
+                dmPolicy: "open",
+                allowFrom: ["users/456"],
+              },
+            },
+          },
+        },
+      },
+      { dmAllowFromModes: new Map([["googlechat", dmAllowFromMode]]) },
+    );
+
+    expect(warnings.map(({ path }) => path)).toEqual([
+      "channels.googlechat.allowFrom",
+      "channels.googlechat.accounts.work.allowFrom",
+    ]);
   });
 
   it("returns Slack route semantics without loading its channel plugin", () => {

--- a/src/commands/doctor/shared/open-policy-allowfrom.test.ts
+++ b/src/commands/doctor/shared/open-policy-allowfrom.test.ts
@@ -58,7 +58,7 @@ describe("doctor open-policy allowFrom repair", () => {
     expect(GoogleChatConfigSchema.safeParse(result.config.channels?.googlechat).success).toBe(true);
   });
 
-  it.each([
+  it.each<{ label: string; config: GoogleChatConfig }>([
     {
       label: "root",
       config: { dmPolicy: "open", allowFrom: ["*"] },
@@ -83,20 +83,15 @@ describe("doctor open-policy allowFrom repair", () => {
         accounts: { work: { dmPolicy: "open", allowFrom: ["*"] } },
       },
     },
-  ] satisfies Array<{ label: string; config: GoogleChatConfig }>)(
-    "preserves schema-valid googlechat $label DM access",
-    ({ config }) => {
-      expect(GoogleChatConfigSchema.safeParse(config).success).toBe(true);
+  ])("preserves schema-valid googlechat $label DM access", ({ config }) => {
+    expect(GoogleChatConfigSchema.safeParse(config).success).toBe(true);
 
-      const result = maybeRepairOpenPolicyAllowFrom({ channels: { googlechat: config } });
+    const result = maybeRepairOpenPolicyAllowFrom({ channels: { googlechat: config } });
 
-      expect(result.changes).toEqual([]);
-      expect(result.config.channels?.googlechat).toEqual(config);
-      expect(GoogleChatConfigSchema.safeParse(result.config.channels?.googlechat).success).toBe(
-        true,
-      );
-    },
-  );
+    expect(result.changes).toEqual([]);
+    expect(result.config.channels?.googlechat).toEqual(config);
+    expect(GoogleChatConfigSchema.safeParse(result.config.channels?.googlechat).success).toBe(true);
+  });
 
   it("repairs nested-only matrix dm allowFrom", () => {
     const result = maybeRepairOpenPolicyAllowFrom({

--- a/src/commands/doctor/shared/open-policy-allowfrom.test.ts
+++ b/src/commands/doctor/shared/open-policy-allowfrom.test.ts
@@ -1,19 +1,12 @@
 // Open policy allow-from tests cover doctor handling of open allowlist policy.
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
+import type { GoogleChatConfig } from "../../../config/types.googlechat.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { GoogleChatConfigSchema } from "../../../config/zod-schema.providers-googlechat.js";
 import {
   collectOpenPolicyAllowFromWarnings,
   maybeRepairOpenPolicyAllowFrom,
 } from "./open-policy-allowfrom.js";
-
-vi.mock("../channel-capabilities.js", () => ({
-  getDoctorChannelCapabilities: (channelName?: string) => ({
-    dmAllowFromMode: channelName === "matrix" ? "nestedOnly" : "topOnly",
-    groupModel: "sender",
-    groupAllowFromFallbackToAllowFrom: true,
-    warnOnEmptyGroupSenderAllowlist: true,
-  }),
-}));
 
 describe("doctor open-policy allowFrom repair", () => {
   it('adds top-level wildcard when dmPolicy="open" has no allowFrom', () => {
@@ -44,7 +37,66 @@ describe("doctor open-policy allowFrom repair", () => {
       '- channels.googlechat.allowFrom: set to ["*"] (required by dmPolicy="open")',
     ]);
     expect(result.config.channels?.googlechat?.allowFrom).toEqual(["*"]);
+    expect(GoogleChatConfigSchema.safeParse(result.config.channels?.googlechat).success).toBe(true);
   });
+
+  it("repairs a named googlechat account with canonical top-level allowFrom", () => {
+    const result = maybeRepairOpenPolicyAllowFrom({
+      channels: {
+        googlechat: {
+          accounts: {
+            work: { dmPolicy: "open" },
+          },
+        },
+      },
+    });
+
+    expect(result.config.channels?.googlechat?.accounts?.work).toEqual({
+      dmPolicy: "open",
+      allowFrom: ["*"],
+    });
+    expect(GoogleChatConfigSchema.safeParse(result.config.channels?.googlechat).success).toBe(true);
+  });
+
+  it.each([
+    {
+      label: "root",
+      config: { dmPolicy: "open", allowFrom: ["*"] },
+    },
+    {
+      label: "root inherited by a named account",
+      config: { dmPolicy: "open", allowFrom: ["*"], accounts: { work: {} } },
+    },
+    {
+      label: "named account",
+      config: { accounts: { work: { dmPolicy: "open", allowFrom: ["*"] } } },
+    },
+    {
+      label: "default account",
+      config: { accounts: { default: { dmPolicy: "open", allowFrom: ["*"] } } },
+    },
+    {
+      label: "root and named override",
+      config: {
+        dmPolicy: "open",
+        allowFrom: ["*"],
+        accounts: { work: { dmPolicy: "open", allowFrom: ["*"] } },
+      },
+    },
+  ] satisfies Array<{ label: string; config: GoogleChatConfig }>)(
+    "preserves schema-valid googlechat $label DM access",
+    ({ config }) => {
+      expect(GoogleChatConfigSchema.safeParse(config).success).toBe(true);
+
+      const result = maybeRepairOpenPolicyAllowFrom({ channels: { googlechat: config } });
+
+      expect(result.changes).toEqual([]);
+      expect(result.config.channels?.googlechat).toEqual(config);
+      expect(GoogleChatConfigSchema.safeParse(result.config.channels?.googlechat).success).toBe(
+        true,
+      );
+    },
+  );
 
   it("repairs nested-only matrix dm allowFrom", () => {
     const result = maybeRepairOpenPolicyAllowFrom({


### PR DESCRIPTION
## Summary
- Align the Google Chat plugin's discovery metadata with its actual top-level direct-message policy and strict account schema.
- Stop `openclaw doctor --fix` from converting valid root/default/named account settings into rejected legacy nested configuration.
- Restore canonical root and named-account mutable-identity warnings while preserving supported group warnings and explicit dangerous-name opt-ins.

## Reproduction and verification
- The real doctor previously converted each of five schema-valid account configurations into invalid settings; valid configurations now remain unchanged, while missing open-policy wildcards are repaired in the canonical location.
- Real bundled-manifest discovery and full plugin-aware config validation now expose both root and named-account security warnings.
- Genuine plugin-owner collector coverage verifies root, named, inherited, overridden, retired, stable-ID, and group cases.
- Four focused owner/integration suites: 97 passing tests.
- Affected shipped versions: `v2026.7.2-beta.4` through `beta.7` and current main; stable `v2026.7.1` and earlier beta releases are unaffected.
- Independent formal review: zero P0/P1 findings; confidence 0.94.
- Production code decreases by two lines; no new compatibility fallback, configuration key, cache behavior, or core production code.