### PR TITLE
feat(volcengine): add Doubao realtime voice provider

### DIFF
--- a/extensions/volcengine/index.ts
+++ b/extensions/volcengine/index.ts
@@ -6,6 +6,7 @@ import { ensureModelAllowlistEntry } from "openclaw/plugin-sdk/provider-onboard"
 import { applyVolcengineToolSchemaCompat } from "./api.js";
 import { VOLCENGINE_PROVIDER_CATALOG } from "./models.js";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
+import { buildDoubaoRealtimeVoiceProvider } from "./realtime-voice-provider.js";
 import { buildVolcengineSpeechProvider } from "./speech-provider.js";
 
 const PROVIDER_ID = "volcengine";
@@ -37,6 +38,7 @@ export default defineSingleProviderPluginEntry({
     normalizeResolvedModel: ({ model }) => applyVolcengineToolSchemaCompat(model),
   },
   register(api) {
+    api.registerRealtimeVoiceProvider(buildDoubaoRealtimeVoiceProvider());
     api.registerSpeechProvider(buildVolcengineSpeechProvider());
   },
 });

--- a/extensions/volcengine/openclaw.plugin.json
+++ b/extensions/volcengine/openclaw.plugin.json
@@ -31,6 +31,14 @@
   "providerAuthAliases": {
     "volcengine-plan": "volcengine"
   },
