### PR TITLE
fix(gateway): drain admitted node results before disconnect

### DIFF
--- a/src/gateway/server.node-result-close.test.ts
+++ b/src/gateway/server.node-result-close.test.ts
@@ -1,0 +1,200 @@
+// Node result/close ordering tests keep admitted terminal frames authoritative.
+import { randomUUID } from "node:crypto";
+import { afterEach, expect, test, vi } from "vitest";
+import { writeConfigFile } from "../config/config.js";
+import { approveNodePairing, requestNodePairing } from "../infra/node-pairing.js";
+import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
+import { pairDeviceIdentity } from "./device-authz.test-helpers.js";
+import { GatewayNodeLifecycleDispatchTracker } from "./server/ws-connection/node-lifecycle-dispatch.js";
+import { connectGatewayClient } from "./test-helpers.e2e.js";
+import { installGatewayTestHooks, startServer } from "./test-helpers.js";
+
+const pairingRead = vi.hoisted(() => ({
+  blocked: null as Promise<void> | null,
+  onBlocked: null as (() => void) | null,
+  release: null as (() => void) | null,
+}));
+
+vi.mock("../infra/node-pairing-state.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/node-pairing-state.js")>();
+  return {
+    ...actual,
+    resolveCurrentNodePairingBinding: async (nodeId: string) => {
+      const current = await actual.resolveCurrentNodePairingBinding(nodeId);
+      if (pairingRead.blocked) {
+        pairingRead.onBlocked?.();
+        await pairingRead.blocked;
+      }
+      return current;
+    },
+  };
+});
+
+installGatewayTestHooks({ scope: "suite" });
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  pairingRead.blocked = null;
+  pairingRead.onBlocked = null;
+  pairingRead.release = null;
+});
+
+test("a terminal node result admitted before close wins over disconnect cleanup", async () => {
+  const pairedNode = await pairDeviceIdentity({
+    name: "node-result-before-close",
+    role: "node",
+    scopes: [],
+    clientId: GATEWAY_CLIENT_NAMES.NODE_HOST,
+    clientMode: GATEWAY_CLIENT_MODES.NODE,
+  });
+  const pairing = await requestNodePairing({
+    nodeId: pairedNode.identity.deviceId,
+    platform: "linux",
+    deviceFamily: "Linux",
+    commands: ["camera.list"],
+  });
+  await approveNodePairing(pairing.request.requestId, {
+    callerScopes: ["operator.pairing", "operator.write"],
+  });
+  await writeConfigFile({
+    gateway: { nodes: { commands: { allow: ["camera.list"] } } },
+  });
+
+  const { port, server } = await startServer("secret");
+  const url = `ws://127.0.0.1:${port}`;
+  let operator: Awaited<ReturnType<typeof connectGatewayClient>> | undefined;
+  let node: Awaited<ReturnType<typeof connectGatewayClient>> | undefined;
+  let resolveInvokeFrame:
+    | ((frame: { id: string; nodeId: string; command: string }) => void)
+    | undefined;
+  const invokeFrame = new Promise<{ id: string; nodeId: string; command: string }>((resolve) => {
+    resolveInvokeFrame = resolve;
+  });
+
+  try {
+    operator = await connectGatewayClient({
+      url,
+      token: "secret",
+      role: "operator",
+      clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+      clientDisplayName: "node result close operator",
+      mode: GATEWAY_CLIENT_MODES.BACKEND,
+      scopes: ["operator.admin", "operator.read", "operator.write"],
+    });
+    node = await connectGatewayClient({
+      url,
+      token: "secret",
+      role: "node",
+      clientName: GATEWAY_CLIENT_NAMES.NODE_HOST,
+      clientDisplayName: "node result close host",
+      mode: GATEWAY_CLIENT_MODES.NODE,
+      platform: "linux",
+      deviceFamily: "Linux",
+      scopes: [],
+      commands: ["camera.list"],
+      deviceIdentity: pairedNode.identity,
+      onEvent: (event) => {
+        if (event.event !== "node.invoke.request" || !event.payload) {
+          return;
+        }
+        resolveInvokeFrame?.(event.payload as { id: string; nodeId: string; command: string });
+      },
+    });
+    await vi.waitFor(async () => {
+      const listed = await operator?.request<{
+        nodes?: Array<{ nodeId?: string; connected?: boolean; commands?: string[] }>;
+      }>("node.list", {}, { timeoutMs: 10_000 });
+      expect(listed?.nodes?.find((entry) => entry.nodeId === pairedNode.identity.deviceId)).toEqual(
+        expect.objectContaining({
+          connected: true,
+          commands: ["camera.list"],
+        }),
+      );
+    });
+
+    const invoked = operator.request<{
+      ok: boolean;
+      nodeId: string;
+      command: string;
+      payload: unknown;
+    }>(
+      "node.invoke",
+      {
+        nodeId: pairedNode.identity.deviceId,
+        command: "camera.list",
+        timeoutMs: 10_000,
+        idempotencyKey: randomUUID(),
+      },
+      { timeoutMs: 10_000 },
+    );
+    const frame = await Promise.race([
+      invokeFrame,
+      invoked.then(
+        () => {
+          throw new Error("node.invoke settled without sending a node request");
+        },
+        (error: unknown) => {
+          throw error instanceof Error ? error : new Error(String(error));
+        },
+      ),
+    ]);
+
+    pairingRead.blocked = new Promise<void>((resolve) => {
+      pairingRead.release = resolve;
+    });
+    const pairingReadStarted = new Promise<void>((resolve) => {
+      pairingRead.onBlocked = resolve;
+    });
+    const drainSpy = vi.spyOn(GatewayNodeLifecycleDispatchTracker.prototype, "drain");
+    const resultAck = node
+      .request(
+        "node.invoke.result",
+        {
+          id: frame.id,
+          nodeId: frame.nodeId,
+          ok: true,
+          payloadJSON: JSON.stringify({ completed: "before-close" }),
+        },
+        { timeoutMs: 10_000 },
+      )
+      .catch((error: unknown) => error);
+    await pairingReadStarted;
+    const rawNodeSocket = Reflect.get(node, "ws") as { terminate?: () => void } | null;
+    const stopped = node.stopAndWait({ timeoutMs: 1_000 });
+    rawNodeSocket?.terminate?.();
+    await stopped;
+    node = undefined;
+    await vi.waitFor(() => expect(drainSpy).toHaveBeenCalledOnce());
+    pairingRead.release?.();
+
+    await expect(invoked).resolves.toMatchObject({
+      ok: true,
+      nodeId: pairedNode.identity.deviceId,
+      command: "camera.list",
+      payload: { completed: "before-close" },
+    });
+    await resultAck;
+    await vi.waitFor(async () => {
+      const listed = await operator?.request<{
+        nodes?: Array<{ nodeId?: string; connected?: boolean }>;
+      }>("node.list", {}, { timeoutMs: 10_000 });
+      expect(
+        listed?.nodes?.find((entry) => entry.nodeId === pairedNode.identity.deviceId)?.connected,
+      ).toBe(false);
+    });
+  } finally {
+    releaseBlockedPairingRead();
+    await Promise.allSettled([
+      ...(node ? [node.stopAndWait({ timeoutMs: 1_000 })] : []),
+      ...(operator ? [operator.stopAndWait({ timeoutMs: 1_000 })] : []),
+    ]);
+    await server.close();
+  }
+});
+
+function releaseBlockedPairingRead(): void {
+  pairingRead.release?.();
+  pairingRead.onBlocked = null;
+  pairingRead.blocked = null;
+  pairingRead.release = null;
+}

