### PR TITLE
ci(macos): budget macos-swift by runner so fork PRs finish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3582,12 +3582,8 @@ jobs:
     needs: [preflight]
     if: needs.preflight.outputs.run_macos_swift == 'true'
     runs-on: ${{ vars.OPENCLAW_CI_RUNNER_BACKEND == 'github' && 'macos-26' || (github.event_name == 'workflow_dispatch' || github.run_attempt > 1) && 'macos-26' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association)) && 'blacksmith-12vcpu-macos-26' || 'macos-26') }}
-    # The timeout tracks every path runs-on can route to a hosted runner
-    # (breaker fallback, dispatches, retries, and pull requests whose author
-    # association keeps them off Blacksmith), not just trigger type, so hosted
-    # compiles get the hosted budget instead of the tighter Blacksmith one.
-    # Hosted runs may also still be finalizing large Swift caches after every
-    # test passes; that post-job work stays non-blocking.
+    # Hosted paths include untrusted first-attempt PRs, so their timeout must
+    # follow the runner rather than inheriting Blacksmith's tighter budget.
     timeout-minutes: ${{ (vars.OPENCLAW_CI_RUNNER_BACKEND == 'github' || github.event_name == 'workflow_dispatch' || github.run_attempt > 1 || github.repository != 'openclaw/openclaw' || (github.event_name == 'pull_request' && !contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association))) && 30 || 20 }}
     env:
       HISTORICAL_TARGET: ${{ needs.preflight.outputs.compatibility_target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3582,9 +3582,13 @@ jobs:
     needs: [preflight]
     if: needs.preflight.outputs.run_macos_swift == 'true'
     runs-on: ${{ vars.OPENCLAW_CI_RUNNER_BACKEND == 'github' && 'macos-26' || (github.event_name == 'workflow_dispatch' || github.run_attempt > 1) && 'macos-26' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association)) && 'blacksmith-12vcpu-macos-26' || 'macos-26') }}
-    # Hosted runs may still be finalizing large Swift caches after every test
-    # passes; keep that post-job work non-blocking.
-    timeout-minutes: ${{ (vars.OPENCLAW_CI_RUNNER_BACKEND == 'github' || github.event_name == 'workflow_dispatch' || github.run_attempt > 1) && 30 || 20 }}
+    # The timeout tracks every path runs-on can route to a hosted runner
+    # (breaker fallback, dispatches, retries, and pull requests whose author
+    # association keeps them off Blacksmith), not just trigger type, so hosted
+    # compiles get the hosted budget instead of the tighter Blacksmith one.
+    # Hosted runs may also still be finalizing large Swift caches after every
+    # test passes; that post-job work stays non-blocking.
+    timeout-minutes: ${{ (vars.OPENCLAW_CI_RUNNER_BACKEND == 'github' || github.event_name == 'workflow_dispatch' || github.run_attempt > 1 || github.repository != 'openclaw/openclaw' || (github.event_name == 'pull_request' && !contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association))) && 30 || 20 }}
     env:
       HISTORICAL_TARGET: ${{ needs.preflight.outputs.compatibility_target }}
       SWIFT_TEST_EXECUTION: ${{ (github.event_name == 'workflow_dispatch' || github.run_attempt > 1) && 'serial' || 'parallel' }}

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -111,6 +111,8 @@ When the check fails, update the PR body instead of pushing another code commit.
 
 Scope logic lives in `scripts/ci-changed-scope.mjs` and is covered by unit tests in `src/scripts/ci-changed-scope.test.ts`. Ordinary manual dispatch skips changed-scope detection and makes the preflight manifest act as if every scoped area changed. The exact-head `release_gate` exception evaluates the fetched pull request merge tree and retains its macOS, iOS-build, and screenshot-risk decisions.
 
