### PR TITLE
fix(qa): align release scenario setup and compaction proof

### DIFF
--- a/extensions/qa-lab/src/live-transports/matrix/matrix-scenario-flows.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/matrix-scenario-flows.test.ts
@@ -221,6 +221,7 @@ describe("Matrix QA Lab scenario flows", () => {
   });
 
   it("loads the voice preflight provider and media overrides", () => {
+    expect(readQaScenarioById("matrix-voice-preflight-mention").plugins).toEqual(["openai"]);
     expect(readQaScenarioById("matrix-voice-preflight-mention").execution).toMatchObject({
       kind: "flow",
       providerMode: "mock-openai",
@@ -254,6 +255,22 @@ describe("Matrix QA Lab scenario flows", () => {
           prompt: "MATRIX_QA_VOICE_PREFLIGHT_TRIGGER",
         },
         groupMentionPatterns: ["matrix\\W+qa\\W+voice\\W+pre[ -]?flight\\W+ok(?:ay)?"],
+      },
+    });
+  });
+
+  it("loads the generated-image provider and model selection", () => {
+    const scenario = readQaScenarioById("matrix-room-generated-image-delivery");
+    expect(scenario.plugins).toEqual(["openai"]);
+    expect(scenario.gatewayConfigPatch).toMatchObject({
+      agents: {
+        defaults: {
+          mediaModels: {
+            image: {
+              primary: "openai/gpt-image-1",
+            },
+          },
+        },
       },
     });
   });

--- a/extensions/qa-lab/src/qa-gateway-config.test.ts
+++ b/extensions/qa-lab/src/qa-gateway-config.test.ts
@@ -287,6 +287,34 @@ describe("buildQaGatewayConfig", () => {
     });
   });
 
