### PR TITLE
chore(qa): prove workspace mutation tools

### DIFF
--- a/qa/scenarios/runtime/openclaw-workspace-mutation-tools.yaml
+++ b/qa/scenarios/runtime/openclaw-workspace-mutation-tools.yaml
@@ -1,0 +1,27 @@
+title: OpenClaw workspace mutation tools
+
+scenario:
+  id: openclaw-workspace-mutation-tools
+  surface: runtime-tools
+  coverage:
+    primary:
+      - agent-runtime.tool-apply-patch
+      - agent-runtime.tool-edit
+  objective: Prove OpenClaw's assembled workspace mutation tools persist exact bytes, report useful receipts, and reject workspace escapes.
+  successCriteria:
+    - The real assembled apply_patch tool creates an artifact with exact draft bytes and reports its path and add summary.
+    - A traversal patch is rejected by the workspace root guard without changing the outside sentinel.
+    - The real assembled edit tool changes the same artifact to exact final bytes and reports its display diff, unified patch, and first changed line.
+    - Final disk bytes contain no draft marker.
+  docsRefs:
+    - docs/help/testing.md
+    - docs/gateway/sandboxing.md
+  codeRefs:
+    - src/agents/agent-tools.ts
+    - src/agents/apply-patch.ts
+    - src/agents/sessions/tools/edit.ts
+    - test/e2e/qa-lab/runtime/openclaw-workspace-mutation-tools.e2e.test.ts
+  execution:
+    kind: vitest
+    path: test/e2e/qa-lab/runtime/openclaw-workspace-mutation-tools.e2e.test.ts
+    summary: Execute real OpenClaw apply_patch and edit tools against exact workspace and outside-sentinel bytes.

--- a/test/e2e/qa-lab/runtime/openclaw-workspace-mutation-tools.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/openclaw-workspace-mutation-tools.e2e.test.ts
@@ -1,0 +1,110 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, test } from "vitest";
+import { createOpenClawCodingTools } from "../../../../src/agents/agent-tools.js";
+import type { AnyAgentTool } from "../../../../src/agents/agent-tools.types.js";
+import type { OpenClawConfig } from "../../../../src/config/types.openclaw.js";
+import { useAutoCleanupTempDirTracker } from "../../../helpers/temp-dir.js";
+
+const ARTIFACT = "mutation-receipt.md";
+const DRAFT = "# Workspace mutation\n\nstate: DRAFT\n";
+const FINAL = "# Workspace mutation\n\nstate: FINAL\n";
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function requireTool(tools: AnyAgentTool[], name: string): AnyAgentTool {
+  const tool = tools.find((candidate) => candidate.name === name);
+  if (!tool) {
+    throw new Error(`expected assembled ${name} tool`);
+  }
+  return tool;
+}
+
+function textOf(result: Awaited<ReturnType<AnyAgentTool["execute"]>>): string {
+  return result.content.find((part) => part.type === "text")?.text ?? "";
+}
+
+test("OpenClaw applies and edits exact workspace bytes while rejecting escapes", async () => {
+  // Resolve once so macOS /var and /private/var aliases cannot skew workspace checks.
+  const root = await fs.realpath(tempDirs.make("openclaw-workspace-mutation-"));
+  const workspace = path.join(root, "workspace");
+  const sentinel = path.join(root, "outside-sentinel");
+  await fs.mkdir(workspace);
+  await fs.writeFile(sentinel, "OUTSIDE\n", "utf8");
+
+  const config: OpenClawConfig = {
+    tools: {
+      fs: { workspaceOnly: true },
+      exec: { applyPatch: { enabled: true, workspaceOnly: true } },
+    },
+  };
+  const tools = createOpenClawCodingTools({
+    workspaceDir: workspace,
+    modelProvider: "openai",
+    modelId: "gpt-5.4",
+    config,
+    toolConstructionPlan: {
+      includeBaseCodingTools: true,
+      includeShellTools: true,
+      includeChannelTools: false,
+      includeOpenClawTools: false,
+      includePluginTools: false,
+    },
+  });
+  const applyPatch = requireTool(tools, "apply_patch");
+  const edit = requireTool(tools, "edit");
+
+  const applied = await applyPatch.execute("apply-draft", {
+    input: [
+      "*** Begin Patch",
+      `*** Add File: ${ARTIFACT}`,
+      "+# Workspace mutation",
+      "+",
+      "+state: DRAFT",
+      "*** End Patch",
+    ].join("\n"),
+  });
+  expect(textOf(applied)).toBe(`Success. Updated the following files:\nA ${ARTIFACT}`);
+  expect(applied.details).toEqual({
+    summary: { added: [ARTIFACT], modified: [], deleted: [] },
+  });
+  await expect(fs.readFile(path.join(workspace, ARTIFACT), "utf8")).resolves.toBe(DRAFT);
+
+  await expect(
+    applyPatch.execute("reject-escape", {
+      input: [
+        "*** Begin Patch",
+        "*** Update File: ../outside-sentinel",
+        "@@",
+        "-OUTSIDE",
+        "+ESCAPED",
+        "*** End Patch",
+      ].join("\n"),
+    }),
+  ).rejects.toThrow(/Path escapes sandbox root/);
+  await expect(fs.readFile(sentinel, "utf8")).resolves.toBe("OUTSIDE\n");
+
+  const edited = await edit.execute("edit-final", {
+    path: ARTIFACT,
+    edits: [{ oldText: "state: DRAFT", newText: "state: FINAL" }],
+  });
+  expect(textOf(edited)).toBe(`Successfully replaced 1 block(s) in ${ARTIFACT}.`);
+  expect(edited.details).toMatchObject({
+    changed: true,
+    firstChangedLine: 3,
+  });
+  const details = edited.details as {
+    changed: true;
+    diff: string;
+    patch: string;
+    firstChangedLine?: number;
+  };
+  expect(details.diff).toBe(
+    [" 1 # Workspace mutation", " 2 ", "-3 state: DRAFT", "+3 state: FINAL"].join("\n"),
+  );
+  expect(details.patch).toContain(`--- ${ARTIFACT}`);
+  expect(details.patch).toContain(`+++ ${ARTIFACT}`);
+  expect(details.patch).toContain("-state: DRAFT\n+state: FINAL");
+  const finalBytes = await fs.readFile(path.join(workspace, ARTIFACT), "utf8");
+  expect(finalBytes).toBe(FINAL);
+  expect(finalBytes).not.toContain("DRAFT");
+});


