### PR TITLE
fix(queue): honor steer mode for active room events

### DIFF
--- a/src/auto-reply/reply/agent-runner-run.ts
+++ b/src/auto-reply/reply/agent-runner-run.ts
@@ -220,6 +220,12 @@ export async function runReplyAgent(
   let shouldQueueAfterSteerRejection = false;
   let beforeAgentReplyDispatchedForSteer = false;
   if (effectiveShouldSteer && isActive) {
+    const steerPrompt =
+      followupRun.currentInboundEventKind === "room_event"
+        ? (followupRun.currentInboundContext?.text ??
+          followupRun.transcriptPrompt ??
+          followupRun.prompt)
+        : followupRun.prompt;
     // Steer against the operation that owns THIS session's run slot. A native
     // command continuation whose slot adoption was skipped (#104844) still
     // carries a source-keyed reservation; steering by its stale sessionId
@@ -257,7 +263,7 @@ export async function runReplyAgent(
     const hookResult = await runBeforeAgentReplyForTurn({
       runId: steerRunId,
       trigger,
-      event: { cleanedBody: followupRun.prompt },
+      event: { cleanedBody: steerPrompt },
       context: {
         runId: steerRunId,
         agentId: followupRun.run.agentId,
@@ -290,7 +296,7 @@ export async function runReplyAgent(
     }
     const steerOutcome = await queueEmbeddedAgentMessageWithOutcomeAsync(
       steerSessionId,
-      followupRun.prompt,
+      steerPrompt,
       {
         steeringMode: "all",
         isInboundUserMessage: true,

--- a/src/auto-reply/reply/agent-runner.media-paths.test.ts
+++ b/src/auto-reply/reply/agent-runner.media-paths.test.ts
@@ -462,6 +462,44 @@ describe("runReplyAgent media path normalization", () => {
     expect(enqueueFollowupRunMock).not.toHaveBeenCalled();
   });
 
+  it("steers room events with their current inbound context", async () => {
+    queueEmbeddedAgentMessageWithOutcomeAsyncMock.mockImplementation(async (sessionId: string) => ({
+      queued: true,
+      sessionId,
+      target: "embedded_run",
+      gatewayHealth: "live",
+    }));
+    const roomEventPrompt = [
+      "[OpenClaw room event]",
+      "inbound_event_kind: room_event",
+      "Current event:\n#123 Alice: stop the current task",
+    ].join("\n\n");
+    const followupRun = createMockFollowupRun({ prompt: "[OpenClaw room event]" });
+    followupRun.currentInboundEventKind = "room_event";
+    followupRun.currentInboundContext = { text: roomEventPrompt };
+
+    await runReplyAgent(
+      makeRunReplyAgentParams({
+        resolvedQueue: { mode: "steer" } as QueueSettings,
+        shouldSteer: true,
+        shouldFollowup: true,
+        isActive: true,
+        followupRun,
+      }),
+    );
+
+    expect(queueEmbeddedAgentMessageWithOutcomeAsyncMock).toHaveBeenLastCalledWith(
+      "session",
+      roomEventPrompt,
+      {
+        steeringMode: "all",
+        isInboundUserMessage: true,
+        taskSuggestionDeliveryMode: undefined,
+      },
+    );
+    expect(enqueueFollowupRunMock).not.toHaveBeenCalled();
+  });
+
   it("steers ordered current-turn images with the active prompt", async () => {
     queueEmbeddedAgentMessageWithOutcomeAsyncMock.mockImplementation(async (sessionId: string) => ({
       queued: true,

--- a/src/auto-reply/reply/get-reply-run-admission.ts
+++ b/src/auto-reply/reply/get-reply-run-admission.ts
@@ -499,7 +499,6 @@ export async function prepareReplyRunAdmission(context: PreparedReplyRunContext)
   const { activeSessionId, isActive, isStreaming } = resolveQueueBusyState();
   const activeRunAcceptsCurrentThread = resolveActiveRunAcceptsCurrentThread({ isActive });
   const shouldSteer =
-    !isRoomEvent &&
     activeRunAcceptsCurrentThread &&
     !context.isHeartbeat &&
     !effectiveResetTriggered &&

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -2463,7 +2463,7 @@ describe("runPreparedReply media-only handling", () => {
     );
   });
 
-  it("queues active room events as followups instead of steering fake prompts", async () => {
+  it("steers active room events with their runtime context", async () => {
     const queueSettings = await import("./queue/settings-runtime.js");
     const embeddedAgentRuntime = await import("../../agents/embedded-agent.runtime.js");
     const abortController = new AbortController();
@@ -2498,7 +2498,7 @@ describe("runPreparedReply media-only handling", () => {
     );
 
     const call = requireLastRunReplyAgentCall();
-    expect(call.shouldSteer).toBe(false);
+    expect(call.shouldSteer).toBe(true);
     expect(call.shouldFollowup).toBe(true);
     expect(call.isActive).toBe(true);
     expect(call.resolvedQueue.mode).toBe("steer");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators who explicitly set `messages.queue.mode` to `steer` still cannot use an active room-event message to correct, cancel, or unblock the in-flight task. OpenClaw silently forces that event into the follow-up queue, so time-sensitive input can arrive only after the stale run finishes.

## Why This Change Was Made

This treats the existing `steer` queue mode as the operator opt-in instead of adding another overlapping setting. The active-run, same-thread, heartbeat, reset, backend-capability, and source-delivery guards remain in place.

Room events carry their full runtime-only context into the steering message. This avoids injecting only the placeholder `[OpenClaw room event]`; the active model receives the attributed current event, room context, and quiet-room delivery directive.

The current default remains unchanged because the default queue mode is not `steer`.

## User Impact

In operator-owned task rooms configured for steering, an ambient correction or approval can influence the active run immediately. Rooms that do not explicitly use `steer` keep the existing follow-up behavior.

## Evidence

- Updated the active-room-event admission regression to require steering only under explicit `steer` mode.
- Added runner coverage proving the full current-event context—not the placeholder marker—is injected into the active run.
- Existing guards still cover heartbeats, resets, cross-thread Slack turns, source-delivery mismatches, and runtime steering rejection/follow-up fallback.
- `git diff --check` passes.

AI-assisted; I reviewed and understand the change.
