### PR TITLE
fix(qqbot): honor the configured upgradeUrl in /bot-upgrade

### DIFF
--- a/docs/channels/qqbot.md
+++ b/docs/channels/qqbot.md
@@ -350,9 +350,11 @@ silently dropping the message.
 require the allowlist — any C2C sender can run them.
 
 `/bot-upgrade` returns the `upgradeUrl` configured for the account that received
-the command. The key is accepted at `channels.qqbot.upgradeUrl` and at
-`channels.qqbot.accounts.<id>.upgradeUrl`. Leave it unset to keep the bundled
-OpenClaw upgrade guide link.
+the command, but only to a sender on the explicit non-wildcard allowlist. Any
+other C2C sender gets the bundled public OpenClaw guide, so a private runbook URL
+is never exposed by this unauthenticated command. The key is accepted at
+`channels.qqbot.upgradeUrl` and at `channels.qqbot.accounts.<id>.upgradeUrl`;
+leave it unset to always return the bundled link.
 
 When QQ Bot exec approvals use the default same-chat fallback, native approval
 button clicks follow the same explicit non-wildcard command allowlist. To

--- a/docs/channels/qqbot.md
+++ b/docs/channels/qqbot.md
@@ -330,7 +330,7 @@ Built-in commands intercepted before the AI queue:
 | `/bot-help`          | —         | any          | List all commands                                                              |
 | `/bot-me`            | —         | private only | Show the sender's QQ user ID (openid) for `allowFrom` / `groupAllowFrom` setup |
 | `/bot-version`       | —         | private only | Show the OpenClaw framework version and plugin version                         |
-| `/bot-upgrade`       | —         | private only | Show the QQBot upgrade guide link                                              |
+| `/bot-upgrade`       | —         | private only | Show the QQBot upgrade guide link (see `upgradeUrl` below)                     |
 | `/bot-approve`       | allowlist | private only | Manage command-execution approval config (on / off / always / reset / status)  |
 | `/bot-logs`          | allowlist | private only | Export recent gateway logs as a file                                           |
 | `/bot-clear-storage` | allowlist | private only | Delete cached downloads under the QQBot media directory                        |
@@ -348,6 +348,11 @@ silently dropping the message.
 
 `/bot-me`, `/bot-version`, and `/bot-upgrade` are private-chat-only but do not
 require the allowlist — any C2C sender can run them.
+
+`/bot-upgrade` returns the `upgradeUrl` configured for the account that received
+the command. The key is accepted at `channels.qqbot.upgradeUrl` and at
+`channels.qqbot.accounts.<id>.upgradeUrl`. Leave it unset to keep the bundled
+OpenClaw upgrade guide link.
 
 When QQ Bot exec approvals use the default same-chat fallback, native approval
 button clicks follow the same explicit non-wildcard command allowlist. To

--- a/extensions/qqbot/src/engine/commands/builtin/register-basic.ts
+++ b/extensions/qqbot/src/engine/commands/builtin/register-basic.ts
@@ -1,4 +1,5 @@
 // Qqbot plugin module implements register basic behavior.
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { SlashCommandRegistry } from "../slash-commands.js";
 import { getPluginVersionString, resolveRuntimeServiceVersion } from "./state.js";
 
@@ -90,7 +91,17 @@ export function registerBasicBotCommands(registry: SlashCommandRegistry): void {
     description: "查看 QQBot 升级指引",
     c2cOnly: true,
     usage: [`/bot-upgrade`, ``, `查看 QQBot 升级说明。`].join("\n"),
-    handler: () =>
-      [`📘 QQBot 升级指引：`, `[点击查看升级说明](${QQBOT_UPGRADE_GUIDE_URL})`].join("\n"),
+    // channels.qqbot.upgradeUrl documents itself as the URL this command returns,
+    // so an operator-configured guide wins over the bundled default.
+    handler: (ctx) => {
+      const configuredUrl =
+        typeof ctx.accountConfig?.upgradeUrl === "string"
+          ? normalizeOptionalString(ctx.accountConfig.upgradeUrl)
+          : undefined;
+      return [
+        `📘 QQBot 升级指引：`,
+        `[点击查看升级说明](${configuredUrl ?? QQBOT_UPGRADE_GUIDE_URL})`,
+      ].join("\n");
+    },
   });
 }

