### PR TITLE
fix(tui): keep whitespace-prefixed bang input in chat

### DIFF
--- a/qa/scenarios/ui/tui-local-shell-pty.yaml
+++ b/qa/scenarios/ui/tui-local-shell-pty.yaml
@@ -1,0 +1,44 @@
+title: TUI local shell routing PTY contracts
+scenario:
+  id: tui-local-shell-pty
+  surface: tui
+  category: tui.local-shell-execution
+  coverage:
+    primary:
+      - tui.bang-command-routing
+      - tui.approval-prompt
+      - tui.command-output-display
+      - tui.execution-environment-marker
+  risk: high
+  objective: Prove local shell routing, confirmation, output, and environment behavior through the built local TUI and a real PTY.
+  successCriteria:
+    - Whitespace-prefixed bang input remains chat input after local shell execution has already been approved.
+    - Column-one bang input requires explicit session approval before execution.
+    - Approved commands visibly render stdout, stderr, and their terminal exit status.
+    - Approved commands receive the TUI local shell environment marker.
+  codeRefs:
+    - src/tui/components/custom-editor.ts
+    - src/tui/tui-submit.ts
+    - src/tui/tui-local-shell.ts
+    - src/tui/tui-pty-local.e2e.test.ts
+  execution:
+    kind: script
+    path: test/e2e/qa-lab/tui/tui-pty-evidence-producer.ts
+    summary: Runs exact built local-TUI PTY assertions and authenticates their fresh Vitest results as QA evidence.
+    timeoutMs: 360000
+    args: [--artifact-base, "${outputDir}", --scenario-id, "${scenarioId}"]
+    config:
+      requireBuiltCli: true
+      tuiPtyCases:
+        - coverageId: tui.bang-command-routing
+          testFile: src/tui/tui-pty-local.e2e.test.ts
+          testNamePattern: ^TUI PTY real backends keeps whitespace-prefixed bang input in chat after local shell approval$
+        - coverageId: tui.approval-prompt
+          testFile: src/tui/tui-pty-local.e2e.test.ts
+          testNamePattern: ^TUI PTY real backends confirms and renders local shell output and environment through a real local PTY$
+        - coverageId: tui.command-output-display
+          testFile: src/tui/tui-pty-local.e2e.test.ts
+          testNamePattern: ^TUI PTY real backends confirms and renders local shell output and environment through a real local PTY$
+        - coverageId: tui.execution-environment-marker
+          testFile: src/tui/tui-pty-local.e2e.test.ts
+          testNamePattern: ^TUI PTY real backends confirms and renders local shell output and environment through a real local PTY$

--- a/src/tui/components/custom-editor.test.ts
+++ b/src/tui/components/custom-editor.test.ts
@@ -213,16 +213,32 @@ describe("CustomEditor", () => {
     expect(onSubmit).toHaveBeenCalledWith("/help");
   });
 
