### PR TITLE
fix(bedrock): forward resolved maxTokens on reasoning-off requests

### DIFF
--- a/extensions/amazon-bedrock/stream.runtime.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.test.ts
@@ -487,6 +487,19 @@ describe("Bedrock thinking effort mapping", () => {
     },
   );
 
+  it("does not forward the model cap for non-Opus reasoning-off requests", () => {
+    const model = bedrockModel({
+      id: "anthropic.claude-sonnet-4-6",
+      name: "Claude Sonnet 4.6",
+      reasoning: true,
+      maxTokens: 128_000,
+    });
+    const options = testing.resolveSimpleBedrockOptions(model, { reasoning: "off" });
+
+    expect(options).toMatchObject({ reasoning: "off" });
+    expect(options.maxTokens).toBeUndefined();
+  });
+
   it.each([
     { reasoning: undefined, expected: "high" },
     { reasoning: "off" as const, expected: "low" },

--- a/extensions/amazon-bedrock/stream.runtime.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.test.ts
@@ -461,7 +461,7 @@ describe("Bedrock stop reasons", () => {
 describe("Bedrock thinking effort mapping", () => {
   it.each([
     { reasoning: undefined, expected: "high", maxTokens: 128_000, fields: true },
-    { reasoning: "off" as const, expected: "off", maxTokens: undefined, fields: false },
+    { reasoning: "off" as const, expected: "off", maxTokens: 128_000, fields: false },
   ])(
     "uses the Opus 5 default for reasoning=$reasoning",
     ({ reasoning, expected, maxTokens, fields }) => {

--- a/extensions/amazon-bedrock/stream.runtime.ts
+++ b/extensions/amazon-bedrock/stream.runtime.ts
@@ -465,7 +465,14 @@ function resolveSimpleBedrockOptions(
   }
 
   if (options.reasoning === "off") {
-    return { ...base, reasoning: "off" } satisfies BedrockOptions;
+    return {
+      ...base,
+      // reasoning-off requests must still forward the resolved model output
+      // cap; without it Bedrock uses its provider default and heavy turns end
+      // with stopReason "length" (#119148).
+      maxTokens: resolveAdaptiveBedrockMaxTokens(model, base.maxTokens),
+      reasoning: "off",
+    } satisfies BedrockOptions;
   }
 
   if (isAnthropicClaudeModel(model)) {

--- a/extensions/amazon-bedrock/stream.runtime.ts
+++ b/extensions/amazon-bedrock/stream.runtime.ts
@@ -467,10 +467,12 @@ function resolveSimpleBedrockOptions(
   if (options.reasoning === "off") {
     return {
       ...base,
-      // reasoning-off requests must still forward the resolved model output
-      // cap; without it Bedrock uses its provider default and heavy turns end
-      // with stopReason "length" (#119148).
-      maxTokens: resolveAdaptiveBedrockMaxTokens(model, base.maxTokens),
+      // Opus 5 reasoning-off requests must still forward the resolved model
+      // output cap; without it Bedrock uses its provider default and heavy
+      // turns end with stopReason "length".
+      ...(usesClaudeOpus5BedrockContract(model)
+        ? { maxTokens: resolveAdaptiveBedrockMaxTokens(model, base.maxTokens) }
+        : {}),
       reasoning: "off",
     } satisfies BedrockOptions;
   }


### PR DESCRIPTION
## What Problem This Solves

Amazon Bedrock Claude Opus 5 requests with `reasoning: "off"` omitted `inferenceConfig.maxTokens` even when the resolved model has a configured output cap, so output-heavy turns ended with `stopReason: "length"` and no usable response (`Agent couldn't generate a response`). Fixes #119148.

## Why This Change Was Made

The `reasoning: "off"` branch of `resolveSimpleBedrockOptions` returned the base options without touching `maxTokens`, while every adaptive/thinking branch forwards `resolveAdaptiveBedrockMaxTokens`. That helper already encodes the right precedence: a request-level cap wins, and OpenClaw's synthetic fallback caps (4096/8192/16384) stay omitted so Bedrock uses its native default. The fix applies the same helper to the reasoning-off branch — matching the shipped adaptive-thinking behavior (#97343).

## User Impact

Before: with `thinkingDefault: "off"` and `maxTokens: 32000` configured, heavy Bedrock turns hit the provider default output cap and ended with `stopReason: "length"` and an unusable response.
After: the configured model output cap is forwarded on reasoning-off requests; explicit request caps still win and synthetic fallback caps remain omitted.

## Evidence

### Updated reasoning-off expectations (`stream.runtime.test.ts`)
The Opus 5 thinking-effort mapping test now expects `maxTokens: 128_000` (the model's configured cap) for `reasoning: "off"` instead of `undefined`, and still expects no adaptive-thinking fields.

### Test run (extension suite)
```text
$ node scripts/test-extension.mjs amazon-bedrock
Test Files  14 passed (14)
Tests  284 passed (284)
```

[AI-assisted]


### Scoped to the Opus 5 contract (P1 review follow-up)
The reasoning-off cap forwarding is now gated to `usesClaudeOpus5BedrockContract`, so non-Opus Bedrock reasoning-off requests keep their previous provider-default output behavior; explicit request caps still win via `...base`. The runtime comment no longer embeds the issue reference.

```text
$ ../node_modules/.bin/vitest run --config test/vitest/vitest.extension-providers.config.ts extensions/amazon-bedrock/stream.runtime.test.ts
Test Files  1 passed (1)
Tests  54 passed (54)
```
Non-Opus regression (fails pre-fix, `expected 128000 to be undefined`): full amazon-bedrock suite Test Files 11 passed, Tests 231 passed.

### Blocker: real AWS environment proof
A live Bedrock run (configured / explicit / synthetic-fallback caps against a real AWS account) cannot be produced from this local environment; the unit-level contract coverage above is the available evidence. PR stays open for a maintainer or an operator with AWS access.
