### PR TITLE
fix(voice-call): keep paced telephony audio on cadence instead of drifting late

### DIFF
--- a/extensions/voice-call/src/webhook/realtime-audio-pacer.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-audio-pacer.test.ts
@@ -41,9 +41,78 @@ function inspectQueue(pacer: RealtimeAudioPacer): { length: number; head: number
   return { length: state.queue.length, head: state.queueHead };
 }
 
+/**
+ * Drives the pacer through a scheduler that always fires `overheadMs` late, which is how
+ * send cost and event-loop latency show up in a real call. Returns the simulated wall clock
+ * once every queued frame has been sent.
+ */
+function runPacedFrames(params: { frameCount: number; overheadMs: number }): {
+  delaysMs: number[];
+  elapsedMs: number;
+  sentFrames: number;
+} {
+  let clockMs = 0;
+  const pending: Array<{ delayMs: number; fn: () => void }> = [];
+  const delaysMs: number[] = [];
+  const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => clockMs);
+  const timeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+    fn: () => void,
+    delayMs?: number,
+  ) => {
+    pending.push({ delayMs: delayMs ?? 0, fn });
+    delaysMs.push(delayMs ?? 0);
+    return 1 as unknown as ReturnType<typeof setTimeout>;
+  }) as unknown as typeof setTimeout);
+
+  let sentFrames = 0;
+  try {
+    const pacer = new RealtimeAudioPacer({
+      serializer: createCompactSerializer(),
+      send: () => {
+        sentFrames += 1;
+        return true;
+      },
+    });
+    pacer.sendAudio(createSequencedAudio(params.frameCount));
+    for (let guard = 0; pending.length > 0 && guard < params.frameCount * 4; guard += 1) {
+      const next = pending.shift();
+      if (!next) {
+        break;
+      }
+      // A timer never fires early; model the fixed lateness a real event loop adds.
+      clockMs += next.delayMs + params.overheadMs;
+      next.fn();
+    }
+  } finally {
+    timeoutSpy.mockRestore();
+    nowSpy.mockRestore();
+  }
+  return { delaysMs, elapsedMs: clockMs, sentFrames };
+}
+
 describe("RealtimeAudioPacer", () => {
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it("holds telephony cadence when each paced send fires late", () => {
+    const frameCount = 100;
+    const overheadMs = 3;
+    const { elapsedMs, sentFrames } = runPacedFrames({ frameCount, overheadMs });
+    // The first frame goes out immediately, so only the remaining frames are paced.
+    const idealMs = (frameCount - 1) * 20;
+
+    expect(sentFrames).toBe(frameCount);
+    // Relative rescheduling adds `overheadMs` to every frame and drifts ~15% over this run.
+    expect(elapsedMs).toBeLessThanOrEqual(idealMs + 50);
+  });
+
+  it("does not burst-send to catch up after a stall beyond the pacing window", () => {
+    const { delaysMs, sentFrames } = runPacedFrames({ frameCount: 20, overheadMs: 500 });
+
+    expect(sentFrames).toBe(20);
+    // A long stall must reset the deadline instead of collapsing later frames to zero delay.
+    expect(delaysMs.filter((delayMs) => delayMs === 0)).toHaveLength(0);
   });
 
   it("paces realtime audio as 20ms telephony frames before marks (Twilio shape)", async () => {

--- a/extensions/voice-call/src/webhook/realtime-audio-pacer.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-audio-pacer.test.ts
@@ -109,6 +109,29 @@ function runPacedFrames(params: { frameCount: number; overheadMs: number }): {
   return { delaysMs, elapsedMs: clockMs, sentFrames };
 }
 
+function capturePacingDelays(run: (advanceTime: (durationMs: number) => void) => void): number[] {
+  let nowMs = 0;
+  const delaysMs: number[] = [];
+  const nowSpy = vi.spyOn(performance, "now").mockImplementation(() => nowMs);
+  const timeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+    _: () => void,
+    delayMs?: number,
+  ) => {
+    delaysMs.push(delayMs ?? 0);
+    return 1 as unknown as ReturnType<typeof setTimeout>;
+  }) as unknown as typeof setTimeout);
+
+  try {
+    run((durationMs) => {
+      nowMs += durationMs;
+    });
+  } finally {
+    timeoutSpy.mockRestore();
+    nowSpy.mockRestore();
+  }
+  return delaysMs;
+}
+
 describe("RealtimeAudioPacer", () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -124,6 +147,37 @@ describe("RealtimeAudioPacer", () => {
     expect(sentFrames).toBe(frameCount);
     // Relative rescheduling adds `overheadMs` to every frame and drifts ~15% over this run.
     expect(elapsedMs).toBeLessThanOrEqual(idealMs + 50);
+  });
+
+  it("subtracts synchronous send work from the first paced delay", () => {
+    const delaysMs = capturePacingDelays((advanceTime) => {
+      const pacer = new RealtimeAudioPacer({
+        serializer: createCompactSerializer(),
+        send: () => {
+          advanceTime(5);
+          return true;
+        },
+      });
+
+      pacer.sendAudio(Buffer.alloc(320));
+    });
+
+    expect(delaysMs).toEqual([15]);
+  });
+
+  it("starts a fresh cadence after a successful terminal send", () => {
+    const delaysMs = capturePacingDelays((advanceTime) => {
+      const pacer = new RealtimeAudioPacer({
+        serializer: createCompactSerializer(),
+        send: () => true,
+      });
+
+      pacer.sendAudio(Buffer.alloc(160));
+      advanceTime(40);
+      pacer.sendAudio(Buffer.alloc(320));
+    });
+
+    expect(delaysMs).toEqual([20]);
   });
 
   it("does not burst-send to catch up after a stall beyond the pacing window", () => {

--- a/extensions/voice-call/src/webhook/realtime-audio-pacer.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-audio-pacer.test.ts
@@ -36,6 +36,25 @@ function createSequencedAudio(frameCount: number): Buffer {
   return audio;
 }
 
+/**
+ * The pacer schedules against `performance.now()`, which vitest does not fake by default.
+ * Fake it alongside the timers so paced sends and the fake clock stay in one time domain.
+ */
+function useTelephonyFakeTimers(): void {
+  vi.useFakeTimers({
+    toFake: [
+      "setTimeout",
+      "clearTimeout",
+      "setInterval",
+      "clearInterval",
+      "setImmediate",
+      "clearImmediate",
+      "Date",
+      "performance",
+    ],
+  });
+}
+
 function inspectQueue(pacer: RealtimeAudioPacer): { length: number; head: number } {
   const state = pacer as unknown as { queue: unknown[]; queueHead: number };
   return { length: state.queue.length, head: state.queueHead };
@@ -54,7 +73,7 @@ function runPacedFrames(params: { frameCount: number; overheadMs: number }): {
   let clockMs = 0;
   const pending: Array<{ delayMs: number; fn: () => void }> = [];
   const delaysMs: number[] = [];
-  const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => clockMs);
+  const nowSpy = vi.spyOn(performance, "now").mockImplementation(() => clockMs);
   const timeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
     fn: () => void,
     delayMs?: number,
@@ -116,7 +135,7 @@ describe("RealtimeAudioPacer", () => {
   });
 
   it("paces realtime audio as 20ms telephony frames before marks (Twilio shape)", async () => {
-    vi.useFakeTimers();
+    useTelephonyFakeTimers();
     const sent: unknown[] = [];
     const pacer = new RealtimeAudioPacer({
       serializer: createTwilioSerializer("MZ-test"),
@@ -149,7 +168,7 @@ describe("RealtimeAudioPacer", () => {
   });
 
   it("clears queued audio immediately (Twilio shape)", async () => {
-    vi.useFakeTimers();
+    useTelephonyFakeTimers();
     const sent: unknown[] = [];
     const pacer = new RealtimeAudioPacer({
       serializer: createTwilioSerializer("MZ-test"),
@@ -168,7 +187,7 @@ describe("RealtimeAudioPacer", () => {
   });
 
   it("stops instead of buffering unbounded realtime audio", async () => {
-    vi.useFakeTimers();
+    useTelephonyFakeTimers();
     const sent: unknown[] = [];
     const onBackpressure = vi.fn();
     const pacer = new RealtimeAudioPacer({
@@ -190,7 +209,7 @@ describe("RealtimeAudioPacer", () => {
   });
 
   it("paces audio in Telnyx envelope shape (no streamSid)", async () => {
-    vi.useFakeTimers();
+    useTelephonyFakeTimers();
     const sent: unknown[] = [];
     const pacer = new RealtimeAudioPacer({
       serializer: createTelnyxSerializer(),
@@ -211,7 +230,7 @@ describe("RealtimeAudioPacer", () => {
   });
 
   it("drains the full default audio backlog in order and resets queue storage", async () => {
-    vi.useFakeTimers();
+    useTelephonyFakeTimers();
     const frameCount = 6_000;
     const sentFrames: number[] = [];
     const sentMarks: string[] = [];
@@ -238,7 +257,7 @@ describe("RealtimeAudioPacer", () => {
   });
 
   it("compacts a long queue while preserving pending bytes through clear", async () => {
-    vi.useFakeTimers();
+    useTelephonyFakeTimers();
     const frameCount = 800;
     const sent: string[] = [];
     const pacer = new RealtimeAudioPacer({

--- a/extensions/voice-call/src/webhook/realtime-audio-pacer.ts
+++ b/extensions/voice-call/src/webhook/realtime-audio-pacer.ts
@@ -3,6 +3,9 @@
 const TELEPHONY_SAMPLE_RATE = 8_000;
 const TELEPHONY_CHUNK_BYTES = 160;
 const TELEPHONY_CHUNK_MS = 20;
+// Beyond this much clock movement the stream already underran, or the wall clock jumped;
+// restart the cadence from now instead of firing a catch-up burst the carrier would drop.
+const MAX_PACING_CATCHUP_MS = 100;
 const DEFAULT_MAX_QUEUED_AUDIO_BYTES = TELEPHONY_SAMPLE_RATE * 120;
 const QUEUE_COMPACT_HEAD_THRESHOLD = 256;
 
@@ -35,6 +38,8 @@ export class RealtimeAudioPacer {
   private timer: ReturnType<typeof setTimeout> | null = null;
   private queuedAudioBytes = 0;
   private closed = false;
+  /** Wall time the next audio frame is due, so pacing cannot drift late frame by frame. */
+  private nextSendDeadlineMs: number | null = null;
 
   constructor(
     private readonly params: {
@@ -151,6 +156,9 @@ export class RealtimeAudioPacer {
   private resetQueue(): void {
     this.queue.length = 0;
     this.queueHead = 0;
+    // Nothing is pending, so the next audio starts a fresh cadence rather than
+    // inheriting a deadline from the previous utterance.
+    this.nextSendDeadlineMs = null;
   }
 
   /** Send one queued item and schedule the next send based on audio duration. */
@@ -169,7 +177,21 @@ export class RealtimeAudioPacer {
     if (item.type === "audio") {
       this.queuedAudioBytes = Math.max(0, this.queuedAudioBytes - item.chunk.length);
       sent = this.params.send(this.params.serializer.media(item.chunk.toString("base64")));
-      delayMs = item.durationMs || TELEPHONY_CHUNK_MS;
+      // Schedule against a running deadline instead of sleeping a full frame after each
+      // send; a relative sleep adds send and event-loop cost to every frame, and that
+      // underfeed accumulates into carrier jitter-buffer concealment.
+      const frameDurationMs = item.durationMs || TELEPHONY_CHUNK_MS;
+      const nowMs = Date.now();
+      // Read the same clock the scheduler runs on, and drop the deadline whenever it is
+      // no longer meaningful: a long stall, or a wall-clock jump in either direction.
+      if (
+        this.nextSendDeadlineMs === null ||
+        Math.abs(nowMs - this.nextSendDeadlineMs) > MAX_PACING_CATCHUP_MS
+      ) {
+        this.nextSendDeadlineMs = nowMs;
+      }
+      this.nextSendDeadlineMs += frameDurationMs;
+      delayMs = Math.max(0, this.nextSendDeadlineMs - nowMs);
     } else {
       sent = this.params.send(this.params.serializer.mark(item.name));
     }

--- a/extensions/voice-call/src/webhook/realtime-audio-pacer.ts
+++ b/extensions/voice-call/src/webhook/realtime-audio-pacer.ts
@@ -3,8 +3,8 @@
 const TELEPHONY_SAMPLE_RATE = 8_000;
 const TELEPHONY_CHUNK_BYTES = 160;
 const TELEPHONY_CHUNK_MS = 20;
-// Beyond this much clock movement the stream already underran, or the wall clock jumped;
-// restart the cadence from now instead of firing a catch-up burst the carrier would drop.
+// Past this much lateness the stream already underran; restart the cadence from now
+// instead of firing a catch-up burst the carrier jitter buffer would drop.
 const MAX_PACING_CATCHUP_MS = 100;
 const DEFAULT_MAX_QUEUED_AUDIO_BYTES = TELEPHONY_SAMPLE_RATE * 120;
 const QUEUE_COMPACT_HEAD_THRESHOLD = 256;
@@ -38,7 +38,7 @@ export class RealtimeAudioPacer {
   private timer: ReturnType<typeof setTimeout> | null = null;
   private queuedAudioBytes = 0;
   private closed = false;
-  /** Wall time the next audio frame is due, so pacing cannot drift late frame by frame. */
+  /** Monotonic time the next audio frame is due, so pacing cannot drift late frame by frame. */
   private nextSendDeadlineMs: number | null = null;
 
   constructor(
@@ -181,12 +181,15 @@ export class RealtimeAudioPacer {
       // send; a relative sleep adds send and event-loop cost to every frame, and that
       // underfeed accumulates into carrier jitter-buffer concealment.
       const frameDurationMs = item.durationMs || TELEPHONY_CHUNK_MS;
-      const nowMs = Date.now();
-      // Read the same clock the scheduler runs on, and drop the deadline whenever it is
-      // no longer meaningful: a long stall, or a wall-clock jump in either direction.
+      // Monotonic clock: `setTimeout` schedules against libuv's monotonic time, so pacing
+      // must use the same domain. A wall-clock source would let an NTP correction distort
+      // the cadence and reintroduce the artifacts this pacing exists to prevent.
+      const nowMs = performance.now();
+      // Drop the deadline once it is no longer meaningful, i.e. after a stall longer than
+      // the pacing window.
       if (
         this.nextSendDeadlineMs === null ||
-        Math.abs(nowMs - this.nextSendDeadlineMs) > MAX_PACING_CATCHUP_MS
+        nowMs - this.nextSendDeadlineMs > MAX_PACING_CATCHUP_MS
       ) {
         this.nextSendDeadlineMs = nowMs;
       }

--- a/extensions/voice-call/src/webhook/realtime-audio-pacer.ts
+++ b/extensions/voice-call/src/webhook/realtime-audio-pacer.ts
@@ -176,7 +176,6 @@ export class RealtimeAudioPacer {
     let sent;
     if (item.type === "audio") {
       this.queuedAudioBytes = Math.max(0, this.queuedAudioBytes - item.chunk.length);
-      sent = this.params.send(this.params.serializer.media(item.chunk.toString("base64")));
       // Schedule against a running deadline instead of sleeping a full frame after each
       // send; a relative sleep adds send and event-loop cost to every frame, and that
       // underfeed accumulates into carrier jitter-buffer concealment.
@@ -184,17 +183,19 @@ export class RealtimeAudioPacer {
       // Monotonic clock: `setTimeout` schedules against libuv's monotonic time, so pacing
       // must use the same domain. A wall-clock source would let an NTP correction distort
       // the cadence and reintroduce the artifacts this pacing exists to prevent.
-      const nowMs = performance.now();
+      const beforeSendMs = performance.now();
       // Drop the deadline once it is no longer meaningful, i.e. after a stall longer than
       // the pacing window.
       if (
         this.nextSendDeadlineMs === null ||
-        nowMs - this.nextSendDeadlineMs > MAX_PACING_CATCHUP_MS
+        beforeSendMs - this.nextSendDeadlineMs > MAX_PACING_CATCHUP_MS
       ) {
-        this.nextSendDeadlineMs = nowMs;
+        this.nextSendDeadlineMs = beforeSendMs;
       }
       this.nextSendDeadlineMs += frameDurationMs;
-      delayMs = Math.max(0, this.nextSendDeadlineMs - nowMs);
+      sent = this.params.send(this.params.serializer.media(item.chunk.toString("base64")));
+      // Synchronous serialization and sending consume part of this frame's pacing window.
+      delayMs = Math.max(0, this.nextSendDeadlineMs - performance.now());
     } else {
       sent = this.params.send(this.params.serializer.mark(item.name));
     }
@@ -204,8 +205,12 @@ export class RealtimeAudioPacer {
       this.queuedAudioBytes = 0;
       return;
     }
-    if (this.pendingQueueSize > 0) {
-      this.timer = setTimeout(() => this.pump(), delayMs);
+    if (this.pendingQueueSize === 0) {
+      // No timer can consume this deadline after the terminal send; a later delta must
+      // begin a fresh cadence rather than treating the completed utterance as overdue.
+      this.nextSendDeadlineMs = null;
+      return;
     }
+    this.timer = setTimeout(() => this.pump(), delayMs);
   }
 }


### PR DESCRIPTION
Fixes #119070

## What Problem This Solves

Realtime voice-call audio was paced from a deadline sampled after synchronous serializer/WebSocket work. The first wait of an utterance therefore included that work plus a whole 20ms frame, which can underfeed the carrier stream. A completed utterance could also retain an unused deadline and make a later delta schedule a catch-up frame too early.

## Why This Change Was Made

`RealtimeAudioPacer` is the shared cadence owner for Twilio and Telnyx media. It now establishes or resets the monotonic deadline before serializing/sending an audio frame, then subtracts a fresh post-send `performance.now()` reading from that deadline. After a successful terminal send it clears the deadline, so a future delta always establishes fresh cadence.

No framing, queue limits, backpressure, mark ordering, or provider serializer behavior changed.

## User Impact

Synchronous send work no longer adds a full pacing interval at the start of each utterance, and a short pause after a drained utterance cannot produce a zero-delay successor frame. This preserves the intended 20ms telephony cadence for both carrier adapters.

## Evidence

Head: [`fb576f635c056a706eb5e879f26711dfcd62cf12`](https://github.com/MoerAI/openclaw/commit/fb576f635c056a706eb5e879f26711dfcd62cf12)

- RED before the production edit: a synchronous 5ms send scheduled 20ms instead of 15ms; a two-frame delta 40ms after a successful terminal frame scheduled 0ms instead of 20ms.
- GREEN after the edit: `node scripts/run-vitest.mjs extensions/voice-call/src/webhook/realtime-audio-pacer.test.ts` - 10 passed, including the two focused lifecycle regressions.
- Real-timer send-boundary trace of the actual pacer on this head, with 5ms synchronous work in each `send`: 6 frames; intervals `[20.477, 21.185, 20.196, 18.839, 20.595]`ms; mean `20.258`ms.
- `node scripts/test-voicecall-closedloop.mjs` - passed (the selected voice media-stream slice: 19 passed).
- Targeted `oxfmt --check` and oxlint on both changed files passed.
- The `tsgo:extensions` and `tsgo:extensions:test` target configs, run through the pinned native compiler, failed only in unrelated extension files (`onepassword`, `policy`, `vault`, and `line`); neither changed path was reported.
- Full `node scripts/build-all.mjs` is externally blocked before build work: its pnpm dependency-status preflight retries npm registry downloads and aborts with `TimeoutError: The operation was aborted due to timeout`.
- Final isolated autoreview: clean, no accepted/actionable findings.

AI-assisted; reviewed and understood every changed line.



## Independent Live Twilio Behavior Proof

Independent validator @DougButdorf reproduced the defect on OpenClaw 2026.7.2-beta.7 with the official voice-call plugin, Twilio bidirectional Media Streams, OpenAI Realtime, and Linux x64, then deployed this branch commit `fb576f635c`. The same real-call path changed from rapid-fire/chopped first audio after blocking turns to continuous audio without rapid-fire delivery; the queue-head optimization alone did not improve the caller experience, isolating the relative 20 ms pacing boundary. Provider dual-channel recordings localized the original fragmentation to outbound assistant audio, while the caller channel remained clean. Sanitized evidence and methodology: https://github.com/openclaw/openclaw/pull/119086#issuecomment-5249371897

Risk proof (`merge-risk: message-delivery`): this live Twilio call exercised the actual outbound carrier stream after the fix and observed no rapid-fire burst or chopped first response.
