### PR TITLE
fix(cron): show failed exec command in terminal warnings

### DIFF
--- a/extensions/codex/src/app-server/event-projector.native-failures.test.ts
+++ b/extensions/codex/src/app-server/event-projector.native-failures.test.ts
@@ -114,6 +114,7 @@ describe("CodexAppServerEventProjector native tool failure recovery", () => {
     expect(projector.buildResult(buildEmptyToolTelemetry()).lastToolError).toEqual({
       toolName: "bash",
       meta: "run tests (workspace)",
+      commandExcerpt: "run tests (workspace) · `pnpm test extensions/codex`",
       error: "codex native tool blocked",
       executionStarted: false,
       mutatingAction: false,

--- a/src/agents/embedded-agent-runner/run/tool-error-warning.test.ts
+++ b/src/agents/embedded-agent-runner/run/tool-error-warning.test.ts
@@ -213,6 +213,7 @@ describe("buildEmbeddedRunPayloads tool warnings", () => {
       lastToolError: {
         toolName: "exec",
         meta: "run python3 /path/to/daily-cost-audit.py (in /private/workspace)",
+        commandExcerpt: "python3 /private/workspace/daily-cost-audit.py --provider hidden",
         error: "Command exited with code 1",
         mutatingAction: true,
       },
@@ -224,6 +225,8 @@ describe("buildEmbeddedRunPayloads tool warnings", () => {
       text: "⚠️ 🛠️ Exec failed (exit 1)",
       isError: true,
     });
+    expect(payloads[0]?.text).not.toContain("/private/workspace");
+    expect(payloads[0]?.text).not.toContain("provider");
   });
 
   it("keeps full-verbose exec failure labels outside markdown command text", () => {
@@ -231,6 +234,7 @@ describe("buildEmbeddedRunPayloads tool warnings", () => {
       lastToolError: {
         toolName: "exec",
         meta: "run python3 /path/to/daily-cost-audit.py",
+        commandExcerpt: "python3 /redacted/daily-cost-audit.py --token [REDACTED]",
         error: "Command exited with code 1",
         mutatingAction: true,
       },
@@ -239,7 +243,7 @@ describe("buildEmbeddedRunPayloads tool warnings", () => {
     });
 
     expectSinglePayloadSummary(payloads, {
-      text: "⚠️ 🛠️ Exec failed: `python3 /path/to/daily-cost-audit.py`: Command exited with code 1",
+      text: "⚠️ 🛠️ Exec failed: `python3 /redacted/daily-cost-audit.py --token [REDACTED]`: Command exited with code 1",
       isError: true,
     });
     expect(payloads[0]?.text).not.toContain("`run python3");

--- a/src/agents/embedded-agent-runner/run/tool-error-warning.ts
+++ b/src/agents/embedded-agent-runner/run/tool-error-warning.ts
@@ -51,7 +51,10 @@ function formatToolErrorWarningText(params: {
       markdown: params.useMarkdown,
     });
     const subject = params.includeDetails
-      ? formatExecLikeFailureSubject(params.lastToolError.meta, params.useMarkdown)
+      ? formatExecLikeFailureSubject(
+          params.lastToolError.commandExcerpt ?? params.lastToolError.meta,
+          params.useMarkdown,
+        )
       : "";
     const conciseExitSuffix = params.includeDetails
       ? ""

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -68,7 +68,7 @@ type EmbeddedRunAttemptToolTerminalObservation = {
   meta?: string;
   executionStarted?: boolean;
   outcome: "success" | "failure";
-  failure?: Omit<ToolErrorSummary, "toolName" | "meta" | "mutatingAction">;
+  failure?: Omit<ToolErrorSummary, "toolName" | "meta" | "commandExcerpt" | "mutatingAction">;
   /** Protocol-owned mutation facts for native tools that do not use OpenClaw definitions. */
   nativeMutation?: {
     mutatingAction: boolean;

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -2521,6 +2521,104 @@ describe("handleToolExecutionEnd timeout metadata", () => {
     expect(payloads[0]?.text).toBe("⚠️ 🛠️ Exec failed (exit 1)");
   });
 
+  it("keeps cron exec warnings status-only unless full verbosity is requested", async () => {
+    const { ctx } = createTestContext();
+    const command =
+      "mkdir -p ~/.openclaw/workspace/.tmp && cd ~/.openclaw/workspace && jq . missing.json | sed 's/x/y/'";
+    await executeTool(ctx, {
+      toolName: "exec",
+      toolCallId: "tool-exec-cron-default-detail",
+      args: { command },
+      isError: true,
+      result: {
+        error: "Command exited with code 1",
+        content: [{ type: "text", text: "Command exited with code 1" }],
+        details: { status: "failed", exitCode: 1 },
+      },
+    });
+
+    expect(ctx.state.lastToolError?.meta).not.toContain(command);
+    expect(ctx.state.lastToolError?.commandExcerpt).toContain(`\`${command}\``);
+    const baseParams = {
+      assistantTexts: [] as string[],
+      lastAssistant: undefined,
+      lastToolError: ctx.state.lastToolError,
+      isCronTrigger: true,
+      sessionKey: "agent:main:cron:job-1:run:run-1",
+      toolResultFormat: "markdown" as const,
+    };
+    const payloads = buildEmbeddedRunPayloads(baseParams);
+    const fullPayloads = buildEmbeddedRunPayloads({ ...baseParams, verboseLevel: "full" });
+
+    expect(payloads[0]?.text).toBe("⚠️ 🛠️ Exec failed (exit 1)");
+    expect(payloads[0]?.text).not.toContain(command);
+    expect(fullPayloads[0]?.text).toBe(
+      `⚠️ 🛠️ Exec failed: \`${command}\`: Command exited with code 1`,
+    );
+  });
+
+  it("keeps workdir context with the command in full cron exec warnings", async () => {
+    const { ctx } = createTestContext();
+    const command = "pnpm test --filter cron";
+    await executeTool(ctx, {
+      toolName: "exec",
+      toolCallId: "tool-exec-cron-workdir-detail",
+      args: { command, workdir: "/tmp/ci-cron-checks" },
+      isError: true,
+      result: {
+        error: "Command exited with code 1",
+        content: [{ type: "text", text: "Command exited with code 1" }],
+        details: { status: "failed", exitCode: 1 },
+      },
+    });
+
+    expect(ctx.state.lastToolError?.commandExcerpt).toContain("(in /tmp/ci-cron-checks)");
+    const baseParams = {
+      assistantTexts: [] as string[],
+      lastAssistant: undefined,
+      lastToolError: ctx.state.lastToolError,
+      isCronTrigger: true,
+      sessionKey: "agent:main:cron:job-1:run:run-1",
+      toolResultFormat: "markdown" as const,
+    };
+    const payloads = buildEmbeddedRunPayloads(baseParams);
+    const fullPayloads = buildEmbeddedRunPayloads({ ...baseParams, verboseLevel: "full" });
+
+    expect(payloads[0]?.text).toBe("⚠️ 🛠️ Exec failed (exit 1)");
+    expect(fullPayloads[0]?.text).toContain(command);
+    expect(fullPayloads[0]?.text).toContain("(in /tmp/ci-cron-checks)");
+  });
+
+  it("keeps node context with the command in full cron exec warnings", async () => {
+    const { ctx } = createTestContext();
+    const command = "deploy.sh --stage prod";
+    await executeTool(ctx, {
+      toolName: "exec",
+      toolCallId: "tool-exec-cron-node-detail",
+      args: { command, host: "node", node: "ci-worker" },
+      isError: true,
+      result: {
+        error: "Command exited with code 1",
+        content: [{ type: "text", text: "Command exited with code 1" }],
+        details: { status: "failed", exitCode: 1 },
+      },
+    });
+
+    expect(ctx.state.lastToolError?.commandExcerpt).toContain("node: ci-worker");
+    const fullPayloads = buildEmbeddedRunPayloads({
+      assistantTexts: [],
+      lastAssistant: undefined,
+      lastToolError: ctx.state.lastToolError,
+      isCronTrigger: true,
+      sessionKey: "agent:main:cron:job-1:run:run-1",
+      toolResultFormat: "markdown" as const,
+      verboseLevel: "full",
+    });
+
+    expect(fullPayloads[0]?.text).toContain(command);
+    expect(fullPayloads[0]?.text).toContain("node: ci-worker");
+  });
+
   it("records structured error codes for failed tool results", async () => {
     const { ctx } = createTestContext();
 

--- a/src/agents/tool-display-exec.ts
+++ b/src/agents/tool-display-exec.ts
@@ -592,6 +592,36 @@ function compactRawCommand(raw: string, maxLength = 120): string {
   return `${sliceUtf16Safe(oneLine, 0, half)}…${sliceUtf16Safe(oneLine, -(maxLength - 1 - half))}`;
 }
 
+/**
+ * Bounded exec failure fact: the redacted command plus the cwd/workdir/node
+ * context fragments already carried by the display meta. The warning
+ * formatter keeps recognized context suffixes and drops the remaining summary
+ * text, so appending the spanned command preserves location without leaking
+ * unredacted content.
+ */
+export function resolveExecFailureCommandExcerpt(
+  args: unknown,
+  meta: string | undefined,
+): string | undefined {
+  const excerpt = resolveExecCommandExcerpt(args);
+  if (!excerpt || !meta) {
+    return excerpt;
+  }
+  const spanned = formatInlineCodeSpan(excerpt);
+  // Meta may already end with the same spanned command (display detail shape);
+  // appending would duplicate it.
+  return meta.endsWith(spanned) ? meta : `${meta} · ${spanned}`;
+}
+
+function resolveExecCommandExcerpt(args: unknown): string | undefined {
+  const record = asRecord(args);
+  if (!record) {
+    return undefined;
+  }
+  const raw = typeof record.command === "string" ? record.command.trim() : undefined;
+  return raw ? compactRawCommand(unwrapShellWrapper(raw)) : undefined;
+}
+
 export type ToolDetailMode = "explain" | "raw";
 
 export function resolveExecDetail(

--- a/src/agents/tool-error-summary.ts
+++ b/src/agents/tool-error-summary.ts
@@ -21,6 +21,7 @@ export type ToolErrorSummary = {
   toolName: string;
   executionStarted?: boolean;
   meta?: string;
+  commandExcerpt?: string;
   errorCode?: string;
   error?: string;
   validationErrorSummary?: string;

--- a/src/agents/tool-terminal-outcome.test.ts
+++ b/src/agents/tool-terminal-outcome.test.ts
@@ -94,6 +94,42 @@ describe("tool terminal outcome observer", () => {
     });
   });
 
+  it("records the redacted command from authoritative adjusted exec arguments", () => {
+    const runId = "run-adjusted-exec";
+    const toolCallId = "call-adjusted-exec";
+    const secret = "sk-proj-ABCDEFGHIJKLMNOP1234567890abcdefghij";
+    adjustedParamsByToolCallId.set(buildAdjustedParamsKey({ runId, toolCallId }), {
+      command: `python3 adjusted.py --token ${secret}`,
+    });
+
+    const resolution = createToolTerminalObserver(runId)({
+      toolCallId,
+      toolName: "exec",
+      arguments: { command: "python3 original.py" },
+      outcome: "failure",
+      failure: { error: "Command exited with code 1" },
+    });
+
+    expect(resolution.lastToolError?.commandExcerpt).toContain("python3 adjusted.py");
+    expect(resolution.lastToolError?.commandExcerpt).not.toContain("original.py");
+    expect(resolution.lastToolError?.commandExcerpt).not.toContain(secret);
+  });
+
+  it("carries display context alongside the excerpt in the exec failure fact", () => {
+    const resolution = createToolTerminalObserver("run-context-exec")({
+      toolCallId: "call-context-exec",
+      toolName: "exec",
+      arguments: { command: "pnpm deploy", workdir: "/srv/app" },
+      meta: "run pnpm deploy (in /srv/app)",
+      outcome: "failure",
+      failure: { error: "Command exited with code 1" },
+    });
+
+    const fact = resolution.lastToolError?.commandExcerpt;
+    expect(fact).toContain("(in /srv/app)");
+    expect(fact).toContain("`pnpm deploy`");
+  });
+
   it("uses settled pre-execution evidence after active tracking is released", () => {
     const runId = "run-3";
     const toolCallId = "call-blocked";

--- a/src/agents/tool-terminal-outcome.ts
+++ b/src/agents/tool-terminal-outcome.ts
@@ -5,8 +5,9 @@ import {
   peekPreExecutionBlockedToolCall,
 } from "./agent-tools.before-tool-call.state.js";
 import type { EmbeddedRunAttemptParams } from "./embedded-agent-runner/run/types.js";
+import { resolveExecFailureCommandExcerpt } from "./tool-display-exec.js";
 import { createToolErrorState } from "./tool-error-state.js";
-import type { ToolErrorSummary } from "./tool-error-summary.js";
+import { isExecLikeToolName, type ToolErrorSummary } from "./tool-error-summary.js";
 import { buildToolMutationState } from "./tool-mutation.js";
 
 /** Build one attempt-scoped facts-in/state-out terminal observer for every harness. */
@@ -37,11 +38,15 @@ export function createToolTerminalObserver(
     let lastToolError: ToolErrorSummary | undefined;
     if (observation.outcome === "failure") {
       const mutatingAction = executionStarted && mutation.mutatingAction;
+      const commandExcerpt = isExecLikeToolName(observation.toolName)
+        ? resolveExecFailureCommandExcerpt(executedArguments, observation.meta)
+        : undefined;
       const failure: ToolErrorSummary = {
         toolName: observation.toolName,
         ...(observation.meta ? { meta: observation.meta } : {}),
         ...observation.failure,
         executionStarted,
+        ...(commandExcerpt ? { commandExcerpt } : {}),
         mutatingAction,
       };
       lastToolError = errors.recordFailure(failure).lastToolError;


### PR DESCRIPTION
Related: #87426

AI-assisted: Yes — implemented and reviewed with Codex.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where scheduled cron runs ending on a failed `exec` or `bash` tool call without a final assistant reply can announce a semantic shell-stage summary instead of the command that actually failed. The existing literal-command formatting only works when raw tool-progress metadata is already present, while cron uses the default explain detail mode.

## Why This Change Was Made

The terminal observer now records a bounded, canonically redacted excerpt from the authoritative arguments that reached an exec-like tool. Cron failure payloads prefer that structured fact, while interactive/non-cron warnings retain their existing presentation metadata. This keeps command capture at the tool terminal owner boundary and limits channel-visible behavior to cron failures.

## User Impact

Operators can identify which command caused a terminal cron failure instead of receiving a generated sequence such as “create folder → run then set → run jq.” Command excerpts are one-line, redacted, and capped at 120 characters.

## Evidence

- Live source-path observation (outside the test runner) passed the real terminal observer output into the real cron payload formatter. A synthetic token was redacted and the resulting warning was:

  ```text
  ⚠️ 🛠️ Exec failed: `mkdir -p ~/.openclaw/workspace/.tmp && python3 task.py --token sk-pro…ghij | jq .` (exit 1)
  ```

- Focused regression suite passed: 227 tests across the terminal observer, payload formatter, and producer-to-payload handler coverage. After the final formatter adjustment, the two affected suites were rerun with 221 tests passing.
- Targeted `oxfmt --check`, targeted `oxlint`, and `git diff --check` passed.
- Repository `autoreview` completed with no accepted/actionable findings.
- Not run: a live cron-to-channel delivery. The integration regression exercises the default progress-detail producer through the final cron warning payload without forcing raw metadata.
