### PR TITLE
fix: unblock queued replies after repeated model requests

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
@@ -18,6 +18,14 @@ type MockOpenAiRequestOutcome = "success" | "error";
 export type StreamEvent =
   | { type: "response.created"; response: { id: string } }
   | {
+      type: "response.failed";
+      response: {
+        id: string;
+        status: "failed";
+        error?: { code: string; message: string };
+      };
+    }
+  | {
       type: "response.output_item.added";
       output_index?: number;
       item: Record<string, unknown>;
@@ -197,6 +205,10 @@ export const QA_EMPTY_RESPONSE_RECOVERY_PROMPT_RE = /empty response continuation
 export const QA_EMPTY_RESPONSE_EXHAUSTION_PROMPT_RE = /empty response exhaustion qa check/i;
 export const QA_EMPTY_RESPONSE_SIDE_EFFECT_RECOVERY_PROMPT_RE =
   /empty response after write recovery qa check/i;
+export const QA_REPEATED_REQUEST_RECOVERY_PROMPT_RE = /repeated request recovery gateway qa check/i;
+export const QA_REPEATED_REQUEST_QUEUED_REPLY_PROMPT_RE =
+  /repeated request queued reply gateway qa check/i;
+export const QA_REPEATED_REQUEST_QUEUED_REPLY_MARKER = "GATEWAY_REPEATED_REQUEST_QUEUED_OK";
 export const QA_STREAMING_PROMPT_RE = /(?:partial|quiet) streaming qa check/i;
 export const QA_FINAL_ONLY_MARKER_STREAMING_PROMPT_RE = /final-only marker streaming qa check/i;
 export const QA_BLOCK_STREAMING_PROMPT_RE = /block streaming qa check/i;

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-events.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-events.test.ts
@@ -3,6 +3,7 @@ import type { StreamEvent } from "./mock-openai-contracts.js";
 import {
   buildAssistantEvents,
   buildAssistantThenToolCallEvents,
+  buildFailedResponseEvents,
   buildReasoningAndAssistantEvents,
   buildReasoningOnlyEvents,
 } from "./mock-openai-events.js";
@@ -29,6 +30,16 @@ function readOutputItemSlots(events: StreamEvent[]) {
 }
 
 describe("mock OpenAI Responses output item slots", () => {
+  it("emits the provider no-details failure used by repeated-request recovery QA", () => {
+    expect(buildFailedResponseEvents()).toEqual([
+      expect.objectContaining({ type: "response.created" }),
+      expect.objectContaining({
+        type: "response.failed",
+        response: expect.not.objectContaining({ error: expect.anything() }),
+      }),
+    ]);
+  });
+
   it("indexes preview deltas and the final answer on the same assistant slot", () => {
     const events = buildAssistantEvents([
       {

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-events.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-events.ts
@@ -6,6 +6,21 @@ import {
   buildMockFunctionCall,
   buildToolCallEventsWithArgs,
 } from "./mock-openai-tooling.js";
+
+export function buildFailedResponseEvents(): StreamEvent[] {
+  const responseId = `resp_qa_failed_${Date.now()}`;
+  return [
+    { type: "response.created", response: { id: responseId } },
+    {
+      type: "response.failed",
+      response: {
+        id: responseId,
+        status: "failed",
+      },
+    },
+  ];
+}
+
 export function buildToolCallEvents(prompt: string): StreamEvent[] {
   const targetPath = readTargetFromPrompt(prompt);
   return buildToolCallEventsWithArgs("read", { path: targetPath });

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-responses-websocket.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-responses-websocket.ts
@@ -13,6 +13,7 @@ export type QaMockResponsesDispatchResult = {
   };
   onResponseSent?: () => void;
   previewPauseMs?: number;
+  responsePauseMs?: number;
 };
 
 type QaMockResponsesWebSocketDispatch = (params: {
@@ -208,6 +209,9 @@ export function attachQaMockResponsesWebSocketServer(params: {
             return;
           }
           const { events } = dispatched;
+          if (dispatched.responsePauseMs !== undefined) {
+            await sleep(dispatched.responsePauseMs);
+          }
           const completion = events.find((event) => event.type === "response.completed");
           if (completion?.type === "response.completed") {
             if (!events.some((event) => event.type === "response.created")) {

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -32,6 +32,9 @@ import {
   QA_EMPTY_RESPONSE_RECOVERY_PROMPT_RE,
   QA_EMPTY_RESPONSE_EXHAUSTION_PROMPT_RE,
   QA_EMPTY_RESPONSE_SIDE_EFFECT_RECOVERY_PROMPT_RE,
+  QA_REPEATED_REQUEST_RECOVERY_PROMPT_RE,
+  QA_REPEATED_REQUEST_QUEUED_REPLY_PROMPT_RE,
+  QA_REPEATED_REQUEST_QUEUED_REPLY_MARKER,
   QA_STREAMING_PROMPT_RE,
   QA_FINAL_ONLY_MARKER_STREAMING_PROMPT_RE,
   QA_BLOCK_STREAMING_PROMPT_RE,
@@ -133,6 +136,7 @@ import {
   buildAssistantEvents,
   buildReasoningOnlyEvents,
   buildReasoningAndAssistantEvents,
+  buildFailedResponseEvents,
 } from "./mock-openai-events.js";
 import {
   extractLastUserText,
@@ -277,6 +281,9 @@ const QA_STREAMING_TOOL_PROGRESS_CONTINUATION_RE =
   /^Continue with (?:the current Matrix QA scenario|the QA scenario plan and report worked, failed, and blocked items)\.$/i;
 const QA_CODE_MODE_TARGET_MARKER = "qa-code-mode-target:";
 const QA_FAILED_TOOL_TERMINAL_RECOVERY_PROMPT_RE = /failed tool terminal recovery qa check/i;
+// Keep each real provider request active long enough for retries to span the
+// unchanged five-minute recovery bound while remaining below first-byte timeout.
+const QA_REPEATED_REQUEST_RESPONSE_PAUSE_MS = 110_000;
 
 function isStreamingToolProgressContinuationText(text: string) {
   const trimmed = text.trim();
@@ -758,6 +765,14 @@ async function buildResponsesPayload(
     )
       ? extractLatestToolOutput(input)
       : "");
+  // The queued followup carries the stalled prompt in transcript history, so
+  // current-turn dispatch must win before the persistent recovery fixture.
+  if (QA_REPEATED_REQUEST_QUEUED_REPLY_PROMPT_RE.test(prompt)) {
+    return buildAssistantEvents(QA_REPEATED_REQUEST_QUEUED_REPLY_MARKER);
+  }
+  if (QA_REPEATED_REQUEST_RECOVERY_PROMPT_RE.test(allInputText)) {
+    return buildFailedResponseEvents();
+  }
   const toolJson = parseToolOutputJson(scenarioToolOutput);
   if (
     codeModeControlJson?.status === "waiting" &&
@@ -2334,7 +2349,11 @@ export async function startQaMockOpenAiServer(params?: {
         : undefined;
     recordRequest({
       ...requestSnapshotBase,
-      outcome: failure ? "error" : "success",
+      outcome:
+        failure || events.some((event) => event.type === "response.failed") ? "error" : "success",
+      ...(events.some((event) => event.type === "response.failed")
+        ? { errorCode: "response_failed_no_details" }
+        : {}),
       plannedToolCallId: extractPlannedToolCallId(events),
       plannedToolName: plannedTool.name,
       ...(plannedTool.wireName && plannedTool.wireName !== plannedTool.name
@@ -2358,6 +2377,10 @@ export async function startQaMockOpenAiServer(params?: {
       ...(failure ? { failure } : {}),
       ...(QA_FINAL_ONLY_MARKER_STREAMING_PROMPT_RE.test(allInputText)
         ? { previewPauseMs: finalOnlyMarkerPauseMs }
+        : {}),
+      ...(QA_REPEATED_REQUEST_RECOVERY_PROMPT_RE.test(allInputText) &&
+      !QA_REPEATED_REQUEST_QUEUED_REPLY_PROMPT_RE.test(prompt)
+        ? { responsePauseMs: QA_REPEATED_REQUEST_RESPONSE_PAUSE_MS }
         : {}),
     };
   };
@@ -2514,6 +2537,9 @@ export async function startQaMockOpenAiServer(params?: {
           return;
         }
         const { events } = dispatched;
+        if (dispatched.responsePauseMs !== undefined) {
+          await sleep(dispatched.responsePauseMs);
+        }
         if (body.stream === false) {
           const completion = events.at(-1);
           if (!completion || completion.type !== "response.completed") {

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
@@ -528,6 +528,11 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents", () => {
       expect(snapshot.lastProgressReason).toBe("model_call:stream_progress");
       expect(snapshot.lastProgressAgeMs).toBe(0);
       expect(runProgressEvents).toHaveLength(2);
+      expect(
+        runProgressEvents.every(
+          (event) => event.type === "run.progress" && event.progressKind === "liveness",
+        ),
+      ).toBe(true);
     } finally {
       await iterator.return?.();
       await waitForDiagnosticEventsDrained();

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
@@ -323,6 +323,7 @@ function maybeEmitModelCallStreamProgress(
     ...(eventBase.sessionKey ? { sessionKey: eventBase.sessionKey } : {}),
     ...(eventBase.sessionId ? { sessionId: eventBase.sessionId } : {}),
     reason: MODEL_CALL_STREAM_PROGRESS_REASON,
+    progressKind: "liveness" as const,
   };
   markDiagnosticRunProgress(progressFields);
   if (

--- a/src/auto-reply/reply/agent-runner-embedded-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-embedded-candidate.ts
@@ -341,6 +341,7 @@ export async function runEmbeddedFallbackCandidate(params: {
           messageToolDeliveryState: params.messageToolDeliveryState,
           provider: params.provider,
           model: params.model,
+          runId: params.runId,
           effectiveSessionId: params.effectiveRun.sessionId,
           notifyUserAboutCompaction: params.notifyUserAboutCompaction,
           onCompactionCompleted: () => {

--- a/src/auto-reply/reply/agent-runner-event-handler.ts
+++ b/src/auto-reply/reply/agent-runner-event-handler.ts
@@ -3,6 +3,7 @@ import { isMessagingToolSendAction } from "../../agents/embedded-agent-messaging
 import type { RunEmbeddedAgentParams } from "../../agents/embedded-agent-runner/run/params.js";
 import { normalizeAgentPlanSteps } from "../../channels/streaming.js";
 import { logVerbose } from "../../globals.js";
+import { markDiagnosticRunProgress } from "../../logging/diagnostic-run-activity.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { ReplyPayload } from "../types.js";
 import type { AgentLifecycleTerminalBackstop } from "./agent-lifecycle-terminal.js";
@@ -35,6 +36,7 @@ export function createAgentRunEventHandler(params: {
   sourceRepliesAreToolOnly: boolean;
   provider: string;
   model: string;
+  runId: string;
   effectiveSessionId?: string;
   notifyUserAboutCompaction: boolean;
   onCompactionCompleted: () => number;
@@ -83,6 +85,17 @@ export function createAgentRunEventHandler(params: {
 
   return async (evt) => {
     params.turn.replyOperation?.recordActivity();
+    // Agent outputs are portable forward-progress facts. Usage and lifecycle
+    // bookkeeping stay mechanical so repeated model attempts cannot self-refresh.
+    if (evt.stream !== "usage" && evt.stream !== "lifecycle") {
+      markDiagnosticRunProgress({
+        runId: params.runId,
+        sessionId: params.effectiveSessionId,
+        sessionKey: params.turn.sessionKey,
+        reason: `agent_event:${evt.stream}`,
+        progressKind: "semantic",
+      });
+    }
     params.lifecycleBackstop.note(evt);
     const hasLifecyclePhase = evt.stream === "lifecycle" && typeof evt.data.phase === "string";
     if (evt.stream !== "lifecycle" || hasLifecyclePhase) {

--- a/src/auto-reply/reply/agent-runner-execution-progress.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-progress.test.ts
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createDraftStreamLoop } from "../../channels/draft-stream-loop.js";
+import {
+  getDiagnosticSessionActivitySnapshot,
+  markDiagnosticEmbeddedRunStarted,
+  resetDiagnosticRunActivityForTest,
+} from "../../logging/diagnostic-run-activity.js";
+import { markDiagnosticModelStartedForTest } from "../../logging/diagnostic-run-activity.test-support.js";
 import type { PartialReplyPayload } from "../get-reply-options.types.js";
 import type { GetReplyOptions } from "../types.js";
 import {
@@ -39,6 +45,7 @@ const state = setupAgentRunnerExecutionTestState();
 
 beforeEach(() => {
   sanitizerState.sanitizeUserFacingText.mockClear();
+  resetDiagnosticRunActivityForTest();
 });
 
 async function executeTestTurn(
@@ -50,6 +57,40 @@ async function executeTestTurn(
 }
 
 describe("executeAgentTurn: lifecycle progress", () => {
+  it("records assistant events as semantic run progress", async () => {
+    state.runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      const sessionId = params.sessionId ?? "session";
+      const sessionKey = params.sessionKey ?? "main";
+      markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey, runId: params.runId });
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        markDiagnosticModelStartedForTest({
+          sessionId,
+          sessionKey,
+          runId: params.runId,
+          provider: "mock",
+          model: "request-model",
+          observationUnit: "request",
+        });
+      }
+      expect(
+        getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey })
+          .repeatedRequestNoProgressAgeMs,
+      ).toBe(0);
+
+      await params.onAgentEvent?.({
+        stream: "assistant",
+        data: { phase: "commentary", text: "Working" },
+      });
+      expect(
+        getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey })
+          .repeatedRequestNoProgressAgeMs,
+      ).toBeUndefined();
+      return { payloads: [{ text: "final" }], meta: {} };
+    });
+
+    await executeTestTurn();
+  });
+
   it("forwards item lifecycle events to reply options", async () => {
     const onItemEvent = vi.fn();
     state.runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {

--- a/src/auto-reply/reply/agent-runner-execution.test-support.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test-support.ts
@@ -325,6 +325,9 @@ export type FallbackRunnerParams = {
 };
 
 export type EmbeddedAgentParams = {
+  runId: string;
+  sessionId?: string;
+  sessionKey?: string;
   prompt?: string;
   transcriptPrompt?: string;
   lifecycleGeneration?: string;

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -277,6 +277,7 @@ type DiagnosticSessionAttentionBaseEvent = DiagnosticBaseEvent & {
   activeToolName?: string;
   activeToolCallId?: string;
   activeToolAgeMs?: number;
+  repeatedRequestNoProgressAgeMs?: number;
   terminalProgressStale?: boolean;
 };
 
@@ -364,6 +365,8 @@ export type DiagnosticRunProgressEvent = DiagnosticBaseEvent & {
   sessionId?: string;
   runId?: string;
   reason: string;
+  /** Semantic progress resets no-forward-progress evidence; liveness only keeps work alive. */
+  progressKind?: "semantic" | "liveness";
 };
 
 /**

--- a/src/logging/diagnostic-repeated-request-activity.ts
+++ b/src/logging/diagnostic-repeated-request-activity.ts
@@ -1,0 +1,109 @@
+// Mechanical request retries stay continuous for one run owner. Only typed
+// semantic progress or owner teardown can clear the clock that recovery reads.
+type RepeatedRequestOwner = { runId: string; sequence: number };
+
+export type DiagnosticRepeatedRequestActivity = {
+  repeatedRequestOwnerRunId?: string;
+  repeatedRequestFirstStartedAt?: number;
+  repeatedRequestCount?: number;
+  repeatedRequestMutationSequence?: number;
+};
+
+let mutationSequence = 0;
+
+function nextMutationSequence(): number {
+  mutationSequence += 1;
+  return mutationSequence;
+}
+
+function currentOwner(owners: Iterable<RepeatedRequestOwner>): RepeatedRequestOwner | undefined {
+  let current: RepeatedRequestOwner | undefined;
+  for (const owner of owners) {
+    if (!current || owner.sequence > current.sequence) {
+      current = owner;
+    }
+  }
+  return current;
+}
+
+export function recordRepeatedRequestObservation(
+  activity: DiagnosticRepeatedRequestActivity,
+  owners: Iterable<RepeatedRequestOwner>,
+  params: {
+    runId?: string;
+    observationUnit?: "request" | "turn";
+    now?: number;
+  },
+): void {
+  if (params.observationUnit === "turn") {
+    return;
+  }
+  const owner = currentOwner(owners);
+  const runId = params.runId?.trim();
+  if (!owner || !runId || owner.runId !== runId) {
+    return;
+  }
+  if (activity.repeatedRequestOwnerRunId !== runId) {
+    activity.repeatedRequestOwnerRunId = runId;
+    activity.repeatedRequestFirstStartedAt = params.now ?? Date.now();
+    activity.repeatedRequestCount = 1;
+  } else {
+    activity.repeatedRequestCount = (activity.repeatedRequestCount ?? 0) + 1;
+  }
+  activity.repeatedRequestMutationSequence = nextMutationSequence();
+}
+
+export function clearRepeatedRequestActivity(
+  activity: DiagnosticRepeatedRequestActivity,
+  params: { runId?: string } = {},
+): boolean {
+  if (
+    params.runId !== undefined &&
+    activity.repeatedRequestOwnerRunId !== undefined &&
+    activity.repeatedRequestOwnerRunId !== params.runId
+  ) {
+    return false;
+  }
+  const cleared = activity.repeatedRequestCount !== undefined;
+  if (!cleared && params.runId !== undefined) {
+    return false;
+  }
+  activity.repeatedRequestOwnerRunId = undefined;
+  activity.repeatedRequestFirstStartedAt = undefined;
+  activity.repeatedRequestCount = undefined;
+  activity.repeatedRequestMutationSequence = nextMutationSequence();
+  return cleared;
+}
+
+export function mergeRepeatedRequestActivity(
+  target: DiagnosticRepeatedRequestActivity,
+  source: DiagnosticRepeatedRequestActivity,
+): void {
+  if (
+    source.repeatedRequestMutationSequence === undefined ||
+    (target.repeatedRequestMutationSequence ?? 0) >= source.repeatedRequestMutationSequence
+  ) {
+    return;
+  }
+  target.repeatedRequestOwnerRunId = source.repeatedRequestOwnerRunId;
+  target.repeatedRequestFirstStartedAt = source.repeatedRequestFirstStartedAt;
+  target.repeatedRequestCount = source.repeatedRequestCount;
+  target.repeatedRequestMutationSequence = source.repeatedRequestMutationSequence;
+}
+
+export function resolveRepeatedRequestNoProgressAgeMs(
+  activity: DiagnosticRepeatedRequestActivity,
+  owners: Iterable<RepeatedRequestOwner>,
+  now: number,
+): number | undefined {
+  const owner = currentOwner(owners);
+  if (
+    !owner ||
+    owner.runId !== activity.repeatedRequestOwnerRunId ||
+    (activity.repeatedRequestCount ?? 0) < 2 ||
+    activity.repeatedRequestFirstStartedAt === undefined
+  ) {
+    return undefined;
+  }
+  return Math.max(0, now - activity.repeatedRequestFirstStartedAt);
+}

--- a/src/logging/diagnostic-run-activity-snapshot.ts
+++ b/src/logging/diagnostic-run-activity-snapshot.ts
@@ -1,0 +1,69 @@
+import type { DiagnosticSessionActiveWorkKind } from "../infra/diagnostic-events.js";
+import {
+  type DiagnosticArgumentChurnActivity,
+  resolveArgumentChurnProgress,
+} from "./diagnostic-argument-churn-activity.js";
+import {
+  type DiagnosticRepeatedRequestActivity,
+  resolveRepeatedRequestNoProgressAgeMs,
+} from "./diagnostic-repeated-request-activity.js";
+
+export type DiagnosticSessionActivitySnapshot = {
+  activeWorkKind?: DiagnosticSessionActiveWorkKind;
+  hasActiveEmbeddedRun?: boolean;
+  activeToolName?: string;
+  activeToolCallId?: string;
+  activeToolAgeMs?: number;
+  lastProgressAgeMs?: number;
+  lastProgressReason?: string;
+  repeatedRequestNoProgressAgeMs?: number;
+};
+
+type SnapshotTool = { toolName: string; toolCallId?: string; startedAt: number };
+type SnapshotActivity = DiagnosticArgumentChurnActivity &
+  DiagnosticRepeatedRequestActivity & {
+    activeEmbeddedRuns: ReadonlyMap<string, { runId: string; sequence: number }>;
+    activeModelCalls: ReadonlyMap<string, unknown>;
+    activeTools: ReadonlyMap<string, SnapshotTool>;
+    lastProgressAt: number;
+    lastProgressReason?: string;
+  };
+
+export function buildDiagnosticSessionActivitySnapshot(
+  activity: SnapshotActivity,
+  now: number,
+): DiagnosticSessionActivitySnapshot {
+  const activeWorkKind: DiagnosticSessionActiveWorkKind | undefined =
+    activity.activeTools.size > 0
+      ? "tool_call"
+      : activity.activeModelCalls.size > 0
+        ? "model_call"
+        : activity.activeEmbeddedRuns.size > 0
+          ? "embedded_run"
+          : undefined;
+  let activeTool: SnapshotTool | undefined;
+  for (const tool of activity.activeTools.values()) {
+    if (!activeTool || tool.startedAt < activeTool.startedAt) {
+      activeTool = tool;
+    }
+  }
+  const churnProgress = resolveArgumentChurnProgress(
+    activity,
+    activity.activeEmbeddedRuns.values(),
+    now,
+  );
+  return {
+    activeWorkKind,
+    ...(activity.activeEmbeddedRuns.size > 0 ? { hasActiveEmbeddedRun: true } : {}),
+    activeToolName: activeTool?.toolName,
+    activeToolCallId: activeTool?.toolCallId,
+    activeToolAgeMs: activeTool ? Math.max(0, now - activeTool.startedAt) : undefined,
+    lastProgressAgeMs: Math.max(0, now - churnProgress.lastProgressAt),
+    lastProgressReason: churnProgress.lastProgressReason,
+    repeatedRequestNoProgressAgeMs: resolveRepeatedRequestNoProgressAgeMs(
+      activity,
+      activity.activeEmbeddedRuns.values(),
+      now,
+    ),
+  };
+}

--- a/src/logging/diagnostic-run-activity.test-support.ts
+++ b/src/logging/diagnostic-run-activity.test-support.ts
@@ -3,12 +3,12 @@ import "./diagnostic-run-activity.js";
 
 type DiagnosticModelStartedActivityEvent = Pick<
   Extract<DiagnosticEventPayload, { type: "model.call.started" }>,
-  "runId" | "sessionId" | "sessionKey" | "provider" | "model"
+  "runId" | "sessionId" | "sessionKey" | "provider" | "model" | "observationUnit"
 > & { seq?: number };
 
 type DiagnosticRunProgressActivityEvent = Pick<
   Extract<DiagnosticEventPayload, { type: "run.progress" }>,
-  "runId" | "sessionId" | "sessionKey" | "reason"
+  "runId" | "sessionId" | "sessionKey" | "reason" | "progressKind"
 >;
 
 type DiagnosticRunActivityTestApi = {

--- a/src/logging/diagnostic-run-activity.test.ts
+++ b/src/logging/diagnostic-run-activity.test.ts
@@ -15,15 +15,17 @@ import {
   markDiagnosticEmbeddedRunEnded,
   markDiagnosticEmbeddedRunStarted,
   markDiagnosticRunProgress,
+  resetDiagnosticRunActivityForTest,
   resolveRunStaleThresholdMs,
   RUN_STALE_TAKEOVER_MS,
   startDiagnosticRunActivityTracking,
   stopDiagnosticRunActivityTracking,
 } from "./diagnostic-run-activity.js";
+import { markDiagnosticModelStartedForTest } from "./diagnostic-run-activity.test-support.js";
 
 afterEach(() => {
   vi.useRealTimers();
-  stopDiagnosticRunActivityTracking();
+  resetDiagnosticRunActivityForTest();
   resetDiagnosticEventsForTest();
 });
 
@@ -366,6 +368,203 @@ describe("argument-churn liveness", () => {
       lastProgressAgeMs: 6 * 60_000,
       lastProgressReason: "tool_loop:argument_churn",
     });
+  });
+});
+
+describe("repeated request liveness", () => {
+  it("ages repeated requests across mechanical progress until semantic progress arrives", () => {
+    vi.useFakeTimers();
+    const startedAt = Date.parse("2026-08-04T00:00:00Z");
+    vi.setSystemTime(startedAt);
+    const ref = { sessionId: "retry-session", sessionKey: "agent:main:retry" };
+    const runId = "retry-run";
+
+    markDiagnosticEmbeddedRunStarted({ ...ref, runId });
+    markDiagnosticModelStartedForTest({
+      ...ref,
+      runId,
+      provider: "mock",
+      model: "retrying-model",
+      observationUnit: "request",
+    });
+    expect(
+      getDiagnosticSessionActivitySnapshot(ref).repeatedRequestNoProgressAgeMs,
+    ).toBeUndefined();
+
+    for (let attempt = 2; attempt <= 11; attempt += 1) {
+      vi.setSystemTime(startedAt + (attempt - 1) * 30_000);
+      markDiagnosticModelStartedForTest({
+        ...ref,
+        runId,
+        provider: "mock",
+        model: "retrying-model",
+        observationUnit: "request",
+      });
+      markDiagnosticRunProgress({
+        ...ref,
+        runId,
+        reason: "model_call:stream_progress",
+        progressKind: "liveness",
+      });
+    }
+
+    expect(getDiagnosticSessionActivitySnapshot(ref)).toMatchObject({
+      activeWorkKind: "model_call",
+      lastProgressAgeMs: 0,
+      repeatedRequestNoProgressAgeMs: 5 * 60_000,
+    });
+
+    markDiagnosticRunProgress({
+      ...ref,
+      runId,
+      reason: "assistant:progress",
+      progressKind: "semantic",
+    });
+    expect(
+      getDiagnosticSessionActivitySnapshot(ref).repeatedRequestNoProgressAgeMs,
+    ).toBeUndefined();
+  });
+
+  it("ignores turn observations and clears request evidence across owner lifecycle", () => {
+    vi.useFakeTimers();
+    const startedAt = Date.parse("2026-08-04T01:00:00Z");
+    vi.setSystemTime(startedAt);
+    const ref = { sessionId: "owner-session", sessionKey: "agent:main:owner" };
+
+    markDiagnosticEmbeddedRunStarted({ ...ref, runId: "first-owner" });
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      markDiagnosticModelStartedForTest({
+        ...ref,
+        runId: "first-owner",
+        provider: "cli",
+        model: "turn-model",
+        observationUnit: "turn",
+      });
+    }
+    expect(
+      getDiagnosticSessionActivitySnapshot(ref).repeatedRequestNoProgressAgeMs,
+    ).toBeUndefined();
+
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      markDiagnosticModelStartedForTest({
+        ...ref,
+        runId: "first-owner",
+        provider: "mock",
+        model: "request-model",
+        observationUnit: "request",
+      });
+    }
+    vi.setSystemTime(startedAt + 6 * 60_000);
+    expect(getDiagnosticSessionActivitySnapshot(ref).repeatedRequestNoProgressAgeMs).toBe(
+      6 * 60_000,
+    );
+
+    markDiagnosticEmbeddedRunStarted({ ...ref, runId: "replacement-owner" });
+    markDiagnosticModelStartedForTest({
+      ...ref,
+      runId: "first-owner",
+      provider: "mock",
+      model: "delayed-request",
+      observationUnit: "request",
+    });
+    expect(
+      getDiagnosticSessionActivitySnapshot(ref).repeatedRequestNoProgressAgeMs,
+    ).toBeUndefined();
+
+    markDiagnosticModelStartedForTest({
+      ...ref,
+      runId: "replacement-owner",
+      provider: "mock",
+      model: "request-model",
+      observationUnit: "request",
+    });
+    markDiagnosticModelStartedForTest({
+      ...ref,
+      runId: "replacement-owner",
+      provider: "mock",
+      model: "request-model",
+      observationUnit: "request",
+    });
+    vi.setSystemTime(startedAt + 7 * 60_000);
+    markDiagnosticRunProgress({
+      ...ref,
+      runId: "first-owner",
+      reason: "delayed-old-owner-output",
+      progressKind: "semantic",
+    });
+    expect(getDiagnosticSessionActivitySnapshot(ref).repeatedRequestNoProgressAgeMs).toBe(60_000);
+    expect(
+      clearDiagnosticEmbeddedRunActivityForSession({
+        ...ref,
+        activeSessionId: "replacement-owner",
+      }).cleared,
+    ).toBe(true);
+    expect(
+      getDiagnosticSessionActivitySnapshot(ref).repeatedRequestNoProgressAgeMs,
+    ).toBeUndefined();
+  });
+
+  it("orders semantic progress across merged session aliases", () => {
+    vi.useFakeTimers();
+    const startedAt = Date.parse("2026-08-04T02:00:00Z");
+    vi.setSystemTime(startedAt);
+    const sessionId = "merge-session";
+    const sessionKey = "agent:main:merge";
+    const runId = "merge-run";
+
+    markDiagnosticEmbeddedRunStarted({ sessionId, runId });
+    markDiagnosticModelStartedForTest({
+      sessionId,
+      runId,
+      provider: "mock",
+      model: "request-model",
+      observationUnit: "request",
+    });
+    markDiagnosticRunProgress({
+      sessionKey,
+      reason: "reply:delivered",
+      progressKind: "semantic",
+    });
+
+    vi.setSystemTime(startedAt + 6 * 60_000);
+    expect(
+      getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey })
+        .repeatedRequestNoProgressAgeMs,
+    ).toBeUndefined();
+  });
+
+  it("clears repeated request evidence on run completion and listener restart", async () => {
+    const ref = { sessionId: "completed-session", sessionKey: "agent:main:completed" };
+    const runId = "completed-run";
+
+    startDiagnosticRunActivityTracking();
+    markDiagnosticEmbeddedRunStarted({ ...ref, runId });
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      markDiagnosticModelStartedForTest({
+        ...ref,
+        runId,
+        provider: "mock",
+        model: "request-model",
+        observationUnit: "request",
+      });
+    }
+    expect(getDiagnosticSessionActivitySnapshot(ref).repeatedRequestNoProgressAgeMs).toBe(0);
+
+    emitTrustedDiagnosticEvent({
+      type: "run.completed",
+      ...ref,
+      runId,
+      durationMs: 1,
+      outcome: "completed",
+    });
+    await waitForDiagnosticEventsDrained();
+    expect(
+      getDiagnosticSessionActivitySnapshot(ref).repeatedRequestNoProgressAgeMs,
+    ).toBeUndefined();
+
+    stopDiagnosticRunActivityTracking();
+    startDiagnosticRunActivityTracking();
+    expect(getDiagnosticSessionActivitySnapshot(ref)).toEqual({});
   });
 });
 

--- a/src/logging/diagnostic-run-activity.test.ts
+++ b/src/logging/diagnostic-run-activity.test.ts
@@ -533,22 +533,25 @@ describe("repeated request liveness", () => {
     ).toBeUndefined();
   });
 
-  it("clears repeated request evidence on run completion and listener restart", async () => {
+  it("keeps repeated request evidence across same-logical-owner attempt rearming", async () => {
     const ref = { sessionId: "completed-session", sessionKey: "agent:main:completed" };
     const runId = "completed-run";
 
     startDiagnosticRunActivityTracking();
     markDiagnosticEmbeddedRunStarted({ ...ref, runId });
-    for (let attempt = 0; attempt < 2; attempt += 1) {
-      markDiagnosticModelStartedForTest({
-        ...ref,
-        runId,
-        provider: "mock",
-        model: "request-model",
-        observationUnit: "request",
-      });
-    }
-    expect(getDiagnosticSessionActivitySnapshot(ref).repeatedRequestNoProgressAgeMs).toBe(0);
+    markDiagnosticModelStartedForTest({
+      ...ref,
+      runId,
+      provider: "mock",
+      model: "request-model",
+      observationUnit: "request",
+    });
+
+    markDiagnosticEmbeddedRunEnded(ref);
+    expect(getDiagnosticSessionActivitySnapshot(ref)).toMatchObject({
+      activeWorkKind: undefined,
+      repeatedRequestNoProgressAgeMs: undefined,
+    });
 
     emitTrustedDiagnosticEvent({
       type: "run.completed",
@@ -558,6 +561,34 @@ describe("repeated request liveness", () => {
       outcome: "completed",
     });
     await waitForDiagnosticEventsDrained();
+    markDiagnosticEmbeddedRunStarted({ ...ref, runId });
+    markDiagnosticModelStartedForTest({
+      ...ref,
+      runId,
+      provider: "mock",
+      model: "request-model",
+      observationUnit: "request",
+    });
+    expect(getDiagnosticSessionActivitySnapshot(ref)).toMatchObject({
+      hasActiveEmbeddedRun: true,
+    });
+    expect(
+      getDiagnosticSessionActivitySnapshot(ref).repeatedRequestNoProgressAgeMs,
+    ).toBeGreaterThanOrEqual(0);
+
+    markDiagnosticEmbeddedRunEnded(ref);
+    expect(
+      getDiagnosticSessionActivitySnapshot(ref).repeatedRequestNoProgressAgeMs,
+    ).toBeUndefined();
+
+    markDiagnosticEmbeddedRunStarted({ ...ref, runId: "successor-run" });
+    markDiagnosticModelStartedForTest({
+      ...ref,
+      runId: "successor-run",
+      provider: "mock",
+      model: "request-model",
+      observationUnit: "request",
+    });
     expect(
       getDiagnosticSessionActivitySnapshot(ref).repeatedRequestNoProgressAgeMs,
     ).toBeUndefined();

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -3,7 +3,6 @@ import {
   getInternalDiagnosticEventSequence,
   onInternalDiagnosticEvent,
   type DiagnosticEventPayload,
-  type DiagnosticSessionActiveWorkKind,
 } from "../infra/diagnostic-events.js";
 import {
   applyArgumentChurnObservation,
@@ -13,20 +12,32 @@ import {
   type DiagnosticArgumentChurnObservationParams,
   mergeArgumentChurnActivity,
   recordDiagnosticActivityProgress,
-  resolveArgumentChurnProgress,
 } from "./diagnostic-argument-churn-activity.js";
 import { createDiagnosticEmbeddedRunIndex } from "./diagnostic-embedded-run-index.js";
+import {
+  clearRepeatedRequestActivity,
+  type DiagnosticRepeatedRequestActivity,
+  mergeRepeatedRequestActivity,
+  recordRepeatedRequestObservation,
+} from "./diagnostic-repeated-request-activity.js";
+import {
+  buildDiagnosticSessionActivitySnapshot,
+  type DiagnosticSessionActivitySnapshot,
+} from "./diagnostic-run-activity-snapshot.js";
 
-type SessionActivity = DiagnosticArgumentChurnActivity & {
-  sessionId?: string;
-  sessionKey?: string;
-  activeEmbeddedRuns: Map<string, ActiveEmbeddedRun>;
-  activeTools: Map<string, ActiveTool>;
-  activeModelCalls: Map<string, ActiveModelCall>;
-  recoveredOwnerStartEventCutoffs: Map<string, number>;
-  lastProgressAt: number;
-  lastProgressReason?: string;
-};
+export type { DiagnosticSessionActivitySnapshot } from "./diagnostic-run-activity-snapshot.js";
+
+type SessionActivity = DiagnosticArgumentChurnActivity &
+  DiagnosticRepeatedRequestActivity & {
+    sessionId?: string;
+    sessionKey?: string;
+    activeEmbeddedRuns: Map<string, ActiveEmbeddedRun>;
+    activeTools: Map<string, ActiveTool>;
+    activeModelCalls: Map<string, ActiveModelCall>;
+    recoveredOwnerStartEventCutoffs: Map<string, number>;
+    lastProgressAt: number;
+    lastProgressReason?: string;
+  };
 
 type ActiveEmbeddedRun = {
   runId: string;
@@ -60,12 +71,12 @@ type DiagnosticToolStartedActivityEvent = Pick<
 
 type DiagnosticModelStartedActivityEvent = Pick<
   Extract<DiagnosticEventPayload, { type: "model.call.started" }>,
-  "runId" | "sessionId" | "sessionKey" | "provider" | "model"
+  "runId" | "sessionId" | "sessionKey" | "provider" | "model" | "observationUnit"
 > & { seq?: number };
 
 type DiagnosticRunProgressActivityEvent = Pick<
   Extract<DiagnosticEventPayload, { type: "run.progress" }>,
-  "runId" | "sessionId" | "sessionKey" | "reason"
+  "runId" | "sessionId" | "sessionKey" | "reason" | "progressKind"
 >;
 
 // Quiet-but-alive tools are normal agent behavior; the CLI byte watchdog kills
@@ -76,16 +87,6 @@ export const BLOCKED_TOOL_CALL_ABORT_FLOOR_MS = 15 * 60_000;
 
 // Default quiet-run reclaim window for steer/takeover. Evidence clocks stay local.
 export const RUN_STALE_TAKEOVER_MS = 10 * 60_000;
-
-export type DiagnosticSessionActivitySnapshot = {
-  activeWorkKind?: DiagnosticSessionActiveWorkKind;
-  hasActiveEmbeddedRun?: boolean;
-  activeToolName?: string;
-  activeToolCallId?: string;
-  activeToolAgeMs?: number;
-  lastProgressAgeMs?: number;
-  lastProgressReason?: string;
-};
 
 // Quiet-but-alive tool phases get the blocked-tool floor so a human message
 // cannot reclaim a healthy long tool that stuck recovery would not touch yet.
@@ -175,6 +176,7 @@ function mergeSessionActivity(target: SessionActivity, source: SessionActivity):
     target.lastProgressSequence = source.lastProgressSequence;
   }
   mergeArgumentChurnActivity(target, source);
+  mergeRepeatedRequestActivity(target, source);
   replaceSessionActivityReferences(source, target);
 }
 
@@ -232,6 +234,15 @@ function touchSessionActivity(activity: SessionActivity, reason: string, now = D
   recordDiagnosticActivityProgress(activity);
 }
 
+function touchSemanticSessionActivity(
+  activity: SessionActivity,
+  reason: string,
+  params: { runId?: string; now?: number } = {},
+): void {
+  clearRepeatedRequestActivity(activity, { runId: params.runId });
+  touchSessionActivity(activity, reason, params.now);
+}
+
 function toolKey(event: {
   runId?: string;
   sessionId?: string;
@@ -267,7 +278,10 @@ function recordToolStarted(event: DiagnosticToolStartedActivityEvent): void {
     startedAt: now,
     lastProgressAt: now,
   });
-  touchSessionActivity(activity, `tool:${event.toolName}:started`, now);
+  touchSemanticSessionActivity(activity, `tool:${event.toolName}:started`, {
+    runId: event.runId,
+    now,
+  });
 }
 
 function recordToolEnded(
@@ -281,7 +295,7 @@ function recordToolEnded(
     return;
   }
   activity.activeTools.delete(toolKey(event));
-  touchSessionActivity(activity, `tool:${event.toolName}:ended`);
+  touchSemanticSessionActivity(activity, `tool:${event.toolName}:ended`, { runId: event.runId });
 }
 
 function recordModelStarted(event: DiagnosticModelStartedActivityEvent): void {
@@ -292,6 +306,7 @@ function recordModelStarted(event: DiagnosticModelStartedActivityEvent): void {
   if (shouldIgnoreRecoveredOwnerStartEvent(activity, event)) {
     return;
   }
+  recordRepeatedRequestObservation(activity, activity.activeEmbeddedRuns.values(), event);
   activity.activeModelCalls.set(modelCallKey(event), {
     runId: event.runId,
     sessionId: event.sessionId,
@@ -330,7 +345,11 @@ export function markDiagnosticRunProgress(params: DiagnosticRunProgressActivityE
   if (!activity) {
     return;
   }
-  touchSessionActivity(activity, params.reason);
+  if (params.progressKind === "liveness") {
+    touchSessionActivity(activity, params.reason);
+    return;
+  }
+  touchSemanticSessionActivity(activity, params.reason, { runId: params.runId });
 }
 
 function recordRunCompleted(
@@ -346,7 +365,7 @@ function recordRunCompleted(
   embeddedRunIndex.clear(activity);
   clearArgumentChurnActivity(activity, { runId: event.runId });
   clearArgumentChurnPolicyWaits(activity, { runId: event.runId });
-  touchSessionActivity(activity, "run:completed");
+  touchSemanticSessionActivity(activity, "run:completed", { runId: event.runId });
 }
 
 export function markDiagnosticEmbeddedRunStarted(params: {
@@ -362,6 +381,7 @@ export function markDiagnosticEmbeddedRunStarted(params: {
   }
   // Registration is the ownership boundary. A replacement or re-armed run
   // must never inherit the prior owner's semantic-stall clock.
+  clearRepeatedRequestActivity(activity);
   if (activity.argumentChurnStartedAt !== undefined) {
     clearArgumentChurnActivity(activity, { runId: ownerRunId });
   }
@@ -398,8 +418,9 @@ export function markDiagnosticEmbeddedRunEnded(params: {
   if (activity.activeEmbeddedRuns.size === 0) {
     clearArgumentChurnActivity(activity);
     clearArgumentChurnPolicyWaits(activity);
+    clearRepeatedRequestActivity(activity);
   }
-  touchSessionActivity(activity, "embedded_run:ended");
+  touchSemanticSessionActivity(activity, "embedded_run:ended");
 }
 
 function resolveEmbeddedRunWorkKey(params: { sessionId: string; workKey?: string }): string {
@@ -619,8 +640,9 @@ export function clearDiagnosticEmbeddedRunActivityForSession(params: {
     const clearedPolicyWait = clearArgumentChurnPolicyWaits(activity, {
       runId: params.activeSessionId,
     });
+    const clearedRepeatedRequests = clearRepeatedRequestActivity(activity);
     return {
-      cleared: clearedChurn || clearedPolicyWait,
+      cleared: clearedChurn || clearedPolicyWait || clearedRepeatedRequests,
       blockedByActiveEmbeddedRun: false,
     };
   }
@@ -650,7 +672,8 @@ export function clearDiagnosticEmbeddedRunActivityForSession(params: {
   activity.activeModelCalls.clear();
   clearArgumentChurnActivity(activity, { runId: params.activeSessionId });
   clearArgumentChurnPolicyWaits(activity, { runId: params.activeSessionId });
-  touchSessionActivity(activity, "embedded_run:ended");
+  clearRepeatedRequestActivity(activity);
+  touchSemanticSessionActivity(activity, "embedded_run:ended");
   return { cleared: true, blockedByActiveEmbeddedRun: false };
 }
 
@@ -663,35 +686,7 @@ export function getDiagnosticSessionActivitySnapshot(
     return {};
   }
 
-  let activeWorkKind: DiagnosticSessionActiveWorkKind | undefined;
-  if (activity.activeTools.size > 0) {
-    activeWorkKind = "tool_call";
-  } else if (activity.activeModelCalls.size > 0) {
-    activeWorkKind = "model_call";
-  } else if (activity.activeEmbeddedRuns.size > 0) {
-    activeWorkKind = "embedded_run";
-  }
-
-  let activeTool: ActiveTool | undefined;
-  for (const tool of activity.activeTools.values()) {
-    if (!activeTool || tool.startedAt < activeTool.startedAt) {
-      activeTool = tool;
-    }
-  }
-  const churnProgress = resolveArgumentChurnProgress(
-    activity,
-    activity.activeEmbeddedRuns.values(),
-    now,
-  );
-  return {
-    activeWorkKind,
-    ...(activity.activeEmbeddedRuns.size > 0 ? { hasActiveEmbeddedRun: true } : {}),
-    activeToolName: activeTool?.toolName,
-    activeToolCallId: activeTool?.toolCallId,
-    activeToolAgeMs: activeTool ? Math.max(0, now - activeTool.startedAt) : undefined,
-    lastProgressAgeMs: Math.max(0, now - churnProgress.lastProgressAt),
-    lastProgressReason: churnProgress.lastProgressReason,
-  };
+  return buildDiagnosticSessionActivitySnapshot(activity, now);
 }
 
 export function getDiagnosticEmbeddedRunActivitySequence(): number {
@@ -718,6 +713,17 @@ function markDiagnosticModelStartedForTest(params: DiagnosticModelStartedActivit
 
 export function resetDiagnosticRunActivityForTest(): void {
   stopDiagnosticRunActivityTracking();
+  installDiagnosticRunActivityTestApi();
+}
+
+function installDiagnosticRunActivityTestApi(): void {
+  (globalThis as Record<PropertyKey, unknown>)[
+    Symbol.for("openclaw.diagnosticRunActivityTestApi")
+  ] = {
+    markDiagnosticModelStartedForTest,
+    markDiagnosticRunProgressForTest,
+    markDiagnosticToolStartedForTest,
+  };
 }
 
 let unregisterDiagnosticRunActivityListener: (() => void) | undefined;
@@ -769,11 +775,5 @@ export function stopDiagnosticRunActivityTracking(): void {
 }
 
 if (process.env.VITEST || process.env.NODE_ENV === "test") {
-  (globalThis as Record<PropertyKey, unknown>)[
-    Symbol.for("openclaw.diagnosticRunActivityTestApi")
-  ] = {
-    markDiagnosticModelStartedForTest,
-    markDiagnosticRunProgressForTest,
-    markDiagnosticToolStartedForTest,
-  };
+  installDiagnosticRunActivityTestApi();
 }

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -359,9 +359,13 @@ function recordRunCompleted(
   if (!activity) {
     return;
   }
-  activityByRunId.delete(event.runId);
   activity.activeTools.clear();
   activity.activeModelCalls.clear();
+  if (activity.repeatedRequestOwnerRunId === event.runId) {
+    touchSessionActivity(activity, "run:attempt_completed"); // This run id re-arms after retries.
+    return;
+  }
+  activityByRunId.delete(event.runId);
   embeddedRunIndex.clear(activity);
   clearArgumentChurnActivity(activity, { runId: event.runId });
   clearArgumentChurnPolicyWaits(activity, { runId: event.runId });
@@ -375,13 +379,11 @@ export function markDiagnosticEmbeddedRunStarted(params: {
   workKey?: string;
 }): void {
   const ownerRunId = params.runId?.trim() || params.sessionId.trim();
-  const activity = resolveSessionActivity({ ...params, runId: ownerRunId, create: true });
-  if (!activity) {
-    return;
+  const activity = resolveSessionActivity({ ...params, runId: ownerRunId, create: true })!;
+  // New owners must not inherit the prior owner's semantic-stall clock.
+  if (activity.repeatedRequestOwnerRunId !== ownerRunId) {
+    clearRepeatedRequestActivity(activity);
   }
-  // Registration is the ownership boundary. A replacement or re-armed run
-  // must never inherit the prior owner's semantic-stall clock.
-  clearRepeatedRequestActivity(activity);
   if (activity.argumentChurnStartedAt !== undefined) {
     clearArgumentChurnActivity(activity, { runId: ownerRunId });
   }
@@ -418,9 +420,8 @@ export function markDiagnosticEmbeddedRunEnded(params: {
   if (activity.activeEmbeddedRuns.size === 0) {
     clearArgumentChurnActivity(activity);
     clearArgumentChurnPolicyWaits(activity);
-    clearRepeatedRequestActivity(activity);
   }
-  touchSemanticSessionActivity(activity, "embedded_run:ended");
+  touchSessionActivity(activity, "embedded_run:ended"); // Retained retry evidence is inert here.
 }
 
 function resolveEmbeddedRunWorkKey(params: { sessionId: string; workKey?: string }): string {

--- a/src/logging/diagnostic-session-attention.ts
+++ b/src/logging/diagnostic-session-attention.ts
@@ -34,6 +34,19 @@ export function classifySessionAttention(params: {
 }): SessionAttentionClassification {
   if (params.activity.activeWorkKind) {
     const lastProgressAgeMs = params.activity.lastProgressAgeMs ?? 0;
+    if (
+      params.activity.hasActiveEmbeddedRun === true &&
+      typeof params.stuckSessionAbortMs === "number" &&
+      (params.activity.repeatedRequestNoProgressAgeMs ?? 0) >= params.stuckSessionAbortMs
+    ) {
+      return {
+        eventType: "session.stalled",
+        reason: "repeated_model_requests_without_progress",
+        classification: "stalled_agent_run",
+        activeWorkKind: params.activity.activeWorkKind,
+        recoveryEligible: false,
+      };
+    }
 
     // Idle session with queued work and stale orphaned activity (no active
     // embedded owner) should be classified as recoverable stuck state, not as

--- a/src/logging/diagnostic-stability.test.ts
+++ b/src/logging/diagnostic-stability.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   emitDiagnosticEvent,
+  emitTrustedDiagnosticEvent,
   resetDiagnosticEventsForTest,
   waitForDiagnosticEventsDrained,
 } from "../infra/diagnostic-events.js";
@@ -471,6 +472,30 @@ describe("diagnostic stability recorder", () => {
       type: "payload.large",
       action: "chunked",
     });
+  });
+
+  it("records sanitized trusted model request instrumentation", async () => {
+    startDiagnosticStabilityRecorder();
+
+    emitTrustedDiagnosticEvent({
+      type: "model.call.started",
+      runId: "private-run-id",
+      callId: "private-call-id",
+      sessionKey: "private-session-key",
+      provider: "openai",
+      model: "gpt-5.4",
+      observationUnit: "request",
+    });
+    await waitForDiagnosticEventsDrained();
+
+    expect(getDiagnosticStabilitySnapshot({ type: "model.call.started" }).events).toEqual([
+      expect.objectContaining({
+        type: "model.call.started",
+        provider: "openai",
+        model: "gpt-5.4",
+      }),
+    ]);
+    expect(JSON.stringify(getDiagnosticStabilitySnapshot())).not.toContain("private-");
   });
 
   it("keeps async queue drop summaries after drained queued events for sinceSeq polling", async () => {

--- a/src/logging/diagnostic-stability.ts
+++ b/src/logging/diagnostic-stability.ts
@@ -1,6 +1,6 @@
 // Diagnostic stability helpers compare diagnostic outputs across runs.
 import {
-  onDiagnosticEvent,
+  onInternalDiagnosticEvent,
   type DiagnosticEventPayload,
   type DiagnosticMemoryUsage,
 } from "../infra/diagnostic-events.js";
@@ -733,7 +733,9 @@ export function startDiagnosticStabilityRecorder(): void {
   if (state.unsubscribe) {
     return;
   }
-  state.unsubscribe = onDiagnosticEvent((event) => {
+  // Model-call instrumentation is trusted core telemetry. Record both trust
+  // classes here, then retain only the bounded payload-free projection.
+  state.unsubscribe = onInternalDiagnosticEvent((event) => {
     appendRecord(sanitizeDiagnosticEvent(event));
   });
 }

--- a/src/logging/diagnostic-stuck-session-recovery.integration.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.integration.test.ts
@@ -8,6 +8,11 @@ import {
 import { testing as embeddedRunTesting } from "../agents/embedded-agent-runner/runs.test-support.js";
 import { createReplyOperation } from "../auto-reply/reply/reply-run-registry.js";
 import { testing as replyRunTesting } from "../auto-reply/reply/reply-run-registry.test-support.js";
+import {
+  onDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  type DiagnosticEventPayload,
+} from "../infra/diagnostic-events.js";
 import { enqueueCommandInLane, getQueueSize, resetCommandLane } from "../process/command-queue.js";
 import { resetCommandQueueStateForTest } from "../process/command-queue.test-support.js";
 import {
@@ -15,12 +20,17 @@ import {
   markDiagnosticArgumentChurnObservation,
   markDiagnosticEmbeddedRunStarted,
   markDiagnosticRunProgress,
-  resetDiagnosticRunActivityForTest,
 } from "./diagnostic-run-activity.js";
+import { markDiagnosticModelStartedForTest } from "./diagnostic-run-activity.test-support.js";
 import {
   testing as recoveryTesting,
   recoverStuckDiagnosticSession,
 } from "./diagnostic-stuck-session-recovery.runtime.js";
+import {
+  logSessionStateChange,
+  resetDiagnosticStateForTest,
+  startDiagnosticHeartbeat,
+} from "./diagnostic.js";
 
 async function expectPendingAfterEventLoopTurn(promise: Promise<unknown>): Promise<void> {
   let settled = false;
@@ -44,7 +54,93 @@ describe("stuck session recovery integration", () => {
     embeddedRunTesting.resetActiveEmbeddedRuns();
     replyRunTesting.resetReplyRunRegistry();
     resetCommandQueueStateForTest();
-    resetDiagnosticRunActivityForTest();
+    resetDiagnosticStateForTest();
+    resetDiagnosticEventsForTest();
+  });
+
+  it("recovers repeated paid-call-shaped activity once without duplicate queued delivery", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.parse("2026-08-04T03:00:00Z"));
+    const sessionKey = "agent:main:repeated-requests";
+    const sessionId = "repeated-requests-session";
+    const lane = resolveEmbeddedSessionLane(sessionKey);
+    const operation = createReplyOperation({ sessionKey, sessionId, resetTriggered: false });
+    operation.setPhase("running");
+    let markActiveStarted!: () => void;
+    const activeStarted = new Promise<void>((resolve) => {
+      markActiveStarted = resolve;
+    });
+    const active = enqueueCommandInLane(
+      lane,
+      () =>
+        new Promise<"aborted">((resolve) => {
+          markActiveStarted();
+          operation.abortSignal.addEventListener(
+            "abort",
+            () => {
+              operation.complete();
+              resolve("aborted");
+            },
+            { once: true },
+          );
+        }),
+      { warnAfterMs: Number.MAX_SAFE_INTEGER },
+    );
+    let deliveries = 0;
+    const queued = enqueueCommandInLane(
+      lane,
+      async () => {
+        deliveries += 1;
+        return "delivered";
+      },
+      { warnAfterMs: Number.MAX_SAFE_INTEGER },
+    );
+    await activeStarted;
+
+    const events: DiagnosticEventPayload[] = [];
+    const unsubscribe = onDiagnosticEvent((event) => events.push(event));
+    startDiagnosticHeartbeat(
+      { diagnostics: { enabled: true } },
+      {
+        recoverStuckSession: recoverStuckDiagnosticSession,
+        testTimings: { stuckSessionWarnMs: 30_000, stuckSessionAbortMs: 90_000 },
+      },
+    );
+    logSessionStateChange({ sessionId, sessionKey, state: "processing" });
+    markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey, runId: sessionId });
+    markDiagnosticModelStartedForTest({
+      sessionId,
+      sessionKey,
+      runId: sessionId,
+      provider: "mock",
+      model: "repeated-request-model",
+      observationUnit: "request",
+    });
+    for (let attempt = 2; attempt <= 3; attempt += 1) {
+      await vi.advanceTimersByTimeAsync(30_000);
+      markDiagnosticModelStartedForTest({
+        sessionId,
+        sessionKey,
+        runId: sessionId,
+        provider: "mock",
+        model: "repeated-request-model",
+        observationUnit: "request",
+      });
+    }
+    await vi.advanceTimersByTimeAsync(30_000);
+    await Promise.resolve();
+
+    await expect(active).resolves.toBe("aborted");
+    await expect(queued).resolves.toBe("delivered");
+    await vi.advanceTimersByTimeAsync(1);
+    expect(deliveries).toBe(1);
+    expect(getQueueSize(lane)).toBe(0);
+    expect(events.filter((event) => event.type === "session.recovery.requested")).toHaveLength(1);
+    expect(events.find((event) => event.type === "session.recovery.completed")).toMatchObject({
+      status: "aborted",
+      action: "abort_embedded_run",
+    });
+    unsubscribe();
   });
 
   it("does not reset a blocked lane while a reply operation is still active", async () => {

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -1051,6 +1051,67 @@ describe("stuck session diagnostics threshold", () => {
     );
   });
 
+  it("recovers repeated request attempts despite fresh mechanical activity", async () => {
+    const events: DiagnosticEventPayload[] = [];
+    const recoverStuckSession = vi.fn(() => new Promise<never>(() => {}));
+    const stuckSessionWarnMs = 30_000;
+    const stuckSessionAbortMs = 90_000;
+    const unsubscribe = onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+    try {
+      startDiagnosticHeartbeat(
+        { diagnostics: { enabled: true } },
+        {
+          recoverStuckSession,
+          testTimings: { stuckSessionWarnMs, stuckSessionAbortMs },
+        },
+      );
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+      markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main", runId: "run-1" });
+      markDiagnosticModelStartedForTest({
+        sessionId: "s1",
+        sessionKey: "main",
+        runId: "run-1",
+        provider: "mock",
+        model: "retrying-model",
+        observationUnit: "request",
+      });
+
+      for (let attempt = 2; attempt <= 6; attempt += 1) {
+        vi.advanceTimersByTime(30_000);
+        markDiagnosticModelStartedForTest({
+          sessionId: "s1",
+          sessionKey: "main",
+          runId: "run-1",
+          provider: "mock",
+          model: "retrying-model",
+          observationUnit: "request",
+        });
+      }
+    } finally {
+      unsubscribe();
+    }
+
+    expectRecordFields(
+      requireRecord(
+        events.find((event) => event.type === "session.stalled"),
+        "stalled event",
+      ),
+      {
+        classification: "stalled_agent_run",
+        reason: "repeated_model_requests_without_progress",
+        repeatedRequestNoProgressAgeMs: stuckSessionAbortMs,
+      },
+    );
+    expect(recoverStuckSession).toHaveBeenCalledTimes(1);
+    expectRecoveryCall(
+      recoverStuckSession,
+      { sessionId: "s1", sessionKey: "main", queueDepth: 0, allowActiveAbort: true },
+      ["ageMs", "stateGeneration"],
+    );
+  });
+
   it("reports silent model calls as long-running before the abort threshold", async () => {
     const events: DiagnosticEventPayload[] = [];
     const recoverStuckSession = vi.fn();

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -1080,6 +1080,12 @@ describe("stuck session diagnostics threshold", () => {
 
       for (let attempt = 2; attempt <= 6; attempt += 1) {
         vi.advanceTimersByTime(30_000);
+        logSessionStateChange({
+          sessionId: "s1",
+          sessionKey: "main",
+          state: "processing",
+          reason: "run_started",
+        });
         markDiagnosticModelStartedForTest({
           sessionId: "s1",
           sessionKey: "main",

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -1320,13 +1320,17 @@ export function startDiagnosticHeartbeat(
         activity,
         staleMs: stuckSessionWarnMs,
       });
+      const repeatedRequestAttention =
+        state.state === "processing" &&
+        (activity.repeatedRequestNoProgressAgeMs ?? 0) > stuckSessionWarnMs;
       if (
         (state.state === "processing" && ageMs > stuckSessionWarnMs) ||
+        repeatedRequestAttention ||
         idleQueuedRecoverableStall
       ) {
         const attentionAgeMs = idleQueuedRecoverableStall
           ? (activity.lastProgressAgeMs ?? ageMs)
-          : ageMs;
+          : Math.max(ageMs, activity.repeatedRequestNoProgressAgeMs ?? 0);
         const classification = logSessionAttention({
           sessionId: state.sessionId,
           sessionKey: state.sessionKey,

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -568,6 +568,10 @@ function isActiveAbortRecoveryEligible(params: {
   stuckSessionAbortMs: number;
 }): boolean {
   return (
+    (params.classification?.eventType === "session.stalled" &&
+      params.classification.classification === "stalled_agent_run" &&
+      params.activity?.hasActiveEmbeddedRun === true &&
+      (params.activity.repeatedRequestNoProgressAgeMs ?? 0) >= params.stuckSessionAbortMs) ||
     isStalledEmbeddedRunRecoveryEligible(params) ||
     isBlockedToolCallRecoveryEligible(params) ||
     isStalledModelCallRecoveryEligible(params)
@@ -953,6 +957,9 @@ function sessionAttentionFields(params: {
     ...(params.activity.activeToolAgeMs !== undefined
       ? { activeToolAgeMs: params.activity.activeToolAgeMs }
       : {}),
+    ...(params.activity.repeatedRequestNoProgressAgeMs !== undefined
+      ? { repeatedRequestNoProgressAgeMs: params.activity.repeatedRequestNoProgressAgeMs }
+      : {}),
     ...(terminalProgressStale ? { terminalProgressStale: true } : {}),
   };
 }
@@ -973,6 +980,11 @@ function formatSessionActivityLogFields(activity: DiagnosticSessionActivitySnaps
   }
   if (activity.activeToolAgeMs !== undefined) {
     fields.push(`activeToolAge=${Math.round(activity.activeToolAgeMs / 1000)}s`);
+  }
+  if (activity.repeatedRequestNoProgressAgeMs !== undefined) {
+    fields.push(
+      `repeatedRequestNoProgressAge=${Math.round(activity.repeatedRequestNoProgressAgeMs / 1000)}s`,
+    );
   }
   if (isTerminalDiagnosticProgressReason(activity.lastProgressReason)) {
     fields.push("terminalProgressStale=true");

--- a/test/e2e/qa-lab/runtime/gateway-repeated-request-recovery.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-repeated-request-recovery.e2e.test.ts
@@ -1,0 +1,180 @@
+import { randomUUID } from "node:crypto";
+import { setTimeout as sleep } from "node:timers/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import { startQaLiveLaneGateway } from "../../../../extensions/qa-lab/runtime-api.js";
+
+type StabilityEvent = {
+  seq?: unknown;
+  type?: unknown;
+  action?: unknown;
+  reason?: unknown;
+  outcome?: unknown;
+  ageMs?: unknown;
+};
+
+type StabilitySnapshot = {
+  lastSeq?: unknown;
+  events?: StabilityEvent[];
+};
+
+type GatewayChatRun = {
+  runId?: unknown;
+  status?: unknown;
+  stopReason?: unknown;
+};
+
+const RECOVERY_PROMPT =
+  "Repeated request recovery Gateway QA check. Keep attempting without producing a reply.";
+const QUEUED_PROMPT =
+  "Repeated request queued reply Gateway QA check. Reply with the fixture marker.";
+const RECOVERY_REASON = "repeated_model_requests_without_progress";
+const PRODUCTION_RECOVERY_BOUND_MS = 360_000;
+
+let harness: Awaited<ReturnType<typeof startQaLiveLaneGateway>> | undefined;
+
+afterEach(async () => {
+  await harness?.stop().catch(() => undefined);
+  harness = undefined;
+});
+
+async function readStability(
+  gateway: Awaited<ReturnType<typeof startQaLiveLaneGateway>>["gateway"],
+  sinceSeq?: number,
+): Promise<StabilitySnapshot> {
+  return (await gateway.call(
+    "diagnostics.stability",
+    { limit: 1000, ...(sinceSeq === undefined ? {} : { sinceSeq }) },
+    { timeoutMs: 10_000 },
+  )) as StabilitySnapshot;
+}
+
+async function waitForStability(
+  gateway: Awaited<ReturnType<typeof startQaLiveLaneGateway>>["gateway"],
+  sinceSeq: number,
+  predicate: (events: StabilityEvent[]) => boolean,
+  timeoutMs: number,
+): Promise<StabilityEvent[]> {
+  const startedAt = Date.now();
+  let latest: StabilityEvent[] = [];
+  while (Date.now() - startedAt < timeoutMs) {
+    latest = (await readStability(gateway, sinceSeq)).events ?? [];
+    if (predicate(latest)) {
+      return latest;
+    }
+    await sleep(1_000);
+  }
+  throw new Error(
+    `timed out after ${timeoutMs}ms waiting for stability events: ${JSON.stringify(latest)}`,
+  );
+}
+
+describe("Gateway repeated-request recovery", () => {
+  it(
+    "aborts the real stalled owner once and releases one queued followup",
+    { timeout: 510_000 },
+    async () => {
+      harness = await startQaLiveLaneGateway({
+        repoRoot: process.cwd(),
+        providerMode: "mock-openai",
+        primaryModel: "mock-openai/gpt-5.6-luna",
+        alternateModel: "mock-openai/gpt-5.6-luna-alt",
+        transport: {
+          requiredPluginIds: [],
+          createGatewayConfig: () => ({
+            messages: { queue: { mode: "followup" } },
+          }),
+        },
+        transportBaseUrl: "http://127.0.0.1",
+        controlUiEnabled: false,
+        mutateConfig: (config) => ({ ...config, diagnostics: { enabled: true } }),
+      });
+      const { gateway } = harness;
+
+      const baseline = await readStability(gateway);
+      const baselineSeq = typeof baseline.lastSeq === "number" ? baseline.lastSeq : 0;
+      const sessionKey = `agent:qa:repeated-request-recovery-${randomUUID()}`;
+      const active = (await gateway.call(
+        "chat.send",
+        {
+          sessionKey,
+          message: RECOVERY_PROMPT,
+          deliver: false,
+          idempotencyKey: randomUUID(),
+        },
+        { timeoutMs: 30_000 },
+      )) as GatewayChatRun;
+      expect(active).toMatchObject({ status: "started" });
+      expect(typeof active.runId).toBe("string");
+
+      await waitForStability(
+        gateway,
+        baselineSeq,
+        (events) => events.filter((event) => event.type === "model.call.started").length >= 2,
+        150_000,
+      );
+
+      const queued = (await gateway.call(
+        "chat.send",
+        {
+          sessionKey,
+          message: QUEUED_PROMPT,
+          queueMode: "followup",
+          deliver: false,
+          idempotencyKey: randomUUID(),
+        },
+        { timeoutMs: 30_000 },
+      )) as GatewayChatRun;
+      expect(queued).toMatchObject({ status: "started" });
+      expect(typeof queued.runId).toBe("string");
+
+      const events = await waitForStability(
+        gateway,
+        baselineSeq,
+        (records) => records.some((event) => event.type === "session.recovery.completed"),
+        350_000,
+      );
+      const stalled = events.filter(
+        (event) => event.type === "session.stalled" && event.reason === RECOVERY_REASON,
+      );
+      const requested = events.filter(
+        (event) => event.type === "session.recovery.requested" && event.reason === RECOVERY_REASON,
+      );
+      const completed = events.filter((event) => event.type === "session.recovery.completed");
+
+      expect(stalled).toHaveLength(1);
+      expect(stalled[0]?.ageMs).toEqual(expect.any(Number));
+      expect(stalled[0]?.ageMs as number).toBeGreaterThanOrEqual(PRODUCTION_RECOVERY_BOUND_MS);
+      expect(requested).toEqual([
+        expect.objectContaining({ action: "abort", reason: RECOVERY_REASON }),
+      ]);
+      expect(completed).toEqual([
+        expect.objectContaining({ action: "abort_embedded_run", outcome: "aborted" }),
+      ]);
+      expect(
+        events.filter((event) => event.type === "model.call.started").length,
+      ).toBeGreaterThanOrEqual(3);
+
+      const activeTerminal = (await gateway.call(
+        "agent.wait",
+        { runId: active.runId, timeoutMs: 30_000 },
+        { timeoutMs: 35_000 },
+      )) as GatewayChatRun;
+      expect(activeTerminal.status).not.toBe("ok");
+
+      const queuedTerminal = (await gateway.call(
+        "agent.wait",
+        { runId: queued.runId, timeoutMs: 30_000 },
+        { timeoutMs: 35_000 },
+      )) as GatewayChatRun;
+      expect(queuedTerminal.status).toBe("ok");
+
+      const finalEvents = (await readStability(gateway, baselineSeq)).events ?? [];
+      expect(
+        finalEvents.filter((event) => event.type === "session.recovery.requested"),
+      ).toHaveLength(1);
+      expect(
+        finalEvents.filter((event) => event.type === "session.recovery.completed"),
+      ).toHaveLength(1);
+    },
+  );
+});


### PR DESCRIPTION
Closes #119009

## What Problem This Solves

A run could repeatedly start paid provider requests without producing semantic output. Mechanical attempt completion, embedded-handle re-arming, and generic liveness prevented the typed no-progress clock from reaching the existing recovery owner, so queued user work remained blocked.

## Why This Change Was Made

Retain repeated-request evidence across replay-safe same-owner lifecycle gaps, record trusted model telemetry in the bounded stability projection, and let heartbeat classification enter the existing canonical recovery path from the typed clock. The QA mock now supports a delayed response.failed fixture so the real production bound is exercised without credentials.

## User Impact

Runs that repeat provider requests without semantic output are aborted and drained once after the existing recovery threshold, allowing one queued follow-up to complete. Healthy semantic progress, new owners, tools, CLI turns, policy waits, argument churn, and background work retain their existing behavior.

## Evidence

447 focused local assertions passed. Blacksmith Testbox exact-content private-QA build passed. Full changed gate passed all six lanes in 30m52.9s (Actions 30962160622). Credential-free mock-openai + ephemeral Gateway E2E passed in 401.6s after the 360s production bound: >=3 request starts, one stall, one abort request/completion, stalled run non-ok, queued run ok, no duplicate recovery (Actions 30964498864).