### PR TITLE
fix: unhandled rejection crashes process when raw stream write fails

### DIFF
--- a/src/agents/embedded-agent-subscribe.raw-stream.test.ts
+++ b/src/agents/embedded-agent-subscribe.raw-stream.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for raw-stream write failure handling.
+ * Verifies that both synchronous throws and async rejections are contained
+ * without crashing the process.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import os from "node:os";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock appendRegularFile before importing the module under test so we
+// control whether it resolves, rejects, or throws synchronously.
+const mockAppendRegularFile = vi.fn<(...args: unknown[]) => Promise<void>>();
+
+vi.mock("../infra/fs-safe.js", () => ({
+  appendRegularFile: (...args: unknown[]) => mockAppendRegularFile(...args),
+}));
+
+// Reload the module with our mock in place.
+const { appendRawStream } = await import(
+  "./embedded-agent-subscribe.raw-stream.js"
+);
+
+describe("appendRawStream", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    vi.stubEnv("OPENCLAW_RAW_STREAM", "true");
+    tmpDir = path.join(
+      os.tmpdir(),
+      `openclaw-raw-stream-test-${randomUUID()}`,
+    );
+    vi.stubEnv("OPENCLAW_RAW_STREAM_PATH", path.join(tmpDir, "raw.jsonl"));
+    mockAppendRegularFile.mockReset();
+  });
+
+  it("survives a rejected write without throwing", async () => {
+    mockAppendRegularFile.mockRejectedValue(
+      new Error("ENOSPC: no space left on device"),
+    );
+    expect(() => appendRawStream({ event: "test", ts: 1 })).not.toThrow();
+    // Let the microtask queue flush so the rejection reaches the catch handler.
+    await vi.waitFor(() => {
+      expect(mockAppendRegularFile).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("survives a synchronous throw from the dependency", () => {
+    mockAppendRegularFile.mockImplementation(() => {
+      throw new Error("synchronous construction failure");
+    });
+    expect(() => appendRawStream({ event: "test", ts: 1 })).not.toThrow();
+    expect(mockAppendRegularFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("writes successfully in the normal case", async () => {
+    fs.mkdirSync(tmpDir, { recursive: true });
+    try {
+      mockAppendRegularFile.mockResolvedValue(undefined);
+      expect(() => appendRawStream({ event: "test", ts: 1 })).not.toThrow();
+      await vi.waitFor(() => {
+        expect(mockAppendRegularFile).toHaveBeenCalledTimes(1);
+      });
+      expect(
+        mockAppendRegularFile,
+      ).toHaveBeenCalledWith({
+        filePath: path.join(tmpDir, "raw.jsonl"),
+        content: '{"event":"test","ts":1}\n',
+        rejectSymlinkParents: true,
+      });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("is a no-op when OPENCLAW_RAW_STREAM is not set", () => {
+    vi.stubEnv("OPENCLAW_RAW_STREAM", "");
+    appendRawStream({ event: "test", ts: 1 });
+    expect(mockAppendRegularFile).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/embedded-agent-subscribe.raw-stream.test.ts
+++ b/src/agents/embedded-agent-subscribe.raw-stream.test.ts
@@ -1,82 +1,86 @@
-/**
- * Tests for raw-stream write failure handling.
- * Verifies that both synchronous throws and async rejections are contained
- * without crashing the process.
- */
 import fs from "node:fs";
-import path from "node:path";
-import { randomUUID } from "node:crypto";
 import os from "node:os";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-
-// Mock appendRegularFile before importing the module under test so we
-// control whether it resolves, rejects, or throws synchronously.
-const mockAppendRegularFile = vi.fn<(...args: unknown[]) => Promise<void>>();
-
-vi.mock("../infra/fs-safe.js", () => ({
-  appendRegularFile: (...args: unknown[]) => mockAppendRegularFile(...args),
-}));
-
-// Reload the module with our mock in place.
-const { appendRawStream } = await import(
-  "./embedded-agent-subscribe.raw-stream.js"
-);
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { appendRawStream } from "./embedded-agent-subscribe.raw-stream.js";
 
 describe("appendRawStream", () => {
   let tmpDir: string;
+  const unhandledRejections: unknown[] = [];
+  const onUnhandledRejection = (reason: unknown) => {
+    unhandledRejections.push(reason);
+  };
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-raw-stream-test-"));
+  });
 
   beforeEach(() => {
     vi.stubEnv("OPENCLAW_RAW_STREAM", "true");
-    tmpDir = path.join(
-      os.tmpdir(),
-      `openclaw-raw-stream-test-${randomUUID()}`,
-    );
-    vi.stubEnv("OPENCLAW_RAW_STREAM_PATH", path.join(tmpDir, "raw.jsonl"));
-    mockAppendRegularFile.mockReset();
+    process.on("unhandledRejection", onUnhandledRejection);
   });
 
-  it("survives a rejected write without throwing", async () => {
-    mockAppendRegularFile.mockRejectedValue(
-      new Error("ENOSPC: no space left on device"),
-    );
-    expect(() => appendRawStream({ event: "test", ts: 1 })).not.toThrow();
-    // Let the microtask queue flush so the rejection reaches the catch handler.
-    await vi.waitFor(() => {
-      expect(mockAppendRegularFile).toHaveBeenCalledTimes(1);
+  afterEach(() => {
+    process.off("unhandledRejection", onUnhandledRejection);
+    unhandledRejections.length = 0;
+    vi.unstubAllEnvs();
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function drainAsyncWrites(): Promise<void> {
+    await Promise.resolve();
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
     });
-  });
+  }
 
-  it("survives a synchronous throw from the dependency", () => {
-    mockAppendRegularFile.mockImplementation(() => {
-      throw new Error("synchronous construction failure");
-    });
+  it("contains a real rejected append without leaking an unhandled rejection", async () => {
+    const directoryTarget = path.join(tmpDir, "directory-target");
+    fs.mkdirSync(directoryTarget);
+    vi.stubEnv("OPENCLAW_RAW_STREAM_PATH", directoryTarget);
+
     expect(() => appendRawStream({ event: "test", ts: 1 })).not.toThrow();
-    expect(mockAppendRegularFile).toHaveBeenCalledTimes(1);
+    await drainAsyncWrites();
+
+    expect(unhandledRejections).toHaveLength(0);
   });
 
-  it("writes successfully in the normal case", async () => {
-    fs.mkdirSync(tmpDir, { recursive: true });
-    try {
-      mockAppendRegularFile.mockResolvedValue(undefined);
-      expect(() => appendRawStream({ event: "test", ts: 1 })).not.toThrow();
-      await vi.waitFor(() => {
-        expect(mockAppendRegularFile).toHaveBeenCalledTimes(1);
-      });
-      expect(
-        mockAppendRegularFile,
-      ).toHaveBeenCalledWith({
-        filePath: path.join(tmpDir, "raw.jsonl"),
-        content: '{"event":"test","ts":1}\n',
-        rejectSymlinkParents: true,
-      });
-    } finally {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-    }
-  });
+  it("appends exact JSONL through the real dependency", async () => {
+    const rawStreamPath = path.join(tmpDir, "raw.jsonl");
+    vi.stubEnv("OPENCLAW_RAW_STREAM_PATH", rawStreamPath);
 
-  it("is a no-op when OPENCLAW_RAW_STREAM is not set", () => {
-    vi.stubEnv("OPENCLAW_RAW_STREAM", "");
     appendRawStream({ event: "test", ts: 1 });
-    expect(mockAppendRegularFile).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(fs.existsSync(rawStreamPath)).toBe(true);
+    });
+
+    expect(fs.readFileSync(rawStreamPath, "utf8")).toBe('{"event":"test","ts":1}\n');
+    expect(unhandledRejections).toHaveLength(0);
+  });
+
+  it("does nothing when raw streaming is disabled", async () => {
+    const rawStreamPath = path.join(tmpDir, "disabled.jsonl");
+    vi.stubEnv("OPENCLAW_RAW_STREAM", "");
+    vi.stubEnv("OPENCLAW_RAW_STREAM_PATH", rawStreamPath);
+
+    appendRawStream({ event: "test", ts: 1 });
+    await drainAsyncWrites();
+
+    expect(fs.existsSync(rawStreamPath)).toBe(false);
+    expect(unhandledRejections).toHaveLength(0);
+  });
+
+  it("contains synchronous JSON serialization failures", () => {
+    const rawStreamPath = path.join(tmpDir, "cyclic.jsonl");
+    const payload: Record<string, unknown> = {};
+    payload.self = payload;
+    vi.stubEnv("OPENCLAW_RAW_STREAM_PATH", rawStreamPath);
+
+    expect(() => appendRawStream(payload)).not.toThrow();
+    expect(fs.existsSync(rawStreamPath)).toBe(false);
+    expect(unhandledRejections).toHaveLength(0);
   });
 });

--- a/src/agents/embedded-agent-subscribe.raw-stream.ts
+++ b/src/agents/embedded-agent-subscribe.raw-stream.ts
@@ -33,11 +33,15 @@ export function appendRawStream(payload: Record<string, unknown>) {
       // ignore raw stream mkdir failures
     }
   }
-  void appendRegularFile({
-    filePath: rawStreamPath,
-    content: `${JSON.stringify(payload)}\n`,
-    rejectSymlinkParents: true,
-  }).catch(() => {
-    // ignore raw stream write failures
-  });
+  try {
+    void appendRegularFile({
+      filePath: rawStreamPath,
+      content: `${JSON.stringify(payload)}\n`,
+      rejectSymlinkParents: true,
+    }).catch(() => {
+      // ignore raw stream write failures
+    });
+  } catch {
+    // ignore synchronous failures before the promise is returned
+  }
 }

--- a/src/agents/embedded-agent-subscribe.raw-stream.ts
+++ b/src/agents/embedded-agent-subscribe.raw-stream.ts
@@ -39,9 +39,9 @@ export function appendRawStream(payload: Record<string, unknown>) {
       content: `${JSON.stringify(payload)}\n`,
       rejectSymlinkParents: true,
     }).catch(() => {
-      // ignore raw stream write failures
+      // Raw diagnostics are best-effort; filesystem failures must not terminate agent runs.
     });
   } catch {
-    // ignore synchronous failures before the promise is returned
+    // JSON serialization can fail synchronously, for example with cyclic payloads.
   }
 }

--- a/src/agents/embedded-agent-subscribe.raw-stream.ts
+++ b/src/agents/embedded-agent-subscribe.raw-stream.ts
@@ -33,13 +33,11 @@ export function appendRawStream(payload: Record<string, unknown>) {
       // ignore raw stream mkdir failures
     }
   }
-  try {
-    void appendRegularFile({
-      filePath: rawStreamPath,
-      content: `${JSON.stringify(payload)}\n`,
-      rejectSymlinkParents: true,
-    });
-  } catch {
+  void appendRegularFile({
+    filePath: rawStreamPath,
+    content: `${JSON.stringify(payload)}\n`,
+    rejectSymlinkParents: true,
+  }).catch(() => {
     // ignore raw stream write failures
-  }
+  });
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where enabling the raw diagnostic stream could terminate the
gateway when its best-effort filesystem append was rejected. A directory
target, disk failure, permission error, or rejected symlink parent could escape
as an unhandled promise rejection instead of only dropping the diagnostic
record.

## Why This Change Was Made

The raw-stream producer now attaches a terminal rejection handler to the exact
`appendRegularFile()` promise. The existing synchronous guard remains narrowly
responsible for JSON serialization failures, including cyclic diagnostic
payloads.

The regression tests use the installed `@openclaw/fs-safe` implementation
instead of mocking the append boundary. They cover a real rejected
directory-target append, exact JSONL output, disabled behavior, synchronous
cyclic-payload containment, and shared temporary-directory cleanup.

## User Impact

Operators can keep raw diagnostics enabled without a failed diagnostic write
terminating an otherwise healthy agent run. Successful records retain the same
JSONL format, and the feature remains opt-in.

## Evidence

- Real process-level before/after proof with `OPENCLAW_RAW_STREAM=true` and
  `OPENCLAW_RAW_STREAM_PATH` set to an existing directory, forcing the installed
  `@openclaw/fs-safe` append to reject:
  - `origin/main` at `db90dff1396fecbf7029e9e9ea19d6c6ca3e644e`:
    `current-main-exit=1`.
  - This PR at `d63452035e702c33292b8c37d8c06b058c404c2f`:
    printed `survived` and `rebased-head-exit=0`.
- `node scripts/run-vitest.mjs
  src/agents/embedded-agent-subscribe.raw-stream.test.ts
  src/agents/embedded-agent-subscribe.block-reply-rejections.test.ts
  src/agents/embedded-agent-subscribe.handlers.messages.test.ts`
  - 3 files passed, 79 tests passed.
- `./node_modules/.bin/oxfmt --check
  src/agents/embedded-agent-subscribe.raw-stream.ts
  src/agents/embedded-agent-subscribe.raw-stream.test.ts`
  - Passed.
- `git diff --check origin/main...HEAD`
  - Passed.
- Blacksmith Testbox changed gate:
  - Command: `node scripts/check-changed.mjs --
    src/agents/embedded-agent-subscribe.raw-stream.ts
    src/agents/embedded-agent-subscribe.raw-stream.test.ts`
  - Lease: `tbx_01kzcfb71fymv38890e7xetaj6`
  - Result: exit 0.
  - Run: https://github.com/openclaw/openclaw/actions/runs/31128272683
- Fresh max-P1 autoreview on the exact rebased head: no actionable findings;
  patch correct with 0.98 confidence.

AI-assisted: the contributor used Claude Code; maintainer validation and the
final test rewrite were independently reviewed with Codex.

Punchcard-Session: brisk-cedar-brook-w3


