### PR TITLE
fix(channels): treat adapter_returned_no_identity as potentially visible (#119168)

### DIFF
--- a/src/channels/turn/durable-delivery.producer.test.ts
+++ b/src/channels/turn/durable-delivery.producer.test.ts
@@ -1,0 +1,182 @@
+// Producer-boundary integration test for #119169: drives the REAL durable-send
+// producer (sendDurableMessageBatch -> deliverOutboundPayloadsInternal/deliverCore)
+// with a real channel adapter that returns no identity, and asserts the outcome
+// reaches settlement as potentially visible (handled_visible). Unlike the unit
+// tests in durable-delivery.test.ts, sendDurableMessageBatch is NOT mocked here;
+// only the channel adapter is a fixture, which is the legitimate platform boundary.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
+import type { DispatchReplyWithBufferedBlockDispatcher } from "../../auto-reply/reply/provider-dispatcher.types.js";
+import type { FinalizedMsgContext } from "../../auto-reply/templating.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  captureActivePluginRegistrySnapshot,
+  restoreActivePluginRegistrySnapshot,
+  setActivePluginRegistry,
+} from "../../plugins/runtime.js";
+import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
+import type { ChannelOutboundAdapter } from "../plugins/types.public.js";
+import type { RecordInboundSession } from "../session.types.js";
+import {
+  deliverInboundReplyWithMessageSendContext,
+  isDurableInboundReplyDeliveryHandled,
+  throwIfDurableInboundReplyDeliveryFailed,
+} from "./durable-delivery.js";
+import { dispatchAssembledChannelTurn } from "./lifecycle.js";
+
+const matrixPluginId = "matrix";
+
+function ctxPayload() {
+  return {
+    CommandAuthorized: true,
+    CommandTurn: { kind: "normal", source: "message", authorized: false },
+  } as Parameters<typeof deliverInboundReplyWithMessageSendContext>[0]["ctxPayload"];
+}
+
+describe("durable inbound reply delivery — real producer boundary (#119169)", () => {
+  let pluginRuntimeSnapshot: ReturnType<typeof captureActivePluginRegistrySnapshot>;
+
+  beforeEach(() => {
+    // Snapshot the full plugin-runtime state (registry + cache key + subagent
+    // mode + workspace dir) before installing the fixture adapter, restored in
+    // afterEach. setActivePluginRegistry defaults those metadata fields, so
+    // restoring only an empty registry would leak reset metadata into later
+    // tests. restoreActivePluginRegistrySnapshot is the canonical pair.
+    pluginRuntimeSnapshot = captureActivePluginRegistrySnapshot();
+    // Adapter was invoked but returned no identity (empty messageId): the
+    // platform may have delivered. sendTextOnlyErrorPayloads routes error
+    // payloads through sendPayload so the no-identity branch is exercised.
+    const noIdentityAdapter: ChannelOutboundAdapter = {
+      deliveryMode: "direct",
+      sendTextOnlyErrorPayloads: true,
+      deliveryCapabilities: {
+        durableFinal: { text: true, payload: true, messageSendingHooks: true },
+      },
+      sendText: async () => ({ channel: matrixPluginId, messageId: "unused-text" }),
+      sendPayload: async () => ({ channel: matrixPluginId, messageId: "" }),
+    };
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: matrixPluginId,
+          source: "test",
+          plugin: createOutboundTestPlugin({ id: matrixPluginId, outbound: noIdentityAdapter }),
+        },
+      ]),
+    );
+  });
+
+  afterEach(() => {
+    restoreActivePluginRegistrySnapshot(pluginRuntimeSnapshot);
+  });
+
+  it("treats a real producer adapter-no-identity outcome as potentially visible", async () => {
+    const result = await deliverInboundReplyWithMessageSendContext({
+      cfg: {},
+      channel: matrixPluginId,
+      to: "!room:example",
+      agentId: "main",
+      info: { kind: "final" },
+      payload: { text: "final error reply", isError: true },
+      ctxPayload: ctxPayload(),
+    });
+
+    // Real producer: sendDurableMessageBatch -> deliverCore -> sendPayload
+    // returned no identity -> suppressed/adapter_returned_no_identity.
+    // Settlement: durable-delivery maps it to handled_visible, not handled_no_send.
+    // Explicit status guard narrows the result union so `.delivery` typechecks
+    // (vitest's expect().toBe() does not narrow; matches the adjacent unit test).
+    if (result.status !== "handled_visible") {
+      throw new Error(`expected handled_visible, got ${result.status}`);
+    }
+    expect(result.delivery.visibleReplySent).toBe(true);
+
+    // Lifecycle settlement boundary (lifecycle.ts:519-522): the durable result
+    // must (1) not throw as a failed delivery, (2) be classified handled so the
+    // caller skips fallback, and (3) carry visibleReplySent=true so the private
+    // isExplicitlyNonVisibleChannelDelivery predicate (lifecycle.ts:129,
+    // `visibleReplySent === false`) settles it as a visible send — emitting
+    // message_sent and suppressing a duplicate fallback reply. Current main
+    // returns handled_no_send (visibleReplySent=false) for this outcome, which
+    // settles as explicitly non-visible and would allow a duplicate reply.
+    expect(() => throwIfDurableInboundReplyDeliveryFailed(result)).not.toThrow();
+    expect(isDurableInboundReplyDeliveryHandled(result)).toBe(true);
+    expect(result.delivery.visibleReplySent).toBe(true);
+  });
+
+  it("settles the no-identity outcome through the real lifecycle delivery owner as visible", async () => {
+    // Drives the real durable producer (sendDurableMessageBatch -> deliverCore,
+    // NOT mocked) through dispatchAssembledChannelTurn, the real lifecycle
+    // delivery owner. The faked dispatchReplyWithBufferedBlockDispatcher is the
+    // legitimate model/reply boundary: it calls the real
+    // dispatcherOptions.deliver (constructed inside lifecycle.ts:475-525), which
+    // runs delivery.durable -> deliverInboundReplyWithMessageSendContext ->
+    // sendDurableMessageBatch -> the real no-identity adapter. The durable-handled
+    // branch (lifecycle.ts:515-522) then invokes runChannelDeliveryObserver
+    // (the settlement callback) and recordSettledDelivery — the owner whose
+    // visibleReplySent flag controls isExplicitlyNonVisibleChannelDelivery
+    // (lifecycle.ts:129) and thus final accounting. Current main returns
+    // handled_no_send (visibleReplySent=false) here, so onDelivered would receive
+    // visibleReplySent=false and the delivery would settle as non-visible.
+    const cfg = {} as OpenClawConfig;
+    const turnCtxPayload = {
+      Body: "hi",
+      From: "sender",
+      To: "!room:example",
+      OriginatingTo: "!room:example",
+      SessionKey: "agent:main:matrix:peer",
+      Provider: "matrix",
+      Surface: "matrix",
+    } as FinalizedMsgContext;
+    const recordInboundSession = vi.fn(async () => undefined) as unknown as RecordInboundSession;
+    const onDelivered = vi.fn();
+    const replyPayload: ReplyPayload = { text: "final error reply", isError: true };
+
+    // Faked reply dispatcher (model/reply boundary, NOT the delivery producer):
+    // enqueues one final reply through the real dispatcherOptions.deliver, which
+    // lifecycle.ts constructs to run delivery.durable against the real producer.
+    // The type assertion matches the kernel.test.ts createDispatch() pattern: the
+    // fake only uses dispatcherOptions.deliver, the legitimate test seam.
+    const dispatchReplyWithBufferedBlockDispatcher = vi.fn(
+      async (params: {
+        dispatcherOptions: { deliver: (p: ReplyPayload, i: { kind: string }) => Promise<unknown> };
+      }) => {
+        await params.dispatcherOptions.deliver(replyPayload, { kind: "final" });
+        return { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } };
+      },
+    ) as DispatchReplyWithBufferedBlockDispatcher;
+
+    const result = await dispatchAssembledChannelTurn({
+      cfg,
+      channel: matrixPluginId,
+      agentId: "main",
+      routeSessionKey: "agent:main:matrix:peer",
+      storePath: "/tmp/openclaw-producer-settlement.json",
+      ctxPayload: turnCtxPayload,
+      recordInboundSession,
+      dispatchReplyWithBufferedBlockDispatcher,
+      delivery: {
+        deliver: vi.fn(),
+        durable: { to: "!room:example", replyToMode: "first" },
+        onDelivered,
+      },
+    });
+
+    // The real lifecycle settlement owner observed the delivery: onDelivered is
+    // the settlement callback (lifecycle.ts:516-520, runChannelDeliveryObserver).
+    expect(onDelivered).toHaveBeenCalledTimes(1);
+    const settledCall = onDelivered.mock.calls[0] as unknown as [
+      ReplyPayload,
+      { kind: string },
+      { visibleReplySent: boolean },
+    ];
+    const settledResult = settledCall[2];
+    // PR fix: the no-identity adapter outcome is handled_visible, so the
+    // settlement callback receives visibleReplySent=true — the delivery is
+    // accounted as a visible send, suppressing a duplicate fallback reply.
+    expect(settledResult.visibleReplySent).toBe(true);
+    // Dispatch succeeded and recorded the final reply count from the faked
+    // dispatcher (settlement did not override the queued-final accounting).
+    expect(result.dispatched).toBe(true);
+  });
+});

