### PR TITLE
fix(macos): timestamp hash-pinned Developer ID signatures

### DIFF
--- a/docs/platforms/mac/signing.md
+++ b/docs/platforms/mac/signing.md
@@ -13,7 +13,8 @@ title: "macOS signing"
 - Node: `>=22.22.3 <23`, `>=24.15.0 <25`, or `>=25.9.0` (repo `package.json` `engines`). The packager also builds the Control UI (`pnpm ui:build`).
 - Requires a real signing identity by default; the codesign script exits with an error if none is found and `ALLOW_ADHOC_SIGNING` is not set. Ad-hoc signing (`SIGN_IDENTITY="-"`) is explicit opt-in and does not persist TCC permissions across rebuilds. See [macOS permissions](/platforms/mac/permissions).
 - Reads `SIGN_IDENTITY` from the environment (e.g. `export SIGN_IDENTITY="Apple Development: Your Name (TEAMID)"`, or a Developer ID Application cert). Without it, `codesign-mac-app.sh` auto-selects an identity in this order: Developer ID Application, Apple Distribution, Apple Development, then the first valid codesigning identity found.
-- `CODESIGN_TIMESTAMP=auto` (default) enables trusted timestamps only for Developer ID Application signatures. Set `on`/`off` to force either way.
+- `SIGN_IDENTITY` also accepts a certificate SHA-1 hash to distinguish certificates with the same common name.
+- `CODESIGN_TIMESTAMP=auto` (default) enables trusted timestamps for Developer ID Application signatures selected by name or certificate hash. Set `on`/`off` to force either way.
 - Stamps Info.plist with `OpenClawBuildTimestamp` (ISO8601 UTC) and `OpenClawGitCommit` (short hash, `unknown` if unavailable) so the About tab can show build, git, and debug/release channel.
 - Runs a Team ID audit after signing and fails if any Mach-O inside the bundle has a different Team ID. Set `SKIP_TEAM_ID_CHECK=1` to bypass.
 

--- a/scripts/codesign-mac-app.sh
+++ b/scripts/codesign-mac-app.sh
@@ -162,7 +162,13 @@ case "$TIMESTAMP_MODE" in
     timestamp_arg="--timestamp=none"
     ;;
   auto)
-    if [[ "$IDENTITY" == *"Developer ID Application"* ]]; then
+    identity_name="$IDENTITY"
+    if [[ "$IDENTITY" =~ ^[[:xdigit:]]{40}$ ]]; then
+      # A hash selector conceals the certificate class required for notarization timestamps.
+      identity_name="$(security find-identity -p codesigning -v 2>/dev/null \
+        | awk -v hash="$IDENTITY" 'toupper($2) == toupper(hash) { print }')"
+    fi
+    if [[ "$identity_name" == *"Developer ID Application"* ]]; then
       timestamp_arg="--timestamp"
     fi
     ;;

