### PR TITLE
feat(provider): add Nexforce Router

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -565,6 +565,11 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/moonshot/**"
+"extensions: nexforce":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/nexforce/**"
+          - "docs/providers/nexforce.md"
 "extensions: nvidia":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -92,6 +92,22 @@
     "target": "clawrouter"
   },
   {
+    "source": "Nexforce Router (multi-provider routing)",
+    "target": "Nexforce Router（多提供商路由）"
+  },
+  {
+    "source": "Nexforce Router",
+    "target": "Nexforce Router"
+  },
+  {
+    "source": "Nexforce plugin",
+    "target": "Nexforce 插件"
+  },
+  {
+    "source": "nexforce",
+    "target": "nexforce"
+  },
+  {
     "source": "OpenAI",
     "target": "OpenAI"
   },

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -288,6 +288,7 @@ messages and normalizes `stats.cached` into `cacheRead`; legacy
 | Mistral                                 | `mistral`                        | `MISTRAL_API_KEY`                                    | `mistral/mistral-large-latest`                         |
 | Moonshot                                | `moonshot`                       | `MOONSHOT_API_KEY`                                   | `moonshot/kimi-k2.6`                                   |
 | NVIDIA                                  | `nvidia`                         | `NVIDIA_API_KEY`                                     | `nvidia/nvidia/nemotron-3-ultra-550b-a55b`             |
+| Nexforce Router                         | `nexforce`                       | `NEXFORCE_API_KEY`                                   | `nexforce/smart-route`                                 |
 | NovitaAI                                | `novita`                         | `NOVITA_API_KEY`                                     | `novita/deepseek/deepseek-v3-0324`                     |
 | [Ollama Cloud](/providers/ollama-cloud) | `ollama-cloud`                   | `OLLAMA_API_KEY`                                     | `ollama-cloud/kimi-k2.6`                               |
 | OpenRouter                              | `openrouter`                     | OpenRouter OAuth or `OPENROUTER_API_KEY`             | `openrouter/auto`                                      |

--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -51,7 +51,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Core npm package
 
-54 plugins
+55 plugins
 
 - **[admin-http-rpc](/plugins/reference/admin-http-rpc)** (`@openclaw/admin-http-rpc`) - included in OpenClaw. OpenClaw admin HTTP RPC endpoint.
 
@@ -118,6 +118,8 @@ Each entry lists the package, distribution route, and description.
 - **[migrate-hermes](/plugins/reference/migrate-hermes)** (`@openclaw/migrate-hermes`) - included in OpenClaw. Imports Hermes configuration, memories, skills, and supported credentials into OpenClaw.
 
 - **[minimax](/plugins/reference/minimax)** (`@openclaw/minimax-provider`) - included in OpenClaw. Adds MiniMax, MiniMax Portal model provider support to OpenClaw.
+
+- **[nexforce](/plugins/reference/nexforce)** (`@openclaw/nexforce-provider`) - included in OpenClaw; npm; ClawHub: `clawhub:@openclaw/nexforce-provider`. Adds Nexforce model provider support to OpenClaw.
 
 - **[nvidia](/plugins/reference/nvidia)** (`@openclaw/nvidia-provider`) - included in OpenClaw. Adds NVIDIA model provider support to OpenClaw.
 

--- a/docs/plugins/reference.md
+++ b/docs/plugins/reference.md
@@ -15,5 +15,5 @@ This page is generated from `extensions/*/package.json` and
 pnpm plugins:inventory:gen
 ```
 
-Use [Plugin inventory](/plugins/plugin-inventory) to browse all 146
+Use [Plugin inventory](/plugins/plugin-inventory) to browse all 147
 generated plugin reference pages by distribution, package, and description.

--- a/docs/plugins/reference/nexforce.md
+++ b/docs/plugins/reference/nexforce.md
@@ -1,0 +1,23 @@
+---
+summary: "Adds Nexforce model provider support to OpenClaw."
+read_when:
+  - You are installing, configuring, or auditing the nexforce plugin
+title: "Nexforce plugin"
+---
+
+# Nexforce plugin
+
+Adds Nexforce model provider support to OpenClaw.
+
+## Distribution
+
+- Package: `@openclaw/nexforce-provider`
+- Install route: included in OpenClaw; npm; ClawHub: `clawhub:@openclaw/nexforce-provider`
+
+## Surface
+
+providers: `nexforce`
+
+## Related docs
+
+- [nexforce](/providers/nexforce)

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -58,6 +58,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 - [MiniMax](/providers/minimax)
 - [Mistral](/providers/mistral)
 - [Moonshot AI (Kimi + Kimi Coding)](/providers/moonshot)
+- [Nexforce Router (multi-provider routing)](/providers/nexforce)
 - [NovitaAI](/providers/novita)
 - [NVIDIA](/providers/nvidia)
 - [Ollama (cloud + local models)](/providers/ollama)

