### PR TITLE
fix(cli): gateway usage-cost and stability honor local --port

### DIFF
--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -229,6 +229,8 @@ openclaw gateway usage-cost
 openclaw gateway usage-cost --days 7
 openclaw gateway usage-cost --agent work --json
 openclaw gateway usage-cost --all-agents
+openclaw gateway usage-cost --port 18999
+openclaw gateway --port 18999 usage-cost
 openclaw gateway usage-cost --json
 ```
 
@@ -241,6 +243,9 @@ openclaw gateway usage-cost --json
 <ParamField path="--all-agents" type="boolean">
   Aggregate across all configured agents. Cannot combine with `--agent`.
 </ParamField>
+<ParamField path="--port <port>" type="number">
+  Target a local loopback Gateway on this port. Overrides `OPENCLAW_GATEWAY_URL` and `OPENCLAW_GATEWAY_PORT` for this call. Cannot combine with `--url`.
+</ParamField>
 
 ### `gateway stability`
 
@@ -251,6 +256,7 @@ openclaw gateway stability
 openclaw gateway stability --type payload.large
 openclaw gateway stability --bundle latest
 openclaw gateway stability --bundle latest --export
+openclaw gateway --port 18999 stability
 openclaw gateway stability --json
 ```
 
@@ -271,6 +277,9 @@ openclaw gateway stability --json
 </ParamField>
 <ParamField path="--output <path>" type="string">
   Output path for `--export`.
+</ParamField>
+<ParamField path="--port <port>" type="number">
+  Target a local loopback Gateway on this port. Overrides `OPENCLAW_GATEWAY_URL` and `OPENCLAW_GATEWAY_PORT` for this call. Cannot combine with `--url`. Applies to the live stability query; `--bundle` reads from disk and `--export` collects its snapshots through the support-export path, so neither is redirected by `--port`.
 </ParamField>
 
 <AccordionGroup>

--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -279,7 +279,7 @@ openclaw gateway stability --json
   Output path for `--export`.
 </ParamField>
 <ParamField path="--port <port>" type="number">
-  Target a local loopback Gateway on this port. Overrides `OPENCLAW_GATEWAY_URL` and `OPENCLAW_GATEWAY_PORT` for this call. Cannot combine with `--url`. Applies to the live stability query; `--bundle` reads from disk and `--export` collects its snapshots through the support-export path, so neither is redirected by `--port`.
+  Target a local loopback Gateway on this port for the live stability query. Overrides `OPENCLAW_GATEWAY_URL` and `OPENCLAW_GATEWAY_PORT` for this call. Cannot combine with `--url`, and is rejected with `--export` because the support export always targets the configured Gateway. `--bundle` reads from disk, so `--port` has no effect there.
 </ParamField>
 
 <AccordionGroup>

--- a/src/cli/gateway-cli/register.option-collisions.test.ts
+++ b/src/cli/gateway-cli/register.option-collisions.test.ts
@@ -278,6 +278,34 @@ describe("gateway register option collisions", () => {
         expect(params).toEqual({ days: 30 });
       },
     },
