### PR TITLE
fix(macos): sign with any valid certificate when no Apple-class identity is installed

### DIFF
--- a/scripts/check-changed.mts
+++ b/scripts/check-changed.mts
@@ -127,7 +127,7 @@ const ANDROID_VERSION_SYNC_PATHS = new Set([
   "apps/android/version.json",
 ]);
 const MACOS_APP_CI_PATH_RE =
-  /^(?:apps\/(?:macos|macos-mlx-tts|shared|swabble)\/|Swabble\/|src\/(?:shared\/worker-bundle-hash\.ts|worker\/workspace-rsync-receiver\.ts|gateway\/worker-environments\/workspace-(?:accepted-(?:remote-script|sync)|mutation-remote-script|rsync-path\.test|sync(?:-helpers)?)\.ts)$|scripts\/(?:codesign-mac-app|create-dmg|mac-elevation-host|notarize-mac-artifact|package-mac-app|package-mac-dist|stage-cua-driver-macos)\.sh$|scripts\/lib\/(?:plistbuddy|swift-toolchain)\.sh$|test\/scripts\/(?:codesign-mac-app|create-dmg|mac-elevation-host|notarize-mac-artifact|package-mac-app|package-mac-dist)\.test\.ts$)/u;
+  /^(?:apps\/(?:macos|macos-mlx-tts|shared|swabble)\/|Swabble\/|src\/(?:shared\/worker-bundle-hash\.ts|worker\/workspace-rsync-receiver\.ts|gateway\/worker-environments\/workspace-(?:accepted-(?:remote-script|sync)|mutation-remote-script|rsync-path\.test|sync(?:-helpers)?)\.ts)$|scripts\/(?:codesign-mac-app|create-dmg|mac-elevation-host|notarize-mac-artifact|package-mac-app|package-mac-dist|stage-cua-driver-macos)\.sh$|scripts\/lib\/(?:mac-signing-identity|plistbuddy|swift-toolchain)\.sh$|test\/scripts\/(?:codesign-mac-app|create-dmg|mac-elevation-host|notarize-mac-artifact|package-mac-app|package-mac-dist)\.test\.ts$)/u;
 let corepackPnpmShimDir: string | undefined;
 let corepackPnpmShimCleanupRegistered = false;
 let cachedGeneratedExtensionAssetPaths: Set<string> | undefined;

--- a/scripts/ci-changed-scope.mjs
+++ b/scripts/ci-changed-scope.mjs
@@ -46,7 +46,7 @@ const APPLE_SHARED_CONTRACT_FIXTURE_RE =
 const MACOS_NATIVE_RE =
   /^(apps\/macos\/|apps\/macos-mlx-tts\/|apps\/shared\/|apps\/swabble\/|Swabble\/)/;
 const MACOS_SCRIPT_SCOPE_RE =
-  /^(?:scripts\/(?:check-swift-tools|codesign-mac-app|create-dmg|format-swift|install-swift-tools|install-xcodegen|lint-swift|mac-elevation-host|notarize-mac-artifact|package-mac-app|package-mac-dist|stage-cua-driver-macos)\.sh|scripts\/lib\/(?:plistbuddy|swift-toolchain)\.sh|test\/scripts\/(?:codesign-mac-app|create-dmg|mac-elevation-host|notarize-mac-artifact|package-mac-app|package-mac-dist)\.test\.ts)$/;
+  /^(?:scripts\/(?:check-swift-tools|codesign-mac-app|create-dmg|format-swift|install-swift-tools|install-xcodegen|lint-swift|mac-elevation-host|notarize-mac-artifact|package-mac-app|package-mac-dist|stage-cua-driver-macos)\.sh|scripts\/lib\/(?:mac-signing-identity|plistbuddy|swift-toolchain)\.sh|test\/scripts\/(?:codesign-mac-app|create-dmg|mac-elevation-host|notarize-mac-artifact|package-mac-app|package-mac-dist)\.test\.ts)$/;
 const WORKSPACE_RSYNC_RECEIVER_SCOPE_RE =
   /^src\/(?:shared\/worker-bundle-hash\.ts|worker\/workspace-rsync-receiver\.ts|gateway\/worker-environments\/workspace-(?:accepted-(?:remote-script|sync)|mutation-remote-script|rsync-path\.test|sync(?:-helpers)?)\.ts)$/;
 const IOS_BUILD_RE =

--- a/scripts/codesign-mac-app.sh
+++ b/scripts/codesign-mac-app.sh
@@ -75,45 +75,27 @@ if [ ! -d "$APP_BUNDLE" ]; then
   exit 1
 fi
 
