### PR TITLE
fix(bedrock): requests respect model output limit when reasoning is off

### DIFF
--- a/extensions/amazon-bedrock/stream.runtime.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.test.ts
@@ -526,7 +526,7 @@ describe("Bedrock thinking request composition", () => {
           thinkingLevelMap: { xhigh: "xhigh", max: "max" },
         }),
       reasoning: "off" as const,
-      expectedMaxTokens: undefined,
+      expectedMaxTokens: 128_000,
       expectedEffort: undefined,
     },
     {
@@ -607,20 +607,58 @@ describe("Bedrock thinking request composition", () => {
       modelMaxTokens: 128_000,
       requestedMaxTokens: undefined,
       expected: 128_000,
+      reasoning: "high" as const,
     },
     {
       name: "fallback model cap",
       modelMaxTokens: 4096,
       requestedMaxTokens: undefined,
       expected: undefined,
+      reasoning: "high" as const,
     },
     {
       name: "explicit request cap",
       modelMaxTokens: 128_000,
       requestedMaxTokens: 32_000,
       expected: 32_000,
+      reasoning: "high" as const,
     },
-  ])("uses the $name for adaptive thinking", async (testCase) => {
+    {
+      name: "native model cap with thinking disabled",
+      modelMaxTokens: 128_000,
+      requestedMaxTokens: undefined,
+      expected: 128_000,
+      reasoning: "off" as const,
+    },
+    {
+      name: "fallback model cap with thinking disabled",
+      modelMaxTokens: 4096,
+      requestedMaxTokens: undefined,
+      expected: undefined,
+      reasoning: "off" as const,
+    },
+    {
+      name: "medium fallback model cap with thinking disabled",
+      modelMaxTokens: 8192,
+      requestedMaxTokens: undefined,
+      expected: undefined,
+      reasoning: "off" as const,
+    },
+    {
+      name: "large fallback model cap with thinking disabled",
+      modelMaxTokens: 16_384,
+      requestedMaxTokens: undefined,
+      expected: undefined,
+      reasoning: "off" as const,
+    },
+    {
+      name: "explicit request cap with thinking disabled",
+      modelMaxTokens: 128_000,
+      requestedMaxTokens: 4096,
+      expected: 4096,
+      reasoning: "off" as const,
+    },
+  ])("uses the $name for adaptive-capable models", async (testCase) => {
     const input = await captureCommandInput(
       bedrockModel({
         id: "us.anthropic.claude-opus-4-8",
@@ -630,7 +668,7 @@ describe("Bedrock thinking request composition", () => {
       }),
       context,
       {
-        reasoning: "high",
+        reasoning: testCase.reasoning,
         ...(testCase.requestedMaxTokens === undefined
           ? {}
           : { maxTokens: testCase.requestedMaxTokens }),
@@ -640,10 +678,14 @@ describe("Bedrock thinking request composition", () => {
     expect(input.inferenceConfig).toEqual(
       testCase.expected === undefined ? {} : { maxTokens: testCase.expected },
     );
-    expect(input.additionalModelRequestFields).toEqual({
-      thinking: { type: "adaptive", display: "summarized" },
-      output_config: { effort: "high" },
-    });
+    expect(input.additionalModelRequestFields).toEqual(
+      testCase.reasoning === "off"
+        ? undefined
+        : {
+            thinking: { type: "adaptive", display: "summarized" },
+            output_config: { effort: "high" },
+          },
+    );
   });
 
   it.each([

--- a/extensions/amazon-bedrock/stream.runtime.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.test.ts
@@ -631,11 +631,25 @@ describe("Bedrock thinking request composition", () => {
       reasoning: "off" as const,
     },
     {
+      name: "native model cap with default thinking",
+      modelMaxTokens: 128_000,
+      requestedMaxTokens: undefined,
+      expected: 128_000,
+      reasoning: undefined,
+    },
+    {
       name: "fallback model cap with thinking disabled",
       modelMaxTokens: 4096,
       requestedMaxTokens: undefined,
       expected: undefined,
       reasoning: "off" as const,
+    },
+    {
+      name: "fallback model cap with default thinking",
+      modelMaxTokens: 4096,
+      requestedMaxTokens: undefined,
+      expected: undefined,
+      reasoning: undefined,
     },
     {
       name: "medium fallback model cap with thinking disabled",
@@ -668,7 +682,7 @@ describe("Bedrock thinking request composition", () => {
       }),
       context,
       {
-        reasoning: testCase.reasoning,
+        ...(testCase.reasoning === undefined ? {} : { reasoning: testCase.reasoning }),
         ...(testCase.requestedMaxTokens === undefined
           ? {}
           : { maxTokens: testCase.requestedMaxTokens }),
@@ -679,7 +693,7 @@ describe("Bedrock thinking request composition", () => {
       testCase.expected === undefined ? {} : { maxTokens: testCase.expected },
     );
     expect(input.additionalModelRequestFields).toEqual(
-      testCase.reasoning === "off"
+      testCase.reasoning !== "high"
         ? undefined
         : {
             thinking: { type: "adaptive", display: "summarized" },

--- a/extensions/amazon-bedrock/stream.runtime.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.test.ts
@@ -461,7 +461,7 @@ describe("Bedrock stop reasons", () => {
 describe("Bedrock thinking effort mapping", () => {
   it.each([
     { reasoning: undefined, expected: "high", maxTokens: 128_000, fields: true },
-    { reasoning: "off" as const, expected: "off", maxTokens: undefined, fields: false },
+    { reasoning: "off" as const, expected: "off", maxTokens: 128_000, fields: false },
   ])(
     "uses the Opus 5 default for reasoning=$reasoning",
     ({ reasoning, expected, maxTokens, fields }) => {
@@ -486,6 +486,34 @@ describe("Bedrock thinking effort mapping", () => {
       );
     },
   );
+
+  it("sends the configured model maxTokens when Opus 5 reasoning is off", async () => {
+    const send = vi.spyOn(BedrockRuntimeClient.prototype, "send").mockResolvedValue({
+      $metadata: { httpStatusCode: 200 },
+      stream: streamEvents([
+        { messageStart: { role: ConversationRole.ASSISTANT } },
+        { messageStop: { stopReason: BedrockStopReason.END_TURN } },
+      ]),
+    } as never);
+    const model = bedrockModel({
+      id: "global.anthropic.claude-opus-5",
+      name: "Claude Opus 5",
+      contextWindow: 1_000_000,
+      maxTokens: 32_000,
+    });
+
+    await streamBedrockForTest(
+      model,
+      { messages: [{ role: "user", content: "Reply briefly.", timestamp: 0 }] } as never,
+      { reasoning: "off" },
+    ).result();
+
+    const command = send.mock.calls[0]?.[0] as { input?: Record<string, unknown> };
+    expect(command.input).toMatchObject({
+      inferenceConfig: { maxTokens: 32_000 },
+    });
+    expect(command.input?.additionalModelRequestFields).toBeUndefined();
+  });
 
   it.each([
     { reasoning: undefined, expected: "high" },
@@ -560,19 +588,26 @@ describe("Bedrock thinking effort mapping", () => {
     });
   });
 
-  it.each([4096, 8192, 16_384])(
-    "does not turn fallback maxTokens %s into an adaptive cap",
-    (maxTokens) => {
+  it.each([
+    { reasoning: "high" as const, maxTokens: 4096 },
+    { reasoning: "high" as const, maxTokens: 8192 },
+    { reasoning: "high" as const, maxTokens: 16_384 },
+    { reasoning: "off" as const, maxTokens: 4096 },
+    { reasoning: "off" as const, maxTokens: 8192 },
+    { reasoning: "off" as const, maxTokens: 16_384 },
+  ])(
+    "does not turn fallback maxTokens $maxTokens into a cap for reasoning=$reasoning",
+    ({ reasoning, maxTokens }) => {
       const model = bedrockModel({
         id: "us.anthropic.claude-opus-4-8",
         name: "Claude Opus 4.8",
         reasoning: true,
         maxTokens,
       });
-      const options = testing.resolveSimpleBedrockOptions(model, { reasoning: "high" });
+      const options = testing.resolveSimpleBedrockOptions(model, { reasoning });
 
       expect(options.maxTokens).toBeUndefined();
-      expect(options.reasoning).toBe("high");
+      expect(options.reasoning).toBe(reasoning);
     },
   );
 

--- a/extensions/amazon-bedrock/stream.runtime.ts
+++ b/extensions/amazon-bedrock/stream.runtime.ts
@@ -486,7 +486,13 @@ function resolveSimpleBedrockOptions(
   }
 
   if (options.reasoning === "off") {
-    return { ...base, reasoning: "off" } satisfies BedrockOptions;
+    return {
+      ...base,
+      ...(supportsAdaptiveThinking(model)
+        ? { maxTokens: resolveAdaptiveBedrockMaxTokens(model, base.maxTokens) }
+        : {}),
+      reasoning: "off",
+    } satisfies BedrockOptions;
   }
 
   if (isAnthropicClaudeModel(model)) {

--- a/extensions/amazon-bedrock/stream.runtime.ts
+++ b/extensions/amazon-bedrock/stream.runtime.ts
@@ -478,7 +478,7 @@ function resolveSimpleBedrockOptions(
         : undefined;
     return {
       ...base,
-      ...(reasoning !== undefined
+      ...(reasoning !== undefined || supportsAdaptiveThinking(model)
         ? { maxTokens: resolveAdaptiveBedrockMaxTokens(model, base.maxTokens) }
         : {}),
       reasoning,

--- a/extensions/amazon-bedrock/stream.runtime.ts
+++ b/extensions/amazon-bedrock/stream.runtime.ts
@@ -119,10 +119,10 @@ function normalizeAdaptiveClaudeToolChoice(
 }
 
 // OpenClaw synthesizes these caps when the provider's real output limit is unknown.
-// Keep them out of Bedrock adaptive requests so Bedrock can use its native default.
+// Keep them out of Bedrock requests so Bedrock can use its native default.
 const OPENCLAW_FALLBACK_MODEL_MAX_TOKENS = new Set([4096, 8192, 16_384]);
 
-function resolveAdaptiveBedrockMaxTokens(
+function resolveBedrockMaxTokens(
   model: Model<"bedrock-converse-stream">,
   baseMaxTokens: number | undefined,
 ): number | undefined {
@@ -444,7 +444,7 @@ function resolveSimpleBedrockOptions(
   if (requiresMandatoryAdaptiveThinking(model)) {
     return {
       ...base,
-      maxTokens: resolveAdaptiveBedrockMaxTokens(model, base.maxTokens),
+      maxTokens: resolveBedrockMaxTokens(model, base.maxTokens),
       reasoning: options?.reasoning === "off" ? "low" : (options?.reasoning ?? "high"),
       thinkingBudgets: options?.thinkingBudgets,
     } satisfies BedrockOptions;
@@ -458,21 +458,27 @@ function resolveSimpleBedrockOptions(
     return {
       ...base,
       ...(reasoning !== undefined
-        ? { maxTokens: resolveAdaptiveBedrockMaxTokens(model, base.maxTokens) }
+        ? { maxTokens: resolveBedrockMaxTokens(model, base.maxTokens) }
         : {}),
       reasoning,
     } satisfies BedrockOptions;
   }
 
   if (options.reasoning === "off") {
-    return { ...base, reasoning: "off" } satisfies BedrockOptions;
+    return {
+      ...base,
+      ...(supportsAdaptiveThinking(model)
+        ? { maxTokens: resolveBedrockMaxTokens(model, base.maxTokens) }
+        : {}),
+      reasoning: "off",
+    } satisfies BedrockOptions;
   }
 
   if (isAnthropicClaudeModel(model)) {
     if (supportsAdaptiveThinking(model)) {
       return {
         ...base,
-        maxTokens: resolveAdaptiveBedrockMaxTokens(model, base.maxTokens),
+        maxTokens: resolveBedrockMaxTokens(model, base.maxTokens),
         reasoning: options.reasoning,
         thinkingBudgets: options.thinkingBudgets,
       } satisfies BedrockOptions;


### PR DESCRIPTION
Closes #119148

## What Problem This Solves

Fixes an issue where Bedrock users running adaptive-capable Claude models with reasoning disabled could have the configured model output limit omitted from requests. Long or tool-heavy turns could then stop at the provider default and surface `Agent couldn't generate a response` or an empty tool-result response.

## Why This Change Was Made

The Bedrock option resolver now applies the configured model `maxTokens` to reasoning-off requests for adaptive-capable models. Explicit request caps still win, and OpenClaw's synthetic fallback caps (`4096`, `8192`, and `16384`) remain omitted so Bedrock can use its native default.

AI-assisted: yes. The change and its request-path behavior were manually reviewed and verified against the live failure mode.

## User Impact

Configured Bedrock output limits are honored even when reasoning is disabled, reducing length-truncated turns that cannot produce a deliverable agent response. Other models and reasoning modes retain their existing behavior.

## Evidence

- Before the fix, redacted live request auditing showed `maxTokens=unset` with `reasoning=off`; affected turns ended with `stopReason=length`, including a tool replay that could not be safely resumed.
- After applying the same runtime behavior locally, auditing showed `maxTokens=32000`; a normal agent turn returned `status=ok`, and a tool round trip returned the expected final response.
- Focused runtime tests: 57 passed.
- Amazon Bedrock extension tests: 288 passed across 14 files.
- `pnpm check:changed`: passed on the latest upstream `main` baseline.
- Full `pnpm build`: passed before the final clean rebase; focused tests, extension tests, type checks, lint, formatting, boundary checks, and import-cycle checks were rerun after rebase through `check:changed`.
