### PR TITLE
test(qa): claim sessionless heartbeat coverage

### DIFF
--- a/qa/scenarios/runtime/gateway-rpc-automation.yaml
+++ b/qa/scenarios/runtime/gateway-rpc-automation.yaml
@@ -7,10 +7,13 @@ scenario:
   coverage:
     primary:
       - gateway.task-and-automation-apis
+      - agent-runtime.session-heartbeat-target-none
   objective: Verify the real Gateway persists cron RPC mutations, wakes a heartbeat into the agent runtime, and controls a Gateway-created agent task.
   successCriteria:
     - Cron add, get, list, update, and remove RPCs expose the persisted job state after each mutation.
-    - A wake RPC with mode now reaches the downstream model through the real heartbeat path.
+    - A wake RPC with mode now executes a real heartbeat turn whose provider returns a concrete reply.
+    - last-heartbeat records skipped status, target-none reason, and the provider reply preview.
+    - This scenario makes no channel delivery claim; target-none is asserted through the recorded heartbeat outcome.
     - A real agent RPC creates a running CLI task exposed through tasks.list and tasks.get.
     - tasks.cancel records the terminal cancelled state, and later agent completion does not overwrite it.
   docsRefs:


### PR DESCRIPTION
## What Problem This Solves

The QA inventory had no primary owner for
`agent-runtime.session-heartbeat-target-none`, even though the existing
Gateway automation E2E already executes the full behavior.

## Why This Change Was Made

Claim the existing real-Gateway proof and describe its actual boundary: `wake`
with `mode: now` runs a real heartbeat turn, the provider returns a concrete
reply, and `last-heartbeat` records `skipped`, `target-none`, and the reply
preview. This deliberately makes no channel-delivery claim and does not change
the runtime work discussed in https://github.com/openclaw/openclaw/pull/116373.

## User Impact

No runtime behavior changes. Maintainers can now select and audit the exact
sessionless heartbeat contract through the QA coverage inventory.

## Evidence

- Focused real-Gateway E2E: 1/1 passed after current-main rebase.
- Exact QA suite: 1/1 passed; structured evidence lists both primary IDs.
- Coverage query: one match, `gateway-rpc-automation`.
- Formatting and `git diff --check`: passed.
- Codex `gpt-5.6-sol`, high reasoning autoreview: clean.
- Production LOC: 0. Test LOC: 0. QA metadata: +3 net lines.
