### PR TITLE
feat(codex): add lean runtime profile

### DIFF
--- a/extensions/codex/README.md
+++ b/extensions/codex/README.md
@@ -2,6 +2,22 @@
 
 Official OpenClaw plugin for OpenAI Codex app-server integration. It exposes the Codex-managed GPT model catalog, the Codex runtime surfaces used by OpenClaw agents, and opt-in supervision of native Codex sessions.
 
+## Runtime profiles
+
+Codex defaults to the `lean` profile. It registers the app-server harness, the
+`/codex` command, hosted web search, image understanding, and binding lifecycle
+hooks. Advanced operator surfaces remain opt-in.
+
+Set `plugins.entries.codex.config.runtimeProfile` to `"full"` when you need the
+native session catalog, supervision tools, migration provider, `codex_threads`,
+or node-hosted Codex session controls. The profile is a registration boundary;
+it does not install Codex or change app-server approval or sandbox policy.
+
+This follows Hermes' narrow-core approach: keep the core loop small and make
+specialized tools and workflows explicit. A future bundle-splitting change can
+reduce physical import size further; this first step limits runtime surface area
+without hiding a build-time tradeoff.
+
 Install from OpenClaw:
 
 ```bash

--- a/extensions/codex/index.test.ts
+++ b/extensions/codex/index.test.ts
@@ -123,7 +123,7 @@ describe("codex plugin", () => {
     }
   });
 
-  it("registers the agent harness, native thread tool, and hosted web search", () => {
+  it("registers the full profile surfaces when explicitly requested", () => {
     const registerAgentHarness = vi.fn();
     const registerCommand = vi.fn();
     const registerMediaUnderstandingProvider = vi.fn();
@@ -141,7 +141,7 @@ describe("codex plugin", () => {
         name: "Codex",
         source: "test",
         config: {},
-        pluginConfig: {},
+        pluginConfig: { runtimeProfile: "full" },
         runtime: createCodexTestRuntime(),
         registerAgentHarness,
         registerCommand,
@@ -208,6 +208,40 @@ describe("codex plugin", () => {
     expect(typeof bindingResolvedRegistration?.[0]).toBe("function");
   });
 
+  it("keeps the default profile lean", () => {
+    const registerMigrationProvider = vi.fn();
+    const registerNodeHostCommand = vi.fn();
+    const registerTool = vi.fn();
+    const registerToolMetadata = vi.fn();
+    const registerAgentHarness = vi.fn();
+
+    plugin.register(
+      createTestPluginApi({
+        id: "codex",
+        name: "Codex",
+        source: "test",
+        config: {},
+        pluginConfig: {},
+        runtime: createCodexTestRuntime(),
+        registerAgentHarness,
+        registerCommand: vi.fn(),
+        registerMediaUnderstandingProvider: vi.fn(),
+        registerMigrationProvider,
+        registerNodeHostCommand,
+        registerTool,
+        registerToolMetadata,
+        registerWebSearchProvider: vi.fn(),
+        on: vi.fn(),
+      }),
+    );
+
+    expect(registerAgentHarness).toHaveBeenCalledOnce();
+    expect(registerMigrationProvider).not.toHaveBeenCalled();
+    expect(registerTool).not.toHaveBeenCalledWith(expect.any(Function), { name: "codex_threads" });
+    expect(registerToolMetadata).not.toHaveBeenCalled();
+    expect(registerNodeHostCommand).not.toHaveBeenCalled();
+  });
+
   it("lets native session discovery be disabled without disabling the Codex plugin", () => {
     const registerAgentHarness = vi.fn();
     const registerNodeHostCommand = vi.fn();
@@ -219,7 +253,7 @@ describe("codex plugin", () => {
         name: "Codex",
         source: "test",
         config: {},
-        pluginConfig: { sessionCatalog: { enabled: false } },
+        pluginConfig: { runtimeProfile: "full", sessionCatalog: { enabled: false } },
         runtime: createCodexTestRuntime(),
         registerAgentHarness,
         registerCommand: vi.fn(),
@@ -280,7 +314,7 @@ describe("codex plugin", () => {
         name: "Codex",
         source: "test",
         config: {},
-        pluginConfig: { supervision: { enabled: true } },
+        pluginConfig: { runtimeProfile: "full", supervision: { enabled: true } },
         runtime: createCodexTestRuntime(),
         registerAgentHarness: vi.fn(),
         registerCommand: vi.fn(),
@@ -389,7 +423,7 @@ describe("codex plugin", () => {
     ) as
       | [(context: { senderIsOwner?: boolean }) => { name: string } | null, { name: string }]
       | undefined;
-    expect(registration?.[0]({ senderIsOwner: true })).toBeNull();
+    expect(registration).toBeUndefined();
   });
 
   it("activates from live supervision config through a normalized Codex entry id", () => {

--- a/extensions/codex/index.ts
+++ b/extensions/codex/index.ts
@@ -34,6 +34,7 @@ import {
   resumeCodexCliSessionOnNode,
   resolveCodexCliSessionForBindingOnNode,
 } from "./src/node-cli-sessions.js";
+import { isCodexFullRuntime } from "./src/runtime-profile.js";
 import {
   createCodexSessionCatalogControl,
   createCodexSessionCatalogNodeHostCommands,
@@ -92,6 +93,8 @@ export default definePluginEntry({
     };
     const resolveCurrentPluginConfig = () => resolvePluginConfig(resolveCurrentConfig);
     const appServerConfig = readCodexPluginConfig(resolveCurrentPluginConfig()).appServer;
+    const isFullRuntime = () =>
+      isCodexFullRuntime(readCodexPluginConfig(resolveCurrentPluginConfig()));
     if (appServerConfig?.transport === "websocket") {
       api.registerService(
         createCodexAppServerConnectionHealthService({
@@ -127,6 +130,7 @@ export default definePluginEntry({
       getRuntimeConfig: resolveCurrentConfig,
     });
     const sessionCatalogEnabled =
+      isFullRuntime() &&
       readCodexPluginConfig(resolveCurrentPluginConfig()).sessionCatalog?.enabled !== false;
     if (sessionCatalogEnabled) {
       codexSessionCatalogRuntime.register({
@@ -139,10 +143,15 @@ export default definePluginEntry({
         api.registerNodeHostCommand(command);
       }
     }
-    for (const policy of createCodexSessionCatalogNodeInvokePolicies()) {
-      api.registerNodeInvokePolicy(policy);
+    if (isFullRuntime()) {
+      for (const policy of createCodexSessionCatalogNodeInvokePolicies()) {
+        api.registerNodeInvokePolicy(policy);
+      }
     }
-    if (readCodexPluginConfig(resolveCurrentPluginConfig()).supervision?.enabled === true) {
+    if (
+      isFullRuntime() &&
+      readCodexPluginConfig(resolveCurrentPluginConfig()).supervision?.enabled === true
+    ) {
       api.registerTool(
         (context) => {
           if (context.senderIsOwner !== true) {
@@ -177,29 +186,31 @@ export default definePluginEntry({
     api.registerWebSearchProvider(
       createCodexWebSearchProvider({ resolvePluginConfig: resolveCurrentPluginConfig }),
     );
-    api.registerMigrationProvider(buildCodexMigrationProvider({ runtime: api.runtime }));
-    api.registerTool(
-      (context) =>
-        createCodexThreadsTool({
-          bindingStore,
-          context,
-          runtime: api.runtime,
-          getPluginConfig: resolveCurrentPluginConfig,
-        }),
-      { name: "codex_threads" },
-    );
-    api.registerToolMetadata({
-      toolName: "codex_threads",
-      displayName: "Codex Threads",
-      description: "Manage native Codex threads in the shared user Codex home.",
-      risk: "high",
-      tags: ["codex", "sessions"],
-    });
-    for (const command of createCodexCliSessionNodeHostCommands()) {
-      api.registerNodeHostCommand(command);
-    }
-    for (const policy of createCodexCliSessionNodeInvokePolicies()) {
-      api.registerNodeInvokePolicy(policy);
+    if (isFullRuntime()) {
+      api.registerMigrationProvider(buildCodexMigrationProvider({ runtime: api.runtime }));
+      api.registerTool(
+        (context) =>
+          createCodexThreadsTool({
+            bindingStore,
+            context,
+            runtime: api.runtime,
+            getPluginConfig: resolveCurrentPluginConfig,
+          }),
+        { name: "codex_threads" },
+      );
+      api.registerToolMetadata({
+        toolName: "codex_threads",
+        displayName: "Codex Threads",
+        description: "Manage native Codex threads in the shared user Codex home.",
+        risk: "high",
+        tags: ["codex", "sessions"],
+      });
+      for (const command of createCodexCliSessionNodeHostCommands()) {
+        api.registerNodeHostCommand(command);
+      }
+      for (const policy of createCodexCliSessionNodeInvokePolicies()) {
+        api.registerNodeInvokePolicy(policy);
+      }
     }
     api.registerCommand(
       createCodexCommand({

--- a/extensions/codex/openclaw.plugin.json
+++ b/extensions/codex/openclaw.plugin.json
@@ -28,6 +28,7 @@
     "onAgentHarnesses": ["codex"],
     "onCommands": ["codex"],
     "onConfigPaths": [
+      "plugins.entries.codex.config.runtimeProfile",
       "plugins.entries.codex.config.appServer.transport",
       "plugins.entries.codex.config.sessionCatalog.enabled",
       "plugins.entries.codex.config.supervision.enabled"
@@ -44,6 +45,12 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {
+      "runtimeProfile": {
+        "type": "string",
+        "enum": ["lean", "full"],
+        "default": "lean",
+        "description": "Lean keeps advanced session/operator surfaces opt-in. Full enables native session catalog, supervision, migration, thread controls, and node session controls."
+      },
       "codexDynamicToolsLoading": {
         "type": "string",
         "enum": ["searchable", "direct"],

--- a/extensions/codex/src/app-server/config-contracts.ts
+++ b/extensions/codex/src/app-server/config-contracts.ts
@@ -42,6 +42,7 @@ export type CodexAppServerApprovalsReviewer = "user" | "auto_review" | "guardian
 export type CodexAppServerCommandSource = "managed" | "resolved-managed" | "config" | "env";
 export type CodexManagedCommandOrder = "package-first" | "desktop-first";
 export type CodexDynamicToolsLoading = "searchable" | "direct";
+export type CodexRuntimeProfile = "lean" | "full";
 export type CodexPluginDestructivePolicy = boolean | "auto" | "ask";
 export type CodexPluginDestructiveApprovalMode = "allow" | "deny" | "auto" | "ask";
 
@@ -225,6 +226,8 @@ export type CodexModelBackedReviewerContext = {
 };
 
 export type CodexPluginConfig = {
+  /** Lean keeps advanced operator surfaces opt-in; full restores them. */
+  runtimeProfile?: CodexRuntimeProfile;
   codexDynamicToolsLoading?: CodexDynamicToolsLoading;
   codexDynamicToolsExclude?: string[];
   sessionCatalog?: z.infer<typeof codexSessionCatalogConfigSchema>;

--- a/extensions/codex/src/app-server/config-parsing.ts
+++ b/extensions/codex/src/app-server/config-parsing.ts
@@ -39,6 +39,7 @@ const codexAppServerApprovalPolicySchema = z.preprocess(
 const codexAppServerSandboxSchema = z.enum(["read-only", "workspace-write", "danger-full-access"]);
 const codexAppServerApprovalsReviewerSchema = z.enum(["user", "auto_review", "guardian_subagent"]);
 const codexDynamicToolsLoadingSchema = z.enum(["searchable", "direct"]);
+const codexRuntimeProfileSchema = z.enum(["lean", "full"]);
 const codexComputerUseHealthIntervalSchema = z.union([
   z.literal(30),
   z.literal(60),
@@ -139,6 +140,7 @@ const codexSupervisionConfigSchema = z
 
 const codexPluginConfigSchema = z
   .object({
+    runtimeProfile: codexRuntimeProfileSchema.optional(),
     codexDynamicToolsLoading: codexDynamicToolsLoadingSchema.optional(),
     codexDynamicToolsExclude: z.array(z.string()).optional(),
     sessionCatalog: codexSessionCatalogConfigSchema.optional(),

--- a/extensions/codex/src/runtime-profile.test.ts
+++ b/extensions/codex/src/runtime-profile.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { isCodexFullRuntime, resolveCodexRuntimeProfile } from "./runtime-profile.js";
+
+describe("Codex runtime profile", () => {
+  it("defaults to lean", () => {
+    expect(resolveCodexRuntimeProfile({})).toBe("lean");
+    expect(isCodexFullRuntime({})).toBe(false);
+  });
+
+  it("enables advanced surfaces only for full", () => {
+    expect(resolveCodexRuntimeProfile({ runtimeProfile: "full" })).toBe("full");
+    expect(isCodexFullRuntime({ runtimeProfile: "full" })).toBe(true);
+  });
+
+  it("preserves advanced behavior for existing configured surfaces", () => {
+    expect(resolveCodexRuntimeProfile({ supervision: { enabled: false } })).toBe("full");
+    expect(resolveCodexRuntimeProfile({ sessionCatalog: { enabled: false } })).toBe("full");
+  });
+});

--- a/extensions/codex/src/runtime-profile.ts
+++ b/extensions/codex/src/runtime-profile.ts
@@ -1,0 +1,26 @@
+import type { CodexPluginConfig, CodexRuntimeProfile } from "./app-server/config-contracts.js";
+
+/**
+ * Keeps the default Codex registration narrow. Full exposes the operator and
+ * supervision surfaces that are useful for advanced integrations, but are not
+ * required for ordinary coding turns.
+ */
+export function resolveCodexRuntimeProfile(config: CodexPluginConfig): CodexRuntimeProfile {
+  if (config.runtimeProfile) {
+    return config.runtimeProfile;
+  }
+  // Existing configs that mention an advanced surface keep their historical
+  // behavior. New/unconfigured installs get the lean default.
+  if (
+    config.sessionCatalog !== undefined ||
+    config.supervision !== undefined ||
+    config.appServer?.homeScope === "user"
+  ) {
+    return "full";
+  }
+  return "lean";
+}
+
+export function isCodexFullRuntime(config: CodexPluginConfig): boolean {
+  return resolveCodexRuntimeProfile(config) === "full";
+}


### PR DESCRIPTION
## Summary

Adds a lean-by-default Codex runtime profile inspired by Hermes Agent's narrow-core and optional-skills approach.

### What changed

- Adds `runtimeProfile: "lean" | "full"` to the Codex config.
- Defaults new/unconfigured Codex setups to `lean`.
- Keeps existing advanced configurations backward-compatible: configs that already declare `sessionCatalog`, `supervision`, or user-home app-server scope continue to receive the full registration surface unless explicitly set to `lean`.
- In lean mode, retains the app-server harness, `/codex`, hosted search, image understanding, binding lifecycle, and core app-server health behavior.
- In full mode, restores the native session catalog, supervision tools, migration provider, `codex_threads`, and node-hosted Codex session controls.
- Adds focused profile and registration-boundary tests and documents the behavior.

## Design review

The audit found that the Codex extension entrypoint combines the core harness with several advanced operator surfaces. Those are useful, but they increase registration work, tool inventory, prompt exposure, state/control paths, and risk for ordinary coding turns.

The lean boundary keeps the core loop useful while making high-risk or specialized workflows explicit. It also avoids silently changing app-server approval or sandbox policy.

The first slice deliberately does not claim to shrink the compiled native Codex binary or eliminate all static imports. A physical bundle split is a separate follow-up because it needs a build/runtime loading design and platform packaging validation. This PR measures and reduces active runtime surface without hiding that remaining work.

## Validation

- `pnpm exec vitest run extensions/codex/index.test.ts extensions/codex/src/runtime-profile.test.ts --reporter=dot`
  - 2 files, 32 tests passed.
- Targeted Oxlint over `extensions/codex` passed.
- `pnpm run test:extensions:package-boundary:compile -- extensions/codex` passed; all 125 extension packages compiled.
- Oxfmt check passed for all changed source, test, manifest, and documentation files.
- No plugin installation or activation was performed.

## References

- OpenAI Codex manual: plugin architecture and separation of skills/MCP from the smallest plugin shape: https://developers.openai.com/codex/plugins/
- OpenAI Codex manual: App Server as the integration boundary for threads, turns, approvals, and streamed events: https://developers.openai.com/codex/app-server/
- Hermes Agent documentation: learning loop, memory, skills, tools/toolsets, and architecture: https://hermes-agent.nousresearch.com/docs/
- Hermes Agent contributor guidance: narrow core, prompt-cache discipline, optional skills, and plugin boundaries: https://github.com/NousResearch/hermes-agent/blob/main/AGENTS.md

## Follow-up

Prototype a separate optional bundle/entry for full operator surfaces and add startup/RSS/import benchmarks before attempting physical code splitting.
