### PR TITLE
perf(cli): split plugin registry startup timing

### DIFF
--- a/src/cli/plugin-registry-loader.test.ts
+++ b/src/cli/plugin-registry-loader.test.ts
@@ -1,7 +1,12 @@
 // Plugin registry loader tests cover CLI plugin registry loading and cache reset behavior.
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { measureCliCommandStartup } from "./command-startup-timing.js";
 
 const ensurePluginRegistryLoadedMock = vi.hoisted(() => vi.fn());
+const tempDirs: string[] = [];
 
 vi.mock("./plugin-registry.js", () => ({
   ensurePluginRegistryLoaded: ensurePluginRegistryLoadedMock,
@@ -23,8 +28,10 @@ describe("plugin-registry-loader", () => {
     loggingState.forceConsoleToStderr = false;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     loggingState.forceConsoleToStderr = originalForceStderr;
+    vi.unstubAllEnvs();
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
   });
 
   it("routes plugin load logs to stderr and restores state", async () => {
@@ -84,5 +91,34 @@ describe("plugin-registry-loader", () => {
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({
       scope: "configured-channels",
     });
+  });
+
+  it("attributes module import separately from runtime loading", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "openclaw-plugin-registry-startup-"));
+    tempDirs.push(dir);
+    const timelinePath = join(dir, "timeline.jsonl");
+    vi.stubEnv("OPENCLAW_DIAGNOSTICS", "timeline");
+    vi.stubEnv("OPENCLAW_DIAGNOSTICS_TIMELINE_PATH", timelinePath);
+
+    await measureCliCommandStartup("plugin-registry", () =>
+      ensureCliPluginRegistryLoaded({
+        scope: "all",
+      }),
+    );
+
+    const events = (await readFile(timelinePath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    const starts = events.filter((event) => event.type === "span.start");
+    const outer = starts.find(
+      (event) => (event.attributes as { stage?: string } | undefined)?.stage === "plugin-registry",
+    );
+    expect(outer).toBeDefined();
+    expect(
+      starts
+        .filter((event) => event.parentSpanId === outer?.spanId)
+        .map((event) => (event.attributes as { stage?: string } | undefined)?.stage),
+    ).toEqual(["plugin-registry-module-import", "plugin-registry-runtime-load"]);
   });
 });

--- a/src/cli/plugin-registry-loader.test.ts
+++ b/src/cli/plugin-registry-loader.test.ts
@@ -1,12 +1,12 @@
 // Plugin registry loader tests cover CLI plugin registry loading and cache reset behavior.
-import { mkdtemp, readFile, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { measureCliCommandStartup } from "./command-startup-timing.js";
 
 const ensurePluginRegistryLoadedMock = vi.hoisted(() => vi.fn());
-const tempDirs: string[] = [];
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 vi.mock("./plugin-registry.js", () => ({
   ensurePluginRegistryLoaded: ensurePluginRegistryLoadedMock,
@@ -28,10 +28,9 @@ describe("plugin-registry-loader", () => {
     loggingState.forceConsoleToStderr = false;
   });
 
-  afterEach(async () => {
+  afterEach(() => {
     loggingState.forceConsoleToStderr = originalForceStderr;
     vi.unstubAllEnvs();
-    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
   });
 
   it("routes plugin load logs to stderr and restores state", async () => {
@@ -94,8 +93,7 @@ describe("plugin-registry-loader", () => {
   });
 
   it("attributes module import separately from runtime loading", async () => {
-    const dir = await mkdtemp(join(tmpdir(), "openclaw-plugin-registry-startup-"));
-    tempDirs.push(dir);
+    const dir = tempDirs.make("openclaw-plugin-registry-startup-");
     const timelinePath = join(dir, "timeline.jsonl");
     vi.stubEnv("OPENCLAW_DIAGNOSTICS", "timeline");
     vi.stubEnv("OPENCLAW_DIAGNOSTICS_TIMELINE_PATH", timelinePath);

--- a/src/cli/plugin-registry-loader.ts
+++ b/src/cli/plugin-registry-loader.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { loggingState } from "../logging/state.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import type { CliPluginRegistryScope } from "./command-catalog.js";
+import { measureCliCommandStartup } from "./command-startup-timing.js";
 
 const pluginRegistryModuleLoader = createLazyImportLoader(() => import("./plugin-registry.js"));
 
@@ -17,20 +18,25 @@ export async function ensureCliPluginRegistryLoaded(params: {
   config?: OpenClawConfig;
   activationSourceConfig?: OpenClawConfig;
 }) {
-  const { ensurePluginRegistryLoaded } = await loadPluginRegistryModule();
-  const previousForceStderr = loggingState.forceConsoleToStderr;
-  if (params.routeLogsToStderr) {
-    loggingState.forceConsoleToStderr = true;
-  }
-  try {
-    ensurePluginRegistryLoaded({
-      scope: params.scope,
-      ...(params.config ? { config: params.config } : {}),
-      ...(params.activationSourceConfig
-        ? { activationSourceConfig: params.activationSourceConfig }
-        : {}),
-    });
-  } finally {
-    loggingState.forceConsoleToStderr = previousForceStderr;
-  }
+  const { ensurePluginRegistryLoaded } = await measureCliCommandStartup(
+    "plugin-registry-module-import",
+    loadPluginRegistryModule,
+  );
+  await measureCliCommandStartup("plugin-registry-runtime-load", () => {
+    const previousForceStderr = loggingState.forceConsoleToStderr;
+    if (params.routeLogsToStderr) {
+      loggingState.forceConsoleToStderr = true;
+    }
+    try {
+      ensurePluginRegistryLoaded({
+        scope: params.scope,
+        ...(params.config ? { config: params.config } : {}),
+        ...(params.activationSourceConfig
+          ? { activationSourceConfig: params.activationSourceConfig }
+          : {}),
+      });
+    } finally {
+      loggingState.forceConsoleToStderr = previousForceStderr;
+    }
+  });
 }


### PR DESCRIPTION
## What Problem This Solves

Latest-main Kova runs can attribute roughly 1.3 seconds to CLI plugin-registry startup, but the existing aggregate cannot distinguish lazy module import from runtime registry loading. That makes the next performance change speculative.

## Why This Change Was Made

Add nested `cli.command-startup` spans for the plugin-registry module import and runtime load while preserving the existing parent aggregate. Plugin activation, config handling, cache behavior, and log routing remain unchanged.

## User Impact

There is no direct user-visible behavior change. Maintainers can now identify whether CLI plugin startup time belongs to the import graph or registry work before choosing an optimization.

## Evidence

- Exact-main Kova run `kova-260804-185805-67747a` passed 5/5 at `832459d2ae76`; the existing `plugin-registry` stage remained the largest unattributed warm-start bucket.
- `node scripts/run-vitest.mjs src/cli/plugin-registry-loader.test.ts src/cli/command-bootstrap.test.ts src/cli/command-startup-timing.test.ts` (14 tests passed).
- Core production and core-test `tsgo` checks passed.
- `env CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false node scripts/build-all.mjs cliStartup` passed.
- Targeted `oxfmt`, `oxlint`, and `git diff --check` passed.
- The staged test-temp creation guard returned no findings after switching to the shared auto-cleanup tracker.
- Local autoreview reported no actionable findings and rated the patch correct at 0.99.
- Production delta: +22/-16 (net +6); tests: +34/-0.

AI-assisted: yes. The implementation, ownership boundary, and proof were verified against current `main`.

Punchcard-Session: coral-workshop-workshop-3f
