### PR TITLE
fix(qa): carry selected runtime into flow scenarios

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog-compaction.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-compaction.test.ts
@@ -102,9 +102,7 @@ describe("qa compaction scenario catalog", () => {
       | Record<string, unknown>
       | undefined;
     expect(runtimeGuard?.assert).toMatchObject({
-      expr: expect.stringContaining(
-        "(env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME ?? 'openclaw') === 'openclaw'",
-      ),
+      expr: expect.stringContaining("env.runtimeId === 'openclaw'"),
     });
 
     const knownGapIndex = flow.indexOf(knownGap);

--- a/extensions/qa-lab/src/scenario-catalog-compaction.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-compaction.test.ts
@@ -27,7 +27,7 @@ describe("qa compaction scenario catalog", () => {
     expect(scenario.gatewayConfigPatch).toMatchObject({
       agents: { defaults: { compaction: { mode: "default" } } },
     });
-    expect(flow).toContain("OPENCLAW_QA_FORCE_RUNTIME === 'openclaw'");
+    expect(flow).toContain("env.runtimeId === 'openclaw'");
     expect(flow).toContain("initialRequests[0].errorCode === 'context_length_exceeded'");
     expect(flow).toContain("initialRequests.length === 2");
     expect(flow).toContain("compactionSummaryRequests.length === 2");
@@ -85,7 +85,7 @@ describe("qa compaction scenario catalog", () => {
       | undefined;
     expect(firstAction).toBeDefined();
     const conditional = firstAction?.if as Record<string, unknown> | undefined;
-    expect(conditional?.expr).toBe("env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME === 'codex'");
+    expect(conditional?.expr).toBe("env.runtimeId === 'codex'");
     expect(conditional?.["then"]).toMatchObject([
       {
         call: "qaImport",
@@ -115,7 +115,7 @@ describe("qa compaction scenario catalog", () => {
     expect(flow).toContain("new qaErrors.QaSuiteScenarioSkipError");
     expect(flow).toContain("seedQaSessionTranscript");
     expect(flow).toContain("sessions.compaction.branch");
-    expect(flow).toContain("OPENCLAW_QA_FORCE_RUNTIME");
+    expect(flow).toContain("env.runtimeId");
     expect(flow).toContain('"transcriptToolName":"write"');
     expect(flow).toContain('"requireSuccessfulTranscriptToolResult":true');
     expect(flow).toContain("outbound.text === config.finalMarker");

--- a/extensions/qa-lab/src/scenario-catalog.runtime-pair.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.runtime-pair.test.ts
@@ -79,7 +79,7 @@ describe("QA runtime-pair scenario catalog", () => {
     const longContextScenario = readQaScenarioById("long-context-progress-watchdog");
     expect(longContextScenario.execution).toMatchObject({ kind: "flow", runtime: "codex" });
     const longContextFlow = JSON.stringify(longContextScenario.execution.flow);
-    expect(longContextFlow).toContain("OPENCLAW_QA_FORCE_RUNTIME");
+    expect(longContextFlow).toContain("env.runtimeId");
     expect(longContextFlow).not.toContain("patchConfig");
   });
 });

--- a/extensions/qa-lab/src/suite-run-standard.parity-retry.test.ts
+++ b/extensions/qa-lab/src/suite-run-standard.parity-retry.test.ts
@@ -131,6 +131,27 @@ beforeEach(() => {
 });
 
 describe("QA runtime parity scenario retry isolation", () => {
+  it.each([
+    { forcedRuntime: undefined, expectedRuntime: "openclaw" },
+    { forcedRuntime: "codex" as const, expectedRuntime: "codex" },
+  ])(
+    "records $expectedRuntime as the selected runtime fact",
+    async ({ forcedRuntime, expectedRuntime }) => {
+      const runScenario = vi.fn<QaSuiteScenarioRunner>().mockImplementation(async (env) => {
+        expect(env.runtimeId).toBe(expectedRuntime);
+        return makeRetryTestResult("pass");
+      });
+
+      await runQaFlowSuiteStandard(
+        { lab: makeRetryTestLab(), ...(forcedRuntime ? { forcedRuntime } : {}) },
+        makeRetryTestContext(),
+        runScenario,
+      );
+
+      expect(runScenario).toHaveBeenCalledOnce();
+    },
+  );
+
   it("skips connected-transport readiness for intentionally unhealthy startup", async () => {
     const context = makeRetryTestContext();
     context.gatewayRuntimeOptions = { allowUnhealthyStartup: true };

--- a/extensions/qa-lab/src/suite-run-standard.ts
+++ b/extensions/qa-lab/src/suite-run-standard.ts
@@ -152,6 +152,7 @@ export async function runQaFlowSuiteStandard(
       lab,
       mock: activeMock,
       gateway: activeGateway,
+      runtimeId: params?.forcedRuntime ?? "openclaw",
       outputDir,
       // YAML scenarios should see the full staged gateway config, not just
       // the transport fragment. Routing/session/plugin assertions depend on it.

--- a/extensions/qa-lab/src/suite-types.ts
+++ b/extensions/qa-lab/src/suite-types.ts
@@ -26,6 +26,7 @@ export type QaSuiteScenarioResult = {
 
 export type QaSuiteEnvironment = {
   lab: QaLabServerHandle;
+  runtimeId: RuntimeId;
   webSessionIds: Set<string>;
 } & QaSuiteRuntimeEnv;
 

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -74,6 +74,7 @@ export type QaSuiteScenarioResult = {
 
 type QaSuiteEnvironment = {
   lab: QaLabServerHandle;
+  runtimeId: RuntimeId;
   webSessionIds: Set<string>;
 } & QaSuiteRuntimeEnv;
 

--- a/qa/scenarios/models/codex-harness-no-meta-leak.yaml
+++ b/qa/scenarios/models/codex-harness-no-meta-leak.yaml
@@ -65,10 +65,10 @@ flow:
             message:
               expr: "`expected live primary model ${config.requiredModel}, got ${env.primaryModel}`"
         - assert:
-            expr: "env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME === config.harnessRuntime"
+            expr: "env.runtimeId === config.harnessRuntime"
             message:
-              expr: "`expected suite runtime ${config.harnessRuntime}, got ${env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME}`"
-      detailsExpr: "`provider=${selected?.provider} model=${selected?.model} runtime=${env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME}`"
+              expr: "`expected suite runtime ${config.harnessRuntime}, got ${env.runtimeId}`"
+      detailsExpr: "`provider=${selected?.provider} model=${selected?.model} runtime=${env.runtimeId}`"
     - name: keeps codex coordination chatter out of the visible reply
       actions:
         - call: reset

--- a/qa/scenarios/runtime/compaction-empty-response-recovery.yaml
+++ b/qa/scenarios/runtime/compaction-empty-response-recovery.yaml
@@ -39,7 +39,7 @@ flow:
     - name: retries an empty compaction summary at the compaction owner
       actions:
         - assert:
-            expr: "env.providerMode === 'mock-openai' && env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME === 'openclaw' && Boolean(env.mock)"
+            expr: "env.providerMode === 'mock-openai' && env.runtimeId === 'openclaw' && Boolean(env.mock)"
             message: compaction output recovery requires the mock-openai OpenClaw runtime
         - call: waitForGatewayHealthy
           args:

--- a/qa/scenarios/runtime/compaction-reasoning-only-recovery.yaml
+++ b/qa/scenarios/runtime/compaction-reasoning-only-recovery.yaml
@@ -39,7 +39,7 @@ flow:
     - name: retries a reasoning-only compaction summary at the compaction owner
       actions:
         - assert:
-            expr: "env.providerMode === 'mock-openai' && env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME === 'openclaw' && Boolean(env.mock)"
+            expr: "env.providerMode === 'mock-openai' && env.runtimeId === 'openclaw' && Boolean(env.mock)"
             message: compaction output recovery requires the mock-openai OpenClaw runtime
         - call: waitForGatewayHealthy
           args:

--- a/qa/scenarios/runtime/compaction-retry-mutating-tool.yaml
+++ b/qa/scenarios/runtime/compaction-retry-mutating-tool.yaml
@@ -48,7 +48,7 @@ flow:
     - name: compacts bulky history and mutates exactly once after overflow
       actions:
         - if:
-            expr: "env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME === 'codex'"
+            expr: "env.runtimeId === 'codex'"
             then:
               - call: qaImport
                 args:
@@ -57,7 +57,7 @@ flow:
               - throw:
                   expr: "new qaErrors.QaSuiteScenarioSkipError('known-harness-gap compaction-retry-mutating-tool: provider-error recovery does not invoke Codex native compaction; native token-threshold compaction needs a separate scenario.')"
         - assert:
-            expr: "(env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME ?? 'openclaw') === 'openclaw' && env.providerMode === 'mock-openai' && Boolean(env.mock)"
+            expr: "env.runtimeId === 'openclaw' && env.providerMode === 'mock-openai' && Boolean(env.mock)"
             message: compaction overflow injection requires the mock-openai OpenClaw runtime
         - call: waitForGatewayHealthy
           args:

--- a/qa/scenarios/runtime/long-context-progress-watchdog.yaml
+++ b/qa/scenarios/runtime/long-context-progress-watchdog.yaml
@@ -44,9 +44,9 @@ flow:
             - ref: env
             - 60000
         - assert:
-            expr: "env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME === config.harnessRuntime"
+            expr: "env.runtimeId === config.harnessRuntime"
             message:
-              expr: "`expected suite runtime ${config.harnessRuntime}, got ${env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME}`"
+              expr: "`expected suite runtime ${config.harnessRuntime}, got ${env.runtimeId}`"
         - call: reset
         - set: logCursor
           value:

--- a/qa/scenarios/workspace/medium-game-plan-codex-harness.yaml
+++ b/qa/scenarios/workspace/medium-game-plan-codex-harness.yaml
@@ -68,10 +68,10 @@ flow:
             message:
               expr: "`expected live primary model ${config.requiredModel}, got ${env.primaryModel}`"
         - assert:
-            expr: "env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME === config.harnessRuntime"
+            expr: "env.runtimeId === config.harnessRuntime"
             message:
-              expr: "`expected suite runtime ${config.harnessRuntime}, got ${env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME}`"
-      detailsExpr: "`provider=${selected?.provider} model=${selected?.model} runtime=${env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME}`"
+              expr: "`expected suite runtime ${config.harnessRuntime}, got ${env.runtimeId}`"
+      detailsExpr: "`provider=${selected?.provider} model=${selected?.model} runtime=${env.runtimeId}`"
     - name: builds the medium game artifact
       actions:
         - call: reset

--- a/qa/scenarios/workspace/medium-game-plan-openclaw-harness.yaml
+++ b/qa/scenarios/workspace/medium-game-plan-openclaw-harness.yaml
@@ -66,10 +66,10 @@ flow:
             message:
               expr: "`expected live primary model ${config.requiredModel}, got ${env.primaryModel}`"
         - assert:
-            expr: "env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME === config.harnessRuntime"
+            expr: "env.runtimeId === config.harnessRuntime"
             message:
-              expr: "`expected suite runtime ${config.harnessRuntime}, got ${env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME}`"
-      detailsExpr: "`provider=${selected?.provider} model=${selected?.model} runtime=${env.gateway.runtimeEnv.OPENCLAW_QA_FORCE_RUNTIME}`"
+              expr: "`expected suite runtime ${config.harnessRuntime}, got ${env.runtimeId}`"
+      detailsExpr: "`provider=${selected?.provider} model=${selected?.model} runtime=${env.runtimeId}`"
     - name: builds the medium game artifact
       actions:
         - call: reset


### PR DESCRIPTION
Closes https://github.com/openclaw/openclaw/issues/119323

## What Problem This Solves

Runtime-specific QA Lab flows used `OPENCLAW_QA_FORCE_RUNTIME` as their runtime identity. Normal `openclaw qa suite` runs deliberately leave that override unset because OpenClaw is the default runtime, so the scenarios rejected a valid default run before exercising the behavior they claimed to cover.

The full default mock-provider catalog exposed this as a cluster: all three compaction-owner scenarios failed. Serial reruns reproduced the same guard failure outside load.

## Root Cause

The suite selected the runtime when it created each Gateway worker but did not carry that prepared fact into the flow environment. Scenarios rediscovered runtime identity from an optional process override instead. That made the absence of an override indistinguishable from an unknown runtime, even though the suite contract defines OpenClaw as the default.

## What Changed

- Record `runtimeId` when constructing the QA scenario environment: explicit runtime-pair cells keep their selected runtime and ordinary runs record `openclaw`.
- Move every runtime-specific flow assertion and diagnostic to `env.runtimeId`.
- Add regression coverage for both the default OpenClaw fact and an explicit Codex cell.

The Gateway process still tests the real default selection path; this does not force `OPENCLAW_QA_FORCE_RUNTIME=openclaw` into ordinary runs. No product runtime, provider, protocol, config, storage, or shipped UI behavior changes.

## Evidence

Exact head: `d4b3f98c624367f59bf524d423bf488f4d57d3b6`.

- Baseline full catalog on current main: 133 scenarios at concurrency 8 produced 120 passes, 8 expected optional-tool skips, and 5 failures. The three compaction scenarios formed one deterministic runtime-fact cluster: https://github.com/openclaw/openclaw/actions/runs/30940223840.
- Baseline serial confirmation: the three compaction scenarios failed before behavior execution with the OpenClaw-runtime guard on Testbox `tbx_01kz72tz20m8vgwapacga18601`.
- Focused unit proof: 5 files / 62 tests passed.
- One clean rebase onto `aa07d55ec98f14e6c67836991550acf05e62b4a8` preserved https://github.com/openclaw/openclaw/pull/119188's relaxed contiguous-tail compaction proof while replacing its one-scenario env fallback with the shared runtime fact.
- Exact-head local real-behavior proof: all 3 compaction scenarios passed. Empty/reasoning-only recovery each made two ordered summary requests and persisted one compaction; the mutating-tool case shrank 1,469,507 bytes to 192,330 bytes with one write, one compaction, and one checkpoint.
- Exact-head Linux Testbox real-behavior proof `tbx_01kz76xx5g3ax7v3gdw0gmzj0k`, https://github.com/openclaw/openclaw/actions/runs/30947375307: all 3 default OpenClaw scenarios passed; the OpenClaw/Codex runtime-pair run passed with the OpenClaw cell executing and the Codex cell taking its documented early skip.
- Exact-head Blacksmith Testbox changed gate `tbx_01kz75s1tgv1hdc53ty699syfj`, https://github.com/openclaw/openclaw/actions/runs/30945824761: all projects typechecked; core/extensions/scripts linted clean; formatting, dependency, plugin boundary, SDK, storage, media, dead-export, and import-cycle guards passed.
- Exact-head hosted CI, https://github.com/openclaw/openclaw/actions/runs/30945764129: every required build, test, type, lint, QA smoke, security, and artifact check passed on attempt 1.
- Fresh exact-head full-branch AutoReview: clean, no accepted/actionable findings, correctness 0.98.
- Public model-identifier audit: PASS. The diff adds no model identifier.

## Codex Dependency Contract

Inspected sibling Codex at `003ec63bba93cf994246799f795a6a4f6d67743a`:

- [`ThreadStartParams`](https://github.com/openai/codex/blob/003ec63bba93cf994246799f795a6a4f6d67743a/codex-rs/app-server-protocol/src/protocol/v2/thread.rs#L57-L61) accepts the explicit model/provider selection used by Codex QA cells.
- [`ThreadStartResponse`](https://github.com/openai/codex/blob/003ec63bba93cf994246799f795a6a4f6d67743a/codex-rs/app-server-protocol/src/protocol/v2/thread.rs#L171-L175) reports the resolved model provider.
- App-server constructs that response from the selected config snapshot in [`thread_processor.rs`](https://github.com/openai/codex/blob/003ec63bba93cf994246799f795a6a4f6d67743a/codex-rs/app-server/src/request_processors/thread_processor.rs#L1386-L1390).

This patch does not change Codex protocol or provider resolution; it preserves the already-selected QA cell identity for scenario logic.

## Repair Doctrine Summary

- Architectural owner: QA suite environment construction, where the runtime is selected.
- Canonical fix: carry the selected runtime forward as one typed fact.
- Removed path: scenario-local inference from the optional Gateway override environment variable.
- Runtime QA plumbing delta: +3/-0.
- Regression-test delta: +21/-0; scenario/catalog migrations are net-neutral replacements.
- Total delta: +44/-22 across 13 QA-only files.
- Risk: low. The change affects private QA execution only and is proven under default and runtime-pair modes.

Changelog not required: internal QA correctness only.

AI-assisted: yes.