+  "providerEndpoints": [
+    {
+      "endpointClass": "doubao-realtime",
+      "hosts": [
+        "openspeech.bytedance.com"
+      ]
+    }
+  ],
   "providerRequest": {
     "providers": {
       "volcengine": {
@@ -351,6 +359,9 @@
     "properties": {}
   },
   "contracts": {
+    "realtimeVoiceProviders": [
+      "doubao"
+    ],
     "speechProviders": [
       "volcengine"
     ]

--- a/extensions/volcengine/package.json
+++ b/extensions/volcengine/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/openclaw/openclaw"
   },
   "type": "module",
+  "dependencies": {
+    "ws": "8.21.1"
+  },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"
   },

--- a/extensions/volcengine/realtime-voice-provider.test.ts
+++ b/extensions/volcengine/realtime-voice-provider.test.ts
@@ -1,10 +1,10 @@
 import type { RealtimeVoiceBridgeCreateRequest } from "openclaw/plugin-sdk/realtime-voice";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildDoubaoRealtimeVoiceProvider } from "./realtime-voice-provider.js";
 import {
-  buildDoubaoRealtimeVoiceProvider,
   extractDoubaoSpeakableMessage,
   resamplePcm16Mono24kTo16k,
-} from "./realtime-voice-provider.js";
+} from "./realtime-voice-utils.js";
 import {
   DOUBAO_CLIENT_EVENT,
   DOUBAO_SERVER_EVENT,

--- a/extensions/volcengine/realtime-voice-provider.test.ts
+++ b/extensions/volcengine/realtime-voice-provider.test.ts
@@ -1,0 +1,304 @@
+import type { RealtimeVoiceBridgeCreateRequest } from "openclaw/plugin-sdk/realtime-voice";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildDoubaoRealtimeVoiceProvider,
+  extractDoubaoSpeakableMessage,
+  resamplePcm16Mono24kTo16k,
+} from "./realtime-voice-provider.js";
+import {
+  DOUBAO_CLIENT_EVENT,
+  DOUBAO_SERVER_EVENT,
+  decodeDoubaoFrame,
+  encodeDoubaoFrame,
+} from "./realtime-wire.js";
+
+type SocketListener = (...args: unknown[]) => void;
+
+class FakeSocket {
+  readyState = 0;
+  readonly sent: Buffer[] = [];
+  readonly listeners = new Map<string, SocketListener[]>();
+
+  on(event: string, listener: SocketListener): this {
+    const listeners = this.listeners.get(event) ?? [];
+    listeners.push(listener);
+    this.listeners.set(event, listeners);
+    return this;
+  }
+
+  send(data: Buffer): void {
+    this.sent.push(Buffer.from(data));
+  }
+
+  close(): void {
+    this.readyState = 3;
+  }
+
+  emit(event: string, ...args: unknown[]): void {
+    for (const listener of this.listeners.get(event) ?? []) {
+      listener(...args);
+    }
+  }
+
+  open(): void {
+    this.readyState = 1;
+    this.emit("open");
+  }
+
+  serverFrame(event: number, payload: unknown, options?: { binary?: boolean }): void {
+    this.emit(
+      "message",
+      encodeDoubaoFrame({
+        messageType: options?.binary ? 0b1011 : 0b1001,
+        event,
+        sessionId: "session-test",
+        serialization: options?.binary ? "raw" : "json",
+        payload: options?.binary ? Buffer.from(payload as Uint8Array) : payload,
+      }),
+      true,
+    );
+  }
+}
+
+function createRequest(
+  overrides: Partial<RealtimeVoiceBridgeCreateRequest> = {},
+): RealtimeVoiceBridgeCreateRequest {
+  return {
+    providerConfig: {
+      apiKey: "test-key", // pragma: allowlist secret
+      model: "1.2.1.1",
+      speakerVoice: "zh_male_yunzhou_jupiter_bigtts",
+    },
+    audioFormat: { encoding: "pcm16", sampleRateHz: 24000, channels: 1 },
+    autoRespondToAudio: false,
+    onAudio: vi.fn(),
+    onClearAudio: vi.fn(),
+    onTranscript: vi.fn(),
+    onEvent: vi.fn(),
+    onReady: vi.fn(),
+    onError: vi.fn(),
+    onClose: vi.fn(),
+    ...overrides,
+  };
+}
+
+function decodeClientFrame(frame: Buffer) {
+  const decoded = decodeDoubaoFrame(frame);
+  if (!decoded) {
+    throw new Error("expected a decodable Doubao frame");
+  }
+  return decoded;
+}
+
+async function connectBridge(request = createRequest()) {
+  const socket = new FakeSocket();
+  const provider = buildDoubaoRealtimeVoiceProvider({
+    createSocket: () => socket,
+    connectTimeoutMs: 1_000,
+  });
+  const bridge = provider.createBridge(request);
+  const connecting = bridge.connect();
+  socket.open();
+
+  expect(decodeClientFrame(socket.sent[0]!).event).toBe(DOUBAO_CLIENT_EVENT.StartConnection);
+  socket.serverFrame(DOUBAO_SERVER_EVENT.ConnectionStarted, {});
+
+  const startSession = decodeClientFrame(socket.sent[1]!);
+  expect(startSession.event).toBe(DOUBAO_CLIENT_EVENT.StartSession);
+  expect(startSession.sessionId).toBe("session-test");
+  expect(startSession.jsonPayload).toMatchObject({
+    asr: { audio_info: { format: "pcm", sample_rate: 16000, channel: 1 } },
+    tts: {
+      speaker: "zh_male_yunzhou_jupiter_bigtts",
+      audio_config: { format: "pcm_s16le", sample_rate: 24000, channel: 1 },
+    },
+    dialog: { extra: { model: "1.2.1.1" } },
+  });
+
+  socket.serverFrame(DOUBAO_SERVER_EVENT.SessionStarted, {});
+  await connecting;
+  return { bridge, provider, request, socket };
+}
+
+describe("Doubao realtime binary framing", () => {
+  it("round-trips gzipped JSON frames with a session id", () => {
+    const encoded = encodeDoubaoFrame({
+      messageType: 0b0001,
+      event: DOUBAO_CLIENT_EVENT.StartSession,
+      sessionId: "session-1",
+      serialization: "json",
+      payload: { dialog: { extra: { model: "1.2.1.1" } } },
+    });
+
+    expect(encoded[2]! & 0x0f).toBe(1);
+    expect(decodeDoubaoFrame(encoded)).toMatchObject({
+      event: DOUBAO_CLIENT_EVENT.StartSession,
+      sessionId: "session-1",
+      jsonPayload: { dialog: { extra: { model: "1.2.1.1" } } },
+    });
+  });
+
+  it("decodes raw server audio payloads", () => {
+    const pcm = Buffer.from([1, 2, 3, 4]);
+    const decoded = decodeDoubaoFrame(
+      encodeDoubaoFrame({
+        messageType: 0b1011,
+        event: DOUBAO_SERVER_EVENT.TTSResponse,
+        sessionId: "session-1",
+        serialization: "raw",
+        payload: pcm,
+      }),
+    );
+
+    expect(decoded?.binaryPayload).toEqual(pcm);
+  });
+});
+
+describe("Doubao realtime voice provider", () => {
+  beforeEach(() => vi.useRealTimers());
+
+  it("requires a resolved API key and advertises the gateway relay contract", () => {
+    const provider = buildDoubaoRealtimeVoiceProvider();
+
+    expect(provider.isConfigured({ providerConfig: {} })).toBe(false);
+    expect(provider.isConfigured({ providerConfig: { apiKey: "resolved-key" } })).toBe(true);
+    expect(provider.capabilities).toMatchObject({
+      transports: ["gateway-relay"],
+      supportsBrowserSession: false,
+      supportsBargeIn: true,
+      supportsToolCalls: false,
+    });
+    expect(provider.capabilities).not.toHaveProperty("handlesAgentConsult");
+    const internalApi = Reflect.get(
+      provider,
+      Symbol.for("openclaw.internal.realtime-voice-provider.v1"),
+    ) as { resolveGatewayRelayCapabilities: () => Record<string, unknown> };
+    expect(internalApi.resolveGatewayRelayCapabilities()).toMatchObject({
+      supportsToolCalls: false,
+      handlesAgentConsult: true,
+    });
+  });
+
+  it("connects through StartConnection then StartSession without exposing the API key", async () => {
+    const { request, socket } = await connectBridge();
+
+    expect(request.onReady).toHaveBeenCalledTimes(1);
+    expect(Buffer.concat(socket.sent).toString("utf8")).not.toContain("test-key");
+  });
+
+  it("resamples relay PCM16 24 kHz audio to the required 16 kHz input", async () => {
+    const { bridge, socket } = await connectBridge();
+    const input = Buffer.alloc(480 * 2);
+    for (let index = 0; index < 480; index += 1) {
+      input.writeInt16LE((index % 100) * 100, index * 2);
+    }
+
+    bridge.sendAudio(input);
+
+    const audioFrame = decodeClientFrame(socket.sent.at(-1)!);
+    expect(audioFrame.event).toBe(DOUBAO_CLIENT_EVENT.TaskRequest);
+    expect(audioFrame.binaryPayload).toHaveLength(320 * 2);
+  });
+
+  it("publishes final ASR while dropping native model audio in agent-consult mode", async () => {
+    const request = createRequest();
+    const { socket } = await connectBridge(request);
+
+    socket.serverFrame(DOUBAO_SERVER_EVENT.ASRInfo, { question_id: "q-1" });
+    socket.serverFrame(DOUBAO_SERVER_EVENT.ASRResponse, {
+      results: [{ text: "看看我的任务", is_interim: true }],
+    });
+    socket.serverFrame(DOUBAO_SERVER_EVENT.ASREnded, {});
+    socket.serverFrame(DOUBAO_SERVER_EVENT.TTSSentenceStart, {
+      tts_type: "default",
+      text: "豆包原生回答",
+    });
+    socket.serverFrame(DOUBAO_SERVER_EVENT.TTSResponse, Buffer.from([1, 2]), { binary: true });
+
+    expect(request.onClearAudio).toHaveBeenCalledWith("barge-in");
+    expect(request.onTranscript).toHaveBeenCalledWith("user", "看看我的任务", false);
+    expect(request.onTranscript).toHaveBeenCalledWith("user", "看看我的任务", true);
+    expect(request.onAudio).not.toHaveBeenCalled();
+  });
+
+  it("injects the OpenClaw result with ChatTTSText and forwards only tagged audio", async () => {
+    const request = createRequest();
+    const { bridge, socket } = await connectBridge(request);
+
+    bridge.sendUserMessage?.(
+      [
+        "OpenClaw finished checking. Speak this result naturally and concisely.",
+        "Do not mention tool calls, JSON, or internal routing.",
+        "",
+        "你还有三项任务。",
+      ].join("\n"),
+    );
+
+    const ttsFrames = socket.sent
+      .map(decodeClientFrame)
+      .filter((frame) => frame.event === DOUBAO_CLIENT_EVENT.ChatTTSText);
+    expect(ttsFrames).toHaveLength(2);
+    expect(ttsFrames[0]?.jsonPayload).toEqual({
+      start: true,
+      content: "你还有三项任务。",
+      end: false,
+    });
+    expect(ttsFrames[1]?.jsonPayload).toEqual({ start: false, content: "", end: true });
+
+    socket.serverFrame(DOUBAO_SERVER_EVENT.TTSSentenceStart, {
+      tts_type: "chat_tts_text",
+      text: "你还有三项任务。",
+    });
+    socket.serverFrame(DOUBAO_SERVER_EVENT.TTSResponse, Buffer.from([1, 2, 3, 4]), {
+      binary: true,
+    });
+    socket.serverFrame(DOUBAO_SERVER_EVENT.TTSEnded, {});
+
+    expect(request.onTranscript).toHaveBeenCalledWith("assistant", "你还有三项任务。", true);
+    expect(request.onAudio).toHaveBeenCalledWith(Buffer.from([1, 2, 3, 4]));
+    expect(request.onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ direction: "server", type: "response.audio.done" }),
+    );
+  });
+
+  it("uses SayHello for a greeting before any user query", async () => {
+    const request = createRequest();
+    const { bridge, socket } = await connectBridge(request);
+
+    bridge.triggerGreeting?.("你好，我是 OpenClaw。");
+
+    const greeting = decodeClientFrame(socket.sent.at(-1)!);
+    expect(greeting).toMatchObject({
+      event: DOUBAO_CLIENT_EVENT.SayHello,
+      jsonPayload: { content: "你好，我是 OpenClaw。" },
+    });
+    expect(request.onTranscript).toHaveBeenCalledWith("assistant", "你好，我是 OpenClaw。", true);
+  });
+
+  it("extracts exact OpenClaw status messages before TTS", () => {
+    expect(
+      extractDoubaoSpeakableMessage(
+        [
+          "Internal OpenClaw voice control result.",
+          "Speak this exact OpenClaw status.",
+          'Status: "已经停止当前任务。"',
+        ].join("\n"),
+      ),
+    ).toBe("已经停止当前任务。");
+  });
+});
+
+describe("24 kHz to 16 kHz PCM resampling", () => {
+  it("preserves streaming continuity across odd chunk boundaries", () => {
+    const samples = Buffer.alloc(9 * 2);
+    for (let index = 0; index < 9; index += 1) {
+      samples.writeInt16LE(index * 1_000, index * 2);
+    }
+    const state = { pending: Buffer.alloc(0), sourcePosition: 0 };
+
+    const first = resamplePcm16Mono24kTo16k(samples.subarray(0, 5), state);
+    const second = resamplePcm16Mono24kTo16k(samples.subarray(5), state);
+
+    expect(Buffer.concat([first, second])).toHaveLength(6 * 2);
+  });
+});

