### PR TITLE
fix(voice): wait for auth before starting realtime timeout

### DIFF
--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -787,6 +787,9 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
         attempt.resolve();
         return;
       }
+      // Auth preparation owns its own timeout. Start the socket deadline only
+      // after connection parameters are available.
+      attempt.startTimeout();
       const url = resolvedConnection.url;
       this.connectionUrl = resolvedConnection.url;
       const debugProxy = resolveDebugProxySettings();

--- a/extensions/xai/realtime-voice-bridge.ts
+++ b/extensions/xai/realtime-voice-bridge.ts
@@ -160,6 +160,9 @@ export class XaiRealtimeVoiceBridge extends XaiRealtimeVoiceEvents implements Re
         attempt.resolve();
         return;
       }
+      // Credential refresh has its own bounded lifecycle. Arm the socket timeout
+      // only once valid connection parameters are ready.
+      attempt.startTimeout();
       const { url, headers } = resolvedConnection;
       this.connectionUrl = url;
       const proxyAgent = createDebugProxyWebSocketAgent(resolveDebugProxySettings());

--- a/extensions/xai/realtime-voice-provider.test.ts
+++ b/extensions/xai/realtime-voice-provider.test.ts
@@ -286,6 +286,60 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     await waitForRealtimeState(() => expect(FakeWebSocket.instances).toHaveLength(0));
   });
 
