### PR TITLE
fix(thread-ownership): treat blank SLACK_BOT_USER_ID as unset for mention tracking

### DIFF
--- a/extensions/thread-ownership/index.test.ts
+++ b/extensions/thread-ownership/index.test.ts
@@ -473,6 +473,30 @@ describe("thread-ownership plugin", () => {
       expect(globalThis.fetch).not.toHaveBeenCalled();
     });
 
+    // Regression: a SLACK_BOT_USER_ID with surrounding whitespace was stored verbatim,
+    // so the <@id> substring check never matched a real mention and the ownership
+    // forwarder was consulted even in threads where the bot was explicitly addressed.
+    it("tracks bot user ID mentions when SLACK_BOT_USER_ID has surrounding whitespace", async () => {
+      process.env.SLACK_BOT_USER_ID = " U999 ";
+
+      await requireHook("message_received")(
+        {
+          content: "Hey <@U999> help",
+          threadId: "8888.0002",
+          metadata: { channelId: "C789" },
+        },
+        { channelId: "slack", conversationId: "C789" },
+      );
+
+      const result = await requireHook("message_sending")(
+        { content: "On it!", replyToId: "8888.0002", metadata: { channelId: "C789" }, to: "C789" },
+        { channelId: "slack", conversationId: "C789" },
+      );
+
+      expect(result).toBeUndefined();
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
     it("tracks agent-name mentions case-insensitively", async () => {
       await requireHook("message_received")(
         {

--- a/extensions/thread-ownership/index.ts
+++ b/extensions/thread-ownership/index.ts
@@ -111,7 +111,7 @@ export default definePluginEntry({
             .map((entry) => resolveSlackConversationId(entry))
             .filter(Boolean),
         ),
-        botUserId: process.env.SLACK_BOT_USER_ID ?? "",
+        botUserId: normalizeOptionalString(process.env.SLACK_BOT_USER_ID) ?? "",
         agent: resolveOwnershipAgent(currentConfig),
       };
     };


### PR DESCRIPTION
## Summary

Normalize `SLACK_BOT_USER_ID` with the already-imported `normalizeOptionalString` before storing it, so blank or whitespace-padded values no longer disable `<@botUserId>` mention tracking in Slack threads.

## What Problem This Solves

The thread-ownership plugin resolves its per-event state with (`extensions/thread-ownership/index.ts:114`):

```ts
botUserId: process.env.SLACK_BOT_USER_ID ?? "",
```

`??` only falls through on `undefined`/`null`, so any defined value is stored verbatim. The mention check then does a literal substring match:

```ts
const mentioned =
  containsAgentNameMention(text, agent.name) ||
  (botUserId && text.includes(`<@${botUserId}>`));
```

When the process runs with a padded or whitespace-only `SLACK_BOT_USER_ID` — common when the variable is templated from an env file or secret manager that leaves surrounding whitespace, e.g. `SLACK_BOT_USER_ID=" U12345 "` — the stored value is never trimmed:

1. `" U12345 "` makes the check search for the literal `<@ U12345 >`, which never appears in a real Slack message — real `<@U12345>` mentions are missed.
2. A whitespace-only `" "` searches for `<@ >` — same dead check.
3. An empty `""` is stored as a configured value and only accidentally behaves like "unset" because of the truthiness guard.

A missed mention means the thread is never recorded in `mentionedThreads`, so when the agent later sends in a thread where it was explicitly `<@U12345>`-addressed, the plugin still consults the ownership forwarder and can cancel the send on a 409 — **the agent stays silent in threads where a user explicitly called it**, with no error surfaced anywhere.

The neighboring env var in the same resolver (`SLACK_FORWARDER_URL`, line 102) already goes through `normalizeOptionalString`; `SLACK_BOT_USER_ID` was the one left raw.

**Code evidence**: `index.ts:114` stored `process.env.SLACK_BOT_USER_ID` verbatim while the sibling line right above it normalized its env var, and the `<@id>` substring check at line 140 can never match a padded stored value against a real mention.

## Root Cause

- The raw `?? ""` read dates to commit 834e50f83cf (2026-04-22), which moved the plugin to live config resolution.
- Violated invariant: the code assumes "variable is defined" implies "variable is a usable Slack user ID". A blank or padded string satisfies the first and breaks the second — Slack IDs never contain spaces, so a verbatim-stored padded value makes the substring check unreachable.
- Trigger: run the gateway with `SLACK_BOT_USER_ID=" U12345 "` (or whitespace-only); `<@U12345>` mentions stop marking threads, and later sends in those threads hit the ownership forwarder (and can be cancelled) despite the explicit mention.

## Why This Fix

- Reuse the `normalizeOptionalString` already imported and applied to `SLACK_FORWARDER_URL` two lines above: blank/whitespace-only values become `undefined` and fall through to the `""` default ("unset"), and a padded valid ID is trimmed to the usable `U12345`.
- One-line change at the single resolution point; `botUserId` has exactly one consumer (the mention check), so there is no ripple.
- Alternative considered: trimming at the comparison site (`text.includes(...)`) — rejected because the resolver is where every other value in this plugin is normalized, and fixing the consumer would leave the stored state inconsistent with `SLACK_FORWARDER_URL` handling.

## User Impact

- Affected operations: Slack thread-ownership mention tracking on deployments whose `SLACK_BOT_USER_ID` carries surrounding whitespace (env-file templating, secret managers, copy-paste).
- Before: `<@U12345>` mentions silently fail to register; the agent consults the ownership forwarder — and may cancel its own reply — in threads where it was explicitly addressed.
- After: padded values are trimmed and blank values are treated as unset, so mention detection works exactly as with a cleanly exported variable.

## Evidence

- **Before**: on main, the real plugin registered against a real loopback HTTP forwarder with `SLACK_BOT_USER_ID=" U12345 "` misses a real `<@U12345>` mention — `message_sending` in the same thread issues `POST /api/v1/ownership/C555/4200.0001` → FAIL
- **After**: the same flow tracks the mention and skips the ownership call entirely (zero HTTP hits) → PASS

## Real Behavior Proof

### Before (on main)
```bash
$ node --import tsx proof.mjs
forwarder HTTP hits: ["POST /api/v1/ownership/C555/4200.0001"]
message_sending result: "allowed"
FAIL: padded SLACK_BOT_USER_ID was stored verbatim, so the real <@U12345> mention was never matched and the agent still consulted the ownership forwarder in a thread where it was explicitly addressed
```

### After (with fix)
```bash
$ node --import tsx proof.mjs
forwarder HTTP hits: []
message_sending result: "allowed"
PASS: padded SLACK_BOT_USER_ID normalized to U12345; the <@U12345> mention was tracked and the ownership check was skipped
```

## Tests and Validation

- `node scripts/run-vitest.mjs extensions/thread-ownership/index.test.ts extensions/thread-ownership/index.transport.test.ts` passed (28 cases) and `git diff --check` is clean
- Added regression coverage in `extensions/thread-ownership/index.test.ts`: with `SLACK_BOT_USER_ID=" U999 "` (surrounding whitespace), a `<@U999>` mention is tracked and the subsequent `message_sending` skips the ownership fetch
- Proof above registers the real plugin entrypoint and uses a real loopback HTTP server as the forwarder; the only stubbed surface is the host plugin API object, and no external services are involved
