### PR TITLE
fix(chutes): report accurate context windows for sparse catalog rows

### DIFF
--- a/extensions/chutes/models.test.ts
+++ b/extensions/chutes/models.test.ts
@@ -238,6 +238,41 @@ describe("chutes-models", () => {
     });
   });
 
+  it("selects Chutes context limits in provider precedence order", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      jsonResponse({
+        data: [
+          {
+            id: "provider/context-primary",
+            context_length: 131072,
+            max_model_len: 262144,
+          },
+          { id: "provider/serving-fallback", max_model_len: 131072 },
+          {
+            id: "provider/invalid-primary",
+            context_length: -1,
+            max_model_len: 131072,
+          },
+          {
+            id: "provider/default-control",
+            context_length: 0,
+            max_model_len: 0,
+          },
+        ],
+      }),
+    );
+
+    await withLiveChutesDiscovery(mockFetch, async () => {
+      const models = await discoverChutesModels("context-limit-precedence");
+      expect(models.map(({ id, contextWindow }) => ({ id, contextWindow }))).toEqual([
+        { id: "provider/context-primary", contextWindow: 131072 },
+        { id: "provider/serving-fallback", contextWindow: 131072 },
+        { id: "provider/invalid-primary", contextWindow: 131072 },
+        { id: "provider/default-control", contextWindow: 128000 },
+      ]);
+    });
+  });
+
   it("falls back from malformed live token metadata", async () => {
     const mockFetch = vi.fn().mockResolvedValue(
       jsonResponse({

--- a/extensions/chutes/models.ts
+++ b/extensions/chutes/models.ts
@@ -50,6 +50,7 @@ interface ChutesModelEntry {
   supported_features?: string[];
   input_modalities?: string[];
   context_length?: number;
+  max_model_len?: number;
   max_output_length?: number;
   pricing?: {
     prompt?: number;
@@ -93,7 +94,10 @@ function projectChutesModels(rows: readonly unknown[]): ModelDefinitionConfig[] 
         cacheRead: entry.pricing?.input_cache_read || 0,
         cacheWrite: 0,
       },
-      contextWindow: asPositiveSafeInteger(entry.context_length) ?? CHUTES_DEFAULT_CONTEXT_WINDOW,
+      contextWindow:
+        asPositiveSafeInteger(entry.context_length) ??
+        asPositiveSafeInteger(entry.max_model_len) ??
+        CHUTES_DEFAULT_CONTEXT_WINDOW,
       maxTokens: asPositiveSafeInteger(entry.max_output_length) ?? CHUTES_DEFAULT_MAX_TOKENS,
       compat: { supportsUsageInStreaming: false },
     });


### PR DESCRIPTION
Related: #118868

## What Problem This Solves

Fixes an issue where Chutes users could have models registered with a smaller context window when a live catalog row omitted `context_length` but provided a valid `max_model_len`. The current public catalog exposes two such models with `max_model_len=131072`, while OpenClaw registered both with the generic `128000` fallback.

## Why This Change Was Made

The Chutes-owned live catalog projection now selects the first valid value in this order: `context_length`, `max_model_len`, then the existing `128000` default. Keeping `context_length` first preserves the provider's explicit product-level limit when both fields are present, while `max_model_len` supplies the serving limit only when that primary field is unavailable or invalid.

## User Impact

Chutes model discovery now preserves the provider's available context capacity for sparse catalog entries. Existing rows with `context_length` keep their current behavior, and malformed or non-positive metadata still falls back safely.

## Evidence

- Regression-first proof: the new precedence test failed before the production change because the missing/invalid `context_length` cases registered `128000` instead of `131072`.
- `node scripts/run-vitest.mjs extensions/chutes/models.test.ts` — 14 tests passed.
- All four Chutes test files through `scripts/run-vitest.mjs` — 27 tests passed.
- `node scripts/run-tsgo.mjs -p extensions/chutes/tsconfig.json --noEmit` — passed.
- `oxfmt --check`, targeted oxlint, and `git diff --check` — passed.
- Chutes documents `max_model_len` as the [maximum sequence length](https://github.com/chutesai/chutes-docs/blob/5cbd19e7962adf5cf1ee1b2edd887690a521d179/src/templates/vllm.md#L100-L106), and its catalog aggregation preserves the instance value by [excluding it from metadata overrides](https://github.com/chutesai/chutes-api/blob/49abc1d6a995df4ab35b377bb1d18f91ba31208f/api/chute/util.py#L2165-L2188).
- Production LOC: +5/-1; tests: +35/-0. The production growth declares and consumes one provider-published contract field at its owning projection boundary.

Exact-head live proof (`704192488b3cffd1e2b64c2d39129ef3c756e239`), using the public `https://llm.chutes.ai/v1/models` response and the production `discoverChutesModels()` path:

```text
BEFORE
unsloth/Mistral-Nemo-Instruct-2407-TEE: context_length=null, max_model_len=131072, registered=128000
Nemotron-3-Nano-Omni-30B-TEE: context_length=null, max_model_len=131072, registered=128000
allServingLimitsPreserved=false

AFTER
unsloth/Mistral-Nemo-Instruct-2407-TEE: context_length=null, max_model_len=131072, registered=131072
Nemotron-3-Nano-Omni-30B-TEE: context_length=null, max_model_len=131072, registered=131072
allServingLimitsPreserved=true

CONTROL
google/gemma-4-31B-turbo-TEE: context_length=131072, max_model_len=262144, registered=131072
contextLengthPriorityPreserved=true
```
