### PR TITLE
fix(slack): keep reasoning in one partial preview

### DIFF
--- a/extensions/slack/src/__traces__/preview-reasoning-cycles.trace.jsonl
+++ b/extensions/slack/src/__traces__/preview-reasoning-cycles.trace.jsonl
@@ -1,0 +1,18 @@
+{"seq":1,"at":0,"dir":"in","kind":"reply-start"}
+{"seq":2,"at":0,"dir":"out","kind":"assistant.threads.setStatus","data":{"payload":{"channel_id":"C0TRACE","status":"is typing...","thread_ts":"ts#1"},"result":{"ok":true},"target":"C0TRACE/ts#1"}}
+{"seq":3,"at":0,"dir":"in","kind":"assistant-start"}
+{"seq":4,"at":0,"dir":"in","kind":"reasoning","data":{"text":"Planning the change"}}
+{"seq":5,"at":0,"dir":"out","kind":"chat.postMessage","data":{"payload":{"channel":"C0TRACE","text":"Working\n\n• Planning the change","thread_ts":"ts#1","unfurl_links":false},"result":{"ts":"ts#2"},"target":"C0TRACE"}}
+{"seq":6,"at":0,"dir":"in","kind":"reasoning-end"}
+{"seq":7,"at":0,"dir":"in","kind":"tool-progress","data":{"name":"exec","phase":"start"}}
+{"seq":8,"at":0,"dir":"in","kind":"assistant-start"}
+{"seq":9,"at":0,"dir":"in","kind":"reasoning","data":{"text":"Checking the result"}}
+{"seq":10,"at":0,"dir":"in","kind":"reasoning-end"}
+{"seq":11,"at":0,"dir":"in","kind":"tool-progress","data":{"name":"read","phase":"start"}}
+{"seq":12,"at":0,"dir":"in","kind":"assistant-start"}
+{"seq":13,"at":0,"dir":"in","kind":"partial","data":{"text":"final answer"}}
+{"seq":14,"at":1000,"dir":"out","kind":"chat.update","data":{"payload":{"channel":"C0TRACE","text":"final answer","ts":"ts#2"},"result":{"ok":true},"target":"ts#2"}}
+{"seq":15,"at":1100,"dir":"in","kind":"final","data":{"text":"final answer"}}
+{"seq":16,"at":1100,"dir":"out","kind":"chat.update","data":{"payload":{"channel":"C0TRACE","text":"final answer","ts":"ts#2"},"result":{"ok":true},"target":"ts#2"}}
+{"seq":17,"at":1100,"dir":"in","kind":"idle"}
+{"seq":18,"at":1100,"dir":"out","kind":"assistant.threads.setStatus","data":{"payload":{"channel_id":"C0TRACE","status":"","thread_ts":"ts#1"},"result":{"ok":true},"target":"C0TRACE/ts#1"}}