--- a/src/channels/turn/durable-delivery.test.ts
+++ b/src/channels/turn/durable-delivery.test.ts
@@ -186,4 +186,39 @@ describe("durable inbound reply delivery", () => {
     expect(result).toEqual({ status: "failed", error, sentBeforeError: true });
     expect(error).toMatchObject({ sentBeforeError: true, visibleReplySent: true });
   });
+
+  it("treats adapter_returned_no_identity as potentially visible, not handled_no_send", async () => {
+    // The adapter was called but returned no identity — the platform may have
+    // delivered. routeReply and the delivery queue treat this as potentially
+    // visible (ambiguous); durable-delivery must match, or a reply that may
+    // have been delivered is marked "explicitly not sent" and recovery state /
+    // fallback decisions are wrong.
+    mocks.sendDurableMessageBatch.mockResolvedValueOnce({
+      status: "suppressed",
+      reason: "adapter_returned_no_identity",
+      results: [],
+      receipt: {
+        primaryPlatformMessageId: undefined,
+        platformMessageIds: [],
+        parts: [],
+        sentAt: 1,
+      },
+    });
+
+    const result = await deliverInboundReplyWithMessageSendContext({
+      cfg: {},
+      channel: "telegram",
+      agentId: "main",
+      info: { kind: "final" },
+      payload: { text: "final" },
+      ctxPayload: ctxPayload({
+        OriginatingTo: "chat-1",
+      }),
+    });
+
+    if (result.status !== "handled_visible") {
+      throw new Error(`expected handled_visible, got ${result.status}`);
+    }
+    expect(result.delivery.visibleReplySent).toBe(true);
+  });
 });

