### PR TITLE
fix(feishu): keep bot's own mention in group content

### DIFF
--- a/extensions/feishu/src/bot.stripBotMention.test.ts
+++ b/extensions/feishu/src/bot.stripBotMention.test.ts
@@ -5,7 +5,7 @@ import { parseFeishuMessageEvent, type FeishuMessageEvent } from "./bot.js";
 function makeEvent(
   text: string,
   mentions?: Array<{ key: string; name: string; id: { open_id?: string; user_id?: string } }>,
-  chatType: "p2p" | "group" = "p2p",
+  chatType: "p2p" | "group" | "topic_group" = "p2p",
 ): FeishuMessageEvent {
   return {
     sender: { sender_id: { user_id: "u1", open_id: "ou_sender" } },
@@ -60,7 +60,7 @@ describe("normalizeMentions (via parseFeishuMessageEvent)", () => {
     expect(ctx.content).toBe("hello");
   });
 
-  it("strips bot mention in group so slash commands work (#35994)", () => {
+  it("keeps bot mention in group so the model sees it was addressed (#72504)", () => {
     const ctx = parseFeishuMessageEvent(
       makeEvent(
         "@_bot_1 hello",
@@ -69,10 +69,10 @@ describe("normalizeMentions (via parseFeishuMessageEvent)", () => {
       ),
       BOT_OPEN_ID,
     );
-    expect(ctx.content).toBe("hello");
+    expect(ctx.content).toBe('<at user_id="ou_bot">Bot</at> hello');
   });
 
-  it("strips bot mention in group preserving slash command prefix (#35994)", () => {
+  it("keeps bot mention in group alongside slash command prefix (#72504)", () => {
     const ctx = parseFeishuMessageEvent(
       makeEvent(
         "@_bot_1 /model",
@@ -81,7 +81,38 @@ describe("normalizeMentions (via parseFeishuMessageEvent)", () => {
       ),
       BOT_OPEN_ID,
     );
-    expect(ctx.content).toBe("/model");
+    expect(ctx.content).toBe('<at user_id="ou_bot">Bot</at> /model');
+  });
+
+  it("keeps bot mention when multiple bots are addressed in a group (#72504)", () => {
+    const ctx = parseFeishuMessageEvent(
+      makeEvent(
+        "@_bot_1 @_bot_2 hello",
+        [
+          { key: "@_bot_1", name: "Bot A", id: { open_id: "ou_bot" } },
+          { key: "@_bot_2", name: "Bot B", id: { open_id: "ou_other_bot" } },
+        ],
+        "group",
+      ),
+      BOT_OPEN_ID,
+    );
+    // Both mentions stay visible to the model; this bot sees its own <at>.
+    expect(ctx.content).toBe(
+      '<at user_id="ou_bot">Bot A</at> <at user_id="ou_other_bot">Bot B</at> hello',
+    );
+    expect(ctx.mentionedBot).toBe(true);
+  });
+
+  it("keeps bot mention in topic groups so the model sees it was addressed (#72504)", () => {
+    const ctx = parseFeishuMessageEvent(
+      makeEvent(
+        "@_bot_1 hello",
+        [{ key: "@_bot_1", name: "Bot", id: { open_id: "ou_bot" } }],
+        "topic_group",
+      ),
+      BOT_OPEN_ID,
+    );
+    expect(ctx.content).toBe('<at user_id="ou_bot">Bot</at> hello');
   });
 
   it("strips bot mention but normalizes other mentions in p2p (mention-forward)", () => {

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -174,11 +174,21 @@ export function parseFeishuMessageEvent(
   const mentionedBot = checkBotMentioned(event, botOpenId);
   const hasAnyMention = (event.message.mentions?.length ?? 0) > 0;
   // Strip the bot's own mention so slash commands like @Bot /help retain
-  // the leading /. This applies in both p2p *and* group contexts — the
-  // mentionedBot flag already captures whether the bot was addressed, so
-  // keeping the mention tag in content only breaks command detection (#35994).
+  // the leading /. This applies in p2p contexts — the mentionedBot flag
+  // already captures whether the bot was addressed, so keeping the mention
+  // tag in content only breaks command detection (#35994).
+  // In group chats (including topic groups) keep the bot's own <at> tag so
+  // the model can see it was explicitly addressed among several bots
+  // (#72504); command probing strips all <at> tags via
+  // normalizeFeishuCommandProbeBody, and routing uses the mentionedBot flag,
+  // so keeping the tag is safe there.
   // Non-bot mentions (e.g. mention-forward targets) are still normalized to <at> tags.
-  const content = normalizeMentions(rawContent, event.message.mentions, botOpenId);
+  const isGroupChat = isFeishuGroupChatType(event.message.chat_type);
+  const content = normalizeMentions(
+    rawContent,
+    event.message.mentions,
+    isGroupChat ? undefined : botOpenId,
+  );
   const senderOpenId = event.sender.sender_id.open_id?.trim();
   const senderUserId = event.sender.sender_id.user_id?.trim();
   const senderFallbackId = senderOpenId || senderUserId || "";

--- a/extensions/feishu/src/sequential-key.test.ts
+++ b/extensions/feishu/src/sequential-key.test.ts
@@ -91,4 +91,47 @@ describe("getFeishuSequentialKey", () => {
       }),
     ).toBe("feishu:default:oc_dm_chat");
   });
+
+  it("selects the control lane for a group /stop with the bot's own mention kept", () => {
+    const event = createTextEvent({ text: "@_bot_1 /stop", chatId: "oc_group_chat" });
+    event.message.chat_type = "group";
+    event.message.mentions = [
+      {
+        key: "@_bot_1",
+        id: { open_id: "ou_bot_1" },
+        name: "OpenClaw",
+      },
+    ];
+
+    expect(
+      getFeishuSequentialKey({
+        accountId: "default",
+        event,
+        botOpenId: "ou_bot_1",
+      }),
+    ).toBe("feishu:default:oc_group_chat:control");
+  });
+
+  it("selects the btw lane for a group /btw with the bot's own mention kept", () => {
+    const event = createTextEvent({
+      text: "@_bot_1 /btw what changed?",
+      chatId: "oc_group_chat",
+    });
+    event.message.chat_type = "group";
+    event.message.mentions = [
+      {
+        key: "@_bot_1",
+        id: { open_id: "ou_bot_1" },
+        name: "OpenClaw",
+      },
+    ];
+
+    expect(
+      getFeishuSequentialKey({
+        accountId: "default",
+        event,
+        botOpenId: "ou_bot_1",
+      }),
+    ).toBe("feishu:default:oc_group_chat:btw");
+  });
 });

--- a/extensions/feishu/src/sequential-key.test.ts
+++ b/extensions/feishu/src/sequential-key.test.ts
@@ -7,6 +7,8 @@ function createTextEvent(params: {
   text: string;
   messageId?: string;
   chatId?: string;
+  chatType?: "p2p" | "group" | "topic_group";
+  mentions?: Array<{ key: string; name: string; id: { open_id?: string; user_id?: string } }>;
 }): FeishuMessageEvent {
   return {
     sender: {
@@ -19,9 +21,10 @@ function createTextEvent(params: {
     message: {
       message_id: params.messageId ?? "om_message_1",
       chat_id: params.chatId ?? "oc_dm_chat",
-      chat_type: "p2p",
+      chat_type: params.chatType ?? "p2p",
       message_type: "text",
       content: JSON.stringify({ text: params.text }),
+      mentions: params.mentions,
     },
   } as FeishuMessageEvent;
 }
@@ -57,6 +60,45 @@ describe("getFeishuSequentialKey", () => {
         event: second,
       }),
     ).toBe("feishu:default:oc_dm_chat:btw");
+  });
+
+  it("does not classify a p2p mention-forwarded /stop as a control command", () => {
+    // p2p keeps non-bot mentions for mention forwarding (the command owner
+    // strips mentions only in groups), so "@Bot @Alice /stop" must stay on the
+    // base lane instead of entering :control (ClawSweeper P2 on #119243).
+    const event = createTextEvent({
+      text: "@Alice /stop",
+      chatType: "p2p",
+      mentions: [{ key: "@Alice", name: "Alice", id: { open_id: "ou_alice" } }],
+    });
+
+    expect(
+      getFeishuSequentialKey({
+        accountId: "default",
+        event,
+        botOpenId: "ou_bot",
+        botName: "Bot",
+      }),
+    ).toBe("feishu:default:oc_dm_chat");
+  });
+
+  it("classifies a group @Bot /stop as a control command", () => {
+    // Group content keeps the bot's own <at> tag (#72504); the sequential key
+    // strips it so the :control lane still matches dispatch.
+    const event = createTextEvent({
+      text: "@Bot /stop",
+      chatType: "group",
+      mentions: [{ key: "@Bot", name: "Bot", id: { open_id: "ou_bot" } }],
+    });
+
+    expect(
+      getFeishuSequentialKey({
+        accountId: "default",
+        event,
+        botOpenId: "ou_bot",
+        botName: "Bot",
+      }),
+    ).toBe("feishu:default:oc_dm_chat:control");
   });
 
   it("falls back to a stable btw lane when the message id is unavailable", () => {

--- a/extensions/feishu/src/sequential-key.ts
+++ b/extensions/feishu/src/sequential-key.ts
@@ -3,6 +3,7 @@ import {
   isAbortRequestText,
   isBtwRequestText,
 } from "openclaw/plugin-sdk/command-primitives-runtime";
+import { normalizeFeishuCommandProbeBody } from "./bot-content.js";
 import { parseFeishuMessageEvent, type FeishuMessageEvent } from "./bot.js";
 
 export function getFeishuSequentialKey(params: {
@@ -15,7 +16,11 @@ export function getFeishuSequentialKey(params: {
   const chatId = event.message.chat_id?.trim() || "unknown";
   const baseKey = `feishu:${accountId}:${chatId}`;
   const parsed = parseFeishuMessageEvent(event, botOpenId, botName);
-  const text = parsed.content.trim();
+  // Group and topic-group content keeps the bot's own <at> mention (see
+  // #72504), so strip mention tags before classifying: otherwise a group
+  // "@Bot /stop" or "@Bot /btw ..." no longer selects the :control / :btw
+  // sequential lanes.
+  const text = normalizeFeishuCommandProbeBody(parsed.content);
 
   if (isAbortRequestText(text)) {
     return `${baseKey}:control`;

--- a/extensions/feishu/src/sequential-key.ts
+++ b/extensions/feishu/src/sequential-key.ts
@@ -5,6 +5,7 @@ import {
 } from "openclaw/plugin-sdk/command-primitives-runtime";
 import { normalizeFeishuCommandProbeBody } from "./bot-content.js";
 import { parseFeishuMessageEvent, type FeishuMessageEvent } from "./bot.js";
+import { isFeishuGroupChatType } from "./types.js";
 
 export function getFeishuSequentialKey(params: {
   accountId: string;
@@ -19,8 +20,12 @@ export function getFeishuSequentialKey(params: {
   // Group and topic-group content keeps the bot's own <at> mention (see
   // #72504), so strip mention tags before classifying: otherwise a group
   // "@Bot /stop" or "@Bot /btw ..." no longer selects the :control / :btw
-  // sequential lanes.
-  const text = normalizeFeishuCommandProbeBody(parsed.content);
+  // sequential lanes. In p2p the command owner keeps non-bot mentions for
+  // mention forwarding, so stripping there would misclassify
+  // "@Bot @Alice /stop" as a :control command even though dispatch treats it
+  // as ordinary text.
+  const isGroupChat = isFeishuGroupChatType(event.message.chat_type);
+  const text = isGroupChat ? normalizeFeishuCommandProbeBody(parsed.content) : parsed.content;
 
   if (isAbortRequestText(text)) {
     return `${baseKey}:control`;


### PR DESCRIPTION
## What Problem This Solves

In Feishu group chats where a user @mentions several bots at once, every bot returned NO_REPLY. `normalizeMentions` stripped the receiving bot's own `<at>` tag (botStripId), so each bot's model saw only the *other* bots' mentions, concluded it was not addressed, and stayed silent. Fixes #72504.

## Why This Change Was Made

The strip-bot-mention behavior was added for slash-command detection (#35994), but it is only *needed* in p2p, where the @ prefix is an addressing convention. Two downstream consumers already make keeping the tag safe in group chats:
- routing uses the `mentionedBot` flag (`checkBotMentioned`), not the rendered content;
- command probing (`normalizeFeishuCommandProbeBody`) strips **all** `<at>` tags before command detection.

So the fix keeps the bot's own `<at>` tag in group content (the model can see it was addressed among several bots) while p2p keeps stripping. Non-bot mentions are still normalized to `<at>` tags in both contexts.

## User Impact

Before: multi-bot group mentions were silently ignored by every bot (NO_REPLY).
After: each bot sees its own mention in the content and responds; slash commands in groups still work (probe body strips tags); p2p behavior is unchanged.

## Evidence

### Updated + new tests (`extensions/feishu/src/bot.stripBotMention.test.ts`)
- Group `@_bot_1 hello` → content keeps `<at user_id="ou_bot">Bot</at> hello`
- Group `@_bot_1 /model` → `<at user_id="ou_bot">Bot</at> /model` (probe body still yields `/model`)
- **New:** two bots addressed in a group → both `<at>` tags visible to the model, `mentionedBot: true`
- p2p stripping tests unchanged (still `hello`)

### Test run (feishu extension, mention-related)
```text
$ node scripts/test-extension.mjs feishu -- -t "mention"
Test Files  17 passed | 77 skipped (94)
Tests  70 passed | 1498 skipped (1568)
```

[AI-assisted]

## CI status

- Latest CI on head `267a5d4862c6`: all check-runs green (latest per check).
- `Real behavior proof` check: success.

## topic_group coverage (P2 finding, head `9bca6e3d9ba`)

The group rule now uses `isFeishuGroupChatType` (covers both `group` and `topic_group`), so topic-group messages no longer stay on the old stripping path where the multi-bot no-reply failure remained. Regression test added: topic-group `@_bot_1 hello` → content keeps `<at user_id="ou_bot">Bot</at> hello`.

Branch rebuilt on current main (was 1370 commits behind).

```text
❯ node_modules/.bin/vitest run extensions/feishu/src/bot.stripBotMention.test.ts
 ✓  extension-feishu  extensions/feishu/src/bot.stripBotMention.test.ts (15 tests)
 Test Files  1 passed (1)
      Tests  15 passed (15)

❯ node_modules/.bin/vitest run extensions/feishu/src/bot.test.ts extensions/feishu/src/bot.checkBotMentioned.test.ts
 Test Files  2 passed (2)
      Tests  126 passed (126)
```


## 2026-08-12 patrol update (head `a3bdc37dcd`)

- **Rebuilt on current main** (branch was 149 commits behind; the previous head's `build-artifacts` UI startup-JS budget failure was main drift — this PR only touches `extensions/feishu/src/bot.ts`, which cannot affect the control-ui bundle). Rebase is clean: same 2 files, no conflicts.