+The macOS Swift job receives 20 minutes on Blacksmith runners and 30 minutes on every GitHub-hosted route, including first-attempt pull requests from untrusted contributors.
+
 Release screenshot routing is deliberately conservative because an app change can break deterministic App Store capture without breaking compilation. Pull requests and exact-head release gates run the full iPhone, iPad, and Watch matrix when the diff touches `apps/ios/**`, linked OpenClawKit or Swabble code, Apple Swift configuration, or the scripts used by screenshot capture. Ordinary manual CI and Full Release Validation always run that matrix. The screenshot decision is independent of macOS routing; a pure iOS app change does not select macOS jobs by itself.
 
 Separate iOS and macOS Periphery workflows enforce a zero-findings dead-code policy. Each runs only when a non-draft pull request touches its native scan scope, or when manually dispatched.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -111,13 +111,12 @@ When the check fails, update the PR body instead of pushing another code commit.
 
 Scope logic lives in `scripts/ci-changed-scope.mjs` and is covered by unit tests in `src/scripts/ci-changed-scope.test.ts`. Ordinary manual dispatch skips changed-scope detection and makes the preflight manifest act as if every scoped area changed. The exact-head `release_gate` exception evaluates the fetched pull request merge tree and retains its macOS, iOS-build, and screenshot-risk decisions.
 
-The macOS Swift job receives 20 minutes on Blacksmith runners and 30 minutes on every GitHub-hosted route, including first-attempt pull requests from untrusted contributors.
-
 Release screenshot routing is deliberately conservative because an app change can break deterministic App Store capture without breaking compilation. Pull requests and exact-head release gates run the full iPhone, iPad, and Watch matrix when the diff touches `apps/ios/**`, linked OpenClawKit or Swabble code, Apple Swift configuration, or the scripts used by screenshot capture. Ordinary manual CI and Full Release Validation always run that matrix. The screenshot decision is independent of macOS routing; a pure iOS app change does not select macOS jobs by itself.
 
 Separate iOS and macOS Periphery workflows enforce a zero-findings dead-code policy. Each runs only when a non-draft pull request touches its native scan scope, or when manually dispatched.
 
 - **CI workflow edits** validate the Node CI graph, workflow linting, and the Windows lane (`ci.yml` executes it), but do not force iOS, Android, or macOS native builds by themselves; those platform lanes stay scoped to platform source changes.
+- **macOS Swift runner budgets** are 20 minutes on Blacksmith and 30 minutes on every GitHub-hosted route, including first-attempt pull requests from untrusted contributors.
 - **Workflow Sanity** runs `actionlint`, `zizmor` over all workflow YAML files, the composite-action interpolation guard, and the conflict-marker guard. The PR-scoped `security-fast` job also runs `zizmor` over changed workflow files so workflow security findings fail early in the main CI graph.
 - **Docs on `main` pushes** are checked by the standalone `Docs` workflow with the same ClawHub docs mirror used by CI, so mixed code+docs pushes do not also queue the CI `check-docs` shard. Pull requests and manual CI still run `check-docs` from CI when docs changed.
 - **TUI PTY** splits by proof ownership. The dedicated `core-runtime-tui-pty` Node shard owns the full real-backend suite against the exact-head built CLI in metadata-complete pull request fallbacks plus manual and release runs; routine `main` push compacts omit that serial shard. The `build-artifacts` job keeps a local model roundtrip and a real Gateway connection canary on every artifact boundary without duplicating the full serial suite inside the build job.

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -3516,6 +3516,27 @@ NODE
         jobName,
       ).toBe(hostedTimeout);
     }
