### PR TITLE
fix: keep gateway recovery working with unlabeled system plists

### DIFF
--- a/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
+++ b/.agents/skills/openclaw-live-updater/scripts/update-main.mjs
@@ -1036,18 +1036,25 @@ export function assertNoSystemLaunchDaemonOwnership(label, dependencies = {}) {
   }
   for (const entry of entries.filter((candidate) => candidate.endsWith(".plist")).toSorted()) {
     const plistPath = path.join(SYSTEM_LAUNCH_DAEMON_DIR, entry);
-    const result = run(
-      "/usr/bin/plutil",
-      ["-extract", "Label", "raw", "-o", "-", "--", plistPath],
-      { encoding: "utf8" },
-    );
+    const result = run("/usr/bin/plutil", ["-convert", "json", "-o", "-", "--", plistPath], {
+      encoding: "utf8",
+    });
     if (result.status !== 0) {
       throw new UpdateInvariantError(
         "gateway_system_launchdaemon_unverifiable",
         `could not inspect system LaunchDaemon plist ${plistPath}`,
       );
     }
-    if (String(result.stdout).trim() === label) {
+    let plist;
+    try {
+      plist = JSON.parse(String(result.stdout));
+    } catch {
+      throw new UpdateInvariantError(
+        "gateway_system_launchdaemon_unverifiable",
+        `could not inspect system LaunchDaemon plist ${plistPath}`,
+      );
+    }
+    if (plist?.Label === label) {
       throw new UpdateInvariantError(
         "gateway_system_launchdaemon_conflict",
         `System LaunchDaemon plist ${plistPath} already owns the managed Gateway label`,

--- a/src/daemon/launchd-system.test.ts
+++ b/src/daemon/launchd-system.test.ts
@@ -1,12 +1,17 @@
 // System launchd ownership tests cover loaded, installed, and unverifiable states.
+import { execFileSync } from "node:child_process";
+import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 
 const state = vi.hoisted(() => ({
   launchctl: { stdout: "", stderr: "Could not find service", code: 113 },
   files: new Map<string, string>(),
   accessErrors: new Map<string, string>(),
   readdirError: "",
-  plutilLabels: new Map<string, string>(),
+  plutilValues: new Map<string, unknown>(),
+  plutilErrors: new Map<string, string>(),
 }));
 
 function fsError(code: string, target: string): NodeJS.ErrnoException {
@@ -57,10 +62,10 @@ vi.mock("./launchd-exec.js", () => ({
 const execFileUtf8 = vi.hoisted(() =>
   vi.fn(async (_command: string, args: string[]) => {
     const target = args.at(-1) ?? "";
-    const label = state.plutilLabels.get(target);
-    return label
-      ? { stdout: `${label}\n`, stderr: "", code: 0 }
-      : { stdout: "", stderr: "missing Label", code: 1 };
+    const error = state.plutilErrors.get(target);
+    return error
+      ? { stdout: "", stderr: error, code: 1 }
+      : { stdout: JSON.stringify(state.plutilValues.get(target) ?? {}), stderr: "", code: 0 };
   }),
 );
 
@@ -72,6 +77,57 @@ import {
   renderSystemLaunchDaemonOwnershipShellProbe,
 } from "./launchd-system.js";
 
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const hostPlatform = process.platform;
+
+function runRenderedProbe(plistName: string, plistMode: "unlabeled" | "same-label" | "malformed") {
+  const root = tempDirs.make("openclaw-launchd-probe-");
+  const daemonsDir = path.join(root, "daemons");
+  const binDir = path.join(root, "bin");
+  mkdirSync(daemonsDir);
+  mkdirSync(binDir);
+  writeFileSync(path.join(daemonsDir, plistName), `${plistMode}\n`);
+  const plutilShim = path.join(binDir, "plutil");
+  writeFileSync(
+    plutilShim,
+    `#!/bin/sh
+mode=$1
+for last; do :; done
+fixture=$(cat "$last")
+if [ "$mode" = "-extract" ]; then
+  if [ "$fixture" = "same-label" ]; then
+    printf '%s\\n' "ai.openclaw.gateway"
+    exit 0
+  fi
+  printf '%s\\n' "No value at that key path: Label" >&2
+  exit 1
+fi
+if [ "$mode" = "-lint" ] && [ "$fixture" != "malformed" ]; then
+  exit 0
+fi
+exit 1
+`,
+    { mode: 0o700 },
+  );
+  const launchctlShim = path.join(binDir, "launchctl");
+  writeFileSync(
+    launchctlShim,
+    '#!/bin/sh\nprintf "%s\\n" "Could not find service" >&2\nexit 113\n',
+    { mode: 0o700 },
+  );
+  chmodSync(plutilShim, 0o700);
+  chmodSync(launchctlShim, 0o700);
+  const script = renderSystemLaunchDaemonOwnershipShellProbe("ai.openclaw.gateway")
+    .replaceAll("/Library/LaunchDaemons", daemonsDir)
+    .replaceAll("/usr/bin/plutil", plutilShim)
+    .concat('printf "conflict=%s\\n" "$openclaw_system_launchd_conflict"\n');
+  const shell = hostPlatform === "darwin" ? "/bin/sh" : "/bin/bash";
+  return execFileSync(shell, ["-c", script], {
+    encoding: "utf8",
+    env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
+  }).match(/^conflict=(.*)$/m)?.[1];
+}
+
 describe("system LaunchDaemon ownership", () => {
   const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
 
@@ -81,7 +137,8 @@ describe("system LaunchDaemon ownership", () => {
     state.files.clear();
     state.accessErrors.clear();
     state.readdirError = "";
-    state.plutilLabels.clear();
+    state.plutilValues.clear();
+    state.plutilErrors.clear();
     if (originalPlatformDescriptor) {
       Object.defineProperty(process, "platform", {
         ...originalPlatformDescriptor,
@@ -120,7 +177,7 @@ describe("system LaunchDaemon ownership", () => {
   it("detects the canonical unloaded plist by its structural Label", async () => {
     const plistPath = "/Library/LaunchDaemons/ai.openclaw.gateway.plist";
     state.files.set(plistPath, "bplist00-binary-payload");
-    state.plutilLabels.set(plistPath, "ai.openclaw.gateway");
+    state.plutilValues.set(plistPath, { Label: "ai.openclaw.gateway" });
 
     await expect(inspectSystemLaunchDaemonOwnership("ai.openclaw.gateway")).resolves.toEqual({
       status: "installed",
@@ -135,7 +192,7 @@ describe("system LaunchDaemon ownership", () => {
       plistPath,
       "<plist><dict><key>Label</key><string>ai.openclaw.gateway</string></dict></plist>",
     );
-    state.plutilLabels.set(plistPath, "ai.openclaw.gateway");
+    state.plutilValues.set(plistPath, { Label: "ai.openclaw.gateway" });
 
     const ownership = await inspectSystemLaunchDaemonOwnership("ai.openclaw.gateway");
 
@@ -149,7 +206,7 @@ describe("system LaunchDaemon ownership", () => {
       plistPath,
       "<plist><dict><key>EnvironmentVariables</key><dict><key>Label</key><string>nested</string></dict><key>Label</key><string>ai.openclaw.gateway</string></dict></plist>",
     );
-    state.plutilLabels.set(plistPath, "ai.openclaw.gateway");
+    state.plutilValues.set(plistPath, { Label: "ai.openclaw.gateway" });
 
     await expect(inspectSystemLaunchDaemonOwnership("ai.openclaw.gateway")).resolves.toMatchObject({
       status: "installed",
@@ -160,15 +217,14 @@ describe("system LaunchDaemon ownership", () => {
   it("uses native plutil for binary and non-XML plist formats", async () => {
     const plistPath = "/Library/LaunchDaemons/binary-openclaw.plist";
     state.files.set(plistPath, "bplist00-binary-payload");
-    state.plutilLabels.set(plistPath, "ai.openclaw.gateway");
+    state.plutilValues.set(plistPath, { Label: "ai.openclaw.gateway" });
 
     const ownership = await inspectSystemLaunchDaemonOwnership("ai.openclaw.gateway");
 
     expect(ownership).toMatchObject({ status: "installed", plistPath });
     expect(execFileUtf8).toHaveBeenCalledWith("/usr/bin/plutil", [
-      "-extract",
-      "Label",
-      "raw",
+      "-convert",
+      "json",
       "-o",
       "-",
       "--",
@@ -176,10 +232,39 @@ describe("system LaunchDaemon ownership", () => {
     ]);
   });
 
+  it("skips a valid plist without a string Label and detects a later owner", async () => {
+    const unrelated = "/Library/LaunchDaemons/com.google.keystone.daemon.plist";
+    const owner = "/Library/LaunchDaemons/vendor-openclaw.plist";
+    state.files.set(unrelated, "<plist><dict><key>RunAtLoad</key><true/></dict></plist>");
+    state.plutilValues.set(unrelated, { RunAtLoad: true });
+    state.files.set(owner, "<plist/>");
+    state.plutilValues.set(owner, { Label: "ai.openclaw.gateway" });
+
+    await expect(inspectSystemLaunchDaemonOwnership("ai.openclaw.gateway")).resolves.toEqual({
+      status: "installed",
+      serviceTarget: "system/ai.openclaw.gateway",
+      plistPath: owner,
+    });
+    expect(execFileUtf8).toHaveBeenCalledTimes(2);
+  });
+
+  it("treats a valid non-string Label as unable to own the gateway label", async () => {
+    const unrelated = "/Library/LaunchDaemons/com.vendor.numeric-label.plist";
+    state.files.set(unrelated, "<plist/>");
+    state.plutilValues.set(unrelated, { Label: 42 });
+
+    await expect(inspectSystemLaunchDaemonOwnership("ai.openclaw.gateway")).resolves.toEqual({
+      status: "absent",
+      serviceTarget: "system/ai.openclaw.gateway",
+    });
+    expect(execLaunchctl).toHaveBeenCalledTimes(2);
+  });
+
   it("fails closed on an unreadable noncanonical vendor plist", async () => {
     const unrelated = "/Library/LaunchDaemons/com.vendor.locked.plist";
     state.files.set(unrelated, "<plist/>");
     state.accessErrors.set(unrelated, "EACCES");
+    state.plutilErrors.set(unrelated, "Operation not permitted");
 
     await expect(inspectSystemLaunchDaemonOwnership("ai.openclaw.gateway")).resolves.toEqual({
       status: "unverifiable",
@@ -241,6 +326,9 @@ describe("system LaunchDaemon ownership", () => {
       '/usr/bin/plutil -extract Label raw -o - -- "$openclaw_system_launchd_plist"',
     );
     expect(script).toContain(
+      '/usr/bin/plutil -lint -- "$openclaw_system_launchd_plist" >/dev/null 2>&1',
+    );
+    expect(script).toContain(
       "/usr/bin/find \"$openclaw_system_launchd_dir\" -mindepth 1 -maxdepth 1 -name '*.plist' -print0",
     );
     expect(script).toContain("while IFS= read -r -d '' openclaw_system_launchd_plist");
@@ -250,5 +338,15 @@ describe("system LaunchDaemon ownership", () => {
       'if [ "$openclaw_system_launchd_plist_label" != "$openclaw_system_launchd_label" ]',
     );
     expect(script).not.toContain("|| true");
+  });
+
+  it("executes the rendered probe across unlabeled, same-label, and malformed plists", () => {
+    expect(runRenderedProbe("com.google.keystone.daemon.plist", "unlabeled")).toBe("");
+    expect(runRenderedProbe("vendor-openclaw.plist", "same-label")).toContain(
+      "vendor-openclaw.plist",
+    );
+    expect(runRenderedProbe("com.vendor.broken.plist", "malformed")).toContain(
+      "com.vendor.broken.plist",
+    );
   });
 });

--- a/src/daemon/launchd-system.ts
+++ b/src/daemon/launchd-system.ts
@@ -78,6 +78,8 @@ if [ -z "$openclaw_system_launchd_conflict" ]; then
             openclaw_system_launchd_conflict="$openclaw_system_launchd_plist"
             openclaw_system_launchd_detail="installed same-label system LaunchDaemon plist $openclaw_system_launchd_plist"
             break
+          elif /usr/bin/plutil -lint -- "$openclaw_system_launchd_plist" >/dev/null 2>&1; then
+            continue
           else
             openclaw_system_launchd_conflict="$openclaw_system_launchd_plist"
             openclaw_system_launchd_detail="could not inspect system LaunchDaemon plist $openclaw_system_launchd_plist: $openclaw_system_launchd_plist_label"
@@ -111,6 +113,7 @@ fi
 
 type LaunchDaemonPlistLabelResult =
   | { status: "ok"; label: string }
+  | { status: "unlabeled" }
   | { status: "missing" }
   | { status: "unverifiable"; detail: string };
 
@@ -118,18 +121,24 @@ type LaunchDaemonPlistLabelResult =
 export async function readLaunchDaemonPlistLabel(
   plistPath: string,
 ): Promise<LaunchDaemonPlistLabelResult> {
-  const extracted = await execFileUtf8(PLUTIL_PATH, [
-    "-extract",
-    "Label",
-    "raw",
+  const converted = await execFileUtf8(PLUTIL_PATH, [
+    "-convert",
+    "json",
     "-o",
     "-",
     "--",
     plistPath,
   ]);
-  const label = extracted.stdout.trim();
-  if (extracted.code === 0 && label) {
-    return { status: "ok", label };
+  if (converted.code === 0) {
+    try {
+      const plist = JSON.parse(converted.stdout) as { Label?: unknown } | null;
+      const label = plist?.Label;
+      return typeof label === "string" && label.length > 0
+        ? { status: "ok", label }
+        : { status: "unlabeled" };
+    } catch (error) {
+      return { status: "unverifiable", detail: formatUnknownError(error) };
+    }
   }
   try {
     await fs.access(plistPath);
@@ -141,7 +150,7 @@ export async function readLaunchDaemonPlistLabel(
   }
   return {
     status: "unverifiable",
-    detail: formatLaunchctlResultDetail(extracted) || "plutil did not return a Label",
+    detail: formatLaunchctlResultDetail(converted) || "plutil could not decode the plist",
   };
 }
 

--- a/test/scripts/openclaw-live-updater.test.ts
+++ b/test/scripts/openclaw-live-updater.test.ts
@@ -444,9 +444,11 @@ describe("openclaw live updater", () => {
           }
           return {
             status: 0,
-            stdout: args.at(-1)?.endsWith("openclaw-system.plist")
-              ? "ai.openclaw.gateway\n"
-              : "com.example.other\n",
+            stdout: JSON.stringify({
+              Label: args.at(-1)?.endsWith("openclaw-system.plist")
+                ? "ai.openclaw.gateway"
+                : "com.example.other",
+            }),
             stderr: "",
           };
         },
@@ -466,6 +468,43 @@ describe("openclaw live updater", () => {
       }),
     ).toThrow("system/ai.openclaw.gateway already owns the managed Gateway label");
     expect(calls).toHaveLength(2);
+  });
+
+  test("skips valid system LaunchDaemon plists without a string Label", () => {
+    const missing = { status: 113, stdout: "", stderr: "Could not find service" };
+    const calls: string[] = [];
+
+    expect(() =>
+      assertNoSystemLaunchDaemonOwnership("ai.openclaw.gateway", {
+        readdirSync: () => ["com.google.keystone.daemon.plist", "com.vendor.numeric-label.plist"],
+        spawnSync: (command: string, args: string[]) => {
+          calls.push([command, ...args].join(" "));
+          if (command === "/bin/launchctl") {
+            return missing;
+          }
+          return {
+            status: 0,
+            stdout: JSON.stringify(
+              args.at(-1)?.endsWith("numeric-label.plist") ? { Label: 42 } : { RunAtLoad: true },
+            ),
+            stderr: "",
+          };
+        },
+      }),
+    ).not.toThrow();
+    expect(calls.filter((call) => call.startsWith("/bin/launchctl print"))).toHaveLength(2);
+  });
+
+  test("fails closed when a system LaunchDaemon plist cannot be decoded", () => {
+    const missing = { status: 113, stdout: "", stderr: "Could not find service" };
+
+    expect(() =>
+      assertNoSystemLaunchDaemonOwnership("ai.openclaw.gateway", {
+        readdirSync: () => ["com.vendor.broken.plist"],
+        spawnSync: (command: string) =>
+          command === "/bin/launchctl" ? missing : { status: 0, stdout: "not json", stderr: "" },
+      }),
+    ).toThrow("could not inspect system LaunchDaemon plist");
   });
 
   test("audits raw file logs when RPC log retrieval is unavailable", () => {
@@ -2267,6 +2306,118 @@ console.log(JSON.stringify({ ok: true, channels: {} }));
       },
     });
     expect(JSON.stringify(formatted)).not.toContain("secret rollback");
+  });
+
+  test("restores an absent managed service past bootout exit 3 and an unlabeled vendor plist", () => {
+    const { root, mirror, seed } = makeFixture({ includeSeed: true });
+    mkdirSync(path.join(mirror, "node_modules"));
+    writeBuild(mirror);
+    writeFileSync(path.join(seed, "README.md"), "replacement recovery update\n");
+    git(seed, "add", "README.md");
+    git(seed, "commit", "-m", "replacement recovery update");
+    git(seed, "push");
+    const snapshot = path.join(root, "gateway-ancestor/dist/index.js");
+    const source = path.join(mirror, "dist/index.js");
+    const plistPath = path.join(root, "ai.openclaw.gateway.plist");
+    writeFileSync(plistPath, "plist\n", { mode: 0o600 });
+    const calls: string[] = [];
+    let bootoutCount = 0;
+    let serviceLoaded = true;
+    let deployedEntrypoint = snapshot;
+
+    const inspectGatewayDeployment = () => ({
+      configPath: path.join(root, "openclaw.json"),
+      entrypoint: deployedEntrypoint,
+      entrypointIndex: 1,
+      executable: process.execPath,
+      invocationPrefix: [deployedEntrypoint],
+      label: "ai.openclaw.gateway",
+      plistPath,
+      port: 18789,
+      runtime: process.execPath,
+    });
+    const runCommand = (command: string, args: string[]) => {
+      const call = [command, ...args].join(" ");
+      calls.push(call);
+      if (command === "pnpm" && args[0] === "build") {
+        writeBuild(mirror);
+      }
+      if (command === "/bin/launchctl" && args[0] === "bootout") {
+        bootoutCount += 1;
+        serviceLoaded = false;
+        if (bootoutCount === 2) {
+          throw new Error("Boot-out failed: 3: No such process");
+        }
+      }
+      if (command === "/bin/launchctl" && args[0] === "bootstrap") {
+        serviceLoaded = true;
+      }
+    };
+    const assertSystemOwnership = () =>
+      assertNoSystemLaunchDaemonOwnership("ai.openclaw.gateway", {
+        readdirSync: () => ["com.google.keystone.daemon.plist"],
+        spawnSync: (command: string) =>
+          command === "/bin/launchctl"
+            ? { status: 113, stdout: "", stderr: "Could not find service" }
+            : {
+                status: 0,
+                stdout: JSON.stringify({ RunAtLoad: true }),
+                stderr: "",
+              },
+      });
+
+    expect(() =>
+      maintainFixture(
+        { checkout: mirror, remote: "origin", lockPath: path.join(root, "maintenance.lock") },
+        {
+          runCommand,
+          assertNoSystemLaunchDaemonOwnership: assertSystemOwnership,
+          inspectGatewayDeployment,
+          isGatewayLoaded: () => serviceLoaded,
+          prepareGatewayEntrypointReplacement: () => ({
+            install() {
+              deployedEntrypoint = source;
+            },
+            restore() {
+              deployedEntrypoint = snapshot;
+            },
+            discard() {},
+          }),
+          proveGatewayStopped: () => ({
+            runtimeStatus: "stopped",
+            port: 18789,
+            portStatus: "free",
+            proofSource: "fixture",
+          }),
+          repointGatewayDeployment: (
+            _checkout: string,
+            deployment: { entrypoint: string; invocationPrefix: string[] },
+            replaceEntrypoint: (deployment: unknown, entrypoint: string) => void,
+          ) => {
+            replaceEntrypoint(deployment, source);
+            return {
+              changed: true,
+              ...deployment,
+              entrypoint: source,
+              invocationPrefix: [source],
+              previousEntrypoint: deployment.entrypoint,
+            };
+          },
+          verifyAndAuditGateway: () => {
+            throw new Error("replacement readiness failed");
+          },
+        },
+      ),
+    ).toThrow("replacement readiness failed");
+
+    const uid = process.getuid?.() ?? 501;
+    expect(serviceLoaded).toBe(true);
+    expect(deployedEntrypoint).toBe(snapshot);
+    expect(calls).toContain(`/bin/launchctl bootout gui/${uid}/ai.openclaw.gateway`);
+    expect(calls.filter((call) => call.includes("/bin/launchctl bootstrap"))).toEqual([
+      `/bin/launchctl bootstrap gui/${uid} ${plistPath}`,
+      `/bin/launchctl bootstrap gui/${uid} ${plistPath}`,
+    ]);
   });
 
   test("resumes suspension when system ownership appears before bootout", () => {


### PR DESCRIPTION
Related: #85133
Related: #117616

## What Problem This Solves

Fixes an issue where macOS gateway activation and live-update recovery could reject an unrelated, valid system LaunchDaemon plist that has no top-level `Label`. If the managed gateway was already stopped, the same false ownership failure could block both replacement activation and rollback bootstrap, leaving the LaunchAgent absent.

## Why This Change Was Made

The ownership checks now decode candidate plists structurally. A valid plist whose top-level `Label` is absent or non-string cannot own the gateway label and is skipped; an exact same-label plist still conflicts, while unreadable or malformed plists remain fail-closed. The canonical daemon classifier, detached shell probe, and standalone live updater use the same rule.

## User Impact

Gateway restart, repair, and exact-build live-update recovery can bootstrap the managed LaunchAgent on Macs with valid unlabeled vendor plists such as the observed Google Keystone daemon. Existing protection against loaded or installed same-label system daemons remains intact.

## Evidence

- Base: `12beeb7b29476d0ac96590e51bbc14fff63fbe60`.
- Red reproduction on unmodified main: the valid unlabeled Keystone plist caused `gateway_system_launchdaemon_unverifiable`; replacement recovery then ended with `Boot-out failed: 3: No such process` and `Gateway replacement failed and the previous managed service could not be restored`.
- Blacksmith Testbox `tbx_01kz5cgnj11eg90p1r4z5vnmqg`: 14 daemon ownership tests and 68 live-updater tests passed, including shell-probe classification and rollback after bootout exit 3.
- `pnpm check:changed` passed all selected lanes: format, guards, full `tsgo`, lint, and import-cycle analysis.
- Source-blind read-only host validation passed the live Keystone case plus same-label, malformed, non-string, and no-mutation controls.
- `autoreview --mode uncommitted`: clean, no accepted/actionable findings.

AI-assisted. I reviewed the implementation and validation results.
