### PR TITLE
fix(media): roll back partial generated batches

### DIFF
--- a/src/agents/tools/generated-media-batch-persistence.test.ts
+++ b/src/agents/tools/generated-media-batch-persistence.test.ts
@@ -1,0 +1,82 @@
+import fs from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import { resolveMediaBufferPath, saveMediaBuffer, type SavedMedia } from "../../media/store.js";
+import { withTempDir } from "../../test-helpers/temp-dir.js";
+import { createDeferred } from "../../test-utils/deferred.js";
+import { withEnvAsync } from "../../test-utils/env.js";
+import { persistGeneratedMediaBatch } from "./generated-media-batch-persistence.js";
+
+const GENERATED_MEDIA_SUBDIR = "generated";
+
+async function expectSavedMediaMissing(saved: SavedMedia): Promise<void> {
+  await expect(resolveMediaBufferPath(saved.id, GENERATED_MEDIA_SUBDIR)).rejects.toThrow(
+    "media ID does not resolve to a file",
+  );
+}
+
+describe("persistGeneratedMediaBatch filesystem rollback", () => {
+  it("removes a real file when a later sequential save fails", async () => {
+    await withTempDir({ prefix: "openclaw-generated-media-batch-" }, async (stateDir) => {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+        const payload = Buffer.from("persisted before failure");
+        let saved: SavedMedia | undefined;
+        const failure = new Error("later save failed");
+
+        await expect(
+          persistGeneratedMediaBatch({
+            subdir: GENERATED_MEDIA_SUBDIR,
+            mode: "sequential",
+            saves: [
+              async () => {
+                saved = await saveMediaBuffer(payload, "text/plain", GENERATED_MEDIA_SUBDIR);
+                const savedPath = await resolveMediaBufferPath(saved.id, GENERATED_MEDIA_SUBDIR);
+                await expect(fs.readFile(savedPath)).resolves.toEqual(payload);
+                return { value: savedPath, savedMedia: saved };
+              },
+              async () => {
+                throw failure;
+              },
+            ],
+          }),
+        ).rejects.toBe(failure);
+
+        expect(saved).toBeDefined();
+        await expectSavedMediaMissing(saved!);
+      });
+    });
+  });
+
+  it("drains and removes a real concurrent write that finishes after failure", async () => {
+    await withTempDir({ prefix: "openclaw-generated-media-batch-" }, async (stateDir) => {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+        const releaseLateSave = createDeferred();
+        const payload = Buffer.from("persisted after failure");
+        let saved: SavedMedia | undefined;
+        const failure = new Error("concurrent save failed");
+
+        await expect(
+          persistGeneratedMediaBatch({
+            subdir: GENERATED_MEDIA_SUBDIR,
+            mode: "concurrent",
+            saves: [
+              async () => {
+                await releaseLateSave.promise;
+                saved = await saveMediaBuffer(payload, "text/plain", GENERATED_MEDIA_SUBDIR);
+                const savedPath = await resolveMediaBufferPath(saved.id, GENERATED_MEDIA_SUBDIR);
+                await expect(fs.readFile(savedPath)).resolves.toEqual(payload);
+                return { value: savedPath, savedMedia: saved };
+              },
+              async () => {
+                releaseLateSave.resolve();
+                throw failure;
+              },
+            ],
+          }),
+        ).rejects.toBe(failure);
+
+        expect(saved).toBeDefined();
+        await expectSavedMediaMissing(saved!);
+      });
+    });
+  });
+});

