### PR TITLE
fix(testbox): restore claims across path aliases

### DIFF
--- a/scripts/crabbox-wrapper.mjs
+++ b/scripts/crabbox-wrapper.mjs
@@ -10,6 +10,7 @@ import {
   mkdtempSync,
   readFileSync,
   readdirSync,
+  realpathSync,
   renameSync,
   rmSync,
   statfsSync,
@@ -3783,7 +3784,9 @@ try {
     const checkout = prepareFullCheckoutForSync({ changedGateBase });
     fullCheckout = checkout;
     normalizedArgs = injectFullCheckoutLeaseReclaim(normalizedArgs);
-    childCwd = checkout.dir;
+    // Crabbox claims Git's physical top-level. Match it so macOS /var aliases
+    // restore to the invoking repository instead of the disposable checkout.
+    childCwd = realpathSync(checkout.dir);
     cleanupChildCwd = () => checkout.cleanup();
     remoteChangedGateBase = checkout.changedGateBase;
     remoteChangedGateAlias = changedGate?.remoteAlias ?? "";

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -7,8 +7,10 @@ import {
   mkdtempSync,
   readFileSync,
   readdirSync,
+  realpathSync,
   rmSync,
   statSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -607,7 +609,23 @@ function runSuccessfulMacosScript(script: string, trailingArgs: string[] = []): 
 }
 
 function runDelegatedBlacksmith(args: string[], env: Record<string, string>) {
-  return runDefaultWrapper(args, { ...cleanSparseSyncOptions, env });
+  if (process.platform === "win32") {
+    return runDefaultWrapper(args, { ...cleanSparseSyncOptions, env });
+  }
+  const physicalSyncRoot = mkdtempSync(path.join(tmpdir(), "openclaw-crabbox-sync-physical-"));
+  const syncRootAlias = `${physicalSyncRoot}-alias`;
+  symlinkSync(physicalSyncRoot, syncRootAlias, "dir");
+  tempDirs.push(syncRootAlias, physicalSyncRoot);
+  const result = runDefaultWrapper(args, {
+    ...cleanSparseSyncOptions,
+    env: { ...env, OPENCLAW_CRABBOX_SYNC_TMPDIR: syncRootAlias },
+  });
+  if (result.stdout.trim()) {
+    expect(
+      parseFakeCrabboxOutput(result).cwd.startsWith(`${realpathSync(physicalSyncRoot)}${path.sep}`),
+    ).toBe(true);
+  }
+  return result;
 }
 
 const remoteChangedGateEnvPrefix =


### PR DESCRIPTION
## Summary

- launch delegated Crabbox runs from the physical temporary worktree path
- match the path identity Git/Crabbox records in reusable Testbox claims
- make every delegated-claim regression traverse a symlinked sync root on POSIX

Fixes #119167.

## Root cause

The wrapper constructed a sparse-sync checkout through a lexical path such as `/var/...`, while the child process and `git rev-parse --show-toplevel` recorded its physical `/private/var/...` path. Claim restoration compared that recorded `repoRoot` to the lexical `childCwd` as strings, skipped the restore, and left a retained lease owned by the disposable checkout.

## Proof

- before fix in a sparse macOS Codex worktree: both successful and failed delegated-run claim tests retained `/private/var/.../openclaw-crabbox-sync-*` instead of the invoking repository
- exact claim-path cases after fix — 6 passed / 238 skipped
- complete sparse-worktree wrapper suite — 244/244 passed
- the delegated-claim helper now forces a symlinked sync root on POSIX, so Linux CI exercises the same lexical/physical path class
- AutoReview against current `origin/main` — clean, no accepted/actionable findings
- diff: tooling +4/-1, tests +19/-1; production runtime LOC delta 0
- public model identifier gate: PASS; the diff contains no model identifiers

Risk is low and limited to canonicalizing a disposable directory immediately after creation. No changelog entry is needed for a Testbox lifecycle repair.
