### PR TITLE
fix(gateway): MCP App standalone UI hangs when sandbox fetch never resolves

### DIFF
--- a/src/agents/agent-bundle-mcp-combined.ts
+++ b/src/agents/agent-bundle-mcp-combined.ts
@@ -194,6 +194,9 @@ export function createCombinedSessionMcpRuntime(params: {
       }
       return mergeMcpToolCatalogs(peeked as McpToolCatalog[]);
     },
+    getServerRequestTimeoutMs(serverName) {
+      return serverOwner.get(serverName)?.getServerRequestTimeoutMs?.(serverName);
+    },
     markUsed() {
       lastUsedAt = Date.now();
       for (const part of parts) {

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -1651,6 +1651,7 @@ process.on("SIGINT", shutdown);`,
             volatile: {
               command: process.execPath,
               args: [serverPath],
+              requestTimeoutMs: 123_456,
             },
           },
         },
@@ -1667,6 +1668,7 @@ process.on("SIGINT", shutdown);`,
         "list_changed to invalidate the catalog",
         LIST_TOOLS_SERVER_LOG_TIMEOUT_MS,
       );
+      expect(runtime.getServerRequestTimeoutMs?.("volatile")).toBe(123_456);
 
       const refreshedCatalog = await runtime.getCatalog();
       expect(refreshedCatalog.tools).toEqual([]);
@@ -3798,6 +3800,7 @@ describe("requester-scoped MCP connection resolution", () => {
         requesterScope: params.requesterScope,
         peekCatalog: () => current,
         getCatalog: async () => current,
+        getServerRequestTimeoutMs: () => (serverName === "user-mail" ? 90_000 : 60_000),
       };
     };
     const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
@@ -3824,6 +3827,7 @@ describe("requester-scoped MCP connection resolution", () => {
     swapCatalogByServer.get("user-mail")?.("send_v2");
     const after = await runtime.getCatalog();
     expect(after.tools.map((tool) => tool.toolName).toSorted()).toEqual(["send_v2", "shared_tool"]);
+    expect(runtime.getServerRequestTimeoutMs?.("user-mail")).toBe(90_000);
     expect(
       runtime
         .peekCatalog()

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -1074,6 +1074,10 @@ export function createSessionMcpRuntime(params: {
     peekCatalog() {
       return catalog;
     },
+    /** Session-owned timeout that survives catalog invalidation. */
+    getServerRequestTimeoutMs(serverName: string) {
+      return sessions.get(serverName)?.requestTimeoutMs;
+    },
     markUsed() {
       lastUsedAt = Date.now();
     },

--- a/src/agents/agent-bundle-mcp-types.ts
+++ b/src/agents/agent-bundle-mcp-types.ts
@@ -120,6 +120,8 @@ export type SessionMcpRuntime = {
   getCatalog: () => Promise<McpToolCatalog>;
   /** Returns the cached catalog only; must not start runtimes, connect transports, or issue tools/list. */
   peekCatalog: () => McpToolCatalog | null;
+  /** Returns the configured request timeout for a server from the connected session, without touching the catalog. */
+  getServerRequestTimeoutMs?: (serverName: string) => number | undefined;
   markUsed: () => void;
   callTool: (serverName: string, toolName: string, input: unknown) => Promise<CallToolResult>;
   listTools?: (serverName: string, params?: { cursor?: string }) => Promise<ListToolsResult>;

--- a/src/agents/mcp-transport-config.ts
+++ b/src/agents/mcp-transport-config.ts
@@ -54,7 +54,7 @@ type ResolvedHttpMcpTransportConfig = ResolvedBaseMcpTransportConfig & {
 type ResolvedMcpTransportConfig = ResolvedStdioMcpTransportConfig | ResolvedHttpMcpTransportConfig;
 
 const DEFAULT_CONNECTION_TIMEOUT_MS = 30_000;
-export const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
 
 function getPositiveNumber(rawServer: unknown, keys: readonly string[]): number | undefined {
   if (!rawServer || typeof rawServer !== "object") {

--- a/src/agents/mcp-transport-config.ts
+++ b/src/agents/mcp-transport-config.ts
@@ -54,7 +54,7 @@ type ResolvedHttpMcpTransportConfig = ResolvedBaseMcpTransportConfig & {
 type ResolvedMcpTransportConfig = ResolvedStdioMcpTransportConfig | ResolvedHttpMcpTransportConfig;
 
 const DEFAULT_CONNECTION_TIMEOUT_MS = 30_000;
-const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
+export const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
 
 function getPositiveNumber(rawServer: unknown, keys: readonly string[]): number | undefined {
   if (!rawServer || typeof rawServer !== "object") {

--- a/src/agents/mcp-ui-resource.test.ts
+++ b/src/agents/mcp-ui-resource.test.ts
@@ -295,6 +295,38 @@ describe("MCP App UI resources", () => {
     expect(getMcpAppViewLease(viewIds[31] ?? "", sessionRuntime)).toBeDefined();
   });
 
+  it("reads the request timeout from the runtime session when the cached catalog is null", async () => {
+    const sessionRuntime = runtime(async () => ({
+      contents: [
+        {
+          uri: "ui://demo/app",
+          mimeType: MCP_APP_RESOURCE_MIME_TYPE,
+          text: "<html>demo</html>",
+          _meta: { ui: { csp: { connectDomains: ["https://api.example.com"] } } },
+        },
+      ],
+    }));
+    // Simulate catalog invalidation (peekCatalog returns null) while the session
+    // still has the configured timeout.
+    sessionRuntime.peekCatalog = () => null;
+    sessionRuntime.getServerRequestTimeoutMs = (serverName) =>
+      serverName === "demo" ? 120_000 : undefined;
+
+    const result = await fetchMcpAppView({
+      runtime: sessionRuntime,
+      serverName: "demo",
+      toolName: "show",
+      uiResourceUri: "ui://demo/app",
+      toolInput: {},
+      toolResult: { content: [] },
+    });
+    expect(result).toBeDefined();
+
+    const lease = getMcpAppViewLease(result!.viewId, sessionRuntime);
+    expect(lease).toBeDefined();
+    expect(lease!.requestTimeoutMs).toBe(120_000);
+  });
+
   it("replaces a reconstructed view id without leaking the previous runtime lease", async () => {
     const releases = [vi.fn(), vi.fn()];
     const sessionRuntime = runtime(async () => ({

--- a/src/agents/mcp-ui-resource.test.ts
+++ b/src/agents/mcp-ui-resource.test.ts
@@ -162,7 +162,7 @@ describe("MCP App UI resources", () => {
     releases.slice(1).forEach((entry) => entry());
   });
 
-  it("normalizes CSP metadata before retaining the view", async () => {
+  it("normalizes CSP and snapshots the session deadline before retaining the view", async () => {
     const sessionRuntime = runtime(async () => ({
       contents: [
         {
@@ -180,6 +180,10 @@ describe("MCP App UI resources", () => {
         },
       ],
     }));
+    const peekCatalog = vi.fn(() => null);
+    sessionRuntime.peekCatalog = peekCatalog;
+    sessionRuntime.getServerRequestTimeoutMs = (serverName) =>
+      serverName === "demo" ? 120_000 : undefined;
     const result = await fetchMcpAppView({
       runtime: sessionRuntime,
       serverName: "demo",
@@ -194,6 +198,8 @@ describe("MCP App UI resources", () => {
       resourceDomains: ["https://cdn.example.com"],
     });
     expect(view?.html.startsWith("<!doctype html>")).toBe(true);
+    expect(view?.requestTimeoutMs).toBe(120_000);
+    expect(peekCatalog).not.toHaveBeenCalled();
     expect(buildMcpAppSandboxPath(view?.csp)).toContain("?csp=");
   });
 
@@ -293,38 +299,6 @@ describe("MCP App UI resources", () => {
 
     expect(getMcpAppViewLease(viewIds[0] ?? "", sessionRuntime)).toBeDefined();
     expect(getMcpAppViewLease(viewIds[31] ?? "", sessionRuntime)).toBeDefined();
-  });
-
-  it("reads the request timeout from the runtime session when the cached catalog is null", async () => {
-    const sessionRuntime = runtime(async () => ({
-      contents: [
-        {
-          uri: "ui://demo/app",
-          mimeType: MCP_APP_RESOURCE_MIME_TYPE,
-          text: "<html>demo</html>",
-          _meta: { ui: { csp: { connectDomains: ["https://api.example.com"] } } },
-        },
-      ],
-    }));
-    // Simulate catalog invalidation (peekCatalog returns null) while the session
-    // still has the configured timeout.
-    sessionRuntime.peekCatalog = () => null;
-    sessionRuntime.getServerRequestTimeoutMs = (serverName) =>
-      serverName === "demo" ? 120_000 : undefined;
-
-    const result = await fetchMcpAppView({
-      runtime: sessionRuntime,
-      serverName: "demo",
-      toolName: "show",
-      uiResourceUri: "ui://demo/app",
-      toolInput: {},
-      toolResult: { content: [] },
-    });
-    expect(result).toBeDefined();
-
-    const lease = getMcpAppViewLease(result!.viewId, sessionRuntime);
-    expect(lease).toBeDefined();
-    expect(lease!.requestTimeoutMs).toBe(120_000);
   });
 
   it("replaces a reconstructed view id without leaking the previous runtime lease", async () => {

--- a/src/agents/mcp-ui-resource.ts
+++ b/src/agents/mcp-ui-resource.ts
@@ -270,7 +270,11 @@ export async function fetchMcpAppView(params: {
     // cached catalog can be invalidated later (e.g. tools/list_changed), but the
     // browser-side deadline must stay consistent with the runtime deadline that
     // will be used for operations initiated from this view.
+    // Read from the runtime session first — its timeout survives catalog
+    // invalidation, so a tools/list_changed right before view creation does not
+    // substitute the 60-second default for a configured 120-second MCP operation.
     const requestTimeoutMs =
+      params.runtime.getServerRequestTimeoutMs?.(params.serverName) ??
       params.runtime.peekCatalog()?.servers[params.serverName]?.requestTimeoutMs ??
       DEFAULT_REQUEST_TIMEOUT_MS;
     releaseRuntimeLease = params.runtime.acquireLease?.();

--- a/src/agents/mcp-ui-resource.ts
+++ b/src/agents/mcp-ui-resource.ts
@@ -7,7 +7,6 @@ import { completeDeferredSessionMcpRuntimeRetirement } from "./agent-bundle-mcp-
 import type { SessionMcpRuntime } from "./agent-bundle-mcp-types.js";
 import { clearMcpAppModelContextForView } from "./mcp-app-model-context.js";
 import { type McpAppCsp, normalizeMcpAppCsp } from "./mcp-app-sandbox.js";
-import { DEFAULT_REQUEST_TIMEOUT_MS } from "./mcp-transport-config.js";
 
 const MCP_APP_RESOURCE_MIME_TYPE = "text/html;profile=mcp-app";
 const MCP_APP_RESOURCE_MAX_BYTES = 2 * 1024 * 1024;
@@ -37,7 +36,7 @@ export type McpAppViewLease = {
   readOnly?: true;
   toolInput: unknown;
   toolResult: CallToolResult;
-  requestTimeoutMs: number;
+  requestTimeoutMs?: number;
   expiresAtMs: number;
   requestWindowStartedAtMs: number;
   requestCount: number;
@@ -266,17 +265,9 @@ export async function fetchMcpAppView(params: {
     const permissions = normalizePermissions(uiMeta?.permissions);
     const title = `${params.toolName} UI`;
     const viewId = params.viewId ?? `mcp-app-${randomUUID()}`;
-    // Snapshot the configured request timeout when the view is created. The
-    // cached catalog can be invalidated later (e.g. tools/list_changed), but the
-    // browser-side deadline must stay consistent with the runtime deadline that
-    // will be used for operations initiated from this view.
-    // Read from the runtime session first — its timeout survives catalog
-    // invalidation, so a tools/list_changed right before view creation does not
-    // substitute the 60-second default for a configured 120-second MCP operation.
-    const requestTimeoutMs =
-      params.runtime.getServerRequestTimeoutMs?.(params.serverName) ??
-      params.runtime.peekCatalog()?.servers[params.serverName]?.requestTimeoutMs ??
-      DEFAULT_REQUEST_TIMEOUT_MS;
+    // resources/read established the authoritative server session above. Carry
+    // its deadline into the view so catalog invalidation cannot change it later.
+    const requestTimeoutMs = params.runtime.getServerRequestTimeoutMs?.(params.serverName);
     releaseRuntimeLease = params.runtime.acquireLease?.();
     deleteView(viewId);
     pruneViewStore(byteSize, { reserveEntry: true });
@@ -300,7 +291,7 @@ export async function fetchMcpAppView(params: {
       ...(params.readOnly ? { readOnly: true as const } : {}),
       toolInput: params.toolInput,
       toolResult: params.toolResult,
-      requestTimeoutMs,
+      ...(requestTimeoutMs !== undefined ? { requestTimeoutMs } : {}),
       expiresAtMs: Date.now() + MCP_APP_VIEW_TTL_MS,
       requestWindowStartedAtMs: Date.now(),
       requestCount: 0,

--- a/src/agents/mcp-ui-resource.ts
+++ b/src/agents/mcp-ui-resource.ts
@@ -7,6 +7,7 @@ import { completeDeferredSessionMcpRuntimeRetirement } from "./agent-bundle-mcp-
 import type { SessionMcpRuntime } from "./agent-bundle-mcp-types.js";
 import { clearMcpAppModelContextForView } from "./mcp-app-model-context.js";
 import { type McpAppCsp, normalizeMcpAppCsp } from "./mcp-app-sandbox.js";
+import { DEFAULT_REQUEST_TIMEOUT_MS } from "./mcp-transport-config.js";
 
 const MCP_APP_RESOURCE_MIME_TYPE = "text/html;profile=mcp-app";
 const MCP_APP_RESOURCE_MAX_BYTES = 2 * 1024 * 1024;
@@ -36,6 +37,7 @@ export type McpAppViewLease = {
   readOnly?: true;
   toolInput: unknown;
   toolResult: CallToolResult;
+  requestTimeoutMs: number;
   expiresAtMs: number;
   requestWindowStartedAtMs: number;
   requestCount: number;
@@ -264,6 +266,13 @@ export async function fetchMcpAppView(params: {
     const permissions = normalizePermissions(uiMeta?.permissions);
     const title = `${params.toolName} UI`;
     const viewId = params.viewId ?? `mcp-app-${randomUUID()}`;
+    // Snapshot the configured request timeout when the view is created. The
+    // cached catalog can be invalidated later (e.g. tools/list_changed), but the
+    // browser-side deadline must stay consistent with the runtime deadline that
+    // will be used for operations initiated from this view.
+    const requestTimeoutMs =
+      params.runtime.peekCatalog()?.servers[params.serverName]?.requestTimeoutMs ??
+      DEFAULT_REQUEST_TIMEOUT_MS;
     releaseRuntimeLease = params.runtime.acquireLease?.();
     deleteView(viewId);
     pruneViewStore(byteSize, { reserveEntry: true });
@@ -287,6 +296,7 @@ export async function fetchMcpAppView(params: {
       ...(params.readOnly ? { readOnly: true as const } : {}),
       toolInput: params.toolInput,
       toolResult: params.toolResult,
+      requestTimeoutMs,
       expiresAtMs: Date.now() + MCP_APP_VIEW_TTL_MS,
       requestWindowStartedAtMs: Date.now(),
       requestCount: 0,

--- a/src/gateway/mcp-app-standalone.test.ts
+++ b/src/gateway/mcp-app-standalone.test.ts
@@ -465,4 +465,33 @@ describe("MCP App standalone host", () => {
       ).res.statusCode,
     ).toBe(400);
   });
+
+  it("omits requestTimeoutMs from the view payload for native MCP App runtimes without a request-deadline contract", async () => {
+    const nativeRuntime = {
+      ...runtime,
+      getServerRequestTimeoutMs: undefined,
+    };
+    const nativeView = { ...view, runtime: nativeRuntime };
+    mocks.peekSessionMcpRuntime.mockReturnValue(nativeRuntime);
+    mocks.getMcpAppViewLease.mockReturnValue(nativeView);
+
+    const issued = issueTicket({ sessionKey: "agent:main:main", view: nativeView, nowMs, secret });
+    const accepted = await request({
+      url: "/__openclaw__/mcp-app/view",
+      authorization: `MCP-App ${issued.ticket}`,
+    });
+    expect(accepted.res.statusCode).toBe(200);
+    const payload = JSON.parse(String(accepted.end.mock.calls[0]?.[0]));
+    expect(payload).not.toHaveProperty("requestTimeoutMs");
+
+    // The serialized browser host must keep the initial-load timeout but
+    // omit the operation AbortSignal for runtimes with no deadline contract.
+    const shell = await request({ url: "/__openclaw__/mcp-app" });
+    const html = String(shell.end.mock.calls[0]?.[0]);
+    expect(html).toContain("AbortSignal.timeout(config.initialLoadTimeoutMs)");
+    // The operation fetch uses a ternary that only adds AbortSignal when
+    // payload.requestTimeoutMs is set; for native runtimes the key is
+    // omitted, so the null check must be present.
+    expect(html).toContain("payload?.requestTimeoutMs != null");
+  });
 });

--- a/src/gateway/mcp-app-standalone.test.ts
+++ b/src/gateway/mcp-app-standalone.test.ts
@@ -1,6 +1,6 @@
 import type { IncomingMessage } from "node:http";
 import { Readable } from "node:stream";
-import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
+import { runInNewContext } from "node:vm";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { makeMockHttpResponse } from "./test-http-response.js";
 
@@ -37,34 +37,19 @@ function issueTicket(params: Parameters<typeof createMcpAppStandaloneTicket>[0])
 const nowMs = 1_800_000_000_000;
 const secret = Buffer.alloc(32, 7);
 const releaseRuntimeLease = vi.fn();
-const defaultCatalog = {
-  version: 1,
-  generatedAt: Date.now(),
-  servers: {
-    demo: {
-      serverName: "demo",
-      launchSummary: "demo server",
-      toolCount: 3,
-      requestTimeoutMs: 60_000,
-    },
-  },
-  tools: [
-    { serverName: "demo", toolName: "shared" },
-    { serverName: "demo", toolName: "app-only", uiVisibility: ["app"] },
-    { serverName: "demo", toolName: "model-only", uiVisibility: ["model"] },
-    { serverName: "other", toolName: "cross-only", uiVisibility: ["app"] },
-  ],
-};
 const runtime = {
   sessionId: "runtime-session",
   mcpAppsEnabled: true,
   markUsed: vi.fn(),
   acquireLease: vi.fn(() => releaseRuntimeLease),
-  getCatalog: vi.fn(async () => defaultCatalog),
-  peekCatalog: vi.fn(() => defaultCatalog),
-  getServerRequestTimeoutMs: vi.fn((serverName: string) =>
-    serverName === "demo" ? 60_000 : undefined,
-  ),
+  getCatalog: vi.fn(async () => ({
+    tools: [
+      { serverName: "demo", toolName: "shared" },
+      { serverName: "demo", toolName: "app-only", uiVisibility: ["app"] },
+      { serverName: "demo", toolName: "model-only", uiVisibility: ["model"] },
+      { serverName: "other", toolName: "cross-only", uiVisibility: ["app"] },
+    ],
+  })),
   callTool: vi.fn(async (serverName: string, toolName: string) => ({
     content: [{ type: "text", text: `${serverName}:${toolName}` }],
   })),
@@ -151,8 +136,6 @@ describe("MCP App standalone host", () => {
     });
     mocks.peekSessionMcpRuntime.mockReturnValue(runtime);
     mocks.getMcpAppViewLease.mockReturnValue(view);
-    runtime.getCatalog.mockReturnValue(Promise.resolve(defaultCatalog));
-    runtime.peekCatalog.mockReturnValue(defaultCatalog);
   });
 
   it("mints an opaque ticket bound to the session, runtime, view, and lease", () => {
@@ -223,12 +206,7 @@ describe("MCP App standalone host", () => {
     expect(body).toContain("location.hash");
     expect(body).toContain("event.origin");
     expect(body).toContain("if (!initializeAccepted)");
-    // Initial view load keeps a bounded timeout passed through serialized config;
-    // operation fetches honor the configured MCP request deadline plus a bounded
-    // gateway grace clamped to the timer-safe maximum.
-    expect(body).toContain("AbortSignal.timeout(config.initialLoadTimeoutMs)");
-    expect(body).toContain("Math.min(");
-    expect(body).toContain("config.timerSafeMax");
+    expect(body).not.toContain("MCP_APP_STANDALONE_INITIAL_LOAD_TIMEOUT_MS");
     expect(body).not.toContain('postMessage(message, "*")');
     expect(body).not.toContain(view.html);
     expect(body).not.toContain("agent:main:main");
@@ -236,6 +214,139 @@ describe("MCP App standalone host", () => {
     expect(result.setHeader).toHaveBeenCalledWith(
       "Content-Security-Policy",
       expect.stringMatching(/script-src 'sha256-[^']+';.*connect-src 'self'/u),
+    );
+  });
+
+  it("executes serialized fetch deadlines with visible outcomes", async () => {
+    const shell = await request({ url: "/__openclaw__/mcp-app" });
+    const html = String(shell.end.mock.calls[0]?.[0]);
+    const source = /<script>([\s\S]+)<\/script>/u.exec(html)?.[1];
+    expect(source).toBeDefined();
+
+    let renderedError = "";
+    const timeoutError = Object.assign(new Error("timed out"), { name: "TimeoutError" });
+    const initialSignal = AbortSignal.abort(timeoutError);
+    const initialTimeout = vi.fn(() => initialSignal);
+    const initialFetch = vi.fn(() => Promise.reject(timeoutError));
+
+    runInNewContext(source!, {
+      AbortSignal: { timeout: initialTimeout },
+      URL,
+      addEventListener: vi.fn(),
+      document: {
+        createElement: () => ({ className: "", textContent: "" }),
+        getElementById: () => ({
+          replaceChildren: (child: { textContent?: string }) => {
+            renderedError = child.textContent ?? "";
+          },
+        }),
+      },
+      fetch: initialFetch,
+      innerWidth: 800,
+      location: { hash: "#ticket", origin: "http://127.0.0.1:18789" },
+      matchMedia: () => ({ matches: false }),
+      navigator: { language: "en" },
+      setTimeout,
+    });
+    await vi.waitFor(() =>
+      expect(renderedError).toBe("MCP App view timed out; reload to try again"),
+    );
+    expect(initialTimeout).toHaveBeenCalledWith(30_000);
+    expect(initialFetch).toHaveBeenCalledWith(
+      "/__openclaw__/mcp-app/view",
+      expect.objectContaining({ signal: initialSignal }),
+    );
+
+    const sandboxOrigin = "http://127.0.0.1:18790";
+    const postMessage = vi.fn();
+    const contentWindow = { postMessage };
+    const frame = {
+      setAttribute: vi.fn(),
+      contentWindow,
+    };
+    const replaceChildren = vi.fn();
+    let onMessage: ((event: unknown) => void) | undefined;
+    const operationController = new AbortController();
+    const timeout = vi.fn((delay: number) => {
+      if (delay === 65_000) {
+        queueMicrotask(() => operationController.abort(timeoutError));
+        return operationController.signal;
+      }
+      return new AbortController().signal;
+    });
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          sandboxUrl: "/mcp-app-sandbox",
+          sandboxPort: 18_790,
+          html: "<html>demo</html>",
+          toolInput: {},
+          toolResult: { content: [] },
+          serverTools: true,
+          operationTimeoutMs: 65_000,
+        }),
+      })
+      .mockImplementationOnce((_url: string, init: RequestInit) => {
+        const signal = init.signal as AbortSignal;
+        return new Promise<never>((_resolve, reject) => {
+          signal.addEventListener("abort", () => reject(timeoutError), { once: true });
+        });
+      });
+
+    runInNewContext(source!, {
+      AbortSignal: { timeout },
+      URL,
+      addEventListener: (type: string, listener: (event: unknown) => void) => {
+        if (type === "message") {
+          onMessage = listener;
+        }
+      },
+      document: {
+        createElement: () => frame,
+        getElementById: () => ({ replaceChildren }),
+      },
+      fetch,
+      innerWidth: 800,
+      location: { hash: "#ticket", origin: "http://127.0.0.1:18789" },
+      matchMedia: () => ({ matches: false }),
+      navigator: { language: "en" },
+      setTimeout,
+    });
+    await vi.waitFor(() => expect(replaceChildren).toHaveBeenCalledWith(frame));
+
+    const emit = (data: unknown) =>
+      onMessage?.({ data, origin: sandboxOrigin, source: contentWindow });
+    emit({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "ui/initialize",
+      params: {
+        protocolVersion: "2026-01-26",
+        appInfo: { name: "demo", version: "1" },
+        appCapabilities: {},
+      },
+    });
+    emit({ jsonrpc: "2.0", method: "ui/notifications/initialized" });
+    emit({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: "slow" } });
+
+    await vi.waitFor(() =>
+      expect(postMessage).toHaveBeenCalledWith(
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          error: { code: -32000, message: "MCP App operation timed out; try again" },
+        },
+        sandboxOrigin,
+      ),
+    );
+    expect(timeout).toHaveBeenNthCalledWith(1, 30_000);
+    expect(timeout).toHaveBeenNthCalledWith(2, 65_000);
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      "/__openclaw__/mcp-app/view",
+      expect.objectContaining({ signal: operationController.signal }),
     );
   });
 
@@ -251,6 +362,7 @@ describe("MCP App standalone host", () => {
       sandboxPort: 18_790,
       serverTools: true,
       serverResources: true,
+      operationTimeoutMs: 65_000,
     });
     expect(
       (await request({ url: route, authorization: `MCP-App ${issued.ticket}` })).res.statusCode,
@@ -259,78 +371,6 @@ describe("MCP App standalone host", () => {
     expect(
       (await request({ url: route, authorization: `MCP-App ${issued.ticket}` })).res.statusCode,
     ).toBe(401);
-  });
-
-  it("includes the configured MCP request timeout in the view payload", async () => {
-    const issued = issueTicket({ sessionKey: "agent:main:main", view, nowMs, secret });
-    const accepted = await request({
-      url: "/__openclaw__/mcp-app/view",
-      authorization: `MCP-App ${issued.ticket}`,
-    });
-    expect(accepted.res.statusCode).toBe(200);
-    expect(JSON.parse(String(accepted.end.mock.calls[0]?.[0]))).toMatchObject({
-      requestTimeoutMs: 60_000,
-    });
-  });
-
-  it("emits an operation fetch timeout that honors a non-default configured deadline plus gateway grace", async () => {
-    const customView = { ...view, requestTimeoutMs: 120_000 };
-    mocks.getMcpAppViewLease.mockReturnValue(customView);
-    const issued = issueTicket({ sessionKey: "agent:main:main", view: customView, nowMs, secret });
-    const accepted = await request({
-      url: "/__openclaw__/mcp-app/view",
-      authorization: `MCP-App ${issued.ticket}`,
-    });
-    expect(accepted.res.statusCode).toBe(200);
-    expect(JSON.parse(String(accepted.end.mock.calls[0]?.[0]))).toMatchObject({
-      requestTimeoutMs: 120_000,
-    });
-
-    const shell = await request({ url: "/__openclaw__/mcp-app" });
-    const body = String(shell.end.mock.calls[0]?.[0]);
-    // The operation fetch must use the configured deadline plus a bounded grace,
-    // not the hardcoded 30s cap.
-    expect(body).toContain("Math.min(");
-    expect(body).toContain("config.timerSafeMax");
-    expect(body).toContain("AbortSignal.timeout(config.initialLoadTimeoutMs)");
-  });
-
-  it("preserves the configured timeout in the view payload even when the cached catalog is invalidated", async () => {
-    const customView = { ...view, requestTimeoutMs: 120_000 };
-    mocks.getMcpAppViewLease.mockReturnValue(customView);
-    runtime.peekCatalog.mockReturnValue(null as never);
-    const issued = issueTicket({ sessionKey: "agent:main:main", view: customView, nowMs, secret });
-    const accepted = await request({
-      url: "/__openclaw__/mcp-app/view",
-      authorization: `MCP-App ${issued.ticket}`,
-    });
-    expect(accepted.res.statusCode).toBe(200);
-    expect(JSON.parse(String(accepted.end.mock.calls[0]?.[0]))).toMatchObject({
-      requestTimeoutMs: 120_000,
-    });
-  });
-
-  it("clamps the browser operation timeout at the timer-safe maximum even when the configured deadline plus grace would overflow", async () => {
-    // requestTimeoutMs at the timer-safe maximum + 5,000 ms grace would overflow
-    // AbortSignal.timeout; the clamp must keep the serialized timeout within range.
-    const maxView = { ...view, requestTimeoutMs: MAX_TIMER_TIMEOUT_MS };
-    mocks.getMcpAppViewLease.mockReturnValue(maxView);
-    const issued = issueTicket({ sessionKey: "agent:main:main", view: maxView, nowMs, secret });
-    const accepted = await request({
-      url: "/__openclaw__/mcp-app/view",
-      authorization: `MCP-App ${issued.ticket}`,
-    });
-    expect(accepted.res.statusCode).toBe(200);
-    expect(JSON.parse(String(accepted.end.mock.calls[0]?.[0]))).toMatchObject({
-      requestTimeoutMs: MAX_TIMER_TIMEOUT_MS,
-    });
-
-    const shell = await request({ url: "/__openclaw__/mcp-app" });
-    const body = String(shell.end.mock.calls[0]?.[0]);
-    // The clamp is applied in the serialized host so the operation timeout stays
-    // within the timer-safe range even at the maximum configured deadline.
-    expect(body).toContain("Math.min(");
-    expect(body).toContain("config.timerSafeMax");
   });
 
   it("executes only owning-server app-visible allowed tools and resources", async () => {
@@ -466,32 +506,22 @@ describe("MCP App standalone host", () => {
     ).toBe(400);
   });
 
-  it("omits requestTimeoutMs from the view payload for native MCP App runtimes without a request-deadline contract", async () => {
-    const nativeRuntime = {
-      ...runtime,
-      getServerRequestTimeoutMs: undefined,
-    };
-    const nativeView = { ...view, runtime: nativeRuntime };
-    mocks.peekSessionMcpRuntime.mockReturnValue(nativeRuntime);
-    mocks.getMcpAppViewLease.mockReturnValue(nativeView);
+  it("omits the browser operation deadline when the view has no runtime deadline contract", async () => {
+    const noDeadlineView = { ...view, requestTimeoutMs: undefined };
+    mocks.getMcpAppViewLease.mockReturnValue(noDeadlineView);
 
-    const issued = issueTicket({ sessionKey: "agent:main:main", view: nativeView, nowMs, secret });
+    const issued = issueTicket({
+      sessionKey: "agent:main:main",
+      view: noDeadlineView,
+      nowMs,
+      secret,
+    });
     const accepted = await request({
       url: "/__openclaw__/mcp-app/view",
       authorization: `MCP-App ${issued.ticket}`,
     });
     expect(accepted.res.statusCode).toBe(200);
     const payload = JSON.parse(String(accepted.end.mock.calls[0]?.[0]));
-    expect(payload).not.toHaveProperty("requestTimeoutMs");
-
-    // The serialized browser host must keep the initial-load timeout but
-    // omit the operation AbortSignal for runtimes with no deadline contract.
-    const shell = await request({ url: "/__openclaw__/mcp-app" });
-    const html = String(shell.end.mock.calls[0]?.[0]);
-    expect(html).toContain("AbortSignal.timeout(config.initialLoadTimeoutMs)");
-    // The operation fetch uses a ternary that only adds AbortSignal when
-    // payload.requestTimeoutMs is set; for native runtimes the key is
-    // omitted, so the null check must be present.
-    expect(html).toContain("payload?.requestTimeoutMs != null");
+    expect(payload).not.toHaveProperty("operationTimeoutMs");
   });
 });

--- a/src/gateway/mcp-app-standalone.test.ts
+++ b/src/gateway/mcp-app-standalone.test.ts
@@ -61,6 +61,9 @@ const runtime = {
   acquireLease: vi.fn(() => releaseRuntimeLease),
   getCatalog: vi.fn(async () => defaultCatalog),
   peekCatalog: vi.fn(() => defaultCatalog),
+  getServerRequestTimeoutMs: vi.fn((serverName: string) =>
+    serverName === "demo" ? 60_000 : undefined,
+  ),
   callTool: vi.fn(async (serverName: string, toolName: string) => ({
     content: [{ type: "text", text: `${serverName}:${toolName}` }],
   })),

--- a/src/gateway/mcp-app-standalone.test.ts
+++ b/src/gateway/mcp-app-standalone.test.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage } from "node:http";
 import { Readable } from "node:stream";
+import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { makeMockHttpResponse } from "./test-http-response.js";
 
@@ -224,11 +225,10 @@ describe("MCP App standalone host", () => {
     expect(body).toContain("if (!initializeAccepted)");
     // Initial view load keeps a bounded timeout passed through serialized config;
     // operation fetches honor the configured MCP request deadline plus a bounded
-    // gateway grace.
+    // gateway grace clamped to the timer-safe maximum.
     expect(body).toContain("AbortSignal.timeout(config.initialLoadTimeoutMs)");
-    expect(body).toContain(
-      "(payload?.requestTimeoutMs ?? config.defaultRequestTimeoutMs) + config.requestTimeoutGraceMs",
-    );
+    expect(body).toContain("Math.min(");
+    expect(body).toContain("config.timerSafeMax");
     expect(body).not.toContain('postMessage(message, "*")');
     expect(body).not.toContain(view.html);
     expect(body).not.toContain("agent:main:main");
@@ -290,9 +290,8 @@ describe("MCP App standalone host", () => {
     const body = String(shell.end.mock.calls[0]?.[0]);
     // The operation fetch must use the configured deadline plus a bounded grace,
     // not the hardcoded 30s cap.
-    expect(body).toContain(
-      "(payload?.requestTimeoutMs ?? config.defaultRequestTimeoutMs) + config.requestTimeoutGraceMs",
-    );
+    expect(body).toContain("Math.min(");
+    expect(body).toContain("config.timerSafeMax");
     expect(body).toContain("AbortSignal.timeout(config.initialLoadTimeoutMs)");
   });
 
@@ -309,6 +308,29 @@ describe("MCP App standalone host", () => {
     expect(JSON.parse(String(accepted.end.mock.calls[0]?.[0]))).toMatchObject({
       requestTimeoutMs: 120_000,
     });
+  });
+
+  it("clamps the browser operation timeout at the timer-safe maximum even when the configured deadline plus grace would overflow", async () => {
+    // requestTimeoutMs at the timer-safe maximum + 5,000 ms grace would overflow
+    // AbortSignal.timeout; the clamp must keep the serialized timeout within range.
+    const maxView = { ...view, requestTimeoutMs: MAX_TIMER_TIMEOUT_MS };
+    mocks.getMcpAppViewLease.mockReturnValue(maxView);
+    const issued = issueTicket({ sessionKey: "agent:main:main", view: maxView, nowMs, secret });
+    const accepted = await request({
+      url: "/__openclaw__/mcp-app/view",
+      authorization: `MCP-App ${issued.ticket}`,
+    });
+    expect(accepted.res.statusCode).toBe(200);
+    expect(JSON.parse(String(accepted.end.mock.calls[0]?.[0]))).toMatchObject({
+      requestTimeoutMs: MAX_TIMER_TIMEOUT_MS,
+    });
+
+    const shell = await request({ url: "/__openclaw__/mcp-app" });
+    const body = String(shell.end.mock.calls[0]?.[0]);
+    // The clamp is applied in the serialized host so the operation timeout stays
+    // within the timer-safe range even at the maximum configured deadline.
+    expect(body).toContain("Math.min(");
+    expect(body).toContain("config.timerSafeMax");
   });
 
   it("executes only owning-server app-visible allowed tools and resources", async () => {

--- a/src/gateway/mcp-app-standalone.test.ts
+++ b/src/gateway/mcp-app-standalone.test.ts
@@ -222,9 +222,10 @@ describe("MCP App standalone host", () => {
     expect(body).toContain("location.hash");
     expect(body).toContain("event.origin");
     expect(body).toContain("if (!initializeAccepted)");
-    // Initial view load keeps a short bounded timeout; operation fetches honor
-    // the configured MCP request deadline plus a bounded gateway grace.
-    expect(body).toContain("AbortSignal.timeout(MCP_APP_STANDALONE_INITIAL_LOAD_TIMEOUT_MS)");
+    // Initial view load keeps a bounded timeout passed through serialized config;
+    // operation fetches honor the configured MCP request deadline plus a bounded
+    // gateway grace.
+    expect(body).toContain("AbortSignal.timeout(config.initialLoadTimeoutMs)");
     expect(body).toContain(
       "(payload?.requestTimeoutMs ?? config.defaultRequestTimeoutMs) + config.requestTimeoutGraceMs",
     );
@@ -292,7 +293,7 @@ describe("MCP App standalone host", () => {
     expect(body).toContain(
       "(payload?.requestTimeoutMs ?? config.defaultRequestTimeoutMs) + config.requestTimeoutGraceMs",
     );
-    expect(body).toContain("AbortSignal.timeout(MCP_APP_STANDALONE_INITIAL_LOAD_TIMEOUT_MS)");
+    expect(body).toContain("AbortSignal.timeout(config.initialLoadTimeoutMs)");
   });
 
   it("preserves the configured timeout in the view payload even when the cached catalog is invalidated", async () => {

--- a/src/gateway/mcp-app-standalone.test.ts
+++ b/src/gateway/mcp-app-standalone.test.ts
@@ -93,6 +93,7 @@ const view = {
   allowedAppToolNames: new Set(["shared", "app-only"]),
   toolInput: { city: "Paris" },
   toolResult: { content: [{ type: "text", text: "sunny" }] },
+  requestTimeoutMs: 60_000,
   expiresAtMs: nowMs + 10 * 60_000,
   requestWindowStartedAtMs: nowMs,
   requestCount: 0,
@@ -138,6 +139,7 @@ describe("MCP App standalone host", () => {
     Object.assign(view, {
       allowedAppToolNames: new Set(["shared", "app-only"]),
       readOnly: undefined,
+      requestTimeoutMs: 60_000,
       requestWindowStartedAtMs: nowMs,
       requestCount: 0,
       toolCallCount: 0,
@@ -218,9 +220,11 @@ describe("MCP App standalone host", () => {
     expect(body).toContain("event.origin");
     expect(body).toContain("if (!initializeAccepted)");
     // Initial view load keeps a short bounded timeout; operation fetches honor
-    // the configured MCP request deadline carried in the view payload.
+    // the configured MCP request deadline plus a bounded gateway grace.
     expect(body).toContain("AbortSignal.timeout(MCP_APP_STANDALONE_INITIAL_LOAD_TIMEOUT_MS)");
-    expect(body).toContain("payload?.requestTimeoutMs ?? config.defaultRequestTimeoutMs");
+    expect(body).toContain(
+      "(payload?.requestTimeoutMs ?? config.defaultRequestTimeoutMs) + config.requestTimeoutGraceMs",
+    );
     expect(body).not.toContain('postMessage(message, "*")');
     expect(body).not.toContain(view.html);
     expect(body).not.toContain("agent:main:main");
@@ -265,18 +269,10 @@ describe("MCP App standalone host", () => {
     });
   });
 
-  it("emits an operation fetch timeout that honors a non-default configured deadline", async () => {
-    const customCatalog = {
-      ...defaultCatalog,
-      servers: {
-        demo: {
-          ...defaultCatalog.servers.demo,
-          requestTimeoutMs: 120_000,
-        },
-      },
-    };
-    runtime.peekCatalog.mockReturnValue(customCatalog);
-    const issued = issueTicket({ sessionKey: "agent:main:main", view, nowMs, secret });
+  it("emits an operation fetch timeout that honors a non-default configured deadline plus gateway grace", async () => {
+    const customView = { ...view, requestTimeoutMs: 120_000 };
+    mocks.getMcpAppViewLease.mockReturnValue(customView);
+    const issued = issueTicket({ sessionKey: "agent:main:main", view: customView, nowMs, secret });
     const accepted = await request({
       url: "/__openclaw__/mcp-app/view",
       authorization: `MCP-App ${issued.ticket}`,
@@ -288,9 +284,27 @@ describe("MCP App standalone host", () => {
 
     const shell = await request({ url: "/__openclaw__/mcp-app" });
     const body = String(shell.end.mock.calls[0]?.[0]);
-    // The operation fetch must use the configured deadline, not the hardcoded 30s cap.
-    expect(body).toContain("payload?.requestTimeoutMs ?? config.defaultRequestTimeoutMs");
+    // The operation fetch must use the configured deadline plus a bounded grace,
+    // not the hardcoded 30s cap.
+    expect(body).toContain(
+      "(payload?.requestTimeoutMs ?? config.defaultRequestTimeoutMs) + config.requestTimeoutGraceMs",
+    );
     expect(body).toContain("AbortSignal.timeout(MCP_APP_STANDALONE_INITIAL_LOAD_TIMEOUT_MS)");
+  });
+
+  it("preserves the configured timeout in the view payload even when the cached catalog is invalidated", async () => {
+    const customView = { ...view, requestTimeoutMs: 120_000 };
+    mocks.getMcpAppViewLease.mockReturnValue(customView);
+    runtime.peekCatalog.mockReturnValue(null as never);
+    const issued = issueTicket({ sessionKey: "agent:main:main", view: customView, nowMs, secret });
+    const accepted = await request({
+      url: "/__openclaw__/mcp-app/view",
+      authorization: `MCP-App ${issued.ticket}`,
+    });
+    expect(accepted.res.statusCode).toBe(200);
+    expect(JSON.parse(String(accepted.end.mock.calls[0]?.[0]))).toMatchObject({
+      requestTimeoutMs: 120_000,
+    });
   });
 
   it("executes only owning-server app-visible allowed tools and resources", async () => {

--- a/src/gateway/mcp-app-standalone.test.ts
+++ b/src/gateway/mcp-app-standalone.test.ts
@@ -203,6 +203,7 @@ describe("MCP App standalone host", () => {
     expect(body).toContain("location.hash");
     expect(body).toContain("event.origin");
     expect(body).toContain("if (!initializeAccepted)");
+    expect(body).toMatch(/AbortSignal\.timeout\([^)]+\)/u);
     expect(body).not.toContain('postMessage(message, "*")');
     expect(body).not.toContain(view.html);
     expect(body).not.toContain("agent:main:main");

--- a/src/gateway/mcp-app-standalone.test.ts
+++ b/src/gateway/mcp-app-standalone.test.ts
@@ -36,19 +36,31 @@ function issueTicket(params: Parameters<typeof createMcpAppStandaloneTicket>[0])
 const nowMs = 1_800_000_000_000;
 const secret = Buffer.alloc(32, 7);
 const releaseRuntimeLease = vi.fn();
+const defaultCatalog = {
+  version: 1,
+  generatedAt: Date.now(),
+  servers: {
+    demo: {
+      serverName: "demo",
+      launchSummary: "demo server",
+      toolCount: 3,
+      requestTimeoutMs: 60_000,
+    },
+  },
+  tools: [
+    { serverName: "demo", toolName: "shared" },
+    { serverName: "demo", toolName: "app-only", uiVisibility: ["app"] },
+    { serverName: "demo", toolName: "model-only", uiVisibility: ["model"] },
+    { serverName: "other", toolName: "cross-only", uiVisibility: ["app"] },
+  ],
+};
 const runtime = {
   sessionId: "runtime-session",
   mcpAppsEnabled: true,
   markUsed: vi.fn(),
   acquireLease: vi.fn(() => releaseRuntimeLease),
-  getCatalog: vi.fn(async () => ({
-    tools: [
-      { serverName: "demo", toolName: "shared" },
-      { serverName: "demo", toolName: "app-only", uiVisibility: ["app"] },
-      { serverName: "demo", toolName: "model-only", uiVisibility: ["model"] },
-      { serverName: "other", toolName: "cross-only", uiVisibility: ["app"] },
-    ],
-  })),
+  getCatalog: vi.fn(async () => defaultCatalog),
+  peekCatalog: vi.fn(() => defaultCatalog),
   callTool: vi.fn(async (serverName: string, toolName: string) => ({
     content: [{ type: "text", text: `${serverName}:${toolName}` }],
   })),
@@ -133,6 +145,8 @@ describe("MCP App standalone host", () => {
     });
     mocks.peekSessionMcpRuntime.mockReturnValue(runtime);
     mocks.getMcpAppViewLease.mockReturnValue(view);
+    runtime.getCatalog.mockReturnValue(Promise.resolve(defaultCatalog));
+    runtime.peekCatalog.mockReturnValue(defaultCatalog);
   });
 
   it("mints an opaque ticket bound to the session, runtime, view, and lease", () => {
@@ -203,7 +217,10 @@ describe("MCP App standalone host", () => {
     expect(body).toContain("location.hash");
     expect(body).toContain("event.origin");
     expect(body).toContain("if (!initializeAccepted)");
-    expect(body).toMatch(/AbortSignal\.timeout\([^)]+\)/u);
+    // Initial view load keeps a short bounded timeout; operation fetches honor
+    // the configured MCP request deadline carried in the view payload.
+    expect(body).toContain("AbortSignal.timeout(MCP_APP_STANDALONE_INITIAL_LOAD_TIMEOUT_MS)");
+    expect(body).toContain("payload?.requestTimeoutMs ?? config.defaultRequestTimeoutMs");
     expect(body).not.toContain('postMessage(message, "*")');
     expect(body).not.toContain(view.html);
     expect(body).not.toContain("agent:main:main");
@@ -234,6 +251,46 @@ describe("MCP App standalone host", () => {
     expect(
       (await request({ url: route, authorization: `MCP-App ${issued.ticket}` })).res.statusCode,
     ).toBe(401);
+  });
+
+  it("includes the configured MCP request timeout in the view payload", async () => {
+    const issued = issueTicket({ sessionKey: "agent:main:main", view, nowMs, secret });
+    const accepted = await request({
+      url: "/__openclaw__/mcp-app/view",
+      authorization: `MCP-App ${issued.ticket}`,
+    });
+    expect(accepted.res.statusCode).toBe(200);
+    expect(JSON.parse(String(accepted.end.mock.calls[0]?.[0]))).toMatchObject({
+      requestTimeoutMs: 60_000,
+    });
+  });
+
+  it("emits an operation fetch timeout that honors a non-default configured deadline", async () => {
+    const customCatalog = {
+      ...defaultCatalog,
+      servers: {
+        demo: {
+          ...defaultCatalog.servers.demo,
+          requestTimeoutMs: 120_000,
+        },
+      },
+    };
+    runtime.peekCatalog.mockReturnValue(customCatalog);
+    const issued = issueTicket({ sessionKey: "agent:main:main", view, nowMs, secret });
+    const accepted = await request({
+      url: "/__openclaw__/mcp-app/view",
+      authorization: `MCP-App ${issued.ticket}`,
+    });
+    expect(accepted.res.statusCode).toBe(200);
+    expect(JSON.parse(String(accepted.end.mock.calls[0]?.[0]))).toMatchObject({
+      requestTimeoutMs: 120_000,
+    });
+
+    const shell = await request({ url: "/__openclaw__/mcp-app" });
+    const body = String(shell.end.mock.calls[0]?.[0]);
+    // The operation fetch must use the configured deadline, not the hardcoded 30s cap.
+    expect(body).toContain("payload?.requestTimeoutMs ?? config.defaultRequestTimeoutMs");
+    expect(body).toContain("AbortSignal.timeout(MCP_APP_STANDALONE_INITIAL_LOAD_TIMEOUT_MS)");
   });
 
   it("executes only owning-server app-visible allowed tools and resources", async () => {

--- a/src/gateway/mcp-app-standalone.ts
+++ b/src/gateway/mcp-app-standalone.ts
@@ -346,13 +346,15 @@ function runStandaloneMcpAppHost(config: {
       body: JSON.stringify({ method, params }),
       cache: "no-store",
       credentials: "omit",
-      signal: AbortSignal.timeout(
-        Math.min(
-          (payload?.requestTimeoutMs ?? config.defaultRequestTimeoutMs) +
-            config.requestTimeoutGraceMs,
-          config.timerSafeMax,
-        ),
-      ),
+      signal:
+        payload?.requestTimeoutMs != null
+          ? AbortSignal.timeout(
+              Math.min(
+                payload.requestTimeoutMs + config.requestTimeoutGraceMs,
+                config.timerSafeMax,
+              ),
+            )
+          : undefined,
     });
     const body = (await response.json().catch(() => undefined)) as
       | { ok?: boolean; result?: unknown; error?: string }
@@ -704,7 +706,9 @@ export async function handleMcpAppStandaloneHttpRequest(
               toolResult: view.toolResult,
               serverTools: supportsStandaloneToolOperations(view),
               serverResources: runtime.readResource !== undefined,
-              requestTimeoutMs: view.requestTimeoutMs,
+              ...(runtime.getServerRequestTimeoutMs !== undefined
+                ? { requestTimeoutMs: view.requestTimeoutMs }
+                : {}),
             }),
       );
       return true;

--- a/src/gateway/mcp-app-standalone.ts
+++ b/src/gateway/mcp-app-standalone.ts
@@ -224,6 +224,7 @@ function sendText(res: ServerResponse, statusCode: number, body: string): void {
 function runStandaloneMcpAppHost(config: {
   protocolVersion: string;
   viewPath: string;
+  initialLoadTimeoutMs: number;
   defaultRequestTimeoutMs: number;
   requestTimeoutGraceMs: number;
 }): void {
@@ -509,7 +510,7 @@ function runStandaloneMcpAppHost(config: {
     headers: { Authorization: `MCP-App ${ticket}` },
     cache: "no-store",
     credentials: "omit",
-    signal: AbortSignal.timeout(MCP_APP_STANDALONE_INITIAL_LOAD_TIMEOUT_MS),
+    signal: AbortSignal.timeout(config.initialLoadTimeoutMs),
   })
     .then(async (response) => {
       if (!response.ok) {
@@ -533,6 +534,7 @@ function standaloneHostHtml(): { html: string; scriptHash: string } {
   const clientSource = `(${runStandaloneMcpAppHost.toString()})(${JSON.stringify({
     protocolVersion: MCP_APP_STABLE_PROTOCOL_VERSION,
     viewPath: MCP_APP_STANDALONE_VIEW_PATH,
+    initialLoadTimeoutMs: MCP_APP_STANDALONE_INITIAL_LOAD_TIMEOUT_MS,
     defaultRequestTimeoutMs: DEFAULT_REQUEST_TIMEOUT_MS,
     requestTimeoutGraceMs: MCP_APP_STANDALONE_REQUEST_GRACE_MS,
   })});`;

--- a/src/gateway/mcp-app-standalone.ts
+++ b/src/gateway/mcp-app-standalone.ts
@@ -1,5 +1,6 @@
 import { createHash, createHmac, randomBytes } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { peekSessionMcpRuntime } from "../agents/agent-bundle-mcp-runtime.js";
 import { buildMcpAppSandboxPath, resolveMcpAppSandboxPort } from "../agents/mcp-app-sandbox.js";
 import { DEFAULT_REQUEST_TIMEOUT_MS } from "../agents/mcp-transport-config.js";
@@ -227,6 +228,7 @@ function runStandaloneMcpAppHost(config: {
   initialLoadTimeoutMs: number;
   defaultRequestTimeoutMs: number;
   requestTimeoutGraceMs: number;
+  timerSafeMax: number;
 }): void {
   type StandaloneElement = { className: string; textContent: string };
   type StandaloneFrame = StandaloneElement & {
@@ -345,8 +347,11 @@ function runStandaloneMcpAppHost(config: {
       cache: "no-store",
       credentials: "omit",
       signal: AbortSignal.timeout(
-        (payload?.requestTimeoutMs ?? config.defaultRequestTimeoutMs) +
-          config.requestTimeoutGraceMs,
+        Math.min(
+          (payload?.requestTimeoutMs ?? config.defaultRequestTimeoutMs) +
+            config.requestTimeoutGraceMs,
+          config.timerSafeMax,
+        ),
       ),
     });
     const body = (await response.json().catch(() => undefined)) as
@@ -537,6 +542,7 @@ function standaloneHostHtml(): { html: string; scriptHash: string } {
     initialLoadTimeoutMs: MCP_APP_STANDALONE_INITIAL_LOAD_TIMEOUT_MS,
     defaultRequestTimeoutMs: DEFAULT_REQUEST_TIMEOUT_MS,
     requestTimeoutGraceMs: MCP_APP_STANDALONE_REQUEST_GRACE_MS,
+    timerSafeMax: MAX_TIMER_TIMEOUT_MS,
   })});`;
   const escapedSource = clientSource.replaceAll("</script", "<\\/script");
   return {

--- a/src/gateway/mcp-app-standalone.ts
+++ b/src/gateway/mcp-app-standalone.ts
@@ -21,6 +21,11 @@ import {
 
 const MCP_APP_STANDALONE_TICKET_SCOPE = "mcp-app-standalone-view";
 const MCP_APP_STANDALONE_INITIAL_LOAD_TIMEOUT_MS = 30_000;
+// Grace added to the browser-side operation fetch so the outer timer expires
+// only after the runtime MCP deadline has had time to complete and the Gateway
+// has had time to return its response. This avoids visible false failures for
+// valid near-deadline operations.
+const MCP_APP_STANDALONE_REQUEST_GRACE_MS = 5_000;
 const MCP_APP_STANDALONE_TICKET_TTL_MS = 2 * 60_000;
 const MCP_APP_STANDALONE_TICKET_MIN_REMAINING_MS = 15_000;
 const MCP_APP_STANDALONE_TICKET_MAX_ENTRIES = 256;
@@ -220,6 +225,7 @@ function runStandaloneMcpAppHost(config: {
   protocolVersion: string;
   viewPath: string;
   defaultRequestTimeoutMs: number;
+  requestTimeoutGraceMs: number;
 }): void {
   type StandaloneElement = { className: string; textContent: string };
   type StandaloneFrame = StandaloneElement & {
@@ -337,7 +343,10 @@ function runStandaloneMcpAppHost(config: {
       body: JSON.stringify({ method, params }),
       cache: "no-store",
       credentials: "omit",
-      signal: AbortSignal.timeout(payload?.requestTimeoutMs ?? config.defaultRequestTimeoutMs),
+      signal: AbortSignal.timeout(
+        (payload?.requestTimeoutMs ?? config.defaultRequestTimeoutMs) +
+          config.requestTimeoutGraceMs,
+      ),
     });
     const body = (await response.json().catch(() => undefined)) as
       | { ok?: boolean; result?: unknown; error?: string }
@@ -525,6 +534,7 @@ function standaloneHostHtml(): { html: string; scriptHash: string } {
     protocolVersion: MCP_APP_STABLE_PROTOCOL_VERSION,
     viewPath: MCP_APP_STANDALONE_VIEW_PATH,
     defaultRequestTimeoutMs: DEFAULT_REQUEST_TIMEOUT_MS,
+    requestTimeoutGraceMs: MCP_APP_STANDALONE_REQUEST_GRACE_MS,
   })});`;
   const escapedSource = clientSource.replaceAll("</script", "<\\/script");
   return {
@@ -666,9 +676,9 @@ export async function handleMcpAppStandaloneHttpRequest(
   try {
     return await withMcpAppActiveView(active, "read", () => {
       const { runtime, view } = active;
-      const requestTimeoutMs =
-        runtime.peekCatalog()?.servers[view.serverName]?.requestTimeoutMs ??
-        DEFAULT_REQUEST_TIMEOUT_MS;
+      // The timeout was snapshotted onto the view when it was created, so it
+      // survives later catalog invalidation (e.g. tools/list_changed) that can
+      // clear the runtime's cached catalog.
       res.statusCode = 200;
       res.setHeader("Content-Type", "application/json; charset=utf-8");
       res.end(
@@ -686,7 +696,7 @@ export async function handleMcpAppStandaloneHttpRequest(
               toolResult: view.toolResult,
               serverTools: supportsStandaloneToolOperations(view),
               serverResources: runtime.readResource !== undefined,
-              requestTimeoutMs,
+              requestTimeoutMs: view.requestTimeoutMs,
             }),
       );
       return true;

--- a/src/gateway/mcp-app-standalone.ts
+++ b/src/gateway/mcp-app-standalone.ts
@@ -330,6 +330,7 @@ function runStandaloneMcpAppHost(config: { protocolVersion: string; viewPath: st
       body: JSON.stringify({ method, params }),
       cache: "no-store",
       credentials: "omit",
+      signal: AbortSignal.timeout(30_000),
     });
     const body = (await response.json().catch(() => undefined)) as
       | { ok?: boolean; result?: unknown; error?: string }
@@ -492,6 +493,7 @@ function runStandaloneMcpAppHost(config: { protocolVersion: string; viewPath: st
     headers: { Authorization: `MCP-App ${ticket}` },
     cache: "no-store",
     credentials: "omit",
+    signal: AbortSignal.timeout(30_000),
   })
     .then(async (response) => {
       if (!response.ok) {

--- a/src/gateway/mcp-app-standalone.ts
+++ b/src/gateway/mcp-app-standalone.ts
@@ -2,6 +2,7 @@ import { createHash, createHmac, randomBytes } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { peekSessionMcpRuntime } from "../agents/agent-bundle-mcp-runtime.js";
 import { buildMcpAppSandboxPath, resolveMcpAppSandboxPort } from "../agents/mcp-app-sandbox.js";
+import { DEFAULT_REQUEST_TIMEOUT_MS } from "../agents/mcp-transport-config.js";
 import { getMcpAppViewLease, type McpAppViewLease } from "../agents/mcp-ui-resource.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { safeEqualSecret } from "../security/secret-equal.js";
@@ -19,6 +20,7 @@ import {
 } from "./mcp-app-operations.js";
 
 const MCP_APP_STANDALONE_TICKET_SCOPE = "mcp-app-standalone-view";
+const MCP_APP_STANDALONE_INITIAL_LOAD_TIMEOUT_MS = 30_000;
 const MCP_APP_STANDALONE_TICKET_TTL_MS = 2 * 60_000;
 const MCP_APP_STANDALONE_TICKET_MIN_REMAINING_MS = 15_000;
 const MCP_APP_STANDALONE_TICKET_MAX_ENTRIES = 256;
@@ -214,7 +216,11 @@ function sendText(res: ServerResponse, statusCode: number, body: string): void {
   res.end(body);
 }
 
-function runStandaloneMcpAppHost(config: { protocolVersion: string; viewPath: string }): void {
+function runStandaloneMcpAppHost(config: {
+  protocolVersion: string;
+  viewPath: string;
+  defaultRequestTimeoutMs: number;
+}): void {
   type StandaloneElement = { className: string; textContent: string };
   type StandaloneFrame = StandaloneElement & {
     contentWindow?: { postMessage(message: unknown, targetOrigin: string): void };
@@ -257,6 +263,7 @@ function runStandaloneMcpAppHost(config: { protocolVersion: string; viewPath: st
     toolResult: unknown;
     serverTools?: boolean;
     serverResources?: boolean;
+    requestTimeoutMs?: number;
   };
 
   const host = browser.document.getElementById("host");
@@ -330,7 +337,7 @@ function runStandaloneMcpAppHost(config: { protocolVersion: string; viewPath: st
       body: JSON.stringify({ method, params }),
       cache: "no-store",
       credentials: "omit",
-      signal: AbortSignal.timeout(30_000),
+      signal: AbortSignal.timeout(payload?.requestTimeoutMs ?? config.defaultRequestTimeoutMs),
     });
     const body = (await response.json().catch(() => undefined)) as
       | { ok?: boolean; result?: unknown; error?: string }
@@ -493,7 +500,7 @@ function runStandaloneMcpAppHost(config: { protocolVersion: string; viewPath: st
     headers: { Authorization: `MCP-App ${ticket}` },
     cache: "no-store",
     credentials: "omit",
-    signal: AbortSignal.timeout(30_000),
+    signal: AbortSignal.timeout(MCP_APP_STANDALONE_INITIAL_LOAD_TIMEOUT_MS),
   })
     .then(async (response) => {
       if (!response.ok) {
@@ -517,6 +524,7 @@ function standaloneHostHtml(): { html: string; scriptHash: string } {
   const clientSource = `(${runStandaloneMcpAppHost.toString()})(${JSON.stringify({
     protocolVersion: MCP_APP_STABLE_PROTOCOL_VERSION,
     viewPath: MCP_APP_STANDALONE_VIEW_PATH,
+    defaultRequestTimeoutMs: DEFAULT_REQUEST_TIMEOUT_MS,
   })});`;
   const escapedSource = clientSource.replaceAll("</script", "<\\/script");
   return {
@@ -658,6 +666,9 @@ export async function handleMcpAppStandaloneHttpRequest(
   try {
     return await withMcpAppActiveView(active, "read", () => {
       const { runtime, view } = active;
+      const requestTimeoutMs =
+        runtime.peekCatalog()?.servers[view.serverName]?.requestTimeoutMs ??
+        DEFAULT_REQUEST_TIMEOUT_MS;
       res.statusCode = 200;
       res.setHeader("Content-Type", "application/json; charset=utf-8");
       res.end(
@@ -675,6 +686,7 @@ export async function handleMcpAppStandaloneHttpRequest(
               toolResult: view.toolResult,
               serverTools: supportsStandaloneToolOperations(view),
               serverResources: runtime.readResource !== undefined,
+              requestTimeoutMs,
             }),
       );
       return true;

--- a/src/gateway/mcp-app-standalone.ts
+++ b/src/gateway/mcp-app-standalone.ts
@@ -1,9 +1,8 @@
 import { createHash, createHmac, randomBytes } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
+import { addTimerTimeoutGraceMs } from "@openclaw/normalization-core/number-coercion";
 import { peekSessionMcpRuntime } from "../agents/agent-bundle-mcp-runtime.js";
 import { buildMcpAppSandboxPath, resolveMcpAppSandboxPort } from "../agents/mcp-app-sandbox.js";
-import { DEFAULT_REQUEST_TIMEOUT_MS } from "../agents/mcp-transport-config.js";
 import { getMcpAppViewLease, type McpAppViewLease } from "../agents/mcp-ui-resource.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { safeEqualSecret } from "../security/secret-equal.js";
@@ -22,11 +21,6 @@ import {
 
 const MCP_APP_STANDALONE_TICKET_SCOPE = "mcp-app-standalone-view";
 const MCP_APP_STANDALONE_INITIAL_LOAD_TIMEOUT_MS = 30_000;
-// Grace added to the browser-side operation fetch so the outer timer expires
-// only after the runtime MCP deadline has had time to complete and the Gateway
-// has had time to return its response. This avoids visible false failures for
-// valid near-deadline operations.
-const MCP_APP_STANDALONE_REQUEST_GRACE_MS = 5_000;
 const MCP_APP_STANDALONE_TICKET_TTL_MS = 2 * 60_000;
 const MCP_APP_STANDALONE_TICKET_MIN_REMAINING_MS = 15_000;
 const MCP_APP_STANDALONE_TICKET_MAX_ENTRIES = 256;
@@ -226,9 +220,6 @@ function runStandaloneMcpAppHost(config: {
   protocolVersion: string;
   viewPath: string;
   initialLoadTimeoutMs: number;
-  defaultRequestTimeoutMs: number;
-  requestTimeoutGraceMs: number;
-  timerSafeMax: number;
 }): void {
   type StandaloneElement = { className: string; textContent: string };
   type StandaloneFrame = StandaloneElement & {
@@ -272,7 +263,7 @@ function runStandaloneMcpAppHost(config: {
     toolResult: unknown;
     serverTools?: boolean;
     serverResources?: boolean;
-    requestTimeoutMs?: number;
+    operationTimeoutMs?: number;
   };
 
   const host = browser.document.getElementById("host");
@@ -289,6 +280,12 @@ function runStandaloneMcpAppHost(config: {
     value && typeof value === "object" && !Array.isArray(value)
       ? (value as Record<string, unknown>)
       : undefined;
+  const errorMessage = (error: unknown, timeoutMessage: string) =>
+    asRecord(error)?.name === "TimeoutError"
+      ? timeoutMessage
+      : error instanceof Error
+        ? error.message
+        : String(error);
   const fail = (message: string) => {
     frame?.remove();
     frame = undefined;
@@ -347,13 +344,8 @@ function runStandaloneMcpAppHost(config: {
       cache: "no-store",
       credentials: "omit",
       signal:
-        payload?.requestTimeoutMs != null
-          ? AbortSignal.timeout(
-              Math.min(
-                payload.requestTimeoutMs + config.requestTimeoutGraceMs,
-                config.timerSafeMax,
-              ),
-            )
+        payload?.operationTimeoutMs != null
+          ? AbortSignal.timeout(payload.operationTimeoutMs)
           : undefined,
     });
     const body = (await response.json().catch(() => undefined)) as
@@ -500,7 +492,7 @@ function runStandaloneMcpAppHost(config: {
         reject(
           message.id as JsonRpcId,
           -32000,
-          error instanceof Error ? error.message : "MCP App operation failed",
+          errorMessage(error, "MCP App operation timed out; try again"),
         ),
       );
   });
@@ -534,18 +526,18 @@ function runStandaloneMcpAppHost(config: {
       frame.src = sandboxUrl.href;
       host?.replaceChildren(frame);
     })
-    .catch((error: unknown) => fail(error instanceof Error ? error.message : String(error)));
+    .catch((error: unknown) =>
+      fail(errorMessage(error, "MCP App view timed out; reload to try again")),
+    );
 }
 
 function standaloneHostHtml(): { html: string; scriptHash: string } {
-  const clientSource = `(${runStandaloneMcpAppHost.toString()})(${JSON.stringify({
+  const serializedConfig = JSON.stringify({
     protocolVersion: MCP_APP_STABLE_PROTOCOL_VERSION,
     viewPath: MCP_APP_STANDALONE_VIEW_PATH,
     initialLoadTimeoutMs: MCP_APP_STANDALONE_INITIAL_LOAD_TIMEOUT_MS,
-    defaultRequestTimeoutMs: DEFAULT_REQUEST_TIMEOUT_MS,
-    requestTimeoutGraceMs: MCP_APP_STANDALONE_REQUEST_GRACE_MS,
-    timerSafeMax: MAX_TIMER_TIMEOUT_MS,
-  })});`;
+  });
+  const clientSource = `;(() => { const __name = (target) => target; (${runStandaloneMcpAppHost.toString()})(${serializedConfig}); })();`;
   const escapedSource = clientSource.replaceAll("</script", "<\\/script");
   return {
     html: `<!doctype html>
@@ -686,9 +678,6 @@ export async function handleMcpAppStandaloneHttpRequest(
   try {
     return await withMcpAppActiveView(active, "read", () => {
       const { runtime, view } = active;
-      // The timeout was snapshotted onto the view when it was created, so it
-      // survives later catalog invalidation (e.g. tools/list_changed) that can
-      // clear the runtime's cached catalog.
       res.statusCode = 200;
       res.setHeader("Content-Type", "application/json; charset=utf-8");
       res.end(
@@ -706,8 +695,12 @@ export async function handleMcpAppStandaloneHttpRequest(
               toolResult: view.toolResult,
               serverTools: supportsStandaloneToolOperations(view),
               serverResources: runtime.readResource !== undefined,
-              ...(runtime.getServerRequestTimeoutMs !== undefined
-                ? { requestTimeoutMs: view.requestTimeoutMs }
+              ...(view.requestTimeoutMs !== undefined
+                ? {
+                    // Keep the browser's outer deadline behind the SDK request
+                    // so a valid near-deadline response can reach the App.
+                    operationTimeoutMs: addTimerTimeoutGraceMs(view.requestTimeoutMs),
+                  }
                 : {}),
             }),
       );


### PR DESCRIPTION
<!--
Related: gap finding — MCP App standalone requests could stall without a visible bounded outcome.
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Standalone MCP Apps now give every stalled browser action a bounded, visible result:

- the initial view fetch times out after 30 seconds and tells the user to reload;
- tool/resource operations use the view's configured MCP request deadline plus the repository's canonical timer-safe grace;
- runtimes with no deadline contract continue without an invented operation timeout;
- configured deadlines are snapshotted from the connected MCP session into the view lease, so `tools/list_changed` catalog invalidation cannot erase or replace them;
- the stringified browser host is self-contained under the production build transform, including its injected `__name` helper.

## Ownership and implementation

The connected MCP session owns each server's configured request timeout. View creation records that fact on the lease immediately after `resources/read`; the combined runtime delegates the same accessor. The Gateway then emits optional `operationTimeoutMs = addTimerTimeoutGraceMs(view.requestTimeoutMs)` in the standalone view payload. The browser host consumes that already-normalized value and does not rediscover catalog/default policy.

The generated host passes the fixed initial-load deadline through serialized config. Its wrapper injects the same local no-op `__name` helper used by the existing Control UI serialized-host test owner, preventing the build transform's `__name(...)` calls from becoming detached unresolved references after `Function#toString()`.

## User impact

- Blank or permanently loading standalone views become an actionable timeout message.
- Hanging operations return `MCP App operation timed out; try again`.
- Valid near-deadline MCP responses retain a 5-second outer delivery grace.
- Custom server deadlines survive catalog refresh/invalidation for the lifetime of the view.
- Normal requests and native no-deadline runtimes preserve their existing behavior.

## Evidence

Reviewed head: `6b87395f6ab6d915443437c2efc779c57de13ba6`

Blacksmith Testbox [run 31299757689](https://github.com/openclaw/openclaw/actions/runs/31299757689) executed the actual generated shell in headless Chromium over real HTTP:

- hanging initial GET aborted at 30.379 seconds and rendered `MCP App view timed out; reload to try again`;
- hanging operation POST aborted and returned `MCP App operation timed out; try again`;
- the normal operation completed with its expected result;
- both intentionally hanging HTTP requests were observed aborted.

The same run passed:

- `src/gateway/mcp-app-standalone.test.ts`: 11/11;
- `src/agents/agent-bundle-mcp-runtime.test.ts` plus `src/agents/mcp-ui-resource.test.ts`: 101/101;
- targeted oxfmt and oxlint for all eight changed files;
- full `pnpm build`.

After the final LOC-only config extraction, [run 31300131443](https://github.com/openclaw/openclaw/actions/runs/31300131443) passed the exact final gateway test (11/11), oxfmt, and oxlint. Final Codex autoreview is clean at 0.99 confidence with no actionable/P0 finding.

## Repair Doctrine / LOC

Original contributor head: production `+61/-2` (net `+59`), tests `+167/-8` (net `+159`), total net `+218`.

Final head: production `+48/-5` (net `+43`), tests `+168/-1` (net `+167`), total net `+210`, across the intended eight files.

Removed duplicate paths include the transport-level default-timeout export/fallback, catalog-derived deadline fallback, browser-side grace/clamp policy literals, unused serialized config, redundant clamp/synthetic tests, and duplicate VM scaffolding. The remaining positive production LOC records the session/view deadline contract and supplies the browser/Gateway cancellation and visible-outcome capability.
