### PR TITLE
fix(buzz): bound NIP-11 relay information responses

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -133,7 +133,6 @@ extensions/buzz/src/gateway.ts	1
 extensions/buzz/src/inbound.ts	1
 extensions/buzz/src/message-event.ts	2
 extensions/buzz/src/qa/adapter.runtime.ts	2
-extensions/buzz/src/relay-auth.ts	1
 extensions/buzz/src/room-membership.ts	2
 extensions/buzz/src/setup-core.ts	1
 extensions/buzz/src/setup-surface.ts	1

--- a/extensions/buzz/src/buzz-bus.archived-rooms.test.ts
+++ b/extensions/buzz/src/buzz-bus.archived-rooms.test.ts
@@ -109,13 +109,12 @@ describe("Buzz archived room lifecycle", () => {
     relayMocks.roomMetadataEvents = [];
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => ({
-        ok: true,
-        json: async () => ({
+      vi.fn(async () =>
+        Response.json({
           self: RELAY_PUBLIC_KEY,
           software: "https://github.com/block/buzz",
         }),
-      })),
+      ),
     );
   });
 

--- a/extensions/buzz/src/buzz-bus.archived-rooms.test.ts
+++ b/extensions/buzz/src/buzz-bus.archived-rooms.test.ts
@@ -109,13 +109,15 @@ describe("Buzz archived room lifecycle", () => {
     relayMocks.roomMetadataEvents = [];
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => ({
-        ok: true,
-        json: async () => ({
-          self: RELAY_PUBLIC_KEY,
-          software: "https://github.com/block/buzz",
-        }),
-      })),
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              self: RELAY_PUBLIC_KEY,
+              software: "https://github.com/block/buzz",
+            }),
+          ),
+      ),
     );
   });
 

--- a/extensions/buzz/src/buzz-bus.history-catchup.test.ts
+++ b/extensions/buzz/src/buzz-bus.history-catchup.test.ts
@@ -204,13 +204,12 @@ describe("Buzz reconnect history catch-up", () => {
     relayMocks.connected = true;
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => ({
-        ok: true,
-        json: async () => ({
+      vi.fn(async () =>
+        Response.json({
           self: RELAY_PUBLIC_KEY,
           software: "https://github.com/block/buzz",
         }),
-      })),
+      ),
     );
   });
 

--- a/extensions/buzz/src/buzz-bus.history-catchup.test.ts
+++ b/extensions/buzz/src/buzz-bus.history-catchup.test.ts
@@ -204,13 +204,15 @@ describe("Buzz reconnect history catch-up", () => {
     relayMocks.connected = true;
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => ({
-        ok: true,
-        json: async () => ({
-          self: RELAY_PUBLIC_KEY,
-          software: "https://github.com/block/buzz",
-        }),
-      })),
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              self: RELAY_PUBLIC_KEY,
+              software: "https://github.com/block/buzz",
+            }),
+          ),
+      ),
     );
   });
 

