### PR TITLE
test(qa): prove failure recovery visibility

### DIFF
--- a/qa/scenarios/runtime/empty-response-recovery-replay-safe-read.yaml
+++ b/qa/scenarios/runtime/empty-response-recovery-replay-safe-read.yaml
@@ -6,13 +6,15 @@ scenario:
   coverage:
     primary:
       - agent-runtime.failure-recovery-empty-response-recovery
-    secondary:
       - agent-runtime.failure-recovery-retry-policy
+      - agent-runtime.failure-recovery-evidence
+      - agent-runtime.progress-visibility-failure-recovery
   objective: Verify an empty visible GPT turn after a replay-safe read auto-continues into a visible answer.
   successCriteria:
     - Scenario is mock-openai only so live lanes do not pick it up implicitly.
     - The agent performs a replay-safe read before the empty response.
     - The runtime injects the visible-answer continuation instruction after the empty turn.
+    - The authenticated read result survives the empty turn and canonical retry unchanged.
     - The final visible reply contains the exact recovery marker.
   docsRefs:
     - docs/help/testing.md
@@ -27,6 +29,7 @@ scenario:
       promptSnippet: Empty response continuation QA check
       prompt: "Empty response continuation QA check: read QA_KICKOFF_TASK.md, then answer with exactly EMPTY-RECOVERED-OK."
       expectedReply: EMPTY-RECOVERED-OK
+      evidenceNonce: EMPTY-RECOVERY-EVIDENCE-7B2F
       retryNeedle: The previous assistant turn completed its tool calls but did not produce a user-visible answer.
 
 flow:
@@ -41,6 +44,17 @@ flow:
             - ref: env
             - 60000
         - call: reset
+        - assert:
+            expr: "!config.prompt.includes(config.evidenceNonce)"
+            message: recovery evidence nonce must originate only from the read result
+        - call: fs.writeFile
+          args:
+            - expr: "path.join(env.gateway.workspaceDir, 'QA_KICKOFF_TASK.md')"
+            - expr: "`${config.evidenceNonce}\\n`"
+            - utf8
+        - set: outboundStartIndex
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
         - set: requestCursorBefore
           value:
             expr: "env.mock ? (await fetchJson(`${env.mock.baseUrl}/debug/request-cursor`)).cursor : 0"
@@ -68,16 +82,46 @@ flow:
             expr: "outbound.text.includes(config.expectedReply)"
             message:
               expr: "`missing empty-response recovery marker: ${outbound.text}`"
+        - call: sleep
+          args:
+            - 300
+        - set: scenarioOutbound
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').slice(outboundStartIndex).filter((message) => message.conversation.id === 'qa-operator')"
+        - call: readSessionTranscriptSummary
+          saveAs: transcript
+          args:
+            - ref: env
+            - ref: sessionKey
         - if:
             expr: "Boolean(env.mock)"
             then:
               - set: scenarioRequests
                 value:
-                  expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBefore}`))"
+                  expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBefore}`)).filter((request) => String(request.allInputText ?? '').includes(config.promptSnippet))"
+              - set: retryRequests
+                value:
+                  expr: "scenarioRequests.filter((request) => String(request.allInputText ?? '').includes(config.retryNeedle))"
               - assert:
-                  expr: "scenarioRequests.some((request) => String(request.allInputText ?? '').includes(config.promptSnippet) && request.plannedToolName === 'read')"
-                  message: expected replay-safe read request in mock trace
+                  expr: "scenarioRequests.length === 3"
+                  message:
+                    expr: "`expected read, post-tool empty, and canonical retry requests; saw ${JSON.stringify(scenarioRequests.map((request) => ({ cursor: request.cursor, tool: request.plannedToolName ?? null, callId: request.toolOutputCallId ?? null })))}`"
               - assert:
