### PR TITLE
fix(reset): preserve bootstrap guidance for dynamic models

### DIFF
--- a/src/auto-reply/reply/session-reset-prompt.runtime-model.test.ts
+++ b/src/auto-reply/reply/session-reset-prompt.runtime-model.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+
+const inventoryMocks = vi.hoisted(() => {
+  const runtimeModel = {
+    id: "dynamic-chat",
+    name: "dynamic-chat",
+    provider: "dynamic-provider",
+    api: "openai-responses",
+    baseUrl: "https://example.invalid/v1",
+  };
+  return {
+    runtimeModel,
+    resolveRuntimeModelContext: vi.fn(async () => ({
+      modelApi: runtimeModel.api,
+      runtimeModel,
+    })),
+    resolveInventory: vi.fn((params: Record<string, unknown>) => {
+      if (!Object.hasOwn(params, "modelApi") || !Object.hasOwn(params, "runtimeModel")) {
+        throw new Error("runtime model facts must be explicitly owner-published");
+      }
+      return {
+        agentId: "main",
+        profile: "coding",
+        groups: [
+          {
+            id: "core",
+            label: "Built-in tools",
+            source: "core",
+            tools: [
+              {
+                id: "read",
+                label: "Read",
+                description: "Read files",
+                rawDescription: "Read files",
+                source: "core",
+              },
+            ],
+          },
+        ],
+      };
+    }),
+  };
+});
+
+vi.mock("../../agents/tools-effective-inventory.js", () => ({
+  resolveEffectiveToolInventory: inventoryMocks.resolveInventory,
+  resolveEffectiveToolInventoryRuntimeModelContextAsync: inventoryMocks.resolveRuntimeModelContext,
+}));
+
+describe("resolveBareResetBootstrapFileAccess runtime model ownership", () => {
+  beforeEach(() => {
+    inventoryMocks.resolveInventory.mockClear();
+    inventoryMocks.resolveRuntimeModelContext.mockClear();
+  });
+
+  it("resolves runtime model context once and passes explicit facts to sync inventory", async () => {
+    const { resolveBareResetBootstrapFileAccess } = await import("./session-reset-prompt.js");
+    const cfg = {} as OpenClawConfig;
+    const params = {
+      cfg,
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      workspaceDir: "/tmp/workspace-main",
+      modelProvider: "dynamic-provider",
+      modelId: "dynamic-chat",
+    };
+
+    await expect(resolveBareResetBootstrapFileAccess(params)).resolves.toBe(true);
+
+    expect(inventoryMocks.resolveRuntimeModelContext).toHaveBeenCalledTimes(1);
+    expect(inventoryMocks.resolveRuntimeModelContext).toHaveBeenCalledWith({
+      cfg,
+      agentId: params.agentId,
+      workspaceDir: params.workspaceDir,
+      modelProvider: params.modelProvider,
+      modelId: params.modelId,
+    });
+    expect(inventoryMocks.resolveInventory).toHaveBeenCalledTimes(1);
+    const inventoryParams = inventoryMocks.resolveInventory.mock.calls[0]?.[0];
+    expect(inventoryParams).toMatchObject({
+      ...params,
+      modelApi: inventoryMocks.runtimeModel.api,
+      runtimeModel: inventoryMocks.runtimeModel,
+    });
+    expect(Object.hasOwn(inventoryParams ?? {}, "modelApi")).toBe(true);
+    expect(Object.hasOwn(inventoryParams ?? {}, "runtimeModel")).toBe(true);
+  });
+});

--- a/src/auto-reply/reply/session-reset-prompt.test.ts
+++ b/src/auto-reply/reply/session-reset-prompt.test.ts
@@ -1,7 +1,7 @@
 // Tests session reset prompt generation and transcript-preserving restart hints.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { describe, it, expect } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import { makeTempWorkspace } from "../../test-helpers/workspace.js";
 import { resolveBareSessionResetPromptState } from "./session-reset-prompt.js";
@@ -140,5 +140,19 @@ describe("resolveBareSessionResetPromptState", () => {
     expect(pending.prompt).toContain("cannot safely complete the full BOOTSTRAP.md workflow here");
     expect(pending.prompt).toContain("while bootstrap is still pending for this workspace");
     expect(pending.prompt).not.toContain("Execute your Session Startup sequence now");
+  });
+
+  it("awaits async bootstrap file access before selecting reset mode", async () => {
+    const workspaceDir = await makeBootstrapPendingWorkspace();
+    const hasBootstrapFileAccess = vi.fn(async () => false);
+
+    const pending = await resolveBareSessionResetPromptState({
+      workspaceDir,
+      hasBootstrapFileAccess,
+    });
+
+    expect(hasBootstrapFileAccess).toHaveBeenCalledTimes(1);
+    expect(pending.bootstrapMode).toBe("limited");
+    expect(pending.shouldPrependStartupContext).toBe(false);
   });
 });

--- a/src/auto-reply/reply/session-reset-prompt.ts
+++ b/src/auto-reply/reply/session-reset-prompt.ts
@@ -5,7 +5,10 @@ import {
   buildLimitedBootstrapPromptLines,
 } from "../../agents/bootstrap-prompt.js";
 import { appendCronStyleCurrentTimeLine } from "../../agents/current-time.js";
-import { resolveEffectiveToolInventory } from "../../agents/tools-effective-inventory.js";
+import {
+  resolveEffectiveToolInventory,
+  resolveEffectiveToolInventoryRuntimeModelContextAsync,
+} from "../../agents/tools-effective-inventory.js";
 import { isWorkspaceBootstrapPending } from "../../agents/workspace.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 