--- a/test/scripts/codesign-mac-app.test.ts
+++ b/test/scripts/codesign-mac-app.test.ts
@@ -39,6 +39,10 @@ function installFakeCodesign(binDir: string) {
     `#!/usr/bin/env bash
 set -euo pipefail
 
+if [ -n "\${CODESIGN_ARGS_LOG:-}" ]; then
+  printf '%s\\n' "$*" >>"$CODESIGN_ARGS_LOG"
+fi
+
 entitlements=""
 target=""
 while [ "$#" -gt 0 ]; do
@@ -474,5 +478,83 @@ describe("codesign-mac-app temp file hygiene", () => {
     expect(result.stderr).not.toContain("Transient Apple timestamp failure");
     expect(readFileSync(countFile, "utf8")).toBe("1");
     expect(entitlementTemps(tempRoot)).toEqual([]);
+  });
+
+  it.each([
+    {
+      label: "Developer ID hash",
+      identity: "63A99BFF1D40E5A75C8A32B84BE99D1DDA6A44E1",
+      timestamp: true,
+    },
+    {
+      label: "lowercase Developer ID hash",
+      identity: "63a99bff1d40e5a75c8a32b84be99d1dda6a44e1",
+      timestamp: true,
+    },
+    {
+      label: "Developer ID name",
+      identity: "Developer ID Application: Example Corp (ABCDE12345)",
+      timestamp: true,
+    },
+    {
+      label: "development certificate hash",
+      identity: "11AA22BB33CC44DD55EE66FF77008899AABBCCDD",
+      timestamp: false,
+    },
+    {
+      label: "unknown certificate hash",
+      identity: "0123456789ABCDEF0123456789ABCDEF01234567",
+      timestamp: false,
+    },
+    { label: "ad-hoc identity", identity: "-", timestamp: false },
+    {
+      label: "explicitly disabled timestamp",
+      identity: "63A99BFF1D40E5A75C8A32B84BE99D1DDA6A44E1",
+      timestamp: false,
+      mode: "off",
+    },
+  ])("applies automatic timestamp policy to $label", ({ identity, timestamp, mode }) => {
+    const tempRoot = tempDirs.make("openclaw-codesign-timestamp-");
+    const app = path.join(tempRoot, "Fake.app");
+    const binDir = path.join(tempRoot, "bin");
+    const captureDir = path.join(tempRoot, "capture");
+    const argsLog = path.join(captureDir, "codesign-args.log");
+    mkdirSync(path.join(app, "Contents", "MacOS"), { recursive: true });
+    mkdirSync(binDir);
+    mkdirSync(captureDir);
+    writeFileSync(path.join(app, "Contents", "MacOS", "OpenClaw"), "#!/bin/sh\n");
+    installFakeCodesign(binDir);
+    const fakeSecurity = path.join(binDir, "security");
+    writeFileSync(
+      fakeSecurity,
+      `#!/usr/bin/env bash
+printf '%s\\n' \\
+  '  1) 63A99BFF1D40E5A75C8A32B84BE99D1DDA6A44E1 "Developer ID Application: Example Corp (ABCDE12345)"' \\
+  '  2) 11AA22BB33CC44DD55EE66FF77008899AABBCCDD "Apple Development: Example Developer (ABCDE12345)"'
+`,
+    );
+    chmodSync(fakeSecurity, 0o755);
+
+    const result = spawnSync("bash", [scriptPath, app], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CODESIGN_ARGS_LOG: argsLog,
+        CODESIGN_CAPTURE_DIR: captureDir,
+        CODESIGN_LOG: path.join(captureDir, "codesign.log"),
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        SIGN_IDENTITY: identity,
+        SKIP_TEAM_ID_CHECK: "1",
+        TMPDIR: tempRoot,
+        ...(mode === undefined ? {} : { CODESIGN_TIMESTAMP: mode }),
+      },
+    });
+
+    expect(result.status).toBe(0);
+    const expectedFlag = timestamp ? "--timestamp" : "--timestamp=none";
+    for (const args of readFileSync(argsLog, "utf8").trim().split("\n")) {
+      expect(args.split(" ")).toContain(expectedFlag);
+    }
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Closes #118740.

Fixes an issue where macOS developers signing an OpenClaw app with a Developer ID certificate selected by its SHA-1 hash produced an app without the trusted timestamp required for notarization. Signing appeared successful and displayed a local signing time, so the failure surfaced only at notarization.

## Why This Change Was Made

Apple `codesign` explicitly accepts a 40-character certificate SHA-1 hash as a signing identity. Hash selection is necessary when certificates share a common name, but the previous automatic timestamp policy classified the selector text rather than the certificate it selected.

Resolve hash selectors against the existing `security find-identity -p codesigning -v` contract before applying the existing Developer ID timestamp policy. Name-selected identities retain their existing fast path, non-Developer-ID and ad-hoc identities remain untimestamped, and explicit timestamp settings continue to win. Unknown hashes remain unclassified and still fail in the real signing tool.

The existing timestamp retry policy handles transient Apple timestamp-service failures. Operators who intentionally require an offline, non-notarizable build retain the documented `CODESIGN_TIMESTAMP=off` override.

## User Impact

Developer ID certificates now produce the same notarizable signature whether selected by name or hash, without changing iOS signing, ordinary development identities, ad-hoc signing, or explicit timestamp overrides.

## Evidence

Maintainer proof used the **same real Developer ID certificate**, selected by its real SHA-1 hash, to sign isolated throwaway macOS app bundles through the production signing script. Certificate details were redacted.

```text
BEFORE — current main
proof=main developer_id_authority=yes trusted_timestamp=ABSENT local_signed_time=present

AFTER — this repair
proof=fixed developer_id_authority=yes trusted_timestamp=present local_signed_time=absent
```

The after result was produced by the actual `security` and `codesign` tools contacting Apple's trusted timestamp service, not by mocked signing tools.

Focused owner-boundary regression coverage first failed on unmodified main for both uppercase and lowercase Developer ID hashes; after the repair, all 24 signing tests pass. The seven-case table also covers Developer ID names, Apple Development hashes, unknown hashes, ad-hoc signing, and explicit timestamp opt-out.

```text
Test Files  1 passed (1)
Tests       24 passed (24)
```

The maintainer rewrite preserves @harjothkhara's original fix and contributor credit while reducing production growth from +16 to +6 lines and regression-test growth from +178 to +82 lines.
