### PR TITLE
fix(cli): gateway call honors local --port

### DIFF
--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -470,6 +470,7 @@ Low-level RPC helper.
 
 ```bash
 openclaw gateway call status
+openclaw gateway call health --port 18999
 openclaw gateway call logs.tail --params '{"limit": 200}'
 ```
 
@@ -478,6 +479,9 @@ openclaw gateway call logs.tail --params '{"limit": 200}'
 </ParamField>
 <ParamField path="--url <url>" type="string">
   Gateway WebSocket URL.
+</ParamField>
+<ParamField path="--port <port>" type="number">
+  Target a local loopback Gateway on this port. Overrides `OPENCLAW_GATEWAY_URL` and `OPENCLAW_GATEWAY_PORT` for this call. Cannot combine with `--url`.
 </ParamField>
 <ParamField path="--token <token>" type="string">
   Gateway token.
@@ -496,7 +500,7 @@ openclaw gateway call logs.tail --params '{"limit": 200}'
 </ParamField>
 
 <Note>
-`--params` must be valid JSON, and each method validates its own param shape (extra/misnamed fields are rejected).
+`--params` must be valid JSON, and each method validates its own param shape (extra/misnamed fields are rejected). Use `--port` for a custom-port local Gateway; explicit `--url` targets still require explicit credentials.
 </Note>
 
 ## Manage the Gateway service

--- a/docs/platforms/mac/bundled-gateway.md
+++ b/docs/platforms/mac/bundled-gateway.md
@@ -115,7 +115,7 @@ openclaw gateway --port 18999 --bind loopback
 Then:
 
 ```bash
-openclaw gateway call health --url ws://127.0.0.1:18999 --timeout 3000
+openclaw gateway call health --port 18999 --timeout 3000
 ```
 
 ## Related

--- a/src/cli/gateway-cli/register.option-collisions.test.ts
+++ b/src/cli/gateway-cli/register.option-collisions.test.ts
@@ -135,6 +135,23 @@ function firstGatewayStatusCall() {
   return gatewayStatusCommand.mock.calls[0] ?? [];
 }
 
