### PR TITLE
chore(tui): add PTY command surface coverage

### DIFF
--- a/qa/scenarios/ui/tui-command-surfaces-pty.yaml
+++ b/qa/scenarios/ui/tui-command-surfaces-pty.yaml
@@ -1,0 +1,40 @@
+title: TUI command surfaces PTY contracts
+scenario:
+  id: tui-command-surfaces-pty
+  surface: tui
+  category: tui.input-and-commands
+  coverage:
+    primary: [tui.slash-commands, tui.pickers, tui.settings]
+  risk: low
+  objective: Prove slash commands, model and session pickers, and settings updates through the real runTui PTY loop.
+  successCriteria:
+    - Slash command help and an executed backend command are visible in authenticated final terminal frames.
+    - Model and session picker choices are visible, selected through literal PTY input, and applied to subsequent backend calls.
+    - The settings overlay visibly updates tool output and thinking values, including the history refresh triggered by showing thinking.
+  codeRefs:
+    - src/tui/tui-pty-command-surfaces-test-support.ts
+    - src/tui/tui-pty-harness-assertion-test-support.ts
+    - src/tui/tui-pty-harness.e2e.test.ts
+  execution:
+    kind: script
+    path: test/e2e/qa-lab/tui/tui-pty-evidence-producer.ts
+    summary: Runs independently matched real-PTY command surface assertions and authenticates their fresh Vitest results.
+    timeoutMs: 180000
+    args: [--artifact-base, "${outputDir}", --scenario-id, "${scenarioId}"]
+    config:
+      tuiPtyCases:
+        - {
+            coverageId: tui.slash-commands,
+            testFile: src/tui/tui-pty-harness.e2e.test.ts,
+            testNamePattern: "^TUI PTY harness lists and executes slash commands through authenticated real PTY frames$",
+          }
+        - {
+            coverageId: tui.pickers,
+            testFile: src/tui/tui-pty-harness.e2e.test.ts,
+            testNamePattern: "^TUI PTY harness selects model and session pickers through authenticated real PTY frames$",
+          }
+        - {
+            coverageId: tui.settings,
+            testFile: src/tui/tui-pty-harness.e2e.test.ts,
+            testNamePattern: "^TUI PTY harness updates settings through an authenticated real PTY overlay$",
+          }

