### PR TITLE
fix(ui): ignore malformed realtime talk audio frames instead of throwing

### DIFF
--- a/ui/src/pages/chat/realtime-talk-audio.test.ts
+++ b/ui/src/pages/chat/realtime-talk-audio.test.ts
@@ -191,6 +191,15 @@ describe("RealtimeTalkPcmOutputQueue", () => {
     expect(context.sources).toHaveLength(0);
   });
 
+  it("ignores malformed base64 frames instead of throwing", () => {
+    const context = new MockOutputAudioContext();
+    const queue = new RealtimeTalkPcmOutputQueue();
+
+    // Short enough to pass the size gate, invalid enough to fail atob.
+    expect(queue.play("!!!", context as unknown as AudioContext, 100)).toBe("ignored");
+    expect(context.sources).toHaveLength(0);
+  });
+
   it("hard-caps source ownership across ten thousand suspended-context chunks", () => {
     const context = new MockOutputAudioContext();
     const queue = new RealtimeTalkPcmOutputQueue();

--- a/ui/src/pages/chat/realtime-talk-audio.ts
+++ b/ui/src/pages/chat/realtime-talk-audio.ts
@@ -258,7 +258,14 @@ export class RealtimeTalkPcmOutputQueue {
     ) {
       return "overflow";
     }
-    const samples = pcm16ToFloat(base64ToBytes(base64));
+    let samples: Float32Array;
+    try {
+      samples = pcm16ToFloat(base64ToBytes(base64));
+    } catch {
+      // Malformed base64 in a relayed frame must not throw back into the
+      // realtime event path; drop it like any other ignorable frame.
+      return "ignored";
+    }
     if (samples.length === 0) {
       return "ignored";
     }


### PR DESCRIPTION
## Summary

`fix(ui): ignore malformed realtime Talk audio frames instead of throwing InvalidCharacterError through the playback result contract`

## What Problem This Solves

In the Control UI's realtime Talk mode, PCM audio frames arrive from the network as base64 strings (Google Live websocket messages, or gateway-relay session events). `RealtimeTalkPcmOutputQueue.play()` decodes each frame and queues it for playback, returning one of `"queued" | "ignored" | "overflow"` so callers can react to backpressure. Both call sites — `ui/src/pages/chat/realtime-talk-google-live.ts:480` (`playPcm16`) and `ui/src/pages/chat/realtime-talk-gateway-relay.ts:382` (`playPcm16`) — only handle those three outcomes; neither expects `play()` to throw.

A malformed frame that is *short* slips past the overflow/size gate (which only estimates the decoded byte length from the string length) and then hits the raw `atob` decode, which throws `InvalidCharacterError`. That exception escapes `play()` and propagates back into the realtime event path. On Google Live it surfaces as an unhandled rejection for that message. On gateway-relay, active listener dispatch isolates and logs the exception, while a malformed frame queued before activation can abort startup when the pending event is replayed.

Blast radius: any Talk session whose transport relays a corrupt or truncated base64 frame — e.g. a gateway restart mid-stream, a proxy mangling a websocket message, or a provider emitting an unexpected payload shape. Rare per-frame; the malformed chunk is not playable, but it currently produces a runtime exception and can abort gateway-relay startup when replayed before activation.

**Code evidence**: in `ui/src/pages/chat/realtime-talk-audio.ts` (pre-fix, main), `play()` decodes unguarded at line 261:

```ts
const samples = pcm16ToFloat(base64ToBytes(base64));
```

and `base64ToBytes` at lines 12-19 calls `atob(value)` directly:

```ts
function base64ToBytes(value: string): Uint8Array {
  const binary = atob(value); // throws InvalidCharacterError on malformed input
  ...
}
```

The size gate at lines 252-260 only inspects `estimateBase64DecodedByteLength(base64)` — a length *estimate* — so a 3-character string like `"!!!"` (estimated ~2 bytes = 1 sample = 0.01s at 100 Hz) passes every gate and reaches `atob`, which throws.

Minimal reproduction: `new RealtimeTalkPcmOutputQueue().play("!!!", anyAudioContext, 100)` — see Real Behavior Proof below.

## Root Cause

- The unguarded decode was introduced by commit `65e12328aa` (2026-07-04, `feat: refactor the Control UI architecture`), which created this file with `play()` calling `pcm16ToFloat(base64ToBytes(base64))` on an unprotected `atob` (verified via the GitHub API at ref `65e12328aa`: `base64ToBytes` at lines 12-13, direct call at line 56). At that time `play()` returned `void`, so a throw was merely unhandled; commit `b54e0049c5` (2026-07-31, `fix(ui): bound realtime Talk PCM playback ownership`) then gave `play()` the `"queued" | "ignored" | "overflow"` result contract *without* guarding the decode, turning the unhandled throw into an outright contract violation.
- Violated invariant: `play()` is specified to always classify a frame into `queued`/`ignored`/`overflow` and never throw — its callers are written against exactly that contract. The code assumed every string reaching the decode step is valid base64, but the size gate upstream only bounds *estimated length*, it does not validate content.
- Trigger condition: a relayed PCM frame whose base64 payload is malformed but short enough to pass the decoded-length estimate — e.g. `"!!!"` — delivered over the Google Live websocket or a gateway-relay session event while the browser output context is available.

## Why This Fix

- Option A: validate the base64 payload before decoding (regex or charset scan) — rejected: duplicates work `atob` already does, adds a second definition of "valid base64" that can drift from the decoder's, and costs a full pass over every healthy frame on the hot audio path.
- Option B: fix the callers to wrap `play()` in try/catch — rejected: two call sites would each need the same defensive code, the contract stays dishonest, and any future caller re-introduces the crash. The contract should be honored inside `play()`, not patched around outside it.
- Option C (chosen): wrap only the decode (`pcm16ToFloat(base64ToBytes(base64))`) in try/catch inside `play()` and return `"ignored"` — the same classification already used for empty frames and for bad JSON frames in both realtime transports. One decode site, one guard, contract restored exactly where it is defined, zero cost for healthy frames beyond the try block itself.

## User Impact

- Affected operations: Control UI realtime Talk sessions on both transports (Google Live and gateway-relay) when a malformed PCM frame is relayed.
- Before: one corrupt frame throws `InvalidCharacterError` out of the playback queue — surfacing as an unhandled rejection for that Google Live message, being isolated and logged during active gateway-relay dispatch, or aborting gateway-relay startup when replayed before activation.
- After: the corrupt frame is dropped and reported as `"ignored"`, exactly like an empty frame; playback of subsequent healthy frames continues uninterrupted.
- Behavior change: malformed frames now degrade to a classified skipped audio chunk instead of escaping through the event path as an exception. Healthy playback and overflow behavior remain unchanged.

## Evidence
Setup: the **real** `ui/src/pages/chat/realtime-talk-audio.ts` module is imported directly with `node --import tsx` and `RealtimeTalkPcmOutputQueue.play("!!!", ctx, 100)` is driven through the module's own `outputContext` parameter; only the browser `AudioContext` is stubbed (external audio device/environment — `currentTime`, `createBuffer`, `createBufferSource`, mirroring the test file's `MockOutputAudioContext`). No code under test is mocked.

### Before (on main)

```bash
$ node --import tsx proof.mjs
play("!!!") on RealtimeTalkPcmOutputQueue
FAIL: play() threw InvalidCharacterError: Invalid character
contract violated: callers only expect 'queued' | 'ignored' | 'overflow'
exit code: 1
```

### After (with fix)

```bash
$ node --import tsx proof.mjs
play("!!!") on RealtimeTalkPcmOutputQueue
returned: "ignored"
PASS: malformed frame ignored per the queued|ignored|overflow contract
exit code: 0
```

## Tests and Validation

- `cd ui && node ../node_modules/vitest/vitest.mjs run --config vitest.config.ts src/pages/chat/realtime-talk-audio.test.ts` — 10/10 passed (includes the new `ignores malformed base64 frames instead of throwing` case asserting `play("!!!", ...) === "ignored"` and no source allocated)
- Manual verification (the proof above):
  1. On main, `play("!!!", ctx, 100)` throws `InvalidCharacterError` through the result contract (exit 1).
  2. With the fix, the same call returns `"ignored"` and allocates no playback source (exit 0).
- Note: validation was scoped to the affected test file as instructed; the repo-wide suite was not run in this environment.

