### PR TITLE
chore(qa): cover sandbox workspace isolation

### DIFF
--- a/qa/scenarios/runtime/openclaw-sandbox-workspace-isolation.yaml
+++ b/qa/scenarios/runtime/openclaw-sandbox-workspace-isolation.yaml
@@ -1,0 +1,25 @@
+title: OpenClaw sandbox workspace isolation
+
+scenario:
+  id: openclaw-sandbox-workspace-isolation
+  surface: runtime-tools
+  coverage:
+    primary:
+      - tools.workspace-isolation
+  objective: Verify real Docker sandbox mounts isolate host workspaces according to none, read-only, and read-write access.
+  successCriteria:
+    - None mode exposes neither the agent workspace nor its sentinel and rejects sandbox workspace mutation.
+    - Read-only mode exposes the agent workspace at /agent, rejects mutation, and leaves host content unchanged.
+    - Read-write mode persists /workspace mutation to the host workspace.
+    - Every mode keeps an unrelated host sentinel inaccessible and cleans up its runtime and state.
+  docsRefs:
+    - docs/gateway/sandboxing.md
+  codeRefs:
+    - src/agents/sandbox/context.ts
+    - src/agents/sandbox/docker-backend.ts
+    - src/agents/sandbox/workspace-mounts.ts
+    - test/e2e/qa-lab/runtime/openclaw-sandbox-workspace-isolation.e2e.test.ts
+  execution:
+    kind: vitest
+    path: test/e2e/qa-lab/runtime/openclaw-sandbox-workspace-isolation.e2e.test.ts
+    summary: Provision real Docker sandboxes and prove observed mount behavior through backend shell commands.

--- a/test/e2e/qa-lab/runtime/openclaw-sandbox-workspace-isolation.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/openclaw-sandbox-workspace-isolation.e2e.test.ts
@@ -1,0 +1,158 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "vitest";
+import type { OpenClawConfig } from "../../../../src/config/types.openclaw.js";
+import { captureEnv, setTestEnvValue } from "../../../../src/test-utils/env.js";
+
+type WorkspaceAccess = "none" | "ro" | "rw";
+type SandboxContext = NonNullable<
+  Awaited<
+    ReturnType<typeof import("../../../../src/agents/sandbox/context.js").resolveSandboxContext>
+  >
+>;
+
+function createConfig(params: {
+  access: WorkspaceAccess;
+  image: string;
+  prefix: string;
+  workspaceRoot: string;
+}): OpenClawConfig {
+  return {
+    agents: {
+      defaults: {
+        skipBootstrap: true,
+        sandbox: {
+          mode: "all",
+          backend: "docker",
+          scope: "session",
+          workspaceAccess: params.access,
+          workspaceRoot: params.workspaceRoot,
+          docker: {
+            image: params.image,
+            containerPrefix: params.prefix,
+          },
+          browser: { enabled: false },
+          prune: { idleHours: 0, maxAgeDays: 0 },
+        },
+      },
+    },
+  };
+}
+
+async function run(
+  sandbox: SandboxContext,
+  script: string,
+  args: string[] = [],
+  allowFailure = false,
+) {
+  if (!sandbox.backend) {
+    throw new Error("provisioned sandbox has no backend handle");
+  }
+  return await sandbox.backend.runShellCommand({ script, args, allowFailure });
+}
+
+async function expectOk(sandbox: SandboxContext, script: string, args: string[] = []) {
+  const result = await run(sandbox, script, args);
+  expect(result.code, result.stderr.toString()).toBe(0);
+  return result.stdout.toString();
+}
+
+test("Docker enforces none, read-only, and read-write workspace isolation", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-isolation-"));
+  const stateDir = path.join(root, "state");
+  const workspaceRoot = path.join(root, "sandboxes");
+  const unrelatedSentinel = path.join(root, "host-only-sentinel.txt");
+  const image = process.env.OPENCLAW_SANDBOX_TEST_IMAGE ?? "openclaw-sandbox:bookworm-slim";
+  const prefix = `oc-qa-${process.pid}-`;
+  const env = captureEnv(["OPENCLAW_STATE_DIR"]);
+  const runtimes: string[] = [];
+
+  await fs.mkdir(stateDir, { recursive: true });
+  await fs.writeFile(unrelatedSentinel, "host-only");
+  setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+
+  try {
+    const [{ resolveSandboxContext }, { removeSandboxContainer }] = await Promise.all([
+      import("../../../../src/agents/sandbox/context.js"),
+      import("../../../../src/agents/sandbox/manage.js"),
+    ]);
+
+    for (const access of ["none", "ro", "rw"] as const) {
+      const hostWorkspace = path.join(root, `agent-${access}-${randomUUID()}`);
+      const hostSentinel = path.join(hostWorkspace, "host-sentinel.txt");
+      await fs.mkdir(hostWorkspace, { recursive: true });
+      if (access === "rw") {
+        // Rootful Docker otherwise creates this nested bind target as root,
+        // which leaves fixture teardown unable to remove its own temp tree.
+        await fs.mkdir(path.join(hostWorkspace, ".openclaw", "sandbox-skills", "skills"), {
+          recursive: true,
+        });
+      }
+      await fs.writeFile(hostSentinel, `original-${access}`);
+
+      let sandbox: SandboxContext | null = null;
+      try {
+        sandbox = await resolveSandboxContext({
+          config: createConfig({ access, image, prefix, workspaceRoot }),
+          agentId: `workspace-${access}`,
+          sessionKey: `agent:workspace-${access}:qa-${randomUUID()}`,
+          workspaceDir: hostWorkspace,
+          requireCurrentConfig: true,
+        });
+        expect(sandbox).not.toBeNull();
+        if (!sandbox) {
+          throw new Error(`sandbox context missing for ${access}`);
+        }
+        runtimes.push(sandbox.runtimeId);
+        expect(sandbox.workspaceAccess).toBe(access);
+        await expectOk(sandbox, "grep -Eq ' /workspace ' /proc/self/mountinfo");
+        await expectOk(sandbox, 'test ! -e "$1"', [unrelatedSentinel]);
+
+        if (access === "none") {
+          await expectOk(
+            sandbox,
+            'test ! -e /agent && test ! -e /workspace/host-sentinel.txt && test ! -e "$1"',
+            [hostSentinel],
+          );
+          const mutation = await run(sandbox, "printf blocked > /workspace/blocked.txt", [], true);
+          expect(mutation.code).not.toBe(0);
+          await expect(fs.readFile(hostSentinel, "utf8")).resolves.toBe("original-none");
+        } else if (access === "ro") {
+          await expectOk(
+            sandbox,
+            'grep -Eq \' /agent \' /proc/self/mountinfo && test "$(cat /agent/host-sentinel.txt)" = "$1"',
+            ["original-ro"],
+          );
+          const mutation = await run(
+            sandbox,
+            "printf blocked > /agent/host-sentinel.txt",
+            [],
+            true,
+          );
+          expect(mutation.code).not.toBe(0);
+          await expect(fs.readFile(hostSentinel, "utf8")).resolves.toBe("original-ro");
+        } else {
+          await expectOk(
+            sandbox,
+            'printf persisted > /workspace/host-sentinel.txt && test "$(cat /workspace/host-sentinel.txt)" = persisted',
+          );
+          await expect(fs.readFile(hostSentinel, "utf8")).resolves.toBe("persisted");
+        }
+      } finally {
+        if (sandbox) {
+          await removeSandboxContainer(sandbox.runtimeId);
+          runtimes.splice(runtimes.indexOf(sandbox.runtimeId), 1);
+        }
+      }
+    }
+  } finally {
+    const { execDocker } = await import("../../../../src/agents/sandbox/docker.js");
+    for (const runtimeId of runtimes) {
+      await execDocker(["rm", "-f", runtimeId], { allowFailure: true });
+    }
+    env.restore();
+    await fs.rm(root, { recursive: true, force: true });
+  }
+}, 120_000);


