### PR TITLE
fix(tasks): owner-key TaskFlow lookup prefers the newest non-terminal flow

### DIFF
--- a/src/tasks/task-flow-owner-access.test.ts
+++ b/src/tasks/task-flow-owner-access.test.ts
@@ -6,7 +6,10 @@ import {
   listTaskFlowsForOwner,
   resolveTaskFlowForLookupTokenForOwner,
 } from "./task-flow-owner-access.js";
-import { createManagedTaskFlow as createManagedTaskFlowOrNull } from "./task-flow-registry.js";
+import {
+  createManagedTaskFlow as createManagedTaskFlowOrNull,
+  finishFlow,
+} from "./task-flow-registry.js";
 import type { TaskFlowRecord } from "./task-flow-registry.types.js";
 import {
   configureTaskFlowRegistryRuntime,
@@ -21,6 +24,17 @@ function createManagedTaskFlow(
     throw new Error("expected managed TaskFlow creation to succeed");
   }
   return flow;
+}
+
+function requireAppliedFinish(flow: TaskFlowRecord): TaskFlowRecord {
+  const result = finishFlow({
+    flowId: flow.flowId,
+    expectedRevision: flow.revision,
+  });
+  if (!result.applied) {
+    throw new Error(`expected finishFlow to apply, got ${result.reason}`);
+  }
+  return result.flow;
 }
 
 beforeEach(() => {
@@ -110,5 +124,48 @@ describe("task flow owner access", () => {
         callerOwnerKey: "agent:main:other",
       }),
     ).toStrictEqual([]);
+  });
+
+  it("prefers the newest non-terminal flow for owner-key lookups", () => {
+    const running = createManagedTaskFlow({
+      ownerKey: "agent:main:main",
+      controllerId: "tests/owner-access",
+      goal: "Still running flow",
+      status: "running",
+      createdAt: 100,
+      updatedAt: 100,
+    });
+    const newerTerminal = createManagedTaskFlow({
+      ownerKey: "agent:main:main",
+      controllerId: "tests/owner-access",
+      goal: "Newer finished flow",
+      status: "succeeded",
+      createdAt: 200,
+      updatedAt: 200,
+    });
+
+    // The newest flow is terminal, but the older flow is still active, so an
+    // owner-key lookup must resolve to the running flow, not the finished one.
+    expect(
+      resolveTaskFlowForLookupTokenForOwner({
+        token: "agent:main:main",
+        callerOwnerKey: "agent:main:main",
+      })?.flowId,
+    ).toBe(running.flowId);
+    expect(
+      findLatestTaskFlowForOwner({
+        callerOwnerKey: "agent:main:main",
+      })?.flowId,
+    ).toBe(newerTerminal.flowId);
+
+    // When every flow is terminal, the lookup falls back to the newest overall.
+    const finished = requireAppliedFinish(running);
+    expect(
+      resolveTaskFlowForLookupTokenForOwner({
+        token: "agent:main:main",
+        callerOwnerKey: "agent:main:main",
+      })?.flowId,
+    ).toBe(newerTerminal.flowId);
+    expect(finished.flowId).toBe(running.flowId);
   });
 });

--- a/src/tasks/task-flow-owner-access.ts
+++ b/src/tasks/task-flow-owner-access.ts
@@ -1,6 +1,7 @@
 // Checks whether a requester can read or mutate task-flow records.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
+  findLatestActionableTaskFlowForOwnerKey,
   findLatestTaskFlowForOwnerKey,
   getTaskFlowById,
   listTaskFlowsForOwnerKey,
