### PR TITLE
test(qa): cover agent session reconnect dedupe

### DIFF
--- a/qa/scenarios/agents/session-dedup-reconnect.yaml
+++ b/qa/scenarios/agents/session-dedup-reconnect.yaml
@@ -1,0 +1,27 @@
+title: Agent session deduplication across reconnect
+
+scenario:
+  id: session-dedup-reconnect
+  surface: agent-runtime
+  category: agent-runtime.agent-turn-execution
+  coverage:
+    primary:
+      - agent-runtime.session-dedup
+      - agent-runtime.session-reconnect
+  objective: Verify a disconnected agent RPC can be replayed from a new authenticated client without rerunning the embedded agent turn.
+  successCriteria:
+    - Client A starts one fixed-session agent RPC, observes acceptance, and disconnects while the deterministic provider response is paused.
+    - Client B reconnects and repeats the same idempotency key, receiving the same in-flight run identity.
+    - The provider is invoked once, agent.wait resolves the canonical terminal result, and a changed-message replay returns that cached result.
+    - The session transcript contains exactly one user turn and one terminal assistant turn.
+  docsRefs:
+    - docs/gateway/protocol.md
+    - docs/help/testing.md
+  codeRefs:
+    - src/gateway/server-methods/agent-dedupe.ts
+    - src/gateway/server-methods/agent-wait.ts
+    - test/e2e/qa-lab/runtime/agent-session-dedup-reconnect.e2e.test.ts
+  execution:
+    kind: vitest
+    path: test/e2e/qa-lab/runtime/agent-session-dedup-reconnect.e2e.test.ts
+    summary: Run one real child Gateway and gated mock provider while two authenticated clients reconnect and replay one embedded agent turn.

