### PR TITLE
fix(qa): provision ffmpeg for Playwright scenarios

### DIFF
--- a/extensions/qa-lab/src/test-file-scenario-runner.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.test.ts
@@ -262,7 +262,7 @@ describe("qa test file scenario runner", () => {
 
     expect(result.executionKind).toBe("playwright");
     expect(commands.map((command) => command.args)).toEqual([
-      ["scripts/ensure-playwright-chromium.mjs", "--skip-ffmpeg"],
+      ["scripts/ensure-playwright-chromium.mjs"],
       [
         "scripts/run-vitest.mjs",
         "run",

--- a/extensions/qa-lab/src/test-file-scenario-runner.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.ts
@@ -143,7 +143,7 @@ function playwrightSteps(
   return [
     {
       command: process.execPath,
-      args: ["scripts/ensure-playwright-chromium.mjs", "--skip-ffmpeg"],
+      args: ["scripts/ensure-playwright-chromium.mjs"],
     },
     {
       command: process.execPath,


### PR DESCRIPTION
Closes https://github.com/openclaw/openclaw/issues/119058

## What this fixes

The shared QA Playwright scenario runner opted out of installing Playwright's ffmpeg binary even though registered scenarios can require it through `recordVideo`. On a clean runner, those scenarios failed before opening a page.

This restores the setup helper's normal contract for Playwright scenarios: ensure the runnable browser and the managed ffmpeg binary before executing the selected test. The separate QA web runtime does not record video and keeps its existing opt-out.

## Root cause and scope

- `extensions/qa-lab/src/test-file-scenario-runner.ts` passed `--skip-ffmpeg` for every Playwright scenario.
- Playwright rejects `browserContext.newPage()` when `recordVideo` is configured and its managed ffmpeg binary is absent.
- Five registered Playwright scenario files currently record video unconditionally, so changing only the first failing UI test would leave the catalog runner broken.

Diff: 2 files, +2/-2. Production delta: +1/-1. No product runtime, scenario schema, config, protocol, dependency, or changelog change.

## Reproduction

Current-main baseline `25e3b6c9b79dadb912195d86fbff968602d58798` failed twice on clean Testbox `tbx_01kz57r042hwwxqt4p3dfqf6hr`:

- mixed CLI/TUI/Control UI/Gateway QA matrix: 6 passed, 1 failed
- isolated `control-ui-shell-routing` repeat: failed in 11.6 seconds
- exact failure: Playwright-managed `ffmpeg-1011/ffmpeg-linux` missing before page creation
- run: https://github.com/openclaw/openclaw/actions/runs/30870241613

## Proof

Candidate Testbox `tbx_01kz58enw6h1dd4swytz0s399g`, run https://github.com/openclaw/openclaw/actions/runs/30870884320:

- focused runner suite: 45/45 passed
- cold-cache `control-ui-shell-routing`: passed after the setup log downloaded Playwright ffmpeg v1011 (2.3 MiB), then launched the same real Chromium assertion
- registered unconditional-video scenario matrix: 5/5 passed (`control-ui-shell-routing`, device pairing, token/password auth, static-asset recovery, update status)
- path-scoped full changed gate: passed
- `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build`: passed, including all 149 public plugin-sdk subpaths and Control UI performance checks
- final exact-base Codex autoreview: clean, no accepted/actionable findings, confidence 0.99
- `git diff --check`: passed
- public model identifier gate: passed; no identifiers added or changed

Exact pushed head `126020b9b2b459d1c1252847ee8c54f50d3ed3c3` was then verified from a clean branch-pinned checkout on Testbox `tbx_01kz59eyds27mpd7jq3p9qbywp`, run https://github.com/openclaw/openclaw/actions/runs/30871762572:

- remote `HEAD` matched the PR SHA and `git status --porcelain` was empty
- focused runner suite: 45/45 passed
- cold-cache `control-ui-shell-routing`: downloaded Playwright ffmpeg v1011 and passed the same Chromium assertion in 21.9 seconds

## Best-fix judgment

The generic Playwright scenario runner owns dependency readiness for every registered Playwright scenario. Keeping its global opt-out and weakening individual video-producing tests would duplicate policy and leave sibling scenarios dependent on warm caches. Restoring the helper default is the smallest complete owner-boundary fix.

## Changelog

Not required: internal QA runner repair; release-note context is in this PR.

## AI assistance

AI-assisted implementation and testing. No agent transcript is attached.