--- a/docs/providers/nexforce.md
+++ b/docs/providers/nexforce.md
@@ -1,0 +1,143 @@
+---
+summary: "Nexforce Router setup (auth + model selection)"
+title: "Nexforce Router"
+read_when:
+  - You want one API key for many LLMs
+  - You want Latin American local billing and compliance for AI inference
+  - You want automatic fallback and per-key cost control
+---
+
+Nexforce Router is Latin America's largest AI inference router. One
+OpenAI-compatible endpoint routes to Anthropic, OpenAI, Google, DeepSeek,
+Moonshot, Zhipu, and Cloudflare Workers AI models behind a single API key, with
+per-key fallback chains and spend caps.
+
+| Property | Value                                  |
+| -------- | -------------------------------------- |
+| Provider | `nexforce`                             |
+| Auth     | `NEXFORCE_API_KEY`                     |
+| API      | OpenAI-compatible                      |
+| Base URL | `https://router.nexforce.ai/v1`        |
+| Models   | `https://router.nexforce.ai/v1/models` |
+
+For teams in the region, Nexforce handles billing and compliance locally for
+each country, so you get compliant, locally-issued invoices and payment
+infrastructure without FX or foreign-procurement friction.
+
+## Install plugin
+
+Install the official plugin, then restart Gateway:
+
+```bash
+openclaw plugins install @openclaw/nexforce-provider
+openclaw gateway restart
+```
+
+## Getting started
+
+<Steps>
+  <Step title="Get your API key">
+    Create an API key at
+    [marketplace.nexforce.ai](https://marketplace.nexforce.ai/workspace/ai-gateway/ai-gateway-keys).
+  </Step>
+  <Step title="Run onboarding">
+    ```bash
+    openclaw onboard --auth-choice nexforce-api-key
+    ```
+
+    Prompts for your API key and sets `nexforce/smart-route` as the default
+    model. `smart-route` lets the router pick an equivalent model per request
+    while preserving the required capabilities.
+
+  </Step>
+  <Step title="Verify models are available">
+    ```bash
+    openclaw models list --provider nexforce
+    ```
+
+    OpenClaw discovers the live catalog from the router's public `/v1/models`
+    endpoint. To inspect the plugin's static fallback catalog without a running
+    Gateway:
+
+    ```bash
+    openclaw models list --all --provider nexforce
+    ```
+
+  </Step>
+</Steps>
+
+<AccordionGroup>
+  <Accordion title="Non-interactive setup">
+    For scripted or headless installations, pass all flags directly:
+
+    ```bash
+    openclaw onboard --non-interactive \
+      --mode local \
+      --auth-choice nexforce-api-key \
+      --nexforce-api-key "$NEXFORCE_API_KEY" \
+      --skip-health \
+      --accept-risk
+    ```
+
+  </Accordion>
+</AccordionGroup>
+
+<Warning>
+If Gateway runs as a daemon (launchd/systemd), make sure `NEXFORCE_API_KEY` is
+available to that process (for example, in `~/.openclaw/.env` or via
+`env.shellEnv`).
+</Warning>
+
+## Built-in catalog
+
+These bundled fallback models are available before live catalog discovery, and
+are also the recommended agentic (tool-calling) set. Any other model the router
+serves, including the full per-vendor catalogs, resolves dynamically from the
+live `/v1/models` endpoint.
+
+| Model ref                              | Name                 | Input      | Context   | Max output | Notes                                |
+| -------------------------------------- | -------------------- | ---------- | --------- | ---------- | ------------------------------------ |
+| `nexforce/smart-route`                 | Nexforce Smart Route | text       | 200,000   | 128,000    | Default; router picks the best model |
+| `nexforce/anthropic/claude-sonnet-4-6` | Claude Sonnet 4.6    | text+image | 1,000,000 | 128,000    | Agentic fallback (Anthropic)         |
+| `nexforce/openai/gpt-5.4`              | GPT-5.4              | text+image | 1,050,000 | 128,000    | Agentic fallback (OpenAI)            |
+| `nexforce/deepseek/deepseek-v4-flash`  | DeepSeek V4 Flash    | text       | 1,000,000 | 384,000    | Cheap auxiliary model                |
+| `nexforce/google/gemini-3.6-flash`     | Gemini 3.6 Flash     | text+image | 1,048,576 | 65,536     | Agentic fallback (Google)            |
+| `nexforce/z-ai/glm-5`                  | GLM-5                | text       | 204,800   | 131,072    | Agentic fallback (Zhipu)             |
+
+<Note>
+Model refs include the provider prefix: `nexforce/<upstream-provider>/<model>`.
+For example `nexforce/openai/gpt-5.4` or `nexforce/smart-route`. The model id
+`nexforce/smart-route` routes dynamically; model limits then follow the model
+the router actually serves for that request.
+</Note>
+
+## Cost control and transparency
+
+Fallback chains, rate limits, and spend caps are configured per API key on the
+Nexforce side. Every response discloses which model actually served the request
+via the `X-Nexforce-Requested-Model` / `X-Nexforce-Served-Model` headers, so you
+always know which model answered and what it cost.
+
+## Config example
+
+```json5
+{
+  env: { NEXFORCE_API_KEY: "nfc_..." },
+  agents: {
+    defaults: {
+      model: { primary: "nexforce/smart-route" },
+    },
+  },
+}
+```
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Model selection" href="/concepts/model-providers" icon="layers">
+    Choosing providers, model refs, and failover behavior.
+  </Card>
+  <Card title="Configuration reference" href="/gateway/configuration-reference" icon="gear">
+    Full config reference for agents, models, and providers.
+  </Card>
+</CardGroup>

--- a/docs/providers/nexforce.md
+++ b/docs/providers/nexforce.md
@@ -114,9 +114,11 @@ the router actually serves for that request.
 ## Cost control and transparency
 
 Fallback chains, rate limits, and spend caps are configured per API key on the
-Nexforce side. Every response discloses which model actually served the request
-via the `X-Nexforce-Requested-Model` / `X-Nexforce-Served-Model` headers, so you
-always know which model answered and what it cost.
+Nexforce side. On the Nexforce side, every response discloses which model
+actually served the request via the `X-Nexforce-Requested-Model` /
+`X-Nexforce-Served-Model` response headers. Those headers are provider-side
+metadata; inspect them at your HTTP layer if you want to audit the served model
+and associated cost.
 
 ## Config example
 

--- a/extensions/nexforce/README.md
+++ b/extensions/nexforce/README.md
@@ -1,0 +1,15 @@
+# OpenClaw Nexforce Router Provider
+
+Official OpenClaw provider plugin for the Nexforce Router, Latin America's
+largest AI inference router. One OpenAI-compatible endpoint and one API key
+reach Anthropic, OpenAI, Google, DeepSeek, Moonshot, Zhipu, and Cloudflare
+Workers AI models, with automatic fallback and per-key cost control.
+
+Install from OpenClaw:
+
+```bash
+openclaw plugins install @openclaw/nexforce-provider
+openclaw gateway restart
+```
+
+See <https://docs.openclaw.ai/providers/nexforce> for setup and configuration.

--- a/extensions/nexforce/api.ts
+++ b/extensions/nexforce/api.ts
@@ -1,0 +1,6 @@
+/**
+ * Public Nexforce Router provider plugin API exports.
+ */
+export { buildNexforceCatalogModels, NEXFORCE_BASE_URL, NEXFORCE_MODEL_CATALOG } from "./models.js";
+export { buildNexforceProvider } from "./provider-catalog.js";
+export { applyNexforceConfig, NEXFORCE_DEFAULT_MODEL_REF } from "./onboard.js";

--- a/extensions/nexforce/index.test.ts
+++ b/extensions/nexforce/index.test.ts
@@ -1,0 +1,94 @@
+// Nexforce tests cover index plugin behavior.
+import {
+  registerSingleProviderPlugin,
+  resolveProviderPluginChoice,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
+import { describe, expect, it } from "vitest";
+import nexforcePlugin from "./index.js";
+
+describe("nexforce provider plugin", () => {
+  it("registers Nexforce with api-key auth wizard metadata", async () => {
+    const provider = await registerSingleProviderPlugin(nexforcePlugin);
+    const resolved = resolveProviderPluginChoice({
+      providers: [provider],
+      choice: "nexforce-api-key",
+    });
+
+    expect(provider.id).toBe("nexforce");
+    expect(provider.label).toBe("Nexforce Router");
+    expect(provider.envVars).toEqual(["NEXFORCE_API_KEY"]);
+    expect(provider.auth).toHaveLength(1);
+    if (!resolved) {
+      throw new Error("expected Nexforce api-key auth choice");
+    }
+    expect(resolved.provider.id).toBe("nexforce");
+    expect(resolved.method.id).toBe("api-key");
+  });
+
+  it("builds the static Nexforce model catalog", async () => {
+    const provider = await registerSingleProviderPlugin(nexforcePlugin);
+    const staticResult = await provider.staticCatalog?.run({ config: {}, env: {} } as never);
+    if (!staticResult || !("provider" in staticResult)) {
+      throw new Error("expected static Nexforce provider catalog");
+    }
+
+    expect(staticResult.provider.api).toBe("openai-completions");
+    expect(staticResult.provider.baseUrl).toBe("https://router.nexforce.ai/v1");
+    expect(staticResult.provider.models.map((model) => model.id)).toEqual([
+      "smart-route",
+      "anthropic/claude-sonnet-4-6",
+      "openai/gpt-5.4",
+      "deepseek/deepseek-v4-flash",
+      "google/gemini-3.6-flash",
+      "z-ai/glm-5",
+    ]);
+    const smartRoute = staticResult.provider.models.find((model) => model.id === "smart-route");
+    expect(smartRoute?.name).toBe("Nexforce Smart Route");
+    expect(smartRoute?.input).toEqual(["text"]);
+  });
+
+  it("owns OpenAI-compatible replay policy", async () => {
+    const provider = await registerSingleProviderPlugin(nexforcePlugin);
+
+    const replayPolicy = provider.buildReplayPolicy?.({ modelApi: "openai-completions" } as never);
+    expect(replayPolicy?.sanitizeToolCallIds).toBe(true);
+    expect(replayPolicy?.toolCallIdMode).toBe("strict");
+    expect(replayPolicy?.validateGeminiTurns).toBe(true);
+    expect(replayPolicy?.validateAnthropicTurns).toBe(true);
+  });
+
+  it("publishes configured Nexforce models through plugin-owned catalog augmentation", async () => {
+    const provider = await registerSingleProviderPlugin(nexforcePlugin);
+
+    expect(
+      provider.augmentModelCatalog?.({
+        config: {
+          models: {
+            providers: {
+              nexforce: {
+                models: [
+                  {
+                    id: "custom/model",
+                    name: "Custom model",
+                    input: ["text"],
+                    reasoning: false,
+                    contextWindow: 65536,
+                  },
+                ],
+              },
+            },
+          },
+        },
+      } as never),
+    ).toEqual([
+      {
+        provider: "nexforce",
+        id: "custom/model",
+        name: "Custom model",
+        input: ["text"],
+        reasoning: false,
+        contextWindow: 65536,
+      },
+    ]);
+  });
+});

--- a/extensions/nexforce/index.ts
+++ b/extensions/nexforce/index.ts
@@ -1,0 +1,47 @@
+/**
+ * Nexforce Router provider plugin entrypoint.
+ */
+import { readConfiguredProviderCatalogEntries } from "openclaw/plugin-sdk/provider-catalog-shared";
+import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
+import { buildProviderReplayFamilyHooks } from "openclaw/plugin-sdk/provider-model-shared";
+import { applyNexforceConfig } from "./onboard.js";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
+import { buildNexforceProvider } from "./provider-catalog.js";
+
+const PROVIDER_ID = "nexforce";
+
+export default defineSingleProviderPluginEntry({
+  id: PROVIDER_ID,
+  name: "Nexforce Router Provider",
+  description: "Bundled Nexforce Router provider plugin",
+  manifest,
+  provider: {
+    label: "Nexforce Router",
+    docsPath: "/providers/nexforce",
+    manifestAuth: {
+      hint: "API key",
+      preserveExistingPrimary: true,
+      applyConfig: applyNexforceConfig,
+      noteTitle: "Nexforce Router",
+      noteMessage: [
+        "One API key reaches Anthropic, OpenAI, Google, DeepSeek, Moonshot, Zhipu, and Cloudflare Workers AI models.",
+        "Get an API key at: https://marketplace.nexforce.ai/workspace/ai-gateway/ai-gateway-keys",
+      ].join("\n"),
+    },
+    catalog: {
+      buildProvider: buildNexforceProvider,
+      buildStaticProvider: buildNexforceProvider,
+      allowExplicitBaseUrl: true,
+      liveModelDiscovery: true,
+    },
+    augmentModelCatalog: ({ config }) =>
+      readConfiguredProviderCatalogEntries({
+        config,
+        providerId: PROVIDER_ID,
+      }),
+    ...buildProviderReplayFamilyHooks({
+      family: "openai-compatible",
+      dropReasoningFromHistory: false,
+    }),
+  },
+});

--- a/extensions/nexforce/models.ts
+++ b/extensions/nexforce/models.ts
@@ -1,0 +1,20 @@
+/**
+ * Nexforce Router model catalog helpers derived from the plugin manifest.
+ */
+import { buildManifestModelDefinition } from "openclaw/plugin-sdk/provider-catalog-shared";
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
+
+const NEXFORCE_MANIFEST_CATALOG = manifest.modelCatalog.providers.nexforce;
+
+/** Base URL for Nexforce Router OpenAI-compatible inference. */
+export const NEXFORCE_BASE_URL = NEXFORCE_MANIFEST_CATALOG.baseUrl;
+/** Nexforce Router model catalog entries from the plugin manifest. */
+export const NEXFORCE_MODEL_CATALOG = NEXFORCE_MANIFEST_CATALOG.models;
+
+/** Builds normalized Nexforce Router catalog model definitions. */
+export function buildNexforceCatalogModels(): ModelDefinitionConfig[] {
+  return NEXFORCE_MODEL_CATALOG.map(
+    buildManifestModelDefinition({ providerId: "nexforce", catalog: NEXFORCE_MANIFEST_CATALOG }),
+  );
+}

--- a/extensions/nexforce/onboard.test.ts
+++ b/extensions/nexforce/onboard.test.ts
@@ -1,0 +1,165 @@
+import { registerSingleProviderPlugin } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
+import { resolveAgentModelPrimaryValue } from "openclaw/plugin-sdk/provider-onboard";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import plugin from "./index.js";
+import { applyNexforceConfig, NEXFORCE_DEFAULT_MODEL_REF } from "./onboard.js";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
+
+const ssrfRuntimeMocks = vi.hoisted(() => ({
+  fetchWithSsrFGuard: vi.fn(),
+  ssrfPolicyFromHttpBaseUrlAllowedHostname: vi.fn((baseUrl: string) => ({
+    allowedHostnames: [new URL(baseUrl).hostname],
+  })),
+}));
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ssrfRuntimeMocks);
+
+function jsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+afterEach(() => {
+  clearLiveCatalogCacheForTests();
+  ssrfRuntimeMocks.fetchWithSsrFGuard.mockReset();
+  ssrfRuntimeMocks.ssrfPolicyFromHttpBaseUrlAllowedHostname.mockClear();
+});
+
+describe("Nexforce onboarding", () => {
+  it("applies the manifest catalog, default, and alias", () => {
+    const config = applyNexforceConfig({});
+
+    expect(config.models?.providers?.nexforce?.models.map((model) => model.id)).toEqual(
+      manifest.modelCatalog.providers.nexforce.models.map((model) => model.id),
+    );
+    expect(resolveAgentModelPrimaryValue(config.agents?.defaults?.model)).toBe(
+      NEXFORCE_DEFAULT_MODEL_REF,
+    );
+    expect(config.agents?.defaults?.models).toEqual({
+      [NEXFORCE_DEFAULT_MODEL_REF]: { alias: "Nexforce Smart Route" },
+    });
+  });
+
+  it("preserves an existing primary during non-interactive auth setup", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const method = provider.auth?.[0];
+    if (!method?.runNonInteractive) {
+      throw new Error("expected Nexforce non-interactive auth method");
+    }
+
+    const result = await method.runNonInteractive({
+      authChoice: "nexforce-api-key",
+      config: {
+        agents: {
+          defaults: {
+            model: { primary: "anthropic/claude-sonnet-4-6" },
+            models: { "anthropic/claude-sonnet-4-6": { alias: "Existing" } },
+          },
+        },
+      },
+      opts: {},
+      runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
+      resolveApiKey: vi.fn(async () => ({ key: "fixture-value", source: "profile" })),
+      toApiKeyCredential: vi.fn(() => null),
+    } as never);
+
+    expect(resolveAgentModelPrimaryValue(result?.agents?.defaults?.model)).toBe(
+      "anthropic/claude-sonnet-4-6",
+    );
+    expect(result?.agents?.defaults?.models).toEqual({
+      "anthropic/claude-sonnet-4-6": { alias: "Existing" },
+      [NEXFORCE_DEFAULT_MODEL_REF]: { alias: "Nexforce Smart Route" },
+    });
+  });
+
+  it("keeps the static catalog without querying the model endpoint", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const staticResult = await provider.staticCatalog?.run({ config: {}, env: {} } as never);
+    if (!staticResult || !("provider" in staticResult)) {
+      throw new Error("expected static Nexforce provider catalog");
+    }
+
+    expect(ssrfRuntimeMocks.fetchWithSsrFGuard).not.toHaveBeenCalled();
+    expect(staticResult.provider.baseUrl).toBe("https://router.nexforce.ai/v1");
+    expect(staticResult.provider.api).toBe("openai-completions");
+    expect(staticResult.provider.models.map((model) => model.id)).toEqual(
+      manifest.modelCatalog.providers.nexforce.models.map((model) => model.id),
+    );
+    expect(
+      staticResult.provider.models.find((model) => model.id === "openai/gpt-5.4")?.input,
+    ).toEqual(["text", "image"]);
+  });
+
+  it("discovers the live catalog from the router /v1/models endpoint", async () => {
+    ssrfRuntimeMocks.fetchWithSsrFGuard.mockResolvedValueOnce({
+      response: jsonResponse({
+        object: "list",
+        data: [
+          {
+            id: "openai/gpt-5.4",
+            name: "GPT-5.4",
+            context_length: 1050000,
+            max_output_tokens: 128000,
+            architecture: { input_modalities: ["text", "image", "pdf"] },
+          },
+          {
+            id: "anthropic/claude-opus-4-7",
+            name: "Claude Opus 4.7",
+            context_length: 1000000,
+            max_output_tokens: 128000,
+            architecture: { input_modalities: ["text", "image", "pdf"] },
+          },
+          {
+            id: "meta-llama/llama-3.1-70b",
+            name: "Llama 3.1 70B",
+            context_length: 131072,
+            max_output_tokens: 8192,
+          },
+        ],
+      }),
+      finalUrl: "https://router.nexforce.ai/v1/models",
+      release: vi.fn(),
+    });
+    const provider = await registerSingleProviderPlugin(plugin);
+    const result = await provider.catalog?.run({
+      config: {},
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: "fixture-nexforce-key" }),
+    } as never);
+
+    if (!result || !("provider" in result)) {
+      throw new Error("expected authenticated Nexforce provider catalog");
+    }
+    expect(result.provider.apiKey).toBe("fixture-nexforce-key");
+    expect(result.provider.models.map((model) => model.id)).toEqual([
+      "anthropic/claude-opus-4-7",
+      "meta-llama/llama-3.1-70b",
+      "openai/gpt-5.4",
+    ]);
+    expect(ssrfRuntimeMocks.fetchWithSsrFGuard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://router.nexforce.ai/v1/models",
+      }),
+    );
+  });
+
+  it("declares the bundled provider catalog as refreshable", () => {
+    expect(manifest.modelCatalog.discovery.nexforce).toBe("refreshable");
+  });
+
+  it("keeps the runtime catalog inactive without a Nexforce credential", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+
+    await expect(
+      provider.catalog?.run({
+        config: {},
+        env: {},
+        resolveProviderApiKey: () => ({}),
+      } as never),
+    ).resolves.toBeNull();
+    expect(ssrfRuntimeMocks.fetchWithSsrFGuard).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/nexforce/onboard.ts
+++ b/extensions/nexforce/onboard.ts
@@ -1,0 +1,20 @@
+import { readManifestProviderDefaultModelRef } from "openclaw/plugin-sdk/provider-catalog-shared";
+import { createModelCatalogPresetAppliers } from "openclaw/plugin-sdk/provider-onboard";
+import { buildNexforceCatalogModels, NEXFORCE_BASE_URL } from "./models.js";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
+
+export const NEXFORCE_DEFAULT_MODEL_REF = readManifestProviderDefaultModelRef(
+  manifest,
+  "nexforce",
+)!;
+
+export const { applyConfig: applyNexforceConfig } = createModelCatalogPresetAppliers<[]>({
+  primaryModelRef: NEXFORCE_DEFAULT_MODEL_REF,
+  resolveParams: () => ({
+    providerId: "nexforce",
+    api: "openai-completions",
+    baseUrl: NEXFORCE_BASE_URL,
+    catalogModels: buildNexforceCatalogModels(),
+    aliases: [{ modelRef: NEXFORCE_DEFAULT_MODEL_REF, alias: "Nexforce Smart Route" }],
+  }),
+});

--- a/extensions/nexforce/openclaw.plugin.json
+++ b/extensions/nexforce/openclaw.plugin.json
@@ -6,12 +6,6 @@
   },
   "enabledByDefault": true,
   "providers": ["nexforce"],
