### PR TITLE
fix(sandbox): resolve the configured agent workspace when workspaceDir is omitted (#89743)

### DIFF
--- a/src/agents/sandbox.resolveSandboxContext.test.ts
+++ b/src/agents/sandbox.resolveSandboxContext.test.ts
@@ -121,6 +121,32 @@ describe("resolveSandboxContext", () => {
     expect(result).toBeNull();
   }, 15_000);
 
+  it("resolves the configured agent workspace when workspaceDir is omitted (#89743)", async () => {
+    const configuredWorkspaceDir = await createSandboxFixtureDir("configured-default-workspace");
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          workspace: configuredWorkspaceDir,
+          sandbox: { mode: "all", scope: "session", workspaceAccess: "ro" },
+        },
+        list: [{ id: "main" }],
+      },
+    };
+
+    syncSkillsToWorkspaceMock.mockClear();
+    const result = await ensureSandboxWorkspaceForSession({
+      config: cfg,
+      sessionKey: "agent:main:main",
+      // workspaceDir deliberately omitted: the configured agents.defaults.workspace
+      // must be used, not the hardcoded DEFAULT_AGENT_WORKSPACE_DIR fallback.
+    });
+
+    expect(syncSkillsToWorkspaceMock).toHaveBeenCalledWith(
+      expect.objectContaining({ sourceWorkspaceDir: configuredWorkspaceDir }),
+    );
+    expect(result).not.toBeNull();
+  }, 15_000);
+
   it("does not touch sandbox backends for cron or sub-agent sessions when sandbox mode is off", async () => {
     // Mode=off should short-circuit before resolving any backend implementation.
     const backendFactory = vi.fn(async () => ({

--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -92,7 +92,7 @@ async function ensureSandboxWorkspaceLayout(params: {
   workspaceDir: string;
 }> {
   const { cfg, rawSessionKey } = params;
-  // #89743: when the caller omits workspaceDir, resolve the agent's configured
+  // When the caller omits workspaceDir, resolve the agent's configured
   // workspace instead of silently falling back to the process-default path in
   // resolveSandboxWorkspaceLayoutPaths (shared.ts). This keeps skills reads and
   // the sandbox scope key tied to the operator's configured workspace.

--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -15,6 +15,7 @@ import {
 } from "../../plugin-sdk/browser-profiles.js";
 import { defaultRuntime } from "../../runtime.js";
 import type { SkillEligibilityContext, SkillUsagePath } from "../../skills/types.js";
+import { resolveAgentWorkspaceDir } from "../agent-scope-config.js";
 import type { ExecPolicyOverrides } from "../exec-defaults.js";
 import { getSandboxBackendWorkdirResolver, requireSandboxBackendFactory } from "./backend.js";
 import { ensureSandboxBrowser } from "./browser.js";
@@ -91,11 +92,17 @@ async function ensureSandboxWorkspaceLayout(params: {
   workspaceDir: string;
 }> {
   const { cfg, rawSessionKey } = params;
+  // #89743: when the caller omits workspaceDir, resolve the agent's configured
+  // workspace instead of silently falling back to the process-default path in
+  // resolveSandboxWorkspaceLayoutPaths (shared.ts). This keeps skills reads and
+  // the sandbox scope key tied to the operator's configured workspace.
+  const resolvedWorkspaceDir =
+    params.workspaceDir?.trim() || resolveAgentWorkspaceDir(params.config ?? {}, params.agentId);
   const { agentWorkspaceDir, sandboxWorkspaceDir, scopeKey, skillsWorkspaceDir, workspaceDir } =
     resolveSandboxWorkspaceLayoutPaths({
       cfg,
       rawSessionKey,
-      workspaceDir: params.workspaceDir,
+      workspaceDir: resolvedWorkspaceDir,
     });
 
   let syncedSkills: Awaited<ReturnType<typeof syncSandboxSkillsToWorkspace>>;


### PR DESCRIPTION
## What Problem This Solves

When a sandboxed session is set up without an explicit `workspaceDir`, the sandbox layout resolver falls back to the process-default `~/.openclaw/workspace` (`DEFAULT_AGENT_WORKSPACE_DIR`) instead of the operator-configured `agents.defaults.workspace` (or a per-agent `workspace`). Skills are then read from the wrong directory and the sandbox scope key is keyed to the wrong workspace.

Fixes #89743

## Why This Change Was Made

`resolveSandboxWorkspaceLayoutPaths` (`src/agents/sandbox/shared.ts`) receives only the sandbox `cfg` — it has no `config`/`agentId` to resolve a configured workspace from, so it substitutes `params.workspaceDir?.trim() || DEFAULT_AGENT_WORKSPACE_DIR`. The resolution belongs at the sandbox context owner (`ensureSandboxWorkspaceLayout` in `src/agents/sandbox/context.ts`), which has both `config` and `agentId`: it now calls `resolveAgentWorkspaceDir(config, agentId)` when `workspaceDir` is omitted or blank, then passes the resolved path into the layout resolver. Both public entries (`resolveSandboxContext`, `ensureSandboxWorkspaceForSession`) route through this one function, so one fix covers the whole sandbox boundary. Explicit-`workspaceDir` callers are unchanged, and configless callers fall through to the same default path as before.

## User Impact

- **Before:** configuring `agents.defaults.workspace` (or a per-agent `workspace`) had no effect on sandboxed sessions that omitted `workspaceDir` — skills loaded from `~/.openclaw/workspace` and the scope key ignored the configured path.
- **After:** the configured agent workspace is used, so skills reads and sandbox scope follow the operator's workspace configuration.

## Evidence

**Repro (regression test, fails on main, passes after fix):**

```
node scripts/run-vitest.mjs src/agents/sandbox.resolveSandboxContext.test.ts -t "resolves the configured agent workspace when workspaceDir is omitted"
# main: FAILED — syncSkillsToWorkspace received sourceWorkspaceDir=/tmp/.../.openclaw/workspace (hardcoded default) instead of the configured fixture dir
# after: passed
```

**Full suites (trusted source, local checkout):**

```
node scripts/run-vitest.mjs src/agents/sandbox.resolveSandboxContext.test.ts
# 18 passed

node scripts/run-vitest.mjs src/agents/sandbox/shared.test.ts
# 5 passed (explicit-workspace semantics unchanged)
```

**Real configured-sandbox transcript (unmocked `syncSkillsToWorkspace` on a real workspace):**

```
PROOF_119138 workspaceDir: /tmp/openclaw-proof-119138-.../configured-ws-0
PROOF_119138 matchesConfigured: true
PROOF_119138 skillUsagePaths: 18
```

The real `ensureSandboxWorkspaceForSession` runs with `syncSkillsToWorkspace` **not mocked** — the real skill-sync boundary executes against a configured workspace containing a real `SKILL.md`. The resolved `workspaceDir` matches the configured `agents.defaults.workspace`, and 18 skill usage paths are returned from the real sync. Only sandbox backend/browser/docker mocks remain (those require full plugin runtime).

**Boundary:** 2 files, production +2 net (`src/agents/sandbox/context.ts`: one import + one resolved-variable line). No config/schema/plugin-boundary change; explicit `workspaceDir` callers see zero behavior change.

**Pre-existing unrelated:** `tsgo` on `tsconfig.core.json` reports 1 pre-existing error in `packages/terminal-core/src/ansi.ts:194` (verified present on `origin/main`); unrelated to this PR.