--- a/extensions/slack/src/delivery-trace.test.ts
+++ b/extensions/slack/src/delivery-trace.test.ts
@@ -44,6 +44,9 @@ type CapturedDispatcherOptions = {
 type CapturedReplyOptions = {
   suppressDefaultToolProgressMessages?: boolean;
   onPartialReply?: (payload: { text: string }) => Promise<void> | void;
+  onAssistantMessageStart?: () => Promise<void> | void;
+  onReasoningStream?: (payload: { text: string }) => Promise<void> | void;
+  onReasoningEnd?: () => Promise<void> | void;
   onToolStart?: (payload: { name: string; phase: "start" | "result" }) => Promise<void> | void;
 };
 
@@ -171,7 +174,8 @@ type SlackTraceScenarioName =
   | "stream-stop-first-network-call"
   | "final-blocks-and-text"
   | "cancel-mid-stream"
-  | "preview-edit-fallback";
+  | "preview-edit-fallback"
+  | "preview-reasoning-cycles";
 
 const NATIVE_SCENARIOS = new Set<SlackTraceScenarioName>([
   "streaming-happy-native",
@@ -259,6 +263,22 @@ const slackTraceScenarios: Record<SlackTraceScenarioName, readonly DeliveryTrace
     { kind: "partial", text: PREVIEW_PARTIAL_TWO },
     { kind: "advance", ms: 1100 },
     { kind: "final", text: PREVIEW_FINAL_TEXT },
+    { kind: "idle" },
+  ],
+  "preview-reasoning-cycles": [
+    { kind: "reply-start" },
+    { kind: "assistant-start" },
+    { kind: "reasoning", text: "Planning the change" },
+    { kind: "reasoning-end" },
+    { kind: "tool-progress", name: "exec", phase: "start" },
+    { kind: "assistant-start" },
+    { kind: "reasoning", text: "Checking the result" },
+    { kind: "reasoning-end" },
+    { kind: "tool-progress", name: "read", phase: "start" },
+    { kind: "assistant-start" },
+    { kind: "partial", text: "final answer" },
+    { kind: "advance", ms: 1100 },
+    { kind: "final", text: "final answer" },
     { kind: "idle" },
   ],
 };
@@ -553,6 +573,15 @@ async function setupSlackTrace(
     switch (step.kind) {
       case "reply-start":
         await turn.options.typingCallbacks?.onReplyStart?.();
+        break;
+      case "assistant-start":
+        await turn.replyOptions.onAssistantMessageStart?.();
+        break;
+      case "reasoning":
+        await turn.replyOptions.onReasoningStream?.({ text: step.text });
+        break;
+      case "reasoning-end":
+        await turn.replyOptions.onReasoningEnd?.();
         break;
       case "partial":
         // Present only on the draft-preview tier; native streaming leaves

--- a/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
@@ -96,7 +96,9 @@ export function createSlackProgressRuntime(runtimeParams: {
         warn: logVerbose,
       })
     : undefined;
-  let hasStreamedMessage = false;
+  // Reasoning and tool progress keep editing one draft; only answer text owns
+  // the assistant-message boundary that may rotate to a new Slack message.
+  let hasStreamedAnswer = false;
   const streamMode = slackStreaming.draftMode;
   const useNativeProgressStreaming = useStreaming && slackStreaming.mode === "progress";
   const progressDraftActive = Boolean(draftStream) || useNativeProgressStreaming;
@@ -365,7 +367,6 @@ export function createSlackProgressRuntime(runtimeParams: {
           ? { text: previewText, blocks: richProgressBlocks }
           : previewText,
       );
-      hasStreamedMessage = true;
       if (options?.flush) {
         await draftStream.flush();
       }
@@ -453,7 +454,6 @@ export function createSlackProgressRuntime(runtimeParams: {
     });
     if (text) {
       draftStream.update(text);
-      hasStreamedMessage = true;
     }
     return false;
   };
@@ -501,7 +501,7 @@ export function createSlackProgressRuntime(runtimeParams: {
         return false;
       }
       draftStream?.update(next.rendered);
-      hasStreamedMessage = true;
+      hasStreamedAnswer = true;
       return false;
     }
 
@@ -512,7 +512,7 @@ export function createSlackProgressRuntime(runtimeParams: {
     previewToolProgressSuppressed = true;
     progressDraft.suppress();
     draftStream?.update(trimmed);
-    hasStreamedMessage = true;
+    hasStreamedAnswer = true;
     return false;
   };
   const pushReasoningProgress = async (payload?: {
@@ -548,7 +548,7 @@ export function createSlackProgressRuntime(runtimeParams: {
     });
   };
   const resetDraftDeliveryState = () => {
-    hasStreamedMessage = false;
+    hasStreamedAnswer = false;
     appendRenderedText = "";
     appendSourceText = "";
   };
@@ -591,9 +591,11 @@ export function createSlackProgressRuntime(runtimeParams: {
             await beginNewProgressTurn();
             return;
           }
-          if (hasStreamedMessage) {
-            draftStream?.forceNewMessage();
+          if (!hasStreamedAnswer) {
+            progressDraft.resetReasoningProgress();
+            return;
           }
+          draftStream?.forceNewMessage();
           resetDraftDeliveryState();
           resetDraftProgressState();
         };

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -3722,6 +3722,39 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expect(draftStream.update).toHaveBeenLastCalledWith("Working\n\n• queued turn");
   });
 
+  it("keeps reasoning and tool cycles on one partial draft", async () => {
+    const draftStream = createDraftStreamStub();
+    createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
+    mockedSlackStreamingMode = "partial";
+    mockedSlackDraftMode = "replace";
+    mockedReplyOptionEvents = [
+      { kind: "assistant_start" },
+      { kind: "reasoning", text: "Planning the change" },
+      { kind: "reasoning_end" },
+      { kind: "tool_start", name: "exec", phase: "start" },
+      { kind: "assistant_start" },
+      { kind: "reasoning", text: "Checking the result" },
+      { kind: "reasoning_end" },
+      { kind: "tool_start", name: "read", phase: "start" },
+      { kind: "assistant_start" },
+      { kind: "partial", text: "final answer" },
+    ];
+
+    await dispatchPreparedSlackMessage(
+      createPreparedSlackMessage({
+        accountConfig: {
+          streaming: { mode: "partial", progress: { label: false } },
+        },
+      }),
+    );
+
+    const updates = draftStream.update.mock.calls.flat().join("\n");
+    expect(updates).toContain("Planning the change");
+    expect(updates).toContain("Checking the result");
+    expect(draftStream.forceNewMessage).not.toHaveBeenCalled();
+    expect(draftStream.update).toHaveBeenLastCalledWith("final answer");
+  });
+
   it("forces a new draft message on assistant boundaries in partial mode", async () => {
     const draftStream = createDraftStreamStub();
     createSlackDraftStreamMock.mockReturnValueOnce(draftStream);

--- a/src/channels/plugins/contracts/trace/delivery-trace.ts
+++ b/src/channels/plugins/contracts/trace/delivery-trace.ts
@@ -65,6 +65,9 @@ export type TraceNormalizer = (event: TraceEvent) => TraceEvent;
  */
 export type DeliveryTraceInStep =
   | { kind: "reply-start" }
+  | { kind: "assistant-start" }
+  | { kind: "reasoning"; text: string }
+  | { kind: "reasoning-end" }
   | { kind: "partial"; text: string }
   | { kind: "block-final"; text: string }
   | { kind: "tool-progress"; name: string; phase: "start" | "result" }


### PR DESCRIPTION
Closes #119041

## What Problem This Solves

Slack users running reasoning-streaming models in `partial` preview mode received a new Slack message at every reasoning or tool boundary. One assistant turn could leave several stale progress previews instead of continuously editing one bounded draft.

## Why This Change Was Made

Slack preview state now distinguishes streamed answer text from reasoning, tool, and plan progress. Reasoning-only assistant boundaries retain the active draft and reset only the reasoning accumulator; a boundary after actual answer text still rotates to a new message. Queued followups retain their existing unconditional rotation and delivery reset.

The branch was rebuilt on current `main` (`8b8058a68b6`) and preserves the newer Slack callback visibility contract: `onReasoningEnd` still invokes the draft boundary and returns `false`, while the progress owner decides whether that boundary rotates.

## User Impact

MiniMax-style reasoning and tool cycles remain in one Slack partial-preview message. Completed answer blocks and queued followups still start a fresh message when required.

## Evidence

Exact head: `0152476c773f1aa0c29db6176b53a9e84d958125`

### Slack Web API behavior trace

Command:

```text
node scripts/run-vitest.mjs extensions/slack/src/delivery-trace.test.ts extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
```

Result: 2 files and 146 tests passed.

The new replayable `preview-reasoning-cycles` trace runs the production path from `dispatchPreparedSlackMessage` through draft preview/finalization to a recording Slack Web API client. Only the core agent turn and external Slack network are replaced. The scripted turn contains two reasoning bursts, two tool starts, three assistant boundaries, a final partial, and final delivery.

```json
{
  "schemaVersion": 1,
  "headSha": "0152476c773f1aa0c29db6176b53a9e84d958125",
  "verdict": "pass",
  "boundary": "production Slack dispatcher to recording Slack Web API",
  "events": 18,
  "assistantAndReasoningBoundaries": 5,
  "chatPostMessageCalls": 1,
  "chatUpdateCalls": 2,
  "chatDeleteCalls": 0,
  "createdMessageId": "ts#2",
  "updateMessageIds": ["ts#2", "ts#2"],
  "observed": "All reasoning/tool progress and the final answer used one Slack draft identity."
}
```

The committed JSONL trace records one `chat.postMessage` for `ts#2`; both the answer preview and final promotion are `chat.update` calls targeting that same `ts#2`. No extra post or delete occurs across the five boundaries.

### Static and type verification

- `pnpm tsgo:extensions:test` - passed
- `pnpm tsgo:core:test` - passed
- `node scripts/run-oxlint.mjs` on all changed TypeScript files - 0 warnings, 0 errors
- `oxfmt --check` on all changed files - passed
- `git diff --check origin/main...HEAD` - passed

## Out-of-scope Follow-ups

- No real Slack workspace credential was used. The committed wire trace intentionally uses a deterministic recording Web API client so the exact message identity and call order are reproducible in CI.
- Native Slack streaming and `status_final` behavior are unchanged.

## AI-assisted

- [x] AI-assisted implementation; reviewed the Slack draft owner, current callback ordering, wire-level delivery trace, sibling channel behavior, and focused regression coverage before submission.
