### PR TITLE
fix(ui): prevent Labs config refresh races

### DIFF
--- a/ui/src/e2e/config-safe-write.e2e.test.ts
+++ b/ui/src/e2e/config-safe-write.e2e.test.ts
@@ -129,6 +129,8 @@ suite.define(() => {
         });
 
         expect((await page.goto(`${suite.server.baseUrl}settings/labs`))?.status()).toBe(200);
+        const labsLink = page.locator('.settings-sidebar__item[href="/settings/labs"]');
+        await expect.poll(() => labsLink.getAttribute("aria-current")).toBe("page");
         const codeModeRow = settingsRow(page, "Code Mode");
         await codeModeRow.getByRole("switch", { name: "Code Mode", exact: true }).waitFor();
         await expect.poll(() => codeModeRow.textContent()).toContain("Default: Enabled");
@@ -151,14 +153,18 @@ suite.define(() => {
         });
         await expect
           .poll(async () => (await gateway.getRequests("config.get")).length)
-          .toBeGreaterThan(configGetsBeforePatch);
+          .toBe(configGetsBeforePatch + 1);
         await expect.poll(() => codeModeRow.textContent()).toContain("Using default: Enabled");
+        await expect.poll(() => labsLink.getAttribute("aria-current")).toBe("page");
+        await capture(page, "00-labs-canonical-refresh.png");
 
         expect(
           (
             await page.goto(`${suite.server.baseUrl}settings/advanced?section=laboratory`)
           )?.status(),
         ).toBe(200);
+        const advancedLink = page.locator('.settings-sidebar__item[href="/settings/advanced"]');
+        await expect.poll(() => advancedLink.getAttribute("aria-current")).toBe("page");
         const endpoint = page.getByRole("textbox", { name: "Endpoint", exact: true });
         await expect.poll(() => endpoint.inputValue()).toBe("local-api");
 

--- a/ui/src/pages/labs/labs-page.test.ts
+++ b/ui/src/pages/labs/labs-page.test.ts
@@ -124,7 +124,7 @@ describe("LabsPage", () => {
     expect(codeModeToggle(page).checked).toBe(true);
   });
 
