### PR TITLE
feat: smart model tiering for cost optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- Models: add smart model tiering to route simple requests to a cheaper model via `agents.defaults.model.tiering` (and per-agent `agents.list[].model.tiering`). Applies to chat channels, the `agent` CLI, gateway RPC, and the OpenAI-compatible HTTP APIs; never overrides an explicit `/model`, a stored session model, or `heartbeat.model`.
-- Docs: add a "Running OpenClaw on a Budget" guide covering local and low-cost providers.
+- Models: add smart model tiering to route simple requests to a cheaper model via `agents.defaults.model.tiering` (and per-agent `agents.list[].model.tiering`). Applies to chat channels, the `agent` CLI, gateway RPC, and the OpenAI-compatible HTTP APIs; never overrides an explicit `/model`, a stored session model, or `heartbeat.model`. (#8258)
+- Docs: add a "Running OpenClaw on a Budget" guide covering local and low-cost providers. (#8258)
 - Web UI: add Agents dashboard for managing agent files, tools, skills, models, channels, and cron jobs.
 - Security: add healthcheck skill and bootstrap audit guidance. (#7641) Thanks @Takhoffman.
 - Docs: seed zh-CN translations. (#6619) Thanks @joshp123.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- Models: add smart model tiering to route simple requests to a cheaper model via `agents.defaults.model.tiering` (and per-agent `agents.list[].model.tiering`). Applies to chat channels, the `agent` CLI, gateway RPC, and the OpenAI-compatible HTTP APIs; never overrides an explicit `/model`, a stored session model, or `heartbeat.model`. (#8258)
-- Docs: add a "Running OpenClaw on a Budget" guide covering local and low-cost providers. (#8258)
+- Models: add smart model tiering to route simple requests to a cheaper model via `agents.defaults.model.tiering` (and per-agent `agents.list[].model.tiering`). Applies to chat channels, the `agent` CLI, gateway RPC, and the OpenAI-compatible HTTP APIs; never overrides an explicit `/model`, a stored session model, or `heartbeat.model`. (#119135)
+- Docs: add a "Running OpenClaw on a Budget" guide covering local and low-cost providers. (#119135)
 - Web UI: add Agents dashboard for managing agent files, tools, skills, models, channels, and cron jobs.
 - Security: add healthcheck skill and bootstrap audit guidance. (#7641) Thanks @Takhoffman.
 - Docs: seed zh-CN translations. (#6619) Thanks @joshp123.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Models: add smart model tiering to route simple requests to a cheaper model via `agents.defaults.model.tiering` (and per-agent `agents.list[].model.tiering`). Applies to chat channels, the `agent` CLI, gateway RPC, and the OpenAI-compatible HTTP APIs; never overrides an explicit `/model`, a stored session model, or `heartbeat.model`.
+- Docs: add a "Running OpenClaw on a Budget" guide covering local and low-cost providers.
 - Web UI: add Agents dashboard for managing agent files, tools, skills, models, channels, and cron jobs.
 - Security: add healthcheck skill and bootstrap audit guidance. (#7641) Thanks @Takhoffman.
 - Docs: seed zh-CN translations. (#6619) Thanks @joshp123.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -860,6 +860,7 @@
               "start/showcase",
               "start/hubs",
               "start/onboarding",
+              "start/budget",
               "start/lore"
             ]
           },

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -11,6 +11,8 @@ title: "Model Providers"
 OpenClaw can use many LLM providers. Pick a provider, authenticate, then set the
 default model as `provider/model`.
 
+**Looking to minimize costs?** See [Running OpenClaw on a Budget](/start/budget) for free and low-cost options.
+
 Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugin)/etc.)? See [Channels](/channels).
 
 ## Highlight: Venice (Venice AI)

--- a/docs/start/budget.md
+++ b/docs/start/budget.md
@@ -1,0 +1,340 @@
+---
+summary: "Run OpenClaw for free or low cost using local models and budget-friendly providers"
+read_when:
+  - You want to minimize API costs
+  - You want to run OpenClaw with local models
+  - You're looking for cheaper alternatives to Claude/OpenAI
+title: "Running OpenClaw on a Budget"
+---
+
+# Running OpenClaw on a Budget
+
+OpenClaw works with many AI providers, from expensive frontier models to completely free local options. This guide helps you choose the most cost-effective setup for your needs.
+
+## Cost comparison at a glance
+
+| Provider | Cost | Best for |
+|----------|------|----------|
+| [Ollama](#free-local-models-with-ollama) | **Free** | Privacy, offline use, unlimited usage |
+| [DeepSeek](#very-cheap-deepseek-api) | ~$0.14/M input | High quality at low cost |
+| [OpenRouter](#flexible-openrouter) | Varies | Access to many models, pay-per-use |
+| [Venice](#privacy-focused-venice) | Subscription | Privacy + hosted convenience |
+| [Claude/OpenAI API](#when-to-use-frontier-models) | $3-15/M input | Maximum capability |
+
+## Free: Local models with Ollama
+
+The cheapest way to run OpenClaw is with local models via [Ollama](/providers/ollama). Models run entirely on your machine with zero API costs.
+
+### Quick start
+
+1. Install Ollama from [ollama.ai](https://ollama.ai)
+
+2. Pull a capable model:
+
+```bash
+# General purpose (recommended starting point)
+ollama pull llama3.3
+
+# For coding tasks
+ollama pull qwen2.5-coder:32b
+
+# For reasoning tasks
+ollama pull deepseek-r1:32b
+```
+
+3. Enable in OpenClaw:
+
+```bash
+export OLLAMA_API_KEY="ollama-local"
+```
+
+4. Set as default model:
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: { primary: "ollama/llama3.3" },
+    },
+  },
+}
+```
+
+OpenClaw auto-discovers tool-capable Ollama models. Run `openclaw models list` to see available models.
+
+### Hardware requirements
+
+| Model size | RAM needed | GPU VRAM |
+|------------|------------|----------|
+| 7B params | 8GB | 6GB |
+| 13B params | 16GB | 10GB |
+| 32B params | 32GB | 24GB |
+| 70B params | 64GB+ | 48GB+ |
+
+**Tip:** Start with `llama3.3` (8B) to test your setup, then try larger models if your hardware supports them.
+
+### Recommended local models
+
+- **llama3.3** - Best balance of speed and capability for general use
+- **qwen2.5-coder:32b** - Excellent for coding tasks
+- **deepseek-r1:32b** - Strong reasoning, marked as `reasoning: true` automatically
+- **mistral** - Fast and lightweight
+
+## Very cheap: DeepSeek API
+
+[DeepSeek](https://deepseek.com) offers high-quality models at very competitive prices (~10x cheaper than Claude/OpenAI for many tasks).
+
+### Configuration
+
+```json5
+{
+  models: {
+    providers: {
+      deepseek: {
+        id: "deepseek",
+        baseUrl: "https://api.deepseek.com",
+        apiKey: "$DEEPSEEK_API_KEY",  // or set env var
+        apiType: "openai-chat-completions",
+        models: [
+          {
+            id: "deepseek-chat",
+            name: "DeepSeek Chat",
+            contextWindow: 200000,
+            maxOutputTokens: 8192,
+            reasoning: false,
+            cost: { input: 0.14, output: 0.28, cacheRead: 0.014, cacheWrite: 0.14 }
+          },
+          {
+            id: "deepseek-reasoner",
+            name: "DeepSeek Reasoner",
+            contextWindow: 200000,
+            maxOutputTokens: 8192,
+            reasoning: true,
+            cost: { input: 0.55, output: 2.19, cacheRead: 0.055, cacheWrite: 0.55 }
+          }
+        ]
+      }
+    }
+  },
+  agents: {
+    defaults: {
+      model: { primary: "deepseek/deepseek-chat" },
+    },
+  },
+}
+```
+
+**Note:** Get your API key at [platform.deepseek.com](https://platform.deepseek.com).
+
+## Flexible: OpenRouter
+
+[OpenRouter](/providers/openrouter) provides unified access to many models through a single API. Pay only for what you use, with access to both budget and premium options.
+
+### Setup
+
+```bash
+openclaw onboard --auth-choice apiKey --token-provider openrouter --token "$OPENROUTER_API_KEY"
+```
+
+### Budget-friendly models on OpenRouter
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: {
+        // Use a cheap model by default
+        primary: "openrouter/meta-llama/llama-3.3-70b-instruct",
+        // Fall back to Claude for complex tasks
+        fallback: ["openrouter/anthropic/claude-sonnet-4-5"],
+      },
+    },
+  },
+}
+```
+
+Check [openrouter.ai/models](https://openrouter.ai/models) for current pricing. Sort by price to find the cheapest options.
+
+## Privacy-focused: Venice
+
+[Venice](/providers/venice) offers privacy-first inference with no data retention. It's our recommended hosted option for users who want convenience without compromising privacy.
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: { primary: "venice/llama-3.3-70b" },
+    },
+  },
+}
+```
+
+## Monitoring your costs
+
+OpenClaw includes built-in cost tracking:
+
+### Check current usage
+
+```
+/status
+```
+
+Shows session model, context usage, and estimated cost.
+
+### Enable per-response tracking
+
+```
+/usage full
+```
+
+Appends token counts and costs to every response.
+
+### View session cost summary
+
+```
+/usage cost
+```
+
+Shows accumulated costs from session logs.
+
+## Tips for reducing costs
+
+### 1. Use `/compact` regularly
+
+Long conversations accumulate context. Summarize periodically:
+
+```
+/compact
+```
+
+### 2. Choose smaller models for simple tasks
+
+Use expensive models only when needed:
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: {
+        primary: "ollama/llama3.3",  // Free for most tasks
+        fallback: ["anthropic/claude-sonnet-4-5"],  // Paid backup
+      },
+    },
+  },
+}
+```
+
+### 3. Keep skill descriptions short
+
+Skills are injected into every prompt. Verbose descriptions add token overhead.
+
+### 4. Leverage prompt caching
+
+For Anthropic models, keep the cache warm to reduce costs:
+
+```json5
+{
+  agents: {
+    defaults: {
+      heartbeat: { every: "55m" },  // Just under 1h cache TTL
+    },
+  },
+}
+```
+
+### 5. Trim large tool outputs
+
+Configure tools to return only essential information.
+
+## When to use frontier models
+
+Local and budget models work well for:
+- Casual conversations
+- Simple coding tasks
+- Research and summarization
+- Routine automation
+
+Consider Claude or GPT-4 for:
+- Complex multi-step reasoning
+- Large codebase refactoring
+- Tasks requiring deep context understanding
+- When accuracy is critical
+
+## Automatic: Smart Model Tiering
+
+OpenClaw can automatically route simple queries (greetings, acknowledgments, simple questions) to cheaper models while using your primary model for complex tasks.
+
+### Enable tiering
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: {
+        primary: "anthropic/claude-sonnet-4-5",  // Complex tasks
+        tiering: {
+          enabled: true,
+          simple: "ollama/llama3.3",  // Simple queries (free)
+        },
+      },
+    },
+  },
+}
+```
+
+### How it works
+
+Queries are automatically classified:
+
+**Simple** (uses cheap model):
+- Greetings: "hi", "hello", "good morning"
+- Acknowledgments: "thanks", "ok", "got it"
+- Yes/no: "yes", "no", "sure"
+- Short questions: "what time is it", "who are you"
+
+**Complex** (uses primary model):
+- Code requests: "write a function that..."
+- Multi-step reasoning: "step by step", "compare and contrast"
+- System operations: "git commit", "npm install"
+- Long messages (500+ characters)
+
+### Customize detection
+
+```json5
+{
+  tiering: {
+    enabled: true,
+    simple: "ollama/llama3.3",
+    // Custom patterns that trigger complex tier (regex)
+    complexPatterns: ["\\bspecial\\b.*\\bkeyword\\b"],
+    // Character threshold for complexity (default: 500)
+    complexLengthThreshold: 300,
+  },
+}
+```
+
+## Hybrid approach
+
+The most cost-effective setup often combines approaches:
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: {
+        // Free local model for routine work
+        primary: "ollama/llama3.3",
+        // Cheap API for when local isn't enough
+        fallback: ["deepseek/deepseek-chat", "anthropic/claude-sonnet-4-5"],
+      },
+    },
+  },
+}
+```
+
+## See also
+
+- [Ollama provider](/providers/ollama) - Full local model setup
+- [OpenRouter provider](/providers/openrouter) - Multi-model access
+- [Token use and costs](/token-use) - Detailed cost tracking
+- [Model providers](/providers/index) - All supported providers

--- a/docs/start/budget.md
+++ b/docs/start/budget.md
@@ -71,7 +71,7 @@ OpenClaw auto-discovers tool-capable Ollama models. Run `openclaw models list` t
 | 32B params | 32GB | 24GB |
 | 70B params | 64GB+ | 48GB+ |
 
-**Tip:** Start with `llama3.3` (8B) to test your setup, then try larger models if your hardware supports them.
+**Tip:** `llama3.3` is a 70B model. If your hardware is closer to the top of the table, start with a smaller model such as `mistral` (7B) to test your setup, then move up.
 
 ### Recommended local models
 
@@ -91,16 +91,15 @@ OpenClaw auto-discovers tool-capable Ollama models. Run `openclaw models list` t
   models: {
     providers: {
       deepseek: {
-        id: "deepseek",
         baseUrl: "https://api.deepseek.com",
         apiKey: "$DEEPSEEK_API_KEY",  // or set env var
-        apiType: "openai-chat-completions",
+        api: "openai-completions",
         models: [
           {
             id: "deepseek-chat",
             name: "DeepSeek Chat",
             contextWindow: 200000,
-            maxOutputTokens: 8192,
+            maxTokens: 8192,
             reasoning: false,
             cost: { input: 0.14, output: 0.28, cacheRead: 0.014, cacheWrite: 0.14 }
           },
@@ -108,7 +107,7 @@ OpenClaw auto-discovers tool-capable Ollama models. Run `openclaw models list` t
             id: "deepseek-reasoner",
             name: "DeepSeek Reasoner",
             contextWindow: 200000,
-            maxOutputTokens: 8192,
+            maxTokens: 8192,
             reasoning: true,
             cost: { input: 0.55, output: 2.19, cacheRead: 0.055, cacheWrite: 0.55 }
           }
@@ -146,7 +145,7 @@ openclaw onboard --auth-choice apiKey --token-provider openrouter --token "$OPEN
         // Use a cheap model by default
         primary: "openrouter/meta-llama/llama-3.3-70b-instruct",
         // Fall back to Claude for complex tasks
-        fallback: ["openrouter/anthropic/claude-sonnet-4-5"],
+        fallbacks: ["openrouter/anthropic/claude-sonnet-4-5"],
       },
     },
   },
@@ -217,7 +216,7 @@ Use expensive models only when needed:
     defaults: {
       model: {
         primary: "ollama/llama3.3",  // Free for most tasks
-        fallback: ["anthropic/claude-sonnet-4-5"],  // Paid backup
+        fallbacks: ["anthropic/claude-sonnet-4-5"],  // Paid backup
       },
     },
   },
@@ -262,7 +261,9 @@ Consider Claude or GPT-4 for:
 
 ## Automatic: Smart Model Tiering
 
-OpenClaw can automatically route simple queries (greetings, acknowledgments, simple questions) to cheaper models while using your primary model for complex tasks.
+OpenClaw can automatically route simple queries to a cheaper model, keeping your primary model for work that needs it.
+
+Note the direction of the default: tiering routes a message to the **cheap** model unless it matches a complexity signal. It is an opt-out list, not an opt-in one, so more than just pleasantries will go to the cheap model.
 
 ### Enable tiering
 
@@ -284,19 +285,38 @@ OpenClaw can automatically route simple queries (greetings, acknowledgments, sim
 
 ### How it works
 
-Queries are automatically classified:
+A message goes to the **primary** model when it matches any complexity signal:
 
-**Simple** (uses cheap model):
-- Greetings: "hi", "hello", "good morning"
-- Acknowledgments: "thanks", "ok", "got it"
-- Yes/no: "yes", "no", "sure"
-- Short questions: "what time is it", "who are you"
-
-**Complex** (uses primary model):
 - Code requests: "write a function that..."
 - Multi-step reasoning: "step by step", "compare and contrast"
 - System operations: "git commit", "npm install"
-- Long messages (500+ characters)
+- Two or more question words ("what", "why", "how", "explain", ...)
+- Requests for an enumerated list: "show me all ..."
+- Messages longer than 500 characters (see `complexLengthThreshold`)
+
+Everything else goes to the **cheap** model, including short greetings
+("hi", "thanks", "yes") and single-word messages. Because the classifier only
+looks at the wording of the message, it is a cost heuristic and not a capability
+check: if the cheap model is much weaker than your primary, expect some
+misroutes.
+
+Only the current message is classified. In group batches and queued turns that
+carry earlier context, the accumulated history is ignored.
+
+### What tiering never overrides
+
+Tiering only replaces the model you would otherwise have got by default. It
+leaves a deliberate choice alone:
+
+- An inline `/model` directive on the message
+- A sticky session model set earlier with `/model`
+- `agents.defaults.heartbeat.model` on heartbeat runs
+
+It also respects the `agents.defaults.models` allowlist: if you keep one, the
+tiered model must be in it, exactly as with `/model`.
+
+Tiering applies on every surface — chat channels, the `openclaw agent` CLI, the
+gateway RPC, and the OpenAI-compatible HTTP APIs.
 
 ### Customize detection
 
@@ -313,6 +333,40 @@ Queries are automatically classified:
 }
 ```
 
+Patterns are validated when the config loads, so an uncompilable regex is
+reported instead of being silently ignored. Only the first 4000 characters of a
+message are scanned for patterns, regardless of `complexLengthThreshold`.
+
+### Per-agent tiering
+
+Set `tiering` on an individual agent to override the global config. Fields merge
+over `agents.defaults.model.tiering`, so you can change just one:
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: {
+        primary: "anthropic/claude-sonnet-4-5",
+        tiering: { enabled: true, simple: "ollama/llama3.3" },
+      },
+    },
+    list: [
+      {
+        id: "researcher",
+        // Inherits enabled: true, but routes simple work elsewhere.
+        model: { tiering: { simple: "deepseek/deepseek-chat" } },
+      },
+      {
+        id: "oncall",
+        // Always uses the primary model.
+        model: { tiering: { enabled: false } },
+      },
+    ],
+  },
+}
+```
+
 ## Hybrid approach
 
 The most cost-effective setup often combines approaches:
@@ -325,7 +379,7 @@ The most cost-effective setup often combines approaches:
         // Free local model for routine work
         primary: "ollama/llama3.3",
         // Cheap API for when local isn't enough
-        fallback: ["deepseek/deepseek-chat", "anthropic/claude-sonnet-4-5"],
+        fallbacks: ["deepseek/deepseek-chat", "anthropic/claude-sonnet-4-5"],
       },
     },
   },

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -1,6 +1,7 @@
 import os from "node:os";
 import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
+import type { ModelTieringConfig } from "../config/types.agent-defaults.js";
 import { resolveStateDir } from "../config/paths.js";
 import {
   DEFAULT_AGENT_ID,
@@ -162,6 +163,17 @@ export function resolveAgentModelFallbacksOverride(
     return undefined;
   }
   return Array.isArray(raw.fallbacks) ? raw.fallbacks : undefined;
+}
+
+export function resolveAgentModelTiering(
+  cfg: OpenClawConfig,
+  agentId: string,
+): ModelTieringConfig | undefined {
+  const raw = resolveAgentConfig(cfg, agentId)?.model;
+  if (!raw || typeof raw === "string") {
+    return undefined;
+  }
+  return raw.tiering;
 }
 
 export function resolveAgentWorkspaceDir(cfg: OpenClawConfig, agentId: string) {

--- a/src/agents/model-tiering.test.ts
+++ b/src/agents/model-tiering.test.ts
@@ -1,0 +1,310 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyQueryComplexity,
+  describeComplexityReason,
+  resolveTieredModel,
+  resolveTieringConfig,
+  type TieringConfig,
+} from "./model-tiering.js";
+import type { OpenClawConfig } from "../config/config.js";
+
+describe("classifyQueryComplexity", () => {
+  describe("simple queries", () => {
+    it("classifies greetings as simple", () => {
+      expect(classifyQueryComplexity("hi")).toBe("simple");
+      expect(classifyQueryComplexity("hello")).toBe("simple");
+      expect(classifyQueryComplexity("hey!")).toBe("simple");
+      expect(classifyQueryComplexity("good morning")).toBe("simple");
+      expect(classifyQueryComplexity("Good afternoon!")).toBe("simple");
+    });
+
+    it("classifies acknowledgments as simple", () => {
+      expect(classifyQueryComplexity("thanks")).toBe("simple");
+      expect(classifyQueryComplexity("thank you!")).toBe("simple");
+      expect(classifyQueryComplexity("ok")).toBe("simple");
+      expect(classifyQueryComplexity("got it")).toBe("simple");
+      expect(classifyQueryComplexity("cool")).toBe("simple");
+    });
+
+    it("classifies yes/no responses as simple", () => {
+      expect(classifyQueryComplexity("yes")).toBe("simple");
+      expect(classifyQueryComplexity("no")).toBe("simple");
+      expect(classifyQueryComplexity("yep")).toBe("simple");
+      expect(classifyQueryComplexity("nope")).toBe("simple");
+    });
+
+    it("classifies empty/very short queries as simple", () => {
+      expect(classifyQueryComplexity("")).toBe("simple");
+      expect(classifyQueryComplexity("  ")).toBe("simple");
+      expect(classifyQueryComplexity("hi")).toBe("simple");
+    });
+
+    it("classifies short non-matching queries as simple", () => {
+      expect(classifyQueryComplexity("what's up")).toBe("simple");
+      expect(classifyQueryComplexity("how are you")).toBe("simple");
+    });
+  });
+
+  describe("complex queries", () => {
+    it("classifies code writing requests as complex", () => {
+      expect(classifyQueryComplexity("write a function to sort an array")).toBe("complex");
+      expect(classifyQueryComplexity("create a class for handling user authentication")).toBe(
+        "complex",
+      );
+      expect(classifyQueryComplexity("implement an API endpoint for user registration")).toBe(
+        "complex",
+      );
+    });
+
+    it("classifies debugging requests as complex", () => {
+      expect(classifyQueryComplexity("debug this code and fix the error")).toBe("complex");
+      expect(classifyQueryComplexity("fix the bug in the login function")).toBe("complex");
+      expect(classifyQueryComplexity("refactor this code to be more efficient")).toBe("complex");
+    });
+
+    it("classifies multi-step reasoning as complex", () => {
+      expect(classifyQueryComplexity("let's think step by step about this problem")).toBe(
+        "complex",
+      );
+      expect(classifyQueryComplexity("break down the algorithm into smaller parts")).toBe(
+        "complex",
+      );
+      expect(classifyQueryComplexity("what are the pros and cons of this approach")).toBe(
+        "complex",
+      );
+    });
+
+    it("classifies long-form content requests as complex", () => {
+      expect(classifyQueryComplexity("write an essay about climate change")).toBe("complex");
+      expect(classifyQueryComplexity("draft a proposal for the new feature")).toBe("complex");
+      expect(classifyQueryComplexity("summarize this article about AI")).toBe("complex");
+    });
+
+    it("classifies system operations as complex", () => {
+      expect(classifyQueryComplexity("run npm install")).toBe("complex");
+      expect(classifyQueryComplexity("execute the tests")).toBe("complex");
+      expect(classifyQueryComplexity("deploy to production")).toBe("complex");
+      expect(classifyQueryComplexity("git commit the changes")).toBe("complex");
+    });
+
+    it("classifies queries with code blocks as complex", () => {
+      const queryWithCode = "explain this code:\n\`\`\`javascript\nfunction fibonacci(n) {\n  if (n <= 1) return n;\n  return fibonacci(n - 1) + fibonacci(n - 2);\n}\n\`\`\`";
+      expect(classifyQueryComplexity(queryWithCode)).toBe("complex");
+    });
+
+    it("classifies long queries as complex", () => {
+      const longQuery = "a".repeat(501);
+      expect(classifyQueryComplexity(longQuery)).toBe("complex");
+    });
+
+    it("classifies queries with multiple question words as complex", () => {
+      expect(classifyQueryComplexity("what is the best way to explain how this works")).toBe(
+        "complex",
+      );
+      expect(classifyQueryComplexity("why does this happen and how can we fix it")).toBe("complex");
+    });
+  });
+
+  describe("with custom config", () => {
+    it("respects custom length threshold", () => {
+      const config: TieringConfig = {
+        enabled: true,
+        complexLengthThreshold: 100,
+      };
+      const query = "a".repeat(101);
+      expect(classifyQueryComplexity(query, config)).toBe("complex");
+
+      const shorterQuery = "a".repeat(50);
+      expect(classifyQueryComplexity(shorterQuery, config)).toBe("simple");
+    });
+
+    it("respects custom complex patterns", () => {
+      const config: TieringConfig = {
+        enabled: true,
+        complexPatterns: ["secret.*pattern", "magic.*word"],
+      };
+      expect(classifyQueryComplexity("this has a secret custom pattern", config)).toBe("complex");
+      expect(classifyQueryComplexity("use the magic word please", config)).toBe("complex");
+      expect(classifyQueryComplexity("normal query", config)).toBe("simple");
+    });
+
+    it("ignores invalid regex patterns", () => {
+      const config: TieringConfig = {
+        enabled: true,
+        complexPatterns: ["[invalid(regex"],
+      };
+      // Should not throw, just skip the invalid pattern
+      expect(classifyQueryComplexity("test query", config)).toBe("simple");
+    });
+  });
+});
+
+describe("resolveTieringConfig", () => {
+  it("returns null when model config is missing", () => {
+    const cfg = {} as OpenClawConfig;
+    expect(resolveTieringConfig(cfg)).toBeNull();
+  });
+
+  it("returns null when model config is a string", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: "anthropic/claude-3",
+        },
+      },
+    } as unknown as OpenClawConfig;
+    expect(resolveTieringConfig(cfg)).toBeNull();
+  });
+
+  it("returns null when tiering is not enabled", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-3",
+            tiering: {
+              enabled: false,
+              simple: "ollama/llama3.3",
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    expect(resolveTieringConfig(cfg)).toBeNull();
+  });
+
+  it("returns tiering config when enabled", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-3",
+            tiering: {
+              enabled: true,
+              simple: "ollama/llama3.3",
+              complexLengthThreshold: 300,
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const result = resolveTieringConfig(cfg);
+    expect(result).toEqual({
+      enabled: true,
+      simple: "ollama/llama3.3",
+      complexLengthThreshold: 300,
+    });
+  });
+});
+
+describe("resolveTieredModel", () => {
+  it("returns null when tiering is disabled", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-3",
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const result = resolveTieredModel({
+      cfg,
+      query: "hello",
+      defaultProvider: "anthropic",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns simple model for simple queries", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-3",
+            tiering: {
+              enabled: true,
+              simple: "ollama/llama3.3",
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const result = resolveTieredModel({
+      cfg,
+      query: "hello",
+      defaultProvider: "anthropic",
+    });
+    expect(result).not.toBeNull();
+    expect(result?.ref.provider).toBe("ollama");
+    expect(result?.ref.model).toBe("llama3.3");
+    expect(result?.tier).toBe("simple");
+  });
+
+  it("returns null for complex queries (use default)", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-3",
+            tiering: {
+              enabled: true,
+              simple: "ollama/llama3.3",
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const result = resolveTieredModel({
+      cfg,
+      query: "write a function to implement binary search",
+      defaultProvider: "anthropic",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when no simple model is configured", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-3",
+            tiering: {
+              enabled: true,
+              // No simple model configured
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const result = resolveTieredModel({
+      cfg,
+      query: "hello",
+      defaultProvider: "anthropic",
+    });
+    expect(result).toBeNull();
+  });
+});
+
+describe("describeComplexityReason", () => {
+  it("returns length reason for long queries", () => {
+    const longQuery = "a".repeat(501);
+    const reason = describeComplexityReason(longQuery);
+    expect(reason).toBe("Query length exceeds 500 characters");
+  });
+
+  it("returns pattern match for code requests", () => {
+    const reason = describeComplexityReason("write a function for authentication");
+    expect(reason).toContain("Matches complex pattern");
+  });
+
+  it("returns question word count reason", () => {
+    const reason = describeComplexityReason("what is the best way to explain something");
+    expect(reason).toContain("question/explanation words");
+  });
+
+  it("returns null for simple queries", () => {
+    const reason = describeComplexityReason("hello");
+    expect(reason).toBeNull();
+  });
+});

--- a/src/agents/model-tiering.test.ts
+++ b/src/agents/model-tiering.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
 import {
   classifyQueryComplexity,
   describeComplexityReason,
@@ -6,7 +7,6 @@ import {
   resolveTieringConfig,
   type TieringConfig,
 } from "./model-tiering.js";
-import type { OpenClawConfig } from "../config/config.js";
 
 describe("classifyQueryComplexity", () => {
   describe("simple queries", () => {
@@ -88,7 +88,8 @@ describe("classifyQueryComplexity", () => {
     });
 
     it("classifies queries with code blocks as complex", () => {
-      const queryWithCode = "explain this code:\n\`\`\`javascript\nfunction fibonacci(n) {\n  if (n <= 1) return n;\n  return fibonacci(n - 1) + fibonacci(n - 2);\n}\n\`\`\`";
+      const queryWithCode =
+        "explain this code:\n```javascript\nfunction fibonacci(n) {\n  if (n <= 1) return n;\n  return fibonacci(n - 1) + fibonacci(n - 2);\n}\n```";
       expect(classifyQueryComplexity(queryWithCode)).toBe("complex");
     });
 
@@ -135,6 +136,15 @@ describe("classifyQueryComplexity", () => {
       };
       // Should not throw, just skip the invalid pattern
       expect(classifyQueryComplexity("test query", config)).toBe("simple");
+    });
+
+    it("only scans the head of very long input for complex patterns", () => {
+      // A high threshold keeps long input in the classifier; the pattern sweep
+      // is still bounded, so a keyword past the scan limit is not detected.
+      const config: TieringConfig = { enabled: true, complexLengthThreshold: 100_000 };
+      const padding = "z ".repeat(3_000);
+      expect(classifyQueryComplexity(`npm install ${padding}`, config)).toBe("complex");
+      expect(classifyQueryComplexity(`${padding} npm install`, config)).toBe("simple");
     });
   });
 });
@@ -197,6 +207,16 @@ describe("resolveTieringConfig", () => {
   });
 });
 
+function tieringCfg(tiering: unknown): OpenClawConfig {
+  return {
+    agents: {
+      defaults: {
+        model: { primary: "anthropic/claude-3", tiering },
+      },
+    },
+  } as unknown as OpenClawConfig;
+}
+
 describe("resolveTieredModel", () => {
   it("returns null when tiering is disabled", () => {
     const cfg = {
@@ -235,10 +255,7 @@ describe("resolveTieredModel", () => {
       query: "hello",
       defaultProvider: "anthropic",
     });
-    expect(result).not.toBeNull();
-    expect(result?.ref.provider).toBe("ollama");
-    expect(result?.ref.model).toBe("llama3.3");
-    expect(result?.tier).toBe("simple");
+    expect(result).toEqual({ provider: "ollama", model: "llama3.3" });
   });
 
   it("returns null for complex queries (use default)", () => {
@@ -283,6 +300,101 @@ describe("resolveTieredModel", () => {
       defaultProvider: "anthropic",
     });
     expect(result).toBeNull();
+  });
+
+  it("does not override a deliberately chosen model", () => {
+    const result = resolveTieredModel({
+      cfg: tieringCfg({ enabled: true, simple: "ollama/llama3.3" }),
+      query: "hello",
+      defaultProvider: "anthropic",
+      explicitModel: true,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("resolves the simple model through model aliases", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          models: { "ollama/llama3.3": { alias: "cheap" } },
+          model: {
+            primary: "anthropic/claude-3",
+            tiering: { enabled: true, simple: "cheap" },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const result = resolveTieredModel({
+      cfg,
+      query: "hello",
+      defaultProvider: "anthropic",
+    });
+    expect(result).toEqual({ provider: "ollama", model: "llama3.3" });
+  });
+
+  it("refuses a simple model outside the allowlist", () => {
+    const result = resolveTieredModel({
+      cfg: tieringCfg({ enabled: true, simple: "ollama/llama3.3" }),
+      query: "hello",
+      defaultProvider: "anthropic",
+      allowedModelKeys: new Set(["anthropic/claude-3"]),
+    });
+    expect(result).toBeNull();
+  });
+
+  it("accepts a simple model inside the allowlist", () => {
+    const result = resolveTieredModel({
+      cfg: tieringCfg({ enabled: true, simple: "ollama/llama3.3" }),
+      query: "hello",
+      defaultProvider: "anthropic",
+      allowedModelKeys: new Set(["anthropic/claude-3", "ollama/llama3.3"]),
+    });
+    expect(result).toEqual({ provider: "ollama", model: "llama3.3" });
+  });
+});
+
+describe("per-agent tiering", () => {
+  function cfgWithAgent(agentTiering: unknown, globalTiering?: unknown): OpenClawConfig {
+    return {
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-3",
+            ...(globalTiering ? { tiering: globalTiering } : undefined),
+          },
+        },
+        list: [{ id: "scribe", model: { tiering: agentTiering } }],
+      },
+    } as unknown as OpenClawConfig;
+  }
+
+  it("enables tiering for one agent without any global config", () => {
+    const cfg = cfgWithAgent({ enabled: true, simple: "ollama/llama3.3" });
+    expect(
+      resolveTieredModel({ cfg, agentId: "scribe", query: "hi", defaultProvider: "anthropic" }),
+    ).toEqual({ provider: "ollama", model: "llama3.3" });
+    // Other agents are unaffected.
+    expect(
+      resolveTieredModel({ cfg, agentId: "other", query: "hi", defaultProvider: "anthropic" }),
+    ).toBeNull();
+  });
+
+  it("merges per-agent fields over the global tiering config", () => {
+    const cfg = cfgWithAgent(
+      { simple: "ollama/mistral" },
+      { enabled: true, simple: "ollama/llama3.3", complexLengthThreshold: 42 },
+    );
+    expect(resolveTieringConfig(cfg, "scribe")).toEqual({
+      enabled: true,
+      simple: "ollama/mistral",
+      complexLengthThreshold: 42,
+    });
+  });
+
+  it("lets an agent opt out of global tiering", () => {
+    const cfg = cfgWithAgent({ enabled: false }, { enabled: true, simple: "ollama/llama3.3" });
+    expect(resolveTieringConfig(cfg, "scribe")).toBeNull();
+    expect(resolveTieringConfig(cfg)).not.toBeNull();
   });
 });
 

--- a/src/agents/model-tiering.ts
+++ b/src/agents/model-tiering.ts
@@ -25,12 +25,11 @@
 
 import type { OpenClawConfig } from "../config/config.js";
 import { parseModelRef, type ModelRef } from "./model-selection.js";
-import { DEFAULT_PROVIDER } from "./defaults.js";
 
 export type QueryComplexity = "simple" | "complex";
 
 export type TieringConfig = {
-  enabled: boolean;
+  enabled?: boolean;
   /** Model to use for simple queries (e.g., "ollama/llama3.3") */
   simple?: string;
   /** Custom patterns that indicate complex queries (regex strings) */

--- a/src/agents/model-tiering.ts
+++ b/src/agents/model-tiering.ts
@@ -1,0 +1,233 @@
+/**
+ * Smart Model Tiering
+ *
+ * Routes simple queries to cheaper models automatically, escalating to expensive
+ * models only when complexity warrants it. This can significantly reduce costs
+ * for users who primarily use OpenClaw for casual conversations.
+ *
+ * Configuration:
+ * ```json5
+ * {
+ *   agents: {
+ *     defaults: {
+ *       model: {
+ *         primary: "anthropic/claude-sonnet-4-5",  // Complex tasks
+ *         tiering: {
+ *           enabled: true,
+ *           simple: "ollama/llama3.3",  // Simple queries (free/cheap)
+ *         },
+ *       },
+ *     },
+ *   },
+ * }
+ * ```
+ */
+
+import type { OpenClawConfig } from "../config/config.js";
+import { parseModelRef, type ModelRef } from "./model-selection.js";
+import { DEFAULT_PROVIDER } from "./defaults.js";
+
+export type QueryComplexity = "simple" | "complex";
+
+export type TieringConfig = {
+  enabled: boolean;
+  /** Model to use for simple queries (e.g., "ollama/llama3.3") */
+  simple?: string;
+  /** Custom patterns that indicate complex queries (regex strings) */
+  complexPatterns?: string[];
+  /** Minimum message length to consider for simple tier (default: 500 chars) */
+  complexLengthThreshold?: number;
+};
+
+/**
+ * Patterns that indicate a query is complex and needs a powerful model.
+ * These are checked case-insensitively.
+ */
+const DEFAULT_COMPLEX_PATTERNS = [
+  // Code-related tasks
+  /\b(write|create|implement|build|code|program)\b.*\b(function|class|api|endpoint|algorithm|module|component|service|script)\b/i,
+  /\b(function|class|api|endpoint|algorithm)\b.*\b(for|that|which|to)\b/i,
+  /\b(debug|fix|refactor|optimize|review)\b.*\b(code|function|bug|error|issue)\b/i,
+  /\b(explain|analyze)\b.*\b(code|algorithm|architecture|system)\b/i,
+  /```[\s\S]{50,}```/, // Code blocks over 50 chars
+
+  // Multi-step reasoning
+  /\b(step[- ]by[- ]step|let'?s think|break down|analyze|compare and contrast)\b/i,
+  /\b(pros? and cons?|trade[- ]?offs?|advantages? and disadvantages?)\b/i,
+
+  // Long-form content
+  /\b(write|draft|compose|create)\b.*\b(essay|article|report|document|proposal|plan)\b/i,
+  /\b(summarize|synthesize)\b.*\b(article|paper|document|book|chapter)\b/i,
+
+  // Data/file operations
+  /\b(read|parse|process|transform|convert)\b.*\b(file|json|csv|xml|data)\b/i,
+  /\b(search|find|grep|locate)\b.*\b(in|across|through)\b.*\b(files?|codebase|project)\b/i,
+
+  // System operations
+  /\b(run|execute|install|deploy|configure|setup)\b/i,
+  /\b(git|npm|pip|docker|kubectl|terraform)\b/i,
+
+  // Complex questions
+  /\b(how (does|do|can|should|would)|why (does|do|is|are|would)|what (is the best|are the|would happen))\b.*\?/i,
+
+  // Planning/architecture
+  /\b(design|architect|plan|structure|organize)\b.*\b(system|app|application|project|database)\b/i,
+];
+
+/**
+ * Patterns that indicate a query is simple and can use a cheaper model.
+ */
+const SIMPLE_PATTERNS = [
+  // Greetings
+  /^(hi|hello|hey|good (morning|afternoon|evening)|howdy|yo|sup)[\s!?.]*$/i,
+
+  // Simple status/info
+  /^(thanks|thank you|ok|okay|got it|understood|cool|great|nice|awesome|perfect)[\s!?.]*$/i,
+
+  // Simple questions
+  /^(what time is it|what'?s the (time|date|weather))[\s?]*$/i,
+  /^(who are you|what are you|what can you do)[\s?]*$/i,
+
+  // Single-word or very short queries
+  /^[a-z]{1,15}[\s!?.]*$/i,
+
+  // Yes/no responses
+  /^(yes|no|yep|nope|yeah|nah|sure|maybe)[\s!?.]*$/i,
+];
+
+/**
+ * Classify a query as simple or complex to determine model tier.
+ */
+export function classifyQueryComplexity(
+  query: string,
+  config?: TieringConfig,
+): QueryComplexity {
+  const trimmed = query.trim();
+
+  // Empty or very short queries are simple
+  if (!trimmed || trimmed.length < 3) {
+    return "simple";
+  }
+
+  // Check explicit simple patterns first
+  for (const pattern of SIMPLE_PATTERNS) {
+    if (pattern.test(trimmed)) {
+      return "simple";
+    }
+  }
+
+  // Check length threshold (default: 500 chars indicates complexity)
+  const lengthThreshold = config?.complexLengthThreshold ?? 500;
+  if (trimmed.length > lengthThreshold) {
+    return "complex";
+  }
+
+  // Check default complex patterns
+  for (const pattern of DEFAULT_COMPLEX_PATTERNS) {
+    if (pattern.test(trimmed)) {
+      return "complex";
+    }
+  }
+
+  // Check custom complex patterns from config
+  if (config?.complexPatterns) {
+    for (const patternStr of config.complexPatterns) {
+      try {
+        const pattern = new RegExp(patternStr, "i");
+        if (pattern.test(trimmed)) {
+          return "complex";
+        }
+      } catch {
+        // Invalid regex, skip
+      }
+    }
+  }
+
+  // Check for question complexity by counting question words
+  const questionWords = (trimmed.match(/\b(what|why|how|when|where|which|who|explain|describe)\b/gi) || []).length;
+  if (questionWords >= 2) {
+    return "complex";
+  }
+
+  // Check for list requests (often need structured thinking)
+  if (/\b(list|enumerate|give me|show me|tell me)\b.*\b(all|every|each|different|various)\b/i.test(trimmed)) {
+    return "complex";
+  }
+
+  // Default to simple for short, non-matching queries
+  if (trimmed.length < 100) {
+    return "simple";
+  }
+
+  // Medium-length queries without complex indicators are also simple
+  return "simple";
+}
+
+/**
+ * Resolve the tiering configuration from OpenClawConfig.
+ */
+export function resolveTieringConfig(cfg: OpenClawConfig): TieringConfig | null {
+  const modelConfig = cfg.agents?.defaults?.model;
+  if (!modelConfig || typeof modelConfig === "string") {
+    return null;
+  }
+
+  const tiering = (modelConfig as { tiering?: TieringConfig }).tiering;
+  if (!tiering?.enabled) {
+    return null;
+  }
+
+  return tiering;
+}
+
+/**
+ * Resolve the model to use based on query complexity and tiering config.
+ * Returns the tiered model ref if applicable, or null to use the default.
+ */
+export function resolveTieredModel(params: {
+  cfg: OpenClawConfig;
+  query: string;
+  defaultProvider: string;
+}): { ref: ModelRef; tier: QueryComplexity } | null {
+  const tiering = resolveTieringConfig(params.cfg);
+  if (!tiering) {
+    return null;
+  }
+
+  const complexity = classifyQueryComplexity(params.query, tiering);
+
+  // Only override for simple queries when a simple model is configured
+  if (complexity === "simple" && tiering.simple) {
+    const ref = parseModelRef(tiering.simple, params.defaultProvider);
+    if (ref) {
+      return { ref, tier: "simple" };
+    }
+  }
+
+  // Complex queries or no simple model configured - use default
+  return null;
+}
+
+/**
+ * Get a human-readable description of why a query was classified as complex.
+ */
+export function describeComplexityReason(query: string): string | null {
+  const trimmed = query.trim();
+
+  if (trimmed.length > 500) {
+    return "Query length exceeds 500 characters";
+  }
+
+  for (const pattern of DEFAULT_COMPLEX_PATTERNS) {
+    if (pattern.test(trimmed)) {
+      return `Matches complex pattern: ${pattern.source.slice(0, 50)}...`;
+    }
+  }
+
+  const questionWords = (trimmed.match(/\b(what|why|how|when|where|which|who|explain|describe)\b/gi) || []).length;
+  if (questionWords >= 2) {
+    return `Contains ${questionWords} question/explanation words`;
+  }
+
+  return null;
+}

--- a/src/agents/model-tiering.ts
+++ b/src/agents/model-tiering.ts
@@ -1,11 +1,18 @@
 /**
  * Smart Model Tiering
  *
- * Routes simple queries to cheaper models automatically, escalating to expensive
- * models only when complexity warrants it. This can significantly reduce costs
- * for users who primarily use OpenClaw for casual conversations.
+ * Routes simple requests to a cheaper model, keeping the primary model for work
+ * that warrants it. This can significantly reduce costs for users who primarily
+ * use OpenClaw for casual conversations.
  *
- * Configuration:
+ * This module only decides *which* model a request should use; callers own model
+ * resolution. It is wired into the two places that resolve a model for a
+ * user-initiated run — `createModelSelectionState` (chat channels) and
+ * `agentCommand` (CLI, gateway RPC, OpenAI-compatible HTTP APIs) — so every
+ * surface behaves the same. Internal sub-runs (memory extraction, follow-ups)
+ * deliberately do not tier: they have their own prompts, not the user's.
+ *
+ * Configuration (per-agent `agents.list[].model.tiering` merges over this):
  * ```json5
  * {
  *   agents: {
@@ -24,19 +31,30 @@
  */
 
 import type { OpenClawConfig } from "../config/config.js";
-import { parseModelRef, type ModelRef } from "./model-selection.js";
+import type { ModelTieringConfig } from "../config/types.agent-defaults.js";
+import { resolveAgentModelTiering } from "./agent-scope.js";
+import {
+  buildModelAliasIndex,
+  modelKey,
+  resolveModelRefFromString,
+  type ModelAliasIndex,
+  type ModelRef,
+} from "./model-selection.js";
 
 export type QueryComplexity = "simple" | "complex";
 
-export type TieringConfig = {
-  enabled?: boolean;
-  /** Model to use for simple queries (e.g., "ollama/llama3.3") */
-  simple?: string;
-  /** Custom patterns that indicate complex queries (regex strings) */
-  complexPatterns?: string[];
-  /** Minimum message length to consider for simple tier (default: 500 chars) */
-  complexLengthThreshold?: number;
-};
+export type TieringConfig = ModelTieringConfig;
+
+const DEFAULT_COMPLEX_LENGTH_THRESHOLD = 500;
+
+/**
+ * Upper bound on the text handed to the complex-pattern sweep. Several patterns
+ * contain `.*`, which is O(n^2) on non-matching input, so a large
+ * `complexLengthThreshold` would otherwise let a big paste block the event loop.
+ * The patterns are keyword-shaped, so the head of a message is enough to
+ * classify it.
+ */
+const PATTERN_SCAN_LIMIT = 4000;
 
 /**
  * Patterns that indicate a query is complex and needs a powerful model.
@@ -95,138 +113,191 @@ const SIMPLE_PATTERNS = [
 ];
 
 /**
- * Classify a query as simple or complex to determine model tier.
+ * Question/explanation words; two or more of them signal a compound question.
+ * Carries the `g` flag, so it must only be used with `String.match` (which
+ * resets `lastIndex`), never with `RegExp.test` on this shared instance.
  */
-export function classifyQueryComplexity(
+const QUESTION_WORDS_PATTERN = /\b(what|why|how|when|where|which|who|explain|describe)\b/gi;
+
+/** List requests ("show me all ...") often need structured thinking. */
+const LIST_REQUEST_PATTERN =
+  /\b(list|enumerate|give me|show me|tell me)\b.*\b(all|every|each|different|various)\b/i;
+
+/**
+ * Cache of compiled user-supplied patterns, keyed by the raw pattern string.
+ * Classification runs once per inbound message, so compiling here keeps the
+ * per-message cost at a map lookup. Invalid patterns cache as `null` so a
+ * broken config costs one failed compile rather than a throw every message.
+ */
+const customPatternCache = new Map<string, RegExp | null>();
+
+function compileCustomPattern(patternStr: string): RegExp | null {
+  const cached = customPatternCache.get(patternStr);
+  if (cached !== undefined) {
+    return cached;
+  }
+  let compiled: RegExp | null = null;
+  try {
+    compiled = new RegExp(patternStr, "i");
+  } catch {
+    // Invalid regex; remember the failure so we don't retry per message.
+    compiled = null;
+  }
+  customPatternCache.set(patternStr, compiled);
+  return compiled;
+}
+
+function complexPatternMatch(pattern: RegExp): { tier: QueryComplexity; reason: string } {
+  return { tier: "complex", reason: `Matches complex pattern: ${pattern.source.slice(0, 50)}...` };
+}
+
+/**
+ * Single source of truth for the tier decision and the reason behind it, so
+ * the classification and its explanation can never drift apart.
+ */
+function classify(
   query: string,
   config?: TieringConfig,
-): QueryComplexity {
+): { tier: QueryComplexity; reason: string | null } {
+  const simple = { tier: "simple", reason: null } as const;
   const trimmed = query.trim();
 
   // Empty or very short queries are simple
   if (!trimmed || trimmed.length < 3) {
-    return "simple";
+    return simple;
   }
 
   // Check explicit simple patterns first
   for (const pattern of SIMPLE_PATTERNS) {
     if (pattern.test(trimmed)) {
-      return "simple";
+      return simple;
     }
   }
 
-  // Check length threshold (default: 500 chars indicates complexity)
-  const lengthThreshold = config?.complexLengthThreshold ?? 500;
+  const lengthThreshold = config?.complexLengthThreshold ?? DEFAULT_COMPLEX_LENGTH_THRESHOLD;
   if (trimmed.length > lengthThreshold) {
-    return "complex";
+    return { tier: "complex", reason: `Query length exceeds ${lengthThreshold} characters` };
   }
 
-  // Check default complex patterns
+  // Bound the input to the `.*`-bearing patterns; see PATTERN_SCAN_LIMIT.
+  const scanned =
+    trimmed.length > PATTERN_SCAN_LIMIT ? trimmed.slice(0, PATTERN_SCAN_LIMIT) : trimmed;
+
   for (const pattern of DEFAULT_COMPLEX_PATTERNS) {
-    if (pattern.test(trimmed)) {
-      return "complex";
+    if (pattern.test(scanned)) {
+      return complexPatternMatch(pattern);
     }
   }
 
-  // Check custom complex patterns from config
-  if (config?.complexPatterns) {
-    for (const patternStr of config.complexPatterns) {
-      try {
-        const pattern = new RegExp(patternStr, "i");
-        if (pattern.test(trimmed)) {
-          return "complex";
-        }
-      } catch {
-        // Invalid regex, skip
-      }
+  for (const patternStr of config?.complexPatterns ?? []) {
+    const pattern = compileCustomPattern(patternStr);
+    if (pattern?.test(scanned)) {
+      return complexPatternMatch(pattern);
     }
   }
 
-  // Check for question complexity by counting question words
-  const questionWords = (trimmed.match(/\b(what|why|how|when|where|which|who|explain|describe)\b/gi) || []).length;
+  const questionWords = (scanned.match(QUESTION_WORDS_PATTERN) || []).length;
   if (questionWords >= 2) {
-    return "complex";
+    return { tier: "complex", reason: `Contains ${questionWords} question/explanation words` };
   }
 
-  // Check for list requests (often need structured thinking)
-  if (/\b(list|enumerate|give me|show me|tell me)\b.*\b(all|every|each|different|various)\b/i.test(trimmed)) {
-    return "complex";
+  if (LIST_REQUEST_PATTERN.test(scanned)) {
+    return { tier: "complex", reason: "Requests an enumerated list" };
   }
 
-  // Default to simple for short, non-matching queries
-  if (trimmed.length < 100) {
-    return "simple";
-  }
-
-  // Medium-length queries without complex indicators are also simple
-  return "simple";
+  // No complex signal: route to the cheap tier.
+  return simple;
 }
 
 /**
- * Resolve the tiering configuration from OpenClawConfig.
+ * Classify a query as simple or complex to determine model tier.
  */
-export function resolveTieringConfig(cfg: OpenClawConfig): TieringConfig | null {
-  const modelConfig = cfg.agents?.defaults?.model;
-  if (!modelConfig || typeof modelConfig === "string") {
-    return null;
-  }
-
-  const tiering = (modelConfig as { tiering?: TieringConfig }).tiering;
-  if (!tiering?.enabled) {
-    return null;
-  }
-
-  return tiering;
+export function classifyQueryComplexity(query: string, config?: TieringConfig): QueryComplexity {
+  return classify(query, config).tier;
 }
 
 /**
- * Resolve the model to use based on query complexity and tiering config.
- * Returns the tiered model ref if applicable, or null to use the default.
+ * Resolve the effective tiering configuration for an agent.
+ *
+ * Per-agent `agents.list[].model.tiering` is merged over the global
+ * `agents.defaults.model.tiering`, field by field, so an agent can override
+ * just `simple` (or switch tiering off) while inheriting the rest.
+ */
+export function resolveTieringConfig(cfg: OpenClawConfig, agentId?: string): TieringConfig | null {
+  const globalTiering = cfg.agents?.defaults?.model?.tiering;
+  const agentTiering = agentId ? resolveAgentModelTiering(cfg, agentId) : undefined;
+  if (!globalTiering && !agentTiering) {
+    return null;
+  }
+  const merged: TieringConfig = { ...globalTiering, ...agentTiering };
+  return merged.enabled ? merged : null;
+}
+
+/**
+ * Resolve the cheaper model to route this request to, or null to keep the
+ * model the caller already resolved.
+ *
+ * Callers must pass the text of the *current* request only (no transcript or
+ * structural context), otherwise length and greeting checks measure the wrong
+ * thing. `explicitModel` must be set whenever the model was deliberately
+ * chosen — an inline `/model` directive, a stored session override, or a
+ * configured heartbeat model — so tiering never overrides a deliberate choice.
  */
 export function resolveTieredModel(params: {
   cfg: OpenClawConfig;
   query: string;
   defaultProvider: string;
-}): { ref: ModelRef; tier: QueryComplexity } | null {
-  const tiering = resolveTieringConfig(params.cfg);
-  if (!tiering) {
+  agentId?: string;
+  explicitModel?: boolean;
+  aliasIndex?: ModelAliasIndex;
+  /** When non-empty, the tiered model must appear in this allowlist. */
+  allowedModelKeys?: Set<string>;
+}): ModelRef | null {
+  if (params.explicitModel) {
     return null;
   }
 
-  const complexity = classifyQueryComplexity(params.query, tiering);
-
-  // Only override for simple queries when a simple model is configured
-  if (complexity === "simple" && tiering.simple) {
-    const ref = parseModelRef(tiering.simple, params.defaultProvider);
-    if (ref) {
-      return { ref, tier: "simple" };
-    }
+  const tiering = resolveTieringConfig(params.cfg, params.agentId);
+  // Skip classification entirely when there is no cheaper model to route to.
+  if (!tiering?.simple) {
+    return null;
   }
 
-  // Complex queries or no simple model configured - use default
-  return null;
+  if (classifyQueryComplexity(params.query, tiering) !== "simple") {
+    return null;
+  }
+
+  const aliasIndex =
+    params.aliasIndex ??
+    buildModelAliasIndex({ cfg: params.cfg, defaultProvider: params.defaultProvider });
+  const resolved = resolveModelRefFromString({
+    raw: tiering.simple,
+    defaultProvider: params.defaultProvider,
+    aliasIndex,
+  });
+  if (!resolved) {
+    return null;
+  }
+
+  // Honour the same allowlist as `/model`; a tiered model must not be a way
+  // around `agents.defaults.models`.
+  const allowed = params.allowedModelKeys;
+  if (
+    allowed &&
+    allowed.size > 0 &&
+    !allowed.has(modelKey(resolved.ref.provider, resolved.ref.model))
+  ) {
+    return null;
+  }
+
+  return resolved.ref;
 }
 
 /**
- * Get a human-readable description of why a query was classified as complex.
+ * Get a human-readable description of why a query was classified as complex,
+ * or null when the query is simple. Shares `classify` with
+ * `classifyQueryComplexity`, so the reason always matches the decision.
  */
-export function describeComplexityReason(query: string): string | null {
-  const trimmed = query.trim();
-
-  if (trimmed.length > 500) {
-    return "Query length exceeds 500 characters";
-  }
-
-  for (const pattern of DEFAULT_COMPLEX_PATTERNS) {
-    if (pattern.test(trimmed)) {
-      return `Matches complex pattern: ${pattern.source.slice(0, 50)}...`;
-    }
-  }
-
-  const questionWords = (trimmed.match(/\b(what|why|how|when|where|which|who|explain|describe)\b/gi) || []).length;
-  if (questionWords >= 2) {
-    return `Contains ${questionWords} question/explanation words`;
-  }
-
-  return null;
+export function describeComplexityReason(query: string, config?: TieringConfig): string | null {
+  return classify(query, config).reason;
 }

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -7,7 +7,6 @@ import type { MsgContext, TemplateContext } from "../templating.js";
 import type { ElevatedLevel, ReasoningLevel, ThinkLevel, VerboseLevel } from "../thinking.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import type { TypingController } from "./typing.js";
-import { resolveTieredModel } from "../../agents/model-tiering.js";
 import { resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
 import { listChatCommands, shouldHandleTextCommands } from "../commands-registry.js";
 import { listSkillCommandsForWorkspace } from "../skill-commands.js";
@@ -17,7 +16,12 @@ import { type InlineDirectives, parseInlineDirectives } from "./directive-handli
 import { applyInlineDirectiveOverrides } from "./get-reply-directives-apply.js";
 import { clearInlineDirectives } from "./get-reply-directives-utils.js";
 import { defaultGroupActivation, resolveGroupRequireMention } from "./groups.js";
-import { CURRENT_MESSAGE_MARKER, stripMentions, stripStructuralPrefixes } from "./mentions.js";
+import {
+  CURRENT_MESSAGE_MARKER,
+  extractCurrentMessageBody,
+  stripMentions,
+  stripStructuralPrefixes,
+} from "./mentions.js";
 import { createModelSelectionState, resolveContextTokens } from "./model-selection.js";
 import { formatElevatedUnavailableMessage, resolveElevatedPermissions } from "./reply-elevated.js";
 import { stripInlineStatus } from "./reply-inline.js";
@@ -107,6 +111,8 @@ export async function resolveReplyDirectives(params: {
   aliasIndex: ModelAliasIndex;
   provider: string;
   model: string;
+  /** True when the caller already picked provider/model deliberately (e.g. heartbeat.model). */
+  modelPreselected?: boolean;
   typing: TypingController;
   opts?: GetReplyOptions;
   skillFilter?: string[];
@@ -392,6 +398,10 @@ export async function resolveReplyDirectives(params: {
     provider,
     model,
     hasModelDirective: directives.hasModelDirective,
+    agentId,
+    aliasIndex: params.aliasIndex,
+    tieringQuery: extractCurrentMessageBody(cleanedBody),
+    modelPreselected: params.modelPreselected,
   });
   provider = modelState.provider;
   model = modelState.model;
@@ -453,21 +463,6 @@ export async function resolveReplyDirectives(params: {
   contextTokens = applyResult.contextTokens;
   const { directiveAck, perMessageQueueMode, perMessageQueueOptions } = applyResult;
   const execOverrides = resolveExecOverrides({ directives, sessionEntry });
-
-  // Apply smart model tiering: use cheaper models for simple queries
-  // Only apply if no explicit model directive was given
-  if (!directives.hasModelDirective) {
-    const tiered = resolveTieredModel({
-      cfg,
-      query: cleanedBody,
-      defaultProvider,
-    });
-    if (tiered) {
-      provider = tiered.ref.provider;
-      model = tiered.ref.model;
-      contextTokens = resolveContextTokens({ agentCfg, model });
-    }
-  }
 
   return {
     kind: "continue",

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -78,6 +78,9 @@ export async function getReplyFromConfig(
   });
   let provider = defaultProvider;
   let model = defaultModel;
+  // Tracks whether provider/model below is a deliberate choice rather than the
+  // configured default, so model tiering does not override it.
+  let modelPreselected = false;
   if (opts?.isHeartbeat) {
     const heartbeatRaw = agentCfg?.heartbeat?.model?.trim() ?? "";
     const heartbeatRef = heartbeatRaw
@@ -90,6 +93,7 @@ export async function getReplyFromConfig(
     if (heartbeatRef) {
       provider = heartbeatRef.ref.provider;
       model = heartbeatRef.ref.model;
+      modelPreselected = true;
     }
   }
 
@@ -195,6 +199,7 @@ export async function getReplyFromConfig(
     aliasIndex,
     provider,
     model,
+    modelPreselected,
     typing,
     opts: resolvedOpts,
     skillFilter: mergedSkillFilter,

--- a/src/auto-reply/reply/mentions.test.ts
+++ b/src/auto-reply/reply/mentions.test.ts
@@ -1,5 +1,25 @@
 import { describe, expect, it } from "vitest";
-import { matchesMentionWithExplicit } from "./mentions.js";
+import {
+  CURRENT_MESSAGE_MARKER,
+  extractCurrentMessageBody,
+  matchesMentionWithExplicit,
+} from "./mentions.js";
+
+describe("extractCurrentMessageBody", () => {
+  it("returns the text unchanged when there is no marker", () => {
+    expect(extractCurrentMessageBody("just a message")).toBe("just a message");
+  });
+
+  it("drops batched context ahead of the marker", () => {
+    const body = `[10:00] alice: an earlier long message about deployments\n${CURRENT_MESSAGE_MARKER}\nthanks`;
+    expect(extractCurrentMessageBody(body)).toBe("thanks");
+  });
+
+  it("keeps the current message intact when it spans lines", () => {
+    const body = `context here\n${CURRENT_MESSAGE_MARKER}\nline one\nline two`;
+    expect(extractCurrentMessageBody(body)).toBe("line one\nline two");
+  });
+});
 
 describe("matchesMentionWithExplicit", () => {
   const mentionRegexes = [/\bopenclaw\b/i];

--- a/src/auto-reply/reply/mentions.ts
+++ b/src/auto-reply/reply/mentions.ts
@@ -107,12 +107,20 @@ export function matchesMentionWithExplicit(params: {
   return explicit || params.mentionRegexes.some((re) => re.test(cleaned));
 }
 
+/**
+ * Isolate the current inbound message from a body that may also carry batched
+ * history/context ahead of CURRENT_MESSAGE_MARKER. Returns the text unchanged
+ * when no marker is present.
+ */
+export function extractCurrentMessageBody(text: string): string {
+  const index = text.indexOf(CURRENT_MESSAGE_MARKER);
+  return index < 0 ? text : text.slice(index + CURRENT_MESSAGE_MARKER.length).trimStart();
+}
+
 export function stripStructuralPrefixes(text: string): string {
   // Ignore wrapper labels, timestamps, and sender prefixes so directive-only
   // detection still works in group batches that include history/context.
-  const afterMarker = text.includes(CURRENT_MESSAGE_MARKER)
-    ? text.slice(text.indexOf(CURRENT_MESSAGE_MARKER) + CURRENT_MESSAGE_MARKER.length).trimStart()
-    : text;
+  const afterMarker = extractCurrentMessageBody(text);
 
   return afterMarker
     .replace(/\[[^\]]+\]\s*/g, "")

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -12,6 +12,7 @@ import {
   resolveModelRefFromString,
   resolveThinkingDefault,
 } from "../../agents/model-selection.js";
+import { resolveTieredModel } from "../../agents/model-tiering.js";
 import { type SessionEntry, updateSessionStore } from "../../config/sessions.js";
 import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
 import { resolveThreadParentSessionKey } from "../../sessions/session-key-utils.js";
@@ -271,6 +272,15 @@ export async function createModelSelectionState(params: {
   provider: string;
   model: string;
   hasModelDirective: boolean;
+  agentId?: string;
+  aliasIndex?: ModelAliasIndex;
+  /**
+   * Text of the current inbound message only (no transcript/context), used to
+   * classify complexity for model tiering. Omit to disable tiering.
+   */
+  tieringQuery?: string;
+  /** True when the caller already picked the model deliberately (e.g. heartbeat.model). */
+  modelPreselected?: boolean;
 }): Promise<ModelSelectionState> {
   const {
     cfg,
@@ -343,12 +353,35 @@ export async function createModelSelectionState(params: {
     sessionKey,
     parentSessionKey,
   });
+  let appliedStoredOverride = false;
   if (storedOverride?.model) {
     const candidateProvider = storedOverride.provider || defaultProvider;
     const key = modelKey(candidateProvider, storedOverride.model);
     if (allowedModelKeys.size === 0 || allowedModelKeys.has(key)) {
       provider = candidateProvider;
       model = storedOverride.model;
+      appliedStoredOverride = true;
+    }
+  }
+
+  // Model tiering: route simple requests to a cheaper model. Applied here, so
+  // the tiered model is the one every downstream consumer sees — including the
+  // thinking-level default resolved below, which must match the model actually
+  // used. Never overrides a deliberate choice.
+  if (params.tieringQuery !== undefined) {
+    const tiered = resolveTieredModel({
+      cfg,
+      agentId: params.agentId,
+      query: params.tieringQuery,
+      defaultProvider,
+      explicitModel:
+        params.hasModelDirective || appliedStoredOverride || params.modelPreselected === true,
+      aliasIndex: params.aliasIndex,
+      allowedModelKeys,
+    });
+    if (tiered) {
+      provider = tiered.provider;
+      model = tiered.model;
     }
   }
 

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -21,6 +21,7 @@ import {
   resolveConfiguredModelRef,
   resolveThinkingDefault,
 } from "../agents/model-selection.js";
+import { resolveTieredModel } from "../agents/model-tiering.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 import { buildWorkspaceSkillSnapshot } from "../agents/skills.js";
 import { getSkillsSnapshotVersion } from "../agents/skills/refresh.js";
@@ -309,6 +310,7 @@ export async function agentCommand(
 
     const storedProviderOverride = sessionEntry?.providerOverride?.trim();
     const storedModelOverride = sessionEntry?.modelOverride?.trim();
+    let appliedStoredOverride = false;
     if (storedModelOverride) {
       const candidateProvider = storedProviderOverride || defaultProvider;
       const key = modelKey(candidateProvider, storedModelOverride);
@@ -319,7 +321,23 @@ export async function agentCommand(
       ) {
         provider = candidateProvider;
         model = storedModelOverride;
+        appliedStoredOverride = true;
       }
+    }
+
+    // Model tiering for every non-chat entry point: the CLI, gateway RPC, and
+    // the OpenAI-compatible HTTP APIs all run through agentCommand.
+    const tieredModel = resolveTieredModel({
+      cfg,
+      agentId: sessionAgentId,
+      query: body,
+      defaultProvider,
+      explicitModel: appliedStoredOverride,
+      allowedModelKeys,
+    });
+    if (tieredModel) {
+      provider = tieredModel.provider;
+      model = tieredModel.model;
     }
     if (sessionEntry) {
       const authProfileId = sessionEntry.authProfileOverride;

--- a/src/config/config.model-tiering.test.ts
+++ b/src/config/config.model-tiering.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { OpenClawSchema } from "./zod-schema.js";
+
+describe("model tiering config schema", () => {
+  it("accepts tiering under agents.defaults.model", () => {
+    const res = OpenClawSchema.safeParse({
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-sonnet-4-5",
+            tiering: {
+              enabled: true,
+              simple: "ollama/llama3.3",
+              complexPatterns: ["\\bspecial\\b.*\\bkeyword\\b"],
+              complexLengthThreshold: 300,
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.success).toBe(true);
+  });
+
+  it("accepts per-agent tiering under agents.list[].model", () => {
+    const res = OpenClawSchema.safeParse({
+      agents: {
+        list: [
+          {
+            id: "scribe",
+            model: {
+              primary: "anthropic/claude-sonnet-4-5",
+              tiering: { enabled: true, simple: "ollama/llama3.3" },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.success).toBe(true);
+  });
+
+  it("rejects an uncompilable complexPatterns entry", () => {
+    const res = OpenClawSchema.safeParse({
+      agents: {
+        defaults: {
+          model: {
+            tiering: { enabled: true, complexPatterns: ["ok", "[invalid(regex"] },
+          },
+        },
+      },
+    });
+
+    expect(res.success).toBe(false);
+    if (!res.success) {
+      const issue = res.error.issues.find((entry) => entry.path.includes("complexPatterns"));
+      expect(issue?.path).toEqual(["agents", "defaults", "model", "tiering", "complexPatterns", 1]);
+      expect(issue?.message).toContain("Invalid regular expression");
+    }
+  });
+
+  it("rejects unknown tiering fields", () => {
+    const res = OpenClawSchema.safeParse({
+      agents: {
+        defaults: {
+          model: { tiering: { enabled: true, simpel: "ollama/llama3.3" } },
+        },
+      },
+    });
+
+    expect(res.success).toBe(false);
+  });
+});

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -284,6 +284,15 @@ const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.models": "Models",
   "agents.defaults.model.primary": "Primary Model",
   "agents.defaults.model.fallbacks": "Model Fallbacks",
+  "agents.defaults.model.tiering": "Model Tiering",
+  "agents.defaults.model.tiering.enabled": "Enable Model Tiering",
+  "agents.defaults.model.tiering.simple": "Simple Query Model",
+  "agents.defaults.model.tiering.complexPatterns": "Complex Query Patterns",
+  "agents.defaults.model.tiering.complexLengthThreshold": "Complex Length Threshold",
+  "agents.defaults.rateLimitStrategy": "Rate Limit Strategy",
+  "agents.defaults.rateLimitStrategy.strategy": "Strategy",
+  "agents.defaults.rateLimitStrategy.maxWaitSeconds": "Max Wait Seconds",
+  "agents.defaults.rateLimitStrategy.backupModel": "Backup Model",
   "agents.defaults.imageModel.primary": "Image Model",
   "agents.defaults.imageModel.fallbacks": "Image Model Fallbacks",
   "agents.defaults.humanDelay.mode": "Human Delay Mode",
@@ -633,6 +642,23 @@ const FIELD_HELP: Record<string, string> = {
   "agents.defaults.model.primary": "Primary model (provider/model).",
   "agents.defaults.model.fallbacks":
     "Ordered fallback models (provider/model). Used when the primary model fails.",
+  "agents.defaults.model.tiering":
+    "Smart model tiering: automatically route simple queries to cheaper models.",
+  "agents.defaults.model.tiering.enabled": "Enable automatic model tiering based on query complexity.",
+  "agents.defaults.model.tiering.simple":
+    'Cheaper model for simple queries (e.g., "ollama/llama3.3"). Falls back to primary if not set.',
+  "agents.defaults.model.tiering.complexPatterns":
+    "Custom regex patterns that indicate complex queries requiring the primary model.",
+  "agents.defaults.model.tiering.complexLengthThreshold":
+    "Character length threshold above which queries are considered complex (default: 500).",
+  "agents.defaults.rateLimitStrategy":
+    "Configure how rate limits (HTTP 429) are handled.",
+  "agents.defaults.rateLimitStrategy.strategy":
+    'Strategy when rate limited: "switch" (use fallback), "wait" (respect Retry-After), or "ask" (prompt user).',
+  "agents.defaults.rateLimitStrategy.maxWaitSeconds":
+    "Maximum seconds to wait before switching to fallback (default: 60).",
+  "agents.defaults.rateLimitStrategy.backupModel":
+    "Specific backup model to use when switching (uses configured fallbacks if not set).",
   "agents.defaults.imageModel.primary":
     "Optional image model (provider/model) used when the primary model lacks image input.",
   "agents.defaults.imageModel.fallbacks": "Ordered fallback image models (provider/model).",

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -289,10 +289,6 @@ const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.model.tiering.simple": "Simple Query Model",
   "agents.defaults.model.tiering.complexPatterns": "Complex Query Patterns",
   "agents.defaults.model.tiering.complexLengthThreshold": "Complex Length Threshold",
-  "agents.defaults.rateLimitStrategy": "Rate Limit Strategy",
-  "agents.defaults.rateLimitStrategy.strategy": "Strategy",
-  "agents.defaults.rateLimitStrategy.maxWaitSeconds": "Max Wait Seconds",
-  "agents.defaults.rateLimitStrategy.backupModel": "Backup Model",
   "agents.defaults.imageModel.primary": "Image Model",
   "agents.defaults.imageModel.fallbacks": "Image Model Fallbacks",
   "agents.defaults.humanDelay.mode": "Human Delay Mode",
@@ -644,21 +640,14 @@ const FIELD_HELP: Record<string, string> = {
     "Ordered fallback models (provider/model). Used when the primary model fails.",
   "agents.defaults.model.tiering":
     "Smart model tiering: automatically route simple queries to cheaper models.",
-  "agents.defaults.model.tiering.enabled": "Enable automatic model tiering based on query complexity.",
+  "agents.defaults.model.tiering.enabled":
+    "Enable automatic model tiering based on query complexity.",
   "agents.defaults.model.tiering.simple":
     'Cheaper model for simple queries (e.g., "ollama/llama3.3"). Falls back to primary if not set.',
   "agents.defaults.model.tiering.complexPatterns":
     "Custom regex patterns that indicate complex queries requiring the primary model.",
   "agents.defaults.model.tiering.complexLengthThreshold":
     "Character length threshold above which queries are considered complex (default: 500).",
-  "agents.defaults.rateLimitStrategy":
-    "Configure how rate limits (HTTP 429) are handled.",
-  "agents.defaults.rateLimitStrategy.strategy":
-    'Strategy when rate limited: "switch" (use fallback), "wait" (respect Retry-After), or "ask" (prompt user).',
-  "agents.defaults.rateLimitStrategy.maxWaitSeconds":
-    "Maximum seconds to wait before switching to fallback (default: 60).",
-  "agents.defaults.rateLimitStrategy.backupModel":
-    "Specific backup model to use when switching (uses configured fallbacks if not set).",
   "agents.defaults.imageModel.primary":
     "Optional image model (provider/model) used when the primary model lacks image input.",
   "agents.defaults.imageModel.fallbacks": "Ordered fallback image models (provider/model).",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -18,9 +18,22 @@ export type AgentModelEntryConfig = {
   params?: Record<string, unknown>;
 };
 
+export type ModelTieringConfig = {
+  /** Enable automatic model tiering based on query complexity. */
+  enabled?: boolean;
+  /** Model to use for simple queries (e.g., "ollama/llama3.3"). */
+  simple?: string;
+  /** Custom regex patterns that indicate complex queries. */
+  complexPatterns?: string[];
+  /** Character length threshold above which queries are considered complex (default: 500). */
+  complexLengthThreshold?: number;
+};
+
 export type AgentModelListConfig = {
   primary?: string;
   fallbacks?: string[];
+  /** Smart model tiering: use cheaper models for simple queries. */
+  tiering?: ModelTieringConfig;
 };
 
 export type AgentContextPruningConfig = {

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -32,6 +32,14 @@ export type ModelTieringConfig = {
 export type AgentModelListConfig = {
   primary?: string;
   fallbacks?: string[];
+};
+
+/**
+ * Primary model config. Kept separate from `AgentModelListConfig` because
+ * tiering applies only to `model`, not to `imageModel` (which shares the
+ * narrower shape in both the type and the zod schema).
+ */
+export type AgentPrimaryModelConfig = AgentModelListConfig & {
   /** Smart model tiering: use cheaper models for simple queries. */
   tiering?: ModelTieringConfig;
 };
@@ -106,7 +114,7 @@ export type CliBackendConfig = {
 
 export type AgentDefaultsConfig = {
   /** Primary model and fallbacks (provider/model). */
-  model?: AgentModelListConfig;
+  model?: AgentPrimaryModelConfig;
   /** Optional image-capable model and fallbacks (provider/model). */
   imageModel?: AgentModelListConfig;
   /** Model catalog with optional aliases (full provider/model keys). */

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -1,4 +1,4 @@
-import type { AgentDefaultsConfig } from "./types.agent-defaults.js";
+import type { AgentDefaultsConfig, ModelTieringConfig } from "./types.agent-defaults.js";
 import type { HumanDelayConfig, IdentityConfig } from "./types.base.js";
 import type { GroupChatConfig } from "./types.messages.js";
 import type {
@@ -15,6 +15,8 @@ export type AgentModelConfig =
       primary?: string;
       /** Per-agent model fallbacks (provider/model). */
       fallbacks?: string[];
+      /** Per-agent model tiering; merged over agents.defaults.model.tiering. */
+      tiering?: ModelTieringConfig;
     };
 
 export type AgentConfig = {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -13,12 +13,30 @@ import {
   HumanDelaySchema,
 } from "./zod-schema.core.js";
 
+export const ModelTieringSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    simple: z.string().optional(),
+    complexPatterns: z.array(z.string()).optional(),
+    complexLengthThreshold: z.number().int().positive().optional(),
+  })
+  .strict();
+
+export const RateLimitStrategySchema = z
+  .object({
+    strategy: z.union([z.literal("switch"), z.literal("wait"), z.literal("ask")]).optional(),
+    maxWaitSeconds: z.number().int().positive().optional(),
+    backupModel: z.string().optional(),
+  })
+  .strict();
+
 export const AgentDefaultsSchema = z
   .object({
     model: z
       .object({
         primary: z.string().optional(),
         fallbacks: z.array(z.string()).optional(),
+        tiering: ModelTieringSchema.optional(),
       })
       .strict()
       .optional(),
@@ -168,6 +186,7 @@ export const AgentDefaultsSchema = z
       })
       .strict()
       .optional(),
+    rateLimitStrategy: RateLimitStrategySchema.optional(),
   })
   .strict()
   .optional();

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -22,14 +22,6 @@ export const ModelTieringSchema = z
   })
   .strict();
 
-export const RateLimitStrategySchema = z
-  .object({
-    strategy: z.union([z.literal("switch"), z.literal("wait"), z.literal("ask")]).optional(),
-    maxWaitSeconds: z.number().int().positive().optional(),
-    backupModel: z.string().optional(),
-  })
-  .strict();
-
 export const AgentDefaultsSchema = z
   .object({
     model: z
@@ -186,7 +178,6 @@ export const AgentDefaultsSchema = z
       })
       .strict()
       .optional(),
-    rateLimitStrategy: RateLimitStrategySchema.optional(),
   })
   .strict()
   .optional();

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -11,16 +11,8 @@ import {
   BlockStreamingCoalesceSchema,
   CliBackendSchema,
   HumanDelaySchema,
+  ModelTieringSchema,
 } from "./zod-schema.core.js";
-
-export const ModelTieringSchema = z
-  .object({
-    enabled: z.boolean().optional(),
-    simple: z.string().optional(),
-    complexPatterns: z.array(z.string()).optional(),
-    complexLengthThreshold: z.number().int().positive().optional(),
-  })
-  .strict();
 
 export const AgentDefaultsSchema = z
   .object({

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -4,6 +4,7 @@ import {
   GroupChatSchema,
   HumanDelaySchema,
   IdentitySchema,
+  ModelTieringSchema,
   ToolsLinksSchema,
   ToolsMediaSchema,
 } from "./zod-schema.core.js";
@@ -416,6 +417,7 @@ export const AgentModelSchema = z.union([
     .object({
       primary: z.string().optional(),
       fallbacks: z.array(z.string()).optional(),
+      tiering: ModelTieringSchema.optional(),
     })
     .strict(),
 ]);

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -59,6 +59,30 @@ export const ModelProviderSchema = z
   })
   .strict();
 
+export const ModelTieringSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    simple: z.string().optional(),
+    complexPatterns: z.array(z.string()).optional(),
+    complexLengthThreshold: z.number().int().positive().optional(),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    // Reject unusable regexes at config load; the classifier would otherwise
+    // skip them silently on every message with no way for the user to notice.
+    value.complexPatterns?.forEach((pattern, index) => {
+      try {
+        new RegExp(pattern, "i");
+      } catch (err) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["complexPatterns", index],
+          message: `Invalid regular expression: ${err instanceof Error ? err.message : String(err)}`,
+        });
+      }
+    });
+  });
+
 export const BedrockDiscoverySchema = z
   .object({
     enabled: z.boolean().optional(),


### PR DESCRIPTION
Adds optional smart model tiering: route simple requests to a cheaper model, keep the primary model for work that needs it. Also adds a "Running OpenClaw on a Budget" guide for free and low-cost provider setups.

Supersedes #8258, which was auto-closed for inactivity and cannot be reopened (GitHub returns `Could not open the pull request` — the head linkage broke when my fork was renamed). Same branch and history, plus the review follow-ups below. Triage on that PR was `keep/review`, with config/type consistency as the one thing to validate before merge; that is now done.

## Config

Off by default. Global:

```json5
{
  agents: {
    defaults: {
      model: {
        primary: "anthropic/claude-sonnet-4-5",
        tiering: {
          enabled: true,
          simple: "ollama/llama3.3",
          // optional
          complexPatterns: ["\\bspecial\\b.*\\bkeyword\\b"],
          complexLengthThreshold: 300,
        },
      },
    },
  },
}
```

Per-agent `agents.list[].model.tiering` merges over the global config, so an agent can override just `simple` or set `enabled: false` to opt out.

## Behaviour

A request goes to the **primary** model when it matches a complexity signal (code/system/multi-step patterns, two or more question words, list requests, or longer than `complexLengthThreshold`). Everything else goes to the cheap model — it is an opt-out list, not an opt-in one, and the docs say so plainly rather than implying it only affects pleasantries.

Tiering never overrides a deliberate choice: an inline `/model` directive, a stored session model, or `agents.defaults.heartbeat.model`. It also respects the `agents.defaults.models` allowlist, exactly as `/model` does, and resolves `tiering.simple` through model aliases.

It applies on chat channels via `createModelSelectionState`, and on every other surface via `agentCommand` — the CLI, gateway RPC, node events, boot, the restart sentinel, and both the OpenAI-compatible and OpenResponses HTTP APIs all funnel through it. Internal sub-runs (memory extraction, follow-ups) deliberately do not tier, since they run their own prompts rather than the user's.

## Review follow-ups from #8258

Both @greptile-apps comments are resolved:

- **`TieringConfig.enabled` required vs optional, forcing casts** — `TieringConfig` is now an alias of `ModelTieringConfig`, so the shape is declared once. That removed the `(modelConfig as { tiering?: TieringConfig }).tiering` cast, which the PR itself had made unnecessary.
- **`rateLimitStrategy` validating at runtime with no matching type** — dropped from the changeset as suggested. The schema went in the earlier round, but eight orphaned `FIELD_LABELS`/`FIELD_HELP` entries in `src/config/schema.ts` remained, documenting config that could not be set. Those are gone.

Related drift found while checking: `tiering` had been added to `AgentModelListConfig`, which backs both `model` and `imageModel`, so TypeScript accepted `imageModel.tiering` while the strict schema rejected it. Split into `AgentPrimaryModelConfig`.

## Other fixes in this round

- Tiering used to mutate locals at the tail of `resolveReplyDirectives`, leaving `modelState` and the thinking-level closure pointing at the pre-tiering model. Resolving it inside `createModelSelectionState` means the thinking default is now computed against the model actually used.
- The classifier was fed the full prompt body, which in grouped/queued turns includes prior transcript plus `CURRENT_MESSAGE_MARKER` — so "hi" in a long thread always tripped the length threshold and never matched a greeting. It now sees only the current message, via a helper hoisted next to the marker (`stripStructuralPrefixes` already inlined the same slice, so this removed a duplication).
- Every heartbeat was silently downgraded: the default heartbeat prompt classifies as simple, and the old guard only checked inline directives, so `heartbeat.model` was overwritten.
- `describeComplexityReason` was a diverging second copy of the classification rules (hardcoded 500, ignored custom patterns, reported "complex" reasons for simple queries). Both entry points now share one `classify` function.
- `complexPatterns` are validated at config load, so an uncompilable regex is a config error with an exact path instead of being silently skipped on every message. Compiled patterns are cached instead of rebuilt per message, and the pattern sweep is bounded so a large `complexLengthThreshold` cannot make the `.*` patterns quadratic on a big paste.
- Removed a dead `if (length < 100) return "simple"` branch followed by `return "simple"`, and fixed six pre-existing `no-useless-escape` errors in the test file that failed `pnpm check`.
- Budget guide config examples did not validate: `fallback` should be `fallbacks` (three places), and the DeepSeek block used `id`, `apiType: "openai-chat-completions"` and `maxOutputTokens`. Also corrected a "llama3.3 (8B)" tip (it is 70B, pointing 8GB-RAM readers at a 43GB model).

## Testing

- 36 tests in `src/agents/model-tiering.test.ts`, covering classification, alias resolution, allowlist accept/reject, the explicit-model guard, per-agent enable/merge/opt-out, and the scan bound.
- New `src/config/config.model-tiering.test.ts`: schema acceptance global and per-agent, rejection of an uncompilable pattern, rejection of unknown fields.
- New coverage for current-message extraction in `src/auto-reply/reply/mentions.test.ts`.
- 728 tests pass across `src/config`, `src/auto-reply/reply` and the agent-command suites; type-check, oxlint and oxfmt clean.

Changelog entry included. Happy to narrow the changeset if you would rather land the feature and the cleanups separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
