### PR TITLE
fix(infra): derive gateway lock dir from resolved state dir

### DIFF
--- a/src/config/paths.test.ts
+++ b/src/config/paths.test.ts
@@ -17,6 +17,7 @@ import {
   resolveConfigPathCandidate,
   resolveConfigPath,
   resolveGatewayPort,
+  resolveGatewayLockDir,
   resolveIncludeRoots,
   resolveOAuthDir,
   resolveStateDir,
@@ -576,5 +577,21 @@ describe("resolveIncludeRoots", () => {
       OPENCLAW_INCLUDE_ROOTS: ["", a, "  ", a].join(path.delimiter),
     });
     expect(resolveIncludeRoots(env, () => HOME)).toEqual([a]);
+  });
+});
+
+describe("resolveGatewayLockDir", () => {
+  const systemTmp = () => "/system/tmp";
+
+  it("derives the lock dir from OPENCLAW_STATE_DIR when overridden (#118371)", () => {
+    const dir = resolveGatewayLockDir(systemTmp, { OPENCLAW_STATE_DIR: "/sandbox/home" }, () => "/real/home");
+    expect(dir.startsWith(path.join("/sandbox/home", "tmp"))).toBe(true);
+    expect(dir).not.toContain("/system/tmp");
+    expect(dir).not.toContain("/real/home/.openclaw");
+  });
+
+  it("derives the lock dir from the default state dir when not overridden", () => {
+    const dir = resolveGatewayLockDir(systemTmp, {}, () => "/home/user");
+    expect(dir.startsWith(path.join("/home/user", ".openclaw", "tmp", "openclaw-"))).toBe(true);
   });
 });

--- a/src/config/paths.test.ts
+++ b/src/config/paths.test.ts
@@ -581,21 +581,15 @@ describe("resolveIncludeRoots", () => {
 });
 
 describe("resolveGatewayLockDir", () => {
-  const systemTmp = () => "/system/tmp";
-
   it("derives the lock dir from OPENCLAW_STATE_DIR when overridden (#118371)", () => {
-    const dir = resolveGatewayLockDir(
-      systemTmp,
-      { OPENCLAW_STATE_DIR: "/sandbox/home" },
-      () => "/real/home",
-    );
+    const dir = resolveGatewayLockDir({ OPENCLAW_STATE_DIR: "/sandbox/home" }, () => "/real/home");
     expect(dir.startsWith(path.join("/sandbox/home", "tmp"))).toBe(true);
     expect(dir).not.toContain("/system/tmp");
     expect(dir).not.toContain("/real/home/.openclaw");
   });
 
   it("derives the lock dir from the default state dir when not overridden", () => {
-    const dir = resolveGatewayLockDir(systemTmp, {}, () => "/home/user");
+    const dir = resolveGatewayLockDir({}, () => "/home/user");
     expect(dir.startsWith(path.join("/home/user", ".openclaw", "tmp", "openclaw-"))).toBe(true);
   });
 });