+    {
+      name: "projects gateway usage-cost --port into local config",
+      argv: ["gateway", "usage-cost", "--port", "19086", "--json"],
+      assert: () => {
+        expectLocalGatewayCall("usage.cost", 19086, { days: 30 });
+      },
+    },
+    {
+      name: "inherits parent --port for gateway usage-cost",
+      argv: ["gateway", "--port", "19087", "usage-cost", "--json"],
+      assert: () => {
+        expectLocalGatewayCall("usage.cost", 19087);
+      },
+    },
+    {
+      name: "projects gateway stability --port into local config",
+      argv: ["gateway", "stability", "--port", "19088", "--json"],
+      assert: () => {
+        expectLocalGatewayCall("diagnostics.stability", 19088, { limit: 25 });
+      },
+    },
+    {
+      name: "inherits parent --port for gateway stability",
+      argv: ["gateway", "--port", "19089", "stability", "--json"],
+      assert: () => {
+        expectLocalGatewayCall("diagnostics.stability", 19089);
+      },
+    },
   ])("$name", async ({ argv, assert }) => {
     await sharedProgram.parseAsync(argv, { from: "user" });
     assert();
@@ -294,6 +322,38 @@ describe("gateway register option collisions", () => {
       "Gateway call failed: Error: Use either --url or --port, not both.",
     );
     expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it.each([
+    {
+      name: "usage-cost",
+      argv: ["gateway", "usage-cost", "--url", "ws://127.0.0.1:19090", "--port", "19090", "--json"],
+      failurePrefix: "Gateway usage cost failed",
+    },
+    {
+      name: "stability",
+      argv: ["gateway", "stability", "--url", "ws://127.0.0.1:19090", "--port", "19090", "--json"],
+      failurePrefix: "Gateway stability failed",
+    },
+  ])("rejects combining --url and --port for gateway $name", async ({ argv, failurePrefix }) => {
+    await sharedProgram.parseAsync(argv, { from: "user" });
+
+    expect(callGatewayCli).not.toHaveBeenCalled();
+    expect(defaultRuntime.error).toHaveBeenCalledWith(
+      `${failurePrefix}: Error: Use either --url or --port, not both.`,
+    );
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("keeps gateway stability --bundle a local read that ignores --port", async () => {
+    await sharedProgram.parseAsync(
+      ["gateway", "stability", "--bundle", "latest", "--port", "19091", "--json"],
+      { from: "user" },
+    );
+
+    // --bundle reads a persisted bundle from disk and must never open an RPC
+    // connection, so the local-port resolver has no target to redirect.
+    expect(callGatewayCli).not.toHaveBeenCalled();
   });
 
   it("uses the effective local port config for gateway health auth diagnostics", async () => {

--- a/src/cli/gateway-cli/register.option-collisions.test.ts
+++ b/src/cli/gateway-cli/register.option-collisions.test.ts
@@ -345,6 +345,19 @@ describe("gateway register option collisions", () => {
     expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
   });
 
+  it("rejects --port with gateway stability --export instead of silently ignoring it", async () => {
+    await sharedProgram.parseAsync(
+      ["gateway", "stability", "--export", "--port", "19092", "--json"],
+      { from: "user" },
+    );
+
+    expect(callGatewayCli).not.toHaveBeenCalled();
+    expect(defaultRuntime.error).toHaveBeenCalledWith(
+      expect.stringContaining("--port is not supported with --export"),
+    );
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+  });
+
   it("keeps gateway stability --bundle a local read that ignores --port", async () => {
     await sharedProgram.parseAsync(
       ["gateway", "stability", "--bundle", "latest", "--port", "19091", "--json"],

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -602,10 +602,11 @@ export function registerGatewayCli(program: Command, deps: GatewayCliDependencie
       .option("--days <days>", "Number of days to include", "30")
       .option("--agent <id>", "Scope the cost summary to a specific agent id")
       .option("--all-agents", "Aggregate the cost summary across all agents", false)
+      .option("--port <port>", "Local Gateway port")
       .action(async (opts, command) => {
         await runGatewayCommand(
           async () => {
-            const rpcOpts = resolveGatewayRpcOptions(opts, command);
+            const rpcOpts = await resolveGatewayRpcOptionsWithLocalPort(opts, command);
             const days = parseDaysOption(opts.days);
             const agentId = typeof opts.agent === "string" ? opts.agent.trim() : undefined;
             // The gateway honors agentScope only when no agentId is set, so reject the
@@ -707,12 +708,13 @@ export function registerGatewayCli(program: Command, deps: GatewayCliDependencie
       )
       .option("--export", "Write a shareable support diagnostics export", false)
       .option("--output <path>", "Diagnostics export output .zip path")
+      .option("--port <port>", "Local Gateway port")
       .action(async (opts, command) => {
         await runGatewayCommand(
           async () => {
             const { normalizeDiagnosticStabilityQuery, selectDiagnosticStabilitySnapshot } =
               await import("../../logging/diagnostic-stability.js");
-            const rpcOpts = resolveGatewayRpcOptions(opts, command);
+            const rpcOpts = await resolveGatewayRpcOptionsWithLocalPort(opts, command);
             const query = normalizeDiagnosticStabilityQuery(
               {
                 limit: opts.limit,

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -725,6 +725,15 @@ export function registerGatewayCli(program: Command, deps: GatewayCliDependencie
             );
             const bundleTarget = normalizeStabilityBundleTarget(opts.bundle);
             if (opts.export) {
+              // The support export collects its status/health snapshots through
+              // writeSupportExportFromCli, which narrows RPC options to url/token/password/
+              // timeout and drops the local-port override. Accepting --port here would
+              // silently export a different Gateway than the one named.
+              if (rpcOpts.localPortOverride !== undefined) {
+                throw new Error(
+                  "--port is not supported with --export; the support export targets the configured Gateway. Run the export against that Gateway, or use --port without --export for a live stability query.",
+                );
+              }
               await writeSupportExportFromCli({
                 json: rpcOpts.json,
                 output: opts.output,


### PR DESCRIPTION
Related: #119036

## What Problem This Solves

Fixes an issue where operators running a local Gateway on a non-default port would get a
different Gateway's usage/cost totals and stability diagnostics when they pointed
`openclaw gateway usage-cost` or `openclaw gateway stability` at it.

`openclaw gateway` accepts `--port` at the parent level, so `openclaw gateway --port 18999
usage-cost` parses without complaint. Those two subcommands never read it. They connect to
the configured/default target instead and print its usage totals or its stability
diagnostics — no error, no warning, nothing in the output that says the requested Gateway
was not the one that answered.

This is the same defect #119036 described for `gateway call`, on the two RPC subcommands
that were not part of that fix. Per that issue, pointing `--url` at the loopback Gateway is
not an equivalent workaround, because URL overrides are deliberately rejected without
explicit credentials.

**Root cause:** `usage-cost` and `stability` resolved their RPC options through
`resolveGatewayRpcOptions`, which inherits only `token` and `password` from the parent
command, so the accepted `--port` never reached the transport.

## Why This Change Was Made

This PR changes both subcommands to route through the existing local-port resolver
(`resolveGatewayRpcOptionsWithLocalPort`) and to declare `--port`, so on a live RPC path an
accepted port either reaches the named Gateway or is rejected with a reason.

`gateway usage-cost` and `gateway stability` now resolve RPC options through
`resolveGatewayRpcOptionsWithLocalPort`, the helper `gateway health` and `gateway call`
already use. That helper takes a direct or parent-inherited `--port`, projects it into the
call's config as `gateway: { mode: "local", port }` plus a `localPortOverride`, and rejects
`--url` together with `--port`. Because the port is applied to the resolved local config
rather than as a bare URL, the operator's configured local credentials still apply — that
is the resolver's existing behavior, unchanged here and shared with `health`/`call`. Both
subcommands also declare `--port` so it appears in `--help`.

No new helper and no change to the shared resolver; production is +11 lines, of which 5
are the export guard and its comment.

This change is **limited to** those two subcommands. Deliberately **out of scope** here:

- `gateway diagnostics export` and `gateway stability --export` route through
  `writeSupportExportFromCli`, whose `rpc` parameter is typed
  `Pick<GatewayRpcOpts, "url" | "token" | "password" | "timeout">`. It rebuilds the options
  object and drops `localPortOverride`/`config`, and its status snapshot goes through
  `gatherDaemonStatus`, which reads only `rpc.url`. Switching the resolver there would look
  correct and change nothing, so that path needs its own owner-boundary fix.

  Because `stability` now declares `--port`, `--export` would otherwise start *accepting* a
  port it cannot honor — reintroducing this PR's own bug on that branch. So
  `stability --export --port N` is **rejected** with a message naming the constraint,
  rather than silently exporting the wrong Gateway.
- `gateway status` lives in `addGatewayServiceCommands`
  (`src/cli/daemon-cli/register-service-commands.ts`) with a different helper
  (`resolveRpcOptions`) and is attached to more than one parent command.
- `gateway probe` is already correct — it uses the plain resolver but forwards `port`
  explicitly to `gatewayStatusCommand`.
- `gateway stability --bundle` reads a persisted bundle from disk and opens no RPC
  connection. It accepts `--port` (the flag is declared on the subcommand) and
  intentionally ignores it, because there is no connection to redirect. A regression test
  pins that it stays a local read.

## User Impact

Operators can target a local Gateway on a custom port for usage/cost reporting and
stability diagnostics the same way they already can for `health`, `probe`, and `call`:

```bash
openclaw gateway --port 18999 usage-cost --json
openclaw gateway stability --port 18999
```

No token or password has to go on the command line, because `--port` resolves against the
local config rather than overriding the URL.

For these two subcommands' live RPC paths, `--port` now reaches the Gateway the operator
named instead of being dropped. `gateway status` and `stability --bundle` behave exactly as
before. The support-export implementation is also unchanged; what is new there is the CLI
guard that refuses `stability --export --port` instead of accepting a port the export
cannot honor.

**Limitations:** the proof runs both Gateways with `auth: none` on loopback, so it
exercises target selection only — credential reuse under `--port` is the pre-existing
resolver contract shared with `health`/`call` and is not re-proven here. `gateway status`
and `gateway diagnostics export` still ignore a parent-inherited `--port`; that is
pre-existing behavior this PR neither fixes nor worsens, and it is named above as
follow-up work.

## Evidence

Two real Gateways were started from the packaged build (`pnpm build`, no mocks, no test
runner): **A** on `:18991` — the target the shell/config resolves to — and **B** on
`:18999`, the one the operator names with `--port`. Both must be running, because the claim
is that the wrong one answers; with only B up, the "before" run would just fail to connect,
which is a different symptom.

Which Gateway served the call is read from **that Gateway's own log**: only the Gateway
that accepts the websocket writes a `device pairing auto-approved` line for the connecting
device, and each case runs the CLI from a fresh state dir (so a fresh, unpaired device
identity) whose config still points at A. The serving Gateway therefore logs exactly one
new line per case and the other logs none — a server-side signal the CLI cannot fabricate.
`OPENCLAW_GATEWAY_URL`, `OPENCLAW_GATEWAY_PORT`, `OPENCLAW_GATEWAY_TOKEN`, and
`OPENCLAW_GATEWAY_PASSWORD` are unset so the env fallback cannot mask the result. Both
Gateways run `auth: none` on loopback, so this run exercises target selection only, not
credential handling.

Environment: Linux 6.8.0, Node v24.18.0, package version 2026.7.2, packaged build only —
no mocks and no test runner.

Both captures were taken against base `e4aab26d017e535d84eb486564278cfefe1238a1` with head
`f24de646a5dace6f3be5bc94c58cd6b0670c03cc`: **before** = that base tree built as-is,
**after** = the same tree with this patch, rebuilt. The branch has since been rebased onto
`e2b90e6e71c54184d13eae2030c058549f4098c9` (head
`758b47bbfc63f40f982b81e297dce19c5981ed90`). That rebase changed no file in this diff, and
the two intervening upstream commits are test-only (`test(gateway): isolate scheduled
service timers`, `test(qa): cover Canvas agent and node controls`) touching nothing under
`src/cli/`, so the captures still describe this head. The focused suite was re-run green on
the rebased head.

The counting criterion is one `grep -c "device pairing auto-approved"` per Gateway log,
taken over only the lines appended during that case. A served case looks like this in the
winning Gateway's log and produces no counterpart line in the other:

```
2026-08-04T20:47:22.061+09:00 [gateway] device pairing auto-approved device=387685ea… role=operator
```

Routing is the oracle rather than the returned totals on purpose: `usage.cost` and
`diagnostics.stability` are computed from each Gateway's own state, and two freshly created
state dirs both report empty, so the payloads would be identical and could not distinguish
the targets. Which Gateway accepted the connection can.

In the captures below, the `$ openclaw ...` and the message lines are real CLI output; the
`connections logged by ...` and `ANSWERED BY: ...` lines are the harness reporting what it
counted in each Gateway's log.

**Before**

```
$ openclaw gateway --port 18999 usage-cost --json
  exit=0
  connections logged by A (:18991) = 1
  connections logged by B (:18999) = 0
  ANSWERED BY: A   <-- wrong Gateway, exit code still 0

$ openclaw gateway --port 18999 stability --limit 1 --json
  exit=0
  connections logged by A (:18991) = 1
  connections logged by B (:18999) = 0
  ANSWERED BY: A   <-- wrong Gateway, exit code still 0

$ openclaw gateway usage-cost --port 18999 --json
  OpenClaw does not recognize option "--port".

$ openclaw gateway usage-cost --url ws://127.0.0.1:18999 --port 18999 --json
  OpenClaw does not recognize option "--port".

# control
$ openclaw gateway usage-cost --json                        # no --port
  exit=0 · connections A=1 B=0 · ANSWERED BY: A   OK (unchanged by this PR)
```

The two failure modes differ: the parent-inherited form is accepted and answered by the
wrong Gateway with exit 0, while the direct child form is rejected outright because the
subcommand never declared `--port`. (The `--url` + `--port` line above fails for that same
parsing reason before the fix — it is not a demonstration of the URL credential policy,
which is #119036's point and is not re-proven here.)

**After**

```
$ openclaw gateway --port 18999 usage-cost --json
  exit=0 · connections A=0 B=1 · ANSWERED BY: B   OK

$ openclaw gateway usage-cost --port 18999 --json
  exit=0 · connections A=0 B=1 · ANSWERED BY: B   OK

$ openclaw gateway --port 18999 stability --limit 1 --json
  exit=0 · connections A=0 B=1 · ANSWERED BY: B   OK

$ openclaw gateway usage-cost --url ws://127.0.0.1:18999 --port 18999 --json
  Gateway usage cost failed: Error: Use either --url or --port, not both.

$ openclaw gateway stability --export --port 18999 --json
  Gateway stability failed: Error: --port is not supported with --export; the support
  export targets the configured Gateway. Run the export against that Gateway, or use
  --port without --export for a live stability query.

# controls
$ openclaw gateway usage-cost --json                        # no --port
  exit=0 · connections A=1 B=0 · ANSWERED BY: A   OK (unchanged)
$ openclaw gateway stability --bundle latest --port 18999 --json
  connections A=0 B=0 · no RPC opened   OK (stays a local read)
```

**Focused tests**

```
node scripts/run-vitest.mjs src/cli/gateway-cli/register.option-collisions.test.ts
Test Files  1 passed (1)
     Tests  23 passed (23)
```

Eight cases were added to the existing table-driven suite, which drives the real Commander
tree and asserts on the options handed to the RPC transport (so it covers resolver output,
not just parsing):

- `projects gateway usage-cost --port into local config`
- `inherits parent --port for gateway usage-cost`
- `projects gateway stability --port into local config`
- `inherits parent --port for gateway stability`
- `rejects combining --url and --port for gateway usage-cost`
- `rejects combining --url and --port for gateway stability`
- `rejects --port with gateway stability --export instead of silently ignoring it`
- `keeps gateway stability --bundle a local read that ignores --port`

The first six fail without the production change. The `--export` case pins the guard
described above, and the `--bundle` case passes before and after to pin that the local-read
path stays local.

These unit cases build the Commander tree directly, so unknown-option handling differs from
the packaged binary — the `--url` + `--port` pair reaches the resolver there, while the
packaged CLI rejects the undeclared child flag during parsing (visible in the "before"
capture). Both are pre-fix symptoms of the same missing wiring; the live capture above is
the authoritative behavior evidence.

Paths in the captures are `mktemp -d` temp dirs; both Gateways run loopback with
`auth: none`, so no tokens, passwords, or hostnames appear. The run never touches
`~/.openclaw`.
