### PR TITLE
fix(whatsapp,discord,mattermost): release the ingress lane on defer so the inbound debounce can merge

### DIFF
--- a/extensions/discord/src/monitor/ingress.test.ts
+++ b/extensions/discord/src/monitor/ingress.test.ts
@@ -230,6 +230,50 @@ describe("Discord durable ingress", () => {
     });
   });
 
+  it("admits a second same-lane message while the first is still deferred, without waiting for adoption", async () => {
+    await withQueue(async (queue) => {
+      const dispatched: string[] = [];
+      const lifecycles = new Map<string, DiscordIngressLifecycle>();
+      const dispatch = vi.fn(async (event: { id: string }, lifecycle: DiscordIngressLifecycle) => {
+        dispatched.push(event.id);
+        lifecycles.set(event.id, lifecycle);
+        return { kind: "deferred" as const };
+      });
+      const monitor = createDiscordIngressMonitor({
+        accountId: "default",
+        client: {} as never,
+        runtime: runtime(),
+        queue,
+        dispatch,
+      });
+      monitor.start();
+      try {
+        // Same channel_id: both messages share a lane.
+        const first = createRawMessage("2001", "channel-shared");
+        const second = createRawMessage("2002", "channel-shared");
+        await monitor.accept(first);
+        await monitor.accept(second);
+
+        // deferredLaneOccupancy: "release" frees the channel lane as soon as
+        // the first claim defers (before adoption), so the second message is
+        // dispatched without waiting for the first to be adopted. Holding the
+        // lane (the drain default) would guillotine it instead. Same defect
+        // and fix as #101335 (Telegram) and #119382 (WhatsApp).
+        await vi.waitFor(() => expect(dispatched).toEqual(["2001", "2002"]));
+
+        const firstLifecycle = lifecycles.get("2001");
+        const secondLifecycle = lifecycles.get("2002");
+        if (!firstLifecycle || !secondLifecycle) {
+          throw new Error("expected both dispatch lifecycles");
+        }
+        await firstLifecycle.onAdopted();
+        await secondLifecycle.onAdopted();
+      } finally {
+        await monitor.stop();
+      }
+    });
+  });
+
   it("dead-letters a permanent Discord authentication failure", async () => {
     await withQueue(async (queue) => {
       const monitor = createDiscordIngressMonitor({

--- a/extensions/discord/src/monitor/ingress.ts
+++ b/extensions/discord/src/monitor/ingress.ts
@@ -156,6 +156,13 @@ export function createDiscordIngressMonitor(params: {
         }
         return null;
       },
+      // The lane is per-channel and dispatch can defer into the reply/turn
+      // debouncer while a merge window is open. Holding the lane during that
+      // wait (the drain default) blocks every other message in the same
+      // channel from being admitted, so a same-lane follow-up guillotines
+      // instead of merging. Same defect and fix as #101335 (Telegram) and
+      // #119382 (WhatsApp).
+      deferredLaneOccupancy: "release",
       onLog: (message) => params.runtime.error?.(danger(`discord ingress: ${message}`)),
     },
     onError: (error) =>

--- a/extensions/mattermost/src/mattermost/monitor-ingress.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-ingress.test.ts
@@ -300,6 +300,45 @@ describe("Mattermost durable ingress", () => {
     });
   });
 
+  it("admits a second same-lane post while the first is still deferred, without waiting for adoption", async () => {
+    await withQueue(async (queue) => {
+      const dispatched: string[] = [];
+      const lifecycles = new Map<string, MattermostIngressLifecycle>();
+      const dispatch = vi.fn((post, _payload, lifecycle) => {
+        dispatched.push(post.id);
+        lifecycles.set(post.id, lifecycle);
+        return { kind: "deferred" } as const;
+      });
+      const monitor = startMonitor(queue, dispatch);
+      try {
+        // Same channel_id: both posts share a lane.
+        await monitor.receive(
+          postedEvent({ postId: "post-lane-a", channelId: "channel-shared", message: "a" }),
+        );
+        await monitor.receive(
+          postedEvent({ postId: "post-lane-b", channelId: "channel-shared", message: "b" }),
+        );
+
+        // deferredLaneOccupancy: "release" frees the channel lane as soon as
+        // the first claim defers (before adoption), so the second post is
+        // dispatched without waiting for the first to be adopted. Holding
+        // the lane (the drain default) would guillotine it instead. Same
+        // defect and fix as #101335 (Telegram) and #119382 (WhatsApp).
+        await vi.waitFor(() => expect(dispatched).toEqual(["post-lane-a", "post-lane-b"]));
+
+        const firstLifecycle = lifecycles.get("post-lane-a");
+        const secondLifecycle = lifecycles.get("post-lane-b");
+        if (!firstLifecycle || !secondLifecycle) {
+          throw new Error("expected both dispatch lifecycles");
+        }
+        await firstLifecycle.onAdopted();
+        await secondLifecycle.onAdopted();
+      } finally {
+        await monitor.stop();
+      }
+    });
+  });
+
   it("does not let ignored post_edited events tombstone a later posted event", async () => {
     await withQueue(async (queue) => {
       const dispatch = vi.fn(async (_post, _payload, lifecycle) => {

--- a/extensions/mattermost/src/mattermost/monitor-ingress.ts
+++ b/extensions/mattermost/src/mattermost/monitor-ingress.ts
@@ -204,6 +204,13 @@ export function createMattermostIngressMonitor(options: {
     retention: "standard",
     drain: {
       resolveNonRetryableFailure: resolveMattermostIngressNonRetryableFailure,
+      // The lane is per-channel and dispatch can defer into the reply/turn
+      // debouncer while a merge window is open. Holding the lane during that
+      // wait (the drain default) blocks every other post in the same channel
+      // from being admitted, so a same-lane follow-up guillotines instead of
+      // merging. Same defect and fix as #101335 (Telegram) and #119382
+      // (WhatsApp).
+      deferredLaneOccupancy: "release",
       ...(options.adoptionStallTimeoutMs === undefined
         ? {}
         : { adoptionStallTimeoutMs: options.adoptionStallTimeoutMs }),

--- a/extensions/whatsapp/src/inbound/durable-receive.test.ts
+++ b/extensions/whatsapp/src/inbound/durable-receive.test.ts
@@ -135,7 +135,7 @@ describe("createWhatsAppIngressMonitor", () => {
     });
   });
 
-  it("keeps a second same-lane message pending until the first turn adopts", async () => {
+  it("admits a second same-lane message while the first is still deferred, without waiting for adoption", async () => {
     await withTempState(async (stateDir) => {
       const queue = createChannelIngressQueueForTests<WhatsAppDurableInboundPayload>({
         channelId: "whatsapp",
@@ -155,6 +155,7 @@ describe("createWhatsAppIngressMonitor", () => {
 
       const dispatched: string[] = [];
       let adoptFirst: (() => void | Promise<void>) | undefined;
+      let adoptSecond: (() => void | Promise<void>) | undefined;
       const monitor = createWhatsAppIngressMonitor({
         queue,
         pollIntervalMs: 10,
@@ -166,28 +167,34 @@ describe("createWhatsAppIngressMonitor", () => {
           dispatched.push(id);
           if (id === "msg-4a") {
             adoptFirst = lifecycle.onAdopted;
-            return { kind: "deferred" as const };
+          } else {
+            adoptSecond = lifecycle.onAdopted;
           }
-          return { kind: "completed" as const };
+          return { kind: "deferred" as const };
         },
       });
 
       monitor.start();
       await monitor.waitForIdle();
 
-      // Core drain serializes a conversation lane: msg-4b cannot reach the
-      // channel debouncer until msg-4a transfers into the reply lane.
-      expect(dispatched).toEqual(["msg-4a"]);
-      expect((await queue.listClaims()).map((row) => row.id)).toEqual([firstId]);
-      expect((await queue.listPending({ limit: "all" })).map((row) => row.id)).toEqual([secondId]);
+      // deferredLaneOccupancy: "release" frees the conversation lane as soon as
+      // a claim defers (before adoption), so a debounce-window merge is
+      // possible: msg-4b reaches the channel debouncer without waiting for
+      // msg-4a to transfer into the reply lane. This is the WhatsApp side of
+      // the same fix Telegram already carries for #101335.
+      expect(dispatched).toEqual(["msg-4a", "msg-4b"]);
+      expect((await queue.listClaims()).map((row) => row.id).toSorted()).toEqual(
+        [firstId, secondId].toSorted(),
+      );
+      expect(await queue.listPending({ limit: "all" })).toEqual([]);
 
-      if (!adoptFirst) {
-        throw new Error("expected first adoption callback");
+      if (!adoptFirst || !adoptSecond) {
+        throw new Error("expected both adoption callbacks");
       }
       await adoptFirst();
+      await adoptSecond();
       await monitor.waitForIdle();
 
-      expect(dispatched).toEqual(["msg-4a", "msg-4b"]);
       expect(await queue.listClaims()).toEqual([]);
       expect(await queue.listPending({ limit: "all" })).toEqual([]);
       await monitor.stop();

--- a/extensions/whatsapp/src/inbound/durable-receive.ts
+++ b/extensions/whatsapp/src/inbound/durable-receive.ts
@@ -138,6 +138,12 @@ export function createWhatsAppIngressMonitor(params: {
     },
     drain: {
       resolveNonRetryableFailure: resolveWhatsAppIngressNonRetryableFailure,
+      // The lane is per-conversation (remoteJid) and dispatch defers into the
+      // debouncer while the merge window is open. Holding the lane during that
+      // wait (the drain default) blocks every other message in the same
+      // conversation from being admitted, so no two messages ever land in the
+      // same debounce flush. Same defect and same fix as #101335 (Telegram).
+      deferredLaneOccupancy: "release",
       deriveLaneKey: (record) => {
         try {
           return inspectWhatsAppIngressMessage(

--- a/extensions/whatsapp/src/inbound/message-debounce.test.ts
+++ b/extensions/whatsapp/src/inbound/message-debounce.test.ts
@@ -1,0 +1,82 @@
+// Whatsapp plugin module test: debounce merge window and flush ordering.
+import { describe, expect, it } from "vitest";
+import {
+  createWhatsAppInboundMessageDebouncer,
+  type WhatsAppQueuedInboundMessage,
+} from "./message-debounce.js";
+import { createTestWebInboundMessage } from "./test-message.test-helper.js";
+
+function queuedMessage(overrides: {
+  id: string;
+  body: string;
+  timestamp?: number;
+  receiveOrder?: number;
+}): WhatsAppQueuedInboundMessage {
+  const base = createTestWebInboundMessage({
+    event: { id: overrides.id, timestamp: overrides.timestamp },
+    payload: { body: overrides.body },
+  });
+  return { ...base, receiveOrder: overrides.receiveOrder };
+}
+
+describe("createWhatsAppInboundMessageDebouncer", () => {
+  it("merges two same-lane messages that arrive inside one debounce window into a single flush", async () => {
+    const flushed: WhatsAppQueuedInboundMessage[] = [];
+    const debouncer = createWhatsAppInboundMessageDebouncer({
+      debounceMs: 50,
+      onMessage: async (msg) => {
+        flushed.push(msg as WhatsAppQueuedInboundMessage);
+      },
+      markRead: async () => {},
+      onPendingWorkChanged: () => {},
+      onError: (err) => {
+        throw err;
+      },
+    });
+
+    // Both messages arrive back-to-back, well inside the 50ms debounce window.
+    await debouncer.enqueue(
+      queuedMessage({ id: "msg-1", body: "hello", timestamp: 100, receiveOrder: 0 }),
+    );
+    await debouncer.enqueue(
+      queuedMessage({ id: "msg-2", body: "world", timestamp: 100, receiveOrder: 1 }),
+    );
+    await debouncer.drain();
+
+    expect(flushed).toHaveLength(1);
+    expect(flushed[0]?.payload.body).toBe("hello\nworld");
+    expect(flushed[0]?.event.isBatched).toBe(true);
+  });
+
+  it("orders a merged flush by timestamp first, then receiveOrder as the tiebreaker", async () => {
+    const flushed: WhatsAppQueuedInboundMessage[] = [];
+    const debouncer = createWhatsAppInboundMessageDebouncer({
+      debounceMs: 50,
+      onMessage: async (msg) => {
+        flushed.push(msg as WhatsAppQueuedInboundMessage);
+      },
+      markRead: async () => {},
+      onPendingWorkChanged: () => {},
+      onError: (err) => {
+        throw err;
+      },
+    });
+
+    // Arrival order is reversed relative to timestamp order; the flush must
+    // still combine bodies in timestamp order, not arrival order.
+    await debouncer.enqueue(
+      queuedMessage({ id: "msg-later", body: "second", timestamp: 200, receiveOrder: 5 }),
+    );
+    await debouncer.enqueue(
+      queuedMessage({ id: "msg-earlier", body: "first", timestamp: 100, receiveOrder: 4 }),
+    );
+    // Same timestamp as msg-earlier; receiveOrder breaks the tie.
+    await debouncer.enqueue(
+      queuedMessage({ id: "msg-tiebreak", body: "middle", timestamp: 100, receiveOrder: 6 }),
+    );
+    await debouncer.drain();
+
+    expect(flushed).toHaveLength(1);
+    expect(flushed[0]?.payload.body).toBe("first\nmiddle\nsecond");
+  });
+});

--- a/extensions/whatsapp/src/monitor-inbox.delivery-and-dedupe.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.delivery-and-dedupe.test.ts
@@ -344,10 +344,15 @@ describe("web monitor inbox delivery and dedupe", () => {
     const closePromise = listener.close().then(() => {
       closed = true;
     });
-    await waitForMessageCalls(onMessage, 3);
+    // deferredLaneOccupancy: "release" frees the conversation lane as soon as
+    // the first message's ingress dispatch defers, instead of holding it
+    // until the first turn adopts. So "second" and "third" (delivered in the
+    // same upsert batch) both reach the debouncer inside one debounce window
+    // and land in a single merged flush, rather than each paying its own
+    // window serially.
+    await waitForMessageCalls(onMessage, 2);
     expect(closed).toBe(false);
-    expect(inboundMessage(onMessage, 1).payload.body).toBe("second");
-    expect(inboundMessage(onMessage, 2).payload.body).toBe("third");
+    expect(inboundMessage(onMessage, 1).payload.body).toBe("second\nthird");
 
     releaseFirst?.();
     await closePromise;
@@ -650,7 +655,7 @@ describe("web monitor inbox delivery and dedupe", () => {
     await listener.close();
   });
 
-  it("delivery coordinator keeps same-lane follow-up pending until turn adoption", async () => {
+  it("delivery coordinator admits a same-lane follow-up before the first turn adopts", async () => {
     let adoptFirst: (() => void | Promise<void>) | undefined;
     const onMessage = vi.fn(async (message: WebInboundMessage) => {
       if (!adoptFirst) {
@@ -686,17 +691,18 @@ describe("web monitor inbox delivery and dedupe", () => {
         },
       ],
     });
-    await settleInboundWork();
 
-    expect(onMessage).toHaveBeenCalledTimes(1);
-    expect(inboundMessage(onMessage).payload.body).toBe("ping");
+    // deferredLaneOccupancy: "release" frees the WhatsApp conversation lane as
+    // soon as the first message's ingress dispatch defers, so the follow-up
+    // reaches onMessage without waiting for the first turn's own (much
+    // later) session-level adoption.
+    await waitForMessageCalls(onMessage, 2);
+    expect(inboundMessage(onMessage, 1).payload.body).toBe("pong");
 
     if (!adoptFirst) {
       throw new Error("expected first adoption callback");
     }
     await adoptFirst();
-    await waitForMessageCalls(onMessage, 2);
-    expect(inboundMessage(onMessage, 1).payload.body).toBe("pong");
     await listener.close();
   });
 });


### PR DESCRIPTION
Fixes #119382

## What Problem This Solves

`createWhatsAppIngressMonitor` dispatches inbound messages into the WhatsApp inbound debouncer and returns `"deferred"`, but it passes no `deferredLaneOccupancy` to `createIngressDrain`, so the drain default applies:

```ts
// src/infra/ingress-drain.ts
const deferredLaneOccupancy = options.deferredLaneOccupancy ?? "hold";
```

The WhatsApp lane key is the conversation (`remoteJid`), so `"hold"` keeps the lane occupied for the entire debounce window. While message 1 waits to be merged, the start loop cannot admit message 2 in the same conversation and releases it back to the queue; the lane only frees at `onAdopted`, which happens *after* the flush has already created a turn. Message 2 therefore always opens a fresh, empty window and pays `debounceMs` again.

The result is that debounce and per-conversation lane serialization are mutually exclusive as wired: no two messages can ever land in the same flush, and every message pays the full debounce window for no benefit. With `messages.inbound.byChannel.whatsapp.debounceMs = 10000`, every inbound message is delayed 10s and nothing merges.

This is #101335 on a second channel. Telegram had the identical starvation in its spooled drain and was fixed with `deferredLaneOccupancy: "release"`; this applies the same one-line fix to WhatsApp's durable ingress monitor.

## Evidence

**Production symptom** (gateway journal, 2026-08-04, one WhatsApp conversation, `debounceMs = 10000`) — two rapid-fire bursts, one turn per message, zero merges:

```
20:49:07.632  inbound  -> turn
20:49:18.423  inbound  -> turn   (+10.79s)
20:49:28.900  inbound  -> turn   (+10.48s)
20:50:02.977  inbound  -> turn
20:50:13.959  inbound  -> turn   (+10.98s)
20:50:24.352  inbound  -> turn   (+10.39s)
20:50:34.586  inbound  -> turn   (+10.23s)
```

Every delta sits between 10.23s and 10.98s against a 10s window. Across two days of logs, no two consecutive same-lane inbound messages are ever spaced under 10.0s — the signature of each message opening its own window.

**Ruled out, layer by layer:** config intact (`byChannel.whatsapp = 10000`); `resolveInboundDebounceMs` returns `10000` against the real loader; `createInboundDebouncer` merges two items and flushes at 10.3s in isolation; `shouldDebounceTextInbound` returns `true` for plain text. Every layer is healthy on its own — the starvation only exists once the drain wraps it.

**Regression coverage:** three existing cases in `extensions/whatsapp/src/inbound/durable-receive.test.ts` and `extensions/whatsapp/src/monitor-inbox.delivery-and-dedupe.test.ts` asserted the old hold-and-serialize behavior as if intended, and are rewritten here to assert admission of a same-lane follow-up before adoption. Verified both directions on this branch:

- with `deferredLaneOccupancy: "release"` removed → **3 failed | 22 passed**
- with the fix → **25 passed**

Full extension suite: 104 files / 1350 tests pass. `tsgo:extensions`, `tsgo:extensions:test`, `oxfmt` and `oxlint` clean.

## Discord and Mattermost carry the identical defect — fixed here too

The follow-up flagged in the first revision of this PR was confirmed, so it is included rather than deferred. `createDiscordIngressMonitor` (`extensions/discord/src/monitor/ingress.ts`) and `createMattermostIngressMonitor` (`extensions/mattermost/src/mattermost/monitor-ingress.ts`) both dispatch into the reply/turn debouncer, both can return `"deferred"`, and neither passed `deferredLaneOccupancy` — so the same `"hold"` default applied to a `channel:<id>` lane. Both now pass `"release"`.

One regression test per channel proves a second same-lane message arriving while the first is still deferred is dispatched immediately instead of waiting for adoption. Verified both directions:

| channel | flag removed | with the fix |
|---|---|---|
| discord (`extensions/discord/src/monitor/ingress.test.ts`) | 1 failed \| 5 passed — `expected [ '2001' ] to deeply equal [ '2001', '2002' ]` | 6 passed |
| mattermost (`extensions/mattermost/src/mattermost/monitor-ingress.test.ts`) | 1 failed \| 16 passed — `expected [ 'post-lane-a' ] to deeply equal [ 'post-lane-a', 'post-lane-b' ]` | 17 passed |

`oxlint` clean on all four touched source/test files.

## Scope / follow-up

Kept per-channel across the three channels that provably share the shape, matching the Telegram precedent, rather than flipping the `ingress-drain` default. Flipping the default to `"release"` (with `"hold"` opted into by the drains that genuinely need serialization) is probably the right end state, but it would change behavior for channels with no coverage for this path, so it belongs in its own change.

**Explicitly out of scope, to avoid a false claim:** releasing the lane does **not** disarm the claim→adoption stall watchdog. It stays armed through the deferred phase by design — `armStallWatchdog` returns early only outside `"dispatching" | "deferred"`, and `onDeferred` touches lane ownership without clearing the timer. So an agent turn longer than `adoptionStallTimeoutMs` still dead-letters its own deferred claim with `handler-timeout`, on every channel, with or without this fix. That is #116547, and this PR does not address it.
