### PR TITLE
fix(media): forward caller abort signal to retry backoff sleep

### DIFF
--- a/src/media/content-disposition.ts
+++ b/src/media/content-disposition.ts
@@ -1,0 +1,132 @@
+// Content-Disposition and remote filename parsing helpers extracted from
+// fetch.ts to keep the media fetch module within the max-lines budget.
+import { basenameFromAnyPath } from "@openclaw/media-core/file-name";
+
+function stripQuotes(value: string): string {
+  return value.replace(/^["']|["']$/g, "");
+}
+
+function decodeRemoteFileNameComponent(value: string): string {
+  try {
+    return decodeURIComponent(value).replace(/[\\/]/g, "_");
+  } catch {
+    return value;
+  }
+}
+
+function decodeExtendedRemoteFileName(value: string): string | undefined {
+  const match = /^([^']*)'[^']*'(.*)$/u.exec(value);
+  if (!match) {
+    return undefined;
+  }
+  const charset = match[1]?.toLowerCase();
+  const encoded = match[2] ?? "";
+  try {
+    if (charset === "utf-8") {
+      return decodeURIComponent(encoded).replace(/[\\/]/g, "_");
+    }
+    if (charset === "iso-8859-1") {
+      if (/%(?![\da-f]{2})/iu.test(encoded)) {
+        return undefined;
+      }
+      return encoded
+        .replace(/%([\da-f]{2})/giu, (_match, hex: string) =>
+          String.fromCharCode(Number.parseInt(hex, 16)),
+        )
+        .replace(/[\\/]/g, "_");
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+function* parseContentDispositionParameters(header: string): Generator<{
+  name: string;
+  value: string;
+}> {
+  let start = 0;
+  let quoted = false;
+  let escaped = false;
+  for (let index = 0; index <= header.length; index += 1) {
+    const character = header[index];
+    if (escaped || (quoted && character === "\\")) {
+      escaped = !escaped;
+      continue;
+    }
+    if (character === '"') {
+      quoted = !quoted;
+      continue;
+    }
+    if (index !== header.length && (quoted || character !== ";")) {
+      continue;
+    }
+    const parameter = header.slice(start, index).trim();
+    start = index + 1;
+    const separator = parameter.indexOf("=");
+    if (separator > 0) {
+      yield {
+        name: parameter.slice(0, separator).trim().toLowerCase(),
+        value: stripQuotes(parameter.slice(separator + 1).trim()),
+      };
+    }
+  }
+}
+
+function decodeQuotedRemoteFileName(value: string): string {
+  const windowsDrivePath = /^[a-z]:[\\/]/iu.test(value);
+  const windowsNetworkPath = value.startsWith("\\\\");
+  const mixedWindowsPath = value.includes("/") && value.includes("\\");
+  const relativeWindowsPath =
+    /\\[\p{L}\p{N}]/u.test(value) && /^[^\\/:]+(?:\\[^\\]+)+$/u.test(value);
+  if (!windowsDrivePath && !windowsNetworkPath && !mixedWindowsPath && !relativeWindowsPath) {
+    return value.replace(/\\(.)/gu, "$1");
+  }
+  const lastForwardSeparator = value.lastIndexOf("/");
+  if (lastForwardSeparator >= 0) {
+    const prefix = value.slice(0, lastForwardSeparator + 1);
+    const fileName = value.slice(lastForwardSeparator + 1).replace(/\\([^\p{L}\p{N}])/gu, "$1");
+    return `${prefix}${fileName}`;
+  }
+  const firstBackslash = value.indexOf("\\");
+  if (
+    !windowsDrivePath &&
+    !windowsNetworkPath &&
+    firstBackslash === value.lastIndexOf("\\") &&
+    /\\[^\p{L}\p{N}]/u.test(value)
+  ) {
+    return value.replace(/\\(.)/gu, "$1");
+  }
+  // Backslash-only legacy paths need every separator, including before Unicode or spaces.
+  return value.replace(/\\"/gu, '"');
+}
+
+export function parseContentDispositionFileName(header?: string | null): string | undefined {
+  if (!header) {
+    return undefined;
+  }
+  let fallbackFileName: string | undefined;
+  for (const parameter of parseContentDispositionParameters(header)) {
+    if (parameter.name === "filename") {
+      fallbackFileName ??=
+        basenameFromAnyPath(decodeQuotedRemoteFileName(parameter.value)) || undefined;
+      continue;
+    }
+    if (parameter.name !== "filename*") {
+      continue;
+    }
+    const decoded = decodeExtendedRemoteFileName(parameter.value);
+    if (decoded) {
+      return basenameFromAnyPath(decoded) || undefined;
+    }
+  }
+  return fallbackFileName;
+}
+
+export function basenameFromUrlPathname(pathname: string): string {
+  const base = basenameFromAnyPath(pathname);
+  if (!base) {
+    return "";
+  }
+  return decodeRemoteFileNameComponent(base);
+}

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -1,5 +1,6 @@
 // Media fetch tests cover remote media download limits and validation.
 import fs from "node:fs/promises";
+import { createServer } from "node:http";
 import path from "node:path";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -745,6 +746,61 @@ describe("readRemoteMediaBuffer", () => {
       }),
     ).rejects.toMatchObject({ code: "fetch_failed" });
     expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    {
+      name: "buffer reads",
+      fetchMedia: (options: Parameters<ReadRemoteMediaBuffer>[0]) => readRemoteMediaBuffer(options),
+    },
+    {
+      name: "store writes",
+      fetchMedia: (options: Parameters<ReadRemoteMediaBuffer>[0]) => saveRemoteMedia(options),
+    },
+  ])("cancels retry backoff for $name", async ({ fetchMedia }) => {
+    let requests = 0;
+    const server = createServer((_request, response) => {
+      requests += 1;
+      response.writeHead(503).end("busy");
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("expected a local media test server address");
+      }
+      const controller = new AbortController();
+      const operation = fetchMedia({
+        url: `http://127.0.0.1:${address.port}/retry.bin`,
+        requestInit: { signal: controller.signal },
+        retry: {
+          attempts: 2,
+          minDelayMs: 25,
+          maxDelayMs: 25,
+          jitter: 0,
+          onRetry: () => {
+            setImmediate(() => controller.abort());
+          },
+        },
+      });
+
+      await expect(operation).rejects.toMatchObject({
+        name: "MediaFetchError",
+        code: "fetch_failed",
+        cause: { name: "AbortError" },
+      });
+      expect(requests).toBe(1);
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(1);
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
   });
 
   it("does not retry SSRF guard blocks", async () => {

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -765,7 +765,11 @@ describe("readRemoteMediaBuffer", () => {
     });
     controller.abort();
 
-    await expect(promise).rejects.toThrow();
+    await expect(promise).rejects.toMatchObject({
+      name: "MediaFetchError",
+      code: "fetch_failed",
+      cause: { name: "AbortError" },
+    });
     // Without signal-aware sleep the backoff would block for 10s and retry;
     // with the fix the abort interrupts the sleep immediately.
     expect(fetchImpl).toHaveBeenCalledTimes(1);

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -745,6 +745,32 @@ describe("readRemoteMediaBuffer", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
+  it("aborts retry backoff when caller signal fires during sleep", async () => {
+    const transientError = Object.assign(new Error("socket hang up"), { code: "ECONNRESET" });
+    const fetchImpl = vi.fn().mockRejectedValueOnce(transientError);
+    const controller = new AbortController();
+
+    const promise = readRemoteMediaBuffer({
+      url: "https://example.com/file.bin",
+      fetchImpl,
+      lookupFn: makeLookupFn(),
+      maxBytes: 1024,
+      retry: { attempts: 3, minDelayMs: 10_000, maxDelayMs: 10_000, jitter: 0 },
+      requestInit: { signal: controller.signal },
+    });
+
+    // Let the first fetch attempt fail and enter the retry backoff sleep.
+    await new Promise<void>((resolve) => {
+      setTimeout(() => resolve(), 50);
+    });
+    controller.abort();
+
+    await expect(promise).rejects.toThrow();
+    // Without signal-aware sleep the backoff would block for 10s and retry;
+    // with the fix the abort interrupts the sleep immediately.
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
   it("does not retry SSRF guard blocks", async () => {
     const fetchImpl = vi.fn();
 

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -5,6 +5,7 @@ import { basenameFromAnyPath, extnameFromAnyPath } from "@openclaw/media-core/fi
 import { detectMime, extensionForMime } from "@openclaw/media-core/mime";
 import { expectDefined } from "@openclaw/normalization-core";
 import { isAbortError } from "../infra/abort-signal.js";
+import { sleepWithAbort } from "../infra/backoff.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import {
   readChunkWithIdleTimeout,
@@ -282,6 +283,14 @@ function redactMediaUrl(url: string): string {
   return redactSensitiveText(url);
 }
 
+function createMediaFetchFailure(sourceUrl: string, cause: unknown): MediaFetchError {
+  return new MediaFetchError(
+    "fetch_failed",
+    `Failed to fetch media from ${sourceUrl}: ${formatErrorMessage(cause)}`,
+    { cause },
+  );
+}
+
 async function fetchGuardedMediaResponse(
   options: FetchMediaOptions,
 ): Promise<GuardedMediaResponse> {
@@ -379,13 +388,7 @@ async function fetchGuardedMediaResponse(
     };
   } catch (err) {
     responseHeaderDeadline.cleanup();
-    throw new MediaFetchError(
-      "fetch_failed",
-      `Failed to fetch media from ${sourceUrl}: ${formatErrorMessage(err)}`,
-      {
-        cause: err,
-      },
-    );
+    throw createMediaFetchFailure(sourceUrl, err);
   }
 }
 
@@ -598,11 +601,7 @@ async function saveOkMediaResponse(params: {
         { cause: err },
       );
     }
-    throw new MediaFetchError(
-      "fetch_failed",
-      `Failed to fetch media from ${params.sourceUrl}: ${formatErrorMessage(err)}`,
-      { cause: err },
-    );
+    throw createMediaFetchFailure(params.sourceUrl, err);
   }
 }
 
@@ -633,12 +632,17 @@ async function withMediaFetchRetry<T>(
   if (!retry) {
     return await fn();
   }
-  const callerShouldRetry = retry.shouldRetry;
   return await retryAsync(fn, {
     label: "media:fetch",
     ...retry,
     shouldRetry: (err, attempt) =>
-      callerShouldRetry ? callerShouldRetry(err, attempt) : shouldRetryMediaFetch(err),
+      retry.shouldRetry ? retry.shouldRetry(err, attempt) : shouldRetryMediaFetch(err),
+    sleep:
+      retry.sleep ??
+      ((delay) =>
+        sleepWithAbort(delay, options.requestInit?.signal ?? undefined).catch((cause: unknown) => {
+          throw createMediaFetchFailure(redactMediaUrl(options.url), cause);
+        })),
   });
 }
 
@@ -738,11 +742,7 @@ async function readRemoteMediaBufferOnce(options: FetchMediaOptions): Promise<Fe
       if (err instanceof MediaFetchError) {
         throw err;
       }
-      throw new MediaFetchError(
-        "fetch_failed",
-        `Failed to fetch media from ${redactMediaUrl(res.url || options.url)}: ${formatErrorMessage(err)}`,
-        { cause: err },
-      );
+      throw createMediaFetchFailure(redactMediaUrl(res.url || options.url), err);
     }
     let fileName = resolveRemoteFileName({
       res,

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -5,6 +5,7 @@ import { basenameFromAnyPath, extnameFromAnyPath } from "@openclaw/media-core/fi
 import { detectMime, extensionForMime } from "@openclaw/media-core/mime";
 import { expectDefined } from "@openclaw/normalization-core";
 import { isAbortError } from "../infra/abort-signal.js";
+import { sleepWithAbort } from "../infra/backoff.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import {
   readChunkWithIdleTimeout,
@@ -637,12 +638,12 @@ async function withMediaFetchRetry<T>(
   if (!retry) {
     return await fn();
   }
-  const callerShouldRetry = retry.shouldRetry;
   return await retryAsync(fn, {
     label: "media:fetch",
     ...retry,
     shouldRetry: (err, attempt) =>
-      callerShouldRetry ? callerShouldRetry(err, attempt) : shouldRetryMediaFetch(err),
+      retry.shouldRetry ? retry.shouldRetry(err, attempt) : shouldRetryMediaFetch(err),
+    sleep: retry.sleep ?? ((ms) => sleepWithAbort(ms, options.requestInit?.signal ?? undefined)),
   });
 }
 

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -4,7 +4,7 @@ import { parseMediaContentLength } from "@openclaw/media-core/content-length";
 import { basenameFromAnyPath, extnameFromAnyPath } from "@openclaw/media-core/file-name";
 import { detectMime, extensionForMime } from "@openclaw/media-core/mime";
 import { expectDefined } from "@openclaw/normalization-core";
-import { isAbortError } from "../infra/abort-signal.js";
+import { createAbortError, isAbortError } from "../infra/abort-signal.js";
 import { sleepWithAbort } from "../infra/backoff.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import {
@@ -22,6 +22,7 @@ import { retryAsync, type RetryOptions } from "../infra/retry.js";
 import { isTransientNetworkError } from "../infra/retryable-network-errors.js";
 import { redactSensitiveText } from "../logging/redact.js";
 import { buildTimeoutAbortSignal } from "../utils/fetch-timeout.js";
+import { basenameFromUrlPathname, parseContentDispositionFileName } from "./content-disposition.js";
 import { saveMediaBuffer, saveMediaStream, type SavedMedia } from "./store.js";
 
 /** Default remote media fetch cap shared by buffer reads and store writes. */
@@ -129,135 +130,6 @@ type GuardedMediaResponse = {
   release: (() => Promise<void>) | null;
   sourceUrl: string;
 };
-
-function stripQuotes(value: string): string {
-  return value.replace(/^["']|["']$/g, "");
-}
-
-function decodeRemoteFileNameComponent(value: string): string {
-  try {
-    return decodeURIComponent(value).replace(/[\\/]/g, "_");
-  } catch {
-    return value;
-  }
-}
-
-function decodeExtendedRemoteFileName(value: string): string | undefined {
-  const match = /^([^']*)'[^']*'(.*)$/u.exec(value);
-  if (!match) {
-    return undefined;
-  }
-  const charset = match[1]?.toLowerCase();
-  const encoded = match[2] ?? "";
-  try {
-    if (charset === "utf-8") {
-      return decodeURIComponent(encoded).replace(/[\\/]/g, "_");
-    }
-    if (charset === "iso-8859-1") {
-      if (/%(?![\da-f]{2})/iu.test(encoded)) {
-        return undefined;
-      }
-      return encoded
-        .replace(/%([\da-f]{2})/giu, (_match, hex: string) =>
-          String.fromCharCode(Number.parseInt(hex, 16)),
-        )
-        .replace(/[\\/]/g, "_");
-    }
-  } catch {
-    return undefined;
-  }
-  return undefined;
-}
-
-function* parseContentDispositionParameters(header: string): Generator<{
-  name: string;
-  value: string;
-}> {
-  let start = 0;
-  let quoted = false;
-  let escaped = false;
-  for (let index = 0; index <= header.length; index += 1) {
-    const character = header[index];
-    if (escaped || (quoted && character === "\\")) {
-      escaped = !escaped;
-      continue;
-    }
-    if (character === '"') {
-      quoted = !quoted;
-      continue;
-    }
-    if (index !== header.length && (quoted || character !== ";")) {
-      continue;
-    }
-    const parameter = header.slice(start, index).trim();
-    start = index + 1;
-    const separator = parameter.indexOf("=");
-    if (separator > 0) {
-      yield {
-        name: parameter.slice(0, separator).trim().toLowerCase(),
-        value: stripQuotes(parameter.slice(separator + 1).trim()),
-      };
-    }
-  }
-}
-
-function decodeQuotedRemoteFileName(value: string): string {
-  const windowsDrivePath = /^[a-z]:[\\/]/iu.test(value);
-  const windowsNetworkPath = value.startsWith("\\\\");
-  const mixedWindowsPath = value.includes("/") && value.includes("\\");
-  const relativeWindowsPath =
-    /\\[\p{L}\p{N}]/u.test(value) && /^[^\\/:]+(?:\\[^\\]+)+$/u.test(value);
-  if (!windowsDrivePath && !windowsNetworkPath && !mixedWindowsPath && !relativeWindowsPath) {
-    return value.replace(/\\(.)/gu, "$1");
-  }
-  const lastForwardSeparator = value.lastIndexOf("/");
-  if (lastForwardSeparator >= 0) {
-    const prefix = value.slice(0, lastForwardSeparator + 1);
-    const fileName = value.slice(lastForwardSeparator + 1).replace(/\\([^\p{L}\p{N}])/gu, "$1");
-    return `${prefix}${fileName}`;
-  }
-  const firstBackslash = value.indexOf("\\");
-  if (
-    !windowsDrivePath &&
-    !windowsNetworkPath &&
-    firstBackslash === value.lastIndexOf("\\") &&
-    /\\[^\p{L}\p{N}]/u.test(value)
-  ) {
-    return value.replace(/\\(.)/gu, "$1");
-  }
-  // Backslash-only legacy paths need every separator, including before Unicode or spaces.
-  return value.replace(/\\"/gu, '"');
-}
-
-function parseContentDispositionFileName(header?: string | null): string | undefined {
-  if (!header) {
-    return undefined;
-  }
-  let fallbackFileName: string | undefined;
-  for (const parameter of parseContentDispositionParameters(header)) {
-    if (parameter.name === "filename") {
-      fallbackFileName ??=
-        basenameFromAnyPath(decodeQuotedRemoteFileName(parameter.value)) || undefined;
-      continue;
-    }
-    if (parameter.name !== "filename*") {
-      continue;
-    }
-    const decoded = decodeExtendedRemoteFileName(parameter.value);
-    if (decoded) {
-      return basenameFromAnyPath(decoded) || undefined;
-    }
-  }
-  return fallbackFileName;
-}
-
-function basenameFromUrlPathname(pathname: string): string {
-  const base = basenameFromAnyPath(pathname);
-  if (!base) {
-    return "";
-  }
-  return decodeRemoteFileNameComponent(base);
-}
 
 async function readErrorBodySnippet(
   res: Response,
@@ -638,12 +510,28 @@ async function withMediaFetchRetry<T>(
   if (!retry) {
     return await fn();
   }
+  // sleepWithAbort rejects raw Error("aborted") on caller signal abort during
+  // backoff; normalize to MediaFetchError so callers retain the established
+  // fetch_failed / AbortError-cause contract used by header and body aborts.
+  const signal = options.requestInit?.signal ?? undefined;
+  const sleep =
+    retry.sleep ??
+    ((ms: number) =>
+      sleepWithAbort(ms, signal).catch((err) => {
+        throw new MediaFetchError(
+          "fetch_failed",
+          `Failed to fetch media from ${redactMediaUrl(options.url)}: ${formatErrorMessage(err)}`,
+          {
+            cause: createAbortError("aborted", { cause: err }),
+          },
+        );
+      }));
   return await retryAsync(fn, {
     label: "media:fetch",
     ...retry,
     shouldRetry: (err, attempt) =>
       retry.shouldRetry ? retry.shouldRetry(err, attempt) : shouldRetryMediaFetch(err),
-    sleep: retry.sleep ?? ((ms) => sleepWithAbort(ms, options.requestInit?.signal ?? undefined)),
+    sleep,
   });
 }
 


### PR DESCRIPTION
## What Problem This Solves

Remote media downloads ignored caller cancellation while waiting between retry attempts. After a real HTTP 503, aborting a buffer download or media-store write left its retry backoff timer running and entered the guarded fetch path a second time, even though the operation was already canceled.

## Why This Change Was Made

The shared media retry owner passed requestInit.signal into guarded HTTP fetches but never forwarded it to retryAsync's sleep callback. The narrow owner-boundary repair uses canonical sleepWithAbort whenever the caller did not provide an explicit retry.sleep implementation. Three duplicate fetch_failed constructors become one owner-local adapter, preserving redacted URLs and the existing MediaFetchError(fetch_failed) with its original AbortError cause.

The unrelated 132-line Content-Disposition extraction from the original contributor branch was removed. Original contributor authorship is preserved, and both readRemoteMediaBuffer and saveRemoteMedia receive the same canonical repair without increasing production LOC.

## User Impact

Canceled remote media reads and media-store writes now stop promptly during retry backoff. They do not start a second guarded request and keep the existing caller-visible media error contract. Existing custom retry sleepers, SSRF policy, URL redaction, and media parsing behavior remain unchanged.

## Evidence

Verified exact contributor head: 0e72a2d2097b00f28abe6d7a2af9104aadba7329

Real transport regression: an actual localhost HTTP server returns HTTP 503, then the retry callback schedules the caller abort after backoff has started. The table-driven scenario independently covers both buffer reads and media-store writes.

- Before the repair: both real-HTTP scenarios fail because the canceled operation invokes guarded fetch twice.
- After the repair: both scenarios pass with exactly one real HTTP request, one guarded fetch, and MediaFetchError(fetch_failed) whose cause is AbortError.
- Focused regression: node scripts/run-vitest.mjs src/media/fetch.test.ts -t 'cancels retry backoff' passes both real-server scenarios.
- Complete media suite: node scripts/run-vitest.mjs src/media/fetch.test.ts passes all 81 tests.
- Both changed files pass formatting checks.
- The exact hosted type-aware lint rule passes after the explicit unknown catch annotation.
- Fresh independent Codex autoreview reports no accepted or actionable findings.
- Production LOC: +19/-19, net zero. Regression tests: +56/-0.
- Final landing requires green Workflow Sanity and comprehensive hosted CI on this exact head.

@clawsweeper re-review
