### PR TITLE
fix: startup migration refusal suggests restarting a container

### DIFF
--- a/src/commands/doctor-config-preflight.process.test.ts
+++ b/src/commands/doctor-config-preflight.process.test.ts
@@ -16,6 +16,8 @@ import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js
 
 const STARTUP_REFUSAL =
   "OpenClaw startup migrations did not complete cleanly; refusing to report the gateway ready.";
+const STARTUP_RECOVERY =
+  'Run "openclaw doctor --fix" against the same state/config, then restart the gateway.';
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function runIsolatedModuleScript(env: NodeJS.ProcessEnv, script: string) {
@@ -130,6 +132,7 @@ describe("gateway startup-migration refusal", () => {
       expect(result.status, output).toBe(1);
       expect(result.signal, output).toBeNull();
       expect(result.stderr).toContain(STARTUP_REFUSAL);
+      expect(result.stderr).toContain(STARTUP_RECOVERY);
       expect(result.stderr.split(STARTUP_REFUSAL)).toHaveLength(2);
       expect(result.stderr).not.toContain("[openclaw] Could not start the CLI.");
       expect(hasActiveStartupMigrationLease({ env })).toBe(false);

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -169,7 +169,7 @@ function formatStartupMigrationFailure(params: { warnings: string[]; blockers: s
   return [
     "OpenClaw startup migrations did not complete cleanly; refusing to report the gateway ready.",
     ...details,
-    'Run "openclaw doctor --fix" against the mounted state/config, then restart the container.',
+    'Run "openclaw doctor --fix" against the same state/config, then restart the gateway.',
   ].join("\n");
 }
 


### PR DESCRIPTION
Related: #112395

## What Problem This Solves

Fixes an issue where operators using npm, launchd, systemd, or other non-container installs could be told to restart a container when startup migrations refused Gateway readiness.

## Why This Change Was Made

The refusal text originated in a container-image migration flow but now serves every Gateway startup method. The remediation now tells operators to run `openclaw doctor --fix` against the same state/config and restart the Gateway, without assuming a container or service manager.

This is intentionally separate from #114678: it changes only operator guidance and does not alter state-directory classification or migration behavior.

AI-assisted: yes.

## User Impact

Operators now receive recovery guidance that is accurate for managed services, foreground processes, containers, and externally supervised Gateways.

## Evidence

- `node scripts/run-vitest.mjs src/commands/doctor-config-preflight.process.test.ts` — 2 tests passed, including the real-process refusal output, exit status, single emission, and lease cleanup.
- `./node_modules/.bin/oxfmt --check --threads=1 src/commands/doctor-config-preflight.ts src/commands/doctor-config-preflight.process.test.ts` — passed.
- `node scripts/run-oxlint.mjs src/commands/doctor-config-preflight.ts src/commands/doctor-config-preflight.process.test.ts` — passed.
- `git diff --check` — passed.
- Source-blind behavior validation — all six refusal contract clauses passed.
- Codex autoreview — clean, no accepted/actionable findings.
- `node scripts/check-changed.mjs -- ...` could not acquire a ready Crabbox provider; the targeted trusted-source local fallback checks above passed.

### Real non-container Gateway proof

Ran the actual foreground Gateway from the PR head with an isolated config/state root and a real conflicting plugin-state sidecar. This is a non-container process; temporary paths were omitted from the capture.

```text
[state/db] state database schema migration pending; verifying integrity first
[state-migrations] Legacy state migration warnings:
- Left plugin-state sidecar in place because 1 row differs from shared state without a newer canonical timestamp. First key: discord/components/interaction:1
OpenClaw startup migrations did not complete cleanly; refusing to report the gateway ready.
- Left plugin-state sidecar in place because 1 row differs from shared state without a newer canonical timestamp. First key: discord/components/interaction:1
Run "openclaw doctor --fix" against the same state/config, then restart the gateway.
[ELIFECYCLE] Command failed with exit code 1.

__PROOF_EXIT_CODE__=1
__PROOF_MODE__=foreground-non-container
```

The capture confirms the operator-visible refusal uses install-neutral guidance, exits 1, and contains no `restart the container` instruction.