+
+    const macosSwift = workflow.jobs["macos-swift"];
+    for (const [authorAssociation, runner, timeout] of [
+      ["NONE", "macos-26", 30],
+      ["FIRST_TIME_CONTRIBUTOR", "macos-26", 30],
+      ["CONTRIBUTOR", "blacksmith-12vcpu-macos-26", 20],
+    ] as const) {
+      const forkContext = {
+        ...canonicalPullRequest,
+        authorAssociation,
+        headRepository: "contributor/openclaw",
+      };
+      expect(
+        evaluateWorkflowExpression(macosSwift["runs-on"], forkContext),
+        authorAssociation,
+      ).toBe(runner);
+      expect(
+        evaluateWorkflowExpression(macosSwift["timeout-minutes"], forkContext),
+        authorAssociation,
+      ).toBe(timeout);
+    }
   });
 
   it("scans only the pull request commit range for leaked credentials", () => {
@@ -5799,124 +5820,6 @@ server.listen(0, "127.0.0.1", () => writeFileSync(readyPath, String(server.addre
     expect(buildStep.run.indexOf("swift package --package-path apps/macos reset")).toBeGreaterThan(
       buildStep.run.indexOf("swift build failed"),
     );
-  });
-
-  it("budgets macOS Swift time by runner, so every hosted path gets the hosted timeout", () => {
-    const workflow = readCiWorkflow();
-    const macosSwift = workflow.jobs["macos-swift"];
-    const runsOnExpression = macosSwift["runs-on"];
-    const timeoutExpression = macosSwift["timeout-minutes"];
-
-    // Both expressions must route on the same set of conditions: whichever
-    // path sends runs-on to hosted macos-26 has to send timeout-minutes to
-    // the hosted budget too, or that path keeps the tighter Blacksmith
-    // budget on a slower runner and gets cancelled mid-compile.
-    const scenarios = [
-      {
-        name: "same-repo pull request, first attempt, default backend",
-        context: {
-          eventName: "pull_request",
-          headRepository: "openclaw/openclaw",
-          repository: "openclaw/openclaw",
-          runAttempt: 1,
-        },
-        hosted: false,
-      },
-      {
-        name: "same-repo pull request, breaker routed to GitHub-hosted",
-        context: {
-          eventName: "pull_request",
-          headRepository: "openclaw/openclaw",
-          repository: "openclaw/openclaw",
-          runnerBackend: "github",
-          runAttempt: 1,
-        },
-        hosted: true,
-      },
-      {
-        name: "same-repo pull request retry",
-        context: {
-          eventName: "pull_request",
-          headRepository: "openclaw/openclaw",
-          repository: "openclaw/openclaw",
-          runAttempt: 2,
-        },
-        hosted: true,
-      },
-      {
-        // An untrusted fork cannot spend Blacksmith capacity, so runs-on sends it
-        // to a hosted runner; the budget has to follow it there.
-        name: "untrusted fork pull request, default backend",
-        context: {
-          authorAssociation: "NONE",
-          eventName: "pull_request",
-          headRepository: "contributor/openclaw",
-          repository: "openclaw/openclaw",
-          runAttempt: 1,
-        },
-        hosted: true,
-      },
-      {
-        // A returning contributor's fork still routes to Blacksmith, so it keeps
-        // the tighter budget: the timeout tracks the runner, not fork-ness.
-        name: "returning-contributor fork pull request, default backend",
-        context: {
-          authorAssociation: "CONTRIBUTOR",
-          eventName: "pull_request",
-          headRepository: "contributor/openclaw",
-          repository: "openclaw/openclaw",
-          runAttempt: 1,
-        },
-        hosted: false,
-      },
-      {
-        name: "fork pull request, breaker routed to GitHub-hosted",
-        context: {
-          authorAssociation: "NONE",
-          eventName: "pull_request",
-          headRepository: "contributor/openclaw",
-          repository: "openclaw/openclaw",
-          runnerBackend: "github",
-          runAttempt: 1,
-        },
-        hosted: true,
-      },
-      {
-        name: "manual workflow dispatch",
-        context: {
-          eventName: "workflow_dispatch",
-          repository: "openclaw/openclaw",
-          runAttempt: 1,
-        },
-        hosted: true,
-      },
-      {
-        name: "canonical main push, default backend",
-        context: {
-          eventName: "push",
-          repository: "openclaw/openclaw",
-          runAttempt: 1,
-        },
-        hosted: false,
-      },
-      {
-        name: "canonical main push, breaker routed to GitHub-hosted",
-        context: {
-          eventName: "push",
-          repository: "openclaw/openclaw",
-          runnerBackend: "github",
-          runAttempt: 1,
-        },
-        hosted: true,
-      },
-    ] as const;
-
-    for (const { context, hosted, name } of scenarios) {
-      expect(evaluateWorkflowExpression(runsOnExpression, context), name).toBe(
-        hosted ? "macos-26" : "blacksmith-12vcpu-macos-26",
-      );
-      expect(evaluateWorkflowExpression(timeoutExpression, context), name).toBe(hosted ? 30 : 20);
-    }
   });
 
   it("serializes macOS Swift tests only on hosted dispatches and retries", () => {

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -5801,6 +5801,107 @@ server.listen(0, "127.0.0.1", () => writeFileSync(readyPath, String(server.addre
     );
   });
 
+  it("budgets macOS Swift time by runner, so every hosted path gets the hosted timeout", () => {
+    const workflow = readCiWorkflow();
+    const macosSwift = workflow.jobs["macos-swift"];
+    const runsOnExpression = macosSwift["runs-on"];
+    const timeoutExpression = macosSwift["timeout-minutes"];
+
+    // Both expressions must route on the same set of conditions: whichever
+    // path sends runs-on to hosted macos-26 has to send timeout-minutes to
+    // the hosted budget too, or that path keeps the tighter Blacksmith
+    // budget on a slower runner and gets cancelled mid-compile.
+    const scenarios = [
+      {
+        name: "same-repo pull request, first attempt, default backend",
+        context: {
+          eventName: "pull_request",
+          headRepository: "openclaw/openclaw",
+          repository: "openclaw/openclaw",
+          runAttempt: 1,
+        },
+        hosted: false,
+      },
+      {
+        name: "same-repo pull request, breaker routed to GitHub-hosted",
+        context: {
+          eventName: "pull_request",
+          headRepository: "openclaw/openclaw",
+          repository: "openclaw/openclaw",
+          runnerBackend: "github",
+          runAttempt: 1,
+        },
+        hosted: true,
+      },
+      {
+        name: "same-repo pull request retry",
+        context: {
+          eventName: "pull_request",
+          headRepository: "openclaw/openclaw",
+          repository: "openclaw/openclaw",
+          runAttempt: 2,
+        },
+        hosted: true,
+      },
+      {
+        name: "fork pull request, default backend",
+        context: {
+          eventName: "pull_request",
+          headRepository: "contributor/openclaw",
+          repository: "openclaw/openclaw",
+          runAttempt: 1,
+        },
+        hosted: true,
+      },
+      {
+        name: "fork pull request, breaker routed to GitHub-hosted",
+        context: {
+          eventName: "pull_request",
+          headRepository: "contributor/openclaw",
+          repository: "openclaw/openclaw",
+          runnerBackend: "github",
+          runAttempt: 1,
+        },
+        hosted: true,
+      },
+      {
+        name: "manual workflow dispatch",
+        context: {
+          eventName: "workflow_dispatch",
+          repository: "openclaw/openclaw",
+          runAttempt: 1,
+        },
+        hosted: true,
+      },
+      {
+        name: "canonical main push, default backend",
+        context: {
+          eventName: "push",
+          repository: "openclaw/openclaw",
+          runAttempt: 1,
+        },
+        hosted: false,
+      },
+      {
+        name: "canonical main push, breaker routed to GitHub-hosted",
+        context: {
+          eventName: "push",
+          repository: "openclaw/openclaw",
+          runnerBackend: "github",
+          runAttempt: 1,
+        },
+        hosted: true,
+      },
+    ] as const;
+
+    for (const { context, hosted, name } of scenarios) {
+      expect(evaluateWorkflowExpression(runsOnExpression, context), name).toBe(
+        hosted ? "macos-26" : "blacksmith-12vcpu-macos-26",
+      );
+      expect(evaluateWorkflowExpression(timeoutExpression, context), name).toBe(hosted ? 30 : 20);
+    }
+  });
+
   it("serializes macOS Swift tests only on hosted dispatches and retries", () => {
     const workflow = readCiWorkflow();
     const macosSwift = workflow.jobs["macos-swift"];

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -5844,8 +5844,11 @@ server.listen(0, "127.0.0.1", () => writeFileSync(readyPath, String(server.addre
         hosted: true,
       },
       {
-        name: "fork pull request, default backend",
+        // An untrusted fork cannot spend Blacksmith capacity, so runs-on sends it
+        // to a hosted runner; the budget has to follow it there.
+        name: "untrusted fork pull request, default backend",
         context: {
+          authorAssociation: "NONE",
           eventName: "pull_request",
           headRepository: "contributor/openclaw",
           repository: "openclaw/openclaw",
@@ -5854,8 +5857,22 @@ server.listen(0, "127.0.0.1", () => writeFileSync(readyPath, String(server.addre
         hosted: true,
       },
       {
+        // A returning contributor's fork still routes to Blacksmith, so it keeps
+        // the tighter budget: the timeout tracks the runner, not fork-ness.
+        name: "returning-contributor fork pull request, default backend",
+        context: {
+          authorAssociation: "CONTRIBUTOR",
+          eventName: "pull_request",
+          headRepository: "contributor/openclaw",
+          repository: "openclaw/openclaw",
+          runAttempt: 1,
+        },
+        hosted: false,
+      },
+      {
         name: "fork pull request, breaker routed to GitHub-hosted",
         context: {
+          authorAssociation: "NONE",
           eventName: "pull_request",
           headRepository: "contributor/openclaw",
           repository: "openclaw/openclaw",


### PR DESCRIPTION
## What Problem This Solves

First-time external contributors can have the required macOS Swift CI job cancelled before compilation finishes because runner selection and timeout selection disagree. Their pull requests correctly route to GitHub-hosted `macos-26`, but the existing timeout expression gives that slower runner the 20-minute budget intended for a 12-vCPU Blacksmith Mac.

The original failure was observed on contributor PR #118989: its hosted `macos-swift` job ran for 20 minutes 25 seconds, was cancelled while compiling file 1,365 of 1,416, and never reached its tests. The contributor could not rerun the protected repository workflow.

## Why This Change Was Made

Keep the existing timeout budgets and make them follow the already-selected runner:

| scenario | selected runner | previous budget | repaired budget |
| --- | --- | ---: | ---: |
| first-time/untrusted contributor PR | GitHub-hosted `macos-26` | 20 minutes | 30 minutes |
| returning trusted contributor PR | Blacksmith macOS | 20 minutes | 20 minutes |
| GitHub-hosted breaker route | GitHub-hosted `macos-26` | 30 minutes | 30 minutes |
| workflow dispatch or retry | GitHub-hosted `macos-26` | 30 minutes | 30 minutes |

The repair matches GitHub author-association trust routing instead of assuming every fork uses the same runner. It does not increase Blacksmith concurrency, consume additional runner registrations, change repository trust, or introduce a new timeout policy.

## User Impact

External contributors no longer lose the required Apple Swift check solely because their first run inherited the wrong runner budget. Trusted returning contributors, canonical pushes, and existing hosted fallback routes retain their established behavior.

## Evidence

- Observed pre-fix production failure: [hosted `macos-swift` cancelled after 20m25s](https://github.com/openclaw/openclaw/actions/runs/30857126028/job/91830753798).
- Independently evaluated the actual workflow expressions against current `main`: author associations `NONE` and `FIRST_TIME_CONTRIBUTOR` select `macos-26` but receive only 20 minutes.
- The repaired workflow gives both untrusted author associations 30 minutes, while `CONTRIBUTOR` still selects `blacksmith-12vcpu-macos-26` with 20 minutes.
- Extended the existing runner-budget owner regression instead of maintaining a duplicate scenario suite; the update removes 97 lines of unnecessary test scaffolding while preserving breaker, retry, trusted, and first-time-contributor coverage.
- Added the runner-budget contract to `docs/ci.md`; focused formatting verification and independent structured review both pass.
- Workflow-only pull requests intentionally skip native builds under the documented changed-scope contract, so the required exact-head PR checks validate the executable policy regression. A hosted macOS build from a native-changing PR remains the production deployment proof after landing.

Contributor credit: @harjothkhara.
