### PR TITLE
fix(auto-reply): include completed media transcripts in room-event prompts

### DIFF
--- a/src/auto-reply/reply/prompt-prelude.test.ts
+++ b/src/auto-reply/reply/prompt-prelude.test.ts
@@ -225,6 +225,41 @@ describe("buildReplyPromptEnvelope", () => {
     );
   });
 
+  it("uses completed transcripts when room-event command text is stale", () => {
+    const sessionCtx = finalizeInboundContext({
+      Body: "[Audio]",
+      BodyStripped: "[Audio]",
+      CommandBody: "[Audio]",
+      Provider: "discord",
+      ChatType: "group",
+      InboundEventKind: "room_event",
+      MessageSid: "voice-123",
+      SenderName: "Alice",
+    });
+    sessionCtx.Transcript = "Please stop the current task";
+
+    const envelope = buildReplyPromptEnvelope({
+      ctx: sessionCtx,
+      sessionCtx,
+      baseBody: "[Audio]",
+      hasUserBody: true,
+      inboundUserContext: "Conversation context:",
+      isBareSessionReset: false,
+      startupAction: "new",
+      inboundEventKind: "room_event",
+    });
+
+    expect(envelope.transcriptCommandBody).toBe(
+      "#voice-123 Alice: Please stop the current task",
+    );
+    expect(envelope.currentInboundContext?.text).toContain(
+      "Current event:\n#voice-123 Alice: Please stop the current task",
+    );
+    expect(envelope.currentInboundContext?.text).not.toContain(
+      "Current event:\n#voice-123 Alice: [Audio]",
+    );
+  });
+
   it("uses the raw current body for room-event current event text", () => {
     const sessionCtx = finalizeInboundContext({
       Body: "[Chat history]\nAlice: old context\n\nBob: current note",

--- a/src/auto-reply/reply/prompt-prelude.ts
+++ b/src/auto-reply/reply/prompt-prelude.ts
@@ -138,6 +138,8 @@ function formatRoomEventLine(ctx: TemplateContext, body: string): string {
 
 function resolveRoomEventBody(params: ReplyPromptEnvelopeBaseParams): string {
   return (
+    normalizeOptionalString(params.ctx.Transcript) ??
+    normalizeOptionalString(params.sessionCtx.Transcript) ??
     normalizeOptionalString(params.ctx.commandText) ??
     normalizeOptionalString(params.sessionCtx.commandText) ??
     (params.hasUserBody ? params.baseBody.trim() : undefined) ??


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a room-event voice note could be transcribed successfully but still reach the model as a generic media marker when the canonical command text was finalized before speech recognition completed.

The missing transcript affected both the current-event context shown to the model and the user turn persisted to the session transcript.

## Why This Change Was Made

Room-event prompt construction now reads the completed `Transcript` field before falling back to canonical command text or the media-only marker. Existing text-only and failed-transcription fallbacks are unchanged.

## User Impact

Models receive the spoken words from transcribed room-event voice notes instead of an attachment placeholder, so they can understand and act on the actual message.

## Evidence

- Added a regression test that reproduces a stale `[Audio]` command body followed by a completed transcript.
- The test verifies that the spoken text appears in both `Current event` and the transcript row, and that the stale marker does not.
- `git diff --check` passes.

AI-assisted; I reviewed and understand the change.
