### PR TITLE
docs(browser): a declared local profile must set cdpPort or cdpUrl

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -502,9 +502,10 @@ See [Plugins](/tools/plugin).
   snapshot/ref-driven actions instead of CSS-selector targeting, one-file upload
   hooks, no dialog timeout overrides, no `wait --load networkidle`, and no
   `responsebody`, PDF export, download interception, or batch actions.
-- Local managed `openclaw` profiles auto-assign `cdpPort` and `cdpUrl`; set
-  `cdpUrl` explicitly only for remote CDP profiles or existing-session endpoint
-  attach.
+- Local managed `openclaw` profiles get a `cdpPort` allocated from the managed
+  range when OpenClaw creates the profile. A profile you declare by hand must
+  set `cdpPort` itself, or `cdpUrl` for a remote CDP endpoint; the schema
+  rejects an `openclaw` or `clawd` profile that sets neither.
 - Local managed profiles can set `executablePath` to override the global
   `browser.executablePath` for that profile. Use this to run one profile in
   Chrome and another in Brave.

--- a/docs/tools/browser-linux-troubleshooting.md
+++ b/docs/tools/browser-linux-troubleshooting.md
@@ -149,8 +149,9 @@ Notes:
   limits: ref-driven actions only, one file per upload, no dialog `timeoutMs`
   overrides, no `wait --load networkidle`, and no `responsebody`, PDF export,
   download interception, or batch actions.
-- Local `openclaw`-driver profiles auto-assign `cdpPort`/`cdpUrl`; only set
-  those manually for remote CDP.
+- Local `openclaw`-driver profiles get a `cdpPort` allocated when OpenClaw
+  creates them; a profile you declare by hand must set `cdpPort` itself, or
+  `cdpUrl` for remote CDP.
 - Remote CDP profiles accept `http://`, `https://`, `ws://`, and `wss://`.
   Use HTTP(S) for `/json/version` discovery, or WS(S) when your browser
   service gives you a direct DevTools socket URL.

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -312,8 +312,7 @@ main model can read the screenshot directly.
   for a remote endpoint: the schema rejects an `openclaw` or `clawd` profile
   that sets neither with `Profile must set cdpPort or cdpUrl`.
   `existing-session` profiles take the endpoint from `cdpUrl` and ignore
-  `cdpPort`; `extension` profiles own their relay port and reject `cdpUrl`. The
-  top-level `browser.cdpUrl` defaults to the managed local CDP port when unset.
+  `cdpPort`; `extension` profiles own their relay port and reject `cdpUrl`.
 - Remote and `attachOnly` CDP reachability, WebSocket handshakes, and local
   managed-Chrome startup use built-in deadlines.
 - Repeated managed Chrome launch/readiness failures are circuit-broken per

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -305,9 +305,15 @@ main model can read the screenshot directly.
 <Accordion title="Ports and reachability">
 
 - Control service binds to loopback on a port derived from `gateway.port` (default `18791` = gateway + 2). `OPENCLAW_GATEWAY_PORT` takes priority over `gateway.port`; either shifts the derived ports in the same family.
-- Local `openclaw` profiles auto-assign `cdpPort`/`cdpUrl` from a range starting 9 ports above the control port (default `18800`-`18899`); set those only for
-  remote CDP profiles or existing-session endpoint attach. `cdpUrl` defaults to
-  the managed local CDP port when unset.
+- Local `openclaw` profiles use a CDP port range starting 9 ports above the control port (default `18800`-`18899`). OpenClaw allocates from that range for
+  the implicit default profile and for profiles created with
+  `openclaw browser create-profile`, writing the chosen `cdpPort` into the
+  config. A profile you declare by hand must set `cdpPort` itself, or `cdpUrl`
+  for a remote endpoint: the schema rejects an `openclaw` or `clawd` profile
+  that sets neither with `Profile must set cdpPort or cdpUrl`.
+  `existing-session` profiles take the endpoint from `cdpUrl` and ignore
+  `cdpPort`; `extension` profiles own their relay port and reject `cdpUrl`. The
+  top-level `browser.cdpUrl` defaults to the managed local CDP port when unset.
 - Remote and `attachOnly` CDP reachability, WebSocket handshakes, and local
   managed-Chrome startup use built-in deadlines.
 - Repeated managed Chrome launch/readiness failures are circuit-broken per


### PR DESCRIPTION
Fixes #119335

## What Problem This Solves