--- a/src/channels/turn/durable-delivery.ts
+++ b/src/channels/turn/durable-delivery.ts
@@ -236,11 +236,16 @@ export async function deliverInboundReplyWithMessageSendContext(
     };
   }
 
+  // adapter_returned_no_identity: adapter was invoked, platform may have delivered
+  // without returning an identity. Treat as potentially visible (ambiguous), matching
+  // routeReply/delivery-queue/audit — marking it "not sent" would drop recovery state.
+  const adapterReturnedNoIdentity =
+    send.status === "suppressed" && send.reason === "adapter_returned_no_identity";
   const receiptDelivery = createChannelDeliveryResultFromReceipt({
     receipt: send.receipt,
     threadId: stringifyThreadId(threadId),
     ...(replyToId ? { replyToId } : {}),
-    visibleReplySent: send.status === "sent",
+    visibleReplySent: send.status === "sent" || adapterReturnedNoIdentity,
     ...(send.deliveryIntent ? { deliveryIntent: toDeliveryIntent(send.deliveryIntent) } : {}),
   });
   const delivery: ChannelDeliveryResult =
@@ -248,7 +253,9 @@ export async function deliverInboundReplyWithMessageSendContext(
       ? { ...receiptDelivery, suppression: resolveDurableSuppression(send) }
       : receiptDelivery;
   if (send.status === "suppressed") {
-    return { status: "handled_no_send", reason: "no_visible_result", delivery };
+    return adapterReturnedNoIdentity
+      ? { status: "handled_visible", delivery }
+      : { status: "handled_no_send", reason: "no_visible_result", delivery };
   }
   return { status: "handled_visible", delivery };
 }


### PR DESCRIPTION
## What Problem This Solves

`durable-delivery.ts` classifies `adapter_returned_no_identity` as `handled_no_send` (`visibleReplySent: false`) — "explicitly not sent". That reason means the adapter was invoked and the platform may have delivered without returning an identity, so the reply may already be visible. The misclassification drops recovery state and enables a duplicate fallback.

