### PR TITLE
fix(agents): honor account-scoped history limits instead of silently ignoring them

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1783,7 +1783,7 @@ src/agents/embedded-agent-runner/empty-assistant-turn.ts	1
 src/agents/embedded-agent-runner/extensions.ts	1
 src/agents/embedded-agent-runner/extra-params.ts	12
 src/agents/embedded-agent-runner/google-prompt-cache.ts	6
-src/agents/embedded-agent-runner/history.ts	3
+src/agents/embedded-agent-runner/history.ts	2
 src/agents/embedded-agent-runner/message-visibility.ts	13
 src/agents/embedded-agent-runner/model-context-tokens.ts	1
 src/agents/embedded-agent-runner/model.compat.ts	1

--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -74,7 +74,13 @@ Type `/compact` in any chat to force a compaction. Add instructions to guide the
 /compact Focus on the API design decisions
 ```
 
-Manual compaction uses `agents.defaults.compaction.keepRecentTokens` (default: 20,000) as its cut-point budget and keeps that recent tail in rebuilt context.
+Client-side manual compaction uses `agents.defaults.compaction.keepRecentTokens` (default: 20,000) as its cut-point budget and keeps that recent tail in rebuilt context.
+
+### Provider checkpoints
+
+When an embedded Responses provider returns a compacted window, OpenClaw preserves the complete returned context alongside the checkpoint. Recent-turn history limits do not discard an eligible checkpoint, and the retained context still counts toward the model's prompt budget. The saved checkpoint is limited to 16 MiB; oversized or incompatible endpoint output uses the normal client-side compaction path instead of being truncated.
+
+If an older version or transcript redaction removes the complete window needed for replay, OpenClaw asks you to run `/compact`. That command rebuilds context from the saved conversation through client-side compaction. It does not guess the missing provider context or delete the transcript.
 
 ## Configuration
 

--- a/docs/gateway/config-channels.md
+++ b/docs/gateway/config-channels.md
@@ -883,9 +883,40 @@ Fix: either pick a stronger tool-calling model, remove the explicit `"message_to
 }
 ```
 
-Resolution: per-DM override → provider default → no limit (all retained).
+Resolution: per-DM override → provider default → no limit (all retained). On a multi-account channel, the account for the current message is checked before the channel root, so `channels.<provider>.accounts.<id>.dmHistoryLimit` overrides `channels.<provider>.dmHistoryLimit` for that account only.
 
-This resolver reads `channels.<provider>.dmHistoryLimit` and `channels.<provider>.dms.<id>.historyLimit` for any channel whose session key follows the standard `provider:direct:<id>` (or legacy `provider:dm:<id>`) shape, so it works across bundled and plugin channels alike, not just a fixed list.
+The `dms` map is the exception: an account that defines `accounts.<id>.dms` replaces the root `dms` map for that account rather than merging entry by entry. A peer listed only at the root therefore falls through to that account's `dmHistoryLimit`, not to the root per-DM value. Repeat any root entries you still want inside the account map.
+
+The embedded OpenClaw runtime applies these limits to recent turns during prompt preparation for channel-scoped DM sessions, including `per-account-channel-peer`. Shared main sessions remain unwindowed by these channel limits. Client-side compaction still summarizes older durable history; the resulting summary is preserved alongside the windowed recent turns. These limits do not delete stored messages. Native runtimes manage their own transcript history.
+
+Provider-side compaction uses the prepared transcript window. Gateway-triggered compaction resolves a linked peer from the current session's recorded primary conversation; missing or stale route facts do not select another peer's override.
+
+Channel-supplied recent-message context is a separate window. For example, Telegram looks up `dms` by native user ID and counts individual messages, while the embedded transcript window looks up the session peer and counts user turns. With `session.identityLinks`, that session peer is the linked ID. Configure both keys when you want both windows limited for a linked identity:
+
+```json5
+{
+  session: {
+    dmScope: "per-channel-peer",
+    identityLinks: { alice: ["telegram:123456789"] },
+  },
+  channels: {
+    telegram: {
+      accounts: {
+        work: {
+          dms: {
+            "123456789": { historyLimit: 2 }, // Telegram supplemental context
+            alice: { historyLimit: 2 }, // Embedded session transcript
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+These existing windows are not one strict whole-prompt cap: supplemental reply context, saved compaction summaries, and the transcript window's batching cushion can add context beyond the configured count.
+
+Session keys alone can be ambiguous when account names or linked peer IDs contain tokens such as `direct`. OpenClaw uses the observed route peer to select the correct per-DM override. When an ambiguous session has no observed peer, or its identity link has changed, the known account/channel DM default applies instead of another peer's override. Unambiguous session keys retain their existing per-DM lookup.
 
 #### Self-chat mode
 

--- a/extensions/anthropic/stream-wrappers.test.ts
+++ b/extensions/anthropic/stream-wrappers.test.ts
@@ -2,6 +2,7 @@ import { configureAiTransportHost, getAiTransportHost } from "@openclaw/ai";
 // Anthropic tests cover stream wrappers plugin behavior.
 import { expectDefined } from "@openclaw/normalization-core";
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
+import { resolveProviderEndpoint } from "openclaw/plugin-sdk/provider-model-shared";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   createAnthropicBetaHeadersWrapper,
@@ -24,6 +25,7 @@ beforeAll(() => {
     ...initialTransportHost,
     resolveProviderRequestCapabilities: (input) => ({
       ...initialTransportHost.resolveProviderRequestCapabilities(input),
+      endpointClass: resolveProviderEndpoint(input.baseUrl).endpointClass,
       allowsAnthropicServiceTier: input.provider === "anthropic",
     }),
   });

--- a/extensions/anthropic/stream-wrappers.ts
+++ b/extensions/anthropic/stream-wrappers.ts
@@ -17,7 +17,9 @@ import {
   composeProviderStreamWrappers,
   createAnthropicThinkingPrefillPayloadWrapper,
   createPayloadPatchStreamWrapper,
+  isAnthropicOAuthApiKey,
   resolveAnthropicPayloadPolicy,
+  resolveAnthropicServerCompactionPlan,
 } from "openclaw/plugin-sdk/provider-stream-shared";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import {
@@ -74,14 +76,7 @@ function mergeAnthropicBetaHeader(
   return merged;
 }
 
-/**
- * Claude subscription credentials are OAuth access tokens rather than API keys.
- * Anthropic authenticates them through `Authorization: Bearer`, so every caller
- * that builds request auth must branch on this instead of assuming `x-api-key`.
- */
-export function isAnthropicOAuthApiKey(apiKey: unknown): boolean {
-  return typeof apiKey === "string" && apiKey.includes("sk-ant-oat");
-}
+export { isAnthropicOAuthApiKey } from "openclaw/plugin-sdk/provider-stream-shared";
 
 function resolveAnthropicFastServiceTier(enabled: boolean): AnthropicServiceTier {
   return enabled ? "auto" : "standard_only";
@@ -235,11 +230,7 @@ function createAnthropicCompactionWrapper(
     applyAnthropicPayloadPolicyToParams(payload, payloadPolicy, new Set());
   });
   return (model, context, options) => {
-    if (
-      extraParams?.anthropicServerCompaction !== true ||
-      isAnthropicOAuthApiKey(options?.apiKey) ||
-      !isDirectAnthropicApiModel(model)
-    ) {
+    if (!resolveAnthropicServerCompactionPlan(model, extraParams, options?.apiKey).enabled) {
       return underlying(model, context, options);
     }
     return payloadWrapper(model, context, {

--- a/extensions/xai/server-compaction.test.ts
+++ b/extensions/xai/server-compaction.test.ts
@@ -63,15 +63,10 @@ function wrapResponses(options: { fastMode?: boolean; clientVersion?: string }):
 beforeEach(() => {
   sdkState.clients.length = 0;
   sdkState.post.mockReset();
-  sdkState.post.mockReturnValue({
-    asResponse: async () =>
-      new Response(
-        JSON.stringify({
-          object: "response.compaction",
-          output: [{ type: "compaction", id: "cmp_1", encrypted_content: "opaque" }],
-          usage: { input_tokens: 1_000, output_tokens: 200 },
-        }),
-      ),
+  sdkState.post.mockResolvedValue({
+    object: "response.compaction",
+    output: [{ type: "compaction", id: "cmp_1", encrypted_content: "opaque" }],
+    usage: { input_tokens: 1_000, output_tokens: 200 },
   });
 });
 

--- a/extensions/xai/server-compaction.test.ts
+++ b/extensions/xai/server-compaction.test.ts
@@ -63,10 +63,15 @@ function wrapResponses(options: { fastMode?: boolean; clientVersion?: string }):
 beforeEach(() => {
   sdkState.clients.length = 0;
   sdkState.post.mockReset();
-  sdkState.post.mockResolvedValue({
-    object: "response.compaction",
-    output: [{ type: "compaction", id: "cmp_1", encrypted_content: "opaque" }],
-    usage: { input_tokens: 1_000, output_tokens: 200 },
+  sdkState.post.mockReturnValue({
+    asResponse: async () =>
+      new Response(
+        JSON.stringify({
+          object: "response.compaction",
+          output: [{ type: "compaction", id: "cmp_1", encrypted_content: "opaque" }],
+          usage: { input_tokens: 1_000, output_tokens: 200 },
+        }),
+      ),
   });
 });
 

--- a/packages/ai/src/internal/openai-responses-payload-policy.ts
+++ b/packages/ai/src/internal/openai-responses-payload-policy.ts
@@ -1,2 +1,6 @@
 export { OPENAI_RESPONSES_APIS } from "../transports/openai-responses-contracts.js";
+export {
+  readOpenAIResponsesCompactionWindow,
+  type OpenAIResponsesCompactionOutput,
+} from "../transports/openai-responses-compaction-window.js";
 export { resolveOpenAIResponsesServerCompactionPlan } from "../transports/openai-responses-payload-policy.js";

--- a/packages/ai/src/providers/anthropic-auth-headers.ts
+++ b/packages/ai/src/providers/anthropic-auth-headers.ts
@@ -1,3 +1,13 @@
+import { getAiTransportHost } from "../host.js";
+
+/** Inspect resolved credential shape for auth routing without exposing its value. */
+export function isAnthropicOAuthApiKey(apiKey: unknown): boolean {
+  return (
+    typeof apiKey === "string" &&
+    getAiTransportHost().resolveSecretSentinel(apiKey).includes("sk-ant-oat")
+  );
+}
+
 type AnthropicAuthModel = {
   provider?: string;
   authHeader?: boolean;

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -67,6 +67,7 @@ import {
   stripSystemPromptCacheBoundary,
 } from "../utils/system-prompt-cache-boundary.js";
 import {
+  isAnthropicOAuthApiKey,
   omitFoundryBearerCredentialHeaders,
   usesFoundryBearerAuth,
 } from "./anthropic-auth-headers.js";
@@ -839,11 +840,6 @@ export const streamSimpleAnthropic: StreamFunction<
   } satisfies AnthropicCompactionOptions);
 };
 
-function isOAuthToken(apiKey: string): boolean {
-  // Inspect the host-resolved shape only for auth routing; the SDK still receives the sentinel.
-  return getAiTransportHost().resolveSecretSentinel(apiKey).includes("sk-ant-oat");
-}
-
 function isAnthropicPublicEndpoint(baseUrl: string | undefined): boolean {
   if (!baseUrl) {
     return true;
@@ -971,7 +967,7 @@ function createClient(
   }
 
   // OAuth: Bearer auth, Claude Code identity headers
-  if (isOAuthToken(apiKey)) {
+  if (isAnthropicOAuthApiKey(apiKey)) {
     const client = new Anthropic({
       apiKey: null,
       authToken: apiKey,

--- a/packages/ai/src/transports/anthropic-compaction-replay.ts
+++ b/packages/ai/src/transports/anthropic-compaction-replay.ts
@@ -175,7 +175,7 @@ export function suppressAnthropicCompaction(
   };
 }
 
-function resolveNewestAnthropicCompaction(
+export function resolveNewestAnthropicCompaction(
   messages: Context["messages"],
   model: Model,
   options?: ReplayOpts,

--- a/packages/ai/src/transports/anthropic-payload-policy.test.ts
+++ b/packages/ai/src/transports/anthropic-payload-policy.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { resolveAnthropicEphemeralCacheControl } from "./anthropic-payload-policy.js";
+import { configureAiTransportHost, getAiTransportHost } from "../host.js";
+import {
+  resolveAnthropicEphemeralCacheControl,
+  resolveAnthropicServerCompactionPlan,
+} from "./anthropic-payload-policy.js";
 
 describe("resolveAnthropicEphemeralCacheControl", () => {
   afterEach(() => {
@@ -32,5 +36,36 @@ describe("resolveAnthropicEphemeralCacheControl", () => {
     expect(
       resolveAnthropicEphemeralCacheControl("https://proxy.example.test/vertex", "long"),
     ).toEqual({ type: "ephemeral", ttl: "1h" });
+  });
+});
+
+describe("Anthropic compaction authentication eligibility", () => {
+  const model = { provider: "anthropic", api: "anthropic-messages", contextWindow: 200_000 };
+  const extraParams = { anthropicServerCompaction: true };
+
+  it("rejects OAuth credentials without changing config-only threshold planning", () => {
+    expect(resolveAnthropicServerCompactionPlan(model, extraParams)).toEqual({
+      enabled: true,
+      threshold: 140_000,
+    });
+    expect(resolveAnthropicServerCompactionPlan(model, extraParams, "test-api-key")).toEqual({
+      enabled: true,
+      threshold: 140_000,
+    });
+    expect(
+      resolveAnthropicServerCompactionPlan(model, extraParams, "test-sk-ant-oat-fixture"),
+    ).toEqual({ enabled: false });
+  });
+
+  it("uses the same host-resolved credential shape as the transport", () => {
+    const host = getAiTransportHost();
+    configureAiTransportHost({ ...host, resolveSecretSentinel: () => "test-sk-ant-oat-fixture" });
+    try {
+      expect(
+        resolveAnthropicServerCompactionPlan(model, extraParams, "credential-sentinel"),
+      ).toEqual({ enabled: false });
+    } finally {
+      configureAiTransportHost(host);
+    }
   });
 });

--- a/packages/ai/src/transports/anthropic-payload-policy.ts
+++ b/packages/ai/src/transports/anthropic-payload-policy.ts
@@ -1,5 +1,6 @@
 import type { Model } from "@openclaw/llm-core";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+import { isAnthropicOAuthApiKey } from "../providers/anthropic-auth-headers.js";
 import { resolveCacheRetention } from "../providers/cache-retention.js";
 import {
   splitSystemPromptCacheBoundary,
@@ -70,12 +71,14 @@ export function resolveAnthropicServerCompactionPlan(
     contextWindow?: unknown;
   },
   extraParams?: Record<string, unknown>,
+  apiKey?: string,
 ): { enabled: boolean; threshold?: number } {
   const provider = normalizeOptionalLowercaseString(model.provider);
   const api = normalizeOptionalLowercaseString(model.api);
   const endpointClass = resolveProviderEndpoint(model).endpointClass;
   const enabled =
     extraParams?.anthropicServerCompaction === true &&
+    !isAnthropicOAuthApiKey(apiKey) &&
     provider === "anthropic" &&
     api === "anthropic-messages" &&
     (endpointClass === "default" || endpointClass === "anthropic-public");

--- a/packages/ai/src/transports/anthropic-transport-stream.test.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.test.ts
@@ -12,6 +12,7 @@ import {
   type AiInlineContentBlock,
 } from "../host.js";
 import { createCompactionCapture } from "./anthropic-compaction-replay.js";
+import { resolveCompactionReplayPressure } from "./provider-compaction-replay.js";
 import { withProviderAcceptanceObserver } from "./transport-stream-shared.js";
 
 const { buildGuardedModelFetchMock, guardedFetchMock } = vi.hoisted(() => ({
@@ -543,7 +544,7 @@ describe("anthropic transport stream", () => {
     expect(result.usage.contextUsage).toEqual(testCase.context);
   });
 
-  it("captures and replays streamed compaction summaries", async () => {
+  it("replays captured compaction after restart without trusting usage from disabled replay", async () => {
     guardedFetchMock
       .mockResolvedValueOnce(
         createSseResponse([
@@ -566,6 +567,18 @@ describe("anthropic transport stream", () => {
       )
       .mockResolvedValueOnce(
         createSseResponse([
+          anthropicMessageStart({
+            id: "msg_disabled",
+            usage: { input_tokens: 1, output_tokens: 0 },
+          }),
+          anthropicContentBlockStart(0, { type: "text", text: "Replay was disabled." }),
+          { type: "content_block_stop", index: 0 },
+          anthropicMessageDelta({ stop_reason: "end_turn" }, { input_tokens: 1, output_tokens: 1 }),
+          { type: "message_stop" },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        createSseResponse([
           anthropicMessageStart({ id: "msg_replay", usage: { input_tokens: 1, output_tokens: 0 } }),
           anthropicMessageDelta({ stop_reason: "end_turn" }, { input_tokens: 1, output_tokens: 1 }),
           { type: "message_stop" },
@@ -578,7 +591,7 @@ describe("anthropic transport stream", () => {
       authProfileId: "anthropic:work",
       sessionId: "session-1",
     } as unknown as AnthropicStreamOptions;
-    const firstUser = { role: "user" as const, content: "old question" };
+    const firstUser = { role: "user" as const, content: "old question", timestamp: 1 };
     const first = await runTransportStream(
       model,
       { messages: [firstUser] } as AnthropicStreamContext,
@@ -591,22 +604,63 @@ describe("anthropic transport stream", () => {
       replayIndex: 0,
     });
 
-    await runTransportStream(
-      model,
-      {
-        messages: [firstUser, first, { role: "user", content: "new question" }],
-      } as AnthropicStreamContext,
-      replayOptions,
+    const offContext = {
+      messages: [
+        firstUser,
+        first,
+        { role: "user" as const, content: "while disabled", timestamp: 2 },
+      ],
+    };
+    const offOptions = { ...replayOptions, anthropicServerCompaction: false };
+    const offResult = await runTransportStream(model, offContext, offOptions);
+    expect(JSON.stringify(latestAnthropicRequest().payload.messages)).not.toContain(
+      '"type":"compaction"',
     );
+    expect(offResult.usage.contextUsage).toEqual({
+      state: "available",
+      promptTokens: 1,
+      totalTokens: 2,
+    });
+    // oxlint-disable-next-line unicorn/prefer-structured-clone -- Exercise persisted JSON reload, not an in-memory clone.
+    const resumed: AnthropicStreamContext["messages"] = JSON.parse(
+      JSON.stringify([
+        ...offContext.messages,
+        offResult,
+        { role: "user", content: "new question", timestamp: 3 },
+      ]),
+    );
+
+    await runTransportStream(model, { messages: resumed }, replayOptions);
 
     const replayMessages = latestAnthropicRequest().payload.messages as Array<
       Record<string, unknown>
     >;
-    expect(replayMessages.map((message) => message.role)).toEqual(["assistant", "user"]);
+    expect(replayMessages.map((message) => message.role)).toEqual([
+      "assistant",
+      "user",
+      "assistant",
+      "user",
+    ]);
     expect(replayMessages[0]?.content).toEqual([
       { type: "compaction", content: "summary checkpoint" },
       { type: "text", text: "Done." },
     ]);
+    const pressure = resolveCompactionReplayPressure(
+      resumed,
+      model,
+      { ...replayOptions, enabled: true },
+      {
+        text: (text) => text.length,
+        image: () => 100,
+        json: (value) => JSON.stringify(value).length,
+      },
+    );
+    expect(pressure?.prefixTokens).toBe("summary checkpoint".length);
+    expect(pressure?.messages[2]).not.toHaveProperty("usage.contextUsage");
+    expect(pressure?.messages[2]).toMatchObject({
+      usage: { totalTokens: offResult.usage.totalTokens, cost: offResult.usage.cost },
+    });
+    expect(offResult.usage.contextUsage?.state).toBe("available");
   });
 
   it("records suppression when Anthropic rejects a replayed compaction block", async () => {

--- a/packages/ai/src/transports/anthropic-transport-stream.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.ts
@@ -27,6 +27,7 @@ import {
 import { calculateCost } from "../model-utils.js";
 import type { AnthropicOptions, AnthropicThinkingDisplay } from "../provider-options.js";
 import {
+  isAnthropicOAuthApiKey,
   omitFoundryBearerCredentialHeaders,
   usesFoundryBearerAuth,
 } from "../providers/anthropic-auth-headers.js";
@@ -124,7 +125,6 @@ import {
   parseRetryAfterSeconds,
   readResponseTextSnippet,
   resolveModelHeaderSentinels,
-  resolveSecretSentinel,
 } from "./transport-utils.js";
 
 const ANTHROPIC_MESSAGES_ERROR_BODY_MAX_BYTES = 8 * 1024;
@@ -226,12 +226,6 @@ function resolveAnthropicMessagesMaxTokens(params: {
           Math.floor(contextWindow / ANTHROPIC_MESSAGES_FALLBACK_CONTEXT_DIVISOR),
         ),
       );
-}
-
-function isAnthropicOAuthToken(apiKey: string): boolean {
-  // Auth routing may inspect the real shape, but guarded fetch still receives the sentinel.
-  const resolved = resolveSecretSentinel(apiKey);
-  return (resolved ?? apiKey).includes("sk-ant-oat");
 }
 
 function isDirectAnthropicModel(model: Pick<AnthropicTransportModel, "provider" | "baseUrl">) {
@@ -872,7 +866,7 @@ function createAnthropicTransportClient(params: {
   if (needsInterleavedBeta) {
     betaFeatures.push("interleaved-thinking-2025-05-14");
   }
-  if (isAnthropicOAuthToken(apiKey)) {
+  if (isAnthropicOAuthApiKey(apiKey)) {
     const betaHeader = buildAnthropicBetaHeader(model, betaFeatures, { oauth: true });
     return {
       client: createAnthropicMessagesClient({

--- a/packages/ai/src/transports/openai-responses-client.compact-http.test.ts
+++ b/packages/ai/src/transports/openai-responses-client.compact-http.test.ts
@@ -21,10 +21,7 @@ const compacted = {
 
 describe("prepared Responses compaction HTTP lifetime", () => {
   it("settles pending reads and releases the body when the consumer cancels", async () => {
-    let started!: () => void;
-    const pulling = new Promise<void>((resolve) => {
-      started = resolve;
-    });
+    const { promise: pulling, resolve: started } = Promise.withResolvers<void>();
     const cancel = vi.fn(() => new Promise<void>(() => {}));
     const body = new ReadableStream<Uint8Array>({
       pull() {
@@ -36,7 +33,10 @@ describe("prepared Responses compaction HTTP lifetime", () => {
     const response = await createBoundedOpenAIResponsesCompactionFetch(
       async () => new Response(body),
     )("https://synthetic.invalid/compact");
-    const reader = response.body!.getReader();
+    if (!response.body) {
+      throw new Error("Bounded response is missing its body");
+    }
+    const reader = response.body.getReader();
     const pending = reader.read();
     await pulling;
     try {
@@ -81,10 +81,7 @@ describe("prepared Responses compaction HTTP lifetime", () => {
     const abortController = new AbortController();
     const requestPaths: string[] = [];
     let watchdogFired = false;
-    let firstHeaders!: () => void;
-    const headersReceived = new Promise<void>((resolve) => {
-      firstHeaders = resolve;
-    });
+    const { promise: headersReceived, resolve: firstHeaders } = Promise.withResolvers<void>();
     configureAiTransportHost({
       resolveModelRequestTimeoutMs: () => (mode === "host-timeout" ? timeoutMs : undefined),
       buildModelFetch: () => async (input, init) => {
@@ -116,7 +113,9 @@ describe("prepared Responses compaction HTTP lifetime", () => {
         response.write('{"object":"response.compaction","output":[');
       }
     });
-    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
     const watchdog = setTimeout(() => {
       watchdogFired = true;
       abortController.abort(new Error("fixture cleanup: compaction did not settle"));
@@ -124,7 +123,9 @@ describe("prepared Responses compaction HTTP lifetime", () => {
     }, 2_000);
     try {
       const address = server.address();
-      if (!address || typeof address === "string") throw new Error("Missing loopback address");
+      if (!address || typeof address === "string") {
+        throw new Error("Missing loopback address");
+      }
       const model = {
         id: "synthetic-model",
         name: "Synthetic model",
@@ -180,7 +181,9 @@ describe("prepared Responses compaction HTTP lifetime", () => {
       clearTimeout(watchdog);
       abortController.abort();
       server.closeAllConnections();
-      await new Promise<void>((resolve) => server.close(() => resolve()));
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
     }
   });
 });

--- a/packages/ai/src/transports/openai-responses-client.compact-http.test.ts
+++ b/packages/ai/src/transports/openai-responses-client.compact-http.test.ts
@@ -1,0 +1,186 @@
+import { createServer } from "node:http";
+import type { Context, Model } from "@openclaw/llm-core";
+import OpenAI from "openai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { configureAiTransportHost, getAiTransportHost } from "../host.js";
+import { createOpenAIResponsesTransportStreamFn } from "./openai-responses-client.js";
+import { requestPreparedOpenAIResponsesCompaction } from "./openai-responses-compact-request.js";
+import { createBoundedOpenAIResponsesCompactionFetch } from "./openai-responses-compaction-window.js";
+
+const initialHost = getAiTransportHost();
+afterEach(() => configureAiTransportHost(initialHost));
+
+const context = {
+  messages: [{ role: "user", content: "Retain this synthetic conversation.", timestamp: 1 }],
+} satisfies Context;
+const compacted = {
+  object: "response.compaction",
+  output: [{ type: "compaction", id: "cmp_http", encrypted_content: "synthetic-opaque" }],
+  usage: { input_tokens: 10, output_tokens: 2 },
+};
+
+describe("prepared Responses compaction HTTP lifetime", () => {
+  it("settles pending reads and releases the body when the consumer cancels", async () => {
+    let started!: () => void;
+    const pulling = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    const cancel = vi.fn(() => new Promise<void>(() => {}));
+    const body = new ReadableStream<Uint8Array>({
+      pull() {
+        started();
+        return new Promise<void>(() => {});
+      },
+      cancel,
+    });
+    const response = await createBoundedOpenAIResponsesCompactionFetch(
+      async () => new Response(body),
+    )("https://synthetic.invalid/compact");
+    const reader = response.body!.getReader();
+    const pending = reader.read();
+    await pulling;
+    try {
+      await reader.cancel("consumer stopped");
+      await expect(pending).resolves.toEqual({ done: true, value: undefined });
+      expect(cancel).toHaveBeenCalledExactlyOnceWith("consumer stopped");
+      expect(body.locked).toBe(false);
+    } finally {
+      reader.releaseLock();
+    }
+  });
+
+  it("cancels and unlocks an oversized body without awaiting upstream cleanup", async () => {
+    const cancel = vi.fn(() => new Promise<void>(() => {}));
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(16 * 1024 * 1024 + 1));
+      },
+      cancel,
+    });
+    const boundedFetch = createBoundedOpenAIResponsesCompactionFetch(
+      async () => new Response(body),
+    );
+    const response = await boundedFetch("https://synthetic.invalid/compact");
+    await expect(response.json()).rejects.toThrow("response exceeds 16 MiB");
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(body.locked).toBe(false);
+  });
+
+  it.each([
+    "request-timeout",
+    "host-timeout",
+    "body-timeout-retry",
+    "status-retry",
+    "caller-abort",
+    "success",
+    "oversized-body",
+  ] as const)("preserves SDK %s behavior with a bounded response body", async (mode) => {
+    const deadlineCase =
+      mode === "request-timeout" || mode === "host-timeout" || mode === "body-timeout-retry";
+    const timeoutMs = deadlineCase ? 100 : 1_000;
+    const abortController = new AbortController();
+    const requestPaths: string[] = [];
+    let watchdogFired = false;
+    let firstHeaders!: () => void;
+    const headersReceived = new Promise<void>((resolve) => {
+      firstHeaders = resolve;
+    });
+    configureAiTransportHost({
+      resolveModelRequestTimeoutMs: () => (mode === "host-timeout" ? timeoutMs : undefined),
+      buildModelFetch: () => async (input, init) => {
+        const response = await fetch(input, init);
+        firstHeaders();
+        return response;
+      },
+    });
+    const server = createServer((request, response) => {
+      requestPaths.push(request.url ?? "");
+      request.resume();
+      if (mode === "status-retry" && requestPaths.length === 1) {
+        response.writeHead(503, { "content-type": "application/json", "retry-after-ms": "1" });
+        response.end(JSON.stringify({ error: { message: "retry this synthetic request" } }));
+        return;
+      }
+      response.writeHead(200, { "content-type": "application/json" });
+      response.flushHeaders();
+      if (mode === "oversized-body") {
+        response.end(Buffer.alloc(16 * 1024 * 1024 + 1, "x"));
+      } else if (
+        mode === "success" ||
+        mode === "status-retry" ||
+        (mode === "body-timeout-retry" && requestPaths.length > 1)
+      ) {
+        response.end(JSON.stringify(compacted));
+      } else {
+        // Headers arrive promptly; only SDK body parsing can enforce this deadline.
+        response.write('{"object":"response.compaction","output":[');
+      }
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const watchdog = setTimeout(() => {
+      watchdogFired = true;
+      abortController.abort(new Error("fixture cleanup: compaction did not settle"));
+      server.closeAllConnections();
+    }, 2_000);
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") throw new Error("Missing loopback address");
+      const model = {
+        id: "synthetic-model",
+        name: "Synthetic model",
+        provider: "synthetic-provider",
+        api: "openai-responses",
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 100_000,
+        maxTokens: 1_000,
+      } satisfies Model;
+      const outcome = requestPreparedOpenAIResponsesCompaction(
+        createOpenAIResponsesTransportStreamFn(),
+        model,
+        context,
+        {
+          apiKey: "synthetic-loopback-only",
+          ...(mode !== "host-timeout" ? { timeoutMs } : {}),
+          maxRetries: mode === "body-timeout-retry" || mode === "status-retry" ? 1 : 0,
+          signal: abortController.signal,
+        },
+      ).then(
+        (value) => ({ value, error: undefined }),
+        (error: unknown) => ({ value: undefined, error }),
+      );
+      if (mode === "caller-abort") {
+        await headersReceived;
+        abortController.abort();
+      }
+      const result = await outcome;
+      if (mode === "request-timeout" || mode === "host-timeout") {
+        expect(result.error).toBeInstanceOf(OpenAI.APIConnectionTimeoutError);
+      } else if (mode === "caller-abort") {
+        expect(result.error).toBeInstanceOf(OpenAI.APIUserAbortError);
+      } else if (mode === "oversized-body") {
+        expect(result.error).toBeInstanceOf(Error);
+        expect(String(result.error)).toContain("response exceeds 16 MiB");
+      } else {
+        expect(result.error).toBeUndefined();
+        expect(result.value?.output).toEqual(compacted.output);
+      }
+      expect(watchdogFired).toBe(false);
+      expect(requestPaths).toEqual(
+        Array.from(
+          {
+            length: mode === "body-timeout-retry" || mode === "status-retry" ? 2 : 1,
+          },
+          () => "/v1/responses/compact",
+        ),
+      );
+    } finally {
+      clearTimeout(watchdog);
+      abortController.abort();
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});

--- a/packages/ai/src/transports/openai-responses-client.compact-http.test.ts
+++ b/packages/ai/src/transports/openai-responses-client.compact-http.test.ts
@@ -2,6 +2,7 @@ import { createServer } from "node:http";
 import type { Context, Model } from "@openclaw/llm-core";
 import OpenAI from "openai";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import { configureAiTransportHost, getAiTransportHost } from "../host.js";
 import { createOpenAIResponsesTransportStreamFn } from "./openai-responses-client.js";
 import { requestPreparedOpenAIResponsesCompaction } from "./openai-responses-compact-request.js";
@@ -21,7 +22,7 @@ const compacted = {
 
 describe("prepared Responses compaction HTTP lifetime", () => {
   it("settles pending reads and releases the body when the consumer cancels", async () => {
-    const { promise: pulling, resolve: started } = Promise.withResolvers<void>();
+    const { promise: pulling, resolve: started } = createDeferred();
     const cancel = vi.fn(() => new Promise<void>(() => {}));
     const body = new ReadableStream<Uint8Array>({
       pull() {
@@ -81,7 +82,7 @@ describe("prepared Responses compaction HTTP lifetime", () => {
     const abortController = new AbortController();
     const requestPaths: string[] = [];
     let watchdogFired = false;
-    const { promise: headersReceived, resolve: firstHeaders } = Promise.withResolvers<void>();
+    const { promise: headersReceived, resolve: firstHeaders } = createDeferred();
     configureAiTransportHost({
       resolveModelRequestTimeoutMs: () => (mode === "host-timeout" ? timeoutMs : undefined),
       buildModelFetch: () => async (input, init) => {

--- a/packages/ai/src/transports/openai-responses-client.compact.test.ts
+++ b/packages/ai/src/transports/openai-responses-client.compact.test.ts
@@ -50,9 +50,7 @@ const context = {
 } satisfies Context;
 
 function mockCompactResponse(body: unknown): void {
-  sdkState.post.mockReturnValue({
-    asResponse: () => Promise.resolve(new Response(JSON.stringify(body))),
-  });
+  sdkState.post.mockResolvedValue(body);
 }
 
 describe("responses compact endpoint", () => {
@@ -232,27 +230,6 @@ describe("responses compact endpoint", () => {
         { apiKey: "test-key" },
       ),
     ).rejects.toThrow("one trailing compaction item");
-  });
-
-  it("bounds the response before parsing and cancels the oversized body", async () => {
-    const cancel = vi.fn();
-    const body = new ReadableStream<Uint8Array>({
-      start(controller) {
-        controller.enqueue(new Uint8Array(16 * 1024 * 1024 + 1));
-      },
-      cancel,
-    });
-    sdkState.post.mockReturnValue({ asResponse: () => Promise.resolve(new Response(body)) });
-    await expect(
-      requestPreparedOpenAIResponsesCompaction(
-        createOpenAIResponsesTransportStreamFn(),
-        model,
-        context,
-        { apiKey: "test-key" },
-      ),
-    ).rejects.toThrow("response exceeds 16 MiB");
-    expect(cancel).toHaveBeenCalledOnce();
-    expect(body.locked).toBe(false);
   });
 
   it.each([model, { ...model, provider: "custom", baseUrl: "https://responses.example/v1" }])(

--- a/packages/ai/src/transports/openai-responses-client.compact.test.ts
+++ b/packages/ai/src/transports/openai-responses-client.compact.test.ts
@@ -49,6 +49,12 @@ const context = {
   messages: [{ role: "user", content: "Remember NORTH-COPPER-17.", timestamp: 1 }],
 } satisfies Context;
 
+function mockCompactResponse(body: unknown): void {
+  sdkState.post.mockReturnValue({
+    asResponse: () => Promise.resolve(new Response(JSON.stringify(body))),
+  });
+}
+
 describe("responses compact endpoint", () => {
   beforeEach(() => {
     sdkState.clients.length = 0;
@@ -56,7 +62,7 @@ describe("responses compact endpoint", () => {
   });
 
   it("accepts retained-message prefixes from the official OpenAI endpoint", async () => {
-    sdkState.post.mockResolvedValue({
+    mockCompactResponse({
       object: "response.compaction",
       output: [
         {
@@ -98,6 +104,11 @@ describe("responses compact endpoint", () => {
       }),
     );
     expect(result).toMatchObject({
+      output: [
+        expect.objectContaining({ role: "developer" }),
+        expect.objectContaining({ role: "user" }),
+        { type: "compaction", id: "cmp_1", encrypted_content: "opaque" },
+      ],
       item: { type: "compaction", id: "cmp_1", encrypted_content: "opaque" },
       historyMode: "retained-users",
       usage: { input_tokens: 8_614, output_tokens: 736, dropped_message_count: 3 },
@@ -111,7 +122,7 @@ describe("responses compact endpoint", () => {
   });
 
   it("rejects retained-message prefixes from native xAI", async () => {
-    sdkState.post.mockResolvedValue({
+    mockCompactResponse({
       object: "response.compaction",
       output: [
         {
@@ -165,7 +176,7 @@ describe("responses compact endpoint", () => {
       ],
     ],
   ])("rejects a %s compaction item", async (_case, output) => {
-    sdkState.post.mockResolvedValue({
+    mockCompactResponse({
       object: "response.compaction",
       output,
       usage: { input_tokens: 1, output_tokens: 1 },
@@ -182,7 +193,7 @@ describe("responses compact endpoint", () => {
   });
 
   it("keeps the checkpoint-only response shape distinct from retained user history", async () => {
-    sdkState.post.mockResolvedValue({
+    mockCompactResponse({
       object: "response.compaction",
       output: [{ type: "compaction", id: "cmp_1", encrypted_content: "opaque" }],
       usage: { input_tokens: 1, output_tokens: 1 },
@@ -196,6 +207,98 @@ describe("responses compact endpoint", () => {
         { apiKey: "test-key" },
       ),
     ).resolves.toMatchObject({ historyMode: "compacted-prefix" });
+  });
+
+  it.each([
+    { type: "input_text", text: 1 },
+    { type: "input_image", detail: "auto" },
+    { type: "input_image", detail: "invalid", image_url: "https://media.example/image.png" },
+    { type: "input_file", file_id: 42 },
+    { type: "output_text", text: "not supported input" },
+  ])("rejects unsupported retained content without rewriting it: %j", async (block) => {
+    mockCompactResponse({
+      object: "response.compaction",
+      output: [
+        { type: "message", role: "user", content: [block] },
+        { type: "compaction", encrypted_content: "opaque" },
+      ],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    });
+    await expect(
+      requestPreparedOpenAIResponsesCompaction(
+        createOpenAIResponsesTransportStreamFn(),
+        officialOpenAIModel,
+        context,
+        { apiKey: "test-key" },
+      ),
+    ).rejects.toThrow("one trailing compaction item");
+  });
+
+  it("bounds the response before parsing and cancels the oversized body", async () => {
+    const cancel = vi.fn();
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(16 * 1024 * 1024 + 1));
+      },
+      cancel,
+    });
+    sdkState.post.mockReturnValue({ asResponse: () => Promise.resolve(new Response(body)) });
+    await expect(
+      requestPreparedOpenAIResponsesCompaction(
+        createOpenAIResponsesTransportStreamFn(),
+        model,
+        context,
+        { apiKey: "test-key" },
+      ),
+    ).rejects.toThrow("response exceeds 16 MiB");
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(body.locked).toBe(false);
+  });
+
+  it.each([model, { ...model, provider: "custom", baseUrl: "https://responses.example/v1" }])(
+    "rejects endpoint output altered by the $provider route's status policy",
+    async (route) => {
+      mockCompactResponse({
+        object: "response.compaction",
+        output: [{ type: "compaction", encrypted_content: "opaque", status: "completed" }],
+        usage: { input_tokens: 1, output_tokens: 1 },
+      });
+      await expect(
+        requestPreparedOpenAIResponsesCompaction(
+          createOpenAIResponsesTransportStreamFn(),
+          route,
+          context,
+          { apiKey: "test-key" },
+        ),
+      ).rejects.toThrow("one trailing compaction item");
+    },
+  );
+
+  it.each([
+    "data:image/png;base64,invalid",
+    "data:image/bmp;base64,Qk0=",
+    "data:image/png;base64,/9j/",
+  ])("rejects canonical image output that the transport would change: %s", async (imageUrl) => {
+    mockCompactResponse({
+      object: "response.compaction",
+      output: [
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_image", detail: "auto", image_url: imageUrl }],
+        },
+        { type: "compaction", encrypted_content: "opaque" },
+      ],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    });
+    await expect(
+      requestPreparedOpenAIResponsesCompaction(
+        createOpenAIResponsesTransportStreamFn(),
+        officialOpenAIModel,
+        context,
+        { apiKey: "test-key" },
+      ),
+    ).rejects.toThrow("one trailing compaction item");
   });
 
   it.each([

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -26,6 +26,10 @@ import {
   type OpenAIResponsesReplayMode,
 } from "./openai-responses-compaction-replay.js";
 import {
+  isOpenAIResponsesCompactionOutput,
+  readOpenAIResponsesCompactionResponse,
+} from "./openai-responses-compaction-window.js";
+import {
   claimOpenAIResponsesHttpContinuation,
   type ResponsesContinuationRequest,
 } from "./openai-responses-continuation.js";
@@ -183,25 +187,19 @@ async function postOpenAIResponsesCompaction(params: {
           ...(params.request.input ?? []),
         ]
       : params.request.input;
-  const response = await params.client.post<unknown>("/responses/compact", {
-    ...buildOpenAISdkRequestOptions(params.model, params.options?.signal, {
-      timeoutMs: params.options?.timeoutMs,
-      maxRetries: params.options?.maxRetries,
-    }),
-    body: { model: params.request.model, input: compactInput },
-  });
+  const rawResponse = await params.client
+    .post<unknown>("/responses/compact", {
+      ...buildOpenAISdkRequestOptions(params.model, params.options?.signal, {
+        timeoutMs: params.options?.timeoutMs,
+        maxRetries: params.options?.maxRetries,
+      }),
+      body: { model: params.request.model, input: compactInput },
+    })
+    .asResponse();
+  const response = await readOpenAIResponsesCompactionResponse(rawResponse);
   const output = isRecord(response) && Array.isArray(response.output) ? response.output : [];
   const item = output.at(-1);
   const retainedItems = output.slice(0, -1);
-  const retainedMessagesAreValid = retainedItems.every(
-    (candidate) =>
-      isRecord(candidate) &&
-      candidate.type === "message" &&
-      (candidate.role === "user" ||
-        candidate.role === "developer" ||
-        candidate.role === "system") &&
-      Array.isArray(candidate.content),
-  );
   const retainedUserMessageCount = retainedItems.filter(
     (candidate) =>
       isRecord(candidate) &&
@@ -220,7 +218,7 @@ async function postOpenAIResponsesCompaction(params: {
   if (
     !isRecord(response) ||
     response.object !== "response.compaction" ||
-    !retainedMessagesAreValid ||
+    !isOpenAIResponsesCompactionOutput(output, params.model) ||
     (retainedItems.length > 0 &&
       (!retainedMessagePrefixSupported || retainedUserMessageCount !== inputUserMessageCount)) ||
     !isRecord(item) ||
@@ -234,6 +232,7 @@ async function postOpenAIResponsesCompaction(params: {
     throw new Error("Responses compact endpoint did not return one trailing compaction item");
   }
   return {
+    output,
     item,
     historyMode: retainedUserMessageCount > 0 ? "retained-users" : "compacted-prefix",
     usage,

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -26,8 +26,8 @@ import {
   type OpenAIResponsesReplayMode,
 } from "./openai-responses-compaction-replay.js";
 import {
+  createBoundedOpenAIResponsesCompactionFetch,
   isOpenAIResponsesCompactionOutput,
-  readOpenAIResponsesCompactionResponse,
 } from "./openai-responses-compaction-window.js";
 import {
   claimOpenAIResponsesHttpContinuation,
@@ -163,13 +163,14 @@ export function createOpenAIResponsesClient(
   optionHeaders?: Record<string, string>,
   turnHeaders?: Record<string, string>,
   sessionId?: string,
+  fetchOverride?: typeof globalThis.fetch,
 ) {
   return new OpenAI({
     apiKey,
     baseURL: resolveOpenAIClientBaseUrl(model),
     dangerouslyAllowBrowser: true,
     defaultHeaders: buildOpenAIClientHeaders(model, context, optionHeaders, turnHeaders, sessionId),
-    fetch: buildGuardedModelFetch(model),
+    fetch: fetchOverride ?? buildGuardedModelFetch(model),
     ...buildOpenAISdkClientOptions(model),
   });
 }
@@ -187,16 +188,13 @@ async function postOpenAIResponsesCompaction(params: {
           ...(params.request.input ?? []),
         ]
       : params.request.input;
-  const rawResponse = await params.client
-    .post<unknown>("/responses/compact", {
-      ...buildOpenAISdkRequestOptions(params.model, params.options?.signal, {
-        timeoutMs: params.options?.timeoutMs,
-        maxRetries: params.options?.maxRetries,
-      }),
-      body: { model: params.request.model, input: compactInput },
-    })
-    .asResponse();
-  const response = await readOpenAIResponsesCompactionResponse(rawResponse);
+  const response = await params.client.post<unknown>("/responses/compact", {
+    ...buildOpenAISdkRequestOptions(params.model, params.options?.signal, {
+      timeoutMs: params.options?.timeoutMs,
+      maxRetries: params.options?.maxRetries,
+    }),
+    body: { model: params.request.model, input: compactInput },
+  });
   const output = isRecord(response) && Array.isArray(response.output) ? response.output : [];
   const item = output.at(-1);
   const retainedItems = output.slice(0, -1);
@@ -314,6 +312,9 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
           options?.headers,
           turnState?.headers,
           options?.sessionId,
+          compactRequest
+            ? createBoundedOpenAIResponsesCompactionFetch(buildGuardedModelFetch(model))
+            : undefined,
         );
         const buildRequest = async (replayMode: OpenAIResponsesReplayMode) => {
           let params = config.buildRequest(
@@ -685,6 +686,8 @@ export function createAzureOpenAIClient(
   apiKey: string,
   optionHeaders?: Record<string, string>,
   turnHeaders?: Record<string, string>,
+  _sessionId?: string,
+  fetchOverride?: typeof globalThis.fetch,
 ) {
   const baseURL = normalizeAzureBaseUrl(model.baseUrl);
   const clientOptions = {
@@ -692,7 +695,7 @@ export function createAzureOpenAIClient(
     dangerouslyAllowBrowser: true,
     defaultHeaders: buildOpenAIClientHeaders(model, context, optionHeaders, turnHeaders),
     baseURL,
-    fetch: buildGuardedModelFetch(model),
+    fetch: fetchOverride ?? buildGuardedModelFetch(model),
     ...buildOpenAISdkClientOptions(model),
   };
 

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -669,10 +669,6 @@ export function createAzureOpenAIResponsesTransportStreamFn(): StreamFn {
   });
 }
 
-function normalizeAzureBaseUrl(baseUrl: string): string {
-  return baseUrl.replace(/\/+$/, "");
-}
-
 function resolveAzureDeploymentName(model: Model): string {
   return resolveAzureDeploymentNameFromMap({
     modelId: model.id,
@@ -689,7 +685,7 @@ export function createAzureOpenAIClient(
   _sessionId?: string,
   fetchOverride?: typeof globalThis.fetch,
 ) {
-  const baseURL = normalizeAzureBaseUrl(model.baseUrl);
+  const baseURL = model.baseUrl.replace(/\/+$/, "");
   const clientOptions = {
     apiKey,
     dangerouslyAllowBrowser: true,

--- a/packages/ai/src/transports/openai-responses-compact-request.ts
+++ b/packages/ai/src/transports/openai-responses-compact-request.ts
@@ -1,10 +1,12 @@
 import type { Context, Model, StreamFn } from "@openclaw/llm-core";
+import type { OpenAIResponsesCompactionOutput } from "./openai-responses-compaction-window.js";
 import type {
   OpenAIResponsesOptions,
   OpenAIResponsesReasoningReplayMetadata,
 } from "./openai-responses-contracts.js";
 
 export type OpenAIResponsesCompactEndpointResult = {
+  output: OpenAIResponsesCompactionOutput;
   item: { type: "compaction"; id?: string; encrypted_content: string };
   historyMode: "compacted-prefix" | "retained-users";
   usage: Record<string, unknown> & { input_tokens: number; output_tokens: number };

--- a/packages/ai/src/transports/openai-responses-compaction-replay.ts
+++ b/packages/ai/src/transports/openai-responses-compaction-replay.ts
@@ -10,6 +10,11 @@ import type {
 } from "../provider-options.js";
 import { shortHash } from "../utils/hash.js";
 import {
+  isOpenAIResponsesCompactionOutput,
+  readOpenAIResponsesCompactionWindow,
+  type OpenAIResponsesCompactionOutput,
+} from "./openai-responses-compaction-window.js";
+import {
   OPENAI_RESPONSES_COMPACTION_REPLAY_TYPE,
   OPENAI_RESPONSES_RETAINED_COMPACTION_REPLAY_TYPE,
   OPENAI_RESPONSES_REPLAY_ITEM_ID_MAX_LENGTH,
@@ -124,6 +129,7 @@ export function captureOpenAIResponsesCompaction(
   boundary: number | "retained-users",
   model: Model,
   captureMetadata?: OpenAIResponsesReasoningReplayMetadata,
+  compactedOutput?: OpenAIResponsesCompactionOutput,
 ): void {
   const metadata = captureMetadata ?? buildOpenAIResponsesReasoningReplayMetadata(model);
   if (!item.encrypted_content) {
@@ -141,22 +147,30 @@ export function captureOpenAIResponsesCompaction(
   ) {
     return;
   }
-  output.providerReplay = {
+  if (compactedOutput && !isOpenAIResponsesCompactionOutput(compactedOutput, model)) {
+    throw new Error("Responses compact endpoint checkpoint is invalid");
+  }
+  const replay = {
     v: 1,
-    type:
-      boundary === "retained-users"
-        ? OPENAI_RESPONSES_RETAINED_COMPACTION_REPLAY_TYPE
-        : OPENAI_RESPONSES_COMPACTION_REPLAY_TYPE,
+    ...(boundary === "retained-users"
+      ? { type: OPENAI_RESPONSES_RETAINED_COMPACTION_REPLAY_TYPE }
+      : { type: OPENAI_RESPONSES_COMPACTION_REPLAY_TYPE, replayIndex: boundary }),
     ...(item.id ? { id: item.id } : {}),
     data: item.encrypted_content,
-    ...(typeof boundary === "number" ? { replayIndex: boundary } : {}),
     provider: metadata.provider,
     api: metadata.api,
     model: metadata.model,
     baseUrlHash: metadata.baseUrlHash,
     ...(metadata.sessionHash ? { sessionHash: metadata.sessionHash } : {}),
     ...(metadata.authProfileHash ? { authProfileHash: metadata.authProfileHash } : {}),
-  };
+    ...(compactedOutput
+      ? { compactedWindow: { state: "ready" as const, output: JSON.stringify(compactedOutput) } }
+      : {}),
+  } satisfies OpenAIResponsesCompactionReplayState;
+  if (compactedOutput && !readOpenAIResponsesCompactionWindow(replay, model)) {
+    throw new Error("Responses compact endpoint checkpoint is invalid or exceeds 16 MiB");
+  }
+  output.providerReplay = replay;
 }
 
 export function suppressOpenAIResponsesCompaction(
@@ -229,7 +243,7 @@ export function isSafeResponsesReplayItemId(id: unknown): id is string {
   );
 }
 
-function resolveNewestOpenAIResponsesCompactionReplay(
+export function resolveNewestOpenAIResponsesCompactionReplay(
   messages: Context["messages"],
   model: Model,
   options?: Pick<BaseOpenAIStreamOptions, "authProfileId" | "sessionId">,
@@ -243,8 +257,11 @@ function resolveNewestOpenAIResponsesCompactionReplay(
   | {
       owner: AssistantMessage;
       item: ResponseCompactionItemParam;
-      mode: "retained-users";
+      mode: "complete-window";
+      output: OpenAIResponsesCompactionOutput;
+      replayIndex: number;
     }
+  | { owner: AssistantMessage; mode: "refresh-required" }
   | undefined {
   const context = buildOpenAIResponsesReplayContext(model, options);
   for (let index = messages.length - 1; index >= 0; index -= 1) {
@@ -276,6 +293,26 @@ function resolveNewestOpenAIResponsesCompactionReplay(
     if (!openAIResponsesReplayContextMatches(replay, context)) {
       return undefined;
     }
+    if (
+      replay.compactedWindow !== undefined ||
+      replay.type === OPENAI_RESPONSES_RETAINED_COMPACTION_REPLAY_TYPE
+    ) {
+      const output = readOpenAIResponsesCompactionWindow(replay, model);
+      const item = output?.at(-1);
+      if (!output || item?.type !== "compaction") {
+        return { owner: message, mode: "refresh-required" };
+      }
+      return {
+        owner: message,
+        mode: "complete-window",
+        output,
+        item,
+        replayIndex:
+          replay.type === OPENAI_RESPONSES_RETAINED_COMPACTION_REPLAY_TYPE
+            ? message.content.length
+            : (replay.replayIndex ?? 0),
+      };
+    }
     return {
       owner: message,
       item: {
@@ -283,9 +320,8 @@ function resolveNewestOpenAIResponsesCompactionReplay(
         ...(isSafeResponsesReplayItemId(replay.id) ? { id: replay.id } : {}),
         encrypted_content: replay.data,
       },
-      ...(replay.type === OPENAI_RESPONSES_RETAINED_COMPACTION_REPLAY_TYPE
-        ? { mode: "retained-users" as const }
-        : { mode: "compacted-prefix" as const, replayIndex: replay.replayIndex ?? 0 }),
+      mode: "compacted-prefix",
+      replayIndex: replay.replayIndex ?? 0,
     };
   }
   return undefined;
@@ -295,10 +331,19 @@ export type OpenAIResponsesReplayMode = "checkpoint" | "full-history";
 
 type OpenAIResponsesCompactionReplayPlan = {
   messages: Context["messages"];
-  retainedMessages?: Context["messages"];
+  compactedWindow?: OpenAIResponsesCompactionOutput;
   compaction?: ResponseCompactionItemParam;
   preserveUnframedToolResults: boolean;
 };
+
+export class CompactionReplayRefreshRequiredError extends Error {
+  constructor() {
+    super(
+      "Provider compaction checkpoint needs rebuilding. Run /compact to rebuild from saved conversation history.",
+    );
+    this.name = "CompactionReplayRefreshRequiredError";
+  }
+}
 
 export function buildOpenAIResponsesCompactionReplayPlan(
   messages: Context["messages"],
@@ -316,38 +361,21 @@ export function buildOpenAIResponsesCompactionReplayPlan(
   if (!compaction) {
     return { messages, preserveUnframedToolResults: false };
   }
+  if (compaction.mode === "refresh-required") {
+    throw new CompactionReplayRefreshRequiredError();
+  }
   const ownerIndex = messages.indexOf(compaction.owner);
-  const collectRetainedUserMessages = (prefix: Context["messages"]): Context["messages"] => {
-    const previous = resolveNewestOpenAIResponsesCompactionReplay(prefix, model, options);
-    if (!previous) {
-      return prefix.filter((message) => message.role === "user");
-    }
-    const previousOwnerIndex = prefix.indexOf(previous.owner);
-    const laterUsers = prefix
-      .slice(previousOwnerIndex + 1)
-      .filter((message) => message.role === "user");
-    // A checkpoint-only window replaces its prefix; a retained-user window extends it.
-    return previous.mode === "retained-users"
-      ? [...collectRetainedUserMessages(prefix.slice(0, previousOwnerIndex)), ...laterUsers]
-      : laterUsers;
-  };
-  const retainedMessages =
-    compaction.mode === "retained-users"
-      ? collectRetainedUserMessages(messages.slice(0, ownerIndex))
-      : undefined;
   const owner = {
     ...compaction.owner,
-    content:
-      compaction.mode === "retained-users"
-        ? []
-        : compaction.owner.content.slice(compaction.replayIndex),
+    content: compaction.owner.content.slice(compaction.replayIndex),
   };
   // Slice before transcript repair so compacted calls cannot synthesize outputs,
   // while real results emitted after the checkpoint remain in chronological order.
   return {
     messages: [owner, ...messages.slice(ownerIndex + 1)],
-    ...(retainedMessages?.length ? { retainedMessages } : {}),
-    compaction: compaction.item,
+    ...(compaction.mode === "complete-window"
+      ? { compactedWindow: compaction.output }
+      : { compaction: compaction.item }),
     preserveUnframedToolResults: true,
   };
 }

--- a/packages/ai/src/transports/openai-responses-compaction-window.ts
+++ b/packages/ai/src/transports/openai-responses-compaction-window.ts
@@ -158,29 +158,45 @@ export function readOpenAIResponsesCompactionWindow(
   }
 }
 
-/** Bound the success body before SDK JSON parsing can allocate an unlimited response. */
-export async function readOpenAIResponsesCompactionResponse(response: Response): Promise<unknown> {
-  if (!response.body) {
-    throw new Error("Responses compact endpoint returned an empty body");
-  }
-  const reader = response.body.getReader();
-  const guard = createSseByteGuard(reader, {
-    maxBytes: COMPACTION_WINDOW_MAX_BYTES,
-    onOverflow: () => new Error("Responses compact endpoint response exceeds 16 MiB"),
-  });
-  const decoder = new TextDecoder();
-  let body = "";
-  try {
-    while (true) {
-      const chunk = await guard.read();
-      if (chunk.done) {
-        break;
-      }
-      body += decoder.decode(chunk.value, { stream: true });
+/** Bound success bytes while leaving body deadlines, retries, and parsing to the SDK. */
+export function createBoundedOpenAIResponsesCompactionFetch(
+  upstreamFetch: typeof globalThis.fetch,
+): typeof globalThis.fetch {
+  return async (input, init) => {
+    const response = await upstreamFetch(input, init);
+    if (!response.ok || !response.body) {
+      return response;
     }
-    return JSON.parse(body + decoder.decode()) as unknown;
-  } finally {
-    await guard.cancel();
-    reader.releaseLock();
-  }
+    const reader = response.body.getReader();
+    const guard = createSseByteGuard(reader, {
+      maxBytes: COMPACTION_WINDOW_MAX_BYTES,
+      onOverflow: () => new Error("Responses compact endpoint response exceeds 16 MiB"),
+    });
+    const body = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        try {
+          const chunk = await guard.read();
+          if (chunk.done) {
+            reader.releaseLock();
+            controller.close();
+          } else {
+            controller.enqueue(chunk.value);
+          }
+        } catch (error) {
+          reader.releaseLock();
+          controller.error(error);
+        }
+      },
+      cancel(reason) {
+        // Cancellation may never settle; it must not hold the SDK's timeout outcome.
+        void guard.cancel(reason);
+        reader.releaseLock();
+      },
+    });
+    return new Response(body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  };
 }

--- a/packages/ai/src/transports/openai-responses-compaction-window.ts
+++ b/packages/ai/src/transports/openai-responses-compaction-window.ts
@@ -1,0 +1,186 @@
+import type { Model } from "@openclaw/llm-core";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import type { ResponseInputItem } from "openai/resources/responses/responses.js";
+import { createSseByteGuard } from "../utils/streaming-byte-guard.js";
+import type { ReplayableResponseCompactionItem } from "./openai-responses-contracts.js";
+import {
+  applyOpenAIResponsesPayloadPolicy,
+  resolveOpenAIResponsesPayloadPolicy,
+} from "./openai-responses-payload-policy.js";
+import { sanitizeResponsesImagePayload } from "./responses-image-payload-sanitizer.js";
+
+// This is the host's response/storage ceiling, not a provider context-token limit.
+const COMPACTION_WINDOW_MAX_BYTES = 16 * 1024 * 1024;
+export type OpenAIResponsesCompactionOutput = Array<
+  ResponseInputItem.Message | ReplayableResponseCompactionItem
+>;
+export type OpenAIResponsesCompactedWindow =
+  | { state: "ready"; output: string }
+  | { state: "refresh-required" };
+
+// Schema validation, not coercion: supplied non-string fields must be rejected.
+function isOptionalCompactionString(value: unknown): boolean {
+  return value === undefined || typeof value === "string";
+}
+
+function isBoundedJson(value: unknown, depth = 0): boolean {
+  // Optional provider metadata reaches recursive transcript redaction. Bound
+  // its nesting as well as bytes before retaining an otherwise valid window.
+  if (depth > 64) {
+    return false;
+  }
+  if (value === null || typeof value === "string" || typeof value === "boolean") {
+    return true;
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value);
+  }
+  return (
+    (Array.isArray(value) || isRecord(value)) &&
+    Object.values(value).every((child) => isBoundedJson(child, depth + 1))
+  );
+}
+
+function isInputContent(value: unknown): boolean {
+  if (!isRecord(value)) {
+    return false;
+  }
+  const breakpoint = value.prompt_cache_breakpoint;
+  if (breakpoint !== undefined && (!isRecord(breakpoint) || breakpoint.mode !== "explicit")) {
+    return false;
+  }
+  switch (value.type) {
+    case "input_text":
+      return typeof value.text === "string";
+    case "input_image":
+      return (
+        typeof value.detail === "string" &&
+        ["auto", "low", "high", "original"].includes(value.detail) &&
+        (typeof value.image_url === "string" || typeof value.file_id === "string") &&
+        (value.image_url === null || isOptionalCompactionString(value.image_url)) &&
+        (value.file_id === null || isOptionalCompactionString(value.file_id))
+      );
+    case "input_file":
+      return (
+        (value.detail === undefined ||
+          (typeof value.detail === "string" && ["auto", "low", "high"].includes(value.detail))) &&
+        [value.file_data, value.file_id, value.file_url].some(
+          (entry) => typeof entry === "string",
+        ) &&
+        isOptionalCompactionString(value.file_data) &&
+        (value.file_id === null || isOptionalCompactionString(value.file_id)) &&
+        isOptionalCompactionString(value.file_url) &&
+        isOptionalCompactionString(value.filename)
+      );
+    default:
+      return false;
+  }
+}
+
+/** Validate without projecting: accepted provider fields must survive replay unchanged. */
+export function isOpenAIResponsesCompactionOutput(
+  value: unknown,
+  model?: Model,
+): value is OpenAIResponsesCompactionOutput {
+  if (!Array.isArray(value) || value.length === 0 || !isBoundedJson(value)) {
+    return false;
+  }
+  const item: unknown = value.at(-1);
+  const valid =
+    isRecord(item) &&
+    item.type === "compaction" &&
+    typeof item.encrypted_content === "string" &&
+    item.encrypted_content.length > 0 &&
+    isOptionalCompactionString(item.id) &&
+    isOptionalCompactionString(item.created_by) &&
+    value
+      .slice(0, -1)
+      .every(
+        (message: unknown) =>
+          isRecord(message) &&
+          message.type === "message" &&
+          typeof message.role === "string" &&
+          ["user", "developer", "system"].includes(message.role) &&
+          isOptionalCompactionString(message.id) &&
+          (message.status === undefined ||
+            (typeof message.status === "string" &&
+              ["in_progress", "completed", "incomplete"].includes(message.status))) &&
+          Array.isArray(message.content) &&
+          message.content.every(isInputContent),
+      );
+  // Storage accepts some image formats that Responses egress would replace.
+  // A canonical window must survive that existing policy without any rewrite.
+  if (!valid) {
+    return false;
+  }
+  const payload = sanitizeResponsesImagePayload({ input: value });
+  if (model) {
+    applyOpenAIResponsesPayloadPolicy(payload, resolveOpenAIResponsesPayloadPolicy(model));
+  }
+  return JSON.stringify(payload.input) === JSON.stringify(value);
+}
+
+/** Read the saved canonical window only when it still matches its opaque checkpoint. */
+export function readOpenAIResponsesCompactionWindow(
+  replay: {
+    data: string;
+    id?: string;
+    compactedWindow?: unknown;
+  },
+  model?: Model,
+): OpenAIResponsesCompactionOutput | undefined {
+  const window = replay.compactedWindow;
+  if (!isRecord(window) || window.state !== "ready" || typeof window.output !== "string") {
+    return undefined;
+  }
+  if (
+    Buffer.byteLength(window.output, "utf8") + Buffer.byteLength(replay.data, "utf8") >
+    COMPACTION_WINDOW_MAX_BYTES
+  ) {
+    return undefined;
+  }
+  try {
+    if (Buffer.byteLength(JSON.stringify(replay), "utf8") > COMPACTION_WINDOW_MAX_BYTES) {
+      return undefined;
+    }
+    const output: unknown = JSON.parse(window.output);
+    if (!isOpenAIResponsesCompactionOutput(output, model)) {
+      return undefined;
+    }
+    const item = output.at(-1);
+    return item?.type === "compaction" &&
+      item.encrypted_content === replay.data &&
+      item.id === replay.id
+      ? output
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Bound the success body before SDK JSON parsing can allocate an unlimited response. */
+export async function readOpenAIResponsesCompactionResponse(response: Response): Promise<unknown> {
+  if (!response.body) {
+    throw new Error("Responses compact endpoint returned an empty body");
+  }
+  const reader = response.body.getReader();
+  const guard = createSseByteGuard(reader, {
+    maxBytes: COMPACTION_WINDOW_MAX_BYTES,
+    onOverflow: () => new Error("Responses compact endpoint response exceeds 16 MiB"),
+  });
+  const decoder = new TextDecoder();
+  let body = "";
+  try {
+    while (true) {
+      const chunk = await guard.read();
+      if (chunk.done) {
+        break;
+      }
+      body += decoder.decode(chunk.value, { stream: true });
+    }
+    return JSON.parse(body + decoder.decode()) as unknown;
+  } finally {
+    await guard.cancel();
+    reader.releaseLock();
+  }
+}

--- a/packages/ai/src/transports/openai-responses-contracts.ts
+++ b/packages/ai/src/transports/openai-responses-contracts.ts
@@ -17,6 +17,7 @@ import type {
   OpenAIApiReasoningEffort,
   OpenAIReasoningEffort,
 } from "../providers/openai-reasoning-effort.js";
+import type { OpenAIResponsesCompactedWindow } from "./openai-responses-compaction-window.js";
 
 export const DEFAULT_AZURE_OPENAI_API_VERSION = "preview";
 export const OPENAI_CODEX_RESPONSES_EMPTY_INPUT_TEXT = " ";
@@ -127,8 +128,9 @@ export type ReplayableResponseReasoningItem = Omit<ResponseReasoningItem, "id"> 
   id?: string;
   [OPENAI_RESPONSES_REASONING_REPLAY_META_KEY]?: OpenAIResponsesReasoningReplayMetadata;
 };
-export type OpenAIResponsesCompactionReplayState = ProviderReplayState &
-  (
+export type OpenAIResponsesCompactionReplayState = ProviderReplayState & {
+  compactedWindow?: OpenAIResponsesCompactedWindow;
+} & (
     | { type: typeof OPENAI_RESPONSES_COMPACTION_REPLAY_TYPE; baseUrlHash: string }
     | {
         type: typeof OPENAI_RESPONSES_RETAINED_COMPACTION_REPLAY_TYPE;

--- a/packages/ai/src/transports/openai-responses-replay-messages-internal.ts
+++ b/packages/ai/src/transports/openai-responses-replay-messages-internal.ts
@@ -296,9 +296,6 @@ function convertResponsesMessagesWithStyle(
           preserveUnframedToolResults: replayPlan.preserveUnframedToolResults,
         });
   const transformedMessages = transformMessages(replayPlan.messages);
-  const transformedRetainedMessages = replayPlan.retainedMessages
-    ? transformMessages(replayPlan.retainedMessages)
-    : [];
   const includeSystemPrompt = options?.includeSystemPrompt ?? true;
   if (includeSystemPrompt && context.systemPrompt) {
     messages.push(
@@ -319,8 +316,13 @@ function convertResponsesMessagesWithStyle(
       ),
     );
   }
+  // The compact endpoint's output is already canonical provider input, not
+  // internal user content to normalize or reinterpret as text/image blocks.
+  if (replayPlan.compactedWindow) {
+    messages.push(...replayPlan.compactedWindow);
+  }
   let replayMessages = replayPlan.compaction
-    ? [...transformedRetainedMessages, replayPlan.compaction, ...transformedMessages]
+    ? [replayPlan.compaction, ...transformedMessages]
     : transformedMessages;
   // Responses continuation requires the complete prior input before tool output.
   // Anchor context after the user or its compaction checkpoint, not each tool round.
@@ -334,7 +336,8 @@ function convertResponsesMessagesWithStyle(
       stableMessages.findLastIndex((message) =>
         "role" in message ? message.role === "user" : message.type === "compaction",
       ) + 1;
-    if (insertionIndex > 0) {
+    // A canonical window is already emitted above; its checkpoint anchors an otherwise userless tail.
+    if (insertionIndex > 0 || replayPlan.compactedWindow) {
       replayMessages = [
         ...stableMessages.slice(0, insertionIndex),
         ...carriers,

--- a/packages/ai/src/transports/openai-responses-retained-compaction-replay.test.ts
+++ b/packages/ai/src/transports/openai-responses-retained-compaction-replay.test.ts
@@ -2,9 +2,17 @@ import type { AssistantMessage, Context, Model, ProviderReplayState } from "@ope
 import { describe, expect, it } from "vitest";
 import { convertResponsesMessages as convertProviderResponsesMessages } from "../providers/openai-responses-shared.js";
 import {
+  buildOpenAIResponsesCompactionReplayPlan,
   buildOpenAIResponsesReasoningReplayMetadata,
+  captureOpenAIResponsesCompaction,
+  CompactionReplayRefreshRequiredError,
   type OpenAIResponsesReplayMode,
 } from "./openai-responses-compaction-replay.js";
+import {
+  isOpenAIResponsesCompactionOutput,
+  readOpenAIResponsesCompactionWindow,
+  type OpenAIResponsesCompactionOutput,
+} from "./openai-responses-compaction-window.js";
 import { resolveResponsesContinuationRequest } from "./openai-responses-continuation.js";
 import { convertResponsesMessages } from "./openai-responses-replay-internal.js";
 
@@ -21,6 +29,7 @@ const model = {
   maxTokens: 8192,
 } satisfies Model<"openai-responses">;
 const replayIdentity = { sessionId: "session-a", authProfileId: "profile-a" };
+const COMPACTION_WINDOW_MAX_BYTES = 16 * 1024 * 1024;
 
 function createAssistant(
   content: string | AssistantMessage["content"],
@@ -88,8 +97,47 @@ const converters = [
 ] as const;
 
 describe("Responses retained-user compaction replay", () => {
-  it.each(converters)("$name retains user messages before the checkpoint", ({ convert }) => {
-    const input = convert({
+  it.each(converters)(
+    "$name replays the complete saved provider window verbatim",
+    ({ convert }) => {
+      const output = [
+        {
+          type: "message",
+          role: "developer",
+          content: [{ type: "input_text", text: "saved instructions" }],
+        },
+        {
+          type: "message",
+          role: "user",
+          id: "msg_saved",
+          content: [{ type: "input_text", text: "canonical retained user" }],
+        },
+        {
+          type: "compaction",
+          id: "cmp_retained",
+          encrypted_content: "opaque-retained",
+          created_by: "compactor",
+        },
+      ];
+      const replay = {
+        ...compactionState("openai-responses-retained-compaction"),
+        compactedWindow: { state: "ready", output: JSON.stringify(output) },
+      };
+      const input = convert({
+        messages: [
+          { role: "user", content: "not the returned provider window", timestamp: 1 },
+          createAssistant("covered owner text", replay),
+          { role: "user", content: "new turn", timestamp: 2 },
+        ],
+      });
+      expect(input.slice(0, output.length)).toEqual(output);
+      expect(JSON.stringify(input)).not.toContain("not the returned provider window");
+      expect(JSON.stringify(input)).not.toContain("covered owner text");
+    },
+  );
+
+  it.each(converters)("$name requires rebuilding legacy retained-user state", ({ convert }) => {
+    const context: Context = {
       systemPrompt: "current system instructions",
       messages: [
         { role: "user", content: "user absorbed by older checkpoint", timestamp: 0 },
@@ -103,19 +151,55 @@ describe("Responses retained-user compaction replay", () => {
         ),
         { role: "user", content: "new user after compaction", timestamp: 3 },
       ],
-    });
+    };
+    expect(() => convert(context)).toThrow(CompactionReplayRefreshRequiredError);
+    expect(
+      buildOpenAIResponsesCompactionReplayPlan(context.messages, model, {
+        ...replayIdentity,
+        mode: "full-history",
+      }).messages,
+    ).toBe(context.messages);
+  });
 
-    expect(input.slice(0, 4)).toMatchObject([
-      { role: "developer" },
-      { role: "user", content: [{ text: "first retained user" }] },
-      { role: "user", content: [{ text: "second retained user" }] },
-      { type: "compaction", encrypted_content: "opaque-retained" },
-    ]);
-    const encoded = JSON.stringify(input);
-    expect(encoded).toContain("new user after compaction");
-    expect(encoded).not.toContain("user absorbed by older checkpoint");
-    expect(encoded).not.toContain("discarded assistant");
-    expect(encoded).not.toContain("assistant content absorbed by compaction");
+  it("captures and replays SDK media and optional metadata without conversion", () => {
+    const output = [
+      {
+        type: "message",
+        role: "user",
+        status: "completed",
+        content: [
+          { type: "input_text", text: "saved", prompt_cache_breakpoint: { mode: "explicit" } },
+          { type: "input_image", detail: "original", image_url: "https://media.example/image.png" },
+          { type: "input_image", detail: "auto", file_id: "file_image", image_url: null },
+          { type: "input_file", file_id: "file_pdf", filename: "source.pdf", detail: "high" },
+        ],
+      },
+      {
+        type: "compaction",
+        id: "cmp_retained",
+        encrypted_content: "opaque-retained",
+        created_by: "compactor",
+      },
+    ] satisfies OpenAIResponsesCompactionOutput;
+    const owner = createAssistant("covered text");
+    const item = output.at(-1);
+    if (item?.type !== "compaction") {
+      throw new Error("missing test compaction");
+    }
+    captureOpenAIResponsesCompaction(
+      owner,
+      item,
+      "retained-users",
+      model,
+      buildOpenAIResponsesReasoningReplayMetadata(model, replayIdentity),
+      output,
+    );
+    // oxlint-disable-next-line unicorn/prefer-structured-clone -- Exercise persisted JSON reload, not an in-memory clone.
+    const saved: AssistantMessage = JSON.parse(JSON.stringify(owner));
+    expect(saved.providerReplay).not.toHaveProperty("replayIndex");
+    expect(
+      convertResponsesMessages(model, { messages: [saved] }, new Set(["openai"]), replayIdentity),
+    ).toEqual(output);
   });
 
   it.each(
@@ -135,14 +219,33 @@ describe("Responses retained-user compaction replay", () => {
   )(
     "$name preserves the compacted prefix and current context across tool rounds ($scenario)",
     ({ convert, scenario, retainedUsers, fullHistory, laterUser }) => {
+      const owner = createAssistant([], compactionState("openai-responses-compaction"));
+      if (retainedUsers) {
+        const item = {
+          type: "compaction" as const,
+          id: "cmp_retained",
+          encrypted_content: "opaque-retained",
+          created_by: "compactor",
+        };
+        captureOpenAIResponsesCompaction(
+          owner,
+          item,
+          "retained-users",
+          model,
+          buildOpenAIResponsesReasoningReplayMetadata(model, replayIdentity),
+          [
+            {
+              type: "message",
+              role: "user",
+              content: [{ type: "input_text", text: "active request before compaction" }],
+            },
+            item,
+          ],
+        );
+      }
       const messages: Context["messages"] = [
         { role: "user", content: "active request before compaction", timestamp: 1 },
-        createAssistant(
-          [],
-          compactionState(
-            retainedUsers ? "openai-responses-retained-compaction" : "openai-responses-compaction",
-          ),
-        ),
+        owner,
       ];
       if (laterUser) {
         messages.push({ role: "user", content: "new request after compaction", timestamp: 2 });
@@ -202,6 +305,149 @@ describe("Responses retained-user compaction replay", () => {
         ]);
         input = nextInput;
       }
+    },
+  );
+
+  it.each([
+    { state: "refresh-required" },
+    { state: "ready", output: "not JSON" },
+    {
+      state: "ready",
+      output: JSON.stringify([{ type: "compaction", encrypted_content: "wrong" }]),
+    },
+  ])("does not fall back past an invalid complete window: %j", (compactedWindow) => {
+    const replay = {
+      ...compactionState("openai-responses-retained-compaction"),
+      compactedWindow,
+    };
+    const owner = createAssistant("covered", replay);
+    expect(() =>
+      buildOpenAIResponsesCompactionReplayPlan(
+        [createAssistant("old", compactionState("openai-responses-compaction")), owner],
+        model,
+        replayIdentity,
+      ),
+    ).toThrow(CompactionReplayRefreshRequiredError);
+  });
+
+  it("rejects invalid depth before capture and counts duplicated opaque bytes in the envelope", () => {
+    let metadata: unknown = "nested";
+    for (let index = 0; index < 65; index += 1) {
+      metadata = { child: metadata };
+    }
+    expect(
+      isOpenAIResponsesCompactionOutput([
+        { type: "compaction", encrypted_content: "opaque", metadata },
+      ]),
+    ).toBe(false);
+    const owner = createAssistant("unchanged", compactionState("openai-responses-compaction"));
+    const previous = owner.providerReplay;
+    const item = {
+      type: "compaction" as const,
+      encrypted_content: "a".repeat(COMPACTION_WINDOW_MAX_BYTES / 2),
+    };
+    expect(() =>
+      captureOpenAIResponsesCompaction(
+        owner,
+        item,
+        1,
+        model,
+        buildOpenAIResponsesReasoningReplayMetadata(model, replayIdentity),
+        [item],
+      ),
+    ).toThrow("exceeds 16 MiB");
+    expect(owner.providerReplay).toBe(previous);
+    expect(
+      readOpenAIResponsesCompactionWindow({
+        data: item.encrypted_content,
+        compactedWindow: { state: "ready", output: " ".repeat(COMPACTION_WINDOW_MAX_BYTES + 1) },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("refuses capture and persisted windows that the current route would mutate", () => {
+    const route = { ...model, provider: "xai", baseUrl: "https://api.x.ai/v1" };
+    const item = {
+      type: "compaction" as const,
+      id: "cmp_route",
+      encrypted_content: "opaque",
+      status: "completed",
+    };
+    const owner = createAssistant("covered");
+    const metadata = buildOpenAIResponsesReasoningReplayMetadata(route, replayIdentity);
+    expect(() => captureOpenAIResponsesCompaction(owner, item, 1, route, metadata, [item])).toThrow(
+      "checkpoint is invalid",
+    );
+    expect(owner.providerReplay).toBeUndefined();
+    const replay = {
+      type: "openai-responses-compaction",
+      id: item.id,
+      data: item.encrypted_content,
+      replayIndex: 1,
+      ...metadata,
+      compactedWindow: { state: "ready", output: JSON.stringify([item]) },
+    };
+    const savedOwner = createAssistant("covered", replay);
+    expect(() =>
+      buildOpenAIResponsesCompactionReplayPlan([savedOwner], route, replayIdentity),
+    ).toThrow(CompactionReplayRefreshRequiredError);
+    // The same SDK metadata is valid on the native route that retains it.
+    captureOpenAIResponsesCompaction(
+      owner,
+      item,
+      1,
+      model,
+      buildOpenAIResponsesReasoningReplayMetadata(model, replayIdentity),
+      [item],
+    );
+    expect(
+      buildOpenAIResponsesCompactionReplayPlan([owner], model, replayIdentity).compactedWindow,
+    ).toEqual([item]);
+  });
+
+  it.each(["duplicated opaque", "escaped plaintext"])(
+    "keeps imported %s over the envelope limit as a refresh barrier",
+    (kind) => {
+      const data = kind === "duplicated opaque" ? "a".repeat(9 * 1024 * 1024) : "opaque-retained";
+      const output = JSON.stringify([
+        ...(kind === "escaped plaintext"
+          ? [
+              {
+                type: "message",
+                role: "user",
+                content: [{ type: "input_text", text: '"'.repeat(5 * 1024 * 1024) }],
+              },
+            ]
+          : []),
+        { type: "compaction", id: "cmp_retained", encrypted_content: data },
+      ]);
+      const replay = {
+        ...compactionState("openai-responses-retained-compaction"),
+        data,
+        compactedWindow: { state: "ready", output },
+      };
+      expect(Buffer.byteLength(data)).toBeLessThan(COMPACTION_WINDOW_MAX_BYTES);
+      expect(Buffer.byteLength(output)).toBeLessThan(COMPACTION_WINDOW_MAX_BYTES);
+      if (kind === "escaped plaintext") {
+        expect(Buffer.byteLength(data) + Buffer.byteLength(output)).toBeLessThan(
+          COMPACTION_WINDOW_MAX_BYTES,
+        );
+      }
+      expect(Buffer.byteLength(JSON.stringify(replay))).toBeGreaterThan(
+        COMPACTION_WINDOW_MAX_BYTES,
+      );
+      const accepted = readOpenAIResponsesCompactionWindow(replay, model) !== undefined;
+      expect(accepted).toBe(false);
+      expect(() =>
+        buildOpenAIResponsesCompactionReplayPlan(
+          [
+            createAssistant("older", compactionState("openai-responses-compaction")),
+            createAssistant("oversized import", replay),
+          ],
+          model,
+          replayIdentity,
+        ),
+      ).toThrow(CompactionReplayRefreshRequiredError);
     },
   );
 });

--- a/packages/ai/src/transports/provider-compaction-replay.test.ts
+++ b/packages/ai/src/transports/provider-compaction-replay.test.ts
@@ -1,8 +1,24 @@
-import type { AssistantMessage, Model, ProviderReplayState } from "@openclaw/llm-core";
+import type { AssistantMessage, Context, Model, ProviderReplayState } from "@openclaw/llm-core";
 import { describe, expect, it } from "vitest";
-import { buildOpenAIResponsesReasoningReplayMetadata } from "./openai-responses-compaction-replay.js";
+import {
+  createCompactionCapture,
+  buildAnthropicReplayPlan,
+} from "./anthropic-compaction-replay.js";
+import {
+  buildOpenAIResponsesReasoningReplayMetadata,
+  captureOpenAIResponsesCompaction,
+  suppressOpenAIResponsesCompaction,
+} from "./openai-responses-compaction-replay.js";
+import type { OpenAIResponsesCompactionOutput } from "./openai-responses-compaction-window.js";
 import { convertResponsesMessages } from "./openai-responses-replay-internal.js";
-import { replaceCompactionReplayOwnerContent } from "./provider-compaction-replay.js";
+import {
+  CompactionReplayRefreshRequiredError,
+  preserveCompactionReplayWindow,
+  replaceCompactionReplayOwnerContent,
+  requiresCompactionReplayRefresh,
+  resolveCompactionReplayEligibility,
+  resolveCompactionReplayPressure,
+} from "./provider-compaction-replay.js";
 
 const model = {
   id: "gpt-5.6-luna",
@@ -136,5 +152,354 @@ describe("compaction replay owner rewrites", () => {
       data: "opaque-replay-compaction",
     });
     expect(rewritten.providerReplay).not.toHaveProperty("replayIndex");
+  });
+});
+
+describe("bounded compaction replay projection", () => {
+  const latest: Context["messages"][number] = { role: "user", content: "latest", timestamp: 10 };
+
+  it("projects only the newest evicted owner without old content or source mutation", () => {
+    const prelude = { role: "user" as const, content: "covered history prelude", timestamp: 0 };
+    const old = createAssistant([{ type: "text", text: "older owner" }], 1);
+    captureOpenAIResponsesCompaction(
+      old,
+      { type: "compaction", encrypted_content: "older opaque state" },
+      1,
+      model,
+      buildOpenAIResponsesReasoningReplayMetadata(model, replayIdentity),
+    );
+    const newest = createAssistant([{ type: "text", text: "covered owner" }], 1);
+    const replay = newest.providerReplay;
+    const source = [prelude, old, newest, latest];
+    const projected = preserveCompactionReplayWindow(
+      source,
+      [prelude, latest],
+      model,
+      replayIdentity,
+    );
+    expect(projected[0]).toMatchObject({ content: [], providerReplay: { replayIndex: 0 } });
+    expect(newest.providerReplay).toBe(replay);
+    expect(newest.providerReplay?.replayIndex).toBe(1);
+    expect(newest.content).toEqual([{ type: "text", text: "covered owner" }]);
+    expect(preserveCompactionReplayWindow(projected, projected, model, replayIdentity)).toBe(
+      projected,
+    );
+    const input = convertResponsesMessages(
+      model,
+      { messages: projected },
+      new Set(["openai"]),
+      replayIdentity,
+    );
+    expect(input[0]).toMatchObject({
+      type: "compaction",
+      encrypted_content: "opaque-replay-compaction",
+    });
+    const pressure = resolveCompactionReplayPressure(projected, model, replayIdentity, estimator);
+    expect({
+      wireContainsCoveredPrelude: JSON.stringify(input).includes(prelude.content),
+      pressureContainsCoveredPrelude: JSON.stringify(pressure?.messages).includes(prelude.content),
+    }).toEqual({ wireContainsCoveredPrelude: false, pressureContainsCoveredPrelude: false });
+    expect(pressure?.prefixTokens).toBe("opaque-replay-compaction".length);
+    expect(projected).toHaveLength(2);
+    expect(JSON.stringify(input)).not.toContain("owner");
+  });
+
+  it("does not project when the owner is retained, even after earlier source entries", () => {
+    const owner = createAssistant([{ type: "text", text: "covered" }], 1);
+    const source = [latest, owner];
+    expect(preserveCompactionReplayWindow(source, source, model, replayIdentity)).toBe(source);
+    expect(preserveCompactionReplayWindow(source, [owner], model, replayIdentity)).toEqual([owner]);
+  });
+
+  it.each([
+    "azure-openai-responses",
+    "openai-chatgpt-responses",
+    "openclaw-openai-responses-transport",
+  ])("preserves checkpoints on the %s Responses API route", (api) => {
+    const route = { ...model, api };
+    const owner = createAssistant([{ type: "text", text: "covered" }], 1);
+    captureOpenAIResponsesCompaction(
+      owner,
+      { type: "compaction", encrypted_content: "route checkpoint" },
+      1,
+      route,
+      buildOpenAIResponsesReasoningReplayMetadata(route, replayIdentity),
+    );
+    const projected = preserveCompactionReplayWindow(
+      [owner, latest],
+      [latest],
+      route,
+      replayIdentity,
+    );
+    expect(
+      convertResponsesMessages(
+        route,
+        { messages: projected },
+        new Set(["openai"]),
+        replayIdentity,
+      )[0],
+    ).toMatchObject({ type: "compaction", encrypted_content: "route checkpoint" });
+    expect(
+      resolveCompactionReplayPressure(projected, route, replayIdentity, estimator)?.prefixTokens,
+    ).toBe("route checkpoint".length);
+  });
+
+  it.each(["malformed", "mismatched", "suppressed"])("honors the newest %s barrier", (kind) => {
+    const old = createAssistant([], 0);
+    const barrier = createAssistant([], 0);
+    if (!barrier.providerReplay) {
+      throw new Error("missing replay state");
+    }
+    if (kind === "malformed") {
+      barrier.providerReplay = { ...barrier.providerReplay, data: "" };
+    } else if (kind === "mismatched") {
+      barrier.providerReplay = { ...barrier.providerReplay, model: "different-model" };
+    } else {
+      suppressOpenAIResponsesCompaction(barrier, model, replayIdentity);
+    }
+    const windowed = [latest];
+    expect(
+      preserveCompactionReplayWindow([old, barrier, latest], windowed, model, replayIdentity),
+    ).toBe(windowed);
+    expect(
+      resolveCompactionReplayPressure([old, barrier, latest], model, replayIdentity, estimator),
+    ).toBeUndefined();
+  });
+
+  it("keeps missing retained-user windows as refresh barriers without an invented index", () => {
+    const owner = createAssistant([], 0);
+    if (!owner.providerReplay) {
+      throw new Error("missing replay state");
+    }
+    const { replayIndex: _index, ...replay } = owner.providerReplay;
+    owner.providerReplay = { ...replay, type: "openai-responses-retained-compaction" };
+    const projected = preserveCompactionReplayWindow(
+      [owner, latest],
+      [latest],
+      model,
+      replayIdentity,
+    );
+    expect(projected[0]).toMatchObject({
+      providerReplay: { type: "openai-responses-retained-compaction" },
+    });
+    expect(projected[0]).not.toHaveProperty("providerReplay.replayIndex");
+    expect(requiresCompactionReplayRefresh(projected, model, replayIdentity)).toBe(true);
+    expect(() =>
+      resolveCompactionReplayPressure(projected, model, replayIdentity, estimator),
+    ).toThrow(CompactionReplayRefreshRequiredError);
+  });
+
+  it.each(["anthropic-messages", "openclaw-anthropic-messages-transport"])(
+    "projects %s summaries through their own replay owner",
+    (api) => {
+      const anthropic = {
+        ...model,
+        api,
+        provider: "anthropic",
+        id: "claude-sonnet-4-6",
+        baseUrl: "https://api.anthropic.com/v1",
+      } satisfies Model;
+      const owner = createAssistant([{ type: "text", text: "covered" }], 1);
+      const capture = createCompactionCapture(owner, anthropic, replayIdentity);
+      capture.begin(0, { type: "compaction", content: "complete summary" }, 1);
+      capture.complete(0);
+      const projected = preserveCompactionReplayWindow([owner, latest], [latest], anthropic, {
+        ...replayIdentity,
+        enabled: true,
+      });
+      expect(
+        buildAnthropicReplayPlan(projected, anthropic, { ...replayIdentity, enabled: true })
+          .compaction,
+      ).toEqual({ type: "compaction", content: "complete summary" });
+      expect(
+        resolveCompactionReplayPressure(
+          projected,
+          anthropic,
+          { ...replayIdentity, enabled: true },
+          estimator,
+        )?.prefixTokens,
+      ).toBe("complete summary".length);
+    },
+  );
+
+  it.each([false, undefined])(
+    "does not use Anthropic checkpoints without enabled replay: %s",
+    (enabled) => {
+      const anthropic = {
+        ...model,
+        api: "anthropic-messages",
+        provider: "anthropic",
+        id: "claude-sonnet-4-6",
+      };
+      const owner = createAssistant([{ type: "text", text: "covered" }], 1);
+      const capture = createCompactionCapture(owner, anthropic, replayIdentity);
+      capture.begin(0, { type: "compaction", content: "complete summary" }, 1);
+      capture.complete(0);
+      const identity = { ...replayIdentity, enabled };
+      const window = [latest];
+      expect(preserveCompactionReplayWindow([owner, latest], window, anthropic, identity)).toBe(
+        window,
+      );
+      expect(
+        resolveCompactionReplayPressure([owner, latest], anthropic, identity, estimator),
+      ).toBeUndefined();
+    },
+  );
+});
+
+const estimator = {
+  text: (value: string) => value.length,
+  image: () => 100,
+  json: (value: unknown) => JSON.stringify(value).length,
+};
+
+describe("prepared compaction replay eligibility", () => {
+  const anthropic = {
+    ...model,
+    api: "anthropic-messages",
+    provider: "anthropic",
+    id: "claude-sonnet-4-6",
+  };
+
+  it.each([
+    { apiKey: undefined, extraParams: { anthropicServerCompaction: true }, expected: false },
+    { apiKey: "test-key", extraParams: {}, expected: false },
+    { apiKey: "test-key", extraParams: { anthropicServerCompaction: true }, expected: true },
+    {
+      apiKey: "test-sk-ant-oat-fixture",
+      extraParams: { anthropicServerCompaction: true },
+      expected: false,
+    },
+  ])("requires known eligible authentication and opt-in: $expected", ({ expected, ...options }) => {
+    expect(resolveCompactionReplayEligibility(anthropic, options)).toBe(expected);
+  });
+
+  it("keeps Responses checkpoint replay independent of new compaction generation", () => {
+    expect(
+      resolveCompactionReplayEligibility(model, {
+        extraParams: { responsesServerCompaction: false },
+      }),
+    ).toBe(true);
+    const owner = createAssistant([], 0);
+    expect(
+      resolveCompactionReplayPressure(
+        [owner],
+        model,
+        { ...replayIdentity, enabled: false },
+        estimator,
+      ),
+    ).toBeUndefined();
+  });
+});
+
+describe("canonical compaction replay pressure", () => {
+  it.each([
+    { provider: "other-provider" },
+    { api: "openai-completions" },
+    { model: "other-model" },
+  ])("does not trust later usage from a different route: %j", (route) => {
+    const owner = createAssistant([], 0);
+    const later = { ...createAssistant([{ type: "text", text: "later" }], 0), ...route };
+    delete later.providerReplay;
+    later.usage.contextUsage = { state: "available", promptTokens: 100, totalTokens: 101 };
+    later.usage.totalTokens = 101;
+    const plan = resolveCompactionReplayPressure([owner, later], model, replayIdentity, estimator);
+    expect(plan?.messages[1]).not.toHaveProperty("usage.contextUsage");
+    expect(plan?.messages[1]).toMatchObject({
+      content: later.content,
+      usage: { totalTokens: 101, cost: later.usage.cost },
+    });
+    expect(later.usage.contextUsage.totalTokens).toBe(101);
+  });
+
+  it("counts the returned prefix once after restart and an auth A to B to A round trip", () => {
+    const owner = createAssistant([{ type: "text", text: "covered" }], 1);
+    const output = [
+      { type: "message", role: "user", content: [{ type: "input_text", text: "canonical" }] },
+      { type: "compaction", encrypted_content: "opaque" },
+    ] satisfies OpenAIResponsesCompactionOutput;
+    captureOpenAIResponsesCompaction(
+      owner,
+      { type: "compaction", encrypted_content: "opaque" },
+      "retained-users",
+      model,
+      buildOpenAIResponsesReasoningReplayMetadata(model, replayIdentity),
+      output,
+    );
+    const later = createAssistant([{ type: "text", text: "later" }], 0);
+    delete later.providerReplay;
+    owner.usage.contextUsage = { state: "available", promptTokens: 90_000, totalTokens: 90_001 };
+    later.usage.contextUsage = { state: "available", promptTokens: 2_000, totalTokens: 2_001 };
+    const source: Context["messages"] = [
+      { role: "user", content: "raw".repeat(100_000), timestamp: 1 },
+      owner,
+    ];
+    const requestB = convertResponsesMessages(model, { messages: source }, new Set(["openai"]), {
+      ...replayIdentity,
+      authProfileId: "profile-b",
+    });
+    expect(requestB.some((item) => item.type === "compaction")).toBe(false);
+    // oxlint-disable-next-line unicorn/prefer-structured-clone -- Exercise persisted JSON reload, not an in-memory clone.
+    const resumed: Context["messages"] = JSON.parse(JSON.stringify([...source, later]));
+    const requestA = convertResponsesMessages(
+      model,
+      { messages: resumed },
+      new Set(["openai"]),
+      replayIdentity,
+    );
+    expect(requestA.slice(0, output.length)).toEqual(output);
+    const plan = resolveCompactionReplayPressure(resumed, model, replayIdentity, estimator);
+    expect(plan?.prefixTokens).toBe(
+      "canonical".length +
+        "opaque".length +
+        estimator.json({ type: "message", role: "user" }) +
+        estimator.json({ type: "input_text" }) +
+        estimator.json({ type: "compaction" }),
+    );
+    expect(plan?.messages).toHaveLength(2);
+    expect(plan?.messages[0]).toMatchObject({ content: [] });
+    expect(plan?.messages[0]).not.toHaveProperty("usage.contextUsage");
+    expect(plan?.messages[1]).not.toHaveProperty("usage.contextUsage");
+    expect(plan?.messages[1]).toMatchObject({
+      content: later.content,
+      usage: { cost: later.usage.cost },
+    });
+    expect(owner.usage.contextUsage.totalTokens).toBe(90_001);
+    expect(later.usage.contextUsage.totalTokens).toBe(2_001);
+  });
+
+  it("accounts for image metadata and file data without charging base64 image bytes twice", () => {
+    const owner = createAssistant([], 0);
+    const image = {
+      type: "input_image" as const,
+      detail: "high" as const,
+      image_url:
+        "data:image/jpeg;base64," +
+        Buffer.concat([Buffer.from([0xff, 0xd8, 0xff]), Buffer.alloc(10_000)]).toString("base64"),
+    };
+    const remoteImage = { ...image, image_url: "https://media.example/image.png?signature=test" };
+    const file = { type: "input_file" as const, file_data: "file-data", filename: "source.txt" };
+    const output: OpenAIResponsesCompactionOutput = [
+      { type: "message", role: "user", content: [image, remoteImage, file] },
+      { type: "compaction", encrypted_content: "opaque" },
+    ];
+    captureOpenAIResponsesCompaction(
+      owner,
+      { type: "compaction", encrypted_content: "opaque" },
+      "retained-users",
+      model,
+      buildOpenAIResponsesReasoningReplayMetadata(model, replayIdentity),
+      output,
+    );
+    const plan = resolveCompactionReplayPressure([owner], model, replayIdentity, estimator);
+    expect(plan?.prefixTokens).toBe(
+      200 +
+        estimator.json({ type: "input_image", detail: "high" }) +
+        estimator.json(remoteImage) +
+        estimator.json(file) +
+        estimator.json({ type: "message", role: "user" }) +
+        estimator.json({ type: "compaction" }) +
+        "opaque".length,
+    );
   });
 });

--- a/packages/ai/src/transports/provider-compaction-replay.ts
+++ b/packages/ai/src/transports/provider-compaction-replay.ts
@@ -1,4 +1,185 @@
-import type { AssistantMessage, ProviderReplayState } from "@openclaw/llm-core";
+import type { AssistantMessage, Model, ProviderReplayState } from "@openclaw/llm-core";
+import { resolveNewestAnthropicCompaction } from "./anthropic-compaction-replay.js";
+import { resolveAnthropicServerCompactionPlan } from "./anthropic-payload-policy.js";
+import {
+  CompactionReplayRefreshRequiredError,
+  resolveNewestOpenAIResponsesCompactionReplay,
+} from "./openai-responses-compaction-replay.js";
+import { OPENAI_RESPONSES_APIS } from "./openai-responses-contracts.js";
+
+export { CompactionReplayRefreshRequiredError } from "./openai-responses-compaction-replay.js";
+
+type ReplayIdentity = { sessionId?: string; authProfileId?: string; enabled?: boolean };
+type ReplayMessage = { role: string };
+type ReplayPressureEstimator = {
+  text(value: string): number;
+  image(): number;
+  json(value: unknown): number;
+};
+
+function isAssistantReplayMessage<T extends ReplayMessage>(
+  message: T,
+): message is T & AssistantMessage {
+  return message.role === "assistant";
+}
+
+/** Resolve from prepared transport facts; never retain or return credential material. */
+export function resolveCompactionReplayEligibility(
+  model: Model,
+  options: { extraParams?: Record<string, unknown>; apiKey?: string },
+): boolean {
+  if (OPENAI_RESPONSES_APIS.has(model.api)) {
+    return true;
+  }
+  return (
+    Boolean(options.apiKey?.trim()) &&
+    resolveAnthropicServerCompactionPlan(model, options.extraParams, options.apiKey).enabled
+  );
+}
+
+function resolveCompactionSource<T extends ReplayMessage>(
+  messages: readonly T[],
+  model: Model,
+  identity: ReplayIdentity,
+) {
+  if (identity.enabled === false) {
+    return undefined;
+  }
+  const assistants = messages.filter(isAssistantReplayMessage);
+  const selected = (() => {
+    if (OPENAI_RESPONSES_APIS.has(model.api)) {
+      const responses = resolveNewestOpenAIResponsesCompactionReplay(assistants, model, identity);
+      return responses ? { family: "responses" as const, ...responses } : undefined;
+    }
+    if (identity.enabled !== true) {
+      return undefined;
+    }
+    const anthropic = resolveNewestAnthropicCompaction(assistants, model, identity);
+    return anthropic ? { family: "anthropic" as const, ...anthropic } : undefined;
+  })();
+  if (!selected) {
+    return undefined;
+  }
+  const owner = assistants.find((message) => message === selected.owner);
+  return owner ? { ...selected, owner } : undefined;
+}
+
+/** Manual recovery uses the durable client compactor, never a guessed retained-user prefix. */
+export function requiresCompactionReplayRefresh(
+  messages: readonly ReplayMessage[],
+  model: Model,
+  identity: ReplayIdentity,
+): boolean {
+  const checkpoint = resolveCompactionSource(messages, model, identity);
+  return checkpoint?.family === "responses" && checkpoint.mode === "refresh-required";
+}
+
+/** Carry a checkpoint immediately after reference-preserving history limiting, before repair. */
+export function preserveCompactionReplayWindow<T extends ReplayMessage>(
+  source: readonly T[],
+  windowed: T[],
+  model: Model,
+  identity: ReplayIdentity,
+): T[] {
+  const checkpoint = resolveCompactionSource(source, model, identity);
+  if (!checkpoint || windowed.some((message) => message === checkpoint.owner)) {
+    return windowed;
+  }
+  const owner = checkpoint.owner;
+  const replay = checkpoint.owner.providerReplay;
+  // Retained-user state has no content index, including its refresh-required barrier.
+  const providerReplay =
+    replay?.type === "openai-responses-retained-compaction"
+      ? replay
+      : { ...replay, replayIndex: 0 };
+  // The limiter can preserve a leading prelude that this checkpoint already
+  // covers. Only the original suffix may follow its projected owner.
+  const suffix = new Set(source.slice(source.indexOf(owner) + 1));
+  return [
+    { ...owner, content: [], providerReplay },
+    ...windowed.filter((message) => suffix.has(message)),
+  ];
+}
+
+function estimateResponsesWindow(
+  checkpoint: NonNullable<ReturnType<typeof resolveNewestOpenAIResponsesCompactionReplay>> & {
+    mode: "complete-window";
+  },
+  estimate: ReplayPressureEstimator,
+): number {
+  return checkpoint.output.reduce((tokens, entry) => {
+    if (entry.type === "compaction") {
+      const { encrypted_content, ...metadata } = entry;
+      return tokens + estimate.text(encrypted_content) + estimate.json(metadata);
+    }
+    const { content, ...metadata } = entry;
+    return (
+      tokens +
+      estimate.json(metadata) +
+      content.reduce((sum, block) => {
+        if (block.type === "input_text") {
+          const { text, ...fields } = block;
+          return sum + estimate.text(text) + estimate.json(fields);
+        }
+        if (block.type === "input_image") {
+          const { image_url: _imageUrl, ...fields } = block;
+          return (
+            sum +
+            estimate.image() +
+            estimate.json(block.image_url?.startsWith("data:") ? fields : block)
+          );
+        }
+        return sum + estimate.json(block);
+      }, 0)
+    );
+  }, 0);
+}
+
+/** Estimate the canonical prefix and its tail once, independent of unbound usage snapshots. */
+export function resolveCompactionReplayPressure<T extends ReplayMessage>(
+  messages: T[],
+  model: Model,
+  identity: ReplayIdentity,
+  estimate: ReplayPressureEstimator,
+): { messages: T[]; prefixTokens: number } | undefined {
+  const checkpoint = resolveCompactionSource(messages, model, identity);
+  if (!checkpoint) {
+    return undefined;
+  }
+  if (checkpoint.family === "responses" && checkpoint.mode === "refresh-required") {
+    throw new CompactionReplayRefreshRequiredError();
+  }
+  const ownerIndex = messages.findIndex((message) => message === checkpoint.owner);
+  const owner = messages[ownerIndex];
+  if (!owner) {
+    return undefined;
+  }
+  const prefixTokens =
+    checkpoint.family === "anthropic"
+      ? estimate.text(checkpoint.summary)
+      : checkpoint.mode === "complete-window"
+        ? estimateResponsesWindow(checkpoint, estimate)
+        : estimate.text(checkpoint.item.encrypted_content);
+  // Persisted usage does not identify the checkpoint sent with that request.
+  // Route/auth/config may have changed away and back; keep billing, not pressure authority.
+  const { contextUsage: _staleContextUsage, ...usage } = checkpoint.owner.usage;
+  const tail: T[] = [];
+  for (const message of messages.slice(ownerIndex + 1)) {
+    if (!isAssistantReplayMessage(message) || message.usage.contextUsage === undefined) {
+      tail.push(message);
+      continue;
+    }
+    const { contextUsage: _unboundContextUsage, ...billedUsage } = message.usage;
+    tail.push({ ...message, usage: billedUsage });
+  }
+  return {
+    messages: [
+      { ...owner, content: checkpoint.owner.content.slice(checkpoint.replayIndex), usage },
+      ...tail,
+    ],
+    prefixTokens,
+  };
+}
 
 /** Whether provider replay state is a prefix-bound server compaction checkpoint. */
 export function isCompactionReplayCheckpoint(replay: unknown): replay is ProviderReplayState {

--- a/packages/ai/src/transports/transport-utils.ts
+++ b/packages/ai/src/transports/transport-utils.ts
@@ -46,17 +46,13 @@ export function redactSensitiveText(text: string, _options?: unknown): string {
   return getAiTransportHost().redactToolPayloadText(text);
 }
 
-export function resolveSecretSentinel(value: string): string {
-  return getAiTransportHost().resolveSecretSentinel(value);
-}
-
 export function resolveModelHeaderSentinels<TModel extends Model>(model: TModel): TModel {
   if (!model.headers) {
     return model;
   }
   let headers: Record<string, string> | undefined;
   for (const [name, value] of Object.entries(model.headers)) {
-    const resolved = resolveSecretSentinel(value);
+    const resolved = getAiTransportHost().resolveSecretSentinel(value);
     if (resolved !== value) {
       headers ??= { ...model.headers };
       headers[name] = resolved;

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -78,6 +78,12 @@ export const sessionCompactImpl = vi.fn(async () => ({
   tokensBefore: 120,
   details: { ok: true },
 }));
+export const getHistoryLimitFromSessionKeyMock = vi.fn<
+  typeof import("./history.js").getHistoryLimitFromSessionKey
+>(() => undefined);
+export const limitHistoryTurnsMock = vi.fn<typeof import("./history.js").limitHistoryTurns>(
+  (messages) => messages.slice(0, 2),
+);
 export const sessionManualCompactionMock = vi.fn();
 export const sessionAutomaticCompactionMock = vi.fn();
 export const attemptServerEndpointCompactionMock: Mock<(_params?: unknown) => Promise<unknown>> =
@@ -212,7 +218,8 @@ function createMockToolDefinitions(tools: unknown[] = []) {
 export const createOpenClawCodingToolsMock = vi.fn<typeof createOpenClawCodingTools>(() => []);
 export const buildEmbeddedExtensionFactoriesMock = vi.fn(() => []);
 export const resolveEffectiveCompactionModeMock = vi.fn(() => "default");
-export const guardSessionManagerMock = vi.fn(() => ({
+export const guardSessionManagerMock = vi.fn((sessionManager: Record<string, unknown>) => ({
+  ...sessionManager,
   flushPendingToolResults: vi.fn(),
 }));
 export const applyAgentCompactionSettingsFromConfigMock = vi.fn();
@@ -654,9 +661,10 @@ export function resetCompactHooksHarnessMocks(workspaceDir: string): void {
   createOpenClawCodingToolsMock.mockReset();
   createOpenClawCodingToolsMock.mockReturnValue([]);
   guardSessionManagerMock.mockReset();
-  guardSessionManagerMock.mockReturnValue({
+  guardSessionManagerMock.mockImplementation((sessionManager) => ({
+    ...sessionManager,
     flushPendingToolResults: vi.fn(),
-  });
+  }));
   applyAgentCompactionSettingsFromConfigMock.mockReset();
   createPreparedEmbeddedAgentSettingsManagerMock.mockReset();
   createPreparedEmbeddedAgentSettingsManagerMock.mockReturnValue({
@@ -991,8 +999,8 @@ export async function loadCompactHooksHarness(): Promise<{
   }));
 
   vi.doMock("./history.js", () => ({
-    getHistoryLimitFromSessionKey: vi.fn(() => undefined),
-    limitHistoryTurns: vi.fn((msgs: unknown[]) => msgs.slice(0, 2)),
+    getHistoryLimitFromSessionKey: getHistoryLimitFromSessionKeyMock,
+    limitHistoryTurns: limitHistoryTurnsMock,
   }));
 
   vi.doMock("../../skills/runtime/env-overrides.js", () => ({

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -30,10 +30,12 @@ import {
   ensureAuthProfileStoreMock,
   estimateTokensMock,
   getApiKeyForModelMock,
+  getHistoryLimitFromSessionKeyMock,
   getMemorySearchManagerMock,
   guardSessionManagerMock,
   hookRunner,
   listRegisteredPluginAgentPromptGuidanceMock,
+  limitHistoryTurnsMock,
   loadCompactHooksHarness,
   maybeCompactAgentHarnessSessionMock,
   resolveAgentHarnessPolicyMock,
@@ -388,7 +390,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       ok: true,
       compacted: true,
       compactionKind: "server-endpoint",
-      result: { tokensBefore: 1_000, tokensAfter: 200 },
+      result: { tokensBefore: 1_000 },
     });
     expect(result.result).not.toHaveProperty("summary");
     expect(attemptServerEndpointCompactionMock).toHaveBeenCalledWith(
@@ -545,6 +547,59 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     expect(result).toMatchObject({ ok: true, compacted: true });
     expect(result.compactionKind).toBeUndefined();
     expect(sessionManualCompactionMock).toHaveBeenCalledOnce();
+  });
+
+  it("prepares the routed peer's account window for server-endpoint compaction", async () => {
+    const history = await vi.importActual<typeof import("./history.js")>("./history.js");
+    getHistoryLimitFromSessionKeyMock.mockImplementationOnce(history.getHistoryLimitFromSessionKey);
+    limitHistoryTurnsMock.mockImplementationOnce(history.limitHistoryTurns);
+    attemptServerEndpointCompactionMock.mockResolvedValueOnce({
+      item: { type: "compaction", encrypted_content: "opaque" },
+      usage: { input_tokens: 1_000, output_tokens: 200 },
+    });
+    const sessionKey = "agent:main:telegram:direct:direct:peer";
+    sessionMessages.splice(
+      0,
+      sessionMessages.length,
+      ...Array.from({ length: 6 }, (_, index) => ({
+        role: "user",
+        content: `turn-${index + 1}`,
+        timestamp: index + 1,
+      })),
+    );
+    await compactEmbeddedAgentSessionDirect(
+      wrappedCompactionArgs({
+        sessionKey,
+        sessionTarget: { ...wrappedCompactionArgs().sessionTarget, sessionKey },
+        agentAccountId: "direct",
+        conversationRoutePeerId: "123",
+        chatType: "direct",
+        config: {
+          session: { identityLinks: { "direct:peer": ["telegram:123"] } },
+          channels: {
+            telegram: {
+              dmHistoryLimit: 20,
+              accounts: {
+                direct: {
+                  dmHistoryLimit: 10,
+                  dms: { "direct:peer": { historyLimit: 2 }, peer: { historyLimit: 6 } },
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+    expect(attemptServerEndpointCompactionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          messages: [
+            { role: "user", content: "turn-5", timestamp: 5 },
+            { role: "user", content: "turn-6", timestamp: 6 },
+          ],
+        }),
+      }),
+    );
   });
 
   it("fails closed before generic compaction for a model-locked native session", async () => {

--- a/src/agents/embedded-agent-runner/compact.types.ts
+++ b/src/agents/embedded-agent-runner/compact.types.ts
@@ -38,6 +38,8 @@ export type CompactEmbeddedAgentSessionParams = {
   clientCaps?: string[];
   chatType?: ChatType;
   agentAccountId?: string;
+  /** Raw peer observed by the inbound routing owner, before identity linking. */
+  conversationRoutePeerId?: string;
   conversationToolPolicy?: GroupToolPolicyConfig;
   currentChannelId?: string;
   currentThreadTs?: string;

--- a/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
@@ -137,6 +137,7 @@ describe("buildEmbeddedCompactionRuntimeContext", () => {
       messageProvider: "slack",
       chatType: "channel",
       agentAccountId: "acct-1",
+      conversationRoutePeerId: "peer",
       currentChannelId: "C123",
       currentThreadTs: "thread-9",
       currentMessageId: "msg-42",
@@ -159,6 +160,7 @@ describe("buildEmbeddedCompactionRuntimeContext", () => {
     expect(result.messageProvider).toBe("slack");
     expect(result.chatType).toBe("channel");
     expect(result.agentAccountId).toBe("acct-1");
+    expect(result.conversationRoutePeerId).toBe("peer");
     expect(result.currentChannelId).toBe("C123");
     expect(result.currentThreadTs).toBe("thread-9");
     expect(result.currentMessageId).toBe("msg-42");

--- a/src/agents/embedded-agent-runner/compaction-runtime-context.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-context.ts
@@ -337,6 +337,7 @@ export function buildEmbeddedCompactionRuntimeContext(
     clientCaps: params.clientCaps,
     chatType: params.chatType ?? undefined,
     agentAccountId: params.agentAccountId ?? undefined,
+    conversationRoutePeerId: params.conversationRoutePeerId,
     currentChannelId: params.currentChannelId ?? undefined,
     currentThreadTs: params.currentThreadTs ?? undefined,
     currentMessageId: params.currentMessageId ?? undefined,

--- a/src/agents/embedded-agent-runner/compaction-session-execution.ts
+++ b/src/agents/embedded-agent-runner/compaction-session-execution.ts
@@ -2,6 +2,10 @@
  * Executes compaction while owning the transcript lock, session lifecycle,
  * hooks, checkpoint, and optional successor transcript rotation.
  */
+import {
+  preserveCompactionReplayWindow,
+  resolveCompactionReplayEligibility,
+} from "@openclaw/ai/transports";
 import { formatSqliteSessionFileMarker } from "../../config/sessions/legacy-sqlite-marker.js";
 import type { CapturedCompactionCheckpointSnapshot } from "../../gateway/session-compaction-checkpoints.js";
 import { resolveDiagnosticModelContentCapturePolicy } from "../../infra/diagnostic-llm-content.js";
@@ -62,6 +66,7 @@ import type { PreparedCompactionRuntime } from "./prepared-compaction-runtime.js
 import { sanitizeSessionHistory, validateReplayTurns } from "./replay-history.js";
 import { createEmbeddedAgentResourceLoader } from "./resource-loader.js";
 import { wrapStreamFnWithDiagnosticModelCallEvents } from "./run/attempt.model-diagnostic-events.js";
+import { estimateLlmBoundaryTokenPressure } from "./run/preemptive-compaction.js";
 import { attemptServerEndpointCompaction } from "./server-endpoint-compaction.js";
 import { applySystemPromptToSession } from "./system-prompt.js";
 import { collectRegisteredToolNames, toSessionToolAllowlist } from "./tool-name-allowlist.js";
@@ -279,6 +284,10 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
             senderUsername: params.senderUsername,
             senderE164: params.senderE164,
           });
+          const compactionReplayEnabled = resolveCompactionReplayEligibility(effectiveModel, {
+            extraParams: effectiveExtraParams,
+            apiKey: transportApiKey,
+          });
           diagnosticOwner = createDiagnosticEmbeddedRunOwner({
             sessionId: params.sessionId,
             ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
@@ -345,9 +354,22 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
           // "Original" compaction metrics should describe the validated transcript that enters
           // limiting/compaction, not the raw on-disk session snapshot.
           const originalMessages = session.messages.slice();
-          const truncated = limitHistoryTurns(
-            session.messages,
-            getHistoryLimitFromSessionKey(params.sessionKey, params.config),
+          const truncated = preserveCompactionReplayWindow(
+            originalMessages,
+            limitHistoryTurns(
+              session.messages,
+              getHistoryLimitFromSessionKey(params.sessionKey, params.config, {
+                accountId: params.agentAccountId,
+                peerId: params.conversationRoutePeerId,
+                chatType: params.chatType,
+              }),
+            ),
+            effectiveModel,
+            {
+              sessionId: params.sessionId,
+              authProfileId: runtimePlan.auth.forwardedAuthProfileId,
+              enabled: compactionReplayEnabled,
+            },
           );
           // Re-run tool_use/tool_result pairing repair after truncation, since
           // limitHistoryTurns can orphan tool_result blocks by removing the
@@ -420,6 +442,7 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
             sessionManager,
             extraParams: effectiveExtraParams,
             customInstructions: params.customInstructions,
+            config: params.config,
             requestOptions: {
               apiKey: transportApiKey,
               sessionId: params.sessionId,
@@ -449,15 +472,26 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
               );
           const effectiveFirstKeptEntryId = clientResult?.firstKeptEntryId;
           const tokensBefore = serverResult?.usage.input_tokens ?? clientResult!.tokensBefore;
-          // Estimate tokens after compaction by summing token estimates for remaining messages
-          const tokensAfter =
-            serverResult?.usage.output_tokens ??
-            estimateTokensAfterCompaction({
-              messagesAfter: session.messages,
-              observedTokenCount,
-              fullSessionTokensBefore: limitedTranscriptTokensBefore ?? 0,
-              estimateTokensFn: estimateTokens,
-            });
+          // Endpoint output_tokens excludes retained inputs. Count the actual
+          // committed replacement window, not the owner's pre-compaction usage.
+          const tokensAfter = serverResult
+            ? estimateLlmBoundaryTokenPressure({
+                messages: sessionManager.buildSessionContext().messages,
+                systemPrompt: systemPromptText,
+                prompt: "",
+                replay: {
+                  model: effectiveModel,
+                  sessionId: params.sessionId,
+                  authProfileId: runtimePlan.auth.forwardedAuthProfileId,
+                  enabled: compactionReplayEnabled,
+                },
+              })
+            : estimateTokensAfterCompaction({
+                messagesAfter: session.messages,
+                observedTokenCount,
+                fullSessionTokensBefore: limitedTranscriptTokensBefore ?? 0,
+                estimateTokensFn: estimateTokens,
+              });
           const messageCountAfter = session.messages.length;
           const compactedCount = Math.max(0, messageCountOriginal - messageCountAfter);
           const activeSessionFile = formatSqliteSessionFileMarker({

--- a/src/agents/embedded-agent-runner/history.test.ts
+++ b/src/agents/embedded-agent-runner/history.test.ts
@@ -1,7 +1,9 @@
 // Coverage for resolving channel and DM history limits from session keys.
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
-import { getHistoryLimitFromSessionKey } from "./history.js";
+import { buildAgentPeerSessionKey } from "../../routing/session-key.js";
+import type { AgentMessage } from "../runtime/index.js";
+import { getHistoryLimitFromSessionKey, limitHistoryTurns } from "./history.js";
 
 describe("getHistoryLimitFromSessionKey", () => {
   it("does not match channel history limits across provider id variants", () => {
@@ -59,6 +61,250 @@ describe("getHistoryLimitFromSessionKey", () => {
     expect(getHistoryLimitFromSessionKey("telegram:dm:123:thread:999", config)).toBe(7);
   });
 
+  it("resolves account-scoped direct session keys", () => {
+    // session.dmScope "per-account-channel-peer" builds
+    // agent:<agent>:<channel>:<account>:direct:<peer>, so the account segment sits
+    // where the kind normally does.
+    const config = {
+      channels: {
+        telegram: {
+          dmHistoryLimit: 4,
+          accounts: { work: { dmHistoryLimit: 11, dms: { "123": { historyLimit: 22 } } } },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(getHistoryLimitFromSessionKey("agent:main:telegram:work:direct:456", config)).toBe(11);
+    expect(getHistoryLimitFromSessionKey("agent:main:telegram:work:direct:123", config)).toBe(22);
+    // A key without the account segment still resolves the root value.
+    expect(getHistoryLimitFromSessionKey("agent:main:telegram:direct:456", config)).toBe(4);
+  });
+
+  it("uses observed peer identity rather than the account name to resolve ambiguous keys", () => {
+    const config = {
+      channels: {
+        telegram: {
+          dmHistoryLimit: 4,
+          dms: { "direct:peer": { historyLimit: 31 } },
+          accounts: { direct: { dmHistoryLimit: 12, dms: { peer: { historyLimit: 41 } } } },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(
+      getHistoryLimitFromSessionKey("agent:main:telegram:direct:direct:peer", config, {
+        accountId: "direct",
+        peerId: "peer",
+      }),
+    ).toBe(41);
+    expect(
+      getHistoryLimitFromSessionKey("agent:main:telegram:direct:direct:peer", config, {
+        accountId: "direct",
+      }),
+    ).toBe(12);
+    expect(getHistoryLimitFromSessionKey("agent:main:telegram:direct:direct:peer", config)).toBe(4);
+  });
+
+  it("does not read a root peer id beginning with direct as an account segment", () => {
+    // A root key whose peer id starts with "direct:" has the same segment shape as
+    // the account form, so inferring account scope from segment 2 alone would look
+    // up dms["peer"] and silently ignore the configured dms["direct:peer"].
+    const config = {
+      channels: {
+        telegram: {
+          dmHistoryLimit: 4,
+          dms: { "direct:peer": { historyLimit: 31 }, peer: { historyLimit: 32 } },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(
+      getHistoryLimitFromSessionKey("agent:main:telegram:direct:direct:peer", config, {
+        peerId: "direct:peer",
+      }),
+    ).toBe(31);
+    expect(getHistoryLimitFromSessionKey("agent:main:telegram:dm:dm:peer", config)).toBe(4);
+  });
+
+  it("preserves a linked DM peer when its first segment matches the routed account", () => {
+    const config = {
+      session: {
+        dmScope: "per-channel-peer",
+        identityLinks: { "direct:peer": ["telegram:123"] },
+      },
+      channels: {
+        telegram: {
+          dmHistoryLimit: 4,
+          accounts: {
+            direct: {
+              dmHistoryLimit: 12,
+              dms: { "direct:peer": { historyLimit: 31 }, peer: { historyLimit: 41 } },
+            },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+    const sessionKey = buildAgentPeerSessionKey({
+      agentId: "main",
+      channel: "telegram",
+      accountId: "direct",
+      peerKind: "direct",
+      peerId: "123",
+      dmScope: config.session.dmScope,
+      identityLinks: config.session.identityLinks,
+    });
+
+    expect(
+      getHistoryLimitFromSessionKey(sessionKey, config, {
+        accountId: "direct",
+        peerId: "123",
+        chatType: "direct",
+      }),
+    ).toBe(31);
+  });
+
+  it("lets an account dms map replace the root map instead of merging per entry", () => {
+    // The account merge contract replaces the whole map, so a root peer that the
+    // account map omits must fall through to the account default, not the root entry.
+    const config = {
+      channels: {
+        telegram: {
+          dmHistoryLimit: 4,
+          dms: { "123": { historyLimit: 99 }, "456": { historyLimit: 98 } },
+          accounts: { work: { dmHistoryLimit: 11, dms: { "123": { historyLimit: 22 } } } },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(
+      getHistoryLimitFromSessionKey("agent:main:telegram:direct:123", config, {
+        accountId: "work",
+      }),
+    ).toBe(22);
+    // 456 exists only in the root map, so the account default wins over it.
+    expect(
+      getHistoryLimitFromSessionKey("agent:main:telegram:direct:456", config, {
+        accountId: "work",
+      }),
+    ).toBe(11);
+    // With no account, the root map still applies.
+    expect(getHistoryLimitFromSessionKey("agent:main:telegram:direct:456", config)).toBe(98);
+  });
+
+  it.each(["direct", "dm", "group", "channel"])(
+    "resolves routed scope for an account named %s",
+    (accountId) => {
+      const config = {
+        channels: {
+          telegram: {
+            historyLimit: 8,
+            dmHistoryLimit: 4,
+            accounts: {
+              [accountId]: {
+                historyLimit: 9,
+                dmHistoryLimit: 12,
+                dms: { peer: { historyLimit: 41 }, "direct:peer": { historyLimit: 31 } },
+              },
+            },
+          },
+        },
+      } satisfies OpenClawConfig;
+      const route = { accountId, peerId: "peer", chatType: "direct" as const };
+      const sessionKey = buildAgentPeerSessionKey({
+        agentId: "main",
+        channel: "telegram",
+        accountId,
+        peerKind: "direct",
+        peerId: route.peerId,
+        dmScope: "per-account-channel-peer",
+      });
+      expect(getHistoryLimitFromSessionKey(sessionKey, config, route)).toBe(41);
+      expect(getHistoryLimitFromSessionKey(`${sessionKey}:thread:99`, config, route)).toBe(41);
+      const sharedKey = buildAgentPeerSessionKey({
+        agentId: "main",
+        channel: "telegram",
+        accountId,
+        peerId: route.peerId,
+        dmScope: "main",
+      });
+      expect(getHistoryLimitFromSessionKey(sharedKey, config, route)).toBeUndefined();
+      const groupKey = buildAgentPeerSessionKey({
+        agentId: "main",
+        channel: "telegram",
+        accountId,
+        peerKind: "group",
+        peerId: "direct:peer",
+      });
+      expect(getHistoryLimitFromSessionKey(groupKey, config, { ...route, chatType: "group" })).toBe(
+        9,
+      );
+      expect(
+        getHistoryLimitFromSessionKey(groupKey, config, {
+          ...route,
+          accountId: "other",
+          chatType: "group",
+        }),
+      ).toBe(8);
+    },
+  );
+
+  it("does not select another peer's override after identity-link changes or a dispatch override", () => {
+    const config = {
+      session: { identityLinks: { "direct:peer": ["telegram:123"] } },
+      channels: {
+        telegram: {
+          accounts: {
+            direct: {
+              dmHistoryLimit: 12,
+              dms: { peer: { historyLimit: 41 }, "direct:peer": { historyLimit: 31 } },
+            },
+            personal: { dmHistoryLimit: 19, dms: { "direct:peer": { historyLimit: 23 } } },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+    const route = { accountId: "direct", peerId: "123", chatType: "direct" as const };
+    const sessionKey = buildAgentPeerSessionKey({
+      agentId: "main",
+      channel: "telegram",
+      accountId: route.accountId,
+      peerId: route.peerId,
+      dmScope: "per-channel-peer",
+      identityLinks: config.session.identityLinks,
+    });
+    expect(getHistoryLimitFromSessionKey(sessionKey, config, route)).toBe(31);
+    expect(
+      getHistoryLimitFromSessionKey(
+        sessionKey,
+        { ...config, session: { identityLinks: { changed: ["telegram:123"] } } },
+        route,
+      ),
+    ).toBe(12);
+    expect(getHistoryLimitFromSessionKey(sessionKey, { ...config, session: {} }, route)).toBe(12);
+    expect(getHistoryLimitFromSessionKey("agent:main:telegram:direct:another", config, route)).toBe(
+      12,
+    );
+    expect(getHistoryLimitFromSessionKey("agent:main:main", config, route)).toBeUndefined();
+    const overrideKey = buildAgentPeerSessionKey({
+      agentId: "main",
+      channel: "telegram",
+      accountId: "work",
+      peerId: route.peerId,
+      dmScope: "per-account-channel-peer",
+      identityLinks: config.session.identityLinks,
+    });
+    expect(
+      getHistoryLimitFromSessionKey(overrideKey, config, { ...route, accountId: "personal" }),
+    ).toBe(23);
+    expect(
+      getHistoryLimitFromSessionKey(overrideKey, config, {
+        ...route,
+        accountId: "personal",
+        peerId: "456",
+      }),
+    ).toBe(19);
+  });
+
   it("keeps non-numeric thread markers in direct message ids", () => {
     const config = {
       channels: {
@@ -68,6 +314,43 @@ describe("getHistoryLimitFromSessionKey", () => {
 
     expect(getHistoryLimitFromSessionKey("agent:main:telegram:dm:user:thread:abc", config)).toBe(9);
   });
+
+  it.each(["a::b", "alice:thread:123", "alice:topic:123"])(
+    "preserves linked peer %s and known accounts after peer changes",
+    (linkedPeer) => {
+      const config = {
+        session: { identityLinks: { [linkedPeer]: ["telegram:123"] } },
+        channels: {
+          telegram: {
+            dmHistoryLimit: 4,
+            accounts: {
+              work: {
+                dmHistoryLimit: 12,
+                dms: {
+                  [linkedPeer]: { historyLimit: 31 },
+                  "a:b": { historyLimit: 41 },
+                  alice: { historyLimit: 42 },
+                },
+              },
+            },
+          },
+        },
+      } satisfies OpenClawConfig;
+      const sessionKey = buildAgentPeerSessionKey({
+        agentId: "main",
+        channel: "telegram",
+        accountId: "work",
+        peerId: "123",
+        dmScope: "per-account-channel-peer",
+        identityLinks: config.session.identityLinks,
+      });
+      expect(getHistoryLimitFromSessionKey(sessionKey, config, { peerId: "123" })).toBe(31);
+      expect(
+        getHistoryLimitFromSessionKey(`${sessionKey}:thread:99`, config, { peerId: "123" }),
+      ).toBe(31);
+      expect(getHistoryLimitFromSessionKey(sessionKey, config, { peerId: "changed" })).toBe(12);
+    },
+  );
 
   it("uses per-DM overrides before provider defaults", () => {
     const config = {
@@ -155,5 +438,148 @@ describe("getHistoryLimitFromSessionKey", () => {
       expect(getHistoryLimitFromSessionKey(`${provider}:channel:123`, config)).toBe(12);
       expect(getHistoryLimitFromSessionKey(`agent:main:${provider}:channel:456`, config)).toBe(12);
     }
+  });
+
+  it("prefers account-scoped limits over the channel root for that account", () => {
+    const config = {
+      channels: {
+        telegram: {
+          historyLimit: 10,
+          dmHistoryLimit: 15,
+          dms: { "123": { historyLimit: 7 } },
+          accounts: {
+            work: {
+              historyLimit: 40,
+              dmHistoryLimit: 41,
+              dms: { "123": { historyLimit: 42 } },
+            },
+            sparse: { historyLimit: 50 },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const cases: Array<[string, string | undefined, number | undefined]> = [
+      // Account values win for every scope the resolver supports.
+      ["telegram:channel:c1", "work", 40],
+      ["telegram:group:g1", "work", 40],
+      ["telegram:dm:999", "work", 41],
+      ["telegram:dm:123", "work", 42],
+      // Without an account id, or for an account that omits the key, the root still applies.
+      ["telegram:channel:c1", undefined, 10],
+      ["telegram:dm:999", undefined, 15],
+      ["telegram:dm:123", undefined, 7],
+      ["telegram:dm:999", "sparse", 15],
+      ["telegram:dm:123", "sparse", 7],
+      ["telegram:channel:c1", "missing-account", 10],
+    ];
+
+    for (const [sessionKey, accountId, expected] of cases) {
+      expect(
+        getHistoryLimitFromSessionKey(sessionKey, config, { accountId }),
+        `${sessionKey}/${accountId}`,
+      ).toBe(expected);
+    }
+  });
+
+  it("matches an operator-written account key against the canonical routed id", () => {
+    // Routing canonicalizes account ids, so "Work Team" arrives as "work-team".
+    // Exact-key config lookup would miss it and silently fall back to the root.
+    const config = {
+      channels: {
+        telegram: {
+          historyLimit: 10,
+          dmHistoryLimit: 15,
+          dms: { "123": { historyLimit: 7 } },
+          accounts: {
+            "Work Team": {
+              historyLimit: 40,
+              dmHistoryLimit: 41,
+              dms: { "123": { historyLimit: 42 } },
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    for (const accountId of ["work-team", "Work Team", "WORK TEAM"]) {
+      expect(getHistoryLimitFromSessionKey("telegram:channel:c1", config, { accountId })).toBe(40);
+      expect(getHistoryLimitFromSessionKey("telegram:dm:999", config, { accountId })).toBe(41);
+      expect(getHistoryLimitFromSessionKey("telegram:dm:123", config, { accountId })).toBe(42);
+    }
+    // An unrelated account still falls back to the root.
+    expect(
+      getHistoryLimitFromSessionKey("telegram:channel:c1", config, { accountId: "other" }),
+    ).toBe(10);
+  });
+
+  it("treats an explicit account limit of 0 as a real override", () => {
+    const config = {
+      channels: {
+        slack: {
+          historyLimit: 25,
+          dmHistoryLimit: 30,
+          accounts: { off: { historyLimit: 0, dmHistoryLimit: 0 } },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(getHistoryLimitFromSessionKey("slack:channel:c1", config, { accountId: "off" })).toBe(0);
+    expect(getHistoryLimitFromSessionKey("slack:dm:u1", config, { accountId: "off" })).toBe(0);
+  });
+});
+
+describe("account-scoped limits change the retained transcript", () => {
+  // The resolver returning a different number is not the user-visible effect;
+  // what matters is that the transcript actually keeps fewer turns. This drives
+  // the real resolver and the real trimmer together, no mocks.
+  function transcript(userTurns: number): AgentMessage[] {
+    return Array.from(
+      { length: userTurns * 2 },
+      (_, i) =>
+        (i % 2 === 0
+          ? { role: "user", content: `q${i / 2}` }
+          : { role: "assistant", content: `a${(i - 1) / 2}` }) as AgentMessage,
+    );
+  }
+
+  function countUserTurns(messages: AgentMessage[]) {
+    return messages.filter((message) => message.role === "user").length;
+  }
+
+  const cfg = {
+    channels: {
+      telegram: {
+        historyLimit: 20,
+        accounts: { "Work Team": { historyLimit: 2 } },
+      },
+    },
+  } as unknown as OpenClawConfig;
+
+  const sessionKey = "agent:main:telegram:channel:c1";
+  const messages = transcript(40);
+
+  it("trims to the account limit for that account", () => {
+    const limited = limitHistoryTurns(
+      messages,
+      getHistoryLimitFromSessionKey(sessionKey, cfg, { accountId: "work-team" }),
+    );
+    // limit 2 with the documented 1.5x eviction cushion keeps far fewer turns
+    // than the root limit of 20, and strictly fewer than the input.
+    expect(countUserTurns(limited)).toBeLessThan(countUserTurns(messages));
+    expect(countUserTurns(limited)).toBeLessThanOrEqual(3);
+  });
+
+  it("trims to the channel root when the account does not override", () => {
+    const rootLimited = limitHistoryTurns(
+      messages,
+      getHistoryLimitFromSessionKey(sessionKey, cfg, { accountId: "other-account" }),
+    );
+    const accountLimited = limitHistoryTurns(
+      messages,
+      getHistoryLimitFromSessionKey(sessionKey, cfg, { accountId: "work-team" }),
+    );
+    expect(countUserTurns(rootLimited)).toBeGreaterThan(countUserTurns(accountLimited));
+    expect(countUserTurns(rootLimited)).toBeLessThanOrEqual(30);
   });
 });

--- a/src/agents/embedded-agent-runner/history.ts
+++ b/src/agents/embedded-agent-runner/history.ts
@@ -2,8 +2,13 @@
  * Limits embedded-agent history length from session-key policy.
  */
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+import { normalizeChatType, type ChatType } from "../../channels/chat-type.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { normalizeAccountId } from "../../routing/account-id.js";
+import { resolveNormalizedAccountEntry } from "../../routing/account-lookup.js";
+import { resolveLinkedDirectPeerId } from "../../routing/session-key.js";
 import type { AgentMessage } from "../runtime/index.js";
 
 const THREAD_SUFFIX_REGEX = /^(.*)(?::(?:thread|topic):\d+)$/i;
@@ -89,20 +94,30 @@ export function limitHistoryTurns(
   return messages;
 }
 
+/** Raw channel-config fields this resolver reads, at channel root or under `accounts.<id>`. */
+type HistoryLimitChannelConfig = {
+  historyLimit?: number;
+  dmHistoryLimit?: number;
+  dms?: Record<string, { historyLimit?: number }>;
+  accounts?: Record<string, HistoryLimitChannelConfig | undefined>;
+};
+
 /**
  * Extract provider + user ID from a session key and look up dmHistoryLimit.
  * Supports per-DM overrides and provider defaults.
  * For channel/group sessions, uses historyLimit from provider config.
+ * Account-scoped values override the channel root for that account.
  */
 export function getHistoryLimitFromSessionKey(
   sessionKey: string | undefined,
   config: OpenClawConfig | undefined,
+  route?: { accountId?: string | null; peerId?: string; chatType?: ChatType },
 ): number | undefined {
   if (!sessionKey || !config) {
     return undefined;
   }
 
-  const parts = sessionKey.split(":").filter(Boolean);
+  const parts = sessionKey.split(":");
   const providerParts = parts.length >= 3 && parts[0] === "agent" ? parts.slice(2) : parts;
 
   const provider = normalizeProviderId(providerParts[0] ?? "");
@@ -110,60 +125,101 @@ export function getHistoryLimitFromSessionKey(
     return undefined;
   }
 
-  const kind = normalizeOptionalLowercaseString(providerParts[1]);
-  const userIdRaw = providerParts.slice(2).join(":");
-  const userId = stripThreadSuffix(userIdRaw);
-
-  const resolveProviderConfig = (
-    cfg: OpenClawConfig | undefined,
-    providerId: string,
-  ):
-    | {
-        historyLimit?: number;
-        dmHistoryLimit?: number;
-        dms?: Record<string, { historyLimit?: number }>;
-      }
-    | undefined => {
-    const channels = cfg?.channels;
-    if (!channels || typeof channels !== "object") {
-      return undefined;
+  // Account names and linked peers can both contain kind tokens. Enumerate the
+  // actual key's interpretations, then use observed route facts to disambiguate;
+  // current dmScope cannot describe old sessions or explicit session overrides.
+  const candidates = [0, 1].flatMap((accountSegments) => {
+    const kind = normalizeChatType(providerParts[1 + accountSegments]);
+    const accountId = accountSegments ? providerParts[1] : undefined;
+    if (
+      !kind ||
+      (route?.chatType && kind !== route.chatType) ||
+      (accountSegments && kind !== "direct")
+    ) {
+      return [];
     }
-    for (const [configuredProviderId, value] of Object.entries(
-      channels as Record<string, unknown>,
-    )) {
-      if (normalizeProviderId(configuredProviderId) !== providerId) {
-        continue;
-      }
-      if (!value || typeof value !== "object" || Array.isArray(value)) {
-        return undefined;
-      }
-      return value as {
-        historyLimit?: number;
-        dmHistoryLimit?: number;
-        dms?: Record<string, { historyLimit?: number }>;
-      };
-    }
-    return undefined;
-  };
+    return [
+      {
+        kind,
+        accountId,
+        userId: providerParts.slice(2 + accountSegments).join(":"),
+      },
+    ];
+  });
+  const rawPeerId = route?.peerId?.trim();
+  const logicalPeerId = rawPeerId
+    ? normalizeOptionalLowercaseString(
+        resolveLinkedDirectPeerId({
+          identityLinks: config.session?.identityLinks,
+          channel: provider,
+          peerId: rawPeerId,
+        }) ?? rawPeerId,
+      )
+    : undefined;
+  const matching = logicalPeerId
+    ? candidates.filter(
+        (candidate) =>
+          candidate.kind !== "direct" ||
+          candidate.userId === logicalPeerId ||
+          stripThreadSuffix(candidate.userId) === logicalPeerId,
+      )
+    : candidates;
+  const resolved = matching.length === 1 ? matching[0] : undefined;
+  const kind =
+    resolved?.kind ??
+    (candidates.every((candidate) => candidate.kind === candidates[0]?.kind)
+      ? candidates[0]?.kind
+      : undefined);
+  // A linked peer may itself end in :thread:<number>; observed identity wins
+  // over the legacy suffix heuristic, including when an actual thread is appended.
+  const userId = resolved && (logicalPeerId ?? stripThreadSuffix(resolved.userId));
+  // An explicit session override can name another account; the admitted route
+  // still owns policy without erasing the key's independently known chat kind.
+  const routedAccountId =
+    route?.accountId ?? (candidates.length === 1 ? candidates[0]?.accountId : resolved?.accountId);
 
-  const providerConfig = resolveProviderConfig(config, provider);
+  const providerConfig = asOptionalRecord(
+    Object.entries(config.channels ?? {}).find(
+      ([channel]) => normalizeProviderId(channel) === provider,
+    )?.[1],
+  ) as HistoryLimitChannelConfig | undefined;
   if (!providerConfig) {
     return undefined;
   }
 
+  // Channel schemas accept these keys at the channel root and under `accounts.<id>`,
+  // so an account value must win for that account or it validates and is silently
+  // ignored. The routed account id is canonical, while config keys are operator
+  // text, so both sides normalize before matching (`accounts["Work Team"]` must
+  // match the routed `work-team`).
+  const trimmedAccountId = routedAccountId?.trim();
+  const accountConfig = trimmedAccountId
+    ? resolveNormalizedAccountEntry(
+        providerConfig.accounts,
+        normalizeAccountId(trimmedAccountId),
+        normalizeAccountId,
+      )
+    : undefined;
+
   // For DM sessions: per-DM override -> dmHistoryLimit.
-  // Accept both "direct" (new) and "dm" (legacy) for backward compat.
-  if (kind === "dm" || kind === "direct") {
-    if (userId && providerConfig.dms?.[userId]?.historyLimit !== undefined) {
-      return providerConfig.dms[userId].historyLimit;
+  if (kind === "direct") {
+    if (userId) {
+      // An explicit account `dms` map replaces the root map under the account
+      // merge contract, so pick the owning map before indexing. Falling back per
+      // entry would leak root per-peer overrides into that account.
+      const dms = accountConfig?.dms ?? providerConfig.dms;
+      const perDmLimit = dms?.[userId]?.historyLimit;
+      if (perDmLimit !== undefined) {
+        return perDmLimit;
+      }
     }
-    return providerConfig.dmHistoryLimit;
+    return accountConfig?.dmHistoryLimit ?? providerConfig.dmHistoryLimit;
   }
 
   // For channel/group sessions: use historyLimit from provider config
   // This prevents context overflow in long-running channel sessions
   if (kind === "channel" || kind === "group") {
-    return providerConfig.historyLimit;
+    return accountConfig?.historyLimit ?? providerConfig.historyLimit;
   }
 
   return undefined;

--- a/src/agents/embedded-agent-runner/run/attempt-context-guards.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-context-guards.test.ts
@@ -57,6 +57,7 @@ function createInput(overrides: Record<string, unknown> = {}) {
     getPrePromptMessageCount: () => 4,
     getPromptCache: () => undefined,
     getPromptCacheRetention: () => "short" as const,
+    getCompactionReplayEnabled: () => false,
     getSystemPrompt: () => "system prompt",
     isOpenAIResponsesApi: false,
     repairToolUseResultPairing: false,

--- a/src/agents/embedded-agent-runner/run/attempt-execution-phase.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-phase.ts
@@ -111,6 +111,7 @@ export async function runEmbeddedAttemptExecutionPhase(
       ...(input.activeContextEngine ? { activeContextEngine: input.activeContextEngine } : {}),
       cacheTrace,
       capabilityToolNames,
+      compactionReplayEnabled: sessionRuntime.transport.compactionReplayEnabled,
       effectiveWorkspace: input.setup.effectiveWorkspace,
       isOpenAIResponsesApi,
       isRawModelRun: input.isRawModelRun,

--- a/src/agents/embedded-agent-runner/run/attempt-history.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-history.ts
@@ -1,3 +1,4 @@
+import { preserveCompactionReplayWindow } from "@openclaw/ai/transports";
 /**
  * Prepares user-message boundaries, restored history, and transcript policy for an attempt.
  * It may assume normalized attempt and session inputs are ready.
@@ -37,6 +38,7 @@ import { sanitizeSessionHistory, validateReplayTurns } from "../replay-history.j
 import type { AttemptContextEngine } from "./attempt-context-engine-helpers.js";
 import type { resolveOrphanRepairPlan } from "./attempt-orphan-repair.js";
 import { prependSystemPromptAddition } from "./attempt-prompt-helpers.js";
+import { resolveAttemptStreamAuthProfileId } from "./attempt-run-decisions.js";
 import { isRunnerToolCallBlockType } from "./attempt-tool-call-block-type.js";
 import { loadAttemptSessionEntryAfterQuotaMaintenance } from "./attempt-transcript-helpers.js";
 import { estimateRenderedLlmBoundaryTokenPressure } from "./preemptive-compaction.js";
@@ -400,6 +402,7 @@ export async function prepareEmbeddedAttemptHistory(input: {
   activeContextEngine?: AttemptContextEngine;
   cacheTrace: CacheTrace;
   capabilityToolNames: ReadonlySet<string>;
+  compactionReplayEnabled: boolean;
   effectiveWorkspace: string;
   isOpenAIResponsesApi: boolean;
   isRawModelRun: boolean;
@@ -536,9 +539,22 @@ export async function prepareEmbeddedAttemptHistory(input: {
         heartbeatSummary?.ackMaxChars,
         heartbeatSummary?.prompt,
       );
-      const truncated = limitHistoryTurns(
+      const truncated = preserveCompactionReplayWindow(
         heartbeatFiltered,
-        getHistoryLimitFromSessionKey(attempt.sessionKey, attempt.config),
+        limitHistoryTurns(
+          heartbeatFiltered,
+          getHistoryLimitFromSessionKey(attempt.sessionKey, attempt.config, {
+            accountId: attempt.agentAccountId,
+            peerId: attempt.conversationRoutePeerId,
+            chatType: attempt.chatType,
+          }),
+        ),
+        attempt.model,
+        {
+          sessionId: attempt.sessionId,
+          authProfileId: resolveAttemptStreamAuthProfileId(attempt),
+          enabled: input.compactionReplayEnabled,
+        },
       );
       // Truncation can orphan tool_result blocks by removing the assistant message
       // that contained the matching tool_use, so repair the pairs once more.

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-phase.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-phase.test.ts
@@ -260,6 +260,7 @@ function createFixture() {
       coreReadAuthorized: true,
     },
     preflight: {
+      compactionReplayEnabled: false,
       contextEngineAssemblySucceeded: false,
       contextEnginePromptAuthority: "assembled",
       includeBoundaryTimestamp: false,

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-preflight.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-preflight.test.ts
@@ -1,6 +1,10 @@
+import { captureOpenAIResponsesCompaction } from "@openclaw/ai/transports";
+import type { Model } from "@openclaw/llm-core";
 import { describe, expect, it, vi } from "vitest";
+import { testing } from "../../openai-transport-stream.test-support.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import { SessionManager } from "../../sessions/index.js";
+import { makeAgentAssistantMessage } from "../../test-helpers/agent-message-fixtures.js";
 import {
   handleEmbeddedAttemptMidTurnPrecheck,
   prepareEmbeddedAttemptPromptPreflight,
@@ -16,6 +20,18 @@ const attempt = {
   sessionFile: "/tmp/openclaw-attempt-preflight-test.jsonl",
   sessionId: "session-1",
   sessionKey: "agent:test:main",
+  model: {
+    id: "gpt-5.6-luna",
+    name: "GPT-5.6 Luna",
+    provider: "openai",
+    api: "openai-responses",
+    baseUrl: "https://api.openai.com/v1",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 100_000,
+    maxTokens: 8_192,
+  } satisfies Model,
 };
 
 const request = {
@@ -45,6 +61,143 @@ function createSessionManagerWithMessage(message: AgentMessage): SessionManager 
 }
 
 describe("attempt prompt preflight", () => {
+  it.each([
+    "oversized",
+    "unwindowed",
+    "unwindowed-tools",
+    "missing-window",
+    "discarded",
+    "discarded-invalid",
+    "fitting-with-raw-overflow",
+    "fitting-with-discarded-invalid",
+  ] as const)(
+    "handles a %s checkpoint when a context engine owns ordinary compaction",
+    async (variant) => {
+      const discarded = variant === "discarded" || variant === "discarded-invalid";
+      const fitting = variant.startsWith("fitting-");
+      const unwindowed = variant === "unwindowed" || variant === "unwindowed-tools";
+      const owner = makeAgentAssistantMessage({
+        content: [{ type: "text", text: "covered" }],
+        model: attempt.model.id,
+      });
+      const item = { type: "compaction" as const, id: "cmp_test", encrypted_content: "opaque" };
+      captureOpenAIResponsesCompaction(
+        owner,
+        item,
+        "retained-users",
+        attempt.model,
+        testing.buildOpenAIResponsesReasoningReplayMetadata(attempt.model, attempt),
+        variant !== "missing-window" && variant !== "discarded-invalid"
+          ? [
+              {
+                type: "message",
+                role: "user",
+                content: [
+                  {
+                    type: "input_text",
+                    text: fitting ? "small retained window" : "retained content ".repeat(8_000),
+                  },
+                ],
+              },
+              item,
+            ]
+          : undefined,
+      );
+      const discardedInvalid = makeAgentAssistantMessage({
+        content: [],
+        model: attempt.model.id,
+      });
+      captureOpenAIResponsesCompaction(
+        discardedInvalid,
+        { ...item, id: "cmp_discarded", encrypted_content: "discarded opaque" },
+        "retained-users",
+        attempt.model,
+        testing.buildOpenAIResponsesReasoningReplayMetadata(attempt.model, attempt),
+      );
+      const result = await prepareEmbeddedAttemptPromptPreflight({
+        attempt,
+        compactionReplayEnabled: true,
+        activeContextEngine: { info: { id: "owner", name: "Owner", ownsCompaction: true } },
+        contextEngineAssemblySucceeded: true,
+        contextEnginePromptAuthority:
+          unwindowed || discarded || fitting ? "preassembly_may_overflow" : "assembled",
+        ...(unwindowed || discarded || fitting
+          ? {
+              unwindowedContextEngineMessagesForPrecheck: discarded
+                ? [owner]
+                : [
+                    ...(variant === "fitting-with-discarded-invalid"
+                      ? [owner, discardedInvalid]
+                      : []),
+                    ...(variant === "unwindowed-tools"
+                      ? [
+                          makeAgentAssistantMessage({
+                            content: [
+                              { type: "toolCall", id: "call-1", name: "read", arguments: {} },
+                            ],
+                          }),
+                          makeToolResultMessage("raw tool history ".repeat(40_000)),
+                        ]
+                      : [
+                          {
+                            role: "user" as const,
+                            content: "raw history ".repeat(40_000),
+                            timestamp: 1,
+                          },
+                        ]),
+                  ],
+            }
+          : {}),
+        contextTokenBudget: 1_000,
+        hookMessagesForCurrentPrompt: discarded ? [] : [owner],
+        includeBoundaryTimestamp: false,
+        promptForPrecheck: "follow-up",
+        reserveTokens: 100,
+        sessionMessageCount: 1,
+        systemPrompt: "",
+        toolResultMaxChars: 1_000,
+        state: {
+          contextBudgetStatus: undefined,
+          preflightRecovery: undefined,
+          promptError: null,
+          promptErrorSource: null,
+          skipPromptSubmission: false,
+        },
+      });
+      if (discarded || fitting) {
+        expect(result.skipPromptSubmission).toBe(false);
+        expect(result.promptError).toBeNull();
+        expect(result.preflightRecovery).toBeUndefined();
+        if (fitting) {
+          expect(result.contextBudgetStatus?.estimatedPromptTokens).toBeGreaterThan(20_000);
+        }
+        return;
+      }
+      expect(result.skipPromptSubmission).toBe(true);
+      expect(result.promptErrorSource).toBe("precheck");
+      if (variant !== "missing-window") {
+        expect(result.preflightRecovery?.route).toBe("compact_only");
+        expect(result.contextBudgetStatus?.estimatedPromptTokens).toBeGreaterThan(20_000);
+        if (unwindowed) {
+          expect(result.preflightRecovery?.estimatedPromptTokens).toBe(
+            estimateLlmBoundaryTokenPressure({
+              messages: [owner],
+              prompt: "follow-up",
+              replay: { model: attempt.model, sessionId: attempt.sessionId, enabled: true },
+            }),
+          );
+          if (variant === "unwindowed-tools") {
+            expect(result.contextBudgetStatus?.toolResultReducibleChars).toBeGreaterThan(0);
+            expect(result.contextBudgetStatus?.route).not.toBe("compact_only");
+          }
+        }
+      } else {
+        expect(result.preflightRecovery).toBeUndefined();
+        expect(String(result.promptError)).toContain("Run /compact");
+      }
+    },
+  );
+
   it("routes a mid-turn compaction request with its measured budget", () => {
     const outcome = handleEmbeddedAttemptMidTurnPrecheck({
       attempt,
@@ -139,6 +292,7 @@ describe("attempt prompt preflight", () => {
   it("records heuristic pressure without short-circuiting the provider attempt", async () => {
     const result = await prepareEmbeddedAttemptPromptPreflight({
       attempt,
+      compactionReplayEnabled: true,
       contextEngineAssemblySucceeded: false,
       contextEnginePromptAuthority: "assembled",
       contextTokenBudget: 100,
@@ -176,6 +330,7 @@ describe("attempt prompt preflight", () => {
     };
     const result = await prepareEmbeddedAttemptPromptPreflight({
       attempt,
+      compactionReplayEnabled: true,
       activeContextEngine: {
         info: { id: "owner", name: "Owner", ownsCompaction: true },
       },
@@ -209,6 +364,7 @@ describe("attempt prompt preflight", () => {
 
     const result = await prepareEmbeddedAttemptPromptPreflight({
       attempt,
+      compactionReplayEnabled: true,
       contextEngineAssemblySucceeded: false,
       contextEnginePromptAuthority: "assembled",
       contextTokenBudget,

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-preflight.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-preflight.ts
@@ -1,6 +1,7 @@
 /**
  * Reports prompt pressure and owns explicit mid-turn recovery routing.
  */
+import { CompactionReplayRefreshRequiredError } from "@openclaw/ai/transports";
 import type { AssembleResult } from "../../../context-engine/types.js";
 import type { AgentRunAttemptFailureSource } from "../../agent-run-terminal-outcome.js";
 import { sanitizeCompactionReplayMessages } from "../../compaction-replay.js";
@@ -14,11 +15,11 @@ import {
 } from "../tool-result-truncation.js";
 import type { AttemptContextEngine } from "./attempt-context-engine-helpers.js";
 import { normalizeMessagesForLlmBoundary } from "./attempt-llm-boundary.js";
+import { resolveAttemptStreamAuthProfileId } from "./attempt-run-decisions.js";
 import type { MidTurnPrecheckRequest } from "./midturn-precheck.js";
 import {
   PREEMPTIVE_OVERFLOW_ERROR_TEXT,
   buildPrePromptContextBudgetStatus,
-  estimateLlmBoundaryTokenPressure,
   formatPrePromptPrecheckLog,
   shouldPreemptivelyCompactBeforePrompt,
 } from "./preemptive-compaction.js";
@@ -158,8 +159,10 @@ export function handleEmbeddedAttemptMidTurnPrecheck(input: {
 }
 
 export async function prepareEmbeddedAttemptPromptPreflight(input: {
-  attempt: AttemptPromptPreflightParams;
+  attempt: AttemptPromptPreflightParams &
+    Pick<EmbeddedRunAttemptParams, "model" | "runtimePlan" | "authProfileId">;
   activeContextEngine?: Pick<AttemptContextEngine, "info">;
+  compactionReplayEnabled: boolean;
   contextEngineAssemblySucceeded: boolean;
   contextEnginePromptAuthority: NonNullable<AssembleResult["promptAuthority"]>;
   contextTokenBudget: number;
@@ -192,17 +195,42 @@ export async function prepareEmbeddedAttemptPromptPreflight(input: {
           boundaryOptions,
         )
       : undefined;
-  const llmBoundaryTokenPressure = estimateLlmBoundaryTokenPressure({
-    messages: input.hookMessagesForCurrentPrompt,
-    systemPrompt: input.systemPrompt,
-    prompt: input.promptForPrecheck,
-  });
   let preemptiveCompaction: ReturnType<typeof shouldPreemptivelyCompactBeforePrompt> | null = null;
+  if (!skipPromptSubmission) {
+    try {
+      preemptiveCompaction = shouldPreemptivelyCompactBeforePrompt({
+        messages: input.hookMessagesForCurrentPrompt,
+        unwindowedMessages: unwindowedLlmBoundaryMessagesForPrecheck,
+        systemPrompt: input.systemPrompt,
+        prompt: input.promptForPrecheck,
+        contextTokenBudget: input.contextTokenBudget,
+        reserveTokens: input.reserveTokens,
+        toolResultMaxChars: input.toolResultMaxChars,
+        replay: {
+          model: attempt.model,
+          sessionId: attempt.sessionId,
+          authProfileId: resolveAttemptStreamAuthProfileId(attempt),
+          enabled: input.compactionReplayEnabled,
+        },
+      });
+    } catch (error) {
+      if (!(error instanceof CompactionReplayRefreshRequiredError)) {
+        throw error;
+      }
+      return {
+        ...input.state,
+        promptError: error,
+        promptErrorSource: "precheck",
+        skipPromptSubmission: true,
+      };
+    }
+  }
   const shouldSkipPrecheck =
     skipPromptSubmission ||
     (input.contextEngineAssemblySucceeded &&
       input.activeContextEngine?.info.ownsCompaction &&
-      input.contextEnginePromptAuthority !== "preassembly_may_overflow");
+      input.contextEnginePromptAuthority !== "preassembly_may_overflow" &&
+      !preemptiveCompaction?.compactionReplay);
 
   if (shouldSkipPrecheck && !skipPromptSubmission) {
     log.info(
@@ -210,23 +238,8 @@ export async function prepareEmbeddedAttemptPromptPreflight(input: {
     );
   }
 
-  if (!shouldSkipPrecheck) {
-    preemptiveCompaction = shouldPreemptivelyCompactBeforePrompt({
-      messages: input.hookMessagesForCurrentPrompt,
-      ...(unwindowedLlmBoundaryMessagesForPrecheck
-        ? { unwindowedMessages: unwindowedLlmBoundaryMessagesForPrecheck }
-        : {}),
-      systemPrompt: input.systemPrompt,
-      prompt: input.promptForPrecheck,
-      contextTokenBudget: input.contextTokenBudget,
-      reserveTokens: input.reserveTokens,
-      toolResultMaxChars: input.toolResultMaxChars,
-      llmBoundaryTokenPressure: {
-        estimatedPromptTokens: llmBoundaryTokenPressure,
-        source: "llm_boundary_normalized_prompt",
-        renderedChars: input.promptForPrecheck.length,
-      },
-    });
+  if (shouldSkipPrecheck) {
+    preemptiveCompaction = null;
   }
   if (preemptiveCompaction) {
     contextBudgetStatus = buildPrePromptContextBudgetStatus({
@@ -259,6 +272,22 @@ export async function prepareEmbeddedAttemptPromptPreflight(input: {
         ...(attempt.sessionFile ? { sessionFile: attempt.sessionFile } : {}),
       }),
     );
+    const checkpointPressure = preemptiveCompaction.compactionReplay;
+    if (checkpointPressure && checkpointPressure.route !== "fits") {
+      // Only the actual canonical window can require recovery; the raw-history
+      // maximum above remains diagnostic even when it exceeds this window.
+      return {
+        ...input.state,
+        contextBudgetStatus,
+        preflightRecovery: {
+          route: checkpointPressure.route,
+          ...buildPreflightRecoveryBudgetSnapshot(checkpointPressure),
+        },
+        promptError: new Error(PREEMPTIVE_OVERFLOW_ERROR_TEXT),
+        promptErrorSource: "precheck",
+        skipPromptSubmission: true,
+      };
+    }
     if (preemptiveCompaction.route !== "fits") {
       // This pressure estimate is diagnostic only; it never compacts or discards history.
       // Real compaction runs through explicit preflight or provider-overflow recovery.

--- a/src/agents/embedded-agent-runner/run/attempt-session-runtime-prepare.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-runtime-prepare.test.ts
@@ -76,6 +76,7 @@ function createFixture() {
   const anthropicPayloadLogger = { kind: "payload-logger" };
   const trajectoryRecorder = { kind: "trajectory" };
   const transport = {
+    compactionReplayEnabled: true,
     effectiveAgentTransport: "sse",
     effectiveExtraParams: { cacheRetention: "long" },
     effectivePromptCacheRetention: "long",
@@ -283,6 +284,7 @@ describe("prepareEmbeddedAttemptSessionRuntime", () => {
     expect(guardInput.getPrePromptMessageCount()).toBe(7);
     expect(guardInput.getPromptCache()).toEqual({ cacheRead: 3 });
     expect(guardInput.getPromptCacheRetention()).toBe("long");
+    expect(guardInput.getCompactionReplayEnabled()).toBe(true);
     expect(guardInput.getSystemPrompt()).toBe("updated prompt");
     guardInput.onCurrentTurnImageFailure(2);
     guardInput.onCurrentTurnImageFailure(1);

--- a/src/agents/embedded-agent-runner/run/attempt-session-runtime-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-runtime-prepare.ts
@@ -165,12 +165,7 @@ export async function prepareEmbeddedAttemptSessionRuntime(input: {
     activeSession,
   });
 
-  // Guard hooks run during prompt submission, after transport setup fills this value.
-  const promptCacheRetentionRef: {
-    current: Awaited<
-      ReturnType<typeof prepareEmbeddedAttemptTransport>
-    >["effectivePromptCacheRetention"];
-  } = { current: undefined };
+  // Guard hooks execute during prompt submission, after transport preparation.
   const contextGuards = installEmbeddedAttemptContextGuards({
     ...(input.activeContextEngine ? { activeContextEngine: input.activeContextEngine } : {}),
     activeSession,
@@ -184,7 +179,8 @@ export async function prepareEmbeddedAttemptSessionRuntime(input: {
     getPrePromptMessageCount: () => state.prePromptMessageCount,
     getPromptCache: () => state.promptCache,
     onCurrentTurnImageFailure: recordCurrentTurnImageFailure,
-    getPromptCacheRetention: () => promptCacheRetentionRef.current,
+    getPromptCacheRetention: () => transport.effectivePromptCacheRetention,
+    getCompactionReplayEnabled: () => transport.compactionReplayEnabled,
     getSystemPrompt: () => state.systemPromptText,
     isOpenAIResponsesApi,
     repairToolUseResultPairing: transcriptPolicy.repairToolUseResultPairing,
@@ -256,7 +252,6 @@ export async function prepareEmbeddedAttemptSessionRuntime(input: {
       ...(trajectoryRecorder ? { recordEvent: trajectoryRecorder.recordEvent } : {}),
     },
   });
-  promptCacheRetentionRef.current = transport.effectivePromptCacheRetention;
 
   return {
     agentSession: preparedAgentSession,

--- a/src/agents/embedded-agent-runner/run/attempt-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-settle.ts
@@ -296,6 +296,7 @@ export async function runEmbeddedAttemptSettledPhase(
       },
       preflight: {
         ...(input.activeContextEngine ? { activeContextEngine: input.activeContextEngine } : {}),
+        compactionReplayEnabled: sessionRuntime.transport.compactionReplayEnabled,
         contextEngineAssemblySucceeded,
         contextEnginePromptAuthority,
         includeBoundaryTimestamp,

--- a/src/agents/embedded-agent-runner/run/attempt-setup.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-setup.test.ts
@@ -79,6 +79,7 @@ describe("prepareEmbeddedAttemptSetup", () => {
       getPrePromptMessageCount: () => 0,
       getPromptCache: () => undefined,
       getPromptCacheRetention: () => undefined,
+      getCompactionReplayEnabled: () => false,
       getSystemPrompt: () => "",
       isOpenAIResponsesApi: false,
       repairToolUseResultPairing: false,

--- a/src/agents/embedded-agent-runner/run/attempt-setup.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-setup.ts
@@ -71,6 +71,7 @@ import {
   buildAfterTurnRuntimeContext,
   resolveAttemptFsWorkspaceOnly,
 } from "./attempt-prompt-helpers.js";
+import { resolveAttemptStreamAuthProfileId } from "./attempt-run-decisions.js";
 import {
   createEmbeddedRunStageSummaryEmitter,
   createEmbeddedRunStageTracker,
@@ -271,6 +272,7 @@ export function installEmbeddedAttemptContextGuards(input: {
   getPrePromptMessageCount: () => number;
   getPromptCache: () => EmbeddedRunAttemptResult["promptCache"];
   getPromptCacheRetention: () => PromptCacheRetention;
+  getCompactionReplayEnabled: () => boolean;
   getSystemPrompt: () => string;
   onCurrentTurnImageFailure?: (count: number) => void;
   isOpenAIResponsesApi: boolean;
@@ -304,6 +306,12 @@ export function installEmbeddedAttemptContextGuards(input: {
       ? {
           midTurnPrecheck: {
             enabled: true,
+            getReplay: () => ({
+              model: attempt.model,
+              sessionId: attempt.sessionId,
+              authProfileId: resolveAttemptStreamAuthProfileId(attempt),
+              enabled: input.getCompactionReplayEnabled(),
+            }),
             contextTokenBudget,
             reserveTokens: () => settingsManager.getCompactionReserveTokens(),
             toolResultMaxChars,

--- a/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
@@ -112,7 +112,7 @@ type AttemptSpawnWorkspaceHoisted = {
   runContextEngineMaintenanceMock: AsyncContextEngineMaintenanceMock;
   detectAndLoadPromptImagesMock: AsyncUnknownMock;
   getHistoryLimitFromSessionKeyMock: Mock<
-    (sessionKey: string | undefined, config: unknown) => number | undefined
+    (sessionKey: string | undefined, config: unknown, route?: unknown) => number | undefined
   >;
   limitHistoryTurnsMock: Mock<<T>(messages: T, limit: number | undefined) => T>;
   preemptiveCompactionCalls: Parameters<ShouldPreemptivelyCompactBeforePromptFn>[0][];
@@ -225,7 +225,7 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
     skippedCount: 0,
   }));
   const getHistoryLimitFromSessionKeyMock = vi.fn<
-    (sessionKey: string | undefined, config: unknown) => number | undefined
+    (sessionKey: string | undefined, config: unknown, route?: unknown) => number | undefined
   >(() => undefined);
   const limitHistoryTurnsMock = vi.fn<<T>(messages: T, limit: number | undefined) => T>(
     (messages) => messages,
@@ -840,8 +840,13 @@ vi.mock("../compaction-safety-timeout.js", () => ({
 }));
 
 vi.mock("../history.js", () => ({
-  getHistoryLimitFromSessionKey: (sessionKey: string | undefined, config: unknown) =>
-    hoisted.getHistoryLimitFromSessionKeyMock(sessionKey, config),
+  // Forward the account id too: dropping it here would hide whether the prompt
+  // path actually scopes the limit to the routed account.
+  getHistoryLimitFromSessionKey: (
+    sessionKey: string | undefined,
+    config: unknown,
+    route?: unknown,
+  ) => hoisted.getHistoryLimitFromSessionKeyMock(sessionKey, config, route),
   limitHistoryTurns: (messages: unknown, limit: number | undefined) =>
     hoisted.limitHistoryTurnsMock(messages, limit),
 }));

--- a/src/agents/embedded-agent-runner/run/attempt-stream-settle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-settle.test.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   resolveProviderContext,
   type ProviderStreamOptions,
@@ -11,6 +11,7 @@ import { bindStreamLlmRuntime } from "../../../llm/model-runtime-binding.js";
 import { attachRuntimePromptMediaFacts } from "../../../media/media-facts.js";
 import { SessionManager } from "../../sessions/index.js";
 import { castAgentMessage } from "../../test-helpers/agent-message-fixtures.js";
+import { testing as extraParamsTesting } from "../extra-params.test-support.js";
 import { RUN_LIVENESS_JOIN_TIMEOUT_MS } from "./abortable.js";
 import {
   prepareEmbeddedAttemptTransport,
@@ -123,11 +124,20 @@ describe("settleEmbeddedAttemptStream liveness", () => {
 });
 
 describe("prepareEmbeddedAttemptTransport", () => {
+  beforeEach(() => {
+    // These cases own prepared auth/config, not runtime plugin discovery.
+    extraParamsTesting.setProviderRuntimeDepsForTest({ wrapProviderStreamFn: () => undefined });
+  });
   afterEach(() => {
+    extraParamsTesting.resetProviderRuntimeDepsForTest();
     registerProviderStreamForModel.mockReset();
   });
 
-  it("applies the prepared transport to the live agent owner", async () => {
+  it.each([
+    { compaction: true, apiKey: "test-api-key", replayEnabled: true },
+    { compaction: true, apiKey: "test-sk-ant-oat-oauth", replayEnabled: false },
+    { compaction: false, apiKey: "test-api-key", replayEnabled: false },
+  ])("prepares transport and replay from resolved auth/config: %j", async (testCase) => {
     const streamFn = vi.fn();
     bindStreamLlmRuntime(streamFn, {
       streamSimple: streamFn,
@@ -143,19 +153,24 @@ describe("prepareEmbeddedAttemptTransport", () => {
       attempt: {
         config: {},
         model: {
-          api: "test-api",
-          provider: "test-provider",
-          id: "test-model",
+          api: "anthropic-messages",
+          provider: "anthropic",
+          id: "claude-sonnet-4-6",
+          baseUrl: "https://api.anthropic.com",
         },
-        modelId: "test-model",
-        provider: "test-provider",
+        modelId: "claude-sonnet-4-6",
+        provider: "anthropic",
         promptCacheKey: undefined,
         resolvedApiKey: undefined,
+        authStorage: { getApiKey: async () => testCase.apiKey },
         runId: "run-transport-1",
         runtimePlan: {
           auth: { forwardedAuthProfileId: undefined },
           transport: {
-            resolveExtraParams: () => ({ transport: "sse" }),
+            resolveExtraParams: () => ({
+              transport: "sse",
+              anthropicServerCompaction: testCase.compaction,
+            }),
           },
         },
         sessionId: "sess-transport-1",
@@ -172,8 +187,8 @@ describe("prepareEmbeddedAttemptTransport", () => {
       agentDir: "/agent",
       abortSignal: new AbortController().signal,
       getProviderRuntimeHandle: () => ({
-        provider: "test-provider",
-        modelId: "test-model",
+        provider: "anthropic",
+        modelId: "claude-sonnet-4-6",
       }),
       sandboxSessionKey: "agent:main:test",
       codeModeControlsEnabled: false,
@@ -187,6 +202,7 @@ describe("prepareEmbeddedAttemptTransport", () => {
 
     expect(result.effectiveAgentTransport).toBe("sse");
     expect(session.agent.transport).toBe("sse");
+    expect(result.compactionReplayEnabled).toBe(testCase.replayEnabled);
   });
 
   it("materializes native video from the prepared session agent workspace", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt-stream-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-settle.ts
@@ -2,6 +2,7 @@
  * Prepares transport before streaming and settles the completed stream afterward.
  * It may assume session runtime ownership and provider inputs are established.
  */
+import { resolveCompactionReplayEligibility } from "@openclaw/ai/transports";
 import { formatErrorMessage } from "../../../infra/errors.js";
 import { createCodexNativeWebSearchWrapper } from "../../../llm/providers/stream-wrappers/openai.js";
 import type { AssistantMessage } from "../../../llm/types.js";
@@ -637,6 +638,10 @@ export async function prepareEmbeddedAttemptTransport(input: {
   }
   session.agent.transport = effectiveAgentTransport;
   return {
+    compactionReplayEnabled: resolveCompactionReplayEligibility(attempt.model, {
+      extraParams: effectiveExtraParams,
+      apiKey: transportApiKey,
+    }),
     effectiveAgentTransport,
     effectiveExtraParams,
     effectivePromptCacheRetention,

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -2234,10 +2234,11 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expect(sawPrompt).toBe(true);
     expect(projectAgentRunAttemptTerminal(result.terminal).promptError).toBeNull();
     expect(projectAgentRunAttemptTerminal(result.terminal).promptErrorSource).toBeNull();
-    expect(hoisted.preemptiveCompactionCalls.at(-1)).not.toHaveProperty("unwindowedMessages");
+    expect(hoisted.preemptiveCompactionCalls).toHaveLength(1);
+    expect(hoisted.preemptiveCompactionCalls.at(-1)?.unwindowedMessages).toBeUndefined();
   });
 
-  it("skips the generic precheck when the context engine owns compaction", async () => {
+  it("defers ordinary admission when the context engine owns compaction", async () => {
     let sawPrompt = false;
     const hugeHistory = "large raw history ".repeat(2_000);
 
@@ -2274,7 +2275,8 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expect(sawPrompt).toBe(true);
     expect(projectAgentRunAttemptTerminal(result.terminal).promptError).toBeNull();
     expect(projectAgentRunAttemptTerminal(result.terminal).promptErrorSource).toBeNull();
-    expect(hoisted.preemptiveCompactionCalls).toHaveLength(0);
+    expect(result.contextBudgetStatus).toBeUndefined();
+    expect(result.preflightRecovery).toBeUndefined();
   });
 
   it("preserves pipeline history when owning context engine assembly mutates then fails", async () => {
@@ -2323,7 +2325,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expect(projectAgentRunAttemptTerminal(result.terminal).promptErrorSource).toBeNull();
     expect(result.preflightRecovery).toBeUndefined();
     expect(hoisted.preemptiveCompactionCalls).toHaveLength(1);
-    expect(hoisted.preemptiveCompactionCalls.at(-1)).not.toHaveProperty("unwindowedMessages");
+    expect(hoisted.preemptiveCompactionCalls.at(-1)?.unwindowedMessages).toBeUndefined();
   });
 
   it("repairs tool-result pairing after context engine assembly", async () => {
@@ -2398,7 +2400,10 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expect(projectAgentRunAttemptTerminal(result.terminal).promptErrorSource).toBeNull();
     expect(result.preflightRecovery).toBeUndefined();
     expect(hoisted.preemptiveCompactionCalls).toHaveLength(1);
-    expect(hoisted.preemptiveCompactionCalls.at(-1)).toHaveProperty("unwindowedMessages");
+    expect(hoisted.preemptiveCompactionCalls.at(-1)?.unwindowedMessages).toEqual([
+      expect.objectContaining({ role: "user", content: expect.stringContaining(hugeHistory) }),
+    ]);
+    expect(result.contextBudgetStatus?.overflowTokens).toBeGreaterThan(0);
   });
 
   it("submits owning context-engine preassembly pressure to the provider once", async () => {
@@ -2441,7 +2446,10 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expect(projectAgentRunAttemptTerminal(result.terminal).promptErrorSource).toBeNull();
     expect(result.preflightRecovery).toBeUndefined();
     expect(hoisted.preemptiveCompactionCalls).toHaveLength(1);
-    expect(hoisted.preemptiveCompactionCalls.at(-1)).toHaveProperty("unwindowedMessages");
+    expect(hoisted.preemptiveCompactionCalls.at(-1)?.unwindowedMessages).toEqual([
+      expect.objectContaining({ role: "user", content: expect.stringContaining(hugeHistory) }),
+    ]);
+    expect(result.contextBudgetStatus?.overflowTokens).toBeGreaterThan(0);
   });
 
   it("snapshots pre-assembly messages before assemble even when the engine windows in place", async () => {

--- a/src/agents/embedded-agent-runner/run/compaction-runtime.ts
+++ b/src/agents/embedded-agent-runner/run/compaction-runtime.ts
@@ -90,6 +90,7 @@ export async function compactEmbeddedRunForRecovery(
       clientCaps: runParams.clientCaps,
       chatType: runParams.chatType,
       agentAccountId: runParams.agentAccountId,
+      conversationRoutePeerId: runParams.conversationRoutePeerId,
       currentChannelId: runParams.currentChannelId,
       currentThreadTs: runParams.currentThreadTs,
       currentMessageId: runParams.currentMessageId,

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -114,6 +114,8 @@ export type RunEmbeddedAgentParams = {
   toolBindings?: Readonly<Record<string, unknown>>;
   chatType?: ChatType;
   agentAccountId?: string;
+  /** Raw peer observed by the inbound routing owner, before identity linking. */
+  conversationRoutePeerId?: string;
   /** What initiated this agent run: "user", "heartbeat", "cron", "memory", "overflow", or "manual". */
   trigger?: EmbeddedRunTrigger;
   /** Stable cron job identifier populated for cron-triggered runs. */

--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.replay.test.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.replay.test.ts
@@ -1,0 +1,92 @@
+import { captureOpenAIResponsesCompaction } from "@openclaw/ai/transports";
+import type { AssistantMessage, Model } from "@openclaw/llm-core";
+import { describe, expect, it } from "vitest";
+import { testing } from "../../openai-transport-stream.test-support.js";
+import type { AgentMessage } from "../../runtime/index.js";
+import { estimateLlmBoundaryTokenPressure } from "./preemptive-compaction.js";
+
+const model = {
+  id: "gpt-5.6-luna",
+  name: "GPT-5.6 Luna",
+  api: "openai-responses",
+  provider: "openai",
+  baseUrl: "https://api.openai.com/v1",
+  reasoning: true,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 100_000,
+  maxTokens: 8_192,
+} satisfies Model;
+const identity = { sessionId: "session-a", authProfileId: "profile-a" };
+
+function assistant(totalTokens: number): AssistantMessage {
+  return {
+    role: "assistant",
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    content: [{ type: "text", text: "covered assistant" }],
+    timestamp: 2,
+    stopReason: "stop",
+    usage: {
+      input: totalTokens - 1,
+      output: 1,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens,
+      contextUsage: { state: "available", promptTokens: totalTokens - 1, totalTokens },
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+  };
+}
+
+function checkpoint(text: string): AssistantMessage {
+  const owner = assistant(90_000);
+  const item = { type: "compaction" as const, id: "cmp_pressure", encrypted_content: "opaque" };
+  captureOpenAIResponsesCompaction(
+    owner,
+    item,
+    "retained-users",
+    model,
+    testing.buildOpenAIResponsesReasoningReplayMetadata(model, identity),
+    [{ type: "message", role: "user", content: [{ type: "input_text", text }] }, item],
+  );
+  return owner;
+}
+
+function pressure(messages: AgentMessage[]) {
+  return estimateLlmBoundaryTokenPressure({
+    messages,
+    prompt: "new turn",
+    replay: { model, ...identity },
+  });
+}
+
+describe("provider checkpoint prompt pressure", () => {
+  it("counts the canonical window once instead of covered text or stale owner usage", () => {
+    const owner = checkpoint("small canonical window");
+    const tail: AgentMessage[] = [{ role: "user", content: "follow-up", timestamp: 3 }];
+    const canonicalPressure = pressure([owner, ...tail]);
+    const withCoveredRaw = pressure([
+      { role: "user", content: "covered raw text ".repeat(20_000), timestamp: 1 },
+      owner,
+      ...tail,
+    ]);
+    expect(canonicalPressure).toBeLessThan(1_000);
+    expect(withCoveredRaw).toBe(canonicalPressure);
+    expect(pressure([checkpoint("retained content ".repeat(8_000)), ...tail])).toBeGreaterThan(
+      20_000,
+    );
+  });
+
+  it("counts the window once without attributing unbound later usage to its prefix", () => {
+    const owner = checkpoint("retained content ".repeat(8_000));
+    const response = assistant(100);
+    response.timestamp = 4;
+    const tail: AgentMessage[] = [{ role: "user", content: "follow-up", timestamp: 3 }, response];
+    const measuredPressure = pressure([owner, ...tail]);
+    expect(measuredPressure).toBeGreaterThan(20_000);
+    delete response.usage.contextUsage;
+    expect(pressure([owner, ...tail])).toBe(measuredPressure);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
@@ -1,6 +1,8 @@
 /**
  * Estimates prompt pressure and decides pre-prompt compaction routing.
  */
+import { resolveCompactionReplayPressure } from "@openclaw/ai/transports";
+import type { Model } from "@openclaw/llm-core";
 import { estimateStringChars } from "@openclaw/normalization-core/cjk-chars";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { SessionContextBudgetStatus } from "../../../config/sessions.js";
@@ -29,8 +31,7 @@ const MESSAGE_BOUNDARY_OVERHEAD_TOKENS = 12;
 const CONTENT_BLOCK_OVERHEAD_TOKENS = 6;
 const TRUNCATION_ROUTE_BUFFER_TOKENS = 512;
 
-/** Pre-prompt routing decision plus the budget facts used to explain it in logs and session state. */
-export type PreemptiveCompactionDecision = {
+type CompactionPressureDecision = {
   route: PreemptiveCompactionRoute;
   shouldCompact: boolean;
   estimatedPromptTokens: number;
@@ -39,6 +40,18 @@ export type PreemptiveCompactionDecision = {
   overflowTokens: number;
   toolResultReducibleChars: number;
   effectiveReserveTokens: number;
+};
+
+/** Diagnostic maximum plus the independently selected outgoing checkpoint's budget. */
+export type PreemptiveCompactionDecision = CompactionPressureDecision & {
+  compactionReplay?: CompactionPressureDecision;
+};
+
+export type CompactionReplayPressureContext = {
+  model: Model;
+  sessionId?: string;
+  authProfileId?: string;
+  enabled?: boolean;
 };
 
 /** Token pressure reported by the rendered provider-boundary prompt when available. */
@@ -230,7 +243,9 @@ function estimateRenderedPromptTokens(params: { systemPrompt?: string; prompt: s
 
 type TranscriptBoundaryTokenPressure = {
   estimatedPromptTokens: number;
-  source: "provider_context_usage" | "transcript_estimate";
+  source: "provider_context_usage" | "transcript_estimate" | "provider_compaction_estimate";
+  messages: AgentMessage[];
+  hasCompactionReplay: boolean;
 };
 
 function isProviderContextUsageBarrier(message: AgentMessage): boolean {
@@ -270,21 +285,34 @@ function estimateTranscriptBoundaryTokenPressure(params: {
   messages: AgentMessage[];
   systemPrompt?: string;
   prompt: string;
+  replay?: CompactionReplayPressureContext;
 }): TranscriptBoundaryTokenPressure {
-  const boundary = resolveProviderContextBoundary(params.messages);
+  const replay = params.replay
+    ? resolveCompactionReplayPressure(params.messages, params.replay.model, params.replay, {
+        text: estimateStringTokenPressure,
+        image: () => IMAGE_BLOCK_TOKENS,
+        json: estimateJsonPayloadTokenPressure,
+      })
+    : undefined;
+  const messages = replay?.messages ?? params.messages;
+  const boundary = resolveProviderContextBoundary(messages);
   // The provider total owns transcript items through its assistant record. It has
   // no system-prompt provenance, so the current rendered prompt stays local too.
-  const messagesForPressure = boundary
-    ? params.messages.slice(boundary.index + 1)
-    : params.messages;
+  const messagesForPressure = boundary ? messages.slice(boundary.index + 1) : messages;
   const locallyEstimatedTokens = messagesForPressure.reduce(
     (sum, message) => sum + estimateMessageTokenPressure(message),
-    estimateRenderedPromptTokens(params),
+    estimateRenderedPromptTokens(params) + (boundary ? 0 : (replay?.prefixTokens ?? 0)),
   );
   return {
     estimatedPromptTokens:
       (boundary?.totalTokens ?? 0) + Math.ceil(locallyEstimatedTokens * SAFETY_MARGIN),
-    source: boundary ? "provider_context_usage" : "transcript_estimate",
+    source: boundary
+      ? "provider_context_usage"
+      : replay
+        ? "provider_compaction_estimate"
+        : "transcript_estimate",
+    messages,
+    hasCompactionReplay: Boolean(replay),
   };
 }
 
@@ -292,6 +320,7 @@ export function estimateLlmBoundaryTokenPressure(params: {
   messages: AgentMessage[];
   systemPrompt?: string;
   prompt: string;
+  replay?: CompactionReplayPressureContext;
 }): number {
   return estimateTranscriptBoundaryTokenPressure(params).estimatedPromptTokens;
 }
@@ -334,36 +363,68 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
   reserveTokens: number;
   toolResultMaxChars?: number;
   llmBoundaryTokenPressure?: LlmBoundaryTokenPressure;
+  replay?: CompactionReplayPressureContext;
 }): PreemptiveCompactionDecision {
-  let messagesForPressure = params.messages;
   const llmBoundaryTokenPressure = normalizeLlmBoundaryTokenPressure(
     params.llmBoundaryTokenPressure,
   );
-  const transcriptTokenPressure = llmBoundaryTokenPressure
+  const transcriptTokenPressure =
+    llmBoundaryTokenPressure && !params.replay
+      ? undefined
+      : estimateTranscriptBoundaryTokenPressure({
+          messages: params.messages,
+          systemPrompt: params.systemPrompt,
+          prompt: params.prompt,
+          replay: params.replay,
+        });
+  // The selected provider window owns its covered prefix, including when a
+  // context engine supplied an estimate of the raw transcript instead.
+  const boundaryPressure = transcriptTokenPressure?.hasCompactionReplay
     ? undefined
-    : estimateTranscriptBoundaryTokenPressure({
-        messages: params.messages,
-        systemPrompt: params.systemPrompt,
-        prompt: params.prompt,
-      });
-  let estimatedPromptTokens =
-    llmBoundaryTokenPressure?.estimatedPromptTokens ??
-    transcriptTokenPressure?.estimatedPromptTokens ??
-    0;
-  let pressureSource =
-    llmBoundaryTokenPressure?.source ?? transcriptTokenPressure?.source ?? "transcript_estimate";
+    : llmBoundaryTokenPressure;
+  const outgoingDecision = resolveCompactionPressureDecision(
+    {
+      messages: transcriptTokenPressure?.messages ?? params.messages,
+      estimatedPromptTokens:
+        boundaryPressure?.estimatedPromptTokens ??
+        transcriptTokenPressure?.estimatedPromptTokens ??
+        0,
+      source: boundaryPressure?.source ?? transcriptTokenPressure?.source ?? "transcript_estimate",
+    },
+    params,
+  );
+  let diagnosticDecision = outgoingDecision;
   if (params.unwindowedMessages && params.unwindowedMessages !== params.messages) {
     const unwindowedTokenPressure = estimateTranscriptBoundaryTokenPressure({
       messages: params.unwindowedMessages,
       systemPrompt: params.systemPrompt,
       prompt: params.prompt,
     });
-    if (unwindowedTokenPressure.estimatedPromptTokens > estimatedPromptTokens) {
-      estimatedPromptTokens = unwindowedTokenPressure.estimatedPromptTokens;
-      messagesForPressure = params.unwindowedMessages;
-      pressureSource = `unwindowed_${unwindowedTokenPressure.source}`;
+    // Unwindowed history is diagnostic: neither its checkpoints nor its larger
+    // raw estimate may authorize recovery of a different outgoing window.
+    if (unwindowedTokenPressure.estimatedPromptTokens > outgoingDecision.estimatedPromptTokens) {
+      diagnosticDecision = resolveCompactionPressureDecision(
+        {
+          ...unwindowedTokenPressure,
+          source: `unwindowed_${unwindowedTokenPressure.source}`,
+        },
+        params,
+      );
     }
   }
+  return {
+    ...diagnosticDecision,
+    ...(transcriptTokenPressure?.hasCompactionReplay ? { compactionReplay: outgoingDecision } : {}),
+  };
+}
+
+function resolveCompactionPressureDecision(
+  pressure: Pick<TranscriptBoundaryTokenPressure, "messages" | "estimatedPromptTokens"> & {
+    source: string;
+  },
+  params: { contextTokenBudget: number; reserveTokens: number; toolResultMaxChars?: number },
+): CompactionPressureDecision {
+  const { estimatedPromptTokens } = pressure;
   const contextTokenBudget = Math.max(1, Math.floor(params.contextTokenBudget));
   const effectiveReserveTokens = resolveEffectiveCompactionReserveTokens({
     contextTokenBudget,
@@ -372,7 +433,7 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
   const promptBudgetBeforeReserve = Math.max(1, contextTokenBudget - effectiveReserveTokens);
   const overflowTokens = Math.max(0, estimatedPromptTokens - promptBudgetBeforeReserve);
   const toolResultPotential = estimateToolResultReductionPotential({
-    messages: messagesForPressure,
+    messages: pressure.messages,
     contextWindowTokens: params.contextTokenBudget,
     maxCharsOverride: params.toolResultMaxChars,
   });
@@ -399,7 +460,7 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
     route,
     shouldCompact: route === "compact_only" || route === "compact_then_truncate",
     estimatedPromptTokens,
-    pressureSource,
+    pressureSource: pressure.source,
     promptBudgetBeforeReserve,
     overflowTokens,
     toolResultReducibleChars,

--- a/src/agents/embedded-agent-runner/run/prompt-failure.test.ts
+++ b/src/agents/embedded-agent-runner/run/prompt-failure.test.ts
@@ -85,6 +85,7 @@ describe("handleEmbeddedPromptFailure", () => {
         },
       });
       expect(recoveryText).toContain("/compact");
+      // oxlint-disable-next-line unicorn/prefer-structured-clone -- Verify JSON transport serialization, not an in-memory clone.
       expect(JSON.parse(JSON.stringify(outcome))).toMatchObject({
         result: { payloads: [{ text: recoveryText, isError: true }] },
       });

--- a/src/agents/embedded-agent-runner/run/prompt-failure.test.ts
+++ b/src/agents/embedded-agent-runner/run/prompt-failure.test.ts
@@ -1,4 +1,4 @@
-// Prompt failure tests cover retry composition around profile rotation.
+import { CompactionReplayRefreshRequiredError } from "@openclaw/ai/transports";
 import { describe, expect, it, vi } from "vitest";
 import { handleEmbeddedPromptFailure } from "./prompt-failure.js";
 
@@ -60,6 +60,88 @@ function makeParams(overrides: Partial<Params> = {}): Params {
 }
 
 describe("handleEmbeddedPromptFailure", () => {
+  it.each([false, true])(
+    "surfaces trusted checkpoint recovery without provider failover (altered message: %s)",
+    async (alteredMessage) => {
+      const promptError = new CompactionReplayRefreshRequiredError();
+      const recoveryText = promptError.message;
+      if (alteredMessage) {
+        promptError.message = "untrusted provider detail: rate limit exceeded";
+      }
+      const params = makeParams({ promptError, promptErrorSource: "precheck" });
+
+      const outcome = await handleEmbeddedPromptFailure(params);
+
+      expect(outcome).toMatchObject({
+        action: "complete",
+        result: {
+          payloads: [{ text: recoveryText, isError: true }],
+          meta: {
+            finalAssistantVisibleText: recoveryText,
+            finalAssistantRawText: recoveryText,
+            livenessState: "blocked",
+            error: { kind: "compaction_replay_refresh_required", message: recoveryText },
+          },
+        },
+      });
+      expect(recoveryText).toContain("/compact");
+      expect(JSON.parse(JSON.stringify(outcome))).toMatchObject({
+        result: { payloads: [{ text: recoveryText, isError: true }] },
+      });
+      expect(JSON.stringify(outcome)).not.toContain("untrusted provider detail");
+      expect(params.setTerminalLifecycleMeta).toHaveBeenCalledWith({
+        replayInvalid: false,
+        livenessState: "blocked",
+      });
+      for (const callback of [
+        params.maybeRefreshRuntimeAuthForAuthError,
+        params.suspendForFailure,
+        params.resolveAuthProfileFailureReason,
+        params.advanceAuthProfile,
+        params.advanceRateLimitAuthProfile,
+        params.maybeMarkAuthProfileFailure,
+        params.maybeBackoffBeforeOverloadFailover,
+      ]) {
+        expect(callback).not.toHaveBeenCalled();
+      }
+      expect(params.traceAttempts).toEqual([]);
+    },
+  );
+
+  it.each([
+    ["plain error", new Error(new CompactionReplayRefreshRequiredError().message), "precheck"],
+    [
+      "spoofed error name",
+      Object.assign(new Error(new CompactionReplayRefreshRequiredError().message), {
+        name: "CompactionReplayRefreshRequiredError",
+      }),
+      "precheck",
+    ],
+    [
+      "serialized error",
+      {
+        name: "CompactionReplayRefreshRequiredError",
+        message: new CompactionReplayRefreshRequiredError().message,
+      },
+      "precheck",
+    ],
+    ["provider error", new CompactionReplayRefreshRequiredError(), "prompt"],
+  ] satisfies Array<[string, unknown, Params["promptErrorSource"]]>)(
+    "does not trust %s as local checkpoint recovery",
+    async (_label, promptError, promptErrorSource) => {
+      const params = makeParams({
+        promptError,
+        promptErrorSource,
+        resolveAuthProfileFailureReason: vi.fn(() => null),
+      });
+
+      await expect(handleEmbeddedPromptFailure(params)).rejects.toBeInstanceOf(Error);
+
+      expect(params.setTerminalLifecycleMeta).not.toHaveBeenCalled();
+      expect(params.maybeRefreshRuntimeAuthForAuthError).toHaveBeenCalledOnce();
+    },
+  );
+
   it("returns the profile-rotation retry before failure marking finishes", async () => {
     const events: string[] = [];
     let releaseMark: (() => void) | undefined;

--- a/src/agents/embedded-agent-runner/run/prompt-failure.ts
+++ b/src/agents/embedded-agent-runner/run/prompt-failure.ts
@@ -1,3 +1,4 @@
+import { CompactionReplayRefreshRequiredError } from "@openclaw/ai/transports";
 import type { ThinkLevel } from "../../../auto-reply/thinking.js";
 import { formatErrorMessage, toErrorObject } from "../../../infra/errors.js";
 import type { AgentRunAttemptFailureSource } from "../../agent-run-terminal-outcome.js";
@@ -86,6 +87,18 @@ export async function handleEmbeddedPromptFailure(input: {
   traceAttempts: TraceAttempt[];
   previousRetryFailoverReason: FailoverReason | null;
 }): Promise<PromptFailureOutcome> {
+  // Only the local precheck owns this recovery; provider text cannot request it.
+  if (
+    input.promptErrorSource === "precheck" &&
+    input.promptError instanceof CompactionReplayRefreshRequiredError
+  ) {
+    const text = new CompactionReplayRefreshRequiredError().message;
+    return completeBlockedPromptFailure(input, {
+      text,
+      errorKind: "compaction_replay_refresh_required",
+      errorMessage: text,
+    });
+  }
   const promptAuthMode = input.authProfileId
     ? input.authProfileStore.profiles?.[input.authProfileId]?.type
     : undefined;
@@ -122,7 +135,7 @@ export async function handleEmbeddedPromptFailure(input: {
 
   const blockedResult = resolveBlockedPromptResult(input, errorText);
   if (blockedResult) {
-    return { action: "complete", result: blockedResult };
+    return blockedResult;
   }
 
   const promptFailoverReason =
@@ -297,7 +310,7 @@ export async function handleEmbeddedPromptFailure(input: {
 function resolveBlockedPromptResult(
   input: Parameters<typeof handleEmbeddedPromptFailure>[0],
   errorText: string,
-): EmbeddedAgentRunResult | undefined {
+): PromptFailureOutcome | undefined {
   let text: string;
   let errorKind: "role_ordering" | "image_size";
   if (/incorrect role information|roles must alternate/i.test(errorText)) {
@@ -318,16 +331,27 @@ function resolveBlockedPromptResult(
       "Please compress or resize the image and try again.";
     errorKind = "image_size";
   }
+  return completeBlockedPromptFailure(input, { text, errorKind, errorMessage: errorText });
+}
+
+function completeBlockedPromptFailure(
+  input: Parameters<typeof handleEmbeddedPromptFailure>[0],
+  copy: Pick<
+    Parameters<typeof buildEmbeddedRunBlockedResult>[0],
+    "text" | "errorKind" | "errorMessage"
+  >,
+): PromptFailureOutcome {
   const replayInvalid = input.resolveReplayInvalid();
   input.setTerminalLifecycleMeta({ replayInvalid, livenessState: "blocked" });
-  return buildEmbeddedRunBlockedResult({
-    text,
-    errorKind,
-    errorMessage: errorText,
-    durationMs: Date.now() - input.startedAtMs,
-    agentMeta: input.buildErrorAgentMeta(),
-    attempt: input.attempt,
-    replayInvalid,
-    finalPromptText: input.attempt.finalPromptText,
-  });
+  return {
+    action: "complete",
+    result: buildEmbeddedRunBlockedResult({
+      ...copy,
+      durationMs: Date.now() - input.startedAtMs,
+      agentMeta: input.buildErrorAgentMeta(),
+      attempt: input.attempt,
+      replayInvalid,
+      finalPromptText: input.attempt.finalPromptText,
+    }),
+  };
 }

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
@@ -291,6 +291,7 @@ export async function dispatchEmbeddedRunAttempt(input: {
     githubPublicationAvailable: params.githubPublicationAvailable,
     chatType: params.chatType,
     agentAccountId: params.agentAccountId,
+    conversationRoutePeerId: params.conversationRoutePeerId,
     messageTo: params.messageTo,
     messageThreadId: params.messageThreadId,
     conversationToolPolicy: params.conversationToolPolicy,

--- a/src/agents/embedded-agent-runner/server-endpoint-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/server-endpoint-compaction.test.ts
@@ -12,6 +12,7 @@ vi.mock("@openclaw/ai/transports", async (importOriginal) => ({
   requestPreparedOpenAIResponsesCompaction: requestPreparedCompactionMock,
 }));
 
+import { testing } from "../openai-transport-stream.test-support.js";
 import { attemptServerEndpointCompaction } from "./server-endpoint-compaction.js";
 
 const model = {
@@ -75,17 +76,16 @@ beforeEach(() => {
   requestPreparedCompactionMock.mockReset();
   requestPreparedCompactionMock.mockResolvedValue({
     item: { type: "compaction", id: "cmp_test", encrypted_content: "opaque" },
+    output: [
+      { type: "message", role: "user", content: [{ type: "input_text", text: "remember copper" }] },
+      { type: "compaction", id: "cmp_test", encrypted_content: "opaque" },
+    ],
     historyMode: "retained-users",
     usage: { input_tokens: 1_000, output_tokens: 200, dropped_message_count: 1 },
     model,
-    replayMetadata: {
-      v: 1,
-      source: "openai-responses",
-      provider: "xai",
-      api: "openai-responses",
-      model: "grok-4.5",
-      baseUrlHash: "test-base-url",
-    },
+    replayMetadata: testing.buildOpenAIResponsesReasoningReplayMetadata(model, {
+      sessionId: "session-1",
+    }),
   });
 });
 
@@ -108,6 +108,17 @@ describe("attemptServerEndpointCompaction", () => {
       type: "openai-responses-retained-compaction",
       id: "cmp_test",
       data: "opaque",
+      compactedWindow: {
+        state: "ready",
+        output: JSON.stringify([
+          {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "remember copper" }],
+          },
+          { type: "compaction", id: "cmp_test", encrypted_content: "opaque" },
+        ]),
+      },
     });
     expect(owner.message.providerReplay).not.toHaveProperty("replayIndex");
   });
@@ -115,17 +126,13 @@ describe("attemptServerEndpointCompaction", () => {
   it("marks a checkpoint-only response at the assistant content boundary", async () => {
     requestPreparedCompactionMock.mockResolvedValueOnce({
       item: { type: "compaction", id: "cmp_test", encrypted_content: "opaque" },
+      output: [{ type: "compaction", id: "cmp_test", encrypted_content: "opaque" }],
       historyMode: "compacted-prefix",
       usage: { input_tokens: 1_000, output_tokens: 200 },
       model,
-      replayMetadata: {
-        v: 1,
-        source: "openai-responses",
-        provider: "xai",
-        api: "openai-responses",
-        model: "grok-4.5",
-        baseUrlHash: "test-base-url",
-      },
+      replayMetadata: testing.buildOpenAIResponsesReasoningReplayMetadata(model, {
+        sessionId: "session-1",
+      }),
     });
     const { session, result } = attempt();
 
@@ -168,6 +175,19 @@ describe("attemptServerEndpointCompaction", () => {
 
     await expect(result).resolves.toBeUndefined();
     expect(requestAborted).toBe(true);
+  });
+
+  it("leaves the durable transcript intact when policy would redact the canonical window", async () => {
+    const session = createSession();
+    const before = structuredClone(session.sessionManager.getBranch());
+    const { result } = attempt({
+      sessionManager: session.sessionManager,
+      context: { systemPrompt: "system", messages: session.messages },
+      config: { logging: { redactPatterns: ["remember copper"] } },
+    });
+
+    await expect(result).resolves.toBeUndefined();
+    expect(session.sessionManager.getBranch()).toEqual(before);
   });
 
   it("does not call the endpoint during overflow recovery", async () => {

--- a/src/agents/embedded-agent-runner/server-endpoint-compaction.ts
+++ b/src/agents/embedded-agent-runner/server-endpoint-compaction.ts
@@ -1,11 +1,15 @@
+import { isDeepStrictEqual } from "node:util";
 import {
   captureOpenAIResponsesCompaction,
   requestPreparedOpenAIResponsesCompaction,
+  requiresCompactionReplayRefresh,
   resolveOpenAIResponsesCompactEndpointPlan,
 } from "@openclaw/ai/transports";
 import type { Message } from "@openclaw/llm-core";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type { AgentMessage } from "../runtime/index.js";
+import { redactTranscriptMessage } from "../transcript-redact.js";
 import { compactWithSafetyTimeout } from "./compaction-safety-timeout.js";
 import { log } from "./logger.js";
 import { rewriteTranscriptEntriesInSessionManager } from "./transcript-rewrite.js";
@@ -28,6 +32,7 @@ export async function attemptServerEndpointCompaction(params: {
   extraParams: Record<string, unknown>;
   requestOptions: Parameters<typeof requestPreparedOpenAIResponsesCompaction>[3];
   customInstructions?: string;
+  config?: OpenClawConfig;
 }): Promise<ServerEndpointCompactionResult | undefined> {
   if (
     params.trigger === "overflow" ||
@@ -42,6 +47,11 @@ export async function attemptServerEndpointCompaction(params: {
         message.role === "user" || message.role === "assistant" || message.role === "toolResult",
     );
     if (messages.at(-1)?.role !== "assistant") {
+      return undefined;
+    }
+    if (requiresCompactionReplayRefresh(messages, params.model, params.requestOptions)) {
+      // The exact old window is gone. Only the durable full-history client
+      // compactor can rebuild it; recent-turn endpoint input cannot.
       return undefined;
     }
     const owner = params.sessionManager
@@ -68,10 +78,18 @@ export async function attemptServerEndpointCompaction(params: {
       compacted.historyMode === "retained-users" ? "retained-users" : replacement.content.length,
       compacted.model,
       compacted.replayMetadata,
+      compacted.output,
     );
+    const redacted = redactTranscriptMessage(replacement, params.config);
+    if (
+      redacted.role !== "assistant" ||
+      !isDeepStrictEqual(redacted.providerReplay, replacement.providerReplay)
+    ) {
+      throw new Error("Responses compact endpoint window requires transcript redaction");
+    }
     const rewritten = rewriteTranscriptEntriesInSessionManager({
       sessionManager: params.sessionManager,
-      replacements: [{ entryId: owner.id, message: replacement }],
+      replacements: [{ entryId: owner.id, message: redacted }],
       preserveReplacementCompactionReplay: true,
     });
     if (

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.ts
@@ -11,7 +11,10 @@ import type { AgentMessage } from "../runtime/index.js";
 import { formatContextLimitTruncationNotice } from "./context-truncation-notice.js";
 import { log } from "./logger.js";
 import { MidTurnPrecheckSignal, type MidTurnPrecheckRequest } from "./run/midturn-precheck.js";
-import { shouldPreemptivelyCompactBeforePrompt } from "./run/preemptive-compaction.js";
+import {
+  shouldPreemptivelyCompactBeforePrompt,
+  type CompactionReplayPressureContext,
+} from "./run/preemptive-compaction.js";
 import {
   TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE,
   type MessageCharEstimateCache,
@@ -37,6 +40,7 @@ type GuardableAgentRecord = {
 };
 
 type MidTurnPrecheckOptions = {
+  getReplay?: () => CompactionReplayPressureContext;
   enabled?: boolean;
   contextTokenBudget: number;
   reserveTokens: () => number;
@@ -498,6 +502,7 @@ export function installToolResultContextGuard(params: {
         // Recovery re-applies truncation to the persisted session manager, so
         // this precheck is only a routing signal, not the source of truth.
         const precheck = shouldPreemptivelyCompactBeforePrompt({
+          replay: params.midTurnPrecheck.getReplay?.(),
           messages: contextMessages,
           systemPrompt: params.midTurnPrecheck.getSystemPrompt?.(),
           // During a tool loop, the active user prompt is already part of messages.

--- a/src/agents/embedded-agent-runner/transcript-rewrite.test.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.test.ts
@@ -1,12 +1,11 @@
 // Transcript rewrite tests cover in-memory and persisted branch rewrites for
 // tool-result externalization, labels, and compaction markers.
-import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
-import { beforeAll, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { formatSqliteSessionFileMarker } from "../../config/sessions/legacy-sqlite-marker.js";
 import {
   loadTranscriptEvents,
@@ -16,6 +15,7 @@ import type { SessionEntry } from "../../config/sessions/types.js";
 
 let rewriteTranscriptEntriesInSessionManager: typeof import("./transcript-rewrite.js").rewriteTranscriptEntriesInSessionManager;
 let installSessionToolResultGuard: typeof import("../session-tool-result-guard.js").installSessionToolResultGuard;
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 type AppendMessage = Parameters<SessionManager["appendMessage"]>[0];
 
@@ -294,67 +294,101 @@ describe("rewriteTranscriptEntriesInSessionManager", () => {
     expect(replayedAssistant.content).toEqual([{ type: "text", text: "summarized" }]);
   });
 
-  it("preserves original SQLite rows on the abandoned branch", async () => {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-transcript-rewrite-runtime-"));
-    const storePath = path.join(dir, "sessions.json");
-    const sessionId = "runtime-sqlite-branch-rewrite";
-    const sessionKey = "agent:main:test";
-    const sessionFile = formatSqliteSessionFileMarker({
-      agentId: "main",
-      sessionId,
-      storePath,
-    });
-    const target = {
-      agentId: "main",
-      sessionId,
-      sessionKey,
-      storePath,
-    };
-    await replaceSessionEntry({ sessionKey, storePath }, {
-      sessionFile,
-      sessionId,
-      updatedAt: 10,
-    } as SessionEntry);
-    const sessionManager = SessionManager.open(target, dir);
-    const [, toolResultEntryId] = appendSessionMessages(sessionManager, [
-      asAppendMessage({ role: "user", content: "run tool", timestamp: 1 }),
-      asAppendMessage(createToolResultReplacement("exec", "before rewrite", 2)),
-      asAppendMessage({
-        role: "assistant",
-        content: createTextContent("summarized"),
-        timestamp: 3,
-      }),
-    ]);
+  it.each(["unkeyed", "keyed suffix", "keyed replacement"])(
+    "preserves original SQLite rows and the rewritten %s branch",
+    async (variant) => {
+      const dir = tempDirs.make("openclaw-transcript-rewrite-runtime-");
+      const storePath = path.join(dir, "sessions.json");
+      const sessionId = "runtime-sqlite-branch-rewrite";
+      const sessionKey = "agent:main:test";
+      const sessionFile = formatSqliteSessionFileMarker({
+        agentId: "main",
+        sessionId,
+        storePath,
+      });
+      const target = {
+        agentId: "main",
+        sessionId,
+        sessionKey,
+        storePath,
+      };
+      await replaceSessionEntry({ sessionKey, storePath }, {
+        sessionFile,
+        sessionId,
+        updatedAt: 10,
+      } as SessionEntry);
+      const sessionManager = SessionManager.open(target, dir);
+      const keyed = variant !== "unkeyed";
+      appendSessionMessages(sessionManager, [
+        asAppendMessage({ role: "user", content: "run tool", timestamp: 1 }),
+        asAppendMessage(createToolResultReplacement("exec", "before rewrite", 2)),
+        ...(keyed
+          ? [
+              asAppendMessage({
+                role: "user",
+                content: "keep this later turn",
+                idempotencyKey: "rewrite-later-user",
+                timestamp: 3,
+              }),
+            ]
+          : []),
+        asAppendMessage({
+          role: "assistant",
+          content: createTextContent("summarized"),
+          timestamp: 4,
+        }),
+      ]);
+      const originalBranch = sessionManager.getBranch();
+      const originalRows = await loadTranscriptEvents(target);
+      const replacementIndex = variant === "keyed replacement" ? 2 : 1;
+      const originalEntry = originalBranch[replacementIndex];
+      if (originalEntry?.type !== "message") {
+        throw new Error("expected a persisted rewrite target");
+      }
+      let replacement = createToolResultReplacement("exec", "[runtime rewrite]", 2);
+      if (variant === "keyed replacement") {
+        if (originalEntry.message.role !== "user") {
+          throw new Error("expected a keyed user replacement");
+        }
+        replacement = { ...originalEntry.message, content: "rewritten later turn" };
+      }
 
-    const result = rewriteTranscriptEntriesInSessionManager({
-      sessionManager,
-      replacements: [
-        {
-          entryId: expectDefined(toolResultEntryId, "persisted tool result entry id"),
-          message: createToolResultReplacement("exec", "[runtime rewrite]", 2),
-        },
-      ],
-    });
+      const result = rewriteTranscriptEntriesInSessionManager({
+        sessionManager,
+        replacements: [
+          {
+            entryId: originalEntry.id,
+            message: replacement,
+          },
+        ],
+      });
 
-    expect(result.changed).toBe(true);
-    const storedEvents = await loadTranscriptEvents(target);
-    const original = storedEvents.find(
-      (entry) =>
-        typeof entry === "object" &&
-        entry !== null &&
-        "id" in entry &&
-        entry.id === toolResultEntryId,
-    ) as { message?: AgentMessage } | undefined;
-    expect(original?.message).toEqual(createToolResultReplacement("exec", "before rewrite", 2));
-
-    const activeMessages = getBranchMessages(SessionManager.open(target, dir));
-    expect(activeMessages.map((message) => message.role)).toEqual([
-      "user",
-      "toolResult",
-      "assistant",
-    ]);
-    expect((activeMessages[1] as Extract<AgentMessage, { role: "toolResult" }>).content).toEqual([
-      { type: "text", text: "[runtime rewrite]" },
-    ]);
-  });
+      expect(result.changed).toBe(true);
+      const storedEvents = await loadTranscriptEvents(target);
+      expect(storedEvents.slice(0, originalRows.length)).toEqual(originalRows);
+      expect(storedEvents).toHaveLength(
+        originalRows.length + originalBranch.length - replacementIndex,
+      );
+      const reopened = SessionManager.open(target, dir);
+      const activeBranch = reopened.getBranch();
+      expect(getBranchMessages(reopened)).toEqual(
+        originalBranch.flatMap((entry, index) =>
+          entry.type === "message"
+            ? [index === replacementIndex ? replacement : entry.message]
+            : [],
+        ),
+      );
+      expect(activeBranch.slice(0, replacementIndex)).toEqual(
+        originalBranch.slice(0, replacementIndex),
+      );
+      const originalIds = new Set(originalBranch.map((entry) => entry.id));
+      for (const [index, entry] of activeBranch.entries()) {
+        expect(entry.parentId).toBe(activeBranch[index - 1]?.id ?? null);
+        if (index >= replacementIndex) {
+          expect(originalIds.has(entry.id)).toBe(false);
+        }
+      }
+      expect(reopened.getLeafId()).toBe(activeBranch.at(-1)?.id);
+    },
+  );
 });

--- a/src/agents/embedded-agent-runner/transcript-rewrite.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.ts
@@ -185,7 +185,10 @@ export function rewriteTranscriptEntriesInSessionManager(params: {
 
   // Maintenance rewrites should preserve the exact requested history without
   // re-running persistence hooks or size truncation on replayed messages.
-  const appendMessage = getRawSessionAppendMessage(params.sessionManager);
+  const rawAppendMessage = getRawSessionAppendMessage(params.sessionManager);
+  // Deliberate copies retain ingress keys without adopting their old branch entries.
+  const appendMessage: SessionManagerLike["appendMessage"] = (message) =>
+    rawAppendMessage(message, { idempotencyLookup: "caller-checked" });
   const rewrittenEntryIds = new Map<string, string>();
   // Every re-appended message follows the rewritten prefix, so its prefix-bound checkpoint is stale.
   for (const entry of branch.slice(firstMatchedIndex)) {

--- a/src/agents/embedded-agent-runner/types.ts
+++ b/src/agents/embedded-agent-runner/types.ts
@@ -205,6 +205,7 @@ export type EmbeddedAgentRunMeta = {
     kind:
       | "context_overflow"
       | "compaction_failure"
+      | "compaction_replay_refresh_required"
       | "role_ordering"
       | "image_size"
       | "retry_limit"

--- a/src/agents/sessions/agent-session-inspection.ts
+++ b/src/agents/sessions/agent-session-inspection.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
+import { isCompactionReplayCheckpoint } from "@openclaw/ai/transports";
 import { CURRENT_SESSION_VERSION } from "../../config/sessions/version.js";
 import { calculateContextTokens, estimateContextTokens } from "../runtime/index.js";
 import { AgentSessionModels } from "./agent-session-models.js";
@@ -89,16 +90,31 @@ export abstract class AgentSessionInspection extends AgentSessionModels {
     // If no such assistant exists, context token count is unknown until the next LLM response.
     const branchEntries = this.sessionManager.getBranch();
     const latestCompaction = getLatestCompactionEntry(branchEntries);
+    const providerCheckpointIndex = branchEntries.findLastIndex(
+      (entry) =>
+        entry.type === "message" &&
+        entry.message.role === "assistant" &&
+        isCompactionReplayCheckpoint(entry.message.providerReplay),
+    );
+    const clientCompactionIndex = latestCompaction
+      ? branchEntries.lastIndexOf(latestCompaction)
+      : -1;
+    const compactionIndex = Math.max(clientCompactionIndex, providerCheckpointIndex);
+    const providerCheckpoint = providerCheckpointIndex > clientCompactionIndex;
     let estimateFromContent = false;
 
-    if (latestCompaction) {
+    if (compactionIndex >= 0) {
       // Check if there's a valid assistant usage after the compaction boundary
-      const compactionIndex = branchEntries.lastIndexOf(latestCompaction);
       let hasPostCompactionUsage = false;
       for (const entry of branchEntries.slice(compactionIndex + 1).toReversed()) {
         if (entry.type === "message" && entry.message.role === "assistant") {
           const assistant = entry.message;
           if (assistant.stopReason !== "aborted" && assistant.stopReason !== "error") {
+            // Inspection has no prepared auth identity to select replay content.
+            // Stay unknown until a later provider measurement owns that window.
+            if (providerCheckpoint && assistant.usage.contextUsage?.state !== "available") {
+              continue;
+            }
             if (assistant.usage.contextUsage?.state === "unavailable") {
               estimateFromContent = true;
               continue;
@@ -113,7 +129,7 @@ export abstract class AgentSessionInspection extends AgentSessionModels {
         }
       }
 
-      if (!hasPostCompactionUsage && !estimateFromContent) {
+      if (!hasPostCompactionUsage && (providerCheckpoint || !estimateFromContent)) {
         return { tokens: null, contextWindow, percent: null };
       }
     }

--- a/src/agents/sessions/agent-session.context-usage.test.ts
+++ b/src/agents/sessions/agent-session.context-usage.test.ts
@@ -1,8 +1,50 @@
 import { describe, expect, it } from "vitest";
 import type { AgentMessage } from "../runtime/index.js";
+import { makeAgentAssistantMessage } from "../test-helpers/agent-message-fixtures.js";
 import { AgentSession } from "./agent-session.js";
 
 describe("AgentSession context usage", () => {
+  it("reports unknown usage after a provider checkpoint until a later measured response", () => {
+    const owner = makeAgentAssistantMessage({ content: [{ type: "text", text: "covered" }] });
+    owner.usage = {
+      ...owner.usage,
+      input: 90_000,
+      totalTokens: 90_000,
+      contextUsage: { state: "available", promptTokens: 90_000, totalTokens: 90_000 },
+    };
+    owner.providerReplay = {
+      v: 1,
+      type: "openai-responses-retained-compaction",
+      data: "opaque",
+      provider: owner.provider,
+      api: owner.api,
+      model: owner.model,
+      baseUrlHash: "hash",
+    };
+    const messages: AgentMessage[] = [owner];
+    const branchEntries = [{ type: "message", id: "checkpoint-owner", message: owner }];
+    const session = {
+      model: { contextWindow: 100_000 },
+      messages,
+      sessionManager: { getBranch: () => branchEntries },
+    } as unknown as AgentSession;
+    expect(AgentSession.prototype.getContextUsage.call(session)).toEqual({
+      tokens: null,
+      contextWindow: 100_000,
+      percent: null,
+    });
+    const later = makeAgentAssistantMessage({ content: [{ type: "text", text: "later" }] });
+    later.usage = {
+      ...later.usage,
+      input: 8_000,
+      totalTokens: 8_000,
+      contextUsage: { state: "available", promptTokens: 8_000, totalTokens: 8_000 },
+    };
+    messages.push(later);
+    branchEntries.push({ type: "message", id: "later", message: later });
+    expect(AgentSession.prototype.getContextUsage.call(session)?.tokens).toBe(8_000);
+  });
+
   it("preserves an earlier exact snapshot when unavailable usage precedes any compaction", () => {
     const messages = [
       {

--- a/src/agents/transcript-redact-replay.ts
+++ b/src/agents/transcript-redact-replay.ts
@@ -1,3 +1,4 @@
+import { readOpenAIResponsesCompactionWindow } from "@openclaw/ai/internal/openai-responses-payload-policy";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
 type TranscriptReplayRoute = {
@@ -14,6 +15,7 @@ type TranscriptReplaySanitizerHelpers = {
   isOpenAIResponsesRoute: (route: TranscriptReplayRoute | undefined) => boolean;
   isPlainTranscriptObject: (value: object) => value is Record<string, unknown>;
   isStructurallyValidOpaqueReplayToken: (value: string) => boolean;
+  redactTranscriptStructuredValue: (value: unknown, cfg?: OpenClawConfig) => unknown;
   redactTranscriptText: (value: string, cfg?: OpenClawConfig) => string;
 };
 
@@ -65,6 +67,31 @@ const ANTHROPIC_REPLAY_DESCRIPTOR: TranscriptReplayDescriptor = {
 };
 
 const REPLAY_DESCRIPTORS = [OPENAI_REPLAY_DESCRIPTOR, ANTHROPIC_REPLAY_DESCRIPTOR];
+
+function sanitizeCompactedWindow(
+  replay: { data: string; id?: string; compactedWindow?: unknown },
+  cfg: OpenClawConfig | undefined,
+  helpers: TranscriptReplaySanitizerHelpers,
+) {
+  const window = replay.compactedWindow;
+  const output = readOpenAIResponsesCompactionWindow(replay);
+  const unchanged = output?.every((item) => {
+    if (item.type !== "compaction") {
+      return helpers.redactTranscriptStructuredValue(item, cfg) === item;
+    }
+    // Only the encrypted token is opaque; optional provider fields still pass
+    // through the same plaintext policy as the retained messages.
+    const { encrypted_content: _encrypted, ...plaintext } = item;
+    return helpers.redactTranscriptStructuredValue(plaintext, cfg) === plaintext;
+  });
+  return unchanged &&
+    window &&
+    typeof window === "object" &&
+    helpers.isPlainTranscriptObject(window) &&
+    typeof window.output === "string"
+    ? { state: "ready", output: window.output }
+    : { state: "refresh-required" };
+}
 
 export function sanitizeCompactionReplayState(
   value: unknown,
@@ -122,5 +149,18 @@ export function sanitizeCompactionReplayState(
     baseUrlHash: value.baseUrlHash,
     ...(value.sessionHash !== undefined ? { sessionHash: value.sessionHash } : {}),
     ...(value.authProfileHash !== undefined ? { authProfileHash: value.authProfileHash } : {}),
+    ...(!isSuppression &&
+    descriptor === OPENAI_REPLAY_DESCRIPTOR &&
+    value.compactedWindow !== undefined
+      ? {
+          // Keep the newest fenced barrier when its canonical plaintext cannot
+          // survive redaction; dropping it could expose an older checkpoint.
+          compactedWindow: sanitizeCompactedWindow(
+            { data, id: replayId, compactedWindow: value.compactedWindow },
+            cfg,
+            helpers,
+          ),
+        }
+      : {}),
   };
 }

--- a/src/agents/transcript-redact.test.ts
+++ b/src/agents/transcript-redact.test.ts
@@ -451,6 +451,40 @@ describe("redactTranscriptMessage", () => {
   ] as const)(
     "preserves only validated %s OpenAI compaction replay state",
     (_name, type, replayIndex) => {
+      const compactedWindow = {
+        state: "ready",
+        output: JSON.stringify(
+          [
+            {
+              type: "message",
+              role: "developer",
+              content: [{ type: "input_text", text: "rules" }],
+            },
+            { type: "message", role: "system", content: [{ type: "input_text", text: "context" }] },
+            {
+              type: "message",
+              role: "user",
+              content: [
+                { type: "input_text", text: "retained request" },
+                {
+                  type: "input_image",
+                  detail: "auto",
+                  image_url: `data:image/png;base64,${IMAGE_BASE64_WITH_SECRET_TOKEN_SUBSTRING}`,
+                },
+                { type: "input_file", file_id: "file_document", filename: "document.pdf" },
+              ],
+            },
+            {
+              type: "compaction",
+              id: "cmp_1",
+              encrypted_content: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
+              created_by: "responses",
+            },
+          ],
+          null,
+          2,
+        ),
+      };
       const msg = castAgentMessage({
         role: "assistant",
         api: "openclaw-openai-responses-transport",
@@ -469,6 +503,7 @@ describe("redactTranscriptMessage", () => {
           baseUrlHash: "ozhevd1smnk8s",
           sessionHash: "171dzdv17gum5g",
           authProfileHash: "oe8bkr3r8947",
+          compactedWindow,
           secret: "sk-abcdef1234567890xyz",
         },
       });
@@ -489,8 +524,83 @@ describe("redactTranscriptMessage", () => {
         baseUrlHash: "ozhevd1smnk8s",
         sessionHash: "171dzdv17gum5g",
         authProfileHash: "oe8bkr3r8947",
+        compactedWindow,
       });
       expect(JSON.stringify(result)).not.toContain("sk-abcdef1234567890xyz");
+    },
+  );
+
+  it.each([
+    ["plaintext secret", { type: "input_text", text: "sk-abcdef1234567890xyz" }, {}],
+    ["custom text rule", { type: "input_text", text: "retained-private" }, {}],
+    ["structured secret", { type: "input_text", text: "safe", apiKey: "plainsecretvalue123" }, {}],
+    [
+      "file reference",
+      { type: "input_file", file_url: "https://example.com/retained-private" },
+      {},
+    ],
+    [
+      "image normalization",
+      {
+        type: "input_image",
+        detail: "auto",
+        image_url: `data:image/jpeg;base64,${IMAGE_BASE64_WITH_SECRET_TOKEN_SUBSTRING}`,
+      },
+      {},
+    ],
+    [
+      "compaction metadata",
+      { type: "input_text", text: "safe" },
+      { created_by: "retained-private" },
+    ],
+    [
+      "mismatched opaque item",
+      { type: "input_text", text: "safe" },
+      { encrypted_content: "other-token" },
+    ],
+    ["malformed content", { type: "input_text", text: 42 }, {}],
+  ])(
+    "invalidates the whole canonical window for %s without erasing its replay barrier",
+    (_name, content, itemOverride) => {
+      const providerReplay = {
+        v: 1,
+        type: "openai-responses-retained-compaction",
+        id: "cmp_1",
+        data: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
+        provider: "openai",
+        api: "openai-responses",
+        model: "gpt-5.6-luna",
+        baseUrlHash: "ozhevd1smnk8s",
+        sessionHash: "171dzdv17gum5g",
+        authProfileHash: "oe8bkr3r8947",
+        compactedWindow: {
+          state: "ready",
+          output: JSON.stringify([
+            { type: "message", role: "user", content: [content] },
+            {
+              type: "compaction",
+              id: "cmp_1",
+              encrypted_content: CIPHERTEXT_WITH_TOKEN_SHAPED_BYTES,
+              ...itemOverride,
+            },
+          ]),
+        },
+      };
+      const message = castAgentMessage({
+        role: "assistant",
+        api: "openai-responses",
+        model: "gpt-5.6-luna",
+        provider: "openai",
+        content: [],
+        providerReplay,
+      });
+      const result = redactTranscriptMessage(message, cfg("tools", ["retained-private"]));
+      expect(result).toHaveProperty("providerReplay", {
+        ...providerReplay,
+        compactedWindow: { state: "refresh-required" },
+      });
+      expect(redactTranscriptMessage(result, cfg("tools"))).toEqual(result);
+      expect(message).toHaveProperty("providerReplay.compactedWindow.state", "ready");
     },
   );
 

--- a/src/agents/transcript-redact.ts
+++ b/src/agents/transcript-redact.ts
@@ -243,6 +243,7 @@ const replaySanitizerHelpers = {
   isOpenAIResponsesRoute,
   isPlainTranscriptObject,
   isStructurallyValidOpaqueReplayToken,
+  redactTranscriptStructuredValue,
   redactTranscriptText,
 };
 

--- a/src/auto-reply/reply/agent-runner-memory.preflight-stale-tokens.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.preflight-stale-tokens.test.ts
@@ -145,6 +145,53 @@ describe("runSessionCompactionIfNeeded stale totalTokens gating", () => {
     expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(1);
   });
 
+  it("forwards the routed account id into preflight compaction", async () => {
+    // Group session keys carry no account identity, so if this launcher drops the
+    // account the compaction path resolves the root history limit after prompt
+    // preparation already used the account limit.
+    const sessionFile = path.join(rootDir, "session.jsonl");
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      sessionFile,
+      updatedAt: Date.now(),
+      totalTokens: 200_000,
+      totalTokensFresh: true,
+      totalTokensVersion: 1,
+    };
+    await writeTestSessionStore(
+      path.join(rootDir, "sessions.json"),
+      "agent:main:main",
+      sessionEntry,
+    );
+
+    await runSessionCompactionIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun: createTestFollowupRun({
+        sessionId: "session",
+        sessionFile,
+        sessionKey: "agent:main:main",
+        agentAccountId: "work",
+        conversationRoutePeerId: "peer",
+        chatType: "direct",
+      }),
+      defaultModel: "anthropic/claude-opus-4-6",
+      modelContextTokens: 100_000,
+      sessionEntry,
+      sessionStore: { "agent:main:main": sessionEntry },
+      sessionKey: "agent:main:main",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      abortSignal: new AbortController().signal,
+    });
+
+    expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(1);
+    expect(compactEmbeddedAgentSessionMock.mock.calls[0]?.[0]).toMatchObject({
+      agentAccountId: "work",
+      conversationRoutePeerId: "peer",
+      chatType: "direct",
+    });
+  });
+
   it.each([
     {
       name: "the configured roster default for an embedded provider",

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -996,6 +996,12 @@ export async function runSessionCompactionIfNeeded(params: {
       cwd: params.followupRun.run.cwd,
       agentDir: params.followupRun.run.agentDir,
       config: params.cfg,
+      // Group session keys do not encode account identity, so without this the
+      // preflight path resolves the root history limit after prompt preparation
+      // already used the account limit.
+      agentAccountId: params.followupRun.run.agentAccountId,
+      conversationRoutePeerId: params.followupRun.run.conversationRoutePeerId,
+      chatType: params.followupRun.run.chatType,
       skillsSnapshot: entry.skillsSnapshot ?? params.followupRun.run.skillsSnapshot,
       provider: params.followupRun.run.provider,
       model: params.followupRun.run.model,

--- a/src/auto-reply/reply/agent-runner-utils.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.test.ts
@@ -381,7 +381,11 @@ describe("agent-runner-utils", () => {
   });
 
   it("prefers OriginatingChannel over Provider for messageProvider", () => {
-    const run = makeRun({ agentAccountId: "work", chatType: "group" });
+    const run = makeRun({
+      agentAccountId: "work",
+      chatType: "group",
+      conversationRoutePeerId: "queued-peer",
+    });
 
     const resolved = buildEmbeddedRunExecutionParams({
       run,
@@ -389,6 +393,7 @@ describe("agent-runner-utils", () => {
         Provider: "heartbeat",
         OriginatingChannel: "Telegram",
         OriginatingTo: "268300329",
+        ConversationRoutePeerId: "later-peer",
       },
       hasRepliedRef: undefined,
       provider: "openai",
@@ -399,6 +404,7 @@ describe("agent-runner-utils", () => {
     expect(resolved.embeddedContext.messageProvider).toBe("telegram");
     expect(resolved.embeddedContext.agentAccountId).toBe("work");
     expect(resolved.embeddedContext.chatType).toBe("group");
+    expect(resolved.embeddedContext.conversationRoutePeerId).toBe("queued-peer");
     expect(resolved.embeddedContext.messageTo).toBe("268300329");
   });
 

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -277,6 +277,7 @@ function buildEmbeddedContextFromTemplate(params: {
     }),
     ...(sessionCtx.ChatType ? { chatType: sessionCtx.ChatType } : {}),
     agentAccountId: sessionCtx.AccountId,
+    conversationRoutePeerId: params.run.conversationRoutePeerId,
     messageTo: sessionCtx.OriginatingTo ?? sessionCtx.To,
     messageThreadId: sessionCtx.MessageThreadId ?? undefined,
     chatId:

--- a/src/auto-reply/reply/commands-compact.test.ts
+++ b/src/auto-reply/reply/commands-compact.test.ts
@@ -720,4 +720,32 @@ describe("handleCompactCommand", () => {
     expect(result?.reply?.text).toContain("Compaction finished (resulting context unknown) •");
     expect(result?.reply?.text).not.toContain("undefined");
   });
+
+  it("forwards the routed account id from the command context", async () => {
+    // Group session keys carry no account identity, so manual /compact has to
+    // pass it explicitly or it resolves the root history limit while prompt
+    // preparation already used the account limit.
+    vi.mocked(compactEmbeddedAgentSession).mockResolvedValueOnce({ ok: true, compacted: false });
+    const params = {
+      ...buildCompactParams("/compact", {
+        commands: { text: true },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+      } as OpenClawConfig),
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      contextTokens: 200_000,
+      sessionEntry: { sessionId: "session", updatedAt: Date.now() },
+    } as unknown as HandleCommandsParams;
+    params.ctx.AccountId = "work";
+    params.ctx.ConversationRoutePeerId = "peer";
+    params.ctx.ChatType = "direct";
+
+    await handleCompactCommand(params, true);
+
+    expect(requireCompactEmbeddedAgentSessionCall().agentAccountId).toBe("work");
+    expect(requireCompactEmbeddedAgentSessionCall()).toMatchObject({
+      conversationRoutePeerId: "peer",
+      chatType: "direct",
+    });
+  });
 });

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -18,6 +18,7 @@ import {
 } from "../../agents/openai-routing.js";
 import { resolveOwnerPromptNumbers } from "../../agents/owner-display.js";
 import { resolveManualCompactionCliTarget } from "../../agents/session-runtime-compat.js";
+import { normalizeChatType } from "../../channels/chat-type.js";
 import { resolveSessionAuthProfileOverrideSource } from "../../config/sessions/auth-profile-override-provenance.js";
 import { resolveSessionStorePathCore } from "../../config/sessions/paths.js";
 import { resolveSessionStorePathForScope } from "../../config/sessions/session-store-path.js";
@@ -317,6 +318,12 @@ export const handleCompactCommand: CommandHandler = async (params) => {
     workspaceDir: params.workspaceDir,
     agentDir: sessionAgentDir,
     config: params.cfg,
+    // Group session keys carry no account identity, so without this manual
+    // /compact resolves the root history limit while prompt preparation used the
+    // account limit.
+    agentAccountId: params.ctx.AccountId,
+    conversationRoutePeerId: params.ctx.ConversationRoutePeerId,
+    chatType: normalizeChatType(params.ctx.ChatType),
     skillsSnapshot: targetSessionEntry.skillsSnapshot,
     provider: params.provider,
     model: params.model,

--- a/src/auto-reply/reply/get-reply-run-execute.ts
+++ b/src/auto-reply/reply/get-reply-run-execute.ts
@@ -408,6 +408,7 @@ export async function executePreparedReplyRun(state: PreparedReplyRunAdmission) 
       toolBindings: ctx.GatewayRunToolBindings,
       chatType: replyRoute.chatType,
       agentAccountId: replyRoute.accountId,
+      conversationRoutePeerId: sessionCtx.ConversationRoutePeerId,
       conversationToolPolicy: sessionCtx.ConversationToolPolicy,
       groupId: resolveGroupSessionKey(sessionCtx)?.id ?? undefined,
       groupChannel:

--- a/src/auto-reply/reply/queue.collect.test.ts
+++ b/src/auto-reply/reply/queue.collect.test.ts
@@ -439,6 +439,24 @@ describe("followup queue collect routing", () => {
     },
   );
 
+  it("keeps history-policy peers separate when delivery targets coincide", async () => {
+    const { key, calls, done, runFollowup, settings } = createQueueCase(
+      "history-route-peers",
+      {},
+      2,
+    );
+    for (const peerId of ["peer", "direct:peer"]) {
+      enqueueSlackRun(key, settings, peerId, { conversationRoutePeerId: peerId });
+    }
+    await drainRecordedQueue(key, runFollowup, done);
+    expect(calls.map((call) => call.run.conversationRoutePeerId)).toEqual(["peer", "direct:peer"]);
+    expect(calls.map((call) => call.prompt)).toEqual(
+      ["peer", "direct:peer"].map(
+        (peerId) => `[Queued messages while agent was busy]\n\n---\nQueued #1\n${peerId}`,
+      ),
+    );
+  });
+
   it("collects distinct messages inside the same routed thread", async () => {
     const { key, calls, done, runFollowup, settings } = createQueueCase(
       `test-collect-shared-thread-${Date.now()}`,

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -252,6 +252,7 @@ export function resolveFollowupDeliveryContextKey(run: FollowupRun): string {
     stableStringify(execution.toolBindings ?? null),
     execution.chatType ?? "",
     execution.agentAccountId ?? "",
+    execution.conversationRoutePeerId ?? "",
     execution.groupId ?? "",
     execution.groupChannel ?? "",
     execution.groupSpace ?? "",

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -177,6 +177,7 @@ export type FollowupRun = {
     toolBindings?: Readonly<Record<string, unknown>>;
     chatType?: ChatType;
     agentAccountId?: string;
+    conversationRoutePeerId?: string;
     conversationToolPolicy?: GroupToolPolicyConfig;
     groupId?: string;
     groupChannel?: string;

--- a/src/config/sessions/conversation-registry.test.ts
+++ b/src/config/sessions/conversation-registry.test.ts
@@ -13,6 +13,7 @@ import {
   listConversations,
   registerConversationAddresses,
   resolveConversation,
+  resolveCurrentSessionPrimaryConversation,
 } from "./conversation-registry.js";
 import {
   commitReplySessionInitialization,
@@ -75,6 +76,9 @@ describe("conversation registry", () => {
     ]);
     expect(conversations.every((entry) => entry.role === "participant")).toBe(true);
     expect(conversations.every((entry) => entry.sessionKey === scope.sessionKey)).toBe(true);
+    expect(
+      resolveCurrentSessionPrimaryConversation({ ...scope, sessionId: "shared-main-session" }),
+    ).toBeUndefined();
 
     const peerA = conversations.find((entry) => entry.target === "reef:peer-a");
     expect(peerA).toBeDefined();
@@ -145,6 +149,19 @@ describe("conversation registry", () => {
     );
     expect(canonicalConversation).toBeDefined();
     const conversationRef = canonicalConversation!.conversationRef;
+    expect(
+      resolveCurrentSessionPrimaryConversation({ ...scope, sessionId: "ops-session" }),
+    ).toEqual(canonicalConversation);
+    expect(
+      resolveCurrentSessionPrimaryConversation({ ...scope, sessionId: "another-session" }),
+    ).toBeUndefined();
+    expect(
+      resolveCurrentSessionPrimaryConversation({
+        ...scope,
+        sessionId: "ops-session",
+        sessionKey: "agent:main:discord:channel:another",
+      }),
+    ).toBeUndefined();
     expect(resolveConversation({ agentId: "main", storePath }, conversationRef)).toMatchObject({
       peerId: "canonical-ops",
       observedFromSession: true,
@@ -189,6 +206,10 @@ describe("conversation registry", () => {
     expect(resolveConversation({ agentId: "main", storePath }, conversationRef)).not.toMatchObject({
       routeContextObserved: true,
     });
+    expect(
+      resolveCurrentSessionPrimaryConversation({ ...scope, sessionId: "ops-session" })
+        ?.routeContext,
+    ).toBeUndefined();
     await upsertCanonicalSessionEntry(scope, {
       label: "after older writer",
       updatedAt: afterCurrentWrite!.lastSeenAt + 1,
@@ -233,6 +254,19 @@ describe("conversation registry", () => {
       { target: "channel:alpha", routeContext: { guildId: "guild-alpha" } },
       { target: "channel:beta", routeContext: { guildId: "guild-beta" } },
     ]);
+    const resolved = resolveSqliteReadScope(scope);
+    const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+    executeSqliteQuerySync(
+      database.db,
+      getSessionKysely(database.db)
+        .updateTable("session_conversations")
+        .set({ last_seen_at: 300 })
+        .where("session_id", "=", "shared-session")
+        .where("role", "=", "related"),
+    );
+    expect(
+      resolveCurrentSessionPrimaryConversation({ ...scope, sessionId: "shared-session" }),
+    ).toMatchObject({ target: "channel:beta", routeContext: { guildId: "guild-beta" } });
   });
 
   it("preserves context across an unobserved rollover and clears it on observed-empty ingress", async () => {
@@ -272,6 +306,12 @@ describe("conversation registry", () => {
       routeContextObserved: true,
       routeContext: { guildId: "guild-a", memberRoleIds: ["support"] },
     });
+    expect(
+      resolveCurrentSessionPrimaryConversation({ ...scope, sessionId: "before-rollover" }),
+    ).toBeUndefined();
+    expect(
+      resolveCurrentSessionPrimaryConversation({ ...scope, sessionId: "after-rollover" }),
+    ).toMatchObject({ routeContext: { guildId: "guild-a" } });
 
     snapshot = loadReplySessionInitializationSnapshot(scope);
     await commitReplySessionInitialization({
@@ -289,6 +329,35 @@ describe("conversation registry", () => {
       routeContextObserved: true,
     });
     expect(listConversations(scope)[0]?.routeContext).toBeUndefined();
+    expect(
+      resolveCurrentSessionPrimaryConversation({ ...scope, sessionId: "after-rollover" })
+        ?.routeContext,
+    ).toBeUndefined();
+  });
+
+  it.each([
+    { entry_valid: 0 },
+    { entry_json: JSON.stringify({ sessionId: "wrong-session", updatedAt: 100 }) },
+  ])("does not bind an invalid current entry to its primary address: %j", async (invalid) => {
+    const scope = { agentId: "main", sessionKey: "agent:main:reef:direct:peer-a", storePath };
+    await upsertSessionEntry(scope, {
+      sessionId: "peer-a-session",
+      updatedAt: 100,
+      chatType: "direct",
+      deliveryContext: { channel: "reef", accountId: "default", to: "reef:peer-a" },
+    });
+    const resolved = resolveSqliteReadScope(scope);
+    const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+    executeSqliteQuerySync(
+      database.db,
+      getSessionKysely(database.db)
+        .updateTable("session_nodes")
+        .set(invalid)
+        .where("session_key", "=", scope.sessionKey),
+    );
+    expect(
+      resolveCurrentSessionPrimaryConversation({ ...scope, sessionId: "peer-a-session" }),
+    ).toBeUndefined();
   });
 
   it("orders fresh directory addresses with session-backed conversation activity", async () => {
@@ -419,6 +488,9 @@ describe("conversation registry", () => {
       target: { canonicalKey: sessionKey, storeKeys: [sessionKey] },
       archiveTranscript: false,
     });
+    expect(
+      resolveCurrentSessionPrimaryConversation({ ...scope, sessionId: "deleted-session" }),
+    ).toBeUndefined();
 
     expect(
       resolveConversation({ agentId: "main", storePath }, linked?.conversationRef ?? "missing"),

--- a/src/config/sessions/conversation-registry.ts
+++ b/src/config/sessions/conversation-registry.ts
@@ -149,7 +149,12 @@ function mapConversationRow(row: {
 
 function selectConversationRows(
   scope: ConversationRegistryScope,
-  options: { channel?: string; conversationRef?: string; limit?: number } = {},
+  options: {
+    channel?: string;
+    conversationRef?: string;
+    limit?: number;
+    primarySession?: { sessionId: string; sessionKey: string };
+  } = {},
 ): ConversationRecord[] {
   const resolved = resolveSqliteReadScope({
     agentId: scope.agentId,
@@ -198,6 +203,17 @@ function selectConversationRows(
       "=",
       normalizeConversationRef(options.conversationRef),
     );
+  }
+  if (options.primarySession) {
+    // The window's primary pointer, not address recency, owns this route.
+    // Require its current node so reset/deleted sessions cannot lend old facts.
+    query = query
+      .where("s.session_id", "=", options.primarySession.sessionId)
+      .where("s.session_key", "=", options.primarySession.sessionKey)
+      .where("sn.current_session_id", "=", options.primarySession.sessionId)
+      .where("sn.entry_valid", "=", 1)
+      .whereRef("s.primary_conversation_id", "=", "c.conversation_id")
+      .where("sc.role", "=", "primary");
   }
   const rows = executeSqliteQuerySync(
     database.db,
@@ -284,4 +300,14 @@ export function resolveConversation(
     conversationRef: normalizeConversationRef(conversationRef),
     limit: 1,
   })[0];
+}
+
+/** Reads only the primary address bound to this exact current session window. */
+export function resolveCurrentSessionPrimaryConversation(
+  scope: ConversationRegistryScope & { sessionId: string; sessionKey: string },
+): ConversationRecord | undefined {
+  const [conversation] = selectConversationRows(scope, { primarySession: scope });
+  return conversation?.sessionId === scope.sessionId && conversation.sessionKey === scope.sessionKey
+    ? conversation
+    : undefined;
 }

--- a/src/gateway/server-methods/sessions-compaction-runner.ts
+++ b/src/gateway/server-methods/sessions-compaction-runner.ts
@@ -9,6 +9,7 @@ import { resolveIngressWorkspaceOverrideForSessionRun } from "../../agents/spawn
 import { normalizeReasoningLevel, normalizeThinkLevel } from "../../auto-reply/thinking.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { resolveSessionAuthProfileOverrideSource } from "../../config/sessions/auth-profile-override-provenance.js";
+import { resolveCurrentSessionPrimaryConversation } from "../../config/sessions/conversation-registry.js";
 import {
   loadTranscriptEvents,
   resolveSessionTranscriptRuntimeTarget,
@@ -99,6 +100,7 @@ export async function runGatewaySessionCompaction(
     entry: params.entry,
     cfg: params.cfg,
   });
+  const primaryConversation = resolveCurrentSessionPrimaryConversation(transcriptTarget);
   return await compactEmbeddedAgentSession({
     contextEngineAgentId: params.agentId,
     sessionId: params.sessionId,
@@ -115,6 +117,14 @@ export async function runGatewaySessionCompaction(
     workspaceDir,
     cwd: normalizeOptionalString(params.entry.spawnedCwd),
     config: params.cfg,
+    // Current delivery owns the account; origin can retain historical identity.
+    // Group session keys do not carry an account themselves.
+    agentAccountId:
+      params.entry.delivery?.kind === "external"
+        ? params.entry.delivery.context?.accountId
+        : undefined,
+    conversationRoutePeerId: primaryConversation?.routeContext?.peerId,
+    chatType: primaryConversation?.kind,
     provider: resolvedModel.provider,
     model: resolvedModel.model,
     authProfileId:

--- a/src/plugin-sdk/provider-stream-shared.ts
+++ b/src/plugin-sdk/provider-stream-shared.ts
@@ -28,7 +28,11 @@ import type { Model } from "../llm/types.js";
 import { createAssistantMessageEventStream } from "../llm/utils/event-stream.js";
 import { findCodeRegions } from "../shared/text/code-regions.js";
 import { assertProviderStreamEvent } from "./provider-stream-event-normalization.js";
-export { applyAnthropicRefusal } from "@openclaw/ai/internal/anthropic";
+export {
+  applyAnthropicRefusal,
+  isAnthropicOAuthApiKey,
+  resolveAnthropicServerCompactionPlan,
+} from "@openclaw/ai/internal/anthropic";
 export { createDeferredEventBuffer } from "@openclaw/ai/internal/runtime";
 export { notifyLlmRequestActivity, onLlmRequestActivity } from "@openclaw/ai/internal/runtime";
 

--- a/test/gateway-account-history.e2e.test.ts
+++ b/test/gateway-account-history.e2e.test.ts
@@ -1,0 +1,324 @@
+import { createHash } from "node:crypto";
+import { createServer, request as httpRequest, type ServerResponse } from "node:http";
+import path from "node:path";
+import { expect, test } from "vitest";
+import {
+  startQaMockOpenAiServer,
+  type MockOpenAiRequestSnapshot,
+} from "../extensions/qa-lab/api.js";
+import { listConversations } from "../src/config/sessions/conversation-registry.js";
+import { connectGatewayClient, disconnectGatewayClient } from "../src/gateway/test-helpers.e2e.js";
+import { createOpenClawTestInstance } from "./helpers/openclaw-test-instance.js";
+
+async function runAccountHistoryProof(compactionMode: "client" | "server-endpoint") {
+  const model = await startQaMockOpenAiServer({ modelRefs: ["history-proof/history-proof"] });
+  const replies: string[] = [];
+  const compactRequests: string[] = [];
+  const checkpoint = (generation: number) => ({
+    type: "compaction",
+    id: `cmp_history_${generation}`,
+    encrypted_content: `HISTORY_ENDPOINT_CHECKPOINT_${generation}`,
+    created_by: `history-proof-${generation}`,
+  });
+  const hash = (value: unknown) => createHash("sha256").update(JSON.stringify(value)).digest("hex");
+  let poll: ServerResponse | undefined;
+  const respond = (response: ServerResponse, result: unknown) => {
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify({ ok: true, result }));
+  };
+  const transport = createServer((request, response) => {
+    if (request.url?.startsWith("/v1/") && request.url !== "/v1/responses/compact") {
+      const upstream = httpRequest(
+        new URL(request.url, model.baseUrl),
+        {
+          method: request.method,
+          headers: request.headers,
+        },
+        (incoming) => {
+          response.writeHead(incoming.statusCode ?? 500, incoming.headers);
+          incoming.pipe(response);
+        },
+      );
+      upstream.on("error", (error) => response.writeHead(502).end(String(error)));
+      request.pipe(upstream);
+      return;
+    }
+    void (async () => {
+      const method = request.url?.split("/").at(-1);
+      if (method === "getUpdates") {
+        poll = response;
+        response.on("close", () => {
+          if (poll === response) poll = undefined;
+        });
+        return;
+      }
+      if (method === "getMe") {
+        respond(response, {
+          id: 424242,
+          is_bot: true,
+          first_name: "History",
+          username: "history_proof_bot",
+        });
+        return;
+      }
+      let raw = "";
+      for await (const chunk of request) raw += chunk;
+      if (request.url === "/v1/responses/compact") {
+        compactRequests.push(raw);
+        response.writeHead(200, { "content-type": "application/json" }).end(
+          JSON.stringify({
+            object: "response.compaction",
+            output: [checkpoint(compactRequests.length)],
+            usage: { input_tokens: 1000, output_tokens: 50 },
+          }),
+        );
+        return;
+      }
+      const body = raw ? (JSON.parse(raw) as { text?: string; chat_id?: number }) : {};
+      if (method === "sendMessage") {
+        replies.push(body.text ?? "");
+        respond(response, {
+          message_id: replies.length + 100,
+          date: Math.floor(Date.now() / 1000),
+          chat: { id: body.chat_id, type: "private" },
+          text: body.text,
+        });
+        return;
+      }
+      respond(response, true);
+    })().catch((error: unknown) => {
+      response.writeHead(500).end(String(error));
+    });
+  });
+  await new Promise<void>((resolve) => transport.listen(0, "127.0.0.1", resolve));
+  const address = transport.address();
+  if (!address || typeof address === "string") throw new Error("Telegram fixture did not bind");
+  const instance = await createOpenClawTestInstance({
+    name: "account-history",
+    config: {
+      plugins: { slots: { memory: "none" } },
+      agents: {
+        defaults: {
+          heartbeat: { every: "0m" },
+          model: { primary: "history-proof/history-proof" },
+          models: {
+            "history-proof/history-proof": {
+              agentRuntime: { id: "openclaw" },
+              ...(compactionMode === "server-endpoint"
+                ? { params: { responsesCompactEndpoint: true } }
+                : {}),
+            },
+          },
+          skipBootstrap: true,
+          skills: [],
+          compaction: {
+            mode: "default",
+            keepRecentTokens: 1,
+            recentTurnsPreserve: 0,
+            memoryFlush: { enabled: false },
+          },
+        },
+      },
+      tools: { profile: "minimal" },
+      messages: { visibleReplies: "automatic" },
+      session: {
+        dmScope: "per-channel-peer",
+        identityLinks: { "direct:peer": ["telegram:123"] },
+      },
+      channels: {
+        telegram: {
+          enabled: true,
+          defaultAccount: "direct",
+          apiRoot: `http://127.0.0.1:${address.port}`,
+          dmHistoryLimit: 20,
+          commands: { native: false, nativeSkills: false },
+          streaming: { mode: "off" },
+          accounts: {
+            direct: {
+              botToken: "424242:TEST_TOKEN_PLACEHOLDER_FOR_LOCAL_GATEWAY",
+              dmPolicy: "allowlist",
+              allowFrom: ["123"],
+              dmHistoryLimit: 10,
+              // Telegram's channel context uses the native ID; the embedded
+              // transcript historically uses the linked session peer.
+              dms: {
+                "123": { historyLimit: 2 },
+                "direct:peer": { historyLimit: 2 },
+                peer: { historyLimit: 6 },
+              },
+            },
+          },
+        },
+      },
+      models: {
+        mode: "replace",
+        providers: {
+          "history-proof": {
+            baseUrl: `http://127.0.0.1:${address.port}/v1`,
+            apiKey: "test-token-placeholder",
+            api: "openai-responses",
+            request: { allowPrivateNetwork: true },
+            models: [
+              {
+                id: "history-proof",
+                name: "History proof",
+                api: "openai-responses",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 128000,
+                maxTokens: 4096,
+              },
+            ],
+          },
+        },
+      },
+    },
+    env: {
+      OPENCLAW_SKIP_CHANNELS: undefined,
+      OPENCLAW_SKIP_PROVIDERS: undefined,
+      OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
+      TELEGRAM_BOT_TOKEN: undefined,
+    },
+  });
+  let client: Awaited<ReturnType<typeof connectGatewayClient>> | undefined;
+  try {
+    await instance.startGateway();
+    const sendTurn = async (turn: number) => {
+      await expect.poll(() => Boolean(poll), { timeout: 30000 }).toBe(true);
+      const currentPoll = poll!;
+      poll = undefined;
+      respond(currentPoll, [
+        {
+          update_id: turn,
+          message: {
+            message_id: turn,
+            date: Math.floor(Date.now() / 1000),
+            from: { id: 123, is_bot: false, first_name: "Fixture" },
+            chat: { id: 123, type: "private", first_name: "Fixture" },
+            text: `HISTORY_TURN_${turn}. Reply exactly: ACK_${turn}`,
+          },
+        },
+      ]);
+      await expect
+        .poll(() => replies.some((reply) => reply.includes(`ACK_${turn}`)), { timeout: 30000 })
+        .toBe(true);
+    };
+    for (let turn = 1; turn <= 6; turn++) await sendTurn(turn);
+    const requests = async () =>
+      (await fetch(`${model.baseUrl}/debug/requests`).then((response) =>
+        response.json(),
+      )) as MockOpenAiRequestSnapshot[];
+    const prompt = (await requests()).findLast(
+      (request) => request.requestKind === "agent-initial",
+    )!;
+    expect(prompt.allInputText).toContain("HISTORY_TURN_6");
+    expect(prompt.allInputText).not.toContain("HISTORY_TURN_1");
+    expect(prompt.allInputText).not.toContain("HISTORY_TURN_2");
+    client = await connectGatewayClient({
+      url: instance.url,
+      token: instance.gatewayToken,
+      role: "operator",
+      scopes: ["operator.admin", "operator.read", "operator.write"],
+    });
+    const key = "agent:main:telegram:direct:direct:peer";
+    const listed = await client.request<{ sessions: Array<{ key: string; sessionId: string }> }>(
+      "sessions.list",
+      { limit: 20 },
+    );
+    const session = listed.sessions.find((entry) => entry.key === key);
+    expect(session).toBeDefined();
+    const conversation = listConversations({
+      agentId: "main",
+      storePath: path.join(instance.state.agentDir("main"), "openclaw-agent.sqlite"),
+    }).find(
+      (entry) =>
+        entry.sessionKey === key &&
+        entry.sessionId === session!.sessionId &&
+        entry.role === "primary",
+    );
+    expect(conversation).toMatchObject({
+      accountId: "direct",
+      kind: "direct",
+      routeContext: { peerId: "123" },
+    });
+    const compacted = await client.request<{
+      ok: boolean;
+      compacted: boolean;
+      result?: { summary?: string; kind?: string };
+    }>("sessions.compact", { key }, { timeoutMs: 60000 });
+    expect(compacted).toMatchObject({ ok: true, compacted: true });
+    if (compactionMode === "server-endpoint") {
+      expect(compacted.result?.kind).toBe("server-endpoint");
+      expect(compactRequests).toHaveLength(1);
+      expect(compactRequests[0]).toContain("HISTORY_TURN_5");
+      expect(compactRequests[0]).toContain("HISTORY_TURN_6");
+      expect(compactRequests[0]).not.toContain("HISTORY_TURN_1");
+      expect(compactRequests[0]).not.toContain("HISTORY_TURN_2");
+      for (let generation = 1; generation <= 2; generation++) {
+        const firstTurn = generation * 6 + 1;
+        for (let turn = firstTurn; turn < firstTurn + 6; turn++) {
+          await sendTurn(turn);
+          const replay = (await requests()).findLast(
+            (request) => request.requestKind === "agent-initial",
+          )!;
+          const body = JSON.parse(replay.raw) as { input: Array<{ type?: string }> };
+          const checkpoints = body.input.filter((item) => item.type === "compaction");
+          expect(checkpoints).toHaveLength(1);
+          expect(hash(checkpoints)).toBe(hash([checkpoint(generation)]));
+          if (turn === firstTurn + 5) {
+            expect(replay.allInputText).not.toContain(`HISTORY_TURN_${firstTurn}.`);
+            expect(replay.allInputText).not.toContain(`HISTORY_TURN_${firstTurn + 1}.`);
+          }
+        }
+        if (generation === 1) {
+          const next = await client.request<{ result?: { kind?: string } }>(
+            "sessions.compact",
+            { key },
+            { timeoutMs: 60000 },
+          );
+          expect(next.result?.kind).toBe("server-endpoint");
+          expect(compactRequests).toHaveLength(2);
+          expect(compactRequests[1]).toContain(checkpoint(1).encrypted_content);
+          expect(compactRequests[1]).not.toContain("HISTORY_TURN_5.");
+          expect(compactRequests[1]).not.toContain("HISTORY_TURN_6.");
+        }
+      }
+      return;
+    }
+    expect(compactRequests).toHaveLength(0);
+    const summary = (await requests()).filter(
+      (request) => request.requestKind === "compaction-summary",
+    );
+    expect(summary.length).toBeGreaterThan(0);
+    const summaryInput = summary.map((request) => request.allInputText).join("\n");
+    expect(summaryInput).toContain("HISTORY_TURN_5");
+    // Compaction preserves older durable context, rather than treating a prompt
+    // window as deletion. Its saved summary survives subsequent history cuts.
+    expect(summaryInput).toContain("HISTORY_TURN_1");
+    expect(summaryInput).toContain("HISTORY_TURN_4");
+    expect(compacted.result?.summary).toBeTruthy();
+    for (let turn = 7; turn <= 12; turn++) await sendTurn(turn);
+    const afterCompaction = (await requests()).findLast(
+      (request) => request.requestKind === "agent-initial",
+    )!;
+    expect(afterCompaction.allInputText).toContain(compacted.result!.summary);
+    expect(afterCompaction.allInputText).toContain("HISTORY_TURN_12");
+    expect(afterCompaction.allInputText).not.toContain("HISTORY_TURN_7.");
+    expect(afterCompaction.allInputText).not.toContain("HISTORY_TURN_8.");
+  } catch (error) {
+    throw new Error(`${String(error)}\n${instance.logs()}`, { cause: error });
+  } finally {
+    if (client) await disconnectGatewayClient(client);
+    await instance.cleanup();
+    await model.stop();
+    transport.closeAllConnections();
+    await new Promise<void>((resolve) => transport.close(() => resolve()));
+  }
+}
+
+test.each(["client", "server-endpoint"] as const)(
+  "routes account-scoped history through Gateway prompts and %s compaction",
+  runAccountHistoryProof,
+  180000,
+);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where channel users received the wrong amount of conversation history when the active account or peer policy differed from the channel default. Fixes connected cases where a short history window evicted a provider compaction checkpoint, causing context loss or replay rejection on later turns.

Related: #129599. This is a maintainer rewrite of the existing account-history PR, preserving @ayaangazali's contribution and covering the checkpoint lifecycle exposed by realistic short-window testing.

## Why This Change Was Made

Account policy now uses normalized account configuration and admitted route facts, including peer and conversation kind. Manual Gateway compaction reads the existing current-primary conversation registry; it does not infer routing from a possibly ambiguous session key or create another routing store. Explicit zero and whole-map per-peer replacement retain their existing semantics.

Provider replay owns checkpoint continuity. The existing v1 assistant-owned envelope retains the complete validated OpenAI compact output, or the complete native xAI item, and preserves the opaque field for old readers. A transient projection carries at most one eligible original owner across history trimming, after identity/auth checks and before pairing. It neither copies checkpoints into later durable messages nor resurrects covered prelude messages. Prompt pressure measures the canonical checkpoint plus uncovered tail once and does not trust context totals that lack checkpoint/auth lineage. The actually prepared outgoing request determines checkpoint authority.

The complete output is bounded to 16 MiB, including serialized-envelope escaping/duplication; raw successful HTTP bodies are bounded before JSON parsing, with depth capped at 64. Capture falls back to ordinary client compaction if current payload/image/redaction policy would alter the checkpoint. Later redaction or a legacy retained-user checkpoint without its complete output requires explicit `/compact` recovery from full durable history. Provider/model/endpoint/session/auth fences remain intact. Anthropic replay uses its existing canonical resolved-key classifier, passing only a prepared eligibility boolean into core.

The compact-only fetch wrapper bounds successful response bytes before the ordinary OpenAI SDK parser consumes them. The SDK still owns per-attempt body deadlines, retries and typed caller cancellation. This replaces the rewrite's raw `.asResponse()` reader, which bypassed those SDK lifecycle guarantees; ordinary streaming and non-success HTTP responses retain their existing paths.

No database schema/version, index, protocol, dependency, or new configuration setting changes. The additive persisted checkpoint field is an explicitly approved data contract, not a claim of zero persistence impact. Existing database newer-schema guards remain enforced.

## User Impact

Per-account and per-peer history limits are applied consistently through ordinary turns, queued turns, and explicit compaction. Tight limits no longer silently discard valid provider context. Unsupported or redacted legacy checkpoint state fails visibly with a recovery action rather than sending a misleading partial transcript. Existing durable messages remain available for explicit recovery.

Telegram's native-ID supplemental history and linked-peer embedded turn history remain distinct documented policies. This does not change native Codex behavior, add Buzz multi-account support, or implement Buzz DM/reaction/media features.

## Evidence

Land-ready candidate: `bb3d9a22eeb79362f9f58f2f6a9e36d9eeb8bea6`, rebased onto `f93be5b5fe56be6293a5517bd57ddcc135375fda` after checkout-cleanup repairs #132169, #132204 and #132203 landed. The six-commit range-diff preserves the patch, with only context around upstream's isolated compaction-test workspace changed. All 154 compaction-hook tests and nine real HTTP lifecycle controls passed on this head. Normal and private-QA builds passed, including the UI budget (344732 B below 345947 B); the canonical build stamp matches the full candidate SHA. Exact-head [CI run 33228608553](https://github.com/openclaw/openclaw/actions/runs/33228608553) passed, including `openclaw/ci-gate`.

The final compiled-boundary repeat also passed: both Gateway client/endpoint compaction cases (12 and 18 turns respectively, two endpoint generations with exact checkpoint hashes), 27 provider-replay tests and seven transcript-rewrite tests using real SQLite. Command: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/gateway-account-history.e2e.test.ts packages/ai/src/transports/provider-compaction-replay.test.ts src/agents/embedded-agent-runner/transcript-rewrite.test.ts --reporter=verbose`; three shards completed in 245.79 seconds. Source remained clean and the build stamp was checked before and after. This is actual compiled Gateway behavior with controlled channel/model services, not authenticated Telegram/OpenAI. Current native review baseline `5d8ef653` has no overlapping production, test or documentation changes since the pinned base; only unrelated assertion-ratchet entries overlap by filename.

The preceding `aa463aaa` candidate passed final local changed checks and normal `pnpm build`, including the UI budget (346606 B below 347037 B), but [CI run 33222068278](https://github.com/openclaw/openclaw/actions/runs/33222068278) failed in the main-introduced checkout-cleanup test. This rebase incorporates the existing repairs; no duplicate cleanup patch or relaxed assertion was added. The older `70382159812587afc4f9c00240449b6f1190987e` run is not proof for the SDK-lifetime repair.

The preceding failed merge job reported cleanup-failure fatal125 in the process-boundary assertion (small47, job99018176316). That test was introduced on main by #132105 and was absent from the pre-rebase `aa463aaa` head. A separate isolated Linux diagnostic completed 80 cases and 568 boundary checks with 264 later ENOENT probes, all passing including the original implementation; this is not a local RED/GREEN reproduction and does not classify the failed CI processes as zombies or active writers. [Diagnostic details and coordination](https://github.com/openclaw/openclaw/pull/132169#issuecomment-5459468144) are recorded with the existing repair owner.

- Regression evidence includes actual caller-level account precedence failures, checkpoint eviction across a compiled Gateway's short window, discarded-checkpoint admission, explicit-account override with known conversation kind, covered-prelude duplication, and retained-user runtime-carrier placement across two tool rounds.
- Integrated focused suite: 280 tests across 11 files passed. The review-fix suite then passed 267 tests across nine files with refreshed dependencies; final preflight and failure-owner tests passed 22 cases across two files. Counts overlap and are not summed. The complete outgoing checkpoint route/budget is independent of the diagnostic raw-history maximum. Whole-candidate changed checks and the final five-path follow-up gate passed. Independent Codex review of the complete candidate found no actionable P0–P2 findings; the final test-only JSON-serialization comment also received a clean review.
- Hosted CI exposed three stale context-engine assertions. They reproduced RED before the test repair; both complete owner suites then passed (73 tests across two files). Assertions now check ordinary-admission deferral and actual preassembly snapshots while retaining checkpoint validation. The follow-up's changed-file gate and independent P0–P2 review passed; no production workaround or weakened checkpoint guard was added.
- Pre-land installed OpenAI 7.5.0 source inspection and a real loopback HTTP server exposed four failures in the raw-reader rewrite: explicit and host-derived body deadlines, body-timeout retries and typed cancellation. The regression was RED before repair, then all 83 focused tests across five files passed, including nine HTTP/lifecycle controls. A standalone stalled-body repeat settled at 107 ms for the fixed 100 ms deadline instead of waiting for fixture cleanup; the existing embedded compaction safety owner remained bounded throughout. The final lint/type-only cleanup passed all core-test type shards, the nine new controls and fresh independent P0–P2 review. Lint and test-library-target failures were repaired, not waived.
- Before the SDK-lifetime follow-up, the normal production build and private QA runtime passed through their supported profiles and canonical build-provenance writer. A source-blind validator completed 19 replies, 19 initial provider requests, and two endpoint generations through the compiled Gateway. Both explicit RPC compactions used the linked-peer limit of 2 rather than account 10 or root 20; complete output hashes stayed exact across repeated trimming, and rejected controls made no requests. The subsequent SDK transport repair has its own real HTTP and authenticated-provider repeats described above and below; it does not change the history, persistence or routing owners.
- Synthetic legacy import through the actual compiled canonical rewrite preserved all 43 original raw rows and IDs byte-for-byte, with only 15 intentional suffix copies and no extra checkpoint appends. The next chat visibly requested `/compact` without a provider call. Public `sessions.compact` made one client-summary request containing first and later durable markers, with zero endpoint calls or opaque checkpoint bytes. A further Gateway restart and continuation retained the resulting summary. The deterministic summary derives only from the actual model request; this proves persistence/continuation, not model semantic quality.
- The rewrite regression first failed on keyed replacement/suffix messages: global ingestion deduplication was incorrectly suppressing deliberate canonical copies. The rewrite owner now marks only those already-checked appends explicitly, preserving ordinary ingress deduplication and original row identity. Focused rewrite/old-reader tests passed. A separate failure-owner regression first reproduced the generic `/new` response, then proved that only the native precheck error selects the fixed `/compact` instruction; mutated, serialized, and spoofed errors do not become trusted copy.
- Final runtime build passed. The actual official pre-change reader at `3270b4d3e6e35a4980757e5bdff535d120697f35` opened the candidate database, retained the additive v1 field on read, and dropped only that field during its real rewrite. Exactly three intentional message appends preserved seven original rows byte-for-byte. Final-candidate reopen retained all six ordinary messages, added no rows, and required explicit `/compact` recovery. Both revisions use unchanged state/agent schema guards 13/18. This is matching-schema pre-change-reader proof, not certification of a released older version; public full-history recovery is tested separately.
- Real OpenAI proof was repeated after the SDK-lifetime repair: two compact calls and six continuations, all HTTP 200; whole-output hashes stayed exact across HTTP egress, JSON reopen and repeated owner eviction, with three then seven retained items and synthetic recall. This is external provider transport proof, separate from the controlled-service Gateway/database and Linux Testbox proofs. It is not a claim that Testbox exercised authenticated OpenAI.
- Linux compiled Gateway E2E: both client-compaction and 18-turn/two-generation endpoint scenarios passed through Blacksmith Testbox; [run 33208500509](https://github.com/openclaw/openclaw/actions/runs/33208500509). Transport/model services were controlled fixtures, not authenticated Telegram/OpenAI calls. The lease completed.

Production/tooling LOC: +1021/-233 (net +788); tests/support: +2675/-146; docs: +40/-3; assertion inventory +1/-1. The production growth is primarily the complete-output validator/bounds and shared replay projection/pressure owner needed for a lossless provider contract; caller plumbing reuses the existing route and conversation owners. A lossy single-item projection, copy-forward checkpoint writes, or downstream retry would not repair the demonstrated lifecycle failure.

Provenance: account-history introduction is not reliably traceable through the available shallow boundary. The endpoint implementations carried the incomplete-output assumption forward: #123622 (xAI, merged 2026-08-14, author/merger @steipete) and #124974 (retained Responses messages, merged 2026-08-18, author/merger @steipete). This does not attribute the original account bug to the author at the shallow boundary. Actual upstream Codex source was inspected at d47e5cc0e2bbd35774dff15c83570519735d2ac4; complete-vector ownership informed the review, without claiming native-runtime parity.

Both rank-up moves from the earlier review are addressed: Gateway compaction consumes the persisted current-primary peer/chat-kind facts, and a real compiled RPC trace distinguishes the peer override from the account default. The latest [ClawSweeper review](https://github.com/openclaw/openclaw/pull/119326#issuecomment-5184023904), updated August 29 at 02:30 UTC for this exact head, reports no code or security findings. Its requests for final-head compatibility/session validation and confirmation of rank-up requirements are satisfied by the final compiled-boundary, persistence and CI results above; no requirement was waived. The previous review's 30-second runner interruption was not a terminal product failure; the Linux and final local executions completed.

Release context:

- Agents/history: honor active account and peer history limits and retain complete eligible provider checkpoints across short windows, with visible full-history recovery for unsupported legacy checkpoints. Thanks @ayaangazali.
