### PR TITLE
fix(perf): give each concurrency sample a full deadline

### DIFF
--- a/scripts/bench-gateway-concurrency.ts
+++ b/scripts/bench-gateway-concurrency.ts
@@ -190,7 +190,7 @@ Options:
   --runs <n>         Measured gateway runs (default: ${DEFAULT_RUNS})
   --warmup <n>       Warmup gateway runs (default: ${DEFAULT_WARMUP})
   --cadence-ms <ms>  Probe cadence (default: ${DEFAULT_CADENCE_MS})
-  --timeout-ms <ms>  Whole benchmark cap, excluding probe warmup (default: ${DEFAULT_TIMEOUT_MS})
+  --timeout-ms <ms>  Per-run cap, excluding probe warmup (default: ${DEFAULT_TIMEOUT_MS})
   --entry <path>     Gateway CLI entry file (default: ${DEFAULT_ENTRY})
   --output <path>    Write machine-readable JSON to a file
   --json             Emit machine-readable JSON
@@ -814,6 +814,35 @@ function summarizeRuns(runs: readonly BenchmarkRun[]) {
   };
 }
 
+async function runBenchmarkSamples(params: {
+  now?: () => number;
+  onProgress?: (message: string) => void;
+  options: CliOptions;
+  runSample?: typeof runGatewaySample;
+}): Promise<BenchmarkRun[]> {
+  const now = params.now ?? performance.now.bind(performance);
+  const runSample = params.runSample ?? runGatewaySample;
+  const runs: BenchmarkRun[] = [];
+  const total = params.options.runs + params.options.warmup;
+  for (let index = 0; index < total; index += 1) {
+    // Each sample gets the same budget so earlier runs cannot shrink later agent waits.
+    // runGatewaySample extends this deadline by its probe warmup before load starts.
+    const deadlineAt = now() + params.options.timeoutMs;
+    const run = await runSample({ ...params.options, deadlineAt });
+    if (index >= params.options.warmup) {
+      runs.push(run);
+      params.onProgress?.(
+        `[bench-gateway-concurrency] run ${runs.length}/${params.options.runs}: turns=${run.turnCount} samples=${run.readyz.length} duration=${run.durationMs.toFixed(1)}ms`,
+      );
+    } else {
+      params.onProgress?.(
+        `[bench-gateway-concurrency] warmup ${index + 1}/${params.options.warmup}: duration=${run.durationMs.toFixed(1)}ms`,
+      );
+    }
+  }
+  return runs;
+}
+
 async function main(): Promise<void> {
   const argv = process.argv.slice(2);
   if (hasHelpFlag(argv)) {
@@ -821,24 +850,7 @@ async function main(): Promise<void> {
     return;
   }
   const options = parseOptions(argv);
-  let deadlineAt = performance.now() + options.timeoutMs;
-  const runs: BenchmarkRun[] = [];
-  const total = options.runs + options.warmup;
-  for (let index = 0; index < total; index += 1) {
-    requireRemainingMs(deadlineAt, "starting gateway run");
-    const run = await runGatewaySample({ ...options, deadlineAt });
-    deadlineAt += run.probeWarmup.durationMs;
-    if (index >= options.warmup) {
-      runs.push(run);
-      console.error(
-        `[bench-gateway-concurrency] run ${runs.length}/${options.runs}: turns=${run.turnCount} samples=${run.readyz.length} duration=${run.durationMs.toFixed(1)}ms`,
-      );
-    } else {
-      console.error(
-        `[bench-gateway-concurrency] warmup ${index + 1}/${options.warmup}: duration=${run.durationMs.toFixed(1)}ms`,
-      );
-    }
-  }
+  const runs = await runBenchmarkSamples({ onProgress: console.error, options });
   const payload = {
     cadenceMs: options.cadenceMs,
     concurrency: options.concurrency,
@@ -862,6 +874,7 @@ export const testing = {
   formatProbeFailure,
   formatRunFailure,
   requestHttp,
+  runBenchmarkSamples,
   runTurn,
   sampleGateway,
   summarizeNumbers,

--- a/test/scripts/bench-gateway-concurrency.test.ts
+++ b/test/scripts/bench-gateway-concurrency.test.ts
@@ -76,6 +76,34 @@ describe("gateway concurrency benchmark script", () => {
     expect(wait?.timeoutMs).toBeLessThanOrEqual(2_000);
   });
 
+  it("gives every gateway sample a fresh pre-warmup timeout budget", async () => {
+    const deadlines: number[] = [];
+    const sample = {
+      controlUi: [],
+      durationMs: 10,
+      probeWarmup: { durationMs: 2, samples: [] },
+      readyz: [],
+      sessionsList: [],
+      turnCount: 8,
+      turnsDurationMs: 5,
+    };
+
+    const runs = await testing.runBenchmarkSamples({
+      now: (() => {
+        const values = [1_000, 9_000];
+        return () => values.shift() ?? 9_000;
+      })(),
+      options: testing.parseOptions(["--runs", "1", "--warmup", "1", "--timeout-ms", "5000"]),
+      runSample: async ({ deadlineAt }) => {
+        deadlines.push(deadlineAt);
+        return sample;
+      },
+    });
+
+    expect(deadlines).toEqual([6_000, 14_000]);
+    expect(runs).toEqual([sample]);
+  });
+
   it("preserves HTTP and RPC failures in baseline probe diagnostics", async () => {
     const probeOrder: string[] = [];
     const server = createHttpServer((req, res) => {


### PR DESCRIPTION
Follow-up to #118364 and #119063.

## What Problem This Solves

Fixes an issue where release validation running the gateway concurrency benchmark with a warmup and multiple measured samples could time out a later sample even when that sample completed within the configured timeout. The benchmark treated `--timeout-ms` as one shared budget, so earlier runs consumed the time available to later runs.

## Why This Change Was Made

Each warmup or measured gateway sample now receives its own pre-warmup timeout budget. The existing per-sample probe-warmup exclusion remains in `runGatewaySample`, and the sample loop is extracted behind focused injection points so deadline renewal is covered without booting a gateway.

This is the benchmark owner boundary. Increasing the release workflow timeout would only hide the shared-deadline bug and would leave later samples with progressively less time.

Provenance: the shared whole-benchmark deadline originated with the concurrency benchmark in #118193 (`3f3ceb2defbe`) and was carried forward when probe warmup was added in #118364 (`347f16d5565d`). Beta 8 full validation made the failure deterministic by running one warmup plus three measured samples.

## User Impact

Tooling only. Release and performance validation can run repeated gateway concurrency samples without false late-run timeouts caused by earlier samples.

## Evidence

- Before: exact candidate `05c987ccec4cd0032aa7727d2de0644916bafa11` reproduced the third-sample timeout in both the standalone performance run and the canonical Full Release Validation child:
  - https://github.com/openclaw/openclaw/actions/runs/30889828427
  - https://github.com/openclaw/openclaw/actions/runs/30889863642
- After: exact branch head `dd3ee190d375bf57345cce7d1835da2e54ff284d` built and completed one warmup plus three measured samples on a fresh Blacksmith Testbox:
  - https://github.com/openclaw/openclaw/actions/runs/30892729670
  - measured durations: 28.7 s, 31.9 s, 32.4 s
  - 8/8 turns completed in every measured sample
  - all probe-warmup samples healthy
  - one under-load ready/UI sample timed out while the RPC probe stayed healthy; the benchmark completed and retained that telemetry
- Exact-head `check:changed` passed on the same Testbox.
- Focused test: `test/scripts/bench-gateway-concurrency.test.ts`, 9/9 passed.
- Fresh P1 autoreview at `dd3ee190d375bf57345cce7d1835da2e54ff284d`: clean, no accepted/actionable findings.
- `oxfmt --check` and `git diff --check`: passed.

AI-assisted: yes. I reviewed the implementation and validation evidence.