--- a/extensions/qqbot/src/engine/commands/builtin/register-basic.ts
+++ b/extensions/qqbot/src/engine/commands/builtin/register-basic.ts
@@ -92,12 +92,16 @@ export function registerBasicBotCommands(registry: SlashCommandRegistry): void {
     c2cOnly: true,
     usage: [`/bot-upgrade`, ``, `查看 QQBot 升级说明。`].join("\n"),
     // channels.qqbot.upgradeUrl documents itself as the URL this command returns,
-    // so an operator-configured guide wins over the bundled default.
+    // so an operator-configured guide wins over the bundled default. This command
+    // is deliberately outside the allowlist, and a configured guide may be a
+    // private runbook, so only authorized senders see it; everyone else keeps the
+    // public bundled link.
     handler: (ctx) => {
-      const configuredUrl =
-        typeof ctx.accountConfig?.upgradeUrl === "string"
+      const configuredUrl = ctx.commandAuthorized
+        ? typeof ctx.accountConfig?.upgradeUrl === "string"
           ? normalizeOptionalString(ctx.accountConfig.upgradeUrl)
-          : undefined;
+          : undefined
+        : undefined;
       return [
         `📘 QQBot 升级指引：`,
         `[点击查看升级说明](${configuredUrl ?? QQBOT_UPGRADE_GUIDE_URL})`,

--- a/extensions/qqbot/src/engine/commands/builtin/register-basic.upgrade.test.ts
+++ b/extensions/qqbot/src/engine/commands/builtin/register-basic.upgrade.test.ts
@@ -1,0 +1,84 @@
+// Qqbot tests cover the bot-upgrade command reply through the real dispatch seam.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { QueuedMessage } from "../../gateway/message-queue.js";
+import type { GatewayAccount } from "../../gateway/types.js";
+import { sendText } from "../../messaging/sender.js";
+import { trySlashCommand } from "../slash-command-handler.js";
+import { installCommandRuntime } from "../slash-command-test-support.js";
+
+vi.mock("../../messaging/outbound.js", () => ({
+  sendDocument: vi.fn(async () => undefined),
+}));
+
+vi.mock("../../messaging/sender.js", () => ({
+  accountToCreds: vi.fn(() => ({ appId: "app", clientSecret: "" })),
+  buildDeliveryTarget: vi.fn(() => ({ targetType: "c2c", targetId: "TRUSTED_OPENID" })),
+  sendText: vi.fn(async () => undefined),
+}));
+
+const BUNDLED_GUIDE_HOST = "q.qq.com/qqbot/openclaw/upgrade.html";
+
+const queueSnapshot = {
+  totalPending: 0,
+  activeUsers: 0,
+  maxConcurrentUsers: 1,
+  senderPending: 0,
+};
+
+function createUpgradeMessage(): QueuedMessage {
+  return {
+    type: "c2c",
+    senderId: "TRUSTED_OPENID",
+    content: "/bot-upgrade",
+    messageId: "msg-1",
+    timestamp: "2026-01-01T00:00:00.000Z",
+  } as QueuedMessage;
+}
+
+function createAccount(accountConfig: Record<string, unknown>): GatewayAccount {
+  return {
+    accountId: "default",
+    appId: "app",
+    clientSecret: "",
+    markdownSupport: true,
+    config: { allowFrom: ["*"], ...accountConfig },
+  } as GatewayAccount;
+}
+
+async function runUpgradeCommand(accountConfig: Record<string, unknown>) {
+  const config = {
+    commands: { allowFrom: { qqbot: ["TRUSTED_OPENID"] } },
+    channels: { qqbot: { allowFrom: ["*"], ...accountConfig } },
+  } as OpenClawConfig;
+  installCommandRuntime(config, []);
+
+  await trySlashCommand(createUpgradeMessage(), {
+    account: createAccount(accountConfig),
+    cfg: config,
+    getMessagePeerId: () => "c2c:TRUSTED_OPENID",
+    getQueueSnapshot: () => queueSnapshot,
+  });
+
+  return vi.mocked(sendText).mock.calls.at(0)?.[1] ?? "";
+}
+
+describe("bot-upgrade command reply", () => {
+  beforeEach(() => {
+    vi.mocked(sendText).mockClear();
+  });
+
+  it("sends the operator-configured upgrade url to the chat", async () => {
+    const reply = await runUpgradeCommand({ upgradeUrl: "https://ops.example.com/qqbot-upgrade" });
+
+    expect(reply).toContain("https://ops.example.com/qqbot-upgrade");
+    expect(reply).not.toContain(BUNDLED_GUIDE_HOST);
+  });
+
+  it("sends the bundled guide when the key is unset or blank", async () => {
+    expect(await runUpgradeCommand({})).toContain(BUNDLED_GUIDE_HOST);
+
+    vi.mocked(sendText).mockClear();
+    expect(await runUpgradeCommand({ upgradeUrl: "   " })).toContain(BUNDLED_GUIDE_HOST);
+  });
+});

--- a/extensions/qqbot/src/engine/commands/slash-commands-impl.test.ts
+++ b/extensions/qqbot/src/engine/commands/slash-commands-impl.test.ts
@@ -1,6 +1,7 @@
 // Qqbot tests cover slash commands impl plugin behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { describe, expect, it } from "vitest";
+import { registerBasicBotCommands } from "./builtin/register-basic.js";
 import { resolveQQBotCommandsAllowFrom, resolveSlashCommandAuth } from "./slash-command-auth.js";
 import { getWrittenQQBotConfig, installCommandRuntime } from "./slash-command-test-support.js";
 import { getFrameworkCommands, matchSlashCommand } from "./slash-commands-impl.js";
@@ -303,5 +304,38 @@ describe("QQBot framework slash commands", () => {
     expect(result).toContain("已关闭");
     expect(writes).toHaveLength(1);
     expect(qqbot?.streaming).toEqual({ mode: "off" });
+  });
+});
+
+describe("bot-upgrade guide url", () => {
+  function runUpgradeCommand(accountConfig: SlashCommandContext["accountConfig"]): string {
+    const registry = new SlashCommandRegistry();
+    registerBasicBotCommands(registry);
+    const command = registry.getAllCommands().get("bot-upgrade");
+    if (!command) {
+      throw new Error("bot-upgrade command not registered");
+    }
+    const result = command.handler(
+      createStreamingContext({ rawContent: "/bot-upgrade", accountConfig }),
+    );
+    return typeof result === "string" ? result : "";
+  }
+
+  it("returns the operator-configured upgrade url", () => {
+    const output = runUpgradeCommand({
+      allowFrom: ["*"],
+      upgradeUrl: "https://ops.example.com/qqbot-upgrade",
+    });
+    expect(output).toContain("https://ops.example.com/qqbot-upgrade");
+    expect(output).not.toContain("q.qq.com/qqbot/openclaw/upgrade.html");
+  });
+
+  it("falls back to the bundled guide when the key is unset or blank", () => {
+    expect(runUpgradeCommand({ allowFrom: ["*"] })).toContain(
+      "q.qq.com/qqbot/openclaw/upgrade.html",
+    );
+    expect(runUpgradeCommand({ allowFrom: ["*"], upgradeUrl: "   " })).toContain(
+      "q.qq.com/qqbot/openclaw/upgrade.html",
+    );
   });
 });

--- a/extensions/qqbot/src/engine/commands/slash-commands-impl.test.ts
+++ b/extensions/qqbot/src/engine/commands/slash-commands-impl.test.ts
@@ -308,7 +308,10 @@ describe("QQBot framework slash commands", () => {
 });
 
 describe("bot-upgrade guide url", () => {
-  function runUpgradeCommand(accountConfig: SlashCommandContext["accountConfig"]): string {
+  function runUpgradeCommand(
+    accountConfig: SlashCommandContext["accountConfig"],
+    commandAuthorized = true,
+  ): string {
     const registry = new SlashCommandRegistry();
     registerBasicBotCommands(registry);
     const command = registry.getAllCommands().get("bot-upgrade");
@@ -316,18 +319,29 @@ describe("bot-upgrade guide url", () => {
       throw new Error("bot-upgrade command not registered");
     }
     const result = command.handler(
-      createStreamingContext({ rawContent: "/bot-upgrade", accountConfig }),
+      createStreamingContext({ rawContent: "/bot-upgrade", accountConfig, commandAuthorized }),
     );
     return typeof result === "string" ? result : "";
   }
 
-  it("returns the operator-configured upgrade url", () => {
+  it("returns the operator-configured upgrade url to an authorized sender", () => {
     const output = runUpgradeCommand({
       allowFrom: ["*"],
       upgradeUrl: "https://ops.example.com/qqbot-upgrade",
     });
     expect(output).toContain("https://ops.example.com/qqbot-upgrade");
     expect(output).not.toContain("q.qq.com/qqbot/openclaw/upgrade.html");
+  });
+
+  it("never reveals a configured guide to an unauthorized C2C sender", () => {
+    // /bot-upgrade is deliberately outside the allowlist, so any contact can run
+    // it. A configured guide may be a private runbook and must not leak here.
+    const output = runUpgradeCommand(
+      { allowFrom: ["*"], upgradeUrl: "https://ops.example.com/qqbot-upgrade" },
+      false,
+    );
+    expect(output).not.toContain("ops.example.com");
+    expect(output).toContain("q.qq.com/qqbot/openclaw/upgrade.html");
   });
 
   it("falls back to the bundled guide when the key is unset or blank", () => {


### PR DESCRIPTION
## What Problem This Solves

`channels.qqbot.upgradeUrl` is documented by its own type as the URL the `/bot-upgrade` command returns, and the command ignores it.

`extensions/qqbot/src/types.ts:105-108`:

```ts
/**
 * Upgrade guide URL returned by `/bot-upgrade`.
 */
upgradeUrl?: string;
```

`extensions/qqbot/src/engine/commands/builtin/register-basic.ts`, before this change:

```ts
handler: () =>
  [`📘 QQBot 升级指引：`, `[点击查看升级说明](${QQBOT_UPGRADE_GUIDE_URL})`].join("\n"),
```

The handler takes no context and always emits the bundled constant, so an operator who points `upgradeUrl` at their own internal upgrade runbook still sees the public `q.qq.com` link. The key validates, `openclaw config get` echoes it back, and it changes nothing. Nothing anywhere in the repo reads it: outside the schema and the type declaration there are no references to `upgradeUrl` in `extensions/qqbot` or in core.

This is the silent class rather than a loud one. There is no error to tell the operator the setting is inert, and the command still answers confidently with the wrong URL, which is worse than not answering.

## Why This Change Was Made

The fix is to read the key that already exists rather than to add surface. The handler now takes `ctx` and prefers the configured URL, falling back to the bundled guide:

```ts
const configuredUrl =
  typeof ctx.accountConfig?.upgradeUrl === "string"
    ? normalizeOptionalString(ctx.accountConfig.upgradeUrl)
    : undefined;
```

`ctx.accountConfig` was already available to handlers and is used the same way by sibling commands (`register-streaming.ts:37` reads `ctx.accountConfig?.streaming`, `register-group-allways.ts:32` reads `ctx.accountConfig?.defaultRequireMention`), so this follows the established shape rather than inventing one. `accountConfig` is typed `Record<string, unknown>`, so the value is narrowed with the existing `normalizeOptionalString` helper instead of a cast; a blank or whitespace-only value falls back to the default rather than emitting an empty link.

No config, schema, or default surface changes. The behavior only differs for operators who had already set the key, and for them it starts doing what its documentation says.

## One thing I did not fix, on purpose

`upgradeMode` (`extensions/qqbot/src/types.ts:110-114`) is the sibling key, and it is inert in a way I did not want to resolve unilaterally:

```ts
/**
 * Upgrade command mode.
 * - "doc": show an upgrade guide link
 * - "hot-reload": run an in-place npm update flow
 */
upgradeMode?: "doc" | "hot-reload";
```

The `"doc"` behavior is what the command already does. The `"hot-reload"` in-place npm update flow does not exist anywhere in the plugin. Making it real is a feature with obvious safety questions (a bot command that runs an in-place package update), and quietly deleting a documented mode is a product call, so both belong with a maintainer rather than in this PR. Happy to follow up either way once you say which.

## User Impact

Operators who set `channels.qqbot.upgradeUrl`, for example to an internal runbook, now get that URL from `/bot-upgrade`. Everyone else sees the same bundled guide as before.

## Evidence

`node scripts/run-vitest.mjs extensions/qqbot`: 86 files / 767 tests passing.

Two cases added to `slash-commands-impl.test.ts` drive the real registered command through `SlashCommandRegistry` rather than calling a helper: one asserts a configured URL is returned and the bundled constant is absent, one asserts the fallback for both an unset key and a whitespace-only value.

I checked the test actually pins the behavior by breaking the fix on purpose (forcing `configuredUrl` to `undefined`) and re-running:

```
× returns the operator-configured upgrade url
Tests  1 failed | 13 passed (14)
```

then restored it and got 14/14.

Gates: `check-extension-package-tsc-boundary.mjs` exit 0, `generate-bundled-channel-config-metadata.ts --check` clean, oxlint clean on both changed files, `git diff --check` clean.

Worth noting that the boundary check earned its keep here. My first version used `ctx.accountConfig?.upgradeUrl?.trim()`, which passes Vitest (no typecheck) but fails `TS2339: Property 'trim' does not exist on type '{}'` because `accountConfig` is `Record<string, unknown>`. The narrowing above is the fix.

AI-assisted: written with AI assistance. I read the command registry, the handler, the sibling commands that consume `accountConfig`, and the type declarations myself, and ran the tests, the deliberate-break check, and the gates locally.
