### PR TITLE
test(qa): cover composed tool result consumption

### DIFF
--- a/qa/scenarios/runtime/agent-tool-consumption.yaml
+++ b/qa/scenarios/runtime/agent-tool-consumption.yaml
@@ -1,0 +1,141 @@
+title: Agent tool result consumption
+
+scenario:
+  id: agent-tool-consumption
+  surface: agent-runtime
+  coverage:
+    primary:
+      - agent-runtime.tool-switching
+      - agent-runtime.tool-no-fake-progress
+      - agent-runtime.tool-evidence
+  objective: Verify one agent turn consumes two distinct real tool results in order before producing one evidence-backed terminal response.
+  successCriteria:
+    - The agent calls memory_search and memory_get in strict sequence with distinct call identities.
+    - Each tool result reaches the next provider request with the matching call identity.
+    - No terminal response is emitted until both tool results have been consumed.
+    - The single terminal response quotes a nonce available only from the memory_get result.
+  docsRefs:
+    - docs/help/testing.md
+  codeRefs:
+    - src/agents/embedded-agent-runner/run/attempt.ts
+    - extensions/memory-core/src/tools.ts
+    - extensions/qa-lab/src/providers/mock-openai/server.ts
+  execution:
+    kind: flow
+    summary: Consume an ordered memory_search and memory_get chain before one evidence-backed terminal response.
+    providerMode: mock-openai
+    retryCount: 0
+    config:
+      requiredProviderMode: mock-openai
+      memoryQuery: hidden project codename
+      expectedMemoryPath: memory/qa-agent-tool-consumption.md
+      promptSnippet: "Memory tools check"
+      prompt: "Memory tools check: what is the hidden project codename stored only in memory? Use memory tools first. Do not guess, narrate progress, or claim completion before both tool results are available."
+
+flow:
+  steps:
+    - name: consumes both matched tool results before replying
+      actions:
+        - assert:
+            expr: "env.providerMode === config.requiredProviderMode"
+            message:
+              expr: "`expected provider mode ${config.requiredProviderMode}, got ${env.providerMode}`"
+        - call: reset
+        - set: nonce
+          value:
+            expr: "`ORBIT-${parseInt(randomUUID().replaceAll('-', '').slice(0, 8), 16)}`"
+        - set: memoryFact
+          value:
+            expr: "`Hidden QA fact: the project codename is ${nonce}.`"
+        - assert:
+            expr: "!config.prompt.includes(nonce)"
+            message: tool-only nonce leaked into the user prompt
+        - call: fs.mkdir
+          args:
+            - expr: "path.dirname(path.join(env.gateway.workspaceDir, config.expectedMemoryPath))"
+            - recursive: true
+        - call: fs.writeFile
+          args:
+            - expr: "path.join(env.gateway.workspaceDir, config.expectedMemoryPath)"
+            - expr: "`${memoryFact}\\n`"
+            - utf8
+        - call: forceMemoryIndex
+          args:
+            - env:
+                ref: env
+              query:
+                expr: config.memoryQuery
+              expectedNeedle:
+                ref: nonce
+        - call: waitForGatewayHealthy
+          args:
+            - ref: env
+            - 60000
+        - set: requestCursorBefore
+          value:
+            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/request-cursor`)).cursor"
+        - set: outboundStartIndex
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
+        - set: sessionKey
+          value:
+            expr: "`agent:qa:tool-consumption:${randomUUID().slice(0, 8)}`"
+        - call: runAgentPrompt
+          args:
+            - ref: env
+            - sessionKey:
+                ref: sessionKey
+              message:
+                expr: config.prompt
+              timeoutMs:
+                expr: liveTurnTimeoutMs(env, 30000)
+        - call: waitForOutboundMessage
+          saveAs: outbound
+          args:
+            - ref: state
+            - lambda:
+                params: [candidate]
+                expr: "candidate.conversation.id === 'qa-operator' && candidate.text.includes(nonce)"
+            - expr: liveTurnTimeoutMs(env, 30000)
+            - sinceIndex:
+                ref: outboundStartIndex
+        - set: scenarioRequests
+          value:
+            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBefore}`)).filter((request) => String(request.allInputText ?? '').includes(config.promptSnippet))"
+        - assert:
+            expr: scenarioRequests.length === 3
+            message:
+              expr: "`expected exactly three provider requests, got ${JSON.stringify(scenarioRequests)}`"
+        - set: searchPlanRequest
+          value:
+            expr: scenarioRequests[0]
+        - set: searchResultRequest
+          value:
+            expr: scenarioRequests[1]
+        - set: getResultRequest
+          value:
+            expr: scenarioRequests[2]
+        - assert:
+            expr: "searchPlanRequest.plannedToolName === 'memory_search' && typeof searchPlanRequest.plannedToolCallId === 'string' && searchPlanRequest.plannedToolCallId.length > 0 && !searchPlanRequest.toolOutputCallId && !String(searchPlanRequest.allInputText ?? '').includes(nonce)"
+            message:
+              expr: "`first request did not exclusively plan memory_search without the nonce: ${JSON.stringify(searchPlanRequest)}`"
+        - assert:
+            expr: "searchResultRequest.toolOutputCallId === searchPlanRequest.plannedToolCallId && searchResultRequest.toolOutputStructuredError !== true && String(searchResultRequest.toolOutput ?? '').includes(config.expectedMemoryPath) && String(searchResultRequest.toolOutput ?? '').includes(nonce) && String(searchResultRequest.allInputText ?? '').includes(nonce) && searchResultRequest.plannedToolName === 'memory_get' && searchResultRequest.plannedToolArgs?.path === config.expectedMemoryPath && typeof searchResultRequest.plannedToolCallId === 'string' && searchResultRequest.plannedToolCallId.length > 0 && searchResultRequest.plannedToolCallId !== searchPlanRequest.plannedToolCallId"
+            message:
+              expr: "`memory_search result did not causally plan a distinct memory_get call: ${JSON.stringify(searchResultRequest)}`"
+        - assert:
+            expr: "getResultRequest.toolOutputCallId === searchResultRequest.plannedToolCallId && getResultRequest.toolOutputStructuredError !== true && String(getResultRequest.toolOutput ?? '').includes(nonce) && String(getResultRequest.allInputText ?? '').includes(nonce) && !getResultRequest.plannedToolName"
+            message:
+              expr: "`memory_get result was not consumed before terminal generation: ${JSON.stringify(getResultRequest)}`"
+        - set: terminalOutbounds
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').slice(outboundStartIndex)"
+        - assert:
+            expr: "terminalOutbounds.length === 1 && terminalOutbounds[0].id === outbound.id"
+            message:
+              expr: "`expected exactly one visible terminal outcome after both results: ${JSON.stringify(terminalOutbounds)}`"
+        - assert:
+            expr: "outbound.text.includes(nonce) && (outbound.text.match(new RegExp(nonce, 'g')) ?? []).length === 1"
+            message:
+              expr: "`terminal response did not quote the tool-only nonce exactly once: ${outbound.text}`"
+      detailsExpr: "`${outbound.text}; tools=${searchPlanRequest.plannedToolName}->${searchResultRequest.plannedToolName}; matched=${searchResultRequest.toolOutputCallId === searchPlanRequest.plannedToolCallId && getResultRequest.toolOutputCallId === searchResultRequest.plannedToolCallId}; terminalOutcomes=${terminalOutbounds.length}`"


