### PR TITLE
fix(gateway): honor external status target context

### DIFF
--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -593,8 +593,11 @@ describe("gatherDaemonStatus", () => {
   });
 
   it("does not force local TLS fingerprint when probe URL is explicitly overridden", async () => {
-    setTestEnvValue("OPENCLAW_GATEWAY_PORT", "18900");
-    isDefaultInstallIdentity.mockReturnValue(false);
+    callGatewayStatusProbe.mockResolvedValueOnce({
+      ok: false,
+      url: "wss://override.example:18790",
+      error: "connect ECONNREFUSED override.example:18790",
+    });
 
     const status = await gatherDaemonStatus({
       rpc: { url: "wss://override.example:18790" },
@@ -613,6 +616,8 @@ describe("gatherDaemonStatus", () => {
     expect(status.rpc?.url).toBe("wss://override.example:18790");
     expect(loadInstalledPluginIndexInstallRecords).not.toHaveBeenCalled();
     expect(status.pluginVersionDrift).toBeUndefined();
+    expect(status.service.targetRole).toBe("diagnostic-only");
+    expect(inspectGatewayRestart).not.toHaveBeenCalled();
   });
 
   it("keeps the standalone gateway default when no native service target exists", async () => {
@@ -628,6 +633,7 @@ describe("gatherDaemonStatus", () => {
 
     expect(status.gateway?.probeUrl).toBe("ws://127.0.0.1:18789");
     expect((callArg(callGatewayStatusProbe) as { url?: string }).url).toBe("ws://127.0.0.1:18789");
+    expect(status.service.targetRole).toBe("target");
   });
 
   it.each([
@@ -650,6 +656,11 @@ describe("gatherDaemonStatus", () => {
       resolveGatewayPort.mockImplementation((_cfg?: unknown, env?: unknown) =>
         Number((env as NodeJS.ProcessEnv | undefined)?.OPENCLAW_GATEWAY_PORT ?? 18789),
       );
+      callGatewayStatusProbe.mockResolvedValueOnce({
+        ok: false,
+        url: "ws://127.0.0.1:18900",
+        error: "connect ECONNREFUSED 127.0.0.1:18900",
+      });
 
       const status = await gatherDaemonStatus({
         rpc: {},
@@ -674,6 +685,7 @@ describe("gatherDaemonStatus", () => {
       };
       expect(authInput.cfg).toBe(cliLoadedConfig);
       expect(authInput.env?.OPENCLAW_GATEWAY_PORT).toBe("18900");
+      expect(status.service.targetRole).toBe("diagnostic-only");
       expect(inspectGatewayRestart).not.toHaveBeenCalled();
     },
   );

--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -32,6 +32,8 @@ const callGatewayStatusProbe = vi.fn<
   error: null,
   server: { version: "2026.5.6", connId: "conn-1" },
 }));
+const isDefaultInstallIdentity = vi.fn((_env?: NodeJS.ProcessEnv) => true);
+const isGatewayExternallySupervised = vi.fn((_env?: NodeJS.ProcessEnv) => false);
 const resolveGatewayProbeAuthSafeWithSecretInputsCalls = vi.fn<(opts?: unknown) => void>();
 const loadGatewayTlsRuntime = vi.fn(async (_cfg?: unknown) => ({
   enabled: true,
@@ -208,6 +210,11 @@ vi.mock("../../config/config.js", () => ({
   resolveStateDir: (env: NodeJS.ProcessEnv) => resolveStateDir(env),
 }));
 
+vi.mock("../../config/paths.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../config/paths.js")>()),
+  isDefaultInstallIdentity: (env?: NodeJS.ProcessEnv) => isDefaultInstallIdentity(env),
+}));
+
 vi.mock("../../daemon/diagnostics.js", () => ({
   readLastGatewayErrorLine: (env: NodeJS.ProcessEnv, options?: { requirePatternMatch?: boolean }) =>
     readLastGatewayErrorLine(env, options),
@@ -278,6 +285,11 @@ vi.mock("../../infra/restart-handoff.js", () => ({
   readGatewayRestartHandoffSync: (env?: NodeJS.ProcessEnv) => readGatewayRestartHandoffSync(env),
 }));
 
+vi.mock("../../infra/gateway-supervision.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../infra/gateway-supervision.js")>()),
+  isGatewayExternallySupervised: (env?: NodeJS.ProcessEnv) => isGatewayExternallySupervised(env),
+}));
+
 vi.mock("../../infra/tailnet.js", () => ({
   pickPrimaryTailnetIPv4: () => pickPrimaryTailnetIPv4(),
 }));
@@ -321,6 +333,7 @@ describe("gatherDaemonStatus", () => {
     envSnapshot = captureEnv([
       "OPENCLAW_STATE_DIR",
       "OPENCLAW_CONFIG_PATH",
+      "OPENCLAW_GATEWAY_PORT",
       "OPENCLAW_GATEWAY_TOKEN",
       "OPENCLAW_GATEWAY_PASSWORD",
       "DAEMON_GATEWAY_TOKEN",
@@ -332,6 +345,8 @@ describe("gatherDaemonStatus", () => {
     deleteTestEnvValue("OPENCLAW_GATEWAY_PASSWORD");
     deleteTestEnvValue("DAEMON_GATEWAY_TOKEN");
     deleteTestEnvValue("DAEMON_GATEWAY_PASSWORD");
+    isDefaultInstallIdentity.mockReset().mockReturnValue(true);
+    isGatewayExternallySupervised.mockReset().mockReturnValue(false);
     callGatewayStatusProbe.mockClear();
     resolveAdvertisedControlUiLinks.mockClear();
     resolveAdvertisedControlUiLinks.mockResolvedValue({
@@ -578,6 +593,9 @@ describe("gatherDaemonStatus", () => {
   });
 
   it("does not force local TLS fingerprint when probe URL is explicitly overridden", async () => {
+    setTestEnvValue("OPENCLAW_GATEWAY_PORT", "18900");
+    isDefaultInstallIdentity.mockReturnValue(false);
+
     const status = await gatherDaemonStatus({
       rpc: { url: "wss://override.example:18790" },
       probe: true,
@@ -596,6 +614,69 @@ describe("gatherDaemonStatus", () => {
     expect(loadInstalledPluginIndexInstallRecords).not.toHaveBeenCalled();
     expect(status.pluginVersionDrift).toBeUndefined();
   });
+
+  it("keeps the standalone gateway default when no native service target exists", async () => {
+    serviceReadCommand.mockResolvedValueOnce(null);
+    serviceIsLoaded.mockResolvedValueOnce(false);
+
+    const status = await gatherDaemonStatus({
+      rpc: {},
+      probe: true,
+      requireRpc: true,
+      deep: true,
+    });
+
+    expect(status.gateway?.probeUrl).toBe("ws://127.0.0.1:18789");
+    expect((callArg(callGatewayStatusProbe) as { url?: string }).url).toBe("ws://127.0.0.1:18789");
+  });
+
+  it.each([
+    ["non-default install identity", false, false],
+    ["external supervisor", true, true],
+  ])(
+    "uses the active %s context instead of an unrelated native service",
+    async (_, isDefault, external) => {
+      setTestEnvValue("OPENCLAW_GATEWAY_PORT", "18900");
+      isDefaultInstallIdentity.mockReturnValue(isDefault);
+      isGatewayExternallySupervised.mockReturnValue(external);
+      serviceReadCommand.mockResolvedValueOnce({
+        programArguments: ["/bin/node", "cli", "gateway", "--port", "18789"],
+        environment: {
+          OPENCLAW_GATEWAY_PORT: "18789",
+          OPENCLAW_CONFIG_PATH: "/tmp/legacy-openclaw/openclaw.json",
+          OPENCLAW_STATE_DIR: "/tmp/legacy-openclaw",
+        },
+      });
+      resolveGatewayPort.mockImplementation((_cfg?: unknown, env?: unknown) =>
+        Number((env as NodeJS.ProcessEnv | undefined)?.OPENCLAW_GATEWAY_PORT ?? 18789),
+      );
+
+      const status = await gatherDaemonStatus({
+        rpc: {},
+        probe: true,
+        requireRpc: true,
+        deep: true,
+      });
+
+      expect(status.gateway?.probeUrl).toBe("ws://127.0.0.1:18900");
+      expect((callArg(callGatewayStatusProbe) as { url?: string }).url).toBe(
+        "ws://127.0.0.1:18900",
+      );
+      const probeInput = callArg(callGatewayStatusProbe) as {
+        config?: unknown;
+        configPath?: string;
+      };
+      expect(probeInput.config).toBe(cliLoadedConfig);
+      expect(probeInput.configPath).toBe("/tmp/openclaw-cli/openclaw.json");
+      const authInput = callArg(resolveGatewayProbeAuthSafeWithSecretInputsCalls) as {
+        cfg?: unknown;
+        env?: NodeJS.ProcessEnv;
+      };
+      expect(authInput.cfg).toBe(cliLoadedConfig);
+      expect(authInput.env?.OPENCLAW_GATEWAY_PORT).toBe("18900");
+      expect(inspectGatewayRestart).not.toHaveBeenCalled();
+    },
+  );
 
   it("uses fallback network details when interface discovery throws during status inspection", async () => {
     daemonLoadedConfig = {

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -292,6 +292,7 @@ export type DaemonStatus = {
     loaded: boolean;
     loadedText: string;
     notLoadedText: string;
+    targetRole?: "target" | "diagnostic-only";
     command?: {
       programArguments: string[];
       workingDirectory?: string;
@@ -616,6 +617,7 @@ export async function gatherDaemonStatus(
     commandProgramArguments: targetServiceCommand?.programArguments,
     rpcUrlOverride: opts.rpc.url,
   });
+  const serviceTargetsProbe = useNativeServiceTargetContext && !probeUrlOverride;
   const shouldInspectLocalGateway = daemonCfg.gateway?.mode !== "remote" && !probeUrlOverride;
   const windowsFirewall =
     opts.deep === true && shouldInspectLocalGateway
@@ -723,7 +725,7 @@ export async function gatherDaemonStatus(
     rpcAuthWarning = undefined;
   }
   const health =
-    opts.probe && useNativeServiceTargetContext && loaded && rpc?.ok !== true
+    opts.probe && serviceTargetsProbe && loaded && rpc?.ok !== true
       ? await loadRestartHealthModule()
           .then(({ inspectGatewayRestart }) =>
             inspectGatewayRestart({
@@ -787,6 +789,7 @@ export async function gatherDaemonStatus(
       loaded,
       loadedText: service.loadedText,
       notLoadedText: service.notLoadedText,
+      targetRole: serviceTargetsProbe ? "target" : "diagnostic-only",
       command,
       runtime,
       configAudit,

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -8,6 +8,7 @@ import {
   resolveGatewayPort,
   resolveStateDir,
 } from "../../config/config.js";
+import { isDefaultInstallIdentity } from "../../config/paths.js";
 import type {
   OpenClawConfig,
   ConfigFileSnapshot,
@@ -31,6 +32,7 @@ import {
   ALL_GATEWAY_SECRET_INPUT_PATHS,
   readGatewaySecretInputValue,
 } from "../../gateway/secret-input-paths.js";
+import { isGatewayExternallySupervised } from "../../infra/gateway-supervision.js";
 import {
   inspectBestEffortPrimaryTailnetIPv4,
   resolveBestEffortGatewayBindHostForDisplay,
@@ -585,6 +587,11 @@ export async function gatherDaemonStatus(
     timeoutMs,
   });
   const { command, env: serviceEnv, loaded, runtime } = serviceState;
+  // A non-default or externally supervised process does not own the host's
+  // native service. Keep that service visible, but do not let it retarget probes.
+  const useNativeServiceTargetContext =
+    isDefaultInstallIdentity(process.env) && !isGatewayExternallySupervised(process.env);
+  const targetServiceCommand = useNativeServiceTargetContext ? command : null;
   const restartHandoff = opts.deep ? readGatewayRestartHandoffSync(serviceEnv) : null;
   const configAudit: ServiceConfigAudit = command
     ? await loadServiceAuditModule().then(({ auditGatewayServiceConfig }) =>
@@ -601,12 +608,12 @@ export async function gatherDaemonStatus(
     cliConfigSummary,
     daemonConfigSummary,
     configMismatch,
-  } = await loadDaemonConfigContext(command?.environment, { deep: opts.deep });
+  } = await loadDaemonConfigContext(targetServiceCommand?.environment, { deep: opts.deep });
   const { gateway, daemonPort, cliPort, probeUrlOverride } = await resolveGatewayStatusSummary({
     cliCfg,
     daemonCfg,
     mergedDaemonEnv,
-    commandProgramArguments: command?.programArguments,
+    commandProgramArguments: targetServiceCommand?.programArguments,
     rpcUrlOverride: opts.rpc.url,
   });
   const shouldInspectLocalGateway = daemonCfg.gateway?.mode !== "remote" && !probeUrlOverride;
@@ -716,7 +723,7 @@ export async function gatherDaemonStatus(
     rpcAuthWarning = undefined;
   }
   const health =
-    opts.probe && loaded && rpc?.ok !== true
+    opts.probe && useNativeServiceTargetContext && loaded && rpc?.ok !== true
       ? await loadRestartHealthModule()
           .then(({ inspectGatewayRestart }) =>
             inspectGatewayRestart({

--- a/src/cli/daemon-cli/status.print.test.ts
+++ b/src/cli/daemon-cli/status.print.test.ts
@@ -1036,6 +1036,46 @@ describe("printDaemonStatus", () => {
     expect(logged).not.toContain("Warm-up: launch agents");
   });
 
+  it("does not combine diagnostic-only service state with the active probe target", () => {
+    printDaemonStatus(
+      {
+        service: {
+          label: "LaunchAgent",
+          loaded: true,
+          loadedText: "loaded",
+          notLoadedText: "not loaded",
+          targetRole: "diagnostic-only",
+          runtime: { status: "running", pid: 8000 },
+        },
+        gateway: {
+          bindMode: "loopback",
+          bindHost: "127.0.0.1",
+          port: 18900,
+          portSource: "env/config",
+          probeUrl: "ws://127.0.0.1:18900",
+        },
+        port: {
+          port: 18900,
+          status: "free",
+          listeners: [],
+          hints: [],
+        },
+        rpc: {
+          ok: false,
+          error: "connect ECONNREFUSED 127.0.0.1:18900",
+          url: "ws://127.0.0.1:18900",
+        },
+        extraServices: [],
+      },
+      { json: false },
+    );
+
+    expectMockLineContains(runtime.log, "Runtime: running");
+    const output = [...runtime.log.mock.calls, ...runtime.error.mock.calls].flat().join("\n");
+    expect(output).not.toContain("Warm-up: launch agents");
+    expect(output).not.toContain("service appears running");
+  });
+
   it("keeps the warm-up hint (not owns-port guidance) when healthy is reachability-only and a stale gateway PID is still held", () => {
     // inspectGatewayRestart can set healthy from reachability after ownership failed,
     // while still returning non-empty staleGatewayPids. That must not be treated as

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -103,6 +103,7 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
   const spacer = () => defaultRuntime.log("");
 
   const { service, rpc, extraServices } = status;
+  const serviceTargetsProbe = service.targetRole !== "diagnostic-only";
   const serviceStatus = service.loaded
     ? okText(service.loadedText)
     : warnText(service.notLoadedText);
@@ -269,7 +270,13 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
     defaultRuntime.log(infoText(formatGatewayRestartHandoffDiagnostic(service.restartHandoff)));
   }
 
-  if (rpc && !rpc.ok && service.loaded && service.runtime?.status === "running") {
+  if (
+    rpc &&
+    !rpc.ok &&
+    serviceTargetsProbe &&
+    service.loaded &&
+    service.runtime?.status === "running"
+  ) {
     // The RPC probe failed while the service is loaded and running. Only the case where
     // the gateway process is up and owns the listening port (health.healthy === true with
     // no stale gateway PIDs, deep status only) is an unambiguous "not warm-up" signal, so it
@@ -475,6 +482,7 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
   }
 
   if (
+    serviceTargetsProbe &&
     service.loaded &&
     service.runtime?.status === "running" &&
     status.port &&

--- a/src/commands/gateway-readiness.test.ts
+++ b/src/commands/gateway-readiness.test.ts
@@ -158,6 +158,56 @@ describe("ensureGatewayReadyForOperation", () => {
     expect(installGateway).not.toHaveBeenCalled();
   });
 
+  it("does not recover a diagnostic-only native service for an active external target", async () => {
+    const status = createStatus({
+      service: {
+        label: "systemd user",
+        loaded: true,
+        loadedText: "enabled",
+        notLoadedText: "disabled",
+        targetRole: "diagnostic-only",
+        command: { programArguments: ["openclaw", "gateway", "run", "--port", "18789"] },
+        runtime: { status: "running" },
+      },
+      gateway: {
+        bindMode: "loopback",
+        bindHost: "127.0.0.1",
+        port: 18900,
+        portSource: "env/config",
+        probeUrl: "ws://127.0.0.1:18900",
+      },
+      port: { port: 18900, status: "free", listeners: [], hints: [] },
+      rpc: {
+        ok: false,
+        error: "connect ECONNREFUSED 127.0.0.1:18900",
+        url: "ws://127.0.0.1:18900",
+      },
+    });
+    const confirm = vi.fn().mockResolvedValue(false);
+    const installGateway = vi.fn();
+    const startGateway = vi.fn();
+
+    const result = await ensureGatewayReadyForOperation({
+      runtime,
+      operation: "open the dashboard",
+      interactive: true,
+      deps: {
+        gatherStatus: vi.fn().mockResolvedValue(status),
+        confirm,
+        installGateway,
+        startGateway,
+      },
+    });
+
+    expect(result).toMatchObject({ ready: false, recoverable: false });
+    expect(confirm).not.toHaveBeenCalled();
+    expect(installGateway).not.toHaveBeenCalled();
+    expect(startGateway).not.toHaveBeenCalled();
+    expect(runtime.log.mock.calls.map(([line]) => String(line)).join("\n")).toContain(
+      "owning environment or supervisor to start or repair",
+    );
+  });
+
   it("does not prompt to start when the gateway is reachable but unhealthy", async () => {
     const status = createStatus({
       service: {

--- a/src/commands/gateway-readiness.ts
+++ b/src/commands/gateway-readiness.ts
@@ -127,6 +127,10 @@ function gatewayServiceIsInstalled(status: DaemonStatus): boolean {
   return Boolean(status.service.command || status.service.loaded);
 }
 
+function nativeServiceTargetsGateway(status: DaemonStatus): boolean {
+  return status.service.targetRole !== "diagnostic-only";
+}
+
 function readinessFailureReason(status: DaemonStatus): string {
   if (gatewayLooksStopped(status)) {
     return "Gateway is not running.";
@@ -136,9 +140,19 @@ function readinessFailureReason(status: DaemonStatus): string {
     : "Gateway is not healthy.";
 }
 
-function printGatewayNotReadyHints(runtime: RuntimeEnv, reason: string): void {
+function printGatewayNotReadyHints(
+  runtime: RuntimeEnv,
+  reason: string,
+  nativeServiceCanRecover = true,
+): void {
   runtime.log(reason);
   runtime.log("Run `openclaw gateway status --deep` for details.");
+  if (!nativeServiceCanRecover) {
+    runtime.log(
+      "Use the owning environment or supervisor to start or repair the selected Gateway.",
+    );
+    return;
+  }
   runtime.log("Run `openclaw gateway start` to start a managed gateway.");
   runtime.log("Run `openclaw gateway run` for a foreground gateway.");
 }
@@ -209,8 +223,9 @@ export async function ensureGatewayReadyForOperation(
   }
 
   const reason = readinessFailureReason(initialStatus);
-  if (!gatewayLooksStopped(initialStatus)) {
-    printGatewayNotReadyHints(options.runtime, reason);
+  const nativeServiceCanRecover = nativeServiceTargetsGateway(initialStatus);
+  if (!gatewayLooksStopped(initialStatus) || !nativeServiceCanRecover) {
+    printGatewayNotReadyHints(options.runtime, reason, nativeServiceCanRecover);
     return { ready: false, status: initialStatus, reason, recoverable: false };
   }
 
@@ -250,7 +265,11 @@ export async function ensureGatewayReadyForOperation(
   }
 
   const recoveredReason = readinessFailureReason(recoveredStatus);
-  printGatewayNotReadyHints(options.runtime, recoveredReason);
+  printGatewayNotReadyHints(
+    options.runtime,
+    recoveredReason,
+    nativeServiceTargetsGateway(recoveredStatus),
+  );
   return {
     ready: false,
     status: recoveredStatus,


### PR DESCRIPTION
## What Problem This Solves

`openclaw gateway status` could retarget a non-default or externally supervised invocation to an unrelated host-native gateway service. For OCM environments, that meant a selected environment on one configured port could be diagnosed through legacy service metadata on port 18789.

## Why This Change Was Made

Status gathering now uses native-service command and environment metadata for probe targeting only when the active process owns that native-service identity and is not externally supervised. The service remains visible in diagnostic output, but it cannot override the active environment's config, auth, TLS, port, or restart-health context.

The resulting precedence is:

1. explicit `--url`
2. active non-default or externally supervised process context
3. ordinary native-service command/environment context
4. standalone config and default port

## User Impact

OCM and other externally supervised or relocated OpenClaw environments diagnose their selected gateway instead of a coexisting legacy/default service. Ordinary standalone and profile-native service diagnostics retain their existing behavior.

## Evidence

- Reproduced on unmodified canonical main: caller port 18900 plus unrelated native-service metadata on 18789 selected `ws://127.0.0.1:18789`.
- Focused regression suite: `node scripts/run-vitest.mjs src/cli/daemon-cli/status.gather.test.ts` (41 passed).
- Full TypeScript project check: `node scripts/run-tsgo.mjs -b tsconfig.projects.json` (passed).
- Changed-file remote gate passed all guards before exposing a corrected test-mock signature issue; the corrected exact branch passed the full local typecheck.
- Source-blind compiled-CLI validation passed environment-port selection with conflicting legacy metadata, explicit URL precedence, standalone port 18789, and adjacent OCM passthrough.
- Autoreview: clean, no actionable findings, patch correct (0.90 confidence).
