### PR TITLE
fix(auto-reply): retain pending final when some payloads failed before delivery (#119161)

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.pending-final.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.pending-final.test.ts
@@ -223,4 +223,50 @@ describe("pending final delivery restart proof", () => {
     expect(entry?.pendingFinalDelivery?.kind).toBe("replayable");
     expect(entry?.pendingFinalDelivery?.text).toContain("retry B");
   });
+
+  it("does not replay a block-deduped payload when only a failed-before-deliver payload is present (#119162)", async () => {
+    // The all-failed shortcut must not retain the block-deduped payload C in the
+    // marker — it was already visible, so recovery must not resend it.
+    const payloadB = setReplyPayloadMetadata(
+      { text: "reply B" },
+      { pendingFinalDeliveryIntentId: "intent-1", pendingFinalDeliveryRetryText: "retry B" },
+    );
+    const payloadC = setReplyPayloadMetadata(
+      { text: "reply C" },
+      { pendingFinalDeliveryIntentId: "intent-1", pendingFinalDeliveryRetryText: "retry C" },
+    );
+    await replaceSessionEntry(
+      { storePath, sessionKey },
+      {
+        sessionId: "session",
+        status: "running",
+        startedAt: 10,
+        updatedAt: Date.now(),
+        pendingFinalDelivery: {
+          kind: "replayable",
+          text: "retry B\n\nretry C",
+          createdAt: 1,
+          intentId: "intent-1",
+        },
+      },
+    );
+    const identity = capturePendingFinalDeliveryIdentity({
+      intentId: "intent-1",
+      sessionKey,
+      storePath,
+    });
+
+    await reconcilePendingFinalDeliveryAfterSettlement({
+      deliveries: [{ outcome: "failed-before-deliver", payload: payloadB }],
+      identity,
+      replies: [payloadB, payloadC],
+      sessionKey,
+      storePath,
+    });
+
+    const entry = loadSessionEntry({ sessionKey, storePath });
+    expect(entry?.pendingFinalDelivery?.kind).toBe("replayable");
+    expect(entry?.pendingFinalDelivery?.text).toBe("retry B");
+    expect(entry?.pendingFinalDelivery?.text).not.toContain("retry C");
+  });
 });

--- a/src/auto-reply/reply/dispatch-from-config.pending-final.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.pending-final.test.ts
@@ -3,8 +3,8 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { loadSessionEntry, replaceSessionEntry } from "../../config/sessions/session-accessor.js";
-import type { InternalSessionEntry as SessionEntry } from "../../config/sessions/types.js";
-import type { ReplyPayload } from "../reply-payload.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
+import { setReplyPayloadMetadata, type ReplyPayload } from "../reply-payload.js";
 import {
   capturePendingFinalDeliveryIdentity,
   clearPendingFinalDeliveryAfterSuccess,
@@ -169,5 +169,58 @@ describe("pending final delivery restart proof", () => {
     expect(
       loadSessionEntry({ sessionKey, storePath })?.restartRecoveryTerminalRunIds,
     ).toBeUndefined();
+  });
+
+  it("retains the pending final when some payloads failed before delivery and others were block-deduped", async () => {
+    // Three intent payloads are pending; A delivered, B failed before deliver
+    // (proven not sent), C was block-deduped (no delivery entry). The marker
+    // must be retained with B's text — not cleared, or B is permanently lost.
+    const payloadA = setReplyPayloadMetadata(
+      { text: "reply A" },
+      { pendingFinalDeliveryIntentId: "intent-1", pendingFinalDeliveryRetryText: "retry A" },
+    );
+    const payloadB = setReplyPayloadMetadata(
+      { text: "reply B" },
+      { pendingFinalDeliveryIntentId: "intent-1", pendingFinalDeliveryRetryText: "retry B" },
+    );
+    const payloadC = setReplyPayloadMetadata(
+      { text: "reply C" },
+      { pendingFinalDeliveryIntentId: "intent-1", pendingFinalDeliveryRetryText: "retry C" },
+    );
+    await replaceSessionEntry(
+      { storePath, sessionKey },
+      {
+        sessionId: "session",
+        status: "running",
+        startedAt: 10,
+        updatedAt: Date.now(),
+        pendingFinalDelivery: {
+          kind: "replayable",
+          text: "retry A\n\nretry B\n\nretry C",
+          createdAt: 1,
+          intentId: "intent-1",
+        },
+      },
+    );
+    const identity = capturePendingFinalDeliveryIdentity({
+      intentId: "intent-1",
+      sessionKey,
+      storePath,
+    });
+
+    await reconcilePendingFinalDeliveryAfterSettlement({
+      deliveries: [
+        { outcome: "delivered", payload: payloadA },
+        { outcome: "failed-before-deliver", payload: payloadB },
+      ],
+      identity,
+      replies: [payloadA, payloadB, payloadC],
+      sessionKey,
+      storePath,
+    });
+
+    const entry = loadSessionEntry({ sessionKey, storePath });
+    expect(entry?.pendingFinalDelivery?.kind).toBe("replayable");
+    expect(entry?.pendingFinalDelivery?.text).toContain("retry B");
   });
 });