--- a/src/tui/tui-pty-command-surfaces-test-support.ts
+++ b/src/tui/tui-pty-command-surfaces-test-support.ts
@@ -1,0 +1,94 @@
+import { expect } from "vitest";
+import {
+  type StartTuiPtyFixture,
+  waitForSynchronizedFrameRows,
+} from "./tui-pty-harness-assertion-test-support.js";
+import { objectFieldEquals, readFixtureLog } from "./tui-pty-harness-fixture-test-support.js";
+
+const slashHelpMarkers =
+  "Slash commands:,/help,/verbose <on|off|full>,/reasoning <on|off|stream>,/goal,/goal start <objective>,/btw <side question>,/queue,/stop,/exit".split(
+    ",",
+  );
+const countHistoryLoads = async (logPath: string) =>
+  (await readFixtureLog(logPath)).filter((entry) => entry.method === "loadHistory").length;
+const rowsInclude = (rows: string[], ...texts: string[]) =>
+  rows.some((row) => texts.every((text) => row.includes(text)));
+
+export async function exerciseTuiCommandSurface(
+  startFixture: StartTuiPtyFixture,
+  surface: "slash-commands" | "pickers" | "settings",
+  startupTimeoutMs: number,
+) {
+  const fixture = await startFixture({
+    env: {
+      OPENCLAW_TUI_PTY_COLS: "100",
+      OPENCLAW_TUI_PTY_ROWS: "24",
+      ...(surface === "pickers" ? { OPENCLAW_TUI_PTY_PICKER_FIXTURE: "1" } : {}),
+    },
+  });
+  try {
+    const waitForRows = (predicate: Parameters<typeof waitForSynchronizedFrameRows>[1]) =>
+      waitForSynchronizedFrameRows(fixture.run, predicate, startupTimeoutMs);
+    await fixture.run.waitForOutput("local ready", startupTimeoutMs);
+    if (surface === "slash-commands") {
+      await fixture.run.write("/help\r", { delay: false });
+      for (const text of slashHelpMarkers) {
+        await fixture.run.waitForOutput(text, startupTimeoutMs);
+      }
+      await waitForRows((rows) =>
+        ["/settings", "/exit"].every((text) => rows.some((row) => row.trim() === text)),
+      );
+      await fixture.run.write("/gateway-status\r", { delay: false });
+      await fixture.waitForLogEntry((entry) => entry.method === "getGatewayStatus");
+      await waitForRows((rows) => rows.some((row) => row.trim() === "fixture gateway ok"));
+      return;
+    }
+    if (surface === "pickers") {
+      await fixture.run.write("/models\r", { delay: false });
+      await fixture.waitForLogEntry((entry) => entry.method === "listModels");
+      await waitForRows((rows) => rows.some((row) => row.includes("Fixture 2")));
+      await fixture.run.write("\x1b[B\r", { delay: false });
+      await fixture.waitForLogEntry(
+        (entry) =>
+          entry.method === "patchSession" &&
+          objectFieldEquals(entry, "model", "fixture-provider/fixture-model-2"),
+      );
+      await fixture.run.write("/sessions\r", { delay: false });
+      await fixture.waitForLogEntry(
+        (entry) => entry.method === "listSessions" && objectFieldEquals(entry, "purpose", "picker"),
+      );
+      await waitForRows((rows) => rows.some((row) => row.includes("Picker target")));
+      await fixture.run.write("\x1b[B\r", { delay: false });
+      await fixture.waitForLogEntry(
+        (entry) =>
+          entry.method === "loadHistory" &&
+          objectFieldEquals(entry, "sessionKey", "agent:main:picker-target"),
+      );
+      await fixture.run.write("picker selection proof\r", { delay: false });
+      const sent = await fixture.waitForLogEntry(
+        (entry) =>
+          entry.method === "sendChat" &&
+          objectFieldEquals(entry, "message", "picker selection proof"),
+      );
+      expect(sent.payload).toMatchObject({ sessionKey: "agent:main:picker-target" });
+      await waitForRows((rows) => rowsInclude(rows, "PTY_RESPONSE: picker selection proof"));
+      return;
+    }
+    const initialHistoryLoads = await countHistoryLoads(fixture.logPath);
+    await fixture.run.write("/settings\r", { delay: false });
+    await waitForRows(
+      (rows) =>
+        rowsInclude(rows, "Tool output", "collapsed") && rowsInclude(rows, "Show thinking", "off"),
+    );
+    await fixture.run.write("\r", { delay: false });
+    await waitForRows((rows) => rowsInclude(rows, "Tool output", "expanded"));
+    expect(await countHistoryLoads(fixture.logPath)).toBe(initialHistoryLoads);
+    await fixture.run.write("\x1b[B\r", { delay: false });
+    await waitForRows((rows) => rowsInclude(rows, "Show thinking", "on"));
+    await expect
+      .poll(() => countHistoryLoads(fixture.logPath), { timeout: startupTimeoutMs })
+      .toBe(initialHistoryLoads + 1);
+  } finally {
+    await fixture.cleanup();
+  }
+}