+# Auto-selection order is a documented contract (docs/platforms/mac/signing.md): Developer ID
+# Application, Apple Distribution, Apple Development, then any valid codesigning identity. The
+# best rank wins across the whole listing rather than the first line, so ranks are collected in
+# one pass and resolved at END. `security` status is ignored on purpose: selection is judged by
+# the emitted listing, and a non-zero exit alongside usable output must not strand the caller.
 select_identity() {
-  local preferred available first
-
-  # Prefer a Developer ID Application cert.
-  preferred="$(security find-identity -p codesigning -v 2>/dev/null \
-    | awk -F'\"' '/Developer ID Application/ { print $2; exit }')"
-
-  if [ -n "$preferred" ]; then
-    echo "$preferred"
-    return
-  fi
-
-  # Next, try Apple Distribution.
-  preferred="$(security find-identity -p codesigning -v 2>/dev/null \
-    | awk -F'\"' '/Apple Distribution/ { print $2; exit }')"
-  if [ -n "$preferred" ]; then
-    echo "$preferred"
-    return
-  fi
-
-  # Then, try Apple Development.
-  preferred="$(security find-identity -p codesigning -v 2>/dev/null \
-    | awk -F'\"' '/Apple Development/ { print $2; exit }')"
-  if [ -n "$preferred" ]; then
-    echo "$preferred"
-    return
-  fi
-
-  # Fallback to the first valid signing identity.
-  available="$(security find-identity -p codesigning -v 2>/dev/null \
-    | sed -n 's/.*\"\\(.*\\)\"/\\1/p')"
-
-  if [ -n "$available" ]; then
-    first="$(printf '%s\n' "$available" | head -n1)"
-    echo "$first"
-    return
-  fi
-
-  return 1
+  { security find-identity -p codesigning -v 2>/dev/null || true; } | awk -F'"' '
+    NF > 1 && $2 != "" {
+      rank = 4
+      if ($2 ~ /Developer ID Application/) rank = 1
+      else if ($2 ~ /Apple Distribution/) rank = 2
+      else if ($2 ~ /Apple Development/) rank = 3
+      if (!(rank in best)) best[rank] = $2
+    }
+    END {
+      for (rank = 1; rank <= 4; rank++) {
+        if (rank in best) { print best[rank]; exit 0 }
+      }
+      exit 1
+    }
+  '
 }
 
 if [ -z "$IDENTITY" ]; then

--- a/scripts/codesign-mac-app.sh
+++ b/scripts/codesign-mac-app.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "${ROOT_DIR}/scripts/lib/mac-signing-identity.sh"
+
 APP_BUNDLE="dist/OpenClaw.app"
 IDENTITY="${SIGN_IDENTITY:-}"
 SIGNING_VARIANT="${OPENCLAW_MAC_SIGNING_VARIANT:-standard}"
@@ -75,31 +78,8 @@ if [ ! -d "$APP_BUNDLE" ]; then
   exit 1
 fi
 
-# Auto-selection order is a documented contract (docs/platforms/mac/signing.md): Developer ID
-# Application, Apple Distribution, Apple Development, then any valid codesigning identity. The
-# best rank wins across the whole listing rather than the first line, so ranks are collected in
-# one pass and resolved at END. `security` status is ignored on purpose: selection is judged by
-# the emitted listing, and a non-zero exit alongside usable output must not strand the caller.
-select_identity() {
-  { security find-identity -p codesigning -v 2>/dev/null || true; } | awk -F'"' '
-    NF > 1 && $2 != "" {
-      rank = 4
-      if ($2 ~ /Developer ID Application/) rank = 1
-      else if ($2 ~ /Apple Distribution/) rank = 2
-      else if ($2 ~ /Apple Development/) rank = 3
-      if (!(rank in best)) best[rank] = $2
-    }
-    END {
-      for (rank = 1; rank <= 4; rank++) {
-        if (rank in best) { print best[rank]; exit 0 }
-      }
-      exit 1
-    }
-  '
-}
-
 if [ -z "$IDENTITY" ]; then
-  if ! IDENTITY="$(select_identity)"; then
+  if ! IDENTITY="$(select_mac_signing_identity)"; then
     if [[ "${ALLOW_ADHOC_SIGNING:-}" == "1" ]]; then
       echo "WARN: No signing identity found. Falling back to ad-hoc signing (-)." >&2
       echo "      !!! WARNING: Ad-hoc signed apps do NOT persist TCC permissions (Accessibility, etc) !!!" >&2

