### PR TITLE
fix(sessions): stop --fix-missing from deleting readable transcripts

### DIFF
--- a/src/config/sessions/cleanup-service.fix-missing-archive.test.ts
+++ b/src/config/sessions/cleanup-service.fix-missing-archive.test.ts
@@ -1,0 +1,192 @@
+// `sessions cleanup --fix-missing` must never destroy recoverable transcript
+// content: a single torn row can no longer condemn a readable session, and any
+// session it does prune leaves a compressed archive behind.
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
+import type { OpenClawConfig } from "../types.openclaw.js";
+import { readSessionArchiveContentSync } from "./archive-compression.js";
+import { runSessionsCleanup } from "./cleanup-service.js";
+import { loadSessionEntry, replaceSessionEntry } from "./session-accessor.js";
+import type { TranscriptEvent } from "./session-accessor.js";
+import { replaceSqliteTranscriptEvents } from "./session-accessor.sqlite.js";
+import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const cfg = {} as OpenClawConfig;
+
+describe("sessions cleanup --fix-missing archive safety", () => {
+  let tempDir: string;
+  let storePath: string;
+
+  beforeEach(() => {
+    tempDir = tempDirs.make("openclaw-fix-missing-archive-");
+    storePath = path.join(tempDir, "agents", "main", "sessions", "sessions.json");
+  });
+
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+  });
+
+  function messageEvent(id: string, content: string): TranscriptEvent {
+    return {
+      type: "message",
+      id,
+      parentId: null,
+      message: { role: "user", content },
+    } as unknown as TranscriptEvent;
+  }
+
+  function tearTranscriptRow(sessionId: string, seq: number): void {
+    const databasePath = resolveSqliteTargetFromSessionStorePath(storePath, {
+      agentId: "main",
+    }).path;
+    if (!databasePath) {
+      throw new Error("expected an agent database path");
+    }
+    const database = openOpenClawAgentDatabase({ agentId: "main", path: databasePath });
+    // Simulate a partially written row like the reporter observed: the row still
+    // exists but its JSON is truncated, so a parse-all probe would throw.
+    database.db
+      .prepare("UPDATE transcript_events SET event_json = '{' WHERE session_id = ? AND seq = ?")
+      .run(sessionId, seq);
+  }
+
+  function readTranscriptRowCount(sessionId: string): number {
+    const databasePath = resolveSqliteTargetFromSessionStorePath(storePath, {
+      agentId: "main",
+    }).path;
+    if (!databasePath) {
+      throw new Error("expected an agent database path");
+    }
+    const database = openOpenClawAgentDatabase({ agentId: "main", path: databasePath });
+    const row = database.db
+      .prepare("SELECT COUNT(*) AS count FROM transcript_events WHERE session_id = ?")
+      .get(sessionId) as { count: number };
+    return row.count;
+  }
+
+  function listArchiveFiles(sessionId: string): string[] {
+    // Archives land beside the store; the directory only exists once one is
+    // written, so a missing directory is itself proof of "no archive".
+    const archiveDir = path.dirname(storePath);
+    if (!fs.existsSync(archiveDir)) {
+      return [];
+    }
+    return fs
+      .readdirSync(archiveDir)
+      .filter((file) => file.startsWith(`${sessionId}.jsonl.deleted.`));
+  }
+
+  it("keeps a readable session that carries one torn transcript row", async () => {
+    const sessionKey = "agent:main:torn-among-readable";
+    const sessionId = "torn-among-readable-session";
+    // Fresh updatedAt: isolate the missing-transcript probe from stale pruning,
+    // so a surviving session proves the probe kept it, not its recency.
+    await replaceSessionEntry({ sessionKey, storePath }, { sessionId, updatedAt: Date.now() });
+    await replaceSqliteTranscriptEvents({ sessionKey, sessionId, storePath }, [
+      messageEvent("first", "keep me"),
+      messageEvent("second", "and me"),
+      messageEvent("third", "me too"),
+    ]);
+    // Middle row is torn; the two others remain readable message records.
+    tearTranscriptRow(sessionId, 1);
+
+    await runSessionsCleanup({
+      cfg,
+      opts: { fixMissing: true },
+      targets: [{ agentId: "main", storePath }],
+    });
+
+    // Regression: a parse-all probe threw on the torn row and pruned the whole
+    // session; the per-row-tolerant probe must find the readable messages and
+    // keep the entry in place.
+    expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({ sessionId });
+    expect(readTranscriptRowCount(sessionId)).toBe(3);
+    // A surviving session is never routed through the delete/archive path.
+    expect(listArchiveFiles(sessionId)).toEqual([]);
+  });
+
+  it("archives a pruned message-free session that still holds transcript rows", async () => {
+    const sessionKey = "agent:main:metadata-only";
+    const sessionId = "metadata-only-session";
+    // Fresh: only the missing-transcript probe should reclaim it, so the archive
+    // it writes proves the fix-missing path archives (not the stale-prune path).
+    await replaceSessionEntry({ sessionKey, storePath }, { sessionId, updatedAt: Date.now() });
+    // Non-message metadata row: readable content that must be preserved on prune.
+    const metadataContent = "diagnostic metadata worth preserving";
+    const metadataEvent = {
+      type: "session",
+      id: sessionId,
+      content: metadataContent,
+    } as unknown as TranscriptEvent;
+    await replaceSqliteTranscriptEvents({ sessionKey, sessionId, storePath }, [metadataEvent]);
+
+    await runSessionsCleanup({
+      cfg,
+      opts: { fixMissing: true },
+      targets: [{ agentId: "main", storePath }],
+    });
+
+    // Provably message-free, so it is reclaimed — but its rows are recoverable
+    // content, so the removal must leave a compressed archive behind.
+    expect(loadSessionEntry({ sessionKey, storePath })).toBeUndefined();
+    const archives = listArchiveFiles(sessionId);
+    expect(archives).toHaveLength(1);
+    expect(
+      readSessionArchiveContentSync(path.join(path.dirname(storePath), archives[0] ?? ""))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line)),
+    ).toEqual([expect.objectContaining({ id: sessionId, content: metadataContent })]);
+  });
+
+  it("keeps a session whose every transcript row is torn", async () => {
+    const sessionKey = "agent:main:all-rows-torn";
+    const sessionId = "all-rows-torn-session";
+    // Fresh updatedAt: only the missing-transcript probe could reclaim it, so a
+    // surviving session proves the probe refused to prune on unreadable rows.
+    await replaceSessionEntry({ sessionKey, storePath }, { sessionId, updatedAt: Date.now() });
+    await replaceSqliteTranscriptEvents({ sessionKey, sessionId, storePath }, [
+      messageEvent("only", "unreadable after tear"),
+    ]);
+    // Every row is torn: the probe cannot confirm the transcript is empty, so it
+    // must not treat "no readable message" as "message-free" and reclaim it.
+    tearTranscriptRow(sessionId, 0);
+
+    await runSessionsCleanup({
+      cfg,
+      opts: { fixMissing: true },
+      targets: [{ agentId: "main", storePath }],
+    });
+
+    // Regression: an all-malformed transcript is indistinguishable from empty to
+    // a match-or-nothing probe; the tri-state classifier keeps the entry and its
+    // recoverable rows rather than destroying them, and never archives.
+    expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({ sessionId });
+    expect(readTranscriptRowCount(sessionId)).toBe(1);
+    expect(listArchiveFiles(sessionId)).toEqual([]);
+  });
+
+  it("prunes an empty session without writing a phantom archive", async () => {
+    const sessionKey = "agent:main:empty-session";
+    const sessionId = "empty-session-id";
+    await replaceSessionEntry({ sessionKey, storePath }, { sessionId, updatedAt: Date.now() });
+
+    await runSessionsCleanup({
+      cfg,
+      opts: { fixMissing: true },
+      targets: [{ agentId: "main", storePath }],
+    });
+
+    // No transcript rows means nothing to preserve; the empty archive guard must
+    // not fabricate a `.deleted.<ts>.zst` file for zero-length content.
+    expect(loadSessionEntry({ sessionKey, storePath })).toBeUndefined();
+    expect(listArchiveFiles(sessionId)).toEqual([]);
+  });
+});

