### PR TITLE
fix(qa): stop zombie-only gateway process groups

### DIFF
--- a/extensions/qa-lab/src/gateway-child.test.ts
+++ b/extensions/qa-lab/src/gateway-child.test.ts
@@ -1375,26 +1375,131 @@ describe("buildQaRuntimeEnv", () => {
         testing.stopQaGatewayChildProcessTree(child as never, {
           gracefulTimeoutMs: 1,
           forceTimeoutMs: 1,
+          inspectLinuxProcessGroup: () => null,
         }),
-      ).rejects.toThrow("qa gateway process tree remained alive after forced shutdown");
+      ).rejects.toThrow(
+        process.platform === "linux"
+          ? "qa gateway process tree remained alive after forced shutdown: pgid=12345 members=unknown (/proc unavailable) childExitRecorded=false"
+          : "qa gateway process tree remained alive after forced shutdown: pid=12345 childExitRecorded=false",
+      );
     },
   );
 
-  it("treats Linux process groups with only dead members as stopped", () => {
-    const stats = [
+  it("reports Linux process-tree diagnostics when forced shutdown times out", async () => {
+    const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    const child = Object.assign(new EventEmitter(), {
+      pid: 12345,
+      exitCode: null as number | null,
+      signalCode: null as string | null,
+      kill: vi.fn(() => true),
+    });
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+    try {
+      await expect(
+        testing.stopQaGatewayChildProcessTree(child as never, {
+          gracefulTimeoutMs: 1,
+          forceTimeoutMs: 1,
+          inspectLinuxProcessGroup: () => ({
+            alive: true,
+            diagnostics:
+              'pgid=12345 members=[pid=12345 state=Z command="gateway", pid=12346 state=S command="worker"]',
+          }),
+        }),
+      ).rejects.toThrow(
+        'qa gateway process tree remained alive after forced shutdown: pgid=12345 members=[pid=12345 state=Z command="gateway", pid=12346 state=S command="worker"] childExitRecorded=false',
+      );
+    } finally {
+      if (platformDescriptor) {
+        Object.defineProperty(process, "platform", platformDescriptor);
+      }
+    }
+  });
+
+  it("classifies Linux zombie-only process groups as stopped", () => {
+    const inspection = testing.inspectLinuxProcessGroupStats(123, [
       "123 (gateway child) Z 1 123 123 0 -1 0",
       "124 (helper (worker)) X 1 123 123 0 -1 0",
       "125 (unrelated) S 1 999 999 0 -1 0",
-    ];
+    ]);
 
-    expect(testing.classifyLinuxProcessGroupStats(123, stats)).toBe(false);
+    expect(inspection).toEqual({
+      alive: false,
+      diagnostics:
+        'pgid=123 members=[pid=123 state=Z command="gateway child", pid=124 state=X command="helper (worker)"]',
+    });
+  });
+
+  it("classifies Linux process groups with a runnable descendant as alive", () => {
+    const inspection = testing.inspectLinuxProcessGroupStats(123, [
+      "123 (gateway child) Z 1 123 123 0 -1 0",
+      "126 (live helper) D 1 123 123 0 -1 0",
+    ]);
+
+    expect(inspection).toEqual({
+      alive: true,
+      diagnostics:
+        'pgid=123 members=[pid=123 state=Z command="gateway child", pid=126 state=D command="live helper"]',
+    });
+  });
+
+  it("classifies an empty Linux process-group snapshot as unknown", () => {
     expect(
-      testing.classifyLinuxProcessGroupStats(123, [
-        ...stats,
-        "126 (live helper) D 1 123 123 0 -1 0",
-      ]),
-    ).toBe(true);
-    expect(testing.classifyLinuxProcessGroupStats(456, stats)).toBeNull();
+      testing.inspectLinuxProcessGroupStats(123, ["125 (unrelated) S 1 999 999 0 -1 0"]),
+    ).toEqual({
+      alive: null,
+      diagnostics: "pgid=123 members=[]",
+    });
+  });
+
+  it("bounds Linux process-group diagnostics", () => {
+    const stats = Array.from(
+      { length: 300 },
+      (_, index) => `${index + 1} (${`worker-${index}`.padEnd(32, "x")}) S 1 123 123 0 -1 0`,
+    );
+
+    const inspection = testing.inspectLinuxProcessGroupStats(123, stats);
+
+    expect(inspection.alive).toBe(true);
+    expect(inspection.diagnostics.length).toBeLessThanOrEqual(2_048);
+    expect(inspection.diagnostics).toMatch(/\.\.\.$/u);
+  });
+
+  it("trusts Linux runnable-member inspection before child exit metadata settles", () => {
+    const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    const processKill = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const child = {
+      pid: 12345,
+      exitCode: null,
+      signalCode: null,
+    };
+    try {
+      expect(
+        testing.isQaGatewayChildProcessTreeAlive(child as never, () => ({
+          alive: false,
+          diagnostics: 'pgid=12345 members=[pid=12345 state=Z command="gateway"]',
+        })),
+      ).toBe(false);
+      expect(
+        testing.isQaGatewayChildProcessTreeAlive(child as never, () => ({
+          alive: true,
+          diagnostics: 'pgid=12345 members=[pid=12346 state=S command="worker"]',
+        })),
+      ).toBe(true);
+      expect(
+        testing.isQaGatewayChildProcessTreeAlive(child as never, () => ({
+          alive: null,
+          diagnostics: "pgid=12345 members=[]",
+        })),
+      ).toBe(true);
+      expect(testing.isQaGatewayChildProcessTreeAlive(child as never, () => null)).toBe(true);
+      expect(processKill).toHaveBeenCalledWith(-12345, 0);
+    } finally {
+      if (platformDescriptor) {
+        Object.defineProperty(process, "platform", platformDescriptor);
+      }
+    }
   });
 
   it("force-kills Windows gateway process trees when graceful taskkill fails", () => {
@@ -1479,6 +1584,10 @@ describe("buildQaRuntimeEnv", () => {
       {
         gracefulTimeoutMs: 1,
         forceTimeoutMs: 50,
+        inspectLinuxProcessGroup: () => ({
+          alive: !sawForceKill || postKillLivenessChecks < 2,
+          diagnostics: 'pgid=12346 members=[pid=12347 state=S command="worker"]',
+        }),
       },
     );
 

--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -88,6 +88,7 @@ const QA_GATEWAY_CHILD_GRACEFUL_SHUTDOWN_TIMEOUT_MS = 30_000;
 // Loaded Docker runners can take several seconds to reap a force-killed process group.
 const QA_GATEWAY_CHILD_FORCE_SHUTDOWN_TIMEOUT_MS = 10_000;
 const QA_GATEWAY_LOG_CLOSE_TIMEOUT_MS = 5_000;
+const QA_GATEWAY_PROCESS_TREE_DIAGNOSTIC_MAX_CHARS = 2_048;
 const QA_MOCK_OPENAI_API_KEY = ["qa", "mock", "openai", "key"].join("-");
 const QA_GATEWAY_CHILD_BLOCKED_SECRET_ENV_VARS = Object.freeze([
   "OPENCLAW_QA_CONVEX_SECRET_CI",
@@ -692,7 +693,8 @@ export const testing = {
   signalQaGatewayChildProcessTree,
   resolveQaGatewayChildStopTimeouts,
   stopQaGatewayChildProcessTree,
-  classifyLinuxProcessGroupStats,
+  inspectLinuxProcessGroupStats,
+  isQaGatewayChildProcessTreeAlive,
   closeWriteStream,
 };
 
@@ -705,36 +707,73 @@ function isProcessAlreadyExitedError(error: unknown): boolean {
 }
 
 function parseLinuxProcessStat(raw: string) {
+  const commandStart = raw.indexOf("(");
   const commandEnd = raw.lastIndexOf(")");
-  if (commandEnd < 0) {
+  if (commandStart <= 0 || commandEnd <= commandStart) {
     return null;
   }
+  const pid = Number.parseInt(raw.slice(0, commandStart).trim(), 10);
   const fields = raw
     .slice(commandEnd + 1)
     .trim()
     .split(/\s+/u);
   const state = fields[0];
   const processGroupId = Number.parseInt(fields[2] ?? "", 10);
-  if (!state || !Number.isSafeInteger(processGroupId) || processGroupId <= 0) {
+  if (
+    !Number.isSafeInteger(pid) ||
+    pid <= 0 ||
+    !state ||
+    !Number.isSafeInteger(processGroupId) ||
+    processGroupId <= 0
+  ) {
     return null;
   }
-  return { processGroupId, state };
+  return {
+    command: raw.slice(commandStart + 1, commandEnd),
+    pid,
+    processGroupId,
+    state,
+  };
 }
 
-function classifyLinuxProcessGroupStats(processGroupId: number, stats: readonly string[]) {
+function boundQaGatewayProcessTreeDiagnostics(details: string) {
+  if (details.length <= QA_GATEWAY_PROCESS_TREE_DIAGNOSTIC_MAX_CHARS) {
+    return details;
+  }
+  return `${sliceUtf16Safe(details, 0, QA_GATEWAY_PROCESS_TREE_DIAGNOSTIC_MAX_CHARS - 3)}...`;
+}
+
+function inspectLinuxProcessGroupStats(processGroupId: number, stats: readonly string[]) {
   const members = stats
     .map((raw) => parseLinuxProcessStat(raw))
     .filter(
       (entry): entry is NonNullable<ReturnType<typeof parseLinuxProcessStat>> =>
         entry?.processGroupId === processGroupId,
-    );
-  if (members.length === 0) {
-    return null;
-  }
-  return members.some((entry) => entry.state !== "Z" && entry.state !== "X");
+    )
+    .toSorted((left, right) => left.pid - right.pid);
+  const diagnostics = members
+    .map(
+      (member) =>
+        `pid=${member.pid} state=${member.state} command=${JSON.stringify(member.command)}`,
+    )
+    .join(", ");
+  return {
+    alive:
+      members.length === 0
+        ? null
+        : members.some((entry) => entry.state !== "Z" && entry.state !== "X"),
+    diagnostics: boundQaGatewayProcessTreeDiagnostics(
+      `pgid=${processGroupId} members=[${diagnostics}]`,
+    ),
+  };
 }
 
-function inspectLinuxProcessGroupLiveness(processGroupId: number) {
+type QaLinuxProcessGroupInspection = ReturnType<typeof inspectLinuxProcessGroupStats>;
+type QaLinuxProcessGroupInspector = (
+  processGroupId: number,
+) => QaLinuxProcessGroupInspection | null;
+
+function inspectLinuxProcessGroup(processGroupId: number): QaLinuxProcessGroupInspection | null {
   if (process.platform !== "linux") {
     return null;
   }
@@ -751,14 +790,20 @@ function inspectLinuxProcessGroupLiveness(processGroupId: number) {
     }
     try {
       stats.push(readFileSync(path.join("/proc", entry.name, "stat"), "utf8"));
-    } catch {
+    } catch (error) {
       // Processes can exit while /proc is being scanned.
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        return null;
+      }
     }
   }
-  return classifyLinuxProcessGroupStats(processGroupId, stats);
+  return inspectLinuxProcessGroupStats(processGroupId, stats);
 }
 
-function isQaGatewayChildProcessTreeAlive(child: ChildProcess) {
+function isQaGatewayChildProcessTreeAlive(
+  child: ChildProcess,
+  inspectLinuxProcessGroupFn: QaLinuxProcessGroupInspector = inspectLinuxProcessGroup,
+) {
   if (!child.pid) {
     return false;
   }
@@ -767,12 +812,12 @@ function isQaGatewayChildProcessTreeAlive(child: ChildProcess) {
   }
   try {
     process.kill(-child.pid, 0);
-    if (!hasChildExited(child)) {
-      return true;
+    if (process.platform === "linux") {
+      // Linux can retain zombie-only process groups after SIGKILL while Node's
+      // child metadata is still unsettled. Runnable /proc members are the owner.
+      return inspectLinuxProcessGroupFn(child.pid)?.alive ?? true;
     }
-    // Container PID 1 can leave killed descendants as zombies. They cannot
-    // retain ports or execute work, so do not make release QA wait forever.
-    return inspectLinuxProcessGroupLiveness(child.pid) ?? true;
+    return true;
   } catch (error) {
     if (!isProcessAlreadyExitedError(error) && !hasChildExited(child)) {
       return true;
@@ -838,43 +883,78 @@ function signalQaGatewayChildProcessTree(
   }
 }
 
-async function waitForQaGatewayChildExit(child: ChildProcess, timeoutMs: number) {
+async function waitForQaGatewayChildExit(
+  child: ChildProcess,
+  timeoutMs: number,
+  inspectLinuxProcessGroupFn: QaLinuxProcessGroupInspector,
+) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() <= deadline) {
-    if (!isQaGatewayChildProcessTreeAlive(child)) {
+    if (!isQaGatewayChildProcessTreeAlive(child, inspectLinuxProcessGroupFn)) {
       return true;
     }
     await sleep(Math.min(25, Math.max(0, deadline - Date.now())));
   }
-  return !isQaGatewayChildProcessTreeAlive(child);
+  return !isQaGatewayChildProcessTreeAlive(child, inspectLinuxProcessGroupFn);
 }
 
-function resolveQaGatewayChildStopTimeouts(opts?: {
+type QaGatewayChildStopOptions = {
   gracefulTimeoutMs?: number;
   forceTimeoutMs?: number;
-}) {
+  inspectLinuxProcessGroup?: QaLinuxProcessGroupInspector;
+};
+
+function resolveQaGatewayChildStopTimeouts(opts?: QaGatewayChildStopOptions) {
   return {
     gracefulTimeoutMs: opts?.gracefulTimeoutMs ?? QA_GATEWAY_CHILD_GRACEFUL_SHUTDOWN_TIMEOUT_MS,
     forceTimeoutMs: opts?.forceTimeoutMs ?? QA_GATEWAY_CHILD_FORCE_SHUTDOWN_TIMEOUT_MS,
   };
 }
 
+function formatQaGatewayProcessTreeDiagnostics(
+  child: ChildProcess,
+  inspectLinuxProcessGroupFn: QaLinuxProcessGroupInspector,
+) {
+  const childExitRecorded = hasChildExited(child);
+  if (process.platform !== "linux" || !child.pid) {
+    return `pid=${child.pid ?? "unknown"} childExitRecorded=${childExitRecorded}`;
+  }
+  const inspection = inspectLinuxProcessGroupFn(child.pid);
+  const processGroupDetails =
+    inspection?.diagnostics ?? `pgid=${child.pid} members=unknown (/proc unavailable)`;
+  return boundQaGatewayProcessTreeDiagnostics(
+    `${processGroupDetails} childExitRecorded=${childExitRecorded}`,
+  );
+}
+
 async function stopQaGatewayChildProcessTree(
   child: ChildProcess,
-  opts?: { gracefulTimeoutMs?: number; forceTimeoutMs?: number },
+  opts?: QaGatewayChildStopOptions,
 ) {
-  if (!isQaGatewayChildProcessTreeAlive(child)) {
+  const inspectLinuxProcessGroupFn = opts?.inspectLinuxProcessGroup ?? inspectLinuxProcessGroup;
+  if (!isQaGatewayChildProcessTreeAlive(child, inspectLinuxProcessGroupFn)) {
     return;
   }
   const timeouts = resolveQaGatewayChildStopTimeouts(opts);
   signalQaGatewayChildProcessTree(child, "SIGTERM");
-  if (await waitForQaGatewayChildExit(child, timeouts.gracefulTimeoutMs)) {
+  if (
+    await waitForQaGatewayChildExit(child, timeouts.gracefulTimeoutMs, inspectLinuxProcessGroupFn)
+  ) {
     return;
   }
   signalQaGatewayChildProcessTree(child, "SIGKILL");
-  const stopped = await waitForQaGatewayChildExit(child, timeouts.forceTimeoutMs);
+  const stopped = await waitForQaGatewayChildExit(
+    child,
+    timeouts.forceTimeoutMs,
+    inspectLinuxProcessGroupFn,
+  );
   if (!stopped) {
-    throw new Error("qa gateway process tree remained alive after forced shutdown");
+    throw new Error(
+      `qa gateway process tree remained alive after forced shutdown: ${formatQaGatewayProcessTreeDiagnostics(
+        child,
+        inspectLinuxProcessGroupFn,
+      )}`,
+    );
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where successful Docker live/E2E lanes could be reported as failed after cleanup when Linux retained only zombie members in the Gateway process group.

## Why This Change Was Made

The QA Lab Gateway child teardown treated unsettled Node child-exit metadata as authoritative before checking Linux process-group members. The process owner now classifies `/proc` members directly: runnable members remain alive, while zombie/exited-only groups are stopped. If `/proc` cannot be inspected, cleanup still fails closed.

Forced-shutdown errors now include process-group membership and child-exit state, capped at 2 KiB. This does not change convergence restart behavior, provider execution, or other live-test failures.

Architectural owner: `extensions/qa-lab/src/gateway-child.ts`.

Canonical invariant: on Linux, runnable process-group membership owns teardown liveness; zombie-only groups cannot retain ports or execute work.

Removed path: the child-exit metadata short-circuit and boolean-only Linux group classifier.

Production LOC: +109/-29. Test LOC: +120/-11. The production growth makes the owner boundary explicit and adds bounded diagnostics for real cleanup failures.

## User Impact

Maintainers no longer get false-red live/E2E results after every scenario has passed and the remaining process-group entries are non-runnable zombies. Genuine runnable descendants still fail cleanup with actionable diagnostics.

## Evidence

- `node scripts/run-vitest.mjs extensions/qa-lab/src/gateway-child.test.ts` (94 passed)
- `oxfmt --check extensions/qa-lab/src/gateway-child.ts extensions/qa-lab/src/gateway-child.test.ts`
- `git diff --check origin/main...HEAD`
- Structured autoreview: no accepted/actionable findings; patch correct, confidence 0.99
- ClawSweeper P2 addressed: an empty `/proc` match remains unknown and fail-closed, with classifier and liveness regressions
- Prior reviewed-head Linux proof: https://github.com/openclaw/openclaw/actions/runs/30966031549 (success)
- Current exact-head Linux proof: https://github.com/openclaw/openclaw/actions/runs/30967236922 (success)
- Original false-red run: https://github.com/openclaw/openclaw/actions/runs/30880690275

Two Linux changed-gate Testbox attempts hung with zero output before any repository check and ended only when their exact owned runs were stopped. Testbox reported `blocked_stage=unknown` and `blacksmith testbox run exited -1`; the lease was stopped. This is a transport-stage failure, not a code/test failure, so the repository-hosted Linux checks on this exact head are the authoritative platform validation.

AI-assisted: yes. The change was independently reviewed and the implementation and tests were verified before publication.

Punchcard-Session: amber-orchard-valley-s4
