### PR TITLE
feat(agents): allow session_status to set thinking level

### DIFF
--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -1691,7 +1691,7 @@ describe("session_status tool", () => {
       },
     });
     // resetSessionStore restores default mocks; install the ACP policy afterward.
-    resolveProviderThinkingProfileMock.mockImplementation(({ context }) => ({
+    resolveProviderThinkingProfileMock.mockImplementation(({ context } = {}) => ({
       levels: [
         { id: "off" },
         { id: "max" },
@@ -1733,7 +1733,7 @@ describe("session_status tool", () => {
         agentRuntimeOverride: "openclaw",
       },
     });
-    resolveProviderThinkingProfileMock.mockImplementation(({ context }) => ({
+    resolveProviderThinkingProfileMock.mockImplementation(({ context } = {}) => ({
       levels: [
         { id: "off" },
         { id: "max" },

--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -21,6 +21,12 @@ import { compactToolOutputHint } from "./tool-schema-hints.js";
 const loadSessionStoreMock = vi.fn();
 const updateSessionStoreMock = vi.fn();
 const callGatewayMock = vi.fn();
+const readAcpSessionMetaForEntryMock = vi.hoisted(() =>
+  vi.fn((_params?: { sessionKey: string; entry?: SessionEntry }) => undefined as unknown),
+);
+const resolveProviderThinkingProfileMock = vi.hoisted(() =>
+  vi.fn((_params?: { context?: { agentRuntime?: string } }) => undefined as unknown),
+);
 const buildStatusMessageMock = vi.hoisted(() =>
   vi.fn((_params?: unknown) => "OpenClaw\n🧠 Model: GPT-5.4"),
 );
@@ -214,6 +220,13 @@ function createModelCatalogModuleMock() {
         reasoning: true,
         contextWindow: 400000,
       },
+      {
+        provider: "openai",
+        id: "no-think",
+        name: "No Think",
+        reasoning: false,
+        contextWindow: 128000,
+      },
     ],
   };
 }
@@ -314,6 +327,9 @@ function createCommandsStatusRuntimeModuleMock() {
 
 vi.mock("../config/sessions.js", createSessionsModuleMock);
 vi.mock("../gateway/call.js", createGatewayCallModuleMock);
+vi.mock("../acp/runtime/session-meta.js", () => ({
+  readAcpSessionMetaForEntry: readAcpSessionMetaForEntryMock,
+}));
 vi.mock("../config/config.js", createConfigModuleMock);
 vi.mock("../agents/prepared-model-catalog.js", createModelCatalogModuleMock);
 vi.mock("../agents/provider-model-normalization.runtime.js", () => ({
@@ -330,7 +346,7 @@ vi.mock("../plugins/plugin-metadata-snapshot.js", async (importOriginal) => ({
 vi.mock("../plugins/provider-thinking.js", () => ({
   resolveProviderBinaryThinking: () => undefined,
   resolveProviderDefaultThinkingLevel: () => undefined,
-  resolveProviderThinkingProfile: () => undefined,
+  resolveProviderThinkingProfile: resolveProviderThinkingProfileMock,
   resolveProviderXHighThinking: () => undefined,
 }));
 // Keep provider-runtime/plugin activation out of this focused tool test. The
@@ -409,6 +425,10 @@ function resetSessionStore(inputStore: Record<string, SessionEntry>) {
   resolveEnvApiKeyMock.mockReturnValue(null);
   resolveUsableCustomProviderApiKeyMock.mockReset();
   resolveUsableCustomProviderApiKeyMock.mockReturnValue(null);
+  readAcpSessionMetaForEntryMock.mockReset();
+  readAcpSessionMetaForEntryMock.mockReturnValue(undefined);
+  resolveProviderThinkingProfileMock.mockReset();
+  resolveProviderThinkingProfileMock.mockReturnValue(undefined);
   loadSessionStoreMock.mockClear();
   updateSessionStoreMock.mockClear();
   callGatewayMock.mockClear();
@@ -596,9 +616,11 @@ describe("session_status tool", () => {
     expect(details.statusText).toContain("🧠 Model:");
     expect(details.statusText).not.toContain("OAuth/token status");
     expect(tool.outputSchema).toBeDefined();
+    expect(Value.Check(tool.parameters, { thinkingLevel: "high" })).toBe(true);
+    expect(tool.description).toContain("`thinkingLevel` sets thinking");
     expect(Value.Check(tool.outputSchema!, result.details)).toBe(true);
     expect(compactToolOutputHint(tool.outputSchema)).toBe(
-      '{ changedModel: boolean; ok: true; sessionKey: string; stateVersion: number; statusText: string; active?: { accountId?: string; channel?: string; threadId?: string | number; to?: string }; deliveryContext?: { accountId?: string; channel?: string; threadId?: string | number; to?: string }; model?: string; modelOverride?: string | null; modelProvider?: string; origin?: { accountId?: string; provider?: string; threadId?: string | number }; stateChanges?: { earliestAvailableSequence: number; events: Array<{ actorType: "human" | "agent" | "system"; kind: string; occurredAt: number; sequence: number; summary: string; actorId?: string; payload?: { channel?: string; outcome?: "error" | "timeout" | "cancelled"; turns?: number }; runId?: string }>; historyGap: boolean; truncated: boolean } }',
+      '{ changedModel: boolean; ok: true; sessionKey: string; stateVersion: number; statusText: string; active?: { accountId?: string; channel?: string; threadId?: string | number; to?: string }; deliveryContext?: { accountId?: string; channel?: string; threadId?: string | number; to?: string }; model?: string; modelOverride?: string | null; modelProvider?: string; origin?: { accountId?: string; provider?: string; threadId?: string | number }; stateChanges?: { earliestAvailableSequence: number; events: Array<{ actorType: "human" | "agent" | "system"; kind: string; occurredAt: number; sequence: number; summary: string; actorId?: string; payload?: { channel?: string; outcome?: "error" | "timeout" | "cancelled"; turns?: number }; runId?: string }>; historyGap: boolean; truncated: boolean }; thinkingLevel?: string }',
     );
   });
 
@@ -1536,6 +1558,212 @@ describe("session_status tool", () => {
     });
   });
 
+  it("persists a canonical thinking-only update and fires session:patch", async () => {
+    const events: InternalHookEvent[] = [];
+    registerInternalHook("session:patch", async (event) => {
+      events.push(event);
+    });
+    resetSessionStore({
+      main: {
+        sessionId: "s-thinking",
+        updatedAt: 10,
+        thinkingLevel: "low",
+        modelFallback: {
+          prevModel: "gpt-5.4",
+          prevProvider: "openai",
+          prevThinkingLevel: "low",
+          ts: 1,
+          source: "agent-patch",
+        },
+      },
+    });
+
+    const result = await getSessionStatusTool().execute("call-session-status-thinking", {
+      thinkingLevel: "med",
+    });
+
+    expect(result.details).toMatchObject({
+      ok: true,
+      changedModel: false,
+      thinkingLevel: "medium",
+    });
+    const savedStore = latestMockCallArg(updateSessionStoreMock, 1) as Record<string, SessionEntry>;
+    expect(savedStore.main?.thinkingLevel).toBe("medium");
+    expect(savedStore.main?.modelFallback).toEqual({
+      prevModel: "gpt-5.4",
+      prevProvider: "openai",
+      prevThinkingLevel: "medium",
+      ts: 1,
+      source: "agent-patch",
+    });
+    await vi.waitFor(() => expect(events).toHaveLength(1));
+    const event = expectDefined(events[0], "events[0] test invariant");
+    expect(event.context.patch).toEqual({
+      key: "main",
+      thinkingLevel: "medium",
+    });
+    expect(event.context.sessionEntry).toMatchObject({ thinkingLevel: "medium" });
+  });
+
+  it("validates combined model and thinking updates against the new model", async () => {
+    const events: InternalHookEvent[] = [];
+    registerInternalHook("session:patch", async (event) => {
+      events.push(event);
+    });
+    resetSessionStore({
+      main: {
+        sessionId: "s-model-thinking",
+        updatedAt: 10,
+        providerOverride: "openai",
+        modelOverride: "no-think",
+        thinkingLevel: "off",
+      },
+    });
+
+    const result = await getSessionStatusTool().execute("call-session-status-model-thinking", {
+      model: "openai/gpt-5.4",
+      thinkingLevel: "high",
+    });
+
+    expect(result.details).toMatchObject({
+      ok: true,
+      changedModel: true,
+      model: "gpt-5.4",
+      modelProvider: "openai",
+      modelOverride: null,
+      thinkingLevel: "high",
+    });
+    const savedStore = latestMockCallArg(updateSessionStoreMock, 1) as Record<string, SessionEntry>;
+    expect(savedStore.main).toMatchObject({
+      thinkingLevel: "high",
+      liveModelSwitchPending: true,
+    });
+    expect(savedStore.main?.providerOverride).toBeUndefined();
+    expect(savedStore.main?.modelOverride).toBeUndefined();
+    await vi.waitFor(() => expect(events).toHaveLength(1));
+    expect(events[0]?.context.patch).toEqual({
+      key: "main",
+      model: "openai/gpt-5.4",
+      thinkingLevel: "high",
+    });
+  });
+
+  it("rejects unsupported thinking for the new model without partial persistence", async () => {
+    const events: InternalHookEvent[] = [];
+    registerInternalHook("session:patch", async (event) => {
+      events.push(event);
+    });
+    const store: Record<string, SessionEntry> = {
+      main: {
+        sessionId: "s-invalid-thinking",
+        updatedAt: 10,
+        providerOverride: "anthropic",
+        modelOverride: "claude-sonnet-4-6",
+        thinkingLevel: "low",
+      },
+    };
+    resetSessionStore(store);
+
+    await expect(
+      getSessionStatusTool().execute("call-session-status-invalid-thinking", {
+        model: "openai/no-think",
+        thinkingLevel: "high",
+      }),
+    ).rejects.toThrow(
+      'Thinking level "high" is not supported for openai/no-think. Use one of: off.',
+    );
+
+    expect(updateSessionStoreMock).not.toHaveBeenCalled();
+    expect(events).toEqual([]);
+    expect(store.main).toMatchObject({
+      providerOverride: "anthropic",
+      modelOverride: "claude-sonnet-4-6",
+      thinkingLevel: "low",
+    });
+  });
+
+  it("uses ACP backend metadata to accept thinking unsupported by the ordinary runtime", async () => {
+    resetSessionStore({
+      main: {
+        sessionId: "s-acp-thinking-accept",
+        updatedAt: 10,
+        agentRuntimeOverride: "codex",
+      },
+    });
+    // resetSessionStore restores default mocks; install the ACP policy afterward.
+    resolveProviderThinkingProfileMock.mockImplementation(({ context }) => ({
+      levels: [
+        { id: "off" },
+        { id: "max" },
+        ...(context?.agentRuntime === "openclaw" ? [{ id: "ultra" }] : []),
+      ],
+    }));
+    readAcpSessionMetaForEntryMock.mockReturnValue({
+      backend: "openclaw",
+      agent: "main",
+      runtimeSessionName: "main",
+      mode: "persistent",
+      state: "idle",
+      lastActivityAt: 1,
+    });
+    mockConfig = {
+      agents: { defaults: { model: { primary: "openai/gpt-5.6-luna" } } },
+    };
+
+    const result = await getSessionStatusTool().execute("call-acp-thinking-accept", {
+      thinkingLevel: "ultra",
+    });
+
+    expect(result.details).toMatchObject({ thinkingLevel: "ultra" });
+    expect(readAcpSessionMetaForEntryMock).toHaveBeenCalledTimes(2);
+    expect(readAcpSessionMetaForEntryMock).toHaveBeenLastCalledWith({
+      sessionKey: "main",
+      entry: expect.objectContaining({
+        sessionId: "s-acp-thinking-accept",
+        agentRuntimeOverride: "codex",
+      }),
+    });
+  });
+
+  it("uses ACP backend metadata to reject thinking supported by the ordinary runtime", async () => {
+    resetSessionStore({
+      main: {
+        sessionId: "s-acp-thinking-reject",
+        updatedAt: 10,
+        agentRuntimeOverride: "openclaw",
+      },
+    });
+    resolveProviderThinkingProfileMock.mockImplementation(({ context }) => ({
+      levels: [
+        { id: "off" },
+        { id: "max" },
+        ...(context?.agentRuntime === "openclaw" ? [{ id: "ultra" }] : []),
+      ],
+    }));
+    readAcpSessionMetaForEntryMock.mockReturnValue({
+      backend: "codex",
+      agent: "main",
+      runtimeSessionName: "main",
+      mode: "persistent",
+      state: "idle",
+      lastActivityAt: 1,
+    });
+    mockConfig = {
+      agents: { defaults: { model: { primary: "openai/gpt-5.6-luna" } } },
+    };
+
+    await expect(
+      getSessionStatusTool().execute("call-acp-thinking-reject", {
+        thinkingLevel: "ultra",
+      }),
+    ).rejects.toThrow(
+      'Thinking level "ultra" is not supported for openai/gpt-5.6-luna. Use one of: off, max.',
+    );
+
+    expect(updateSessionStoreMock).not.toHaveBeenCalled();
+    expect(readAcpSessionMetaForEntryMock).toHaveBeenCalledOnce();
+  });
+
   it("rejects model changes for model-locked sessions", async () => {
     const store: Record<string, SessionEntry> = {
       main: {
@@ -2174,7 +2402,7 @@ describe("session_status tool", () => {
     await expect(
       tool.execute("call-tree-visibility", {
         sessionKey: "agent:main:main",
-        model: "default",
+        thinkingLevel: "high",
       }),
     ).rejects.toThrow(
       "Session status visibility is restricted to the current session tree and any watched same-agent group sessions (tools.sessions.visibility=tree).",

--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -1605,6 +1605,79 @@ describe("session_status tool", () => {
     expect(event.context.sessionEntry).toMatchObject({ thinkingLevel: "medium" });
   });
 
+  it("clears a thinking override via thinkingLevel=default", async () => {
+    const events: InternalHookEvent[] = [];
+    registerInternalHook("session:patch", async (event) => {
+      events.push(event);
+    });
+    resetSessionStore({
+      main: {
+        sessionId: "s-thinking-reset",
+        updatedAt: 10,
+        thinkingLevel: "high",
+        modelFallback: {
+          prevModel: "gpt-5.4",
+          prevProvider: "openai",
+          prevThinkingLevel: "high",
+          ts: 1,
+          source: "agent-patch",
+        },
+      },
+    });
+
+    const tool = getSessionStatusTool();
+    const result = await tool.execute("call-session-status-thinking-reset", {
+      thinkingLevel: "default",
+    });
+
+    expect(result.details).toMatchObject({ ok: true, changedModel: false });
+    expect(result.details).not.toHaveProperty("thinkingLevel");
+    expect(Value.Check(tool.outputSchema!, result.details)).toBe(true);
+    const savedStore = latestMockCallArg(updateSessionStoreMock, 1) as Record<string, SessionEntry>;
+    expect(savedStore.main?.thinkingLevel).toBeUndefined();
+    expect(savedStore.main?.modelFallback?.prevThinkingLevel).toBeUndefined();
+    await vi.waitFor(() => expect(events).toHaveLength(1));
+    const event = expectDefined(events[0], "events[0] test invariant");
+    expect(event.context.patch).toEqual({
+      key: "main",
+      thinkingLevel: null,
+    });
+    expect(event.context.sessionEntry.thinkingLevel).toBeUndefined();
+  });
+
+  it("validates thinking-only updates against the persisted next-run model", async () => {
+    const store: Record<string, SessionEntry> = {
+      main: {
+        sessionId: "s-thinking-next-run-model",
+        updatedAt: 10,
+        providerOverride: "openai",
+        modelOverride: "no-think",
+        thinkingLevel: "off",
+      },
+    };
+    resetSessionStore(store);
+
+    const tool = getSessionStatusTool("main", {
+      activeModelProvider: "openai",
+      activeModelId: "gpt-5.4",
+    });
+
+    await expect(
+      tool.execute("call-session-status-thinking-next-run-model", {
+        sessionKey: "current",
+        thinkingLevel: "high",
+      }),
+    ).rejects.toThrow(
+      'Thinking level "high" is not supported for openai/no-think. Use one of: off.',
+    );
+    expect(updateSessionStoreMock).not.toHaveBeenCalled();
+    expect(store.main).toMatchObject({
+      providerOverride: "openai",
+      modelOverride: "no-think",
+      thinkingLevel: "off",
+    });
+  });
+
   it("validates combined model and thinking updates against the new model", async () => {
     const events: InternalHookEvent[] = [];
     registerInternalHook("session:patch", async (event) => {

--- a/src/agents/tool-description-presets.ts
+++ b/src/agents/tool-description-presets.ts
@@ -131,7 +131,7 @@ export function describeSessionStatusTool(): string {
   return [
     "Show visible-session model/usage/time/cost/tasks.",
     '`sessionKey="current"` for current; UI labels are not keys.',
-    "`model` overrides; `model=default` resets. Use for active model/session questions.",
+    "`model` overrides; `model=default` resets; `thinkingLevel` sets thinking for the effective model. Use for active model/session questions.",
   ].join(" ");
 }
 

--- a/src/agents/tool-description-presets.ts
+++ b/src/agents/tool-description-presets.ts
@@ -131,7 +131,7 @@ export function describeSessionStatusTool(): string {
   return [
     "Show visible-session model/usage/time/cost/tasks.",
     '`sessionKey="current"` for current; UI labels are not keys.',
-    "`model` overrides; `model=default` resets; `thinkingLevel` sets thinking for the effective model. Use for active model/session questions.",
+    "`model` overrides; `model=default` resets; `thinkingLevel` sets thinking for the effective model; `thinkingLevel=default` resets. Use for active model/session questions.",
   ].join(" ");
 }
 

--- a/src/agents/tool-mutation.test.ts
+++ b/src/agents/tool-mutation.test.ts
@@ -10,12 +10,18 @@ import {
 } from "./tool-mutation.js";
 
 describe("tool mutation helpers", () => {
-  it("treats session_status as mutating only when model override is provided", () => {
+  it("treats session_status as mutating only when a session override is provided", () => {
     expect(isMutatingToolCall("session_status", { sessionKey: "agent:main:main" })).toBe(false);
     expect(
       isMutatingToolCall("session_status", {
         sessionKey: "agent:main:main",
         model: "openai/gpt-4o",
+      }),
+    ).toBe(true);
+    expect(
+      isMutatingToolCall("session_status", {
+        sessionKey: "agent:main:main",
+        thinkingLevel: "high",
       }),
     ).toBe(true);
   });

--- a/src/agents/tool-mutation.ts
+++ b/src/agents/tool-mutation.ts
@@ -367,7 +367,9 @@ export function isMutatingToolCall(toolName: string, args: unknown): boolean {
     case "subagents":
       return action === "cancel" || action === "kill" || action === "steer";
     case "session_status":
-      return typeof record?.model === "string" && record.model.trim().length > 0;
+      return [record?.model, record?.thinkingLevel].some(
+        (value) => typeof value === "string" && value.trim().length > 0,
+      );
     case "gateway":
       return action == null || !GATEWAY_REPLAY_SAFE_ACTIONS.has(action);
     case "nodes":

--- a/src/agents/tool-schema-hints.ts
+++ b/src/agents/tool-schema-hints.ts
@@ -2,9 +2,9 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 
 const MAX_COMPACT_INPUT_HINT_CHARS = 300;
-// Sized so real multi-branch contracts like web_search's four-way union stay
-// promotable with headroom; the quick index independently truncates total bytes.
-const MAX_COMPACT_OUTPUT_HINT_CHARS = 800;
+// Sized so real contracts like web_search's four-way union and session_status
+// stay promotable with headroom; the quick index independently truncates total bytes.
+const MAX_COMPACT_OUTPUT_HINT_CHARS = 850;
 const MAX_COMPACT_INPUT_SCHEMA_PROPERTIES = 16;
 const MAX_COMPACT_OUTPUT_SCHEMA_PROPERTIES = 20;
 const MAX_COMPACT_SCHEMA_PROPERTY_NAME_CHARS = 128;

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -16,6 +16,7 @@ import type {
 } from "../../auto-reply/thinking.js";
 import {
   formatThinkingLevels,
+  isSessionDefaultDirectiveValue,
   isThinkingLevelSupported,
   normalizeThinkLevel,
 } from "../../auto-reply/thinking.js";
@@ -102,7 +103,10 @@ const SessionStatusToolSchema = Type.Object({
   sessionKey: Type.Optional(Type.String()),
   model: Type.Optional(Type.String()),
   thinkingLevel: Type.Optional(
-    Type.String({ description: "Thinking level override for the effective session model" }),
+    Type.String({
+      description:
+        'Thinking level override for the effective session model; use "default" to reset',
+    }),
   ),
   changesSince: Type.Optional(Type.Integer({ minimum: 0 })),
 });
@@ -559,15 +563,8 @@ function resolveValidatedThinkingLevel(params: {
   agentId: string;
   sessionKey: string;
   catalog: ThinkingCatalogEntry[];
-  activeModelIdentity?: ActiveStatusModelIdentity;
 }): ThinkLevel {
-  const persistedModel = resolveSessionModelRef(params.cfg, params.entry, params.agentId);
-  const selected = params.activeModelIdentity
-    ? {
-        provider: params.activeModelIdentity.provider ?? persistedModel.provider,
-        model: params.activeModelIdentity.model,
-      }
-    : persistedModel;
+  const selected = resolveSessionModelRef(params.cfg, params.entry, params.agentId);
   const level = normalizeThinkLevel(params.raw);
   // ACP metadata can own canonical agent keys, so its backend must override
   // key/config-derived runtime policy when validating thinking.
@@ -938,6 +935,8 @@ export function createSessionStatusTool(opts?: {
           const selectedWorkspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
           const modelRaw = readStringParam(params, "model");
           const thinkingLevelRaw = readStringParam(params, "thinkingLevel");
+          const resetsThinkingLevel =
+            thinkingLevelRaw !== undefined && isSessionDefaultDirectiveValue(thinkingLevelRaw);
           const isImplicitCurrentRequest = requestedKeyParam === undefined;
           const liveSessionKeys = [
             opts?.runSessionKey,
@@ -1013,17 +1012,21 @@ export function createSessionStatusTool(opts?: {
             }).updated;
           }
           if (thinkingLevelRaw !== undefined) {
-            const thinkingLevel = resolveValidatedThinkingLevel({
-              raw: thinkingLevelRaw,
-              cfg,
-              entry: prospectiveEntry,
-              agentId,
-              sessionKey: scopedResolved.key,
-              catalog: await loadMutationThinkingCatalog(),
-              activeModelIdentity: modelSelection ? undefined : activeModelIdentity,
-            });
-            changedThinking = prospectiveEntry.thinkingLevel !== thinkingLevel;
-            prospectiveEntry.thinkingLevel = thinkingLevel;
+            if (resetsThinkingLevel) {
+              changedThinking = prospectiveEntry.thinkingLevel !== undefined;
+              delete prospectiveEntry.thinkingLevel;
+            } else {
+              const thinkingLevel = resolveValidatedThinkingLevel({
+                raw: thinkingLevelRaw,
+                cfg,
+                entry: prospectiveEntry,
+                agentId,
+                sessionKey: scopedResolved.key,
+                catalog: await loadMutationThinkingCatalog(),
+              });
+              changedThinking = prospectiveEntry.thinkingLevel !== thinkingLevel;
+              prospectiveEntry.thinkingLevel = thinkingLevel;
+            }
           }
 
           if (changedModel || changedThinking) {
@@ -1043,17 +1046,21 @@ export function createSessionStatusTool(opts?: {
                     }).updated
                   : false;
                 if (thinkingLevelRaw !== undefined) {
-                  const thinkingLevel = resolveValidatedThinkingLevel({
-                    raw: thinkingLevelRaw,
-                    cfg,
-                    entry: persistedEntryPatch,
-                    agentId,
-                    sessionKey: scopedResolved.key,
-                    catalog: await loadMutationThinkingCatalog(),
-                    activeModelIdentity: modelSelection ? undefined : activeModelIdentity,
-                  });
-                  changedThinking = persistedEntryPatch.thinkingLevel !== thinkingLevel;
-                  persistedEntryPatch.thinkingLevel = thinkingLevel;
+                  if (resetsThinkingLevel) {
+                    changedThinking = persistedEntryPatch.thinkingLevel !== undefined;
+                    delete persistedEntryPatch.thinkingLevel;
+                  } else {
+                    const thinkingLevel = resolveValidatedThinkingLevel({
+                      raw: thinkingLevelRaw,
+                      cfg,
+                      entry: persistedEntryPatch,
+                      agentId,
+                      sessionKey: scopedResolved.key,
+                      catalog: await loadMutationThinkingCatalog(),
+                    });
+                    changedThinking = persistedEntryPatch.thinkingLevel !== thinkingLevel;
+                    persistedEntryPatch.thinkingLevel = thinkingLevel;
+                  }
                   if (changedThinking && !changedModel) {
                     persistedEntryPatch.updatedAt = Date.now();
                     // Keep a pending agent model-revert marker aligned with an
@@ -1061,7 +1068,7 @@ export function createSessionStatusTool(opts?: {
                     if (persistedEntryPatch.modelFallback?.source === "agent-patch") {
                       persistedEntryPatch.modelFallback = {
                         ...persistedEntryPatch.modelFallback,
-                        prevThinkingLevel: thinkingLevel,
+                        prevThinkingLevel: persistedEntryPatch.thinkingLevel,
                       };
                     }
                   }
@@ -1098,7 +1105,11 @@ export function createSessionStatusTool(opts?: {
                 patch: {
                   key: patchResult.sessionKey,
                   ...(changedModel ? { model: modelPatchValue } : {}),
-                  ...(changedThinking ? { thinkingLevel: persistedEntry.thinkingLevel } : {}),
+                  ...(changedThinking
+                    ? {
+                        thinkingLevel: resetsThinkingLevel ? null : persistedEntry.thinkingLevel,
+                      }
+                    : {}),
                 },
               });
             }
@@ -1258,7 +1269,7 @@ export function createSessionStatusTool(opts?: {
                     modelOverride: modelOverrideForResult,
                   }
                 : {}),
-              ...(thinkingLevelRaw !== undefined
+              ...(thinkingLevelRaw !== undefined && statusSessionEntry.thinkingLevel !== undefined
                 ? { thinkingLevel: statusSessionEntry.thinkingLevel }
                 : {}),
               statusText: visibleStatusText,

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -6,11 +6,18 @@
 import { randomUUID } from "node:crypto";
 import { readStringValue } from "@openclaw/normalization-core/string-coerce";
 import { Type } from "typebox";
+import { readAcpSessionMetaForEntry } from "../../acp/runtime/session-meta.js";
 import type {
   ElevatedLevel,
   ReasoningLevel,
   ThinkLevel,
+  ThinkingCatalogEntry,
   VerboseLevel,
+} from "../../auto-reply/thinking.js";
+import {
+  formatThinkingLevels,
+  isThinkingLevelSupported,
+  normalizeThinkLevel,
 } from "../../auto-reply/thinking.js";
 import { getRuntimeConfig } from "../../config/config.js";
 import {
@@ -61,7 +68,8 @@ import {
 } from "../model-selection.js";
 import { createModelVisibilityPolicy } from "../model-visibility-policy.js";
 import { loadPreparedModelCatalog } from "../prepared-model-catalog.js";
-import { resolveSessionModelIdentityRef } from "../session-model-ref.js";
+import { resolveSessionModelIdentityRef, resolveSessionModelRef } from "../session-model-ref.js";
+import { resolveEffectiveAgentRuntime } from "../thinking-runtime.js";
 import {
   describeSessionStatusTool,
   SESSION_STATUS_TOOL_DISPLAY_SUMMARY,
@@ -93,6 +101,9 @@ import {
 const SessionStatusToolSchema = Type.Object({
   sessionKey: Type.Optional(Type.String()),
   model: Type.Optional(Type.String()),
+  thinkingLevel: Type.Optional(
+    Type.String({ description: "Thinking level override for the effective session model" }),
+  ),
   changesSince: Type.Optional(Type.Integer({ minimum: 0 })),
 });
 
@@ -161,6 +172,7 @@ const SessionStatusOutputSchema = Type.Object(
     model: Type.Optional(Type.String()),
     modelProvider: Type.Optional(Type.String()),
     modelOverride: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+    thinkingLevel: Type.Optional(Type.String()),
     origin: Type.Optional(SessionStatusOriginSchema),
     active: Type.Optional(SessionStatusDeliveryContextSchema),
     deliveryContext: Type.Optional(SessionStatusDeliveryContextSchema),
@@ -540,6 +552,63 @@ async function resolveModelOverride(params: {
   };
 }
 
+function resolveValidatedThinkingLevel(params: {
+  raw: string;
+  cfg: OpenClawConfig;
+  entry: SessionEntry;
+  agentId: string;
+  sessionKey: string;
+  catalog: ThinkingCatalogEntry[];
+  activeModelIdentity?: ActiveStatusModelIdentity;
+}): ThinkLevel {
+  const persistedModel = resolveSessionModelRef(params.cfg, params.entry, params.agentId);
+  const selected = params.activeModelIdentity
+    ? {
+        provider: params.activeModelIdentity.provider ?? persistedModel.provider,
+        model: params.activeModelIdentity.model,
+      }
+    : persistedModel;
+  const level = normalizeThinkLevel(params.raw);
+  // ACP metadata can own canonical agent keys, so its backend must override
+  // key/config-derived runtime policy when validating thinking.
+  const acpMeta = readAcpSessionMetaForEntry({
+    sessionKey: params.sessionKey,
+    entry: params.entry,
+  });
+  const agentRuntime =
+    acpMeta?.backend ??
+    resolveEffectiveAgentRuntime({
+      cfg: params.cfg,
+      provider: selected.provider,
+      modelId: selected.model,
+      agentId: params.agentId,
+      sessionKey: params.sessionKey,
+      sessionEntry: params.entry,
+    });
+  const hint = formatThinkingLevels(
+    selected.provider,
+    selected.model,
+    ", ",
+    params.catalog,
+    agentRuntime,
+  );
+  if (
+    !level ||
+    !isThinkingLevelSupported({
+      provider: selected.provider,
+      model: selected.model,
+      level,
+      catalog: params.catalog,
+      agentRuntime,
+    })
+  ) {
+    throw new Error(
+      `Thinking level "${params.raw}" is not supported for ${selected.provider}/${selected.model}. Use one of: ${hint}.`,
+    );
+  }
+  return level;
+}
+
 export function createSessionStatusTool(opts?: {
   agentSessionKey?: string;
   /**
@@ -868,7 +937,31 @@ export function createSessionStatusTool(opts?: {
           const selectedAgentDir = resolveAgentDir(cfg, agentId);
           const selectedWorkspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
           const modelRaw = readStringParam(params, "model");
-          let changedModel = false;
+          const thinkingLevelRaw = readStringParam(params, "thinkingLevel");
+          const isImplicitCurrentRequest = requestedKeyParam === undefined;
+          const liveSessionKeys = [
+            opts?.runSessionKey,
+            storeScopedRequesterKey,
+            effectiveRequesterKey,
+            visibilityRequesterKey,
+          ];
+          const activeModelIdentity = resolveActiveStatusModelIdentity({
+            activeModelId: opts?.activeModelId?.trim(),
+            activeModelProvider: opts?.activeModelProvider?.trim(),
+            isImplicitCurrentRequest,
+            isSemanticCurrentRequest,
+            liveSessionKeys,
+            modelRaw,
+            resolvedKey: scopedResolved.key,
+          });
+          let modelSelection:
+            | {
+                provider: string;
+                model: string;
+                isDefault: boolean;
+              }
+            | undefined;
+          let modelPatchValue: string | null | undefined;
           if (typeof modelRaw === "string") {
             const selection = await resolveModelOverride({
               cfg,
@@ -879,7 +972,7 @@ export function createSessionStatusTool(opts?: {
               workspaceDir: selectedWorkspaceDir,
               metadataSnapshot: opts?.metadataSnapshot,
             });
-            const modelSelection =
+            modelSelection =
               selection.kind === "reset"
                 ? {
                     provider: configured.provider,
@@ -891,80 +984,126 @@ export function createSessionStatusTool(opts?: {
                     model: selection.model,
                     isDefault: selection.isDefault,
                   };
-            const nextEntry: SessionEntry = { ...scopedResolved.entry };
-            const applied = applyModelOverrideToSessionEntry({
-              entry: nextEntry,
+            modelPatchValue =
+              selection.kind === "reset" ? null : `${selection.provider}/${selection.model}`;
+          }
+
+          let mutationThinkingCatalog: ThinkingCatalogEntry[] | undefined;
+          const loadMutationThinkingCatalog = async () => {
+            mutationThinkingCatalog ??= await loadPreparedModelCatalog({
+              config: cfg,
+              agentId,
+              agentDir: selectedAgentDir,
+              readOnly: true,
+              ...(scopedResolved.entry.spawnedWorkspaceDir
+                ? { workspaceDir: scopedResolved.entry.spawnedWorkspaceDir }
+                : {}),
+            });
+            return mutationThinkingCatalog;
+          };
+
+          const prospectiveEntry: SessionEntry = { ...scopedResolved.entry };
+          let changedModel = false;
+          let changedThinking = false;
+          if (modelSelection) {
+            changedModel = applyModelOverrideToSessionEntry({
+              entry: prospectiveEntry,
               selection: modelSelection,
               markLiveSwitchPending: true,
+            }).updated;
+          }
+          if (thinkingLevelRaw !== undefined) {
+            const thinkingLevel = resolveValidatedThinkingLevel({
+              raw: thinkingLevelRaw,
+              cfg,
+              entry: prospectiveEntry,
+              agentId,
+              sessionKey: scopedResolved.key,
+              catalog: await loadMutationThinkingCatalog(),
+              activeModelIdentity: modelSelection ? undefined : activeModelIdentity,
             });
-            if (applied.updated) {
-              const patchResult = await patchSessionEntryWithKey(
-                {
-                  agentId,
-                  sessionKey: scopedResolved.key,
-                  storePath,
-                },
-                (entry, context) => {
-                  const persistedEntryPatch: SessionEntry = { ...entry };
-                  applyModelOverrideToSessionEntry({
+            changedThinking = prospectiveEntry.thinkingLevel !== thinkingLevel;
+            prospectiveEntry.thinkingLevel = thinkingLevel;
+          }
+
+          if (changedModel || changedThinking) {
+            const patchResult = await patchSessionEntryWithKey(
+              {
+                agentId,
+                sessionKey: scopedResolved.key,
+                storePath,
+              },
+              async (entry, context) => {
+                const persistedEntryPatch: SessionEntry = { ...entry };
+                changedModel = modelSelection
+                  ? applyModelOverrideToSessionEntry({
+                      entry: persistedEntryPatch,
+                      selection: modelSelection,
+                      markLiveSwitchPending: true,
+                    }).updated
+                  : false;
+                if (thinkingLevelRaw !== undefined) {
+                  const thinkingLevel = resolveValidatedThinkingLevel({
+                    raw: thinkingLevelRaw,
+                    cfg,
                     entry: persistedEntryPatch,
-                    selection: modelSelection,
-                    markLiveSwitchPending: true,
+                    agentId,
+                    sessionKey: scopedResolved.key,
+                    catalog: await loadMutationThinkingCatalog(),
+                    activeModelIdentity: modelSelection ? undefined : activeModelIdentity,
                   });
-                  if (
-                    !persistedEntryPatch.sessionId.trim() &&
-                    !context.existingEntry?.sessionId?.trim()
-                  ) {
-                    persistedEntryPatch.sessionId = randomUUID();
+                  changedThinking = persistedEntryPatch.thinkingLevel !== thinkingLevel;
+                  persistedEntryPatch.thinkingLevel = thinkingLevel;
+                  if (changedThinking && !changedModel) {
+                    persistedEntryPatch.updatedAt = Date.now();
+                    // Keep a pending agent model-revert marker aligned with an
+                    // independent thinking choice so rollback cannot clobber it.
+                    if (persistedEntryPatch.modelFallback?.source === "agent-patch") {
+                      persistedEntryPatch.modelFallback = {
+                        ...persistedEntryPatch.modelFallback,
+                        prevThinkingLevel: thinkingLevel,
+                      };
+                    }
                   }
-                  return persistedEntryPatch;
-                },
-                {
-                  fallbackEntry: scopedResolved.persisted ? undefined : scopedResolved.entry,
-                  replaceEntry: true,
-                },
-              );
-              if (!patchResult) {
-                throw new Error(`Unknown sessionKey: ${scopedResolved.key}`);
-              }
-              const persistedEntry = patchResult.entry;
-              scopedResolved = {
-                entry: persistedEntry,
-                key: patchResult.sessionKey,
-                persisted: true,
-              };
+                } else {
+                  changedThinking = false;
+                }
+                if (
+                  !persistedEntryPatch.sessionId.trim() &&
+                  !context.existingEntry?.sessionId?.trim()
+                ) {
+                  persistedEntryPatch.sessionId = randomUUID();
+                }
+                return persistedEntryPatch;
+              },
+              {
+                fallbackEntry: scopedResolved.persisted ? undefined : scopedResolved.entry,
+                replaceEntry: true,
+              },
+            );
+            if (!patchResult) {
+              throw new Error(`Unknown sessionKey: ${scopedResolved.key}`);
+            }
+            const persistedEntry = patchResult.entry;
+            scopedResolved = {
+              entry: persistedEntry,
+              key: patchResult.sessionKey,
+              persisted: true,
+            };
+            if (changedModel || changedThinking) {
               triggerSessionPatchHook({
                 cfg,
                 sessionEntry: persistedEntry,
                 sessionKey: patchResult.sessionKey,
                 patch: {
                   key: patchResult.sessionKey,
-                  model:
-                    selection.kind === "reset" ? null : `${selection.provider}/${selection.model}`,
+                  ...(changedModel ? { model: modelPatchValue } : {}),
+                  ...(changedThinking ? { thinkingLevel: persistedEntry.thinkingLevel } : {}),
                 },
               });
-              changedModel = true;
             }
           }
 
-          const activeModelId = opts?.activeModelId?.trim();
-          const activeModelProvider = opts?.activeModelProvider?.trim();
-          const isImplicitCurrentRequest = requestedKeyParam === undefined;
-          const liveSessionKeys = [
-            opts?.runSessionKey,
-            storeScopedRequesterKey,
-            effectiveRequesterKey,
-            visibilityRequesterKey,
-          ];
-          const activeModelIdentity = resolveActiveStatusModelIdentity({
-            activeModelId,
-            activeModelProvider,
-            isImplicitCurrentRequest,
-            isSemanticCurrentRequest,
-            liveSessionKeys,
-            modelRaw,
-            resolvedKey: scopedResolved.key,
-          });
           const runtimeModelIdentity = activeModelIdentity
             ? activeModelIdentity
             : resolveSessionModelIdentityRef(
@@ -1007,15 +1146,17 @@ export function createSessionStatusTool(opts?: {
             callerOwnerKey: visibilityRequesterKey,
           });
           // Tool status may read persisted/configured facts, but must not start provider discovery.
-          const thinkingCatalog = await loadPreparedModelCatalog({
-            config: cfg,
-            agentId,
-            agentDir: selectedAgentDir,
-            readOnly: true,
-            ...(statusSessionEntry.spawnedWorkspaceDir
-              ? { workspaceDir: statusSessionEntry.spawnedWorkspaceDir }
-              : {}),
-          });
+          const thinkingCatalog =
+            mutationThinkingCatalog ??
+            (await loadPreparedModelCatalog({
+              config: cfg,
+              agentId,
+              agentDir: selectedAgentDir,
+              readOnly: true,
+              ...(statusSessionEntry.spawnedWorkspaceDir
+                ? { workspaceDir: statusSessionEntry.spawnedWorkspaceDir }
+                : {}),
+            }));
           const { buildStatusText } = await loadCommandsStatusRuntime();
           const statusText = await buildStatusText({
             cfg,
@@ -1116,6 +1257,9 @@ export function createSessionStatusTool(opts?: {
                       : {}),
                     modelOverride: modelOverrideForResult,
                   }
+                : {}),
+              ...(thinkingLevelRaw !== undefined
+                ? { thinkingLevel: statusSessionEntry.thinkingLevel }
                 : {}),
               statusText: visibleStatusText,
               ...routeDetails,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -1292,7 +1292,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Show visible-session model/usage/time/cost/tasks. `sessionKey=\"current\"` for current; UI labels are not keys. `model` overrides; `model=default` resets. Use for active model/session questions.",
+        "description": "Show visible-session model/usage/time/cost/tasks. `sessionKey=\"current\"` for current; UI labels are not keys. `model` overrides; `model=default` resets; `thinkingLevel` sets thinking for the effective model. Use for active model/session questions.",
         "inputSchema": {
           "properties": {
             "changesSince": {
@@ -1303,6 +1303,10 @@
               "type": "string"
             },
             "sessionKey": {
+              "type": "string"
+            },
+            "thinkingLevel": {
+              "description": "Thinking level override for the effective session model",
               "type": "string"
             }
           },

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -1292,7 +1292,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Show visible-session model/usage/time/cost/tasks. `sessionKey=\"current\"` for current; UI labels are not keys. `model` overrides; `model=default` resets; `thinkingLevel` sets thinking for the effective model. Use for active model/session questions.",
+        "description": "Show visible-session model/usage/time/cost/tasks. `sessionKey=\"current\"` for current; UI labels are not keys. `model` overrides; `model=default` resets; `thinkingLevel` sets thinking for the effective model; `thinkingLevel=default` resets. Use for active model/session questions.",
         "inputSchema": {
           "properties": {
             "changesSince": {
@@ -1306,7 +1306,7 @@
               "type": "string"
             },
             "thinkingLevel": {
-              "description": "Thinking level override for the effective session model",
+              "description": "Thinking level override for the effective session model; use \"default\" to reset",
               "type": "string"
             }
           },

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -221,8 +221,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 61710,
-    "roughTokens": 15428
+    "chars": 61768,
+    "roughTokens": 15442
   },
   "openClawDeveloperInstructions": {
     "chars": 3811,
@@ -233,8 +233,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 7049
   },
   "totalWithDynamicToolsJson": {
-    "chars": 89906,
-    "roughTokens": 22477
+    "chars": 89964,
+    "roughTokens": 22491
   },
   "userInputText": {
     "chars": 1300,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -221,8 +221,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 61490,
-    "roughTokens": 15373
+    "chars": 61710,
+    "roughTokens": 15428
   },
   "openClawDeveloperInstructions": {
     "chars": 3811,
@@ -233,8 +233,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 7049
   },
   "totalWithDynamicToolsJson": {
-    "chars": 89686,
-    "roughTokens": 22422
+    "chars": 89906,
+    "roughTokens": 22477
   },
   "userInputText": {
     "chars": 1300,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -221,8 +221,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 61402,
-    "roughTokens": 15351
+    "chars": 61460,
+    "roughTokens": 15365
   },
   "openClawDeveloperInstructions": {
     "chars": 2702,
@@ -233,8 +233,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6679
   },
   "totalWithDynamicToolsJson": {
-    "chars": 88118,
-    "roughTokens": 22030
+    "chars": 88176,
+    "roughTokens": 22044
   },
   "userInputText": {
     "chars": 929,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -221,8 +221,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 61182,
-    "roughTokens": 15296
+    "chars": 61402,
+    "roughTokens": 15351
   },
   "openClawDeveloperInstructions": {
     "chars": 2702,
@@ -233,8 +233,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6679
   },
   "totalWithDynamicToolsJson": {
-    "chars": 87898,
-    "roughTokens": 21975
+    "chars": 88118,
+    "roughTokens": 22030
   },
   "userInputText": {
     "chars": 929,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -222,8 +222,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 62936,
-    "roughTokens": 15734
+    "chars": 62994,
+    "roughTokens": 15749
   },
   "openClawDeveloperInstructions": {
     "chars": 2702,
@@ -234,8 +234,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6783
   },
   "totalWithDynamicToolsJson": {
-    "chars": 90068,
-    "roughTokens": 22517
+    "chars": 90126,
+    "roughTokens": 22532
   },
   "userInputText": {
     "chars": 1271,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -222,8 +222,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 62716,
-    "roughTokens": 15679
+    "chars": 62936,
+    "roughTokens": 15734
   },
   "openClawDeveloperInstructions": {
     "chars": 2702,
@@ -234,8 +234,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6783
   },
   "totalWithDynamicToolsJson": {
-    "chars": 89848,
-    "roughTokens": 22462
+    "chars": 90068,
+    "roughTokens": 22517
   },
   "userInputText": {
     "chars": 1271,


### PR DESCRIPTION
Closes #118924

## What Problem This Solves

Agents can change their active session model through session_status(model=...), but cannot change the corresponding thinking level through the same tool.

This blocks channel-backed workflows where slash commands are unavailable or unreliable. It also affects non-owner collaborators: they retain the narrow session_status model override, but cannot use the broader owner-only sessions(action="patch") tool added by #107471.

As a result, an agent can select a model for a new phase of work but cannot select a compatible thinking level without human intervention or a channel-specific workaround.

## Why This Change Was Made

This adds an optional thinkingLevel input to session_status and applies it through the same self-session mutation transaction already used for model overrides. Model and thinking can therefore be validated against the prospective effective model and persisted atomically.

The change normalizes existing thinking aliases, validates support against the effective model and runtime—including ACP backend metadata—and rejects invalid combined updates without partially persisting either value. Existing visibility, model-lock, mutation detection, and session patch-hook behavior remain in place.

This does not expose the broader owner-only sessions tool to collaborators or replace sessions.patch; it provides model/thinking parity on the narrower tool surface already available to them.

## User Impact

Agents can now change thinking without relying on /think command handling:
session_status(thinkingLevel="high")
They can also switch model and thinking together:
session_status(
  model="openai/gpt-5.6-sol",
  thinkingLevel="high"
)
Unsupported combinations return a clear error and leave the existing session settings unchanged. Existing read-only and model-only session_status calls behave as before.

## Evidence

Focused tests cover:

• Thinking-only persistence and alias normalization (med → medium).
• Atomic model-plus-thinking updates validated against the new model.
• Rejection of unsupported thinking without partial persistence or hook emission.
• ACP backend-specific thinking capabilities.
• Existing session visibility and mutation classification.
• Backward compatibility for read-only and model-only calls.

Validation results:

• 78/78 focused schema and mutation tests passed.
• 74/74 focused session_status tests passed.
• Branch commits have verified signatures.

Submitter: llunved
Agent: ClawDev
Model: openai/gpt-5.6-sol
Thinking: high