+  it("keeps inferred live providers when scenarios require additional plugins", () => {
+    const cfg = buildQaGatewayConfig({
+      bind: "loopback",
+      gatewayPort: 18789,
+      gatewayToken: "token",
+      workspaceDir: "/tmp/qa-workspace",
+      providerMode: "live-frontier",
+      primaryModel: "openai/gpt-5.6-luna",
+      alternateModel: "anthropic/claude-sonnet-4-6",
+      imageGenerationModel: null,
+      enabledPluginIds: ["active-memory"],
+      ...createQaChannelTransportParams(),
+    });
+
+    expect(cfg.plugins?.allow).toEqual([
+      "acpx",
+      "memory-core",
+      "qa-lab",
+      "active-memory",
+      "openai",
+      "anthropic",
+      "qa-channel",
+    ]);
+    expect(cfg.plugins?.entries?.["active-memory"]).toEqual({ enabled: true });
+    expect(cfg.plugins?.entries?.openai).toEqual({ enabled: true });
+    expect(cfg.plugins?.entries?.anthropic).toEqual({ enabled: true });
+  });
+
   it("keeps forced Codex cells free of OpenClaw request params", () => {
     const cfg = buildQaGatewayConfig({
       bind: "loopback",

--- a/extensions/qa-lab/src/qa-gateway-config.ts
+++ b/extensions/qa-lab/src/qa-gateway-config.ts
@@ -11,6 +11,7 @@ import {
 } from "./model-selection.js";
 import { getQaProvider } from "./providers/index.js";
 import { DEFAULT_QA_PROVIDER_MODE } from "./providers/index.js";
+import { QA_FRONTIER_PROVIDER_IDS } from "./providers/live-frontier/catalog.js";
 import type { QaThinkingLevel } from "./qa-thinking.js";
 import type { QaTransportGatewayConfig } from "./qa-transport.js";
 import type { RuntimeId } from "./runtime-parity.js";
@@ -27,6 +28,7 @@ export const DEFAULT_QA_CONTROL_UI_ALLOWED_ORIGINS = Object.freeze([
 export const QA_BASE_RUNTIME_PLUGIN_IDS = Object.freeze(["acpx", "memory-core"]);
 export const QA_CODEX_OPENAI_CATALOG_BASE_URL = "https://api.openai.com/v1";
 const QA_LAB_PLUGIN_ID = "qa-lab";
+const QA_DIRECT_FRONTIER_PLUGIN_IDS = new Set<string>(QA_FRONTIER_PROVIDER_IDS);
 
 export function mergeQaControlUiAllowedOrigins(extraOrigins?: string[]) {
   const normalizedExtra = (extraOrigins ?? [])
@@ -114,12 +116,15 @@ export function buildQaGatewayConfig(params: {
       .map((pluginId) => pluginId.trim())
       .filter((pluginId) => pluginId.length > 0),
   );
+  // Only canonical frontier provider ids are also plugin ids. Provider aliases
+  // and custom providers rely on the explicit owner mapping supplied above.
+  const inferredProviderPluginIds = selectedProviderIds.filter((providerId) =>
+    QA_DIRECT_FRONTIER_PLUGIN_IDS.has(providerId),
+  );
   const providerSelectedPluginIds = usesCodexMockAppServer
     ? uniqueStrings([...configuredPluginIds, ...selectedProviderIds])
     : provider.usesModelProviderPlugins
-      ? uniqueStrings(
-          (params.enabledPluginIds?.length ?? 0) > 0 ? configuredPluginIds : selectedProviderIds,
-        )
+      ? uniqueStrings([...configuredPluginIds, ...inferredProviderPluginIds])
       : configuredPluginIds;
   // A forced Codex cell must stage its harness even when the provider owner is
   // selected independently; otherwise its QA-only sandbox never takes effect.

--- a/extensions/qa-lab/src/scenario-catalog-compaction.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-compaction.test.ts
@@ -73,7 +73,7 @@ describe("qa compaction scenario catalog", () => {
       "OpenClaw performs exactly one successful write, one causal continuation, and returns the exact file content and final marker.",
     );
     expect(scenario.successCriteria).toContain(
-      "OpenClaw proves session-memory.pruning by retaining tail blocks 11..15 while pruning marker block 10.",
+      "OpenClaw proves session-memory.pruning by retaining a nonempty contiguous suffix ending at block 15 while pruning marker block 10.",
     );
     expect(scenario.successCriteria).toContain(
       "The Codex runtime-pair cell reports a known harness gap before gateway, session, or provider work and makes no compaction coverage claim.",
@@ -158,7 +158,9 @@ describe("qa compaction scenario catalog", () => {
     );
     expect(flow).toContain("!String(writeRequest.allInputText ?? '').includes(config.bulkyMarker)");
     expect(flow).toContain("JSON.stringify(overflowEvidence.tailBlocks)");
-    expect(flow).toContain("JSON.stringify(['11', '12', '13', '14', '15'])");
+    expect(flow).toContain("writeEvidence.tailBlocks.length > 0");
+    expect(flow).toContain("!writeEvidence.tailBlocks.includes('10')");
+    expect(flow).toContain("16 - writeEvidence.tailBlocks.length + index");
     expect(serializedScenario).not.toContain("remote-compaction");
     expect(serializedScenario).not.toContain("remoteCompaction");
     expect(flow).not.toContain("JSON.stringify(overflowRequest)");

--- a/extensions/qa-lab/src/scenario-catalog-compaction.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-compaction.test.ts
@@ -98,6 +98,14 @@ describe("qa compaction scenario catalog", () => {
         },
       },
     ]);
+    const runtimeGuard = scenario.execution.flow?.steps[0]?.actions[1] as
+      | Record<string, unknown>
+      | undefined;
+    expect(runtimeGuard?.assert).toMatchObject({
+      expr: expect.stringContaining(
+        "(env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME ?? 'openclaw') === 'openclaw'",
+      ),
+    });
 
     const knownGapIndex = flow.indexOf(knownGap);
     const gatewayWorkIndex = flow.indexOf('"call":"waitForGatewayHealthy"');

--- a/qa/scenarios/channels/matrix-room-generated-image-delivery.yaml
+++ b/qa/scenarios/channels/matrix-room-generated-image-delivery.yaml
@@ -2,9 +2,17 @@ title: Matrix generated images deliver as real image attachments while streaming
 scenario:
   id: matrix-room-generated-image-delivery
   surface: channels
+  plugins:
+    - openai
   coverage:
     primary:
       - matrix.media-and-rich-content
+  gatewayConfigPatch:
+    agents:
+      defaults:
+        mediaModels:
+          image:
+            primary: openai/gpt-image-1
   execution:
     kind: flow
     channel: matrix

--- a/qa/scenarios/channels/matrix-voice-preflight-mention.yaml
+++ b/qa/scenarios/channels/matrix-voice-preflight-mention.yaml
@@ -2,6 +2,8 @@ title: Matrix voice notes can trigger mention gating through transcription
 scenario:
   id: matrix-voice-preflight-mention
   surface: channels
+  plugins:
+    - openai
   coverage:
     primary:
       - matrix.media-and-rich-content

--- a/qa/scenarios/runtime/compaction-retry-mutating-tool.yaml
+++ b/qa/scenarios/runtime/compaction-retry-mutating-tool.yaml
@@ -13,7 +13,7 @@ scenario:
   successCriteria:
     - One coded over-threshold provider overflow produces one persisted OpenClaw overflow compaction and one compacted retry retaining durable current context.
     - OpenClaw performs exactly one successful write, one causal continuation, and returns the exact file content and final marker.
-    - OpenClaw proves session-memory.pruning by retaining tail blocks 11..15 while pruning marker block 10.
+    - OpenClaw proves session-memory.pruning by retaining a nonempty contiguous suffix ending at block 15 while pruning marker block 10.
     - OpenClaw records one overflow-retry checkpoint whose branch preserves the independent pre-compaction assistant marker.
     - The Codex runtime-pair cell reports a known harness gap before gateway, session, or provider work and makes no compaction coverage claim.
   docsRefs:
@@ -180,9 +180,9 @@ flow:
             message:
               expr: "`OpenClaw retry did not prune marker block 10: ${JSON.stringify({ overflow: overflowEvidence, write: writeEvidence })}`"
         - assert:
-            expr: "JSON.stringify(overflowEvidence.tailBlocks) === JSON.stringify(Array.from({ length: 16 }, (_, index) => String(index).padStart(2, '0'))) && JSON.stringify(writeEvidence.tailBlocks) === JSON.stringify(['11', '12', '13', '14', '15'])"
+            expr: "JSON.stringify(overflowEvidence.tailBlocks) === JSON.stringify(Array.from({ length: 16 }, (_, index) => String(index).padStart(2, '0'))) && writeEvidence.tailBlocks.length > 0 && !writeEvidence.tailBlocks.includes('10') && JSON.stringify(writeEvidence.tailBlocks) === JSON.stringify(Array.from({ length: writeEvidence.tailBlocks.length }, (_, index) => String(16 - writeEvidence.tailBlocks.length + index).padStart(2, '0')))"
             message:
-              expr: "`OpenClaw tail retention did not prove causal pruning of block 10: ${JSON.stringify({ overflow: overflowEvidence, write: writeEvidence })}`"
+              expr: "`OpenClaw tail retention did not keep a contiguous suffix ending at block 15 while pruning block 10: ${JSON.stringify({ overflow: overflowEvidence, write: writeEvidence })}`"
         - assert:
             expr: "writeRequest.rawByteLength < config.overflowThresholdBytes && writeRequest.rawByteLength < overflowRequest.rawByteLength"
             message:

--- a/qa/scenarios/runtime/compaction-retry-mutating-tool.yaml
+++ b/qa/scenarios/runtime/compaction-retry-mutating-tool.yaml
@@ -57,7 +57,7 @@ flow:
               - throw:
                   expr: "new qaErrors.QaSuiteScenarioSkipError('known-harness-gap compaction-retry-mutating-tool: provider-error recovery does not invoke Codex native compaction; native token-threshold compaction needs a separate scenario.')"
         - assert:
-            expr: "env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME === 'openclaw' && env.providerMode === 'mock-openai' && Boolean(env.mock)"
+            expr: "(env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME ?? 'openclaw') === 'openclaw' && env.providerMode === 'mock-openai' && Boolean(env.mock)"
             message: compaction overflow injection requires the mock-openai OpenClaw runtime
         - call: waitForGatewayHealthy
           args:


### PR DESCRIPTION
## What Problem This Solves

Fixes three Beta release-validation failures caused by stale or incomplete QA scenario contracts:

- Matrix generated-image delivery did not enable the OpenAI image provider or select an image model.
- Matrix voice preflight configured OpenAI transcription without loading the OpenAI plugin.
- Compaction retry required exactly five retained tail blocks even though the runtime correctly retained a smaller suffix under the current token budget.

## Why This Change Was Made

The Matrix scenarios now declare the provider and image-model setup they require. QA gateway config retains explicit plugins plus provider plugins inferred from configured models. The compaction scenario checks the real invariant: block 10 is pruned and retry keeps a nonempty contiguous suffix ending at block 15.

## User Impact

Release validation no longer reports product failures for missing scenario setup or for valid compaction suffix sizes. Product runtime is unchanged.

## Evidence

- Exact PR head: `0ae194ddc13ae3b7b798639d8d381cda9ac947bd`.
- Focused QA catalog, gateway-config, and Matrix-flow tests: 36 passed.
- Fresh autoreview: clean, confidence 0.98.
- Exact-head delegated full `check:changed`: https://github.com/openclaw/openclaw/actions/runs/30937211854
- Exact-head hosted CI and `openclaw/ci-gate`: https://github.com/openclaw/openclaw/actions/runs/30937183379
- Exact release QA proof: https://github.com/openclaw/openclaw/actions/runs/30938114463
  - Matrix job: https://github.com/openclaw/openclaw/actions/runs/30938114463/job/92090029360
  - aggregate artifact `qa-live-matrix-30938114463-1`: 92 total, 92 passed, 0 failed, 0 skipped;
  - every evidence ref resolved to exact head `0ae194ddc13ae3b7b798639d8d381cda9ac947bd`;
  - `matrix-room-generated-image-delivery` passed with an `m.image` event for `qa-lighthouse.png`;
  - `matrix-voice-preflight-mention` passed.
- OpenAI candidate parity: 12/12 passed in the same exact release run.
- Direct dependency inspection against pinned `@openai/codex` 0.146.0 confirms explicit `thread/compact/start` submits `Op::Compact`, while native automatic compaction is token/context-budget driven. The scenario's explicit Codex skip is intentional.

No changelog entry: this repairs release QA contracts and does not change shipped product behavior.

Punchcard-Session: amber-workshop-river-yr
