### PR TITLE
fix(media): prune empty openclaw-staged-* inbound staging dirs

### DIFF
--- a/src/auto-reply/reply/stage-sandbox-media.prune.test.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.prune.test.ts
@@ -1,0 +1,42 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { testing } from "./stage-sandbox-media.test-support.js";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+});
+
+async function makeWorkspace(): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-stage-prune-"));
+  tempRoots.push(root);
+  return root;
+}
+
+describe("pruneEmptyStagedMediaDirs", () => {
+  it("removes empty openclaw-staged-* dirs and keeps non-empty and unrelated dirs", async () => {
+    const root = await makeWorkspace();
+    const inbound = path.join(root, "media", "inbound");
+    const emptyStaged = path.join(inbound, "openclaw-staged-00000000-0000-4000-8000-000000000001");
+    const nonEmptyStaged = path.join(inbound, "openclaw-staged-00000000-0000-4000-8000-000000000002");
+    const unrelated = path.join(inbound, "keep-me");
+    await fs.mkdir(emptyStaged, { recursive: true });
+    await fs.mkdir(nonEmptyStaged, { recursive: true });
+    await fs.writeFile(path.join(nonEmptyStaged, "file.bin"), "x");
+    await fs.mkdir(unrelated, { recursive: true });
+
+    await testing.pruneEmptyStagedMediaDirs(root);
+
+    await expect(fs.stat(emptyStaged)).rejects.toThrow();
+    await expect(fs.stat(nonEmptyStaged)).resolves.toBeDefined();
+    await expect(fs.stat(unrelated)).resolves.toBeDefined();
+  });
+
+  it("tolerates a missing inbound directory", async () => {
+    const root = await makeWorkspace();
+    await expect(testing.pruneEmptyStagedMediaDirs(root)).resolves.toBeUndefined();
+  });
+});

--- a/src/auto-reply/reply/stage-sandbox-media.test-support.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.test-support.ts
@@ -2,6 +2,7 @@ import "./stage-sandbox-media.js";
 
 type StageSandboxMediaTestApi = {
   scpFile(remoteHost: string, remotePath: string, localPath: string): Promise<void>;
+  pruneEmptyStagedMediaDirs(workspaceDir: string): Promise<void>;
 };
 
 function getTestApi(): StageSandboxMediaTestApi {
@@ -17,5 +18,8 @@ function getTestApi(): StageSandboxMediaTestApi {
 export const testing = {
   async scpFile(remoteHost: string, remotePath: string, localPath: string): Promise<void> {
     await getTestApi().scpFile(remoteHost, remotePath, localPath);
+  },
+  async pruneEmptyStagedMediaDirs(workspaceDir: string): Promise<void> {
+    await getTestApi().pruneEmptyStagedMediaDirs(workspaceDir);
   },
 };

--- a/src/auto-reply/reply/stage-sandbox-media.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.ts
@@ -89,6 +89,12 @@ export async function stageSandboxMedia(params: {
       ? path.join("media", "inbound", `openclaw-staged-${crypto.randomUUID()}`)
       : undefined;
 
+  if (hostWorkspaceStagingDir) {
+    // Prune leftover empty one-shot staging dirs from earlier runs; dirs that
+    // still hold staged files are left untouched (#104358).
+    await pruneEmptyStagedMediaDirs(effectiveWorkspaceDir);
+  }
+
   for (const entry of pathEntries) {
     const source = await resolveStageableMediaSource(entry.path);
     if (!source) {
@@ -264,6 +270,24 @@ async function stageLocalFileIntoRoot(params: {
   });
 }
 
+/** Removes leftover empty one-shot staging dirs under media/inbound
+ * (openclaw-staged-*). Directories that still hold staged files are left
+ * untouched; only empty ones are pruned (#104358). */
+async function pruneEmptyStagedMediaDirs(workspaceDir: string): Promise<void> {
+  const inboundDir = path.join(workspaceDir, "media", "inbound");
+  const entries = await fs.readdir(inboundDir, { withFileTypes: true }).catch(() => []);
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !entry.name.startsWith("openclaw-staged-")) {
+      continue;
+    }
+    const dirPath = path.join(inboundDir, entry.name);
+    const children = await fs.readdir(dirPath).catch(() => null);
+    if (children !== null && children.length === 0) {
+      await fs.rmdir(dirPath).catch(() => {});
+    }
+  }
+}
+
 async function stageRemoteFileIntoRoot(params: {
   remoteHost: string;
   remotePath: string;
@@ -415,5 +439,6 @@ function appendScpStderrTail(
 if (process.env.VITEST || process.env.NODE_ENV === "test") {
   (globalThis as Record<PropertyKey, unknown>)[Symbol.for("openclaw.stageSandboxMediaTestApi")] = {
     scpFile,
+    pruneEmptyStagedMediaDirs,
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Per-run host-mode inbound media staging creates `media/inbound/openclaw-staged-<uuid>` directories. When a run stages nothing (or the staged files were already consumed), the empty directory is never removed, so `media/inbound` accumulates empty `openclaw-staged-*` leftovers that look like temp artifacts but live forever. Fixes #104358.

## Why This Change Was Made

The staging directory cannot be deleted unconditionally at the end of `stageSandboxMedia` — staged paths are recorded in media facts and may still be referenced by the pending reply. The safe invariant is: directories still holding staged files are never touched; only **empty** `openclaw-staged-*` directories (which by definition hold no referenced files) are pruned. Pruning runs opportunistically right before a new staging dir is created, so it costs nothing when there is nothing to clean.

## User Impact

Before: `media/inbound` slowly fills with empty `openclaw-staged-<uuid>` directories that never go away.
After: empty staging leftovers are removed automatically on the next inbound-media staging run; directories with staged content are untouched.

## Evidence

### New unit tests (`stage-sandbox-media.prune.test.ts`)
```text
$ ./node_modules/.bin/vitest run src/auto-reply/reply/stage-sandbox-media.prune.test.ts src/auto-reply/reply/stage-sandbox-media.scp.test.ts
Test Files  2 passed (2)
Tests  5 passed (5)
```

Cases covered: empty `openclaw-staged-*` dir removed, non-empty `openclaw-staged-*` dir kept, unrelated dir kept, missing inbound dir tolerated.

[AI-assisted]
