### PR TITLE
fix(slack): recover Home and Assistant events after temporary API failures

### DIFF
--- a/extensions/slack/src/monitor/events/assistant.ingress.test.ts
+++ b/extensions/slack/src/monitor/events/assistant.ingress.test.ts
@@ -54,8 +54,9 @@ function createGuardedSlackFetch(steps: SlackFetchStep[]) {
     );
     const step = steps[requests.length];
     if (
+      !step ||
       url.origin !== "https://slack-proof.invalid" ||
-      url.pathname !== `/api/${step?.method}` ||
+      url.pathname !== `/api/${step.method}` ||
       init?.method !== "POST" ||
       typeof init.body !== "string"
     ) {

--- a/extensions/slack/src/monitor/events/assistant.ingress.test.ts
+++ b/extensions/slack/src/monitor/events/assistant.ingress.test.ts
@@ -23,7 +23,12 @@ type SlackFetchStep = { method: string; body: Record<string, unknown>; retryAfte
 
 const slackApiRoot = "https://slack-proof.invalid/api/";
 const botMessage = { user: "U_BOT", ts: "1700000000.000200", text: "assistant reply" };
-const transientPlatformErrors = ["internal_error", "service_unavailable", "ratelimited"] as const;
+const transientPlatformErrors = [
+  "internal_error",
+  "service_unavailable",
+  "ratelimited",
+  "fatal_error",
+] as const;
 
 function slackResponse(body: Record<string, unknown>, retryAfter?: string): Response {
   return new Response(JSON.stringify(body), {

--- a/extensions/slack/src/monitor/events/assistant.ingress.test.ts
+++ b/extensions/slack/src/monitor/events/assistant.ingress.test.ts
@@ -28,6 +28,7 @@ const transientPlatformErrors = [
   "service_unavailable",
   "ratelimited",
   "fatal_error",
+  "request_timeout",
 ] as const;
 
 function slackResponse(body: Record<string, unknown>, retryAfter?: string): Response {
@@ -306,6 +307,21 @@ describe("Slack Assistant durable ingress", () => {
       type: "assistant_thread_context_changed" as const,
       method: "conversations.replies",
       error: "invalid_arguments",
+    },
+    {
+      type: "assistant_thread_started" as const,
+      method: "assistant.threads.setSuggestedPrompts",
+      error: "org_login_required",
+    },
+    {
+      type: "assistant_thread_started" as const,
+      method: "assistant.threads.setSuggestedPrompts",
+      error: "invalid_auth",
+    },
+    {
+      type: "assistant_thread_started" as const,
+      method: "assistant.threads.setSuggestedPrompts",
+      error: "invalid_form_data",
     },
   ])("surfaces permanent $error from $type without poisoning the next event", async (scenario) => {
     const { fetch, requests } = createGuardedSlackFetch([

--- a/extensions/slack/src/monitor/events/assistant.ingress.test.ts
+++ b/extensions/slack/src/monitor/events/assistant.ingress.test.ts
@@ -1,0 +1,371 @@
+// Slack Assistant ingress proof uses real Bolt, Web API requests, and SQLite state.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { App, LogLevel, type Receiver, type ReceiverEvent } from "@slack/bolt";
+import { WebAPIPlatformError, type WebClient } from "@slack/web-api";
+import {
+  closeOpenClawStateDatabaseForTest,
+  createChannelIngressQueueForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SlackAssistantThreadContext } from "../context.js";
+import { createSlackDurableIngress } from "../ingress.js";
+import { updateSlackSuggestedPrompts } from "../suggested-prompts.js";
+import { registerSlackAssistantEvents } from "./assistant.js";
+import { createSlackSystemEventTestHarness } from "./system-event-test-harness.js";
+
+type SlackIngressQueue = NonNullable<Parameters<typeof createSlackDurableIngress>[0]["queue"]>;
+type SlackIngressPayload = Parameters<SlackIngressQueue["enqueue"]>[1];
+type SlackFetch = NonNullable<ConstructorParameters<typeof WebClient>[1]>["fetch"];
+type AssistantEventType = "assistant_thread_started" | "assistant_thread_context_changed";
+type SlackFetchStep = { method: string; body: Record<string, unknown>; retryAfter?: string };
+
+const slackApiRoot = "https://slack-proof.invalid/api/";
+const botMessage = { user: "U_BOT", ts: "1700000000.000200", text: "assistant reply" };
+const transientPlatformErrors = ["internal_error", "service_unavailable", "ratelimited"] as const;
+
+function slackResponse(body: Record<string, unknown>, retryAfter?: string): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {
+      "content-type": "application/json",
+      ...(retryAfter === undefined ? {} : { "retry-after": retryAfter }),
+    },
+  });
+}
+
+function transientSlackFailure(
+  method: string,
+  error: (typeof transientPlatformErrors)[number],
+): SlackFetchStep {
+  return {
+    method,
+    body: { ok: false, error },
+    ...(error === "ratelimited" ? { retryAfter: "1" } : {}),
+  };
+}
+
+function createGuardedSlackFetch(steps: SlackFetchStep[]) {
+  const requests: Array<{ method: string; body: URLSearchParams; requestedAt: number }> = [];
+  const fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = new URL(
+      typeof input === "string" ? input : input instanceof URL ? input.href : input.url,
+    );
+    const step = steps[requests.length];
+    if (
+      url.origin !== "https://slack-proof.invalid" ||
+      url.pathname !== `/api/${step?.method}` ||
+      init?.method !== "POST" ||
+      typeof init.body !== "string"
+    ) {
+      throw new Error(`unexpected Slack proof request: ${url.origin}${url.pathname}`);
+    }
+    requests.push({
+      method: step.method,
+      body: new URLSearchParams(init.body),
+      requestedAt: Date.now(),
+    });
+    return slackResponse(step.body, step.retryAfter);
+  });
+  return { fetch, requests };
+}
+
+function createAssistantEvent(eventId: string, type: AssistantEventType): ReceiverEvent {
+  return {
+    ack: vi.fn(async () => {}),
+    body: {
+      token: "verification-fixture",
+      team_id: "T_TEST",
+      api_app_id: "A_TEST",
+      type: "event_callback",
+      event_id: eventId,
+      event_time: 1_700_000_000,
+      event: {
+        type,
+        assistant_thread: {
+          user_id: "U_TEST",
+          channel_id: "D_TEST",
+          thread_ts: "1700000000.000100",
+          context: { channel_id: "C_PRIVATE", team_id: "T_TEST", enterprise_id: null },
+        },
+        event_ts: "1700000000.000300",
+      },
+    },
+  };
+}
+
+async function withDurableAssistantIngress(
+  fetch: SlackFetch,
+  run: (params: {
+    receive: (event: ReceiverEvent) => Promise<void>;
+    ingress: ReturnType<typeof createSlackDurableIngress>;
+    queue: SlackIngressQueue;
+    runtimeError: ReturnType<typeof vi.fn>;
+  }) => Promise<void>,
+) {
+  const temporaryRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-slack-assistant-"));
+  const stateDir = await fs.realpath(temporaryRoot);
+  const queue = createChannelIngressQueueForTests<SlackIngressPayload>({
+    channelId: "slack",
+    accountId: "default",
+    stateDir,
+  });
+  const ingress = createSlackDurableIngress({
+    accountId: "default",
+    queue,
+    pollIntervalMs: 25,
+    adoptionStallTimeoutMs: 5_000,
+  });
+  let receive: ((event: ReceiverEvent) => Promise<void>) | undefined;
+  const receiver: Receiver = {
+    init: (app) => {
+      receive = async (event) => await app.processEvent(event);
+    },
+    start: async () => undefined,
+    stop: async () => undefined,
+  };
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    setLevel: vi.fn(),
+    getLevel: () => LogLevel.INFO,
+    setName: vi.fn(),
+  };
+  const app = new App({
+    token: "xoxb-fixture",
+    botId: "B_BOT",
+    botUserId: "U_BOT",
+    receiver: ingress.wrapReceiver(receiver),
+    tokenVerificationEnabled: false,
+    convoStore: false,
+    ignoreSelf: false,
+    logger,
+    clientOptions: {
+      slackApiUrl: slackApiRoot,
+      fetch,
+      retryConfig: { retries: 0 },
+    },
+  });
+  const harness = createSlackSystemEventTestHarness();
+  const assistantThreads = new Map<string, SlackAssistantThreadContext>();
+  const runtimeError = vi.fn();
+  harness.ctx.app = app;
+  harness.ctx.botToken = "xoxb-fixture";
+  harness.ctx.runtime.error = runtimeError;
+  harness.ctx.getSlackAssistantThreadContext = (channelId, threadTs) =>
+    assistantThreads.get(`${channelId}:${threadTs}`);
+  harness.ctx.saveSlackAssistantThreadContext = (thread) =>
+    assistantThreads.set(`${thread.assistantChannelId}:${thread.threadTs}`, {
+      ...thread,
+      updatedAt: Date.now(),
+    });
+  harness.ctx.setSlackSuggestedPrompts = (input) =>
+    updateSlackSuggestedPrompts({ ...input, botToken: "xoxb-fixture", client: app.client });
+  registerSlackAssistantEvents({ ctx: harness.ctx });
+  ingress.start();
+
+  try {
+    if (!receive) {
+      throw new Error("expected Slack receiver initialization");
+    }
+    await run({ receive, ingress, queue, runtimeError });
+  } finally {
+    await ingress.stop();
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Slack Assistant durable ingress", () => {
+  it.each(transientPlatformErrors)(
+    "replays suggested-prompt %s without acknowledging the event twice",
+    async (error) => {
+      const { fetch, requests } = createGuardedSlackFetch([
+        transientSlackFailure("assistant.threads.setSuggestedPrompts", error),
+        { method: "assistant.threads.setSuggestedPrompts", body: { ok: true } },
+      ]);
+
+      await withDurableAssistantIngress(
+        fetch,
+        async ({ receive, ingress, queue, runtimeError }) => {
+          const eventId = `Ev-assistant-started-${error}`;
+          const event = createAssistantEvent(eventId, "assistant_thread_started");
+          await receive(event);
+          await ingress.waitForIdle();
+
+          await expect(queue.listPending()).resolves.toMatchObject([
+            { id: eventId, attempts: 1, lastError: expect.stringContaining(error) },
+          ]);
+          await vi.waitFor(
+            async () => {
+              await ingress.waitForIdle();
+              expect(requests).toHaveLength(2);
+            },
+            { timeout: 5_000, interval: 50 },
+          );
+
+          expect(event.ack).toHaveBeenCalledOnce();
+          expect(runtimeError).toHaveBeenCalledOnce();
+          expect(requests[1]?.body.get("channel_id")).toBe("D_TEST");
+          expect(requests[1]?.body.get("thread_ts")).toBe("1700000000.000100");
+          if (error === "ratelimited") {
+            expect(requests[1]!.requestedAt - requests[0]!.requestedAt).toBeGreaterThanOrEqual(950);
+          }
+          await expect(queue.enqueue(eventId, {} as SlackIngressPayload)).resolves.toMatchObject({
+            kind: "completed",
+          });
+        },
+      );
+    },
+  );
+
+  it.each(
+    transientPlatformErrors.flatMap((error) => [
+      {
+        name: "history lookup",
+        error,
+        steps: [
+          transientSlackFailure("conversations.replies", error),
+          { method: "conversations.replies", body: { ok: true, messages: [botMessage] } },
+          { method: "chat.update", body: { ok: true } },
+        ],
+      },
+      {
+        name: "metadata update",
+        error,
+        steps: [
+          { method: "conversations.replies", body: { ok: true, messages: [botMessage] } },
+          transientSlackFailure("chat.update", error),
+          { method: "conversations.replies", body: { ok: true, messages: [botMessage] } },
+          { method: "chat.update", body: { ok: true } },
+        ],
+      },
+    ]),
+  )("replays Assistant context $name $error", async ({ name, error, steps }) => {
+    const { fetch, requests } = createGuardedSlackFetch(steps);
+
+    await withDurableAssistantIngress(fetch, async ({ receive, ingress, queue, runtimeError }) => {
+      const eventId = `Ev-assistant-context-${name.replace(" ", "-")}-${error}`;
+      const event = createAssistantEvent(eventId, "assistant_thread_context_changed");
+      await receive(event);
+      await ingress.waitForIdle();
+
+      await expect(queue.listPending()).resolves.toMatchObject([
+        { id: eventId, attempts: 1, lastError: expect.stringContaining(error) },
+      ]);
+      await vi.waitFor(
+        async () => {
+          await ingress.waitForIdle();
+          expect(requests).toHaveLength(steps.length);
+        },
+        { timeout: 5_000, interval: 50 },
+      );
+
+      expect(event.ack).toHaveBeenCalledOnce();
+      expect(runtimeError).toHaveBeenCalledOnce();
+      const metadata = JSON.parse(requests.at(-1)?.body.get("metadata") ?? "null") as {
+        event_payload?: { channel_id?: string; team_id?: string };
+      };
+      expect(metadata.event_payload).toMatchObject({ channel_id: "C_PRIVATE", team_id: "T_TEST" });
+      await expect(queue.enqueue(eventId, {} as SlackIngressPayload)).resolves.toMatchObject({
+        kind: "completed",
+      });
+    });
+  });
+
+  it.each([
+    {
+      type: "assistant_thread_started" as const,
+      method: "assistant.threads.setSuggestedPrompts",
+      error: "missing_scope",
+    },
+    {
+      type: "assistant_thread_started" as const,
+      method: "assistant.threads.setSuggestedPrompts",
+      error: "invalid_arguments",
+    },
+    {
+      type: "assistant_thread_context_changed" as const,
+      method: "conversations.replies",
+      error: "missing_scope",
+    },
+    {
+      type: "assistant_thread_context_changed" as const,
+      method: "conversations.replies",
+      error: "invalid_arguments",
+    },
+  ])("surfaces permanent $error from $type without poisoning the next event", async (scenario) => {
+    const { fetch, requests } = createGuardedSlackFetch([
+      {
+        method: scenario.method,
+        body: {
+          ok: false,
+          error: scenario.error,
+          ...(scenario.type === "assistant_thread_started" && scenario.error === "missing_scope"
+            ? { needed: "assistant:write" }
+            : {}),
+        },
+      },
+      { method: "assistant.threads.setSuggestedPrompts", body: { ok: true } },
+    ]);
+
+    await withDurableAssistantIngress(fetch, async ({ receive, ingress, queue, runtimeError }) => {
+      const rejectedId = `Ev-assistant-rejected-${scenario.error}`;
+      const nextId = `Ev-assistant-next-${scenario.error}`;
+      const rejected = createAssistantEvent(rejectedId, scenario.type);
+      const next = createAssistantEvent(nextId, "assistant_thread_started");
+      await receive(rejected);
+      await ingress.waitForIdle();
+
+      expect(requests).toHaveLength(1);
+      expect(runtimeError).toHaveBeenCalledOnce();
+      expect(runtimeError).toHaveBeenCalledWith(expect.stringContaining(scenario.error));
+      if (scenario.type === "assistant_thread_started" && scenario.error === "missing_scope") {
+        expect(runtimeError).toHaveBeenCalledWith(expect.stringContaining("assistant:write"));
+      }
+      expect(runtimeError.mock.calls[0]?.[0]).not.toContain("xoxb-fixture");
+      await expect(queue.enqueue(rejectedId, {} as SlackIngressPayload)).resolves.toMatchObject({
+        kind: "completed",
+      });
+
+      await receive(next);
+      await ingress.waitForIdle();
+
+      expect(requests).toHaveLength(2);
+      expect(runtimeError).toHaveBeenCalledOnce();
+      expect(rejected.ack).toHaveBeenCalledOnce();
+      expect(next.ack).toHaveBeenCalledOnce();
+      await expect(queue.enqueue(nextId, {} as SlackIngressPayload)).resolves.toMatchObject({
+        kind: "completed",
+      });
+    });
+  });
+
+  it("keeps temporary failures diagnostic-only when no durable lifecycle owns the direct event", async () => {
+    const harness = createSlackSystemEventTestHarness();
+    const runtimeError = vi.fn();
+    harness.ctx.runtime.error = runtimeError;
+    harness.ctx.getSlackAssistantThreadContext = () => undefined;
+    harness.ctx.saveSlackAssistantThreadContext = () => {};
+    harness.ctx.setSlackSuggestedPrompts = vi.fn(async () => {
+      throw new WebAPIPlatformError({ ok: false, error: "internal_error" });
+    });
+    registerSlackAssistantEvents({ ctx: harness.ctx });
+
+    const event = createAssistantEvent("Ev-assistant-direct", "assistant_thread_started");
+    await expect(
+      harness.getHandler("assistant_thread_started")!({
+        event: event.body.event as Record<string, unknown>,
+        body: event.body,
+      }),
+    ).resolves.toBeUndefined();
+    expect(runtimeError).toHaveBeenCalledWith(expect.stringContaining("internal_error"));
+  });
+});

--- a/extensions/slack/src/monitor/events/assistant.ingress.test.ts
+++ b/extensions/slack/src/monitor/events/assistant.ingress.test.ts
@@ -19,7 +19,12 @@ type SlackIngressQueue = NonNullable<Parameters<typeof createSlackDurableIngress
 type SlackIngressPayload = Parameters<SlackIngressQueue["enqueue"]>[1];
 type SlackFetch = NonNullable<ConstructorParameters<typeof WebClient>[1]>["fetch"];
 type AssistantEventType = "assistant_thread_started" | "assistant_thread_context_changed";
-type SlackFetchStep = { method: string; body: Record<string, unknown>; retryAfter?: string };
+type SlackFetchStep = {
+  method: string;
+  body: Record<string, unknown>;
+  retryAfter?: string;
+  status?: number;
+};
 
 const slackApiRoot = "https://slack-proof.invalid/api/";
 const botMessage = { user: "U_BOT", ts: "1700000000.000200", text: "assistant reply" };
@@ -30,10 +35,14 @@ const transientPlatformErrors = [
   "fatal_error",
   "request_timeout",
 ] as const;
+const malformedRetryAfterHeaders = [
+  { headerLabel: "missing", retryAfter: undefined },
+  { headerLabel: "invalid", retryAfter: "not-a-timeout" },
+] as const;
 
-function slackResponse(body: Record<string, unknown>, retryAfter?: string): Response {
+function slackResponse(body: Record<string, unknown>, retryAfter?: string, status = 200): Response {
   return new Response(JSON.stringify(body), {
-    status: 200,
+    status,
     headers: {
       "content-type": "application/json",
       ...(retryAfter === undefined ? {} : { "retry-after": retryAfter }),
@@ -73,7 +82,7 @@ function createGuardedSlackFetch(steps: SlackFetchStep[]) {
       body: new URLSearchParams(init.body),
       requestedAt: Date.now(),
     });
-    return slackResponse(step.body, step.retryAfter);
+    return slackResponse(step.body, step.retryAfter, step.status);
   });
   return { fetch, requests };
 }
@@ -232,6 +241,76 @@ describe("Slack Assistant durable ingress", () => {
       );
     },
   );
+
+  it.each(
+    malformedRetryAfterHeaders.flatMap(({ headerLabel, retryAfter }) => [
+      {
+        headerLabel,
+        name: "suggested prompts",
+        type: "assistant_thread_started" as const,
+        steps: [
+          {
+            method: "assistant.threads.setSuggestedPrompts",
+            body: { ok: false },
+            status: 429,
+            retryAfter,
+          },
+          { method: "assistant.threads.setSuggestedPrompts", body: { ok: true } },
+        ],
+      },
+      {
+        headerLabel,
+        name: "history lookup",
+        type: "assistant_thread_context_changed" as const,
+        steps: [
+          { method: "conversations.replies", body: { ok: false }, status: 429, retryAfter },
+          { method: "conversations.replies", body: { ok: true, messages: [botMessage] } },
+          { method: "chat.update", body: { ok: true } },
+        ],
+      },
+      {
+        headerLabel,
+        name: "metadata update",
+        type: "assistant_thread_context_changed" as const,
+        steps: [
+          { method: "conversations.replies", body: { ok: true, messages: [botMessage] } },
+          { method: "chat.update", body: { ok: false }, status: 429, retryAfter },
+          { method: "conversations.replies", body: { ok: true, messages: [botMessage] } },
+          { method: "chat.update", body: { ok: true } },
+        ],
+      },
+    ]),
+  )("replays malformed Retry-After $headerLabel for Assistant $name", async (scenario) => {
+    const { fetch, requests } = createGuardedSlackFetch(scenario.steps);
+
+    await withDurableAssistantIngress(fetch, async ({ receive, ingress, queue, runtimeError }) => {
+      const eventId = `Ev-assistant-${scenario.name.replace(" ", "-")}-${scenario.headerLabel}-429`;
+      const event = createAssistantEvent(eventId, scenario.type);
+      await receive(event);
+      await ingress.waitForIdle();
+
+      await expect(queue.listPending()).resolves.toMatchObject([
+        {
+          id: eventId,
+          attempts: 1,
+          lastError: expect.stringContaining("Retry header did not contain a valid timeout"),
+        },
+      ]);
+      await vi.waitFor(
+        async () => {
+          await ingress.waitForIdle();
+          expect(requests).toHaveLength(scenario.steps.length);
+        },
+        { timeout: 5_000, interval: 50 },
+      );
+
+      expect(event.ack).toHaveBeenCalledOnce();
+      expect(runtimeError).toHaveBeenCalledOnce();
+      await expect(queue.enqueue(eventId, {} as SlackIngressPayload)).resolves.toMatchObject({
+        kind: "completed",
+      });
+    });
+  });
 
   it.each(
     transientPlatformErrors.flatMap((error) => [

--- a/extensions/slack/src/monitor/events/assistant.ts
+++ b/extensions/slack/src/monitor/events/assistant.ts
@@ -1,9 +1,11 @@
 // Slack plugin module implements assistant behavior.
 import type { Block, KnownBlock } from "@slack/web-api";
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { formatSlackError } from "../../errors.js";
 import { buildSlackAssistantThreadMetadata, DEFAULT_SLACK_SUGGESTED_PROMPTS } from "../context.js";
 import type { SlackMonitorContext, SlackAssistantThreadContext } from "../context.js";
+import { resolveSlackIngressTurnLifecycle } from "../ingress.js";
+import { isTransientSlackApiError } from "../transient-api-error.js";
 
 type SlackAssistantThreadPayload = {
   user_id?: string;
@@ -32,7 +34,11 @@ type SlackAssistantThreadContextChangedEvent = {
   event_ts?: string;
 };
 
-type SlackAssistantEventHandler<TEvent> = (args: { event: TEvent; body: unknown }) => Promise<void>;
+type SlackAssistantEventHandler<TEvent> = (args: {
+  event: TEvent;
+  body: unknown;
+  context?: unknown;
+}) => Promise<void>;
 
 type SlackAssistantEventRegistrar = {
   (
@@ -93,42 +99,36 @@ async function persistAssistantThreadMetadata(params: {
   assistantThread: Omit<SlackAssistantThreadContext, "updatedAt">;
 }) {
   const { ctx, assistantThread } = params;
-  try {
-    const response = (await ctx.app.client.conversations.replies({
-      token: ctx.botToken,
-      channel: assistantThread.assistantChannelId,
-      ts: assistantThread.threadTs,
-      oldest: assistantThread.threadTs,
-      include_all_metadata: true,
-      limit: 4,
-    })) as {
-      messages?: Array<{
-        subtype?: string;
-        user?: string;
-        ts?: string;
-        text?: string;
-        blocks?: (Block | KnownBlock)[];
-      }>;
-    };
-    const initialMessage = (response.messages ?? []).find(
-      (message) => !message.subtype && message.user === ctx.botUserId && message.ts,
-    );
-    if (!initialMessage?.ts) {
-      return;
-    }
-    await ctx.app.client.chat.update({
-      token: ctx.botToken,
-      channel: assistantThread.assistantChannelId,
-      ts: initialMessage.ts,
-      text: initialMessage.text ?? "",
-      blocks: Array.isArray(initialMessage.blocks) ? initialMessage.blocks : [],
-      metadata: buildSlackAssistantThreadMetadata(assistantThread),
-    });
-  } catch (err) {
-    logVerbose(
-      `slack assistant thread metadata persist failed for channel ${assistantThread.assistantChannelId}: ${formatErrorMessage(err)}`,
-    );
+  const response = (await ctx.app.client.conversations.replies({
+    token: ctx.botToken,
+    channel: assistantThread.assistantChannelId,
+    ts: assistantThread.threadTs,
+    oldest: assistantThread.threadTs,
+    include_all_metadata: true,
+    limit: 4,
+  })) as {
+    messages?: Array<{
+      subtype?: string;
+      user?: string;
+      ts?: string;
+      text?: string;
+      blocks?: (Block | KnownBlock)[];
+    }>;
+  };
+  const initialMessage = (response.messages ?? []).find(
+    (message) => !message.subtype && message.user === ctx.botUserId && message.ts,
+  );
+  if (!initialMessage?.ts) {
+    return;
   }
+  await ctx.app.client.chat.update({
+    token: ctx.botToken,
+    channel: assistantThread.assistantChannelId,
+    ts: initialMessage.ts,
+    text: initialMessage.text ?? "",
+    blocks: Array.isArray(initialMessage.blocks) ? initialMessage.blocks : [],
+    metadata: buildSlackAssistantThreadMetadata(assistantThread),
+  });
 }
 
 export function registerSlackAssistantEvents(params: {
@@ -139,7 +139,9 @@ export function registerSlackAssistantEvents(params: {
   const { ctx, trackEvent } = params;
   const slackApp = ctx.app as unknown as { event: SlackAssistantEventRegistrar };
 
-  slackApp.event("assistant_thread_started", async ({ event, body }) => {
+  const handleEvent: SlackAssistantEventHandler<
+    SlackAssistantThreadStartedEvent | SlackAssistantThreadContextChangedEvent
+  > = async ({ event, body, context }) => {
     try {
       if (ctx.shouldDropMismatchedSlackEvent(body)) {
         return;
@@ -147,44 +149,28 @@ export function registerSlackAssistantEvents(params: {
       trackEvent?.();
       const assistantThread = normalizeAssistantThread(event, ctx.getSlackAssistantThreadContext);
       if (!assistantThread) {
-        logVerbose(
-          "slack assistant_thread_started dropped: missing assistant thread channel/thread",
-        );
+        logVerbose(`slack ${event.type} dropped: missing assistant thread channel/thread`);
         return;
       }
       ctx.saveSlackAssistantThreadContext(assistantThread);
-      await ctx.setSlackSuggestedPrompts({
-        channelId: assistantThread.assistantChannelId,
-        threadTs: assistantThread.threadTs,
-        title: "Try asking",
-        prompts: DEFAULT_SLACK_SUGGESTED_PROMPTS,
-      });
-    } catch (err) {
-      ctx.runtime.error?.(
-        danger(`slack assistant_thread_started handler failed: ${formatErrorMessage(err)}`),
-      );
-    }
-  });
-
-  slackApp.event("assistant_thread_context_changed", async ({ event, body }) => {
-    try {
-      if (ctx.shouldDropMismatchedSlackEvent(body)) {
+      if (event.type === "assistant_thread_started") {
+        await ctx.setSlackSuggestedPrompts({
+          channelId: assistantThread.assistantChannelId,
+          threadTs: assistantThread.threadTs,
+          title: "Try asking",
+          prompts: DEFAULT_SLACK_SUGGESTED_PROMPTS,
+        });
         return;
       }
-      trackEvent?.();
-      const assistantThread = normalizeAssistantThread(event, ctx.getSlackAssistantThreadContext);
-      if (!assistantThread) {
-        logVerbose(
-          "slack assistant_thread_context_changed dropped: missing assistant thread channel/thread",
-        );
-        return;
-      }
-      ctx.saveSlackAssistantThreadContext(assistantThread);
       await persistAssistantThreadMetadata({ ctx, assistantThread });
     } catch (err) {
-      ctx.runtime.error?.(
-        danger(`slack assistant_thread_context_changed handler failed: ${formatErrorMessage(err)}`),
-      );
+      ctx.runtime.error?.(danger(`slack ${event.type} handler failed: ${formatSlackError(err)}`));
+      if (resolveSlackIngressTurnLifecycle(context) && isTransientSlackApiError(err)) {
+        throw err;
+      }
     }
-  });
+  };
+
+  slackApp.event("assistant_thread_started", handleEvent);
+  slackApp.event("assistant_thread_context_changed", handleEvent);
 }

--- a/extensions/slack/src/monitor/events/home.test.ts
+++ b/extensions/slack/src/monitor/events/home.test.ts
@@ -1,10 +1,165 @@
 // Slack tests cover home plugin behavior.
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { App, LogLevel, type Receiver, type ReceiverEvent } from "@slack/bolt";
+import {
+  WebAPIHTTPError,
+  WebAPIPlatformError,
+  WebAPIRateLimitedError,
+  WebAPIRequestError,
+  WebClient,
+} from "@slack/web-api";
+import {
+  closeOpenClawStateDatabaseForTest,
+  createChannelIngressQueueForTests,
+  createPluginStateKeyedStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { getOptionalSlackRuntime, setSlackRuntime } from "../../runtime.js";
+import { createSlackAgentViewState } from "../agent-view-state.js";
+import { createSlackDurableIngress, type SlackIngressTurnLifecycle } from "../ingress.js";
+import { updateSlackSuggestedPrompts } from "../suggested-prompts.js";
 
 let registerSlackHomeEvents: typeof import("./home.js").registerSlackHomeEvents;
 let createSlackSystemEventTestHarness: typeof import("./system-event-test-harness.js").createSlackSystemEventTestHarness;
 
-type HomeHandler = (args: { event: Record<string, unknown>; body: unknown }) => Promise<void>;
+type HomeHandler = (args: {
+  event: Record<string, unknown>;
+  body: unknown;
+  context?: Record<string, unknown>;
+}) => Promise<void>;
+
+type SlackIngressQueue = NonNullable<Parameters<typeof createSlackDurableIngress>[0]["queue"]>;
+type SlackIngressPayload = Parameters<SlackIngressQueue["enqueue"]>[1];
+
+function createDurableHomeLifecycle(): SlackIngressTurnLifecycle {
+  return {
+    admission: "exclusive",
+    abortSignal: new AbortController().signal,
+    onAdopted: vi.fn(async () => {}),
+    onDeferred: vi.fn(),
+    onAbandoned: vi.fn(async () => {}),
+  };
+}
+
+function createHomeEvent(eventId: string, tab: "home" | "messages" = "home"): ReceiverEvent {
+  return {
+    ack: vi.fn(async () => {}),
+    body: {
+      token: "verification-fixture",
+      team_id: "T_TEST",
+      api_app_id: "A_TEST",
+      type: "event_callback",
+      event_id: eventId,
+      event_time: 1_700_000_000,
+      event: {
+        type: "app_home_opened",
+        user: "U_TEST",
+        channel: "D_TEST",
+        tab,
+        event_ts: "1700000000.000100",
+      },
+    },
+  };
+}
+
+async function withDurableHomeIngress(
+  fetch: NonNullable<ConstructorParameters<typeof WebClient>[1]>["fetch"],
+  run: (params: {
+    receive: (event: ReceiverEvent) => Promise<void>;
+    ingress: ReturnType<typeof createSlackDurableIngress>;
+    queue: SlackIngressQueue;
+    runtimeError: ReturnType<typeof vi.fn>;
+    agentViewState: ReturnType<typeof createSlackAgentViewState>;
+    recordSlackAgentView: ReturnType<typeof vi.fn>;
+  }) => Promise<void>,
+) {
+  const temporaryRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-slack-home-ingress-"));
+  const stateDir = await fs.realpath(temporaryRoot);
+  const queue = createChannelIngressQueueForTests<SlackIngressPayload>({
+    channelId: "slack",
+    accountId: "default",
+    stateDir,
+  });
+  const previousSlackRuntime = getOptionalSlackRuntime();
+  setSlackRuntime({
+    state: {
+      openKeyedStore: (options: { namespace: string; maxEntries: number }) =>
+        createPluginStateKeyedStoreForTests("slack", {
+          ...options,
+          env: { OPENCLAW_STATE_DIR: stateDir },
+        }),
+    },
+  } as never);
+  const agentViewState = createSlackAgentViewState({
+    accountId: "default",
+    teamId: "T_TEST",
+    apiAppId: "A_TEST",
+    warn: vi.fn(),
+  });
+  const recordSlackAgentView = vi.fn(agentViewState.record);
+  const ingress = createSlackDurableIngress({
+    accountId: "default",
+    queue,
+    pollIntervalMs: 25,
+    adoptionStallTimeoutMs: 5_000,
+  });
+  let receive: ((event: ReceiverEvent) => Promise<void>) | undefined;
+  const receiver: Receiver = {
+    init: (app) => {
+      receive = async (event) => await app.processEvent(event);
+    },
+    start: async () => undefined,
+    stop: async () => undefined,
+  };
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    setLevel: vi.fn(),
+    getLevel: () => LogLevel.INFO,
+    setName: vi.fn(),
+  };
+  const app = new App({
+    token: "xoxb-test",
+    botId: "B_BOT",
+    botUserId: "U_BOT",
+    receiver: ingress.wrapReceiver(receiver),
+    tokenVerificationEnabled: false,
+    convoStore: false,
+    ignoreSelf: false,
+    logger,
+    clientOptions: {
+      fetch,
+      retryConfig: { retries: 2, minTimeout: 0, maxTimeout: 0, randomize: false },
+    },
+  });
+  const harness = createSlackSystemEventTestHarness();
+  const runtimeError = vi.fn();
+  harness.ctx.app = app;
+  harness.ctx.runtime.error = runtimeError;
+  harness.ctx.botToken = "xoxb-test";
+  harness.ctx.setSlackSuggestedPrompts = (input) =>
+    updateSlackSuggestedPrompts({ ...input, botToken: "xoxb-test", client: app.client });
+  harness.ctx.recordSlackAgentView = recordSlackAgentView;
+  harness.ctx.isSlackAgentView = agentViewState.isEnabled;
+  registerSlackHomeEvents({ ctx: harness.ctx });
+  ingress.start();
+
+  try {
+    if (!receive) {
+      throw new Error("expected Slack receiver initialization");
+    }
+    await run({ receive, ingress, queue, runtimeError, agentViewState, recordSlackAgentView });
+  } finally {
+    await ingress.stop();
+    setSlackRuntime(previousSlackRuntime as never);
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  }
+}
 
 function createHomeContext(params?: {
   slashCommandName?: string;
@@ -26,6 +181,7 @@ function createHomeContext(params?: {
     trackEvent: params?.trackEvent,
   });
   return {
+    ctx: harness.ctx,
     publish,
     getHomeHandler: () => harness.getHandler("app_home_opened") as HomeHandler | null,
   };
@@ -40,6 +196,7 @@ function createAgentHomeContext(params?: { suggestedPromptsResult?: boolean }) {
   harness.ctx.recordSlackAgentView = recordSlackAgentView;
   registerSlackHomeEvents({ ctx: harness.ctx });
   return {
+    ctx: harness.ctx,
     setSlackSuggestedPrompts,
     recordSlackAgentView,
     getHomeHandler: () => harness.getHandler("app_home_opened") as HomeHandler | null,
@@ -54,6 +211,10 @@ describe("registerSlackHomeEvents", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    closeOpenClawStateDatabaseForTest();
   });
 
   it("publishes the Home tab without an inactive slash command hint", async () => {
@@ -114,6 +275,376 @@ describe("registerSlackHomeEvents", () => {
         text: "Send a DM, mention OpenClaw in a channel, or use `/acme` to start a session.",
       },
     });
+  });
+
+  it("retries an actual Slack platform failure through durable ingress and publishes once", async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: false, error: "internal_error" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true, view: { id: "V_TEST" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+    await withDurableHomeIngress(fetch, async ({ receive, ingress, queue, runtimeError }) => {
+      const event = createHomeEvent("Ev-home-transient");
+      await receive(event);
+
+      await vi.waitFor(
+        async () => {
+          await ingress.waitForIdle();
+          expect(fetch).toHaveBeenCalledTimes(2);
+        },
+        { timeout: 5_000, interval: 50 },
+      );
+
+      expect(event.ack).toHaveBeenCalledOnce();
+      expect(runtimeError).toHaveBeenCalledOnce();
+      expect(runtimeError).toHaveBeenCalledWith(expect.stringContaining("internal_error"));
+      await expect(
+        queue.enqueue("Ev-home-transient", {} as SlackIngressPayload),
+      ).resolves.toMatchObject({ kind: "completed" });
+    });
+  });
+
+  it("retries Agent View suggested prompts and durably records its marker", async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: false, error: "internal_error" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+    await withDurableHomeIngress(
+      fetch,
+      async ({ receive, ingress, queue, runtimeError, agentViewState, recordSlackAgentView }) => {
+        const event = createHomeEvent("Ev-agent-view-transient", "messages");
+        await receive(event);
+
+        await vi.waitFor(
+          async () => {
+            await ingress.waitForIdle();
+            expect(fetch).toHaveBeenCalledTimes(2);
+          },
+          { timeout: 5_000, interval: 50 },
+        );
+
+        expect(event.ack).toHaveBeenCalledOnce();
+        expect(runtimeError).toHaveBeenCalledOnce();
+        expect(recordSlackAgentView).toHaveBeenCalledOnce();
+        await expect(agentViewState.isEnabled()).resolves.toBe(true);
+        const restartedAgentViewState = createSlackAgentViewState({
+          accountId: "default",
+          teamId: "T_TEST",
+          apiAppId: "A_TEST",
+          warn: vi.fn(),
+        });
+        await expect(restartedAgentViewState.isEnabled()).resolves.toBe(true);
+        await expect(
+          queue.enqueue("Ev-agent-view-transient", {} as SlackIngressPayload),
+        ).resolves.toMatchObject({ kind: "completed" });
+      },
+    );
+  });
+
+  it.each(["home", "messages"] as const)(
+    "replays exhausted real Slack client rate limits for the %s tab",
+    async (tab) => {
+      const rateLimited = () => new Response("", { status: 429, headers: { "retry-after": "0" } });
+      const fetch = vi
+        .fn()
+        .mockImplementationOnce(async () => rateLimited())
+        .mockImplementationOnce(async () => rateLimited())
+        .mockImplementationOnce(async () => rateLimited())
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ ok: true, view: { id: "V_TEST" } }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+
+      await withDurableHomeIngress(
+        fetch,
+        async ({ receive, ingress, queue, agentViewState, recordSlackAgentView }) => {
+          const eventId = `Ev-${tab}-rate-limited`;
+          const event = createHomeEvent(eventId, tab);
+          await receive(event);
+
+          await vi.waitFor(
+            async () => {
+              await ingress.waitForIdle();
+              expect(fetch).toHaveBeenCalledTimes(4);
+            },
+            { timeout: 5_000, interval: 50 },
+          );
+
+          expect(event.ack).toHaveBeenCalledOnce();
+          expect(recordSlackAgentView).toHaveBeenCalledTimes(tab === "messages" ? 1 : 0);
+          await expect(agentViewState.isEnabled()).resolves.toBe(tab === "messages");
+          await expect(queue.enqueue(eventId, {} as SlackIngressPayload)).resolves.toMatchObject({
+            kind: "completed",
+          });
+        },
+      );
+    },
+  );
+
+  it.each(["invalid_arguments", "missing_scope"])(
+    "keeps permanent Agent View capability rejection %s from blocking the next event",
+    async (errorCode) => {
+      const fetch = vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ ok: false, error: errorCode }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ ok: true }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+
+      await withDurableHomeIngress(
+        fetch,
+        async ({ receive, ingress, queue, agentViewState, recordSlackAgentView }) => {
+          const permanentId = `Ev-agent-view-rejected-${errorCode}`;
+          const nextId = `Ev-agent-view-next-${errorCode}`;
+          await receive(createHomeEvent(permanentId, "messages"));
+          await ingress.waitForIdle();
+
+          expect(fetch).toHaveBeenCalledOnce();
+          expect(recordSlackAgentView).not.toHaveBeenCalled();
+          await expect(agentViewState.isEnabled()).resolves.toBe(false);
+          await expect(
+            queue.enqueue(permanentId, {} as SlackIngressPayload),
+          ).resolves.toMatchObject({ kind: "completed" });
+
+          await receive(createHomeEvent(nextId, "messages"));
+          await ingress.waitForIdle();
+
+          expect(fetch).toHaveBeenCalledTimes(2);
+          expect(recordSlackAgentView).toHaveBeenCalledOnce();
+          await expect(agentViewState.isEnabled()).resolves.toBe(true);
+          await expect(queue.enqueue(nextId, {} as SlackIngressPayload)).resolves.toMatchObject({
+            kind: "completed",
+          });
+        },
+      );
+    },
+  );
+
+  it.each([
+    {
+      label: "an actually malformed URL",
+      fail: async () => await globalThis.fetch("http://[invalid"),
+    },
+    {
+      label: "a permanent TLS certificate error",
+      fail: async () => {
+        throw new TypeError("fetch failed", {
+          cause: Object.assign(new Error("certificate fixture"), { code: "CERT_HAS_EXPIRED" }),
+        });
+      },
+    },
+    {
+      label: "a malformed fetch response",
+      fail: async () => null,
+    },
+  ])("keeps real SDK-wrapped $label from poisoning either Home lane", async ({ fail }) => {
+    for (const tab of ["home", "messages"] as const) {
+      const fetch = vi
+        .fn()
+        .mockImplementationOnce(fail)
+        .mockImplementationOnce(fail)
+        .mockImplementationOnce(fail)
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ ok: true, view: { id: "V_TEST" } }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+
+      await withDurableHomeIngress(
+        fetch,
+        async ({ receive, ingress, queue, agentViewState, recordSlackAgentView }) => {
+          const permanentId = `Ev-${tab}-permanent-fetch`;
+          const nextId = `Ev-${tab}-next-after-fetch`;
+          const nextTab = tab === "home" ? "messages" : "home";
+          await receive(createHomeEvent(permanentId, tab));
+          await ingress.waitForIdle();
+
+          expect(fetch).toHaveBeenCalledTimes(3);
+          expect(recordSlackAgentView).not.toHaveBeenCalled();
+          await expect(
+            queue.enqueue(permanentId, {} as SlackIngressPayload),
+          ).resolves.toMatchObject({ kind: "completed" });
+
+          await receive(createHomeEvent(nextId, nextTab));
+          await ingress.waitForIdle();
+
+          expect(fetch).toHaveBeenCalledTimes(4);
+          expect(recordSlackAgentView).toHaveBeenCalledTimes(nextTab === "messages" ? 1 : 0);
+          await expect(agentViewState.isEnabled()).resolves.toBe(nextTab === "messages");
+          await expect(queue.enqueue(nextId, {} as SlackIngressPayload)).resolves.toMatchObject({
+            kind: "completed",
+          });
+        },
+      );
+    }
+  });
+
+  it.each(["invalid_blocks", "user_not_found"])(
+    "completes permanent %s errors without blocking the user's next event",
+    async (errorCode) => {
+      const fetch = vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ ok: false, error: errorCode }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ ok: true, view: { id: "V_TEST" } }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+
+      await withDurableHomeIngress(fetch, async ({ receive, ingress, queue, runtimeError }) => {
+        const permanentId = `Ev-home-permanent-${errorCode}`;
+        const nextId = `Ev-home-next-${errorCode}`;
+        await receive(createHomeEvent(permanentId));
+        await ingress.waitForIdle();
+
+        expect(fetch).toHaveBeenCalledOnce();
+        expect(runtimeError).toHaveBeenCalledWith(expect.stringContaining(errorCode));
+        await expect(queue.enqueue(permanentId, {} as SlackIngressPayload)).resolves.toMatchObject({
+          kind: "completed",
+        });
+
+        await receive(createHomeEvent(nextId));
+        await ingress.waitForIdle();
+
+        expect(fetch).toHaveBeenCalledTimes(2);
+        await expect(queue.enqueue(nextId, {} as SlackIngressPayload)).resolves.toMatchObject({
+          kind: "completed",
+        });
+      });
+    },
+  );
+
+  it.each([
+    { label: "rate-limit", error: new WebAPIRateLimitedError(1) },
+    {
+      label: "temporary HTTP outage",
+      error: new WebAPIHTTPError(503, "Service Unavailable", {}, "temporary outage"),
+    },
+    {
+      label: "connection reset",
+      error: new WebAPIRequestError(
+        Object.assign(new Error("socket reset"), { code: "ECONNRESET" }),
+      ),
+    },
+  ])("returns genuine $label failures to durable ingress", async ({ error }) => {
+    const { ctx, publish, getHomeHandler } = createHomeContext();
+    ctx.runtime.error = vi.fn();
+    publish.mockRejectedValueOnce(error);
+
+    await expect(
+      getHomeHandler()!({
+        event: { type: "app_home_opened", user: "U_TEST", tab: "home" },
+        body: {},
+        context: { openclawIngressLifecycle: createDurableHomeLifecycle() },
+      }),
+    ).rejects.toBe(error);
+
+    expect(ctx.runtime.error).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    {
+      label: "unknown platform failure",
+      error: new WebAPIPlatformError({ ok: false, error: "unknown_error" }),
+    },
+    {
+      label: "missing permission",
+      error: new WebAPIPlatformError({ ok: false, error: "missing_scope" }),
+    },
+    {
+      label: "invalid HTTP request",
+      error: new WebAPIHTTPError(400, "Bad Request", {}, "invalid"),
+    },
+    {
+      label: "operator cancellation",
+      error: new WebAPIRequestError(new DOMException("request canceled", "AbortError")),
+    },
+  ])("keeps $label terminal even when durable ingress owns the event", async ({ error }) => {
+    const { ctx, publish, getHomeHandler } = createHomeContext();
+    ctx.runtime.error = vi.fn();
+    publish.mockRejectedValueOnce(error);
+
+    await expect(
+      getHomeHandler()!({
+        event: { type: "app_home_opened", user: "U_TEST", tab: "home" },
+        body: {},
+        context: { openclawIngressLifecycle: createDurableHomeLifecycle() },
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(ctx.runtime.error).toHaveBeenCalledOnce();
+  });
+
+  it("preserves direct handler logging without durable ingress replay", async () => {
+    const { ctx, publish, getHomeHandler } = createHomeContext();
+    ctx.runtime.error = vi.fn();
+    publish.mockRejectedValueOnce(new WebAPIPlatformError({ ok: false, error: "internal_error" }));
+
+    await expect(
+      getHomeHandler()!({
+        event: { type: "app_home_opened", user: "U_TEST", tab: "home" },
+        body: {},
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(ctx.runtime.error).toHaveBeenCalledWith(expect.stringContaining("internal_error"));
+  });
+
+  it("preserves direct Agent View handler logging without durable ingress replay", async () => {
+    const { ctx, setSlackSuggestedPrompts, recordSlackAgentView, getHomeHandler } =
+      createAgentHomeContext();
+    ctx.runtime.error = vi.fn();
+    setSlackSuggestedPrompts.mockRejectedValueOnce(
+      new WebAPIPlatformError({ ok: false, error: "internal_error" }),
+    );
+
+    await expect(
+      getHomeHandler()!({
+        event: { type: "app_home_opened", user: "U_TEST", channel: "D_TEST", tab: "messages" },
+        body: {},
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(recordSlackAgentView).not.toHaveBeenCalled();
+    expect(ctx.runtime.error).toHaveBeenCalledWith(expect.stringContaining("internal_error"));
   });
 
   it("records Agent View only after Slack accepts threadless prompts", async () => {

--- a/extensions/slack/src/monitor/events/home.test.ts
+++ b/extensions/slack/src/monitor/events/home.test.ts
@@ -40,6 +40,10 @@ const transientPlatformErrors = [
   "fatal_error",
   "request_timeout",
 ] as const;
+const malformedRetryAfterHeaders = [
+  { headerLabel: "missing", retryAfter: undefined },
+  { headerLabel: "invalid", retryAfter: "not-a-timeout" },
+] as const;
 
 function createDurableHomeLifecycle(): SlackIngressTurnLifecycle {
   return {
@@ -436,6 +440,59 @@ describe("registerSlackHomeEvents", () => {
     },
   );
 
+  it.each(
+    malformedRetryAfterHeaders.flatMap(({ headerLabel, retryAfter }) =>
+      (["home", "messages"] as const).map((tab) => ({ headerLabel, retryAfter, tab })),
+    ),
+  )("replays malformed Retry-After $headerLabel for the $tab tab", async (scenario) => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response("", {
+          status: 429,
+          headers: scenario.retryAfter === undefined ? {} : { "retry-after": scenario.retryAfter },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true, view: { id: "V_TEST" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+    await withDurableHomeIngress(
+      fetch,
+      async ({ receive, ingress, queue, agentViewState, recordSlackAgentView }) => {
+        const eventId = `Ev-${scenario.tab}-${scenario.headerLabel}-retry-header`;
+        const event = createHomeEvent(eventId, scenario.tab);
+        await receive(event);
+        await ingress.waitForIdle();
+
+        await expect(queue.listPending()).resolves.toMatchObject([
+          {
+            id: eventId,
+            attempts: 1,
+            lastError: expect.stringContaining("Retry header did not contain a valid timeout"),
+          },
+        ]);
+        await vi.waitFor(
+          async () => {
+            await ingress.waitForIdle();
+            expect(fetch).toHaveBeenCalledTimes(2);
+          },
+          { timeout: 5_000, interval: 50 },
+        );
+
+        expect(event.ack).toHaveBeenCalledOnce();
+        expect(recordSlackAgentView).toHaveBeenCalledTimes(scenario.tab === "messages" ? 1 : 0);
+        await expect(agentViewState.isEnabled()).resolves.toBe(scenario.tab === "messages");
+        await expect(queue.enqueue(eventId, {} as SlackIngressPayload)).resolves.toMatchObject({
+          kind: "completed",
+        });
+      },
+    );
+  });
+
   it.each([
     "invalid_arguments",
     "missing_scope",
@@ -619,6 +676,14 @@ describe("registerSlackHomeEvents", () => {
   });
 
   it.each([
+    {
+      label: "unclassified plain local failure",
+      error: new Error("local provider unavailable"),
+    },
+    {
+      label: "incomplete rate-limit-like failure",
+      error: new Error("Retry header did not contain a valid timeout"),
+    },
     {
       label: "unknown platform failure",
       error: new WebAPIPlatformError({ ok: false, error: "unknown_error" }),

--- a/extensions/slack/src/monitor/events/home.test.ts
+++ b/extensions/slack/src/monitor/events/home.test.ts
@@ -277,64 +277,36 @@ describe("registerSlackHomeEvents", () => {
     });
   });
 
-  it("retries an actual Slack platform failure through durable ingress and publishes once", async () => {
-    const fetch = vi
-      .fn()
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ ok: false, error: "internal_error" }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-      )
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ ok: true, view: { id: "V_TEST" } }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-      );
+  it.each(["internal_error", "service_unavailable", "ratelimited"])(
+    "retries actual Slack Home platform %s through durable ingress",
+    async (errorCode) => {
+      const fetch = vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ ok: false, error: errorCode }), {
+            status: 200,
+            headers: {
+              "content-type": "application/json",
+              ...(errorCode === "ratelimited" ? { "retry-after": "1" } : {}),
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ ok: true, view: { id: "V_TEST" } }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        );
 
-    await withDurableHomeIngress(fetch, async ({ receive, ingress, queue, runtimeError }) => {
-      const event = createHomeEvent("Ev-home-transient");
-      await receive(event);
-
-      await vi.waitFor(
-        async () => {
-          await ingress.waitForIdle();
-          expect(fetch).toHaveBeenCalledTimes(2);
-        },
-        { timeout: 5_000, interval: 50 },
-      );
-
-      expect(event.ack).toHaveBeenCalledOnce();
-      expect(runtimeError).toHaveBeenCalledOnce();
-      expect(runtimeError).toHaveBeenCalledWith(expect.stringContaining("internal_error"));
-      await expect(
-        queue.enqueue("Ev-home-transient", {} as SlackIngressPayload),
-      ).resolves.toMatchObject({ kind: "completed" });
-    });
-  });
-
-  it("retries Agent View suggested prompts and durably records its marker", async () => {
-    const fetch = vi
-      .fn()
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ ok: false, error: "internal_error" }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-      )
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ ok: true }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        }),
-      );
-
-    await withDurableHomeIngress(
-      fetch,
-      async ({ receive, ingress, queue, runtimeError, agentViewState, recordSlackAgentView }) => {
-        const event = createHomeEvent("Ev-agent-view-transient", "messages");
+      await withDurableHomeIngress(fetch, async ({ receive, ingress, queue, runtimeError }) => {
+        const eventId = `Ev-home-transient-${errorCode}`;
+        const event = createHomeEvent(eventId);
         await receive(event);
+        await ingress.waitForIdle();
+
+        await expect(queue.listPending()).resolves.toMatchObject([
+          { id: eventId, attempts: 1, lastError: expect.stringContaining(errorCode) },
+        ]);
 
         await vi.waitFor(
           async () => {
@@ -346,21 +318,73 @@ describe("registerSlackHomeEvents", () => {
 
         expect(event.ack).toHaveBeenCalledOnce();
         expect(runtimeError).toHaveBeenCalledOnce();
-        expect(recordSlackAgentView).toHaveBeenCalledOnce();
-        await expect(agentViewState.isEnabled()).resolves.toBe(true);
-        const restartedAgentViewState = createSlackAgentViewState({
-          accountId: "default",
-          teamId: "T_TEST",
-          apiAppId: "A_TEST",
-          warn: vi.fn(),
+        expect(runtimeError).toHaveBeenCalledWith(expect.stringContaining(errorCode));
+        await expect(queue.enqueue(eventId, {} as SlackIngressPayload)).resolves.toMatchObject({
+          kind: "completed",
         });
-        await expect(restartedAgentViewState.isEnabled()).resolves.toBe(true);
-        await expect(
-          queue.enqueue("Ev-agent-view-transient", {} as SlackIngressPayload),
-        ).resolves.toMatchObject({ kind: "completed" });
-      },
-    );
-  });
+      });
+    },
+  );
+
+  it.each(["internal_error", "service_unavailable", "ratelimited"])(
+    "retries Agent View prompt platform %s and durably records its marker",
+    async (errorCode) => {
+      const fetch = vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ ok: false, error: errorCode }), {
+            status: 200,
+            headers: {
+              "content-type": "application/json",
+              ...(errorCode === "ratelimited" ? { "retry-after": "1" } : {}),
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ ok: true }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+
+      await withDurableHomeIngress(
+        fetch,
+        async ({ receive, ingress, queue, runtimeError, agentViewState, recordSlackAgentView }) => {
+          const eventId = `Ev-agent-view-transient-${errorCode}`;
+          const event = createHomeEvent(eventId, "messages");
+          await receive(event);
+          await ingress.waitForIdle();
+
+          await expect(queue.listPending()).resolves.toMatchObject([
+            { id: eventId, attempts: 1, lastError: expect.stringContaining(errorCode) },
+          ]);
+
+          await vi.waitFor(
+            async () => {
+              await ingress.waitForIdle();
+              expect(fetch).toHaveBeenCalledTimes(2);
+            },
+            { timeout: 5_000, interval: 50 },
+          );
+
+          expect(event.ack).toHaveBeenCalledOnce();
+          expect(runtimeError).toHaveBeenCalledOnce();
+          expect(recordSlackAgentView).toHaveBeenCalledOnce();
+          await expect(agentViewState.isEnabled()).resolves.toBe(true);
+          const restartedAgentViewState = createSlackAgentViewState({
+            accountId: "default",
+            teamId: "T_TEST",
+            apiAppId: "A_TEST",
+            warn: vi.fn(),
+          });
+          await expect(restartedAgentViewState.isEnabled()).resolves.toBe(true);
+          await expect(queue.enqueue(eventId, {} as SlackIngressPayload)).resolves.toMatchObject({
+            kind: "completed",
+          });
+        },
+      );
+    },
+  );
 
   it.each(["home", "messages"] as const)(
     "replays exhausted real Slack client rate limits for the %s tab",

--- a/extensions/slack/src/monitor/events/home.test.ts
+++ b/extensions/slack/src/monitor/events/home.test.ts
@@ -277,7 +277,7 @@ describe("registerSlackHomeEvents", () => {
     });
   });
 
-  it.each(["internal_error", "service_unavailable", "ratelimited"])(
+  it.each(["internal_error", "service_unavailable", "ratelimited", "fatal_error"])(
     "retries actual Slack Home platform %s through durable ingress",
     async (errorCode) => {
       const fetch = vi
@@ -326,7 +326,7 @@ describe("registerSlackHomeEvents", () => {
     },
   );
 
-  it.each(["internal_error", "service_unavailable", "ratelimited"])(
+  it.each(["internal_error", "service_unavailable", "ratelimited", "fatal_error"])(
     "retries Agent View prompt platform %s and durably records its marker",
     async (errorCode) => {
       const fetch = vi

--- a/extensions/slack/src/monitor/events/home.test.ts
+++ b/extensions/slack/src/monitor/events/home.test.ts
@@ -33,6 +33,14 @@ type HomeHandler = (args: {
 type SlackIngressQueue = NonNullable<Parameters<typeof createSlackDurableIngress>[0]["queue"]>;
 type SlackIngressPayload = Parameters<SlackIngressQueue["enqueue"]>[1];
 
+const transientPlatformErrors = [
+  "internal_error",
+  "service_unavailable",
+  "ratelimited",
+  "fatal_error",
+  "request_timeout",
+] as const;
+
 function createDurableHomeLifecycle(): SlackIngressTurnLifecycle {
   return {
     admission: "exclusive",
@@ -277,7 +285,7 @@ describe("registerSlackHomeEvents", () => {
     });
   });
 
-  it.each(["internal_error", "service_unavailable", "ratelimited", "fatal_error"])(
+  it.each(transientPlatformErrors)(
     "retries actual Slack Home platform %s through durable ingress",
     async (errorCode) => {
       const fetch = vi
@@ -326,7 +334,7 @@ describe("registerSlackHomeEvents", () => {
     },
   );
 
-  it.each(["internal_error", "service_unavailable", "ratelimited", "fatal_error"])(
+  it.each(transientPlatformErrors)(
     "retries Agent View prompt platform %s and durably records its marker",
     async (errorCode) => {
       const fetch = vi
@@ -428,7 +436,13 @@ describe("registerSlackHomeEvents", () => {
     },
   );
 
-  it.each(["invalid_arguments", "missing_scope"])(
+  it.each([
+    "invalid_arguments",
+    "missing_scope",
+    "org_login_required",
+    "invalid_auth",
+    "invalid_form_data",
+  ])(
     "keeps permanent Agent View capability rejection %s from blocking the next event",
     async (errorCode) => {
       const fetch = vi

--- a/extensions/slack/src/monitor/events/home.ts
+++ b/extensions/slack/src/monitor/events/home.ts
@@ -1,9 +1,11 @@
 // Slack plugin module implements home behavior.
-import type { SlackEventMiddlewareArgs } from "@slack/bolt";
+import type { AllMiddlewareArgs, SlackEventMiddlewareArgs } from "@slack/bolt";
 import type { HomeView } from "@slack/types";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { danger } from "openclaw/plugin-sdk/runtime-env";
 import { DEFAULT_SLACK_SUGGESTED_PROMPTS, type SlackMonitorContext } from "../context.js";
+import { resolveSlackIngressTurnLifecycle } from "../ingress.js";
+import { isTransientSlackApiError } from "../transient-api-error.js";
 import type { SlackAppHomeOpenedEvent } from "../types.js";
 
 function buildSlackHomeView(slashCommandName?: string): HomeView {
@@ -50,7 +52,11 @@ export function registerSlackHomeEvents(params: {
 
   ctx.app.event(
     "app_home_opened",
-    async ({ event, body }: SlackEventMiddlewareArgs<"app_home_opened">) => {
+    async ({
+      event,
+      body,
+      context,
+    }: SlackEventMiddlewareArgs<"app_home_opened"> & AllMiddlewareArgs) => {
       try {
         if (ctx.shouldDropMismatchedSlackEvent(body)) {
           return;
@@ -86,6 +92,9 @@ export function registerSlackHomeEvents(params: {
         });
       } catch (err) {
         ctx.runtime.error?.(danger(`slack app home handler failed: ${formatErrorMessage(err)}`));
+        if (resolveSlackIngressTurnLifecycle(context) && isTransientSlackApiError(err)) {
+          throw err;
+        }
       }
     },
   );

--- a/extensions/slack/src/monitor/monitor.thread-resolution.test.ts
+++ b/extensions/slack/src/monitor/monitor.thread-resolution.test.ts
@@ -1,9 +1,11 @@
 // Slack tests cover monitor.thread resolution plugin behavior.
 import {
+  LogLevel,
   WebAPIHTTPError,
   WebAPIPlatformError,
   WebAPIRateLimitedError,
   WebAPIRequestError,
+  WebClient,
 } from "@slack/web-api";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SlackMessageEvent } from "../types.js";
@@ -98,6 +100,10 @@ describe("createSlackThreadTsResolver", () => {
       error: new WebAPIRateLimitedError(1),
     },
     {
+      label: "an actual Slack platform internal error",
+      error: new WebAPIPlatformError({ ok: false, error: "internal_error" }),
+    },
+    {
       label: "an actual Slack request timeout",
       error: new WebAPIRequestError(
         Object.assign(new Error("request timed out"), { code: "ETIMEDOUT" }),
@@ -111,6 +117,18 @@ describe("createSlackThreadTsResolver", () => {
       label: "an actual Slack connection reset",
       error: new WebAPIRequestError(
         Object.assign(new Error("socket was reset"), { code: "ECONNRESET" }),
+      ),
+    },
+    {
+      label: "an uncoded Slack request failure",
+      error: new WebAPIRequestError(new Error("temporary request failure")),
+    },
+    {
+      label: "a fetch transport type error",
+      error: new WebAPIRequestError(
+        new TypeError("fetch failed", {
+          cause: Object.assign(new Error("socket reset"), { code: "ECONNRESET" }),
+        }),
       ),
     },
   ])("hands $label to durable ingress without poisoning the cache", async ({ error }) => {
@@ -134,6 +152,85 @@ describe("createSlackThreadTsResolver", () => {
     ).resolves.toMatchObject({ thread_ts: "9" });
 
     expect(historyMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries exhausted actual Slack client rate limits without caching ambiguity", async () => {
+    const rateLimited = () => new Response("", { status: 429, headers: { "retry-after": "0" } });
+    const fetch = vi
+      .fn()
+      .mockImplementationOnce(async () => rateLimited())
+      .mockImplementationOnce(async () => rateLimited())
+      .mockImplementationOnce(async () => rateLimited())
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true, messages: [{ ts: "1", thread_ts: "9" }] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    const client = new WebClient("xoxb-test", {
+      fetch,
+      logLevel: LogLevel.ERROR,
+      retryConfig: { retries: 2, minTimeout: 0, maxTimeout: 0, randomize: false },
+    });
+    const resolver = createSlackThreadTsResolver({
+      client,
+      cacheTtlMs: 60_000,
+      maxSize: 5,
+    });
+    const message = makeThreadReplyMessage("1");
+    const turnAdoptionLifecycle = createDurableTurnLifecycle();
+
+    await expect(
+      resolver.resolve({ message, source: "message", turnAdoptionLifecycle }),
+    ).rejects.toBeInstanceOf(WebAPIRequestError);
+    expect(fetch).toHaveBeenCalledTimes(3);
+
+    await expect(
+      resolver.resolve({ message, source: "app_mention", turnAdoptionLifecycle }),
+    ).resolves.toMatchObject({ thread_ts: "9" });
+    expect(fetch).toHaveBeenCalledTimes(4);
+  });
+
+  it.each([
+    {
+      label: "an actually malformed URL",
+      fail: async () => await globalThis.fetch("http://[invalid"),
+    },
+    {
+      label: "an untrusted TLS certificate",
+      fail: async () => {
+        throw new TypeError("fetch failed", {
+          cause: Object.assign(new Error("certificate fixture"), {
+            code: "ERR_TLS_CERT_ALTNAME_INVALID",
+          }),
+        });
+      },
+    },
+    {
+      label: "a malformed fetch response",
+      fail: async () => null,
+    },
+  ])("keeps real SDK-wrapped $label terminal without retrying the cache", async ({ fail }) => {
+    const fetch = vi.fn().mockImplementation(fail);
+    const resolver = createSlackThreadTsResolver({
+      client: new WebClient("xoxb-test", {
+        fetch,
+        logLevel: LogLevel.ERROR,
+        retryConfig: { retries: 2, minTimeout: 0, maxTimeout: 0, randomize: false },
+      }),
+      cacheTtlMs: 60_000,
+      maxSize: 5,
+    });
+    const message = makeThreadReplyMessage("1");
+    const turnAdoptionLifecycle = createDurableTurnLifecycle();
+
+    await expect(
+      resolver.resolve({ message, source: "message", turnAdoptionLifecycle }),
+    ).resolves.toMatchObject({ _ambiguousThreadReply: true });
+    await expect(
+      resolver.resolve({ message, source: "app_mention", turnAdoptionLifecycle }),
+    ).resolves.toMatchObject({ _ambiguousThreadReply: true });
+    expect(fetch).toHaveBeenCalledTimes(3);
   });
 
   it("keeps direct transient failures ambiguous without poisoning their future lookup", async () => {
@@ -219,12 +316,54 @@ describe("createSlackThreadTsResolver", () => {
       error: new WebAPIPlatformError({ ok: false, error: "missing_scope" }),
     },
     {
+      label: "Slack platform invalid_blocks",
+      error: new WebAPIPlatformError({ ok: false, error: "invalid_blocks" }),
+    },
+    {
+      label: "Slack platform user_not_found",
+      error: new WebAPIPlatformError({ ok: false, error: "user_not_found" }),
+    },
+    {
       label: "unclassified local failure",
       error: new Error("local lookup unavailable"),
     },
     {
       label: "operator-canceled Slack request",
       error: new WebAPIRequestError(new DOMException("request was canceled", "AbortError")),
+    },
+    {
+      label: "nested operator-canceled Slack request",
+      error: new WebAPIRequestError(
+        new Error("request wrapper", {
+          cause: new DOMException("request was canceled", "AbortError"),
+        }),
+      ),
+    },
+    {
+      label: "unwrapped local type failure",
+      error: new TypeError("invalid local request"),
+    },
+    {
+      label: "SDK-wrapped invalid URL",
+      error: new WebAPIRequestError(
+        new TypeError("invalid request", {
+          cause: Object.assign(new TypeError("invalid URL"), { code: "ERR_INVALID_URL" }),
+        }),
+      ),
+    },
+    {
+      label: "SDK-wrapped untrusted TLS certificate",
+      error: new WebAPIRequestError(
+        new TypeError("fetch failed", {
+          cause: Object.assign(new Error("certificate fixture"), {
+            code: "DEPTH_ZERO_SELF_SIGNED_CERT",
+          }),
+        }),
+      ),
+    },
+    {
+      label: "SDK-wrapped malformed fetch response",
+      error: new WebAPIRequestError(new TypeError("invalid fetch response")),
     },
   ])("preserves cached ambiguity for definitive $label", async ({ error }) => {
     const historyMock = vi.fn().mockRejectedValue(error);

--- a/extensions/slack/src/monitor/monitor.thread-resolution.test.ts
+++ b/extensions/slack/src/monitor/monitor.thread-resolution.test.ts
@@ -154,7 +154,7 @@ describe("createSlackThreadTsResolver", () => {
     expect(historyMock).toHaveBeenCalledTimes(2);
   });
 
-  it.each(["service_unavailable", "ratelimited", "fatal_error"])(
+  it.each(["service_unavailable", "ratelimited", "fatal_error", "request_timeout"])(
     "returns actual Slack platform %s to durable ingress without caching ambiguity",
     async (errorCode) => {
       const responses = [

--- a/extensions/slack/src/monitor/monitor.thread-resolution.test.ts
+++ b/extensions/slack/src/monitor/monitor.thread-resolution.test.ts
@@ -154,6 +154,68 @@ describe("createSlackThreadTsResolver", () => {
     expect(historyMock).toHaveBeenCalledTimes(2);
   });
 
+  it.each(["service_unavailable", "ratelimited"])(
+    "returns actual Slack platform %s to durable ingress without caching ambiguity",
+    async (errorCode) => {
+      const responses = [
+        new Response(JSON.stringify({ ok: false, error: errorCode }), {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            ...(errorCode === "ratelimited" ? { "retry-after": "1" } : {}),
+          },
+        }),
+        new Response(JSON.stringify({ ok: true, messages: [{ ts: "1", thread_ts: "9" }] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ];
+      const fetch = vi.fn(async (input: RequestInfo | URL) => {
+        const url = new URL(
+          typeof input === "string" ? input : input instanceof URL ? input.href : input.url,
+        );
+        if (
+          url.origin !== "https://slack-proof.invalid" ||
+          url.pathname !== "/api/conversations.history"
+        ) {
+          throw new Error(`unexpected Slack thread proof request: ${url.origin}${url.pathname}`);
+        }
+        const response = responses.shift();
+        if (!response) {
+          throw new Error("unexpected Slack thread proof retry");
+        }
+        return response;
+      });
+      const resolver = createSlackThreadTsResolver({
+        client: new WebClient("xoxb-fixture", {
+          slackApiUrl: "https://slack-proof.invalid/api/",
+          fetch,
+          logLevel: LogLevel.ERROR,
+          retryConfig: { retries: 0 },
+        }),
+        cacheTtlMs: 60_000,
+        maxSize: 5,
+      });
+      const message = makeThreadReplyMessage("1");
+      const turnAdoptionLifecycle = createDurableTurnLifecycle();
+
+      await expect(
+        resolver.resolve({ message, source: "message", turnAdoptionLifecycle }),
+      ).rejects.toMatchObject({
+        data: {
+          error: errorCode,
+          ...(errorCode === "ratelimited" ? { response_metadata: { retryAfter: 1 } } : {}),
+        },
+      });
+      expect(fetch).toHaveBeenCalledOnce();
+
+      await expect(
+        resolver.resolve({ message, source: "app_mention", turnAdoptionLifecycle }),
+      ).resolves.toMatchObject({ thread_ts: "9" });
+      expect(fetch).toHaveBeenCalledTimes(2);
+    },
+  );
+
   it("retries exhausted actual Slack client rate limits without caching ambiguity", async () => {
     const rateLimited = () => new Response("", { status: 429, headers: { "retry-after": "0" } });
     const fetch = vi

--- a/extensions/slack/src/monitor/monitor.thread-resolution.test.ts
+++ b/extensions/slack/src/monitor/monitor.thread-resolution.test.ts
@@ -154,7 +154,7 @@ describe("createSlackThreadTsResolver", () => {
     expect(historyMock).toHaveBeenCalledTimes(2);
   });
 
-  it.each(["service_unavailable", "ratelimited"])(
+  it.each(["service_unavailable", "ratelimited", "fatal_error"])(
     "returns actual Slack platform %s to durable ingress without caching ambiguity",
     async (errorCode) => {
       const responses = [

--- a/extensions/slack/src/monitor/monitor.thread-resolution.test.ts
+++ b/extensions/slack/src/monitor/monitor.thread-resolution.test.ts
@@ -254,6 +254,50 @@ describe("createSlackThreadTsResolver", () => {
   });
 
   it.each([
+    { headerLabel: "missing", retryAfter: undefined },
+    { headerLabel: "invalid", retryAfter: "not-a-timeout" },
+  ])(
+    "replays malformed Retry-After $headerLabel without poisoning thread lookup",
+    async (scenario) => {
+      const fetch = vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response("", {
+            status: 429,
+            headers:
+              scenario.retryAfter === undefined ? {} : { "retry-after": scenario.retryAfter },
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ ok: true, messages: [{ ts: "1", thread_ts: "9" }] }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+      const resolver = createSlackThreadTsResolver({
+        client: new WebClient("xoxb-fixture", {
+          slackApiUrl: "https://slack-proof.invalid/api/",
+          fetch,
+          logLevel: LogLevel.ERROR,
+          retryConfig: { retries: 0 },
+        }),
+        cacheTtlMs: 60_000,
+        maxSize: 5,
+      });
+      const message = makeThreadReplyMessage("1");
+      const turnAdoptionLifecycle = createDurableTurnLifecycle();
+
+      await expect(
+        resolver.resolve({ message, source: "message", turnAdoptionLifecycle }),
+      ).rejects.toThrow("Retry header did not contain a valid timeout");
+      await expect(
+        resolver.resolve({ message, source: "app_mention", turnAdoptionLifecycle }),
+      ).resolves.toMatchObject({ thread_ts: "9" });
+      expect(fetch).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it.each([
     {
       label: "an actually malformed URL",
       fail: async () => await globalThis.fetch("http://[invalid"),

--- a/extensions/slack/src/monitor/suggested-prompts.test.ts
+++ b/extensions/slack/src/monitor/suggested-prompts.test.ts
@@ -1,7 +1,18 @@
 // Slack tests cover suggested-prompt capability detection across view generations.
 import type { App } from "@slack/bolt";
+import {
+  WebAPIHTTPError,
+  WebAPIPlatformError,
+  WebAPIRateLimitedError,
+  WebAPIRequestError,
+} from "@slack/web-api";
 import { describe, expect, it, vi } from "vitest";
-import { updateSlackSuggestedPrompts } from "./suggested-prompts.js";
+import type { SlackMonitorContext } from "./context.js";
+import { registerSlackAssistantEvents } from "./events/assistant.js";
+import {
+  updateSlackSuggestedPrompts,
+  type SlackSuggestedPromptsInput,
+} from "./suggested-prompts.js";
 
 function createSlackClient(setSuggestedPrompts: ReturnType<typeof vi.fn>): App["client"] {
   return {
@@ -47,5 +58,160 @@ describe("updateSlackSuggestedPrompts", () => {
     });
 
     expect(updated).toBe(false);
+  });
+
+  it.each([
+    {
+      label: "Slack platform internal failure",
+      error: new WebAPIPlatformError({ ok: false, error: "internal_error" }),
+    },
+    {
+      label: "temporary HTTP outage",
+      error: new WebAPIHTTPError(503, "Service Unavailable", {}, "temporary outage"),
+    },
+    {
+      label: "explicit Slack rate limit",
+      error: new WebAPIRateLimitedError(1),
+    },
+    {
+      label: "uncoded Slack request failure",
+      error: new WebAPIRequestError(new Error("temporary request failure")),
+    },
+    {
+      label: "actual SDK request timeout",
+      error: new WebAPIRequestError(new DOMException("request timed out", "TimeoutError")),
+    },
+    {
+      label: "actual SDK fetch connection reset",
+      error: new WebAPIRequestError(
+        new TypeError("fetch failed", {
+          cause: Object.assign(new Error("socket reset"), { code: "ECONNRESET" }),
+        }),
+      ),
+    },
+  ])("returns $label to its durable event owner", async ({ error }) => {
+    const setSuggestedPrompts = vi.fn().mockRejectedValue(error);
+
+    await expect(
+      updateSlackSuggestedPrompts({
+        botToken: "",
+        client: createSlackClient(setSuggestedPrompts),
+        channelId: "D123",
+        prompts: [{ title: "Draft a reply", message: "Help me draft a reply." }],
+      }),
+    ).rejects.toBe(error);
+  });
+
+  it.each([
+    {
+      label: "Assistant View capability rejection",
+      error: new WebAPIPlatformError({ ok: false, error: "invalid_arguments" }),
+    },
+    {
+      label: "missing permission",
+      error: new WebAPIPlatformError({ ok: false, error: "missing_scope" }),
+    },
+    {
+      label: "invalid prompt blocks",
+      error: new WebAPIPlatformError({ ok: false, error: "invalid_blocks" }),
+    },
+    {
+      label: "missing recipient",
+      error: new WebAPIPlatformError({ ok: false, error: "user_not_found" }),
+    },
+    {
+      label: "invalid HTTP request",
+      error: new WebAPIHTTPError(400, "Bad Request", {}, "invalid request"),
+    },
+    {
+      label: "operator cancellation",
+      error: new WebAPIRequestError(new DOMException("request canceled", "AbortError")),
+    },
+    {
+      label: "nested operator cancellation",
+      error: new WebAPIRequestError(
+        new Error("request wrapper", { cause: new DOMException("request canceled", "AbortError") }),
+      ),
+    },
+    {
+      label: "unwrapped local type failure",
+      error: new TypeError("invalid local request"),
+    },
+    {
+      label: "SDK-wrapped invalid URL",
+      error: new WebAPIRequestError(
+        new TypeError("invalid request", {
+          cause: Object.assign(new TypeError("invalid URL"), { code: "ERR_INVALID_URL" }),
+        }),
+      ),
+    },
+    {
+      label: "SDK-wrapped expired TLS certificate",
+      error: new WebAPIRequestError(
+        new TypeError("fetch failed", {
+          cause: Object.assign(new Error("certificate fixture"), { code: "CERT_HAS_EXPIRED" }),
+        }),
+      ),
+    },
+    {
+      label: "SDK-wrapped malformed response",
+      error: new WebAPIRequestError(new TypeError("invalid fetch response")),
+    },
+  ])("keeps $label as a definitive unsupported capability", async ({ error }) => {
+    const setSuggestedPrompts = vi.fn().mockRejectedValue(error);
+
+    await expect(
+      updateSlackSuggestedPrompts({
+        botToken: "",
+        client: createSlackClient(setSuggestedPrompts),
+        channelId: "D123",
+        prompts: [{ title: "Draft a reply", message: "Help me draft a reply." }],
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("preserves the Assistant View owner's existing transient-failure catch", async () => {
+    const error = new WebAPIPlatformError({ ok: false, error: "internal_error" });
+    const setSuggestedPrompts = vi.fn().mockRejectedValue(error);
+    const client = createSlackClient(setSuggestedPrompts);
+    const handlers = new Map<
+      string,
+      (args: { event: Record<string, unknown>; body: unknown }) => Promise<void>
+    >();
+    const runtimeError = vi.fn();
+    const ctx = {
+      app: {
+        client,
+        event: (
+          name: string,
+          handler: (args: { event: Record<string, unknown>; body: unknown }) => Promise<void>,
+        ) => handlers.set(name, handler),
+      },
+      runtime: { error: runtimeError },
+      botToken: "",
+      shouldDropMismatchedSlackEvent: () => false,
+      getSlackAssistantThreadContext: () => undefined,
+      saveSlackAssistantThreadContext: vi.fn(),
+      setSlackSuggestedPrompts: (input: SlackSuggestedPromptsInput) =>
+        updateSlackSuggestedPrompts({ ...input, botToken: "", client }),
+    } as unknown as SlackMonitorContext;
+    registerSlackAssistantEvents({ ctx });
+
+    await expect(
+      handlers.get("assistant_thread_started")?.({
+        event: {
+          type: "assistant_thread_started",
+          assistant_thread: {
+            user_id: "U123",
+            channel_id: "D123",
+            thread_ts: "1729999327.187299",
+          },
+        },
+        body: {},
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(setSuggestedPrompts).toHaveBeenCalledOnce();
+    expect(runtimeError).toHaveBeenCalledWith(expect.stringContaining("internal_error"));
   });
 });

--- a/extensions/slack/src/monitor/suggested-prompts.test.ts
+++ b/extensions/slack/src/monitor/suggested-prompts.test.ts
@@ -66,6 +66,14 @@ describe("updateSlackSuggestedPrompts", () => {
       error: new WebAPIPlatformError({ ok: false, error: "internal_error" }),
     },
     {
+      label: "Slack platform service outage",
+      error: new WebAPIPlatformError({ ok: false, error: "service_unavailable" }),
+    },
+    {
+      label: "Slack platform rate limit",
+      error: new WebAPIPlatformError({ ok: false, error: "ratelimited" }),
+    },
+    {
       label: "temporary HTTP outage",
       error: new WebAPIHTTPError(503, "Service Unavailable", {}, "temporary outage"),
     },
@@ -169,6 +177,24 @@ describe("updateSlackSuggestedPrompts", () => {
       }),
     ).resolves.toBe(false);
   });
+
+  it.each(["missing_scope", "invalid_arguments"])(
+    "returns the original threaded Assistant %s rejection to its event owner",
+    async (errorCode) => {
+      const error = new WebAPIPlatformError({ ok: false, error: errorCode });
+      const setSuggestedPrompts = vi.fn().mockRejectedValue(error);
+
+      await expect(
+        updateSlackSuggestedPrompts({
+          botToken: "",
+          client: createSlackClient(setSuggestedPrompts),
+          channelId: "D123",
+          threadTs: "1729999327.187299",
+          prompts: [{ title: "Draft a reply", message: "Help me draft a reply." }],
+        }),
+      ).rejects.toBe(error);
+    },
+  );
 
   it("preserves the Assistant View owner's existing transient-failure catch", async () => {
     const error = new WebAPIPlatformError({ ok: false, error: "internal_error" });

--- a/extensions/slack/src/monitor/suggested-prompts.test.ts
+++ b/extensions/slack/src/monitor/suggested-prompts.test.ts
@@ -120,6 +120,14 @@ describe("updateSlackSuggestedPrompts", () => {
 
   it.each([
     {
+      label: "unclassified plain local failure",
+      error: new Error("local prompt provider unavailable"),
+    },
+    {
+      label: "incomplete rate-limit-like failure",
+      error: new Error("Retry header did not contain a valid timeout"),
+    },
+    {
       label: "Assistant View capability rejection",
       error: new WebAPIPlatformError({ ok: false, error: "invalid_arguments" }),
     },

--- a/extensions/slack/src/monitor/suggested-prompts.test.ts
+++ b/extensions/slack/src/monitor/suggested-prompts.test.ts
@@ -66,6 +66,10 @@ describe("updateSlackSuggestedPrompts", () => {
       error: new WebAPIPlatformError({ ok: false, error: "internal_error" }),
     },
     {
+      label: "Slack platform fatal failure",
+      error: new WebAPIPlatformError({ ok: false, error: "fatal_error" }),
+    },
+    {
       label: "Slack platform service outage",
       error: new WebAPIPlatformError({ ok: false, error: "service_unavailable" }),
     },

--- a/extensions/slack/src/monitor/suggested-prompts.test.ts
+++ b/extensions/slack/src/monitor/suggested-prompts.test.ts
@@ -70,6 +70,10 @@ describe("updateSlackSuggestedPrompts", () => {
       error: new WebAPIPlatformError({ ok: false, error: "fatal_error" }),
     },
     {
+      label: "Slack platform request_timeout",
+      error: new WebAPIPlatformError({ ok: false, error: "request_timeout" }),
+    },
+    {
       label: "Slack platform service outage",
       error: new WebAPIPlatformError({ ok: false, error: "service_unavailable" }),
     },
@@ -122,6 +126,18 @@ describe("updateSlackSuggestedPrompts", () => {
     {
       label: "missing permission",
       error: new WebAPIPlatformError({ ok: false, error: "missing_scope" }),
+    },
+    {
+      label: "enterprise migration",
+      error: new WebAPIPlatformError({ ok: false, error: "org_login_required" }),
+    },
+    {
+      label: "invalid authentication",
+      error: new WebAPIPlatformError({ ok: false, error: "invalid_auth" }),
+    },
+    {
+      label: "malformed request configuration",
+      error: new WebAPIPlatformError({ ok: false, error: "invalid_form_data" }),
     },
     {
       label: "invalid prompt blocks",

--- a/extensions/slack/src/monitor/suggested-prompts.ts
+++ b/extensions/slack/src/monitor/suggested-prompts.ts
@@ -2,6 +2,7 @@
 import type { App } from "@slack/bolt";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { formatSlackError } from "../errors.js";
+import { isTransientSlackApiError } from "./transient-api-error.js";
 
 type SlackSuggestedPrompt = {
   title: string;
@@ -47,6 +48,10 @@ export async function updateSlackSuggestedPrompts(
     });
     return true;
   } catch (error) {
+    if (isTransientSlackApiError(error)) {
+      // Definitive capability rejection stays false; durable owners must retry temporary failures.
+      throw error;
+    }
     logVerbose(
       `slack suggested prompts update failed for channel ${params.channelId}: ${formatSlackError(error)}`,
     );

--- a/extensions/slack/src/monitor/suggested-prompts.ts
+++ b/extensions/slack/src/monitor/suggested-prompts.ts
@@ -48,8 +48,8 @@ export async function updateSlackSuggestedPrompts(
     });
     return true;
   } catch (error) {
-    if (isTransientSlackApiError(error)) {
-      // Definitive capability rejection stays false; durable owners must retry temporary failures.
+    if (params.threadTs || isTransientSlackApiError(error)) {
+      // Threaded actions need their real failure; only threadless Home probes may reject quietly.
       throw error;
     }
     logVerbose(

--- a/extensions/slack/src/monitor/thread-resolution.ts
+++ b/extensions/slack/src/monitor/thread-resolution.ts
@@ -1,26 +1,16 @@
 // Slack plugin module implements thread resolution behavior.
-import {
-  type WebClient as SlackWebClient,
-  WebAPIHTTPError,
-  WebAPIRateLimitedError,
-  WebAPIRequestError,
-} from "@slack/web-api";
+import type { WebClient as SlackWebClient } from "@slack/web-api";
 import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
-import {
-  collectErrorGraphCandidates,
-  extractErrorCode,
-  readErrorName,
-} from "openclaw/plugin-sdk/error-runtime";
 import {
   asDateTimestampMs,
   parseFiniteNumber,
   resolveExpiresAtMsFromDurationMs,
 } from "openclaw/plugin-sdk/number-runtime";
-import { classifyTransientNetworkErrorCode } from "openclaw/plugin-sdk/retry-runtime";
 import { logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { formatSlackError } from "../errors.js";
 import type { SlackMessageEvent } from "../types.js";
 import type { SlackIngressTurnLifecycle } from "./ingress.js";
+import { isTransientSlackApiError } from "./transient-api-error.js";
 
 type ThreadTsCacheEntry = {
   threadTs: string | null;
@@ -39,31 +29,6 @@ const markAmbiguousThreadReply = (message: SlackMessageEvent): SlackMessageEvent
   ...message,
   _ambiguousThreadReply: true,
 });
-
-function isTransientSlackThreadLookupError(error: unknown): boolean {
-  if (error instanceof WebAPIRateLimitedError) {
-    return true;
-  }
-  if (error instanceof WebAPIHTTPError) {
-    return (
-      error.statusCode === 408 ||
-      error.statusCode === 429 ||
-      (error.statusCode >= 500 && error.statusCode < 600)
-    );
-  }
-  if (!(error instanceof WebAPIRequestError)) {
-    return false;
-  }
-  return collectErrorGraphCandidates(error.original, (current) => [
-    current.cause,
-    current.error,
-    current.original,
-  ]).some(
-    (candidate) =>
-      classifyTransientNetworkErrorCode(extractErrorCode(candidate)) ||
-      readErrorName(candidate) === "TimeoutError",
-  );
-}
 
 async function resolveThreadTsFromHistory(params: {
   client: SlackWebClient;
@@ -170,7 +135,7 @@ export function createSlackThreadTsResolver(params: {
             `slack inbound: failed to resolve thread_ts via conversations.history for channel=${message.channel} ts=${message.ts}: ${formatSlackError(err)}`,
           );
         }
-        if (isTransientSlackThreadLookupError(err)) {
+        if (isTransientSlackApiError(err)) {
           if (request.turnAdoptionLifecycle) {
             // The already-acknowledged durable ingress owner retries without dropping the turn.
             throw err;

--- a/extensions/slack/src/monitor/transient-api-error.ts
+++ b/extensions/slack/src/monitor/transient-api-error.ts
@@ -1,0 +1,56 @@
+// Slack plugin module owns retry classification for durable Web API operations.
+import {
+  WebAPIHTTPError,
+  WebAPIPlatformError,
+  WebAPIRateLimitedError,
+  WebAPIRequestError,
+} from "@slack/web-api";
+import {
+  collectErrorGraphCandidates,
+  extractErrorCode,
+  readErrorName,
+} from "openclaw/plugin-sdk/error-runtime";
+import { classifyTransientNetworkErrorCode } from "openclaw/plugin-sdk/retry-runtime";
+
+export function isTransientSlackApiError(error: unknown): boolean {
+  if (error instanceof WebAPIPlatformError) {
+    // Slack converts successful HTTP responses into platform errors after its request retries.
+    return error.data.error === "internal_error";
+  }
+  if (error instanceof WebAPIRateLimitedError) {
+    return true;
+  }
+  if (error instanceof WebAPIHTTPError) {
+    return (
+      error.statusCode === 408 ||
+      error.statusCode === 429 ||
+      (error.statusCode >= 500 && error.statusCode < 600)
+    );
+  }
+  if (!(error instanceof WebAPIRequestError)) {
+    return false;
+  }
+  const candidates = collectErrorGraphCandidates(error.original, (current) => [
+    current.cause,
+    current.error,
+    current.original,
+  ]);
+  if (candidates.some((candidate) => readErrorName(candidate) === "AbortError")) {
+    return false;
+  }
+  if (
+    candidates.some(
+      (candidate) =>
+        readErrorName(candidate) === "TimeoutError" ||
+        classifyTransientNetworkErrorCode(extractErrorCode(candidate)),
+    )
+  ) {
+    return true;
+  }
+  // Exhausted rate limits become uncoded plain Errors; broken config and fetches keep
+  // a structured error code or TypeError, so retrying them would block the whole lane.
+  return !candidates.some(
+    (candidate) =>
+      readErrorName(candidate) === "TypeError" || Boolean(extractErrorCode(candidate)?.trim()),
+  );
+}

--- a/extensions/slack/src/monitor/transient-api-error.ts
+++ b/extensions/slack/src/monitor/transient-api-error.ts
@@ -16,6 +16,7 @@ export function isTransientSlackApiError(error: unknown): boolean {
   if (error instanceof WebAPIPlatformError) {
     // Slack converts successful HTTP responses into platform errors after its request retries.
     return (
+      error.data.error === "fatal_error" ||
       error.data.error === "internal_error" ||
       error.data.error === "service_unavailable" ||
       error.data.error === "ratelimited"

--- a/extensions/slack/src/monitor/transient-api-error.ts
+++ b/extensions/slack/src/monitor/transient-api-error.ts
@@ -12,15 +12,19 @@ import {
 } from "openclaw/plugin-sdk/error-runtime";
 import { classifyTransientNetworkErrorCode } from "openclaw/plugin-sdk/retry-runtime";
 
+// SDK-built POSTs have complete bodies, so request_timeout signals transport truncation.
+const retryableSlackPlatformErrors = new Set([
+  "fatal_error",
+  "internal_error",
+  "request_timeout",
+  "ratelimited",
+  "service_unavailable",
+]);
+
 export function isTransientSlackApiError(error: unknown): boolean {
   if (error instanceof WebAPIPlatformError) {
     // Slack converts successful HTTP responses into platform errors after its request retries.
-    return (
-      error.data.error === "fatal_error" ||
-      error.data.error === "internal_error" ||
-      error.data.error === "service_unavailable" ||
-      error.data.error === "ratelimited"
-    );
+    return retryableSlackPlatformErrors.has(error.data.error);
   }
   if (error instanceof WebAPIRateLimitedError) {
     return true;

--- a/extensions/slack/src/monitor/transient-api-error.ts
+++ b/extensions/slack/src/monitor/transient-api-error.ts
@@ -15,7 +15,11 @@ import { classifyTransientNetworkErrorCode } from "openclaw/plugin-sdk/retry-run
 export function isTransientSlackApiError(error: unknown): boolean {
   if (error instanceof WebAPIPlatformError) {
     // Slack converts successful HTTP responses into platform errors after its request retries.
-    return error.data.error === "internal_error";
+    return (
+      error.data.error === "internal_error" ||
+      error.data.error === "service_unavailable" ||
+      error.data.error === "ratelimited"
+    );
   }
   if (error instanceof WebAPIRateLimitedError) {
     return true;

--- a/extensions/slack/src/monitor/transient-api-error.ts
+++ b/extensions/slack/src/monitor/transient-api-error.ts
@@ -37,7 +37,13 @@ export function isTransientSlackApiError(error: unknown): boolean {
     );
   }
   if (!(error instanceof WebAPIRequestError)) {
-    return false;
+    // Slack SDK unwraps malformed 429 Retry-After into this exact uncoded Error;
+    // retry only that dependency contract so durable work is not lost.
+    return (
+      error instanceof Error &&
+      error.name === "Error" &&
+      error.message.startsWith("Retry header did not contain a valid timeout (url: ")
+    );
   }
   const candidates = collectErrorGraphCandidates(error.original, (current) => [
     current.cause,


### PR DESCRIPTION
## What Problem This Solves

Slack App Home, Agent View, and Assistant thread events could disappear silently when Slack temporarily rejected Home rendering, suggested prompts, conversation lookup, or thread metadata. The plugin caught the provider error and returned success to the existing durable ingress owner; consequently the event was acknowledged but never retried. Thread lookup could additionally cache temporary uncertainty as a lasting answer.

A real HTTP 429 with a missing or invalid `Retry-After` header was especially subtle: the installed Slack SDK and `p-retry` discard every typed status/code/cause field and expose a plain `Error`. Genuine documented `fatal_error` and `request_timeout` failures were also incorrectly terminal. Permanent authorization/configuration failures must remain terminal and report their actual redacted provider reason.

## Why This Change Was Made

Keep provider-specific classification in the Slack plugin owner and return only genuine transient failures to the **existing** durable ingress retry owner. A single shared Slack classifier recognizes documented finite platform errors (`fatal_error`, `internal_error`, `request_timeout`, `ratelimited`, and `service_unavailable`), existing typed transient HTTP/transport failures, and the exact installed-SDK plain-`Error` signature for a genuine malformed/missing-`Retry-After` 429. Ordinary plain errors and incomplete matching prefixes remain terminal. The plugin no longer duplicates provider classification in thread resolution or stores transient uncertainty in its thread cache.

`request_timeout` can mean a missing/truncated POST body, but the installed Web API producer always builds a nonempty urlencoded request body; transport truncation of that actual generated request is retryable. `invalid_auth`, `invalid_form_data`, `missing_scope`, `invalid_arguments`, `org_login_required`, malformed URLs/responses, TLS failures, and cancellation/abort remain terminal.

This is an owner-boundary refactor, not a new queue system: **no SQLite schema, migration, persisted contract, durable-queue policy, configuration, or plugin SDK surface changes**. Production delta is **+36 net lines** (`+146/-110`) because five production owners are consolidated behind one finite Slack-owned classifier while duplicate thread-resolution classification is removed; the remaining additions are focused real-SDK/durable-owner regression coverage. Generic ingress handling of provider `Retry-After` hints longer than one second is unchanged and remains a separate cross-channel owner follow-up.

## User Impact

Temporary Slack failures now replay and complete Home, Agent View, and Assistant work without asking users to reopen or recreate the conversation. External events receive one acknowledgment; persisted attempts release for retry, preserve the original failure reason, replay successfully, become completed tombstones, and unblock subsequent work in the same lane. Agent View progress markers survive restart, workspace/account isolation remains intact, and temporary thread lookup ambiguity cannot poison the cache. Permanent failures stay terminal and surface their redacted Slack error exactly once.

## Evidence

### Exact immutable reviewed candidate

- Existing PR: #119395; exact head `93d706659fe954c9b7e30ba7de8ebbd5b6ba0e5b`.
- Tree `841193285ba3130128110301a41b23005179026d`; immutable original base `73535e4ede7eaa51cd4f97f4087657b05814e3d4`.
- Full nine-path binary patch SHA-256 `7e3fc27e63b6cbc545cf95a2d13c3cff6a97323ff1b03cf8b3e54d9109dd5b86`; patch applies cleanly to independently checked current main `392e1c0620b53b29cf98d216ce1081b9f3df4cc3`.

### Authentic RED before the owner fix

- **12 real missing/invalid `Retry-After` HTTP-429 failures**: Home `views.publish`, Agent View prompts, Assistant suggested prompts, `conversations.replies`, `chat.update`, and history/cache resolution, each with both missing and invalid headers.
- **7 real documented `fatal_error` failures** across the affected owner surfaces.
- **7 real documented `request_timeout` failures** across the affected owner surfaces.
- Execution used the actual installed Slack Bolt **5.0.0**, Slack Web API **8.0.0**, and `p-retry` **4.6.2**, guarded synthetic HTTPS responses, and actual isolated SQLite durable ingress. This is an inspectable real-dependency/real-SQLite harness: **no live Slack tenant, no actual running Gateway, no external network assertion, and no live-provider claim**.

Installed SDK output for actual guarded HTTP 429 responses:

```json
{"fixture":"missing","constructor":"Error","name":"Error","ownKeys":["message"],"code":null,"statusCode":null,"cause":null,"originalError":null,"isSlackError":false,"isRetryAbortError":false,"message":"Retry header did not contain a valid timeout (url: https://slack-proof.invalid/api/assistant.threads.setSuggestedPrompts, retry-after header: null)"}
{"fixture":"invalid","constructor":"Error","name":"Error","ownKeys":["message"],"code":null,"statusCode":null,"cause":null,"originalError":null,"isSlackError":false,"isRetryAbortError":false,"message":"Retry header did not contain a valid timeout (url: https://slack-proof.invalid/api/assistant.threads.setSuggestedPrompts, retry-after header: not-a-timeout)"}
```

Durable-owner assertions at `extensions/slack/src/monitor/events/home.test.ts:474` and `extensions/slack/src/monitor/events/assistant.ingress.test.ts:295` observe `attempts: 1` plus the original failure text in real SQLite; replay reaches `kind: "completed"` at `extensions/slack/src/monitor/events/home.test.ts:490` and `extensions/slack/src/monitor/events/assistant.ingress.test.ts:310`. Companion assertions verify one external ACK, released retry ownership, next-lane progress, restart durability, account/workspace isolation, and no poisoned resolver cache.

### Exact-head final GREEN

```text
 Test Files  5 passed (5)
      Tests  152 passed (152)
   Duration  66.66s (transform 10.72s, setup 254ms, import 10.86s, tests 55.00s, environment 0ms)

[test] passed 1 Vitest shard in 83.75s
```

```text
node scripts/run-vitest.mjs   extensions/slack/src/monitor/events/home.test.ts   extensions/slack/src/monitor/events/assistant.ingress.test.ts   extensions/slack/src/monitor/events/assistant.test.ts   extensions/slack/src/monitor/monitor.thread-resolution.test.ts   extensions/slack/src/monitor/suggested-prompts.test.ts
```

Configured **type-aware oxlint over all nine changed paths** exits `0`; all-nine formatting and committed whitespace checks pass. Earlier hosted run `30966069008`, job `92180284544`, failed on the old public head `0ec58d43fbedfa9d37ca55506078551063b1f67a` with three `TS18048` complaints about a possibly undefined synthetic response-plan step. The exact final head adds the fail-closed `!step ||` guard before property access at `extensions/slack/src/monitor/events/assistant.ingress.test.ts:72`. **Exact-head hosted strict `check-test-types` and required CI remain pending until their newly dispatched runs complete; type-aware lint is not represented as that hosted gate.**

### Independent review and dependency contract

Four fresh signed hostile exact-head/full-surface reviews found zero P0–P3 issues:

- `/root/fresh_media_pipeline/fresh_429_sdk_contract_20260804_m13`
- `/root/fresh_media_pipeline/fresh_429_durable_replay_20260804_n14`
- `/root/fresh_media_pipeline/fresh_429_security_taxonomy_20260804_o15`
- `/root/fresh_media_pipeline/fresh_429_proof_types_20260804_p16`

One genuine official `gpt-5.6-sol` high-reasoning, P3, no-web full-branch review reported `findings: []`, `patch is correct`, confidence **0.88**; review JSON SHA-256 `57649d110887f9863190d7ba91a24f0e6bff5003c3934e6bdeeecea8c4607b15`. Real checksum-pinned TruffleHog completed cleanly (binary SHA-256 `09c30c73bf4a265942c4a3e1a889833464c01db18fb4e53002220baa3367eb5d`).

Dependency source was directly inspected: installed `@slack/web-api/dist/WebClient.js` request-body construction, platform-error creation, HTTP-429 malformed-header abort, and `Retry-After` parsing; installed `@slack/web-api/dist/errors.d.ts` platform-error contract; installed `p-retry/index.js` abort unwrapping. Official references: [Slack API rate limits](https://docs.slack.dev/apis/web-api/rate-limits/), [views.publish](https://docs.slack.dev/reference/methods/views.publish/), [assistant.threads.setSuggestedPrompts](https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts/), [chat.update](https://docs.slack.dev/reference/methods/chat.update/), [conversations.history](https://docs.slack.dev/reference/methods/conversations.history/), and [conversations.replies](https://docs.slack.dev/reference/methods/conversations.replies/).

### Response to the prior ClawSweeper rank-up moves

1. **Attach exact-head runtime output showing one ACK, retry, and terminal completion:** addressed above with actual exact-head real Bolt/Web API/p-retry/SQLite runtime output, source-linked persisted-attempt/completion assertions, explicit SDK wire shape, authentic RED failures, and final **152/152** GREEN. This is stronger harness evidence, not a claim of a live Slack workspace or actual running Gateway.
2. **Resolve and rerun the exact-head typecheck gate:** the concrete old-head `TS18048` cause is repaired with an exhausted-plan guard, and exact-nine type-aware lint passes; the full exact-head hosted strict gate is **pending** and must pass before landing.
3. Human maintainer final judgment and required exact-head hosted CI remain owner-controlled; neither is silently represented as already complete.