--- a/src/agents/tools/generated-media-batch-persistence.ts
+++ b/src/agents/tools/generated-media-batch-persistence.ts
@@ -1,0 +1,58 @@
+import { deleteMediaBuffer, type SavedMedia } from "../../media/store.js";
+
+type GeneratedMediaSave<T> = {
+  value: T;
+  savedMedia?: SavedMedia;
+};
+
+type GeneratedMediaSaveMode = "concurrent" | "sequential";
+
+/** Gives generated-media batches all-or-nothing result semantics with best-effort rollback. */
+export async function persistGeneratedMediaBatch<T>(params: {
+  subdir: string;
+  saves: ReadonlyArray<() => Promise<GeneratedMediaSave<T>>>;
+  mode: GeneratedMediaSaveMode;
+}): Promise<T[]> {
+  let firstFailure: { error: unknown } | undefined;
+  const savedMedia: Array<SavedMedia | undefined> = [];
+  const runSave = async (save: () => Promise<GeneratedMediaSave<T>>, index: number) => {
+    try {
+      const result = await save();
+      savedMedia[index] = result.savedMedia;
+      return result.value;
+    } catch (error) {
+      firstFailure ??= { error };
+      throw error;
+    }
+  };
+
+  let values: T[];
+  if (params.mode === "concurrent") {
+    const settled = await Promise.allSettled(
+      params.saves.map((save, index) => runSave(save, index)),
+    );
+    values = settled.flatMap((entry) => (entry.status === "fulfilled" ? [entry.value] : []));
+  } else {
+    values = [];
+    for (const [index, save] of params.saves.entries()) {
+      try {
+        values.push(await runSave(save, index));
+      } catch {
+        break;
+      }
+    }
+  }
+
+  if (firstFailure) {
+    // Concurrent batches must drain sibling writes before cleanup so a late
+    // success cannot escape rollback after the caller observes failure.
+    await Promise.allSettled(
+      savedMedia.flatMap((saved) =>
+        saved ? [Promise.resolve().then(() => deleteMediaBuffer(saved.id, params.subdir))] : [],
+      ),
+    );
+    throw firstFailure.error;
+  }
+
+  return values;
+}

--- a/src/agents/tools/image-generate-tool.test.ts
+++ b/src/agents/tools/image-generate-tool.test.ts
@@ -768,6 +768,69 @@ describe("createImageGenerateTool", () => {
     expect(text).not.toMatch(/^MEDIA:/m);
   });
 
