### PR TITLE
fix(memory): report vector store available on fast status path

### DIFF
--- a/extensions/memory-core/src/memory/manager.status-vector-store.test.ts
+++ b/extensions/memory-core/src/memory/manager.status-vector-store.test.ts
@@ -1,0 +1,134 @@
+// Fast-path status must report the vector store as available when indexed
+// chunks exist, even though lazy vector init has not run (#92102).
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { resolveOpenClawAgentSqlitePath } from "openclaw/plugin-sdk/sqlite-runtime";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { closeAllMemorySearchManagers, getMemorySearchManager } from "./index.js";
+import type { MemoryIndexManager } from "./manager.js";
+import { isolateMemoryManagerTestConfig } from "./test-config-helpers.js";
+import "./test-runtime-mocks.js";
+
+const createEmbeddingProviderMock = vi.hoisted(() =>
+  vi.fn(async () => ({
+    requestedProvider: "auto",
+    provider: null,
+    providerUnavailableReason: "No embeddings provider available.",
+  })),
+);
+
+vi.mock("./embeddings.js", () => ({
+  createEmbeddingProvider: createEmbeddingProviderMock,
+  resolveEmbeddingProviderAdapterId: (providerId: string) => providerId,
+  resolveEmbeddingProviderAdapterTransport: (providerId: string) =>
+    providerId === "local" ? "local" : "remote",
+  resolveEmbeddingProviderIndexIdentity: () => undefined,
+  resolveEmbeddingProviderFallbackModel: () => "fts-only",
+}));
+
+describe("memory manager fast-path vector store availability (#92102)", () => {
+  let fixtureRoot = "";
+  let caseId = 0;
+  let workspaceDir = "";
+  let indexPath = "";
+  let managers: MemoryIndexManager[] = [];
+
+  beforeAll(async () => {
+    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mem-status-92102-"));
+  });
+
+  beforeEach(async () => {
+    createEmbeddingProviderMock.mockClear();
+    workspaceDir = path.join(fixtureRoot, `case-${caseId++}`);
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "Alpha topic\n\nKeep this note.");
+    Reflect.set(process.env, "OPENCLAW_STATE_DIR", path.join(workspaceDir, "state"));
+    indexPath = resolveOpenClawAgentSqlitePath({ agentId: "main" });
+  });
+
+  afterEach(async () => {
+    for (const activeManager of managers.toReversed()) {
+      await activeManager.close();
+    }
+    managers = [];
+    await closeAllMemorySearchManagers();
+  });
+
+  afterAll(async () => {
+    await fs.rm(fixtureRoot, { recursive: true, force: true });
+  });
+
+  async function createManager(params: { vectorEnabled?: boolean; purpose?: "status" } = {}) {
+    const store =
+      params.vectorEnabled === undefined
+        ? undefined
+        : { vector: { enabled: params.vectorEnabled } };
+    const cfg = isolateMemoryManagerTestConfig({
+      memory: {
+        backend: "builtin",
+        search: {
+          provider: "auto",
+          model: "",
+          store,
+          cache: { enabled: false },
+          sync: { watch: false, onSessionStart: false, onSearch: false },
+        },
+      },
+      agents: {
+        defaults: { workspace: workspaceDir },
+        list: [{ id: "main", default: true }],
+      },
+    } as OpenClawConfig);
+    const result = await getMemorySearchManager({
+      cfg,
+      agentId: "main",
+      purpose: params.purpose,
+    });
+    if (!result.manager) {
+      throw new Error(result.error ?? "manager missing");
+    }
+    const activeManager = result.manager as unknown as MemoryIndexManager;
+    managers.push(activeManager);
+    return activeManager;
+  }
+
+  async function seedChunk(id: string): Promise<void> {
+    await fs.mkdir(path.dirname(indexPath), { recursive: true });
+    const db = new DatabaseSync(indexPath);
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS memory_index_chunks (
+        id TEXT PRIMARY KEY,
+        path TEXT NOT NULL,
+        source TEXT NOT NULL DEFAULT 'memory',
+        start_line INTEGER NOT NULL,
+        end_line INTEGER NOT NULL,
+        hash TEXT NOT NULL,
+        model TEXT NOT NULL,
+        text TEXT NOT NULL,
+        embedding TEXT NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      INSERT INTO memory_index_chunks (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at)
+        VALUES ('${id}', 'MEMORY.md', 'memory', 1, 3, 'hash-1', 'fts-only', 'Alpha topic', '[]', ${Date.now()});
+    `);
+    db.close();
+  }
+
+  it("reports vector store available from indexed chunks on the fast status path", async () => {
+    await seedChunk("chunk-1");
+    const memoryManager = await createManager({ vectorEnabled: true, purpose: "status" });
+
+    const status = memoryManager.status();
+    expect(status.vector.storeAvailable).toBe(true);
+  });
+
+  it("reports unknown when no indexed chunks exist", async () => {
+    const memoryManager = await createManager({ vectorEnabled: true, purpose: "status" });
+
+    const status = memoryManager.status();
+    expect(status.vector.storeAvailable).toBeUndefined();
+  });
+});

--- a/extensions/memory-core/src/memory/manager.status-vector-store.test.ts
+++ b/extensions/memory-core/src/memory/manager.status-vector-store.test.ts
@@ -122,13 +122,13 @@ describe("memory manager fast-path vector store availability (#92102)", () => {
     const memoryManager = await createManager({ vectorEnabled: true, purpose: "status" });
 
     const status = memoryManager.status();
-    expect(status.vector.storeAvailable).toBe(true);
+    expect(status.vector?.storeAvailable).toBe(true);
   });
 
   it("reports unknown when no indexed chunks exist", async () => {
     const memoryManager = await createManager({ vectorEnabled: true, purpose: "status" });
 
     const status = memoryManager.status();
-    expect(status.vector.storeAvailable).toBeUndefined();
+    expect(status.vector?.storeAvailable).toBeUndefined();
   });
 });

--- a/extensions/memory-core/src/memory/manager.status-vector-store.test.ts
+++ b/extensions/memory-core/src/memory/manager.status-vector-store.test.ts
@@ -34,6 +34,7 @@ describe("memory manager fast-path vector store availability (#92102)", () => {
   let caseId = 0;
   let workspaceDir = "";
   let indexPath = "";
+  let previousStateDir: string | undefined;
   let managers: MemoryIndexManager[] = [];
 
   beforeAll(async () => {
@@ -45,11 +46,17 @@ describe("memory manager fast-path vector store availability (#92102)", () => {
     workspaceDir = path.join(fixtureRoot, `case-${caseId++}`);
     await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
     await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "Alpha topic\n\nKeep this note.");
+    previousStateDir = process.env.OPENCLAW_STATE_DIR;
     Reflect.set(process.env, "OPENCLAW_STATE_DIR", path.join(workspaceDir, "state"));
     indexPath = resolveOpenClawAgentSqlitePath({ agentId: "main" });
   });
 
   afterEach(async () => {
+    if (previousStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      Reflect.set(process.env, "OPENCLAW_STATE_DIR", previousStateDir);
+    }
     for (const activeManager of managers.toReversed()) {
       await activeManager.close();
     }
@@ -95,7 +102,7 @@ describe("memory manager fast-path vector store availability (#92102)", () => {
     return activeManager;
   }
 
-  async function seedChunk(id: string): Promise<void> {
+  async function seedChunk(id: string, opts: { model?: string } = {}): Promise<void> {
     await fs.mkdir(path.dirname(indexPath), { recursive: true });
     const db = new DatabaseSync(indexPath);
     db.exec(`
@@ -112,17 +119,31 @@ describe("memory manager fast-path vector store availability (#92102)", () => {
         updated_at INTEGER NOT NULL
       );
       INSERT INTO memory_index_chunks (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at)
-        VALUES ('${id}', 'MEMORY.md', 'memory', 1, 3, 'hash-1', 'fts-only', 'Alpha topic', '[]', ${Date.now()});
+        VALUES ('${id}', 'MEMORY.md', 'memory', 1, 3, 'hash-1', '${opts.model ?? "local"}', 'Alpha topic', '[0.1,0.2,0.3]', ${Date.now()});
+      CREATE TABLE IF NOT EXISTS memory_index_chunks_vec (
+        id TEXT PRIMARY KEY,
+        embedding FLOAT32[3]
+      );
     `);
     db.close();
   }
 
-  it("reports vector store available from indexed chunks on the fast status path", async () => {
+  it("reports vector store available from a real vector index on the fast status path", async () => {
     await seedChunk("chunk-1");
     const memoryManager = await createManager({ vectorEnabled: true, purpose: "status" });
 
     const status = memoryManager.status();
     expect(status.vector?.storeAvailable).toBe(true);
+  });
+
+  it("does not claim vector store ready from FTS-only rows", async () => {
+    // FTS-only rows have no semantic embedding; presence of any chunk row must
+    // not be treated as evidence that sqlite-vec is loadable (#92102, review P1).
+    await seedChunk("chunk-1", { model: "fts-only" });
+    const memoryManager = await createManager({ vectorEnabled: true, purpose: "status" });
+
+    const status = memoryManager.status();
+    expect(status.vector?.storeAvailable).toBeUndefined();
   });
 
   it("reports unknown when no indexed chunks exist", async () => {

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -2191,9 +2191,15 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       vector: {
         enabled: this.vector.enabled,
         // When lazy vector init has not run (fast status path), fall back to a
-        // cheap chunks-presence check instead of reporting "unknown" for an
-        // index that is actually built (#92102).
-        storeAvailable: this.vector.available ?? (this.hasIndexedChunks() ? true : undefined),
+        // probe-backed fact instead of reporting "unknown" for an index that is
+        // actually built (#92102). Chunk presence alone is NOT sufficient: an
+        // FTS-only or stale row would claim "ready" even when sqlite-vec cannot
+        // load in this process. Require semantic chunks (rows written by the
+        // vector pipeline) AND the vector table to exist — the only synchronous
+        // evidence that a real vector index was built.
+        storeAvailable:
+          this.vector.available ??
+          (this.hasSemanticChunks() && memoryTableExists(this.db, VECTOR_TABLE) ? true : undefined),
         semanticAvailable: this.vector.semanticAvailable,
         available: this.vector.semanticAvailable,
         extensionPath: this.vector.extensionPath,
@@ -2461,6 +2467,12 @@ function hasTargetedSessionSyncParams(params: MemorySyncParams | undefined): boo
   return Boolean(
     params?.sessions?.some((session) => session.sessionId.trim().length > 0) ||
     params?.archiveFiles?.some((sessionFile) => sessionFile.trim().length > 0),
+  );
+}
+
+function memoryTableExists(db: DatabaseSync, tableName: string): boolean {
+  return Boolean(
+    db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?").get(tableName),
   );
 }
 

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -2190,7 +2190,10 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         : undefined,
       vector: {
         enabled: this.vector.enabled,
-        storeAvailable: this.vector.available ?? undefined,
+        // When lazy vector init has not run (fast status path), fall back to a
+        // cheap chunks-presence check instead of reporting "unknown" for an
+        // index that is actually built (#92102).
+        storeAvailable: this.vector.available ?? (this.hasIndexedChunks() ? true : undefined),
         semanticAvailable: this.vector.semanticAvailable,
         available: this.vector.semanticAvailable,
         extensionPath: this.vector.extensionPath,


### PR DESCRIPTION
## What Problem This Solves

`openclaw memory status` (fast path, without `--deep`/`--index`) always showed **"Vector store: unknown"** even when the index had been built and vector chunks were present — `this.vector.available` stays `null` until lazy vector init runs, and the fast path never triggers it. Operators falsely believed vector search was unavailable. Fixes #92102.

## Why This Change Was Made

Instead of forcing sqlite-vec to load on the fast path (defeats the point of the fast path), the status renderer falls back to a synchronous, probe-backed readiness fact: semantic chunks (rows written by the vector pipeline, `model != 'fts-only'`) must exist AND the vector table (`memory_index_chunks_vec`) must be present. This is the strongest evidence a real vector index was built without loading the extension — strictly stronger than raw chunk presence, which an FTS-only or stale row would satisfy even when sqlite-vec cannot load in this process.

## User Impact

Before: `memory status` → `Vector store: unknown` even with a fully built index (only `--deep` showed `ready`).
After: the fast path reports `Vector store: ready` when a real vector index exists, without loading the vector extension; FTS-only or stale rows no longer produce a false "ready".

## Evidence

### Review P1 repair — probe-backed readiness (head `0b135cbf39`)

`storeAvailable` now requires `hasSemanticChunks() && memoryTableExists(db, VECTOR_TABLE)` instead of `hasIndexedChunks()` (any row). The review's failure mode — FTS-only rows claiming "Vector store: ready" while sqlite-vec cannot load — is covered by a regression test.

### Review P3 repair — fixture env restore

`OPENCLAW_STATE_DIR` is restored (or deleted) in `afterEach`, so later tests cannot inherit the temporary state dir.

### Regression tests (`extensions/memory-core/src/memory/manager.status-vector-store.test.ts`)

```text
$ ./node_modules/.bin/vitest run extensions/memory-core/src/memory/manager.status-vector-store.test.ts
 ✓ reports vector store available from a real vector index on the fast status path
 ✓ does not claim vector store ready from FTS-only rows
 ✓ reports unknown when no indexed chunks exist
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

### Neighboring suites (unaffected)

```text
$ ./node_modules/.bin/vitest run .../manager.status.test.ts .../manager-search.test.ts
 Test Files  2 passed (2)
      Tests  43 passed (43)
```

[AI-assisted]

## CI status

- Head `0b135cbf39`: pushed for CI; prior head `29fe602559b1` was all green.
- `Real behavior proof` check: success on prior head.
