### PR TITLE
fix(discord): bound realtime exact speech retention

### DIFF
--- a/extensions/discord/src/voice/manager.e2e.test.ts
+++ b/extensions/discord/src/voice/manager.e2e.test.ts
@@ -4117,7 +4117,7 @@ describe("DiscordVoiceManager", () => {
     expectUserMessageIncludes("third answer");
   });
 
-  it("terminates realtime voice when retained exact speech exceeds the character budget", async () => {
+  it("terminates realtime voice when retained Unicode speech exceeds the byte budget", async () => {
     const client = createClient();
     client.fetchChannel.mockImplementation(async (channelId: string) => {
       const guildId = channelId === "2001" ? "g2" : "g1";
@@ -4138,7 +4138,9 @@ describe("DiscordVoiceManager", () => {
     const connection = (entry as unknown as { connection: { destroy: ReturnType<typeof vi.fn> } })
       .connection;
     const bridgeParams = lastRealtimeBridgeParams();
-    const accepted = "a".repeat(32 * 1024);
+    const accepted = "😀".repeat(8 * 1024);
+    expect(accepted.length).toBe(16 * 1024);
+    expect(Buffer.byteLength(accepted, "utf8")).toBe(32 * 1024);
 
     await manager.join({ guildId: "g2", channelId: "2001" });
     const siblingRealtime = getSessionEntry(manager, "g2").realtime as unknown as {

--- a/extensions/discord/src/voice/manager.e2e.test.ts
+++ b/extensions/discord/src/voice/manager.e2e.test.ts
@@ -4114,6 +4114,66 @@ describe("DiscordVoiceManager", () => {
     expectUserMessageIncludes("third answer");
   });
 
+  it("terminates realtime voice when retained exact speech exceeds the character budget", async () => {
+    const manager = createAgentProxyManager();
+
+    await manager.join({ guildId: "g1", channelId: "1001" });
+    const entry = getSessionEntry(manager);
+    const realtime = entry.realtime as unknown as {
+      enqueueExactSpeechMessage: (text: string) => void;
+    };
+    const connection = (entry as unknown as { connection: { destroy: ReturnType<typeof vi.fn> } })
+      .connection;
+    const bridgeParams = lastRealtimeBridgeParams();
+    const accepted = "a".repeat(32 * 1024);
+
+    realtime.enqueueExactSpeechMessage(accepted);
+    expectUserMessageIncludes(accepted);
+    expect(manager.status()).toHaveLength(1);
+
+    realtime.enqueueExactSpeechMessage("overflow");
+
+    expect(manager.status()).toStrictEqual([]);
+    expect(connection.destroy).toHaveBeenCalledOnce();
+    expect(realtimeSessionMock.close).toHaveBeenCalledOnce();
+    expectUserMessageNotIncludes("overflow");
+
+    bridgeParams.onReady?.();
+    bridgeParams.onEvent?.({ direction: "server", type: "response.done" });
+    realtime.enqueueExactSpeechMessage("late");
+    entry.stop();
+
+    expect(connection.destroy).toHaveBeenCalledOnce();
+    expect(realtimeSessionMock.close).toHaveBeenCalledOnce();
+    expectUserMessageNotIncludes("late");
+  });
+
+  it("terminates realtime voice when retained exact speech exceeds the message budget", async () => {
+    const manager = createAgentProxyManager();
+
+    await manager.join({ guildId: "g1", channelId: "1001" });
+    const entry = getSessionEntry(manager);
+    const realtime = entry.realtime as unknown as {
+      enqueueExactSpeechMessage: (text: string) => void;
+    };
+    const connection = (entry as unknown as { connection: { destroy: ReturnType<typeof vi.fn> } })
+      .connection;
+
+    for (let index = 0; index < 32; index += 1) {
+      realtime.enqueueExactSpeechMessage(`answer-${index}`);
+    }
+
+    expect(manager.status()).toHaveLength(1);
+    expect(realtimeSessionMock.sendUserMessage).toHaveBeenCalledOnce();
+
+    realtime.enqueueExactSpeechMessage("answer-overflow");
+
+    expect(manager.status()).toStrictEqual([]);
+    expect(connection.destroy).toHaveBeenCalledOnce();
+    expect(realtimeSessionMock.close).toHaveBeenCalledOnce();
+    expectUserMessageNotIncludes("answer-overflow");
+  });
+
   it("does not interrupt active exact speech for a later forced agent-proxy consult", async () => {
     agentCommandMock
       .mockResolvedValueOnce({ payloads: [{ text: "first answer" }] })

--- a/extensions/discord/src/voice/manager.e2e.test.ts
+++ b/extensions/discord/src/voice/manager.e2e.test.ts
@@ -433,15 +433,18 @@ describe("DiscordVoiceManager", () => {
       runtime: createRuntime(),
     });
 
-  const createAgentProxyManager = () =>
-    createManager({
-      groupPolicy: "open",
-      voice: {
-        enabled: true,
-        mode: "agent-proxy",
-        realtime: { provider: "openai" },
+  const createAgentProxyManager = (clientOverride?: ReturnType<typeof createClient>) =>
+    createManager(
+      {
+        groupPolicy: "open",
+        voice: {
+          enabled: true,
+          mode: "agent-proxy",
+          realtime: { provider: "openai" },
+        },
       },
-    });
+      clientOverride,
+    );
 
   const expectConnectedStatus = (
     manager: InstanceType<typeof managerModule.DiscordVoiceManager>,
@@ -4115,7 +4118,17 @@ describe("DiscordVoiceManager", () => {
   });
 
   it("terminates realtime voice when retained exact speech exceeds the character budget", async () => {
-    const manager = createAgentProxyManager();
+    const client = createClient();
+    client.fetchChannel.mockImplementation(async (channelId: string) => {
+      const guildId = channelId === "2001" ? "g2" : "g1";
+      return {
+        id: channelId,
+        guildId,
+        guild: { id: guildId, name: guildId },
+        type: ChannelType.GuildVoice,
+      };
+    });
+    const manager = createAgentProxyManager(client);
 
     await manager.join({ guildId: "g1", channelId: "1001" });
     const entry = getSessionEntry(manager);
@@ -4127,16 +4140,26 @@ describe("DiscordVoiceManager", () => {
     const bridgeParams = lastRealtimeBridgeParams();
     const accepted = "a".repeat(32 * 1024);
 
+    await manager.join({ guildId: "g2", channelId: "2001" });
+    const siblingRealtime = getSessionEntry(manager, "g2").realtime as unknown as {
+      enqueueExactSpeechMessage: (text: string) => void;
+    };
+
     realtime.enqueueExactSpeechMessage(accepted);
     expectUserMessageIncludes(accepted);
-    expect(manager.status()).toHaveLength(1);
+    expect(manager.status()).toHaveLength(2);
 
     realtime.enqueueExactSpeechMessage("overflow");
 
-    expect(manager.status()).toStrictEqual([]);
+    expect(manager.status()).toEqual([
+      expect.objectContaining({ guildId: "g2", channelId: "2001" }),
+    ]);
     expect(connection.destroy).toHaveBeenCalledOnce();
     expect(realtimeSessionMock.close).toHaveBeenCalledOnce();
     expectUserMessageNotIncludes("overflow");
+
+    siblingRealtime.enqueueExactSpeechMessage("sibling remains usable");
+    expectUserMessageIncludes("sibling remains usable");
 
     bridgeParams.onReady?.();
     bridgeParams.onEvent?.({ direction: "server", type: "response.done" });

--- a/extensions/discord/src/voice/manager.ts
+++ b/extensions/discord/src/voice/manager.ts
@@ -746,6 +746,7 @@ export class DiscordVoiceManager {
       receiveRecovery: createVoiceReceiveRecoveryState(),
       isStopped: () => stopped,
       stop: () => {
+        clearSessionIfCurrent();
         stopEntry(entry, {
           destroyConnection: true,
           reason: `stop guild ${guildId} channel ${channelId}`,
@@ -884,6 +885,12 @@ export class DiscordVoiceManager {
       entry,
       getHumanParticipantCount: () => this.membership.countHumanParticipants(entry, this.botUserId),
       mode: voiceMode,
+      onTerminalError: (error) => {
+        logger.error(
+          `discord voice: realtime session failed terminally guild=${entry.guildId} channel=${entry.channelId}: ${formatErrorMessage(error)}`,
+        );
+        entry.stop();
+      },
       runAgentTurn: ({ context, message, toolsAllow, userId }) =>
         this.runDiscordRealtimeAgentTurn({ context, entry, message, toolsAllow, userId }),
     });

--- a/extensions/discord/src/voice/realtime.ts
+++ b/extensions/discord/src/voice/realtime.ts
@@ -90,7 +90,7 @@ const DISCORD_REALTIME_DUPLICATE_ERROR_SUPPRESS_MS = 60_000;
 const DISCORD_REALTIME_CONTROL_SPEECH_DEDUPE_MS = 5_000;
 const DISCORD_REALTIME_OUTPUT_PLAYBACK_WATCHDOG_MARGIN_MS = 1_500;
 const DISCORD_REALTIME_MAX_RETAINED_EXACT_SPEECH_MESSAGES = 32;
-const DISCORD_REALTIME_MAX_RETAINED_EXACT_SPEECH_CHARS = 32 * 1024;
+const DISCORD_REALTIME_MAX_RETAINED_EXACT_SPEECH_BYTES = 32 * 1024;
 const DISCORD_REALTIME_CANCELLATION_RACE_DETAIL = "Cancellation failed: no active response found";
 const DISCORD_REALTIME_WAKE_ACKS = ["Yeah.", "Mm-hmm.", "Got it.", "One sec."];
 const discordRealtimeTalkPayload = () => ({});
@@ -999,12 +999,15 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     }
     const retainedMessages =
       this.queuedExactSpeechMessages.length + (this.activeExactSpeechMessage ? 1 : 0);
-    const retainedChars =
-      this.queuedExactSpeechMessages.reduce((total, message) => total + message.length, 0) +
-      (this.activeExactSpeechMessage?.length ?? 0);
+    const retainedBytes =
+      this.queuedExactSpeechMessages.reduce(
+        (total, message) => total + Buffer.byteLength(message, "utf8"),
+        0,
+      ) + Buffer.byteLength(this.activeExactSpeechMessage ?? "", "utf8");
+    const incomingBytes = Buffer.byteLength(text, "utf8");
     if (
       retainedMessages >= DISCORD_REALTIME_MAX_RETAINED_EXACT_SPEECH_MESSAGES ||
-      retainedChars + text.length > DISCORD_REALTIME_MAX_RETAINED_EXACT_SPEECH_CHARS
+      retainedBytes + incomingBytes > DISCORD_REALTIME_MAX_RETAINED_EXACT_SPEECH_BYTES
     ) {
       // Completed speech cannot be silently dropped. Overflow terminally retires
       // this session before late provider or playback events can drain stale work.
@@ -1019,7 +1022,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
       this.clearOutputAudio("exact-speech-overflow");
       this.params.onTerminalError(
         new Error(
-          `Discord realtime exact speech overflow: retained=${retainedMessages} retainedChars=${retainedChars} incomingChars=${text.length}`,
+          `Discord realtime exact speech overflow: retained=${retainedMessages} retainedBytes=${retainedBytes} incomingBytes=${incomingBytes}`,
         ),
       );
       return;

--- a/extensions/discord/src/voice/realtime.ts
+++ b/extensions/discord/src/voice/realtime.ts
@@ -89,6 +89,8 @@ const DISCORD_REALTIME_FORCED_CONSULT_FALLBACK_DELAY_MS = 200;
 const DISCORD_REALTIME_DUPLICATE_ERROR_SUPPRESS_MS = 60_000;
 const DISCORD_REALTIME_CONTROL_SPEECH_DEDUPE_MS = 5_000;
 const DISCORD_REALTIME_OUTPUT_PLAYBACK_WATCHDOG_MARGIN_MS = 1_500;
+const DISCORD_REALTIME_MAX_RETAINED_EXACT_SPEECH_MESSAGES = 32;
+const DISCORD_REALTIME_MAX_RETAINED_EXACT_SPEECH_CHARS = 32 * 1024;
 const DISCORD_REALTIME_CANCELLATION_RACE_DETAIL = "Cancellation failed: no active response found";
 const DISCORD_REALTIME_WAKE_ACKS = ["Yeah.", "Mm-hmm.", "Got it.", "One sec."];
 const discordRealtimeTalkPayload = () => ({});
@@ -388,6 +390,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
       mode: Exclude<DiscordVoiceMode, "stt-tts">;
       bootstrapContextInstructions?: string;
       getHumanParticipantCount?: () => number;
+      onTerminalError: (error: Error) => void;
       runAgentTurn: (params: VoiceRealtimeAgentTurnParams) => Promise<string>;
     },
   ) {
@@ -992,6 +995,33 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
 
   private enqueueExactSpeechMessage(text: string): void {
     if (this.stopped || !text.trim()) {
+      return;
+    }
+    const retainedMessages =
+      this.queuedExactSpeechMessages.length + (this.activeExactSpeechMessage ? 1 : 0);
+    const retainedChars =
+      this.queuedExactSpeechMessages.reduce((total, message) => total + message.length, 0) +
+      (this.activeExactSpeechMessage?.length ?? 0);
+    if (
+      retainedMessages >= DISCORD_REALTIME_MAX_RETAINED_EXACT_SPEECH_MESSAGES ||
+      retainedChars + text.length > DISCORD_REALTIME_MAX_RETAINED_EXACT_SPEECH_CHARS
+    ) {
+      // Completed speech cannot be silently dropped. Overflow terminally retires
+      // this session before late provider or playback events can drain stale work.
+      this.stopped = true;
+      this.bridgeReady = false;
+      this.outputBackpressure = undefined;
+      this.talkback.close();
+      this.queuedExactSpeechMessages = [];
+      this.exactSpeechResponseActive = false;
+      this.exactSpeechAudioStarted = false;
+      this.activeExactSpeechMessage = undefined;
+      this.clearOutputAudio("exact-speech-overflow");
+      this.params.onTerminalError(
+        new Error(
+          `Discord realtime exact speech overflow: retained=${retainedMessages} retainedChars=${retainedChars} incomingChars=${text.length}`,
+        ),
+      );
       return;
     }
     if (!this.bridgeReady || this.exactSpeechResponseActive || this.hasInterruptibleOutputAudio()) {


### PR DESCRIPTION
Related: #116201

## What Problem This Solves

Fixes an issue where Discord realtime voice sessions could retain unbounded completed speech while provider readiness, an active response, or playback prevented delivery. A stalled session could grow memory indefinitely and later emit a large stale backlog.

## Why This Change Was Made

`DiscordRealtimeVoiceSession` now owns a fixed exact-speech budget of 32 messages and 32 KiB measured as UTF-8 bytes. The first overflow is terminal for only that guild session: it clears session-owned speech and playback state, reports one terminal error, and ignores late provider or player events.

The manager's canonical `entry.stop()` path removes the exact current session and destroys its connection idempotently. This stays Discord-local because the shared talkback queue owns pending questions, not completed speech or Discord playback lifecycle.

Maintainer decision: preserve completed speech exactly while the session remains healthy; do not silently evict, replace, or coalesce it. If the bounded retention contract is exceeded, close only the affected session and leave sibling guild sessions usable.

No provider, config, environment-variable, protocol, public SDK, or docs surface changes.

## User Impact

Discord realtime voice can no longer retain an unbounded completed-speech backlog. When the safety bound is exceeded, the affected voice session stops once instead of risking continued memory growth or later speaking stale responses. Other guild voice sessions continue normally.

## Evidence

- Exact final head `c238564d2707be5527e83b112025443401e7e2fa` passed the full Discord voice manager E2E suite locally and on Blacksmith Testbox: 1 file, 194/194 tests. Run: https://github.com/openclaw/openclaw/actions/runs/30919138499
- Deterministic overflow coverage proves UTF-8 byte accounting with multibyte speech, first-overflow terminal precedence, close idempotence, late-event suppression, queue/audio cleanup, and that a second guild session remains registered and can still enqueue speech.
- Live Discord transport proof passed `discord-voice-autojoin` on the preceding head; the only subsequent production change is the corrected UTF-8 byte metric. Workflow: https://github.com/openclaw/openclaw/actions/runs/30916744848; job: https://github.com/openclaw/openclaw/actions/runs/30916744848/job/92017440511; artifact `qa-live-discord-30916744848-1`.
- Live OpenAI realtime proof passed on the preceding head; the subsequent production change is Discord-local byte accounting. The backend bridge connected to `gpt-realtime-2.1`; 3/3 synthesized PCM round trips completed with terminal responses and zero late audio; browser WebRTC applied the remote description and connected.
- Blacksmith Testbox `tbx_01kz6g8b094g0zttq4t500x8d6` passed extension test types, oxlint, database-first guards, media helper guard, sidecar loader guard, and import-cycle checks.
- Original branch autoreview: clean, 0.98 confidence. Exact byte-accounting fix commit: clean, patch correct at 0.99 confidence.
- `git diff --check` and direct `oxfmt --check` passed.

The literal overflow cannot be induced through the current live Discord driver without adding a private playback-stall control and a second driver. The proof is therefore intentionally split: deterministic manager E2E owns the overflow and sibling-isolation invariant; live Discord owns transport regression; live OpenAI owns provider/WebRTC regression. This keeps the PR narrow and avoids a new test-only runtime surface.

Scope: production `+40/-0`; tests `+93/-8`; three files.
