### PR TITLE
[AI-assisted] fix(channels): preserve recorded runtime running for config-disabled channel plugins

### DIFF
--- a/src/channels/plugins/status.test.ts
+++ b/src/channels/plugins/status.test.ts
@@ -121,4 +121,34 @@ describe("buildChannelAccountSnapshotFromAccount", () => {
     });
     expect(isLinked).not.toHaveBeenCalled();
   });
+
+  it("preserves recorded runtime running for a config-disabled but live account", async () => {
+    const account = { enabled: true, configured: true };
+    const plugin = {
+      config: {
+        isEnabled: () => false,
+        disabledReason: () => "not in allowlist",
+        describeAccount: () => ({ accountId: "default", configured: true, linked: true }),
+      },
+    } as unknown as ChannelPlugin<typeof account>;
+
+    const snapshot = await buildChannelAccountSnapshotFromAccount({
+      plugin,
+      cfg: {} as OpenClawConfig,
+      accountId: "default",
+      account,
+      runtime: { accountId: "default", running: true, connected: true },
+    });
+
+    expect(snapshot).toMatchObject({
+      accountId: "default",
+      enabled: false,
+      configured: true,
+      linked: true,
+      running: true,
+      connected: true,
+      stateReason: "not in allowlist",
+      lastError: null,
+    });
+  });
 });

--- a/src/channels/status/account-state.test.ts
+++ b/src/channels/status/account-state.test.ts
@@ -29,12 +29,13 @@ const baseInput = {
 describe("resolveChannelAccountState", () => {
   it.each([
     [
-      "disabled wins over later states",
-      { enabled: false, configured: false, linked: false, runtime: { running: true } },
+      "disabled preserves recorded runtime running",
+      { enabled: false, configured: true, linked: true, runtime: { running: true } },
       {
         kind: "disabled",
-        configured: false,
-        linked: false,
+        configured: true,
+        linked: true,
+        running: true,
         reason: "disabled reason",
         failure: null,
       },
@@ -96,6 +97,7 @@ describe("projectChannelAccountState", () => {
         kind: "disabled",
         configured: false,
         linked: false,
+        running: false,
         reason: "disabled",
         failure: null,
       },
@@ -104,6 +106,25 @@ describe("projectChannelAccountState", () => {
         linked: false,
         running: false,
         stateReason: "disabled",
+        lastError: null,
+      },
+    ],
+    [
+      {
+        kind: "disabled",
+        configured: true,
+        linked: true,
+        running: true,
+        connected: false,
+        reason: "not in allowlist",
+        failure: null,
+      },
+      {
+        configured: true,
+        linked: true,
+        running: true,
+        connected: false,
+        stateReason: "not in allowlist",
         lastError: null,
       },
     ],

--- a/src/channels/status/account-state.ts
+++ b/src/channels/status/account-state.ts
@@ -12,6 +12,8 @@ type ChannelAccountState =
       kind: "disabled";
       configured: boolean;
       linked: boolean | undefined;
+      running: boolean;
+      connected?: boolean;
       reason: string;
       failure: string | null;
     }
@@ -37,10 +39,15 @@ function assertNeverState(state: never): never {
 export function resolveChannelAccountState(input: ChannelAccountStateInput): ChannelAccountState {
   const failure = input.runtime?.lastError ?? null;
   if (!input.enabled) {
+    const running = input.runtime?.running === true;
     return {
       kind: "disabled",
       configured: input.configured,
       linked: input.linked,
+      running,
+      ...(running && typeof input.runtime?.connected === "boolean"
+        ? { connected: input.runtime.connected }
+        : {}),
       reason: input.disabledReason ?? "disabled",
       failure,
     };
@@ -95,7 +102,8 @@ function projectChannelAccountState(state: ChannelAccountState): {
       return {
         configured: state.configured,
         ...(typeof state.linked === "boolean" ? { linked: state.linked } : {}),
-        running: false,
+        running: state.running,
+        ...(typeof state.connected === "boolean" ? { connected: state.connected } : {}),
         stateReason: state.reason,
         lastError: state.failure,
       };


### PR DESCRIPTION
[AI-assisted]

## What Problem This Solves

`openclaw channels status --deep` (and `--probe`) report `health:not-running` for channel plugins that are actually running but are not in `plugins.allow`, e.g. plugins auto-loaded via `activation.onChannels`. The CLI still needs to surface the allowlist warning, but it must not overwrite the Gateway’s recorded runtime liveness.

Closes openclaw/openclaw#111346.

## Root Cause

- `src/channels/status/account-state.ts` `resolveChannelAccountState` short-circuited on `!input.enabled` and returned a `disabled` state that did not consult `input.runtime.running`.
- `projectChannelAccountState` for the `disabled` kind hardcoded `running: false`, which clobbered the recorded running fact.

## What Changed

- `resolveChannelAccountState` now reads `input.runtime.running` for the `disabled` state and, when running, also preserves `input.runtime.connected`.
- `projectChannelAccountState` projects `running` and `connected` from the disabled state instead of forcing `running: false`.
- `ChannelAccountState` type for `disabled` gains `running` and optional `connected` fields.
- Updated the existing `disabled wins over later states` test to reflect the new behavior and added a `projectChannelAccountState` case for a config-disabled but live account.
- Added a regression test in `src/channels/plugins/status.test.ts` covering a plugin whose `isEnabled` returns false with `disabledReason: "not in allowlist"` while a `running: true` runtime snapshot is present.

## Evidence

Verified with the repository’s own test wrappers:

- `node scripts/run-vitest.mjs src/channels/status/account-state.test.ts` — 20/20 passed
- `node scripts/run-vitest.mjs src/channels/plugins/status.test.ts` — 5/5 passed
- `node scripts/run-vitest.mjs src/gateway/server-methods/channels.status.test.ts` — 13/13 passed
- `pnpm tsgo:core` — passed
- `pnpm tsgo:core:test` — passed
- `git diff --check` — clean
- `pnpm format:check --no-error-on-unmatched-pattern -- src/channels/status/account-state.ts src/channels/status/account-state.test.ts src/channels/plugins/status.test.ts` — clean

Note: `src/plugins/channel-plugin-ids.test.ts` cannot currently run in this environment because Node v22.22.2 embeds SQLite 3.51.2, which the repo’s `node-sqlite.ts` guard rejects as unsafe (WAL-reset bug). This is an environment limitation, not a change-related failure.
