### PR TITLE
fix: audit effective systemd gateway unit

### DIFF
--- a/extensions/memory-core/index.test.ts
+++ b/extensions/memory-core/index.test.ts
@@ -87,6 +87,16 @@ describe("buildPromptSection", () => {
     expect(result[1]).not.toContain("then use memory_get");
   });
 
+  it("routes unavailable semantic recall through native session search", () => {
+    const result = buildPromptSection({
+      availableTools: new Set(["memory_search", "sessions_search"]),
+    });
+
+    expect(result).toContain(
+      "If memory_search reports unavailable or disabled, immediately search canonical conversation history with sessions_search using the same query. Do not guess or ask the user to repeat known context merely because semantic retrieval failed.",
+    );
+  });
+
   it("limits the guidance to memory_get when only get is available", () => {
     const result = buildPromptSection({ availableTools: new Set(["memory_get"]) });
     expect(result[0]).toBe("## Memory Recall");

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -129,7 +129,7 @@ function createLazyMemorySearchTool(options: MemoryToolOptions): AnyAgentTool | 
     label: "Memory Search",
     name: "memory_search",
     description:
-      "Mandatory recall step: semantically search MEMORY.md + memory/*.md (and optional session transcripts) before answering questions about prior work, decisions, dates, people, preferences, or todos. Optional `corpus=wiki` or `corpus=all` also searches registered compiled-wiki supplements. `corpus=memory` restricts hits to indexed memory files (excludes session transcript chunks from ranking). `corpus=sessions` restricts hits to indexed session transcripts (same visibility rules as session history tools). If response has disabled=true, memory retrieval is unavailable and should be surfaced to the user.",
+      "Mandatory recall step: semantically search MEMORY.md + memory/*.md (and optional session transcripts) before answering questions about prior work, decisions, dates, people, preferences, or todos. Optional `corpus=wiki` or `corpus=all` also searches registered compiled-wiki supplements. `corpus=memory` restricts hits to indexed memory files (excludes session transcript chunks from ranking). `corpus=sessions` restricts hits to indexed session transcripts (same visibility rules as session history tools). If response has disabled=true, semantic retrieval is unavailable; use native sessions_search with the same query for conversation history before answering, and surface any remaining coverage gap.",
     parameters: MemorySearchSchema,
     load: (module, loadOptions) => module.createMemorySearchTool(loadOptions),
   });

--- a/extensions/memory-core/src/prompt-section.ts
+++ b/extensions/memory-core/src/prompt-section.ts
@@ -7,6 +7,7 @@ export const buildPromptSection: MemoryPromptSectionBuilder = ({
 }) => {
   const hasMemorySearch = availableTools.has("memory_search");
   const hasMemoryGet = availableTools.has("memory_get");
+  const hasSessionsSearch = availableTools.has("sessions_search");
 
   if (!hasMemorySearch && !hasMemoryGet) {
     return [];
@@ -25,6 +26,11 @@ export const buildPromptSection: MemoryPromptSectionBuilder = ({
   }
 
   const lines = ["## Memory Recall", toolGuidance];
+  if (hasMemorySearch && hasSessionsSearch) {
+    lines.push(
+      "If memory_search reports unavailable or disabled, immediately search canonical conversation history with sessions_search using the same query. Do not guess or ask the user to repeat known context merely because semantic retrieval failed.",
+    );
+  }
   if (citationsMode === "off") {
     lines.push(
       "Citations are disabled: do not mention file paths or line numbers in replies unless the user explicitly asks.",

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -464,7 +464,7 @@ export function createMemorySearchTool(options: {
     label: "Memory Search",
     name: "memory_search",
     description:
-      "Mandatory recall step: semantically search MEMORY.md + memory/*.md (and optional session transcripts) before answering questions about prior work, decisions, dates, people, preferences, or todos. Optional `corpus=wiki` or `corpus=all` also searches registered compiled-wiki supplements. `corpus=memory` restricts hits to indexed memory files (excludes session transcript chunks from ranking). `corpus=sessions` restricts hits to indexed session transcripts (same visibility rules as session history tools). If response has disabled=true, memory retrieval is unavailable; you must tell the user and include the warning/action guidance.",
+      "Mandatory recall step: semantically search MEMORY.md + memory/*.md (and optional session transcripts) before answering questions about prior work, decisions, dates, people, preferences, or todos. Optional `corpus=wiki` or `corpus=all` also searches registered compiled-wiki supplements. `corpus=memory` restricts hits to indexed memory files (excludes session transcript chunks from ranking). `corpus=sessions` restricts hits to indexed session transcripts (same visibility rules as session history tools). If response has disabled=true, semantic retrieval is unavailable; use native sessions_search with the same query for conversation history before answering, and surface any remaining coverage gap.",
     parameters: MemorySearchSchema,
     execute:
       ({ cfg, agentId }) =>

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -2068,12 +2068,8 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       delivered: true,
       path: "direct",
       phases: [
-        {
-          phase: "direct-primary",
-          delivered: true,
-          path: "direct",
-          error: undefined,
-        },
+        { phase: "steer-primary", delivered: false, path: "none", error: undefined },
+        { phase: "direct-fallback", delivered: true, path: "direct", error: undefined },
       ],
     });
     expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledTimes(1);
@@ -2114,17 +2110,13 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       error: "requester session abandoned after timeout",
     });
     expect(result.phases).toEqual([
+      expect.objectContaining({ phase: "steer-primary", delivered: false, path: "none" }),
       expect.objectContaining({
-        phase: "direct-primary",
+        phase: "direct-fallback",
         delivered: false,
         path: "none",
         reason: "requester_abandoned",
         error: "requester session abandoned after timeout",
-      }),
-      expect.objectContaining({
-        phase: "steer-fallback",
-        delivered: false,
-        path: "none",
       }),
     ]);
     expect(callGateway).not.toHaveBeenCalled();
@@ -2132,7 +2124,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(queueEmbeddedAgentMessageWithOutcome).not.toHaveBeenCalled();
   });
 
-  it("uses steer fallback when a completion handoff has no visible output", async () => {
+  it("does not re-steer after a completion handoff has no visible output", async () => {
     const callGateway = createPayloadGatewayMock();
     const queueEmbeddedAgentMessageWithOutcome = vi
       .fn<QueueEmbeddedAgentMessageWithOutcome>()
@@ -2163,12 +2155,8 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       delivered: true,
       path: "direct",
       phases: [
-        {
-          phase: "direct-primary",
-          delivered: true,
-          path: "direct",
-          error: undefined,
-        },
+        { phase: "steer-primary", delivered: false, path: "none", error: undefined },
+        { phase: "direct-fallback", delivered: true, path: "direct", error: undefined },
       ],
     });
     expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledTimes(1);
@@ -3648,7 +3636,10 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expectRecordFields(result, {
       delivered: true,
       path: "none",
-      phases: [{ phase: "direct-primary", delivered: true, path: "none", error: undefined }],
+      phases: [
+        { phase: "steer-primary", delivered: false, path: "none", error: undefined },
+        { phase: "direct-fallback", delivered: true, path: "none", error: undefined },
+      ],
     });
     expect(queueEmbeddedAgentMessageWithOutcome).not.toHaveBeenCalled();
     expect(callGateway).not.toHaveBeenCalled();
@@ -3973,20 +3964,19 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       }),
     });
 
