### PR TITLE
fix(sessions): reject a transcript turn when the session id rotates mid-append (#119220)

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-transcript-sequences.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-sequences.ts
@@ -80,7 +80,7 @@ export function rememberCommittedSqliteTranscriptMessageSequences(
   scope: SessionTranscriptTurnWriteContext,
   messages: readonly TranscriptMessageAppendResult<unknown>[],
 ): void {
-  if (!scope.agentId || !scope.sessionId || !scope.sessionKey) {
+  if (messages.length === 0 || !scope.agentId || !scope.sessionId || !scope.sessionKey) {
     return;
   }
   const resolved = resolveSqliteTranscriptScope({

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -12,7 +12,10 @@ import {
 } from "../../sessions/transcript-events.js";
 import {
   closeOpenClawAgentDatabasesForTest,
+  isOpenClawAgentDatabaseOpen,
+  listOpenClawRegisteredAgentDatabases,
   openOpenClawAgentDatabase,
+  resolveOpenClawAgentSqlitePath,
 } from "../../state/openclaw-agent-db.js";
 import { appendSqliteTrajectoryRuntimeEvents } from "../../trajectory/runtime-store.sqlite.js";
 import type { TrajectoryEvent } from "../../trajectory/types.js";
@@ -38,6 +41,7 @@ import {
   listSessionTranscriptInstances,
   loadReplySessionInitializationSnapshot,
   loadSessionEntry,
+  loadSessionEntryReadOnly,
   loadTranscriptEvents,
   markSessionAbortTarget,
   onSessionIdentityMutation,
@@ -1098,6 +1102,244 @@ describe("session accessor seam", () => {
           role: "user",
           content: "default store sqlite turn",
         }),
+      }),
+    );
+  });
+
+  it("rejects a transcript turn when the session id rotates mid-append", async () => {
+    const scope = {
+      agentId: "main",
+      sessionId: "old-rotate-session",
+      sessionKey: "agent:main:turn-rotate",
+      storePath,
+    };
+    await replaceSessionEntry(
+      { sessionKey: scope.sessionKey, storePath },
+      { sessionId: scope.sessionId, updatedAt: Date.now() },
+    );
+
+    const result = await persistSessionTranscriptTurn(scope, {
+      messages: [
+        {
+          message: { role: "user", content: "rotate-hello", timestamp: Date.now() },
+          shouldAppend: async () => {
+            // Simulate a concurrent reset rotating the session id between target
+            // resolution and the transcript append.
+            await replaceSessionEntry(
+              { sessionKey: scope.sessionKey, storePath },
+              { sessionId: "new-rotate-session", updatedAt: Date.now() },
+            );
+            return true;
+          },
+        },
+      ],
+      touchSessionEntry: true,
+      updateMode: "none",
+    });
+
+    expect(result.rejectedReason).toBe("session-rebound");
+    // The message must not be silently written into the stale session transcript.
+    await expect(
+      loadTranscriptEvents({ ...scope, sessionId: "old-rotate-session" }),
+    ).resolves.not.toContainEqual(
+      expect.objectContaining({
+        type: "message",
+        message: expect.objectContaining({ content: "rotate-hello" }),
+      }),
+    );
+  });
+
+  it("rejects a default-store transcript turn when the session id rotates mid-append", async () => {
+    // Caller omits storePath; resolveTranscriptTurnTarget derives the default
+    // store. The guarded path must still apply so rotation is visible.
+    const stateDir = path.join(tempDir, "state-rotate-default");
+    const expectedStorePath = path.join(stateDir, "agents", "main", "sessions", "sessions.json");
+    const scope = {
+      agentId: "main",
+      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+      sessionId: "old-default-rotate",
+      sessionKey: "agent:main:default-rotate",
+    };
+    await replaceSessionEntry(
+      { sessionKey: scope.sessionKey, storePath: expectedStorePath },
+      { sessionId: scope.sessionId, updatedAt: Date.now() },
+    );
+
+    const result = await persistSessionTranscriptTurn(scope, {
+      messages: [
+        {
+          message: { role: "user", content: "default-rotate-hello", timestamp: Date.now() },
+          shouldAppend: async () => {
+            await replaceSessionEntry(
+              { sessionKey: scope.sessionKey, storePath: expectedStorePath },
+              { sessionId: "new-default-rotate", updatedAt: Date.now() },
+            );
+            return true;
+          },
+        },
+      ],
+      touchSessionEntry: true,
+      updateMode: "none",
+    });
+
+    expect(result.rejectedReason).toBe("session-rebound");
+    await expect(
+      loadTranscriptEvents({
+        agentId: "main",
+        sessionId: "old-default-rotate",
+        sessionKey: scope.sessionKey,
+        storePath: expectedStorePath,
+      }),
+    ).resolves.not.toContainEqual(
+      expect.objectContaining({
+        type: "message",
+        message: expect.objectContaining({ content: "default-rotate-hello" }),
+      }),
+    );
+  });
+
+  it("keeps sessionStore-mirrored transcript turns on the legacy append path (#119221)", async () => {
+    // Mirror-only sessionStore callers (entry from memory, not a persisted
+    // SQLite row) must stay on the legacy append — the guarded transaction
+    // requires a persisted row to validate and would reject as session-rebound.
+    // Populate the mirror with an entry and deliberately create NO SQLite row,
+    // so resolveTranscriptTurnTarget resolves from the mirror (resolved.existing)
+    // and loadSessionEntry finds nothing — entryFromPersistedStore stays false.
+    const sessionStore = {} as Record<string, import("./types.js").SessionEntry>;
+    const scope = {
+      agentId: "main",
+      sessionId: "mirror-only-session",
+      sessionKey: "agent:main:mirror-only",
+      storePath,
+      sessionStore,
+    };
+    sessionStore[scope.sessionKey] = {
+      sessionId: scope.sessionId,
+      updatedAt: Date.now(),
+    };
+    // No replaceSessionEntry: the SQLite store has no row for this key.
+
+    const result = await persistSessionTranscriptTurn(scope, {
+      messages: [
+        {
+          message: { role: "user", content: "mirror-only-hello", timestamp: Date.now() },
+        },
+      ],
+      touchSessionEntry: true,
+      updateMode: "none",
+    });
+
+    // No session-rebound — the legacy append accepted the message.
+    expect(result.rejectedReason).toBeUndefined();
+    expect(result.appendedCount).toBe(1);
+  });
+
+  it("does not create database state for rejected memory-only transcript turns", async () => {
+    for (const source of ["sessionStore", "sessionEntry"] as const) {
+      const stateDir = path.join(tempDir, `rejected-memory-only-${source}`);
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+      const agentId = "main";
+      const sessionKey = `agent:main:rejected-memory-only-${source}`;
+      const sessionId = `rejected-memory-only-${source}`;
+      const memoryStorePath = path.join(stateDir, "agents", agentId, "sessions", "sessions.json");
+      const databasePath = resolveOpenClawAgentSqlitePath({ agentId, env });
+      const sessionEntry: SessionEntry = { sessionId, updatedAt: Date.now() };
+      const memorySource =
+        source === "sessionStore"
+          ? { sessionStore: { [sessionKey]: sessionEntry } }
+          : { sessionEntry };
+      expect(
+        loadSessionEntryReadOnly({ agentId, env, sessionKey, storePath: memoryStorePath }),
+      ).toBeUndefined();
+      expect(fs.existsSync(databasePath)).toBe(false);
+
+      const result = await persistSessionTranscriptTurn(
+        { agentId, env, sessionId, sessionKey, storePath: memoryStorePath, ...memorySource },
+        {
+          messages: [
+            {
+              message: { role: "user", content: "rejected-memory-only" },
+              shouldAppend: () => false,
+            },
+          ],
+          touchSessionEntry: true,
+          updateMode: "none",
+        },
+      );
+
+      expect(result).toMatchObject({ appendedCount: 0, messages: [] });
+      expect(fs.existsSync(databasePath)).toBe(false);
+      expect(isOpenClawAgentDatabaseOpen(databasePath)).toBe(false);
+      expect(listOpenClawRegisteredAgentDatabases({ env })).toEqual([]);
+    }
+  });
+
+  it("guards durable sessionStore transcript turns when the entry falls back to SQLite (#119221)", async () => {
+    // sessionStore mirror is empty (no entry for the key), so resolveTranscriptTurnTarget
+    // falls back to loadSessionEntry (SQLite). The entry is persisted — the guarded
+    // path must apply and reject on rotation.
+    const scope = {
+      agentId: "main",
+      sessionId: "durable-fallback-session",
+      sessionKey: "agent:main:durable-fallback",
+      storePath,
+      sessionStore: {} as Record<string, import("./types.js").SessionEntry>,
+    };
+    await replaceSessionEntry(
+      { sessionKey: scope.sessionKey, storePath },
+      { sessionId: scope.sessionId, updatedAt: Date.now() },
+    );
+
+    const result = await persistSessionTranscriptTurn(scope, {
+      messages: [
+        {
+          message: { role: "user", content: "durable-fallback-hello", timestamp: Date.now() },
+          shouldAppend: async () => {
+            await replaceSessionEntry(
+              { sessionKey: scope.sessionKey, storePath },
+              { sessionId: "new-durable-fallback", updatedAt: Date.now() },
+            );
+            return true;
+          },
+        },
+      ],
+      touchSessionEntry: true,
+      updateMode: "none",
+    });
+
+    expect(result.rejectedReason).toBe("session-rebound");
+  });
+
+  it("rejects a transcript turn when the session id rotates before target resolution", async () => {
+    // A reset wins before resolveTranscriptTurnTarget reads the entry, so the
+    // resolved entry already holds the replacement id. The caller still passes
+    // its old id. The guarded transaction must use the caller's id (not the
+    // resolved entry's) to detect the mismatch and reject.
+    const scope = {
+      agentId: "main",
+      sessionId: "old-preresolve-session",
+      sessionKey: "agent:main:preresolve-rotate",
+      storePath,
+    };
+    // Rotate the entry before the turn is attempted — resolve will read the new id.
+    await replaceSessionEntry(
+      { sessionKey: scope.sessionKey, storePath },
+      { sessionId: "new-preresolve-session", updatedAt: Date.now() },
+    );
+
+    const result = await persistSessionTranscriptTurn(scope, {
+      messages: [{ message: { role: "user", content: "preresolve-hello", timestamp: Date.now() } }],
+      touchSessionEntry: true,
+      updateMode: "none",
+    });
+
+    expect(result.rejectedReason).toBe("session-rebound");
+    await expect(
+      loadTranscriptEvents({ ...scope, sessionId: "new-preresolve-session" }),
+    ).resolves.not.toContainEqual(
+      expect.objectContaining({
+        type: "message",
+        message: expect.objectContaining({ content: "preresolve-hello" }),
       }),
     );
   });

--- a/src/config/sessions/session-accessor.transcript-turn.ts
+++ b/src/config/sessions/session-accessor.transcript-turn.ts
@@ -5,7 +5,7 @@ import { getRuntimeConfig } from "../io.js";
 import { resolveStorePath } from "./paths.js";
 import { updateSessionEntry } from "./session-accessor.entry-mutation.js";
 import {
-  loadSessionEntry,
+  loadSessionEntryReadOnly,
   resolveSessionEntryFromStore,
   resolveSessionEntrySelection,
 } from "./session-accessor.entry.js";
@@ -84,6 +84,28 @@ export async function persistSessionTranscriptTurn(
     throw new Error("Cannot patch session lifecycle without an expected session id");
   }
   const target = await resolveTranscriptTurnTarget(scope, options.config);
+  // Route through the guarded SQLite path when the session entry was loaded
+  // from a persisted SQLite row (not an in-memory mirror), so a session-id
+  // rotation between resolve and append surfaces a visible session-rebound
+  // rejection. Use the caller's session id (target.sessionId). Mirror-only
+  // entries (from scope.sessionStore/scope.sessionEntry) and transcript-only
+  // scopes (no entry) keep the legacy append — the guarded transaction
+  // requires a persisted row to validate. (#119221)
+  if (
+    target.entryFromPersistedStore &&
+    target.storePath &&
+    target.sessionKey &&
+    target.sessionEntry &&
+    target.sessionId
+  ) {
+    return await persistExpectedSessionTranscriptTurn(
+      { ...scope, storePath: target.storePath },
+      {
+        ...options,
+        expectedSessionId: target.sessionId,
+      },
+    );
+  }
   const appendedMessages = await runWithOwnedSessionTranscriptWriteLock(
     {
       sessionFile: target.sessionKey,
@@ -275,6 +297,7 @@ async function resolveTranscriptTurnTarget(
 ): Promise<
   SessionTranscriptTurnWriteContext & {
     sessionEntry: SessionEntry | undefined;
+    entryFromPersistedStore: boolean;
   }
 > {
   const sessionKey = scope.sessionKey?.trim();
@@ -295,22 +318,28 @@ async function resolveTranscriptTurnTarget(
     });
   const resolved = scope.sessionStore
     ? resolveSessionEntryFromStore({ store: scope.sessionStore, sessionKey })
-    : resolveSessionEntrySelection({
-        agentId,
-        ...(scope.env ? { env: scope.env } : {}),
-        sessionKey,
-        storePath,
-      });
-  const sessionEntry =
-    resolved?.existing ??
-    scope.sessionEntry ??
-    loadSessionEntry({ ...scope, agentId, sessionKey, storePath });
+    : resolveSessionEntrySelection(
+        {
+          agentId,
+          ...(scope.env ? { env: scope.env } : {}),
+          sessionKey,
+          storePath,
+        },
+        { readOnly: true },
+      );
+  // Mirrors can represent either durable Gateway state or memory-only internal
+  // sessions. Classify that provenance without materializing SQLite state.
+  const persistedEntry = scope.sessionStore
+    ? loadSessionEntryReadOnly({ ...scope, agentId, sessionKey, storePath })
+    : resolved?.existing;
+  const sessionEntry = resolved?.existing ?? scope.sessionEntry ?? persistedEntry;
   return {
     agentId,
     sessionId: scope.sessionId,
     sessionKey: resolved?.normalizedKey ?? sessionKey,
     storePath,
     sessionEntry,
+    entryFromPersistedStore: persistedEntry != null,
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

An unguarded transcript turn could resolve an active SQLite session, await message selection, and then append after that session id had rotated. The stale transcript received the message while the caller saw success.

Fixes #119220.

## Why This Change Was Made

Persisted session turns now reuse the existing identity-checked transaction and return `session-rebound` when the row changes. Target resolution uses the existing read-only session accessor, so classifying a memory mirror never creates or registers an agent database. Empty cursor bookkeeping also exits before opening SQLite.

Memory-only `sessionStore` and direct `sessionEntry` callers retain their established append behavior. Transcript-only scopes remain supported.

## User Impact

Concurrent reset or rewind no longer silently writes a turn into an obsolete transcript. The caller gets a visible rebound result and can retry against the current session. Rejected memory-only turns leave no database file, process handle, or registry row.

## Evidence

Head: `b6752c9d087e33c703dead60543d15284cca5d10`

- `node scripts/run-vitest.mjs src/config/sessions/session-accessor.test.ts` — 100 passed.
- `node scripts/run-vitest.mjs src/config/sessions/transcript.test.ts src/config/sessions/session-accessor.sqlite-active-events.test.ts` — 77 passed.
- Focused rotation, persisted-mirror, memory-mirror, and rejected-turn selection — 4 passed.
- `git diff --check` — passed.
- Structured autoreview — clean; no accepted/actionable findings.

The latest ClawSweeper rank-up moves are applied: provenance is read-only, and the rejected pure-memory boundary proves that neither supported mirror form creates SQLite lifecycle state.

Production delta: +41/-12 across two owner modules. Tests: +242. The production growth records the persisted-versus-memory ownership boundary and reuses the existing guarded transaction; the takeover removed the contributor branch's duplicate provenance policy.

Co-authored-by: ruel225 <ruel225@users.noreply.github.com>