-                  expr: "scenarioRequests.some((request) => String(request.allInputText ?? '').includes(config.retryNeedle))"
-                  message: expected empty-response retry instruction in mock trace
-      detailsExpr: "env.mock ? `${outbound.text}\\nrequests=${String(scenarioRequests?.length ?? 0)}` : outbound.text"
+                  expr: "scenarioRequests[0]?.plannedToolName === 'read' && scenarioRequests.filter((request) => request.plannedToolName === 'read').length === 1 && retryRequests.length === 1 && scenarioRequests[2] === retryRequests[0] && String(scenarioRequests[2]?.allInputText ?? '').split(config.promptSnippet).length === 2 && String(scenarioRequests[2]?.allInputText ?? '').split(config.retryNeedle).length === 2"
+                  message: expected one replay-safe read and one final canonical retry
+              - assert:
+                  expr: "typeof scenarioRequests[0]?.plannedToolCallId === 'string' && scenarioRequests[0].plannedToolCallId.length > 0 && scenarioRequests[1]?.toolOutputCallId === scenarioRequests[0].plannedToolCallId && [scenarioRequests[1], scenarioRequests[2]].every((request) => { const input = Array.isArray(request?.body?.input) ? request.body.input : []; const callIds = input.filter((item) => item?.type === 'function_call').map((item) => item.call_id); const outputIds = input.filter((item) => item?.type === 'function_call_output').map((item) => item.call_id); return callIds.length === 1 && outputIds.length === 1 && callIds[0] === outputIds[0]; })"
+                  message:
+                    expr: "`read result call id did not remain paired through the empty turn and normalized retry: ${JSON.stringify(scenarioRequests.map((request) => ({ cursor: request.cursor, plannedToolCallId: request.plannedToolCallId ?? null, toolOutputCallId: request.toolOutputCallId ?? null })))}`"
+              - assert:
+                  expr: "[scenarioRequests[1], scenarioRequests[2]].every((request) => String(request.toolOutput ?? '').includes(config.evidenceNonce) && String(request.allInputText ?? '').includes(config.evidenceNonce))"
+                  message: authenticated read nonce did not survive into both post-tool requests
+        - assert:
+            expr: "transcript.userMessageCount === 2 && transcript.assistantToolCallCounts.read === 1 && transcript.completedToolCallCounts.read === 1 && transcript.successfulToolCallCounts.read === 1 && transcript.finalText.includes(config.expectedReply)"
+            message:
+              expr: "`recovery transcript lost requester, read-result, or final evidence: ${JSON.stringify(transcript)}`"
+        - assert:
+            expr: "scenarioOutbound.length === 1 && scenarioOutbound[0]?.text.trim() === config.expectedReply && !scenarioOutbound[0].text.trim().startsWith('⚠️')"
+            message:
+              expr: "`expected one warning-free final delivery and no intermediate success: ${JSON.stringify(scenarioOutbound.map((message) => message.text))}`"
+      detailsExpr: "env.mock ? `${outbound.text}\\nrequests=${String(scenarioRequests?.length ?? 0)} readResults=${String(transcript.successfulToolCallCounts.read ?? 0)}` : outbound.text"

--- a/qa/scenarios/runtime/empty-response-retry-budget-exhausted.yaml
+++ b/qa/scenarios/runtime/empty-response-retry-budget-exhausted.yaml
@@ -6,6 +6,7 @@ scenario:
   coverage:
     primary:
       - agent-runtime.failure-recovery-empty-response-recovery
+      - agent-runtime.progress-visibility-failure-recovery
     secondary:
       - agent-runtime.failure-recovery-retry-policy
   objective: Verify repeated empty GPT turns exhaust each configured model's retry budget after one continuation attempt.

--- a/qa/scenarios/runtime/reasoning-only-no-auto-retry-after-write.yaml
+++ b/qa/scenarios/runtime/reasoning-only-no-auto-retry-after-write.yaml
@@ -6,14 +6,15 @@ scenario:
   coverage:
     primary:
       - agent-runtime.failure-recovery-reasoning-only-recovery
-    secondary:
       - agent-runtime.failure-recovery-retry-policy
+      - agent-runtime.failure-recovery-no-fake-progress
   objective: Verify a GPT-style reasoning-only turn after a mutating write stays replay-unsafe and does not auto-retry.
   successCriteria:
     - Scenario is mock-openai only so live lanes do not pick it up implicitly.
     - The agent performs the seeded mutating write.
     - Mock trace does not include an automatic reasoning-only retry instruction.
     - Mock trace stops after the write-side reasoning-only terminal turn instead of attempting a continuation.
