### PR TITLE
fix(telegram): bound the request deadline to the body read

### DIFF
--- a/extensions/telegram/src/client-fetch.ts
+++ b/extensions/telegram/src/client-fetch.ts
@@ -1,5 +1,6 @@
 // Telegram plugin module implements client fetch behavior.
 import type { ApiClientOptions } from "grammy";
+import { responseWithRelease } from "openclaw/plugin-sdk/fetch-runtime";
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { TelegramTransport } from "./fetch.js";
 import { isTelegramMisdirectedRequestError, tagTelegramNetworkError } from "./network-errors.js";
@@ -179,30 +180,53 @@ export function createTelegramClientFetch(params: {
         requestTimeout.unref?.();
       }
 
-      try {
-        return await callFetch(input, {
-          ...init,
-          signal: controller.signal,
-        });
-      } catch (err) {
-        if (requestTimedOut && timeoutError) {
-          throw timeoutError;
-        }
-        throw err;
-      } finally {
+      const disarm = () => {
         if (requestTimeout) {
           clearTimeout(requestTimeout);
+          requestTimeout = undefined;
         }
         shutdownSignal?.removeEventListener("abort", onShutdown);
         if (requestSignal && onRequestAbort) {
           requestSignal.removeEventListener("abort", onRequestAbort);
         }
+      };
+      // An aborted request never reaches the body observer below.
+      controller.signal.addEventListener("abort", disarm, { once: true });
+
+      let response: Awaited<ReturnType<typeof callFetch>>;
+      try {
+        response = await callFetch(input, {
+          ...init,
+          signal: controller.signal,
+        });
+      } catch (err) {
+        disarm();
+        if (requestTimedOut && timeoutError) {
+          throw timeoutError;
+        }
+        throw err;
       }
+      // Headers arriving is not request completion: the Bot API client reads the
+      // body after this returns. Disarming here let a peer that sends headers and
+      // then stalls mid-body outlive the request timeout entirely, leaving only
+      // the far slower stall watchdog to notice (#119007).
+      // grammY types Bot API responses as node-fetch's Response while the SDK
+      // helper speaks the platform Response; they are the same runtime object.
+      return responseWithRelease(response as unknown as Response, async () =>
+        disarm(),
+      ) as unknown as typeof response;
     };
 
     try {
       const response = await runFetch();
       if (response.status === 421 && canForceTransportFallback("misdirected-request")) {
+        // Cleanup rides on body settlement now, so a discarded attempt would hold
+        // its deadline, listeners, and transport until the method timeout.
+        // Same seam: node-fetch's body type lacks cancel(); the runtime object is
+        // a web ReadableStream. Probe defensively so a non-cancellable body is a
+        // no-op rather than a throw.
+        const discarded = response.body as unknown as { cancel?: () => Promise<void> } | null;
+        await discarded?.cancel?.().catch(() => undefined);
         return await runFetch();
       }
       return response;


### PR DESCRIPTION
## What Problem This Solves

Telegram `getUpdates` long-polling stalls for 150–184s before the gateway's stall watchdog force-restarts the transport — 3–4× longer than the 45s `TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS` that should have aborted it. During a stall, replies are held long enough that the bot reads as silent.

The request deadline was only ever bounding the **headers** phase.

`createTelegramClientFetch` arms a `setTimeout` that aborts an `AbortController` whose signal is passed to `fetch`, then clears it in a `finally`:

```ts
try {
  return await callFetch(input, { ...init, signal: controller.signal });
} finally {
  if (requestTimeout) clearTimeout(requestTimeout);   // ← fires on headers
  ...
}
```

`await callFetch(...)` resolves as soon as headers arrive. The Bot API client consumes the response body *after* this wrapper returns, so the moment headers land the deadline is disarmed and a stalled body read is unbounded. Only the separate ~120s stall watchdog eventually notices — which is exactly the reported 150–184s window.

Closes #119007

## Why This Change Was Made

The deadline (and the shutdown/request-signal wiring that shares its lifetime) now stays armed until the body settles, rather than until headers arrive. That release rides on the SDK's `responseWithRelease` (`openclaw/plugin-sdk/fetch-runtime`, already used by mattermost and msteams) so EOF, stream error, reader cancellation, and null-body statuses all disarm — an earlier hand-rolled version of this only released on the success path, which left a stalled error path unbounded. A discarded HTTP 421 body is cancelled before the fallback retry, so an abandoned attempt no longer holds its deadline and transport until the method timeout.

This repairs the timeout at the boundary that owns it instead of raising the watchdog or adding a second timer downstream — the watchdog is a last-resort supervisor, not the request deadline.

Scope is deliberately narrow: no change to timeout *values*, to `resolveTelegramRequestTimeoutMs`, to the stall watchdog, or to retry/fallback classification.

**Sibling surfaces.** Telegram is the only extension that hands a *wrapped* `fetch` to a third-party client (grammY) which then consumes the body itself — that hand-off is what made the headers-phase disarm reachable. The closest analogue, `extensions/browser/src/browser/client-fetch.ts`, is unaffected: it reads the body **inside** its `try` (so `clearTimeout` runs after the read completes) and additionally bounds it with `readResponseWithLimit`. A sweep of `fetch:` injection across `extensions/*/src/**` found no other hand-off of this shape, so this fix is intentionally one-sided.

## User Impact

A Telegram peer that answers headers and then stalls mid-body is now aborted at its configured request deadline (45s for `getUpdates`) instead of hanging until the ~120s watchdog restarts the transport. Polling recovers ~3–4× sooner, so the user-visible "bot went quiet" window shrinks accordingly.

Applies to every Telegram API call, not just `getUpdates` — any method whose body stalls is now bounded by the deadline it already advertised. No configuration changes; no behavior change when bodies arrive normally.

## Evidence

**Real-behavior proof harness** driving the real `createTelegramClientFetch` against a **real TCP socket**: a `node:http` server that writes status + headers, flushes, then never sends the body — the exact stall shape reported. Only Telegram's servers are stood in for; the client code under test is unmodified.

Negative control, same harness, same commit of the harness — only `client-fetch.ts` differs:

**On unfixed `main`:**
```
observed: outcome=hung after 60013ms
[FAIL] stalled body read ends in the request deadline, not another error (outcome=hung)
[FAIL] deadline fires at ~45000ms, not after the ~120s watchdog (observed 60013ms)
PROOF FAIL — 0/2 checks
```

**On this branch:**
```
[detail] threw after 45014ms: Error: Telegram getupdates timed out after 45000ms
observed: outcome=deadline after 45014ms
[PASS] stalled body read ends in the request deadline, not another error (outcome=deadline)
[PASS] deadline fires at ~45000ms, not after the ~120s watchdog (observed 45014ms)
PROOF PASS — 2/2 checks
```

The harness asserts the *specific* timeout error at ≥80% of the deadline, not merely "something threw" — an early or unrelated rejection fails the check rather than reading as a bounded read.

Focused command:
```
node scripts/run-vitest.mjs extensions/telegram
```

**What was not tested.** This is a real stalling socket, not a live Telegram probe or the bot-to-bot QA lane that `extensions/telegram/CLAUDE.md` prefers for transport changes. I could not reproduce a genuine Telegram-side mid-body stall on demand. The harness exercises the real client against a real socket, but a maintainer may reasonably want live-lane confirmation before merge.

*AI-assisted.*

