### PR TITLE
test(channels): verify built sanitizer semantics

### DIFF
--- a/src/channels/plugins/contracts/plugin-shape.contract.test.ts
+++ b/src/channels/plugins/contracts/plugin-shape.contract.test.ts
@@ -1,3 +1,4 @@
+import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 // Plugin-shape coherence contract for bundled channel plugins.
 //
 // Catalog routing keys off plugin ids, docs surfaces render `meta.docsPath`,
@@ -14,21 +15,12 @@
 //   slash commands through gateway HTTP routes).
 // - blockStreaming=true does not imply a streaming adapter (coalesce tuning
 //   is optional).
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { listBundledPackageChannelMetadata } from "../../../plugins/bundled-package-channel-metadata.js";
 import {
   getBundledChannelPluginAsync,
   listBundledChannelPluginIds,
 } from "./test-helpers/bundled-channel-plugin-loader.js";
-
-const sanitizeAssistantVisibleTextMock = vi.hoisted(() =>
-  vi.fn((text: string) => `shared-sanitizer:${text}`),
-);
-
-vi.mock("openclaw/plugin-sdk/text-chunking", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/text-chunking")>();
-  return { ...actual, sanitizeAssistantVisibleText: sanitizeAssistantVisibleTextMock };
-});
 
 const CHAT_TYPES = new Set(["direct", "group", "channel", "thread"]);
 const bundledChannelPluginIds = listBundledChannelPluginIds();
@@ -60,18 +52,25 @@ describe("bundled channel plugin shape coherence", () => {
   });
 
   it.each(SHARED_SANITIZER_CHANNEL_IDS)(
-    "%s wires outbound sanitizeText through the shared sanitizer",
+    "%s applies shared sanitizer semantics to outbound text",
     (id) => {
       const sanitizeText = plugins.get(id)?.outbound?.sanitizeText;
       if (!sanitizeText) {
         throw new Error(`Missing outbound sanitizeText hook for ${id}`);
       }
-      const text = `visible:${id}`;
+      const visible = `Visible answer: ${id}`;
+      const text = [
+        '<invoke name="read">payload</invoke></minimax:tool_call>',
+        '<tool_result>{"output":"hidden"}</tool_result>',
+        "[Tool Call: read (ID: toolu_1)]",
+        'Arguments: {"path":"/tmp/x"}',
+        "<think>secret</think>",
+        visible,
+      ].join("\n");
+      const expected = sanitizeAssistantVisibleText(text);
 
-      sanitizeAssistantVisibleTextMock.mockClear();
-
-      expect(sanitizeText({ text, payload: { text } })).toBe(`shared-sanitizer:${text}`);
-      expect(sanitizeAssistantVisibleTextMock).toHaveBeenCalledExactlyOnceWith(text);
+      expect(expected).toBe(visible);
+      expect(sanitizeText({ text, payload: { text } })).toBe(expected);
     },
   );
 


### PR DESCRIPTION
## Summary

- replace the bundled-channel sanitizer contract's cross-module mock with the real shared sanitizer semantics
- keep the assertion meaningful by using internal scaffolding that must collapse to one visible answer
- make the contract identical for source surfaces and generated `dist` public artifacts

Fixes #119145.

## Root cause

The contract mocked the source `openclaw/plugin-sdk/text-chunking` module. After `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build`, five channel public surfaces loaded compiled `dist/plugin-sdk/text-chunking.js` instead, so the mock could not intercept them. The test therefore failed according to artifact resolution rather than shipped sanitizer behavior.

## Proof

- before: source-only contract passed 144/144; the same head after a private-QA build failed 5 sanitizer assertions
- `node scripts/run-vitest.mjs src/channels/plugins/contracts/plugin-shape.contract.test.ts` — 144/144 passed
- Blacksmith Testbox private-QA build — passed
- built-artifact contract on Testbox — 144/144 passed
- `pnpm check:changed` on Testbox — passed (typecheck, lint, import-cycle and guard lanes)
- AutoReview, branch against `origin/main` — clean, no accepted/actionable findings
- production LOC delta: 0; test diff: +15/-16
- public model identifier gate: PASS; the diff contains no model identifiers

Risk is low and test-only. No changelog entry is needed.