+    - Exactly one visible warning reports that side effects may already have happened.
   docsRefs:
     - docs/help/testing.md
   codeRefs:
@@ -28,6 +29,8 @@ scenario:
       prompt: "Reasoning-only after write safety check: write reasoning-only-side-effect.txt, then answer with exactly SIDE-EFFECT-GUARD-OK."
       retryNeedle: recorded reasoning but did not produce a user-visible answer
       outputFile: reasoning-only-side-effect.txt
+      expectedWarning: "⚠️ Agent couldn't generate a response. Note: some tool actions may have already been executed — please verify before retrying."
+      forbiddenReplyNeedles: [SIDE-EFFECT-GUARD-OK, successfully, completed, complete]
 
 flow:
   steps:
@@ -41,6 +44,9 @@ flow:
             - ref: env
             - 60000
         - call: reset
+        - set: outboundStartIndex
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
         - set: requestCursorBefore
           value:
             expr: "env.mock ? (await fetchJson(`${env.mock.baseUrl}/debug/request-cursor`)).cursor : 0"
@@ -61,9 +67,9 @@ flow:
           value:
             expr: "await env.gateway.call('agent.wait', { runId: started.runId, timeoutMs: liveTurnTimeoutMs(env, 45000) }, { timeoutMs: liveTurnTimeoutMs(env, 50000) })"
         - assert:
-            expr: "['ok', 'completed', 'succeeded'].includes(String(waited?.status)) || (waited?.status === 'error' && String(waited?.error ?? '').trim().toLowerCase() === 'completed')"
+            expr: "String(waited?.status) === 'error' && String(waited?.error) === 'failed'"
             message:
-              expr: "`agent.wait returned ${String(waited?.status ?? 'unknown')}: ${String(waited?.error ?? '')}`"
+              expr: "`agent.wait should expose the terminal no-visible-answer failure, got ${String(waited?.status ?? 'unknown')}: ${String(waited?.error ?? '')}`"
         - call: fs.readFile
           saveAs: sideEffect
           args:
@@ -73,19 +79,49 @@ flow:
             expr: "sideEffect.includes('side effects already happened')"
             message:
               expr: "`side-effect file missing expected contents: ${sideEffect}`"
+        - set: warning
+          value:
+            expr: "(async () => { const deadline = Date.now() + liveTurnTimeoutMs(env, 30000); do { const message = state.getSnapshot().messages.filter((candidate) => candidate.direction === 'outbound').slice(outboundStartIndex).find((candidate) => candidate.conversation.id === 'qa-operator' && candidate.text === config.expectedWarning); if (message) { return message; } await sleep(100); } while (Date.now() < deadline); throw new Error('timed out waiting for the side-effect warning'); })()"
+        - call: sleep
+          args:
+            - 300
+        - set: scenarioOutbound
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').slice(outboundStartIndex).filter((message) => message.conversation.id === 'qa-operator')"
+        - call: readSessionTranscriptSummary
+          saveAs: transcript
+          args:
+            - ref: env
+            - ref: sessionKey
         - if:
             expr: "Boolean(env.mock)"
             then:
               - set: scenarioRequests
                 value:
-                  expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBefore}`))"
+                  expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBefore}`)).filter((request) => String(request.allInputText ?? '').includes(config.promptSnippet))"
+              - set: retryRequests
+                value:
+                  expr: "scenarioRequests.filter((request) => String(request.allInputText ?? '').includes(config.retryNeedle))"
               - assert:
-                  expr: "scenarioRequests.some((request) => String(request.allInputText ?? '').includes(config.promptSnippet) && request.plannedToolName === 'write')"
-                  message: expected mutating write request in mock trace
+                  expr: "scenarioRequests.length === 2 && scenarioRequests[0]?.plannedToolName === 'write' && !scenarioRequests[1]?.plannedToolName"
+                  message:
+                    expr: "`expected exactly one write request plus one reasoning-only terminal request: ${JSON.stringify(scenarioRequests.map((request) => ({ cursor: request.cursor, tool: request.plannedToolName ?? null, callId: request.toolOutputCallId ?? null })))}`"
               - assert:
-                  expr: "!scenarioRequests.some((request) => String(request.allInputText ?? '').includes(config.retryNeedle))"
+                  expr: "retryRequests.length === 0"
                   message: reasoning-only retry instruction should not be injected after a write
               - assert:
