### PR TITLE
fix(macos): restore dashboard frame double-click zoom

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -32171,7 +32171,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 898,
+      "line": 888,
       "path": "apps/macos/Sources/OpenClaw/DashboardWindowController.swift",
       "source": "[\\(host)]",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -24,16 +24,6 @@ private final class DashboardWindow: NSWindow {
     }
 }
 
-private final class DashboardWindowDragRegionView: NSView {
-    override var mouseDownCanMoveWindow: Bool {
-        true
-    }
-
-    override func mouseDown(with event: NSEvent) {
-        window?.performDrag(with: event)
-    }
-}
-
 private final class DashboardLinkSplitView: NSSplitView {
     var onDividerDragEnded: (() -> Void)?
 
@@ -597,7 +587,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         else {
             return
         }
-        window.performDrag(with: event)
+        DashboardWindowDragGesture.handle(event, in: window)
     }
 
     static func isWindowDragRequest(_ body: Any) -> Bool {

--- a/apps/macos/Sources/OpenClaw/DashboardWindowDragRegionView.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowDragRegionView.swift
@@ -1,0 +1,25 @@
+import AppKit
+
+enum DashboardWindowDragGesture {
+    @MainActor
+    static func handle(_ event: NSEvent, in window: NSWindow) {
+        // These custom surfaces replace AppKit's titlebar hit region. Preserve
+        // its maximize gesture instead of consuming the second click as a drag.
+        if event.type == .leftMouseDown, event.clickCount == 2 {
+            window.performZoom(nil)
+            return
+        }
+        window.performDrag(with: event)
+    }
+}
+
+final class DashboardWindowDragRegionView: NSView {
+    override var mouseDownCanMoveWindow: Bool {
+        true
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        guard let window else { return }
+        DashboardWindowDragGesture.handle(event, in: window)
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -41,9 +41,55 @@ private final class DashboardBrowserImportGate {
     }
 }
 
+private final class DashboardWindowGestureSpy: NSWindow {
+    private(set) var dragCount = 0
+    private(set) var zoomCount = 0
+
+    override func performDrag(with _: NSEvent) {
+        self.dragCount += 1
+    }
+
+    override func performZoom(_: Any?) {
+        self.zoomCount += 1
+    }
+}
+
 @Suite(.serialized)
 @MainActor
 struct DashboardWindowSmokeTests {
+    @Test func `dashboard frame routes single click to drag and double click to zoom`() throws {
+        let window = DashboardWindowGestureSpy(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
+            styleMask: [.titled, .resizable],
+            backing: .buffered,
+            defer: false)
+        let dragRegion = DashboardWindowDragRegionView(
+            frame: NSRect(x: 0, y: 0, width: 300, height: 12))
+        window.contentView = dragRegion
+        let mouseDownEvent: (Int) -> NSEvent? = { clickCount in
+            NSEvent.mouseEvent(
+                with: .leftMouseDown,
+                location: NSPoint(x: 100, y: 6),
+                modifierFlags: [],
+                timestamp: 0,
+                windowNumber: window.windowNumber,
+                context: nil,
+                eventNumber: clickCount,
+                clickCount: clickCount,
+                pressure: 1)
+        }
+
+        dragRegion.mouseDown(with: try #require(mouseDownEvent(1)))
+
+        #expect(window.dragCount == 1)
+        #expect(window.zoomCount == 0)
+
+        dragRegion.mouseDown(with: try #require(mouseDownEvent(2)))
+
+        #expect(window.dragCount == 1)
+        #expect(window.zoomCount == 1)
+    }
+
     @Test func `dashboard window controller shows and closes`() throws {
         let url = try #require(URL(string: "http://127.0.0.1:18789/control/#token=device-token"))
         let controller = DashboardWindowController(


### PR DESCRIPTION
## What Problem This Solves

The macOS dashboard uses custom drag regions around its unified titlebar. Those regions always began a window drag, so the second click of a double-click was consumed and the normal titlebar zoom/maximize gesture never ran.

This routes left-mouse double-clicks on both native and WebView-backed drag surfaces to AppKit window zoom while preserving normal single-click dragging.

## Evidence

- Deterministic AppKit reproduction before the fix: `zoom=0 drag=1`.
- The same source-backed harness after the fix: `zoom=1 drag=0`.
- Real `NSWindow.performZoom` proof changed the frame from `800x632` to `1512x883` and set `isZoomed=true`.
- Added regression coverage for single-click drag and double-click zoom routing.
- Swift parser passed for all three changed Swift files.
- `git diff --check` passed.
- Blacksmith Testbox changed gate passed: https://github.com/openclaw/openclaw/actions/runs/30851650067
- Branch autoreview reported no actionable findings.

## Native proof limitation

A full macOS app build/test and visual Crabbox run were not available locally: this Mac has Command Line Tools but not full Xcode, no Parallels VM or SSH-accessible Mac is configured, and the AWS Mac no-spend/quota preflight requires unavailable broker-admin access. The PR macOS CI lane is therefore the authoritative full-Xcode validation gate.