--- a/src/auto-reply/reply/dispatch-from-config.pending-final.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.pending-final.test.ts
@@ -221,7 +221,11 @@ describe("pending final delivery restart proof", () => {
 
     const entry = loadSessionEntry({ sessionKey, storePath });
     expect(entry?.pendingFinalDelivery?.kind).toBe("replayable");
-    expect(entry?.pendingFinalDelivery?.text).toContain("retry B");
+    expect(
+      entry?.pendingFinalDelivery?.kind === "replayable"
+        ? entry.pendingFinalDelivery.text
+        : undefined,
+    ).toContain("retry B");
   });
 
   it("does not replay a block-deduped payload when only a failed-before-deliver payload is present (#119162)", async () => {
@@ -266,7 +270,11 @@ describe("pending final delivery restart proof", () => {
 
     const entry = loadSessionEntry({ sessionKey, storePath });
     expect(entry?.pendingFinalDelivery?.kind).toBe("replayable");
-    expect(entry?.pendingFinalDelivery?.text).toBe("retry B");
-    expect(entry?.pendingFinalDelivery?.text).not.toContain("retry C");
+    const retryText =
+      entry?.pendingFinalDelivery?.kind === "replayable"
+        ? entry.pendingFinalDelivery.text
+        : undefined;
+    expect(retryText).toBe("retry B");
+    expect(retryText).not.toContain("retry C");
   });
 });

