### PR TITLE
fix(bedrock): forward the resolved model cap on reasoning-off requests (#119148)

### DIFF
--- a/extensions/amazon-bedrock/stream.runtime.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.test.ts
@@ -461,7 +461,7 @@ describe("Bedrock stop reasons", () => {
 describe("Bedrock thinking effort mapping", () => {
   it.each([
     { reasoning: undefined, expected: "high", maxTokens: 128_000, fields: true },
-    { reasoning: "off" as const, expected: "off", maxTokens: undefined, fields: false },
+    { reasoning: "off" as const, expected: "off", maxTokens: 128_000, fields: false },
   ])(
     "uses the Opus 5 default for reasoning=$reasoning",
     ({ reasoning, expected, maxTokens, fields }) => {
@@ -521,6 +521,23 @@ describe("Bedrock thinking effort mapping", () => {
     const options = testing.resolveSimpleBedrockOptions(model, {});
 
     expect(options.reasoning).toBeUndefined();
+    expect(testing.buildAdditionalModelRequestFields(model, options)).toBeUndefined();
+  });
+
+  it("keeps synthetic fallback caps omitted for explicit reasoning-off requests", () => {
+    // OpenClaw synthesizes 4096/8192/16384 when the real provider cap is
+    // unknown; those must stay out of the request so Bedrock uses its native
+    // default, while real catalog caps are forwarded (see Opus 5 case above).
+    const model = bedrockModel({
+      id: "us.anthropic.claude-sonnet-4-6",
+      name: "Claude Sonnet 4.6",
+      reasoning: true,
+      maxTokens: 8192,
+    });
+    const options = testing.resolveSimpleBedrockOptions(model, { reasoning: "off" });
+
+    expect(options.maxTokens).toBeUndefined();
+    expect(options.reasoning).toBe("off");
     expect(testing.buildAdditionalModelRequestFields(model, options)).toBeUndefined();
   });
 

--- a/extensions/amazon-bedrock/stream.runtime.ts
+++ b/extensions/amazon-bedrock/stream.runtime.ts
@@ -465,7 +465,13 @@ function resolveSimpleBedrockOptions(
   }
 
   if (options.reasoning === "off") {
-    return { ...base, reasoning: "off" } satisfies BedrockOptions;
+    // Reasoning-off requests still forward the resolved model output cap;
+    // synthetic fallback caps stay omitted so Bedrock uses its native default.
+    return {
+      ...base,
+      maxTokens: resolveAdaptiveBedrockMaxTokens(model, base.maxTokens),
+      reasoning: "off",
+    } satisfies BedrockOptions;
   }
 
   if (isAnthropicClaudeModel(model)) {


### PR DESCRIPTION
## What Problem This Solves

[AI-assisted]

Amazon Bedrock Claude Opus 5 requests with `reasoning: "off"` omit `inferenceConfig.maxTokens` even when the resolved model catalog carries a real output cap (e.g. `global.anthropic.claude-opus-5` with `maxTokens: 32000`). Output-heavy turns then end at the provider default with `stopReason: "length"` and no usable response — the user-visible result was `Agent couldn't generate a response`.

The gap is in `resolveSimpleBedrockOptions` (`extensions/amazon-bedrock/stream.runtime.ts`): the `options.reasoning === "off"` branch returned `{ ...base, reasoning: "off" }` without resolving `maxTokens`, while every adaptive branch already routes through `resolveAdaptiveBedrockMaxTokens`. The Opus 5 reasoning-off unit test even encoded the bug by expecting `maxTokens: undefined`.

## Why

The model-cap propagation shipped for adaptive-thinking Bedrock requests (#97343) fixed the same class of failure for every path except explicit reasoning-off. A configured model output cap is a first-class catalog fact (`discovery.ts` resolves `maxTokens` from the catalog), and `buildBaseOptions` only carries an explicit request-level override — so the catalog cap was silently dropped on this path. Without it, long generations truncate mid-turn and the gateway reports an incomplete turn.

## User Impact

Bedrock Opus 5 users running with thinking disabled (`thinkingDefault: "off"`) and a configured output cap no longer hit premature `stopReason: "length"` truncation on long turns. Explicit per-request `maxTokens` overrides still win (unchanged), and known synthetic fallback caps (4096/8192/16384) remain omitted so Bedrock keeps using its native default. Four observed affected turns in the report (including one after two tool actions) go from `Agent couldn't generate a response` to a complete `status=ok stopReason=stop` turn.

## Evidence

- **Code diff** — `extensions/amazon-bedrock/stream.runtime.ts`: the reasoning-off branch now returns `maxTokens: resolveAdaptiveBedrockMaxTokens(model, base.maxTokens)`, the exact resolver the adaptive branches already use (same helper, same semantics: explicit cap wins → synthetic fallback omitted → real catalog cap forwarded).
- **Unit tests** — `extensions/amazon-bedrock/stream.runtime.test.ts`:
  - Opus 5 reasoning-off case updated from `maxTokens: undefined` to `maxTokens: 128_000` (real catalog cap now forwarded), `fields: false` unchanged (no adaptive thinking fields).
  - New regression: explicit reasoning-off with a synthetic fallback cap (`maxTokens: 8192`) keeps `maxTokens: undefined`, proving synthetic caps stay omitted.
- **Inline verification** — `vitest run extensions/amazon-bedrock`: **11 test files, 231 tests passed** (54/54 in `stream.runtime.test.ts`). `tsc --noEmit -p extensions/amazon-bedrock/tsconfig.json` reports 85 pre-existing environment errors on pristine `main` and 85 with this change — **zero new type errors**.
- The report's local runtime patch produced the before/after: `maxTokens=unset reasoning=off` → `incomplete turn detected ... stopReason=length`, versus `maxTokens=32000 reasoning=off` → `agent result: status=ok stopReason=stop`.
