### PR TITLE
feat(plugins): inspect compatible bundle agent templates

### DIFF
--- a/docs/plugins/bundles.md
+++ b/docs/plugins/bundles.md
@@ -203,13 +203,14 @@ them:
 
 ### Agent templates: inspected, not executed
 
-OpenClaw parses Claude `agents/` and Cursor `.cursor/agents/` Markdown files
-into normalized, metadata-only capability records. Run
+OpenClaw parses agent Markdown from Claude and Cursor bundles into normalized,
+metadata-only capability records. It recognizes default Claude `agents/`,
+default Cursor `.cursor/agents/`, and either format's manifest-declared agent roots. Run
 `openclaw plugins inspect <id>` for a template summary. Add `--json` to inspect
 the full record: source format, name, description, prompt file reference and
 digest, source path, model and effort hints, maximum-turn hint, requested tools
-and skills, supported execution hints, and fields retained with an unsupported
-reason. Malformed definitions produce diagnostics instead of stopping bundle
+and skills, supported execution hints, and unsupported field names with their
+reasons. Malformed definitions produce diagnostics instead of stopping bundle
 loading.
 
 These records are **not executable**. Discovery does not instantiate an
@@ -298,10 +299,10 @@ Other detected-but-not-executed surfaces remain:
   <Accordion title="Cursor bundles">
     Markers: `.cursor-plugin/plugin.json`
 
-    Optional content: `skills/`, `.cursor/commands/`, `.cursor/agents/`, `.cursor/rules/`, `.cursor/hooks.json`, `.mcp.json`
+    Optional content: `skills/`, `.cursor/commands/`, `.cursor/agents/`, manifest-declared agent roots, `.cursor/rules/`, `.cursor/hooks.json`, `.mcp.json`
 
     - `.cursor/commands/` is treated as skill content
-    - `.cursor/agents/` definitions are parsed for inspection but are not executed
+    - `.cursor/agents/` and manifest-declared agent roots (commonly `agents/`) are parsed for inspection but are not executed
     - `.cursor/rules/` and `.cursor/hooks.json` are detect-only
 
   </Accordion>

--- a/docs/plugins/bundles.md
+++ b/docs/plugins/bundles.md
@@ -201,13 +201,33 @@ them:
 - Only supported stdio-backed LSP servers are runnable today; unsupported
   transports still show up in `openclaw plugins inspect <id>`.
 
-### Detected but not executed
+### Agent templates: inspected, not executed
 
-These are recognized and shown in diagnostics, but OpenClaw does not run them:
+OpenClaw parses Claude `agents/` and Cursor `.cursor/agents/` Markdown files
+into normalized, metadata-only capability records. Run
+`openclaw plugins inspect <id>` for a template summary. Add `--json` to inspect
+the full record: source format, name, description, prompt file reference and
+digest, source path, model and effort hints, maximum-turn hint, requested tools
+and skills, supported execution hints, and fields retained with an unsupported
+reason. Malformed definitions produce diagnostics instead of stopping bundle
+loading.
 
-- Claude `agents`, `hooks/hooks.json` automation, `outputStyles`
-- Cursor `.cursor/agents`, `.cursor/hooks.json`, `.cursor/rules`
+These records are **not executable**. Discovery does not instantiate an
+OpenClaw subagent, add template prompts to an active agent prompt, or grant
+tools, skills, models, memory, background execution, or isolation.
+
+Other detected-but-not-executed surfaces remain:
+
+- Claude `hooks/hooks.json` automation and `outputStyles`
+- Cursor `.cursor/hooks.json` and `.cursor/rules`
 - Codex `.app.json` metadata beyond capability reporting
+
+<Info>
+  **Future execution path:** a later feature could convert these records into
+  native subagent templates only after explicit operator opt-in, mapping model
+  and tool requests through the selected OpenClaw agent's local policy and
+  requiring approval review before activation.
+</Info>
 
 ## Bundle formats
 
@@ -269,6 +289,7 @@ These are recognized and shown in diagnostics, but OpenClaw does not run them:
     - `settings.json` is imported into embedded OpenClaw settings (shell override keys are sanitized)
     - `.mcp.json` exposes supported stdio tools to embedded OpenClaw
     - `.lsp.json` plus manifest-declared `lspServers` paths load into embedded OpenClaw LSP defaults
+    - `agents/` definitions are parsed for inspection but are not executed
     - `hooks/hooks.json` is detected but not executed
     - Custom component paths in the manifest are additive; they extend defaults, not replace them
 
@@ -280,7 +301,8 @@ These are recognized and shown in diagnostics, but OpenClaw does not run them:
     Optional content: `skills/`, `.cursor/commands/`, `.cursor/agents/`, `.cursor/rules/`, `.cursor/hooks.json`, `.mcp.json`
 
     - `.cursor/commands/` is treated as skill content
-    - `.cursor/rules/`, `.cursor/agents/`, and `.cursor/hooks.json` are detect-only
+    - `.cursor/agents/` definitions are parsed for inspection but are not executed
+    - `.cursor/rules/` and `.cursor/hooks.json` are detect-only
 
   </Accordion>
 </AccordionGroup>

--- a/packages/markdown-core/src/frontmatter.test.ts
+++ b/packages/markdown-core/src/frontmatter.test.ts
@@ -196,6 +196,17 @@ metadata:
     expect(result.metadata).toBe('{"openclaw":true}');
   });
 
