### PR TITLE
fix(sessions): keep admitted turns attached during retries

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-session-boundary.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-boundary.test.ts
@@ -373,6 +373,63 @@ describe("prepareEmbeddedAttemptSessionBoundary", () => {
     expect(onUserMessagePersistenceInvalidated).not.toHaveBeenCalled();
   });
 
+  it("preserves a recorder-owned durable user when the prepared message is unavailable", () => {
+    const currentUser = {
+      role: "user" as const,
+      content: "current prompt",
+      idempotencyKey: "current-run:user",
+      timestamp: 1,
+    };
+    const { activeSession } = createActiveSession([]);
+    const branch = vi.fn();
+    const resetLeaf = vi.fn();
+    const clearNextUserMessagePersistenceSuppression = vi.fn();
+    const onUserMessagePersistenceInvalidated = vi.fn();
+    const sessionManager = createSessionManager({
+      branch,
+      resetLeaf,
+      clearNextUserMessagePersistenceSuppression,
+      buildSessionContext: () => ({ messages: [] }),
+      getLeafEntry: () => ({
+        id: "current-user",
+        parentId: "previous-assistant",
+        timestamp: "2026-07-13T00:00:00.000Z",
+        type: "message",
+        message: currentUser,
+      }),
+    });
+    const recorder = {
+      getPersistedMessage: () => currentUser,
+      hasPersisted: () => true,
+    } as unknown as NonNullable<
+      Parameters<
+        typeof prepareEmbeddedAttemptSessionBoundary
+      >[0]["attempt"]["userTurnTranscriptRecorder"]
+    >;
+
+    const boundary = prepareEmbeddedAttemptSessionBoundary({
+      activeSession,
+      attempt: {
+        onUserMessagePersistenceInvalidated,
+        prompt: "current prompt",
+        trigger: "user",
+        userTurnTranscriptRecorder: recorder,
+      },
+      getUserTranscriptContexts: () => undefined,
+      isRawModelRun: false,
+      preparedUserTurnMessage: undefined,
+      sessionManager,
+      setActiveSessionSystemPrompt: vi.fn(),
+    });
+
+    expect(boundary.orphanRepair).toBeUndefined();
+    expect(activeSession.agent.state.messages).toEqual([]);
+    expect(branch).not.toHaveBeenCalled();
+    expect(resetLeaf).not.toHaveBeenCalled();
+    expect(clearNextUserMessagePersistenceSuppression).not.toHaveBeenCalled();
+    expect(onUserMessagePersistenceInvalidated).not.toHaveBeenCalled();
+  });
+
   it("adopts an exact durable user leaf after recorder state is lost on restart", () => {
     const currentUser = {
       role: "user" as const,
@@ -458,8 +515,9 @@ describe("prepareEmbeddedAttemptSessionBoundary", () => {
       buildSessionContext: () => ({ messages: repairedMessages }),
     });
     const recorder = {
+      getPersistedMessage: () => currentUser,
       hasPersisted: () => true,
-    } as NonNullable<
+    } as unknown as NonNullable<
       Parameters<
         typeof prepareEmbeddedAttemptSessionBoundary
       >[0]["attempt"]["userTurnTranscriptRecorder"]
@@ -475,7 +533,7 @@ describe("prepareEmbeddedAttemptSessionBoundary", () => {
       },
       getUserTranscriptContexts: () => undefined,
       isRawModelRun: false,
-      preparedUserTurnMessage: currentUser,
+      preparedUserTurnMessage: undefined,
       sessionManager,
       setActiveSessionSystemPrompt: vi.fn(),
     });

--- a/src/agents/embedded-agent-runner/run/attempt-session-boundary.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-boundary.ts
@@ -57,12 +57,16 @@ export function prepareEmbeddedAttemptSessionBoundary(input: {
         prompt: attempt.prompt,
         trigger: attempt.trigger,
       });
+  // Admission can persist the turn before prompt preparation intentionally omits it.
+  // Prefer the recorder-owned row so orphan repair cannot detach the canonical leaf.
+  const currentUserTurnMessage =
+    attempt.userTurnTranscriptRecorder?.getPersistedMessage?.() ?? input.preparedUserTurnMessage;
   const reconciledCurrentUser =
     !preserveExactPrompt &&
     reconcilePrePersistedCurrentUserTurn({
       activeSession,
+      currentUserTurnMessage,
       durableUserTurnMessage: orphanRepairCandidate?.messageEntry.message,
-      preparedUserTurnMessage: input.preparedUserTurnMessage,
       userTurnAlreadyPersisted: attempt.userTurnTranscriptRecorder?.hasPersisted() === true,
     });
   const orphanRepair = reconciledCurrentUser ? undefined : orphanRepairCandidate;

--- a/src/agents/embedded-agent-runner/run/pre-persisted-user-turn.ts
+++ b/src/agents/embedded-agent-runner/run/pre-persisted-user-turn.ts
@@ -13,13 +13,12 @@ export function sessionMessagesContainIdempotencyKey(
 
 export function reconcilePrePersistedCurrentUserTurn(params: {
   activeSession: { agent: { state: { messages: AgentMessage[] } } };
+  currentUserTurnMessage: AgentMessage | undefined;
   durableUserTurnMessage: AgentMessage | undefined;
-  preparedUserTurnMessage: AgentMessage | undefined;
   userTurnAlreadyPersisted: boolean;
 }): boolean {
-  const idempotencyKey = (
-    params.preparedUserTurnMessage as { idempotencyKey?: unknown } | undefined
-  )?.idempotencyKey;
+  const idempotencyKey = (params.currentUserTurnMessage as { idempotencyKey?: unknown } | undefined)
+    ?.idempotencyKey;
   if (typeof idempotencyKey !== "string" || idempotencyKey.length === 0) {
     return false;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an admitted user turn could be detached from the active
session transcript during an internal retry that intentionally omitted the
prepared user-message projection. A later turn could then fail with
`Session transcript parent entry was not persisted` instead of reaching the
provider.

The failure was observed on the exact `main` SHA
`7a0a4c5f2a3b778deec2eacafbeffc45f24579cf`:
https://github.com/openclaw/openclaw/actions/runs/30933537375/job/92074656753

## Why This Change Was Made

The session boundary now uses the transcript recorder's persisted message as
the authoritative current-turn identity, with the prepared message retained as
the fallback. Reconciliation still requires an exact non-empty idempotency-key
match, so genuinely stale durable leaves continue through orphan repair.

This does not weaken SQLite idempotency or SessionManager parent validation and
does not change config, protocol, schema, or migration surfaces.

## User Impact

Persisted user turns remain attached to the canonical transcript across
internal retries, allowing subsequent turns to continue instead of dead-ending
on a detached parent.

The vulnerable source path is present in `v2026.7.2-beta.6` and
`v2026.7.2-beta.7`; stable `v2026.7.1-1` and `v2026.7.1-2` do not contain it.

## Evidence

- Added a regression that reproduces the missing prepared-message state while
  the recorder and durable leaf hold the same admitted turn. It triggered
  orphan repair before the fix and now preserves the leaf.
- Strengthened the mismatch regression so recorder fallback still repairs a
  durable leaf with a different idempotency key.
- 59 focused tests pass across session-boundary, runtime-prepare,
  SessionManager idempotency, and user-turn transcript coverage.
- The complete `core, coreTests` changed-scope gate passes, including tsgo,
  oxlint, dead exports, plugin boundaries, import cycles, SQLite/storage
  guards, and auth guards.
- `git diff --check` and targeted `oxfmt --check` pass.
- Final branch autoreview is clean with no accepted/actionable findings.
- The local execution-order E2E could not prepare its gateway because linked
  worktrees may not reconcile `node_modules`; that repository safety rule was
  not bypassed. Exact-head PR CI, including
  `check-sqlite-session-flip-proof`, is required before merge.

Provenance: https://github.com/openclaw/openclaw/pull/116924 introduced durable
leaf reconciliation while still depending on the prepared projection;
https://github.com/openclaw/openclaw/pull/117310 carried that assumption
forward. https://github.com/openclaw/openclaw/pull/117260 correctly rejects
detached keyed-row adoption and exposed the upstream ownership error.

AI-assisted: yes. The implementation, history, and proof were reviewed by the
maintainer.

Punchcard-Session: coral-workshop-workshop-3f
