### PR TITLE
test(qa): prove overflow compaction retry and pruning

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
@@ -7,6 +7,10 @@ import { writeJson } from "../shared/http-json.js";
 
 export type ResponsesInputItem = Record<string, unknown>;
 
+export type MockOpenAiRequestKind = "agent-initial" | "compaction-summary" | "tool-continuation";
+
+type MockOpenAiRequestOutcome = "success" | "error";
+
 export type StreamEvent =
   | { type: "response.created"; response: { id: string } }
   | {
@@ -122,6 +126,10 @@ export type MockOpenAiRequestSnapshot = {
   model: string;
   providerVariant: MockOpenAiProviderVariant;
   imageInputCount: number;
+  requestKind: MockOpenAiRequestKind;
+  outcome: MockOpenAiRequestOutcome;
+  errorCode?: string;
+  rawByteLength: number;
   plannedToolCallId?: string;
   plannedToolName?: string;
   plannedWireToolName?: string;
@@ -302,6 +310,8 @@ export const QA_MCP_CODE_MODE_API_FILE_PROMPT_RE = /mcp code mode api file qa ch
 
 export type MockScenarioState = {
   anthropicThinkingErrorScenarioKeys: Set<string>;
+  compactionOverflowInjected: boolean;
+  compactionRetryActive: boolean;
   subagentFanoutCompletedWorkers: Set<"alpha" | "beta">;
   subagentFanoutPhase: number;
   subagentHandoffSpawned: boolean;

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-responses-websocket.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-responses-websocket.test.ts
@@ -4,6 +4,8 @@ import { WebSocket, type RawData } from "ws";
 import { startQaMockOpenAiServer } from "./server.js";
 
 const cleanups: Array<() => Promise<void>> = [];
+const QA_COMPACTION_RETRY_PROMPT =
+  "Compaction retry mutating tool check. Current durable context marker: QA-COMPACTION-DURABLE-MARKER. Create compaction-retry-summary.txt.";
 
 afterEach(async () => {
   while (cleanups.length > 0) {
@@ -360,6 +362,51 @@ describe("QA mock OpenAI Responses WebSocket", () => {
     )) as Array<Record<string, unknown>>;
     expect(requests).toHaveLength(2);
     expect(requests[1]).toMatchObject({ prompt, toolOutput: "QA mission loaded" });
+  });
+
+  it("preserves the coded compaction overflow on the WebSocket transport", async () => {
+    const server = await startServer();
+    const socket = await connectResponsesWebSocket(server.baseUrl);
+    const failure = await collectResponseEvents(socket, {
+      type: "response.create",
+      model: "gpt-5.6-sol",
+      stream: true,
+      instructions: "Runtime: codex | sessionId=compaction-websocket",
+      input: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "input_text",
+              text: `${QA_COMPACTION_RETRY_PROMPT}\n${"x".repeat(300_000)}`,
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(failure).toEqual([
+      expect.objectContaining({
+        type: "error",
+        status: 400,
+        error: {
+          type: "invalid_request_error",
+          code: "context_length_exceeded",
+          message: "This model's maximum context length was exceeded.",
+        },
+      }),
+    ]);
+    const requests = (await fetch(`${server.baseUrl}/debug/requests`).then((response) =>
+      response.json(),
+    )) as Array<Record<string, unknown>>;
+    expect(requests).toEqual([
+      expect.objectContaining({
+        requestKind: "agent-initial",
+        outcome: "error",
+        errorCode: "context_length_exceeded",
+        rawByteLength: expect.any(Number),
+      }),
+    ]);
   });
 
   it("rejects a response delta whose previous response belongs to another connection", async () => {

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-responses-websocket.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-responses-websocket.ts
@@ -8,6 +8,7 @@ export type QaMockResponsesDispatchResult = {
   failure?: {
     status: number;
     type: string;
+    code?: string;
     message: string;
   };
   onResponseSent?: () => void;
@@ -200,6 +201,7 @@ export function attachQaMockResponsesWebSocketServer(params: {
               status: dispatched.failure.status,
               error: {
                 type: dispatched.failure.type,
+                ...(dispatched.failure.code ? { code: dispatched.failure.code } : {}),
                 message: dispatched.failure.message,
               },
             });

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -59,6 +59,12 @@ const QA_COMPACTION_RETRY_CODE_MODE_WRITE_RESULT = {
     callCount: 1,
   },
 } as const;
+const QA_COMPACTION_RETRY_PROMPT =
+  "Compaction retry mutating tool check. Current durable context marker: QA-COMPACTION-DURABLE-MARKER. Create compaction-retry-summary.txt.";
+const QA_COMPACTION_RETRY_OVERFLOW_PADDING = "x".repeat(300_000);
+const QA_COMPACTION_SUMMARY_INSTRUCTIONS = `You are a context summarization assistant. Your task is to read a conversation between a user and an AI assistant, then produce a structured summary following the exact format specified.
+
+Do NOT continue the conversation. Do NOT respond to any questions in the conversation. ONLY output the structured summary.`;
 
 afterEach(async () => {
   while (cleanups.length > 0) {
@@ -2200,23 +2206,14 @@ describe("qa mock openai server", () => {
     const server = await startMockServer();
 
     const writePlanBody = await expectOpenAiStreamingResponsesText(server, {
-      input: [
-        makeUserInput(
-          "Compaction retry mutating tool check: read COMPACTION_RETRY_CONTEXT.md, then create compaction-retry-summary.txt and keep replay safety explicit.",
-        ),
-        makeToolOutput(
-          "compaction retry evidence block 0000\ncompaction retry evidence block 0001",
-        ),
-      ],
+      input: [makeUserInput(QA_COMPACTION_RETRY_PROMPT)],
     });
     expect(writePlanBody).toContain('"name":"write"');
     expect(writePlanBody).toContain("compaction-retry-summary.txt");
 
     const finalPayload = (await expectOpenAiNonStreamingResponsesJson(server, {
       input: [
-        makeUserInput(
-          "Compaction retry mutating tool check: read COMPACTION_RETRY_CONTEXT.md, then create compaction-retry-summary.txt and keep replay safety explicit.",
-        ),
+        makeUserInput(QA_COMPACTION_RETRY_PROMPT),
         makeToolOutput("Successfully wrote 41 bytes to compaction-retry-summary.txt"),
       ],
     })) as {
@@ -2225,6 +2222,272 @@ describe("qa mock openai server", () => {
     expect(finalPayload.output?.[0]?.content?.[0]?.text).toBe(
       "Protocol note: replay unsafe after write.",
     );
+  });
+
+  it("does not inject compaction overflow below the request-size threshold", async () => {
+    const server = await startMockServer();
+    const runtimeSessionId = "compaction-below-threshold";
+
+    await expectOpenAiNonStreamingResponsesJson(server, {
+      instructions: `Runtime: embedded | sessionId=${runtimeSessionId}`,
+      input: [makeUserInput(QA_COMPACTION_RETRY_PROMPT)],
+    });
+
+    const requests = requireArray(
+      await getJson(server, "/debug/requests"),
+      "compaction requests",
+    ).map((request) => requireRecord(request, "compaction request"));
+    expect(requests).toHaveLength(1);
+    const request = requireRecord(requests[0], "compaction request 0");
+    expect(request).toMatchObject({
+      requestKind: "agent-initial",
+      outcome: "success",
+      plannedToolName: "write",
+    });
+    expect(request.rawByteLength).toEqual(expect.any(Number));
+    expect(Number(request.rawByteLength)).toBeLessThanOrEqual(256 * 1024);
+  });
+
+  it("injects one coded overflow per session before planning", async () => {
+    const server = await startMockServer();
+    const runtimeSessionId = "compaction-one-shot";
+    const body = {
+      model: "gpt-5.6-luna",
+      instructions: `Runtime: embedded | sessionId=${runtimeSessionId}`,
+      input: [
+        makeUserInput(`${QA_COMPACTION_RETRY_PROMPT}\n${QA_COMPACTION_RETRY_OVERFLOW_PADDING}`),
+      ],
+    };
+
+    const first = await postNonStreamingResponses(server, body);
+    expect(first.status).toBe(400);
+    expect(await first.json()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        code: "context_length_exceeded",
+        message: "This model's maximum context length was exceeded.",
+      },
+    });
+
+    const second = await postNonStreamingResponses(server, body);
+    expect(second.status).toBe(200);
+    const requests = requireArray(
+      await getJson(server, "/debug/requests"),
+      "compaction requests",
+    ).map((request) => requireRecord(request, "compaction request"));
+    expect(requests).toHaveLength(2);
+    const firstRequest = requireRecord(requests[0], "compaction request 0");
+    const secondRequest = requireRecord(requests[1], "compaction request 1");
+    expect(firstRequest).toMatchObject({
+      requestKind: "agent-initial",
+      outcome: "error",
+      errorCode: "context_length_exceeded",
+    });
+    expect(firstRequest.plannedToolName).toBeUndefined();
+    expect(secondRequest).toMatchObject({
+      requestKind: "agent-initial",
+      outcome: "success",
+      plannedToolName: "write",
+    });
+  });
+
+  it("tracks compaction overflow injection independently by runtime session", async () => {
+    const server = await startMockServer();
+
+    for (const runtimeSessionId of ["compaction-session-a", "compaction-session-b"]) {
+      const response = await postNonStreamingResponses(server, {
+        model: "gpt-5.6-luna",
+        instructions: `Runtime: embedded | sessionId=${runtimeSessionId}`,
+        input: [
+          makeUserInput(`${QA_COMPACTION_RETRY_PROMPT}\n${QA_COMPACTION_RETRY_OVERFLOW_PADDING}`),
+        ],
+      });
+      expect(response.status).toBe(400);
+    }
+
+    const requests = requireArray(
+      await getJson(server, "/debug/requests"),
+      "compaction requests",
+    ).map((request) => requireRecord(request, "compaction request"));
+    expect(requests).toHaveLength(2);
+    expect(requests.every((request) => request.errorCode === "context_length_exceeded")).toBe(true);
+  });
+
+  it("excludes compaction summary requests from overflow injection", async () => {
+    const server = await startMockServer();
+    const initial = await postNonStreamingResponses(server, {
+      model: "gpt-5.6-luna",
+      instructions: "Runtime: embedded | sessionId=compaction-summary",
+      input: [
+        makeUserInput(`${QA_COMPACTION_RETRY_PROMPT}\n${QA_COMPACTION_RETRY_OVERFLOW_PADDING}`),
+      ],
+    });
+    expect(initial.status).toBe(400);
+
+    const response = await postNonStreamingResponses(server, {
+      model: "gpt-5.6-luna",
+      instructions: QA_COMPACTION_SUMMARY_INSTRUCTIONS,
+      input: `<conversation>\n[Chunk 1 - oldest messages]\nQA-COMPACTION-BULKY-HISTORICAL-MARKER\n${QA_COMPACTION_RETRY_OVERFLOW_PADDING}\n</conversation>\n\nAdditional focus: preserve exact identifiers and current work.`,
+    });
+
+    expect(response.status).toBe(200);
+    const summary = outputText(await response.json());
+    expect(summary).toContain("## Goal");
+    expect(summary).not.toContain("QA-COMPACTION-DURABLE-MARKER");
+    expect(summary).not.toContain("QA-COMPACTION-BULKY-HISTORICAL-MARKER");
+    const requests = requireArray(
+      await getJson(server, "/debug/requests"),
+      "compaction requests",
+    ).map((request) => requireRecord(request, "compaction request"));
+    expect(requests).toHaveLength(2);
+    const summaryRequest = requireRecord(requests[1], "compaction request 1");
+    expect(summaryRequest).toMatchObject({
+      requestKind: "compaction-summary",
+      outcome: "success",
+    });
+    expect(Number(summaryRequest.rawByteLength)).toBeGreaterThan(256 * 1024);
+    expect(summaryRequest.errorCode).toBeUndefined();
+    expect(summaryRequest.allInputText).toContain("[Chunk 1 - oldest messages]");
+  });
+
+  it("handles staged scalar compaction summaries and promotes the durable merge without state leakage", async () => {
+    const server = await startMockServer();
+    const genericChunkPayload = await expectOpenAiNonStreamingResponsesJson(server, {
+      model: "gpt-5.6-luna",
+      instructions: QA_COMPACTION_SUMMARY_INSTRUCTIONS,
+      input:
+        "<conversation>\n[Chunk 1 - oldest messages]\nunrelated historical context\n</conversation>\n\nAdditional focus: preserve exact identifiers.",
+    });
+    const genericChunkSummary = outputText(genericChunkPayload);
+    expect(genericChunkSummary).toContain("## Goal");
+    expect(genericChunkSummary).not.toContain("QA-COMPACTION-DURABLE-MARKER");
+
+    const scenarioChunkPayload = await expectOpenAiNonStreamingResponsesJson(server, {
+      model: "gpt-5.6-luna",
+      instructions: QA_COMPACTION_SUMMARY_INSTRUCTIONS,
+      input:
+        "<conversation>\n[Chunk 2 - most recent messages]\nQA-COMPACTION-BULKY-HISTORICAL-MARKER\n</conversation>\n\nAdditional focus: preserve exact identifiers.",
+    });
+    const scenarioChunkSummary = outputText(scenarioChunkPayload);
+    expect(scenarioChunkSummary).toContain("## Goal");
+    expect(scenarioChunkSummary).not.toContain("QA-COMPACTION-DURABLE-MARKER");
+    expect(scenarioChunkSummary).not.toContain("QA-COMPACTION-BULKY-HISTORICAL-MARKER");
+
+    const durableChunkPayload = await expectOpenAiNonStreamingResponsesJson(server, {
+      model: "gpt-5.6-luna",
+      instructions: QA_COMPACTION_SUMMARY_INSTRUCTIONS,
+      input: `<conversation>
+Retain QA-COMPACTION-DURABLE-MARKER for the active task.
+</conversation>
+
+Additional focus: preserve QA-COMPACTION-DURABLE-MARKER.`,
+    });
+    const durableChunkSummary = outputText(durableChunkPayload);
+    expect(durableChunkSummary).toContain("QA-COMPACTION-DURABLE-MARKER");
+
+    const promptOnlyChunkPayload = await expectOpenAiNonStreamingResponsesJson(server, {
+      model: "gpt-5.6-luna",
+      instructions: QA_COMPACTION_SUMMARY_INSTRUCTIONS,
+      input: `<conversation>
+Compaction retry mutating tool check. Create compaction-retry-summary.txt.
+</conversation>
+
+Additional focus: preserve current work.`,
+    });
+    const promptOnlyChunkSummary = outputText(promptOnlyChunkPayload);
+    expect(promptOnlyChunkSummary).not.toContain("QA-COMPACTION-DURABLE-MARKER");
+
+    const currentChunkPayload = await expectOpenAiNonStreamingResponsesJson(server, {
+      model: "gpt-5.6-luna",
+      instructions: QA_COMPACTION_SUMMARY_INSTRUCTIONS,
+      input: `<conversation>
+Compaction retry mutating tool check. Current durable context marker: QA-COMPACTION-DURABLE-MARKER.
+Create compaction-retry-summary.txt.
+</conversation>
+
+Additional focus: preserve current work.`,
+    });
+    const currentChunkSummary = outputText(currentChunkPayload);
+    expect(currentChunkSummary).toContain("QA-COMPACTION-DURABLE-MARKER");
+
+    const mergePayload = await expectOpenAiNonStreamingResponsesJson(server, {
+      model: "gpt-5.6-luna",
+      instructions: QA_COMPACTION_SUMMARY_INSTRUCTIONS,
+      input: `<conversation>
+[Chunk 1 - oldest messages]
+${genericChunkSummary}
+[Chunk 2 - most recent messages]
+${scenarioChunkSummary}
+[Chunk 3 - current work]
+${currentChunkSummary}
+</conversation>
+
+<previous-summary>
+${durableChunkSummary}
+</previous-summary>
+
+Update and merge these partial structured summaries.`,
+    });
+    expect(outputText(mergePayload)).toContain("QA-COMPACTION-DURABLE-MARKER");
+
+    const unrelatedPayload = await expectOpenAiNonStreamingResponsesJson(server, {
+      model: "gpt-5.6-luna",
+      instructions: QA_COMPACTION_SUMMARY_INSTRUCTIONS,
+      input:
+        "<conversation>\na later unrelated scenario\n</conversation>\n\nCreate a structured summary.",
+    });
+    expect(outputText(unrelatedPayload)).toContain("## Goal");
+    expect(outputText(unrelatedPayload)).not.toContain("QA-COMPACTION-DURABLE-MARKER");
+
+    const requests = requireArray(
+      await getJson(server, "/debug/requests"),
+      "compaction requests",
+    ).map((request) => requireRecord(request, "compaction request"));
+    expect(requests).toHaveLength(7);
+    expect(
+      requests.every(
+        (request) =>
+          request.requestKind === "compaction-summary" &&
+          request.outcome === "success" &&
+          request.plannedToolName === undefined,
+      ),
+    ).toBe(true);
+  });
+
+  it("plans the write from an OpenClaw compacted retry payload", async () => {
+    const server = await startMockServer();
+    const runtimeSessionId = "compaction-openclaw-retry";
+    const initial = await postNonStreamingResponses(server, {
+      model: "gpt-5.6-luna",
+      instructions: `Runtime: embedded | sessionId=${runtimeSessionId}`,
+      input: [
+        makeUserInput(`${QA_COMPACTION_RETRY_PROMPT}\n${QA_COMPACTION_RETRY_OVERFLOW_PADDING}`),
+      ],
+    });
+    expect(initial.status).toBe(400);
+
+    const summaryPayload = await expectOpenAiNonStreamingResponsesJson(server, {
+      model: "gpt-5.6-luna",
+      instructions: QA_COMPACTION_SUMMARY_INSTRUCTIONS,
+      input: [
+        makeUserInput(
+          `<conversation>\n${QA_COMPACTION_RETRY_PROMPT}\nhistorical context only\n</conversation>\n\nAdditional focus: preserve exact identifiers and current work.`,
+        ),
+      ],
+    });
+    const compactedSummary = outputText(summaryPayload);
+    expect(compactedSummary).toContain("QA-COMPACTION-DURABLE-MARKER");
+
+    const writePlan = await expectOpenAiStreamingResponsesText(server, {
+      model: "gpt-5.6-luna",
+      instructions: `Runtime: embedded | sessionId=${runtimeSessionId}`,
+      input: [
+        makeUserInput(compactedSummary),
+        makeUserInput("Continue from the compacted context."),
+      ],
+    });
+    expect(writePlan).toContain('"name":"write"');
+    expect(writePlan).toContain("compaction-retry-summary.txt");
   });
 
   it("finishes a compacted retry after the canonical successful write result", async () => {
@@ -2395,14 +2658,9 @@ describe("qa mock openai server", () => {
   it("keeps compaction retry planning across continuation prompts", async () => {
     const server = await startMockServer();
 
-    const prompt =
-      "Compaction retry mutating tool check: read COMPACTION_RETRY_CONTEXT.md, then create compaction-retry-summary.txt and keep replay safety explicit.";
     const writePlan = await expectOpenAiStreamingResponses(server, {
       input: [
-        makeUserInput(prompt),
-        makeToolOutput(
-          "compaction retry evidence block 0000\ncompaction retry evidence block 0001",
-        ),
+        makeUserInput(QA_COMPACTION_RETRY_PROMPT),
         makeUserInput("Continue after compaction."),
       ],
     });
@@ -2410,9 +2668,7 @@ describe("qa mock openai server", () => {
 
     const contextOnlyWritePlan = await expectOpenAiStreamingResponses(server, {
       input: [
-        makeToolOutput(
-          "compaction retry evidence block 0000\ncompaction retry evidence block 0001",
-        ),
+        makeUserInput(QA_COMPACTION_RETRY_PROMPT),
         makeUserInput("Continue after compaction."),
       ],
     });
@@ -2420,7 +2676,7 @@ describe("qa mock openai server", () => {
 
     const finalReply = await expectOpenAiNonStreamingResponses(server, {
       input: [
-        makeUserInput(prompt),
+        makeUserInput(QA_COMPACTION_RETRY_PROMPT),
         makeToolOutput("Successfully wrote 41 bytes to compaction-retry-summary.txt"),
         makeUserInput("Continue after compaction."),
       ],

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -21,6 +21,7 @@ import {
   resolveProviderVariant,
   type MockOpenAiRequestSnapshot,
   type MockOpenAiRequestSnapshotInput,
+  type MockOpenAiRequestKind,
   type AnthropicMessagesRequest,
   TINY_PNG_BASE64,
   QA_REASONING_ONLY_RECOVERY_PROMPT_RE,
@@ -171,6 +172,62 @@ import {
   isSnackRecallPrompt,
   extractSnackPreference,
 } from "./mock-openai-tooling.js";
+
+const QA_COMPACTION_RETRY_PROMPT_RE = /compaction retry mutating tool check/i;
+const QA_COMPACTION_SUMMARY_INSTRUCTIONS_RE =
+  /context summarization assistant[\s\S]*structured summary[\s\S]*do not continue/i;
+const QA_COMPACTION_RETRY_OVERFLOW_THRESHOLD_BYTES = 256 * 1024;
+const QA_COMPACTION_RETRY_DURABLE_MARKER = "QA-COMPACTION-DURABLE-MARKER";
+const QA_COMPACTION_RETRY_BULKY_MARKER = "QA-COMPACTION-BULKY-HISTORICAL-MARKER";
+const QA_COMPACTION_RETRY_SUMMARY = `## Goal
+Complete the compaction retry mutating tool check.
+
+## Constraints & Preferences
+- Preserve ${QA_COMPACTION_RETRY_DURABLE_MARKER}.
+
+## Progress
+### Done
+- [x] Historical context compacted after overflow.
+
+### In Progress
+- [ ] Write compaction-retry-summary.txt exactly once.
+
+### Blocked
+- (none)
+
+## Key Decisions
+- **Retry once**: Continue from compacted context without replaying a completed mutation.
+
+## Next Steps
+1. Write the required file.
+2. Return the final replay-safety marker.
+
+## Critical Context
+- ${QA_COMPACTION_RETRY_DURABLE_MARKER}`;
+const QA_GENERIC_COMPACTION_SUMMARY = `## Goal
+Preserve the active conversation context.
+
+## Constraints & Preferences
+- Keep current requirements and identifiers.
+
+## Progress
+### Done
+- [x] Historical context summarized.
+
+### In Progress
+- [ ] Continue the active task.
+
+### Blocked
+- (none)
+
+## Key Decisions
+- **Continue from summary**: Do not restart completed work.
+
+## Next Steps
+1. Continue the active task from the retained context.
+
+## Critical Context
+- Refer to the retained recent turns for current task details.`;
 
 const QA_STREAMING_TOOL_PROGRESS_FAMILY_PROMPT_RE =
   /(?:partial|quiet) streaming qa check|final-only marker streaming qa check|block streaming qa check|tool progress(?: error)? qa check/i;
@@ -516,6 +573,16 @@ function resolveQaRuntimeSessionId(input: ResponsesInputItem[], body: Record<str
   return /\bRuntime:\s*[^\n]*\bsessionId=([^\s|]+)/u.exec(extractAllRequestTexts(input, body))?.[1];
 }
 
+function normalizeResponsesInput(value: unknown): ResponsesInputItem[] {
+  if (Array.isArray(value)) {
+    return value as ResponsesInputItem[];
+  }
+  if (typeof value === "string") {
+    return [{ role: "user", content: [{ type: "input_text", text: value }] }];
+  }
+  return [];
+}
+
 function resolveQaChildSessionKey(input: ResponsesInputItem[], body: Record<string, unknown>) {
   const systemPrompt = extractAllRequestTexts(
     input.filter((item) => item.role === "developer" || item.role === "system"),
@@ -531,17 +598,28 @@ function resolveAcceptedChildSessionKey(input: ResponsesInputItem[]) {
     : undefined;
 }
 
+function classifyMockOpenAiRequest(
+  input: ResponsesInputItem[],
+  body: Record<string, unknown>,
+): MockOpenAiRequestKind {
+  if (QA_COMPACTION_SUMMARY_INSTRUCTIONS_RE.test(extractInstructionsText(body))) {
+    return "compaction-summary";
+  }
+  return hasToolOutput(input) ? "tool-continuation" : "agent-initial";
+}
+
 async function buildResponsesPayload(
   body: Record<string, unknown>,
   scenarioState: MockScenarioState,
   options: {
     waitForTerminalRequesterSettled?: (caseName: string, childSessionKey: string) => Promise<void>;
+    requestKind?: MockOpenAiRequestKind;
   } = {},
 ) {
   const providerVariant = resolveProviderVariant(
     typeof body.model === "string" ? body.model : undefined,
   );
-  const input = Array.isArray(body.input) ? (body.input as ResponsesInputItem[]) : [];
+  const input = normalizeResponsesInput(body.input);
   const toolDeclarationBody = resolveCurrentToolDeclarationSurface(body, input);
   const prompt = extractLastUserText(input);
   const hasCompletedToolOutput = hasToolOutput(input);
@@ -564,6 +642,29 @@ async function buildResponsesPayload(
   const buildToolCallEventsWithArgs = (name: string, args: Record<string, unknown>) =>
     buildScenarioToolCallEvents(toolDeclarationBody, name, args);
   const allInputText = extractAllRequestTexts(input, body);
+  const hasCompactionRetryDurableContext = allInputText.includes(
+    QA_COMPACTION_RETRY_DURABLE_MARKER,
+  );
+  const hasCompactionRetryMarker =
+    QA_COMPACTION_RETRY_PROMPT_RE.test(allInputText) ||
+    hasCompactionRetryDurableContext ||
+    allInputText.includes(QA_COMPACTION_RETRY_BULKY_MARKER);
+  const requestKind = options.requestKind ?? classifyMockOpenAiRequest(input, body);
+  if (requestKind === "compaction-summary") {
+    return buildAssistantEvents(
+      hasCompactionRetryDurableContext
+        ? QA_COMPACTION_RETRY_SUMMARY
+        : QA_GENERIC_COMPACTION_SUMMARY,
+    );
+  }
+  if (
+    QA_COMPACTION_RETRY_PROMPT_RE.test(allInputText) ||
+    /compaction-retry-summary\.txt/i.test(toolOutput)
+  ) {
+    scenarioState.compactionRetryActive = true;
+  }
+  const compactionRetryScenarioActive =
+    scenarioState.compactionRetryActive || hasCompactionRetryMarker;
   const scenarioToolOutput =
     toolOutput ||
     (/thread memory check|session memory ranking check|memory tools check|repo contract followthrough check/i.test(
@@ -578,6 +679,18 @@ async function buildResponsesPayload(
     hasToolDefinition(toolDeclarationBody, "wait")
   ) {
     return buildRawToolCallEventsWithArgs("wait", { runId: codeModeControlJson.runId });
+  }
+  if (compactionRetryScenarioActive) {
+    if (isCanonicalCompactionRetryWriteResult(toolOutput)) {
+      return buildAssistantEvents(QA_COMPACTION_RETRY_FINAL_MARKER);
+    }
+    if (!hasCompletedToolOutput) {
+      return buildToolCallEventsWithArgs("write", {
+        path: "compaction-retry-summary.txt",
+        content: "Replay safety: unsafe after write.\n",
+      });
+    }
+    return buildAssistantEvents("");
   }
   const memoryToolUnavailable =
     toolJson?.unavailable === true ||
@@ -1538,24 +1651,6 @@ async function buildResponsesPayload(
       });
     }
   }
-  if (
-    /compaction retry mutating tool check/i.test(allInputText) ||
-    /compaction retry evidence/i.test(toolOutput) ||
-    /compaction-retry-summary\.txt/i.test(toolOutput)
-  ) {
-    if (isCanonicalCompactionRetryWriteResult(toolOutput)) {
-      return buildAssistantEvents(QA_COMPACTION_RETRY_FINAL_MARKER);
-    }
-    if (!hasCompletedToolOutput) {
-      return buildToolCallEventsWithArgs("read", { path: "COMPACTION_RETRY_CONTEXT.md" });
-    }
-    if (toolOutput.includes("compaction retry evidence")) {
-      return buildToolCallEventsWithArgs("write", {
-        path: "compaction-retry-summary.txt",
-        content: "Replay safety: unsafe after write.\n",
-      });
-    }
-  }
   if (/memory tools check/i.test(allInputText)) {
     if (!scenarioToolOutput) {
       return buildToolCallEventsWithArgs("memory_search", {
@@ -2003,12 +2098,13 @@ export async function startQaMockOpenAiServer(params?: {
   const terminalRequesterSettleGate = createTerminalRequesterSettleGate();
   const scenarioStates = new Map<string, MockScenarioState>();
   const scenarioStateFor = (body: Record<string, unknown>): MockScenarioState => {
-    const input = Array.isArray(body.input)
-      ? body.input
-      : convertAnthropicMessagesToResponsesInput({
-          system: body.system as AnthropicMessagesRequest["system"],
-          messages: [],
-        });
+    const input =
+      typeof body.input === "string" || Array.isArray(body.input)
+        ? normalizeResponsesInput(body.input)
+        : convertAnthropicMessagesToResponsesInput({
+            system: body.system as AnthropicMessagesRequest["system"],
+            messages: [],
+          });
     const sessionId =
       resolveQaRuntimeSessionId(input, body) ??
       (body.client_metadata as { session_id?: unknown } | undefined)?.session_id;
@@ -2016,6 +2112,8 @@ export async function startQaMockOpenAiServer(params?: {
     // Runtime session identity survives provider switches and cache-boundary changes.
     const state = scenarioStates.get(key) ?? {
       anthropicThinkingErrorScenarioKeys: new Set<string>(),
+      compactionOverflowInjected: false,
+      compactionRetryActive: false,
       subagentFanoutCompletedWorkers: new Set<"alpha" | "beta">(),
       subagentFanoutPhase: 0,
       subagentHandoffSpawned: false,
@@ -2043,25 +2141,75 @@ export async function startQaMockOpenAiServer(params?: {
     body: Record<string, unknown>;
     raw: string;
   }): Promise<QaMockResponsesDispatchResult> => {
-    const input = Array.isArray(request.body.input)
-      ? (request.body.input as ResponsesInputItem[])
-      : [];
+    const input = normalizeResponsesInput(request.body.input);
     if (isRemoteCompactionV2Request(input)) {
       return { events: buildRemoteCompactionV2Events() };
     }
     const prompt = extractLastUserText(input);
     const allInputText = extractAllRequestTexts(input, request.body);
+    const scenarioState = scenarioStateFor(request.body);
+    const requestKind = classifyMockOpenAiRequest(input, request.body);
+    if (requestKind !== "compaction-summary" && QA_COMPACTION_RETRY_PROMPT_RE.test(allInputText)) {
+      scenarioState.compactionRetryActive = true;
+    }
+    const rawByteLength = Buffer.byteLength(request.raw);
+    const resolvedModel = typeof request.body.model === "string" ? request.body.model : "";
+    const requestSnapshotBase = {
+      raw: request.raw,
+      body: request.body,
+      prompt,
+      allInputText,
+      instructions: extractInstructionsText(request.body) || undefined,
+      toolOutput: extractToolOutput(input),
+      model: resolvedModel,
+      providerVariant: resolveProviderVariant(resolvedModel),
+      imageInputCount: countImageInputs(input),
+      requestKind,
+      rawByteLength,
+    } satisfies Omit<
+      MockOpenAiRequestSnapshotInput,
+      | "outcome"
+      | "errorCode"
+      | "plannedToolCallId"
+      | "plannedToolName"
+      | "plannedWireToolName"
+      | "plannedToolArgs"
+      | "toolOutputCallId"
+      | "toolOutputStructuredError"
+    >;
+    if (
+      requestKind === "agent-initial" &&
+      QA_COMPACTION_RETRY_PROMPT_RE.test(allInputText) &&
+      rawByteLength > QA_COMPACTION_RETRY_OVERFLOW_THRESHOLD_BYTES &&
+      !scenarioState.compactionOverflowInjected
+    ) {
+      scenarioState.compactionOverflowInjected = true;
+      recordRequest({
+        ...requestSnapshotBase,
+        outcome: "error",
+        errorCode: "context_length_exceeded",
+      });
+      return {
+        events: [],
+        failure: {
+          status: 400,
+          type: "invalid_request_error",
+          code: "context_length_exceeded",
+          message: "This model's maximum context length was exceeded.",
+        },
+      };
+    }
     const inflightRequestId = nextInflightRequestId++;
     inflightRequests.set(inflightRequestId, { prompt, allInputText });
     let events: StreamEvent[];
     try {
-      events = await buildResponsesPayload(request.body, scenarioStateFor(request.body), {
+      events = await buildResponsesPayload(request.body, scenarioState, {
         waitForTerminalRequesterSettled: terminalRequesterSettleGate.waitUntilSettled,
+        requestKind,
       });
     } finally {
       inflightRequests.delete(inflightRequestId);
     }
-    const resolvedModel = typeof request.body.model === "string" ? request.body.model : "";
     const plannedTool = extractScenarioPlannedTool(events);
     const terminalRequesterCase = extractLastMatchingUserTurn(
       input,
@@ -2078,16 +2226,17 @@ export async function startQaMockOpenAiServer(params?: {
         : undefined;
     const settledTerminalCaseName = settledTerminalRequester?.caseName;
     const settledChildSessionKey = settledTerminalRequester?.childSessionKey;
+    const failure =
+      QA_PROVIDER_HTTP_503_AFTER_TOOL_PROMPT_RE.test(allInputText) && hasToolOutput(input)
+        ? {
+            status: 503,
+            type: "server_error",
+            message: "Service Unavailable",
+          }
+        : undefined;
     recordRequest({
-      raw: request.raw,
-      body: request.body,
-      prompt,
-      allInputText,
-      instructions: extractInstructionsText(request.body) || undefined,
-      toolOutput: extractToolOutput(input),
-      model: resolvedModel,
-      providerVariant: resolveProviderVariant(resolvedModel),
-      imageInputCount: countImageInputs(input),
+      ...requestSnapshotBase,
+      outcome: failure ? "error" : "success",
       plannedToolCallId: extractPlannedToolCallId(events),
       plannedToolName: plannedTool.name,
       ...(plannedTool.wireName && plannedTool.wireName !== plannedTool.name
@@ -2108,15 +2257,7 @@ export async function startQaMockOpenAiServer(params?: {
               ),
           }
         : {}),
-      ...(QA_PROVIDER_HTTP_503_AFTER_TOOL_PROMPT_RE.test(allInputText) && hasToolOutput(input)
-        ? {
-            failure: {
-              status: 503,
-              type: "server_error",
-              message: "Service Unavailable",
-            },
-          }
-        : {}),
+      ...(failure ? { failure } : {}),
       ...(QA_FINAL_ONLY_MARKER_STREAMING_PROMPT_RE.test(allInputText)
         ? { previewPauseMs: finalOnlyMarkerPauseMs }
         : {}),
@@ -2253,7 +2394,7 @@ export async function startQaMockOpenAiServer(params?: {
           writeOpenAiMalformedJsonError(res, "OpenAI Responses");
           return;
         }
-        const input = Array.isArray(body.input) ? (body.input as ResponsesInputItem[]) : [];
+        const input = normalizeResponsesInput(body.input);
         if (isRemoteCompactionV2Request(input)) {
           const events = buildRemoteCompactionV2Events();
           if (body.stream === false) {
@@ -2268,6 +2409,7 @@ export async function startQaMockOpenAiServer(params?: {
           writeJson(res, dispatched.failure.status, {
             error: {
               type: dispatched.failure.type,
+              ...(dispatched.failure.code ? { code: dispatched.failure.code } : {}),
               message: dispatched.failure.message,
             },
           });
@@ -2329,6 +2471,9 @@ export async function startQaMockOpenAiServer(params?: {
           model: normalizedModel,
           providerVariant: resolveProviderVariant(normalizedModel),
           imageInputCount: countImageInputs(input),
+          requestKind: classifyMockOpenAiRequest(input, body as Record<string, unknown>),
+          outcome: "success",
+          rawByteLength: Buffer.byteLength(raw),
           plannedToolCallId: extractPlannedToolCallId(events),
           plannedToolName: plannedTool.name,
           ...(plannedTool.wireName && plannedTool.wireName !== plannedTool.name

--- a/extensions/qa-lab/src/scenario-catalog-compaction.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-compaction.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { readQaScenarioById } from "./scenario-catalog.js";
+import { requireFlowScenario } from "./scenario-catalog.test-utils.js";
+
+describe("qa compaction scenario catalog", () => {
+  it("assigns compaction retry and pruning to OpenClaw with an early Codex gap", () => {
+    const scenario = requireFlowScenario(readQaScenarioById("compaction-retry-mutating-tool"));
+    const flow = JSON.stringify(scenario.execution.flow);
+    const serializedScenario = JSON.stringify(scenario);
+    const knownGap =
+      "known-harness-gap compaction-retry-mutating-tool: provider-error recovery does not invoke Codex native compaction; native token-threshold compaction needs a separate scenario.";
+
+    expect(scenario.runtimePairLane).toBe("core");
+    expect(scenario.coverage?.primary).toEqual([
+      "session-memory.compaction",
+      "session-memory.compaction-retry-policy",
+      "session-memory.pruning",
+    ]);
+    expect(scenario.coverage?.secondary ?? []).toEqual([]);
+    expect(scenario.successCriteria).toContain(
+      "One coded over-threshold provider overflow produces one persisted OpenClaw overflow compaction and one compacted retry retaining durable current context.",
+    );
+    expect(scenario.successCriteria).toContain(
+      "OpenClaw performs exactly one successful write, one causal continuation, and returns the exact file content and final marker.",
+    );
+    expect(scenario.successCriteria).toContain(
+      "OpenClaw proves session-memory.pruning by retaining tail blocks 11..15 while pruning marker block 10.",
+    );
+    expect(scenario.successCriteria).toContain(
+      "The Codex runtime-pair cell reports a known harness gap before gateway, session, or provider work and makes no compaction coverage claim.",
+    );
+    expect(scenario.successCriteria.join("\n")).not.toContain("Both runtime cells");
+
+    const firstAction = scenario.execution.flow?.steps[0]?.actions[0] as
+      | Record<string, unknown>
+      | undefined;
+    expect(firstAction).toBeDefined();
+    const conditional = firstAction?.if as Record<string, unknown> | undefined;
+    expect(conditional?.expr).toBe("env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME === 'codex'");
+    expect(conditional?.["then"]).toMatchObject([
+      {
+        call: "qaImport",
+        args: ["./errors.js"],
+        saveAs: "qaErrors",
+      },
+      {
+        throw: {
+          expr: expect.stringContaining(`QaSuiteScenarioSkipError('${knownGap}')`),
+        },
+      },
+    ]);
+
+    const knownGapIndex = flow.indexOf(knownGap);
+    const gatewayWorkIndex = flow.indexOf('"call":"waitForGatewayHealthy"');
+    expect(knownGapIndex).toBeGreaterThanOrEqual(0);
+    expect(knownGapIndex).toBeLessThan(gatewayWorkIndex);
+    expect(flow).toContain('"call":"qaImport","args":["./errors.js"],"saveAs":"qaErrors"');
+    expect(flow).toContain("new qaErrors.QaSuiteScenarioSkipError");
+    expect(flow).toContain("seedQaSessionTranscript");
+    expect(flow).toContain("sessions.compaction.branch");
+    expect(flow).toContain("OPENCLAW_QA_FORCE_RUNTIME");
+    expect(flow).toContain('"transcriptToolName":"write"');
+    expect(flow).toContain('"requireSuccessfulTranscriptToolResult":true');
+    expect(flow).toContain("outbound.text === config.finalMarker");
+    expect(flow).toContain("overflowRequests.length === 1");
+    expect(flow).toContain("overflowRequest.rawByteLength > config.overflowThresholdBytes");
+    expect(flow).toContain("writeRequests.length === 1");
+    expect(flow).toContain("String(request.allInputText ?? '').includes(sessionId)");
+    expect(flow).toContain(
+      "String(writeRequest.allInputText ?? '').includes(config.durableMarker)",
+    );
+    expect(flow).toContain("request.cursor > overflowRequest.cursor");
+    expect(flow).toContain("request.plannedToolArgs?.path === config.outputFile");
+    expect(flow).toContain("request.plannedToolArgs?.content === config.expectedFileContent");
+    expect(flow).toContain("request.toolOutputCallId === writeRequest.plannedToolCallId");
+    expect(flow).toContain("request.cursor > writeRequest.cursor");
+    expect(flow).toContain(
+      "String(request.toolOutput ?? '').trim() === config.expectedWriteToolResult",
+    );
+    expect(flow).not.toContain("config.expectedOpenClawToolResult");
+    expect(flow).not.toContain("String(request.toolOutput ?? '').includes(`---");
+    expect(flow).not.toContain("String(request.toolOutput ?? '').includes(`+++");
+    expect(flow).toContain("postWriteContinuations.length === 1");
+    expect(flow).toContain(
+      "compactionSummaryRequests.every((request) => request.outcome === 'success' && request.plannedToolName === undefined)",
+    );
+    expect(flow).not.toContain("compactionSummaryRequests.length >= 1");
+    expect(flow).toContain(
+      "writeRequest.rawByteLength < config.overflowThresholdBytes && writeRequest.rawByteLength < overflowRequest.rawByteLength",
+    );
+    expect(flow).not.toContain("initialRequests.length === 2");
+    expect(flow).toContain("index === 10 ? config.bulkyMarker + ' ' : ''");
+    expect(flow).toContain("post-marker historical user block");
+    expect(flow).not.toContain("index === 12 ? config.bulkyMarker + ' ' : ''");
+    expect(flow).toContain("{ role: 'assistant', text: config.checkpointMarker");
+    expect(flow).not.toContain("{ role: 'assistant', text: config.bulkyMarker");
+    expect(flow).toContain("branchSummary.finalText === config.checkpointMarker");
+    expect(flow).toContain('"set":"requestEvidence"');
+    expect(flow).toContain("durable: String(request.allInputText ?? '')");
+    expect(flow).toContain("bulky: String(request.allInputText ?? '')");
+    expect(flow).toContain("inputChars: String(request.allInputText ?? '').length");
+    expect(flow).not.toContain("clientSessionId");
+    expect(flow).toContain("tailBlocks:");
+    expect(flow).toContain(".sort().slice(0, 16)");
+    expect(flow).toContain('"set":"overflowEvidence"');
+    expect(flow).toContain('"set":"writeEvidence"');
+    expect(flow).toContain(
+      "String(overflowRequest.allInputText ?? '').includes(config.bulkyMarker)",
+    );
+    expect(flow).toContain("!String(writeRequest.allInputText ?? '').includes(config.bulkyMarker)");
+    expect(flow).toContain("JSON.stringify(overflowEvidence.tailBlocks)");
+    expect(flow).toContain("JSON.stringify(['11', '12', '13', '14', '15'])");
+    expect(serializedScenario).not.toContain("remote-compaction");
+    expect(serializedScenario).not.toContain("remoteCompaction");
+    expect(flow).not.toContain("JSON.stringify(overflowRequest)");
+    const requestEvidenceIndex = flow.indexOf('"set":"scenarioRequests"');
+    expect(requestEvidenceIndex).toBeGreaterThanOrEqual(0);
+    expect(requestEvidenceIndex).toBeLessThan(flow.indexOf('"call":"fs.readFile"'));
+  });
+});

--- a/extensions/qa-lab/src/scenario-flow-runner.test.ts
+++ b/extensions/qa-lab/src/scenario-flow-runner.test.ts
@@ -1,6 +1,7 @@
 // Qa Lab tests cover scenario flow runner plugin behavior.
 import { describe, expect, it } from "vitest";
 import { createQaBusState } from "./bus-state.js";
+import { QaSuiteScenarioSkipError } from "./errors.js";
 import {
   readQaScenarioById,
   readQaScenarioPack,
@@ -744,6 +745,71 @@ describe("scenario-flow-runner", () => {
 
     expect(result.status).toBe("pass");
     expect(result.steps[0]?.details).toBe("loaded");
+  });
+
+  it("passes an imported QA skip error through to runScenario", async () => {
+    const message = "known-harness-gap flow import skip";
+    let receivedError: unknown;
+
+    const result = await runScenarioFlow({
+      api: {
+        state: createQaBusState(),
+        scenario: {
+          id: "qa-skip-import",
+          title: "qa-skip-import",
+          sourcePath: "qa/scenarios/qa-skip-import.yaml",
+          surface: "test",
+          objective: "test",
+          successCriteria: ["test"],
+          execution: { kind: "flow" },
+        },
+        config: {},
+        runScenario: async (
+          _name: string,
+          steps: Array<{ name: string; run: () => Promise<string | void> }>,
+        ) => {
+          try {
+            await steps[0]?.run();
+          } catch (error) {
+            receivedError = error;
+          }
+          return {
+            name: "qa-skip-import",
+            status: "skip" as const,
+            steps: [{ name: "throws imported skip", status: "skip" as const, details: message }],
+            details: message,
+          };
+        },
+      },
+      scenarioTitle: "qa-skip-import",
+      flow: {
+        steps: [
+          {
+            name: "throws imported skip",
+            actions: [
+              {
+                call: "qaImport",
+                args: ["./errors.js"],
+                saveAs: "qaErrors",
+              },
+              {
+                throw: {
+                  expr: `new qaErrors.QaSuiteScenarioSkipError(${JSON.stringify(message)})`,
+                },
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(receivedError).toBeInstanceOf(QaSuiteScenarioSkipError);
+    expect(receivedError).toMatchObject({
+      name: "QaSuiteScenarioSkipError",
+      message,
+    });
+    expect(result.status).toBe("skip");
+    expect(result.details).toBe(message);
   });
 
   it.each([

--- a/extensions/qa-lab/src/scenario-flow-runner.ts
+++ b/extensions/qa-lab/src/scenario-flow-runner.ts
@@ -36,6 +36,7 @@ const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor as
 const qaFlowImportLoaders: Record<string, QaFlowImportLoader> = {
   "./auth-profile.fixture.js": () => import("./auth-profile.fixture.js"),
   "./codex-plugin.fixture.js": () => import("./codex-plugin.fixture.js"),
+  "./errors.js": () => import("./errors.js"),
   "./live-transports/matrix/scenarios/scenario-runtime-allowbots.js": () =>
     import("./live-transports/matrix/scenarios/scenario-runtime-allowbots.js"),
   "./live-transports/matrix/scenarios/scenario-runtime-approval.js": () =>

--- a/qa/scenarios/runtime/compaction-retry-mutating-tool.yaml
+++ b/qa/scenarios/runtime/compaction-retry-mutating-tool.yaml
@@ -7,53 +7,87 @@ scenario:
   coverage:
     primary:
       - session-memory.compaction
-    secondary:
       - session-memory.compaction-retry-policy
-  objective: Verify a real mutating tool step keeps replay-unsafety explicit instead of disappearing into a clean-looking success if the run compacts or retries.
+      - session-memory.pruning
+  objective: Verify OpenClaw persists one overflow compaction, prunes bulky historical turns, retries from durable context, and performs the requested mutation exactly once.
   successCriteria:
-    - Agent reads the seeded large context before it writes.
-    - Agent performs a real mutating write in the workspace.
-    - Final reply explicitly says replay is unsafe after the write instead of implying replay-safe completion.
-    - Scenario details preserve the observed compaction count for review context.
+    - One coded over-threshold provider overflow produces one persisted OpenClaw overflow compaction and one compacted retry retaining durable current context.
+    - OpenClaw performs exactly one successful write, one causal continuation, and returns the exact file content and final marker.
+    - OpenClaw proves session-memory.pruning by retaining tail blocks 11..15 while pruning marker block 10.
+    - OpenClaw records one overflow-retry checkpoint whose branch preserves the independent pre-compaction assistant marker.
+    - The Codex runtime-pair cell reports a known harness gap before gateway, session, or provider work and makes no compaction coverage claim.
   docsRefs:
     - docs/help/testing.md
   codeRefs:
-    - extensions/qa-lab/src/suite.ts
     - extensions/qa-lab/src/providers/mock-openai/server.ts
-    - src/agents/embedded-agent-subscribe.ts
-    - src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
+    - src/agents/embedded-agent-runner/run/overflow-context-recovery.ts
+    - src/gateway/session-compaction-checkpoints.ts
   execution:
     kind: flow
-    summary: Verify a mutating tool step keeps replay-unsafety explicit through compaction or retry pressure.
+    summary: Force one OpenClaw context overflow, verify persisted pruning evidence, and prove exactly-once mutation after compaction.
     config:
-      contextFile: COMPACTION_RETRY_CONTEXT.md
       outputFile: compaction-retry-summary.txt
       promptSnippet: Compaction retry mutating tool check
-      replayUnsafeNeedle: replay unsafe after write
+      durableMarker: QA-COMPACTION-DURABLE-MARKER
+      bulkyMarker: QA-COMPACTION-BULKY-HISTORICAL-MARKER
+      checkpointMarker: QA-COMPACTION-PRECOMPACTION-ASSISTANT-MARKER
+      overflowThresholdBytes: 262144
+      expectedFileContent: "Replay safety: unsafe after write.\n"
+      expectedWriteToolResult: Successfully wrote 35 bytes to compaction-retry-summary.txt
+      finalMarker: "Protocol note: replay unsafe after write."
       prompt: |-
-        Compaction retry mutating tool check: read `COMPACTION_RETRY_CONTEXT.md`, then create `compaction-retry-summary.txt` in the workspace containing exactly this line:
+        Compaction retry mutating tool check. Current durable context marker: QA-COMPACTION-DURABLE-MARKER.
+
+        Create `compaction-retry-summary.txt` in the workspace containing exactly:
         Replay safety: unsafe after write.
 
-        After the write, reply with one short sentence that includes the exact phrase `replay unsafe after write`.
-        If the run gets compacted or retried, keep that replay-safety truth explicit and do not claim the task stayed replay-safe.
+        Then reply with exactly: Protocol note: replay unsafe after write.
 
 flow:
   steps:
-    - name: keeps replay-unsafety explicit after a mutating write under compaction pressure
+    - name: compacts bulky history and mutates exactly once after overflow
       actions:
+        - if:
+            expr: "env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME === 'codex'"
+            then:
+              - call: qaImport
+                args:
+                  - ./errors.js
+                saveAs: qaErrors
+              - throw:
+                  expr: "new qaErrors.QaSuiteScenarioSkipError('known-harness-gap compaction-retry-mutating-tool: provider-error recovery does not invoke Codex native compaction; native token-threshold compaction needs a separate scenario.')"
+        - assert:
+            expr: "env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME === 'openclaw' && env.providerMode === 'mock-openai' && Boolean(env.mock)"
+            message: compaction overflow injection requires the mock-openai OpenClaw runtime
         - call: waitForGatewayHealthy
           args:
             - ref: env
             - 60000
         - call: reset
-        - call: fs.writeFile
-          args:
-            - expr: "path.join(env.gateway.workspaceDir, config.contextFile)"
-            - expr: "Array.from({ length: env.providerMode === 'mock-openai' ? 160 : 2200 }, (_, index) => `compaction retry evidence block ${String(index).padStart(4, '0')} :: keep replay truth explicit after side effects`).join('\\n')"
-            - utf8
+        - set: sessionId
+          value:
+            expr: "`qa-compaction-retry-${randomUUID()}`"
         - set: sessionKey
           value:
             expr: "`agent:qa:compaction-retry:${randomUUID().slice(0, 8)}`"
+        - set: now
+          value:
+            expr: "Date.now()"
+        - call: seedQaSessionTranscript
+          args:
+            - ref: env
+            - sessionId:
+                ref: sessionId
+              sessionKey:
+                ref: sessionKey
+              updatedAt:
+                ref: now
+              label: QA compaction retry historical transcript
+              messages:
+                expr: "[...Array.from({ length: 32 }, (_, index) => [{ role: 'user', text: `historical user block ${String(index).padStart(2, '0')} ${'u'.repeat(8192)}`, timestamp: now - (70000 - index * 2000) }, { role: 'assistant', text: `historical assistant block ${String(index).padStart(2, '0')} ${'a'.repeat(8192)}`, timestamp: now - (69000 - index * 2000) }]).flat(), ...Array.from({ length: 16 }, (_, index) => ({ role: 'user', text: `${index === 10 ? config.bulkyMarker + ' ' : ''}post-marker historical user block ${String(index).padStart(2, '0')} ${Array.from({ length: 4096 }, (_, tokenIndex) => `tail_${String(index).padStart(2, '0')}_${String(tokenIndex).padStart(4, '0')}`).join(' ')}`, timestamp: now - (6000 - index * 300) })), { role: 'assistant', text: config.checkpointMarker, timestamp: now - 1000 }]"
+        - set: requestCursorBefore
+          value:
+            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/request-cursor`)).cursor"
         - call: runAgentPrompt
           args:
             - ref: env
@@ -62,30 +96,104 @@ flow:
               message:
                 ref: config.prompt
               timeoutMs:
-                expr: liveTurnTimeoutMs(env, 90000)
+                expr: liveTurnTimeoutMs(env, 120000)
+              transcriptToolName: write
+              requireSuccessfulTranscriptToolResult: true
         - call: waitForCondition
           saveAs: outbound
           args:
             - lambda:
-                expr: "state.getSnapshot().messages.filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === 'qa-operator' && normalizeLowercaseStringOrEmpty(candidate.text).includes(config.replayUnsafeNeedle)).at(-1)"
+                expr: "state.getSnapshot().messages.filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === 'qa-operator' && candidate.text.includes(config.finalMarker)).at(-1)"
             - expr: liveTurnTimeoutMs(env, 45000)
-            - expr: "env.providerMode === 'mock-openai' ? 100 : 250"
+            - 100
+        - assert:
+            expr: "outbound.text === config.finalMarker"
+            message:
+              expr: "`unexpected final compaction reply: ${JSON.stringify(outbound.text)}`"
+        - set: scenarioRequests
+          value:
+            expr: "await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBefore}`)"
+        - set: requestEvidence
+          value:
+            expr: "scenarioRequests.map((request) => ({ cursor: request.cursor, kind: request.requestKind, outcome: request.outcome, code: request.errorCode ?? null, bytes: request.rawByteLength, inputChars: String(request.allInputText ?? '').length, tailBlocks: [...new Set(Array.from({ length: 16 }, (_, index) => String(index).padStart(2, '0')).filter((id) => String(request.allInputText ?? '').includes(`post-marker historical user block ${id}`)))].sort().slice(0, 16), prompt: String(request.allInputText ?? '').includes(config.promptSnippet), durable: String(request.allInputText ?? '').includes(config.durableMarker), bulky: String(request.allInputText ?? '').includes(config.bulkyMarker), tool: request.plannedToolName ?? null }))"
+        - set: overflowRequests
+          value:
+            expr: "scenarioRequests.filter((request) => request.requestKind === 'agent-initial' && request.outcome === 'error' && request.errorCode === 'context_length_exceeded' && String(request.allInputText ?? '').includes(sessionId) && String(request.allInputText ?? '').includes(config.promptSnippet) && String(request.allInputText ?? '').includes(config.durableMarker))"
+        - assert:
+            expr: "overflowRequests.length === 1"
+            message:
+              expr: "`expected one scenario-owned coded overflow: ${JSON.stringify(requestEvidence)}`"
+        - set: overflowRequest
+          value:
+            expr: "overflowRequests[0]"
+        - set: writeRequests
+          value:
+            expr: "scenarioRequests.filter((request) => request.requestKind === 'agent-initial' && request.outcome === 'success' && request.plannedToolName === 'write' && !request.toolOutput && request.cursor > overflowRequest.cursor && String(request.allInputText ?? '').includes(sessionId) && String(request.allInputText ?? '').includes(config.promptSnippet) && String(request.allInputText ?? '').includes(config.durableMarker) && request.plannedToolArgs?.path === config.outputFile && request.plannedToolArgs?.content === config.expectedFileContent)"
+        - assert:
+            expr: "writeRequests.length === 1"
+            message:
+              expr: "`expected one later scenario-owned write retry: ${JSON.stringify(requestEvidence)}`"
+        - set: writeRequest
+          value:
+            expr: "writeRequests[0]"
+        - set: overflowEvidence
+          value:
+            expr: "requestEvidence.find((request) => request.cursor === overflowRequest.cursor)"
+        - set: writeEvidence
+          value:
+            expr: "requestEvidence.find((request) => request.cursor === writeRequest.cursor)"
+        - call: readSessionTranscriptSummary
+          saveAs: transcript
+          args:
+            - ref: env
+            - ref: sessionKey
+        - assert:
+            expr: "transcript.successfulToolCallCounts.write === 1"
+            message:
+              expr: "`expected exactly one successful write, got ${JSON.stringify(transcript.successfulToolCallCounts)}`"
+        - assert:
+            expr: "overflowRequest.rawByteLength > config.overflowThresholdBytes"
+            message:
+              expr: "`original request did not exceed the overflow threshold: ${JSON.stringify(overflowEvidence)}`"
+        - assert:
+            expr: "String(writeRequest.allInputText ?? '').includes(config.durableMarker)"
+            message:
+              expr: "`compacted retry did not retain durable current context: ${JSON.stringify({ overflow: overflowEvidence, write: writeEvidence })}`"
+        - set: postWriteContinuations
+          value:
+            expr: "scenarioRequests.filter((request) => request.requestKind === 'tool-continuation' && request.outcome === 'success' && request.plannedToolName === undefined && request.cursor > writeRequest.cursor && request.toolOutputCallId === writeRequest.plannedToolCallId && String(request.allInputText ?? '').includes(sessionId) && String(request.toolOutput ?? '').trim() === config.expectedWriteToolResult)"
+        - assert:
+            expr: "postWriteContinuations.length === 1"
+            message:
+              expr: "`expected one post-write continuation and no replayed mutation: ${JSON.stringify(requestEvidence.filter((request) => request.cursor > writeRequest.cursor))}`"
         - call: fs.readFile
           saveAs: writtenSummary
           args:
             - expr: "path.join(env.gateway.workspaceDir, config.outputFile)"
             - utf8
         - assert:
-            expr: "writtenSummary.includes('Replay safety: unsafe after write.')"
+            expr: "writtenSummary === config.expectedFileContent"
             message:
-              expr: "`summary file missed replay marker: ${writtenSummary}`"
-        - if:
-            expr: "Boolean(env.mock)"
-            then:
-              - assert:
-                  expr: "!env.mock || ([...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].toReversed().find((request) => String(request.allInputText ?? '').includes(config.promptSnippet) && String(request.toolOutput ?? '').includes('compaction retry evidence block'))?.plannedToolName === 'write')"
-                  message:
-                    expr: "`expected write after seeded context read, got ${String(([...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].toReversed().find((request) => String(request.allInputText ?? '').includes(config.promptSnippet) && String(request.toolOutput ?? '').includes('compaction retry evidence block'))?.plannedToolName ?? '')}`"
+              expr: "`unexpected compaction retry file content: ${JSON.stringify(writtenSummary)}; requests=${JSON.stringify(requestEvidence)}`"
+        - assert:
+            expr: "String(overflowRequest.allInputText ?? '').includes(config.bulkyMarker) && !String(writeRequest.allInputText ?? '').includes(config.bulkyMarker)"
+            message:
+              expr: "`OpenClaw retry did not prune marker block 10: ${JSON.stringify({ overflow: overflowEvidence, write: writeEvidence })}`"
+        - assert:
+            expr: "JSON.stringify(overflowEvidence.tailBlocks) === JSON.stringify(Array.from({ length: 16 }, (_, index) => String(index).padStart(2, '0'))) && JSON.stringify(writeEvidence.tailBlocks) === JSON.stringify(['11', '12', '13', '14', '15'])"
+            message:
+              expr: "`OpenClaw tail retention did not prove causal pruning of block 10: ${JSON.stringify({ overflow: overflowEvidence, write: writeEvidence })}`"
+        - assert:
+            expr: "writeRequest.rawByteLength < config.overflowThresholdBytes && writeRequest.rawByteLength < overflowRequest.rawByteLength"
+            message:
+              expr: "`OpenClaw retry was not compacted below the overflow threshold: original=${String(overflowRequest.rawByteLength)} retry=${String(writeRequest.rawByteLength)}`"
+        - set: compactionSummaryRequests
+          value:
+            expr: "scenarioRequests.filter((request) => request.requestKind === 'compaction-summary')"
+        - assert:
+            expr: "compactionSummaryRequests.every((request) => request.outcome === 'success' && request.plannedToolName === undefined)"
+            message:
+              expr: "`OpenClaw compaction summary requests included a failure or tool plan: ${JSON.stringify(requestEvidence.filter((request) => request.kind === 'compaction-summary'))}`"
         - call: readRawQaSessionStore
           saveAs: store
           args:
@@ -94,7 +202,29 @@ flow:
           value:
             expr: "store[sessionKey]"
         - assert:
-            expr: "Boolean(sessionEntry)"
+            expr: "sessionEntry?.compactionCount === 1 && Number.isFinite(sessionEntry?.totalTokens) && sessionEntry?.totalTokensFresh === true"
             message:
-              expr: "`missing QA session entry for ${sessionKey}`"
-      detailsExpr: "`${outbound.text}\\ncompactionCount=${String(sessionEntry?.compactionCount ?? 0)}\\nstatus=${String(sessionEntry?.status ?? 'unknown')}`"
+              expr: "`OpenClaw token snapshot was not fresh after one compaction: ${JSON.stringify({ compactionCount: sessionEntry?.compactionCount, totalTokens: sessionEntry?.totalTokens, totalTokensFresh: sessionEntry?.totalTokensFresh })}`"
+        - set: checkpointPage
+          value:
+            expr: "await env.gateway.call('sessions.compaction.list', { key: sessionKey }, { timeoutMs: 15000 })"
+        - set: overflowCheckpoints
+          value:
+            expr: "(checkpointPage.checkpoints ?? []).filter((checkpoint) => checkpoint.reason === 'overflow-retry')"
+        - assert:
+            expr: "overflowCheckpoints.length === 1 && Number.isFinite(overflowCheckpoints[0].tokensBefore) && Number.isFinite(overflowCheckpoints[0].tokensAfter) && overflowCheckpoints[0].tokensBefore > overflowCheckpoints[0].tokensAfter && overflowCheckpoints[0].tokensAfter >= 0"
+            message:
+              expr: "`invalid overflow checkpoint evidence: ${JSON.stringify(overflowCheckpoints.map((checkpoint) => ({ checkpointId: checkpoint.checkpointId, reason: checkpoint.reason, tokensBefore: checkpoint.tokensBefore, tokensAfter: checkpoint.tokensAfter })))}`"
+        - set: branchResult
+          value:
+            expr: "await env.gateway.call('sessions.compaction.branch', { key: sessionKey, checkpointId: overflowCheckpoints[0].checkpointId }, { timeoutMs: 30000 })"
+        - call: readSessionTranscriptSummary
+          saveAs: branchSummary
+          args:
+            - ref: env
+            - expr: "branchResult.key"
+        - assert:
+            expr: "branchSummary.finalText === config.checkpointMarker"
+            message:
+              expr: "`checkpoint branch did not preserve pre-compaction assistant marker: ${JSON.stringify({ key: branchResult.key, finalText: branchSummary.finalText })}`"
+      detailsExpr: "`${outbound.text}\\nOpenClaw originalBytes=${String(overflowRequest.rawByteLength)} retryBytes=${String(writeRequest.rawByteLength)} writes=${String(transcript.successfulToolCallCounts.write ?? 0)} compactions=${String(sessionEntry.compactionCount)} checkpoints=${String(overflowCheckpoints.length)}`"


### PR DESCRIPTION
## What Problem This Solves

The existing compaction-retry QA scenario did not prove that one coded provider overflow causes exactly one OpenClaw compaction and retry, preserves durable current context, prunes older history, and avoids replaying a mutating tool. Its paired Codex cell could also look successful without exercising Codex native compaction.

## Why This Change Was Made

This strengthens the mock provider contract and scenario evidence around request kind, coded overflow outcome, raw request size, retry ordering, transcript checkpoints, one successful write, one causal continuation, and exact pruning boundaries. The Codex cell now exits before gateway or provider work with an explicit known-harness-gap because provider-error recovery does not invoke Codex native token-threshold compaction.

## User Impact

No production runtime behavior changes. Maintainers gain deterministic regression coverage for overflow compaction retry safety and pruning, without overstating cross-runtime parity.

## Evidence

- Exact head: `dc41d697799007dd907a8054f5b4d82f00a3dce1`
- Exact-head private QA runtime pair passed:
  - OpenClaw: pass, one successful `write`, exact final text `Protocol note: replay unsafe after write.`, `totalTokens=168`
  - Codex: intentional skip in 4 ms with zero tools and the documented known harness gap
  - Pair verdict: pass with structural drift
- Coverage evidence records these primary IDs:
  - `session-memory.compaction`
  - `session-memory.compaction-retry-policy`
  - `session-memory.pruning`
- Focused QA Lab tests: 270 passed
- Extension lint: passed
- Import-cycle check: 0 runtime value cycles
- Project tsgo build: passed
- Exact-head private QA build: passed
- Sol/high autoreview: clean, confidence 0.99
- `git diff --check` and privacy scan: clean
- Blacksmith was unavailable because this session was unauthenticated. The changed-gate Daytona attempt failed before command execution during remote seed/hydration, so trusted local fallback was used per repository policy.

Codex contract checked directly at `openai/codex@bb1af235ea2822d7a40f75ef52e4d6a2cde84da2`:

- `codex-rs/codex-api/src/sse/responses.rs:625-627`
- `codex-rs/core/src/compact.rs:240-385`
- `codex-rs/core/src/compact.rs:525-547`
- `codex-rs/core/src/compact.rs:630-654`
- `codex-rs/core/src/compact_remote_v2.rs:201-321`
- `codex-rs/core/src/compact_remote_v2.rs:330-378`
- `codex-rs/core/src/compact_remote_v2_attempt.rs:30-134`
- `codex-rs/core/src/session/turn.rs:330-545`
- `codex-rs/core/src/session/turn.rs:983-1010`
- `codex-rs/core/src/session/turn.rs:1369-1373`

- [x] AI-assisted
- [x] I understand the changed QA behavior and proof boundary
