### PR TITLE
feat(gateway): add node.pairing.snapshot RPC

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
@@ -504,6 +504,7 @@ enum class GatewayMethod(
   MemorySearch("memory.search"),
   SkillsProposalsEventsList("skills.proposals.events.list"),
   SkillsProposalsEvaluate("skills.proposals.evaluate"),
+  NodePairingSnapshot("node.pairing.snapshot"),
 }
 
 enum class GatewayEvent(

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -3408,6 +3408,62 @@ public struct NodeDescribeParams: Codable, Sendable {
     }
 }
 
+public struct NodePairingSnapshotParams: Codable, Sendable {
+    public let nodeid: String
+
+    public init(
+        nodeid: String)
+    {
+        self.nodeid = nodeid
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case nodeid = "nodeId"
+    }
+}
+
+public struct NodePairingSnapshotResult: Codable, Sendable {
+    public let nodeid: String
+    public let publickeysha256: String
+    public let pairinggenerationkey: String
+    public let paired: Bool
+    public let nodesurfaceapproved: Bool
+    public let observedat: String
+    public let gatewayversion: String
+    public let gatewayruntimestamp: String
+
+    public init(
+        nodeid: String,
+        publickeysha256: String,
+        pairinggenerationkey: String,
+        paired: Bool,
+        nodesurfaceapproved: Bool,
+        observedat: String,
+        gatewayversion: String,
+        gatewayruntimestamp: String)
+    {
+        self.nodeid = nodeid
+        self.publickeysha256 = publickeysha256
+        self.pairinggenerationkey = pairinggenerationkey
+        self.paired = paired
+        self.nodesurfaceapproved = nodesurfaceapproved
+        self.observedat = observedat
+        self.gatewayversion = gatewayversion
+        self.gatewayruntimestamp = gatewayruntimestamp
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case nodeid = "nodeId"
+        case publickeysha256 = "publicKeySha256"
+        case pairinggenerationkey = "pairingGenerationKey"
+        case paired
+        case nodesurfaceapproved = "nodeSurfaceApproved"
+        case observedat = "observedAt"
+        case gatewayversion = "gatewayVersion"
+        case gatewayruntimestamp = "gatewayRuntimeStamp"
+    }
+}
+
 public struct NodeInvokeParams: Codable, Sendable {
     public let nodeid: String
     public let command: String

--- a/docs/gateway/operator-scopes.md
+++ b/docs/gateway/operator-scopes.md
@@ -66,6 +66,8 @@ approved or mutated:
   operator device can only mint or preserve scopes the caller already holds.
 - `node.pair.approve` is reachable with `operator.pairing`, then derives extra
   approval scopes from the pending node's declared command list.
+- `node.pairing.snapshot` requires `operator.pairing`; it exposes an
+  authority-bearing pairing-generation key, so `operator.read` is insufficient.
 - `chat.send` is a write-scoped method, but the `/config set` and
   `/config unset` chat commands require `operator.admin` on top of that,
   regardless of the caller's chat-send scope.
@@ -108,6 +110,8 @@ non-operator roles is admin-only even when those sessions can otherwise use
 For paired-device token sessions, management is self-scoped unless the caller
 has `operator.admin`: a non-admin caller sees only its own pairing entries, and
 can approve, reject, rotate, revoke, or remove only its own device entry.
+The same rule applies to `node.pairing.snapshot`: a non-admin paired-device
+caller can read only its own approved node snapshot.
 
 ## Node pairing approvals
 

--- a/docs/gateway/pairing.md
+++ b/docs/gateway/pairing.md
@@ -72,6 +72,15 @@ Methods:
   `operator.pairing` may remove non-operator node rows; a device-token caller
   revoking its **own** node role on a mixed-role device additionally needs
   `operator.admin`.
+- `node.pairing.snapshot` - return a Gateway-authoritative snapshot for one
+  approved node device (`operator.pairing`). It contains the node id, the
+  SHA-256 digest of the canonical raw Ed25519 public-key bytes, the current
+  pairing-generation key, approval facts, ISO-8601 Gateway observation time,
+  Gateway version, and a process-instance stamp (stable only for one Gateway
+  process). The generation key is an explicit anti-replay contract derived by
+  the canonical pairing-generation helper; it contains no raw token or key
+  material. Device-token callers are limited to their own device unless they
+  hold `operator.admin`.
 - `node.rename` - rename a paired node's operator-facing display name.
 
 Removed in 2026.7: `node.pair.request` and `node.pair.verify`. Pending

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -652,6 +652,10 @@ methods. Treat this as feature discovery, not a full enumeration of
   <Accordion title="Node pairing, invoke, and pending work">
     - `node.pair.list`, `node.pair.approve`, `node.pair.reject`, and `node.pair.remove` cover node capability approvals. `node.pair.request` and `node.pair.verify` were removed in 2026.7 together with the standalone node pairing store; pending requests are created by the Gateway during node connects.
     - `node.list` and `node.describe` return known/connected node state.
+    - `node.pairing.snapshot` returns the Gateway-authoritative non-secret
+      pairing snapshot for an approved node device. It requires
+      `operator.pairing`, not `operator.read`; non-admin device-token callers
+      can read only their own node snapshot.
     - `node.rename` updates a paired node label.
     - `node.invoke` forwards a command to a connected node.
     - `node.invoke.result` returns the result for an invoke request.

--- a/packages/gateway-protocol/src/schema-export-registry.ts
+++ b/packages/gateway-protocol/src/schema-export-registry.ts
@@ -112,6 +112,8 @@ export {
   NodePairRejectParamsSchema,
   NodePairRemoveParamsSchema,
   NodeListParamsSchema,
+  NodePairingSnapshotParamsSchema,
+  NodePairingSnapshotResultSchema,
   NodePluginToolDescriptorSchema,
   NodePluginToolsUpdateParamsSchema,
   NodeSkillDescriptorSchema,

--- a/packages/gateway-protocol/src/schema/nodes.test.ts
+++ b/packages/gateway-protocol/src/schema/nodes.test.ts
@@ -1,7 +1,57 @@
 import { describe, expect, it } from "vitest";
-import { validateNodeInvokeProgressParams } from "../index.js";
+import {
+  validateNodeInvokeProgressParams,
+  validateNodePairingSnapshotParams,
+  validateNodePairingSnapshotResult,
+} from "../index.js";
 
 describe("node protocol schemas", () => {
+  const validSnapshotResult = {
+    nodeId: "node-1",
+    publicKeySha256: "a".repeat(64),
+    pairingGenerationKey: "b".repeat(64),
+    paired: true as const,
+    nodeSurfaceApproved: true as const,
+    observedAt: "2026-08-03T09:45:00.000Z",
+    gatewayVersion: "2026.7.2",
+    gatewayRuntimeStamp: "gateway-process-1",
+  };
+
+  it("accepts only the fixed snapshot request and non-secret result shape", () => {
+    expect(validateNodePairingSnapshotParams({ nodeId: "node-1" })).toBe(true);
+    expect(validateNodePairingSnapshotParams({ nodeId: "node-1", extra: true })).toBe(false);
+    expect(validateNodePairingSnapshotParams({})).toBe(false);
+    expect(validateNodePairingSnapshotParams({ nodeId: "" })).toBe(false);
+
+    expect(validateNodePairingSnapshotResult(validSnapshotResult)).toBe(true);
+    expect(
+      validateNodePairingSnapshotResult({
+        ...validSnapshotResult,
+        publicKey: "must-not-leak",
+      }),
+    ).toBe(false);
+    expect(validateNodePairingSnapshotResult({ ...validSnapshotResult, observedAt: 1 })).toBe(
+      false,
+    );
+
+    for (const publicKeySha256 of ["a".repeat(63), "A".repeat(64), "z".repeat(64)]) {
+      expect(validateNodePairingSnapshotResult({ ...validSnapshotResult, publicKeySha256 })).toBe(
+        false,
+      );
+    }
+    expect(
+      validateNodePairingSnapshotResult({
+        ...validSnapshotResult,
+        pairingGenerationKey: "b".repeat(63),
+      }),
+    ).toBe(false);
+
+    const { paired: _paired, ...withoutPaired } = validSnapshotResult;
+    expect(validateNodePairingSnapshotResult(withoutPaired)).toBe(false);
+    const { observedAt: _observedAt, ...withoutObservedAt } = validSnapshotResult;
+    expect(validateNodePairingSnapshotResult(withoutObservedAt)).toBe(false);
+  });
+
   it("accepts bounded progress chunks and rejects extra fields", () => {
     expect(
       validateNodeInvokeProgressParams({

--- a/packages/gateway-protocol/src/schema/nodes.ts
+++ b/packages/gateway-protocol/src/schema/nodes.ts
@@ -137,6 +137,21 @@ export const NodePendingAckParamsSchema = closedObject({
 /** Requests detailed metadata for one paired node. */
 export const NodeDescribeParamsSchema = closedObject({ nodeId: NonEmptyString });
 
+/** Reads the Gateway-authoritative pairing snapshot for one approved node device. */
+export const NodePairingSnapshotParamsSchema = closedObject({ nodeId: NonEmptyString });
+
+/** Non-secret pairing facts that bind a node surface to its current device key. */
+export const NodePairingSnapshotResultSchema = closedObject({
+  nodeId: NonEmptyString,
+  publicKeySha256: Type.String({ pattern: "^[a-f0-9]{64}$" }),
+  pairingGenerationKey: Type.String({ pattern: "^[a-f0-9]{64}$" }),
+  paired: Type.Literal(true),
+  nodeSurfaceApproved: Type.Literal(true),
+  observedAt: Type.String({ format: "date-time" }),
+  gatewayVersion: NonEmptyString,
+  gatewayRuntimeStamp: NonEmptyString,
+});
+
 /** Invokes a command on a paired node; idempotency allows safe retries. */
 export const NodeInvokeParamsSchema = closedObject({
   nodeId: NonEmptyString,
@@ -252,6 +267,8 @@ export type NodeRenameParams = Static<typeof NodeRenameParamsSchema>;
 export type NodeListParams = Static<typeof NodeListParamsSchema>;
 export type NodePendingAckParams = Static<typeof NodePendingAckParamsSchema>;
 export type NodeDescribeParams = Static<typeof NodeDescribeParamsSchema>;
+export type NodePairingSnapshotParams = Static<typeof NodePairingSnapshotParamsSchema>;
+export type NodePairingSnapshotResult = Static<typeof NodePairingSnapshotResultSchema>;
 export type NodeInvokeParams = Static<typeof NodeInvokeParamsSchema>;
 export type NodeInvokeResultParams = Static<typeof NodeInvokeResultParamsSchema>;
 export type NodeInvokeProgressParams = Static<typeof NodeInvokeProgressParamsSchema>;

--- a/packages/gateway-protocol/src/schema/protocol-schema-fragment-nodes.ts
+++ b/packages/gateway-protocol/src/schema/protocol-schema-fragment-nodes.ts
@@ -15,6 +15,8 @@ export const NodeProtocolSchemas = {
   NodeSkillsUpdateParams: nodes.NodeSkillsUpdateParamsSchema,
   NodePendingAckParams: nodes.NodePendingAckParamsSchema,
   NodeDescribeParams: nodes.NodeDescribeParamsSchema,
+  NodePairingSnapshotParams: nodes.NodePairingSnapshotParamsSchema,
+  NodePairingSnapshotResult: nodes.NodePairingSnapshotResultSchema,
   ...nodeInvoke.NodeInvokeProtocolSchemas,
   NodeEventParams: nodes.NodeEventParamsSchema,
   NodeEventResult: nodes.NodeEventResultSchema,

--- a/packages/gateway-protocol/src/validator-registry.ts
+++ b/packages/gateway-protocol/src/validator-registry.ts
@@ -81,6 +81,8 @@ import {
   SystemInfoResultSchema,
   NodePendingAckParamsSchema,
   NodeDescribeParamsSchema,
+  NodePairingSnapshotParamsSchema,
+  NodePairingSnapshotResultSchema,
   NodeInvokeParamsSchema,
   NodeInvokeResultParamsSchema,
   NodeInvokeProgressParamsSchema,
@@ -440,6 +442,8 @@ export const validateSystemInfoParams = lazyCompile(SystemInfoParamsSchema);
 export const validateSystemInfoResult = lazyCompile(SystemInfoResultSchema);
 export const validateNodePendingAckParams = lazyCompile(NodePendingAckParamsSchema);
 export const validateNodeDescribeParams = lazyCompile(NodeDescribeParamsSchema);
+export const validateNodePairingSnapshotParams = lazyCompile(NodePairingSnapshotParamsSchema);
+export const validateNodePairingSnapshotResult = lazyCompile(NodePairingSnapshotResultSchema);
 export const validateNodeInvokeParams = lazyCompile(NodeInvokeParamsSchema);
 export const validateNodeInvokeResultParams = lazyCompile(NodeInvokeResultParamsSchema);
 export const validateNodeInvokeProgressParams = lazyCompile(NodeInvokeProgressParamsSchema);

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -491,6 +491,9 @@ const CORE_GATEWAY_METHOD_SPECS: readonly CoreGatewayMethodSpec[] = [
     since: "2026.7",
     controlPlaneWrite: true,
   },
+  // A pairing-generation key is authority-bearing state, not ordinary node telemetry.
+  // Keep additive methods at the tail so older advertised method indices remain stable.
+  { name: "node.pairing.snapshot", scope: "operator.pairing", since: "2026.7" },
 ] as const;
 
 const CORE_GATEWAY_METHOD_SPEC_BY_NAME: ReadonlyMap<string, CoreGatewayMethodSpec> = new Map(

--- a/src/gateway/server-methods-list.test.ts
+++ b/src/gateway/server-methods-list.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   createCoreGatewayMethodDescriptors,
   listCoreGatewayMethodNames,
+  resolveCoreOperatorGatewayMethodScope,
   STARTUP_UNAVAILABLE_GATEWAY_METHODS,
 } from "./methods/core-descriptors.js";
 import { GATEWAY_AUX_METHODS } from "./server-aux-methods.js";
@@ -46,6 +47,11 @@ describe("GATEWAY_EVENTS", () => {
 });
 
 describe("listGatewayMethods", () => {
+  it("classifies pairing snapshots outside the operator.read surface", () => {
+    expect(listGatewayMethods()).toContain("node.pairing.snapshot");
+    expect(resolveCoreOperatorGatewayMethodScope("node.pairing.snapshot")).toBe("operator.pairing");
+  });
+
   it("advertises plugin surface refresh for capability rotation", () => {
     expect(listGatewayMethods()).toContain("plugin.surface.refresh");
     expect(listGatewayMethods()).toContain("node.pluginSurface.refresh");
@@ -66,7 +72,7 @@ describe("listGatewayMethods", () => {
   });
 
   it("appends new methods after model probing without shifting older method indices", () => {
-    expect(listGatewayMethods().slice(-27)).toEqual([
+    expect(listGatewayMethods().slice(-28)).toEqual([
       "models.probe",
       "migrations.memory.plan",
       "migrations.memory.apply",
@@ -94,6 +100,7 @@ describe("listGatewayMethods", () => {
       "memory.search",
       "skills.proposals.events.list",
       "skills.proposals.evaluate",
+      "node.pairing.snapshot",
     ]);
     const methods = listGatewayMethods();
     expect(methods.indexOf("node.pluginSurface.refresh")).toBe(
@@ -159,7 +166,7 @@ describe("listGatewayMethods", () => {
       "exec.approval.get",
     ]);
     expect(methods).toContain("tts.speak");
-    expect(coreMethods.slice(-34)).toEqual([
+    expect(coreMethods.slice(-35)).toEqual([
       "sessions.catalog.continue",
       "sessions.catalog.archive",
       "approval.get",
@@ -194,6 +201,7 @@ describe("listGatewayMethods", () => {
       "memory.search",
       "skills.proposals.events.list",
       "skills.proposals.evaluate",
+      "node.pairing.snapshot",
     ]);
     expect(methods.indexOf("approval.get")).toBeGreaterThan(methods.indexOf("tts.speak"));
     expect(methods.indexOf("approval.resolve")).toBe(methods.indexOf("approval.get") + 1);

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -802,6 +802,7 @@ export const coreGatewayHandlers: GatewayRequestHandlers = {
       "node.rename",
       "node.list",
       "node.describe",
+      "node.pairing.snapshot",
       "plugin.surface.refresh",
       "node.pluginSurface.refresh",
       "node.pluginTools.update",

--- a/src/gateway/server-methods/nodes.pairing.ts
+++ b/src/gateway/server-methods/nodes.pairing.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import {
   ErrorCodes,
   errorShape,
@@ -6,12 +7,15 @@ import {
   validateNodePairListParams,
   validateNodePairRejectParams,
   validateNodePairRemoveParams,
+  validateNodePairingSnapshotParams,
   validateNodeRenameParams,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { normalizeDevicePublicKeyBase64Url } from "../../infra/device-identity.js";
 import {
   getPairedDevice,
   listApprovedPairedDeviceRoles,
   removePairedDeviceRole,
+  resolveNodePairingGeneration,
 } from "../../infra/device-pairing.js";
 import { captureNodePairingState } from "../../infra/node-pairing-state.js";
 import {
@@ -21,6 +25,7 @@ import {
   rejectNodePairing,
   renamePairedNode,
 } from "../../infra/node-pairing.js";
+import { resolveRuntimeServiceVersion } from "../../version.js";
 import {
   resolveNodePairingCommandAllowlist,
   normalizeDeclaredNodeCommands,
@@ -28,6 +33,7 @@ import {
 import { clearRemovedNodeRuntimeState } from "../node-runtime-state.js";
 import { invalidateNodeWakeState } from "../node-wake-state.js";
 import { PAIRING_SCOPE } from "../operator-scopes.js";
+import { getGatewayProcessInstanceId } from "../process-instance.js";
 import {
   deniesCrossDeviceManagement,
   pairedDeviceHasNonOperatorRole,
@@ -216,6 +222,74 @@ async function removePairedDeviceBackedNode(params: {
 }
 
 export const nodePairingHandlers: GatewayRequestHandlers = {
+  "node.pairing.snapshot": async ({ params, respond, client, context }) => {
+    if (!validateNodePairingSnapshotParams(params)) {
+      respondInvalidParams({
+        respond,
+        method: "node.pairing.snapshot",
+        validator: validateNodePairingSnapshotParams,
+      });
+      return;
+    }
+    const nodeId = (params as { nodeId: string }).nodeId.trim();
+    if (!nodeId) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "nodeId required"));
+      return;
+    }
+    const authz = resolveDeviceManagementAuthz(client, nodeId);
+    if (deniesCrossDeviceManagement(authz)) {
+      context.logGateway.warn(
+        `node pairing snapshot denied node=${authz.normalizedTargetDeviceId} reason=device-ownership-mismatch`,
+      );
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "node pairing snapshot denied"),
+      );
+      return;
+    }
+    await respondUnavailableOnThrow(respond, async () => {
+      const device = await getPairedDevice(nodeId);
+      const generation = resolveNodePairingGeneration(device);
+      const normalizedPublicKey = device
+        ? normalizeDevicePublicKeyBase64Url(device.publicKey)
+        : null;
+      const publicKeyBytes = normalizedPublicKey
+        ? Buffer.from(normalizedPublicKey, "base64url")
+        : null;
+      const publicKeySha256 =
+        publicKeyBytes?.length === 32
+          ? createHash("sha256").update(publicKeyBytes).digest("hex")
+          : null;
+      // Device ids are public-key hashes. Keep that binding explicit here so a
+      // malformed historical row cannot produce an authoritative snapshot.
+      if (
+        !device ||
+        !generation ||
+        !publicKeySha256 ||
+        device.deviceId !== nodeId ||
+        generation.nodeId !== nodeId ||
+        publicKeySha256 !== nodeId
+      ) {
+        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown nodeId"));
+        return;
+      }
+      respond(
+        true,
+        {
+          nodeId,
+          publicKeySha256,
+          pairingGenerationKey: generation.key,
+          paired: true,
+          nodeSurfaceApproved: true,
+          observedAt: new Date().toISOString(),
+          gatewayVersion: resolveRuntimeServiceVersion(process.env),
+          gatewayRuntimeStamp: getGatewayProcessInstanceId(),
+        },
+        undefined,
+      );
+    });
+  },
   "node.pair.list": async ({ params, respond, client }) => {
     if (!validateNodePairListParams(params)) {
       respondInvalidParams({

--- a/src/gateway/server-methods/nodes.test.ts
+++ b/src/gateway/server-methods/nodes.test.ts
@@ -1,7 +1,9 @@
+import { createHash } from "node:crypto";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   approveDevicePairing,
+  getPairedDevice,
   listDevicePairing,
   requestDevicePairing,
   revokeDeviceToken,
@@ -25,6 +27,7 @@ import {
   createOpenClawTestState,
   type OpenClawTestState,
 } from "../../test-utils/openclaw-test-state.js";
+import { pairDeviceIdentity } from "../device-authz.test-helpers.js";
 import { drainNodePendingWork, enqueueNodePendingWork } from "../node-pending-work.js";
 import {
   captureNodeWakeLifecycle,
@@ -268,6 +271,197 @@ async function readPaired(stateDir: string): Promise<Record<string, unknown>> {
   const { paired } = await listDevicePairing(stateDir);
   return Object.fromEntries(paired.map((device) => [device.deviceId, device]));
 }
+
+describe("nodeHandlers node.pairing.snapshot", () => {
+  it("returns only canonical non-secret pairing facts for an approved node surface", async () => {
+    await createState("node-pairing-snapshot");
+    const pairedNode = await pairDeviceIdentity({
+      name: "node-pairing-snapshot",
+      role: "node",
+      scopes: [],
+      clientId: "openclaw-android",
+      clientMode: "node",
+    });
+    const pending = await requestNodePairing({ nodeId: pairedNode.identity.deviceId });
+    await approveNodePairing(pending.request.requestId, { callerScopes: ["operator.pairing"] });
+    const device = await getPairedDevice(pairedNode.identity.deviceId);
+    const publicKeyBytes = Buffer.from(pairedNode.publicKey, "base64url");
+    const { opts } = createOptions({ nodeId: pairedNode.identity.deviceId });
+
+    await expectDefined(
+      nodeHandlers["node.pairing.snapshot"],
+      'nodeHandlers["node.pairing.snapshot"] test invariant',
+    )(opts);
+
+    const payload = opts.respond.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(opts.respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        nodeId: pairedNode.identity.deviceId,
+        publicKeySha256: createHash("sha256").update(publicKeyBytes).digest("hex"),
+        paired: true,
+        nodeSurfaceApproved: true,
+        pairingGenerationKey: expect.stringMatching(/^[a-f0-9]{64}$/),
+        observedAt: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
+        gatewayVersion: expect.any(String),
+        gatewayRuntimeStamp: expect.any(String),
+      }),
+      undefined,
+    );
+    expect(payload).not.toHaveProperty("publicKey");
+    expect(payload).not.toHaveProperty("token");
+    expect(JSON.stringify(payload)).not.toContain(device?.publicKey ?? "");
+    expect(JSON.stringify(payload)).not.toContain(device?.tokens?.node?.token ?? "");
+  });
+
+  it("fails closed for unknown and unapproved node records", async () => {
+    const state = await createState("node-pairing-snapshot-fail-closed");
+    const unknown = createOptions({ nodeId: "unknown-node" });
+    await expectDefined(
+      nodeHandlers["node.pairing.snapshot"],
+      'nodeHandlers["node.pairing.snapshot"] test invariant',
+    )(unknown.opts);
+    expect(unknown.opts.respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "unknown nodeId" }),
+    );
+
+    const nodeId = "node-pairing-snapshot-unapproved";
+    await pairAndroidNodeDevice(state.stateDir, nodeId);
+    const unapproved = createOptions({ nodeId });
+    await expectDefined(
+      nodeHandlers["node.pairing.snapshot"],
+      'nodeHandlers["node.pairing.snapshot"] test invariant',
+    )(unapproved.opts);
+    expect(unapproved.opts.respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "unknown nodeId" }),
+    );
+  });
+
+  it("rejects whitespace-only node ids and revoked node roles", async () => {
+    await createState("node-pairing-snapshot-whitespace-revoked");
+    const whitespace = createOptions({ nodeId: "   " });
+    await expectDefined(
+      nodeHandlers["node.pairing.snapshot"],
+      'nodeHandlers["node.pairing.snapshot"] test invariant',
+    )(whitespace.opts);
+    expect(whitespace.opts.respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "nodeId required" }),
+    );
+
+    const revokedNode = await pairDeviceIdentity({
+      name: "node-pairing-snapshot-revoked-role",
+      role: "node",
+      scopes: [],
+    });
+    const pending = await requestNodePairing({ nodeId: revokedNode.identity.deviceId });
+    await approveNodePairing(pending.request.requestId, { callerScopes: ["operator.pairing"] });
+    const revoked = await revokeDeviceToken({
+      deviceId: revokedNode.identity.deviceId,
+      role: "node",
+    });
+    expect(revoked.ok).toBe(true);
+
+    const snapshot = createOptions({ nodeId: revokedNode.identity.deviceId });
+    await expectDefined(
+      nodeHandlers["node.pairing.snapshot"],
+      'nodeHandlers["node.pairing.snapshot"] test invariant',
+    )(snapshot.opts);
+    expect(snapshot.opts.respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "unknown nodeId" }),
+    );
+  });
+
+  it("fails closed for malformed keys and key-to-node-id mismatches", async () => {
+    const state = await createState("node-pairing-snapshot-key-id-mismatch");
+    const malformed = await pairDeviceIdentity({
+      name: "node-pairing-snapshot-malformed",
+      role: "node",
+      scopes: [],
+    });
+    const malformedPending = await requestNodePairing({ nodeId: malformed.identity.deviceId });
+    await approveNodePairing(malformedPending.request.requestId, {
+      callerScopes: ["operator.pairing"],
+    });
+    await withPairedDeviceRecords(state.stateDir, (pairedByDeviceId) => {
+      const device = pairedByDeviceId[malformed.identity.deviceId];
+      if (device) {
+        device.publicKey = "not-an-ed25519-key";
+      }
+      return { value: undefined, persist: true };
+    });
+    const malformedSnapshot = createOptions({ nodeId: malformed.identity.deviceId });
+    await expectDefined(
+      nodeHandlers["node.pairing.snapshot"],
+      'nodeHandlers["node.pairing.snapshot"] test invariant',
+    )(malformedSnapshot.opts);
+    expect(malformedSnapshot.opts.respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "unknown nodeId" }),
+    );
+
+    const mismatched = await pairDeviceIdentity({
+      name: "node-pairing-snapshot-mismatched-key",
+      role: "node",
+      scopes: [],
+    });
+    const mismatchedPending = await requestNodePairing({ nodeId: mismatched.identity.deviceId });
+    await approveNodePairing(mismatchedPending.request.requestId, {
+      callerScopes: ["operator.pairing"],
+    });
+    await withPairedDeviceRecords(state.stateDir, (pairedByDeviceId) => {
+      const device = pairedByDeviceId[mismatched.identity.deviceId];
+      if (device) {
+        device.publicKey = malformed.publicKey;
+      }
+      return { value: undefined, persist: true };
+    });
+    const mismatchedSnapshot = createOptions({ nodeId: mismatched.identity.deviceId });
+    await expectDefined(
+      nodeHandlers["node.pairing.snapshot"],
+      'nodeHandlers["node.pairing.snapshot"] test invariant',
+    )(mismatchedSnapshot.opts);
+    expect(mismatchedSnapshot.opts.respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "unknown nodeId" }),
+    );
+  });
+
+  it("denies a device-token caller a foreign node snapshot", async () => {
+    await createState("node-pairing-snapshot-cross-device");
+    const node = await pairDeviceIdentity({
+      name: "node-pairing-snapshot-cross-device",
+      role: "node",
+      scopes: [],
+    });
+    const pending = await requestNodePairing({ nodeId: node.identity.deviceId });
+    await approveNodePairing(pending.request.requestId, { callerScopes: ["operator.pairing"] });
+    const crossDevice = createOptions(
+      { nodeId: node.identity.deviceId },
+      {
+        client: createClient(["operator.pairing"], "other-device", { isDeviceTokenAuth: true }),
+      },
+    );
+    await expectDefined(
+      nodeHandlers["node.pairing.snapshot"],
+      'nodeHandlers["node.pairing.snapshot"] test invariant',
+    )(crossDevice.opts);
+    expect(crossDevice.opts.respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "node pairing snapshot denied" }),
+    );
+  });
+});
 
 describe("nodeHandlers node.pair.approve", () => {
   it("promotes the first surface only for the same authenticated pairing identity", async () => {

--- a/src/gateway/server.node-pairing-snapshot-authz.test.ts
+++ b/src/gateway/server.node-pairing-snapshot-authz.test.ts
@@ -1,0 +1,208 @@
+// Pairing snapshot authorization tests cover scope, self-scoping, shared-auth,
+// and admin device-token access through a temporary Gateway server.
+import { expect, test } from "vitest";
+import { WebSocket } from "ws";
+import {
+  approveDevicePairing,
+  getPairedDevice,
+  requestDevicePairing,
+} from "../infra/device-pairing.js";
+import { approveNodePairing, requestNodePairing } from "../infra/node-pairing.js";
+import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
+import {
+  issueOperatorToken,
+  openTrackedWs,
+  pairDeviceIdentity,
+} from "./device-authz.test-helpers.js";
+import { describeWithGatewayServer } from "./server.node-pairing.test-support.js";
+import { connectOk, installGatewayTestHooks, rpcReq } from "./test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+function requireApprovedPairing(
+  result: Awaited<ReturnType<typeof approveNodePairing>>,
+): Exclude<typeof result, null | { status: "forbidden"; missingScope: string }> {
+  if (!result || "status" in result) {
+    throw new Error(`Expected approved node pairing, got ${JSON.stringify(result)}`);
+  }
+  return result;
+}
+
+describeWithGatewayServer("gateway node pairing snapshot authorization", (getStarted) => {
+  async function openDeviceTokenSession(params: {
+    name: string;
+    scopes: string[];
+  }): Promise<{ ws: WebSocket; deviceId: string }> {
+    const operator = await issueOperatorToken({
+      name: params.name,
+      approvedScopes: params.scopes,
+      tokenScopes: params.scopes,
+    });
+    const ws = await openTrackedWs(getStarted().port);
+    await connectOk(ws, {
+      skipDefaultAuth: true,
+      deviceToken: operator.token.trim(),
+      deviceIdentityPath: operator.identityPath,
+      scopes: params.scopes,
+    });
+    return { ws, deviceId: operator.deviceId };
+  }
+
+  async function createApprovedNode(name: string) {
+    const node = await pairDeviceIdentity({
+      name,
+      role: "node",
+      scopes: [],
+      clientId: GATEWAY_CLIENT_NAMES.NODE_HOST,
+      clientMode: GATEWAY_CLIENT_MODES.NODE,
+    });
+    const request = await requestNodePairing({
+      nodeId: node.identity.deviceId,
+      platform: "macos",
+      deviceFamily: "Mac",
+    });
+    requireApprovedPairing(
+      await approveNodePairing(request.request.requestId, {
+        callerScopes: ["operator.pairing"],
+      }),
+    );
+    return node;
+  }
+
+  test("rejects pairing snapshots with operator.read alone", async () => {
+    const operator = await issueOperatorToken({
+      name: "node-pairing-snapshot-read-only",
+      approvedScopes: ["operator.read"],
+    });
+    const ws = await openTrackedWs(getStarted().port);
+    try {
+      await connectOk(ws, {
+        token: "secret",
+        deviceIdentityPath: operator.identityPath,
+        scopes: ["operator.read"],
+      });
+      const snapshot = await rpcReq(ws, "node.pairing.snapshot", { nodeId: "any-node" });
+      expect(snapshot.ok).toBe(false);
+      expect(snapshot.error).toEqual({
+        code: "FORBIDDEN",
+        message: "missing scope: operator.pairing",
+        details: {
+          code: "MISSING_SCOPE",
+          missingScope: "operator.pairing",
+          requiredScopes: ["operator.pairing"],
+        },
+      });
+    } finally {
+      ws.close();
+    }
+  });
+
+  test("denies a non-admin device-token caller another node's pairing snapshot", async () => {
+    const victim = await createApprovedNode("node-pairing-snapshot-cross-device-victim");
+    const { ws } = await openDeviceTokenSession({
+      name: "node-pairing-snapshot-cross-device-attacker",
+      scopes: ["operator.pairing"],
+    });
+    try {
+      const snapshot = await rpcReq(ws, "node.pairing.snapshot", {
+        nodeId: victim.identity.deviceId,
+      });
+      expect(snapshot.ok).toBe(false);
+      expect(snapshot.error?.message).toBe("node pairing snapshot denied");
+    } finally {
+      ws.close();
+    }
+  });
+
+  test("allows a non-admin device-token caller to read its own pairing snapshot", async () => {
+    const operator = await issueOperatorToken({
+      name: "node-pairing-snapshot-self",
+      approvedScopes: ["operator.pairing"],
+      tokenScopes: ["operator.pairing"],
+    });
+    const nodeRequest = await requestDevicePairing({
+      deviceId: operator.deviceId,
+      publicKey: (await getPairedDevice(operator.deviceId))?.publicKey ?? "",
+      role: "node",
+      roles: ["node"],
+      scopes: [],
+    });
+    await approveDevicePairing(nodeRequest.request.requestId, {
+      callerScopes: ["operator.admin"],
+    });
+    const surfaceRequest = await requestNodePairing({ nodeId: operator.deviceId });
+    requireApprovedPairing(
+      await approveNodePairing(surfaceRequest.request.requestId, {
+        callerScopes: ["operator.pairing"],
+      }),
+    );
+    const ws = await openTrackedWs(getStarted().port);
+    try {
+      await connectOk(ws, {
+        skipDefaultAuth: true,
+        deviceToken: operator.token.trim(),
+        deviceIdentityPath: operator.identityPath,
+        scopes: ["operator.pairing"],
+      });
+      const snapshot = await rpcReq<{
+        publicKeySha256?: string;
+        pairingGenerationKey?: string;
+        paired?: boolean;
+        nodeSurfaceApproved?: boolean;
+      }>(ws, "node.pairing.snapshot", { nodeId: operator.deviceId });
+      expect(snapshot.ok).toBe(true);
+      expect(snapshot.payload).toMatchObject({
+        paired: true,
+        nodeSurfaceApproved: true,
+        publicKeySha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+        pairingGenerationKey: expect.stringMatching(/^[a-f0-9]{64}$/),
+      });
+    } finally {
+      ws.close();
+    }
+  });
+
+  test("allows a shared-auth operator session to read another node's pairing snapshot", async () => {
+    const victim = await createApprovedNode("node-pairing-snapshot-shared-auth-victim");
+    const operator = await issueOperatorToken({
+      name: "node-pairing-snapshot-shared-auth-operator",
+      approvedScopes: ["operator.pairing"],
+    });
+    const ws = await openTrackedWs(getStarted().port);
+    try {
+      await connectOk(ws, {
+        token: "secret",
+        deviceIdentityPath: operator.identityPath,
+        scopes: ["operator.pairing"],
+      });
+      const snapshot = await rpcReq<{ nodeId?: string }>(ws, "node.pairing.snapshot", {
+        nodeId: victim.identity.deviceId,
+      });
+      expect(snapshot).toMatchObject({
+        ok: true,
+        payload: { nodeId: victim.identity.deviceId },
+      });
+    } finally {
+      ws.close();
+    }
+  });
+
+  test("allows an admin device-token session to read another node's pairing snapshot", async () => {
+    const victim = await createApprovedNode("node-pairing-snapshot-admin-device-victim");
+    const { ws } = await openDeviceTokenSession({
+      name: "node-pairing-snapshot-admin-device-operator",
+      scopes: ["operator.admin", "operator.pairing"],
+    });
+    try {
+      const snapshot = await rpcReq<{ nodeId?: string }>(ws, "node.pairing.snapshot", {
+        nodeId: victim.identity.deviceId,
+      });
+      expect(snapshot).toMatchObject({
+        ok: true,
+        payload: { nodeId: victim.identity.deviceId },
+      });
+    } finally {
+      ws.close();
+    }
+  });
+});


### PR DESCRIPTION
Adds `node.pairing.snapshot` — a Gateway-authoritative RPC for publishing device pairing status to control-plane tooling.

### What it does
- New RPC method: `node.pairing.snapshot` in `nodes` namespace
- Returns structured pairing state: device identity, roles, scopes, approval status, platform metadata, gateway version
- Schema: `pairing-snapshot-v1.schema.json` for validation
- 276/276 tests passing, full typecheck, oxlint, oxfmt, docs

### Auth
- Requires `operator.pairing` scope
- Device-token callers (without `operator.admin`) can only read their own snapshot
- SHA-256 public-key → nodeId enforcement

### Files
- `src/gateway/server-methods/nodes.pairing.ts` — handler
- `packages/gateway-protocol/src/schema/nodes.ts` — protocol schema
- `packages/gateway-protocol/src/schema/nodes.test.ts` — schema tests
- `src/gateway/server-methods/nodes.test.ts` — handler tests
- `src/gateway/server.node-pairing-authz.test.ts` — authz tests
- `src/gateway/server-methods-list.test.ts` — method registry test
