### PR TITLE
feat(signal): add signal-cli account linking

### DIFF
--- a/extensions/signal/src/daemon.ts
+++ b/extensions/signal/src/daemon.ts
@@ -1,9 +1,8 @@
 // Signal plugin module implements daemon behavior.
 import { spawn } from "node:child_process";
-import os from "node:os";
-import path from "node:path";
 import { createInterface } from "node:readline";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { resolveSignalCliConfigPath } from "./signal-cli-config-path.js";
 
 type SignalDaemonOpts = {
   cliPath: string;
@@ -80,17 +79,6 @@ function bindSignalCliOutput(params: {
       params.error(`signal-cli: ${line.trim()}`);
     }
   });
-}
-
-function resolveSignalCliConfigPath(raw: string): string {
-  const value = raw.trim();
-  if (value === "~") {
-    return os.homedir();
-  }
-  if (value.startsWith("~/") || value.startsWith("~\\")) {
-    return path.join(os.homedir(), value.slice(2));
-  }
-  return value;
 }
 
 function buildDaemonArgs(opts: SignalDaemonOpts): string[] {

--- a/extensions/signal/src/signal-cli-config-path.ts
+++ b/extensions/signal/src/signal-cli-config-path.ts
@@ -1,0 +1,14 @@
+import os from "node:os";
+import path from "node:path";
+
+/** Keep every Signal-owned signal-cli invocation on the daemon's established path contract. */
+export function resolveSignalCliConfigPath(raw: string): string {
+  const value = raw.trim();
+  if (value === "~") {
+    return os.homedir();
+  }
+  if (value.startsWith("~/") || value.startsWith("~\\")) {
+    return path.join(os.homedir(), value.slice(2));
+  }
+  return value;
+}

--- a/extensions/signal/src/signal-cli-link.test.ts
+++ b/extensions/signal/src/signal-cli-link.test.ts
@@ -387,6 +387,30 @@ describe("linkSignalCliAccount", () => {
     });
   });
 
