### PR TITLE
test(qa): cover agent session streaming

### DIFF
--- a/qa/scenarios/agents/session-streaming.yaml
+++ b/qa/scenarios/agents/session-streaming.yaml
@@ -1,0 +1,27 @@
+title: Agent session streaming
+
+scenario:
+  id: session-streaming
+  surface: agent-runtime
+  category: agent-runtime.agent-turn-execution
+  coverage:
+    primary:
+      - agent-runtime.session-streaming
+  objective: Verify a generic agent RPC streams ordered Gateway events and persists one final assistant transcript message without channel delivery.
+  successCriteria:
+    - One real child Gateway runs an embedded agent turn against a deterministic paced streaming provider.
+    - Every assistant delta carries the accepted run and session identity with strictly increasing sequence numbers.
+    - Exactly one terminal lifecycle event follows streamed assistant content.
+    - Reassembled deltas equal the single persisted assistant transcript entry.
+    - No channel transport message is emitted.
+  docsRefs:
+    - docs/gateway/protocol.md
+    - docs/help/testing.md
+  codeRefs:
+    - src/infra/agent-events.ts
+    - src/gateway/server-chat.ts
+    - test/e2e/qa-lab/runtime/agent-session-streaming.e2e.test.ts
+  execution:
+    kind: vitest
+    path: test/e2e/qa-lab/runtime/agent-session-streaming.e2e.test.ts
+    summary: Run one real child Gateway and paced loopback provider while an authenticated operator captures ordered agent stream events and the canonical transcript.