-  "providerEndpoints": [
-    {
-      "endpointClass": "nexforce",
-      "hosts": ["router.nexforce.ai"]
-    }
-  ],
   "modelCatalog": {
     "providers": {
       "nexforce": {

--- a/extensions/nexforce/openclaw.plugin.json
+++ b/extensions/nexforce/openclaw.plugin.json
@@ -1,0 +1,102 @@
+{
+  "id": "nexforce",
+  "icon": "https://router.nexforce.ai/favicon.ico",
+  "activation": {
+    "onStartup": false
+  },
+  "enabledByDefault": true,
+  "providers": ["nexforce"],
+  "providerEndpoints": [
+    {
+      "endpointClass": "nexforce",
+      "hosts": ["router.nexforce.ai"]
+    }
+  ],
+  "modelCatalog": {
+    "providers": {
+      "nexforce": {
+        "baseUrl": "https://router.nexforce.ai/v1",
+        "api": "openai-completions",
+        "defaultModel": "smart-route",
+        "defaultUtilityModel": "deepseek/deepseek-v4-flash",
+        "models": [
+          {
+            "id": "smart-route",
+            "name": "Nexforce Smart Route",
+            "input": ["text"],
+            "contextWindow": 200000,
+            "maxTokens": 128000
+          },
+          {
+            "id": "anthropic/claude-sonnet-4-6",
+            "name": "Claude Sonnet 4.6",
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 128000
+          },
+          {
+            "id": "openai/gpt-5.4",
+            "name": "GPT-5.4",
+            "input": ["text", "image"],
+            "contextWindow": 1050000,
+            "maxTokens": 128000
+          },
+          {
+            "id": "deepseek/deepseek-v4-flash",
+            "name": "DeepSeek V4 Flash",
+            "input": ["text"],
+            "contextWindow": 1000000,
+            "maxTokens": 384000
+          },
+          {
+            "id": "google/gemini-3.6-flash",
+            "name": "Gemini 3.6 Flash",
+            "input": ["text", "image"],
+            "contextWindow": 1048576,
+            "maxTokens": 65536
+          },
+          {
+            "id": "z-ai/glm-5",
+            "name": "GLM-5",
+            "input": ["text"],
+            "contextWindow": 204800,
+            "maxTokens": 131072
+          }
+        ]
+      }
+    },
+    "discovery": {
+      "nexforce": "refreshable"
+    }
+  },
+  "setup": {
+    "providers": [
+      {
+        "id": "nexforce",
+        "envVars": ["NEXFORCE_API_KEY"]
+      }
+    ]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "nexforce",
+      "method": "api-key",
+      "choiceId": "nexforce-api-key",
+      "appGuidedSecret": true,
+      "choiceLabel": "Nexforce Router API key",
+      "choiceHint": "One key for Anthropic, OpenAI, Google, DeepSeek, Moonshot, Zhipu, and Cloudflare Workers AI models",
+      "groupId": "nexforce",
+      "groupLabel": "Nexforce Router",
+      "groupHint": "Multi-provider inference routing",
+      "optionKey": "nexforceApiKey",
+      "cliFlag": "--nexforce-api-key",
+      "cliOption": "--nexforce-api-key <key>",
+      "cliDescription": "Nexforce Router API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/nexforce/openclaw.plugin.json
+++ b/extensions/nexforce/openclaw.plugin.json
@@ -46,7 +46,10 @@
             "name": "DeepSeek V4 Flash",
             "input": ["text"],
             "contextWindow": 1000000,
-            "maxTokens": 384000
+            "maxTokens": 384000,
+            "compat": {
+              "codeMode": "preferred"
+            }
           },
           {
             "id": "google/gemini-3.6-flash",

--- a/extensions/nexforce/package.json
+++ b/extensions/nexforce/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@openclaw/nexforce-provider",
+  "version": "2026.7.2",
+  "description": "OpenClaw Nexforce Router provider plugin.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/openclaw/openclaw"
+  },
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "install": {
+      "clawhubSpec": "clawhub:@openclaw/nexforce-provider",
+      "npmSpec": "@openclaw/nexforce-provider",
+      "defaultChoice": "npm",
+      "minHostVersion": ">=2026.6.8"
+    },
+    "compat": {
+      "pluginApi": ">=2026.7.2"
+    },
+    "build": {
+      "openclawVersion": "2026.7.2",
+      "bundledDist": false
+    },
+    "release": {
+      "publishToClawHub": true,
+      "publishToNpm": true
+    }
+  }
+}

--- a/extensions/nexforce/provider-catalog.ts
+++ b/extensions/nexforce/provider-catalog.ts
@@ -1,0 +1,14 @@
+/**
+ * Nexforce Router model provider builder.
+ */
+import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
+
+/** Builds the Nexforce Router OpenAI-compatible model provider config. */
+export function buildNexforceProvider(): ModelProviderConfig {
+  return buildManifestModelProviderConfig({
+    providerId: "nexforce",
+    catalog: manifest.modelCatalog.providers.nexforce,
+  });
+}

--- a/extensions/nexforce/tsconfig.json
+++ b/extensions/nexforce/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json"
+}

--- a/package.json
+++ b/package.json
@@ -293,6 +293,7 @@
     "!dist/extensions/msteams/**",
     "!dist/extensions/mxc/**",
     "!dist/extensions/nextcloud-talk/**",
+    "!dist/extensions/nexforce/**",
     "!dist/extensions/nostr/**",
     "!dist/extensions/novita/**",
     "!dist/extensions/opencode/**",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1408,6 +1408,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/nexforce:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/nextcloud-talk:
     dependencies:
       zod:

--- a/test/scripts/publish-model-catalog.test.ts
+++ b/test/scripts/publish-model-catalog.test.ts
@@ -123,7 +123,7 @@ describe("publish model catalog", () => {
       { cwd: root, encoding: "utf8" },
     );
     expect(result.status, result.stderr).toBe(0);
-    const stats = /dry-run schemaVersion=1 providers=40 models=(\d+)/u.exec(result.stdout);
+    const stats = /dry-run schemaVersion=1 providers=41 models=(\d+)/u.exec(result.stdout);
     expect(stats).not.toBeNull();
     expect(Number(stats?.[1])).toBeGreaterThanOrEqual(MODEL_CATALOG_MIN_MODELS);
     expect(fs.existsSync(out)).toBe(false);

--- a/test/vitest-scoped-config.test.ts
+++ b/test/vitest-scoped-config.test.ts
@@ -806,6 +806,7 @@ describe("scoped vitest configs", () => {
       "mistral/**/*.test.ts",
       "qwen/**/*.test.ts",
       "moonshot/**/*.test.ts",
+      "nexforce/**/*.test.ts",
       "nvidia/**/*.test.ts",
       "ollama/**/*.test.ts",
       "openrouter/**/*.test.ts",

--- a/test/vitest/vitest.extension-provider-paths.mjs
+++ b/test/vitest/vitest.extension-provider-paths.mjs
@@ -22,6 +22,7 @@ const providerExtensionIds = [
   "mistral",
   "qwen",
   "moonshot",
+  "nexforce",
   "nvidia",
   "ollama",
   "openrouter",


### PR DESCRIPTION
## What Problem This Solves

This PR adds **Nexforce Router** — Latin America's largest AI inference router — so OpenClaw users get one API key that reaches Anthropic, OpenAI, Google, DeepSeek, Moonshot, Zhipu, and Cloudflare Workers AI models, with automatic fallback and per-key cost control.

### Value proposition

One OpenAI-compatible endpoint, one key, many model families. Nexforce routes to Anthropic, OpenAI, Google, DeepSeek, Moonshot, Zhipu, and Cloudflare Workers AI models behind `https://router.nexforce.ai/v1`, with per-key fallback chains, rate limits, and spend caps. The new bundled `nexforce` provider surfaces the router's full catalog from the live `/v1/models` endpoint, defaults to `nexforce/smart-route` (the router picks an equivalent model per request while preserving required capabilities), and bundles the recommended agentic tool-calling fallback models — `anthropic/claude-sonnet-4-6`, `openai/gpt-5.4`, `deepseek/deepseek-v4-flash`, `google/gemini-3.6-flash`, `z-ai/glm-5` — plus `deepseek/deepseek-v4-flash` as the cheap auxiliary model.

### Regional differentiator

For teams across the region, Nexforce handles billing and compliance locally per country: invoicing, taxes, and payment infrastructure are managed locally, so teams get compliant, locally-issued invoices without the FX and foreign-procurement friction of paying a provider abroad. Nexforce also exposes which model served each request through the `X-Nexforce-Requested-Model` / `X-Nexforce-Served-Model` response headers (provider-side metadata, inspectable at your HTTP layer).

## Why This Change Was Made

OpenClaw already ships bundled provider plugins for routers and OpenAI-compatible gateways (OpenRouter, ClawRouter, LiteLLM, Vercel AI Gateway, DeepSeek, Cerebras, and more). Nexforce is the same class of integration: a declarative provider plugin under `extensions/nexforce/` following the repo's provider-plugin pattern, giving users first-class onboarding (`openclaw onboard --auth-choice nexforce-api-key`), `NEXFORCE_API_KEY` env auth, and live model discovery — instead of hand-wiring a single fixed model through the generic custom-provider path.

## User Impact

- `openclaw onboard --auth-choice nexforce-api-key` prompts for a key and sets `nexforce/smart-route` as the default model.
- `openclaw models list --provider nexforce` shows the live router catalog (129 chat models at the time of writing), discovered from the public `/v1/models` endpoint.
- Model refs use `nexforce/<upstream-provider>/<model>`, e.g. `nexforce/openai/gpt-5.4` or `nexforce/smart-route`.

## What Changed

- `extensions/nexforce/` — new bundled provider plugin: declarative manifest (`openclaw.plugin.json`), entry (`index.ts`), catalog builder (`provider-catalog.ts`), onboarding (`onboard.ts`), models (`models.ts`), public API (`api.ts`), package/tsconfig/README, plus `index.test.ts` and `onboard.test.ts`.
- `docs/providers/nexforce.md` — new provider setup guide.
- `docs/providers/index.md` — provider directory entry.
- `docs/concepts/model-providers.md` — bundled provider table row.
- `docs/plugins/plugin-inventory.md`, `docs/plugins/reference.md`, `docs/plugins/reference/nexforce.md` — regenerated plugin inventory.
- `docs/.i18n/glossary.zh-CN.json` — i18n glossary entries for the new page titles/labels.
- `.github/labeler.yml` — `extensions: nexforce` label mapping.
- `test/vitest/vitest.extension-provider-paths.mjs` — route the nexforce tests into the provider vitest project.
- `pnpm-lock.yaml` — new workspace package entry.

## How to Configure

```bash
export NEXFORCE_API_KEY="nfc_..."
openclaw onboard --auth-choice nexforce-api-key
# or non-interactive:
openclaw onboard --non-interactive --mode local --auth-choice nexforce-api-key \
  --nexforce-api-key "$NEXFORCE_API_KEY" --skip-health --accept-risk
```

Config example:

```json5
{
  env: { NEXFORCE_API_KEY: "nfc_..." },
  agents: {
    defaults: {
      model: { primary: "nexforce/smart-route" },
    },
  },
}
```

- Base URL: `https://router.nexforce.ai/v1`
- Models: `https://router.nexforce.ai/v1/models` (public, no key)
- Signup: https://marketplace.nexforce.ai/workspace/ai-gateway/ai-gateway-keys

## Evidence

- Focused plugin tests: `extensions/nexforce` — 10 passing (onboarding, non-interactive auth preserves existing primary, static fallback catalog, live discovery from `/v1/models`, refreshable discovery declaration, no-credential catalog returns null).
- Shared-surface contracts: `src/plugins/contracts/*` — 1059 passing, including `shared-upstream-model.contract.test.ts` (nexforce now declares the matching `compat.codeMode` tier for the shared DeepSeek model), `extension-runtime-dependencies.contract.test.ts` (454 passing — auto-discovers the new plugin), `official-external-provider-endpoints.test.ts` (mirror contract green after dropping the inert endpoint class), `bundled-manifest-contract-plugins.test.ts`, `manifest-planner.test.ts`, `provider-public-artifacts.test.ts`.
- Tooling registrations: `test/vitest-scoped-config.test.ts` (146 passing), `test/plugin-npm-release.test.ts` (39 passing), `test/scripts/publish-model-catalog.test.ts` (8 passing).
- Live E2E (no mocks): the plugin's live catalog discovery fetched the real public `https://router.nexforce.ai/v1/models` and surfaced 129 chat models, including `nexforce/smart-route` and all recommended fallback models.
- `pnpm tsgo:extensions`, oxfmt, oxlint, `pnpm check:import-cycles`, and `pnpm plugin-sdk:surface:check` all pass.
- Known gaps, requested by ClawSweeper review:
  - Authenticated model-call proof: skipped — no `NEXFORCE_API_KEY` was available in this environment; the user opted to validate the public models endpoint only. The full `pnpm build` and check suite run in CI on the PR.
  - Full `pnpm build` ran in CI (the local run exceeded 20 min on this machine and was left to CI).
- Pre-existing note: `pnpm plugins:inventory:check` is already stale on `main` for unrelated plugins (`sms`, `cua-computer`, `google` descriptions), so this PR keeps only the nexforce-related generated-doc changes.

## ClawSweeper review responses

- **[P1] External provider catalog** — not registered in `scripts/lib/official-external-provider-catalog.json` by design: registering there declares official OpenClaw sponsorship, which is the maintainer ownership decision below. The trigger for the mirror contract was the `providerEndpoints` block, which has been **removed** (see next), so `official-external-provider-endpoints.test.ts` is green without a catalog entry.
- **[P2] Unsupported endpoint class** — fixed: the `nexforce` endpoint class is not in the core allowlist and was filtered out by metadata preparation, so the `providerEndpoints` block was inert. Removed it entirely, matching the router-provider precedent (ClawRouter, LiteLLM, Vercel AI Gateway omit `providerEndpoints`). This also clears the medium security finding (inert endpoint security metadata).
- **[P2] Response-header visibility** — fixed: the docs now describe `X-Nexforce-Requested-Model` / `X-Nexforce-Served-Model` as provider-side response metadata instead of implying OpenClaw surfaces them.
- **Merge risk: dependency guard** — the `pnpm-lock.yaml` and `extensions/nexforce/package.json` changes are the intentional, necessary result of adding a new bundled provider workspace package (its lockfile importer entry). `check-dependencies` CI passes. Merge needs a maintainer/admin `/allow-dependencies-change` approval for the current head SHA.
- **Owner decision (official vs independent)** — the ClawSweeper review recommends independent plugin distribution (no official catalog entry). Keeping the plugin bundled in this PR reflects the requested integration; maintainer direction is required on whether Nexforce should be sponsored as an official OpenClaw external provider or moved to an independently maintained package. Happy to adjust the PR accordingly.

---

_AI-assisted: authored with an OpenClaw agent. The author reviewed the integration surface (provider plugin pattern, SDK seams, docs, and test conventions) before writing code._