--- a/scripts/lib/mac-signing-identity.sh
+++ b/scripts/lib/mac-signing-identity.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Single owner of "which Keychain certificate may be picked automatically" for the Mac developer
+# entry points. Both the signer (scripts/codesign-mac-app.sh) and the restart flow's signed-vs-ad-hoc
+# decision (scripts/restart-mac.sh) must judge the same listing the same way: when only one of them
+# accepts a certificate, restart silently ad-hoc-signs a machine that packaging would have signed
+# properly, and ad-hoc signatures drop TCC grants on every rebuild.
+#
+# Selection order is a documented contract (docs/platforms/mac/signing.md): Developer ID Application,
+# Apple Distribution, Apple Development, then any valid codesigning identity. The best rank wins
+# across the whole listing rather than the first line, so ranks are collected in one pass and
+# resolved at END. `security` status is ignored on purpose: selection is judged by the emitted
+# listing, and a non-zero exit alongside usable output must not strand the caller.
+select_mac_signing_identity() {
+  { security find-identity -p codesigning -v 2>/dev/null || true; } | awk -F'"' '
+    NF > 1 && $2 != "" {
+      rank = 4
+      if ($2 ~ /Developer ID Application/) rank = 1
+      else if ($2 ~ /Apple Distribution/) rank = 2
+      else if ($2 ~ /Apple Development/) rank = 3
+      if (!(rank in best)) best[rank] = $2
+    }
+    END {
+      for (rank = 1; rank <= 4; rank++) {
+        if (rank in best) { print best[rank]; exit 0 }
+      }
+      exit 1
+    }
+  '
+}
+
+# Boolean form for callers that only need to know whether automatic signing can proceed. It runs the
+# selection itself so eligibility can never drift from what the signer would actually choose.
+has_mac_signing_identity() {
+  select_mac_signing_identity >/dev/null
+}

--- a/scripts/restart-mac.sh
+++ b/scripts/restart-mac.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "${ROOT_DIR}/scripts/lib/restart-mac-gateway.sh"
+source "${ROOT_DIR}/scripts/lib/mac-signing-identity.sh"
 APP_BUNDLE="${OPENCLAW_APP_BUNDLE:-}"
 APP_EXECUTABLE_RELATIVE_PATH="Contents/MacOS/OpenClaw"
 DEBUG_PROCESS_PATTERN="${ROOT_DIR}/apps/macos/.build/debug/OpenClaw"
@@ -90,9 +91,12 @@ acquire_lock() {
   done
 }
 
+# Signed-vs-ad-hoc must use the exact rule the signer selects with (scripts/lib/
+# mac-signing-identity.sh). A local predicate here would silently route to ad-hoc signing on a
+# machine whose certificate scripts/codesign-mac-app.sh would have accepted, and ad-hoc signatures
+# drop TCC grants on every rebuild.
 check_signing_keys() {
-  security find-identity -p codesigning -v 2>/dev/null \
-    | grep -Eq '(Developer ID Application|Apple Distribution|Apple Development)'
+  has_mac_signing_identity
 }
 
 canonicalize_app_bundle() {

--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -2075,6 +2075,7 @@ const changedScope = "src/scripts/ci-changed-scope.test.ts";
 const changedScopeTests = [
   "src/scripts/ci-changed-scope.contract-fixtures.test.ts",
   "src/scripts/ci-changed-scope.control-ui.test.ts",
+  "src/scripts/ci-changed-scope.macos.test.ts",
   "src/scripts/ci-changed-scope.native-i18n.test.ts",
   changedScope,
   "src/scripts/ci-changed-scope.windows.test.ts",

--- a/src/scripts/ci-changed-scope.macos.test.ts
+++ b/src/scripts/ci-changed-scope.macos.test.ts
@@ -1,0 +1,54 @@
+// macOS CI scope tests cover the Darwin-only packaging scripts, their shared libraries, and their
+// owner tests, which route to the macOS runner rather than the Node lane.
+import { describe, expect, it } from "vitest";
+
+const { detectChangedScope } = await import("../../scripts/ci-changed-scope.mjs");
+
+describe("detectChangedScope macOS routing", () => {
+  it("runs macOS CI for macOS packaging scripts with Darwin-only tests", () => {
+    for (const changedPath of [
+      "scripts/codesign-mac-app.sh",
+      "scripts/create-dmg.sh",
+      "scripts/lib/mac-signing-identity.sh",
+      "scripts/lib/plistbuddy.sh",
+      "scripts/lib/swift-toolchain.sh",
+      "scripts/notarize-mac-artifact.sh",
+      "scripts/package-mac-app.sh",
+      "scripts/package-mac-dist.sh",
+    ]) {
+      expect(detectChangedScope([changedPath])).toEqual({
+        runNode: true,
+        runMacos: true,
+        runIosBuild: false,
+        runAndroid: false,
+        runWindows: false,
+        runSkillsPython: false,
+        runChangedSmoke: false,
+        runControlUiI18n: false,
+        runUiTests: false,
+      });
+    }
+  });
+
+  it("runs macOS CI for Darwin-only mac packaging owner tests", () => {
+    for (const changedPath of [
+      "test/scripts/codesign-mac-app.test.ts",
+      "test/scripts/create-dmg.test.ts",
+      "test/scripts/notarize-mac-artifact.test.ts",
+      "test/scripts/package-mac-app.test.ts",
+      "test/scripts/package-mac-dist.test.ts",
+    ]) {
+      expect(detectChangedScope([changedPath])).toEqual({
+        runNode: true,
+        runMacos: true,
+        runIosBuild: false,
+        runAndroid: false,
+        runWindows: false,
+        runSkillsPython: false,
+        runChangedSmoke: false,
+        runControlUiI18n: false,
+        runUiTests: false,
+      });
+    }
+  });
+});

--- a/src/scripts/ci-changed-scope.test.ts
+++ b/src/scripts/ci-changed-scope.test.ts
@@ -380,52 +380,6 @@ describe("detectChangedScope", () => {
     });
   });
 