+  it("starts the socket timeout after async credential resolution", async () => {
+    vi.useFakeTimers();
+    let resolveCredentials: ((value: { apiKey: string | undefined }) => void) | undefined;
+    resolveApiKeyForProviderMock.mockImplementation(
+      () =>
+        new Promise<{ apiKey: string | undefined }>((resolve) => {
+          resolveCredentials = resolve;
+        }),
+    );
+    const bridge = createTestBridge({
+      cfg: {} as never,
+      providerConfig: {},
+    });
+
+    const connecting = bridge.connect();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(resolveApiKeyForProviderMock).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(FakeWebSocket.instances).toHaveLength(0);
+
+    resolveCredentials?.({ apiKey: "xai-oauth" }); // pragma: allowlist secret
+    await vi.advanceTimersByTimeAsync(0);
+    const socket = requireSocket();
+    socket.open();
+    socket.emitServer({ type: "session.updated" });
+    await connecting;
+
+    const options = socket.args[1] as { headers?: Record<string, string> } | undefined;
+    expect(options?.headers?.Authorization).toBe("Bearer xai-oauth");
+    bridge.close();
+  });
+
+  it("retains the socket timeout after async credential resolution", async () => {
+    vi.useFakeTimers();
+    resolveApiKeyForProviderMock.mockResolvedValue({ apiKey: "xai-oauth" });
+    const bridge = createTestBridge({
+      cfg: {} as never,
+      providerConfig: {},
+    });
+
+    const connecting = bridge.connect();
+    await vi.advanceTimersByTimeAsync(0);
+    const socket = requireSocket();
+    const timeoutAssertion = expect(connecting).rejects.toThrow(
+      "xAI realtime voice connection timeout",
+    );
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    await timeoutAssertion;
+    expect(socket.terminated).toBe(true);
+    expect(bridge.isConnected()).toBe(false);
+  });
+
   it("starts a replacement immediately after canceling pending credentials", async () => {
     let resolveFirstCredentials: ((value: { apiKey: string | undefined }) => void) | undefined;
     resolveApiKeyForProviderMock

--- a/src/plugin-sdk/realtime-voice.test.ts
+++ b/src/plugin-sdk/realtime-voice.test.ts
@@ -164,7 +164,7 @@ describe("RealtimeVoiceSessionLifecycle", () => {
     expect(openTransport).not.toHaveBeenCalled();
   });
 
-  it("settles connect attempts once and releases timeout and abort ownership", async () => {
+  it("starts connect timeouts explicitly and releases timeout and abort ownership", async () => {
     vi.useFakeTimers();
     try {
       const lifecycle = new RealtimeVoiceSessionLifecycle("Test");
@@ -179,6 +179,7 @@ describe("RealtimeVoiceSessionLifecycle", () => {
         timeoutMs: 10,
       });
 
+      attempt.startTimeout();
       attempt.resolve(true);
       attempt.reject(new Error("late failure"));
       await expect(attempt.promise).resolves.toBeUndefined();
@@ -200,6 +201,11 @@ describe("RealtimeVoiceSessionLifecycle", () => {
         timeoutMs: 10,
       });
       const rejected = expect(timeoutAttempt.promise).rejects.toThrow("timed out");
+      await vi.advanceTimersByTimeAsync(10);
+      expect(onTimeout).not.toHaveBeenCalled();
+
+      timeoutAttempt.startTimeout();
+      timeoutAttempt.startTimeout();
       await vi.advanceTimersByTimeAsync(10);
       await rejected;
 

--- a/src/talk/realtime-session-lifecycle.ts
+++ b/src/talk/realtime-session-lifecycle.ts
@@ -88,6 +88,7 @@ type RealtimeVoiceConnectAttempt = {
   reject: (error: Error) => void;
   rejectStartup: (error: Error) => boolean;
   resolve: (providerReady?: boolean) => void;
+  startTimeout: () => void;
 };
 
 type RealtimeVoiceConnectAttemptOptions = {
@@ -174,8 +175,11 @@ export class RealtimeVoiceSessionLifecycle {
       rejectPromise = reject;
     });
     let removeAbortListener = () => {};
+    let timeout: ReturnType<typeof setTimeout> | undefined;
     const cleanup = () => {
-      clearTimeout(timeout);
+      if (timeout) {
+        clearTimeout(timeout);
+      }
       removeAbortListener();
     };
     const resolve = (providerReady = false) => {
@@ -203,17 +207,22 @@ export class RealtimeVoiceSessionLifecycle {
       reject(error);
       return true;
     };
-    const timeout = setTimeout(() => {
-      if (
-        this.isCurrent(options.connection) &&
-        !ready &&
-        this.terminalOutcome(options.connection) !== "completed"
-      ) {
-        startupFailed = true;
-        options.onTimeout();
-        reject(options.timeoutError());
+    const startTimeout = () => {
+      if (settled || timeout) {
+        return;
       }
-    }, options.timeoutMs);
+      timeout = setTimeout(() => {
+        if (
+          this.isCurrent(options.connection) &&
+          !ready &&
+          this.terminalOutcome(options.connection) !== "completed"
+        ) {
+          startupFailed = true;
+          options.onTimeout();
+          reject(options.timeoutError());
+        }
+      }, options.timeoutMs);
+    };
     const onAbort = () => {
       const outcome = this.terminalOutcome(options.connection);
       options.onAbort(outcome);
@@ -243,6 +252,7 @@ export class RealtimeVoiceSessionLifecycle {
       reject,
       rejectStartup,
       resolve,
+      startTimeout,
     };
   }
 


### PR DESCRIPTION
Related: #116201

## What Problem This Solves

Fixes an issue where xAI realtime voice users authenticating through OAuth could receive a connection timeout while credentials were still being refreshed, even though the resolved bearer and realtime endpoint were valid.

## Why This Change Was Made

The shared connection attempt now acquires cancellation ownership immediately but starts its socket deadline explicitly after provider authentication and connection parameters are ready. The xAI and OpenAI realtime adapters use that boundary; the existing 10-second socket timeout and all terminal behavior remain unchanged.

## User Impact

OAuth-backed realtime voice connections no longer fail solely because credential preparation takes longer than the socket handshake budget. Direct API-key connections, cancellation, close, retry, and terminal outcomes keep their existing behavior.

## Evidence

- Before: OAuth bearer resolution succeeded, the xAI models endpoint returned HTTP 200, and a raw realtime WebSocket opened, while the provider bridge still ended with `xAI realtime voice connection timeout`.
- After: OAuth-only live talkback on `grok-voice-latest` returned 260,120 audio bytes, the expected final transcript marker, and `response.done`; double-close was idempotent, with zero late audio and zero errors.
- Focused lifecycle tests: 9/9 passed.
- Focused OpenAI provider tests: 120/120 passed.
- Focused xAI provider and terminal-outcome tests: 74/74 passed.
- Structured P0 autoreview: no accepted or actionable findings.
- Blacksmith Testbox changed-surface validation: passed on signed head `dc8bcf97d09b6f4dde45e83c9c40ba28a42d38e8`.
- GitHub exact-head CI: 78 checks passed, including `openclaw/ci-gate`, on final reviewed head `a7cf1ba9fc74dad4924886051a7667db8388b3c5`; zero failures or pending checks.
- ClawSweeper exact-head review: no actionable patch findings; it identified this as the canonical shared-lifecycle fix and recommended merge after exact-head checks.

AI-assisted: yes.
