### PR TITLE
fix(gateway): keep agents list on prepared model facts

### DIFF
--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -97,7 +97,7 @@ import {
   isConfiguredAgent,
   updateAgentConfigEntry,
 } from "./agents-config-mutations.js";
-import { loadOptionalServerMethodModelCatalog } from "./optional-model-catalog.js";
+import { readPreparedServerMethodModelCatalog } from "./optional-model-catalog.js";
 import type { GatewayRequestHandlers, RespondFn } from "./types.js";
 
 // Derived from the canonical workspace list so retiring a bootstrap file cannot
@@ -879,9 +879,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
     }
 
     const cfg = context.getRuntimeConfig();
-    const modelCatalog = await loadOptionalServerMethodModelCatalog(context, "agents.list", {
-      logOnceKey: "agents.list",
-    });
+    const modelCatalog = await readPreparedServerMethodModelCatalog(context);
     const result = listAgentsForGateway(cfg, modelCatalog, {
       includeSystem: hasGatewayClientCap(client?.connect.caps, GATEWAY_CLIENT_CAPS.AGENT_KIND),
     });

--- a/src/gateway/server-methods/optional-model-catalog.test.ts
+++ b/src/gateway/server-methods/optional-model-catalog.test.ts
@@ -1,28 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
-import {
-  loadOptionalServerMethodModelCatalog,
-  readPreparedServerMethodModelCatalog,
-} from "./optional-model-catalog.js";
+import { readPreparedServerMethodModelCatalog } from "./optional-model-catalog.js";
 import type { GatewayRequestContext } from "./types.js";