-  it("writes an explicit false in the RFC 7396 merge patch when disabling", async () => {
+  it("delegates refresh ownership to the canonical patch flow when disabling", async () => {
     const { page, runtimeConfig } = await mountPage({
       tools: { codeMode: { enabled: true } },
     });
@@ -138,7 +138,7 @@ describe("LabsPage", () => {
       raw: { tools: { codeMode: { enabled: false } } },
       note: "labs: update codeMode",
     });
-    expect(runtimeConfig.refresh).toHaveBeenCalledOnce();
+    expect(runtimeConfig.refresh).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/ui/src/pages/labs/labs-page.ts
+++ b/ui/src/pages/labs/labs-page.ts
@@ -90,10 +90,6 @@ class LabsPage extends OpenClawLightDomElement {
       });
       if (!patched) {
         this.saveError = runtimeConfig.state.lastError ?? t("labsPage.saveFailed");
-        return;
-      }
-      if (this.context.runtimeConfig === runtimeConfig) {
-        await runtimeConfig.refresh();
       }
     } catch (error) {
       this.saveError = String(error);


### PR DESCRIPTION
Closes #119112.

## What Problem This Solves

Fixes an issue where resetting a Labs setting could start a second caller-owned configuration refresh after the runtime configuration owner had already completed the patch lifecycle. That duplicate read could race route state and make the guarded configuration-write browser scenario intermittently miss its next `config.set`.

## Why This Change Was Made

`runtimeConfig.patch()` is the authoritative owner: it adopts a config-bearing Gateway acknowledgement and performs the required fallback `config.get` for older hash-only acknowledgements. The Labs page now waits only for `patch()` and does not start another refresh.

The focused browser regression keeps the hash-only acknowledgement case, requires exactly one owner fallback refresh, verifies the Labs route remains active, and captures the resulting visible state.

Production LOC: +0/-4 (net -4) | Tests: +9/-3

## User Impact

Labs setting changes now settle through one configuration owner instead of adding a competing page-level refresh. This changes no config schema, default, migration, dependency, authentication, credential, or public protocol surface.

## Evidence

### Exact head

- Signed head: `a8d8aa95157d74297271ced259b6267ed72f2b99`
- Tree: `a19f455ce45e87006a5b1de345f755cc74f29b6b`
- `Co-authored-by: ZYV5ge <39863830+ZYV5ge@users.noreply.github.com>` parses as a contiguous trailer.
- `Punchcard-Session: amber-workshop-workshop-36` parses and is attested by the existing campaign session.

### Focused deterministic proof

- Labs unit suite: 43/43 passed.
- Runtime config owner suite: 115/115 passed.
- Control UI guarded-config Chromium E2E: 1/1 passed.
  - Exact-head Vite Control UI and real Chromium.
  - Mocked Gateway WebSocket, intentionally using a hash-only `config.patch` acknowledgement.
  - Exactly one post-patch owner `config.get`.
  - Labs route remained active and rendered `Using default: Enabled`.
- `git diff --check`, targeted formatting, and targeted lint passed.
- Mocked-browser screenshot:
  - `.artifacts/control-ui-e2e/config-safe-write/00-labs-canonical-refresh.png`
  - SHA-256 `44f13018051c97bee97018406695f67bdccffa4ab0f8b2a20efa7affe2fb10e3`

### Real Gateway and Control UI proof

A separate isolated run used the repository's real in-process Gateway server, exact-head Vite Control UI source, and Chromium. It used a dummy loopback token with channels, providers, and external credentials disabled.

- The real `config.patch` acknowledgement included authoritative config.
- The visible Labs state settled to `Using default: Enabled`.
- Instrumentation of the exported `runtimeConfig.refresh()` boundary recorded `app-shell-gateway` as the explicit refresh caller and recorded no call from `labs-page`.
- The real Gateway lifecycle emitted two later reconciliation `config.get` requests. This is not claimed as single-request proof: the assertion here is that Labs contributes no additional refresh.
- A subsequent browser-owned guarded `config.set` used the runtime owner's final authoritative hash as `baseHash`.
- The visible Labs switch then reflected the isolated disabled override.
- No browser page errors occurred.

Public, independently downloadable evidence:

- Bundle overview: https://gist.github.com/vincentkoc/9d33601e050038dd4cb6f3c3bf8dfd56
- Immutable Gist revision: `050c58236e69f5942ed0e6f8df6e096b7b3d9ace`
- Provenance manifest: https://gist.githubusercontent.com/vincentkoc/9d33601e050038dd4cb6f3c3bf8dfd56/raw/399dd2c177cf4d30b27a64bfe31bb5a09e84ceda/manifest.json
- Real Gateway receipt: https://gist.githubusercontent.com/vincentkoc/9d33601e050038dd4cb6f3c3bf8dfd56/raw/1af74c733d19db764f02c45070c8e6f0ed93e011/real-gateway-proof.json
  - SHA-256 `dd84cdd8b6330b7be6495f419159195499fa48988510a586091edfeaf3e03895`
- Human-readable trace: https://gist.githubusercontent.com/vincentkoc/9d33601e050038dd4cb6f3c3bf8dfd56/raw/dd572ae178a8185d6ffd711a7caf044420b09de4/real-gateway-trace.txt
- Labs owner-ack screenshot: https://gist.githubusercontent.com/vincentkoc/9d33601e050038dd4cb6f3c3bf8dfd56/raw/b49eff96f6d5ac6aa03e228305139b2b2e81d0d7/00-real-labs-owner-ack.png
  - SHA-256 `906e849b14f734b237c0fc382be337ccd7d5c71ebac77a4a92bb1d343e8a4158`
- Guarded-save screenshot: https://gist.githubusercontent.com/vincentkoc/9d33601e050038dd4cb6f3c3bf8dfd56/raw/329dba6adf8d7be4d82e3cfdaff9b18a302e3b22/01-real-guarded-save.png
  - SHA-256 `df527e1c88438efa31f71fbd25ebf84b8475dda099ca9539577c341cd717b82f`

![Labs owner acknowledgement](https://gist.githubusercontent.com/vincentkoc/9d33601e050038dd4cb6f3c3bf8dfd56/raw/b49eff96f6d5ac6aa03e228305139b2b2e81d0d7/00-real-labs-owner-ack.png)

![Guarded save](https://gist.githubusercontent.com/vincentkoc/9d33601e050038dd4cb6f3c3bf8dfd56/raw/329dba6adf8d7be4d82e3cfdaff9b18a302e3b22/01-real-guarded-save.png)

The public raw files were downloaded without GitHub API authentication and
verified byte-for-byte against the scrubbed local bundle.

### Current main

- Compared with exact current main `1471881af7aaff047c605dce08caa9a86f0de316`.
- `git merge-tree --write-tree` completed cleanly with tree `f66cea22972e3470834d7eec73b503fa35c62769`.
- Current-main drift does not touch the three changed files, so no rebase is required solely for being behind.
### Unrelated linked-worktree check noise

The reported `packages/terminal-core/src/ansi.ts:194` boundary-DTS failure is not caused by this change:

- `packages/terminal-core/src/ansi.ts` is byte-identical to current main (`50c82d9609bf7273d4ad0eac7110766d00a71e66`).
- `packages/terminal-core` declares `string-width` 8.2.2, whose types accept the second options argument.
- This linked worktree lacks the package-local dependency link and resolves root `string-width` 4.2.3, whose types accept only one argument.

No terminal-core change belongs in this PR.

## Follow-up Evidence

Three sibling callers still explicitly refresh after a successful `runtimeConfig.patch()` and should be audited separately rather than widening this repair:

- `ui/src/lib/config/mcp-servers.ts:227`
- `ui/src/pages/skill-workshop/self-learning.ts:71`
- `ui/src/pages/model-providers/config-mutation.ts:70`

## AI Assistance

AI assistance was used for source/history inspection, the owner-boundary repair, focused validation, and evidence drafting. The exact diff, signed commit, real and mocked proof, and current-main merge-tree were independently reviewed.

Punchcard-Session: amber-workshop-workshop-36

### Inline redacted real-Gateway receipt

```json
{
  "exactHead": "a8d8aa95157d74297271ced259b6267ed72f2b99",
  "proofKind": "real Gateway + exact-head Vite Control UI + Chromium",
  "isolatedState": true,
  "credentials": "dummy loopback token; no provider or channel credentials",
  "gateway": {
    "implementation": "src/gateway/server.ts via startGatewayWithClient",
    "patchAckIncludedConfig": true
  },
  "controlUi": {
    "source": "exact-head ui/ source through Vite",
    "labsVisibleOutcome": "Using default: Enabled",
    "postPatchLifecycleConfigGets": 2,
    "explicitRefreshCallers": ["app-shell-gateway"],
    "labsIssuedExplicitRefresh": false,
    "guardedSetBaseHashMatchedOwner": true,
    "guardedSaveVisibleOutcome": "Code Mode override disabled",
    "pageErrors": []
  },
  "requestSequenceAfterLabsReady": [
    "config.patch",
    "config.get",
    "agents.list",
    "config.get",
    "config.set",
    "config.get",
    "config.get",
    "agents.list"
  ]
}
```

### Inline human-readable trace

```text
OpenClaw PR #119115 real Gateway / Control UI trace
exactHead=a8d8aa95157d74297271ced259b6267ed72f2b99
proofKind=real Gateway + exact-head Vite Control UI + Chromium
isolatedState=true
gatewayImplementation=src/gateway/server.ts via startGatewayWithClient
patchAckIncludedConfig=true
labsVisibleOutcome=Using default: Enabled
postPatchLifecycleConfigGets=2
explicitRefreshCallers=app-shell-gateway
labsIssuedExplicitRefresh=false
guardedSetBaseHashMatchedOwner=true
guardedSaveVisibleOutcome=Code Mode override disabled
pageErrors=[]
requestSequenceAfterLabsReady=config.patch -> config.get -> agents.list -> config.get -> config.set -> config.get -> config.get -> agents.list
```
