### PR TITLE
fix(tasks): prefer the newest live flow for owner-key TaskFlow lookup (#119129)

### DIFF
--- a/src/commands/flows.test.ts
+++ b/src/commands/flows.test.ts
@@ -4,7 +4,10 @@ import { visibleWidth } from "../../packages/terminal-core/src/ansi.js";
 import { runCommandWithRuntime } from "../cli/cli-utils.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { createRunningTaskRunCore as createRunningTaskRunOrNull } from "../tasks/task-executor.js";
-import { createManagedTaskFlow as createManagedTaskFlowOrNull } from "../tasks/task-flow-registry.js";
+import {
+  createManagedTaskFlow as createManagedTaskFlowOrNull,
+  getTaskFlowById,
+} from "../tasks/task-flow-registry.js";
 import type { TaskFlowRecord } from "../tasks/task-flow-registry.types.js";
 import * as taskFlowRuntime from "../tasks/task-flow-runtime-internal.js";
 import { markTaskLostById, markTaskTerminalById } from "../tasks/task-registry.js";
@@ -381,6 +384,48 @@ describe("flows commands", () => {
           failures: 0,
         },
       });
+    });
+  });
+
+  it("shows and cancels live work before newer terminal history", async () => {
+    await withTaskFlowCommandStateDir(async () => {
+      const ownerKey = "agent:main:main";
+      const olderRunning = createManagedTaskFlow({
+        ownerKey,
+        controllerId: "tests/flows-command-owner-lookup",
+        goal: "Older live flow",
+        status: "running",
+        createdAt: 100,
+        updatedAt: 100,
+      });
+      const newerTerminal = createManagedTaskFlow({
+        ownerKey,
+        controllerId: "tests/flows-command-owner-lookup",
+        goal: "Newer terminal flow",
+        status: "succeeded",
+        createdAt: 200,
+        updatedAt: 200,
+        endedAt: 200,
+      });
+
+      const showRuntime = createRuntime();
+      await flowsShowCommand({ lookup: ownerKey, json: true }, showRuntime);
+      expect(vi.mocked(showRuntime.writeJson).mock.calls[0]?.[0]).toMatchObject({
+        flowId: olderRunning.flowId,
+        status: "running",
+      });
+
+      const cancelRuntime = createRuntime();
+      await flowsCancelCommand({ lookup: ownerKey }, cancelRuntime);
+      expect(vi.mocked(cancelRuntime.log)).toHaveBeenCalledWith(
+        `Cancelled ${olderRunning.flowId} (managed) with status cancelled.`,
+      );
+      expect(getTaskFlowById(olderRunning.flowId)).toMatchObject({
+        status: "cancelled",
+        cancelRequestedAt: expect.any(Number),
+      });
+      expect(getTaskFlowById(newerTerminal.flowId)).toMatchObject({ status: "succeeded" });
+      expect(getTaskFlowById(newerTerminal.flowId)?.cancelRequestedAt).toBeUndefined();
     });
   });
 

