### PR TITLE
fix(memory): show canonical-session migration recovery instead of provider error

### DIFF
--- a/extensions/memory-core/src/memory-corpus.ts
+++ b/extensions/memory-core/src/memory-corpus.ts
@@ -1,5 +1,5 @@
 import { runTasksWithConcurrency } from "openclaw/plugin-sdk/concurrency-runtime";
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { extractErrorCode, formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   listMemoryCorpusSupplements,
   type MemoryCorpusSearchResult,
@@ -19,17 +19,31 @@ type MemorySupplementReadResult = Omit<MemorySupplementGetResult, "content"> & {
   text: string;
 };
 
+export type MemoryCorpusFailure = { error: string; code?: string };
+type UnavailableMemoryCorpus<T> = {
+  corpus: MemoryCorpus;
+  outcome: "unavailable";
+  value: T;
+} & MemoryCorpusFailure;
+
 export type MemoryCorpusAttempt<T> =
   | { corpus: MemoryCorpus; outcome: "ok"; value: T }
-  | { corpus: MemoryCorpus; outcome: "unavailable"; value: T; error: string }
+  | UnavailableMemoryCorpus<T>
   | { corpus: MemoryCorpus; outcome: "not-registered" };
 
 export function unavailableMemoryCorpus<T>(
   corpus: MemoryCorpus,
   value: T,
   error: unknown,
-): MemoryCorpusAttempt<T> {
-  return { corpus, outcome: "unavailable", value, error: formatErrorMessage(error) };
+): UnavailableMemoryCorpus<T> {
+  const code = extractErrorCode(error);
+  return {
+    corpus,
+    outcome: "unavailable",
+    value,
+    error: formatErrorMessage(error),
+    ...(code ? { code } : {}),
+  };
 }
 
 async function raceMemoryCorpusSignal<T>(signal: AbortSignal, task: Promise<T>): Promise<T> {

--- a/extensions/memory-core/src/tools.real-manager.test.ts
+++ b/extensions/memory-core/src/tools.real-manager.test.ts
@@ -1,11 +1,13 @@
 // Memory Core integration tests exercise the real SQLite search manager through tools.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
-import { describe, expect, it } from "vitest";
+import { openOpenClawAgentDatabase } from "openclaw/plugin-sdk/sqlite-runtime";
+import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
   createManagerIndexFixture,
   type ManagerIndexFixture,
 } from "./memory/manager-index.test-support.js";
-import { createMemorySearchTool } from "./tools.js";
+import { createMemorySearchTool, testing } from "./tools.js";
 
 const { closeAllMemorySearchManagers, getMemorySearchManager } = await import("./memory/index.js");
 
@@ -13,6 +15,10 @@ describe("memory_search real manager", () => {
   const fixture: ManagerIndexFixture = createManagerIndexFixture({
     getMemorySearchManager,
     closeAllMemorySearchManagers,
+  });
+
+  beforeEach(() => {
+    testing.resetMemorySearchToolCooldowns();
   });
 
   it("backfills visible sessions with one bounded query embedding", async () => {
@@ -104,5 +110,64 @@ describe("memory_search real manager", () => {
       withheldHits: 2,
       searchWindow: 4,
     });
+  });
+
+  it("preserves canonical-session migration recovery through cooldown", async () => {
+    const baseConfig = fixture.createConfig({
+      sources: ["sessions"],
+      sessionMemory: true,
+      minScore: 0,
+      vectorEnabled: false,
+    });
+    const cfg = {
+      ...baseConfig,
+      memory: { ...baseConfig.memory, citations: "off" },
+    } satisfies OpenClawConfig;
+    const initializedManager = await fixture.getFreshManager(cfg);
+    await initializedManager.sync({ reason: "test", force: true });
+    await initializedManager.close();
+    await closeAllMemorySearchManagers();
+
+    openOpenClawAgentDatabase({ agentId: "main" })
+      .db.prepare(
+        "INSERT INTO session_nodes (session_key, current_session_id, entry_json, updated_at) VALUES (?, ?, ?, ?)",
+      )
+      .run(
+        "Agent:Main:Main",
+        "legacy-session",
+        JSON.stringify({ sessionId: "legacy-session", updatedAt: 1 }),
+        1,
+      );
+    closeOpenClawAgentDatabasesForTest();
+
+    const tool = createMemorySearchTool({
+      config: cfg,
+      agentId: "main",
+      agentSessionKey: "agent:main:main",
+    });
+    if (!tool) {
+      throw new Error("memory_search tool missing");
+    }
+
+    const first = await tool.execute("migration-first", { query: "operator recovery" });
+    openOpenClawAgentDatabase({ agentId: "main" })
+      .db.prepare("DELETE FROM session_nodes WHERE session_key = ?")
+      .run("Agent:Main:Main");
+    closeOpenClawAgentDatabasesForTest();
+    const replay = await tool.execute("migration-replay", {
+      query: "different anti-cheat query",
+    });
+    const expected = {
+      unavailable: true,
+      error: expect.stringContaining("openclaw doctor --fix"),
+      warning:
+        "Memory search is unavailable because the session catalog requires canonical-key migration.",
+      action:
+        "Stop the Gateway and run openclaw doctor --fix, then restart the Gateway and retry memory_search.",
+    };
+
+    expect(first.details).toMatchObject(expected);
+    expect(replay.details).toMatchObject(expected);
+    expect(fixture.provider.embedQueryCalls).toBe(0);
   });
 });

--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -11,6 +11,15 @@ import {
   type MemoryToolOptions,
 } from "./memory-tool-contract.js";
 import type { MemoryCoreAcquireLocalService } from "./memory/embedding-local-service.js";
+
+// Core owns this session-store error; Memory Core must preserve its exact code
+// without importing a core-internal module across the plugin boundary.
+const SESSION_CANONICAL_KEY_MIGRATION_REQUIRED = "SESSION_CANONICAL_KEY_MIGRATION_REQUIRED";
+const SESSION_CANONICAL_KEY_MIGRATION_WARNING =
+  "Memory search is unavailable because the session catalog requires canonical-key migration.";
+const SESSION_CANONICAL_KEY_MIGRATION_ACTION =
+  "Stop the Gateway and run openclaw doctor --fix, then restart the Gateway and retry memory_search.";
+
 type MemorySearchManagerResult = Awaited<
   ReturnType<(typeof import("./memory/index.js"))["getMemorySearchManager"]>
 >;
@@ -83,6 +92,7 @@ export function buildMemorySearchUnavailableResult(
   overrides?: {
     warning?: string;
     action?: string;
+    code?: string;
   },
 ) {
   const reason = (error ?? "memory search unavailable").trim() || "memory search unavailable";
@@ -93,18 +103,22 @@ export function buildMemorySearchUnavailableResult(
   );
   const warning =
     overrides?.warning ??
-    (isQuotaError
-      ? "Memory search is unavailable because the embedding provider quota is exhausted."
-      : isMissingNodeSqlite
-        ? "Memory search is unavailable because this OpenClaw Node runtime does not provide SQLite support."
-        : "Memory search is unavailable due to an embedding/provider error.");
+    (overrides?.code === SESSION_CANONICAL_KEY_MIGRATION_REQUIRED
+      ? SESSION_CANONICAL_KEY_MIGRATION_WARNING
+      : isQuotaError
+        ? "Memory search is unavailable because the embedding provider quota is exhausted."
+        : isMissingNodeSqlite
+          ? "Memory search is unavailable because this OpenClaw Node runtime does not provide SQLite support."
+          : "Memory search is unavailable due to an embedding/provider error.");
   const action =
     overrides?.action ??
-    (isQuotaError
-      ? "Top up or switch embedding provider, then retry memory_search."
-      : isMissingNodeSqlite
-        ? "Run OpenClaw with a Node runtime that includes node:sqlite, then retry memory_search."
-        : "Check embedding provider configuration and retry memory_search.");
+    (overrides?.code === SESSION_CANONICAL_KEY_MIGRATION_REQUIRED
+      ? SESSION_CANONICAL_KEY_MIGRATION_ACTION
+      : isQuotaError
+        ? "Top up or switch embedding provider, then retry memory_search."
+        : isMissingNodeSqlite
+          ? "Run OpenClaw with a Node runtime that includes node:sqlite, then retry memory_search."
+          : "Check embedding provider configuration and retry memory_search.");
   return {
     results: [],
     disabled: true,

--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -27,6 +27,21 @@ type MemoryToolOptions = {
   withLease?: PluginStateLeaseRunner;
 };
 
+// Mirrors the core session error contract without crossing the plugin boundary.
+export const MEMORY_SEARCH_CANONICAL_SESSION_MIGRATION_CODE =
+  "SESSION_CANONICAL_KEY_MIGRATION_REQUIRED";
+
+type MemorySearchUnavailableOverrides = {
+  warning?: string;
+  action?: string;
+  code?: typeof MEMORY_SEARCH_CANONICAL_SESSION_MIGRATION_CODE;
+};
+
+const CANONICAL_SESSION_MIGRATION_WARNING =
+  "Memory search is unavailable because the session catalog requires canonical-key migration.";
+const CANONICAL_SESSION_MIGRATION_ACTION =
+  "Stop the Gateway and run openclaw doctor --fix, then restart the Gateway and retry memory_search.";
+
 export const loadMemoryToolRuntime = createLazyRuntimeModule(() => import("./tools.runtime.js"));
 
 export const MemorySearchSchema = Type.Object({
@@ -120,19 +135,20 @@ export function createMemoryTool(params: {
 
 export function buildMemorySearchUnavailableResult(
   error: string | undefined,
-  overrides?: {
-    warning?: string;
-    action?: string;
-  },
+  overrides?: MemorySearchUnavailableOverrides,
 ) {
   const reason = (error ?? "memory search unavailable").trim() || "memory search unavailable";
   const normalizedReason = normalizeLowercaseStringOrEmpty(reason);
+  const canonicalMigrationGuidance = resolveMemorySearchCanonicalMigrationGuidance(
+    overrides?.code,
+  );
   const isQuotaError = /insufficient_quota|quota|429/.test(normalizedReason);
   const isMissingNodeSqlite = /missing node:sqlite|no such built-?in module: node:sqlite/.test(
     normalizedReason,
   );
   const warning =
     overrides?.warning ??
+    canonicalMigrationGuidance?.warning ??
     (isQuotaError
       ? "Memory search is unavailable because the embedding provider quota is exhausted."
       : isMissingNodeSqlite
@@ -140,6 +156,7 @@ export function buildMemorySearchUnavailableResult(
         : "Memory search is unavailable due to an embedding/provider error.");
   const action =
     overrides?.action ??
+    canonicalMigrationGuidance?.action ??
     (isQuotaError
       ? "Top up or switch embedding provider, then retry memory_search."
       : isMissingNodeSqlite
@@ -157,6 +174,18 @@ export function buildMemorySearchUnavailableResult(
       action,
       error: reason,
     },
+  };
+}
+
+function resolveMemorySearchCanonicalMigrationGuidance(
+  code: typeof MEMORY_SEARCH_CANONICAL_SESSION_MIGRATION_CODE | undefined,
+) {
+  if (code !== MEMORY_SEARCH_CANONICAL_SESSION_MIGRATION_CODE) {
+    return undefined;
+  }
+  return {
+    warning: CANONICAL_SESSION_MIGRATION_WARNING,
+    action: CANONICAL_SESSION_MIGRATION_ACTION,
   };
 }
 

--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -139,9 +139,7 @@ export function buildMemorySearchUnavailableResult(
 ) {
   const reason = (error ?? "memory search unavailable").trim() || "memory search unavailable";
   const normalizedReason = normalizeLowercaseStringOrEmpty(reason);
-  const canonicalMigrationGuidance = resolveMemorySearchCanonicalMigrationGuidance(
-    overrides?.code,
-  );
+  const canonicalMigrationGuidance = resolveMemorySearchCanonicalMigrationGuidance(overrides?.code);
   const isQuotaError = /insufficient_quota|quota|429/.test(normalizedReason);
   const isMissingNodeSqlite = /missing node:sqlite|no such built-?in module: node:sqlite/.test(
     normalizedReason,

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -277,15 +277,15 @@ describe("memory_search unavailable payloads", () => {
     });
   });
 
-  it("returns explicit unavailable metadata for non-quota failures", async () => {
+  it("does not infer migration recovery from non-quota error text", async () => {
     setMemorySearchImpl(async () => {
-      throw new Error("embedding provider timeout");
+      throw new Error("embedding provider timeout; run openclaw doctor --fix");
     });
 
     const tool = createMemorySearchToolOrThrow();
     const result = await tool.execute("generic", { query: "hello" });
     expectUnavailableMemorySearchDetails(result.details, {
-      error: "embedding provider timeout",
+      error: "embedding provider timeout; run openclaw doctor --fix",
       warning: "Memory search is unavailable due to an embedding/provider error.",
       action: "Check embedding provider configuration and retry memory_search.",
     });

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -28,6 +28,7 @@ import {
 import { createMemorySearchTool, testing as memoryToolsTesting } from "./tools.js";
 import {
   buildMemorySearchUnavailableResult,
+  MEMORY_SEARCH_CANONICAL_SESSION_MIGRATION_CODE,
   MemoryGetSchema,
   MemorySearchSchema,
 } from "./tools.shared.js";
@@ -349,6 +350,65 @@ describe("memory_search unavailable payloads", () => {
 
     expectUnavailableMemorySearchDetails(result, {
       error: "missing node:sqlite",
+      warning: "custom warning",
+      action: "custom action",
+    });
+  });
+
+  it("preserves typed canonical session migration recovery through cooldown", async () => {
+    const error =
+      "refusing a non-canonical session key write; stop the Gateway and run openclaw doctor --fix";
+    const search = vi.fn(async () => {
+      throw Object.assign(new Error(error), {
+        code: MEMORY_SEARCH_CANONICAL_SESSION_MIGRATION_CODE,
+      });
+    });
+    setMemorySearchImpl(search);
+
+    const tool = createMemorySearchToolOrThrow();
+    const result = await tool.execute("canonical-session-migration", { query: "hello" });
+    expectUnavailableMemorySearchDetails(result.details, {
+      error,
+      warning:
+        "Memory search is unavailable because the session catalog requires canonical-key migration.",
+      action:
+        "Stop the Gateway and run openclaw doctor --fix, then restart the Gateway and retry memory_search.",
+    });
+
+    const cooldownResult = await tool.execute("canonical-session-migration-cooldown", {
+      query: "hello again",
+    });
+    expectUnavailableMemorySearchDetails(cooldownResult.details, {
+      error,
+      warning:
+        "Memory search is unavailable because the session catalog requires canonical-key migration.",
+      action:
+        "Stop the Gateway and run openclaw doctor --fix, then restart the Gateway and retry memory_search.",
+    });
+    expect(search).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not infer canonical migration guidance from error text", () => {
+    const error = "embedding provider rejected a request; run openclaw doctor --fix";
+
+    const result = buildMemorySearchUnavailableResult(error);
+
+    expectUnavailableMemorySearchDetails(result, {
+      error,
+      warning: "Memory search is unavailable due to an embedding/provider error.",
+      action: "Check embedding provider configuration and retry memory_search.",
+    });
+  });
+
+  it("keeps explicit guidance overrides for typed canonical migration failures", () => {
+    const result = buildMemorySearchUnavailableResult("canonical migration required", {
+      code: MEMORY_SEARCH_CANONICAL_SESSION_MIGRATION_CODE,
+      warning: "custom warning",
+      action: "custom action",
+    });
+
+    expectUnavailableMemorySearchDetails(result, {
+      error: "canonical migration required",
       warning: "custom warning",
       action: "custom action",
     });

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -1,5 +1,4 @@
 // Memory Core plugin module implements tools behavior.
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   resolveMemorySearchStaleness,
   stripMemoryAnnotationCarriers,
@@ -27,6 +26,7 @@ import {
   searchMemoryCorpusSupplements,
   unavailableMemoryCorpus,
   type MemoryCorpusAttempt,
+  type MemoryCorpusFailure,
 } from "./memory-corpus.js";
 import { executeMemoryReadResult, executeWikiMemoryReadResult } from "./memory-read-tool.js";
 import {
@@ -78,7 +78,7 @@ type PrimaryMemorySearchValue = {
 
 const MEMORY_SEARCH_TOOL_COOLDOWN_MS = 60_000;
 
-const memorySearchToolCooldowns = new Map<string, { until: number; error: string }>();
+const memorySearchToolCooldowns = new Map<string, MemoryCorpusFailure & { until: number }>();
 
 /**
  * Validate the model-authored corpus argument against the tool's closed enum.
@@ -107,7 +107,7 @@ function resolveMemorySearchToolCooldownKey(options: {
   return options.agentId ?? options.agentSessionKey ?? "default";
 }
 
-function readMemorySearchToolCooldown(key: string): { error: string } | undefined {
+function readMemorySearchToolCooldown(key: string): MemoryCorpusFailure | undefined {
   const entry = memorySearchToolCooldowns.get(key);
   if (!entry) {
     return undefined;
@@ -116,13 +116,13 @@ function readMemorySearchToolCooldown(key: string): { error: string } | undefine
     memorySearchToolCooldowns.delete(key);
     return undefined;
   }
-  return { error: entry.error };
+  return { error: entry.error, ...(entry.code ? { code: entry.code } : {}) };
 }
 
-function recordMemorySearchToolCooldown(key: string, error: string): void {
+function recordMemorySearchToolCooldown(key: string, failure: MemoryCorpusFailure): void {
   memorySearchToolCooldowns.set(key, {
     until: Date.now() + MEMORY_SEARCH_TOOL_COOLDOWN_MS,
-    error,
+    ...failure,
   });
 }
 
@@ -331,7 +331,7 @@ export function createMemorySearchTool(options: MemoryToolOptions) {
           signal: AbortSignal,
         ): Promise<MemoryCorpusAttempt<PrimaryMemorySearchValue | null>> => {
           if (cooldown) {
-            return unavailableMemoryCorpus("memory", null, cooldown.error);
+            return { corpus: "memory", outcome: "unavailable", value: null, ...cooldown };
           }
           const attempted = await attemptMemoryCorpus<Awaited<
             ReturnType<typeof executeMemorySearchToolQuery>
@@ -396,10 +396,15 @@ export function createMemorySearchTool(options: MemoryToolOptions) {
             if (callerSignal?.aborted) {
               throw resolveMemorySearchAbortError(callerSignal);
             }
-            const error =
-              attempted.outcome === "unavailable" ? attempted.error : "memory search unavailable";
-            recordMemorySearchToolCooldown(cooldownKey, error);
-            return unavailableMemoryCorpus("memory", null, error);
+            const failure: MemoryCorpusFailure =
+              attempted.outcome === "unavailable"
+                ? {
+                    error: attempted.error,
+                    ...(attempted.code ? { code: attempted.code } : {}),
+                  }
+                : { error: "memory search unavailable" };
+            recordMemorySearchToolCooldown(cooldownKey, failure);
+            return { corpus: "memory", outcome: "unavailable", value: null, ...failure };
           }
           const executed = attempted.value!;
           if (executed.pausedIndexIdentityReason) {
@@ -484,7 +489,7 @@ export function createMemorySearchTool(options: MemoryToolOptions) {
               if (searchesMemory && !searchesWiki && memory?.outcome === "unavailable") {
                 return jsonResult(
                   memoryValue?.unavailableResult ??
-                    buildMemorySearchUnavailableResult(memory.error),
+                    buildMemorySearchUnavailableResult(memory.error, { code: memory.code }),
                 );
               }
               const wikiResults = wiki?.outcome === "not-registered" ? [] : (wiki?.value ?? []);
@@ -528,11 +533,13 @@ export function createMemorySearchTool(options: MemoryToolOptions) {
           if (callerSignal?.aborted) {
             throw resolveMemorySearchAbortError(callerSignal);
           }
-          const message = formatErrorMessage(error);
+          const failed = unavailableMemoryCorpus("memory", null, error);
           if (requestedCorpus !== "wiki") {
-            recordMemorySearchToolCooldown(cooldownKey, message);
+            recordMemorySearchToolCooldown(cooldownKey, failed);
           }
-          return jsonResult(buildMemorySearchUnavailableResult(message));
+          return jsonResult(
+            buildMemorySearchUnavailableResult(failed.error, { code: failed.code }),
+          );
         } finally {
           cleanupStarted = true;
           await closeMemoryManagers(memoryManagersToClose, callerSignal);

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -557,9 +557,10 @@ export function createMemorySearchTool(options: {
           const shouldQueryMemory = requestedCorpus !== "wiki" && !cooldown;
           if (cooldown && !shouldQuerySupplements) {
             return jsonResult(
-              buildMemorySearchUnavailableResult(cooldown.error, {
-                ...(cooldown.code ? { code: cooldown.code } : {}),
-              }),
+              buildMemorySearchUnavailableResult(
+                cooldown.error,
+                cooldown.code ? { code: cooldown.code } : undefined,
+              ),
             );
           }
           const memoryManagerPurpose = options.oneShotCliRun ? "cli" : undefined;
@@ -916,9 +917,7 @@ export function createMemorySearchTool(options: {
             });
           }
           return jsonResult(
-            buildMemorySearchUnavailableResult(message, {
-              ...(code ? { code } : {}),
-            }),
+            buildMemorySearchUnavailableResult(message, code ? { code } : undefined),
           );
         }
       },

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -1,5 +1,5 @@
 // Memory Core plugin module implements tools behavior.
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { extractErrorCode, formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   resolveMemorySearchStaleness,
   stripMemoryAnnotationCarriers,
@@ -51,6 +51,7 @@ import {
   getMemoryCorpusSupplementResult,
   getMemoryManagerContextWithPurpose,
   loadMemoryToolRuntime,
+  MEMORY_SEARCH_CANONICAL_SESSION_MIGRATION_CODE,
   MemoryGetSchema,
   MemorySearchSchema,
   searchMemoryCorpusSupplements,
@@ -66,10 +67,17 @@ type MemoryManagerSearchOptions = NonNullable<
 > &
   MemorySearchDeadlineControlOptions;
 type QmdRuntimeDebug = NonNullable<MemorySearchRuntimeDebug["qmd"]>;
+type MemorySearchToolCooldownFailure = {
+  error: string;
+  code?: typeof MEMORY_SEARCH_CANONICAL_SESSION_MIGRATION_CODE;
+};
 
 const MEMORY_SEARCH_TOOL_COOLDOWN_MS = 60_000;
 
-const memorySearchToolCooldowns = new Map<string, { until: number; error: string }>();
+const memorySearchToolCooldowns = new Map<
+  string,
+  MemorySearchToolCooldownFailure & { until: number }
+>();
 
 /**
  * Validate the model-authored corpus argument against the tool's closed enum.
@@ -132,7 +140,7 @@ function resolveMemorySearchToolCooldownKey(options: {
   return options.agentId ?? options.agentSessionKey ?? "default";
 }
 
-function readMemorySearchToolCooldown(key: string): { error: string } | undefined {
+function readMemorySearchToolCooldown(key: string): MemorySearchToolCooldownFailure | undefined {
   const entry = memorySearchToolCooldowns.get(key);
   if (!entry) {
     return undefined;
@@ -141,13 +149,20 @@ function readMemorySearchToolCooldown(key: string): { error: string } | undefine
     memorySearchToolCooldowns.delete(key);
     return undefined;
   }
-  return { error: entry.error };
+  return {
+    error: entry.error,
+    ...(entry.code ? { code: entry.code } : {}),
+  };
 }
 
-function recordMemorySearchToolCooldown(key: string, error: string): void {
+function recordMemorySearchToolCooldown(
+  key: string,
+  failure: MemorySearchToolCooldownFailure,
+): void {
   memorySearchToolCooldowns.set(key, {
     until: Date.now() + MEMORY_SEARCH_TOOL_COOLDOWN_MS,
-    error,
+    error: failure.error,
+    ...(failure.code ? { code: failure.code } : {}),
   });
 }
 
@@ -541,7 +556,11 @@ export function createMemorySearchTool(options: {
           const shouldQuerySupplements = requestedCorpus === "wiki" || requestedCorpus === "all";
           const shouldQueryMemory = requestedCorpus !== "wiki" && !cooldown;
           if (cooldown && !shouldQuerySupplements) {
-            return jsonResult(buildMemorySearchUnavailableResult(cooldown.error));
+            return jsonResult(
+              buildMemorySearchUnavailableResult(cooldown.error, {
+                ...(cooldown.code ? { code: cooldown.code } : {}),
+              }),
+            );
           }
           const memoryManagerPurpose = options.oneShotCliRun ? "cli" : undefined;
           const memoryManagersToClose = new Set<ActiveMemoryManagerContext["manager"]>();
@@ -583,7 +602,7 @@ export function createMemorySearchTool(options: {
             if (shouldQueryMemory && memory && "error" in memory && !shouldQuerySupplements) {
               recordMemorySearchToolCooldown(
                 cooldownKey,
-                memory.error ?? "memory search unavailable",
+                { error: memory.error ?? "memory search unavailable" },
               );
               return jsonResult(buildMemorySearchUnavailableResult(memory.error));
             }
@@ -876,15 +895,31 @@ export function createMemorySearchTool(options: {
           if (callerSignal?.aborted) {
             throw resolveMemorySearchAbortError(callerSignal);
           }
-          const unavailablePhase = failedUnavailablePhase ?? activeUnavailablePhase;
+          const unavailablePhase =
+            failedUnavailablePhase ??
+            activeUnavailablePhase ??
+            (requestedCorpus === "wiki" ? "supplement" : "memory");
           const shouldRecordCooldown =
             requestedCorpus !== "wiki" &&
             (requestedCorpus !== "all" || unavailablePhase === "memory");
           const message = formatErrorMessage(error);
+          const extractedCode = extractErrorCode(error);
+          const code =
+            unavailablePhase === "memory" &&
+            extractedCode === MEMORY_SEARCH_CANONICAL_SESSION_MIGRATION_CODE
+              ? MEMORY_SEARCH_CANONICAL_SESSION_MIGRATION_CODE
+              : undefined;
           if (shouldRecordCooldown) {
-            recordMemorySearchToolCooldown(cooldownKey, message);
+            recordMemorySearchToolCooldown(cooldownKey, {
+              error: message,
+              ...(code ? { code } : {}),
+            });
           }
-          return jsonResult(buildMemorySearchUnavailableResult(message));
+          return jsonResult(
+            buildMemorySearchUnavailableResult(message, {
+              ...(code ? { code } : {}),
+            }),
+          );
         }
       },
   });

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -601,10 +601,9 @@ export function createMemorySearchTool(options: {
               : null;
             const memory = memorySetup?.context ?? null;
             if (shouldQueryMemory && memory && "error" in memory && !shouldQuerySupplements) {
-              recordMemorySearchToolCooldown(
-                cooldownKey,
-                { error: memory.error ?? "memory search unavailable" },
-              );
+              recordMemorySearchToolCooldown(cooldownKey, {
+                error: memory.error ?? "memory search unavailable",
+              });
               return jsonResult(buildMemorySearchUnavailableResult(memory.error));
             }
 


### PR DESCRIPTION
Closes #119060

Related: #116703

Related: #112196

## What Problem This Solves

When the session catalog requires canonical-key migration, `memory_search` reports an embedding/provider failure. The 60-second cooldown repeats the same incorrect recovery advice.

## Root Cause

Memory Core converted every corpus failure to text before it built the tool result. That conversion discarded the typed `SESSION_CANONICAL_KEY_MIGRATION_REQUIRED` code. The cooldown then stored only the text.

## Fix

- Preserve the optional typed error code in the existing per-corpus failure record.
- Store the same bounded `{ error, code }` record in the cooldown.
- Map only the exact canonical-session migration code to the supported `openclaw doctor --fix` recovery.
- Keep quota, missing SQLite runtime, generic provider, and text-only error guidance unchanged.

## Evidence

- Current-main baseline `f5ff15cb568efc85ff479198cb9062a0512a4d69`: a real SQLite session catalog with a legacy key made both the first `memory_search` request and cooldown replay return generic embedding/provider guidance.
- Gateway proof `96d0c9e7390c6bd2643c466b412ba0c014f6e7b8`: a real Gateway agent turn returned canonical-session migration guidance and the `openclaw doctor --fix` action.
- Current head `f26b115fa6a10145f729f4e83e0d0af82ba54dd0` is a patch-identical rebase onto current main.
- The proof removed the legacy row before a second session used a different query. The cooldown still returned the same canonical recovery, which proves the typed cause survived replay.

### Sanitized Gateway Terminal Capture

```text
GATEWAY_AGENT_LIVE_PROOF={"head":"96d0c9e7390c6bd2643c466b412ba0c014f6e7b8","first":{"warning":"Memory search is unavailable because the session catalog requires canonical-key migration.","action":"Stop the Gateway and run openclaw doctor --fix, then restart the Gateway and retry memory_search.","unavailable":true},"replay":{"warning":"Memory search is unavailable because the session catalog requires canonical-key migration.","action":"Stop the Gateway and run openclaw doctor --fix, then restart the Gateway and retry memory_search.","unavailable":true},"antiCheat":{"modelRequestPausedAfterAdmission":true,"differentSecondQuery":true,"legacyRowRemovedBeforeReplay":true}}
```

## Validation

- `node scripts/run-vitest.mjs extensions/memory-core/src/tools.real-manager.test.ts extensions/memory-core/src/tools.test.ts`: 42 tests passed.
- Exact-head full build passed.
- `git diff --check origin/main...HEAD` passed.
- No configuration, protocol, schema, dependency, migration, or user-data change.

## Scope

The change is limited to Memory Core failure projection, its existing in-process cooldown, and focused regression coverage. It does not run migrations, change session data, alter providers, or infer migration state from error text.

## AI Assistance

Codex helped reproduce the bug, port the contributor repair to current Memory Core ownership, add the regression proof, and verify the final behavior.
