### PR TITLE
test(qa): repair scenario catalog baselines

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -674,7 +674,10 @@ describe("qa scenario catalog", () => {
   it("loads the opt-in update.run package self-upgrade script proof", () => {
     const scenario = readQaScenarioById("update-run-package-self-upgrade");
 
-    expect(scenario.coverage?.primary).toEqual([`${cli}.update-status-and-rpc`]);
+    expect(scenario.coverage?.primary).toEqual([
+      `${cli}.update-status-and-rpc`,
+      "gateway.update-and-setup-apis",
+    ]);
     expect(scenario.coverage?.secondary).toEqual([`${cli}.managed-gateway-restart`]);
     expect(scenario.execution.kind).toBe("script");
     if (scenario.execution.kind !== "script") {

--- a/qa/scenarios/agents/session-scope-continuity.yaml
+++ b/qa/scenarios/agents/session-scope-continuity.yaml
@@ -20,7 +20,7 @@ scenario:
     - docs/help/testing.md
   codeRefs:
     - src/gateway/server-methods/agent-session-prepare.ts
-    - src/agents/embedded-agent-runner/run/history.ts
+    - src/agents/embedded-agent-runner/history.ts
     - test/e2e/qa-lab/runtime/agent-session-scope-continuity.e2e.test.ts
   execution:
     kind: vitest


### PR DESCRIPTION
## Problem

Fresh `main` has two QA catalog baseline mismatches:

- `update-run-package-self-upgrade` gained `gateway.update-and-setup-apis` as an ordered primary coverage claim, but its catalog assertion still expected only the CLI claim.
- `session-scope-continuity` references the retired nested history path instead of the current runner history module.

Together these make the focused scenario catalog fail despite both scenarios otherwise loading correctly.

## Fix

- Align the update-run catalog assertion with the scenario's existing ordered primary claims.
- Point the session-scope scenario at `src/agents/embedded-agent-runner/history.ts`.

No runtime, taxonomy, schema, or changelog behavior changes.

## Evidence

- `node scripts/run-vitest.mjs extensions/qa-lab/src/scenario-catalog.test.ts` - 47/47 passed
- `node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/update-run-package-self-upgrade.test.ts` - 8/8 passed
- Coverage JSON lookups resolve `gateway.update-and-setup-apis` and `session-scope-continuity` to the corrected scenarios and references
- Targeted `oxfmt` and `git diff --check` passed
- `node scripts/check-changed.mjs -- extensions/qa-lab/src/scenario-catalog.test.ts qa/scenarios/agents/session-scope-continuity.yaml` passed on Blacksmith Testbox
- Sol-high autoreview: clean, no actionable findings