--- a/extensions/buzz/src/buzz-bus.lifecycle.test.ts
+++ b/extensions/buzz/src/buzz-bus.lifecycle.test.ts
@@ -127,6 +127,7 @@ const BOT_PUBLIC_KEY = getPublicKey(Uint8Array.from(Buffer.from(PRIVATE_KEY, "he
 const SENDER_PUBLIC_KEY = getPublicKey(Uint8Array.from(Buffer.from(SENDER_PRIVATE_KEY, "hex")));
 const SENDER_SECRET_KEY = Uint8Array.from(Buffer.from(SENDER_PRIVATE_KEY, "hex"));
 const RELAY_PUBLIC_KEY = "f".repeat(64);
+const BUZZ_RELAY_INFO_MAX_BYTES = 16 * 1024 * 1024;
 const tempDirs = new Set<string>();
 let previousStateDir: string | undefined;
 let stateDir: string;
@@ -209,13 +210,12 @@ describe("Buzz bus lifecycle", () => {
     relayMocks.stallRoomEoseChannelId = undefined;
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => ({
-        ok: true,
-        json: async () => ({
+      vi.fn(async () =>
+        Response.json({
           self: RELAY_PUBLIC_KEY,
           software: "https://github.com/block/buzz",
         }),
-      })),
+      ),
     );
   });
 
@@ -289,6 +289,58 @@ describe("Buzz bus lifecycle", () => {
     expect(fetchSignal?.aborted).toBe(true);
     expect(relayMocks.close).toHaveBeenCalledOnce();
     vi.useRealTimers();
+  });
+
+  it("cancels oversized NIP-11 relay information before consuming the entire response", async () => {
+    relayMocks.auth.mockResolvedValue("ok");
+    const cancel = vi.fn();
+    const chunk = new Uint8Array(1024 * 1024).fill("x".charCodeAt(0));
+    let emittedChunks = 0;
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (emittedChunks === 0) {
+          controller.enqueue(
+            new TextEncoder().encode(`{"self":"${RELAY_PUBLIC_KEY}","description":"`),
+          );
+        } else if (emittedChunks <= 17) {
+          controller.enqueue(chunk);
+        } else {
+          controller.enqueue(new TextEncoder().encode('"}'));
+          controller.close();
+        }
+        emittedChunks += 1;
+      },
+      cancel,
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => new Response(body)),
+    );
+
+    await expect(startTestBus()).rejects.toThrow(
+      `Buzz relay information: JSON response exceeds ${BUZZ_RELAY_INFO_MAX_BYTES} bytes`,
+    );
+
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(emittedChunks).toBeLessThan(19);
+    expect(relayMocks.close).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ["truncated JSON", '{"self":'],
+    ["null", "null"],
+    ["an array", "[]"],
+    ["a primitive", "true"],
+  ])("rejects malformed NIP-11 relay information containing %s", async (_label, body) => {
+    relayMocks.auth.mockResolvedValue("ok");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => new Response(body)),
+    );
+
+    await expect(startTestBus()).rejects.toThrow("Buzz relay information: malformed JSON response");
+
+    expect(relayMocks.close).toHaveBeenCalledOnce();
   });
 
   it("publishes and closes a standalone authenticated send", async () => {

--- a/extensions/buzz/src/buzz-bus.lifecycle.test.ts
+++ b/extensions/buzz/src/buzz-bus.lifecycle.test.ts
@@ -329,6 +329,18 @@ describe("Buzz bus lifecycle", () => {
     expect(relayMocks.close).toHaveBeenCalledOnce();
   });
 
+  it("rejects non-object NIP-11 relay information", async () => {
+    relayMocks.auth.mockResolvedValue("ok");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => new Response("null")),
+    );
+
+    await expect(startTestBus()).rejects.toThrow("Buzz relay information: malformed JSON response");
+
+    expect(relayMocks.close).toHaveBeenCalledOnce();
+  });
+
   it("publishes and closes a standalone authenticated send", async () => {
     relayMocks.auth.mockResolvedValue("ok");
 

--- a/extensions/buzz/src/buzz-bus.lifecycle.test.ts
+++ b/extensions/buzz/src/buzz-bus.lifecycle.test.ts
@@ -127,6 +127,7 @@ const BOT_PUBLIC_KEY = getPublicKey(Uint8Array.from(Buffer.from(PRIVATE_KEY, "he
 const SENDER_PUBLIC_KEY = getPublicKey(Uint8Array.from(Buffer.from(SENDER_PRIVATE_KEY, "hex")));
 const SENDER_SECRET_KEY = Uint8Array.from(Buffer.from(SENDER_PRIVATE_KEY, "hex"));
 const RELAY_PUBLIC_KEY = "f".repeat(64);
+const BUZZ_RELAY_INFO_MAX_BYTES = 16 * 1024 * 1024;
 const tempDirs = new Set<string>();
 let previousStateDir: string | undefined;
 let stateDir: string;
@@ -209,13 +210,16 @@ describe("Buzz bus lifecycle", () => {
     relayMocks.stallRoomEoseChannelId = undefined;
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => ({
-        ok: true,
-        json: async () => ({
-          self: RELAY_PUBLIC_KEY,
-          software: "https://github.com/block/buzz",
-        }),
-      })),
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              self: RELAY_PUBLIC_KEY,
+              software: "https://github.com/block/buzz",
+            }),
+            { headers: { "Content-Type": "application/nostr+json" } },
+          ),
+      ),
     );
   });
 
