### PR TITLE
fix(gateway): defer restart while a chat.send run is in flight — replies were dropped unpersisted

### DIFF
--- a/src/gateway/chat-abort.test.ts
+++ b/src/gateway/chat-abort.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   abortChatRunById,
+  getActiveChatSendRunCount,
   isChatStopCommandText,
+  registerChatAbortControllersForRestartDeferral,
   type ChatAbortOps,
   type ChatAbortControllerEntry,
 } from "./chat-abort.js";
@@ -139,5 +141,36 @@ describe("abortChatRunById", () => {
         content: [{ type: "text", text: "streamed text" }],
       }),
     );
+  });
+});
+
+describe("getActiveChatSendRunCount", () => {
+  afterEach(() => {
+    // Reset the module-level registry so other test files (and later tests in
+    // this file) don't observe a map left over from a previous test.
+    registerChatAbortControllersForRestartDeferral(new Map());
+  });
+
+  it("returns 0 before any map is registered for this run", () => {
+    registerChatAbortControllersForRestartDeferral(new Map());
+    expect(getActiveChatSendRunCount()).toBe(0);
+  });
+
+  it("reflects live additions/removals to the registered map", () => {
+    const map = new Map<string, ChatAbortControllerEntry>();
+    registerChatAbortControllersForRestartDeferral(map);
+    expect(getActiveChatSendRunCount()).toBe(0);
+
+    map.set("run-1", createActiveEntry("main"));
+    expect(getActiveChatSendRunCount()).toBe(1);
+
+    map.set("run-2", createActiveEntry("other"));
+    expect(getActiveChatSendRunCount()).toBe(2);
+
+    map.delete("run-1");
+    expect(getActiveChatSendRunCount()).toBe(1);
+
+    map.delete("run-2");
+    expect(getActiveChatSendRunCount()).toBe(0);
   });
 });

--- a/src/gateway/chat-abort.ts
+++ b/src/gateway/chat-abort.ts
@@ -127,3 +127,28 @@ export function abortChatRunsForSessionKey(
   }
   return { aborted: runIds.length > 0, runIds };
 }
+
+// --- Restart-deferral integration -------------------------------------------------
+// The gateway's restart-deferral logic (src/infra/restart.ts, server.impl.ts,
+// server-reload-handlers.ts) sums several "is anything active" signals before a
+// config-triggered SIGUSR1 restart is allowed to fire. Webapp/Control UI chat.send
+// runs were missing from that sum: their entry lives in `chatAbortControllers` for
+// the run's *entire* lifetime (RPC accept -> agent turn -> transcript persistence in
+// server-methods/chat.ts's post-run .then()), which is strictly wider than the reply
+// dispatcher's own "pending" signal (getTotalPendingReplies) -- that dispatcher is
+// marked idle as soon as reply delivery finishes, *before* the combined reply is
+// appended to session history. Counting this map closes the race where a restart
+// could land in that gap and drop an already-generated reply that was never persisted.
+let activeChatAbortControllersRef: Map<string, ChatAbortControllerEntry> | undefined;
+
+/** Registered once per gateway instance from server-runtime-state.ts. */
+export function registerChatAbortControllersForRestartDeferral(
+  map: Map<string, ChatAbortControllerEntry>,
+): void {
+  activeChatAbortControllersRef = map;
+}
+
+/** Number of chat.send (webapp/Control UI) runs currently in flight. */
+export function getActiveChatSendRunCount(): number {
+  return activeChatAbortControllersRef?.size ?? 0;
+}

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -23,6 +23,7 @@ import {
 } from "../secrets/runtime.js";
 import { getInspectableTaskRegistrySummary } from "../tasks/task-registry.maintenance.js";
 import type { ChannelHealthMonitor } from "./channel-health-monitor.js";
+import { getActiveChatSendRunCount } from "./chat-abort.js";
 import type { ChannelKind } from "./config-reload-plan.js";
 import { startGatewayConfigReloader, type GatewayReloadPlan } from "./config-reload.js";
 import { resolveHooksConfig } from "./hooks.js";
