### PR TITLE
fix(media): release rejected BytePlus and Runway video downloads under debug capture

### DIFF
--- a/extensions/byteplus/video-generation-provider.test.ts
+++ b/extensions/byteplus/video-generation-provider.test.ts
@@ -337,6 +337,60 @@ describe("byteplus video generation provider", () => {
     expect(canceled).toHaveBeenCalledOnce();
   });
 
+  it("releases a rejected download body without awaiting a debug-capture tee branch", async () => {
+    postJsonRequestMock.mockResolvedValue({
+      response: streamedJsonResponse({ id: "task-captured-response" }),
+      release: vi.fn(async () => {}),
+    });
+    // The debug proxy clones every captured response, so the caller-facing body is one
+    // branch of a live tee. Cancelling such a branch settles only once both branches
+    // cancel, so awaiting it here would hang the download instead of surfacing the error.
+    const response = new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('{"error":"still streaming"}'));
+        },
+      }),
+      { headers: { "content-type": "application/json" } },
+    );
+    const captureClone = response.clone();
+    const captureReader = captureClone.body?.getReader();
+    await captureReader?.read();
+    fetchWithTimeoutMock
+      .mockResolvedValueOnce(
+        streamedJsonResponse({
+          id: "task-captured-response",
+          status: "succeeded",
+          content: { video_url: "https://example.com/invalid.mp4" },
+        }),
+      )
+      .mockResolvedValueOnce(response);
+
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await expect(
+        Promise.race([
+          buildBytePlusVideoGenerationProvider().generateVideo({
+            provider: "byteplus",
+            model: "seedance-1-0-pro-250528",
+            prompt: "captured invalid response",
+            cfg: {},
+          }),
+          new Promise<never>((_resolve, reject) => {
+            timeout = setTimeout(() => {
+              reject(new Error("BytePlus download waited for a captured response clone"));
+            }, 500);
+          }),
+        ]),
+      ).rejects.toThrow("BytePlus generated video download: malformed video response");
+    } finally {
+      if (timeout !== undefined) {
+        clearTimeout(timeout);
+      }
+      await captureReader?.cancel().catch(() => undefined);
+    }
+  });
+
   it("rejects generated video downloads that exceed the configured media cap", async () => {
     postJsonRequestMock.mockResolvedValue({
       response: streamedJsonResponse({ id: "task_too_large" }),

--- a/extensions/byteplus/video-generation-provider.ts
+++ b/extensions/byteplus/video-generation-provider.ts
@@ -201,7 +201,9 @@ async function downloadBytePlusVideo(params: {
     assertProviderBinaryResponseContent(response, "BytePlus generated video download", "video");
   } catch (error) {
     // A rejected binary response still owns a live socket until its unread body is canceled.
-    await response.body?.cancel().catch(() => undefined);
+    // A debug-capture clone can keep the tee open, so waiting for cancel would hang
+    // before the rejected response and its dispatcher can be released.
+    void response.body?.cancel().catch(() => undefined);
     throw error;
   }
   const mimeType = normalizeOptionalString(response.headers.get("content-type")) ?? "video/mp4";

--- a/extensions/runway/video-generation-provider.test.ts
+++ b/extensions/runway/video-generation-provider.test.ts
@@ -210,6 +210,60 @@ describe("runway video generation provider", () => {
     expect(canceled).toHaveBeenCalledOnce();
   });
 
+  it("releases a rejected download body without awaiting a debug-capture tee branch", async () => {
+    postJsonRequestMock.mockResolvedValue({
+      response: streamedJsonResponse({ id: "task-captured-response" }),
+      release: vi.fn(async () => {}),
+    });
+    // The debug proxy clones every captured response, so the caller-facing body is one
+    // branch of a live tee. Cancelling such a branch settles only once both branches
+    // cancel, so awaiting it here would hang the download instead of surfacing the error.
+    const response = new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('{"error":"still streaming"}'));
+        },
+      }),
+      { headers: { "content-type": "application/json" } },
+    );
+    const captureClone = response.clone();
+    const captureReader = captureClone.body?.getReader();
+    await captureReader?.read();
+    fetchWithTimeoutMock
+      .mockResolvedValueOnce(
+        streamedJsonResponse({
+          id: "task-captured-response",
+          status: "SUCCEEDED",
+          output: ["https://example.com/invalid.mp4"],
+        }),
+      )
+      .mockResolvedValueOnce(response);
+
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await expect(
+        Promise.race([
+          buildRunwayVideoGenerationProvider().generateVideo({
+            provider: "runway",
+            model: "gen4.5",
+            prompt: "captured invalid response",
+            cfg: {},
+          }),
+          new Promise<never>((_resolve, reject) => {
+            timeout = setTimeout(() => {
+              reject(new Error("Runway download waited for a captured response clone"));
+            }, 500);
+          }),
+        ]),
+      ).rejects.toThrow("Runway generated video download: malformed video response");
+    } finally {
+      if (timeout !== undefined) {
+        clearTimeout(timeout);
+      }
+      await captureReader?.cancel().catch(() => undefined);
+    }
+  });
+
   it("rejects generated video downloads that exceed the configured media cap", async () => {
     postJsonRequestMock.mockResolvedValue({
       response: streamedJsonResponse({ id: "task-too-large" }),

--- a/extensions/runway/video-generation-provider.ts
+++ b/extensions/runway/video-generation-provider.ts
@@ -320,7 +320,9 @@ async function downloadRunwayVideos(params: {
       assertProviderBinaryResponseContent(response, "Runway generated video download", "video");
     } catch (error) {
       // A rejected binary response still owns a live socket until its unread body is canceled.
-      await response.body?.cancel().catch(() => undefined);
+      // A debug-capture clone can keep the tee open, so waiting for cancel would hang
+      // before the rejected response and its dispatcher can be released.
+      void response.body?.cancel().catch(() => undefined);
       throw error;
     }
     const mimeType = normalizeOptionalString(response.headers.get("content-type")) ?? "video/mp4";


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users generating video with BytePlus or Runway while the debug proxy is enabled would see the generation hang instead of failing, when the provider returns a successful HTTP 200 whose body is not video (a JSON error page, an HTML sign-in page) and that body does not finish arriving.

The download never returns, so the request sits pending until the surrounding timeout fires, and the user never sees the `malformed video response` error the provider already knows how to raise.

## Why This Change Was Made

`OPENCLAW_DEBUG_PROXY_ENABLED` installs a global-fetch patch that clones every captured response (`src/proxy-capture/runtime.ts:292-320`, `:51`). A clone tees the body, and the repo already documents the consequence at `src/proxy-capture/runtime.ts:41-46`:

> cancelling such a branch never settles (it only resolves once BOTH branches cancel)

Both providers resolve their download `fetchFn` to the global `fetch` (`extensions/byteplus/video-generation-provider.ts:281`, `extensions/runway/video-generation-provider.ts:394`), so under capture the response they hold is exactly such a branch — and both `await` its cancellation when the binary check rejects. The capture branch is read concurrently and `captureHttpExchange` is not awaited, so while that read is still in flight nothing releases the awaited cancel.

This switches the two rejected-download paths to the fire-and-forget release used by the other generated-media owners, matching the decision already merged for the Ollama setup path in #111802 (`extensions/ollama/src/setup.ts:147`). Scope is deliberately limited to these two call sites; the surrounding validation, error wording, and byte caps are untouched.

## User Impact

With the debug proxy on, a malformed BytePlus or Runway video download now fails immediately with the existing `... generated video download: malformed video response` error instead of hanging until a timeout. With the proxy off, behavior is unchanged — the socket is still released, just without waiting on it.

## Evidence

**The mechanism, measured with a control arm** (`node v22.20.0`, plain web streams):

```
control (no clone)                : settled
teed, sibling live (await cancel) : PENDING
teed, both branches cancel        : settled
```

Only the teed-with-live-sibling arm fails to settle, which is the shape the capture clone produces.

**Regression tests.** One per provider, each building a real `Response`, cloning it as the debug proxy does, leaving the capture branch mid-read, then racing the download against a 500 ms deadline:

```
extensions/byteplus/video-generation-provider.test.ts
  ✓ releases a rejected download body without awaiting a debug-capture tee branch
extensions/runway/video-generation-provider.test.ts
  ✓ releases a rejected download body without awaiting a debug-capture tee branch

Test Files  2 passed (2)
     Tests  35 passed (35)
```

**Mutation control.** Reverting only the two production lines and re-running the same suites fails exactly the two new tests and nothing else, at the deadline rather than on the assertion:

```
× releases a rejected download body without awaiting a debug-capture tee branch 510ms
  Received: "BytePlus download waited for a captured response clone"
× releases a rejected download body without awaiting a debug-capture tee branch 521ms
  Received: "Runway download waited for a captured response clone"

Test Files  2 failed (2)
     Tests  2 failed | 33 passed (35)
```

The pre-existing `cancels the unread response body when a generated-video MIME type is rejected` tests pass either way — their stubbed `cancel` resolves immediately, so they cannot see this — which is why the new coverage builds a real tee.

**Gates.** `oxfmt --check` clean on the four files, `oxlint` clean on both extensions, `check-max-lines-ratchet` OK, and `tsgo --noEmit` reports nothing in these files.


### Real-runtime proof: shipped capture patch, real socket

Added after review. Harness on `node v24.15.0` that runs the real provider entry point
(`buildBytePlusVideoGenerationProvider().generateVideo` / the Runway equivalent) through the
real capture patch:

- `initializeDebugProxyCapture()` installs the shipped global-fetch patch;
  `isDebugProxyGlobalFetchPatchInstalled()` is asserted `true` before the run.
- A real `node:http` loopback origin serves the generated-media URL: HTTP 200,
  `content-type: application/json`, one chunk written and the body never ended.
- The media download is issued over real undici through that patched global fetch, so the
  response the provider holds is a live capture-clone tee branch, not a modeled one.
- Only the provider task API (create + poll) is served by a local stand-in, because it needs a
  paid account. It sits below the capture patch, so the download path is untouched. The SSRF
  guard dials undici directly when the caller fetch is identity-equal to `globalThis.fetch`
  (`src/infra/net/fetch-guard.ts:645-658`), so the harness re-wraps the patched chain under a
  fresh identity; that affects only the two task-API calls.

After fix, BytePlus:

```
[t+  807ms] debug-capture global fetch patch installed: true
[t+ 3039ms] calling byteplus generateVideo()
[t+ 5941ms] provider task API <- POST https://example.com/v1/contents/generations/tasks
[t+ 5951ms] provider task API <- GET  https://example.com/v1/contents/generations/tasks/proof-task
[t+ 5953ms] real undici fetch     -> GET http://127.0.0.1:52996/generated-video.mp4
[t+ 5962ms] loopback origin       <- GET /generated-video.mp4
[t+ 5963ms] loopback origin       -> headers sent, body left open (no end())
[t+ 5967ms] RESULT after 14ms after the media download started:
            BytePlus generated video download: malformed video response
```

After fix, Runway:

```
[t+ 5858ms] real undici fetch     -> GET http://127.0.0.1:50303/generated-video.mp4
[t+ 5868ms] loopback origin       -> headers sent, body left open (no end())
[t+ 5872ms] RESULT after 14ms after the media download started:
            Runway generated video download: malformed video response
```

Same harness, reverting only the two production lines to `await response.body?.cancel()`:

```
[t+ 8227ms] loopback origin       -> headers sent, body left open (no end())
[t+14835ms] RESULT after 6620ms after the media download started:
            HUNG: no result after 10000ms          (byteplus)

[t+ 6284ms] loopback origin       -> headers sent, body left open (no end())
[t+13429ms] RESULT after 7155ms after the media download started:
            HUNG: no result after 10000ms          (runway)
```

The full matrix isolates debug capture as the cause rather than the loopback origin or the
never-ending body:

| Provider | Debug capture | Rejected-download release | Outcome, measured from download start |
|---|---|---|---|
| BytePlus | on  | `await` (before this PR) | hung, no result within the 10 s budget |
| BytePlus | on  | `void` (this PR)         | `malformed video response` after 14 ms |
| BytePlus | off | `await` (before this PR) | `malformed video response` after 64 ms |
| BytePlus | off | `void` (this PR)         | `malformed video response` after 15 ms |
| Runway   | on  | `await` (before this PR) | hung, no result within the 10 s budget |
| Runway   | on  | `void` (this PR)         | `malformed video response` after 14 ms |

The hang appears only in the capture-on, `await` cell, which is the cell this PR removes.