@@ -289,6 +293,40 @@ describe("Buzz bus lifecycle", () => {
     expect(fetchSignal?.aborted).toBe(true);
     expect(relayMocks.close).toHaveBeenCalledOnce();
     vi.useRealTimers();
+  });
+
+  it("rejects oversized NIP-11 relay information", async () => {
+    relayMocks.auth.mockResolvedValue("ok");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(
+        async () =>
+          new Response(
+            JSON.stringify({
+              self: RELAY_PUBLIC_KEY,
+              description: "x".repeat(BUZZ_RELAY_INFO_MAX_BYTES),
+            }),
+          ),
+      ),
+    );
+
+    await expect(startTestBus()).rejects.toThrow(
+      `Buzz relay information: JSON response exceeds ${BUZZ_RELAY_INFO_MAX_BYTES} bytes`,
+    );
+
+    expect(relayMocks.close).toHaveBeenCalledOnce();
+  });
+
+  it("rejects malformed NIP-11 relay information", async () => {
+    relayMocks.auth.mockResolvedValue("ok");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => new Response('{"self":', { status: 200 })),
+    );
+
+    await expect(startTestBus()).rejects.toThrow("Buzz relay information: malformed JSON response");
+
+    expect(relayMocks.close).toHaveBeenCalledOnce();
   });
 
   it("publishes and closes a standalone authenticated send", async () => {

--- a/extensions/buzz/src/buzz-bus.mentions.test.ts
+++ b/extensions/buzz/src/buzz-bus.mentions.test.ts
@@ -118,13 +118,12 @@ describe("Buzz mention delivery", () => {
     relayMocks.send.mockResolvedValue();
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => ({
-        ok: true,
-        json: async () => ({
+      vi.fn(async () =>
+        Response.json({
           self: RELAY_PUBLIC_KEY,
           software: "https://github.com/block/buzz",
         }),
-      })),
+      ),
     );
   });
 

--- a/extensions/buzz/src/buzz-bus.mentions.test.ts
+++ b/extensions/buzz/src/buzz-bus.mentions.test.ts
@@ -118,13 +118,15 @@ describe("Buzz mention delivery", () => {
     relayMocks.send.mockResolvedValue();
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => ({
-        ok: true,
-        json: async () => ({
-          self: RELAY_PUBLIC_KEY,
-          software: "https://github.com/block/buzz",
-        }),
-      })),
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              self: RELAY_PUBLIC_KEY,
+              software: "https://github.com/block/buzz",
+            }),
+          ),
+      ),
     );
   });
 

