### PR TITLE
fix(release): filter validation ancestry fetch

### DIFF
--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -968,7 +968,7 @@ jobs:
           EXPECTED_SHA="$(git rev-parse HEAD)"
           MANIFEST_FILE="full-release-validation/full-release-validation-manifest.json"
           export EXPECTED_SHA MANIFEST_FILE
-          timeout --signal=TERM --kill-after=10s 120s git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          timeout --signal=TERM --kill-after=10s 120s git fetch --filter=blob:none --no-tags origin +refs/heads/main:refs/remotes/origin/main
           gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${FULL_RELEASE_VALIDATION_RUN_ID}/attempts/${FULL_RELEASE_VALIDATION_RUN_ATTEMPT}" | \
             node trusted-workflow/scripts/validate-full-release-validation-evidence.mjs
 

--- a/test/scripts/openclaw-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/openclaw-npm-extended-stable-workflow.test.ts
@@ -252,6 +252,7 @@ describe("minimal npm extended-stable workflow", () => {
     expect(fullValidation.run).toContain(
       "actions/runs/${FULL_RELEASE_VALIDATION_RUN_ID}/attempts/${FULL_RELEASE_VALIDATION_RUN_ATTEMPT}",
     );
+    expect(fullValidation.run).toContain("--filter=blob:none");
     expect(fullValidation.run).toContain(
       "trusted-workflow/scripts/validate-full-release-validation-evidence.mjs",
     );


### PR DESCRIPTION
## What Problem This Solves

The core `v2026.6.34` recovery publish reached `Verify full release validation evidence` and timed out after 120 seconds while fetching `main` to prove the SHA-pinned validation harness is trusted. It failed before npm publication.

## Why This Change Was Made

The publish job checks out the immutable release tag at depth 1. Its ancestry-only fetch then requested `main` without an object filter, allowing the Git fetch to transfer repository blobs it never reads. This adds Git's `blob:none` filter to that one fetch while preserving the complete commit graph required by `git merge-base --is-ancestor`.

## User Impact

This changes no release artifact, tag, validation policy, or npm publishing permission. It makes the existing trusted-harness evidence check reliably complete within its existing timeout, so the frozen 2026.6.34 core tarball can be promoted after approval.

## Evidence

- Reproduced the production topology locally: depth-1 checkout of `v2026.6.34`, filtered fetch of `main`, then verified trusted harness `b5d41f90053b414267bb203b64f1f8dde12b2bda` is an ancestor of `main`.
- `node scripts/run-vitest.mjs test/scripts/openclaw-npm-extended-stable-workflow.test.ts test/scripts/validate-full-release-validation-evidence.test.ts` — 39 passed.
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/openclaw-npm-release.yml` — passed.
- `pnpm exec oxfmt --check .github/workflows/openclaw-npm-release.yml test/scripts/openclaw-npm-extended-stable-workflow.test.ts` and `git diff --check` — passed.
- Fresh autoreview — clean, no accepted/actionable findings.

