### PR TITLE
test(agents): realpath apply-patch temp dir fixture

### DIFF
--- a/src/agents/apply-patch.test.ts
+++ b/src/agents/apply-patch.test.ts
@@ -16,7 +16,9 @@ import { applyPatch } from "./apply-patch.test-support.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 
 async function withTempDir<T>(fn: (dir: string) => Promise<T>) {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-patch-"));
+  // realpath: production sandbox checks compare against canonical paths; on macOS
+  // os.tmpdir() is a /var -> /private/var symlink, which otherwise trips the guard.
+  const dir = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-patch-")));
   try {
     return await fn(dir);
   } finally {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the apply-patch symlink-delete test failed on macOS with `Path escapes sandbox root`. The test's `withTempDir` helper used a raw `fs.mkdtemp(os.tmpdir())` path. On macOS `os.tmpdir()` is a `/var` → `/private/var` symlink, while the production sandbox guard compares against canonical (realpath'd) paths, so the guard rejected the lexical temp path.

## Why This Change Was Made

The production guard is correct; the fixture was not. The fix realpaths the `mkdtemp` result so the temp directory matches the canonical form the guard expects. Test-only change, no production behavior touched.

## User Impact

No user-visible impact — this makes the apply-patch test suite portable across macOS and Linux so the sandbox path-safety behavior is reliably exercised.

## Evidence

- `node scripts/run-vitest.mjs src/agents/apply-patch.test.ts`: **52 tests pass** on macOS (previously the symlink-delete case threw `Path escapes sandbox root`).
- Autoreview (codex, high): clean, no accepted findings.

Found during a broad stress sweep of the repo's test surface.
