### PR TITLE
fix: preserve Claude follow-up replies after background tasks

### DIFF
--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -116,6 +116,25 @@ The `openclaw agent` command also has its own request deadline. Its 600-second f
 
 ### Claude CLI specifics
 
+OpenClaw's managed Claude stdio sessions require Claude Code 2.1.206 or newer.
+At runtime OpenClaw does not trust the version string alone: it waits for
+Claude Code's `system/init` record to advertise `msg_lifecycle_v1`, then accepts
+assistant, tool, and result records only after the matching input lifecycle has
+started. Unknown capabilities are ignored. A CLI that omits the required
+capability fails immediately with `claude update` and gateway-restart guidance
+instead of waiting for the no-output watchdog.
+
+```bash
+claude --version
+claude update
+# Restart the OpenClaw gateway after updating.
+```
+
+Claude Code's public CLI documentation covers stream-json mode and updates but
+does not currently document the lifecycle event itself. OpenClaw therefore
+feature-detects the advertised capability; 2.1.206 is the first published
+Claude Code build observed to provide it.
+
 The bundled `claude-cli` backend prefers Claude Code's native skill resolver. When the current skills snapshot has at least one selected skill with a materialized path, OpenClaw passes a temporary Claude Code plugin via `--plugin-dir` and omits the duplicate OpenClaw skills catalog from the appended system prompt. Without a materialized plugin skill, OpenClaw keeps the prompt catalog as a fallback. Skill env/API key overrides still apply to the child process environment for the run.
 
 Claude CLI has its own noninteractive permission mode; OpenClaw maps that to the existing exec policy instead of adding Claude-specific config. For OpenClaw-managed Claude live sessions, the effective exec policy is authoritative: YOLO (`tools.exec.mode: "full"`) normally launches Claude with `--permission-mode bypassPermissions`, while a restrictive policy launches it with `--permission-mode default`. Root-run gateways also use `default` because Claude Code rejects bypass mode for root. Per-agent `agents.entries.*.tools.exec` settings override the global `tools.exec` for that agent. The Anthropic plugin normalizes Claude's permission flags to match the effective policy and host restriction.
@@ -202,19 +221,20 @@ Anthropic owns `claude-cli` and Google owns `google-gemini-cli`. OpenAI Codex ag
 
 The bundled Anthropic plugin registers for `claude-cli`:
 
-| Key                   | Value                                                                                                                                                                                                         |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `command`             | `claude`                                                                                                                                                                                                      |
-| `args`                | `-p --output-format stream-json --include-partial-messages --verbose --setting-sources user --allowedTools mcp__openclaw__* --disallowedTools ScheduleWakeup,CronCreate,Bash(run_in_background:true),Monitor` |
-| `output`              | `jsonl`                                                                                                                                                                                                       |
-| `input`               | `stdin`                                                                                                                                                                                                       |
-| `modelArg`            | `--model`                                                                                                                                                                                                     |
-| `sessionArgs`         | `["--session-id", "{sessionId}"]`                                                                                                                                                                             |
-| `sessionMode`         | `always`                                                                                                                                                                                                      |
-| `imageArg`            | `@`                                                                                                                                                                                                           |
-| `imagePathScope`      | `workspace`                                                                                                                                                                                                   |
-| `systemPromptFileArg` | `--append-system-prompt-file`                                                                                                                                                                                 |
-| `systemPromptMode`    | `append`                                                                                                                                                                                                      |
+| Key                      | Value                                                                                                                                                                                                         |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `command`                | `claude`                                                                                                                                                                                                      |
+| `args`                   | `-p --output-format stream-json --include-partial-messages --verbose --setting-sources user --allowedTools mcp__openclaw__* --disallowedTools ScheduleWakeup,CronCreate,Bash(run_in_background:true),Monitor` |
+| `output`                 | `jsonl`                                                                                                                                                                                                       |
+| `input`                  | `stdin`                                                                                                                                                                                                       |
+| `modelArg`               | `--model`                                                                                                                                                                                                     |
+| `sessionArgs`            | `["--session-id", "{sessionId}"]`                                                                                                                                                                             |
+| `sessionMode`            | `always`                                                                                                                                                                                                      |
+| live-session requirement | `msg_lifecycle_v1` (first observed in Claude Code 2.1.206)                                                                                                                                                    |
+| `imageArg`               | `@`                                                                                                                                                                                                           |
+| `imagePathScope`         | `workspace`                                                                                                                                                                                                   |
+| `systemPromptFileArg`    | `--append-system-prompt-file`                                                                                                                                                                                 |
+| `systemPromptMode`       | `append`                                                                                                                                                                                                      |
 
 The bundled Google plugin registers for `google-gemini-cli`:
 

--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -116,13 +116,17 @@ The `openclaw agent` command also has its own request deadline. Its 600-second f
 
 ### Claude CLI specifics
 
-OpenClaw's managed Claude stdio sessions require Claude Code 2.1.206 or newer.
-At runtime OpenClaw does not trust the version string alone: it waits for
+OpenClaw's managed Claude stdio sessions require the `msg_lifecycle_v1`
+capability, first observed in the published Claude Code 2.1.206 build. At
+runtime OpenClaw does not trust the version string alone: it waits for
 Claude Code's `system/init` record to advertise `msg_lifecycle_v1`, then accepts
 assistant, tool, and result records only after the matching input lifecycle has
 started. Unknown capabilities are ignored. A CLI that omits the required
 capability fails immediately with `claude update` and gateway-restart guidance
 instead of waiting for the no-output watchdog.
+
+Setup and Doctor treat 2.1.206 as advisory, so a lower-version compatible
+backport or wrapper remains selectable and is verified by the runtime gate.
 
 ```bash
 claude --version

--- a/docs/plugins/cli-backend-plugins.md
+++ b/docs/plugins/cli-backend-plugins.md
@@ -240,9 +240,17 @@ only for behavior that really belongs to the backend.
 | `ownsNativeCompaction`             | Backend owns its own compaction - OpenClaw defers                           |
 | `subscriptionAuthDispatch`         | Opted-in embedded runs on subscription credentials execute via this backend |
 | `runtimeArtifact`                  | Bound a script launcher to its complete bundled package tree                |
+| `liveSessionRequirement`           | Require an init capability before trusting long-lived session output        |
 
 Keep these hooks provider-owned. Do not add CLI-specific branches to core when
 a backend hook can express the behavior.
+
+`liveSessionRequirement` declares one exact capability that the CLI must
+advertise in its initialization record before OpenClaw trusts streamed output.
+It also supplies the first known compatible version, version-probe arguments,
+and update command used by setup and Doctor. Runtime support remains
+capability-based, so a compatible backport or wrapper is not rejected only
+because of its version string.
 
 `prepareExecution(ctx)` receives `ctx.contextTokenBudget`, the effective token
 limit selected for the run. Backends that own native compaction can map that

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -91,14 +91,17 @@ OpenClaw release:
 
     <Steps>
       <Step title="Ensure Claude CLI is installed and logged in">
-        OpenClaw's streamed session correlation requires Claude Code 2.1.206 or
-        newer. Verify the installed version:
+        OpenClaw's streamed session correlation requires the
+        `msg_lifecycle_v1` capability. Claude Code 2.1.206 is the first
+        published build known to advertise it. Verify the installed version:
 
         ```bash
         claude --version
         ```
 
-        If it is older, update Claude Code and restart OpenClaw so the gateway
+        A lower-version compatible backport or wrapper remains selectable;
+        OpenClaw verifies the capability at runtime. If the runtime rejects the
+        installed build, update Claude Code and restart OpenClaw so the gateway
         launches the new binary:
 
         ```bash
@@ -122,8 +125,8 @@ OpenClaw release:
 
     <Note>
     Setup and runtime details for the Claude CLI backend are in [CLI Backends](/gateway/cli-backends).
-    `openclaw doctor` also reports an installed Claude Code version below the
-    supported floor.
+    `openclaw doctor` also reports advisory guidance for an installed Claude
+    Code version below the first-known compatible release.
     </Note>
 
     <Warning>

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -91,10 +91,18 @@ OpenClaw release:
 
     <Steps>
       <Step title="Ensure Claude CLI is installed and logged in">
-        Verify with:
+        OpenClaw's streamed session correlation requires Claude Code 2.1.206 or
+        newer. Verify the installed version:
 
         ```bash
         claude --version
+        ```
+
+        If it is older, update Claude Code and restart OpenClaw so the gateway
+        launches the new binary:
+
+        ```bash
+        claude update
         ```
       </Step>
       <Step title="Run onboarding">
@@ -114,6 +122,8 @@ OpenClaw release:
 
     <Note>
     Setup and runtime details for the Claude CLI backend are in [CLI Backends](/gateway/cli-backends).
+    `openclaw doctor` also reports an installed Claude Code version below the
+    supported floor.
     </Note>
 
     <Warning>

--- a/extensions/anthropic/cli-backend.ts
+++ b/extensions/anthropic/cli-backend.ts
@@ -135,6 +135,14 @@ export function buildAnthropicCliBackend(): CliBackendPlugin {
       entrypoint: "command",
       nativeExecutableNames: ["claude", "claude.exe"],
     },
+    // Claude Code 2.1.206 first shipped per-input lifecycle correlation. The
+    // runtime checks the advertised capability so backports and wrappers work.
+    liveSessionRequirement: {
+      capability: "msg_lifecycle_v1",
+      minimumVersion: "2.1.206",
+      versionArgs: ["--version"],
+      updateCommand: "claude update",
+    },
     bundleMcp: true,
     bundleMcpMode: "claude-config-file",
     nativeToolMode: "selectable",

--- a/extensions/anthropic/cli-shared.test.ts
+++ b/extensions/anthropic/cli-shared.test.ts
@@ -659,6 +659,12 @@ describe("normalizeClaudeBackendConfig", () => {
       entrypoint: "command",
       nativeExecutableNames: ["claude", "claude.exe"],
     });
