### PR TITLE
test(qa): prove shared-channel memory recall

### DIFF
--- a/qa/scenarios/memory/memory-tools-channel-context.yaml
+++ b/qa/scenarios/memory/memory-tools-channel-context.yaml
@@ -5,13 +5,16 @@ scenario:
   surface: session-memory
   coverage:
     primary:
-      - session-memory.memory-tools
+      - session-memory.group-memory
+      - session-memory.qa-channel-memory
     secondary:
+      - session-memory.memory-tools
       - channels.room-session-group-messages
-  objective: Verify the agent uses memory tools in a shared channel when the answer lives only in memory files, not the live transcript.
+  objective: Verify a shared QA-channel message causally recalls a fact from a nested memory file before the agent replies in the same room.
   successCriteria:
-    - Agent uses memory_search before answering.
-    - Final reply returns the memory-only fact correctly in-channel.
+    - The initial model request does not contain the memory-only fact and plans memory_search with the expected arguments.
+    - The matching memory_search result plans memory_get for the seeded path, whose correlated result supplies the recalled fact.
+    - The ordered tool chain produces exactly one visible final reply in the originating QA room.
   docsRefs:
     - docs/concepts/memory.md
     - docs/concepts/memory-search.md
@@ -21,12 +24,17 @@ scenario:
   execution:
     kind: flow
     channel: qa-channel
-    summary: Verify the agent uses memory tools in a shared channel when the answer lives only in memory files, not the live transcript.
+    providerMode: mock-openai
+    retryCount: 0
+    summary: Prove a QA-channel group message consumes a matched nested-memory result before one in-room reply.
     config:
+      requiredProviderMode: mock-openai
       channelId: qa-memory-room
       channelTitle: QA Memory Room
+      expectedMemoryPath: memory/qa-shared-channel.md
       memoryFact: "Hidden QA fact: the project codename is ORBIT-9."
       memoryQuery: "hidden project codename"
+      expectedCorpus: null
       expectedNeedle: ORBIT-9
       prompt: "@openclaw Memory tools check: what is the hidden project codename stored only in memory? Use memory tools first."
       promptSnippet: "Memory tools check"
@@ -35,10 +43,18 @@ flow:
   steps:
     - name: uses memory_search before answering in-channel
       actions:
+        - assert:
+            expr: "env.providerMode === config.requiredProviderMode"
+            message:
+              expr: "`expected provider mode ${config.requiredProviderMode}, got ${env.providerMode}`"
         - call: reset
+        - call: fs.mkdir
+          args:
+            - expr: "path.dirname(path.join(env.gateway.workspaceDir, config.expectedMemoryPath))"
+            - recursive: true
         - call: fs.writeFile
           args:
-            - expr: "path.join(env.gateway.workspaceDir, 'MEMORY.md')"
+            - expr: "path.join(env.gateway.workspaceDir, config.expectedMemoryPath)"
             - expr: "`${config.memoryFact}\\n`"
             - utf8
         - call: forceMemoryIndex
@@ -57,6 +73,12 @@ flow:
           args:
             - ref: env
             - 60000
+        - set: requestCursorBeforeInbound
+          value:
+            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/request-cursor`)).cursor"
+        - set: outboundStartIndex
+          value:
+            expr: "state.getSnapshot().messages.length"
         - sendInbound:
             conversation:
               id:
@@ -74,9 +96,49 @@ flow:
             - ref: state
             - lambda:
                 params: [candidate]
-                expr: "candidate.conversation.id === config.channelId && candidate.text.includes(config.expectedNeedle)"
+                expr: "candidate.direction === 'outbound' && candidate.conversation.id === config.channelId && candidate.conversation.kind === 'channel' && candidate.text.includes(config.expectedNeedle)"
             - expr: liveTurnTimeoutMs(env, 30000)
+            - sinceIndex:
+                ref: outboundStartIndex
+        - set: scenarioRequests
+          value:
+            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBeforeInbound}`)).filter((request) => String(request.allInputText ?? '').includes(config.promptSnippet))"
         - assert:
