### PR TITLE
perf(cli): skip absent gateway workspace dotenv

### DIFF
--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import process from "node:process";
 import { expectDefined } from "@openclaw/normalization-core";
 import { CommanderError } from "commander";
-import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { GATEWAY_SERVICE_RUNTIME_PID_ENV } from "../daemon/constants.js";
 import { loggingState } from "../logging/state.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -14,8 +14,12 @@ import type { LocalOnboardingState } from "../state/local-onboarding-state.js";
 import { captureEnv, withEnvAsync } from "../test-utils/env.js";
 import { getGatewayRunRuntimeHooks } from "./gateway-cli/runtime-hooks.js";
 import type { RootHelpRenderOptions } from "./program/root-help.js";
-import { runCli, shouldStartProxyForCli } from "./run-main.js";
 import { registerSignalExitBarrier } from "./signal-exit-barrier.js";
+
+type RunMainModule = typeof import("./run-main.js");
+
+let runCli: RunMainModule["runCli"];
+let shouldStartProxyForCli: RunMainModule["shouldStartProxyForCli"];
 
 type ConfigSnapshotStub = {
   exists: boolean;
@@ -493,6 +497,14 @@ async function expectNonInteractiveBareCliError(
 }
 
 describe("runCli exit behavior", () => {
+  beforeAll(async () => {
+    expect(dotenvModuleImportState.count).toBe(0);
+    const runMainModule = await import("./run-main.js");
+    expect(dotenvModuleImportState.count).toBe(0);
+    runCli = runMainModule.runCli;
+    shouldStartProxyForCli = runMainModule.shouldStartProxyForCli;
+  });
+
   afterAll(() => {
     serviceEnvSnapshot.restore();
   });
@@ -553,7 +565,7 @@ describe("runCli exit behavior", () => {
 
   it("does not import dotenv for gateway forms without a workspace file", async () => {
     existsSyncOverride.value = () => false;
-    const importsBefore = dotenvModuleImportState.count;
+    expect(dotenvModuleImportState.count).toBe(0);
 
     await runCli(["node", "openclaw", "gateway"]);
     await runCli(["node", "openclaw", "gateway", "run"]);
@@ -564,7 +576,7 @@ describe("runCli exit behavior", () => {
     });
     await runCli(["node", "openclaw", "--log-level", "debug", "gateway", "run"]);
 
-    expect(dotenvModuleImportState.count).toBe(importsBefore);
+    expect(dotenvModuleImportState.count).toBe(0);
     expect(loadDotEnvMock).not.toHaveBeenCalled();
     expect(buildProgramMock).toHaveBeenCalledTimes(1);
     expect(commanderParseAsyncMock).toHaveBeenLastCalledWith([

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -38,6 +38,7 @@ type ConfigSnapshotReadOptionsStub = {
 
 const tryRouteCliMock = vi.hoisted(() => vi.fn());
 const loadDotEnvMock = vi.hoisted(() => vi.fn());
+const dotenvModuleImportState = vi.hoisted(() => ({ count: 0 }));
 const existsSyncOverride = vi.hoisted(
   () =>
     ({ value: undefined }) as {
@@ -247,9 +248,12 @@ vi.mock("node:fs", async () => {
   };
 });
 
-vi.mock("./dotenv.js", () => ({
-  loadCliDotEnv: loadDotEnvMock,
-}));
+vi.mock("./dotenv.js", () => {
+  dotenvModuleImportState.count += 1;
+  return {
+    loadCliDotEnv: loadDotEnvMock,
+  };
+});
 
 vi.mock("./one-shot-exit.js", () => ({
   flushExitAfterOneShotOutput: flushExitAfterOneShotOutputMock,
@@ -545,6 +549,32 @@ describe("runCli exit behavior", () => {
     delete process.env.OPENCLAW_DISABLE_CLI_STARTUP_HELP_FAST_PATH;
     delete process.env.OPENCLAW_HIDE_BANNER;
     loggingState.forceConsoleToStderr = false;
+  });
+
+  it("does not import dotenv for gateway forms without a workspace file", async () => {
+    existsSyncOverride.value = () => false;
+    const importsBefore = dotenvModuleImportState.count;
+
+    await runCli(["node", "openclaw", "gateway"]);
+    await runCli(["node", "openclaw", "gateway", "run"]);
+    tryRouteCliMock.mockResolvedValueOnce(false);
+    buildProgramMock.mockReturnValueOnce({
+      commands: [{ name: () => "gateway", aliases: () => [] }],
+      parseAsync: commanderParseAsyncMock,
+    });
+    await runCli(["node", "openclaw", "--log-level", "debug", "gateway", "run"]);
+
+    expect(dotenvModuleImportState.count).toBe(importsBefore);
+    expect(loadDotEnvMock).not.toHaveBeenCalled();
+    expect(buildProgramMock).toHaveBeenCalledTimes(1);
+    expect(commanderParseAsyncMock).toHaveBeenLastCalledWith([
+      "node",
+      "openclaw",
+      "--log-level",
+      "debug",
+      "gateway",
+      "run",
+    ]);
   });
 
   it("does not force process.exit after successful routed command", async () => {
@@ -2466,6 +2496,7 @@ describe("runCli exit behavior", () => {
   });
 
   it.each([
+    ["bare gateway fast path", ["node", "openclaw", "gateway"]],
     ["fast path", ["node", "openclaw", "gateway", "run"]],
     [
       "full Commander path with root options",
@@ -2474,25 +2505,25 @@ describe("runCli exit behavior", () => {
   ])("loads trusted dotenv and isolates %s gateway proxy config reads", async (_name, argv) => {
     existsSyncOverride.value = (target) => target === path.join(process.cwd(), ".env");
     if (_name === "full Commander path with root options") {
-      tryRouteCliMock.mockResolvedValueOnce(true);
+      tryRouteCliMock.mockResolvedValueOnce(false);
+      buildProgramMock.mockReturnValueOnce({
+        commands: [{ name: () => "gateway", aliases: () => [] }],
+        parseAsync: commanderParseAsyncMock,
+      });
     }
     await runCli(argv);
 
     expect(loadDotEnvMock).toHaveBeenCalledWith({ loadGlobalEnv: false, quiet: true });
+    if (_name === "full Commander path with root options") {
+      expect(buildProgramMock).toHaveBeenCalledTimes(1);
+      expect(commanderParseAsyncMock).toHaveBeenLastCalledWith(argv);
+    }
     expect(loadConfigMock).toHaveBeenCalledWith({
       isolateEnv: true,
       observe: false,
       skipPluginValidation: true,
     });
     expect(startProxyMock).toHaveBeenCalledWith(undefined);
-  });
-
-  it("skips gateway dotenv loading when the workspace file is absent", async () => {
-    existsSyncOverride.value = () => false;
-
-    await runCli(["node", "openclaw", "gateway", "run"]);
-
-    expect(loadDotEnvMock).not.toHaveBeenCalled();
   });
 
   it("keeps state dotenv loading for non-gateway commands", async () => {

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -38,6 +38,12 @@ type ConfigSnapshotReadOptionsStub = {
 
 const tryRouteCliMock = vi.hoisted(() => vi.fn());
 const loadDotEnvMock = vi.hoisted(() => vi.fn());
+const existsSyncOverride = vi.hoisted(
+  () =>
+    ({ value: undefined }) as {
+      value: ((target: string) => boolean) | undefined;
+    },
+);
 const normalizeEnvMock = vi.hoisted(() => vi.fn());
 const pinConfigDirMock = vi.hoisted(() => vi.fn());
 const pinRuntimePathsMock = vi.hoisted(() => vi.fn());
@@ -229,6 +235,17 @@ vi.mock("./container-target.js", () => ({
   maybeRunCliInContainer: maybeRunCliInContainerMock,
   parseCliContainerArgs: (argv: string[]) => ({ ok: true, container: null, argv }),
 }));
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    existsSync: (target: Parameters<typeof actual.existsSync>[0]) =>
+      typeof target === "string" && existsSyncOverride.value
+        ? existsSyncOverride.value(target)
+        : actual.existsSync(target),
+  };
+});
 
 vi.mock("./dotenv.js", () => ({
   loadCliDotEnv: loadDotEnvMock,
@@ -485,6 +502,7 @@ describe("runCli exit behavior", () => {
     delete process.env.OPENCLAW_GATEWAY_TOKEN;
     delete process.env.OPENCLAW_GATEWAY_PASSWORD;
     delete process.env[GATEWAY_SERVICE_RUNTIME_PID_ENV];
+    existsSyncOverride.value = undefined;
     vi.clearAllMocks();
     readConfigFileSnapshotMock.mockResolvedValue({
       exists: true,
@@ -2454,6 +2472,7 @@ describe("runCli exit behavior", () => {
       ["node", "openclaw", "--log-level", "debug", "gateway", "run"],
     ],
   ])("loads trusted dotenv and isolates %s gateway proxy config reads", async (_name, argv) => {
+    existsSyncOverride.value = (target) => target === path.join(process.cwd(), ".env");
     if (_name === "full Commander path with root options") {
       tryRouteCliMock.mockResolvedValueOnce(true);
     }
@@ -2466,6 +2485,26 @@ describe("runCli exit behavior", () => {
       skipPluginValidation: true,
     });
     expect(startProxyMock).toHaveBeenCalledWith(undefined);
+  });
+
+  it("skips gateway dotenv loading when the workspace file is absent", async () => {
+    existsSyncOverride.value = () => false;
+
+    await runCli(["node", "openclaw", "gateway", "run"]);
+
+    expect(loadDotEnvMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps state dotenv loading for non-gateway commands", async () => {
+    const stateDir = path.join(os.tmpdir(), "openclaw-run-main-state");
+    existsSyncOverride.value = (target) => target === path.join(stateDir, ".env");
+    tryRouteCliMock.mockResolvedValueOnce(true);
+
+    await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, () =>
+      runCli(["node", "openclaw", "status"]),
+    );
+
+    expect(loadDotEnvMock).toHaveBeenCalledWith({ loadGlobalEnv: true, quiet: true });
   });
 
   it("keeps agent exec outside the CLI dotenv loader", async () => {

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -719,12 +719,15 @@ export function resolveMissingPluginCommandMessage(
   );
 }
 
-function shouldLoadCliDotEnv(env: NodeJS.ProcessEnv = process.env): boolean {
+function shouldLoadCliDotEnv(
+  loadGlobalEnv: boolean,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
   const cwd = tryProcessCwd();
   if (cwd && existsSync(path.join(cwd, ".env"))) {
     return true;
   }
-  return existsSync(path.join(resolveStateDir(env), ".env"));
+  return loadGlobalEnv && existsSync(path.join(resolveStateDir(env), ".env"));
 }
 
 function isAgentExecInvocation(commandPath: string[]): boolean {
@@ -1155,6 +1158,9 @@ async function runCliWithPreparedOutputMode(
   const normalizedInvocation = resolveCliArgvInvocation(normalizedArgv);
   const isHelpOrVersionInvocation = normalizedInvocation.hasHelpOrVersion;
   const isGatewayRunInvocation = isGatewayRunInvocationArgv(normalizedArgv);
+  // Gateway pre-bootstrap owns state/config dotenv selection. This phase only
+  // needs the workspace file, so avoid importing the loader when it is absent.
+  const loadGlobalEnv = !isGatewayRunInvocation;
   startupTrace.mark("argv");
 
   // Enforce the minimum supported runtime before gateway selection can read or recover config.
@@ -1163,7 +1169,7 @@ async function runCliWithPreparedOutputMode(
   if (
     !isHelpOrVersionInvocation &&
     !isAgentExecInvocation(normalizedInvocation.commandPath) &&
-    (isGatewayRunInvocation || shouldLoadCliDotEnv())
+    shouldLoadCliDotEnv(loadGlobalEnv)
   ) {
     await startupTrace.measure("dotenv", async () => {
       if (isRemoteAgentDispatchInvocation(normalizedArgv, normalizedInvocation.primary)) {
@@ -1171,7 +1177,7 @@ async function runCliWithPreparedOutputMode(
         await loadGatewayDispatchCliDotEnv({ quiet: true });
       } else {
         const { loadCliDotEnv } = await import("./dotenv.js");
-        loadCliDotEnv({ loadGlobalEnv: !isGatewayRunInvocation, quiet: true });
+        loadCliDotEnv({ loadGlobalEnv, quiet: true });
       }
     });
   }


### PR DESCRIPTION
## What Problem This Solves

`openclaw gateway run` always imported and ran the CLI dotenv loader, even when
the workspace had no `.env` file. Gateway pre-bootstrap already owns
state/config dotenv selection, so the common path paid an unnecessary dynamic
import and filesystem/env parsing cost.

## Root Cause And Owner

The CLI invocation boundary selected the command but delegated dotenv loading
without carrying that command fact forward. As a result, gateway startup could
not skip global/state dotenv work that its pre-bootstrap path already owns.

The CLI invocation owner now decides whether global/state dotenv loading is
allowed:

- gateway startup checks only the workspace `.env`;
- non-gateway commands retain workspace plus state dotenv behavior;
- gateway pre-bootstrap remains the owner of state/config dotenv selection.

This is the best fix because it removes the work at the boundary that already
knows the command. Optimizing the dotenv module would still pay the dynamic
import, while skipping all gateway dotenv handling would break supported
workspace `.env` behavior.

## User Impact

Typical gateway startup no longer imports the CLI dotenv loader when no
workspace `.env` exists. Workspace `.env`, state/config dotenv, CLI config, and
public API behavior are unchanged.

Production LOC: +10/-4. Tests: +88/-6. No config/default surface changes.

## ClawSweeper Resolution

- Refreshed onto exact current `main`
  `52954a1fa8f4d63914967a87f56ada21f5a0252e`.
- Re-ran focused startup proof at exact head
  `d0ce3f8e314df58a35202631a8b6cb6006c1dde0`.
- Re-ran exact-head autoreview: no findings, 0.94 correctness confidence.
- Re-ran the Kova comparison against the same current-main baseline; evidence
  below replaces the earlier stale samples.

## Verification

- Focused Vitest: 205 tests passed across the affected CLI startup suites.
- `oxfmt --check`: clean.
- `oxlint`: clean.
- `git diff --check`: clean.
- `trufflehog`: clean.

## Kova Evidence

Exact `main` run `kova-260804-135713-433310`:

- six gateway process starts contained a `cli.main.dotenv` span;
- direct span duration range: 104.083-1510.949 ms;
- aggregate harness result: 1 pass / 2 threshold failures caused by unrelated
  readiness/health timing noise.

Exact PR-head run `kova-260804-140445-8c1576`:

- zero of six gateway process starts contained a `cli.main.dotenv` span;
- aggregate harness result: 1 pass / 2 threshold failures caused by unrelated
  post-ready health timing noise.

The claim is intentionally narrow: the gateway no-file path removes the exact
dotenv span in all observed starts. The noisy aggregate pass rate and wall time
are not used as performance claims.

No changelog entry: this is an internal startup optimization with no
user-facing contract change.
