### PR TITLE
fix(signal): drain accepted websocket messages before shutdown

### DIFF
--- a/extensions/signal/src/client-container.test.ts
+++ b/extensions/signal/src/client-container.test.ts
@@ -216,9 +216,17 @@ function delayedBodyStream(
   };
 }
 const wsMockState = vi.hoisted(() => ({
-  behavior: "close" as "close" | "open" | "error" | "message" | "unexpected-response",
+  behavior: "close" as
+    | "close"
+    | "open"
+    | "error"
+    | "message"
+    | "buffered-message"
+    | "pending"
+    | "unexpected-response",
   urls: [] as string[],
   options: [] as Array<{ maxPayload?: number; handshakeTimeout?: number } | undefined>,
+  terminations: 0,
 }));
 
 beforeEach(() => {
@@ -226,6 +234,7 @@ beforeEach(() => {
   wsMockState.behavior = "close";
   wsMockState.urls = [];
   wsMockState.options = [];
+  wsMockState.terminations = 0;
 });
 
 function requireFetchCall(index = 0): [RequestInfo | URL, RequestInit] {
@@ -266,6 +275,7 @@ function expectMockLogNotContains(mock: ReturnType<typeof vi.fn>, expected: stri
 vi.mock("ws", () => ({
   default: class MockWebSocket {
     private handlers = new Map<string, Array<(...args: unknown[]) => void>>();
+    private bufferedMessageFlushed = false;
 
     constructor(url: string | URL, options?: { maxPayload?: number; handshakeTimeout?: number }) {
       wsMockState.urls.push(String(url));
@@ -281,6 +291,11 @@ vi.mock("ws", () => ({
         } else if (wsMockState.behavior === "message") {
           this.emit("message", Buffer.from('{"envelope":{"timestamp":1}}'));
           this.emit("close", 1000, Buffer.from("done"));
+        } else if (wsMockState.behavior === "buffered-message") {
+          this.emit("open");
+          this.emit("message", Buffer.from('{"envelope":{"timestamp":1}}'));
+        } else if (wsMockState.behavior === "pending") {
+          // Keep the opening handshake unresolved until shutdown closes it.
         } else {
           this.emit("close", 1000, Buffer.from("done"));
         }
@@ -306,10 +321,17 @@ vi.mock("ws", () => ({
     }
 
     close() {
+      if (wsMockState.behavior === "buffered-message" && !this.bufferedMessageFlushed) {
+        this.bufferedMessageFlushed = true;
+        // ws flushes already-buffered receiver frames before its final close event.
+        this.emit("message", Buffer.from('{"envelope":{"timestamp":2}}'));
+      }
       this.emit("close", 1000, Buffer.from("done"));
     }
 
-    terminate() {}
+    terminate() {
+      wsMockState.terminations += 1;
+    }
 
     private emit(event: string, ...args: unknown[]) {
       for (const handler of this.handlers.get(event) ?? []) {
@@ -1623,6 +1645,146 @@ describe("streamContainerEvents", () => {
     const abortHandler = addEventListener.mock.calls.find((call) => call[0] === "abort")?.[1];
     expect(abortHandler).toBeTypeOf("function");
     expect(removeEventListener).toHaveBeenCalledWith("abort", abortHandler);
+  });
+
+  it("drains accepted and socket-buffered receive events before resolving shutdown", async () => {
+    wsMockState.behavior = "buffered-message";
+    const abort = new AbortController();
+    const removeEventListener = vi.spyOn(abort.signal, "removeEventListener");
+    let releaseFirst!: () => void;
+    const firstDelivery = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let markFirstStarted!: () => void;
+    const firstStarted = new Promise<void>((resolve) => {
+      markFirstStarted = resolve;
+    });
+    const timestamps: number[] = [];
+    const stream = streamContainerEvents({
+      baseUrl: "http://localhost:8080",
+      abortSignal: abort.signal,
+      timeoutMs: 0,
+      onEvent: async (event) => {
+        timestamps.push(event.envelope?.timestamp ?? 0);
+        if (timestamps.length === 1) {
+          markFirstStarted();
+          await firstDelivery;
+        }
+      },
+    });
+    let settled = false;
+    void stream.then(() => {
+      settled = true;
+    });
+
+    await firstStarted;
+    abort.abort();
+    const settledBeforeDrain = await Promise.race([
+      stream.then(() => true),
+      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 10)),
+    ]);
+    expect(settledBeforeDrain).toBe(false);
+    expect(settled).toBe(false);
+
+    releaseFirst();
+    await expect(stream).resolves.toBeUndefined();
+    expect(timestamps).toEqual([1, 2]);
+    expect(removeEventListener).toHaveBeenCalledWith("abort", expect.any(Function));
+    expect(wsMockState.terminations).toBe(0);
+  });
+
+  it("propagates a receive-handler failure that settles during shutdown", async () => {
+    wsMockState.behavior = "buffered-message";
+    const abort = new AbortController();
+    const appendError = new Error("durable append failed during shutdown");
+    let rejectDelivery!: (error: Error) => void;
+    const delivery = new Promise<void>((_resolve, reject) => {
+      rejectDelivery = reject;
+    });
+    let markFirstStarted!: () => void;
+    const firstStarted = new Promise<void>((resolve) => {
+      markFirstStarted = resolve;
+    });
+    const stream = streamContainerEvents({
+      baseUrl: "http://localhost:8080",
+      abortSignal: abort.signal,
+      onEvent: async () => {
+        markFirstStarted();
+        await delivery;
+      },
+    });
+
+    await firstStarted;
+    abort.abort();
+    rejectDelivery(appendError);
+    await expect(stream).rejects.toBe(appendError);
+    expect(wsMockState.terminations).toBe(0);
+  });
+
+  it("bounds a stalled shutdown drain and records the accepted-message loss risk", async () => {
+    vi.useFakeTimers();
+    try {
+      wsMockState.behavior = "buffered-message";
+      const abort = new AbortController();
+      const error = vi.fn();
+      let settled = false;
+      const stream = streamContainerEvents({
+        baseUrl: "http://localhost:8080",
+        abortSignal: abort.signal,
+        timeoutMs: 0,
+        onEvent: async () => await new Promise<void>(() => {}),
+        logger: { error },
+      }).then(() => {
+        settled = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+      abort.abort();
+      await vi.advanceTimersByTimeAsync(1_499);
+      expect(settled).toBe(false);
+      expect(error).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(stream).resolves.toBeUndefined();
+      expect(error).toHaveBeenCalledWith(expect.stringMatching(/receive events.*may be lost/i));
+      expect(wsMockState.terminations).toBe(1);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("closes immediately when aborted before the opening handshake completes", async () => {
+    wsMockState.behavior = "pending";
+    const abort = new AbortController();
+    const removeEventListener = vi.spyOn(abort.signal, "removeEventListener");
+    const stream = streamContainerEvents({
+      baseUrl: "http://localhost:8080",
+      abortSignal: abort.signal,
+      onEvent: vi.fn(),
+    });
+
+    abort.abort();
+    await expect(stream).resolves.toBeUndefined();
+    expect(removeEventListener).toHaveBeenCalledWith("abort", expect.any(Function));
+    expect(wsMockState.terminations).toBe(0);
+  });
+
+  it("handles an already-aborted signal without leaving its connection pending", async () => {
+    wsMockState.behavior = "pending";
+    const abort = new AbortController();
+    abort.abort();
+    const result = await Promise.race([
+      streamContainerEvents({
+        baseUrl: "http://localhost:8080",
+        abortSignal: abort.signal,
+        onEvent: vi.fn(),
+      }).then(() => "closed"),
+      new Promise<string>((resolve) => setTimeout(() => resolve("still pending"), 25)),
+    ]);
+
+    expect(result).toBe("closed");
+    expect(wsMockState.terminations).toBe(0);
   });
 
   it("propagates receive-handler failures to the stream", async () => {

--- a/extensions/signal/src/client-container.test.ts
+++ b/extensions/signal/src/client-container.test.ts
@@ -1681,7 +1681,9 @@ describe("streamContainerEvents", () => {
     abort.abort();
     const settledBeforeDrain = await Promise.race([
       stream.then(() => true),
-      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 10)),
+      new Promise<boolean>((resolve) => {
+        setTimeout(() => resolve(false), 10);
+      }),
     ]);
     expect(settledBeforeDrain).toBe(false);
     expect(settled).toBe(false);
@@ -1780,7 +1782,9 @@ describe("streamContainerEvents", () => {
         abortSignal: abort.signal,
         onEvent: vi.fn(),
       }).then(() => "closed"),
-      new Promise<string>((resolve) => setTimeout(() => resolve("still pending"), 25)),
+      new Promise<string>((resolve) => {
+        setTimeout(() => resolve("still pending"), 25);
+      }),
     ]);
 
     expect(result).toBe("closed");

--- a/extensions/signal/src/client-container.ts
+++ b/extensions/signal/src/client-container.ts
@@ -63,6 +63,7 @@ const SIGNAL_REST_SUCCESS_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
 // Receive envelopes contain metadata only; cap frames, and do not let upgrades block reconnect.
 const WS_MAX_PAYLOAD = 1024 * 1024;
 const WS_HANDSHAKE_MS = 30_000;
+const WS_SHUTDOWN_DRAIN_TIMEOUT_MS = 1_500;
 // Outbound file paths are converted to base64 before posting to the container. Cap
 // reads to the same default the native signal send path uses (8 MiB) so a path to a
 // huge or symlinked file cannot OOM the gateway before encoding.
@@ -445,8 +446,13 @@ export async function streamContainerEvents(params: {
     let settled = false;
     let eventChain = Promise.resolve();
     let abortHandler: (() => void) | undefined;
+    let shutdownDrainTimer: ReturnType<typeof setTimeout> | undefined;
 
     const cleanup = () => {
+      if (shutdownDrainTimer) {
+        clearTimeout(shutdownDrainTimer);
+        shutdownDrainTimer = undefined;
+      }
       if (abortHandler) {
         params.abortSignal?.removeEventListener("abort", abortHandler);
         abortHandler = undefined;
@@ -532,10 +538,22 @@ export async function streamContainerEvents(params: {
     if (params.abortSignal) {
       abortHandler = () => {
         log("[signal-ws] aborted, closing connection");
+        // Arm before close: ws can synchronously flush buffered messages and emit
+        // close, whose final eventChain owns every accepted durable admission.
+        shutdownDrainTimer = setTimeout(() => {
+          logError(
+            "[signal-ws] shutdown timed out draining accepted receive events; messages may be lost",
+          );
+          ws.terminate();
+          resolveOnce();
+        }, WS_SHUTDOWN_DRAIN_TIMEOUT_MS);
+        shutdownDrainTimer.unref?.();
         ws.close();
-        resolveOnce();
       };
       params.abortSignal.addEventListener("abort", abortHandler, { once: true });
+      if (params.abortSignal.aborted) {
+        abortHandler();
+      }
     }
   });
 }


### PR DESCRIPTION
## Summary
- Keep Signal's existing WebSocket-close event-chain draining behavior when shutdown is initiated through an AbortSignal.
- Allow already received messages to enter durable SQLite ingress before stopping the account.
- Bound shutdown with a fixed, unrefed 1.5-second grace period; explicitly log potential message loss and terminate if an existing handler cannot complete.

## Real behavior proof
- A real localhost Signal-compatible WebSocket and the production ingress monitor delivered two unique events before abort. Before this fix only one reached SQLite; after the fix both events dispatch and reach completed durable state.
- 84 complete container owner tests and 124 container/client/ingress sibling tests pass, including buffered close frames, handler failures, pre-aborted connections, synchronous close events, and the exact grace-timeout boundary.
- Direct installed `ws` source confirms buffered frames are delivered before the final close event; the official REST adapter consumes received messages without acknowledgment or replay.

## Independent review adjudication
- Two independent manual reviews report zero actionable P0/P1 findings.
- The single formal review suggested that aborting during the opening handshake would reject the stream. This was independently disproved with the actual installed `ws` implementation, a real delayed-upgrade localhost server, the production stream, and the full reconnect caller:

```json
{"rawWsEventOrder":["error:WebSocket was closed before the connection was established","close:1006"],"productionResults":[{"mode":"already-aborted","outcome":"resolved","removedAbortListeners":1},{"mode":"immediate-abort","outcome":"resolved","removedAbortListeners":1},{"mode":"during-handshake","outcome":"resolved","removedAbortListeners":1}],"reconnectMessages":[],"recoveringStatuses":0}
```

The existing production socket error handler only logs; the subsequent close resolves the final event chain. No connection failure or retry occurs.

## Inspectable actual WebSocket and SQLite durable-ingress proof

The before/after run uses an actual loopback WebSocket server, production `streamContainerEvents`, the real Signal ingress monitor, and real per-account SQLite. The first write is briefly blocked to represent ordinary storage contention; sender identities are synthetic.

```json
{"phase":"before","framesDeliveredByServer":2,"callbacks":2,"dispatches":0,"persistedPending":1,"persistedIds":["[\"number:+15550001111\",1700000000001]"],"handlerFailures":1}
{"phase":"after","framesDeliveredByServer":2,"dispatches":[1700000000001,1700000000002],"durable":[{"timestamp":1700000000001,"status":"completed"},{"timestamp":1700000000002,"status":"completed"}],"handlerFailures":0}
```

Independent real opening-handshake cancellation controls using the actual installed WebSocket implementation confirm no connection-failure or reconnect regression:

```json
{"mode":"already-aborted","outcome":"resolved","errorCount":1,"closed":true}
{"mode":"during-handshake","outcome":"resolved","errorCount":1,"closed":true}
{"runtime":"actual runSignalSseLoop","outcome":"resolved","connections":1,"reconnectMessages":[],"recoveringStatuses":0}
```

The single socket error is the existing expected cancellation diagnostic; production error handling logs it and the subsequent close resolves normally. Full owner suite: 84 tests; client/adapter/native-ingress siblings: 124 tests.