### PR TITLE
fix(exec): leave safe builtins unrewritten in enforced mode

### DIFF
--- a/src/infra/exec-authorization-render.test.ts
+++ b/src/infra/exec-authorization-render.test.ts
@@ -157,6 +157,25 @@ describe("exec authorization renderer", () => {
     expect(command).toMatch(/^\/.+\/head -c 16$/);
   });
 
+  it("leaves POSIX safe builtins unrewritten in enforced mode", async () => {
+    const plan = await planShellAuthorization({
+      command: "cd .",
+      env: POSIX_ENV,
+    });
+
+    const command = renderOk(
+      buildAuthorizedShellCommandFromPlan({
+        plan,
+        mode: "enforced",
+        segmentSatisfiedBy: ["safeBuiltins"],
+      }),
+    );
+
+    // Builtins run in the shell, not via a filesystem executable, so enforced
+    // mode must not rewrite `cd` to a resolved path like /usr/bin/cd.
+    expect(command).toBe("cd .");
+  });
+
   it("rewrites quoted POSIX executable source spans", async () => {
     const plan = await planShellAuthorization({
       command: '"head" -c 16',

--- a/src/infra/exec-authorization-render.ts
+++ b/src/infra/exec-authorization-render.ts
@@ -130,7 +130,10 @@ function shouldRewriteCandidate(params: {
   satisfiedBy: ExecSegmentSatisfiedBy | undefined;
 }): boolean {
   if (params.mode === "enforced") {
-    return true;
+    // Safe builtins (cd, :, true, false, pwd, test) are handled by the shell itself, not by an
+    // external executable. Rewriting them to a resolved path (e.g. /usr/bin/cd) is semantically
+    // wrong and does not strengthen PATH-shadowing protection, so enforced mode leaves them as-is.
+    return params.satisfiedBy !== "safeBuiltins";
   }
   return params.satisfiedBy === "safeBins" || params.satisfiedBy === "inlineChain";
 }


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the enforced-mode exec renderer rewrote POSIX shell builtins to absolute filesystem paths. When an operator-approved command containing a safe builtin such as `cd .` ran through the enforced authorization path, the rendered command became `/usr/bin/cd .` instead of `cd .`. Builtins (`cd`, `:`, `true`, `false`, `pwd`, `test`) are executed by the shell itself, not by an external binary, so the rewrite is semantically wrong and provides no security benefit.

## Why This Change Was Made

The enforced-mode security invariant exists to pin real external executables to their resolved absolute path so a PATH-shadowed binary cannot be substituted. That invariant does not apply to builtins, which the shell resolves internally without consulting PATH. `shouldRewriteCandidate` previously returned `true` unconditionally in enforced mode; it now returns `satisfiedBy !== "safeBuiltins"`, exempting only the closed builtin set while leaving every real external executable pinned to its resolved path. Non-goal: changing behavior for any non-builtin segment.

## User Impact

Operators on platforms that ship a real external builtin binary (notably macOS, which has `/usr/bin/cd`) no longer get a rewritten, semantically different command for approved builtins. There is no behavior change for external executables, which still resolve to absolute paths.

## Evidence

- New regression test `leaves POSIX safe builtins unrewritten in enforced mode` in `src/infra/exec-authorization-render.test.ts` locks that `cd .` renders as `cd .`.
- `node scripts/run-vitest.mjs src/infra/exec-authorization-render.test.ts src/infra/exec-safe-builtins.test.ts src/agents/bash-tools.exec-host-gateway.test.ts` — all green (15 + 90 + 14 tests).
- Verified via `buildAuthorizedShellCommandFromPlan({ command: "cd .", mode: "enforced", segmentSatisfiedBy: ["safeBuiltins"] })` returns `cd .` (was `/usr/bin/cd .`).
- Production delta: +4/−1 in one file. Autoreview (codex, high): clean, no accepted findings.

Found during a 87,932-test stress sweep of the feature surface (30 parallel agents); this was one of two confirmed production defects.
