### PR TITLE
fix(ci): reuse bundled UI for auth origin coverage

### DIFF
--- a/test/vitest/vitest.ui-e2e.global-setup.ts
+++ b/test/vitest/vitest.ui-e2e.global-setup.ts
@@ -11,6 +11,7 @@ import { createTempDirTracker } from "../helpers/temp-dir.ts";
 declare module "vitest" {
   export interface ProvidedContext {
     controlUiE2eServerBaseUrl: string | null;
+    controlUiE2eServerOutDir: string | null;
   }
 }
 
@@ -18,6 +19,7 @@ export default async function setup(project: TestProject) {
   const executablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
   if (!canRunPlaywrightChromium(executablePath)) {
     project.provide("controlUiE2eServerBaseUrl", null);
+    project.provide("controlUiE2eServerOutDir", null);
     // No-op teardown keeps both paths value-returning for Vitest's setup contract.
     return () => {};
   }
@@ -34,6 +36,7 @@ export default async function setup(project: TestProject) {
   });
   try {
     project.provide("controlUiE2eServerBaseUrl", server.baseUrl);
+    project.provide("controlUiE2eServerOutDir", outDir);
     return async () => {
       try {
         await server.close();

--- a/test/vitest/vitest.ui-e2e.setup.ts
+++ b/test/vitest/vitest.ui-e2e.setup.ts
@@ -5,10 +5,12 @@ import { setSharedControlUiE2eServerBaseUrl } from "../../ui/src/test-helpers/co
 declare module "vitest" {
   export interface ProvidedContext {
     controlUiE2eServerBaseUrl: string | null;
+    controlUiE2eServerOutDir: string | null;
   }
 }
 
 const serverBaseUrl = inject("controlUiE2eServerBaseUrl");
+const serverOutDir = inject("controlUiE2eServerOutDir");
 if (serverBaseUrl) {
-  setSharedControlUiE2eServerBaseUrl(serverBaseUrl);
+  setSharedControlUiE2eServerBaseUrl(serverBaseUrl, serverOutDir);
 }

--- a/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
+++ b/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
@@ -409,6 +409,7 @@ async function createBrowserPage(
 ): Promise<{
   context: BrowserContext;
   evidenceStartIndex: number;
+  errors: string[];
   page: Page;
 }> {
   await mkdir(artifactDir, { recursive: true });
@@ -420,6 +421,8 @@ async function createBrowserPage(
   });
   openContexts.add(context);
   const page = await context.newPage();
+  const errors: string[] = [];
+  page.on("pageerror", (error) => errors.push(String(error)));
   page.setDefaultTimeout(15_000);
   const evidenceStartIndex = proxy.evidence.length;
   const response = await page.goto(withGatewayUrl(baseUrl, gatewayUrl), {
@@ -439,7 +442,7 @@ async function createBrowserPage(
   await expect
     .poll(() => proxy.evidence.length, { timeout: 15_000 })
     .toBeGreaterThan(evidenceStartIndex);
-  return { context, evidenceStartIndex, page };
+  return { context, errors, evidenceStartIndex, page };
 }
 
 async function warmBundledControlUiOrigin(baseUrl: string): Promise<void> {
@@ -574,9 +577,24 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
   });
 
   it("connects through the trusted path and rejects the untrusted proxy path", async () => {
+    // A connected shell starts bootstrap RPCs that can outlive context teardown.
+    // Keep it last so those requests cannot starve the next browser interaction.
+    const rejected = await createBrowserPage(allowedUi.baseUrl, proxy.untrustedUrl);
+    const expectedReason = "trusted_proxy_missing_header_x-forwarded-proto";
+    await waitForVisibleFailure(rejected.page, "unauthorized");
+    const untrustedEvidence = await waitForConnectionEvidence(
+      (entry) => entry.route === "untrusted" && entry.gatewayResult?.ok === false,
+      rejected.evidenceStartIndex,
+    );
+    expect(untrustedEvidence.gatewayResult?.message).toContain("unauthorized");
+    expect(untrustedEvidence.gatewayResult?.errorReason).toBe(expectedReason);
+    expect(untrustedEvidence.identityInjected).toBe(false);
+    expect(untrustedEvidence.requiredHeaderInjected).toBe(false);
+    await captureChromiumScreenshot(rejected.page, "02-untrusted-proxy-rejected.png");
+    expect(rejected.errors).toEqual([]);
+    await closeContext(rejected.context);
+
     const connected = await createBrowserPage(allowedUi.baseUrl, proxy.trustedUrl);
-    const connectedErrors: string[] = [];
-    connected.page.on("pageerror", (error) => connectedErrors.push(String(error)));
     await connected.page
       .locator("openclaw-app-shell")
       .waitFor({ timeout: controlUiSettleTimeoutMs });
@@ -596,24 +614,8 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
     expect(trustedEvidence.identityInjected).toBe(true);
     expect(trustedEvidence.requiredHeaderInjected).toBe(true);
     await captureChromiumScreenshot(connected.page, "01-trusted-proxy-connected.png");
-    expect(connectedErrors).toEqual([]);
+    expect(connected.errors).toEqual([]);
     await closeContext(connected.context);
-
-    const rejected = await createBrowserPage(allowedUi.baseUrl, proxy.untrustedUrl);
-    const rejectedErrors: string[] = [];
-    rejected.page.on("pageerror", (error) => rejectedErrors.push(String(error)));
-    const expectedReason = "trusted_proxy_missing_header_x-forwarded-proto";
-    await waitForVisibleFailure(rejected.page, "unauthorized");
-    const untrustedEvidence = await waitForConnectionEvidence(
-      (entry) => entry.route === "untrusted" && entry.gatewayResult?.ok === false,
-      rejected.evidenceStartIndex,
-    );
-    expect(untrustedEvidence.gatewayResult?.message).toContain("unauthorized");
-    expect(untrustedEvidence.gatewayResult?.errorReason).toBe(expectedReason);
-    expect(untrustedEvidence.identityInjected).toBe(false);
-    expect(untrustedEvidence.requiredHeaderInjected).toBe(false);
-    await captureChromiumScreenshot(rejected.page, "02-untrusted-proxy-rejected.png");
-    expect(rejectedErrors).toEqual([]);
 
     await writeFile(
       path.join(artifactDir, "trusted-proxy-behavior.json"),
@@ -634,25 +636,7 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
   });
 
   it("confirms gatewayUrl, accepts the allowed origin, and rejects an unlisted origin", async () => {
-    const allowed = await createBrowserPage(allowedUi.baseUrl, proxy.trustedUrl);
-    const allowedErrors: string[] = [];
-    allowed.page.on("pageerror", (error) => allowedErrors.push(String(error)));
-    await allowed.page.locator("openclaw-app-shell").waitFor({ timeout: controlUiSettleTimeoutMs });
-    const allowedOrigin = new URL(allowedUi.baseUrl).origin;
-    const allowedEvidence = await waitForConnectionEvidence(
-      (entry) =>
-        entry.route === "trusted" &&
-        entry.browserOrigin === allowedOrigin &&
-        entry.gatewayResult?.ok === true,
-      allowed.evidenceStartIndex,
-    );
-    await captureChromiumScreenshot(allowed.page, "03-allowed-origin-connected.png");
-    expect(allowedErrors).toEqual([]);
-    await closeContext(allowed.context);
-
     const rejected = await createBrowserPage(rejectedUi.baseUrl, proxy.trustedUrl);
-    const rejectedErrors: string[] = [];
-    rejected.page.on("pageerror", (error) => rejectedErrors.push(String(error)));
     await waitForVisibleFailure(rejected.page, "origin not allowed");
     const rejectedOrigin = new URL(rejectedUi.baseUrl).origin;
     const rejectedEvidence = await waitForConnectionEvidence(
@@ -664,7 +648,22 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
       rejected.evidenceStartIndex,
     );
     await captureChromiumScreenshot(rejected.page, "04-rejected-origin-recovery.png");
-    expect(rejectedErrors).toEqual([]);
+    expect(rejected.errors).toEqual([]);
+    await closeContext(rejected.context);
+
+    const allowed = await createBrowserPage(allowedUi.baseUrl, proxy.trustedUrl);
+    await allowed.page.locator("openclaw-app-shell").waitFor({ timeout: controlUiSettleTimeoutMs });
+    const allowedOrigin = new URL(allowedUi.baseUrl).origin;
+    const allowedEvidence = await waitForConnectionEvidence(
+      (entry) =>
+        entry.route === "trusted" &&
+        entry.browserOrigin === allowedOrigin &&
+        entry.gatewayResult?.ok === true,
+      allowed.evidenceStartIndex,
+    );
+    await captureChromiumScreenshot(allowed.page, "03-allowed-origin-connected.png");
+    expect(allowed.errors).toEqual([]);
+    await closeContext(allowed.context);
 
     await writeFile(
       path.join(artifactDir, "allowed-origins-behavior.json"),

--- a/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
+++ b/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
@@ -529,7 +529,7 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
     }
     await mkdir(artifactDir, { recursive: true });
     allowedUi = await startControlUiE2eServer();
-    rejectedUi = await startControlUiE2eServer(undefined, { source: true });
+    rejectedUi = await startControlUiE2eServer(undefined, { isolatedBundledOrigin: true });
     gateway = await startRealGateway(new URL(allowedUi.baseUrl).origin);
     proxy = await startRealTransportProxy(gateway.url);
     browser = await chromium.launch({ executablePath: chromiumExecutablePath });

--- a/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
+++ b/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
@@ -427,7 +427,7 @@ async function createBrowserPage(
     waitUntil: "domcontentloaded",
   });
   expect(response?.status()).toBe(200);
-  // Source-served UI startup shares CI shard CPU. Bound navigation and the
+  // Bundled UI startup shares CI shard CPU. Bound navigation and the
   // first rendered interaction separately; transport assertions stay narrow.
   const confirmation = page.locator("openclaw-gateway-url-confirmation");
   await confirmation.waitFor({ timeout: controlUiSettleTimeoutMs });
@@ -442,7 +442,7 @@ async function createBrowserPage(
   return { context, evidenceStartIndex, page };
 }
 
-async function warmControlUiSource(baseUrl: string): Promise<void> {
+async function warmBundledControlUiOrigin(baseUrl: string): Promise<void> {
   const context = await browser.newContext({
     locale: "en-US",
     serviceWorkers: "block",
@@ -533,8 +533,8 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
     gateway = await startRealGateway(new URL(allowedUi.baseUrl).origin);
     proxy = await startRealTransportProxy(gateway.url);
     browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-    await warmControlUiSource(allowedUi.baseUrl);
-    await warmControlUiSource(rejectedUi.baseUrl);
+    await warmBundledControlUiOrigin(allowedUi.baseUrl);
+    await warmBundledControlUiOrigin(rejectedUi.baseUrl);
   }, 120_000);
 
   afterAll(async () => {

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -259,6 +259,8 @@ export type ControlUiE2eServer = {
 };
 
 type ControlUiE2eServerOptions = {
+  /** Serve the shard-owned production bundle from a distinct origin. */
+  isolatedBundledOrigin?: boolean;
   source?: boolean;
 };
 
@@ -274,9 +276,14 @@ const DEFAULT_CONTROL_UI_E2E_BUILD_INFO: ControlUiBuildInfo = {
 };
 
 let sharedControlUiE2eServerBaseUrl: string | null = null;
+let sharedControlUiE2eServerOutDir: string | null = null;
 
-export function setSharedControlUiE2eServerBaseUrl(baseUrl: string | null): void {
+export function setSharedControlUiE2eServerBaseUrl(
+  baseUrl: string | null,
+  outDir: string | null = null,
+): void {
   sharedControlUiE2eServerBaseUrl = baseUrl;
+  sharedControlUiE2eServerOutDir = outDir;
 }
 
 export type MockGatewayControls = {
@@ -356,6 +363,15 @@ export async function startControlUiE2eServer(
   buildInfo?: ControlUiBuildInfo,
   options: ControlUiE2eServerOptions = {},
 ): Promise<ControlUiE2eServer> {
+  if (options.isolatedBundledOrigin) {
+    if (buildInfo !== undefined || options.source === true) {
+      throw new Error("An isolated bundled Control UI origin cannot use source build options");
+    }
+    if (sharedControlUiE2eServerOutDir === null) {
+      throw new Error("An isolated bundled Control UI origin requires the shared E2E build");
+    }
+    return startBuiltControlUiE2eServer(sharedControlUiE2eServerOutDir);
+  }
   // Ordinary E2E files exercise the shipped bundle. Source-module and custom
   // build-info tests retain a private Vite server through the same lease API.
   if (


### PR DESCRIPTION
## What Problem This Solves

Fork PRs run UI E2E on the protected four-vCPU GitHub-hosted path. The auth-transport test added a second source Vite dev server beside Chromium, the in-process Gateway, the proxy, and the shard-scoped production preview. Under shard contention, the Gateway repeatedly reached 99.7% event-loop utilization and stopped answering before the test deadline, blocking unrelated Control UI PRs.

## Summary

- reuse the shard-scoped production Control UI build for the auth-transport test second origin
- start a second lightweight preview server from the already-built output instead of a source Vite dev server
- preserve the real Gateway, trusted/untrusted proxy, browser-origin rejection, and separate-origin assertions
- leave fork runner trust routing and all existing timeouts unchanged

Fixes #119084.

## Evidence

The unmodified fork path repeatedly failed while the source Vite server competed with the rest of shard 2/4:

- run 30873295346, job 91879610652
- run 30874334465, job 91882758422
- run 30873558328, job 91880364069
- run 30875521840, job 91886186335

The public logs show 99.7% event-loop utilization, multi-gigabyte RSS, delayed Gateway heartbeats, and the auth transport timing out.

Official run 30877732035 on functional parent `fa25aebbb91d55379773c166e565680db013b8fa` validates the changed lane:

- shard 2/4 job 91892536184 passed 37/37 files and 104/104 tests;
- both real auth-transport scenarios passed while using the isolated bundled origin;
- build artifacts, Control UI checks, type checks, and every non-E2E check completed so far are green.

The run's only E2E failure is an independent shard-4 `config-safe-write.e2e.test.ts` readiness race, reproduced identically on unrelated PR #118884 and tracked separately in #119112 with the focused test-only repair in #119115.

Exact-head run 30879902090 then reproduced the remaining same-shard lifecycle hazard after the source-server removal: the trusted WebSocket authenticated in about 3.6 seconds, but bootstrap RPCs from the connected shell remained in flight for 88–90 seconds and the shell visibility wait expired. Follow-up `bef832606416fe5c654eb18a14ff43814db6a1c6` applies the already reviewed lifecycle ordering from #118893: capture page errors before navigation, run rejection paths before connected shells, and close every context explicitly. No timeout or auth assertion is changed. No local dependency installation, build, or test run was performed.

## Test Plan

- the first commit changes the auth E2E contract to require an isolated bundled origin before the helper supports it
- the second commit publishes the global build directory to workers and serves that exact bundle from a distinct preview origin
- confirm the target auth-transport shard passes on the fork runner path
- keep the independent config-safe-write flake scoped to #119112 rather than mixing it into this PR

## Safety Boundary

This does not weaken origin validation, remove assertions, increase timeouts, move untrusted fork code onto a trusted runner, or disable any feature.

## Current Head

- `bef832606416fe5c654eb18a14ff43814db6a1c6`
- Follow-up `bef832606416` preserves the bundled-origin repair and adds the reviewed #118893 browser-lifecycle ordering after exact-head run 30879902090 exposed 88–90 second bootstrap RPC starvation.
- Official Actions on this exact head are the verification authority; no local dependency installation, build, or test execution was performed.

## AI Assistance

AI assistance was used to analyze the repeated hosted-run failure signature, prepare the focused test-infrastructure change, and draft this description. The exact-head behavior claims above are limited to linked official Actions; no local execution is claimed.