### PR TITLE
feat(mattermost): acknowledge accepted posts while replies are processing

### DIFF
--- a/docs/channels/mattermost.md
+++ b/docs/channels/mattermost.md
@@ -357,6 +357,21 @@ Config:
 - `channels.mattermost.actions.reactions`: enable/disable reaction actions (default true).
 - Per-account override: `channels.mattermost.accounts.<id>.actions.reactions`.
 
+## Ack reactions
+
+`messages.ackReaction` reacts to an inbound post with an emoji while OpenClaw is processing it. `messages.ackReactionScope` decides _when_ that happens: `"group-mentions"` (default) only acks group/channel posts that mention the agent; `"group-all"` acks every group/channel post; `"direct"` acks DMs; `"all"` acks everything; `"off"`/`"none"` disables ack reactions entirely.
+
+```json5
+{
+  messages: {
+    ackReaction: "eyes", // emoji name or ":shortcode:"; empty string disables
+    ackReactionScope: "all", // react in DMs and channels/groups too
+  },
+}
+```
+
+The ack reaction fires only after the accepted post is durably recorded, so a replayed or dropped post never double-reacts. Mattermost keeps the ack reaction on the post after the reply is delivered.
+
 ## Interactive buttons (message tool)
 
 Send messages with clickable buttons. When a user clicks a button, the agent receives the selection and can respond.

--- a/extensions/mattermost/src/mattermost/ack-reactions.test.ts
+++ b/extensions/mattermost/src/mattermost/ack-reactions.test.ts
@@ -1,0 +1,105 @@
+// Mattermost tests cover automatic ack policy and reaction transport.
+import { describe, expect, it, vi } from "vitest";
+import {
+  createMattermostAckReactionRuntime,
+  resolveMattermostReactionEmojiName,
+} from "./ack-reactions.js";
+import type { MattermostClient } from "./client.js";
+import type { OpenClawConfig } from "./runtime-api.js";
+
+function createStubClient(request: MattermostClient["request"]): MattermostClient {
+  return {
+    baseUrl: "https://mattermost.example.com",
+    apiBaseUrl: "https://mattermost.example.com/api/v4",
+    token: "bot-token",
+    request,
+    fetchImpl: fetch,
+  };
+}
+
+function createRuntime(params: {
+  cfg?: OpenClawConfig;
+  isDirect?: boolean;
+  effectiveWasMentioned?: boolean;
+  request?: MattermostClient["request"];
+}) {
+  const request = params.request ?? (vi.fn(async () => ({})) as MattermostClient["request"]);
+  return {
+    request,
+    runtime: createMattermostAckReactionRuntime({
+      cfg: params.cfg ?? {},
+      client: createStubClient(request),
+      botUserId: "bot-1",
+      agentId: "main",
+      accountId: "default",
+      postId: "post-1",
+      gate: {
+        isDirect: params.isDirect ?? false,
+        isGroup: !(params.isDirect ?? false),
+        canDetectMention: true,
+        effectiveWasMentioned: params.effectiveWasMentioned ?? true,
+        shouldBypassMention: false,
+      },
+      log: vi.fn(),
+    }),
+  };
+}
+
+describe("resolveMattermostReactionEmojiName", () => {
+  it.each([
+    ["👀", "eyes"],
+    [":eyes:", "eyes"],
+    ["white_check_mark", "white_check_mark"],
+    ["❤️", "heart"],
+    ["+1", "+1"],
+  ])("normalizes %s to %s", (input, expected) => {
+    expect(resolveMattermostReactionEmojiName(input)).toBe(expected);
+  });
+
+  it.each(["", "🦄", ":eyes", "eyes:", "skin tone"])("rejects invalid name %s", (input) => {
+    expect(resolveMattermostReactionEmojiName(input)).toBeNull();
+  });
+});
+
+describe("createMattermostAckReactionRuntime", () => {
+  it("adds the resolved ack reaction once after recording", async () => {
+    const { request, runtime } = createRuntime({});
+
+    runtime.queueAfterRecord();
+    runtime.queueAfterRecord();
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1));
+
+    expect(request).toHaveBeenCalledWith("/reactions", {
+      method: "POST",
+      body: JSON.stringify({ user_id: "bot-1", post_id: "post-1", emoji_name: "eyes" }),
+    });
+  });
+
+  it("does not ack direct messages under the default group-mentions scope", async () => {
+    const { request, runtime } = createRuntime({ isDirect: true });
+
+    runtime.queueAfterRecord();
+    await Promise.resolve();
+
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("does not ack unmentioned group messages under the default scope", async () => {
+    const { request, runtime } = createRuntime({ effectiveWasMentioned: false });
+
+    runtime.queueAfterRecord();
+    await Promise.resolve();
+
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("acks direct messages when scope is all", async () => {
+    const { request, runtime } = createRuntime({
+      cfg: { messages: { ackReactionScope: "all" } },
+      isDirect: true,
+    });
+
+    runtime.queueAfterRecord();
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1));
+  });
+});