@@ -31,6 +32,19 @@ export function findLatestTaskFlowForOwner(params: {
   return ownerKey ? findLatestTaskFlowForOwnerKey(ownerKey) : undefined;
 }
 
+/**
+ * Resolves the owner-key lookup for `show`/`cancel` to the newest non-terminal
+ * flow the caller owns, falling back to the newest flow overall when every
+ * flow is terminal. Mirrors `findLatestActionableTaskFlowForOwnerKey` under
+ * the caller-owner scope.
+ */
+export function findLatestActionableTaskFlowForOwner(params: {
+  callerOwnerKey: string;
+}): TaskFlowRecord | undefined {
+  const ownerKey = normalizeOptionalString(params.callerOwnerKey);
+  return ownerKey ? findLatestActionableTaskFlowForOwnerKey(ownerKey) : undefined;
+}
+
 export function resolveTaskFlowForLookupTokenForOwner(params: {
   token: string;
   callerOwnerKey: string;
@@ -47,5 +61,5 @@ export function resolveTaskFlowForLookupTokenForOwner(params: {
   if (!normalizedToken || normalizedToken !== normalizedCallerOwnerKey) {
     return undefined;
   }
-  return findLatestTaskFlowForOwner({ callerOwnerKey: normalizedCallerOwnerKey });
+  return findLatestActionableTaskFlowForOwner({ callerOwnerKey: normalizedCallerOwnerKey });
 }

--- a/src/tasks/task-flow-registry.test.ts
+++ b/src/tasks/task-flow-registry.test.ts
@@ -7,10 +7,12 @@ import {
   deleteTaskFlowRecordById,
   getTaskFlowRegistryRestoreFailure,
   failFlow,
+  finishFlow,
   getTaskFlowById,
   listTaskFlowRecords,
   requestFlowCancel,
   reloadTaskFlowRegistryFromStore,
+  resolveTaskFlowForLookupToken,
   resumeFlow,
   setFlowWaiting,
   syncFlowFromTaskResult,
@@ -582,5 +584,55 @@ describe("task-flow-registry", () => {
       expect(resumed.flow.flowId).toBe(created.flowId);
       expect(resumed.flow.stateJson).toBeNull();
     });
+  });
+
+  it("resolves owner-key lookups to the newest non-terminal flow, not a newer terminal one", () => {
+    configureTaskFlowRegistryRuntime({
+      store: {
+        loadSnapshot: () => ({ flows: new Map() }),
+        saveSnapshot: () => {},
+      },
+    });
+
+    const olderRunning = createManagedTaskFlow({
+      ownerKey: "agent:main:main",
+      controllerId: "tests/lookup",
+      goal: "Older running flow",
+      status: "running",
+      createdAt: 100,
+      updatedAt: 100,
+    });
+    const newerTerminal = createManagedTaskFlow({
+      ownerKey: "agent:main:main",
+      controllerId: "tests/lookup",
+      goal: "Newer finished flow",
+      status: "succeeded",
+      createdAt: 200,
+      updatedAt: 200,
+    });
+
+    // Direct flow-id lookup always targets the requested flow.
+    expect(resolveTaskFlowForLookupToken(newerTerminal.flowId)?.flowId).toBe(
+      newerTerminal.flowId,
+    );
+
+    // Owner-key lookup must skip the newer terminal flow and hit the live one.
+    expect(resolveTaskFlowForLookupToken("agent:main:main")?.flowId).toBe(
+      olderRunning.flowId,
+    );
+
+    // When the last non-terminal flow finishes, fall back to the newest overall.
+    const finished = finishFlow({
+      flowId: olderRunning.flowId,
+      expectedRevision: olderRunning.revision,
+      endedAt: 300,
+    });
+    expect(finished.applied).toBe(true);
+    if (!finished.applied) {
+      throw new Error("Expected finish update to apply");
+    }
+    expect(resolveTaskFlowForLookupToken("agent:main:main")?.flowId).toBe(
+      newerTerminal.flowId,
+    );
   });
 });

--- a/src/tasks/task-flow-registry.ts
+++ b/src/tasks/task-flow-registry.ts
@@ -779,12 +779,29 @@ export function findLatestTaskFlowForOwnerKey(ownerKey: string): TaskFlowRecord 
   return flow ? cloneFlowRecord(flow) : undefined;
 }
 
