### PR TITLE
fix(slack): Fix bad escaping in slack tool commentary

### DIFF
--- a/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
@@ -442,6 +442,7 @@ export function createSlackProgressRuntime(runtimeParams: {
       entry: account.config,
       lines: [...progressDraft.getSnapshot().lines],
       seed: progressSeed,
+      formatLine: formatSlackProgressDraftLine,
       narration: explanation,
       plan: steps,
     });

--- a/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
@@ -32,6 +32,7 @@ import {
   stopSlackStream,
   type SlackStreamSession,
 } from "../../streaming.js";
+import { escapeSlackMrkdwn } from "../mrkdwn.js";
 import {
   resolveExplicitSlackProgressTitle,
   resolveSlackStreamRecipientTeamId,

--- a/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
@@ -322,6 +322,7 @@ export function createSlackProgressRuntime(runtimeParams: {
     mode: slackStreaming.mode,
     active: progressDraftActive,
     seed: progressSeed,
+    formatLine: formatSlackProgressDraftLine,
     reasoningLinePrefix: "🧠 ",
     commentaryLinePrefix: "💬 ",
     reasoningGate: previewToolProgressEnabled,
@@ -653,4 +654,8 @@ export function createSlackProgressRuntime(runtimeParams: {
     },
     shouldYieldDraftProgress: () => shouldYieldDraftProgress(),
   };
+}
+
+function formatSlackProgressDraftLine(line: string): string {
+  return /^(?:🧠|💬)\s/u.test(line) ? line : escapeSlackMrkdwn(line);
 }

--- a/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
@@ -32,7 +32,6 @@ import {
   stopSlackStream,
   type SlackStreamSession,
 } from "../../streaming.js";
-import { escapeSlackMrkdwn } from "../mrkdwn.js";
 import {
   resolveExplicitSlackProgressTitle,
   resolveSlackStreamRecipientTeamId,
@@ -322,7 +321,6 @@ export function createSlackProgressRuntime(runtimeParams: {
     mode: slackStreaming.mode,
     active: progressDraftActive,
     seed: progressSeed,
-    formatLine: escapeSlackMrkdwn,
     reasoningLinePrefix: "🧠 ",
     commentaryLinePrefix: "💬 ",
     reasoningGate: previewToolProgressEnabled,
@@ -442,7 +440,6 @@ export function createSlackProgressRuntime(runtimeParams: {
       entry: account.config,
       lines: [...progressDraft.getSnapshot().lines],
       seed: progressSeed,
-      formatLine: escapeSlackMrkdwn,
       narration: explanation,
       plan: steps,
     });

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -3749,6 +3749,37 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expect(draftStream.update).toHaveBeenCalledTimes(updateCount);
   });
 
+  it("preserves Markdown in Slack commentary drafts for the outbound renderer", async () => {
+    const draftStream = createDraftStreamStub();
+    createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
+    mockedSlackStreamingMode = "progress";
+    mockedSlackDraftMode = "status_final";
+    mockedDispatchSequence = [];
+    mockedReplyOptionEvents = [
+      {
+        kind: "item",
+        itemKind: "preamble",
+        itemId: "preamble-1",
+        progressText: "I’m using the `monorepo` skill on Linux x86_64.",
+      },
+    ];
+
+    await dispatchPreparedSlackMessage(
+      createPreparedSlackMessage({
+        accountConfig: {
+          streaming: {
+            mode: "progress",
+            progress: { label: false, commentary: true, toolProgress: false },
+          },
+        },
+      }),
+    );
+
+    expect(draftStream.update).toHaveBeenLastCalledWith(
+      "💬 I’m using the `monorepo` skill on Linux x86_64.",
+    );
+  });
+
   it("uses the enterprise event client for Slack commentary drafts", async () => {
     const draftStream = createDraftStreamStub();
     createSlackDraftStreamMock.mockReturnValueOnce(draftStream);

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -1968,7 +1968,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
       }),
     );
 
-    expect(draftStream.update).toHaveBeenLastCalledWith(
+    expect(draftStream.update).toHaveBeenCalledWith(
       [
         "Shelling",
         "",

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -1966,7 +1966,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     );
 
     expect(draftStream.update).toHaveBeenLastCalledWith(
-      ["Shelling", "", "• exec", "🧠 \\_Reading the Slack handler\\_"].join("\n"),
+      ["Shelling", "", "• exec", "🧠 _Reading the Slack handler_"].join("\n"),
     );
     const updates = draftStream.update.mock.calls.map((call) => String(call[0]));
     expect(updates.join("\n")).not.toContain("Reasoning");
@@ -1995,7 +1995,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     );
 
     expect(draftStream.update).toHaveBeenLastCalledWith(
-      ["Shelling", "", "• exec", "🧠 \\_Reading Checking\\_"].join("\n"),
+      ["Shelling", "", "• exec", "🧠 _Reading Checking_"].join("\n"),
     );
     const updates = draftStream.update.mock.calls.map((call) => String(call[0]));
     expect(updates.join("\n")).not.toContain("Checking Reading");
@@ -2022,7 +2022,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     );
 
     expect(draftStream.update).toHaveBeenLastCalledWith(
-      ["Shelling", "", "🧠 \\_Reading Checking\\_"].join("\n"),
+      ["Shelling", "", "🧠 _Reading Checking_"].join("\n"),
     );
     const updates = draftStream.update.mock.calls.map((call) => String(call[0]));
     expect(updates.join("\n")).toContain("Reading Checking");
@@ -2049,7 +2049,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     );
 
     expect(draftStream.update).toHaveBeenLastCalledWith(
-      ["Shelling", "", "🧠 \\_Thinking about Slack preview state\\_"].join("\n"),
+      ["Shelling", "", "🧠 _Thinking about Slack preview state_"].join("\n"),
     );
   });
 

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -1946,40 +1946,6 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     );
   });
 
