### PR TITLE
fix(ui): clear stale PR chips when switching to a session without a snapshot

### DIFF
--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -309,6 +309,7 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
   protected sessionPullRequests: ControlUiSessionPullRequest[] = [];
   protected sessionPullRequestsBranch: ControlUiSessionBranch | undefined;
   protected sessionPullRequestsRateLimited = false;
+  protected sessionPullRequestsKey: string | undefined;
   protected sessionPullRequestsExpanded = false;
   protected dismissedSessionPullRequestIds: ReadonlySet<string> = new Set();
   protected readonly dismissedWorkspaceConflictRefs = new Map<string, string>();

--- a/ui/src/pages/chat/chat-pane-pull-requests.test.ts
+++ b/ui/src/pages/chat/chat-pane-pull-requests.test.ts
@@ -77,6 +77,35 @@ describe("chat pane pushed pull request state", () => {
     expect(pane.sessionPullRequests).toEqual([expect.objectContaining({ number: 2 })]);
   });
 
+  it("clears the previous session's PR chips when the new session's snapshot is unavailable", async () => {
+    const { pane, state, emitGatewayEvent } = createPullRequestPane({
+      capturePullRequestEpoch: vi.fn(() => Symbol("pr-refresh")),
+      setPullRequestSummary: vi.fn(),
+    } as unknown as SessionCapability);
+
+    await pane.refreshSessionPullRequests();
+    emitSnapshot(emitGatewayEvent, "agent:main:current", {
+      pullRequests: [pullRequest(1, "open")],
+      rateLimited: false,
+      status: "ready",
+    });
+    await pane.refreshSessionPullRequests();
+    expect(pane.sessionPullRequests).toHaveLength(1);
+
+    state.sessionKey = "agent:main:other";
+    await pane.refreshSessionPullRequests();
+    emitSnapshot(emitGatewayEvent, "agent:main:other", {
+      pullRequests: [],
+      rateLimited: false,
+      status: "unavailable",
+    });
+    await pane.refreshSessionPullRequests();
+
+    // The unavailable snapshot must preserve the new session's own (empty)
+    // state, not keep rendering the previous session's chips.
+    expect(pane.sessionPullRequests).toEqual([]);
+  });
+
   it("subscribes and publishes pushed live PR state", async () => {
     const epoch = Symbol("pr-refresh");
     const setPullRequestSummary = vi.fn();

--- a/ui/src/pages/chat/chat-pane-session.ts
+++ b/ui/src/pages/chat/chat-pane-session.ts
@@ -123,6 +123,7 @@ export abstract class ChatPaneSession extends ChatPaneSharing {
       this.sessionPullRequests = [];
       this.sessionPullRequestsBranch = undefined;
       this.sessionPullRequestsRateLimited = false;
+      this.sessionPullRequestsKey = undefined;
       this.requestUpdate();
       return;
     }
@@ -132,6 +133,7 @@ export abstract class ChatPaneSession extends ChatPaneSharing {
       this.sessionPullRequests = [];
       this.sessionPullRequestsBranch = undefined;
       this.sessionPullRequestsRateLimited = false;
+      this.sessionPullRequestsKey = undefined;
       this.requestUpdate();
       return;
     }
@@ -147,15 +149,23 @@ export abstract class ChatPaneSession extends ChatPaneSharing {
       store.refresh(pullRequestKey);
     }
     const result = store.get(pullRequestKey);
-    if (
-      !result ||
-      result.status === "unavailable" ||
-      !this.isConnectionScopeCurrent(scope) ||
-      sessionKey !== scope.state.sessionKey
-    ) {
+    const scopeCurrent =
+      this.isConnectionScopeCurrent(scope) && sessionKey === scope.state.sessionKey;
+    if (!result || result.status === "unavailable" || !scopeCurrent) {
+      // Chips still showing a previous session must not linger while the new
+      // session's snapshot is missing or unavailable. Only clear on a stable
+      // scope so a mid-refresh session switch cannot wipe valid state.
+      if (scopeCurrent && this.sessionPullRequestsKey !== sessionKey) {
+        this.sessionPullRequests = [];
+        this.sessionPullRequestsBranch = undefined;
+        this.sessionPullRequestsRateLimited = false;
+        this.sessionPullRequestsKey = sessionKey;
+        this.requestUpdate();
+      }
       return;
     }
     this.sessionPullRequests = result.pullRequests;
+    this.sessionPullRequestsKey = sessionKey;
     if (!result.rateLimited || result.pullRequests.length > 0) {
       scope.context.sessions.setPullRequestSummary(
         sessionKey,
@@ -174,6 +184,7 @@ export abstract class ChatPaneSession extends ChatPaneSharing {
     this.sessionPullRequests = [];
     this.sessionPullRequestsBranch = undefined;
     this.sessionPullRequestsRateLimited = false;
+    this.sessionPullRequestsKey = undefined;
     this.sessionPullRequestsExpanded = false;
     this.dismissedSessionPullRequestIds = new Set();
   }


### PR DESCRIPTION
## Summary

`fix(ui): clear stale PR chips when switching to a session without a snapshot`

## What Problem This Solves

The chat pane renders per-session pull-request chips (cards) from a pushed session-PR store. `ChatPaneSession.refreshSessionPullRequests()` applies chips only when the store holds a **usable** snapshot for the pane's current session. When the pane's `sessionKey` moves to a session whose snapshot is missing or `unavailable` — e.g. the new session was never subscribed, the gateway lost the backend PR source, or the pushed delta has not arrived yet — the method used to return early **without touching the rendered chips**. The previous session's PR cards kept rendering on the newly selected session for as long as the snapshot stayed unavailable, attributing PRs to a conversation they do not belong to.

Blast radius: any Control UI user switching between sessions where the target session has no ready PR snapshot. The wrong PR number/branch/state is shown against the wrong session, and clicking it navigates away from a session that has nothing to do with that PR.

**Code evidence**: at `ui/src/pages/chat/chat-pane-session.ts:151-156` (main, pre-fix), the missing/unavailable path returns while leaving `this.sessionPullRequests` untouched:

```ts
const result = store.get(pullRequestKey);
if (
  !result ||
  result.status === "unavailable" ||
  !this.isConnectionScopeCurrent(scope) ||
  sessionKey !== scope.state.sessionKey
) {
  return; // <- chips of the previous session keep rendering
}
```

Note that the other two guards in the same method (method-not-advertised at line ~113, catalog/empty key at line ~131) already cleared `this.sessionPullRequests` on the way out — only this third early-return forgot to.

Minimal reproduction: with session A showing PR #1, point the pane at session B and push B's snapshot as `status: "unavailable"`, then refresh — see Real Behavior Proof below.

## Root Cause

- Bug introduced by commit `662abec754` (2026-07-29, `feat(gateway): push session PR indicators to subscribed clients (#115643)`), which moved the pane from a request/response fetch to the pushed store model (`sessionPullRequestsForGateway(...).get(...)`) and added the `!result || result.status === "unavailable"` early-return in exactly the shape quoted above. (The earlier split commit `3e44b5f5dd`, 2026-07-24, still used the request/response form in `chat-pane-suggestions.ts`, whose only early return guarded stale in-flight requests — a different, correct guard.)
- Violated invariant: the pane assumes `this.sessionPullRequests` always describes `state.sessionKey`. The store-based refresh broke that assumption: ownership of the rendered chips was implicit, so a refresh for session B that found no usable snapshot left session A's chips in place — the pane had no record of which session the chips belonged to and therefore could not tell they were stale.
- Trigger condition: `state.sessionKey` points at session B while session A's chips are rendered, and `refreshSessionPullRequests()` runs (pushed store event, hydration after transcript load, or a manual refresh) with B's store entry absent or `status: "unavailable"`.

## Why This Fix

- Option A: clear the chips unconditionally on every missing/unavailable snapshot — rejected: while a refresh is in flight across a session switch, the scope/session can change mid-await; an unconditional clear could wipe valid chips that a concurrent refresh just applied for the new session (the guard must not fire when `sessionKey !== scope.state.sessionKey` or the connection scope moved on).
- Option B: clear chips from every caller that might switch sessions (`switchPaneSession`, reconnection handlers, etc.) — rejected: spreads the invariant across call sites and still misses event-driven refreshes; `switchPaneSession` already calls `resetSessionPullRequests()` yet the stale render still occurred via the refresh path.
- Option C (chosen): track ownership explicitly with a new `sessionPullRequestsKey` field (`ui/src/pages/chat/chat-pane-base.ts:312`) that records which session the rendered chips belong to. On a missing/unavailable snapshot, clear the chips only when the scope is stable **and** the chips belong to a different session (`chat-pane-session.ts:158-164`); on success the key is updated alongside the chips. This keeps the invariant local to the one method that maintains it and cannot wipe valid state mid-switch.

## User Impact

- Affected operations: switching chat sessions in the Control UI when the target session's PR snapshot is missing or unavailable (unsubscribed session, backend PR source down, snapshot not yet pushed).
- Before: the previous session's PR chips (number, branch, state) stayed rendered on the newly opened session until a usable snapshot happened to arrive.
- After: the chips are cleared as soon as the pane knows the new session has no usable snapshot; they reappear only when the new session's own snapshot becomes ready.
- Behavior change: a session with an unavailable PR snapshot now shows no PR chips instead of another session's chips — strictly less misleading; no valid state is lost because the store re-renders chips on the next ready snapshot.

## Real Behavior Proof

Setup: the **real** `openclaw-chat-pane` custom element (`ui/src/pages/chat/chat-pane.ts`) driven in jsdom through its own test harness (`createTestChatPane`), with real gateway-event plumbing and the real session-PR store; only the vitest `vi` helper is shimmed and the client/sessions fakes enter through the harness's own constructor parameters. Scenario: session A (`agent:main:current`) receives a ready snapshot with PR #1 → chips = `[1]`; switch `state.sessionKey` to session B (`agent:main:other`); push B's snapshot as `unavailable` → refresh.

### Before (on main)

```bash
$ node --import tsx --import ./_proof/setup-env.mjs proof.mjs
[proof] pane class: ChatPane
[proof] refreshSessionPullRequests tracks sessionPullRequestsKey: no (buggy build)
[proof] step 1: session A = "agent:main:current"
[proof] after ready snapshot for A: chips = [1]
[proof] step 2: switched sessionKey to B = "agent:main:other"
[proof] step 3: B snapshot unavailable -> chips = [1]
[proof] RESULT: FAIL - session A's PR chip(s) [1] still rendered on session B whose snapshot is unavailable
exit code: 1
```

### After (with fix)

```bash
$ node --import tsx --import ./_proof/setup-env.mjs proof.mjs
[proof] pane class: ChatPane
[proof] refreshSessionPullRequests tracks sessionPullRequestsKey: yes (fixed build)
[proof] step 1: session A = "agent:main:current"
[proof] after ready snapshot for A: chips = [1]
[proof] step 2: switched sessionKey to B = "agent:main:other"
[proof] step 3: B snapshot unavailable -> chips = []
[proof] RESULT: PASS - stale PR chips cleared for the session without a snapshot
exit code: 0
```

## Tests and Validation

- `cd ui && node ../node_modules/vitest/vitest.mjs run --config vitest.config.ts src/pages/chat/chat-pane-pull-requests.test.ts` — **7 passed (7)**, including the new regression test `clears the previous session's PR chips when the new session's snapshot is unavailable` (vitest 4.1.10, jsdom).
- Real-behavior proof above: same scenario run against the actual pane source on the pre-fix tree (FAIL, stale chip `[1]`) and on the fixed tree (PASS, chips `[]`).
- Manual verification steps:
  1. Session A with a ready snapshot renders its PR chip (`chips = [1]`) on both builds — setup unchanged.
  2. Pre-fix build: after switching to session B with an unavailable snapshot, chips remain `[1]` (stale render).
  3. Fixed build: chips become `[]` immediately and stay owned by session B via `sessionPullRequestsKey`.
