### PR TITLE
fix(dev): rebuild when agent-core, llm-core or model-catalog-core sources change

### DIFF
--- a/scripts/run-node-watch-paths.mjs
+++ b/scripts/run-node-watch-paths.mjs
@@ -21,6 +21,9 @@ const RUN_NODE_PACKAGE_SOURCE_ROOTS = [
   "packages/acp-core/src",
   "packages/terminal-core/src",
   "packages/net-policy/src",
+  "packages/agent-core/src",
+  "packages/llm-core/src",
+  "packages/model-catalog-core/src",
 ];
 
 /** Source roots whose changes require the root dev build pipeline. */

--- a/src/infra/watch-node.test.ts
+++ b/src/infra/watch-node.test.ts
@@ -150,6 +150,9 @@ describe("watch-node script", () => {
       expect(watchPaths).toContain("packages/media-generation-core/src");
       expect(watchPaths).toContain("packages/acp-core/src");
       expect(watchPaths).toContain("packages/net-policy/src");
+      expect(watchPaths).toContain("packages/agent-core/src");
+      expect(watchPaths).toContain("packages/llm-core/src");
+      expect(watchPaths).toContain("packages/model-catalog-core/src");
       expect(watchPaths).toContain("tsdown.config.ts");
       expect(watchOptions.ignoreInitial).toBe(true);
       expect(watchOptions.ignored("src")).toBe(false);


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where contributors editing `packages/agent-core/src`,
`packages/llm-core/src`, or `packages/model-catalog-core/src` see their change silently
ignored: the dev runtime keeps running the previously built `dist/`, with no rebuild, no
restart, and no warning. The edit looks like it had no effect.

The affected entrypoints are the `package.json` scripts that run through
`scripts/run-node.mjs` — `dev`, `openclaw`, `gateway:dev`, `tui`, `proxy:*`, `qa:*` — plus
`gateway:watch`, which reaches the same planner via `scripts/watch-node.mjs`. They share
one build-planning path, which is the single place the defect lives; the capture below
exercises that path directly rather than each wrapper.

**Scope of impact, stated plainly:** this is a contributor-loop defect with **no
end-user impact**. Release artifacts come from `pnpm build` (`scripts/build-all.mjs`),
which content-hashes its own inputs and does not consult this list. CI builds from a clean
checkout, so the dirty-working-tree path this list feeds is not exercised there either.
The stale window also self-heals on `git commit` (`git_head_changed`) or as soon as any
file under an already-watched root is dirty (`dirty_watched_tree`). It bites when
uncommitted edits are confined to these three package roots.

## Why This Change Was Made

**Root cause.** `RUN_NODE_PACKAGE_SOURCE_ROOTS` in `scripts/run-node-watch-paths.mjs` is
the list `scripts/run-node.mjs` consults to decide whether a package edit requires a dev
rebuild. Its own comment states the intent: *"Root runtime code imports these package
sources through tsconfig aliases, while pnpm dev/watch still runs the root dist
entrypoint. Treat them like src/ so edits restart the same process that consumes them."*
Three roots that match that description are absent, so `resolveBuildRequirement` reports
`clean` for edits that do change `dist/`.

**Fix.** This PR changes `RUN_NODE_PACKAGE_SOURCE_ROOTS` to include those three roots, and
extends the existing watched-paths enumeration in `src/infra/watch-node.test.ts` to cover
them. That is the whole change: +3 production lines, +3 test lines, no planner or build
algorithm changes — only the set of paths the existing planner treats as build inputs.

Each of the three has source files that rolldown bundles into root `dist/`, which is the
property the list is tracking. Counted on a built checkout from rolldown's own
`//#region <source path>` markers, and from the import specifiers left in the output:

```
for p in agent-core model-catalog-core llm-core retry gateway-protocol; do
  inlined=$(grep -rho "#region packages/$p/src/[^ ]*" dist/*.js | sort -u | wc -l)
  external=$(grep -rl "\"@openclaw/$p\"" dist/*.js | wc -l)
  echo "$p inlined=$inlined external=$external"
done
```

| package root | source files bundled into root `dist/` | `dist/` files containing an `"@openclaw/<pkg>"` import string | currently watched |
| --- | ---: | ---: | --- |
| `packages/agent-core/src` | 17 | 0 | no |
| `packages/model-catalog-core/src` | 8 | 0 | no |
| `packages/llm-core/src` | 3 | 1 | no |
| `packages/retry/src` | 1 | 0 | **yes** |
| `packages/gateway-protocol/src` | 73 | 0 | **yes** |

`llm-core` is the one mixed case: three of its source files are bundled into the root
artifact and one output file additionally imports it as an external. The watch entry is
justified by the bundled files — an edit to any of those three changes root `dist/`. It is
not a claim that every file under `packages/llm-core/src` is bundled.

`packages/retry/src` is already listed with a single bundled file, so there is no threshold
on this measure that would include `retry` and exclude roots with 3, 8 and 17.

The entries are whole `src` roots, not file lists, so an edit to a file under a watched root
that happens not to be bundled also triggers a rebuild. That over-watch is how all eleven
existing entries already behave — `retry` watches its whole root for one bundled file — and
a per-file manifest would need regenerating on every import change. The cost of over-watch
is an occasional rebuild that was not strictly required; the cost of the current behaviour
is a dev runtime that is silently wrong.

**Out of scope.** Deliberately not included in this PR:

- `packages/ai/src` — externalized via `explicitNeverBundleDependencies` in
  `tsdown.config.ts` (1 inlined file vs 5 external imports in `dist/`). Different
  mechanism; folding it in would mix two claims in one change.
- `packages/sdk/src` and `packages/session-url-contract/src` — 0 inlined, 0 external; root
  `src/` does not import them, so their absence from the list is correct.
- `packages/workboard-contract/src` — 1 inlined file but no direct root `src/` import; left
  out pending a separate reachability check rather than added speculatively.
- A guard that keeps this list in sync with the tsconfig alias graph. That is a new helper
  surface and belongs in its own change if it is wanted at all.
- The build planner itself (`resolveBuildRequirement`), the build cache, and the
  `git_head_changed` short-circuit are untouched.

## User Impact

No change for end users, and none observed for CI: the release path
(`scripts/build-all.mjs`) does not read this list, and CI builds from a clean checkout so
the dirty-working-tree branch it feeds is not reached. For contributors working in those
three packages, a source edit now triggers the rebuild and restart it already triggers for
`src/` and for the eleven package roots already listed.

## Evidence

Real-behavior capture on a built checkout of this PR head: the actual dev-lane planner
(`scripts/run-node.mjs` `resolveBuildRequirement`) and the actual build
(`scripts/build-all.mjs`) driven with no mocks or stubs. The probe adds one entry to an
exported, consumed array in `packages/model-catalog-core/src/configured-model-refs.ts`, a
file rolldown inlines into root `dist/` as `dist/configured-model-refs-XCtO9k7W.js`. Steps
3 and 4 differ only in whether `scripts/run-node-watch-paths.mjs` holds its pre-fix or
post-fix content.

Reproduce it in a throwaway worktree built once beforehand — the snippet uses
`git checkout -- <path>`, which discards uncommitted changes to that path, and it mutates
a source file (`$BASE` = the commit before this PR's):

```
# re-glob after every build rather than caching the path: the chunk name is
# hash-suffixed. Fail loudly if a stale sibling is left behind rather than
# silently probing the wrong file.
chunk() { local m=(dist/configured-model-refs-*.js); [ ${#m[@]} -eq 1 ] || { echo "expected 1 chunk, got ${#m[@]}" >&2; return 1; }; echo "${m[0]}"; }
# the planner verdict, called the way run-node.mjs calls it
plan() { node --input-type=module -e '
  import fs from "node:fs"; import path from "node:path"; import {spawnSync} from "node:child_process";
  const cwd = process.cwd();
  const {resolveBuildRequirement} = await import(path.join(cwd,"scripts/run-node.mjs"));
  const w = await import(path.join(cwd,"scripts/run-node-watch-paths.mjs"));
  const distRoot = path.join(cwd,"dist");
  console.log(resolveBuildRequirement({cwd, env: process.env, fs, spawnSync, distRoot,
    distEntry: path.join(distRoot,"index.js"),
    buildStampPath: path.join(distRoot,".buildstamp"),
    runtimePostBuildStampPath: path.join(distRoot,".runtime-postbuildstamp"),
    sourceRoots: w.runNodeSourceRoots.map(n=>({name:n, path:path.join(cwd,n)})),
    configFiles: w.runNodeConfigFiles.map(n=>path.join(cwd,n))}));'; }

sed -i 's/^  "pdfModel",$/  "pdfModel",\n  "cp0ProbeModel",/' \
  packages/model-catalog-core/src/configured-model-refs.ts
git checkout $BASE -- scripts/run-node-watch-paths.mjs && plan   # step 3: without this PR
grep -c cp0ProbeModel "$(chunk)"                                 #   -> 0, dist is stale
git checkout HEAD  -- scripts/run-node-watch-paths.mjs && plan   # step 4: with this PR
pnpm build && grep -c cp0ProbeModel "$(chunk)"                   # step 5 -> 1
```

```
PR head = 27c0f4371474d032b72147358f7d1d4e86e01a21
base (pre-fix) = 7a0a4c5f2a3b778deec2eacafbeffc45f24579cf
probed chunk = configured-model-refs-XCtO9k7W.js

## 1. Baseline: clean tree, built dist, fix present
    resolveBuildRequirement -> shouldBuild=false reason=clean
    probe marker present in built chunk: 0

## 2. Add one entry to an exported, consumed array in
##    packages/model-catalog-core/src/configured-model-refs.ts
    added: "cp0ProbeModel" to AGENT_MODEL_CONFIG_KEYS

## 3. Behaviour WITHOUT this PR (watch list restored to its pre-fix content)
    resolveBuildRequirement -> shouldBuild=false reason=clean
    probe marker present in built chunk: 0   <- dist is stale

## 4. Behaviour WITH this PR (watch list back to the committed version)
    resolveBuildRequirement -> shouldBuild=true reason=dirty_watched_tree

## 5. Run the rebuild the planner now asks for
    build exit=0
    probe marker present in built chunk: 1
    const AGENT_MODEL_CONFIG_KEYS = [
    	"model",
    	"utilityModel",
    	"imageModel",
    	"voiceModel",
    	"pdfModel",
    	"cp0ProbeModel"
    ];

## 6. Restore the probe edit
    tree clean: yes
```

Step 3 is the defect: an edit to a file bundled into `dist/` sits in the working tree and
the planner still reports `clean`. Step 4 is the fix. Step 5 confirms the edit really is a
root build input — the same edit does reach `dist/` once a build runs.

What this capture shows directly is the build decision. The restart is inferred from the
same array rather than separately exercised: `scripts/watch-node.mjs` builds its chokidar
watch set from `runNodeWatchedPaths`, which is `runNodeSourceRoots` plus the root config
files — the array this PR edits. A path absent from it is therefore not a *watched-tree*
trigger for either a rebuild or a restart, which is why the symptom is "no rebuild and no
restart" rather than "rebuilt but not reloaded".

That is specifically about the dirty-working-tree path. `resolveBuildRequirement` has other
branches that do not consult this list at all — most relevantly `git_head_changed`, which
is why committing heals the staleness. The two statements are about different branches of
the same function, not in conflict. The added assertions in `src/infra/watch-node.test.ts`
cover the watcher-input array.

**Tests.** Focused run of the existing suite that owns this list (supplemental — it does
not substitute for the capture above):

```
$ node scripts/run-vitest.mjs src/infra/watch-node.test.ts
[test] starting test/vitest/vitest.infra.config.ts
 Test Files  1 passed (1)
      Tests  19 passed (19)
[test] passed 1 Vitest shard in 4.63s
```

The existing enumeration in `src/infra/watch-node.test.ts` uses `toContain`, so the three
added assertions are additive and do not re-pin unrelated entries.

### What was not tested

- Linux only (Ubuntu 22.04, Node 24.18.0). The list is platform-independent but the capture
  is not cross-platform.
- **The restart was not exercised.** The capture measures the build decision
  (`resolveBuildRequirement`) and the resulting artifact. That a missing entry also means no
  watcher restart is read off `scripts/watch-node.mjs`, which derives its watch set from the
  same `runNodeWatchedPaths` array, and is covered by the added assertions — it is not a
  second live measurement.
- No live gateway session driven end to end.

### Proof limitations

- The probe marker must go in an exported array that is actually consumed; an unused
  `export const` is tree-shaken out of `dist/` and proves nothing.
- The staleness self-heals on `git commit` or on any dirty file under an already-watched
  root, so the capture keeps the working tree otherwise clean — that is the condition under
  which the defect is observable.
