### PR TITLE
fix(auto-reply): prune empty openclaw-staged-* inbound media staging dirs

### DIFF
--- a/src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts
@@ -344,6 +344,52 @@ describe("stageSandboxMedia", () => {
     });
   });
 
+  it("keeps staging media when pruning a stale leftover fails", async () => {
+    await withSandboxMediaTempHome("openclaw-triggers-", async (home) => {
+      const { cfg, workspaceDir } = await setupSandboxWorkspace(home);
+      sandboxMocks.ensureSandboxWorkspaceForSession.mockResolvedValue(null);
+      const inboundMediaDir = join(workspaceDir, "media", "inbound");
+      await fs.mkdir(inboundMediaDir, { recursive: true });
+
+      const staleEmpty = join(
+        inboundMediaDir,
+        "openclaw-staged-8a4ba094-a431-423d-acd3-cd2cc4e3cf50",
+      );
+      await fs.mkdir(staleEmpty, { recursive: true });
+      const old = new Date(Date.now() - 2 * 60 * 60 * 1000);
+      await fs.utimes(staleEmpty, old, old);
+
+      const fileName = "host-prune-error.png";
+      await writeInboundMedia(home, fileName, "host-image-bytes");
+      const mediaUri = `media://inbound/${fileName}`;
+      const { ctx, sessionCtx } = createSandboxMediaContexts(mediaUri);
+
+      // A non-tolerated prune error (EACCES) must not abort the reply-path
+      // staging of the current inbound media.
+      const rmdirSpy = vi
+        .spyOn(fs, "rmdir")
+        .mockRejectedValueOnce(Object.assign(new Error("denied"), { code: "EACCES" }));
+
+      try {
+        await expect(
+          stageSandboxMedia({
+            ctx,
+            sessionCtx,
+            cfg,
+            sessionKey: "agent:main:main",
+            workspaceDir,
+          }),
+        ).resolves.toBeDefined();
+      } finally {
+        rmdirSpy.mockRestore();
+      }
+
+      await expect(fs.readFile(ctx.media?.[0]?.path ?? "", "utf8")).resolves.toBe(
+        "host-image-bytes",
+      );
+    });
+  });
+
   it("stages allowed media and blocks unsafe paths", async () => {
     await withSandboxMediaTempHome("openclaw-triggers-", async (home) => {
       const { cfg, workspaceDir, sandboxDir } = await setupSandboxWorkspace(home);

--- a/src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts
@@ -278,6 +278,72 @@ describe("stageSandboxMedia", () => {
     });
   });
 
+  it("prunes stale empty openclaw-staged-* leftovers in host mode", async () => {
+    await withSandboxMediaTempHome("openclaw-triggers-", async (home) => {
+      const { cfg, workspaceDir } = await setupSandboxWorkspace(home);
+      sandboxMocks.ensureSandboxWorkspaceForSession.mockResolvedValue(null);
+      const inboundMediaDir = join(workspaceDir, "media", "inbound");
+      await fs.mkdir(inboundMediaDir, { recursive: true });
+
+      const staleEmpty = join(
+        inboundMediaDir,
+        "openclaw-staged-8a4ba094-a431-423d-acd3-cd2cc4e3cf50",
+      );
+      await fs.mkdir(staleEmpty, { recursive: true });
+      const old = new Date(Date.now() - 2 * 60 * 60 * 1000);
+      await fs.utimes(staleEmpty, old, old);
+
+      const freshEmpty = join(
+        inboundMediaDir,
+        "openclaw-staged-ae9365fe-fa63-4aec-8687-07a2f9bbc1d8",
+      );
+      await fs.mkdir(freshEmpty, { recursive: true });
+
+      const nonEmptyLeftover = join(
+        inboundMediaDir,
+        "openclaw-staged-1b2c3d4e-5f6a-7b8c-9d0e-1f2a3b4c5d6e",
+      );
+      await fs.mkdir(nonEmptyLeftover, { recursive: true });
+      await fs.writeFile(join(nonEmptyLeftover, "still-used.jpg"), "keep");
+      // Age the directory after writing its file: the write refreshes the
+      // parent mtime, so the age must be applied last for the fixture to
+      // represent a stale nonempty directory.
+      await fs.utimes(nonEmptyLeftover, old, old);
+
+      const lookalike = join(inboundMediaDir, "openclaw-staged-not-a-uuid");
+      await fs.mkdir(lookalike, { recursive: true });
+      await fs.utimes(lookalike, old, old);
+
+      const projectFile = join(inboundMediaDir, "notes.txt");
+      await fs.writeFile(projectFile, "user file");
+
+      const fileName = "host-prune.png";
+      await writeInboundMedia(home, fileName, "host-image-bytes");
+      const mediaUri = `media://inbound/${fileName}`;
+      const { ctx, sessionCtx } = createSandboxMediaContexts(mediaUri);
+
+      await stageSandboxMedia({
+        ctx,
+        sessionCtx,
+        cfg,
+        sessionKey: "agent:main:main",
+        workspaceDir,
+      });
+
+      await expect(fs.stat(staleEmpty)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.stat(freshEmpty)).resolves.toBeDefined();
+      await expect(fs.readFile(join(nonEmptyLeftover, "still-used.jpg"), "utf8")).resolves.toBe(
+        "keep",
+      );
+      // Lookalike directory names outside the canonical UUID shape are kept.
+      await expect(fs.stat(lookalike)).resolves.toBeDefined();
+      await expect(fs.readFile(projectFile, "utf8")).resolves.toBe("user file");
+      await expect(fs.readFile(ctx.media?.[0]?.path ?? "", "utf8")).resolves.toBe(
+        "host-image-bytes",
+      );
+    });
+  });
+
   it("stages allowed media and blocks unsafe paths", async () => {
     await withSandboxMediaTempHome("openclaw-triggers-", async (home) => {
       const { cfg, workspaceDir, sandboxDir } = await setupSandboxWorkspace(home);

--- a/src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts
@@ -4,7 +4,10 @@ import path, { basename, dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MEDIA_MAX_BYTES } from "../media/store.js";
-import { stageSandboxMedia } from "./reply/stage-sandbox-media.js";
+import {
+  stageSandboxMedia,
+  STAGED_MEDIA_PRUNE_MAX_REMOVALS_PER_PASS,
+} from "./reply/stage-sandbox-media.js";
 import {
   createSandboxMediaContexts,
   createSandboxMediaStageConfig,
@@ -341,6 +344,76 @@ describe("stageSandboxMedia", () => {
       await expect(fs.readFile(ctx.media?.[0]?.path ?? "", "utf8")).resolves.toBe(
         "host-image-bytes",
       );
+    });
+  });
+
+  it("bounds stale-directory pruning so a large backlog cannot postpone staging", async () => {
+    await withSandboxMediaTempHome("openclaw-triggers-", async (home) => {
+      const { cfg, workspaceDir } = await setupSandboxWorkspace(home);
+      sandboxMocks.ensureSandboxWorkspaceForSession.mockResolvedValue(null);
+      const inboundMediaDir = join(workspaceDir, "media", "inbound");
+      await fs.mkdir(inboundMediaDir, { recursive: true });
+
+      // A backlog well beyond the per-pass removal budget: 24 stale empty
+      // staging directories, all older than the age cutoff.
+      const old = new Date(Date.now() - 2 * 60 * 60 * 1000);
+      const staleDirs: string[] = [];
+      for (let i = 0; i < 24; i += 1) {
+        const dir = join(
+          inboundMediaDir,
+          `openclaw-staged-00000000-0000-4000-8000-${String(i).padStart(12, "0")}`,
+        );
+        await fs.mkdir(dir, { recursive: true });
+        await fs.utimes(dir, old, old);
+        staleDirs.push(dir);
+      }
+      const countStaleRemaining = async (): Promise<number> => {
+        let count = 0;
+        for (const dir of staleDirs) {
+          if (
+            await fs.stat(dir).then(
+              () => true,
+              () => false,
+            )
+          ) {
+            count += 1;
+          }
+        }
+        return count;
+      };
+
+      const fileName = "host-prune-backlog.png";
+      await writeInboundMedia(home, fileName, "host-image-bytes");
+      const mediaUri = `media://inbound/${fileName}`;
+      const { ctx, sessionCtx } = createSandboxMediaContexts(mediaUri);
+
+      await stageSandboxMedia({
+        ctx,
+        sessionCtx,
+        cfg,
+        sessionKey: "agent:main:main",
+        workspaceDir,
+      });
+
+      // The current attachment is staged despite the backlog.
+      await expect(fs.readFile(ctx.media?.[0]?.path ?? "", "utf8")).resolves.toBe(
+        "host-image-bytes",
+      );
+
+      // Exactly the per-pass removal budget was reclaimed; the remainder is
+      // left for later passes instead of delaying this staging run.
+      expect(await countStaleRemaining()).toBe(24 - STAGED_MEDIA_PRUNE_MAX_REMOVALS_PER_PASS);
+
+      // A later pass sweeps the next batch, so the backlog is eventually
+      // reclaimed without any single staging run doing unbounded work.
+      await stageSandboxMedia({
+        ctx,
+        sessionCtx,
+        cfg,
+        sessionKey: "agent:main:main",
+        workspaceDir,
+      });
+      expect(await countStaleRemaining()).toBe(0);
     });
   });
 

--- a/src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts
@@ -4,10 +4,7 @@ import path, { basename, dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MEDIA_MAX_BYTES } from "../media/store.js";
-import {
-  stageSandboxMedia,
-  STAGED_MEDIA_PRUNE_MAX_REMOVALS_PER_PASS,
-} from "./reply/stage-sandbox-media.js";
+import { stageSandboxMedia } from "./reply/stage-sandbox-media.js";
 import {
   createSandboxMediaContexts,
   createSandboxMediaStageConfig,
@@ -401,8 +398,10 @@ describe("stageSandboxMedia", () => {
       );
 
       // Exactly the per-pass removal budget was reclaimed; the remainder is
-      // left for later passes instead of delaying this staging run.
-      expect(await countStaleRemaining()).toBe(24 - STAGED_MEDIA_PRUNE_MAX_REMOVALS_PER_PASS);
+      // left for later passes instead of delaying this staging run. The budget
+      // constant is module-private (production dead-code check), so the test
+      // pins the contract value explicitly: 24 stale dirs - 16 per-pass budget.
+      expect(await countStaleRemaining()).toBe(24 - 16);
 
       // A later pass sweeps the next batch, so the backlog is eventually
       // reclaimed without any single staging run doing unbounded work.

--- a/src/auto-reply/reply/stage-sandbox-media.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.ts
@@ -255,22 +255,34 @@ const STAGED_MEDIA_DIR_PATTERN =
   /^openclaw-staged-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
 async function pruneEmptyStagedMediaDirs(inboundMediaDir: string): Promise<void> {
-  const entries = await fs.readdir(inboundMediaDir, { withFileTypes: true }).catch(() => []);
   const cutoffMs = Date.now() - STAGED_MEDIA_PRUNE_MIN_AGE_MS;
   const candidates: Array<{ dirPath: string; mtimeMs: number }> = [];
-  for (const entry of entries) {
-    if (!entry.isDirectory() || !STAGED_MEDIA_DIR_PATTERN.test(entry.name)) {
-      continue;
+  // Enumerate lazily instead of materializing the whole directory: stop
+  // reading as soon as the per-pass candidate budget is filled, so a large
+  // media/inbound backlog is never fully enumerated before staging the
+  // current attachment.
+  const dir = await fs.opendir(inboundMediaDir).catch(() => null);
+  if (!dir) {
+    return;
+  }
+  try {
+    while (candidates.length < STAGED_MEDIA_PRUNE_MAX_CANDIDATES_PER_PASS) {
+      const entry = await dir.read();
+      if (!entry) {
+        break;
+      }
+      if (!entry.isDirectory() || !STAGED_MEDIA_DIR_PATTERN.test(entry.name)) {
+        continue;
+      }
+      const dirPath = path.join(inboundMediaDir, entry.name);
+      const stat = await fs.lstat(dirPath).catch(() => null);
+      if (!stat?.isDirectory() || stat.mtimeMs > cutoffMs) {
+        continue;
+      }
+      candidates.push({ dirPath, mtimeMs: stat.mtimeMs });
     }
-    if (candidates.length >= STAGED_MEDIA_PRUNE_MAX_CANDIDATES_PER_PASS) {
-      break;
-    }
-    const dirPath = path.join(inboundMediaDir, entry.name);
-    const stat = await fs.lstat(dirPath).catch(() => null);
-    if (!stat?.isDirectory() || stat.mtimeMs > cutoffMs) {
-      continue;
-    }
-    candidates.push({ dirPath, mtimeMs: stat.mtimeMs });
+  } finally {
+    await dir.close().catch(() => {});
   }
   // Reclaim the oldest leftovers first, up to the per-pass removal budget.
   candidates.sort((a, b) => a.mtimeMs - b.mtimeMs);

--- a/src/auto-reply/reply/stage-sandbox-media.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.ts
@@ -88,6 +88,9 @@ export async function stageSandboxMedia(params: {
     !sandbox && !ctx.MediaRemoteHost
       ? path.join("media", "inbound", `openclaw-staged-${crypto.randomUUID()}`)
       : undefined;
+  if (hostWorkspaceStagingDir) {
+    await pruneEmptyStagedMediaDirs(path.join(effectiveWorkspaceDir, "media", "inbound"));
+  }
 
   for (const entry of pathEntries) {
     const source = await resolveStageableMediaSource(entry.path);
@@ -229,6 +232,40 @@ function applyStagedMediaContext(ctx: MsgContext, media: MediaFact[]): void {
 
 function toPosixRelativePath(filePath: string): string {
   return filePath.split(path.sep).join(path.posix.sep);
+}
+
+// Host-mode staging dirs are one-shot temp artifacts: their files are consumed
+// during the run, but the UUID directory can outlive them. Prune empty leftovers
+// old enough that no in-flight run is still populating them.
+const STAGED_MEDIA_PRUNE_MIN_AGE_MS = 60 * 60 * 1000;
+// Canonical shape emitted by stageSandboxMedia: `openclaw-staged-` + UUID.
+const STAGED_MEDIA_DIR_PATTERN =
+  /^openclaw-staged-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+async function pruneEmptyStagedMediaDirs(inboundMediaDir: string): Promise<void> {
+  const entries = await fs.readdir(inboundMediaDir, { withFileTypes: true }).catch(() => []);
+  const cutoffMs = Date.now() - STAGED_MEDIA_PRUNE_MIN_AGE_MS;
+  await Promise.all(
+    entries.map(async (entry) => {
+      if (!entry.isDirectory() || !STAGED_MEDIA_DIR_PATTERN.test(entry.name)) {
+        return;
+      }
+      const dirPath = path.join(inboundMediaDir, entry.name);
+      const stat = await fs.lstat(dirPath).catch(() => null);
+      if (!stat?.isDirectory() || stat.mtimeMs > cutoffMs) {
+        return;
+      }
+      // Remove the directory itself only if it is still empty. Non-recursive
+      // removal tolerates ENOTEMPTY (a concurrent staging run wrote a file
+      // after our check) and ENOENT (someone else removed it first), so a
+      // late-arriving staged file is never deleted.
+      await fs.rmdir(dirPath).catch((error: NodeJS.ErrnoException) => {
+        if (error.code !== "ENOTEMPTY" && error.code !== "ENOENT") {
+          throw error;
+        }
+      });
+    }),
+  );
 }
 
 async function resolveStageableMediaSource(value: string): Promise<StageableMediaSource | null> {

--- a/src/auto-reply/reply/stage-sandbox-media.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.ts
@@ -259,8 +259,9 @@ async function pruneEmptyStagedMediaDirs(inboundMediaDir: string): Promise<void>
       // removal tolerates ENOTEMPTY (a concurrent staging run wrote a file
       // after our check) and ENOENT (someone else removed it first), so a
       // late-arriving staged file is never deleted.
-      await fs.rmdir(dirPath).catch((error: NodeJS.ErrnoException) => {
-        if (error.code !== "ENOTEMPTY" && error.code !== "ENOENT") {
+      await fs.rmdir(dirPath).catch((error: unknown) => {
+        const code = (error as NodeJS.ErrnoException | undefined)?.code;
+        if (code !== "ENOTEMPTY" && code !== "ENOENT") {
           throw error;
         }
       });

--- a/src/auto-reply/reply/stage-sandbox-media.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.ts
@@ -243,6 +243,13 @@ function toPosixRelativePath(filePath: string): string {
 // during the run, but the UUID directory can outlive them. Prune empty leftovers
 // old enough that no in-flight run is still populating them.
 const STAGED_MEDIA_PRUNE_MIN_AGE_MS = 60 * 60 * 1000;
+// Housekeeping is best-effort and must not delay the current inbound-media
+// reply: each staging pass inspects at most this many pattern-matching
+// candidate directories and removes at most this many stale leftovers, so a
+// large accumulated backlog cannot postpone staging the current attachment.
+// Leftovers beyond the budget are swept by later passes.
+const STAGED_MEDIA_PRUNE_MAX_CANDIDATES_PER_PASS = 32;
+export const STAGED_MEDIA_PRUNE_MAX_REMOVALS_PER_PASS = 16;
 // Canonical shape emitted by stageSandboxMedia: `openclaw-staged-` + UUID.
 const STAGED_MEDIA_DIR_PATTERN =
   /^openclaw-staged-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
@@ -250,16 +257,25 @@ const STAGED_MEDIA_DIR_PATTERN =
 async function pruneEmptyStagedMediaDirs(inboundMediaDir: string): Promise<void> {
   const entries = await fs.readdir(inboundMediaDir, { withFileTypes: true }).catch(() => []);
   const cutoffMs = Date.now() - STAGED_MEDIA_PRUNE_MIN_AGE_MS;
+  const candidates: Array<{ dirPath: string; mtimeMs: number }> = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !STAGED_MEDIA_DIR_PATTERN.test(entry.name)) {
+      continue;
+    }
+    if (candidates.length >= STAGED_MEDIA_PRUNE_MAX_CANDIDATES_PER_PASS) {
+      break;
+    }
+    const dirPath = path.join(inboundMediaDir, entry.name);
+    const stat = await fs.lstat(dirPath).catch(() => null);
+    if (!stat?.isDirectory() || stat.mtimeMs > cutoffMs) {
+      continue;
+    }
+    candidates.push({ dirPath, mtimeMs: stat.mtimeMs });
+  }
+  // Reclaim the oldest leftovers first, up to the per-pass removal budget.
+  candidates.sort((a, b) => a.mtimeMs - b.mtimeMs);
   await Promise.all(
-    entries.map(async (entry) => {
-      if (!entry.isDirectory() || !STAGED_MEDIA_DIR_PATTERN.test(entry.name)) {
-        return;
-      }
-      const dirPath = path.join(inboundMediaDir, entry.name);
-      const stat = await fs.lstat(dirPath).catch(() => null);
-      if (!stat?.isDirectory() || stat.mtimeMs > cutoffMs) {
-        return;
-      }
+    candidates.slice(0, STAGED_MEDIA_PRUNE_MAX_REMOVALS_PER_PASS).map(async ({ dirPath }) => {
       // Remove the directory itself only if it is still empty. Non-recursive
       // removal tolerates ENOTEMPTY (a concurrent staging run wrote a file
       // after our check) and ENOENT (someone else removed it first), so a

--- a/src/auto-reply/reply/stage-sandbox-media.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.ts
@@ -249,7 +249,7 @@ const STAGED_MEDIA_PRUNE_MIN_AGE_MS = 60 * 60 * 1000;
 // large accumulated backlog cannot postpone staging the current attachment.
 // Leftovers beyond the budget are swept by later passes.
 const STAGED_MEDIA_PRUNE_MAX_CANDIDATES_PER_PASS = 32;
-export const STAGED_MEDIA_PRUNE_MAX_REMOVALS_PER_PASS = 16;
+const STAGED_MEDIA_PRUNE_MAX_REMOVALS_PER_PASS = 16;
 // Canonical shape emitted by stageSandboxMedia: `openclaw-staged-` + UUID.
 const STAGED_MEDIA_DIR_PATTERN =
   /^openclaw-staged-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;

--- a/src/auto-reply/reply/stage-sandbox-media.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.ts
@@ -89,7 +89,12 @@ export async function stageSandboxMedia(params: {
       ? path.join("media", "inbound", `openclaw-staged-${crypto.randomUUID()}`)
       : undefined;
   if (hostWorkspaceStagingDir) {
-    await pruneEmptyStagedMediaDirs(path.join(effectiveWorkspaceDir, "media", "inbound"));
+    // Best-effort housekeeping: a prune failure (e.g. EACCES on a sibling
+    // leftover) must never abort staging the current inbound media, which is
+    // the reply path's actual job.
+    await pruneEmptyStagedMediaDirs(path.join(effectiveWorkspaceDir, "media", "inbound")).catch(
+      () => {},
+    );
   }
 
   for (const entry of pathEntries) {


### PR DESCRIPTION
## What Problem This Solves

Host-mode inbound media staging creates a per-run UUID directory under `media/inbound/openclaw-staged-*` in the agent workspace (`src/auto-reply/reply/stage-sandbox-media.ts:87-90`). The staged files are consumed during the run and later removed, but the UUID-named directory itself is never cleaned up, so empty `openclaw-staged-*` directories accumulate over time and make `media/inbound` look unhealthy (#104358).

## Why This Change Was Made

The staging directory cannot be removed immediately after `stageSandboxMedia` returns — the staged paths are rewritten into the media facts and consumed by the agent during the run, and may be referenced by later turns. So cleanup is deferred: on the next host-mode staging pass, empty `openclaw-staged-*` leftovers are pruned. Two guards keep the prune safe:

- only **empty** directories are removed (in-flight media files are never touched);
- only directories **older than 1 hour** are removed, so a concurrent staging run that just created its directory (seconds old) can never be pruned while it is about to populate it.

This matches the "prune empty openclaw-staged-* directories during startup or on a periodic internal maintenance pass" option the issue proposes, implemented as a natural maintenance pass piggybacked on the next staging run.

## User Impact

- Before: empty `media/inbound/openclaw-staged-<uuid>` directories accumulate indefinitely and require an external cron janitor job to remove.
- After: stale empty staging directories are automatically removed on the next media-bearing run; non-empty directories, recent directories, and unrelated user files in `media/inbound` are untouched.

## Evidence

### Regression test — fails before the fix, passes after

Without the production change (`git stash push src/.../stage-sandbox-media.ts`):

```text
 ❯  auto-reply  ../../src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts (12 tests | 1 failed) 314ms
     ✓ stages managed inbound media URIs into the sandbox workspace 53ms
     ✓ keeps host-staged inbound images available to native vision 59ms
     × prunes stale empty openclaw-staged-* leftovers in host mode 27ms
     ✓ stages allowed media and blocks unsafe paths 24ms
     ✓ updates facts positionally: 'failed slot before staged slot' 12ms
     ✓ updates facts positionally: 'staged slot before failed slot' 27ms
     ✓ rewrites resolved local URL aliases: 'media URI path and physical-path URL' 14ms
     ✓ rewrites resolved local URL aliases: 'physical path and media-URI URL' 21ms
     ✓ rewrites resolved local URL aliases: 'physical path and file-URL URL' 11ms
     ✓ rewrites resolved local URL aliases: 'physical path and distinct remote URL' 20ms
     ✓ blocks destination symlink escapes when staging into sandbox workspace 16ms
     ✓ skips oversized media staging and keeps original media paths 24ms
 FAIL   auto-reply  ../../src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts > stageSandboxMedia > prunes stale empty openclaw-staged-* leftovers in host mode
 Test Files  1 failed (1)
      Tests  1 failed | 11 passed (12)
```

With the fix:

```text
 RUN  v4.1.10 /tmp/wt-104358

 ✓  auto-reply  ../../src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts (12 tests) 186ms

 Test Files  1 passed (1)
      Tests  12 passed (12)
   Start at  20:50:35
   Duration  5.54s (transform 3.97s, setup 2.06s, import 3.00s, tests 186ms, environment 0ms)
```

The new test asserts: a stale empty `openclaw-staged-*` dir is removed (ENOENT), a fresh empty dir is kept, a stale non-empty staging dir keeps its file, an unrelated `notes.txt` in `media/inbound` is kept, and the current run's staging dir still contains its staged file.

[AI-assisted]

## CI status

- Latest CI on head `5e91ac604956`: all check-runs green (latest per check).
- `Real behavior proof` check: success.

## Review findings repaired (head `35d7743177f`, rebuilt on current main)

- **[P1] Remove only atomically empty staging directories**: recursive `rm` replaced with non-recursive `rmdir` that tolerates `ENOTEMPTY`/`ENOENT`, so a concurrent staging run that writes a file after the emptiness check can never lose it (no TOCTOU window).
- **[P2] Match only canonical staging UUID directories**: matcher restricted to the exact `openclaw-staged-` + UUID shape emitted by the staging creator (`STAGED_MEDIA_DIR_PATTERN`); a user-created lookalike directory (`openclaw-staged-not-a-uuid`) is retained and covered by a regression assertion.
- **[P2] Age the nonempty fixture after writing its file**: the fixture now calls `utimes` after `writeFile` so the stale-nonempty case is actually exercised.

```text
❯ node_modules/.bin/vitest run src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts
 ✓  auto-reply  src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts (21 tests)
 Test Files  1 passed (1)
      Tests  21 passed (21)
```


## 2026-08-12 patrol update (head `c6661f7224`)

- **P1 fixed — cleanup error no longer aborts the reply**: `pruneEmptyStagedMediaDirs` is best-effort housekeeping, but a non-tolerated `rmdir` error (e.g. EACCES on a sibling leftover) propagated out of `stageSandboxMedia` and aborted staging the current inbound media. The prune is now swallowed at the call site (matching the file's existing best-effort cleanup pattern), and a regression test proves staging still completes when pruning fails.
- **lint**: catch callback now uses the repo-standard `unknown` + cast (oxlint `use-unknown-in-catch-callback-variable`).

```text
❯ node_modules/.bin/vitest run src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts
 ✓  auto-reply  src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts (22 tests)
 Test Files  1 passed (1)
      Tests  22 passed (22)
```


## ClawSweeper P2 repair (head `2a506bfc29b`)

P2 "Bound cleanup work before staging inbound media" fixed: `pruneEmptyStagedMediaDirs` now inspects at most 32 pattern-matching candidates and removes at most 16 stale leftovers per staging pass (oldest first), so a workspace with a large accumulated backlog cannot delay staging the current attachment; the remainder is swept by later passes.

Large-backlog regression added: 24 stale dirs - the current attachment still stages, exactly the per-pass budget is reclaimed, and a later pass sweeps the next batch.

```text
node scripts/run-vitest.mjs src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts
 Test Files  1 passed (1)
      Tests  23 passed (23)
```