--- a/extensions/volcengine/realtime-voice-provider.ts
+++ b/extensions/volcengine/realtime-voice-provider.ts
@@ -12,6 +12,12 @@ import { REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ } from "openclaw/plugin-sdk/rea
 import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
 import WebSocket from "ws";
 import {
+  extractDoubaoSpeakableMessage,
+  resamplePcm16Mono24kTo16k,
+  truncateCharacters,
+  type Pcm24kTo16kResamplerState,
+} from "./realtime-voice-utils.js";
+import {
   DOUBAO_CLIENT_EVENT,
   DOUBAO_SERVER_EVENT,
   decodeDoubaoFrame,
@@ -27,7 +33,6 @@ const DOUBAO_REALTIME_CONNECT_TIMEOUT_MS = 15_000;
 const DOUBAO_MAX_PENDING_AUDIO_BYTES = 1024 * 1024;
 const DOUBAO_MAX_PENDING_TEXT_BYTES = 16 * 1024;
 const DOUBAO_CHAT_TTS_CHUNK_CHARACTERS = 400;
-const DOUBAO_MAX_SPEAKABLE_CHARACTERS = 1_800;
 
 const DOUBAO_REALTIME_CAPABILITIES: RealtimeVoiceProviderCapabilities = {
   transports: ["gateway-relay"],
@@ -68,11 +73,6 @@ type DoubaoRealtimeVoiceProviderOptions = {
   connectTimeoutMs?: number;
 };
 
-export type Pcm24kTo16kResamplerState = {
-  pending: Buffer;
-  sourcePosition: number;
-};
-
 function optionalString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
@@ -95,74 +95,6 @@ function normalizeDoubaoProviderConfig(
     speakingStyle: optionalString(raw.speakingStyle),
     silenceDurationMs: optionalNonNegativeInteger(raw.silenceDurationMs),
   };
-}
-
-function clampPcm16(value: number): number {
-  return Math.max(-32_768, Math.min(32_767, Math.round(value)));
-}
-
-/** Exact streaming 3:2 conversion for the relay's PCM16 mono 24 kHz contract. */
-export function resamplePcm16Mono24kTo16k(input: Buffer, state: Pcm24kTo16kResamplerState): Buffer {
-  const combined = state.pending.byteLength > 0 ? Buffer.concat([state.pending, input]) : input;
-  const completeGroupBytes = Math.floor(combined.byteLength / 6) * 6;
-  state.pending = Buffer.from(combined.subarray(completeGroupBytes));
-  if (completeGroupBytes === 0) {
-    return Buffer.alloc(0);
-  }
-
-  const output = Buffer.allocUnsafe((completeGroupBytes / 6) * 4);
-  let outputOffset = 0;
-  for (let offset = 0; offset < completeGroupBytes; offset += 6) {
-    const first = combined.readInt16LE(offset);
-    const second = combined.readInt16LE(offset + 2);
-    const third = combined.readInt16LE(offset + 4);
-    output.writeInt16LE(first, outputOffset);
-    output.writeInt16LE(clampPcm16((second + third) / 2), outputOffset + 2);
-    outputOffset += 4;
-    state.sourcePosition += 3;
-  }
-  return output;
-}
-
-function truncateCharacters(value: string, max: number): string {
-  return Array.from(value).slice(0, max).join("");
-}
-
-/** Removes OpenClaw's internal relay wrapper before sending text to Doubao TTS. */
-export function extractDoubaoSpeakableMessage(input: string): string {
-  const trimmed = input.trim();
-  if (!trimmed) {
-    return "";
-  }
-
-  if (trimmed.startsWith("Internal OpenClaw voice control result.")) {
-    const status = trimmed.match(/^Status:\s*(.+)$/mu)?.[1]?.trim();
-    if (status) {
-      try {
-        const decoded = JSON.parse(status) as unknown;
-        if (typeof decoded === "string") {
-          return truncateCharacters(decoded.trim(), DOUBAO_MAX_SPEAKABLE_CHARACTERS);
-        }
-      } catch {
-        return truncateCharacters(status, DOUBAO_MAX_SPEAKABLE_CHARACTERS);
-      }
-    }
-  }
-
-  if (trimmed.startsWith("OpenClaw finished checking.")) {
-    const separator = trimmed.indexOf("\n\n");
-    if (separator >= 0) {
-      return truncateCharacters(
-        trimmed.slice(separator + 2).trim(),
-        DOUBAO_MAX_SPEAKABLE_CHARACTERS,
-      );
-    }
-  }
-
-  if (trimmed.startsWith("OpenClaw is checking")) {
-    return "我正在处理，请稍等。";
-  }
-  return truncateCharacters(trimmed, DOUBAO_MAX_SPEAKABLE_CHARACTERS);
 }
 
 function readText(payload: unknown): string | undefined {

--- a/extensions/volcengine/realtime-voice-provider.ts
+++ b/extensions/volcengine/realtime-voice-provider.ts
@@ -1,0 +1,754 @@
+// Doubao end-to-end realtime voice provider for OpenClaw's gateway relay.
+import { randomUUID } from "node:crypto";
+import type {
+  RealtimeVoiceBridge,
+  RealtimeVoiceBridgeCreateRequest,
+  RealtimeVoiceProviderCapabilities,
+  RealtimeVoiceProviderConfig,
+  RealtimeVoiceProviderPlugin,
+  RealtimeVoiceToolResultOptions,
+} from "openclaw/plugin-sdk/realtime-voice";
+import { REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ } from "openclaw/plugin-sdk/realtime-voice";
+import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
+import WebSocket from "ws";
+import {
+  DOUBAO_CLIENT_EVENT,
+  DOUBAO_SERVER_EVENT,
+  decodeDoubaoFrame,
+  encodeDoubaoFrame,
+  type DecodedDoubaoFrame,
+} from "./realtime-wire.js";
+
+const DOUBAO_REALTIME_URL = "wss://openspeech.bytedance.com/api/v3/realtime/dialogue";
+const DOUBAO_REALTIME_RESOURCE_ID = "volc.speech.dialog";
+const DOUBAO_REALTIME_DEFAULT_MODEL = "1.2.1.1";
+const DOUBAO_REALTIME_DEFAULT_VOICE = "zh_male_yunzhou_jupiter_bigtts";
+const DOUBAO_REALTIME_CONNECT_TIMEOUT_MS = 15_000;
+const DOUBAO_MAX_PENDING_AUDIO_BYTES = 1024 * 1024;
+const DOUBAO_MAX_PENDING_TEXT_BYTES = 16 * 1024;
+const DOUBAO_CHAT_TTS_CHUNK_CHARACTERS = 400;
+const DOUBAO_MAX_SPEAKABLE_CHARACTERS = 1_800;
+
+const DOUBAO_REALTIME_CAPABILITIES: RealtimeVoiceProviderCapabilities = {
+  transports: ["gateway-relay"],
+  inputAudioFormats: [REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ],
+  outputAudioFormats: [REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ],
+  supportsBrowserSession: false,
+  supportsBargeIn: true,
+  handlesInputAudioBargeIn: true,
+  supportsToolCalls: false,
+  supportsVideoFrames: false,
+};
+
+const INTERNAL_REALTIME_VOICE_PROVIDER = Symbol.for("openclaw.internal.realtime-voice-provider.v1");
+
+type DoubaoRealtimeProviderConfig = {
+  apiKey?: string;
+  model?: string;
+  voice?: string;
+  botName?: string;
+  speakingStyle?: string;
+  silenceDurationMs?: number;
+};
+
+type DoubaoSocket = {
+  readyState: number;
+  on(event: string, listener: (...args: unknown[]) => void): DoubaoSocket;
+  send(data: Buffer): void;
+  close(): void;
+};
+
+type DoubaoSocketFactory = (
+  url: string,
+  options: { headers: Record<string, string> },
+) => DoubaoSocket;
+
+type DoubaoRealtimeVoiceProviderOptions = {
+  createSocket?: DoubaoSocketFactory;
+  connectTimeoutMs?: number;
+};
+
+export type Pcm24kTo16kResamplerState = {
+  pending: Buffer;
+  sourcePosition: number;
+};
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function optionalNonNegativeInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+}
+
+function normalizeDoubaoProviderConfig(
+  raw: RealtimeVoiceProviderConfig,
+): DoubaoRealtimeProviderConfig {
+  return {
+    apiKey: normalizeResolvedSecretInputString({
+      value: raw.apiKey,
+      path: "talk.realtime.providers.doubao.apiKey",
+    }),
+    model: optionalString(raw.model),
+    voice: optionalString(raw.speakerVoice) ?? optionalString(raw.voice),
+    botName: optionalString(raw.botName),
+    speakingStyle: optionalString(raw.speakingStyle),
+    silenceDurationMs: optionalNonNegativeInteger(raw.silenceDurationMs),
+  };
+}
+
+function clampPcm16(value: number): number {
+  return Math.max(-32_768, Math.min(32_767, Math.round(value)));
+}
+
+/** Exact streaming 3:2 conversion for the relay's PCM16 mono 24 kHz contract. */
+export function resamplePcm16Mono24kTo16k(input: Buffer, state: Pcm24kTo16kResamplerState): Buffer {
+  const combined = state.pending.byteLength > 0 ? Buffer.concat([state.pending, input]) : input;
+  const completeGroupBytes = Math.floor(combined.byteLength / 6) * 6;
+  state.pending = Buffer.from(combined.subarray(completeGroupBytes));
+  if (completeGroupBytes === 0) {
+    return Buffer.alloc(0);
+  }
+
+  const output = Buffer.allocUnsafe((completeGroupBytes / 6) * 4);
+  let outputOffset = 0;
+  for (let offset = 0; offset < completeGroupBytes; offset += 6) {
+    const first = combined.readInt16LE(offset);
+    const second = combined.readInt16LE(offset + 2);
+    const third = combined.readInt16LE(offset + 4);
+    output.writeInt16LE(first, outputOffset);
+    output.writeInt16LE(clampPcm16((second + third) / 2), outputOffset + 2);
+    outputOffset += 4;
+    state.sourcePosition += 3;
+  }
+  return output;
+}
+
+function truncateCharacters(value: string, max: number): string {
+  return Array.from(value).slice(0, max).join("");
+}
+
+/** Removes OpenClaw's internal relay wrapper before sending text to Doubao TTS. */
+export function extractDoubaoSpeakableMessage(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  if (trimmed.startsWith("Internal OpenClaw voice control result.")) {
+    const status = trimmed.match(/^Status:\s*(.+)$/mu)?.[1]?.trim();
+    if (status) {
+      try {
+        const decoded = JSON.parse(status) as unknown;
+        if (typeof decoded === "string") {
+          return truncateCharacters(decoded.trim(), DOUBAO_MAX_SPEAKABLE_CHARACTERS);
+        }
+      } catch {
+        return truncateCharacters(status, DOUBAO_MAX_SPEAKABLE_CHARACTERS);
+      }
+    }
+  }
+
+  if (trimmed.startsWith("OpenClaw finished checking.")) {
+    const separator = trimmed.indexOf("\n\n");
+    if (separator >= 0) {
+      return truncateCharacters(
+        trimmed.slice(separator + 2).trim(),
+        DOUBAO_MAX_SPEAKABLE_CHARACTERS,
+      );
+    }
+  }
+
+  if (trimmed.startsWith("OpenClaw is checking")) {
+    return "我正在处理，请稍等。";
+  }
+  return truncateCharacters(trimmed, DOUBAO_MAX_SPEAKABLE_CHARACTERS);
+}
+
+function readText(payload: unknown): string | undefined {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return undefined;
+  }
+  const record = payload as Record<string, unknown>;
+  const direct = optionalString(record.text) ?? optionalString(record.transcript);
+  if (direct) {
+    return direct;
+  }
+  const results = Array.isArray(record.results)
+    ? record.results
+    : Array.isArray(record.result)
+      ? record.result
+      : undefined;
+  if (!results) {
+    return undefined;
+  }
+  for (let index = results.length - 1; index >= 0; index -= 1) {
+    const entry = results[index];
+    if (entry && typeof entry === "object" && !Array.isArray(entry)) {
+      const text = optionalString((entry as Record<string, unknown>).text);
+      if (text) {
+        return text;
+      }
+    }
+  }
+  return undefined;
+}
+
+function readTtsType(payload: unknown): string | undefined {
+  return payload && typeof payload === "object" && !Array.isArray(payload)
+    ? optionalString((payload as Record<string, unknown>).tts_type)
+    : undefined;
+}
+
+function readFailureDetail(payload: unknown): string | undefined {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return undefined;
+  }
+  const record = payload as Record<string, unknown>;
+  for (const key of ["error", "message", "status_code"] as const) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) {
+      return truncateCharacters(value.trim(), 240);
+    }
+    if (typeof value === "number") {
+      return String(value);
+    }
+  }
+  return undefined;
+}
+
+function resultText(result: unknown): string {
+  if (typeof result === "string") {
+    return result;
+  }
+  if (result && typeof result === "object" && !Array.isArray(result)) {
+    const record = result as Record<string, unknown>;
+    for (const key of ["text", "result", "output", "error", "message"] as const) {
+      const value = record[key];
+      if (typeof value === "string" && value.trim()) {
+        return value;
+      }
+    }
+  }
+  return JSON.stringify(result ?? "");
+}
+
+function toBuffer(value: unknown): Buffer | undefined {
+  if (Buffer.isBuffer(value)) {
+    return value;
+  }
+  if (value instanceof ArrayBuffer) {
+    return Buffer.from(value);
+  }
+  if (ArrayBuffer.isView(value)) {
+    return Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+  }
+  if (Array.isArray(value) && value.every((entry) => Buffer.isBuffer(entry))) {
+    return Buffer.concat(value);
+  }
+  return undefined;
+}
+
+class DoubaoRealtimeVoiceBridge implements RealtimeVoiceBridge {
+  readonly supportsToolResultContinuation = false;
+  readonly supportsToolResultSuppression = false;
+  readonly handlesInputAudioBargeIn = true;
+
+  private socket: DoubaoSocket | undefined;
+  private sessionId = "";
+  private ready = false;
+  private closing = false;
+  private terminalNotified = false;
+  private sessionStartSent = false;
+  private lastUserTranscript = "";
+  private lastAssistantTranscript = "";
+  private activeTtsType: string | undefined;
+  private forwardActiveTts = false;
+  private pendingAudio: Buffer[] = [];
+  private pendingAudioBytes = 0;
+  private pendingText: string[] = [];
+  private pendingTextBytes = 0;
+  private pendingGreeting: string | undefined;
+  private readonly resamplerState: Pcm24kTo16kResamplerState = {
+    pending: Buffer.alloc(0),
+    sourcePosition: 0,
+  };
+
+  constructor(
+    private readonly request: RealtimeVoiceBridgeCreateRequest,
+    private readonly config: Required<
+      Pick<DoubaoRealtimeProviderConfig, "apiKey" | "model" | "voice" | "botName">
+    > &
+      DoubaoRealtimeProviderConfig,
+    private readonly createSocket: DoubaoSocketFactory,
+    private readonly connectTimeoutMs: number,
+  ) {}
+
+  connect(): Promise<void> {
+    if (this.ready) {
+      return Promise.resolve();
+    }
+    if (this.socket) {
+      return Promise.reject(new Error("Doubao realtime connection is already starting"));
+    }
+
+    return new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const finishResolve = () => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timeout);
+          resolve();
+        }
+      };
+      const finishReject = (error: Error) => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timeout);
+          reject(error);
+        }
+      };
+      const timeout = setTimeout(() => {
+        const error = new Error("Doubao realtime connection timed out");
+        this.request.onError?.(error);
+        finishReject(error);
+        this.socket?.close();
+      }, this.connectTimeoutMs);
+
+      try {
+        this.socket = this.createSocket(DOUBAO_REALTIME_URL, {
+          headers: {
+            "X-Api-Key": this.config.apiKey,
+            "X-Api-Resource-Id": DOUBAO_REALTIME_RESOURCE_ID,
+            "X-Api-Request-Id": randomUUID(),
+            "X-Api-Connect-Id": randomUUID(),
+            "X-Api-Sequence": "-1",
+          },
+        });
+      } catch (cause) {
+        finishReject(cause instanceof Error ? cause : new Error("Doubao socket creation failed"));
+        return;
+      }
+
+      this.socket
+        .on("open", () => {
+          this.sendJson(DOUBAO_CLIENT_EVENT.StartConnection, {}, false);
+          this.emitEvent("client", "connection.start");
+        })
+        .on("message", (data) => {
+          const buffer = toBuffer(data);
+          if (!buffer) {
+            return;
+          }
+          const frame = decodeDoubaoFrame(buffer);
+          if (frame) {
+            this.handleServerFrame(frame, finishResolve, finishReject);
+          }
+        })
+        .on("error", (cause) => {
+          const error = cause instanceof Error ? cause : new Error("Doubao realtime socket failed");
+          this.request.onError?.(error);
+          finishReject(error);
+        })
+        .on("close", () => {
+          this.ready = false;
+          if (!this.closing) {
+            const error = new Error("Doubao realtime socket closed unexpectedly");
+            this.request.onError?.(error);
+            finishReject(error);
+            this.notifyClose("error");
+          } else {
+            this.notifyClose("completed");
+          }
+        });
+    });
+  }
+
+  sendAudio(audio: Buffer): void {
+    if (!this.ready) {
+      this.queueAudio(audio);
+      return;
+    }
+    const resampled = resamplePcm16Mono24kTo16k(audio, this.resamplerState);
+    if (resampled.byteLength > 0) {
+      this.sendRaw(DOUBAO_CLIENT_EVENT.TaskRequest, resampled);
+    }
+  }
+
+  setMediaTimestamp(_timestamp: number): void {}
+
+  sendUserMessage(text: string): void {
+    const speakable = extractDoubaoSpeakableMessage(text);
+    if (!speakable) {
+      return;
+    }
+    if (!this.ready) {
+      this.queueText(speakable);
+      return;
+    }
+    this.sendChatTtsText(speakable);
+  }
+
+  triggerGreeting(instructions?: string): void {
+    const content = extractDoubaoSpeakableMessage(
+      instructions?.trim() || "你好，我是 OpenClaw，有什么可以帮你？",
+    );
+    if (!content) {
+      return;
+    }
+    if (!this.ready) {
+      this.pendingGreeting = content;
+      return;
+    }
+    this.sendJson(DOUBAO_CLIENT_EVENT.SayHello, { content });
+    this.request.onTranscript?.("assistant", content, true);
+  }
+
+  handleBargeIn(): void {
+    this.request.onClearAudio("barge-in");
+    this.emitEvent("server", "input_audio_buffer.speech_started");
+  }
+
+  submitToolResult(
+    _callId: string,
+    result: unknown,
+    options?: RealtimeVoiceToolResultOptions,
+  ): void {
+    if (!options?.suppressResponse) {
+      this.sendUserMessage(resultText(result));
+    }
+  }
+
+  acknowledgeMark(_markName?: string): void {}
+
+  close(): void {
+    if (this.closing) {
+      return;
+    }
+    this.closing = true;
+    if (this.socket?.readyState === WebSocket.OPEN) {
+      if (this.sessionStartSent) {
+        this.sendJson(DOUBAO_CLIENT_EVENT.FinishSession, {});
+      }
+      this.sendJson(DOUBAO_CLIENT_EVENT.FinishConnection, {}, false);
+    }
+    this.socket?.close();
+    if (!this.socket) {
+      this.notifyClose("completed");
+    }
+  }
+
+  isConnected(): boolean {
+    return this.ready && this.socket?.readyState === WebSocket.OPEN;
+  }
+
+  private handleServerFrame(
+    frame: DecodedDoubaoFrame,
+    resolveConnect: () => void,
+    rejectConnect: (error: Error) => void,
+  ): void {
+    if (frame.messageType === 0x0f || frame.errorCode !== undefined) {
+      const error = new Error(`Doubao realtime protocol error (${frame.errorCode ?? "unknown"})`);
+      this.request.onError?.(error);
+      rejectConnect(error);
+      return;
+    }
+
+    switch (frame.event) {
+      case DOUBAO_SERVER_EVENT.ConnectionStarted:
+        if (!this.sessionStartSent) {
+          if (!frame.sessionId) {
+            const error = new Error("Doubao realtime connection did not return a session id");
+            this.request.onError?.(error);
+            rejectConnect(error);
+            break;
+          }
+          this.sessionId = frame.sessionId;
+          this.sessionStartSent = true;
+          this.sendJson(DOUBAO_CLIENT_EVENT.StartSession, this.buildStartSessionPayload());
+          this.emitEvent("client", "session.start");
+        }
+        break;
+      case DOUBAO_SERVER_EVENT.SessionStarted:
+        this.ready = true;
+        this.request.onReady?.();
+        this.emitEvent("server", "session.ready");
+        resolveConnect();
+        this.flushPending();
+        break;
+      case DOUBAO_SERVER_EVENT.ASRInfo:
+        this.request.onClearAudio("barge-in");
+        this.emitEvent("server", "input_audio_buffer.speech_started");
+        break;
+      case DOUBAO_SERVER_EVENT.ASRResponse: {
+        const text = readText(frame.jsonPayload);
+        if (text) {
+          this.lastUserTranscript = text;
+          this.request.onTranscript?.("user", text, false);
+        }
+        break;
+      }
+      case DOUBAO_SERVER_EVENT.ASREnded: {
+        const text = readText(frame.jsonPayload) ?? this.lastUserTranscript;
+        if (text) {
+          this.request.onTranscript?.("user", text, true);
+        }
+        this.lastUserTranscript = "";
+        break;
+      }
+      case DOUBAO_SERVER_EVENT.ChatResponse: {
+        const text = readText(frame.jsonPayload);
+        if (text) {
+          this.lastAssistantTranscript = text;
+          if (this.request.autoRespondToAudio !== false) {
+            this.request.onTranscript?.("assistant", text, false);
+          }
+        }
+        break;
+      }
+      case DOUBAO_SERVER_EVENT.ChatEnded: {
+        const text = readText(frame.jsonPayload) ?? this.lastAssistantTranscript;
+        if (text && this.request.autoRespondToAudio !== false) {
+          this.request.onTranscript?.("assistant", text, true);
+        }
+        this.lastAssistantTranscript = "";
+        break;
+      }
+      case DOUBAO_SERVER_EVENT.TTSSentenceStart:
+        this.activeTtsType = readTtsType(frame.jsonPayload);
+        this.forwardActiveTts =
+          this.request.autoRespondToAudio !== false || this.activeTtsType === "chat_tts_text";
+        break;
+      case DOUBAO_SERVER_EVENT.TTSResponse:
+        if (this.forwardActiveTts && frame.binaryPayload?.byteLength) {
+          this.request.onAudio(frame.binaryPayload);
+          this.emitEvent("server", "response.audio.delta");
+        }
+        break;
+      case DOUBAO_SERVER_EVENT.TTSEnded:
+        if (this.forwardActiveTts) {
+          this.emitEvent("server", "response.audio.done");
+        }
+        this.activeTtsType = undefined;
+        this.forwardActiveTts = false;
+        break;
+      case DOUBAO_SERVER_EVENT.ConnectionFailed:
+      case DOUBAO_SERVER_EVENT.SessionFailed:
+      case DOUBAO_SERVER_EVENT.ChatFailed: {
+        const detail = readFailureDetail(frame.jsonPayload);
+        const error = new Error(
+          `Doubao realtime request failed (event ${frame.event}${detail ? `: ${detail}` : ""})`,
+        );
+        this.request.onError?.(error);
+        rejectConnect(error);
+        break;
+      }
+      case DOUBAO_SERVER_EVENT.SessionFinished:
+      case DOUBAO_SERVER_EVENT.ConnectionFinished:
+        if (!this.closing) {
+          this.close();
+        }
+        break;
+      default:
+        break;
+    }
+  }
+
+  private buildStartSessionPayload(): Record<string, unknown> {
+    const dialog: Record<string, unknown> = {
+      bot_name: this.config.botName,
+      extra: {
+        model: this.config.model,
+        strict_audit: false,
+      },
+    };
+    if (this.request.instructions?.trim()) {
+      dialog.system_role = this.request.instructions.trim();
+    }
+    if (this.config.speakingStyle) {
+      dialog.speaking_style = this.config.speakingStyle;
+    }
+    return {
+      asr: {
+        audio_info: { format: "pcm", sample_rate: 16_000, channel: 1 },
+        extra: {
+          end_smooth_window_ms: Math.max(
+            500,
+            Math.min(50_000, this.config.silenceDurationMs ?? 1_500),
+          ),
+        },
+      },
+      tts: {
+        speaker: this.config.voice,
+        audio_config: { channel: 1, format: "pcm_s16le", sample_rate: 24_000 },
+        extra: {},
+      },
+      dialog,
+    };
+  }
+
+  private sendChatTtsText(text: string): void {
+    const characters = Array.from(text);
+    const chunks: string[] = [];
+    for (let offset = 0; offset < characters.length; offset += DOUBAO_CHAT_TTS_CHUNK_CHARACTERS) {
+      chunks.push(characters.slice(offset, offset + DOUBAO_CHAT_TTS_CHUNK_CHARACTERS).join(""));
+    }
+    chunks.forEach((content, index) => {
+      this.sendJson(DOUBAO_CLIENT_EVENT.ChatTTSText, {
+        start: index === 0,
+        content,
+        end: false,
+      });
+    });
+    this.sendJson(DOUBAO_CLIENT_EVENT.ChatTTSText, { start: false, content: "", end: true });
+    this.request.onTranscript?.("assistant", text, true);
+    this.emitEvent("client", "response.text.injected");
+  }
+
+  private queueAudio(audio: Buffer): void {
+    const copy = Buffer.from(audio);
+    if (copy.byteLength > DOUBAO_MAX_PENDING_AUDIO_BYTES) {
+      return;
+    }
+    while (
+      this.pendingAudio.length > 0 &&
+      this.pendingAudioBytes + copy.byteLength > DOUBAO_MAX_PENDING_AUDIO_BYTES
+    ) {
+      const dropped = this.pendingAudio.shift();
+      this.pendingAudioBytes -= dropped?.byteLength ?? 0;
+    }
+    if (this.pendingAudioBytes + copy.byteLength <= DOUBAO_MAX_PENDING_AUDIO_BYTES) {
+      this.pendingAudio.push(copy);
+      this.pendingAudioBytes += copy.byteLength;
+    }
+  }
+
+  private queueText(text: string): void {
+    const bytes = Buffer.byteLength(text, "utf8");
+    if (bytes > DOUBAO_MAX_PENDING_TEXT_BYTES) {
+      return;
+    }
+    while (
+      this.pendingText.length > 0 &&
+      this.pendingTextBytes + bytes > DOUBAO_MAX_PENDING_TEXT_BYTES
+    ) {
+      const dropped = this.pendingText.shift();
+      this.pendingTextBytes -= dropped ? Buffer.byteLength(dropped, "utf8") : 0;
+    }
+    this.pendingText.push(text);
+    this.pendingTextBytes += bytes;
+  }
+
+  private flushPending(): void {
+    const audio = this.pendingAudio;
+    const text = this.pendingText;
+    const greeting = this.pendingGreeting;
+    this.pendingAudio = [];
+    this.pendingAudioBytes = 0;
+    this.pendingText = [];
+    this.pendingTextBytes = 0;
+    this.pendingGreeting = undefined;
+    if (greeting) {
+      this.sendJson(DOUBAO_CLIENT_EVENT.SayHello, { content: greeting });
+      this.request.onTranscript?.("assistant", greeting, true);
+    }
+    for (const chunk of audio) {
+      this.sendAudio(chunk);
+    }
+    for (const message of text) {
+      this.sendChatTtsText(message);
+    }
+  }
+
+  private sendJson(event: number, payload: unknown, includeSession = true): void {
+    this.sendFrame(
+      encodeDoubaoFrame({
+        messageType: 0x01,
+        event,
+        sessionId: includeSession ? this.sessionId : undefined,
+        serialization: "json",
+        payload,
+      }),
+    );
+  }
+
+  private sendRaw(event: number, payload: Buffer): void {
+    this.sendFrame(
+      encodeDoubaoFrame({
+        messageType: 0x02,
+        event,
+        sessionId: this.sessionId,
+        serialization: "raw",
+        payload,
+      }),
+    );
+  }
+
+  private sendFrame(frame: Buffer): void {
+    if (this.socket?.readyState === WebSocket.OPEN) {
+      this.socket.send(frame);
+    }
+  }
+
+  private emitEvent(direction: "client" | "server", type: string): void {
+    this.request.onEvent?.({ direction, type });
+  }
+
+  private notifyClose(reason: "completed" | "error"): void {
+    if (!this.terminalNotified) {
+      this.terminalNotified = true;
+      this.request.onClose?.(reason);
+    }
+  }
+}
+
+export function buildDoubaoRealtimeVoiceProvider(
+  options: DoubaoRealtimeVoiceProviderOptions = {},
+): RealtimeVoiceProviderPlugin {
+  const createSocket: DoubaoSocketFactory =
+    options.createSocket ??
+    ((url, socketOptions) => new WebSocket(url, socketOptions) as unknown as DoubaoSocket);
+  const provider: RealtimeVoiceProviderPlugin = {
+    id: "doubao",
+    label: "Doubao Realtime Voice",
+    aliases: ["volcengine-realtime"],
+    defaultModel: DOUBAO_REALTIME_DEFAULT_MODEL,
+    models: [DOUBAO_REALTIME_DEFAULT_MODEL],
+    voices: [DOUBAO_REALTIME_DEFAULT_VOICE],
+    autoSelectOrder: 30,
+    capabilities: DOUBAO_REALTIME_CAPABILITIES,
+    resolveConfig: ({ rawConfig }) => normalizeDoubaoProviderConfig(rawConfig),
+    isConfigured: ({ providerConfig }) =>
+      Boolean(normalizeDoubaoProviderConfig(providerConfig).apiKey),
+    createBridge: (request) => {
+      const config = normalizeDoubaoProviderConfig(request.providerConfig);
+      if (!config.apiKey) {
+        throw new Error("Doubao realtime API key missing");
+      }
+      return new DoubaoRealtimeVoiceBridge(
+        request,
+        {
+          ...config,
+          apiKey: config.apiKey,
+          model: config.model ?? DOUBAO_REALTIME_DEFAULT_MODEL,
+          voice: config.voice ?? DOUBAO_REALTIME_DEFAULT_VOICE,
+          botName: config.botName ?? "OpenClaw",
+        },
+        createSocket,
+        options.connectTimeoutMs ?? DOUBAO_REALTIME_CONNECT_TIMEOUT_MS,
+      );
+    },
+  };
+  const internalApi = {
+    isBrowserSessionConfigured: () => false,
+    resolveGatewayRelayCapabilities: () => ({
+      ...DOUBAO_REALTIME_CAPABILITIES,
+      handlesAgentConsult: true,
+    }),
+  };
+  Object.defineProperty(provider, INTERNAL_REALTIME_VOICE_PROVIDER, {
+    configurable: true,
+    value: internalApi,
+  });
+  return provider;
+}

