### PR TITLE
fix(release): accept legacy empty core artifacts

### DIFF
--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -1101,11 +1101,17 @@ jobs:
             echo "Prepared preflight tarball digest mismatch." >&2
             exit 1
           fi
-          if ! jq -e '.corePackageTarballs | type == "array"' "$MANIFEST_FILE" >/dev/null; then
-            echo "Prepared core package metadata is missing." >&2
-            exit 1
+          # Older frozen candidates predate core subpackage publication. Only an
+          # absent field is an empty set; present malformed metadata still fails closed.
+          if jq -e 'has("corePackageTarballs")' "$MANIFEST_FILE" >/dev/null; then
+            if ! jq -e '.corePackageTarballs | type == "array"' "$MANIFEST_FILE" >/dev/null; then
+              echo "Prepared core package metadata is invalid." >&2
+              exit 1
+            fi
+            CORE_PACKAGE_TARBALL_COUNT="$(jq -r '.corePackageTarballs | length' "$MANIFEST_FILE")"
+          else
+            CORE_PACKAGE_TARBALL_COUNT=0
           fi
-          CORE_PACKAGE_TARBALL_COUNT="$(jq -r '.corePackageTarballs | length' "$MANIFEST_FILE")"
           if [[ "$CORE_PACKAGE_TARBALL_COUNT" -gt 0 ]]; then
             if [[ ! -f preflight-tarball/core-packages-SHA256SUMS ]]; then
               echo "Prepared core package checksums are missing." >&2
@@ -1149,7 +1155,7 @@ jobs:
               echo "Prepared ${package_name} tarball is missing or has a digest mismatch." >&2
               exit 1
             fi
-          done < <(jq -r '.corePackageTarballs[] | [.packageName, .packageVersion, .tarballName, .tarballSha256] | @tsv' "$MANIFEST_FILE")
+          done < <(jq -r '(.corePackageTarballs // [])[] | [.packageName, .packageVersion, .tarballName, .tarballSha256] | @tsv' "$MANIFEST_FILE")
           if node -e 'const pkg = require("./package.json"); process.exit(pkg.dependencies?.["@openclaw/ai"] ? 0 : 1)'; then
             if [[ "$SEEN_AI_TARBALL" != "true" ]] || ! jq -e '.dependencyTarballs[] | select(.packageName == "@openclaw/ai")' "$MANIFEST_FILE" >/dev/null; then
               echo "Prepared AI runtime dependency tarball is missing from the manifest." >&2
@@ -1164,7 +1170,7 @@ jobs:
               echo "Prepared @openclaw/gateway-protocol tarball is missing from the manifest." >&2
               exit 1
             fi
-          elif jq -e '.corePackageTarballs[] | select(.packageName == "@openclaw/gateway-protocol")' "$MANIFEST_FILE" >/dev/null || find preflight-tarball -maxdepth 1 -type f -name 'openclaw-gateway-protocol-*.tgz' -print -quit | grep -q .; then
+          elif jq -e '(.corePackageTarballs // [])[] | select(.packageName == "@openclaw/gateway-protocol")' "$MANIFEST_FILE" >/dev/null || find preflight-tarball -maxdepth 1 -type f -name 'openclaw-gateway-protocol-*.tgz' -print -quit | grep -q .; then
             echo "Frozen target without a publishable @openclaw/gateway-protocol package contains unexpected artifacts." >&2
             exit 1
           fi
@@ -1173,7 +1179,7 @@ jobs:
               echo "Prepared @openclaw/gateway-client tarball is missing from the manifest." >&2
               exit 1
             fi
