### PR TITLE
fix(memory): load configured providers for CLI search

### DIFF
--- a/src/cli/command-bootstrap.test.ts
+++ b/src/cli/command-bootstrap.test.ts
@@ -68,15 +68,16 @@ describe("ensureCliCommandBootstrap", () => {
   it("skips config guard without skipping plugin loading", async () => {
     await ensureCliCommandBootstrap({
       runtime: {} as never,
-      commandPath: ["status"],
+      commandPath: ["memory", "search"],
       suppressDoctorStdout: true,
       skipConfigGuard: true,
       loadPlugins: true,
+      pluginRegistry: { scope: "memory" },
     });
 
     expect(ensureConfigReadyMock).not.toHaveBeenCalled();
     expect(ensureCliPluginRegistryLoadedMock).toHaveBeenCalledWith({
-      scope: "channels",
+      scope: "memory",
       routeLogsToStderr: true,
     });
   });

--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -10,7 +10,7 @@ type CliConfigGuardMode = "run" | "skip" | "when-suppressed";
 type CliConfigGuardPolicy =
   | CliConfigGuardMode
   | ((ctx: { argv: string[]; commandPath: string[] }) => CliConfigGuardMode);
-export type CliPluginRegistryScope = "all" | "channels" | "configured-channels";
+export type CliPluginRegistryScope = "all" | "channels" | "configured-channels" | "memory";
 export type CliPluginRegistryPolicy = {
   scope: CliPluginRegistryScope;
 };
@@ -608,9 +608,13 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     policy: { configGuard: "skip", loadPlugins: "never" },
   },
   {
+    commandPath: ["memory"],
+    policy: { loadPlugins: "always", pluginRegistry: { scope: "memory" } },
+  },
+  {
     commandPath: ["memory", "search"],
     exact: true,
-    policy: { configGuard: "skip", loadPlugins: "never" },
+    policy: { configGuard: "skip" },
   },
   {
     commandPath: ["memory", "status"],
@@ -618,7 +622,6 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     policy: {
       configGuard: ({ argv }) =>
         hasFlag(argv, "--index") || hasFlag(argv, "--fix") ? "run" : "skip",
-      loadPlugins: "never",
     },
   },
   { commandPath: ["skills", "update"], exact: true },

--- a/src/cli/command-path-policy.test.ts
+++ b/src/cli/command-path-policy.test.ts
@@ -377,18 +377,19 @@ describe("command-path-policy", () => {
         networkProxy: "bypass",
       });
     }
-    for (const commandPath of [
-      ["skills", "search"],
-      ["memory", "search"],
-    ]) {
-      expectResolvedPolicy(commandPath, {
-        configGuard: "skip",
-        loadPlugins: "never",
-      });
-    }
+    expectResolvedPolicy(["skills", "search"], {
+      configGuard: "skip",
+      loadPlugins: "never",
+    });
+    expectResolvedPolicy(["memory", "search"], {
+      configGuard: "skip",
+      loadPlugins: "always",
+      pluginRegistry: { scope: "memory" },
+    });
     const memoryStatusPolicy = resolveCliCommandPathPolicy(["memory", "status"]);
     expectConfigGuardResolver(memoryStatusPolicy);
