### PR TITLE
fix(media): fail closed when managed-media cleanup cannot read the session store

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -199,6 +199,7 @@ export function listSqliteSessionEntryKeysReadOnly(
 /** Exact persisted-key probe on the read-only handle, for per-row hot paths. */
 export function loadExactSqliteSessionEntryReadOnly(
   scope: SessionAccessScope,
+  options?: { strictStoreAvailable?: boolean },
 ): ExactSessionEntry | undefined {
   const sessionKey = scope.sessionKey.trim();
   if (!sessionKey) {
@@ -209,7 +210,17 @@ export function loadExactSqliteSessionEntryReadOnly(
     (database) => readExactSessionEntryRowValidated(database, sessionKey)?.entry,
     toDatabaseOptions(resolved),
   );
-  return result.found && result.value
+  if (!result.found) {
+    if (options?.strictStoreAvailable === true && result.reason !== "database-missing") {
+      // Fail-closed callers (destructive cleanup) must observe a present-but-
+      // unusable store (missing schema/tables) instead of an absent entry that
+      // looks like "no sessions". database-missing stays an absence: discovery
+      // legitimately probes candidate paths that may not exist yet.
+      throw new Error(`session store is unavailable (${result.reason}) for ${sessionKey}`);
+    }
+    return undefined;
+  }
+  return result.value
     ? {
         sessionKey,
         entry: scope.clone === false ? result.value : cloneSessionEntry(result.value),

--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -2181,5 +2181,23 @@ describe("cleanupManagedOutgoingImageRecords", () => {
     await expect(fs.access(fixture.originalPath)).resolves.toBeUndefined();
     expect(readSessionMessagesMock).not.toHaveBeenCalled();
   });
+
+  it("keeps ticket/HTTP ownership checks fail-closed when the store read throws", async () => {
+    const fixture = await createFixture(stateDir);
+    loadSessionEntryMock.mockImplementation(() => {
+      throw new Error("session store is unreadable");
+    });
+
+    // The non-strict path must not accept a thrown lookup as transcript
+    // ownership: no ticket may be minted, no media served.
+    const download = await resolveManagedOutgoingImageArtifactDownload({
+      sessionKey: fixture.sessionKey,
+      artifactId: `${MANAGED_OUTGOING_IMAGE_ARTIFACT_ID_PREFIX}${fixture.attachmentId}`,
+      stateDir,
+    });
+
+    expect(download).toBeNull();
+    expect(readSessionMessagesMock).not.toHaveBeenCalled();
+  });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -2182,21 +2182,23 @@ describe("cleanupManagedOutgoingImageRecords", () => {
     expect(readSessionMessagesMock).not.toHaveBeenCalled();
   });
 
-  it("keeps ticket/HTTP ownership checks fail-closed when the store read throws", async () => {
+  it("propagates store read errors on the ticket/HTTP path instead of minting a ticket", async () => {
     const fixture = await createFixture(stateDir);
     loadSessionEntryMock.mockImplementation(() => {
       throw new Error("session store is unreadable");
     });
 
-    // The non-strict path must not accept a thrown lookup as transcript
-    // ownership: no ticket may be minted, no media served.
-    const download = await resolveManagedOutgoingImageArtifactDownload({
-      sessionKey: fixture.sessionKey,
-      artifactId: `${MANAGED_OUTGOING_IMAGE_ARTIFACT_ID_PREFIX}${fixture.attachmentId}`,
-      stateDir,
-    });
-
-    expect(download).toBeNull();
+    // Non-strict artifact/HTTP readers keep the pre-existing error contract:
+    // an escaping lookup failure (for example a canonical-key migration error
+    // carrying openclaw doctor --fix guidance) propagates instead of degrading
+    // to an opaque null/404. No ticket is minted and no media is served.
+    await expect(
+      resolveManagedOutgoingImageArtifactDownload({
+        sessionKey: fixture.sessionKey,
+        artifactId: `${MANAGED_OUTGOING_IMAGE_ARTIFACT_ID_PREFIX}${fixture.attachmentId}`,
+        stateDir,
+      }),
+    ).rejects.toThrow("session store is unreadable");
     expect(readSessionMessagesMock).not.toHaveBeenCalled();
   });
 });

--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -2106,7 +2106,10 @@ describe("cleanupManagedOutgoingImageRecords", () => {
       agentId: "main",
     });
 
-    expect(loadSessionEntryMock).toHaveBeenCalledWith("global", { agentId: "main" });
+    expect(loadSessionEntryMock).toHaveBeenCalledWith("global", {
+      agentId: "main",
+      strictRead: true,
+    });
     expect(result.deletedRecordCount).toBe(1);
     expect(result.retainedCount).toBe(1);
     await expect(fs.access(retainedFixture.originalPath)).resolves.toBeUndefined();
@@ -2161,6 +2164,22 @@ describe("cleanupManagedOutgoingImageRecords", () => {
     expect(result.deletedRecordCount).toBe(1);
     expect(result.retainedCount).toBe(0);
     await expectPathMissing(fixture.originalPath);
+  });
+
+  it("retains records when the owning session store is unreadable (fail closed)", async () => {
+    const fixture = await createFixture(stateDir);
+    // A real unreadable store surfaces as a thrown read failure in strict mode
+    // (the store-lookup layer propagates it instead of degrading to an empty
+    // store). Cleanup must retain the record and its backing file.
+    loadSessionEntryMock.mockImplementation(() => {
+      throw new Error("session store is unreadable");
+    });
+
+    const result = await cleanupManagedOutgoingImageRecords({ stateDir });
+
+    expect(result).toEqual({ deletedRecordCount: 0, deletedFileCount: 0, retainedCount: 1 });
+    await expect(fs.access(fixture.originalPath)).resolves.toBeUndefined();
+    expect(readSessionMessagesMock).not.toHaveBeenCalled();
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -891,11 +891,17 @@ async function getSessionManagedOutgoingAttachmentIndex(
       : loadSessionEntryReadOnly(sessionKey);
     storePath = loaded.storePath;
     entry = loaded.entry;
-  } catch {
+  } catch (error) {
+    if (opts?.strictStore !== true) {
+      // Only strict cleanup reads convert failures into the unavailable
+      // sentinel. Artifact/HTTP readers must keep their existing error
+      // contract: canonical-key migration errors surface recovery guidance
+      // (openclaw doctor --fix) instead of degrading to an opaque 404.
+      throw error;
+    }
     // Fail closed: an unreadable session store is unknown retention state, not
     // proof the record is unreferenced. Cleanup retains the artifact and the
-    // next healthy sweep can decide. HTTP/artifact readers never pass
-    // strictStore, so they keep their existing unavailable-to-404 behavior.
+    // next healthy sweep can decide.
     const unavailable: SessionManagedOutgoingAttachmentIndexResult = { kind: "unavailable" };
     cache?.set(cacheKey, unavailable);
     return unavailable;

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -1020,7 +1020,11 @@ async function recordMatchesTranscriptMessage(
     opts,
   );
   if (result.kind === "unavailable") {
-    return "unavailable";
+    // The unavailable sentinel is reserved for the strict cleanup path, which
+    // retains media on unknown retention state. Ticket/HTTP readers never pass
+    // strictStore: an unavailable store must stay non-truthy (false) so their
+    // boolean negation keeps rejecting access, exactly as before this change.
+    return opts?.strictStore === true ? "unavailable" : false;
   }
   return (
     result.index?.has(

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -15,6 +15,7 @@ import { resolveDefaultAgentId } from "../agents/agent-scope-config.js";
 import type { ReplyMediaAttachment } from "../auto-reply/reply-payload.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
+import type { SessionEntry } from "../config/sessions.js";
 import { openLocalFileSafely, readLocalFileSafely } from "../infra/fs-safe.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
 import { assertLocalMediaAllowed, resolveLocalMediaRoots } from "../media/local-media-access.js";
@@ -112,6 +113,15 @@ type CleanupManagedOutgoingMediaRecordsResult = {
 };
 
 type SessionManagedOutgoingAttachmentIndex = Set<string>;
+
+/**
+ * Transcript attachment lookup outcome. Cleanup must not delete media when the
+ * owning session store is unreadable: an unavailable store is unknown retention
+ * state, not proof that a record is unreferenced.
+ */
+type SessionManagedOutgoingAttachmentIndexResult =
+  | { kind: "index"; index: SessionManagedOutgoingAttachmentIndex | null }
+  | { kind: "unavailable" };
 
 type SessionManagedOutgoingAttachmentIndexCacheEntry = {
   transcriptPath: string;
@@ -612,7 +622,7 @@ export async function cleanupManagedOutgoingMediaRecords(params?: {
   let retainedCount = 0;
   const transcriptAttachmentIndexCache = new Map<
     string,
-    SessionManagedOutgoingAttachmentIndex | null
+    SessionManagedOutgoingAttachmentIndexResult
   >();
   for (const entry of entries) {
     const { record } = entry;
@@ -639,10 +649,18 @@ export async function cleanupManagedOutgoingMediaRecords(params?: {
     ) {
       shouldDelete = true;
     } else if (!entry.cleanupPending && record.messageId) {
-      shouldDelete = !(await recordMatchesTranscriptMessage(
+      const referenced = await recordMatchesTranscriptMessage(
         record,
         transcriptAttachmentIndexCache,
-      ));
+        { strictStore: true },
+      );
+      if (referenced === "unavailable") {
+        // Unreadable session store is unknown retention state. Retain the record
+        // and its backing file; a later sweep on a healthy store decides.
+        retainedCount += 1;
+        continue;
+      }
+      shouldDelete = !referenced;
     } else if (!entry.cleanupPending) {
       const createdAtMs = Date.parse(record.createdAt);
       shouldDelete = Number.isFinite(createdAtMs) && nowMs - createdAtMs >= transientMaxAgeMs;
@@ -851,21 +869,42 @@ function sameManagedOutgoingAttachmentTranscriptStat(
 
 async function getSessionManagedOutgoingAttachmentIndex(
   sessionKey: string,
-  cache?: Map<string, SessionManagedOutgoingAttachmentIndex | null>,
+  cache?: Map<string, SessionManagedOutgoingAttachmentIndexResult>,
   agentId?: string,
-) {
+  opts?: { strictStore?: boolean },
+): Promise<SessionManagedOutgoingAttachmentIndexResult> {
   const cacheKey = buildSessionManagedOutgoingAttachmentIndexCacheKey(sessionKey, agentId);
   if (cache?.has(cacheKey)) {
-    return cache.get(cacheKey) ?? null;
+    return cache.get(cacheKey) ?? { kind: "index", index: null };
   }
-  const { storePath, entry } = loadSessionEntryReadOnly(
-    sessionKey,
-    sessionKey === "global" && agentId ? { agentId } : undefined,
-  );
+  let storePath: string;
+  let entry: SessionEntry | undefined;
+  try {
+    const readParams =
+      sessionKey === "global" && agentId
+        ? { agentId, ...(opts?.strictStore ? { strictRead: true } : {}) }
+        : opts?.strictStore
+          ? { strictRead: true }
+          : undefined;
+    const loaded = readParams
+      ? loadSessionEntryReadOnly(sessionKey, readParams)
+      : loadSessionEntryReadOnly(sessionKey);
+    storePath = loaded.storePath;
+    entry = loaded.entry;
+  } catch {
+    // Fail closed: an unreadable session store is unknown retention state, not
+    // proof the record is unreferenced. Cleanup retains the artifact and the
+    // next healthy sweep can decide. HTTP/artifact readers never pass
+    // strictStore, so they keep their existing unavailable-to-404 behavior.
+    const unavailable: SessionManagedOutgoingAttachmentIndexResult = { kind: "unavailable" };
+    cache?.set(cacheKey, unavailable);
+    return unavailable;
+  }
   const sessionId = entry?.sessionId;
   if (!sessionId) {
-    cache?.set(cacheKey, null);
-    return null;
+    const empty: SessionManagedOutgoingAttachmentIndexResult = { kind: "index", index: null };
+    cache?.set(cacheKey, empty);
+    return empty;
   }
 
   let transcriptStat: SessionManagedOutgoingAttachmentTranscriptStat | null = null;
@@ -891,8 +930,12 @@ async function getSessionManagedOutgoingAttachmentIndex(
         transcriptStat,
       );
       if (cachedIndex) {
-        cache?.set(cacheKey, cachedIndex);
-        return cachedIndex;
+        const result: SessionManagedOutgoingAttachmentIndexResult = {
+          kind: "index",
+          index: cachedIndex,
+        };
+        cache?.set(cacheKey, result);
+        return result;
       }
     } catch {
       sessionManagedOutgoingAttachmentIndexCache.delete(cacheKey);
@@ -957,24 +1000,32 @@ async function getSessionManagedOutgoingAttachmentIndex(
   if (transcriptStat) {
     setCachedSessionManagedOutgoingAttachmentIndex(sessionKey, agentId, transcriptStat, index);
   }
-  cache?.set(cacheKey, index);
-  return index;
+  const result: SessionManagedOutgoingAttachmentIndexResult = { kind: "index", index };
+  cache?.set(cacheKey, result);
+  return result;
 }
 
 async function recordMatchesTranscriptMessage(
   record: ManagedImageRecord,
-  cache?: Map<string, SessionManagedOutgoingAttachmentIndex | null>,
-) {
+  cache?: Map<string, SessionManagedOutgoingAttachmentIndexResult>,
+  opts?: { strictStore?: boolean },
+): Promise<boolean | "unavailable"> {
   if (!record.messageId) {
     return false;
   }
-  const index = await getSessionManagedOutgoingAttachmentIndex(
+  const result = await getSessionManagedOutgoingAttachmentIndex(
     record.sessionKey,
     cache,
     record.agentId,
+    opts,
   );
+  if (result.kind === "unavailable") {
+    return "unavailable";
+  }
   return (
-    index?.has(buildManagedOutgoingAttachmentRefKey(record.messageId, record.attachmentId)) ?? false
+    result.index?.has(
+      buildManagedOutgoingAttachmentRefKey(record.messageId, record.attachmentId),
+    ) ?? false
   );
 }
 

--- a/src/gateway/managed-image-attachments.unavailable-store.test.ts
+++ b/src/gateway/managed-image-attachments.unavailable-store.test.ts
@@ -41,7 +41,10 @@ vi.mock("./http-utils.js", () => ({
   resolveOpenAiCompatibleHttpSenderIsOwner: vi.fn(),
 }));
 
-import { cleanupManagedOutgoingMediaRecords } from "./managed-image-attachments.js";
+import {
+  cleanupManagedOutgoingMediaRecords,
+  resolveManagedOutgoingMediaArtifactDownload,
+} from "./managed-image-attachments.js";
 import {
   insertManagedImageRecord,
   MANAGED_OUTGOING_ORIGINALS_SUBDIR,
@@ -49,8 +52,11 @@ import {
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
-async function createManagedMediaFixture(stateDir: string, attachmentId: string) {
-  const sessionKey = "agent:main:main";
+async function createManagedMediaFixture(
+  stateDir: string,
+  attachmentId: string,
+  sessionKey = "agent:main:main",
+) {
   const filename = `${attachmentId}-cat-full.png`;
   const originalPath = path.join(stateDir, "media", MANAGED_OUTGOING_ORIGINALS_SUBDIR, filename);
   await fs.mkdir(path.dirname(originalPath), { recursive: true });
@@ -130,6 +136,90 @@ describe("cleanupManagedOutgoingMediaRecords with a real SQLite session store", 
       );
       const agentSqlitePath = await createRealSessionStore(stateDir);
       await fs.chmod(agentSqlitePath, 0o000);
+
+      const result = await cleanupManagedOutgoingMediaRecords({ stateDir });
+
+      expect(result).toEqual({ deletedRecordCount: 0, deletedFileCount: 0, retainedCount: 1 });
+      await expect(fs.access(fixture.originalPath)).resolves.toBeUndefined();
+    });
+  });
+});
+
+async function createDuplicateCanonicalKeyStore(stateDir: string): Promise<void> {
+  const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+  const database = openOpenClawAgentDatabase({ agentId: "main", env });
+  writeSessionEntry(database, "agent:main:work", {
+    sessionId: "sess-work",
+    updatedAt: Date.now(),
+  });
+  // Raw insert of the legacy ":main" alias row. Canonical write assertions
+  // refuse this key under mainKey "work"; this is the pre-repair state that
+  // openclaw doctor --fix owns, so it must keep surfacing as a migration
+  // error instead of an unavailable store.
+  database.db
+    .prepare(
+      "INSERT INTO session_nodes (session_key, current_session_id, entry_json, updated_at) VALUES (?, ?, ?, ?)",
+    )
+    .run(
+      "agent:main:main",
+      "sess-legacy-main",
+      JSON.stringify({ sessionId: "sess-legacy-main", updatedAt: 1 }),
+      1,
+    );
+  database.db
+    .prepare(
+      "INSERT INTO session_windows (session_id, session_key, created_at, updated_at) VALUES (?, ?, ?, ?)",
+    )
+    .run("sess-legacy-main", "agent:main:main", 1, 1);
+  // The insert trigger marks new rows pending (entry_valid = 0); settle this
+  // row the way ensureSessionEntryValidityProjection would after open.
+  database.db
+    .prepare("UPDATE session_nodes SET entry_valid = 1 WHERE session_key = ?")
+    .run("agent:main:main");
+  closeOpenClawAgentDatabasesForTest();
+}
+
+describe("managed media with a session store pending canonical-key repair", () => {
+  let stateDir: string;
+
+  beforeEach(() => {
+    stateDir = tempDirs.make("managed-image-canonical-migration-");
+    vi.clearAllMocks();
+    getRuntimeConfigMock.mockReturnValue({
+      agents: { list: [{ id: "main" }] },
+      session: { mainKey: "work" },
+    });
+  });
+
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+  });
+
+  it("surfaces canonical migration errors on the artifact read path instead of a 404", async () => {
+    await withEnvAsync({ ...process.env, OPENCLAW_STATE_DIR: stateDir }, async () => {
+      const attachmentId = "33333333-3333-4333-8333-333333333333";
+      await createManagedMediaFixture(stateDir, attachmentId, "agent:main:work");
+      await createDuplicateCanonicalKeyStore(stateDir);
+
+      await expect(
+        resolveManagedOutgoingMediaArtifactDownload({
+          sessionKey: "agent:main:work",
+          artifactId: `artifact_managed_image_${attachmentId}`,
+          stateDir,
+        }),
+      ).rejects.toThrow(/openclaw doctor --fix/);
+    });
+  });
+
+  it("retains managed media when the session store needs canonical-key repair", async () => {
+    await withEnvAsync({ ...process.env, OPENCLAW_STATE_DIR: stateDir }, async () => {
+      const fixture = await createManagedMediaFixture(
+        stateDir,
+        "44444444-4444-4444-8444-444444444444",
+        "agent:main:work",
+      );
+      await createDuplicateCanonicalKeyStore(stateDir);
 
       const result = await cleanupManagedOutgoingMediaRecords({ stateDir });
 

--- a/src/gateway/managed-image-attachments.unavailable-store.test.ts
+++ b/src/gateway/managed-image-attachments.unavailable-store.test.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { writeSessionEntry } from "../config/sessions/session-accessor.sqlite-entry-store.js";
+import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
@@ -136,6 +137,28 @@ describe("cleanupManagedOutgoingMediaRecords with a real SQLite session store", 
       );
       const agentSqlitePath = await createRealSessionStore(stateDir);
       await fs.chmod(agentSqlitePath, 0o000);
+
+      const result = await cleanupManagedOutgoingMediaRecords({ stateDir });
+
+      expect(result).toEqual({ deletedRecordCount: 0, deletedFileCount: 0, retainedCount: 1 });
+      await expect(fs.access(fixture.originalPath)).resolves.toBeUndefined();
+    });
+  });
+
+  it("retains a record when the session store is missing its session tables", async () => {
+    await withEnvAsync({ ...process.env, OPENCLAW_STATE_DIR: stateDir }, async () => {
+      const fixture = await createManagedMediaFixture(
+        stateDir,
+        "55555555-5555-4555-8555-555555555555",
+      );
+      const agentSqlitePath = await createRealSessionStore(stateDir);
+      // A store that opens but lost its session tables reports a non-throwing
+      // table-missing result on ordinary reads; strict cleanup must still
+      // treat it as unknown retention state, not as "no sessions".
+      const { DatabaseSync } = requireNodeSqlite();
+      const database = new DatabaseSync(agentSqlitePath);
+      database.exec("DROP TABLE session_nodes");
+      database.close();
 
       const result = await cleanupManagedOutgoingMediaRecords({ stateDir });
 

--- a/src/gateway/managed-image-attachments.unavailable-store.test.ts
+++ b/src/gateway/managed-image-attachments.unavailable-store.test.ts
@@ -1,0 +1,140 @@
+// Regression coverage for #119090: managed-media cleanup must fail closed when
+// the owning SQLite session store is unreadable. These tests drive the real
+// session-store lookup (no session-utils mock) against a real agent database,
+// so an unreadable store surfaces as a thrown read that cleanup must treat as
+// unknown retention state instead of proof the record is unreferenced.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { writeSessionEntry } from "../config/sessions/session-accessor.sqlite-entry-store.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { withEnvAsync } from "../test-utils/env.js";
+
+const getRuntimeConfigMock = vi.hoisted(() => vi.fn(() => ({})));
+
+vi.mock("../config/io.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/io.js")>();
+  return { ...actual, getRuntimeConfig: getRuntimeConfigMock };
+});
+vi.mock("../config/config.js", () => ({
+  getRuntimeConfig: getRuntimeConfigMock,
+}));
+vi.mock("./session-transcript-readers.js", () => ({
+  readSessionMessagesWithSourceAsync: vi.fn(async () => ({ messages: [], transcriptPath: null })),
+}));
+vi.mock("../media/media-probe.js", () => ({
+  probePlaybackMediaFileDescriptor: vi.fn(async () => ({ durationMs: 1000 })),
+}));
+vi.mock("../media/playback-transcode.js", () => ({
+  replacePlaybackFileExtension: vi.fn((value: string) => value),
+  resolvePlaybackModeForSource: vi.fn(async () => "native"),
+  resolvePlaybackTranscode: vi.fn(async () => ({ kind: "passthrough" })),
+}));
+vi.mock("./http-utils.js", () => ({
+  authorizeGatewayHttpRequestOrReply: vi.fn(),
+  resolveOpenAiCompatibleHttpOperatorScopes: vi.fn(),
+  resolveOpenAiCompatibleHttpSenderIsOwner: vi.fn(),
+}));
+
+import { cleanupManagedOutgoingMediaRecords } from "./managed-image-attachments.js";
+import {
+  insertManagedImageRecord,
+  MANAGED_OUTGOING_ORIGINALS_SUBDIR,
+} from "./managed-image-record-store.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+async function createManagedMediaFixture(stateDir: string, attachmentId: string) {
+  const sessionKey = "agent:main:main";
+  const filename = `${attachmentId}-cat-full.png`;
+  const originalPath = path.join(stateDir, "media", MANAGED_OUTGOING_ORIGINALS_SUBDIR, filename);
+  await fs.mkdir(path.dirname(originalPath), { recursive: true });
+  await fs.writeFile(originalPath, "original-image");
+  insertManagedImageRecord(
+    {
+      attachmentId,
+      sessionKey,
+      messageId: "msg-1",
+      createdAt: new Date().toISOString(),
+      alt: "Cat",
+      original: {
+        mediaRoot: path.join(stateDir, "media"),
+        mediaId: filename,
+        mediaSubdir: MANAGED_OUTGOING_ORIGINALS_SUBDIR,
+        contentType: "image/png",
+        width: 1024,
+        height: 768,
+        sizeBytes: 14,
+        filename: "cat.png",
+      },
+    },
+    stateDir,
+  );
+  return { sessionKey, originalPath };
+}
+
+async function createRealSessionStore(stateDir: string): Promise<string> {
+  const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+  const database = openOpenClawAgentDatabase({ agentId: "main", env });
+  writeSessionEntry(database, "agent:main:main", {
+    sessionId: "sess-main",
+    updatedAt: Date.now(),
+  });
+  closeOpenClawAgentDatabasesForTest();
+  return path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
+}
+
+describe("cleanupManagedOutgoingMediaRecords with a real SQLite session store", () => {
+  let stateDir: string;
+
+  beforeEach(() => {
+    stateDir = tempDirs.make("managed-image-unavailable-store-");
+    vi.clearAllMocks();
+    getRuntimeConfigMock.mockReturnValue({ agents: { list: [{ id: "main" }] } });
+  });
+
+  afterEach(async () => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    await fs
+      .chmod(path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite"), 0o644)
+      .catch(() => {});
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  it("deletes an unreferenced record when the session store is healthy", async () => {
+    await withEnvAsync({ ...process.env, OPENCLAW_STATE_DIR: stateDir }, async () => {
+      const fixture = await createManagedMediaFixture(
+        stateDir,
+        "11111111-1111-4111-8111-111111111111",
+      );
+      await createRealSessionStore(stateDir);
+
+      const result = await cleanupManagedOutgoingMediaRecords({ stateDir });
+
+      expect(result).toEqual({ deletedRecordCount: 1, deletedFileCount: 1, retainedCount: 0 });
+      await expect(fs.access(fixture.originalPath)).rejects.toMatchObject({ code: "ENOENT" });
+    });
+  });
+
+  it("retains a record when the session store is unreadable", async () => {
+    await withEnvAsync({ ...process.env, OPENCLAW_STATE_DIR: stateDir }, async () => {
+      const fixture = await createManagedMediaFixture(
+        stateDir,
+        "22222222-2222-4222-8222-222222222222",
+      );
+      const agentSqlitePath = await createRealSessionStore(stateDir);
+      await fs.chmod(agentSqlitePath, 0o000);
+
+      const result = await cleanupManagedOutgoingMediaRecords({ stateDir });
+
+      expect(result).toEqual({ deletedRecordCount: 0, deletedFileCount: 0, retainedCount: 1 });
+      await expect(fs.access(fixture.originalPath)).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/gateway/session-utils-store-lookup.ts
+++ b/src/gateway/session-utils-store-lookup.ts
@@ -186,12 +186,18 @@ function loadGatewaySessionLookupStoreUncached(
     if (options.exactKeys) {
       const store: Record<string, SessionEntry> = {};
       for (const sessionKey of options.exactKeys) {
-        const match = loadExactSessionEntryReadOnly({
-          ...(agentId ? { agentId } : {}),
-          clone: false,
-          sessionKey,
-          storePath,
-        });
+        // Strict readers must see a present-but-unusable store (missing schema
+        // or tables surface as a typed non-throwing result) as a failure, not
+        // as an absent entry.
+        const match = loadExactSessionEntryReadOnly(
+          {
+            ...(agentId ? { agentId } : {}),
+            clone: false,
+            sessionKey,
+            storePath,
+          },
+          options.strict ? { strictStoreAvailable: true } : undefined,
+        );
         if (match) {
           store[match.sessionKey] = match.entry;
         }

--- a/src/gateway/session-utils-store-lookup.ts
+++ b/src/gateway/session-utils-store-lookup.ts
@@ -151,11 +151,13 @@ function loadGatewaySessionLookupStore(
     cache?: GatewaySessionStoreCache;
     exactKeys?: readonly string[];
     projection?: SessionEntryListScope["projection"];
+    /** Propagate store-read failures instead of degrading to an empty store. */
+    strict?: boolean;
   } = {},
 ): Record<string, SessionEntry> {
   const cache = options.cache;
   const cacheKey = cache
-    ? `${storePath}\u0000${agentId ?? ""}\u0000${clone === false ? "0" : "1"}\u0000${options.readOnly ? "1" : "0"}\u0000${options.projection ?? "full"}\u0000${options.exactKeys?.join("\u0001") ?? ""}`
+    ? `${storePath}\u0000${agentId ?? ""}\u0000${clone === false ? "0" : "1"}\u0000${options.readOnly ? "1" : "0"}\u0000${options.projection ?? "full"}\u0000${options.exactKeys?.join("\u0001") ?? ""}\u0000${options.strict ? "1" : "0"}`
     : "";
   if (cache) {
     const cached = cache.get(cacheKey);
@@ -176,6 +178,8 @@ function loadGatewaySessionLookupStoreUncached(
     exactKeys?: readonly string[];
     readOnly?: boolean;
     projection?: SessionEntryListScope["projection"];
+    /** Propagate store-read failures instead of degrading to an empty store. */
+    strict?: boolean;
   } = {},
 ): Record<string, SessionEntry> {
   try {
@@ -205,7 +209,12 @@ function loadGatewaySessionLookupStoreUncached(
         storePath,
       }).map(({ sessionKey, entry }) => [sessionKey, entry]),
     );
-  } catch {
+  } catch (error) {
+    if (options.strict) {
+      // Fail-closed callers (destructive cleanup) must observe an unreadable
+      // store instead of receiving an empty store that looks like "no sessions".
+      throw error;
+    }
     return {};
   }
 }
@@ -221,6 +230,7 @@ function resolveGatewaySessionStoreLookup(params: {
   readOnly?: boolean;
   exactRead?: boolean;
   deferCanonicalValidation?: boolean;
+  strictRead?: boolean;
   storeCache?: GatewaySessionStoreCache;
   targetDiscoveryCache?: GatewaySessionStoreDiscoveryCache;
 }): {
@@ -253,6 +263,7 @@ function resolveGatewaySessionStoreLookup(params: {
       readOnly: params.readOnly || !configured,
       ...(params.exactRead ? { exactKeys: scanTargets } : {}),
       ...(params.projection ? { projection: params.projection } : {}),
+      ...(params.strictRead ? { strict: true } : {}),
       ...(params.storeCache ? { cache: params.storeCache } : {}),
     });
   const firstCandidate = candidates[0] ?? fallback;
@@ -316,6 +327,7 @@ function resolveExplicitDeletedLegacyMainStoreTarget(params: {
   projection?: SessionEntryListScope["projection"];
   readOnly?: boolean;
   exactRead?: boolean;
+  strictRead?: boolean;
   storeCache?: GatewaySessionStoreCache;
   targetDiscoveryCache?: GatewaySessionStoreDiscoveryCache;
 }): GatewaySessionStoreTargetWithStore | null {
@@ -367,6 +379,7 @@ function resolveExplicitDeletedLegacyMainStoreTarget(params: {
       readOnly: true,
       ...(params.exactRead ? { exactKeys: lookupSeeds } : {}),
       ...(params.projection ? { projection: params.projection } : {}),
+      ...(params.strictRead ? { strict: true } : {}),
       ...(params.storeCache ? { cache: params.storeCache } : {}),
     });
     const match = findCanonicalStoreMatch(store, lookupSeeds, recordCanonicalError);
@@ -417,6 +430,7 @@ export function resolveGatewaySessionStoreTargetWithStore(params: {
   readOnly?: boolean;
   exactRead?: boolean;
   deferCanonicalValidation?: boolean;
+  strictRead?: boolean;
   includeStoreChildEntries?: boolean;
   store?: Record<string, SessionEntry>;
   storeCache?: GatewaySessionStoreCache;
@@ -430,6 +444,7 @@ export function resolveGatewaySessionStoreTargetWithStore(params: {
     ...(params.deferCanonicalValidation ? { deferCanonicalValidation: true } : {}),
     readOnly: params.readOnly,
     exactRead: params.exactRead,
+    ...(params.strictRead ? { strictRead: true } : {}),
     ...(params.projection ? { projection: params.projection } : {}),
     ...(params.storeCache ? { storeCache: params.storeCache } : {}),
     ...(params.targetDiscoveryCache ? { targetDiscoveryCache: params.targetDiscoveryCache } : {}),
@@ -457,6 +472,7 @@ export function resolveGatewaySessionStoreTargetWithStore(params: {
       readOnly: true,
       ...(params.exactRead ? { exactKeys: [canonicalKey] } : {}),
       ...(params.projection ? { projection: params.projection } : {}),
+      ...(params.strictRead ? { strict: true } : {}),
       ...(params.storeCache ? { cache: params.storeCache } : {}),
     });
     return includeDirectChildEntries(
@@ -479,6 +495,7 @@ export function resolveGatewaySessionStoreTargetWithStore(params: {
     readOnly: params.readOnly,
     exactRead: params.exactRead,
     deferCanonicalValidation: params.deferCanonicalValidation,
+    strictRead: params.strictRead,
     initialStore: params.store,
     ...(params.projection ? { projection: params.projection } : {}),
     ...(params.storeCache ? { storeCache: params.storeCache } : {}),

--- a/src/gateway/session-utils-store.ts
+++ b/src/gateway/session-utils-store.ts
@@ -123,7 +123,14 @@ function readAcpMetaForDeletedAgentCheck(params: {
 
 function loadSessionEntryWithMode(
   sessionKey: string,
-  opts: { agentId?: string; clone?: boolean; includeStoreChildEntries?: boolean } | undefined,
+  opts:
+    | {
+        agentId?: string;
+        clone?: boolean;
+        includeStoreChildEntries?: boolean;
+        strictRead?: boolean;
+      }
+    | undefined,
   readOnly: boolean,
 ) {
   const cfg = getRuntimeConfig();
@@ -138,6 +145,7 @@ function loadSessionEntryWithMode(
           exactRead: true,
           readOnly: true,
           ...(opts?.includeStoreChildEntries ? { includeStoreChildEntries: true } : {}),
+          ...(opts?.strictRead ? { strictRead: true } : {}),
         }
       : {}),
   });
@@ -166,7 +174,12 @@ export function loadSessionEntry(sessionKey: string, opts?: { agentId?: string; 
 
 export function loadSessionEntryReadOnly(
   sessionKey: string,
-  opts?: { agentId?: string; clone?: boolean; includeStoreChildEntries?: boolean },
+  opts?: {
+    agentId?: string;
+    clone?: boolean;
+    includeStoreChildEntries?: boolean;
+    strictRead?: boolean;
+  },
 ) {
   return loadSessionEntryWithMode(sessionKey, opts, true);
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes #119090 (P0 data loss). Managed outgoing media cleanup deletes a session's generated media permanently when the owning SQLite session store is unreadable (permissions, I/O error, corrupt/locked database). The transcript survives with dead URLs; the originals and their SQLite records are gone with no archive or recovery path.

The sweep is reachable from an ordinary `chat.history` read.

## Why This Change Was Made

Root cause: `loadGatewaySessionLookupStoreUncached` swallows any session-store read failure into `{}`. Cleanup then treats the missing session entry as "unreferenced" and force-removes the managed-media originals plus their records — an unreadable store is misread as proof of orphanhood.

This follows the ClawSweeper best-fix recommendation for #119090: only the destructive cleanup path (`strictStore`) translates store-read failures into the unavailable/retain outcome. Non-strict artifact and HTTP readers keep their pre-existing error contract: canonical-key migration errors still surface `openclaw doctor --fix` recovery guidance instead of degrading to an opaque 404.

## User Impact

Before: a single `chat.history` read after any store read failure permanently deletes generated images/audio/video for that session, with surviving transcript URLs returning 404 and no recovery path.

After: an unreadable session store is treated as unknown retention state. Cleanup retains the records and backing files; a later sweep on a healthy store decides. Artifact/HTTP reads keep surfacing canonical migration errors with their recovery guidance.

## Evidence

### Real behavior proof: isolated gateway `chat.history` run (exact head, built from source)

Gateway built from this branch (`pnpm build`), run with an isolated `OPENCLAW_STATE_DIR`, token auth, real SQLite state. A managed media record + original file were seeded, then `openclaw gateway call chat.history --params '{"sessionKey":"agent:main:main"}'` was issued over the real WebSocket RPC (the operator path that schedules the cleanup sweep).

A/B result:

- **Healthy store (control):** `chat.history` → sweep ran → original file deleted and record row removed (records table empty afterwards). This proves the sweep actually executes on this path and would have deleted the media.
- **Unreadable store (agent DB corrupted; gateway log shows `database disk image is malformed`):** `chat.history` returned 200 with empty history → sweep ran → **media file and record retained**. A later sweep on a healthy store can decide.

### Regression coverage (real SQLite boundary, no session-utils mock)

**Test file:** `src/gateway/managed-image-attachments.unavailable-store.test.ts`

- `retains a record when the session store is unreadable` (chmod 000)
- `surfaces canonical migration errors on the artifact read path instead of a 404` — red on the previous head (returned `null`); green now: rejects with the migration-required error carrying `openclaw doctor --fix` guidance
- `retains managed media when the session store needs canonical-key repair` — duplicate canonical-key rows make cleanup retain instead of delete
- `deletes an unreferenced record when the session store is healthy` (control)

**Test file:** `src/gateway/managed-image-attachments.test.ts`

- Updated the ticket/HTTP test to assert the restored contract: an escaping store-read error propagates to the caller; no ticket is minted and no media is served.

### Test output (exact head)

```
src/gateway/managed-image-attachments.test.ts                     76 passed
src/gateway/managed-image-attachments.unavailable-store.test.ts    4 passed
src/gateway/session-utils.test.ts                                160 passed
src/gateway/sessions-history-http.test.ts                         72 passed (incl. the 409 migration_required contract)
```
