### PR TITLE
improve(tui): prove CLI entrypoints under real PTY

### DIFF
--- a/qa/scenarios/ui/tui-entrypoints-pty.yaml
+++ b/qa/scenarios/ui/tui-entrypoints-pty.yaml
@@ -1,0 +1,50 @@
+title: TUI entrypoint PTY contracts
+scenario:
+  id: tui-entrypoints-pty
+  surface: tui
+  category: tui.runtime-modes
+  coverage:
+    primary:
+      - tui.gateway-tui-launch
+      - tui.local-chat-launch
+      - tui.terminal-alias-launch
+      - tui.initial-message-launch
+      - tui.launch-option-validation
+  risk: low
+  objective: Launch each supported TUI CLI entrypoint through a real PTY and verify its visible ready state, launch options, and initial message behavior.
+  successCriteria:
+    - The canonical tui command reaches a real ephemeral Gateway and renders its connected state.
+    - The chat and terminal aliases launch the embedded local runtime and complete a model-backed turn.
+    - A launch-time message reaches the mocked external model endpoint without terminal input.
+    - Local aliases reject incompatible Gateway connection options before startup.
+  codeRefs:
+    - src/cli/tui-cli.ts
+    - src/tui/tui-pty-local.e2e.test.ts
+    - test/e2e/qa-lab/tui/tui-pty-evidence-producer.ts
+  execution:
+    kind: script
+    path: test/e2e/qa-lab/tui/tui-pty-evidence-producer.ts
+    summary: Runs exact real-PTY TUI entrypoint assertions and authenticates their fresh Vitest results as QA evidence.
+    timeoutMs: 300000
+    args:
+      - --artifact-base
+      - ${outputDir}
+      - --scenario-id
+      - ${scenarioId}
+    config:
+      tuiPtyCases:
+        - coverageId: tui.gateway-tui-launch
+          testFile: src/tui/tui-pty-local.e2e.test.ts
+          testNamePattern: ^TUI PTY real backends with shared Gateway fixture launches openclaw tui against a real Gateway through a real PTY$
+        - coverageId: tui.local-chat-launch
+          testFile: src/tui/tui-pty-local.e2e.test.ts
+          testNamePattern: ^TUI PTY real backends launches openclaw chat as local mode through a real PTY$
+        - coverageId: tui.terminal-alias-launch
+          testFile: src/tui/tui-pty-local.e2e.test.ts
+          testNamePattern: ^TUI PTY real backends launches openclaw terminal as local mode through a real PTY$
+        - coverageId: tui.initial-message-launch
+          testFile: src/tui/tui-pty-local.e2e.test.ts
+          testNamePattern: ^TUI PTY real backends sends the initial message supplied to openclaw tui through a real local PTY$
+        - coverageId: tui.launch-option-validation
+          testFile: src/tui/tui-pty-local.e2e.test.ts
+          testNamePattern: ^TUI PTY real backends rejects Gateway options on a local TUI alias through a real PTY$

--- a/qa/scenarios/ui/tui-entrypoints-pty.yaml
+++ b/qa/scenarios/ui/tui-entrypoints-pty.yaml
@@ -32,6 +32,7 @@ scenario:
       - --scenario-id
       - ${scenarioId}
     config:
+      requireBuiltCli: true
       tuiPtyCases:
         - coverageId: tui.gateway-tui-launch
           testFile: src/tui/tui-pty-local.e2e.test.ts