-    expect(memoryStatusPolicy.loadPlugins).toBe("never");
+    expect(memoryStatusPolicy.loadPlugins).toBe("always");
+    expect(memoryStatusPolicy.pluginRegistry).toEqual({ scope: "memory" });
     expect(
       memoryStatusPolicy.configGuard({
         argv: ["node", "openclaw", "memory", "status"],

--- a/src/cli/command-startup-policy.test.ts
+++ b/src/cli/command-startup-policy.test.ts
@@ -185,6 +185,15 @@ describe("command-startup-policy", () => {
   });
 
   it("matches plugin preload policy", () => {
+    for (const commandPath of [
+      ["memory", "index"],
+      ["memory", "search"],
+      ["memory", "status"],
+    ]) {
+      const policy = resolvePolicy({ commandPath });
+      expect(policy.loadPlugins, commandPath.join(" ")).toBe(true);
+      expect(policy.pluginRegistry, commandPath.join(" ")).toEqual({ scope: "memory" });
+    }
     expect(
       resolvePolicy({
         commandPath: ["status"],

--- a/src/cli/program/preaction.test-helpers.ts
+++ b/src/cli/program/preaction.test-helpers.ts
@@ -7,8 +7,6 @@ export const COLD_READ_COMMAND_PATHS: string[][] = [
   ["hooks", "list"],
   ["hooks", "info"],
   ["hooks", "check"],
-  ["memory", "status"],
-  ["memory", "search"],
   ["update", "--dry-run"],
 ];
 

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -137,11 +137,18 @@ export function registerPreActionHooks(program: Command, programVersion: string)
     if (!verbose) {
       process.env.NODE_NO_WARNINGS ??= "1";
     }
-    if (
-      startupPolicy.skipConfigGuard ||
-      isGuidedConfigAction(actionCommand) ||
-      isGuidedConfigCommandPath(commandPath)
-    ) {
+    if (isGuidedConfigAction(actionCommand) || isGuidedConfigCommandPath(commandPath)) {
+      return;
+    }
+    if (startupPolicy.skipConfigGuard) {
+      // Config validation and plugin activation are independent startup policies.
+      // A cold config read must not suppress a plugin runtime explicitly required by the command.
+      await ensureCliExecutionBootstrap({
+        runtime: defaultRuntime,
+        commandPath,
+        startupPolicy,
+        skipConfigGuard: true,
+      });
       return;
     }
     let beforeStateMigrations: ((snapshot?: ConfigFileSnapshot) => Promise<boolean>) | undefined;

--- a/src/cli/program/root-command-descriptions.test.ts
+++ b/src/cli/program/root-command-descriptions.test.ts
@@ -17,6 +17,7 @@ const RESERVED_CATALOG_ROOTS = {
 } as const;
 
 const PLUGIN_CATALOG_PATHS = {
+  memory: "registered and covered by the memory-core plugin",
   "memory search": "registered and covered by the memory-core plugin",
   "memory status": "registered and covered by the memory-core plugin",
 } as const;

--- a/src/plugins/activation-context.test.ts
+++ b/src/plugins/activation-context.test.ts
@@ -21,11 +21,44 @@ vi.mock("../config/plugin-auto-enable.js", () => ({
   applyPluginAutoEnable: applyPluginAutoEnableMock,
 }));
 
-import { resolveBundledPluginCompatibleActivationInputs } from "./activation-context.js";
+import {
+  resolveBundledPluginCompatibleActivationInputs,
+  withActivatedPluginIds,
+} from "./activation-context.js";
 
 afterEach(() => {
   clearCurrentPluginMetadataSnapshot();
   applyPluginAutoEnableMock.mockClear();
+});
+
+describe("withActivatedPluginIds", () => {
+  it("can activate configured owners through a restrictive allowlist", () => {
+    expect(
+      withActivatedPluginIds({
+        config: {
+          plugins: {
+            allow: ["memory-core"],
+            deny: ["blocked"],
+            entries: {
+              disabled: { enabled: false },
+            },
+          },
+        },
+        pluginIds: ["openai", "blocked", "disabled"],
+        allowRestrictiveAllowlistBypass: true,
+      }),
+    ).toEqual({
+      plugins: {
+        allow: ["memory-core", "openai", "blocked", "disabled"],
+        deny: ["blocked"],
+        entries: {
+          openai: { enabled: true },
+          blocked: { enabled: true },
+          disabled: { enabled: false },
+        },
+      },
+    });
+  });
 });
 
 describe("resolveBundledPluginCompatibleActivationInputs", () => {

--- a/src/plugins/activation-context.test.ts
+++ b/src/plugins/activation-context.test.ts
@@ -32,7 +32,7 @@ afterEach(() => {
 });
 
 describe("withActivatedPluginIds", () => {
-  it("can activate configured owners through a restrictive allowlist", () => {
+  it("keeps omitted plugin ids outside restrictive allowlists", () => {
     expect(
       withActivatedPluginIds({
         config: {
@@ -45,15 +45,12 @@ describe("withActivatedPluginIds", () => {
           },
         },
         pluginIds: ["openai", "blocked", "disabled"],
-        allowRestrictiveAllowlistBypass: true,
       }),
     ).toEqual({
       plugins: {
-        allow: ["memory-core", "openai", "blocked", "disabled"],
+        allow: ["memory-core"],
         deny: ["blocked"],
         entries: {
-          openai: { enabled: true },
-          blocked: { enabled: true },
           disabled: { enabled: false },
         },
       },

--- a/src/plugins/activation-context.ts
+++ b/src/plugins/activation-context.ts
@@ -67,6 +67,7 @@ export function withActivatedPluginIds(params: {
   pluginIds: readonly string[];
   overrideGlobalDisable?: boolean;
   overrideExplicitDisable?: boolean;
+  allowRestrictiveAllowlistBypass?: boolean;
 }): OpenClawConfig | undefined {
   if (params.pluginIds.length === 0) {
     return params.config;
@@ -83,7 +84,11 @@ export function withActivatedPluginIds(params: {
     if (!normalized) {
       continue;
     }
-    if (originalAllowSet && !originalAllowSet.has(normalized)) {
+    if (
+      originalAllowSet &&
+      !originalAllowSet.has(normalized) &&
+      params.allowRestrictiveAllowlistBypass !== true
+    ) {
       continue;
     }
     allow.add(normalized);

--- a/src/plugins/activation-context.ts
+++ b/src/plugins/activation-context.ts
@@ -67,7 +67,6 @@ export function withActivatedPluginIds(params: {
   pluginIds: readonly string[];
   overrideGlobalDisable?: boolean;
   overrideExplicitDisable?: boolean;
-  allowRestrictiveAllowlistBypass?: boolean;
 }): OpenClawConfig | undefined {
   if (params.pluginIds.length === 0) {
     return params.config;
@@ -84,11 +83,7 @@ export function withActivatedPluginIds(params: {
     if (!normalized) {
       continue;
     }
-    if (
-      originalAllowSet &&
-      !originalAllowSet.has(normalized) &&
-      params.allowRestrictiveAllowlistBypass !== true
-    ) {
+    if (originalAllowSet && !originalAllowSet.has(normalized)) {
       continue;
     }
     allow.add(normalized);

--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -776,6 +776,18 @@ describe("resolveGatewayStartupPluginIdsFromRegistry", () => {
       ["browser", "openai", "memory-core"],
     ],
     [
+      "keeps configured memory embedding providers behind restrictive allowlists",
+      {
+        channels: {},
+        memory: { search: { provider: "openai" } },
+        plugins: {
+          allow: ["memory-core"],
+          slots: { memory: "memory-core" },
+        },
+      } as OpenClawConfig,
+      ["memory-core"],
+    ],
+    [
       "includes the owning plugin for a configured memory embedding fallback at startup",
       {
         channels: {},

--- a/src/plugins/runtime/runtime-registry-loader.test.ts
+++ b/src/plugins/runtime/runtime-registry-loader.test.ts
@@ -177,22 +177,8 @@ describe("ensurePluginRegistryLoaded", () => {
     expect(mocks.collectConfiguredMemoryEmbeddingProviderIds).toHaveBeenCalledWith(config);
     expect(requireLoadOptions()).toEqual(
       expect.objectContaining({
-        config: expect.objectContaining({
-          plugins: expect.objectContaining({
-            allow: ["acpx", "memory-core", "openai"],
-            entries: expect.objectContaining({
-              openai: { enabled: true },
-            }),
-          }),
-        }),
-        activationSourceConfig: expect.objectContaining({
-          plugins: expect.objectContaining({
-            allow: ["acpx", "memory-core", "openai"],
-            entries: expect.objectContaining({
-              openai: { enabled: true },
-            }),
-          }),
-        }),
+        config,
+        activationSourceConfig: config,
         onlyPluginIds: ["memory-core", "openai"],
         throwOnLoadError: true,
       }),
@@ -247,14 +233,8 @@ describe("ensurePluginRegistryLoaded", () => {
 
     const options = requireLoadOptions();
     expect(options.onlyPluginIds).toEqual(["google", "memory-core"]);
-    expect(options.config).toEqual(
-      expect.objectContaining({
-        plugins: expect.objectContaining({
-          allow: ["memory-core", "google"],
-          deny: ["google"],
-        }),
-      }),
-    );
+    expect(options.config).toEqual(config);
+    expect(options.activationSourceConfig).toEqual(config);
   });
 
   it("keeps an explicitly disabled memory provider owner disabled", () => {
@@ -276,15 +256,8 @@ describe("ensurePluginRegistryLoaded", () => {
 
     const options = requireLoadOptions();
     expect(options.onlyPluginIds).toEqual(["llama-cpp", "memory-core"]);
-    expect(options.config).toEqual(
-      expect.objectContaining({
-        plugins: expect.objectContaining({
-          entries: expect.objectContaining({
-            "llama-cpp": { enabled: false },
-          }),
-        }),
-      }),
-    );
+    expect(options.config).toEqual(config);
+    expect(options.activationSourceConfig).toEqual(config);
   });
 
   it("keeps an empty memory scope empty when no backend is selected", () => {

--- a/src/plugins/runtime/runtime-registry-loader.test.ts
+++ b/src/plugins/runtime/runtime-registry-loader.test.ts
@@ -107,7 +107,7 @@ function requireLoadOptions(): Record<string, unknown> {
 describe("ensurePluginRegistryLoaded", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.resolvePluginMetadataSnapshot.mockReturnValue(undefined);
+    mocks.resolvePluginMetadataSnapshot.mockReset();
     mocks.isPluginMetadataSnapshotCompatible.mockReturnValue(true);
     mocks.applyPluginAutoEnable.mockImplementation((params) => ({
       config: params.config ?? {},

--- a/src/plugins/runtime/runtime-registry-loader.test.ts
+++ b/src/plugins/runtime/runtime-registry-loader.test.ts
@@ -17,6 +17,8 @@ const mocks = vi.hoisted(() => ({
     vi.fn<typeof import("../../config/plugin-auto-enable.js").applyPluginAutoEnable>(),
   resolvePluginMetadataSnapshot:
     vi.fn<typeof import("../plugin-metadata-snapshot.js").resolvePluginMetadataSnapshot>(),
+  isPluginMetadataSnapshotCompatible:
+    vi.fn<typeof import("../plugin-metadata-snapshot.js").isPluginMetadataSnapshotCompatible>(),
   resolveAgentWorkspaceDir: vi.fn<
     typeof import("../../agents/agent-scope.js").resolveAgentWorkspaceDir
   >(() => "/resolved-workspace"),
@@ -58,6 +60,9 @@ vi.mock("../plugin-metadata-snapshot.js", () => ({
   resolvePluginMetadataSnapshot: (
     ...args: Parameters<typeof mocks.resolvePluginMetadataSnapshot>
   ) => mocks.resolvePluginMetadataSnapshot(...args),
+  isPluginMetadataSnapshotCompatible: (
+    ...args: Parameters<typeof mocks.isPluginMetadataSnapshotCompatible>
+  ) => mocks.isPluginMetadataSnapshotCompatible(...args),
 }));
 
 vi.mock("../../agents/agent-scope.js", () => ({
@@ -68,6 +73,28 @@ vi.mock("../../agents/agent-scope.js", () => ({
 }));
 
 import { ensurePluginRegistryLoaded } from "./runtime-registry-loader.js";
+
+function useMemoryProviderOwner(params: {
+  adapterId: string;
+  contract: "embeddingProviders" | "memoryEmbeddingProviders";
+  pluginId: string;
+}): void {
+  mocks.resolvePluginMetadataSnapshot.mockReturnValue({
+    policyHash: "test",
+    index: {
+      installRecords: {},
+      plugins: [
+        {
+          pluginId: params.pluginId,
+          contributions: {
+            contracts: { [params.contract]: [params.adapterId] },
+          },
+        },
+      ],
+    },
+    manifestRegistry: { plugins: [], diagnostics: [] },
+  } as never);
+}
 
 function requireLoadOptions(): Record<string, unknown> {
   const options = mocks.loadOpenClawPlugins.mock.calls[0]?.[0];
@@ -80,6 +107,8 @@ function requireLoadOptions(): Record<string, unknown> {
 describe("ensurePluginRegistryLoaded", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.resolvePluginMetadataSnapshot.mockReturnValue(undefined);
+    mocks.isPluginMetadataSnapshotCompatible.mockReturnValue(true);
     mocks.applyPluginAutoEnable.mockImplementation((params) => ({
       config: params.config ?? {},
       changes: [],
@@ -170,33 +199,102 @@ describe("ensurePluginRegistryLoaded", () => {
     );
   });
 
-  it("keeps explicit memory provider disablement authoritative", () => {
+  it.each([
+    {
+      adapterId: "gemini",
+      contract: "memoryEmbeddingProviders" as const,
+      pluginId: "google",
+    },
+    {
+      adapterId: "local",
+      contract: "embeddingProviders" as const,
+      pluginId: "llama-cpp",
+    },
+  ])("loads the $pluginId owner for the $adapterId memory adapter", (provider) => {
     const config = {
-      memory: { search: { provider: "openai" } },
-      plugins: {
-        allow: ["memory-core"],
-        deny: ["openai"],
-        entries: { openai: { enabled: false } },
-        slots: { memory: "memory-core" },
-      },
+      memory: { search: { provider: provider.adapterId } },
+      plugins: { slots: { memory: "memory-core" } },
     };
-    mocks.collectConfiguredMemoryEmbeddingProviderIds.mockReturnValue(new Set(["openai"]));
+    mocks.collectConfiguredMemoryEmbeddingProviderIds.mockReturnValue(
+      new Set([provider.adapterId]),
+    );
+    useMemoryProviderOwner(provider);
 
     ensurePluginRegistryLoaded({ scope: "memory", config });
 
-    expect(requireLoadOptions()).toEqual(
+    expect(requireLoadOptions().onlyPluginIds).toEqual(
+      [provider.pluginId, "memory-core"].toSorted(),
+    );
+  });
+
+  it("keeps a denied memory provider owner denied", () => {
+    const config = {
+      memory: { search: { provider: "gemini" } },
+      plugins: {
+        allow: ["memory-core"],
+        deny: ["google"],
+        slots: { memory: "memory-core" },
+      },
+    };
+    mocks.collectConfiguredMemoryEmbeddingProviderIds.mockReturnValue(new Set(["gemini"]));
+    useMemoryProviderOwner({
+      adapterId: "gemini",
+      contract: "memoryEmbeddingProviders",
+      pluginId: "google",
+    });
+
+    ensurePluginRegistryLoaded({ scope: "memory", config });
+
+    const options = requireLoadOptions();
+    expect(options.onlyPluginIds).toEqual(["google", "memory-core"]);
+    expect(options.config).toEqual(
       expect.objectContaining({
-        config: expect.objectContaining({
-          plugins: expect.objectContaining({
-            allow: ["memory-core", "openai"],
-            deny: ["openai"],
-            entries: expect.objectContaining({
-              openai: { enabled: false },
-            }),
-          }),
+        plugins: expect.objectContaining({
+          allow: ["memory-core", "google"],
+          deny: ["google"],
         }),
-        onlyPluginIds: ["memory-core", "openai"],
       }),
     );
+  });
+
+  it("keeps an explicitly disabled memory provider owner disabled", () => {
+    const config = {
+      memory: { search: { provider: "local" } },
+      plugins: {
+        entries: { "llama-cpp": { enabled: false } },
+        slots: { memory: "memory-core" },
+      },
+    };
+    mocks.collectConfiguredMemoryEmbeddingProviderIds.mockReturnValue(new Set(["local"]));
+    useMemoryProviderOwner({
+      adapterId: "local",
+      contract: "embeddingProviders",
+      pluginId: "llama-cpp",
+    });
+
+    ensurePluginRegistryLoaded({ scope: "memory", config });
+
+    const options = requireLoadOptions();
+    expect(options.onlyPluginIds).toEqual(["llama-cpp", "memory-core"]);
+    expect(options.config).toEqual(
+      expect.objectContaining({
+        plugins: expect.objectContaining({
+          entries: expect.objectContaining({
+            "llama-cpp": { enabled: false },
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("keeps an empty memory scope empty when no backend is selected", () => {
+    mocks.collectConfiguredMemoryEmbeddingProviderIds.mockReturnValue(new Set());
+
+    ensurePluginRegistryLoaded({
+      scope: "memory",
+      config: { plugins: { slots: { memory: "none" } } },
+    });
+
+    expect(requireLoadOptions().onlyPluginIds).toEqual([]);
   });
 });

--- a/src/plugins/runtime/runtime-registry-loader.test.ts
+++ b/src/plugins/runtime/runtime-registry-loader.test.ts
@@ -9,6 +9,10 @@ const mocks = vi.hoisted(() => ({
     vi.fn<typeof import("../channel-plugin-ids.js").resolveChannelPluginIds>(),
   resolveEffectivePluginIds:
     vi.fn<typeof import("../effective-plugin-ids.js").resolveEffectivePluginIds>(),
+  collectConfiguredMemoryEmbeddingProviderIds:
+    vi.fn<
+      typeof import("../gateway-startup-plugin-ids.js").collectConfiguredMemoryEmbeddingProviderIds
+    >(),
   applyPluginAutoEnable:
     vi.fn<typeof import("../../config/plugin-auto-enable.js").applyPluginAutoEnable>(),
   resolvePluginMetadataSnapshot:
@@ -37,6 +41,12 @@ vi.mock("../channel-plugin-ids.js", () => ({
 vi.mock("../effective-plugin-ids.js", () => ({
   resolveEffectivePluginIds: (...args: Parameters<typeof mocks.resolveEffectivePluginIds>) =>
     mocks.resolveEffectivePluginIds(...args),
+}));
+
+vi.mock("../gateway-startup-plugin-ids.js", () => ({
+  collectConfiguredMemoryEmbeddingProviderIds: (
+    ...args: Parameters<typeof mocks.collectConfiguredMemoryEmbeddingProviderIds>
+  ) => mocks.collectConfiguredMemoryEmbeddingProviderIds(...args),
 }));
 
 vi.mock("../../config/plugin-auto-enable.js", () => ({
@@ -118,6 +128,74 @@ describe("ensurePluginRegistryLoaded", () => {
       expect.objectContaining({
         onlyPluginIds: ["demo", "memory-core"],
         throwOnLoadError: true,
+      }),
+    );
+  });
+
+  it("loads only the selected memory backend and embedding provider owners", () => {
+    const config = {
+      memory: { search: { provider: "openai" } },
+      plugins: {
+        allow: ["acpx", "memory-core"],
+        slots: { memory: "memory-core" },
+        entries: { unrelated: { enabled: true } },
+      },
+    };
+    mocks.collectConfiguredMemoryEmbeddingProviderIds.mockReturnValue(new Set(["openai"]));
+
+    ensurePluginRegistryLoaded({ scope: "memory", config });
+
+    expect(mocks.collectConfiguredMemoryEmbeddingProviderIds).toHaveBeenCalledWith(config);
+    expect(requireLoadOptions()).toEqual(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          plugins: expect.objectContaining({
+            allow: ["acpx", "memory-core", "openai"],
+            entries: expect.objectContaining({
+              openai: { enabled: true },
+            }),
+          }),
+        }),
+        activationSourceConfig: expect.objectContaining({
+          plugins: expect.objectContaining({
+            allow: ["acpx", "memory-core", "openai"],
+            entries: expect.objectContaining({
+              openai: { enabled: true },
+            }),
+          }),
+        }),
+        onlyPluginIds: ["memory-core", "openai"],
+        throwOnLoadError: true,
+      }),
+    );
+  });
+
+  it("keeps explicit memory provider disablement authoritative", () => {
+    const config = {
+      memory: { search: { provider: "openai" } },
+      plugins: {
+        allow: ["memory-core"],
+        deny: ["openai"],
+        entries: { openai: { enabled: false } },
+        slots: { memory: "memory-core" },
+      },
+    };
+    mocks.collectConfiguredMemoryEmbeddingProviderIds.mockReturnValue(new Set(["openai"]));
+
+    ensurePluginRegistryLoaded({ scope: "memory", config });
+
+    expect(requireLoadOptions()).toEqual(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          plugins: expect.objectContaining({
+            allow: ["memory-core", "openai"],
+            deny: ["openai"],
+            entries: expect.objectContaining({
+              openai: { enabled: false },
+            }),
+          }),
+        }),
+        onlyPluginIds: ["memory-core", "openai"],
       }),
     );
   });

--- a/src/plugins/runtime/runtime-registry-loader.ts
+++ b/src/plugins/runtime/runtime-registry-loader.ts
@@ -5,7 +5,9 @@ import {
   resolveChannelPluginIds,
   resolveConfiguredChannelPluginIds,
 } from "../channel-plugin-ids.js";
+import { normalizePluginsConfig } from "../config-state.js";
 import { resolveEffectivePluginIds } from "../effective-plugin-ids.js";
+import { collectConfiguredMemoryEmbeddingProviderIds } from "../gateway-startup-plugin-ids.js";
 import { loadOpenClawPlugins } from "../loader.js";
 import { hasNonEmptyPluginIdScope } from "../plugin-scope.js";
 import {
@@ -13,7 +15,20 @@ import {
   resolvePluginRuntimeLoadContext,
 } from "./load-context.js";
 
-export type PluginRegistryScope = "configured-channels" | "channels" | "all";
+export type PluginRegistryScope = "configured-channels" | "channels" | "memory" | "all";
+
+function resolveMemoryPluginIds(
+  context: ReturnType<typeof resolvePluginRuntimeLoadContext>,
+): string[] {
+  const pluginIds = new Set(
+    collectConfiguredMemoryEmbeddingProviderIds(context.activationSourceConfig),
+  );
+  const memoryPluginId = normalizePluginsConfig(context.config.plugins).slots.memory?.trim();
+  if (memoryPluginId) {
+    pluginIds.add(memoryPluginId);
+  }
+  return [...pluginIds].toSorted();
+}
 
 function resolveScopePluginIds(params: {
   scope: PluginRegistryScope;
@@ -34,6 +49,11 @@ function resolveScopePluginIds(params: {
       env: params.context.env,
     });
   }
+  if (params.scope === "memory") {
+    // Memory CLI commands must use the same backend and embedding adapters as
+    // Gateway, without activating unrelated explicitly enabled plugins.
+    return resolveMemoryPluginIds(params.context);
+  }
   return resolveEffectivePluginIds({
     config: params.context.rawConfig,
     workspaceDir: params.context.workspaceDir,
@@ -51,13 +71,20 @@ export function ensurePluginRegistryLoaded(options?: {
   const scope = options?.scope ?? "all";
   const context = resolvePluginRuntimeLoadContext(options);
   const pluginIds = resolveScopePluginIds({ scope, context });
-  const activateConfigured = scope === "configured-channels" && pluginIds.length > 0;
+  const activateConfigured =
+    (scope === "configured-channels" || scope === "memory") && pluginIds.length > 0;
+  const activationOptions = {
+    pluginIds,
+    ...(scope === "memory" ? { allowRestrictiveAllowlistBypass: true } : {}),
+  };
   const config = activateConfigured
-    ? (withActivatedPluginIds({ config: context.config, pluginIds }) ?? context.config)
+    ? (withActivatedPluginIds({ config: context.config, ...activationOptions }) ?? context.config)
     : context.config;
   const activationSourceConfig = activateConfigured
-    ? (withActivatedPluginIds({ config: context.activationSourceConfig, pluginIds }) ??
-      context.activationSourceConfig)
+    ? (withActivatedPluginIds({
+        config: context.activationSourceConfig,
+        ...activationOptions,
+      }) ?? context.activationSourceConfig)
     : context.activationSourceConfig;
   loadOpenClawPlugins(
     buildPluginRuntimeLoadOptionsFromValues(
@@ -65,6 +92,7 @@ export function ensurePluginRegistryLoaded(options?: {
       {
         throwOnLoadError: true,
         ...(scope === "configured-channels" ||
+        scope === "memory" ||
         scope === "all" ||
         hasNonEmptyPluginIdScope(pluginIds)
           ? { onlyPluginIds: pluginIds }

--- a/src/plugins/runtime/runtime-registry-loader.ts
+++ b/src/plugins/runtime/runtime-registry-loader.ts
@@ -8,6 +8,7 @@ import {
 import { normalizePluginsConfig } from "../config-state.js";
 import { resolveEffectivePluginIds } from "../effective-plugin-ids.js";
 import { collectConfiguredMemoryEmbeddingProviderIds } from "../gateway-startup-plugin-ids.js";
+import { createInstalledPluginIndexScopeLookup } from "../installed-plugin-index-scope-lookup.js";
 import { loadOpenClawPlugins } from "../loader.js";
 import { hasNonEmptyPluginIdScope } from "../plugin-scope.js";
 import {
@@ -20,9 +21,19 @@ export type PluginRegistryScope = "configured-channels" | "channels" | "memory" 
 function resolveMemoryPluginIds(
   context: ReturnType<typeof resolvePluginRuntimeLoadContext>,
 ): string[] {
-  const pluginIds = new Set(
-    collectConfiguredMemoryEmbeddingProviderIds(context.activationSourceConfig),
-  );
+  const configuredProviderIds = [
+    ...collectConfiguredMemoryEmbeddingProviderIds(context.activationSourceConfig),
+  ];
+  const pluginIds = new Set<string>();
+  if (context.metadataSnapshot) {
+    createInstalledPluginIndexScopeLookup(
+      context.metadataSnapshot.index,
+    ).addProviderContributionOwners(pluginIds, configuredProviderIds);
+  } else {
+    for (const providerId of configuredProviderIds) {
+      pluginIds.add(providerId);
+    }
+  }
   const memoryPluginId = normalizePluginsConfig(context.config.plugins).slots.memory?.trim();
   if (memoryPluginId) {
     pluginIds.add(memoryPluginId);

--- a/src/plugins/runtime/runtime-registry-loader.ts
+++ b/src/plugins/runtime/runtime-registry-loader.ts
@@ -82,19 +82,14 @@ export function ensurePluginRegistryLoaded(options?: {
   const scope = options?.scope ?? "all";
   const context = resolvePluginRuntimeLoadContext(options);
   const pluginIds = resolveScopePluginIds({ scope, context });
-  const activateConfigured =
-    (scope === "configured-channels" || scope === "memory") && pluginIds.length > 0;
-  const activationOptions = {
-    pluginIds,
-    ...(scope === "memory" ? { allowRestrictiveAllowlistBypass: true } : {}),
-  };
+  const activateConfigured = scope === "configured-channels" && pluginIds.length > 0;
   const config = activateConfigured
-    ? (withActivatedPluginIds({ config: context.config, ...activationOptions }) ?? context.config)
+    ? (withActivatedPluginIds({ config: context.config, pluginIds }) ?? context.config)
     : context.config;
   const activationSourceConfig = activateConfigured
     ? (withActivatedPluginIds({
         config: context.activationSourceConfig,
-        ...activationOptions,
+        pluginIds,
       }) ?? context.activationSourceConfig)
     : context.activationSourceConfig;
   loadOpenClawPlugins(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw memory search` and read-only `memory status` commands could ignore configured plugin-owned memory embedding providers. The Gateway could index successfully with the configured provider, while a later CLI process fell back to a different provider identity and returned no matches.

## Why This Change Was Made

Memory CLI commands now load a narrow registry containing only the selected memory backend and manifest owners for configured memory embedding providers. The scope is discovery-only: canonical allowlist, deny, and explicit-disable policy remains authoritative and identical to Gateway startup.

## User Impact

Users can search memory from a fresh CLI process with the same allowed provider configuration used by the Gateway. Read-only memory commands do not activate unrelated or unallowlisted plugins.

## Evidence

- Reproduced before the fix: the Gateway indexed `ORBIT-22` with provider `openai`, then `memory search` initialized `openai-compatible` and returned no result.
- Exact landing head: `9f40997c7f3879ebd9a3a4256df9281d3b6c615f`.
- Exact-head delegated `check:changed` passed in 10m13s: https://github.com/openclaw/openclaw/actions/runs/30917644057
- The production tree is unchanged from runtime-proven head `af50418f94e2d75ca08a5c3eb532f3082cf2c1d0`; the only later change classifies the plugin-owned `memory` root in the catalog consistency test.
- `thread-memory-isolation` passed for OpenClaw and Codex, then passed three additional bounded repetitions on the same Testbox: https://github.com/openclaw/openclaw/actions/runs/30914390530
- Focused CLI startup and catalog tests: 47 passed on the rebased landing head.
- Restrictive allowlist regression proves a configured provider owner omitted from `plugins.allow` remains inactive in both Gateway and fresh CLI startup.
- Fresh full-branch autoreview after rebase: clean, confidence 0.97.
