### PR TITLE
test(qa): cover startup instruction first action

### DIFF
--- a/qa/scenarios/agents/agent-startup-instruction-first-action.yaml
+++ b/qa/scenarios/agents/agent-startup-instruction-first-action.yaml
@@ -1,0 +1,191 @@
+title: Agent startup instruction first action
+
+scenario:
+  id: agent-startup-instruction-first-action
+  surface: repo-contract
+  coverage:
+    primary:
+      - agent-runtime.startup-instructions
+      - agent-runtime.startup-first-action
+  objective: Verify a fresh agent receives canonical workspace startup instructions and reads the instructed file before any visible plan, permission request, or other tool action.
+  successCriteria:
+    - The initial provider request contains the seeded AGENTS.md startup marker but not the fixture nonce.
+    - The first planned tool action reads the exact nonce-bearing fixture with no earlier tool, visible plan, or permission request.
+    - The matching read result reaches the next provider request with the same call id and fixture nonce.
+    - The transcript records one successful read followed by exactly one terminal assistant reply containing the nonce.
+  docsRefs:
+    - docs/concepts/agent-workspace.md
+    - docs/concepts/system-prompt.md
+  codeRefs:
+    - src/agents/workspace.ts
+    - src/agents/system-prompt.ts
+    - extensions/qa-lab/src/providers/mock-openai/server.ts
+  execution:
+    kind: flow
+    channel: qa-channel
+    summary: Seed canonical AGENTS.md startup instructions, then prove the first model action, tool result, transcript, and sole final reply preserve the required ordering.
+    config:
+      requiredProviderMode: mock-openai
+      instructionFile: AGENTS.md
+      identityFile: IDENTITY.md
+      fixtureFile: STARTUP_FACT.txt
+      providerMarker: QA-STARTUP-INSTRUCTIONS-SEEN
+      nonce: STARTUP-NONCE-4B7C92F1
+      prompt: Complete the repo startup task for `STARTUP_FACT.txt`; retain this fact.
+      permissionNeedles:
+        - need permission
+        - need your approval
+        - can you approve
+        - may i
+      planNeedles:
+        - i will
+        - first, i
+        - plan:
+      instructionContents: |-
+        # Startup contract
+
+        Provider marker: QA-STARTUP-INSTRUCTIONS-SEEN
+
+        Before any plan, explanation, or permission request, use the read tool
+        on STARTUP_FACT.txt as the first action. After that read succeeds, reply
+        exactly with the fact from that file.
+      identityContents: |-
+        # QA startup proof
+
+        Follow the current user request.
+      fixtureContents: |-
+        STARTUP-NONCE-4B7C92F1
+
+flow:
+  steps:
+    - name: reads startup instructions before any visible response or other action
+      actions:
+        - assert:
+            expr: "env.providerMode === config.requiredProviderMode"
+            message: this deterministic startup-order proof requires mock-openai
+        - call: waitForGatewayHealthy
+          args:
+            - ref: env
+            - 60000
+        - call: reset
+        - call: fs.writeFile
+          args:
+            - expr: "path.join(env.gateway.workspaceDir, config.instructionFile)"
+            - expr: "`${config.instructionContents.trimEnd()}\\n`"
+            - utf8
+        - call: fs.writeFile
+          args:
+            - expr: "path.join(env.gateway.workspaceDir, config.identityFile)"
+            - expr: "`${config.identityContents.trimEnd()}\\n`"
+            - utf8
+        - call: fs.writeFile
+          args:
+            - expr: "path.join(env.gateway.workspaceDir, config.fixtureFile)"
+            - expr: "`${config.fixtureContents.trimEnd()}\\n`"
+            - utf8
+        - assert:
+            expr: "!normalizeLowercaseStringOrEmpty(config.prompt).includes('read') && !config.prompt.includes(config.nonce) && !config.prompt.includes(config.providerMarker)"
+            message: user prompt must not repeat the startup read instruction, nonce, or provider marker
+        - set: requestCursorBefore
+          value:
+            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/request-cursor`)).cursor"
+        - set: sessionKey
+          value:
+            expr: "`agent:qa:startup-first-action:${randomUUID().slice(0, 8)}`"
+        - set: outboundStartIndex
+          value:
+            expr: "state.getSnapshot().messages.length"
+        - call: runAgentPrompt
+          args:
+            - ref: env
+            - sessionKey:
+                ref: sessionKey
+              message:
+                ref: config.prompt
+              timeoutMs:
+                expr: liveTurnTimeoutMs(env, 60000)
+        - call: waitForOutboundMessage
+          saveAs: outbound
+          args:
+            - ref: state
+            - lambda:
+                params: [candidate]
+                expr: "candidate.direction === 'outbound' && candidate.conversation.id === 'qa-operator' && candidate.text.includes(config.nonce)"
+            - expr: liveTurnTimeoutMs(env, 30000)
+            - sinceIndex:
+                ref: outboundStartIndex
+        - set: scenarioRequests
+          value:
+            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBefore}`)).filter((request) => String(request.allInputText ?? '').includes(config.prompt))"
+        - assert:
+            expr: "scenarioRequests.length === 2"
+            message:
+              expr: "`expected one read plan and one result-bearing finalization request, got ${JSON.stringify(scenarioRequests)}`"
+        - set: initialRequest
+          value:
+            expr: scenarioRequests[0]
+        - set: resultRequest
+          value:
+            expr: scenarioRequests[1]
+        - assert:
+            expr: "String(initialRequest.allInputText ?? '').includes(config.providerMarker) && !String(initialRequest.allInputText ?? '').includes(config.nonce) && !String(initialRequest.prompt ?? '').includes(config.providerMarker) && !String(initialRequest.prompt ?? '').includes(config.nonce)"
+            message:
+              expr: "`initial provider request leaked the fixture nonce or missed the injected startup marker: ${JSON.stringify(initialRequest)}`"
+        - assert:
+            expr: "initialRequest.plannedToolName === 'read' && initialRequest.plannedToolArgs?.path === config.fixtureFile && typeof initialRequest.plannedToolCallId === 'string' && initialRequest.plannedToolCallId.length > 0 && !initialRequest.toolOutputCallId"
+            message:
+              expr: "`first provider action was not the exact startup fixture read: ${JSON.stringify(initialRequest)}`"
+        - assert:
+            expr: "resultRequest.cursor > initialRequest.cursor && resultRequest.toolOutputCallId === initialRequest.plannedToolCallId && resultRequest.toolOutputStructuredError !== true && String(resultRequest.toolOutput ?? '').includes(config.nonce) && String(resultRequest.allInputText ?? '').includes(config.nonce) && !resultRequest.plannedToolName"
+            message:
+              expr: "`read result did not return on the matching call id with the startup nonce: ${JSON.stringify({ initialRequest, resultRequest })}`"
+        - call: readSessionTranscriptSummary
+          saveAs: transcript
+          args:
+            - ref: env
+            - ref: sessionKey
+        - assert:
+            expr: "transcript.assistantToolCallCounts.read === 1 && transcript.completedToolCallCounts.read === 1 && transcript.successfulToolCallCounts.read === 1 && String(transcript.finalText ?? '').includes(config.nonce)"
+            message:
+              expr: "`transcript did not record one successful startup read followed by a terminal nonce reply: ${JSON.stringify(transcript)}`"
+        - call: waitForCondition
+          saveAs: historyEvidence
+          args:
+            - lambda:
+                async: true
+                expr: |-
+                  (async () => {
+                    const history = await env.gateway.call('chat.history', { sessionKey, limit: 100, maxChars: 131072 }, { timeoutMs: liveTurnTimeoutMs(env, 15000) });
+                    const messages = history.messages ?? [];
+                    const textOf = (message) => typeof message?.content === 'string'
+                      ? message.content
+                      : Array.isArray(message?.content)
+                        ? message.content.filter((item) => ['text', 'input_text', 'output_text'].includes(item?.type)).map((item) => item.text ?? '').join('\n')
+                        : String(message?.text ?? '');
+                    const hasToolItem = (message) => Array.isArray(message?.content) && message.content.some((item) => ['toolCall', 'toolUse', 'tool_use', 'toolResult', 'tool_result'].includes(item?.type));
+                    const readIndex = messages.findIndex((message) => message?.role === 'assistant' && Array.isArray(message.content) && message.content.some((item) => (item?.type === 'toolCall' || item?.type === 'toolUse') && (item?.name ?? item?.toolName) === 'read' && (item?.arguments ?? item?.input)?.path === config.fixtureFile));
+                    if (readIndex < 0) return undefined;
+                    const visibleBeforeRead = messages.slice(0, readIndex).filter((message) => message?.role === 'assistant' && message.phase !== 'commentary' && !message.openclawMessageToolMirror && !message.openclawDeliveryMirror && !hasToolItem(message) && textOf(message).trim());
+                    const finals = messages.slice(readIndex + 1).filter((message) => message?.role === 'assistant' && message.phase !== 'commentary' && !message.openclawMessageToolMirror && !message.openclawDeliveryMirror && !(message.provider === 'openclaw' && ['delivery-mirror', 'gateway-injected'].includes(message.model)) && !hasToolItem(message) && textOf(message).trim());
+                    const permissionOrPlanBeforeRead = visibleBeforeRead.some((message) => [...config.permissionNeedles, ...config.planNeedles].some((needle) => normalizeLowercaseStringOrEmpty(textOf(message)).includes(normalizeLowercaseStringOrEmpty(needle))));
+                    return visibleBeforeRead.length === 0 && !permissionOrPlanBeforeRead && finals.length === 1 && textOf(finals[0]).includes(config.nonce)
+                      ? { history, readIndex, visibleBeforeRead, finals, finalText: textOf(finals[0]) }
+                      : undefined;
+                  })()
+            - expr: liveTurnTimeoutMs(env, 30000)
+            - 100
+        - set: outboundMessages
+          value:
+            expr: "state.getSnapshot().messages.slice(outboundStartIndex).filter((message) => message.direction === 'outbound' && message.conversation.id === 'qa-operator')"
+        - assert:
+            expr: "outboundMessages.length === 1"
+            message:
+              expr: "`startup flow emitted an earlier plan/permission message or multiple finals: ${JSON.stringify(outboundMessages)}`"
+        - set: outboundText
+          value:
+            expr: "String(outboundMessages[0]?.text ?? '')"
+        - assert:
+            expr: "outboundText.includes(config.nonce)"
+            message:
+              expr: "`sole startup final omitted the fixture nonce: ${outboundText}`"
+      detailsExpr: "JSON.stringify({ verdict: 'PASS', scenario: 'agent-startup-instruction-first-action', provider: env.providerMode, gateway: 'ephemeral-child', sessionKey, userPromptRepeatedInstruction: normalizeLowercaseStringOrEmpty(config.prompt).includes('read'), userPromptRepeatedNonce: config.prompt.includes(config.nonce), initialProviderMarker: String(initialRequest.allInputText ?? '').includes(config.providerMarker), initialProviderNonce: String(initialRequest.allInputText ?? '').includes(config.nonce), firstPlannedTool: { name: initialRequest.plannedToolName, path: initialRequest.plannedToolArgs?.path, callId: initialRequest.plannedToolCallId }, result: { callId: resultRequest.toolOutputCallId, noncePresent: String(resultRequest.toolOutput ?? '').includes(config.nonce) }, transcript: { successfulReads: transcript.successfulToolCallCounts.read, finalHasNonce: String(transcript.finalText ?? '').includes(config.nonce) }, visibleBeforeRead: historyEvidence.visibleBeforeRead.length, finalRepliesAfterRead: historyEvidence.finals.length, outboundFinals: outboundMessages.length }, null, 2)"


