### PR TITLE
fix(auth): limit inline key cooldowns to credential failures

### DIFF
--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -15,6 +15,7 @@ import {
   isProfileInCooldown,
   markAuthProfileBlockedUntil,
   markAuthProfileFailure,
+  markInlineProviderApiKeyFailure,
   maybeReprobeWhamBlockedProfiles,
   resolveProfilesUnavailableReason,
   resolveProfileUnusableUntilForDisplay,
@@ -1163,6 +1164,21 @@ describe("markAuthProfileFailure — locked update failure", () => {
       }
       consoleWarn.mockRestore();
     }
+  });
+});
+
+describe("markInlineProviderApiKeyFailure", () => {
+  it("does not cool an inline key after a provider timeout", async () => {
+    const store = makeStore(undefined);
+
+    await markInlineProviderApiKeyFailure({
+      store,
+      provider: "anthropic",
+      reason: "timeout",
+    });
+
+    expect(store.usageStats).toBeUndefined();
+    expect(storeMocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
   });
 });
 

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -1150,7 +1150,10 @@ export async function markInlineProviderApiKeyFailure(params: {
   modelId?: string;
 }): Promise<void> {
   const { store, provider, reason, agentDir, runId, modelId } = params;
-  if (isAuthCooldownBypassedForProvider(provider)) {
+  if (
+    (reason !== "auth" && reason !== "auth_permanent" && reason !== "billing") ||
+    isAuthCooldownBypassedForProvider(provider)
+  ) {
     return;
   }
 


### PR DESCRIPTION
## Summary

### High Level TLDR

A transient provider timeout could disable a configured inline API key for every later session, even though inline-key cooldowns are intended only for credential auth and billing failures. Restrict the inline-key cooldown producer to those credential failures so unrelated sessions remain usable after transient provider faults.

This is deliberately scoped to inline keys. Stored auth profiles keep their existing timeout and failover accounting.

## Root Cause

Commit `196d81195bf` added provider-scoped cooldown persistence for inline API keys. Its controller and resolver describe that state as an auth/billing cooldown, but `markInlineProviderApiKeyFailure` accepted the full `AuthProfileFailureReason` union.

In the failing artifact, a provider-started status-only HTTP 503 followed the stock path below:

1. The provider error classifier mapped the 503 to `timeout`.
2. The failover controller passed that reason to the inline-key marker.
3. The marker persisted `inline-api-key:qa-mock` with a cooldown.
4. The resolver rejected later independent sessions before provider ingress with `Inline API key ... temporarily disabled after a provider auth/billing failure`.

The captured no-auto-retry and mutation/compaction scenarios therefore had no provider wire records and never planned or executed their mutation tools. A pre-regression baseline produced each expected mutation file exactly once and completed manual compaction.

Stock counterfactual: stock OpenClaw on the affected code reaches the same failure with an ordinary configured inline provider API key when a provider-started 503 precedes another session. The Nightly wrapper makes that request ordering deterministic but is not in the classifier, cooldown producer, or resolver path. `openclaw update`, update finalization, and doctor are not involved and do not own this per-run provider state.

## Verification

- `node scripts/run-vitest.mjs src/agents/auth-profiles/usage.test.ts -t 'does not cool an inline key after a provider timeout'`
  - `Test Files 2 passed (2)`
  - `Tests 2 passed | 196 skipped (198)`
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.incomplete-turn.test.ts -t 'continues from settled side-effecting tools after an empty stop without replaying them'`
  - matched lifecycle variants passed
- `node scripts/run-vitest.mjs src/gateway/server.sessions.compaction.test.ts -t 'sessions.compact without maxLines runs embedded manual compaction for checkpoint-capable flows'`
  - `Test Files 1 passed (1)`
  - `Tests 1 passed | 23 skipped (24)`
- `oxfmt --check src/agents/auth-profiles/usage.ts src/agents/auth-profiles/usage.test.ts`
  - `All matched files use the correct format.`
- `git diff --check origin/main...HEAD`
  - clean
- `.agents/skills/autoreview/scripts/autoreview --mode local`
  - `autoreview clean: no accepted/actionable findings reported`
  - `overall: patch is correct (0.99)`

The focused tests used the existing trusted normal-checkout dependencies after remote proof backends failed preflight before source execution: Testbox was not authenticated, Proxmox had no template ID, and AWS had no configured broker.

## Real behavior proof

**Behavior fixed:** a transient provider timeout no longer writes or locks inline-key auth state; auth, permanent-auth, and billing failures continue to use the accepted provider-scoped cooldown.

**Closest feasible environment:** the captured packaged Gateway run supplied the before behavior, and the focused regression invoked the production cooldown owner with the same `timeout` reason after the patch.

**Exact after-patch result:**

```text
Test Files  2 passed (2)
     Tests  2 passed | 196 skipped (198)
```

The regression also asserts that `usageStats` remains absent and the locked auth-store updater is never called, proving the transient reason is stopped at the authoritative producer boundary.

Production delta is `+4/-1`; tests are `+16/-0`. No retry, replay, compaction, provider classifier, config, schema, or resolver behavior was changed.

## What was not tested

- The frozen Nightly suite was not rerun end-to-end.
- No live paid provider was forced to return a post-tool 503.
- Full repository tests and builds were not run; the change does not touch build, packaging, or published surfaces.

<!-- ocqa: origin=pipeline; sig=330bdc659ec0; tests=mutation-exactly-once-under-retry-and-compaction,no-auto-retry-after-mutating-tool; run=2026-08-04-8393b37779d9-a1 -->
