### PR TITLE
[AI-assisted] fix(agents): models auth order set drops inherited profile IDs

### DIFF
--- a/src/agents/auth-profiles/profiles.test.ts
+++ b/src/agents/auth-profiles/profiles.test.ts
@@ -22,6 +22,7 @@ import {
   promoteAuthProfileInOrder,
   removeAuthProfilesAcrossOwnerStores,
   removeAuthProfilesWithLock,
+  setAuthProfileOrder,
   upsertAuthProfileWithLock,
 } from "./profiles.js";
 import {
@@ -1398,4 +1399,50 @@ describe("promoteAuthProfileInOrder", () => {
     });
   });
 });
+
+describe("setAuthProfileOrder", () => {
+  it("preserves inherited main OAuth profile IDs in a custom agent order", async () => {
+    await withAuthProfileTestState(
+      "openclaw-auth-order-set-inherited-",
+      async ({ agentDirFor }) => {
+        const mainAgentDir = agentDirFor("main");
+        const customAgentDir = agentDirFor("custom");
+        fs.mkdirSync(mainAgentDir, { recursive: true });
+        fs.mkdirSync(customAgentDir, { recursive: true });
+        const inheritedProfileId = "openai:shared";
+        saveAuthProfileStore(
+          {
+            version: AUTH_STORE_VERSION,
+            profiles: {
+              [inheritedProfileId]: {
+                type: "oauth",
+                provider: "openai",
+                access: "inherited-access",
+                refresh: "inherited-refresh",
+                expires: Date.now() + 60_000,
+              },
+            },
+          },
+          mainAgentDir,
+        );
+
+        const updated = await setAuthProfileOrder({
+          agentDir: customAgentDir,
+          provider: "openai",
+          order: [inheritedProfileId],
+        });
+
+        expect(updated?.order?.["openai"]).toEqual([inheritedProfileId]);
+        expect(loadAuthProfileStoreForRuntime(customAgentDir).order?.["openai"]).toEqual([
+          inheritedProfileId,
+        ]);
+        expect(loadPersistedAuthProfileStore(customAgentDir)?.order?.["openai"]).toEqual([
+          inheritedProfileId,
+        ]);
+      },
+      { clearOAuthDir: true },
+    );
+  });
+});
+
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/auth-profiles/profiles.ts
+++ b/src/agents/auth-profiles/profiles.ts
@@ -88,6 +88,7 @@ export async function setAuthProfileOrder(params: {
 
   return await updateAuthProfileStoreWithLock({
     agentDir: params.agentDir,
+    ...(deduped.length > 0 ? { saveOptions: { preserveOrderProfileIds: deduped } } : {}),
     updater: (store) => {
       store.order = store.order ?? {};
       if (deduped.length === 0) {


### PR DESCRIPTION
Closes openclaw/openclaw#119233

## What Problem This Solves

Fixes an issue where `openclaw models auth order set --provider <p> <inheritedProfileId...>` on a secondary agent reports success but the inherited main OAuth profile IDs silently disappear from the saved order. The CLI validated the IDs against the merged runtime store (which includes inherited profiles), but the subsequent locked save pruned them because they were not owned by the local agent store.

## Why This Change Was Made

`setAuthProfileOrder` now passes `saveOptions: { preserveOrderProfileIds: deduped }` into `updateAuthProfileStoreWithLock` when the requested order is non-empty, mirroring the existing `promoteAuthProfileInOrder` path. This tells `buildLocalAuthProfileStoreForSave` to keep the requested profile IDs in `order` even when they are inherited from the main agent and do not otherwise exist in the local store.

## User Impact

Users can now set an auth profile order override on a secondary agent that references inherited main OAuth profiles, and the order will survive in the persisted auth store and be reflected on subsequent `models auth order get` or `models auth list` calls.

## Evidence

- Added a focused regression test in `src/agents/auth-profiles/profiles.test.ts` that reproduces the exact scenario: a custom agent whose only matching credential is an OAuth profile inherited from the main store; it sets the provider order to that inherited profile and asserts the order persists after a runtime reload.
- All 28 `profiles.test.ts` tests pass, including the new regression test:
  `node scripts/run-vitest.mjs src/agents/auth-profiles/profiles.test.ts` (28/28)
- `pnpm tsgo:core` passes with no new type errors.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/auth-profiles/profiles.ts src/agents/auth-profiles/profiles.test.ts` reports 0 warnings and 0 errors.
- `pnpm exec oxfmt --check` reports both changed files are correctly formatted.

[AI-assisted] This PR was prepared with AI assistance and has been verified against the current `upstream/main` source and the focused regression test above.
