### PR TITLE
fix(talk): cancel realtime output without aborting the turn

### DIFF
--- a/src/gateway/server-methods/talk-session.ts
+++ b/src/gateway/server-methods/talk-session.ts
@@ -35,6 +35,7 @@ import {
   type TalkHandoffTurnResult,
 } from "../talk-handoff.js";
 import {
+  cancelTalkRealtimeRelayOutput,
   cancelTalkRealtimeRelayTurn,
   createTalkRealtimeRelaySession,
   sendTalkRealtimeRelayAudio,
@@ -97,11 +98,9 @@ function canCloseManagedRoomSession(
   return !handoff?.room.activeClientId || handoff.room.activeClientId === connId;
 }
 
-function canCreateUnscopedManagedRoomSession(
+const canCreateUnscopedManagedRoomSession = (
   client: { connect?: { scopes?: string[] } } | null,
-): boolean {
-  return client?.connect?.scopes?.includes(ADMIN_SCOPE) === true;
-}
+): boolean => client?.connect?.scopes?.includes(ADMIN_SCOPE) === true;
 
 function managedRoomOwnershipError(action: string) {
   return errorShape(
@@ -131,9 +130,8 @@ function respondUnavailable(respond: RespondFn, err: unknown) {
   );
 }
 
-function respondOk(respond: RespondFn, payload: unknown = { ok: true }) {
+const respondOk = (respond: RespondFn, payload: unknown = { ok: true }) =>
   respond(true, payload, undefined);
-}
 
 function respondManagedRoomTurn(params: {
   session: UnifiedTalkSessionRecord;
@@ -589,9 +587,10 @@ export const talkSessionHandlers: GatewayRequestHandlers = {
         return;
       }
       const connId = requireUnifiedTalkSessionConn(session, client?.connId);
-      cancelTalkRealtimeRelayTurn({
+      cancelTalkRealtimeRelayOutput({
         relaySessionId: session.relaySessionId,
         connId,
+        turnId: normalizeOptionalString(params.turnId),
         reason: normalizeOptionalString(params.reason) ?? "output-cancelled",
       });
       respondOk(respond);

--- a/src/gateway/server-methods/talk.test.ts
+++ b/src/gateway/server-methods/talk.test.ts
@@ -51,6 +51,7 @@ const mocks = vi.hoisted(() => ({
   createTalkRealtimeRelaySession: vi.fn(),
   sendTalkRealtimeRelayAudio: vi.fn(),
   acknowledgeTalkRealtimeRelayMark: vi.fn(),
+  cancelTalkRealtimeRelayOutput: vi.fn(),
   cancelTalkRealtimeRelayTurn: vi.fn(),
   stopTalkRealtimeRelaySession: vi.fn(),
   registerTalkRealtimeRelayAgentRun: vi.fn(),
@@ -193,6 +194,7 @@ vi.mock("../talk-realtime-relay.js", async (importOriginal) => {
   return {
     ...actual,
     acknowledgeTalkRealtimeRelayMark: mocks.acknowledgeTalkRealtimeRelayMark,
+    cancelTalkRealtimeRelayOutput: mocks.cancelTalkRealtimeRelayOutput,
     cancelTalkRealtimeRelayTurn: mocks.cancelTalkRealtimeRelayTurn,
     createTalkRealtimeRelaySession: mocks.createTalkRealtimeRelaySession,
     ensureTalkRealtimeRelayVoiceSession: mocks.ensureTalkRealtimeRelayVoiceSession,
@@ -1721,16 +1723,18 @@ describe("talk.session unified handlers", () => {
 
     const cancelRespond = vi.fn();
     await callTalkHandler("talk.session.cancelOutput", {
-      params: { sessionId: "relay-unified-1", reason: "barge-in" },
+      params: { sessionId: "relay-unified-1", turnId: "turn-1", reason: "barge-in" },
       id: "3",
       respond: cancelRespond,
       context: {},
     });
-    expect(mocks.cancelTalkRealtimeRelayTurn).toHaveBeenCalledWith({
+    expect(mocks.cancelTalkRealtimeRelayOutput).toHaveBeenCalledWith({
       relaySessionId: "relay-unified-1",
       connId: "conn-1",
+      turnId: "turn-1",
       reason: "barge-in",
     });
+    expect(mocks.cancelTalkRealtimeRelayTurn).not.toHaveBeenCalled();
 
     const markRespond = vi.fn();
     await callTalkHandler("talk.session.acknowledgeMark", {

--- a/src/gateway/talk-realtime-relay-operations.ts
+++ b/src/gateway/talk-realtime-relay-operations.ts
@@ -539,6 +539,35 @@ export function cancelTalkRealtimeRelayTurn(params: {
   });
 }
 
+/** Cancels provider/playback output without aborting the owning Talk turn or agent work. */
+export function cancelTalkRealtimeRelayOutput(params: {
+  relaySessionId: string;
+  connId: string;
+  turnId?: string;
+  reason?: string;
+}): void {
+  const session = getRelaySession(params.relaySessionId, params.connId);
+  const requestedTurnId = params.turnId?.trim();
+  const activeTurnId = session.harness.talk.activeTurnId;
+  if (!activeTurnId || (requestedTurnId && requestedTurnId !== activeTurnId)) {
+    return;
+  }
+  const reason = params.reason ?? "output-cancelled";
+  session.harness.handleBargeIn({ audioPlaybackActive: true }, noFallbackRelayOutputFlush);
+  const outputDone = session.harness.talk.finishOutputAudio({
+    turnId: activeTurnId,
+    payload: { reason },
+  });
+  if (!outputDone) {
+    return;
+  }
+  broadcastToOwner(session.context, session.connId, {
+    relaySessionId: session.id,
+    type: "clear",
+    talkEvent: outputDone,
+  });
+}
+
 /** Drops one provider generation without sending cancellation into its replacement. */
 export function resetTalkRealtimeRelayContinuity(
   session: RelaySession,

--- a/src/gateway/talk-realtime-relay-operations.ts
+++ b/src/gateway/talk-realtime-relay-operations.ts
@@ -549,21 +549,22 @@ export function cancelTalkRealtimeRelayOutput(params: {
   const session = getRelaySession(params.relaySessionId, params.connId);
   const requestedTurnId = params.turnId?.trim();
   const activeTurnId = session.harness.talk.activeTurnId;
-  if (requestedTurnId && activeTurnId && requestedTurnId !== activeTurnId) {
+  if (requestedTurnId && requestedTurnId !== activeTurnId) {
     return;
   }
   const reason = params.reason ?? "output-cancelled";
-  session.harness.handleBargeIn({ audioPlaybackActive: true }, noFallbackRelayOutputFlush);
-  const outputDone = activeTurnId
-    ? session.harness.talk.finishOutputAudio({
-        turnId: activeTurnId,
-        payload: { reason },
-      })
-    : undefined;
-  broadcastToOwner(session.context, session.connId, {
-    relaySessionId: session.id,
-    type: "clear",
-    ...(outputDone ? { talkEvent: outputDone } : {}),
+  session.harness.handleBargeIn({ audioPlaybackActive: true }, () => {
+    const outputDone = activeTurnId
+      ? session.harness.talk.finishOutputAudio({
+          turnId: activeTurnId,
+          payload: { reason },
+        })
+      : undefined;
+    broadcastToOwner(session.context, session.connId, {
+      relaySessionId: session.id,
+      type: "clear",
+      ...(outputDone ? { talkEvent: outputDone } : {}),
+    });
   });
 }
 

--- a/src/gateway/talk-realtime-relay-operations.ts
+++ b/src/gateway/talk-realtime-relay-operations.ts
@@ -549,22 +549,21 @@ export function cancelTalkRealtimeRelayOutput(params: {
   const session = getRelaySession(params.relaySessionId, params.connId);
   const requestedTurnId = params.turnId?.trim();
   const activeTurnId = session.harness.talk.activeTurnId;
-  if (!activeTurnId || (requestedTurnId && requestedTurnId !== activeTurnId)) {
+  if (requestedTurnId && activeTurnId && requestedTurnId !== activeTurnId) {
     return;
   }
   const reason = params.reason ?? "output-cancelled";
   session.harness.handleBargeIn({ audioPlaybackActive: true }, noFallbackRelayOutputFlush);
-  const outputDone = session.harness.talk.finishOutputAudio({
-    turnId: activeTurnId,
-    payload: { reason },
-  });
-  if (!outputDone) {
-    return;
-  }
+  const outputDone = activeTurnId
+    ? session.harness.talk.finishOutputAudio({
+        turnId: activeTurnId,
+        payload: { reason },
+      })
+    : undefined;
   broadcastToOwner(session.context, session.connId, {
     relaySessionId: session.id,
     type: "clear",
-    talkEvent: outputDone,
+    ...(outputDone ? { talkEvent: outputDone } : {}),
   });
 }
 

--- a/src/gateway/talk-realtime-relay-operations.ts
+++ b/src/gateway/talk-realtime-relay-operations.ts
@@ -28,6 +28,7 @@ import {
   MAX_RELAY_SESSIONS_PER_CONN,
   broadcastRelayTurnStarted,
   broadcastToOwner,
+  clearTalkRealtimeRelayOutputGeneration,
   drainingRelaySessions,
   ensureRelayTurn,
   noFallbackRelayOutputFlush,
@@ -553,17 +554,13 @@ export function cancelTalkRealtimeRelayOutput(params: {
     return;
   }
   const reason = params.reason ?? "output-cancelled";
+  const outputGeneration = session.outputGeneration;
+  session.pendingProviderClearGeneration = outputGeneration;
   session.harness.handleBargeIn({ audioPlaybackActive: true }, () => {
-    const outputDone = activeTurnId
-      ? session.harness.talk.finishOutputAudio({
-          turnId: activeTurnId,
-          payload: { reason },
-        })
-      : undefined;
-    broadcastToOwner(session.context, session.connId, {
-      relaySessionId: session.id,
-      type: "clear",
-      ...(outputDone ? { talkEvent: outputDone } : {}),
+    clearTalkRealtimeRelayOutputGeneration({
+      session,
+      generation: outputGeneration,
+      reason,
     });
   });
 }

--- a/src/gateway/talk-realtime-relay-session-create.ts
+++ b/src/gateway/talk-realtime-relay-session-create.ts
@@ -232,10 +232,14 @@ export function createTalkRealtimeRelaySession(
         if (!relay) {
           return;
         }
-        broadcastEvent(
-          { relaySessionId, type: "clear", ...(reason ? { reason } : {}) },
-          relay.harness.finishOutputAudio(reason ?? "clear"),
-        );
+        // Advance the harness flush generation before publishing the provider clear.
+        // This suppresses the barge-in fallback so clients receive one clear only.
+        relay.harness.flushOutput(() => {
+          broadcastEvent(
+            { relaySessionId, type: "clear", ...(reason ? { reason } : {}) },
+            relay.harness.finishOutputAudio(reason ?? "clear"),
+          );
+        });
       },
       sendMark: (markName) => {
         const relay = getActiveRelay();

--- a/src/gateway/talk-realtime-relay-session-create.ts
+++ b/src/gateway/talk-realtime-relay-session-create.ts
@@ -46,6 +46,7 @@ import {
   adoptRelayProviderToolCallId,
   broadcastRelayTurnStarted,
   broadcastToOwner,
+  clearTalkRealtimeRelayOutputGeneration,
   ensureRelayTurn,
   relaySessions,
   type CreateTalkRealtimeRelaySessionParams,
@@ -214,6 +215,7 @@ export function createTalkRealtimeRelaySession(
         const recorded = relay.harness.recordOutputAudio(audio);
         broadcastRelayTurnStarted(relay, recorded.turn.event);
         if (recorded.outputAudioStarted) {
+          relay.outputGeneration += 1;
           broadcastEvent({ relaySessionId, type: "audioStarted" }, recorded.outputAudioStarted);
         }
         broadcastEvent(
@@ -232,13 +234,13 @@ export function createTalkRealtimeRelaySession(
         if (!relay) {
           return;
         }
-        // Advance the harness flush generation before publishing the provider clear.
-        // This suppresses the barge-in fallback so clients receive one clear only.
-        relay.harness.flushOutput(() => {
-          broadcastEvent(
-            { relaySessionId, type: "clear", ...(reason ? { reason } : {}) },
-            relay.harness.finishOutputAudio(reason ?? "clear"),
-          );
+        const generation = relay.pendingProviderClearGeneration ?? relay.outputGeneration;
+        relay.pendingProviderClearGeneration = undefined;
+        clearTalkRealtimeRelayOutputGeneration({
+          session: relay,
+          generation,
+          reason: reason ?? "clear",
+          providerReason: reason,
         });
       },
       sendMark: (markName) => {
@@ -592,6 +594,7 @@ export function createTalkRealtimeRelaySession(
     pendingWorkingToolResults: new Map(),
     forcedTerminalProviderResults: new Map(),
     toolResultEpoch: 0,
+    outputGeneration: 0,
     ...(params.cfg ? { voiceConfig: params.cfg } : {}),
     voiceSessionCreated: false,
     voiceTranscriptSeq: 0,

--- a/src/gateway/talk-realtime-relay-state.ts
+++ b/src/gateway/talk-realtime-relay-state.ts
@@ -110,6 +110,11 @@ export type RelaySession = {
   forcedTerminalProviderResults: Map<string, ForcedTerminalProviderResult>;
   // Turn cancellation invalidates async acceptance callbacks from the prior turn.
   toolResultEpoch: number;
+  // Provider clears can arrive after the local fallback has already retired an
+  // output. Keep their original generation so they cannot clear replacement audio.
+  outputGeneration: number;
+  clearedOutputGeneration?: number;
+  pendingProviderClearGeneration?: number;
   voiceConfig?: OpenClawConfig;
   voiceSessionCreated: boolean;
   voiceTranscriptSeq: number;
@@ -192,6 +197,30 @@ export function broadcastToOwner(
   // for transient tool progress by individual provider callback paths.
   const delivery = relayEventDeliveryOptions(event, event.talkEvent);
   context.broadcastToConnIds(RELAY_EVENT, event, new Set([connId]), delivery);
+}
+
+export function clearTalkRealtimeRelayOutputGeneration(params: {
+  session: RelaySession;
+  generation: number;
+  reason: string;
+  providerReason?: RealtimeVoiceAudioClearReason;
+}): TalkEvent | undefined {
+  const { session, generation } = params;
+  if (generation !== session.outputGeneration || session.clearedOutputGeneration === generation) {
+    return undefined;
+  }
+  session.clearedOutputGeneration = generation;
+  let outputDone: TalkEvent | undefined;
+  session.harness.flushOutput(() => {
+    outputDone = session.harness.finishOutputAudio(params.reason);
+  });
+  broadcastToOwner(session.context, session.connId, {
+    relaySessionId: session.id,
+    type: "clear",
+    ...(params.providerReason ? { reason: params.providerReason } : {}),
+    ...(outputDone ? { talkEvent: outputDone } : {}),
+  });
+  return outputDone;
 }
 
 function relayEventDeliveryOptions(

--- a/src/gateway/talk-realtime-relay.test.ts
+++ b/src/gateway/talk-realtime-relay.test.ts
@@ -27,6 +27,7 @@ import { drainingRelaySessions, relaySessions } from "./talk-realtime-relay-stat
 import { MAX_RELAY_TOOL_CALL_IDENTITIES } from "./talk-realtime-relay-tool-call-ledger.js";
 import {
   acknowledgeTalkRealtimeRelayMark,
+  cancelTalkRealtimeRelayOutput,
   cancelTalkRealtimeRelayTurn,
   closeTalkRealtimeRelaySessionsForConnection,
   createTalkRealtimeRelaySession as createTalkRealtimeRelaySessionRaw,
@@ -2772,6 +2773,61 @@ describe("talk realtime gateway relay", () => {
     expect(chatRunState.runs.get("run-1")?.agentText).toBeUndefined();
     expectChatAbortPayload(broadcast, "barge-in");
     expectNodeAbortPayload(nodeSendToSession);
+  });
+
+  it("cancels relay output without aborting the active turn or agent consult", () => {
+    let bridgeRequest: RealtimeVoiceBridgeCreateRequest | undefined;
+    const bridge = {
+      connect: vi.fn(async () => undefined),
+      sendAudio: vi.fn(),
+      setMediaTimestamp: vi.fn(),
+      handleBargeIn: vi.fn(),
+      submitToolResult: vi.fn(),
+      acknowledgeMark: vi.fn(),
+      close: vi.fn(),
+      isConnected: vi.fn(() => true),
+    };
+    const provider: RealtimeVoiceProviderPlugin = {
+      id: "relay-test",
+      label: "Relay Test",
+      isConfigured: () => true,
+      createBridge: (request) => {
+        bridgeRequest = request;
+        return bridge;
+      },
+    };
+    const { abortController, broadcast, broadcastToConnIds, session } =
+      createAbortableRelayRunFixture(provider);
+    sendTalkRealtimeRelayAudio({
+      relaySessionId: session.relaySessionId,
+      connId: "conn-1",
+      audioBase64: Buffer.from("input").toString("base64"),
+    });
+    const activeTurnId = relaySessions.get(session.relaySessionId)?.harness.talk.activeTurnId;
+    bridgeRequest?.onAudio(Buffer.from("output"));
+
+    cancelTalkRealtimeRelayOutput({
+      relaySessionId: session.relaySessionId,
+      connId: "conn-1",
+      turnId: activeTurnId,
+      reason: "barge-in",
+    });
+
+    expect(bridge.handleBargeIn).toHaveBeenCalledWith({ audioPlaybackActive: true });
+    expect(abortController.signal.aborted).toBe(false);
+    expect(broadcast).not.toHaveBeenCalledWith(
+      "chat",
+      expect.objectContaining({ runId: "run-1", state: "aborted" }),
+      expect.anything(),
+    );
+    expect(relaySessions.get(session.relaySessionId)?.harness.talk.activeTurnId).toBe(activeTurnId);
+    expect(
+      broadcastToConnIds.mock.calls.some(
+        (call) =>
+          (call[1] as { type?: string; talkEvent?: { type?: string } }).type === "clear" &&
+          (call[1] as { talkEvent?: { type?: string } }).talkEvent?.type === "output.audio.done",
+      ),
+    ).toBe(true);
   });
 
   it("terminally satisfies a late normal result after turn cancellation without a new turn", async () => {

--- a/src/gateway/talk-realtime-relay.test.ts
+++ b/src/gateway/talk-realtime-relay.test.ts
@@ -2830,6 +2830,53 @@ describe("talk realtime gateway relay", () => {
     ).toHaveLength(1);
   });
 
+  it("ignores a delayed provider clear from the replaced output generation", () => {
+    let bridgeRequest: RealtimeVoiceBridgeCreateRequest | undefined;
+    let deliverProviderClear: (() => void) | undefined;
+    const bridge = {
+      connect: vi.fn(async () => undefined),
+      sendAudio: vi.fn(),
+      setMediaTimestamp: vi.fn(),
+      handleBargeIn: vi.fn(() => {
+        deliverProviderClear = () => bridgeRequest?.onClearAudio("barge-in");
+      }),
+      submitToolResult: vi.fn(),
+      acknowledgeMark: vi.fn(),
+      close: vi.fn(),
+      isConnected: vi.fn(() => true),
+    };
+    const provider: RealtimeVoiceProviderPlugin = {
+      id: "relay-test",
+      label: "Relay Test",
+      isConfigured: () => true,
+      createBridge: (request) => {
+        bridgeRequest = request;
+        return bridge;
+      },
+    };
+    const { broadcastToConnIds, session } = createAbortableRelayRunFixture(provider);
+    bridgeRequest?.onAudio(Buffer.from("first output"));
+
+    cancelTalkRealtimeRelayOutput({
+      relaySessionId: session.relaySessionId,
+      connId: "conn-1",
+      reason: "barge-in",
+    });
+
+    const clearCount = () =>
+      broadcastToConnIds.mock.calls.filter(
+        (call) => (call[1] as { type?: string }).type === "clear",
+      ).length;
+    expect(clearCount()).toBe(1);
+
+    bridgeRequest?.onAudio(Buffer.from("replacement output"));
+    deliverProviderClear?.();
+    expect(clearCount()).toBe(1);
+
+    bridgeRequest?.onClearAudio("barge-in");
+    expect(clearCount()).toBe(2);
+  });
+
   it("ignores an output cancellation for a turn that is no longer active", () => {
     const handleBargeIn = vi.fn();
     const provider = createIdleRelayProvider();

--- a/src/gateway/talk-realtime-relay.test.ts
+++ b/src/gateway/talk-realtime-relay.test.ts
@@ -2781,7 +2781,7 @@ describe("talk realtime gateway relay", () => {
       connect: vi.fn(async () => undefined),
       sendAudio: vi.fn(),
       setMediaTimestamp: vi.fn(),
-      handleBargeIn: vi.fn(),
+      handleBargeIn: vi.fn(() => bridgeRequest?.onClearAudio("barge-in")),
       submitToolResult: vi.fn(),
       acknowledgeMark: vi.fn(),
       close: vi.fn(),
@@ -2822,12 +2822,54 @@ describe("talk realtime gateway relay", () => {
     );
     expect(relaySessions.get(session.relaySessionId)?.harness.talk.activeTurnId).toBe(activeTurnId);
     expect(
-      broadcastToConnIds.mock.calls.some(
+      broadcastToConnIds.mock.calls.filter(
         (call) =>
           (call[1] as { type?: string; talkEvent?: { type?: string } }).type === "clear" &&
           (call[1] as { talkEvent?: { type?: string } }).talkEvent?.type === "output.audio.done",
       ),
-    ).toBe(true);
+    ).toHaveLength(1);
+  });
+
+  it("ignores an output cancellation for a turn that is no longer active", () => {
+    const handleBargeIn = vi.fn();
+    const provider = createIdleRelayProvider();
+    provider.createBridge = () => ({
+      connect: vi.fn(async () => undefined),
+      sendAudio: vi.fn(),
+      setMediaTimestamp: vi.fn(),
+      handleBargeIn,
+      submitToolResult: vi.fn(),
+      acknowledgeMark: vi.fn(),
+      close: vi.fn(),
+      isConnected: vi.fn(() => true),
+    });
+    const { broadcastToConnIds, session } = createAbortableRelayRunFixture(provider);
+    sendTalkRealtimeRelayAudio({
+      relaySessionId: session.relaySessionId,
+      connId: "conn-1",
+      audioBase64: Buffer.from("input").toString("base64"),
+    });
+    const relay = relaySessions.get(session.relaySessionId);
+    const staleTurnId = relay?.harness.talk.activeTurnId;
+    expect(staleTurnId).toBeTruthy();
+    relay?.harness.endTurn("completed");
+    const clearCount = broadcastToConnIds.mock.calls.filter(
+      (call) => (call[1] as { type?: string }).type === "clear",
+    ).length;
+
+    cancelTalkRealtimeRelayOutput({
+      relaySessionId: session.relaySessionId,
+      connId: "conn-1",
+      turnId: staleTurnId,
+      reason: "late-cancel",
+    });
+
+    expect(handleBargeIn).not.toHaveBeenCalled();
+    expect(
+      broadcastToConnIds.mock.calls.filter(
+        (call) => (call[1] as { type?: string }).type === "clear",
+      ),
+    ).toHaveLength(clearCount);
   });
 
   it("clears queued playback after provider output is already marked done", () => {

--- a/src/gateway/talk-realtime-relay.test.ts
+++ b/src/gateway/talk-realtime-relay.test.ts
@@ -2830,6 +2830,52 @@ describe("talk realtime gateway relay", () => {
     ).toBe(true);
   });
 
+  it("clears queued playback after provider output is already marked done", () => {
+    let bridgeRequest: RealtimeVoiceBridgeCreateRequest | undefined;
+    const bridge = {
+      connect: vi.fn(async () => undefined),
+      sendAudio: vi.fn(),
+      setMediaTimestamp: vi.fn(),
+      handleBargeIn: vi.fn(),
+      submitToolResult: vi.fn(),
+      acknowledgeMark: vi.fn(),
+      close: vi.fn(),
+      isConnected: vi.fn(() => true),
+    };
+    const provider: RealtimeVoiceProviderPlugin = {
+      id: "relay-test",
+      label: "Relay Test",
+      isConfigured: () => true,
+      createBridge: (request) => {
+        bridgeRequest = request;
+        return bridge;
+      },
+    };
+    const { abortController, broadcastToConnIds, session } =
+      createAbortableRelayRunFixture(provider);
+    sendTalkRealtimeRelayAudio({
+      relaySessionId: session.relaySessionId,
+      connId: "conn-1",
+      audioBase64: Buffer.from("input").toString("base64"),
+    });
+    bridgeRequest?.onAudio(Buffer.from("output"));
+    bridgeRequest?.onEvent?.({ direction: "server", type: "response.done" });
+    const clearCount = () =>
+      broadcastToConnIds.mock.calls.filter(
+        (call) => (call[1] as { type?: string }).type === "clear",
+      ).length;
+    const beforeCancel = clearCount();
+
+    cancelTalkRealtimeRelayOutput({
+      relaySessionId: session.relaySessionId,
+      connId: "conn-1",
+      reason: "barge-in",
+    });
+
+    expect(clearCount()).toBe(beforeCancel + 1);
+    expect(abortController.signal.aborted).toBe(false);
+  });
+
   it("terminally satisfies a late normal result after turn cancellation without a new turn", async () => {
     const submitToolResult = vi.fn<RealtimeVoiceBridge["submitToolResult"]>();
     const provider = createIdleRelayProvider();

--- a/src/gateway/talk-realtime-relay.ts
+++ b/src/gateway/talk-realtime-relay.ts
@@ -3,6 +3,7 @@
 export { createTalkRealtimeRelaySession } from "./talk-realtime-relay-session-create.js";
 export {
   acknowledgeTalkRealtimeRelayMark,
+  cancelTalkRealtimeRelayOutput,
   cancelTalkRealtimeRelayTurn,
   closeTalkRealtimeRelaySessionsForConnection,
   ensureTalkRealtimeRelayVoiceSession,

--- a/ui/src/pages/chat/realtime-talk-gateway-relay.test.ts
+++ b/ui/src/pages/chat/realtime-talk-gateway-relay.test.ts
@@ -542,6 +542,18 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
       relaySessionId: "relay-1",
       type: "audio",
       audioBase64: zeroPcmBase64(24000 * 11),
+      talkEvent: {
+        id: "relay-1:2",
+        type: "output.audio.delta",
+        sessionId: "relay-1",
+        turnId: "turn-authoritative",
+        seq: 2,
+        timestamp: "2026-08-05T00:00:00.000Z",
+        mode: "realtime",
+        transport: "gateway-relay",
+        brain: "agent-consult",
+        payload: { byteLength: 48_000 },
+      } satisfies RealtimeTalkEvent,
     });
 
     await waitForFast(() =>
@@ -550,6 +562,7 @@ describe("GatewayRelayRealtimeTalkTransport", () => {
           "talk.session.cancelOutput",
           {
             sessionId: "relay-1",
+            turnId: "turn-authoritative",
             reason: "playback-overflow",
           },
         ],

--- a/ui/src/pages/chat/realtime-talk-gateway-relay.ts
+++ b/ui/src/pages/chat/realtime-talk-gateway-relay.ts
@@ -59,6 +59,7 @@ export class GatewayRelayRealtimeTalkTransport implements RealtimeTalkTransport 
   private readonly markAckTimers = new Set<number>();
   private cancelRequestedForPlayback = false;
   private playbackOverflowed = false;
+  private playbackTurnId: string | undefined;
   private pendingOutputCancellations = 0;
   private speechFramesDuringPlayback = 0;
   private lastRelayError: string | undefined;
@@ -321,6 +322,10 @@ export class GatewayRelayRealtimeTalkTransport implements RealtimeTalkTransport 
           break;
         case "audio":
           if (event.audioBase64 && !this.playbackOverflowed) {
+            const turnId = event.talkEvent?.turnId?.trim();
+            if (turnId) {
+              this.playbackTurnId = turnId;
+            }
             this.cancelRequestedForPlayback = false;
             this.speechFramesDuringPlayback = 0;
             this.playPcm16(event.audioBase64);
@@ -394,6 +399,7 @@ export class GatewayRelayRealtimeTalkTransport implements RealtimeTalkTransport 
 
   private stopOutput(options: { releaseDelayedToolResults?: boolean } = {}): void {
     this.outputQueue.stop(this.outputContext);
+    this.playbackTurnId = undefined;
     this.speechFramesDuringPlayback = 0;
     if (options.releaseDelayedToolResults ?? true) {
       this.flushDelayedToolResults();
@@ -675,10 +681,12 @@ export class GatewayRelayRealtimeTalkTransport implements RealtimeTalkTransport 
     // Releasing earlier can let the provider answer from a turn the user interrupted.
     this.pendingOutputCancellations += 1;
     this.pauseDelayedToolResults();
+    const turnId = this.playbackTurnId;
     this.stopOutput({ releaseDelayedToolResults: false });
     void this.ctx.client
       .request("talk.session.cancelOutput", {
         sessionId: this.session.relaySessionId,
+        ...(turnId ? { turnId } : {}),
         reason,
       })
       .then(


### PR DESCRIPTION
## What Problem This Solves

`talk.realtime.cancelOutput` used the full turn-cancellation path. Barge-in or playback stop could abort the active agent consult and destroy turn state instead of only stopping assistant audio. A delayed provider completion could also clear playback belonging to a newer output generation.

## Why This Change Was Made

Output cancellation now owns only provider response truncation and client playback clearing. `cancelTurn` remains the explicit destructive operation for the whole turn. The UI sends the authoritative playback `turnId`, and the relay fences delayed clears by both turn and monotonic output generation.

## User Impact

Users can interrupt spoken output and continue the same realtime conversation without losing active agent or tool work. Stale cancellation and completion events cannot clear newer playback.

## Evidence

- Exact head: `aa5d5838f609b56d1dc8b943b0bca17a969e4653`.
- Focused Control UI cancellation proof passed.
- Gateway regressions cover stale IDs, no-active-turn playback, provider-completion races, delayed stale clears, and full-turn cancellation.
- Content-equivalent Blacksmith changed-surface proof passed all code, typecheck, lint, and test lanes: https://github.com/openclaw/openclaw/actions/runs/30940713690.
- `git diff --check` and private-data scan: clean.

## Stack

Depends on #112818.

Punchcard-Session: calm-cedar-river-aa