--- a/extensions/volcengine/realtime-voice-utils.ts
+++ b/extensions/volcengine/realtime-voice-utils.ts
@@ -1,0 +1,74 @@
+const DOUBAO_MAX_SPEAKABLE_CHARACTERS = 1_800;
+
+export type Pcm24kTo16kResamplerState = {
+  pending: Buffer;
+  sourcePosition: number;
+};
+
+function clampPcm16(value: number): number {
+  return Math.max(-32_768, Math.min(32_767, Math.round(value)));
+}
+
+/** Exact streaming 3:2 conversion for the relay's PCM16 mono 24 kHz contract. */
+export function resamplePcm16Mono24kTo16k(input: Buffer, state: Pcm24kTo16kResamplerState): Buffer {
+  const combined = state.pending.byteLength > 0 ? Buffer.concat([state.pending, input]) : input;
+  const completeGroupBytes = Math.floor(combined.byteLength / 6) * 6;
+  state.pending = Buffer.from(combined.subarray(completeGroupBytes));
+  if (completeGroupBytes === 0) {
+    return Buffer.alloc(0);
+  }
+
+  const output = Buffer.allocUnsafe((completeGroupBytes / 6) * 4);
+  let outputOffset = 0;
+  for (let offset = 0; offset < completeGroupBytes; offset += 6) {
+    const first = combined.readInt16LE(offset);
+    const second = combined.readInt16LE(offset + 2);
+    const third = combined.readInt16LE(offset + 4);
+    output.writeInt16LE(first, outputOffset);
+    output.writeInt16LE(clampPcm16((second + third) / 2), outputOffset + 2);
+    outputOffset += 4;
+    state.sourcePosition += 3;
+  }
+  return output;
+}
+
+export function truncateCharacters(value: string, max: number): string {
+  return Array.from(value).slice(0, max).join("");
+}
+
+/** Removes OpenClaw's internal relay wrapper before sending text to Doubao TTS. */
+export function extractDoubaoSpeakableMessage(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  if (trimmed.startsWith("Internal OpenClaw voice control result.")) {
+    const status = trimmed.match(/^Status:\s*(.+)$/mu)?.[1]?.trim();
+    if (status) {
+      try {
+        const decoded = JSON.parse(status) as unknown;
+        if (typeof decoded === "string") {
+          return truncateCharacters(decoded.trim(), DOUBAO_MAX_SPEAKABLE_CHARACTERS);
+        }
+      } catch {
+        return truncateCharacters(status, DOUBAO_MAX_SPEAKABLE_CHARACTERS);
+      }
+    }
+  }
+
+  if (trimmed.startsWith("OpenClaw finished checking.")) {
+    const separator = trimmed.indexOf("\n\n");
+    if (separator >= 0) {
+      return truncateCharacters(
+        trimmed.slice(separator + 2).trim(),
+        DOUBAO_MAX_SPEAKABLE_CHARACTERS,
+      );
+    }
+  }
+
+  if (trimmed.startsWith("OpenClaw is checking")) {
+    return "我正在处理，请稍等。";
+  }
+  return truncateCharacters(trimmed, DOUBAO_MAX_SPEAKABLE_CHARACTERS);
+}

