### PR TITLE
fix(model-picker): preserve non-picker auth-profile override on model switch

### DIFF
--- a/extensions/telegram/src/bot-handlers.callback-model.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.callback-model.runtime.ts
@@ -284,6 +284,10 @@ export async function handleTelegramModelCallback(params: {
               model: selection.model,
               isDefault: isDefaultSelection,
             },
+            // A non-default picker selection must not silently destroy an
+            // auth-profile override set by a non-picker source (#92244). Only
+            // an explicit reset to the default model clears it.
+            preserveAuthProfileOverride: !isDefaultSelection,
           });
           return entry;
         },

--- a/src/model-picker/apply-session-model-selection.test.ts
+++ b/src/model-picker/apply-session-model-selection.test.ts
@@ -528,4 +528,31 @@ describe("applySessionModelSelection", () => {
     expect(effects.refreshQueuedFollowupSession).not.toHaveBeenCalled();
     expect(effects.enqueueSystemEvent).not.toHaveBeenCalled();
   });
+
+  it("keeps a non-picker auth-profile override when switching to a non-default model (#92244)", async () => {
+    const sessionEntry = createEntry({
+      authProfileOverride: "openai:work",
+      authProfileOverrideSource: "cli",
+    });
+    const result = await applySessionModelSelection(
+      createParams({
+        sessionEntry,
+        currentProvider: "anthropic",
+        currentModel: "claude-opus-4-6",
+        request: {
+          provider: "openai",
+          model: "gpt-4o",
+          runtime: { kind: "unchanged" },
+        },
+      }),
+    );
+
+    expect(result).toMatchObject({ status: "applied" });
+    expect(sessionEntry.providerOverride).toBe("openai");
+    expect(sessionEntry.modelOverride).toBe("gpt-4o");
+    // The auth-profile override set by a non-picker source (CLI flag) must
+    // survive a non-default model switch instead of being silently destroyed.
+    expect(sessionEntry.authProfileOverride).toBe("openai:work");
+    expect(sessionEntry.authProfileOverrideSource).toBe("cli");
+  });
 });

--- a/src/model-picker/apply-session-model-selection.ts
+++ b/src/model-picker/apply-session-model-selection.ts
@@ -106,6 +106,11 @@ function applySessionModelSelectionToEntry(params: {
     entry: params.entry,
     selection: params.request,
     profileOverride: params.request.profileOverride,
+    // A non-default selection must not silently destroy an auth-profile
+    // override that was set by a non-picker source (session-level override,
+    // CLI flag, another picker). Only an explicit reset to the default model
+    // clears the auth profile override (#92244).
+    preserveAuthProfileOverride: !params.request.isDefault,
     markLiveSwitchPending: params.markLiveSwitchPending,
   });
   const runtimeChange = applyModelRuntimeDirective(params.entry, params.runtime);


### PR DESCRIPTION
## What Problem This Solves

Fixes #92244: both the core model-directive path and the **Telegram model-picker button callback** invoked `applyModelOverrideToSessionEntry` without `preserveAuthProfileOverride`. Switching to a non-default model therefore **unconditionally deleted** `authProfileOverride`, `authProfileOverrideSource`, and `authProfileOverrideCompactionCount` — even when those fields were set by a non-picker source (session-level override, CLI flag, env var). The user saw "Model changed to X" with no warning that their auth-profile override was silently destroyed.

## Why This Change Was Made

The shared mutator (`applyModelOverrideToSessionEntry`) already supports `preserveAuthProfileOverride`: when set and no explicit `profileOverride` is supplied, the destructive branch that deletes the auth-profile fields is skipped. Both call sites simply never passed it. The fix keys preservation off `isDefault` — an explicit reset to the default model is the one case where clearing the auth-profile override is intended; any other model switch keeps a non-picker override (and still updates it when the request carries an explicit `profileOverride`).

Changed call sites:
- `src/model-picker/apply-session-model-selection.ts` — core directive path (`preserveAuthProfileOverride: !params.request.isDefault`)
- `extensions/telegram/src/bot-handlers.callback-model.runtime.ts` — the Telegram picker button callback named in the report (`preserveAuthProfileOverride: !isDefaultSelection`)

## User Impact

Before: selecting a different model via the Telegram picker (or a model directive) silently removed a session's auth-profile override and its source/compaction metadata, breaking profile-bound auth for later turns with no error surfaced.

After: switching models keeps the existing auth-profile override. Only an explicit reset to the default model clears it. Explicit profile selection still updates the override exactly as before.

## Evidence

### New regression test (core path)
`src/model-picker/apply-session-model-selection.test.ts` — "keeps a non-picker auth-profile override when switching to a non-default model (#92244)": entry with `authProfileOverride: "openai:work"` / source `cli` switches from the default (anthropic/claude-opus-4-6) to openai/gpt-4o; asserts both the override and its source survive.

```text
$ ./node_modules/.bin/vitest run src/model-picker/
Test Files  2 passed (2)
Tests  25 passed (25)
```

### Telegram callback path
`bot-handlers.callback-model.runtime.ts` now passes `preserveAuthProfileOverride: !isDefaultSelection` into the same mutator, so the Telegram button path (the exact user action named in the report) no longer deletes non-picker auth-profile overrides.

### Intentional behavior preserved
The pre-existing test "resets to default and clears auth plus a provider-incompatible runtime" (explicit `isDefault: true` selection clears auth) still passes — included in the 25 above.

[AI-assisted]
