### PR TITLE
fix(telegram): a failed chunk silently drops the rest of a long message

### DIFF
--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -263,6 +263,11 @@ async function deliverTextReply(params: {
     replyMarkup: params.replyMarkup,
     replyQuoteText: params.replyQuoteText,
     quoteOnlyOnFirstChunk: params.quoteOnlyOnFirstChunk,
+    invalidate: () => params.progress.promptContext?.invalidate(),
+    onRejected: (error) =>
+      params.runtime.error?.(
+        danger(`telegram reply chunk rejected; continuing: ${formatErrorMessage(error)}`),
+      ),
     markDelivered,
     sendChunk: async ({ chunk, isFirstChunk, replyToMessageId, replyMarkup, replyQuoteText }) => {
       const includeQuoteMetadata = params.quoteOnlyOnFirstChunk !== true || isFirstChunk;
@@ -289,6 +294,10 @@ async function deliverTextReply(params: {
           replyMarkup,
         },
       );
+      return messageId;
+    },
+    recordChunk: async (result, chunk) => {
+      const messageId = result;
       if (firstDeliveredMessageId == null) {
         firstDeliveredMessageId = messageId;
       }

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -1,5 +1,6 @@
 // Telegram tests cover delivery plugin behavior.
 import type { Bot } from "grammy";
+import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createTelegramPromptContextProjectionSequence } from "../prompt-context-projection.js";
@@ -219,6 +220,10 @@ function createThreadNotFoundError(operation = "sendMessage") {
   return new Error(
     `GrammyError: Call to '${operation}' failed! (400: Bad Request: message thread not found)`,
   );
+}
+
+function createChunkRejection(message = "chunk content rejected"): Error {
+  return Object.assign(new Error(`400: Bad Request: ${message}`), { error_code: 400 });
 }
 
 function createQuoteNotFoundError(operation = "sendMessage") {
@@ -524,6 +529,32 @@ describe("deliverReplies", () => {
           ],
         ],
       },
+    });
+  });
+
+  it("keeps first-chunk buttons on a later reply payload", async () => {
+    const runtime = createRuntime(false);
+    const sendMessage = vi
+      .fn()
+      .mockResolvedValueOnce({ message_id: 2, chat: { id: "123" } })
+      .mockResolvedValueOnce({ message_id: 3, chat: { id: "123" } });
+
+    await deliverWith({
+      replies: [
+        { text: "Earlier reply" },
+        {
+          text: "Approve?",
+          channelData: {
+            telegram: { buttons: [[{ text: "Allow", callback_data: "allow" }]] },
+          },
+        },
+      ],
+      runtime,
+      bot: createBot({ sendMessage }),
+    });
+
+    expectRecordFields(mockCallArg(sendMessage, 1, 2), {
+      reply_markup: { inline_keyboard: [[{ text: "Allow", callback_data: "allow" }]] },
     });
   });
 
@@ -2293,32 +2324,61 @@ describe("deliverReplies", () => {
     expect(observer).toHaveBeenCalledWith({ messageId: 304, text: "rewritten" });
   });
 
