### PR TITLE
perf(cli): install prepared plugin metadata snapshot for models list

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2606,7 +2606,6 @@ src/commands/models/list.persisted-catalog.ts	2
 src/commands/models/list.probe.ts	2
 src/commands/models/list.registry.ts	3
 src/commands/models/list.rows.ts	3
-src/commands/models/list.status-command.ts	1
 src/commands/models/shared.ts	3
 src/commands/onboard-agent.ts	1
 src/commands/onboard-config.ts	3

--- a/src/commands/models/list.list-command.ts
+++ b/src/commands/models/list.list-command.ts
@@ -11,6 +11,7 @@ import { requestExitAfterOneShotOutput } from "../../cli/one-shot-exit.js";
 import type { ModelRegistry } from "../../llm/model-registry.js";
 import type { Model } from "../../llm/types.js";
 import { loadManifestMetadataSnapshot } from "../../plugins/manifest-contract-eligibility.js";
+import { installCommandPluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { createModelListAuthIndex } from "./list.auth-index.js";
@@ -90,199 +91,212 @@ export async function modelsListCommand(
     workspaceDir,
     env: process.env,
   });
-  const providerAliasCanonicalizer = createModelCatalogProviderAliasCanonicalizer({
-    cfg,
-    metadataSnapshot,
-  });
-  const providerFilter = parsedProviderFilter
-    ? providerAliasCanonicalizer.provider(parsedProviderFilter)
-    : undefined;
-  const { entries } = resolveConfiguredModelEntries({
-    cfg,
-    agentId,
-    ...DISPLAY_MODEL_PARSE_OPTIONS,
-    canonicalizeRef: providerAliasCanonicalizer.ref,
-  });
-  if (providerFilter) {
-    const knownProviderIds = new Set(
-      [
-        ...metadataSnapshot.owners.providers.keys(),
-        ...metadataSnapshot.owners.modelCatalogProviders.keys(),
-        ...Object.keys(cfg.models?.providers ?? {}),
-        ...entries.map((entry) => entry.ref.provider),
-      ].map((providerId) => providerAliasCanonicalizer.provider(providerId)),
-    );
-    if (!knownProviderIds.has(providerFilter)) {
-      const message = `Unknown provider filter "${sanitizeTerminalText(rawProviderFilter ?? providerFilter)}" for this installation. Run ${formatCliCommand("openclaw plugins list --json")} to see installed providers, or configure it under models.providers.`;
-      throw new ExpectedCliError({ message, humanOutput: message, machineOutput: message });
-    }
-  }
-  const inheritedAuthDir = resolveLegacyInheritedAuthDir(cfg);
-  const authStore = inheritedAuthDir
-    ? loadAuthProfileStoreWithoutExternalProfiles(agentDir, { inheritedAuthDir })
-    : loadAuthProfileStoreWithoutExternalProfiles(agentDir);
-  const authIndex = createModelListAuthIndex({
-    cfg,
-    authStore,
-    agentDir,
+  // Publish the prepared snapshot for this invocation: downstream provider-alias
+  // and manifest-suppression lookups consult the process-current slot and would
+  // otherwise each repeat a full discovery scan.
+  const cleanupPluginMetadataSnapshot = installCommandPluginMetadataSnapshot({
+    snapshot: metadataSnapshot,
+    config: cfg,
     workspaceDir,
-    metadataSnapshot,
-    // Default output can append authenticated catalog rows beyond the configured
-    // default, so keep the nonprompting OpenAI CLI overlay available in every view.
-    externalCliProviderIds: ["openai"],
+    env: process.env,
   });
-
-  let modelRegistry: ModelRegistry | undefined;
-  let registryModels: Model[] = [];
-  let discoveredKeys = new Set<string>();
-  let availableKeys: Set<string> | undefined;
-  let availabilityErrorMessage: string | undefined;
-  const configuredByKey = new Map(entries.map((entry) => [entry.key, entry]));
-  // The default configured view remains lazy; full and filtered views share
-  // the registry and the same committed model generation as the Gateway.
-  const includePreparedCatalog = Boolean(opts.all || providerFilter);
-  const providerDiscoveryProviderIds = (() => {
-    if (opts.all && !providerFilter) {
-      return undefined;
-    }
+  try {
+    const providerAliasCanonicalizer = createModelCatalogProviderAliasCanonicalizer({
+      cfg,
+      metadataSnapshot,
+    });
+    const providerFilter = parsedProviderFilter
+      ? providerAliasCanonicalizer.provider(parsedProviderFilter)
+      : undefined;
+    const { entries } = resolveConfiguredModelEntries({
+      cfg,
+      agentId,
+      ...DISPLAY_MODEL_PARSE_OPTIONS,
+      canonicalizeRef: providerAliasCanonicalizer.ref,
+    });
     if (providerFilter) {
-      return [providerFilter];
-    }
-    return [
-      ...new Set([
-        ...(authIndex.providerDiscoveryProviderIds ?? []),
-        ...entries.map((entry) => entry.ref.provider),
-        ...Object.keys(cfg.models?.providers ?? {}),
-      ]),
-    ].toSorted((left, right) => left.localeCompare(right));
-  })();
-  const providerRuntimeDiscoveryProviderIds = providerFilter
-    ? [providerFilter]
-    : opts.all
-      ? undefined
-      : [];
-  // Default lists use authenticated providers' authored fallback rows. Live
-  // account discovery remains explicit because it imports full provider runtimes.
-  const providerManifestFallbackProviderIds =
-    !providerFilter && !opts.all ? authIndex.providerDiscoveryProviderIds : undefined;
-  try {
-    if (includePreparedCatalog) {
-      const { loadModelRegistry } = await registryModuleLoader.load();
-      const loaded = await loadModelRegistry(cfg, {
-        agentId,
-        agentDir,
-        providerFilter,
-        normalizeModels: Boolean(providerFilter),
-        workspaceDir,
-      });
-      modelRegistry = loaded.registry;
-      registryModels = loaded.models;
-      discoveredKeys = loaded.discoveredKeys;
-      availableKeys = loaded.availableKeys;
-      availabilityErrorMessage = loaded.availabilityErrorMessage;
-    } else if (!opts.all && opts.local) {
-      const { loadConfiguredListModelRegistry } = await registryModuleLoader.load();
-      const loaded = await loadConfiguredListModelRegistry(cfg, entries, {
-        agentId,
-        agentDir,
-        providerFilter,
-        workspaceDir,
-      });
-      modelRegistry = loaded.registry;
-      discoveredKeys = loaded.discoveredKeys;
-      availableKeys = loaded.availableKeys;
-    }
-  } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
-    const message = `Model registry unavailable: ${detail}`;
-    throw new ExpectedCliError({
-      message,
-      humanOutput: `Model registry unavailable:\n${formatErrorWithStack(err)}`,
-      machineOutput: message,
-    });
-  }
-  const promotionsModulePromise = humanReadable ? promotionsModuleLoader.load() : undefined;
-  const promotionsRefreshPromise = promotionsModulePromise
-    ?.then((promotionsModule) => promotionsModule.startPromotionsFeedRefresh())
-    .catch(() => undefined);
-  const rowContext = {
-    cfg,
-    agentId,
-    agentDir,
-    ...(inheritedAuthDir ? { inheritedAuthDir } : {}),
-    authIndex,
-    canonicalizeProvider: providerAliasCanonicalizer.provider,
-    providerDiscoveryProviderIds,
-    providerRuntimeDiscoveryProviderIds,
-    providerManifestFallbackProviderIds,
-    availableKeys,
-    configuredByKey,
-    discoveredKeys,
-    filter: {
-      provider: providerFilter,
-      local: opts.local,
-    },
-    metadataSnapshot,
-    workspaceDir,
-  };
-  const rows: ModelRow[] = [];
-
-  if (includePreparedCatalog) {
-    const { appendAllModelRowSources } = await rowSourcesModuleLoader.load();
-    await appendAllModelRowSources({
-      rows,
-      entries,
-      context: rowContext,
-      modelRegistry,
-      registryModels,
-    });
-  } else {
-    const { appendConfiguredModelRowSources } = await rowSourcesModuleLoader.load();
-    await appendConfiguredModelRowSources({
-      rows,
-      entries,
-      modelRegistry,
-      context: rowContext,
-    });
-  }
-
-  if (availabilityErrorMessage !== undefined) {
-    runtime.error(
-      `Model availability lookup failed; falling back to auth heuristics for discovered models: ${availabilityErrorMessage}`,
-    );
-  }
-
-  // Promotion decorations are best-effort: claim tags come from local
-  // provenance, and the discovery section reads a cadence-gated feed cache.
-  // Neither may break the core listing; stale refreshes have a short timeout.
-  const promotionsModule = await (promotionsModulePromise ?? promotionsModuleLoader.load());
-  try {
-    promotionsModule.applyPromotionClaimTags(rows);
-  } catch {
-    // Tags are annotation-only.
-  }
-  if (rows.length === 0 && !opts.json && !opts.plain) {
-    runtime.log("No models found.");
-  } else {
-    printModelTable(rows, runtime, opts);
-  }
-  if (promotionsRefreshPromise) {
-    // Runs on the empty listing too: a fresh install with zero configured
-    // models is exactly the user passive discovery is for. Compares against
-    // the configured entries, not the rendered rows — filtered and --all
-    // listings show a different set.
-    try {
-      const refresh = await promotionsRefreshPromise;
-      if (refresh) {
-        await promotionsModule.printAvailablePromotionsSection({
-          configuredKeys: new Set(entries.map((entry) => entry.key)),
-          refresh,
-          runtime,
-        });
+      const knownProviderIds = new Set(
+        [
+          ...metadataSnapshot.owners.providers.keys(),
+          ...metadataSnapshot.owners.modelCatalogProviders.keys(),
+          ...Object.keys(cfg.models?.providers ?? {}),
+          ...entries.map((entry) => entry.ref.provider),
+        ].map((providerId) => providerAliasCanonicalizer.provider(providerId)),
+      );
+      if (!knownProviderIds.has(providerFilter)) {
+        const message = `Unknown provider filter "${sanitizeTerminalText(rawProviderFilter ?? providerFilter)}" for this installation. Run ${formatCliCommand("openclaw plugins list --json")} to see installed providers, or configure it under models.providers.`;
+        throw new ExpectedCliError({ message, humanOutput: message, machineOutput: message });
       }
-    } catch {
-      // Passive discovery must never fail the listing.
     }
+    const inheritedAuthDir = resolveLegacyInheritedAuthDir(cfg);
+    const authStore = inheritedAuthDir
+      ? loadAuthProfileStoreWithoutExternalProfiles(agentDir, { inheritedAuthDir })
+      : loadAuthProfileStoreWithoutExternalProfiles(agentDir);
+    const authIndex = createModelListAuthIndex({
+      cfg,
+      authStore,
+      agentDir,
+      workspaceDir,
+      metadataSnapshot,
+      // Default output can append authenticated catalog rows beyond the configured
+      // default, so keep the nonprompting OpenAI CLI overlay available in every view.
+      externalCliProviderIds: ["openai"],
+    });
+
+    let modelRegistry: ModelRegistry | undefined;
+    let registryModels: Model[] = [];
+    let discoveredKeys = new Set<string>();
+    let availableKeys: Set<string> | undefined;
+    let availabilityErrorMessage: string | undefined;
+    const configuredByKey = new Map(entries.map((entry) => [entry.key, entry]));
+    // The default configured view remains lazy; full and filtered views share
+    // the registry and the same committed model generation as the Gateway.
+    const includePreparedCatalog = Boolean(opts.all || providerFilter);
+    const providerDiscoveryProviderIds = (() => {
+      if (opts.all && !providerFilter) {
+        return undefined;
+      }
+      if (providerFilter) {
+        return [providerFilter];
+      }
+      return [
+        ...new Set([
+          ...(authIndex.providerDiscoveryProviderIds ?? []),
+          ...entries.map((entry) => entry.ref.provider),
+          ...Object.keys(cfg.models?.providers ?? {}),
+        ]),
+      ].toSorted((left, right) => left.localeCompare(right));
+    })();
+    const providerRuntimeDiscoveryProviderIds = providerFilter
+      ? [providerFilter]
+      : opts.all
+        ? undefined
+        : [];
+    // Default lists use authenticated providers' authored fallback rows. Live
+    // account discovery remains explicit because it imports full provider runtimes.
+    const providerManifestFallbackProviderIds =
+      !providerFilter && !opts.all ? authIndex.providerDiscoveryProviderIds : undefined;
+    try {
+      if (includePreparedCatalog) {
+        const { loadModelRegistry } = await registryModuleLoader.load();
+        const loaded = await loadModelRegistry(cfg, {
+          agentId,
+          agentDir,
+          providerFilter,
+          normalizeModels: Boolean(providerFilter),
+          workspaceDir,
+        });
+        modelRegistry = loaded.registry;
+        registryModels = loaded.models;
+        discoveredKeys = loaded.discoveredKeys;
+        availableKeys = loaded.availableKeys;
+        availabilityErrorMessage = loaded.availabilityErrorMessage;
+      } else if (!opts.all && opts.local) {
+        const { loadConfiguredListModelRegistry } = await registryModuleLoader.load();
+        const loaded = await loadConfiguredListModelRegistry(cfg, entries, {
+          agentId,
+          agentDir,
+          providerFilter,
+          workspaceDir,
+        });
+        modelRegistry = loaded.registry;
+        discoveredKeys = loaded.discoveredKeys;
+        availableKeys = loaded.availableKeys;
+      }
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      const message = `Model registry unavailable: ${detail}`;
+      throw new ExpectedCliError({
+        message,
+        humanOutput: `Model registry unavailable:\n${formatErrorWithStack(err)}`,
+        machineOutput: message,
+      });
+    }
+    const promotionsModulePromise = humanReadable ? promotionsModuleLoader.load() : undefined;
+    const promotionsRefreshPromise = promotionsModulePromise
+      ?.then((promotionsModule) => promotionsModule.startPromotionsFeedRefresh())
+      .catch(() => undefined);
+    const rowContext = {
+      cfg,
+      agentId,
+      agentDir,
+      ...(inheritedAuthDir ? { inheritedAuthDir } : {}),
+      authIndex,
+      canonicalizeProvider: providerAliasCanonicalizer.provider,
+      providerDiscoveryProviderIds,
+      providerRuntimeDiscoveryProviderIds,
+      providerManifestFallbackProviderIds,
+      availableKeys,
+      configuredByKey,
+      discoveredKeys,
+      filter: {
+        provider: providerFilter,
+        local: opts.local,
+      },
+      metadataSnapshot,
+      workspaceDir,
+    };
+    const rows: ModelRow[] = [];
+
+    if (includePreparedCatalog) {
+      const { appendAllModelRowSources } = await rowSourcesModuleLoader.load();
+      await appendAllModelRowSources({
+        rows,
+        entries,
+        context: rowContext,
+        modelRegistry,
+        registryModels,
+      });
+    } else {
+      const { appendConfiguredModelRowSources } = await rowSourcesModuleLoader.load();
+      await appendConfiguredModelRowSources({
+        rows,
+        entries,
+        modelRegistry,
+        context: rowContext,
+      });
+    }
+
+    if (availabilityErrorMessage !== undefined) {
+      runtime.error(
+        `Model availability lookup failed; falling back to auth heuristics for discovered models: ${availabilityErrorMessage}`,
+      );
+    }
+
+    // Promotion decorations are best-effort: claim tags come from local
+    // provenance, and the discovery section reads a cadence-gated feed cache.
+    // Neither may break the core listing; stale refreshes have a short timeout.
+    const promotionsModule = await (promotionsModulePromise ?? promotionsModuleLoader.load());
+    try {
+      promotionsModule.applyPromotionClaimTags(rows);
+    } catch {
+      // Tags are annotation-only.
+    }
+    if (rows.length === 0 && !opts.json && !opts.plain) {
+      runtime.log("No models found.");
+    } else {
+      printModelTable(rows, runtime, opts);
+    }
+    if (promotionsRefreshPromise) {
+      // Runs on the empty listing too: a fresh install with zero configured
+      // models is exactly the user passive discovery is for. Compares against
+      // the configured entries, not the rendered rows — filtered and --all
+      // listings show a different set.
+      try {
+        const refresh = await promotionsRefreshPromise;
+        if (refresh) {
+          await promotionsModule.printAvailablePromotionsSection({
+            configuredKeys: new Set(entries.map((entry) => entry.key)),
+            refresh,
+            runtime,
+          });
+        }
+      } catch {
+        // Passive discovery must never fail the listing.
+      }
+    }
+    requestExitAfterOneShotOutput(runtime);
+  } finally {
+    cleanupPluginMetadataSnapshot();
   }
-  requestExitAfterOneShotOutput(runtime);
 }

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -73,12 +73,8 @@ import { parseModelPolicyWildcardRef } from "../../config/model-policy-ref.js";
 import { resolveMergedModelProviderConfig } from "../../config/model-provider-config.js";
 import { getShellEnvAppliedKeys, shouldEnableShellEnvFallback } from "../../infra/shell-env.js";
 import type { ProviderModelRouteCandidate } from "../../plugin-sdk/provider-model-types.js";
-import {
-  getCurrentPluginMetadataSnapshot,
-  installTemporaryCurrentPluginMetadataSnapshot,
-} from "../../plugins/current-plugin-metadata-snapshot.js";
 import { loadManifestMetadataSnapshot } from "../../plugins/manifest-contract-eligibility.js";
-import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
+import { installCommandPluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.js";
 import type { ProviderSyntheticAuthResult } from "../../plugins/provider-external-auth.types.js";
 import { resolveProviderSyntheticAuthWithPlugin } from "../../plugins/provider-runtime.js";
 import { resolveRuntimeSyntheticAuthProviderRefs } from "../../plugins/synthetic-auth.runtime.js";
@@ -237,43 +233,6 @@ function parseOptionalPositiveIntegerOption(raw: unknown, label: string, fallbac
     throw new Error(`${label} must be a positive integer.`);
   }
   return parsed;
-}
-
-function isCompletePluginMetadataSnapshot(value: unknown): value is PluginMetadataSnapshot {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const snapshot = value as Partial<PluginMetadataSnapshot>;
-  return (
-    typeof snapshot.policyHash === "string" &&
-    snapshot.index !== undefined &&
-    snapshot.manifestRegistry !== undefined
-  );
-}
-
-function installCommandPluginMetadataSnapshot(params: {
-  snapshot: PluginMetadataSnapshot;
-  config: Awaited<ReturnType<typeof loadModelsConfig>>;
-  workspaceDir?: string;
-  env: NodeJS.ProcessEnv;
-}): () => void {
-  if (!isCompletePluginMetadataSnapshot(params.snapshot)) {
-    return () => {};
-  }
-  const current = getCurrentPluginMetadataSnapshot({
-    config: params.config,
-    workspaceDir: params.workspaceDir,
-    env: params.env,
-  });
-  if (current) {
-    return () => {};
-  }
-  const lease = installTemporaryCurrentPluginMetadataSnapshot(params.snapshot, {
-    config: params.config,
-    workspaceDir: params.workspaceDir,
-    env: params.env,
-  });
-  return lease.release;
 }
 
 function syntheticAuthCredential(

--- a/src/plugins/plugin-metadata-snapshot.test.ts
+++ b/src/plugins/plugin-metadata-snapshot.test.ts
@@ -1,7 +1,9 @@
 // Verifies lifecycle snapshot loading, ownership facts, and immutable boundaries.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   adoptCurrentPluginMetadataSnapshotIfAbsent,
+  getCurrentPluginMetadataSnapshot,
   setCurrentPluginMetadataSnapshot,
 } from "./current-plugin-metadata-snapshot.js";
 import type { PluginDiscoveryResult } from "./discovery.js";
@@ -11,6 +13,7 @@ import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-re
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
 import {
   completePluginMetadataSnapshot,
+  installCommandPluginMetadataSnapshot,
   loadPluginMetadataSnapshot,
   resolvePluginMetadataSnapshot,
   restorePluginMetadataSnapshot,
@@ -716,4 +719,68 @@ describe("plugin metadata snapshot", () => {
       }).toThrow();
     },
   );
+
+  describe("installCommandPluginMetadataSnapshot", () => {
+    function buildCompleteSnapshot(config: OpenClawConfig) {
+      const index = makeIndex();
+      index.policyHash = resolveInstalledPluginIndexPolicyHash(config);
+      loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
+        source: "provided",
+        snapshot: index,
+        diagnostics: [],
+      });
+      return loadPluginMetadataSnapshot({ config, env: {}, index });
+    }
+
+    it("serves a command's installed snapshot to same-config readers, then restores the slot", () => {
+      const config = {};
+      const snapshot = buildCompleteSnapshot(config);
+
+      const cleanup = installCommandPluginMetadataSnapshot({
+        snapshot,
+        config,
+        env: process.env,
+      });
+
+      // The install is what turns a downstream cold `loadPluginMetadataSnapshot`
+      // into a slot read; `resolvePluginMetadataSnapshot` consults the slot first.
+      expect(getCurrentPluginMetadataSnapshot({ config })).toBe(snapshot);
+      expect(resolvePluginMetadataSnapshot({ config, env: process.env })).toBe(snapshot);
+
+      cleanup();
+
+      expect(getCurrentPluginMetadataSnapshot({ config })).toBeUndefined();
+    });
+
+    it("leaves an outer owner's installed snapshot in place", () => {
+      const config = {};
+      const outer = buildCompleteSnapshot(config);
+      const inner = buildCompleteSnapshot(config);
+      setCurrentPluginMetadataSnapshot(outer, { config });
+
+      const cleanup = installCommandPluginMetadataSnapshot({
+        snapshot: inner,
+        config,
+        env: process.env,
+      });
+      cleanup();
+
+      // A nested install that replaced the slot would publish `inner` when the
+      // outer owner later restored its own captured state.
+      expect(getCurrentPluginMetadataSnapshot({ config })).toBe(outer);
+    });
+
+    it("does not install an incomplete snapshot", () => {
+      const config = {};
+
+      const cleanup = installCommandPluginMetadataSnapshot({
+        snapshot: { policyHash: "hash" } as unknown as ReturnType<typeof buildCompleteSnapshot>,
+        config,
+        env: process.env,
+      });
+      cleanup();
+
+      expect(getCurrentPluginMetadataSnapshot({ config })).toBeUndefined();
+    });
+  });
 });

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -6,6 +6,7 @@ import {
 } from "../infra/diagnostics-timeline.js";
 import {
   getCurrentPluginMetadataSnapshot,
+  installTemporaryCurrentPluginMetadataSnapshot,
   isCurrentPluginMetadataSnapshotRuntimeGeneration,
 } from "./current-plugin-metadata-snapshot.js";
 import { resolveActivePluginInstallRoots } from "./install-root-context.js";
