### PR TITLE
fix(memory): doctor stalls importing a large legacy memory index and restarts each run

### DIFF
--- a/extensions/memory-core/doctor-contract-api.test.ts
+++ b/extensions/memory-core/doctor-contract-api.test.ts
@@ -398,6 +398,17 @@ function readMemoryRows(agentPath: string) {
   }
 }
 
+// Which copy proof ran is only observable through the SQL the import prepares: the
+// empty-canonical path must never prepare the per-row anti-join over text/embedding.
+const CHUNK_BLOB_ANTI_JOIN_SQL = "canonical.text IS legacy.text";
+
+// vi.spyOn keeps the original implementation, so the import still runs for real while the
+// spy records every statement it prepares.
+function recordPreparedSql(): (needle: string) => boolean {
+  const spy = vi.spyOn(DatabaseSync.prototype, "prepare");
+  return (needle) => spy.mock.calls.some(([sql]) => sql.includes(needle));
+}
+
 function readMemoryCacheRows(agentPath: string) {
   const db = new DatabaseSync(agentPath);
   try {
@@ -2085,6 +2096,50 @@ describe("memory-core doctor dreaming migration", () => {
     });
     await expect(fs.access(legacyPath)).rejects.toThrow();
     await expect(fs.access(`${legacyPath}.migrated`)).resolves.toBeUndefined();
+  });
+
+  it("verifies an empty-canonical sidecar import by row count instead of chunk blobs", async () => {
+    const stateDir = path.join(rootDir, "state");
+    const legacyPath = path.join(stateDir, "memory", "main.sqlite");
+    const agentPath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
+    await writeLegacyMemorySidecar(legacyPath);
+    const preparedSql = recordPreparedSql();
+
+    try {
+      const result = await legacyMemoryIndexMigration().migrateLegacyState(migrationParams());
+
+      expect(result.warnings).toEqual([]);
+      expect(preparedSql(CHUNK_BLOB_ANTI_JOIN_SQL)).toBe(false);
+      expect(readMemoryRows(agentPath)).toEqual({
+        sources: [{ path: "MEMORY.md", source: "memory", hash: "" }],
+        chunks: [{ id: "chunk-1", text: "remember this" }],
+        cache: [{ provider: "openai", hash: "chunk-hash" }],
+      });
+    } finally {
+      vi.restoreAllMocks();
+    }
+  });
+
+  it("keeps the per-row copy verification when canonical memory index rows already exist", async () => {
+    const stateDir = path.join(rootDir, "state");
+    const legacyPath = path.join(stateDir, "memory", "main.sqlite");
+    const agentPath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
+    await writeLegacyMemorySidecar(legacyPath);
+    await createUnrelatedCanonicalMemoryIndex(agentPath);
+    const preparedSql = recordPreparedSql();
+
+    try {
+      const result = await legacyMemoryIndexMigration().migrateLegacyState(migrationParams());
+
+      expect(result.warnings).toEqual([]);
+      expect(preparedSql(CHUNK_BLOB_ANTI_JOIN_SQL)).toBe(true);
+      expect(readMemoryRows(agentPath).chunks).toEqual([
+        { id: "canonical-other-chunk", text: "canonical unrelated memory" },
+        { id: "chunk-1", text: "remember this" },
+      ]);
+    } finally {
+      vi.restoreAllMocks();
+    }
   });
 
   it("archives conflicting custom derived indexes without creating a retry copy", async () => {

--- a/extensions/memory-core/src/migration/doctor-memory-sidecar-import.ts
+++ b/extensions/memory-core/src/migration/doctor-memory-sidecar-import.ts
@@ -156,6 +156,21 @@ function assertLegacyDerivedRowsCopied(db: DatabaseSync, query: string, tableNam
   }
 }
 
+// Only the chunks anti-join may be skipped this way, and only into an empty canonical table.
+// Legacy and canonical chunks declare identical column types and both key on `id`, so the
+// copy cannot coerce a value or collapse two rows: equal counts then prove every legacy row
+// landed unchanged. Do NOT extend this to meta or files — files.mtime is INTEGER in the
+// legacy sidecar and REAL in the canonical schema, so a value above 2^53 is rewritten in
+// transit while the counts still match, and the anti-join must stay to catch it.
+function legacyRowCountsMatch(
+  db: DatabaseSync,
+  schema: string,
+  legacyTable: string,
+  canonicalTable: string,
+): boolean {
+  return tableRowCount(db, "main", canonicalTable) === tableRowCount(db, schema, legacyTable);
+}
+
 function assertLegacyVectorRowsReferenceChunks(db: DatabaseSync, schema: string): void {
   const row = db
     .prepare(
@@ -346,6 +361,7 @@ function copyLegacyMemoryIndexRows(
   schema: string,
   options: { copyVectorRows: boolean },
 ): void {
+  const chunksStartedEmpty = tableRowCount(db, "main", MEMORY_INDEX_CHUNKS_TABLE) === 0;
   db.exec(`
     INSERT OR IGNORE INTO main.${MEMORY_INDEX_META_TABLE} (key, value)
     SELECT key, value FROM ${schema}.meta;
@@ -383,25 +399,30 @@ function copyLegacyMemoryIndexRows(
      )`,
     "files",
   );
-  assertLegacyDerivedRowsCopied(
-    db,
-    `SELECT COUNT(*) AS missing
-     FROM ${schema}.chunks AS legacy
-     WHERE NOT EXISTS (
-       SELECT 1 FROM main.${MEMORY_INDEX_CHUNKS_TABLE} AS canonical
-       WHERE canonical.id = legacy.id
-         AND canonical.path IS legacy.path
-         AND canonical.source IS legacy.source
-         AND canonical.start_line IS legacy.start_line
-         AND canonical.end_line IS legacy.end_line
-         AND canonical.hash IS legacy.hash
-         AND canonical.model IS legacy.model
-         AND canonical.text IS legacy.text
-         AND canonical.embedding IS legacy.embedding
-         AND canonical.updated_at IS legacy.updated_at
-     )`,
-    "chunks",
-  );
+  if (
+    !chunksStartedEmpty ||
+    !legacyRowCountsMatch(db, schema, "chunks", MEMORY_INDEX_CHUNKS_TABLE)
+  ) {
+    assertLegacyDerivedRowsCopied(
+      db,
+      `SELECT COUNT(*) AS missing
+       FROM ${schema}.chunks AS legacy
+       WHERE NOT EXISTS (
+         SELECT 1 FROM main.${MEMORY_INDEX_CHUNKS_TABLE} AS canonical
+         WHERE canonical.id = legacy.id
+           AND canonical.path IS legacy.path
+           AND canonical.source IS legacy.source
+           AND canonical.start_line IS legacy.start_line
+           AND canonical.end_line IS legacy.end_line
+           AND canonical.hash IS legacy.hash
+           AND canonical.model IS legacy.model
+           AND canonical.text IS legacy.text
+           AND canonical.embedding IS legacy.embedding
+           AND canonical.updated_at IS legacy.updated_at
+       )`,
+      "chunks",
+    );
+  }
   copyLegacyMemoryFtsRows(db, schema);
   if (options.copyVectorRows) {
     copyLegacyMemoryVectorRows(db, schema);
@@ -425,7 +446,8 @@ function copyLegacyMemoryIndexRows(
       FROM ${schema}.embedding_cache;
     `);
     // Matching cache keys are derived rows. Validate shape before deciding whether the
-    // entire stale sidecar should yield to the canonical index.
+    // entire stale sidecar should yield to the canonical index. This checks embedding
+    // shape, not just copy completeness, so the row-count shortcut must not skip it.
     assertLegacyDerivedRowsCopied(
       db,
       `SELECT COUNT(*) AS missing


### PR DESCRIPTION
Related: #96184

## What Problem This Solves

Resolves a problem where an operator upgrading an OpenClaw install that has a large
legacy memory index sidecar never gets past `openclaw doctor --fix`. The doctor
migration that folds `memory/<agent>.sqlite` into the per-agent
`agents/<agentId>/agent/openclaw-agent.sqlite` appears to hang, and each rerun starts
over from nothing instead of resuming, so the sidecar is never retired.

Since v2026.7.1 the gateway startup gate is fail-closed on a skipped legacy import, so
on a store this size the practical result is an install that cannot reach readiness
until the sidecar is archived by hand.

## Why This Change Was Made

The import copies legacy `meta`, `files`, and `chunks` into the canonical tables with a
single unfiltered `INSERT OR IGNORE ... SELECT`, then verifies each copy with a per-row
anti-join. For `chunks` that anti-join byte-compares every column it just wrote, including
`text` and `embedding` — that verification, not the copy, is what dominates the migration
on a large store, and it grows super-linearly. Because the whole import runs inside a
savepoint, any interruption rolls it back and the next doctor run repeats the work.

This skips that anti-join **for the chunks copy only**, and only when the canonical chunks
table was empty beforehand and the post-copy row counts match. Legacy and canonical
`chunks` declare identical column types and both key on `id`, so the copy can neither
coerce a value nor collapse two rows into one; equal counts therefore prove every legacy
chunk landed unchanged, and the anti-join could only have returned zero.

**The `meta` and `files` anti-joins stay unconditional**, and that is the load-bearing
decision here. They are cheap — one meta row and a few hundred sources against 92,349
chunks — and the row-count argument does **not** hold for them: legacy `files.mtime` is
`INTEGER` while canonical `sources.mtime` is `REAL` in a STRICT table, so a value above
2^53 is rewritten in transit while the counts still match. Guarding those tables would
have skipped a check the anti-join *fails*. A one-row reproduction:

```
legacy    integer = 9007199254740993
canonical real    = 9.00719925474099e+15
counts    legacy=1 canonical=1   (match)
anti-join missing = 1            (would have failed)
```

An earlier revision of this branch did guard all three tables. That was wrong, and the
above is why it now guards one.

Other boundaries, deliberately:

- **Fail-closed behavior is unchanged.** Anything that reduces the copied chunk count — an
  `INSERT OR IGNORE` constraint drop, a prefilled canonical table — fails the count match,
  reaches the same anti-join, and raises the same `LegacyMemoryDerivedRowsConflictError`.
- **`embedding_cache` is excluded.** Its assertion validates embedding JSON shape rather
  than copy completeness, so a row-count match must not stand in for it.
- **`chunks_vec` is left alone** and is a named follow-up. Its copy is filtered by a join
  against canonical chunks, so row counts are not a valid proof, and exercising that path
  needs `sqlite-vec`.
- **`packages/memory-host-sdk/src/host/memory-schema.ts` does not get this change and must
  not.** #110216 already replaced its anti-joins with key-only comparisons, so no blob
  compare remains there to remove, and its chunk copy is filtered by legacy ownership —
  row counts would not prove that copy.

## User Impact

Operators with a large legacy memory index can complete `openclaw doctor --fix` in one
pass: the sidecar is imported, archived, and the gateway reaches readiness without manual
intervention. Installs with a small or already-migrated store see no behavior change, and
no conflict that previously failed the migration now passes it.

## Evidence

**Reported store shape.** Observed on a per-agent index of 205 sources / 92,349 chunks,
where the chunk byte-compare is what stalls.

**Which proof path ran is asserted directly.** The tests spy on
`DatabaseSync.prototype.prepare` and assert on the SQL the import prepares, so they
distinguish the row-count path from the anti-join path rather than inferring it from timing:

- empty canonical → `canonical.text IS legacy.text` is never prepared
- prefilled canonical → it is prepared, and both the pre-existing canonical chunk and the
  imported chunk survive

**Focused suite**, against a `node_modules` rebuilt from `pnpm-lock.yaml`:

```
Test Files  1 passed (1)
     Tests  61 passed (61)
```

**Revert proof.** Restoring only the production file to its `main` version and keeping the
new tests isolates exactly the intended assertion:

```
 FAIL  extensions/memory-core/doctor-contract-api.test.ts
       > verifies an empty-canonical sidecar import by row count instead of chunk blobs

Test Files  1 failed (1)
     Tests  1 failed | 60 passed (61)
```

To be explicit about what this suite does and does not show: the fixture store holds a
single chunk, so the reverted and fixed runs take comparable wall-clock time. These tests
prove *which verification path runs*, not that it is faster. The cost claim rests on the
production store described above, not on this suite.

**Checks**, all on the same clean tree:

| Lane | Result |
| --- | --- |
| `pnpm tsgo:extensions:all` | exit 0 |
| `pnpm lint:extensions` | exit 0 |
| `oxfmt --check` (both changed files) | exit 0 |

**Production LOC.** `git diff --numstat upstream/main HEAD`:

```
55	 0	extensions/memory-core/doctor-contract-api.test.ts
42	20	extensions/memory-core/src/migration/doctor-memory-sidecar-import.ts
```

Net +22 production lines: one snapshot, one `legacyRowCountsMatch` helper, and one guarded
branch. Most of the 42 added lines are the existing chunks anti-join re-indented under that
guard.

This supersedes #96184, which was auto-closed for inactivity rather than rejected on merit;
this branch is a fresh port onto current `main`.
