### PR TITLE
test(qa): prove packaged plugin lifecycle transitions

### DIFF
--- a/qa/scenarios/plugins/plugin-lifecycle-probe.yaml
+++ b/qa/scenarios/plugins/plugin-lifecycle-probe.yaml
@@ -4,16 +4,23 @@ scenario:
   id: plugin-lifecycle-probe
   surface: plugins
   coverage:
+    primary:
+      - plugins.activation-runtime
+      - plugins.docker-lifecycle-suites
+      - plugins.enable-and-disable-lifecycle
+      - plugins.lifecycle-package-update
+      - plugins.lifecycle-update-run
+      - plugins.smoke-tests-lifecycle
     secondary:
       - cli.plugin-validation-and-repair
       - plugins.plugin-setup
-      - plugins.smoke-tests-lifecycle
   objective: Exercise packaged plugin install, inspect, disable, enable, update, downgrade, and uninstall behavior in a clean Docker runtime.
   successCriteria:
     - A clean container installs the candidate OpenClaw package and fixture plugin package.
-    - Runtime inspect reports the installed plugin as enabled and loaded.
-    - Disable and enable commands persist the expected plugin state.
-    - Update and downgrade commands replace the installed plugin version while preserving the npm project root.
+    - Runtime inspect reports the installed plugin as enabled and loaded after install.
+    - Disable persists the disabled state and runtime inspect reports disabled; re-enable persists the enabled state and runtime inspect reports loaded.
+    - Upgrade and downgrade update commands both complete successfully.
+    - After each update, the SQLite install record and installed package.json match the requested version, the npm project root is canonical, and runtime inspect reports loaded.
     - Forced uninstall succeeds after installed plugin code is removed and emits a bounded resource summary.
   docsRefs:
     - docs/plugins/manifest.md

--- a/test/e2e/qa-lab/plugins/plugin-lifecycle-probe-runtime.ts
+++ b/test/e2e/qa-lab/plugins/plugin-lifecycle-probe-runtime.ts
@@ -142,7 +142,11 @@ function assertNpmProjectRoot(pluginId: string, packageName: string, env: ProbeE
   );
 }
 