### PR DESCRIPTION
## What Problem This Solves

OpenClaw's real assembled `apply_patch` and `edit` tools only had secondary runtime-pair fixture ownership for their QA taxonomy IDs. That left no primary evidence that the OpenClaw tool surface persists exact workspace bytes, returns actionable receipts, and rejects a traversal mutation.

## Why This Change Was Made

Adds one native Vitest QA scenario that obtains both tools from `createOpenClawCodingTools`, applies exact draft bytes, edits the same artifact to exact final bytes, verifies the result metadata, and proves a matching outside sentinel remains unchanged after traversal rejection. Runtime-pair fixtures and production code are unchanged.

## User Impact

No runtime behavior changes. Maintainers gain primary QA evidence for `agent-runtime.tool-apply-patch` and `agent-runtime.tool-edit`.

## Evidence

- Local focused E2E: `node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/openclaw-workspace-mutation-tools.e2e.test.ts` (1/1)
- Blacksmith Testbox: exact final head `370924fc37ac51f72d84a748119e58caabcb4b2c`, [run 30869575137](https://github.com/openclaw/openclaw/actions/runs/30869575137)
  - focused E2E passed (1/1)
  - QA Suite evidence passed with exactly the two primary IDs and no runtime-pair lane
  - scenario catalog passed (47/47)
  - scoped `pnpm check:changed -- test/e2e/qa-lab/runtime/openclaw-workspace-mutation-tools.e2e.test.ts qa/scenarios/runtime/openclaw-workspace-mutation-tools.yaml` passed
- Coverage inventory: the new native Vitest scenario owns `agent-runtime.tool-apply-patch` and `agent-runtime.tool-edit`; existing runtime-pair fixtures remain secondary and unchanged
- Sol-high autoreview: clean, no accepted/actionable findings
- `node_modules/.bin/oxfmt --check test/e2e/qa-lab/runtime/openclaw-workspace-mutation-tools.e2e.test.ts qa/scenarios/runtime/openclaw-workspace-mutation-tools.yaml`
- `git diff --check origin/main...HEAD`
- Production LOC: 0
- QA LOC: +137

AI-assisted: yes. The maintainer supplied and reviewed the exact scope and stop conditions.
