### PR TITLE
test(telegram): cover reply and selected-quote inbound contracts

### DIFF
--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -4163,6 +4163,8 @@ describe("createTelegramBot", () => {
     expect(payload.ReplyToId).toBe("9001");
     expect(payload.ReplyToBody).toBe("summarize this");
     expect(payload.ReplyToSender).toBe("Ada");
+    expect(payload.ReplyToIsQuote).toBe(true);
+    expect(payload.BodyForAgent).toBe("Sure, see below");
     const telegramPayload = payload as Record<string, unknown>;
     expect(telegramPayload.ReplyToQuoteText).toBe(" summarize this\n");
     expect(telegramPayload.ReplyToQuotePosition).toBe(8);
@@ -5343,6 +5345,11 @@ describe("createTelegramBot", () => {
     expect(replySpy).toHaveBeenCalledTimes(1);
     const payload = mockMsgContextArg(replySpy as unknown as MockCallSource, 0, 0, "replySpy call");
     expect(payload.WasMentioned).toBe(true);
+    expect(payload.BodyForAgent).toBe("following up");
+    expect(payload.ReplyToId).toBe("42");
+    expect(payload.ReplyToBody).toBe("original reply");
+    expect(payload.ReplyToSender).toBe("openclaw_bot (you)");
+    expect(payload.ReplyToIsQuote).toBeUndefined();
   });
 
   it("prefers topic allowFrom over group allowFrom", async () => {


### PR DESCRIPTION
## Summary

- add seven assertions to the existing Telegram bot tests for ordinary replies and selected quotes
- prove reply and quote facts remain structured while `BodyForAgent` contains only the current message
- cover the replied-message ID, body and sender, plus the selected-quote flag alongside the existing quote text and position assertions

This is a test-only companion to #90745 and #88032. It does not duplicate the runtime implementation in #90745; it adds regression coverage at the Telegram ingress boundary.

## Current diff

- `extensions/telegram/src/bot.test.ts`: 7 assertions added
- no production code changes

The selected-quote fixture now explicitly asserts `ReplyToIsQuote === true` and that `BodyForAgent` remains the new message. The ordinary-reply fixture asserts `BodyForAgent`, `ReplyToId`, `ReplyToBody`, and `ReplyToSender`, while leaving `ReplyToIsQuote` unset.

## Validation

The assertions live in the current consolidated test file. The focused validation commands are:

- `pnpm exec vitest run extensions/telegram/src/bot.test.ts`
- `pnpm exec oxfmt --check extensions/telegram/src/bot.test.ts`
- `pnpm exec oxlint extensions/telegram/src/bot.test.ts`
- `git diff --check`

When the contribution was prepared, the focused Telegram contract tests passed on then-current `main` and after applying the assertions to exact #90745 head `d225b53a4cac058fd5be66ee218af9b6b7b13dfc`.

## Redacted live-behaviour proof

A Telegram direct-message smoke on OpenClaw 2026.7.1 confirmed both paths before the obsolete local compatibility patch was retired:

```text
ordinary reply
  BodyForAgent: <new message only>
  reply context: <prior message id, body, sender>
  selected-quote flag: absent

selected quote
  BodyForAgent: <new message only>
  reply context: <replied message id, body, sender>
  selected-quote context: <quote text and source position>
  selected-quote flag: true
```

Message contents and account identifiers are redacted; the field separation shown above is the behaviour these assertions preserve.

Related: #88032  
Companion: #90745

AI-assisted; reviewed and validated before submission.