--- a/src/tui/tui-pty-harness-assertion-test-support.test.ts
+++ b/src/tui/tui-pty-harness-assertion-test-support.test.ts
@@ -37,6 +37,7 @@ describe("hasSynchronizedFrameRow", () => {
     expect(hasExpected(frame("T08A  safe T08B"))).toBe(false);
     expect(parse(frame("界X\r\x1b[2G?"))[0]).toEqual([" ?X"]);
     expect(parse(frame("界X\r\x1b[2G\x1b[K"))[0]).toEqual([""]);
+    expect(parse(`${EXPECTED}${frame("")}`)).toEqual([[""]]);
     expect(parse(frame("\u2067RTL\u2069"))[0]).toEqual(["RTL"]);
     expect(parse(frame(`${"x".repeat(32)}\x1b[3Jy`), { cols: 32, rows: 2 })[0]).toEqual([
       "x".repeat(32),

--- a/src/tui/tui-pty-harness-assertion-test-support.ts
+++ b/src/tui/tui-pty-harness-assertion-test-support.ts
@@ -13,6 +13,7 @@ import {
 } from "./tui-pty-test-support.js";
 
 export type FixtureLogEntry = { method: string; payload?: unknown };
+type FixtureLogPredicate = (entry: FixtureLogEntry) => boolean;
 
 export const COMPACT_TERMINAL_SIZES = [
   [64, 18],
@@ -38,7 +39,7 @@ export async function readFixtureLog(logPath: string): Promise<FixtureLogEntry[]
 
 export async function waitForFixtureLogEntry(
   logPath: string,
-  predicate: (entry: FixtureLogEntry) => boolean,
+  predicate: FixtureLogPredicate,
   timeoutMs: number,
   readPtyOutput?: () => string,
 ) {
@@ -67,8 +68,14 @@ export function objectFieldEquals(entry: FixtureLogEntry, field: string, value: 
   return Object.hasOwn(payload, field) && payload[field] === value;
 }
 
-type StartTuiPtyFixture = Parameters<typeof exerciseFragmentedUnicodePrompt>[0];
-type StartedTuiPtyFixture = Awaited<ReturnType<StartTuiPtyFixture>>;
+type StartedTuiPtyFixture = {
+  run: PtyRun;
+  logPath: string;
+  waitForLogEntry: (predicate: FixtureLogPredicate, timeoutMs?: number) => Promise<FixtureLogEntry>;
+  cleanup: () => Promise<void>;
+};
+type TuiPtyFixtureOptions = { env?: NodeJS.ProcessEnv };
+export type StartTuiPtyFixture = (opts?: TuiPtyFixtureOptions) => Promise<StartedTuiPtyFixture>;
 type TerminalAttackPayload = {
   text: string;
   markers: string[];
@@ -261,31 +268,43 @@ function parseTerminalState(
     : undefined;
 }
 
+function authenticatedRowText(cells: PtyTestScreen["cells"][number]) {
+  return cells
+    .slice(0, cells.findLastIndex((cell) => cell.authenticated) + 1)
+    .map((cell) => (cell.text === "" || cell.authenticated ? cell.text : STALE_CELL_SENTINEL))
+    .join("")
+    .trimEnd();
+}
+
 export function synchronizedFrameRows(raw: string, dimensions: PtyTerminalDimensions): string[][] {
   const screen = parseTerminalState(raw, dimensions);
   if (!screen) {
     return [];
   }
-  const rows = screen.cells.map((row) =>
-    row
-      .map((cell) => cell.text)
-      .join("")
-      .trimEnd(),
-  );
+  const rows = screen.cells.map(authenticatedRowText);
   while (rows.length > 1 && rows.at(-1) === "") {
     rows.pop();
   }
   return [rows];
 }
 
-function screenHasRow(screen: PtyTestScreen, predicate: (row: string) => boolean) {
-  return screen.cells.some((cells) => {
-    const authoredRow = cells
-      .map((cell) => (cell.text === "" || cell.authenticated ? cell.text : STALE_CELL_SENTINEL))
-      .join("")
-      .trimEnd();
-    return predicate(authoredRow);
+export async function waitForSynchronizedFrameRows(
+  run: PtyRun,
+  predicate: (rows: string[]) => boolean,
+  timeoutMs: number,
+) {
+  return await waitFor({
+    timeoutMs,
+    read: () => {
+      const rows = synchronizedFrameRows(run.output(), run).at(0);
+      return rows && predicate(rows) ? rows : null;
+    },
+    onTimeout: () => new Error(`expected completed synchronized frame\n${run.output()}`),
   });
+}
+
+function screenHasRow(screen: PtyTestScreen, predicate: (row: string) => boolean) {
+  return screen.cells.some((cells) => predicate(authenticatedRowText(cells)));
 }
 
 function latestFrameHasRow(
@@ -693,11 +712,7 @@ export async function exerciseTerminalOutputSafety(
 
 /** Proves fixture-local fragmentation preserves a Unicode prompt through the real TUI loop. */
 export async function exerciseFragmentedUnicodePrompt(
-  startFixture: (opts: { env?: NodeJS.ProcessEnv }) => Promise<{
-    run: PtyRun;
-    waitForLogEntry: (predicate: (entry: FixtureLogEntry) => boolean) => Promise<FixtureLogEntry>;
-    cleanup: () => Promise<void>;
-  }>,
+  startFixture: StartTuiPtyFixture,
   startupTimeoutMs: number,
 ) {
   const fixture = await startFixture({

--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { exerciseTuiCommandSurface } from "./tui-pty-command-surfaces-test-support.js";
 import {
   approveWorkspaceSkill,
   COMPACT_TERMINAL_SIZES,
@@ -901,14 +902,14 @@ describe.sequential("TUI PTY harness", () => {
     STARTUP_TEST_TIMEOUT_MS,
   );
 
-  it(
-    "renders slash command help",
-    async () => {
-      await fixture.run.write("/help\r", { delay: false });
-      // prettier-ignore
-      for (const text of ["Slash commands:", "/help", "/verbose <on|off|full>", "/reasoning <on|off|stream>", "/goal", "/goal start <objective>", "/btw <side question>", "/queue", "/stop", "/exit"]) { await fixture.run.waitForOutput(text); }
-    },
-    TEST_TIMEOUT_MS,
+  it.each([
+    ["lists and executes slash commands through authenticated real PTY frames", "slash-commands"],
+    ["selects model and session pickers through authenticated real PTY frames", "pickers"],
+    ["updates settings through an authenticated real PTY overlay", "settings"],
+  ] as const)(
+    "%s",
+    (_name, surface) => exerciseTuiCommandSurface(startTuiFixture, surface, STARTUP_TIMEOUT_MS),
+    STARTUP_TEST_TIMEOUT_MS,
   );
 
   it(


### PR DESCRIPTION
## What Problem This Solves

The TUI command surfaces lacked primary real-PTY QA evidence for slash commands, model and session pickers, and settings updates.

## Why This Change Was Made

Adds one QA scenario with exact anchored cases through the fake-backend `runTui()` PTY harness. The assertions reuse the landed synchronized final-screen oracle, preserve the existing slash-help markers, and add authenticated final-frame and backend-execution proof without changing production behavior.

## User Impact

No runtime behavior changes. Regressions in slash command listing and execution, picker selection, and settings updates now fail through the real terminal boundary.

## Evidence

- Signed exact head: `942e50121934f17407479a17d48b3443a166dd81`
- Exact-head artifact: `.artifacts/qa-e2e/tui-command-surfaces-pty-exact-head-942e50121934f17407479a17d48b3443a166dd81-20260804/qa-evidence.json`
- Producer result: `3` passed, `0` failed; exact primary coverage for `tui.slash-commands`, `tui.pickers`, and `tui.settings`
- Slash proof retains `Slash commands:`, `/help`, `/verbose`, `/reasoning`, `/goal`, `/goal start`, `/btw`, `/queue`, `/stop`, and `/exit`; authenticated final rows include `/settings` and `/exit`; `/gateway-status` executes against the fixture backend
- Picker proof selects a model and session through literal PTY input and verifies the selected session on the subsequent backend call
- Settings proof shows Tool output causes zero additional `loadHistory` calls, then Show thinking causes exactly one
- Authenticated row materialization rejects stale pre-frame cells; focused assertion unit tests: `2` passed
- Focused PTY tests: `3` passed, `57` skipped
- Pinned Knip production, full-tree, and script unused-export scans passed with zero entries
- Targeted oxfmt, scoped oxlint, scenario parsing, `git diff --check`, privacy scan, signature verification, and artifact reference validation passed
- AWS changed gate `run_0d629c09cbeb` passed all earlier guards, then stopped only on a pre-existing `src/config/**` dead-export inventory; no T04b path or symbol was listed
- Sol autoreview (`gpt-5.6-sol`, high): no accepted/actionable findings; patch correct at `0.91`
- Diff: production `+0`; QA/test `+180/-29`; no docs, taxonomy, changelog, dependency, or T02 local-Gateway changes
