### PR TITLE
fix(telegram): reject webhook and health route collisions

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -796,6 +796,8 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
   <Accordion title="Long polling vs webhook">
     Default is long polling. For webhook mode, set `channels.telegram.webhookUrl` and `channels.telegram.webhookSecret`; optional `webhookPath` (default `/telegram-webhook`), `webhookHost` (default `127.0.0.1`), `webhookPort` (default `8787`), `webhookCertPath` (self-signed cert PEM for direct-IP or no-domain setups).
 
+    The listener reserves `/healthz` for health checks, so `webhookPath` must use a different route. If an existing setup uses `/healthz`, choose another route, update the path in `webhookUrl` and the reverse proxy mapping, then restart OpenClaw.
+
     In long-polling mode, OpenClaw persists its restart watermark only after an update dispatches successfully; a failed handler leaves that update retryable in the same process instead of marking it completed.
 
     The local listener binds to `127.0.0.1:8787` by default. For public ingress, put a reverse proxy in front of the local port, or set `webhookHost: "0.0.0.0"` intentionally.

--- a/extensions/telegram/src/doctor.test.ts
+++ b/extensions/telegram/src/doctor.test.ts
@@ -534,6 +534,62 @@ describe("telegram doctor", () => {
     expect(warnings[1]).toContain(DOCTOR_FIX_COMMAND);
   });
 