+  it("reports which values came from structured YAML", () => {
+    const result = parseFrontmatterBlockResult(`---
+name: sample-skill
+tools: [Read, Grep]
+metadata:
+  openclaw: true
+---`);
+
+    expect(result.structuredFields).toEqual(["tools", "metadata"]);
+  });
+
   it("returns empty when frontmatter is missing", () => {
     const content = "# No frontmatter";
     expect(parseFrontmatterBlock(content)).toStrictEqual({});

--- a/packages/markdown-core/src/frontmatter.ts
+++ b/packages/markdown-core/src/frontmatter.ts
@@ -6,7 +6,7 @@ type ParsedFrontmatter = Record<string, string>;
 export type ParsedFrontmatterBlockResult = {
   frontmatter: ParsedFrontmatter;
   issues: FrontmatterParseIssue[];
-  structuredFields?: string[];
+  structuredFields: string[];
 };
 
 export type FrontmatterParseIssue = {
@@ -114,6 +114,7 @@ function parseYamlFrontmatterOnce(
     if (doc.errors.length > 0 || !isMap(doc.contents)) {
       return {
         frontmatter: fallback,
+        structuredFields: [],
         issues:
           doc.errors.length > 0
             ? doc.errors.map((error) => ({
@@ -128,6 +129,7 @@ function parseYamlFrontmatterOnce(
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
       return {
         frontmatter: fallback,
+        structuredFields: [],
         issues: [{ code: "INVALID_ROOT", message: "frontmatter must be a YAML mapping" }],
       };
     }
@@ -176,6 +178,7 @@ function parseYamlFrontmatterOnce(
     const message = error instanceof Error ? error.message : String(error);
     return {
       frontmatter: fallback,
+      structuredFields: [],
       issues: [{ code: "YAML_EXCEPTION", message }],
     };
   }
@@ -247,11 +250,14 @@ export function parseFrontmatterBlockResult(content: string): ParsedFrontmatterB
   const normalized = normalizeFrontmatterContent(content);
   const block = extractFrontmatterBlockFromNormalized(normalized)?.block;
   if (block !== undefined) {
-    return block ? parseYamlFrontmatter(block) : { frontmatter: {}, issues: [] };
+    return block
+      ? parseYamlFrontmatter(block)
+      : { frontmatter: {}, issues: [], structuredFields: [] };
   }
   return FRONTMATTER_OPENING_DELIMITER.test(normalized)
     ? {
         frontmatter: {},
+        structuredFields: [],
         issues: [
           {
             code: "UNTERMINATED_FRONTMATTER",
@@ -259,5 +265,5 @@ export function parseFrontmatterBlockResult(content: string): ParsedFrontmatterB
           },
         ],
       }
-    : { frontmatter: {}, issues: [] };
+    : { frontmatter: {}, issues: [], structuredFields: [] };
 }

--- a/packages/markdown-core/src/frontmatter.ts
+++ b/packages/markdown-core/src/frontmatter.ts
@@ -6,6 +6,7 @@ type ParsedFrontmatter = Record<string, string>;
 export type ParsedFrontmatterBlockResult = {
   frontmatter: ParsedFrontmatter;
   issues: FrontmatterParseIssue[];
+  structuredFields?: string[];
 };
 
 export type FrontmatterParseIssue = {
@@ -149,6 +150,7 @@ function parseYamlFrontmatterOnce(
     }
 
     const result: ParsedFrontmatter = {};
+    const structuredFields: string[] = [];
     for (const [rawKey, value] of Object.entries(parsed as Record<string, unknown>)) {
       const key = rawKey.trim();
       const coerced = key ? coerceYamlFrontmatterValue(value) : undefined;
@@ -156,10 +158,12 @@ function parseYamlFrontmatterOnce(
         continue;
       }
       const fallbackValue = Object.hasOwn(fallback, key) ? fallback[key] : undefined;
-      result[key] =
-        coerced.kind === "structured" && inlineColonKeys.has(key) && fallbackValue !== undefined
-          ? fallbackValue
-          : coerced.value;
+      const useFallback =
+        coerced.kind === "structured" && inlineColonKeys.has(key) && fallbackValue !== undefined;
+      result[key] = useFallback ? fallbackValue : coerced.value;
+      if (coerced.kind === "structured" && !useFallback) {
+        structuredFields.push(key);
+      }
     }
 
     for (const [key, value] of Object.entries(fallback)) {
@@ -167,7 +171,7 @@ function parseYamlFrontmatterOnce(
         result[key] = value;
       }
     }
-    return { frontmatter: result, issues: [] };
+    return { frontmatter: result, issues: [], structuredFields };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     return {

--- a/src/auto-reply/reply/commands-plugins.test.ts
+++ b/src/auto-reply/reply/commands-plugins.test.ts
@@ -272,6 +272,57 @@ describe("handlePluginsCommand", () => {
     expect(inspectAllResult?.reply?.text).toContain('"superpowers"');
   });
 
+  it("bounds compatible agent metadata in chat inspection replies", async () => {
+    const templates = Array.from({ length: 4 }, (_, index) => ({
+      id: `superpowers:reviewer-${index}-${"x".repeat(120)}`,
+      pluginId: "superpowers",
+      sourceFormat: "claude",
+      name: `reviewer-${index}-${"y".repeat(120)}`,
+      description: "not included in chat summaries",
+      prompt: {
+        kind: "file",
+        path: `agents/reviewer-${index}.md`,
+        contentDigest: "a".repeat(64),
+      },
+      sourceFilePath: `agents/${"z".repeat(120)}-${index}.md`,
+    }));
+    buildPluginInspectReportMock.mockReturnValue({
+      plugin: { id: "superpowers", bundleAgentTemplates: templates },
+      compatibility: [],
+      bundleAgentTemplates: templates,
+    });
+    buildAllPluginInspectReportsMock.mockReturnValue([
+      {
+        plugin: { id: "superpowers", bundleAgentTemplates: templates },
+        compatibility: [],
+        bundleAgentTemplates: templates,
+      },
+    ]);
+
+    const result = await handlePluginsCommand(
+      buildPluginsParams("/plugins inspect superpowers", buildCfg()),
+      true,
+    );
+    const text = result?.reply?.text ?? "";
+
+    expect(text).toContain('"bundleAgentTemplateCount": 4');
+    expect(text).toContain('"bundleAgentTemplatesOmitted": 2');
+    expect(text).toContain("reviewer-0");
+    expect(text).toContain("reviewer-1");
+    expect(text).not.toContain("reviewer-2");
+    expect(text).not.toContain("not included in chat summaries");
+    expect(text).not.toContain("x".repeat(100));
+
+    const allResult = await handlePluginsCommand(
+      buildPluginsParams("/plugins inspect all", buildCfg()),
+      true,
+    );
+    const allText = allResult?.reply?.text ?? "";
+    expect(allText).toContain('"bundleAgentTemplatesOmitted": 2');
+    expect(allText).not.toContain("not included in chat summaries");
+    expect(allText).not.toContain("x".repeat(100));
+  });
+
   it("rejects internal writes without operator.admin", async () => {
     const params = buildPluginsParams("/plugins enable superpowers", buildCfg());
     params.command.channel = "webchat";

--- a/src/auto-reply/reply/commands-plugins.test.ts
+++ b/src/auto-reply/reply/commands-plugins.test.ts
@@ -287,13 +287,13 @@ describe("handlePluginsCommand", () => {
       sourceFilePath: `agents/${"z".repeat(120)}-${index}.md`,
     }));
     buildPluginInspectReportMock.mockReturnValue({
-      plugin: { id: "superpowers", bundleAgentTemplates: templates },
+      plugin: { id: "superpowers" },
       compatibility: [],
       bundleAgentTemplates: templates,
     });
     buildAllPluginInspectReportsMock.mockReturnValue([
       {
-        plugin: { id: "superpowers", bundleAgentTemplates: templates },
+        plugin: { id: "superpowers" },
         compatibility: [],
         bundleAgentTemplates: templates,
       },

--- a/src/auto-reply/reply/commands-plugins.ts
+++ b/src/auto-reply/reply/commands-plugins.ts
@@ -38,12 +38,41 @@ function renderJsonBlock(label: string, value: unknown): string {
   return `${label}\n\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\``;
 }
 
+const CHAT_AGENT_TEMPLATE_LIMIT = 2;
+const CHAT_AGENT_TEMPLATE_TEXT_LIMIT = 80;
+
+function truncateChatMetadata(value: string): string {
+  const characters = Array.from(value);
+  return characters.length <= CHAT_AGENT_TEMPLATE_TEXT_LIMIT
+    ? value
+    : `${characters.slice(0, CHAT_AGENT_TEMPLATE_TEXT_LIMIT - 1).join("")}…`;
+}
+
+function buildChatSafePluginInspect(
+  inspect: ReturnType<typeof buildAllPluginInspectReports>[number],
+) {
+  const templates = inspect.bundleAgentTemplates ?? [];
+  const { bundleAgentTemplates: _nestedTemplates, ...plugin } = inspect.plugin;
+  return {
+    ...inspect,
+    plugin,
+    bundleAgentTemplates: templates.slice(0, CHAT_AGENT_TEMPLATE_LIMIT).map((template) => ({
+      id: truncateChatMetadata(template.id),
+      sourceFormat: template.sourceFormat,
+      name: truncateChatMetadata(template.name),
+      sourceFilePath: truncateChatMetadata(template.sourceFilePath),
+    })),
+    bundleAgentTemplateCount: templates.length,
+    bundleAgentTemplatesOmitted: Math.max(0, templates.length - CHAT_AGENT_TEMPLATE_LIMIT),
+  };
+}
+
 function buildPluginInspectJson(
   inspect: ReturnType<typeof buildAllPluginInspectReports>[number],
   installRecords: Record<string, PluginInstallRecord>,
 ) {
   return {
-    inspect,
+    inspect: buildChatSafePluginInspect(inspect),
     compatibilityWarnings: inspect.compatibility.map((warning) => ({
       code: warning.code,
       severity: warning.severity,
@@ -275,7 +304,7 @@ export const handlePluginsCommand: CommandHandler = defineAuthorizedTextCommand(
         const payload = buildPluginInspectJson(inspect, installRecords);
         return commandReply(
           renderJsonBlock(`🔌 Plugin "${inspect.plugin.id}"`, {
-            ...inspect,
+            ...payload.inspect,
             compatibilityWarnings: payload.compatibilityWarnings,
             install: payload.install,
           }),

--- a/src/auto-reply/reply/commands-plugins.ts
+++ b/src/auto-reply/reply/commands-plugins.ts
@@ -42,20 +42,22 @@ const CHAT_AGENT_TEMPLATE_LIMIT = 2;
 const CHAT_AGENT_TEMPLATE_TEXT_LIMIT = 80;
 
 function truncateChatMetadata(value: string): string {
-  const characters = Array.from(value);
-  return characters.length <= CHAT_AGENT_TEMPLATE_TEXT_LIMIT
-    ? value
-    : `${characters.slice(0, CHAT_AGENT_TEMPLATE_TEXT_LIMIT - 1).join("")}…`;
+  const prefix: string[] = [];
+  for (const character of value) {
+    if (prefix.length === CHAT_AGENT_TEMPLATE_TEXT_LIMIT) {
+      return `${prefix.slice(0, -1).join("")}…`;
+    }
+    prefix.push(character);
+  }
+  return value;
 }
 
 function buildChatSafePluginInspect(
   inspect: ReturnType<typeof buildAllPluginInspectReports>[number],
 ) {
   const templates = inspect.bundleAgentTemplates ?? [];
-  const { bundleAgentTemplates: _nestedTemplates, ...plugin } = inspect.plugin;
   return {
     ...inspect,
-    plugin,
     bundleAgentTemplates: templates.slice(0, CHAT_AGENT_TEMPLATE_LIMIT).map((template) => ({
       id: truncateChatMetadata(template.id),
       sourceFormat: template.sourceFormat,

--- a/src/cli/plugins-cli.list.test.ts
+++ b/src/cli/plugins-cli.list.test.ts
@@ -826,7 +826,22 @@ describe("plugins cli list", () => {
       lspServers: [],
       httpRouteCount: 0,
       bundleCapabilities: [],
-      diagnostics: [],
+      bundleAgentTemplates: [
+        {
+          id: "reviewer",
+          pluginId: "openclaw-mem0",
+          sourceFormat: "claude",
+          name: "reviewer\u001b[2J\nforged",
+          description: "Review safely\u009b31m",
+          prompt: {
+            kind: "file",
+            path: "agents/reviewer.md",
+            contentDigest: "a".repeat(64),
+          },
+          sourceFilePath: "agents/reviewer.md\rforged",
+        },
+      ],
+      diagnostics: [{ level: "warn", message: "warning\u001b[2J\nforged" }],
       policy: {
         allowConversationAccess: true,
         allowedModels: [],
@@ -840,6 +855,9 @@ describe("plugins cli list", () => {
 
     expect(buildPluginDiagnosticsReport).not.toHaveBeenCalled();
     expect(runtimeLogs.join("\n")).toContain("Policy");
+    expect(runtimeLogs.join("\n")).toContain("reviewer\\nforged");
+    expect(runtimeLogs.join("\n")).toContain("warning\\nforged");
+    expect(runtimeLogs.join("\n")).not.toContain("\u001b[2J");
     expect(runtimeLogs.join("\n")).toContain("allowConversationAccess: true");
     expect(runtimeLogs.join("\n")).toContain("ClawHub package: openclaw-mem0");
     expect(runtimeLogs.join("\n")).toContain("Artifact kind: npm-pack");
@@ -877,6 +895,7 @@ describe("plugins cli list", () => {
       lspServers: [],
       httpRouteCount: 0,
       bundleCapabilities: [],
+      bundleAgentTemplates: [],
       diagnostics: [],
       policy: {
         allowedModels: [],

--- a/src/cli/plugins-inspect-command.ts
+++ b/src/cli/plugins-inspect-command.ts
@@ -1,3 +1,4 @@
+import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 // `openclaw plugins inspect`: renders plugin registry shape, capabilities, policy, diagnostics, and install records.
 import { getTerminalTableWidth, renderTable } from "../../packages/terminal-core/src/table.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
@@ -316,6 +317,15 @@ export async function runPluginsInspectCommand(
   }
   lines.push(
     ...formatInspectSection(
+      "Bundle agent templates (metadata only; not executable)",
+      inspect.bundleAgentTemplates.map(
+        (entry) =>
+          `${sanitizeTerminalText(entry.name)} [${entry.sourceFormat}] — ${sanitizeTerminalText(entry.description)} (${sanitizeTerminalText(entry.sourceFilePath)})`,
+      ),
+    ),
+  );
+  lines.push(
+    ...formatInspectSection(
       "Capabilities",
       inspect.capabilities.map(
         (entry) => `${entry.kind}: ${entry.ids.length > 0 ? entry.ids.join(", ") : "(registered)"}`,
@@ -397,7 +407,9 @@ export async function runPluginsInspectCommand(
   lines.push(
     ...formatInspectSection(
       "Diagnostics",
-      inspect.diagnostics.map((entry) => `${entry.level.toUpperCase()}: ${entry.message}`),
+      inspect.diagnostics.map(
+        (entry) => `${entry.level.toUpperCase()}: ${sanitizeTerminalText(entry.message)}`,
+      ),
     ),
   );
   lines.push(...formatInspectSection("Install", formatInstallLines(install)));

--- a/src/plugins/bundle-agent-manifest.test.ts
+++ b/src/plugins/bundle-agent-manifest.test.ts
@@ -1,0 +1,405 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadBundleAgentTemplates } from "./bundle-agent-manifest.js";
+import { loadBundleManifest } from "./bundle-manifest.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeBundleRoot(): string {
+  const rootDir = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bundle-agents-")),
+  );
+  tempDirs.push(rootDir);
+  return rootDir;
+}
+
+function writeAgent(rootDir: string, relativePath: string, content: string): string {
+  const filePath = path.join(rootDir, relativePath);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, "utf8");
+  return filePath;
+}
+
+describe("loadBundleAgentTemplates", () => {
+  it("normalizes Claude agent frontmatter without persisting prompt text", () => {
+    const rootDir = makeBundleRoot();
+    writeAgent(
+      rootDir,
+      "agents/reviewer.md",
+      [
+        "---",
+        "name: reviewer",
+        "description: Reviews changes for correctness and security",
+        "model: sonnet",
+        "effort: high",
+        "maxTurns: 12",
+        "tools: [Read, Grep, Bash]",
+        "disallowedTools: [Write, Edit]",
+        "skills: [security-review]",
+        "memory: project",
+        "background: true",
+        "isolation: worktree",
+        "permissionMode: plan",
+        "---",
+        "Review the requested change and return prioritized findings.",
+      ].join("\n"),
+    );
+
+    const result = loadBundleAgentTemplates({
+      rootDir,
+      agentRoots: ["agents"],
+      sourceFormat: "claude",
+      pluginId: "review-pack",
+      rejectHardlinks: true,
+    });
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.agentTemplates).toEqual([
+      expect.objectContaining({
+        id: "reviewer",
+        pluginId: "review-pack",
+        sourceFormat: "claude",
+        name: "reviewer",
+        description: "Reviews changes for correctness and security",
+        prompt: {
+          kind: "file",
+          path: "agents/reviewer.md",
+          contentDigest: expect.stringMatching(/^[a-f0-9]{64}$/u),
+        },
+        sourceFilePath: "agents/reviewer.md",
+        model: "sonnet",
+        effort: "high",
+        maxTurns: 12,
+        tools: ["Read", "Grep", "Bash"],
+        disallowedTools: ["Write", "Edit"],
+        skills: ["security-review"],
+        memory: "project",
+        background: true,
+        isolation: "worktree",
+        unsupportedFields: [
+          {
+            field: "permissionMode",
+            reason: "not mapped to OpenClaw runtime policy",
+          },
+        ],
+      }),
+    ]);
+    expect(JSON.stringify(result.agentTemplates)).not.toContain("prioritized findings");
+  });
+
+  it("preserves a quoted scalar description that begins with a bracket", () => {
+    const rootDir = makeBundleRoot();
+    writeAgent(
+      rootDir,
+      "agents/security-reviewer.md",
+      [
+        "---",
+        "name: security-reviewer",
+        'description: "[Security] Reviews changes"',
+        "---",
+        "Review safely.",
+      ].join("\n"),
+    );
+
+    const result = loadBundleAgentTemplates({
+      rootDir,
+      agentRoots: ["agents"],
+      sourceFormat: "claude",
+      pluginId: "quoted-pack",
+      rejectHardlinks: true,
+    });
+
+    expect(result.agentTemplates).toMatchObject([
+      { name: "security-reviewer", description: "[Security] Reviews changes" },
+    ]);
+  });
+
+  it("rejects a Claude agent name outside the source format contract", () => {
+    const rootDir = makeBundleRoot();
+    writeAgent(
+      rootDir,
+      "agents/invalid.md",
+      ["---", "name: Security Reviewer", "description: Invalid name", "---", "Review."].join("\n"),
+    );
+
+    const result = loadBundleAgentTemplates({
+      rootDir,
+      agentRoots: ["agents"],
+      sourceFormat: "claude",
+      pluginId: "invalid-name-pack",
+      rejectHardlinks: true,
+    });
+
+    expect(result.agentTemplates).toEqual([]);
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ message: expect.stringContaining("invalid Claude agent name") }),
+    );
+  });
+
+  it("normalizes Cursor agent files from .cursor/agents", () => {
+    const rootDir = makeBundleRoot();
+    writeAgent(
+      rootDir,
+      ".cursor/agents/explorer.md",
+      [
+        "---",
+        "name: explorer",
+        "description: Maps an unfamiliar repository",
+        "tools: Read, Grep, Glob",
+        "---",
+        "Explore the repository without editing it.",
+      ].join("\n"),
+    );
+
+    const result = loadBundleAgentTemplates({
+      rootDir,
+      agentRoots: [".cursor/agents"],
+      sourceFormat: "cursor",
+      pluginId: "cursor-pack",
+      rejectHardlinks: true,
+    });
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.agentTemplates).toEqual([
+      expect.objectContaining({
+        id: "explorer",
+        pluginId: "cursor-pack",
+        sourceFormat: "cursor",
+        name: "explorer",
+        description: "Maps an unfamiliar repository",
+        tools: ["Read", "Grep", "Glob"],
+      }),
+    ]);
+  });
+
+  it("preserves Claude agent metadata when Codex is the preferred bundle format", () => {
+    const rootDir = makeBundleRoot();
+    writeAgent(
+      rootDir,
+      ".codex-plugin/plugin.json",
+      JSON.stringify({ name: "mixed-pack", version: "1.0.0" }),
+    );
+    writeAgent(
+      rootDir,
+      "agents/reviewer.md",
+      ["---", "name: reviewer", "description: Claude reviewer", "---", "Review changes."].join(
+        "\n",
+      ),
+    );
+
+    const result = loadBundleManifest({ rootDir, bundleFormat: "codex" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("expected mixed bundle manifest to load");
+    }
+    expect(result.manifest.bundleFormat).toBe("codex");
+    expect(result.manifest.agentTemplates).toEqual([
+      expect.objectContaining({ name: "reviewer", sourceFormat: "claude" }),
+    ]);
+  });
+
+  it("allows discovery to skip the full agent metadata scan", () => {
+    const rootDir = makeBundleRoot();
+    writeAgent(rootDir, ".claude-plugin/plugin.json", JSON.stringify({ name: "discovery-pack" }));
+    writeAgent(
+      rootDir,
+      "agents/reviewer.md",
+      ["---", "name: reviewer", "description: Reviewer", "---", "Review changes."].join("\n"),
+    );
+
+    const result = loadBundleManifest({
+      rootDir,
+      bundleFormat: "claude",
+      loadAgentTemplates: false,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("expected bundle manifest to load for discovery");
+    }
+    expect(result.manifest.agentTemplates).toBeUndefined();
+  });
+
+  it("skips malformed or incomplete agents and returns diagnostics", () => {
+    const rootDir = makeBundleRoot();
+    writeAgent(
+      rootDir,
+      "agents/malformed.md",
+      ["---", "name: malformed", "description: [unterminated", "Prompt body."].join("\n"),
+    );
+    writeAgent(
+      rootDir,
+      "agents/missing-description.md",
+      ["---", "name: missing-description", "---", "Prompt body."].join("\n"),
+    );
+
+    const result = loadBundleAgentTemplates({
+      rootDir,
+      agentRoots: ["agents"],
+      sourceFormat: "claude",
+      pluginId: "broken-pack",
+      rejectHardlinks: true,
+    });
+
+    expect(result.agentTemplates).toEqual([]);
+    expect(result.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ message: expect.stringContaining("frontmatter") }),
+        expect.objectContaining({ message: expect.stringContaining("description") }),
+      ]),
+    );
+  });
+
+  it("reports a manifest-declared agent root that cannot be inspected", () => {
+    const rootDir = makeBundleRoot();
+    const result = loadBundleAgentTemplates({
+      rootDir,
+      agentRoots: ["missing-agents"],
+      sourceFormat: "claude",
+      pluginId: "missing-root-pack",
+      rejectHardlinks: true,
+    });
+
+    expect(result.agentTemplates).toEqual([]);
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ message: expect.stringContaining("could not be inspected") }),
+    );
+  });
+
+  it("rejects declared agent roots outside the bundle", () => {
+    const rootDir = makeBundleRoot();
+    const outsideDir = makeBundleRoot();
+    writeAgent(
+      outsideDir,
+      "reviewer.md",
+      ["---", "name: reviewer", "description: Escaped agent", "---", "Do not load."].join("\n"),
+    );
+
+    const result = loadBundleAgentTemplates({
+      rootDir,
+      agentRoots: [path.relative(rootDir, outsideDir)],
+      sourceFormat: "claude",
+      pluginId: "unsafe-pack",
+      rejectHardlinks: true,
+    });
+
+    expect(result.agentTemplates).toEqual([]);
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ message: expect.stringContaining("escapes the plugin root") }),
+    );
+  });
+
+  it("skips oversized files without dropping safe siblings", () => {
+    const rootDir = makeBundleRoot();
+    writeAgent(
+      rootDir,
+      "agents/oversized.md",
+      ["---", "name: oversized", "description: Too large", "---", "x".repeat(1024 * 1024)].join(
+        "\n",
+      ),
+    );
+    writeAgent(
+      rootDir,
+      "agents/reviewer.md",
+      ["---", "name: reviewer", "description: Safe sibling", "---", "Review."].join("\n"),
+    );
+
+    const result = loadBundleAgentTemplates({
+      rootDir,
+      agentRoots: ["agents"],
+      sourceFormat: "claude",
+      pluginId: "large-pack",
+      rejectHardlinks: true,
+    });
+
+    expect(result.agentTemplates.map((entry) => entry.name)).toEqual(["reviewer"]);
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ message: expect.stringContaining("exceeds the size limit") }),
+    );
+  });
+
+  it("drops conflicting template ids instead of choosing one implicitly", () => {
+    const rootDir = makeBundleRoot();
+    for (const relativePath of ["agents/reviewer.md", "agents/nested/reviewer.md"]) {
+      writeAgent(
+        rootDir,
+        relativePath,
+        ["---", "name: reviewer", "description: Conflicting reviewer", "---", "Review."].join("\n"),
+      );
+    }
+
+    const result = loadBundleAgentTemplates({
+      rootDir,
+      agentRoots: ["agents"],
+      sourceFormat: "claude",
+      pluginId: "collision-pack",
+      rejectHardlinks: true,
+    });
+
+    expect(result.agentTemplates).toEqual([]);
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ message: expect.stringContaining("conflicting compatible") }),
+    );
+  });
+
+  it("drops a cross-format template when the same id already conflicts within one format", () => {
+    const rootDir = makeBundleRoot();
+    writeAgent(rootDir, ".claude-plugin/plugin.json", JSON.stringify({ name: "mixed-pack" }));
+    for (const relativePath of ["agents/reviewer.md", "agents/nested/reviewer.md"]) {
+      writeAgent(
+        rootDir,
+        relativePath,
+        ["---", "name: reviewer", "description: Claude reviewer", "---", "Review."].join("\n"),
+      );
+    }
+    writeAgent(
+      rootDir,
+      ".cursor/agents/reviewer.md",
+      ["---", "name: reviewer", "description: Cursor reviewer", "---", "Explore."].join("\n"),
+    );
+
+    const result = loadBundleManifest({ rootDir, bundleFormat: "claude" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("expected mixed bundle manifest to load");
+    }
+    expect(result.manifest.agentTemplates ?? []).toEqual([]);
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ message: expect.stringContaining("conflicting compatible") }),
+    );
+  });
+
+  it("keeps default agents visible when an optional secondary manifest is malformed", () => {
+    const rootDir = makeBundleRoot();
+    writeAgent(rootDir, ".codex-plugin/plugin.json", JSON.stringify({ name: "codex-pack" }));
+    writeAgent(rootDir, ".claude-plugin/plugin.json", "{ malformed");
+    writeAgent(
+      rootDir,
+      "agents/reviewer.md",
+      ["---", "name: reviewer", "description: Default agent", "---", "Review."].join("\n"),
+    );
+
+    const result = loadBundleManifest({ rootDir, bundleFormat: "codex" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("expected Codex bundle manifest to load");
+    }
+    expect(result.manifest.agentTemplates).toMatchObject([
+      { name: "reviewer", sourceFormat: "claude" },
+    ]);
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({ message: expect.stringContaining("failed to parse") }),
+    );
+  });
+});

--- a/src/plugins/bundle-agent-manifest.test.ts
+++ b/src/plugins/bundle-agent-manifest.test.ts
@@ -64,7 +64,7 @@ describe("loadBundleAgentTemplates", () => {
     expect(result.diagnostics).toEqual([]);
     expect(result.agentTemplates).toEqual([
       expect.objectContaining({
-        id: "reviewer",
+        id: "review-pack:reviewer",
         pluginId: "review-pack",
         sourceFormat: "claude",
         name: "reviewer",
@@ -170,7 +170,7 @@ describe("loadBundleAgentTemplates", () => {
     expect(result.diagnostics).toEqual([]);
     expect(result.agentTemplates).toEqual([
       expect.objectContaining({
-        id: "explorer",
+        id: "cursor-pack:explorer",
         pluginId: "cursor-pack",
         sourceFormat: "cursor",
         name: "explorer",
@@ -178,6 +178,37 @@ describe("loadBundleAgentTemplates", () => {
         tools: ["Read", "Grep", "Glob"],
       }),
     ]);
+  });
+
+  it("keeps a Cursor manifest-declared agents root owned by Cursor", () => {
+    const rootDir = makeBundleRoot();
+    writeAgent(
+      rootDir,
+      ".cursor-plugin/plugin.json",
+      JSON.stringify({ name: "cursor-team-kit", agents: "./agents/" }),
+    );
+    writeAgent(
+      rootDir,
+      "agents/ci-watcher.md",
+      [
+        "---",
+        "name: ci-watcher",
+        "description: Watches CI until completion",
+        "---",
+        "Monitor CI and report failures.",
+      ].join("\n"),
+    );
+
+    const result = loadBundleManifest({ rootDir, bundleFormat: "cursor" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("expected Cursor bundle manifest to load");
+    }
+    expect(result.manifest.agentTemplates).toMatchObject([
+      { name: "ci-watcher", sourceFormat: "cursor" },
+    ]);
+    expect(result.diagnostics).toEqual([]);
   });
 
   it("preserves Claude agent metadata when Codex is the preferred bundle format", () => {
@@ -327,7 +358,7 @@ describe("loadBundleAgentTemplates", () => {
     );
   });
 
-  it("drops conflicting template ids instead of choosing one implicitly", () => {
+  it("preserves Claude plugin subfolder identity when names repeat", () => {
     const rootDir = makeBundleRoot();
     for (const relativePath of ["agents/reviewer.md", "agents/nested/reviewer.md"]) {
       writeAgent(
@@ -345,13 +376,14 @@ describe("loadBundleAgentTemplates", () => {
       rejectHardlinks: true,
     });
 
-    expect(result.agentTemplates).toEqual([]);
-    expect(result.diagnostics).toContainEqual(
-      expect.objectContaining({ message: expect.stringContaining("conflicting compatible") }),
-    );
+    expect(result.agentTemplates).toMatchObject([
+      { id: "collision-pack:nested:reviewer", name: "reviewer" },
+      { id: "collision-pack:reviewer", name: "reviewer" },
+    ]);
+    expect(result.diagnostics).toEqual([]);
   });
 
-  it("drops a cross-format template when the same id already conflicts within one format", () => {
+  it("drops cross-format definitions with the same scoped id", () => {
     const rootDir = makeBundleRoot();
     writeAgent(rootDir, ".claude-plugin/plugin.json", JSON.stringify({ name: "mixed-pack" }));
     for (const relativePath of ["agents/reviewer.md", "agents/nested/reviewer.md"]) {
@@ -373,10 +405,40 @@ describe("loadBundleAgentTemplates", () => {
     if (!result.ok) {
       throw new Error("expected mixed bundle manifest to load");
     }
-    expect(result.manifest.agentTemplates ?? []).toEqual([]);
+    expect(result.manifest.agentTemplates).toMatchObject([
+      { id: "mixed-pack:nested:reviewer", sourceFormat: "claude" },
+    ]);
     expect(result.diagnostics).toContainEqual(
       expect.objectContaining({ message: expect.stringContaining("conflicting compatible") }),
     );
+  });
+
+  it("does not reinterpret native Agent Plugin directories as compatible templates", () => {
+    const rootDir = makeBundleRoot();
+    writeAgent(
+      rootDir,
+      "plugin.json",
+      JSON.stringify({
+        $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+        name: "portable-pack",
+      }),
+    );
+    for (const relativePath of ["agents/reviewer.md", ".cursor/agents/explorer.md"]) {
+      writeAgent(
+        rootDir,
+        relativePath,
+        ["---", "name: reviewer", "description: Metadata", "---", "Prompt."].join("\n"),
+      );
+    }
+
+    const result = loadBundleManifest({ rootDir, bundleFormat: "agent" });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("expected Agent Plugin manifest to load");
+    }
+    expect(result.manifest.agentTemplates).toBeUndefined();
+    expect(result.diagnostics).toEqual([]);
   });
 
   it("keeps default agents visible when an optional secondary manifest is malformed", () => {

--- a/src/plugins/bundle-agent-manifest.test.ts
+++ b/src/plugins/bundle-agent-manifest.test.ts
@@ -1,24 +1,14 @@
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { loadBundleAgentTemplates } from "./bundle-agent-manifest.js";
 import { loadBundleManifest } from "./bundle-manifest.js";
 
-const tempDirs: string[] = [];
-
-afterEach(() => {
-  for (const dir of tempDirs.splice(0)) {
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
-});
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function makeBundleRoot(): string {
-  const rootDir = fs.realpathSync(
-    fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bundle-agents-")),
-  );
-  tempDirs.push(rootDir);
-  return rootDir;
+  return fs.realpathSync(tempDirs.make("openclaw-bundle-agents-"));
 }
 
 function writeAgent(rootDir: string, relativePath: string, content: string): string {

--- a/src/plugins/bundle-agent-manifest.test.ts
+++ b/src/plugins/bundle-agent-manifest.test.ts
@@ -199,7 +199,11 @@ describe("loadBundleAgentTemplates", () => {
       ].join("\n"),
     );
 
-    const result = loadBundleManifest({ rootDir, bundleFormat: "cursor" });
+    const result = loadBundleManifest({
+      rootDir,
+      bundleFormat: "cursor",
+      loadAgentTemplates: true,
+    });
 
     expect(result.ok).toBe(true);
     if (!result.ok) {
@@ -226,7 +230,11 @@ describe("loadBundleAgentTemplates", () => {
       ),
     );
 
-    const result = loadBundleManifest({ rootDir, bundleFormat: "codex" });
+    const result = loadBundleManifest({
+      rootDir,
+      bundleFormat: "codex",
+      loadAgentTemplates: true,
+    });
 
     expect(result.ok).toBe(true);
     if (!result.ok) {
@@ -238,7 +246,7 @@ describe("loadBundleAgentTemplates", () => {
     ]);
   });
 
-  it("allows discovery to skip the full agent metadata scan", () => {
+  it("keeps the general manifest load shallow unless metadata is requested", () => {
     const rootDir = makeBundleRoot();
     writeAgent(rootDir, ".claude-plugin/plugin.json", JSON.stringify({ name: "discovery-pack" }));
     writeAgent(
@@ -250,7 +258,6 @@ describe("loadBundleAgentTemplates", () => {
     const result = loadBundleManifest({
       rootDir,
       bundleFormat: "claude",
-      loadAgentTemplates: false,
     });
 
     expect(result.ok).toBe(true);
@@ -399,7 +406,11 @@ describe("loadBundleAgentTemplates", () => {
       ["---", "name: reviewer", "description: Cursor reviewer", "---", "Explore."].join("\n"),
     );
 
-    const result = loadBundleManifest({ rootDir, bundleFormat: "claude" });
+    const result = loadBundleManifest({
+      rootDir,
+      bundleFormat: "claude",
+      loadAgentTemplates: true,
+    });
 
     expect(result.ok).toBe(true);
     if (!result.ok) {
@@ -451,7 +462,11 @@ describe("loadBundleAgentTemplates", () => {
       ["---", "name: reviewer", "description: Default agent", "---", "Review."].join("\n"),
     );
 
-    const result = loadBundleManifest({ rootDir, bundleFormat: "codex" });
+    const result = loadBundleManifest({
+      rootDir,
+      bundleFormat: "codex",
+      loadAgentTemplates: true,
+    });
 
     expect(result.ok).toBe(true);
     if (!result.ok) {

--- a/src/plugins/bundle-agent-manifest.ts
+++ b/src/plugins/bundle-agent-manifest.ts
@@ -45,7 +45,7 @@ const COMMON_FIELDS = new Set([
 ]);
 const CURSOR_FIELDS = new Set(["is_background", "readonly"]);
 
-export type BundleAgentTemplateLoadResult = {
+type BundleAgentTemplateLoadResult = {
   agentTemplates: BundleAgentTemplate[];
   conflictingIds: string[];
   diagnostics: PluginDiagnostic[];

--- a/src/plugins/bundle-agent-manifest.ts
+++ b/src/plugins/bundle-agent-manifest.ts
@@ -1,0 +1,554 @@
+/** Parses compatible-bundle agent files into cold, non-executable metadata. */
+import fs from "node:fs";
+import path from "node:path";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import JSON5 from "json5";
+import {
+  parseFrontmatterBlockResult,
+  stripFrontmatterBlock,
+} from "../../packages/markdown-core/src/frontmatter.js";
+import { openRootFileSync, readFileDescriptorBoundedSync } from "../infra/boundary-file-read.js";
+import { sha256Hex } from "../infra/crypto-digest.js";
+import { walkDirectorySync } from "../infra/fs-safe.js";
+import { normalizeStringList } from "../shared/frontmatter.js";
+import { parseBooleanValue } from "../utils/boolean.js";
+import type {
+  BundleAgentTemplate,
+  BundleAgentUnsupportedField,
+  PluginBundleFormat,
+  PluginDiagnostic,
+} from "./manifest-types.js";
+import { isPathInside, safeRealpathSync } from "./path-safety.js";
+
+// These caps bound synchronous, cold metadata discovery per compatible format.
+// Keep both filesystem traversal and retained prompt-derived metadata predictable.
+const MAX_AGENT_ROOTS = 64;
+const MAX_AGENT_DEPTH = 8;
+const MAX_AGENT_SCAN_ENTRIES = 2_048;
+const MAX_AGENT_FILES = 256;
+const MAX_AGENT_FILE_BYTES = 1024 * 1024;
+const MAX_AGENT_TOTAL_BYTES = 8 * 1024 * 1024;
+
+const COMMON_FIELDS = new Set([
+  "name",
+  "description",
+  "model",
+  "effort",
+  "maxTurns",
+  "tools",
+  "disallowedTools",
+  "skills",
+  "memory",
+  "background",
+  "isolation",
+  "readOnly",
+]);
+const CURSOR_FIELDS = new Set(["is_background", "readonly"]);
+
+export type BundleAgentTemplateLoadResult = {
+  agentTemplates: BundleAgentTemplate[];
+  conflictingIds: string[];
+  diagnostics: PluginDiagnostic[];
+};
+
+/** Drops every definition involved in an id collision instead of choosing implicitly. */
+export function filterConflictingBundleAgentTemplates(templates: readonly BundleAgentTemplate[]): {
+  agentTemplates: BundleAgentTemplate[];
+  conflictingIds: string[];
+} {
+  const counts = new Map<string, number>();
+  for (const template of templates) {
+    counts.set(template.id, (counts.get(template.id) ?? 0) + 1);
+  }
+  const conflictingIds = [...counts]
+    .filter(([, count]) => count > 1)
+    .map(([id]) => id)
+    .toSorted();
+  const conflicts = new Set(conflictingIds);
+  return {
+    agentTemplates: templates.filter((entry) => !conflicts.has(entry.id)),
+    conflictingIds,
+  };
+}
+
+function normalizeRelativePath(value: string): string {
+  return value.split(path.sep).join("/");
+}
+
+function addDiagnostic(params: {
+  diagnostics: PluginDiagnostic[];
+  pluginId: string;
+  source: string;
+  message: string;
+}): void {
+  params.diagnostics.push({
+    level: "warn",
+    pluginId: params.pluginId,
+    source: params.source,
+    message: params.message,
+  });
+}
+
+function listAgentFiles(params: {
+  rootDir: string;
+  rootRealPath: string;
+  agentRoots: readonly string[];
+  pluginId: string;
+  diagnostics: PluginDiagnostic[];
+}): string[] {
+  const uniqueRoots = [...new Set(params.agentRoots.map((entry) => entry.trim()).filter(Boolean))];
+  const roots = uniqueRoots.toSorted().slice(0, MAX_AGENT_ROOTS);
+  if (uniqueRoots.length > MAX_AGENT_ROOTS) {
+    addDiagnostic({
+      ...params,
+      source: params.rootDir,
+      message: "bundle agent metadata root limit reached; remaining roots ignored",
+    });
+  }
+
+  const files = new Set<string>();
+  const scannedRoots: string[] = [];
+  let remainingEntries = MAX_AGENT_SCAN_ENTRIES;
+  for (const declaredRoot of roots) {
+    const absoluteRoot = path.resolve(params.rootDir, declaredRoot);
+    if (!isPathInside(params.rootDir, absoluteRoot)) {
+      addDiagnostic({
+        ...params,
+        source: absoluteRoot,
+        message: "bundle agent metadata root escapes the plugin root; entry ignored",
+      });
+      continue;
+    }
+    const realRoot = safeRealpathSync(absoluteRoot);
+    if (!realRoot) {
+      addDiagnostic({
+        diagnostics: params.diagnostics,
+        pluginId: params.pluginId,
+        source: absoluteRoot,
+        message: "declared bundle agent metadata root could not be inspected; entry ignored",
+      });
+      continue;
+    }
+    if (!isPathInside(params.rootRealPath, realRoot)) {
+      addDiagnostic({
+        ...params,
+        source: absoluteRoot,
+        message: "bundle agent metadata root escapes the plugin root; entry ignored",
+      });
+      continue;
+    }
+    if (scannedRoots.some((scannedRoot) => isPathInside(scannedRoot, realRoot))) {
+      continue;
+    }
+
+    let stat: fs.Stats;
+    try {
+      stat = fs.lstatSync(absoluteRoot);
+    } catch {
+      addDiagnostic({
+        diagnostics: params.diagnostics,
+        pluginId: params.pluginId,
+        source: absoluteRoot,
+        message: "declared bundle agent metadata root could not be inspected; entry ignored",
+      });
+      continue;
+    }
+    if (stat.isFile()) {
+      if (absoluteRoot.toLowerCase().endsWith(".md")) {
+        files.add(normalizeRelativePath(path.relative(params.rootDir, absoluteRoot)));
+      }
+      continue;
+    }
+    if (!stat.isDirectory() || stat.isSymbolicLink()) {
+      continue;
+    }
+    if (remainingEntries <= 0) {
+      addDiagnostic({
+        ...params,
+        source: absoluteRoot,
+        message: "bundle agent metadata scan limit reached; remaining entries ignored",
+      });
+      break;
+    }
+    scannedRoots.push(realRoot);
+    const scan = walkDirectorySync(absoluteRoot, {
+      maxDepth: MAX_AGENT_DEPTH,
+      maxEntries: remainingEntries,
+      symlinks: "skip",
+      include: (entry) => entry.kind === "file" && entry.name.toLowerCase().endsWith(".md"),
+    });
+    for (const entry of scan.entries) {
+      files.add(normalizeRelativePath(path.relative(params.rootDir, entry.path)));
+    }
+    remainingEntries -= scan.scannedEntryCount;
+    if (scan.truncated) {
+      addDiagnostic({
+        ...params,
+        source: absoluteRoot,
+        message: "bundle agent metadata scan limit reached; remaining entries ignored",
+      });
+      break;
+    }
+    for (const failedDir of scan.failedDirs ?? []) {
+      addDiagnostic({
+        ...params,
+        source: failedDir.path,
+        message: "bundle agent metadata directory could not be read; entry ignored",
+      });
+    }
+  }
+
+  const ordered = [...files].toSorted();
+  if (ordered.length > MAX_AGENT_FILES) {
+    addDiagnostic({
+      ...params,
+      source: params.rootDir,
+      message: "bundle agent metadata file limit reached; remaining files ignored",
+    });
+  }
+  return ordered.slice(0, MAX_AGENT_FILES);
+}
+
+function readAgentFile(params: {
+  rootDir: string;
+  rootRealPath: string;
+  relativePath: string;
+  rejectHardlinks: boolean;
+}): { raw: string; size: number } | undefined {
+  const opened = openRootFileSync({
+    absolutePath: path.join(params.rootDir, params.relativePath),
+    rootPath: params.rootDir,
+    rootRealPath: params.rootRealPath,
+    boundaryLabel: "plugin root",
+    maxBytes: MAX_AGENT_FILE_BYTES,
+    rejectHardlinks: params.rejectHardlinks,
+  });
+  if (!opened.ok) {
+    return undefined;
+  }
+  try {
+    const buffer = readFileDescriptorBoundedSync(opened.fd, MAX_AGENT_FILE_BYTES);
+    return {
+      raw: buffer.toString("utf8"),
+      size: buffer.byteLength,
+    };
+  } catch {
+    return undefined;
+  } finally {
+    try {
+      fs.closeSync(opened.fd);
+    } catch {
+      // Closing a metadata-only descriptor must not make bundle discovery fatal.
+    }
+  }
+}
+
+function parseListField(params: {
+  field: string;
+  value: string | undefined;
+  structured: boolean;
+  unsupported: Map<string, string>;
+}): string[] | undefined {
+  if (params.value === undefined) {
+    return undefined;
+  }
+  let input: unknown = params.value;
+  if (params.structured) {
+    try {
+      input = JSON5.parse(params.value);
+    } catch {
+      params.unsupported.set(params.field, "expected a list of strings; field ignored");
+      return undefined;
+    }
+    if (!Array.isArray(input) || input.some((entry) => typeof entry !== "string")) {
+      params.unsupported.set(params.field, "expected a list of strings; field ignored");
+      return undefined;
+    }
+  }
+  return normalizeStringList(input);
+}
+
+function parseScalar(
+  field: string,
+  value: string | undefined,
+  structured: boolean,
+  unsupported: Map<string, string>,
+): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (structured) {
+    unsupported.set(field, "expected a scalar value; field ignored");
+    return undefined;
+  }
+  return normalizeOptionalString(value);
+}
+
+function parseBoolean(
+  field: string,
+  value: string | undefined,
+  unsupported: Map<string, string>,
+): boolean | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = parseBooleanValue(value);
+  if (parsed === undefined) {
+    unsupported.set(field, "expected a boolean value; field ignored");
+  }
+  return parsed;
+}
+
+function buildUnsupportedFields(params: {
+  frontmatter: Record<string, string>;
+  sourceFormat: PluginBundleFormat;
+  invalid: ReadonlyMap<string, string>;
+}): BundleAgentUnsupportedField[] | undefined {
+  const unsupported = Object.keys(params.frontmatter)
+    .filter(
+      (field) =>
+        !COMMON_FIELDS.has(field) &&
+        !(params.sourceFormat === "cursor" && CURSOR_FIELDS.has(field)),
+    )
+    .map((field) => ({ field, reason: "not mapped to OpenClaw runtime policy" }));
+  for (const [field, reason] of params.invalid) {
+    unsupported.push({ field, reason });
+  }
+  const ordered = unsupported.toSorted((left, right) => left.field.localeCompare(right.field));
+  return ordered.length > 0 ? ordered : undefined;
+}
+
+function parseAgentTemplate(params: {
+  raw: string;
+  relativePath: string;
+  sourceFormat: PluginBundleFormat;
+  pluginId: string;
+  diagnostics: PluginDiagnostic[];
+}): BundleAgentTemplate | undefined {
+  const parsed = parseFrontmatterBlockResult(params.raw);
+  if (parsed.issues.length > 0) {
+    const issue = parsed.issues[0];
+    addDiagnostic({
+      diagnostics: params.diagnostics,
+      pluginId: params.pluginId,
+      source: params.relativePath,
+      message: `bundle agent metadata has invalid frontmatter (${issue?.code}: ${issue?.message}); entry ignored`,
+    });
+    return undefined;
+  }
+  const name = normalizeOptionalString(parsed.frontmatter.name);
+  const description = normalizeOptionalString(parsed.frontmatter.description);
+  const structuredFields = new Set(parsed.structuredFields);
+  const body = stripFrontmatterBlock(params.raw);
+  const rejectMissingRequired = (field: string): undefined => {
+    addDiagnostic({
+      diagnostics: params.diagnostics,
+      pluginId: params.pluginId,
+      source: params.relativePath,
+      message: `bundle agent metadata is missing required ${field}; entry ignored`,
+    });
+    return undefined;
+  };
+  if (!name || structuredFields.has("name")) {
+    return rejectMissingRequired("scalar name");
+  }
+  if (params.sourceFormat === "claude" && !/^[a-z]+(?:-[a-z]+)*$/u.test(name)) {
+    addDiagnostic({
+      diagnostics: params.diagnostics,
+      pluginId: params.pluginId,
+      source: params.relativePath,
+      message:
+        "bundle agent metadata has an invalid Claude agent name (expected lowercase letters and hyphens); entry ignored",
+    });
+    return undefined;
+  }
+  if (!description || structuredFields.has("description")) {
+    return rejectMissingRequired("scalar description");
+  }
+  if (!body) {
+    return rejectMissingRequired("prompt body");
+  }
+
+  const invalid = new Map<string, string>();
+  const model = parseScalar(
+    "model",
+    parsed.frontmatter.model,
+    structuredFields.has("model"),
+    invalid,
+  );
+  const effort = parseScalar(
+    "effort",
+    parsed.frontmatter.effort,
+    structuredFields.has("effort"),
+    invalid,
+  );
+  const memory = parseScalar(
+    "memory",
+    parsed.frontmatter.memory,
+    structuredFields.has("memory"),
+    invalid,
+  );
+  const isolation = parseScalar(
+    "isolation",
+    parsed.frontmatter.isolation,
+    structuredFields.has("isolation"),
+    invalid,
+  );
+  const maxTurnsRaw = parseScalar(
+    "maxTurns",
+    parsed.frontmatter.maxTurns,
+    structuredFields.has("maxTurns"),
+    invalid,
+  );
+  const maxTurnsNumber = maxTurnsRaw === undefined ? undefined : Number(maxTurnsRaw);
+  const maxTurns =
+    maxTurnsNumber !== undefined && Number.isSafeInteger(maxTurnsNumber) && maxTurnsNumber > 0
+      ? maxTurnsNumber
+      : undefined;
+  if (maxTurnsRaw !== undefined && maxTurns === undefined) {
+    invalid.set("maxTurns", "expected a positive integer; field ignored");
+  }
+
+  const standardBackground = parseBoolean("background", parsed.frontmatter.background, invalid);
+  const cursorBackground =
+    params.sourceFormat === "cursor"
+      ? parseBoolean("is_background", parsed.frontmatter.is_background, invalid)
+      : undefined;
+  const standardReadOnly = parseBoolean("readOnly", parsed.frontmatter.readOnly, invalid);
+  const cursorReadOnly =
+    params.sourceFormat === "cursor"
+      ? parseBoolean("readonly", parsed.frontmatter.readonly, invalid)
+      : undefined;
+  const background = cursorBackground ?? standardBackground;
+  const readOnly = cursorReadOnly ?? standardReadOnly;
+  const tools = parseListField({
+    field: "tools",
+    value: parsed.frontmatter.tools,
+    structured: structuredFields.has("tools"),
+    unsupported: invalid,
+  });
+  const disallowedTools = parseListField({
+    field: "disallowedTools",
+    value: parsed.frontmatter.disallowedTools,
+    structured: structuredFields.has("disallowedTools"),
+    unsupported: invalid,
+  });
+  const skills = parseListField({
+    field: "skills",
+    value: parsed.frontmatter.skills,
+    structured: structuredFields.has("skills"),
+    unsupported: invalid,
+  });
+  const unsupportedFields = buildUnsupportedFields({
+    frontmatter: parsed.frontmatter,
+    sourceFormat: params.sourceFormat,
+    invalid,
+  });
+  return {
+    id: name,
+    pluginId: params.pluginId,
+    sourceFormat: params.sourceFormat,
+    name,
+    description,
+    prompt: {
+      kind: "file",
+      path: params.relativePath,
+      contentDigest: sha256Hex(body),
+    },
+    sourceFilePath: params.relativePath,
+    ...(model ? { model } : {}),
+    ...(effort ? { effort } : {}),
+    ...(maxTurns !== undefined ? { maxTurns } : {}),
+    ...(tools !== undefined ? { tools } : {}),
+    ...(disallowedTools !== undefined ? { disallowedTools } : {}),
+    ...(skills !== undefined ? { skills } : {}),
+    ...(memory ? { memory } : {}),
+    ...(background !== undefined ? { background } : {}),
+    ...(isolation ? { isolation } : {}),
+    ...(readOnly !== undefined ? { readOnly } : {}),
+    ...(unsupportedFields ? { unsupportedFields } : {}),
+  };
+}
+
+/** Loads bounded metadata records only; prompt bodies never leave this control-plane function. */
+export function loadBundleAgentTemplates(params: {
+  rootDir: string;
+  agentRoots: readonly string[];
+  sourceFormat: PluginBundleFormat;
+  pluginId: string;
+  rejectHardlinks: boolean;
+}): BundleAgentTemplateLoadResult {
+  const rootDir = path.resolve(params.rootDir);
+  const rootRealPath = safeRealpathSync(rootDir);
+  const diagnostics: PluginDiagnostic[] = [];
+  if (!rootRealPath) {
+    addDiagnostic({
+      diagnostics,
+      pluginId: params.pluginId,
+      source: rootDir,
+      message: "bundle agent metadata plugin root could not be inspected",
+    });
+    return { agentTemplates: [], conflictingIds: [], diagnostics };
+  }
+
+  const templates: BundleAgentTemplate[] = [];
+  let totalBytes = 0;
+  for (const relativePath of listAgentFiles({
+    rootDir,
+    rootRealPath,
+    agentRoots: params.agentRoots,
+    pluginId: params.pluginId,
+    diagnostics,
+  })) {
+    const file = readAgentFile({
+      rootDir,
+      rootRealPath,
+      relativePath,
+      rejectHardlinks: params.rejectHardlinks,
+    });
+    if (!file) {
+      addDiagnostic({
+        diagnostics,
+        pluginId: params.pluginId,
+        source: relativePath,
+        message: "bundle agent metadata file exceeds the size limit or is unsafe; entry ignored",
+      });
+      continue;
+    }
+    totalBytes += file.size;
+    if (totalBytes > MAX_AGENT_TOTAL_BYTES) {
+      addDiagnostic({
+        diagnostics,
+        pluginId: params.pluginId,
+        source: relativePath,
+        message: "bundle agent metadata aggregate size limit reached; remaining files ignored",
+      });
+      break;
+    }
+    const template = parseAgentTemplate({
+      raw: file.raw,
+      relativePath,
+      sourceFormat: params.sourceFormat,
+      pluginId: params.pluginId,
+      diagnostics,
+    });
+    if (template) {
+      templates.push(template);
+    }
+  }
+
+  const conflicts = filterConflictingBundleAgentTemplates(templates);
+  for (const id of conflicts.conflictingIds) {
+    addDiagnostic({
+      diagnostics,
+      pluginId: params.pluginId,
+      source: rootDir,
+      message: `agent-template "${id}" has conflicting compatible definitions; entries ignored`,
+    });
+  }
+  return {
+    agentTemplates: conflicts.agentTemplates,
+    conflictingIds: conflicts.conflictingIds,
+    diagnostics,
+  };
+}

--- a/src/plugins/bundle-agent-manifest.ts
+++ b/src/plugins/bundle-agent-manifest.ts
@@ -1,8 +1,9 @@
 /** Parses compatible-bundle agent files into cold, non-executable metadata. */
 import fs from "node:fs";
 import path from "node:path";
+import { asPositiveSafeInteger } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import JSON5 from "json5";
+import { normalizeSortedUniqueTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
 import {
   parseFrontmatterBlockResult,
   stripFrontmatterBlock,
@@ -46,7 +47,6 @@ const CURSOR_FIELDS = new Set(["is_background", "readonly"]);
 
 type BundleAgentTemplateLoadResult = {
   agentTemplates: BundleAgentTemplate[];
-  conflictingIds: string[];
   diagnostics: PluginDiagnostic[];
 };
 
@@ -101,8 +101,8 @@ function listAgentFiles(params: {
   pluginId: string;
   diagnostics: PluginDiagnostic[];
 }): BundleAgentFile[] {
-  const uniqueRoots = [...new Set(params.agentRoots.map((entry) => entry.trim()).filter(Boolean))];
-  const roots = uniqueRoots.toSorted().slice(0, MAX_AGENT_ROOTS);
+  const uniqueRoots = normalizeSortedUniqueTrimmedStringList(params.agentRoots);
+  const roots = uniqueRoots.slice(0, MAX_AGENT_ROOTS);
   if (uniqueRoots.length > MAX_AGENT_ROOTS) {
     addDiagnostic({
       ...params,
@@ -272,7 +272,7 @@ function parseListField(params: {
   let input: unknown = params.value;
   if (params.structured) {
     try {
-      input = JSON5.parse(params.value);
+      input = JSON.parse(params.value);
     } catch {
       params.unsupported.set(params.field, "expected a list of strings; field ignored");
       return undefined;
@@ -418,11 +418,8 @@ function parseAgentTemplate(params: {
     structuredFields.has("maxTurns"),
     invalid,
   );
-  const maxTurnsNumber = maxTurnsRaw === undefined ? undefined : Number(maxTurnsRaw);
   const maxTurns =
-    maxTurnsNumber !== undefined && Number.isSafeInteger(maxTurnsNumber) && maxTurnsNumber > 0
-      ? maxTurnsNumber
-      : undefined;
+    maxTurnsRaw === undefined ? undefined : asPositiveSafeInteger(Number(maxTurnsRaw));
   if (maxTurnsRaw !== undefined && maxTurns === undefined) {
     invalid.set("maxTurns", "expected a positive integer; field ignored");
   }
@@ -509,7 +506,7 @@ export function loadBundleAgentTemplates(params: {
       source: rootDir,
       message: "bundle agent metadata plugin root could not be inspected",
     });
-    return { agentTemplates: [], conflictingIds: [], diagnostics };
+    return { agentTemplates: [], diagnostics };
   }
 
   const templates: BundleAgentTemplate[] = [];
@@ -559,18 +556,8 @@ export function loadBundleAgentTemplates(params: {
     }
   }
 
-  const conflicts = filterConflictingBundleAgentTemplates(templates);
-  for (const id of conflicts.conflictingIds) {
-    addDiagnostic({
-      diagnostics,
-      pluginId: params.pluginId,
-      source: rootDir,
-      message: `agent-template "${id}" has conflicting compatible definitions; entries ignored`,
-    });
-  }
   return {
-    agentTemplates: conflicts.agentTemplates,
-    conflictingIds: conflicts.conflictingIds,
+    agentTemplates: templates,
     diagnostics,
   };
 }

--- a/src/plugins/bundle-agent-manifest.ts
+++ b/src/plugins/bundle-agent-manifest.ts
@@ -15,7 +15,6 @@ import { parseBooleanValue } from "../utils/boolean.js";
 import type {
   BundleAgentTemplate,
   BundleAgentUnsupportedField,
-  PluginBundleFormat,
   PluginDiagnostic,
 } from "./manifest-types.js";
 import { isPathInside, safeRealpathSync } from "./path-safety.js";
@@ -51,6 +50,11 @@ type BundleAgentTemplateLoadResult = {
   diagnostics: PluginDiagnostic[];
 };
 
+type BundleAgentFile = {
+  relativePath: string;
+  identityPath: string;
+};
+
 /** Drops every definition involved in an id collision instead of choosing implicitly. */
 export function filterConflictingBundleAgentTemplates(templates: readonly BundleAgentTemplate[]): {
   agentTemplates: BundleAgentTemplate[];
@@ -82,6 +86,7 @@ function addDiagnostic(params: {
   message: string;
 }): void {
   params.diagnostics.push({
+    code: "bundle-agent-metadata",
     level: "warn",
     pluginId: params.pluginId,
     source: params.source,
@@ -95,7 +100,7 @@ function listAgentFiles(params: {
   agentRoots: readonly string[];
   pluginId: string;
   diagnostics: PluginDiagnostic[];
-}): string[] {
+}): BundleAgentFile[] {
   const uniqueRoots = [...new Set(params.agentRoots.map((entry) => entry.trim()).filter(Boolean))];
   const roots = uniqueRoots.toSorted().slice(0, MAX_AGENT_ROOTS);
   if (uniqueRoots.length > MAX_AGENT_ROOTS) {
@@ -106,7 +111,7 @@ function listAgentFiles(params: {
     });
   }
 
-  const files = new Set<string>();
+  const files = new Map<string, BundleAgentFile>();
   const scannedRoots: string[] = [];
   let remainingEntries = MAX_AGENT_SCAN_ENTRIES;
   for (const declaredRoot of roots) {
@@ -155,7 +160,11 @@ function listAgentFiles(params: {
     }
     if (stat.isFile()) {
       if (absoluteRoot.toLowerCase().endsWith(".md")) {
-        files.add(normalizeRelativePath(path.relative(params.rootDir, absoluteRoot)));
+        const relativePath = normalizeRelativePath(path.relative(params.rootDir, absoluteRoot));
+        files.set(relativePath, {
+          relativePath,
+          identityPath: path.basename(relativePath),
+        });
       }
       continue;
     }
@@ -178,7 +187,13 @@ function listAgentFiles(params: {
       include: (entry) => entry.kind === "file" && entry.name.toLowerCase().endsWith(".md"),
     });
     for (const entry of scan.entries) {
-      files.add(normalizeRelativePath(path.relative(params.rootDir, entry.path)));
+      const relativePath = normalizeRelativePath(path.relative(params.rootDir, entry.path));
+      if (!files.has(relativePath)) {
+        files.set(relativePath, {
+          relativePath,
+          identityPath: normalizeRelativePath(path.relative(absoluteRoot, entry.path)),
+        });
+      }
     }
     remainingEntries -= scan.scannedEntryCount;
     if (scan.truncated) {
@@ -198,7 +213,9 @@ function listAgentFiles(params: {
     }
   }
 
-  const ordered = [...files].toSorted();
+  const ordered = [...files.values()].toSorted((left, right) =>
+    left.relativePath.localeCompare(right.relativePath),
+  );
   if (ordered.length > MAX_AGENT_FILES) {
     addDiagnostic({
       ...params,
@@ -301,7 +318,7 @@ function parseBoolean(
 
 function buildUnsupportedFields(params: {
   frontmatter: Record<string, string>;
-  sourceFormat: PluginBundleFormat;
+  sourceFormat: BundleAgentTemplate["sourceFormat"];
   invalid: ReadonlyMap<string, string>;
 }): BundleAgentUnsupportedField[] | undefined {
   const unsupported = Object.keys(params.frontmatter)
@@ -321,7 +338,8 @@ function buildUnsupportedFields(params: {
 function parseAgentTemplate(params: {
   raw: string;
   relativePath: string;
-  sourceFormat: PluginBundleFormat;
+  identityPath: string;
+  sourceFormat: BundleAgentTemplate["sourceFormat"];
   pluginId: string;
   diagnostics: PluginDiagnostic[];
 }): BundleAgentTemplate | undefined {
@@ -445,7 +463,10 @@ function parseAgentTemplate(params: {
     invalid,
   });
   return {
-    id: name,
+    id: [
+      params.pluginId,
+      ...params.identityPath.replace(/\.md$/iu, "").split("/").filter(Boolean),
+    ].join(":"),
     pluginId: params.pluginId,
     sourceFormat: params.sourceFormat,
     name,
@@ -474,7 +495,7 @@ function parseAgentTemplate(params: {
 export function loadBundleAgentTemplates(params: {
   rootDir: string;
   agentRoots: readonly string[];
-  sourceFormat: PluginBundleFormat;
+  sourceFormat: BundleAgentTemplate["sourceFormat"];
   pluginId: string;
   rejectHardlinks: boolean;
 }): BundleAgentTemplateLoadResult {
@@ -493,7 +514,7 @@ export function loadBundleAgentTemplates(params: {
 
   const templates: BundleAgentTemplate[] = [];
   let totalBytes = 0;
-  for (const relativePath of listAgentFiles({
+  for (const agentFile of listAgentFiles({
     rootDir,
     rootRealPath,
     agentRoots: params.agentRoots,
@@ -503,14 +524,14 @@ export function loadBundleAgentTemplates(params: {
     const file = readAgentFile({
       rootDir,
       rootRealPath,
-      relativePath,
+      relativePath: agentFile.relativePath,
       rejectHardlinks: params.rejectHardlinks,
     });
     if (!file) {
       addDiagnostic({
         diagnostics,
         pluginId: params.pluginId,
-        source: relativePath,
+        source: agentFile.relativePath,
         message: "bundle agent metadata file exceeds the size limit or is unsafe; entry ignored",
       });
       continue;
@@ -520,14 +541,15 @@ export function loadBundleAgentTemplates(params: {
       addDiagnostic({
         diagnostics,
         pluginId: params.pluginId,
-        source: relativePath,
+        source: agentFile.relativePath,
         message: "bundle agent metadata aggregate size limit reached; remaining files ignored",
       });
       break;
     }
     const template = parseAgentTemplate({
       raw: file.raw,
-      relativePath,
+      relativePath: agentFile.relativePath,
+      identityPath: agentFile.identityPath,
       sourceFormat: params.sourceFormat,
       pluginId: params.pluginId,
       diagnostics,

--- a/src/plugins/bundle-claude-inspect.test.ts
+++ b/src/plugins/bundle-claude-inspect.test.ts
@@ -93,7 +93,11 @@ describe("Claude bundle plugin inspect integration", () => {
   }
 
   function expectLoadedClaudeManifest() {
-    const result = loadBundleManifest({ rootDir, bundleFormat: "claude" });
+    const result = loadBundleManifest({
+      rootDir,
+      bundleFormat: "claude",
+      loadAgentTemplates: true,
+    });
     expect(result.ok).toBe(true);
     if (!result.ok) {
       throw new Error("expected Claude bundle manifest to load");

--- a/src/plugins/bundle-manifest.ts
+++ b/src/plugins/bundle-manifest.ts
@@ -419,10 +419,12 @@ function loadCompatibleAgentTemplates(params: {
         ? CURSOR_BUNDLE_MANIFEST_RELATIVE_PATH
         : CLAUDE_BUNDLE_MANIFEST_RELATIVE_PATH;
     const defaultAgentRoot = format === "cursor" ? ".cursor/agents" : "agents";
+    const hasManifest = pluginScanExistsSync(path.join(params.rootDir, manifestRelativePath));
+    const canInferDefaultRoot = !(params.preferredFormat === "cursor" && format === "claude");
     const hasContribution =
       params.preferredFormat === format ||
-      pluginScanExistsSync(path.join(params.rootDir, manifestRelativePath)) ||
-      pluginScanExistsSync(path.join(params.rootDir, defaultAgentRoot));
+      hasManifest ||
+      (canInferDefaultRoot && pluginScanExistsSync(path.join(params.rootDir, defaultAgentRoot)));
     if (!hasContribution) {
       continue;
     }
@@ -567,6 +569,7 @@ export function loadBundleManifest(params: {
         capabilities: buildAgentCapabilities(params.rootDir),
       },
       manifestPath: loaded.manifestPath,
+      diagnostics: [],
     };
   }
 

--- a/src/plugins/bundle-manifest.ts
+++ b/src/plugins/bundle-manifest.ts
@@ -453,7 +453,6 @@ function loadCompatibleAgentTemplates(params: {
     contributions.push({ format, raw: loaded.raw });
   }
 
-  const contributionConflictingIds = new Set<string>();
   const agentTemplates = contributions.flatMap(({ format, raw }) => {
     const loaded = loadBundleAgentTemplates({
       rootDir: params.rootDir,
@@ -466,9 +465,6 @@ function loadCompatibleAgentTemplates(params: {
       rejectHardlinks: params.rejectHardlinks,
     });
     diagnostics.push(...loaded.diagnostics);
-    for (const id of loaded.conflictingIds) {
-      contributionConflictingIds.add(id);
-    }
     return loaded.agentTemplates;
   });
   const conflicts = filterConflictingBundleAgentTemplates(agentTemplates);
@@ -481,9 +477,7 @@ function loadCompatibleAgentTemplates(params: {
     });
   }
   return {
-    agentTemplates: conflicts.agentTemplates.filter(
-      (entry) => !contributionConflictingIds.has(entry.id),
-    ),
+    agentTemplates: conflicts.agentTemplates,
     diagnostics,
   };
 }
@@ -528,7 +522,7 @@ export function loadBundleManifest(params: {
   const version = normalizeOptionalString(raw.version);
   const id = slugifyPluginId(name, params.rootDir);
   const agents =
-    params.bundleFormat === "agent" || params.loadAgentTemplates === false
+    params.bundleFormat === "agent" || params.loadAgentTemplates !== true
       ? { agentTemplates: [], diagnostics: [] }
       : loadCompatibleAgentTemplates({
           rootDir: params.rootDir,

--- a/src/plugins/bundle-manifest.ts
+++ b/src/plugins/bundle-manifest.ts
@@ -11,7 +11,15 @@ import { matchRootFileOpenFailure } from "../infra/boundary-file-read.js";
 import { readRootStructuredFileSync } from "../infra/json-files.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { isRecord } from "../utils.js";
-import type { PluginBundleFormat } from "./manifest-types.js";
+import {
+  filterConflictingBundleAgentTemplates,
+  loadBundleAgentTemplates,
+} from "./bundle-agent-manifest.js";
+import type {
+  BundleAgentTemplate,
+  PluginBundleFormat,
+  PluginDiagnostic,
+} from "./manifest-types.js";
 import type { PluginManifestActivation } from "./manifest.js";
 import {
   DEFAULT_PLUGIN_ENTRY_CANDIDATES,
@@ -31,7 +39,7 @@ const MAX_AGENT_BUNDLE_MANIFEST_BYTES = 256 * 1024;
 const log = createSubsystemLogger("plugins/bundle-manifest");
 
 /** Normalized bundle manifest shape consumed by plugin discovery. */
-type BundlePluginManifest = {
+export type BundlePluginManifest = {
   id: string;
   name?: string;
   description?: string;
@@ -43,10 +51,16 @@ type BundlePluginManifest = {
   bundleFormat: PluginBundleFormat;
   activation?: PluginManifestActivation;
   capabilities: string[];
+  agentTemplates?: BundleAgentTemplate[];
 };
 
 type BundleManifestLoadResult =
-  | { ok: true; manifest: BundlePluginManifest; manifestPath: string }
+  | {
+      ok: true;
+      manifest: BundlePluginManifest;
+      manifestPath: string;
+      diagnostics: PluginDiagnostic[];
+    }
   | { ok: false; error: string; manifestPath: string };
 
 type BundleManifestFileLoadResult =
@@ -386,11 +400,99 @@ function resolveAgentActivation(
   return normalizeManifestActivation(openclawExtension.activation);
 }
 
+function loadCompatibleAgentTemplates(params: {
+  rootDir: string;
+  rootRealPath?: string;
+  preferredFormat: PluginBundleFormat;
+  preferredRaw: Record<string, unknown>;
+  pluginId: string;
+  rejectHardlinks: boolean;
+}): { agentTemplates: BundleAgentTemplate[]; diagnostics: PluginDiagnostic[] } {
+  const diagnostics: PluginDiagnostic[] = [];
+  const contributions: Array<{
+    format: "claude" | "cursor";
+    raw: Record<string, unknown>;
+  }> = [];
+  for (const format of ["cursor", "claude"] as const) {
+    const manifestRelativePath =
+      format === "cursor"
+        ? CURSOR_BUNDLE_MANIFEST_RELATIVE_PATH
+        : CLAUDE_BUNDLE_MANIFEST_RELATIVE_PATH;
+    const defaultAgentRoot = format === "cursor" ? ".cursor/agents" : "agents";
+    const hasContribution =
+      params.preferredFormat === format ||
+      pluginScanExistsSync(path.join(params.rootDir, manifestRelativePath)) ||
+      pluginScanExistsSync(path.join(params.rootDir, defaultAgentRoot));
+    if (!hasContribution) {
+      continue;
+    }
+    if (params.preferredFormat === format) {
+      contributions.push({ format, raw: params.preferredRaw });
+      continue;
+    }
+    const loaded = loadBundleManifestFile({
+      rootDir: params.rootDir,
+      ...(params.rootRealPath !== undefined ? { rootRealPath: params.rootRealPath } : {}),
+      manifestRelativePath,
+      rejectHardlinks: params.rejectHardlinks,
+      allowMissing: true,
+    });
+    if (!loaded.ok) {
+      diagnostics.push({
+        level: "warn",
+        pluginId: params.pluginId,
+        source: loaded.manifestPath,
+        message: loaded.error,
+      });
+      // A malformed optional manifest must not hide a valid default agents directory.
+      contributions.push({ format, raw: {} });
+      continue;
+    }
+    contributions.push({ format, raw: loaded.raw });
+  }
+
+  const contributionConflictingIds = new Set<string>();
+  const agentTemplates = contributions.flatMap(({ format, raw }) => {
+    const loaded = loadBundleAgentTemplates({
+      rootDir: params.rootDir,
+      agentRoots:
+        format === "cursor"
+          ? resolveCursorAgentDirs(raw, params.rootDir)
+          : resolveClaudeAgentDirs(raw, params.rootDir),
+      sourceFormat: format,
+      pluginId: params.pluginId,
+      rejectHardlinks: params.rejectHardlinks,
+    });
+    diagnostics.push(...loaded.diagnostics);
+    for (const id of loaded.conflictingIds) {
+      contributionConflictingIds.add(id);
+    }
+    return loaded.agentTemplates;
+  });
+  const conflicts = filterConflictingBundleAgentTemplates(agentTemplates);
+  for (const id of conflicts.conflictingIds) {
+    diagnostics.push({
+      level: "warn",
+      pluginId: params.pluginId,
+      source: params.rootDir,
+      message: `agent-template "${id}" has conflicting compatible definitions; entries ignored`,
+    });
+  }
+  return {
+    agentTemplates: conflicts.agentTemplates.filter(
+      (entry) => !contributionConflictingIds.has(entry.id),
+    ),
+    diagnostics,
+  };
+}
+
 export function loadBundleManifest(params: {
   rootDir: string;
   rootRealPath?: string;
   bundleFormat: PluginBundleFormat;
   rejectHardlinks?: boolean;
+  /** Discovery only needs the bundle id; registry loading owns the metadata scan. */
+  loadAgentTemplates?: boolean;
 }): BundleManifestLoadResult {
   const rejectHardlinks = params.rejectHardlinks ?? true;
   const manifestRelativePath =
@@ -422,6 +524,18 @@ export function loadBundleManifest(params: {
     normalizeOptionalString(raw.shortDescription) ??
     normalizeOptionalString(interfaceRecord?.shortDescription);
   const version = normalizeOptionalString(raw.version);
+  const id = slugifyPluginId(name, params.rootDir);
+  const agents =
+    params.bundleFormat === "agent" || params.loadAgentTemplates === false
+      ? { agentTemplates: [], diagnostics: [] }
+      : loadCompatibleAgentTemplates({
+          rootDir: params.rootDir,
+          ...(params.rootRealPath !== undefined ? { rootRealPath: params.rootRealPath } : {}),
+          preferredFormat: params.bundleFormat,
+          preferredRaw: raw,
+          pluginId: id,
+          rejectHardlinks,
+        });
 
   if (params.bundleFormat === "agent") {
     if (raw.$schema !== AGENT_BUNDLE_MANIFEST_SCHEMA) {
@@ -462,7 +576,7 @@ export function loadBundleManifest(params: {
     return {
       ok: true,
       manifest: {
-        id: slugifyPluginId(name, params.rootDir),
+        id,
         name,
         description,
         version,
@@ -472,8 +586,10 @@ export function loadBundleManifest(params: {
         bundleFormat: "codex",
         activation: normalizeManifestActivation(raw.activation),
         capabilities: buildCodexCapabilities(raw, params.rootDir),
+        ...(agents.agentTemplates.length > 0 ? { agentTemplates: agents.agentTemplates } : {}),
       },
       manifestPath: loaded.manifestPath,
+      diagnostics: agents.diagnostics,
     };
   }
 
@@ -481,7 +597,7 @@ export function loadBundleManifest(params: {
     return {
       ok: true,
       manifest: {
-        id: slugifyPluginId(name, params.rootDir),
+        id,
         name,
         description,
         version,
@@ -491,15 +607,17 @@ export function loadBundleManifest(params: {
         bundleFormat: "cursor",
         activation: normalizeManifestActivation(raw.activation),
         capabilities: buildCursorCapabilities(raw, params.rootDir),
+        ...(agents.agentTemplates.length > 0 ? { agentTemplates: agents.agentTemplates } : {}),
       },
       manifestPath: loaded.manifestPath,
+      diagnostics: agents.diagnostics,
     };
   }
 
   return {
     ok: true,
     manifest: {
-      id: slugifyPluginId(name, params.rootDir),
+      id,
       name,
       description,
       version,
@@ -509,8 +627,10 @@ export function loadBundleManifest(params: {
       bundleFormat: "claude",
       activation: normalizeManifestActivation(raw.activation),
       capabilities: buildClaudeCapabilities(raw, params.rootDir),
+      ...(agents.agentTemplates.length > 0 ? { agentTemplates: agents.agentTemplates } : {}),
     },
     manifestPath: loaded.manifestPath,
+    diagnostics: agents.diagnostics,
   };
 }
 

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -839,7 +839,6 @@ function discoverBundleInRoot(params: {
       ...(rootRealPath !== undefined ? { rootRealPath } : {}),
       bundleFormat,
       rejectHardlinks,
-      loadAgentTemplates: false,
     });
     if (!bundleManifest.ok) {
       params.diagnostics.push({

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -839,6 +839,7 @@ function discoverBundleInRoot(params: {
       ...(rootRealPath !== undefined ? { rootRealPath } : {}),
       bundleFormat,
       rejectHardlinks,
+      loadAgentTemplates: false,
     });
     if (!bundleManifest.ok) {
       params.diagnostics.push({

--- a/src/plugins/installed-plugin-index-record-builder.ts
+++ b/src/plugins/installed-plugin-index-record-builder.ts
@@ -199,6 +199,7 @@ function hashManifestlessBundleRecord(record: PluginManifestRecord): string {
     format: record.format,
     bundleFormat: record.bundleFormat,
     bundleCapabilities: record.bundleCapabilities ?? [],
+    bundleAgentTemplates: record.bundleAgentTemplates ?? [],
     skills: record.skills ?? [],
     settingsFiles: record.settingsFiles ?? [],
     hooks: record.hooks ?? [],

--- a/src/plugins/installed-plugin-index.ts
+++ b/src/plugins/installed-plugin-index.ts
@@ -74,7 +74,11 @@ function buildInstalledPluginIndex(
     diagnostics: discovery.diagnostics,
     installRecords,
   });
-  const diagnostics = [...(registry.diagnostics ?? [])];
+  // Agent Markdown is rescanned when the manifest registry is materialized from
+  // the index. Persisting these diagnostics would make repaired files look stale.
+  const diagnostics = (registry.diagnostics ?? []).filter(
+    (diagnostic) => diagnostic.code !== "bundle-agent-metadata",
+  );
   const generatedAtMs = (params.now?.() ?? new Date()).getTime();
   const plugins = buildInstalledPluginIndexRecords({
     candidates: discovery.candidates,

--- a/src/plugins/installed-plugin-index.ts
+++ b/src/plugins/installed-plugin-index.ts
@@ -22,6 +22,7 @@ import {
   type RefreshInstalledPluginIndexParams,
 } from "./installed-plugin-index-types.js";
 import { loadPluginManifestRegistry, type PluginManifestRegistry } from "./manifest-registry.js";
+import { isTransientPluginDiagnostic } from "./manifest-types.js";
 
 export {
   INSTALLED_PLUGIN_INDEX_MIGRATION_VERSION,
@@ -77,7 +78,7 @@ function buildInstalledPluginIndex(
   // Agent Markdown is rescanned when the manifest registry is materialized from
   // the index. Persisting these diagnostics would make repaired files look stale.
   const diagnostics = (registry.diagnostics ?? []).filter(
-    (diagnostic) => diagnostic.code !== "bundle-agent-metadata",
+    (diagnostic) => !isTransientPluginDiagnostic(diagnostic),
   );
   const generatedAtMs = (params.now?.() ?? new Date()).getTime();
   const plugins = buildInstalledPluginIndexRecords({

--- a/src/plugins/loader-records.ts
+++ b/src/plugins/loader-records.ts
@@ -2,7 +2,12 @@
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { PluginCompatCode } from "./compat/registry.js";
 import type { PluginActivationState } from "./config-state.js";
-import type { PluginBundleFormat, PluginDiagnosticCode, PluginFormat } from "./manifest-types.js";
+import type {
+  BundleAgentTemplate,
+  PluginBundleFormat,
+  PluginDiagnosticCode,
+  PluginFormat,
+} from "./manifest-types.js";
 import type {
   PluginManifestContracts,
   PluginManifestDashboard,
@@ -28,6 +33,7 @@ export function createPluginRecord(params: {
   format?: PluginFormat;
   bundleFormat?: PluginBundleFormat;
   bundleCapabilities?: string[];
+  bundleAgentTemplates?: BundleAgentTemplate[];
   source: string;
   rootDir?: string;
   origin: PluginRecord["origin"];
@@ -55,6 +61,7 @@ export function createPluginRecord(params: {
     format: params.format ?? "openclaw",
     bundleFormat: params.bundleFormat,
     bundleCapabilities: params.bundleCapabilities,
+    bundleAgentTemplates: params.bundleAgentTemplates,
     source: params.source,
     rootDir: params.rootDir,
     origin: params.origin,

--- a/src/plugins/loader-shared.ts
+++ b/src/plugins/loader-shared.ts
@@ -295,6 +295,7 @@ export function createManifestPluginRecord(params: {
     format: manifestRecord.format,
     bundleFormat: manifestRecord.bundleFormat,
     bundleCapabilities: manifestRecord.bundleCapabilities,
+    bundleAgentTemplates: manifestRecord.bundleAgentTemplates,
     source: candidate.source,
     rootDir: candidate.rootDir,
     origin: candidate.origin,

--- a/src/plugins/loader.bundle.test.ts
+++ b/src/plugins/loader.bundle.test.ts
@@ -209,4 +209,94 @@ describe("bundle plugins", () => {
       ),
     ).toBe(false);
   });
+
+  it.each([
+    {
+      pluginId: "claude-agent-pack",
+      bundleFormat: "claude" as const,
+      manifestDir: ".claude-plugin",
+      agentPath: "agents/reviewer.md",
+      name: "reviewer",
+      description: "Reviews changes for correctness",
+    },
+    {
+      pluginId: "cursor-agent-pack",
+      bundleFormat: "cursor" as const,
+      manifestDir: ".cursor-plugin",
+      agentPath: ".cursor/agents/explorer.md",
+      name: "explorer",
+      description: "Maps an unfamiliar repository",
+    },
+  ])("preserves $bundleFormat bundle agents as metadata", (fixture) => {
+    const registry = loadBundleFixture({
+      pluginId: fixture.pluginId,
+      build: (bundleRoot) => {
+        mkdirSafe(path.join(bundleRoot, fixture.manifestDir));
+        fs.writeFileSync(
+          path.join(bundleRoot, fixture.manifestDir, "plugin.json"),
+          JSON.stringify({ name: fixture.pluginId }),
+          "utf8",
+        );
+        mkdirSafe(path.dirname(path.join(bundleRoot, fixture.agentPath)));
+        fs.writeFileSync(
+          path.join(bundleRoot, fixture.agentPath),
+          [
+            "---",
+            `name: ${fixture.name}`,
+            `description: ${fixture.description}`,
+            "model: inherit",
+            "---",
+            "Template prompt body.",
+          ].join("\n"),
+          "utf8",
+        );
+      },
+    });
+
+    const plugin = registry.plugins.find((entry) => entry.id === fixture.pluginId);
+    expect(plugin).toMatchObject({
+      bundleFormat: fixture.bundleFormat,
+      bundleAgentTemplates: [
+        {
+          id: fixture.name,
+          pluginId: fixture.pluginId,
+          sourceFormat: fixture.bundleFormat,
+          name: fixture.name,
+          description: fixture.description,
+          prompt: {
+            kind: "file",
+            path: fixture.agentPath,
+            contentDigest: expect.stringMatching(/^[a-f0-9]{64}$/u),
+          },
+          sourceFilePath: fixture.agentPath,
+          model: "inherit",
+        },
+      ],
+    });
+  });
+
+  it("keeps loading a bundle when an agent definition is malformed", () => {
+    const registry = loadBundleFixture({
+      pluginId: "malformed-agent-pack",
+      build: (bundleRoot) => {
+        mkdirSafe(path.join(bundleRoot, "agents"));
+        fs.writeFileSync(
+          path.join(bundleRoot, "agents", "broken.md"),
+          ["---", "name: broken", "description: [unterminated", "Prompt body."].join("\n"),
+          "utf8",
+        );
+      },
+    });
+
+    const plugin = registry.plugins.find((entry) => entry.id === "malformed-agent-pack");
+    expect(plugin?.status).toBe("loaded");
+    expect(plugin).toMatchObject({ bundleAgentTemplates: [] });
+    expect(registry.diagnostics).toContainEqual(
+      expect.objectContaining({
+        pluginId: "malformed-agent-pack",
+        level: "warn",
+        message: expect.stringContaining("invalid frontmatter"),
+      }),
+    );
+  });
 });

--- a/src/plugins/loader.bundle.test.ts
+++ b/src/plugins/loader.bundle.test.ts
@@ -258,7 +258,7 @@ describe("bundle plugins", () => {
       bundleFormat: fixture.bundleFormat,
       bundleAgentTemplates: [
         {
-          id: fixture.name,
+          id: `${fixture.pluginId}:${fixture.name}`,
           pluginId: fixture.pluginId,
           sourceFormat: fixture.bundleFormat,
           name: fixture.name,

--- a/src/plugins/manifest-registry-installed.test.ts
+++ b/src/plugins/manifest-registry-installed.test.ts
@@ -7,7 +7,7 @@ import {
   readPersistedInstalledPluginIndex,
   writePersistedInstalledPluginIndex,
 } from "./installed-plugin-index-store.js";
-import type { InstalledPluginIndex } from "./installed-plugin-index.js";
+import { loadInstalledPluginIndex, type InstalledPluginIndex } from "./installed-plugin-index.js";
 import {
   loadPluginManifestRegistryForInstalledIndex,
   resolveInstalledManifestRegistryIndexFingerprint,
@@ -785,5 +785,71 @@ describe("loadPluginManifestRegistryForInstalledIndex", () => {
     expect(registry.plugins[0]?.bundleFormat).toBe("claude");
     expect(registry.plugins[0]?.rootDir).toBe(rootDir);
     expect(registry.plugins[0]?.skills).toEqual(["commands"]);
+  });
+
+  it("rescans agent diagnostics instead of persisting stale file state", async () => {
+    const stateDir = makeTempDir();
+    const rootDir = makeTempDir();
+    fs.mkdirSync(path.join(rootDir, ".claude-plugin"), { recursive: true });
+    fs.mkdirSync(path.join(rootDir, "agents"), { recursive: true });
+    fs.writeFileSync(
+      path.join(rootDir, ".claude-plugin", "plugin.json"),
+      JSON.stringify({ name: "agent-pack" }),
+      "utf8",
+    );
+    const agentPath = path.join(rootDir, "agents", "reviewer.md");
+    fs.writeFileSync(
+      agentPath,
+      ["---", "name: reviewer", "description: [unterminated", "Prompt."].join("\n"),
+      "utf8",
+    );
+    const env = { OPENCLAW_VERSION: "2026.4.25", VITEST: "true" };
+    const index = loadInstalledPluginIndex({
+      candidates: [
+        {
+          idHint: "agent-pack",
+          source: rootDir,
+          rootDir,
+          origin: "global",
+          format: "bundle",
+          bundleFormat: "claude",
+        },
+      ],
+      env,
+    });
+
+    expect(index.diagnostics.map((diagnostic) => diagnostic.code)).not.toContain(
+      "bundle-agent-metadata",
+    );
+    await writePersistedInstalledPluginIndex(index, { stateDir });
+    const persisted = await readPersistedInstalledPluginIndex({ stateDir });
+    if (!persisted) {
+      throw new Error("expected persisted installed plugin index");
+    }
+    const malformed = loadPluginManifestRegistryForInstalledIndex({
+      index: persisted,
+      env,
+      includeDisabled: true,
+    });
+    expect(
+      malformed.diagnostics.filter((diagnostic) => diagnostic.code === "bundle-agent-metadata"),
+    ).toHaveLength(1);
+
+    fs.writeFileSync(
+      agentPath,
+      ["---", "name: reviewer", "description: Reviews changes", "---", "Review."].join("\n"),
+      "utf8",
+    );
+    clearPluginMetadataLifecycleCaches();
+    const repaired = loadPluginManifestRegistryForInstalledIndex({
+      index: persisted,
+      env,
+      includeDisabled: true,
+    });
+
+    expect(repaired.diagnostics).toStrictEqual([]);
+    expect(repaired.plugins[0]?.bundleAgentTemplates).toMatchObject([
+      { id: "agent-pack:reviewer", name: "reviewer" },
+    ]);
   });
 });

--- a/src/plugins/manifest-registry-installed.ts
+++ b/src/plugins/manifest-registry-installed.ts
@@ -21,6 +21,7 @@ import {
   type PluginManifestRegistry,
 } from "./manifest-registry.js";
 import type { BundledChannelConfigCollector } from "./manifest-registry.js";
+import { isTransientPluginDiagnostic } from "./manifest-types.js";
 import {
   DEFAULT_PLUGIN_ENTRY_CANDIDATES,
   getPackageManifestMetadata,
@@ -569,7 +570,9 @@ export function loadPluginManifestRegistryForInstalledIndex(params: {
           diagnostics: [
             ...diagnostics,
             ...params.manifestRegistry.diagnostics.filter(
-              (diagnostic) => diagnostic.code === "bundle-agent-metadata",
+              (diagnostic) =>
+                isTransientPluginDiagnostic(diagnostic) &&
+                (!pluginIdSet || !diagnostic.pluginId || pluginIdSet.has(diagnostic.pluginId)),
             ),
           ],
         };

--- a/src/plugins/manifest-registry-installed.ts
+++ b/src/plugins/manifest-registry-installed.ts
@@ -569,7 +569,7 @@ export function loadPluginManifestRegistryForInstalledIndex(params: {
             .map(normalizePreparedManifestRecord),
           diagnostics: [
             ...diagnostics,
-            ...params.manifestRegistry.diagnostics.filter(
+            ...(params.manifestRegistry.diagnostics ?? []).filter(
               (diagnostic) =>
                 isTransientPluginDiagnostic(diagnostic) &&
                 (!pluginIdSet || !diagnostic.pluginId || pluginIdSet.has(diagnostic.pluginId)),

--- a/src/plugins/manifest-registry-installed.ts
+++ b/src/plugins/manifest-registry-installed.ts
@@ -566,7 +566,12 @@ export function loadPluginManifestRegistryForInstalledIndex(params: {
             .filter((plugin) => enabledPluginIds.has(plugin.id))
             .filter((plugin) => !pluginIdSet || pluginIdSet.has(plugin.id))
             .map(normalizePreparedManifestRecord),
-          diagnostics: [...diagnostics],
+          diagnostics: [
+            ...diagnostics,
+            ...params.manifestRegistry.diagnostics.filter(
+              (diagnostic) => diagnostic.code === "bundle-agent-metadata",
+            ),
+          ],
         };
       }
       const candidates = params.index.plugins

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -1061,6 +1061,7 @@ export function loadPluginManifestRegistry(
               rootDir: candidate.rootDir,
               bundleFormat: candidate.bundleFormat,
               rejectHardlinks,
+              loadAgentTemplates: true,
             })
           : isManifestlessConfiguredFile
             ? {

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -13,7 +13,7 @@ import { satisfiesPluginApiRange } from "../infra/clawhub.js";
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveCompatibilityHostVersion } from "../version.js";
-import { loadBundleManifest } from "./bundle-manifest.js";
+import { loadBundleManifest, type BundlePluginManifest } from "./bundle-manifest.js";
 import { normalizePluginsConfigWithResolver } from "./config-policy.js";
 import { isBundledPluginInsideDevSourceRoot } from "./dev-source-root.js";
 import {
@@ -25,6 +25,7 @@ import { shouldRejectHardlinkedPluginFiles } from "./hardlink-policy.js";
 import { loadInstalledPluginIndexInstallRecordsSync } from "./installed-plugin-index-record-reader.js";
 import type { PluginManifestCommandAlias } from "./manifest-command-aliases.js";
 import type {
+  BundleAgentTemplate,
   PluginBundleFormat,
   PluginConfigUiHint,
   PluginDiagnostic,
@@ -227,6 +228,7 @@ export type PluginManifestRecord = {
   format?: PluginFormat;
   bundleFormat?: PluginBundleFormat;
   bundleCapabilities?: string[];
+  bundleAgentTemplates?: BundleAgentTemplate[];
   kind?: PluginKind | PluginKind[];
   channels: string[];
   providers: string[];
@@ -654,17 +656,7 @@ function buildRecord(params: {
 }
 
 function buildBundleRecord(params: {
-  manifest: {
-    id: string;
-    name?: string;
-    description?: string;
-    version?: string;
-    skills: string[];
-    settingsFiles?: string[];
-    hooks: string[];
-    capabilities: string[];
-    activation?: PluginManifestRecord["activation"];
-  };
+  manifest: BundlePluginManifest;
   candidate: PluginCandidate;
   manifestPath: string;
 }): PluginManifestRecord {
@@ -684,6 +676,7 @@ function buildBundleRecord(params: {
     format: "bundle",
     bundleFormat: params.candidate.bundleFormat,
     bundleCapabilities: params.manifest.capabilities,
+    bundleAgentTemplates: params.manifest.agentTemplates ?? [],
     activation: params.manifest.activation,
     channels: [],
     providers: [],
@@ -1090,6 +1083,9 @@ export function loadPluginManifestRegistry(
     }
     const manifest = manifestRes.manifest;
     const effectivePluginId = candidate.effectivePluginId ?? manifest.id;
+    if ("diagnostics" in manifestRes) {
+      diagnostics.push(...manifestRes.diagnostics);
+    }
     if (candidate.origin !== "bundled") {
       const packageManifestSource = path.join(
         candidate.packageDir ?? candidate.rootDir,

--- a/src/plugins/manifest-types.ts
+++ b/src/plugins/manifest-types.ts
@@ -23,7 +23,7 @@ export type PluginFormat = "openclaw" | "bundle";
 export type PluginBundleFormat = "agent" | "codex" | "claude" | "cursor";
 
 /** Prompt source metadata for a compatible-bundle agent. Prompt bytes are not persisted. */
-export type BundlePromptReference = {
+type BundlePromptReference = {
   kind: "file";
   path: string;
   contentDigest: string;

--- a/src/plugins/manifest-types.ts
+++ b/src/plugins/manifest-types.ts
@@ -76,6 +76,11 @@ export type PluginDiagnostic = {
   code?: PluginDiagnosticCode;
 };
 
+/** Diagnostics derived from mutable plugin payloads rather than the installed index itself. */
+export function isTransientPluginDiagnostic(diagnostic: PluginDiagnostic): boolean {
+  return diagnostic.code === "bundle-agent-metadata";
+}
+
 export type PluginManifestChannelConfig = {
   schema: JsonSchemaObject;
   uiHints?: Record<string, PluginConfigUiHint>;

--- a/src/plugins/manifest-types.ts
+++ b/src/plugins/manifest-types.ts
@@ -22,6 +22,41 @@ export type PluginFormat = "openclaw" | "bundle";
 /** Supported external bundle manifest formats. */
 export type PluginBundleFormat = "agent" | "codex" | "claude" | "cursor";
 
+/** Prompt source metadata for a compatible-bundle agent. Prompt bytes are not persisted. */
+export type BundlePromptReference = {
+  kind: "file";
+  path: string;
+  contentDigest: string;
+};
+
+/** Declared metadata that OpenClaw preserves but does not currently map to runtime policy. */
+export type BundleAgentUnsupportedField = {
+  field: string;
+  reason: string;
+};
+
+/** Normalized, metadata-only agent definition discovered in a compatible bundle. */
+export type BundleAgentTemplate = {
+  id: string;
+  pluginId: string;
+  sourceFormat: PluginBundleFormat;
+  name: string;
+  description: string;
+  prompt: BundlePromptReference;
+  sourceFilePath: string;
+  model?: string;
+  effort?: string;
+  maxTurns?: number;
+  tools?: string[];
+  disallowedTools?: string[];
+  skills?: string[];
+  memory?: string;
+  background?: boolean;
+  isolation?: string;
+  readOnly?: boolean;
+  unsupportedFields?: BundleAgentUnsupportedField[];
+};
+
 /**
  * Closed classification codes for plugin diagnostics. Health surfaces branch
  * on these instead of matching freeform diagnostic message text.

--- a/src/plugins/manifest-types.ts
+++ b/src/plugins/manifest-types.ts
@@ -39,7 +39,7 @@ export type BundleAgentUnsupportedField = {
 export type BundleAgentTemplate = {
   id: string;
   pluginId: string;
-  sourceFormat: PluginBundleFormat;
+  sourceFormat: "claude" | "cursor";
   name: string;
   description: string;
   prompt: BundlePromptReference;
@@ -62,6 +62,7 @@ export type BundleAgentTemplate = {
  * on these instead of matching freeform diagnostic message text.
  */
 export type PluginDiagnosticCode =
+  | "bundle-agent-metadata"
   | "channel-setup-failure"
   | "dashboard-declaration-invalid"
   | "plugin-verification";

--- a/src/plugins/registry-types.ts
+++ b/src/plugins/registry-types.ts
@@ -27,6 +27,7 @@ import type {
 } from "./host-hooks.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import type {
+  BundleAgentTemplate,
   PluginBundleFormat,
   PluginConfigUiHint,
   PluginDiagnostic,
@@ -456,6 +457,7 @@ export type PluginRecord = {
   format?: PluginFormat;
   bundleFormat?: PluginBundleFormat;
   bundleCapabilities?: string[];
+  bundleAgentTemplates?: BundleAgentTemplate[];
   kind?: PluginKind | PluginKind[];
   source: string;
   rootDir?: string;

--- a/src/plugins/status-snapshot.ts
+++ b/src/plugins/status-snapshot.ts
@@ -87,6 +87,12 @@ function buildPluginRecordFromInstalledIndex(
     ...(manifest?.description ? { description: manifest.description } : {}),
     format,
     ...(bundleFormat ? { bundleFormat } : {}),
+    ...(manifest?.bundleCapabilities
+      ? { bundleCapabilities: [...manifest.bundleCapabilities] }
+      : {}),
+    ...(manifest?.bundleAgentTemplates
+      ? { bundleAgentTemplates: structuredClone(manifest.bundleAgentTemplates) }
+      : {}),
     ...(manifest?.kind ? { kind: manifest.kind } : {}),
     source: plugin.source ?? plugin.manifestPath,
     rootDir: plugin.rootDir,

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -22,7 +22,7 @@ import {
 } from "./inspect-shape.js";
 import { extractPluginInstallRecordsFromInstalledPluginIndex } from "./installed-plugin-index-install-records.js";
 import { loadPluginRegistryHandle, resolveCompatibleRuntimePluginRegistry } from "./loader.js";
-import type { PluginDiagnostic } from "./manifest-types.js";
+import type { BundleAgentTemplate, PluginDiagnostic } from "./manifest-types.js";
 import { tracePluginLifecyclePhase } from "./plugin-lifecycle-trace.js";
 import {
   loadPluginMetadataSnapshot,
@@ -103,6 +103,8 @@ export type PluginInspectReport = {
   }>;
   httpRouteCount: number;
   bundleCapabilities: string[];
+  /** Metadata-only compatible-bundle templates. Prompt bodies are never included. */
+  bundleAgentTemplates: BundleAgentTemplate[];
   diagnostics: PluginDiagnostic[];
   policy: {
     allowPromptInjection?: boolean;
@@ -488,6 +490,7 @@ export function buildPluginInspectReport(params: {
     lspServers,
     httpRouteCount: plugin.httpRoutes,
     bundleCapabilities: plugin.bundleCapabilities ?? [],
+    bundleAgentTemplates: structuredClone(plugin.bundleAgentTemplates ?? []),
     diagnostics,
     policy: {
       allowPromptInjection: policyEntry?.hooks?.allowPromptInjection,

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -70,7 +70,7 @@ export type PluginCompatibilitySummary = {
 
 export type PluginInspectReport = {
   workspaceDir?: string;
-  plugin: PluginRegistry["plugins"][number];
+  plugin: Omit<PluginRegistry["plugins"][number], "bundleAgentTemplates">;
   shape: PluginInspectShape;
   capabilityMode: "none" | "plain" | "hybrid";
   capabilityCount: number;
@@ -471,9 +471,10 @@ export function buildPluginInspectReport(params: {
     diagnostics,
     hasRuntimeMemoryEmbeddingProviderRegistration,
   });
+  const { bundleAgentTemplates, ...inspectPlugin } = plugin;
   return {
     workspaceDir: report.workspaceDir,
-    plugin,
+    plugin: inspectPlugin,
     shape,
     capabilityMode: shapeSummary.capabilityMode,
     capabilityCount: shapeSummary.capabilityCount,
@@ -490,7 +491,7 @@ export function buildPluginInspectReport(params: {
     lspServers,
     httpRouteCount: plugin.httpRoutes,
     bundleCapabilities: plugin.bundleCapabilities ?? [],
-    bundleAgentTemplates: structuredClone(plugin.bundleAgentTemplates ?? []),
+    bundleAgentTemplates: structuredClone(bundleAgentTemplates ?? []),
     diagnostics,
     policy: {
       allowPromptInjection: policyEntry?.hooks?.allowPromptInjection,


### PR DESCRIPTION
Related: #119044

## What Problem This Solves

Compatible Claude and Cursor bundles can contain reusable agent definitions, but OpenClaw currently reduces that surface to a coarse `agents` capability flag. Operators cannot inspect which templates a bundle carries, what model or policy hints they request, or which fields OpenClaw would ignore before deciding whether the bundle should ever be activated.

## Why This Change Was Made

This adds a cold, normalized capability record for compatible-bundle agent definitions and carries it through the existing plugin registry and `plugins inspect` path. Parsing is deliberately metadata-only: prompt bodies are represented by a root-relative path and digest, directory and file reads are bounded and confined to the bundle root, conflicting identities are dropped, malformed definitions degrade to diagnostics, and terminal output sanitizes bundle-controlled text.

This PR does not instantiate subagents, inject external prompts into active agents, grant tools or skills, select models, or change any runtime trust boundary. It is the inspection foundation for the opt-in activation work described in #119044.

## User Impact

Operators can run `openclaw plugins inspect <id>` to see a clear metadata-only summary of bundled agent templates, or add `--json` to review their complete normalized records. Claude `agents/` and Cursor `.cursor/agents/` definitions now remain visible for future policy review without becoming executable.

Existing bundle skills, commands, MCP, hooks, settings, and LSP behavior is unchanged. Invalid or ambiguous agent definitions do not stop the rest of a bundle from loading.

## Evidence

Built this branch, installed two local fixtures through the stock `plugins install` path, and inspected the installed records from an isolated state directory. The output below is reduced to the relevant fields; no source paths or credentials are included.

Claude `agents/reviewer.md`:

```json
{
  "id": "review-proof",
  "format": "bundle",
  "bundleFormat": "claude",
  "bundleCapabilities": ["skills", "agents"],
  "bundleAgentTemplates": [{
    "id": "review-proof:reviewer",
    "pluginId": "review-proof",
    "sourceFormat": "claude",
    "name": "reviewer",
    "description": "Reviews changes for correctness",
    "prompt": {"kind": "file", "path": "agents/reviewer.md", "contentDigest": "74b9a979408dfa9b8bfad165c3720408d2575a3049bf9d86d38c55636a45452c"},
    "sourceFilePath": "agents/reviewer.md",
    "model": "sonnet",
    "effort": "high",
    "maxTurns": 8,
    "tools": ["Read", "Grep"]
  }],
  "diagnostics": []
}
```

Cursor `.cursor/agents/explorer.md`:

```json
{
  "id": "explore-proof",
  "format": "bundle",
  "bundleFormat": "cursor",
  "bundleCapabilities": ["agents"],
  "bundleAgentTemplates": [{
    "id": "explore-proof:explorer",
    "pluginId": "explore-proof",
    "sourceFormat": "cursor",
    "name": "explorer",
    "description": "Maps an unfamiliar repository",
    "prompt": {"kind": "file", "path": ".cursor/agents/explorer.md", "contentDigest": "8885f0adcb01b76990b9f8305d435d08c711b302e7fa8660a5475bbb1ff01115"},
    "sourceFilePath": ".cursor/agents/explorer.md",
    "model": "inherit",
    "tools": ["Read"]
  }],
  "diagnostics": []
}
```

## Validation

- Rebased cleanly onto `openclaw/main` at `2d5ff4768cd`.
- Focused parser, loader, registry, CLI, command, frontmatter, and prepared-registry regression suite: 9 files / 152 tests passed.
- Production dependency audit passed with no high-or-higher advisories.
- `pnpm tsgo:core` passed.
- Runtime import-cycle check passed with 0 cycles.
- Focused `oxfmt` and `oxlint` passed for all 23 changed files.
- `pnpm build` passed, including plugin SDK export guards, CLI bootstrap imports, and Control UI performance checks.

The change was developed with AI assistance. I reviewed the implementation, validated the reported findings against the surrounding code and source-format contracts, and understand the submitted behavior and boundaries.

## Post-Deploy Monitoring & Validation

This change has no execution path or new persistent state. After release, validate `plugins inspect` against representative Claude, Cursor, and mixed-format bundles; unexpected registry startup latency, new bundle-agent diagnostics, or missing template records are the relevant failure signals. Reverting this PR fully removes the metadata surface without migrating user state.