--- a/src/tasks/task-flow-owner-access.test.ts
+++ b/src/tasks/task-flow-owner-access.test.ts
@@ -40,7 +40,7 @@ afterEach(() => {
 });
 
 describe("task flow owner access", () => {
-  it("returns owner-scoped flows for direct and owner-key lookups", () => {
+  it("returns owner-scoped flows and resolves owner keys to live work", () => {
     const older = createManagedTaskFlow({
       ownerKey: "agent:main:main",
       controllerId: "tests/owner-access",
@@ -52,8 +52,10 @@ describe("task flow owner access", () => {
       ownerKey: "agent:main:main",
       controllerId: "tests/owner-access",
       goal: "Latest flow",
+      status: "succeeded",
       createdAt: 200,
       updatedAt: 200,
+      endedAt: 200,
     });
 
     expect(
@@ -72,7 +74,7 @@ describe("task flow owner access", () => {
         token: "agent:main:main",
         callerOwnerKey: "agent:main:main",
       })?.flowId,
-    ).toBe(latest.flowId);
+    ).toBe(older.flowId);
     expect(
       listTaskFlowsForOwner({
         callerOwnerKey: "agent:main:main",

--- a/src/tasks/task-flow-owner-access.ts
+++ b/src/tasks/task-flow-owner-access.ts
@@ -2,6 +2,7 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   findLatestTaskFlowForOwnerKey,
+  findTaskFlowForOwnerLookup,
   getTaskFlowById,
   listTaskFlowsForOwnerKey,
 } from "./task-flow-registry.js";
@@ -47,5 +48,5 @@ export function resolveTaskFlowForLookupTokenForOwner(params: {
   if (!normalizedToken || normalizedToken !== normalizedCallerOwnerKey) {
     return undefined;
   }
-  return findLatestTaskFlowForOwner({ callerOwnerKey: normalizedCallerOwnerKey });
+  return findTaskFlowForOwnerLookup(normalizedCallerOwnerKey);
 }

--- a/src/tasks/task-flow-owner-access.ts
+++ b/src/tasks/task-flow-owner-access.ts
@@ -50,8 +50,9 @@ export function resolveTaskFlowForLookupTokenForOwner(params: {
   }
   const latest = findLatestTaskFlowForOwner({ callerOwnerKey: normalizedCallerOwnerKey });
   // Mirror resolveTaskFlowForLookupToken (#119129): prefer the newest live flow
-  // when the newest overall is terminal/blocked, so owner-key lookups do not
-  // silently resolve to a finished flow.
+  // (including resumable blocked flows without an endedAt) when the newest
+  // overall is terminal, so owner-key lookups do not silently resolve to a
+  // finished flow.
   if (latest) {
     const active = findNewestNonTerminalTaskFlowForOwnerKey(normalizedCallerOwnerKey);
     return active ?? latest;

--- a/src/tasks/task-flow-owner-access.ts
+++ b/src/tasks/task-flow-owner-access.ts
@@ -2,6 +2,7 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   findLatestTaskFlowForOwnerKey,
+  findNewestNonTerminalTaskFlowForOwnerKey,
   getTaskFlowById,
   listTaskFlowsForOwnerKey,
 } from "./task-flow-registry.js";
@@ -47,5 +48,13 @@ export function resolveTaskFlowForLookupTokenForOwner(params: {
   if (!normalizedToken || normalizedToken !== normalizedCallerOwnerKey) {
     return undefined;
   }
-  return findLatestTaskFlowForOwner({ callerOwnerKey: normalizedCallerOwnerKey });
+  const latest = findLatestTaskFlowForOwner({ callerOwnerKey: normalizedCallerOwnerKey });
+  // Mirror resolveTaskFlowForLookupToken (#119129): prefer the newest live flow
+  // when the newest overall is terminal/blocked, so owner-key lookups do not
+  // silently resolve to a finished flow.
+  if (latest) {
+    const active = findNewestNonTerminalTaskFlowForOwnerKey(normalizedCallerOwnerKey);
+    return active ?? latest;
+  }
+  return latest;
 }

--- a/src/tasks/task-flow-registry.test.ts
+++ b/src/tasks/task-flow-registry.test.ts
@@ -11,6 +11,7 @@ import {
   listTaskFlowRecords,
   requestFlowCancel,
   reloadTaskFlowRegistryFromStore,
+  resolveTaskFlowForLookupToken,
   resumeFlow,
   setFlowWaiting,
   syncFlowFromTaskResult,
@@ -581,6 +582,35 @@ describe("task-flow-registry", () => {
       }
       expect(resumed.flow.flowId).toBe(created.flowId);
       expect(resumed.flow.stateJson).toBeNull();
+    });
+  });
+});
+
+describe("owner-key lookup prefers an active flow over a terminal one", () => {
+  it("resolves owner-key token to the newest non-terminal flow when the newest is terminal", async () => {
+    await withFlowRegistryTempDir(async () => {
+      const olderRunning = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/owner-lookup-active",
+        goal: "Older running flow",
+        status: "running",
+        createdAt: 100,
+        updatedAt: 100,
+      });
+      const newerTerminal = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/owner-lookup-active",
+        goal: "Newer finished flow",
+        status: "running",
+        createdAt: 200,
+        updatedAt: 200,
+      });
+      failFlow({ flowId: newerTerminal.flowId, expectedRevision: newerTerminal.revision });
+
+      // An owner-key lookup must not point `cancel`/`show` at the terminal flow
+      // while an older flow is still running — it would silently miss the active flow.
+      const resolved = resolveTaskFlowForLookupToken("agent:main:main");
+      expect(resolved?.flowId).toBe(olderRunning.flowId);
     });
   });
 });

--- a/src/tasks/task-flow-registry.test.ts
+++ b/src/tasks/task-flow-registry.test.ts
@@ -613,4 +613,57 @@ describe("owner-key lookup prefers an active flow over a terminal one", () => {
       expect(resolved?.flowId).toBe(olderRunning.flowId);
     });
   });
+
+  it("keeps a newest resumable blocked flow as the owner-key lookup target (#119130)", async () => {
+    await withFlowRegistryTempDir(async () => {
+      createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/owner-lookup-blocked",
+        goal: "Older running flow",
+        status: "running",
+        createdAt: 100,
+        updatedAt: 100,
+      });
+      // Blocked without an endedAt is resumable state (maintenance contract):
+      // it must remain the lookup target even though an older flow is running.
+      const newerBlocked = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/owner-lookup-blocked",
+        goal: "Newer resumable blocked flow",
+        status: "blocked",
+        blockedSummary: "Waiting on an external approval",
+        createdAt: 200,
+        updatedAt: 200,
+      });
+
+      const resolved = resolveTaskFlowForLookupToken("agent:main:main");
+      expect(resolved?.flowId).toBe(newerBlocked.flowId);
+    });
+  });
+
+  it("falls back past a terminal blocked flow (endedAt set) to an older running flow (#119130)", async () => {
+    await withFlowRegistryTempDir(async () => {
+      const olderRunning = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/owner-lookup-terminal-blocked",
+        goal: "Older running flow",
+        status: "running",
+        createdAt: 100,
+        updatedAt: 100,
+      });
+      createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/owner-lookup-terminal-blocked",
+        goal: "Newer terminal blocked flow",
+        status: "blocked",
+        blockedSummary: "Completed with a blocked result",
+        createdAt: 200,
+        updatedAt: 250,
+        endedAt: 250,
+      });
+
+      const resolved = resolveTaskFlowForLookupToken("agent:main:main");
+      expect(resolved?.flowId).toBe(olderRunning.flowId);
+    });
+  });
 });