--- a/extensions/buzz/src/directory.test.ts
+++ b/extensions/buzz/src/directory.test.ts
@@ -88,13 +88,12 @@ describe("Buzz live directory", () => {
     gatewayMocks.activeBus = undefined;
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => ({
-        ok: true,
-        json: async () => ({
+      vi.fn(async () =>
+        Response.json({
           self: RELAY_PUBLIC_KEY,
           software: "https://github.com/block/buzz",
         }),
-      })),
+      ),
     );
     relayMocks.subscribe.mockImplementation(
       (

--- a/extensions/buzz/src/directory.test.ts
+++ b/extensions/buzz/src/directory.test.ts
@@ -88,13 +88,15 @@ describe("Buzz live directory", () => {
     gatewayMocks.activeBus = undefined;
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => ({
-        ok: true,
-        json: async () => ({
-          self: RELAY_PUBLIC_KEY,
-          software: "https://github.com/block/buzz",
-        }),
-      })),
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              self: RELAY_PUBLIC_KEY,
+              software: "https://github.com/block/buzz",
+            }),
+          ),
+      ),
     );
     relayMocks.subscribe.mockImplementation(
       (

--- a/extensions/buzz/src/qa/relay-client.test.ts
+++ b/extensions/buzz/src/qa/relay-client.test.ts
@@ -89,13 +89,12 @@ describe("Buzz QA relay driver", () => {
     relayMocks.replayedMessage = undefined;
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => ({
-        ok: true,
-        json: async () => ({
+      vi.fn(async () =>
+        Response.json({
           self: RELAY_PUBLIC_KEY,
           software: "https://github.com/block/buzz",
         }),
-      })),
+      ),
     );
   });
 

--- a/extensions/buzz/src/qa/relay-client.test.ts
+++ b/extensions/buzz/src/qa/relay-client.test.ts
@@ -89,13 +89,15 @@ describe("Buzz QA relay driver", () => {
     relayMocks.replayedMessage = undefined;
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => ({
-        ok: true,
-        json: async () => ({
-          self: RELAY_PUBLIC_KEY,
-          software: "https://github.com/block/buzz",
-        }),
-      })),
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              self: RELAY_PUBLIC_KEY,
+              software: "https://github.com/block/buzz",
+            }),
+          ),
+      ),
     );
   });
 

--- a/extensions/buzz/src/relay-auth.ts
+++ b/extensions/buzz/src/relay-auth.ts
@@ -1,4 +1,5 @@
 import { type EventTemplate, finalizeEvent, Relay, type VerifiedEvent } from "nostr-tools";
