### PR TITLE
fix(agents): agent emits Unix commands (head, ~) that fail in PowerShell on Windows

### DIFF
--- a/src/agents/bash-tools.descriptions.test.ts
+++ b/src/agents/bash-tools.descriptions.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for the model-facing exec/process tool descriptions.
+ * Protects the Windows PowerShell command-language guidance contract
+ * produced by describeExecTool (issue #117644).
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describeExecTool, describeProcessTool } from "./bash-tools.descriptions.js";
+
+const initialProcessPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+
+function setProcessPlatformForTest(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", {
+    configurable: true,
+    enumerable: true,
+    value: platform,
+  });
+}
+
+function restoreProcessPlatformForTest(): void {
+  if (initialProcessPlatform) {
+    Object.defineProperty(process, "platform", initialProcessPlatform);
+  }
+}
+
+describe("describeExecTool", () => {
+  beforeEach(() => restoreProcessPlatformForTest());
+  afterEach(() => restoreProcessPlatformForTest());
+
+  it("returns the base description without Windows guidance on non-win32 platforms", () => {
+    setProcessPlatformForTest("linux");
+    const description = describeExecTool();
+    expect(description).toBe(
+      "Run shell now; background continuation supported. Use yieldMs/background, then process for logs/status/input/intervention. Long run: automatic completion wake when enabled and output/failure occurs; otherwise process confirms completion. TTY CLI/UI/coding agent: pty=true.",
+    );
+    expect(description).not.toContain("PowerShell");
+    expect(description).not.toContain("Select-Object");
+  });
+
+  it("emits PowerShell command-language guidance on win32", () => {
+    setProcessPlatformForTest("win32");
+    const description = describeExecTool();
+
+    // Preserves the direct-executable instruction (issue #117644 root cause:
+    // extend, not replace, the existing Windows guidance).
+    expect(description).toContain("Run executables directly");
+    expect(description).toContain("do NOT wrap commands in `cmd /c`");
+
+    // PowerShell pipeline: Select-Object -First N instead of head -N.
+    expect(description).toContain("Select-Object -First N");
+    expect(description).toContain("head -N");
+
+    // Home path: $env:USERPROFILE instead of ~.
+    expect(description).toContain("$env:USERPROFILE");
+    expect(description).toContain("instead of `~`");
+
+    // Redirect: 2>$null instead of 2>nul.
+    expect(description).toContain("2>$null");
+    expect(description).toContain("2>nul");
+
+    // Avoid Unix-only utilities.
+    expect(description).toMatch(/avoid unix-only utilities/i);
+    expect(description).toContain("sed, awk, grep, head, tail");
+  });
+
+  it("produces stable output across repeated calls on win32", () => {
+    setProcessPlatformForTest("win32");
+    const first = describeExecTool();
+    const second = describeExecTool();
+    expect(second).toEqual(first);
+  });
+});
+
+describe("describeProcessTool", () => {
+  beforeEach(() => restoreProcessPlatformForTest());
+  afterEach(() => restoreProcessPlatformForTest());
+
+  it("returns the process-control description on any platform", () => {
+    setProcessPlatformForTest("win32");
+    const description = describeProcessTool();
+    expect(description).toContain("Control existing exec");
+  });
+});

