### PR TITLE
fix(qa): follow durable finals after streamed previews

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog-causality.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-causality.test.ts
@@ -267,15 +267,24 @@ describe("qa scenario catalog causality", () => {
   ] as const)("isolates $scenarioId durable lifecycle evidence by account", async (fixture) => {
     const scenario = requireFlowScenario(readQaScenarioById(fixture.scenarioId));
     const actions = scenario.execution.flow?.steps[0]?.actions ?? [];
-    const durableWait = actions.find(
+    const durableWaitIndex = actions.findIndex(
       (action) =>
         (action as { call?: string }).call === "waitForCondition" &&
         (action as { saveAs?: string }).saveAs === fixture.saveAs,
     );
-    expect(durableWait, fixture.scenarioId).toBeDefined();
-    if (!durableWait) {
-      throw new Error(`missing durable lifecycle wait for ${fixture.scenarioId}`);
+    const cardinalityAssertIndex = actions.findIndex((action) =>
+      readFlowAssertExpression(action).includes(
+        fixture.scenarioId === "memory-tools-channel-context"
+          ? "visibleChannelOutbounds.length === 1"
+          : "completionMessages.length === 1",
+      ),
+    );
+    expect(durableWaitIndex, fixture.scenarioId).toBeGreaterThanOrEqual(0);
+    expect(cardinalityAssertIndex, fixture.scenarioId).toBeGreaterThan(durableWaitIndex);
+    if (durableWaitIndex < 0 || cardinalityAssertIndex <= durableWaitIndex) {
+      throw new Error(`missing durable lifecycle assertion path for ${fixture.scenarioId}`);
     }
+    const postWaitAssertionPath = actions.slice(durableWaitIndex, cardinalityAssertIndex + 1);
 
     const config = scenario.execution.config ?? {};
     const conversationId = String(config[fixture.conversationKey]);
@@ -298,7 +307,7 @@ describe("qa scenario catalog causality", () => {
               actions: [
                 { set: "outboundStartIndex", value: { expr: "0" } },
                 { set: fixture.cursorName, value: { expr: "0" } },
-                durableWait,
+                ...postWaitAssertionPath,
                 {
                   assert: {
                     expr: `${fixture.saveAs}.message.accountId === transport.accountId`,

--- a/extensions/qa-lab/src/scenario-catalog-causality.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-causality.test.ts
@@ -227,4 +227,21 @@ describe("qa scenario catalog causality", () => {
       }
     },
   );
+
+  it.each([
+    ["memory-tools-channel-context", "durableChannelLifecycle", 30000],
+    ["agent-progress-evidence", "durableCompletionLifecycle", 60000],
+  ] as const)("keeps the policy-aware durable delivery budget for %s", (scenarioId, saveAs, ms) => {
+    const scenario = requireFlowScenario(readQaScenarioById(scenarioId));
+    const actions = scenario.execution.flow?.steps[0]?.actions ?? [];
+    const durableWait = actions.find(
+      (action) =>
+        (action as { call?: string }).call === "waitForCondition" &&
+        (action as { saveAs?: string }).saveAs === saveAs,
+    );
+
+    expect(durableWait, scenarioId).toMatchObject({
+      args: [expect.any(Object), { expr: `liveTurnTimeoutMs(env, ${ms})` }],
+    });
+  });
 });

--- a/extensions/qa-lab/src/scenario-catalog-causality.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-causality.test.ts
@@ -296,6 +296,19 @@ describe("qa scenario catalog causality", () => {
       state.deleteMessage({ accountId, messageId: preview.id });
       state.addOutboundMessage({ accountId, to: target, text: marker });
     }
+    const foreignKind = fixture.targetPrefix === "dm" ? "channel" : "dm";
+    const foreignKindTarget = `${foreignKind}:${conversationId}`;
+    const foreignKindPreview = state.addOutboundMessage({
+      accountId: "qa-channel",
+      to: foreignKindTarget,
+      text: marker,
+    });
+    state.deleteMessage({ accountId: "qa-channel", messageId: foreignKindPreview.id });
+    state.addOutboundMessage({
+      accountId: "qa-channel",
+      to: foreignKindTarget,
+      text: marker,
+    });
 
     await expect(
       runLoadedScenarioFlow(fixture.scenarioId, {

--- a/extensions/qa-lab/src/scenario-catalog-causality.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-causality.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
+import { createQaBusState } from "./bus-state.js";
 import { readQaScenarioById, readQaScenarioExecutionConfig } from "./scenario-catalog.js";
 import { readFlowAssertExpression, requireFlowScenario } from "./scenario-catalog.test-utils.js";
+import { runLoadedScenarioFlow } from "./scenario-flow-runner.test-support.js";
 
 describe("qa scenario catalog causality", () => {
   it("loads live gateway sentinel scenarios for harness self-health", () => {
@@ -243,5 +245,70 @@ describe("qa scenario catalog causality", () => {
     expect(durableWait, scenarioId).toMatchObject({
       args: [expect.any(Object), { expr: `liveTurnTimeoutMs(env, ${ms})` }],
     });
+  });
+
+  it.each([
+    {
+      scenarioId: "memory-tools-channel-context",
+      saveAs: "durableChannelLifecycle",
+      cursorName: "busCursorBeforeInbound",
+      conversationKey: "channelId",
+      markerKey: "expectedNeedle",
+      targetPrefix: "channel",
+    },
+    {
+      scenarioId: "agent-progress-evidence",
+      saveAs: "durableCompletionLifecycle",
+      cursorName: "busCursorBefore",
+      conversationKey: "conversationId",
+      markerKey: "completionText",
+      targetPrefix: "dm",
+    },
+  ] as const)("isolates $scenarioId durable lifecycle evidence by account", async (fixture) => {
+    const scenario = requireFlowScenario(readQaScenarioById(fixture.scenarioId));
+    const actions = scenario.execution.flow?.steps[0]?.actions ?? [];
+    const durableWait = actions.find(
+      (action) =>
+        (action as { call?: string }).call === "waitForCondition" &&
+        (action as { saveAs?: string }).saveAs === fixture.saveAs,
+    );
+    expect(durableWait, fixture.scenarioId).toBeDefined();
+    if (!durableWait) {
+      throw new Error(`missing durable lifecycle wait for ${fixture.scenarioId}`);
+    }
+
+    const config = scenario.execution.config ?? {};
+    const conversationId = String(config[fixture.conversationKey]);
+    const marker = String(config[fixture.markerKey]);
+    const target = `${fixture.targetPrefix}:${conversationId}`;
+    const state = createQaBusState();
+    for (const accountId of ["foreign", "qa-channel"]) {
+      const preview = state.addOutboundMessage({ accountId, to: target, text: marker });
+      state.deleteMessage({ accountId, messageId: preview.id });
+      state.addOutboundMessage({ accountId, to: target, text: marker });
+    }
+
+    await expect(
+      runLoadedScenarioFlow(fixture.scenarioId, {
+        state,
+        flow: {
+          steps: [
+            {
+              name: "keeps foreign account lifecycle evidence isolated",
+              actions: [
+                { set: "outboundStartIndex", value: { expr: "0" } },
+                { set: fixture.cursorName, value: { expr: "0" } },
+                durableWait,
+                {
+                  assert: {
+                    expr: `${fixture.saveAs}.message.accountId === transport.accountId`,
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    ).resolves.toMatchObject({ status: "pass" });
   });
 });

--- a/extensions/qa-lab/src/scenario-catalog-causality.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-causality.test.ts
@@ -144,24 +144,30 @@ describe("qa scenario catalog causality", () => {
       "thread-memory-isolation",
       "poll",
       "finalRequest.toolOutputCallId === searchResultRequest.plannedToolCallId",
+      null,
     ],
     [
       "memory-tools-channel-context",
       "poll",
       "finalRequest.toolOutputCallId === searchResultRequest.plannedToolCallId",
+      "durableChannelLifecycle",
     ],
     [
       "agent-tool-consumption",
       "immediate",
       "getResultRequest.toolOutputCallId === searchResultRequest.plannedToolCallId",
+      null,
     ],
   ] as const)(
     "asserts the complete memory tool chain before %s delivery",
-    (scenarioId, requestCollectionMode, finalLinkNeedle) => {
+    (scenarioId, requestCollectionMode, finalLinkNeedle, durableWaitSaveAs) => {
       const scenario = requireFlowScenario(readQaScenarioById(scenarioId));
       const actions = scenario.execution.flow?.steps[0]?.actions ?? [];
-      const outboundIndex = actions.findIndex(
-        (action) => (action as { call?: string }).call === "waitForOutboundMessage",
+      const outboundIndex = actions.findIndex((action) =>
+        durableWaitSaveAs
+          ? (action as { call?: string }).call === "waitForCondition" &&
+            (action as { saveAs?: string }).saveAs === durableWaitSaveAs
+          : (action as { call?: string }).call === "waitForOutboundMessage",
       );
       const requestCollectionIndex = actions.findIndex((action) =>
         requestCollectionMode === "poll"
@@ -192,6 +198,15 @@ describe("qa scenario catalog causality", () => {
       expect(searchResultAssertIndex, scenarioId).toBeGreaterThan(searchPlanAssertIndex);
       expect(finalRequestAssertIndex, scenarioId).toBeGreaterThan(searchResultAssertIndex);
       expect(outboundIndex, scenarioId).toBeGreaterThan(finalRequestAssertIndex);
+
+      if (durableWaitSaveAs) {
+        const durableWait = actions[outboundIndex] as
+          | { args?: Array<{ lambda?: { expr?: string } }> }
+          | undefined;
+        const durableExpr = durableWait?.args?.[0]?.lambda?.expr ?? "";
+        expect(durableExpr, scenarioId).toContain("event.cursor < finalSent.cursor");
+        expect(durableExpr, scenarioId).toContain("event.cursor < previewRetired.cursor");
+      }
 
       if (requestCollectionMode === "poll") {
         const requestPoll = actions[requestCollectionIndex] as

--- a/qa/scenarios/memory/active-memory-preprompt-recall.yaml
+++ b/qa/scenarios/memory/active-memory-preprompt-recall.yaml
@@ -127,7 +127,8 @@ flow:
                     await fs.rm(toggleStorePath, { force: true });
                     await fs.mkdir(path.dirname(toggleStorePath), { recursive: true });
                     await fs.writeFile(toggleStorePath, `${JSON.stringify({ sessions: { [baselineSessionKey]: { disabled: true, updatedAt: Date.now() } } }, null, 2)}\n`, "utf8");
-                    const doctorFixOutput = await runQaCli(env, ["doctor", "--fix", "--yes"], {
+                    // This automation owns a safe state migration, so use doctor's non-interactive contract.
+                    const doctorFixOutput = await runQaCli(env, ["doctor", "--fix", "--yes", "--non-interactive"], {
                       timeoutMs: liveTurnTimeoutMs(env, 60000),
                     });
                     await fs.writeFile(doctorOutputPath, doctorFixOutput, "utf8");

--- a/qa/scenarios/memory/active-memory-preprompt-recall.yaml
+++ b/qa/scenarios/memory/active-memory-preprompt-recall.yaml
@@ -174,11 +174,12 @@ flow:
             expr: "normalizeLowercaseStringOrEmpty(baselineReply.text)"
         - set: baselineMockRequests
           value:
-            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBeforeBaseline}`))"
+            # Heartbeats share this mock provider, so bind the trace to this scenario's turn.
+            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBeforeBaseline}`)).filter((request) => String(request.allInputText ?? '').includes(config.turnMarker))"
         - assert:
             expr: baselineMockRequests.length === 1
             message:
-              expr: "`disabled baseline expected exactly one model request: ${JSON.stringify(baselineMockRequests)}`"
+              expr: "`disabled baseline expected exactly one marked model request: ${JSON.stringify(baselineMockRequests)}`"
         - set: baselineMainRequest
           value:
             expr: baselineMockRequests[0]
@@ -243,7 +244,8 @@ flow:
             message: active memory recall left a transient SQLite session behind
         - set: activeRequests
           value:
-            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBeforeActive}`))"
+            # The marker propagates through the helper context and excludes unrelated background turns.
+            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBeforeActive}`)).filter((request) => String(request.allInputText ?? '').includes(config.turnMarker))"
         - assert:
             expr: activeRequests.length === 4
             message:

--- a/qa/scenarios/memory/active-memory-preprompt-recall.yaml
+++ b/qa/scenarios/memory/active-memory-preprompt-recall.yaml
@@ -127,8 +127,7 @@ flow:
                     await fs.rm(toggleStorePath, { force: true });
                     await fs.mkdir(path.dirname(toggleStorePath), { recursive: true });
                     await fs.writeFile(toggleStorePath, `${JSON.stringify({ sessions: { [baselineSessionKey]: { disabled: true, updatedAt: Date.now() } } }, null, 2)}\n`, "utf8");
-                    // This automation owns a safe state migration, so use doctor's non-interactive contract.
-                    const doctorFixOutput = await runQaCli(env, ["doctor", "--fix", "--yes", "--non-interactive"], {
+                    const doctorFixOutput = await runQaCli(env, ["doctor", "--fix", "--yes"], {
                       timeoutMs: liveTurnTimeoutMs(env, 60000),
                     });
                     await fs.writeFile(doctorOutputPath, doctorFixOutput, "utf8");
@@ -175,12 +174,11 @@ flow:
             expr: "normalizeLowercaseStringOrEmpty(baselineReply.text)"
         - set: baselineMockRequests
           value:
-            # Heartbeats share this mock provider, so bind the trace to this scenario's turn.
-            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBeforeBaseline}`)).filter((request) => String(request.allInputText ?? '').includes(config.turnMarker))"
+            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBeforeBaseline}`))"
         - assert:
             expr: baselineMockRequests.length === 1
             message:
-              expr: "`disabled baseline expected exactly one marked model request: ${JSON.stringify(baselineMockRequests)}`"
+              expr: "`disabled baseline expected exactly one model request: ${JSON.stringify(baselineMockRequests)}`"
         - set: baselineMainRequest
           value:
             expr: baselineMockRequests[0]
@@ -245,8 +243,7 @@ flow:
             message: active memory recall left a transient SQLite session behind
         - set: activeRequests
           value:
-            # The marker propagates through the helper context and excludes unrelated background turns.
-            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBeforeActive}`)).filter((request) => String(request.allInputText ?? '').includes(config.turnMarker))"
+            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBeforeActive}`))"
         - assert:
             expr: activeRequests.length === 4
             message:

--- a/qa/scenarios/memory/memory-tools-channel-context.yaml
+++ b/qa/scenarios/memory/memory-tools-channel-context.yaml
@@ -144,7 +144,7 @@ flow:
                     const previewSent = events.find((event) => event.kind === "outbound-message" && event.message.id === previewRetired.message.id && event.cursor < previewRetired.cursor);
                     return previewSent ? { message: candidate, previewId: previewRetired.message.id, finalId: candidate.id, previewSentCursor: previewSent.cursor, previewDeletedCursor: previewRetired.cursor, finalSentCursor: finalSent.cursor } : undefined;
                   })()
-            - 10000
+            - expr: liveTurnTimeoutMs(env, 30000)
         - set: durableChannelOutbound
           value:
             expr: durableChannelLifecycle.message

--- a/qa/scenarios/memory/memory-tools-channel-context.yaml
+++ b/qa/scenarios/memory/memory-tools-channel-context.yaml
@@ -127,7 +127,7 @@ flow:
             message:
               expr: "`final request did not consume the matching successful memory_get result: ${JSON.stringify(finalRequest)}`"
         - call: waitForCondition
-          saveAs: durableChannelOutbound
+          saveAs: durableChannelLifecycle
           args:
             - lambda:
                 expr: |-
@@ -141,10 +141,13 @@ flow:
                     if (!finalSent) return undefined;
                     const previewRetired = events.find((event) => event.kind === "message-deleted" && event.message.id !== candidate.id && event.cursor < finalSent.cursor);
                     if (!previewRetired) return undefined;
-                    const previewSent = events.some((event) => event.kind === "outbound-message" && event.message.id === previewRetired.message.id && event.cursor < previewRetired.cursor);
-                    return previewSent ? candidate : undefined;
+                    const previewSent = events.find((event) => event.kind === "outbound-message" && event.message.id === previewRetired.message.id && event.cursor < previewRetired.cursor);
+                    return previewSent ? { message: candidate, previewId: previewRetired.message.id, finalId: candidate.id, previewSentCursor: previewSent.cursor, previewDeletedCursor: previewRetired.cursor, finalSentCursor: finalSent.cursor } : undefined;
                   })()
             - 10000
+        - set: durableChannelOutbound
+          value:
+            expr: durableChannelLifecycle.message
         - set: visibleChannelOutbounds
           value:
             expr: "state.getSnapshot().messages.slice(outboundStartIndex).filter((message) => message.direction === 'outbound' && !message.deleted && message.conversation.id === config.channelId && message.conversation.kind === 'channel')"
@@ -157,4 +160,4 @@ flow:
             expr: "(durableChannelOutbound.text.match(new RegExp(config.expectedNeedle, 'g')) ?? []).length === 1"
             message:
               expr: "`final QA-room reply must contain ${config.expectedNeedle} exactly once: ${durableChannelOutbound.text}`"
-      detailsExpr: "`${durableChannelOutbound.text}; path=${config.expectedMemoryPath}; matched=${searchResultRequest.toolOutputCallId === searchPlanRequest.plannedToolCallId}; room=${config.channelId}`"
+      detailsExpr: "`${durableChannelOutbound.text}; path=${config.expectedMemoryPath}; matched=${searchResultRequest.toolOutputCallId === searchPlanRequest.plannedToolCallId}; room=${config.channelId}; lifecycle=${JSON.stringify({ previewId: durableChannelLifecycle.previewId, previewSentCursor: durableChannelLifecycle.previewSentCursor, previewDeletedCursor: durableChannelLifecycle.previewDeletedCursor, finalId: durableChannelLifecycle.finalId, finalSentCursor: durableChannelLifecycle.finalSentCursor })}`"

--- a/qa/scenarios/memory/memory-tools-channel-context.yaml
+++ b/qa/scenarios/memory/memory-tools-channel-context.yaml
@@ -150,7 +150,7 @@ flow:
             expr: durableChannelLifecycle.message
         - set: visibleChannelOutbounds
           value:
-            expr: "state.getSnapshot().messages.slice(outboundStartIndex).filter((message) => message.direction === 'outbound' && !message.deleted && message.conversation.id === config.channelId && message.conversation.kind === 'channel')"
+            expr: "state.getSnapshot().messages.slice(outboundStartIndex).filter((message) => message.accountId === transport.accountId && message.direction === 'outbound' && !message.deleted && message.conversation.id === config.channelId && message.conversation.kind === 'channel')"
         - assert:
             # Tool-backed finals replace their streamed preview; prove sent -> deleted -> final ordering first.
             expr: "visibleChannelOutbounds.length === 1 && visibleChannelOutbounds[0].id === durableChannelOutbound.id"

--- a/qa/scenarios/memory/memory-tools-channel-context.yaml
+++ b/qa/scenarios/memory/memory-tools-channel-context.yaml
@@ -133,10 +133,10 @@ flow:
                 expr: |-
                   (() => {
                     const snapshot = state.getSnapshot();
-                    const visible = snapshot.messages.slice(outboundStartIndex).filter((message) => message.direction === "outbound" && !message.deleted && message.conversation.id === config.channelId && message.conversation.kind === "channel" && message.text.includes(config.expectedNeedle));
+                    const visible = snapshot.messages.slice(outboundStartIndex).filter((message) => message.accountId === transport.accountId && message.direction === "outbound" && !message.deleted && message.conversation.id === config.channelId && message.conversation.kind === "channel" && message.text.includes(config.expectedNeedle));
                     if (visible.length !== 1) return undefined;
                     const candidate = visible[0];
-                    const events = snapshot.events.filter((event) => event.cursor > busCursorBeforeInbound && "message" in event && event.message.direction === "outbound" && event.message.conversation.id === config.channelId && event.message.text.includes(config.expectedNeedle));
+                    const events = snapshot.events.filter((event) => event.cursor > busCursorBeforeInbound && "message" in event && event.message.accountId === transport.accountId && event.message.direction === "outbound" && event.message.conversation.id === config.channelId && event.message.text.includes(config.expectedNeedle));
                     const finalSent = events.find((event) => event.kind === "outbound-message" && event.message.id === candidate.id);
                     if (!finalSent) return undefined;
                     const previewRetired = events.find((event) => event.kind === "message-deleted" && event.message.id !== candidate.id && event.cursor < finalSent.cursor);

--- a/qa/scenarios/memory/memory-tools-channel-context.yaml
+++ b/qa/scenarios/memory/memory-tools-channel-context.yaml
@@ -139,11 +139,15 @@ flow:
           value:
             expr: "state.getSnapshot().messages.slice(outboundStartIndex).filter((message) => message.direction === 'outbound' && !message.deleted && message.conversation.id === config.channelId && message.conversation.kind === 'channel')"
         - assert:
-            expr: "visibleChannelOutbounds.length === 1 && visibleChannelOutbounds[0].id === outbound.id"
+            # Tool-backed finals replace their streamed preview; only the durable visible reply is contractual.
+            expr: visibleChannelOutbounds.length === 1
             message:
               expr: "`expected exactly one visible QA-room reply after the ordered memory result: ${JSON.stringify(visibleChannelOutbounds)}`"
+        - set: visibleChannelOutbound
+          value:
+            expr: visibleChannelOutbounds[0]
         - assert:
-            expr: "(outbound.text.match(new RegExp(config.expectedNeedle, 'g')) ?? []).length === 1"
+            expr: "(visibleChannelOutbound.text.match(new RegExp(config.expectedNeedle, 'g')) ?? []).length === 1"
             message:
-              expr: "`final QA-room reply must contain ${config.expectedNeedle} exactly once: ${outbound.text}`"
-      detailsExpr: "`${outbound.text}; path=${config.expectedMemoryPath}; matched=${searchResultRequest.toolOutputCallId === searchPlanRequest.plannedToolCallId}; room=${config.channelId}`"
+              expr: "`final QA-room reply must contain ${config.expectedNeedle} exactly once: ${visibleChannelOutbound.text}`"
+      detailsExpr: "`${visibleChannelOutbound.text}; path=${config.expectedMemoryPath}; matched=${searchResultRequest.toolOutputCallId === searchPlanRequest.plannedToolCallId}; room=${config.channelId}`"

--- a/qa/scenarios/memory/memory-tools-channel-context.yaml
+++ b/qa/scenarios/memory/memory-tools-channel-context.yaml
@@ -79,6 +79,9 @@ flow:
         - set: outboundStartIndex
           value:
             expr: "state.getSnapshot().messages.length"
+        - set: busCursorBeforeInbound
+          value:
+            expr: "state.getSnapshot().cursor"
         - sendInbound:
             conversation:
               id:
@@ -123,31 +126,32 @@ flow:
             expr: "finalRequest.cursor > searchResultRequest.cursor && finalRequest.toolOutputCallId === searchResultRequest.plannedToolCallId && finalRequest.toolOutputStructuredError !== true && String(finalRequest.toolOutput ?? '').includes(config.expectedMemoryPath) && String(finalRequest.toolOutput ?? '').includes(config.expectedNeedle) && !finalRequest.plannedToolName"
             message:
               expr: "`final request did not consume the matching successful memory_get result: ${JSON.stringify(finalRequest)}`"
-        - call: waitForOutboundMessage
-          saveAs: outbound
+        - call: waitForCondition
+          saveAs: durableChannelOutbound
           args:
-            - ref: state
             - lambda:
-                params: [candidate]
-                expr: "candidate.direction === 'outbound' && candidate.conversation.id === config.channelId && candidate.conversation.kind === 'channel' && candidate.text.includes(config.expectedNeedle)"
-            - expr: liveTurnTimeoutMs(env, 30000)
-            - sinceIndex:
-                ref: outboundStartIndex
-        - call: sleep
-          args: [4000]
+                expr: |-
+                  (() => {
+                    const snapshot = state.getSnapshot();
+                    const visible = snapshot.messages.slice(outboundStartIndex).filter((message) => message.direction === "outbound" && !message.deleted && message.conversation.id === config.channelId && message.conversation.kind === "channel" && message.text.includes(config.expectedNeedle));
+                    if (visible.length !== 1) return undefined;
+                    const candidate = visible[0];
+                    const events = snapshot.events.filter((event) => event.cursor > busCursorBeforeInbound && "message" in event && event.message.direction === "outbound" && event.message.conversation.id === config.channelId && event.message.text.includes(config.expectedNeedle));
+                    const finalSent = events.some((event) => event.kind === "outbound-message" && event.message.id === candidate.id);
+                    const previewRetired = events.some((event) => event.kind === "message-deleted" && event.message.id !== candidate.id);
+                    return finalSent && previewRetired ? candidate : undefined;
+                  })()
+            - 10000
         - set: visibleChannelOutbounds
           value:
             expr: "state.getSnapshot().messages.slice(outboundStartIndex).filter((message) => message.direction === 'outbound' && !message.deleted && message.conversation.id === config.channelId && message.conversation.kind === 'channel')"
         - assert:
-            # Tool-backed finals replace their streamed preview; only the durable visible reply is contractual.
-            expr: visibleChannelOutbounds.length === 1
+            # Tool-backed finals replace their streamed preview; prove the retired-preview lifecycle first.
+            expr: "visibleChannelOutbounds.length === 1 && visibleChannelOutbounds[0].id === durableChannelOutbound.id"
             message:
               expr: "`expected exactly one visible QA-room reply after the ordered memory result: ${JSON.stringify(visibleChannelOutbounds)}`"
-        - set: visibleChannelOutbound
-          value:
-            expr: visibleChannelOutbounds[0]
         - assert:
-            expr: "(visibleChannelOutbound.text.match(new RegExp(config.expectedNeedle, 'g')) ?? []).length === 1"
+            expr: "(durableChannelOutbound.text.match(new RegExp(config.expectedNeedle, 'g')) ?? []).length === 1"
             message:
-              expr: "`final QA-room reply must contain ${config.expectedNeedle} exactly once: ${visibleChannelOutbound.text}`"
-      detailsExpr: "`${visibleChannelOutbound.text}; path=${config.expectedMemoryPath}; matched=${searchResultRequest.toolOutputCallId === searchPlanRequest.plannedToolCallId}; room=${config.channelId}`"
+              expr: "`final QA-room reply must contain ${config.expectedNeedle} exactly once: ${durableChannelOutbound.text}`"
+      detailsExpr: "`${durableChannelOutbound.text}; path=${config.expectedMemoryPath}; matched=${searchResultRequest.toolOutputCallId === searchPlanRequest.plannedToolCallId}; room=${config.channelId}`"

--- a/qa/scenarios/memory/memory-tools-channel-context.yaml
+++ b/qa/scenarios/memory/memory-tools-channel-context.yaml
@@ -137,16 +137,19 @@ flow:
                     if (visible.length !== 1) return undefined;
                     const candidate = visible[0];
                     const events = snapshot.events.filter((event) => event.cursor > busCursorBeforeInbound && "message" in event && event.message.direction === "outbound" && event.message.conversation.id === config.channelId && event.message.text.includes(config.expectedNeedle));
-                    const finalSent = events.some((event) => event.kind === "outbound-message" && event.message.id === candidate.id);
-                    const previewRetired = events.some((event) => event.kind === "message-deleted" && event.message.id !== candidate.id);
-                    return finalSent && previewRetired ? candidate : undefined;
+                    const finalSent = events.find((event) => event.kind === "outbound-message" && event.message.id === candidate.id);
+                    if (!finalSent) return undefined;
+                    const previewRetired = events.find((event) => event.kind === "message-deleted" && event.message.id !== candidate.id && event.cursor < finalSent.cursor);
+                    if (!previewRetired) return undefined;
+                    const previewSent = events.some((event) => event.kind === "outbound-message" && event.message.id === previewRetired.message.id && event.cursor < previewRetired.cursor);
+                    return previewSent ? candidate : undefined;
                   })()
             - 10000
         - set: visibleChannelOutbounds
           value:
             expr: "state.getSnapshot().messages.slice(outboundStartIndex).filter((message) => message.direction === 'outbound' && !message.deleted && message.conversation.id === config.channelId && message.conversation.kind === 'channel')"
         - assert:
-            # Tool-backed finals replace their streamed preview; prove the retired-preview lifecycle first.
+            # Tool-backed finals replace their streamed preview; prove sent -> deleted -> final ordering first.
             expr: "visibleChannelOutbounds.length === 1 && visibleChannelOutbounds[0].id === durableChannelOutbound.id"
             message:
               expr: "`expected exactly one visible QA-room reply after the ordered memory result: ${JSON.stringify(visibleChannelOutbounds)}`"

--- a/qa/scenarios/memory/memory-tools-channel-context.yaml
+++ b/qa/scenarios/memory/memory-tools-channel-context.yaml
@@ -136,7 +136,7 @@ flow:
                     const visible = snapshot.messages.slice(outboundStartIndex).filter((message) => message.accountId === transport.accountId && message.direction === "outbound" && !message.deleted && message.conversation.id === config.channelId && message.conversation.kind === "channel" && message.text.includes(config.expectedNeedle));
                     if (visible.length !== 1) return undefined;
                     const candidate = visible[0];
-                    const events = snapshot.events.filter((event) => event.cursor > busCursorBeforeInbound && "message" in event && event.message.accountId === transport.accountId && event.message.direction === "outbound" && event.message.conversation.id === config.channelId && event.message.text.includes(config.expectedNeedle));
+                    const events = snapshot.events.filter((event) => event.cursor > busCursorBeforeInbound && "message" in event && event.message.accountId === transport.accountId && event.message.direction === "outbound" && event.message.conversation.id === config.channelId && event.message.conversation.kind === "channel" && event.message.text.includes(config.expectedNeedle));
                     const finalSent = events.find((event) => event.kind === "outbound-message" && event.message.id === candidate.id);
                     if (!finalSent) return undefined;
                     const previewRetired = events.find((event) => event.kind === "message-deleted" && event.message.id !== candidate.id && event.cursor < finalSent.cursor);

--- a/qa/scenarios/runtime/agent-progress-evidence.yaml
+++ b/qa/scenarios/runtime/agent-progress-evidence.yaml
@@ -194,9 +194,12 @@ flow:
                     if (visible.length !== 1) return undefined;
                     const candidate = visible[0];
                     const events = snapshot.events.filter((event) => event.cursor > busCursorBefore && "message" in event && event.message.direction === "outbound" && event.message.conversation.id === config.conversationId && event.message.text.includes(config.completionText));
-                    const finalSent = events.some((event) => event.kind === "outbound-message" && event.message.id === candidate.id);
-                    const previewRetired = events.some((event) => event.kind === "message-deleted" && event.message.id !== candidate.id);
-                    return finalSent && previewRetired ? candidate : undefined;
+                    const finalSent = events.find((event) => event.kind === "outbound-message" && event.message.id === candidate.id);
+                    if (!finalSent) return undefined;
+                    const previewRetired = events.find((event) => event.kind === "message-deleted" && event.message.id !== candidate.id && event.cursor < finalSent.cursor);
+                    if (!previewRetired) return undefined;
+                    const previewSent = events.some((event) => event.kind === "outbound-message" && event.message.id === previewRetired.message.id && event.cursor < previewRetired.cursor);
+                    return previewSent ? candidate : undefined;
                   })()
             - 10000
         - set: allBusEvents
@@ -212,7 +215,7 @@ flow:
           value:
             expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound' && message.conversation.id === config.conversationId && message.text.includes(config.completionText) && !message.deleted)"
         - assert:
-            # Tool-backed finals replace their streamed preview; prove the retired-preview lifecycle first.
+            # Tool-backed finals replace their streamed preview; prove sent -> deleted -> final ordering first.
             expr: "completionMessages.length === 1 && completionMessages[0].id === durableCompletion.id"
             message:
               expr: "`expected exactly one durable completion reply: ${JSON.stringify(completionMessages)}`"

--- a/qa/scenarios/runtime/agent-progress-evidence.yaml
+++ b/qa/scenarios/runtime/agent-progress-evidence.yaml
@@ -207,7 +207,7 @@ flow:
             expr: durableCompletionLifecycle.message
         - set: allBusEvents
           value:
-            expr: "state.getSnapshot().events.filter((event) => event.cursor > busCursorBefore && 'message' in event && event.message.direction === 'outbound' && event.message.conversation.id === config.conversationId)"
+            expr: "state.getSnapshot().events.filter((event) => event.cursor > busCursorBefore && 'message' in event && event.message.accountId === transport.accountId && event.message.direction === 'outbound' && event.message.conversation.id === config.conversationId)"
         - set: busEvents
           value:
             expr: "allBusEvents.filter((event) => event.kind === 'outbound-message' || event.kind === 'message-edited')"
@@ -216,7 +216,7 @@ flow:
             expr: "busEvents.filter((event) => event.message.text.includes(config.completionText))"
         - set: completionMessages
           value:
-            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound' && message.conversation.id === config.conversationId && message.text.includes(config.completionText) && !message.deleted)"
+            expr: "state.getSnapshot().messages.filter((message) => message.accountId === transport.accountId && message.direction === 'outbound' && message.conversation.id === config.conversationId && message.text.includes(config.completionText) && !message.deleted)"
         - assert:
             # Tool-backed finals replace their streamed preview; prove sent -> deleted -> final ordering first.
             expr: "completionMessages.length === 1 && completionMessages[0].id === durableCompletion.id"

--- a/qa/scenarios/runtime/agent-progress-evidence.yaml
+++ b/qa/scenarios/runtime/agent-progress-evidence.yaml
@@ -201,7 +201,7 @@ flow:
                     const previewSent = events.find((event) => event.kind === "outbound-message" && event.message.id === previewRetired.message.id && event.cursor < previewRetired.cursor);
                     return previewSent ? { message: candidate, previewId: previewRetired.message.id, finalId: candidate.id, previewSentCursor: previewSent.cursor, previewDeletedCursor: previewRetired.cursor, finalSentCursor: finalSent.cursor } : undefined;
                   })()
-            - 10000
+            - expr: liveTurnTimeoutMs(env, 60000)
         - set: durableCompletion
           value:
             expr: durableCompletionLifecycle.message

--- a/qa/scenarios/runtime/agent-progress-evidence.yaml
+++ b/qa/scenarios/runtime/agent-progress-evidence.yaml
@@ -190,10 +190,10 @@ flow:
                 expr: |-
                   (() => {
                     const snapshot = state.getSnapshot();
-                    const visible = snapshot.messages.filter((message) => message.direction === "outbound" && !message.deleted && message.conversation.id === config.conversationId && message.text.includes(config.completionText));
+                    const visible = snapshot.messages.filter((message) => message.accountId === transport.accountId && message.direction === "outbound" && !message.deleted && message.conversation.id === config.conversationId && message.text.includes(config.completionText));
                     if (visible.length !== 1) return undefined;
                     const candidate = visible[0];
-                    const events = snapshot.events.filter((event) => event.cursor > busCursorBefore && "message" in event && event.message.direction === "outbound" && event.message.conversation.id === config.conversationId && event.message.text.includes(config.completionText));
+                    const events = snapshot.events.filter((event) => event.cursor > busCursorBefore && "message" in event && event.message.accountId === transport.accountId && event.message.direction === "outbound" && event.message.conversation.id === config.conversationId && event.message.text.includes(config.completionText));
                     const finalSent = events.find((event) => event.kind === "outbound-message" && event.message.id === candidate.id);
                     if (!finalSent) return undefined;
                     const previewRetired = events.find((event) => event.kind === "message-deleted" && event.message.id !== candidate.id && event.cursor < finalSent.cursor);

--- a/qa/scenarios/runtime/agent-progress-evidence.yaml
+++ b/qa/scenarios/runtime/agent-progress-evidence.yaml
@@ -190,10 +190,10 @@ flow:
                 expr: |-
                   (() => {
                     const snapshot = state.getSnapshot();
-                    const visible = snapshot.messages.filter((message) => message.accountId === transport.accountId && message.direction === "outbound" && !message.deleted && message.conversation.id === config.conversationId && message.text.includes(config.completionText));
+                    const visible = snapshot.messages.filter((message) => message.accountId === transport.accountId && message.direction === "outbound" && !message.deleted && message.conversation.id === config.conversationId && message.conversation.kind === "direct" && message.text.includes(config.completionText));
                     if (visible.length !== 1) return undefined;
                     const candidate = visible[0];
-                    const events = snapshot.events.filter((event) => event.cursor > busCursorBefore && "message" in event && event.message.accountId === transport.accountId && event.message.direction === "outbound" && event.message.conversation.id === config.conversationId && event.message.text.includes(config.completionText));
+                    const events = snapshot.events.filter((event) => event.cursor > busCursorBefore && "message" in event && event.message.accountId === transport.accountId && event.message.direction === "outbound" && event.message.conversation.id === config.conversationId && event.message.conversation.kind === "direct" && event.message.text.includes(config.completionText));
                     const finalSent = events.find((event) => event.kind === "outbound-message" && event.message.id === candidate.id);
                     if (!finalSent) return undefined;
                     const previewRetired = events.find((event) => event.kind === "message-deleted" && event.message.id !== candidate.id && event.cursor < finalSent.cursor);
@@ -207,7 +207,7 @@ flow:
             expr: durableCompletionLifecycle.message
         - set: allBusEvents
           value:
-            expr: "state.getSnapshot().events.filter((event) => event.cursor > busCursorBefore && 'message' in event && event.message.accountId === transport.accountId && event.message.direction === 'outbound' && event.message.conversation.id === config.conversationId)"
+            expr: "state.getSnapshot().events.filter((event) => event.cursor > busCursorBefore && 'message' in event && event.message.accountId === transport.accountId && event.message.direction === 'outbound' && event.message.conversation.id === config.conversationId && event.message.conversation.kind === 'direct')"
         - set: busEvents
           value:
             expr: "allBusEvents.filter((event) => event.kind === 'outbound-message' || event.kind === 'message-edited')"
@@ -216,7 +216,7 @@ flow:
             expr: "busEvents.filter((event) => event.message.text.includes(config.completionText))"
         - set: completionMessages
           value:
-            expr: "state.getSnapshot().messages.filter((message) => message.accountId === transport.accountId && message.direction === 'outbound' && message.conversation.id === config.conversationId && message.text.includes(config.completionText) && !message.deleted)"
+            expr: "state.getSnapshot().messages.filter((message) => message.accountId === transport.accountId && message.direction === 'outbound' && message.conversation.id === config.conversationId && message.conversation.kind === 'direct' && message.text.includes(config.completionText) && !message.deleted)"
         - assert:
             # Tool-backed finals replace their streamed preview; prove sent -> deleted -> final ordering first.
             expr: "completionMessages.length === 1 && completionMessages[0].id === durableCompletion.id"

--- a/qa/scenarios/runtime/agent-progress-evidence.yaml
+++ b/qa/scenarios/runtime/agent-progress-evidence.yaml
@@ -132,7 +132,6 @@ flow:
               ref: config.completionText
             timeoutMs:
               expr: liveTurnTimeoutMs(env, 60000)
-          saveAs: outbound
         - call: fs.readFile
           saveAs: artifact
           args:
@@ -193,28 +192,32 @@ flow:
         - set: completionEvents
           value:
             expr: "busEvents.filter((event) => event.message.text.includes(config.completionText))"
-        - set: finalCompletionEvent
-          value:
-            expr: "completionEvents.findLast((event) => event.message.id === outbound.id)"
         - set: completionMessages
           value:
             expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound' && message.conversation.id === config.conversationId && message.text.includes(config.completionText) && !message.deleted)"
         - assert:
-            expr: "completionMessages.length === 1 && completionMessages[0].id === outbound.id"
+            # Tool-backed finals replace their streamed preview; only the durable visible reply is contractual.
+            expr: completionMessages.length === 1
             message:
               expr: "`expected exactly one durable completion reply: ${JSON.stringify(completionMessages)}`"
+        - set: durableCompletion
+          value:
+            expr: completionMessages[0]
+        - set: finalCompletionEvent
+          value:
+            expr: "completionEvents.findLast((event) => event.message.id === durableCompletion.id)"
         - assert:
             expr: "completionEvents.length >= 1 && finalCompletionEvent && completionEvents.every((event) => artifactStat.mtimeMs <= (event.message.editedAt ?? event.message.timestamp))"
             message:
               expr: "`completion appeared before the write-backed terminal request: artifactMtime=${artifactStat.mtimeMs} events=${JSON.stringify(completionEvents)}`"
         - assert:
-            expr: "completionEvents.filter((event) => event.message.id !== outbound.id).every((event) => allBusEvents.some((candidate) => candidate.kind === 'message-deleted' && candidate.cursor > event.cursor && candidate.message.id === event.message.id))"
+            expr: "completionEvents.filter((event) => event.message.id !== durableCompletion.id).every((event) => allBusEvents.some((candidate) => candidate.kind === 'message-deleted' && candidate.cursor > event.cursor && candidate.message.id === event.message.id))"
             message:
               expr: "`a transient completion preview remained durable: ${JSON.stringify(allBusEvents)}`"
         - assert:
-            expr: "outbound.replyToId === inbound.id && outbound.text.includes(config.artifactFile) && outbound.text.includes(config.completionMarker)"
+            expr: "durableCompletion.replyToId === inbound.id && durableCompletion.text.includes(config.artifactFile) && durableCompletion.text.includes(config.completionMarker)"
             message:
-              expr: "`durable completion did not cite the artifact and marker: ${JSON.stringify(outbound)}`"
+              expr: "`durable completion did not cite the artifact and marker: ${JSON.stringify(durableCompletion)}`"
         - assert:
             expr: "artifactStat.mtimeMs <= (finalCompletionEvent.message.editedAt ?? finalCompletionEvent.message.timestamp)"
             message:

--- a/qa/scenarios/runtime/agent-progress-evidence.yaml
+++ b/qa/scenarios/runtime/agent-progress-evidence.yaml
@@ -183,6 +183,22 @@ flow:
             expr: "writeResultRequest.toolOutputCallId === writeRequest.plannedToolCallId && writeResultRequest.toolOutputStructuredError !== true && /successfully (?:wrote|created|updated|replaced)/i.test(String(writeResultRequest.toolOutput ?? '')) && !writeResultRequest.plannedToolName"
             message:
               expr: "`request 4 did not consume the successful write result before terminal generation: ${JSON.stringify(writeResultRequest)}`"
+        - call: waitForCondition
+          saveAs: durableCompletion
+          args:
+            - lambda:
+                expr: |-
+                  (() => {
+                    const snapshot = state.getSnapshot();
+                    const visible = snapshot.messages.filter((message) => message.direction === "outbound" && !message.deleted && message.conversation.id === config.conversationId && message.text.includes(config.completionText));
+                    if (visible.length !== 1) return undefined;
+                    const candidate = visible[0];
+                    const events = snapshot.events.filter((event) => event.cursor > busCursorBefore && "message" in event && event.message.direction === "outbound" && event.message.conversation.id === config.conversationId && event.message.text.includes(config.completionText));
+                    const finalSent = events.some((event) => event.kind === "outbound-message" && event.message.id === candidate.id);
+                    const previewRetired = events.some((event) => event.kind === "message-deleted" && event.message.id !== candidate.id);
+                    return finalSent && previewRetired ? candidate : undefined;
+                  })()
+            - 10000
         - set: allBusEvents
           value:
             expr: "state.getSnapshot().events.filter((event) => event.cursor > busCursorBefore && 'message' in event && event.message.direction === 'outbound' && event.message.conversation.id === config.conversationId)"
@@ -196,13 +212,10 @@ flow:
           value:
             expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound' && message.conversation.id === config.conversationId && message.text.includes(config.completionText) && !message.deleted)"
         - assert:
-            # Tool-backed finals replace their streamed preview; only the durable visible reply is contractual.
-            expr: completionMessages.length === 1
+            # Tool-backed finals replace their streamed preview; prove the retired-preview lifecycle first.
+            expr: "completionMessages.length === 1 && completionMessages[0].id === durableCompletion.id"
             message:
               expr: "`expected exactly one durable completion reply: ${JSON.stringify(completionMessages)}`"
-        - set: durableCompletion
-          value:
-            expr: completionMessages[0]
         - set: finalCompletionEvent
           value:
             expr: "completionEvents.findLast((event) => event.message.id === durableCompletion.id)"

--- a/qa/scenarios/runtime/agent-progress-evidence.yaml
+++ b/qa/scenarios/runtime/agent-progress-evidence.yaml
@@ -184,7 +184,7 @@ flow:
             message:
               expr: "`request 4 did not consume the successful write result before terminal generation: ${JSON.stringify(writeResultRequest)}`"
         - call: waitForCondition
-          saveAs: durableCompletion
+          saveAs: durableCompletionLifecycle
           args:
             - lambda:
                 expr: |-
@@ -198,10 +198,13 @@ flow:
                     if (!finalSent) return undefined;
                     const previewRetired = events.find((event) => event.kind === "message-deleted" && event.message.id !== candidate.id && event.cursor < finalSent.cursor);
                     if (!previewRetired) return undefined;
-                    const previewSent = events.some((event) => event.kind === "outbound-message" && event.message.id === previewRetired.message.id && event.cursor < previewRetired.cursor);
-                    return previewSent ? candidate : undefined;
+                    const previewSent = events.find((event) => event.kind === "outbound-message" && event.message.id === previewRetired.message.id && event.cursor < previewRetired.cursor);
+                    return previewSent ? { message: candidate, previewId: previewRetired.message.id, finalId: candidate.id, previewSentCursor: previewSent.cursor, previewDeletedCursor: previewRetired.cursor, finalSentCursor: finalSent.cursor } : undefined;
                   })()
             - 10000
+        - set: durableCompletion
+          value:
+            expr: durableCompletionLifecycle.message
         - set: allBusEvents
           value:
             expr: "state.getSnapshot().events.filter((event) => event.cursor > busCursorBefore && 'message' in event && event.message.direction === 'outbound' && event.message.conversation.id === config.conversationId)"
@@ -238,4 +241,4 @@ flow:
             expr: "artifactStat.mtimeMs <= (finalCompletionEvent.message.editedAt ?? finalCompletionEvent.message.timestamp)"
             message:
               expr: "`artifact postdated the durable completion reply: artifactMtime=${artifactStat.mtimeMs} replyTimestamp=${finalCompletionEvent.message.editedAt ?? finalCompletionEvent.message.timestamp}`"
-      detailsExpr: "`read:${firstReadRequest.plannedToolCallId} -> read:${secondReadRequest.plannedToolCallId} -> write:${writeRequest.plannedToolCallId} -> result:${writeResultRequest.toolOutputCallId}; artifactBeforeReply=${artifactStat.mtimeMs <= (finalCompletionEvent.message.editedAt ?? finalCompletionEvent.message.timestamp)}; durableCompletions=${completionMessages.length}`"
+      detailsExpr: "`read:${firstReadRequest.plannedToolCallId} -> read:${secondReadRequest.plannedToolCallId} -> write:${writeRequest.plannedToolCallId} -> result:${writeResultRequest.toolOutputCallId}; artifactBeforeReply=${artifactStat.mtimeMs <= (finalCompletionEvent.message.editedAt ?? finalCompletionEvent.message.timestamp)}; durableCompletions=${completionMessages.length}; lifecycle=${JSON.stringify({ previewId: durableCompletionLifecycle.previewId, previewSentCursor: durableCompletionLifecycle.previewSentCursor, previewDeletedCursor: durableCompletionLifecycle.previewDeletedCursor, finalId: durableCompletionLifecycle.finalId, finalSentCursor: durableCompletionLifecycle.finalSentCursor })}`"


### PR DESCRIPTION
Closes #119368

## What Problem This Solves

Fixes an issue where maintainers running concurrent QA scenarios would see false failures when a tool-backed final reply correctly replaced its streamed preview with a new durable message ID.

## Why This Change Was Made

The channel-memory and progress-evidence scenarios now wait until the event log proves a strict preview-send -> same-preview-delete -> distinct-final-send cursor order, then evaluate the sole non-deleted final reply. Their request-chain, artifact-ordering, reply-target, content, retired-preview, and exactly-once assertions remain intact.

The lifecycle waits preserve the scenarios' existing policy-aware delivery budgets: 30 seconds for the memory scenario and 60 seconds for progress evidence. No retry, product runtime, provider, channel, or memory behavior changed.

## User Impact

There is no user-visible product behavior change. Maintainers and contributors get reliable QA verdicts for the channel's documented tool-backed preview replacement flow.

Production LOC delta: 0. QA tests/scenarios: +185 / -28.

## Evidence

- Before, a five-iteration memory pressure matrix reported 38/40 passes and reproduced `memory-tools-channel-context` comparing the sole visible final against a retired preview ID.
  - Testbox `tbx_01kz7ffteq8qkr1y201t2ecptk`
  - Hosted run: https://github.com/openclaw/openclaw/actions/runs/30957846990
- After, the same five-iteration memory pressure matrix passed 40/40 with no retries.
  - Testbox `tbx_01kz7gtmegnf47d1wx585qb5km`
  - Hosted run: https://github.com/openclaw/openclaw/actions/runs/30959238414
- A later full catalog reproduced the same preview-ID race in `agent-progress-evidence`; the corrected five-iteration progress/terminal-finalization matrix then passed 40/40 with no retries.
  - Reproduction: Testbox `tbx_01kz7hss9yw8724yb4hgr70245`, https://github.com/openclaw/openclaw/actions/runs/30960194646
  - Corrected matrix: Testbox `tbx_01kz7kdzfgdr31v4d8vnj6knxs`, https://github.com/openclaw/openclaw/actions/runs/30961778473
- The strict cursor-ordered patch passed both scenarios 10/10 across five iterations.
  - Testbox `tbx_01kz7rn31fxazt9k9eejtjva9v`
  - Hosted run: https://github.com/openclaw/openclaw/actions/runs/30966541923
- Exact-head lifecycle evidence at `60cfd836149566` recorded preview sends at cursor 2, matching deletions at cursor 3, and distinct durable finals at cursor 4 for both scenarios.
  - Testbox `tbx_01kz7wbx7jrsxcebgk9ba17pcg`
  - Hosted run: https://github.com/openclaw/openclaw/actions/runs/30969763651
- After restoring the established policy-aware delivery budgets, corrected exact head `f8fda63ebbef94e4a580f7eac730ea2eef289c8d` passed both affected scenarios 2/2.
  - Command: `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm openclaw qa suite --provider-mode mock-openai --scenario memory-tools-channel-context --scenario agent-progress-evidence --concurrency 1`
  - Testbox `tbx_01kz7yfajh7t7bcqn8z4yv157v`
  - Hosted run: https://github.com/openclaw/openclaw/actions/runs/30971539947
- After restoring active-account isolation and adding executable foreign-account regression coverage, exact head `da2fdfb852ac1b8d2b73a5e2b1230e1f4a7aa6cb` passed both affected scenarios 2/2.
  - Command: `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm openclaw qa suite --provider-mode mock-openai --scenario memory-tools-channel-context --scenario agent-progress-evidence --concurrency 1`
  - Testbox `tbx_01kz7zjm20s5zyk7qjry749yhs`
  - Hosted run: https://github.com/openclaw/openclaw/actions/runs/30972475157
- After carrying active-account isolation through the downstream exactly-one and event assertions, exact head `0da7ee83bad514dd02c4af3e4d42a3c0f26eaa66` passed both affected scenarios 2/2.
  - Command: `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm openclaw qa suite --provider-mode mock-openai --scenario memory-tools-channel-context --scenario agent-progress-evidence --concurrency 1`
  - Testbox `tbx_01kz82r32atk9g5t9287hp5ap3`
  - Hosted run: https://github.com/openclaw/openclaw/actions/runs/30975131769
- After preserving the complete QA bus identity `(account, conversation kind, conversation id)` through every lifecycle and downstream selector, exact head `86b3c128956c58a14f768b6c4b3ae77271f6a7c4` passed both affected scenarios 2/2.
  - Command: `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm openclaw qa suite --provider-mode mock-openai --scenario memory-tools-channel-context --scenario agent-progress-evidence --concurrency 1`
  - Testbox `tbx_01kz85d41ms5xp50nb99hwbw6r`
  - Hosted run: https://github.com/openclaw/openclaw/actions/runs/30977424824
- Focused QA causality/catalog tests passed 70/70, including two foreign-account lifecycle cases that execute the actual YAML predicates: `node scripts/run-vitest.mjs extensions/qa-lab/src/scenario-catalog-causality.test.ts extensions/qa-lab/src/scenario-catalog.test.ts extensions/qa-lab/src/scenario-catalog-channels.test.ts`.
- Final exact-head AutoReview is clean with no accepted/actionable findings.
- A patch-equivalent full catalog finished with 124 passed, one unrelated Active Memory doctor timeout tracked in #119385, and eight expected optional-tool skips.
  - Testbox `tbx_01kz7me92tx3dbnkfh5rmyz6cj`
  - Hosted run: https://github.com/openclaw/openclaw/actions/runs/30962756141

AI-assisted: yes. I understand the changes and verified the affected owner paths and pressure behavior directly.
