### PR TITLE
docs: openclaw-refactor-docs points at a skill renamed in 0dabb70

### DIFF
--- a/.agents/skills/openclaw-refactor-docs/SKILL.md
+++ b/.agents/skills/openclaw-refactor-docs/SKILL.md
@@ -10,7 +10,7 @@ description: Refactor an existing OpenClaw docs page with source-audited preserv
 Use this skill when the user gives a target OpenClaw docs page and asks to
 rewrite, refactor, reorganize, split, shorten, or improve it.
 
-This skill builds on `openclaw-docs`: use that skill for style, page types,
+This skill builds on `technical-documentation`: use that skill for style, page types,
 structure, examples, discoverability, and verification. This skill adds the
 rewrite workflow needed to avoid losing accurate behavior during a major docs
 refactor.
@@ -53,7 +53,7 @@ Prefer this split:
 
 ### 1. Load the doc standard
 
-Read `../openclaw-docs/SKILL.md` first. Apply its page-type, style,
+Read `../technical-documentation/SKILL.md` first. Apply its page-type, style,
 examples, navigation, and verification guidance throughout the refactor.
 
 Run `pnpm docs:list` when available, then read only the target page and the
@@ -61,7 +61,7 @@ likely entry points, references, or related pages needed for the refactor.
 
 ### 2. Classify the page
 
-Before editing, decide the intended page type from `openclaw-docs`.
+Before editing, decide the intended page type from `technical-documentation`.
 
 If the current page mixes page types, choose the main page type and plan where
 the other material belongs:

--- a/.agents/skills/openclaw-refactor-docs/SKILL.md
+++ b/.agents/skills/openclaw-refactor-docs/SKILL.md
@@ -53,7 +53,7 @@ Prefer this split:
 
 ### 1. Load the doc standard
 
-Read `.agents/skills/technical-documentation/SKILL.md` first. Apply its page-type, style,
+Read `../technical-documentation/SKILL.md` first. Apply its page-type, style,
 examples, navigation, and verification guidance throughout the refactor.
 
 Run `pnpm docs:list` when available, then read only the target page and the

--- a/.agents/skills/openclaw-refactor-docs/SKILL.md
+++ b/.agents/skills/openclaw-refactor-docs/SKILL.md
@@ -53,7 +53,7 @@ Prefer this split:
 
 ### 1. Load the doc standard
 
-Read `../technical-documentation/SKILL.md` first. Apply its page-type, style,
+Read `.agents/skills/technical-documentation/SKILL.md` first. Apply its page-type, style,
 examples, navigation, and verification guidance throughout the refactor.
 
 Run `pnpm docs:list` when available, then read only the target page and the

--- a/.agents/skills/technical-documentation/SKILL.md
+++ b/.agents/skills/technical-documentation/SKILL.md
@@ -29,14 +29,14 @@ Produce and review technical documentation that is clear, actionable, and mainta
 1. Classify task: `build` or `review`; context: `brownfield` or `evergreen`.
 2. Inventory full documentation scope early (governance + product docs): AGENTS/CONTRIBUTING/aliases plus docs directories, framework sources, and root/module READMEs.
 3. Detect multilingual scope (README/docs in multiple languages) and define required parity level.
-4. Read `{baseDir}/references/agent-and-contributing.md` for agent instruction and `CONTRIBUTING.md` workflow rules (inventory, canonical/alias mapping, dual-mode balance, deliverable standards, and precedence/conflict handling).
-5. Read `{baseDir}/references/principles.md` for the governing ruleset (Matt Palmer & OpenAI).
-6. For OpenClaw docs work, read `{baseDir}/references/openclaw.md` before the build/review playbook.
-7. For build tasks, follow `{baseDir}/references/build.md`.
-8. For review tasks, follow `{baseDir}/references/review.md` and proactively detect issues without waiting for repeated prompts.
+4. Read `references/agent-and-contributing.md` for agent instruction and `CONTRIBUTING.md` workflow rules (inventory, canonical/alias mapping, dual-mode balance, deliverable standards, and precedence/conflict handling).
+5. Read `references/principles.md` for the governing ruleset (Matt Palmer & OpenAI).
+6. For OpenClaw docs work, read `references/openclaw.md` before the build/review playbook.
+7. For build tasks, follow `references/build.md`.
+8. For review tasks, follow `references/review.md` and proactively detect issues without waiting for repeated prompts.
 9. For complex or high-risk tasks (build or review), it is acceptable to run longer, deeper, and more exhaustive investigations when needed for confidence.
 10. When available, use sub-agents for bounded parallel discovery/review work, then merge outputs into one coherent final deliverable.
