### PR TITLE
fix(cron): record external stream failures in the task run ledger

### DIFF
--- a/src/cron/service.stream-validation.test.ts
+++ b/src/cron/service.stream-validation.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import { CronService } from "./service.js";
 import { setupCronServiceSuite } from "./service.test-harness.js";
+import { cronStoreKey } from "./store/key.js";
 import { cronStreamScheduleKey } from "./stream-schedule.js";
+import { readCronTaskRunHistoryPage } from "./task-run-history.js";
 import type { CronJobCreate } from "./types.js";
 
 const { logger, makeStorePath } = setupCronServiceSuite({ prefix: "cron-stream-validation-" });
@@ -172,6 +174,45 @@ describe("cron stream schedule validation", () => {
         expect.stringContaining("stream source exhausted restarts"),
         expect.any(Object),
       );
+    } finally {
+      cron.stop();
+    }
+  });
+
+  it("records restart exhaustion in the cron task run history", async () => {
+    const { storePath } = await makeStorePath();
+    const cron = new CronService({
+      storePath,
+      cronEnabled: true,
+      cronConfig: {
+        triggers: { enabled: true },
+        failureAlert: { enabled: true, after: 5, cooldownMs: 0 },
+      },
+      log: logger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+    await cron.start();
+    try {
+      const created = await cron.add(streamJob());
+      await cron.recordExternalFailure(created.id, "stream source exhausted restarts", {
+        streamStatus: "error",
+        streamRestartExhausted: true,
+        streamConsecutiveFailures: 5,
+      });
+      const history = readCronTaskRunHistoryPage({
+        storeKey: cronStoreKey(storePath),
+        jobId: created.id,
+        limit: 10,
+      });
+      expect(history.total).toBe(1);
+      expect(history.entries[0]).toMatchObject({
+        jobId: created.id,
+        action: "finished",
+        status: "error",
+        error: "stream source exhausted restarts",
+      });
     } finally {
       cron.stop();
     }

--- a/src/cron/service/ops-read.ts
+++ b/src/cron/service/ops-read.ts
@@ -17,6 +17,7 @@ import type {
 import { locked } from "./locked.js";
 import { normalizeOptionalAgentId } from "./normalize.js";
 import { updateLoadedJob } from "./ops-mutations.js";
+import { emitCronRunFinished } from "./ops-run-preparation.js";
 import {
   ensureLoadedForRead,
   ownsStreamSource,
@@ -24,7 +25,6 @@ import {
   resolveEffectiveJobAgentId,
 } from "./ops-shared.js";
 import type { CronServiceState, DeferredCronNotifications } from "./state.js";
-import { emit } from "./state.js";
 import { ensureLoaded, persistOrRestore, snapshotStoreForRollback } from "./store.js";
 import { applyJobResult, armTimer } from "./timer.js";
 
@@ -133,7 +133,7 @@ export async function recordExternalFailure(
     // Stream schedules are event-driven; applyJobResult's generic recurring
     // backoff must never turn source failure into a time-due payload run.
     job.state.nextRunAtMs = undefined;
-    emit(state, {
+    emitCronRunFinished(state, {
       jobId: job.id,
       action: "finished",
       job,


### PR DESCRIPTION
## Summary

`fix(cron): record external stream failures in the task run ledger so terminal restart exhaustion is inspectable in run history`

## What Problem This Solves

Stream-scheduled cron jobs are event-driven: a watched command source is restarted by the scheduler until its restart budget is exhausted, at which point the scheduler calls `recordExternalFailure` to record the terminal failure. That path updated the job state (`lastRunStatus=error`, `consecutiveErrors`, failure alert via `enqueueSystemEvent`) but emitted the `finished` event with a bare `emit()` — bypassing `emitCronRunFinished`, which is the only emission path that finalizes the cron task run ledger row (`tryFinishCronTaskRun`).

Result: the job visibly failed (state shows `lastRunStatus=error`, a failure alert fires pointing at the run), yet `readCronTaskRunHistoryPage` — the API backing cron run history in CLI/RPC surfaces — returns **zero** entries for the job. Operators get an alert about a failed run they cannot inspect.

Scope: every stream-scheduled cron job whose source exhausts its restart budget (e.g. a watched command that keeps crashing). Payload-run failures go through the normal execution path and are unaffected.

**Code evidence**: at `src/cron/service/ops-read.ts:136` (pre-fix), `recordExternalFailure` emitted the terminal event directly:

```ts
job.state.nextRunAtMs = undefined;
emit(state, {            // bare emit: no tryFinishCronTaskRun, no ledger row
  jobId: job.id,
  action: "finished",
  job,
  status: "error",
  ...
});
```

while the function's own comment two lines above states terminal exhaustion "should enter the same alert/history path as a fifth consecutive payload error" — the history half of that invariant was never implemented.

Minimal reproduction: create a `CronService` with triggers enabled, add a stream job, call `recordExternalFailure(id, "stream source exhausted restarts", { streamStatus: "error", streamRestartExhausted: true, streamConsecutiveFailures: 5 })`, then read `readCronTaskRunHistoryPage({ storeKey: cronStoreKey(storePath), jobId, limit: 10 })` — see Real Behavior Proof below.

## Root Cause

- Bug introduced by commit `98742bc2c7f2` (2026-07-21, `feat(cron): stream schedule sources with durable source identity (#112387)`): `recordExternalFailure` was created there (in `src/cron/service/ops.ts`) already emitting the terminal event via bare `emit(state, ...)`. Commit `731a5d1e45` (2026-07-25, `refactor(cron): split service operations (#113830)`) later moved the function verbatim into `src/cron/service/ops-read.ts` without changing the behavior. Verified via GitHub API: the parent commit `2cd4e5a8be` contains no `recordExternalFailure`; both `98742bc2c7f2` and `731a5d1e45` contain the bare `emit`.
- Violated invariant: every `finished` cron event must be routed through `emitCronRunFinished`, which calls `tryFinishCronTaskRun` before `emit` so the durable task ledger row is finalized and run history can serve it. `recordExternalFailure` was the one `finished` emission that skipped the ledger.
- Trigger condition: a stream-scheduled job whose event source fails terminally (restart budget exhausted), i.e. the scheduler-owned source calls `recordExternalFailure`. No payload run ever starts (`executionStarted: false`), so no other code path finalizes a ledger row for this failure.

## Why This Fix

- Option A: call `tryFinishCronTaskRun` directly in `recordExternalFailure` and keep the bare `emit` — rejected: duplicates the internals of `emitCronRunFinished` (event shaping, manual-run tracker handling) and creates a second place that must stay in sync with it.
- Option B (chosen): route the existing event through `emitCronRunFinished(state, { ... })` — one-line change that makes `recordExternalFailure` use the same finalization path as every other `finished` emission in the service. The event payload is unchanged, so listeners and failure-alert delivery (`failureNotificationDeliveryFromJobState`) behave exactly as before; the only delta is that the ledger row is now finalized.
- Option C: synthesize a ledger row in `readCronTaskRunHistoryPage` for jobs whose state shows an unrecorded error — rejected: repairs data at read time instead of writing it correctly, and cannot reconstruct run metadata (timestamps, error classification).

## User Impact

- Affected operations: cron run history views (CLI/RPC) and failure-alert follow-up for stream-scheduled jobs whose source died permanently.
- Before: the job shows `lastRunStatus=error` and a failure alert fires, but run history for the job is empty — the alert references a run that does not exist anywhere inspectable.
- After: the terminal failure appears in run history as a `finished` entry with `status=error` and the exhaustion error message (`stream source exhausted restarts`), consistent with how a fifth consecutive payload error is recorded.
- Behavior change: run history gains one additional `error` entry per terminal stream-source exhaustion. This is strictly better: the entry reflects a real state transition that previously updated job state and fired alerts without leaving any durable run record.

## Evidence
Setup: the **real** `CronService` from `src/cron/service.ts` driven end-to-end via `node --import tsx proof.mjs` — real store on a temp directory, real stream job add, real `recordExternalFailure`, real `readCronTaskRunHistoryPage`. Only constructor-injected dependencies (logger, `enqueueSystemEvent`, `requestHeartbeat`, `runIsolatedAgentJob`) are provided through the service's existing DI interface; nothing under test is mocked.

### Before (on main)

```bash
$ node --import tsx proof.mjs   # src/cron/service/ops-read.ts @ HEAD~1
created job: 9010a27f-601d-42f9-9328-019442d31868
[enqueueSystemEvent] Automation "stream" failed 5 times
Last error: stream source exhausted restarts
job.state.lastRunStatus: error
job.state.streamRestartExhausted: true
run history total: 0
FAIL: job.state.lastRunStatus=error but the task run ledger has no record (total=0)
exit code: 1
```

### After (with fix)

```bash
$ node --import tsx proof.mjs   # src/cron/service/ops-read.ts @ HEAD
created job: ac53c256-c0a1-4cb0-a769-88d025c552a5
[enqueueSystemEvent] Automation "stream" failed 5 times
Last error: stream source exhausted restarts
job.state.lastRunStatus: error
job.state.streamRestartExhausted: true
run history total: 1
history entry: {"jobId":"ac53c256-...","action":"finished","status":"error","error":"stream source exhausted restarts"}
PASS: terminal stream failure recorded in the task run ledger
exit code: 0
```

## Tests and Validation

- `node node_modules/vitest/vitest.mjs run src/cron/service.stream-validation.test.ts` — 8 passed (1 test file), including the new `records restart exhaustion in the cron task run history` regression test asserting `history.total === 1` with `status: "error"`.
- Manual verification (the proof above), same script against both versions of `src/cron/service/ops-read.ts`:
  1. Pre-fix (`git checkout HEAD~1 -- src/cron/service/ops-read.ts`): job state shows `lastRunStatus=error`, failure alert fires, but `readCronTaskRunHistoryPage` returns `total: 0` — FAIL.
  2. Fixed (`git checkout HEAD -- src/cron/service/ops-read.ts`): same scenario returns `total: 1` with a `finished`/`error` entry carrying the exhaustion message — PASS.