-    expectDeliveryPath(result, "steered");
-    expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledTimes(2);
+    expectDeliveryPath(result, "direct");
+    expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledTimes(1);
     expectRecordFields(mockCallArg(queueEmbeddedAgentMessageWithOutcome, 0, 2), {
-      sourceReplyDeliveryMode: "message_tool_only",
-      waitForTranscriptCommit: true,
-    });
-    const retryOptions = mockCallArg(queueEmbeddedAgentMessageWithOutcome, 1, 2);
-    expectRecordFields(retryOptions, {
       waitForTranscriptCommit: true,
     });
     expect(
-      (retryOptions as { sourceReplyDeliveryMode?: unknown }).sourceReplyDeliveryMode,
+      (
+        mockCallArg(queueEmbeddedAgentMessageWithOutcome, 0, 2) as {
+          sourceReplyDeliveryMode?: unknown;
+        }
+      ).sourceReplyDeliveryMode,
     ).toBeUndefined();
-    expect(callGateway).not.toHaveBeenCalled();
+    expect(callGateway).toHaveBeenCalledTimes(1);
   });
 
   it("falls back to the external requester route when completion origin is internal", async () => {
@@ -4053,7 +4043,10 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(result.delivered).toBe(false);
     expect(result.path).toBe("direct");
     expect(result.terminal).toBe(true);
-    expect(result.phases?.map((phase) => phase.phase)).toEqual(["direct-primary"]);
+    expect(result.phases?.map((phase) => phase.phase)).toEqual([
+      "steer-primary",
+      "direct-fallback",
+    ]);
     expect(callGateway).toHaveBeenCalledTimes(1);
     expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledTimes(1);
   });
@@ -4087,7 +4080,10 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(result.path).toBe("direct");
     expect(result.error).toBe("some model error");
     expect(result.terminal).toBe(true);