-  it("keeps tool progress escaped when a plan refreshes a replace-mode draft", async () => {
-    const draftStream = createDraftStreamStub();
-    createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
-    mockedSlackStreamingMode = "progress";
-    mockedSlackDraftMode = "replace";
-    mockedDispatchSequence = [];
-    mockedReplyOptionEvents = [
-      { kind: "item", progressText: "ran <!here> <@U123> *bold* `code` & done" },
-      {
-        kind: "plan",
-        phase: "update",
-        explanation: "Following the checklist.",
-        steps: [{ step: "Patch", status: "in_progress" }],
-      },
-    ];
-
-    await dispatchPreparedSlackMessage(
-      createPreparedSlackMessage({
-        accountConfig: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
-      }),
-    );
-
-    expect(draftStream.update).toHaveBeenCalledWith(
-      [
-        "Shelling",
-        "",
-        "Following the checklist.",
-        "",
-        "• ran &lt;!here&gt; &lt;@U123&gt; \\*bold\\* \\`code\\` &amp; done",
-        "▸ Patch",
-      ].join("\n"),
-    );
-  });
-
   it("shows reasoning text in Slack progress draft previews", async () => {
     const draftStream = createDraftStreamStub();
     createSlackDraftStreamMock.mockReturnValueOnce(draftStream);

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -1946,6 +1946,40 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     );
   });
 
+  it("keeps tool progress escaped when a plan refreshes a replace-mode draft", async () => {
+    const draftStream = createDraftStreamStub();
+    createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
+    mockedSlackStreamingMode = "progress";
+    mockedSlackDraftMode = "replace";
+    mockedDispatchSequence = [];
+    mockedReplyOptionEvents = [
+      { kind: "item", progressText: "ran <!here> <@U123> *bold* `code` & done" },
+      {
+        kind: "plan",
+        phase: "update",
+        explanation: "Following the checklist.",
+        steps: [{ step: "Patch", status: "in_progress" }],
+      },
+    ];
+
+    await dispatchPreparedSlackMessage(
+      createPreparedSlackMessage({
+        accountConfig: { streaming: { mode: "progress", progress: { label: "Shelling" } } },
+      }),
+    );
+
+    expect(draftStream.update).toHaveBeenLastCalledWith(
+      [
+        "Shelling",
+        "",
+        "Following the checklist.",
+        "",
+        "• ran &lt;!here&gt; &lt;@U123&gt; \\*bold\\* \\`code\\` &amp; done",
+        "▸ Patch",
+      ].join("\n"),
+    );
+  });
+
   it("shows reasoning text in Slack progress draft previews", async () => {
     const draftStream = createDraftStreamStub();
     createSlackDraftStreamMock.mockReturnValueOnce(draftStream);

--- a/extensions/slack/src/progress-blocks.test.ts
+++ b/extensions/slack/src/progress-blocks.test.ts
@@ -200,6 +200,35 @@ describe("buildSlackProgressDraftBlocks", () => {
     ).toEqual([legacyLineBlock("• *Preamble*", "—"), legacyLineBlock("🛠️ *Exec*", "run tests")]);
   });
 
+  it("renders authored commentary Markdown in legacy rich draft details", () => {
+    expect(
+      buildSlackProgressDraftBlocks({
+        lines: [
+          {
+            id: "commentary:preamble-1",
+            kind: "item",
+            label: "Commentary",
+            text: "💬 I’m using the `monorepo` skill on **Linux x86_64**.",
+            prefix: false,
+          },
+          {
+            id: "reasoning",
+            kind: "item",
+            label: "Reasoning",
+            text: "_Reading the Slack handler_",
+            prefix: false,
+          },
+        ],
+      }),
+    ).toEqual([
+      legacyLineBlock(
+        "• *Commentary*",
+        "I’m using the `monorepo` skill on *Linux x86_64*.",
+      ),
+      legacyLineBlock("• *Reasoning*", "_Reading the Slack handler_"),
+    ]);
+  });
+
   it("does not emit legacy rich draft blocks when there are no lines or heading", () => {
     expect(
       buildSlackProgressDraftBlocks({

--- a/extensions/slack/src/progress-blocks.test.ts
+++ b/extensions/slack/src/progress-blocks.test.ts
@@ -221,10 +221,7 @@ describe("buildSlackProgressDraftBlocks", () => {
         ],
       }),
     ).toEqual([
-      legacyLineBlock(
-        "• *Commentary*",
-        "I’m using the `monorepo` skill on *Linux x86_64*.",
-      ),
+      legacyLineBlock("• *Commentary*", "I’m using the `monorepo` skill on *Linux x86_64*."),
       legacyLineBlock("• *Reasoning*", "_Reading the Slack handler_"),
     ]);
   });

--- a/extensions/slack/src/progress-blocks.test.ts
+++ b/extensions/slack/src/progress-blocks.test.ts
@@ -208,7 +208,7 @@ describe("buildSlackProgressDraftBlocks", () => {
             id: "commentary:preamble-1",
             kind: "item",
             label: "Commentary",
-            text: "💬 I’m using the `monorepo` skill on **Linux x86_64**.",
+            text: "💬 Rendering the `sample-widget` fixture on **example.test**.",
             prefix: false,
           },
           {
@@ -221,7 +221,7 @@ describe("buildSlackProgressDraftBlocks", () => {
         ],
       }),
     ).toEqual([
-      legacyLineBlock("• *Commentary*", "I’m using the `monorepo` skill on *Linux x86_64*."),
+      legacyLineBlock("• *Commentary*", "Rendering the `sample-widget` fixture on *example.test*."),
       legacyLineBlock("• *Reasoning*", "_Reading the Slack handler_"),
     ]);
   });