+/**
+ * Resolves an owner-key lookup to the newest non-terminal flow for the owner,
+ * falling back to the newest flow overall only when every flow is terminal.
+ * Owner-key lookups back `show`/`cancel`, which must target a live flow rather
+ * than a finished one; a newer terminal flow must not shadow an older flow
+ * that is still running.
+ */
+export function findLatestActionableTaskFlowForOwnerKey(
+  ownerKey: string,
+): TaskFlowRecord | undefined {
+  const ownerFlows = listTaskFlowsForOwnerKey(ownerKey);
+  const flow =
+    ownerFlows.find((candidate) => !isTerminalTaskFlowStatus(candidate.status)) ??
+    ownerFlows[0];
+  return flow ? cloneFlowRecord(flow) : undefined;
+}
+
 export function resolveTaskFlowForLookupToken(token: string): TaskFlowRecord | undefined {
   const lookup = token.trim();
   if (!lookup) {
     return undefined;
   }
-  return getTaskFlowById(lookup) ?? findLatestTaskFlowForOwnerKey(lookup);
+  return getTaskFlowById(lookup) ?? findLatestActionableTaskFlowForOwnerKey(lookup);
 }
 
 export function listTaskFlowRecords(): TaskFlowRecord[] {


### PR DESCRIPTION
## What Problem

`openclaw tasks flow show <ownerKey>` and `openclaw tasks flow cancel <ownerKey>` resolve owner-key lookups via `resolveTaskFlowForLookupToken` -> `findLatestTaskFlowForOwnerKey`, which sorts the owner's flows by `createdAt` descending and returns `[0]` **without filtering terminal states** (`src/tasks/task-flow-registry.ts`).

When the newest TaskFlow for an owner key is in a terminal state (`succeeded`/`failed`/`cancelled`/`blocked`/`lost`) while an older flow for the same owner is still `running`, the lookup resolves to the finished flow. `flows cancel <ownerKey>` then reports "Flow is already cancelled/succeeded." (exit 1) and never sets `cancelRequestedAt` on the active flow, which keeps consuming resources. `flows show <ownerKey>` prints the finished flow's goal instead of the live flow's.

The same flaw exists on the owner-scoped plugin-runtime path: `resolveTaskFlowForLookupTokenForOwner` (`src/tasks/task-flow-owner-access.ts`) falls back to `findLatestTaskFlowForOwner`, which has identical semantics.

## Why

An owner-key lookup is a "point me at the live flow for this owner" operation. A newer finished flow must not shadow an older flow that is still running, otherwise the two primary owner-key commands (`show`, `cancel`) target a record that can no longer be acted upon, and `cancel` silently fails to stop the resource-consuming active flow. Per the issue: "If the caller means a specific flow, they use the flow id."

## User Impact

- `openclaw tasks flow cancel agent:main:main` now cancels the still-active flow instead of exiting 1 with "Flow is already cancelled/succeeded." - `cancelRequestedAt` is set on the live flow and it stops consuming resources.
- `openclaw tasks flow show agent:main:main` shows the live flow's goal/step, not a stale finished one.
- When every flow for the owner is terminal, the lookup falls back to the newest flow overall (previous behavior), so nothing regresses for the all-finished case.
- Flow-id lookups are untouched: a caller targeting a specific flow by id still gets that exact record.
- Plugin-runtime `findLatest` API semantics are unchanged (still returns the newest flow regardless of status); only the lookup-token resolve paths prefer non-terminal flows.

## Evidence

**Code change** - `src/tasks/task-flow-registry.ts`:

```ts
export function findLatestActionableTaskFlowForOwnerKey(
  ownerKey: string,
): TaskFlowRecord | undefined {
  const ownerFlows = listTaskFlowsForOwnerKey(ownerKey);
  const flow =
    ownerFlows.find((candidate) => !isTerminalTaskFlowStatus(candidate.status)) ??
    ownerFlows[0];
  return flow ? cloneFlowRecord(flow) : undefined;
}

export function resolveTaskFlowForLookupToken(token: string): TaskFlowRecord | undefined {
  const lookup = token.trim();
  if (!lookup) {
    return undefined;
  }
  return getTaskFlowById(lookup) ?? findLatestActionableTaskFlowForOwnerKey(lookup);
}
```

`resolveTaskFlowForLookupTokenForOwner` (`src/tasks/task-flow-owner-access.ts`) now returns `findLatestActionableTaskFlowForOwner(...)`, sharing the same selector under the caller-owner scope. `isTerminalTaskFlowStatus` already exists in the registry (succeeded/blocked/failed/cancelled/lost), so the fix reuses the established terminal-state definition.

**Inline verification (vitest, run locally)**:

- `src/tasks/task-flow-registry.test.ts` - new test "resolves owner-key lookups to the newest non-terminal flow, not a newer terminal one": creates an older `running` flow + newer `succeeded` flow for the same owner key, asserts `resolveTaskFlowForLookupToken("agent:main:main")` returns the running flow's id, direct flow-id lookup still targets the newer terminal flow, and after the running flow finishes the lookup falls back to the newest overall. Passed.
- `src/tasks/task-flow-owner-access.test.ts` - new test "prefers the newest non-terminal flow for owner-key lookups": same scenario through `resolveTaskFlowForLookupTokenForOwner`, also asserting `findLatestTaskFlowForOwner` still returns the newest overall flow (unchanged `findLatest` semantics). Passed (3/3 tests in file).
- `oxlint` on all four changed files: 0 errors, 0 warnings.
- `tsc --noEmit` scoped to the four changed files: no errors in the changed files (only pre-existing `src/media/qr-runtime.ts` `@types/qrcode` noise from the shared tsconfig, untouched by this change).

**Environment note**: the full `task-flow-registry.test.ts` file has 4 pre-existing failures on this machine caused by Node 24.13.1 embedding SQLite 3.51.2 (repo requires 3.51.3+ for WAL safety; these tests open a real SQLite store). The new tests use the in-memory store and pass; the pre-existing SQLite-guard failures are unrelated to this change.

Fixes #119129

[AI-assisted]