--- a/test/e2e/qa-lab/runtime/agent-session-dedup-reconnect.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/agent-session-dedup-reconnect.e2e.test.ts
@@ -1,0 +1,321 @@
+import { createServer, type ServerResponse } from "node:http";
+import { GatewayClient } from "openclaw/plugin-sdk/gateway-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { startQaGatewayChild } from "../../../../extensions/qa-lab/api.js";
+import {
+  GATEWAY_CLIENT_MODES,
+  GATEWAY_CLIENT_NAMES,
+} from "../../../../packages/gateway-protocol/src/client-info.js";
+
+const TEST_TIMEOUT_MS = 120_000;
+const REQUEST_TIMEOUT_MS = 20_000;
+const MODEL_REF = "mock-openai/gpt-5.6-luna";
+const SESSION_KEY = "agent:qa:qa:session-dedup-reconnect";
+const IDEMPOTENCY_KEY = "qa-session-dedup-reconnect";
+const ORIGINAL_MESSAGE = "Return exactly SESSION-DEDUP-RECONNECT-OK.";
+const CHANGED_MESSAGE = "This changed replay must not create another turn.";
+const TERMINAL_TEXT = "SESSION-DEDUP-RECONNECT-OK";
+
+type GatewayHandle = Awaited<ReturnType<typeof startQaGatewayChild>>;
+type AgentResult = {
+  runId?: string;
+  status?: string;
+  result?: {
+    payloads?: Array<{ text?: string }>;
+  };
+};
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  const errors: unknown[] = [];
+  for (const cleanup of cleanups.splice(0).toReversed()) {
+    try {
+      await cleanup();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  if (errors.length === 1) {
+    throw errors[0];
+  }
+  if (errors.length > 1) {
+    throw new AggregateError(errors, "session dedup reconnect cleanup failed");
+  }
+});
+
+function writeResponsesEvents(response: ServerResponse, events: unknown[]): void {
+  response.writeHead(200, {
+    "content-type": "text/event-stream",
+    "cache-control": "no-store",
+    connection: "keep-alive",
+  });
+  response.end(
+    `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`,
+  );
+}
+
+function writeAssistantResponse(response: ServerResponse): void {
+  const message = {
+    type: "message",
+    id: "qa-session-dedup-message",
+    role: "assistant",
+    status: "completed",
+    content: [{ type: "output_text", text: TERMINAL_TEXT, annotations: [] }],
+  };
+  writeResponsesEvents(response, [
+    {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { ...message, status: "in_progress", content: [] },
+    },
+    { type: "response.output_item.done", output_index: 0, item: message },
+    {
+      type: "response.completed",
+      response: {
+        id: "qa-session-dedup-response",
+        status: "completed",
+        output: [message],
+        usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+      },
+    },
+  ]);
+}
+
+async function startControlledProvider() {
+  let releaseResponse: (() => void) | undefined;
+  const responseGate = new Promise<void>((resolve) => {
+    releaseResponse = resolve;
+  });
+  const requests: Array<Record<string, unknown>> = [];
+  const server = createServer((request, response) => {
+    void (async () => {
+      if (request.method === "GET" && request.url === "/v1/models") {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(
+          JSON.stringify({
+            data: [{ id: "gpt-5.6-luna", object: "model" }],
+          }),
+        );
+        return;
+      }
+      if (request.method !== "POST" || request.url !== "/v1/responses") {
+        response.writeHead(404).end();
+        return;
+      }
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+      requests.push(JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>);
+      await responseGate;
+      writeAssistantResponse(response);
+    })().catch((error: unknown) => {
+      response.writeHead(500).end(error instanceof Error ? error.message : String(error));
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("controlled provider did not bind a loopback port");
+  }
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    requests,
+    release: () => releaseResponse?.(),
+    stop: async () => {
+      releaseResponse?.();
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    },
+  };
+}
+
+async function connectOperator(
+  gateway: GatewayHandle,
+  displayName: string,
+): Promise<GatewayClient> {
+  return await new Promise<GatewayClient>((resolve, reject) => {
+    let settled = false;
+    let timeout: ReturnType<typeof setTimeout>;
+    const finish = (error?: Error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      if (error) {
+        client.stop();
+        reject(error);
+        return;
+      }
+      resolve(client);
+    };
+    const client = new GatewayClient({
+      url: gateway.wsUrl,
+      token: gateway.token,
+      env: gateway.runtimeEnv,
+      role: "operator",
+      clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+      clientDisplayName: displayName,
+      clientVersion: "1.0.0",
+      platform: process.platform,
+      mode: GATEWAY_CLIENT_MODES.BACKEND,
+      scopes: ["operator.admin", "operator.read", "operator.write"],
+      deviceIdentity: null,
+      requestTimeoutMs: REQUEST_TIMEOUT_MS,
+      onHelloOk: () => finish(),
+      onConnectError: (error) => finish(error),
+      onClose: (code, reason) => finish(new Error(`Gateway closed (${code}): ${reason}`)),
+    });
+    timeout = setTimeout(
+      () => finish(new Error(`Gateway client connection timed out:\n${gateway.logs()}`)),
+      REQUEST_TIMEOUT_MS,
+    );
+    timeout.unref();
+    client.start();
+  });
+}
+
+function messageRole(message: unknown): string | undefined {
+  return message && typeof message === "object"
+    ? String((message as { role?: unknown }).role ?? "")
+    : undefined;
+}
+
+function messageText(message: unknown): string {
+  if (!message || typeof message !== "object") {
+    return "";
+  }
+  const content = (message as { content?: unknown }).content;
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content
+    .flatMap((part) =>
+      part && typeof part === "object" && typeof (part as { text?: unknown }).text === "string"
+        ? [(part as { text: string }).text]
+        : [],
+    )
+    .join("\n");
+}
+
+describe("agent session deduplication across reconnect", () => {
+  it(
+    "replays one accepted run and one terminal transcript without a second provider call",
+    { timeout: TEST_TIMEOUT_MS },
+    async () => {
+      const provider = await startControlledProvider();
+      cleanups.push(() => provider.stop());
+      const gateway = await startQaGatewayChild({
+        repoRoot: process.cwd(),
+        command: {
+          executablePath: process.execPath,
+          argsPrefix: ["--import", "tsx", "src/entry.ts"],
+          cwd: process.cwd(),
+          usePackagedPlugins: true,
+        },
+        providerBaseUrl: `${provider.baseUrl}/v1`,
+        providerMode: "mock-openai",
+        primaryModel: MODEL_REF,
+        alternateModel: MODEL_REF,
+        transportBaseUrl: "http://127.0.0.1",
+        controlUiEnabled: false,
+        fastMode: true,
+        runtimeEnvPatch: {
+          OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+          OPENCLAW_SKIP_CHANNELS: "1",
+          OPENCLAW_TEST_MINIMAL_GATEWAY: "1",
+        },
+        mutateConfig: ({ plugins: _plugins, ...config }) => config,
+      });
+      cleanups.push(() => gateway.stop());
+
+      const clientA = await connectOperator(gateway, "Session dedup client A");
+      const acceptedA = await clientA.request<AgentResult>("agent", {
+        sessionKey: SESSION_KEY,
+        message: ORIGINAL_MESSAGE,
+        deliver: false,
+        idempotencyKey: IDEMPOTENCY_KEY,
+      });
+      expect(acceptedA).toMatchObject({
+        status: "accepted",
+        runId: IDEMPOTENCY_KEY,
+      });
+      await vi.waitFor(() => expect(provider.requests).toHaveLength(1), {
+        interval: 20,
+        timeout: REQUEST_TIMEOUT_MS,
+      });
+      await clientA.stopAndWait({ timeoutMs: 1_000 });
+
+      const clientB = await connectOperator(gateway, "Session dedup client B");
+      cleanups.push(() => clientB.stopAndWait({ timeoutMs: 1_000 }));
+      const acceptedB = await clientB.request<AgentResult>("agent", {
+        sessionKey: SESSION_KEY,
+        message: ORIGINAL_MESSAGE,
+        deliver: false,
+        idempotencyKey: IDEMPOTENCY_KEY,
+      });
+      expect(acceptedB).toMatchObject({
+        status: "in_flight",
+        runId: acceptedA.runId,
+        sessionKey: SESSION_KEY,
+      });
+      expect(provider.requests).toHaveLength(1);
+
+      provider.release();
+      const terminal = await clientB.request<AgentResult>(
+        "agent.wait",
+        { runId: IDEMPOTENCY_KEY, timeoutMs: 30_000 },
+        { timeoutMs: 35_000 },
+      );
+      expect(terminal).toMatchObject({
+        status: "ok",
+        runId: IDEMPOTENCY_KEY,
+      });
+
+      const cachedTerminal = await clientB.request<AgentResult>("agent", {
+        sessionKey: SESSION_KEY,
+        message: ORIGINAL_MESSAGE,
+        deliver: false,
+        idempotencyKey: IDEMPOTENCY_KEY,
+      });
+      expect(cachedTerminal).toMatchObject({
+        status: terminal.status,
+        runId: terminal.runId,
+        result: {
+          payloads: [{ text: TERMINAL_TEXT }],
+        },
+      });
+      const changedReplay = await clientB.request<AgentResult>("agent", {
+        sessionKey: SESSION_KEY,
+        message: CHANGED_MESSAGE,
+        deliver: false,
+        idempotencyKey: IDEMPOTENCY_KEY,
+      });
+      expect(changedReplay).toEqual(cachedTerminal);
+      expect(provider.requests).toHaveLength(1);
+
+      const history = await clientB.request<{ messages?: unknown[] }>("chat.history", {
+        sessionKey: SESSION_KEY,
+        limit: 20,
+      });
+      const turns = (history.messages ?? []).filter((message) =>
+        ["user", "assistant"].includes(messageRole(message) ?? ""),
+      );
+      expect(turns.map(messageRole)).toEqual(["user", "assistant"]);
+      expect(messageText(turns[0])).toContain(ORIGINAL_MESSAGE);
+      expect(messageText(turns[0])).not.toContain(CHANGED_MESSAGE);
+      expect(messageText(turns[1])).toContain(TERMINAL_TEXT);
+      expect(JSON.stringify(provider.requests[0])).toContain(ORIGINAL_MESSAGE);
+      expect(JSON.stringify(provider.requests[0])).not.toContain(CHANGED_MESSAGE);
+    },
+  );
+});


### PR DESCRIPTION
## What Problem This Solves

The Gateway's agent idempotency contract had unit coverage built around a mocked
`agentCommand`, but no product-boundary proof that a real embedded turn survives
client disconnect and reconnect without duplicated model work or transcript rows.

## Why This Change Was Made

Add one QA Lab scenario and one focused E2E test. The test starts a real child
Gateway and a gated loopback OpenAI Responses provider, then:

- starts a fixed-session agent RPC from client A and disconnects after acceptance;
- reconnects as client B and replays the same idempotency key while the provider is paused;
- releases the single provider response and resolves the run through `agent.wait`;
- replays changed message text under the same key and verifies cached terminal truth;
- verifies exactly one user turn and one terminal assistant turn.

No production or QA-internal code changes.

## User Impact

This locks in the reconnect contract operators depend on: retrying an accepted
agent request after transport loss does not run the model twice, append duplicate
turns, or let changed replay text overwrite the original request.

## Evidence

- `node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/agent-session-dedup-reconnect.e2e.test.ts`
  - pass on rebased head `11acb412b3dfddcbae35872add068290e3086f24`: 1 file, 1 test
- QA coverage match:
  - scenario: `session-dedup-reconnect`
  - execution: `vitest`
  - primary IDs: `agent-runtime.session-dedup`, `agent-runtime.session-reconnect`
- Direct Codex `gpt-5.6-sol` / high autoreview:
  - clean, no accepted or actionable findings
  - patch correct, confidence 0.99
- Production LOC: +0
- QA LOC: +348 across exactly two new files

The path-scoped changed gate is running on Blacksmith Testbox; this PR will be
updated with its final result before merge.