-          elif jq -e '.corePackageTarballs[] | select(.packageName == "@openclaw/gateway-client")' "$MANIFEST_FILE" >/dev/null || find preflight-tarball -maxdepth 1 -type f -name 'openclaw-gateway-client-*.tgz' -print -quit | grep -q .; then
+          elif jq -e '(.corePackageTarballs // [])[] | select(.packageName == "@openclaw/gateway-client")' "$MANIFEST_FILE" >/dev/null || find preflight-tarball -maxdepth 1 -type f -name 'openclaw-gateway-client-*.tgz' -print -quit | grep -q .; then
             echo "Frozen target without a publishable @openclaw/gateway-client package contains unexpected artifacts." >&2
             exit 1
           fi
@@ -1253,7 +1259,7 @@ jobs:
           }
           while IFS=$'\t' read -r package_name tarball_name; do
             publish_if_missing "$package_name" "preflight-tarball/$tarball_name"
-          done < <(jq -r '.corePackageTarballs[] | [.packageName, .tarballName] | @tsv' preflight-tarball/preflight-manifest.json)
+          done < <(jq -r '(.corePackageTarballs // [])[] | [.packageName, .tarballName] | @tsv' preflight-tarball/preflight-manifest.json)
           bash scripts/openclaw-npm-publish.sh --publish "${publish_target}"
 
       - name: Verify extended-stable registry readback

--- a/test/scripts/openclaw-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/openclaw-npm-extended-stable-workflow.test.ts
@@ -311,6 +311,8 @@ describe("minimal npm extended-stable workflow", () => {
     expect(provenance.run).toContain(
       'ARTIFACT_TARBALL_PATH="preflight-tarball/$ARTIFACT_TARBALL_NAME"',
     );
+    expect(provenance.run).toContain('has("corePackageTarballs")');
+    expect(provenance.run).toContain("CORE_PACKAGE_TARBALL_COUNT=0");
     expect(provenance.run).toContain('echo "tarball_path=$ARTIFACT_TARBALL_PATH"');
     expect(publishStep.env?.PUBLISH_TARBALL_PATH).toBe(
       "${{ steps.preflight_provenance.outputs.tarball_path }}",
@@ -334,7 +336,7 @@ describe("minimal npm extended-stable workflow", () => {
       "packages/ai packages/gateway-protocol packages/gateway-client",
     );
     expect(readFileSync(workflowPath, "utf8")).toContain('packageName: "@openclaw/gateway-client"');
-    expect(publish.run).toContain(".corePackageTarballs[] | [.packageName, .tarballName] | @tsv");
+    expect(publish.run).toContain("(.corePackageTarballs // [])[]");
     expect(publish.run).toContain(
       'bash scripts/openclaw-npm-publish.sh --publish "${publish_target}"',
     );


### PR DESCRIPTION
## What Problem This Solves

The 2026.6.34 extended-stable core publish cannot consume its already-passing preflight artifact because that frozen candidate predates the additive `corePackageTarballs` manifest field. The candidate has no publishable core subpackages, but the current trusted harness treats the absent field as an error.

## Why This Change Was Made

Treat only an absent `corePackageTarballs` field as the empty set for older frozen artifacts. A present non-array remains invalid, and the existing target-package checks still fail if a candidate actually requires a missing core subpackage tarball. Every manifest consumer uses the same empty-list form.

## User Impact

Unblocks publication of the already validated 2026.6.34 extended-stable package without weakening provenance for candidates that publish `@openclaw/*` core packages. The rule is generic for older compatible artifacts, not a release-SHA allowlist.

## Evidence

- Failed publish: https://github.com/openclaw/openclaw/actions/runs/30948507295/job/92124566029
- Verified the passing 2026.6.34 preflight artifact has the tag/SHA/root-tarball digest and no `corePackageTarballs` field; its frozen package graph has no publishable core subpackages.
- `node scripts/run-vitest.mjs test/scripts/openclaw-npm-extended-stable-workflow.test.ts`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/openclaw-npm-release.yml`
- `pnpm exec oxfmt --check .github/workflows/openclaw-npm-release.yml test/scripts/openclaw-npm-extended-stable-workflow.test.ts`
- `git diff --check`
- Fresh `autoreview --mode local`: clean; no accepted/actionable findings.