### PR DESCRIPTION
## Summary

- add one mock-openai flow scenario for composed tool result consumption
- prove `memory_search` and `memory_get` run in strict order with distinct matched call/result identities
- prove the single terminal response appears only after both results and quotes a nonce absent from the prompt

## Scope

- one new QA scenario file
- production LOC: +0
- QA LOC: +141
- no runtime, harness, taxonomy, docs, or existing scenario changes

## QA verdict

```json
{
  "scenario": "agent-tool-consumption",
  "head": "4cda5d9fb2e2e0d418f11ba6a34b7bb581feaba0",
  "providerMode": "mock-openai",
  "gateway": "ephemeral",
  "result": "pass",
  "orderedTools": ["memory_search", "memory_get"],
  "matchedCallResults": true,
  "promptContainsNonce": false,
  "terminalOutcomes": 1,
  "primaryCoverage": [
    "agent-runtime.tool-switching",
    "agent-runtime.tool-no-fake-progress",
    "agent-runtime.tool-evidence"
  ]
}
```

## Validation

- exact-head focused suite:
  - `pnpm openclaw qa suite --provider-mode mock-openai --scenario agent-tool-consumption --concurrency 1`
  - pass: 1/1
  - `qa-evidence.json` ref: `4cda5d9fb2e2e0d418f11ba6a34b7bb581feaba0`
  - exactly three primary coverage IDs and no secondary coverage
- coverage lookup:
  - `pnpm openclaw qa coverage --json --match agent-tool-consumption`
  - one `flow` / `mock-openai` match with the three claimed IDs
- changed gate:
  - Blacksmith Testbox was selected and leased as `tbx_01kz4vn4b2zq018n4eex5esam7`, but its updated CLI stalled before remote command execution with no host or run history
  - trusted local fallback passed the full fail-safe all-lanes gate, including typecheck, lint, and zero runtime import cycles
- fresh direct-binary Sol/high autoreview:
  - no findings
  - patch correct, confidence 0.99
- `pnpm format qa/scenarios/runtime/agent-tool-consumption.yaml`
- `git diff --check`
