### PR TITLE
test(gateway): isolate scheduled service timers

### DIFF
--- a/src/gateway/server-runtime-services.test.ts
+++ b/src/gateway/server-runtime-services.test.ts
@@ -184,6 +184,7 @@ describe("server-runtime-services", () => {
   );
 
   it("warns when cron is disabled but scheduled heartbeats remain enabled", () => {
+    vi.useFakeTimers();
     const warn = vi.fn();
     const log = {
       child: vi.fn(() => ({ info: vi.fn(), warn, error: vi.fn() })),
@@ -205,6 +206,7 @@ describe("server-runtime-services", () => {
   });
 
   it("does not warn about disabled cron when heartbeat cadence is disabled", () => {
+    vi.useFakeTimers();
     const warn = vi.fn();
     const log = {
       child: vi.fn(() => ({ info: vi.fn(), warn, error: vi.fn() })),


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-validation failure where the full Gateway server test shard could wait about 62 seconds and then fail because warning-only tests leaked scheduled recovery timers into a later timer assertion.

## Why This Change Was Made

The two warning-only cases now use fake timers, matching the rest of the timer-sensitive suite. This keeps their background scheduler handles test-local without changing Gateway runtime behavior.

## User Impact

No product runtime behavior changes. Maintainers get deterministic release and CI proof for the Gateway server shard under load.

## Evidence

- Before: exact `origin/main` Testbox run failed `server-runtime-services > activates heartbeat, cron, and delivery recovery after sidecars are ready` after 62 seconds because `schedulePendingSessionDeliveries` was called 3 times instead of 1: https://github.com/openclaw/openclaw/actions/runs/30907007898
- After: the same full `vitest.gateway-server.config.ts` lane passed all four processes, 2670/2670 tests, on Testbox.
- Focused local proof: `src/gateway/server-runtime-services.test.ts`, 28/28 tests.
- Exact post-rebase changed gate: https://github.com/openclaw/openclaw/actions/runs/30908924340
- Fresh autoreview: clean, no actionable findings, confidence 0.99.