--- a/src/agents/bash-tools.descriptions.ts
+++ b/src/agents/bash-tools.descriptions.ts
@@ -36,6 +36,9 @@ export function describeExecTool(params?: { agentId?: string; hasCronTool?: bool
   lines.push(
     "IMPORTANT (Windows): Run executables directly; do NOT wrap commands in `cmd /c`, `powershell -Command`, `& ` prefix, or WSL. Use backslash paths (C:\\path), not forward slashes. Use short executable names (e.g. `node`, `python3`) instead of full paths.",
   );
+  lines.push(
+    "Use PowerShell command syntax, not Unix or CMD: `Select-Object -First N` instead of `head -N`, `$env:USERPROFILE` instead of `~`, and `2>$null` instead of `2>nul`. Avoid Unix-only utilities (sed, awk, grep, head, tail).",
+  );
   try {
     const approvalsFile = loadExecApprovals();
     const approvals = resolveExecApprovalsFromFile({


### PR DESCRIPTION
> [AI-assisted] This PR was generated using Claude Code.

## What Problem This Solves

Fixes an issue where the embedded agent on native Windows/PowerShell emits Unix-only commands (`head -N`, `~` tilde expansion, `2>nul` redirect) that fail in PowerShell. The Windows exec tool description only told the model how to invoke executables (do not wrap in `cmd /c`) and gave no PowerShell command-language guidance, so the model emits Unix/CMD pipeline syntax such as `dir /b /o-n ~\memory\2026-*.md 2>nul | head -5` - where `head` is not a native PowerShell cmdlet and `2>nul` is CMD-only redirect syntax.

Closes #117644.

## Why This Change Was Made

Extended the existing win32 exec description - the single shared owner at `src/agents/bash-tools.descriptions.ts`, read by the eager, lazy, and deferred exec tool assembly paths (`bash-tools.exec-run.ts`, `lazy-exec-tool.ts`, `agent-tools.deferred-followup.ts`) - with concise PowerShell command-language guidance: `Select-Object -First N` instead of `head -N`, `$env:USERPROFILE` instead of `~`, and `2>$null` instead of `2>nul`, plus an avoid-list for Unix-only utilities (sed, awk, grep, head, tail). The direct-executable instruction is preserved (extend, not replace). A platform-conditional regression test exercises the Windows description produced by `describeExecTool`, which previously had no test coverage (the existing deferred-guidance test only asserts the non-win32 base wording).

## User Impact

On Windows/PowerShell hosts, the agent now receives explicit PowerShell command-language guidance and will emit PowerShell-compatible pipelines (`Get-ChildItem | Select-Object -First N`, `$env:USERPROFILE`, `2>$null`) instead of Unix/CMD syntax that fails or produces noisy device-name errors on every heartbeat/startup memory scan. Non-Windows hosts are unchanged (the guidance is win32-only); normal exec paths are unaffected.

## Evidence

- Repro environment (os): Windows 10 / native PowerShell (process.platform === "win32")
- Repro steps (commands): `pnpm exec tsx .tmp/proof/win32-exec-description.mjs` loads `describeExecTool()` from source and runs the recommended pipelines via native PowerShell
- Expected (after fix): win32 description includes the PowerShell command-language guidance markers and the recommended commands run in native PowerShell
- Actual (before fix): win32 description had NO PowerShell command-language guidance (all markers ABSENT), so the model received no command-language help and emitted Unix/CMD syntax
- Evidence type (real): production-path terminal output (tsx loading the real `describeExecTool` + native PowerShell `execFileSync`)

BEFORE (main, commit c6c7d7d9de5b):

```text
=== describeExecTool() output (model-facing exec contract on win32) ===
Run shell now; background continuation supported. ...
IMPORTANT (Windows): Run executables directly; do NOT wrap commands in `cmd /c`, ... Use short executable names (e.g. `node`, `python3`) instead of full paths.

=== PowerShell command-language guidance markers ===
  ABSENT   Select-Object -First N
  ABSENT   $env:USERPROFILE
  ABSENT   2>$null
  ABSENT   Avoid Unix-only utilities

=== native Windows PowerShell: recommended commands work ===
cmd: Get-ChildItem -Path $env:USERPROFILE -Name | Select-Object -First 3  (compatible dir-listing pipeline)
  -> ".ai_completion\r\n.antigravity\r\n.antigravity_tools"
cmd: $env:USERPROFILE  (home path resolves; replaces ~)
  -> "C:\\Users\\10314642.WIN-OFOJT2VJ1D2"
cmd: Write-Output ok 2>$null  (PowerShell stderr redirect; replaces 2>nul)
  -> "ok"

=== Select-Object is a native PowerShell cmdlet; head is NOT (external-only) ===
cmd: Get-Command Select-Object -CommandType Cmdlet
  -> "1"
cmd: Get-Command head -ErrorAction SilentlyContinue  (Application = external exe, not guaranteed on Windows)
  -> "Application"
```

AFTER (this branch, with PowerShell command-language guidance added):

```text
=== describeExecTool() output (model-facing exec contract on win32) ===
Run shell now; background continuation supported. ...
IMPORTANT (Windows): Run executables directly; do NOT wrap commands in `cmd /c`, ... Use short executable names ...
Use PowerShell command syntax, not Unix or CMD: `Select-Object -First N` instead of `head -N`, `$env:USERPROFILE` instead of `~`, and `2>$null` instead of `2>nul`. Avoid Unix-only utilities (sed, awk, grep, head, tail).

=== PowerShell command-language guidance markers ===
  PRESENT  Select-Object -First N
  PRESENT  $env:USERPROFILE
  PRESENT  2>$null
  PRESENT  Avoid Unix-only utilities
```

- `node scripts/run-vitest.mjs src/agents/bash-tools.descriptions.test.ts` - 4/4 passed (and 1/4 fails on unfixed main, confirming the test guards the contract)
- `pnpm exec oxfmt --check src/agents/bash-tools.descriptions.ts src/agents/bash-tools.descriptions.test.ts` - passed
- `pnpm tsgo` - passed (0 errors)
- `pnpm exec oxlint src/agents/bash-tools.descriptions.ts src/agents/bash-tools.descriptions.test.ts` - passed

AI-assisted: Claude Code
