### PR TITLE
chore(ci): lower environment variable budget

### DIFF
--- a/config/env-var-count-budget.txt
+++ b/config/env-var-count-budget.txt
@@ -1,3 +1,3 @@
 # Distinct OPENCLAW_* names in production source under src, packages, and extensions.
 # Ratchet: lower this number when cleanup removes names; never raise it.
-515
+513


### PR DESCRIPTION
## What Problem This Solves

Resolves a CI ratchet failure on current `main`, where production source contains 513 distinct `OPENCLAW_*` names but the checked-in budget still permits 515.

## Why This Change Was Made

Lower the ratchet to the measured current count. This preserves the existing policy that the budget must fall whenever environment-variable cleanup removes names.

## User Impact

No runtime behavior changes. Maintainers regain a passing environment-variable count gate, and future changes cannot reintroduce either removed name without an explicit budget increase.

## Evidence

- `NODENV_VERSION=24.18.0 node scripts/check-env-var-count.mjs --base origin/main` -> `OPENCLAW_* count 513/513`
- `NODENV_VERSION=24.18.0 node scripts/check-no-conflict-markers.mjs`
- `git diff --check`

Punchcard-Session: coral-workshop-workshop-3f
