### PR TITLE
test(slack): drop redundant .js-suffixed system-event mock

### DIFF
--- a/extensions/slack/src/monitor/events/channels.test.ts
+++ b/extensions/slack/src/monitor/events/channels.test.ts
@@ -8,9 +8,6 @@ let createSlackSystemEventTestHarness: typeof import("./system-event-test-harnes
 vi.mock("openclaw/plugin-sdk/system-event-runtime", () => ({
   enqueueSystemEvent: (...args: unknown[]) => enqueueSystemEventMock(...args),
 }));
-vi.mock("openclaw/plugin-sdk/system-event-runtime.js", () => ({
-  enqueueSystemEvent: (...args: unknown[]) => enqueueSystemEventMock(...args),
-}));
 type SlackChannelHandler = (args: {
   event: Record<string, unknown>;
   body: unknown;

--- a/extensions/slack/src/monitor/events/members.test.ts
+++ b/extensions/slack/src/monitor/events/members.test.ts
@@ -11,9 +11,6 @@ type MemberOverrides = import("./system-event-test-harness.js").SlackSystemEvent
 vi.mock("openclaw/plugin-sdk/system-event-runtime", () => ({
   enqueueSystemEvent: (...args: unknown[]) => memberMocks.enqueue(...args),
 }));
-vi.mock("openclaw/plugin-sdk/system-event-runtime.js", () => ({
-  enqueueSystemEvent: (...args: unknown[]) => memberMocks.enqueue(...args),
-}));
 type MemberHandler = (args: { event: Record<string, unknown>; body: unknown }) => Promise<void>;
 
 type MemberCaseArgs = {

--- a/extensions/slack/src/monitor/events/messages.test.ts
+++ b/extensions/slack/src/monitor/events/messages.test.ts
@@ -38,9 +38,6 @@ vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {
 vi.mock("openclaw/plugin-sdk/system-event-runtime", () => ({
   enqueueSystemEvent: (...args: unknown[]) => messageQueueMock(...args),
 }));
-vi.mock("openclaw/plugin-sdk/system-event-runtime.js", () => ({
-  enqueueSystemEvent: (...args: unknown[]) => messageQueueMock(...args),
-}));
 vi.mock("openclaw/plugin-sdk/conversation-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/conversation-runtime")>();
   return {

--- a/extensions/slack/src/monitor/events/pins.test.ts
+++ b/extensions/slack/src/monitor/events/pins.test.ts
@@ -9,9 +9,6 @@ type PinOverrides = import("./system-event-test-harness.js").SlackSystemEventTes
 vi.mock("openclaw/plugin-sdk/system-event-runtime", () => ({
   enqueueSystemEvent: (...args: unknown[]) => pinEnqueueMock(...args),
 }));
-vi.mock("openclaw/plugin-sdk/system-event-runtime.js", () => ({
-  enqueueSystemEvent: (...args: unknown[]) => pinEnqueueMock(...args),
-}));
 type PinHandler = (args: { event: Record<string, unknown>; body: unknown }) => Promise<void>;
 
 type PinCase = {

--- a/extensions/slack/src/monitor/events/reactions.test.ts
+++ b/extensions/slack/src/monitor/events/reactions.test.ts
@@ -10,9 +10,6 @@ type SlackSystemEventTestOverrides =
 vi.mock("openclaw/plugin-sdk/system-event-runtime", () => ({
   enqueueSystemEvent: (...args: unknown[]) => reactionQueueMock(...args),
 }));
-vi.mock("openclaw/plugin-sdk/system-event-runtime.js", () => ({
-  enqueueSystemEvent: (...args: unknown[]) => reactionQueueMock(...args),
-}));
 type ReactionHandler = (args: { event: Record<string, unknown>; body: unknown }) => Promise<void>;
 
 type ReactionRunInput = {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where 42 Slack monitor test suites failed at collection before a single test ran. Each of the five monitor event suites registered a duplicate `vi.mock` for `"openclaw/plugin-sdk/system-event-runtime.js"` (with a `.js` suffix) alongside the extensionless mock. That suffixed subpath is not a declared export of the `openclaw` package, so vitest aborts collection with `"./plugin-sdk/system-event-runtime.js" is not exported under the conditions ["node", "development", "import"]`.

## Why This Change Was Made

The extensionless mock `vi.mock("openclaw/plugin-sdk/system-event-runtime", ...)` already intercepts the production import, so the `.js`-suffixed duplicate is dead weight that only breaks resolution. The fix deletes the redundant three-line mock block from each of the five files. No production code is touched; this is test-only cleanup.

## User Impact

No user-visible impact — this restores a broken test suite so the Slack monitor event behavior is actually exercised again (1026 tests across 48 suites).

## Evidence

- `node scripts/run-vitest.mjs extensions/slack/src/monitor -- --reporter=dot`: **48 suites / 1026 tests pass** (previously 42 suites errored at collection with the export-resolution failure).
- Autoreview (codex, high): clean, no accepted findings.

Found during a broad stress sweep of the repo's test surface.
