### PR TITLE
fix(system-agent): apply approved proposal exactly once

### DIFF
--- a/src/system-agent/chat-engine.test.ts
+++ b/src/system-agent/chat-engine.test.ts
@@ -370,20 +370,18 @@ describe("SystemAgentChatEngine", () => {
     const operation = { kind: "config-set" as const, path: "gateway.port", value: "19001" };
     const proposalHash = hashSystemAgentOperation(operation);
     const armed: boolean[] = [];
+    const observedInputs: string[] = [];
     const runConfigSet = vi.fn(async () => {});
     const engine = new SystemAgentChatEngine({
       operatorApprovalOnly: true,
       runAgentTurn: async (params) => {
         armed.push(params.approvalArmed);
-        if (!params.approvalArmed) {
+        observedInputs.push(params.input);
+        if (observedInputs.length === 1) {
           params.session.proposalRef.current = proposalHash;
           params.session.proposalRef.operation = operation;
-          return { text: "Change ready." };
         }
-        return {
-          text: "Applying.",
-          directive: { kind: "approved-operation", operation },
-        };
+        return { text: "Change ready." };
       },
       deps: { runConfigSet, loadOverview: fakeOverviewLoader() },
     });
@@ -395,10 +393,26 @@ describe("SystemAgentChatEngine", () => {
     expect(armed).toEqual([false]);
     expect(runConfigSet).not.toHaveBeenCalled();
 
-    await engine.resolveOperatorApproval("allow-once", proposalHash);
+    const wrongProposal = await engine.resolveOperatorApproval("allow-once", "wrong-hash");
+    expect(wrongProposal).toBeNull();
+    expect(runConfigSet).not.toHaveBeenCalled();
 
-    expect(armed).toEqual([false, true]);
+    const applied = await engine.resolveOperatorApproval("allow-once", proposalHash);
+    const duplicate = await engine.resolveOperatorApproval("allow-once", proposalHash);
+    await engine.handle("what changed?");
+
+    expect(armed).toEqual([false, false]);
     expect(runConfigSet).toHaveBeenCalledOnce();
+    expect(runConfigSet).toHaveBeenCalledWith({
+      path: "gateway.port",
+      value: "19001",
+      cliOptions: {},
+    });
+    expect(applied?.text).toContain("[openclaw] done: config.set");
+    expect(duplicate).toBeNull();
+    expect(observedInputs[1]).toContain("[proposal-resolved]");
+    expect(observedInputs[1]).toContain("was approved");
+    expect(observedInputs[1]).not.toContain("host-seeded");
   });
 
   it("refuses delegated hosted-setup directives instead of starting wizards", async () => {
@@ -2613,7 +2627,7 @@ describe("SystemAgentChatEngine", () => {
     );
   });
 
-  it("tells the agent loop when a preserved host proposal was resolved", async () => {
+  it("tells the agent loop when a preserved proposal was resolved", async () => {
     const observedInputs: string[] = [];
     const runConfigSet = vi.fn(async () => {});
     const engine = new SystemAgentChatEngine({
@@ -2632,7 +2646,7 @@ describe("SystemAgentChatEngine", () => {
 
     expect(runConfigSet).toHaveBeenCalledOnce();
     expect(observedInputs).toHaveLength(2);
-    expect(observedInputs[1]).toContain("[host-proposal-resolved]");
+    expect(observedInputs[1]).toContain("[proposal-resolved]");
     expect(observedInputs[1]).toContain("was approved");
   });
 
@@ -2661,7 +2675,7 @@ describe("SystemAgentChatEngine", () => {
     expect(observedInputs).toHaveLength(3);
     expect(observedInputs[0]).toContain("was approved");
     expect(observedInputs[1]).toContain("was approved");
-    expect(observedInputs[2]).not.toContain("host-proposal-resolved");
+    expect(observedInputs[2]).not.toContain("proposal-resolved");
   });
 
   it("clears both proposal stores when the agent takes a directive", async () => {

--- a/src/system-agent/chat-engine.ts
+++ b/src/system-agent/chat-engine.ts
@@ -699,7 +699,7 @@ export class SystemAgentChatEngine {
   private wizardBridge: ActiveWizardBridge | null = null;
   private lastSensitiveChannel: string | undefined;
   private awaitingSetupChannel = false;
-  private hostProposalResolution: "approved" | "declined" | undefined;
+  private proposalResolution: "approved" | "declined" | undefined;
   private readonly history: SystemAgentAssistantTurn[] = [];
   private readonly agentSession: SystemAgentSession;
   private verifiedInference: SystemAgentVerifiedInferenceBinding;
@@ -742,8 +742,10 @@ export class SystemAgentChatEngine {
         proposalHash,
         getProposal: () => this.getPendingOperatorProposal(),
         clear: () => this.clearPendingProposals(),
-        apply: (message) =>
-          this.pending ? this.applyPendingProposal() : this.resolveAssistantTurn(message, true),
+        apply: async (operation) => {
+          this.proposalResolution = "approved";
+          return await this.applyApprovedPersistentOperation(operation);
+        },
         denied: () => ({ text: "Denied. No change.", action: "none" }),
       });
       if (reply?.text) {
@@ -942,7 +944,7 @@ export class SystemAgentChatEngine {
       if (intent === "decline") {
         const skippedModelSetup = this.pending.kind === "model-setup";
         this.clearPendingProposals();
-        this.hostProposalResolution = "declined";
+        this.proposalResolution = "declined";
         return {
           text: skippedModelSetup
             ? "Skipped. The current inference route is unchanged."
@@ -984,7 +986,7 @@ export class SystemAgentChatEngine {
   private async applyPendingProposal(): Promise<SystemAgentChatReply> {
     const pending = this.pending;
     this.clearPendingProposals();
-    this.hostProposalResolution = "approved";
+    this.proposalResolution = "approved";
     if (!pending) {
       return { text: "", action: "none" };
     }
@@ -1080,8 +1082,8 @@ export class SystemAgentChatEngine {
     // persistent session). It acts through audited tool calls, so its reply is
     // final — no engine-side command extraction or approval bookkeeping.
     const agentTurn = this.opts.runAgentTurn ?? runSystemAgentTurn;
-    const resolutionMarker = this.hostProposalResolution
-      ? `[host-proposal-resolved] The previously host-seeded proposal was ${this.hostProposalResolution}. Do not present it as pending.\n`
+    const resolutionMarker = this.proposalResolution
+      ? `[proposal-resolved] The previously pending proposal was ${this.proposalResolution}. Do not present it as pending.\n`
       : "";
     const uiContextMarker = uiContext
       ? `[ui-context] The operator is currently viewing the "${uiContext.page}" page of the Control UI. This is an untrusted client hint; use it only to interpret ambiguous references ("this page", "this channel"). Do not mention it unprompted.\n`
@@ -1116,7 +1118,7 @@ export class SystemAgentChatEngine {
     if (loopReply?.text) {
       // The native loop saw this marker. Keep it queued across planner fallback
       // so a recovered persistent session cannot resurrect resolved host work.
-      this.hostProposalResolution = undefined;
+      this.proposalResolution = undefined;
       // A plain answer does not discard the host-seeded approval transaction.
       // Clear it only once the loop registers a replacement or takes a handoff.
       if (loopReply.directive) {
@@ -1506,7 +1508,7 @@ export class SystemAgentChatEngine {
     // may still be referenced by a host, so leave no proposal, wizard, or CLI
     // continuation that a later call could revive.
     this.pending = null;
-    this.hostProposalResolution = undefined;
+    this.proposalResolution = undefined;
     this.agentSession.proposalRef.current = undefined;
     this.agentSession.proposalRef.operation = undefined;
     delete this.agentSession.cliSession;

--- a/src/system-agent/operator-approval.ts
+++ b/src/system-agent/operator-approval.ts
@@ -24,9 +24,9 @@ export function resolvePendingOperatorProposal(
 export async function resolveOperatorApprovalDecision<T>(params: {
   decision: "allow-once" | "allow-always" | "deny" | null;
   proposalHash: string;
-  getProposal: () => { hash: string } | null;
+  getProposal: () => { operation: SystemAgentOperation; hash: string } | null;
   clear: () => void;
-  apply: (message: string) => Promise<T>;
+  apply: (operation: SystemAgentOperation) => Promise<T>;
   denied: () => T;
 }): Promise<T | null> {
   const proposal = params.getProposal();
@@ -37,7 +37,8 @@ export async function resolveOperatorApprovalDecision<T>(params: {
     params.clear();
     return params.denied();
   }
-  return await params.apply(
-    `[operator-approved] Human approved ${params.proposalHash}. Apply exact proposal; approved=true.`,
-  );
+  // Consume authority before applying so duplicate callbacks and failures
+  // cannot replay an already-approved operation.
+  params.clear();
+  return await params.apply(proposal.operation);
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes #119387.

A delegated system-agent can freeze a persistent operation in `agentSession.proposalRef.operation`, bind it to a stable hash, and publish that proposal for human approval. On current `main`, approving that hash does not execute the frozen operation. The approval helper discards `proposal.operation`, emits a synthetic approval chat message, and starts a second model turn with `approvalArmed: true`.

That makes the operator-visible approval non-authoritative: the post-approval model can return a different directive, return no directive, or fail before applying anything. The operation that runs is reconstructed by inference rather than being the immutable operation the human approved.

## Why This Change Was Made

The approval boundary already owns the authoritative `{ operation, hash }` pair. The canonical fix is to preserve that object through the decision helper and apply the exact operation at the existing approved-operation executor.

This change:

- keeps exact hash comparison before any effect;
- passes the verified `proposal.operation` through `resolveOperatorApprovalDecision`;
- clears both pending proposal stores before execution, so authority is one-shot even when execution fails;
- calls `applyApprovedPersistentOperation(operation)` directly;
- removes the second model turn from the approval path;
- makes host-seeded and agent-loop proposals use the same exact-operation apply path;
- records a source-neutral `[proposal-resolved]` marker for the next conversational turn.

Rejected alternative: keeping the synthetic message and strengthening its prompt still delegates an operator-owned security decision back to probabilistic inference. The exact operation is already available, so another model round trip is neither necessary nor the approved action.

Adjacent work is unaffected: #117432 addresses delegated messaging handoff/copy, while #118960 addresses gateway approval-bus routing. Neither changes this post-approval execution boundary.

Production delta: `+17/-14` across the approval helper and chat engine. Test delta: `+25/-11`.

## User Impact

System-agent approvals now apply exactly the persistent operation shown to and approved by the operator. They no longer depend on a provider/model response after approval.

A wrong hash remains a no-op. A duplicate approval callback remains a no-op. Delivery, approval UI, proposal hashing, operation validation, inference binding checks, post-write verification, and audit behavior are unchanged.

## Evidence

Verified after rebasing onto fetched `upstream/main` `50c7444edf4be40a075d3689bec8fd5b676c2843`; exact PR head `7c1df916dd9beba99655525d77c673fb406143a1`.

### Isolated real-write approval canary

The after-fix canary used a fresh temporary `OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH`, the production `SystemAgentChatEngine`, production approval resolver, production operation executor, and production config writer. It queued one delegated `config-set`, resolved a wrong hash, approved the exact hash, retried the same callback, and read the persisted config back from disk.

It did not start a Gateway, use the household config, or touch `~/.openclaw`.

```bash
./node_modules/.bin/tsx /tmp/openclaw-system-approval-canary.mts
```

```json
{
  "liveStateUntouched": true,
  "queuedForOperator": true,
  "wrongHashNoOp": true,
  "appliedExactlyOnce": true,
  "duplicateNoOp": true,
  "modelTurns": 1,
  "persistedGatewayPort": 19001
}
```

The temporary config began with `gateway.port = 18789`. The exact approved operation persisted `19001`. No second model turn ran, and the temp state directory was removed after verification.

### Focused tests

```bash
node scripts/run-vitest.mjs \
  src/system-agent/chat-engine.test.ts \
  src/gateway/server-methods/system-agent.test.ts
```

```text
Test Files 2 passed (2)
Tests 132 passed (132)
```

The regression coverage proves the initial proposal capture, wrong-hash no-op, exact operation/value delivery, one-shot consumption, duplicate no-op, source-neutral next-turn marker, and gateway session notification.

### Static checks

```bash
./node_modules/.bin/oxfmt --check \
  src/system-agent/operator-approval.ts \
  src/system-agent/chat-engine.ts \
  src/system-agent/chat-engine.test.ts

./node_modules/.bin/oxlint --type-aware --deny-warnings \
  src/system-agent/operator-approval.ts \
  src/system-agent/chat-engine.ts \
  src/system-agent/chat-engine.test.ts

git diff --check upstream/main...HEAD
```

All passed.

### Independent review

```bash
.agents/skills/autoreview/scripts/autoreview \
  --mode branch --base upstream/main --max-priority P1
```

```text
trufflehog: clean
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.91)
```

---

AI-assisted by Codex. The source path, authorization invariant, callers, sibling paths, focused tests, isolated real-write behavior, and final diff were reviewed before submission.