-  it("runs macOS CI for macOS packaging scripts with Darwin-only tests", () => {
-    for (const changedPath of [
-      "scripts/codesign-mac-app.sh",
-      "scripts/create-dmg.sh",
-      "scripts/lib/plistbuddy.sh",
-      "scripts/lib/swift-toolchain.sh",
-      "scripts/notarize-mac-artifact.sh",
-      "scripts/package-mac-app.sh",
-      "scripts/package-mac-dist.sh",
-    ]) {
-      expect(detectChangedScope([changedPath])).toEqual({
-        runNode: true,
-        runMacos: true,
-        runIosBuild: false,
-        runAndroid: false,
-        runWindows: false,
-        runSkillsPython: false,
-        runChangedSmoke: false,
-        runControlUiI18n: false,
-        runUiTests: false,
-      });
-    }
-  });
-
-  it("runs macOS CI for Darwin-only mac packaging owner tests", () => {
-    for (const changedPath of [
-      "test/scripts/codesign-mac-app.test.ts",
-      "test/scripts/create-dmg.test.ts",
-      "test/scripts/notarize-mac-artifact.test.ts",
-      "test/scripts/package-mac-app.test.ts",
-      "test/scripts/package-mac-dist.test.ts",
-    ]) {
-      expect(detectChangedScope([changedPath])).toEqual({
-        runNode: true,
-        runMacos: true,
-        runIosBuild: false,
-        runAndroid: false,
-        runWindows: false,
-        runSkillsPython: false,
-        runChangedSmoke: false,
-        runControlUiI18n: false,
-        runUiTests: false,
-      });
-    }
-  });
-
   it("runs Windows only for Windows-relevant changes", () => {
     expect(detectChangedScope(["extensions/memory-lancedb/index.test.ts"])).toEqual({
       runNode: true,
@@ -901,6 +855,7 @@ describe("detectChangedScope", () => {
         "scripts/test-projects.test-support.mts",
         "src/commands/status.scan-result.test.ts",
         "src/scripts/ci-changed-scope.control-ui.test.ts",
+        "src/scripts/ci-changed-scope.macos.test.ts",
         "src/scripts/ci-changed-scope.native-i18n.test.ts",
         "src/scripts/ci-changed-scope.test.ts",
         "src/scripts/ci-changed-scope.windows.test.ts",

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -2091,6 +2091,7 @@ describe("scripts/changed-lanes", () => {
     for (const changedPath of [
       "scripts/codesign-mac-app.sh",
       "scripts/create-dmg.sh",
+      "scripts/lib/mac-signing-identity.sh",
       "scripts/lib/plistbuddy.sh",
       "scripts/lib/swift-toolchain.sh",
       "scripts/mac-elevation-host.sh",

--- a/test/scripts/codesign-mac-app.test.ts
+++ b/test/scripts/codesign-mac-app.test.ts
@@ -44,12 +44,17 @@ if [ -n "\${CODESIGN_ARGS_LOG:-}" ]; then
 fi
 
 entitlements=""
+identity=""
 target=""
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --entitlements)
       shift
       entitlements="$1"
+      ;;
+    --sign)
+      shift
+      identity="$1"
       ;;
   esac
   target="$1"
@@ -71,9 +76,9 @@ if [ -n "$entitlements" ]; then
   printf '%s' "$count" >"$count_file"
   copy="$CODESIGN_CAPTURE_DIR/entitlements-$count.plist"
   cp "$entitlements" "$copy"
-  printf 'entitled\\t%s\\t%s\\t%s\\n' "$target" "$entitlements" "$copy" >>"$CODESIGN_LOG"
+  printf 'entitled\\t%s\\t%s\\t%s\\t%s\\n' "$target" "$entitlements" "$copy" "$identity" >>"$CODESIGN_LOG"
 else
-  printf 'plain\\t%s\\n' "$target" >>"$CODESIGN_LOG"
+  printf 'plain\\t%s\\t%s\\n' "$target" "$identity" >>"$CODESIGN_LOG"
 fi
 `,
   );
@@ -135,6 +140,31 @@ exit 0
 `,
   );
   chmodSync(fakeCodesign, 0o755);
+}
+
+function autoSelectEnv(extra: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env, ...extra };
+  // Auto-selection only runs when the operator pinned nothing, and ad-hoc must stay off so a
+  // failed selection surfaces as an error instead of being masked by the "-" fallback.
+  delete env.SIGN_IDENTITY;
+  delete env.ALLOW_ADHOC_SIGNING;
+  delete env.DISABLE_LIBRARY_VALIDATION;
+  return env;
+}
+
+function installFakeSecurity(binDir: string, listing: string) {
+  const fakeSecurity = path.join(binDir, "security");
+  writeFileSync(
+    fakeSecurity,
+    `#!/usr/bin/env bash
+set -euo pipefail
+
+cat <<'LISTING'
+${listing}
+LISTING
+`,
+  );
+  chmodSync(fakeSecurity, 0o755);
 }
 
 describe("codesign-mac-app temp file hygiene", () => {
@@ -238,7 +268,11 @@ describe("codesign-mac-app temp file hygiene", () => {
 
     const signLines = readFileSync(logPath, "utf8").trim().split("\n");
     expect(signLines).toHaveLength(3);
-    expect(signLines[0]).toBe(`plain\t${path.join(app, "Contents", "MacOS", "openclaw-mlx-tts")}`);
+    // The signing log carries the selected identity as a trailing column, so assert the
+    // kind/target columns instead of the whole line.
+    const plainColumns = expectDefined(signLines[0], "plain codesign log line").split("\t");
+    expect(plainColumns[0]).toBe("plain");
+    expect(plainColumns[1]).toBe(path.join(app, "Contents", "MacOS", "openclaw-mlx-tts"));
     expect(signLines[1]).toContain(
       `entitled\t${path.join(app, "Contents", "MacOS", "OpenClaw")}\t`,
     );
@@ -556,5 +590,90 @@ printf '%s\\n' \\
     for (const args of readFileSync(argsLog, "utf8").trim().split("\n")) {
       expect(args.split(" ")).toContain(expectedFlag);
     }
+  });
+});
+
+describe("codesign-mac-app identity selection", () => {
+  it("falls back to the first valid identity when no Apple-class cert exists", () => {
+    const tempRoot = tempDirs.make("openclaw-codesign-fallback-");
+    const app = path.join(tempRoot, "Fake.app");
+    const binDir = path.join(tempRoot, "bin");
+    const captureDir = path.join(tempRoot, "capture");
+    const logPath = path.join(captureDir, "codesign.log");
+    mkdirSync(path.join(app, "Contents", "MacOS"), { recursive: true });
+    mkdirSync(binDir);
+    mkdirSync(captureDir);
+    writeFileSync(path.join(app, "Contents", "MacOS", "OpenClaw"), "#!/bin/sh\n");
+    installFakeCodesign(binDir);
+    installFakeSecurity(
+      binDir,
+      [
+        '  1) 1A2B3C4D5E6F70819293A4B5C6D7E8F901234567 "Contoso Internal Signing (Z9Q8W7E6R5)"',
+        "     1 valid identities found",
+      ].join("\n"),
+    );
+
+    const result = spawnSync("bash", [scriptPath, app], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: autoSelectEnv({
+        CODESIGN_CAPTURE_DIR: captureDir,
+        CODESIGN_LOG: logPath,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        SKIP_TEAM_ID_CHECK: "1",
+        TMPDIR: tempRoot,
+      }),
+    });
+
+    expect(result.stderr).not.toContain("No signing identity found");
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(
+      "Using signing identity: Contoso Internal Signing (Z9Q8W7E6R5)",
+    );
+
+    // The selected identity must reach `codesign --sign`, not merely be echoed.
+    const signLines = readFileSync(logPath, "utf8").trim().split("\n");
+    expect(signLines.length).toBeGreaterThan(0);
+    for (const line of signLines) {
+      expect(line.split("\t").at(-1)).toBe("Contoso Internal Signing (Z9Q8W7E6R5)");
+    }
+  });
+
+  it("prefers a Developer ID Application cert over lower-ranked identities", () => {
+    const tempRoot = tempDirs.make("openclaw-codesign-preferred-");
+    const app = path.join(tempRoot, "Fake.app");
+    const binDir = path.join(tempRoot, "bin");
+    const captureDir = path.join(tempRoot, "capture");
+    mkdirSync(path.join(app, "Contents", "MacOS"), { recursive: true });
+    mkdirSync(binDir);
+    mkdirSync(captureDir);
+    installFakeCodesign(binDir);
+    // Ranking must win over listing order, so the preferred cert is listed last.
+    installFakeSecurity(
+      binDir,
+      [
+        '  1) 1A2B3C4D5E6F70819293A4B5C6D7E8F901234567 "Contoso Internal Signing (Z9Q8W7E6R5)"',
+        '  2) 2B3C4D5E6F70819293A4B5C6D7E8F9012345678A "Apple Development: Dev Person (T1E2A3M4I5)"',
+        '  3) 3C4D5E6F70819293A4B5C6D7E8F9012345678A2B "Developer ID Application: Contoso (T1E2A3M4I5)"',
+        "     3 valid identities found",
+      ].join("\n"),
+    );
+
+    const result = spawnSync("bash", [scriptPath, app], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: autoSelectEnv({
+        CODESIGN_CAPTURE_DIR: captureDir,
+        CODESIGN_LOG: path.join(captureDir, "codesign.log"),
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        SKIP_TEAM_ID_CHECK: "1",
+        TMPDIR: tempRoot,
+      }),
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(
+      "Using signing identity: Developer ID Application: Contoso (T1E2A3M4I5)",
+    );
   });
 });

--- a/test/scripts/restart-mac.test.ts
+++ b/test/scripts/restart-mac.test.ts
@@ -816,3 +816,79 @@ describe("scripts/restart-mac.sh", () => {
     expect(result.stderr).toBe("");
   });
 });
+
+// The signed-vs-ad-hoc decision and the signer must accept the same certificates. When they drift,
+// restart silently ad-hoc-signs a machine scripts/codesign-mac-app.sh would have signed properly,
+// and ad-hoc signatures drop TCC grants on every rebuild. These drive the real predicate through
+// the real auto-detect block with a fake `security` listing, so a locally reintroduced Apple-only
+// rule here fails the suite.
+function runSigningDetection(listing: string) {
+  const root = mkdtempSync(join(tmpdir(), "openclaw-restart-mac-signing-detect-"));
+  tempRoots.push(root);
+  const binDir = join(root, "bin");
+  mkdirSync(binDir);
+  const securityPath = join(binDir, "security");
+  writeFileSync(securityPath, `#!/usr/bin/env bash\ncat <<'LISTING'\n${listing}\nLISTING\n`);
+  chmodSync(securityPath, 0o755);
+
+  const script = readFileSync(restartScriptPath, "utf8");
+  const predicateBlock = script.slice(
+    script.indexOf("check_signing_keys() {"),
+    script.indexOf("canonicalize_app_bundle()"),
+  );
+  const detectBlock = script.slice(
+    script.indexOf('if [ "$AUTO_DETECT_SIGNING" -eq 1 ]; then'),
+    script.indexOf('if [ "$NO_SIGN" -eq 1 ]; then'),
+  );
+  const harnessPath = join(root, "signing-detect-harness.sh");
+  writeFileSync(
+    harnessPath,
+    [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      `source ${shellQuote(realpathSync("scripts/lib/mac-signing-identity.sh"))}`,
+      "NO_SIGN=0",
+      "SIGN=0",
+      "AUTO_DETECT_SIGNING=1",
+      'log() { printf "%s\\n" "$*"; }',
+      predicateBlock,
+      detectBlock,
+      'printf "sign=%s no_sign=%s\\n" "$SIGN" "$NO_SIGN"',
+    ].join("\n"),
+  );
+  chmodSync(harnessPath, 0o755);
+  return spawnSync("bash", [harnessPath], {
+    encoding: "utf8",
+    env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+  });
+}
+
+describe("restart-mac signing eligibility", () => {
+  it("code signs when only a valid non-Apple-class identity is installed", () => {
+    const result = runSigningDetection(
+      [
+        '  1) 1A2B3C4D5E6F70819293A4B5C6D7E8F901234567 "Contoso Internal Signing (Z9Q8W7E6R5)"',
+        "     1 valid identities found",
+      ].join("\n"),
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Signing keys detected");
+    expect(result.stdout).toContain("sign=1 no_sign=0");
+  });
+
+  it("falls back to ad-hoc signing only when the listing holds no identity at all", () => {
+    const result = runSigningDetection("     0 valid identities found");
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("No signing keys found");
+    expect(result.stdout).toContain("sign=0 no_sign=1");
+  });
+
+  it("delegates eligibility to the shared selection rule instead of a local predicate", () => {
+    const script = readFileSync(restartScriptPath, "utf8");
+
+    expect(script).toContain('source "${ROOT_DIR}/scripts/lib/mac-signing-identity.sh"');
+    expect(script).not.toContain("find-identity");
+  });
+});


### PR DESCRIPTION
Related: #118989 — touches the same script in a different region (timestamp classification); independent defect, no functional overlap.
Related: #119019 — the `scripts/restart-mac.sh` inconsistency this change exposes. **Now fixed here** (see the update at the end); the earlier plan to defer it was wrong.

## What Problem This Solves

Fixes an issue where developers packaging the Mac app on a machine whose keychain holds only codesigning certificates outside Apple's three well-known classes — an enterprise or internal-CA cert, for example — would see `scripts/codesign-mac-app.sh` fail with `ERROR: No signing identity found`, even though `security find-identity -p codesigning -v` listed a perfectly valid certificate.

[macOS signing](https://docs.openclaw.ai/platforms/mac/signing) documents a four-tier auto-selection order and promises the last tier explicitly: "Developer ID Application, Apple Distribution, Apple Development, then the first valid codesigning identity found." The fourth tier never selected anything, so the documented behavior and the shipped behavior disagreed.

The practical cost lands on permissions. An operator hitting this either has to discover `SIGN_IDENTITY` themselves, or reach for `ALLOW_ADHOC_SIGNING=1` — and ad-hoc signing does not persist TCC grants across rebuilds, so notifications, accessibility, and screen-recording permissions silently reset on every rebuild. The script's own warning text says as much.

## Why This Change Was Made

The fallback tier's `sed` script was over-escaped:

```
sed -n 's/.*\"\\(.*\\)\"/\\1/p'
```

Inside single quotes those bytes reach `sed` verbatim, so `\\(` is an escaped backslash followed by a literal `(` — the BRE requires a literal backslash in the input line, and it declares **no capture group at all** (`\\1` is a literal backslash-one, not a backreference). `security find-identity` output never contains a backslash, so the expression matched nothing, `available` was always empty, and `select_identity` returned failure.

Rather than patch the escaping in place, this collapses all four tiers into one `security` invocation plus a single ranked `awk` pass. The three working tiers above it already used the `awk -F'"'` idiom, so this makes the whole function one canonical flow instead of four near-identical pipelines, and removes the bug class rather than the instance. Semantics are preserved exactly: the highest available certificate class still wins across the entire listing, and the first match within a class still wins. The rewrite also stops depending on `security`'s exit status, so usable output alongside a non-zero exit can no longer strand the caller.

~~Deliberately out of scope: the `check_signing_keys` divergence in `scripts/restart-mac.sh`, filed as #119019.~~ **Superseded — it is fixed in this PR.** Deferring it was the wrong call: as the original text itself conceded, that divergence *only becomes real once this PR lands*, so shipping this change while filing its own consequence as someone else's follow-up would knowingly land an inconsistency. See the update below.

## User Impact

Developers with a valid but non-Apple-class signing certificate can now build and sign the Mac app out of the box, with no `SIGN_IDENTITY` export and without falling back to ad-hoc signing — which means their TCC permission grants survive rebuilds. Everyone whose keychain contains a Developer ID Application, Apple Distribution, or Apple Development certificate sees identical behavior to before; those three tiers are unchanged in both order and outcome.

No configuration, flags, or documented behavior change. This brings the code into line with what the docs already promised, so no docs update is needed.

## Evidence

**The dead expression, byte-verified.** `od -c` on lines 79-80 confirms the bytes reaching `sed` are `s/.*\"\\(.*\\)\"/\\1/p`, with the escaped-backslash sequences intact and no capture group.

**Reproduced empirically against a synthetic listing** — the broken idiom emits zero bytes; both candidate fixes emit the identity:

```
$ printf '  1) AAAA...AAAA "Contoso Internal Signing (Z9Q8W7E6R5)"\n' > listing.txt
$ sed -n 's/.*\"\\(.*\\)\"/\\1/p' listing.txt | od -c   # broken: no output at all
0000000
$ awk -F'"' 'NF>1 { print $2; exit }' listing.txt
Contoso Internal Signing (Z9Q8W7E6R5)
```

**RED then GREEN.** The regression test was written and run against the unmodified script first, and failed with the real operator-visible error (`ERROR: No signing identity found. Set SIGN_IDENTITY to a valid codesigning certificate.`) — the RED state comes from production code, not hand-built state. It passes after the fix. A second test pins the ranking by listing a Developer ID cert *last* in the fixture, so a naive first-match rewrite would fail it; that one passed before the change too, as a guard should.

```
node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts \
  test/scripts/codesign-mac-app.test.ts test/scripts/package-mac-app.test.ts
# Test Files 2 passed (2) · Tests 43 passed (43)
```

Both tests drive the real script through `spawnSync` with a fake `security` binary on `PATH`, following the file's existing PATH-shim pattern — no assertions on script text.

**Sibling surfaces checked.** The other two `find-identity` parsers are unaffected and were verified directly, not assumed: `scripts/restart-mac.sh:94` uses `grep -Eq` as a boolean, and `scripts/ios-team-id.sh:202` greps `(TEAMID)`. Neither extracts quoted names, so this defect was single-site.

**Other gates.** `tsgo -p test/tsconfig/tsconfig.test.root.json` exits 0; `oxlint` and `oxfmt --check` clean on the touched test; `bash -n` clean on the script; `git diff --check` clean; `changed-lanes` 148/148.

**Size.** Production LOC is net **−18** (20 added, 38 removed in `scripts/codesign-mac-app.sh`); the remaining additions are tests.


---

### Update — eligibility unified (P1), and real-signing proof with one disclosed shim

**P1 — both Mac entry points now share one eligibility rule.** They each parsed the same `security find-identity -p codesigning -v` listing with their own predicate, which is how they came to disagree about the same certificate. The rule now lives in one file, `scripts/lib/mac-signing-identity.sh`:

- `select_mac_signing_identity()` — the documented four-tier ranking (moved, not rewritten)
- `has_mac_signing_identity()` — the boolean form, which **runs that same selection**, so eligibility cannot drift from what the signer would actually pick

`codesign-mac-app.sh` sources it and calls `select_…`; in `restart-mac.sh`, `check_signing_keys` is now just `has_mac_signing_identity`. Neither script parses `find-identity` for eligibility any more, so choosing a signing policy is one edit in one file that lands on both paths at once.

**This reverses the earlier decision to defer #119019, and that reversal is the point.** The original body conceded that the divergence "only becomes a real divergence once this PR lands" — which is precisely why it could not be someone else's follow-up. Landing a change that knowingly creates an inconsistency and filing the inconsistency separately is how a default-path regression ships. Note the policy question is *not* settled by this: the two paths now agree, but **which** tier set they agree on is the open trust-boundary decision below.

Regression coverage in `test/scripts/restart-mac.test.ts`, verified RED against the pre-fix predicate:

```
× code signs when only a valid non-Apple-class identity is installed
× delegates eligibility to the shared selection rule instead of a local predicate
  Tests  2 failed | 34 passed (36)
```

GREEN after: 36 passed. The negative control (no identities → ad-hoc) passes both before and after, as it should.

**Proof — real cert, real codesign, one shimmed verdict, stated plainly.** I built a throwaway keychain holding a genuine self-signed code-signing certificate. It does **not** fully close the ask, for a reason worth recording: macOS reports a self-signed cert as `CSSMERR_TP_NOT_TRUSTED`, so `find-identity -v` lists zero valid identities until the cert is added to a trust store — a security-settings change I declined to make on this machine:

```
1) <SHA1-REDACTED> "OpenClaw Proof Internal Signing" (CSSMERR_TP_NOT_TRUSTED)
   1 identities found
   0 valid identities found
```

So exactly one thing is shimmed — the trust verdict. Every other call delegates to real `/usr/bin/security`. Against the final committed code, with a real certificate, real `codesign`, and a real `.app`:

```
BEFORE (merge-base main)
  ERROR: No signing identity found. Set SIGN_IDENTITY to a valid codesigning certificate.
  --- script exit: 1 ---
  CodeDirectory flags=0x20002(adhoc,linker-signed)   Signature=adhoc
  restart-mac.sh: ==> No signing keys found, will skip code signing (--no-sign)   SIGN=0 NO_SIGN=1

AFTER (this branch)
  Using signing identity: OpenClaw Proof Internal Signing
  Codesign complete
  --- script exit: 0 ---
  CodeDirectory flags=0x10000(runtime)
  Authority=OpenClaw Proof Internal Signing    TeamIdentifier=not set
  restart-mac.sh: ==> Signing keys detected, will code sign   SIGN=1 NO_SIGN=0
```

The BEFORE signer row combined with the BEFORE restart row is exactly the P1 divergence state this PR removes.

**Remaining proof gap, unglossed:** fully unshimmed evidence needs a machine that already trusts a non-Apple code-signing CA. This one has none, so the `-v` trust verdict could not be produced honestly without altering the system trust store. Everything downstream of that verdict is real. Cleanup verified: keychain deleted, search list restored to its single original entry, and `security dump-trust-settings` reports `No Trust Settings were found` — it was never modified.

**Still needs a maintainer decision (not mine to make).** Whether automatic signing should accept every identity `find-identity -v` returns, or only Apple-class ones. Two findings that bear on it, both verified rather than assumed: policy A can only ever select a certificate the machine *already trusts*; and under policy B the restart path's `NO_SIGN=1` branch does `export SIGN_IDENTITY="-"`, which overwrites an operator's own exported value — so "just set `SIGN_IDENTITY`" does not rescue that path. Happy to implement either once chosen; the unification above means it is now a one-file change.

**Gate.** Touched tooling and core-scope suites pass (300+) · `oxfmt --check` clean · `oxlint --tsconfig oxlint.core.json` exit 0 · `pnpm tsgo:core` exit 0 · max-lines ratchet OK · `git diff --check` clean · `bash -n` clean on all three scripts (no shellcheck lane exists for these). `codex review --base origin/main` clean on both passes. Production LOC for the whole PR: **+48/−46, net +2** — the +2 is the shared file's header comment.

One unrelated pre-existing issue noted in passing: `test/scripts/mac-elevation-host.test.ts` stalls locally past the runner's no-output guard. It stalls identically on the pre-change tree, so it is not from this PR; CI covers it.

🤖 AI-assisted (Claude Code): investigation, fix, and proof prepared with an AI agent; a human reviews and owns the result.