-  it("records only concrete text chunks that Telegram accepted", async () => {
+  it("continues streamed replies after a rejected middle chunk", async () => {
     const runtime = createRuntime();
     const sendMessage = vi
       .fn()
       .mockResolvedValueOnce({ message_id: 301, chat: { id: "123" } })
-      .mockRejectedValueOnce(new Error("second chunk failed"));
+      .mockRejectedValueOnce(createChunkRejection())
+      .mockResolvedValueOnce({ message_id: 303, chat: { id: "123" } });
     const observer = vi.fn();
     const promptContextSequence = createObservedPromptContextSequence(observer);
     const cfg = { session: { store: "/tmp/telegram-partial-store.json" } } as const;
 
-    await expect(
-      deliverWith({
-        replies: [{ text: "chunk-one\n\nchunk-two" }],
+    let observed: unknown;
+    try {
+      await deliverWith({
+        replies: [{ text: "chunk-one\n\nchunk-two\n\nchunk-three" }],
         cfg,
         runtime,
         bot: createBot({ sendMessage }),
         textLimit: 12,
         promptContextSequence,
-      }),
-    ).rejects.toThrow("second chunk failed");
+      });
+    } catch (error) {
+      observed = error;
+    }
     await promptContextSequence.fail();
 
-    expect(observer).toHaveBeenCalledTimes(1);
-    expect(observer).toHaveBeenCalledWith({ messageId: 301, text: "chunk-one\n\n" });
-    expect(recordSentMessage).toHaveBeenCalledTimes(1);
+    expect(isChannelPartialDeliveryError(observed)).toBe(true);
+    if (!isChannelPartialDeliveryError(observed)) {
+      throw observed;
+    }
+    expect(observed.deliveryResult.messageIds).toEqual(["301", "303"]);
+    expect(sendMessage).toHaveBeenCalledTimes(3);
+    expect(observer).toHaveBeenCalledTimes(2);
+    expect(observer).toHaveBeenNthCalledWith(1, { messageId: 301, text: "chunk-one\n\n" });
+    expect(observer).toHaveBeenNthCalledWith(2, { messageId: 303, text: "chunk-three" });
+    expect(recordSentMessage).toHaveBeenCalledTimes(2);
     expect(recordSentMessage).toHaveBeenCalledWith("123", 301, cfg);
+    expect(recordSentMessage).toHaveBeenCalledWith("123", 303, cfg);
+  });
+
+  it("fails streamed replies when every chunk is rejected", async () => {
+    const rejection = createChunkRejection();
+    const sendMessage = vi.fn().mockRejectedValue(rejection);
+
+    await expect(
+      deliverWith({
+        replies: [{ text: "chunk-one\n\nchunk-two\n\nchunk-three" }],
+        runtime: createRuntime(),
+        bot: createBot({ sendMessage }),
+        textLimit: 12,
+      }),
+    ).rejects.toBe(rejection);
+
+    expect(sendMessage).toHaveBeenCalledTimes(3);
+    expect(recordSentMessage).not.toHaveBeenCalled();
   });
 
   it("records the concrete Telegram media message", async () => {

--- a/extensions/telegram/src/bot/reply-threading.ts
+++ b/extensions/telegram/src/bot/reply-threading.ts
@@ -1,6 +1,7 @@
 // Telegram plugin module implements reply threading behavior.
 import type { ReplyToMode } from "openclaw/plugin-sdk/config-contracts";
 import { isSingleUseReplyToMode } from "openclaw/plugin-sdk/reply-reference";
+import { createTelegramChunkDeliveryTracker } from "../chunk-delivery.js";
 
 export type DeliveryProgress = {
   hasReplied: boolean;
@@ -39,6 +40,8 @@ export async function sendChunkedTelegramReplyText<
   replyMarkup?: TReplyMarkup;
   replyQuoteText?: string;
   quoteOnlyOnFirstChunk?: boolean;
+  invalidate: () => void;
+  onRejected: (error: unknown) => void;
   markDelivered?: (progress: TProgress) => void;
   sendChunk: (opts: {
     chunk: TChunk;
@@ -46,17 +49,24 @@ export async function sendChunkedTelegramReplyText<
     replyToMessageId?: number;
     replyMarkup?: TReplyMarkup;
     replyQuoteText?: string;
-  }) => Promise<void>;
+  }) => Promise<number>;
+  recordChunk: (result: number, chunk: TChunk) => Promise<void>;
 }): Promise<void> {
   const applyDelivered = params.markDelivered ?? markDelivered;
+  const messageIds: string[] = [];
+  const tracker = createTelegramChunkDeliveryTracker({
+    invalidate: params.invalidate,
+    onRejected: params.onRejected,
+    partialDeliveryResult: () => ({ messageIds: [...messageIds], visibleReplySent: true }),
+  });
   const suppressSingleUseReply =
     params.chunks.length > 1 && isSingleUseReplyToMode(params.replyToMode);
-  for (let i = 0; i < params.chunks.length; i += 1) {
-    const chunk = params.chunks[i];
+  let hasAcceptedChunk = false;
+  for (const chunk of params.chunks) {
     if (!chunk) {
       continue;
     }
-    const isFirstChunk = i === 0;
+    const isFirstChunk = !hasAcceptedChunk;
     // Telegram Desktop can render long formatted native-reply chunks as
     // unsupported messages. Multi-part `first` replies consume the reply target
     // without adding native reply params, preserving visible text.
@@ -71,17 +81,31 @@ export async function sendChunkedTelegramReplyText<
       Boolean(replyToMessageId) &&
       Boolean(params.replyQuoteText) &&
       (params.quoteOnlyOnFirstChunk !== true || isFirstChunk);
-    await params.sendChunk({
-      chunk,
-      isFirstChunk,
-      replyToMessageId,
-      replyMarkup: isFirstChunk ? params.replyMarkup : undefined,
-      replyQuoteText: shouldAttachQuote ? params.replyQuoteText : undefined,
-    });
+    const accepted = await tracker.attempt(
+      () =>
+        params.sendChunk({
+          chunk,
+          isFirstChunk,
+          replyToMessageId,
+          replyMarkup: isFirstChunk ? params.replyMarkup : undefined,
+          replyQuoteText: shouldAttachQuote ? params.replyQuoteText : undefined,
+        }),
+      (result) => {
+        // Capture Telegram's accepted identity before fallible bookkeeping so
+        // partial delivery reports retain the concrete streamed messages.
+        messageIds.push(String(result));
+        return params.recordChunk(result, chunk);
+      },
+    );
+    if (!accepted) {
+      continue;
+    }
+    hasAcceptedChunk = true;
     markReplyApplied(
       params.progress,
       suppressSingleUseReply && isFirstChunk ? params.replyToId : replyToMessageId,
     );
     applyDelivered(params.progress);
   }
+  tracker.finish();
 }

--- a/extensions/telegram/src/chunk-delivery.test.ts
+++ b/extensions/telegram/src/chunk-delivery.test.ts
@@ -1,0 +1,85 @@
+import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
+import { describe, expect, it, vi } from "vitest";
+import { createTelegramChunkDeliveryTracker } from "./chunk-delivery.js";
+
+const telegramError = (errorCode: number, message: string) =>
+  Object.assign(new Error(message), { error_code: errorCode });
+
+describe("Telegram chunk delivery", () => {
+  it.each([
+    [telegramError(400, "content rejected"), true],
+    [Object.assign(new Error("dns failed"), { code: "ENOTFOUND" }), true],
+    [telegramError(400, "message thread not found"), false],
+    [telegramError(401, "unauthorized"), false],
+    [telegramError(429, "rate limited"), false],
+    [telegramError(500, "server error"), false],
+    [new Error("ambiguous transport failure"), false],
+  ])("classifies %s as skippable=%s", async (error, expected) => {
+    const tracker = createTelegramChunkDeliveryTracker({
+      invalidate: vi.fn(),
+      onRejected: vi.fn(),
+      partialDeliveryResult: () => ({ visibleReplySent: true }),
+    });
+    const attempt = tracker.attempt(
+      async () => {
+        throw error;
+      },
+      async () => {},
+    );
+
+    if (expected) {
+      await expect(attempt).resolves.toBe(false);
+    } else {
+      await expect(attempt).rejects.toBe(error);
+    }
+  });
+
+  it("drains skippable failures then reports accepted partial delivery", async () => {
+    const invalidate = vi.fn();
+    const onRejected = vi.fn();
+    const record = vi.fn(async (_value: number) => {});
+    const tracker = createTelegramChunkDeliveryTracker({
+      invalidate,
+      onRejected,
+      partialDeliveryResult: () => ({ messageIds: ["1", "3"], visibleReplySent: true }),
+    });
+
+    await tracker.attempt(async () => 1, record);
+    await tracker.attempt(async () => {
+      throw telegramError(400, "content rejected");
+    }, record);
+    await tracker.attempt(async () => 3, record);
+
+    let observed: unknown;
+    try {
+      tracker.finish();
+    } catch (error) {
+      observed = error;
+    }
+    expect(isChannelPartialDeliveryError(observed)).toBe(true);
+    expect(invalidate).toHaveBeenCalledOnce();
+    expect(onRejected).toHaveBeenCalledOnce();
+    expect(record.mock.calls.map(([value]) => value)).toEqual([1, 3]);
+  });
+
+  it("stops after accepted-send bookkeeping fails", async () => {
+    const tracker = createTelegramChunkDeliveryTracker({
+      invalidate: vi.fn(),
+      onRejected: vi.fn(),
+      partialDeliveryResult: () => ({ visibleReplySent: true }),
+    });
+
+    let observed: unknown;
+    try {
+      await tracker.attempt(
+        async () => 1,
+        async () => {
+          throw new Error("observer failed");
+        },
+      );
+    } catch (error) {
+      observed = error;
+    }
+    expect(isChannelPartialDeliveryError(observed)).toBe(true);
+  });
+});

--- a/extensions/telegram/src/chunk-delivery.ts
+++ b/extensions/telegram/src/chunk-delivery.ts
@@ -1,0 +1,79 @@
+import {
+  createChannelPartialDeliveryError,
+  isChannelPartialDeliveryError,
+} from "openclaw/plugin-sdk/channel-inbound";
+import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
+import { isSafeToRetrySendError, isTelegramBadRequestError } from "./network-errors.js";
+
+// A missing chat/thread invalidates the route for every remaining chunk.
+// Draining would only repeat the same bad target instead of preserving content.
+const TELEGRAM_TERMINAL_BAD_REQUEST_RE = /\b(?:chat|message thread) not found\b/i;
+
+type PartialDeliveryResult = Parameters<typeof createChannelPartialDeliveryError>[1];
+
+function isTelegramSkippableChunkSendError(error: unknown): boolean {
+  if (isSafeToRetrySendError(error)) {
+    return true;
+  }
+  // A structured Telegram 400 is a definite rejection, so later chunks cannot
+  // duplicate this one. HTTP/5xx failures remain ambiguous and stop immediately.
+  return (
+    isTelegramBadRequestError(error) &&
+    !TELEGRAM_TERMINAL_BAD_REQUEST_RE.test(formatErrorMessage(error))
+  );
+}
+
+export function createTelegramChunkDeliveryTracker(params: {
+  invalidate: () => void;
+  onRejected: (error: unknown) => void;
+  partialDeliveryResult: () => PartialDeliveryResult;
+}) {
+  let acceptedCount = 0;
+  let firstRejectedError: unknown;
+
+  const throwAfterAccepted = (error: unknown): never => {
+    if (acceptedCount === 0 || isChannelPartialDeliveryError(error)) {
+      throw error;
+    }
+    throw createChannelPartialDeliveryError(error, params.partialDeliveryResult());
+  };
+
+  const reject = (error: unknown): false => {
+    if (!isTelegramSkippableChunkSendError(error)) {
+      throwAfterAccepted(error);
+    }
+    firstRejectedError ??= error;
+    params.invalidate();
+    params.onRejected(error);
+    return false;
+  };
+
+  const recordAccepted = async <T>(result: T, record: (result: T) => Promise<void>) => {
+    acceptedCount += 1;
+    try {
+      await record(result);
+    } catch (error) {
+      throwAfterAccepted(error);
+    }
+  };
+
+  return {
+    async attempt<T>(send: () => Promise<T>, record: (result: T) => Promise<void>) {
+      let result: T;
+      try {
+        result = await send();
+      } catch (error) {
+        return reject(error);
+      }
+      await recordAccepted(result, record);
+      return true;
+    },
+    recordAccepted,
+    reject,
+    finish() {
+      if (firstRejectedError !== undefined) {
+        throwAfterAccepted(firstRejectedError);
+      }
+    },
+  };
+}

--- a/extensions/telegram/src/network-errors.ts
+++ b/extensions/telegram/src/network-errors.ts
@@ -305,6 +305,10 @@ export function isTelegramClientRejection(err: unknown): boolean {
   return hasTelegramErrorCode(err, (code) => code >= 400 && code < 500);
 }
 
+export function isTelegramBadRequestError(err: unknown): boolean {
+  return hasTelegramErrorCode(err, (code) => code === 400);
+}
+
 export function isRecoverableTelegramNetworkError(
   err: unknown,
   options: { context?: TelegramNetworkErrorContext; allowMessageMatch?: boolean } = {},

--- a/extensions/telegram/src/send-message-text.ts
+++ b/extensions/telegram/src/send-message-text.ts
@@ -4,6 +4,7 @@ import { resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-chunking";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import type { ResolvedTelegramAccount } from "./accounts.js";
+import { createTelegramChunkDeliveryTracker } from "./chunk-delivery.js";
 import {
   markdownToTelegramChunks,
   splitTelegramHtmlChunks,
@@ -233,6 +234,14 @@ export function createTelegramTextSender(config: {
       hasInlineKeyboard: boolean;
     }) => {
       const messageId = resolveTelegramMessageIdOrThrow(params.result, context);
+      // Preserve Telegram's accepted identity before fallible observers run so
+      // partial errors retain every provider-visible delivery fact.
+      lastMessageId = String(messageId);
+      lastChatId = String(params.result?.chat?.id ?? chatId);
+      lastAcceptedParams = params.acceptedParams;
+      acceptedReplyToMessageId ??= resolveAcceptedReplyToMessageId(params.acceptedParams);
+      messageIds.push(lastMessageId);
+      sentChunkCount += 1;
       recordSentMessage(chatId, messageId, cfg);
       await reportDelivery(messageId, params.result?.chat?.id ?? chatId, {
         telegramDeliveredText: params.plainText,
@@ -249,12 +258,6 @@ export function createTelegramTextSender(config: {
         },
         params.finalPart,
       );
-      lastMessageId = String(messageId);
-      lastChatId = String(params.result?.chat?.id ?? chatId);
-      lastAcceptedParams = params.acceptedParams;
-      acceptedReplyToMessageId ??= resolveAcceptedReplyToMessageId(params.acceptedParams);
-      messageIds.push(lastMessageId);
-      sentChunkCount += 1;
     };
 
     const finish = (operation: string): TelegramSendResult => {
@@ -284,7 +287,21 @@ export function createTelegramTextSender(config: {
       };
     };
 
-    return { record, finish };
+    const partialDeliveryResult = () => {
+      const receipt = buildTelegramTextSendReceipt({
+        messageIds,
+        chatId: lastChatId,
+        messageThreadId: lastAcceptedParams?.message_thread_id,
+        replyToMessageId: acceptedReplyToMessageId,
+      });
+      return {
+        messageIds: [...messageIds],
+        ...(receipt ? { receipt } : {}),
+        visibleReplySent: true as const,
+      };
+    };
+
+    return { record, finish, partialDeliveryResult };
   };
 
   const sendTelegramTextChunks = async (
@@ -293,29 +310,37 @@ export function createTelegramTextSender(config: {
     options: { replyToAlreadyUsed?: boolean } = {},
   ): Promise<TelegramSendResult> => {
     const delivery = createTextDelivery(context);
+    const tracker = createTelegramChunkDeliveryTracker({
+      invalidate: () => opts.promptContextProjectionPlan?.cursor.invalidate(),
+      onRejected: (error) =>
+        logVerbose(
+          `telegram ${context} text chunk rejected; continuing: ${formatErrorMessage(error)}`,
+        ),
+      partialDeliveryResult: delivery.partialDeliveryResult,
+    });
     for (let index = 0; index < chunks.length; index += 1) {
       const chunk = chunks[index];
       if (!chunk) {
         continue;
       }
-      const { result: res, acceptedParams } = await sendTelegramTextChunk(
-        chunk,
-        buildTextParams(
-          index,
-          chunks.length,
-          index === chunks.length - 1,
-          options.replyToAlreadyUsed === true,
-        ),
-      );
       const finalPart = index === chunks.length - 1;
-      await delivery.record({
-        result: res,
-        acceptedParams,
-        plainText: chunk.plainText,
-        finalPart,
-        hasInlineKeyboard: finalPart && Boolean(replyMarkup),
-      });
+      await tracker.attempt(
+        () =>
+          sendTelegramTextChunk(
+            chunk,
+            buildTextParams(index, chunks.length, finalPart, options.replyToAlreadyUsed === true),
+          ),
+        ({ result, acceptedParams }) =>
+          delivery.record({
+            result,
+            acceptedParams,
+            plainText: chunk.plainText,
+            finalPart,
+            hasInlineKeyboard: finalPart && Boolean(replyMarkup),
+          }),
+      );
     }
+    tracker.finish();
     return delivery.finish("sendMessage");
   };
 
@@ -391,6 +416,14 @@ export function createTelegramTextSender(config: {
   ): Promise<TelegramSendResult> => {
     const richRawApi = getTelegramRichRawApi(api);
     const delivery = createTextDelivery(context);
+    const tracker = createTelegramChunkDeliveryTracker({
+      invalidate: () => opts.promptContextProjectionPlan?.cursor.invalidate(),
+      onRejected: (error) =>
+        logVerbose(
+          `telegram ${context} rich chunk rejected; continuing: ${formatErrorMessage(error)}`,
+        ),
+      partialDeliveryResult: delivery.partialDeliveryResult,
+    });
     for (let index = 0; index < chunks.length; index += 1) {
       const chunk = chunks[index];
       if (!chunk) {
@@ -442,7 +475,8 @@ export function createTelegramTextSender(config: {
           warn: (message) => sendLogger.warn(message),
         });
         if (!fallbackPlan) {
-          throw err;
+          tracker.reject(err);
+          continue;
         }
         const fallbackChunks = fallbackPlan.chunks;
         const fallbackReplyChunkCount = Math.max(chunks.length, fallbackChunks.length);
@@ -455,31 +489,34 @@ export function createTelegramTextSender(config: {
             index === chunks.length - 1 && fallbackIndex === fallbackChunks.length - 1,
             options.replyToAlreadyUsed === true,
           );
-          const plainResult = await sendTelegramTextChunk(
-            { plainText: fallbackText },
-            fallbackParams,
-          );
           const finalPart =
             index === chunks.length - 1 && fallbackIndex === fallbackChunks.length - 1;
-          await delivery.record({
-            result: plainResult.result,
-            acceptedParams: plainResult.acceptedParams,
-            plainText: fallbackText,
-            finalPart,
-            hasInlineKeyboard: finalPart && Boolean(replyMarkup),
-          });
+          await tracker.attempt(
+            () => sendTelegramTextChunk({ plainText: fallbackText }, fallbackParams),
+            ({ result: fallbackResult, acceptedParams: fallbackAcceptedParams }) =>
+              delivery.record({
+                result: fallbackResult,
+                acceptedParams: fallbackAcceptedParams,
+                plainText: fallbackText,
+                finalPart,
+                hasInlineKeyboard: finalPart && Boolean(replyMarkup),
+              }),
+          );
         }
         continue;
       }
       const finalPart = index === chunks.length - 1;
-      await delivery.record({
-        result,
-        acceptedParams: recordedParams,
-        plainText: chunk.plainText,
-        finalPart,
-        hasInlineKeyboard: finalPart && Boolean(replyMarkup),
-      });
+      await tracker.recordAccepted(result, (acceptedResult) =>
+        delivery.record({
+          result: acceptedResult,
+          acceptedParams: recordedParams,
+          plainText: chunk.plainText,
+          finalPart,
+          hasInlineKeyboard: finalPart && Boolean(replyMarkup),
+        }),
+      );
     }
+    tracker.finish();
     return delivery.finish("sendRichMessage");
   };
 

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1,6 +1,7 @@
 // Telegram tests cover send plugin behavior.
 import fs from "node:fs";
 import type { Bot } from "grammy";
+import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import {
   createPluginStateKeyedStoreForTests,
@@ -382,6 +383,10 @@ function createHtmlParseError(operation = "sendMessage"): Error {
   return new Error(
     `GrammyError: Call to '${operation}' failed! (400: Bad Request: can't parse entities: Can't find end of the entity)`,
   );
+}
+
+function createChunkRejection(message = "chunk content rejected"): Error {
+  return Object.assign(new Error(`400: Bad Request: ${message}`), { error_code: 400 });
 }
 
 function createQuoteNotFoundError(operation = "sendMessage"): Error {
@@ -1317,8 +1322,8 @@ describe("sendMessageTelegram", () => {
     );
   });
 
-  it("chunks long plain text when durable rich sends reject an invalid entity", async () => {
-    const text = `Status includes openai:owner@example.com ${"A".repeat(5000)}`;
+  it("continues rich plain-fallback chunks after a middle rejection", async () => {
+    const text = `Status includes openai:owner@example.com ${"A".repeat(8500)}`;
     const storePath = `/tmp/openclaw-telegram-projection-rich-fallback-${process.pid}-${Date.now()}.json`;
     const cursor = createTelegramPromptContextProjectionCursor({
       transcriptMessageId: "assistant-rich",
@@ -1326,41 +1331,52 @@ describe("sendMessageTelegram", () => {
     botRawApi.sendRichMessage.mockRejectedValueOnce(createRichEntityInvalidError("EMAIL"));
     botApi.sendMessage
       .mockResolvedValueOnce({ message_id: 47, chat: { id: "123" } })
-      .mockResolvedValueOnce({ message_id: 48, chat: { id: "123" } });
+      .mockRejectedValueOnce(createChunkRejection())
+      .mockResolvedValueOnce({ message_id: 49, chat: { id: "123" } });
 
-    const result = await sendMessageTelegram("123", text, {
-      cfg: {
-        channels: { telegram: { richMessages: true } },
-        session: { store: storePath },
-      },
-      token: "tok",
-      replyToMessageId: 100,
-      replyToIdSource: "implicit",
-      replyToMode: "first",
-      promptContextProjectionPlan: { cursor, finalPart: true },
-    });
+    let observed: unknown;
+    try {
+      await sendMessageTelegram("123", text, {
+        cfg: {
+          channels: { telegram: { richMessages: true } },
+          session: { store: storePath },
+        },
+        token: "tok",
+        replyToMessageId: 100,
+        replyToIdSource: "implicit",
+        replyToMode: "first",
+        promptContextProjectionPlan: { cursor, finalPart: true },
+      });
+    } catch (error) {
+      observed = error;
+    }
 
     expect(botRawApi.sendRichMessage).toHaveBeenCalledTimes(1);
-    expect(botApi.sendMessage).toHaveBeenCalledTimes(2);
+    expect(botApi.sendMessage).toHaveBeenCalledTimes(3);
     expect(sendMessageTexts(botApi.sendMessage).every((chunk) => chunk.length <= 4000)).toBe(true);
     for (const call of botApi.sendMessage.mock.calls) {
       expect(call[2]).toBeUndefined();
     }
-    expect(result.messageId).toBe("48");
+    expect(isChannelPartialDeliveryError(observed)).toBe(true);
+    if (!isChannelPartialDeliveryError(observed)) {
+      throw observed;
+    }
+    expect(observed.deliveryResult.messageIds).toEqual(["47", "49"]);
     const cache = createTelegramMessageCache({
       scope: resolveTelegramMessageCacheScope(storePath),
     });
     const first = await cache.get({ accountId: "default", chatId: "123", messageId: "47" });
-    const second = await cache.get({ accountId: "default", chatId: "123", messageId: "48" });
-    expect([first?.promptContextProjectionMarker, second?.promptContextProjectionMarker]).toEqual([
+    const third = await cache.get({ accountId: "default", chatId: "123", messageId: "49" });
+    expect([first?.promptContextProjectionMarker, third?.promptContextProjectionMarker]).toEqual([
       {
         kind: "valid",
         projection: { ...cursor.source, partIndex: 0, finalPart: false },
       },
-      { kind: "valid", projection: { ...cursor.source, partIndex: 1, finalPart: true } },
+      { kind: "valid", projection: { ...cursor.source, partIndex: 1, finalPart: false } },
     ]);
     expect(cursor.nextPartIndex).toBe(2);
-    expect(result.receipt?.platformMessageIds).toEqual(["47", "48"]);
+    expect(cursor.complete).toBe(false);
+    expect(observed.deliveryResult.receipt?.platformMessageIds).toEqual(["47", "49"]);
   });
 
   it("chunks rich paragraph output at Telegram's block limit", async () => {
@@ -1761,40 +1777,104 @@ describe("sendMessageTelegram", () => {
     );
   });
 
-  it("reports the first Telegram chunk before a later chunk fails", async () => {
+  it("continues after a rejected middle chunk and reports incomplete delivery", async () => {
     const storePath = `/tmp/openclaw-telegram-projection-partial-${process.pid}-${Date.now()}.json`;
     const cursor = createTelegramPromptContextProjectionCursor({
       transcriptMessageId: "assistant-partial",
     });
     botApi.sendMessage
       .mockResolvedValueOnce({ message_id: 54, chat: { id: "123" } })
-      .mockRejectedValueOnce(new Error("second chunk failed"));
+      .mockRejectedValueOnce(createChunkRejection())
+      .mockResolvedValueOnce({ message_id: 56, chat: { id: "123" } });
     const onDeliveryResult = vi.fn();
-    const markdown = `# Long\n\n${"**section** with _style_ and `code`\n".repeat(3000)}`;
+    const html = "A".repeat(9000);
 
-    await expect(
-      sendMessageTelegram("123", markdown, {
+    let observed: unknown;
+    try {
+      await sendMessageTelegram("123", html, {
         cfg: { session: { store: storePath } },
         token: "tok",
+        textMode: "html",
         onDeliveryResult,
         promptContextProjectionPlan: { cursor, finalPart: true },
-      }),
-    ).rejects.toThrow("second chunk failed");
+      });
+    } catch (error) {
+      observed = error;
+    }
 
-    expect(onDeliveryResult.mock.calls.map((call) => call[0]?.messageId)).toEqual(["54"]);
-    const cached = await createTelegramMessageCache({
+    expect(isChannelPartialDeliveryError(observed)).toBe(true);
+    if (!isChannelPartialDeliveryError(observed)) {
+      throw observed;
+    }
+    expect(botApi.sendMessage).toHaveBeenCalledTimes(3);
+    expect(onDeliveryResult.mock.calls.map((call) => call[0]?.messageId)).toEqual(["54", "56"]);
+    expect(observed.deliveryResult.messageIds).toEqual(["54", "56"]);
+    const cache = createTelegramMessageCache({
       scope: resolveTelegramMessageCacheScope(storePath),
-    }).get({ accountId: "default", chatId: "123", messageId: "54" });
-    expect(cached?.promptContextProjectionMarker).toEqual({
-      kind: "valid",
-      projection: {
-        transcriptMessageId: "assistant-partial",
-        partIndex: 0,
-        finalPart: false,
-      },
     });
-    expect(cursor.nextPartIndex).toBe(1);
+    const cached = await Promise.all(
+      [54, 56].map((messageId) =>
+        cache.get({ accountId: "default", chatId: "123", messageId: String(messageId) }),
+      ),
+    );
+    expect(cached.map((node) => node?.promptContextProjectionMarker)).toEqual([
+      {
+        kind: "valid",
+        projection: { transcriptMessageId: "assistant-partial", partIndex: 0, finalPart: false },
+      },
+      {
+        kind: "valid",
+        projection: { transcriptMessageId: "assistant-partial", partIndex: 1, finalPart: false },
+      },
+    ]);
+    expect(cursor.nextPartIndex).toBe(2);
     expect(cursor.complete).toBe(false);
+  });
+
+  it("fails when every Telegram chunk is rejected", async () => {
+    const rejection = createChunkRejection();
+    botApi.sendMessage.mockRejectedValue(rejection);
+
+    await expect(
+      sendMessageTelegram("123", "A".repeat(9000), {
+        cfg: TELEGRAM_TEST_CFG,
+        token: "tok",
+        textMode: "html",
+      }),
+    ).rejects.toBe(rejection);
+
+    expect(botApi.sendMessage).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not continue after accepted-send bookkeeping fails", async () => {
+    botApi.sendMessage
+      .mockResolvedValueOnce({ message_id: 54, chat: { id: "123" } })
+      .mockResolvedValueOnce({ message_id: 55, chat: { id: "123" } });
+    const onDeliveryResult = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("delivery observer failed"));
+
+    let observed: unknown;
+    try {
+      await sendMessageTelegram("123", "A".repeat(9000), {
+        cfg: TELEGRAM_TEST_CFG,
+        token: "tok",
+        textMode: "html",
+        onDeliveryResult,
+      });
+    } catch (error) {
+      observed = error;
+    }
+
+    expect(isChannelPartialDeliveryError(observed)).toBe(true);
+    if (!isChannelPartialDeliveryError(observed)) {
+      throw observed;
+    }
+    expect(observed.deliveryResult.messageIds).toEqual(["54", "55"]);
+    expect(observed.deliveryResult.receipt?.platformMessageIds).toEqual(["54", "55"]);
+    expect(botApi.sendMessage).toHaveBeenCalledTimes(2);
+    expect(onDeliveryResult).toHaveBeenCalledTimes(2);
   });
 
   it("chunks long inline markdown through the HTML text path", async () => {


### PR DESCRIPTION
Closes #99693

## What problem this solves

Telegram serially aborted the rest of a long reply after one chunk failed. Users received a silently truncated answer. Current main and the latest release both retained this behavior in durable text, rich-to-plain fallback, and streamed reply paths.

## Fix

- Continue only after a failure known to be unsent: a pre-connect failure or structured Telegram `400` rejection.
- Stop on auth, rate-limit, server, route/thread, and ambiguous transport failures.
- Keep send failures separate from message-ID resolution, sent-cache, delivery callbacks, and prompt-context recording.
- Invalidate incomplete prompt projection before later chunks are recorded.
- Drain later chunks, then surface accepted gaps as `ChannelPartialDeliveryError` with accepted message IDs and receipt.
- Apply one contract to durable text, rich plain-fallback, and streamed replies.
- Keep first-chunk reply and button state local to each reply payload.
- Capture accepted durable and streamed message IDs before fallible bookkeeping.

## Product impact

A rejected middle chunk no longer deletes the whole reply tail. Complete failure still fails. Partial delivery remains explicitly incomplete instead of being reported as success. No config or default changes.

## Evidence

- Focused Telegram suite: 3 files, 307 tests passed.
- Targeted Oxlint passed.
- Oxfmt check passed.
- `git diff --check` passed.
- Fault-injected coverage proves middle-`400` continuation, all-rejected failure, projection invalidation, accepted-message receipts, post-send bookkeeping failure, rich fallback, and streamed parity.

### Real Telegram user proof

Exact head `a36dd2c8a4d135fc3e89eb5bf79587217f3acc6b`; real Telegram DM driven by the Telegram E2E userbot with a mock model provider:

```json
{
  "recordingComplete": true,
  "mockProviderRequests": 1,
  "pendingUpdatesBefore": 0,
  "pendingUpdatesAfter": 0,
  "sutMessages": 5,
  "messageTextLengths": [19, 4000, 321, 4000, 318],
  "startMarkerObserved": true,
  "middleMarkerObserved": true,
  "endMarkerObserved": true
}
```

The live run proves the rewritten head delivers the complete long-message path through Telegram. The deterministic Telegram API fault tests provide the rejected-middle proof that a live Telegram chat cannot safely force on one selected chunk.

## Review notes

The original branch was rewritten on current main around the shared delivery owner. Contributor credit remains in the commit trailer. Production delta: +206/-53; tests: +273/-48. The production growth establishes one explicit partial-delivery owner shared by four physical send loops and removes their divergent failure policy.
