### PR TITLE
fix(talk): preserve agent consults when relay disconnects

### DIFF
--- a/extensions/openai/realtime-quicksilver-delegation-controller.ts
+++ b/extensions/openai/realtime-quicksilver-delegation-controller.ts
@@ -66,12 +66,22 @@ function readWireEventType(payload: string): string | undefined {
 export class OpenAIQuicksilverDelegationController {
   private activeDelegationId: string | undefined;
   private consultController: AbortController | undefined;
+  private readonly onSessionAbort = () => {
+    const reason = this.options.signal.reason;
+    this.stop(reason instanceof Error ? reason : new Error("GPT-Live session stopped"));
+  };
   private partialTranscriptRole: "user" | "assistant" | undefined;
   private pendingDelegation: PendingDelegation | undefined;
   private stopped = false;
   private transcript: OpenAIQuicksilverTranscriptEntry[] = [];
 
-  constructor(private readonly options: OpenAIQuicksilverDelegationControllerOptions) {}
+  constructor(private readonly options: OpenAIQuicksilverDelegationControllerOptions) {
+    if (options.signal.aborted) {
+      this.onSessionAbort();
+    } else {
+      options.signal.addEventListener("abort", this.onSessionAbort, { once: true });
+    }
+  }
 
   handleFrame(data: RawData, isBinary: boolean): void {
     if (isBinary) {
@@ -134,11 +144,17 @@ export class OpenAIQuicksilverDelegationController {
     if (this.stopped) {
       return;
     }
-    this.stopped = true;
-    this.pendingDelegation = undefined;
-    this.activeDelegationId = undefined;
+    this.markStopped();
     this.consultController?.abort(reason);
     this.consultController = undefined;
+  }
+
+  /** Releases sideband ownership without canceling work already accepted by the host. */
+  detach(): void {
+    if (this.stopped) {
+      return;
+    }
+    this.markStopped();
   }
 
   private appendTranscript(
@@ -192,8 +208,7 @@ export class OpenAIQuicksilverDelegationController {
     const controller = new AbortController();
     this.consultController = controller;
     this.activeDelegationId = delegation.id;
-    const signal = AbortSignal.any([this.options.signal, controller.signal]);
-    void this.runDelegation(delegation, signal)
+    void this.runDelegation(delegation, controller.signal)
       .catch((error: unknown) => this.fail(toError(error)))
       .finally(() => {
         if (this.consultController !== controller) {
@@ -208,6 +223,15 @@ export class OpenAIQuicksilverDelegationController {
           this.activeDelegationId = undefined;
         }
       });
+  }
+
+  private markStopped(): void {
+    this.stopped = true;
+    this.options.signal.removeEventListener("abort", this.onSessionAbort);
+    this.pendingDelegation = undefined;
+    this.activeDelegationId = undefined;
+    this.partialTranscriptRole = undefined;
+    this.transcript = [];
   }
 
   private async runDelegation(delegation: PendingDelegation, signal: AbortSignal): Promise<void> {

--- a/extensions/openai/realtime-quicksilver-delegation.test.ts
+++ b/extensions/openai/realtime-quicksilver-delegation.test.ts
@@ -266,6 +266,70 @@ describe("GPT-Live sideband protocol", () => {
     expect(runAgentConsult.mock.calls[1]?.[0].prompt).toContain("latest task");
     expect(runAgentConsult.mock.calls[1]?.[0].prompt).not.toContain("second task");
     controller.stop(new Error("test complete"));
+    expect(signals[1]?.aborted).toBe(true);
+  });
+
+  it("detaches sideband ownership without aborting accepted work", async () => {
+    let consultSignal: AbortSignal | undefined;
+    let resolveConsult!: (result: { text: string }) => void;
+    let resolveCompleted!: () => void;
+    const consultResult = new Promise<{ text: string }>((resolve) => {
+      resolveConsult = resolve;
+    });
+    const completed = new Promise<void>((resolve) => {
+      resolveCompleted = resolve;
+    });
+    const runAgentConsult = vi.fn<ConsultRunner>(async ({ signal }) => {
+      consultSignal = signal;
+      try {
+        return await consultResult;
+      } finally {
+        resolveCompleted();
+      }
+    });
+    const { controller, sessionController, socket } = createDelegationHarness({
+      runAgentConsult,
+    });
+
+    delegate(controller, "delegation-1", "long task");
+    await vi.waitFor(() => expect(runAgentConsult).toHaveBeenCalledOnce());
+
+    controller.detach();
+    sessionController.abort(new Error("transport closed"));
+    expect(consultSignal?.aborted).toBe(false);
+
+    delegate(controller, "delegation-late", "late task");
+    expect(runAgentConsult).toHaveBeenCalledOnce();
+
+    resolveConsult({ text: "finished after close" });
+    await completed;
+    await Promise.resolve();
+    expect(socket.sent).toEqual([]);
+  });
+
+  it("keeps session lifecycle abort destructive", async () => {
+    let consultSignal: AbortSignal | undefined;
+    const runAgentConsult = vi.fn<ConsultRunner>(
+      async ({ signal }) =>
+        await new Promise<{ text: string }>((_resolve, reject) => {
+          consultSignal = signal;
+          signal?.addEventListener(
+            "abort",
+            () => reject(signal.reason instanceof Error ? signal.reason : new Error("aborted")),
+            { once: true },
+          );
+        }),
+    );
+    const { controller, sessionController } = createDelegationHarness({ runAgentConsult });
+
+    delegate(controller, "delegation-1", "long task");
+    await vi.waitFor(() => expect(runAgentConsult).toHaveBeenCalledOnce());
+
+    sessionController.abort(new Error("session closed"));
+    expect(consultSignal?.aborted).toBe(true);
+
+    delegate(controller, "delegation-late", "late task");
+    expect(runAgentConsult).toHaveBeenCalledOnce();
   });
 
   it("keeps transcript context when it skips an empty delegation", async () => {

--- a/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
@@ -858,7 +858,7 @@ describe("GPT-Live gateway relay bridge", () => {
     const onClose = vi.fn();
     const bridge = new OpenAIQuicksilverGatewayBridge({
       providerConfig: {},
-      model: "gpt-live-1-codex",
+      model: "gpt-live-1-boulder-alpha",
       voice: "marin",
       audioFormat: { encoding: "pcm16", sampleRateHz: 24_000, channels: 1 },
       onAudio: vi.fn(),

--- a/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
@@ -835,6 +835,84 @@ describe("GPT-Live gateway relay bridge", () => {
     expect(onClose).toHaveBeenCalledWith("completed");
   });
 
+  it("closes transport without aborting an accepted delegation", async () => {
+    let socket: FakeSocket | undefined;
+    let consultSignal: AbortSignal | undefined;
+    let resolveConsult!: (result: { text: string }) => void;
+    let resolveCompleted!: () => void;
+    const consultResult = new Promise<{ text: string }>((resolve) => {
+      resolveConsult = resolve;
+    });
+    const completed = new Promise<void>((resolve) => {
+      resolveCompleted = resolve;
+    });
+    const runAgentConsult = vi.fn(async ({ signal }: { prompt: string; signal?: AbortSignal }) => {
+      consultSignal = signal;
+      try {
+        return await consultResult;
+      } finally {
+        resolveCompleted();
+      }
+    });
+    const closePeer = vi.fn();
+    const onClose = vi.fn();
+    const bridge = new OpenAIQuicksilverGatewayBridge({
+      providerConfig: {},
+      model: "gpt-live-1-codex",
+      voice: "marin",
+      audioFormat: { encoding: "pcm16", sampleRateHz: 24_000, channels: 1 },
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onClose,
+      runAgentConsult,
+      logger: { debug: vi.fn(), warn: vi.fn() },
+      resolveAuth: vi.fn(async () => ({
+        type: "api-key" as const,
+        token: "platform-key",
+      })),
+      createPeer: vi.fn(async () => ({
+        createOffer: vi.fn(async () => "v=offer\r\n"),
+        applyAnswer: vi.fn(async () => undefined),
+        sendAudio: vi.fn(),
+        close: closePeer,
+      })),
+      fetchImpl: vi.fn(async () => createCallResponse("v=answer\r\n", "rtc_detach")),
+      webSocketFactory: () => {
+        socket = new FakeSocket();
+        return socket;
+      },
+    });
+
+    await bridge.connect();
+    if (!socket) {
+      throw new Error("expected sideband socket");
+    }
+    const connectedSocket = socket;
+    emitSideband(connectedSocket, {
+      type: "delegation.created",
+      item: {
+        type: "delegation",
+        target: "client",
+        id: "delegation-1",
+        content: [{ type: "input_text", text: "Finish this task" }],
+      },
+    });
+    await vi.waitFor(() => expect(runAgentConsult).toHaveBeenCalledOnce());
+
+    bridge.close();
+    expect(consultSignal?.aborted).toBe(false);
+    expect(closePeer).toHaveBeenCalledOnce();
+    expect(connectedSocket.closed).toBe(true);
+    expect(onClose).toHaveBeenCalledWith("completed");
+
+    resolveConsult({ text: "finished after close" });
+    await completed;
+    await Promise.resolve();
+    expect(
+      parseSent(connectedSocket).filter((event) => event.type === "delegation.context.append"),
+    ).toEqual([]);
+  });
+
   it("treats a normal upstream sideband close as completion", async () => {
     let socket: FakeSocket | undefined;
     const onClose = vi.fn();

--- a/extensions/openai/realtime-quicksilver-gateway-bridge.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge.ts
@@ -357,8 +357,10 @@ export class OpenAIQuicksilverGatewayBridge implements RealtimeVoiceBridge {
     releaseOpenAIQuicksilverSession(this);
     this.connected = false;
     this.pendingAudio = Buffer.alloc(0);
+    // Transport teardown releases sideband ownership, but accepted Gateway work
+    // remains owned by the durable consult runtime until explicit cancellation.
+    this.delegations?.detach();
     this.abortController.abort(new Error("GPT-Live gateway relay bridge closed"));
-    this.delegations?.stop(new Error("GPT-Live delegation stopped"));
     if (this.timer) {
       clearTimeout(this.timer);
       this.timer = undefined;

--- a/src/gateway/talk-realtime-relay-operations.ts
+++ b/src/gateway/talk-realtime-relay-operations.ts
@@ -68,7 +68,7 @@ export function ensureTalkRealtimeRelayVoiceSession(params: {
   }
 }
 
-export function abortRelayAgentRuns(session: RelaySession, reason: string): void {
+function abortRelayAgentRuns(session: RelaySession, reason: string): void {
   for (const [runId, sessionKey] of session.activeAgentRuns) {
     abortChatRunById(session.context, {
       runId,
@@ -76,6 +76,12 @@ export function abortRelayAgentRuns(session: RelaySession, reason: string): void
       stopReason: reason,
     });
   }
+  session.activeAgentRuns.clear();
+  session.activeAgentToolCalls.clear();
+}
+
+/** Releases relay-local correlation without cancelling durable voice-bound agent runs. */
+export function detachRelayAgentRuns(session: RelaySession): void {
   session.activeAgentRuns.clear();
   session.activeAgentToolCalls.clear();
 }
@@ -99,7 +105,7 @@ export function closeRelaySession(session: RelaySession, reason: "completed" | "
   relaySessions.delete(session.id);
   forgetUnifiedTalkSession(session.id);
   clearTimeout(session.cleanupTimer);
-  abortRelayAgentRuns(session, reason === "error" ? "relay-error" : "relay-closed");
+  detachRelayAgentRuns(session);
   try {
     session.bridge.close();
   } finally {
@@ -599,7 +605,9 @@ export function resetTalkRealtimeRelayContinuity(
   session.pendingWorkingToolResults.clear();
   session.forcedTerminalProviderResults.clear();
   session.harness.forcedConsults.clear();
-  abortRelayAgentRuns(session, reason);
+  // The provider generation no longer owns these calls, but the durable voice
+  // session still owns any running consult and its eventual mutation evidence.
+  session.activeAgentToolCalls.clear();
   const turnId = session.harness.talk.activeTurnId;
   session.harness.flushOutput(noFallbackRelayOutputFlush);
   session.harness.finishOutputAudio(reason);

--- a/src/gateway/talk-realtime-relay-session-create.ts
+++ b/src/gateway/talk-realtime-relay-session-create.ts
@@ -30,9 +30,9 @@ import {
   createTalkRealtimeRelayIssue as realtimeRelayIssue,
 } from "./talk-realtime-relay-issues.js";
 import {
-  abortRelayAgentRuns,
   cancelTalkRealtimeRelayProviderToolCall,
   closeRelaySession,
+  detachRelayAgentRuns,
   enforceRelaySessionLimits,
   pruneInactiveRelayAgentRuns,
   registerTalkRealtimeRelayAgentRun,
@@ -500,7 +500,7 @@ export function createTalkRealtimeRelaySession(
       relaySessions.delete(relaySessionId);
       forgetUnifiedTalkSession(relaySessionId);
       clearTimeout(active.cleanupTimer);
-      abortRelayAgentRuns(active, "relay-closed");
+      detachRelayAgentRuns(active);
       void closeRelayVoiceSession(active);
       if (!ready && !failureEmitted) {
         const issue = realtimeRelayIssue({

--- a/src/gateway/talk-realtime-relay.test.ts
+++ b/src/gateway/talk-realtime-relay.test.ts
@@ -16,6 +16,7 @@ import type { OpenClawConfig } from "../config/types.js";
 import type { RealtimeVoiceProviderPlugin } from "../plugins/types.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { resolveClientVoiceRunBinding } from "../talk/client-voice-session.js";
 import { clientVoiceSessionTesting } from "../talk/client-voice-session.test-support.js";
 import type {
   RealtimeVoiceBridge,
@@ -1287,12 +1288,12 @@ describe("talk realtime gateway relay", () => {
       type: "session.continuity.reset",
     });
 
-    expect(fixture.abortController.signal.aborted).toBe(true);
+    expect(fixture.abortController.signal.aborted).toBe(false);
     expect(handleBargeIn).not.toHaveBeenCalled();
     expect(bridge.close).not.toHaveBeenCalled();
     expect(submitToolResult).toHaveBeenCalledTimes(1);
     expect(relay.pendingWorkingToolResults.size).toBe(0);
-    expect(relay.activeAgentRuns.size).toBe(0);
+    expect(relay.activeAgentRuns.size).toBe(1);
     expect(relay.activeAgentToolCalls.size).toBe(0);
     const payloads = fixture.broadcastToConnIds.mock.calls.map(([, payload]) => payload);
     const clears = payloads.filter(
@@ -4242,18 +4243,25 @@ describe("talk realtime gateway relay", () => {
     expect(bridge.submitToolResult).not.toHaveBeenCalled();
   });
 
-  it("aborts linked agent consult runs when the relay session closes", () => {
+  it("keeps durable agent consult runs alive when the relay session closes", () => {
     const { abortController, broadcast, nodeSendToSession, chatRunState, session } =
       createAbortableRelayRunFixture();
     stopTalkRealtimeRelaySession({ relaySessionId: session.relaySessionId, connId: "conn-1" });
 
-    expect(abortController.signal.aborted).toBe(true);
-    expect(chatRunState.runs.get("run-1")?.agentText).toBeUndefined();
-    expectChatAbortPayload(broadcast, "relay-closed");
-    expectNodeAbortPayload(nodeSendToSession);
+    expect(abortController.signal.aborted).toBe(false);
+    expect(chatRunState.runs.get("run-1")?.agentText).toBeDefined();
+    expect(broadcast).not.toHaveBeenCalledWith(
+      "chat",
+      expect.objectContaining({ runId: "run-1", state: "aborted" }),
+      expect.anything(),
+    );
+    expect(nodeSendToSession).not.toHaveBeenCalled();
+    expect(resolveClientVoiceRunBinding("run-1")).toMatchObject({
+      voiceSessionId: session.relaySessionId,
+    });
   });
 
-  it("aborts linked agent consult runs when the provider closes the relay", () => {
+  it("keeps durable agent consult runs alive when the provider closes the relay", () => {
     const abortController = new AbortController();
     let bridgeRequest: RealtimeVoiceBridgeCreateRequest | undefined;
     const broadcast = vi.fn();
@@ -4332,10 +4340,17 @@ describe("talk realtime gateway relay", () => {
     });
     bridgeRequest?.onClose?.("error");
 
-    expect(abortController.signal.aborted).toBe(true);
-    expect(chatRunState.runs.get("run-1")?.agentText).toBeUndefined();
-    expectChatAbortPayload(broadcast, "relay-closed");
-    expectNodeAbortPayload(nodeSendToSession);
+    expect(abortController.signal.aborted).toBe(false);
+    expect(chatRunState.runs.get("run-1")?.agentText).toBeDefined();
+    expect(broadcast).not.toHaveBeenCalledWith(
+      "chat",
+      expect.objectContaining({ runId: "run-1", state: "aborted" }),
+      expect.anything(),
+    );
+    expect(nodeSendToSession).not.toHaveBeenCalled();
+    expect(resolveClientVoiceRunBinding("run-1")).toMatchObject({
+      voiceSessionId: session.relaySessionId,
+    });
   });
 
   it("fails closed when retained relay tool-call identities reach their hard cap", () => {


### PR DESCRIPTION
## What Problem This Solves

Normal relay teardown or provider disconnect aborted durable agent consults already launched for the voice turn. A transient transport boundary could cancel useful work even though the user never requested cancellation.

## Why This Change Was Made

Relay teardown now uses a non-destructive detach path that drops relay-local correlation state without aborting durable agent runs. Direct session abort, explicit stop, supersession, and exact provider tool-call cancellation remain destructive. Late completion cannot append into a closed sideband.

## User Impact

Accepted agent and tool work survives normal voice relay teardown and can finish durably, while explicit user or provider cancellation still stops the intended run.

## Evidence

- Exact head: `cad6aa8920627c7cb2a40f914a12bf9c02afcf8a`.
- Delegation lifecycle tests: 17 passed.
- Gateway bridge tests: 29 passed.
- Relay tests: 68 passed.
- Exact stacked Talk proof: 7 unit plus 131 Gateway assertions passed.
- Content-equivalent Blacksmith changed-surface proof passed all code, typecheck, lint, and test lanes: https://github.com/openclaw/openclaw/actions/runs/30940713690.
- `git diff --check` and private-data scan: clean.

## Stack

Depends on #119211.

Punchcard-Session: calm-cedar-river-aa