Fixes #119168

## Why This Change Was Made

Every sibling consumer of the same `sendDurableMessageBatch` result treats `adapter_returned_no_identity` as potentially visible:
- `route-reply.ts`: `{ ok: true, delivered: true, ambiguous: true }`
- `deliver-queue-execute.ts` / `delivery-queue-recovery.ts`: retains `unknown_after_send` for reconciliation
- cron delivery: `payloadMayHaveReachedRecipientBeforeFailure = true`
- outbound audit: counted as `unknown`

Only `durable-delivery.ts` treated it as `handled_no_send`. The fix marks it `visibleReplySent: true` and returns `handled_visible`, matching the ambiguous/potentially-visible semantics. Genuine `handled_no_send` reasons (hook-cancel, empty-after-hook, `no_visible_result`) are unchanged.

## User Impact

- **Before:** a reply whose adapter was invoked but returned no identity was recorded as "explicitly not sent", dropping pending-final recovery state and enabling a duplicate fallback even though the platform may have delivered.
- **After:** it is recorded as potentially visible, consistent with all other consumers, so recovery decisions are not wrongly reset.

## Evidence

**Repro (regression test, fails on main, passes after fix):**

```
FORCE_COLOR=0 node scripts/run-vitest.mjs src/channels/turn/durable-delivery.test.ts -t "treats adapter_returned_no_identity as potentially visible"
# main: FAILED — result.status is "handled_no_send" instead of "handled_visible"
# after: passed
```

**Full suites (trusted source, local checkout):**

```
FORCE_COLOR=0 node scripts/run-vitest.mjs src/channels/turn/durable-delivery.test.ts
# 5 passed (4 existing + 1 new regression)

FORCE_COLOR=0 node scripts/run-vitest.mjs src/channels/message/send.test.ts
# 19 passed
```

**Real after-fix runtime transcript (real `deliverInboundReplyWithMessageSendContext`):**

```
PROOF_119169 status: handled_visible
PROOF_119169 visibleReplySent: true
PROOF_119169 hook_cancel status: handled_no_send
PROOF_119169 hook_cancel visibleReplySent: false
```

The real durable-delivery function (only the send boundary is mocked) classifies `adapter_returned_no_identity` as `handled_visible` with `visibleReplySent: true` (matching routeReply/audit), while a genuine `hook_cancel` suppression stays `handled_no_send` with `visibleReplySent: false` (unchanged).

**Real adapter-to-settlement transcript (real `deliverInboundReplyWithMessageSendContext` → `isDurableInboundReplyDeliveryHandled` → settlement):**

```
PROOF_119169 step1 isHandled: true
PROOF_119169 step2 visibleReplySent: true
PROOF_119169 step2 suppression: adapter_returned_no_identity
PROOF_119169 hook_cancel isHandled: true
PROOF_119169 hook_cancel visibleReplySent: false
```

The real durable-delivery function feeds into the real settlement predicates (only the send boundary is mocked): `adapter_returned_no_identity` is classified `handled_visible` with `visibleReplySent: true` and `suppression.reason: adapter_returned_no_identity` — settlement would `recordSettledDelivery` as a visible delivery. `hook_cancel` stays `handled_no_send` with `visibleReplySent: false` (unchanged).

**Real producer boundary → lifecycle settlement (no `sendDurableMessageBatch` mock, final head `ccc80ade341`):**

A committed integration test (`src/channels/turn/durable-delivery.producer.test.ts`) drives the REAL producer end-to-end and then through the REAL lifecycle settlement predicates. `sendDurableMessageBatch` is NOT mocked — only the channel adapter is a fixture (the legitimate platform boundary), and its `sendPayload` returns no identity (empty `messageId`):

```
deliverInboundReplyWithMessageSendContext
  -> sendDurableMessageBatch (real)
    -> withDurableMessageSendContext -> deliverOutboundPayloadsInternal (real deliverCore)
      -> deliveryHandler.sendPayload() => { messageId: "" }   // adapter invoked, no identity
      -> results.length === 0 -> payload outcome {suppressed, adapter_returned_no_identity}
    -> sendDurableMessageBatch returns {status:"suppressed", reason:"adapter_returned_no_identity"}
  -> adapterReturnedNoIdentity = true -> {status:"handled_visible", delivery.visibleReplySent:true}
```

