### PR TITLE
fix(ci): retry interrupted Windows dashboard release checks

### DIFF
--- a/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
+++ b/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
@@ -964,19 +964,39 @@ jobs:
           if [[ -n "${OPENCLAW_DISCORD_SMOKE_BOT_TOKEN}" ]] && [[ -n "${OPENCLAW_DISCORD_SMOKE_GUILD_ID}" ]] && [[ -n "${OPENCLAW_DISCORD_SMOKE_CHANNEL_ID}" ]]; then
             DISCORD_ARGS+=(--run-discord-roundtrip true)
           fi
-          bash workflow/scripts/github/run-openclaw-cross-os-release-checks.sh \
-            --candidate-tgz "${CANDIDATE_TGZ}" \
-            --candidate-version "${CANDIDATE_VERSION}" \
-            --source-sha "${SOURCE_SHA}" \
-            --baseline-spec "${BASELINE_SPEC}" \
-            --previous-version "${PREVIOUS_VERSION}" \
-            --baseline-tgz "${BASELINE_TGZ}" \
-            --provider "${PROVIDER}" \
-            --mode "${MODE}" \
-            --suite "${SUITE}" \
-            --ref "${REF}" \
-            "${DISCORD_ARGS[@]}" \
-            --output-dir "${OUTPUT_DIR}"
+          run_cross_os_release_checks() {
+            bash workflow/scripts/github/run-openclaw-cross-os-release-checks.sh \
+              --candidate-tgz "${CANDIDATE_TGZ}" \
+              --candidate-version "${CANDIDATE_VERSION}" \
+              --source-sha "${SOURCE_SHA}" \
+              --baseline-spec "${BASELINE_SPEC}" \
+              --previous-version "${PREVIOUS_VERSION}" \
+              --baseline-tgz "${BASELINE_TGZ}" \
+              --provider "${PROVIDER}" \
+              --mode "${MODE}" \
+              --suite "${SUITE}" \
+              --ref "${REF}" \
+              "${DISCORD_ARGS[@]}" \
+              --output-dir "${OUTPUT_DIR}"
+          }
+
+          if run_cross_os_release_checks; then
+            exit 0
+          else
+            status=$?
+          fi
+
+          dashboard_log="${OUTPUT_DIR}/logs/${MODE}-dashboard.log"
+          if [[ "${OPENCLAW_RELEASE_CHECK_OS}" != "windows" ||
+                "$status" -ne 127 ||
+                ! -f "${dashboard_log}" ||
+                -f "${OUTPUT_DIR}/summary.json" ]] ||
+            ! grep -q 'attempt=.*url=http://127.0.0.1:' "${dashboard_log}"; then
+            exit "$status"
+          fi
+
+          echo "::warning::retrying Windows release checks after the outer process exited 127 after the dashboard probe and before summary generation"
+          run_cross_os_release_checks
 
       - name: Summarize release checks
         if: always()

--- a/test/scripts/openclaw-cross-os-release-workflow.test.ts
+++ b/test/scripts/openclaw-cross-os-release-workflow.test.ts
@@ -61,6 +61,22 @@ describe("cross-OS release checks workflow", () => {
     expect(workflow).not.toContain("TSX_VERSION");
   });
 
+  it("retries only an interrupted Windows dashboard probe", () => {
+    const workflow = readWorkflow(WORKFLOW_PATH);
+    const consumer = job(workflow, "cross_os_release_checks");
+    const run = step(consumer, "Run cross-OS release checks").run;
+
+    expect(run).toContain("run_cross_os_release_checks() {");
+    expect(run).toContain("if run_cross_os_release_checks; then");
+    expect(run).toContain('"${OPENCLAW_RELEASE_CHECK_OS}" != "windows"');
+    expect(run).toContain('"$status" -ne 127');
+    expect(run).toContain('dashboard_log="${OUTPUT_DIR}/logs/${MODE}-dashboard.log"');
+    expect(run).toContain('-f "${OUTPUT_DIR}/summary.json"');
+    expect(run).toContain("attempt=.*url=http://127.0.0.1:");
+    expect(run).toContain("retrying Windows release checks after the outer process exited 127");
+    expect(run).toContain("run_cross_os_release_checks\n");
+  });
+
   it("bounds npm baseline packing during prepare", () => {
     const workflow = readFileSync(WORKFLOW_PATH, "utf8");
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-validation issue where the Windows packaged-upgrade lane could terminate with exit 127 immediately after the first dashboard probe, even though the upgrade and gateway startup had completed. The job produced neither a harness error nor a release summary, so it could not distinguish this runner interruption from an application failure.

## Why This Change Was Made

Retry the complete release-check harness once only for the observed Windows signature: exit 127, a dashboard probe log, and no generated summary. All other failures preserve their original result; this does not retry application-level dashboard failures.

## User Impact

Release operators get a self-healing retry for this narrow hosted-Windows interruption while genuine validation failures remain actionable.

## Evidence

- Failure: https://github.com/openclaw/openclaw/actions/runs/30841611644/job/91780463714 — the dashboard artifact ends at `attempt=1 url=http://127.0.0.1:62316/`, followed by outer exit 127 and no summary.
- Same run, attempt 2 passed with the same candidate, baseline, and trusted workflow: https://github.com/openclaw/openclaw/actions/runs/30841611644/job/91881723898
- A shell simulation of the extracted workflow step verified both the matching retry path and the no-dashboard-log no-retry path.
- `actionlint` and `git diff --check` pass.
- Added focused workflow assertions in `test/scripts/openclaw-cross-os-release-workflow.test.ts`. The local test wrapper is blocked by this worktree's missing `p-map` dependency; remote verification is blocked because neither Blacksmith nor Crabbox authentication is available.

AI-assisted: investigation and implementation.