### PR TITLE
fix(commands): restore tool inventory for dynamic models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Tool inventory commands:** prepare dynamic model context before rendering `/tools`, preventing dynamic-provider sessions from returning a temporary inventory failure when no synchronous runtime snapshot is published; make Telegram live QA use the model-aware wait and report unexpected replies.
 - **Control UI agent and skill permissions:** gate Agents, Skills, Skill Workshop, and delayed mutation dispatches by the current Gateway method catalog and operator scopes while preserving read-only browsing and legacy Gateway compatibility. Fixes #119176. Thanks @shakkernerd.
 - **Guided onboarding skip-UI routing:** keep `openclaw onboard --skip-ui` and `openclaw setup --skip-ui` on guided onboarding while skipping both browser and terminal handoffs, instead of silently switching to the classic wizard. Thanks @shakkernerd.
 - **Telegram durable ingress:** preserve pre-identity control-lane ownership during replay and attempt each drain snapshot row only once per pass, preventing targeted commands from spinning the spool and blocking polling shutdown.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Tool inventory commands:** prepare dynamic model context before rendering `/tools`, preventing dynamic-provider sessions from returning a temporary inventory failure when no synchronous runtime snapshot is published; make Telegram live QA use the model-aware wait and report unexpected replies.
 - **Control UI agent and skill permissions:** gate Agents, Skills, Skill Workshop, and delayed mutation dispatches by the current Gateway method catalog and operator scopes while preserving read-only browsing and legacy Gateway compatibility. Fixes #119176. Thanks @shakkernerd.
 - **Guided onboarding skip-UI routing:** keep `openclaw onboard --skip-ui` and `openclaw setup --skip-ui` on guided onboarding while skipping both browser and terminal handoffs, instead of silently switching to the classic wizard. Thanks @shakkernerd.
 - **Telegram durable ingress:** preserve pre-identity control-lane ownership during replay and attempt each drain snapshot row only once per pass, preventing targeted commands from spinning the spool and blocking polling shutdown.

--- a/config/env-var-count-budget.txt
+++ b/config/env-var-count-budget.txt
@@ -1,3 +1,3 @@
 # Distinct OPENCLAW_* names in production source under src, packages, and extensions.
 # Ratchet: lower this number when cleanup removes names; never raise it.
-515
+513

--- a/extensions/qa-lab/src/live-scenario-timeouts.test.ts
+++ b/extensions/qa-lab/src/live-scenario-timeouts.test.ts
@@ -340,10 +340,26 @@ describe("live transport scenario timeouts", () => {
 
     expect(waitForReply).toMatchObject({
       waitForOutbound: {
-        textIncludes: "exec",
         timeoutMs: { expr: "liveTurnTimeoutMs(env, 60000)" },
       },
     });
+    expect(waitForReply).not.toHaveProperty("waitForOutbound.textIncludes");
+  });
+
+  it("reports the unexpected Telegram compact tools reply", async () => {
+    await expect(
+      runLoadedScenarioFlow("telegram-tools-compact-command", {
+        onWaitForOutboundMessage: ({ state }) => {
+          state.addOutboundMessage({
+            accountId: "qa-channel",
+            to: "channel:telegram-command-room",
+            text: "Couldn't load available tools right now. Try again in a moment.",
+          });
+        },
+      }),
+    ).rejects.toThrow(
+      "tools reply missing expected text: Couldn't load available tools right now. Try again in a moment.",
+    );
   });
 });
 

--- a/extensions/qa-lab/src/live-scenario-timeouts.test.ts
+++ b/extensions/qa-lab/src/live-scenario-timeouts.test.ts
@@ -329,6 +329,24 @@ function runCompletionPolicyFlow(
   };
 }
 
