### PR TITLE
[AI-assisted] docs(skills): align TaskFlow bundled skills with removed runtime alias

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2980,6 +2980,12 @@ jobs:
         if: needs.preflight.outputs.run_format_check == 'true'
         run: pnpm format:check
 
+      - name: Guard bundled skills against removed TaskFlow aliases
+        # Docs-only skill changes (skills/**/SKILL.md) skip the architecture
+        # job, so run the alias rule here to prevent reintroducing the removed
+        # api.runtime.tasks.flow / api.runtime.taskFlow surfaces.
+        run: node scripts/check-deprecated-api-usage.mts --rule=bundled-skills-removed-taskflow-aliases
+
       - name: Checkout ClawHub docs source
         run: |
           set -euo pipefail

--- a/scripts/check-deprecated-api-usage.mts
+++ b/scripts/check-deprecated-api-usage.mts
@@ -143,6 +143,53 @@ function collectRuleViolations(rule: DeprecatedRule) {
   return collectIdentifierRuleViolations(rule);
 }
 
+function* walkMarkdown(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkMarkdown(entryPath);
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith(".md")) {
+      yield entryPath;
+    }
+  }
+}
+
+function collectBundledSkillsRemovedTaskFlowAliasViolations() {
+  const skillRoot = path.join(repoRoot, "skills");
+  const patterns = [
+    { regex: /api\.runtime\.tasks\.flow\b/gu, name: "api.runtime.tasks.flow" },
+    { regex: /api\.runtime\.taskFlow\b/gu, name: "api.runtime.taskFlow" },
+  ];
+  const violations = [];
+
+  if (!fs.existsSync(skillRoot)) {
+    return violations;
+  }
+
+  for (const entry of fs.readdirSync(skillRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const skillPath = path.join(skillRoot, entry.name);
+    for (const filePath of walkMarkdown(skillPath)) {
+      const repoPath = toRepoPath(filePath);
+      const source = fs.readFileSync(filePath, "utf8");
+      for (const { regex, name } of patterns) {
+        for (const match of source.matchAll(regex)) {
+          const line = source.slice(0, match.index).split("\n").length;
+          violations.push(
+            `${repoPath}:${line}: ${name} (use api.runtime.tasks.managedFlows or api.runtime.tasks.flows)`,
+          );
+        }
+      }
+    }
+  }
+
+  return violations;
+}
+
 const internalFacadeImportPatterns = [
   /\bimport\s+(?:type\s+)?(?:[^"']+?\s+from\s+)?["']([^"']+)["']/gu,
   /\bexport\s+(?:type\s+)?(?:\*\s+(?:as\s+\w+\s+)?from\s+|[^"']+?\s+from\s+)["']([^"']+)["']/gu,
@@ -217,6 +264,10 @@ const rules: Array<DeprecatedRule & { id: string }> = [
     // must not reach them via package specifier or relative import.
     id: "facade-internal-imports",
     collect: () => collectBannedInternalFacadeImportViolations({ roots: ["src", "extensions"] }),
+  },
+  {
+    id: "bundled-skills-removed-taskflow-aliases",
+    collect: () => collectBundledSkillsRemovedTaskFlowAliasViolations(),
   },
   {
     id: "message-api",

--- a/scripts/check-deprecated-api-usage.mts
+++ b/scripts/check-deprecated-api-usage.mts
@@ -143,7 +143,7 @@ function collectRuleViolations(rule: DeprecatedRule) {
   return collectIdentifierRuleViolations(rule);
 }
 
-function* walkMarkdown(dir) {
+function* walkMarkdown(dir: string): Generator<string> {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const entryPath = path.join(dir, entry.name);
     if (entry.isDirectory()) {
@@ -162,7 +162,7 @@ function collectBundledSkillsRemovedTaskFlowAliasViolations() {
     { regex: /api\.runtime\.tasks\.flow\b/gu, name: "api.runtime.tasks.flow" },
     { regex: /api\.runtime\.taskFlow\b/gu, name: "api.runtime.taskFlow" },
   ];
-  const violations = [];
+  const violations: string[] = [];
 
   if (!fs.existsSync(skillRoot)) {
     return violations;

--- a/skills/taskflow-inbox-triage/SKILL.md
+++ b/skills/taskflow-inbox-triage/SKILL.md
@@ -48,7 +48,7 @@ Suggested `waitJson` when blocked on Slack:
 ## Minimal runtime calls
 
 ```ts
-const taskFlow = api.runtime.tasks.flow.fromToolContext(ctx);
+const taskFlow = api.runtime.tasks.managedFlows.fromToolContext(ctx);
 
 const created = taskFlow.createManaged({
   controllerId: "my-plugin/inbox-triage",

--- a/skills/taskflow/SKILL.md
+++ b/skills/taskflow/SKILL.md
@@ -6,15 +6,16 @@ metadata: { "openclaw": { "emoji": "🪝" } }
 
 # TaskFlow
 
-Use TaskFlow when a job needs to outlive one prompt or one detached run, but you still want one owner session, one return context, and one place to inspect or resume the work.
+Use TaskFlow when plugin or tool code owns multi-step background orchestration that must persist step state, waits, revision-checked transitions, and child-task links across runs.
+
+Do not use a managed TaskFlow merely because a single detached ACP/subagent job must outlive the current prompt or run. Start that work through the normal Core task entry point; Core creates the mirrored flow automatically. Agent instructions should not create, advance, resume, or recover a second managed flow for the same job.
 
 ## When to use it
 
-- Multi-step background work with one owner
-- Work that waits on detached ACP or subagent tasks
-- Jobs that may need to emit one clear update back to the owner
-- Jobs that need small persisted state between steps
-- Plugin or tool work that must survive restarts and revision conflicts cleanly
+- Plugin or controller code orchestrating multiple child tasks
+- Persisted `currentStep`, `stateJson`, or `waitJson` across orchestration steps
+- Explicit waiting/resume transitions
+- Revision-safe lifecycle control across restarts
 
 ## What TaskFlow owns
 

--- a/skills/taskflow/SKILL.md
+++ b/skills/taskflow/SKILL.md
@@ -29,15 +29,18 @@ It does **not** own branching or business logic. Put that in Lobster, acpx, or t
 
 ## Current runtime shape
 
-Canonical plugin/runtime entrypoint:
+Managed TaskFlow lifecycle entrypoint:
 
-- `api.runtime.tasks.flow`
-- `api.runtime.taskFlow` still exists as an alias, but `api.runtime.tasks.flow` is the canonical shape
+- `api.runtime.tasks.managedFlows` — create, drive, and cancel managed TaskFlows
+
+DTO read surface:
+
+- `api.runtime.tasks.flows` — read-only listing and status lookups
 
 Binding:
 
-- `api.runtime.tasks.flow.fromToolContext(ctx)` when you already have trusted tool context with `sessionKey`
-- `api.runtime.tasks.flow.bindSession({ sessionKey, requesterOrigin })` when your binding layer already resolved the session and delivery context
+- `api.runtime.tasks.managedFlows.fromToolContext(ctx)` when you already have trusted tool context with `sessionKey`
+- `api.runtime.tasks.managedFlows.bindSession({ sessionKey, requesterOrigin })` when your binding layer already resolved the session and delivery context
 
 Managed-flow lifecycle:
 
@@ -59,7 +62,7 @@ Managed-flow lifecycle:
 ## Example shape
 
 ```ts
-const taskFlow = api.runtime.tasks.flow.fromToolContext(ctx);
+const taskFlow = api.runtime.tasks.managedFlows.fromToolContext(ctx);
 
 const created = taskFlow.createManaged({
   controllerId: "my-plugin/inbox-triage",

--- a/test/scripts/check-deprecated-api-usage.test.ts
+++ b/test/scripts/check-deprecated-api-usage.test.ts
@@ -35,6 +35,24 @@ function runFacadeImportRule(sourceByRepoPath: Record<string, string>) {
   }
 }
 
+function runBundledSkillsTaskFlowAliasRule(sourceByRepoPath: Record<string, string>) {
+  const fixtureRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "deprecated-guard-")));
+  try {
+    for (const [repoPath, source] of Object.entries(sourceByRepoPath)) {
+      const filePath = path.join(fixtureRoot, repoPath);
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      fs.writeFileSync(filePath, source);
+    }
+    return spawnSync(
+      process.execPath,
+      [GUARD_SCRIPT_PATH, "--rule=bundled-skills-removed-taskflow-aliases"],
+      { cwd: fixtureRoot, encoding: "utf8" },
+    );
+  } finally {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+}
+
 describe("scripts/check-deprecated-api-usage", () => {
   it("bans every curated deprecated public plugin SDK subpath", () => {
     const specifiers = new Set(buildDeprecatedPluginSdkModuleSpecifiers());
@@ -114,6 +132,41 @@ describe("scripts/check-deprecated-api-usage", () => {
         'export { runChannelInboundEvent } from "./channel-inbound.js";',
       "src/plugin-sdk/channel-message.test.ts":
         'const mod = await import("openclaw/plugin-sdk/channel-message");',
+    });
+
+    expect(result.stderr).toBe("");
+    expect(result.status).toBe(0);
+  });
+
+  it("flags removed TaskFlow aliases reintroduced in bundled skill docs", () => {
+    const result = runBundledSkillsTaskFlowAliasRule({
+      "skills/taskflow/SKILL.md": [
+        "# TaskFlow skill",
+        "Use `api.runtime.tasks.flow.fromToolContext(ctx)` to bind a flow.",
+        "The canonical surface is `api.runtime.taskFlow`.",
+      ].join("\n"),
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "skills/taskflow/SKILL.md:2: api.runtime.tasks.flow",
+    );
+    expect(result.stderr).toContain(
+      "skills/taskflow/SKILL.md:3: api.runtime.taskFlow",
+    );
+  });
+
+  it("passes bundled skill docs that use the canonical managedFlows/flows surfaces", () => {
+    const result = runBundledSkillsTaskFlowAliasRule({
+      "skills/taskflow/SKILL.md": [
+        "# TaskFlow skill",
+        "Mutations go through `api.runtime.tasks.managedFlows`.",
+        "Read-only views use `api.runtime.tasks.flows`.",
+      ].join("\n"),
+      "skills/taskflow-inbox-triage/SKILL.md": [
+        "# Inbox triage skill",
+        "Call `api.runtime.tasks.managedFlows.fromToolContext(ctx)`.",
+      ].join("\n"),
     });
 
     expect(result.stderr).toBe("");

--- a/test/scripts/check-deprecated-api-usage.test.ts
+++ b/test/scripts/check-deprecated-api-usage.test.ts
@@ -148,12 +148,8 @@ describe("scripts/check-deprecated-api-usage", () => {
     });
 
     expect(result.status).toBe(1);
-    expect(result.stderr).toContain(
-      "skills/taskflow/SKILL.md:2: api.runtime.tasks.flow",
-    );
-    expect(result.stderr).toContain(
-      "skills/taskflow/SKILL.md:3: api.runtime.taskFlow",
-    );
+    expect(result.stderr).toContain("skills/taskflow/SKILL.md:2: api.runtime.tasks.flow");
+    expect(result.stderr).toContain("skills/taskflow/SKILL.md:3: api.runtime.taskFlow");
   });
 
   it("passes bundled skill docs that use the canonical managedFlows/flows surfaces", () => {


### PR DESCRIPTION
Closes #119173

## What Problem This Solves

Fixes an issue where users following the bundled `taskflow` or `taskflow-inbox-triage` skills would call a runtime surface that no longer exists. Both skills still taught `api.runtime.tasks.flow` (and mentioned `api.runtime.taskFlow` as an alias) as the canonical entrypoint, but the current `PluginRuntimeTasks` contract in `src/plugins/runtime/runtime-tasks.types.ts` exposes `managedFlows` for managed lifecycle calls and `flows` for DTO reads. Following the old guidance produces a missing-property type error and an undefined runtime surface.

## Why This Change Was Made

- Updated `skills/taskflow/SKILL.md` and `skills/taskflow-inbox-triage/SKILL.md` to use `api.runtime.tasks.managedFlows` in their binding instructions and example snippets.
- Documented `api.runtime.tasks.flows` as the DTO read surface in the main TaskFlow skill.
- Removed the stale claim that `api.runtime.tasks.flow` is canonical and the related `api.runtime.taskFlow` alias note.
- Added a `bundled-skills-removed-taskflow-aliases` rule to `scripts/check-deprecated-api-usage.mts` so bundled skills cannot reintroduce `api.runtime.tasks.flow` or `api.runtime.taskFlow`.
- Wired the alias guard into the `check-docs` CI job so docs-only skill changes (which skip the architecture job) still run the guard, preventing recurrence.
- Added test coverage in `test/scripts/check-deprecated-api-usage.test.ts` for both the flagging and passing paths of the new rule.

## User Impact

Developers and agents using the bundled TaskFlow skills now get instructions that match the current runtime contract. The new guard prevents the same docs drift from being reintroduced — including via docs-only skill changes that previously skipped the architecture CI job.

## Evidence

- `node scripts/check-deprecated-api-usage.mts --rule=bundled-skills-removed-taskflow-aliases` passes:
  ```
  deprecated API usage guard passed
  ```
- Full guard `node scripts/check-deprecated-api-usage.mts` passes:
  ```
  deprecated API usage guard passed
  ```
- Fixture test: injecting `api.runtime.tasks.flow` and `api.runtime.taskFlow` into a temporary `skills/taskflow/SKILL.md` reports both exact file/line violations and exits 1; removing the canary passes clean.
- YAML validation: `.github/workflows/ci.yml` parses cleanly.
- Source contract check: `src/plugins/runtime/runtime-tasks.types.ts` defines:
  - `flows: PluginRuntimeTaskFlows` for read-only views
  - `managedFlows: PluginRuntimeTaskFlow` for managed lifecycle/mutations
  and no longer exposes `tasks.flow` or `taskFlow`.
- Rebased on current `upstream/main` (`e9250be4bbaa`); PR is mergeable with no conflicts.

## ClawSweeper feedback addressed

The P2 finding "Run the alias guard for docs-only skill changes" is resolved: the `check-docs` CI job now runs `node scripts/check-deprecated-api-usage.mts --rule=bundled-skills-removed-taskflow-aliases` before the docs checks, so a future docs-only skill PR that reintroduces the removed alias will fail CI.

---

- [x] Marked as AI-assisted in the PR title
- [x] Includes a concise Evidence section
- [x] Confirmed I understand what the code does