### PR TITLE
fix(auto-reply): mark truncated row lists in export-session warnings

### DIFF
--- a/src/auto-reply/reply/commands-export-session.test.ts
+++ b/src/auto-reply/reply/commands-export-session.test.ts
@@ -615,6 +615,30 @@ describe("buildExportSessionReply", () => {
     );
   });
 
+  it("marks the skipped-row list as truncated when more than 20 rows are invalid", async () => {
+    hoisted.sessionTranscriptEvents = [
+      ...Array.from({ length: 25 }, (_, index) => ({
+        type: "message",
+        id: `bad-${index + 1}`,
+        timestamp: `2026-05-16T00:00:${String(index).padStart(2, "0")}.000Z`,
+        message: { content: "missing role" },
+      })),
+      {
+        type: "message",
+        id: "entry-valid",
+        timestamp: "2026-05-16T00:01:00.000Z",
+        message: { role: "assistant", content: "valid assistant" },
+      },
+    ];
+
+    const reply = await buildExportSessionReply(makeParams());
+
+    const expectedRows = Array.from({ length: 20 }, (_, index) => index + 1).join(", ");
+    expect(reply.text).toContain(
+      `⚠️ Skipped 25 malformed transcript rows that were not session entries. rows ${expectedRows}, …`,
+    );
+  });
+
   it("warns when the session only contains user messages (backend-delegated transcript)", async () => {
     hoisted.loadSessionStoreMock.mockReturnValue({
       "agent:target:session": {

--- a/src/auto-reply/reply/commands-export-session.ts
+++ b/src/auto-reply/reply/commands-export-session.ts
@@ -256,7 +256,10 @@ function formatSkippedRows(count: number): string {
 }
 
 function formatSessionExportWarning(summary: SessionExportWarningSummary): string {
-  const rows = summary.rows.length > 0 ? ` rows ${summary.rows.join(", ")}` : "";
+  const rows =
+    summary.rows.length > 0
+      ? ` rows ${summary.rows.join(", ")}${summary.count > summary.rows.length ? ", …" : ""}`
+      : "";
   const verb = summary.count === 1 ? "was" : "were";
   switch (summary.code) {
     case "invalid-session-json":


### PR DESCRIPTION
## Summary

`fix(auto-reply): mark truncated row lists in /export-session malformed-row warnings so a capped list no longer reads as complete`

## What Problem This Solves

When `/export-session` loads a session transcript, rows that are not valid session entries are skipped and reported in the command reply: `⚠️ Skipped N malformed transcript rows ... rows 1, 2, 3, ...`. To keep the reply bounded, `summarizeSessionExportWarnings` caps the recorded row list at 20 entries while `count` keeps the true total.

The bug: when more than 20 rows are malformed, the reply prints the true count **and** the first 20 row numbers with no truncation marker. `⚠️ Skipped 25 malformed transcript rows that were not session entries. rows 1, 2, …, 20` reads as a complete enumeration — the user has no way to tell that rows 21–25 even exist, let alone which they are. Any diagnosis or cleanup based on the message silently misses those rows.

Trigger condition: any `/export-session` on a transcript containing more than 20 malformed rows of the same warning code. This is an edge case (it needs a corrupt/legacy transcript with 20+ bad rows), but exactly the scenario the warning exists for — and the warning actively misleads in that scenario.

**Code evidence** (on main, `src/auto-reply/reply/commands-export-session.ts`):

- The list is silently capped at 20, while `count` accumulates every occurrence — `:240`:

  ```ts
  if (summary.rows.length < 20) {
    summary.rows.push(warning.row);
  }
  ```

- The formatter prints `count` plus the joined list with no indication that the list may be shorter than `count` — `:259`:

  ```ts
  const rows = summary.rows.length > 0 ? ` rows ${summary.rows.join(", ")}` : "";
  ```

## Root Cause

- Bug introduced by commit `192caba6311e9fe98e324de20a3cfec1756b7318` (2026-05-16, `fix(export): report malformed transcript rows (#82553)`), which added the malformed-row warning feature. Verified via the GitHub API: at that commit the file already contains the `summary.rows.length < 20` cap (then line 208) and a `formatSessionExportWarning` that joins the rows with no truncation marker (then line 227); its parent `d32b2a47715c17b8b1e2b3fa937f00c06566348c` contains no skip-warning logic at all. (The `/export-session` command itself dates to `add3afb7439e`, 2026-02-16, but that revision has no warning logic, so it did not introduce this bug form.)
- Violated invariant: a truncated list presented to the user must be marked as truncated. The summarizer upholds a bounded-list contract (`rows.length ≤ 20` < `count`), but the formatter was written as if `rows` always enumerates every skipped row.
- Trigger condition: `count > 20` malformed transcript rows sharing one warning code, e.g. 25 corrupt `message` rows missing `role` in the persisted transcript store.

## Why This Fix

- Option A: print all skipped rows unbounded — rejected: it defeats the purpose of the 20-row cap, which exists to keep command replies bounded for pathological transcripts (hundreds/thousands of corrupt rows).
- Option B: when truncated, print only the count and drop the row list — rejected: it throws away diagnostic information (the first 20 row numbers are exactly what a user needs to start inspecting the transcript) and changes output shape more than necessary.
- Option C (chosen): keep the cap and append `", …"` to the row list if and only if `summary.count > summary.rows.length`. One conditional suffix, no behavior change for the common `count ≤ 20` case, and the truncation becomes explicit: `rows 1, …, 20, …` with `Skipped 25` now unambiguously means "20 shown of 25".

## User Impact

- Affected operation: `/export-session` replies for transcripts with more than 20 malformed rows of one warning code (`invalid-session-row` / `invalid-session-json`).
- Before: `⚠️ Skipped 25 malformed transcript rows that were not session entries. rows 1, 2, …, 20` — indistinguishable from a complete list; rows 21–25 are silently invisible.
- After: the same message ends with `rows 1, 2, …, 20, …`, explicitly signalling that the list is truncated while the count already conveys the true total.
- Behavior change: the only change is the added `", …"` suffix when truncation actually occurred. Replies for `count ≤ 20` are byte-identical.

## Evidence

Setup: the **real** `buildExportSessionReply` (`node --import tsx proof.mjs`, no test framework, no mocks of the code under test) is driven end-to-end against a real SQLite-backed session store in a temporary `OPENCLAW_STATE_DIR`. The session entry and transcript header are created through the real `createSessionEntryWithTranscript` write API; 26 fixture transcript rows (25 malformed `message` rows without `role` + 1 valid row) are persisted into the real `transcript_events` table to simulate corrupt persisted state; the command then resolves the store/entry/transcript, loads events from SQLite, builds the real HTML export (real templates + generated vendor assets), and really writes the export file into a temp workspace. One environment accommodation: `cfg.plugins.enabled = false` (a real config knob) because plugin-tool discovery hangs indefinitely on this Windows runner — unrelated to the export/warning path.

### Before (on main)

```bash
$ node --import tsx proof.mjs   # HEAD~1 (buggy formatSessionExportWarning)
[proof] transcript rows persisted: 26 (25 malformed + 1 valid)

=== buildExportSessionReply reply.text ===
✅ Session exported!

📄 File: openclaw-session-proofses-2026-08-05T03-35-31.html
📊 Entries: 1
⚠️ Skipped 25 malformed transcript rows that were not session entries. rows 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20
🧠 System prompt: 13,792 chars
🔧 Tools: 38
=== end reply.text ===

[proof] count mentions 25: true; rows listed: 20; ellipsis marker: false
[proof] files written to workspace: openclaw-session-proofses-2026-08-05T03-35-31.html
PROOF RESULT: FAIL (bug present) - 25 rows skipped but only 20 listed with NO truncation marker; the list reads as complete
exit code: 1
```

### After (with fix)

```bash
$ node --import tsx proof.mjs   # HEAD (fixed formatSessionExportWarning)
[proof] transcript rows persisted: 26 (25 malformed + 1 valid)

=== buildExportSessionReply reply.text ===
✅ Session exported!

📄 File: openclaw-session-proofses-2026-08-05T03-39-32.html
📊 Entries: 1
⚠️ Skipped 25 malformed transcript rows that were not session entries. rows 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, …
🧠 System prompt: 13,792 chars
🔧 Tools: 38
=== end reply.text ===

[proof] count mentions 25: true; rows listed: 20; ellipsis marker: true
[proof] files written to workspace: openclaw-session-proofses-2026-08-05T03-39-32.html
PROOF RESULT: PASS - truncated row list is explicitly marked with ', …'
exit code: 0
```

## Tests and Validation

- `node node_modules/vitest/vitest.mjs run src/auto-reply/reply/commands-export-session.test.ts` — **32 passed, 2 skipped, 1 failed**. The single failure is the pre-existing Windows-only `preserves replacement text with dollar sequences` case: the test's fs mock matches POSIX-style suffixes (`vendor/marked.min.js`), which never match Windows backslash paths once the real vendor assets exist on disk. Verified unrelated: the same test fails identically with `commands-export-session.ts` checked out at HEAD~1.
- Targeted run of the new regression test: `... -t "marks the skipped-row list as truncated when more than 20 rows are invalid"` — **1 passed**.
- Manual verification (the proof above):
  1. On main, exporting a session whose transcript has 25 malformed rows prints `Skipped 25 ... rows 1, …, 20` with no truncation marker (PROOF RESULT: FAIL).
  2. With the fix, the identical scenario prints `rows 1, …, 20, …` (PROOF RESULT: PASS), with the real HTML export written to disk in both runs.