+import { readProviderJsonObjectResponse } from "openclaw/plugin-sdk/provider-http";
 import {
   fetchWithSsrFGuard,
   ssrfPolicyFromHttpBaseUrlAllowedOrigin,
@@ -91,10 +92,7 @@ async function resolveBuzzRelayPublicKey(params: {
       await response.body?.cancel().catch(() => undefined);
       throw new Error(`Buzz relay information request failed with HTTP ${response.status}`);
     }
-    const document = (await response.json()) as {
-      self?: unknown;
-      software?: unknown;
-    };
+    const document = await readProviderJsonObjectResponse(response, "Buzz relay information");
     const relayPublicKey =
       typeof document.self === "string" ? document.self.trim().toLowerCase() : "";
     if (HEX_PUBLIC_KEY_PATTERN.test(relayPublicKey)) {

--- a/extensions/buzz/src/relay-auth.ts
+++ b/extensions/buzz/src/relay-auth.ts
@@ -1,5 +1,5 @@
 import { type EventTemplate, finalizeEvent, Relay, type VerifiedEvent } from "nostr-tools";
-import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
+import { readProviderJsonObjectResponse } from "openclaw/plugin-sdk/provider-http";
 import {
   fetchWithSsrFGuard,
   ssrfPolicyFromHttpBaseUrlAllowedOrigin,
@@ -92,10 +92,7 @@ async function resolveBuzzRelayPublicKey(params: {
       await response.body?.cancel().catch(() => undefined);
       throw new Error(`Buzz relay information request failed with HTTP ${response.status}`);
     }
-    const document = await readProviderJsonResponse<{
-      self?: unknown;
-      software?: unknown;
-    }>(response, "Buzz relay information");
+    const document = await readProviderJsonObjectResponse(response, "Buzz relay information");
     const relayPublicKey =
       typeof document.self === "string" ? document.self.trim().toLowerCase() : "";
     if (HEX_PUBLIC_KEY_PATTERN.test(relayPublicKey)) {

--- a/extensions/buzz/src/relay-auth.ts
+++ b/extensions/buzz/src/relay-auth.ts
@@ -1,4 +1,5 @@
 import { type EventTemplate, finalizeEvent, Relay, type VerifiedEvent } from "nostr-tools";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import {
   fetchWithSsrFGuard,
   ssrfPolicyFromHttpBaseUrlAllowedOrigin,
@@ -91,10 +92,10 @@ async function resolveBuzzRelayPublicKey(params: {
       await response.body?.cancel().catch(() => undefined);
       throw new Error(`Buzz relay information request failed with HTTP ${response.status}`);
     }
-    const document = (await response.json()) as {
+    const document = await readProviderJsonResponse<{
       self?: unknown;
       software?: unknown;
-    };
+    }>(response, "Buzz relay information");
     const relayPublicKey =
       typeof document.self === "string" ? document.self.trim().toLowerCase() : "";
     if (HEX_PUBLIC_KEY_PATTERN.test(relayPublicKey)) {

--- a/extensions/buzz/src/room-discovery.test.ts
+++ b/extensions/buzz/src/room-discovery.test.ts
@@ -68,13 +68,12 @@ describe("discoverBuzzRooms", () => {
     relayMocks.subscribe.mockReset();
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => ({
-        ok: true,
-        json: async () => ({
+      vi.fn(async () =>
+        Response.json({
           self: RELAY_PUBLIC_KEY,
           software: "https://github.com/block/buzz",
         }),
-      })),
+      ),
     );
   });
 

--- a/extensions/buzz/src/room-discovery.test.ts
+++ b/extensions/buzz/src/room-discovery.test.ts
@@ -68,13 +68,15 @@ describe("discoverBuzzRooms", () => {
     relayMocks.subscribe.mockReset();
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => ({
-        ok: true,
-        json: async () => ({
-          self: RELAY_PUBLIC_KEY,
-          software: "https://github.com/block/buzz",
-        }),
-      })),
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              self: RELAY_PUBLIC_KEY,
+              software: "https://github.com/block/buzz",
+            }),
+          ),
+      ),
     );
   });
 


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where enabling Buzz against a relay with an oversized NIP-11 information response could make the Gateway buffer the response without a limit. Malformed or non-object relay information could also surface a raw JavaScript error instead of a stable Buzz diagnostic.

## Why This Change Was Made

Buzz relay discovery now uses the existing shared provider JSON object reader, which bounds response reads at 16 MiB and normalizes malformed or non-object documents. This keeps the limit, shape validation, and cancellation behavior aligned with the canonical HTTP response helper rather than adding a Buzz-specific parser or policy.

## User Impact

Gateways stop reading oversized Buzz relay-information responses, remain running, and report clear bounded-response or malformed-JSON errors. JSON primitives and arrays are rejected as malformed NIP-11 documents, while valid objects continue through the existing relay-key validation path.

## Evidence

Focused regression tests (6 files, 27 tests):

```text
Test Files  6 passed (6)
     Tests  27 passed
```

Real Gateway proof using the development Gateway starter and a loopback HTTP/WebSocket relay that performs NIP-42 authentication before serving NIP-11 information:

```text
LIVE trigger mode=oversized gateway=real relay=http+websocket nip11_requests=1
LIVE transition mode=oversized gateway_ready=true nip42_authenticated=true auth_frames=1
LIVE transition mode=oversized nip11_client_closed=true bytes_sent=20381786 response_completed=false
LIVE outcome mode=oversized gateway_alive=true error="Buzz relay information: JSON response exceeds 16777216 bytes"
LIVE trigger mode=malformed gateway=real relay=http+websocket nip11_requests=1
LIVE transition mode=malformed gateway_ready=true nip42_authenticated=true auth_frames=1
LIVE transition mode=malformed nip11_response_bytes=8 response_completed=true
LIVE outcome mode=malformed gateway_alive=true error="Buzz relay information: malformed JSON response"
```
