### PR TITLE
fix(doctor): list actual removed ids in stale heartbeat/modelByChannel changes

### DIFF
--- a/src/commands/doctor/shared/stale-plugin-config.test.ts
+++ b/src/commands/doctor/shared/stale-plugin-config.test.ts
@@ -377,6 +377,47 @@ describe("doctor stale plugin config helpers", () => {
     expect(result.config.agents?.list?.[1]?.heartbeat).toEqual({ target: "telegram" });
   });
 
+  it("lists only the actually removed ids in heartbeat and modelByChannel change entries", () => {
+    const result = maybeRepairStalePluginConfig({
+      plugins: {
+        allow: ["missing-a", "missing-b"],
+      },
+      channels: {
+        "missing-a": {
+          enabled: true,
+          token: "stale-a",
+        },
+        "missing-b": {
+          enabled: true,
+          token: "stale-b",
+        },
+        modelByChannel: {
+          openai: {
+            "missing-a": "openai/gpt-5.4",
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          heartbeat: {
+            target: "missing-a",
+            every: "30m",
+          },
+        },
+      },
+    } as OpenClawConfig);
+
+    expect(result.changes).toEqual([
+      "- plugins.allow: removed 2 stale plugin ids (missing-a, missing-b)",
+      "- channels: removed 2 stale channel configs (missing-a, missing-b)",
+      "- agents heartbeat: removed 1 stale heartbeat target (missing-a)",
+      "- channels.modelByChannel: removed 1 stale channel model override (missing-a)",
+    ]);
+    expect(result.config.channels?.["missing-a"]).toBeUndefined();
+    expect(result.config.channels?.["missing-b"]).toBeUndefined();
+    expect(result.config.agents?.defaults?.heartbeat).toEqual({ every: "30m" });
+  });
+
   it("does not remove unknown channel config without stale plugin evidence", () => {
     const cfg = {
       channels: {

--- a/src/commands/doctor/shared/stale-plugin-config.ts
+++ b/src/commands/doctor/shared/stale-plugin-config.ts
@@ -452,15 +452,21 @@ export function maybeRepairStalePluginConfig(
       `- channels: removed ${channelIds.length} stale channel config${channelIds.length === 1 ? "" : "s"} (${channelIds.join(", ")})`,
     );
     const heartbeatCount = hits.filter((hit) => hit.surface === "heartbeat").length;
+    const heartbeatIds = [
+      ...new Set(hits.filter((hit) => hit.surface === "heartbeat").map((hit) => hit.pluginId)),
+    ];
     if (heartbeatCount > 0) {
       changes.push(
-        `- agents heartbeat: removed ${heartbeatCount} stale heartbeat target${heartbeatCount === 1 ? "" : "s"} (${channelIds.join(", ")})`,
+        `- agents heartbeat: removed ${heartbeatCount} stale heartbeat target${heartbeatCount === 1 ? "" : "s"} (${heartbeatIds.join(", ")})`,
       );
     }
     const modelByChannelCount = hits.filter((hit) => hit.surface === "modelByChannel").length;
+    const modelByChannelIds = [
+      ...new Set(hits.filter((hit) => hit.surface === "modelByChannel").map((hit) => hit.pluginId)),
+    ];
     if (modelByChannelCount > 0) {
       changes.push(
-        `- channels.modelByChannel: removed ${modelByChannelCount} stale channel model override${modelByChannelCount === 1 ? "" : "s"} (${channelIds.join(", ")})`,
+        `- channels.modelByChannel: removed ${modelByChannelCount} stale channel model override${modelByChannelCount === 1 ? "" : "s"} (${modelByChannelIds.join(", ")})`,
       );
     }
   }


### PR DESCRIPTION
## Summary

`fix(doctor): list actual removed ids in stale heartbeat/modelByChannel changes`

## What Problem This Solves

When `openclaw doctor --fix` auto-repairs stale plugin config, `maybeRepairStalePluginConfig` returns a human-readable `changes` report (one line per config surface) that is shown to the user to explain what was removed. For the `heartbeat` and `modelByChannel` surfaces the report counted the hits **per surface** but listed **all stale channel ids** in parentheses.

Concretely: with two dangling channels `missing-a` and `missing-b`, where only `missing-a` was the heartbeat target and only `missing-a` had a `channels.modelByChannel` override, the repair report printed:

```
- agents heartbeat: removed 1 stale heartbeat target (missing-a, missing-b)
- channels.modelByChannel: removed 1 stale channel model override (missing-a, missing-b)
```

The count says 1, but the parenthesized list names `missing-b` — a channel that was never a heartbeat target and never had a model override. The user is told doctor removed a heartbeat target / model override for a channel that had neither, making the report internally contradictory and untrustworthy exactly when the user is auditing what an automatic repair touched.

Blast radius: any `doctor --fix` run where ≥2 stale channel configs exist and the heartbeat/modelByChannel surfaces reference only a strict subset of them. The underlying repair itself is correct — only the report text is wrong.

**Code evidence**: at `src/commands/doctor/shared/stale-plugin-config.ts:457` (pre-fix), the heartbeat change entry reuses the channel-surface id list:

```ts
const heartbeatCount = hits.filter((hit) => hit.surface === "heartbeat").length;
if (heartbeatCount > 0) {
  changes.push(
    `- agents heartbeat: removed ${heartbeatCount} stale heartbeat target${heartbeatCount === 1 ? "" : "s"} (${channelIds.join(", ")})`,
  );
}
```

and the identical pattern at `src/commands/doctor/shared/stale-plugin-config.ts:463` for `modelByChannel`. Every other change entry (`plugins.allow`, `plugins.deny`, `plugins.entries`, `plugins.slots`, `channels`) lists exactly the ids of its own hits; these two are the only ones that borrow another surface's id list.

Minimal reproduction: config with `plugins.allow: [missing-a, missing-b]`, dangling `channels."missing-a"` and `channels."missing-b"`, `agents.defaults.heartbeat.target: "missing-a"`, and `channels.modelByChannel.openai: { "missing-a": "openai/gpt-5.4" }` — see Real Behavior Proof below.

## Root Cause

- Bug introduced by commit `edb3e848986084b66e1187b83333c469a2a96deb` (2026-04-27, `fix: clean stale plugin channel config`). Verified via the GitHub API: the file at that commit contains both buggy lines (`channelIds.join(", ")` in the heartbeat and modelByChannel entries), while the file at the previous commit touching this path (`1a193b2d9666`, 2026-04-26) has no heartbeat/modelByChannel handling at all. (The originally suspected commit `ae336d1602`, 2026-03-23, introduced the stale-allowlist repair but has no heartbeat branch — the dependent-channel-config repair that added these two surfaces came one month later.)
- Violated invariant: each `changes` entry is built from the hits of **its own surface** (`hits.filter(h => h.surface === X)`), so the count and the id list always describe the same set. The heartbeat/modelByChannel entries broke that invariant: the count is filtered per surface, but the id list is the enclosing `channelIds` array — the union of **all** stale channel ids, computed one scope up for the `channels` entry.
- Trigger condition: `channelIds.length > 1` (more than one dangling channel config) **and** the heartbeat targets / modelByChannel overrides reference only a proper subset of those channels. With a single stale channel, or when every stale channel is also a heartbeat target, the list happens to coincide with the actual removals and the bug is invisible.

## Why This Fix

- Option A: re-derive the ids from the repaired config (diff old vs. new heartbeat targets / model overrides) — rejected: the repair already mutates via `removeDanglingChannelReferences` and the scan hits already carry the exact ids; re-deriving duplicates logic and can drift from what the scanner considered stale.
- Option B (chosen): collect the deduplicated ids from the surface's own hits, mirroring how the count is computed:

```ts
const heartbeatIds = [
  ...new Set(hits.filter((hit) => hit.surface === "heartbeat").map((hit) => hit.pluginId)),
];
```

  Same filter the count uses, so count and list can never disagree again by construction. The `Set` also fixes a secondary case the old code got wrong even without the cross-surface leak: the same channel targeted by both `agents.defaults.heartbeat.target` and a codex-route agent heartbeat produced 2 hits but would now list the id once instead of twice.
- Option C: drop the parenthesized id list for these two surfaces entirely — rejected: the other five change entries all name the affected ids, and the ids are the most useful part of the report for auditing an automatic mutation.

The fix is two local derivations plus two string substitutions inside the existing `if (channelIds.length > 0)` block; no repair behavior, ordering, or message wording changes beyond the id list.

## User Impact

- Affected operations: `openclaw doctor --fix` (and any caller of `maybeRepairStalePluginConfig`) when it removes dangling channel configs while heartbeat targets or modelByChannel overrides reference only some of those channels.
- Before: the report could claim `removed 1 stale heartbeat target (missing-a, missing-b)` — naming channels that never had a heartbeat target / model override, contradicting its own count and misrepresenting what the automatic repair changed.
- After: the same run reports `removed 1 stale heartbeat target (missing-a)` and `removed 1 stale channel model override (missing-a)`; count and id list always describe the same set, matching the behavior of every other change entry.
- Behavior change: only the report text changes. What gets removed from the config is byte-identical before and after (verified in the proof: the repaired config is the same; only the `changes` lines differ).

## Real Behavior Proof

Setup: the **real** `maybeRepairStalePluginConfig` imported directly from `src/commands/doctor/shared/stale-plugin-config.ts` via `node --import tsx proof.mjs`, driven against the real bundled plugin manifest registry of this repo (discord/voice-call/openai resolve as known; nothing in the module under test is mocked). The config carries two stale channels but a heartbeat target and a modelByChannel override for only one of them.

### Before (on main)

```bash
$ node --import tsx proof.mjs
changes reported by maybeRepairStalePluginConfig:
  - plugins.allow: removed 2 stale plugin ids (missing-a, missing-b)
  - channels: removed 2 stale channel configs (missing-a, missing-b)
  - agents heartbeat: removed 1 stale heartbeat target (missing-a, missing-b)
  - channels.modelByChannel: removed 1 stale channel model override (missing-a, missing-b)

actual state of repaired config:
  heartbeat target still present: false
  modelByChannel.openai[missing-a] still present: false
  channels keys after repair: []

FAIL: heartbeat change line claims 1 removed target but lists ids that were never heartbeat targets: missing-b
FAIL: modelByChannel change line claims 1 removed override but lists ids with no model override: missing-b
exit code: 1
```

### After (with fix)

```bash
$ node --import tsx proof.mjs
changes reported by maybeRepairStalePluginConfig:
  - plugins.allow: removed 2 stale plugin ids (missing-a, missing-b)
  - channels: removed 2 stale channel configs (missing-a, missing-b)
  - agents heartbeat: removed 1 stale heartbeat target (missing-a)
  - channels.modelByChannel: removed 1 stale channel model override (missing-a)

actual state of repaired config:
  heartbeat target still present: false
  modelByChannel.openai[missing-a] still present: false
  channels keys after repair: []

PASS: heartbeat/modelByChannel change lines list only the ids actually removed from each surface (missing-a).
exit code: 0
```

Note the repaired config is identical in both runs — only the report text was wrong.

## Evidence

- Focused regression: `node node_modules/vitest/vitest.mjs run src/commands/doctor/shared/stale-plugin-config.test.ts` — 18 passed (17 existing + 1 new: `lists only the actually removed ids in heartbeat and modelByChannel change entries`).
- Real behavior proof (full terminal output in the Real Behavior Proof section above): the real `maybeRepairStalePluginConfig` run via `node --import tsx proof.mjs` against the repo's real plugin manifest registry, with two stale channels but a heartbeat target and modelByChannel override for only one of them.
  - Before (on main): the report printed `- agents heartbeat: removed 1 stale heartbeat target (missing-a, missing-b)` and `- channels.modelByChannel: removed 1 stale channel model override (missing-a, missing-b)` — count says 1 but the id list names a channel that had neither (exit code 1).
  - After (with fix): the same run prints `- agents heartbeat: removed 1 stale heartbeat target (missing-a)` and `- channels.modelByChannel: removed 1 stale channel model override (missing-a)`; the repaired config is byte-identical in both runs, only the report text changes (exit code 0).

## Tests and Validation

- `node node_modules/vitest/vitest.mjs run src/commands/doctor/shared/stale-plugin-config.test.ts` — 18 passed (17 existing + 1 new: `lists only the actually removed ids in heartbeat and modelByChannel change entries`)
- Manual verification (the proof above):
  1. On main, the heartbeat/modelByChannel change lines list all stale channel ids while counting only their own surface's removals (exit 1, FAIL).
  2. With the fix, both lines list exactly the deduplicated ids of their own surface's hits (exit 0, PASS), and the repaired config is unchanged.



Punchcard-Session: golden-lantern-river-ah