-11. Use `{baseDir}/references/tooling.md` when platform/tooling choices affect recommendations.
+11. Use `references/tooling.md` when platform/tooling choices affect recommendations.
 12. Run a proactive issue sweep for both governance and docs-content surfaces, and fix high-confidence defects in the same pass unless explicitly asked for report-only mode.
 13. In brownfield mode, prioritize compatibility with current docs IA, tooling, and release state.
 14. In evergreen mode, prioritize timeless wording, update strategy, and durable structure.
@@ -46,10 +46,10 @@ Produce and review technical documentation that is clear, actionable, and mainta
 
 Prefer sub-agents when the repo is large or the requested change set is broad; use them by default for repo-wide, multi-framework, or high-conflict work.
 
-- `inventory-agent` -> `{baseDir}/agents/inventory-agent.md` (`fast` / Claude `haiku`): file/config discovery, coverage map, and missing-path checks.
-- `governance-agent` -> `{baseDir}/agents/governance-agent.md` (`thinking` / Claude `sonnet`): AGENTS/CONTRIBUTING/alias precedence, conflicts, and policy drift.
-- `docs-framework-agent` -> `{baseDir}/agents/docs-framework-agent.md` (`thinking` / Claude `sonnet`): framework config, relative path base, and file-path vs URL-path mapping checks.
-- `synthesis-agent` -> `{baseDir}/agents/synthesis-agent.md` (`long` / Claude `opus`): merge sub-agent outputs into one prioritized fix plan and unified precedence model.
+- `inventory-agent` -> `agents/inventory-agent.md` (`fast` / Claude `haiku`): file/config discovery, coverage map, and missing-path checks.
+- `governance-agent` -> `agents/governance-agent.md` (`thinking` / Claude `sonnet`): AGENTS/CONTRIBUTING/alias precedence, conflicts, and policy drift.
+- `docs-framework-agent` -> `agents/docs-framework-agent.md` (`thinking` / Claude `sonnet`): framework config, relative path base, and file-path vs URL-path mapping checks.
+- `synthesis-agent` -> `agents/synthesis-agent.md` (`long` / Claude `opus`): merge sub-agent outputs into one prioritized fix plan and unified precedence model.
 
 ## Inputs
 

--- a/.agents/skills/technical-documentation/SKILL.md
+++ b/.agents/skills/technical-documentation/SKILL.md
@@ -29,14 +29,14 @@ Produce and review technical documentation that is clear, actionable, and mainta
 1. Classify task: `build` or `review`; context: `brownfield` or `evergreen`.
 2. Inventory full documentation scope early (governance + product docs): AGENTS/CONTRIBUTING/aliases plus docs directories, framework sources, and root/module READMEs.
 3. Detect multilingual scope (README/docs in multiple languages) and define required parity level.