--- a/extensions/mattermost/src/mattermost/ack-reactions.test.ts
+++ b/extensions/mattermost/src/mattermost/ack-reactions.test.ts
@@ -1,9 +1,6 @@
 // Mattermost tests cover automatic ack policy and reaction transport.
 import { describe, expect, it, vi } from "vitest";
-import {
-  createMattermostAckReactionRuntime,
-  resolveMattermostReactionEmojiName,
-} from "./ack-reactions.js";
+import { createMattermostAckReactionRuntime } from "./ack-reactions.js";
 import type { MattermostClient } from "./client.js";
 import type { OpenClawConfig } from "./runtime-api.js";
 
@@ -45,23 +42,37 @@ function createRuntime(params: {
   };
 }
 
-describe("resolveMattermostReactionEmojiName", () => {
+describe("createMattermostAckReactionRuntime", () => {
   it.each([
     ["👀", "eyes"],
     [":eyes:", "eyes"],
     ["white_check_mark", "white_check_mark"],
     ["❤️", "heart"],
     ["+1", "+1"],
-  ])("normalizes %s to %s", (input, expected) => {
-    expect(resolveMattermostReactionEmojiName(input)).toBe(expected);
+  ])("normalizes %s to %s", async (input, expected) => {
+    const { request, runtime } = createRuntime({
+      cfg: { messages: { ackReaction: input, ackReactionScope: "all" } },
+    });
+
+    runtime.queueAfterRecord();
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1));
+
+    expect(request).toHaveBeenCalledWith("/reactions", {
+      method: "POST",
+      body: JSON.stringify({ user_id: "bot-1", post_id: "post-1", emoji_name: expected }),
+    });
   });
 
-  it.each(["", "🦄", ":eyes", "eyes:", "skin tone"])("rejects invalid name %s", (input) => {
-    expect(resolveMattermostReactionEmojiName(input)).toBeNull();
-  });
-});
+  it.each(["", "🦄", ":eyes", "eyes:", "skin tone"])("rejects invalid name %s", async (input) => {
+    const { request, runtime } = createRuntime({
+      cfg: { messages: { ackReaction: input, ackReactionScope: "all" } },
+    });
 
-describe("createMattermostAckReactionRuntime", () => {
+    runtime.queueAfterRecord();
+    await Promise.resolve();
+
+    expect(request).not.toHaveBeenCalled();
+  });
   it("adds the resolved ack reaction once after recording", async () => {
     const { request, runtime } = createRuntime({});
 

--- a/extensions/mattermost/src/mattermost/ack-reactions.ts
+++ b/extensions/mattermost/src/mattermost/ack-reactions.ts
@@ -1,0 +1,99 @@
+// Mattermost plugin module implements automatic ack reactions for accepted posts.
+import { resolveAckReaction } from "openclaw/plugin-sdk/agent-runtime";
+import { createAckReactionHandle, shouldAckReaction } from "openclaw/plugin-sdk/channel-feedback";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { MattermostClient } from "./client.js";
+import { createMattermostReactionMutation } from "./reactions.js";
+
+const MATTERMOST_EMOJI_NAME_PATTERN = /^[a-zA-Z0-9_+-]{1,64}$/;
+const MATTERMOST_EMOJI_NAME_BY_GLYPH: Readonly<Record<string, string>> = Object.freeze({
+  "👀": "eyes",
+  "👍": "+1",
+  "👎": "-1",
+  "✅": "white_check_mark",
+  "❤": "heart",
+  "🎉": "tada",
+  "🔥": "fire",
+  "👏": "clap",
+  "🚀": "rocket",
+});
+
+export type MattermostAckReactionGateFacts = {
+  isDirect: boolean;
+  isGroup: boolean;
+  canDetectMention: boolean;
+  effectiveWasMentioned: boolean;
+  shouldBypassMention: boolean;
+};
+
+/** Mattermost reaction endpoints accept emoji names, not raw Unicode glyphs. */
+export function resolveMattermostReactionEmojiName(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const candidate =
+    trimmed.length > 2 && trimmed.startsWith(":") && trimmed.endsWith(":")
+      ? trimmed.slice(1, -1)
+      : trimmed;
+  const withoutVariationSelector = candidate.replace(/[\uFE0E\uFE0F]/g, "");
+  return (
+    MATTERMOST_EMOJI_NAME_BY_GLYPH[withoutVariationSelector] ??
+    (MATTERMOST_EMOJI_NAME_PATTERN.test(candidate) ? candidate : null)
+  );
+}
+
+/** Queues the shared ack policy only after the inbound post has been durably recorded. */
+export function createMattermostAckReactionRuntime(params: {
+  cfg: OpenClawConfig;
+  client: MattermostClient;
+  botUserId: string;
+  agentId: string;
+  accountId: string;
+  postId: string;
+  gate: MattermostAckReactionGateFacts;
+  log: (message: string) => void;
+}) {
+  const configuredReaction = resolveAckReaction(params.cfg, params.agentId, {
+    channel: "mattermost",
+    accountId: params.accountId,
+  });
+  const reactionName = configuredReaction
+    ? resolveMattermostReactionEmojiName(configuredReaction)
+    : null;
+  const shouldSend = Boolean(
+    reactionName &&
+    shouldAckReaction({
+      scope: params.cfg.messages?.ackReactionScope,
+      isDirect: params.gate.isDirect,
+      isGroup: params.gate.isGroup,
+      isMentionableGroup: params.gate.isGroup,
+      canDetectMention: params.gate.canDetectMention,
+      effectiveWasMentioned: params.gate.effectiveWasMentioned,
+      shouldBypassMention: params.gate.shouldBypassMention,
+    }),
+  );
+  let queued = false;
+
+  return {
+    queueAfterRecord: () => {
+      if (queued || !shouldSend || !reactionName) {
+        return;
+      }
+      queued = true;
+      createAckReactionHandle({
+        ackReactionValue: reactionName,
+        send: () =>
+          createMattermostReactionMutation(params.client, {
+            userId: params.botUserId,
+            postId: params.postId,
+            emojiName: reactionName,
+          }),
+        remove: async () => {},
+        onSendError: (err) => {
+          params.log(`mattermost ack reaction failed post=${params.postId}: ${String(err)}`);
+        },
+      });
+    },
+  };
+}

--- a/extensions/mattermost/src/mattermost/ack-reactions.ts
+++ b/extensions/mattermost/src/mattermost/ack-reactions.ts
@@ -27,7 +27,7 @@ export type MattermostAckReactionGateFacts = {
 };
 
 /** Mattermost reaction endpoints accept emoji names, not raw Unicode glyphs. */
-export function resolveMattermostReactionEmojiName(raw: string): string | null {
+function resolveMattermostReactionEmojiName(raw: string): string | null {
   const trimmed = raw.trim();
   if (!trimmed) {
     return null;

--- a/extensions/mattermost/src/mattermost/monitor-posts.ts
+++ b/extensions/mattermost/src/mattermost/monitor-posts.ts
@@ -440,6 +440,11 @@ export function createMattermostPostHandler(monitor: MattermostMonitorContext) {
       channelHistories,
       pinnedMainDmOwner,
       turnAdoptionLifecycle,
+      ackGate: {
+        canDetectMention,
+        effectiveWasMentioned: kind !== "direct" ? mentionDecision.effectiveWasMentioned : false,
+        shouldBypassMention,
+      },
     });
   };
 }

--- a/extensions/mattermost/src/mattermost/monitor-turn.ts
+++ b/extensions/mattermost/src/mattermost/monitor-turn.ts
@@ -14,6 +14,10 @@ import {
 import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import type { finalizeInboundContext } from "openclaw/plugin-sdk/reply-runtime";
 import { resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
+import {
+  createMattermostAckReactionRuntime,
+  type MattermostAckReactionGateFacts,
+} from "./ack-reactions.js";
 import type { MattermostPost } from "./client.js";
 import {
   createMattermostDraftPreviewBoundaryController,
@@ -50,6 +54,7 @@ type MattermostInboundTurnParams = {
   channelHistories: Map<string, HistoryEntry[]>;
   pinnedMainDmOwner: string | null;
   turnAdoptionLifecycle?: MattermostIngressLifecycle;
+  ackGate: Omit<MattermostAckReactionGateFacts, "isDirect" | "isGroup">;
 };
 
 function createDisabledMattermostDraftStream(): ReturnType<typeof createMattermostDraftStream> {
@@ -73,8 +78,9 @@ export async function dispatchMattermostInboundTurn(
   monitor: MattermostMonitorContext,
   params: MattermostInboundTurnParams,
 ): Promise<void> {
-  const { account, cfg, client, core, runtime } = monitor;
+  const { account, botUserId, cfg, client, core, runtime } = monitor;
   const {
+    ackGate,
     channelHistories,
     ctxPayload,
     eventPlan,
@@ -87,6 +93,22 @@ export async function dispatchMattermostInboundTurn(
   } = params;
   const { channelId, kind, route, senderId, thread, to } = eventPlan;
   const { effectiveReplyToId } = thread;
+  const ackReaction = createMattermostAckReactionRuntime({
+    cfg,
+    client,
+    botUserId,
+    agentId: route.agentId,
+    accountId: account.accountId,
+    postId: post.id ?? "",
+    gate: {
+      isDirect: kind === "direct",
+      isGroup: kind !== "direct",
+      canDetectMention: ackGate.canDetectMention,
+      effectiveWasMentioned: ackGate.effectiveWasMentioned,
+      shouldBypassMention: ackGate.shouldBypassMention,
+    },
+    log: monitor.logVerboseMessage,
+  });
   const {
     deliveryBarrier,
     replyOptions,
@@ -428,6 +450,7 @@ export async function dispatchMattermostInboundTurn(
             sessionKey: route.sessionKey,
           },
           ctxPayload,
+          afterRecord: ackReaction.queueAfterRecord,
           record: {
             updateLastRoute:
               kind === "direct"

--- a/extensions/mattermost/src/mattermost/monitor.ack-status-reactions.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ack-status-reactions.test.ts
@@ -220,7 +220,7 @@ function createRuntimeCore(cfg: OpenClawConfig) {
       options,
     }),
   );
-  const recordInboundSession = vi.fn(async () => {});
+  const recordInboundSession = vi.fn(async (_turn?: unknown) => {});
   const dispatchPlanForTest = vi.fn(
     async (turn: {
       cfg: OpenClawConfig;

--- a/extensions/mattermost/src/mattermost/monitor.ack-status-reactions.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ack-status-reactions.test.ts
@@ -1,0 +1,530 @@
+// Mattermost tests cover automatic ack wiring end to end through the real inbound dispatch path.
+import { createTestInboundDebounceFlush } from "openclaw/plugin-sdk/channel-test-helpers";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MattermostPost } from "./client.js";
+import type { MattermostEventPayload } from "./monitor-websocket.js";
+import { monitorMattermostProvider } from "./monitor.js";
+import type { OpenClawConfig, ReplyPayload, RuntimeEnv } from "./runtime-api.js";
+
+class FakeWebSocket {
+  public readonly sent: string[] = [];
+  private readonly openListeners: Array<() => void> = [];
+  private readonly messageListeners: Array<(data: Buffer) => void | Promise<void>> = [];
+  private readonly closeListeners: Array<(code: number, reason: Buffer) => void> = [];
+  private readonly errorListeners: Array<(err: unknown) => void> = [];
+
+  on(event: "open", listener: () => void): void;
+  on(event: "message", listener: (data: Buffer) => void | Promise<void>): void;
+  on(event: "pong", listener: (data: Buffer) => void): void;
+  on(event: "close", listener: (code: number, reason: Buffer) => void): void;
+  on(event: "error", listener: (err: unknown) => void): void;
+  on(event: "open" | "message" | "pong" | "close" | "error", listener: unknown): void {
+    if (event === "open") {
+      this.openListeners.push(listener as () => void);
+      return;
+    }
+    if (event === "message") {
+      this.messageListeners.push(listener as (data: Buffer) => void | Promise<void>);
+      return;
+    }
+    if (event === "close") {
+      this.closeListeners.push(listener as (code: number, reason: Buffer) => void);
+      return;
+    }
+    if (event === "error") {
+      this.errorListeners.push(listener as (err: unknown) => void);
+    }
+  }
+
+  send(): void {}
+  ping(): void {}
+  close(): void {}
+  terminate(): void {
+    this.emitClose(1000);
+  }
+
+  get openListenerCount(): number {
+    return this.openListeners.length;
+  }
+
+  emitOpen(): void {
+    for (const listener of this.openListeners) {
+      listener();
+    }
+  }
+
+  async emitMessage(payload: unknown): Promise<void> {
+    const buffer = Buffer.from(JSON.stringify(payload), "utf8");
+    await Promise.all(this.messageListeners.map((listener) => Promise.resolve(listener(buffer))));
+  }
+
+  emitClose(code: number, reason = ""): void {
+    const buffer = Buffer.from(reason, "utf8");
+    for (const listener of this.closeListeners) {
+      listener(code, buffer);
+    }
+  }
+}
+
+const mockState = vi.hoisted(() => ({
+  createMattermostClient: vi.fn(),
+  createMattermostDraftStream: vi.fn(),
+  dispatchInboundMessage: vi.fn(),
+  createReplyDispatcherWithTyping: vi.fn(),
+  fetchMattermostMe: vi.fn(),
+  getGlobalHookRunner: vi.fn(),
+  recordMattermostThreadParticipation: vi.fn(),
+  registerMattermostMonitorSlashCommands: vi.fn(),
+  registerPluginHttpRoute: vi.fn(),
+  resolveChannelInfo: vi.fn(),
+  resolveMattermostMedia: vi.fn(),
+  resolveUserInfo: vi.fn(),
+  runtimeCore: undefined as unknown,
+  sendMessageMattermost: vi.fn(),
+  request: vi.fn(async () => ({})),
+}));
+
+vi.mock("openclaw/plugin-sdk/plugin-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/plugin-runtime")>()),
+  getGlobalHookRunner: mockState.getGlobalHookRunner,
+}));
+
+vi.mock("openclaw/plugin-sdk/reply-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/reply-runtime")>();
+  return {
+    ...actual,
+    createReplyDispatcherWithTyping: (...args: unknown[]) =>
+      mockState.createReplyDispatcherWithTyping(...args),
+    dispatchInboundMessage: async (params: Parameters<typeof actual.dispatchInboundMessage>[0]) => {
+      try {
+        return await mockState.dispatchInboundMessage(params);
+      } finally {
+        await params.onSettled?.();
+      }
+    },
+  };
+});
+
+vi.mock("./client.js", async () => {
+  const actual = await vi.importActual<typeof import("./client.js")>("./client.js");
+  return {
+    ...actual,
+    createMattermostClient: mockState.createMattermostClient,
+    fetchMattermostMe: mockState.fetchMattermostMe,
+    normalizeMattermostBaseUrl: (value: string | undefined) => value?.trim() ?? "",
+  };
+});
+
+vi.mock("./draft-stream.js", async () => {
+  const actual = await vi.importActual<typeof import("./draft-stream.js")>("./draft-stream.js");
+  return {
+    createMattermostDraftStream: mockState.createMattermostDraftStream,
+    createMattermostDraftPreviewBoundaryController:
+      actual.createMattermostDraftPreviewBoundaryController,
+  };
+});
+
+vi.mock("./monitor-resources.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./monitor-resources.js")>()),
+  createMattermostMonitorResources: () => ({
+    resolveMattermostMedia: mockState.resolveMattermostMedia,
+    sendTypingIndicator: vi.fn(async () => {}),
+    resolveChannelInfo: mockState.resolveChannelInfo,
+    resolveUserInfo: mockState.resolveUserInfo,
+    updateModelPickerPost: vi.fn(async () => {}),
+  }),
+}));
+
+vi.mock("./monitor-ingress.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./monitor-ingress.js")>();
+  return {
+    ...actual,
+    createMattermostIngressMonitor: (
+      options: Parameters<typeof actual.createMattermostIngressMonitor>[0],
+    ) => ({
+      receive: async (rawEvent: string) => {
+        const payload = JSON.parse(rawEvent) as MattermostEventPayload;
+        const post =
+          typeof payload.data?.post === "string"
+            ? (JSON.parse(payload.data.post) as MattermostPost)
+            : (payload.data?.post as MattermostPost | undefined);
+        if (payload.event !== "posted" || !post) {
+          return;
+        }
+        await options.dispatch(post, payload, {
+          abortSignal: new AbortController().signal,
+          onAdopted: async () => {},
+          onDeferred: () => {},
+          onAdoptionFinalizing: () => {},
+          onAbandoned: async () => {},
+        });
+      },
+      stop: async () => {},
+      waitForIdle: async () => {},
+    }),
+  };
+});
+
+vi.mock("./monitor-slash.js", () => ({
+  registerMattermostMonitorSlashCommands: mockState.registerMattermostMonitorSlashCommands,
+}));
+
+vi.mock("./thread-participation.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./thread-participation.js")>()),
+  recordMattermostThreadParticipation: mockState.recordMattermostThreadParticipation,
+}));
+
+vi.mock("./runtime-api.js", async () => {
+  const actual = await vi.importActual<typeof import("./runtime-api.js")>("./runtime-api.js");
+  return {
+    ...actual,
+    buildAgentMediaPayload: vi.fn(() => ({})),
+    createChannelPairingController: vi.fn(() => ({
+      readStoreForDmPolicy: vi.fn(async () => []),
+      upsertPairingRequest: vi.fn(async () => ({ code: "123456", created: true })),
+    })),
+    createChannelMessageReplyPipeline: vi.fn(() => ({
+      onModelSelected: vi.fn(),
+      typingCallbacks: {},
+      resolveResponsePrefix: () => undefined,
+    })),
+    registerPluginHttpRoute: mockState.registerPluginHttpRoute,
+    resolveChannelMediaMaxBytes: vi.fn(() => 8 * 1024 * 1024),
+    warnMissingProviderGroupPolicyFallbackOnce: vi.fn(),
+  };
+});
+
+vi.mock("./send.js", async () => {
+  const actual = await vi.importActual<typeof import("./send.js")>("./send.js");
+  return {
+    ...actual,
+    sendMessageMattermost: mockState.sendMessageMattermost,
+  };
+});
+
+vi.mock("../runtime.js", () => ({
+  getMattermostRuntime: () => mockState.runtimeCore,
+  getOptionalMattermostRuntime: () => mockState.runtimeCore,
+}));
+
+function createRuntimeCore(cfg: OpenClawConfig) {
+  type ReplyDispatcherOptions = {
+    deliver: (payload: ReplyPayload, info: { kind: "tool" | "block" | "final" }) => Promise<void>;
+  };
+  mockState.createReplyDispatcherWithTyping.mockImplementation(
+    (options: ReplyDispatcherOptions) => ({
+      dispatcher: {},
+      replyOptions: {},
+      markDispatchIdle: vi.fn(),
+      markRunComplete: vi.fn(),
+      options,
+    }),
+  );
+  const recordInboundSession = vi.fn(async () => {});
+  const dispatchPlanForTest = vi.fn(
+    async (turn: {
+      cfg: OpenClawConfig;
+      channel: string;
+      route: { agentId: string; sessionKey: string };
+      ctxPayload: { SessionKey?: string };
+      afterRecord?: () => void | Promise<void>;
+      dispatcherOptions?: Record<string, unknown>;
+      delivery: {
+        observeMessageSent?: true;
+        deliver: (
+          payload: ReplyPayload,
+          info: { kind: "tool" | "block" | "final" },
+        ) => Promise<unknown>;
+        onError?: unknown;
+      };
+      replyOptions?: Record<string, unknown>;
+      record?: { onRecordError?: (err: unknown) => void };
+    }) => {
+      await recordInboundSession(turn);
+      await turn.afterRecord?.();
+      const prepared = mockState.createReplyDispatcherWithTyping({
+        ...turn.dispatcherOptions,
+        deliver: turn.delivery.deliver,
+        onError: turn.delivery.onError,
+      }) as { dispatcher: unknown; replyOptions?: Record<string, unknown> };
+      const dispatchResult = await mockState.dispatchInboundMessage({
+        ctx: turn.ctxPayload,
+        cfg: turn.cfg,
+        dispatcher: prepared.dispatcher,
+        replyOptions: { ...prepared.replyOptions, ...turn.replyOptions },
+        onSettled: undefined,
+      });
+      return {
+        admission: { kind: "dispatch" as const },
+        dispatched: true,
+        ctxPayload: turn.ctxPayload,
+        routeSessionKey: turn.route.sessionKey,
+        dispatchResult,
+      };
+    },
+  );
+  const run = vi.fn(
+    async (params: {
+      raw: unknown;
+      adapter: {
+        ingest: (raw: unknown) => unknown;
+        resolveTurn: (
+          input: unknown,
+          eventClass: { kind: "message"; canStartAgentTurn: true },
+          preflight: Record<string, never>,
+        ) => Parameters<typeof dispatchPlanForTest>[0];
+      };
+    }) => {
+      const input = params.adapter.ingest(params.raw);
+      const turn = params.adapter.resolveTurn(
+        input,
+        { kind: "message", canStartAgentTurn: true },
+        {},
+      );
+      return await dispatchPlanForTest(turn);
+    },
+  );
+  return {
+    config: { current: () => cfg },
+    logging: {
+      shouldLogVerbose: () => false,
+      getChildLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+    },
+    media: { mediaKindFromMime: () => "document" },
+    system: { enqueueSystemEvent: vi.fn() },
+    channel: {
+      activity: { record: vi.fn() },
+      commands: {
+        isControlCommandMessage: () => false,
+        shouldComputeCommandAuthorized: () => false,
+        shouldHandleTextCommands: () => false,
+      },
+      debounce: {
+        resolveInboundDebounceMs: () => 0,
+        createInboundDebouncer: <T>(params: {
+          onFlush: (
+            entries: T[],
+            createFlush: typeof createTestInboundDebounceFlush,
+          ) => { completion: Promise<void> };
+        }) => ({
+          enqueue: async (entry: T) => {
+            await params.onFlush([entry], createTestInboundDebounceFlush).completion;
+          },
+          flushKey: async () => {},
+          cancelKey: () => false,
+          drain: async () => {},
+        }),
+      },
+      groups: { resolveRequireMention: () => false },
+      media: { readRemoteMediaBuffer: vi.fn(), saveMediaBuffer: vi.fn() },
+      mentions: {
+        buildMentionRegexes: () => [],
+        matchesMentionPatterns: () => false,
+      },
+      pairing: { buildPairingReply: () => "pairing required" },
+      reply: { settleReplyDispatcher: vi.fn(async ({ onSettled }) => onSettled?.()) },
+      routing: {
+        resolveAgentRoute: () => ({
+          accountId: "default",
+          agentId: "main",
+          lastRoutePolicy: "main" as const,
+          mainSessionKey: "mattermost:default:channel:chan-1",
+          sessionKey: "mattermost:default:channel:chan-1",
+        }),
+      },
+      session: {
+        resolveStorePath: () => "/tmp/openclaw-test-sessions.json",
+        recordInboundSession,
+        updateLastRoute: vi.fn(async () => {}),
+      },
+      inbound: { run },
+      text: {
+        chunkMarkdownTextWithMode: (text: string) => [text],
+        convertMarkdownTables: (text: string) => text,
+        hasControlCommand: () => false,
+        resolveChunkMode: () => "length" as const,
+        resolveMarkdownTableMode: () => "off" as const,
+        resolveTextChunkLimit: () => 4000,
+      },
+    },
+  };
+}
+
+const testRuntime = (): RuntimeEnv =>
+  ({
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: ((code: number): never => {
+      throw new Error(`exit ${code}`);
+    }) as RuntimeEnv["exit"],
+  }) satisfies RuntimeEnv;
+
+async function emitMattermostChannelPost(
+  socket: FakeWebSocket,
+  params: { id: string; message: string; senderId?: string },
+) {
+  const senderId = params.senderId ?? "user-1";
+  await socket.emitMessage({
+    event: "posted",
+    data: {
+      channel_id: "chan-1",
+      channel_name: "town-square",
+      channel_display_name: "Town Square",
+      sender_name: "alice",
+      post: JSON.stringify({
+        id: params.id,
+        channel_id: "chan-1",
+        user_id: senderId,
+        message: params.message,
+        create_at: 1_714_000_000_000,
+      }),
+    },
+    broadcast: { channel_id: "chan-1", user_id: senderId },
+  });
+}
+
+const baseConfig: OpenClawConfig = {
+  channels: {
+    mattermost: {
+      enabled: true,
+      baseUrl: "https://mattermost.example.com",
+      botToken: "bot-token",
+      chatmode: "onmessage",
+      dmPolicy: "open",
+      groupPolicy: "open",
+    },
+  },
+};
+
+describe("mattermost ack reactions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockState.getGlobalHookRunner.mockReturnValue(null);
+    mockState.request.mockReset();
+    mockState.request.mockImplementation(async () => ({}));
+    mockState.createMattermostClient.mockReturnValue({ request: mockState.request });
+    mockState.createMattermostDraftStream.mockReturnValue({
+      update: vi.fn(),
+      updateAssistantText: vi.fn(),
+      flush: vi.fn(async () => {}),
+      postId: vi.fn(() => undefined),
+      clear: vi.fn(async () => {}),
+      discardPending: vi.fn(async () => {}),
+      seal: vi.fn(async () => {}),
+      stop: vi.fn(async () => {}),
+      forceNewMessage: vi.fn(async () => {}),
+      settleBoundaries: vi.fn(async () => {}),
+      resolveFinalText: (text: string) => ({ kind: "full" as const, text, publishedParts: [] }),
+    });
+    mockState.fetchMattermostMe.mockResolvedValue({
+      id: "bot-user",
+      username: "openclaw",
+      update_at: 1,
+    });
+    mockState.registerMattermostMonitorSlashCommands.mockResolvedValue(undefined);
+    mockState.registerPluginHttpRoute.mockReturnValue(vi.fn());
+    mockState.resolveChannelInfo.mockResolvedValue({
+      id: "chan-1",
+      name: "town-square",
+      display_name: "Town Square",
+      team_id: "team-1",
+      type: "O",
+    });
+    mockState.resolveMattermostMedia.mockResolvedValue([]);
+    mockState.resolveUserInfo.mockResolvedValue({ id: "user-1", username: "alice" });
+    mockState.sendMessageMattermost.mockResolvedValue({});
+  });
+
+  it("reacts with the ack emoji only after the accepted post is recorded", async () => {
+    const socket = new FakeWebSocket();
+    const abortController = new AbortController();
+    const recordOrder: string[] = [];
+    const config: OpenClawConfig = {
+      ...baseConfig,
+      messages: { ackReactionScope: "all" },
+    };
+    const runtimeCore = createRuntimeCore(config);
+    runtimeCore.channel.session.recordInboundSession.mockImplementation(async () => {
+      recordOrder.push("record");
+    });
+    mockState.runtimeCore = runtimeCore;
+    mockState.request.mockImplementation(async () => {
+      recordOrder.push("react");
+      return {};
+    });
+    mockState.dispatchInboundMessage.mockImplementation(async () => {
+      abortController.abort();
+      return { queuedFinal: false, counts: {} };
+    });
+
+    const monitor = monitorMattermostProvider({
+      config,
+      runtime: testRuntime(),
+      abortSignal: abortController.signal,
+      webSocketFactory: () => socket,
+    });
+    await vi.waitFor(() => expect(socket.openListenerCount).toBeGreaterThan(0));
+    socket.emitOpen();
+    await emitMattermostChannelPost(socket, { id: "post-ack", message: "hello" });
+    socket.emitClose(1000);
+    await monitor;
+
+    expect(recordOrder).toEqual(["record", "react"]);
+    expect(mockState.request).toHaveBeenCalledExactlyOnceWith("/reactions", {
+      method: "POST",
+      body: JSON.stringify({ user_id: "bot-user", post_id: "post-ack", emoji_name: "eyes" }),
+    });
+  });
+
+  it("does not react when durable session recording fails", async () => {
+    const socket = new FakeWebSocket();
+    const abortController = new AbortController();
+    const config: OpenClawConfig = {
+      ...baseConfig,
+      messages: { ackReactionScope: "all" },
+    };
+    const runtimeCore = createRuntimeCore(config);
+    runtimeCore.channel.session.recordInboundSession.mockRejectedValue(new Error("record failed"));
+    mockState.runtimeCore = runtimeCore;
+
+    const monitor = monitorMattermostProvider({
+      config,
+      runtime: testRuntime(),
+      abortSignal: abortController.signal,
+      webSocketFactory: () => socket,
+    });
+    await vi.waitFor(() => expect(socket.openListenerCount).toBeGreaterThan(0));
+    socket.emitOpen();
+    await emitMattermostChannelPost(socket, { id: "post-record-failed", message: "hello" });
+    abortController.abort();
+    socket.emitClose(1000);
+    await monitor;
+
+    expect(mockState.request).not.toHaveBeenCalled();
+  });
+
+  it("does not react at all under the default group-mentions scope without a mention", async () => {
+    const socket = new FakeWebSocket();
+    const abortController = new AbortController();
+    const runtimeCore = createRuntimeCore(baseConfig);
+    mockState.runtimeCore = runtimeCore;
+    mockState.dispatchInboundMessage.mockImplementation(async () => {
+      abortController.abort();
+      return { queuedFinal: false, counts: {} };
+    });
+
+    const monitor = monitorMattermostProvider({
+      config: baseConfig,
+      runtime: testRuntime(),
+      abortSignal: abortController.signal,
+      webSocketFactory: () => socket,
+    });
+    await vi.waitFor(() => expect(socket.openListenerCount).toBeGreaterThan(0));
+    socket.emitOpen();
+    await emitMattermostChannelPost(socket, { id: "post-no-mention", message: "hello team" });
+    socket.emitClose(1000);
+    await monitor;
+
+    expect(mockState.request).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/mattermost/src/mattermost/reactions.ts
+++ b/extensions/mattermost/src/mattermost/reactions.ts
@@ -31,7 +31,7 @@ type ReactionParams = {
   fetchImpl?: MattermostFetch;
 };
 type ReactionMutation = (client: MattermostClient, params: MutationPayload) => Promise<void>;
-export type MutationPayload = { userId: string; postId: string; emojiName: string };
+type MutationPayload = { userId: string; postId: string; emojiName: string };
 
 const BOT_USER_CACHE_TTL_MS = 10 * 60_000;
 const botUserIdCache = new Map<string, { userId: string; expiresAt: number }>();
@@ -223,7 +223,7 @@ export async function createMattermostReactionMutation(
   });
 }
 