-
-describe("loadOptionalServerMethodModelCatalog", () => {
-  it("forwards the requested agent to the catalog owner", async () => {
-    const entries = [{ id: "work-only", name: "Work Model", provider: "work-provider" }];
-    const loadGatewayModelCatalog = vi.fn(async () => entries);
-    const context = {
-      loadGatewayModelCatalog,
-      logGateway: { debug: vi.fn() },
-    } as unknown as GatewayRequestContext;
-
-    await expect(
-      loadOptionalServerMethodModelCatalog(context, "sessions.list", {
-        loadParams: { agentId: "work" },
-      }),
-    ).resolves.toEqual(entries);
-
-    expect(loadGatewayModelCatalog).toHaveBeenCalledWith({ agentId: "work" });
-  });
-});
 
 describe("readPreparedServerMethodModelCatalog", () => {
   it("reads published startup facts without starting catalog discovery", async () => {

--- a/src/gateway/server-methods/optional-model-catalog.ts
+++ b/src/gateway/server-methods/optional-model-catalog.ts
@@ -1,5 +1,5 @@
-// Optional model-catalog loading gives session/tool methods metadata when fast
-// while never blocking their primary response path on catalog discovery.
+// Optional model-catalog access gives session/tool methods metadata when ready
+// while keeping provider discovery out of ordinary request hot paths.
 import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
 import type { GatewayModelCatalogSnapshot } from "../server-model-catalog.types.js";
 import type { GatewayRequestContext } from "./types.js";
@@ -33,10 +33,6 @@ type LoadOptionalServerMethodModelCatalogOptions<T> = {
   timeoutMs?: number;
 };
 
-function normalizeOptionalModelCatalog(value: unknown): ModelCatalogEntry[] | undefined {
-  return Array.isArray(value) ? value : undefined;
-}
-
 function normalizeOptionalModelCatalogSnapshot(
   value: unknown,
 ): GatewayModelCatalogSnapshot | undefined {
@@ -65,17 +61,6 @@ function startOptionalServerMethodModelCatalogValueLoad<T>(params: {
   return {
     promise: catalogPromise.then(params.normalize, () => undefined),
   };
-}
-
-function startOptionalServerMethodModelCatalogLoad(
-  context: GatewayRequestContext,
-  loadParams?: Parameters<GatewayRequestContext["loadGatewayModelCatalog"]>[0],
-): OptionalServerMethodModelCatalogLoad<ModelCatalogEntry[]> {
-  return startOptionalServerMethodModelCatalogValueLoad({
-    load: () =>
-      loadParams ? context.loadGatewayModelCatalog(loadParams) : context.loadGatewayModelCatalog(),
-    normalize: normalizeOptionalModelCatalog,
-  });
 }
 
 export function startOptionalServerMethodModelCatalogSnapshotLoad(
@@ -120,17 +105,6 @@ async function loadOptionalServerMethodModelCatalogValue<T>(
       clearTimeout(timeout);
     }
   }
-}
-
-/** Loads the gateway model catalog with a short timeout and one-time slow logs. */
-export async function loadOptionalServerMethodModelCatalog(
-  context: GatewayRequestContext,
-  surface: string,
-  options?: LoadOptionalServerMethodModelCatalogOptions<ModelCatalogEntry[]>,
-): Promise<ModelCatalogEntry[] | undefined> {
-  return await loadOptionalServerMethodModelCatalogValue(context, surface, options, () =>
-    startOptionalServerMethodModelCatalogLoad(context, options?.loadParams),
-  );
 }
 
 /** Loads the full gateway model catalog snapshot without blocking the primary response path. */

--- a/src/gateway/server-methods/sessions-read.test.ts
+++ b/src/gateway/server-methods/sessions-read.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { afterEach, beforeEach, expect, test } from "vitest";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import { GATEWAY_CLIENT_CAPS } from "../../../packages/gateway-protocol/src/client-info.js";
 import { replaceSessionEntry } from "../../config/sessions/session-accessor.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../../config/sessions/session-sqlite-target.js";
@@ -42,7 +42,10 @@ function expectAgentStoreAbsent(agentId: string): void {
   );
 }
 
-async function listAgentIdsViaRpc(includeSystem = false): Promise<string[]> {
+async function listAgentIdsViaRpc(
+  includeSystem = false,
+  catalogContext: Partial<GatewayRequestContext> = {},
+): Promise<string[]> {
   const { getRuntimeConfig } = await getGatewayConfigModule();
   let ids: string[] | undefined;
   await agentsHandlers["agents.list"]?.({
@@ -56,6 +59,8 @@ async function listAgentIdsViaRpc(includeSystem = false): Promise<string[]> {
     context: {
       getRuntimeConfig,
       loadGatewayModelCatalog: async () => [],
+      readPreparedGatewayModelCatalog: async () => [],
+      ...catalogContext,
     } as unknown as GatewayRequestContext,
     client: includeSystem
       ? ({ connect: { caps: [GATEWAY_CLIENT_CAPS.AGENT_KIND] } } as never)
@@ -77,6 +82,21 @@ test("agents.list includes system rows only when negotiated", async () => {
 
   expect(await listAgentIdsViaRpc()).toEqual(["main"]);
   expect(await listAgentIdsViaRpc(true)).toEqual(["main", "openclaw"]);
+});
+
+test("agents.list reads published model facts without starting provider discovery", async () => {
+  const loadGatewayModelCatalog = vi.fn(async () => []);
+  const readPreparedGatewayModelCatalog = vi.fn(async () => []);
+
+  await expect(
+    listAgentIdsViaRpc(false, {
+      loadGatewayModelCatalog,
+      readPreparedGatewayModelCatalog,
+    }),
+  ).resolves.toEqual(["main"]);
+
+  expect(readPreparedGatewayModelCatalog).toHaveBeenCalledWith(undefined);
+  expect(loadGatewayModelCatalog).not.toHaveBeenCalled();
 });
 
 beforeEach(async () => {


### PR DESCRIPTION
Closes https://github.com/openclaw/openclaw/issues/119206

Related but distinct: https://github.com/openclaw/openclaw/pull/118465

## What Problem This Solves

The first Control UI connection could leave the Gateway unresponsive for roughly 43 seconds. `agents.list` started model-provider discovery on the request path even though Gateway startup had already published the authoritative catalog. Because part of discovery is synchronous, the intended 750 ms timeout could not fire; unrelated RPCs and liveness timers waited behind the same blocked event loop.

## Why This Is The Owner-Level Fix

Gateway startup owns model-catalog publication. Read-only roster RPCs should consume that published fact, not rediscover providers. `sessions.list` already follows this boundary through `readPreparedServerMethodModelCatalog()`; this change moves its sibling `agents.list` onto the same canonical path.

The broader open PR linked above prewarms different first-message/plugin work after readiness and currently has unresolved availability findings. This patch does not schedule new background work. It removes request-time work instead.

## What Changed

- `agents.list` reads the lifecycle-published catalog.
- The obsolete array-valued optional loader, normalizer, starter, and focused test are removed.
- The handler regression test proves `agents.list` reads published facts and never starts `loadGatewayModelCatalog()`.
- The snapshot-valued optional loader remains for the explicit metadata surface that owns startup retry behavior.

No config, protocol, storage, dependency, plugin, provider, or user-data contract changes.

## Observed Behavior

Current-main baseline on a clean Linux Testbox:

- `agents.list`: 43.4 seconds.
- Other bootstrap RPCs: 43.7 to 44.3 seconds.
- Liveness heartbeat delayed 57.6 seconds.
- RSS reached 2.47 GiB.
- First browser scenario: 52.1 seconds.

Exact-head candidate:

- `agents.list`: 227 ms.
- Every observed bootstrap RPC: at most 913 ms.
- No liveness or memory-pressure warning.
- First browser scenario: 8.9 seconds.

## Evidence

Exact head: `b173fbb6efba69`.

- Exact-head Blacksmith Testbox `tbx_01kz6a9qavzqnp7gmw3bzrkk19`, https://github.com/openclaw/openclaw/actions/runs/30907149584:
  - `pnpm test:ui:e2e -- ui/src/e2e/control-ui-auth-transports.e2e.test.ts`
  - 1 file / 2 real-browser scenarios passed in 27.94 seconds.
  - Both trusted-proxy and allowed-origin flows completed; all Gateway bootstrap RPCs stayed below one second.
- Exact-head focused local proof:
  - `node scripts/run-vitest.mjs src/gateway/server-methods/optional-model-catalog.test.ts src/gateway/server-methods/sessions-read.test.ts`
  - 2 files / 13 tests passed.
- Candidate-diff broad Blacksmith Testbox `tbx_01kz69b87crrr0jjjgq7mh5tdg`, https://github.com/openclaw/openclaw/actions/runs/30905969182:
  - `pnpm check:changed` passed the `core` and `coreTests` lanes.
  - `pnpm build` passed, including the production Control UI build and performance guard.
  - The subsequent rebase added three unrelated main commits and did not overlap any changed file.
- Fresh exact-head AutoReview: clean, no accepted/actionable findings, overall correctness 0.99.
- `git diff --check` and targeted `oxfmt` passed.
- Public model-identifier audit: PASS; the diff, tests, proof, and public text add or change no model identifiers.

## Repair Doctrine Summary

- Root cause: `agents.list` started provider discovery instead of reading the published catalog; synchronous discovery prevented its timeout from firing.
- Architectural owner: Gateway startup publishes model facts; roster RPCs only read them.
- Canonical fix: reuse `readPreparedServerMethodModelCatalog()`.
- Removed paths: the unused array optional-loader stack and its stale test.
- Production delta: +4/-32 (net -28).
- Test delta: +23/-25 (net -2).
- Sibling coverage: `sessions.list` already uses the prepared reader; `agents.list` now matches it, while explicit metadata discovery retains its separate snapshot/retry owner.
- Risk: low. This is a read-only metadata source change backed by focused handler tests and a real browser/Gateway before-after reproduction.

AI-assisted: yes.
