### PR TITLE
fix(lmstudio): expose read-only reachability probe for guided setup

### DIFF
--- a/extensions/lmstudio/api.ts
+++ b/extensions/lmstudio/api.ts
@@ -3,6 +3,7 @@ export {
   buildLmstudioAuthHeaders,
   buildLmstudioModelName,
   configureLmstudioNonInteractive,
+  detectAppGuidedLmstudioAvailability,
   discoverLmstudioProvider,
   LMSTUDIO_DEFAULT_API_KEY_ENV_VAR,
   LMSTUDIO_DEFAULT_BASE_URL,

--- a/extensions/lmstudio/index.test.ts
+++ b/extensions/lmstudio/index.test.ts
@@ -36,6 +36,16 @@ function requireLmstudioResetValidator(): NonNullable<
   return validator;
 }
 
+function requireAppGuidedDetectAvailability(): NonNullable<
+  NonNullable<ProviderAuthMethod["appGuidedSetup"]>["detectAvailability"]
+> {
+  const method = registerProvider().auth[0];
+  if (!method?.appGuidedSetup?.detectAvailability) {
+    throw new Error("expected the LM Studio provider to register detectAvailability");
+  }
+  return method.appGuidedSetup.detectAvailability;
+}
+
 function createLmstudioResetValidationContext(
   opts: Record<string, unknown> = {},
   resolvedApiKey: { key: string; source: "flag" | "env" | "profile" } | null = null,
@@ -112,6 +122,68 @@ describe("lmstudio plugin", () => {
       timeoutMs: 5000,
     });
     expect(ctx.runtime.exit).not.toHaveBeenCalled();
+  });
+
+  it("detects a reachable LM Studio service without requiring a loaded model", async () => {
+    const detectAvailability = requireAppGuidedDetectAvailability();
+    fetchLmstudioModelsMock.mockResolvedValue({ reachable: true, status: 200, models: [] });
+
+    await expect(detectAvailability({ config: {}, env: {} })).resolves.toBe(true);
+    expect(fetchLmstudioModelsMock).toHaveBeenCalledWith({
+      baseUrl: "http://localhost:1234/v1",
+      apiKey: LMSTUDIO_LOCAL_API_KEY_PLACEHOLDER,
+      timeoutMs: 5000,
+    });
+  });
+
+  it("does not mark an unreachable LM Studio service as available", async () => {
+    const detectAvailability = requireAppGuidedDetectAvailability();
+    fetchLmstudioModelsMock.mockResolvedValue({ reachable: false, models: [] });
+
+    await expect(detectAvailability({ config: {}, env: {} })).resolves.toBe(false);
+  });
+
+  it("uses the Docker host default for availability detection during Docker setup", async () => {
+    const detectAvailability = requireAppGuidedDetectAvailability();
+    fetchLmstudioModelsMock.mockResolvedValue({ reachable: true, status: 200, models: [] });
+
+    await detectAvailability({
+      config: {},
+      env: { OPENCLAW_DOCKER_SETUP: "1" },
+    });
+
+    expect(fetchLmstudioModelsMock).toHaveBeenCalledWith({
+      baseUrl: "http://host.docker.internal:1234/v1",
+      apiKey: LMSTUDIO_LOCAL_API_KEY_PLACEHOLDER,
+      timeoutMs: 5000,
+    });
+  });
+
+  it("detects availability through an explicitly configured provider base URL", async () => {
+    const detectAvailability = requireAppGuidedDetectAvailability();
+    fetchLmstudioModelsMock.mockResolvedValue({ reachable: true, status: 200, models: [] });
+
+    await detectAvailability({
+      config: {
+        models: {
+          mode: "merge",
+          providers: {
+            lmstudio: {
+              api: "openai-completions",
+              baseUrl: "http://lmstudio.internal:1234/api/v1/",
+              models: [],
+            },
+          },
+        },
+      },
+      env: {},
+    });
+
+    expect(fetchLmstudioModelsMock).toHaveBeenCalledWith({
+      baseUrl: "http://lmstudio.internal:1234/v1",
+      apiKey: LMSTUDIO_LOCAL_API_KEY_PLACEHOLDER,
+      timeoutMs: 5000,
+    });
   });
 
   it("uses the provider-specific API key for read-only reset discovery", async () => {

--- a/extensions/lmstudio/index.ts
+++ b/extensions/lmstudio/index.ts
@@ -168,6 +168,10 @@ export default definePluginEntry({
           hint: "Connect to a running LM Studio server and use an already loaded model",
           kind: "custom",
           appGuidedSetup: {
+            detectAvailability: async (ctx) => {
+              const { detectAppGuidedLmstudioAvailability } = await import("./src/setup.js");
+              return await detectAppGuidedLmstudioAvailability(ctx);
+            },
             detect: async (ctx) => {
               const providerSetup = await loadProviderSetup();
               const result = await providerSetup.prepareAppGuidedLmstudioSetup(ctx);

--- a/extensions/lmstudio/index.ts
+++ b/extensions/lmstudio/index.ts
@@ -169,8 +169,8 @@ export default definePluginEntry({
           kind: "custom",
           appGuidedSetup: {
             detectAvailability: async (ctx) => {
-              const { detectAppGuidedLmstudioAvailability } = await import("./src/setup.js");
-              return await detectAppGuidedLmstudioAvailability(ctx);
+              const providerSetup = await loadProviderSetup();
+              return await providerSetup.detectAppGuidedLmstudioAvailability(ctx);
             },
             detect: async (ctx) => {
               const providerSetup = await loadProviderSetup();

--- a/extensions/lmstudio/src/api.ts
+++ b/extensions/lmstudio/src/api.ts
@@ -37,6 +37,7 @@ export {
 } from "./runtime.js";
 export {
   configureLmstudioNonInteractive,
+  detectAppGuidedLmstudioAvailability,
   discoverLmstudioProvider,
   prepareAppGuidedLmstudioSetup,
   prepareLmstudioDynamicModels,

--- a/extensions/lmstudio/src/setup.ts
+++ b/extensions/lmstudio/src/setup.ts
@@ -504,6 +504,41 @@ export async function prepareAppGuidedLmstudioSetup(
   };
 }
 
+/** Read-only reachability probe for app-guided setup when no loaded model qualifies. */
+export async function detectAppGuidedLmstudioAvailability(
+  ctx: ProviderAppGuidedSetupContext,
+): Promise<boolean> {
+  const existingProvider = ctx.config.models?.providers?.[PROVIDER_ID];
+  const baseUrl = resolveLmstudioInferenceBase(
+    existingProvider?.baseUrl ?? resolveLmstudioSetupDefaultInferenceBaseUrl(ctx.env),
+  );
+  let headers: Record<string, string> | undefined;
+  let configuredValue: string | undefined;
+  try {
+    headers = await resolveLmstudioProviderHeaders({
+      config: ctx.config,
+      env: ctx.env,
+      headers: existingProvider?.headers,
+    });
+    configuredValue = await resolveLmstudioConfiguredApiKey({
+      config: ctx.config,
+      env: ctx.env,
+      allowUnresolved: true,
+    });
+  } catch {
+    return false;
+  }
+  const environmentValue = ctx.env[LMSTUDIO_DEFAULT_API_KEY_ENV_VAR]?.trim();
+  const accessValue = configuredValue ?? environmentValue;
+  const discovery = await fetchLmstudioModels({
+    baseUrl,
+    apiKey: accessValue ?? LMSTUDIO_LOCAL_API_KEY_PLACEHOLDER,
+    ...(headers ? { headers } : {}),
+    timeoutMs: 5000,
+  });
+  return discovery.reachable;
+}
+
 /** Interactive LM Studio setup with connectivity and model-availability checks. */
 export async function promptAndConfigureLmstudioInteractive(params: {
   config: OpenClawConfig;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where LM Studio disappears from guided onboarding when the local server is reachable but no model is loaded, so new operators cannot discover the provider from the setup picker.

## Why This Change Was Made

The provider now exposes the read-only `appGuidedSetup.detectAvailability` probe defined for guided discovery through the public setup API. It reports whether the LM Studio server responds to `/api/v1/models` without requiring a qualifying loaded model, reusing the same base-URL, header, and API-key resolution as guided setup, including the Docker host default.

## User Impact

A running LM Studio server appears as detected in guided setup even when no model is loaded yet; unreachable servers stay hidden.

## Evidence

- Real LM Studio run: installed LM Studio 0.4.20 on macOS and started its local server headlessly (`lms server start` on `127.0.0.1:1234`). The server has no qualifying loaded model: only a bundled embedding model is present and its `loaded_instances` is empty, so the old `detect` path returns no candidate.
- Real endpoint (LM Studio 0.4.20):

```text
$ curl -sS http://127.0.0.1:1234/api/v1/models
{
  "models": [
    {
      "type": "embedding",
      "key": "text-embedding-nomic-embed-text-v1.5",
      "loaded_instances": [],
      ...
    }
  ]
}
```

- Same `pnpm exec tsx proof-live.ts` on base (`8ad2e06a9d7`) and exact head (`190d8930e8e`):

```text
$ pnpm exec tsx proof-live.ts   # base 8ad2e06a9d7, real server running
detectAvailability: undefined

$ pnpm exec tsx proof-live.ts   # head 190d8930e8e, real server running
detectAvailability: function
real LM Studio reachable (no loaded models): true
guided detect candidate without qualifying loaded model: null

$ pnpm exec tsx proof-live.ts   # head, real server stopped
real LM Studio reachable (no loaded models): false
```

- Matches the merged Ollama pattern from PR #118020 and the `appGuidedSetup.detectAvailability` contract in `docs/plugins/manifest.md`.
- Local focused validation on fixed base `b9901605e83d` and exact head `190d8930e8e`: LM Studio index/setup/runtime tests passed (3 files, 83 tests), including the public-barrel and loader path used by guided setup.

<details>
<summary>proof-live.ts</summary>

```ts
import { capturePluginRegistration } from "openclaw/plugin-sdk/plugin-test-runtime";
import plugin from "./extensions/lmstudio/index.js";

const registration = capturePluginRegistration(plugin);
const method = registration.providers[0].auth[0];
const probe = method.appGuidedSetup?.detectAvailability;
console.log("detectAvailability:", typeof probe === "function" ? "function" : "undefined");

if (!probe) {
  process.exit(0);
}

const baseUrl = process.env.LMS_BASE_URL ?? "http://127.0.0.1:1234/v1";
const result = await probe({
  config: {
    models: {
      mode: "merge",
      providers: { lmstudio: { api: "openai-completions", baseUrl, models: [] } },
    },
  },
  env: {},
});
console.log("real LM Studio reachable (no loaded models):", result);

// Production prepare path: still returns no candidate without a qualifying loaded model.
const { prepareAppGuidedLmstudioSetup } = await import("./extensions/lmstudio/src/setup.js");
const prepared = await prepareAppGuidedLmstudioSetup({
  config: {
    models: {
      mode: "merge",
      providers: { lmstudio: { api: "openai-completions", baseUrl, models: [] } },
    },
  },
  env: {},
});
console.log("guided detect candidate without qualifying loaded model:", prepared === null ? "null" : "non-null");
```

</details>

AI-assisted: built with Codex