-    expect(result.phases?.map((phase) => phase.phase)).toEqual(["direct-primary"]);
+    expect(result.phases?.map((phase) => phase.phase)).toEqual([
+      "steer-primary",
+      "direct-fallback",
+    ]);
     expect(callGateway).toHaveBeenCalledTimes(1);
     expect(queueEmbeddedAgentMessageWithOutcome).toHaveBeenCalledTimes(1);
   });

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -1122,6 +1122,8 @@ async function sendSubagentAnnounceDirectly(params: {
   sourceTool?: string;
   requesterIsSubagent: boolean;
   allowGeneratedMediaDirectFallback: boolean;
+  /** Dispatch already attempted the live requester wake; do not echo it. */
+  skipActiveRequesterWake?: boolean;
   signal?: AbortSignal;
 }): Promise<SubagentAnnounceDeliveryResult> {
   if (params.signal?.aborted) {
@@ -1207,7 +1209,9 @@ async function sendSubagentAnnounceDirectly(params: {
         error: "requester session abandoned after timeout",
       };
     }
-    let activeRequesterWakeFailed = false;
+    // Dispatch has already attempted the active requester wake when this is
+    // a completion fallback, so media repair may proceed without another wake.
+    let activeRequesterWakeFailed = params.skipActiveRequesterWake === true;
     let cronContinuation:
       | {
           sessionId: string;
@@ -1310,6 +1314,7 @@ async function sendSubagentAnnounceDirectly(params: {
     });
     if (
       params.expectsCompletionMessage &&
+      !params.skipActiveRequesterWake &&
       requesterActivity.sessionId &&
       requesterActivity.isActive
     ) {
@@ -1869,6 +1874,10 @@ export async function deliverSubagentAnnouncement(params: {
         requesterIsSubagent: params.requesterIsSubagent,
         expectsCompletionMessage: params.expectsCompletionMessage,
         allowGeneratedMediaDirectFallback: true,
+        // Completion dispatch tries the active parent first. A failed wake
+        // must not be retried here: it could race a late resume and emit a
+        // second visible completion.
+        skipActiveRequesterWake: params.expectsCompletionMessage,
         signal: params.signal,
         bestEffortDeliver: params.bestEffortDeliver,
       }),

--- a/src/agents/subagent-announce-dispatch.test.ts
+++ b/src/agents/subagent-announce-dispatch.test.ts
@@ -1,5 +1,4 @@
-// Subagent announce dispatch tests lock down direct-vs-steer ordering for
-// progress updates and completion messages.
+// Subagent announce dispatch tests lock down parent-owned completion routing.
 import { describe, expect, it, vi } from "vitest";
 import { runSubagentAnnounceDispatch } from "./subagent-announce-dispatch.js";
 
@@ -45,8 +44,37 @@ describe("runSubagentAnnounceDispatch", () => {
     ]);
   });
 
-  it("uses direct-first ordering for completion mode", async () => {
+  it("keeps delegation acknowledgement plus child completion on the parent path", async () => {
     const steer = vi.fn(async () => ({ status: "steered" }) as const);
+    const direct = vi.fn(async () => ({ delivered: true, path: "direct" as const }));
+
+    // The parent may already have emitted an acknowledgement before yielding.
+    // A successful wake makes it the sole author of the completion update.
+    const result = await runSubagentAnnounceDispatch({
+      expectsCompletionMessage: true,
+      steer,
+      direct,
+    });
+
+    expect(steer).toHaveBeenCalledTimes(1);
+    expect(direct).not.toHaveBeenCalled();
+    expect(result.path).toBe("steered");
+    expect(result.phases).toEqual([
+      { phase: "steer-primary", delivered: true, path: "steered", error: undefined },
+    ]);
+  });
+
+  it("does not emit a worker echo after sessions_yield resumes its parent", async () => {
+    const steer = vi.fn(async () => ({ status: "steered" }) as const);
+    const direct = vi.fn(async () => ({ delivered: true, path: "direct" as const }));
+
+    await runSubagentAnnounceDispatch({ expectsCompletionMessage: true, steer, direct });
+
+    expect(direct).not.toHaveBeenCalled();
+  });
+
+  it("uses one idempotent transport fallback only when the parent cannot be woken", async () => {
+    const steer = vi.fn(async () => ({ status: "none" }) as const);
     const direct = vi.fn(async () => ({ delivered: true, path: "direct" as const }));
 
     const result = await runSubagentAnnounceDispatch({
@@ -55,39 +83,17 @@ describe("runSubagentAnnounceDispatch", () => {
       direct,
     });
 
+    expect(steer).toHaveBeenCalledTimes(1);
     expect(direct).toHaveBeenCalledTimes(1);
-    expect(steer).not.toHaveBeenCalled();
     expect(result.path).toBe("direct");
     expect(result.phases).toEqual([
-      { phase: "direct-primary", delivered: true, path: "direct", error: undefined },
+      { phase: "steer-primary", delivered: false, path: "none", error: undefined },
+      { phase: "direct-fallback", delivered: true, path: "direct", error: undefined },
     ]);
   });
 
-  it("falls back to steering when completion direct send fails", async () => {
-    const steer = vi.fn(async () => ({ status: "steered" }) as const);
-    const direct = vi.fn(async () => ({
-      delivered: false,
-      path: "direct" as const,
-      error: "network",
-    }));
-
-    const result = await runSubagentAnnounceDispatch({
-      expectsCompletionMessage: true,
-      steer,
-      direct,
-    });
-
-    expect(direct).toHaveBeenCalledTimes(1);
-    expect(steer).toHaveBeenCalledTimes(1);
-    expect(result.path).toBe("steered");
-    expect(result.phases).toEqual([
-      { phase: "direct-primary", delivered: false, path: "direct", error: "network" },
-      { phase: "steer-fallback", delivered: true, path: "steered", error: undefined },
-    ]);
-  });
-
-  it("does not fallback-steer after terminal completion direct failure", async () => {
-    const steer = vi.fn(async () => ({ status: "steered" }) as const);
+  it("does not retry an uncertain fallback transport outcome", async () => {
+    const steer = vi.fn(async () => ({ status: "none" }) as const);
     const direct = vi.fn(async () => ({
       delivered: false,
       path: "direct" as const,
@@ -95,8 +101,6 @@ describe("runSubagentAnnounceDispatch", () => {
       terminal: true,
     }));
 
-    // Terminal direct failures can represent partial media delivery; fallback
-    // steering would risk duplicate or contradictory completion messages.
     const result = await runSubagentAnnounceDispatch({
       expectsCompletionMessage: true,
       steer,
@@ -104,41 +108,19 @@ describe("runSubagentAnnounceDispatch", () => {
     });
 
     expect(direct).toHaveBeenCalledTimes(1);
-    expect(steer).not.toHaveBeenCalled();
     expect(result.delivered).toBe(false);
-    expect(result.path).toBe("direct");
     expect(result.error).toBe("media send may have partially succeeded");
-    expect(result.phases).toEqual([
-      {
-        phase: "direct-primary",
-        delivered: false,
-        path: "direct",
-        error: "media send may have partially succeeded",
-      },
-    ]);
   });
 
-  it("returns direct failure when completion fallback steering cannot deliver", async () => {
-    const steer = vi.fn(async () => ({ status: "none" }) as const);
-    const direct = vi.fn(async () => ({
-      delivered: false,
-      path: "direct" as const,
-      error: "failed",
-    }));
+  it("keeps distinct completion updates distinct", async () => {
+    const steer = vi.fn(async () => ({ status: "steered" }) as const);
+    const direct = vi.fn(async () => ({ delivered: true, path: "direct" as const }));
 
-    const result = await runSubagentAnnounceDispatch({
-      expectsCompletionMessage: true,
-      steer,
-      direct,
-    });
+    await runSubagentAnnounceDispatch({ expectsCompletionMessage: true, steer, direct });
+    await runSubagentAnnounceDispatch({ expectsCompletionMessage: true, steer, direct });
 
-    expect(result.delivered).toBe(false);
-    expect(result.path).toBe("direct");
-    expect(result.error).toBe("failed");
-    expect(result.phases).toEqual([
-      { phase: "direct-primary", delivered: false, path: "direct", error: "failed" },
-      { phase: "steer-fallback", delivered: false, path: "none", error: undefined },
-    ]);
+    expect(steer).toHaveBeenCalledTimes(2);
+    expect(direct).not.toHaveBeenCalled();
   });
 
   it("does not fall through to direct delivery when non-completion steering drops the new item", async () => {
@@ -160,17 +142,13 @@ describe("runSubagentAnnounceDispatch", () => {
     });
   });
 
-  it("preserves direct failure when completion dispatch aborts before fallback steering", async () => {
+  it("does not fall back to direct delivery when completion dispatch aborts after steering", async () => {
     const controller = new AbortController();
-    const steer = vi.fn(async () => ({ status: "steered" }) as const);
-    const direct = vi.fn(async () => {
+    const steer = vi.fn(async () => {
       controller.abort();
-      return {
-        delivered: false,
-        path: "direct" as const,
-        error: "direct failed before abort",
-      };
+      return { status: "none" } as const;
     });
+    const direct = vi.fn(async () => ({ delivered: true, path: "direct" as const }));
 
     const result = await runSubagentAnnounceDispatch({
       expectsCompletionMessage: true,
@@ -179,19 +157,13 @@ describe("runSubagentAnnounceDispatch", () => {
       direct,
     });
 
-    expect(direct).toHaveBeenCalledTimes(1);
-    expect(steer).not.toHaveBeenCalled();
-    expect(result.delivered).toBe(false);
-    expect(result.path).toBe("direct");
-    expect(result.error).toBe("direct failed before abort");
-    expect(result.phases).toEqual([
-      {
-        phase: "direct-primary",
-        delivered: false,
-        path: "direct",
-        error: "direct failed before abort",
-      },
-    ]);
+    expect(steer).toHaveBeenCalledTimes(1);
+    expect(direct).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      delivered: false,
+      path: "none",
+      phases: [{ phase: "steer-primary", delivered: false, path: "none", error: undefined }],
+    });
   });
 
   it("returns none immediately when signal is already aborted", async () => {

--- a/src/agents/subagent-announce-dispatch.ts
+++ b/src/agents/subagent-announce-dispatch.ts
@@ -31,7 +31,11 @@ export type SubagentAnnounceDeliveryResult = {
   phases?: SubagentAnnounceDispatchPhaseResult[];
 };
 
-type SubagentAnnounceDispatchPhase = "steer-primary" | "direct-primary" | "steer-fallback";
+type SubagentAnnounceDispatchPhase =
+  | "steer-primary"
+  | "direct-primary"
+  | "steer-fallback"
+  | "direct-fallback";
 
 type SubagentAnnounceDispatchPhaseResult = {
   phase: SubagentAnnounceDispatchPhase;
@@ -111,24 +115,25 @@ export async function runSubagentAnnounceDispatch(params: {
     return withPhases(primaryDirect);
   }
 
-  // Completion handoff prefers direct delivery first so the completion agent's
-  // final visible message wins before falling back to steering.
-  const primaryDirect = await params.direct();
-  appendPhase("direct-primary", primaryDirect);
-  if (primaryDirect.delivered || primaryDirect.terminal) {
-    return withPhases(primaryDirect);
+  // A live requester owns its visible reply.  Wake it with the completion
+  // context first; it can synthesize the child result with any acknowledgement
+  // it already gave.  Sending the child text directly first creates a second
+  // user-visible reply when the requester resumes from sessions_yield.
+  const primarySteerOutcome = await params.steer();
+  const primarySteer = mapSteerOutcomeToDeliveryResult(primarySteerOutcome);
+  appendPhase("steer-primary", primarySteer);
+  if (primarySteer.delivered) {
+    return withPhases(primarySteer);
   }
 
   if (params.signal?.aborted) {
-    return withPhases(primaryDirect);
+    return withPhases(primarySteer);
   }
 
-  const fallbackSteerOutcome = await params.steer();
-  const fallbackSteer = mapSteerOutcomeToDeliveryResult(fallbackSteerOutcome);
-  appendPhase("steer-fallback", fallbackSteer);
-  if (fallbackSteer.delivered) {
-    return withPhases(fallbackSteer);
-  }
-
-  return withPhases(primaryDirect);
+  // The requester is unavailable.  Preserve the completion idempotency key on
+  // this single fallback transport attempt; terminal/unknown outcomes are not
+  // replayed by this dispatcher.
+  const fallbackDirect = await params.direct();
+  appendPhase("direct-fallback", fallbackDirect);
+  return withPhases(fallbackDirect);
 }

--- a/src/config/sessions/session-transcript-index.ts
+++ b/src/config/sessions/session-transcript-index.ts
@@ -441,6 +441,37 @@ export function listSessionsNeedingTranscriptIndexReconcile(db: DatabaseSync): s
   return rows.flatMap((row) => (typeof row.session_id === "string" ? [row.session_id] : []));
 }
 
+/** Marks legacy FTS rows for transcript-only assistant artifacts for one rebuild. */
+export function markTranscriptArtifactIndexesDirtyInTransaction(db: DatabaseSync): number {
+  // JSON extraction and the FTS join have no Kysely representation. Matching
+  // the indexed message id makes this self-retiring after the first rebuild.
+  const result = db
+    .prepare(/* sqlite-allow-raw: JSON1 plus FTS5 join */ `
+    UPDATE session_transcript_index_state
+    SET needs_rebuild = 1, updated_at = ?
+    WHERE session_id IN (
+      SELECT events.session_id
+      FROM transcript_events AS events
+      JOIN session_transcript_fts AS search
+        ON search.session_id = events.session_id
+       AND search.message_id = json_extract(events.event_json, '$.id')
+      WHERE json_extract(events.event_json, '$.message.role') = 'assistant'
+        AND (
+          (
+            json_extract(events.event_json, '$.message.provider') = 'openclaw'
+            AND json_extract(events.event_json, '$.message.model')
+              IN ('delivery-mirror', 'gateway-injected')
+          )
+          OR json_extract(events.event_json, '$.message.openclawDeliveryMirror.kind')
+            IN ('channel-final', 'channel-final-suppressed', 'message-tool-source-reply')
+        )
+    )
+      AND needs_rebuild = 0
+  `)
+    .run(Date.now());
+  return Number(result.changes);
+}
+
 /** Drops index rows for sessions whose transcript rows are gone. */
 export function deleteOrphanedTranscriptIndexRowsInTransaction(db: DatabaseSync): void {
   const kysely = getIndexKysely(db);

--- a/src/config/sessions/session-transcript-projection-rebuild.test.ts
+++ b/src/config/sessions/session-transcript-projection-rebuild.test.ts
@@ -150,4 +150,40 @@ describe("canonical session transcript projection", () => {
     ]);
     expect(result.sourceIndexedSeq).toBe(2);
   });
+
+  it("keeps transcript-only assistant artifacts out of search", () => {
+    const result = projection([
+      row(0, { id: SESSION_ID, type: "session", version: 3 }),
+      row(1, {
+        id: "answer",
+        message: { content: "canonical answer", role: "assistant" },
+        parentId: null,
+        type: "message",
+      }),
+      row(2, {
+        id: "delivery-mirror",
+        message: {
+          content: "canonical answer",
+          model: "delivery-mirror",
+          provider: "openclaw",
+          role: "assistant",
+        },
+        parentId: "answer",
+        type: "message",
+      }),
+      row(3, {
+        id: "historical-mirror",
+        message: {
+          content: "historical duplicate",
+          openclawDeliveryMirror: { kind: "channel-final" },
+          role: "assistant",
+        },
+        parentId: "delivery-mirror",
+        type: "message",
+      }),
+    ]);
+
+    expect(result.activeRows).toHaveLength(3);
+    expect(result.ftsRows.map((entry) => entry.messageId)).toEqual(["answer"]);
+  });
 });

--- a/src/config/sessions/session-transcript-projection-rebuild.ts
+++ b/src/config/sessions/session-transcript-projection-rebuild.ts
@@ -6,6 +6,7 @@ import {
   getNodeSqliteKysely,
 } from "../../infra/kysely-sync.js";
 import { runSqliteDeferredTransactionSync } from "../../infra/sqlite-transaction.js";
+import { isTranscriptOnlyOpenClawAssistantMessage } from "../../shared/transcript-only-openclaw-assistant.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import {
   isCanonicalSessionTranscriptEntry,
@@ -113,6 +114,11 @@ export function extractTranscriptIndexEntry(
   const message = record.message as { role?: unknown } | undefined;
   const role = message?.role;
   if (role !== "user" && role !== "assistant") {
+    return undefined;
+  }
+  // Transcript artifacts preserve delivery bookkeeping, not conversation truth.
+  // Indexing them makes recall return duplicate or gateway-authored answers.
+  if (isTranscriptOnlyOpenClawAssistantMessage(message)) {
     return undefined;
   }
   const text = readMessageText(message);

--- a/src/config/sessions/session-transcript-reconcile.ts
+++ b/src/config/sessions/session-transcript-reconcile.ts
@@ -17,7 +17,10 @@ import {
   runExclusiveSqliteSessionWrite,
   toDatabaseOptions,
 } from "./session-accessor.sqlite-scope.js";
-import { deleteOrphanedTranscriptIndexRowsInTransaction } from "./session-transcript-index.js";
+import {
+  deleteOrphanedTranscriptIndexRowsInTransaction,
+  markTranscriptArtifactIndexesDirtyInTransaction,
+} from "./session-transcript-index.js";
 import {
   appendPreparedSessionTranscriptProjectionChunkInTransaction,
   claimPreparedSessionTranscriptProjectionInTransaction,
@@ -198,7 +201,7 @@ async function finalizePreparedProjection(
 }
 
 /** Prepares full trees off-thread, then commits bounded chunks through the runtime writer owner. */
-export function reconcileSessionTranscriptIndexes(
+export async function reconcileSessionTranscriptIndexes(
   params: SessionTranscriptReconcileParams,
 ): Promise<SessionTranscriptReconcileResult> {
   const databasePath = resolveOpenClawAgentSqlitePath(params);
@@ -207,6 +210,11 @@ export function reconcileSessionTranscriptIndexes(
     ...(params.env ? { env: params.env } : {}),
     path: databasePath,
   };
+  await runProjectionWrite(
+    databaseOptions,
+    "sessions.transcript-index.artifact-repair",
+    (database) => markTranscriptArtifactIndexesDirtyInTransaction(database.db),
+  );
   const workerUrl = resolveSessionTranscriptReconcileWorkerUrl();
   const sourceWorkerExecArgv = workerUrl.pathname.endsWith(".ts") ? ["--import", "tsx"] : undefined;
   const input: SessionTranscriptReconcileWorkerInput = {
@@ -221,7 +229,7 @@ export function reconcileSessionTranscriptIndexes(
     return Promise.reject(normalizeReconcileError(error));
   }
 
-  return new Promise<SessionTranscriptReconcileResult>((resolve, reject) => {
+  return await new Promise<SessionTranscriptReconcileResult>((resolve, reject) => {
     let active: ActivePreparedProjection | undefined;
     let doneReceived = false;
     let reconciledSessions = 0;

--- a/src/config/sessions/session-transcript-search.test.ts
+++ b/src/config/sessions/session-transcript-search.test.ts
@@ -16,7 +16,10 @@ import {
   appendSqliteTranscriptMessage,
   replaceSqliteTranscriptEvents,
 } from "./session-accessor.sqlite.js";
-import { listSessionsNeedingTranscriptIndexReconcile } from "./session-transcript-index.js";
+import {
+  listSessionsNeedingTranscriptIndexReconcile,
+  markTranscriptArtifactIndexesDirtyInTransaction,
+} from "./session-transcript-index.js";
 import { searchSessionTranscripts } from "./session-transcript-search.js";
 
 vi.mock("../config.js", async () => ({
@@ -246,6 +249,49 @@ describe("searchSessionTranscripts", () => {
     const result = search("historic");
     expect(result.indexing).toBe(false);
     expect(result.hits).toHaveLength(1);
+  });
+
+  it("rebuilds legacy indexes that contain delivery mirrors", async () => {
+    const scope = transcriptScope("session-1", "agent:main:main");
+    await appendSqliteTranscriptMessage(scope, {
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "duplicated delivery text" }],
+        provider: "openclaw",
+        model: "delivery-mirror",
+      },
+    });
+    const { db, kysely } = agentKysely();
+    const eventRows = executeSqliteQuerySync(
+      db,
+      kysely
+        .selectFrom("transcript_events")
+        .select("event_json")
+        .where("session_id", "=", "session-1"),
+    ).rows;
+    const indexedMessage = eventRows
+      .map((row) => JSON.parse(row.event_json) as { id?: unknown; message?: { role?: unknown } })
+      .find((event) => typeof event.id === "string" && event.message?.role === "assistant");
+    if (typeof indexedMessage?.id !== "string") {
+      throw new Error("expected appended delivery mirror id");
+    }
+    executeSqliteQuerySync(
+      db,
+      kysely.insertInto("session_transcript_fts").values({
+        text: "duplicated delivery text",
+        session_id: "session-1",
+        message_id: indexedMessage.id,
+        role: "assistant",
+        timestamp: "1",
+      }),
+    );
+
+    expect(search("duplicated").hits).toHaveLength(1);
+    expect(markTranscriptArtifactIndexesDirtyInTransaction(db)).toBe(1);
+    expect(search("duplicated")).toMatchObject({ hits: [], indexing: true });
+    await waitForSearchReconcile("duplicated");
+    expect(search("duplicated").hits).toHaveLength(0);
+    expect(markTranscriptArtifactIndexesDirtyInTransaction(db)).toBe(0);
   });
 
   it("detects missing, dirty, and lagging transcript index watermarks", async () => {

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -1112,6 +1112,7 @@ describe("parseSystemdExecStart", () => {
 describe("readSystemdServiceExecStart", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    execFileMock.mockReset();
   });
 
   it("loads OPENCLAW_GATEWAY_TOKEN from EnvironmentFile", async () => {
@@ -1123,6 +1124,43 @@ describe("readSystemdServiceExecStart", () => {
     const command = await readSystemdServiceExecStart({ HOME: TEST_SERVICE_HOME });
     expect(command?.environment?.OPENCLAW_GATEWAY_TOKEN).toBe("env-file-token");
     expect(readFileSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("applies systemd drop-ins when reporting the effective service command", async () => {
+    mockReadGatewayServiceFile([
+      "[Service]",
+      "ExecStart=/usr/bin/node /old/openclaw.js gateway --port 18789",
+      "Environment=OPENCLAW_SERVICE_VERSION=2026.7.2-beta.7",
+    ]);
+    execFileMock.mockImplementation((_cmd, args, _opts, cb) => {
+      expect(args).toEqual(["--user", "cat", GATEWAY_SERVICE, "--no-pager"]);
+      cb(
+        null,
+        [
+          "# /home/test/.config/systemd/user/openclaw-gateway.service",
+          "[Service]",
+          "ExecStart=/usr/bin/node /old/openclaw.js gateway --port 18789",
+          "Environment=OPENCLAW_SERVICE_VERSION=2026.7.2-beta.7",
+          "# /home/test/.config/systemd/user/openclaw-gateway.service.d/release.conf",
+          "[Service]",
+          "ExecStart=",
+          "ExecStart=/usr/bin/node /current/openclaw.js gateway --port 18789",
+          "Environment=OPENCLAW_SERVICE_VERSION=2026.7.2",
+        ].join("\n"),
+        "",
+      );
+    });
+
+    const command = await readSystemdServiceExecStart({ HOME: TEST_SERVICE_HOME });
+
+    expect(command?.programArguments).toEqual([
+      "/usr/bin/node",
+      "/current/openclaw.js",
+      "gateway",
+      "--port",
+      "18789",
+    ]);
+    expect(command?.environment?.OPENCLAW_SERVICE_VERSION).toBe("2026.7.2");
   });
 
   it("lets EnvironmentFile override inline Environment values", async () => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -175,7 +175,21 @@ export async function readSystemdServiceExecStart(
 ): Promise<GatewayServiceCommandConfig | null> {
   const unitPath = resolveSystemdUnitPath(env);
   try {
-    const content = await fs.readFile(unitPath, "utf8");
+    const baseContent = await fs.readFile(unitPath, "utf8");
+    let content = baseContent;
+    try {
+      const unitName = `${resolveSystemdServiceName(env)}.service`;
+      const effective = await execSystemctlUser(env, ["cat", unitName, "--no-pager"]);
+      if (effective.code === 0 && effective.stdout.trim()) {
+        // `systemctl cat` returns the base unit followed by every drop-in in
+        // systemd precedence order. Parsing that stream keeps status/audit in
+        // sync with the command and environment the manager actually applies.
+        content = effective.stdout;
+      }
+    } catch {
+      // Offline inspection and tests may not have a reachable user manager;
+      // the base unit remains a useful best-effort fallback.
+    }
     let execStart = "";
     let workingDirectory = "";
     const inlineEnvironment: Record<string, string> = {};

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -84,6 +84,11 @@ const PLUGIN_INSTALL_TIMESTAMP_KEYS = ["installedAt", "resolvedAt"] as const;
 const BASE_RELOAD_RULES: ReloadRule[] = [
   { prefix: "gateway.remote", kind: "none" },
   { prefix: "gateway.reload", kind: "none" },
+  // Session tools capture orchestration access policy when their owning agent
+  // runtime is created. A baseline-only config commit leaves those live tools
+  // enforcing the previous policy, so routing changes require a fresh process.
+  { prefix: "tools.agentToAgent", kind: "restart" },
+  { prefix: "tools.sessions", kind: "restart" },
   // gateway.terminal.* deliberately has no rule here: it falls through to the
   // `gateway` restart rule below. The terminal drives the Control UI CSP (WASM
   // permissions) and the bootstrap availability flag, both fixed at document

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -315,6 +315,9 @@ describe("buildGatewayReloadPlan", () => {
     "plugins.installs.telegram.installPath",
     "plugins.load.paths.0",
     "gateway.auth.mode",
+    "tools.agentToAgent.enabled",
+    "tools.agentToAgent.allow",
+    "tools.sessions.visibility",
   ])("keeps restart-owned path restart-backed: %s", (path) => {
     const plan = buildGatewayReloadPlan([path]);
 

--- a/src/gateway/server-methods/approval-shared.ts
+++ b/src/gateway/server-methods/approval-shared.ts
@@ -425,7 +425,7 @@ export async function handlePendingApprovalRequest<
   requestEventName: string;
   requestEvent: RequestedApprovalEvent<TPayload>;
   twoPhase: boolean;
-  approvalKind?: "exec" | "plugin";
+  approvalKind?: "exec" | "plugin" | "system-agent";
   deliverRequest: () => boolean | Promise<boolean>;
   afterDecision?: (
     decision: ExecApprovalDecision | null,
@@ -465,12 +465,17 @@ export async function handlePendingApprovalRequest<
         });
       }
     }
-    const internalApprovalSubscriberCount = suppressDelivery
-      ? 0
-      : (params.context.approvalEvents?.publishRequested(
-          params.approvalKind ?? "exec",
-          params.requestEvent,
-        ) ?? 0);
+    const nativeApprovalKind =
+      params.approvalKind === "system-agent" ? undefined : (params.approvalKind ?? "exec");
+    // Native channel subscribers own exec/plugin payloads only. System-agent
+    // approvals have their own gateway event and must not be misclassified.
+    const internalApprovalSubscriberCount =
+      suppressDelivery || !nativeApprovalKind
+        ? 0
+        : (params.context.approvalEvents?.publishRequested(
+            nativeApprovalKind,
+            params.requestEvent,
+          ) ?? 0);
 
     const hasApprovalClients = suppressDelivery
       ? false

--- a/src/gateway/server-methods/system-agent.test.ts
+++ b/src/gateway/server-methods/system-agent.test.ts
@@ -780,12 +780,14 @@ describe("openclaw.chat", () => {
       resolveAllowedDecisions: (request) => request.allowedDecisions,
     });
     const broadcast = vi.fn();
+    const publishRequested = vi.fn(() => 1);
     const context = {
       ...makeContext(sessions),
       systemAgentApprovalManager: manager,
       broadcast,
       broadcastToConnIds: vi.fn(),
       hasExecApprovalClients: () => true,
+      approvalEvents: { publishRequested },
     } as unknown as GatewayRequestContext;
 
     const first = await callChat(context, {
@@ -810,6 +812,7 @@ describe("openclaw.chat", () => {
       expect.objectContaining({ id: proposalId }),
       { dropIfSlow: true },
     );
+    expect(publishRequested).not.toHaveBeenCalled();
     expect(resolveOperatorApproval).not.toHaveBeenCalled();
 
     await callChat(context, {

--- a/src/gateway/server-methods/system-agent.ts
+++ b/src/gateway/server-methods/system-agent.ts
@@ -232,6 +232,7 @@ function queueDelegatedApproval(params: {
     requestEventName: "openclaw.approval.requested",
     requestEvent,
     twoPhase: true,
+    approvalKind: "system-agent",
     deliverRequest: () => false,
     keepPendingWithoutRoute: true,
     requireDeliveryRoute: false,


### PR DESCRIPTION
## What Problem This Solves

`openclaw gateway status` reads only the base systemd unit. When an operator uses supported systemd drop-ins to atomically select a release or override `OPENCLAW_SERVICE_VERSION`, status reports the stale base command and a false `gateway-service-version-mismatch` even though systemd is running the correct effective configuration.

The reader now asks systemd for the assembled unit (base plus ordered drop-ins), while retaining the existing base-file path as an offline fallback.

## Evidence

- Added a regression test with a beta base unit and a stable-release drop-in; the parsed command and service version now match the effective drop-in values.
- `node_modules/.bin/vitest run src/daemon/systemd.test.ts src/daemon/service-audit.test.ts`: 148 tests passed.
- Live Raspberry Pi observation before the patch: `systemctl --user show` reported the stable release path and `OPENCLAW_SERVICE_VERSION=2026.7.2`, while `openclaw gateway status --json` reported the beta base path and `gateway-service-version-mismatch`.

## Summary

- inspect the effective systemd unit assembled from the base file and drop-ins
- report the command and service version systemd actually applies
- retain base-file inspection as an offline fallback