+    expect(backend.liveSessionRequirement).toEqual({
+      capability: "msg_lifecycle_v1",
+      minimumVersion: "2.1.206",
+      versionArgs: ["--version"],
+      updateCommand: "claude update",
+    });
 
     const normalized = normalizeConfig?.({
       ...backend.config,

--- a/src/agents/cli-backend-version-support.ts
+++ b/src/agents/cli-backend-version-support.ts
@@ -3,16 +3,16 @@ import { coerce as coerceSemver } from "semver";
 import { compareValidSemver } from "../infra/semver.js";
 import type { CliBackendLiveSessionRequirement } from "../plugins/cli-backend.types.js";
 
-type CliBackendVersionSupport =
-  | { status: "supported"; version: string }
-  | { status: "unsupported"; version: string }
+type CliBackendVersionGuidance =
+  | { status: "at-or-above-known-floor"; version: string }
+  | { status: "below-known-floor"; version: string }
   | { status: "unknown" };
 
-/** Compare human CLI version output with the provider's published compatibility floor. */
-export function resolveCliBackendVersionSupport(
+/** Compare human CLI version output with the provider's first-known compatible release. */
+export function resolveCliBackendVersionGuidance(
   versionOutput: string | undefined,
   requirement: CliBackendLiveSessionRequirement,
-): CliBackendVersionSupport {
+): CliBackendVersionGuidance {
   const parsed = versionOutput ? coerceSemver(versionOutput)?.version : undefined;
   if (!parsed) {
     return { status: "unknown" };
@@ -22,17 +22,16 @@ export function resolveCliBackendVersionSupport(
     return { status: "unknown" };
   }
   return {
-    status: comparison < 0 ? "unsupported" : "supported",
+    status: comparison < 0 ? "below-known-floor" : "at-or-above-known-floor",
     version: parsed,
   };
 }
 
-/** Actionable guidance shared by setup, Doctor, and live-session failures. */
-export function formatCliBackendUpdateGuidance(params: {
+/** Advisory guidance; runtime capability negotiation remains authoritative. */
+export function formatCliBackendVersionAdvisory(params: {
   label: string;
   requirement: CliBackendLiveSessionRequirement;
-  version?: string;
+  version: string;
 }): string {
-  const found = params.version ? `; found ${params.version}` : "";
-  return `${params.label} ${params.requirement.minimumVersion} or newer is required${found}. Run \`${params.requirement.updateCommand}\`, restart OpenClaw, and retry.`;
+  return `${params.label} ${params.requirement.minimumVersion} is the first published build known to advertise ${params.requirement.capability}; found ${params.version}. OpenClaw verifies this capability at runtime. If this build is rejected, run \`${params.requirement.updateCommand}\`, restart OpenClaw, and retry.`;
 }

--- a/src/agents/cli-backend-version-support.ts
+++ b/src/agents/cli-backend-version-support.ts
@@ -1,0 +1,38 @@
+/** Shared version guidance for provider-owned CLI backend protocol requirements. */
+import { coerce as coerceSemver } from "semver";
+import { compareValidSemver } from "../infra/semver.js";
+import type { CliBackendLiveSessionRequirement } from "../plugins/cli-backend.types.js";
+
+type CliBackendVersionSupport =
+  | { status: "supported"; version: string }
+  | { status: "unsupported"; version: string }
+  | { status: "unknown" };
+
+/** Compare human CLI version output with the provider's published compatibility floor. */
+export function resolveCliBackendVersionSupport(
+  versionOutput: string | undefined,
+  requirement: CliBackendLiveSessionRequirement,
+): CliBackendVersionSupport {
+  const parsed = versionOutput ? coerceSemver(versionOutput)?.version : undefined;
+  if (!parsed) {
+    return { status: "unknown" };
+  }
+  const comparison = compareValidSemver(parsed, requirement.minimumVersion);
+  if (comparison === null) {
+    return { status: "unknown" };
+  }
+  return {
+    status: comparison < 0 ? "unsupported" : "supported",
+    version: parsed,
+  };
+}
+
+/** Actionable guidance shared by setup, Doctor, and live-session failures. */
+export function formatCliBackendUpdateGuidance(params: {
+  label: string;
+  requirement: CliBackendLiveSessionRequirement;
+  version?: string;
+}): string {
+  const found = params.version ? `; found ${params.version}` : "";
+  return `${params.label} ${params.requirement.minimumVersion} or newer is required${found}. Run \`${params.requirement.updateCommand}\`, restart OpenClaw, and retry.`;
+}

--- a/src/agents/cli-backends.test.ts
+++ b/src/agents/cli-backends.test.ts
@@ -11,6 +11,7 @@ import {
   listCliRuntimeModelBackendBindings,
   listCliRuntimeProviderIds,
   resolveCliBackendConfig,
+  resolveCliBackendLiveSessionRequirement,
   resolveCliBackendLiveTest,
   resolveCliRuntimeCanonicalProvider,
   resolveCliRuntimeModelBackendBinding,
@@ -29,6 +30,12 @@ const runtimeArtifact: CliBackendRuntimeArtifactPolicy = {
   packageName: "@fixture/acme-cli",
   entrypoint: "command",
 };
+const liveSessionRequirement = {
+  capability: "acme_lifecycle_v1",
+  minimumVersion: "1.2.3",
+  versionArgs: ["--version"],
+  updateCommand: "acme update",
+} as const;
 
 function createBackend(overrides: Partial<CliBackendPlugin> = {}): CliBackendPlugin {
   return {
@@ -46,6 +53,7 @@ function createBackend(overrides: Partial<CliBackendPlugin> = {}): CliBackendPlu
     bundleMcp: true,
     bundleMcpMode: "claude-config-file",
     runtimeArtifact,
+    liveSessionRequirement,
     liveTest: {
       defaultModelRef: "acme/acme-large",
       defaultImageProbe: true,
@@ -110,6 +118,7 @@ describe("resolveCliBackendConfig", () => {
       bundleMcp: true,
       bundleMcpMode: "claude-config-file",
       runtimeArtifact,
+      liveSessionRequirement,
       config: {
         command: "acme",
         args: ["chat", "--json"],
@@ -192,7 +201,9 @@ describe("resolveCliBackendConfig", () => {
     expect(resolved.pluginId).toBeUndefined();
     expect(resolved.config).toEqual({ command: "setup-acme", args: ["run"] });
     expect(resolved.runtimeArtifact).toEqual(runtimeArtifact);
+    expect(resolved.liveSessionRequirement).toEqual(liveSessionRequirement);
     expect(resolved.parseJsonlEvent).toBe(parseJsonlEvent);
+    expect(resolveCliBackendLiveSessionRequirement("acme-cli")).toEqual(liveSessionRequirement);
   });
 
   it("returns null when no plugin owns the backend", () => {

--- a/src/agents/cli-backends.ts
+++ b/src/agents/cli-backends.ts
@@ -6,6 +6,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ContextEngineHostCapability } from "../context-engine/types.js";
 import type {
   CliBackendConfig,
+  CliBackendLiveSessionRequirement,
   CliBackendRuntimeArtifactPolicy,
 } from "../plugins/cli-backend.types.js";
 import { resolveRuntimeCliBackends } from "../plugins/cli-backends.runtime.js";
@@ -62,6 +63,7 @@ export type ResolvedCliBackend = {
   nativeToolMode?: CliBackendNativeToolMode;
   sideQuestionToolMode?: CliBackendSideQuestionToolMode;
   runtimeArtifact?: CliBackendRuntimeArtifactPolicy;
+  liveSessionRequirement?: CliBackendLiveSessionRequirement;
 };
 
 type ResolvedCliBackendLiveTest = {
@@ -102,6 +104,7 @@ type FallbackCliBackendPolicy = {
   nativeToolMode?: CliBackendNativeToolMode;
   sideQuestionToolMode?: CliBackendSideQuestionToolMode;
   runtimeArtifact?: CliBackendRuntimeArtifactPolicy;
+  liveSessionRequirement?: CliBackendLiveSessionRequirement;
 };
 
 const FALLBACK_CLI_BACKEND_POLICIES: Record<string, FallbackCliBackendPolicy> = {};
@@ -169,6 +172,7 @@ function resolveSetupCliBackendPolicy(provider: string): FallbackCliBackendPolic
     nativeToolMode: entry.backend.nativeToolMode,
     sideQuestionToolMode: entry.backend.sideQuestionToolMode,
     runtimeArtifact: entry.backend.runtimeArtifact,
+    liveSessionRequirement: entry.backend.liveSessionRequirement,
   };
 }
 
@@ -362,6 +366,23 @@ export function resolveCliBackendLiveTest(provider: string): ResolvedCliBackendL
   };
 }
 
+/** Resolves setup-safe live-session protocol metadata without normalizing runtime config. */
+export function resolveCliBackendLiveSessionRequirement(
+  provider: string,
+): CliBackendLiveSessionRequirement | null {
+  const normalized = normalizeBackendKey(provider);
+  const entry =
+    cliBackendsDeps.resolvePluginSetupCliBackend({ backend: normalized }) ??
+    cliBackendsDeps
+      .resolveRuntimeCliBackends()
+      .find((backend) => normalizeBackendKey(backend.id) === normalized);
+  if (!entry) {
+    return null;
+  }
+  const backend = "backend" in entry ? entry.backend : entry;
+  return backend.liveSessionRequirement ?? null;
+}
+
 /** Resolves the executable CLI backend registered by its owning plugin. */
 export function resolveCliBackendConfig(
   provider: string,
@@ -411,6 +432,7 @@ export function resolveCliBackendConfig(
       nativeToolMode: registered.nativeToolMode,
       sideQuestionToolMode: registered.sideQuestionToolMode,
       runtimeArtifact: registered.runtimeArtifact,
+      liveSessionRequirement: registered.liveSessionRequirement,
     };
   }
 
@@ -445,6 +467,7 @@ export function resolveCliBackendConfig(
     nativeToolMode: fallbackPolicy.nativeToolMode,
     sideQuestionToolMode: fallbackPolicy.sideQuestionToolMode,
     runtimeArtifact: fallbackPolicy.runtimeArtifact,
+    liveSessionRequirement: fallbackPolicy.liveSessionRequirement,
   };
 }
 

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -49,6 +49,7 @@ import {
   runPreparedCliAgent,
   setCliRunnerTestDeps,
 } from "./cli-runner.js";
+import { createClaudeInputStartedEvent } from "./cli-runner.test-helpers.js";
 import {
   createManagedRun,
   enqueueSystemEventMock,
@@ -256,6 +257,14 @@ function requireRecord(value: unknown, label: string): Record<string, unknown> {
     throw new Error(`expected ${label}`);
   }
   return value as Record<string, unknown>;
+}
+
+function claudeInputStartedJson(data: string): string {
+  const event = createClaudeInputStartedEvent(data);
+  if (!event) {
+    throw new Error("expected Claude user input UUID");
+  }
+  return JSON.stringify(event);
 }
 
 function requireArray(value: unknown, label: string): Array<unknown> {
@@ -2001,7 +2010,7 @@ describe("runCliAgent reliability", () => {
     expect(clearBeforeRetry).not.toHaveBeenCalled();
   });
 
-  it("forks a synthetic-stalled resume without rebuilding its cached conversation", async () => {
+  it("forks a lifecycle-started resume stall without rebuilding its cached conversation", async () => {
     vi.useFakeTimers();
     supervisorSpawnMock.mockClear();
     const transcriptProbe = vi.fn(async () => false);
@@ -2062,15 +2071,7 @@ describe("runCliAgent reliability", () => {
                     subtype: "init",
                     session_id: "stale-live",
                   }),
-                  JSON.stringify({
-                    type: "assistant",
-                    session_id: "stale-live",
-                    message: {
-                      model: "<synthetic>",
-                      role: "assistant",
-                      content: [{ type: "text", text: "No response requested." }],
-                    },
-                  }),
+                  claudeInputStartedJson(dataValue),
                 ].join("\n") + "\n",
               );
               cb?.();
@@ -2103,6 +2104,7 @@ describe("runCliAgent reliability", () => {
             stdoutListener?.(
               [
                 JSON.stringify({ type: "system", subtype: "init", session_id: "forked-live" }),
+                claudeInputStartedJson(dataValue),
                 JSON.stringify({
                   type: "assistant",
                   uuid: "assistant-after-recovery",
@@ -2234,7 +2236,7 @@ describe("runCliAgent reliability", () => {
     expect(fs.existsSync(artifactDir)).toBe(false);
   });
 
-  it("falls back to transcript reseeding when the cache-preserving fork also stalls", async () => {
+  it("falls back to transcript reseeding when the lifecycle-started fork also stalls", async () => {
     vi.useFakeTimers();
     supervisorSpawnMock.mockClear();
     const spawnedArgv: string[][] = [];
@@ -2277,18 +2279,9 @@ describe("runCliAgent reliability", () => {
             input.onStdout?.(
               [
                 JSON.stringify({ type: "system", subtype: "init", session_id: sessionId }),
+                claudeInputStartedJson(dataValue),
                 ...(spawnIndex < 3
-                  ? [
-                      JSON.stringify({
-                        type: "assistant",
-                        session_id: sessionId,
-                        message: {
-                          model: "<synthetic>",
-                          role: "assistant",
-                          content: [{ type: "text", text: "No response requested." }],
-                        },
-                      }),
-                    ]
+                  ? []
                   : [
                       JSON.stringify({
                         type: "result",
@@ -2434,6 +2427,7 @@ describe("runCliAgent reliability", () => {
             input.onStdout?.(
               [
                 JSON.stringify({ type: "system", subtype: "init", session_id: sessionId }),
+                claudeInputStartedJson(dataValue),
                 ...(spawnIndex === 1
                   ? []
                   : [

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -43,6 +43,7 @@ import {
   buildClaudeLiveRunContext,
   buildPreparedCliRunContext,
   captureModelCallDiagnostics,
+  createClaudeInputStartedEvent,
   createCancelableLiveRunLifecycle,
   expectPathMissing,
   expectRejectsWithFields,
@@ -120,11 +121,9 @@ type ProcessSupervisor = ReturnType<typeof getProcessSupervisor>;
 type SupervisorSpawnFn = ProcessSupervisor["spawn"];
 
 function emitClaudeInputStarted(stdout: ((chunk: string) => void) | undefined, data: string): void {
-  const input = JSON.parse(data) as { type?: string; uuid?: string };
-  if (input.type === "user" && typeof input.uuid === "string") {
-    stdout?.(
-      `${JSON.stringify({ type: "command_lifecycle", command_uuid: input.uuid, state: "started" })}\n`,
-    );
+  const event = createClaudeInputStartedEvent(data);
+  if (event) {
+    stdout?.(`${JSON.stringify(event)}\n`);
   }
 }
 

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -118,6 +118,16 @@ const mockCallGatewayTool = vi.mocked(callGatewayTool);
 
 type ProcessSupervisor = ReturnType<typeof getProcessSupervisor>;
 type SupervisorSpawnFn = ProcessSupervisor["spawn"];
+
+function emitClaudeInputStarted(stdout: ((chunk: string) => void) | undefined, data: string): void {
+  const input = JSON.parse(data) as { type?: string; uuid?: string };
+  if (input.type === "user" && typeof input.uuid === "string") {
+    stdout?.(
+      `${JSON.stringify({ type: "command_lifecycle", command_uuid: input.uuid, state: "started" })}\n`,
+    );
+  }
+}
+
 type ClaudeControlPolicyTestCase = {
   name: string;
   requestId: string;
@@ -1981,6 +1991,7 @@ describe("runCliAgent spawn path", () => {
     const stdin = {
       write: vi.fn((data: string, cb?: (err?: Error | null) => void) => {
         writes.push(data);
+        emitClaudeInputStarted(stdoutListener, data);
         stdoutListener?.(interimChunk);
         cb?.();
       }),
@@ -2037,12 +2048,21 @@ describe("runCliAgent spawn path", () => {
       });
       expectModelCallTypes(diagnostics, ["model.call.started", "model.call.completed"]);
       const completed = diagnostics.events[1];
+      const inputUuid = (JSON.parse(writes[0] ?? "{}") as { uuid?: string }).uuid;
+      const lifecycleChunk = `${JSON.stringify({
+        type: "command_lifecycle",
+        command_uuid: inputUuid,
+        state: "started",
+      })}\n`;
       expect(completed?.event).toMatchObject({
         api: "claude-code",
         transport: "stdio-live",
         observationUnit: "turn",
         requestPayloadBytes: Buffer.byteLength(writes[0] ?? ""),
-        responseStreamBytes: Buffer.byteLength(interimChunk) + Buffer.byteLength(finalChunk),
+        responseStreamBytes:
+          Buffer.byteLength(lifecycleChunk) +
+          Buffer.byteLength(interimChunk) +
+          Buffer.byteLength(finalChunk),
         usage: {
           input: 10,
           output: 3,
@@ -2336,7 +2356,8 @@ describe("runCliAgent spawn path", () => {
     let stdoutListener: ((chunk: string) => void) | undefined;
     const cancel = vi.fn();
     const stdin = {
-      write: vi.fn((_data: string, callback?: (error?: Error | null) => void) => {
+      write: vi.fn((data: string, callback?: (error?: Error | null) => void) => {
+        emitClaudeInputStarted(stdoutListener, data);
         stdoutListener?.(
           [
             JSON.stringify({ type: "system", subtype: "init", session_id: "live-quiet-tool" }),
@@ -3144,7 +3165,8 @@ describe("runCliAgent spawn path", () => {
     });
     let turn = 0;
     const stdin = {
-      write: vi.fn((_data: string, cb?: (err?: Error | null) => void) => {
+      write: vi.fn((data: string, cb?: (err?: Error | null) => void) => {
+        emitClaudeInputStarted(stdoutListener, data);
         turn += 1;
         stdoutListener?.(
           [
@@ -3255,6 +3277,7 @@ describe("runCliAgent spawn path", () => {
       await spawnReady;
       const stdin = {
         write: vi.fn((dataValue: string, cb?: (err?: Error | null) => void) => {
+          emitClaudeInputStarted(input.onStdout, dataValue);
           input.onStdout?.(
             [
               JSON.stringify({
@@ -3562,6 +3585,7 @@ describe("runCliAgent spawn path", () => {
     let stdoutListener: ((chunk: string) => void) | undefined;
     const stdin = {
       write: vi.fn((data: string, cb?: (err?: Error | null) => void) => {
+        emitClaudeInputStarted(stdoutListener, data);
         stdoutListener?.(
           [
             JSON.stringify({
@@ -3729,7 +3753,8 @@ describe("runCliAgent spawn path", () => {
     let stdoutListener: ((chunk: string) => void) | undefined;
     let captureKey = "";
     const stdin = {
-      write: vi.fn((_data: string, cb?: (err?: Error | null) => void) => {
+      write: vi.fn((data: string, cb?: (err?: Error | null) => void) => {
+        emitClaudeInputStarted(stdoutListener, data);
         const captureHandle = markMcpLoopbackToolCallStarted({
           captureKey,
           toolName: "message",
@@ -3842,7 +3867,8 @@ describe("runCliAgent spawn path", () => {
     let captureKey = "";
     const toolArgs = { action: "react", emoji: "same" };
     const stdin = {
-      write: vi.fn((_data: string, cb?: (err?: Error | null) => void) => {
+      write: vi.fn((data: string, cb?: (err?: Error | null) => void) => {
+        emitClaudeInputStarted(stdoutListener, data);
         stdoutListener?.(
           [
             JSON.stringify({ type: "system", subtype: "init", session_id: "live-identical" }),
@@ -3995,7 +4021,8 @@ describe("runCliAgent spawn path", () => {
       });
       let stdoutListener: ((chunk: string) => void) | undefined;
       const stdin = {
-        write: vi.fn((_data: string, cb?: (err?: Error | null) => void) => {
+        write: vi.fn((data: string, cb?: (err?: Error | null) => void) => {
+          emitClaudeInputStarted(stdoutListener, data);
           stdoutListener?.(
             [
               JSON.stringify({ type: "system", subtype: "init", session_id: "live-timeout" }),
@@ -4554,6 +4581,7 @@ describe("runCliAgent spawn path", () => {
         startedAtMs: Date.now(),
         stdin: {
           write: vi.fn((dataValue: string, cb?: (err?: Error | null) => void) => {
+            emitClaudeInputStarted(input.onStdout, dataValue);
             const result = turnResults[turnIndex] ?? "ok";
             turnIndex += 1;
             input.onStdout?.(
@@ -4752,6 +4780,7 @@ describe("runCliAgent spawn path", () => {
   ])("$name", async (testCase) => {
     mockClaudeLiveRun(supervisorSpawnMock, {
       events: testCase.events,
+      inputLifecycle: testCase.events.length > 0,
       exitOnWrite: {
         reason: "exit",
         exitCode: testCase.exitCode,
@@ -4803,6 +4832,7 @@ describe("runCliAgent spawn path", () => {
       cancels.push(cancel);
       const stdin = {
         write: vi.fn((dataValue: string, cb?: (err?: Error | null) => void) => {
+          emitClaudeInputStarted(stdoutListener, dataValue);
           if (spawnIndex === 2) {
             stdoutListener?.(
               [
@@ -4956,6 +4986,7 @@ describe("runCliAgent spawn path", () => {
       cancels.push(cancel);
       const stdin = {
         write: vi.fn((dataValue: string, cb?: (err?: Error | null) => void) => {
+          emitClaudeInputStarted(input.onStdout, dataValue);
           const text = spawnIndex === 1 ? "weather-ok" : "git-ok";
           input.onStdout?.(
             [
@@ -5109,6 +5140,7 @@ describe("runCliAgent spawn path", () => {
     let writeCount = 0;
     const stdin = {
       write: vi.fn((dataValue: string, cb?: (err?: Error | null) => void) => {
+        emitClaudeInputStarted(stdoutListener, dataValue);
         writeCount += 1;
         if (writeCount === 1) {
           stderrListener?.("stale stderr from first turn");

--- a/src/agents/cli-runner.test-helpers.ts
+++ b/src/agents/cli-runner.test-helpers.ts
@@ -79,6 +79,13 @@ export function createTestMcpLoopbackServerConfig(port: number) {
   };
 }
 
+export function createClaudeInputStartedEvent(data: string) {
+  const input = JSON.parse(data) as { type?: string; uuid?: string };
+  return input.type === "user" && typeof input.uuid === "string"
+    ? { type: "command_lifecycle" as const, command_uuid: input.uuid, state: "started" as const }
+    : undefined;
+}
+
 export function createTestMcpLoopbackClientGrant(params: {
   context: McpLoopbackRequestContext;
 }): McpLoopbackClientGrant {
@@ -552,13 +559,9 @@ export function mockClaudeLiveRun(
     write: vi.fn((data: string, callback?: (error?: Error | null) => void) => {
       writes.push(data);
       const writeIndex = writes.length - 1;
-      const input = JSON.parse(data) as { type?: string; uuid?: string };
-      if (
-        options.inputLifecycle !== false &&
-        input.type === "user" &&
-        typeof input.uuid === "string"
-      ) {
-        emit([{ type: "command_lifecycle", command_uuid: input.uuid, state: "started" }]);
+      const inputStartedEvent = createClaudeInputStartedEvent(data);
+      if (options.inputLifecycle !== false && inputStartedEvent) {
+        emit([inputStartedEvent]);
       }
       if (options.onWrite) {
         options.onWrite({ data, emit, writeIndex });

--- a/src/agents/cli-runner.test-helpers.ts
+++ b/src/agents/cli-runner.test-helpers.ts
@@ -145,6 +145,7 @@ export type PreparedCliRunContextOverrides = {
   timeoutMs?: number;
   onSuccessfulAuthBinding?: PreparedCliRunContext["params"]["onSuccessfulAuthBinding"];
   runtimeArtifact?: PreparedCliRunContext["backendResolved"]["runtimeArtifact"];
+  liveSessionRequirement?: PreparedCliRunContext["backendResolved"]["liveSessionRequirement"];
 };
 
 export function buildPreparedCliRunContext(
@@ -238,6 +239,7 @@ export function buildPreparedCliRunContext(
         overrides.toolAvailabilityEnforcement ??
         (provider === "google-gemini-cli" ? "prepare-execution" : "execution-args"),
       runtimeArtifact: overrides.runtimeArtifact,
+      liveSessionRequirement: overrides.liveSessionRequirement,
     },
     preparedBackend: {
       backend,

--- a/src/agents/cli-runner.test-helpers.ts
+++ b/src/agents/cli-runner.test-helpers.ts
@@ -520,6 +520,7 @@ export function mockClaudeLiveRun(
     cancelable?: boolean;
     beforeSpawn?: () => Promise<void>;
     events?: Array<Record<string, unknown> | string>;
+    inputLifecycle?: boolean;
     exitImmediately?: RunExit;
     exitOnWrite?: RunExit;
     onWrite?: (params: {
@@ -551,6 +552,14 @@ export function mockClaudeLiveRun(
     write: vi.fn((data: string, callback?: (error?: Error | null) => void) => {
       writes.push(data);
       const writeIndex = writes.length - 1;
+      const input = JSON.parse(data) as { type?: string; uuid?: string };
+      if (
+        options.inputLifecycle !== false &&
+        input.type === "user" &&
+        typeof input.uuid === "string"
+      ) {
+        emit([{ type: "command_lifecycle", command_uuid: input.uuid, state: "started" }]);
+      }
       if (options.onWrite) {
         options.onWrite({ data, emit, writeIndex });
       } else if (writeIndex === 0 && options.events) {

--- a/src/agents/cli-runner/claude-live-session.background-tasks.test.ts
+++ b/src/agents/cli-runner/claude-live-session.background-tasks.test.ts
@@ -123,18 +123,34 @@ function getProcessSupervisorForTest() {
 
 function installLiveStdoutDriver(params?: {
   onWrite?: (stdout: (chunk: string) => void) => void;
+  autoStart?: boolean;
 }): {
   cancel: ReturnType<typeof vi.fn>;
-  stdout: { emit: (chunk: string) => void; waitReady: () => Promise<void> };
+  userInputUuids: string[];
+  stdout: {
+    emit: (chunk: string) => void;
+    startCurrentInput: () => void;
+    waitReady: () => Promise<void>;
+  };
 } {
   let stdoutListener: ((chunk: string) => void) | undefined;
   const cancel = vi.fn();
+  const userInputUuids: string[] = [];
   let markReady: (() => void) | undefined;
   const ready = new Promise<void>((resolve) => {
     markReady = resolve;
   });
   const stdin = {
-    write: vi.fn((_data: string, cb?: (err?: Error | null) => void) => {
+    write: vi.fn((data: string, cb?: (err?: Error | null) => void) => {
+      const parsed = JSON.parse(data) as { type?: string; uuid?: string };
+      if (parsed.type === "user" && typeof parsed.uuid === "string") {
+        userInputUuids.push(parsed.uuid);
+        if (params?.autoStart !== false) {
+          stdoutListener?.(
+            jsonl([{ type: "command_lifecycle", command_uuid: parsed.uuid, state: "started" }]),
+          );
+        }
+      }
       if (stdoutListener && params?.onWrite) {
         params.onWrite(stdoutListener);
       }
@@ -157,9 +173,19 @@ function installLiveStdoutDriver(params?: {
   });
   return {
     cancel,
+    userInputUuids,
     stdout: {
       emit: (chunk: string) => {
         stdoutListener?.(chunk);
+      },
+      startCurrentInput: () => {
+        const inputUuid = userInputUuids.at(-1);
+        if (!inputUuid) {
+          throw new Error("Claude input UUID was not written");
+        }
+        stdoutListener?.(
+          jsonl([{ type: "command_lifecycle", command_uuid: inputUuid, state: "started" }]),
+        );
       },
       waitReady: () => ready,
     },
@@ -230,6 +256,7 @@ describe("claude live session provisional results", () => {
       credentialFingerprint: "credential-b",
     });
     expect(supervisorSpawnMock).toHaveBeenCalledTimes(2);
+    expect(new Set(driver.userInputUuids).size).toBe(3);
     expect(driver.cancel).toHaveBeenCalledOnce();
   });
 
@@ -433,8 +460,8 @@ describe("claude live session provisional results", () => {
     expect(driver.cancel).not.toHaveBeenCalled();
   });
 
-  it("keeps the turn open after a synthetic placeholder until the real result arrives", async () => {
-    const driver = installLiveStdoutDriver();
+  it("ignores exact synthetic replay until the matching input starts", async () => {
+    const driver = installLiveStdoutDriver({ autoStart: false });
     const resultPromise = startLiveTurn({
       runId: "run-synthetic-placeholder",
       useResume: true,
@@ -459,6 +486,11 @@ describe("claude live session provisional results", () => {
           session_id: "live-synthetic",
           result: "",
         },
+        {
+          type: "command_lifecycle",
+          command_uuid: "prior-synthetic-input",
+          state: "completed",
+        },
       ]),
     );
 
@@ -474,11 +506,8 @@ describe("claude live session provisional results", () => {
     await Promise.resolve();
     expect(settled).toBe(false);
     expect(driver.cancel).not.toHaveBeenCalled();
-    await waitForDiagnosticEventsDrained();
-    expect(
-      getDiagnosticSessionActivitySnapshot({ sessionKey: "agent:main:bg" }).lastProgressReason,
-    ).toBe("cli_live:result_deferred_synthetic_placeholder");
 
+    driver.stdout.startCurrentInput();
     driver.stdout.emit(
       jsonl([
         {
@@ -501,6 +530,70 @@ describe("claude live session provisional results", () => {
 
     const result = await resultPromise;
     expect(result.output.text).toBe("The background work is complete.");
+    expect(driver.cancel).not.toHaveBeenCalled();
+  });
+
+  it("ignores markerless prior results until the matching input starts", async () => {
+    const driver = installLiveStdoutDriver({ autoStart: false });
+    const resultPromise = startLiveTurn({ runId: "run-markerless-prior-result", useResume: true });
+    await driver.stdout.waitReady();
+
+    driver.stdout.emit(
+      jsonl([
+        {
+          type: "result",
+          subtype: "success",
+          session_id: "live-markerless",
+          result: "",
+          origin: { kind: "task-notification" },
+        },
+        {
+          type: "result",
+          subtype: "error_during_execution",
+          is_error: true,
+          session_id: "live-markerless",
+          result: "prior task failed",
+        },
+        {
+          type: "command_lifecycle",
+          command_uuid: "prior-markerless-input",
+          state: "completed",
+        },
+      ]),
+    );
+    let settled = false;
+    void resultPromise.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    driver.stdout.startCurrentInput();
+    driver.stdout.emit(
+      jsonl([
+        {
+          type: "assistant",
+          session_id: "live-markerless",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "current answer" }],
+          },
+        },
+        {
+          type: "result",
+          subtype: "success",
+          session_id: "live-markerless",
+          result: "current answer",
+        },
+      ]),
+    );
+
+    await expect(resultPromise).resolves.toMatchObject({ output: { text: "current answer" } });
     expect(driver.cancel).not.toHaveBeenCalled();
   });
 
@@ -597,57 +690,11 @@ describe("claude live session provisional results", () => {
     expect(driver.cancel).not.toHaveBeenCalled();
   });
 
-  it("expires a terminal resumed placeholder through the existing empty-result path", async () => {
+  it("times out and cleans up when lifecycle records never start the current input", async () => {
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
-    const driver = installLiveStdoutDriver();
+    const driver = installLiveStdoutDriver({ autoStart: false });
     const resultPromise = startLiveTurn({
-      runId: "run-synthetic-grace-expiry",
-      timeoutMs: 60_000,
-      noOutputTimeoutMs: 60_000,
-      useResume: true,
-    });
-    await vi.advanceTimersByTimeAsync(0);
-    await driver.stdout.waitReady();
-
-    driver.stdout.emit(
-      jsonl([
-        { type: "system", subtype: "init", session_id: "live-synthetic-expiry" },
-        {
-          type: "assistant",
-          session_id: "live-synthetic-expiry",
-          message: {
-            model: "<synthetic>",
-            role: "assistant",
-            content: [{ type: "text", text: "No response requested." }],
-          },
-        },
-        {
-          type: "result",
-          subtype: "success",
-          session_id: "live-synthetic-expiry",
-          result: "",
-        },
-      ]),
-    );
-
-    let settled = false;
-    void resultPromise.then(() => {
-      settled = true;
-    });
-    await vi.advanceTimersByTimeAsync(29_999);
-    expect(settled).toBe(false);
-
-    await vi.advanceTimersByTimeAsync(1);
-    const result = await resultPromise;
-    expect(result.output.text).toBe("");
-    expect(driver.cancel).not.toHaveBeenCalled();
-  });
-
-  it("expires the synthetic grace before a matching short no-output watchdog", async () => {
-    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
-    const driver = installLiveStdoutDriver();
-    const resultPromise = startLiveTurn({
-      runId: "run-synthetic-short-watchdog",
+      runId: "run-missing-input-lifecycle",
       timeoutMs: 60_000,
       noOutputTimeoutMs: 1_000,
       useResume: true,
@@ -657,44 +704,42 @@ describe("claude live session provisional results", () => {
 
     driver.stdout.emit(
       jsonl([
-        { type: "system", subtype: "init", session_id: "live-synthetic-short-watchdog" },
         {
-          type: "assistant",
-          session_id: "live-synthetic-short-watchdog",
-          message: {
-            model: "<synthetic>",
-            role: "assistant",
-            content: [{ type: "text", text: "No response requested." }],
-          },
+          type: "command_lifecycle",
+          command_uuid: "unrelated-input",
+          state: "started",
         },
         {
           type: "result",
-          subtype: "success",
-          session_id: "live-synthetic-short-watchdog",
-          result: "",
+          subtype: "error_during_execution",
+          is_error: true,
+          session_id: "live-missing-lifecycle",
+          result: "unrelated failure",
         },
       ]),
     );
 
-    await vi.advanceTimersByTimeAsync(999);
-    let settled = false;
-    void resultPromise.then(() => {
-      settled = true;
+    const rejection = expect(resultPromise).rejects.toMatchObject({
+      name: "FailoverError",
+      code: undefined,
+      cliTimeout: {
+        mode: "no-output",
+        timeoutSeconds: 1,
+        observedActivity: true,
+        activeToolCount: 0,
+        backgroundTaskCount: 0,
+      },
     });
-    await Promise.resolve();
-    expect(settled).toBe(false);
-
-    await vi.advanceTimersByTimeAsync(1);
-    const result = await resultPromise;
-    expect(result.output.text).toBe("");
-    expect(driver.cancel).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1_000);
+    await rejection;
+    expect(driver.cancel).toHaveBeenCalledWith("manual-cancel");
   });
 
   it.each([
     {
-      label: "marks a resumed synthetic-only stall as safe for cache-preserving recovery",
+      label: "does not replay after current-turn synthetic output",
       useResume: true,
-      expectedCode: "cli_no_output_timeout",
+      expectedCode: undefined,
       chunk: jsonl([
         { type: "system", subtype: "init", session_id: "live-synthetic-no-result" },
         {
@@ -782,7 +827,7 @@ describe("claude live session provisional results", () => {
     expect(driver.cancel).toHaveBeenCalledWith("manual-cancel");
   });
 
-  it("still aborts on the turn timeout while waiting after a synthetic placeholder", async () => {
+  it("still aborts on the turn timeout after input starts but never returns a result", async () => {
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
     const driver = installLiveStdoutDriver();
     const resultPromise = startLiveTurn({
@@ -805,12 +850,6 @@ describe("claude live session provisional results", () => {
             role: "assistant",
             content: [{ type: "text", text: "Continue from where you left off." }],
           },
-        },
-        {
-          type: "result",
-          subtype: "success",
-          session_id: "live-synthetic-timeout",
-          result: "",
         },
       ]),
     );

--- a/src/agents/cli-runner/claude-live-session.capability.test.ts
+++ b/src/agents/cli-runner/claude-live-session.capability.test.ts
@@ -1,0 +1,121 @@
+/** Claude live-session capability negotiation and input ownership tests. */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { getProcessSupervisor } from "../../process/supervisor/index.js";
+import { buildClaudeLiveRunContext, mockClaudeLiveRun } from "../cli-runner.test-helpers.js";
+import { supervisorSpawnMock } from "../cli-runner.test-support.js";
+import { runClaudeLiveSessionTurn } from "./claude-live-session.js";
+import { resetClaudeLiveSessionsForTest } from "./claude-live-session.test-support.js";
+
+type ProcessSupervisor = ReturnType<typeof getProcessSupervisor>;
+type SupervisorSpawnFn = ProcessSupervisor["spawn"];
+
+const liveSessionRequirement = {
+  capability: "msg_lifecycle_v1",
+  minimumVersion: "2.1.206",
+  versionArgs: ["--version"],
+  updateCommand: "claude update",
+} as const;
+
+beforeEach(() => {
+  resetClaudeLiveSessionsForTest();
+  supervisorSpawnMock.mockClear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  resetClaudeLiveSessionsForTest();
+});
+
+function getProcessSupervisorForTest() {
+  return {
+    spawn: (params: Parameters<SupervisorSpawnFn>[0]) =>
+      supervisorSpawnMock(params) as ReturnType<SupervisorSpawnFn>,
+    cancel: vi.fn(),
+    cancelScope: vi.fn(),
+    getRecord: vi.fn(),
+  };
+}
+
+function startLiveTurn(runId: string, useResume: boolean) {
+  const context = buildClaudeLiveRunContext({
+    runId,
+    timeoutMs: 60_000,
+    liveSessionRequirement,
+    backend: { resumeArgs: ["-p", "--resume", "{sessionId}"] },
+  });
+  return runClaudeLiveSessionTurn({
+    context,
+    args: context.preparedBackend.backend.args ?? [],
+    env: {},
+    prompt: "hi",
+    useResume,
+    noOutputTimeoutMs: 5_000,
+    getProcessSupervisor: getProcessSupervisorForTest,
+    onAssistantDelta: () => {},
+    cleanup: async () => {},
+  });
+}
+
+describe("Claude live-session capability negotiation", () => {
+  it.each([
+    { label: "fresh", useResume: false },
+    { label: "resumed", useResume: true },
+  ])(
+    "retains a matching start before $label init and trusts capability over version",
+    async (testCase) => {
+      mockClaudeLiveRun(supervisorSpawnMock, {
+        events: [
+          {
+            type: "system",
+            subtype: "init",
+            session_id: "live-capable",
+            claude_code_version: "2.1.100-custom",
+            capabilities: ["interrupt_receipt_v1", "msg_lifecycle_v1", "future_v2"],
+          },
+          {
+            type: "result",
+            subtype: "success",
+            session_id: "live-capable",
+            result: "done",
+          },
+        ],
+      });
+
+      await expect(
+        startLiveTurn(`run-capable-${testCase.label}`, testCase.useResume),
+      ).resolves.toMatchObject({
+        output: { text: "done" },
+      });
+    },
+  );
+
+  it.each([
+    { label: "fresh", useResume: false },
+    { label: "resumed", useResume: true },
+  ])(
+    "fails immediately when $label init omits the required lifecycle capability",
+    async (testCase) => {
+      const fixture = mockClaudeLiveRun(supervisorSpawnMock, {
+        events: [
+          {
+            type: "system",
+            subtype: "init",
+            session_id: "live-legacy",
+            claude_code_version: "2.1.205",
+            capabilities: ["interrupt_receipt_v1"],
+          },
+        ],
+      });
+
+      await expect(
+        startLiveTurn(`run-legacy-${testCase.label}`, testCase.useResume),
+      ).rejects.toMatchObject({
+        code: "cli_live_session_unsupported",
+        message: expect.stringContaining(
+          "Claude Code build (version 2.1.205) did not advertise the required msg_lifecycle_v1 capability",
+        ),
+      });
+      expect(fixture.lifecycle.cancel).toHaveBeenCalledOnce();
+    },
+  );
+});

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -88,19 +88,13 @@ type ClaudeLiveTurn = {
   timeoutTimer: NodeJS.Timeout | null;
   activeTools: Map<string, ClaudeLiveActiveTool>;
   observedStdout: boolean;
+  /** UUID sent with this input; terminal records belong to the turn only after its started event. */
+  inputUuid: string;
+  inputStarted: boolean;
   /** Only resumed turns may replay a lifecycle-only stall through a fork. */
   useResume: boolean;
-  /** True after any output other than init or the exact synthetic queue placeholder. */
+  /** True after output that makes replaying the submitted input unsafe. */
   hasReplayUnsafeActivity: boolean;
-  /**
-   * Claude consumed queued session notifications before processing this turn.
-   * The following empty result is provisional; the same process can emit the
-   * real answer later, so a bounded grace observes whether output continues.
-   */
-  pendingSyntheticPlaceholder: boolean;
-  allowSyntheticContinuationGrace: boolean;
-  deferredSyntheticOutput: CliOutput | null;
-  syntheticContinuationTimer: NodeJS.Timeout | null;
   completedToolCallIds: Set<string>;
   toolEventCount: number;
   streamingParser: ReturnType<typeof createCliJsonlStreamingParser>;
@@ -184,17 +178,6 @@ const CLAUDE_LIVE_CONTROL_TIMEOUT_MS = 3_000;
 const CLAUDE_LIVE_SYSTEM_PROMPT_PROBE_ERROR =
   "set_model: system_prompt must be a non-empty string when present";
 const CLAUDE_LIVE_CLOSE_WAIT_TIMEOUT_MS = 5_000;
-// The observed queued-notification resume emits new process activity within
-// seconds. Cap this below the normal resumed no-output watchdog so terminal
-// placeholders still reach existing empty-response handling promptly.
-const CLAUDE_LIVE_SYNTHETIC_CONTINUATION_GRACE_MS = 30_000;
-// Claude Code uses these exact <synthetic> messages while draining internal
-// session work. Matching both the model sentinel and full text avoids treating
-// user-authored lookalikes as lifecycle signals.
-const CLAUDE_LIVE_PROVISIONAL_SYNTHETIC_PLACEHOLDERS = new Set([
-  "No response requested.",
-  "Continue from where you left off.",
-]);
 const liveSessions = new Map<string, ClaudeLiveSession>();
 const liveSessionCreates = new Map<string, ClaudeLiveSessionCreate>();
 const liveSessionTurns = new KeyedAsyncQueue();
@@ -508,11 +491,6 @@ function clearTurnTimers(turn: ClaudeLiveTurn): void {
     clearTimeout(turn.timeoutTimer);
     turn.timeoutTimer = null;
   }
-  if (turn.syntheticContinuationTimer) {
-    clearTimeout(turn.syntheticContinuationTimer);
-    turn.syntheticContinuationTimer = null;
-  }
-  turn.deferredSyntheticOutput = null;
 }
 
 function clearOutstandingBackgroundTasks(session: ClaudeLiveSession): void {
@@ -876,9 +854,9 @@ function armNoOutputTimer(session: ClaudeLiveSession, turn: ClaudeLiveTurn, dela
       createTimeoutError(
         session,
         `CLI produced no output for ${Math.round((Date.now() - quietSinceMs) / 1000)}s and was terminated.`,
-        // Claude can emit only init or a synthetic queue placeholder before a
-        // resumed stream wedges. No assistant/tool work has happened, so
-        // recovery can fork the cached session before transcript reseed.
+        // A resumed stream can emit only lifecycle/init records before it
+        // wedges. No assistant/tool work has happened, so recovery can fork
+        // the cached session before transcript reseed.
         turn.lastOutputAtMs === null || retryableResumeStall ? "cli_no_output_timeout" : undefined,
         {
           mode: "no-output",
@@ -926,85 +904,21 @@ function applyBackgroundTasksChanged(
   }
 }
 
-function isClaudeLiveProvisionalSyntheticPlaceholder(parsed: Record<string, unknown>): boolean {
-  if (parsed.type !== "assistant" || !isRecord(parsed.message)) {
-    return false;
-  }
-  const message = parsed.message;
-  if (message.model !== "<synthetic>") {
-    return false;
-  }
-  const content = Array.isArray(message.content) ? message.content : [];
-  const text = content
-    .flatMap((block) =>
-      isRecord(block) && block.type === "text" && typeof block.text === "string"
-        ? [block.text]
-        : [],
-    )
-    .join("")
-    .trim();
-  return CLAUDE_LIVE_PROVISIONAL_SYNTHETIC_PLACEHOLDERS.has(text);
-}
-
-function isClaudeLiveSubstantiveAssistantProgress(parsed: Record<string, unknown>): boolean {
-  if (parsed.type === "assistant" && isRecord(parsed.message)) {
-    return parsed.message.model !== "<synthetic>";
-  }
-  if (parsed.type !== "stream_event" || !isRecord(parsed.event)) {
-    return false;
-  }
-  const event = parsed.event;
-  return (
-    event.type === "content_block_delta" &&
-    isRecord(event.delta) &&
-    event.delta.type === "text_delta" &&
-    typeof event.delta.text === "string" &&
-    event.delta.text.length > 0
-  );
-}
-
-function deferClaudeLiveSyntheticResult(
-  session: ClaudeLiveSession,
+function applyClaudeLiveInputLifecycle(
   turn: ClaudeLiveTurn,
-  output: CliOutput,
+  parsed: Record<string, unknown>,
 ): void {
-  turn.pendingSyntheticPlaceholder = false;
-  turn.deferredSyntheticOutput = output;
-  if (turn.noOutputTimer) {
-    clearTimeout(turn.noOutputTimer);
-    turn.noOutputTimer = null;
+  if (
+    parsed.type === "command_lifecycle" &&
+    parsed.command_uuid === turn.inputUuid &&
+    parsed.state === "started" &&
+    !turn.inputStarted
+  ) {
+    // A reused process may finish queued work before reading this input. Only
+    // Claude's matching started event makes later terminal records ours.
+    turn.inputStarted = true;
+    emitClaudeLiveProgress(turn, "cli_live:input_started");
   }
-  if (turn.syntheticContinuationTimer) {
-    clearTimeout(turn.syntheticContinuationTimer);
-  }
-  const graceMs = Math.min(CLAUDE_LIVE_SYNTHETIC_CONTINUATION_GRACE_MS, session.noOutputTimeoutMs);
-  turn.syntheticContinuationTimer = setTimeout(() => {
-    if (session.currentTurn !== turn || !turn.deferredSyntheticOutput) {
-      return;
-    }
-    const terminalOutput = turn.deferredSyntheticOutput;
-    turn.syntheticContinuationTimer = null;
-    turn.deferredSyntheticOutput = null;
-    emitClaudeLiveProgress(turn, "cli_live:synthetic_placeholder_grace_expired");
-    finishTurn(session, terminalOutput);
-  }, graceMs);
-  emitClaudeLiveProgress(turn, "cli_live:result_deferred_synthetic_placeholder");
-}
-
-function noteClaudeLiveContinuationAfterSyntheticPlaceholder(
-  session: ClaudeLiveSession,
-  turn: ClaudeLiveTurn,
-): void {
-  if (!turn.deferredSyntheticOutput) {
-    return;
-  }
-  if (turn.syntheticContinuationTimer) {
-    clearTimeout(turn.syntheticContinuationTimer);
-    turn.syntheticContinuationTimer = null;
-  }
-  turn.deferredSyntheticOutput = null;
-  armNoOutputTimer(session, turn, session.noOutputTimeoutMs);
-  emitClaudeLiveProgress(turn, "cli_live:synthetic_placeholder_continuation");
 }
 
 function resetNoOutputTimer(session: ClaudeLiveSession): void {
@@ -1398,15 +1312,19 @@ function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
   if (!turn) {
     return;
   }
+  applyClaudeLiveInputLifecycle(turn, parsed);
+  if (!turn.inputStarted) {
+    if (!(parsed.type === "system" && parsed.subtype === "init")) {
+      turn.hasReplayUnsafeActivity = true;
+    }
+    return;
+  }
   if (
-    !(
-      (parsed.type === "system" && parsed.subtype === "init") ||
-      isClaudeLiveProvisionalSyntheticPlaceholder(parsed)
-    )
+    !(parsed.type === "system" && parsed.subtype === "init") &&
+    parsed.type !== "command_lifecycle"
   ) {
     turn.hasReplayUnsafeActivity = true;
   }
-  noteClaudeLiveContinuationAfterSyntheticPlaceholder(session, turn);
   turn.rawChars += trimmed.length + 1;
   if (
     turn.rawChars > turn.outputLimits.maxTurnRawChars ||
@@ -1421,11 +1339,6 @@ function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
   }
   turn.rawLines.push(trimmed);
   applyBackgroundTasksChanged(session, parsed);
-  if (turn.allowSyntheticContinuationGrace && isClaudeLiveProvisionalSyntheticPlaceholder(parsed)) {
-    turn.pendingSyntheticPlaceholder = true;
-  } else if (turn.pendingSyntheticPlaceholder && isClaudeLiveSubstantiveAssistantProgress(parsed)) {
-    turn.pendingSyntheticPlaceholder = false;
-  }
   const toolEventCountBefore = turn.toolEventCount;
   turn.streamingParser.push(`${trimmed}\n`);
   turn.sessionId = parsedSessionId ?? turn.sessionId;
@@ -1468,13 +1381,6 @@ function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
     // An interim result is not terminal; background work returns the run to send.
     turn.onPhase?.("send");
     emitClaudeLiveProgress(turn, "cli_live:result_deferred_background_tasks");
-    return;
-  }
-  // A resumed Claude session can first consume queued task notifications and
-  // emit an empty synthetic result, then continue the same user turn. Keep the
-  // live process and watchdogs authoritative instead of racing it with fallback.
-  if (turn.pendingSyntheticPlaceholder && !output.text.trim()) {
-    deferClaudeLiveSyntheticResult(session, turn, output);
     return;
   }
   finishTurn(session, output);
@@ -1569,9 +1475,10 @@ function handleClaudeExit(session: ClaudeLiveSession, exitCode: number | null): 
   );
 }
 
-function createClaudeUserInputMessage(content: string): string {
+function createClaudeUserInputMessage(content: string, uuid: string): string {
   return `${JSON.stringify({
     type: "user",
+    uuid,
     session_id: "",
     parent_tool_use_id: null,
     message: {
@@ -1702,7 +1609,7 @@ async function createClaudeLiveSession(params: {
 function createTurn(params: {
   context: PreparedCliRunContext;
   noOutputTimeoutMs: number;
-  allowSyntheticContinuationGrace: boolean;
+  inputUuid: string;
   useResume: boolean;
   onAssistantDelta: (delta: CliStreamingDelta) => void;
   onThinkingDelta?: (delta: CliThinkingDelta) => void;
@@ -1741,12 +1648,10 @@ function createTurn(params: {
     timeoutTimer: null,
     activeTools: new Map(),
     observedStdout: false,
+    inputUuid: params.inputUuid,
+    inputStarted: false,
     useResume: params.useResume,
     hasReplayUnsafeActivity: false,
-    pendingSyntheticPlaceholder: false,
-    allowSyntheticContinuationGrace: params.allowSyntheticContinuationGrace,
-    deferredSyntheticOutput: null,
-    syntheticContinuationTimer: null,
     completedToolCallIds: new Set(),
     toolEventCount: 0,
     streamingParser: createCliJsonlStreamingParser({
@@ -1973,7 +1878,6 @@ async function runSerializedClaudeLiveSessionTurn(
     env: params.env,
   });
   const systemPromptHash = sha256(stripSystemPromptCacheBoundary(params.context.systemPrompt));
-  let createdSessionForTurn = false;
   let session = liveSessions.get(key) ?? null;
   if (
     session &&
@@ -2151,7 +2055,6 @@ async function runSerializedClaudeLiveSessionTurn(
       liveSessionCreates.set(key, { generation, promise: createSession });
       try {
         session = await createSession;
-        createdSessionForTurn = true;
       } catch (error) {
         await cleanup();
         throw error;
@@ -2189,11 +2092,12 @@ async function runSerializedClaudeLiveSessionTurn(
   liveSession.noOutputTimeoutMs = params.noOutputTimeoutMs;
   liveSession.stderr = "";
 
+  const inputUuid = crypto.randomUUID();
   const outputPromise = new Promise<CliOutput>((resolve, reject) => {
     liveSession.currentTurn = createTurn({
       context: params.context,
       noOutputTimeoutMs: params.noOutputTimeoutMs,
-      allowSyntheticContinuationGrace: params.useResume && createdSessionForTurn,
+      inputUuid,
       useResume: params.useResume,
       onAssistantDelta: params.onAssistantDelta,
       onThinkingDelta: params.onThinkingDelta,
@@ -2235,7 +2139,7 @@ async function runSerializedClaudeLiveSessionTurn(
       abort();
     } else {
       try {
-        const requestPayload = createClaudeUserInputMessage(params.prompt);
+        const requestPayload = createClaudeUserInputMessage(params.prompt, inputUuid);
         params.onRequestPayload?.(requestPayload);
         await Promise.race([writeTurnInput(liveSession, requestPayload), outputPromise]);
       } catch (error) {

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -28,7 +28,10 @@ import {
 } from "../../infra/exec-approvals.js";
 import { BLOCKED_TOOL_CALL_ABORT_FLOOR_MS } from "../../logging/diagnostic-run-activity.js";
 import { KeyedAsyncQueue } from "../../plugin-sdk/keyed-async-queue.js";
-import type { CliBackendConfig } from "../../plugins/cli-backend.types.js";
+import type {
+  CliBackendConfig,
+  CliBackendLiveSessionRequirement,
+} from "../../plugins/cli-backend.types.js";
 import {
   LEGACY_IMPLICIT_AGENT_ID,
   resolveAgentIdFromSessionKey,
@@ -112,6 +115,8 @@ type ClaudeLiveSession = {
   fingerprint: string;
   systemPromptHash: string;
   systemPromptSwitchCapability: "unknown" | "supported" | "unsupported";
+  liveSessionRequirement?: CliBackendLiveSessionRequirement;
+  liveSessionCapabilityReady: boolean;
   managedRun: ManagedRun;
   providerId: string;
   modelId: string;
@@ -923,6 +928,43 @@ function applyClaudeLiveInputLifecycle(
   }
 }
 
+function applyClaudeLiveSessionRequirement(
+  session: ClaudeLiveSession,
+  parsed: Record<string, unknown>,
+): boolean {
+  const requirement = session.liveSessionRequirement;
+  if (!requirement || parsed.type !== "system" || parsed.subtype !== "init") {
+    return true;
+  }
+  const capabilities = Array.isArray(parsed.capabilities)
+    ? parsed.capabilities.filter((value): value is string => typeof value === "string")
+    : [];
+  if (capabilities.includes(requirement.capability)) {
+    session.liveSessionCapabilityReady = true;
+    return true;
+  }
+  const version =
+    typeof parsed.claude_code_version === "string"
+      ? parsed.claude_code_version.trim() || undefined
+      : undefined;
+  const versionDetail = version ? ` (version ${version})` : "";
+  closeLiveSession(
+    session,
+    "abort",
+    new FailoverError(
+      `The running Claude Code build${versionDetail} did not advertise the required ${requirement.capability} capability. Claude Code ${requirement.minimumVersion} is the first known compatible release. Run \`${requirement.updateCommand}\`, restart OpenClaw, and retry.`,
+      {
+        reason: "format",
+        provider: session.providerId,
+        model: session.modelId,
+        status: resolveFailoverStatus("format"),
+        code: "cli_live_session_unsupported",
+      },
+    ),
+  );
+  return false;
+}
+
 function resetNoOutputTimer(session: ClaudeLiveSession): void {
   const turn = session.currentTurn;
   if (!turn) {
@@ -1318,6 +1360,14 @@ function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
     return;
   }
   applyClaudeLiveInputLifecycle(turn, parsed);
+  if (!applyClaudeLiveSessionRequirement(session, parsed)) {
+    return;
+  }
+  // command_lifecycle can precede system/init. Retain the matching start, but
+  // never trust assistant/tool/result records until capability negotiation succeeds.
+  if (!session.liveSessionCapabilityReady) {
+    return;
+  }
   if (!turn.inputStarted) {
     if (!(parsed.type === "system" && parsed.subtype === "init")) {
       turn.hasReplayUnsafeActivity = true;
@@ -1411,6 +1461,9 @@ function handleClaudeStdout(session: ClaudeLiveSession, chunk: string) {
   try {
     for (const line of lines) {
       handleClaudeLiveLine(session, line);
+      if (session.closing) {
+        break;
+      }
     }
   } catch (error) {
     closeLiveSession(session, "abort", error);
@@ -1577,6 +1630,8 @@ async function createClaudeLiveSession(params: {
     fingerprint: params.fingerprint,
     systemPromptHash: params.systemPromptHash,
     systemPromptSwitchCapability: "unknown",
+    liveSessionRequirement: params.context.backendResolved.liveSessionRequirement,
+    liveSessionCapabilityReady: !params.context.backendResolved.liveSessionRequirement,
     managedRun,
     providerId: params.context.params.provider,
     modelId: params.context.modelId,

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -91,6 +91,8 @@ type ClaudeLiveTurn = {
   /** UUID sent with this input; terminal records belong to the turn only after its started event. */
   inputUuid: string;
   inputStarted: boolean;
+  /** Reports process identity from init even when the current input has not started yet. */
+  onSessionId?: (sessionId: string) => void;
   /** Only resumed turns may replay a lifecycle-only stall through a fork. */
   useResume: boolean;
   /** True after output that makes replaying the submitted input unsafe. */
@@ -1305,6 +1307,9 @@ function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
   const parsedSessionId = parseSessionId(parsed);
   if (parsedSessionId) {
     session.sessionId = parsedSessionId;
+    if (parsed.type === "system" && parsed.subtype === "init") {
+      turn?.onSessionId?.(parsedSessionId);
+    }
   }
   if (handleClaudeLiveControlResponse(session, parsed)) {
     return;
@@ -1650,6 +1655,7 @@ function createTurn(params: {
     observedStdout: false,
     inputUuid: params.inputUuid,
     inputStarted: false,
+    onSessionId: params.onSessionId,
     useResume: params.useResume,
     hasReplayUnsafeActivity: false,
     completedToolCallIds: new Set(),

--- a/src/commands/doctor-claude-cli.test.ts
+++ b/src/commands/doctor-claude-cli.test.ts
@@ -162,7 +162,7 @@ describe("noteClaudeCliHealth", () => {
     });
   });
 
-  it("reports an installed Claude Code below the streamed-session floor", async () => {
+  it("advises on a version below the first-known floor without declaring it unsupported", async () => {
     await withTempHome(({ homeDir, workspaceDir }) => {
       cliBackendsTesting.setDepsForTest({
         resolvePluginSetupCliBackend: () => undefined,
@@ -201,7 +201,7 @@ describe("noteClaudeCliHealth", () => {
       );
 
       expect(noteBody(noteFn)).toContain(
-        "Claude Code 2.1.206 or newer is required; found 2.1.205. Run `claude update`, restart OpenClaw, and retry.",
+        "Binary version advisory: Claude Code 2.1.206 is the first published build known to advertise msg_lifecycle_v1; found 2.1.205. OpenClaw verifies this capability at runtime. If this build is rejected, run `claude update`, restart OpenClaw, and retry.",
       );
     });
   });

--- a/src/commands/doctor-claude-cli.test.ts
+++ b/src/commands/doctor-claude-cli.test.ts
@@ -162,6 +162,50 @@ describe("noteClaudeCliHealth", () => {
     });
   });
 
+  it("reports an installed Claude Code below the streamed-session floor", async () => {
+    await withTempHome(({ homeDir, workspaceDir }) => {
+      cliBackendsTesting.setDepsForTest({
+        resolvePluginSetupCliBackend: () => undefined,
+        resolveRuntimeCliBackends: () => [
+          {
+            id: "claude-cli",
+            pluginId: "anthropic",
+            config: { command: "claude" },
+            liveSessionRequirement: {
+              capability: "msg_lifecycle_v1",
+              minimumVersion: "2.1.206",
+              versionArgs: ["--version"],
+              updateCommand: "claude update",
+            },
+          },
+        ],
+      });
+      const noteFn = vi.fn();
+
+      noteClaudeCliHealth(
+        {
+          agents: {
+            defaults: { model: "claude-cli/claude-sonnet-4-6" },
+            entries: { main: { default: true } },
+          },
+        },
+        {
+          homeDir,
+          workspaceDir,
+          noteFn,
+          store: createStore(),
+          readClaudeCliCredentials: () => ({ type: "api_key_helper" }),
+          resolveCommandPath: () => "/opt/homebrew/bin/claude",
+          resolveCommandVersion: () => "2.1.205 (Claude Code)",
+        },
+      );
+
+      expect(noteBody(noteFn)).toContain(
+        "Claude Code 2.1.206 or newer is required; found 2.1.205. Run `claude update`, restart OpenClaw, and retry.",
+      );
+    });
+  });
+
   it("stays quiet for a healthy non-default Claude CLI runtime agent", async () => {
     await withTempHome(({ homeDir, workspaceDir }) => {
       const root = path.dirname(workspaceDir);

--- a/src/commands/doctor-claude-cli.ts
+++ b/src/commands/doctor-claude-cli.ts
@@ -21,8 +21,8 @@ import type {
   TokenCredential,
 } from "../agents/auth-profiles/types.js";
 import {
-  formatCliBackendUpdateGuidance,
-  resolveCliBackendVersionSupport,
+  formatCliBackendVersionAdvisory,
+  resolveCliBackendVersionGuidance,
 } from "../agents/cli-backend-version-support.js";
 import { resolveCliBackendConfig } from "../agents/cli-backends.js";
 import { readClaudeCliCredentialsCached } from "../agents/cli-credentials.js";
@@ -258,13 +258,13 @@ export function noteClaudeCliHealth(
       liveSessionRequirement.versionArgs,
       env,
     );
-    const support = resolveCliBackendVersionSupport(versionOutput, liveSessionRequirement);
-    if (support.status === "unsupported") {
+    const guidance = resolveCliBackendVersionGuidance(versionOutput, liveSessionRequirement);
+    if (guidance.status === "below-known-floor") {
       lines.push(
-        `- Binary version: ${formatCliBackendUpdateGuidance({
+        `- Binary version advisory: ${formatCliBackendVersionAdvisory({
           label: "Claude Code",
           requirement: liveSessionRequirement,
-          version: support.version,
+          version: guidance.version,
         })}`,
       );
     }

--- a/src/commands/doctor-claude-cli.ts
+++ b/src/commands/doctor-claude-cli.ts
@@ -1,4 +1,5 @@
 /** Doctor health note for Claude CLI binary, auth, and workspace/project directories. */
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import {
   normalizeOptionalLowercaseString,
@@ -19,6 +20,10 @@ import type {
   OAuthCredential,
   TokenCredential,
 } from "../agents/auth-profiles/types.js";
+import {
+  formatCliBackendUpdateGuidance,
+  resolveCliBackendVersionSupport,
+} from "../agents/cli-backend-version-support.js";
 import { resolveCliBackendConfig } from "../agents/cli-backends.js";
 import { readClaudeCliCredentialsCached } from "../agents/cli-credentials.js";
 import { resolveClaudeCliProjectDirForWorkspace } from "../agents/command/claude-cli-project-dir.js";
@@ -48,8 +53,20 @@ function usesClaudeCliModelSelection(cfg: OpenClawConfig): boolean {
   );
 }
 
-function resolveClaudeCliCommand(cfg: OpenClawConfig): string {
-  return resolveCliBackendConfig(CLAUDE_CLI_PROVIDER, cfg)?.config.command ?? "claude";
+function resolveCommandVersion(
+  commandPath: string,
+  args: readonly string[],
+  env: NodeJS.ProcessEnv,
+): string | undefined {
+  const result = spawnSync(commandPath, [...args], {
+    encoding: "utf8",
+    env,
+    maxBuffer: 16 * 1024,
+    timeout: 1_500,
+    windowsHide: true,
+  });
+  const output = `${result.stdout ?? ""}\n${result.stderr ?? ""}`.trim();
+  return output.split(/\r?\n/u)[0]?.trim() || undefined;
 }
 
 function probeDirectoryHealth(dirPath: string): ClaudeCliDirHealth {
@@ -186,6 +203,11 @@ export function noteClaudeCliHealth(
     store?: AuthProfileStore;
     readClaudeCliCredentials?: () => ClaudeCliReadableCredential | null;
     resolveCommandPath?: (command: string, env?: NodeJS.ProcessEnv) => string | undefined;
+    resolveCommandVersion?: (
+      commandPath: string,
+      args: readonly string[],
+      env: NodeJS.ProcessEnv,
+    ) => string | undefined;
     workspaceDir?: string;
   },
 ) {
@@ -205,7 +227,8 @@ export function noteClaudeCliHealth(
     deps?.readClaudeCliCredentials ??
     (() => readClaudeCliCredentialsCached({ allowKeychainPrompt: false }));
   const credential = readClaudeCliCredentials();
-  const command = resolveClaudeCliCommand(cfg);
+  const backend = resolveCliBackendConfig(CLAUDE_CLI_PROVIDER, cfg);
+  const command = backend?.config.command ?? "claude";
   const resolveCommandPath =
     deps?.resolveCommandPath ??
     ((rawCommand: string, nextEnv?: NodeJS.ProcessEnv) =>
@@ -226,6 +249,25 @@ export function noteClaudeCliHealth(
     fixHints.push(
       "- Fix: install Claude CLI on PATH for the gateway user; custom executable paths belong in a CLI backend plugin registration.",
     );
+  }
+
+  const liveSessionRequirement = backend?.liveSessionRequirement;
+  if (commandPath && liveSessionRequirement) {
+    const versionOutput = (deps?.resolveCommandVersion ?? resolveCommandVersion)(
+      commandPath,
+      liveSessionRequirement.versionArgs,
+      env,
+    );
+    const support = resolveCliBackendVersionSupport(versionOutput, liveSessionRequirement);
+    if (support.status === "unsupported") {
+      lines.push(
+        `- Binary version: ${formatCliBackendUpdateGuidance({
+          label: "Claude Code",
+          requirement: liveSessionRequirement,
+          version: support.version,
+        })}`,
+      );
+    }
   }
 
   if (!credential) {

--- a/src/commands/onboard-inference-ambient.ts
+++ b/src/commands/onboard-inference-ambient.ts
@@ -24,6 +24,8 @@ export type InferenceBackendCandidate = {
    * unknown (e.g. macOS keychain-backed logins we must not prompt for here).
    */
   credentials?: boolean;
+  /** Installed route that setup must explain but never activate automatically. */
+  unavailableReason?: string;
 };
 
 export function detectAmbientInferenceBackends(

--- a/src/commands/onboard-inference-ambient.ts
+++ b/src/commands/onboard-inference-ambient.ts
@@ -24,8 +24,6 @@ export type InferenceBackendCandidate = {
    * unknown (e.g. macOS keychain-backed logins we must not prompt for here).
    */
   credentials?: boolean;
-  /** Installed route that setup must explain but never activate automatically. */
-  unavailableReason?: string;
 };
 
 export function detectAmbientInferenceBackends(

--- a/src/commands/onboard-inference.test.ts
+++ b/src/commands/onboard-inference.test.ts
@@ -152,7 +152,7 @@ describe("detectInferenceBackends", () => {
     expect(candidates[1]?.credentials).toBeUndefined();
   });
 
-  it("marks an installed Claude Code below the streamed-session floor unavailable", async () => {
+  it("keeps a lower-version Claude wrapper selectable with capability guidance", async () => {
     const candidates = await detectInferenceBackends({
       env: {},
       platform: "linux",
@@ -175,8 +175,9 @@ describe("detectInferenceBackends", () => {
     expect(candidates).toMatchObject([
       {
         kind: "claude-cli",
-        unavailableReason:
-          "Claude Code 2.1.206 or newer is required; found 2.1.205. Run `claude update`, restart OpenClaw, and retry.",
+        credentials: true,
+        detail:
+          "logged in; Claude Code 2.1.206 is the first published build known to advertise msg_lifecycle_v1; found 2.1.205. OpenClaw verifies this capability at runtime. If this build is rejected, run `claude update`, restart OpenClaw, and retry.",
       },
     ]);
   });

--- a/src/commands/onboard-inference.test.ts
+++ b/src/commands/onboard-inference.test.ts
@@ -152,6 +152,35 @@ describe("detectInferenceBackends", () => {
     expect(candidates[1]?.credentials).toBeUndefined();
   });
 
+  it("marks an installed Claude Code below the streamed-session floor unavailable", async () => {
+    const candidates = await detectInferenceBackends({
+      env: {},
+      platform: "linux",
+      deps: {
+        probeLocalCommand: async (command) => ({
+          command,
+          found: command === "claude",
+          ...(command === "claude" ? { version: "2.1.205 (Claude Code)" } : {}),
+        }),
+        readClaudeCliCredentials: () => ({ type: "oauth" }),
+        resolveClaudeLiveSessionRequirement: () => ({
+          capability: "msg_lifecycle_v1",
+          minimumVersion: "2.1.206",
+          versionArgs: ["--version"],
+          updateCommand: "claude update",
+        }),
+      },
+    });
+
+    expect(candidates).toMatchObject([
+      {
+        kind: "claude-cli",
+        unavailableReason:
+          "Claude Code 2.1.206 or newer is required; found 2.1.205. Run `claude update`, restart OpenClaw, and retry.",
+      },
+    ]);
+  });
+
   it("keeps a logged-in Gemini CLI after environment keys", async () => {
     const candidates = await detectInferenceBackends({
       env: { OPENAI_API_KEY: "sk-x" },

--- a/src/commands/onboard-inference.ts
+++ b/src/commands/onboard-inference.ts
@@ -5,8 +5,8 @@ import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { resolveAgentConfig, resolveDefaultAgentId } from "../agents/agent-scope-config.js";
 import {
-  formatCliBackendUpdateGuidance,
-  resolveCliBackendVersionSupport,
+  formatCliBackendVersionAdvisory,
+  resolveCliBackendVersionGuidance,
 } from "../agents/cli-backend-version-support.js";
 import { resolveCliBackendLiveSessionRequirement } from "../agents/cli-backends.js";
 import {
@@ -234,8 +234,8 @@ export async function detectInferenceBackends(
       (
         options.deps?.resolveClaudeLiveSessionRequirement ?? resolveCliBackendLiveSessionRequirement
       )("claude-cli") ?? undefined;
-    const versionSupport = liveSessionRequirement
-      ? resolveCliBackendVersionSupport(claudeProbe.version, liveSessionRequirement)
+    const versionGuidance = liveSessionRequirement
+      ? resolveCliBackendVersionGuidance(claudeProbe.version, liveSessionRequirement)
       : { status: "unknown" as const };
     const claudeCredential = readClaude();
     const credentials = detectCliCredentialState({
@@ -243,28 +243,25 @@ export async function detectInferenceBackends(
       hasStoredCredentials: claudeCredential !== null,
       platform,
     });
-    if (
-      versionSupport.status !== "unsupported" &&
-      credentials === true &&
-      claudeCredential?.type === "oauth"
-    ) {
+    if (credentials === true && claudeCredential?.type === "oauth") {
       subscriptionPromotionEligibleCliKinds.add("claude-cli");
     }
+    const detail = describeCliDetail(credentials, "run `claude auth login`");
+    // Only the live init record can prove capability support. Keep backports and
+    // wrappers selectable here even when their version predates the known release.
     cliCandidates.push({
       kind: "claude-cli",
       modelRef: CLAUDE_CLI_DEFAULT_MODEL_REF,
       label: "Claude Code",
-      detail: describeCliDetail(credentials, "run `claude auth login`"),
-      ...(credentials === undefined ? {} : { credentials }),
-      ...(versionSupport.status === "unsupported" && liveSessionRequirement
-        ? {
-            unavailableReason: formatCliBackendUpdateGuidance({
+      detail:
+        versionGuidance.status === "below-known-floor" && liveSessionRequirement
+          ? `${detail}; ${formatCliBackendVersionAdvisory({
               label: "Claude Code",
               requirement: liveSessionRequirement,
-              version: versionSupport.version,
-            }),
-          }
-        : {}),
+              version: versionGuidance.version,
+            })}`
+          : detail,
+      ...(credentials === undefined ? {} : { credentials }),
     });
   }
   if (codexProbe.found && !codexProbe.timedOut) {

--- a/src/commands/onboard-inference.ts
+++ b/src/commands/onboard-inference.ts
@@ -5,6 +5,11 @@ import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { resolveAgentConfig, resolveDefaultAgentId } from "../agents/agent-scope-config.js";
 import {
+  formatCliBackendUpdateGuidance,
+  resolveCliBackendVersionSupport,
+} from "../agents/cli-backend-version-support.js";
+import { resolveCliBackendLiveSessionRequirement } from "../agents/cli-backends.js";
+import {
   readClaudeCliCredentialsCached,
   readCodexCliCredentialsCached,
   readGeminiCliCredentialsCached,
@@ -45,6 +50,7 @@ type DetectInferenceBackendsDeps = {
   readGeminiCliCredentials?: () => { type: string } | null;
   detectCodexLoginState?: typeof detectCodexLoginState;
   randomInt?: (maxExclusive: number) => number;
+  resolveClaudeLiveSessionRequirement?: typeof resolveCliBackendLiveSessionRequirement;
 };
 
 type DetectInferenceBackendsOptions = {
@@ -224,13 +230,24 @@ export async function detectInferenceBackends(
   const cliCandidates: InferenceBackendCandidate[] = [];
   const subscriptionPromotionEligibleCliKinds = new Set<InferenceBackendKind>();
   if (claudeProbe.found && !claudeProbe.timedOut) {
+    const liveSessionRequirement =
+      (
+        options.deps?.resolveClaudeLiveSessionRequirement ?? resolveCliBackendLiveSessionRequirement
+      )("claude-cli") ?? undefined;
+    const versionSupport = liveSessionRequirement
+      ? resolveCliBackendVersionSupport(claudeProbe.version, liveSessionRequirement)
+      : { status: "unknown" as const };
     const claudeCredential = readClaude();
     const credentials = detectCliCredentialState({
       probe: claudeProbe,
       hasStoredCredentials: claudeCredential !== null,
       platform,
     });
-    if (credentials === true && claudeCredential?.type === "oauth") {
+    if (
+      versionSupport.status !== "unsupported" &&
+      credentials === true &&
+      claudeCredential?.type === "oauth"
+    ) {
       subscriptionPromotionEligibleCliKinds.add("claude-cli");
     }
     cliCandidates.push({
@@ -239,6 +256,15 @@ export async function detectInferenceBackends(
       label: "Claude Code",
       detail: describeCliDetail(credentials, "run `claude auth login`"),
       ...(credentials === undefined ? {} : { credentials }),
+      ...(versionSupport.status === "unsupported" && liveSessionRequirement
+        ? {
+            unavailableReason: formatCliBackendUpdateGuidance({
+              label: "Claude Code",
+              requirement: liveSessionRequirement,
+              version: versionSupport.version,
+            }),
+          }
+        : {}),
     });
   }
   if (codexProbe.found && !codexProbe.timedOut) {

--- a/src/plugin-sdk/cli-backend.ts
+++ b/src/plugin-sdk/cli-backend.ts
@@ -6,6 +6,7 @@ export type {
   CliBackendConfig,
   CliBackendExecutionMode,
   CliBackendJsonlUsage,
+  CliBackendLiveSessionRequirement,
   CliBackendNormalizeConfigContext,
   CliBackendNativeToolMode,
   CliBackendParseJsonlEvent,

--- a/src/plugins/cli-backend.types.ts
+++ b/src/plugins/cli-backend.types.ts
@@ -253,6 +253,18 @@ export type CliBackendRuntimeArtifactPolicy = Readonly<{
   nativeExecutableNames?: readonly string[];
 }>;
 
+/** Provider-owned protocol requirement for a long-lived CLI session. */
+export type CliBackendLiveSessionRequirement = Readonly<{
+  /** Exact capability the CLI must advertise before streamed output is trusted. */
+  capability: string;
+  /** First published version known to advertise the capability; runtime still feature-detects. */
+  minimumVersion: string;
+  /** Arguments used by setup and Doctor to obtain the installed CLI version. */
+  versionArgs: readonly string[];
+  /** Operator command that installs a compatible CLI version. */
+  updateCommand: string;
+}>;
+
 /** Plugin-owned CLI backend defaults used by the text-only CLI runner. */
 export type CliBackendPlugin = {
   /** Provider id used in model refs, for example `claude-cli/opus`. */
@@ -298,6 +310,8 @@ export type CliBackendPlugin = {
   };
   /** Required whenever this backend can become a verified inference owner. */
   runtimeArtifact?: CliBackendRuntimeArtifactPolicy;
+  /** Negotiated protocol capability required by this backend's live-session transport. */
+  liveSessionRequirement?: CliBackendLiveSessionRequirement;
   /**
    * Whether OpenClaw should inject bundle MCP config for this backend.
    *

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -11,6 +11,7 @@ export type {
   CliBackendConfig,
   CliBackendExecutionMode,
   CliBackendJsonlUsage,
+  CliBackendLiveSessionRequirement,
   CliBackendNormalizeConfigContext,
   CliBackendNativeToolMode,
   CliBackendParseJsonlEvent,

--- a/src/system-agent/setup-inference-detect.ts
+++ b/src/system-agent/setup-inference-detect.ts
@@ -137,10 +137,8 @@ export async function detectSetupInference(
     (candidate) => candidate.kind === "existing-model",
   )?.modelRef;
   const configuredCandidateKind = resolveConfiguredCandidateKind(cfg, configuredModel);
-  const unavailableDetected = detected.filter((candidate) => candidate.unavailableReason);
   const raw = detected.filter(
     (candidate) =>
-      !candidate.unavailableReason &&
       candidate.kind !== "gemini-cli" &&
       !(
         candidate.kind === configuredCandidateKind &&
@@ -165,19 +163,6 @@ export async function detectSetupInference(
   const manualProviders = listSetupInferenceManualProviders(authChoices);
   const authOptions = listSetupInferenceAuthOptions(authChoices);
   const prepareOptions = listSetupInferencePrepareOptions(authChoices);
-  unavailableCandidates.push(
-    ...unavailableDetected.map((candidate) =>
-      Object.assign(
-        {
-          id: candidate.kind,
-          label: candidate.label,
-          detail: candidate.detail,
-          reason: candidate.unavailableReason ?? "Unavailable",
-        },
-        resolveCandidatePresentation(candidate, authChoices),
-      ),
-    ),
-  );
   unavailableCandidates.push(...deferredUnavailableCandidates);
   const candidates: SetupInferenceCandidate[] = raw.map((candidate) =>
     // Released macOS clients require this field. Keep it false so the wire

--- a/src/system-agent/setup-inference-detect.ts
+++ b/src/system-agent/setup-inference-detect.ts
@@ -137,8 +137,10 @@ export async function detectSetupInference(
     (candidate) => candidate.kind === "existing-model",
   )?.modelRef;
   const configuredCandidateKind = resolveConfiguredCandidateKind(cfg, configuredModel);
+  const unavailableDetected = detected.filter((candidate) => candidate.unavailableReason);
   const raw = detected.filter(
     (candidate) =>
+      !candidate.unavailableReason &&
       candidate.kind !== "gemini-cli" &&
       !(
         candidate.kind === configuredCandidateKind &&
@@ -163,6 +165,19 @@ export async function detectSetupInference(
   const manualProviders = listSetupInferenceManualProviders(authChoices);
   const authOptions = listSetupInferenceAuthOptions(authChoices);
   const prepareOptions = listSetupInferencePrepareOptions(authChoices);
+  unavailableCandidates.push(
+    ...unavailableDetected.map((candidate) =>
+      Object.assign(
+        {
+          id: candidate.kind,
+          label: candidate.label,
+          detail: candidate.detail,
+          reason: candidate.unavailableReason ?? "Unavailable",
+        },
+        resolveCandidatePresentation(candidate, authChoices),
+      ),
+    ),
+  );
   unavailableCandidates.push(...deferredUnavailableCandidates);
   const candidates: SetupInferenceCandidate[] = raw.map((candidate) =>
     // Released macOS clients require this field. Keep it false so the wire

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -1268,16 +1268,15 @@ describe("detectSetupInference", () => {
     expect(probeLocalCommand).not.toHaveBeenCalledWith("agy");
   });
 
-  it("reports incompatible detected CLI backends without offering them for activation", async () => {
+  it("keeps lower-version capability-compatible CLI wrappers available for activation", async () => {
     vi.mocked(detectInferenceBackends).mockResolvedValueOnce([
       {
         kind: "claude-cli",
         modelRef: "claude-cli/claude-opus-5",
         label: "Claude Code",
-        detail: "logged in",
+        detail:
+          "logged in; Claude Code 2.1.206 is the first published build known to advertise msg_lifecycle_v1; found 2.1.205. OpenClaw verifies this capability at runtime.",
         credentials: true,
-        unavailableReason:
-          "Claude Code 2.1.206 or newer is required; found 2.1.205. Run `claude update`, restart OpenClaw, and retry.",
       },
     ]);
 
@@ -1286,17 +1285,19 @@ describe("detectSetupInference", () => {
       probeLocalCommand: vi.fn(async (command) => ({ command, found: false })),
     });
 
-    expect(detection.candidates).toEqual([]);
-    expect(detection.unavailableCandidates).toEqual([
+    expect(detection.candidates).toEqual([
       {
-        id: "claude-cli",
         brandId: "claude",
+        credentials: true,
+        detail:
+          "logged in; Claude Code 2.1.206 is the first published build known to advertise msg_lifecycle_v1; found 2.1.205. OpenClaw verifies this capability at runtime.",
+        kind: "claude-cli",
         label: "Claude Code",
-        detail: "logged in",
-        reason:
-          "Claude Code 2.1.206 or newer is required; found 2.1.205. Run `claude update`, restart OpenClaw, and retry.",
+        modelRef: "claude-cli/claude-opus-5",
+        recommended: false,
       },
     ]);
+    expect(detection.unavailableCandidates).toEqual([]);
   });
 });
 

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -1267,6 +1267,37 @@ describe("detectSetupInference", () => {
     expect(probeLocalCommand).toHaveBeenCalledWith("opencode");
     expect(probeLocalCommand).not.toHaveBeenCalledWith("agy");
   });
+
+  it("reports incompatible detected CLI backends without offering them for activation", async () => {
+    vi.mocked(detectInferenceBackends).mockResolvedValueOnce([
+      {
+        kind: "claude-cli",
+        modelRef: "claude-cli/claude-opus-5",
+        label: "Claude Code",
+        detail: "logged in",
+        credentials: true,
+        unavailableReason:
+          "Claude Code 2.1.206 or newer is required; found 2.1.205. Run `claude update`, restart OpenClaw, and retry.",
+      },
+    ]);
+
+    const detection = await detectSetupInference({
+      resolveManifestProviderAuthChoices: () => [],
+      probeLocalCommand: vi.fn(async (command) => ({ command, found: false })),
+    });
+
+    expect(detection.candidates).toEqual([]);
+    expect(detection.unavailableCandidates).toEqual([
+      {
+        id: "claude-cli",
+        brandId: "claude",
+        label: "Claude Code",
+        detail: "logged in",
+        reason:
+          "Claude Code 2.1.206 or newer is required; found 2.1.205. Run `claude update`, restart OpenClaw, and retry.",
+      },
+    ]);
+  });
 });
 
 async function runCodexSetupWithFinalConfig(params: {


### PR DESCRIPTION
Closes #115228

## What Problem This Solves

A reused Claude Code stdio session can emit a terminal result for queued background work before it starts the next user input. OpenClaw treated that unrelated result as the new turn's outcome, so the next message could complete with no visible reply.

## Why This Change Was Made

Each streamed input now carries a unique UUID, and the live-session owner accepts assistant and terminal records only after Claude emits `command_lifecycle` state `started` for that UUID. Process-level `system/init` identity is still recorded before that boundary so a stalled fork can be recovered safely. This preserves Agent and Workflow draining and removes marker-text authority.

The lifecycle contract is now provider-owned and capability-gated. The Anthropic backend requires the exact `msg_lifecycle_v1` capability before streamed output is trusted; unknown capabilities are ignored. Claude Code 2.1.206 is the first published build observed to advertise it, but runtime eligibility remains capability-based so compatible backports and wrappers work without version spoofing.

## User Impact

Messages sent immediately after background Agent or Workflow activity now receive the reply for that message instead of silently completing from stale queued output. Stalled resumed or forked sessions retain their successor identity for bounded cache-preserving recovery. Ordinary foreground turns, local Bash behavior, and cleanup remain intact.

An installed Claude Code build that omits the required capability now fails immediately for fresh and resumed sessions with `claude update`, gateway-restart, and retry guidance. Setup keeps lower-version backports and wrappers selectable with an advisory, and `openclaw doctor` reports the same first-known-version guidance without declaring them unsupported.

## Compatibility Contract

- Runtime authority: exact `system/init.capabilities` membership for `msg_lifecycle_v1`; no version-only gate and no legacy parser fallback.
- Operator guidance: Claude Code 2.1.206 is the first published version observed to emit queued/started lifecycle records for the exact input UUID; the version is advisory because runtime capability negotiation is authoritative.
- Unsupported outcome: immediate `cli_live_session_unsupported` failure with update/restart/retry guidance, before assistant/tool/result records can settle the turn.
- Setup and Doctor consume the same plugin-owned version probe and update metadata, but do not reject a lower-version compatible backport or wrapper.

## Evidence

- Direct official-package probes used credential-free fresh homes and the exact input UUID. Claude Code 2.1.205 advertised only `interrupt_receipt_v1` and emitted no lifecycle records. Claude Code 2.1.206 emitted queued and started lifecycle records for that UUID and advertised `msg_lifecycle_v1` in `system/init`.
- Fresh and resumed capability tests cover both supported and unsupported CLIs. A capable custom lower-version wrapper succeeds, proving runtime uses capability detection; a 2.1.205-style init fails immediately and cancels the managed process with actionable guidance.
- Focused local verification passed the ClawSweeper acceptance suite (169 tests) across onboarding, setup inference, Doctor, and fresh/resumed runtime capability negotiation; the broader 244-test affected suite also passed before the advisory-only follow-up.
- Documentation verification passed `docs:check-mdx` (767 files), `docs:check-links` (6,387 links, zero broken), and `docs:check-i18n-glossary`; `plugin-sdk:surface:check` also passed.
- Exact-tree Blacksmith Testbox run [30883656258](https://github.com/openclaw/openclaw/actions/runs/30883656258) passed `node scripts/check-changed.mjs` after the advisory-only follow-up: policy guards, formatting, SDK contracts, dead exports, core/core-test/extension/extension-test typechecks, lint, and changed tests.
- Final exact-tree autoreview found no P0/P1 issue at 0.94 correctness confidence; secret scanning passed.
- Live Claude Code 2.1.220 proof passed a direct reply, a real background Agent launch, and an immediate same-session follow-up in one managed process; all three request UUIDs received matching lifecycle starts and cleanup was verified.

## Repair Scope

Root cause and owner: the Claude live-session owner accepted process-stream records without a per-input ownership boundary. The canonical repair correlates at that owner and places the dependency contract in the Anthropic backend descriptor. There is no compatibility fallback or duplicate parser path. Sibling coverage includes fresh/resumed sessions, setup activation, Doctor diagnostics, backend runtime/setup resolution, fork recovery, and background-task draining.

Combined PR delta: production +246/-132 (net +114), tests +438/-116, docs +59/-14. The positive production delta establishes the public dependency capability contract, provider-owned metadata boundary, and required operator diagnostics.