-4. Read `references/agent-and-contributing.md` for agent instruction and `CONTRIBUTING.md` workflow rules (inventory, canonical/alias mapping, dual-mode balance, deliverable standards, and precedence/conflict handling).
-5. Read `references/principles.md` for the governing ruleset (Matt Palmer & OpenAI).
-6. For OpenClaw docs work, read `references/openclaw.md` before the build/review playbook.
-7. For build tasks, follow `references/build.md`.
-8. For review tasks, follow `references/review.md` and proactively detect issues without waiting for repeated prompts.
+4. Read `{baseDir}/references/agent-and-contributing.md` for agent instruction and `CONTRIBUTING.md` workflow rules (inventory, canonical/alias mapping, dual-mode balance, deliverable standards, and precedence/conflict handling).
+5. Read `{baseDir}/references/principles.md` for the governing ruleset (Matt Palmer & OpenAI).
+6. For OpenClaw docs work, read `{baseDir}/references/openclaw.md` before the build/review playbook.
+7. For build tasks, follow `{baseDir}/references/build.md`.
+8. For review tasks, follow `{baseDir}/references/review.md` and proactively detect issues without waiting for repeated prompts.
 9. For complex or high-risk tasks (build or review), it is acceptable to run longer, deeper, and more exhaustive investigations when needed for confidence.
 10. When available, use sub-agents for bounded parallel discovery/review work, then merge outputs into one coherent final deliverable.
-11. Use `references/tooling.md` when platform/tooling choices affect recommendations.
+11. Use `{baseDir}/references/tooling.md` when platform/tooling choices affect recommendations.
 12. Run a proactive issue sweep for both governance and docs-content surfaces, and fix high-confidence defects in the same pass unless explicitly asked for report-only mode.
 13. In brownfield mode, prioritize compatibility with current docs IA, tooling, and release state.
 14. In evergreen mode, prioritize timeless wording, update strategy, and durable structure.
@@ -46,10 +46,10 @@ Produce and review technical documentation that is clear, actionable, and mainta
 
 Prefer sub-agents when the repo is large or the requested change set is broad; use them by default for repo-wide, multi-framework, or high-conflict work.
 
-- `inventory-agent` -> `agents/inventory-agent.md` (`fast` / Claude `haiku`): file/config discovery, coverage map, and missing-path checks.
-- `governance-agent` -> `agents/governance-agent.md` (`thinking` / Claude `sonnet`): AGENTS/CONTRIBUTING/alias precedence, conflicts, and policy drift.
-- `docs-framework-agent` -> `agents/docs-framework-agent.md` (`thinking` / Claude `sonnet`): framework config, relative path base, and file-path vs URL-path mapping checks.
-- `synthesis-agent` -> `agents/synthesis-agent.md` (`long` / Claude `opus`): merge sub-agent outputs into one prioritized fix plan and unified precedence model.
+- `inventory-agent` -> `{baseDir}/agents/inventory-agent.md` (`fast` / Claude `haiku`): file/config discovery, coverage map, and missing-path checks.
+- `governance-agent` -> `{baseDir}/agents/governance-agent.md` (`thinking` / Claude `sonnet`): AGENTS/CONTRIBUTING/alias precedence, conflicts, and policy drift.
+- `docs-framework-agent` -> `{baseDir}/agents/docs-framework-agent.md` (`thinking` / Claude `sonnet`): framework config, relative path base, and file-path vs URL-path mapping checks.
+- `synthesis-agent` -> `{baseDir}/agents/synthesis-agent.md` (`long` / Claude `opus`): merge sub-agent outputs into one prioritized fix plan and unified precedence model.
 
 ## Inputs
 


### PR DESCRIPTION
Related: #119393

Three references to a skill that was renamed. One file, three lines.

## What Problem This Solves

`openclaw-refactor-docs` opens its workflow by telling the agent to read `../openclaw-docs/SKILL.md` first. That skill does not exist. The read returns nothing, the agent continues, and the docs refactor is performed without the guidance the skill assumed it had. Nothing errors, so the missing input never appears in the transcript and a weak refactor cannot easily be traced back to its cause.

`openclaw-docs` was removed in 0dabb7010bc748c6de5e0e10f42d451bab8a5023 ("docs: replace OpenClaw docs skill and add plugin permissions guide"), which deleted `.agents/skills/openclaw-docs/SKILL.md` and added `.agents/skills/technical-documentation/` in the same commit. `openclaw-refactor-docs` was never updated and kept three references to the old name.