-export function assertInspectLoaded(pluginId: string, inspectPath: string | undefined) {
+function assertInspectState(
+  pluginId: string,
+  inspectPath: string | undefined,
+  expected: { enabled: boolean; status: "disabled" | "loaded" },
+) {
   assertProbe(inspectPath, "inspect JSON path is required");
   const inspect = readRequiredJson(inspectPath);
   const plugin = inspect.plugin as
@@ -153,11 +157,22 @@ export function assertInspectLoaded(pluginId: string, inspectPath: string | unde
     plugin?.id === pluginId,
     `expected inspected plugin id ${pluginId}, got ${plugin?.id}`,
   );
-  assertProbe(plugin.enabled === true, `expected ${pluginId} inspect enabled=true`);
   assertProbe(
-    plugin.status === "loaded",
-    `expected ${pluginId} inspect status loaded, got ${plugin.status}`,
+    plugin.enabled === expected.enabled,
+    `expected ${pluginId} inspect enabled=${expected.enabled}`,
   );
+  assertProbe(
+    plugin.status === expected.status,
+    `expected ${pluginId} inspect status ${expected.status}, got ${plugin.status}`,
+  );
+}
+
+export function assertInspectLoaded(pluginId: string, inspectPath: string | undefined) {
+  assertInspectState(pluginId, inspectPath, { enabled: true, status: "loaded" });
+}
+
+export function assertInspectDisabled(pluginId: string, inspectPath: string | undefined) {
+  assertInspectState(pluginId, inspectPath, { enabled: false, status: "disabled" });
 }
 
 function assertEnabled(pluginId: string, expected: boolean, env: ProbeEnv = process.env) {
@@ -493,6 +508,30 @@ async function runMeasured(
   );
 }
 
+async function runRuntimeInspect(params: {
+  summaryTsv: string;
+  phase: string;
+  entry: string;
+  pluginId: string;
+  inspectPath: string;
+  env: MatrixEnv;
+}) {
+  await runMeasured(
+    params.summaryTsv,
+    params.phase,
+    "bash",
+    [
+      "-c",
+      'node "$1" plugins inspect "$2" --runtime --json >"$3"',
+      "bash",
+      params.entry,
+      params.pluginId,
+      params.inspectPath,
+    ],
+    params.env,
+  );
+}
+
 async function runPluginLifecycleMatrix() {
   const pluginId = "lifecycle-claw";
   const packageName = "@openclaw/lifecycle-claw";
@@ -502,6 +541,10 @@ async function runPluginLifecycleMatrix() {
   const tarballV1 = path.join(resourceDir, "lifecycle-claw-1.0.0.tgz");
   const tarballV2 = path.join(resourceDir, "lifecycle-claw-2.0.0.tgz");
   const inspectV1 = path.join(resourceDir, "plugin-lifecycle-inspect-v1.json");
+  const inspectDisabled = path.join(resourceDir, "plugin-lifecycle-inspect-disabled.json");
+  const inspectReenabled = path.join(resourceDir, "plugin-lifecycle-inspect-reenabled.json");
+  const inspectV2 = path.join(resourceDir, "plugin-lifecycle-inspect-v2.json");
+  const inspectDowngradeV1 = path.join(resourceDir, "plugin-lifecycle-inspect-downgrade-v1.json");
   const summaryTsv = path.join(resourceDir, "resource-summary.tsv");
   let registry: RegistryServer | undefined;
 
@@ -560,20 +603,14 @@ async function runPluginLifecycleMatrix() {
     assertVersion(pluginId, "1.0.0", runEnv);
     assertNpmProjectRoot(pluginId, packageName, runEnv);
 
-    await runMeasured(
+    await runRuntimeInspect({
       summaryTsv,
-      "inspect-v1",
-      "bash",
-      [
-        "-c",
-        'node "$1" plugins inspect "$2" --runtime --json >"$3"',
-        "bash",
-        entry,
-        pluginId,
-        inspectV1,
-      ],
-      runEnv,
-    );
+      phase: "inspect-v1",
+      entry,
+      pluginId,
+      inspectPath: inspectV1,
+      env: runEnv,
+    });
     assertInspectLoaded(pluginId, inspectV1);
 
     await runMeasured(
@@ -584,9 +621,27 @@ async function runPluginLifecycleMatrix() {
       runEnv,
     );
     assertEnabled(pluginId, false, runEnv);
+    await runRuntimeInspect({
+      summaryTsv,
+      phase: "inspect-disabled",
+      entry,
+      pluginId,
+      inspectPath: inspectDisabled,
+      env: runEnv,
+    });
+    assertInspectDisabled(pluginId, inspectDisabled);
 
     await runMeasured(summaryTsv, "enable", "node", [entry, "plugins", "enable", pluginId], runEnv);
     assertEnabled(pluginId, true, runEnv);
+    await runRuntimeInspect({
+      summaryTsv,
+      phase: "inspect-reenabled",
+      entry,
+      pluginId,
+      inspectPath: inspectReenabled,
+      env: runEnv,
+    });
+    assertInspectLoaded(pluginId, inspectReenabled);
 
     await runMeasured(
       summaryTsv,
@@ -597,6 +652,15 @@ async function runPluginLifecycleMatrix() {
     );
     assertVersion(pluginId, "2.0.0", runEnv);
     assertNpmProjectRoot(pluginId, packageName, runEnv);
+    await runRuntimeInspect({
+      summaryTsv,
+      phase: "inspect-v2",
+      entry,
+      pluginId,
+      inspectPath: inspectV2,
+      env: runEnv,
+    });
+    assertInspectLoaded(pluginId, inspectV2);
 
     await runMeasured(
       summaryTsv,
@@ -607,6 +671,15 @@ async function runPluginLifecycleMatrix() {
     );
     assertVersion(pluginId, "1.0.0", runEnv);
     assertNpmProjectRoot(pluginId, packageName, runEnv);
+    await runRuntimeInspect({
+      summaryTsv,
+      phase: "inspect-downgrade-v1",
+      entry,
+      pluginId,
+      inspectPath: inspectDowngradeV1,
+      env: runEnv,
+    });
+    assertInspectLoaded(pluginId, inspectDowngradeV1);
 
     const installedPath = installPath(pluginId, runEnv);
     fs.rmSync(installedPath, { recursive: true, force: true });

--- a/test/e2e/qa-lab/plugins/plugin-lifecycle-probe.e2e.test.ts
+++ b/test/e2e/qa-lab/plugins/plugin-lifecycle-probe.e2e.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveWindowsTaskkillPath } from "../../../../scripts/lib/windows-taskkill.mjs";
 import { createTempDirTracker } from "../../../helpers/temp-dir.js";
 import {
+  assertInspectDisabled,
   assertInspectLoaded,
   assertUninstalled,
   parseDurationMs,
@@ -73,6 +74,32 @@ describe("plugin lifecycle matrix probe", () => {
     );
 
     expect(() => assertInspectLoaded("lifecycle-claw", inspectPath)).not.toThrow();
+  });
+
+  it("accepts inspect JSON for a disabled plugin", async () => {
+    const dir = makeTempDir();
+    const inspectPath = path.join(dir, "inspect.json");
+    writeFileSync(
+      inspectPath,
+      `${JSON.stringify({ plugin: { enabled: false, id: "lifecycle-claw", status: "disabled" } })}\n`,
+      "utf8",
+    );
+
+    expect(() => assertInspectDisabled("lifecycle-claw", inspectPath)).not.toThrow();
+  });
+
+  it("rejects disabled inspect JSON that still reports a loaded plugin", async () => {
+    const dir = makeTempDir();
+    const inspectPath = path.join(dir, "inspect.json");
+    writeFileSync(
+      inspectPath,
+      `${JSON.stringify({ plugin: { enabled: false, id: "lifecycle-claw", status: "loaded" } })}\n`,
+      "utf8",
+    );
+
+    expect(() => assertInspectDisabled("lifecycle-claw", inspectPath)).toThrow(
+      "expected lifecycle-claw inspect status disabled, got loaded",
+    );
   });
 
   it("rejects inspect JSON that does not prove the runtime loaded", async () => {


### PR DESCRIPTION
## What Problem This Solves

The packaged plugin lifecycle scenario did not prove runtime state after every lifecycle transition, and six plugin lifecycle coverage IDs had no primary owner.

## Why This Change Was Made

The existing Docker matrix now inspects runtime state after install, disable, re-enable, upgrade, and downgrade. Update proof separately verifies successful command execution and the resulting SQLite install record, installed package version, canonical managed npm root, and loaded runtime state.

The scenario primarily covers:

- `plugins.activation-runtime`
- `plugins.docker-lifecycle-suites`
- `plugins.enable-and-disable-lifecycle`
- `plugins.lifecycle-package-update`
- `plugins.lifecycle-update-run`
- `plugins.smoke-tests-lifecycle`

CLI repair and setup coverage remains secondary. Failed-update rollback policy is intentionally out of scope.

## User Impact

No production behavior changes. Maintainers get stronger packaged regression proof for plugin activation, enable/disable, update, downgrade, and uninstall behavior.

## Evidence

- `node scripts/run-vitest.mjs test/e2e/qa-lab/plugins/plugin-lifecycle-probe.e2e.test.ts` - 10/10 passed
- `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build` - passed on retained Blacksmith Testbox
- `OPENCLAW_QA_REF=db58fac4af7441201086ca089caf2a67b4b1b53d pnpm openclaw qa suite --scenario plugin-lifecycle-probe --output-dir .artifacts/qa-e2e/plugin-lifecycle-probe-exact-head` - 1/1 passed; all six IDs recorded as primary
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 pnpm check:changed` - passed all lanes on the same retained Testbox
- Sol/high branch autoreview - clean, no actionable findings; correctness 0.99
- Production LOC delta: 0