The test then drives the real settlement boundary (lifecycle.ts:519-522) — the exported predicates the lifecycle `deliver` callback applies to this result, not a mock:

```
throwIfDurableInboundReplyDeliveryFailed(result)   // does not throw (not a failed delivery)
isDurableInboundReplyDeliveryHandled(result)       // true  -> caller skips fallback
result.delivery.visibleReplySent === true          // settles as visible (see below)
```

`visibleReplySent === true` is the contract the private `isExplicitlyNonVisibleChannelDelivery` predicate checks at `lifecycle.ts:129` (`visibleReplySent === false`). So the real producer no-identity outcome settles as a **visible** delivery: `recordSettledDelivery` does not increment `nonVisibleDeliveryCounts`, `message_sent` is emitted (lifecycle.ts:261), and a duplicate fallback reply is suppressed. Current main returns `handled_no_send` (`visibleReplySent: false`) for this outcome, which settles as explicitly non-visible and would allow a duplicate reply.

```
node scripts/run-vitest.mjs src/channels/turn/durable-delivery.producer.test.ts
# 1 passed — real producer no-identity outcome reaches settlement as handled_visible
```

The producer-test result is narrowed with an explicit `if (result.status !== "handled_visible") throw` guard (matching the adjacent unit test) so `.delivery` typechecks — vitest's `expect().toBe()` does not narrow the result union; this was the P2 the prior review flagged as a compile-blocking test error. `tsgo` core-test lane is clean.

This closes the producer-boundary and settlement gaps: a real durable-send producer path receives an adapter no-identity outcome (the adapter is invoked and returns no identity, so `deliverCore` records `adapter_returned_no_identity`), reaches `handled_visible` + `visibleReplySent: true`, and the real settlement predicates classify it as a handled visible send — not `handled_no_send` / explicitly non-visible.

**Boundary:** 1 production file (`src/channels/turn/durable-delivery.ts`, +4 net) + 1 regression test + 1 producer-boundary integration test. The change is scoped to the `adapter_returned_no_identity` suppressed reason; all other suppressed reasons keep `handled_no_send`.

**Pre-existing unrelated:** `tsgo` on `tsconfig.core.json` reports 1 pre-existing error in `packages/terminal-core/src/ansi.ts:194` (verified present on `origin/main`); unrelated to this PR.




### Lifecycle settlement proof — `02c2aa194f1` (ClawSweeper P2)

The prior producer test asserted durable-delivery helpers but never invoked lifecycle's settlement callback, where `visibleReplySent` changes final accounting. The added test drives the **real durable producer** (`sendDurableMessageBatch`, NOT mocked) through `dispatchAssembledChannelTurn` — the real lifecycle delivery owner:

```
dispatchAssembledChannelTurn (real lifecycle owner)
  -> faked dispatchReplyWithBufferedBlockDispatcher (model/reply boundary seam)
    -> params.dispatcherOptions.deliver (real, constructed in lifecycle.ts:475-525)
      -> delivery.durable -> deliverInboundReplyWithMessageSendContext (real)
        -> sendDurableMessageBatch -> deliverCore (real) -> no-identity adapter (fixture)
      -> isDurableInboundReplyDeliveryHandled -> recordSettledDelivery (real)
    -> runChannelDeliveryObserver (real settlement callback, lifecycle.ts:516-520)
      -> onDelivered(payload, info, { visibleReplySent: true })   // REAL settlement
```

The faked `dispatchReplyWithBufferedBlockDispatcher` is the legitimate model/reply boundary (the same seam `kernel.test.ts:130` fakes) — it calls the real `dispatcherOptions.deliver`, which lifecycle.ts constructs to run `delivery.durable` against the real producer. It is NOT the delivery producer and NOT the function under test.

**Fails on main, passes after fix:**

```
node scripts/run-vitest.mjs src/channels/turn/durable-delivery.producer.test.ts -t "settles the no-identity outcome through the real lifecycle"
# main: FAILED — onDelivered receives visibleReplySent=false (handled_no_send)
# after: passed — onDelivered receives visibleReplySent=true (handled_visible)
```

```
node scripts/run-vitest.mjs src/channels/turn/durable-delivery.producer.test.ts
# 2 passed — real producer boundary + real lifecycle settlement
```