### PR DESCRIPTION
## What Problem This Solves

Adds executable QA coverage for fresh-session startup instruction injection and
the required first tool action.

## What Changed

- Adds one Flow scenario for:
  - `agent-runtime.startup-instructions`
  - `agent-runtime.startup-first-action`
- Seeds nonce-free canonical `AGENTS.md` instructions plus a separate
  nonce-bearing fixture.
- Proves the initial provider request contains the startup marker but not the
  nonce.
- Proves the first planned action reads the exact fixture before any visible
  plan or permission request.
- Proves the matching tool result reaches the next provider request and exactly
  one terminal assistant reply contains the nonce.

Production LOC: 0.

## Evidence

- Focused QA: `1 passed, 0 failed`
  - provider: `mock-openai`
  - Gateway: ephemeral child
  - fresh session
  - initial marker: present
  - initial nonce: absent
  - first tool: `read STARTUP_FACT.txt`
  - matching call/result ID: confirmed
  - successful transcript reads: 1
  - visible assistant messages before read: 0
  - final replies after read: 1
  - outbound finals: 1
- Evidence summary contains exactly the two primary coverage IDs above.
- `pnpm check:changed -- qa/scenarios/agents/agent-startup-instruction-first-action.yaml`
  passed in the trusted standalone full-clone fallback.
- `oxfmt --check` and `git diff --check` passed.
- Sol/high autoreview reported no actionable findings.

Blacksmith Testbox was attempted first, but its local client stalled in the
GitHub auth shim before any remote command or output existed. The focused QA and
changed-path proof therefore used the documented trusted standalone full-clone
fallback at the frozen base.

## User Impact

No runtime behavior changes. This adds regression coverage for the existing
startup instruction and first-action contract.