--- a/extensions/volcengine/realtime-wire.ts
+++ b/extensions/volcengine/realtime-wire.ts
@@ -33,7 +33,7 @@ export const DOUBAO_SERVER_EVENT = {
 
 type DoubaoSerialization = "json" | "raw";
 
-export type EncodeDoubaoFrameParams = {
+type EncodeDoubaoFrameParams = {
   messageType: number;
   event: number;
   sessionId?: string;

--- a/extensions/volcengine/realtime-wire.ts
+++ b/extensions/volcengine/realtime-wire.ts
@@ -1,0 +1,190 @@
+// Doubao realtime dialogue binary framing helpers.
+import { gunzipSync, gzipSync } from "node:zlib";
+
+export const DOUBAO_CLIENT_EVENT = {
+  StartConnection: 1,
+  FinishConnection: 2,
+  StartSession: 100,
+  FinishSession: 102,
+  TaskRequest: 200,
+  SayHello: 300,
+  ChatTTSText: 500,
+} as const;
+
+export const DOUBAO_SERVER_EVENT = {
+  ConnectionStarted: 50,
+  ConnectionFailed: 51,
+  ConnectionFinished: 52,
+  SessionStarted: 150,
+  SessionFinished: 152,
+  SessionFailed: 153,
+  UsageResponse: 154,
+  TTSSentenceStart: 350,
+  TTSSentenceEnd: 351,
+  TTSResponse: 352,
+  TTSEnded: 359,
+  ASRInfo: 450,
+  ASRResponse: 451,
+  ASREnded: 459,
+  ChatResponse: 550,
+  ChatEnded: 559,
+  ChatFailed: 599,
+} as const;
+
+type DoubaoSerialization = "json" | "raw";
+
+export type EncodeDoubaoFrameParams = {
+  messageType: number;
+  event: number;
+  sessionId?: string;
+  serialization: DoubaoSerialization;
+  payload: unknown;
+};
+
+export type DecodedDoubaoFrame = {
+  messageType: number;
+  flags: number;
+  event?: number;
+  sessionId?: string;
+  errorCode?: number;
+  jsonPayload?: unknown;
+  binaryPayload?: Buffer;
+};
+
+const PROTOCOL_VERSION_AND_HEADER_SIZE = 0x11;
+const EVENT_FLAG = 0x04;
+const JSON_SERIALIZATION = 0x01;
+const GZIP_COMPRESSION = 0x01;
+const ERROR_MESSAGE_TYPE = 0x0f;
+
+function encodePayload(serialization: DoubaoSerialization, payload: unknown): Buffer {
+  if (serialization === "raw") {
+    return Buffer.isBuffer(payload) ? payload : Buffer.from(payload as Uint8Array);
+  }
+  return Buffer.from(JSON.stringify(payload ?? {}), "utf8");
+}
+
+function writeLengthPrefixed(value: Buffer): Buffer {
+  const length = Buffer.allocUnsafe(4);
+  length.writeUInt32BE(value.byteLength, 0);
+  return Buffer.concat([length, value]);
+}
+
+export function encodeDoubaoFrame(params: EncodeDoubaoFrameParams): Buffer {
+  const serialized = encodePayload(params.serialization, params.payload);
+  const compressed = gzipSync(serialized);
+  const header = Buffer.from([
+    PROTOCOL_VERSION_AND_HEADER_SIZE,
+    ((params.messageType & 0x0f) << 4) | EVENT_FLAG,
+    ((params.serialization === "json" ? JSON_SERIALIZATION : 0) << 4) | GZIP_COMPRESSION,
+    0,
+  ]);
+  const event = Buffer.allocUnsafe(4);
+  event.writeUInt32BE(params.event, 0);
+  const session = params.sessionId
+    ? writeLengthPrefixed(Buffer.from(params.sessionId, "utf8"))
+    : Buffer.alloc(0);
+  return Buffer.concat([header, event, session, writeLengthPrefixed(compressed)]);
+}
+
+function readUInt32(buffer: Buffer, offset: number): number | undefined {
+  return offset + 4 <= buffer.byteLength ? buffer.readUInt32BE(offset) : undefined;
+}
+
+function readPayloadAndSession(
+  buffer: Buffer,
+  offset: number,
+): { payload: Buffer; sessionId?: string } | undefined {
+  const firstLength = readUInt32(buffer, offset);
+  if (firstLength === undefined) {
+    return undefined;
+  }
+  const firstStart = offset + 4;
+
+  // Session-scoped frames encode session-id length + session-id before payload length.
+  const payloadLengthOffset = firstStart + firstLength;
+  const nestedPayloadLength = readUInt32(buffer, payloadLengthOffset);
+  if (
+    firstLength > 0 &&
+    firstLength <= 128 &&
+    nestedPayloadLength !== undefined &&
+    payloadLengthOffset + 4 + nestedPayloadLength === buffer.byteLength
+  ) {
+    const sessionBytes = buffer.subarray(firstStart, payloadLengthOffset);
+    const sessionId = sessionBytes.toString("utf8");
+    if (/^[\x20-\x7e]+$/u.test(sessionId)) {
+      return {
+        sessionId,
+        payload: buffer.subarray(payloadLengthOffset + 4),
+      };
+    }
+  }
+
+  if (firstStart + firstLength !== buffer.byteLength) {
+    return undefined;
+  }
+  return { payload: buffer.subarray(firstStart) };
+}
+
+export function decodeDoubaoFrame(input: Buffer): DecodedDoubaoFrame | undefined {
+  if (input.byteLength < 8) {
+    return undefined;
+  }
+  const headerWords = input[0]! & 0x0f;
+  if (input[0]! >> 4 !== 1 || headerWords < 1) {
+    return undefined;
+  }
+  let offset = headerWords * 4;
+  const messageType = input[1]! >> 4;
+  const flags = input[1]! & 0x0f;
+  const serializationCode = input[2]! >> 4;
+  const compressionCode = input[2]! & 0x0f;
+  let event: number | undefined;
+  if ((flags & EVENT_FLAG) !== 0) {
+    event = readUInt32(input, offset);
+    if (event === undefined) {
+      return undefined;
+    }
+    offset += 4;
+  }
+
+  let errorCode: number | undefined;
+  if (messageType === ERROR_MESSAGE_TYPE) {
+    errorCode = readUInt32(input, offset);
+    if (errorCode === undefined) {
+      return undefined;
+    }
+    offset += 4;
+  }
+
+  const scopedPayload = readPayloadAndSession(input, offset);
+  if (!scopedPayload) {
+    return undefined;
+  }
+  let payload = scopedPayload.payload;
+  if (compressionCode === GZIP_COMPRESSION) {
+    try {
+      payload = gunzipSync(payload);
+    } catch {
+      return undefined;
+    }
+  }
+
+  const decoded: DecodedDoubaoFrame = {
+    messageType,
+    flags,
+    event,
+    sessionId: scopedPayload.sessionId,
+    errorCode,
+  };
+  if (serializationCode === JSON_SERIALIZATION) {
+    try {
+      decoded.jsonPayload = JSON.parse(payload.toString("utf8")) as unknown;
+    } catch {
+      return undefined;
+    }
+  } else {
+    decoded.binaryPayload = payload;
+  }
+  return decoded;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2018,6 +2018,10 @@ importers:
         version: link:../..
 
   extensions/volcengine:
+    dependencies:
+      ws:
+        specifier: 8.21.1
+        version: 8.21.1
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

- add a Doubao end-to-end realtime voice WebSocket provider to the existing Volcengine plugin
- keep the current Gateway relay, Agent/session lifecycle, and `openclaw_agent_consult` tool path unchanged
- use Gateway `force-agent-consult` routing: final Doubao ASR becomes the existing consult call, then the Agent result is injected with Doubao `ChatTTSText`
- keep iOS and core Gateway/Agent/session code untouched

## What Problem This Solves

OpenClaw's current realtime Talk path is tied to the bundled OpenAI provider. This adds a Doubao realtime speech edge without replacing the existing Gateway relay, Agent, session ownership, or tool implementation: final Doubao ASR is routed through the existing forced `openclaw_agent_consult` path, and the returned Agent answer is spoken through Doubao TTS.

## Provider behavior

- authenticates with the standard Doubao realtime dialogue WebSocket contract
- converts OpenClaw PCM16 mono 24 kHz input to Doubao PCM16 mono 16 kHz incrementally
- outputs PCM16 mono 24 kHz for the existing relay player
- suppresses the provider-native answer in Agent mode so OpenClaw remains the single business-logic owner
- uses the same internal gateway-relay capability seam as the bundled OpenAI provider to advertise Agent-owned consult routing
- bounds queued audio/text and speakable result size

## Evidence

- `oxfmt --check`: passed
- `oxlint` on all changed TypeScript files: passed
- targeted TypeScript check against the current realtime voice Provider contract: passed
- focused unit tests: 10 passed
- live Doubao session using a File SecretRef: connection, 24 kHz input resampling, final ASR, and post-query TTS passed
- live Gateway roundtrip: final ASR -> forced `openclaw_agent_consult` -> existing OpenClaw Agent/session -> tool result -> Doubao TTS passed; received 902,658 bytes of post-consult PCM audio
- changed-file secret scan: passed; no credential is present in this branch

The local checkout reuses an older 2026.7.1 dependency tree, so the full 2026.7.2 package-boundary generation is left to clean CI; its local failures were confined to unrelated stale dependency surfaces such as `fs-safe`.
