### PR TITLE
fix(tui): pin TLS fingerprint when connecting to the local gateway

### DIFF
--- a/src/tui/gateway-chat.test.ts
+++ b/src/tui/gateway-chat.test.ts
@@ -13,6 +13,11 @@ import { withSecureTestNodeCommand } from "../secrets/test-node-command.test-sup
 import { captureEnv, withEnvAsync } from "../test-utils/env.js";
 
 const readActiveGatewayLockPortMock = vi.hoisted(() => vi.fn());
+const loadGatewayTlsRuntimeMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../infra/tls/gateway.js", () => ({
+  loadGatewayTlsRuntime: loadGatewayTlsRuntimeMock,
+}));
 
 vi.mock("../config/config.js", async () => {
   const mocks = await import("../gateway/gateway-connection.test-mocks.js");
@@ -129,6 +134,10 @@ describe("resolveGatewayConnection", () => {
     ]);
     loadConfig.mockReset();
     readActiveGatewayLockPortMock.mockReset().mockResolvedValue(undefined);
+    loadGatewayTlsRuntimeMock.mockReset().mockResolvedValue({
+      enabled: false,
+      required: false,
+    });
     resolveGatewayPort.mockReset();
     resolveStateDir.mockReset();
     resolveConfigPath.mockReset();
@@ -254,6 +263,37 @@ describe("resolveGatewayConnection", () => {
 
     expect(result.url).toBe("wss://127.0.0.1:18789");
     expect(result.tlsFingerprint).toBe("sha256:local-self-signed-fingerprint");
+  });
+
+  it("pins to the local gateway TLS fingerprint when TLS is enabled and no override is set", async () => {
+    loadConfig.mockReturnValue({
+      gateway: {
+        mode: "local",
+        tls: { enabled: true },
+        auth: { mode: "token", token: "config-token" },
+      },
+    });
+    loadGatewayTlsRuntimeMock.mockResolvedValue({
+      enabled: true,
+      required: true,
+      fingerprintSha256: "sha256:derived-from-cert",
+    });
+
+    const result = await resolveGatewayConnection({});
+
+    expect(result.url).toBe("wss://127.0.0.1:18789");
+    expect(result.tlsFingerprint).toBe("sha256:derived-from-cert");
+  });
+
+  it("skips local TLS fingerprint resolution when TLS is disabled", async () => {
+    loadConfig.mockReturnValue({
+      gateway: { mode: "local", auth: { mode: "token", token: "config-token" } },
+    });
+
+    const result = await resolveGatewayConnection({});
+
+    expect(result.tlsFingerprint).toBeUndefined();
+    expect(loadGatewayTlsRuntimeMock).not.toHaveBeenCalled();
   });
 
   it("uses a verified active local Gateway port when no target is explicit", async () => {

--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -31,6 +31,7 @@ import { startGatewayClientWhenEventLoopReady } from "../gateway/client-start-re
 import { GatewayClient, GatewayClientRequestError } from "../gateway/client.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { readActiveGatewayLockPort } from "../infra/gateway-lock.js";
+import { loadGatewayTlsRuntime } from "../infra/tls/gateway.js";
 import { roleScopesAllow } from "../shared/operator-scope-compat.js";
 import { sleep } from "../utils/sleep.js";
 import { VERSION } from "../version.js";
@@ -473,6 +474,29 @@ function resolveBoundGatewayConnection(
   };
 }
 
+/**
+ * Resolve the TLS certificate fingerprint to pin when connecting to the local
+ * gateway. An explicit `--tls-fingerprint` wins; otherwise, when the local
+ * gateway has TLS enabled, the on-disk gateway certificate fingerprint is used.
+ * This mirrors the resolution the CLI call path (`src/gateway/call.ts`) and
+ * `openclaw status` already perform. Without it the TUI connects to `wss://`
+ * with strict TLS verification and fails against the self-signed local gateway
+ * certificate.
+ */
+async function resolveLocalGatewayTlsFingerprint(
+  config: OpenClawConfig,
+  overrideFingerprint?: string,
+): Promise<string | undefined> {
+  const override =
+    typeof overrideFingerprint === "string" && overrideFingerprint.trim()
+      ? overrideFingerprint.trim()
+      : undefined;
+  if (override) return override;
+  if (config.gateway?.tls?.enabled !== true) return undefined;
+  const tlsRuntime = await loadGatewayTlsRuntime(config.gateway?.tls);
+  return tlsRuntime?.enabled ? tlsRuntime.fingerprintSha256 : undefined;
+}
+
 async function resolveGatewayConnection(
   opts: GatewayConnectionOptions,
 ): Promise<ResolvedGatewayConnection> {
@@ -506,6 +530,10 @@ async function resolveGatewayConnection(
     ...(activeLocalGatewayPort ? { localPortOverride: activeLocalGatewayPort } : {}),
   }).url;
   const allowInsecureLocalOperatorUi = false;
+  const localTlsFingerprint =
+    urlOverride || isRemoteMode
+      ? undefined
+      : await resolveLocalGatewayTlsFingerprint(config, opts.tlsFingerprint);
 
   if (urlOverride) {
     return {
@@ -550,7 +578,7 @@ async function resolveGatewayConnection(
       url,
       token: resolved.token,
       password: resolved.password,
-      ...(opts.tlsFingerprint ? { tlsFingerprint: opts.tlsFingerprint } : {}),
+      ...(localTlsFingerprint ? { tlsFingerprint: localTlsFingerprint } : {}),
       allowInsecureLocalOperatorUi,
     };
   }
@@ -575,7 +603,7 @@ async function resolveGatewayConnection(
     url,
     token: resolved.token,
     password: resolved.password,
-    ...(opts.tlsFingerprint ? { tlsFingerprint: opts.tlsFingerprint } : {}),
+    ...(localTlsFingerprint ? { tlsFingerprint: localTlsFingerprint } : {}),
     allowInsecureLocalOperatorUi,
   };
 }


### PR DESCRIPTION
## Problem

`openclaw tui` cannot connect to a local gateway that has TLS enabled. The TUI shows:

```
gateway disconnected: self-signed certificate; if the root CA is installed locally, try running Node.js with --use-system-ca
```

The gateway itself is healthy: `openclaw daemon status` reports `running` + `Connectivity probe: ok`, and `openclaw status` reaches the gateway fine. Only the TUI fails.

## Root cause

`openclaw tui` connects through `resolveGatewayConnection` in `src/tui/gateway-chat.ts`. For **local** gateway connections it only forwarded an explicit `--tls-fingerprint` flag:

```ts
return {
  url,
  token: resolved.token,
  password: resolved.password,
  ...(opts.tlsFingerprint ? { tlsFingerprint: opts.tlsFingerprint } : {}),
  allowInsecureLocalOperatorUi,
};
```

Unlike the CLI call path (`resolveGatewayTlsFingerprint` in `src/gateway/call.ts`) and `openclaw status` (`src/cli/daemon-cli/status.gather.ts`), the TUI never resolved the on-disk gateway certificate fingerprint when local TLS is enabled.

The gateway serves a self-signed cert (`CN=openclaw-gateway`, no SAN), so strict TLS can never validate it against `127.0.0.1`. Every other client pins the gateway cert by fingerprint (`rejectUnauthorized: false` + `checkServerIdentity` only when `tlsFingerprint` is present, see `src/gateway/client.ts`). The TUI connected to `wss://` **without** the fingerprint, so it did strict TLS verification and failed against the self-signed cert.

## Fix

Resolve the local gateway TLS fingerprint for the local connection branches, mirroring the resolution the CLI call path and `openclaw status` already perform:

- an explicit `--tls-fingerprint` still wins,
- otherwise, when the local gateway has TLS enabled, use the on-disk cert fingerprint via `loadGatewayTlsRuntime`.

This makes `openclaw tui` pin the gateway cert like every other client. Remote and explicit-`--url` connections are unchanged.

## Verification

- `GatewayChatClient.connect({})` (the exact path `openclaw tui` uses) now resolves `tlsFingerprint` from the local gateway cert; before the fix it returned none.
- A connection with the resolved fingerprint completes successfully (`health` RPC returns `{ ok: true }`) against a TLS-enabled local gateway that previously rejected the TUI with `self-signed certificate`.
- Added unit tests in `gateway-chat.test.ts` covering: TLS enabled + no override resolves the cert fingerprint; TLS disabled skips resolution.