+  it("rolls back late image saves after a concurrent persistence failure", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "test");
+    stubImageGenerationProviders();
+    vi.spyOn(imageGenerationRuntime, "generateImage").mockResolvedValue({
+      provider: "openai",
+      model: "gpt-image-1",
+      attempts: [],
+      ignoredOverrides: [],
+      images: [
+        { buffer: Buffer.from("failed"), mimeType: "image/png", fileName: "failed.png" },
+        { buffer: Buffer.from("late"), mimeType: "image/png", fileName: "late.png" },
+        { buffer: Buffer.from("saved"), mimeType: "image/png", fileName: "saved.png" },
+      ],
+    });
+    const terminalError = new Error("image persistence failed");
+    const lateSavedMedia = {
+      path: "/tmp/late.png",
+      id: "late.png",
+      size: 4,
+      contentType: "image/png",
+    };
+    let resolveLateSave!: (saved: typeof lateSavedMedia) => void;
+    const lateSave = new Promise<typeof lateSavedMedia>((resolve) => {
+      resolveLateSave = resolve;
+    });
+    const immediatelySavedMedia = {
+      path: "/tmp/saved.png",
+      id: "saved.png",
+      size: 5,
+      contentType: "image/png",
+    };
+    const saveMediaBuffer = vi
+      .spyOn(mediaStore, "saveMediaBuffer")
+      .mockRejectedValueOnce(terminalError)
+      .mockImplementationOnce(() => lateSave)
+      .mockResolvedValueOnce(immediatelySavedMedia);
+    const deleteMediaBuffer = vi
+      .spyOn(mediaStore, "deleteMediaBuffer")
+      .mockRejectedValueOnce(new Error("image cleanup failed"))
+      .mockResolvedValueOnce(undefined);
+    const tool = createToolWithPrimaryImageModel("openai/gpt-image-1");
+
+    const execution = tool.execute("call-partial-save", { prompt: "three images", count: 3 });
+    let executionSettled = false;
+    void execution.then(
+      () => {
+        executionSettled = true;
+      },
+      () => {
+        executionSettled = true;
+      },
+    );
+    await vi.waitFor(() => expect(saveMediaBuffer).toHaveBeenCalledTimes(3));
+    await Promise.resolve();
+    expect(executionSettled).toBe(false);
+
+    resolveLateSave(lateSavedMedia);
+    await expect(execution).rejects.toBe(terminalError);
+    expect(deleteMediaBuffer).toHaveBeenCalledTimes(2);
+    expect(deleteMediaBuffer).toHaveBeenNthCalledWith(1, "late.png", "tool-image-generation");
+    expect(deleteMediaBuffer).toHaveBeenNthCalledWith(2, "saved.png", "tool-image-generation");
+  });
+
   it("runs explicit deployment refs and preserves timeout-only image defaults", async () => {
     vi.spyOn(imageGenerationRuntime, "listRuntimeImageGenerationProviders").mockReturnValue([
       {

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -58,6 +58,7 @@ import {
   readPositiveIntegerParam,
   readStringParam,
 } from "./common.js";
+import { persistGeneratedMediaBatch } from "./generated-media-batch-persistence.js";
 import {
   completeImageGenerationTaskRun,
   createImageGenerationTaskRun,
@@ -110,6 +111,7 @@ import {
 
 const DEFAULT_COUNT = 1;
 const MAX_COUNT = 4;
+const GENERATED_IMAGE_MEDIA_SUBDIR = "tool-image-generation";
 const DEFAULT_MAX_INPUT_IMAGES = 10;
 const MAX_REFERENCE_IMAGE_INPUTS = 14;
 const DEFAULT_RESOLUTION: ImageGenerationResolution = "1K";
@@ -784,17 +786,20 @@ async function executeImageGenerationJob(params: {
       Boolean(normalizedAspectRatio));
 
   const mediaMaxBytes = resolveGeneratedMediaMaxBytes(params.effectiveCfg, "image");
-  const savedImages = await Promise.all(
-    result.images.map((image) =>
-      saveMediaBuffer(
+  const savedImages = await persistGeneratedMediaBatch({
+    subdir: GENERATED_IMAGE_MEDIA_SUBDIR,
+    mode: "concurrent",
+    saves: result.images.map((image) => async () => {
+      const savedMedia = await saveMediaBuffer(
         image.buffer,
         image.mimeType,
-        "tool-image-generation",
+        GENERATED_IMAGE_MEDIA_SUBDIR,
         mediaMaxBytes,
         params.filename || image.fileName,
-      ),
-    ),
-  );
+      );
+      return { value: savedMedia, savedMedia };
+    }),
+  });
 
   const revisedPrompts = result.images
     .map((image) => image.revisedPrompt?.trim())

--- a/src/agents/tools/music-generate-tool.test.ts
+++ b/src/agents/tools/music-generate-tool.test.ts
@@ -51,6 +51,7 @@ const configMocks = vi.hoisted(() => ({
 }));
 
 const mediaStoreMocks = vi.hoisted(() => ({
+  deleteMediaBuffer: vi.fn(),
   saveMediaBuffer: vi.fn(),
 }));
 const probeMediaFilesWithinBudgetMock = vi.hoisted(() =>
@@ -188,6 +189,7 @@ function resetMusicGenerateMocks() {
   vi.restoreAllMocks();
   vi.spyOn(musicGenerationRuntime, "listRuntimeMusicGenerationProviders").mockReturnValue([]);
   musicGenerationRuntimeMocks.generateMusic.mockReset();
+  mediaStoreMocks.deleteMediaBuffer.mockReset();
   mediaStoreMocks.saveMediaBuffer.mockReset();
   vi.mocked(webMedia.loadWebMedia).mockReset();
   probeMediaFilesWithinBudgetMock.mockReset();
@@ -1133,6 +1135,67 @@ describe("createMusicGenerateTool", () => {
     const details = detailsOf(result);
     expect(details.duplicateGuard).toBe(true);
     expect(details.active).toBe(false);
+  });
+
+  it("rolls back late music saves after a concurrent persistence failure", async () => {
+    vi.spyOn(musicGenerationRuntime, "generateMusic").mockResolvedValue({
+      provider: "minimax",
+      model: "music-2.6",
+      attempts: [],
+      ignoredOverrides: [],
+      tracks: [
+        { buffer: Buffer.from("failed"), mimeType: "audio/mpeg", fileName: "failed.mp3" },
+        { buffer: Buffer.from("late"), mimeType: "audio/mpeg", fileName: "late.mp3" },
+      ],
+    });
+    const terminalError = new Error("music persistence failed");
+    const lateSavedMedia = {
+      path: "/tmp/late.mp3",
+      id: "late.mp3",
+      size: 4,
+      contentType: "audio/mpeg",
+    };
+    let resolveLateSave!: (saved: typeof lateSavedMedia) => void;
+    const lateSave = new Promise<typeof lateSavedMedia>((resolve) => {
+      resolveLateSave = resolve;
+    });
+    mediaStoreMocks.saveMediaBuffer
+      .mockRejectedValueOnce(terminalError)
+      .mockImplementationOnce(() => lateSave);
+    mediaStoreMocks.deleteMediaBuffer.mockRejectedValueOnce(new Error("music cleanup failed"));
+    const tool = expectMusicGenerateTool(
+      createMusicGenerateTool({
+        config: asConfig({
+          agents: {
+            defaults: {
+              musicGenerationModel: { primary: "minimax/music-2.6" },
+            },
+          },
+        }),
+      }),
+    );
+
+    const execution = tool.execute("call-partial-save", { prompt: "two tracks" });
+    let executionSettled = false;
+    void execution.then(
+      () => {
+        executionSettled = true;
+      },
+      () => {
+        executionSettled = true;
+      },
+    );
+    await vi.waitFor(() => expect(mediaStoreMocks.saveMediaBuffer).toHaveBeenCalledTimes(2));
+    await Promise.resolve();
+    expect(executionSettled).toBe(false);
+
+    resolveLateSave(lateSavedMedia);
+    await expect(execution).rejects.toBe(terminalError);
+    expect(mediaStoreMocks.deleteMediaBuffer).toHaveBeenCalledTimes(1);
+    expect(mediaStoreMocks.deleteMediaBuffer).toHaveBeenCalledWith(
+      "late.mp3",
+      "tool-music-generation",
+    );
   });
 
   it("lists provider capabilities", async () => {

--- a/src/agents/tools/music-generate-tool.ts
+++ b/src/agents/tools/music-generate-tool.ts
@@ -40,6 +40,7 @@ import {
 } from "../media-generation-task-status-shared.js";
 import type { PreparedModelRuntimeSnapshot } from "../prepared-model-runtime.js";
 import { ToolInputError, readNumberParam, readStringParam } from "./common.js";
+import { persistGeneratedMediaBatch } from "./generated-media-batch-persistence.js";
 import { decodeDataUrl } from "./image-tool.helpers.js";
 import {
   buildMediaGenerationStartedToolResult,
@@ -91,6 +92,7 @@ import {
 
 const log = createSubsystemLogger("agents/tools/music-generate");
 const MAX_INPUT_IMAGES = 10;
+const GENERATED_MUSIC_MEDIA_SUBDIR = "tool-music-generation";
 const SUPPORTED_OUTPUT_FORMATS = new Set<MusicGenerationOutputFormat>(["mp3", "wav"]);
 const DEFAULT_REFERENCE_FETCH_TIMEOUT_MS = 30_000;
 const DEFAULT_MUSIC_GENERATION_TIMEOUT_MS = 300_000;
@@ -454,17 +456,20 @@ async function executeMusicGenerationJob(params: {
     });
   }
   const mediaMaxBytes = resolveGeneratedMediaMaxBytes(params.effectiveCfg, "audio");
-  const savedTracks = await Promise.all(
-    result.tracks.map((track) =>
-      saveMediaBuffer(
+  const savedTracks = await persistGeneratedMediaBatch({
+    subdir: GENERATED_MUSIC_MEDIA_SUBDIR,
+    mode: "concurrent",
+    saves: result.tracks.map((track) => async () => {
+      const savedMedia = await saveMediaBuffer(
         track.buffer,
         track.mimeType,
-        "tool-music-generation",
+        GENERATED_MUSIC_MEDIA_SUBDIR,
         mediaMaxBytes,
         params.filename || track.fileName,
-      ),
-    ),
-  );
+      );
+      return { value: savedMedia, savedMedia };
+    }),
+  });
   const ignoredOverrides = result.ignoredOverrides ?? [];
   const ignoredOverrideKeys = new Set(ignoredOverrides.map((entry) => entry.key));
   const requestedDurationSeconds =

--- a/src/agents/tools/video-generate-tool.test.ts
+++ b/src/agents/tools/video-generate-tool.test.ts
@@ -924,6 +924,52 @@ describe("createVideoGenerateTool", () => {
     expect(delivered.reaction).toBeUndefined();
   });
 
+  it("rolls back earlier video saves after sequential persistence fails", async () => {
+    vi.spyOn(videoGenerationRuntime, "generateVideo").mockResolvedValue({
+      provider: "qwen",
+      model: "wan2.6-t2v",
+      attempts: [],
+      ignoredOverrides: [],
+      videos: [
+        { buffer: Buffer.from("saved"), mimeType: "video/mp4", fileName: "saved.mp4" },
+        { buffer: Buffer.from("failed"), mimeType: "video/mp4", fileName: "failed.mp4" },
+      ],
+    });
+    const terminalError = new Error("video persistence failed");
+    const savedMedia = {
+      path: "/tmp/saved.mp4",
+      id: "saved.mp4",
+      size: 5,
+      contentType: "video/mp4",
+    };
+    const saveMediaBuffer = vi
+      .spyOn(mediaStore, "saveMediaBuffer")
+      .mockResolvedValueOnce(savedMedia)
+      .mockRejectedValueOnce(terminalError);
+    const deleteMediaBuffer = vi
+      .spyOn(mediaStore, "deleteMediaBuffer")
+      .mockRejectedValueOnce(new Error("video cleanup failed"));
+    const tool = createVideoGenerateTool({
+      config: asConfig({
+        agents: {
+          defaults: {
+            videoGenerationModel: { primary: "qwen/wan2.6-t2v" },
+          },
+        },
+      }),
+    });
+    if (!tool) {
+      throw new Error("expected video_generate tool");
+    }
+
+    await expect(tool.execute("call-partial-save", { prompt: "two videos" })).rejects.toBe(
+      terminalError,
+    );
+    expect(saveMediaBuffer).toHaveBeenCalledTimes(2);
+    expect(deleteMediaBuffer).toHaveBeenCalledTimes(1);
+    expect(deleteMediaBuffer).toHaveBeenCalledWith("saved.mp4", "tool-video-generation");
+  });
+
   it("falls back to the provider URL when generated video persistence exceeds the media cap", async () => {
     vi.spyOn(videoGenerationRuntime, "generateVideo").mockResolvedValue({
       provider: "fal",

--- a/src/agents/tools/video-generate-tool.ts
+++ b/src/agents/tools/video-generate-tool.ts
@@ -46,6 +46,7 @@ import { getCustomProviderApiKey } from "../model-auth.js";
 import type { PreparedModelRuntimeSnapshot } from "../prepared-model-runtime.js";
 import { resolveProviderIdForAuth } from "../provider-auth-aliases.js";
 import { ToolInputError, readNumberParam, readStringParam } from "./common.js";
+import { persistGeneratedMediaBatch } from "./generated-media-batch-persistence.js";
 import { decodeDataUrl } from "./image-tool.helpers.js";
 import {
   hasSnapshotCapabilityProviderAvailability,
@@ -105,6 +106,7 @@ const log = createSubsystemLogger("agents/tools/video-generate");
 const MAX_INPUT_IMAGES = 9;
 const MAX_INPUT_VIDEOS = 4;
 const MAX_INPUT_AUDIOS = 3;
+const GENERATED_VIDEO_MEDIA_SUBDIR = "tool-video-generation";
 const GENERATED_VIDEO_PROBE_BUDGET_MS = 3000;
 const GENERATED_VIDEO_PROBE_CONCURRENCY = 2;
 const MAX_GENERATED_VIDEO_PROBES = 8;
@@ -737,6 +739,9 @@ async function executeVideoGenerationJob(params: {
   }
 
   const urlOnlyVideos: Array<{ url: string; mimeType: string; fileName?: string }> = [];
+  type PersistedVideo =
+    | { kind: "saved"; media: Awaited<ReturnType<typeof saveMediaBuffer>> }
+    | { kind: "url"; media: (typeof urlOnlyVideos)[number] };
   const bufferVideos: Array<(typeof result.videos)[number] & { buffer: Buffer }> = [];
   for (const video of result.videos) {
     if (video.buffer) {
@@ -757,27 +762,45 @@ async function executeVideoGenerationJob(params: {
   }
 
   const mediaMaxBytes = resolveGeneratedMediaMaxBytes(params.effectiveCfg, "video");
-  const savedVideos: Array<Awaited<ReturnType<typeof saveMediaBuffer>>> = [];
-  for (const video of bufferVideos) {
-    try {
-      const saved = await saveMediaBuffer(
-        video.buffer,
-        video.mimeType,
-        "tool-video-generation",
-        mediaMaxBytes,
-        params.filename || video.fileName,
-      );
-      savedVideos.push(saved);
-    } catch (error) {
-      if (video.url && isGeneratedMediaSizeLimitError(error)) {
-        urlOnlyVideos.push({
-          url: video.url,
-          mimeType: video.mimeType,
-          fileName: video.fileName,
-        });
-        continue;
+  const persistedVideos = await persistGeneratedMediaBatch<PersistedVideo>({
+    subdir: GENERATED_VIDEO_MEDIA_SUBDIR,
+    mode: "sequential",
+    saves: bufferVideos.map((video) => async () => {
+      try {
+        const savedMedia = await saveMediaBuffer(
+          video.buffer,
+          video.mimeType,
+          GENERATED_VIDEO_MEDIA_SUBDIR,
+          mediaMaxBytes,
+          params.filename || video.fileName,
+        );
+        return {
+          value: { kind: "saved" as const, media: savedMedia },
+          savedMedia,
+        };
+      } catch (error) {
+        if (video.url && isGeneratedMediaSizeLimitError(error)) {
+          return {
+            value: {
+              kind: "url" as const,
+              media: {
+                url: video.url,
+                mimeType: video.mimeType,
+                fileName: video.fileName,
+              },
+            },
+          };
+        }
+        throw error;
       }
-      throw error;
+    }),
+  });
+  const savedVideos: Array<Awaited<ReturnType<typeof saveMediaBuffer>>> = [];
+  for (const persisted of persistedVideos) {
+    if (persisted.kind === "saved") {
+      savedVideos.push(persisted.media);
+    } else {
+      urlOnlyVideos.push(persisted.media);
     }
   }
   const totalCount = savedVideos.length + urlOnlyVideos.length;


### PR DESCRIPTION
Closes https://github.com/openclaw/openclaw/issues/119284

## What Problem This Solves

When one generated item in an image, music, or video batch failed to persist, files already saved by the same batch were left in the managed media store even though the tool returned an error and no result referenced them. Concurrent image/music saves could be worse: `Promise.all` returned the first rejection while another filesystem write was still running, allowing a late orphan to appear after failure was already reported.

## Root Cause

Each tool owned its own save loop but none owned batch commit/rollback semantics:

- image and music used `Promise.all`, which rejects before sibling writes settle;
- video saved sequentially but threw without compensating earlier successful writes;
- cleanup existed only in the media store as a guarded single-file operation, not at the generated-batch owner.

Current-main reproduction at `1cf1af4aed3dedb010a885fcc9dc652f6d6d93d2` added one boundary case per tool. All three failed while the other 125 tests passed.

## What Changed

- Added one agent-tool batch persistence owner with concurrent and sequential modes.
- Concurrent image/music batches drain every already-started write before deciding rollback, so late successes cannot escape.
- Sequential video batches stop at the first terminal failure and roll back earlier saved files without changing large-buffer write ordering.
- Rollback uses the canonical path-guarded `deleteMediaBuffer`, best-effort cleanup cannot mask the original persistence error, and successful result ordering is preserved.
- Video's existing over-limit buffer → provider URL fallback remains a successful non-persisted item rather than a batch failure.
- Added filesystem-backed proof against an isolated real managed media store for both sequential and concurrent rollback orderings.

No protocol, configuration, provider, storage schema, background-task, delivery, or successful-result contract changes.

## Observed Behavior

The fixed tests prove:

1. image/music execution does not settle while a sibling save is still running after another save fails;
2. every late or already-successful file from the failed batch is deleted;
3. sequential video rollback deletes files saved before a later failure;
4. cleanup failures are contained and the original persistence error is rethrown;
5. real `saveMediaBuffer` writes resolve and contain the expected bytes before failure, then `resolveMediaBufferPath` rejects after rollback;
6. all existing successful, background, metadata, and URL-fallback cases remain green.

## Evidence

Exact head: `4140df297a113d167e3cdbe74d5db1954d74fa63`.

- Baseline current-main reproduction: 3 new tests failed / 125 existing tests passed.
- Exact-head focused proof: 4 files / 130 tests passed.
- Exact-head real-store proof: `generated-media-batch-persistence.test.ts` passed 2/2 cases using an isolated `OPENCLAW_STATE_DIR`; each case read the persisted bytes from the canonical resolved path before failure and observed the canonical resolver's missing-file error after rollback.
- Exact-head filesystem stress: 20/20 iterations, 40/40 real-store rollback executions passed.
- Exact-head hosted CI, https://github.com/openclaw/openclaw/actions/runs/30935414231: all required build, test, type, lint, QA smoke, security, and artifact checks passed on attempt 2. The first attempt had two unrelated failures: a temporary Git process cleanup error in `openclaw-live-updater.test.ts` and a cron Vitest process that stopped emitting output after its assertions passed; both exact failed jobs passed their single reruns.
- Exact-head ClawSweeper, https://github.com/openclaw/clawsweeper/actions/runs/30937032588: real behavior proof terminally sufficient, proof confidence 5/6, patch quality 4/6, and no actionable code or security findings.
- Repository-native hosted prepare gate accepted the exact-head CI/Testbox evidence with no local heavy-suite fallback.
- Production-head Blacksmith Testbox changed gate `tbx_01kz6tt1adjkk19ny8e0kyf5nt`, https://github.com/openclaw/openclaw/actions/runs/30930890368: core production/test types, lint, formatting, dead exports, plugin boundaries, media guards, and import cycles passed.
- Production-head Blacksmith Testbox build `tbx_01kz6vewf9mvqb7w129hx3t393`, https://github.com/openclaw/openclaw/actions/runs/30931787346: full dist, declarations, Plugin SDK export gate, Control UI production build, and performance guard passed.
- Fresh exact-head full-branch AutoReview: clean, no accepted/actionable findings, correctness 0.98.
- `git diff --check` and targeted oxfmt/oxlint passed.
- Public model-identifier audit: PASS. Test identifiers are existing public provider models documented by [OpenAI](https://developers.openai.com/api/docs/models/gpt-image-1), [MiniMax](https://platform.minimax.io/docs/api-reference/music-generation), and [Alibaba Cloud Model Studio](https://www.alibabacloud.com/help/en/model-studio/wan-video-generation-api).

## Repair Doctrine Summary

- Architectural owner: the generated-media tool layer, which turns a provider batch into one tool result.
- Canonical fix: one all-or-nothing persistence helper shared by image, music, and video.
- Removed/avoided paths: no retry, TTL-only workaround, duplicate per-tool cleanup, fallback store, or weakened error.
- Production delta: +125/-34 (net +91), paying for the shared batch transaction and compensating cleanup boundary.
- Test delta: +254/-0 across the shared owner and all three sibling tools.
- Risk: low-medium. Failure behavior gains bounded local cleanup; successful persistence ordering, video memory behavior, and output shapes are unchanged.

Release-note context: generated image, music, and video batches no longer leave managed-media files behind when a later item fails to save.

AI-assisted: yes.