--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -496,12 +496,14 @@ async function cleanupLocalModeResources(params: {
 async function startLocalModeTui(
   registerCleanup: CleanupRegistrar,
   opts: {
+    cliArgs?: string[];
     invalidEditLoop?: boolean;
     holdFirstResponse?: boolean;
     followupReplyText?: string;
+    replyText?: string;
   } = {},
 ) {
-  const replyText = "LOCAL_PTY_RESPONSE";
+  const replyText = opts.replyText ?? "LOCAL_PTY_RESPONSE";
   const tempDir = await mkdtemp(path.join(tmpdir(), "openclaw-tui-pty-local-"));
   const workspaceDir = path.join(tempDir, "workspace");
   const homeDir = path.join(tempDir, "home");
@@ -532,7 +534,7 @@ async function startLocalModeTui(
       writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf8"),
     ]);
 
-    run = startPty(process.execPath, buildTuiProcessArgs(["tui", "--local"]), {
+    run = startPty(process.execPath, buildTuiProcessArgs(opts.cliArgs ?? ["tui", "--local"]), {
       cwd: process.cwd(),
       env: {
         HOME: homeDir,
@@ -846,6 +848,94 @@ async function startGatewayModeTui(
 // Gateway cases share one real server and PTY but keep isolated models and sessions.
 // Per-case abort cleanup and serial order prevent active-run or queue state leaks.
 describe("TUI PTY real backends", () => {
+  for (const alias of ["chat", "terminal"] as const) {
+    it(
+      `launches openclaw ${alias} as local mode through a real PTY`,
+      async ({ onTestFinished }) => {
+        const replyText = `${alias.toUpperCase()}_ALIAS_RESPONSE`;
+        const prompt = `message through ${alias} alias`;
+        const fixture = await startLocalModeTui(onTestFinished, {
+          cliArgs: [alias],
+          replyText,
+        });
+        try {
+          await fixture.run.waitForOutput("local ready", LOCAL_STARTUP_TIMEOUT_MS);
+          await fixture.run.write(`${prompt}\r`);
+          await waitFor({
+            timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
+            read: () => (fixture.mockModel.requests().length === 1 ? true : null),
+            onTimeout: () =>
+              new Error(`${alias} alias did not reach the model\n${fixture.run.output()}`),
+          });
+          expect(JSON.stringify(fixture.mockModel.requests()[0]?.body)).toContain(prompt);
+          await fixture.run.waitForOutput(replyText, LOCAL_OUTPUT_TIMEOUT_MS);
+          await fixture.run.write("/exit\r", { delay: false });
+          expect((await fixture.run.waitForExit()).exitCode).toBe(0);
+        } finally {
+          await fixture.cleanup();
+        }
+      },
+      LOCAL_TEST_TIMEOUT_MS,
+    );
+  }
+
+  it(
+    "sends the initial message supplied to openclaw tui through a real local PTY",
+    async ({ onTestFinished }) => {
+      const initialMessage = "initial message from CLI launch";
+      const replyText = "INITIAL_MESSAGE_RESPONSE";
+      const fixture = await startLocalModeTui(onTestFinished, {
+        cliArgs: ["tui", "--local", "--message", initialMessage],
+        replyText,
+      });
+      try {
+        await fixture.run.waitForOutput("local ready", LOCAL_STARTUP_TIMEOUT_MS);
+        await waitFor({
+          timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
+          read: () => (fixture.mockModel.requests().length === 1 ? true : null),
+          onTimeout: () =>
+            new Error(`initial message did not reach the model\n${fixture.run.output()}`),
+        });
+        expect(JSON.stringify(fixture.mockModel.requests()[0]?.body)).toContain(initialMessage);
+        await fixture.run.waitForOutput(replyText, LOCAL_OUTPUT_TIMEOUT_MS);
+        await fixture.run.write("/exit\r", { delay: false });
+        expect((await fixture.run.waitForExit()).exitCode).toBe(0);
+      } finally {
+        await fixture.cleanup();
+      }
+    },
+    LOCAL_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "rejects Gateway options on a local TUI alias through a real PTY",
+    async ({ onTestFinished }) => {
+      const run = startPty(
+        process.execPath,
+        buildTuiProcessArgs(["chat", "--url", "ws://127.0.0.1:1"]),
+        {
+          cwd: process.cwd(),
+          env: {
+            OPENCLAW_THEME: "dark",
+            NO_COLOR: undefined,
+          },
+          exitTimeoutMs: LOCAL_EXIT_TIMEOUT_MS,
+          outputTimeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
+        },
+      );
+      onTestFinished(async () => {
+        await run.dispose();
+      });
+
+      await run.waitForOutput(
+        "--local cannot be combined with --url, --token, --password, or --tls-fingerprint",
+        LOCAL_STARTUP_TIMEOUT_MS,
+      );
+      expect((await run.waitForExit()).exitCode).toBe(1);
+    },
+    LOCAL_TEST_TIMEOUT_MS,
+  );
+
   it(
     "drives and steers the real local backend with a mocked model endpoint",
     async ({ onTestFinished }) => {
@@ -1417,6 +1507,11 @@ describe("TUI PTY real backends", () => {
       sharedGatewayFixtureStartup = undefined;
       await cleanupStartedFixture(startup);
     }, LOCAL_TEST_TIMEOUT_MS);
+
+    it("launches openclaw tui against a real Gateway through a real PTY", async () => {
+      const fixture = await requireSharedGatewayFixture();
+      expect(fixture.run.visibleOutput()).toContain("gateway connected");
+    });
 
     for (const register of gatewayTestRegistrations) {
       register();

--- a/test/e2e/qa-lab/tui/tui-pty-evidence-producer.test.ts
+++ b/test/e2e/qa-lab/tui/tui-pty-evidence-producer.test.ts
@@ -33,19 +33,24 @@ function makeScenario(
     secondary?: string[];
     executionKind?: "script" | "vitest";
     executionPath?: string;
+    requireBuiltCli?: unknown;
   } = {},
 ): QaSeedScenarioWithSource {
+  const config = {
+    tuiPtyCases: params.cases ?? [makeCase()],
+    ...(params.requireBuiltCli !== undefined ? { requireBuiltCli: params.requireBuiltCli } : {}),
+  };
   const execution =
     params.executionKind === "vitest"
       ? {
           kind: "vitest" as const,
           path: params.executionPath ?? SOURCE_PATH,
-          config: { tuiPtyCases: params.cases ?? [makeCase()] },
+          config,
         }
       : {
           kind: "script" as const,
           path: params.executionPath ?? SOURCE_PATH,
-          config: { tuiPtyCases: params.cases ?? [makeCase()] },
+          config,
         };
   return {
     id: "tui-pty-producer-test",
@@ -79,6 +84,12 @@ async function makeTempRepo() {
     await fs.writeFile(absolutePath, "// fixture\n", "utf8");
   }
   return repoRoot;
+}
+
+async function writeBuiltCliArtifacts(repoRoot: string, entry: "entry.js" | "entry.mjs") {
+  await fs.writeFile(path.join(repoRoot, "openclaw.mjs"), "// launcher\n", "utf8");
+  await fs.mkdir(path.join(repoRoot, "dist"), { recursive: true });
+  await fs.writeFile(path.join(repoRoot, "dist", entry), "// entry\n", "utf8");
 }
 
 async function writeReport(
@@ -184,10 +195,45 @@ describe("TUI PTY evidence producer", () => {
     );
   });
 
+  it("normalizes missing and false built requirements to source, and true to built", () => {
+    expect(validateTuiPtyScenario(makeScenario()).cliMode).toBe("source");
+    expect(validateTuiPtyScenario(makeScenario({ requireBuiltCli: false })).cliMode).toBe("source");
+    expect(
+      validateTuiPtyScenario(
+        makeScenario({
+          cases: [makeCase({ testFile: LOCAL_FILE })],
+          requireBuiltCli: true,
+        }),
+      ).cliMode,
+    ).toBe("built");
+  });
+
+  it.each(["built", 1, null])("rejects invalid requireBuiltCli value %j", (requireBuiltCli) => {
+    expect(() => validateTuiPtyScenario(makeScenario({ requireBuiltCli }))).toThrow(
+      "execution.config.requireBuiltCli must be a boolean",
+    );
+  });
+
+  it("rejects harness-only and mixed cases in built mode", () => {
+    expect(() => validateTuiPtyScenario(makeScenario({ requireBuiltCli: true }))).toThrow(
+      `every testFile to be exactly ${LOCAL_FILE}`,
+    );
+    expect(() =>
+      validateTuiPtyScenario(
+        makeScenario({
+          requireBuiltCli: true,
+          cases: [makeCase({ testFile: LOCAL_FILE }), makeCase()],
+        }),
+      ),
+    ).toThrow(`every testFile to be exactly ${LOCAL_FILE}`);
+  });
+
   it("builds fake and local PTY commands with the required environment", () => {
     vi.stubEnv("OPENCLAW_TUI_PTY_INCLUDE_LOCAL", "1");
+    vi.stubEnv("OPENCLAW_TUI_PTY_USE_BUILT_CLI", "inherited");
     const fake = buildTuiPtyVitestCommand({
       cases: [makeCase()],
+      cliMode: "source",
       repoRoot: "/repo",
       reportPath: "/artifacts/report.json",
     });
@@ -204,14 +250,17 @@ describe("TUI PTY evidence producer", () => {
     );
     expect(fake.env.OPENCLAW_BEHAVIOR_EVIDENCE).toBe("1");
     expect(fake.env.OPENCLAW_TUI_PTY_INCLUDE_LOCAL).toBeUndefined();
+    expect(fake.env.OPENCLAW_TUI_PTY_USE_BUILT_CLI).toBeUndefined();
 
     const local = buildTuiPtyVitestCommand({
       cases: [makeCase({ testFile: LOCAL_FILE })],
+      cliMode: "built",
       repoRoot: "/repo",
       reportPath: "/artifacts/report.json",
     });
     expect(local.args).toContain(LOCAL_FILE);
     expect(local.env.OPENCLAW_TUI_PTY_INCLUDE_LOCAL).toBe("1");
+    expect(local.env.OPENCLAW_TUI_PTY_USE_BUILT_CLI).toBe("1");
   });
 
   it("rejects wrong-file and unmatched-pattern reports", async () => {
@@ -290,6 +339,77 @@ describe("TUI PTY evidence producer", () => {
     });
   });
 
+  it("fails built preflight for a missing launcher or dist entry without spawning", async () => {
+    for (const missing of ["launcher", "dist"] as const) {
+      const repoRoot = await makeTempRepo();
+      if (missing === "launcher") {
+        await fs.mkdir(path.join(repoRoot, "dist"), { recursive: true });
+        await fs.writeFile(path.join(repoRoot, "dist", "entry.js"), "// entry\n", "utf8");
+      } else {
+        await fs.writeFile(path.join(repoRoot, "openclaw.mjs"), "// launcher\n", "utf8");
+      }
+      const scenario = makeScenario({
+        cases: [makeCase({ testFile: LOCAL_FILE })],
+        requireBuiltCli: true,
+      });
+      const runCommand = vi.fn(async () => ({ exitCode: 0, signal: null }));
+      const artifactBase = path.join(repoRoot, ".artifacts", `missing-${missing}`);
+      const evidence = await runTuiPtyEvidenceProducer(
+        { artifactBase, repoRoot, scenarioId: scenario.id },
+        { loadScenario: () => scenario, runCommand },
+      );
+
+      expect(runCommand).not.toHaveBeenCalled();
+      expect(evidence.entries[0]).toMatchObject({
+        execution: {
+          artifacts: [
+            { kind: "log", path: "tui-pty-evidence-producer.log" },
+            { kind: "proof-matrix", path: "proof-matrix.json" },
+          ],
+        },
+        result: {
+          status: "fail",
+          failure: {
+            reason: expect.stringContaining(
+              "cliMode=built requires readable openclaw.mjs and at least one readable dist/entry.js or dist/entry.mjs",
+            ),
+          },
+        },
+      });
+    }
+  });
+
+  it.each(["entry.js", "entry.mjs"] as const)(
+    "accepts built CLI artifact %s and records built proof mode",
+    async (entry) => {
+      const repoRoot = await makeTempRepo();
+      await writeBuiltCliArtifacts(repoRoot, entry);
+      const artifactBase = path.join(repoRoot, ".artifacts", entry);
+      const scenario = makeScenario({
+        cases: [makeCase({ testFile: LOCAL_FILE })],
+        requireBuiltCli: true,
+      });
+      await runTuiPtyEvidenceProducer(
+        { artifactBase, repoRoot, scenarioId: scenario.id },
+        {
+          loadScenario: () => scenario,
+          runCommand: async (command) => {
+            const reportPath = command.args
+              .find((arg) => arg.startsWith("--outputFile.json="))
+              ?.slice("--outputFile.json=".length);
+            await writeReport(reportPath ?? "", { testFile: LOCAL_FILE });
+            return { exitCode: 0, signal: null };
+          },
+        },
+      );
+
+      const proofMatrix = JSON.parse(
+        await fs.readFile(path.join(artifactBase, "proof-matrix.json"), "utf8"),
+      ) as { cliMode: string };
+      expect(proofMatrix.cliMode).toBe("built");
+    },
+  );
+
   it("writes a sanitized proof matrix and passing QA evidence", async () => {
     const repoRoot = await makeTempRepo();
     const artifactBase = path.join(repoRoot, ".artifacts", "passing-report");
@@ -317,7 +437,8 @@ describe("TUI PTY evidence producer", () => {
     });
     const proofMatrix = JSON.parse(
       await fs.readFile(path.join(artifactBase, "proof-matrix.json"), "utf8"),
-    ) as { cases: Array<{ coverageId: string; matchedAssertions: string[] }> };
+    ) as { cases: Array<{ coverageId: string; matchedAssertions: string[] }>; cliMode: string };
+    expect(proofMatrix.cliMode).toBe("source");
     expect(proofMatrix.cases).toEqual([
       expect.objectContaining({
         coverageId: COVERAGE_ID,

--- a/test/e2e/qa-lab/tui/tui-pty-evidence-producer.ts
+++ b/test/e2e/qa-lab/tui/tui-pty-evidence-producer.ts
@@ -1,5 +1,6 @@
 // Runs allowlisted TUI PTY cases and emits authenticated QA script evidence.
 import { spawn } from "node:child_process";
+import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -19,6 +20,8 @@ const REPORT_FILENAME = "vitest-report.json";
 const PROOF_MATRIX_FILENAME = "proof-matrix.json";
 const REPORT_FRESHNESS_TOLERANCE_MS = 2_000;
 const MAX_PATTERN_LENGTH = 1_024;
+const BUILT_CLI_REQUIREMENT =
+  "cliMode=built requires readable openclaw.mjs and at least one readable dist/entry.js or dist/entry.mjs";
 
 export const TUI_PTY_TEST_FILE_ALLOWLIST = [
   "src/tui/tui-pty-harness.e2e.test.ts",
@@ -33,6 +36,8 @@ export type TuiPtyCase = {
   testFile: AllowedTuiPtyTestFile;
   testNamePattern: string;
 };
+
+export type TuiPtyCliMode = "source" | "built";
 
 export type TuiPtyProducerOptions = {
   artifactBase: string;
@@ -179,13 +184,21 @@ function readTuiPtyCase(value: unknown, index: number): TuiPtyCase {
   return { coverageId, testFile, testNamePattern };
 }
 
-export function validateTuiPtyScenario(scenario: QaSeedScenarioWithSource): TuiPtyCase[] {
+export function validateTuiPtyScenario(scenario: QaSeedScenarioWithSource): {
+  cases: TuiPtyCase[];
+  cliMode: TuiPtyCliMode;
+} {
   if (scenario.execution.kind !== "script") {
     throw new Error(`scenario ${scenario.id} must use execution.kind=script`);
   }
   if (scenario.execution.path !== SOURCE_PATH) {
     throw new Error(`scenario ${scenario.id} must execute ${SOURCE_PATH}`);
   }
+  const requireBuiltCli = scenario.execution.config?.requireBuiltCli;
+  if (requireBuiltCli !== undefined && typeof requireBuiltCli !== "boolean") {
+    throw new Error("execution.config.requireBuiltCli must be a boolean when provided");
+  }
+  const cliMode: TuiPtyCliMode = requireBuiltCli === true ? "built" : "source";
   const rawCases = scenario.execution.config?.tuiPtyCases;
   if (!Array.isArray(rawCases) || rawCases.length === 0) {
     throw new Error(`scenario ${scenario.id} must configure a non-empty tuiPtyCases array`);
@@ -225,11 +238,20 @@ export function validateTuiPtyScenario(scenario: QaSeedScenarioWithSource): TuiP
       `scenario ${scenario.id} has primary coverage IDs without TUI PTY cases: ${missingPrimary.join(", ")}`,
     );
   }
-  return cases;
+  const hasNonLocalCase = cases.some(
+    (configuredCase) => configuredCase.testFile !== LOCAL_PTY_TEST_FILE,
+  );
+  if (cliMode === "built" && hasNonLocalCase) {
+    throw new Error(
+      `execution.config.requireBuiltCli=true requires every testFile to be exactly ${LOCAL_PTY_TEST_FILE}`,
+    );
+  }
+  return { cases, cliMode };
 }
 
 export function buildTuiPtyVitestCommand(params: {
   cases: readonly TuiPtyCase[];
+  cliMode: TuiPtyCliMode;
   repoRoot: string;
   reportPath: string;
 }): ProducerCommand {
@@ -248,6 +270,11 @@ export function buildTuiPtyVitestCommand(params: {
     env.OPENCLAW_TUI_PTY_INCLUDE_LOCAL = "1";
   } else {
     delete env.OPENCLAW_TUI_PTY_INCLUDE_LOCAL;
+  }
+  if (params.cliMode === "built") {
+    env.OPENCLAW_TUI_PTY_USE_BUILT_CLI = "1";
+  } else {
+    delete env.OPENCLAW_TUI_PTY_USE_BUILT_CLI;
   }
   return {
     command: process.execPath,
@@ -358,6 +385,34 @@ async function writeJson(filePath: string, value: unknown) {
   await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
 }
 
+function buildProofMatrix(
+  scenarioId: string,
+  cliMode: TuiPtyCliMode,
+  cases: readonly ProofMatrixCase[],
+) {
+  return {
+    schemaVersion: 1,
+    scenarioId,
+    cliMode,
+    generatedAt: new Date().toISOString(),
+    cases,
+  };
+}
+
+async function requireBuiltCliArtifacts(repoRoot: string, cliMode: TuiPtyCliMode) {
+  if (cliMode !== "built") {
+    return;
+  }
+  const [launcher, ...entries] = await Promise.allSettled(
+    ["openclaw.mjs", "dist/entry.js", "dist/entry.mjs"].map((file) =>
+      fs.access(path.join(repoRoot, file), fsConstants.R_OK),
+    ),
+  );
+  if (launcher?.status !== "fulfilled" || !entries.some((entry) => entry.status === "fulfilled")) {
+    throw new Error(BUILT_CLI_REQUIREMENT);
+  }
+}
+
 function sanitizeVitestReport(report: VitestJsonReport, proofCases: readonly ProofMatrixCase[]) {
   const allowedFiles = new Set(proofCases.map((configuredCase) => configuredCase.testFile));
   const testResults = Array.isArray(report.testResults)
@@ -383,7 +438,7 @@ export async function runTuiPtyEvidenceProducer(
       `loaded scenario ${scenario.id} does not match requested scenario ${options.scenarioId}`,
     );
   }
-  const cases = validateTuiPtyScenario(scenario);
+  const { cases, cliMode } = validateTuiPtyScenario(scenario);
   const reportPath = path.join(options.artifactBase, REPORT_FILENAME);
   const proofMatrixPath = path.join(options.artifactBase, PROOF_MATRIX_FILENAME);
   const target = {
@@ -404,12 +459,20 @@ export async function runTuiPtyEvidenceProducer(
     target,
   });
   const startedAt = (dependencies.now ?? Date.now)();
+  writer.appendLog(`cliMode=${cliMode}\n`);
   await fs.mkdir(options.artifactBase, { recursive: true });
   await Promise.all([fs.rm(reportPath, { force: true }), fs.rm(proofMatrixPath, { force: true })]);
+  const initialProofCases = cases.map((configuredCase) => ({
+    ...configuredCase,
+    matchedAssertions: [],
+  }));
+  await writeJson(proofMatrixPath, buildProofMatrix(scenario.id, cliMode, initialProofCases));
 
   try {
+    await requireBuiltCliArtifacts(options.repoRoot, cliMode);
     const command = buildTuiPtyVitestCommand({
       cases,
+      cliMode,
       reportPath,
       repoRoot: options.repoRoot,
     });
@@ -447,12 +510,7 @@ export async function runTuiPtyEvidenceProducer(
       repoRoot: options.repoRoot,
     });
     await writeJson(reportPath, sanitizeVitestReport(report, proofCases));
-    await writeJson(proofMatrixPath, {
-      schemaVersion: 1,
-      scenarioId: scenario.id,
-      generatedAt: new Date().toISOString(),
-      cases: proofCases,
-    });
+    await writeJson(proofMatrixPath, buildProofMatrix(scenario.id, cliMode, proofCases));
     return await writer.write({
       artifacts: [
         { kind: "vitest-report", filePath: REPORT_FILENAME },
@@ -466,6 +524,7 @@ export async function runTuiPtyEvidenceProducer(
     const details = formatErrorMessage(error);
     writer.appendLog(`\nfail: ${details}\n`);
     return await writer.write({
+      artifacts: [{ kind: "proof-matrix", filePath: PROOF_MATRIX_FILENAME }],
       details,
       durationMs: Math.max(1, (dependencies.now ?? Date.now)() - startedAt),
       status: "fail",


### PR DESCRIPTION
## What Problem This Solves

The supported TUI CLI entrypoints lacked primary end-to-end coverage proving that they launch through a real PTY, reach a visible ready state, honor an initial message, and reject incompatible launch options.

## Why This Change Was Made

Adds five exact QA coverage owners backed by the landed T00 PTY evidence producer through `execution.config.tuiPtyCases`. The producer now normalizes the declarative `requireBuiltCli` option to `cliMode: source|built`, owns `OPENCLAW_TUI_PTY_USE_BUILT_CLI`, and refuses built proof unless the launcher and a built entry artifact are readable before spawn.

The tests launch the real `tui`, `chat`, and `terminal` CLI entrypoints. Only the external model endpoint is mocked.

Primary coverage:

- `tui.gateway-tui-launch`
- `tui.local-chat-launch`
- `tui.terminal-alias-launch`
- `tui.initial-message-launch`
- `tui.launch-option-validation`

## User Impact

No runtime behavior changes. Maintainers gain regression proof for the canonical Gateway-backed TUI launch, both local aliases, launch-time messages, option validation, and the distinction between source-default and required-built CLI evidence.

## Scope

- Four test/QA files total.
- Zero production LOC.
- The existing TUI PTY test remains unchanged by the producer repair.
- Repair delta: `+193/-12`; full PR delta: `+340/-14`.

## Evidence

- Exact head: `26ca43ad328d345f61ac6db6d2d79a68bbf801f6`.
- Focused producer contract: `15 passed`.
- Direct AWS private-QA run: `run_1b43c95e7887`.
  - `OPENCLAW_BUILD_PRIVATE_QA=1` build passed.
  - T01 with ambient built flag unset: `cliMode: built`; all five exact cases authenticated.
  - T01 with ambient built flag `0`: `cliMode: built`; all five exact cases authenticated.
  - T00 source-default with inherited built flag `1`: `cliMode: source`; the configured PTY case authenticated.
- Fresh autoreview: TruffleHog clean; no accepted/actionable P0/P1 findings; overall correctness `0.93`.
- Formatting, `git diff --check`, exact-file scope, collision, and privacy checks are clean.
- Production LOC delta: `0`.

The AWS run's only failing step was the broad changed gate because the raw remote checkout did not contain `origin/main`; all build and QA evidence assertions had already passed. The trusted local fallback resolved that merge-base gate and then exposed unrelated shared-toolchain/generated-file errors outside this PR. Exact-head hosted CI is the authoritative no-reconciliation gate.

## Review Disposition

This addresses the prior ClawSweeper P1 directly: the T01 scenario can no longer authenticate the source fallback when built CLI proof is required. No fallback, build, or retry was added to the producer.

The branch intentionally remains on its reviewed base because newer `main` commits do not materially affect this proof.