+  it("warns only when a selected webhook account uses the reserved health path", async () => {
+    listTelegramAccountIdsMock.mockReturnValue(["ops"]);
+    const cfg = {
+      channels: {
+        telegram: {
+          enabled: true,
+          webhookUrl: "https://example.test/healthz",
+          webhookPath: "/healthz",
+          accounts: {
+            ops: {
+              botToken: "123:abc",
+              webhookUrl: "https://example.test/ops",
+              webhookPath: "/ops",
+            },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    expect((await collectPreviewWarnings(cfg)).join("\n")).not.toContain("reserved");
+
+    cfg.channels.telegram.accounts.ops.webhookUrl = "https://example.test/healthz";
+    cfg.channels.telegram.accounts.ops.webhookPath = "/healthz";
+
+    expect((await collectPreviewWarnings(cfg)).join("\n")).toContain(
+      'Telegram account "ops" resolves webhookPath to /healthz, which is reserved',
+    );
+
+    const disabledCfg = {
+      ...cfg,
+      channels: { telegram: { ...cfg.channels.telegram, enabled: false } },
+    } satisfies OpenClawConfig;
+    expect((await collectPreviewWarnings(disabledCfg)).join("\n")).not.toContain("reserved");
+  });
+
+  it("identifies an explicit default account in the webhook path warning", async () => {
+    listTelegramAccountIdsMock.mockReturnValue(["default"]);
+    const cfg = {
+      channels: {
+        telegram: {
+          accounts: {
+            default: {
+              botToken: "123:abc",
+              webhookUrl: "https://example.test/healthz",
+              webhookPath: "/healthz",
+            },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    expect((await collectPreviewWarnings(cfg)).join("\n")).toContain(
+      'Telegram account "default" resolves webhookPath to /healthz, which is reserved',
+    );
+  });
+
   it("warns and repairs Telegram apiRoot values that include the bot endpoint", async () => {
     const cfg = {
       channels: {

--- a/extensions/telegram/src/doctor.ts
+++ b/extensions/telegram/src/doctor.ts
@@ -16,6 +16,7 @@ import {
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { inspectTelegramAccount } from "./account-inspect.js";
 import {
+  listEnabledTelegramAccounts,
   listTelegramAccountIds,
   mergeTelegramAccountConfig,
   resolveDefaultTelegramAccountId,
@@ -584,6 +585,12 @@ export const telegramDoctor: ChannelDoctorAdapter = {
       hits: scanTelegramBotEndpointApiRoots(cfg),
       doctorFixCommand,
     }),
+    ...listEnabledTelegramAccounts(cfg)
+      .filter(({ config }) => Boolean(config.webhookUrl) && config.webhookPath === "/healthz")
+      .map(
+        ({ accountId }) =>
+          `- Telegram account "${accountId}" resolves webhookPath to /healthz, which is reserved for webhook listener health checks. Change webhookPath and the public webhook URL or proxy route before restarting OpenClaw.`,
+      ),
     ...collectTelegramSelectedQuoteToolProgressWarnings({
       hits: scanTelegramSelectedQuoteToolProgressWarnings(cfg),
     }),

--- a/extensions/telegram/src/webhook.test.ts
+++ b/extensions/telegram/src/webhook.test.ts
@@ -2609,6 +2609,13 @@ describe("startTelegramWebhook", () => {
     ).rejects.toThrow(/requires a non-empty secret token/i);
   });
 
+  it("rejects startup when the webhook path collides with the health path", async () => {
+    await expect(
+      withStartedWebhook({ secret: TELEGRAM_SECRET, path: "/healthz" }, async () => undefined),
+    ).rejects.toThrow(/webhook path.*conflicts with.*health/i);
+    expect(setWebhookSpy).not.toHaveBeenCalled();
+  });
+
   it("registers webhook using the bound listening port when port is 0", async () => {
     setWebhookSpy.mockClear();
     const runtimeLog = vi.fn();

--- a/extensions/telegram/src/webhook.ts
+++ b/extensions/telegram/src/webhook.ts
@@ -314,6 +314,9 @@ export async function startTelegramWebhook(opts: {
 }) {
   const path = opts.path ?? "/telegram-webhook";
   const healthPath = opts.healthPath ?? "/healthz";
+  if (path === healthPath) {
+    throw new Error(`Telegram webhook path "${path}" conflicts with the health path.`);
+  }
   const port = opts.port ?? 8787;
   const host = opts.host ?? "127.0.0.1";
   const secret = normalizeOptionalString(opts.secret) ?? "";


### PR DESCRIPTION
## What Problem This Solves

Setting `channels.telegram.webhookPath` to `/healthz` silently drops Telegram updates. The live Bot API POST receives `200 ok`, but no update reaches the ingress spool or agent.

## Root cause

The standalone webhook server checked its fixed health route before its configurable webhook route. Startup allowed both routes to be identical, making every Telegram POST a health request.

## Fix

Reject an identical webhook and health path at `startTelegramWebhook`, before bot creation, listener binding, or webhook registration. Add an owner-boundary regression that asserts startup fails and `setWebhook` is never called. Telegram Doctor warns enabled webhook accounts using the reserved path; it reuses canonical enabled-account selection. Document `/healthz` and recovery.

## Evidence

Before the fix, a real Telegram user sent an update to a webhook advertised at `/healthz`: OpenClaw received a 400-byte `POST /healthz`, returned `200 ok`, made zero provider requests, and emitted no SUT event.

Final exact head `fac031bd751b909bcde0bc32d8dd356f8c4a171f`:

- owner probe: rejected before registration; zero network calls
- focused Telegram Doctor + webhook tests: 125 passed
- focused Oxlint/Oxfmt, extension prod/test typechecks, test typecheck, docs format/MDX/links, `git diff --check`: passed
- local ClawSweeper: zero findings, security concerns, maintainer decisions, and Rank-up moves
- real Telegram QA user sent message `51032096768`: channel emitted the explicit `/healthz` collision error; no SUT events; zero provider requests

Production/test/docs delta: `+10 / +63 / +2`. No migration, compatibility path, or request-hot-path work.

## Scope

No overlapping open PR found. Nextcloud Talk has the same configurable-webhook/fixed-health route shape in `extensions/nextcloud-talk/src/monitor.ts`; follow-up: audit that plugin owner rather than widening this Telegram fix.

## Maintainer decision

Keep fail-fast startup and a non-mutating Doctor preflight. OpenClaw cannot safely auto-rewrite the route because the public webhook URL and reverse-proxy mapping are operator-owned. The documented manual recovery remains required.
