### PR TITLE
fix(line): prevent unbounded provider response buffering

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -631,7 +631,7 @@ extensions/line/src/monitor-durable.ts	1
 extensions/line/src/monitor.ts	1
 extensions/line/src/outbound.ts	6
 extensions/line/src/rich-menu.ts	1
-extensions/line/src/send.ts	2
+extensions/line/src/send.ts	1
 extensions/line/src/setup-core.ts	1
 extensions/line/src/webhook-spool.ts	4
 extensions/line/src/webhook-utils.ts	1

--- a/extensions/line/src/send.response-bounds.test.ts
+++ b/extensions/line/src/send.response-bounds.test.ts
@@ -1,0 +1,153 @@
+import { HTTPFetchError } from "@line/bot-sdk";
+import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  lineFetchMock,
+  requireRuntimeConfigMock,
+  resolveLineAccountMock,
+  resolveLineChannelAccessTokenMock,
+  recordChannelActivityMock,
+} = vi.hoisted(() => ({
+  lineFetchMock: vi.fn(),
+  requireRuntimeConfigMock: vi.fn((cfg: unknown) => cfg ?? {}),
+  resolveLineAccountMock: vi.fn(() => ({ accountId: "default" })),
+  resolveLineChannelAccessTokenMock: vi.fn(() => "line-token"),
+  recordChannelActivityMock: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/plugin-config-runtime", () => ({
+  requireRuntimeConfig: requireRuntimeConfigMock,
+}));
+vi.mock("./accounts.js", () => ({ resolveLineAccount: resolveLineAccountMock }));
+vi.mock("./channel-access-token.js", () => ({
+  resolveLineChannelAccessToken: resolveLineChannelAccessTokenMock,
+}));
+vi.mock("openclaw/plugin-sdk/channel-activity-runtime", () => ({
+  recordChannelActivity: recordChannelActivityMock,
+}));
+
+let sendModule: typeof import("./send.js");
+const LINE_TEST_CFG = { channels: { line: { accounts: { default: {} } } } };
+
+function createTrackedResponse(body: string, init: ResponseInit) {
+  let canceled = false;
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(body));
+    },
+    cancel() {
+      canceled = true;
+    },
+  });
+  return { response: new Response(stream, init), wasCanceled: () => canceled };
+}
+
+async function captureError(run: () => Promise<unknown>): Promise<unknown> {
+  try {
+    await run();
+  } catch (error) {
+    return error;
+  }
+  throw new Error("expected LINE send to fail");
+}
+
+describe("LINE bounded provider responses", () => {
+  beforeAll(async () => {
+    sendModule = await import("./send.js");
+  });
+
+  afterAll(() => {
+    vi.doUnmock("openclaw/plugin-sdk/plugin-config-runtime");
+    vi.doUnmock("./accounts.js");
+    vi.doUnmock("./channel-access-token.js");
+    vi.doUnmock("openclaw/plugin-sdk/channel-activity-runtime");
+    vi.resetModules();
+  });
+
+  beforeEach(() => {
+    lineFetchMock.mockReset();
+    requireRuntimeConfigMock.mockClear().mockImplementation((cfg: unknown) => cfg ?? LINE_TEST_CFG);
+    resolveLineAccountMock.mockReset().mockReturnValue({ accountId: "default" });
+    resolveLineChannelAccessTokenMock.mockReset().mockReturnValue("line-token");
+    recordChannelActivityMock.mockReset();
+    vi.stubGlobal("fetch", lineFetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("preserves partial delivery when an accepted LINE response is oversized", async () => {
+    const tracked = createTrackedResponse("x".repeat(16 * 1024 + 1), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+    const textSpy = vi.spyOn(tracked.response, "text").mockRejectedValue(new Error("unbounded"));
+    lineFetchMock.mockResolvedValueOnce(tracked.response);
+
+    const caught = await captureError(() =>
+      sendModule.pushMessageLine("U123", "Hello", { cfg: LINE_TEST_CFG }),
+    );
+
+    expect(isChannelPartialDeliveryError(caught)).toBe(true);
+    if (!isChannelPartialDeliveryError(caught)) {
+      throw new Error("expected an accepted LINE delivery without a readable receipt");
+    }
+    expect(caught.deliveryResult).toEqual({ messageIds: [], visibleReplySent: true });
+    expect(textSpy).not.toHaveBeenCalled();
+    expect(tracked.wasCanceled()).toBe(true);
+  });
+
+  it("bounds oversized rejected LINE response bodies", async () => {
+    const tracked = createTrackedResponse(`${"line upstream unavailable ".repeat(1024)}tail`, {
+      status: 400,
+      statusText: "Bad Request",
+      headers: { "content-type": "text/plain" },
+    });
+    const textSpy = vi.spyOn(tracked.response, "text").mockRejectedValue(new Error("unbounded"));
+    lineFetchMock.mockResolvedValueOnce(tracked.response);
+
+    const caught = await captureError(() =>
+      sendModule.pushMessageLine("U123", "Hello", { cfg: LINE_TEST_CFG }),
+    );
+
+    expect(caught).toBeInstanceOf(HTTPFetchError);
+    expect(isChannelPartialDeliveryError(caught)).toBe(false);
+    expect(caught).toMatchObject({ status: 400, statusText: "Bad Request" });
+    expect((caught as HTTPFetchError).body).toContain("line upstream unavailable");
+    expect((caught as HTTPFetchError).body).not.toContain("tail");
+    expect(textSpy).not.toHaveBeenCalled();
+    expect(tracked.wasCanceled()).toBe(true);
+  });
+
+  it("preserves reply rejection status when the LINE error body cannot be read", async () => {
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.error(new Error("provider response body failed"));
+        },
+      }),
+      { status: 503, statusText: "Service Unavailable", headers: { "content-type": "text/plain" } },
+    );
+    const textSpy = vi.spyOn(response, "text").mockRejectedValue(new Error("unbounded"));
+    lineFetchMock.mockResolvedValueOnce(response);
+
+    const caught = await captureError(() =>
+      sendModule.sendMessageLine("U123", "Hello", {
+        cfg: LINE_TEST_CFG,
+        replyToken: "reply-token",
+      }),
+    );
+
+    expect(caught).toBeInstanceOf(HTTPFetchError);
+    expect(isChannelPartialDeliveryError(caught)).toBe(false);
+    expect(caught).toMatchObject({
+      status: 503,
+      statusText: "Service Unavailable",
+      body: "",
+    });
+    expect(lineFetchMock).toHaveBeenCalledOnce();
+    expect(textSpy).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/line/src/send.response-bounds.test.ts
+++ b/extensions/line/src/send.response-bounds.test.ts
@@ -9,7 +9,7 @@ const {
   resolveLineChannelAccessTokenMock,
   recordChannelActivityMock,
 } = vi.hoisted(() => ({
-  lineFetchMock: vi.fn(),
+  lineFetchMock: vi.fn<typeof fetch>(),
   requireRuntimeConfigMock: vi.fn((cfg: unknown) => cfg ?? {}),
   resolveLineAccountMock: vi.fn(() => ({ accountId: "default" })),
   resolveLineChannelAccessTokenMock: vi.fn(() => "line-token"),
@@ -95,6 +95,28 @@ describe("LINE bounded provider responses", () => {
       throw new Error("expected an accepted LINE delivery without a readable receipt");
     }
     expect(caught.deliveryResult).toEqual({ messageIds: [], visibleReplySent: true });
+    expect(textSpy).not.toHaveBeenCalled();
+    expect(tracked.wasCanceled()).toBe(true);
+  });
+
+  it("bounds an accepted retry-key conflict without reclassifying it as rejected", async () => {
+    const tracked = createTrackedResponse("x".repeat(16 * 1024 + 1), {
+      status: 409,
+      statusText: "Conflict",
+      headers: { "content-type": "application/json" },
+    });
+    const textSpy = vi.spyOn(tracked.response, "text").mockRejectedValue(new Error("unbounded"));
+    lineFetchMock.mockResolvedValueOnce(tracked.response);
+
+    const caught = await captureError(() =>
+      sendModule.pushMessageLine("U123", "Hello", { cfg: LINE_TEST_CFG }),
+    );
+
+    expect(isChannelPartialDeliveryError(caught)).toBe(true);
+    expect(caught).not.toBeInstanceOf(HTTPFetchError);
+    expect(lineFetchMock).toHaveBeenCalledOnce();
+    const requestInit = lineFetchMock.mock.calls[0]?.[1];
+    expect(new Headers(requestInit?.headers).get("X-Line-Retry-Key")).toBeTruthy();
     expect(textSpy).not.toHaveBeenCalled();
     expect(tracked.wasCanceled()).toBe(true);
   });

--- a/extensions/line/src/send.test.ts
+++ b/extensions/line/src/send.test.ts
@@ -803,6 +803,43 @@ describe("LINE send helpers", () => {
     expect(tracked.wasCanceled()).toBe(true);
   });
 
+  it("preserves reply rejection status when the LINE error body cannot be read", async () => {
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.error(new Error("provider response body failed"));
+        },
+      }),
+      {
+        status: 503,
+        statusText: "Service Unavailable",
+        headers: { "content-type": "text/plain" },
+      },
+    );
+    const textSpy = vi.spyOn(response, "text").mockRejectedValue(new Error("unbounded"));
+    lineFetchMock.mockResolvedValueOnce(response);
+
+    let caught: unknown;
+    try {
+      await sendModule.sendMessageLine("U123", "Hello", {
+        cfg: LINE_TEST_CFG,
+        replyToken: "reply-token",
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(HTTPFetchError);
+    expect(isChannelPartialDeliveryError(caught)).toBe(false);
+    expect(caught).toMatchObject({
+      status: 503,
+      statusText: "Service Unavailable",
+      body: "",
+    });
+    expect(lineFetchMock).toHaveBeenCalledOnce();
+    expect(textSpy).not.toHaveBeenCalled();
+  });
+
   it("does not misclassify network SyntaxErrors as provider acceptance", async () => {
     const failure = new SyntaxError("upstream network decoder failed");
     lineFetchMock.mockRejectedValueOnce(failure);

--- a/extensions/line/src/send.test.ts
+++ b/extensions/line/src/send.test.ts
@@ -103,28 +103,6 @@ const LINE_TEST_CFG = {
   },
 };
 
-function createTrackedResponse(
-  body: string,
-  init: ResponseInit,
-): {
-  response: Response;
-  wasCanceled: () => boolean;
-} {
-  let canceled = false;
-  const stream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      controller.enqueue(new TextEncoder().encode(body));
-    },
-    cancel() {
-      canceled = true;
-    },
-  });
-  return {
-    response: new Response(stream, init),
-    wasCanceled: () => canceled,
-  };
-}
-
 function createCredentialBearingHttpUrl(): string {
   const url = new URL("http://example.com/image.jpg");
   url.username = ["line", "user"].join("-");
@@ -749,95 +727,6 @@ describe("LINE send helpers", () => {
       statusText: "Bad Request",
       body: "invalid payload",
     });
-  });
-
-  it("preserves partial delivery when an accepted LINE response is oversized", async () => {
-    const tracked = createTrackedResponse("x".repeat(16 * 1024 + 1), {
-      status: 200,
-      headers: { "content-type": "application/json" },
-    });
-    const textSpy = vi.spyOn(tracked.response, "text").mockRejectedValue(new Error("unbounded"));
-    lineFetchMock.mockResolvedValueOnce(tracked.response);
-
-    let caught: unknown;
-    try {
-      await sendModule.pushMessageLine("U123", "Hello", { cfg: LINE_TEST_CFG });
-    } catch (error) {
-      caught = error;
-    }
-
-    expect(isChannelPartialDeliveryError(caught)).toBe(true);
-    if (!isChannelPartialDeliveryError(caught)) {
-      throw new Error("expected an accepted LINE delivery without a readable receipt");
-    }
-    expect(caught.deliveryResult).toEqual({ messageIds: [], visibleReplySent: true });
-    expect(textSpy).not.toHaveBeenCalled();
-    expect(tracked.wasCanceled()).toBe(true);
-  });
-
-  it("bounds oversized rejected LINE response bodies", async () => {
-    const tracked = createTrackedResponse(`${"line upstream unavailable ".repeat(1024)}tail`, {
-      status: 400,
-      statusText: "Bad Request",
-      headers: { "content-type": "text/plain" },
-    });
-    const textSpy = vi.spyOn(tracked.response, "text").mockRejectedValue(new Error("unbounded"));
-    lineFetchMock.mockResolvedValueOnce(tracked.response);
-
-    let caught: unknown;
-    try {
-      await sendModule.pushMessageLine("U123", "Hello", { cfg: LINE_TEST_CFG });
-    } catch (error) {
-      caught = error;
-    }
-
-    expect(caught).toBeInstanceOf(HTTPFetchError);
-    expect(isChannelPartialDeliveryError(caught)).toBe(false);
-    expect(caught).toMatchObject({
-      status: 400,
-      statusText: "Bad Request",
-    });
-    expect((caught as HTTPFetchError).body).toContain("line upstream unavailable");
-    expect((caught as HTTPFetchError).body).not.toContain("tail");
-    expect(textSpy).not.toHaveBeenCalled();
-    expect(tracked.wasCanceled()).toBe(true);
-  });
-
-  it("preserves reply rejection status when the LINE error body cannot be read", async () => {
-    const response = new Response(
-      new ReadableStream<Uint8Array>({
-        start(controller) {
-          controller.error(new Error("provider response body failed"));
-        },
-      }),
-      {
-        status: 503,
-        statusText: "Service Unavailable",
-        headers: { "content-type": "text/plain" },
-      },
-    );
-    const textSpy = vi.spyOn(response, "text").mockRejectedValue(new Error("unbounded"));
-    lineFetchMock.mockResolvedValueOnce(response);
-
-    let caught: unknown;
-    try {
-      await sendModule.sendMessageLine("U123", "Hello", {
-        cfg: LINE_TEST_CFG,
-        replyToken: "reply-token",
-      });
-    } catch (error) {
-      caught = error;
-    }
-
-    expect(caught).toBeInstanceOf(HTTPFetchError);
-    expect(isChannelPartialDeliveryError(caught)).toBe(false);
-    expect(caught).toMatchObject({
-      status: 503,
-      statusText: "Service Unavailable",
-      body: "",
-    });
-    expect(lineFetchMock).toHaveBeenCalledOnce();
-    expect(textSpy).not.toHaveBeenCalled();
   });
 
   it("does not misclassify network SyntaxErrors as provider acceptance", async () => {

--- a/extensions/line/src/send.test.ts
+++ b/extensions/line/src/send.test.ts
@@ -103,6 +103,28 @@ const LINE_TEST_CFG = {
   },
 };
 
+function createTrackedResponse(
+  body: string,
+  init: ResponseInit,
+): {
+  response: Response;
+  wasCanceled: () => boolean;
+} {
+  let canceled = false;
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(body));
+    },
+    cancel() {
+      canceled = true;
+    },
+  });
+  return {
+    response: new Response(stream, init),
+    wasCanceled: () => canceled,
+  };
+}
+
 function createCredentialBearingHttpUrl(): string {
   const url = new URL("http://example.com/image.jpg");
   url.username = ["line", "user"].join("-");
@@ -727,6 +749,58 @@ describe("LINE send helpers", () => {
       statusText: "Bad Request",
       body: "invalid payload",
     });
+  });
+
+  it("preserves partial delivery when an accepted LINE response is oversized", async () => {
+    const tracked = createTrackedResponse("x".repeat(16 * 1024 + 1), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+    const textSpy = vi.spyOn(tracked.response, "text").mockRejectedValue(new Error("unbounded"));
+    lineFetchMock.mockResolvedValueOnce(tracked.response);
+
+    let caught: unknown;
+    try {
+      await sendModule.pushMessageLine("U123", "Hello", { cfg: LINE_TEST_CFG });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(isChannelPartialDeliveryError(caught)).toBe(true);
+    if (!isChannelPartialDeliveryError(caught)) {
+      throw new Error("expected an accepted LINE delivery without a readable receipt");
+    }
+    expect(caught.deliveryResult).toEqual({ messageIds: [], visibleReplySent: true });
+    expect(textSpy).not.toHaveBeenCalled();
+    expect(tracked.wasCanceled()).toBe(true);
+  });
+
+  it("bounds oversized rejected LINE response bodies", async () => {
+    const tracked = createTrackedResponse(`${"line upstream unavailable ".repeat(1024)}tail`, {
+      status: 400,
+      statusText: "Bad Request",
+      headers: { "content-type": "text/plain" },
+    });
+    const textSpy = vi.spyOn(tracked.response, "text").mockRejectedValue(new Error("unbounded"));
+    lineFetchMock.mockResolvedValueOnce(tracked.response);
+
+    let caught: unknown;
+    try {
+      await sendModule.pushMessageLine("U123", "Hello", { cfg: LINE_TEST_CFG });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(HTTPFetchError);
+    expect(isChannelPartialDeliveryError(caught)).toBe(false);
+    expect(caught).toMatchObject({
+      status: 400,
+      statusText: "Bad Request",
+    });
+    expect((caught as HTTPFetchError).body).toContain("line upstream unavailable");
+    expect((caught as HTTPFetchError).body).not.toContain("tail");
+    expect(textSpy).not.toHaveBeenCalled();
+    expect(tracked.wasCanceled()).toBe(true);
   });
 
   it("does not misclassify network SyntaxErrors as provider acceptance", async () => {

--- a/extensions/line/src/send.ts
+++ b/extensions/line/src/send.ts
@@ -6,6 +6,10 @@ import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-i
 import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
+import {
+  readProviderJsonResponse,
+  readResponseTextLimited,
+} from "openclaw/plugin-sdk/provider-http";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { fetchWithRuntimeDispatcherOrMockedGlobal } from "openclaw/plugin-sdk/runtime-fetch";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
@@ -35,6 +39,7 @@ const userProfileCache = new Map<
 const PROFILE_CACHE_TTL_MS = 5 * 60 * 1000;
 const PROFILE_CACHE_MAX_ENTRIES = 1000;
 const LINE_FLEX_ALT_TEXT_LIMIT = 1500;
+const LINE_PROVIDER_RESPONSE_MAX_BYTES = 16 * 1024;
 
 function cacheUserProfile(
   userId: string,
@@ -191,15 +196,16 @@ async function sendLineProviderMessages(
       status: response.status,
       statusText: response.statusText,
       headers: response.headers,
-      body: await response.text(),
+      body: await readResponseTextLimited(response, LINE_PROVIDER_RESPONSE_MAX_BYTES),
     });
   }
 
   try {
-    const text = await response.text();
-    return (text ? JSON.parse(text) : null) as
-      | messagingApi.PushMessageResponse
-      | messagingApi.ReplyMessageResponse;
+    return await readProviderJsonResponse<
+      messagingApi.PushMessageResponse | messagingApi.ReplyMessageResponse
+    >(response, `LINE ${operation} response`, {
+      maxBytes: LINE_PROVIDER_RESPONSE_MAX_BYTES,
+    });
   } catch (error) {
     // LINE accepted this exact request before its receipt became unreadable; retrying duplicates it.
     throw createChannelPartialDeliveryError(error, { messageIds: [], visibleReplySent: true });

--- a/extensions/line/src/send.ts
+++ b/extensions/line/src/send.ts
@@ -192,11 +192,14 @@ async function sendLineProviderMessages(
   );
 
   if (!response.ok) {
+    const body = await readResponseTextLimited(response, LINE_PROVIDER_RESPONSE_MAX_BYTES).catch(
+      () => "",
+    );
     throw new HTTPFetchError(`${response.status} - ${response.statusText}`, {
       status: response.status,
       statusText: response.statusText,
       headers: response.headers,
-      body: await readResponseTextLimited(response, LINE_PROVIDER_RESPONSE_MAX_BYTES),
+      body,
     });
   }
 

--- a/extensions/line/src/send.ts
+++ b/extensions/line/src/send.ts
@@ -204,11 +204,14 @@ async function sendLineProviderMessages(
   const acceptedRetryConflict = retryKey !== undefined && response.status === 409;
 
   if (!response.ok && !acceptedRetryConflict) {
+    const body = await readResponseTextLimited(response, LINE_PROVIDER_RESPONSE_MAX_BYTES).catch(
+      () => "",
+    );
     throw new HTTPFetchError(`${response.status} - ${response.statusText}`, {
       status: response.status,
       statusText: response.statusText,
       headers: response.headers,
-      body: await readResponseTextLimited(response, LINE_PROVIDER_RESPONSE_MAX_BYTES),
+      body,
     });
   }
 

--- a/extensions/line/src/send.ts
+++ b/extensions/line/src/send.ts
@@ -7,6 +7,10 @@ import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-i
 import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
+import {
+  readProviderJsonResponse,
+  readResponseTextLimited,
+} from "openclaw/plugin-sdk/provider-http";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { fetchWithRuntimeDispatcherOrMockedGlobal } from "openclaw/plugin-sdk/runtime-fetch";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
@@ -38,6 +42,9 @@ const PROFILE_CACHE_TTL_MS = 5 * 60 * 1000;
 const PROFILE_CACHE_MAX_ENTRIES = 1000;
 const LINE_FLEX_ALT_TEXT_LIMIT = 1500;
 const LINE_LOCATION_LABEL_LIMIT = 100;
+// This cap bounds receipts and diagnostics: overflow after acceptance becomes no-retry partial
+// delivery, while rejected responses keep their status with prefix-only diagnostics.
+const LINE_PROVIDER_RESPONSE_MAX_BYTES = 16 * 1024;
 
 function cacheUserProfile(
   userId: string,
@@ -201,15 +208,16 @@ async function sendLineProviderMessages(
       status: response.status,
       statusText: response.statusText,
       headers: response.headers,
-      body: await response.text(),
+      body: await readResponseTextLimited(response, LINE_PROVIDER_RESPONSE_MAX_BYTES),
     });
   }
 
   try {
-    const text = await response.text();
-    return (text ? JSON.parse(text) : null) as
-      | messagingApi.PushMessageResponse
-      | messagingApi.ReplyMessageResponse;
+    return await readProviderJsonResponse<
+      messagingApi.PushMessageResponse | messagingApi.ReplyMessageResponse
+    >(response, `LINE ${operation} response`, {
+      maxBytes: LINE_PROVIDER_RESPONSE_MAX_BYTES,
+    });
   } catch (error) {
     // LINE accepted this exact request before its receipt became unreadable; retrying duplicates it.
     throw createChannelPartialDeliveryError(error, { messageIds: [], visibleReplySent: true });


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where LINE outbound sends could buffer an arbitrarily large provider response body after LINE accepted or rejected a request. An oversized response could therefore cause unbounded memory use, while an accepted response still needs to retain the existing partial-delivery behavior so callers do not retry and duplicate the message.

## Why This Change Was Made

The root cause was in the canonical `sendLineProviderMessages` transport boundary: it handed both provider outcomes to unbounded body consumers before receipt or retry semantics were decided. Fixing that owner covers every LINE push and reply caller instead of adding a downstream fallback.

The boundary now uses the shared provider HTTP readers with one 16 KiB LINE response budget. That value is grounded in the shared provider diagnostic reader's existing 16 KiB default and the LINE protocol shape: a successful send receipt contains only `sentMessages` identifiers for a small message batch, while an error body is diagnostic rather than authoritative. The generic provider JSON default of 16 MiB is unnecessarily large here, and separate success/error limits would add another unsupported policy choice. The strict JSON reader rejects overflow; the diagnostic reader retains only the prefix.

Current main's retry-key 409 path remains classified as an earlier accepted push and now passes through the same bounded receipt reader. An accepted response whose receipt is oversized, unreadable, or stalled still reports `visibleReplySent: true` as partial delivery, while rejected responses remain `HTTPFetchError`s with their authoritative status preserved even if the diagnostic body cannot be read. This is a root-cause fix at the response owner, not a retry workaround. LINE's [official retry contract](https://developers.line.biz/en/docs/messaging-api/retrying-api-request/) confirms that a retry-key 409 means an earlier accepted request and must not be retried.

## User Impact

LINE sends no longer consume unbounded memory when the provider returns an unexpectedly large response. Existing delivery and retry semantics are unchanged: accepted-but-unreadable responses, including retry-key 409 conflicts, remain no-retry partial deliveries, and provider rejections remain ordinary send failures.

The shared bounded readers also introduce explicit per-chunk idle deadlines where `response.text()` previously had none: **30 seconds for accepted JSON receipts and 10 seconds for rejected diagnostic bodies**. A stalled accepted receipt becomes no-retry partial delivery; a stalled rejected body preserves its HTTP status and uses an empty diagnostic body. Request bodies, authentication headers, public result types, normal LINE receipts, batching, and other providers are unchanged.

Compatibility and scope are intentionally narrow. Current `main` still contains both unbounded response reads, and GitHub reports the pull request mergeable. The same-problem PR scan found no ready competing fix. The main merge risk is message-delivery classification; the regression suite covers accepted overflow, retry-key 409 overflow, rejected overflow, stream cancellation, and unreadable 503 bodies so partial-delivery and status-based fallback behavior remain explicit.

## Evidence

- Exact reviewed head: `b0b4ca7a377f272f77f21e5187e572fd535c31ce`.
- Exact-head hosted CI: [`openclaw/ci-gate` passed](https://github.com/openclaw/openclaw/actions/runs/32611660361/job/97126322132); the prior exact-head run completed with all 192 checks successful or skipped and no failures. A fresh rerun of that same exact-head CI is being requested because the successful run is older than the maintainer landing freshness window.
- Refreshed-head regression coverage adds the combined retry-key 409 overflow case and verifies the retry key, partial-delivery classification, stream cancellation, and absence of unbounded `response.text()` consumption. No untrusted fork code was executed locally.
- The assertion-safety count for `extensions/line/src/send.ts` improved from 2 to 1 because the old unchecked JSON assertion was removed. The required `config/assertion-safety-baseline.txt` ratchet update records that shrink; the hosted baseline-ratchet check passed.
- Earlier-head full LINE send tests, before the current-main history refresh:

  ```text
  Test Files  2 passed (2)
       Tests  48 passed (48)
  ```

- Earlier-head live loopback E2E using the production `pushMessageLine` path, real `fetch`, and a real local HTTP provider:

  ```text
  trigger: real LINE push against loopback provider with oversized success body
  transition: provider accepted request; receipt parsing stopped at 16384 bytes; partial=true
  trigger: real LINE push against loopback provider with oversized error body
  outcome: error body length=16384; tail_present=false
  observed: requests=/v2/bot/message/push,/v2/bot/message/push
  ```

- Exact-head ClawSweeper execution ran `extensions/line/src/send.response-bounds.test.ts`: **4 tests passed**; its outer display assertion timed out after the successful run, so the test pass is reported separately from that harness timeout.
- `git diff --check` passes on the refreshed head.

Gateway validation is not applicable here: `pushMessageLine` directly owns the canonical LINE provider request/response path, and the loopback proof exercises that boundary through the real fetch implementation. This is real local HTTP transport proof, not a claim of authenticated live LINE-provider execution.