@@ -425,6 +426,53 @@ export function resolvePluginMetadataSnapshot(
     }
   }
   return loadPluginMetadataSnapshot(params);
+}
+
+function isCompletePluginMetadataSnapshot(value: unknown): value is PluginMetadataSnapshot {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const snapshot = value as Partial<PluginMetadataSnapshot>;
+  return (
+    typeof snapshot.policyHash === "string" &&
+    snapshot.index !== undefined &&
+    snapshot.manifestRegistry !== undefined
+  );
+}
+
+/** Publishes a command's prepared snapshot into the process-current slot for its own run.
+ *
+ * Routed cold commands build one snapshot and then call helpers that consult the
+ * slot before falling back to a full `loadPluginMetadataSnapshot` scan (see
+ * `resolvePluginMetadataSnapshot` above). Without an install each of those helpers
+ * repeats discovery. The returned closure must run in the command's `finally`: the
+ * lease keeps a revision-tracked previous state so it never clobbers a snapshot
+ * some other owner (a wrapping command, a concurrent reload) published later. */
+export function installCommandPluginMetadataSnapshot(params: {
+  snapshot: PluginMetadataSnapshot;
+  config: OpenClawConfig;
+  workspaceDir?: string;
+  env: NodeJS.ProcessEnv;
+}): () => void {
+  if (!isCompletePluginMetadataSnapshot(params.snapshot)) {
+    return () => {};
+  }
+  // An existing install belongs to an outer owner (gateway startup, a wrapping
+  // command); never replace it, or that owner's release would restore ours.
+  const current = getCurrentPluginMetadataSnapshot({
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+    env: params.env,
+  });
+  if (current) {
+    return () => {};
+  }
+  const lease = installTemporaryCurrentPluginMetadataSnapshot(params.snapshot, {
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+    env: params.env,
+  });
+  return lease.release;
 }
 
 function loadPluginMetadataSnapshotImpl(

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -1,4 +1,5 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   getActiveDiagnosticsTimelineSpan,
@@ -429,14 +430,13 @@ export function resolvePluginMetadataSnapshot(
 }
 
 function isCompletePluginMetadataSnapshot(value: unknown): value is PluginMetadataSnapshot {
-  if (!value || typeof value !== "object") {
+  if (!isRecord(value)) {
     return false;
   }
-  const snapshot = value as Partial<PluginMetadataSnapshot>;
   return (
-    typeof snapshot.policyHash === "string" &&
-    snapshot.index !== undefined &&
-    snapshot.manifestRegistry !== undefined
+    typeof value.policyHash === "string" &&
+    value.index !== undefined &&
+    value.manifestRegistry !== undefined
   );
 }
 


### PR DESCRIPTION
Related: #118909 (follow-up to #118343 item 4)

## What Problem This Solves

Routed cold CLI commands build one plugin metadata snapshot and then throw it away. Helpers called later in the same invocation consult the process-current slot first (`resolvePluginMetadataSnapshot`, `src/plugins/plugin-metadata-snapshot.ts:295-335`), find it empty, and each pay a full `loadPluginMetadataSnapshot` — two `discovery scan` lifecycle phases per call.

`models status` already fixes this for itself with a private `installCommandPluginMetadataSnapshot` helper. Nothing else can use it.

Measured on the real dist CLI, isolated state dir, 3 configured channels:

```
openclaw models list --json    10 "discovery scan" phases  (5 discoverOpenClawPlugins calls)
openclaw channels list --json   8 "discovery scan" phases  (4 calls)
```

## Why This Change Was Made

Extract `installCommandPluginMetadataSnapshot` into `src/plugins/plugin-metadata-snapshot.ts`, beside `resolvePluginMetadataSnapshot` — resolve reads the process-current slot, install writes it — and apply it to `models list`. The raw slot mechanics (`set`/`get`/`capture`/`restore`) stay in `current-plugin-metadata-snapshot.ts`, which this module already imported.

The shape stays what the issue asked for: build once, install into the existing lifecycle-owned single slot, cleanup in the command's `finally`. No new cache layer and no process-global discovery memo — `src/plugins/plugin-scan-existence-cache.ts:1-33` is deliberately scan-scoped and stays that way.

**`models list` is the beneficiary; `channels list` is not.** Stack-attributing every scan on `channels list --json` shows all four discovery calls land at or before the command body's own build, so an install at that point has nothing left downstream to serve:

| # | origin | position |
|---|---|---|
| 1 | `createConfigValidationMetadataPluginIdScope` → `resolveMemoizedChannelCatalogDiscovery` | config validation |
| 2 | `validateConfigObjectWithPlugins` (pluginId-**scoped** snapshot) | config validation |
| 3 | `getCompiledSecretTargetRegistryState` → `loadSecretTargetRegistryFromPluginMetadata` (asks with `config: {}`) | secret resolution |
| 4 | `channelsListCommand` → `resolvePluginMetadataSnapshot` | command body — **last** |

Calls 1–2 are upstream of the body and 2 is pluginId-scoped, so the scope gate at `current-plugin-metadata-snapshot.ts:178-190` correctly refuses to serve it from an unscoped install. Call 3 asks with `config: {}`, whose policy hash cannot match a real-config snapshot without declaring `{}` compatible — that widens what the **secret target registry** sees and is a maintainer product call on a secrets surface, not something to slip into a latency PR. (@zeroaltitude's #118464 is changing exactly that `defaultDiscoveryCompatible` rule; this PR stays out of its way.)

`models list` is the opposite: two cold readers run *after* its build, and both consult the slot first.

| # | origin | position |
|---|---|---|
| 3 | `modelsListCommand` → `loadManifestMetadataSnapshot` | command body — build |
| 4 | `resolveProviderAuthAliasMap` (`src/agents/provider-auth-aliases.ts:151-182`) | **after** build |
| 5 | `listManifestModelCatalogSuppressions` → `loadManifestMetadataSnapshot` | **after** build |

### Rejected alternative: install at `command-bootstrap.ts:50-52`

The issue points at that early return, so it is worth saying why the install does not go there. Two blockers, both in current source:

1. **No teardown seam.** There is no `postAction` hook anywhere in `src/` (`grep -rn postAction src --include='*.ts'`, excluding tests → 0), and the sole caller of `ensureCliCommandBootstrap` (`src/cli/command-execution-startup.ts:75`) awaits it and discards the result. Nothing can run the cleanup closure, so an install there leaks the slot for the rest of the process — and `channels-list-catalog-row-discovery.test.ts` already runs two invocations with different configs in one process.
2. **No config to build with.** Every beneficiary route is `configGuard: "skip"` (`channels list` at `src/cli/command-catalog.ts:549-552`, `models list` 278-283, `models status` 284-294), so `ensureConfigReady` never runs and no validated config exists at bootstrap. A snapshot built from `{}` carries `policyHash({})`, which the body's lookup rejects at `current-plugin-metadata-snapshot.ts:213-216` for any config that enables channels or plugins — you would pay the bootstrap scan *and* the body scan.

## User Impact

`openclaw models list` does two fewer full plugin discovery rebuilds per invocation. No output, config, or CLI surface change.

Not addressed here, with evidence above rather than a guess: `channels list`'s residual cost is upstream of the command body (config validation ×2, secret target registry ×1). That needs an ordering/compatibility decision at those owners, so it is left for #118909 to direct.

## Evidence

Real dist CLI (`node dist/index.js`, never `tsx`), fresh `OPENCLAW_STATE_DIR` per run so persisted install records cannot skew the count:

```bash
OPENCLAW_PLUGIN_LIFECYCLE_TRACE=1 node dist/index.js models list --json 2>&1 >/dev/null | grep -c 'phase="discovery scan"'
```

| command | before | after |
|---|---|---|
| `models list --json` | **10** | **6** |
| `channels list --json` | 8 | 8 (unchanged by design — see above) |

Phase counts are used rather than wall clock: they are deterministic and reproducible, a local timing delta is not.

Guards named in #118343/#118909, all green:

```bash
node scripts/run-vitest.mjs src/plugins/discovery-threading.test.ts src/cli/channels-list-route-cold-imports.test.ts src/cli/models-status-route-cold-imports.test.ts src/plugins/current-plugin-metadata-snapshot.test.ts src/cli/channels-list-catalog-row-discovery.test.ts
```

```
Test Files  3 passed (3) + 2 passed (2)
     Tests  3 passed (3) + 27 passed (27)
```

`discovery-threading.test.ts` is untouched by this change — the threading seam it pins (`loadPluginManifestRegistry` / `loadInstalledPluginIndexWithDiscovery`) sits below the slot.

New coverage in `current-plugin-metadata-snapshot.test.ts`: a same-config reader is served from the slot and the slot is restored after cleanup; a nested install leaves an outer owner's snapshot in place (a leak here would serve one invocation's metadata to the next in-process command — `channels-list-catalog-row-discovery.test.ts` runs two invocations in one process and would catch it); an incomplete snapshot is not installed.

Typecheck: `node scripts/run-tsgo.mjs -p tsconfig.core.json` clean.

Net production LOC **+22** (+54 shared helper, −46 private copy removed from `models status`, +14 `models list`). The `models list` raw diff is inflated by re-indentation from the `try` block; `git diff -w` shows the real 14 added lines.

### Limits

- Measured on macOS with the repo's own bundled manifests, not the 151-manifest production host; the phase-count *delta* is structural, the absolute numbers are host-dependent.
- `models status` is rewired to the shared helper with no behavior change; its own scan count is unmeasured here because the command is slow enough locally to exceed the measurement budget.
- Running the whole `src/commands/models` directory as one Vitest invocation shows failures, but they are **pre-existing on this base**: with these four files reverted to `origin/main`, `src/commands/models/auth.test.ts` still fails 9 agent-auth-store assertions (`uses the requested agent store for provider auth login`, …), which touch no plugin-metadata code. `shared.test.ts` passes in isolation, so this is cross-file interference in that directory, not a per-file break. Called out rather than left for a reviewer to trip over.

🤖 AI-assisted (Claude Opus 5). Human-reviewed before publishing.