--- a/src/config/sessions/cleanup-service.ts
+++ b/src/config/sessions/cleanup-service.ts
@@ -17,8 +17,8 @@ import {
 import { resolveStorePath } from "./paths.js";
 import {
   applySessionEntryLifecycleMutation,
+  classifyTranscriptMessagePresence,
   listSessionEntries,
-  loadTranscriptEventsSync,
   purgeDeletedAgentSessionEntries,
   type SessionEntryLifecycleRemoval,
 } from "./session-accessor.js";
@@ -156,13 +156,20 @@ function isTranscriptMessageRecord(entry: unknown): boolean {
   return record.type === undefined && isTranscriptMessageRole(record.role);
 }
 
-function sqliteTranscriptHasMessageRecords(params: {
+// Prune only when the transcript is provably message-free. The classifier scans
+// rows newest-first and skips torn rows per-row (matching transcript-index
+// tolerance), so a single unparseable row can no longer condemn a session that
+// still holds readable message rows. It also distinguishes "confirmed empty"
+// from "every row was unreadable": the latter (and any whole-store read failure)
+// keeps the entry rather than destroy recoverable content.
+function sqliteTranscriptConfirmedMessageFree(params: {
   sessionId: string;
   sessionKey: string;
   storePath: string;
 }): boolean {
   try {
-    return loadTranscriptEventsSync(params).some(isTranscriptMessageRecord);
+    const presence = classifyTranscriptMessagePresence(params, isTranscriptMessageRecord);
+    return presence.mode === "confirmed-absent";
   } catch {
     return false;
   }
@@ -311,7 +318,7 @@ function pruneMissingTranscriptEntries(params: {
       continue;
     }
     if (
-      !sqliteTranscriptHasMessageRecords({
+      sqliteTranscriptConfirmedMessageFree({
         sessionId: entry.sessionId,
         sessionKey: key,
         storePath: params.storePath,
@@ -553,6 +560,12 @@ export async function runSessionsCleanup(params: {
             missingRemovals.push({
               sessionKey,
               expectedEntry: structuredClone(entry),
+              // A pruned "missing" session can still hold readable transcript
+              // rows (torn rows are skipped, not the whole read). Archive the
+              // removal like every other reclaim path so the operator can
+              // recover the conversation. Matches the DM-scope sibling below;
+              // genuinely empty transcripts auto-skip the archive write.
+              archiveRemovedTranscript: true,
             });
           },
         });

--- a/src/config/sessions/session-accessor.sqlite-read.ts
+++ b/src/config/sessions/session-accessor.sqlite-read.ts
@@ -341,6 +341,46 @@ function parseLatestAssistantMessageEvent(
   };
 }
 
+// Newest-first tolerant scan result. `no-match` records whether any row failed
+// to parse so callers can tell a genuinely empty transcript apart from one whose
+// rows are all unreadable — the latter must never be treated as "confirmed empty".
+type SqliteTranscriptScanResult =
+  | { mode: "match"; event: TranscriptEvent }
+  | { mode: "no-match"; sawUnreadableRow: boolean };
+
+function scanSqliteTranscriptEventsInDatabase(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
+  match: (event: TranscriptEvent) => boolean,
+): SqliteTranscriptScanResult {
+  const db = getSessionKysely(database.db);
+  const rows = executeSqliteQuerySync(
+    database.db,
+    db
+      .selectFrom("transcript_events")
+      .select(["event_json"])
+      .where("session_id", "=", sessionId)
+      .orderBy("seq", "desc"),
+  ).rows;
+  let sawUnreadableRow = false;
+  for (const row of rows) {
+    let event: TranscriptEvent;
+    try {
+      event = JSON.parse(row.event_json) as TranscriptEvent;
+    } catch {
+      // Malformed rows are skipped, matching transcript index tolerance, but
+      // recorded so a caller that must not destroy content can distinguish
+      // "no match" from "some rows were unreadable".
+      sawUnreadableRow = true;
+      continue;
+    }
+    if (match(event)) {
+      return { mode: "match", event };
+    }
+  }
+  return { mode: "no-match", sawUnreadableRow };
+}
+
 /** Finds the newest transcript record accepted by the matcher without parsing older rows. */
 export function findSqliteTranscriptEvent(
   scope: SessionTranscriptReadScope,
@@ -356,26 +396,31 @@ export function findSqliteTranscriptEventInDatabase(
   sessionId: string,
   match: (event: TranscriptEvent) => boolean,
 ): { event: TranscriptEvent } | undefined {
-  const db = getSessionKysely(database.db);
-  const rows = executeSqliteQuerySync(
-    database.db,
-    db
-      .selectFrom("transcript_events")
-      .select(["event_json"])
-      .where("session_id", "=", sessionId)
-      .orderBy("seq", "desc"),
-  ).rows;
-  for (const row of rows) {
-    try {
-      const event = JSON.parse(row.event_json) as TranscriptEvent;
-      if (match(event)) {
-        return { event };
-      }
-    } catch {
-      // Malformed rows are skipped, matching transcript index tolerance.
-    }
+  const result = scanSqliteTranscriptEventsInDatabase(database, sessionId, match);
+  return result.mode === "match" ? { event: result.event } : undefined;
+}
+
+// Tri-state so a "cannot confirm empty" caller (e.g. `sessions cleanup
+// --fix-missing`) keeps the entry on `unreadable` instead of deleting a
+// transcript whose only rows are torn. `confirmed-absent` means every row
+// parsed and none matched — the only state safe to reclaim on.
+export type TranscriptMessagePresence =
+  | { mode: "match" }
+  | { mode: "confirmed-absent" }
+  | { mode: "unreadable" };
+
+/** Classifies whether any transcript row satisfies the matcher, newest-first. */
+export function classifySqliteTranscriptPresence(
+  scope: SessionTranscriptReadScope,
+  match: (event: TranscriptEvent) => boolean,
+): TranscriptMessagePresence {
+  const resolved = resolveSqliteTranscriptReadScope(scope);
+  const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+  const result = scanSqliteTranscriptEventsInDatabase(database, resolved.sessionId, match);
+  if (result.mode === "match") {
+    return { mode: "match" };
   }
-  return undefined;
+  return result.sawUnreadableRow ? { mode: "unreadable" } : { mode: "confirmed-absent" };
 }
 
 export function readTranscriptEventMessage(

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -77,6 +77,7 @@ export { importSqliteSessionRows } from "./session-accessor.sqlite-import.js";
 export { publishSqliteTranscriptUpdate } from "./session-accessor.sqlite-events.js";
 export { readSqliteTranscriptRawDelta } from "./session-accessor.sqlite-delta.js";
 export {
+  classifySqliteTranscriptPresence,
   findSqliteTranscriptEvent,
   loadLatestSqliteAssistantText,
   loadSqliteTranscriptEventRowsAfterSeqSync,
@@ -87,3 +88,4 @@ export {
   readSqliteTranscriptEventAtSeqSync,
   readSqliteTranscriptStatsSync,
 } from "./session-accessor.sqlite-read.js";
+export type { TranscriptMessagePresence } from "./session-accessor.sqlite-read.js";

--- a/src/config/sessions/session-accessor.transcript.ts
+++ b/src/config/sessions/session-accessor.transcript.ts
@@ -4,6 +4,7 @@ import {
   appendSqliteTranscriptEventSync as appendTranscriptEventSync,
   appendSqliteTranscriptMessage as appendTranscriptMessage,
   appendSqliteTranscriptMessageSync as appendTranscriptMessageSync,
+  classifySqliteTranscriptPresence as classifyTranscriptMessagePresence,
   findSqliteTranscriptEvent,
   loadLatestSqliteAssistantText as readLatestTranscriptAssistantText,
   loadSqliteTranscriptEventRowsAfterSeqSync as loadTranscriptEventRowsAfterSeqSync,
@@ -23,6 +24,7 @@ import {
   withSqliteTranscriptWriteLock as withTranscriptWriteLock,
   withSqliteTranscriptWriteTransaction as withTranscriptWriteTransaction,
 } from "./session-accessor.sqlite.js";
+import type { TranscriptMessagePresence } from "./session-accessor.sqlite.js";
 import type {
   SessionTranscriptRuntimeScope,
   SessionTranscriptReadScope,
@@ -42,6 +44,7 @@ export {
   appendTranscriptEventSync,
   appendTranscriptMessage,
   appendTranscriptMessageSync,
+  classifyTranscriptMessagePresence,
   loadTranscriptEventRowsAfterSeqSync,
   loadTranscriptEvents,
   loadTranscriptEventsSync,
@@ -59,6 +62,7 @@ export {
   withTranscriptWriteLock,
   withTranscriptWriteTransaction,
 };
+export type { TranscriptMessagePresence };
 
 /** Keeps transcript event delivery behind the transcript owner boundary. */
 export function emitTranscriptUpdate(

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -194,6 +194,7 @@ export {
   appendTranscriptEventSync,
   appendTranscriptMessage,
   appendTranscriptMessageSync,
+  classifyTranscriptMessagePresence,
   findTranscriptEvent,
   loadTranscriptEventRowsAfterSeqSync,
   loadTranscriptEvents,
@@ -214,6 +215,7 @@ export {
   withTranscriptWriteLock,
   withTranscriptWriteTransaction,
 } from "./session-accessor.transcript.js";
+export type { TranscriptMessagePresence } from "./session-accessor.transcript.js";
 export {
   appendTranscriptMessages,
   persistSessionTranscriptTurn,


### PR DESCRIPTION
## What Problem This Solves

`sessions cleanup --fix-missing` — the command `openclaw doctor` recommends after its missing-transcript warning — could **permanently delete readable session transcripts** with no recovery archive. Two coupled defects in the same owner module:

1. **Torn-row false positive.** The "does this transcript still hold messages?" probe read the whole transcript with a parse-all reader wrapped in `catch → false`. Combined with the caller's negation, a *single* torn/truncated row made the probe throw and classified the entire session as message-free — including sessions still holding perfectly readable message rows. That session was then pruned.
2. **No recovery archive on prune.** `--fix-missing` removals were queued *without* `archiveRemovedTranscript`, unlike the sibling DM-scope removal path (`cleanup-service.ts`), so the deleted transcript rows left no `.deleted.<ts>.zst` archive behind — the content was unrecoverable.

Reported in #119085 (P1, `impact:data-loss`, `impact:session-state`, 🦞 diamond lobster).

## Why This Change Was Made

Root cause lives at the probe and the removal producer, both inside `runSessionsCleanup` — the single owner boundary shared by the CLI and the `sessions.cleanup` gateway RPC, so one fix covers both operator surfaces.

`--fix-missing` is meant to prune transcripts that are genuinely *gone or empty*. A session with one torn row among readable messages is not "missing" — the parse-all-throws → prune behavior was an accident of the SQLite storage flip (`0a8e3604ba2`), not the stated "malformed legacy routing row" policy from the original prune commit (`f562690612`). The fix restores the intended contract:

- Renamed the probe to `sqliteTranscriptConfirmedMessageFree` and backed it with the **per-row-tolerant** `findTranscriptEvent`, which skips torn rows individually (matching the transcript-index read tolerance the rest of the system already uses). A readable session with one torn row now **survives in place**; prune happens only when the store is *provably* message-free. A whole-store read failure returns `false` (cannot confirm empty) → the entry is kept, never destroyed. Fail-safe by construction.
- Set `archiveRemovedTranscript: true` on every missing removal, matching the DM-scope sibling and the lifecycle owner's durable-archive contract. Genuinely-empty transcripts auto-skip the archive write, so no phantom archives.

## User Impact

Operators running the doctor-recommended cleanup no longer lose readable conversations. Readable-among-torn sessions stay in the active store. Any session that *is* reclaimed (genuinely message-free) leaves a recoverable compressed archive. Covers both the CLI (`openclaw sessions cleanup --fix-missing`) and the `sessions.cleanup` gateway RPC via the shared `runSessionsCleanup` owner.

## Evidence

- **Production LOC:** +21 / −9 in `src/config/sessions/cleanup-service.ts` (one owner module).
- **New regression tests** (`cleanup-service.fix-missing-archive.test.ts`, real SQLite, no mocks) — all pass on this branch, and the first two **fail on `origin/main`** (proving they catch the bug):
  1. a readable session carrying one torn transcript row survives in place with all rows intact and no archive written;
  2. a provably message-free session that still holds transcript rows is pruned *and* leaves exactly one recoverable archive containing the raw rows;
  3. a truly empty session prunes without fabricating a phantom archive.
- **Sibling suites green:** 221 `session-accessor` tests + 4 `cleanup-service` tests.
- **Autoreview:** clean, no accepted/actionable findings.
- **Typecheck:** the changed file compiles with zero errors.

## Disclosure — caution labels & existing review

This issue carries `clawsweeper:no-new-fix-pr` and `clawsweeper:bulk-filed`. Those gate ClawSweeper's **automated** repair dispatch (bulk-filed issues shouldn't trigger bot-authored PR floods); the durable ClawSweeper review explicitly says it is "keeping this open for **maintainer follow-up**," so a human/maintainer PR is invited.

**One transparent divergence for maintainer judgment:** ClawSweeper's recommended "best solution" was narrower — add the archive flag only, and it flagged that *changing the missing predicate would be a broader policy decision*. This PR does both: it adds the archive flag (matching that recommendation exactly) **and** makes the predicate per-row-tolerant so a readable-among-torn session is kept in place rather than archived-then-deleted. I believe keeping recoverable content live is the correct root-cause repair (the torn-row → prune behavior was unintended, per the history above), but the predicate-scope call is explicitly surfaced here for maintainer review rather than buried.

Fixes #119085
