### PR TITLE
fix(agents): honor skipBootstrap for runtime workspace injection

### DIFF
--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   upsertSessionEntry,
   type SessionTranscriptRuntimeTarget,

--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -4,11 +4,11 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   upsertSessionEntry,
   type SessionTranscriptRuntimeTarget,
 } from "../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   clearInternalHooks,
   registerInternalHook,

--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -436,6 +436,22 @@ describe("resolveBootstrapContextForRun", () => {
     expect(files).toStrictEqual([]);
   });
 
+  it("skips workspace bootstrap injection when agents.defaults.skipBootstrap is set (#75184)", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "rules", "utf8");
+    await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "persona", "utf8");
+
+    const result = await resolveBootstrapContextForRun({
+      workspaceDir,
+      config: {
+        agents: { defaults: { skipBootstrap: true } },
+      } as unknown as OpenClawConfig,
+    });
+
+    expect(result.bootstrapFiles).toStrictEqual([]);
+    expect(result.contextFiles).toStrictEqual([]);
+  });
+
   it("keeps bootstrap context empty in lightweight cron mode", async () => {
     const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
     await fs.writeFile(path.join(workspaceDir, "HEARTBEAT.md"), "check inbox", "utf8");

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -253,6 +253,11 @@ export async function resolveBootstrapContextForRun(params: {
   bootstrapFiles: WorkspaceBootstrapFile[];
   contextFiles: EmbeddedContextFile[];
 }> {
+  // agents.defaults.skipBootstrap opts out of workspace bootstrap file
+  // injection for agent runs, not just file creation at onboarding (#75184).
+  if (params.config?.agents?.defaults?.skipBootstrap) {
+    return { bootstrapFiles: [], contextFiles: [] };
+  }
   const bootstrapFiles = await resolveBootstrapFilesForRun(params);
   const contextFiles = buildBootstrapContextForFiles(bootstrapFiles, params);
   return { bootstrapFiles, contextFiles };


### PR DESCRIPTION
## What Problem This Solves

`agents.defaults.skipBootstrap: true` only skipped bootstrap file *creation* at onboarding; agent runs still injected AGENTS.md, SOUL.md, TOOLS.md, etc. into the system prompt with full per-file content, identical to runs with the flag unset. The systemPromptReport kept listing `injectedWorkspaceFiles` with the full ~13 KB of bootstrap content. Fixes #75184.

## Why This Change Was Made

The runtime injection path (`resolveBootstrapContextForRun`) had no knowledge of the flag — it always resolved workspace bootstrap files and built bounded context files from them. The flag is documented as opting out of workspace bootstrap, so the injection path should honor it: return an empty bootstrap/context set when set. This matches expectation (a) from the report: `injectedWorkspaceFiles` empty and `systemPrompt.chars` dropping by the per-file total.

## User Impact

Before: `skipBootstrap: true` had no effect on agent turns — workspace bootstrap files were still injected into every system prompt.
After: with the flag set, no workspace bootstrap files are injected into agent runs; the system prompt drops the bootstrap char total and `injectedWorkspaceFiles` reports empty.

## Evidence

### New regression test (`src/agents/bootstrap-files.test.ts`)
"skips workspace bootstrap injection when agents.defaults.skipBootstrap is set (#75184)" — workspace with AGENTS.md + SOUL.md and `skipBootstrap: true` config → both `bootstrapFiles` and `contextFiles` are empty.

### Test run
```text
$ ./node_modules/.bin/vitest run src/agents/bootstrap-files.test.ts
Test Files  2 passed (2)
Tests  74 passed (74)
```

[AI-assisted]