+  it("ignores a buffered link URI after cancellation", async () => {
+    const command = createDeferredCommand();
+    const abortController = new AbortController();
+    const onLinkUri = vi.fn(async () => undefined);
+    const resultPromise = linkSignalCliAccount({
+      cliPath: "signal-cli",
+      signal: abortController.signal,
+      onLinkUri,
+    });
+
+    abortController.abort();
+    emitStdoutLine("sgnl://linkdevice?uuid=late&pub_key=late");
+    await Promise.resolve();
+
+    expect(onLinkUri).not.toHaveBeenCalled();
+    command.resolve(
+      commandResult({ code: null, signal: "SIGTERM", killed: true, termination: "signal" }),
+    );
+    await expect(resultPromise).resolves.toEqual({
+      ok: false,
+      error: "Signal account linking was cancelled.",
+    });
+  });
+
   it("rejects overlapping links until the active process has stopped", async () => {
     const storePath = path.join(os.tmpdir(), "openclaw-signal-link", "shared");
     const firstCommand = createDeferredCommand();

--- a/extensions/signal/src/signal-cli-link.test.ts
+++ b/extensions/signal/src/signal-cli-link.test.ts
@@ -1,0 +1,422 @@
+import os from "node:os";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { linkSignalCliAccount, listSignalCliAccounts } from "./signal-cli-link.js";
+
+const runCommandMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/process-runtime", () => ({
+  runCommandWithTimeout: runCommandMock,
+}));
+
+type CommandResult = {
+  stdout: string;
+  stderr: string;
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  killed: boolean;
+  termination: "exit" | "timeout" | "no-output-timeout" | "signal";
+};
+
+type CommandOptions = {
+  signal: AbortSignal;
+  killProcessTree: boolean;
+  timeoutMs: number;
+  maxOutputBytes: { stdout: number; stderr: number };
+  maxPreservedOutputLines: number;
+  preserveOutputLine: (line: string, stream: "stdout" | "stderr") => boolean;
+  outputCapture: { stdout: string; stderr: string };
+};
+
+function commandResult(overrides: Partial<CommandResult> = {}): CommandResult {
+  return {
+    stdout: "",
+    stderr: "",
+    code: 0,
+    signal: null,
+    killed: false,
+    termination: "exit",
+    ...overrides,
+  };
+}
+
+function createDeferredCommand() {
+  let resolve!: (result: CommandResult) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<CommandResult>((resolveResult, rejectResult) => {
+    resolve = resolveResult;
+    reject = rejectResult;
+  });
+  runCommandMock.mockReturnValueOnce(promise);
+  return { resolve, reject };
+}
+
+function commandOptions(): CommandOptions {
+  const options = runCommandMock.mock.calls.at(-1)?.[1] as CommandOptions | undefined;
+  if (!options) {
+    throw new Error("expected command options");
+  }
+  return options;
+}
+
+function emitStdoutLine(line: string) {
+  commandOptions().preserveOutputLine(line, "stdout");
+}
+
+function emitStdoutLineForCall(callIndex: number, line: string) {
+  const options = runCommandMock.mock.calls[callIndex]?.[1] as CommandOptions | undefined;
+  if (!options) {
+    throw new Error(`expected command options for call ${callIndex}`);
+  }
+  options.preserveOutputLine(line, "stdout");
+}
+
+beforeEach(() => {
+  runCommandMock.mockReset();
+});
+
+describe("listSignalCliAccounts", () => {
+  it("reads the dependency-owned JSON account list", async () => {
+    runCommandMock.mockResolvedValueOnce(
+      commandResult({
+        stdout: '[{"number":"+15555550123"},{"number":"+15555550124"}]',
+      }),
+    );
+
+    await expect(
+      listSignalCliAccounts({
+        cliPath: "/opt/openclaw/signal-cli",
+        configPath: "~/.local/share/signal-cli",
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      accounts: ["+15555550123", "+15555550124"],
+    });
+    expect(runCommandMock).toHaveBeenCalledWith(
+      [
+        "/opt/openclaw/signal-cli",
+        "--config",
+        path.join(os.homedir(), ".local/share/signal-cli"),
+        "--output",
+        "json",
+        "listAccounts",
+      ],
+      expect.objectContaining({
+        killProcessTree: true,
+        outputCapture: { stdout: "head", stderr: "tail" },
+        terminateOnOutputLimit: { stdout: true },
+      }),
+    );
+  });
+
+  it("rejects failed or malformed account discovery", async () => {
+    runCommandMock
+      .mockResolvedValueOnce(commandResult({ code: 1, stderr: "store locked" }))
+      .mockResolvedValueOnce(commandResult({ stdout: '[{"number":"not-e164"}]' }));
+
+    await expect(listSignalCliAccounts({ cliPath: "signal-cli" })).resolves.toEqual({
+      ok: false,
+      error: "store locked",
+    });
+    await expect(listSignalCliAccounts({ cliPath: "signal-cli" })).resolves.toEqual({
+      ok: false,
+      error: "signal-cli returned an invalid account list.",
+    });
+  });
+});
+
+describe("linkSignalCliAccount", () => {
+  it("does not launch signal-cli when setup is already cancelled", async () => {
+    const abortController = new AbortController();
+    abortController.abort();
+
+    await expect(
+      linkSignalCliAccount({
+        cliPath: "signal-cli",
+        signal: abortController.signal,
+        onLinkUri: vi.fn(async () => undefined),
+      }),
+    ).resolves.toEqual({ ok: false, error: "Signal account linking was cancelled." });
+    expect(runCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("recognizes the upstream link result and forces plain-text output", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_800_000_000_000);
+    const command = createDeferredCommand();
+    const onLinkUri = vi.fn(async () => undefined);
+    const resultPromise = linkSignalCliAccount({
+      cliPath: "/opt/openclaw/signal-cli",
+      configPath: "~/.local/share/signal-cli",
+      onLinkUri,
+    });
+
+    emitStdoutLine("sgnl://linkdevice?uuid=test&pub_key=test");
+    emitStdoutLine("Associated with: +15555550123");
+    command.resolve(commandResult());
+
+    await expect(resultPromise).resolves.toEqual({
+      ok: true,
+      associatedAccount: "+15555550123",
+    });
+    expect(runCommandMock).toHaveBeenCalledWith(
+      [
+        "/opt/openclaw/signal-cli",
+        "--config",
+        path.join(os.homedir(), ".local/share/signal-cli"),
+        "--output",
+        "plain-text",
+        "link",
+        "-n",
+        "OpenClaw",
+      ],
+      expect.objectContaining({
+        signal: expect.any(AbortSignal),
+        killProcessTree: true,
+        maxPreservedOutputLines: 1,
+        preserveOutputLine: expect.any(Function),
+      }),
+    );
+    expect(onLinkUri).toHaveBeenCalledWith(
+      "sgnl://linkdevice?uuid=test&pub_key=test",
+      expect.any(Promise),
+      1_800_000_120_000,
+    );
+    vi.useRealTimers();
+  });
+
+  it("waits for QR presentation to finish before completing setup", async () => {
+    const command = createDeferredCommand();
+    let releasePresentation!: () => void;
+    const presentation = new Promise<void>((resolve) => {
+      releasePresentation = resolve;
+    });
+    const resultPromise = linkSignalCliAccount({
+      cliPath: "signal-cli",
+      onLinkUri: async (_uri, completion) => {
+        await expect(completion).resolves.toBeUndefined();
+        await presentation;
+      },
+    });
+
+    emitStdoutLine("sgnl://linkdevice?uuid=test&pub_key=test");
+    command.resolve(commandResult());
+
+    let completed = false;
+    void resultPromise.then(() => {
+      completed = true;
+    });
+    await Promise.resolve();
+    expect(completed).toBe(false);
+
+    releasePresentation();
+    await expect(resultPromise).resolves.toMatchObject({ ok: true });
+  });
+
+  it("preserves a successful link when QR presentation fails after process exit", async () => {
+    const command = createDeferredCommand();
+    const resultPromise = linkSignalCliAccount({
+      cliPath: "signal-cli",
+      onLinkUri: async (_uri, completion) => {
+        await completion;
+        throw new Error("client disconnected");
+      },
+    });
+
+    emitStdoutLine("sgnl://linkdevice?uuid=test&pub_key=test");
+    emitStdoutLine("Associated with: +15555550123");
+    command.resolve(commandResult());
+
+    await expect(resultPromise).resolves.toEqual({
+      ok: true,
+      associatedAccount: "+15555550123",
+    });
+  });
+
+  it("bounds signal-cli errors and rejects success without a link URI", async () => {
+    const failedCommand = createDeferredCommand();
+    const failurePromise = linkSignalCliAccount({
+      cliPath: "signal-cli",
+      onLinkUri: vi.fn(async () => undefined),
+    });
+    expect(commandOptions()).toMatchObject({
+      maxOutputBytes: { stdout: 8 * 1024, stderr: 2_000 },
+      outputCapture: { stdout: "discard", stderr: "tail" },
+    });
+    failedCommand.resolve(commandResult({ code: 1, stderr: "signal-cli error" }));
+    const failure = await failurePromise;
+    expect(failure.ok).toBe(false);
+    if (!failure.ok) {
+      expect(failure.error).toBe("signal-cli error");
+    }
+
+    const missingUriCommand = createDeferredCommand();
+    const missingUriPromise = linkSignalCliAccount({
+      cliPath: "signal-cli",
+      onLinkUri: vi.fn(async () => undefined),
+    });
+    missingUriCommand.resolve(commandResult());
+    await expect(missingUriPromise).resolves.toEqual({
+      ok: false,
+      error: "signal-cli link finished without producing a device-link QR code.",
+    });
+  });
+
+  it("terminates the signal-cli process tree when presentation fails", async () => {
+    const command = createDeferredCommand();
+    const presentationFailure = linkSignalCliAccount({
+      cliPath: "signal-cli",
+      onLinkUri: async () => {
+        throw new Error("client disconnected");
+      },
+    });
+    emitStdoutLine("sgnl://linkdevice?uuid=test&pub_key=test");
+    await vi.waitFor(() => expect(commandOptions().signal.aborted).toBe(true));
+    expect(commandOptions().killProcessTree).toBe(true);
+    command.resolve(
+      commandResult({ code: null, signal: "SIGTERM", killed: true, termination: "signal" }),
+    );
+    await expect(presentationFailure).resolves.toEqual({
+      ok: false,
+      error: "Signal account linking stopped: client disconnected",
+    });
+  });
+
+  it("bounds the whole link command beyond signal-cli's provisioning deadline", async () => {
+    const command = createDeferredCommand();
+    const resultPromise = linkSignalCliAccount({
+      cliPath: "signal-cli",
+      onLinkUri: vi.fn(async () => undefined),
+    });
+    expect(commandOptions().timeoutMs).toBe(3 * 60_000);
+    emitStdoutLine("sgnl://linkdevice?uuid=test&pub_key=test");
+    command.resolve(commandResult());
+    await expect(resultPromise).resolves.toMatchObject({ ok: true });
+  });
+
+  it("reports the outer link timeout", async () => {
+    runCommandMock.mockResolvedValueOnce(
+      commandResult({ code: null, killed: true, termination: "timeout" }),
+    );
+
+    await expect(
+      linkSignalCliAccount({
+        cliPath: "signal-cli",
+        onLinkUri: vi.fn(async () => undefined),
+      }),
+    ).resolves.toEqual({ ok: false, error: "Signal account linking timed out." });
+  });
+
+  it("keeps cancellation owned until the whole process tree stops", async () => {
+    const command = createDeferredCommand();
+    const abortController = new AbortController();
+    let presentationReleased = false;
+    const onLinkUri = vi.fn(async (_uri: string, completion: Promise<void>) => {
+      await completion;
+      presentationReleased = true;
+    });
+    const resultPromise = linkSignalCliAccount({
+      cliPath: "signal-cli",
+      signal: abortController.signal,
+      onLinkUri,
+    });
+
+    emitStdoutLine("sgnl://linkdevice?uuid=test&pub_key=test");
+    await vi.waitFor(() => expect(onLinkUri).toHaveBeenCalledOnce());
+
+    abortController.abort();
+
+    expect(commandOptions().signal.aborted).toBe(true);
+    expect(commandOptions().killProcessTree).toBe(true);
+    await vi.waitFor(() => expect(presentationReleased).toBe(true));
+    let completed = false;
+    void resultPromise.then(() => {
+      completed = true;
+    });
+    await Promise.resolve();
+    expect(completed).toBe(false);
+
+    command.resolve(
+      commandResult({ code: null, signal: "SIGTERM", killed: true, termination: "signal" }),
+    );
+    await expect(resultPromise).resolves.toEqual({
+      ok: false,
+      error: "Signal account linking was cancelled.",
+    });
+  });
+
+  it("rejects overlapping links until the active process has stopped", async () => {
+    const storePath = path.join(os.tmpdir(), "openclaw-signal-link", "shared");
+    const firstCommand = createDeferredCommand();
+    const first = linkSignalCliAccount({
+      cliPath: "signal-cli",
+      configPath: path.join(storePath, "..", "shared"),
+      onLinkUri: vi.fn(async () => undefined),
+    });
+
+    await expect(
+      linkSignalCliAccount({
+        cliPath: "signal-cli",
+        configPath: storePath,
+        onLinkUri: vi.fn(async () => undefined),
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      error: "Signal account linking is already in progress.",
+    });
+    expect(runCommandMock).toHaveBeenCalledOnce();
+
+    emitStdoutLine("sgnl://linkdevice?uuid=first&pub_key=first");
+    firstCommand.resolve(commandResult());
+    await expect(first).resolves.toMatchObject({ ok: true });
+
+    const retryCommand = createDeferredCommand();
+    const retry = linkSignalCliAccount({
+      cliPath: "signal-cli",
+      configPath: storePath,
+      onLinkUri: vi.fn(async () => undefined),
+    });
+    emitStdoutLine("sgnl://linkdevice?uuid=retry&pub_key=retry");
+    retryCommand.resolve(commandResult());
+    await expect(retry).resolves.toMatchObject({ ok: true });
+    expect(runCommandMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("allows concurrent links for independent config stores", async () => {
+    const firstCommand = createDeferredCommand();
+    const first = linkSignalCliAccount({
+      cliPath: "signal-cli",
+      configPath: path.join(os.tmpdir(), "openclaw-signal-link", "store-a"),
+      onLinkUri: vi.fn(async () => undefined),
+    });
+    const secondCommand = createDeferredCommand();
+    const second = linkSignalCliAccount({
+      cliPath: "signal-cli",
+      configPath: path.join(os.tmpdir(), "openclaw-signal-link", "store-b"),
+      onLinkUri: vi.fn(async () => undefined),
+    });
+
+    expect(runCommandMock).toHaveBeenCalledTimes(2);
+    emitStdoutLineForCall(0, "sgnl://linkdevice?uuid=first&pub_key=first");
+    emitStdoutLineForCall(1, "sgnl://linkdevice?uuid=second&pub_key=second");
+    firstCommand.resolve(commandResult());
+    secondCommand.resolve(commandResult());
+
+    await expect(first).resolves.toMatchObject({ ok: true });
+    await expect(second).resolves.toMatchObject({ ok: true });
+  });
+
+  it("returns an error when signal-cli cannot start", async () => {
+    const command = createDeferredCommand();
+    const resultPromise = linkSignalCliAccount({
+      cliPath: "/missing/signal-cli",
+      onLinkUri: vi.fn(async () => undefined),
+    });
+    command.reject(new Error("spawn ENOENT"));
+
+    await expect(resultPromise).resolves.toEqual({
+      ok: false,
+      error: "Could not start signal-cli: spawn ENOENT",
+    });
+  });
+});

--- a/extensions/signal/src/signal-cli-link.test.ts
+++ b/extensions/signal/src/signal-cli-link.test.ts
@@ -65,14 +65,6 @@ function emitStdoutLine(line: string) {
   commandOptions().preserveOutputLine(line, "stdout");
 }
 
-function emitStdoutLineForCall(callIndex: number, line: string) {
-  const options = runCommandMock.mock.calls[callIndex]?.[1] as CommandOptions | undefined;
-  if (!options) {
-    throw new Error(`expected command options for call ${callIndex}`);
-  }
-  options.preserveOutputLine(line, "stdout");
-}
-
 beforeEach(() => {
   runCommandMock.mockReset();
 });
@@ -213,6 +205,7 @@ describe("linkSignalCliAccount", () => {
     });
 
     emitStdoutLine("sgnl://linkdevice?uuid=test&pub_key=test");
+    emitStdoutLine("Associated with: +15555550123");
     command.resolve(commandResult());
 
     let completed = false;
@@ -246,7 +239,7 @@ describe("linkSignalCliAccount", () => {
     });
   });
 
-  it("bounds signal-cli errors and rejects success without a link URI", async () => {
+  it("bounds signal-cli errors and rejects incomplete success output", async () => {
     const failedCommand = createDeferredCommand();
     const failurePromise = linkSignalCliAccount({
       cliPath: "signal-cli",
@@ -272,6 +265,18 @@ describe("linkSignalCliAccount", () => {
     await expect(missingUriPromise).resolves.toEqual({
       ok: false,
       error: "signal-cli link finished without producing a device-link QR code.",
+    });
+
+    const missingAccountCommand = createDeferredCommand();
+    const missingAccountPromise = linkSignalCliAccount({
+      cliPath: "signal-cli",
+      onLinkUri: vi.fn(async () => undefined),
+    });
+    emitStdoutLine("sgnl://linkdevice?uuid=test&pub_key=test");
+    missingAccountCommand.resolve(commandResult());
+    await expect(missingAccountPromise).resolves.toEqual({
+      ok: false,
+      error: "signal-cli link finished without reporting the associated account.",
     });
   });
 
@@ -326,6 +331,7 @@ describe("linkSignalCliAccount", () => {
     });
     expect(commandOptions().timeoutMs).toBe(3 * 60_000);
     emitStdoutLine("sgnl://linkdevice?uuid=test&pub_key=test");
+    emitStdoutLine("Associated with: +15555550123");
     command.resolve(commandResult());
     await expect(resultPromise).resolves.toMatchObject({ ok: true });
   });
@@ -386,14 +392,13 @@ describe("linkSignalCliAccount", () => {
     const firstCommand = createDeferredCommand();
     const first = linkSignalCliAccount({
       cliPath: "signal-cli",
-      configPath: path.join(storePath, "..", "shared"),
       onLinkUri: vi.fn(async () => undefined),
     });
 
     await expect(
       linkSignalCliAccount({
         cliPath: "signal-cli",
-        configPath: storePath,
+        configPath: "~/.local/share/signal-cli",
         onLinkUri: vi.fn(async () => undefined),
       }),
     ).resolves.toEqual({
@@ -403,6 +408,7 @@ describe("linkSignalCliAccount", () => {
     expect(runCommandMock).toHaveBeenCalledOnce();
 
     emitStdoutLine("sgnl://linkdevice?uuid=first&pub_key=first");
+    emitStdoutLine("Associated with: +15555550123");
     firstCommand.resolve(commandResult());
     await expect(first).resolves.toMatchObject({ ok: true });
 
@@ -413,33 +419,10 @@ describe("linkSignalCliAccount", () => {
       onLinkUri: vi.fn(async () => undefined),
     });
     emitStdoutLine("sgnl://linkdevice?uuid=retry&pub_key=retry");
+    emitStdoutLine("Associated with: +15555550123");
     retryCommand.resolve(commandResult());
     await expect(retry).resolves.toMatchObject({ ok: true });
     expect(runCommandMock).toHaveBeenCalledTimes(2);
-  });
-
-  it("allows concurrent links for independent config stores", async () => {
-    const firstCommand = createDeferredCommand();
-    const first = linkSignalCliAccount({
-      cliPath: "signal-cli",
-      configPath: path.join(os.tmpdir(), "openclaw-signal-link", "store-a"),
-      onLinkUri: vi.fn(async () => undefined),
-    });
-    const secondCommand = createDeferredCommand();
-    const second = linkSignalCliAccount({
-      cliPath: "signal-cli",
-      configPath: path.join(os.tmpdir(), "openclaw-signal-link", "store-b"),
-      onLinkUri: vi.fn(async () => undefined),
-    });
-
-    expect(runCommandMock).toHaveBeenCalledTimes(2);
-    emitStdoutLineForCall(0, "sgnl://linkdevice?uuid=first&pub_key=first");
-    emitStdoutLineForCall(1, "sgnl://linkdevice?uuid=second&pub_key=second");
-    firstCommand.resolve(commandResult());
-    secondCommand.resolve(commandResult());
-
-    await expect(first).resolves.toMatchObject({ ok: true });
-    await expect(second).resolves.toMatchObject({ ok: true });
   });
 
   it("returns an error when signal-cli cannot start", async () => {

--- a/extensions/signal/src/signal-cli-link.test.ts
+++ b/extensions/signal/src/signal-cli-link.test.ts
@@ -239,6 +239,32 @@ describe("linkSignalCliAccount", () => {
     });
   });
 
+  it("preserves a successful link when QR presentation cancels the settling process", async () => {
+    const command = createDeferredCommand();
+    let rejectPresentation!: (error: Error) => void;
+    const presentation = new Promise<void>((_resolve, reject) => {
+      rejectPresentation = reject;
+    });
+    const resultPromise = linkSignalCliAccount({
+      cliPath: "signal-cli",
+      onLinkUri: async () => await presentation,
+    });
+
+    emitStdoutLine("sgnl://linkdevice?uuid=test&pub_key=test");
+    await vi.waitFor(() => expect(rejectPresentation).toBeTypeOf("function"));
+    emitStdoutLine("Associated with: +15555550123");
+    rejectPresentation(new Error("client disconnected"));
+    await vi.waitFor(() => expect(commandOptions().signal.aborted).toBe(true));
+    command.resolve(
+      commandResult({ code: null, signal: "SIGTERM", killed: true, termination: "signal" }),
+    );
+
+    await expect(resultPromise).resolves.toEqual({
+      ok: true,
+      associatedAccount: "+15555550123",
+    });
+  });
+
   it("bounds signal-cli errors and rejects incomplete success output", async () => {
     const failedCommand = createDeferredCommand();
     const failurePromise = linkSignalCliAccount({

--- a/extensions/signal/src/signal-cli-link.test.ts
+++ b/extensions/signal/src/signal-cli-link.test.ts
@@ -239,7 +239,7 @@ describe("linkSignalCliAccount", () => {
     });
   });
 
-  it("preserves a successful link when QR presentation cancels the settling process", async () => {
+  it("trusts the terminal account marker when presentation cancels process exit", async () => {
     const command = createDeferredCommand();
     let rejectPresentation!: (error: Error) => void;
     const presentation = new Promise<void>((_resolve, reject) => {

--- a/extensions/signal/src/signal-cli-link.test.ts
+++ b/extensions/signal/src/signal-cli-link.test.ts
@@ -112,7 +112,14 @@ describe("listSignalCliAccounts", () => {
   it("rejects failed or malformed account discovery", async () => {
     runCommandMock
       .mockResolvedValueOnce(commandResult({ code: 1, stderr: "store locked" }))
-      .mockResolvedValueOnce(commandResult({ stdout: '[{"number":"not-e164"}]' }));
+      .mockResolvedValueOnce(commandResult({ stdout: '[{"number":"not-e164"}]' }))
+      .mockResolvedValueOnce(
+        commandResult({
+          stdout: '[{"number":"+15555550123"}]',
+          signal: "SIGTERM",
+          termination: "signal",
+        }),
+      );
 
     await expect(listSignalCliAccounts({ cliPath: "signal-cli" })).resolves.toEqual({
       ok: false,
@@ -121,6 +128,10 @@ describe("listSignalCliAccounts", () => {
     await expect(listSignalCliAccounts({ cliPath: "signal-cli" })).resolves.toEqual({
       ok: false,
       error: "signal-cli returned an invalid account list.",
+    });
+    await expect(listSignalCliAccounts({ cliPath: "signal-cli" })).resolves.toEqual({
+      ok: false,
+      error: "signal-cli could not inspect its linked accounts.",
     });
   });
 });
@@ -262,7 +273,7 @@ describe("linkSignalCliAccount", () => {
     });
   });
 
-  it("terminates the signal-cli process tree when presentation fails", async () => {
+  it("rejects a zero exit after presentation failure terminates signal-cli", async () => {
     const command = createDeferredCommand();
     const presentationFailure = linkSignalCliAccount({
       cliPath: "signal-cli",
@@ -274,7 +285,7 @@ describe("linkSignalCliAccount", () => {
     await vi.waitFor(() => expect(commandOptions().signal.aborted).toBe(true));
     expect(commandOptions().killProcessTree).toBe(true);
     command.resolve(
-      commandResult({ code: null, signal: "SIGTERM", killed: true, termination: "signal" }),
+      commandResult({ code: 0, signal: "SIGTERM", killed: true, termination: "signal" }),
     );
     await expect(presentationFailure).resolves.toEqual({
       ok: false,

--- a/extensions/signal/src/signal-cli-link.test.ts
+++ b/extensions/signal/src/signal-cli-link.test.ts
@@ -16,6 +16,7 @@ type CommandResult = {
   signal: NodeJS.Signals | null;
   killed: boolean;
   termination: "exit" | "timeout" | "no-output-timeout" | "signal";
+  outputLimitExceeded?: boolean;
 };
 
 type CommandOptions = {
@@ -23,6 +24,7 @@ type CommandOptions = {
   killProcessTree: boolean;
   timeoutMs: number;
   maxOutputBytes: { stdout: number; stderr: number };
+  terminateOnOutputLimit?: { stdout: boolean };
   maxPreservedOutputLines: number;
   preserveOutputLine: (line: string, stream: "stdout" | "stderr") => boolean;
   outputCapture: { stdout: string; stderr: string };
@@ -271,6 +273,29 @@ describe("linkSignalCliAccount", () => {
       ok: false,
       error: "signal-cli link finished without producing a device-link QR code.",
     });
+  });
+
+  it("terminates noisy stdout at the link output cap", async () => {
+    runCommandMock.mockResolvedValueOnce(
+      commandResult({
+        code: null,
+        signal: "SIGTERM",
+        killed: true,
+        termination: "signal",
+        outputLimitExceeded: true,
+      }),
+    );
+
+    await expect(
+      linkSignalCliAccount({
+        cliPath: "signal-cli",
+        onLinkUri: vi.fn(async () => undefined),
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      error: "signal-cli link exceeded its 8 KiB output limit.",
+    });
+    expect(commandOptions().terminateOnOutputLimit).toEqual({ stdout: true });
   });
 
   it("rejects a zero exit after presentation failure terminates signal-cli", async () => {

--- a/extensions/signal/src/signal-cli-link.ts
+++ b/extensions/signal/src/signal-cli-link.ts
@@ -159,6 +159,11 @@ export async function linkSignalCliAccount(params: {
     resolveCompletion();
     await displayPromise;
 
+    if (associatedAccount) {
+      // signal-cli prints the account only after finishDeviceLink succeeds. A late client
+      // cancellation must not turn that durable success into a second linking attempt.
+      return { ok: true, associatedAccount };
+    }
     if (result.code === 0 && result.termination === "exit") {
       if (!linkUriSeen) {
         return {
@@ -166,15 +171,10 @@ export async function linkSignalCliAccount(params: {
           error: "signal-cli link finished without producing a device-link QR code.",
         };
       }
-      if (!associatedAccount) {
-        return {
-          ok: false,
-          error: "signal-cli link finished without reporting the associated account.",
-        };
-      }
-      // signal-cli prints the account only after finishDeviceLink succeeds. A late client
-      // cancellation must not turn that durable success into a second linking attempt.
-      return { ok: true, associatedAccount };
+      return {
+        ok: false,
+        error: "signal-cli link finished without reporting the associated account.",
+      };
     }
     if (displayError) {
       return { ok: false, error: displayError };

--- a/extensions/signal/src/signal-cli-link.ts
+++ b/extensions/signal/src/signal-cli-link.ts
@@ -12,6 +12,7 @@ const SIGNAL_LINK_URI_PREFIX = "sgnl://linkdevice?";
 // Wizard notes become system-agent history, so keep dependency diagnostics well below the
 // repository's per-item model-context budget while retaining the actionable stderr tail.
 const SIGNAL_LINK_ERROR_OUTPUT_LIMIT = 2_000;
+const SIGNAL_CLI_LINK_STDOUT_LIMIT_BYTES = 8 * 1024;
 const SIGNAL_CLI_LINK_QR_TIMEOUT_MS = 120_000;
 // signal-cli waits up to 30 seconds for the link URI, then 120 seconds for provisioning.
 // Leave a small startup/write buffer while still bounding hangs before either timeout starts.
@@ -146,7 +147,11 @@ export async function linkSignalCliAccount(params: {
         killProcessTree: true,
         timeoutMs: SIGNAL_CLI_LINK_TIMEOUT_MS,
         outputCapture: { stdout: "discard", stderr: "tail" },
-        maxOutputBytes: { stdout: 8 * 1024, stderr: SIGNAL_LINK_ERROR_OUTPUT_LIMIT },
+        maxOutputBytes: {
+          stdout: SIGNAL_CLI_LINK_STDOUT_LIMIT_BYTES,
+          stderr: SIGNAL_LINK_ERROR_OUTPUT_LIMIT,
+        },
+        terminateOnOutputLimit: { stdout: true },
         maxPreservedOutputLines: 1,
         preserveOutputLine: (line, stream) => {
           if (stream === "stdout") {
@@ -174,6 +179,9 @@ export async function linkSignalCliAccount(params: {
     }
     if (displayError) {
       return { ok: false, error: displayError };
+    }
+    if (result.outputLimitExceeded) {
+      return { ok: false, error: "signal-cli link exceeded its 8 KiB output limit." };
     }
     if (result.termination === "timeout") {
       return { ok: false, error: "Signal account linking timed out." };

--- a/extensions/signal/src/signal-cli-link.ts
+++ b/extensions/signal/src/signal-cli-link.ts
@@ -1,0 +1,198 @@
+import path from "node:path";
+import { runCommandWithTimeout } from "openclaw/plugin-sdk/process-runtime";
+import { z } from "zod";
+import { resolveSignalCliConfigPath } from "./signal-cli-config-path.js";
+
+type SignalCliLinkResult = { ok: true; associatedAccount?: string } | { ok: false; error: string };
+type SignalCliAccountsResult = { ok: true; accounts: string[] } | { ok: false; error: string };
+
+type SignalCliLinkCompletion = Promise<void>;
+
+const SIGNAL_LINK_URI_PREFIX = "sgnl://linkdevice?";
+// Wizard notes become system-agent history, so keep dependency diagnostics well below the
+// repository's per-item model-context budget while retaining the actionable stderr tail.
+const SIGNAL_LINK_ERROR_OUTPUT_LIMIT = 2_000;
+const SIGNAL_CLI_LINK_QR_TIMEOUT_MS = 120_000;
+// signal-cli waits up to 30 seconds for the link URI, then 120 seconds for provisioning.
+// Leave a small startup/write buffer while still bounding hangs before either timeout starts.
+const SIGNAL_CLI_LINK_TIMEOUT_MS = 3 * 60_000;
+const SIGNAL_CLI_LIST_TIMEOUT_MS = 10_000;
+const SignalCliAccountsSchema = z.array(z.object({ number: z.string().regex(/^\+\d{5,15}$/u) }));
+const DEFAULT_SIGNAL_CLI_STORE_KEY = "<signal-cli-default-store>";
+const activeSignalCliLinkStores = new Set<string>();
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function signalCliArgs(configPath: string | undefined): string[] {
+  return configPath?.trim() ? ["--config", resolveSignalCliConfigPath(configPath)] : [];
+}
+
+function signalCliStoreKey(configPath: string | undefined): string {
+  const configuredPath = configPath?.trim();
+  return configuredPath
+    ? path.resolve(resolveSignalCliConfigPath(configuredPath))
+    : DEFAULT_SIGNAL_CLI_STORE_KEY;
+}
+
+export async function listSignalCliAccounts(params: {
+  cliPath: string;
+  configPath?: string;
+  signal?: AbortSignal;
+}): Promise<SignalCliAccountsResult> {
+  try {
+    const result = await runCommandWithTimeout(
+      [params.cliPath, ...signalCliArgs(params.configPath), "--output", "json", "listAccounts"],
+      {
+        ...(params.signal ? { signal: params.signal } : {}),
+        killProcessTree: true,
+        timeoutMs: SIGNAL_CLI_LIST_TIMEOUT_MS,
+        maxOutputBytes: { stdout: 16 * 1024, stderr: SIGNAL_LINK_ERROR_OUTPUT_LIMIT },
+        outputCapture: { stdout: "head", stderr: "tail" },
+        terminateOnOutputLimit: { stdout: true },
+      },
+    );
+    if (result.code !== 0) {
+      return {
+        ok: false,
+        error: result.stderr.trim() || "signal-cli could not inspect its linked accounts.",
+      };
+    }
+    const parsed = SignalCliAccountsSchema.safeParse(JSON.parse(result.stdout));
+    return parsed.success
+      ? { ok: true, accounts: parsed.data.map((account) => account.number) }
+      : { ok: false, error: "signal-cli returned an invalid account list." };
+  } catch (error) {
+    return { ok: false, error: `Could not inspect signal-cli accounts: ${errorMessage(error)}` };
+  }
+}
+
+export async function linkSignalCliAccount(params: {
+  cliPath: string;
+  configPath?: string;
+  signal?: AbortSignal;
+  onLinkUri: (
+    uri: string,
+    completion: SignalCliLinkCompletion,
+    expiresAtMs: number,
+  ) => Promise<void>;
+}): Promise<SignalCliLinkResult> {
+  if (params.signal?.aborted) {
+    return { ok: false, error: "Signal account linking was cancelled." };
+  }
+  const storeKey = signalCliStoreKey(params.configPath);
+  // Provisioning mutates one signal-cli store. Serialize that store without
+  // blocking accounts whose managed-native transports use independent stores.
+  if (activeSignalCliLinkStores.has(storeKey)) {
+    return { ok: false, error: "Signal account linking is already in progress." };
+  }
+  activeSignalCliLinkStores.add(storeKey);
+
+  const commandAbort = new AbortController();
+  let displayError: string | undefined;
+  let displayPromise = Promise.resolve();
+  let linkUriSeen = false;
+  let associatedAccount: string | undefined;
+  let resolveCompletion!: () => void;
+  const completion = new Promise<void>((complete) => {
+    resolveCompletion = complete;
+  });
+  const stopWithError = (error: string) => {
+    if (displayError) {
+      return;
+    }
+    displayError = error;
+    resolveCompletion();
+    commandAbort.abort();
+  };
+  const abort = () => stopWithError("Signal account linking was cancelled.");
+  params.signal?.addEventListener("abort", abort, { once: true });
+
+  const processLine = (line: string) => {
+    const trimmed = line.trim();
+    if (!linkUriSeen && trimmed.startsWith(SIGNAL_LINK_URI_PREFIX)) {
+      linkUriSeen = true;
+      displayPromise = Promise.resolve()
+        .then(
+          async () =>
+            await params.onLinkUri(trimmed, completion, Date.now() + SIGNAL_CLI_LINK_QR_TIMEOUT_MS),
+        )
+        .catch((error: unknown) => {
+          stopWithError(`Signal account linking stopped: ${errorMessage(error)}`);
+        });
+      return;
+    }
+    const associatedMatch = /^Associated with:\s*(\+\d{5,15})$/iu.exec(trimmed);
+    if (associatedMatch?.[1]) {
+      associatedAccount = associatedMatch[1];
+    }
+  };
+  try {
+    // This repository-owned runner is the lifecycle owner: cancellation terminates wrapped
+    // launchers and their descendants before returning, including on Windows.
+    const result = await runCommandWithTimeout(
+      [
+        params.cliPath,
+        ...signalCliArgs(params.configPath),
+        "--output",
+        "plain-text",
+        "link",
+        "-n",
+        "OpenClaw",
+      ],
+      {
+        signal: commandAbort.signal,
+        killProcessTree: true,
+        timeoutMs: SIGNAL_CLI_LINK_TIMEOUT_MS,
+        outputCapture: { stdout: "discard", stderr: "tail" },
+        maxOutputBytes: { stdout: 8 * 1024, stderr: SIGNAL_LINK_ERROR_OUTPUT_LIMIT },
+        maxPreservedOutputLines: 1,
+        preserveOutputLine: (line, stream) => {
+          if (stream === "stdout") {
+            processLine(line);
+          }
+          // The runner owns UTF-8 decoding and bounded line framing. Signal consumes matching
+          // markers immediately, so no line needs to be copied into the command result.
+          return false;
+        },
+      },
+    );
+    resolveCompletion();
+    await displayPromise;
+
+    if (result.code === 0) {
+      if (!linkUriSeen) {
+        return {
+          ok: false,
+          error: "signal-cli link finished without producing a device-link QR code.",
+        };
+      }
+      // signal-cli prints the account only after finishDeviceLink succeeds. A late client
+      // cancellation must not turn that durable success into a second linking attempt.
+      return { ok: true, ...(associatedAccount ? { associatedAccount } : {}) };
+    }
+    if (displayError) {
+      return { ok: false, error: displayError };
+    }
+    if (result.termination === "timeout") {
+      return { ok: false, error: "Signal account linking timed out." };
+    }
+    return {
+      ok: false,
+      error:
+        result.stderr.trim() ||
+        `signal-cli link exited with ${result.signal ? `signal ${result.signal}` : `code ${result.code ?? "unknown"}`}.`,
+    };
+  } catch (error) {
+    resolveCompletion();
+    await displayPromise;
+    if (displayError) {
+      return { ok: false, error: displayError };
+    }
+    return { ok: false, error: `Could not start signal-cli: ${errorMessage(error)}` };
+  } finally {
+    params.signal?.removeEventListener("abort", abort);
+    activeSignalCliLinkStores.delete(storeKey);
+  }
+}

--- a/extensions/signal/src/signal-cli-link.ts
+++ b/extensions/signal/src/signal-cli-link.ts
@@ -1,9 +1,8 @@
-import path from "node:path";
 import { runCommandWithTimeout } from "openclaw/plugin-sdk/process-runtime";
 import { z } from "zod";
 import { resolveSignalCliConfigPath } from "./signal-cli-config-path.js";
 
-type SignalCliLinkResult = { ok: true; associatedAccount?: string } | { ok: false; error: string };
+type SignalCliLinkResult = { ok: true; associatedAccount: string } | { ok: false; error: string };
 type SignalCliAccountsResult = { ok: true; accounts: string[] } | { ok: false; error: string };
 
 type SignalCliLinkCompletion = Promise<void>;
@@ -19,8 +18,7 @@ const SIGNAL_CLI_LINK_QR_TIMEOUT_MS = 120_000;
 const SIGNAL_CLI_LINK_TIMEOUT_MS = 3 * 60_000;
 const SIGNAL_CLI_LIST_TIMEOUT_MS = 10_000;
 const SignalCliAccountsSchema = z.array(z.object({ number: z.string().regex(/^\+\d{5,15}$/u) }));
-const DEFAULT_SIGNAL_CLI_STORE_KEY = "<signal-cli-default-store>";
-const activeSignalCliLinkStores = new Set<string>();
+let signalCliLinkActive = false;
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -28,13 +26,6 @@ function errorMessage(error: unknown): string {
 
 function signalCliArgs(configPath: string | undefined): string[] {
   return configPath?.trim() ? ["--config", resolveSignalCliConfigPath(configPath)] : [];
-}
-
-function signalCliStoreKey(configPath: string | undefined): string {
-  const configuredPath = configPath?.trim();
-  return configuredPath
-    ? path.resolve(resolveSignalCliConfigPath(configuredPath))
-    : DEFAULT_SIGNAL_CLI_STORE_KEY;
 }
 
 export async function listSignalCliAccounts(params: {
@@ -82,13 +73,12 @@ export async function linkSignalCliAccount(params: {
   if (params.signal?.aborted) {
     return { ok: false, error: "Signal account linking was cancelled." };
   }
-  const storeKey = signalCliStoreKey(params.configPath);
-  // Provisioning mutates one signal-cli store. Serialize that store without
-  // blocking accounts whose managed-native transports use independent stores.
-  if (activeSignalCliLinkStores.has(storeKey)) {
+  // signal-cli chooses its implicit store from process environment. Serialize linking globally
+  // so implicit and explicit aliases cannot mutate the same dependency-owned store concurrently.
+  if (signalCliLinkActive) {
     return { ok: false, error: "Signal account linking is already in progress." };
   }
-  activeSignalCliLinkStores.add(storeKey);
+  signalCliLinkActive = true;
 
   const commandAbort = new AbortController();
   let displayError: string | undefined;
@@ -173,9 +163,15 @@ export async function linkSignalCliAccount(params: {
           error: "signal-cli link finished without producing a device-link QR code.",
         };
       }
+      if (!associatedAccount) {
+        return {
+          ok: false,
+          error: "signal-cli link finished without reporting the associated account.",
+        };
+      }
       // signal-cli prints the account only after finishDeviceLink succeeds. A late client
       // cancellation must not turn that durable success into a second linking attempt.
-      return { ok: true, ...(associatedAccount ? { associatedAccount } : {}) };
+      return { ok: true, associatedAccount };
     }
     if (displayError) {
       return { ok: false, error: displayError };
@@ -201,6 +197,6 @@ export async function linkSignalCliAccount(params: {
     return { ok: false, error: `Could not start signal-cli: ${errorMessage(error)}` };
   } finally {
     params.signal?.removeEventListener("abort", abort);
-    activeSignalCliLinkStores.delete(storeKey);
+    signalCliLinkActive = false;
   }
 }

--- a/extensions/signal/src/signal-cli-link.ts
+++ b/extensions/signal/src/signal-cli-link.ts
@@ -160,8 +160,8 @@ export async function linkSignalCliAccount(params: {
     await displayPromise;
 
     if (associatedAccount) {
-      // signal-cli prints the account only after finishDeviceLink succeeds. A late client
-      // cancellation must not turn that durable success into a second linking attempt.
+      // signal-cli emits this marker only after finishDeviceLink returns. The linked account is
+      // therefore durable even when a late presentation failure terminates the settling process.
       return { ok: true, associatedAccount };
     }
     if (result.code === 0 && result.termination === "exit") {

--- a/extensions/signal/src/signal-cli-link.ts
+++ b/extensions/signal/src/signal-cli-link.ts
@@ -53,7 +53,7 @@ export async function listSignalCliAccounts(params: {
         terminateOnOutputLimit: { stdout: true },
       },
     );
-    if (result.code !== 0) {
+    if (result.code !== 0 || result.termination !== "exit") {
       return {
         ok: false,
         error: result.stderr.trim() || "signal-cli could not inspect its linked accounts.",
@@ -161,7 +161,7 @@ export async function linkSignalCliAccount(params: {
     resolveCompletion();
     await displayPromise;
 
-    if (result.code === 0) {
+    if (result.code === 0 && result.termination === "exit") {
       if (!linkUriSeen) {
         return {
           ok: false,

--- a/extensions/signal/src/signal-cli-link.ts
+++ b/extensions/signal/src/signal-cli-link.ts
@@ -101,6 +101,9 @@ export async function linkSignalCliAccount(params: {
   params.signal?.addEventListener("abort", abort, { once: true });
 
   const processLine = (line: string) => {
+    if (displayError) {
+      return;
+    }
     const trimmed = line.trim();
     if (!linkUriSeen && trimmed.startsWith(SIGNAL_LINK_URI_PREFIX)) {
       linkUriSeen = true;

--- a/src/process/exec.test.ts
+++ b/src/process/exec.test.ts
@@ -264,6 +264,56 @@ describe("runCommandWithTimeout", () => {
     ]);
   });
 
+  it("delivers preserved lines while the command is still running", async () => {
+    const abortController = new AbortController();
+    let resolveLinkUri!: () => void;
+    const linkUriSeen = new Promise<void>((resolve) => {
+      resolveLinkUri = resolve;
+    });
+    let commandSettled = false;
+    const commandPromise = runCommandWithTimeout(
+      [
+        process.execPath,
+        "-e",
+        [
+          "process.stdout.write('sgnl://linkdevice?uuid=test&pub_key=test\\n')",
+          "setInterval(() => {}, 1_000)",
+        ].join(";"),
+      ],
+      {
+        signal: abortController.signal,
+        killProcessTree: true,
+        outputCapture: { stdout: "discard", stderr: "tail" },
+        timeoutMs: 3_000,
+        preserveOutputLine: (line, stream) => {
+          if (stream === "stdout" && line.startsWith("sgnl://linkdevice?")) {
+            resolveLinkUri();
+          }
+          return false;
+        },
+      },
+    );
+    void commandPromise.then(
+      () => {
+        commandSettled = true;
+      },
+      () => {
+        commandSettled = true;
+      },
+    );
+
+    await expect(
+      Promise.race([linkUriSeen.then(() => "line"), commandPromise.then(() => "command")]),
+    ).resolves.toBe("line");
+    expect(commandSettled).toBe(false);
+
+    abortController.abort();
+    await expect(commandPromise).resolves.toMatchObject({
+      code: null,
+      termination: "signal",
+    });
+  });
+
   it("bounds preserved matching output for long lines without newlines", async () => {
     const result = await runCommandWithTimeout(
       [process.execPath, "-e", "process.stdout.write('x'.repeat(10_000))"],


### PR DESCRIPTION
## Superseded

The signal-cli link adapter now ships with its supported setup caller in #118169. Keeping the private adapter separate left its production path unreachable and created an artificial dependency diamond with the generic QR stack.

The combined PR preserves this adapter’s bounded process lifecycle, terminal-marker validation, cancellation behavior, tests, and upstream signal-cli completion contract. No adapter behavior was dropped.

Closing this draft avoids reviewing or landing a dormant production surface.