### PR TITLE
perf(gateway): keep reload and recovery machinery off gateway cold start

### DIFF
--- a/src/cli/gateway-cli/lifecycle-import-boundary.test.ts
+++ b/src/cli/gateway-cli/lifecycle-import-boundary.test.ts
@@ -1,0 +1,37 @@
+// The run loop primes lifecycle.runtime.ts before the HTTP listener binds, so the
+// hub's re-exports decide how much module graph loads during gateway cold start.
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(import.meta.dirname, "../../..");
+
+function readSource(relativePath: string): string {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+describe("gateway lifecycle hub import boundaries", () => {
+  it("re-exports primed symbols from their defining modules instead of facades", () => {
+    const hub = readSource("src/cli/gateway-cli/lifecycle.runtime.ts");
+
+    // server-reload-handlers.ts also re-exports server-reload-hot.ts and
+    // server-reload-managed.ts, so routing through it loads the hot-reload and
+    // managed-reloader graphs before the gateway can accept a connection.
+    expect(hub).toContain('from "../../gateway/server-reload-contracts.js"');
+    expect(hub).not.toContain('from "../../gateway/server-reload-handlers.js"');
+
+    // main-session-restart-recovery.ts also re-exports its -runtime sibling,
+    // which the primed hub never calls.
+    expect(hub).toContain('from "../../agents/main-session-restart-recovery-marking.js"');
+    expect(hub).not.toContain('from "../../agents/main-session-restart-recovery.js"');
+  });
+
+  it("still primes the hub eagerly so signal handlers survive dist chunk rotation", () => {
+    const runLoop = readSource("src/cli/gateway-cli/run-loop.ts");
+    const eagerPrime = runLoop.indexOf("await loadGatewayLifecycleRuntimeModule()");
+    const signalInstall = runLoop.indexOf("process.on(");
+
+    expect(eagerPrime).toBeGreaterThan(-1);
+    expect(signalInstall).toBeGreaterThan(eagerPrime);
+  });
+});

--- a/src/cli/gateway-cli/lifecycle.runtime.ts
+++ b/src/cli/gateway-cli/lifecycle.runtime.ts
@@ -1,4 +1,7 @@
 // Lazy lifecycle runtime export hub used by gateway run-loop restart paths.
+// run-loop.ts primes this hub before the HTTP listener binds, so each re-export
+// must target the module that defines the symbol rather than a re-export facade;
+// a facade also evaluates its siblings and drags their graphs onto cold start.
 export {
   abortEmbeddedAgentRun,
   getActiveEmbeddedRunCount,
@@ -6,7 +9,7 @@ export {
   listActiveEmbeddedRunSessionKeys,
   waitForActiveEmbeddedRuns,
 } from "../../agents/embedded-agent-runner/runs.js";
-export { markRestartAbortedMainSessions } from "../../agents/main-session-restart-recovery.js";
+export { markRestartAbortedMainSessions } from "../../agents/main-session-restart-recovery-marking.js";
 export { getRuntimeConfig } from "../../config/config.js";
 export {
   respawnGatewayProcessForUpdate,
@@ -56,4 +59,4 @@ export {
 export { waitForActiveGatewayRootWork } from "../../process/gateway-work-admission.js";
 export { getInspectableActiveTaskRestartBlockers } from "../../tasks/task-registry.maintenance.js";
 export { reloadTaskRuntimeStateFromStore } from "../../tasks/runtime-internal.js";
-export { abortPendingChannelReloads } from "../../gateway/server-reload-handlers.js";
+export { abortPendingChannelReloads } from "../../gateway/server-reload-contracts.js";

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -244,7 +244,7 @@ vi.mock("../../agents/embedded-agent-runner/runs.js", () => ({
   waitForActiveEmbeddedRuns: (timeoutMs?: number) => waitForActiveEmbeddedRuns(timeoutMs),
 }));
 
-vi.mock("../../agents/main-session-restart-recovery.js", () => ({
+vi.mock("../../agents/main-session-restart-recovery-marking.js", () => ({
   markRestartAbortedMainSessions: (params: unknown) => markRestartAbortedMainSessions(params),
 }));
 
@@ -261,7 +261,7 @@ vi.mock("../../logging/logger.js", () => ({
   flushLogger: () => flushLogger(),
 }));
 
-vi.mock("../../gateway/server-reload-handlers.js", () => ({
+vi.mock("../../gateway/server-reload-contracts.js", () => ({
   abortPendingChannelReloads: () => abortPendingChannelReloads(),
 }));
 


### PR DESCRIPTION
Related: #119087
Related: #106680

AI-assisted.

## What Problem This Solves

Starting a gateway from cold does measurably more work than it needs to before it can accept its first connection. Operators on container platforms pay this on every cold start, where the gap between process start and `http server listening` decides whether a readiness probe passes or the platform kills and retries the container.

The gateway run loop deliberately primes `cli/gateway-cli/lifecycle.runtime.ts` before it installs signal handlers, so everything that hub re-exports is loaded before the listener binds. Two of those re-exports resolved through modules that only forward symbols onward, so priming the hub also evaluated the gateway hot-reload machinery, the managed config reloader, and the main-session recovery runtime — none of which the primed hub calls, and none of which are needed to start serving.

This is one of two contributors we isolated while investigating a ~2.5x gateway boot regression between 2026.7.1-beta.1 and 2026.7.2-beta.7 (#119087). **It does not resolve that regression** — this edge exists in 2026.7.1 too, and the regression's larger driver is the growth of the default startup plugin set, which overlaps #106680. What this change does is make the pre-bind window smaller on every release.

## Why This Change Was Made

Re-export each symbol from the module that defines it instead of from a forwarding module:

- `abortPendingChannelReloads` is a three-line generation bump defined in `gateway/server-reload-contracts.ts`. It was reached through `gateway/server-reload-handlers.ts`, which also re-exports `createGatewayReloadHandlers` (`server-reload-hot.ts`) and `startManagedGatewayConfigReloader` (`server-reload-managed.ts`). ESM evaluates the whole forwarding module, so a three-line function pulled both reload graphs onto cold start.
- `markRestartAbortedMainSessions` is defined in `agents/main-session-restart-recovery-marking.ts`. It was reached through `agents/main-session-restart-recovery.ts`, which also re-exports the `-runtime` sibling.

Both are re-export retargets, not copies: each resolves to the same module instance as before, so module-level state (`abortGeneration` / `currentReloadGeneration` in the reload contracts) stays shared and behavior is unchanged. The eager priming itself is untouched, so the dist chunk-hash-rotation protection it exists for still holds — the boundary test added here asserts the priming still happens before signal handlers are installed.

Both targets already have in-repo precedent as direct import sites: `gateway/server-reload-managed.ts` imports `abortPendingChannelReloads` from `server-reload-contracts.js`, and `gateway/server-startup-post-attach.ts` imports from `main-session-restart-recovery-marking.js`.

Non-goal: `server-reload-handlers.ts` is left in place as the reload surface for its remaining consumers. Retiring the forwarding modules entirely is a larger ownership decision and is not attempted here.

## User Impact

Less work between process start and the gateway accepting connections. No user-visible behavior change: same functions, same module instances, same state.

The hub's own static import closure, measured from source on this branch by walking the non-erased import/export graph (type-only edges dropped, `import()` treated as a boundary):

| | before | after |
|---|---:|---:|
| first-party modules statically reachable from the primed hub | 3,546 | **1,541** |
| bytes of those modules | 26.67 MiB | **10.85 MiB** |
| distinct external package specifiers reached | 52 | **24** |

That closure number is the hub in isolation; most of those modules are also reachable from other boot work, so it is an upper bound, not the boot saving. The honest boot-path figure comes from counting modules the process actually loads before `http server listening` on a 1-vCPU `node:24.18.0-bookworm-slim` container (ESM loader hook plus a `Module._load` wrapper for CommonJS), with the reload edge cut:

| | 2026.7.2-beta.7 | with the reload edge cut |
|---|---:|---:|
| modules loaded before `http server listening` | 5,204 | **5,160** (-44) |
| bytes loaded before listening | 39.86 MiB | **38.82 MiB** (-1.04 MiB) |
| modules loaded in the `starting...` -> `starting HTTP server...` window | 631 | **573** (-58) |
| bytes loaded in that window | 4.63 MiB | **3.42 MiB** (-1.21 MiB, **-26%**) |

**On wall-clock time this change is not separable from run-to-run noise on our bench.** Median time to listen was 11.1 s stock vs 10.0 s patched over 6 interleaved runs, but stock ranged 6.7-28.0 s, so we are not claiming that as a result. The defensible statement is the module census: about a quarter of the bytes loaded in the pre-bind hand-off window go away, and module counts are deterministic where these timings are not.

## Evidence

**Emitted chunk graph after `pnpm build` on this branch.** Walking static edges only (so `import()` is a boundary) from the built hub chunk `dist/cli/gateway-lifecycle.runtime.js`:

```
cli/gateway-lifecycle.runtime.js      674 chunks /  8.657 MiB
  not reachable   createGatewayReloadHandlers      (server-reload-hot)
  not reachable   startManagedGatewayConfigReloader (server-reload-managed)
  not reachable   recoverRestartAbortedMainSessions (recovery -runtime)
  REACHABLE       abortPendingChannelReloads        (still exported, as required)
```

The hub chunk's own import list now reads `from "../server-reload-contracts-*.js"` and `from "../main-session-restart-recovery-marking-*.js"`, and rolldown emitted `server-reload-contracts` as a **1-chunk, 2 KiB leaf** — so the leaf really is a leaf after bundling, not merged back into the reload machinery.

Same build, for scale: the forwarding chunks still exist for their lazy consumers, and their static closures are `server-reload-handlers` 1,407 chunks / 19.34 MiB and `main-session-restart-recovery` 588 chunks / 7.87 MiB. Adding the chunks those graphs would make statically reachable back onto the hub gives **1,424 chunks / 19.52 MiB**, i.e. this change takes **-750 chunks / -10.87 MiB** off the hub's eager chunk closure. (That pre-change figure is computed by unioning the facade graphs into the hub closure rather than by rebuilding with the old edge, so exact chunk boundaries could shift slightly on a real rebuild; the categorical result above — the machinery is not reachable — is measured directly.)



**Validation run locally on this branch (macOS, Node 24.16.0, pnpm 11.15.1):**

```
pnpm build         exit 0   total 15m 7.8s
                            check-cli-bootstrap-imports passed (1m 13.2s)
                            no [INEFFECTIVE_DYNAMIC_IMPORT] in build output
pnpm check         exit 0   tsgo typecheck (prod/scripts/test-root)
                            oxlint core + extensions + scripts
                            oxfmt --check: all 27,267 files correctly formatted
                            import cycles: 0 runtime value cycle(s)
                            all policy/preflight guards passed
pnpm test:changed  exit 0   5 Vitest shards, 23 files, 631 passed / 99 skipped
```

Targeted suites for the touched surface, all passing:

```
src/cli/gateway-cli/lifecycle-import-boundary.test.ts  +  run-loop.test.ts   56 passed
src/gateway/server-import-boundary.test.ts  +  server-startup-post-attach     74 passed
src/agents/main-session-restart-recovery.test.ts                             152 passed
src/gateway/server-reload-handlers.test.ts  +  .hot-reload-status.test.ts    213 passed
```

The new boundary test was confirmed non-vacuous: reverting both re-exports to the forwarding modules makes it fail with `expected ... to contain 'from "../../gateway/server-reload-contracts.js"'`, and restoring them makes it pass.

I did not run the full `pnpm test` locally — this checkout has 8,952 test files and no remote test box was available to me — so the full matrix is left to CI. One note in case it shows up: on a first `pnpm test:changed` run, while this machine was still busy with a concurrent build, `src/cli/help-exit.process.test.ts` failed because a `slow SQLite transaction lock wait` warning (`state.schema.ensure`, 2,209 ms) landed on stderr and that test asserts stderr is empty. It passes 25/25 in isolation and on a repeat run of the whole lane on an idle machine; the file has no reference to anything this PR touches. Flagging it as a load-sensitive test rather than something this PR caused.

Method notes:

- Boot benchmark and module census: stock `node:24.18.0-bookworm-slim`, `docker --cpus=1`, `NODE_DISABLE_COMPILE_CACHE=1`, token auth, no channels, browser disabled, update checks off; interleaved runs with the page cache warmed first. The same instrument runs against every build, so its overhead cancels.
- The `-44 modules / -1.04 MiB` census figure was produced by cutting the reload edge in a published 2026.7.2-beta.7 bundle, which emulates this source change; it covers the reload edge only, not the recovery-marking edge.
- `src/cli/gateway-cli/lifecycle-import-boundary.test.ts` is added so a future edit cannot quietly route these re-exports back through a forwarding module. It follows the existing `src/gateway/server-import-boundary.test.ts` idiom and stays in the CLI lane so PR change classification selects it with the file it guards.
- No `autoreview` skill is present in this checkout, so that step could not be run.
