### PR TITLE
feat(logbook): capture Windows Logbook snapshots via node-screenshots + Rastermill

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -244,6 +244,7 @@ const rootBundledPluginRuntimeDependencies = [
   "linkedom",
   "minimatch",
   "node-edge-tts",
+  "node-screenshots",
   "openshell",
   "clawpdf",
   "tokenjuice",

--- a/docs/plugins/logbook.md
+++ b/docs/plugins/logbook.md
@@ -27,9 +27,10 @@ Gateway into screen capture because `captureEnabled` defaults to `true`.
 You need:
 
 - A connected node that exposes `screen.snapshot` or `logbook.snapshot`. The
-  macOS app node needs Screen Recording permission. A headless macOS node host
-  (`openclaw node host run`) gets the plugin-provided `logbook.snapshot`
-  command backed by the system `screencapture` tool.
+  macOS app node needs Screen Recording permission. A headless macOS or
+  Windows node host (`openclaw node host run`) gets the plugin-provided
+  `logbook.snapshot` command. macOS uses the system `screencapture` tool;
+  Windows uses the bundled native capture runtime.
 - The bundled Codex plugin enabled and authenticated. Codex currently provides
   the structured image-extraction contract Logbook requires. Sign in with
   `openclaw models auth login --provider openai`; see
@@ -81,6 +82,10 @@ openclaw dashboard
 The node description must include `screen.snapshot` or `logbook.snapshot`.
 Headless nodes advertise `logbook.snapshot` only after the plugin is active.
 See [Node troubleshooting](/nodes/troubleshooting) if the command is missing.
+
+For headless Windows capture, run the node host in the interactive signed-in
+desktop session you want Logbook to record. A node host running as a Windows
+service or in another user session can see a different or blank desktop.
 
 The Logbook tab appears only for an enabled plugin and an `operator.write`
 Control UI session. The status row should show **Capturing** without an error.
@@ -158,8 +163,8 @@ and clamped to the supported range.
 | `captureIntervalSeconds`  | `30`    | `5`-`600`               | Delay between capture attempts                                                               |
 | `analysisIntervalMinutes` | `15`    | `3`-`120`               | Target observation window; gaps and midnight can close it earlier                            |
 | `nodeId`                  | unset   | node id or display name | Pins capture to one connected node; matching is case-insensitive                             |
-| `screenIndex`             | `0`     | `0`-`16`                | Zero-based display index                                                                     |
-| `maxWidth`                | `1440`  | `480`-`3840`            | Requested capture size cap; headless macOS applies it to the largest dimension               |
+| `screenIndex`             | `0`     | `0`-`16`                | Zero-based display index; headless Windows puts the primary display first                    |
+| `maxWidth`                | `1440`  | `480`-`3840`            | Requested capture size cap; headless macOS and Windows apply it to the largest dimension     |
 | `visionModel`             | unset   | `provider/model`        | Explicit structured route; malformed refs pause analysis, unsupported providers fail batches |
 | `retentionDays`           | `14`    | `1`-`365`               | Deletes old frames; cards, observations, and standups remain                                 |
 
@@ -168,6 +173,12 @@ Without `nodeId`, Logbook prefers a connected app node exposing
 `logbook.snapshot`. In an unpinned setup, a failed node rotates behind other
 eligible nodes. The dashboard pause toggle is session-only and resets when the
 Gateway restarts; use `captureEnabled: false` for a persistent stop.
+
+Headless Windows capture selects one monitor per snapshot; it does not stitch
+multiple displays. `screenIndex: 0` is the primary display, with other displays
+ordered by desktop coordinates and native id. Re-check the index after changing
+the display topology. The native monitor capture does not composite the mouse
+pointer into the image.
 
 ### Vision model selection
 
@@ -257,6 +268,9 @@ openclaw logs --follow
 
 - Confirm the node exposes `screen.snapshot` or `logbook.snapshot`.
 - Grant Screen Recording permission on the capture Mac.
+- On Windows, run the node host in the interactive signed-in desktop session
+  you want captured. If `screenIndex` is out of range, use the valid range in
+  the capture error or reset it to `0` for the primary display.
 - If `nodeId` is configured, confirm it matches the node id or display name.
 - Check that `gateway.nodes.commands.deny` does not contain
   `screen.snapshot`.

--- a/extensions/logbook/index.test.ts
+++ b/extensions/logbook/index.test.ts
@@ -23,6 +23,7 @@ describe("logbook snapshot invoke policy", () => {
   it("blocks logbook.snapshot when gateway.nodes.commands.deny lists screen.snapshot", async () => {
     const [policy] = registerLogbookPolicies();
     expect(policy?.commands).toEqual(["logbook.snapshot"]);
+    expect(policy?.defaultPlatforms).toEqual(["macos", "windows"]);
     const invokeNode = vi.fn();
     const result = await policy!.handle({
       nodeId: "node-1",

--- a/extensions/logbook/index.ts
+++ b/extensions/logbook/index.ts
@@ -105,11 +105,11 @@ export default definePluginEntry({
       requiredScopes: ["operator.write"],
     });
 
-    // Adds logbook.snapshot to the default macOS node allowlist; without a
+    // Adds logbook.snapshot to the default desktop node allowlist; without a
     // policy the gateway strips plugin commands from pairing surfaces.
     api.registerNodeInvokePolicy({
       commands: ["logbook.snapshot"],
-      defaultPlatforms: ["macos"],
+      defaultPlatforms: ["macos", "windows"],
       handle: async (ctx) => {
         // Honor the operator's screen-capture kill switch: a screen.snapshot
         // deny must block this capture command too, not just the app node's.

--- a/extensions/logbook/openclaw.plugin.json
+++ b/extensions/logbook/openclaw.plugin.json
@@ -17,7 +17,7 @@
     },
     "nodeId": {
       "label": "Capture Node",
-      "help": "Node id or name that provides screen.snapshot. Defaults to the first connected node that supports it."
+      "help": "Node id or name that provides screen.snapshot or logbook.snapshot. Defaults to the first connected node that supports either command."
     },
     "screenIndex": {
       "label": "Screen Index",
@@ -25,8 +25,8 @@
       "advanced": true
     },
     "maxWidth": {
-      "label": "Snapshot Max Width (px)",
-      "help": "Snapshots are scaled down to this width before storage and analysis.",
+      "label": "Snapshot Max Side (px)",
+      "help": "Snapshots are scaled down so their largest side fits this size before storage and analysis.",
       "advanced": true
     },
     "visionModel": {

--- a/extensions/logbook/package.json
+++ b/extensions/logbook/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "description": "OpenClaw automatic work journal plugin",
   "type": "module",
+  "dependencies": {
+    "node-screenshots": "0.2.8",
+    "rastermill": "0.3.1"
+  },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
     "openclaw": "workspace:*"

--- a/extensions/logbook/src/node-host-routing.test.ts
+++ b/extensions/logbook/src/node-host-routing.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("handleLogbookSnapshot platform routing", () => {
+  afterEach(() => {
+    vi.doUnmock("./node-host-windows.runtime.js");
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("routes Windows captures through the lazy runtime", async () => {
+    const captureWindowsLogbookSnapshot = vi.fn(async () => ({
+      format: "jpeg" as const,
+      base64: "d2luZG93cw==",
+      width: 1440,
+      height: 900,
+    }));
+    vi.doMock("./node-host-windows.runtime.js", () => ({ captureWindowsLogbookSnapshot }));
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const { handleLogbookSnapshot } = await import("./node-host.js");
+    const params = { screenIndex: 1, maxWidth: 1440, quality: 0.6 };
+
+    await expect(handleLogbookSnapshot(params)).resolves.toMatchObject({
+      format: "jpeg",
+      width: 1440,
+      height: 900,
+    });
+    expect(captureWindowsLogbookSnapshot).toHaveBeenCalledWith(params);
+  });
+
+  it("returns an actionable error when the Windows runtime cannot load", async () => {
+    vi.doMock("./node-host-windows.runtime.js", () => {
+      throw new Error("Cannot find native binding");
+    });
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const { handleLogbookSnapshot } = await import("./node-host.js");
+
+    await expect(handleLogbookSnapshot({})).resolves.toEqual({
+      error: expect.stringMatching(
+        /could not load node-screenshots or Rastermill:.*Reinstall OpenClaw/,
+      ),
+    });
+  });
+
+  it("does not mislabel an unexpected Windows runtime failure as a load failure", async () => {
+    vi.doMock("./node-host-windows.runtime.js", () => ({
+      captureWindowsLogbookSnapshot: () => {
+        throw new Error("unexpected native state");
+      },
+    }));
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const { handleLogbookSnapshot } = await import("./node-host.js");
+
+    await expect(handleLogbookSnapshot({})).resolves.toEqual({
+      error: expect.stringMatching(
+        /capture failed unexpectedly: unexpected native state.*inspect the node-host logs/,
+      ),
+    });
+  });
+
+  it("does not load the Windows runtime on unsupported platforms", async () => {
+    const loadWindowsRuntime = vi.fn(() => {
+      throw new Error("Windows runtime must stay lazy");
+    });
+    vi.doMock("./node-host-windows.runtime.js", loadWindowsRuntime);
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    const { handleLogbookSnapshot } = await import("./node-host.js");
+
+    await expect(handleLogbookSnapshot({})).resolves.toEqual({
+      error: "logbook.snapshot is not supported on linux",
+    });
+    expect(loadWindowsRuntime).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/logbook/src/node-host-windows.runtime.test.ts
+++ b/extensions/logbook/src/node-host-windows.runtime.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createRastermillMock, encodeMock, monitorAllMock } = vi.hoisted(() => ({
+  createRastermillMock: vi.fn(),
+  encodeMock: vi.fn(),
+  monitorAllMock: vi.fn(),
+}));
+
+vi.mock("node-screenshots", () => ({ Monitor: { all: monitorAllMock } }));
+vi.mock("rastermill", () => ({
+  createRastermill: createRastermillMock.mockReturnValue({ encode: encodeMock }),
+}));
+
+import { captureWindowsLogbookSnapshot } from "./node-host-windows.runtime.js";
+
+function monitor(
+  png = Buffer.from("png"),
+  metadata: { id?: number; isPrimary?: boolean; x?: number; y?: number } = {},
+) {
+  const toPng = vi.fn(async () => png);
+  return {
+    id: vi.fn(() => metadata.id ?? 1),
+    isPrimary: vi.fn(() => metadata.isPrimary ?? true),
+    x: vi.fn(() => metadata.x ?? 0),
+    y: vi.fn(() => metadata.y ?? 0),
+    toPng,
+    captureImage: vi.fn(async () => ({ toPng })),
+  };
+}
+
+describe("captureWindowsLogbookSnapshot", () => {
+  beforeEach(() => {
+    monitorAllMock.mockReset();
+    encodeMock.mockReset();
+  });
+
+  it("captures the selected display and returns a normalized JPEG", async () => {
+    const primary = monitor(Buffer.from("primary"), { id: 2, isPrimary: true, x: 0 });
+    const secondPng = Buffer.from("second");
+    const left = monitor(secondPng, { id: 1, isPrimary: false, x: -1920 });
+    monitorAllMock.mockReturnValue([left, primary]);
+    encodeMock.mockResolvedValue({
+      data: Buffer.from("jpeg"),
+      width: 1440,
+      height: 900,
+    });
+
+    await expect(captureWindowsLogbookSnapshot({ screenIndex: 1 })).resolves.toEqual({
+      format: "jpeg",
+      base64: Buffer.from("jpeg").toString("base64"),
+      width: 1440,
+      height: 900,
+    });
+    expect(primary.captureImage).not.toHaveBeenCalled();
+    expect(left.captureImage).toHaveBeenCalledOnce();
+    expect(createRastermillMock).toHaveBeenCalledWith({
+      execution: "internal",
+      limits: { inputPixels: 100_000_000, outputPixels: 25_000_000 },
+    });
+    expect(encodeMock).toHaveBeenCalledWith(secondPng, {
+      format: "jpeg",
+      quality: 60,
+      resize: { maxSide: 1440 },
+    });
+  });
+
+  it("reports display enumeration failures", async () => {
+    monitorAllMock.mockImplementation(() => {
+      throw new Error("EnumDisplayMonitors failed");
+    });
+
+    await expect(captureWindowsLogbookSnapshot({})).resolves.toEqual({
+      error: expect.stringMatching(
+        /display enumeration failed: EnumDisplayMonitors failed.*interactive signed-in desktop session/,
+      ),
+    });
+    expect(encodeMock).not.toHaveBeenCalled();
+  });
+
+  it("reports when the interactive desktop has no displays", async () => {
+    monitorAllMock.mockReturnValue([]);
+
+    await expect(captureWindowsLogbookSnapshot({})).resolves.toEqual({
+      error: expect.stringMatching(/found no displays.*interactive signed-in desktop session/),
+    });
+    expect(encodeMock).not.toHaveBeenCalled();
+  });
+
+  it("reports an out-of-range display index with the valid config range", async () => {
+    monitorAllMock.mockReturnValue([monitor(), monitor()]);
+
+    await expect(captureWindowsLogbookSnapshot({ screenIndex: 4 })).resolves.toEqual({
+      error: expect.stringMatching(
+        /screenIndex 4 is unavailable.*2 display\(s\).*screenIndex to 0-1/,
+      ),
+    });
+    expect(encodeMock).not.toHaveBeenCalled();
+  });
+
+  it("reports native capture failures separately from encoding failures", async () => {
+    const display = monitor();
+    display.captureImage.mockRejectedValue(new Error("Access is denied"));
+    monitorAllMock.mockReturnValue([display]);
+
+    await expect(captureWindowsLogbookSnapshot({})).resolves.toEqual({
+      error: expect.stringMatching(
+        /display 0 capture failed: Access is denied.*interactive signed-in desktop session/,
+      ),
+    });
+    expect(encodeMock).not.toHaveBeenCalled();
+  });
+
+  it("reports PNG conversion failures as capture-stage failures", async () => {
+    const display = monitor();
+    display.toPng.mockRejectedValue(new Error("PNG encoder failed"));
+    monitorAllMock.mockReturnValue([display]);
+
+    await expect(captureWindowsLogbookSnapshot({})).resolves.toEqual({
+      error: expect.stringMatching(/display 0 capture failed: PNG encoder failed/),
+    });
+    expect(encodeMock).not.toHaveBeenCalled();
+  });
+
+  it("applies the requested max side and clamps fractional JPEG quality", async () => {
+    monitorAllMock.mockReturnValue([monitor()]);
+    encodeMock.mockResolvedValue({ data: Buffer.from("jpeg"), width: 1600, height: 900 });
+
+    await captureWindowsLogbookSnapshot({ maxWidth: 2000, quality: 0.01 });
+
+    expect(encodeMock).toHaveBeenCalledWith(expect.any(Buffer), {
+      format: "jpeg",
+      quality: 10,
+      resize: { maxSide: 2000 },
+    });
+  });
+
+  it("reports Rastermill JPEG failures after capture", async () => {
+    monitorAllMock.mockReturnValue([monitor()]);
+    encodeMock.mockRejectedValue(new Error("Photon unavailable"));
+
+    await expect(captureWindowsLogbookSnapshot({})).resolves.toEqual({
+      error: expect.stringMatching(
+        /was captured, but JPEG normalization failed: Photon unavailable.*restore Rastermill/,
+      ),
+    });
+  });
+});

--- a/extensions/logbook/src/node-host-windows.runtime.ts
+++ b/extensions/logbook/src/node-host-windows.runtime.ts
@@ -1,0 +1,128 @@
+// Windows-only runtime boundary. node-screenshots loads a platform-native
+// binding at import time, so node-host.ts must only import this module on win32.
+import { Monitor } from "node-screenshots";
+import { createRastermill } from "rastermill";
+import type { LogbookSnapshotPayload } from "./node-host.js";
+
+type WindowsLogbookSnapshotParams = {
+  screenIndex?: number;
+  maxWidth?: number;
+  quality?: number;
+};
+
+const DEFAULT_MAX_SIDE = 1440;
+const DEFAULT_JPEG_QUALITY = 60;
+// 8K displays exceed Rastermill's conservative 25 MP default input budget.
+// Keep a finite ceiling while allowing current high-resolution desktops.
+const WINDOWS_CAPTURE_INPUT_PIXELS = 100_000_000;
+const rastermill = createRastermill({
+  execution: "internal",
+  limits: { inputPixels: WINDOWS_CAPTURE_INPUT_PIXELS, outputPixels: 25_000_000 },
+});
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function readParams(value: unknown): WindowsLogbookSnapshotParams {
+  if (!value || typeof value !== "object") {
+    return {};
+  }
+  const record = value as Record<string, unknown>;
+  const num = (key: string) => {
+    const candidate = record[key];
+    return typeof candidate === "number" && Number.isFinite(candidate) ? candidate : undefined;
+  };
+  return { screenIndex: num("screenIndex"), maxWidth: num("maxWidth"), quality: num("quality") };
+}
+
+export async function captureWindowsLogbookSnapshot(
+  rawParams: unknown,
+): Promise<LogbookSnapshotPayload> {
+  const params = readParams(rawParams);
+  const screenIndex = Math.max(0, Math.round(params.screenIndex ?? 0));
+  const maxSide =
+    params.maxWidth && params.maxWidth >= 480 ? Math.round(params.maxWidth) : DEFAULT_MAX_SIDE;
+  const quality = Math.min(
+    100,
+    Math.max(
+      10,
+      Math.round(
+        (params.quality && params.quality > 0 && params.quality <= 1
+          ? params.quality
+          : DEFAULT_JPEG_QUALITY / 100) * 100,
+      ),
+    ),
+  );
+
+  let monitors: Monitor[];
+  try {
+    monitors = Monitor.all()
+      .map((monitor) => ({
+        monitor,
+        id: monitor.id(),
+        isPrimary: monitor.isPrimary(),
+        x: monitor.x(),
+        y: monitor.y(),
+      }))
+      // Native enumeration order is not a stable screenIndex contract.
+      .toSorted(
+        (a, b) =>
+          Number(b.isPrimary) - Number(a.isPrimary) || a.x - b.x || a.y - b.y || a.id - b.id,
+      )
+      .map(({ monitor }) => monitor);
+  } catch (err) {
+    return {
+      error:
+        `Windows display enumeration failed: ${errorMessage(err)}. ` +
+        "Run the OpenClaw node host in the interactive signed-in desktop session you want to capture.",
+    };
+  }
+  if (monitors.length === 0) {
+    return {
+      error:
+        "Windows screen capture found no displays. Run the OpenClaw node host in the " +
+        "interactive signed-in desktop session you want to capture.",
+    };
+  }
+  const targetMonitor = monitors[screenIndex];
+  if (!targetMonitor) {
+    return {
+      error:
+        `screenIndex ${screenIndex} is unavailable: Windows reported ${monitors.length} display(s). ` +
+        `Set plugins.entries.logbook.config.screenIndex to 0-${monitors.length - 1}.`,
+    };
+  }
+
+  let png: Buffer;
+  try {
+    const image = await targetMonitor.captureImage();
+    png = await image.toPng();
+  } catch (err) {
+    return {
+      error:
+        `Windows display ${screenIndex} capture failed: ${errorMessage(err)}. ` +
+        "Run the node host in the interactive signed-in desktop session you want to capture.",
+    };
+  }
+
+  try {
+    const encoded = await rastermill.encode(png, {
+      format: "jpeg",
+      quality,
+      resize: { maxSide },
+    });
+    return {
+      format: "jpeg",
+      base64: encoded.data.toString("base64"),
+      width: encoded.width,
+      height: encoded.height,
+    };
+  } catch (err) {
+    return {
+      error:
+        `Windows display ${screenIndex} was captured, but JPEG normalization failed: ${errorMessage(err)}. ` +
+        "Reinstall OpenClaw on this Windows node to restore Rastermill's image processor.",
+    };
+  }
+}

--- a/extensions/logbook/src/node-host.ts
+++ b/extensions/logbook/src/node-host.ts
@@ -1,4 +1,4 @@
-// Logbook node-host command: screen capture for headless node hosts (macOS).
+// Logbook node-host command: screen capture for headless node hosts.
 // Nodes without the OpenClaw app (plain `openclaw node host run`) advertise
 // logbook.snapshot so capture works anywhere the plugin is enabled.
 import { randomUUID } from "node:crypto";
@@ -13,7 +13,9 @@ type LogbookSnapshotParams = {
   quality?: number;
 };
 
-type LogbookSnapshotPayload = { format: "jpeg"; base64: string } | { error: string };
+export type LogbookSnapshotPayload =
+  | { format: "jpeg"; base64: string; width?: number; height?: number }
+  | { error: string };
 
 const LOGBOOK_SNAPSHOT_EXEC_TIMEOUT_MS = 25_000;
 
@@ -30,6 +32,30 @@ function readParams(value: unknown): LogbookSnapshotParams {
 }
 
 export async function handleLogbookSnapshot(rawParams: unknown): Promise<LogbookSnapshotPayload> {
+  if (process.platform === "win32") {
+    let captureWindowsLogbookSnapshot: (params: unknown) => Promise<LogbookSnapshotPayload>;
+    try {
+      // Keep the native capture binding out of macOS/Linux node-host startup.
+      ({ captureWindowsLogbookSnapshot } = await import("./node-host-windows.runtime.js"));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        error:
+          `Windows Logbook capture could not load node-screenshots or Rastermill: ${message}. ` +
+          "Reinstall OpenClaw on this Windows node to restore its native capture dependencies.",
+      };
+    }
+    try {
+      return await captureWindowsLogbookSnapshot(rawParams);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        error:
+          `Windows Logbook capture failed unexpectedly: ${message}. ` +
+          "Retry once, then inspect the node-host logs if the failure continues.",
+      };
+    }
+  }
   if (process.platform !== "darwin") {
     return { error: `logbook.snapshot is not supported on ${process.platform}` };
   }

--- a/extensions/logbook/src/service.ts
+++ b/extensions/logbook/src/service.ts
@@ -183,8 +183,8 @@ export class LogbookService {
     const captureCommand = (node: { commands?: string[] }) =>
       CAPTURE_COMMANDS.find((command) => (node.commands ?? []).includes(command));
     // App nodes (screen.snapshot) come first: plugin node-host commands are
-    // advertised on every platform, but logbook.snapshot only captures on
-    // macOS, so headless hosts are a fallback rather than the default pick.
+    // advertised more broadly than their macOS/Windows capture runtime, so
+    // headless hosts are a fallback rather than the default pick.
     const commandRank = (node: { commands?: string[] }) =>
       CAPTURE_COMMANDS.indexOf(captureCommand(node) as (typeof CAPTURE_COMMANDS)[number]);
     const candidates = nodes

--- a/package.json
+++ b/package.json
@@ -1986,6 +1986,7 @@
     "minimatch": "10.2.5",
     "ms": "2.1.3",
     "node-edge-tts": "1.2.10",
+    "node-screenshots": "0.2.8",
     "openai": "6.49.0",
     "p-limit": "7.3.1",
     "p-map": "7.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
       node-edge-tts:
         specifier: 1.2.10
         version: 1.2.10(supports-color@10.2.2)
+      node-screenshots:
+        specifier: 0.2.8
+        version: 0.2.8
       openai:
         specifier: 6.49.0
         version: 6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/hash-node@4.4.14)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3)
@@ -1153,6 +1156,13 @@ importers:
         version: link:../../packages/plugin-sdk
 
   extensions/logbook:
+    dependencies:
+      node-screenshots:
+        specifier: 0.2.8
+        version: 0.2.8
+      rastermill:
+        specifier: 0.3.1
+        version: 0.3.1
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
@@ -7857,6 +7867,68 @@ packages:
 
   node-pty@1.2.0-beta.14:
     resolution: {integrity: sha512-XORU9BQgpxVgqr7WivjJ17mLenOHUgKKWzuZZNaw3NDYgHc/wPJQMSaoLDrpEgqV6aU1nNwil1o/OqYj6lWmUA==}
+
+  node-screenshots-darwin-arm64@0.2.8:
+    resolution: {integrity: sha512-CEJE47gG2ceTc1fQRE3T/8lBwCGFJ+0iJiP+CQgCUAll4kKd32DQ7lCANqUseo96/xi6HuDOlrjLkAp7x2TzFw==}
+    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  node-screenshots-darwin-x64@0.2.8:
+    resolution: {integrity: sha512-3WIw4QaEP3pIUtSYh2NThwmzQl00H1bTPwPS7sYRLihAzB3NA/FOnIqRmvtadI0KEnnRGX4apdZgIhfXtgbNZA==}
+    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  node-screenshots-linux-arm64-gnu@0.2.8:
+    resolution: {integrity: sha512-aXJKtekSzQLJX6hh/VT5gilyloiN3DE4oE5xu9z7nLcTPyfC089dqVoERXJxnT+aqSQzx0KkI2te8BZNkjaMtQ==}
+    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  node-screenshots-linux-loong64-gnu@0.2.8:
+    resolution: {integrity: sha512-+982Yn7L7XID/FhYR6W6S2IVTLiueOBcHs/BP1Te5W6MtwlIIRg593zFh5HPQp7G+IaHqEXQzQj6D7kjJhXzsQ==}
+    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  node-screenshots-linux-x64-gnu@0.2.8:
+    resolution: {integrity: sha512-xF0hLfPMm9NEF4WtiQnbCyCUxU15M25lFkBzK4WS1CGOcxM7e30tvvwyYfmrMp3OtW/hESQFtiTb4cjKcOdaSA==}
+    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  node-screenshots-linux-x64-musl@0.2.8:
+    resolution: {integrity: sha512-mu/sVwDMt2yQM5ql2rtyQm+mq6Im2ycQLzQxXFXVJOB+k5A+Hk9h65J+G+Iy3rn1uNrYVDjgUQGvIkgpkIonCg==}
+    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  node-screenshots-win32-arm64-msvc@0.2.8:
+    resolution: {integrity: sha512-g7nnuoJO2yjO8Ovr+Uz9e+LYJMlYc5eqoGPQq7U7NK1LVc2DpyCJ18VT8WdP2f098lfHvE12D3X7Es8NLFjiPg==}
+    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  node-screenshots-win32-ia32-msvc@0.2.8:
+    resolution: {integrity: sha512-Qsh4Ggs7MzO2XuDPFMRcRxRuiUGxxtHEFuqAfLFL1DiOfBIhLpukZ8JUHlEBdzjPxMFFRJw/4nOm0tnyHP/fiQ==}
+    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+    cpu: [ia32]
+    os: [win32]
+
+  node-screenshots-win32-x64-msvc@0.2.8:
+    resolution: {integrity: sha512-DdFORB74FghM1L6UtE1TltIR2H0CCCmfQEa8gp2CTSdtBr2b0TKL7ZlbEV6x/wVKRFT59w7Kd6BULdeMmp0X2w==}
+    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  node-screenshots@0.2.8:
+    resolution: {integrity: sha512-7O2ab89hkUgiXkrYj9iYCbJjY1iFJqIyZt0vuVtHFKlnajeFoyW+hur4CPxwwrnCUK0ahr0WLWQ5A6rCzF8rWQ==}
+    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
 
   node-wav@0.0.2:
     resolution: {integrity: sha512-M6Rm/bbG6De/gKGxOpeOobx/dnGuP0dz40adqx38boqHhlWssBJZgLCPBNtb9NkrmnKYiV04xELq+R6PFOnoLA==}
@@ -15372,6 +15444,45 @@ snapshots:
   node-pty@1.2.0-beta.14:
     dependencies:
       node-addon-api: 7.1.1
+
+  node-screenshots-darwin-arm64@0.2.8:
+    optional: true
+
+  node-screenshots-darwin-x64@0.2.8:
+    optional: true
+
+  node-screenshots-linux-arm64-gnu@0.2.8:
+    optional: true
+
+  node-screenshots-linux-loong64-gnu@0.2.8:
+    optional: true
+
+  node-screenshots-linux-x64-gnu@0.2.8:
+    optional: true
+
+  node-screenshots-linux-x64-musl@0.2.8:
+    optional: true
+
+  node-screenshots-win32-arm64-msvc@0.2.8:
+    optional: true
+
+  node-screenshots-win32-ia32-msvc@0.2.8:
+    optional: true
+
+  node-screenshots-win32-x64-msvc@0.2.8:
+    optional: true
+
+  node-screenshots@0.2.8:
+    optionalDependencies:
+      node-screenshots-darwin-arm64: 0.2.8
+      node-screenshots-darwin-x64: 0.2.8
+      node-screenshots-linux-arm64-gnu: 0.2.8
+      node-screenshots-linux-loong64-gnu: 0.2.8
+      node-screenshots-linux-x64-gnu: 0.2.8
+      node-screenshots-linux-x64-musl: 0.2.8
+      node-screenshots-win32-arm64-msvc: 0.2.8
+      node-screenshots-win32-ia32-msvc: 0.2.8
+      node-screenshots-win32-x64-msvc: 0.2.8
 
   node-wav@0.0.2: {}
 

--- a/scripts/lib/dependency-ownership.json
+++ b/scripts/lib/dependency-ownership.json
@@ -204,6 +204,12 @@
       "class": "plugin-runtime",
       "risk": ["tts", "network"]
     },
+    "node-screenshots": {
+      "owner": "plugin:logbook",
+      "class": "plugin-runtime",
+      "activation": ["plugins.entries.logbook.enabled", "logbook.captureEnabled"],
+      "risk": ["native", "screen-capture", "sensitive-data"]
+    },
     "openai": {
       "owner": "provider:openai",
       "class": "default-runtime-initially",

--- a/src/infra/tsdown-config.test.ts
+++ b/src/infra/tsdown-config.test.ts
@@ -293,6 +293,7 @@ describe("tsdown config", () => {
       expect(neverBundle("@vitest/expect")).toBe(true);
       expect(neverBundle("jimp")).toBe(true);
       expect(neverBundle("matrix-js-sdk/lib/client.js")).toBe(true);
+      expect(neverBundle("node-screenshots")).toBe(true);
       expect(neverBundle("qrcode-terminal/lib/main.js")).toBe(true);
       expect(neverBundle("sharp")).toBe(true);
       expect(neverBundle("vitest")).toBe(true);
@@ -308,6 +309,7 @@ describe("tsdown config", () => {
         "@vitest/expect",
         "jimp",
         "matrix-js-sdk",
+        "node-screenshots",
         "qrcode-terminal",
         "sharp",
         "vitest",
@@ -320,6 +322,7 @@ describe("tsdown config", () => {
     }
     const externalize = external;
     expect(externalize("jimp", undefined, false)).toBe(true);
+    expect(externalize("node-screenshots", undefined, false)).toBe(true);
     expect(externalize("qrcode-terminal/lib/main.js", undefined, false)).toBe(true);
     expect(externalize("sharp", undefined, false)).toBe(true);
   });

--- a/src/plugins/contracts/extension-runtime-dependencies.contract.test.ts
+++ b/src/plugins/contracts/extension-runtime-dependencies.contract.test.ts
@@ -321,6 +321,16 @@ describe("extension runtime dependency manifests", () => {
     expect(manifest.dependencies?.json5).not.toBe("");
   });
 
+  it("keeps Logbook Windows capture dependencies owned and internalized", () => {
+    const root = readPackageManifest("package.json");
+    const logbook = readPackageManifest("extensions/logbook/package.json");
+
+    for (const dependency of ["node-screenshots", "rastermill"]) {
+      expect(logbook.dependencies?.[dependency]).toBeTypeOf("string");
+      expect(root.dependencies?.[dependency]).toBe(logbook.dependencies?.[dependency]);
+    }
+  });
+
   for (const [extensionDir, dependencies] of COMPUTED_RUNTIME_DEPENDENCIES) {
     it(`${extensionDir} declares every computed runtime dependency`, () => {
       const manifest = readPackageManifest(path.join(extensionDir, "package.json"));

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -219,6 +219,7 @@ const explicitNeverBundleDependencies = [
   "@vitest/expect",
   "jimp",
   "matrix-js-sdk",
+  "node-screenshots",
   "prism-media",
   "qrcode-terminal",
   "sharp",


### PR DESCRIPTION
Closes #119361

## What Problem This Solves

Operators running a Windows node host can install and enable the Logbook plugin, see its Control UI timeline tab, and never get a single frame in it. `logbook.snapshot` returns `logbook.snapshot is not supported on win32` on every capture tick, because the handler guarded on `process.platform !== "darwin"` and the capture shelled out to the macOS-only `screencapture` binary. Everything else in Logbook — storage, retention, the timeline tab, the vision-analysis pass — is already cross-platform; capture was the one platform-bound piece, and it is the piece that produces the data the rest of the feature displays.

## Why This Change Was Made

This adds a Windows capture branch to `handleLogbookSnapshot` and leaves the macOS path untouched.

The Windows branch lazily `import()`s a win32-only runtime module, so the `node-screenshots` native binding is never loaded during node-host startup on macOS or Linux. It captures via `node-screenshots` and normalizes through Rastermill to JPEG quality 60 / max side 1440 — the same output contract macOS already produces, so downstream storage and analysis needed no changes.

Two decisions worth calling out for review:

- **Monitor ordering is explicit, not native order.** `node-screenshots` does not guarantee a stable enumeration order, and `screenIndex` is a user-facing config value that must not silently point at a different display between restarts. Monitors are sorted primary-first, then by desktop x/y, then by native id.
- **macOS was deliberately not migrated to the same library.** A production-equivalent benchmark showed native `screencapture` is materially faster and preserves cursor and profile behavior better, so unifying on one library would have regressed working behavior to buy consistency.

Non-goals: Linux/X11, Wayland, WSL-to-host bridging, and multi-display stitching are all out of scope here.

## User Impact

Windows node hosts can now contribute frames to the Logbook timeline. `logbook.snapshot` is registered on `["macos", "windows"]` instead of macOS alone, and Windows operators no longer need to keep a macOS machine in the loop purely to generate journal frames.

Documented limits, rather than claimed support:

- The native capture path does not composite the mouse pointer.
- One snapshot captures one monitor; there is no multi-display stitching.
- Capture requires an interactive signed-in desktop session. Locked-session and RDP-disconnected behavior is **unverified** and is not claimed to work.

No behavior change on macOS or Linux. `docs/plugins/logbook.md` is updated with the Windows path and each caveat above.

## Evidence

**Live validation on a real Windows desktop node** (not mocked, single 1440x900 display), running the capture and normalize logic through the implementation path:

```
monitors found: 1
  [0] id=65537 primary=true x=0 y=0 w=1440 h=900
captureImage+toPng: 39ms, png bytes=525760
rastermill encode: 163ms, jpeg bytes=113723, width=1440, height=900
total elapsed: 202ms
```

The resulting JPEG was fetched back and visually confirmed to be a correct capture of the live desktop, not a black or garbage frame. Only the single-monitor case was live-exercised, since that host has one display attached; multi-monitor ordering is covered by unit tests but is not live-verified.

**Automated tests.** Two new test files:

- `extensions/logbook/src/node-host-routing.test.ts` — platform routing, the non-Windows lazy-load guarantee, and error shaping.
- `extensions/logbook/src/node-host-windows.runtime.test.ts` — capture, enumeration, and encoding error paths against mocked `node-screenshots` / `rastermill`.

Plus a contract test pinning the Logbook package dependency versions to the root versions, and a `tsdown` config test asserting `node-screenshots` stays externalized.

**Gates run locally:** `oxfmt --write` clean, `oxlint extensions/logbook/src` 0 findings, `run-tsgo` clean against both `tsconfig.extensions.json` and `tsconfig.core.json` (this caught a real `noUncheckedIndexedAccess` error on `monitors[screenIndex]`, fixed before commit), 547 tests passing across the logbook extension plus the two touched shared test files, and `docs:check-mdx` passing.

**Not run locally:** `check:changed`, which delegates to a cloud runner unavailable from this environment. CI on this PR is the first full run of that lane.

## Dependencies

- `node-screenshots@0.2.8` — Apache-2.0. New root dependency, externalized from the bundle because it is a native binding, and declared under `plugin:logbook` ownership in `scripts/lib/dependency-ownership.json` gated on the Logbook enable/capture flags.
- `rastermill@0.3.1` — MIT. Already a root dependency via `cua-computer`; this only adds it to the Logbook extension manifest per the dependency-ownership rules.

Neither is adapted or copied source, so neither needs a `THIRD_PARTY_NOTICES.md` entry.

---

🤖 **AI-assisted:** implemented with Claude Code, reviewed and validated by me — including the live Windows capture run above.