--- a/src/tasks/task-flow-registry.ts
+++ b/src/tasks/task-flow-registry.ts
@@ -9,11 +9,12 @@ import {
   resetTaskFlowRegistryRuntimeForTests,
   type TaskFlowRegistryObserverEvent,
 } from "./task-flow-registry.store.js";
-import type {
-  TaskFlowRecord,
-  TaskFlowStatus,
-  TaskFlowSyncMode,
-  JsonValue,
+import {
+  isTerminalTaskFlow,
+  type JsonValue,
+  type TaskFlowRecord,
+  type TaskFlowStatus,
+  type TaskFlowSyncMode,
 } from "./task-flow-registry.types.js";
 import type { TaskNotifyPolicy, TaskRecord } from "./task-registry.types.js";
 
@@ -775,8 +776,14 @@ export function listTaskFlowsForOwnerKey(ownerKey: string): TaskFlowRecord[] {
 }
 
 export function findLatestTaskFlowForOwnerKey(ownerKey: string): TaskFlowRecord | undefined {
-  const flow = listTaskFlowsForOwnerKey(ownerKey)[0];
-  return flow ? cloneFlowRecord(flow) : undefined;
+  return listTaskFlowsForOwnerKey(ownerKey)[0];
+}
+
+// Owner-key actions must target live work before retained terminal history;
+// otherwise `show` and `cancel` silently act on a completed flow.
+export function findTaskFlowForOwnerLookup(ownerKey: string): TaskFlowRecord | undefined {
+  const ownerFlows = listTaskFlowsForOwnerKey(ownerKey);
+  return ownerFlows.find((flow) => !isTerminalTaskFlow(flow)) ?? ownerFlows[0];
 }
 
 export function resolveTaskFlowForLookupToken(token: string): TaskFlowRecord | undefined {
@@ -784,7 +791,7 @@ export function resolveTaskFlowForLookupToken(token: string): TaskFlowRecord | u
   if (!lookup) {
     return undefined;
   }
-  return getTaskFlowById(lookup) ?? findLatestTaskFlowForOwnerKey(lookup);
+  return getTaskFlowById(lookup) ?? findTaskFlowForOwnerLookup(lookup);
 }
 
 export function listTaskFlowRecords(): TaskFlowRecord[] {

--- a/src/tasks/task-flow-registry.ts
+++ b/src/tasks/task-flow-registry.ts
@@ -780,6 +780,19 @@ export function findLatestTaskFlowForOwnerKey(ownerKey: string): TaskFlowRecord 
 }
 
 /**
+ * Whether a flow is terminal for owner-key lookup. Mirrors the maintenance
+ * terminal contract (task-flow-registry.maintenance.ts): a blocked flow is
+ * resumable state unless it carries an endedAt timestamp, so only terminal
+ * blocked flows are skipped. Other statuses use the plain terminal predicate.
+ */
+function isTerminalFlowForOwnerLookup(flow: TaskFlowRecord): boolean {
+  if (flow.status === "blocked") {
+    return flow.endedAt != null;
+  }
+  return isTerminalTaskFlowStatus(flow.status);
+}
+
+/**
  * Newest non-terminal flow for an owner key. `listTaskFlowsForOwnerKey` sorts by
  * createdAt descending, so this is the most recent flow still accepting work.
  * Used by owner-key lookups so `show`/`cancel <ownerKey>` target a live flow.
@@ -787,7 +800,7 @@ export function findLatestTaskFlowForOwnerKey(ownerKey: string): TaskFlowRecord 
 export function findNewestNonTerminalTaskFlowForOwnerKey(
   ownerKey: string,
 ): TaskFlowRecord | undefined {
-  return listTaskFlowsForOwnerKey(ownerKey).find((flow) => !isTerminalTaskFlowStatus(flow.status));
+  return listTaskFlowsForOwnerKey(ownerKey).find((flow) => !isTerminalFlowForOwnerLookup(flow));
 }
 
 export function resolveTaskFlowForLookupToken(token: string): TaskFlowRecord | undefined {
@@ -801,10 +814,11 @@ export function resolveTaskFlowForLookupToken(token: string): TaskFlowRecord | u
   }
   const latest = findLatestTaskFlowForOwnerKey(lookup);
   // #119129: an owner-key lookup must resolve to a live flow. When the newest
-  // flow for the owner is terminal/blocked but an older one is still running,
-  // fall back to the newest non-terminal flow so `show`/`cancel <ownerKey>` do
-  // not silently target a finished flow.
-  if (latest && isTerminalTaskFlowStatus(latest.status)) {
+  // flow for the owner is terminal but an older one is still running, fall back
+  // to the newest non-terminal flow so `show`/`cancel <ownerKey>` do not
+  // silently target a finished flow. A resumable blocked flow (no endedAt) is
+  // not terminal and stays the lookup target.
+  if (latest && isTerminalFlowForOwnerLookup(latest)) {
     return findNewestNonTerminalTaskFlowForOwnerKey(lookup) ?? latest;
   }
   return latest;

--- a/src/tasks/task-flow-registry.ts
+++ b/src/tasks/task-flow-registry.ts
@@ -779,12 +779,35 @@ export function findLatestTaskFlowForOwnerKey(ownerKey: string): TaskFlowRecord 
   return flow ? cloneFlowRecord(flow) : undefined;
 }
 
+/**
+ * Newest non-terminal flow for an owner key. `listTaskFlowsForOwnerKey` sorts by
+ * createdAt descending, so this is the most recent flow still accepting work.
+ * Used by owner-key lookups so `show`/`cancel <ownerKey>` target a live flow.
+ */
+export function findNewestNonTerminalTaskFlowForOwnerKey(
+  ownerKey: string,
+): TaskFlowRecord | undefined {
+  return listTaskFlowsForOwnerKey(ownerKey).find((flow) => !isTerminalTaskFlowStatus(flow.status));
+}
+
 export function resolveTaskFlowForLookupToken(token: string): TaskFlowRecord | undefined {
   const lookup = token.trim();
   if (!lookup) {
     return undefined;
   }
-  return getTaskFlowById(lookup) ?? findLatestTaskFlowForOwnerKey(lookup);
+  const direct = getTaskFlowById(lookup);
+  if (direct) {
+    return direct;
+  }
+  const latest = findLatestTaskFlowForOwnerKey(lookup);
+  // #119129: an owner-key lookup must resolve to a live flow. When the newest
+  // flow for the owner is terminal/blocked but an older one is still running,
+  // fall back to the newest non-terminal flow so `show`/`cancel <ownerKey>` do
+  // not silently target a finished flow.
+  if (latest && isTerminalTaskFlowStatus(latest.status)) {
+    return findNewestNonTerminalTaskFlowForOwnerKey(lookup) ?? latest;
+  }
+  return latest;
 }
 
 export function listTaskFlowRecords(): TaskFlowRecord[] {


### PR DESCRIPTION
## What Problem This Solves

`openclaw tasks flow show <ownerKey>` and `openclaw tasks flow cancel <ownerKey>` selected the newest TaskFlow record. A newer completed flow could hide an older live flow for the same owner. `show` then displayed the completed flow, and `cancel` returned `Flow is already succeeded.` without cancelling the live flow.

Fixes #119129

## Why This Change Was Made

Both owner-key lookup paths used raw latest-history lookup. They now share one owner lookup selector that chooses the newest live flow and falls back to the newest record only when every record is terminal.

The selector uses the existing `isTerminalTaskFlow` lifecycle contract. Managed `blocked` flows without `endedAt` remain live and resumable. Exact flow-ID lookup and the plugin runtime's raw `findLatest` behavior stay unchanged.

## User Impact

- **Before:** `tasks flow show <ownerKey>` could display completed history while work was still running.
- **Before:** `tasks flow cancel <ownerKey>` could exit 1 without recording cancellation on the live flow.
- **After:** both commands target the newest live flow when one exists.

## Evidence

**Real CLI red proof on current main `22d4279245a21fd757c5e9ffb69bdffa9a20a1c0`:** Two flows were persisted for one owner in the production SQLite registry. The older flow was `running`; the newer flow was `succeeded`. `tasks flow show <ownerKey> --json` selected the newer succeeded flow. `tasks flow cancel <ownerKey>` exited 1. The older row still had `cancel_requested_at = null`.

**Identical real CLI green proof on head `e998561c07f8425779cc19a09e99aea93b9cca89`:** `show` selected the older running flow. `cancel` exited 0. The same row became `cancelled` with a persisted `cancel_requested_at`; the newer succeeded row stayed unchanged.

**Regression proof:** Both new behavior tests failed on pre-fix production for the reported ordering. They pass with the repair. The final focused run passed 58 tests across the CLI commands, TaskFlow registry, lifecycle maintenance, owner access, and both plugin runtime surfaces.

```text
node scripts/run-vitest.mjs src/commands/flows.test.ts src/tasks/task-flow-registry.test.ts src/tasks/task-flow-owner-access.test.ts src/tasks/task-flow-registry.maintenance.test.ts src/plugins/runtime/runtime-taskflow.test.ts src/plugins/runtime/runtime-tasks.test.ts
# passed 4 Vitest shards
```

**Repository checks:** `node scripts/check-changed.mjs -- <changed paths>` passed formatting, lint, core and core-test type checks, import-cycle checks, storage guards, schema guards, and changed-scope ratchets. The exact head also passed a full production build.

**Boundary:** production +8 lines; tests +47 lines. The production growth is the shared live-or-latest selector required to keep raw history lookup and owner-action lookup as separate contracts.