-            expr: "!env.mock || (await fetchJson(`${env.mock.baseUrl}/debug/requests`)).filter((request) => String(request.allInputText ?? '').includes(config.promptSnippet)).some((request) => request.plannedToolName === 'memory_search')"
-            message: expected memory_search in mock request plan
-      detailsExpr: outbound.text
+            expr: scenarioRequests.length === 3
+            message:
+              expr: "`expected one memory_search plan, one matched result request, and one finalization request: ${JSON.stringify(scenarioRequests)}`"
+        - set: searchPlanRequest
+          value:
+            expr: scenarioRequests[0]
+        - set: searchResultRequest
+          value:
+            expr: scenarioRequests[1]
+        - set: finalRequest
+          value:
+            expr: scenarioRequests[2]
+        - assert:
+            expr: "searchPlanRequest.plannedToolName === 'memory_search' && searchPlanRequest.plannedToolArgs?.query === config.memoryQuery && (searchPlanRequest.plannedToolArgs?.corpus ?? null) === config.expectedCorpus && typeof searchPlanRequest.plannedToolCallId === 'string' && searchPlanRequest.plannedToolCallId.length > 0 && !searchPlanRequest.toolOutputCallId && !String(searchPlanRequest.allInputText ?? '').includes(config.expectedNeedle)"
+            message:
+              expr: "`initial request exposed the hidden fact or missed the expected memory_search plan: ${JSON.stringify(searchPlanRequest)}`"
+        - assert:
+            expr: "searchResultRequest.cursor > searchPlanRequest.cursor && searchResultRequest.toolOutputCallId === searchPlanRequest.plannedToolCallId && searchResultRequest.toolOutputStructuredError !== true && String(searchResultRequest.toolOutput ?? '').includes(config.expectedMemoryPath) && String(searchResultRequest.toolOutput ?? '').includes(config.expectedNeedle) && searchResultRequest.plannedToolName === 'memory_get' && searchResultRequest.plannedToolArgs?.path === config.expectedMemoryPath && typeof searchResultRequest.plannedToolCallId === 'string' && searchResultRequest.plannedToolCallId.length > 0 && searchResultRequest.plannedToolCallId !== searchPlanRequest.plannedToolCallId"
+            message:
+              expr: "`following request did not consume memory_search and plan a distinct memory_get call for the expected path: ${JSON.stringify(searchResultRequest)}`"
+        - assert:
+            expr: "finalRequest.cursor > searchResultRequest.cursor && finalRequest.toolOutputCallId === searchResultRequest.plannedToolCallId && finalRequest.toolOutputStructuredError !== true && String(finalRequest.toolOutput ?? '').includes(config.expectedMemoryPath) && String(finalRequest.toolOutput ?? '').includes(config.expectedNeedle) && !finalRequest.plannedToolName"
+            message:
+              expr: "`final request did not consume the matching successful memory_get result: ${JSON.stringify(finalRequest)}`"
+        - call: sleep
+          args: [4000]
+        - set: visibleChannelOutbounds
+          value:
+            expr: "state.getSnapshot().messages.slice(outboundStartIndex).filter((message) => message.direction === 'outbound' && !message.deleted && message.conversation.id === config.channelId && message.conversation.kind === 'channel')"
+        - assert:
+            expr: "visibleChannelOutbounds.length === 1 && visibleChannelOutbounds[0].id === outbound.id"
+            message:
+              expr: "`expected exactly one visible QA-room reply after the ordered memory result: ${JSON.stringify(visibleChannelOutbounds)}`"
+        - assert:
+            expr: "(outbound.text.match(new RegExp(config.expectedNeedle, 'g')) ?? []).length === 1"
+            message:
+              expr: "`final QA-room reply must contain ${config.expectedNeedle} exactly once: ${outbound.text}`"
+      detailsExpr: "`${outbound.text}; path=${config.expectedMemoryPath}; matched=${searchResultRequest.toolOutputCallId === searchPlanRequest.plannedToolCallId}; room=${config.channelId}`"


### PR DESCRIPTION
## What Problem This Solves

The existing shared-channel memory scenario only checked that some mock request planned `memory_search`, seeded root `MEMORY.md`, and accepted any matching outbound. It did not prove that a QA-channel group turn consumed the matched nested-memory result before one visible in-room reply.

## Why This Change Was Made

This strengthens the existing `memory-tools-channel-context` scenario without changing production or QA Lab runtime code. It seeds `memory/qa-shared-channel.md`, captures the mock request cursor before inbound delivery, verifies that the matched `memory_search` result plans `memory_get` with a distinct call ID for the seeded path, binds the final request to that exact call ID and current successful output, waits through the established four-second post-final duplicate window, and then requires the complete visible `qa-memory-room` outbound list to contain only the final reply.

The scenario is the sole primary owner for:

- `session-memory.group-memory`
- `session-memory.qa-channel-memory`

The previous generic memory-tools and room-session claims remain secondary.

## User Impact

No production behavior changes. QA now catches regressions where shared-channel memory lookup leaks the answer into initial context, reuses a tool-call ID, loses either tool-call correlation, returns the wrong memory path, finalizes from aggregate transcript text instead of the current `memory_get` result, or emits any early/late extra visible room reply during the bounded observation window regardless of its text.

AI-assisted: yes.

## Evidence

- Signed exact head: `54eab19cea268c26f0770e515d2aaa9307e79ef2`
- Production LOC: `0`
- QA scenario delta: `+72/-10`
- Focused catalog/coverage tests: `81/81` passed.
- Exact-head QA suite: `memory-tools-channel-context` passed `1/1`.
- Exact-head artifacts:
  - `.artifacts/qa-e2e/b3-shared-channel-memory/54eab19cea26-quiet-window-exact/qa-suite-report.md`
  - `.artifacts/qa-e2e/b3-shared-channel-memory/54eab19cea26-quiet-window-exact/qa-suite-summary.json`
  - `.artifacts/qa-e2e/b3-shared-channel-memory/54eab19cea26-quiet-window-exact/qa-evidence.json`
  - `.artifacts/qa-e2e/b3-shared-channel-memory/54eab19cea26-quiet-window-exact/quiet-window-mutations.json`
- `qa-evidence.json` records the exact head and exactly the two primary IDs above.
- Reviewer-style source/mutation proof requires first-final wait → four-second quiet window → scoped room snapshot → exact-list assertion; removing the quiet window or injecting a late nonmatching outbound fails while all prior correlation mutations remain rejected.
- Changed gate: Daytona was selected but failed before execution during the local Actions environment handoff with SSH exit `255`. The permitted trusted-source local fallback passed all guards, full tsgo, lint, and zero runtime import cycles.
- YAML parse, oxfmt, `git diff --check`, privacy scan, and role-aware sole-primary checks passed.
- Fresh Sol/high branch autoreview: clean, confidence `0.99`.