--- a/src/config/paths.test.ts
+++ b/src/config/paths.test.ts
@@ -584,7 +584,11 @@ describe("resolveGatewayLockDir", () => {
   const systemTmp = () => "/system/tmp";
 
   it("derives the lock dir from OPENCLAW_STATE_DIR when overridden (#118371)", () => {
-    const dir = resolveGatewayLockDir(systemTmp, { OPENCLAW_STATE_DIR: "/sandbox/home" }, () => "/real/home");
+    const dir = resolveGatewayLockDir(
+      systemTmp,
+      { OPENCLAW_STATE_DIR: "/sandbox/home" },
+      () => "/real/home",
+    );
     expect(dir.startsWith(path.join("/sandbox/home", "tmp"))).toBe(true);
     expect(dir).not.toContain("/system/tmp");
     expect(dir).not.toContain("/real/home/.openclaw");

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -403,10 +403,18 @@ export const DEFAULT_GATEWAY_PORT = 18789;
 
 /**
  * Gateway lock directory (ephemeral).
- * Default: os.tmpdir()/openclaw-<uid> (uid suffix when available).
+ * Derived from the resolved state dir so a sandboxed instance
+ * (OPENCLAW_STATE_DIR / OPENCLAW_CONFIG_PATH overrides) never writes lock
+ * files into the live instance's home tmp (#118371).
+ * Layout: <stateDir>/tmp/openclaw-<uid> (uid suffix when available).
  */
-export function resolveGatewayLockDir(tmpdir: () => string = os.tmpdir): string {
-  const base = tmpdir();
+export function resolveGatewayLockDir(
+  tmpdir: () => string = os.tmpdir,
+  env: NodeJS.ProcessEnv = process.env,
+  homedir: () => string = envHomedir(env),
+): string {
+  const stateDir = resolveStateDir(env, homedir);
+  const base = path.join(stateDir, "tmp");
   const uid = typeof process.getuid === "function" ? process.getuid() : undefined;
   const suffix = uid != null ? `openclaw-${uid}` : "openclaw";
   return path.join(base, suffix);

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -409,7 +409,6 @@ export const DEFAULT_GATEWAY_PORT = 18789;
  * Layout: <stateDir>/tmp/openclaw-<uid> (uid suffix when available).
  */
 export function resolveGatewayLockDir(
-  tmpdir: () => string = os.tmpdir,
   env: NodeJS.ProcessEnv = process.env,
   homedir: () => string = envHomedir(env),
 ): string {

--- a/src/infra/device-identity-coordinator.ts
+++ b/src/infra/device-identity-coordinator.ts
@@ -57,7 +57,7 @@ function ensurePrivateCoordinatorDirectory(lockDir: string): void {
       throw error;
     }
     try {
-      fs.mkdirSync(lockDir, { mode: 0o700 });
+      fs.mkdirSync(lockDir, { mode: 0o700, recursive: true });
     } catch (mkdirError) {
       if ((mkdirError as NodeJS.ErrnoException).code !== "EEXIST") {
         throw mkdirError;


### PR DESCRIPTION
## What Problem This Solves

`resolveGatewayLockDir` used `os.tmpdir()` unconditionally, so gateway lock files (`gateway.<hash>.lock`, `gateway.state.<hash>.lock`, `device-identity.<hash>.lock.sqlite`) were written under the default home tmp (`~/.openclaw/tmp/openclaw-<uid>/`) even when `OPENCLAW_STATE_DIR` / `OPENCLAW_CONFIG_PATH` pointed elsewhere. A fully sandboxed second instance therefore wrote into the live instance's home — littering it and, in principle, contending with it. Fixes #118371.

## Why This Change Was Made

The resolved state dir (`resolveStateDir`) already honors `OPENCLAW_STATE_DIR` (and `HOME` fallback). The lock dir is an ephemeral artifact of that state, so it should live under the state dir's tmp (`<stateDir>/tmp/openclaw-<uid>`) rather than the system tmp. This keeps sandbox isolation total without changing the lock-keying scheme (still hash-scoped per state).

## User Impact

Before: a sandboxed instance (`OPENCLAW_STATE_DIR=/tmp/sandbox/home`) created `~/.openclaw/tmp/openclaw-<uid>/gateway.*.lock` files in the real user's home.
After: all lock/tmp paths derive from the resolved state dir — sandboxed instances stay fully isolated.

## Evidence

### New unit tests (`src/config/paths.test.ts`)
```text
$ ./node_modules/.bin/vitest run src/config/paths.test.ts src/infra/gateway-lock.test.ts
Test Files  2 passed (2)
Tests  83 passed (83)
```

- With `OPENCLAW_STATE_DIR=/sandbox/home`: lock dir starts with `/sandbox/home/tmp`, contains neither `/system/tmp` nor the default home state dir.
- Without override: lock dir derives from the default state dir (`<home>/.openclaw/tmp/openclaw-…`).

[AI-assisted]

## CI status

- Latest CI on head `9b4473953675`: all check-runs green (latest per check).
- `Real behavior proof` check: success.