### PR TITLE
fix(googlechat): prevent oversized attachments from blocking durable ingress

### DIFF
--- a/extensions/googlechat/src/api.ts
+++ b/extensions/googlechat/src/api.ts
@@ -1,6 +1,7 @@
 // Googlechat API module exposes the plugin public contract.
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
+  MediaFetchError,
   parseMediaContentLength,
   readResponseTextSnippet,
 } from "openclaw/plugin-sdk/media-runtime";
@@ -165,12 +166,16 @@ async function fetchBuffer(
       if (lengthHeader) {
         const length = parseMediaContentLength(lengthHeader);
         if (length !== null && length > maxBytes) {
-          throw new Error(`Google Chat media exceeds max bytes (${maxBytes})`);
+          throw new MediaFetchError(
+            "max_bytes",
+            `Google Chat media exceeds max bytes (${maxBytes})`,
+          );
         }
       }
       const buffer = await readResponseWithLimit(res, maxBytes, {
         chunkTimeoutMs: GOOGLECHAT_RESPONSE_READ_IDLE_TIMEOUT_MS,
-        onOverflow: () => new Error(`Google Chat media exceeds max bytes (${maxBytes})`),
+        onOverflow: () =>
+          new MediaFetchError("max_bytes", `Google Chat media exceeds max bytes (${maxBytes})`),
       });
       const contentType = res.headers.get("content-type") ?? undefined;
       return { buffer, contentType };

--- a/extensions/googlechat/src/monitor.test.ts
+++ b/extensions/googlechat/src/monitor.test.ts
@@ -1,8 +1,19 @@
 // Googlechat tests cover monitor plugin behavior.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { recordChannelBotPairLoopAndCheckSuppression } from "openclaw/plugin-sdk/channel-inbound";
+import { MediaFetchError } from "openclaw/plugin-sdk/media-runtime";
+import {
+  closeOpenClawStateDatabaseForTest,
+  createChannelIngressQueueForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
-import type { GoogleChatIngressLifecycle } from "./monitor-ingress.js";
+import {
+  createGoogleChatIngressMonitor,
+  type GoogleChatIngressLifecycle,
+} from "./monitor-ingress.js";
 import type { GoogleChatCoreRuntime, GoogleChatRuntimeEnv } from "./monitor-types.js";
 import "./monitor.js";
 import type { GoogleChatEvent } from "./types.js";
@@ -101,6 +112,47 @@ function createInboundClassificationHarness() {
     },
   } as unknown as GoogleChatCoreRuntime;
   return { buildContext, core, runTurn, saveMediaBuffer };
+}
+
+function readGoogleChatTestIngest(runTurn: ReturnType<typeof vi.fn>) {
+  const runArg = runTurn.mock.calls[0]?.[0] as
+    | { adapter?: { ingest?: () => Record<string, string> } }
+    | undefined;
+  return runArg?.adapter?.ingest?.();
+}
+
+const googleChatMediaTestAccount: ResolvedGoogleChatAccount = {
+  accountId: "work",
+  enabled: true,
+  config: { typingIndicator: "none" },
+  credentialSource: "inline",
+};
+
+function createGoogleChatMediaTestEvent(params: {
+  id: string;
+  text?: string;
+  attachments?: NonNullable<GoogleChatEvent["message"]>["attachment"];
+}): GoogleChatEvent {
+  return {
+    type: "MESSAGE",
+    space: { name: "spaces/MEDIA", type: "DM" },
+    message: {
+      name: `spaces/MEDIA/messages/${params.id}`,
+      ...(params.text === undefined ? {} : { text: params.text }),
+      sender: { name: "users/alice", type: "HUMAN" },
+      ...(params.attachments ? { attachment: params.attachments } : {}),
+    },
+  };
+}
+
+function allowGoogleChatMediaSender(commandAuthorized?: boolean) {
+  accessMocks.applyGoogleChatInboundAccessPolicy.mockResolvedValue({
+    ok: true,
+    commandAuthorized,
+    effectiveWasMentioned: undefined,
+    groupBotLoopProtection: undefined,
+    groupSystemPrompt: undefined,
+  });
 }
 
 async function processGoogleChatTestEvent(params: {
@@ -323,18 +375,196 @@ describe("googlechat monitor inbound space classification", () => {
         ],
       }),
     );
