### PR TITLE
fix: auto-reply gateway stalls in a zero-work drain loop after a queue drop policy change

### DIFF
--- a/src/auto-reply/reply/agent-runner-run.ts
+++ b/src/auto-reply/reply/agent-runner-run.ts
@@ -56,7 +56,7 @@ import { resolveOriginMessageProvider } from "./origin-routing.js";
 import { resolveActiveRunQueueAction } from "./queue-policy.js";
 import { enqueueFollowupRun, type FollowupRun, scheduleFollowupDrain } from "./queue.js";
 import { createReplyMediaContext } from "./reply-media-paths.js";
-import { resolveReplyOperationRunState } from "./reply-operation-run-state.js";
+import * as replyRunState from "./reply-operation-run-state.js";
 import { type ReplyOperation, replyRunRegistry } from "./reply-run-registry.js";
 import { bindReplyOperationTyping, refreshReplyOperationTyping } from "./reply-run-typing.js";
 import { createReplyToModeFilterForChannel, resolveReplyToMode } from "./reply-threading.js";
@@ -124,7 +124,7 @@ export async function runReplyAgent(
         },
       }
     : opts;
-  const replyOperationRunState = resolveReplyOperationRunState(opts);
+  const replyOperationRunState = replyRunState.resolveReplyOperationRunState(opts);
   const traceAttributes = {
     provider: followupRun.run.provider,
     hasSessionKey: Boolean(sessionKey ?? followupRun.run.sessionKey),
@@ -405,6 +405,7 @@ export async function runReplyAgent(
   }
 
   if (activeRunQueueAction === "enqueue-followup") {
+    replyRunState.bindQueueDispositionToRunState(followupRun, replyOperationRunState);
     const enqueued = enqueueFollowupRun(
       queueKey,
       followupRun,

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -1015,10 +1015,14 @@ describe("runReplyAgent heartbeat followup guard", () => {
     expect(state.runEmbeddedAgentMock).not.toHaveBeenCalled();
   });
 
-  it("cleans up typing when followup admission is rejected", async () => {
-    vi.mocked(enqueueFollowupRun).mockReturnValueOnce(false);
+  it("records queue-cap rejection while cleaning up typing", async () => {
+    vi.mocked(enqueueFollowupRun).mockImplementationOnce((...args) => {
+      args[1].onQueueDisposition?.("queue-cap-new");
+      return false;
+    });
+    const runState: ReplyOperationRunState = {};
     const { run, typing } = createMinimalRun({
-      opts: { isHeartbeat: false },
+      opts: { isHeartbeat: false, [REPLY_OPERATION_RUN_STATE]: runState },
       isActive: true,
       isRunActive: () => true,
       shouldFollowup: true,
@@ -1032,6 +1036,7 @@ describe("runReplyAgent heartbeat followup guard", () => {
     expect(vi.mocked(scheduleFollowupDrain)).not.toHaveBeenCalled();
     expect(state.runEmbeddedAgentMock).not.toHaveBeenCalled();
     expect(typing.cleanup).toHaveBeenCalledTimes(1);
+    expect(runState.admission).toEqual({ status: "skipped", reason: "queue-cap" });
   });
 
   it("keeps typing alive when a followup is queued behind a live active run", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.finalize.ts
+++ b/src/auto-reply/reply/dispatch-from-config.finalize.ts
@@ -14,6 +14,7 @@ import {
   createFinalDispatchPayloadDedupeKey,
   formatSuppressedReplyPayloadForLog,
   NO_VISIBLE_REPLY_FALLBACK_TEXT,
+  QUEUE_CAP_REJECTION_TEXT,
 } from "./dispatch-from-config.payloads.js";
 import {
   clearPendingFinalDeliveryAfterSuccess,
@@ -266,7 +267,10 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
   // ledger intentionally does not own. Directedness gates both the fallback and
   // eligibility: only a turn that positively addressed the bot may surface a
   // visible failure notice.
-  const replyAcceptedByActiveRun = state.replyOperationRunState.admission?.status === "accepted";
+  const replyAdmission = state.replyOperationRunState.admission;
+  const replyAcceptedByActiveRun = replyAdmission?.status === "accepted";
+  const queueCapRejected =
+    replyAdmission?.status === "skipped" && replyAdmission.reason === "queue-cap";
   const noVisibleReplyFallbackAllowed = () =>
     noVisibleReplyFallbackDirected &&
     !suppressDelivery &&
@@ -297,7 +301,9 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
   if (queuedSettleResult === "settled" && noVisibleReplyFallbackAllowed()) {
     try {
       throwIfDispatchOperationAborted();
-      const fallbackPayload: ReplyPayload = { text: NO_VISIBLE_REPLY_FALLBACK_TEXT };
+      const fallbackPayload: ReplyPayload = {
+        text: queueCapRejected ? QUEUE_CAP_REJECTION_TEXT : NO_VISIBLE_REPLY_FALLBACK_TEXT,
+      };
       const result = await routeReplyToOriginating(fallbackPayload, {
         abortSignal: getDispatchAbortSignal(),
         kind: "final",
@@ -347,14 +353,14 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
   }
   counts.final += routedFinalCount;
   state.commitInboundDedupeIfClaimed();
-  state.recordAgentDispatchCompleted("completed");
-  state.recordProcessed(
-    "completed",
-    state.bindingState.pluginFallbackReason
-      ? { reason: state.bindingState.pluginFallbackReason }
-      : undefined,
+  const dispatchOutcome = queueCapRejected ? "skipped" : "completed";
+  const dispatchReason = queueCapRejected ? "queue-cap" : state.bindingState.pluginFallbackReason;
+  state.recordAgentDispatchCompleted(
+    dispatchOutcome,
+    dispatchReason ? { reason: dispatchReason } : undefined,
   );
-  state.markIdle("message_completed");
+  state.recordProcessed(dispatchOutcome, dispatchReason ? { reason: dispatchReason } : undefined);
+  state.markIdle(queueCapRejected ? "message_queue_cap_rejected" : "message_completed");
   state.completeDispatchReplyOperation();
   return {
     status: "complete" as const,

--- a/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
@@ -6,7 +6,10 @@ import type { PluginSubagentRequesterContext } from "../../plugins/runtime/subag
 import { setReplyPayloadMetadata } from "../reply-payload.js";
 import type { MsgContext } from "../templating.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
-import { NO_VISIBLE_REPLY_FALLBACK_TEXT } from "./dispatch-from-config.payloads.js";
+import {
+  NO_VISIBLE_REPLY_FALLBACK_TEXT,
+  QUEUE_CAP_REJECTION_TEXT,
+} from "./dispatch-from-config.payloads.js";
 import {
   createDispatcher,
   diagnosticMocks,
@@ -512,6 +515,45 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(deliveredTexts).not.toContain("visible reply");
     expect(deliveredTexts).toContain(NO_VISIBLE_REPLY_FALLBACK_TEXT);
     expect(result.noVisibleReplyFallbackDelivered).toBe(true);
+  });
+
+  it("reports queue-cap rejection instead of a temporary model failure", async () => {
+    setNoAbort();
+    diagnosticMocks.logMessageDispatchCompleted.mockClear();
+    const deliveredTexts: string[] = [];
+    const dispatcher = createReplyDispatcher({
+      deliver: vi.fn(async (payload) => {
+        deliveredTexts.push(payload.text ?? "");
+      }),
+    });
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      const runState = resolveReplyOperationRunState(opts);
+      if (!runState) {
+        throw new Error("expected reply operation state");
+      }
+      runState.admission = { status: "skipped", reason: "queue-cap" };
+      return undefined;
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({ ChatType: "direct", SessionKey: "test:queue-cap" }),
+      cfg: { diagnostics: { enabled: true } } as OpenClawConfig,
+      dispatcher,
+      replyResolver,
+    });
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+
+    expect(deliveredTexts).toEqual([QUEUE_CAP_REJECTION_TEXT]);
+    expect(deliveredTexts).not.toContain(NO_VISIBLE_REPLY_FALLBACK_TEXT);
+    expect(result.noVisibleReplyFallbackDelivered).toBe(true);
+    expect(diagnosticMocks.logMessageDispatchCompleted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outcome: "skipped",
+        reason: "queue-cap",
+        sessionKey: "test:queue-cap",
+      }),
+    );
   });
 
   it("does not report a pending continuation as an empty terminal reply", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.payloads.ts
+++ b/src/auto-reply/reply/dispatch-from-config.payloads.ts
@@ -18,6 +18,9 @@ const ttsRuntimeLoader = createLazyImportLoader(() => import("../../tts/tts.runt
 export const NO_VISIBLE_REPLY_FALLBACK_TEXT =
   "No reply was generated for this message. This is usually a temporary model failure - please try again.";
 
+export const QUEUE_CAP_REJECTION_TEXT =
+  "This message was not queued because the session queue is full. Please try again after the current response finishes.";
+
 export function createFinalDispatchPayloadDedupeKey(payload: ReplyPayload): string {
   const metadata = getReplyPayloadMetadata(payload);
   return JSON.stringify({

--- a/src/auto-reply/reply/get-reply-run-execute.ts
+++ b/src/auto-reply/reply/get-reply-run-execute.ts
@@ -309,6 +309,9 @@ export async function executePreparedReplyRun(state: PreparedReplyRunAdmission) 
     deliveryCorrelations: opts?.queuedDeliveryCorrelations,
     turnAdoptionLifecycle: opts?.turnAdoptionLifecycle,
     onReplyAdmissionWaitChange: opts?.onReplyAdmissionWaitChange,
+    ...(opts?.onFollowupQueueDisposition
+      ? { onQueueDisposition: opts.onFollowupQueueDisposition }
+      : {}),
     messageId: sessionCtx.MessageSidFull ?? sessionCtx.MessageSid,
     summaryLine: baseBodyTrimmedRaw,
     enqueuedAt: Date.now(),

--- a/src/auto-reply/reply/get-reply.types.ts
+++ b/src/auto-reply/reply/get-reply.types.ts
@@ -5,7 +5,7 @@ import type { ReplyOptionsWithHeartbeatRunScope } from "../../infra/heartbeat-ru
 import type { GetReplyOptions } from "../get-reply-options.types.js";
 import type { ReplyPayload } from "../reply-payload.js";
 import type { MsgContext } from "../templating.js";
-import type { QueueMode } from "./queue/types.js";
+import type { FollowupQueueDisposition, QueueMode } from "./queue/types.js";
 import type { ReplyOptionsWithOperationRunState } from "./reply-operation-run-state.js";
 import type { ReplyOperation } from "./reply-run-registry.js";
 
@@ -27,6 +27,8 @@ type InternalReplySessionOptions = {
   sessionPromptSourceReplyDeliveryMode?: GetReplyOptions["sourceReplyDeliveryMode"];
   /** Marks when this reply is waiting to own its session's reply lane. */
   onReplyAdmissionWaitChange?: (waiting: boolean) => void;
+  /** Receives terminal queue-cap outcomes without widening the public reply API. */
+  onFollowupQueueDisposition?: (disposition: FollowupQueueDisposition) => void;
   /** Overrides persisted queue mode for this reply only. */
   queueModeOverride?: QueueMode;
   /** Dispatch-owned operation used to defer hooks until durable run admission. */

--- a/src/auto-reply/reply/queue.collect.test.ts
+++ b/src/auto-reply/reply/queue.collect.test.ts
@@ -618,13 +618,61 @@ describe("followup queue collect routing", () => {
 
     expect(calls[0]?.prompt).toContain("[Queue overflow] Dropped 1 message due to cap.");
     expect(calls[0]?.prompt).not.toContain("older public content");
-    expect(calls[0]?.prompt).not.toContain("private direct content");
+    expect(calls[0]?.prompt).toContain("- private direct content");
     expect(calls[0]?.originatingTo).toBe("direct:A");
     expect(calls[1]?.prompt).toContain("[Queue overflow] Dropped 1 message due to cap.");
     expect(calls[1]?.prompt).toContain("- older public content");
     expect(calls[1]?.prompt).not.toContain("private direct content");
     expect(calls[1]?.originatingTo).toBe("channel:B");
     expect(calls[2]?.prompt).toContain("newer public content");
+  });
+
+  it("keeps content in every context-isolated overflow summary", async () => {
+    const key = `test-collect-overflow-all-context-lines-${Date.now()}`;
+    const { calls, done, runFollowup } = createDrainRecorder(6);
+    const settings = createQueueSettings({ cap: 3 });
+    const queued = [
+      ["dropped A", "A"],
+      ["dropped B", "B"],
+      ["dropped C1", "C"],
+      ["dropped C2", "C"],
+      ["dropped D", "D"],
+      ["dropped E", "E"],
+      ["survivor 1", "survivor"],
+      ["survivor 2", "survivor"],
+      ["survivor 3", "survivor"],
+    ] as const;
+
+    for (const [prompt, target] of queued) {
+      enqueueTestRun(
+        key,
+        {
+          prompt,
+          originatingChannel: "slack",
+          originatingTo: `channel:${target}`,
+          originatingChatType: "channel",
+        },
+        settings,
+      );
+    }
+
+    scheduleFollowupDrain(key, runFollowup);
+    await done.promise;
+
+    expect(calls).toHaveLength(6);
+    const overflowPrompts = calls.slice(0, 5).map((run) => run.prompt);
+    expect(overflowPrompts).toEqual([
+      expect.stringContaining("- dropped A"),
+      expect.stringContaining("- dropped B"),
+      expect.stringMatching(/- dropped C1[\s\S]*- dropped C2/),
+      expect.stringContaining("- dropped D"),
+      expect.stringContaining("- dropped E"),
+    ]);
+    expect(overflowPrompts[2]).toContain("Dropped 2 messages");
+    expect(overflowPrompts.every((prompt) => prompt.includes("Summary:\n- "))).toBe(true);
+    expect(calls[5]?.prompt).toContain("survivor 1");
+    expect(calls[5]?.prompt).toContain("survivor 2");
+    expect(calls[5]?.prompt).toContain("survivor 3");
   });
 
   it("evicts oldest overflow context metadata when the item cap is reached", () => {
@@ -695,6 +743,8 @@ describe("followup queue collect routing", () => {
   it("does not register a drop:new source that the full queue rejects", () => {
     const key = `test-drop-new-lifecycle-${Date.now()}`;
     const onEnqueued = vi.fn();
+    const onAbandoned = vi.fn();
+    const onDisposition = vi.fn();
     const onComplete = vi.fn();
     const settings = createQueueSettings({ mode: "followup", cap: 1, dropPolicy: "new" });
 
@@ -704,9 +754,11 @@ describe("followup queue collect routing", () => {
         key,
         {
           ...createRun({ prompt: "rejected" }),
+          onQueueDisposition: onDisposition,
           turnAdoptionLifecycle: {
             onAdopted: async () => {},
             onDeferred: onEnqueued,
+            onAbandoned,
             onSettled: onComplete,
           },
         },
@@ -715,6 +767,8 @@ describe("followup queue collect routing", () => {
     ).toBe(false);
 
     expect(onEnqueued).not.toHaveBeenCalled();
+    expect(onDisposition).toHaveBeenCalledWith("queue-cap-new");
+    expect(onAbandoned).toHaveBeenCalledOnce();
     expect(onComplete).toHaveBeenCalledOnce();
     expect(getExistingFollowupQueue(key)?.items.map((item) => item.prompt)).toEqual(["existing"]);
     clearFollowupQueue(key);
@@ -749,7 +803,7 @@ describe("followup queue collect routing", () => {
       "channel:D",
     ]);
     expect(calls[0]?.prompt).toContain("Dropped 1 message");
-    expect(calls[0]?.prompt).not.toContain("content B");
+    expect(calls[0]?.prompt).toContain("- content B");
     expect(calls[1]?.prompt).toContain("- content C");
     expect(calls[2]?.prompt).toContain("content D");
     expect(calls.every((call) => !call.prompt.includes("content A"))).toBe(true);
@@ -1014,6 +1068,7 @@ describe("followup queue collect routing", () => {
     await done.promise;
 
     expect(calls[0]?.prompt).toContain("Dropped 1 message");
+    expect(calls[0]?.prompt).toContain("- second");
     expect(calls[0]?.run.model).toBe("model-b");
     expect(calls[0]?.run.authProfileId).toBe("auth-b");
     expect(calls[1]?.prompt).toContain("- retained");

--- a/src/auto-reply/reply/queue.dedupe.test.ts
+++ b/src/auto-reply/reply/queue.dedupe.test.ts
@@ -381,12 +381,14 @@ describe("followup queue deduplication", () => {
     const key = `test-dedup-evicted-retry-${Date.now()}`;
     const evictSettings: QueueSettings = { mode: "collect", cap: 1, dropPolicy: "old" };
     const onAbandoned = vi.fn();
+    const onDisposition = vi.fn();
     const first = createRun({
       prompt: "first",
       messageId: "m1",
       originatingChannel: "line",
       originatingTo: "group:G1",
     });
+    first.onQueueDisposition = onDisposition;
     first.turnAdoptionLifecycle = { onAdopted: () => {}, onAbandoned };
     expect(enqueueFollowupRun(key, first, evictSettings)).toBe(true);
 
@@ -404,7 +406,8 @@ describe("followup queue deduplication", () => {
         evictSettings,
       ),
     ).toBe(true);
-    expect(onAbandoned).toHaveBeenCalledTimes(1);
+    expect(onDisposition).toHaveBeenCalledWith("queue-cap-old");
+    expect(onAbandoned).toHaveBeenCalledOnce();
 
     const retry = createRun({
       prompt: "first",

--- a/src/auto-reply/reply/queue.drain-restart.test.ts
+++ b/src/auto-reply/reply/queue.drain-restart.test.ts
@@ -566,6 +566,108 @@ describe("followup queue drain restart after idle window", () => {
     expect(retainedIdentityCount).toBeLessThanOrEqual(2);
   });
 
+  it.each(["old", "new"] as const)(
+    "drains a pending overflow summary after future drops switch to %s",
+    async (dropPolicy) => {
+      resetGatewayWorkAdmission();
+      const key = `test-summary-policy-transition-${dropPolicy}-${Date.now()}`;
+      const summarizeSettings: QueueSettings = {
+        mode: "followup",
+        debounceMs: 0,
+        cap: 1,
+        dropPolicy: "summarize",
+      };
+      const nonOutcomeAbandoned = vi.fn();
+      const nonOutcomeSettled = vi.fn();
+      const createRecordedNonOutcome = (prompt: string) => {
+        const run = createRun({ prompt });
+        run.turnAdoptionLifecycle = {
+          admission: "cancel-only",
+          onAdopted: vi.fn(),
+          onAbandoned: nonOutcomeAbandoned,
+          onSettled: nonOutcomeSettled,
+        };
+        return run;
+      };
+      const first = createRun({ prompt: "first overflowed message" });
+      const second =
+        dropPolicy === "old"
+          ? createRecordedNonOutcome("second queued message")
+          : createRun({ prompt: "second queued message" });
+      const third =
+        dropPolicy === "new"
+          ? createRecordedNonOutcome("third rejected message")
+          : createRun({ prompt: "third queued message" });
+      const deliveredPrompts: string[] = [];
+      let forcedCleanup = false;
+      let timerFired = false;
+
+      try {
+        expect(enqueueFollowupRun(key, first, summarizeSettings)).toBe(true);
+        expect(enqueueFollowupRun(key, second, summarizeSettings)).toBe(true);
+        const queue = getExistingFollowupQueue(key);
+        expect(queue).toMatchObject({
+          dropPolicy: "summarize",
+          droppedCount: 1,
+          summaryLines: ["first overflowed message"],
+        });
+        expect(queue?.summarySources).toEqual([first]);
+        expect(queue?.items).toEqual([second]);
+
+        const admitted = enqueueFollowupRun(key, third, {
+          ...summarizeSettings,
+          dropPolicy,
+        });
+        expect(admitted).toBe(dropPolicy === "old");
+        expect(getExistingFollowupQueue(key)).toBe(queue);
+        expect(queue).toMatchObject({
+          dropPolicy,
+          droppedCount: 1,
+          summaryLines: ["first overflowed message"],
+        });
+        expect(queue?.summarySources).toEqual([first]);
+        expect(queue?.items).toEqual([dropPolicy === "old" ? third : second]);
+
+        const timer = new Promise<void>((resolve) => {
+          setTimeout(() => {
+            timerFired = true;
+            resolve();
+          }, 0);
+        });
+        scheduleFollowupDrain(key, async (run) => {
+          deliveredPrompts.push(run.prompt);
+        });
+
+        for (let pass = 0; pass < 2_000 && getExistingFollowupQueue(key); pass += 1) {
+          await Promise.resolve();
+        }
+        if (getExistingFollowupQueue(key)) {
+          forcedCleanup = true;
+          clearSessionQueues([key]);
+        }
+        await timer;
+        await vi.waitFor(() => {
+          expect(getActiveGatewayRootWorkCount()).toBe(0);
+        });
+
+        expect(forcedCleanup).toBe(false);
+        expect(timerFired).toBe(true);
+        expect(deliveredPrompts).toHaveLength(2);
+        expect(deliveredPrompts[0]).toContain("[Queue overflow] Dropped 1 message due to cap.");
+        expect(deliveredPrompts[0]).toContain("first overflowed message");
+        expect(deliveredPrompts[1]).toBe(
+          dropPolicy === "old" ? "third queued message" : "second queued message",
+        );
+        expect(nonOutcomeAbandoned).toHaveBeenCalledTimes(1);
+        expect(nonOutcomeSettled).toHaveBeenCalledTimes(1);
+        expect(getExistingFollowupQueue(key)).toBeUndefined();
+      } finally {
+        clearSessionQueues([key]);
+        resetGatewayWorkAdmission();
+      }
+    },
+  );
+
   it("does not process messages after clearSessionQueues clears the callback", async () => {
     const key = `test-clear-callback-${Date.now()}`;
     const calls: FollowupRun[] = [];

--- a/src/auto-reply/reply/queue.drain-restart.test.ts
+++ b/src/auto-reply/reply/queue.drain-restart.test.ts
@@ -578,9 +578,11 @@ describe("followup queue drain restart after idle window", () => {
         dropPolicy: "summarize",
       };
       const nonOutcomeAbandoned = vi.fn();
+      const nonOutcomeDisposition = vi.fn();
       const nonOutcomeSettled = vi.fn();
       const createRecordedNonOutcome = (prompt: string) => {
         const run = createRun({ prompt });
+        run.onQueueDisposition = nonOutcomeDisposition;
         run.turnAdoptionLifecycle = {
           admission: "cancel-only",
           onAdopted: vi.fn(),
@@ -658,7 +660,8 @@ describe("followup queue drain restart after idle window", () => {
         expect(deliveredPrompts[1]).toBe(
           dropPolicy === "old" ? "third queued message" : "second queued message",
         );
-        expect(nonOutcomeAbandoned).toHaveBeenCalledTimes(1);
+        expect(nonOutcomeDisposition).toHaveBeenCalledWith(`queue-cap-${dropPolicy}`);
+        expect(nonOutcomeAbandoned).toHaveBeenCalledOnce();
         expect(nonOutcomeSettled).toHaveBeenCalledTimes(1);
         expect(getExistingFollowupQueue(key)).toBeUndefined();
       } finally {

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -594,6 +594,16 @@ type QueueSummaryDelivery = {
   sources: FollowupRun[];
 };
 
+function resolveQueueSummaryLines(
+  queue: Pick<FollowupQueueSummaryState, "summaryLines" | "summarySources">,
+  sources: FollowupRun[],
+): string[] {
+  return sources.map((source) => {
+    const sourceIndex = queue.summarySources.indexOf(source);
+    return expectDefined(queue.summaryLines[sourceIndex], "summary line for retained source");
+  });
+}
+
 function createQueueSummaryDelivery(params: {
   queue: FollowupQueueSummaryState;
   sources?: FollowupRun[];
@@ -607,7 +617,7 @@ function createQueueSummaryDelivery(params: {
   }
   const droppedCount = params.sources ? sources.length : params.queue.droppedCount;
   const summaryLines = params.sources
-    ? params.queue.summaryLines.slice(0, sources.length)
+    ? resolveQueueSummaryLines(params.queue, sources)
     : [...params.queue.summaryLines];
   const prompt = previewQueueSummaryPrompt({
     state: {
@@ -1028,7 +1038,7 @@ async function drainElidedOverflowSummary(params: {
   const elidedCount = entry.sources.length;
   const elidedSources = [...entry.sources];
   const droppedCount = elidedCount + retainedSources.length;
-  const retainedSummaryLines = params.queue.summaryLines.slice(0, retainedSources.length);
+  const retainedSummaryLines = resolveQueueSummaryLines(params.queue, retainedSources);
   const summaryLines = [...entry.summaryLines, ...retainedSummaryLines].slice(-params.queue.cap);
   const prompt = previewQueueSummaryPrompt({
     state: {

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -582,6 +582,7 @@ type FollowupQueueSummaryState = {
     contextKey: string;
     count: number;
     sources: FollowupRun[];
+    summaryLines: string[];
     sourceRefs: WeakMap<FollowupRun, FollowupRun>;
   }>;
   evictedSummaryCount: number;
@@ -647,7 +648,10 @@ function consumeQueueSummaryDelivery(
           "summary elisions entry at elision index",
         );
         const elidedSourceIndex = entry.sources.indexOf(entry.sourceRefs.get(source) ?? source);
-        entry.sources.splice(elidedSourceIndex, 1);
+        if (elidedSourceIndex >= 0) {
+          entry.sources.splice(elidedSourceIndex, 1);
+          entry.summaryLines.splice(elidedSourceIndex, 1);
+        }
         entry.count = entry.sources.length;
         consumedCount += 1;
         if (entry.sources.length === 0) {
@@ -1008,6 +1012,7 @@ async function drainElidedOverflowSummary(params: {
       continue;
     }
     entry.sources.splice(index, 1);
+    entry.summaryLines.splice(index, 1);
     entry.count = Math.max(0, entry.count - 1);
     params.queue.droppedCount = Math.max(0, params.queue.droppedCount - 1);
     completeFollowupRunLifecycle(source);
@@ -1023,7 +1028,8 @@ async function drainElidedOverflowSummary(params: {
   const elidedCount = entry.sources.length;
   const elidedSources = [...entry.sources];
   const droppedCount = elidedCount + retainedSources.length;
-  const summaryLines = params.queue.summaryLines.slice(0, retainedSources.length);
+  const retainedSummaryLines = params.queue.summaryLines.slice(0, retainedSources.length);
+  const summaryLines = [...entry.summaryLines, ...retainedSummaryLines].slice(-params.queue.cap);
   const prompt = previewQueueSummaryPrompt({
     state: {
       droppedCount,
@@ -1062,6 +1068,7 @@ async function drainElidedOverflowSummary(params: {
   }
   const consumedCount = Math.min(elidedCount, entry.sources.length);
   const consumedSources = entry.sources.splice(0, consumedCount);
+  entry.summaryLines.splice(0, consumedCount);
   entry.count = entry.sources.length;
   for (const consumedSource of consumedSources) {
     completeFollowupRunLifecycle(consumedSource);

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -574,7 +574,6 @@ function collectRuntimeMetadata(
 
 type FollowupQueueSummaryState = {
   cap: number;
-  dropPolicy: "summarize" | "old" | "new";
   droppedCount: number;
   summaryLines: string[];
   summarySources: FollowupRun[];
@@ -611,7 +610,6 @@ function createQueueSummaryDelivery(params: {
     : [...params.queue.summaryLines];
   const prompt = previewQueueSummaryPrompt({
     state: {
-      dropPolicy: params.queue.dropPolicy,
       droppedCount,
       summaryLines,
     },
@@ -1028,7 +1026,6 @@ async function drainElidedOverflowSummary(params: {
   const summaryLines = params.queue.summaryLines.slice(0, retainedSources.length);
   const prompt = previewQueueSummaryPrompt({
     state: {
-      dropPolicy: params.queue.dropPolicy,
       droppedCount,
       summaryLines,
     },

--- a/src/auto-reply/reply/queue/enqueue.ts
+++ b/src/auto-reply/reply/queue/enqueue.ts
@@ -124,6 +124,7 @@ export function enqueueFollowupRun(
   // publish an external queued identity for work that will never be admitted.
   const pendingCount = countPendingQueueItems(queue.items, queue.inFlight);
   if (queue.dropPolicy === "new" && queue.cap > 0 && pendingCount >= queue.cap) {
+    run.onQueueDisposition?.("queue-cap-new");
     completeFollowupRunLifecycle(run);
     return false;
   }
@@ -131,16 +132,19 @@ export function enqueueFollowupRun(
     return false;
   }
 
+  const elidedSummaryLines: string[] = [];
   const shouldEnqueue = applyQueueDropPolicy({
     queue,
     inFlight: queue.inFlight,
     summarize: (item) => normalizeOptionalString(item.summaryLine) || item.prompt.trim(),
+    onSummaryElide: (lines) => elidedSummaryLines.push(...lines),
     onDrop: (dropped) => {
       if (queue.dropPolicy === "summarize") {
         queue.summarySources.push(...dropped);
         return;
       }
       for (const item of dropped) {
+        item.onQueueDisposition?.("queue-cap-old");
         completeFollowupRunLifecycle(item);
       }
     },
@@ -150,13 +154,18 @@ export function enqueueFollowupRun(
     const overflow = queue.summarySources.length - queue.summaryLines.length;
     if (overflow > 0) {
       const removed = queue.summarySources.splice(0, overflow);
-      for (const item of removed) {
+      for (const [index, item] of removed.entries()) {
+        const summaryLine = elidedSummaryLines[index];
+        if (summaryLine === undefined) {
+          throw new Error("followup queue summary source lost its elided line");
+        }
         const contextKey = resolveFollowupDeliveryContextKey(item);
         const lastElision = queue.summaryElisions.at(-1);
         if (lastElision?.contextKey === contextKey) {
           const compactSource = createOverflowSummaryRetrySource(item);
           lastElision.count += 1;
           lastElision.sources.push(compactSource);
+          lastElision.summaryLines.push(summaryLine);
           lastElision.sourceRefs.set(item, compactSource);
           if (queue.activeSummarySources.has(item)) {
             queue.activeSummarySources.add(compactSource);
@@ -167,6 +176,7 @@ export function enqueueFollowupRun(
             contextKey,
             count: 1,
             sources: [compactSource],
+            summaryLines: [summaryLine],
             sourceRefs: new WeakMap([[item, compactSource]]),
           });
           if (queue.activeSummarySources.has(item)) {
@@ -178,6 +188,7 @@ export function enqueueFollowupRun(
     }
   }
   if (!shouldEnqueue) {
+    run.onQueueDisposition?.("queue-cap");
     completeFollowupRunLifecycle(run);
     return false;
   }

--- a/src/auto-reply/reply/queue/state.test.ts
+++ b/src/auto-reply/reply/queue/state.test.ts
@@ -61,6 +61,7 @@ describe("refreshQueuedFollowupSession", () => {
           run: makeRun(),
         },
       ],
+      summaryLines: ["elided summary"],
       sourceRefs: new WeakMap(),
     });
 
@@ -232,6 +233,7 @@ describe("getFollowupQueue", () => {
           enqueuedAt: Date.now(),
           run: makeRun(),
         })),
+        summaryLines: Array.from({ length: count }, () => contextKey),
         sourceRefs: new WeakMap(),
       });
     }
@@ -241,6 +243,7 @@ describe("getFollowupQueue", () => {
 
     expect(updated.summaryElisions.map((entry) => entry.contextKey)).toEqual(["newest"]);
     expect(updated.summaryElisions[0]?.sources).toHaveLength(1);
+    expect(updated.summaryElisions[0]?.summaryLines).toEqual(["newest"]);
     expect(updated.evictedSummaryCount).toBe(13);
   });
 });

--- a/src/auto-reply/reply/queue/state.ts
+++ b/src/auto-reply/reply/queue/state.ts
@@ -38,6 +38,8 @@ type FollowupQueueState = {
     count: number;
     /** Compact sources stay strong so cancellation follows summarized content until delivery. */
     sources: FollowupRun[];
+    /** Summary lines stay index-aligned with sources across context isolation and eviction. */
+    summaryLines: string[];
     /** Weak source mapping keeps concurrent summary consumption identity-safe. */
     sourceRefs: WeakMap<FollowupRun, FollowupRun>;
   }>;
@@ -102,6 +104,7 @@ export function trimSummaryElisionsToCap(queue: SummaryElisionCapState): void {
         continue;
       }
       const [source] = entry.sources.splice(sourceIndex, 1);
+      entry.summaryLines.splice(sourceIndex, 1);
       entry.count = entry.sources.length;
       queue.evictedSummaryCount += 1;
       sourceCount -= 1;

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -56,6 +56,8 @@ export type EnqueueFollowupRunOptions = {
   position?: QueueInsertPosition;
 };
 
+export type FollowupQueueDisposition = "queue-cap" | "queue-cap-old" | "queue-cap-new";
+
 export class FollowupRunDeferredError extends Error {
   constructor(message = "Follow-up run deferred") {
     super(message);
@@ -89,6 +91,8 @@ export type FollowupRun = {
   turnAdoptionLifecycle?: TurnAdoptionLifecycle;
   /** Dispatch-scoped freshness owner for a queued delivery-barrier wait. */
   onReplyAdmissionWaitChange?: (waiting: boolean) => void;
+  /** Records terminal queue-cap outcomes at the queue owner before lifecycle cleanup. */
+  onQueueDisposition?: (disposition: FollowupQueueDisposition) => void;
   /** Provider message ID, when available (for deduplication). */
   messageId?: string;
   summaryLine?: string;

--- a/src/auto-reply/reply/reply-operation-run-state.ts
+++ b/src/auto-reply/reply/reply-operation-run-state.ts
@@ -1,7 +1,12 @@
+import type { FollowupRun } from "./queue/types.js";
+
 type ReplyOperationAdmissionSnapshot =
   | { status: "owned" }
   | { status: "accepted"; mode: "steer" | "followup" }
-  | { status: "skipped"; reason: "active-run" | "aborted" | "lifecycle-invalidated" };
+  | {
+      status: "skipped";
+      reason: "active-run" | "aborted" | "lifecycle-invalidated" | "queue-cap";
+    };
 
 export type ReplyOperationRunState = {
   admission?: ReplyOperationAdmissionSnapshot;
@@ -19,4 +24,17 @@ export function resolveReplyOperationRunState(
   options: object | undefined,
 ): ReplyOperationRunState | undefined {
   return (options as ReplyOptionsWithOperationRunState | undefined)?.[REPLY_OPERATION_RUN_STATE];
+}
+
+export function bindQueueDispositionToRunState(
+  run: FollowupRun,
+  state: ReplyOperationRunState | undefined,
+): void {
+  const observe = run.onQueueDisposition;
+  run.onQueueDisposition = (disposition) => {
+    observe?.(disposition);
+    if (state && disposition !== "queue-cap-old") {
+      state.admission = { status: "skipped", reason: "queue-cap" };
+    }
+  };
 }

--- a/src/gateway/server-methods/chat-send-handler.ts
+++ b/src/gateway/server-methods/chat-send-handler.ts
@@ -402,6 +402,14 @@ export async function handleChatSend(
                 abortSignal: activeRunAbort.controller.signal,
                 // Keep a Gateway-owned cancel identity after this chat.send
                 // terminalizes while the prompt waits in followup/collect queue.
+                onFollowupQueueDisposition: (reason) => {
+                  context.logGateway.info("chat queue turn intentionally skipped", {
+                    runId: clientRunId,
+                    sessionKey,
+                    outcome: "skipped",
+                    reason,
+                  });
+                },
                 turnAdoptionLifecycle: {
                   // Gateway cancel identity only — share collect key via ownerKey.
                   admission: "cancel-only",

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -3974,10 +3974,12 @@ describe("gateway server chat", () => {
         getRuntimeConfig: () => ({}),
       });
       let turnAdoptionLifecycle: GetReplyOptions["turnAdoptionLifecycle"];
+      let onQueueDisposition: InternalGetReplyOptions["onFollowupQueueDisposition"];
       const dispatchRelease = createDeferred();
       dispatchInboundMessageMock.mockImplementationOnce(async (args: unknown) => {
-        turnAdoptionLifecycle = (args as { replyOptions?: GetReplyOptions }).replyOptions
-          ?.turnAdoptionLifecycle;
+        const replyOptions = (args as { replyOptions?: InternalGetReplyOptions }).replyOptions;
+        turnAdoptionLifecycle = replyOptions?.turnAdoptionLifecycle;
+        onQueueDisposition = replyOptions?.onFollowupQueueDisposition;
         turnAdoptionLifecycle?.onDeferred?.();
         await dispatchRelease.promise;
         return {};
@@ -4032,6 +4034,17 @@ describe("gateway server chat", () => {
       );
       expect(finalEvents).toHaveLength(1);
       expect(context.chatQueuedTurns.has("idem-queued-followup")).toBe(true);
+
+      onQueueDisposition?.("queue-cap-old");
+      expect(context.logGateway.info).toHaveBeenCalledWith(
+        "chat queue turn intentionally skipped",
+        {
+          runId: "idem-queued-followup",
+          sessionKey: "agent:main:main",
+          outcome: "skipped",
+          reason: "queue-cap-old",
+        },
+      );
 
       context.dedupe.delete("chat:idem-queued-followup");
       const replayRespond = vi.fn() as RespondFn;

--- a/src/gateway/server.sessions.compaction.test.ts
+++ b/src/gateway/server.sessions.compaction.test.ts
@@ -1530,6 +1530,7 @@ test("sessions.compact preserves summary-elided queued follow-up work", async ()
     contextKey: "test",
     count: 1,
     sources: [elidedRun],
+    summaryLines: ["elided summary"],
     sourceRefs: new WeakMap(),
   });
 

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -1832,6 +1832,81 @@ describe("EmbeddedTuiBackend", () => {
     await flushMicrotasks();
   });
 
+  it.each(["old", "new"] as const)(
+    "keeps a local overflow summary after future drops switch to %s",
+    async (nextDropPolicy) => {
+      const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+      const active = deferred<{
+        payloads: Array<{ text: string }>;
+        meta: Record<string, unknown>;
+      }>();
+      const collected = deferred<{
+        payloads: Array<{ text: string }>;
+        meta: Record<string, unknown>;
+      }>();
+      agentCommandFromIngressMock
+        .mockReturnValueOnce(active.promise)
+        .mockReturnValueOnce(collected.promise);
+      let dropPolicy: "summarize" | "old" | "new" = "summarize";
+      let cap = 1;
+      loadSessionEntryMock.mockImplementation((sessionKey: string) => ({
+        cfg: { messages: { queue: { mode: "collect", cap, drop: dropPolicy } } },
+        canonicalKey: sessionKey,
+        storePath: "/tmp/openclaw-sessions.json",
+        store: {},
+        entry: { queueDebounceMs: 0 },
+      }));
+
+      const backend = new EmbeddedTuiBackend();
+      backend.start();
+      try {
+        await backend.sendChat({
+          sessionKey: "agent:main:main",
+          message: "active turn",
+          runId: `run-local-policy-active-${nextDropPolicy}`,
+        });
+        await backend.sendChat({
+          sessionKey: "agent:main:main",
+          message: "first overflowed message",
+          runId: `run-local-policy-first-${nextDropPolicy}`,
+        });
+        await backend.sendChat({
+          sessionKey: "agent:main:main",
+          message: "second queued message",
+          runId: `run-local-policy-second-${nextDropPolicy}`,
+        });
+
+        dropPolicy = nextDropPolicy;
+        cap = 2;
+        await backend.sendChat({
+          sessionKey: "agent:main:main",
+          message: "third queued message",
+          runId: `run-local-policy-third-${nextDropPolicy}`,
+        });
+
+        active.resolve({ payloads: [{ text: "active done" }], meta: {} });
+        await vi.waitFor(() => {
+          expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(2);
+        });
+        const queuedCall = agentCommandFromIngressMock.mock.calls[1];
+        if (!queuedCall) {
+          throw new Error("expected queued local followup call");
+        }
+        const queuedPrompt = (queuedCall[0] as { message: string }).message;
+        expect(queuedPrompt).toContain("[Queue overflow] Dropped 1 message due to cap.");
+        expect(queuedPrompt).toContain("first overflowed message");
+        expect(queuedPrompt).toContain("second queued message");
+        expect(queuedPrompt).toContain("third queued message");
+        expect(queuedPrompt.match(/\[Queue overflow\]/g) ?? []).toHaveLength(1);
+
+        collected.resolve({ payloads: [{ text: "collected done" }], meta: {} });
+        await flushMicrotasks();
+      } finally {
+        await backend.stop();
+      }
+    },
+  );
+
   it("applies the local queue cap and drop-new policy", async () => {
     const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const first = deferred<{

--- a/src/utils/queue-helpers.test.ts
+++ b/src/utils/queue-helpers.test.ts
@@ -63,9 +63,8 @@ describe("applyQueueRuntimeSettings", () => {
 });
 
 describe("queue summary helpers", () => {
-  it("previewQueueSummaryPrompt does not mutate state", () => {
+  it("renders pending summary state without mutating it", () => {
     const state = {
-      dropPolicy: "summarize" as const,
       droppedCount: 2,
       summaryLines: ["first", "second"],
     };
@@ -78,7 +77,6 @@ describe("queue summary helpers", () => {
     expect(prompt).toContain("[Queue overflow] Dropped 2 messages due to cap.");
     expect(prompt).toContain("first");
     expect(state).toEqual({
-      dropPolicy: "summarize",
       droppedCount: 2,
       summaryLines: ["first", "second"],
     });

--- a/src/utils/queue-helpers.ts
+++ b/src/utils/queue-helpers.ts
@@ -110,6 +110,7 @@ export function applyQueueDropPolicy<T>(params: {
   summarize: (item: T) => string;
   summaryLimit?: number;
   onDrop?: (items: T[]) => void;
+  onSummaryElide?: (lines: string[]) => void;
   inFlight?: ReadonlySet<T>;
   isProtected?: (item: T) => boolean;
 }): boolean {
@@ -153,8 +154,15 @@ export function applyQueueDropPolicy<T>(params: {
     }
     // Summary memory is bounded independently from the item cap to avoid prompt blowups.
     const limit = Math.max(0, params.summaryLimit ?? cap);
+    const elidedLines: string[] = [];
     while (params.queue.summaryLines.length > limit) {
-      params.queue.summaryLines.shift();
+      const line = params.queue.summaryLines.shift();
+      if (line !== undefined) {
+        elidedLines.push(line);
+      }
+    }
+    if (elidedLines.length > 0) {
+      params.onSummaryElide?.(elidedLines);
     }
   }
   return true;

--- a/src/utils/queue-helpers.ts
+++ b/src/utils/queue-helpers.ts
@@ -8,20 +8,20 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { isFastTestRuntimeEnv } from "../infra/env.js";
 
-/** Mutable summary state for a capped queue. */
+/** Pending overflow summary state produced by the summarize drop policy. */
 type QueueSummaryState = {
-  dropPolicy: "summarize" | "old" | "new";
   droppedCount: number;
   summaryLines: string[];
 };
 
-/** Queue overflow strategy. */
-type QueueDropPolicy = QueueSummaryState["dropPolicy"];
+/** Queue overflow strategy for future admissions. */
+type QueueDropPolicy = "summarize" | "old" | "new";
 
 /** Generic capped queue state with shared overflow summary fields. */
 type QueueState<T> = QueueSummaryState & {
   items: T[];
   cap: number;
+  dropPolicy: QueueDropPolicy;
 };
 
 /** Build a summary prompt preview without mutating the source queue state. */
@@ -307,7 +307,7 @@ function buildQueueSummaryPrompt(params: {
   noun: string;
   title?: string;
 }): string | undefined {
-  if (params.state.dropPolicy !== "summarize" || params.state.droppedCount <= 0) {
+  if (params.state.droppedCount <= 0) {
     return undefined;
   }
   const noun = params.noun;


### PR DESCRIPTION
> [AI-assisted] This PR was investigated and implemented with coding-agent assistance, source-blind behavior validation, and the repository autoreview workflow.

Closes #119312

## What Problem This Solves

Fixes an issue where a session queue that overflowed under the default `summarize` policy could stop the entire gateway after the operator changed future drops to `old` or `new`. The pending overflow summary became unrenderable, so the drain repeatedly scheduled zero-work passes without yielding to timers, channel ingress, typing keepalives, or transport watchdogs.

The same investigation found three connected outcome gaps in the queue owner: context-isolated summarize deliveries could become count-only prompts, `drop: old` evictions had no recorded intentional non-outcome, and `drop: new` incorrectly surfaced the generic temporary-model-failure message.

Reported with a production-path reproduction by @yetval. This PR preserves @ml12580's contributor credit while replacing the earlier transition-reconciliation implementation with a single queue-owner repair.

## Why This Change Was Made

A queue's current drop policy controls future admission. Positive dropped counts, source identities, and summary lines describe already-produced overflow work and must remain deliverable until consumed. The old implementation mixed those two responsibilities and stored summary source/content in parallel structures that could lose their association.

This change:

- renders pending overflow state independently of later admission-policy changes;
- moves bounded summary content with its exact source identity through context isolation, trimming, abort, retry, and consumption;
- resolves retained summary lines by source identity rather than queue position;
- records queue-cap disposition at the enqueue/drop producer and carries it through an internal-only owner callback;
- reports `drop: new` as a skipped queue-full outcome with accurate visible text;
- records later Gateway `drop: old` eviction as an intentional skipped outcome while preserving durable channel-ingress abandonment/retry behavior.

No config, stored-data schema, protocol, plugin SDK, or public reply API changes.

## User Impact

Operators can change queue drop policy after an overflow without wedging the gateway. Pending summaries are delivered once with correctly scoped content, retained queue work continues under the new policy, the queue is deleted, and normal event-loop timers continue running.

A newest-message queue-cap rejection now says the session queue is full instead of blaming a temporary model failure. A previously acknowledged Gateway turn later evicted by `drop: old` is recorded as an intentional skipped queue outcome rather than disappearing behind an earlier generic `completed` diagnostic.

Release-note context: prevent process-wide message stalls and misleading or silent queue-drop outcomes after follow-up queue overflow. Reported by @yetval.

## Evidence

Before the fix, the issue's production-runtime harness observed 5,001 drain passes in 29 ms, only one real followup call, and a zero-delay timer that never fired.

Source-blind validation of the first repair confirmed responsiveness and policy-transition draining, then found the connected summarize-content, `drop: old`, and `drop: new` outcome gaps described above. This exact head addresses each at the queue/admission owner. The exact-head production queue transcript is posted at https://github.com/openclaw/openclaw/pull/119331#issuecomment-5187583498.

Focused proof on exact head `095cb4d1158c6b954c1c60a6732d2f88ad33ace3` after rebasing onto current `main`:

- Exact-head production queue run: five context-isolated overflow deliveries all included content; the `old` and `new` transitions emitted `queue-cap-old`/`queue-cap-new`, delivered the retained work, deleted the queue, and let an armed timer fire.
- `node scripts/run-vitest.mjs` over queue helpers, collect/dedupe/drain/state, agent-runner admission, dispatch finalization, Gateway chat/session, and embedded TUI suites — 24 unit-fast, 121 Gateway, 90 TUI, 448 auto-reply, and 130 E2E tests passed.
- The summarize pressure regression queues nine marked messages at cap 3 across five delivery contexts and proves every one of the five overflow deliveries includes correctly scoped content; the shared C-context delivery contains both C sources.
- The policy-transition regression covers both `old` and `new`, exact original order, lifecycle settlement, queue deletion, bounded drain calls, and real timer progress without forced cleanup.
- Admission/finalization coverage proves `drop: new` emits the queue-full text, never the temporary-model-failure text, and records `outcome=skipped reason=queue-cap`.
- Queue/Gateway coverage proves `drop: old` emits the source-owned `queue-cap-old` disposition, retains durable ingress retry behavior, and records the acknowledged Gateway turn as intentionally skipped.
- `node scripts/check-changed.mjs -- <changed files>` could not use the configured remote route because Crabbox had no ready provider. The required trusted-source local fallback passed conflict/ratchet, formatting, API, boundary, dead-export, typecheck, lint, state-schema, database-first, sidecar, webhook, auth, and import-cycle checks on the current-main rebase.
- `git diff --check` passed.
- Final Codex-backed branch autoreview at P1: clean, no accepted/actionable findings; overall correctness 0.84. A prior review finding about retained-line positional selection was fixed by resolving each line from its exact source identity, then re-reviewed clean at 0.95.

Production delta is net +81 lines; tests are net +300 lines. The production growth establishes the missing queue ownership boundary: paired source/content state, source-owned terminal queue dispositions, centralized accurate presentation, and Gateway recording. No live operator gateway or user-owned channel was touched.