+function expectLocalGatewayCall(method: string, port: number, params?: unknown) {
+  expect(defaultRuntime.error.mock.calls).toEqual([]);
+  expect(callGatewayCli).toHaveBeenCalledTimes(1);
+  const [actualMethod, opts, actualParams] = firstGatewayCall();
+  expect(actualMethod).toBe(method);
+  if (params !== undefined) {
+    expect(actualParams).toEqual(params);
+  }
+  const gatewayOpts = opts as
+    | { config?: { gateway?: { port?: number } }; localPortOverride?: number }
+    | undefined;
+  expect(gatewayOpts?.localPortOverride).toBe(port);
+  expect(gatewayOpts?.config).toEqual({
+    gateway: { mode: "local", port },
+  });
+}
+
 describe("gateway register option collisions", () => {
   const sharedProgram: Command = new Command();
 
@@ -186,6 +203,20 @@ describe("gateway register option collisions", () => {
       },
     },
     {
+      name: "projects gateway call --port into local config",
+      argv: ["gateway", "call", "health", "--port", "19084", "--json"],
+      assert: () => {
+        expectLocalGatewayCall("health", 19084, {});
+      },
+    },
+    {
+      name: "inherits parent --port for gateway call",
+      argv: ["gateway", "--port", "19085", "call", "health", "--json"],
+      assert: () => {
+        expectLocalGatewayCall("health", 19085);
+      },
+    },
+    {
       name: "forwards --token to gateway probe when parent and child option names collide",
       argv: ["gateway", "probe", "--token", "tok_probe", "--json"],
       assert: () => {
@@ -217,34 +248,14 @@ describe("gateway register option collisions", () => {
       name: "projects gateway health --port into local config",
       argv: ["gateway", "health", "--port", "19081", "--json"],
       assert: () => {
-        expect(defaultRuntime.error.mock.calls).toEqual([]);
-        expect(callGatewayCli).toHaveBeenCalledTimes(1);
-        const [method, opts] = firstGatewayCall();
-        expect(method).toBe("health");
-        const gatewayOpts = opts as
-          | { config?: { gateway?: { port?: number } }; localPortOverride?: number }
-          | undefined;
-        expect(gatewayOpts?.localPortOverride).toBe(19081);
-        expect(gatewayOpts?.config).toEqual({
-          gateway: { mode: "local", port: 19081 },
-        });
+        expectLocalGatewayCall("health", 19081);
       },
     },
     {
       name: "inherits parent --port for gateway health",
       argv: ["gateway", "--port", "19083", "health", "--json"],
       assert: () => {
-        expect(defaultRuntime.error.mock.calls).toEqual([]);
-        expect(callGatewayCli).toHaveBeenCalledTimes(1);
-        const [method, opts] = firstGatewayCall();
-        expect(method).toBe("health");
-        const gatewayOpts = opts as
-          | { config?: { gateway?: { port?: number } }; localPortOverride?: number }
-          | undefined;
-        expect(gatewayOpts?.localPortOverride).toBe(19083);
-        expect(gatewayOpts?.config).toEqual({
-          gateway: { mode: "local", port: 19083 },
-        });
+        expectLocalGatewayCall("health", 19083);
       },
     },
     {
@@ -270,6 +281,19 @@ describe("gateway register option collisions", () => {
   ])("$name", async ({ argv, assert }) => {
     await sharedProgram.parseAsync(argv, { from: "user" });
     assert();
+  });
+
+  it("rejects combining --url and --port for gateway call", async () => {
+    await sharedProgram.parseAsync(
+      ["gateway", "call", "health", "--url", "ws://127.0.0.1:19084", "--port", "19084", "--json"],
+      { from: "user" },
+    );
+
+    expect(callGatewayCli).not.toHaveBeenCalled();
+    expect(defaultRuntime.error).toHaveBeenCalledWith(
+      "Gateway call failed: Error: Use either --url or --port, not both.",
+    );
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
   });
 
   it("uses the effective local port config for gateway health auth diagnostics", async () => {

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -572,10 +572,11 @@ export function registerGatewayCli(program: Command, deps: GatewayCliDependencie
       .description("Call a Gateway method")
       .argument("<method>", "Method name (health/status/system-presence/cron.*)")
       .option("--params <json>", "JSON object string for params", "{}")
+      .option("--port <port>", "Local Gateway port")
       .action(async (method, opts, command) => {
         await runGatewayCommand(
           async () => {
-            const rpcOpts = resolveGatewayRpcOptions(opts, command);
+            const rpcOpts = await resolveGatewayRpcOptionsWithLocalPort(opts, command);
             const params = parseGatewayCallParams(String(opts.params ?? "{}"));
             const result = await callGatewayCli(method, rpcOpts, params);
             if (rpcOpts.json) {


### PR DESCRIPTION
Closes https://github.com/openclaw/openclaw/issues/119036

## What Problem This Solves

Fixes an issue where operators targeting a foreground local Gateway on a non-default port could pass the accepted parent `gateway --port` option to `gateway call`, but the command silently ignored it and contacted the default/configured target instead. The child help also offered only `--url`, whose explicit-credential requirement is intentionally stricter.

## Why This Change Was Made

`gateway call` now advertises `--port` and routes direct or parent-inherited values through the existing local-port resolver already used by `gateway health`. That resolver selects loopback, overrides environment URL/port state, preserves local config credentials, and rejects `--url` plus `--port`. The URL-override credential boundary is unchanged.

The tests share one local-port projection assertion across health and call so the two CLI surfaces cannot drift. The macOS foreground-Gateway smoke command now uses the safe local-port form instead of an unauthenticated URL override.

## User Impact

Operators and scripts can call any Gateway RPC on a custom local port with either:

```bash
openclaw gateway call health --port 18999 --json
openclaw gateway --port 18999 call health --json
```

Local configured credentials are reused without putting a token or password on the command line. Wrong ports still fail, and `--url` cannot be combined with `--port`.

## Evidence

- `node scripts/run-vitest.mjs src/cli/gateway-cli/register.option-collisions.test.ts` — 15 passed
- full changed gate — passed all core/core-test/docs lanes in https://github.com/openclaw/openclaw/actions/runs/30867000002 before a later source-blind harness cwd mistake; the code/check stages were green
- exact hash-verified full build — passed on Blacksmith Testbox `tbx_01kz559c978pqt1w49s38gm2tq`, https://github.com/openclaw/openclaw/actions/runs/30868054765
- source-blind built-CLI contract from a private neutral directory — 5/5 passed on the same Testbox:
  - help exposes `--port`
  - direct `gateway call ... --port` returns health JSON
  - inherited `gateway --port ... call` returns health JSON
  - unused port exits nonzero
  - `--url` plus `--port` exits nonzero with the actionable conflict error
- auth-none follow-up probe: existing `gateway health --port` and the new generic call both returned health JSON with exit 0; the earlier cold-run timeout did not reproduce and was not counted as a separate problem
- final Codex autoreview — clean, no accepted/actionable findings, confidence 0.99
- `git diff --check` — passed
- public model identifier gate — PASS; no model identifiers added or changed

Risk is low. Production delta is +2/-1, there is no config/schema/protocol change, and the existing URL credential-exfiltration protection is untouched.
