### PR TITLE
fix(sms): retry stalled MMS response bodies

### DIFF
--- a/extensions/sms/src/media.test.ts
+++ b/extensions/sms/src/media.test.ts
@@ -657,8 +657,30 @@ describe("SMS inbound MMS materialization", () => {
       retryable: true,
     },
     {
+      name: "nested host unreachable",
+      cause: new Error("fetch failed", {
+        cause: Object.assign(new Error("host unreachable"), { code: "EHOSTUNREACH" }),
+      }),
+      retryable: true,
+    },
+    {
+      name: "Undici DNS resolve failure",
+      cause: Object.assign(new Error("DNS resolve failed"), {
+        code: "UND_ERR_DNS_RESOLVE_FAILED",
+      }),
+      retryable: true,
+    },
+    {
       name: "media request deadline",
       cause: new DOMException("timed out", "TimeoutError"),
+      retryable: true,
+    },
+    {
+      name: "aggregate network failure",
+      cause: new AggregateError(
+        [Object.assign(new Error("timed out"), { code: "ETIMEDOUT" })],
+        "all addresses failed",
+      ),
       retryable: true,
     },
     {
@@ -666,6 +688,17 @@ describe("SMS inbound MMS materialization", () => {
       cause: Object.assign(new SsrFBlockedError("blocked private address"), {
         cause: Object.assign(new Error("reset"), { code: "ECONNRESET" }),
       }),
+      retryable: false,
+    },
+    {
+      name: "aggregate containing blocked SSRF and transient failure",
+      cause: new AggregateError(
+        [
+          Object.assign(new Error("reset"), { code: "ECONNRESET" }),
+          new SsrFBlockedError("blocked private address"),
+        ],
+        "mixed failures",
+      ),
       retryable: false,
     },
     {
@@ -679,6 +712,23 @@ describe("SMS inbound MMS materialization", () => {
       retryable,
     );
   });
+
+  it.each(["reason", "original", "error", "data"] as const)(
+    "does not retry when .$field contains an SSRF denial",
+    async (field) => {
+      const cause = Object.assign(
+        new Error("fetch failed", {
+          cause: Object.assign(new Error("reset"), { code: "ECONNRESET" }),
+        }),
+        { [field]: new SsrFBlockedError("blocked private address") },
+      );
+
+      await expectInboundMediaFailure(
+        new MediaFetchError("fetch_failed", "download failed", { cause }),
+        false,
+      );
+    },
+  );
 
   it("keeps oversized MMS visible without retrying its sender lane", async () => {
     await expectInboundMediaFailure(new MediaFetchError("max_bytes", "too large"), false);

--- a/extensions/sms/src/media.ts
+++ b/extensions/sms/src/media.ts
@@ -6,11 +6,7 @@ import {
   toInboundMediaFactsWithMetadata,
   type InboundMediaFacts,
 } from "openclaw/plugin-sdk/channel-inbound";
-import {
-  collectErrorGraphCandidates,
-  extractErrorCode,
-  readErrorName,
-} from "openclaw/plugin-sdk/error-runtime";
+import { collectErrorGraphCandidates } from "openclaw/plugin-sdk/error-runtime";
 import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
 import { MediaFetchError, unlinkIfExists } from "openclaw/plugin-sdk/media-runtime";
 import { resolveExpiresAtMsFromDurationMs } from "openclaw/plugin-sdk/number-runtime";
@@ -22,7 +18,7 @@ import {
   type OutboundMediaLoadOptions,
 } from "openclaw/plugin-sdk/outbound-media";
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
-import { classifyTransientNetworkErrorCode } from "openclaw/plugin-sdk/retry-runtime";
+import { isTransientNetworkError } from "openclaw/plugin-sdk/retry-runtime";
 import { safeEqualSecret, SsrFBlockedError } from "openclaw/plugin-sdk/security-runtime";
 import { getSmsRuntime } from "./runtime.js";
 import { TWILIO_MMS_MAX_BYTES } from "./twilio.js";
@@ -346,6 +342,22 @@ function createInboundMediaCleanup(paths: string[]): () => Promise<void> {
   };
 }
 
+// Keep the SSRF veto on the same wrapper graph as the transient classifier;
+// otherwise a transient sibling could make a blocked fetch retry.
+function nestedSmsMediaErrorCandidates(candidate: Record<string, unknown>): unknown[] {
+  const nested = [
+    candidate.cause,
+    candidate.reason,
+    candidate.original,
+    candidate.error,
+    candidate.data,
+  ];
+  if (Array.isArray(candidate.errors)) {
+    nested.push(...candidate.errors);
+  }
+  return nested;
+}
+
 function isRetryableSmsInboundMediaError(error: unknown): boolean {
   if (!(error instanceof MediaFetchError)) {
     return false;
@@ -360,18 +372,11 @@ function isRetryableSmsInboundMediaError(error: unknown): boolean {
   if (error.code !== "fetch_failed") {
     return false;
   }
-  const causes = collectErrorGraphCandidates(error.cause, (candidate) => [candidate.cause]);
-  if (causes.some((candidate) => candidate instanceof SsrFBlockedError)) {
+  const candidates = collectErrorGraphCandidates(error.cause, nestedSmsMediaErrorCandidates);
+  if (candidates.some((candidate) => candidate instanceof SsrFBlockedError)) {
     return false;
   }
-  return causes.some((candidate) => {
-    const name = readErrorName(candidate);
-    return (
-      classifyTransientNetworkErrorCode(extractErrorCode(candidate)) !== undefined ||
-      name === "AbortError" ||
-      name.endsWith("TimeoutError")
-    );
-  });
+  return isTransientNetworkError(error.cause);
 }
 
 export async function materializeSmsInboundMedia(params: {

--- a/src/infra/error-graph-internal.ts
+++ b/src/infra/error-graph-internal.ts
@@ -1,0 +1,36 @@
+// Internal error-graph traversal shared by runtime classifiers.
+import { collectErrorGraphCandidates, extractErrorCode } from "./errors.js";
+
+export function extractErrorCodeOrErrno(err: unknown): string | undefined {
+  const code = extractErrorCode(err);
+  if (code) {
+    return code.trim().toUpperCase();
+  }
+  if (!err || typeof err !== "object") {
+    return undefined;
+  }
+  const errno = (err as { errno?: unknown }).errno;
+  if (typeof errno === "string" && errno.trim()) {
+    return errno.trim().toUpperCase();
+  }
+  if (typeof errno === "number" && Number.isFinite(errno)) {
+    return String(errno);
+  }
+  return undefined;
+}
+
+export function collectNestedErrorCandidates(err: unknown): unknown[] {
+  return collectErrorGraphCandidates(err, (current) => {
+    const nested: unknown[] = [
+      current.cause,
+      current.reason,
+      current.original,
+      current.error,
+      current.data,
+    ];
+    if (Array.isArray(current.errors)) {
+      nested.push(...current.errors);
+    }
+    return nested;
+  });
+}

--- a/src/infra/errors.test.ts
+++ b/src/infra/errors.test.ts
@@ -1,5 +1,6 @@
 // Tests shared infra error formatting helpers.
 import { describe, expect, it } from "vitest";
+import { collectNestedErrorCandidates, extractErrorCodeOrErrno } from "./error-graph-internal.js";
 import {
   collectErrorGraphCandidates,
   extractErrorCode,
@@ -51,6 +52,44 @@ describe("error helpers", () => {
       ]),
     ).toEqual([root, child, leaf]);
     expect(collectErrorGraphCandidates(null)).toStrictEqual([]);
+  });
+
+  it("walks every canonical wrapper edge once despite duplicates and cycles", () => {
+    const cause = { name: "cause" } as { name: string; cause?: unknown };
+    const reason = { name: "reason" };
+    const original = { name: "original" };
+    const error = { name: "error" };
+    const data = { name: "data" };
+    const aggregate = { name: "aggregate" };
+    const root = {
+      name: "root",
+      cause,
+      reason,
+      original,
+      error,
+      data,
+      errors: [aggregate, cause],
+    };
+    cause.cause = root;
+
+    expect(collectNestedErrorCandidates(root)).toEqual([
+      root,
+      cause,
+      reason,
+      original,
+      error,
+      data,
+      aggregate,
+    ]);
+  });
+
+  it.each([
+    { value: { code: " econnreset " }, expected: "ECONNRESET" },
+    { value: { errno: " eai_again " }, expected: "EAI_AGAIN" },
+    { value: { errno: -3001 }, expected: "-3001" },
+    { value: { errno: false }, expected: undefined },
+  ])("normalizes error code or errno from %#", ({ value, expected }) => {
+    expect(extractErrorCodeOrErrno(value)).toBe(expected);
   });
 
   it("matches errno-shaped errors by code", () => {

--- a/src/infra/http-body.response.test.ts
+++ b/src/infra/http-body.response.test.ts
@@ -183,6 +183,26 @@ describe("readResponseWithLimit", () => {
     5_000,
   );
 
+  it("names the default idle timeout for retry classifiers", async () => {
+    vi.useFakeTimers();
+    try {
+      const result = readResponseWithLimit(
+        new Response(makeStallingStream([new Uint8Array([1, 2])])),
+        1024,
+        { chunkTimeoutMs: 50 },
+      ).catch((error: unknown) => error);
+
+      await vi.advanceTimersByTimeAsync(60);
+
+      await expect(result).resolves.toMatchObject({
+        name: "TimeoutError",
+        message: expect.stringMatching(/stalled/i),
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it.each([
     {
       name: "does not time out while chunks keep arriving",
@@ -260,6 +280,24 @@ describe("readResponseWithLimit", () => {
       expect(cancel).toHaveBeenCalledTimes(1);
       expect(cancel.mock.calls[0]?.[0]).toBeInstanceOf(Error);
       expect((cancel.mock.calls[0]?.[0] as Error | undefined)?.message).toBe("custom overall 100");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("names the default overall timeout for retry classifiers", async () => {
+    vi.useFakeTimers();
+    try {
+      const result = readResponseWithLimit(new Response(makeTricklingStream(40)), 1024, {
+        timeoutMs: 50,
+      }).catch((error: unknown) => error);
+
+      await vi.advanceTimersByTimeAsync(60);
+
+      await expect(result).resolves.toMatchObject({
+        name: "TimeoutError",
+        message: "Response body timed out after 50ms",
+      });
     } finally {
       vi.useRealTimers();
     }

--- a/src/infra/http-response-body-timeout.ts
+++ b/src/infra/http-response-body-timeout.ts
@@ -4,6 +4,12 @@ import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coerc
 
 type TimeoutErrorFactory = (params: { timeoutMs: number }) => Error;
 
+function createResponseBodyTimeoutError(message: string): Error {
+  const error = new Error(message);
+  error.name = "TimeoutError";
+  return error;
+}
+
 async function withCancellableTimeout<T>(params: {
   timeoutMs: number;
   onTimeout: TimeoutErrorFactory;
@@ -62,7 +68,7 @@ export async function readChunkWithIdleTimeout(
     timeoutMs: chunkTimeoutMs,
     onTimeout: ({ timeoutMs }) =>
       onIdleTimeout?.({ chunkTimeoutMs: timeoutMs }) ??
-      new Error(`Media download stalled: no data received for ${timeoutMs}ms`),
+      createResponseBodyTimeoutError(`Media download stalled: no data received for ${timeoutMs}ms`),
     // Cancellation releases fetch sockets and buffers instead of letting the
     // pending read continue after the caller has failed.
     cancel: async (error) => await reader.cancel(error),
@@ -83,7 +89,7 @@ export async function withResponseBodyTimeout<T>(params: {
     timeoutMs: params.timeoutMs,
     onTimeout: ({ timeoutMs }) =>
       params.onTimeout?.({ timeoutMs }) ??
-      new Error(`Response body timed out after ${timeoutMs}ms`),
+      createResponseBodyTimeoutError(`Response body timed out after ${timeoutMs}ms`),
     // Fetch resolves at headers. Body cancellation owns socket cleanup when
     // the separate whole-body deadline wins.
     cancel: params.cancel,

--- a/src/infra/retryable-network-errors.ts
+++ b/src/infra/retryable-network-errors.ts
@@ -1,7 +1,109 @@
-// Keep connection retry policy aligned across provider reads and gateway waits.
+// Keep transient network policy aligned across retries and process-level handling.
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { collectNestedErrorCandidates, extractErrorCodeOrErrno } from "./error-graph-internal.js";
+import { readErrorName } from "./errors.js";
+
+const TRANSIENT_NETWORK_CODES = new Set([
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "ENOTFOUND",
+  "ETIMEDOUT",
+  "ESOCKETTIMEDOUT",
+  "ECONNABORTED",
+  "EPIPE",
+  "ENETDOWN",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "EADDRNOTAVAIL",
+  "EAI_AGAIN",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_DNS_RESOLVE_FAILED",
+  "UND_ERR_CONNECT",
+  "UND_ERR_SOCKET",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_BODY_TIMEOUT",
+  "ERR_HTTP2_INVALID_SESSION",
+  "EPROTO",
+  "ERR_SSL_WRONG_VERSION_NUMBER",
+  "ERR_SSL_PROTOCOL_RETURNED_AN_ERROR",
+]);
+
+const TRANSIENT_NETWORK_ERROR_NAMES = new Set([
+  "AbortError",
+  "ConnectTimeoutError",
+  "HeadersTimeoutError",
+  "BodyTimeoutError",
+  "TimeoutError",
+]);
+
+const TRANSIENT_NETWORK_MESSAGE_CODE_RE =
+  /\b(ECONNRESET|ECONNREFUSED|ENOTFOUND|ETIMEDOUT|ESOCKETTIMEDOUT|ECONNABORTED|EPIPE|ENETDOWN|EHOSTUNREACH|ENETUNREACH|EADDRNOTAVAIL|EAI_AGAIN|EPROTO|UND_ERR_CONNECT_TIMEOUT|UND_ERR_DNS_RESOLVE_FAILED|UND_ERR_CONNECT|UND_ERR_SOCKET|UND_ERR_HEADERS_TIMEOUT|UND_ERR_BODY_TIMEOUT|ERR_HTTP2_INVALID_SESSION)\b/i;
+
+const TRANSIENT_NETWORK_MESSAGE_SNIPPETS = [
+  "getaddrinfo",
+  "socket hang up",
+  "client network socket disconnected before secure tls connection was established",
+  "network error",
+  "network is unreachable",
+  "temporary failure in name resolution",
+  "upstream connect error",
+  "disconnect/reset before headers",
+  "tlsv1 alert",
+  "ssl routines",
+  "packet length too long",
+  "write eproto",
+];
+
 const RETRYABLE_CONNECTION_ERROR_CODE_RE =
   /\b(?:ECONNRESET|ECONNREFUSED|ETIMEDOUT|EPIPE|EHOSTUNREACH|ENETUNREACH|EAI_AGAIN)\b/i;
 
+function isWrappedFetchFailedMessage(message: string): boolean {
+  if (message === "fetch failed") {
+    return true;
+  }
+
+  // Keep wrapped variants (for example "...: fetch failed") while avoiding broad
+  // matches like "Web fetch failed (404): ..." that are not transport failures.
+  return /:\s*fetch failed$/.test(message);
+}
+
 export function hasRetryableConnectionErrorCode(message: string): boolean {
   return RETRYABLE_CONNECTION_ERROR_CODE_RE.test(message);
+}
+
+/** Returns true when any nested error proves a transient network failure. */
+export function isTransientNetworkError(err: unknown): boolean {
+  if (!err) {
+    return false;
+  }
+  for (const candidate of collectNestedErrorCandidates(err)) {
+    const code = extractErrorCodeOrErrno(candidate);
+    if (code && TRANSIENT_NETWORK_CODES.has(code)) {
+      return true;
+    }
+
+    const name = readErrorName(candidate);
+    if (name && TRANSIENT_NETWORK_ERROR_NAMES.has(name)) {
+      return true;
+    }
+
+    if (!candidate || typeof candidate !== "object") {
+      continue;
+    }
+    const message = normalizeLowercaseStringOrEmpty((candidate as { message?: unknown }).message);
+    if (!message) {
+      continue;
+    }
+    if (TRANSIENT_NETWORK_MESSAGE_CODE_RE.test(message)) {
+      return true;
+    }
+    if (isWrappedFetchFailedMessage(message)) {
+      return true;
+    }
+    if (TRANSIENT_NETWORK_MESSAGE_SNIPPETS.some((snippet) => message.includes(snippet))) {
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -3,13 +3,12 @@ import process from "node:process";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { restoreRuntimeTerminalState } from "../runtime.js";
 import { isAbortError } from "./abort-signal.js";
-import {
-  collectErrorGraphCandidates,
-  extractErrorCode,
-  formatUncaughtError,
-  readErrorName,
-} from "./errors.js";
+import { collectNestedErrorCandidates, extractErrorCodeOrErrno } from "./error-graph-internal.js";
+import { extractErrorCode, formatUncaughtError, readErrorName } from "./errors.js";
 import { runFatalErrorHooks } from "./fatal-error-hooks.js";
+import { isTransientNetworkError } from "./retryable-network-errors.js";
+
+export { isTransientNetworkError } from "./retryable-network-errors.js";
 
 type UnhandledRejectionHandler = (reason: unknown) => boolean;
 type UncaughtExceptionHandler = (error: unknown) => boolean;
@@ -56,40 +55,6 @@ const CONFIG_ERROR_CODES = new Set([
 ]);
 const EXIT_CONFIG_ERROR = 78;
 
-// Network error codes that indicate transient failures (shouldn't crash the gateway)
-const TRANSIENT_NETWORK_CODES = new Set([
-  "ECONNRESET",
-  "ECONNREFUSED",
-  "ENOTFOUND",
-  "ETIMEDOUT",
-  "ESOCKETTIMEDOUT",
-  "ECONNABORTED",
-  "EPIPE",
-  "ENETDOWN",
-  "EHOSTUNREACH",
-  "ENETUNREACH",
-  "EADDRNOTAVAIL",
-  "EAI_AGAIN",
-  "UND_ERR_CONNECT_TIMEOUT",
-  "UND_ERR_DNS_RESOLVE_FAILED",
-  "UND_ERR_CONNECT",
-  "UND_ERR_SOCKET",
-  "UND_ERR_HEADERS_TIMEOUT",
-  "UND_ERR_BODY_TIMEOUT",
-  "ERR_HTTP2_INVALID_SESSION",
-  "EPROTO",
-  "ERR_SSL_WRONG_VERSION_NUMBER",
-  "ERR_SSL_PROTOCOL_RETURNED_AN_ERROR",
-]);
-
-const TRANSIENT_NETWORK_ERROR_NAMES = new Set([
-  "AbortError",
-  "ConnectTimeoutError",
-  "HeadersTimeoutError",
-  "BodyTimeoutError",
-  "TimeoutError",
-]);
-
 const TRANSIENT_SQLITE_CODES = new Set([
   "SQLITE_BUSY",
   "SQLITE_CANTOPEN",
@@ -115,8 +80,6 @@ const BENIGN_UNCAUGHT_EXCEPTION_NETWORK_CODES = new Set([
   "ERR_HTTP2_INVALID_SESSION",
 ]);
 
-const TRANSIENT_NETWORK_MESSAGE_CODE_RE =
-  /\b(ECONNRESET|ECONNREFUSED|ENOTFOUND|ETIMEDOUT|ESOCKETTIMEDOUT|ECONNABORTED|EPIPE|ENETDOWN|EHOSTUNREACH|ENETUNREACH|EADDRNOTAVAIL|EAI_AGAIN|EPROTO|UND_ERR_CONNECT_TIMEOUT|UND_ERR_DNS_RESOLVE_FAILED|UND_ERR_CONNECT|UND_ERR_SOCKET|UND_ERR_HEADERS_TIMEOUT|UND_ERR_BODY_TIMEOUT|ERR_HTTP2_INVALID_SESSION)\b/i;
 const BENIGN_UNCAUGHT_EXCEPTION_NETWORK_MESSAGE_CODE_RE =
   /\b(ECONNREFUSED|ENETDOWN|EHOSTUNREACH|ENETUNREACH|EADDRNOTAVAIL|EAI_AGAIN|ENOTFOUND|ETIMEDOUT|UND_ERR_CONNECT_TIMEOUT|UND_ERR_DNS_RESOLVE_FAILED|UND_ERR_CONNECT|ERR_HTTP2_INVALID_SESSION)\b/i;
 const WS_PRE_HANDSHAKE_CLOSE_MESSAGE = "websocket was closed before the connection was established";
@@ -124,21 +87,6 @@ const UNDICI_TERMINATED_TYPE_ERROR_MESSAGE = "terminated";
 
 const TRANSIENT_SQLITE_MESSAGE_CODE_RE =
   /\b(SQLITE_BUSY|SQLITE_CANTOPEN|SQLITE_IOERR|SQLITE_LOCKED)\b/i;
-
-const TRANSIENT_NETWORK_MESSAGE_SNIPPETS = [
-  "getaddrinfo",
-  "socket hang up",
-  "client network socket disconnected before secure tls connection was established",
-  "network error",
-  "network is unreachable",
-  "temporary failure in name resolution",
-  "upstream connect error",
-  "disconnect/reset before headers",
-  "tlsv1 alert",
-  "ssl routines",
-  "packet length too long",
-  "write eproto",
-];
 
 const TRANSIENT_SQLITE_MESSAGE_SNIPPETS = [
   "unable to open database file",
@@ -176,16 +124,6 @@ function hasSqliteSignal(err: unknown): boolean {
   return false;
 }
 
-function isWrappedFetchFailedMessage(message: string): boolean {
-  if (message === "fetch failed") {
-    return true;
-  }
-
-  // Keep wrapped variants (for example "...: fetch failed") while avoiding broad
-  // matches like "Web fetch failed (404): ..." that are not transport failures.
-  return /:\s*fetch failed$/.test(message);
-}
-
 function isBenignUncaughtNetworkMessage(message: string): boolean {
   if (BENIGN_UNCAUGHT_EXCEPTION_NETWORK_MESSAGE_CODE_RE.test(message)) {
     return true;
@@ -201,24 +139,6 @@ function getErrorCause(err: unknown): unknown {
     return undefined;
   }
   return (err as { cause?: unknown }).cause;
-}
-
-function extractErrorCodeOrErrno(err: unknown): string | undefined {
-  const code = extractErrorCode(err);
-  if (code) {
-    return code.trim().toUpperCase();
-  }
-  if (!err || typeof err !== "object") {
-    return undefined;
-  }
-  const errno = (err as { errno?: unknown }).errno;
-  if (typeof errno === "string" && errno.trim()) {
-    return errno.trim().toUpperCase();
-  }
-  if (typeof errno === "number" && Number.isFinite(errno)) {
-    return String(errno);
-  }
-  return undefined;
 }
 
 function extractNumericErrorCode(err: unknown, key: "errno" | "errcode"): number | undefined {
@@ -254,69 +174,12 @@ function isConfigError(err: unknown): boolean {
   return code !== undefined && CONFIG_ERROR_CODES.has(code);
 }
 
-function collectNestedUnhandledErrorCandidates(err: unknown): unknown[] {
-  return collectErrorGraphCandidates(err, (current) => {
-    const nested: Array<unknown> = [
-      current.cause,
-      current.reason,
-      current.original,
-      current.error,
-      current.data,
-    ];
-    if (Array.isArray(current.errors)) {
-      nested.push(...current.errors);
-    }
-    return nested;
-  });
-}
-
-/**
- * Checks if an error is a transient network error that shouldn't crash the gateway.
- * These are typically temporary connectivity issues that will resolve on their own.
- */
-export function isTransientNetworkError(err: unknown): boolean {
-  if (!err) {
-    return false;
-  }
-  for (const candidate of collectNestedUnhandledErrorCandidates(err)) {
-    const code = extractErrorCodeOrErrno(candidate);
-    if (code && TRANSIENT_NETWORK_CODES.has(code)) {
-      return true;
-    }
-
-    const name = readErrorName(candidate);
-    if (name && TRANSIENT_NETWORK_ERROR_NAMES.has(name)) {
-      return true;
-    }
-
-    if (!candidate || typeof candidate !== "object") {
-      continue;
-    }
-    const rawMessage = (candidate as { message?: unknown }).message;
-    const message = normalizeLowercaseStringOrEmpty(rawMessage);
-    if (!message) {
-      continue;
-    }
-    if (TRANSIENT_NETWORK_MESSAGE_CODE_RE.test(message)) {
-      return true;
-    }
-    if (isWrappedFetchFailedMessage(message)) {
-      return true;
-    }
-    if (TRANSIENT_NETWORK_MESSAGE_SNIPPETS.some((snippet) => message.includes(snippet))) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
 export function isTransientSqliteError(err: unknown): boolean {
   if (!err) {
     return false;
   }
 
-  for (const candidate of collectNestedUnhandledErrorCandidates(err)) {
+  for (const candidate of collectNestedErrorCandidates(err)) {
     const code = extractErrorCodeOrErrno(candidate);
     if (code && TRANSIENT_SQLITE_CODES.has(code)) {
       return true;
@@ -384,7 +247,7 @@ export function isTransientFileWatchError(err: unknown): boolean {
     message.includes("watch limit") ||
     message.includes("max watches");
 
-  for (const candidate of collectNestedUnhandledErrorCandidates(err)) {
+  for (const candidate of collectNestedErrorCandidates(err)) {
     // Skip non-object candidates early
     if (!candidate || typeof candidate !== "object") {
       continue;
@@ -428,7 +291,7 @@ export function isTransientUnhandledRejectionError(err: unknown): boolean {
 }
 
 function isBenignUncaughtNetworkException(err: unknown): boolean {
-  for (const candidate of collectNestedUnhandledErrorCandidates(err)) {
+  for (const candidate of collectNestedErrorCandidates(err)) {
     // Undici emits this bare TypeError when a response body aborts after request start.
     // Keep the shape exact so unrelated "terminated" errors still take the fatal path.
     if (
@@ -457,7 +320,7 @@ export function isBenignUncaughtExceptionError(err: unknown): boolean {
   if (isBenignUncaughtNetworkException(err)) {
     return true;
   }
-  for (const candidate of collectNestedUnhandledErrorCandidates(err)) {
+  for (const candidate of collectNestedErrorCandidates(err)) {
     const code = extractErrorCodeOrErrno(candidate);
     if (code && BENIGN_UNCAUGHT_EXCEPTION_CODES.has(code)) {
       return true;

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -413,6 +413,7 @@ describe("readRemoteMediaBuffer", () => {
       expectedError: {
         code: "fetch_failed",
         name: "MediaFetchError",
+        cause: expect.objectContaining({ name: "TimeoutError" }),
       },
     },
   ] as const)("$name", async ({ lookupFn, fetchImpl, readIdleTimeoutMs, expectedError }) => {
@@ -669,6 +670,41 @@ describe("readRemoteMediaBuffer", () => {
 
     expect(result.buffer.toString()).toBe("ok");
     expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries a default response-body idle timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(new Uint8Array([1, 2]));
+              },
+            }),
+            { status: 200 },
+          ),
+        )
+        .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
+      const result = readRemoteMediaBuffer({
+        url: "https://example.com/file.bin",
+        fetchImpl,
+        lookupFn: makeLookupFn(),
+        maxBytes: 1024,
+        readIdleTimeoutMs: 20,
+        retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+      });
+
+      await vi.advanceTimersByTimeAsync(25);
+
+      await expect(result).resolves.toMatchObject({ buffer: Buffer.from("ok") });
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not retry 4xx responses", async () => {

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -18,7 +18,7 @@ import {
 } from "../infra/net/fetch-guard.js";
 import type { LookupFn, PinnedDispatcherPolicy, SsrFPolicy } from "../infra/net/ssrf.js";
 import { retryAsync, type RetryOptions } from "../infra/retry.js";
-import { isTransientNetworkError } from "../infra/unhandled-rejections.js";
+import { isTransientNetworkError } from "../infra/retryable-network-errors.js";
 import { redactSensitiveText } from "../logging/redact.js";
 import { buildTimeoutAbortSignal } from "../utils/fetch-timeout.js";
 import { saveMediaBuffer, saveMediaStream, type SavedMedia } from "./store.js";

--- a/src/plugin-sdk/retry-runtime.ts
+++ b/src/plugin-sdk/retry-runtime.ts
@@ -39,6 +39,7 @@ export {
   type RetryInfo,
   type RetryOptions,
 } from "../infra/retry.js";
+export { isTransientNetworkError } from "../infra/retryable-network-errors.js";
 export {
   createChannelApiRetryRunner,
   createRateLimitRetryRunner,


### PR DESCRIPTION
Related: #118994

## What Problem This Solves

Fixes an issue where an inbound Twilio MMS could still lose its attachment when the remote media server sent response headers and then stalled. The default response-body timeout was emitted as a plain `Error`, so the transient retry policy added by #118994 did not recognize the failure and the durable sender lane treated it as permanent.

## Why This Change Was Made

The default response-body idle and overall deadlines now identify themselves as `TimeoutError`, and media retries use the same nested transient-network classifier as the gateway process boundary. SMS keeps an explicit fail-closed SSRF veto over the complete wrapper and aggregate error graph before applying that shared policy.

The generic classifier moved into the lightweight retry runtime rather than pulling process-level fatal-handler dependencies into plugin code. Existing imports from the old owner remain supported.

## SDK Contract Decision

`plugin-sdk/retry-runtime` remains a private-local subpath for bundled and official plugins. This change reuses that existing internal seam; it does not promote `isTransientNetworkError` to the documented public plugin SDK or create an external compatibility promise. The public SDK surface baseline remains unchanged.

## User Impact

Operators can expect stalled or temporarily unreachable Twilio MMS downloads to stay in the existing durable retry lane instead of permanently degrading an acknowledged callback. Permanent HTTP, size, storage, and SSRF failures remain non-retryable and visible.

## Evidence

- `node scripts/run-vitest.mjs src/infra/errors.test.ts src/infra/http-body.response.test.ts src/media/fetch.test.ts extensions/sms/src/media.test.ts extensions/sms/src/ingress-spool.test.ts`
  - 5 files, 254 tests passed across four repository shards.
- `node scripts/run-vitest.mjs src/infra/errors.test.ts src/infra/unhandled-rejections.test.ts src/infra/http-body.response.test.ts src/media/fetch.test.ts`
  - 180 shared infra/media tests passed.
- `node scripts/run-vitest.mjs extensions/sms/src/media.test.ts extensions/sms/src/ingress-spool.test.ts`
  - 128 SMS tests passed.
- `pnpm plugin-sdk:surface:check`
  - 322 entrypoints checked; public API baseline passed.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/30860707915
  - `openclaw/ci-gate`, build, SDK/API, import-topology, lint, type, and focused channel lanes passed for `9e0517295e619cdc7e77cebc15126fa4b6365317`.
- Isolated publishable SMS runtime import profile against the exact CI-built host artifact
  - SMS descriptor import passed.
  - Full `channel-plugin-api` import passed.
  - Five alternating parent/head runs produced median peak RSS of 446.69 MB at parent `6194cfdfb2fa` and 444.41 MB at head `9e0517295e61`; the private retry-runtime seam adds no observable import-graph cost.
- `git diff --check`
  - passed.
- Repository autoreview on `origin/main..HEAD`
  - clean, no accepted/actionable findings; confidence 0.98.

AI-assisted: yes. The maintainer reviewed the implementation and validation evidence.