The replacement target is taken from that commit rather than inferred, so this is a rename follow-up, not a judgement about which skill is the right one. Nothing else changes — the reference form is left exactly as the file already had it.

## How the reference resolves

The skills catalog gives the model the skill's `<location>` and instructs it how to resolve relative references:

```ts
// src/skills/loading/skill-contract.ts
"When a skill file references a relative path, resolve it against the skill
 directory (parent of SKILL.md / dirname of the path) and use that absolute
 path in tool commands.",
```

So `../technical-documentation/SKILL.md`, resolved against `dirname(.agents/skills/openclaw-refactor-docs/SKILL.md)`, is `.agents/skills/technical-documentation/SKILL.md` — which exists. The retired name resolves the same way to a path that does not.

## Evidence

```console
$ git diff --stat
 .agents/skills/openclaw-refactor-docs/SKILL.md | 6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)

$ git diff --check; echo "exit=$?"
exit=0
```

Resolved the way the catalog instructs, from the workspace root:

```console
$ SKILL=.agents/skills/openclaw-refactor-docs/SKILL.md
$ DIR=$(dirname "$SKILL")
$ echo "$DIR"
.agents/skills/openclaw-refactor-docs

$ grep -n 'SKILL\.md`' "$SKILL"
56:Read `../technical-documentation/SKILL.md` first. Apply its page-type, style,

$ ls .agents/skills/technical-documentation/SKILL.md
.agents/skills/technical-documentation/SKILL.md

$ ls .agents/skills/openclaw-docs/SKILL.md
ls: cannot access '.agents/skills/openclaw-docs/SKILL.md': No such file or directory

$ grep -rn "openclaw-docs" .agents/skills/openclaw-refactor-docs/SKILL.md; echo "exit=$?"
exit=1
```

Lines 13 and 64 name the skill rather than a path, so they are renamed but stay as bare names. Markdown-only change to a single skill file; no code, tests, or CI surfaces touched.

## Scope

Not in this PR: the three missing paths in `openclaw-test-heap-leaks` reported in #119393 (`test/fixtures/test-timings.unit.json`, `test/fixtures/test-parallel.behavior.json`, `scripts/test-update-memory-hotspots.mjs`). Those names appear nowhere else in the tree, so the correct target is not recoverable from the repository and guessing would be worse than leaving them. ClawSweeper reached the same conclusion on the issue: that repair needs an owner decision on the current planner.

## Correction history — two revisions of this PR were wrong, and this is a revert to the original

Worth reading before reviewing, because the middle of this PR's history argues for something this version deliberately undoes.

Revisions 2 and 3 were built on a wrong premise: that a relative reference in a `SKILL.md` is resolved from the session workspace cwd, because that is what the raw read tool does (`resolveReadPath` → `resolveToCwd` → `resolvePath(cwd, path)` in `src/agents/sessions/tools/path-utils.ts`). On that reading `../technical-documentation/SKILL.md` looked broken, so revision 2 rewrote it workspace-relative, and revision 3 additionally rewrote ten support-file references in `technical-documentation/SKILL.md` to `{baseDir}`.

That premise is wrong. `path-utils.ts` describes what happens *after* the model has already resolved the path, and `skill-contract.ts` tells the model to resolve against the skill directory first. Both files were present the whole time; I read the one that was cited to me and stopped there instead of following the mechanism up a level.

@vincentkoc established this when closing #119534, and I have since verified the contract line exists at every commit involved, including the one the earlier reviews ran against. So:

- **Revision 1 was already correct.** `../technical-documentation/SKILL.md` needed no repair beyond the name.
- **The `{baseDir}` rewrite was cleanup, not a fix**, exactly as stated on #119534 — and it did not belong in a rename follow-up regardless.
- **ClawSweeper's P1 finding on revision 2 was incorrect**, and flagging that here rather than quietly reverting, because a reviewer arriving now would otherwise see a PR whose shape was set by that finding.

This revision is a straight revert to revision 1: one file, three lines, the reference form untouched. Reverted in `adf2939` and `8c0f791`.
