### PR TITLE
fix(scripts): bound gh-read gh CLI child process

### DIFF
--- a/scripts/gh-read.ts
+++ b/scripts/gh-read.ts
@@ -20,6 +20,7 @@ const INSTALLATION_ID_ENV = "OPENCLAW_GH_READ_INSTALLATION_ID";
 const PERMISSIONS_ENV = "OPENCLAW_GH_READ_PERMISSIONS";
 const API_VERSION = "2022-11-28";
 const DEFAULT_GITHUB_FETCH_TIMEOUT_MS = 30_000;
+const DEFAULT_GH_CHILD_TIMEOUT_MS = 300_000;
 const GITHUB_ERROR_BODY_MAX_CHARS = 4096;
 const GITHUB_JSON_BODY_MAX_BYTES = 1024 * 1024;
 const GITHUB_APP_PRIVATE_KEY_MAX_BYTES = 64 * 1024;
@@ -103,6 +104,15 @@ export function resolveGitHubFetchTimeoutMs(raw = process.env.OPENCLAW_GH_READ_F
   return parseStrictIntegerOption({
     fallback: DEFAULT_GITHUB_FETCH_TIMEOUT_MS,
     label: "OPENCLAW_GH_READ_FETCH_TIMEOUT_MS",
+    min: 1,
+    raw,
+  });
+}
+
+export function resolveGhChildTimeoutMs(raw = process.env.OPENCLAW_GH_READ_TIMEOUT_MS) {
+  return parseStrictIntegerOption({
+    fallback: DEFAULT_GH_CHILD_TIMEOUT_MS,
+    label: "OPENCLAW_GH_READ_TIMEOUT_MS",
     min: 1,
     raw,
   });
@@ -376,8 +386,11 @@ async function main() {
   const appJwt = createAppJwt(appId, privateKeyPem);
   const installation = await resolveInstallation(appJwt, repo);
   const token = await createInstallationToken(appJwt, installation, repo);
+  const ghChildTimeoutMs = resolveGhChildTimeoutMs();
   const child = spawnSync("gh", ghArgs, {
     stdio: "inherit",
+    timeout: ghChildTimeoutMs,
+    killSignal: "SIGKILL",
     env: {
       ...process.env,
       GH_TOKEN: token,
@@ -386,7 +399,12 @@ async function main() {
   });
 
   if (child.error) {
-    fail(child.error.message);
+    const errorCode = (child.error as NodeJS.ErrnoException).code;
+    fail(
+      errorCode === "ETIMEDOUT"
+        ? `gh child process exceeded timeout of ${ghChildTimeoutMs}ms`
+        : child.error.message,
+    );
   }
 
   process.exit(child.status ?? 1);

--- a/test/scripts/gh-read.test.ts
+++ b/test/scripts/gh-read.test.ts
@@ -13,6 +13,7 @@ import {
   readGitHubAppPrivateKey,
   readBoundedGitHubErrorText,
   readBoundedGitHubJson,
+  resolveGhChildTimeoutMs,
   resolveGitHubFetchTimeoutMs,
 } from "../../scripts/gh-read.js";
 
@@ -244,6 +245,14 @@ describe("gh-read helpers", () => {
     expect(resolveGitHubFetchTimeoutMs("1000")).toBe(1000);
     expect(() => resolveGitHubFetchTimeoutMs("1s")).toThrow(
       /OPENCLAW_GH_READ_FETCH_TIMEOUT_MS must be an integer/u,
+    );
+  });
+
+  it("bounds the gh child process with a configurable timeout", () => {
+    expect(resolveGhChildTimeoutMs(undefined)).toBe(300_000);
+    expect(resolveGhChildTimeoutMs("1000")).toBe(1000);
+    expect(() => resolveGhChildTimeoutMs("1s")).toThrow(
+      /OPENCLAW_GH_READ_TIMEOUT_MS must be an integer/u,
     );
   });
 });


### PR DESCRIPTION
## Summary

`fix(scripts): bound the gh-read gh CLI child process with a configurable timeout so a stalled gh invocation cannot hang CI jobs indefinitely`

## What Problem This Solves

`scripts/gh-read.ts` mints a GitHub App installation token and hands off to the `gh` CLI via `spawnSync`. Repository automation and CI jobs call it for read-only `gh` operations. When the spawned `gh` process stalls — wedged TLS connection, hung API response, or a credential prompt blocking on the inherited stdio — the wrapper waits **forever**. There is no timeout, no kill, and no diagnostic; the calling job burns its entire job-level timeout (often 30+ minutes) and fails with no indication that a `gh` child was the culprit.

Blast radius: every CI/automation lane that routes `gh` calls through `gh-read`; any transient network stall on GitHub's side turns into a full job-timeout failure instead of a fast, diagnosable error.

**代码证据**: at `scripts/gh-read.ts:379` (main), the child is spawned unbounded:

```ts
const child = spawnSync("gh", ghArgs, {
  stdio: "inherit",
  env: { ...process.env, GH_TOKEN: token, GITHUB_TOKEN: token },
});
```

No `timeout`, no `killSignal` — while every `fetch` the same file makes is bounded by `DEFAULT_GITHUB_FETCH_TIMEOUT_MS = 30_000` via `withGitHubFetchTimeout()` (`scripts/gh-read.ts:22`, `:167`). The one operation the file exists to perform is the only one left unbounded.

Minimal reproduction: replace `gh` on PATH with a process that sleeps 60s and run the script — see Real Behavior Proof below.

## Root Cause

- Bug introduced by commit `d51f527cca` (2026-04-07, `feat: add gh-read GitHub app helper`): the unbounded `spawnSync("gh", ...)` has been there since the file was created. Commit `5fb57b533e` (2026-05-27, `fix(dev): bound gh-read API waits`) later added timeouts to every API fetch but left the final child unbounded.
- Violated invariant: the file assumes every blocking operation it performs is time-bounded (that is the entire point of `withGitHubFetchTimeout`). The assumption breaks at the last step: control is handed to an arbitrary external process with no deadline.
- Trigger condition: any `gh` invocation that stalls after the token is minted — e.g. a hung TLS session to api.github.com, a `gh` credential helper prompting on the inherited TTY, or a `gh api --paginate` run against an unresponsive endpoint.

## Why This Fix

- Option A: rely on outer job-level timeouts — rejected: failures take 30+ minutes to surface, produce no diagnostic, and waste runner capacity.
- Option B: wrap `gh-read` in an external watchdog/supervisor script — rejected: adds moving parts outside the script and doesn't match how this repo bounds child processes.
- Option C (chosen): pass `timeout` + `killSignal: "SIGKILL"` directly to `spawnSync`, with a `OPENCLAW_GH_READ_TIMEOUT_MS` env override parsed through the existing `parseStrictIntegerOption` helper — exactly the convention already used by `scripts/check-dependency-pins.mjs`, `scripts/check-file-utils.ts`, and `scripts/lib/npm-verify-exec.ts`, and it mirrors the file's own `resolveGitHubFetchTimeoutMs` pattern.
- Why 300s default instead of the fetch timeout's 30s: `gh api --paginate` and large `gh pr checks` outputs can legitimately run for minutes; the goal is bounding hangs, not tuning latency. 5 minutes is generous for real work, finite for CI.

## User Impact

- Affected operations: CI lanes and repo automation that invoke `scripts/gh-read` for read-only `gh` calls (rate-limit checks, PR metadata reads).
- Before: a stalled `gh` child hangs the job until the outer job-level timeout kills it; logs show nothing between token minting and the kill.
- After: the job fails fast with `gh-read: gh child process exceeded timeout of <N>ms` (default 300000, overridable via `OPENCLAW_GH_READ_TIMEOUT_MS`), and the stalled child is SIGKILLed instead of leaking.
- Behavior change: a `gh` command running longer than the bound now fails instead of running forever. This is strictly better for automation; interactive or unusually long runs can raise the env override.

## Real Behavior Proof

Setup: the **real** `scripts/gh-read.ts` executed end-to-end (`node --import tsx scripts/gh-read.ts ...`) with a generated RSA App key; only GitHub API network responses are stubbed (offline runner) — argument parsing, JWT signing, installation-token flow, and the `spawnSync("gh", ...)` call under test all execute for real. `gh` on PATH is replaced with a process that stalls for 60 seconds.

### Before (on main)

```bash
$ timeout 8 node --import tsx --import ../_tmp/stub-github-fetch.mjs \
    scripts/gh-read.ts -NoProfile -Command "Start-Sleep 60"
--- start: 09:57:41 ---
--- end: 09:57:50 exit=124   # FAIL: still hung after 8s; killed by the outer watchdog
```

The stalled `gh` child holds the script forever; nothing is printed and nothing exits.

### After (with fix)

```bash
$ OPENCLAW_GH_READ_TIMEOUT_MS=2000 time node --import tsx \
    --import ../_tmp/stub-github-fetch.mjs \
    scripts/gh-read.ts -NoProfile -Command "Start-Sleep 60"
gh-read: gh child process exceeded timeout of 2000ms

real    0m5.426s   # ~2s of stall + startup; clean exit code 1
--- end: 09:58:13 exit=1 ---
```

The same stalled child is SIGKILLed at the configured bound and the failure is reported with a clear diagnostic.

## Tests and Validation

- `node node_modules/vitest/vitest.mjs run test/scripts/gh-read.test.ts` — 16 passed (15 existing + 1 new covering the timeout resolver: default value, env override, invalid-value rejection)
- `node_modules/.bin/tsgo --noEmit -p tsconfig.scripts.json` — passed
- Manual verification (the proof above):
  1. On main, a stalled `gh` child hangs `gh-read` indefinitely (killed externally at 8s, exit 124).
  2. With the fix, the same stall terminates at `OPENCLAW_GH_READ_TIMEOUT_MS` with `gh-read: gh child process exceeded timeout of 2000ms`, exit 1.