--- a/src/auto-reply/reply/dispatch-from-config.pending-final.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.pending-final.test.ts
@@ -11,8 +11,11 @@ import {
 import { loadSessionEntry, replaceSessionEntry } from "../../config/sessions/session-accessor.js";
 import type { InternalSessionEntry as SessionEntry } from "../../config/sessions/types.js";
 import { PlatformMessageNotDispatchedError } from "../../infra/outbound/deliver-types.js";
-import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
-import { getActivePluginRegistry, setActivePluginRegistry } from "../../plugins/runtime.js";
+import {
+  captureActivePluginRegistrySnapshot,
+  restoreActivePluginRegistrySnapshot,
+  setActivePluginRegistry,
+} from "../../plugins/runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { setReplyPayloadMetadata, type ReplyPayload } from "../reply-payload.js";
 import {
@@ -335,10 +338,12 @@ describe("pending final delivery restart proof", () => {
         messageId: `msg-${ctx.payload.text ?? ""}`,
       }),
     };
-    // Snapshot the process-global registry before installing the fixture adapter so
-    // later tests in the suite inherit the registry their setup established, not an
-    // empty one. Restore in finally so an assertion failure cannot leak the fixture.
-    const priorRegistry = getActivePluginRegistry();
+    // Snapshot the full plugin-runtime state (registry + cache key + subagent
+    // mode + workspace dir) before installing the fixture adapter, and restore it
+    // in a finally. setActivePluginRegistry defaults those metadata fields, so
+    // restoring only the registry object would leak reset metadata into later
+    // tests. restoreActivePluginRegistrySnapshot is the canonical pair.
+    const pluginRuntimeSnapshot = captureActivePluginRegistrySnapshot();
     try {
       setActivePluginRegistry(
         createTestRegistry([
@@ -450,7 +455,7 @@ describe("pending final delivery restart proof", () => {
       expect(retryText).not.toContain("retry A");
       expect(retryText).not.toContain("retry C");
     } finally {
-      setActivePluginRegistry(priorRegistry ?? createEmptyPluginRegistry());
+      restoreActivePluginRegistrySnapshot(pluginRuntimeSnapshot);
     }
   });
 });

--- a/src/auto-reply/reply/dispatch-from-config.pending-final.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.pending-final.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { loadSessionEntry, replaceSessionEntry } from "../../config/sessions/session-accessor.js";
-import type { SessionEntry } from "../../config/sessions/types.js";
+import type { InternalSessionEntry as SessionEntry } from "../../config/sessions/types.js";
 import { setReplyPayloadMetadata, type ReplyPayload } from "../reply-payload.js";
 import {
   capturePendingFinalDeliveryIdentity,

--- a/src/auto-reply/reply/dispatch-from-config.pending-final.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.pending-final.test.ts
@@ -11,7 +11,8 @@ import {
 import { loadSessionEntry, replaceSessionEntry } from "../../config/sessions/session-accessor.js";
 import type { InternalSessionEntry as SessionEntry } from "../../config/sessions/types.js";
 import { PlatformMessageNotDispatchedError } from "../../infra/outbound/deliver-types.js";
-import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import { getActivePluginRegistry, setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { setReplyPayloadMetadata, type ReplyPayload } from "../reply-payload.js";
 import {
@@ -46,7 +47,6 @@ describe("pending final delivery restart proof", () => {
   });
 
   afterEach(async () => {
-    setActivePluginRegistry(createTestRegistry([]));
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
@@ -335,114 +335,122 @@ describe("pending final delivery restart proof", () => {
         messageId: `msg-${ctx.payload.text ?? ""}`,
       }),
     };
-    setActivePluginRegistry(
-      createTestRegistry([
+    // Snapshot the process-global registry before installing the fixture adapter so
+    // later tests in the suite inherit the registry their setup established, not an
+    // empty one. Restore in finally so an assertion failure cannot leak the fixture.
+    const priorRegistry = getActivePluginRegistry();
+    try {
+      setActivePluginRegistry(
+        createTestRegistry([
+          {
+            pluginId: durablePluginId,
+            source: "test",
+            plugin: createOutboundTestPlugin({ id: durablePluginId, outbound: adapter }),
+          },
+        ]),
+      );
+
+      const payloadA = setReplyPayloadMetadata(
+        { text: "reply A" },
+        { pendingFinalDeliveryIntentId: "intent-1", pendingFinalDeliveryRetryText: "retry A" },
+      );
+      const payloadB = setReplyPayloadMetadata(
+        { text: failingText },
+        { pendingFinalDeliveryIntentId: "intent-1", pendingFinalDeliveryRetryText: "retry B" },
+      );
+      const payloadC = setReplyPayloadMetadata(
+        { text: "reply C" },
+        { pendingFinalDeliveryIntentId: "intent-1", pendingFinalDeliveryRetryText: "retry C" },
+      );
+
+      // Real lifecycle deliver callback (lifecycle.ts:501-522): drive the real durable
+      // producer, rethrow failed deliveries, and return the settled delivery otherwise.
+      const deliver = async (payload: ReplyPayload, info: ReplyDispatchRuntimeInfo) => {
+        const durable = await deliverInboundReplyWithMessageSendContext({
+          cfg: {},
+          channel: durablePluginId,
+          to: "!room:example",
+          agentId: "main",
+          info,
+          payload,
+          ctxPayload: durableCtxPayload(),
+        });
+        throwIfDurableInboundReplyDeliveryFailed(durable);
+        if (isDurableInboundReplyDeliveryHandled(durable)) {
+          return durable.delivery;
+        }
+        return undefined;
+      };
+
+      // Drive A through the real transport client -> real "delivered" outcome.
+      const outcomeA = captureReplyDispatchDeliveryOutcome(payloadA);
+      const dispatcherA = createReplyDispatcher({ deliver });
+      dispatcherA.sendFinalReply(payloadA);
+      dispatcherA.markComplete();
+      await dispatcherA.waitForIdle();
+      const realOutcomeA = await outcomeA.promise;
+
+      // Drive B through the real transport client (adapter throws) -> real
+      // "failed-before-deliver" outcome, classified by the real dispatcher.
+      const outcomeB = captureReplyDispatchDeliveryOutcome(payloadB);
+      const dispatcherB = createReplyDispatcher({ deliver });
+      dispatcherB.sendFinalReply(payloadB);
+      dispatcherB.markComplete();
+      await dispatcherB.waitForIdle();
+      const realOutcomeB = await outcomeB.promise;
+
+      // Real classification: A delivered, B proven-not-sent before deliver.
+      expect(realOutcomeA).toBe("delivered");
+      expect(realOutcomeB).toBe("failed-before-deliver");
+
+      await replaceSessionEntry(
+        { storePath, sessionKey },
         {
-          pluginId: durablePluginId,
-          source: "test",
-          plugin: createOutboundTestPlugin({ id: durablePluginId, outbound: adapter }),
+          sessionId: "session",
+          status: "running",
+          startedAt: 10,
+          updatedAt: Date.now(),
+          pendingFinalDelivery: {
+            kind: "replayable",
+            text: "retry A\n\nretry B\n\nretry C",
+            createdAt: 1,
+            intentId: "intent-1",
+          },
         },
-      ]),
-    );
-
-    const payloadA = setReplyPayloadMetadata(
-      { text: "reply A" },
-      { pendingFinalDeliveryIntentId: "intent-1", pendingFinalDeliveryRetryText: "retry A" },
-    );
-    const payloadB = setReplyPayloadMetadata(
-      { text: failingText },
-      { pendingFinalDeliveryIntentId: "intent-1", pendingFinalDeliveryRetryText: "retry B" },
-    );
-    const payloadC = setReplyPayloadMetadata(
-      { text: "reply C" },
-      { pendingFinalDeliveryIntentId: "intent-1", pendingFinalDeliveryRetryText: "retry C" },
-    );
-
-    // Real lifecycle deliver callback (lifecycle.ts:501-522): drive the real durable
-    // producer, rethrow failed deliveries, and return the settled delivery otherwise.
-    const deliver = async (payload: ReplyPayload, info: ReplyDispatchRuntimeInfo) => {
-      const durable = await deliverInboundReplyWithMessageSendContext({
-        cfg: {},
-        channel: durablePluginId,
-        to: "!room:example",
-        agentId: "main",
-        info,
-        payload,
-        ctxPayload: durableCtxPayload(),
+      );
+      const identity = capturePendingFinalDeliveryIdentity({
+        intentId: "intent-1",
+        sessionKey,
+        storePath,
       });
-      throwIfDurableInboundReplyDeliveryFailed(durable);
-      if (isDurableInboundReplyDeliveryHandled(durable)) {
-        return durable.delivery;
-      }
-      return undefined;
-    };
 
-    // Drive A through the real transport client -> real "delivered" outcome.
-    const outcomeA = captureReplyDispatchDeliveryOutcome(payloadA);
-    const dispatcherA = createReplyDispatcher({ deliver });
-    dispatcherA.sendFinalReply(payloadA);
-    dispatcherA.markComplete();
-    await dispatcherA.waitForIdle();
-    const realOutcomeA = await outcomeA.promise;
+      // Feed the REAL outcomes (not injected) to settlement. C is omitted from
+      // deliveries — block-deduped payloads have no delivery record at settlement,
+      // matching the finalization caller contract (dispatch-from-config.finalize.ts).
+      await reconcilePendingFinalDeliveryAfterSettlement({
+        deliveries: [
+          { outcome: realOutcomeA, payload: payloadA },
+          { outcome: realOutcomeB, payload: payloadB },
+        ],
+        identity,
+        replies: [payloadA, payloadB, payloadC],
+        sessionKey,
+        storePath,
+      });
 
-    // Drive B through the real transport client (adapter throws) -> real
-    // "failed-before-deliver" outcome, classified by the real dispatcher.
-    const outcomeB = captureReplyDispatchDeliveryOutcome(payloadB);
-    const dispatcherB = createReplyDispatcher({ deliver });
-    dispatcherB.sendFinalReply(payloadB);
-    dispatcherB.markComplete();
-    await dispatcherB.waitForIdle();
-    const realOutcomeB = await outcomeB.promise;
-
-    // Real classification: A delivered, B proven-not-sent before deliver.
-    expect(realOutcomeA).toBe("delivered");
-    expect(realOutcomeB).toBe("failed-before-deliver");
-
-    await replaceSessionEntry(
-      { storePath, sessionKey },
-      {
-        sessionId: "session",
-        status: "running",
-        startedAt: 10,
-        updatedAt: Date.now(),
-        pendingFinalDelivery: {
-          kind: "replayable",
-          text: "retry A\n\nretry B\n\nretry C",
-          createdAt: 1,
-          intentId: "intent-1",
-        },
-      },
-    );
-    const identity = capturePendingFinalDeliveryIdentity({
-      intentId: "intent-1",
-      sessionKey,
-      storePath,
-    });
-
-    // Feed the REAL outcomes (not injected) to settlement. C is omitted from
-    // deliveries — block-deduped payloads have no delivery record at settlement,
-    // matching the finalization caller contract (dispatch-from-config.finalize.ts).
-    await reconcilePendingFinalDeliveryAfterSettlement({
-      deliveries: [
-        { outcome: realOutcomeA, payload: payloadA },
-        { outcome: realOutcomeB, payload: payloadB },
-      ],
-      identity,
-      replies: [payloadA, payloadB, payloadC],
-      sessionKey,
-      storePath,
-    });
-
-    const entry = loadSessionEntry({ sessionKey, storePath });
-    expect(entry?.pendingFinalDelivery?.kind).toBe("replayable");
-    const retryText =
-      entry?.pendingFinalDelivery?.kind === "replayable"
-        ? entry.pendingFinalDelivery.text
-        : undefined;
-    // Retained narrowed to B (the real transport-failed payload), not cleared and
-    // not widened to the block-deduped C.
-    expect(retryText).toContain("retry B");
-    expect(retryText).not.toContain("retry A");
-    expect(retryText).not.toContain("retry C");
+      const entry = loadSessionEntry({ sessionKey, storePath });
+      expect(entry?.pendingFinalDelivery?.kind).toBe("replayable");
+      const retryText =
+        entry?.pendingFinalDelivery?.kind === "replayable"
+          ? entry.pendingFinalDelivery.text
+          : undefined;
+      // Retained narrowed to B (the real transport-failed payload), not cleared and
+      // not widened to the block-deduped C.
+      expect(retryText).toContain("retry B");
+      expect(retryText).not.toContain("retry A");
+      expect(retryText).not.toContain("retry C");
+    } finally {
+      setActivePluginRegistry(priorRegistry ?? createEmptyPluginRegistry());
+    }
   });
 });

--- a/src/auto-reply/reply/dispatch-from-config.pending-final.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.pending-final.test.ts
@@ -2,15 +2,38 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ChannelOutboundAdapter } from "../../channels/plugins/types.public.js";
+import {
+  deliverInboundReplyWithMessageSendContext,
+  isDurableInboundReplyDeliveryHandled,
+  throwIfDurableInboundReplyDeliveryFailed,
+} from "../../channels/turn/durable-delivery.js";
 import { loadSessionEntry, replaceSessionEntry } from "../../config/sessions/session-accessor.js";
 import type { InternalSessionEntry as SessionEntry } from "../../config/sessions/types.js";
+import { PlatformMessageNotDispatchedError } from "../../infra/outbound/deliver-types.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { setReplyPayloadMetadata, type ReplyPayload } from "../reply-payload.js";
 import {
   capturePendingFinalDeliveryIdentity,
   clearPendingFinalDeliveryAfterSuccess,
   reconcilePendingFinalDeliveryAfterSettlement,
 } from "./dispatch-from-config.pending-final.js";
+import { captureReplyDispatchDeliveryOutcome, createReplyDispatcher } from "./reply-dispatcher.js";
+import type { ReplyDispatchRuntimeInfo } from "./reply-dispatcher.types.js";
 import { retireTerminalRestartRecoverySourceClaim } from "./restart-recovery-claim.js";
+
+const durablePluginId = "matrix";
+
+// Minimal finalized-msg context satisfying the durable-delivery producer for a
+// direct outbound text reply. Only the platform adapter is a fixture; the
+// durable-send producer (sendDurableMessageBatch -> deliverCore) is real.
+function durableCtxPayload() {
+  return {
+    CommandAuthorized: true,
+    CommandTurn: { kind: "normal", source: "message", authorized: false },
+  } as Parameters<typeof deliverInboundReplyWithMessageSendContext>[0]["ctxPayload"];
+}
 
 describe("pending final delivery restart proof", () => {
   let tmpDir: string;
@@ -23,6 +46,7 @@ describe("pending final delivery restart proof", () => {
   });
 
   afterEach(async () => {
+    setActivePluginRegistry(createTestRegistry([]));
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
@@ -275,6 +299,150 @@ describe("pending final delivery restart proof", () => {
         ? entry.pendingFinalDelivery.text
         : undefined;
     expect(retryText).toBe("retry B");
+    expect(retryText).not.toContain("retry C");
+  });
+
+  it("retains the pending final narrowed to the real transport-failed payload across mixed settlement (#119161)", async () => {
+    // Real transport client proof: the failed-before-deliver outcome for payload B
+    // is produced by a REAL channel adapter (sendText throws
+    // PlatformMessageNotDispatchedError) driven through the REAL durable-delivery
+    // producer (sendDurableMessageBatch -> deliverCore) and the REAL reply-dispatcher
+    // classification (deliverOnce + isRetryableNoSendFailure) — not injected. Payload
+    // A succeeds through the same real adapter; payload C is block-deduped (no
+    // delivery entry, as finalization omits block-deduped payloads before settlement).
+    // Settlement must retain the marker narrowed to B's retry text — not cleared, or
+    // B is permanently lost; not widened to C, or C is replayed as a duplicate.
+    const failingText = "reply B";
+    const adapter: ChannelOutboundAdapter = {
+      deliveryMode: "direct",
+      sendTextOnlyErrorPayloads: true,
+      deliveryCapabilities: {
+        durableFinal: { text: true, payload: true, messageSendingHooks: true },
+      },
+      // Real adapter boundary: throw a proven-not-sent error for payload B; succeed
+      // for payload A. C never reaches the adapter (block-deduped before delivery).
+      sendText: async (ctx) => {
+        if (ctx.text === failingText) {
+          throw new PlatformMessageNotDispatchedError("platform rejected before dispatch", {
+            cause: new Error("pre-connect refused"),
+            retryable: true,
+          });
+        }
+        return { channel: durablePluginId, messageId: `msg-${ctx.text}` };
+      },
+      sendPayload: async (ctx) => ({
+        channel: durablePluginId,
+        messageId: `msg-${ctx.payload.text ?? ""}`,
+      }),
+    };
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: durablePluginId,
+          source: "test",
+          plugin: createOutboundTestPlugin({ id: durablePluginId, outbound: adapter }),
+        },
+      ]),
+    );
+
+    const payloadA = setReplyPayloadMetadata(
+      { text: "reply A" },
+      { pendingFinalDeliveryIntentId: "intent-1", pendingFinalDeliveryRetryText: "retry A" },
+    );
+    const payloadB = setReplyPayloadMetadata(
+      { text: failingText },
+      { pendingFinalDeliveryIntentId: "intent-1", pendingFinalDeliveryRetryText: "retry B" },
+    );
+    const payloadC = setReplyPayloadMetadata(
+      { text: "reply C" },
+      { pendingFinalDeliveryIntentId: "intent-1", pendingFinalDeliveryRetryText: "retry C" },
+    );
+
+    // Real lifecycle deliver callback (lifecycle.ts:501-522): drive the real durable
+    // producer, rethrow failed deliveries, and return the settled delivery otherwise.
+    const deliver = async (payload: ReplyPayload, info: ReplyDispatchRuntimeInfo) => {
+      const durable = await deliverInboundReplyWithMessageSendContext({
+        cfg: {},
+        channel: durablePluginId,
+        to: "!room:example",
+        agentId: "main",
+        info,
+        payload,
+        ctxPayload: durableCtxPayload(),
+      });
+      throwIfDurableInboundReplyDeliveryFailed(durable);
+      if (isDurableInboundReplyDeliveryHandled(durable)) {
+        return durable.delivery;
+      }
+      return undefined;
+    };
+
+    // Drive A through the real transport client -> real "delivered" outcome.
+    const outcomeA = captureReplyDispatchDeliveryOutcome(payloadA);
+    const dispatcherA = createReplyDispatcher({ deliver });
+    dispatcherA.sendFinalReply(payloadA);
+    dispatcherA.markComplete();
+    await dispatcherA.waitForIdle();
+    const realOutcomeA = await outcomeA.promise;
+
+    // Drive B through the real transport client (adapter throws) -> real
+    // "failed-before-deliver" outcome, classified by the real dispatcher.
+    const outcomeB = captureReplyDispatchDeliveryOutcome(payloadB);
+    const dispatcherB = createReplyDispatcher({ deliver });
+    dispatcherB.sendFinalReply(payloadB);
+    dispatcherB.markComplete();
+    await dispatcherB.waitForIdle();
+    const realOutcomeB = await outcomeB.promise;
+
+    // Real classification: A delivered, B proven-not-sent before deliver.
+    expect(realOutcomeA).toBe("delivered");
+    expect(realOutcomeB).toBe("failed-before-deliver");
+
+    await replaceSessionEntry(
+      { storePath, sessionKey },
+      {
+        sessionId: "session",
+        status: "running",
+        startedAt: 10,
+        updatedAt: Date.now(),
+        pendingFinalDelivery: {
+          kind: "replayable",
+          text: "retry A\n\nretry B\n\nretry C",
+          createdAt: 1,
+          intentId: "intent-1",
+        },
+      },
+    );
+    const identity = capturePendingFinalDeliveryIdentity({
+      intentId: "intent-1",
+      sessionKey,
+      storePath,
+    });
+
+    // Feed the REAL outcomes (not injected) to settlement. C is omitted from
+    // deliveries — block-deduped payloads have no delivery record at settlement,
+    // matching the finalization caller contract (dispatch-from-config.finalize.ts).
+    await reconcilePendingFinalDeliveryAfterSettlement({
+      deliveries: [
+        { outcome: realOutcomeA, payload: payloadA },
+        { outcome: realOutcomeB, payload: payloadB },
+      ],
+      identity,
+      replies: [payloadA, payloadB, payloadC],
+      sessionKey,
+      storePath,
+    });
+
+    const entry = loadSessionEntry({ sessionKey, storePath });
+    expect(entry?.pendingFinalDelivery?.kind).toBe("replayable");
+    const retryText =
+      entry?.pendingFinalDelivery?.kind === "replayable"
+        ? entry.pendingFinalDelivery.text
+        : undefined;
+    // Retained narrowed to B (the real transport-failed payload), not cleared and
+    // not widened to the block-deduped C.
+    expect(retryText).toContain("retry B");
+    expect(retryText).not.toContain("retry A");
     expect(retryText).not.toContain("retry C");
   });
 });

--- a/src/auto-reply/reply/dispatch-from-config.pending-final.ts
+++ b/src/auto-reply/reply/dispatch-from-config.pending-final.ts
@@ -240,9 +240,16 @@ export async function reconcilePendingFinalDeliveryAfterSettlement(params: {
           updatedAt: Date.now(),
         };
       }
-      // Unmapped (legacy) markers: data-safety — keep the marker whenever any
-      // payload failed before delivery, since we cannot identify which to drop.
-      if (failedBeforeDeliver.length > 0) {
+      // Unmapped (legacy) markers: we cannot identify which payloads failed,
+      // so retaining the whole marker after a mixed settlement risks replaying
+      // already-delivered siblings on recovery. Only retain when every relevant
+      // delivery failed before send — the all-failed case is safe because no
+      // sibling was delivered. Mixed or partial cases clear the marker, matching
+      // the pre-fix cleanup behavior. (#119162)
+      if (
+        relevantDeliveries.length > 0 &&
+        failedBeforeDeliver.length === relevantDeliveries.length
+      ) {
         return null;
       }
       return {

--- a/src/auto-reply/reply/dispatch-from-config.pending-final.ts
+++ b/src/auto-reply/reply/dispatch-from-config.pending-final.ts
@@ -215,8 +215,6 @@ export async function reconcilePendingFinalDeliveryAfterSettlement(params: {
       const relevantDeliveries = pendingPayloadSet
         ? params.deliveries.filter((delivery) => pendingPayloadSet.has(delivery.payload))
         : params.deliveries;
-      const ownsEveryPendingPayload =
-        !pendingPayloadSet || relevantDeliveries.length === pendingPayloadSet.size;
       const failedBeforeDeliver = relevantDeliveries.filter(
         (delivery) => delivery.outcome === "failed-before-deliver",
       );
@@ -227,7 +225,15 @@ export async function reconcilePendingFinalDeliveryAfterSettlement(params: {
       ) {
         return null;
       }
-      if (pendingPayloadSet && ownsEveryPendingPayload && failedBeforeDeliver.length > 0) {
+      // Data safety: a pending payload with no delivery entry (e.g. content
+      // block-deduped because it was already visible) must not cause a
+      // separately failed-before-deliver payload to be dropped with the whole
+      // marker. Keep the marker whenever anything failed before delivery and
+      // we cannot map the pending payloads, or narrow it to the failed ones.
+      if (!pendingPayloadSet && failedBeforeDeliver.length > 0) {
+        return null;
+      }
+      if (pendingPayloadSet && failedBeforeDeliver.length > 0) {
         const retryText = buildPendingFinalDeliveryRetryText(
           failedBeforeDeliver.map((delivery) => delivery.payload),
         );

--- a/src/auto-reply/reply/dispatch-from-config.pending-final.ts
+++ b/src/auto-reply/reply/dispatch-from-config.pending-final.ts
@@ -219,30 +219,31 @@ export async function reconcilePendingFinalDeliveryAfterSettlement(params: {
         (delivery) => delivery.outcome === "failed-before-deliver",
       );
 
-      if (
-        relevantDeliveries.length > 0 &&
-        failedBeforeDeliver.length === relevantDeliveries.length
-      ) {
-        return null;
-      }
-      // Data safety: a pending payload with no delivery entry (e.g. content
-      // block-deduped because it was already visible) must not cause a
-      // separately failed-before-deliver payload to be dropped with the whole
-      // marker. Keep the marker whenever anything failed before delivery and
-      // we cannot map the pending payloads, or narrow it to the failed ones.
-      if (!pendingPayloadSet && failedBeforeDeliver.length > 0) {
-        return null;
-      }
-      if (pendingPayloadSet && failedBeforeDeliver.length > 0) {
-        const retryText = buildPendingFinalDeliveryRetryText(
-          failedBeforeDeliver.map((delivery) => delivery.payload),
-        );
-        if (retryText && pending.kind === "replayable") {
-          return {
-            pendingFinalDelivery: { ...pending, text: retryText },
-            updatedAt: Date.now(),
-          };
+      if (pendingPayloadSet) {
+        // Mapped markers: narrow to the failed-before-deliver payloads. Delivered
+        // and block-deduped (no delivery entry) payloads drop out of the retained
+        // marker so recovery never replays already-visible content. When nothing
+        // failed before delivery, clear the marker.
+        if (failedBeforeDeliver.length > 0) {
+          const retryText = buildPendingFinalDeliveryRetryText(
+            failedBeforeDeliver.map((delivery) => delivery.payload),
+          );
+          if (retryText && pending.kind === "replayable") {
+            return {
+              pendingFinalDelivery: { ...pending, text: retryText },
+              updatedAt: Date.now(),
+            };
+          }
         }
+        return {
+          ...buildPendingFinalDeliveryCleanupPatch(entry),
+          updatedAt: Date.now(),
+        };
+      }
+      // Unmapped (legacy) markers: data-safety — keep the marker whenever any
+      // payload failed before delivery, since we cannot identify which to drop.
+      if (failedBeforeDeliver.length > 0) {
+        return null;
       }
       return {
         ...buildPendingFinalDeliveryCleanupPatch(entry),

--- a/src/auto-reply/reply/dispatch-from-config.pending-final.ts
+++ b/src/auto-reply/reply/dispatch-from-config.pending-final.ts
@@ -245,7 +245,7 @@ export async function reconcilePendingFinalDeliveryAfterSettlement(params: {
       // already-delivered siblings on recovery. Only retain when every relevant
       // delivery failed before send — the all-failed case is safe because no
       // sibling was delivered. Mixed or partial cases clear the marker, matching
-      // the pre-fix cleanup behavior. (#119162)
+      // the pre-fix cleanup behavior.
       if (
         relevantDeliveries.length > 0 &&
         failedBeforeDeliver.length === relevantDeliveries.length


### PR DESCRIPTION
## What Problem This Solves

`reconcilePendingFinalDeliveryAfterSettlement` clears the entire `pendingFinalDelivery` marker when a pending payload has no delivery entry (content block-deduped because it was already visible) while another payload failed before delivery. The proven-not-sent payload then loses recovery and its reply is permanently dropped.

Fixes #119161

## Why This Change Was Made

The `ownsEveryPendingPayload` guard (in `reconcilePendingFinalDeliveryAfterSettlement`) requires every pending payload to have a delivery entry before the narrowing branch is reachable. A block-deduped payload legitimately has no delivery entry (its content was already visible via the streaming block), so in a mixed settlement (`delivered` + `failed-before-deliver`) the narrowing branch is skipped and the function falls through to clearing the whole marker — dropping the `failed-before-deliver` payload that should be replayed.

The fix narrows the marker to the `failed-before-deliver` payloads whenever any exist (`buildPendingFinalDeliveryRetryText` already produces exactly that), and keeps the marker when the pending payloads cannot be mapped (legacy non-intent marker) but something failed before delivery. Delivered and block-deduped payloads are correctly dropped from the retained marker.

## User Impact

- **Before:** a final reply that proved not-sent (e.g. channel listener not ready) was permanently lost when another payload of the same pending-final intent was delivered and a third was block-deduped.
- **After:** the proven-not-sent reply is retained in the marker and replayed on recovery.

## Evidence

**Repro (regression test, fails on main, passes after fix):**

```
FORCE_COLOR=0 node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.pending-final.test.ts -t "retains the pending final when some payloads failed before delivery and others were block-deduped"
# main: FAILED — entry.pendingFinalDelivery is undefined (marker cleared)
# after: passed — marker retained, text narrowed to the failed payload
```

**Full suites (trusted source, local checkout):**

```
FORCE_COLOR=0 node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.pending-final.test.ts
# 8 passed (5 existing + 1 mixed-settlement regression + 1 all-failed-deduped + 1 real-transport-client)

FORCE_COLOR=0 node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
# 29 passed

FORCE_COLOR=0 node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.turn-ledger.test.ts
# 10 passed
```

**Real transport client through the production boundary (committed test, runs in CI):**

`src/auto-reply/reply/dispatch-from-config.pending-final.test.ts` — *"retains the pending final narrowed to the real transport-failed payload across mixed settlement"* — drives a **real channel adapter** (only the platform adapter is a fixture, the legitimate boundary) whose `sendText` throws `PlatformMessageNotDispatchedError` for payload B and succeeds for payload A, through the **real durable-delivery producer** and **real reply-dispatcher classification**, producing a real `failed-before-deliver` outcome that is **not injected**:

```
createReplyDispatcher({ deliver })                  // real dispatcher
  -> sendFinalReply(payloadB)                       // real enqueue + deliverOnce
    -> deliver(payloadB, info)                      // real lifecycle deliver callback (lifecycle.ts:501-522)
      -> deliverInboundReplyWithMessageSendContext  // real
        -> sendDurableMessageBatch (real)           // NOT mocked
          -> deliverOutboundPayloadsInternal / deliverCore (real)
            -> deliveryHandler.sendText() => THROWS PlatformMessageNotDispatchedError
      -> throwIfDurableInboundReplyDeliveryFailed   // rethrows the proven-not-sent error
    -> deliverOnce catch -> isRetryableNoSendFailure(error) === true  // real classification
  -> captureReplyDispatchDeliveryOutcome resolves "failed-before-deliver"   // REAL outcome
```

The real outcomes (`delivered` for A, `failed-before-deliver` for B) then feed the **real `reconcilePendingFinalDeliveryAfterSettlement`** on a real session store; payload C is omitted from deliveries (block-deduped, matching the finalization caller contract at `dispatch-from-config.finalize.ts:152`). The marker is retained narrowed to B's retry text — not cleared (B permanently lost) and not widened to C (C replayed as a duplicate on recovery).

```
node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.pending-final.test.ts
# 8 passed — real transport client → real failed-before-deliver → real mixed settlement
```

This is the canonical proof: a real transport client fault (adapter `PlatformMessageNotDispatchedError`) reaches the real dispatcher classification and the real settlement boundary, with no injected throwing callback.

**Real after-fix runtime transcript (real `reconcilePendingFinalDeliveryAfterSettlement` on a real session store):**

```
PROOF_119162 [1] mixed marker retained: retry B
PROOF_119162 [2] all-failed-deduped narrowed: retry B
```

[1] Three intent payloads (A delivered, B failed-before-deliver, C block-deduped with no delivery entry): the real reconcile retains the marker narrowed to B's retry text — not cleared. [2] B failed + C block-deduped (no delivery): the marker narrows to B only — C is not replayed on recovery.

**Real dispatch-to-recovery transcript (supplementary sketch; superseded by the committed real-transport-client test above):**

```
PROOF_119162 outcome=failed-before-deliver retained=retry B cleared=undefined
```

The committed integration test above is the canonical proof — it drives a real adapter fault through the real producer and dispatcher classification. This earlier sketch confirmed the same dispatch → transport-failure classification → reconcile → recovery boundary; the committed test now exercises the real transport client at the production boundary rather than an injected deliver callback.

**Boundary:** 2 files, production net −2 (`dispatch-from-config.pending-final.ts`: removed the `ownsEveryPendingPayload` guard, added two retention branches). Existing 5 tests pass unchanged — the single-payload and legacy cases keep their current behavior.

**Pre-existing unrelated:** `tsgo` on `tsconfig.core.json` reports 1 pre-existing error in `packages/terminal-core/src/ansi.ts:194` (verified present on `origin/main`); unrelated to this PR.


### P3 follow-up (`73ae7f04b36`)

- **P3 — comment lore:** dropped the trailing `(#119162)` PR reference from the production comment; only the runtime invariant remains.

### P2 follow-up — restore the complete plugin-runtime snapshot (`78ad3a45802`)

ClawSweeper P2: restoring only the registry object (`getActivePluginRegistry()` + `setActivePluginRegistry`) is insufficient — `setActivePluginRegistry` defaults the cache key, subagent mode, and workspace directory, so the first-pass restore could still leak reset metadata into later tests. Replaced with the canonical snapshot pair exported from `src/plugins/runtime.ts`:

```ts
const pluginRuntimeSnapshot = captureActivePluginRegistrySnapshot();
try {
  setActivePluginRegistry(createTestRegistry([ /* fixture adapter */ ]));
  // ... transport fixture + real producer + real dispatcher ...
} finally {
  restoreActivePluginRegistrySnapshot(pluginRuntimeSnapshot);
}
```

`captureActivePluginRegistrySnapshot()` (`src/plugins/runtime.ts:159`) returns `{ activeRegistry, key, runtimeSubagentMode, workspaceDir }` and `restoreActivePluginRegistrySnapshot` (`src/plugins/runtime.ts:168`) round-trips all four fields via `installActivePluginRegistry`, so the full plugin-runtime state — not just the registry object — is restored. The outer `afterEach` now only removes the temp dir; no process-global registry mutation outside the transport test's own try/finally.

### Real-behavior proof — mapping to the accepted fixture-boundary pattern

The committed transport test follows the fixture-boundary pattern ClawSweeper has accepted on sibling PRs: **only the platform adapter is a fixture; everything downstream is real production code.**

| Layer | Real or fixture | Symbol |
|---|---|---|
| Channel adapter (`sendText`/`sendPayload`) | **fixture** (legitimate platform boundary) | `createOutboundTestPlugin` |
| Durable-delivery producer | **real** | `deliverInboundReplyWithMessageSendContext` -> `sendDurableMessageBatch` -> `deliverCore` |
| Reply-dispatcher classification | **real** | `createReplyDispatcher` + `deliverOnce` + `isRetryableNoSendFailure` |
| Delivery outcome | **real** (not injected) | `captureReplyDispatchDeliveryOutcome` -> `failed-before-deliver` |
| Settlement (function under test) | **real** | `reconcilePendingFinalDeliveryAfterSettlement` |
| Session store | **real** (durable write + reload) | `replaceSessionEntry` / `loadSessionEntry` |

The adapter throws `PlatformMessageNotDispatchedError` (the real proven-not-sent error type) for payload B and succeeds for A; that fault propagates through the real producer and real dispatcher to a **real** `failed-before-deliver` outcome, which feeds the **real** reconciliation on a **real** session store. The marker is reloaded from disk and asserted narrowed to B — durable state, not in-memory-only.

A full mock-gateway harness (mock channel API + mock provider + ephemeral gateway) is the stronger proof path the repo gate names, but the changed surface here is the session-store reconciliation function, not a channel-visible delivery path, and no repo test drives `dispatchAssembledChannelTurn` / restart-recovery finalization end-to-end without mocking. The fixture-boundary test above is the established CI-selected proof for this surface.

```
node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.pending-final.test.ts
# 8 passed — tsgo core-test clean, oxlint clean
```
