### PR TITLE
fix(openai): fall back to registration config when runtime config facade is absent

### DIFF
--- a/extensions/openai/index.test.ts
+++ b/extensions/openai/index.test.ts
@@ -14,6 +14,10 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildOpenAIImageGenerationProvider } from "./image-generation-provider.js";
 import plugin from "./index.js";
+import {
+  createPreflightRequest,
+  createResponseHarness,
+} from "./realtime-quicksilver.test-helpers.js";
 
 const OPENAI_FRIENDLY_PROMPT_OVERLAY = GPT5_FRIENDLY_CHAT_PROMPT_OVERLAY;
 const OPENAI_GPT5_BEHAVIOR_CONTRACT = GPT5_BEHAVIOR_CONTRACT;
@@ -183,6 +187,52 @@ describe("openai plugin", () => {
         cleanup: expect.any(Function),
       }),
     );
+    await registerRuntimeLifecycle.mock.calls[0]?.[0].cleanup({ reason: "disable" });
+  });
+
+  it("serves the GPT-Live offer route from the registration config when the runtime config facade is absent", async () => {
+    const registerHttpRoute = vi.fn();
+    const registerRuntimeLifecycle = vi.fn();
+    // The HTTP-route registration context (Browser Talk WebRTC offer path) has no
+    // runtime config facade: api.runtime.config is absent, so the broker's getConfig
+    // must fall back to the registration snapshot instead of throwing a TypeError
+    // ("Cannot read properties of undefined (reading 'current')").
+    const registrationConfig = {
+      gateway: { controlUi: { allowedOrigins: ["https://control.example.test"] } },
+    } as never;
+    plugin.register(
+      createTestPluginApi({
+        id: "openai",
+        name: "OpenAI Provider",
+        source: "test",
+        config: registrationConfig,
+        runtime: {} as never,
+        registerHttpRoute,
+        registerRuntimeLifecycle,
+      }),
+    );
+
+    const route = registerHttpRoute.mock.calls[0]?.[0] as {
+      path: string;
+      handler: (req: unknown, res: unknown) => Promise<boolean>;
+    };
+    expect(route.path).toBe("/plugins/openai/realtime/calls");
+
+    // An OPTIONS preflight from the registration config's allowed origin must be
+    // answered from the registration snapshot (204 + allow header), proving the
+    // route reached provider/CORS handling without a runtime-config TypeError.
+    const res = createResponseHarness();
+    const handled = await route.handler(
+      createPreflightRequest("https://control.example.test", "localhost:8788"),
+      res.res,
+    );
+    expect(handled).toBe(true);
+    expect(res.res.statusCode).toBe(204);
+    expect(res.setHeader).toHaveBeenCalledWith(
+      "Access-Control-Allow-Origin",
+      "https://control.example.test",
+    );
+
     await registerRuntimeLifecycle.mock.calls[0]?.[0].cleanup({ reason: "disable" });
   });
 