`oxfmt` clean, `oxlint` clean. The `afterEach` now restores the full plugin-runtime snapshot (`captureActivePluginRegistrySnapshot`/`restoreActivePluginRegistrySnapshot`) instead of resetting to an empty registry, so the fixture cannot leak reset metadata into later tests.


## Rebase onto current main

This PR was rebased cleanly onto current `main` (commit `2d627a0c257` at rebase time). The previous head was based on a stale local lineage that carried two artifacts unrelated to this fix:
- a phantom `src/channels/turn/kernel.ts` re-export shim (does not exist on `main`; `dispatchAssembledChannelTurn` is exported from `lifecycle.ts:647`) — caused `check-test-types` TS2307 `Cannot find module './kernel.js'`. The producer test now imports from `./lifecycle.js`, matching sibling tests (`run-channel-turn.delivery.test.ts`).
- a stale `src/auto-reply/reply/get-reply-run.media-only.test.ts` with an unused `applySessionHints` import — caused `check-lint` `no-unused-vars`. `main`'s version has no such import.

The rebased diff is exactly the three intended files (`durable-delivery.ts` +11/-2, `durable-delivery.test.ts` +35, `durable-delivery.producer.test.ts` new +182) on top of current `main`; no stale-lineage drift remains (`requiredCapabilities.reconcileUnknownSend` and all other `main` code is untouched).

## Pre-existing main breakage (check-test-types, checks-node-compact)

The failing checks on this head are **pre-existing breakage on `main`**, not caused by this PR. All trace to one `main` commit — `1f75018600a` (`fix(gateway): prevent restart replay after final delivery`) — which is confirmed on `origin/main` (`git merge-base --is-ancestor 1f75018600a origin/main` ⇒ on main). It rewrote restart-replay/delivery-custody/recovery-state logic across `src/infra/outbound/{deliver-queue-execute,deliver-queue,deliver-channel}.ts`, `src/auto-reply/reply/{before-deliver,pending-final-delivery}.ts`, `src/channels/turn/{durable-delivery,direct-delivery-custody}.ts`, and the Discord/Telegram outbound adapters, but left several test expectations stale.

**Proof these fail identically on `main`** — `main` CI run `31385067274` (commit `60e1f40562dc`, `push` event on `main`):

```
gh run view 31385067274 --json jobs   # main, not this PR
  check-test-types                  failure
  checks-node-compact-small-7       failure
  checks-node-compact-small-9       failure
  checks-node-compact-small-11      failure
  checks-node-compact-large-2       failure
```

Every check that fails on this PR's head fails with the same conclusion on `main`. This PR cannot cause them: it touches only `src/channels/turn/durable-delivery.*`.

**`check-test-types`** — four type errors, all in extension test harnesses, none in the files this PR touches:

```
extensions/discord/src/monitor/message-handler.process.test-harness.ts(415,17): error TS2322: ... 'ReplyDispatchDeliverer'
extensions/telegram/src/bot-message-dispatch.test-harness.ts(229,15): error TS2322: ... 'ReplyDispatchDeliverer'
extensions/telegram/src/bot-native-commands.session-meta.test.ts(117,74): error TS2345: ... 'ChannelProviderOwnedDeliveryInfo'
extensions/telegram/src/bot-native-commands.test-helpers.ts(98,9): error TS2322: ... 'ReplyDispatchDeliverer'
```

**`checks-node-compact`** — `src/infra/outbound/deliver.queue-integration.test.ts` expects `recoveryState: "unknown_after_send"` but the post-`1f75018600a` producer leaves `send_attempt_started`; `1f75018600a` did not update this test file (file-list match count = 0). Also surfaces in `src/auto-reply/reply/before-deliver.test.ts` (custody recording) and `src/infra/heartbeat-runner.ack-token-heartbeat-acks.test.ts`, all in modules this PR does not touch.

```
deliver.queue-integration.test.ts:614  expected recoveryState "unknown_after_send", received "send_attempt_started"
deliver.queue-integration.test.ts:903  expected "unknown_after_send", received "send_attempt_started"
```

These checks will go green once `main`'s `1f75018600a` regression is reconciled with its test expectations; re-trigger CI then. The changed files are type-clean locally (`tsgo -p test/tsconfig/tsconfig.core.test.json` reports zero errors in `durable-delivery.*`; local-only errors are stale-`node_modules` artifacts in unrelated files).