+describe("live transport scenario timeouts", () => {
+  it("uses the model-aware timeout for the Telegram compact tools reply", () => {
+    const scenario = requireFlowScenario(readQaScenarioById("telegram-tools-compact-command"));
+    const waitForReply = scenario.execution.flow?.steps
+      .flatMap((step) => step.actions)
+      .find(
+        (action) => typeof action === "object" && action !== null && "waitForOutbound" in action,
+      );
+
+    expect(waitForReply).toMatchObject({
+      waitForOutbound: {
+        textIncludes: "exec",
+        timeoutMs: { expr: "liveTurnTimeoutMs(env, 60000)" },
+      },
+    });
+  });
+});
+
 describe("live subagent scenario timeouts", () => {
   it.each([
     {

--- a/qa/scenarios/channels/telegram-tools-compact-command.yaml
+++ b/qa/scenarios/channels/telegram-tools-compact-command.yaml
@@ -39,7 +39,8 @@ flow:
             conversation: { id: telegram-command-room, kind: channel }
             sinceIndex: { ref: startIndex }
             textIncludes: exec
-            timeoutMs: 60000
+            timeoutMs:
+              expr: liveTurnTimeoutMs(env, 60000)
         - call: sleep
           args: [1000]
         - set: joinedReply

--- a/qa/scenarios/channels/telegram-tools-compact-command.yaml
+++ b/qa/scenarios/channels/telegram-tools-compact-command.yaml
@@ -38,7 +38,6 @@ flow:
         - waitForOutbound:
             conversation: { id: telegram-command-room, kind: channel }
             sinceIndex: { ref: startIndex }
-            textIncludes: exec
             timeoutMs:
               expr: liveTurnTimeoutMs(env, 60000)
         - call: sleep

--- a/src/auto-reply/reply/commands-info.test.ts
+++ b/src/auto-reply/reply/commands-info.test.ts
@@ -564,7 +564,7 @@ const toolsTestState = vi.hoisted(() => {
   return {
     resolveToolsImpl: defaultResolveTools,
     resolveToolsMock: vi.fn((..._args: unknown[]) => defaultResolveTools()),
-    resolveRuntimeModelContextMock: vi.fn(async () => ({})),
+    resolveRuntimeModelContextMock: vi.fn(async (_params: unknown) => ({})),
     threadingContext: {
       currentChannelId: "channel-123",
       currentMessageId: "message-456",
@@ -575,8 +575,8 @@ const toolsTestState = vi.hoisted(() => {
 
 vi.mock("../../agents/tools-effective-inventory.js", () => ({
   resolveEffectiveToolInventory: (...args: unknown[]) => toolsTestState.resolveToolsMock(...args),
-  resolveEffectiveToolInventoryRuntimeModelContextAsync: (...args: unknown[]) =>
-    toolsTestState.resolveRuntimeModelContextMock(...args),
+  resolveEffectiveToolInventoryRuntimeModelContextAsync: (params: unknown) =>
+    toolsTestState.resolveRuntimeModelContextMock(params),
 }));
 
 vi.mock("./agent-runner-utils.js", () => ({

--- a/src/auto-reply/reply/commands-info.test.ts
+++ b/src/auto-reply/reply/commands-info.test.ts
@@ -564,6 +564,7 @@ const toolsTestState = vi.hoisted(() => {
   return {
     resolveToolsImpl: defaultResolveTools,
     resolveToolsMock: vi.fn((..._args: unknown[]) => defaultResolveTools()),
+    resolveRuntimeModelContextMock: vi.fn(async () => ({})),
     threadingContext: {
       currentChannelId: "channel-123",
       currentMessageId: "message-456",
@@ -574,6 +575,8 @@ const toolsTestState = vi.hoisted(() => {
 
 vi.mock("../../agents/tools-effective-inventory.js", () => ({
   resolveEffectiveToolInventory: (...args: unknown[]) => toolsTestState.resolveToolsMock(...args),
+  resolveEffectiveToolInventoryRuntimeModelContextAsync: (...args: unknown[]) =>
+    toolsTestState.resolveRuntimeModelContextMock(...args),
 }));
 
 vi.mock("./agent-runner-utils.js", () => ({
@@ -626,6 +629,8 @@ describe("handleToolsCommand", () => {
     vi.mocked(resolveSessionAgentId).mockReturnValue("main");
     toolsTestState.resolveToolsMock.mockReset();
     toolsTestState.resolveToolsImpl = () => makeDefaultInventory();
+    toolsTestState.resolveRuntimeModelContextMock.mockReset();
+    toolsTestState.resolveRuntimeModelContextMock.mockResolvedValue({});
     setActivePluginRegistry(createTestRegistry([]));
   });
 
@@ -775,6 +780,43 @@ describe("handleToolsCommand", () => {
 
     expect(result?.reply?.text).toContain("exec");
     expect(result?.reply?.text).toContain("Use /tools verbose for descriptions.");
+  });
+
+  it("prepares dynamic model context before resolving the tool inventory", async () => {
+    const runtimeModel = {
+      id: "chat-latest",
+      name: "chat-latest",
+      provider: "openai",
+      api: "openai-responses",
+    };
+    toolsTestState.resolveRuntimeModelContextMock.mockResolvedValue({
+      modelApi: "openai-responses",
+      runtimeModel,
+    });
+    const { buildCommandTestParamsLocal, handleToolsCommandLocal, resolveToolsMock } =
+      await loadToolsHarness();
+    const params = buildCommandTestParamsLocal("/tools compact", buildConfig(), undefined, {
+      workspaceDir: "/tmp",
+    });
+    params.agentId = "main";
+    params.provider = "openai";
+    params.model = "chat-latest";
+
+    const result = await handleToolsCommandLocal(params, true);
+
+    expect(result?.reply?.text).toContain("exec");
+    expect(toolsTestState.resolveRuntimeModelContextMock).toHaveBeenCalledWith({
+      cfg: params.cfg,
+      agentId: "main",
+      agentDir: undefined,
+      workspaceDir: "/tmp",
+      modelProvider: "openai",
+      modelId: "chat-latest",
+    });
+    expect(resolveToolsArg(resolveToolsMock)).toMatchObject({
+      modelApi: "openai-responses",
+      runtimeModel,
+    });
   });
 
   it("ignores unauthorized senders", async () => {

--- a/src/auto-reply/reply/commands-info.ts
+++ b/src/auto-reply/reply/commands-info.ts
@@ -1,6 +1,9 @@
 /** Handles informational commands such as /help, /commands, /tools, and exports. */
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
-import { resolveEffectiveToolInventory } from "../../agents/tools-effective-inventory.js";
+import {
+  resolveEffectiveToolInventory,
+  resolveEffectiveToolInventoryRuntimeModelContextAsync,
+} from "../../agents/tools-effective-inventory.js";
 import { getChannelPlugin } from "../../channels/plugins/index.js";
 import {
   listSkillCommandsForAgents,
@@ -170,6 +173,14 @@ export const handleToolsCommand: CommandHandler = async (params, allowTextComman
       config: params.cfg,
       hasRepliedRef: undefined,
     });
+    const runtimeModelContext = await resolveEffectiveToolInventoryRuntimeModelContextAsync({
+      cfg: params.cfg,
+      agentId,
+      agentDir: sessionBound ? undefined : params.agentDir,
+      workspaceDir: params.workspaceDir,
+      modelProvider: params.provider,
+      modelId: params.model,
+    });
     const result = resolveEffectiveToolInventory({
       cfg: params.cfg,
       agentId,
@@ -178,6 +189,8 @@ export const handleToolsCommand: CommandHandler = async (params, allowTextComman
       agentDir: sessionBound ? undefined : params.agentDir,
       modelProvider: params.provider,
       modelId: params.model,
+      modelApi: runtimeModelContext.modelApi,
+      runtimeModel: runtimeModelContext.runtimeModel,
       messageProvider: params.command.channel,
       senderId: params.command.senderId,
       senderName: params.ctx.SenderName,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `/tools` could return a temporary inventory failure for dynamic-provider sessions because the command tried to resolve tools before publishing or borrowing the prepared runtime model context.

The Beta 8 release lane also reproduced a separate current-main gate failure: two removed `OPENCLAW_*` names left the environment-variable ratchet at 515 while the observed production count is 513.

## Why This Change Was Made

The command now follows the existing Gateway owner boundary: resolve the effective runtime model context asynchronously, then pass that prepared context into the synchronous tool-inventory projection. The Telegram release-QA scenario uses the established model-aware live-turn timeout and asserts the full expected reply so fallback errors remain visible.

The environment-variable budget is lowered from 515 to 513, matching the repository checker and restoring `check:changed` on current main.

## User Impact

Users running `/tools` with dynamically prepared models receive the tool inventory instead of a temporary failure. Release validation waits for the provider-aware Telegram response budget without accepting an unexpected reply as success.

## Evidence

- Exact candidate: `caafd02384d6cc5e1b437f6efe9eaf0e60849867`.
- Fresh branch autoreview after the ratchet repair: clean, confidence 0.98.
- Local focused proof: 98 tests passed (`commands-info.test.ts` and `live-scenario-timeouts.test.ts`); `OPENCLAW_* count 513/513`; `git diff --check` clean.
- Exact Blacksmith Testbox: full `pnpm check:changed` plus the same 98 focused tests passed, exit 0. Lease `tbx_01kz7cttttf20vy5p9jfv70pyp`; run https://github.com/openclaw/openclaw/actions/runs/30954884840.
- Exact AWS Crabbox/Mantis Telegram proof: `telegram-tools-compact-command` passed with overall `true` at the exact candidate SHA. The artifact's `qa-suite-report.md` contains the full redacted reply (`Available tools`, profile, built-in/connected tools, and the `/tools verbose` hint); the prepared desktop image itself only shows the scenario pass because its observed-message panel is empty. Run https://github.com/openclaw/openclaw/actions/runs/30954874075; artifact https://github.com/openclaw/openclaw/actions/runs/30954874075/artifacts/8911342198.

No changelog edit: the release-owned entry was removed per review, and release generation remains the owner for the eventual note.

Punchcard-Session: amber-workshop-river-yr