-export async function deleteMattermostReactionMutation(
+async function deleteMattermostReactionMutation(
   client: MattermostClient,
   params: MutationPayload,
 ): Promise<void> {

--- a/extensions/mattermost/src/mattermost/reactions.ts
+++ b/extensions/mattermost/src/mattermost/reactions.ts
@@ -31,7 +31,7 @@ type ReactionParams = {
   fetchImpl?: MattermostFetch;
 };
 type ReactionMutation = (client: MattermostClient, params: MutationPayload) => Promise<void>;
-type MutationPayload = { userId: string; postId: string; emojiName: string };
+export type MutationPayload = { userId: string; postId: string; emojiName: string };
 
 const BOT_USER_CACHE_TTL_MS = 10 * 60_000;
 const botUserIdCache = new Map<string, { userId: string; expiresAt: number }>();
@@ -72,7 +72,7 @@ export async function addMattermostReaction(params: {
 }): Promise<Result> {
   return runMattermostReaction(params, {
     action: "add",
-    mutation: createReaction,
+    mutation: createMattermostReactionMutation,
   });
 }
 
@@ -87,7 +87,7 @@ export async function removeMattermostReaction(params: {
 }): Promise<Result> {
   return runMattermostReaction(params, {
     action: "remove",
-    mutation: deleteReaction,
+    mutation: deleteMattermostReactionMutation,
   });
 }
 
@@ -209,7 +209,10 @@ async function runMattermostReaction(
   return { ok: true };
 }
 
-async function createReaction(client: MattermostClient, params: MutationPayload): Promise<void> {
+export async function createMattermostReactionMutation(
+  client: MattermostClient,
+  params: MutationPayload,
+): Promise<void> {
   await client.request<Record<string, unknown>>("/reactions", {
     method: "POST",
     body: JSON.stringify({
@@ -220,7 +223,10 @@ async function createReaction(client: MattermostClient, params: MutationPayload)
   });
 }
 
-async function deleteReaction(client: MattermostClient, params: MutationPayload): Promise<void> {
+export async function deleteMattermostReactionMutation(
+  client: MattermostClient,
+  params: MutationPayload,
+): Promise<void> {
   const emoji = encodeURIComponent(params.emojiName);
   await client.request<unknown>(
     `/users/${params.userId}/posts/${params.postId}/reactions/${emoji}`,


### PR DESCRIPTION
Closes #99277

## What Problem This Solves

Fixes an issue where Mattermost users who enable `messages.ackReactionScope` receive no immediate acknowledgement while an accepted post is being processed. The setting currently behaves as a silent no-op on Mattermost even though the channel already supports reaction transport.

## Why This Change Was Made

This adds a plugin-local bridge to OpenClaw's existing shared ack-reaction policy. Mattermost resolves the configured account/channel/global/identity reaction, applies the shared direct/group/mention gate, and sends the reaction only after the inbound post has been durably recorded. It reuses the monitor's authenticated client and the existing Mattermost reaction mutation instead of introducing channel-specific configuration.

This PR is intentionally limited to static acknowledgement reactions. It does not add Mattermost lifecycle status reactions or a new config surface.

## User Impact

Mattermost operators can now use the same `messages.ackReaction` and `messages.ackReactionScope` settings as other channels. Accepted posts receive an immediate, retained reaction according to the configured scope; dropped, replayed, unmentioned, or failed-to-record posts do not react.

## Evidence

- `node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/ack-reactions.test.ts extensions/mattermost/src/mattermost/monitor.ack-status-reactions.test.ts` — 2 files, 17 tests passed.
- `node scripts/run-oxlint.mjs ...` over all touched Mattermost TypeScript files — passed.
- `pnpm deadcode:dependencies` — passed after keeping the new transport helpers plugin-private.
- `git diff --check origin/main...HEAD` — passed.
- The boundary test exercises the real Mattermost websocket -> accepted-post -> durable-record -> inbound-turn path and proves reaction ordering plus record-failure/mention-gate suppression.
- Production delta: +138/-5 plugin lines, justified by the new Mattermost channel capability and transport adapter; tests add 646 lines and docs add 15 lines.

Known proof gaps:

- No live Mattermost workspace run is attached; hosted CI and maintainer review remain required.
- Targeted Mattermost tsgo is currently blocked by two unchanged `main` errors in `monitor-interactions.ts` (`throwOnFailure`) and `monitor-websocket.ts` (`channelReadyPatch`).
- The required autoreview helper was attempted repeatedly. Codex failed at the review-engine layer without structured output, and the optional Claude reviewer was unavailable with HTTP 429 before consuming tokens; neither produced a code finding.

AI-assisted change. I reviewed the implementation and understand the affected ack-policy, transport, and inbound-recording paths.
