### PR TITLE
fix(plugins): preserve metadata reloads during models status

### DIFF
--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -641,16 +641,8 @@ export async function loadCompactHooksHarness(): Promise<{
   }));
 
   vi.doMock("../../plugins/current-plugin-metadata-snapshot.js", () => ({
-    captureCurrentPluginMetadataSnapshotState: vi.fn(() => ({
-      snapshot: undefined,
-      configFingerprint: undefined,
-      compatiblePolicyHashes: undefined,
-      compatibleConfigFingerprints: undefined,
-      configIdentities: new WeakSet(),
-    })),
     getCurrentPluginMetadataSnapshot: () => emptyPluginMetadataSnapshot,
     resolvePluginMetadataControlPlaneFingerprint: vi.fn(() => "test-plugin-fingerprint"),
-    restoreCurrentPluginMetadataSnapshotState: vi.fn(),
     setCurrentPluginMetadataSnapshot: vi.fn(),
   }));
 

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -75,10 +75,8 @@ import {
 import { getShellEnvAppliedKeys, shouldEnableShellEnvFallback } from "../../infra/shell-env.js";
 import type { ProviderModelRouteCandidate } from "../../plugin-sdk/provider-model-types.js";
 import {
-  captureCurrentPluginMetadataSnapshotState,
   getCurrentPluginMetadataSnapshot,
-  restoreCurrentPluginMetadataSnapshotState,
-  setCurrentPluginMetadataSnapshot,
+  installTemporaryCurrentPluginMetadataSnapshot,
 } from "../../plugins/current-plugin-metadata-snapshot.js";
 import { loadManifestMetadataSnapshot } from "../../plugins/manifest-contract-eligibility.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
@@ -290,15 +288,12 @@ function installCommandPluginMetadataSnapshot(params: {
   if (current) {
     return () => {};
   }
-  const previousState = captureCurrentPluginMetadataSnapshotState();
-  setCurrentPluginMetadataSnapshot(params.snapshot, {
+  const lease = installTemporaryCurrentPluginMetadataSnapshot(params.snapshot, {
     config: params.config,
     workspaceDir: params.workspaceDir,
     env: params.env,
   });
-  return () => {
-    restoreCurrentPluginMetadataSnapshotState(previousState);
-  };
+  return lease.release;
 }
 
 function syntheticAuthCredential(

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -1,5 +1,12 @@
 // Model list status tests cover status column construction and auth/probe summaries.
 import { describe, expect, it, type Mock, vi } from "vitest";
+import {
+  getCurrentPluginMetadataSnapshot,
+  setCurrentPluginMetadataSnapshot,
+} from "../../plugins/current-plugin-metadata-snapshot.js";
+import { clearCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata-state.js";
+import { clearPluginMetadataLifecycleCaches } from "../../plugins/plugin-metadata-lifecycle.js";
+import { createDeferred } from "../../test-utils/deferred.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 
 const mocks = vi.hoisted(() => {
@@ -547,6 +554,57 @@ async function withOpenAIStatusFixture<T>(
 }
 
 describe("modelsStatusCommand auth overview", () => {
+  it("does not restore over plugin metadata published while status is running", async () => {
+    const originalLoadModelCatalog = mocks.loadModelCatalog.getMockImplementation();
+    const config = mocks.loadConfig();
+    const workspaceDir = "/tmp/openclaw-agent/workspace";
+    const catalogStarted = createDeferred();
+    const releaseCatalog = createDeferred();
+    let replacement: ReturnType<typeof getCurrentPluginMetadataSnapshot> = undefined;
+    clearCurrentPluginMetadataSnapshot();
+    mocks.loadModelCatalog.mockImplementationOnce(async () => {
+      replacement = getCurrentPluginMetadataSnapshot({
+        config,
+        workspaceDir,
+        env: process.env,
+      });
+      catalogStarted.resolve();
+      await releaseCatalog.promise;
+      return [];
+    });
+    const commandPromise = modelsStatusCommand({ json: true }, createRuntime() as never);
+
+    try {
+      await catalogStarted.promise;
+      expect(replacement).toBeDefined();
+      clearPluginMetadataLifecycleCaches();
+      setCurrentPluginMetadataSnapshot(replacement!, {
+        config,
+        workspaceDir,
+        env: process.env,
+      });
+      releaseCatalog.resolve();
+      await commandPromise;
+
+      expect(
+        getCurrentPluginMetadataSnapshot({
+          config,
+          workspaceDir,
+          env: process.env,
+        }),
+      ).toBe(replacement);
+    } finally {
+      releaseCatalog.resolve();
+      await commandPromise.catch(() => {});
+      clearCurrentPluginMetadataSnapshot();
+      if (originalLoadModelCatalog) {
+        mocks.loadModelCatalog.mockImplementation(originalLoadModelCatalog);
+      } else {
+        mocks.loadModelCatalog.mockResolvedValue([]);
+      }
+    }
+  });
+
   it.each([
     [{ probeTimeout: "5000ms" }, "--probe-timeout"],
     [{ probeConcurrency: "2.5" }, "--probe-concurrency"],

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -27,11 +27,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { rotateAgentEventLifecycleGeneration } from "../infra/agent-events.js";
 import { onDiagnosticEvent, type DiagnosticPayloadLargeEvent } from "../infra/diagnostic-events.js";
 import { ExecApprovalsMigrationRequiredError } from "../infra/exec-approvals-migration-gate.js";
-import {
-  captureCurrentPluginMetadataSnapshotState,
-  restoreCurrentPluginMetadataSnapshotState,
-  setCurrentPluginMetadataSnapshot,
-} from "../plugins/current-plugin-metadata-snapshot.js";
+import { installTemporaryCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { runExclusiveSessionLifecycleMutation } from "../sessions/session-lifecycle-admission.js";
 import { openOpenClawAgentDatabase } from "../state/openclaw-agent-db.js";
@@ -1239,7 +1235,7 @@ describe("gateway server chat", () => {
         },
       },
       async (state) => {
-        const previousPluginMetadata = captureCurrentPluginMetadataSnapshotState();
+        let releasePluginMetadata: () => boolean = () => false;
         openDirectChatSession();
         try {
           const config = {
@@ -1372,11 +1368,11 @@ describe("gateway server chat", () => {
           // Direct handlers bypass Gateway startup, so publish its process-lifecycle handoff once.
           // Otherwise every route projector rediscovers the full plugin metadata graph.
           const pluginMetadata = resolvePluginMetadataSnapshot({ config, env: process.env });
-          setCurrentPluginMetadataSnapshot(pluginMetadata, {
+          releasePluginMetadata = installTemporaryCurrentPluginMetadataSnapshot(pluginMetadata, {
             config,
             compatibleConfigs: [persistedConfig],
             env: process.env,
-          });
+          }).release;
           expect(persistedConfig.auth?.order?.openai).toEqual([
             "openai:api",
             "openai:chatgpt",
@@ -1481,7 +1477,7 @@ describe("gateway server chat", () => {
           }
         } finally {
           testState.sessionStorePath = undefined;
-          restoreCurrentPluginMetadataSnapshotState(previousPluginMetadata);
+          releasePluginMetadata();
         }
       },
     );

--- a/src/plugins/current-plugin-metadata-snapshot.test.ts
+++ b/src/plugins/current-plugin-metadata-snapshot.test.ts
@@ -2,11 +2,11 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { normalizeConfiguredProviderCatalogModelId } from "@openclaw/model-catalog-core/provider-model-id-normalization";
 import { describe, expect, it } from "vitest";
 import {
-  captureCurrentPluginMetadataSnapshotState,
   getCurrentPluginMetadataSnapshot,
-  restoreCurrentPluginMetadataSnapshotState,
+  installTemporaryCurrentPluginMetadataSnapshot,
   setCurrentPluginMetadataSnapshot,
 } from "./current-plugin-metadata-snapshot.js";
 import { clearCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-state.js";
@@ -19,10 +19,24 @@ function createSnapshot(
   params: {
     config?: Parameters<typeof resolveInstalledPluginIndexPolicyHash>[0];
     pluginIds?: readonly string[];
+    normalizationAlias?: string;
     registrySource?: PluginMetadataSnapshot["registrySource"];
     workspaceDir?: string;
   } = {},
 ): PluginMetadataSnapshot {
+  const plugins = params.normalizationAlias
+    ? ([
+        {
+          modelIdNormalization: {
+            providers: {
+              fixture: {
+                aliases: { raw: params.normalizationAlias },
+              },
+            },
+          },
+        },
+      ] as PluginMetadataSnapshot["plugins"])
+    : [];
   return {
     policyHash: resolveInstalledPluginIndexPolicyHash(params.config),
     ...(params.pluginIds !== undefined ? { pluginIds: params.pluginIds } : {}),
@@ -40,8 +54,8 @@ function createSnapshot(
       diagnostics: [],
     },
     registryDiagnostics: [],
-    manifestRegistry: { plugins: [], diagnostics: [] },
-    plugins: [],
+    manifestRegistry: { plugins, diagnostics: [] },
+    plugins,
     diagnostics: [],
     byPluginId: new Map(),
     normalizePluginId: (pluginId) => pluginId,
@@ -326,16 +340,18 @@ describe("current plugin metadata snapshot", () => {
     expect(getCurrentPluginMetadataSnapshot()).toBe(derived);
   });
 
-  it("restores a captured current snapshot state", () => {
+  it("restores the previous current snapshot after a temporary lease", () => {
     const firstConfig = { plugins: { allow: ["first"] } };
     const secondConfig = { plugins: { allow: ["second"] } };
     const first = createSnapshot({ config: firstConfig });
     const second = createSnapshot({ config: secondConfig });
     setCurrentPluginMetadataSnapshot(first, { config: firstConfig });
-    const captured = captureCurrentPluginMetadataSnapshotState();
 
-    setCurrentPluginMetadataSnapshot(second, { config: secondConfig });
-    restoreCurrentPluginMetadataSnapshotState(captured);
+    const lease = installTemporaryCurrentPluginMetadataSnapshot(second, {
+      config: secondConfig,
+    });
+    expect(getCurrentPluginMetadataSnapshot({ config: secondConfig })).toBe(second);
+    expect(lease.release()).toBe(true);
 
     expect(getCurrentPluginMetadataSnapshot({ config: firstConfig })).toBe(first);
     expect(getCurrentPluginMetadataSnapshot({ config: secondConfig })).toBeUndefined();
@@ -353,10 +369,9 @@ describe("current plugin metadata snapshot", () => {
       OPENCLAW_HOME: undefined,
     } as NodeJS.ProcessEnv;
     setCurrentPluginMetadataSnapshot(snapshot, { config, env: originalEnv });
-    const captured = captureCurrentPluginMetadataSnapshotState();
 
-    setCurrentPluginMetadataSnapshot(createSnapshot());
-    restoreCurrentPluginMetadataSnapshotState(captured);
+    const lease = installTemporaryCurrentPluginMetadataSnapshot(createSnapshot());
+    expect(lease.release()).toBe(true);
 
     expect(getCurrentPluginMetadataSnapshot({ config, env: changedEnv })).toBe(snapshot);
   });
@@ -365,13 +380,78 @@ describe("current plugin metadata snapshot", () => {
     const config = { plugins: { allow: ["first"] } };
     const snapshot = createSnapshot({ config });
     setCurrentPluginMetadataSnapshot(snapshot, { config });
-    const captured = captureCurrentPluginMetadataSnapshotState();
 
-    setCurrentPluginMetadataSnapshot(createSnapshot());
-    restoreCurrentPluginMetadataSnapshotState(captured);
+    const lease = installTemporaryCurrentPluginMetadataSnapshot(createSnapshot());
+    expect(lease.release()).toBe(true);
     config.plugins.allow = ["changed"];
 
     expect(getCurrentPluginMetadataSnapshot({ config })).toBe(snapshot);
+  });
+
+  it("restores a temporary lease while its publication is current", () => {
+    const firstConfig = { plugins: { allow: ["first"] } };
+    const temporaryConfig = { plugins: { allow: ["temporary"] } };
+    const first = createSnapshot({ config: firstConfig });
+    const temporary = createSnapshot({ config: temporaryConfig });
+    setCurrentPluginMetadataSnapshot(first, { config: firstConfig });
+
+    const lease = installTemporaryCurrentPluginMetadataSnapshot(temporary, {
+      config: temporaryConfig,
+    });
+
+    expect(lease.release()).toBe(true);
+    expect(getCurrentPluginMetadataSnapshot({ config: firstConfig })).toBe(first);
+    expect(lease.release()).toBe(false);
+  });
+
+  it("does not release a temporary lease over a newer publication or lifecycle clear", () => {
+    const original = createSnapshot();
+    const temporary = createSnapshot();
+    const newer = createSnapshot();
+    setCurrentPluginMetadataSnapshot(original);
+
+    const clearedLease = installTemporaryCurrentPluginMetadataSnapshot(temporary);
+    clearCurrentPluginMetadataSnapshot();
+    expect(clearedLease.release()).toBe(false);
+    expect(getCurrentPluginMetadataSnapshot()).toBeUndefined();
+
+    const replacedLease = installTemporaryCurrentPluginMetadataSnapshot(temporary);
+    setCurrentPluginMetadataSnapshot(newer);
+    expect(replacedLease.release()).toBe(false);
+    expect(getCurrentPluginMetadataSnapshot()).toBe(newer);
+  });
+
+  it("unwinds nested temporary leases when they release out of order", () => {
+    const original = createSnapshot();
+    const outerSnapshot = createSnapshot();
+    const innerSnapshot = createSnapshot();
+    setCurrentPluginMetadataSnapshot(original);
+
+    const outer = installTemporaryCurrentPluginMetadataSnapshot(outerSnapshot);
+    const inner = installTemporaryCurrentPluginMetadataSnapshot(innerSnapshot);
+
+    expect(outer.release()).toBe(false);
+    expect(getCurrentPluginMetadataSnapshot()).toBe(innerSnapshot);
+    expect(inner.release()).toBe(true);
+    expect(getCurrentPluginMetadataSnapshot()).toBe(original);
+    expect(inner.release()).toBe(false);
+  });
+
+  it("restores the exact captured model normalization records", () => {
+    const original = createSnapshot({ normalizationAlias: "original" });
+    const temporary = createSnapshot({ normalizationAlias: "temporary" });
+    const env = {
+      HOME: "/home/original-snapshot",
+      OPENCLAW_HOME: undefined,
+    } as NodeJS.ProcessEnv;
+    setCurrentPluginMetadataSnapshot(original, { env });
+    expect(normalizeConfiguredProviderCatalogModelId("fixture", "raw")).toBe("original");
+
+    const lease = installTemporaryCurrentPluginMetadataSnapshot(temporary);
+    expect(normalizeConfiguredProviderCatalogModelId("fixture", "raw")).toBe("temporary");
+
+    expect(lease.release()).toBe(true);
+    expect(normalizeConfiguredProviderCatalogModelId("fixture", "raw")).toBe("original");
   });
 
   it("clears the current snapshot when the persisted installed index changes", () => {

--- a/src/plugins/current-plugin-metadata-snapshot.test.ts
+++ b/src/plugins/current-plugin-metadata-snapshot.test.ts
@@ -12,6 +12,7 @@ import {
 import { clearCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-state.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
 import { writePersistedInstalledPluginIndexSync } from "./installed-plugin-index-store.js";
+import type { PluginManifestRecord } from "./manifest-registry.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
 import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
 
@@ -24,9 +25,19 @@ function createSnapshot(
     workspaceDir?: string;
   } = {},
 ): PluginMetadataSnapshot {
-  const plugins = params.normalizationAlias
-    ? ([
+  const plugins: PluginManifestRecord[] = params.normalizationAlias
+    ? [
         {
+          id: "fixture",
+          channels: [],
+          providers: [],
+          cliBackends: [],
+          skills: [],
+          hooks: [],
+          origin: "config",
+          rootDir: "/fixture",
+          source: "test",
+          manifestPath: "/fixture/openclaw.plugin.json",
           modelIdNormalization: {
             providers: {
               fixture: {
@@ -35,7 +46,7 @@ function createSnapshot(
             },
           },
         },
-      ] as PluginMetadataSnapshot["plugins"])
+      ]
     : [];
   return {
     policyHash: resolveInstalledPluginIndexPolicyHash(params.config),

--- a/src/plugins/current-plugin-metadata-snapshot.ts
+++ b/src/plugins/current-plugin-metadata-snapshot.ts
@@ -1,10 +1,10 @@
 /** Tracks the current plugin metadata snapshot for control-plane lookups. */
-import { setCurrentManifestModelIdNormalizationRecords } from "@openclaw/model-catalog-core/provider-model-id-normalization";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   currentPluginMetadataConfigIdentityCache,
   getCurrentPluginMetadataSnapshotState,
   setCurrentPluginMetadataSnapshotState,
+  type CurrentPluginMetadataSnapshotRevision,
 } from "./current-plugin-metadata-state.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
 import {
@@ -23,6 +23,28 @@ type CurrentPluginMetadataSnapshotState = ReturnType<
   configIdentities: WeakSet<OpenClawConfig>;
 };
 
+type CurrentPluginMetadataSnapshotOptions = {
+  config?: OpenClawConfig;
+  compatibleConfigs?: readonly OpenClawConfig[];
+  env?: NodeJS.ProcessEnv;
+  workspaceDir?: string;
+};
+
+type TemporaryPluginMetadataSnapshotLeaseState = {
+  parent: TemporaryPluginMetadataSnapshotLeaseState | undefined;
+  previousState: CurrentPluginMetadataSnapshotState;
+  revision: CurrentPluginMetadataSnapshotRevision;
+  released: boolean;
+};
+
+type TemporaryPluginMetadataSnapshotLease = {
+  release: () => boolean;
+};
+
+let activeTemporaryPluginMetadataSnapshotLease:
+  | TemporaryPluginMetadataSnapshotLeaseState
+  | undefined;
+
 function resolvePluginMetadataControlPlaneFingerprint(
   config?: OpenClawConfig,
   options: Omit<ResolvePluginControlPlaneContextParams, "config"> = {},
@@ -33,17 +55,10 @@ function resolvePluginMetadataControlPlaneFingerprint(
   });
 }
 
-// Single-slot Gateway-owned handoff. Replace or clear it at lifecycle boundaries;
-// never accumulate historical metadata snapshots here.
-export function setCurrentPluginMetadataSnapshot(
+function publishCurrentPluginMetadataSnapshot(
   snapshot: PluginMetadataSnapshot | undefined,
-  options: {
-    config?: OpenClawConfig;
-    compatibleConfigs?: readonly OpenClawConfig[];
-    env?: NodeJS.ProcessEnv;
-    workspaceDir?: string;
-  } = {},
-): void {
+  options: CurrentPluginMetadataSnapshotOptions,
+): CurrentPluginMetadataSnapshotRevision {
   currentPluginMetadataConfigIdentityCache.clear();
   const compatiblePolicyHashes = snapshot
     ? options.compatibleConfigs?.map((config) => resolveInstalledPluginIndexPolicyHash(config))
@@ -83,17 +98,15 @@ export function setCurrentPluginMetadataSnapshot(
     (configFingerprint === defaultDiscoveryConfigFingerprint ||
       snapshot.configFingerprint === defaultDiscoveryConfigFingerprint ||
       Boolean(compatibleConfigFingerprints?.includes(defaultDiscoveryConfigFingerprint)));
-  setCurrentManifestModelIdNormalizationRecords(
-    defaultDiscoveryCompatible ? snapshot.plugins : undefined,
-  );
-  setCurrentPluginMetadataSnapshotState(
+  const revision = setCurrentPluginMetadataSnapshotState(
     snapshot,
     configFingerprint,
     compatiblePolicyHashes,
     compatibleConfigFingerprints,
+    defaultDiscoveryCompatible ? snapshot.plugins : undefined,
   );
   if (!snapshot) {
-    return;
+    return revision;
   }
   if (options.config) {
     const policyHash = resolveInstalledPluginIndexPolicyHash(options.config);
@@ -107,45 +120,96 @@ export function setCurrentPluginMetadataSnapshot(
   for (const config of options.compatibleConfigs ?? []) {
     currentPluginMetadataConfigIdentityCache.add(config);
   }
+  return revision;
 }
 
-export function captureCurrentPluginMetadataSnapshotState(): CurrentPluginMetadataSnapshotState {
+// Single-slot Gateway-owned handoff. Replace or clear it at lifecycle boundaries;
+// never accumulate historical metadata snapshots here.
+export function setCurrentPluginMetadataSnapshot(
+  snapshot: PluginMetadataSnapshot | undefined,
+  options: CurrentPluginMetadataSnapshotOptions = {},
+): void {
+  activeTemporaryPluginMetadataSnapshotLease = undefined;
+  publishCurrentPluginMetadataSnapshot(snapshot, options);
+}
+
+function captureCurrentPluginMetadataSnapshotState(): CurrentPluginMetadataSnapshotState {
   return {
     ...getCurrentPluginMetadataSnapshotState(),
     configIdentities: currentPluginMetadataConfigIdentityCache.capture(),
   };
 }
 
-export function restoreCurrentPluginMetadataSnapshotState(
+function restoreCapturedCurrentPluginMetadataSnapshotState(
   state: CurrentPluginMetadataSnapshotState,
-): void {
+): CurrentPluginMetadataSnapshotRevision {
   currentPluginMetadataConfigIdentityCache.restore(state.configIdentities);
-  const snapshot = state.snapshot as PluginMetadataSnapshot | undefined;
-  const defaultDiscoveryConfigFingerprint = snapshot
-    ? resolvePluginMetadataControlPlaneFingerprint(
-        {},
-        {
-          index: snapshot.index,
-          policyHash: snapshot.policyHash,
-          workspaceDir: snapshot.workspaceDir,
-        },
-      )
-    : undefined;
-  const defaultDiscoveryCompatible =
-    snapshot &&
-    defaultDiscoveryConfigFingerprint &&
-    (state.configFingerprint === defaultDiscoveryConfigFingerprint ||
-      snapshot.configFingerprint === defaultDiscoveryConfigFingerprint ||
-      Boolean(state.compatibleConfigFingerprints?.includes(defaultDiscoveryConfigFingerprint)));
-  setCurrentManifestModelIdNormalizationRecords(
-    defaultDiscoveryCompatible ? snapshot.plugins : undefined,
-  );
-  setCurrentPluginMetadataSnapshotState(
+  return setCurrentPluginMetadataSnapshotState(
     state.snapshot,
     state.configFingerprint,
     state.compatiblePolicyHashes,
     state.compatibleConfigFingerprints,
+    state.manifestModelIdNormalizationRecords,
   );
+}
+
+function resolveTemporaryPluginMetadataSnapshotLeaseParent():
+  | TemporaryPluginMetadataSnapshotLeaseState
+  | undefined {
+  const active = activeTemporaryPluginMetadataSnapshotLease;
+  if (active && getCurrentPluginMetadataSnapshotState().revision !== active.revision) {
+    activeTemporaryPluginMetadataSnapshotLease = undefined;
+    return undefined;
+  }
+  return active;
+}
+
+function releaseTemporaryPluginMetadataSnapshotLease(
+  lease: TemporaryPluginMetadataSnapshotLeaseState,
+): boolean {
+  if (lease.released) {
+    return false;
+  }
+  lease.released = true;
+  if (activeTemporaryPluginMetadataSnapshotLease !== lease) {
+    return false;
+  }
+
+  let restored = false;
+  while (activeTemporaryPluginMetadataSnapshotLease?.released) {
+    const current: TemporaryPluginMetadataSnapshotLeaseState =
+      activeTemporaryPluginMetadataSnapshotLease;
+    if (getCurrentPluginMetadataSnapshotState().revision !== current.revision) {
+      activeTemporaryPluginMetadataSnapshotLease = undefined;
+      return restored;
+    }
+    const restoredRevision = restoreCapturedCurrentPluginMetadataSnapshotState(
+      current.previousState,
+    );
+    activeTemporaryPluginMetadataSnapshotLease = current.parent;
+    if (activeTemporaryPluginMetadataSnapshotLease) {
+      activeTemporaryPluginMetadataSnapshotLease.revision = restoredRevision;
+    }
+    restored = true;
+  }
+  return restored;
+}
+
+/** Temporarily publishes metadata without restoring over lifecycle-owned replacements. */
+export function installTemporaryCurrentPluginMetadataSnapshot(
+  snapshot: PluginMetadataSnapshot,
+  options: CurrentPluginMetadataSnapshotOptions = {},
+): TemporaryPluginMetadataSnapshotLease {
+  const lease: TemporaryPluginMetadataSnapshotLeaseState = {
+    parent: resolveTemporaryPluginMetadataSnapshotLeaseParent(),
+    previousState: captureCurrentPluginMetadataSnapshotState(),
+    revision: publishCurrentPluginMetadataSnapshot(snapshot, options),
+    released: false,
+  };
+  activeTemporaryPluginMetadataSnapshotLease = lease;
+  return {
+    release: () => releaseTemporaryPluginMetadataSnapshotLease(lease),
+  };
 }
 
 export function getCurrentPluginMetadataSnapshot(

--- a/src/plugins/current-plugin-metadata-state.ts
+++ b/src/plugins/current-plugin-metadata-state.ts
@@ -1,12 +1,23 @@
 // Holds current plugin metadata snapshots for process-scoped consumers.
-import { setCurrentManifestModelIdNormalizationRecords } from "@openclaw/model-catalog-core/provider-model-id-normalization";
+import {
+  setCurrentManifestModelIdNormalizationRecords,
+  type ManifestModelIdNormalizationRecord,
+} from "@openclaw/model-catalog-core/provider-model-id-normalization";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
 let currentPluginMetadataSnapshot: unknown;
 let currentPluginMetadataSnapshotConfigFingerprint: string | undefined;
 let currentPluginMetadataSnapshotCompatiblePolicyHashes: readonly string[] | undefined;
 let currentPluginMetadataSnapshotCompatibleConfigFingerprints: readonly string[] | undefined;
+let currentManifestModelIdNormalizationRecords:
+  | readonly ManifestModelIdNormalizationRecord[]
+  | undefined;
+// Temporary snapshot owners compare this publication token before restoring;
+// lifecycle clears and newer publications must always win.
+let currentPluginMetadataSnapshotRevision = Symbol("plugin-metadata-snapshot");
 let currentPluginMetadataConfigIdentities = new WeakSet<OpenClawConfig>();
+
+export type CurrentPluginMetadataSnapshotRevision = typeof currentPluginMetadataSnapshotRevision;
 
 /** Owns config identity reuse for the current immutable metadata snapshot. */
 export const currentPluginMetadataConfigIdentityCache = {
@@ -33,7 +44,8 @@ export function setCurrentPluginMetadataSnapshotState(
   configFingerprint: string | undefined,
   compatiblePolicyHashes?: readonly string[],
   compatibleConfigFingerprints?: readonly string[],
-): void {
+  manifestModelIdNormalizationRecords?: readonly ManifestModelIdNormalizationRecord[],
+): CurrentPluginMetadataSnapshotRevision {
   currentPluginMetadataSnapshot = snapshot;
   currentPluginMetadataSnapshotConfigFingerprint = snapshot ? configFingerprint : undefined;
   currentPluginMetadataSnapshotCompatiblePolicyHashes = snapshot
@@ -42,20 +54,29 @@ export function setCurrentPluginMetadataSnapshotState(
   currentPluginMetadataSnapshotCompatibleConfigFingerprints = snapshot
     ? compatibleConfigFingerprints
     : undefined;
+  currentManifestModelIdNormalizationRecords = snapshot
+    ? manifestModelIdNormalizationRecords
+    : undefined;
+  setCurrentManifestModelIdNormalizationRecords(currentManifestModelIdNormalizationRecords);
+  currentPluginMetadataSnapshotRevision = Symbol("plugin-metadata-snapshot");
+  return currentPluginMetadataSnapshotRevision;
 }
 
 /** Clears the process-current plugin metadata snapshot. */
-function clearCurrentPluginMetadataSnapshotState(): void {
+function clearCurrentPluginMetadataSnapshotState(): CurrentPluginMetadataSnapshotRevision {
   currentPluginMetadataSnapshot = undefined;
   currentPluginMetadataSnapshotConfigFingerprint = undefined;
   currentPluginMetadataSnapshotCompatiblePolicyHashes = undefined;
   currentPluginMetadataSnapshotCompatibleConfigFingerprints = undefined;
+  currentManifestModelIdNormalizationRecords = undefined;
+  setCurrentManifestModelIdNormalizationRecords(undefined);
+  currentPluginMetadataSnapshotRevision = Symbol("plugin-metadata-snapshot");
+  return currentPluginMetadataSnapshotRevision;
 }
 
 /** Clears the snapshot, its identity cache, and process-wide model normalization. */
 export function clearCurrentPluginMetadataSnapshot(): void {
   currentPluginMetadataConfigIdentityCache.clear();
-  setCurrentManifestModelIdNormalizationRecords(undefined);
   clearCurrentPluginMetadataSnapshotState();
 }
 
@@ -65,11 +86,15 @@ export function getCurrentPluginMetadataSnapshotState(): {
   configFingerprint: string | undefined;
   compatiblePolicyHashes: readonly string[] | undefined;
   compatibleConfigFingerprints: readonly string[] | undefined;
+  manifestModelIdNormalizationRecords: readonly ManifestModelIdNormalizationRecord[] | undefined;
+  revision: CurrentPluginMetadataSnapshotRevision;
 } {
   return {
     snapshot: currentPluginMetadataSnapshot,
     configFingerprint: currentPluginMetadataSnapshotConfigFingerprint,
     compatiblePolicyHashes: currentPluginMetadataSnapshotCompatiblePolicyHashes,
     compatibleConfigFingerprints: currentPluginMetadataSnapshotCompatibleConfigFingerprints,
+    manifestModelIdNormalizationRecords: currentManifestModelIdNormalizationRecords,
+    revision: currentPluginMetadataSnapshotRevision,
   };
 }

--- a/src/system-agent/system-agent.test-helpers.ts
+++ b/src/system-agent/system-agent.test-helpers.ts
@@ -12,11 +12,7 @@ import {
 import { resolveCliRuntimeExecutionProvider } from "../agents/model-runtime-aliases.js";
 import { resolveSimpleCompletionSelectionForAgent } from "../agents/simple-completion-runtime.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import {
-  captureCurrentPluginMetadataSnapshotState,
-  restoreCurrentPluginMetadataSnapshotState,
-  setCurrentPluginMetadataSnapshot,
-} from "../plugins/current-plugin-metadata-snapshot.js";
+import { installTemporaryCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { listSystemAgentAuditEntriesForTests } from "./audit.test-support.js";
@@ -71,15 +67,21 @@ export function installSystemAgentClaudeCliBackendTestFixture(): () => void {
 export function installSystemAgentPluginMetadataTestSnapshot(
   config: OpenClawConfig = {},
 ): SystemAgentPluginMetadataTestSnapshot {
-  const previous = captureCurrentPluginMetadataSnapshotState();
   const snapshot = resolvePluginMetadataSnapshot({ config, env: process.env });
+  let releaseCurrentSnapshot: () => boolean = () => false;
   const rebindForCurrentEnv = () => {
-    setCurrentPluginMetadataSnapshot(snapshot, { config, env: process.env });
+    releaseCurrentSnapshot();
+    releaseCurrentSnapshot = installTemporaryCurrentPluginMetadataSnapshot(snapshot, {
+      config,
+      env: process.env,
+    }).release;
   };
   rebindForCurrentEnv();
   return {
     rebindForCurrentEnv,
-    restore: () => restoreCurrentPluginMetadataSnapshotState(previous),
+    restore: () => {
+      releaseCurrentSnapshot();
+    },
   };
 }
 

--- a/test/e2e/qa-lab/media/music-generation-controls.e2e.test.ts
+++ b/test/e2e/qa-lab/media/music-generation-controls.e2e.test.ts
@@ -14,11 +14,7 @@ import {
   withBundledPluginVitestCompat,
 } from "../../../../src/plugins/bundled-compat.js";
 import { prepareMediaCapabilityProviders } from "../../../../src/plugins/capability-provider-runtime.js";
-import {
-  captureCurrentPluginMetadataSnapshotState,
-  restoreCurrentPluginMetadataSnapshotState,
-  setCurrentPluginMetadataSnapshot,
-} from "../../../../src/plugins/current-plugin-metadata-snapshot.js";
+import { installTemporaryCurrentPluginMetadataSnapshot } from "../../../../src/plugins/current-plugin-metadata-snapshot.js";
 import { resolvePluginRegistryLoadCacheKey } from "../../../../src/plugins/loader.js";
 import type { PluginManifestRecord } from "../../../../src/plugins/manifest-registry.js";
 import { createEmptyPluginRegistry } from "../../../../src/plugins/registry.js";
@@ -186,11 +182,13 @@ describe("music generation controls QA product proof", () => {
   it("lists capabilities, falls back in config order, normalizes controls, and persists audio", async () => {
     const fixture = createMusicFixture();
     const activeRegistry = captureActivePluginRegistrySnapshot();
-    const metadataSnapshot = captureCurrentPluginMetadataSnapshotState();
-    try {
-      setCurrentPluginMetadataSnapshot(fixture.pluginMetadataSnapshot, {
+    const metadataLease = installTemporaryCurrentPluginMetadataSnapshot(
+      fixture.pluginMetadataSnapshot,
+      {
         config: fixture.config,
-      });
+      },
+    );
+    try {
       const pluginIds = [PLUGIN_ID];
       const enabledConfig = withBundledPluginEnablementCompat({
         config: fixture.config,
@@ -230,7 +228,7 @@ describe("music generation controls QA product proof", () => {
         "capabilities: modes=generate, maxDurationSeconds=60, lyrics, instrumental, duration, format, supportedFormats=mp3/wav",
       );
     } finally {
-      restoreCurrentPluginMetadataSnapshotState(metadataSnapshot);
+      metadataLease.release();
       restoreActivePluginRegistrySnapshot(activeRegistry);
     }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running `openclaw models status` could lose a newer plugin metadata publication when a config reload, plugin install, Doctor repair, or lifecycle clear completed while the command was awaiting catalog work.

The command previously captured process-global metadata and unconditionally restored that stale state during cleanup.

## Why This Change Was Made

The plugin metadata lifecycle owner now exposes a temporary publication lease. Each publication rotates an opaque revision token; cleanup restores the full prior composite state only while its own publication is still current. Authoritative set/clear operations win, nested leases unwind safely, and exact manifest model-normalization records are restored without re-deriving them from changed environment state.

The old raw capture/restore exports and their test-only borrowers are removed. There are no config, storage, SQLite schema, protocol, or plugin SDK changes.

## User Impact

Plugin metadata refreshed during `models status` remains authoritative instead of being silently replaced by stale command state. Ordinary serial command behavior is unchanged.

## Evidence

- Exact base: `121c6c10423827ce8a65118600f3498e20b8f6e0`.
- Exact head: `d28d2bd6a7acf0cfeeb0f11017434bb33f9dab5e` (signed).
- Reproduced execution order: temporary command publication -> async catalog wait -> lifecycle clear -> republish the same snapshot object -> command cleanup. The newer publication survives.
- Focused Vitest: 393/393 passed across plugin snapshot leases, models status, Gateway chat, system-agent rebinds, QA media flow, and compact harness loading.
- Exact test-only CI repair: the snapshot fixture now constructs a valid `PluginManifestRecord` and keeps the manifest registry's plugin list mutable; its focused file passes 27/27.
- Lease coverage includes lifecycle clear, authoritative replacement, nested out-of-order release, idempotent release, config identity, and exact model-normalization restoration.
- `oxfmt`, scoped `oxlint`, and `git diff --check`: passed.
- Changed-path gate passed conflict, ratchet, boundary, dependency, format, SDK, dead-export, temp-path, and script-declaration checks.
- The exact local core test-type run no longer reports either CI diagnostic from the changed fixture. The full linked-checkout lane still stops on the untouched current-main error at `packages/terminal-core/src/ansi.ts:194:38` and a missing generated UI package surface; exact-head CI is the authoritative type gate.
- Exact-commit autoreview: clean, no actionable findings.
- Delta: production +136/-52 (net +84); tests/support +186/-49 (net +137).
- Build not run locally: no build output, packaging, lazy module, bundled asset, or published surface changes; exact-head CI is the full build gate.

AI-assisted implementation; the exact diff, tests, lifecycle behavior, and commit were reviewed by the maintainer.
