### PR TITLE
fix: prevent denied MCP tools from reaching native agent runs

### DIFF
--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -307,6 +307,25 @@ When bundle MCP is enabled, OpenClaw:
 - loads enabled bundle-MCP servers for the current workspace and merges them with any existing backend MCP config/settings shape;
 - rewrites the launch config using the backend-owned integration mode from the owning plugin.
 
+`tools.allow` and `tools.deny` also constrain configured native MCP servers.
+OpenClaw lists each server through its session-scoped runtime, assigns the same
+provider-safe `<safe-server>__<safe-tool>` identities used by embedded tools,
+and applies the complete layered policy before process spawn or Codex
+`thread/start`/`thread/resume`. It then projects exact raw names into each
+backend's enforcement contract: Claude receives server omission plus bare
+`--disallowedTools` entries, Codex receives `enabled_tools` and
+`disabled_tools`, and Gemini receives `includeTools` and `excludeTools`.
+Configured server filters and session overrides remain additional
+restrictions. These backend fields are generated implementation details; keep
+operator policy in OpenClaw configuration.
+
+For example, `agents.entries.research.tools.allow: ["docs__read_docs"]`
+exposes only that tool from the safe `docs` namespace, while
+`deny: ["docs__delete_*"]` removes matching siblings. If the effective
+intersection is empty or OpenClaw cannot establish the catalog needed for a
+restrictive policy, the run stops before submitting a prompt rather than
+passing the server through unfiltered.
+
 Restricted runs such as cron jobs with `toolsAllow` require an exact
 backend-owned translation. The bundled `claude-cli` backend disables Claude's
 native tools and user, project, and local customizations, including hooks,

--- a/docs/tools/multi-agent-sandbox-tools.md
+++ b/docs/tools/multi-agent-sandbox-tools.md
@@ -238,6 +238,32 @@ The filtering order is:
 
 Tool policies support `group:*` shorthands that expand to multiple tools. See [Tool groups](/gateway/sandbox-vs-tool-policy-vs-elevated#tool-groups-shorthands) for the full list.
 
+Configured MCP tools use the same policy surface. Their canonical names are
+`<safe-server>__<safe-tool>`; globs can target a server namespace. For example:
+
+```json5
+{
+  agents: {
+    entries: {
+      research: {
+        tools: {
+          allow: ["docs__read_docs"],
+          deny: ["docs__delete_*"],
+        },
+      },
+    },
+  },
+}
+```
+
+Every restrictive layer intersects with the earlier layers, and deny always
+wins. OpenClaw projects the resulting raw tool set into native Claude, Codex,
+and Gemini MCP filters before their first model turn. Backend-native names and
+settings are implementation details, not a second operator policy surface. If
+the intersection removes every callable MCP tool, OpenClaw omits that server;
+if no callable tool remains, the run stops with a policy diagnostic before the
+prompt is submitted.
+
 Per-agent elevated overrides (`agents.entries.*.tools.elevated`) can further restrict elevated exec for specific agents. See [Elevated mode](/tools/elevated) for details.
 
 ---
@@ -385,6 +411,7 @@ After configuring multi-agent sandbox and tools:
     - Check the [full filtering order](#tool-restrictions): profile → provider profile → global policy → provider policy → agent policy → agent provider policy → sandbox → subagent.
     - Each level can only further restrict, not grant back.
     - See [Sandbox vs tool policy vs elevated](/gateway/sandbox-vs-tool-policy-vs-elevated) for step-by-step debugging.
+    - For MCP tools, use the provider-safe name shown by OpenClaw, such as `docs__read_docs` or `docs__*`; do not use a backend's raw config field name.
 
   </Accordion>
   <Accordion title="Container not isolated per agent">

--- a/extensions/anthropic/cli-shared.test.ts
+++ b/extensions/anthropic/cli-shared.test.ts
@@ -282,6 +282,8 @@ describe("resolveClaudeCliExecutionArgs", () => {
       "",
       "--allowedTools",
       "mcp__openclaw__openclaw",
+      "--disallowedTools",
+      "ScheduleWakeup,mcp__other__*",
     ]);
   });
 
@@ -356,6 +358,8 @@ describe("resolveClaudeCliExecutionArgs", () => {
       "",
       "--allowedTools",
       "mcp__openclaw__message",
+      "--disallowedTools",
+      "ScheduleWakeup,mcp__other__*",
     ]);
   });
 
@@ -414,7 +418,7 @@ describe("resolveClaudeCliExecutionArgs", () => {
       "--tools",
       "",
       "--disallowedTools",
-      "mcp__*",
+      "mcp__*,mcp__other__*",
     ]);
   });
 

