### PR TITLE
fix(mcp): guard stdio stdout frame parsing against oversized-buffer crash

### DIFF
--- a/src/agents/mcp-stdio-transport.test.ts
+++ b/src/agents/mcp-stdio-transport.test.ts
@@ -246,4 +246,23 @@ describe("OpenClawStdioClientTransport", () => {
     child.stderr.write("server diagnostic");
     expect(transport.stderr?.read()?.toString()).toBe("server diagnostic");
   });
+
+  it("reports an oversized stdout frame without an unhandled error crash", async () => {
+    const child = new MockChildProcess();
+    spawnMock.mockReturnValue(child);
+
+    const transport = new OpenClawStdioClientTransport({ command: "npx" });
+    const onerror = vi.fn();
+    Object.assign(transport, { onerror });
+    const started = transport.start();
+    child.emit("spawn");
+    await started;
+
+    const oversized = Buffer.alloc(10 * 1024 * 1024 + 1, 0x20);
+    expect(() => child.stdout.emit("data", oversized)).not.toThrow();
+    expect(onerror).toHaveBeenCalledTimes(1);
+    const reported = onerror.mock.calls.at(0)?.at(0) as Error;
+    expect(reported).toBeInstanceOf(Error);
+    expect(reported.message).toMatch(/exceeded maximum size/);
+  });
 });

--- a/src/agents/mcp-stdio-transport.ts
+++ b/src/agents/mcp-stdio-transport.ts
@@ -82,8 +82,13 @@ export class OpenClawStdioClientTransport implements Transport {
       });
       child.stdin?.on("error", (error: Error) => this.onerror?.(error));
       child.stdout?.on("data", (chunk: Buffer) => {
-        this.readBuffer.append(chunk);
-        this.processReadBuffer();
+        try {
+          this.readBuffer.append(chunk);
+          this.processReadBuffer();
+        } catch (error) {
+          this.onerror?.(error instanceof Error ? error : new Error(String(error)));
+          void this.close();
+        }
       });
       child.stdout?.on("error", (error: Error) => this.onerror?.(error));
       if (this.stderrStream && child.stderr) {


### PR DESCRIPTION
## Summary
An MCP stdio server whose stdout frame exceeds the SDK `ReadBuffer` 10 MiB cap crashes the whole OpenClaw host process, taking down every concurrent session with it. The frame is emitted by the server subprocess, but its size is driven by tool-result payload data (file contents, a fetched page, a database row) that a lower-privileged message sender can influence, not by the operator who chose which server to run.

## Root cause
`src/agents/mcp-stdio-transport.ts` handles child stdout with an unguarded synchronous call into the SDK read buffer:

```ts
// before
child.stdout?.on("data", (chunk: Buffer) => {
  this.readBuffer.append(chunk);
  this.processReadBuffer();
});
```

`ReadBuffer.append` throws `ReadBuffer exceeded maximum size of 10485760 bytes` synchronously once the accumulated buffer passes `STDIO_DEFAULT_MAX_BUFFER_SIZE` (10 MiB). `processReadBuffer` has its own inner try/catch around `readMessage`, but `append` is called outside it. The throw runs inside the Node stream `data` callback, on a different stack from the per-server isolation the MCP runtime builds, so nothing catches it. It escapes as an uncaughtException and terminates the host process. There is no MCP server quarantine that survives the exit (`serverBackoff` is an in-memory map that dies with the process), so this is a deterministic, remotely influenced gateway kill.

## Fix
Wrap the two calls in the same guard the upstream SDK `StdioClientTransport` uses for this exact code:

```ts
// after
child.stdout?.on("data", (chunk: Buffer) => {
  try {
    this.readBuffer.append(chunk);
    this.processReadBuffer();
  } catch (error) {
    this.onerror?.(error instanceof Error ? error : new Error(String(error)));
    void this.close();
  }
});
```

The oversized frame is now reported through `onerror` and the transport closes, which the MCP runtime already handles as a normal server disconnect. The host stays up.

## Why this is the right boundary
The transport owns the child stdio read path, and this file already guards its sibling surfaces at exactly this boundary: stdin write errors (#75438), the stdout `error` event, and stderr pipe errors (#99803). stdout `data` was the one path left unguarded. The fix mirrors the upstream SDK behavior byte-for-byte (`onerror` + `close`), so a correctly framed stream is unaffected and existing message delivery is unchanged. No sibling transport is left one-sided.

## Verification
- `node scripts/run-vitest.mjs src/agents/mcp-stdio-transport.test.ts` -> 10 passed, including the new `reports an oversized stdout frame without an unhandled error crash` case. The new case fails on pristine `main` (the frame throws out of the handler) and passes with the patch.
- `oxlint` and `oxfmt --check` on both changed files -> clean.
- `run-tsgo.mjs -p tsconfig.core.json` and `-p test/tsconfig/tsconfig.core.test.json` -> no errors.
- SDK version exercised is `@modelcontextprotocol/sdk@1.30.0`, the version pinned by the current lockfile (the 10 MiB cap exists there).

## Real behavior proof
Behavior addressed: an MCP stdio server emitting a single stdout frame larger than 10 MiB kills the entire host process instead of failing just that server connection.
Real environment tested: the real `OpenClawStdioClientTransport` (no stub) spawns a real Node subprocess that writes one oversized line to stdout, parsed by the real `@modelcontextprotocol/sdk@1.30.0` `ReadBuffer`. Nothing is mocked: real `child_process.spawn`, real stdio pipes, real read buffer. Run on pristine main `fb81d03` and on the patched tree with an identical subprocess and identical input.
Exact steps or command run after this patch: `tsx` host script instantiates `OpenClawStdioClientTransport({ command: node, args: [oversized-server.mjs] })`, registers a `process.on("uncaughtException")` recorder plus `onerror`/`onclose` handlers, calls `start()`, and reports whether the host survives.
Evidence after fix:
```
# BEFORE (pristine main fb81d03)
HOST started; awaiting oversized frame
HOST uncaughtException: ReadBuffer exceeded maximum size of 10485760 bytes
host exit=1

# AFTER (this patch, identical subprocess and input)
HOST started; awaiting oversized frame
HOST onerror: ReadBuffer exceeded maximum size of 10485760 bytes
HOST SURVIVED exit=0
host exit=0
```
Observed result after fix: the oversized frame is delivered to `onerror` and the host keeps running and exits cleanly, where before it escaped to the top level and terminated the host with a non-zero exit.
What was not tested: no live third-party MCP server was driven (a local subprocess stands in for the oversized emitter); the full production build was not run.
