### PR TITLE
fix: error when gateway port is busy but process cannot be identified

### DIFF
--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -77,6 +77,7 @@ const restartSystemdService = vi.hoisted(() =>
 );
 const stopSystemdService = vi.hoisted(() => vi.fn<() => Promise<void>>(async () => {}));
 const isTerminalInteractive = vi.fn(() => true);
+const throwIfPortBusyWithoutOwner = vi.fn<(port: number) => Promise<void>>(async () => {});
 const appendGatewayLifecycleAudit = vi.fn();
 const createGatewayLifecycleMutationAudit = vi.fn(
   (params: { action: string; source?: string }) => (mutation: { mode: string; pid?: number }) =>
@@ -164,6 +165,10 @@ vi.mock("../terminal-interactivity.js", () => ({
   isTerminalInteractive: () => isTerminalInteractive(),
   NON_INTERACTIVE_GATEWAY_STOP_MESSAGE:
     "This stops the operator's running gateway service. Use an isolated dev gateway (openclaw gateway run --dev, or --profile <name> with a free port) for testing, or re-run with --force if you really mean it.",
+}));
+
+vi.mock("../../infra/ports-probe.js", () => ({
+  throwIfPortBusyWithoutOwner: (port: number) => throwIfPortBusyWithoutOwner(port),
 }));
 
 vi.mock("./lifecycle-audit.js", () => ({
@@ -270,6 +275,7 @@ describe("runDaemonRestart health checks", () => {
     recoverInstalledLaunchAgent.mockReset().mockResolvedValue(null);
     repairLoadedGatewayServiceForStart.mockReset();
     isTerminalInteractive.mockReset().mockReturnValue(true);
+    throwIfPortBusyWithoutOwner.mockReset().mockResolvedValue(undefined);
     appendGatewayLifecycleAudit.mockClear();
     createGatewayLifecycleMutationAudit.mockClear();
     isDefaultInstallIdentity.mockReset().mockReturnValue(true);
@@ -1114,5 +1120,20 @@ describe("runDaemonRestart health checks", () => {
     expect(signalVerifiedGatewayPidSync).not.toHaveBeenCalled();
     expect(appendGatewayLifecycleAudit).not.toHaveBeenCalled();
     expect(outcome).toBeNull();
+  });
+
+  it("throws when port is busy but no gateway process can be identified", async () => {
+    findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([]);
+    readActiveGatewayLockIdentity.mockResolvedValue(undefined);
+    throwIfPortBusyWithoutOwner.mockRejectedValue(
+      new Error("Port 18789 is in use but the gateway process could not be identified"),
+    );
+
+    await expect(runUnmanagedStop()).rejects.toThrow(
+      /Port 18789 is in use but the gateway process could not be identified/,
+    );
+
+    expect(signalVerifiedGatewayPidSync).not.toHaveBeenCalled();
+    expect(throwIfPortBusyWithoutOwner).toHaveBeenCalledWith(18789);
   });
 });

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -77,7 +77,7 @@ const restartSystemdService = vi.hoisted(() =>
 );
 const stopSystemdService = vi.hoisted(() => vi.fn<() => Promise<void>>(async () => {}));
 const isTerminalInteractive = vi.fn(() => true);
-const throwIfPortBusyWithoutOwner = vi.fn<(port: number) => Promise<void>>(async () => {});
+const throwIfPortBusyWithoutOwner = vi.fn<(port: number, errorMessage?: string) => Promise<void>>(async () => {});
 const appendGatewayLifecycleAudit = vi.fn();
 const createGatewayLifecycleMutationAudit = vi.fn(
   (params: { action: string; source?: string }) => (mutation: { mode: string; pid?: number }) =>
@@ -168,7 +168,7 @@ vi.mock("../terminal-interactivity.js", () => ({
 }));
 
 vi.mock("../../infra/ports-probe.js", () => ({
-  throwIfPortBusyWithoutOwner: (port: number) => throwIfPortBusyWithoutOwner(port),
+  throwIfPortBusyWithoutOwner: (port: number, msg?: string) => throwIfPortBusyWithoutOwner(port, msg),
 }));
 
 vi.mock("./lifecycle-audit.js", () => ({
@@ -1134,6 +1134,9 @@ describe("runDaemonRestart health checks", () => {
     );
 
     expect(signalVerifiedGatewayPidSync).not.toHaveBeenCalled();
-    expect(throwIfPortBusyWithoutOwner).toHaveBeenCalledWith(18789);
+    expect(throwIfPortBusyWithoutOwner).toHaveBeenCalledWith(
+      18789,
+      expect.stringContaining("openclaw gateway status --deep"),
+    );
   });
 });

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -30,6 +30,7 @@ import {
   isGatewayExternallySupervised,
   resolveGatewayServiceMutationError,
 } from "../../infra/gateway-supervision.js";
+import { throwIfPortBusyWithoutOwner } from "../../infra/ports-probe.js";
 import {
   clearGatewayRestartIntentSync,
   type GatewayRestartIntent,
@@ -218,6 +219,7 @@ async function stopGatewayWithoutServiceManager(port: number, lockOwnerPid: numb
   // reporting the gateway as not running while it keeps serving.
   const pids = listenerPids.length > 0 ? listenerPids : lockOwnerPid ? [lockOwnerPid] : [];
   if (pids.length === 0) {
+    await throwIfPortBusyWithoutOwner(port);
     return null;
   }
   for (const pid of pids) {

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -219,7 +219,7 @@ async function stopGatewayWithoutServiceManager(port: number, lockOwnerPid: numb
   // reporting the gateway as not running while it keeps serving.
   const pids = listenerPids.length > 0 ? listenerPids : lockOwnerPid ? [lockOwnerPid] : [];
   if (pids.length === 0) {
-    await throwIfPortBusyWithoutOwner(port);
+    await throwIfPortBusyWithoutOwner(port, `Port ${port} is in use but the gateway process could not be identified (lsof unavailable or PID exited). Run ${formatCliCommand("openclaw gateway status --deep")} to investigate.`);
     return null;
   }
   for (const pid of pids) {

--- a/src/infra/ports-probe.ts
+++ b/src/infra/ports-probe.ts
@@ -66,3 +66,15 @@ export async function probePortUsage(
   }
   return sawUnknown ? "unknown" : "free";
 }
+
+/**
+ * Throws when the port is provably busy but no owning PID was found.
+ * Returns silently when the port is free or the probe is inconclusive.
+ */
+export async function throwIfPortBusyWithoutOwner(port: number): Promise<void> {
+  if ((await probePortUsage(port)) === "busy") {
+    throw new Error(
+      `Port ${port} is in use but the gateway process could not be identified (lsof unavailable or PID exited). Use \`openclaw gateway status --deep\` to investigate.`,
+    );
+  }
+}

--- a/src/infra/ports-probe.ts
+++ b/src/infra/ports-probe.ts
@@ -70,11 +70,16 @@ export async function probePortUsage(
 /**
  * Throws when the port is provably busy but no owning PID was found.
  * Returns silently when the port is free or the probe is inconclusive.
+ * @param errorMessage - Custom error message; when omitted a generic message is used.
  */
-export async function throwIfPortBusyWithoutOwner(port: number): Promise<void> {
+export async function throwIfPortBusyWithoutOwner(
+  port: number,
+  errorMessage?: string,
+): Promise<void> {
   if ((await probePortUsage(port)) === "busy") {
     throw new Error(
-      `Port ${port} is in use but the gateway process could not be identified (lsof unavailable or PID exited). Use \`openclaw gateway status --deep\` to investigate.`,
+      errorMessage ??
+        `Port ${port} is in use but the owning process could not be identified.`,
     );
   }
 }


### PR DESCRIPTION
## What Problem This Solves

`openclaw gateway stop` reports "Gateway service disabled" (exit 0) when the gateway port is still in use but neither `lsof` nor the gateway lock file can identify the owning PID. This misleads the user into thinking the gateway is stopped while it continues serving.

Occurs in containerized/distroless environments without `lsof`, or when the lock file is stale/missing.

Closes #119065.

## Why This Change Was Made

`stopGatewayWithoutServiceManager` returned `null` when `pids.length === 0`, and the caller interpreted that as "service not loaded" — printing a false-success message. The port may still be busy with an active gateway process.

## Shipped Solution

Added a `throwIfPortBusyWithoutOwner(port, errorMessage?)` helper in `ports-probe.ts` that probes the port via TCP before the lifecycle layer returns `null`. If the port is busy, an actionable error is thrown; if the port is free, the existing "not loaded" path proceeds normally.

The helper accepts an optional error message so the lifecycle caller can use `formatCliCommand` to retain active profile/container scope in the recovery hint.

## User Impact

Users in unmanaged-gateway or container scenarios now get an actionable error ("Port X is in use but the gateway process could not be identified") instead of a silent false success.

## Evidence

### Unit test (CI — `checks-node-compact-small-6`)

```
✓ cli src/cli/daemon-cli/lifecycle.test.ts (43 tests) 293ms
```

New test case: `"throws when port is busy but no gateway process can be identified"` — asserts the error is thrown when the port probe returns `"busy"` and no PIDs are available.

[CI run — all 79 checks pass](https://github.com/openclaw/openclaw/pull/119068/checks)

### Real behavior proof (local reproduction)

Standalone TCP probe reproduction on Node v24.19.0, exercising the same `net.createServer` + exclusive bind strategy used by `probePortUsage`:

```
======================================================================
Reproduction: openclaw gateway stop false-success bug
======================================================================

Setup: dummy TCP listener started on port 18789
       (simulates a gateway whose PID cannot be resolved)

--- BEFORE FIX (current behavior) ---
listenerPids: [] (lsof unavailable)
lockOwnerPid: undefined (lock file missing/stale)
pids.length === 0 → return null
Caller interprets null as: "Gateway service disabled" (exit 0)
✗ FALSE SUCCESS — port 18789 is still occupied!

--- AFTER FIX (proposed behavior) ---
listenerPids: [] (lsof unavailable)
lockOwnerPid: undefined (lock file missing/stale)
pids.length === 0 → probing port 18789...
probePortUsage(18789) returned: "busy"
✓ THROWS ERROR:
  Error: Port 18789 is in use but the gateway process could not be
  identified (lsof unavailable or PID exited). Run `openclaw gateway
  status --deep` to investigate.

--- VERIFY: after server closes, probe reports free ---
probePortUsage(18789) after server.close(): "free"
✓ Port is genuinely free → return null is correct

======================================================================
Conclusion: the fix correctly distinguishes busy vs free ports
when lsof and lock file are unavailable.
======================================================================
```

The reproduction binds a TCP listener on `127.0.0.1:18789`, then probes the same port with `net.createServer({ exclusive: true })`. The probe correctly returns `"busy"` (EADDRINUSE), matching the behavior of `probePortUsage` in `ports-probe.ts`. After the listener closes, the probe returns `"free"`, confirming the fix does not regress the normal "gateway not running" case.