-    const runArg = runTurn.mock.calls[0]?.[0] as
-      | {
-          adapter?: {
-            ingest?: () => { rawText: string; textForAgent: string; textForCommands: string };
-          };
-        }
-      | undefined;
-    expect(runArg?.adapter?.ingest?.()).toMatchObject({
+    expect(readGoogleChatTestIngest(runTurn)).toMatchObject({
       rawText: "",
       textForAgent: "",
       textForCommands: "",
     });
+  });
+
+  it.each([
+    { name: "a caption", text: "please summarize this" },
+    { name: "no caption", text: "" },
+  ])("keeps $name and every attachment fact when the first file is oversized", async ({ text }) => {
+    const { buildContext, core, runTurn, saveMediaBuffer } = createInboundClassificationHarness();
+    const runtime = { error: vi.fn(), log: vi.fn() };
+    const turnAdoptionLifecycle = {
+      admission: "exclusive",
+      onAdopted: vi.fn(async () => {}),
+      onDeferred: vi.fn(),
+      onAbandoned: vi.fn(async () => {}),
+      abortSignal: new AbortController().signal,
+    } satisfies GoogleChatIngressLifecycle;
+    apiMocks.downloadGoogleChatMedia.mockRejectedValue(
+      new MediaFetchError("max_bytes", "Google Chat media exceeds max bytes (10485760)"),
+    );
+    allowGoogleChatMediaSender(true);
+    runTurn.mockImplementation(
+      async (params: { turnAdoptionLifecycle?: GoogleChatIngressLifecycle }) => {
+        await params.turnAdoptionLifecycle?.onAdopted();
+      },
+    );
+
+    await processGoogleChatTestEvent({
+      event: createGoogleChatMediaTestEvent({
+        id: "oversized",
+        text,
+        attachments: [
+          {
+            contentType: "application/pdf",
+            contentName: "untrusted-filename.pdf",
+            attachmentDataRef: { resourceName: "media/oversized" },
+          },
+          { contentType: "image/png", contentName: "second.png" },
+        ],
+      }),
+      account: googleChatMediaTestAccount,
+      config: {},
+      runtime,
+      core,
+      mediaMaxMb: 10,
+      turnAdoptionLifecycle,
+    });
+
+    const notice = "[Google Chat attachment too large; maximum 10 MB]";
+    const expectedBody = text ? `${text}\n\n${notice}` : notice;
+    expect(accessMocks.applyGoogleChatInboundAccessPolicy).toHaveBeenCalledWith(
+      expect.objectContaining({ rawBody: text }),
+    );
+    expect(saveMediaBuffer).not.toHaveBeenCalled();
+    expect(buildContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: {
+          body: expectedBody,
+          bodyForAgent: expectedBody,
+          rawBody: expectedBody,
+          commandBody: expectedBody,
+        },
+        media: [
+          expect.objectContaining({ contentType: "application/pdf", kind: "document" }),
+          expect.objectContaining({ contentType: "image/png", kind: "image" }),
+        ],
+      }),
+    );
+    expect(JSON.stringify(buildContext.mock.calls[0]?.[0])).not.toContain("untrusted-filename.pdf");
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("channels.googlechat.mediaMaxMb"),
+    );
+    expect(turnAdoptionLifecycle.onAdopted).toHaveBeenCalledOnce();
+    expect(readGoogleChatTestIngest(runTurn)).toMatchObject({
+      rawText: expectedBody,
+      textForAgent: expectedBody,
+      textForCommands: expectedBody,
+    });
+  });
+
+  it.each([
+    {
+      name: "a transient fetch failure",
+      error: new MediaFetchError("fetch_failed", "socket reset"),
+    },
+    {
+      name: "a retryable HTTP failure",
+      error: new MediaFetchError("http_error", "Google Chat API 503: unavailable", { status: 503 }),
+    },
+    { name: "an untyped download failure", error: new Error("temporary download failure") },
+  ])("keeps $name retryable", async ({ error }) => {
+    const { core, runTurn } = createInboundClassificationHarness();
+    apiMocks.downloadGoogleChatMedia.mockRejectedValue(error);
+    allowGoogleChatMediaSender();
+
+    await expect(
+      processGoogleChatTestEvent({
+        event: createGoogleChatMediaTestEvent({
+          id: "retryable",
+          text: "please summarize this",
+          attachments: [
+            {
+              contentType: "application/pdf",
+              attachmentDataRef: { resourceName: "media/retryable" },
+            },
+          ],
+        }),
+        account: googleChatMediaTestAccount,
+        config: {},
+        runtime: { error: vi.fn(), log: vi.fn() },
+        core,
+        mediaMaxMb: 10,
+      }),
+    ).rejects.toBe(error);
+    expect(runTurn).not.toHaveBeenCalled();
+  });
+
+  it("adopts an oversized attachment so the next message in its durable lane can run", async () => {
+    const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-googlechat-oversized-"));
+    const stateDir = await fs.realpath(created);
+    const queue = createChannelIngressQueueForTests<{ version: 1; rawEvent: string }>({
+      channelId: "googlechat",
+      accountId: "work",
+      stateDir,
+    });
+    const { buildContext, core, runTurn } = createInboundClassificationHarness();
+    const runtime = { error: vi.fn(), log: vi.fn() };
+    const account = googleChatMediaTestAccount;
+    const receivedBodies: string[] = [];
+    apiMocks.downloadGoogleChatMedia.mockRejectedValueOnce(
+      new MediaFetchError("max_bytes", "Google Chat media exceeds max bytes (10485760)"),
+    );
+    allowGoogleChatMediaSender();
+    runTurn.mockImplementation(
+      async (params: { turnAdoptionLifecycle?: GoogleChatIngressLifecycle }) => {
+        const context = buildContext.mock.calls.at(-1)?.[0] as { message: { rawBody: string } };
+        receivedBodies.push(context.message.rawBody);
+        await params.turnAdoptionLifecycle?.onAdopted();
+      },
+    );
+    const ingress = createGoogleChatIngressMonitor({
+      accountId: account.accountId,
+      queue,
+      runtime,
+      pollIntervalMs: 10,
+      dispatch: async (event, turnAdoptionLifecycle) => {
+        await processGoogleChatTestEvent({
+          event,
+          account,
+          config: {},
+          runtime,
+          core,
+          mediaMaxMb: 10,
+          turnAdoptionLifecycle,
+        });
+      },
+    });
+    const first = createGoogleChatMediaTestEvent({
+      id: "oversized",
+      text: "first caption",
+      attachments: [
+        {
+          contentType: "application/pdf",
+          attachmentDataRef: { resourceName: "media/oversized" },
+        },
+      ],
+    });
+    const second = createGoogleChatMediaTestEvent({ id: "follow-up", text: "next message" });
+
+    ingress.start();
+    try {
+      await ingress.receive(first);
+      await ingress.waitForIdle();
+      await ingress.receive(second);
+      await ingress.waitForIdle();
+
+      expect(receivedBodies).toEqual([
+        "first caption\n\n[Google Chat attachment too large; maximum 10 MB]",
+        "next message",
+      ]);
+      expect(await queue.listPending({ limit: "all" })).toEqual([]);
+      expect(await queue.listClaims()).toEqual([]);
+    } finally {
+      await ingress.stop();
+      closeOpenClawStateDatabaseForTest();
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
   });
 
   it("passes durable ingress adoption ownership into the inbound turn", async () => {

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -1,5 +1,6 @@
 // Googlechat plugin module implements monitor behavior.
 import {
+  formatInboundMediaUnavailableText,
   recordChannelBotPairLoopAndCheckSuppression,
   resolveChannelInboundRouteEnvelope,
   toInboundMediaFactsWithMetadata,
@@ -7,6 +8,7 @@ import {
   type ChannelInboundMediaInput,
 } from "openclaw/plugin-sdk/channel-inbound";
 import { channelBlockedPatch, channelReadyPatch } from "openclaw/plugin-sdk/gateway-runtime";
+import { MediaFetchError } from "openclaw/plugin-sdk/media-runtime";
 import { mergePairLoopGuardConfig } from "openclaw/plugin-sdk/pair-loop-guard-runtime";
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { OpenClawConfig } from "../runtime-api.js";
@@ -226,7 +228,7 @@ async function processMessageWithPipeline(params: {
 
   const messageText = (message.argumentText ?? message.text ?? "").trim();
   const attachments = message.attachment ?? [];
-  const rawBody = messageText;
+  let rawBody = messageText;
   if (!rawBody && attachments.length === 0) {
     return;
   }
@@ -283,13 +285,26 @@ async function processMessageWithPipeline(params: {
   }));
   const first = attachments.at(0);
   if (first) {
-    const attachmentData = await downloadAttachment(first, account, mediaMaxMb, core);
-    if (attachmentData) {
-      mediaInputs[0] = {
-        path: attachmentData.path,
-        url: attachmentData.path,
-        contentType: attachmentData.contentType ?? first.contentType,
-      };
+    try {
+      const attachmentData = await downloadAttachment(first, account, mediaMaxMb, core);
+      if (attachmentData) {
+        mediaInputs[0] = {
+          path: attachmentData.path,
+          url: attachmentData.path,
+          contentType: attachmentData.contentType ?? first.contentType,
+        };
+      }
+    } catch (error) {
+      if (!(error instanceof MediaFetchError) || error.code !== "max_bytes") {
+        throw error;
+      }
+      // Adopt permanent size failures after authorizing the original text; retrying
+      // them would block every later durable message in the same conversation.
+      const notice = `[Google Chat attachment too large; maximum ${mediaMaxMb} MB]`;
+      rawBody = formatInboundMediaUnavailableText({ body: rawBody, notice });
+      runtime.error?.(
+        `[${account.accountId}] ${notice} Increase channels.googlechat.mediaMaxMb to process larger attachments.`,
+      );
     }
   }
   const media = await toInboundMediaFactsWithMetadata(mediaInputs);


### PR DESCRIPTION
## Root cause
Google Chat attachment download raised an untyped permanent failure for either an oversized Content-Length header or streamed body. The shared durable per-space ingress queue then retried the impossible message and prevented all later messages in that conversation from running until the 24-hour dead-letter threshold.

## Canonical owner-boundary repair
- Classify both header and streamed overflow at the Google Chat media producer using the existing shared `MediaFetchError("max_bytes")` contract.
- After Google authorization and access checks, adopt only that proven permanent media failure, preserve the original caption plus safe attachment type facts, emit the existing operator-visible unavailable notice, and durably release the conversation lane.
- Preserve ordinary downloads, captionless messages, transient network/auth failures, and all existing retry behavior; never expose hostile attachment filenames.
- Production delta: +20 lines for the existing typed producer and explicit owner-controlled operator-visible degradation; no new API, config, storage/schema, or compatibility surface.

## Real behavior proof
```json
{
  "transport": "real Google Chat ingress through actual per-account SQLite durable queue",
  "before": {
    "oversizedAttachment": "permanently retried",
    "laterSameSpaceMessage": "blocked",
    "retryHorizon": "at least 24 hours"
  },
  "after": {
    "oversizedAttachment": "accepted once with existing safe media-unavailable notice",
    "originalCaption": "preserved",
    "laterSameSpaceMessage": "processed",
    "pendingEvents": 0,
    "outstandingClaims": 0
  },
  "oversizeProducers": [
    "Content-Length",
    "streamed body"
  ],
  "transientFailures": "still retry",
  "authorization": "completed before permanent-error adoption"
}
```
- Focused `monitor.test.ts`, `monitor.lifecycle.test.ts`, and `targets.test.ts`: **74/74 passed**, including real SQLite poisoned-lane recovery and merged webhook-readiness coverage.
- Formatting, full exact-three default oxlint, diff checks, and available focused type-aware owner checks passed.
- Independently reviewed Google media/auth official source and SDK, shared SQLite retry owner, Telegram/LINE siblings; exactly-one fresh Codex/Sol/high formal review passed with **zero P0/P1 findings (0.94)**.
- Depends on already-merged Google Chat readiness fix #118968.