### PR TITLE
fix(agents): record bundle MCP tool calls in the audit ledger

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-tool-catalog.audit-parity.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-catalog.audit-parity.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Regression test for issue #119253: bundle MCP/LSP tools reach the embedded
+ * attempt catalog boundary without the before_tool_call wrapper that owns the
+ * trusted audit lifecycle, so their executions emit no `tool.execution.started`
+ * event and leave no `tool_action` audit records (the audit projection turns
+ * `tool.execution.started` into `tool.action.started` ledger rows).
+ *
+ * The catalog boundary now wraps unwrapped tools with that wrapper; the adapter
+ * (`toToolDefinitions`) skips its own `before_tool_call` invocation for wrapped
+ * tools, so plugin hooks still fire exactly once via this wrapper while the
+ * missing audit event is restored.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  onInternalDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  type DiagnosticEventPayload,
+} from "../../../infra/diagnostic-events.js";
+import { setPluginToolMeta } from "../../../plugins/tools.js";
+import { toToolDefinitions } from "../../agent-tool-definition-adapter.js";
+import {
+  isToolWrappedWithBeforeToolCallHook,
+  wrapToolWithBeforeToolCallHook,
+} from "../../agent-tools.before-tool-call.js";
+import type { AnyAgentTool } from "../../tools/common.js";
+
+const RUN_ID = "audit-parity-run";
+
+/** A bundle-MCP-shaped tool that reaches the catalog boundary unwrapped. */
+function createBundleMcpTool(name = "fixture__echo_constant"): AnyAgentTool {
+  const tool = {
+    name,
+    label: name,
+    description: "bundle MCP fixture tool",
+    parameters: { type: "object" as const, properties: {}, additionalProperties: false },
+    execute: async () => ({
+      content: [{ type: "text" as const, text: "AUDIT-FIXTURE-8F3A" }],
+      details: { status: "ok" },
+    }),
+  } as unknown as AnyAgentTool;
+  setPluginToolMeta(tool, { pluginId: "bundle-mcp", optional: false });
+  return tool;
+}
+
+function createHookContext() {
+  // Minimal context: runId drives the audit event correlation; sessionKey is
+  // intentionally absent so loop detection is skipped without a registry.
+  return { runId: RUN_ID, agentId: "agent" };
+}
+
+function captureToolExecutionEvents(): { events: DiagnosticEventPayload[]; stop: () => void } {
+  const events: DiagnosticEventPayload[] = [];
+  const stop = onInternalDiagnosticEvent((event) => {
+    if (event.type.startsWith("tool.execution.")) {
+      events.push(event);
+    }
+  });
+  return { events, stop };
+}
+
+async function executeViaAdapter(tool: AnyAgentTool): Promise<void> {
+  const definition = toToolDefinitions([tool], createHookContext())[0];
+  if (!definition) {
+    throw new Error("missing tool definition");
+  }
+  const extensionContext = {} as Parameters<typeof definition.execute>[4];
+  await definition.execute("call-1", {}, undefined, undefined, extensionContext);
+  // Trusted diagnostic events are emitted synchronously, but the shared bus
+  // flush is guaranteed on the next macrotask.
+  await new Promise<void>((resolve) => {
+    setImmediate(resolve);
+  });
+}
+
+describe("issue #119253 audit parity at the tool catalog boundary", () => {
+  beforeEach(() => {
+    resetDiagnosticEventsForTest();
+  });
+  afterEach(() => {
+    resetDiagnosticEventsForTest();
+  });
+
+  it("an unwrapped bundle-MCP tool emits no tool.execution.started audit event", async () => {
+    const tool = createBundleMcpTool();
+    const { events, stop } = captureToolExecutionEvents();
+    try {
+      await executeViaAdapter(tool);
+    } finally {
+      stop();
+    }
+    expect(events.filter((event) => event.type === "tool.execution.started")).toHaveLength(0);
+  });
+
+  it("a tool wrapped with the before_tool_call wrapper emits the tool.execution.started audit event", async () => {
+    const tool = wrapToolWithBeforeToolCallHook(createBundleMcpTool(), createHookContext());
+    const { events, stop } = captureToolExecutionEvents();
+    try {
+      await executeViaAdapter(tool);
+    } finally {
+      stop();
+    }
+    const started = events.filter((event) => event.type === "tool.execution.started");
+    expect(started).toHaveLength(1);
+    expect(started[0]).toMatchObject({
+      type: "tool.execution.started",
+      toolName: "fixture__echo_constant",
+      runId: RUN_ID,
+    });
+  });
+
+  it("emits a terminal tool.execution.completed audit event for a wrapped tool", async () => {
+    const tool = wrapToolWithBeforeToolCallHook(createBundleMcpTool(), createHookContext());
+    const { events, stop } = captureToolExecutionEvents();
+    try {
+      await executeViaAdapter(tool);
+    } finally {
+      stop();
+    }
+    expect(events.filter((event) => event.type === "tool.execution.completed")).toHaveLength(1);
+  });
+
+  it("the catalog boundary wraps an unwrapped bundle-MCP tool (audit-lifecycle parity)", async () => {
+    const { prepareEmbeddedAttemptToolCatalog } = await import("./attempt-tool-catalog.js");
+    const unwrapped = createBundleMcpTool();
+    expect(isToolWrappedWithBeforeToolCallHook(unwrapped)).toBe(false);
+
+    const catalogInput = {
+      attempt: {
+        config: {},
+        provider: "provider",
+        model: { api: "responses" },
+        modelId: "model",
+        runId: RUN_ID,
+        sessionId: "session",
+        sessionKey: "session",
+        runtimePlan: { tools: { logDiagnostics: () => {} } },
+        currentChannelId: undefined,
+      },
+      preparedToolBase: {
+        codeModeControlsEnabledForRun: false,
+        codeModeSkills: [],
+        localModelLeanPreserveToolNames: [],
+        runtimeCapabilityProfile: { policy: { trustedGroup: { dropped: false } } },
+        toolSearchConfig: { enabled: false, mode: "directory" },
+        toolSearchControlsEnabledForRun: false,
+        toolSearchRuntimeConfig: {},
+        toolSearchCatalogRef: { current: undefined },
+        toolsEnabled: true,
+        effectiveToolsAllow: undefined,
+        forceDirectMessageTool: false,
+      },
+      bundleTools: { clientTools: undefined, uncompactedEffectiveTools: [unwrapped] },
+      effectiveCwd: "/tmp",
+      effectiveWorkspace: "/tmp",
+      sessionAgentId: "agent",
+      sandboxSessionKey: "session",
+      runTrace: undefined,
+      abortSignal: undefined,
+      executeCodeModeTool: vi.fn(),
+      getProviderRuntimeHandle: () => ({}) as never,
+      markStage: vi.fn(),
+    } as unknown as Parameters<typeof prepareEmbeddedAttemptToolCatalog>[0];
+
+    const result = prepareEmbeddedAttemptToolCatalog(catalogInput);
+    expect(result.effectiveTools.length).toBeGreaterThan(0);
+    const wrappedTool = result.effectiveTools[0];
+    if (!wrappedTool) {
+      throw new Error("catalog boundary produced no effective tools");
+    }
+    expect(isToolWrappedWithBeforeToolCallHook(wrappedTool)).toBe(true);
+  });
+
+  it("the catalog boundary preserves an already-wrapped core tool", async () => {
+    const { prepareEmbeddedAttemptToolCatalog } = await import("./attempt-tool-catalog.js");
+    const coreTool = wrapToolWithBeforeToolCallHook(
+      createBundleMcpTool("core__read"),
+      createHookContext(),
+    );
+    const catalogInput = {
+      attempt: {
+        config: {},
+        provider: "provider",
+        model: { api: "responses" },
+        modelId: "model",
+        runId: RUN_ID,
+        sessionId: "session",
+        sessionKey: "session",
+        runtimePlan: { tools: { logDiagnostics: () => {} } },
+      },
+      preparedToolBase: {
+        codeModeControlsEnabledForRun: false,
+        codeModeSkills: [],
+        localModelLeanPreserveToolNames: [],
+        runtimeCapabilityProfile: { policy: { trustedGroup: { dropped: false } } },
+        toolSearchConfig: { enabled: false, mode: "directory" },
+        toolSearchControlsEnabledForRun: false,
+        toolSearchRuntimeConfig: {},
+        toolSearchCatalogRef: { current: undefined },
+        toolsEnabled: true,
+        effectiveToolsAllow: undefined,
+        forceDirectMessageTool: false,
+      },
+      bundleTools: { clientTools: undefined, uncompactedEffectiveTools: [coreTool] },
+      effectiveCwd: "/tmp",
+      effectiveWorkspace: "/tmp",
+      sessionAgentId: "agent",
+      sandboxSessionKey: "session",
+      runTrace: undefined,
+      abortSignal: undefined,
+      executeCodeModeTool: vi.fn(),
+      getProviderRuntimeHandle: () => ({}) as never,
+      markStage: vi.fn(),
+    } as unknown as Parameters<typeof prepareEmbeddedAttemptToolCatalog>[0];
+
+    const result = prepareEmbeddedAttemptToolCatalog(catalogInput);
+    const wrappedTool = result.effectiveTools[0];
+    if (!wrappedTool) {
+      throw new Error("catalog boundary produced no effective tools");
+    }
+    expect(isToolWrappedWithBeforeToolCallHook(wrappedTool)).toBe(true);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-tool-catalog.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-catalog.ts
@@ -2,6 +2,11 @@
  * Prepares the attempt-local tool catalog, schema projection, and diagnostics.
  */
 import type { DiagnosticTraceContext } from "../../../infra/diagnostic-trace-context.js";
+import {
+  type HookContext,
+  isToolWrappedWithBeforeToolCallHook,
+  wrapToolWithBeforeToolCallHook,
+} from "../../agent-tools.before-tool-call.js";
 import { resolveToolLoopDetectionConfig } from "../../agent-tools.js";
 import {
   CODE_MODE_EXEC_TOOL_NAME,
@@ -20,6 +25,7 @@ import {
   type ToolSearchCatalogToolExecutor,
 } from "../../tool-search.js";
 import { applyAgentToolSurfaceCatalog } from "../../tool-surface-plan.js";
+import type { AnyAgentTool } from "../../tools/common.js";
 import { log } from "../logger.js";
 import type { prepareEmbeddedAttemptBundleTools } from "./attempt-bundle-tools.js";
 import { collectAttemptExplicitToolAllowlistSources } from "./attempt-tool-allowlist.js";
@@ -31,6 +37,32 @@ import type { EmbeddedRunAttemptParams } from "./types.js";
 type PreparedToolBase = ReturnType<typeof prepareEmbeddedAttemptToolBase>;
 type PreparedBundleTools = Awaited<ReturnType<typeof prepareEmbeddedAttemptBundleTools>>;
 type ProviderRuntimeHandle = Parameters<typeof logAgentRuntimeToolDiagnostics>[0]["runtimeHandle"];
+
+/**
+ * Ensure a tool reaching the attempt catalog boundary carries the canonical
+ * before_tool_call wrapper that owns the trusted audit lifecycle.
+ *
+ * Bundle MCP/LSP tools are materialized after the core tool set (see
+ * `prepareEmbeddedAttemptBundleTools`) and reach this boundary without the
+ * wrapper that emits `tool.execution.started` / `finished` / `blocked`, which
+ * the audit projection turns into `tool_action` ledger rows. Core tools are
+ * already wrapped by `createOpenClawCodingTools()`, so the marker check
+ * preserves them as-is; re-wrapping would run plugin authorization and mutation
+ * hooks twice.
+ *
+ * `toToolDefinitions` skips its own `before_tool_call` invocation for wrapped
+ * tools, so moving unwrapped tools onto this wrapper keeps plugin hooks firing
+ * exactly once while adding the audit events they were missing.
+ */
+function ensureAttemptToolAuditLifecycle(
+  tool: AnyAgentTool,
+  hookContext: HookContext | undefined,
+): AnyAgentTool {
+  if (!hookContext || isToolWrappedWithBeforeToolCallHook(tool)) {
+    return tool;
+  }
+  return wrapToolWithBeforeToolCallHook(tool, hookContext);
+}
 
 export function prepareEmbeddedAttemptToolCatalog(input: {
   attempt: EmbeddedRunAttemptParams;
@@ -125,7 +157,10 @@ export function prepareEmbeddedAttemptToolCatalog(input: {
     sessionId: attempt.sessionId,
   });
   effectiveTools = toolSearchSchemaProjection.tools.map((tool) =>
-    wrapEmbeddedAttemptToolWithActivity(tool, attempt.runId),
+    wrapEmbeddedAttemptToolWithActivity(
+      ensureAttemptToolAuditLifecycle(tool, catalogToolHookContext),
+      attempt.runId,
+    ),
   );
   if (toolSearch.compacted && !toolSearch.catalogReused) {
     input.markStage(codeModeControlsEnabledForRun ? "code-mode" : "tool-search");


### PR DESCRIPTION
> [AI-assisted] This PR was generated using Claude Code.

## What Problem This Solves

Fixes an issue where bundle MCP (and LSP) tools called during an embedded agent run would execute correctly and return correct results, but leave no `tool_action` record in the audit ledger and emit no `tool.execution.started` / terminal trusted audit event. Built-in tools produce both on the same run; MCP tools produced neither, so an operator reviewing the metadata-only ledger could not tell whether an agent run caused a side effect on an MCP-managed resource. The official `before_tool_call` / `after_tool_call` plugin hooks were already reached via the adapter and subscription, so this is an audit-observability gap rather than a hook-policy bypass.

## Why This Change Was Made

Bundle MCP/LSP tools are materialized after the core tool set and reach the embedded attempt catalog boundary (`prepareEmbeddedAttemptToolCatalog` in `attempt-tool-catalog.ts`) without the `wrapToolWithBeforeToolCallHook` wrapper that owns the trusted audit lifecycle (`tool.execution.started` / `completed` / `blocked`), which the audit projection turns into `tool_action` ledger rows. This PR adds a small `ensureAttemptToolAuditLifecycle` step at that boundary that wraps any tool missing the `BEFORE_TOOL_CALL_WRAPPED` marker. Core tools are already wrapped by `createOpenClawCodingTools()`, so the marker check preserves them as-is; re-wrapping would run plugin authorization and mutation hooks twice. `toToolDefinitions` skips its own `before_tool_call` invocation for wrapped tools, so plugin hooks still fire exactly once via this wrapper while the missing audit event is restored. This matches the maintainer guidance on the issue: wrap only currently unwrapped final embedded tools at the catalog boundary and retain the adapter/subscription as the single hook-delivery path.

## User Impact

MCP tool calls now leave the same audit trail as built-in tool calls: `tool.action.started` / `tool.action.finished` rows appear in the metadata-only audit ledger, correlated with the surrounding agent run by the same run reference. Normal MCP execution, returned results, and existing `tools.allow` / `tools.deny` policy filtering are unchanged; tool arguments and results remain excluded from the ledger by default (`redaction: metadata_only`). Plugin `before_tool_call` / `after_tool_call` hooks continue to fire exactly once per MCP tool call, as they did before.

## Evidence

- Repro environment (os): Windows 10 / PowerShell, Node v22.22.3
- Repro steps (commands): `pnpm exec tsx .tmp/proof-119253-real.mjs` (production-path proof that materializes a real bundle-MCP tool via `materializeBundleMcpToolsForRun`, wraps it at the attempt catalog boundary, executes through `toToolDefinitions`, and persists the trusted audit events to a real on-disk SQLite audit ledger via `createAgentEventAuditRecorder`, then queries `listAuditEvents` for `tool_action` rows)
- Expected (after fix): the materialized MCP tool call produces correlated `tool_action` ledger records (`tool.action.started` / `tool.action.finished`) in the persisted SQLite audit ledger, tied to the surrounding run
- Actual (before fix): the materialized MCP tool reaches the catalog boundary unwrapped and leaves 0 `tool_action` ledger records
- Evidence type (real): production-path terminal output with persisted SQLite ledger records

```text
$ pnpm exec tsx .tmp/proof-119253-real.mjs
Issue #119253 real-behavior proof (materialized bundle-MCP tool + SQLite audit ledger)
======================================================================================
materialized bundle-MCP tool: name=fixture__echo_constant
  wrapped marker (as materialized): false

--- BEFORE fix: materialized MCP tool reaches the catalog boundary unwrapped ---
  tool_action ledger records: 0

--- AFTER fix: catalog boundary wraps the materialized MCP tool ---
  tool_action ledger records: 2
  persisted tool_action record:
    kind=tool_action action=tool.action.finished toolName=fixture__echo_constant
    runId=audit-parity-real-run sessionKey=agent:main:main

Summary
-------
  BEFORE: tool_action ledger records = 0
  AFTER : tool_action ledger records = 2
RESULT: materialized bundle-MCP tool left no audit record before the fix; the catalog-boundary wrap persists a correlated tool_action ledger record after the fix.

Branch commit: e07672f9aad6cc2d7ca2aaa57cdce35c0a17e21f
```

A focused source-level capture of the trusted diagnostic events (`tool.execution.started` / `completed`) emitted on the same path is in `.tmp/proof-119253.mjs` (BEFORE 0 `tool.execution.started` events, AFTER 1 `tool.execution.started` + 1 `tool.execution.completed`), confirming the audit source event that the ledger projection consumes.

- `node scripts/run-vitest.mjs run src/agents/embedded-agent-runner/run/attempt-tool-catalog.audit-parity.test.ts` - 5/5 passed (regression coverage: an unwrapped tool emits no `tool.execution.started`, a wrapped tool emits `tool.execution.started` + a terminal `tool.execution.completed`, and the catalog boundary `prepareEmbeddedAttemptToolCatalog` wraps an unwrapped bundle-MCP tool while preserving an already-wrapped core tool)
- `node scripts/run-vitest.mjs run src/agents/agent-tool-definition-adapter.after-tool-call.fires-once.test.ts` - 4/4 passed (plugin hooks still fire exactly once)
- `node scripts/run-vitest.mjs run src/audit/audit-events.test.ts` - 45/45 passed
- `node scripts/run-vitest.mjs run src/agents/embedded-agent-runner/run/attempt-bundle-tools.test.ts src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts src/agents/embedded-agent-runner/run/attempt-client-tools.test.ts src/agents/embedded-agent-subscribe.handlers.tools.test.ts` - 187/187 passed
- `node scripts/run-vitest.mjs run src/agents/agent-tools.before-tool-call.integration.e2e.test.ts` - 34/35 passed; the single failure is a pre-existing Windows `EBUSY` sqlite file-lock flake during temp-dir cleanup that fails identically on `main` without this change and is unrelated to MCP audit wrapping
- `pnpm tsgo` - passed
- `pnpm lint` (oxlint core + extensions + scripts shards) - passed

Closes #119253

AI-assisted: Claude Code