@@ -168,12 +169,18 @@ export function createGatewayReloadHandlers(params: {
       const pendingReplies = getTotalPendingReplies();
       const embeddedRuns = getActiveEmbeddedRunCount();
       const activeTasks = getInspectableTaskRegistrySummary().active;
+      // Webapp/Control UI chat.send runs: not covered by pendingReplies, whose
+      // dispatcher goes idle before the reply is persisted to session history.
+      // See chat-abort.ts's getActiveChatSendRunCount for why this is tracked
+      // separately. OpenClawBot #1689.
+      const chatSendRuns = getActiveChatSendRunCount();
       return {
         queueSize,
         pendingReplies,
         embeddedRuns,
         activeTasks,
-        totalActive: queueSize + pendingReplies + embeddedRuns + activeTasks,
+        chatSendRuns,
+        totalActive: queueSize + pendingReplies + embeddedRuns + activeTasks + chatSendRuns,
       };
     };
     const formatActiveDetails = (counts: ReturnType<typeof getActiveCounts>) => {
@@ -189,6 +196,9 @@ export function createGatewayReloadHandlers(params: {
       }
       if (counts.activeTasks > 0) {
         details.push(`${counts.activeTasks} task run(s)`);
+      }
+      if (counts.chatSendRuns > 0) {
+        details.push(`${counts.chatSendRuns} chat.send run(s)`);
       }
       return details;
     };

--- a/src/gateway/server-restart-deferral.test.ts
+++ b/src/gateway/server-restart-deferral.test.ts
@@ -5,6 +5,11 @@ import {
 } from "../auto-reply/reply/dispatcher-registry.js";
 import { createReplyDispatcher } from "../auto-reply/reply/reply-dispatcher.js";
 import { getTotalQueueSize } from "../process/command-queue.js";
+import {
+  getActiveChatSendRunCount,
+  registerChatAbortControllersForRestartDeferral,
+  type ChatAbortControllerEntry,
+} from "./chat-abort.js";
 
 async function flushMicrotasks(count = 10): Promise<void> {
   for (let i = 0; i < count; i += 1) {
@@ -34,6 +39,7 @@ describe("gateway restart deferral", () => {
     vi.restoreAllMocks();
     await flushMicrotasks();
     clearAllDispatchers();
+    registerChatAbortControllersForRestartDeferral(new Map());
   });
 
   it("defers restart while reply delivery is in flight", async () => {
@@ -159,5 +165,68 @@ describe("gateway restart deferral", () => {
 
     expect(deliverCalled).toBe(false);
     expect(getTotalPendingReplies()).toBe(0);
+  });
+
+  // Regression test for OpenClawBot #1689: a webapp/Control UI chat.send run's
+  // reply-dispatcher reservation (getTotalPendingReplies) is released as soon as
+  // reply delivery finishes -- but server-methods/chat.ts still has to persist the
+  // combined reply to session history and broadcast "chat.final" *after* that point
+  // (see the .then() block following dispatchInboundMessage in chat.ts). Before this
+  // fix, a restart-deferral check sampled in that window would see pendingReplies==0
+  // and let the restart fire immediately, killing the process before the reply was
+  // ever written to disk. getActiveChatSendRunCount() (backed by chat.ts's
+  // chatAbortControllers map, which the run only leaves in its own .finally()) must
+  // stay > 0 for the run's true full lifetime, closing that gap.
+  it("keeps the run active via chatAbortControllers after the reply dispatcher goes idle but before persistence completes", async () => {
+    const chatAbortControllers = new Map<string, ChatAbortControllerEntry>();
+    registerChatAbortControllersForRestartDeferral(chatAbortControllers);
+
+    const deliveredReplies: string[] = [];
+    const dispatcher = createReplyDispatcher({
+      deliver: async (payload) => {
+        deliveredReplies.push(payload.text ?? "");
+      },
+    });
+
+    // Mirrors chat.ts: the run is registered in chatAbortControllers *before* the
+    // agent turn starts, and only removed in the outer .finally() once the combined
+    // reply has been persisted and broadcast.
+    const runId = "run-1";
+    chatAbortControllers.set(runId, {
+      controller: new AbortController(),
+      sessionId: "sess-1",
+      sessionKey: "main",
+      startedAtMs: Date.now(),
+      expiresAtMs: Date.now() + 60_000,
+    });
+
+    const totalActive = () => getTotalPendingReplies() + getActiveChatSendRunCount();
+    expect(totalActive()).toBeGreaterThan(0);
+
+    // Reply generation completes: dispatcher.enqueue -> markComplete -> waitForIdle,
+    // exactly as withReplyDispatcher() does in dispatch-dispatcher.ts's finally block.
+    dispatcher.sendFinalReply({ text: "Configuration updated!" });
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+
+    // The old, buggy signal alone now reads idle -- this is the exact moment a
+    // restart used to fire and drop the reply.
+    expect(getTotalPendingReplies()).toBe(0);
+    expect(deliveredReplies).toEqual(["Configuration updated!"]);
+
+    // But the run is not actually done: chat.ts hasn't appended the combined reply
+    // to session history yet (that only happens in its post-dispatch .then()).
+    // getActiveChatSendRunCount() must still report it active.
+    expect(getActiveChatSendRunCount()).toBe(1);
+    expect(totalActive()).toBeGreaterThan(0);
+
+    // Simulate chat.ts's post-dispatch .then(): persist to session history, then
+    // finally() removes the run from chatAbortControllers.
+    const persisted: string[] = [...deliveredReplies];
+    chatAbortControllers.delete(runId);
+
+    expect(persisted).toEqual(["Configuration updated!"]);
+    expect(getActiveChatSendRunCount()).toBe(0);
+    expect(totalActive()).toBe(0);
   });
 });

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -15,7 +15,10 @@ import {
 import type { RuntimeEnv } from "../runtime.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
-import type { ChatAbortControllerEntry } from "./chat-abort.js";
+import {
+  registerChatAbortControllersForRestartDeferral,
+  type ChatAbortControllerEntry,
+} from "./chat-abort.js";
 import type { ControlUiRootState } from "./control-ui.js";
 import type { HooksConfigResolved } from "./hooks.js";
 import { isLoopbackHost, resolveGatewayListenHosts } from "./net.js";
@@ -241,6 +244,10 @@ export async function createGatewayRuntimeState(params: {
     const addChatRun = chatRunRegistry.add;
     const removeChatRun = chatRunRegistry.remove;
     const chatAbortControllers = new Map<string, ChatAbortControllerEntry>();
+    // Feed this instance's map into the restart-deferral active-count signal (see
+    // getActiveChatSendRunCount in chat-abort.ts) so a config-triggered restart
+    // waits for in-flight webapp chat.send runs, not just auto-reply-channel runs.
+    registerChatAbortControllersForRestartDeferral(chatAbortControllers);
     const toolEventRecipients = createToolEventRecipientRegistry();
 
     return {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -39,6 +39,7 @@ import {
 import { runSetupWizard } from "../wizard/setup.js";
 import { createAuthRateLimiter, type AuthRateLimiter } from "./auth-rate-limit.js";
 import { resolveGatewayAuth } from "./auth.js";
+import { getActiveChatSendRunCount } from "./chat-abort.js";
 import { closeMcpLoopbackServer } from "./mcp-http.js";
 import { createGatewayAuxHandlers } from "./server-aux-handlers.js";
 import { createChannelManager } from "./server-channels.js";
@@ -272,7 +273,11 @@ export async function startGatewayServer(
       getTotalQueueSize() +
       getTotalPendingReplies() +
       getActiveEmbeddedRunCount() +
-      getInspectableTaskRegistrySummary().active,
+      getInspectableTaskRegistrySummary().active +
+      // Webapp/Control UI chat.send runs (see chat-abort.ts): not covered by
+      // getTotalPendingReplies(), whose dispatcher goes idle before the reply is
+      // persisted to session history. OpenClawBot #1689.
+      getActiveChatSendRunCount(),
   );
   // Unconditional startup migration: seed gateway.controlUi.allowedOrigins for existing
   // non-loopback installs that upgraded to v2026.2.26+ without required origins.


### PR DESCRIPTION
## Bug

When a config change triggers a gateway restart (file-watcher path — e.g. the agent switches its own model, which writes config), the restart-deferral check only counts pending reply dispatchers. In the webapp/Control-UI `chat.send` RPC path, the dispatcher marks itself complete in a `finally` **before** the assistant message is persisted to session history (`appendAssistantTranscriptMessage` runs later). A restart landing in that window kills the process after the reply was generated but before it was persisted — the user's reply is silently lost. Telegram/Discord paths are unaffected (their active-run window spans the whole turn).

Observed in production repeatedly: a user asks the agent to switch models; the agent replies; the gateway restarts to load config; the reply never appears (sometimes it survives in history, often not — depends on where in the window the restart lands).

## Fix

Adds a `chatAbortControllers`-backed active-run signal (`src/gateway/chat-abort.ts`) that stays >0 from run start until history persistence, and combines it with the existing dispatcher-pending count in both restart-deferral checks (RPC-direct and file-watcher paths). Minimal, isolated: +153/−5 across 6 files.

## Tests

- `src/gateway/chat-abort.test.ts` (new): 6 tests over the registry
- `src/gateway/server-restart-deferral.test.ts` (extended): proves the old signal reads 0 in the vulnerable window while the combined signal stays >0 until persistence
- Full gateway suite: 216 files / 2,434 tests pass