### PR TITLE
fix(code-mode): keep MCP node label truncation UTF-16 safe

### DIFF
--- a/src/agents/code-mode-namespaces.test.ts
+++ b/src/agents/code-mode-namespaces.test.ts
@@ -1,3 +1,4 @@
+import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
 import {
   createCodeModeNamespaceRuntime,
@@ -181,7 +182,7 @@ describe("Code Mode MCP namespace model", () => {
     // The prompt should mention the node label without a dangling high surrogate.
     const labelMatch = prompt.match(/\(node: (.+)\)/);
     expect(labelMatch).not.toBeNull();
-    const label = labelMatch![1];
+    const label = expectDefined(labelMatch?.[1], "node label capture group");
     // No lone high surrogate at the end: the emoji must be fully present or fully absent.
     expect(label.endsWith("\uD83D")).toBe(false);
     expect(label.length).toBe(127);

--- a/src/agents/code-mode-namespaces.test.ts
+++ b/src/agents/code-mode-namespaces.test.ts
@@ -1,4 +1,3 @@
-import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
 import {
   createCodeModeNamespaceRuntime,
@@ -167,11 +166,7 @@ describe("Code Mode MCP namespace model", () => {
   });
 
   it("does not split UTF-16 surrogate pairs in node display names at the 128-char boundary", () => {
-    // 127 ASCII code units + one supplementary character (2 UTF-16 code units) = 129 units.
-    // A naive .slice(0, 128) keeps the high surrogate and drops the low surrogate,
-    // producing a lone surrogate in the model-facing system prompt.
-    const emoji = "\uD83D\uDCF1"; // 📱 U+1F4F1
-    const displayName = "a".repeat(127) + emoji;
+    const displayName = `${"a".repeat(127)}\uD83D\uDCF1`;
     const catalog = [
       mcpCatalogEntry({
         id: "github__read_file",
@@ -179,12 +174,8 @@ describe("Code Mode MCP namespace model", () => {
       }),
     ];
     const prompt = describeCodeModeNamespacesForPrompt(catalog);
-    // The prompt should mention the node label without a dangling high surrogate.
-    const labelMatch = prompt.match(/\(node: (.+)\)/);
-    expect(labelMatch).not.toBeNull();
-    const label = expectDefined(labelMatch?.[1], "node label capture group");
-    // No lone high surrogate at the end: the emoji must be fully present or fully absent.
-    expect(label.endsWith("\uD83D")).toBe(false);
-    expect(label.length).toBe(127);
+
+    expect(prompt).toContain(`visible servers: github (node: ${"a".repeat(127)}).`);
+    expect(prompt).not.toContain("\uD83D");
   });
 });

--- a/src/agents/code-mode-namespaces.test.ts
+++ b/src/agents/code-mode-namespaces.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { createCodeModeNamespaceRuntime } from "./code-mode-namespaces.js";
+import {
+  createCodeModeNamespaceRuntime,
+  describeCodeModeNamespacesForPrompt,
+} from "./code-mode-namespaces.js";
 
 type McpCatalogEntry = NonNullable<Parameters<typeof createCodeModeNamespaceRuntime>[0]>[number];
 
@@ -160,5 +163,27 @@ describe("Code Mode MCP namespace model", () => {
       );
     }
     expect(executeTool).not.toHaveBeenCalled();
+  });
+
+  it("does not split UTF-16 surrogate pairs in node display names at the 128-char boundary", () => {
+    // 127 ASCII code units + one supplementary character (2 UTF-16 code units) = 129 units.
+    // A naive .slice(0, 128) keeps the high surrogate and drops the low surrogate,
+    // producing a lone surrogate in the model-facing system prompt.
+    const emoji = "\uD83D\uDCF1"; // 📱 U+1F4F1
+    const displayName = "a".repeat(127) + emoji;
+    const catalog = [
+      mcpCatalogEntry({
+        id: "github__read_file",
+        node: { id: "node-1", displayName },
+      }),
+    ];
+    const prompt = describeCodeModeNamespacesForPrompt(catalog);
+    // The prompt should mention the node label without a dangling high surrogate.
+    const labelMatch = prompt.match(/\(node: (.+)\)/);
+    expect(labelMatch).not.toBeNull();
+    const label = labelMatch![1];
+    // No lone high surrogate at the end: the emoji must be fully present or fully absent.
+    expect(label.endsWith("\uD83D")).toBe(false);
+    expect(label.length).toBe(127);
   });
 });

--- a/src/agents/code-mode-namespaces.ts
+++ b/src/agents/code-mode-namespaces.ts
@@ -1,9 +1,9 @@
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 /**
  * Registry and runtime projection for code-mode namespaces. Plugins register
  * namespaced tool scopes here; code mode receives descriptors, virtual API
  * files, and a guarded invocation runtime.
  */
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { tokTypes } from "acorn";
 import { isRecord } from "../../packages/normalization-core/src/record-coerce.js";
 import type { PluginToolMcpMeta } from "../plugins/tools.js";

--- a/src/agents/code-mode-namespaces.ts
+++ b/src/agents/code-mode-namespaces.ts
@@ -1,3 +1,4 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 /**
  * Registry and runtime projection for code-mode namespaces. Plugins register
  * namespaced tool scopes here; code mode receives descriptors, virtual API
@@ -341,7 +342,7 @@ function assignMcpNamespaceServerNames(
 }
 
 function mcpNodeLabel(node: NonNullable<McpNamespaceServer["node"]>): string {
-  return (node.displayName?.trim() || node.id).replace(/\s+/gu, " ").slice(0, 128);
+  return truncateUtf16Safe((node.displayName?.trim() || node.id).replace(/\s+/gu, " "), 128);
 }
 
 function createMcpNamespaceModel(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a paired MCP node display name could be cut between UTF-16 surrogate halves when it crossed the 128-code-unit prompt limit. The malformed label was then included in the model-facing Code Mode namespace prompt.

## Why This Change Was Made

The namespace model now applies the existing `truncateUtf16Safe` helper at the point where it owns the node-label bound. The regression test exercises the exported prompt projection and verifies both the exact truncated label and the absence of a dangling high surrogate.

## User Impact

Code Mode prompts keep paired MCP node labels valid Unicode at the length boundary instead of emitting a malformed or replacement character. There are no config, protocol, SDK, or persistence changes.

## Evidence

- Direct before/after prompt projection: the previous `.slice(0, 128)` result ends with `\uD83D`; the fixed prompt contains the exact 127-character label suffix and no `\uD83D`.
- `node scripts/run-vitest.mjs src/agents/code-mode-namespaces.test.ts packages/normalization-core/src/utf16-slice.test.ts` - 31/31 tests passed.
- `node scripts/check-changed.mjs -- src/agents/code-mode-namespaces.ts src/agents/code-mode-namespaces.test.ts` - passed on Blacksmith Testbox, including formatting, core and core-test typechecks, lint, import cycles, and repository guards.
- Testbox evidence: https://github.com/openclaw/openclaw/actions/runs/31126566673

Punchcard-Session: ember-brook-summit-3t
