### PR TITLE
fix(memory-core): treat blank TZ as unset when dating dream diary entries

### DIFF
--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -18,6 +18,7 @@ import {
 import { appendSqliteSessionTranscriptEventForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  appendFallbackNarrativeEntry,
   dedupeDreamDiaryEntries,
   readRecentDreamDiaryEntries,
   removeBackfillDiaryEntries,
@@ -512,6 +513,34 @@ describe("runDreamNarrative", () => {
       `dreaming-narrative-researcher-rem-${workspaceHash}-${nowMs}`,
     );
     expectLogExcludes(logger.warn, "narrative generation failed");
+  });
+
+  // Regression: a blank TZ env reached Intl.DateTimeFormat verbatim and threw
+  // RangeError, so both the narrative entry and its fallback were silently dropped.
+  it("writes the fallback diary entry when TZ is blank", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-blank-tz-");
+    const logger = createMockLogger();
+    const originalTz = process.env.TZ;
+    Reflect.set(process.env, "TZ", "");
+    try {
+      await appendFallbackNarrativeEntry({
+        workspaceDir,
+        data: { phase: "rem", snippets: ["A blank TZ must not lose the diary entry."] },
+        nowMs: Date.parse("2026-04-05T03:00:00Z"),
+        logger,
+        reason: "the narrative run produced no text",
+      });
+    } finally {
+      if (originalTz === undefined) {
+        Reflect.deleteProperty(process.env, "TZ");
+      } else {
+        Reflect.set(process.env, "TZ", originalTz);
+      }
+    }
+
+    const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
+    expect(content).toContain("A memory trace surfaced, but details were unavailable in this run.");
+    expectLogExcludes(logger.warn, "narrative fallback failed");
   });
 
   it("waits for persisted assistant text before falling back", async () => {

--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -543,6 +543,34 @@ describe("runDreamNarrative", () => {
     expectLogExcludes(logger.warn, "narrative fallback failed");
   });
 
+  // Regression: a nonblank invalid TZ (not an IANA zone) also threw RangeError in
+  // Intl.DateTimeFormat, suppressing both the diary entry and its fallback write.
+  it("writes the fallback diary entry when TZ is an invalid zone", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-bad-tz-");
+    const logger = createMockLogger();
+    const originalTz = process.env.TZ;
+    Reflect.set(process.env, "TZ", "Not/AZone");
+    try {
+      await appendFallbackNarrativeEntry({
+        workspaceDir,
+        data: { phase: "rem", snippets: ["An invalid TZ must not lose the diary entry."] },
+        nowMs: Date.parse("2026-04-05T03:00:00Z"),
+        logger,
+        reason: "the narrative run produced no text",
+      });
+    } finally {
+      if (originalTz === undefined) {
+        Reflect.deleteProperty(process.env, "TZ");
+      } else {
+        Reflect.set(process.env, "TZ", originalTz);
+      }
+    }
+
+    const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
+    expect(content).toContain("A memory trace surfaced, but details were unavailable in this run.");
+    expectLogExcludes(logger.warn, "narrative fallback failed");
+  });
+
   it("waits for persisted assistant text before falling back", async () => {
     vi.useFakeTimers();
     try {

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -426,8 +426,13 @@ async function readSettledNarrativeText(params: {
 // ── Date formatting ────────────────────────────────────────────────────
 
 function formatNarrativeDate(epochMs: number, timezone?: string): string {
+  // A blank TZ is not a usable override: Intl.DateTimeFormat throws RangeError
+  // for an empty timeZone, so treat empty/whitespace-only values as unset and
+  // let Intl fall back to the host zone. Trimming only detects blankness; a
+  // nonblank value is preserved byte-for-byte.
+  const envTimeZone = process.env.TZ?.trim() ? process.env.TZ : undefined;
   const opts: Intl.DateTimeFormatOptions = {
-    timeZone: timezone ?? process.env.TZ,
+    timeZone: timezone ?? envTimeZone,
     year: "numeric",
     month: "long",
     day: "numeric",

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -425,14 +425,26 @@ async function readSettledNarrativeText(params: {
 
 // ── Date formatting ────────────────────────────────────────────────────
 
+// An unusable TZ (blank, padded, or not an IANA zone) is not a valid override:
+// Intl.DateTimeFormat throws RangeError for it, which would suppress both the
+// diary entry and its fallback write. Validate once here and let Intl fall back
+// to the host zone for any unusable value, mirroring src/logging/timestamps.ts.
+function resolveEnvTimeZone(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: trimmed });
+    return trimmed;
+  } catch {
+    return undefined;
+  }
+}
+
 function formatNarrativeDate(epochMs: number, timezone?: string): string {
-  // A blank TZ is not a usable override: Intl.DateTimeFormat throws RangeError
-  // for an empty timeZone, so treat empty/whitespace-only values as unset and
-  // let Intl fall back to the host zone. Trimming only detects blankness; a
-  // nonblank value is preserved byte-for-byte.
-  const envTimeZone = process.env.TZ?.trim() ? process.env.TZ : undefined;
   const opts: Intl.DateTimeFormatOptions = {
-    timeZone: timezone ?? envTimeZone,
+    timeZone: timezone ?? resolveEnvTimeZone(process.env.TZ),
     year: "numeric",
     month: "long",
     day: "numeric",


### PR DESCRIPTION
## Summary

Validate the `TZ` environment fallback when formatting dream diary entry dates: blank **or otherwise unusable** (non-IANA) values are treated as unset so `Intl.DateTimeFormat` falls back to the host zone instead of throwing `RangeError` and silently losing DREAMS.md entries (including fallback entries).

## What Problem This Solves

`formatNarrativeDate` (`extensions/memory-core/src/dreaming-narrative.ts:435`) built its formatter options with:

```ts
timeZone: timezone ?? process.env.TZ,
```

`??` only falls through on `undefined`/`null`. When the process runs with an unusable `TZ` — empty (`TZ=""`), whitespace-only, or a non-IANA value like `TZ="Not/AZone"` (common under `env -i`, stripped systemd units, minimal container images, or a mistyped compose file) — the value reaches `new Intl.DateTimeFormat("en-US", { timeZone: ... })`, which throws `RangeError: Invalid time zone specified`.

The throw escapes `appendNarrativeEntry` at exactly the moment the diary entry is written. The orchestrator's catch logs a warning and calls `appendFallbackNarrativeEntry` — but the fallback calls the same `appendNarrativeEntry` → `formatNarrativeDate`, throws the same `RangeError`, and its own catch only logs `narrative fallback failed ... (name=RangeError)`. Net result: **DREAMS.md gets no entry at all** — the dream narrative the pipeline just produced is silently dropped, with only two warnings in the log.

The other `process.env.TZ` consumers in the codebase are already guarded — `src/logging/timestamps.ts:30` validates with `isValidTimeZone` and falls back to the host zone, and `src/hooks/bundled/session-memory/handler.ts:250` goes through `resolveUserTimezone` — this dreaming-narrative site was the remaining unguarded one.

**Code evidence**: `dreaming-narrative.ts:435` passed any defined `TZ` straight into `Intl.DateTimeFormat`, where a blank or non-IANA `timeZone` is a guaranteed `RangeError`.

## Root Cause

- The `timeZone: timezone ?? process.env.TZ` fallback dates to the dreaming-narrative feature commit 3c7a641b8d0 (2026-05-06).
- Violated invariant: the code assumes "TZ is defined" implies "TZ is a usable IANA zone". Blank, padded, or misspelled values satisfy the first and break the second — `Intl.DateTimeFormat` accepts `undefined` (host default) but throws for anything that is not a valid zone.
- Trigger: run the dreaming narrative phase (light or REM) with an unusable `TZ` in the environment; both the real diary entry and the fallback entry fail to write.

## Why This Fix

- Validate once at the shared formatter: trim the env value, then probe it with `new Intl.DateTimeFormat(...)` inside try/catch — any unusable value (blank, padded, non-IANA) becomes `undefined`, so `Intl` falls back to the host zone. This mirrors the guarded sibling `src/logging/timestamps.ts` (`isValidTimeZone`).
- A usable `TZ` keeps working; trimming also makes a padded valid zone like `" UTC "` usable instead of fatal. The explicit `timezone` parameter (dreaming/user configuration contract) is untouched.
- Single change at the shared date formatter cures both write paths (narrative entry and fallback entry) at once.
- Alternative considered: blank-only normalization (first revision of this PR) — rejected on review because a nonblank invalid zone still threw at the same boundary; wrapping `Intl` construction in try/catch at each caller — rejected because there are several callers and the invalid value originates at one point; importing a validation package — the extension's manifest deliberately keeps dependencies minimal, and the probe needs no new dependency.

## User Impact

- Affected operations: the dreaming narrative phase on hosts launched with a blank or invalid `TZ`.
- Before: `RangeError` on every diary write; DREAMS.md silently loses both the narrative entry and the fallback entry — the user sees warnings but no dream diary output.
- After: the unusable `TZ` is ignored and entries are dated in the host timezone, exactly as when `TZ` is unset.

## Evidence

- **Before**: on main, the real exported `appendFallbackNarrativeEntry` against a real temp workspace logs `narrative fallback failed for rem phase (name=RangeError)` and leaves DREAMS.md missing — for both `TZ=""` and `TZ="Not/AZone"` → FAIL
- **After**: the same calls write the fallback entry to DREAMS.md dated in the host timezone (`April 5, 2026 at 3:00 AM GMT+0` on this machine) with no warnings — for both scenarios → PASS

## Real Behavior Proof

### Before (on main)
```bash
$ node --import tsx proof.mjs
--- blank TZ (TZ="") ---
logger.warn output: ["memory-core: narrative fallback failed for rem phase (name=RangeError)"]
DREAMS.md on disk: (missing)
FAIL(blank TZ): TZ reaches Intl.DateTimeFormat and throws RangeError; both the diary entry and its fallback write fail, so DREAMS.md silently loses the entry
--- invalid TZ (TZ="Not/AZone") ---
logger.warn output: ["memory-core: narrative fallback failed for rem phase (name=RangeError)"]
DREAMS.md on disk: (missing)
FAIL(invalid TZ): TZ reaches Intl.DateTimeFormat and throws RangeError; both the diary entry and its fallback write fail, so DREAMS.md silently loses the entry
```

### After (with fix)
```bash
$ node --import tsx proof.mjs
--- blank TZ (TZ="") ---
logger.warn output: []
DREAMS.md on disk: "# Dream Diary\n\n<!-- openclaw:dreaming:diary:start -->\n---\n\n*April 5, 2026 at 3:00 AM GMT+0*\n\nA memory trace surfaced, but details were unava..."
PASS(blank TZ): unusable TZ ignored; diary entry written using the host timezone
--- invalid TZ (TZ="Not/AZone") ---
logger.warn output: []
DREAMS.md on disk: "# Dream Diary\n\n<!-- openclaw:dreaming:diary:start -->\n---\n\n*April 5, 2026 at 3:00 AM GMT+0*\n\nA memory trace surfaced, but details were unava..."
PASS(invalid TZ): unusable TZ ignored; diary entry written using the host timezone
```

## Tests and Validation

- `node scripts/run-vitest.mjs extensions/memory-core/src/dreaming-narrative.test.ts` passed (36 cases) and `git diff --check` is clean
- Regression coverage in `extensions/memory-core/src/dreaming-narrative.test.ts`: with `TZ=""` and separately with `TZ="Not/AZone"` in the environment, `appendFallbackNarrativeEntry` writes the fallback entry to DREAMS.md instead of dropping it, and no `narrative fallback failed` warning is logged
- Proof above exercises the real exported `appendFallbackNarrativeEntry` against a real temporary workspace on disk; no external services involved