-  it("preserves whitespace that keeps bang input on the chat path", () => {
+  it.each(["  !cmd", "  !cmd\n", "!cmd\n", "\n!cmd\n"])(
+    "preserves %j when trimming would create executable bang input",
+    (input) => {
+      const tui = { requestRender: vi.fn() } as unknown as TUI;
+      const editor = new CustomEditor(tui, editorTheme);
+      const onSubmit = vi.fn();
+      editor.onSubmit = onSubmit;
+      editor.setText(input);
+
+      editor.handleInput("\r");
+
+      expect(onSubmit).toHaveBeenCalledExactlyOnceWith(input);
+      expect(editor.getText()).toBe("");
+    },
+  );
+
+  it("leaves harmless bang-prefixed multiline chat on pi-tui's normal submit path", () => {
     const tui = { requestRender: vi.fn() } as unknown as TUI;
     const editor = new CustomEditor(tui, editorTheme);
     const onSubmit = vi.fn();
     editor.onSubmit = onSubmit;
-    editor.setText("  !echo stays in chat");
+    editor.setText(" \n!cmd\nnotes");
 
     editor.handleInput("\r");
 
-    expect(onSubmit).toHaveBeenCalledExactlyOnceWith("  !echo stays in chat");
+    expect(onSubmit).toHaveBeenCalledExactlyOnceWith("!cmd\nnotes");
     expect(editor.getText()).toBe("");
   });
 

--- a/src/tui/components/custom-editor.test.ts
+++ b/src/tui/components/custom-editor.test.ts
@@ -226,6 +226,18 @@ describe("CustomEditor", () => {
     expect(editor.getText()).toBe("");
   });
 
+  it("does not expand stored paste text for ordinary input", () => {
+    const tui = { requestRender: vi.fn() } as unknown as TUI;
+    const editor = new CustomEditor(tui, editorTheme);
+    editor.setText("draft");
+    const getExpandedText = vi.spyOn(editor, "getExpandedText");
+
+    editor.handleInput("x");
+
+    expect(getExpandedText).not.toHaveBeenCalled();
+    expect(editor.getText()).toBe("draftx");
+  });
+
   it("keeps pi-tui trimming for ordinary submissions", () => {
     const tui = { requestRender: vi.fn() } as unknown as TUI;
     const editor = new CustomEditor(tui, editorTheme);

--- a/src/tui/components/custom-editor.test.ts
+++ b/src/tui/components/custom-editor.test.ts
@@ -212,4 +212,29 @@ describe("CustomEditor", () => {
 
     expect(onSubmit).toHaveBeenCalledWith("/help");
   });
+
+  it("preserves whitespace that keeps bang input on the chat path", () => {
+    const tui = { requestRender: vi.fn() } as unknown as TUI;
+    const editor = new CustomEditor(tui, editorTheme);
+    const onSubmit = vi.fn();
+    editor.onSubmit = onSubmit;
+    editor.setText("  !echo stays in chat");
+
+    editor.handleInput("\r");
+
+    expect(onSubmit).toHaveBeenCalledExactlyOnceWith("  !echo stays in chat");
+    expect(editor.getText()).toBe("");
+  });
+
+  it("keeps pi-tui trimming for ordinary submissions", () => {
+    const tui = { requestRender: vi.fn() } as unknown as TUI;
+    const editor = new CustomEditor(tui, editorTheme);
+    const onSubmit = vi.fn();
+    editor.onSubmit = onSubmit;
+    editor.setText("  ordinary message  ");
+
+    editor.handleInput("\r");
+
+    expect(onSubmit).toHaveBeenCalledExactlyOnceWith("ordinary message");
+  });
 });

--- a/src/tui/components/custom-editor.ts
+++ b/src/tui/components/custom-editor.ts
@@ -57,7 +57,7 @@ export class CustomEditor extends Editor {
   onAltUp?: () => void;
   shouldSubmitAutocomplete?: (text: string) => boolean;
 
-  /** Dispatches TUI shortcuts before falling back to normal editor input handling. */
+  /** Preserves whitespace that blocks bang execution before pi-tui trims submitted text. */
   override handleInput(data: string): void {
     if (isKeyRelease(data)) {
       return;
@@ -130,6 +130,21 @@ export class CustomEditor extends Editor {
       this.setText(this.getText());
     }
 
+    const expandedText = this.getExpandedText();
+    if (
+      keybindings.matches(data, "tui.input.submit") &&
+      /^\s+!/u.test(expandedText) &&
+      this.onSubmit
+    ) {
+      const onSubmit = this.onSubmit;
+      this.onSubmit = () => onSubmit(expandedText);
+      try {
+        super.handleInput(data);
+      } finally {
+        this.onSubmit = onSubmit;
+      }
+      return;
+    }
     super.handleInput(data);
   }
 }

--- a/src/tui/components/custom-editor.ts
+++ b/src/tui/components/custom-editor.ts
@@ -130,20 +130,18 @@ export class CustomEditor extends Editor {
       this.setText(this.getText());
     }
 
-    const expandedText = this.getExpandedText();
-    if (
-      keybindings.matches(data, "tui.input.submit") &&
-      /^\s+!/u.test(expandedText) &&
-      this.onSubmit
-    ) {
-      const onSubmit = this.onSubmit;
-      this.onSubmit = () => onSubmit(expandedText);
-      try {
-        super.handleInput(data);
-      } finally {
-        this.onSubmit = onSubmit;
+    if (keybindings.matches(data, "tui.input.submit") && this.onSubmit) {
+      const expandedText = this.getExpandedText();
+      if (/^\s+!/u.test(expandedText)) {
+        const onSubmit = this.onSubmit;
+        this.onSubmit = () => onSubmit(expandedText);
+        try {
+          super.handleInput(data);
+        } finally {
+          this.onSubmit = onSubmit;
+        }
+        return;
       }
-      return;
     }
     super.handleInput(data);
   }

--- a/src/tui/components/custom-editor.ts
+++ b/src/tui/components/custom-editor.ts
@@ -1,5 +1,6 @@
 // Custom editor component handles multiline TUI input and key bindings.
 import { Editor, getKeybindings, isKeyRelease, Key, matchesKey } from "@earendil-works/pi-tui";
+import { trimWouldCreateExecutableBangLine } from "../tui-submit.js";
 
 // Kitty keyboard protocol uses CSI-u sequences for AltGr on international layouts.
 const KITTY_CSI_U_SUFFIX_REGEX = /^(\d+)(?::(\d*))?(?::(\d+))?(?:;(\d+))?(?::(\d+))?u$/u;
@@ -57,7 +58,7 @@ export class CustomEditor extends Editor {
   onAltUp?: () => void;
   shouldSubmitAutocomplete?: (text: string) => boolean;
 
-  /** Preserves whitespace that blocks bang execution before pi-tui trims submitted text. */
+  /** Preserves text when pi-tui trimming would create an executable bang line. */
   override handleInput(data: string): void {
     if (isKeyRelease(data)) {
       return;
@@ -132,7 +133,7 @@ export class CustomEditor extends Editor {
 
     if (keybindings.matches(data, "tui.input.submit") && this.onSubmit) {
       const expandedText = this.getExpandedText();
-      if (/^\s+!/u.test(expandedText)) {
+      if (trimWouldCreateExecutableBangLine(expandedText)) {
         const onSubmit = this.onSubmit;
         this.onSubmit = () => onSubmit(expandedText);
         try {

--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -1126,6 +1126,77 @@ describe("TUI PTY real backends", () => {
     LOCAL_TEST_TIMEOUT_MS,
   );
 
+  it(
+    "keeps whitespace-prefixed bang input in chat after local shell approval",
+    async ({ onTestFinished }) => {
+      const fixture = await startLocalModeTui(onTestFinished, {
+        replyText: "T06_CHAT_RESPONSE",
+      });
+      try {
+        await fixture.run.waitForOutput("local ready", LOCAL_STARTUP_TIMEOUT_MS);
+        await fixture.run.write("!node -e \"console.log('T06_APPROVAL_PRIMER')\"\r");
+        await fixture.run.waitForOutput("Allow local shell commands for this session?");
+        await fixture.run.write("\u001b[B\r", { delay: false });
+        await fixture.run.waitForOutput("local shell: enabled for this session");
+        await fixture.run.waitForOutput("[local] T06_APPROVAL_PRIMER");
+        await fixture.run.waitForOutput("[local] exit 0");
+
+        const chatOffset = fixture.run.visibleOutput().length;
+        const command = " !node -e \"console.log('T06_UNEXPECTED_EXECUTION')\"";
+        await fixture.run.write(`${command}\r`);
+        await waitFor({
+          timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
+          read: () => (fixture.mockModel.requests().length === 1 ? true : null),
+          onTimeout: () =>
+            new Error(`whitespace-prefixed bang did not reach chat\n${fixture.run.output()}`),
+        });
+        expect(JSON.stringify(fixture.mockModel.requests()[0]?.body)).toContain(
+          "T06_UNEXPECTED_EXECUTION",
+        );
+        await waitForOutputAfter(fixture.run, "T06_CHAT_RESPONSE", chatOffset);
+        expect(fixture.run.visibleOutput().slice(chatOffset)).not.toContain(
+          "[local] T06_UNEXPECTED_EXECUTION",
+        );
+
+        await fixture.run.write("/exit\r", { delay: false });
+        expect((await fixture.run.waitForExit()).exitCode).toBe(0);
+      } finally {
+        await fixture.cleanup();
+      }
+    },
+    LOCAL_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "confirms and renders local shell output and environment through a real local PTY",
+    async ({ onTestFinished }) => {
+      const fixture = await startLocalModeTui(onTestFinished);
+      try {
+        await fixture.run.waitForOutput("local ready", LOCAL_STARTUP_TIMEOUT_MS);
+        await fixture.run.write(
+          "!node -e \"console.log('T06_STDOUT'); console.error('T06_STDERR'); console.log('T06_ENV='+process.env.OPENCLAW_SHELL); process.exitCode=7\"\r",
+        );
+        await fixture.run.waitForOutput("Allow local shell commands for this session?");
+        await fixture.run.waitForOutput("Select Yes/No (arrows + Enter), Esc to cancel.");
+        expect(fixture.run.visibleOutput()).toContain("No");
+        expect(fixture.run.visibleOutput()).toContain("Yes");
+
+        await fixture.run.write("\u001b[B\r", { delay: false });
+        await fixture.run.waitForOutput("local shell: enabled for this session");
+        await fixture.run.waitForOutput("[local] T06_STDOUT");
+        await fixture.run.waitForOutput("[local] T06_STDERR");
+        await fixture.run.waitForOutput("[local] T06_ENV=tui-local");
+        await fixture.run.waitForOutput("[local] exit 7");
+
+        await fixture.run.write("/exit\r", { delay: false });
+        expect((await fixture.run.waitForExit()).exitCode).toBe(0);
+      } finally {
+        await fixture.cleanup();
+      }
+    },
+    LOCAL_TEST_TIMEOUT_MS,
+  );
+
   function registerValidationLoopTest(mode: "gateway" | "local") {
     it(
       `renders safe validation-loop abort diagnostics through the real ${mode} backend`,

--- a/src/tui/tui-submit.ts
+++ b/src/tui/tui-submit.ts
@@ -53,6 +53,7 @@ export function createEditorSubmitHandler(params: {
     const raw = text;
     const value = raw.trim();
     const multiline = raw.includes("\n");
+    const hasWhitespacePrefixedBang = /^\s+!/u.test(raw);
 
     // Keep previous behavior: ignore empty/whitespace-only submissions.
     if (!value) {
@@ -82,14 +83,16 @@ export function createEditorSubmitHandler(params: {
       ? params.admitMessage?.(value, snapshot)
       : params.admitMessage?.(value)) ?? { status: "allowed" };
     if (admission.status === "blocked") {
-      restoreBlockedEditor(/^\s+!/u.test(raw) ? raw : value);
+      restoreBlockedEditor(hasWhitespacePrefixedBang ? raw : value);
       params.onBlockedMessageSubmit?.(value, admission);
       return;
     }
 
     clearSubmittedEditor();
-    // Enable built-in editor prompt history navigation (up/down).
-    params.editor.addToHistory(value);
+    // pi-tui trims history, which could turn recalled chat text into a shell command.
+    if (!hasWhitespacePrefixedBang) {
+      params.editor.addToHistory(value);
+    }
     runSubmitAction("message", () => params.sendMessage(value), params.onSubmitError);
   };
 }

--- a/src/tui/tui-submit.ts
+++ b/src/tui/tui-submit.ts
@@ -8,6 +8,14 @@ import type {
 
 export type TuiSubmitAction = "local shell" | "command" | "message";
 
+function isExecutableBangLine(text: string): boolean {
+  return !text.includes("\n") && text.startsWith("!") && text !== "!";
+}
+
+export function trimWouldCreateExecutableBangLine(text: string): boolean {
+  return !isExecutableBangLine(text) && isExecutableBangLine(text.trim());
+}
+
 function runSubmitAction(
   action: TuiSubmitAction,
   run: () => Promise<void> | void,
@@ -53,7 +61,7 @@ export function createEditorSubmitHandler(params: {
     const raw = text;
     const value = raw.trim();
     const multiline = raw.includes("\n");
-    const hasWhitespacePrefixedBang = /^\s+!/u.test(raw);
+    const trimCreatesExecutableBangLine = trimWouldCreateExecutableBangLine(raw);
 
     // Keep previous behavior: ignore empty/whitespace-only submissions.
     if (!value) {
@@ -64,7 +72,7 @@ export function createEditorSubmitHandler(params: {
     // Bash mode: only if the very first character is '!' and it's not just '!'.
     // IMPORTANT: use the raw (untrimmed) text so leading spaces do NOT trigger.
     // Per requirement: a lone '!' should be treated as a normal message.
-    if (!multiline && raw.startsWith("!") && raw !== "!") {
+    if (isExecutableBangLine(raw)) {
       clearSubmittedEditor();
       params.editor.addToHistory(raw);
       runSubmitAction("local shell", () => params.handleBangLine(raw), params.onSubmitError);
@@ -83,14 +91,14 @@ export function createEditorSubmitHandler(params: {
       ? params.admitMessage?.(value, snapshot)
       : params.admitMessage?.(value)) ?? { status: "allowed" };
     if (admission.status === "blocked") {
-      restoreBlockedEditor(hasWhitespacePrefixedBang ? raw : value);
+      restoreBlockedEditor(trimCreatesExecutableBangLine ? raw : value);
       params.onBlockedMessageSubmit?.(value, admission);
       return;
     }
 
     clearSubmittedEditor();
-    // pi-tui trims history, which could turn recalled chat text into a shell command.
-    if (!hasWhitespacePrefixedBang) {
+    // Omit chat text whose trimmed history recall would become executable shell input.
+    if (!trimCreatesExecutableBangLine) {
       params.editor.addToHistory(value);
     }
     runSubmitAction("message", () => params.sendMessage(value), params.onSubmitError);

--- a/src/tui/tui-submit.ts
+++ b/src/tui/tui-submit.ts
@@ -82,7 +82,7 @@ export function createEditorSubmitHandler(params: {
       ? params.admitMessage?.(value, snapshot)
       : params.admitMessage?.(value)) ?? { status: "allowed" };
     if (admission.status === "blocked") {
-      restoreBlockedEditor(value);
+      restoreBlockedEditor(/^\s+!/u.test(raw) ? raw : value);
       params.onBlockedMessageSubmit?.(value, admission);
       return;
     }

--- a/src/tui/tui.submit-handler.test.ts
+++ b/src/tui/tui.submit-handler.test.ts
@@ -12,12 +12,13 @@ import {
 
 describe("createEditorSubmitHandler", () => {
   it("routes lines starting with ! to handleBangLine", () => {
-    const { handleCommand, sendMessage, handleBangLine, onSubmit } = createSubmitHarness();
+    const { editor, handleCommand, sendMessage, handleBangLine, onSubmit } = createSubmitHarness();
 
     onSubmit("!ls");
 
     expect(handleBangLine).toHaveBeenCalledTimes(1);
     expect(handleBangLine).toHaveBeenCalledWith("!ls");
+    expect(editor.addToHistory).toHaveBeenCalledWith("!ls");
     expect(sendMessage).not.toHaveBeenCalled();
     expect(handleCommand).not.toHaveBeenCalled();
   });
@@ -49,8 +50,16 @@ describe("createEditorSubmitHandler", () => {
     editor.handleInput("\r");
 
     expect(handleBangLine).not.toHaveBeenCalled();
-    expect(sendMessage).toHaveBeenCalledWith("!ls");
+    expect(sendMessage).toHaveBeenCalledExactlyOnceWith("!ls");
     expect(editor.getText()).toBe("");
+
+    editor.handleInput("\u001b[A");
+    expect(editor.getText()).toBe("");
+
+    editor.handleInput("\r");
+
+    expect(sendMessage).toHaveBeenCalledExactlyOnceWith("!ls");
+    expect(handleBangLine).not.toHaveBeenCalled();
   });
 
   it("preserves whitespace bang routing across a blocked retry", () => {

--- a/src/tui/tui.submit-handler.test.ts
+++ b/src/tui/tui.submit-handler.test.ts
@@ -53,6 +53,39 @@ describe("createEditorSubmitHandler", () => {
     expect(editor.getText()).toBe("");
   });
 
+  it("preserves whitespace bang routing across a blocked retry", () => {
+    const tui = { requestRender: vi.fn() } as unknown as TUI;
+    const editor = new CustomEditor(tui, editorTheme);
+    const sendMessage = vi.fn();
+    const handleBangLine = vi.fn();
+    const admitMessage = vi
+      .fn()
+      .mockReturnValueOnce({ status: "blocked", reason: "pending" })
+      .mockReturnValueOnce({ status: "allowed" });
+    editor.onSubmit = createEditorSubmitHandler({
+      editor,
+      handleCommand: vi.fn(),
+      sendMessage,
+      handleBangLine,
+      onSubmitError: vi.fn(),
+      admitMessage,
+    });
+    editor.setText("  !cmd");
+
+    editor.handleInput("\r");
+
+    expect(editor.getText()).toBe("  !cmd");
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(handleBangLine).not.toHaveBeenCalled();
+
+    editor.handleInput("\r");
+
+    expect(admitMessage).toHaveBeenCalledTimes(2);
+    expect(sendMessage).toHaveBeenCalledExactlyOnceWith("!cmd");
+    expect(handleBangLine).not.toHaveBeenCalled();
+    expect(editor.getText()).toBe("");
+  });
+
   it("trims normal messages before sending and adding to history", () => {
     const { editor, sendMessage, onSubmit } = createSubmitHarness();
 

--- a/src/tui/tui.submit-handler.test.ts
+++ b/src/tui/tui.submit-handler.test.ts
@@ -10,17 +10,39 @@ import {
   shouldEnableWindowsGitBashPasteFallback,
 } from "./tui-submit.js";
 
-describe("createEditorSubmitHandler", () => {
-  it("routes lines starting with ! to handleBangLine", () => {
-    const { editor, handleCommand, sendMessage, handleBangLine, onSubmit } = createSubmitHarness();
+function createRealEditorSubmitHarness(
+  admitMessage?: NonNullable<Parameters<typeof createEditorSubmitHandler>[0]["admitMessage"]>,
+) {
+  const tui = { requestRender: vi.fn() } as unknown as TUI;
+  const editor = new CustomEditor(tui, editorTheme);
+  const sendMessage = vi.fn();
+  const handleBangLine = vi.fn();
+  editor.onSubmit = createEditorSubmitHandler({
+    editor,
+    handleCommand: vi.fn(),
+    sendMessage,
+    handleBangLine,
+    onSubmitError: vi.fn(),
+    ...(admitMessage ? { admitMessage } : {}),
+  });
+  return { editor, sendMessage, handleBangLine };
+}
 
-    onSubmit("!ls");
+describe("createEditorSubmitHandler", () => {
+  it("routes genuine bang input to local shell and history", () => {
+    const { editor, sendMessage, handleBangLine } = createRealEditorSubmitHarness();
+    editor.setText("!cmd");
+
+    editor.handleInput("\r");
 
     expect(handleBangLine).toHaveBeenCalledTimes(1);
-    expect(handleBangLine).toHaveBeenCalledWith("!ls");
-    expect(editor.addToHistory).toHaveBeenCalledWith("!ls");
+    expect(handleBangLine).toHaveBeenCalledWith("!cmd");
     expect(sendMessage).not.toHaveBeenCalled();
-    expect(handleCommand).not.toHaveBeenCalled();
+    expect(editor.getText()).toBe("");
+
+    editor.handleInput("\u001b[A");
+
+    expect(editor.getText()).toBe("!cmd");
   });
 
   it("treats a lone ! as a normal message", () => {
@@ -33,52 +55,61 @@ describe("createEditorSubmitHandler", () => {
     expect(sendMessage).toHaveBeenCalledWith("!");
   });
 
-  it("does not treat leading whitespace before ! as a bang command", () => {
-    const tui = { requestRender: vi.fn() } as unknown as TUI;
-    const editor = new CustomEditor(tui, editorTheme);
-    const sendMessage = vi.fn();
-    const handleBangLine = vi.fn();
-    editor.onSubmit = createEditorSubmitHandler({
-      editor,
-      handleCommand: vi.fn(),
-      sendMessage,
-      handleBangLine,
-      onSubmitError: vi.fn(),
-    });
-    editor.setText("  !ls");
+  it.each([
+    { name: "a whitespace-prefixed lone bang", input: "  !", expected: "!" },
+    {
+      name: "bang-prefixed true multiline chat",
+      input: " \n!cmd\nnotes",
+      expected: "!cmd\nnotes",
+    },
+  ])("stores, recalls, and safely resubmits $name", ({ input, expected }) => {
+    const { editor, sendMessage, handleBangLine } = createRealEditorSubmitHarness();
+    editor.setText(input);
 
     editor.handleInput("\r");
 
     expect(handleBangLine).not.toHaveBeenCalled();
-    expect(sendMessage).toHaveBeenCalledExactlyOnceWith("!ls");
+    expect(sendMessage).toHaveBeenCalledExactlyOnceWith(expected);
     expect(editor.getText()).toBe("");
 
     editor.handleInput("\u001b[A");
-    expect(editor.getText()).toBe("");
+    expect(editor.getText()).toBe(expected);
 
     editor.handleInput("\r");
 
-    expect(sendMessage).toHaveBeenCalledExactlyOnceWith("!ls");
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(sendMessage).toHaveBeenNthCalledWith(2, expected);
     expect(handleBangLine).not.toHaveBeenCalled();
   });
 
+  it.each(["  !cmd", "  !cmd\n", "!cmd\n", "\n!cmd\n"])(
+    "keeps %j in chat and omits it from history",
+    (input) => {
+      const { editor, sendMessage, handleBangLine } = createRealEditorSubmitHarness();
+      editor.setText(input);
+
+      editor.handleInput("\r");
+
+      expect(sendMessage).toHaveBeenCalledExactlyOnceWith("!cmd");
+      expect(handleBangLine).not.toHaveBeenCalled();
+      expect(editor.getText()).toBe("");
+
+      editor.handleInput("\u001b[A");
+      expect(editor.getText()).toBe("");
+
+      editor.handleInput("\r");
+
+      expect(sendMessage).toHaveBeenCalledExactlyOnceWith("!cmd");
+      expect(handleBangLine).not.toHaveBeenCalled();
+    },
+  );
+
   it("preserves whitespace bang routing across a blocked retry", () => {
-    const tui = { requestRender: vi.fn() } as unknown as TUI;
-    const editor = new CustomEditor(tui, editorTheme);
-    const sendMessage = vi.fn();
-    const handleBangLine = vi.fn();
     const admitMessage = vi
       .fn()
       .mockReturnValueOnce({ status: "blocked", reason: "pending" })
       .mockReturnValueOnce({ status: "allowed" });
-    editor.onSubmit = createEditorSubmitHandler({
-      editor,
-      handleCommand: vi.fn(),
-      sendMessage,
-      handleBangLine,
-      onSubmitError: vi.fn(),
-      admitMessage,
-    });
+    const { editor, sendMessage, handleBangLine } = createRealEditorSubmitHarness(admitMessage);
     editor.setText("  !cmd");
 
     editor.handleInput("\r");

--- a/src/tui/tui.submit-handler.test.ts
+++ b/src/tui/tui.submit-handler.test.ts
@@ -33,13 +33,24 @@ describe("createEditorSubmitHandler", () => {
   });
 
   it("does not treat leading whitespace before ! as a bang command", () => {
-    const { editor, sendMessage, handleBangLine, onSubmit } = createSubmitHarness();
+    const tui = { requestRender: vi.fn() } as unknown as TUI;
+    const editor = new CustomEditor(tui, editorTheme);
+    const sendMessage = vi.fn();
+    const handleBangLine = vi.fn();
+    editor.onSubmit = createEditorSubmitHandler({
+      editor,
+      handleCommand: vi.fn(),
+      sendMessage,
+      handleBangLine,
+      onSubmitError: vi.fn(),
+    });
+    editor.setText("  !ls");
 
-    onSubmit("  !ls");
+    editor.handleInput("\r");
 
     expect(handleBangLine).not.toHaveBeenCalled();
     expect(sendMessage).toHaveBeenCalledWith("!ls");
-    expect(editor.addToHistory).toHaveBeenCalledWith("!ls");
+    expect(editor.getText()).toBe("");
   });
 
   it("trims normal messages before sending and adding to history", () => {


### PR DESCRIPTION
## What Problem This Solves

TUI submission trimming can change chat text into executable local-shell
syntax. Inputs such as `"  !cmd"`, `"!cmd\n"`, and `"\n!cmd\n"` are not
executable as entered, but become `"!cmd"` after trimming.

The same transition also matters across blocked admission and private pi-tui
history, because pi-tui trims before storing history entries.

## Fix

- Define the existing executable-bang grammar once in `tui-submit.ts`: no
  newline, starts with `!`, and is not the lone `!`.
- Export and reuse a transition predicate that detects only cases where
  trimming would newly create executable bang syntax.
- Preserve expanded raw editor text only for that dangerous submit transition.
- Restore raw text after blocked admission only for that transition.
- Omit allowed chat history only for that transition; sending remains the
  existing trimmed chat message.
- Keep genuine column-one bang commands on the existing local-shell and history
  path.

The earlier lazy-expansion repair remains: ordinary printable/cursor input does
not call `getExpandedText()`.

Behavior covered with real `CustomEditor` history navigation:

- `"  !"` chats, recalls `"!"`, and resubmits without shell execution.
- `" \n!cmd\nnotes"` chats, recalls trimmed multiline text, and resubmits
  without shell execution.
- `"  !cmd"` chats, is omitted from history, and restores exact raw text after
  blocked admission.
- `"  !cmd\n"`, `"!cmd\n"`, and `"\n!cmd\n"` chat and are omitted from
  history.
- Genuine `"!cmd"` retains local-shell routing and history.

The branch adds `qa/scenarios/ui/tui-local-shell-pty.yaml`, two real local-PTY
cases, and four explicit coverage mappings. This final repair did not modify
those already-added cases or mappings. The local-shell runner and T00 evidence
producer are unchanged.

Production delta is net `+25` lines. Test and QA additions are gross `+262`
lines. The repository diff remains bounded to the accepted six files.

## Coverage

Primary IDs:

- `tui.bang-command-routing`
- `tui.approval-prompt`
- `tui.command-output-display`
- `tui.execution-environment-marker`

Exact signed and pushed head:

`082d03a11de832956758829e04efe38a7bb782ec`

Proof:

- Focused input-history, custom-editor, and submit-handler tests: `61/61`
  passed.
- Targeted private `qaRuntime` build: passed.
- Selected built real local-PTY cases: `2` passed, `16` skipped.
- Built QA scenario `tui-local-shell-pty`: `1/1` passed under Node `24.18.0`.
- The proof matrix has one passing mapping for each primary coverage ID.
- `git diff --check` and the public-diff privacy scan passed.
- Complete raw and durable QA bundles were sanitized and passed
  `rg --hidden --no-ignore` privacy scans before hashing.

Exact local QA output:

`.artifacts/qa-e2e/tui-local-shell-pty-exact-082d03a11de832956758829e04efe38a7bb782ec-20260804`

SHA-256:

- Bundle manifest:
  `fbfacd0462ea699e7bc964ccfea6cc722d4b8134b5a9f24805848e4f04ab161d`
- `qa-evidence.json`:
  `05f073e220ad20542235dbc257d790193efbad0e6cf445707445da1969dc7281`
- `qa-suite-summary.json`:
  `626587458cddad18ede1172c7c2b2f3c038442c99e49101c3b52e176e6ede623`
- `proof-matrix.json`:
  `82e2c941adfc432b152dd986bdc17178198cf5014e800a3e12791113544018c7`
- `vitest-report.json`:
  `094507365aca5d5a17ebbb8dd4755207c4ffba7c4d22d7c27797350200a090fd`

Unrelated broad and shared-Gateway failures were not repeated.

## Collision Review

https://github.com/openclaw/openclaw/pull/103648 remains open and unchanged at
`0f45550ee1bfa0ff7c0630442bab6723ad9e9a72`. It overlaps `tui-submit.ts`, the
PTY test, and the local-shell subsystem for a separate persistence and
agent-visibility design. It still does not touch `CustomEditor` or equivalent
pre-trim routing ownership, so it does not subsume this fix.

Exact-head independent and ClawSweeper reviews are complete and clean. The PR
remains draft pending maintainer owner decision and refreshed ready-state CI.
