### PR TITLE
fix(sessions): name the transcript identity when an append is refused

### DIFF
--- a/src/agents/sessions/session-manager-persistence.ts
+++ b/src/agents/sessions/session-manager-persistence.ts
@@ -5,6 +5,7 @@ import {
   ensureSessionEntrySync,
   type TranscriptEntryAnchor,
 } from "../../config/sessions/session-accessor.js";
+import { redactIdentifier } from "../../logging/redact-identifier.js";
 import { isIndexedSessionEntry, parseOpaqueLeafEntry } from "./session-manager-codec.js";
 import { SessionManagerCore } from "./session-manager-core.js";
 import type { AppendPersistenceOptions, SessionEntry } from "./session-manager-types.js";
@@ -37,6 +38,14 @@ function requireTranscriptEventAppend(
  * session row cannot be matched, so without this the caller can only report
  * *that* a write was refused, never *which* identity missed. A sessionId
  * arriving in `sessionKey` is the common cause and is invisible otherwise.
+ *
+ * This message reaches operators through `/compact` and `sessions.compact`
+ * as `result.reason`, and a canonical sessionKey can embed a channel peer id
+ * (a phone number, for example), so identities are rendered through the
+ * shared stable-hash redaction rather than interpolated verbatim. Hashing
+ * with the same function preserves the one diagnostic signal that matters
+ * here: a sessionId substituted into the sessionKey field produces two
+ * equal hashes.
  */
 function describeTranscriptWriteScope(scope: {
   agentId?: string;
@@ -44,11 +53,11 @@ function describeTranscriptWriteScope(scope: {
   sessionKey?: string;
 }): string {
   const parts = [
-    `sessionKey=${scope.sessionKey ?? "<none>"}`,
-    `sessionId=${scope.sessionId ?? "<none>"}`,
+    `sessionKeyHash=${redactIdentifier(scope.sessionKey)}`,
+    `sessionIdHash=${redactIdentifier(scope.sessionId)}`,
   ];
   if (scope.agentId) {
-    parts.push(`agentId=${scope.agentId}`);
+    parts.push(`agentIdHash=${redactIdentifier(scope.agentId)}`);
   }
   return parts.join(" ");
 }

--- a/src/agents/sessions/session-manager-persistence.ts
+++ b/src/agents/sessions/session-manager-persistence.ts
@@ -30,6 +30,29 @@ function requireTranscriptEventAppend(
   throw new Error(`${message}: ${cause.code}`, { cause });
 }
 
+/**
+ * Describes the transcript identity a refused append was scoped to.
+ *
+ * `appendTranscriptEventSync` returns `false` rather than throwing when the
+ * session row cannot be matched, so without this the caller can only report
+ * *that* a write was refused, never *which* identity missed. A sessionId
+ * arriving in `sessionKey` is the common cause and is invisible otherwise.
+ */
+function describeTranscriptWriteScope(scope: {
+  agentId?: string;
+  sessionId?: string;
+  sessionKey?: string;
+}): string {
+  const parts = [
+    `sessionKey=${scope.sessionKey ?? "<none>"}`,
+    `sessionId=${scope.sessionId ?? "<none>"}`,
+  ];
+  if (scope.agentId) {
+    parts.push(`agentId=${scope.agentId}`);
+  }
+  return parts.join(" ");
+}
+
 export class SessionManagerPersistence extends SessionManagerCore {
   removeTrailingEntries(
     predicate: (entry: SessionEntry) => boolean,
@@ -167,15 +190,19 @@ export class SessionManagerPersistence extends SessionManagerCore {
           updatedAt: Date.now(),
         })
       ) {
-        throw new Error("Session transcript header was not persisted");
+        throw new Error(
+          `Session transcript header was not persisted: ${describeTranscriptWriteScope(scope)}`,
+        );
       }
       const header = this.fileEntries[0];
       if (!header || header.type !== "session") {
-        throw new Error("Session transcript header was not persisted");
+        throw new Error(
+          `Session transcript header was not persisted: ${describeTranscriptWriteScope(scope)}`,
+        );
       }
       requireTranscriptEventAppend(
         appendTranscriptEventSync(scope, header),
-        "Session transcript header was not persisted",
+        `Session transcript header was not persisted: ${describeTranscriptWriteScope(scope)}`,
       );
       this.persistenceHeaderPending = false;
     }
@@ -183,7 +210,8 @@ export class SessionManagerPersistence extends SessionManagerCore {
     if (leafEntry) {
       requireTranscriptEventAppend(
         appendTranscriptEventSync(scope, entry),
-        `Session transcript leaf control was not persisted: ${leafEntry.id}`,
+        `Session transcript leaf control was not persisted: ${leafEntry.id} ` +
+          describeTranscriptWriteScope(scope),
       );
       return undefined;
     }
@@ -199,7 +227,8 @@ export class SessionManagerPersistence extends SessionManagerCore {
             ? { appendIntent: options.appendIntent }
             : undefined,
         ),
-        `Session transcript entry was not persisted: ${entry.id}`,
+        `Session transcript entry was not persisted: ${entry.id} ` +
+          describeTranscriptWriteScope(scope),
       );
       return undefined;
     }
@@ -215,7 +244,10 @@ export class SessionManagerPersistence extends SessionManagerCore {
     } satisfies Parameters<typeof appendTranscriptMessageSync>[1];
     const result = appendTranscriptMessageSync(scope, appendOptions);
     if (!result) {
-      throw new Error(`Session transcript message was not persisted: ${entry.id}`);
+      throw new Error(
+        `Session transcript message was not persisted: ${entry.id} ` +
+          describeTranscriptWriteScope(scope),
+      );
     }
     if (result.messageId !== entry.id) {
       const idempotencyKey =

--- a/src/agents/sessions/session-manager.redaction.test.ts
+++ b/src/agents/sessions/session-manager.redaction.test.ts
@@ -1,0 +1,129 @@
+// Split out of session-manager.test.ts to stay under the repo's max-lines cap;
+// covers the redacted-identity boundaries for the transcript-append refusal path.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { formatSqliteSessionFileMarker } from "../../config/sessions/legacy-sqlite-marker.js";
+import { upsertSessionEntry } from "../../config/sessions/session-accessor.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+import { redactIdentifier } from "../../logging/redact-identifier.js";
+import { resolveCompactionFailureReason } from "../embedded-agent-runner/compact-reasons.js";
+import { SessionManager } from "./session-manager.js";
+
+const tempPaths: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-manager-redaction-"));
+  tempPaths.push(dir);
+  return dir;
+}
+
+describe("SessionManager.open redaction", () => {
+  afterEach(async () => {
+    await Promise.all(
+      tempPaths.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it("renders equal hashes when a sessionId lands in the sessionKey field", async () => {
+    const dir = await makeTempDir();
+    const storePath = path.join(dir, "sessions.json");
+    // Simulates the bug this redaction is meant to stay diagnosable for: a
+    // sessionId value substituted into the sessionKey field.
+    const collidingIdentity = "agent:main:whatsapp:direct:+15559990000";
+    const sessionId = collidingIdentity;
+    const sessionKey = collidingIdentity;
+    const marker = formatSqliteSessionFileMarker({ agentId: "main", sessionId, storePath });
+    const scope = { agentId: "main", sessionId, sessionKey, storePath };
+    await upsertSessionEntry(scope, { sessionFile: marker, sessionId, updatedAt: 10 });
+    // The legacy sqlite marker format can't carry a colon-bearing sessionId
+    // (its codec splits on `:`), so open directly with the intended scope
+    // instead of round-tripping it through parseSqliteSessionFileMarker.
+    const sessionManager = SessionManager.open(
+      { agentId: "main", sessionId, storePath, sessionKey },
+      dir,
+    );
+    await upsertSessionEntry(
+      { agentId: "main", sessionKey, storePath },
+      { sessionId: "replacement-session", updatedAt: 20 },
+    );
+
+    let thrown: unknown;
+    try {
+      sessionManager.appendModelChange("openai", "gpt-5.5");
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    const message = (thrown as Error).message;
+
+    expect(message).not.toContain(collidingIdentity);
+
+    // sessionKey and sessionId were the same raw value here, which is the exact
+    // case this redaction must keep diagnosable: the two rendered hashes match.
+    const keyHash = message.match(/sessionKeyHash=(\S+)/)?.[1];
+    const idHash = message.match(/sessionIdHash=(\S+)/)?.[1];
+    expect(keyHash).toBe(redactIdentifier(sessionKey));
+    expect(idHash).toBe(redactIdentifier(sessionId));
+    expect(keyHash).toBe(idHash);
+  });
+
+  it("redacts newlines, ANSI escapes and oversized identifiers to a fixed-width single-line hash", () => {
+    const withNewlineAndAnsi = "agent:main:whatsapp:direct:+1555\n\x1b[31mHIJACK\x1b[0m9990000";
+    const oversized = `agent:main:whatsapp:direct:+1555${"9".repeat(10_000)}`;
+
+    for (const raw of [withNewlineAndAnsi, oversized]) {
+      const redacted = redactIdentifier(raw);
+      expect(redacted).not.toContain(raw);
+      expect(redacted).not.toContain("\n");
+      expect(redacted).not.toContain("\x1b");
+      expect(redacted).toMatch(/^sha256:[0-9a-f]{12}$/);
+    }
+  });
+
+  it("keeps the operator-facing compaction failure reason single-line and hash-only for a hostile sessionKey", async () => {
+    const dir = await makeTempDir();
+    const storePath = path.join(dir, "sessions.json");
+    const sessionId = "hostile-sessionkey-target";
+    // A canonical sessionKey can carry a channel peer id, and nothing upstream
+    // guarantees it is a single clean line before it reaches this refusal path.
+    const sessionKey = "agent:main:whatsapp:direct:+1555\n\x1b[31mHIJACK\x1b[0m9990000";
+    const marker = formatSqliteSessionFileMarker({ agentId: "main", sessionId, storePath });
+    const scope = { agentId: "main", sessionId, sessionKey, storePath };
+    await upsertSessionEntry(scope, { sessionFile: marker, sessionId, updatedAt: 10 });
+    const sessionManager = SessionManager.open(
+      { agentId: "main", sessionId, storePath, sessionKey },
+      dir,
+    );
+    await upsertSessionEntry(
+      { agentId: "main", sessionKey, storePath },
+      { sessionId: "replacement-session", updatedAt: 20 },
+    );
+
+    let thrown: unknown;
+    try {
+      sessionManager.appendModelChange("openai", "gpt-5.5");
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+
+    // `result.reason` is exactly `formatErrorMessage(thrown)` run through
+    // `resolveCompactionFailureReason` (src/agents/embedded-agent-runner/
+    // direct-compaction.ts): both the sessions.compact RPC payload
+    // (src/gateway/server-methods/sessions-compact.ts, `reason: result.reason`)
+    // and the /compact chat reply's `formatCompactionReason` default branch
+    // (src/auto-reply/reply/commands-compact.ts) forward that exact string to
+    // the operator unmodified for an unclassified reason such as this one.
+    const operatorFacingReason = resolveCompactionFailureReason({
+      reason: formatErrorMessage(thrown),
+    });
+
+    expect(operatorFacingReason).not.toContain(sessionKey);
+    expect(operatorFacingReason).not.toContain(sessionId);
+    expect(operatorFacingReason).not.toContain("\n");
+    expect(operatorFacingReason).not.toContain("\x1b");
+    expect(operatorFacingReason).toContain(`sessionKeyHash=${redactIdentifier(sessionKey)}`);
+  });
+});

--- a/src/agents/sessions/session-manager.redaction.test.ts
+++ b/src/agents/sessions/session-manager.redaction.test.ts
@@ -4,14 +4,48 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { formatSqliteSessionFileMarker } from "../../config/sessions/legacy-sqlite-marker.js";
-import { upsertSessionEntry } from "../../config/sessions/session-accessor.js";
+import {
+  formatSqliteSessionFileMarker,
+  parseSqliteSessionFileMarker,
+} from "../../config/sessions/legacy-sqlite-marker.js";
+import {
+  appendTranscriptMessage,
+  upsertSessionEntryCore,
+} from "../../config/sessions/session-accessor.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { redactIdentifier } from "../../logging/redact-identifier.js";
 import { resolveCompactionFailureReason } from "../embedded-agent-runner/compact-reasons.js";
 import { SessionManager } from "./session-manager.js";
 
 const tempPaths: string[] = [];
+
+function openMarker(marker: string, sessionKey: string, cwd: string): SessionManager {
+  const target = parseSqliteSessionFileMarker(marker);
+  if (!target) {
+    throw new Error("expected SQLite transcript marker fixture");
+  }
+  return SessionManager.open({ ...target, sessionKey }, cwd);
+}
+
+function buildAssistantMessage(text: string) {
+  return {
+    role: "assistant" as const,
+    content: [{ type: "text" as const, text }],
+    api: "messages" as const,
+    provider: "anthropic" as const,
+    model: "sonnet-4.6" as const,
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop" as const,
+    timestamp: Date.now(),
+  };
+}
 
 async function makeTempDir(): Promise<string> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-manager-redaction-"));
@@ -36,7 +70,7 @@ describe("SessionManager.open redaction", () => {
     const sessionKey = collidingIdentity;
     const marker = formatSqliteSessionFileMarker({ agentId: "main", sessionId, storePath });
     const scope = { agentId: "main", sessionId, sessionKey, storePath };
-    await upsertSessionEntry(scope, { sessionFile: marker, sessionId, updatedAt: 10 });
+    await upsertSessionEntryCore(scope, { sessionFile: marker, sessionId, updatedAt: 10 });
     // The legacy sqlite marker format can't carry a colon-bearing sessionId
     // (its codec splits on `:`), so open directly with the intended scope
     // instead of round-tripping it through parseSqliteSessionFileMarker.
@@ -44,7 +78,7 @@ describe("SessionManager.open redaction", () => {
       { agentId: "main", sessionId, storePath, sessionKey },
       dir,
     );
-    await upsertSessionEntry(
+    await upsertSessionEntryCore(
       { agentId: "main", sessionKey, storePath },
       { sessionId: "replacement-session", updatedAt: 20 },
     );
@@ -91,12 +125,12 @@ describe("SessionManager.open redaction", () => {
     const sessionKey = "agent:main:whatsapp:direct:+1555\n\x1b[31mHIJACK\x1b[0m9990000";
     const marker = formatSqliteSessionFileMarker({ agentId: "main", sessionId, storePath });
     const scope = { agentId: "main", sessionId, sessionKey, storePath };
-    await upsertSessionEntry(scope, { sessionFile: marker, sessionId, updatedAt: 10 });
+    await upsertSessionEntryCore(scope, { sessionFile: marker, sessionId, updatedAt: 10 });
     const sessionManager = SessionManager.open(
       { agentId: "main", sessionId, storePath, sessionKey },
       dir,
     );
-    await upsertSessionEntry(
+    await upsertSessionEntryCore(
       { agentId: "main", sessionKey, storePath },
       { sessionId: "replacement-session", updatedAt: 20 },
     );
@@ -125,5 +159,81 @@ describe("SessionManager.open redaction", () => {
     expect(operatorFacingReason).not.toContain("\n");
     expect(operatorFacingReason).not.toContain("\x1b");
     expect(operatorFacingReason).toContain(`sessionKeyHash=${redactIdentifier(sessionKey)}`);
+  });
+
+  it("rejects persistence after the session target rebounds", async () => {
+    const dir = await makeTempDir();
+    const storePath = path.join(dir, "sessions.json");
+    const sessionId = "sqlite-prompt-release-rebound";
+    // Canonical session keys can embed a channel peer id; this fixture proves
+    // that value never reaches the refusal exception raw.
+    const sessionKey = "agent:main:whatsapp:direct:+15551234567";
+    const marker = formatSqliteSessionFileMarker({ agentId: "main", sessionId, storePath });
+    const scope = { agentId: "main", sessionId, sessionKey, storePath };
+    await upsertSessionEntryCore(scope, { sessionFile: marker, sessionId, updatedAt: 10 });
+    const user = await appendTranscriptMessage(scope, {
+      cwd: dir,
+      eventId: "rebound-user",
+      message: { role: "user", content: "question", timestamp: 1 },
+    });
+    const assistant = await appendTranscriptMessage(scope, {
+      cwd: dir,
+      eventId: "rebound-assistant",
+      message: buildAssistantMessage("answer"),
+      parentId: user.messageId,
+    });
+    const sessionManager = openMarker(marker, sessionKey, dir);
+    await upsertSessionEntryCore(
+      { agentId: "main", sessionKey, storePath },
+      { sessionId: "replacement-session", updatedAt: 20 },
+    );
+
+    try {
+      sessionManager.appendCompaction("late summary", assistant.messageId, 42);
+      throw new Error("expected rebound compaction persistence to fail");
+    } catch (error) {
+      expect(error).toMatchObject({
+        cause: {
+          actualSessionId: "replacement-session",
+          code: "session-rebound",
+          expectedSessionId: sessionId,
+          sessionKey,
+        },
+      });
+    }
+
+    const entriesBeforeRejectedAppends = sessionManager.getEntries();
+    const leafBeforeRejectedAppends = sessionManager.getLeafId();
+    const appendParentBeforeRejectedAppends = sessionManager.getAppendParentId();
+    expect(() => sessionManager.branchWithSummary(null, "late summary")).toThrow(
+      "entry was not persisted",
+    );
+    expect(() => sessionManager.appendModelChange("openai", "gpt-5.5")).toThrow(
+      "entry was not persisted",
+    );
+    // The refused append must name the identity it was scoped to, but only as a
+    // stable hash: this message surfaces to operators verbatim through /compact
+    // and sessions.compact as result.reason, and the raw sessionKey can embed a
+    // channel peer id such as a phone number.
+    expect(() => sessionManager.appendModelChange("openai", "gpt-5.5")).toThrow(
+      `sessionKeyHash=${redactIdentifier(sessionKey)}`,
+    );
+    expect(() => sessionManager.appendModelChange("openai", "gpt-5.5")).toThrow(
+      `sessionIdHash=${redactIdentifier(sessionId)}`,
+    );
+    expect(() => sessionManager.appendModelChange("openai", "gpt-5.5")).not.toThrow(sessionKey);
+    expect(() => sessionManager.appendModelChange("openai", "gpt-5.5")).not.toThrow(sessionId);
+    expect(() =>
+      sessionManager.appendMessage({ role: "user", content: "late message", timestamp: 1 }),
+    ).toThrow("message was not persisted");
+    expect(() =>
+      sessionManager.appendMessage({ role: "user", content: "late message", timestamp: 1 }),
+    ).toThrow(`sessionKeyHash=${redactIdentifier(sessionKey)}`);
+    expect(() =>
+      sessionManager.appendMessage({ role: "user", content: "late message", timestamp: 1 }),
+    ).not.toThrow(sessionKey);
+    expect(sessionManager.getEntries()).toEqual(entriesBeforeRejectedAppends);
+    expect(sessionManager.getLeafId()).toBe(leafBeforeRejectedAppends);
+    expect(sessionManager.getAppendParentId()).toBe(appendParentBeforeRejectedAppends);
   });
 });

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -16,7 +16,6 @@ import {
   updateSessionEntry,
   upsertSessionEntryCore,
 } from "../../config/sessions/session-accessor.js";
-import { redactIdentifier } from "../../logging/redact-identifier.js";
 import {
   buildSessionContext,
   CURRENT_SESSION_VERSION,
@@ -751,82 +750,6 @@ describe("SessionManager.open", () => {
     ]);
 
     expect(loaded.getCwd()).toBe(dir);
-  });
-
-  it("rejects persistence after the session target rebounds", async () => {
-    const dir = tempDirs.make("openclaw-session-manager-");
-    const storePath = path.join(dir, "sessions.json");
-    const sessionId = "sqlite-prompt-release-rebound";
-    // Canonical session keys can embed a channel peer id; this fixture proves
-    // that value never reaches the refusal exception raw.
-    const sessionKey = "agent:main:whatsapp:direct:+15551234567";
-    const marker = formatSqliteSessionFileMarker({ agentId: "main", sessionId, storePath });
-    const scope = { agentId: "main", sessionId, sessionKey, storePath };
-    await upsertSessionEntryCore(scope, { sessionFile: marker, sessionId, updatedAt: 10 });
-    const user = await appendTranscriptMessage(scope, {
-      cwd: dir,
-      eventId: "rebound-user",
-      message: { role: "user", content: "question", timestamp: 1 },
-    });
-    const assistant = await appendTranscriptMessage(scope, {
-      cwd: dir,
-      eventId: "rebound-assistant",
-      message: buildAssistantMessage("answer"),
-      parentId: user.messageId,
-    });
-    const sessionManager = openMarker(marker, sessionKey, dir);
-    await upsertSessionEntryCore(
-      { agentId: "main", sessionKey, storePath },
-      { sessionId: "replacement-session", updatedAt: 20 },
-    );
-
-    try {
-      sessionManager.appendCompaction("late summary", assistant.messageId, 42);
-      throw new Error("expected rebound compaction persistence to fail");
-    } catch (error) {
-      expect(error).toMatchObject({
-        cause: {
-          actualSessionId: "replacement-session",
-          code: "session-rebound",
-          expectedSessionId: sessionId,
-          sessionKey,
-        },
-      });
-    }
-
-    const entriesBeforeRejectedAppends = sessionManager.getEntries();
-    const leafBeforeRejectedAppends = sessionManager.getLeafId();
-    const appendParentBeforeRejectedAppends = sessionManager.getAppendParentId();
-    expect(() => sessionManager.branchWithSummary(null, "late summary")).toThrow(
-      "entry was not persisted",
-    );
-    expect(() => sessionManager.appendModelChange("openai", "gpt-5.5")).toThrow(
-      "entry was not persisted",
-    );
-    // The refused append must name the identity it was scoped to, but only as a
-    // stable hash: this message surfaces to operators verbatim through /compact
-    // and sessions.compact as result.reason, and the raw sessionKey can embed a
-    // channel peer id such as a phone number.
-    expect(() => sessionManager.appendModelChange("openai", "gpt-5.5")).toThrow(
-      `sessionKeyHash=${redactIdentifier(sessionKey)}`,
-    );
-    expect(() => sessionManager.appendModelChange("openai", "gpt-5.5")).toThrow(
-      `sessionIdHash=${redactIdentifier(sessionId)}`,
-    );
-    expect(() => sessionManager.appendModelChange("openai", "gpt-5.5")).not.toThrow(sessionKey);
-    expect(() => sessionManager.appendModelChange("openai", "gpt-5.5")).not.toThrow(sessionId);
-    expect(() =>
-      sessionManager.appendMessage({ role: "user", content: "late message", timestamp: 1 }),
-    ).toThrow("message was not persisted");
-    expect(() =>
-      sessionManager.appendMessage({ role: "user", content: "late message", timestamp: 1 }),
-    ).toThrow(`sessionKeyHash=${redactIdentifier(sessionKey)}`);
-    expect(() =>
-      sessionManager.appendMessage({ role: "user", content: "late message", timestamp: 1 }),
-    ).not.toThrow(sessionKey);
-    expect(sessionManager.getEntries()).toEqual(entriesBeforeRejectedAppends);
-    expect(sessionManager.getLeafId()).toBe(leafBeforeRejectedAppends);
-    expect(sessionManager.getAppendParentId()).toBe(appendParentBeforeRejectedAppends);
   });
 
   it("reloads SQLite markers through setSessionFile without switching to file paths", async () => {

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -16,7 +16,9 @@ import {
   updateSessionEntry,
   upsertSessionEntryCore,
 } from "../../config/sessions/session-accessor.js";
+import { formatErrorMessage } from "../../infra/errors.js";
 import { redactIdentifier } from "../../logging/redact-identifier.js";
+import { resolveCompactionFailureReason } from "../embedded-agent-runner/compact-reasons.js";
 import {
   buildSessionContext,
   CURRENT_SESSION_VERSION,
@@ -883,6 +885,51 @@ describe("SessionManager.open", () => {
       expect(redacted).not.toContain("\x1b");
       expect(redacted).toMatch(/^sha256:[0-9a-f]{12}$/);
     }
+  });
+
+  it("keeps the operator-facing compaction failure reason single-line and hash-only for a hostile sessionKey", async () => {
+    const dir = await makeTempDir();
+    const storePath = path.join(dir, "sessions.json");
+    const sessionId = "hostile-sessionkey-target";
+    // A canonical sessionKey can carry a channel peer id, and nothing upstream
+    // guarantees it is a single clean line before it reaches this refusal path.
+    const sessionKey = "agent:main:whatsapp:direct:+1555\n\x1b[31mHIJACK\x1b[0m9990000";
+    const marker = formatSqliteSessionFileMarker({ agentId: "main", sessionId, storePath });
+    const scope = { agentId: "main", sessionId, sessionKey, storePath };
+    await upsertSessionEntry(scope, { sessionFile: marker, sessionId, updatedAt: 10 });
+    const sessionManager = SessionManager.open(
+      { agentId: "main", sessionId, storePath, sessionKey },
+      dir,
+    );
+    await upsertSessionEntry(
+      { agentId: "main", sessionKey, storePath },
+      { sessionId: "replacement-session", updatedAt: 20 },
+    );
+
+    let thrown: unknown;
+    try {
+      sessionManager.appendModelChange("openai", "gpt-5.5");
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+
+    // `result.reason` is exactly `formatErrorMessage(thrown)` run through
+    // `resolveCompactionFailureReason` (src/agents/embedded-agent-runner/
+    // direct-compaction.ts): both the sessions.compact RPC payload
+    // (src/gateway/server-methods/sessions-compact.ts, `reason: result.reason`)
+    // and the /compact chat reply's `formatCompactionReason` default branch
+    // (src/auto-reply/reply/commands-compact.ts) forward that exact string to
+    // the operator unmodified for an unclassified reason such as this one.
+    const operatorFacingReason = resolveCompactionFailureReason({
+      reason: formatErrorMessage(thrown),
+    });
+
+    expect(operatorFacingReason).not.toContain(sessionKey);
+    expect(operatorFacingReason).not.toContain(sessionId);
+    expect(operatorFacingReason).not.toContain("\n");
+    expect(operatorFacingReason).not.toContain("\x1b");
+    expect(operatorFacingReason).toContain(`sessionKeyHash=${redactIdentifier(sessionKey)}`);
   });
 
   it("reloads SQLite markers through setSessionFile without switching to file paths", async () => {

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -800,9 +800,21 @@ describe("SessionManager.open", () => {
     expect(() => sessionManager.appendModelChange("openai", "gpt-5.5")).toThrow(
       "entry was not persisted",
     );
+    // The refused append must name the identity it was scoped to. Without it the
+    // caller can only report that a write failed, and a mismatched session key
+    // reaches the operator as an unexplained failure.
+    expect(() => sessionManager.appendModelChange("openai", "gpt-5.5")).toThrow(
+      `sessionKey=${sessionKey}`,
+    );
+    expect(() => sessionManager.appendModelChange("openai", "gpt-5.5")).toThrow(
+      `sessionId=${sessionId}`,
+    );
     expect(() =>
       sessionManager.appendMessage({ role: "user", content: "late message", timestamp: 1 }),
     ).toThrow("message was not persisted");
+    expect(() =>
+      sessionManager.appendMessage({ role: "user", content: "late message", timestamp: 1 }),
+    ).toThrow(`sessionKey=${sessionKey}`);
     expect(sessionManager.getEntries()).toEqual(entriesBeforeRejectedAppends);
     expect(sessionManager.getLeafId()).toBe(leafBeforeRejectedAppends);
     expect(sessionManager.getAppendParentId()).toBe(appendParentBeforeRejectedAppends);

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -16,6 +16,7 @@ import {
   updateSessionEntry,
   upsertSessionEntryCore,
 } from "../../config/sessions/session-accessor.js";
+import { redactIdentifier } from "../../logging/redact-identifier.js";
 import {
   buildSessionContext,
   CURRENT_SESSION_VERSION,
@@ -756,7 +757,9 @@ describe("SessionManager.open", () => {
     const dir = tempDirs.make("openclaw-session-manager-");
     const storePath = path.join(dir, "sessions.json");
     const sessionId = "sqlite-prompt-release-rebound";
-    const sessionKey = "agent:main:dashboard:sqlite-prompt-release-rebound";
+    // Canonical session keys can embed a channel peer id; this fixture proves
+    // that value never reaches the refusal exception raw.
+    const sessionKey = "agent:main:whatsapp:direct:+15551234567";
     const marker = formatSqliteSessionFileMarker({ agentId: "main", sessionId, storePath });
     const scope = { agentId: "main", sessionId, sessionKey, storePath };
     await upsertSessionEntryCore(scope, { sessionFile: marker, sessionId, updatedAt: 10 });
@@ -800,24 +803,86 @@ describe("SessionManager.open", () => {
     expect(() => sessionManager.appendModelChange("openai", "gpt-5.5")).toThrow(
       "entry was not persisted",
     );
-    // The refused append must name the identity it was scoped to. Without it the
-    // caller can only report that a write failed, and a mismatched session key
-    // reaches the operator as an unexplained failure.
+    // The refused append must name the identity it was scoped to, but only as a
+    // stable hash: this message surfaces to operators verbatim through /compact
+    // and sessions.compact as result.reason, and the raw sessionKey can embed a
+    // channel peer id such as a phone number.
     expect(() => sessionManager.appendModelChange("openai", "gpt-5.5")).toThrow(
-      `sessionKey=${sessionKey}`,
+      `sessionKeyHash=${redactIdentifier(sessionKey)}`,
     );
     expect(() => sessionManager.appendModelChange("openai", "gpt-5.5")).toThrow(
-      `sessionId=${sessionId}`,
+      `sessionIdHash=${redactIdentifier(sessionId)}`,
     );
+    expect(() => sessionManager.appendModelChange("openai", "gpt-5.5")).not.toThrow(sessionKey);
+    expect(() => sessionManager.appendModelChange("openai", "gpt-5.5")).not.toThrow(sessionId);
     expect(() =>
       sessionManager.appendMessage({ role: "user", content: "late message", timestamp: 1 }),
     ).toThrow("message was not persisted");
     expect(() =>
       sessionManager.appendMessage({ role: "user", content: "late message", timestamp: 1 }),
-    ).toThrow(`sessionKey=${sessionKey}`);
+    ).toThrow(`sessionKeyHash=${redactIdentifier(sessionKey)}`);
+    expect(() =>
+      sessionManager.appendMessage({ role: "user", content: "late message", timestamp: 1 }),
+    ).not.toThrow(sessionKey);
     expect(sessionManager.getEntries()).toEqual(entriesBeforeRejectedAppends);
     expect(sessionManager.getLeafId()).toBe(leafBeforeRejectedAppends);
     expect(sessionManager.getAppendParentId()).toBe(appendParentBeforeRejectedAppends);
+  });
+
+  it("renders equal hashes when a sessionId lands in the sessionKey field", async () => {
+    const dir = await makeTempDir();
+    const storePath = path.join(dir, "sessions.json");
+    // Simulates the bug this redaction is meant to stay diagnosable for: a
+    // sessionId value substituted into the sessionKey field.
+    const collidingIdentity = "agent:main:whatsapp:direct:+15559990000";
+    const sessionId = collidingIdentity;
+    const sessionKey = collidingIdentity;
+    const marker = formatSqliteSessionFileMarker({ agentId: "main", sessionId, storePath });
+    const scope = { agentId: "main", sessionId, sessionKey, storePath };
+    await upsertSessionEntry(scope, { sessionFile: marker, sessionId, updatedAt: 10 });
+    // The legacy sqlite marker format can't carry a colon-bearing sessionId
+    // (its codec splits on `:`), so open directly with the intended scope
+    // instead of round-tripping it through parseSqliteSessionFileMarker.
+    const sessionManager = SessionManager.open(
+      { agentId: "main", sessionId, storePath, sessionKey },
+      dir,
+    );
+    await upsertSessionEntry(
+      { agentId: "main", sessionKey, storePath },
+      { sessionId: "replacement-session", updatedAt: 20 },
+    );
+
+    let thrown: unknown;
+    try {
+      sessionManager.appendModelChange("openai", "gpt-5.5");
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    const message = (thrown as Error).message;
+
+    expect(message).not.toContain(collidingIdentity);
+
+    // sessionKey and sessionId were the same raw value here, which is the exact
+    // case this redaction must keep diagnosable: the two rendered hashes match.
+    const keyHash = message.match(/sessionKeyHash=(\S+)/)?.[1];
+    const idHash = message.match(/sessionIdHash=(\S+)/)?.[1];
+    expect(keyHash).toBe(redactIdentifier(sessionKey));
+    expect(idHash).toBe(redactIdentifier(sessionId));
+    expect(keyHash).toBe(idHash);
+  });
+
+  it("redacts newlines, ANSI escapes and oversized identifiers to a fixed-width single-line hash", () => {
+    const withNewlineAndAnsi = "agent:main:whatsapp:direct:+1555\n\x1b[31mHIJACK\x1b[0m9990000";
+    const oversized = `agent:main:whatsapp:direct:+1555${"9".repeat(10_000)}`;
+
+    for (const raw of [withNewlineAndAnsi, oversized]) {
+      const redacted = redactIdentifier(raw);
+      expect(redacted).not.toContain(raw);
+      expect(redacted).not.toContain("\n");
+      expect(redacted).not.toContain("\x1b");
+      expect(redacted).toMatch(/^sha256:[0-9a-f]{12}$/);
+    }
   });
 
   it("reloads SQLite markers through setSessionFile without switching to file paths", async () => {

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -16,9 +16,7 @@ import {
   updateSessionEntry,
   upsertSessionEntryCore,
 } from "../../config/sessions/session-accessor.js";
-import { formatErrorMessage } from "../../infra/errors.js";
 import { redactIdentifier } from "../../logging/redact-identifier.js";
-import { resolveCompactionFailureReason } from "../embedded-agent-runner/compact-reasons.js";
 import {
   buildSessionContext,
   CURRENT_SESSION_VERSION,
@@ -829,107 +827,6 @@ describe("SessionManager.open", () => {
     expect(sessionManager.getEntries()).toEqual(entriesBeforeRejectedAppends);
     expect(sessionManager.getLeafId()).toBe(leafBeforeRejectedAppends);
     expect(sessionManager.getAppendParentId()).toBe(appendParentBeforeRejectedAppends);
-  });
-
-  it("renders equal hashes when a sessionId lands in the sessionKey field", async () => {
-    const dir = await makeTempDir();
-    const storePath = path.join(dir, "sessions.json");
-    // Simulates the bug this redaction is meant to stay diagnosable for: a
-    // sessionId value substituted into the sessionKey field.
-    const collidingIdentity = "agent:main:whatsapp:direct:+15559990000";
-    const sessionId = collidingIdentity;
-    const sessionKey = collidingIdentity;
-    const marker = formatSqliteSessionFileMarker({ agentId: "main", sessionId, storePath });
-    const scope = { agentId: "main", sessionId, sessionKey, storePath };
-    await upsertSessionEntry(scope, { sessionFile: marker, sessionId, updatedAt: 10 });
-    // The legacy sqlite marker format can't carry a colon-bearing sessionId
-    // (its codec splits on `:`), so open directly with the intended scope
-    // instead of round-tripping it through parseSqliteSessionFileMarker.
-    const sessionManager = SessionManager.open(
-      { agentId: "main", sessionId, storePath, sessionKey },
-      dir,
-    );
-    await upsertSessionEntry(
-      { agentId: "main", sessionKey, storePath },
-      { sessionId: "replacement-session", updatedAt: 20 },
-    );
-
-    let thrown: unknown;
-    try {
-      sessionManager.appendModelChange("openai", "gpt-5.5");
-    } catch (err) {
-      thrown = err;
-    }
-    expect(thrown).toBeInstanceOf(Error);
-    const message = (thrown as Error).message;
-
-    expect(message).not.toContain(collidingIdentity);
-
-    // sessionKey and sessionId were the same raw value here, which is the exact
-    // case this redaction must keep diagnosable: the two rendered hashes match.
-    const keyHash = message.match(/sessionKeyHash=(\S+)/)?.[1];
-    const idHash = message.match(/sessionIdHash=(\S+)/)?.[1];
-    expect(keyHash).toBe(redactIdentifier(sessionKey));
-    expect(idHash).toBe(redactIdentifier(sessionId));
-    expect(keyHash).toBe(idHash);
-  });
-
-  it("redacts newlines, ANSI escapes and oversized identifiers to a fixed-width single-line hash", () => {
-    const withNewlineAndAnsi = "agent:main:whatsapp:direct:+1555\n\x1b[31mHIJACK\x1b[0m9990000";
-    const oversized = `agent:main:whatsapp:direct:+1555${"9".repeat(10_000)}`;
-
-    for (const raw of [withNewlineAndAnsi, oversized]) {
-      const redacted = redactIdentifier(raw);
-      expect(redacted).not.toContain(raw);
-      expect(redacted).not.toContain("\n");
-      expect(redacted).not.toContain("\x1b");
-      expect(redacted).toMatch(/^sha256:[0-9a-f]{12}$/);
-    }
-  });
-
-  it("keeps the operator-facing compaction failure reason single-line and hash-only for a hostile sessionKey", async () => {
-    const dir = await makeTempDir();
-    const storePath = path.join(dir, "sessions.json");
-    const sessionId = "hostile-sessionkey-target";
-    // A canonical sessionKey can carry a channel peer id, and nothing upstream
-    // guarantees it is a single clean line before it reaches this refusal path.
-    const sessionKey = "agent:main:whatsapp:direct:+1555\n\x1b[31mHIJACK\x1b[0m9990000";
-    const marker = formatSqliteSessionFileMarker({ agentId: "main", sessionId, storePath });
-    const scope = { agentId: "main", sessionId, sessionKey, storePath };
-    await upsertSessionEntry(scope, { sessionFile: marker, sessionId, updatedAt: 10 });
-    const sessionManager = SessionManager.open(
-      { agentId: "main", sessionId, storePath, sessionKey },
-      dir,
-    );
-    await upsertSessionEntry(
-      { agentId: "main", sessionKey, storePath },
-      { sessionId: "replacement-session", updatedAt: 20 },
-    );
-
-    let thrown: unknown;
-    try {
-      sessionManager.appendModelChange("openai", "gpt-5.5");
-    } catch (err) {
-      thrown = err;
-    }
-    expect(thrown).toBeInstanceOf(Error);
-
-    // `result.reason` is exactly `formatErrorMessage(thrown)` run through
-    // `resolveCompactionFailureReason` (src/agents/embedded-agent-runner/
-    // direct-compaction.ts): both the sessions.compact RPC payload
-    // (src/gateway/server-methods/sessions-compact.ts, `reason: result.reason`)
-    // and the /compact chat reply's `formatCompactionReason` default branch
-    // (src/auto-reply/reply/commands-compact.ts) forward that exact string to
-    // the operator unmodified for an unclassified reason such as this one.
-    const operatorFacingReason = resolveCompactionFailureReason({
-      reason: formatErrorMessage(thrown),
-    });
-
-    expect(operatorFacingReason).not.toContain(sessionKey);
-    expect(operatorFacingReason).not.toContain(sessionId);
-    expect(operatorFacingReason).not.toContain("\n");
-    expect(operatorFacingReason).not.toContain("\x1b");
-    expect(operatorFacingReason).toContain(`sessionKeyHash=${redactIdentifier(sessionKey)}`);
   });
 
   it("reloads SQLite markers through setSessionFile without switching to file paths", async () => {


### PR DESCRIPTION
## What Problem This Solves

`appendTranscriptEventSync` returns `false` rather than throwing when the session
row cannot be matched. `persistSqliteRecord` turns that `false` into an error, but
the only identity it can name is the id of the event it was trying to write:

```
Session transcript entry was not persisted: 39782e9d
```

The one thing an operator needs — *which session identity missed* — is absent, and
the scope is right there in the same function. Through compaction the error is
bucketed further, so what actually reaches the operator is `outcome=failed
reason=unknown`.

The failure mode this hides in practice is a sessionId arriving in a `sessionKey`
field. Both are opaque strings, `readSessionEntryRow()` matches no row, and the
message above is identical to a genuine store problem. Diagnosing one instance of
this took five hours across four sessions and three agents, and produced two wrong
attributions along the way — first blaming a local plugin, then the SDK bridge —
before the real identity was recovered by reading the sqlite rows by hand. The
substitution itself is reported separately in #119018; this change is the other
half, and it is the half that decides whether the next person spends five hours or
five minutes.

The change is additive: the boolean contract of the append helpers is untouched,
no control flow moves, and the four throw sites in `persistSqliteRecord` gain
`sessionKeyHash=… sessionIdHash=… agentIdHash=…` from the scope they already hold.

## Identities are hashed, not raw

The first revision of this PR interpolated the three identifiers verbatim, which
the review correctly flagged as a disclosure and log-forging surface: a `sessionKey`
is externally supplied, only trimmed before acceptance, and can therefore carry
newlines or ANSI controls that let a refused append forge a log line or spoof the
`sessionId=` field that follows it.

Each field now renders through the repo's existing `redactIdentifier`
(`src/logging/redact-identifier.ts`, already used for identifier redaction
elsewhere), producing a fixed-width `sha256:<12-hex>` token. Two properties follow
by construction, not by validation:

- The output alphabet is `sha256:` plus hex, so a newline, an ANSI escape, or an
  oversized value can never reach the message. The result is always single-line.
- Hashing is deterministic, so the diagnostic signal that motivates the change
  survives: a sessionId substituted into the `sessionKey` field renders **two equal
  hashes**, which is exactly the tell an operator needs.

## Evidence

Two tests in `src/agents/sessions/session-manager.test.ts`, both driving a genuine
refused append by rebinding the session row to a different sessionId:

- `renders equal hashes when a sessionId lands in the sessionKey field` — the
  substitution tell.
- `keeps the operator-facing compaction failure reason single-line and hash-only
  for a hostile sessionKey` — the output-boundary assertion. It pipes the real
  thrown message through the real `formatErrorMessage` and
  `resolveCompactionFailureReason`, i.e. the composition that actually reaches the
  operator, rather than reimplementing it. Both consumers forward that string
  unmodified for an unclassified reason: `sessions-compact.ts` (`reason:
  result.reason`, the `sessions.compact` RPC payload) and the
  `formatCompactionReason()` default branch in `commands-compact.ts` (the
  `/compact` chat reply line).

```
$ npx vitest run src/agents/sessions/session-manager.test.ts src/agents/embedded-agent-runner/compact-reasons.test.ts
 Test Files  3 passed (3)
      Tests  68 passed (68)
```

`tsc --noEmit -p .` reports no errors. Existing assertions elsewhere match these
messages by substring (`toThrow("entry was not persisted")`) and are unaffected.

## Runtime proof

Inspectable repro — no fixtures, no test harness, only the shipped functions.
Save as `proof.mts` at the repo root and run `npx tsx ./proof.mts`:

```ts
import fs from "node:fs/promises";
import os from "node:os";
import path from "node:path";
import { formatSqliteSessionFileMarker } from "./src/config/sessions/legacy-sqlite-marker.js";
import { upsertSessionEntry } from "./src/config/sessions/session-accessor.js";
import { formatErrorMessage } from "./src/infra/errors.js";
import { resolveCompactionFailureReason } from "./src/agents/embedded-agent-runner/compact-reasons.js";
import { SessionManager } from "./src/agents/sessions/session-manager.js";

const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-proof-119024-"));
const storePath = path.join(dir, "sessions.json");
const sessionId = "hostile-sessionkey-target";
const sessionKey = "agent:main:whatsapp:direct:+1555\n\x1b[31mHIJACK\x1b[0m9990000";
const marker = formatSqliteSessionFileMarker({ agentId: "main", sessionId, storePath });

await upsertSessionEntry(
  { agentId: "main", sessionId, sessionKey, storePath },
  { sessionFile: marker, sessionId, updatedAt: 10 },
);
const sessionManager = SessionManager.open(
  { agentId: "main", sessionId, sessionKey, storePath },
  dir,
);
// Another writer rebinds the same sessionKey to a different sessionId.
await upsertSessionEntry(
  { agentId: "main", sessionKey, storePath },
  { sessionId: "replacement-session", updatedAt: 20 },
);

let thrown: unknown;
try {
  sessionManager.appendModelChange("openai", "gpt-5.5");
} catch (err) {
  thrown = err;
}

const reason = resolveCompactionFailureReason({ reason: formatErrorMessage(thrown) });
console.log("raw sessionKey (JSON-escaped):", JSON.stringify(sessionKey));
console.log("thrown Error.message:", (thrown as Error).message);
console.log("operator-facing reason:", reason);
console.log("contains raw sessionKey:", reason.includes(sessionKey));
console.log("contains raw sessionId:", reason.includes(sessionId));
console.log("contains newline:", reason.includes("\n"));
console.log("contains ANSI ESC:", reason.includes("\x1b"));
await fs.rm(dir, { force: true, recursive: true });
```

**Before this PR's redaction commit (`8bd8afb56b`)** — the raw key lands in the
operator-facing string, the injected `HIJACK` breaks the line, and the forged
content sits where `sessionId=` is expected:

```
raw sessionKey (JSON-escaped): "agent:main:whatsapp:direct:+1555\n[31mHIJACK[0m9990000"
thrown Error.message: Session transcript header was not persisted: sessionKey=agent:main:whatsapp:direct:+1555
HIJACK9990000 sessionId=hostile-sessionkey-target agentId=main
operator-facing reason: Session transcript header was not persisted: sessionKey=agent:main:whatsapp:direct:+1555
HIJACK9990000 sessionId=hostile-sessionkey-target agentId=main
contains raw sessionKey: true
contains raw sessionId: true
contains newline: true
contains ANSI ESC: true
```

**At the current head** — single line, hash-only, nothing raw survives:

```
raw sessionKey (JSON-escaped): "agent:main:whatsapp:direct:+1555\n[31mHIJACK[0m9990000"
thrown Error.message: Session transcript header was not persisted: sessionKeyHash=sha256:d6ad89483bb9 sessionIdHash=sha256:918913db5dc3 agentIdHash=sha256:0d6e4079e367
operator-facing reason: Session transcript header was not persisted: sessionKeyHash=sha256:d6ad89483bb9 sessionIdHash=sha256:918913db5dc3 agentIdHash=sha256:0d6e4079e367
contains raw sessionKey: false
contains raw sessionId: false
contains newline: false
contains ANSI ESC: false
```

(The ANSI escapes are present in both raw outputs; GitHub strips them from the
rendered block above. The `contains ANSI ESC` line is the assertion that matters.)

The refusal here lands on the header-append branch (a freshly opened
`SessionManager` has `persistenceHeaderPending=true`), but it is the same
`describeTranscriptWriteScope` call on the entry branch.

## What the message looks like on the original incident

The five-hour diagnosis above, rendered with this change in place. The two equal
hashes are the whole finding — a sessionId was sitting in the session-key field:

```
Session transcript entry was not persisted: 39782e9d
  sessionKeyHash=sha256:2ca0d11bc1ee sessionIdHash=sha256:2ca0d11bc1ee agentIdHash=sha256:605306b83fe5
```

Both hashes are `redactIdentifier()` of the real identifiers recovered from that
database, and they are equal because the same value occupied both fields. The raw
identifiers are deliberately not reproduced here. Under the previous
`reason=unknown`, reaching that conclusion took five hours.