@@ -36,17 +39,24 @@ const BARE_SESSION_RESET_PROMPT_BOOTSTRAP_LIMITED = [
   "Do not mention internal steps, files, tools, or reasoning.",
 ].join(" ");
 
-export function resolveBareResetBootstrapFileAccess(params: {
+export async function resolveBareResetBootstrapFileAccess(params: {
   cfg?: OpenClawConfig;
   agentId?: string;
   sessionKey?: string;
   workspaceDir?: string;
   modelProvider?: string;
   modelId?: string;
-}): boolean {
+}): Promise<boolean> {
   if (!params.cfg) {
     return false;
   }
+  const runtimeModelContext = await resolveEffectiveToolInventoryRuntimeModelContextAsync({
+    cfg: params.cfg,
+    agentId: params.agentId,
+    workspaceDir: params.workspaceDir,
+    modelProvider: params.modelProvider,
+    modelId: params.modelId,
+  });
   const inventory = resolveEffectiveToolInventory({
     cfg: params.cfg,
     agentId: params.agentId,
@@ -54,6 +64,8 @@ export function resolveBareResetBootstrapFileAccess(params: {
     workspaceDir: params.workspaceDir,
     modelProvider: params.modelProvider,
     modelId: params.modelId,
+    modelApi: runtimeModelContext.modelApi,
+    runtimeModel: runtimeModelContext.runtimeModel,
   });
   return inventory.groups.some((group) => group.tools.some((tool) => tool.id === "read"));
 }
@@ -64,7 +76,7 @@ export async function resolveBareSessionResetPromptState(params: {
   nowMs?: number;
   isPrimaryRun?: boolean;
   isCanonicalWorkspace?: boolean;
-  hasBootstrapFileAccess?: boolean | (() => boolean);
+  hasBootstrapFileAccess?: boolean | (() => boolean | Promise<boolean>);
 }): Promise<{
   bootstrapMode: BootstrapMode;
   prompt: string;
@@ -75,7 +87,7 @@ export async function resolveBareSessionResetPromptState(params: {
     : false;
   const hasBootstrapFileAccess = bootstrapPending
     ? typeof params.hasBootstrapFileAccess === "function"
-      ? params.hasBootstrapFileAccess()
+      ? await params.hasBootstrapFileAccess()
       : (params.hasBootstrapFileAccess ?? true)
     : true;
   const bootstrapMode = resolveBootstrapMode({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users starting a bare `/new` or `/reset` with pending
`BOOTSTRAP.md` guidance could receive no reset reply when the selected model
exposes dynamic tool metadata and its prepared runtime had not yet been
published.

## Why This Change Was Made

The reset-prompt owner now resolves the request's runtime model context
asynchronously, then passes those explicit facts into the existing synchronous
effective-inventory calculation. This keeps inventory policy synchronous while
repairing the lifecycle gap at the reset boundary that owns the early lookup.

PR #119306 already landed the lifecycle-aware `/tools` and Gateway behavior,
including Telegram-visible proof. This rewrite deliberately drops those
overlapping changes and keeps only the remaining reset bootstrap defect.

## User Impact

Bare `/new` and `/reset` flows now return the correct full or limited bootstrap
guidance for dynamic models instead of failing before any visible reply.

## Evidence

- Exact head: `89481419fac631004eaaeec7ff9f70c480321aeb`
- Exact base: `392e1c0620b53b29cf98d216ce1081b9f3df4cc3`
- Regression proof: the direct runtime-model test throws on unchanged
  production code unless request-owned `modelApi` and `runtimeModel` facts are
  supplied; it passes with this fix.
- Focused matrix: 73 tests passed across the reset prompt, reset command,
  run-context, and effective-inventory surfaces.
- Independent rerun of the changed tests: 12/12 passed.
- `git diff --check origin/main...HEAD`: passed.
- Targeted formatting: passed.
- Structured autoreview: clean, correctness `0.98`; TruffleHog clean.
- Production LOC: `+17/-5` (net `+12`); tests: `+104/-1`.
- Exact-head CI: pending after the current-main rebase.
- The remote changed-check backend was unavailable during local validation.
  Exact-head CI/Testbox remains the authoritative heavy proof.

Already-landed sibling proof:

- PR #119306: https://github.com/openclaw/openclaw/pull/119306
- Exact Telegram run: https://github.com/openclaw/openclaw/actions/runs/30954874075
- Redacted artifact: https://github.com/openclaw/openclaw/actions/runs/30954874075/artifacts/8911342198
- Scenario `telegram-tools-compact-command`: 1/1 passed at
  `caafd02384d6cc5e1b437f6efe9eaf0e60849867`.

Direct Codex contract inspection:

- OpenClaw pins `@openai/codex` `0.146.0` at
  `e363b08c9175ac1cbe5893615dd2cb9ddf95043b`.
- Pinned source checked:
  `codex-rs/core/src/session/turn_context.rs:113-123,273-290,497-530` and
  `codex-rs/core/src/session/turn.rs:184-200,251-270`.
- Current Codex drift check at
  `5d89ab65dc9d4d0c55796c11df112b54157922b4`:
  `turn_context.rs:105-123,271-295,495-530` and
  `turn.rs:195-205,294-317`.
- Both contracts keep request-owned model/tool context together for context
  construction, advertised tools, and tool calls.

No changelog entry: release-note generation owns this fix. No release, tag, or
publish action is part of this PR.

Punchcard-Session: silver-valley-valley-dt