--- a/src/gateway/server.node-result-close.test.ts
+++ b/src/gateway/server.node-result-close.test.ts
@@ -39,7 +39,10 @@ afterEach(() => {
   pairingRead.release = null;
 });
 
-test("a terminal node result admitted before close wins over disconnect cleanup", async () => {
+test.each([
+  ["a terminal node result admitted before close wins over disconnect cleanup", false],
+  ["pairing removal still fences a terminal node result while close drains", true],
+] as const)("%s", async (_name, removePairingDuringDrain) => {
   const pairedNode = await pairDeviceIdentity({
     name: "node-result-before-close",
     role: "node",
@@ -165,22 +168,38 @@ test("a terminal node result admitted before close wins over disconnect cleanup"
     await stopped;
     node = undefined;
     await vi.waitFor(() => expect(drainSpy).toHaveBeenCalledOnce());
+    if (removePairingDuringDrain) {
+      await operator.request(
+        "node.pair.remove",
+        { nodeId: pairedNode.identity.deviceId },
+        { timeoutMs: 10_000 },
+      );
+    }
     pairingRead.release?.();
 
-    await expect(invoked).resolves.toMatchObject({
-      ok: true,
-      nodeId: pairedNode.identity.deviceId,
-      command: "camera.list",
-      payload: { completed: "before-close" },
-    });
+    if (removePairingDuringDrain) {
+      await expect(invoked).rejects.toThrow("node pairing changed while invocation was active");
+    } else {
+      await expect(invoked).resolves.toMatchObject({
+        ok: true,
+        nodeId: pairedNode.identity.deviceId,
+        command: "camera.list",
+        payload: { completed: "before-close" },
+      });
+    }
     await resultAck;
     await vi.waitFor(async () => {
       const listed = await operator?.request<{
         nodes?: Array<{ nodeId?: string; connected?: boolean }>;
       }>("node.list", {}, { timeoutMs: 10_000 });
-      expect(
-        listed?.nodes?.find((entry) => entry.nodeId === pairedNode.identity.deviceId)?.connected,
-      ).toBe(false);
+      const listedNode = listed?.nodes?.find(
+        (entry) => entry.nodeId === pairedNode.identity.deviceId,
+      );
+      if (removePairingDuringDrain) {
+        expect(listedNode).toBeUndefined();
+      } else {
+        expect(listedNode?.connected).toBe(false);
+      }
     });
   } finally {
     releaseBlockedPairingRead();

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -574,11 +574,13 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
           // still own asynchronous pairing validation. Retire the socket now, then
           // drain only that admitted chain before rejecting unresolved invokes.
           close();
-          const drained = await nodeLifecycleDispatch.drain();
-          if (!drained) {
-            logGateway.warn(
-              `node lifecycle dispatch drain timed out after ${NODE_LIFECYCLE_DISPATCH_DRAIN_TIMEOUT_MS}ms conn=${connId}`,
-            );
+          if (nodeLifecycleDispatch.hasActive()) {
+            const drained = await nodeLifecycleDispatch.drain();
+            if (!drained) {
+              logGateway.warn(
+                `node lifecycle dispatch drain timed out after ${NODE_LIFECYCLE_DISPATCH_DRAIN_TIMEOUT_MS}ms conn=${connId}`,
+              );
+            }
           }
           currentDisconnectedNodeId = context.nodeRegistry.unregister(connId);
         }

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -41,6 +41,10 @@ import {
 } from "./ws-connection/handshake-auth-log-limiter.js";
 import type { WsOriginCheckMetrics } from "./ws-connection/message-handler.js";
 import {
+  GatewayNodeLifecycleDispatchTracker,
+  NODE_LIFECYCLE_DISPATCH_DRAIN_TIMEOUT_MS,
+} from "./ws-connection/node-lifecycle-dispatch.js";
+import {
   attachWorkerWsMessageHandler,
   type WorkerConnectionService,
 } from "./ws-connection/worker-connection.js";
@@ -318,6 +322,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
     let lastFrameMethod: string | undefined;
     let lastFrameId: string | undefined;
     let hasReceivedPreauthFrame = false;
+    const nodeLifecycleDispatch = new GatewayNodeLifecycleDispatchTracker();
 
     socket.once("message", () => {
       hasReceivedPreauthFrame = true;
@@ -476,7 +481,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       normalizeLowercaseStringOrEmpty(requestUserAgent).startsWith("openclaw/") &&
       isLoopbackAddress(remoteAddr);
 
-    socket.once("close", (code, reason) => {
+    const handleSocketClose = async (code: number, reason: Buffer) => {
       const durationMs = Date.now() - openedAt;
       const logForwardedFor = sanitizeLogValue(forwardedFor);
       const logOrigin = sanitizeLogValue(requestOrigin);
@@ -565,6 +570,16 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
         context.terminalSessions?.handleDisconnect(connId);
         let currentDisconnectedNodeId: string | null = null;
         if (client?.connect?.role === "node") {
+          // The transport is already gone, but an earlier result/progress frame can
+          // still own asynchronous pairing validation. Retire the socket now, then
+          // drain only that admitted chain before rejecting unresolved invokes.
+          close();
+          const drained = await nodeLifecycleDispatch.drain();
+          if (!drained) {
+            logGateway.warn(
+              `node lifecycle dispatch drain timed out after ${NODE_LIFECYCLE_DISPATCH_DRAIN_TIMEOUT_MS}ms conn=${connId}`,
+            );
+          }
           currentDisconnectedNodeId = context.nodeRegistry.unregister(connId);
         }
         if (
@@ -597,6 +612,12 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
         endpoint,
       });
       close();
+    };
+    socket.once("close", (code, reason) => {
+      void handleSocketClose(code, reason).catch((error: unknown) => {
+        logGateway.error(`websocket close cleanup failed conn=${connId}: ${formatError(error)}`);
+        close();
+      });
     });
 
     const setClient = (next: GatewayWsClient) => {
@@ -697,6 +718,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       extraHandlers,
       getMethodRegistry,
       buildRequestContext,
+      nodeLifecycleDispatch,
       refreshHealthSnapshot,
       send,
       close,

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -362,6 +362,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
     let pingTimer: ReturnType<typeof setInterval> | undefined;
     let cleanupWorkerConnection: (() => void) | undefined;
     let awaitingPong = false;
+    let retainClientUntilNodeDrain = false;
     const handshakeTimeoutMs = resolvePreauthHandshakeTimeoutMs({
       configuredTimeoutMs: params.preauthHandshakeTimeoutMs,
     });
@@ -384,7 +385,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       }
     }, handshakeTimeoutMs);
 
-    const close = (code = 1000, reason?: string) => {
+    const retireTransport = (code = 1000, reason?: string) => {
       if (closed) {
         return;
       }
@@ -395,13 +396,17 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       }
       cleanupWorkerConnection?.();
       releasePreauthBudget();
-      if (client) {
-        clients.delete(client);
-      }
       try {
         socket.close(code, reason);
       } catch {
         /* ignore */
+      }
+    };
+
+    const close = (code = 1000, reason?: string) => {
+      retireTransport(code, reason);
+      if (client && !retainClientUntilNodeDrain) {
+        clients.delete(client);
       }
     };
 
@@ -570,19 +575,23 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
         context.terminalSessions?.handleDisconnect(connId);
         let currentDisconnectedNodeId: string | null = null;
         if (client?.connect?.role === "node") {
-          // The transport is already gone, but an earlier result/progress frame can
-          // still own asynchronous pairing validation. Retire the socket now, then
-          // drain only that admitted chain before rejecting unresolved invokes.
-          close();
-          if (nodeLifecycleDispatch.hasActive()) {
-            const drained = await nodeLifecycleDispatch.drain();
-            if (!drained) {
-              logGateway.warn(
-                `node lifecycle dispatch drain timed out after ${NODE_LIFECYCLE_DISPATCH_DRAIN_TIMEOUT_MS}ms conn=${connId}`,
-              );
+          // Retire I/O immediately, but keep the client revocable until admitted
+          // lifecycle work drains; pairing/token removal must still fence it.
+          retainClientUntilNodeDrain = true;
+          retireTransport();
+          try {
+            if (nodeLifecycleDispatch.hasActive()) {
+              const drained = await nodeLifecycleDispatch.drain();
+              if (!drained) {
+                logGateway.warn(
+                  `node lifecycle dispatch drain timed out after ${NODE_LIFECYCLE_DISPATCH_DRAIN_TIMEOUT_MS}ms conn=${connId}`,
+                );
+              }
             }
+            currentDisconnectedNodeId = context.nodeRegistry.unregister(connId);
+          } finally {
+            retainClientUntilNodeDrain = false;
           }
-          currentDisconnectedNodeId = context.nodeRegistry.unregister(connId);
         }
         if (
           client?.presenceKey &&

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -391,9 +391,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       }
       closed = true;
       clearTimeout(handshakeTimer);
-      if (pingTimer !== undefined) {
-        clearInterval(pingTimer);
-      }
+      clearInterval(pingTimer);
       cleanupWorkerConnection?.();
       releasePreauthBudget();
       try {

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.ts
@@ -187,12 +187,17 @@ export function createGatewayAuthenticatedRequestDispatcher(params: {
       }
     };
     const upstreamTrace = parseDiagnosticTraceparent(req.traceparent);
-    const requestDispatch = upstreamTrace
-      ? runWithDiagnosticTraceContext(
-          createChildDiagnosticTraceContext(upstreamTrace),
-          executeRequest,
-        )
-      : executeRequest();
+    const dispatchRequest = () =>
+      upstreamTrace
+        ? runWithDiagnosticTraceContext(
+            createChildDiagnosticTraceContext(upstreamTrace),
+            executeRequest,
+          )
+        : executeRequest();
+    const requestDispatch =
+      client.connect.role === "node"
+        ? params.handler.nodeLifecycleDispatch.dispatch(req.method, dispatchRequest)
+        : dispatchRequest();
     if (DEVICE_CREDENTIAL_INVALIDATING_METHODS.has(req.method)) {
       const barrier = requestDispatch.finally(() => {
         if (deviceCredentialMutationBarrier === barrier) {

--- a/src/gateway/server/ws-connection/message-handler-types.ts
+++ b/src/gateway/server/ws-connection/message-handler-types.ts
@@ -20,6 +20,7 @@ import type { GatewayRequestContext, GatewayRequestHandlers } from "../../server
 import type { GatewayWsClient, WsHandshakePhase } from "../ws-types.js";
 import type { resolveControlUiAuthPolicy } from "./connect-policy.js";
 import type { resolvePairingLocality } from "./handshake-auth-helpers.js";
+import type { GatewayNodeLifecycleDispatchTracker } from "./node-lifecycle-dispatch.js";
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 type ControlUiAuthPolicy = ReturnType<typeof resolveControlUiAuthPolicy>;
@@ -60,6 +61,7 @@ export type GatewayWsMessageHandlerParams = {
   extraHandlers: GatewayRequestHandlers;
   getMethodRegistry?: () => GatewayMethodRegistry;
   buildRequestContext: () => GatewayRequestContext;
+  nodeLifecycleDispatch: GatewayNodeLifecycleDispatchTracker;
   refreshHealthSnapshot: GatewayRequestContext["refreshHealthSnapshot"];
   send: (obj: unknown) => void;
   close: (code?: number, reason?: string) => void;

--- a/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
@@ -22,6 +22,7 @@ import type { HealthSummary } from "../../health/types.js";
 import { getOperatorApprovalRuntimeToken } from "../../operator-approval-runtime-token.js";
 import { handleGatewayRequest } from "../../server-methods.js";
 import type { GatewayRequestContext } from "../../server-methods/types.js";
+import { GatewayNodeLifecycleDispatchTracker } from "./node-lifecycle-dispatch.js";
 
 const {
   buildGatewaySnapshotMock,
@@ -257,6 +258,7 @@ function attachGatewayHarness(options: {
     events: [],
     extraHandlers: {},
     buildRequestContext: () => ({}) as GatewayRequestContext,
+    nodeLifecycleDispatch: new GatewayNodeLifecycleDispatchTracker(),
     refreshHealthSnapshot:
       options.refreshHealthSnapshot ?? vi.fn(async () => createHealthSummary()),
     send,

--- a/src/gateway/server/ws-connection/message-handler.suspension-admission.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.suspension-admission.test.ts
@@ -9,6 +9,7 @@ import {
   tryBeginGatewaySuspendAdmission,
 } from "../../../process/gateway-work-admission.js";
 import type { GatewayRequestContext } from "../../server-methods/types.js";
+import { GatewayNodeLifecycleDispatchTracker } from "./node-lifecycle-dispatch.js";
 
 const { incrementPresenceVersionMock, loadConfigMock, upsertPresenceMock } = vi.hoisted(() => ({
   incrementPresenceVersionMock: vi.fn(() => 2),
@@ -100,6 +101,7 @@ function attachHarness(params: { deferSocketSend?: boolean } = {}) {
     events: [],
     extraHandlers: {},
     buildRequestContext: () => ({}) as GatewayRequestContext,
+    nodeLifecycleDispatch: new GatewayNodeLifecycleDispatchTracker(),
     refreshHealthSnapshot: vi.fn(async () => ({}) as never),
     send,
     close,

--- a/src/gateway/server/ws-connection/node-lifecycle-dispatch.test.ts
+++ b/src/gateway/server/ws-connection/node-lifecycle-dispatch.test.ts
@@ -39,10 +39,12 @@ describe("GatewayNodeLifecycleDispatchTracker", () => {
     });
 
     await expect(tracker.dispatch("node.event", async () => undefined)).resolves.toBeUndefined();
+    expect(tracker.hasActive()).toBe(true);
     await expect(tracker.drain(1)).resolves.toBe(false);
 
     releaseResult?.();
     await expect(result).resolves.toBeUndefined();
+    expect(tracker.hasActive()).toBe(false);
     await expect(tracker.drain(1)).resolves.toBe(true);
   });
 });

--- a/src/gateway/server/ws-connection/node-lifecycle-dispatch.test.ts
+++ b/src/gateway/server/ws-connection/node-lifecycle-dispatch.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { GatewayNodeLifecycleDispatchTracker } from "./node-lifecycle-dispatch.js";
+
+describe("GatewayNodeLifecycleDispatchTracker", () => {
+  it("drains every admitted node progress and terminal result", async () => {
+    const tracker = new GatewayNodeLifecycleDispatchTracker();
+    const events: string[] = [];
+    let releaseProgress: (() => void) | undefined;
+    const progressGate = new Promise<void>((resolve) => {
+      releaseProgress = resolve;
+    });
+
+    const progress = tracker.dispatch("node.invoke.progress", async () => {
+      events.push("progress-start");
+      await progressGate;
+      events.push("progress-end");
+    });
+    const result = tracker.dispatch("node.invoke.result", async () => {
+      events.push("result");
+    });
+    const drained = tracker.drain(1_000);
+
+    await vi.waitFor(() => expect(events).toEqual(["progress-start", "result"]));
+    releaseProgress?.();
+
+    await expect(Promise.all([progress, result])).resolves.toEqual([undefined, undefined]);
+    await expect(drained).resolves.toBe(true);
+    expect(events).toEqual(["progress-start", "result", "progress-end"]);
+  });
+
+  it("does not queue unrelated methods and bounds a stuck lifecycle drain", async () => {
+    const tracker = new GatewayNodeLifecycleDispatchTracker();
+    let releaseResult: (() => void) | undefined;
+    const resultGate = new Promise<void>((resolve) => {
+      releaseResult = resolve;
+    });
+    const result = tracker.dispatch("node.invoke.result", async () => {
+      await resultGate;
+    });
+
+    await expect(tracker.dispatch("node.event", async () => undefined)).resolves.toBeUndefined();
+    await expect(tracker.drain(1)).resolves.toBe(false);
+
+    releaseResult?.();
+    await expect(result).resolves.toBeUndefined();
+    await expect(tracker.drain(1)).resolves.toBe(true);
+  });
+});

--- a/src/gateway/server/ws-connection/node-lifecycle-dispatch.ts
+++ b/src/gateway/server/ws-connection/node-lifecycle-dispatch.ts
@@ -9,6 +9,10 @@ export const NODE_LIFECYCLE_DISPATCH_DRAIN_TIMEOUT_MS = 1_000;
 export class GatewayNodeLifecycleDispatchTracker {
   private active = new Set<Promise<void>>();
 
+  hasActive(): boolean {
+    return this.active.size > 0;
+  }
+
   dispatch(method: string, run: () => Promise<void>): Promise<void> {
     const execution = run();
     if (!NODE_LIFECYCLE_METHODS.has(method)) {

--- a/src/gateway/server/ws-connection/node-lifecycle-dispatch.ts
+++ b/src/gateway/server/ws-connection/node-lifecycle-dispatch.ts
@@ -1,0 +1,52 @@
+const NODE_LIFECYCLE_METHODS = new Set(["node.invoke.progress", "node.invoke.result"]);
+
+export const NODE_LIFECYCLE_DISPATCH_DRAIN_TIMEOUT_MS = 1_000;
+
+/**
+ * Tracks admitted node progress/result requests so physical disconnect cleanup
+ * drains their existing work before retiring invokes. It does not add a queue.
+ */
+export class GatewayNodeLifecycleDispatchTracker {
+  private active = new Set<Promise<void>>();
+
+  dispatch(method: string, run: () => Promise<void>): Promise<void> {
+    const execution = run();
+    if (!NODE_LIFECYCLE_METHODS.has(method)) {
+      return execution;
+    }
+    const settled = execution.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.active.add(settled);
+    void settled.finally(() => {
+      this.active.delete(settled);
+    });
+    return execution;
+  }
+
+  async drain(timeoutMs = NODE_LIFECYCLE_DISPATCH_DRAIN_TIMEOUT_MS): Promise<boolean> {
+    const deadlineAt = Date.now() + Math.max(0, timeoutMs);
+    while (this.active.size > 0) {
+      const remainingMs = deadlineAt - Date.now();
+      if (remainingMs <= 0) {
+        return false;
+      }
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      const timedOut = Symbol("node-lifecycle-dispatch-timeout");
+      const result = await Promise.race([
+        Promise.allSettled(this.active),
+        new Promise<typeof timedOut>((resolve) => {
+          timeout = setTimeout(() => resolve(timedOut), remainingMs);
+        }),
+      ]);
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      if (result === timedOut) {
+        return false;
+      }
+    }
+    return true;
+  }
+}


### PR DESCRIPTION
Closes https://github.com/openclaw/openclaw/issues/116363

## What Problem This Solves

A node could send a valid terminal `node.invoke.result` and then close its WebSocket, but disconnect cleanup could synchronously settle the operator invocation as `DISCONNECTED` while the already-received result was still awaiting pairing validation. Retrying the apparently failed operation could repeat a remote side effect.

## Root Cause

Authenticated WebSocket request dispatch intentionally runs asynchronously so one connection can process independent requests concurrently. The physical-close handler, however, immediately unregistered the node and consumed every pending invoke. That let cleanup overtake a terminal result frame whose dispatch had already been admitted from the same connection.

The deterministic current-main reproduction holds the result's persisted-pairing read after frame admission, terminates the real authenticated socket, and lets disconnect cleanup run. Current main returns:

`DISCONNECTED: node disconnected (camera.list)`

The result handler later sees the pairing/session as stale and cannot recover the already-consumed invocation.

## What Changed

- Each Gateway WebSocket connection owns a tracker for admitted node lifecycle requests.
- Only node-role `node.invoke.progress` and `node.invoke.result` requests enter that tracker; unrelated RPCs retain their existing concurrency and no new request queue is introduced.
- Physical close retires transport I/O first, then drains the already-admitted lifecycle work for at most one second before unregistering the node and rejecting unresolved invokes.
- The retired transport remains discoverable to pairing/token revocation until drain and unregister complete, so authority changes still fence admitted work.
- Idle node disconnects keep the prior synchronous cleanup path; the asynchronous boundary exists only when lifecycle work is actually active.
- If the bounded drain expires, existing disconnect behavior wins and cleanup continues with a warning.
- Replacement and revocation still invalidate/unregister the old connection before physical-close cleanup, so stale results cannot settle a new or revoked pairing.

No grace sleep, pairing-check bypass, config, protocol, storage, dependency, or user-data contract change.

## Observed Behavior

The real-WebSocket regression now proves:

1. an operator dispatches `node.invoke`;
2. the node's terminal result reaches the Gateway and blocks inside the real persistent-pairing check;
3. the node socket physically terminates;
4. close cleanup enters the bounded lifecycle drain;
5. pairing validation completes and the admitted result settles the operator successfully;
6. the node is then projected disconnected.

## Evidence

Exact head: `75b99b29d4aa83e2d628ad6ebd0878c8efd7082e`.

- Exact-head focused local proof:
  - `node scripts/run-vitest.mjs src/gateway/server/ws-connection.test.ts src/gateway/server/ws-connection/node-lifecycle-dispatch.test.ts src/gateway/server.node-result-close.test.ts src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts src/gateway/server/ws-connection/message-handler.suspension-admission.test.ts`
  - 5 files / 65 tests passed.
  - The ordering-sensitive real-WebSocket and tracker files passed 10/10 repeated runs (40/40 tests), including close → pairing removal → result release.
- Focused Blacksmith Testbox `tbx_01kz6dajj97ncjadh7r6r2bdes`, https://github.com/openclaw/openclaw/actions/runs/30911085825:
  - 8 Gateway/registry/message-dispatch files / 154 tests passed.
  - 3 real Gateway-node E2E files / 3 scenarios passed: control-plane invoke/presence, pending-work reconnect replay, and replacement-connection exec approval ownership.
- Broad candidate-diff Blacksmith Testbox `tbx_01kz6etnqnqsaam9a9e9pf8dvm`, https://github.com/openclaw/openclaw/actions/runs/30913200657:
  - `pnpm check:changed` passed the `core` and `coreTests` lanes.
  - `pnpm build` passed, including the production Control UI build and performance guard.
- The first hosted CI run, https://github.com/openclaw/openclaw/actions/runs/30914951865, found two existing close-handler tests that require idle disconnect cleanup to remain synchronous. The follow-up commit restored that fast path, and exact-head CI https://github.com/openclaw/openclaw/actions/runs/30916683149 passed every selected job, including the previously failing shard and `openclaw/ci-gate`.
- Exact-head ClawSweeper found that retiring the client from the shared set before drain weakened the pairing/token revocation fence. The corrected head retires I/O immediately while retaining revocation visibility through drain and unregister; the adversarial real-WebSocket regression proves a pairing removal rejects the operator invocation. The branch is rebased onto current `main`; targeted oxlint is green without a max-lines suppression. Fresh exact-head CI and ClawSweeper re-review are pending.
- Fresh exact-head AutoReview: clean, no accepted/actionable findings, overall correctness 0.98. The focused revocation-fence delta was independently clean at 0.98, and the line-budget simplification at 0.99.
- `git diff --check`, targeted `oxfmt`, targeted `oxlint`, and the focused tests passed.
- Public model-identifier audit: PASS; the diff, tests, proof, and public text contain no model identifiers.

## Repair Doctrine Summary

- Root cause: physical-close cleanup consumed pending invokes before already-admitted terminal dispatch completed.
- Architectural owner: the WebSocket connection owns both admitted request lifetime and physical disconnect cleanup.
- Canonical fix: connection-owned tracking plus a bounded drain of the exact admitted lifecycle set.
- Removed/avoided paths: no retry, grace delay, pairing bypass, fallback, or second result path.
- Production delta: +109/-15 (net +94), paying for one explicit connection-lifecycle ownership boundary, bounded cleanup contract, revocation visibility, and preservation of the existing idle fast path.
- Test delta: +273/-0, including deterministic real-WebSocket success and revocation ordering proof, tracker timeout coverage, and idle-state assertions.
- Sibling coverage: progress and terminal result methods share the tracker; ordinary RPC concurrency, idle disconnect cleanup, pairing/token invalidation, replacement connection ownership, pending work, invoke cancellation, and pairing-generation tests pass.
- Risk: medium-low. The change delays node unregister by at most one second only when admitted result/progress work is still active; all security and generation checks remain authoritative.

AI-assisted: yes.
