### PR TITLE
test(qa): restore memory tools primary ownership

### DIFF
--- a/qa/scenarios/memory/memory-tools-channel-context.yaml
+++ b/qa/scenarios/memory/memory-tools-channel-context.yaml
@@ -6,9 +6,9 @@ scenario:
   coverage:
     primary:
       - session-memory.group-memory
+      - session-memory.memory-tools
       - session-memory.qa-channel-memory
     secondary:
-      - session-memory.memory-tools
       - channels.room-session-group-messages
   objective: Verify a shared QA-channel message causally recalls a fact from a nested memory file before the agent replies in the same room.
   successCriteria:


### PR DESCRIPTION
Related: #119111

## What Problem This Solves

Fixes an issue where QA maturity profiles selecting `session-memory.memory-tools` had no primary scenario owner after #119111 moved that coverage ID to secondary evidence.

## Why This Change Was Made

Restores `session-memory.memory-tools` as primary coverage in the existing `memory-tools-channel-context` scenario while preserving the new shared-channel primary claims. This is an ownership-only metadata correction with no scenario behavior or production-code change.

## User Impact

QA profile selection and scorecard validation can again treat the existing memory search/get flow as executable primary proof for the generic memory-tools boundary. Runtime behavior is unchanged.

## Evidence

- Structured inventory scan: exactly one primary owner and zero secondary owners for `session-memory.memory-tools`.
- Focused QA tests: `42/42` passed across `coverage-report.test.ts`, `ci-smoke-plan.test.ts`, and `scenario-catalog-channels.test.ts`.
- Exact current-base mock QA: `memory-tools-channel-context` passed `1/1` on AWS Crabbox run `run_743e1de8e436`.
- Full changed gate: AWS Crabbox run `run_e5a3da87ff77` passed full `tsgo`, lint, and zero runtime import cycles on the patch-equivalent pre-rebase tree. The later rebase had zero upstream drift in the touched scenario.
- Fresh Sol/high autoreview: clean, confidence `0.99`; TruffleHog clean.
- `oxfmt --check`, `git diff --check`, and added-line privacy scan passed.
- Scope: one YAML file, `+1/-1`; production LOC delta `0`.