### PR TITLE
fix(ci): avoid duplicate Matrix release QA runs

### DIFF
--- a/.github/workflows/qa-live-transports-convex.yml
+++ b/.github/workflows/qa-live-transports-convex.yml
@@ -398,9 +398,9 @@ jobs:
   run_live_matrix:
     name: Run Matrix live QA lane
     needs: [authorize_actor, validate_selected_ref]
-    if: github.event_name != 'workflow_call' || inputs.run_matrix
+    if: inputs.expected_sha == '' || inputs.run_matrix
     runs-on: blacksmith-16vcpu-ubuntu-2404
-    timeout-minutes: 60
+    timeout-minutes: 90
     environment: qa-live-shared
     steps:
       - name: Checkout selected ref

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -571,6 +571,7 @@ The scheduled live/E2E workflow runs the full release-path Docker suite daily an
 QA Lab has dedicated CI lanes outside the main smart-scoped workflow. Agentic parity is nested under the broad QA and release harnesses, not a standalone PR workflow. Use `Full Release Validation` with `rerun_group=qa-parity` when parity should ride with a broad validation run.
 
 - The `QA-Lab - All Lanes` workflow runs nightly on `main` and on manual dispatch; it fans out mock parity plus live Matrix, Telegram, Discord, WhatsApp, and Slack jobs. Live jobs use the `qa-live-shared` environment; Telegram, Discord, WhatsApp, and Slack use Convex leases, while Matrix provisions disposable local credentials.
+- Release Matrix catalog validation runs serially on a 16-vCPU Blacksmith runner with a 90-minute job budget. Changes to that timeout, runner size, or concurrency require a matching workflow guard and exact-candidate release proof.
 
 Scheduled, manual, and release Matrix checks use the deterministic mock provider so the live transport contract is isolated from model latency and normal provider-plugin startup. Telegram release checks use the same deterministic model boundary. The live transport gateway disables memory search because QA parity covers memory behavior separately; provider connectivity is covered by the separate live model, native provider, and Docker provider suites.
 

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -3149,7 +3149,7 @@ describe("package artifact reuse", () => {
       "inputs.expected_sha == '' || inputs.run_mock_parity",
     );
     expect(workflowJob(QA_LIVE_TRANSPORTS_WORKFLOW, "run_live_matrix").if).toBe(
-      "github.event_name != 'workflow_call' || inputs.run_matrix",
+      "inputs.expected_sha == '' || inputs.run_matrix",
     );
     for (const channel of ["telegram", "discord", "whatsapp", "slack"]) {
       expect(workflowJob(QA_LIVE_TRANSPORTS_WORKFLOW, `run_live_${channel}`).if).toBe(
@@ -3174,6 +3174,7 @@ describe("package artifact reuse", () => {
     expect(qaWorkflow).not.toContain('"${{ inputs.expected_sha }}" !== ""');
     expect(qaWorkflow).toContain('if [[ -n "${EXPECTED_SHA}" ]]; then');
     const matrixJob = workflowJob(QA_LIVE_TRANSPORTS_WORKFLOW, "run_live_matrix");
+    expect(matrixJob["timeout-minutes"]).toBe(90);
     expect(workflowStep(matrixJob, "Run Matrix live lane").run).toContain(
       "--provider-mode mock-openai",
     );


### PR DESCRIPTION
## What Problem This Solves

Resolves two release-validation failures in the reusable live-transport workflow:

- reusable Buzz-only calls could schedule an unintended second Matrix lane;
- the exhaustive 92-scenario Matrix lane could exceed its former 60-minute deadline while still making progress.

The Beta 8 exact-SHA validation run `30889831481` reproduced both failures.

## Why This Change Was Made

Reusable callers with an `expected_sha` now gate Matrix through the explicit `run_matrix` input. Direct and manual invocations retain the existing Matrix default.

The Matrix deadline is 90 minutes. Coverage remains exhaustive and serial; the fix does not hide failures through sharding or scenario removal.

## User Impact

Release operators get one intentional Matrix lane per reusable invocation, and the exhaustive lane can finish and publish its aggregate verdict. Product runtime is unchanged.

## Evidence

- Exact PR head: `c39fd71ac0789ab36bb362e0798325ba3ea861e3`.
- Focused workflow tests: 236 passed, 1 skipped.
- Workflow sanity, formatting, `git diff --check`, and fresh autoreview: passed with no actionable findings.
- Exact-head delegated `check:changed`: https://github.com/openclaw/openclaw/actions/runs/30896226186
- Exact-head hosted CI and `openclaw/ci-gate`: https://github.com/openclaw/openclaw/actions/runs/30920921378
- Caller-split proof: https://github.com/openclaw/openclaw/actions/runs/30899029730
  - the intended Matrix caller scheduled one Matrix job;
  - the Buzz-only caller's Matrix job was skipped;
  - the requested Buzz job passed.
- Final exact release QA proof, workflow source `c39fd71ac0789ab36bb362e0798325ba3ea861e3`: https://github.com/openclaw/openclaw/actions/runs/30938114463
  - Matrix completed in 60m47s, directly proving the old 60-minute budget was insufficient and the 90-minute budget is required;
  - aggregate artifact `qa-live-matrix-30938114463-1`: 92 total, 92 passed, 0 failed, 0 skipped;
  - all evidence refs resolved to product head `0ae194ddc13ae3b7b798639d8d381cda9ac947bd`.

No changelog entry: this changes release-validation workflow behavior only.

Punchcard-Session: amber-workshop-river-yr