--- a/extensions/openai/index.ts
+++ b/extensions/openai/index.ts
@@ -29,8 +29,7 @@ export default definePluginEntry({
     const quicksilverSession =
       api.registrationMode === "full"
         ? acquireOpenAIQuicksilverBrowserSessionBroker({
-            getConfig: () =>
-              (api.runtime.config?.current?.() ?? api.config) as OpenClawConfig,
+            getConfig: () => (api.runtime.config?.current?.() ?? api.config) as OpenClawConfig,
             logger: api.logger,
           })
         : undefined;

--- a/extensions/openai/index.ts
+++ b/extensions/openai/index.ts
@@ -1,5 +1,4 @@
 // Openai plugin entrypoint registers its OpenClaw integration.
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolvePluginConfigObject } from "openclaw/plugin-sdk/plugin-config-runtime";
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { buildProviderToolCompatFamilyHooks } from "openclaw/plugin-sdk/provider-tools";
@@ -29,7 +28,7 @@ export default definePluginEntry({
     const quicksilverSession =
       api.registrationMode === "full"
         ? acquireOpenAIQuicksilverBrowserSessionBroker({
-            getConfig: () => api.runtime.config.current() as OpenClawConfig,
+            getConfig: () => api.runtime.config?.current?.() ?? api.config,
             logger: api.logger,
           })
         : undefined;

--- a/extensions/openai/index.ts
+++ b/extensions/openai/index.ts
@@ -1,4 +1,5 @@
 // Openai plugin entrypoint registers its OpenClaw integration.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolvePluginConfigObject } from "openclaw/plugin-sdk/plugin-config-runtime";
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { buildProviderToolCompatFamilyHooks } from "openclaw/plugin-sdk/provider-tools";
@@ -28,7 +29,8 @@ export default definePluginEntry({
     const quicksilverSession =
       api.registrationMode === "full"
         ? acquireOpenAIQuicksilverBrowserSessionBroker({
-            getConfig: () => api.runtime.config?.current?.() ?? api.config,
+            getConfig: () =>
+              (api.runtime.config?.current?.() ?? api.config) as OpenClawConfig,
             logger: api.logger,
           })
         : undefined;


### PR DESCRIPTION
## What Problem This Solves

Browser Talk WebRTC fails with HTTP 500 when the OpenAI plugin's GPT-Live broker captures `api.runtime.config.current()` unconditionally. In HTTP-route registration contexts the runtime config facade can be unavailable, so the Gateway route throws `TypeError: Cannot read properties of undefined (reading 'current')` before any provider negotiation happens. Reproduced twice in the Control UI after Gateway restart on `2026.7.2` (see #119274).

## Why

`api.runtime` is resolved lazily (`src/plugins/registry-runtime.ts`) and the `config` facade on it is not guaranteed to exist in every registration context the plugin entry runs in. The broker's `getConfig` contract already accepts `OpenClawConfig | undefined` (`extensions/openai/realtime-gpt-live-session.ts:154`), so the unguarded dereference was both a crash and a contract mismatch. The registration-time snapshot `api.config` is always available.

## User Impact

OpenAI Browser Talk / GPT-Live voice input no longer dies with a client-side HTTP 500 before SDP negotiation. The route falls back to the registration snapshot when the live facade is absent, so a real offer reaches OpenAI and returns either the provider SDP answer or a meaningful 4xx/5xx with the provider's reason (as the reporter verified locally: a malformed SDP now returns OpenAI's parse error instead of a TypeError).

## Evidence

Code change (`extensions/openai/index.ts`):

```diff
-            getConfig: () => api.runtime.config.current() as OpenClawConfig,
+            getConfig: () => api.runtime.config?.current?.() ?? api.config,
```

- **Regression test (commit `65cb87cc18e`, `extensions/openai/index.test.ts`) — `serves the GPT-Live offer route from the registration config when the runtime config facade is absent`**: registers the plugin with an absent runtime config facade (the HTTP-route registration context from #119274) and invokes the captured `/plugins/openai/realtime/calls` route with an OPTIONS preflight from the registration config's `gateway.controlUi.allowedOrigins`. The route answers 204 with `Access-Control-Allow-Origin: https://control.example.test` — served from the registration snapshot — instead of throwing. The test is discriminating: against the unguarded `api.runtime.config.current()` line it fails with the issue's exact `TypeError: Cannot read properties of undefined (reading 'current')`; with the fallback `(api.runtime.config?.current?.() ?? api.config)` it passes. Verified both ways locally on the PR head and on unmodified `main`. Run: `npx vitest run extensions/openai/index.test.ts` — **17/17 passed** on head `65cb87cc18e`.
- Inline verification: the affected broker test suite (`vitest.extension-provider-openai.config.ts`) passes with the change; `extensions/openai/index.test.ts` green. The 4 failing tests in that config (tts/embedding-batch/video-generation) fail identically on unmodified `main` (network-dependent mocks, verified by stash round-trip) and are unrelated to this change.
- Type contract: `getConfig: () => OpenClawConfig | undefined` already permits `undefined`, and `api.config` is a required `OpenClawConfig` snapshot on the plugin API (`src/plugins/plugin-api.types.ts:182`), so the fallback is type-safe.
- Reporter's on-device validation (from the issue): after the same fallback, a malformed SDP POST returned HTTP 502 with OpenAI's "failed to unmarshal SDP" instead of HTTP 500, and a subsequent attempt completed after microphone permission was granted.

[AI-assisted]

## CI status

- Latest CI on head `65cb87cc18e5`: re-running after the regression-test commit; previous head `f4b12424d6f3` was fully green.
- `Real behavior proof` check: success.