--- a/extensions/slack/src/progress-blocks.ts
+++ b/extensions/slack/src/progress-blocks.ts
@@ -8,6 +8,7 @@ import {
   formatPlanChecklistLines,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { SLACK_MAX_BLOCKS } from "./blocks-input.js";
+import { normalizeSlackOutboundText } from "./format.js";
 import { escapeSlackMrkdwn } from "./monitor/mrkdwn.js";
 import { truncateSlackText } from "./truncate.js";
 
@@ -77,9 +78,20 @@ function legacyLineTitle(line: ChannelProgressDraftLine): string {
   return `${line.icon ?? "•"} *${escapeSlackMrkdwn(line.label)}*`;
 }
 
+function isAuthoredProgressLine(line: ChannelProgressDraftLine): boolean {
+  return line.id === "reasoning" || line.id?.startsWith("commentary:") === true;
+}
+
 function legacyLineDetail(line: ChannelProgressDraftLine, maxChars: number): string {
   const detail = lineDetailParts(line).join(" · ");
-  return detail ? escapeSlackMrkdwn(compactDetail(detail, maxChars)) : "—";
+  if (detail) {
+    return escapeSlackMrkdwn(compactDetail(detail, maxChars));
+  }
+  if (isAuthoredProgressLine(line)) {
+    const text = line.text.replace(/^(?:🧠|💬)\s+/u, "");
+    return normalizeSlackOutboundText(compactDetail(text, maxChars));
+  }
+  return "—";
 }
 
 function lineTaskTitle(line: ChannelProgressDraftLine, maxLineChars: number): string {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Slack users viewing agent progress would see literal backslashes around Markdown syntax, such as ``\`monorepo\``` and `x86\_64`, when commentary contained inline code or underscores.

Before:

<img width="641" height="64" alt="Screenshot 2026-08-04 at 17 24 27" src="https://github.com/user-attachments/assets/a2fdc478-cab3-403f-a50e-cbec52566910" />

After:

<img width="705" height="106" alt="Screenshot 2026-08-04 at 17 22 27" src="https://github.com/user-attachments/assets/53527e15-ca8a-4ad0-9192-cd8f56c9c819" />

## Why This Change Was Made

Slack progress drafts were escaping each line before the normal outbound Markdown-to-mrkdwn renderer processed the complete draft. This change preserves source Markdown for authored `💬` commentary and `🧠` reasoning until that established renderer handles it once, while retaining literal escaping for ordinary tool-progress labels.

The same source policy now applies when plan updates rebuild text drafts. Legacy rich Block Kit drafts render authored commentary and reasoning from their structured source text instead of showing an em dash.

## User Impact

Slack progress commentary now renders inline code, underscores, emphasis, and blockquotes without stray backslashes. Tool-progress labels remain literal and cannot turn their content into Slack formatting.

Release note: Fix Slack progress drafts showing literal Markdown escape characters.

## Evidence

- Before: a progress line containing `` `monorepo` `` and `x86_64` displayed as ``\`monorepo\``` and `x86\_64` in Slack.
- Added dispatch-boundary regression coverage requiring the commentary draft transport to receive original Markdown unchanged.
- Added rich Block Kit coverage for authored commentary and reasoning, using synthetic `sample-widget` / `example.test` data.
- Existing tool-progress escaping coverage remains passing, and plan refreshes use the same selective formatter.
- Exact-head focused Slack tests: 2 files, 163 passed, 0 failed.
- Exact-head `oxfmt --check` and `git diff --check` pass.
- Managed staging validation on 2026-08-04: the live text-draft progress line rendered without the stray backslashes from the reported screenshot and completed with the expected tagged final reply.
- Autoreview: clean, no accepted or actionable findings; 0.99 correctness confidence.

AI-assisted: yes. I reviewed and understand the change.