### PR DESCRIPTION
## What Problem This Solves

The QA coverage map had no real-runtime proof for `tools.workspace-isolation`. Existing tests cover sandbox configuration and mocked transports, but did not execute the complete workspace-mode contract inside a real Linux Docker sandbox.

## Why This Change Was Made

Adds one focused QA Lab scenario and one Docker E2E fixture. The fixture follows the production path from `resolveSandboxContext` through provisioning, mount setup, and `backend.runShellCommand`, then verifies the owner invariant for all workspace modes:

- `none`: no `/agent` mount, no host sentinel visibility, and workspace writes fail
- `ro`: `/agent` is readable, mutation fails, and the host workspace stays unchanged
- `rw`: `/workspace` mutation persists to the host workspace
- all modes: an unrelated host sentinel remains inaccessible

Each case uses unique state, session, and scope identifiers and removes its runtime resources in `finally`.

`tools.sandbox-backends` remains a separate blocked coverage claim: built-in Docker, Podman, and SSH implementations exist, but the repository does not yet have a trusted live backend-neutral contract runner covering Docker, Podman, and ephemeral SSH. This PR does not assign or partially claim that identifier.

## User Impact

No production behavior changes. Maintainers gain deterministic real-Docker regression coverage for sandbox workspace isolation and an exact primary QA coverage mapping.

## Evidence

- Production LOC delta: `+0/-0`
- Test/QA delta: `+183/-0` across exactly two files
- QA coverage: exactly one primary mapping for `tools.workspace-isolation`
- Direct Codex `gpt-5.6-sol` high autoreview: clean, no actionable findings, correctness `0.99`
- Blacksmith Testbox `tbx_01kz52ew3cjpb3fz9ykm9k0yhn` / workflow run `30865423746`:
  - built `openclaw-sandbox:bookworm-slim`
  - focused Docker E2E: 1 file, 1 test passed
  - exact QA suite: 1 total, 1 passed, 0 failed, 0 skipped
  - `node scripts/run-tsgo.mjs -b tsconfig.projects.json`: passed
  - path-scoped `node scripts/check-changed.mjs -- <two paths>`: passed, including guards, typecheck, lint, and runtime cycle checks
- `git diff --check`: clean
- Privacy scan: no personal paths, private hosts/IPs, non-public email, phone, secrets, or credentials
- Rebaseline: current `origin/main` is the reviewed base; open PR #116175 touches related sandbox owner files but neither path in this PR; no open PR owns either exact path

No changelog entry: test-only coverage, no shipped behavior change.
