### PR TITLE
fix: unblock macOS release validation

### DIFF
--- a/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
+++ b/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
@@ -10,7 +10,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { FILE_LOCK_TIMEOUT_ERROR_CODE, resetFileLockStateForTest } from "../../infra/file-lock.js";
 import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
-import { captureEnv, setTestEnvValue } from "../../test-utils/env.js";
+import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../../test-utils/env.js";
 import { OAuthRefreshFailureError } from "./oauth-refresh-failure.js";
 import { buildRefreshContentionError } from "./oauth-refresh-lock-errors.js";
 import {
@@ -154,7 +154,7 @@ function requireOAuthContext(context: unknown): OAuthCredential {
 }
 
 describe("resolveApiKeyForProfile openai refresh fallback", () => {
-  const envSnapshot = captureEnv(OAUTH_AGENT_ENV_KEYS);
+  const envSnapshot = captureEnv([...OAUTH_AGENT_ENV_KEYS, "OPENAI_API_KEY"]);
   let tempRoot = "";
   let agentDir = "";
   let caseIndex = 0;
@@ -186,6 +186,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
     await fs.mkdir(agentDir, { recursive: true });
     setTestEnvValue("OPENCLAW_STATE_DIR", caseRoot);
     setTestEnvValue("OPENCLAW_AGENT_DIR", agentDir);
+    deleteTestEnvValue("OPENAI_API_KEY");
   });
 
   afterEach(async () => {

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -948,6 +948,7 @@ describe("processGatewayAllowlist", () => {
     fs.writeFileSync(shadowGit, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
     try {
       const command = "git status";
+      const canonicalShadowGit = fs.realpathSync(shadowGit);
       await configurePlanBackedCommand({
         command,
         env: { PATH: tempDir },
@@ -961,9 +962,9 @@ describe("processGatewayAllowlist", () => {
       });
 
       expect(defaultExecAutoReviewerMock).toHaveBeenCalledWith(
-        expect.objectContaining({ resolvedPath: shadowGit }),
+        expect.objectContaining({ resolvedPath: canonicalShadowGit }),
       );
-      expect(result).toEqual({ execCommandOverride: `${shadowGit} status` });
+      expect(result).toEqual({ execCommandOverride: `${canonicalShadowGit} status` });
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
@@ -1157,6 +1158,15 @@ describe("processGatewayAllowlist", () => {
     if (!authorizationPlan.ok) {
       throw new Error(authorizationPlan.reason);
     }
+    const enforced = buildAuthorizedShellCommandFromPlan({
+      plan: authorizationPlan,
+      mode: "enforced",
+      segmentSatisfiedBy: ["safeBuiltins"],
+    });
+    expect(enforced.ok).toBe(true);
+    if (!enforced.ok) {
+      throw new Error(enforced.reason);
+    }
     hasDurableExecApprovalMock.mockReturnValue(true);
     hasExactCommandDurableExecApprovalMock.mockReturnValue(true);
     evaluateShellAllowlistWithAuthorizationMock.mockReturnValue({
@@ -1183,7 +1193,7 @@ describe("processGatewayAllowlist", () => {
     const result = await runGatewayAllowlist({ command });
 
     expect(createAndRegisterDefaultExecApprovalRequestMock).not.toHaveBeenCalled();
-    expect(result).toEqual({ execCommandOverride: command });
+    expect(result).toEqual({ execCommandOverride: enforced.command });
     expect(commitExecAuthorizationMock).toHaveBeenCalledWith(
       expect.objectContaining({
         authorization: expect.objectContaining({

--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -2,7 +2,7 @@
 
 import { expectDefined } from "@openclaw/normalization-core";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../config/sessions.js";
 import {
   looksLikeSecretSentinel,
@@ -571,6 +571,10 @@ function mockOpenAIPlatformProfile(): void {
 }
 
 describe("runBtwSideQuestion", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   beforeEach(() => {
     streamSimpleMock.mockReset();
     readFileMock.mockReset();
@@ -1001,6 +1005,7 @@ describe("runBtwSideQuestion", () => {
   });
 
   it("lets native Codex bootstrap auth without a host profile", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "");
     const supports = vi.fn((ctx: Parameters<AgentHarness["supports"]>[0]) => {
       if (ctx.modelProvider?.preparedAuth?.source !== "harness") {
         return supportsPreparedOpenAIAuth(ctx);

--- a/src/agents/runtime-plan/prepare-auth.test.ts
+++ b/src/agents/runtime-plan/prepare-auth.test.ts
@@ -1377,6 +1377,7 @@ describe("prepareAgentRuntimeAuthPlan", () => {
   });
 
   it("resolves an env SecretRef on its prepared Platform route", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "");
     vi.stubEnv("OPENAI_PLATFORM_KEY", "secret-ref-platform-key");
     try {
       const config = {

--- a/src/agents/sandbox-paths.test.ts
+++ b/src/agents/sandbox-paths.test.ts
@@ -206,6 +206,30 @@ describe("assertSandboxPath", () => {
       await fs.rm(parent, { recursive: true, force: true });
     }
   });
+
+  it.runIf(process.platform !== "win32")(
+    "preserves final-symlink unlink policy through a root alias",
+    async () => {
+      await withSandboxRoot(async (parent) => {
+        const realRoot = path.join(parent, "real-workspace");
+        const linkedRoot = path.join(parent, "linked-workspace");
+        const outside = path.join(parent, "outside.txt");
+        await fs.mkdir(realRoot);
+        await fs.writeFile(outside, "outside", "utf8");
+        await fs.symlink(realRoot, linkedRoot);
+        await fs.symlink(outside, path.join(realRoot, "link"));
+
+        await expect(
+          assertSandboxPath({
+            filePath: "link",
+            cwd: linkedRoot,
+            root: linkedRoot,
+            allowFinalSymlinkForUnlink: true,
+          }),
+        ).resolves.toMatchObject({ relative: "link" });
+      });
+    },
+  );
 });
 
 describe("resolveSandboxedMediaSource", () => {

--- a/src/agents/sandbox-paths.ts
+++ b/src/agents/sandbox-paths.ts
@@ -115,15 +115,21 @@ async function assertRawParentWithinRoot(params: {
   filePath: string;
   cwd: string;
   root: string;
-}): Promise<string> {
+}): Promise<{ rootCanonical: string; targetCanonical: string }> {
   // Win32 resolves reparse-point/.. paths lexically, so it has no equivalent escape.
   // Avoid adding another realpath to this hot path on Windows, where it is expensive.
   if (process.platform === "win32") {
-    return resolveSandboxInputPath(params.filePath, params.cwd);
+    return {
+      rootCanonical: path.resolve(params.root),
+      targetCanonical: resolveSandboxInputPath(params.filePath, params.cwd),
+    };
   }
   const expanded = expandPath(params.filePath);
   if (isWindowsDrivePath(expanded)) {
-    return path.win32.normalize(expanded);
+    return {
+      rootCanonical: path.resolve(params.root),
+      targetCanonical: path.win32.normalize(expanded),
+    };
   }
   // Do not use path.resolve here: it would erase the symlink-sensitive `..` before
   // native realpath can traverse the raw parent chain. The final component stays
@@ -146,7 +152,7 @@ async function assertRawParentWithinRoot(params: {
       `Path escapes sandbox root (${shortenHomePath(rootCanonical)}): ${params.filePath}`,
     );
   }
-  return targetCanonical;
+  return { rootCanonical, targetCanonical };
 }
 
 export async function assertSandboxPath(params: {
@@ -170,10 +176,10 @@ export async function assertSandboxPath(params: {
   // The alias guard owns its specific symlink/hardlink errors; this closes the raw
   // symlink-then-`..` gap that lexical normalization hides from that guard.
   const rawTarget = await assertRawParentWithinRoot(params);
-  if (path.resolve(rawTarget) !== path.resolve(resolved.resolved)) {
+  if (path.resolve(rawTarget.targetCanonical) !== path.resolve(resolved.resolved)) {
     await assertNoPathAliasEscape({
-      absolutePath: rawTarget,
-      rootPath: params.root,
+      absolutePath: rawTarget.targetCanonical,
+      rootPath: rawTarget.rootCanonical,
       boundaryLabel: "sandbox root",
       policy,
     });

--- a/src/agents/sandbox/fs-bridge-stat-parse.ts
+++ b/src/agents/sandbox/fs-bridge-stat-parse.ts
@@ -6,6 +6,11 @@
 import { parseStrictNonNegativeInteger } from "../../infra/parse-finite-number.js";
 import { asDateTimestampMs } from "../../shared/number-coercion.js";
 
+export function hasMultipleHardlinks(raw: string): boolean {
+  const linkCount = parseStrictNonNegativeInteger(raw);
+  return linkCount === undefined ? /^\d+$/.test(raw) : linkCount > 1;
+}
+
 /** Parses file sizes, capping huge integer strings at the largest safe JS integer. */
 export function parseSandboxStatSize(value: string | undefined): number {
   const raw = value ?? "0";

--- a/src/agents/sandbox/remote-fs-bridge-canonical-path.ts
+++ b/src/agents/sandbox/remote-fs-bridge-canonical-path.ts
@@ -1,0 +1,79 @@
+/** Canonical path resolution for remote shell-backed sandbox mounts. */
+import path from "node:path";
+import type {
+  SandboxBackendCommandParams,
+  SandboxBackendCommandResult,
+} from "./backend-handle.types.js";
+import { relativePathEscapesContainerRoot } from "./path-utils.js";
+import { normalizeContainerPath } from "./remote-fs-bridge-paths.js";
+
+export type RemoteCanonicalPath = {
+  canonicalPath: string;
+  canonicalMountRoot: string;
+  logicalPath: string;
+};
+
+export async function resolveRemoteCanonicalPath(params: {
+  containerPath: string;
+  mountRootPath: string;
+  action: string;
+  allowFinalSymlinkForUnlink?: boolean;
+  signal?: AbortSignal;
+  runRemoteShellScript(command: SandboxBackendCommandParams): Promise<SandboxBackendCommandResult>;
+}): Promise<RemoteCanonicalPath> {
+  // Canonicalize the nearest existing ancestor and append the missing suffix.
+  // This lets create/write operations validate paths that do not exist yet.
+  const script = [
+    "set -eu",
+    'target="$1"',
+    'allow_final="$2"',
+    'suffix=""',
+    'probe="$target"',
+    'if [ "$allow_final" = "1" ] && [ -L "$target" ]; then probe=$(dirname -- "$target"); fi',
+    'cursor="$probe"',
+    'while [ ! -e "$cursor" ] && [ ! -L "$cursor" ]; do',
+    '  parent=$(dirname -- "$cursor")',
+    '  if [ "$parent" = "$cursor" ]; then break; fi',
+    '  base=$(basename -- "$cursor")',
+    '  suffix="/$base$suffix"',
+    '  cursor="$parent"',
+    "done",
+    'canonical=$(readlink -f -- "$cursor")',
+    'canonical_root=$(readlink -f -- "$3")',
+    'printf "%s%s\\n%s\\n" "$canonical" "$suffix" "$canonical_root"',
+  ].join("\n");
+  const result = await params.runRemoteShellScript({
+    script,
+    args: [
+      params.containerPath,
+      params.allowFinalSymlinkForUnlink ? "1" : "0",
+      params.mountRootPath,
+    ],
+    signal: params.signal,
+  });
+  const [canonicalRaw = "", canonicalRootRaw = ""] = result.stdout
+    .toString("utf8")
+    .trim()
+    .split("\n");
+  if (!canonicalRaw || !canonicalRootRaw) {
+    throw new Error(
+      `Sandbox path canonicalization failed; cannot ${params.action}: ${params.containerPath}`,
+    );
+  }
+  const canonicalPath = normalizeContainerPath(canonicalRaw);
+  const canonicalMountRoot = normalizeContainerPath(canonicalRootRaw);
+  const relative = path.posix.relative(canonicalMountRoot, canonicalPath);
+  if (relativePathEscapesContainerRoot(relative)) {
+    throw new Error(
+      `Sandbox path escapes allowed mounts; cannot ${params.action}: ${params.containerPath}`,
+    );
+  }
+  return {
+    canonicalPath,
+    canonicalMountRoot,
+    logicalPath:
+      relative === "."
+        ? params.mountRootPath
+        : normalizeContainerPath(path.posix.join(params.mountRootPath, relative)),
+  };
+}

--- a/src/agents/sandbox/remote-fs-bridge-paths.ts
+++ b/src/agents/sandbox/remote-fs-bridge-paths.ts
@@ -101,6 +101,26 @@ export function compareRemoteMountsByLocalPath(a: RemoteMountInfo, b: RemoteMoun
   return b.localRoot.length - a.localRoot.length || mountPriority(b) - mountPriority(a);
 }
 
+export function buildRemoteProtectedSkillRoots(params: {
+  workspaceContainerRoot: string;
+  agentContainerRoot: string;
+  includeAgentMount: boolean;
+}): string[] {
+  const roots = [
+    path.posix.join(params.workspaceContainerRoot, "skills"),
+    path.posix.join(params.workspaceContainerRoot, ".agents", "skills"),
+    path.posix.join(params.workspaceContainerRoot, ".openclaw", "sandbox-skills", "skills"),
+  ];
+  if (params.includeAgentMount) {
+    roots.push(
+      path.posix.join(params.agentContainerRoot, "skills"),
+      path.posix.join(params.agentContainerRoot, ".agents", "skills"),
+      path.posix.join(params.agentContainerRoot, ".openclaw", "sandbox-skills", "skills"),
+    );
+  }
+  return roots;
+}
+
 function mountPriority(mount: RemoteMountInfo): number {
   if (mount.source === "protectedSkill") {
     return 2;

--- a/src/agents/sandbox/remote-fs-bridge.test.ts
+++ b/src/agents/sandbox/remote-fs-bridge.test.ts
@@ -27,7 +27,7 @@ function createStatRuntime(
         return shellResult("1\n");
       }
       if (command.script.includes('readlink -f -- "$cursor"')) {
-        return shellResult(`${workspaceDir}/note.txt\n`);
+        return shellResult(`${workspaceDir}/note.txt\n${workspaceDir}\n`);
       }
       if (command.script.includes('stat -c "%F|%h"')) {
         return shellResult(`${outputs.hardlinks(command.script)}\n`);
@@ -169,6 +169,53 @@ describe("remote sandbox fs bridge", () => {
   );
 
   it.runIf(process.platform !== "win32")(
+    "accepts a symlinked mount root while rejecting escapes through it",
+    async () => {
+      await withTempDir("openclaw-remote-fs-linked-root-", async (stateDir) => {
+        const realWorkspaceDir = path.join(stateDir, "real-workspace");
+        const linkedWorkspaceDir = path.join(stateDir, "linked-workspace");
+        const outsideDir = path.join(stateDir, "outside");
+        await fs.mkdir(realWorkspaceDir);
+        await fs.mkdir(outsideDir);
+        await fs.symlink(realWorkspaceDir, linkedWorkspaceDir, "dir");
+        await fs.symlink(outsideDir, path.join(realWorkspaceDir, "escape"), "dir");
+        const { runtime } = createLocalRemoteRuntime({
+          remoteWorkspaceDir: linkedWorkspaceDir,
+          remoteAgentWorkspaceDir: linkedWorkspaceDir,
+        });
+        const bridge = createRemoteShellSandboxFsBridge({
+          sandbox: createSandbox({
+            workspaceDir: linkedWorkspaceDir,
+            agentWorkspaceDir: linkedWorkspaceDir,
+          }),
+          runtime,
+        });
+        const createFileExclusive = bridge.createFileExclusive?.bind(bridge);
+        expect(createFileExclusive).toBeTypeOf("function");
+
+        await expect(
+          createFileExclusive!({ filePath: "inside.txt", data: "inside" }),
+        ).resolves.toBe("created");
+        await expect(bridge.readFile({ filePath: "inside.txt" })).resolves.toEqual(
+          Buffer.from("inside"),
+        );
+        await expect(bridge.mkdirp({ filePath: "nested/dir" })).resolves.toBeUndefined();
+        await expect(fs.readFile(path.join(realWorkspaceDir, "inside.txt"), "utf8")).resolves.toBe(
+          "inside",
+        );
+        await expect(
+          fs
+            .stat(path.join(realWorkspaceDir, "nested", "dir"))
+            .then((entry) => entry.isDirectory()),
+        ).resolves.toBe(true);
+        await expect(
+          createFileExclusive!({ filePath: "escape/outside.txt", data: "blocked" }),
+        ).rejects.toThrow(/escapes allowed mounts/);
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
     "reads files with the pinned mutation helper",
     async () => {
       await withTempDir("openclaw-remote-fs-bridge-", async (stateDir) => {
@@ -192,11 +239,11 @@ describe("remote sandbox fs bridge", () => {
         await expect(bridge.readFile({ filePath: "note.txt" })).resolves.toEqual(
           Buffer.from("hello"),
         );
-        expect(calls).toHaveLength(1);
-        expect(calls[0]?.args?.[0]).toBe("read");
-        expect(calls[0]?.script).toContain("python3 /dev/fd/3 \"$@\" 3<<'PY'");
-        expect(calls[0]?.script).toContain("read_file(parent_fd, basename)");
-        expect(calls[0]?.script).not.toContain('cat -- "$1"');
+        expect(calls).toHaveLength(2);
+        const readCall = calls.find((call) => call.args?.[0] === "read");
+        expect(readCall?.script).toContain("python3 /dev/fd/3 \"$@\" 3<<'PY'");
+        expect(readCall?.script).toContain("read_file(parent_fd, basename)");
+        expect(readCall?.script).not.toContain('cat -- "$1"');
       });
     },
   );
@@ -222,14 +269,20 @@ describe("remote sandbox fs bridge", () => {
         await expect(bridge.readFile({ filePath: "note.txt", maxBytes: 5 })).resolves.toEqual(
           Buffer.from("hello"),
         );
-        expect(calls[0]?.args).toEqual(["read", workspaceDir, "", "note.txt", "5"]);
+        expect(calls.find((call) => call.args?.[0] === "read")?.args).toEqual([
+          "read",
+          workspaceDir,
+          "",
+          "note.txt",
+          "5",
+        ]);
         await expect(bridge.readFile({ filePath: "note.txt", maxBytes: 4 })).rejects.toThrow(
           /bounded read limit/i,
         );
         await expect(bridge.readFile({ filePath: "note.txt", maxBytes: -1 })).rejects.toThrow(
           /non-negative safe integer/i,
         );
-        expect(calls).toHaveLength(2);
+        expect(calls).toHaveLength(4);
       });
     },
   );

--- a/src/agents/sandbox/remote-fs-bridge.ts
+++ b/src/agents/sandbox/remote-fs-bridge.ts
@@ -4,10 +4,8 @@
  * Resolves sandbox paths against uploaded remote mounts and performs guarded operations through backend shell commands.
  */
 import path from "node:path";
-import { parseStrictNonNegativeInteger } from "../../infra/parse-finite-number.js";
 import { isPathInside } from "../../infra/path-guards.js";
 import type {
-  SandboxBackendCommandParams,
   SandboxBackendCommandResult,
   SandboxFsBridgeContext,
 } from "./backend-handle.types.js";
@@ -16,41 +14,29 @@ import {
   SANDBOX_PINNED_MUTATION_PYTHON,
 } from "./fs-bridge-mutation-helper.js";
 import { createWritableRenameTargetResolver } from "./fs-bridge-rename-targets.js";
-import { parseSandboxStatMtimeMs, parseSandboxStatSize } from "./fs-bridge-stat-parse.js";
+import {
+  hasMultipleHardlinks,
+  parseSandboxStatMtimeMs,
+  parseSandboxStatSize,
+} from "./fs-bridge-stat-parse.js";
 import type { SandboxFsBridge, SandboxFsStat, SandboxResolvedPath } from "./fs-bridge.types.js";
 import { isPathInsideContainerRoot, relativePathEscapesContainerRoot } from "./path-utils.js";
 import {
+  resolveRemoteCanonicalPath,
+  type RemoteCanonicalPath,
+} from "./remote-fs-bridge-canonical-path.js";
+import {
+  buildRemoteProtectedSkillRoots,
   buildRemoteProtectedSkillMounts,
   compareRemoteMountsByContainerPath,
   compareRemoteMountsByLocalPath,
   normalizeContainerPath,
   type RemoteMountInfo,
-  type RemoteMountSource,
   toPosixRelative,
 } from "./remote-fs-bridge-paths.js";
+import type { ResolvedRemotePath, RemoteShellSandboxHandle } from "./remote-fs-bridge.types.js";
 
-type ResolvedRemotePath = SandboxResolvedPath & {
-  writable: boolean;
-  mountRootPath: string;
-  source: RemoteMountSource;
-};
-
-function hasMultipleHardlinks(raw: string): boolean {
-  const linkCount = parseStrictNonNegativeInteger(raw);
-  if (linkCount !== undefined) {
-    return linkCount > 1;
-  }
-  return /^\d+$/.test(raw);
-}
-
-type MountInfo = RemoteMountInfo;
-
-/** Minimal remote shell contract used by the SSH filesystem bridge. */
-export type RemoteShellSandboxHandle = {
-  remoteWorkspaceDir: string;
-  remoteAgentWorkspaceDir: string;
-  runRemoteShellScript(params: SandboxBackendCommandParams): Promise<SandboxBackendCommandResult>;
-};
+export type { RemoteShellSandboxHandle } from "./remote-fs-bridge.types.js";
 
 /** Create the filesystem bridge for remote shell-backed sandbox runtimes. */
 export function createRemoteShellSandboxFsBridge(params: {
@@ -100,12 +86,18 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     ) {
       throw new Error(`Invalid sandbox entry target: ${target.containerPath}`);
     }
+    const pinned = await this.resolvePinnedParent({
+      containerPath: target.containerPath,
+      mountRootPath: target.mountRootPath,
+      action: "read files",
+      signal: params.signal,
+    });
     const result = await this.runMutation({
       args: [
         "read",
-        target.mountRootPath,
-        path.posix.dirname(relativePath) === "." ? "" : path.posix.dirname(relativePath),
-        path.posix.basename(relativePath),
+        pinned.mountRootPath,
+        pinned.relativeParentPath,
+        pinned.basename,
         ...(params.maxBytes === undefined ? [] : [String(params.maxBytes)]),
       ],
       signal: params.signal,
@@ -133,11 +125,13 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     });
     const sourcePinned = await this.resolvePinnedParent({
       containerPath: source.containerPath,
+      mountRootPath: source.mountRootPath,
       action: "copy files",
       signal: params.signal,
     });
     const destinationPinned = await this.resolvePinnedParent({
       containerPath: destination.containerPath,
+      mountRootPath: destination.mountRootPath,
       action: "copy files",
       requireWritable: true,
       signal: params.signal,
@@ -169,6 +163,7 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     await this.ensureRemoteWritable(target, "write files", params.signal);
     const pinned = await this.resolvePinnedParent({
       containerPath: target.containerPath,
+      mountRootPath: target.mountRootPath,
       action: "write files",
       requireWritable: true,
       signal: params.signal,
@@ -206,6 +201,7 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     await this.ensureRemoteWritable(target, "create files", params.signal);
     const pinned = await this.resolvePinnedParent({
       containerPath: target.containerPath,
+      mountRootPath: target.mountRootPath,
       action: "create files",
       requireWritable: true,
       signal: params.signal,
@@ -245,8 +241,22 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
         `Sandbox path escapes allowed mounts; cannot create directories: ${target.containerPath}`,
       );
     }
+    if (relativePath === "" || relativePath === ".") {
+      return;
+    }
+    const pinned = await this.resolvePinnedParent({
+      containerPath: target.containerPath,
+      mountRootPath: target.mountRootPath,
+      action: "create directories",
+      requireWritable: true,
+      signal: params.signal,
+    });
     await this.runMutation({
-      args: ["mkdirp", target.mountRootPath, relativePath === "." ? "" : relativePath],
+      args: [
+        "mkdirp",
+        pinned.mountRootPath,
+        path.posix.join(pinned.relativeParentPath, pinned.basename),
+      ],
       signal: params.signal,
     });
   }
@@ -269,6 +279,7 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     }
     const pinned = await this.resolvePinnedParent({
       containerPath: target.containerPath,
+      mountRootPath: target.mountRootPath,
       action: "remove files",
       requireWritable: true,
       allowFinalSymlinkForUnlink: true,
@@ -299,6 +310,7 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     await this.ensureRemoteWritable(to, "rename files", params.signal);
     const fromPinned = await this.resolvePinnedParent({
       containerPath: from.containerPath,
+      mountRootPath: from.mountRootPath,
       action: "rename files",
       requireWritable: true,
       allowFinalSymlinkForUnlink: true,
@@ -306,6 +318,7 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     });
     const toPinned = await this.resolvePinnedParent({
       containerPath: to.containerPath,
+      mountRootPath: to.mountRootPath,
       action: "rename files",
       requireWritable: true,
       signal: params.signal,
@@ -335,19 +348,20 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     if (!exists) {
       return null;
     }
-    const canonical = await this.resolveCanonicalPath({
+    const { canonicalPath } = await this.resolveCanonicalPath({
       containerPath: target.containerPath,
+      mountRootPath: target.mountRootPath,
       action: "stat files",
       signal: params.signal,
     });
     await this.assertNoHardlinkedFile({
-      containerPath: canonical,
+      containerPath: canonicalPath,
       action: "stat files",
       signal: params.signal,
     });
-    const result = await this.runRemoteScript({
+    const result = await this.runtime.runRemoteShellScript({
       script: 'set -eu\nLC_ALL=C stat -c "%F|%s|%y" -- "$1"',
-      args: [canonical],
+      args: [canonicalPath],
       signal: params.signal,
     });
     const output = result.stdout.toString("utf8").trim();
@@ -359,12 +373,12 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     };
   }
 
-  private getMounts(): MountInfo[] {
+  private getMounts(): RemoteMountInfo[] {
     const workspaceRoot = path.resolve(this.sandbox.workspaceDir);
     const agentRoot = path.resolve(this.sandbox.agentWorkspaceDir);
     const workspaceContainerRoot = normalizeContainerPath(this.runtime.remoteWorkspaceDir);
     const agentContainerRoot = normalizeContainerPath(this.runtime.remoteAgentWorkspaceDir);
-    const mounts: MountInfo[] = [
+    const mounts: RemoteMountInfo[] = [
       {
         localRoot: workspaceRoot,
         containerRoot: workspaceContainerRoot,
@@ -452,7 +466,10 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     throw new Error(`Sandbox path escapes allowed mounts; cannot access: ${params.filePath}`);
   }
 
-  private toResolvedPath(params: { mount: MountInfo; containerPath: string }): ResolvedRemotePath {
+  private toResolvedPath(params: {
+    mount: RemoteMountInfo;
+    containerPath: string;
+  }): ResolvedRemotePath {
     const relative = path.posix.relative(params.mount.containerRoot, params.containerPath);
     if (relativePathEscapesContainerRoot(relative)) {
       throw new Error(
@@ -476,9 +493,9 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
   }
 
   private resolveMountByContainerPath(
-    mounts: MountInfo[],
+    mounts: RemoteMountInfo[],
     containerPath: string,
-  ): MountInfo | null {
+  ): RemoteMountInfo | null {
     const ordered = [...mounts].toSorted(compareRemoteMountsByContainerPath);
     for (const mount of ordered) {
       if (isPathInsideContainerRoot(mount.containerRoot, containerPath)) {
@@ -488,7 +505,10 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     return null;
   }
 
-  private resolveMountByLocalPath(mounts: MountInfo[], localPath: string): MountInfo | null {
+  private resolveMountByLocalPath(
+    mounts: RemoteMountInfo[],
+    localPath: string,
+  ): RemoteMountInfo | null {
     const ordered = [...mounts].toSorted(compareRemoteMountsByLocalPath);
     for (const mount of ordered) {
       if (isPathInside(mount.localRoot, localPath)) {
@@ -534,7 +554,12 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
   }
 
   private findRemoteProtectedSkillRoot(containerPath: string): string | null {
-    const roots = this.getRemoteProtectedSkillRoots().toSorted((a, b) => b.length - a.length);
+    const roots = buildRemoteProtectedSkillRoots({
+      workspaceContainerRoot: normalizeContainerPath(this.runtime.remoteWorkspaceDir),
+      agentContainerRoot: normalizeContainerPath(this.runtime.remoteAgentWorkspaceDir),
+      includeAgentMount:
+        path.resolve(this.sandbox.agentWorkspaceDir) !== path.resolve(this.sandbox.workspaceDir),
+    }).toSorted((a, b) => b.length - a.length);
     for (const root of roots) {
       if (isPathInsideContainerRoot(root, containerPath)) {
         return root;
@@ -543,26 +568,8 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     return null;
   }
 
-  private getRemoteProtectedSkillRoots(): string[] {
-    const workspaceContainerRoot = normalizeContainerPath(this.runtime.remoteWorkspaceDir);
-    const agentContainerRoot = normalizeContainerPath(this.runtime.remoteAgentWorkspaceDir);
-    const roots = [
-      path.posix.join(workspaceContainerRoot, "skills"),
-      path.posix.join(workspaceContainerRoot, ".agents", "skills"),
-      path.posix.join(workspaceContainerRoot, ".openclaw", "sandbox-skills", "skills"),
-    ];
-    if (path.resolve(this.sandbox.agentWorkspaceDir) !== path.resolve(this.sandbox.workspaceDir)) {
-      roots.push(
-        path.posix.join(agentContainerRoot, "skills"),
-        path.posix.join(agentContainerRoot, ".agents", "skills"),
-        path.posix.join(agentContainerRoot, ".openclaw", "sandbox-skills", "skills"),
-      );
-    }
-    return roots;
-  }
-
   private async remotePathExists(containerPath: string, signal?: AbortSignal): Promise<boolean> {
-    const result = await this.runRemoteScript({
+    const result = await this.runtime.runRemoteShellScript({
       script: 'if [ -e "$1" ] || [ -L "$1" ]; then printf "1\\n"; else printf "0\\n"; fi',
       args: [containerPath],
       signal,
@@ -572,42 +579,15 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
 
   private async resolveCanonicalPath(params: {
     containerPath: string;
+    mountRootPath: string;
     action: string;
     allowFinalSymlinkForUnlink?: boolean;
     signal?: AbortSignal;
-  }): Promise<string> {
-    // Canonicalize the nearest existing ancestor and append the missing suffix.
-    // This lets create/write operations validate paths that do not exist yet.
-    const script = [
-      "set -eu",
-      'target="$1"',
-      'allow_final="$2"',
-      'suffix=""',
-      'probe="$target"',
-      'if [ "$allow_final" = "1" ] && [ -L "$target" ]; then probe=$(dirname -- "$target"); fi',
-      'cursor="$probe"',
-      'while [ ! -e "$cursor" ] && [ ! -L "$cursor" ]; do',
-      '  parent=$(dirname -- "$cursor")',
-      '  if [ "$parent" = "$cursor" ]; then break; fi',
-      '  base=$(basename -- "$cursor")',
-      '  suffix="/$base$suffix"',
-      '  cursor="$parent"',
-      "done",
-      'canonical=$(readlink -f -- "$cursor")',
-      'printf "%s%s\\n" "$canonical" "$suffix"',
-    ].join("\n");
-    const result = await this.runRemoteScript({
-      script,
-      args: [params.containerPath, params.allowFinalSymlinkForUnlink ? "1" : "0"],
-      signal: params.signal,
+  }): Promise<RemoteCanonicalPath> {
+    return await resolveRemoteCanonicalPath({
+      ...params,
+      runRemoteShellScript: async (command) => await this.runtime.runRemoteShellScript(command),
     });
-    const canonical = normalizeContainerPath(result.stdout.toString("utf8").trim());
-    if (!this.resolveMountByContainerPath(this.getMounts(), canonical)) {
-      throw new Error(
-        `Sandbox path escapes allowed mounts; cannot ${params.action}: ${params.containerPath}`,
-      );
-    }
-    return canonical;
   }
 
   private async assertNoHardlinkedFile(params: {
@@ -617,7 +597,7 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
   }): Promise<void> {
     // Remote mutation helpers pin by parent path. Rejecting hardlinked regular
     // files avoids editing another mount-visible name through the same inode.
-    const result = await this.runRemoteScript({
+    const result = await this.runtime.runRemoteShellScript({
       script: [
         'if [ ! -e "$1" ] && [ ! -L "$1" ]; then exit 0; fi',
         'stats=$(LC_ALL=C stat -c "%F|%h" -- "$1")',
@@ -641,6 +621,7 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
 
   private async resolvePinnedParent(params: {
     containerPath: string;
+    mountRootPath: string;
     action: string;
     requireWritable?: boolean;
     allowFinalSymlinkForUnlink?: boolean;
@@ -650,12 +631,14 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     if (!basename || basename === "." || basename === "/") {
       throw new Error(`Invalid sandbox entry target: ${params.containerPath}`);
     }
-    const canonicalParent = await this.resolveCanonicalPath({
+    const { canonicalPath, canonicalMountRoot, logicalPath } = await this.resolveCanonicalPath({
       containerPath: normalizeContainerPath(path.posix.dirname(params.containerPath)),
+      mountRootPath: params.mountRootPath,
       action: params.action,
       allowFinalSymlinkForUnlink: params.allowFinalSymlinkForUnlink,
+      signal: params.signal,
     });
-    const mount = this.resolveMountByContainerPath(this.getMounts(), canonicalParent);
+    const mount = this.resolveMountByContainerPath(this.getMounts(), logicalPath);
     if (!mount) {
       throw new Error(
         `Sandbox path escapes allowed mounts; cannot ${params.action}: ${params.containerPath}`,
@@ -668,20 +651,22 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     }
     if (params.requireWritable) {
       await this.assertRemoteProtectedPathWritable({
-        containerPath: canonicalParent,
+        containerPath: logicalPath,
         action: params.action,
         displayPath: params.containerPath,
         signal: params.signal,
       });
     }
-    const relativeParentPath = path.posix.relative(mount.containerRoot, canonicalParent);
+    // Resolve mount policy in the logical namespace, but pin mutations to the
+    // canonical root so a legitimate symlinked workspace root is not reopened.
+    const relativeParentPath = path.posix.relative(canonicalMountRoot, canonicalPath);
     if (relativePathEscapesContainerRoot(relativeParentPath)) {
       throw new Error(
         `Sandbox path escapes allowed mounts; cannot ${params.action}: ${params.containerPath}`,
       );
     }
     return {
-      mountRootPath: mount.containerRoot,
+      mountRootPath: canonicalMountRoot,
       relativeParentPath: relativeParentPath === "." ? "" : relativeParentPath,
       basename,
     };
@@ -693,29 +678,13 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     signal?: AbortSignal;
     allowFailure?: boolean;
   }): Promise<SandboxBackendCommandResult> {
-    return await this.runRemoteScript({
+    return await this.runtime.runRemoteShellScript({
       script: [
         "set -eu",
         "python3 /dev/fd/3 \"$@\" 3<<'PY'",
         SANDBOX_PINNED_MUTATION_PYTHON,
         "PY",
       ].join("\n"),
-      args: params.args,
-      stdin: params.stdin,
-      signal: params.signal,
-      allowFailure: params.allowFailure,
-    });
-  }
-
-  private async runRemoteScript(params: {
-    script: string;
-    args?: string[];
-    stdin?: Buffer | string;
-    signal?: AbortSignal;
-    allowFailure?: boolean;
-  }) {
-    return await this.runtime.runRemoteShellScript({
-      script: params.script,
       args: params.args,
       stdin: params.stdin,
       signal: params.signal,

--- a/src/agents/sandbox/remote-fs-bridge.types.ts
+++ b/src/agents/sandbox/remote-fs-bridge.types.ts
@@ -1,0 +1,19 @@
+import type {
+  SandboxBackendCommandParams,
+  SandboxBackendCommandResult,
+} from "./backend-handle.types.js";
+import type { SandboxResolvedPath } from "./fs-bridge.types.js";
+import type { RemoteMountSource } from "./remote-fs-bridge-paths.js";
+
+export type ResolvedRemotePath = SandboxResolvedPath & {
+  writable: boolean;
+  mountRootPath: string;
+  source: RemoteMountSource;
+};
+
+/** Minimal remote shell contract used by the SSH filesystem bridge. */
+export type RemoteShellSandboxHandle = {
+  remoteWorkspaceDir: string;
+  remoteAgentWorkspaceDir: string;
+  runRemoteShellScript(params: SandboxBackendCommandParams): Promise<SandboxBackendCommandResult>;
+};

--- a/src/agents/tools/model-config.helpers.test.ts
+++ b/src/agents/tools/model-config.helpers.test.ts
@@ -107,6 +107,7 @@ const hasDirectOpenAiKey = (
   });
 
 beforeEach(() => {
+  vi.stubEnv("OPENAI_API_KEY", "");
   authMocks.resolveEnvApiKey.mockReset();
   authMocks.resolveEnvApiKey.mockImplementation(
     (provider: string, _env?: unknown, options?: { config?: unknown }) =>

--- a/src/claws/lifecycle.ts
+++ b/src/claws/lifecycle.ts
@@ -207,7 +207,8 @@ export async function buildClawAddPlan(params: {
   const packageRoot = await realpath(params.source.packageRoot).catch(
     () => params.source.packageRoot,
   );
-  const source = { ...params.source, packageRoot };
+  const manifestPath = resolvePathViaExistingAncestorSync(resolve(params.source.manifestPath));
+  const source = { ...params.source, packageRoot, manifestPath };
   const sourceRoot = await fsSafeRoot(packageRoot);
   const blockers: ClawDiagnostic[] = [];
   const actions: ClawAddPlanAction[] = [];

--- a/src/claws/workspace.test.ts
+++ b/src/claws/workspace.test.ts
@@ -157,6 +157,51 @@ describe("createClawWorkspaceFiles", () => {
     );
   });
 
+  it.runIf(process.platform !== "win32")(
+    "materializes the CLAW.md body through a symlinked package root",
+    async () => {
+      const root = tempDirs.make("openclaw-claw-linked-package-");
+      const realPackageRoot = join(root, "real-package");
+      const linkedPackageRoot = join(root, "linked-package");
+      const workspace = join(root, "workspace-agent");
+      const body = Buffer.from("# Portable soul\n\nBe concise.\n");
+      await mkdir(realPackageRoot);
+      await symlink(realPackageRoot, linkedPackageRoot, "dir");
+      const manifestPath = join(linkedPackageRoot, "CLAW.md");
+      await writeFile(
+        manifestPath,
+        Buffer.concat([
+          Buffer.from("---\nschemaVersion: 1\nagent: { id: workspace-agent }\n---\n"),
+          body,
+        ]),
+      );
+      const manifest = parseClawManifest({ schemaVersion: 1, agent: { id: "workspace-agent" } });
+      if (!manifest.ok) {
+        throw new Error(JSON.stringify(manifest.diagnostics));
+      }
+      const plan = await buildClawAddPlan({
+        manifest: manifest.manifest,
+        clawMarkdownBody: body,
+        source: {
+          kind: "package",
+          name: "@acme/workspace-agent",
+          version: "1.0.0",
+          packageRoot: linkedPackageRoot,
+          manifestPath,
+          integrityKind: "development-snapshot",
+          integrity: "sha256:manifest",
+          byteLength: 0,
+        },
+        context: { workspace },
+      });
+      await mkdir(workspace);
+
+      await createClawWorkspaceFiles(plan, { env: stateEnv(root), nowMs: 10 });
+
+      await expect(readFile(join(workspace, "SOUL.md"), "utf8")).resolves.toBe(body.toString());
+    },
+  );
+
   it("creates canonical bootstrap and supporting files and records their hashes", async () => {
     const { root, workspace, plan } = await makePlan();
 

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -518,6 +518,7 @@ describe("capability cli", () => {
   });
 
   beforeEach(() => {
+    vi.stubEnv("OPENAI_API_KEY", "");
     mocks.runtime.log.mockClear();
     mocks.runtime.error.mockClear();
     mocks.runtime.writeJson.mockClear();

--- a/src/commands/auth-choice.model-check.test.ts
+++ b/src/commands/auth-choice.model-check.test.ts
@@ -67,7 +67,7 @@ describe("warnIfModelConfigLooksOff", () => {
       },
     } as OpenClawConfig;
 
-    await warnIfModelConfigLooksOff(config, prompter, { validateCatalog: false });
+    await warnIfModelConfigLooksOff(config, prompter, { env: {}, validateCatalog: false });
 
     expect(loadModelCatalog).not.toHaveBeenCalled();
     expect(ensureAuthProfileStore).toHaveBeenCalledOnce();

--- a/src/commands/doctor-workspace.test.ts
+++ b/src/commands/doctor-workspace.test.ts
@@ -31,6 +31,11 @@ async function expectPathMissing(targetPath: string): Promise<void> {
   throw new Error(`expected path to be missing: ${targetPath}`);
 }
 
+async function hasDistinctRootMemoryFiles(directory: string): Promise<boolean> {
+  const entries = new Set(await fs.readdir(directory));
+  return entries.has("MEMORY.md") && entries.has("memory.md");
+}
+
 function firstNoteCall() {
   return note.mock.calls[0];
 }
@@ -67,8 +72,7 @@ describe("root memory repair", () => {
   it("merges true split-brain root memory files into MEMORY.md", async () => {
     await fs.writeFile(path.join(tmpDir, "MEMORY.md"), "# Canonical\n", "utf8");
     await fs.writeFile(path.join(tmpDir, "memory.md"), "# Legacy\n", "utf8");
-    const entries = new Set(await fs.readdir(tmpDir));
-    if (!entries.has("MEMORY.md") || !entries.has("memory.md")) {
+    if (!(await hasDistinctRootMemoryFiles(tmpDir))) {
       return;
     }
 
@@ -95,6 +99,9 @@ describe("root memory repair", () => {
     const legacyPath = path.join(tmpDir, "memory.md");
     await fs.writeFile(canonicalPath, "# Canonical\n", "utf8");
     await fs.writeFile(legacyPath, "# Legacy\n", "utf8");
+    if (!(await hasDistinctRootMemoryFiles(tmpDir))) {
+      return;
+    }
 
     const rename = vi.spyOn(fs, "rename");
     rename.mockImplementationOnce(async (sourcePath, targetPath) => {
@@ -115,6 +122,9 @@ describe("root memory repair", () => {
     const legacyPath = path.join(tmpDir, "memory.md");
     await fs.writeFile(canonicalPath, "# Canonical\n", "utf8");
     await fs.writeFile(legacyPath, "# Legacy\n", "utf8");
+    if (!(await hasDistinctRootMemoryFiles(tmpDir))) {
+      return;
+    }
 
     const rename = vi.spyOn(fs, "rename");
     rename.mockImplementationOnce(async (sourcePath, targetPath) => {
@@ -140,6 +150,9 @@ describe("root memory repair", () => {
     const legacyPath = path.join(tmpDir, "memory.md");
     await fs.writeFile(canonicalPath, "# Canonical\n", "utf8");
     await fs.writeFile(legacyPath, "# Legacy\n", "utf8");
+    if (!(await hasDistinctRootMemoryFiles(tmpDir))) {
+      return;
+    }
 
     const rename = vi.spyOn(fs, "rename");
     rename.mockImplementationOnce(async (sourcePath, targetPath) => {
@@ -164,8 +177,7 @@ describe("root memory repair", () => {
   it("warns and repairs split-brain root memory through workspace doctor helpers", async () => {
     await fs.writeFile(path.join(tmpDir, "MEMORY.md"), "# Canonical\n", "utf8");
     await fs.writeFile(path.join(tmpDir, "memory.md"), "# Legacy\n", "utf8");
-    const entries = new Set(await fs.readdir(tmpDir));
-    if (!entries.has("MEMORY.md") || !entries.has("memory.md")) {
+    if (!(await hasDistinctRootMemoryFiles(tmpDir))) {
       return;
     }
     const cfg = {
@@ -227,6 +239,9 @@ describe("root memory repair", () => {
   it("does not archive or remove an oversized legacy memory file", async () => {
     await fs.writeFile(path.join(tmpDir, "MEMORY.md"), "# Canonical\n", "utf8");
     await fs.writeFile(path.join(tmpDir, "memory.md"), "# Legacy\n".repeat(1_000_000), "utf8");
+    if (!(await hasDistinctRootMemoryFiles(tmpDir))) {
+      return;
+    }
 
     const migration = await migrateLegacyRootMemoryFile(tmpDir);
     expect(migration.changed).toBe(false);
@@ -241,6 +256,9 @@ describe("root memory repair", () => {
   it("does not archive or remove a valid legacy memory file when canonical is oversized", async () => {
     await fs.writeFile(path.join(tmpDir, "MEMORY.md"), "# Canonical\n".repeat(1_000_000), "utf8");
     await fs.writeFile(path.join(tmpDir, "memory.md"), "# Legacy\n", "utf8");
+    if (!(await hasDistinctRootMemoryFiles(tmpDir))) {
+      return;
+    }
 
     const migration = await migrateLegacyRootMemoryFile(tmpDir);
     expect(migration.changed).toBe(false);
@@ -257,6 +275,9 @@ describe("root memory repair", () => {
     await fs.writeFile(targetFile, "# Canonical\n", "utf8");
     await fs.symlink(targetFile, path.join(tmpDir, "MEMORY.md"));
     await fs.writeFile(path.join(tmpDir, "memory.md"), "# Legacy\n", "utf8");
+    if (!(await hasDistinctRootMemoryFiles(tmpDir))) {
+      return;
+    }
 
     const migration = await migrateLegacyRootMemoryFile(tmpDir);
     expect(migration.changed).toBe(false);
@@ -274,6 +295,9 @@ describe("root memory repair", () => {
     await fs.writeFile(targetFile, "# Canonical\n", "utf8");
     await fs.symlink(targetFile, path.join(tmpDir, "MEMORY.md"));
     await fs.writeFile(path.join(tmpDir, "memory.md"), "# Legacy\n", "utf8");
+    if (!(await hasDistinctRootMemoryFiles(tmpDir))) {
+      return;
+    }
     const cfg = {
       agents: { defaults: { workspace: tmpDir }, entries: { main: { default: true } } },
     } as OpenClawConfig;
@@ -296,6 +320,9 @@ describe("root memory repair", () => {
   it("reports a skipped repair when a root memory file is oversized", async () => {
     await fs.writeFile(path.join(tmpDir, "MEMORY.md"), "# Canonical\n", "utf8");
     await fs.writeFile(path.join(tmpDir, "memory.md"), "# Legacy\n".repeat(1_000_000), "utf8");
+    if (!(await hasDistinctRootMemoryFiles(tmpDir))) {
+      return;
+    }
     const cfg = {
       agents: { defaults: { workspace: tmpDir }, entries: { main: { default: true } } },
     } as OpenClawConfig;
@@ -322,6 +349,9 @@ describe("root memory repair", () => {
     const legacyPath = path.join(tmpDir, "memory.md");
     await fs.writeFile(canonicalPath, "# Canonical\n", "utf8");
     await fs.writeFile(legacyPath, "# Legacy\n", "utf8");
+    if (!(await hasDistinctRootMemoryFiles(tmpDir))) {
+      return;
+    }
     const rename = vi
       .spyOn(fs, "rename")
       .mockRejectedValueOnce(Object.assign(new Error("cross-device rename"), { code: "EXDEV" }));
@@ -343,6 +373,9 @@ describe("root memory repair", () => {
   it("reports when legacy memory cannot be archived atomically", async () => {
     await fs.writeFile(path.join(tmpDir, "MEMORY.md"), "# Canonical\n", "utf8");
     await fs.writeFile(path.join(tmpDir, "memory.md"), "# Legacy\n", "utf8");
+    if (!(await hasDistinctRootMemoryFiles(tmpDir))) {
+      return;
+    }
     const cfg = {
       agents: { defaults: { workspace: tmpDir }, entries: { main: { default: true } } },
     } as OpenClawConfig;
@@ -374,6 +407,9 @@ describe("root memory repair", () => {
     const legacyPath = path.join(tmpDir, "memory.md");
     await fs.writeFile(canonicalPath, "# Canonical\n", "utf8");
     await fs.writeFile(legacyPath, "# Legacy\n", "utf8");
+    if (!(await hasDistinctRootMemoryFiles(tmpDir))) {
+      return;
+    }
     const cfg = {
       agents: { defaults: { workspace: tmpDir }, entries: { main: { default: true } } },
     } as OpenClawConfig;

--- a/src/gateway/server-methods/models-auth-status.test.ts
+++ b/src/gateway/server-methods/models-auth-status.test.ts
@@ -2,7 +2,7 @@
 // credential cleanup, secret refresh, and provider run abort side effects.
 
 import { expectDefined } from "@openclaw/normalization-core";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthHealthSummary } from "../../agents/auth-health.js";
 import type { AuthProfileStore } from "../../agents/auth-profiles.js";
 import { NON_ENV_SECRETREF_MARKER } from "../../agents/model-auth-markers.js";
@@ -233,6 +233,7 @@ async function readAuthStatus(params: Record<string, unknown> = {}) {
 }
 
 function resetAuthStatusMocks(): void {
+  vi.stubEnv("OPENAI_API_KEY", "");
   vi.clearAllMocks();
   invalidateModelAuthStatusCache();
   mocks.getRuntimeConfig.mockReturnValue({});
@@ -261,6 +262,10 @@ function resetAuthStatusMocks(): void {
   mocks.loadProviderUsageSummary.mockResolvedValue(emptyUsageSummary());
   mocks.refreshActiveProviderAuthRuntimeSnapshot.mockResolvedValue(false);
 }
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 function firstExternalCliAuthOption() {
   expect(mocks.ensureAuthProfileStore).toHaveBeenCalledTimes(1);

--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -839,9 +839,10 @@ describe("sessions.usage", () => {
   it("preserves JSONL detail lookup for storeless sessions", async () => {
     await withUsageState(async (writeSessionFile) => {
       const sessionFile = writeSessionFile("storeless.jsonl");
+      const canonicalSessionFile = fs.realpathSync(sessionFile);
       await runSessionsUsageTimeseries({ key: "agent:opus:storeless" });
       expect(vi.mocked(loadSessionUsageTimeSeries)).toHaveBeenCalledWith(
-        expect.objectContaining({ sessionFile, sessionEntry: undefined }),
+        expect.objectContaining({ sessionFile: canonicalSessionFile, sessionEntry: undefined }),
       );
     });
   });

--- a/src/gateway/server-methods/usage.status-cache.test.ts
+++ b/src/gateway/server-methods/usage.status-cache.test.ts
@@ -83,6 +83,7 @@ describe("usage.status provider usage cache", () => {
   beforeEach(() => {
     now = 1_000;
     store = createStore();
+    vi.stubEnv("OPENAI_API_KEY", "");
     vi.spyOn(Date, "now").mockImplementation(() => now);
     vi.clearAllMocks();
     clearModelAuthStatusUsageCache();
@@ -109,6 +110,7 @@ describe("usage.status provider usage cache", () => {
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
 

--- a/src/system-agent/setup-inference-detection.test.ts
+++ b/src/system-agent/setup-inference-detection.test.ts
@@ -97,6 +97,7 @@ describe("isolated setup inference detection", () => {
         partialDetection: fallback,
       },
       timeoutMs: 100,
+      fallbackEnv: {},
     });
     const startedAt = performance.now();
     const response = await requestHealth(`http://127.0.0.1:${address.port}/health`);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where macOS release validation could fail when temporary workspaces used case-insensitive or symlink-aliased paths, while tests also inherited maintainer-machine credentials and path spellings.

The same alias mismatch could make remote sandbox reads, directory creation, and mutations fail through a valid symlinked workspace root.

## Why This Change Was Made

The release tests now skip only split-memory assertions that require case-distinct filenames and explicitly isolate credential-sensitive expectations from ambient host state.

Sandbox and Claw workspace paths are canonicalized through their nearest existing ancestor. Remote sandbox policy remains evaluated in the logical mount namespace, while pinned filesystem operations use the canonical root so all operations retain no-follow and mount-escape protections.

## User Impact

Maintainers can run the Beta 8 native release-preparation gate on macOS without host-specific false failures.

Remote sandbox users can read, create directories, and mutate files through a valid symlinked workspace root; paths that escape the canonical mount remain rejected. No config, protocol, or persisted-data contract changes.

## Evidence

- Exact candidate head: `3850c2037d651e21d24b784750c24a646ce20d7b`
- Exact base: `e0799199b30fda0ee7268c8fed7e195cb6f5251b`
- Fresh Testbox: https://github.com/openclaw/openclaw/actions/runs/30884985852
- `pnpm check:changed -- <22 touched paths>`: passed, including core/test typechecks, lint, dead-code, database-first, schema-version, import-cycle, and security guards.
- Focused Testbox proof: 16 files across 7 Vitest shards, 609/609 tests passed.
- Linked-root regression covers exclusive create, pinned read, recursive directory creation, and canonical escape rejection.
- Supported local toolchain: Node 24.18.1 and Python 3.13.14; the same 609 focused tests passed.
- Fresh exact-head autoreview: clean, no accepted/actionable findings, patch correctness 0.99.
- ClawSweeper's read/mkdirp canonical-root finding is addressed in this head.
- AI-assisted: yes.