Three doc pages tell operators that local `openclaw` browser profiles auto-assign
`cdpPort`/`cdpUrl`, and that those keys should be set **only** for remote CDP or
`existing-session` profiles. The config schema enforces the opposite for any profile the
operator declares:

```
browser.profiles.<name>: Profile must set cdpPort or cdpUrl
```

Auto-assignment is real but never covers a hand-written profile. It happens in exactly two
places, both of which materialise a concrete `cdpPort`:

- `ensureDefaultProfile()` synthesises the built-in `openclaw` profile **only when the
  operator has declared none**.
- `createBrowserProfileConfig()` (`openclaw browser create-profile`) allocates a free port
  from `deriveDefaultBrowserCdpPortRange()` at write time and persists it into
  `openclaw.json`.

There is no read-time fallback. The schema refine in
`src/config/zod-schema.root-shape.ts` rejects a declared `openclaw`/`clawd` profile that
sets neither key, and `resolveProfile()` agrees at runtime:

```js
} else if (cdpPort) cdpUrl = `${resolved.cdpProtocol}://${resolved.cdpHost}:${cdpPort}`;
else throw new Error(`Profile "${profileName}" must define cdpPort or cdpUrl.`);
```

The prescriptive half of the sentence was also backwards for both drivers it named:
`existing-session` is one of the two drivers **exempt** from the requirement (and
`resolveProfile()` returns `cdpPort: 0` for it, discarding any port set), while
`extension` rejects `cdpUrl` outright via a sibling refine. The one case that genuinely
must set a key — a declared local managed profile — is the case the doc told readers not
to set it for.

The trailing sentence *"`cdpUrl` defaults to the managed local CDP port when unset"* is
true of the **top-level** `browser.cdpUrl` (`resolveBrowserConfig()` derives
`controlPort + 1` when it is empty), not of `browser.profiles.<name>.cdpUrl`; sitting
inside a bullet about profiles is what made it actionable in the wrong direction.

This PR fixes the documentation rather than relaxing the schema. The schema and
`resolveProfile()` already agree with each other, and relaxing the refine would need a
read-time port allocator that could silently hand two declared profiles the same port.

## Evidence

`openclaw config validate` honours `OPENCLAW_CONFIG_PATH`, so each case below runs against
a standalone file with no live config involved. All five run on `2026.7.2-beta.7`
(`dabe191`), installed from npm on Debian/Node v22.23.1.

Repro of the documented-but-rejected shape:

```bash
cat > /tmp/minimal.json <<'EOF'
{ "browser": { "profiles": { "openclaw": { "driver": "openclaw", "headless": true } } } }
EOF
OPENCLAW_CONFIG_PATH=/tmp/minimal.json openclaw config validate; echo "exit=$?"
```

```
OpenClaw config is invalid: /tmp/minimal.json
  × minimal.json:4 — browser.profiles.openclaw: Profile must set cdpPort or cdpUrl

Run `openclaw doctor --fix` to repair, or fix the keys above manually.
Inspect with openclaw config validate.
exit=1
```

A/B matrix isolating each claim the old wording made:

| config | `config validate` |
| --- | --- |
| `{"browser":{"enabled":true}}` — no profile declared | **valid** (implicit profile gets `cdpPort` 18800) |
| `profiles.openclaw = {driver:"openclaw", headless:true}` | **invalid** — `Profile must set cdpPort or cdpUrl` |
| same, plus `cdpPort: 18800` | **valid** |
| `profiles.mine = {driver:"existing-session"}`, no `cdpPort`/`cdpUrl` | **valid** (exempt) |
| `profiles.mine = {driver:"extension", cdpUrl:"http://127.0.0.1:18799"}` | **invalid** — `cdpUrl is not supported with driver="extension"` |

Row 1 vs row 2 is the contradiction: the same profile is accepted while implicit and
rejected the moment it is written down. Rows 4 and 5 are what the corrected wording now
states about `existing-session` and `extension`.

Operator impact that motivated the fix: `browser.profiles.*` is hot-reloaded, so following
the old wording leaves the gateway running on the last good in-memory config while logging
`[reload] config reload skipped (invalid config)`. The file on disk is broken and the
system looks healthy until the next restart.

## Test plan

Docs-only change; no code paths touched. Prose was rewrapped so no inline code span breaks
across a line, and `oxfmt` (repo pre-commit hook) left the result unchanged. `pnpm
check:docs` was not run locally — no `node_modules` in this worktree — so CI is the gate
for the docs lint/link/MDX suite.