--- a/test/e2e/qa-lab/runtime/agent-session-streaming.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/agent-session-streaming.e2e.test.ts
@@ -1,0 +1,366 @@
+import { createServer, type ServerResponse } from "node:http";
+import { setTimeout as delay } from "node:timers/promises";
+import { GatewayClient } from "openclaw/plugin-sdk/gateway-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { startQaGatewayChild } from "../../../../extensions/qa-lab/api.js";
+import {
+  GATEWAY_CLIENT_MODES,
+  GATEWAY_CLIENT_NAMES,
+} from "../../../../packages/gateway-protocol/src/client-info.js";
+
+const TEST_TIMEOUT_MS = 120_000;
+const REQUEST_TIMEOUT_MS = 20_000;
+const STREAM_INTERVAL_MS = 225;
+const MODEL_REF = "mock-openai/gpt-5.6-luna";
+const SESSION_KEY = "agent:qa:qa:session-streaming";
+const IDEMPOTENCY_KEY = "qa-session-streaming";
+const REQUEST_MESSAGE = "Return exactly SESSION-STREAMING-OK.";
+const STREAM_DELTAS = ["SESSION-", "STREAMING-", "OK"] as const;
+const TERMINAL_TEXT = STREAM_DELTAS.join("");
+
+type GatewayHandle = Awaited<ReturnType<typeof startQaGatewayChild>>;
+type AgentResult = {
+  runId?: string;
+  status?: string;
+};
+type GatewayEvent = {
+  event: string;
+  payload?: unknown;
+};
+type AgentEvent = {
+  runId?: string;
+  sessionKey?: string;
+  seq?: number;
+  stream?: string;
+  data?: {
+    delta?: string;
+    phase?: string;
+    text?: string;
+  };
+};
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  const errors: unknown[] = [];
+  for (const cleanup of cleanups.splice(0).toReversed()) {
+    try {
+      await cleanup();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  if (errors.length === 1) {
+    throw errors[0];
+  }
+  if (errors.length > 1) {
+    throw new AggregateError(errors, "session streaming cleanup failed");
+  }
+});
+
+function writeEvent(response: ServerResponse, event: unknown): void {
+  response.write(`data: ${JSON.stringify(event)}\n\n`);
+}
+
+async function writeStreamingResponse(response: ServerResponse): Promise<void> {
+  const message = {
+    type: "message",
+    id: "qa-session-streaming-message",
+    role: "assistant",
+    status: "completed",
+    content: [{ type: "output_text", text: TERMINAL_TEXT, annotations: [] }],
+  };
+  response.writeHead(200, {
+    "content-type": "text/event-stream",
+    "cache-control": "no-store",
+    connection: "keep-alive",
+  });
+  response.flushHeaders();
+  writeEvent(response, {
+    type: "response.output_item.added",
+    output_index: 0,
+    item: { ...message, status: "in_progress", content: [] },
+  });
+  for (const delta of STREAM_DELTAS) {
+    writeEvent(response, {
+      type: "response.output_text.delta",
+      item_id: message.id,
+      output_index: 0,
+      content_index: 0,
+      delta,
+    });
+    await delay(STREAM_INTERVAL_MS);
+  }
+  writeEvent(response, {
+    type: "response.output_text.done",
+    item_id: message.id,
+    output_index: 0,
+    content_index: 0,
+    text: TERMINAL_TEXT,
+  });
+  writeEvent(response, { type: "response.output_item.done", output_index: 0, item: message });
+  writeEvent(response, {
+    type: "response.completed",
+    response: {
+      id: "qa-session-streaming-response",
+      status: "completed",
+      output: [message],
+      usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+    },
+  });
+  response.end("data: [DONE]\n\n");
+}
+
+async function startStreamingProvider() {
+  const providerRequests: Array<Record<string, unknown>> = [];
+  const transportRequests: string[] = [];
+  const server = createServer((request, response) => {
+    void (async () => {
+      if (request.method === "GET" && request.url === "/v1/models") {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(
+          JSON.stringify({
+            data: [{ id: "gpt-5.6-luna", object: "model" }],
+          }),
+        );
+        return;
+      }
+      if (request.method === "POST" && request.url === "/v1/responses") {
+        const chunks: Buffer[] = [];
+        for await (const chunk of request) {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        }
+        providerRequests.push(
+          JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>,
+        );
+        await writeStreamingResponse(response);
+        return;
+      }
+      transportRequests.push(`${request.method ?? "UNKNOWN"} ${request.url ?? ""}`);
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end("{}");
+    })().catch((error: unknown) => {
+      response.writeHead(500).end(error instanceof Error ? error.message : String(error));
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("streaming provider did not bind a loopback port");
+  }
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    providerRequests,
+    transportRequests,
+    stop: async () => {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    },
+  };
+}
+
+async function connectOperator(
+  gateway: GatewayHandle,
+  events: GatewayEvent[],
+): Promise<GatewayClient> {
+  return await new Promise<GatewayClient>((resolve, reject) => {
+    let settled = false;
+    let timeout: ReturnType<typeof setTimeout>;
+    const finish = (error?: Error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      if (error) {
+        client.stop();
+        reject(error);
+        return;
+      }
+      resolve(client);
+    };
+    const client = new GatewayClient({
+      url: gateway.wsUrl,
+      token: gateway.token,
+      env: gateway.runtimeEnv,
+      role: "operator",
+      clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+      clientDisplayName: "Session streaming QA operator",
+      clientVersion: "1.0.0",
+      platform: process.platform,
+      mode: GATEWAY_CLIENT_MODES.BACKEND,
+      scopes: ["operator.admin", "operator.read", "operator.write"],
+      deviceIdentity: null,
+      requestTimeoutMs: REQUEST_TIMEOUT_MS,
+      onEvent: (event) => events.push(event),
+      onHelloOk: () => finish(),
+      onConnectError: (error) => finish(error),
+      onClose: (code, reason) => finish(new Error(`Gateway closed (${code}): ${reason}`)),
+    });
+    timeout = setTimeout(
+      () => finish(new Error(`Gateway client connection timed out:\n${gateway.logs()}`)),
+      REQUEST_TIMEOUT_MS,
+    );
+    timeout.unref();
+    client.start();
+  });
+}
+
+function asAgentEvent(event: GatewayEvent): AgentEvent | undefined {
+  return event.event === "agent" && event.payload && typeof event.payload === "object"
+    ? (event.payload as AgentEvent)
+    : undefined;
+}
+
+function messageRole(message: unknown): string | undefined {
+  return message && typeof message === "object"
+    ? String((message as { role?: unknown }).role ?? "")
+    : undefined;
+}
+
+function messageText(message: unknown): string {
+  if (!message || typeof message !== "object") {
+    return "";
+  }
+  const content = (message as { content?: unknown }).content;
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content
+    .flatMap((part) =>
+      part && typeof part === "object" && typeof (part as { text?: unknown }).text === "string"
+        ? [(part as { text: string }).text]
+        : [],
+    )
+    .join("\n");
+}
+
+describe("agent session streaming", () => {
+  it(
+    "orders Gateway deltas before one terminal event and persists one assistant message",
+    { timeout: TEST_TIMEOUT_MS },
+    async () => {
+      const provider = await startStreamingProvider();
+      cleanups.push(() => provider.stop());
+      const gateway = await startQaGatewayChild({
+        repoRoot: process.cwd(),
+        command: {
+          executablePath: process.execPath,
+          argsPrefix: ["--import", "tsx", "src/entry.ts"],
+          cwd: process.cwd(),
+          usePackagedPlugins: true,
+        },
+        providerBaseUrl: `${provider.baseUrl}/v1`,
+        providerMode: "mock-openai",
+        primaryModel: MODEL_REF,
+        alternateModel: MODEL_REF,
+        transportBaseUrl: provider.baseUrl,
+        controlUiEnabled: false,
+        fastMode: true,
+        runtimeEnvPatch: {
+          OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+          OPENCLAW_SKIP_CHANNELS: "1",
+          OPENCLAW_TEST_MINIMAL_GATEWAY: "1",
+        },
+        mutateConfig: ({ plugins: _plugins, ...config }) => config,
+      });
+      cleanups.push(() => gateway.stop());
+
+      const gatewayEvents: GatewayEvent[] = [];
+      const client = await connectOperator(gateway, gatewayEvents);
+      cleanups.push(() => client.stopAndWait({ timeoutMs: 1_000 }));
+      const accepted = await client.request<AgentResult>("agent", {
+        sessionKey: SESSION_KEY,
+        message: REQUEST_MESSAGE,
+        deliver: false,
+        idempotencyKey: IDEMPOTENCY_KEY,
+      });
+      expect(accepted).toMatchObject({
+        status: "accepted",
+        runId: IDEMPOTENCY_KEY,
+      });
+
+      const terminal = await client.request<AgentResult>(
+        "agent.wait",
+        { runId: IDEMPOTENCY_KEY, timeoutMs: 30_000 },
+        { timeoutMs: 35_000 },
+      );
+      expect(terminal).toMatchObject({
+        status: "ok",
+        runId: IDEMPOTENCY_KEY,
+      });
+
+      await vi.waitFor(
+        () => {
+          const runEvents = gatewayEvents
+            .map(asAgentEvent)
+            .filter((event): event is AgentEvent => event?.runId === IDEMPOTENCY_KEY);
+          expect(
+            runEvents.filter(
+              (event) =>
+                event.stream === "lifecycle" &&
+                (event.data?.phase === "end" || event.data?.phase === "error"),
+            ),
+          ).toHaveLength(1);
+        },
+        { interval: 20, timeout: REQUEST_TIMEOUT_MS },
+      );
+
+      const runEvents = gatewayEvents
+        .map(asAgentEvent)
+        .filter((event): event is AgentEvent => event?.runId === IDEMPOTENCY_KEY);
+      const assistantDeltas = runEvents.filter(
+        (event) => event.stream === "assistant" && typeof event.data?.delta === "string",
+      );
+      expect(assistantDeltas.length).toBeGreaterThanOrEqual(2);
+      expect(
+        assistantDeltas.every(
+          (event) =>
+            event.runId === accepted.runId &&
+            event.sessionKey === SESSION_KEY &&
+            typeof event.seq === "number",
+        ),
+      ).toBe(true);
+      const deltaSeqs = assistantDeltas.map((event) => event.seq as number);
+      expect(deltaSeqs).toEqual(deltaSeqs.toSorted((left, right) => left - right));
+      expect(new Set(deltaSeqs).size).toBe(deltaSeqs.length);
+
+      const terminalEvents = runEvents.filter(
+        (event) =>
+          event.stream === "lifecycle" &&
+          (event.data?.phase === "end" || event.data?.phase === "error"),
+      );
+      expect(terminalEvents).toHaveLength(1);
+      expect(terminalEvents[0]).toMatchObject({
+        runId: accepted.runId,
+        sessionKey: SESSION_KEY,
+        stream: "lifecycle",
+        data: { phase: "end" },
+      });
+      expect(terminalEvents[0]?.seq).toBeGreaterThan(deltaSeqs.at(-1) ?? 0);
+
+      const streamedText = assistantDeltas.map((event) => event.data?.delta ?? "").join("");
+      expect(streamedText).toBe(TERMINAL_TEXT);
+
+      const history = await client.request<{ messages?: unknown[] }>("chat.history", {
+        sessionKey: SESSION_KEY,
+        limit: 20,
+      });
+      const assistantMessages = (history.messages ?? []).filter(
+        (message) => messageRole(message) === "assistant",
+      );
+      expect(assistantMessages).toHaveLength(1);
+      expect(messageText(assistantMessages[0])).toBe(streamedText);
+      expect(provider.providerRequests).toHaveLength(1);
+      expect(provider.transportRequests).toEqual([]);
+    },
+  );
+});


### PR DESCRIPTION
## What Problem This Solves

Agent session streaming had unit coverage, but no QA product-boundary proof that
a generic Gateway `agent` RPC exposes ordered assistant deltas, terminates once,
and persists one canonical assistant transcript message without channel
delivery.

## Why This Change Was Made

Add one QA Lab scenario and one focused E2E test. The test starts a real child
Gateway and a paced loopback OpenAI Responses provider, then:

- submits one fixed-session `agent` RPC from an authenticated operator;
- captures Gateway `agent` events directly rather than channel transport;
- verifies assistant deltas share the accepted run and session identity;
- verifies delta sequence ordering and one terminal lifecycle event after text;
- reassembles the deltas and compares them with the single assistant history row;
- records every non-provider HTTP request and proves no channel message was sent.

No production, shared helper, QA-internal, channel, runtime-pair, taxonomy, or
Plugin SDK code changes.

## User Impact

This locks in the session streaming contract used by Gateway clients: live
assistant output stays ordered and attributable to one run/session, while
history stores the final message instead of token fragments.

## Evidence

- `node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/agent-session-streaming.e2e.test.ts`
  - pass: 1 file, 1 test
- QA coverage match:
  - scenario: `session-streaming`
  - execution: `vitest`
  - primary ID: `agent-runtime.session-streaming`
- Direct Codex `gpt-5.6-sol` / high autoreview:
  - clean, no accepted or actionable findings
  - patch correct, confidence 0.99
- `git diff --check`: pass
- Repo-native hosted CI/Testbox gates: pass on exact head
- Production LOC: +0
- QA LOC: +393 across exactly two new files

Exact-head hosted CI is green. A redundant standalone Blacksmith changed-gate
lease stayed silent and was stopped after the repo-native hosted/Testbox gate
passed.

ClawSweeper re-review was queued at 2026-08-04T01:14:26Z. Its exact downstream
run `30868494808` failed without producing a publishable artifact; after the
review window there was no durable review comment or `Rank-up moves:` list.
Proceeding under the established unclaimed-review landing precedent.