-                  expr: "scenarioRequests.filter((request) => String(request.allInputText ?? '').includes(config.promptSnippet)).length === 2"
-                  message: expected exactly the write request plus the reasoning-only terminal request
-      detailsExpr: "env.mock ? `requests=${String(scenarioRequests?.length ?? 0)} sideEffect=${sideEffect.trim()}` : sideEffect"
+                  expr: "typeof scenarioRequests[0]?.plannedToolCallId === 'string' && scenarioRequests[0].plannedToolCallId.length > 0 && scenarioRequests[1]?.toolOutputCallId === scenarioRequests[0].plannedToolCallId && String(scenarioRequests[1]?.toolOutput ?? '').length > 0"
+                  message: committed write result did not match its planned tool call
+        - assert:
+            expr: "transcript.userMessageCount === 1 && transcript.assistantToolCallCounts.write === 1 && transcript.completedToolCallCounts.write === 1 && transcript.successfulToolCallCounts.write === 1"
+            message:
+              expr: "`write transcript did not persist exactly one successful side effect: ${JSON.stringify(transcript)}`"
+        - assert:
+            expr: "scenarioOutbound.length === 1 && warning.text === config.expectedWarning && scenarioOutbound[0]?.text === config.expectedWarning"
+            message:
+              expr: "`expected exactly one visible side-effect warning: ${JSON.stringify(scenarioOutbound.map((message) => message.text))}`"
+        - assert:
+            expr: "config.forbiddenReplyNeedles.every((needle) => !normalizeLowercaseStringOrEmpty(warning.text).includes(normalizeLowercaseStringOrEmpty(needle))) && !normalizeLowercaseStringOrEmpty(transcript.finalText).includes(normalizeLowercaseStringOrEmpty('SIDE-EFFECT-GUARD-OK'))"
+            message:
+              expr: "`side-effect warning or transcript claimed success/completion: warning=${warning.text} final=${transcript.finalText}`"
+      detailsExpr: "env.mock ? `requests=${String(scenarioRequests?.length ?? 0)} writes=${String(transcript.successfulToolCallCounts.write ?? 0)} warning=${warning.text}` : sideEffect"


### PR DESCRIPTION
## What Problem This Solves

Failure-recovery coverage named retry policy, evidence, no-fake-progress, and
progress visibility, but the runtime scenarios did not prove those contracts
strongly enough to own them as primary coverage.

## Why This Change Was Made

- Promotes replay-safe recovery to primary ownership of retry policy, evidence,
  and progress visibility.
- Binds the read result to a nonce absent from the prompt and verifies matched
  function-call/result identities through normalized replay.
- Proves exactly three requests, one canonical retry, one successful read, and
  one warning-free visible final.
- Promotes side-effect recovery to primary ownership of retry policy and
  no-fake-progress.
- Proves exactly two requests, one successful write, no retry, and one visible
  side-effect warning without success/completion wording.
- Adds progress-visibility ownership to the existing retry-exhaustion scenario,
  which already proves one sanitized visible failure after bounded retries.

The architectural owner remains the existing runtime QA scenarios. No mock,
runtime, taxonomy, production TypeScript, or compatibility path changed.

## User Impact

No production behavior changes. The QA matrix now fails when recovery silently
drops authenticated evidence, retries a side effect, emits fake progress, or
ends without the expected visible success/failure outcome.

Production LOC delta: `+0`. QA YAML delta: `+98/-17` across three existing
scenarios. No paths were removed.

## Evidence

- Blacksmith Testbox `tbx_01kz53d9nbnkb2an9qyq8hewc7`
  - exact rebased-head scenario suite: `3 passed, 0 failed, 0 skipped`
  - exact coverage queries: all four promoted IDs resolved as expected
- `extensions/qa-lab/src/scenario-catalog.test.ts`: `47 passed`
- `pnpm check:changed`: passed all selected lanes, including `tsgo`, oxlint,
  and runtime import-cycle checks
- Direct Codex `gpt-5.6-sol` high autoreview: no findings; patch correct,
  confidence `0.99`

<!-- Review coverage: replay-safe success, retry exhaustion, side-effect warning -->
