### PR TITLE
fix(ui): chat rail pill status overlaps the headline text

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1800,7 +1800,9 @@ openclaw-chat-session-rail {
 .chat-session-rail__status {
   --rail-health-color: var(--muted);
   gap: 5px;
-  min-width: 0;
+  /* Never shrink: the chip has no overflow clipping, so a squeezed box paints
+     its label over the pill headline next to it. */
+  flex: 0 0 auto;
   color: var(--rail-health-color);
   font-size: 11px;
   font-weight: 650;
@@ -1866,6 +1868,9 @@ openclaw-chat-session-rail {
 }
 
 .chat-session-rail__headline {
+  /* Block, not inline: ellipsis needs a block box inside the pill's expand
+     button, or the text hard-clips at the button edge. */
+  display: block;
   min-width: 0;
   overflow: hidden;
   color: var(--text);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the chat session rail's collapsed pill ("Done" / run-status capsule shown under the Chat | Dashboard header) would render its status label on top of the headline text whenever the observer digest headline was long, producing illegible overlaid text like "DoI'll check whether this active session suppor". The headline also hard-clipped at the pill edge instead of showing an ellipsis.

## Why This Change Was Made

The pill row is a flex container holding the status chip, the headline expand button, and two fixed-width icon buttons. The status chip carried `min-width: 0` with no shrink protection and no overflow clipping, so a long headline squeezed the chip's box below its content width and the label glyphs painted outside the box, straight over the neighboring headline. Separately, `.chat-session-rail__headline` is an inline span inside the pill's expand button, so its `overflow: hidden; text-overflow: ellipsis` had no effect there (ellipsis needs a block box); the visible cut came from the parent button clipping.

The fix makes the chip layout-stable instead of patching the symptom: the chip opts out of flex shrinking entirely (`flex: 0 0 auto` — it only ever holds a short status word and has no overflow handling, so shrinking is never valid), and the headline becomes `display: block` so it truncates with a proper ellipsis in the remaining space. In the expanded card the chip sits in its own grid row and the headline is already blockified, so both surfaces keep their current rendering.

## User Impact

The collapsed session rail pill is readable again: the green "Done" (or any run-health) chip keeps its width, and long headlines truncate with "…" instead of colliding with the status label or hard-clipping. No behavior change for the expanded card, mobile layout, or restore icon.

## Evidence

- Real-behavior proof: rendered the real `<openclaw-chat-session-rail>` element via the `ui/` Vite dev server and measured the pill geometry with Playwright — before (main CSS) the status label paints 21px outside its shrunken chip box and intersects the headline by 12px with the ellipsis inactive; after (this PR) the chip keeps its box, the label paints 0px outside, and the headline ellipsis is active. Full inspectable geometry output and repro recipe: https://github.com/openclaw/openclaw/pull/119397#issuecomment-5186803982
- Reproduced the exact overlap from the report in a static harness that renders the pill DOM from `chat-session-rail.ts` against the repo stylesheets (`base.css`, `components.css`, `chat/sidebar.css`) at desktop width; before/after screenshots were captured (sanitized, synthetic harness text only). Attaching them is currently blocked: the Crabbox artifact coordinator returns 401 (broker auth outage) and no authenticated web session is available for GitHub's attachment upload, so the images will be added in a follow-up comment once artifact publishing recovers. The harness is reproducible from the PR description: pill DOM from `chat-session-rail.ts` + repo stylesheets, 1100px viewport, light theme.
- Autoreview (Codex `gpt-5.6-sol`, high reasoning): clean, no accepted/actionable findings — "patch is correct (0.99)".
- Local checks (Crabbox/Testbox broker auth was unavailable, so trusted-source proof ran locally per repo policy): `pnpm format:check -- ui/src/styles/components.css` clean, `pnpm lint:ui:styles` (stylelint) clean, `git diff --check` clean. The remaining planned lanes (tsgo typecheck, core lint/tests) cannot be affected by a CSS-only diff; PR CI runs them hosted.
