### PR TITLE
fix(testbox): remove changed-gate sync residue

### DIFF
--- a/scripts/crabbox-wrapper.mjs
+++ b/scripts/crabbox-wrapper.mjs
@@ -2421,7 +2421,8 @@ function remoteGitBootstrapForChangedGate(changedGateBase, changedGateAlias) {
     'openclaw_changed_gate_bundle_tmp="$(mktemp /tmp/openclaw-changed-gate.XXXXXX)" || exit 2;',
     "trap 'rm -f \"$openclaw_changed_gate_bundle_tmp\"' EXIT HUP INT TERM;",
     'cp "$openclaw_changed_gate_bundle" "$openclaw_changed_gate_bundle_tmp" || exit 2;',
-    'rm -rf -- "$openclaw_changed_gate_bundle" || exit 2;',
+    // Interrupted rsync leaves bundle.XXXXXX beside the destination; never expose transport residue to lane classification.
+    'rm -rf -- "$openclaw_changed_gate_bundle" "$openclaw_changed_gate_bundle".* || exit 2;',
     "rm -rf .git || exit 2;",
     "git init -q || exit 2;",
     "git remote add origin https://github.com/openclaw/openclaw.git 2>/dev/null || git remote set-url origin https://github.com/openclaw/openclaw.git || exit 2;",

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -663,6 +663,11 @@ function expectChangedGateGitBootstrap(remoteCommand: string): void {
   );
   expect(remoteCommand).toContain("mktemp /tmp/openclaw-changed-gate.XXXXXX");
   expect(remoteCommand).toContain('cp "$openclaw_changed_gate_bundle"');
+  const cleanupIndex = remoteCommand.indexOf(
+    'rm -rf -- "$openclaw_changed_gate_bundle" "$openclaw_changed_gate_bundle".* || exit 2',
+  );
+  expect(cleanupIndex).toBeGreaterThanOrEqual(0);
+  expect(cleanupIndex).toBeLessThan(remoteCommand.indexOf("rm -rf .git || exit 2"));
   expect(remoteCommand).toContain("git init -q || exit 2");
   expect(remoteCommand).toContain(`${remoteChangedGateFetch} || exit 2`);
   expect(remoteCommand).toContain(


### PR DESCRIPTION
## Summary

- remove rsync's same-basename temporary bundle residue during remote changed-gate bootstrap
- keep transport files out of changed-lane classification after an interrupted sync and unchanged-ref retry
- pin cleanup ordering before the remote checkout replaces `.git`

Fixes #119157.

## Root cause

The bootstrap copied and removed `.openclaw-crabbox-changed-gate.bundle`, but an interrupted rsync could leave `.openclaw-crabbox-changed-gate.bundle.XXXXXX` beside it. On the documented `--no-sync` unchanged-head retry, that transport residue reached `check:changed` and was classified as an unknown repository surface, escalating a small change to `lanes=all`.

## Proof

- observed before fix: `.openclaw-crabbox-changed-gate.bundle.XrzBe4: unknown surface; fail-safe all lanes`
- Blacksmith Testbox `tbx_01kz5yb660gtxmtvxbfcb0583z` ([run 30892268909](https://github.com/openclaw/openclaw/actions/runs/30892268909)): seeded `.bundle.stale`, ran the real remote changed-gate bootstrap, asserted the residue was absent, and got exactly `lanes=testRoot, tooling`
- `pnpm test test/scripts/crabbox-wrapper.test.ts` on the same Testbox checkout — 244/244 passed
- exact modified local test — 1 passed / 243 skipped
- AutoReview against current `origin/main` — clean, no accepted/actionable findings
- diff: tooling +2/-1, tests +5/-0; production runtime LOC delta 0
- public model identifier gate: PASS; the diff contains no model identifiers

Risk is low and limited to cleanup of one constant-owned transport basename. No changelog entry is needed for a test-infrastructure repair.