--- a/extensions/anthropic/cli-shared.ts
+++ b/extensions/anthropic/cli-shared.ts
@@ -429,6 +429,21 @@ function resolveClaudeCliRestrictedExecutionArgs(
   baseArgs: readonly string[],
   availability: NonNullable<CliBackendResolveExecutionArgsContext["toolAvailability"]>,
 ): string[] {
+  const preservedDenials: string[] = [];
+  for (let i = 0; i < baseArgs.length; i += 1) {
+    const arg = baseArgs[i] ?? "";
+    if (arg === CLAUDE_DISALLOWED_TOOLS_ARG || arg === "--disallowed-tools") {
+      while (typeof baseArgs[i + 1] === "string" && !baseArgs[i + 1]?.startsWith("-")) {
+        i += 1;
+        preservedDenials.push(...(baseArgs[i] ?? "").split(","));
+      }
+    } else if (
+      arg.startsWith(`${CLAUDE_DISALLOWED_TOOLS_ARG}=`) ||
+      arg.startsWith("--disallowed-tools=")
+    ) {
+      preservedDenials.push(...arg.slice(arg.indexOf("=") + 1).split(","));
+    }
+  }
   const normalized = stripClaudeArgs(baseArgs, {
     bare: CLAUDE_RESTRICTED_BARE_ARGS,
     variadicValue: CLAUDE_RESTRICTED_VARIADIC_VALUE_ARGS,
@@ -453,8 +468,15 @@ function resolveClaudeCliRestrictedExecutionArgs(
       CLAUDE_ALLOWED_TOOLS_ARG,
       availability.openClaw.map((toolName) => `${OPENCLAW_MCP_TOOL_PREFIX}${toolName}`).join(","),
     );
-  } else {
-    normalized.push(CLAUDE_DISALLOWED_TOOLS_ARG, CLAUDE_DENY_MCP_TOOLS_VALUE);
+  }
+  const denials = [
+    ...new Set([
+      ...preservedDenials.map((entry) => entry.trim()).filter(Boolean),
+      ...(availability.openClaw.length === 0 ? [CLAUDE_DENY_MCP_TOOLS_VALUE] : []),
+    ]),
+  ].toSorted();
+  if (denials.length > 0) {
+    normalized.push(CLAUDE_DISALLOWED_TOOLS_ARG, denials.join(","));
   }
   return normalized;
 }

--- a/extensions/codex/src/app-server/thread-lifecycle-preflight.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-preflight.ts
@@ -3,7 +3,7 @@ import {
   formatErrorMessage,
   isHostScopedAgentToolActive,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
-import { buildCodexUserMcpServersThreadConfigPatchForRuntime } from "openclaw/plugin-sdk/codex-mcp-projection";
+import { buildCodexUserMcpServersThreadConfigPatchForRun } from "openclaw/plugin-sdk/codex-mcp-projection";
 import { getCodexAppServerClientInstanceId } from "./client.js";
 import {
   isMessageOnlyCodexSourceReply,
@@ -65,11 +65,12 @@ export async function prepareCodexThreadLifecyclePreflight(params: CodexStartOrR
   const userMcpServersConfigPatch =
     params.userMcpServersEnabled === false
       ? undefined
-      : await buildCodexUserMcpServersThreadConfigPatchForRuntime(params.params.config, {
+      : await buildCodexUserMcpServersThreadConfigPatchForRun({
+          run: params.params,
+          cwd: params.cwd,
           agentId: params.agentId ?? params.params.agentId,
-          agentDir: params.params.agentDir,
           allowLiteralOAuthProjection: params.appServer.connectionClass !== "remote",
-          toolOverrides: params.params.toolOverrides,
+          warn: (message) => embeddedAgentLog.warn(message),
           onServerUnavailable: (serverName, error) =>
             embeddedAgentLog.warn("skipping unavailable MCP OAuth server", {
               serverName,

--- a/extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts
@@ -103,6 +103,27 @@ function createParams(
   } as unknown as EmbeddedRunAttemptParams;
 }
 
+async function writePolicyProbeServer(dir: string): Promise<string> {
+  const filePath = path.join(dir, "policy-probe.mjs");
+  await fs.writeFile(
+    filePath,
+    `import readline from "node:readline";
+const lines = readline.createInterface({ input: process.stdin });
+const send = (id, result) => process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id, result }) + "\\n");
+lines.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.method === "initialize") send(message.id, { protocolVersion: "2024-11-05", capabilities: { tools: {} }, serverInfo: { name: "policy-probe", version: "1" } });
+  if (message.method === "tools/list") send(message.id, { tools: [
+    { name: "read_docs", description: "read", inputSchema: { type: "object" } },
+    { name: "delete_docs", description: "delete", inputSchema: { type: "object" } }
+  ] });
+});
+`,
+    "utf-8",
+  );
+  return filePath;
+}
+
 describe("startOrResumeThread — user mcp.servers projection (regression: #80814)", () => {
   let tempDir = "";
 
@@ -152,6 +173,99 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
     expect(startParams?.config?.mcp_servers).toBeDefined();
     expect(startParams.config!.mcp_servers).toMatchObject({
       outlook: { command: "node", args: ["/opt/outlook-mcp/dist/index.js"] },
+    });
+  });
+
+  it("projects durable allow and deny policy into thread/start and thread/resume before the turn", async () => {
+    const sessionFile = path.join(tempDir, "policy-session.jsonl");
+    registerCodexTestSessionIdentity(sessionFile, "session-1", "agent:main:session-1");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const serverPath = await writePolicyProbeServer(tempDir);
+    const config = {
+      tools: { allow: ["docs__read_docs"], deny: ["docs__delete_docs"] },
+      mcp: {
+        servers: {
+          docs: { transport: "stdio", command: process.execPath, args: [serverPath] },
+        },
+      },
+    } as unknown as EmbeddedRunAttemptParams["config"];
+    const request = vi.fn(async (method: string, _params: unknown) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-policy");
+      }
+      if (method === "thread/resume") {
+        return threadResumeResult("thread-policy");
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const run = async () =>
+      await startOrResumeThread({
+        client: { request } as never,
+        params: createParams(sessionFile, workspaceDir, config),
+        cwd: workspaceDir,
+        dynamicTools: [],
+        appServer: createAppServerOptions(),
+      });
+
+    await run();
+    await run();
+
+    for (const method of ["thread/start", "thread/resume"]) {
+      const call = request.mock.calls.find(([candidate]) => candidate === method);
+      const callParams = call?.[1] as {
+        config?: {
+          mcp_servers?: { docs?: { enabled_tools?: string[]; disabled_tools?: string[] } };
+        };
+      };
+      expect(callParams?.config?.mcp_servers?.docs).toMatchObject({
+        enabled_tools: ["read_docs"],
+        disabled_tools: ["delete_docs"],
+      });
+    }
+  });
+
+  it("keeps session MCP denials additive in thread/start before the turn", async () => {
+    const sessionFile = path.join(tempDir, "policy-session-override.jsonl");
+    registerCodexTestSessionIdentity(
+      sessionFile,
+      "session-override",
+      "agent:main:session-override",
+    );
+    const workspaceDir = path.join(tempDir, "workspace-override");
+    const serverPath = await writePolicyProbeServer(tempDir);
+    const config = {
+      tools: { allow: ["docs__*"] },
+      mcp: {
+        servers: {
+          docs: { transport: "stdio", command: process.execPath, args: [serverPath] },
+        },
+      },
+    } as unknown as EmbeddedRunAttemptParams["config"];
+    const request = vi.fn(async (method: string, _params: unknown) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-session-override");
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const run = {
+      ...createParams(sessionFile, workspaceDir, config),
+      toolOverrides: { mcpToolsDeny: { docs: ["delete_docs"] } },
+    } as EmbeddedRunAttemptParams;
+
+    await startOrResumeThread({
+      client: { request } as never,
+      params: run,
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer: createAppServerOptions(),
+    });
+
+    const callParams = request.mock.calls[0]?.[1] as {
+      config?: { mcp_servers?: { docs?: { enabled_tools?: string[]; disabled_tools?: string[] } } };
+    };
+    expect(callParams.config?.mcp_servers?.docs).toMatchObject({
+      enabled_tools: ["read_docs"],
+      disabled_tools: ["delete_docs"],
     });
   });
 

--- a/src/agents/agent-bundle-mcp-materialize.ts
+++ b/src/agents/agent-bundle-mcp-materialize.ts
@@ -343,6 +343,7 @@ export function buildBundleMcpToolsFromCatalog(params: {
         safeServerName: tool.safeServerName,
         toolName: tool.toolName,
         operation: "tool",
+        ...(tool.excludedByConfiguredFilter ? { excludedByConfiguredFilter: true } : {}),
         ...(tool.deniedBySession ? { deniedBySession: true } : {}),
       },
     });

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -654,6 +654,9 @@ export function createSessionMcpRuntime(params: {
       const tools: McpCatalogTool[] = (retryBaseCatalog?.tools ?? []).filter(
         (tool) => !retryServerNames?.has(tool.serverName),
       );
+      const policyTools: McpCatalogTool[] = (retryBaseCatalog?.policyTools ?? []).filter(
+        (tool) => !retryServerNames?.has(tool.serverName),
+      );
       const sessionDeniedTools: McpCatalogTool[] = (
         retryBaseCatalog?.sessionDeniedTools ?? []
       ).filter((tool) => !retryServerNames?.has(tool.serverName));
@@ -718,6 +721,7 @@ export function createSessionMcpRuntime(params: {
           serverName: string;
           serverEntry: McpServerCatalog | null;
           toolEntries: McpCatalogTool[];
+          policyToolEntries: McpCatalogTool[];
           diagnostics: McpToolCatalogDiagnostic[];
         };
 
@@ -871,7 +875,8 @@ export function createSessionMcpRuntime(params: {
                     : {}),
                 };
                 const toolEntries: McpCatalogTool[] = [];
-                for (const tool of policyEligibleTools) {
+                const policyToolEntries: McpCatalogTool[] = [];
+                for (const tool of listedTools) {
                   const toolName = tool.name.trim();
                   if (!toolName) {
                     continue;
@@ -887,7 +892,7 @@ export function createSessionMcpRuntime(params: {
                       ? rawResourceUri
                       : undefined;
                   const uiVisibility = normalizeToolUiVisibility(uiMeta?.visibility);
-                  toolEntries.push({
+                  const entry: McpCatalogTool = {
                     serverName,
                     safeServerName,
                     toolName,
@@ -897,13 +902,21 @@ export function createSessionMcpRuntime(params: {
                     fallbackDescription: `Provided by bundle MCP server "${serverName}" (${launchDescription}).`,
                     ...(uiResourceUri ? { uiResourceUri } : {}),
                     ...(uiVisibility ? { uiVisibility } : {}),
+                    ...(!shouldExposeMcpTool(selection, toolName)
+                      ? { excludedByConfiguredFilter: true as const }
+                      : {}),
                     ...(deniedToolNames.has(toolName) ? { deniedBySession: true } : {}),
-                  });
+                  };
+                  policyToolEntries.push(entry);
+                  if (!entry.excludedByConfiguredFilter) {
+                    toolEntries.push(entry);
+                  }
                 }
                 return {
                   serverName,
                   serverEntry,
                   toolEntries,
+                  policyToolEntries,
                   diagnostics: [] as McpToolCatalogDiagnostic[],
                 };
               } catch (error) {
@@ -938,6 +951,7 @@ export function createSessionMcpRuntime(params: {
                   serverName,
                   serverEntry: null,
                   toolEntries: [],
+                  policyToolEntries: [],
                   diagnostics: diags,
                 } as ServerResult;
               } finally {
@@ -961,7 +975,7 @@ export function createSessionMcpRuntime(params: {
           if (!result) {
             continue;
           }
-          const { serverEntry, toolEntries, diagnostics: serverDiags } = result;
+          const { serverEntry, toolEntries, policyToolEntries, diagnostics: serverDiags } = result;
           if (serverEntry) {
             servers[result.serverName] = serverEntry;
           }
@@ -972,6 +986,7 @@ export function createSessionMcpRuntime(params: {
               tools.push(tool);
             }
           }
+          policyTools.push(...policyToolEntries);
           diagnostics.push(...serverDiags);
         }
 
@@ -981,6 +996,7 @@ export function createSessionMcpRuntime(params: {
           generatedAt: Date.now(),
           servers,
           tools,
+          ...(policyTools.length > 0 ? { policyTools } : {}),
           ...(sessionDeniedTools.length > 0 ? { sessionDeniedTools } : {}),
           ...(diagnostics.length > 0 ? { diagnostics } : {}),
         };

--- a/src/agents/agent-bundle-mcp-types.ts
+++ b/src/agents/agent-bundle-mcp-types.ts
@@ -56,6 +56,8 @@ export type McpCatalogTool = {
   fallbackDescription: string;
   uiResourceUri?: string;
   uiVisibility?: Array<"app" | "model">;
+  /** Listed by the server but excluded by its configured include/exclude filter. */
+  excludedByConfiguredFilter?: true;
   deniedBySession?: true;
 };
 
@@ -65,9 +67,32 @@ export type McpToolCatalog = {
   generatedAt: number;
   servers: Record<string, McpServerCatalog>;
   tools: McpCatalogTool[];
+  /** Complete raw catalog used to project policy into native MCP clients. */
+  policyTools?: McpCatalogTool[];
   /** Listed tools hidden only by the session override, retained for read-only inventory. */
   sessionDeniedTools?: McpCatalogTool[];
   diagnostics?: readonly McpToolCatalogDiagnostic[];
+};
+
+type PreparedNativeMcpToolPolicy = {
+  rawName: string;
+  safeName: string;
+  allowed: boolean;
+  excludedBy: Array<"configured-filter" | "session-override" | "effective-policy">;
+};
+
+type PreparedNativeMcpServerPolicy = {
+  serverName: string;
+  safeServerName: string;
+  allowedTools: string[];
+  deniedTools: string[];
+  tools: PreparedNativeMcpToolPolicy[];
+};
+
+/** Concrete raw/safe policy fact prepared once for native MCP adapters. */
+export type PreparedNativeMcpPolicy = {
+  servers: Record<string, PreparedNativeMcpServerPolicy>;
+  diagnostics: readonly McpToolCatalogDiagnostic[];
 };
 
 export type McpToolCatalogDiagnostic = {

--- a/src/agents/cli-runner/bundle-mcp-codex.ts
+++ b/src/agents/cli-runner/bundle-mcp-codex.ts
@@ -6,14 +6,20 @@ import type { SessionToolOverrides } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { BundleMcpConfig, BundleMcpServerConfig } from "../../plugins/bundle-mcp.js";
 import { isValidAgentId, normalizeAgentId } from "../../routing/session-key.js";
+import { getOrCreateSessionMcpRuntime } from "../agent-bundle-mcp-manager-api.js";
+import type { PreparedNativeMcpPolicy } from "../agent-bundle-mcp-types.js";
 import { isRecord } from "../bundle-mcp-adapter.js";
 import {
   applyCodexSessionMcpToolDenials,
   buildCodexMcpServersConfig,
   normalizeCodexMcpServerConfig,
 } from "../codex-mcp-config.js";
+import { resolveConversationCapabilityProfile } from "../conversation-capability-profile.js";
+import type { EmbeddedRunAttemptParams } from "../embedded-agent-runner/run/types.js";
 import { requiresMcpBearerProjection, resolveMcpBearerBundleConfig } from "../mcp-auth-profile.js";
 import { partitionMcpServersByConnectionScope } from "../mcp-connection-resolver.js";
+import { prepareNativeMcpPolicy, requiresPreparedNativeMcpPolicy } from "../native-mcp-policy.js";
+import { resolveSandboxRuntimeStatus } from "../sandbox/runtime-status.js";
 import { serializeTomlInlineValue } from "./toml-inline.js";
 
 // Mutable JSON shape structurally compatible with the bundled Codex
@@ -36,6 +42,7 @@ type CodexUserMcpServersProjectionOptions = {
   allowLiteralOAuthProjection?: boolean;
   onServerUnavailable?: (serverName: string, error: unknown) => void;
   toolOverrides?: Pick<SessionToolOverrides, "mcpServers" | "mcpToolsDeny">;
+  preparedNativeMcpPolicy?: PreparedNativeMcpPolicy;
 };
 
 function normalizeAgentIds(value: unknown): string[] {
@@ -156,7 +163,42 @@ export async function buildCodexUserMcpServersThreadConfigPatchForRuntime(
       );
     }),
   ) as BundleMcpConfig["mcpServers"];
+  if (options?.preparedNativeMcpPolicy) {
+    allowedServers = Object.fromEntries(
+      Object.entries(allowedServers).flatMap(([name, server]) => {
+        const prepared = options.preparedNativeMcpPolicy?.servers[name];
+        if (!prepared || prepared.allowedTools.length === 0) {
+          return [];
+        }
+        const toolFilter = isRecord(server.toolFilter) ? server.toolFilter : {};
+        const existingExcluded = Array.isArray(toolFilter.exclude)
+          ? toolFilter.exclude.filter((entry): entry is string => typeof entry === "string")
+          : [];
+        return [
+          [
+            name,
+            {
+              ...server,
+              toolFilter: {
+                ...toolFilter,
+                include: prepared.allowedTools,
+                exclude: [...new Set([...existingExcluded, ...prepared.deniedTools])].toSorted(),
+              },
+            },
+          ],
+        ];
+      }),
+    );
+  }
   if (Object.keys(allowedServers).length === 0) {
+    if (options?.preparedNativeMcpPolicy && entries.length > 0) {
+      const diagnostic = options.preparedNativeMcpPolicy.diagnostics[0]?.message;
+      throw new Error(
+        diagnostic
+          ? `Native MCP policy could not establish a callable catalog: ${diagnostic}`
+          : "Native MCP policy removed every callable configured MCP tool; update tools.allow/tools.deny and retry.",
+      );
+    }
     return undefined;
   }
   if (options?.allowLiteralOAuthProjection === false) {
@@ -196,4 +238,111 @@ export async function buildCodexUserMcpServersThreadConfigPatchForRuntime(
     ]),
   );
   return Object.keys(mcp_servers).length === 0 ? undefined : { mcp_servers };
+}
+
+/** Prepares canonical native MCP policy and projects it into Codex before thread creation. */
+export async function buildCodexUserMcpServersThreadConfigPatchForRun(params: {
+  run: EmbeddedRunAttemptParams;
+  cwd: string;
+  agentId?: string;
+  allowLiteralOAuthProjection?: boolean;
+  onServerUnavailable?: (serverName: string, error: unknown) => void;
+  warn?: (message: string) => void;
+}): Promise<{ mcp_servers: CodexThreadConfigObject } | undefined> {
+  const run = params.run;
+  const agentId = params.agentId ?? run.agentId;
+  const policySessionKey = run.sandboxSessionKey ?? run.sessionKey;
+  const sandboxStatus = resolveSandboxRuntimeStatus({
+    cfg: run.config,
+    sessionKey: policySessionKey,
+    agentId,
+  });
+  const capabilityProfile = resolveConversationCapabilityProfile({
+    config: run.config,
+    sessionKey: policySessionKey,
+    runSessionKey:
+      run.sessionKey && run.sessionKey !== policySessionKey ? run.sessionKey : undefined,
+    sessionId: run.sessionId,
+    runId: run.runId,
+    agentId,
+    agentDir: run.agentDir,
+    agentAccountId: run.agentAccountId,
+    messageProvider: run.messageProvider ?? run.messageChannel,
+    messageChannel: run.messageChannel,
+    chatType: run.chatType,
+    messageTo: run.messageTo,
+    messageThreadId: run.messageThreadId,
+    currentChannelId: run.currentChannelId,
+    currentMessagingTarget: run.currentMessagingTarget,
+    currentThreadTs: run.currentThreadTs,
+    currentMessageId: run.currentMessageId,
+    groupId: run.groupId,
+    groupChannel: run.groupChannel,
+    groupSpace: run.groupSpace,
+    memberRoleIds: run.memberRoleIds,
+    spawnedBy: run.spawnedBy,
+    senderId: run.senderId,
+    senderName: run.senderName,
+    senderUsername: run.senderUsername,
+    senderE164: run.senderE164,
+    senderIsOwner: run.senderIsOwner,
+    modelProvider: run.provider,
+    modelId: run.modelId,
+    modelApi: run.model?.api,
+    modelContextWindowTokens: run.model?.contextWindow,
+    modelHasVision: run.model?.input?.includes("image") ?? false,
+    workspaceDir: run.workspaceDir,
+    cwd: params.cwd,
+    skillsSnapshot: run.skillsSnapshot,
+    sandboxToolPolicy: sandboxStatus.sandboxed ? sandboxStatus.toolPolicy : undefined,
+    runtimeToolAllowlist: run.toolsAllow,
+    inheritRuntimeToolAllowlist: true,
+    runtimePluginToolGrant: run.runtimePluginToolGrant,
+    inputProvenance: run.inputProvenance,
+    trustedInternalHandoff: run.trustedInternalHandoff,
+    scheduledToolPolicy: run.scheduledToolPolicy,
+  });
+  const configuredMcpServers = normalizeConfiguredMcpServers(run.config?.mcp?.servers);
+  if (
+    !requiresPreparedNativeMcpPolicy({
+      capabilityProfile,
+      runtimeToolsAllow: run.toolsAllow,
+      mcpServers: configuredMcpServers,
+    })
+  ) {
+    return await buildCodexUserMcpServersThreadConfigPatchForRuntime(run.config, {
+      agentId,
+      agentDir: run.agentDir,
+      allowLiteralOAuthProjection: params.allowLiteralOAuthProjection,
+      onServerUnavailable: params.onServerUnavailable,
+      toolOverrides: run.toolOverrides,
+    });
+  }
+  const runtime = await getOrCreateSessionMcpRuntime({
+    sessionId: run.sessionId,
+    sessionKey: run.sessionKey,
+    workspaceDir: run.workspaceDir,
+    agentDir: run.agentDir,
+    cfg: run.config,
+    requesterSenderId: run.senderId,
+    agentAccountId: run.agentAccountId,
+    messageChannel: run.messageChannel,
+    toolOverrides: run.toolOverrides,
+  });
+  const preparedNativeMcpPolicy = await prepareNativeMcpPolicy({
+    runtime,
+    config: run.config,
+    workspaceDir: run.workspaceDir,
+    capabilityProfile,
+    runtimeToolsAllow: run.toolsAllow,
+    warn: params.warn ?? (() => {}),
+  });
+  return await buildCodexUserMcpServersThreadConfigPatchForRuntime(run.config, {
+    agentId,
+    agentDir: run.agentDir,
+    allowLiteralOAuthProjection: params.allowLiteralOAuthProjection,
+    onServerUnavailable: params.onServerUnavailable,
+    toolOverrides: run.toolOverrides,
+    preparedNativeMcpPolicy,
+  });
 }

--- a/src/agents/cli-runner/bundle-mcp-gemini.ts
+++ b/src/agents/cli-runner/bundle-mcp-gemini.ts
@@ -90,11 +90,29 @@ function normalizeGeminiServerConfig(
       ]),
     );
   }
-  if (deniedTools?.length) {
+  const toolFilter = isRecord(server.toolFilter) ? server.toolFilter : {};
+  const included = Array.isArray(toolFilter.include)
+    ? toolFilter.include.filter((name): name is string => typeof name === "string")
+    : [];
+  if (included.length > 0) {
+    const existing = Array.isArray(server.includeTools)
+      ? server.includeTools.filter((name): name is string => typeof name === "string")
+      : [];
+    next.includeTools =
+      existing.length > 0
+        ? included.filter((name) => existing.includes(name)).toSorted()
+        : [...new Set(included)].toSorted();
+  }
+  const filteredDenied = Array.isArray(toolFilter.exclude)
+    ? toolFilter.exclude.filter((name): name is string => typeof name === "string")
+    : [];
+  if (deniedTools?.length || filteredDenied.length > 0) {
     const existing = Array.isArray(server.excludeTools)
       ? server.excludeTools.filter((name): name is string => typeof name === "string")
       : [];
-    next.excludeTools = [...new Set([...existing, ...deniedTools])].toSorted();
+    next.excludeTools = [
+      ...new Set([...existing, ...filteredDenied, ...(deniedTools ?? [])]),
+    ].toSorted();
   }
   return next;
 }

--- a/src/agents/cli-runner/bundle-mcp.codex.test.ts
+++ b/src/agents/cli-runner/bundle-mcp.codex.test.ts
@@ -1,6 +1,15 @@
 /** Tests Codex CLI bundle-MCP config override generation. */
 import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { prepareCliBundleMcpConfig } from "./bundle-mcp.js";
+import {
+  cliBundleMcpHarness,
+  cliNativeMcpPolicyContext,
+  setupCliBundleMcpTestHarness,
+  writeCliMcpPolicyProbeServer,
+} from "./bundle-mcp.test-support.js";
+
+setupCliBundleMcpTestHarness();
 
 describe("prepareCliBundleMcpConfig codex", () => {
   it("disables Codex native web search without bundle MCP", async () => {
@@ -37,6 +46,26 @@ describe("prepareCliBundleMcpConfig codex", () => {
       'disabled_tools = ["delete_docs"]',
     );
     expect(prepared.backend.args).toContain('web_search="disabled"');
+  });
+
+  it("projects canonical allow and deny sets into Codex CLI overrides", async () => {
+    const serverPath = await writeCliMcpPolicyProbeServer();
+    const config: OpenClawConfig = {
+      plugins: { enabled: false },
+      tools: { allow: ["docs__read_docs"], deny: ["docs__delete_docs"] },
+      mcp: { servers: { docs: { command: process.execPath, args: [serverPath] } } },
+    };
+    const prepared = await prepareCliBundleMcpConfig({
+      enabled: true,
+      mode: "codex-config-overrides",
+      backend: { command: "codex", args: ["exec"] },
+      workspaceDir: cliBundleMcpHarness.bundleProbeWorkspaceDir,
+      config,
+      nativeMcpPolicy: cliNativeMcpPolicyContext(config, "codex-cli-policy"),
+    });
+    const override = prepared.backend.args?.find((arg) => arg.startsWith("mcp_servers="));
+    expect(override).toContain('enabled_tools = ["read_docs"]');
+    expect(override).toContain('disabled_tools = ["delete_docs"]');
   });
 
   it("injects codex MCP config overrides with env-backed loopback headers", async () => {

--- a/src/agents/cli-runner/bundle-mcp.gemini.test.ts
+++ b/src/agents/cli-runner/bundle-mcp.gemini.test.ts
@@ -3,7 +3,16 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { prepareCliBundleMcpCaptureAttempt, prepareCliBundleMcpConfig } from "./bundle-mcp.js";
+import {
+  cliBundleMcpHarness,
+  cliNativeMcpPolicyContext,
+  setupCliBundleMcpTestHarness,
+  writeCliMcpPolicyProbeServer,
+} from "./bundle-mcp.test-support.js";
+
+setupCliBundleMcpTestHarness();
 
 describe("prepareCliBundleMcpConfig gemini", () => {
   it("disables Gemini native web search without bundle MCP", async () => {
@@ -76,6 +85,31 @@ describe("prepareCliBundleMcpConfig gemini", () => {
     expect(raw.mcpServers?.openclaw?.excludeTools).toEqual(["delete_docs", "global_delete"]);
     expect(raw.tools?.exclude).toEqual(["google_web_search"]);
 
+    await prepared.cleanup?.();
+  });
+
+  it("projects canonical allow and deny sets into Gemini settings", async () => {
+    const serverPath = await writeCliMcpPolicyProbeServer();
+    const config: OpenClawConfig = {
+      plugins: { enabled: false },
+      tools: { allow: ["docs__read_docs"], deny: ["docs__delete_docs"] },
+      mcp: { servers: { docs: { command: process.execPath, args: [serverPath] } } },
+    };
+    const prepared = await prepareCliBundleMcpConfig({
+      enabled: true,
+      mode: "gemini-system-settings",
+      backend: { command: "gemini" },
+      workspaceDir: cliBundleMcpHarness.bundleProbeWorkspaceDir,
+      config,
+      nativeMcpPolicy: cliNativeMcpPolicyContext(config, "gemini-policy"),
+    });
+    const raw = JSON.parse(
+      await fs.readFile(prepared.env?.GEMINI_CLI_SYSTEM_SETTINGS_PATH as string, "utf-8"),
+    ) as { mcpServers?: { docs?: { includeTools?: string[]; excludeTools?: string[] } } };
+    expect(raw.mcpServers?.docs).toMatchObject({
+      includeTools: ["read_docs"],
+      excludeTools: ["delete_docs"],
+    });
     await prepared.cleanup?.();
   });
 

--- a/src/agents/cli-runner/bundle-mcp.test-support.ts
+++ b/src/agents/cli-runner/bundle-mcp.test-support.ts
@@ -1,4 +1,5 @@
 /** Shared test harness for CLI runner bundle-MCP config preparation tests. */
+import fs from "node:fs/promises";
 import { afterAll, beforeAll } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
@@ -6,6 +7,7 @@ import {
   createBundleProbePlugin,
 } from "../../plugins/bundle-mcp.test-support.js";
 import { captureEnv, setTestEnvValue, withEnvAsync } from "../../test-utils/env.js";
+import { resolveConversationCapabilityProfile } from "../conversation-capability-profile.js";
 import { prepareCliBundleMcpConfig } from "./bundle-mcp.js";
 
 const tempHarness = createBundleMcpTempHarness();
@@ -55,6 +57,43 @@ export function setupCliBundleMcpTestHarness(): void {
     envSnapshot?.restore();
     await tempHarness.cleanup();
   });
+}
+
+export async function writeCliMcpPolicyProbeServer(): Promise<string> {
+  const filePath = `${cliBundleMcpHarness.bundleProbeWorkspaceDir}/policy-probe.mjs`;
+  await fs.writeFile(
+    filePath,
+    `import readline from "node:readline";
+const lines = readline.createInterface({ input: process.stdin });
+const send = (id, result) => process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id, result }) + "\\n");
+lines.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.method === "initialize") send(message.id, { protocolVersion: "2024-11-05", capabilities: { tools: {} }, serverInfo: { name: "policy-probe", version: "1" } });
+  if (message.method === "tools/list") send(message.id, { tools: [
+    { name: "read_docs", description: "read", inputSchema: { type: "object" } },
+    { name: "delete_docs", description: "delete", inputSchema: { type: "object" } }
+  ] });
+});
+`,
+    "utf-8",
+  );
+  return filePath;
+}
+
+export function cliNativeMcpPolicyContext(config: OpenClawConfig, sessionId: string) {
+  return {
+    sessionId,
+    sessionKey: `agent:main:${sessionId}`,
+    capabilityProfile: resolveConversationCapabilityProfile({
+      config,
+      sessionKey: `agent:main:${sessionId}`,
+      sessionId,
+      agentId: "main",
+      modelProvider: "openai",
+      modelId: "gpt-5.4-codex",
+      workspaceDir: cliBundleMcpHarness.bundleProbeWorkspaceDir,
+    }),
+  };
 }
 
 function createEnabledBundleProbeConfig(): OpenClawConfig {

--- a/src/agents/cli-runner/bundle-mcp.test.ts
+++ b/src/agents/cli-runner/bundle-mcp.test.ts
@@ -2,13 +2,16 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { writeClaudeBundleManifest } from "../../plugins/bundle-mcp.test-support.js";
 import { prepareCliBundleMcpCaptureAttempt, prepareCliBundleMcpConfig } from "./bundle-mcp.js";
 import {
   cliBundleMcpHarness,
+  cliNativeMcpPolicyContext,
   prepareBundleProbeCliConfig,
   requireMcpConfigPath,
   setupCliBundleMcpTestHarness,
+  writeCliMcpPolicyProbeServer,
 } from "./bundle-mcp.test-support.js";
 
 setupCliBundleMcpTestHarness();
@@ -129,6 +132,149 @@ describe("prepareCliBundleMcpConfig", () => {
 
     expect(prepared.backend.args).toContain("Bash(rm *),WebSearch,mcp__docs__delete_docs");
     await prepared.cleanup?.();
+  });
+
+  it("projects durable policy into the first Claude process config and argv", async () => {
+    const serverPath = await writeCliMcpPolicyProbeServer();
+    const config: OpenClawConfig = {
+      plugins: { enabled: false },
+      tools: { allow: ["docs__read_docs"], deny: ["docs__delete_docs"] },
+      mcp: { servers: { docs: { command: process.execPath, args: [serverPath] } } },
+    };
+    const prepared = await prepareCliBundleMcpConfig({
+      enabled: true,
+      mode: "claude-config-file",
+      backend: { command: "claude", args: ["--print"] },
+      workspaceDir: cliBundleMcpHarness.bundleProbeWorkspaceDir,
+      config,
+      nativeMcpPolicy: cliNativeMcpPolicyContext(config, "claude-policy"),
+    });
+
+    expect(prepared.backend.args).toContain("mcp__docs__delete_docs");
+    const raw = JSON.parse(
+      await fs.readFile(requireMcpConfigPath(prepared.backend.args), "utf-8"),
+    ) as { mcpServers?: Record<string, { toolFilter?: unknown }> };
+    expect(Object.keys(raw.mcpServers ?? {})).toEqual(["docs"]);
+    expect(raw.mcpServers?.docs?.toolFilter).toBeUndefined();
+    await prepared.cleanup?.();
+  });
+
+  it("projects configured MCP filters into Claude denials without a global tool policy", async () => {
+    const serverPath = await writeCliMcpPolicyProbeServer();
+    const config: OpenClawConfig = {
+      plugins: { enabled: false },
+      mcp: {
+        servers: {
+          docs: {
+            command: process.execPath,
+            args: [serverPath],
+            toolFilter: { include: ["read_*"] },
+          },
+        },
+      },
+    };
+    const prepared = await prepareCliBundleMcpConfig({
+      enabled: true,
+      mode: "claude-config-file",
+      backend: { command: "claude", args: ["--print"] },
+      workspaceDir: cliBundleMcpHarness.bundleProbeWorkspaceDir,
+      config,
+      nativeMcpPolicy: cliNativeMcpPolicyContext(config, "claude-configured-filter"),
+    });
+
+    expect(prepared.backend.args).toContain("mcp__docs__delete_docs");
+    expect(prepared.backend.args).not.toContain("mcp__docs__read_docs");
+    await prepared.cleanup?.();
+  });
+
+  it("projects an exact runtime cap into Claude before spawn", async () => {
+    const serverPath = await writeCliMcpPolicyProbeServer();
+    const config: OpenClawConfig = {
+      plugins: { enabled: false },
+      mcp: { servers: { docs: { command: process.execPath, args: [serverPath] } } },
+    };
+    const prepared = await prepareCliBundleMcpConfig({
+      enabled: true,
+      mode: "claude-config-file",
+      backend: { command: "claude", args: ["--print"] },
+      workspaceDir: cliBundleMcpHarness.bundleProbeWorkspaceDir,
+      config,
+      nativeMcpPolicy: {
+        ...cliNativeMcpPolicyContext(config, "claude-runtime-cap"),
+        runtimeToolsAllow: ["docs__read_docs"],
+      },
+    });
+
+    expect(prepared.backend.args).toContain("mcp__docs__delete_docs");
+    expect(prepared.backend.args).not.toContain("mcp__docs__read_docs");
+    await prepared.cleanup?.();
+  });
+
+  it("omits a fully excluded server while retaining an allowed sibling server", async () => {
+    const serverPath = await writeCliMcpPolicyProbeServer();
+    const config: OpenClawConfig = {
+      plugins: { enabled: false },
+      tools: { allow: ["docs__read_docs"] },
+      mcp: {
+        servers: {
+          docs: { command: process.execPath, args: [serverPath] },
+          admin: { command: process.execPath, args: [serverPath] },
+        },
+      },
+    };
+    const prepared = await prepareCliBundleMcpConfig({
+      enabled: true,
+      mode: "claude-config-file",
+      backend: { command: "claude", args: ["--print"] },
+      workspaceDir: cliBundleMcpHarness.bundleProbeWorkspaceDir,
+      config,
+      nativeMcpPolicy: cliNativeMcpPolicyContext(config, "claude-server-omission"),
+    });
+    const raw = JSON.parse(
+      await fs.readFile(requireMcpConfigPath(prepared.backend.args), "utf-8"),
+    ) as { mcpServers?: Record<string, unknown> };
+
+    expect(Object.keys(raw.mcpServers ?? {})).toEqual(["docs"]);
+    await prepared.cleanup?.();
+  });
+
+  it("stops before Claude spawn when durable policy removes every configured MCP tool", async () => {
+    const serverPath = await writeCliMcpPolicyProbeServer();
+    const config: OpenClawConfig = {
+      plugins: { enabled: false },
+      tools: { allow: ["missing__tool"] },
+      mcp: { servers: { docs: { command: process.execPath, args: [serverPath] } } },
+    };
+    await expect(
+      prepareCliBundleMcpConfig({
+        enabled: true,
+        mode: "claude-config-file",
+        backend: { command: "claude", args: ["--print"] },
+        workspaceDir: cliBundleMcpHarness.bundleProbeWorkspaceDir,
+        config,
+        nativeMcpPolicy: cliNativeMcpPolicyContext(config, "claude-policy-empty"),
+      }),
+    ).rejects.toThrow("Native MCP policy removed every callable configured MCP tool");
+  });
+
+  it("stops before Claude spawn when a restrictive policy catalog cannot be established", async () => {
+    const config: OpenClawConfig = {
+      plugins: { enabled: false },
+      tools: { deny: ["docs__delete_docs"] },
+      mcp: {
+        servers: { docs: { command: process.execPath, args: ["-e", "process.exit(1)"] } },
+      },
+    };
+    await expect(
+      prepareCliBundleMcpConfig({
+        enabled: true,
+        mode: "claude-config-file",
+        backend: { command: "claude", args: ["--print"] },
+        workspaceDir: cliBundleMcpHarness.bundleProbeWorkspaceDir,
+        config,
+        nativeMcpPolicy: cliNativeMcpPolicyContext(config, "claude-policy-catalog-failure"),
+      }),
+    ).rejects.toThrow("Native MCP policy could not establish a callable catalog");
   });
 
   it("applies server disables to exclusive CLI MCP configs", async () => {

--- a/src/agents/cli-runner/bundle-mcp.ts
+++ b/src/agents/cli-runner/bundle-mcp.ts
@@ -20,9 +20,13 @@ import {
 } from "../../plugins/bundle-mcp.js";
 import type { CliBackendConfig } from "../../plugins/cli-backend.types.js";
 import type { CliBundleMcpMode } from "../../plugins/types.js";
+import { getOrCreateSessionMcpRuntime } from "../agent-bundle-mcp-manager-api.js";
+import type { PreparedNativeMcpPolicy } from "../agent-bundle-mcp-types.js";
 import { isRecord } from "../bundle-mcp-adapter.js";
 import { loadMergedBundleMcpConfig, toCliBundleMcpServerConfig } from "../bundle-mcp-config.js";
+import type { ResolvedConversationCapabilityProfile } from "../conversation-capability-profile.js";
 import { resolveMcpBearerBundleConfig } from "../mcp-auth-profile.js";
+import { prepareNativeMcpPolicy, requiresPreparedNativeMcpPolicy } from "../native-mcp-policy.js";
 import {
   findClaudeMcpConfigPaths,
   injectClaudeMcpConfigArgs,
@@ -175,6 +179,49 @@ function applyMcpServerOverrides(
     : config;
 }
 
+function applyPreparedNativeMcpPolicy(
+  config: BundleMcpConfig,
+  policy: PreparedNativeMcpPolicy,
+): BundleMcpConfig {
+  const mcpServers: BundleMcpConfig["mcpServers"] = {};
+  for (const [serverName, server] of Object.entries(config.mcpServers)) {
+    const prepared = policy.servers[serverName];
+    if (!prepared || prepared.allowedTools.length === 0) {
+      continue;
+    }
+    const toolFilter = isRecord(server.toolFilter) ? server.toolFilter : {};
+    const existingExcluded = Array.isArray(toolFilter.exclude)
+      ? toolFilter.exclude.filter((name): name is string => typeof name === "string")
+      : [];
+    mcpServers[serverName] = {
+      ...server,
+      toolFilter: {
+        ...toolFilter,
+        include: prepared.allowedTools,
+        exclude: [...new Set([...existingExcluded, ...prepared.deniedTools])].toSorted(),
+      },
+    };
+  }
+  if (Object.keys(config.mcpServers).length > 0 && Object.keys(mcpServers).length === 0) {
+    const diagnostic = policy.diagnostics[0]?.message;
+    throw new Error(
+      diagnostic
+        ? `Native MCP policy could not establish a callable catalog: ${diagnostic}`
+        : "Native MCP policy removed every callable configured MCP tool; update tools.allow/tools.deny and retry.",
+    );
+  }
+  return { mcpServers };
+}
+
+function preparedNativeMcpDenials(
+  policy: PreparedNativeMcpPolicy,
+): Record<string, string[]> | undefined {
+  const entries = Object.values(policy.servers)
+    .filter((server) => server.deniedTools.length > 0)
+    .map((server) => [server.serverName, server.deniedTools] as const);
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
 function resolveOpenClawMcpEnvTemplates(value: unknown, env?: Record<string, string>): unknown {
   if (!env) {
     return value;
@@ -259,9 +306,17 @@ async function prepareModeSpecificBundleMcpConfig(params: {
     params.mergedConfig,
     params.env,
   ) as BundleMcpConfig;
+  const claudeConfig: BundleMcpConfig = {
+    mcpServers: Object.fromEntries(
+      Object.entries(runtimeConfig.mcpServers).map(([name, server]) => {
+        const { toolFilter: _toolFilter, ...nativeServer } = server;
+        return [name, nativeServer];
+      }),
+    ),
+  };
   const temporary = await writeTemporaryBundleMcpJson(
     "openclaw-cli-mcp-",
-    runtimeConfig,
+    claudeConfig,
     "mcp.json",
     false,
   );
@@ -318,6 +373,12 @@ export async function prepareCliBundleMcpConfig(params: {
   exclusiveConfig?: BundleMcpConfig;
   env?: Record<string, string>;
   warn?: (message: string) => void;
+  nativeMcpPolicy?: {
+    sessionId: string;
+    sessionKey?: string;
+    capabilityProfile: ResolvedConversationCapabilityProfile;
+    runtimeToolsAllow?: string[];
+  };
 }): Promise<PreparedCliBundleMcpConfig> {
   if (!params.enabled) {
     return params.toolOverrides?.webSearch === false
@@ -390,15 +451,50 @@ export async function prepareCliBundleMcpConfig(params: {
       ),
   });
 
+  let effectiveConfig = applyMcpServerOverrides(
+    resolvedBearerConfig.config,
+    params.toolOverrides?.mcpServers,
+  );
+  let effectiveDenials = params.toolOverrides?.mcpToolsDeny;
+  if (
+    params.nativeMcpPolicy &&
+    Object.keys(effectiveConfig.mcpServers).length > 0 &&
+    requiresPreparedNativeMcpPolicy({
+      capabilityProfile: params.nativeMcpPolicy.capabilityProfile,
+      runtimeToolsAllow: params.nativeMcpPolicy.runtimeToolsAllow,
+      mcpServers: effectiveConfig.mcpServers,
+    })
+  ) {
+    const policyConfig = {
+      ...params.config,
+      mcp: { ...params.config?.mcp, servers: effectiveConfig.mcpServers },
+    } as OpenClawConfig;
+    const runtime = await getOrCreateSessionMcpRuntime({
+      sessionId: params.nativeMcpPolicy.sessionId,
+      sessionKey: params.nativeMcpPolicy.sessionKey,
+      workspaceDir: params.workspaceDir,
+      agentDir: params.agentDir,
+      cfg: policyConfig,
+      toolOverrides: params.toolOverrides,
+    });
+    const policy = await prepareNativeMcpPolicy({
+      runtime,
+      config: params.config,
+      workspaceDir: params.workspaceDir,
+      capabilityProfile: params.nativeMcpPolicy.capabilityProfile,
+      runtimeToolsAllow: params.nativeMcpPolicy.runtimeToolsAllow,
+      warn: params.warn ?? (() => {}),
+    });
+    effectiveConfig = applyPreparedNativeMcpPolicy(effectiveConfig, policy);
+    effectiveDenials = preparedNativeMcpDenials(policy);
+  }
+
   return await prepareModeSpecificBundleMcpConfig({
     mode,
     backend: params.backend,
-    mergedConfig: applyMcpServerOverrides(
-      resolvedBearerConfig.config,
-      params.toolOverrides?.mcpServers,
-    ),
+    mergedConfig: effectiveConfig,
     env: resolvedBearerConfig.env,
-    mcpToolsDeny: params.toolOverrides?.mcpToolsDeny,
+    mcpToolsDeny: effectiveDenials,
     webSearchEnabled: params.toolOverrides?.webSearch,
   });
 }

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -85,6 +85,7 @@ import {
 } from "../command/attempt-execution.helpers.js";
 import { resolveContextWindowInfo } from "../context-window-guard.js";
 import { resolveContextTokensForModel } from "../context.js";
+import { resolveConversationCapabilityProfile } from "../conversation-capability-profile.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import {
   applyEmbeddedAttemptToolsAllow,
@@ -106,6 +107,7 @@ import type { ResolvedProviderAuth } from "../model-auth-runtime-shared.js";
 import { applyPluginTextReplacements } from "../plugin-text-transforms.js";
 import { collectRuntimeChannelCapabilities } from "../runtime-capabilities.js";
 import { ensureSandboxWorkspaceForSession } from "../sandbox.js";
+import { resolveSandboxRuntimeStatus } from "../sandbox/runtime-status.js";
 import { buildSystemPromptReport } from "../system-prompt-report.js";
 import { appendModelIdentitySystemPrompt, buildModelIdentityPromptLine } from "../system-prompt.js";
 import { expandToolGroups, normalizeToolName } from "../tool-policy.js";
@@ -1105,6 +1107,49 @@ export async function prepareCliRunContext(
     const loopbackServerConfig = mcpLoopbackRuntime
       ? prepareDeps.createMcpLoopbackServerConfig(mcpLoopbackRuntime.port)
       : undefined;
+    const policySessionKey = params.runtimePolicySessionKey ?? params.sessionKey;
+    const sandboxStatus = resolveSandboxRuntimeStatus({
+      cfg: runtimeConfig,
+      sessionKey: policySessionKey,
+      agentId: sessionAgentId,
+    });
+    const nativeMcpCapabilityProfile = resolveConversationCapabilityProfile({
+      config: runtimeConfig,
+      sessionKey: policySessionKey,
+      runSessionKey:
+        params.sessionKey && params.sessionKey !== policySessionKey ? params.sessionKey : undefined,
+      sessionId: params.sessionId,
+      runId: params.runId,
+      agentId: sessionAgentId,
+      agentDir,
+      agentAccountId: params.agentAccountId,
+      messageProvider: params.messageProvider ?? params.messageChannel,
+      messageChannel: params.messageChannel,
+      chatType: runtimeChatType,
+      currentChannelId: params.currentChannelId,
+      currentThreadTs: params.currentThreadTs,
+      currentMessageId: params.currentMessageId,
+      groupId: params.groupId,
+      groupChannel: params.groupChannel,
+      groupSpace: params.groupSpace,
+      spawnedBy: params.spawnedBy,
+      senderId: params.senderId,
+      senderName: params.senderName,
+      senderUsername: params.senderUsername,
+      senderE164: params.senderE164,
+      senderIsOwner: params.senderIsOwner,
+      modelProvider,
+      modelId,
+      modelContextWindowTokens: contextWindowInfo.tokens,
+      workspaceDir,
+      cwd,
+      skillsSnapshot: params.skillsSnapshot,
+      sandboxToolPolicy: sandboxStatus.sandboxed ? sandboxStatus.toolPolicy : undefined,
+      runtimeToolAllowlist: runtimeToolsAllowPolicy,
+      inheritRuntimeToolAllowlist: true,
+      inputProvenance: params.inputProvenance,
+      scheduledToolPolicy: params.scheduledToolPolicy,
+    });
     const preparedBackend = await prepareCliBundleMcpConfig({
       enabled: bundleMcpEnabled || systemAgentMcpConfig !== undefined,
       mode: backendResolved.bundleMcpMode,
@@ -1129,6 +1174,18 @@ export async function prepareCliRunContext(
             }
           : undefined,
       warn: (message) => cliBackendLog.warn(message),
+      ...(!systemAgentMcpConfig && !restrictedLoopbackToolsAllow
+        ? {
+            nativeMcpPolicy: {
+              sessionId: params.sessionId,
+              ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+              capabilityProfile: nativeMcpCapabilityProfile,
+              ...(runtimeToolsAllowPolicy !== undefined
+                ? { runtimeToolsAllow: runtimeToolsAllowPolicy }
+                : {}),
+            },
+          }
+        : {}),
     });
     const cleanupPreparedBackend =
       preparedBackend.cleanup || cleanupMcpClientGrant

--- a/src/agents/native-mcp-policy.test.ts
+++ b/src/agents/native-mcp-policy.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+import { assignSafeServerNames } from "./agent-bundle-mcp-names.js";
+import type { McpToolCatalog, SessionMcpRuntime } from "./agent-bundle-mcp-types.js";
+import { resolveConversationCapabilityProfile } from "./conversation-capability-profile.js";
+import { prepareNativeMcpPolicy, requiresPreparedNativeMcpPolicy } from "./native-mcp-policy.js";
+
+function catalog(): McpToolCatalog {
+  const tools = [
+    {
+      serverName: "docs!",
+      safeServerName: "docs",
+      toolName: "read_docs",
+      inputSchema: { type: "object" } as never,
+      fallbackDescription: "read",
+    },
+    {
+      serverName: "docs!",
+      safeServerName: "docs",
+      toolName: "delete_docs",
+      inputSchema: { type: "object" } as never,
+      fallbackDescription: "delete",
+      excludedByConfiguredFilter: true as const,
+    },
+    {
+      serverName: "docs?",
+      safeServerName: "docs-2",
+      toolName: "read_docs",
+      inputSchema: { type: "object" } as never,
+      fallbackDescription: "other read",
+      deniedBySession: true as const,
+    },
+  ];
+  return {
+    version: 1,
+    generatedAt: 1,
+    servers: {
+      "docs!": { serverName: "docs!", safeServerName: "docs", launchSummary: "test", toolCount: 1 },
+      "docs?": {
+        serverName: "docs?",
+        safeServerName: "docs-2",
+        launchSummary: "test",
+        toolCount: 0,
+      },
+    },
+    tools: [tools[0]!],
+    sessionDeniedTools: [tools[2]!],
+    policyTools: tools,
+  };
+}
+
+function runtime(value: McpToolCatalog): SessionMcpRuntime {
+  return {
+    sessionId: "session-1",
+    workspaceDir: "/tmp/openclaw-native-mcp-policy",
+    configFingerprint: "test",
+    createdAt: 1,
+    lastUsedAt: 1,
+    getCatalog: async () => value,
+    peekCatalog: () => value,
+    markUsed: () => {},
+    callTool: async () => ({ content: [] }),
+    dispose: async () => {},
+  };
+}
+
+describe("prepareNativeMcpPolicy", () => {
+  it("requires catalog preparation for configured MCP filters without a global tool policy", () => {
+    expect(
+      requiresPreparedNativeMcpPolicy({
+        capabilityProfile: resolveConversationCapabilityProfile({}),
+        mcpServers: { docs: { toolFilter: { include: ["read_*"] } } },
+      }),
+    ).toBe(true);
+  });
+
+  it("preserves raw/safe identities and intersects effective, configured, and session policy", async () => {
+    const config = { tools: { allow: ["docs__*"], deny: ["docs__delete_*"] } };
+    const prepared = await prepareNativeMcpPolicy({
+      runtime: runtime(catalog()),
+      config,
+      workspaceDir: "/tmp/openclaw-native-mcp-policy",
+      capabilityProfile: resolveConversationCapabilityProfile({ config }),
+      warn: () => {},
+    });
+
+    expect(prepared.servers["docs!"]).toMatchObject({
+      safeServerName: "docs",
+      allowedTools: ["read_docs"],
+      deniedTools: ["delete_docs"],
+    });
+    expect(prepared.servers["docs?"]).toMatchObject({
+      safeServerName: "docs-2",
+      allowedTools: [],
+      deniedTools: ["read_docs"],
+    });
+    expect(prepared.servers["docs!"]?.tools).toEqual([
+      {
+        rawName: "delete_docs",
+        safeName: "docs__delete_docs",
+        allowed: false,
+        excludedBy: ["configured-filter", "effective-policy"],
+      },
+      { rawName: "read_docs", safeName: "docs__read_docs", allowed: true, excludedBy: [] },
+    ]);
+    expect(prepared.servers["docs?"]?.tools[0]?.excludedBy).toEqual([
+      "session-override",
+      "effective-policy",
+    ]);
+  });
+
+  it("treats an empty runtime allowlist as an exact deny-all cap", async () => {
+    const prepared = await prepareNativeMcpPolicy({
+      runtime: runtime(catalog()),
+      workspaceDir: "/tmp/openclaw-native-mcp-policy",
+      capabilityProfile: resolveConversationCapabilityProfile({}),
+      runtimeToolsAllow: [],
+      warn: () => {},
+    });
+    expect(Object.values(prepared.servers).flatMap((server) => server.allowedTools)).toEqual([]);
+  });
+
+  it("uses catalog-assigned identities for truncated server and colliding tool names", async () => {
+    const serverNames = [
+      "docs.production.endpoint.with.a.long.shared.prefix.alpha",
+      "docs.production.endpoint.with.a.long.shared.prefix.beta",
+    ];
+    const safeNames = assignSafeServerNames(serverNames);
+    const rawTools = [
+      "read.docs.with.a.long.shared.prefix.alpha",
+      "read:docs:with:a:long:shared:prefix:alpha",
+    ];
+    const policyTools = rawTools.map((toolName) => ({
+      serverName: serverNames[1]!,
+      safeServerName: safeNames.get(serverNames[1]!)!,
+      toolName,
+      inputSchema: { type: "object" } as never,
+      fallbackDescription: toolName,
+    }));
+    const collisionCatalog: McpToolCatalog = {
+      version: 1,
+      generatedAt: 1,
+      servers: Object.fromEntries(
+        serverNames.map((serverName) => [
+          serverName,
+          {
+            serverName,
+            safeServerName: safeNames.get(serverName)!,
+            launchSummary: "test",
+            toolCount: serverName === serverNames[1] ? policyTools.length : 0,
+          },
+        ]),
+      ),
+      tools: policyTools,
+      policyTools,
+    };
+    const inventory = await prepareNativeMcpPolicy({
+      runtime: runtime(collisionCatalog),
+      workspaceDir: "/tmp/openclaw-native-mcp-policy",
+      capabilityProfile: resolveConversationCapabilityProfile({}),
+      warn: () => {},
+    });
+    const target = inventory.servers[serverNames[1]!]?.tools.find((tool) =>
+      tool.safeName.endsWith("-2"),
+    );
+    expect(target).toBeDefined();
+    const config = { tools: { allow: [target!.safeName] } };
+    const prepared = await prepareNativeMcpPolicy({
+      runtime: runtime(collisionCatalog),
+      config,
+      workspaceDir: "/tmp/openclaw-native-mcp-policy",
+      capabilityProfile: resolveConversationCapabilityProfile({ config }),
+      warn: () => {},
+    });
+
+    expect(prepared.servers[serverNames[1]!]?.allowedTools).toEqual([target?.rawName]);
+    expect(safeNames.get(serverNames[0]!)).not.toBe(safeNames.get(serverNames[1]!));
+  });
+});

--- a/src/agents/native-mcp-policy.ts
+++ b/src/agents/native-mcp-policy.ts
@@ -1,0 +1,118 @@
+/** Projects the canonical conversation tool policy into raw native MCP identities. */
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { BundleMcpConfig } from "../plugins/bundle-mcp.js";
+import { getPluginToolMeta } from "../plugins/tools.js";
+import { buildBundleMcpToolsFromCatalog } from "./agent-bundle-mcp-materialize.js";
+import type {
+  McpToolCatalog,
+  PreparedNativeMcpPolicy,
+  SessionMcpRuntime,
+} from "./agent-bundle-mcp-types.js";
+import { isRecord } from "./bundle-mcp-adapter.js";
+import type { ResolvedConversationCapabilityProfile } from "./conversation-capability-profile.js";
+import { applyFinalEffectiveToolPolicy } from "./embedded-agent-runner/effective-tool-policy.js";
+import { applyEmbeddedAttemptToolsAllow } from "./embedded-agent-runner/run/attempt-tool-construction-plan.js";
+import { normalizeToolName } from "./tool-policy.js";
+
+/** True when canonical conversation policy needs a concrete native MCP catalog. */
+export function requiresPreparedNativeMcpPolicy(params: {
+  capabilityProfile: ResolvedConversationCapabilityProfile;
+  runtimeToolsAllow?: string[];
+  mcpServers?: BundleMcpConfig["mcpServers"];
+}): boolean {
+  if (params.runtimeToolsAllow !== undefined) {
+    return true;
+  }
+  if (
+    Object.values(params.mcpServers ?? {}).some((server) => {
+      const toolFilter = isRecord(server.toolFilter) ? server.toolFilter : undefined;
+      return Array.isArray(toolFilter?.include) || Array.isArray(toolFilter?.exclude);
+    })
+  ) {
+    return true;
+  }
+  const policy = params.capabilityProfile.policy;
+  return (
+    policy.explicitToolDenylist.length > 0 ||
+    policy.explicitToolAllowlist.some((entry) => normalizeToolName(entry) !== "*")
+  );
+}
+
+function buildPolicyProjectionCatalog(catalog: McpToolCatalog): McpToolCatalog {
+  const policyTools = catalog.policyTools ?? [
+    ...catalog.tools,
+    ...(catalog.sessionDeniedTools ?? []),
+  ];
+  return {
+    ...catalog,
+    // Native clients can expose every raw MCP tool, including App-only tools.
+    // Remove only presentation visibility while assigning canonical safe names.
+    tools: policyTools.map(({ uiVisibility: _uiVisibility, ...tool }) => tool),
+    sessionDeniedTools: undefined,
+  };
+}
+
+export async function prepareNativeMcpPolicy(params: {
+  runtime: SessionMcpRuntime;
+  config?: OpenClawConfig;
+  workspaceDir: string;
+  capabilityProfile: ResolvedConversationCapabilityProfile;
+  runtimeToolsAllow?: string[];
+  warn: (message: string) => void;
+}): Promise<PreparedNativeMcpPolicy> {
+  params.runtime.markUsed();
+  const catalog = await params.runtime.getCatalog();
+  const policyCatalog = buildPolicyProjectionCatalog(catalog);
+  const allTools = buildBundleMcpToolsFromCatalog({ catalog: policyCatalog });
+  const runtimeAllowed = applyEmbeddedAttemptToolsAllow(allTools, params.runtimeToolsAllow, {
+    toolMeta: (tool) => getPluginToolMeta(tool),
+  });
+  const effectiveAllowed = applyFinalEffectiveToolPolicy({
+    bundledTools: runtimeAllowed,
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+    conversationCapabilityProfile: params.capabilityProfile,
+    warn: params.warn,
+  });
+  const effectiveAllowedNames = new Set(effectiveAllowed.map((tool) => tool.name));
+  const servers: PreparedNativeMcpPolicy["servers"] = {};
+
+  for (const tool of allTools) {
+    const mcp = getPluginToolMeta(tool)?.mcp;
+    if (!mcp || mcp.operation !== "tool") {
+      continue;
+    }
+    const excludedBy: Array<"configured-filter" | "session-override" | "effective-policy"> = [];
+    if (mcp.excludedByConfiguredFilter) {
+      excludedBy.push("configured-filter");
+    }
+    if (mcp.deniedBySession) {
+      excludedBy.push("session-override");
+    }
+    if (!effectiveAllowedNames.has(tool.name)) {
+      excludedBy.push("effective-policy");
+    }
+    const server = (servers[mcp.serverName] ??= {
+      serverName: mcp.serverName,
+      safeServerName: mcp.safeServerName,
+      allowedTools: [],
+      deniedTools: [],
+      tools: [],
+    });
+    const allowed = excludedBy.length === 0;
+    (allowed ? server.allowedTools : server.deniedTools).push(mcp.toolName);
+    server.tools.push({ rawName: mcp.toolName, safeName: tool.name, allowed, excludedBy });
+  }
+
+  for (const server of Object.values(servers)) {
+    server.allowedTools = [...new Set(server.allowedTools)].toSorted();
+    server.deniedTools = [...new Set(server.deniedTools)].toSorted();
+    server.tools.sort((left, right) => left.safeName.localeCompare(right.safeName));
+  }
+  return {
+    servers: Object.fromEntries(
+      Object.entries(servers).toSorted(([left], [right]) => left.localeCompare(right)),
+    ),
+    diagnostics: catalog.diagnostics ?? [],
+  };
+}

--- a/src/plugin-sdk/codex-mcp-projection.ts
+++ b/src/plugin-sdk/codex-mcp-projection.ts
@@ -6,4 +6,5 @@
 export {
   buildCodexUserMcpServersThreadConfigPatch,
   buildCodexUserMcpServersThreadConfigPatchForRuntime,
+  buildCodexUserMcpServersThreadConfigPatchForRun,
 } from "../agents/cli-runner/bundle-mcp-codex.js";

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -53,6 +53,7 @@ export type PluginToolMcpMeta = {
   safeServerName: string;
   toolName: string;
   operation: "tool" | "resources_list" | "resources_read" | "prompts_list" | "prompts_get";
+  excludedByConfiguredFilter?: true;
   deniedBySession?: true;
   node?: {
     id: string;


### PR DESCRIPTION
Closes #119310

## What Problem This Solves

Configured MCP servers handed directly to native Claude, Codex, and Gemini clients bypassed OpenClaw's complete layered `tools.allow` and `tools.deny` result. A tool excluded by durable, delegated, scheduled, sandbox, runtime, configured-server, or session policy could therefore appear and remain callable on the first native model turn, including fresh and resumed runs.

## Why This Change Was Made

Core now prepares one concrete raw/safe MCP policy fact from the session-owned catalog and canonical conversation capability profile before native startup. Backend adapters serialize that fact into their authoritative contracts: exact Claude denials and server omission, Codex `enabled_tools`/`disabled_tools`, and Gemini `includeTools`/`excludeTools`. This keeps policy ownership in OpenClaw, preserves catalog-assigned sanitized and collision-safe identities, merges existing restrictions monotonically, and fails closed before prompt submission when a restrictive result cannot be proven.

## User Impact

Per-agent, provider, group/sender, sandbox, subagent, inherited, scheduled, delegated, runtime, configured-filter, and session restrictions now constrain configured native MCP tools consistently. Allowed siblings remain available, denied tools are hidden and rejected by native enforcement, and an empty or unproven result stops with an actionable diagnostic. No new configuration surface is introduced.

## Evidence

The implementation rebased cleanly in final bounded publication attempt 2 onto immutable current main `9ff9aac71a8bd5ec900a799cb27c9f8b5c6448f0`; the final head is `4c8b7fe268e4cfc6b0c27f619c9319180f366bd7`. Upstream independently included the identical 515-to-513 `OPENCLAW_*` ratchet correction, so the issue diff retains only its 21 implementation, test, and documentation files. Exact-head focused Vitest proof passed 443 tests across Claude first-spawn argv/config, Codex CLI plus `thread/start` and `thread/resume`, Gemini settings, configured wildcard filters, exact runtime caps, server omission with an allowed sibling, additive session denial, catalog failure, empty intersections, and sanitized/truncated/colliding identities. Exact-head `node scripts/check-changed.mjs` passed all selected ratchet, format, SDK, boundary, dead-code, typecheck, lint, and runtime guard lanes on Blacksmith Testbox (action 30962640141). Exact-head remote `pnpm build` passed (action 30962629214). Exact-head structured autoreview reported no accepted or actionable finding with correctness confidence 0.94. Direct sibling Codex source inspection confirmed that exact `enabled_tools` and `disabled_tools` filter both listing and call boundaries.