### PR TITLE
fix(discord): avoid doctor runtime loading

### DIFF
--- a/extensions/discord/package.json
+++ b/extensions/discord/package.json
@@ -78,6 +78,12 @@
       "commands": {
         "nativeCommandsAutoEnabled": true,
         "nativeSkillsAutoEnabled": true
+      },
+      "doctorCapabilities": {
+        "dmAllowFromMode": "topOnly",
+        "groupModel": "route",
+        "groupAllowFromFallbackToAllowFrom": false,
+        "warnOnEmptyGroupSenderAllowlist": false
       }
     },
     "install": {

--- a/scripts/lib/official-external-channel-catalog.json
+++ b/scripts/lib/official-external-channel-catalog.json
@@ -571,6 +571,12 @@
           "commands": {
             "nativeCommandsAutoEnabled": true,
             "nativeSkillsAutoEnabled": true
+          },
+          "doctorCapabilities": {
+            "dmAllowFromMode": "topOnly",
+            "groupModel": "route",
+            "groupAllowFromFallbackToAllowFrom": false,
+            "warnOnEmptyGroupSenderAllowlist": false
           }
         },
         "install": {

--- a/src/channels/bundled-channel-catalog-read.test.ts
+++ b/src/channels/bundled-channel-catalog-read.test.ts
@@ -39,7 +39,10 @@ vi.mock("../infra/openclaw-root.js", () => ({
 
 import { resolveBundledPluginsDir } from "../plugins/bundled-dir.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
-import { listBundledChannelCatalogEntries } from "./bundled-channel-catalog-read.js";
+import {
+  findBundledChannelCatalogMetadata,
+  listBundledChannelCatalogEntries,
+} from "./bundled-channel-catalog-read.js";
 import { listBundledChannelIds } from "./plugins/bundled-ids.js";
 
 const tempDirs: string[] = [];
@@ -126,6 +129,12 @@ function seedGeneratedChannelCatalog(
     label: string;
     docsPath: string;
     blurb: string;
+    doctorCapabilities?: {
+      dmAllowFromMode?: "topOnly" | "nestedOnly";
+      groupModel?: "sender" | "route" | "hybrid";
+      groupAllowFromFallbackToAllowFrom?: boolean;
+      warnOnEmptyGroupSenderAllowlist?: boolean;
+    };
   },
 ): void {
   const { packageName, ...channel } = params;
@@ -220,6 +229,31 @@ describe("listBundledChannelCatalogEntries", () => {
     const ids = new Set(entries.map((entry) => entry.id));
     expect(ids.has("qqbot")).toBe(true);
     expect(ids.has("telegram")).toBe(true);
+  });
+
+  it("finds doctor capabilities from the generated catalog when the package is excluded", () => {
+    const root = seedRoot("bcr-generated-doctor-");
+    useBundledPluginsDir(undefined);
+    seedGeneratedChannelCatalog(root, {
+      packageName: "@openclaw/discord",
+      id: "discord",
+      label: "Discord",
+      docsPath: "/channels/discord",
+      blurb: "downloadable channel",
+      doctorCapabilities: {
+        dmAllowFromMode: "topOnly",
+        groupModel: "route",
+        groupAllowFromFallbackToAllowFrom: false,
+        warnOnEmptyGroupSenderAllowlist: false,
+      },
+    });
+
+    expect(findBundledChannelCatalogMetadata("Discord")?.doctorCapabilities).toEqual({
+      dmAllowFromMode: "topOnly",
+      groupModel: "route",
+      groupAllowFromFallbackToAllowFrom: false,
+      warnOnEmptyGroupSenderAllowlist: false,
+    });
   });
 
   it("keeps bundled package metadata when generated catalog entries are stale", () => {

--- a/src/channels/bundled-channel-catalog-read.ts
+++ b/src/channels/bundled-channel-catalog-read.ts
@@ -157,3 +157,16 @@ export function listBundledChannelCatalogEntries(): BundledChannelCatalogEntry[]
     (left, right) => left.order - right.order || left.id.localeCompare(right.id),
   );
 }
+
+/** Finds bundled or generated channel metadata by id or alias. */
+export function findBundledChannelCatalogMetadata(
+  channelId: string,
+): PluginPackageChannel | undefined {
+  const normalized = normalizeOptionalLowercaseString(channelId);
+  if (!normalized) {
+    return undefined;
+  }
+  return listBundledChannelCatalogEntries().find(
+    (entry) => entry.id === normalized || entry.aliases.includes(normalized),
+  )?.channel;
+}

--- a/src/commands/doctor/channel-capabilities.packaged.test.ts
+++ b/src/commands/doctor/channel-capabilities.packaged.test.ts
@@ -1,0 +1,85 @@
+// Packaged doctor capability tests cover generated catalog lookup without plugin runtime loading.
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanupTempDirs,
+  makeTempRepoRoot,
+  writeJsonFile,
+} from "../../../test/helpers/temp-repo.js";
+
+const packageRootMock = vi.hoisted(() => ({ value: "" }));
+const channelPluginMocks = vi.hoisted(() => ({
+  getBundledChannelPlugin: vi.fn(() => undefined),
+  getChannelPlugin: vi.fn(() => undefined),
+}));
+
+vi.mock("../../channels/plugins/bundled.js", () => ({
+  getBundledChannelPlugin: channelPluginMocks.getBundledChannelPlugin,
+}));
+
+vi.mock("../../channels/plugins/index.js", () => ({
+  getChannelPlugin: channelPluginMocks.getChannelPlugin,
+}));
+
+vi.mock("../../plugins/bundled-dir.js", () => ({
+  resolveBundledPluginsDir: () => undefined,
+  resolveSourceCheckoutDependencyDiagnostic: () => null,
+}));
+
+vi.mock("../../infra/openclaw-root.js", () => ({
+  resolveOpenClawPackageRootSync: () => packageRootMock.value,
+  resolveOpenClawPackageRoot: async () => packageRootMock.value,
+}));
+
+import { clearPluginMetadataLifecycleCaches } from "../../plugins/plugin-metadata-lifecycle.js";
+import { getDoctorChannelCapabilities } from "./channel-capabilities.js";
+
+const tempDirs: string[] = [];
+
+beforeEach(() => {
+  const root = makeTempRepoRoot(tempDirs, "doctor-channel-packaged-");
+  packageRootMock.value = root;
+  writeJsonFile(path.join(root, "package.json"), { name: "openclaw" });
+  writeJsonFile(path.join(root, "dist", "channel-catalog.json"), {
+    entries: [
+      {
+        name: "@openclaw/discord",
+        openclaw: {
+          channel: {
+            id: "discord",
+            label: "Discord",
+            doctorCapabilities: {
+              dmAllowFromMode: "topOnly",
+              groupModel: "route",
+              groupAllowFromFallbackToAllowFrom: false,
+              warnOnEmptyGroupSenderAllowlist: false,
+            },
+          },
+        },
+      },
+    ],
+  });
+  clearPluginMetadataLifecycleCaches();
+  channelPluginMocks.getBundledChannelPlugin.mockReset().mockReturnValue(undefined);
+  channelPluginMocks.getChannelPlugin.mockReset().mockReturnValue(undefined);
+});
+
+afterEach(() => {
+  packageRootMock.value = "";
+  clearPluginMetadataLifecycleCaches();
+  cleanupTempDirs(tempDirs);
+  vi.restoreAllMocks();
+});
+
+describe("doctor channel capabilities in a packaged install", () => {
+  it("reads Discord semantics from the generated catalog without loading a plugin", () => {
+    expect(getDoctorChannelCapabilities("discord")).toEqual({
+      dmAllowFromMode: "topOnly",
+      groupModel: "route",
+      groupAllowFromFallbackToAllowFrom: false,
+      warnOnEmptyGroupSenderAllowlist: false,
+    });
+    expect(channelPluginMocks.getChannelPlugin).not.toHaveBeenCalled();
+    expect(channelPluginMocks.getBundledChannelPlugin).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/doctor/channel-capabilities.test.ts
+++ b/src/commands/doctor/channel-capabilities.test.ts
@@ -69,6 +69,17 @@ describe("doctor channel capabilities", () => {
     });
   });
 
+  it("returns Discord route semantics without loading its channel plugin", () => {
+    expect(getDoctorChannelCapabilities("discord")).toEqual({
+      dmAllowFromMode: "topOnly",
+      groupModel: "route",
+      groupAllowFromFallbackToAllowFrom: false,
+      warnOnEmptyGroupSenderAllowlist: false,
+    });
+    expect(channelPluginMocks.getChannelPlugin).not.toHaveBeenCalled();
+    expect(channelPluginMocks.getBundledChannelPlugin).not.toHaveBeenCalled();
+  });
+
   it("returns capability overrides from matrix plugin metadata", () => {
     expect(getDoctorChannelCapabilities("matrix")).toEqual({
       dmAllowFromMode: "nestedOnly",

--- a/src/commands/doctor/channel-capabilities.ts
+++ b/src/commands/doctor/channel-capabilities.ts
@@ -1,10 +1,10 @@
+import { findBundledChannelCatalogMetadata } from "../../channels/bundled-channel-catalog-read.js";
 // Doctor capability lookup for channel-specific policy and migration behavior.
 import { getBundledChannelPlugin } from "../../channels/plugins/bundled.js";
 import type { ChannelDmAllowFromMode } from "../../channels/plugins/dm-access.js";
 import { getChannelPlugin } from "../../channels/plugins/index.js";
 import { normalizeAnyChannelId } from "../../channels/registry.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { findBundledPackageChannelMetadata } from "../../plugins/bundled-package-channel-metadata.js";
 import type { PluginPackageChannelDoctorCapabilities } from "../../plugins/manifest.js";
 
 type DoctorGroupModel = "sender" | "route" | "hybrid";
@@ -39,10 +39,10 @@ function mergeDoctorChannelCapabilities(
   };
 }
 
-function getManifestDoctorCapabilities(
+function getCatalogDoctorCapabilities(
   channelId: string,
 ): PluginPackageChannelDoctorCapabilities | undefined {
-  return findBundledPackageChannelMetadata(channelId)?.doctorCapabilities;
+  return findBundledChannelCatalogMetadata(channelId)?.doctorCapabilities;
 }
 
 /** Resolve doctor behavior capabilities from channel metadata, plugin runtime, or defaults. */
@@ -51,9 +51,9 @@ export function getDoctorChannelCapabilities(channelName?: string): DoctorChanne
     return DEFAULT_DOCTOR_CHANNEL_CAPABILITIES;
   }
 
-  const manifestCapabilities = getManifestDoctorCapabilities(channelName);
-  if (manifestCapabilities) {
-    return mergeDoctorChannelCapabilities(manifestCapabilities);
+  const catalogCapabilities = getCatalogDoctorCapabilities(channelName);
+  if (catalogCapabilities) {
+    return mergeDoctorChannelCapabilities(catalogCapabilities);
   }
 
   const channelId = normalizeAnyChannelId(channelName);
@@ -65,7 +65,7 @@ export function getDoctorChannelCapabilities(channelName?: string): DoctorChanne
   if (pluginDoctor) {
     return mergeDoctorChannelCapabilities(pluginDoctor);
   }
-  return mergeDoctorChannelCapabilities(getManifestDoctorCapabilities(channelId));
+  return mergeDoctorChannelCapabilities(getCatalogDoctorCapabilities(channelId));
 }
 
 type DoctorChannelAccountIds = {

--- a/src/plugins/bundled-package-channel-metadata.test.ts
+++ b/src/plugins/bundled-package-channel-metadata.test.ts
@@ -10,7 +10,7 @@ vi.mock("./bundled-dir.js", () => ({
 }));
 
 import { resolveBundledPluginsDir } from "./bundled-dir.js";
-import { findBundledPackageChannelMetadata } from "./bundled-package-channel-metadata.js";
+import { listBundledPackageChannelMetadata } from "./bundled-package-channel-metadata.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
 
 const tempDirs: string[] = [];
@@ -72,7 +72,7 @@ describe("bundled package channel metadata", () => {
     );
     useBundledPluginsDir(extensionsRoot);
 
-    const matrix = findBundledPackageChannelMetadata("matrix");
+    const matrix = listBundledPackageChannelMetadata().find((channel) => channel.id === "matrix");
 
     expect(matrix?.doctorCapabilities).toEqual({
       dmAllowFromMode: "nestedOnly",
@@ -107,7 +107,9 @@ describe("bundled package channel metadata", () => {
       "export default {};\n",
       "utf8",
     );
-    expect(findBundledPackageChannelMetadata("matrix")?.label).toBe("Before");
+    expect(
+      listBundledPackageChannelMetadata().find((channel) => channel.id === "matrix")?.label,
+    ).toBe("Before");
 
     writeJsonFile(packagePath, {
       name: "@openclaw/matrix",
@@ -120,6 +122,8 @@ describe("bundled package channel metadata", () => {
     });
 
     clearPluginMetadataLifecycleCaches();
-    expect(findBundledPackageChannelMetadata("matrix")?.label).toBe("After");
+    expect(
+      listBundledPackageChannelMetadata().find((channel) => channel.id === "matrix")?.label,
+    ).toBe("After");
   });
 });

--- a/src/plugins/bundled-package-channel-metadata.ts
+++ b/src/plugins/bundled-package-channel-metadata.ts
@@ -6,12 +6,3 @@ import type { PluginPackageChannel } from "./manifest.js";
 export function listBundledPackageChannelMetadata(): readonly PluginPackageChannel[] {
   return listChannelCatalogEntries({ origin: "bundled" }).map((entry) => entry.channel);
 }
-
-/** Finds bundled package channel metadata by id or alias. */
-export function findBundledPackageChannelMetadata(
-  channelId: string,
-): PluginPackageChannel | undefined {
-  return listBundledPackageChannelMetadata().find(
-    (channel) => channel.id === channelId || channel.aliases?.includes(channelId),
-  );
-}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the release unit-fast lane could exceed its 120-second per-test timeout while evaluating Discord `allowFrom` policy. Doctor capability discovery loaded the full Discord plugin graph when static metadata was unavailable, including in packaged installs where Discord is excluded from `dist/extensions`.

## Why This Change Was Made

Publishes Discord's existing doctor capability contract and makes doctor read it through the canonical bundled channel catalog before falling back to runtime plugin loading. That reader uses package manifests in source checkouts and the generated `dist/channel-catalog.json` in packaged installs.

The packaged-layout regression removes the bundled plugin directory, supplies only the generated catalog, and verifies that neither runtime plugin loader is called.

## User Impact

No intentional product behavior changes. Release and CI validation no longer pay the Discord runtime-load cost for static doctor policy checks, and packaged installs use the same static capability contract.

## Evidence

- Reproduced twice on the same exact release-validation child run:
  - attempt 1: https://github.com/openclaw/openclaw/actions/runs/30958865284/job/92158176091
  - attempt 2: https://github.com/openclaw/openclaw/actions/runs/30958865284/job/92168906864
- Exact pushed head: `b0d230f403271e0c840cc06ff051f62c65865a64`
- Exact-head Blacksmith Testbox proof: https://github.com/openclaw/openclaw/actions/runs/30969113539
  - full core unit-fast: 1,297 files passed; 15,096 tests passed
  - original failing file: 14 tests passed in 5 ms
  - `pnpm check:changed`: passed
  - `pnpm build`: passed
  - elapsed: 31m26s
- Exact-head hosted CI: https://github.com/openclaw/openclaw/actions/runs/30969075694
  - 81 checks passed; aggregate `openclaw/ci-gate` passed
  - one unrelated updater test failed once, then passed in the exact failed-job rerun
  - the exact test passed locally in 1.67s; the complete updater test file passed 81/81 in 12.45s
- Focused proof:
  - doctor, packaged catalog, package metadata, catalog reader, and original timeout regressions: 36 tests passed across 4 shards
  - `node scripts/write-official-channel-catalog.mjs --check`
  - `git diff --check`
- Fresh uncommitted Codex autoreview: no accepted/actionable findings; patch correct at 0.99 confidence.
- Fresh committed-branch Codex autoreview at `b0d230f`: no accepted/actionable findings; patch correct at 0.99 confidence.
- ClawSweeper rank-up moves addressed:
  - doctor now reads the generated packaged channel catalog before runtime fallback
  - packaged-layout regression asserts neither plugin loader runs
- Fresh exact-head ClawSweeper: no actionable findings; prior packaged-layout blocker resolved.
- ClawSweeper `Before merge` items satisfied:
  - catalog-generation and packaged-layout regression gates retained
  - exact-head hosted CI completed successfully
- Changelog: omitted because this restores release-validation reliability without changing shipped user behavior.

AI-assisted: yes. The implementation was independently reviewed with the repository autoreview workflow.

Punchcard-Session: amber-workshop-river-yr
