### PR TITLE
fix(slack): apply channel tool restrictions to normalized session IDs

### DIFF
--- a/extensions/slack/src/group-policy.test.ts
+++ b/extensions/slack/src/group-policy.test.ts
@@ -54,6 +54,72 @@ describe("slack group policy", () => {
     expect(wildcardTools).toEqual({ deny: ["exec"] });
   });
 
+  it.each([
+    { configuredChannelId: "C01234567", groupId: "c01234567" },
+    { configuredChannelId: "c01234567", groupId: "C01234567" },
+    { configuredChannelId: "channel:C01234567", groupId: "c01234567" },
+    { configuredChannelId: "channel:c01234567", groupId: "C01234567" },
+  ])(
+    "applies $configuredChannelId channel and sender policies to session $groupId",
+    ({ configuredChannelId, groupId }) => {
+      const channelPolicyCfg = {
+        channels: {
+          slack: {
+            channels: {
+              [configuredChannelId]: {
+                requireMention: false,
+                tools: { allow: ["message.send"] },
+                toolsBySender: {
+                  "id:user:alice": { allow: ["sessions.list"] },
+                },
+              },
+              "*": {
+                requireMention: true,
+                tools: { deny: ["exec"] },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig;
+
+      expect(resolveSlackGroupRequireMention({ cfg: channelPolicyCfg, groupId })).toBe(false);
+      expect(
+        resolveSlackGroupToolPolicy({
+          cfg: channelPolicyCfg,
+          groupId,
+          senderId: "user:bob",
+        }),
+      ).toEqual({ allow: ["message.send"] });
+      expect(
+        resolveSlackGroupToolPolicy({
+          cfg: channelPolicyCfg,
+          groupId,
+          senderId: "user:alice",
+        }),
+      ).toEqual({ allow: ["sessions.list"] });
+    },
+  );
+
+  it("prefers the exact channel ID when case variants have different policies", () => {
+    const caseSensitiveCfg = {
+      channels: {
+        slack: {
+          channels: {
+            c01234567: { tools: { allow: ["message.send"] } },
+            C01234567: { tools: { deny: ["exec"] } },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(resolveSlackGroupToolPolicy({ cfg: caseSensitiveCfg, groupId: "c01234567" })).toEqual({
+      allow: ["message.send"],
+    });
+    expect(resolveSlackGroupToolPolicy({ cfg: caseSensitiveCfg, groupId: "C01234567" })).toEqual({
+      deny: ["exec"],
+    });
+  });
+
   it("keeps wildcard fields hidden by a matched whole entry", () => {
     const partialCfg = {
       channels: {

--- a/extensions/slack/src/group-policy.ts
+++ b/extensions/slack/src/group-policy.ts
@@ -9,6 +9,7 @@ import {
   type ScopeNode,
   type ScopeTree,
 } from "openclaw/plugin-sdk/channel-policy";
+import { buildChannelKeyCandidates } from "openclaw/plugin-sdk/channel-targets";
 import { normalizeHyphenSlug } from "openclaw/plugin-sdk/string-normalization-runtime";
 import { mergeSlackAccountConfig, resolveDefaultSlackAccountId } from "./accounts.js";
 
@@ -17,6 +18,24 @@ type SlackChannelPolicyEntry = {
   tools?: GroupToolPolicyConfig;
   toolsBySender?: GroupToolPolicyBySenderConfig;
 };
+
+export function buildSlackChannelIdCandidates(channelId: string | null | undefined): string[] {
+  const trimmedId = channelId?.trim();
+  if (!trimmedId) {
+    return [];
+  }
+  const lowercaseId = trimmedId.toLowerCase();
+  const uppercaseId = trimmedId.toUpperCase();
+  // Inbound Slack IDs are uppercase, but persisted session group IDs are lowercase.
+  return buildChannelKeyCandidates(
+    trimmedId,
+    lowercaseId,
+    uppercaseId,
+    `channel:${trimmedId}`,
+    `channel:${lowercaseId}`,
+    `channel:${uppercaseId}`,
+  );
+}
 
 export function buildSlackChannelPolicyScope<T extends ScopeNode>(params: {
   channels?: Record<string, T>;
@@ -49,14 +68,13 @@ function resolveSlackGroupPolicyScope(params: ChannelGroupContext) {
   const channels = mergeSlackAccountConfig(params.cfg, accountId).channels as
     | Record<string, SlackChannelPolicyEntry>
     | undefined;
-  const channelId = params.groupId?.trim();
   const channelName = params.groupChannel?.replace(/^#/, "");
-  const candidates = [
-    channelId,
+  const candidates = buildChannelKeyCandidates(
+    ...buildSlackChannelIdCandidates(params.groupId),
     channelName ? `#${channelName}` : undefined,
     channelName,
     normalizeHyphenSlug(channelName),
-  ].filter((candidate): candidate is string => Boolean(candidate));
+  );
   return buildSlackChannelPolicyScope({ channels, candidates });
 }
 

--- a/extensions/slack/src/monitor/channel-config.ts
+++ b/extensions/slack/src/monitor/channel-config.ts
@@ -10,8 +10,7 @@ import type {
   SlackChannelConfig,
 } from "openclaw/plugin-sdk/config-contracts";
 import { mergePairLoopGuardConfig } from "openclaw/plugin-sdk/pair-loop-guard-runtime";
-import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { buildSlackChannelPolicyScope } from "../group-policy.js";
+import { buildSlackChannelIdCandidates, buildSlackChannelPolicyScope } from "../group-policy.js";
 import { normalizeSlackSlug } from "./allow-list.js";
 
 export type SlackChannelConfigResolved = {
@@ -83,22 +82,8 @@ export function resolveSlackChannelConfig(params: {
   const keys = channelKeys ?? Object.keys(entries);
   const normalizedName = channelName ? normalizeSlackSlug(channelName) : "";
   const directName = channelName ? channelName.trim() : "";
-  // Slack always delivers channel IDs in uppercase (e.g. C0ABC12345) but
-  // operators commonly write them in lowercase in their config. Add both
-  // case variants so the lookup is case-insensitive without requiring a full
-  // entry-scan. buildChannelKeyCandidates deduplicates identical keys.
-  const channelIdLower = normalizeLowercaseStringOrEmpty(channelId);
-  const channelIdUpper = channelId.toUpperCase();
-  const channelTarget = `channel:${channelId}`;
-  const channelTargetLower = `channel:${channelIdLower}`;
-  const channelTargetUpper = `channel:${channelIdUpper}`;
   const candidates = buildChannelKeyCandidates(
-    channelId,
-    channelIdLower !== channelId ? channelIdLower : undefined,
-    channelIdUpper !== channelId ? channelIdUpper : undefined,
-    channelTarget,
-    channelTargetLower !== channelTarget ? channelTargetLower : undefined,
-    channelTargetUpper !== channelTarget ? channelTargetUpper : undefined,
+    ...buildSlackChannelIdCandidates(channelId),
     allowNameMatching ? (channelName ? `#${directName}` : undefined) : undefined,
     allowNameMatching ? directName : undefined,
     allowNameMatching ? normalizedName : undefined,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

A Slack channel ID can enter configuration as uppercase `C01234567` while the
real Slack plugin persists its session target as lowercase
`channel:c01234567`. Ingress successfully finds the configured channel, but the
later group-policy lookup misses it.

The miss silently drops channel-scoped `tools.allow`, sender-specific
`toolsBySender`, and `requireMention`. In an actual production-plugin + core
tool-filter run against the parent revision, both a regular member and an owner
incorrectly received `message`, `web_search`, `session_status`, `exec`, and
`gateway`; the configured channel allowed only `message`/`web_search`, with a
separate `message`/`session_status` owner override.

## Why This Change Was Made

Use one canonical Slack channel-ID candidate builder at both existing ownership
boundaries: ingress channel configuration and Slack group-policy resolution.
Bare IDs, `channel:`-prefixed IDs, uppercase IDs, and lowercase IDs now resolve
the same channel without introducing a new config surface, broadening access,
changing sender authorization, or changing exact-match/wildcard precedence.

## User Impact

Slack channel allowlists, sender-specific policies, and mention requirements
remain effective after session-target normalization. Existing exact-case match
precedence, wildcard isolation, channel-name policy, and owner override behavior
are preserved.

## Evidence

### Real production-plugin and core-policy proof: parent red → PR head green

The same standalone command loads the actual Slack plugin, registers it with
the real plugin registry, creates the actual folded session target, resolves
actual Slack ingress and mention policies, calls core `resolveGroupToolPolicy`,
and applies core `filterToolsByPolicy`. No policy resolver or Slack plugin is
mocked.

Run the collapsed command below from the parent checkout with
`OPENCLAW_POLICY_PROOF_EXPECTED=parent-red`, then from this PR checkout with
`OPENCLAW_POLICY_PROOF_EXPECTED=candidate-green`.

**Parent `8d2996937f85786a08e0163d4e62ab8f0cfa903f`:**

```json
{"proof":"real-slack-plugin-and-core-tool-policy","expected":"parent-red","head":"8d2996937f85786a08e0163d4e62ab8f0cfa903f","configuredId":"C01234567","persistedTarget":"channel:c01234567","ingressRequireMention":false,"sessionRequireMention":true,"member":{"policy":null,"tools":["message","web_search","session_status","exec","gateway"]},"owner":{"policy":null,"tools":["message","web_search","session_status","exec","gateway"]}}
```

**PR head `a56436201cf1258e0bb6af9dad3375e00d6247a5`:**

```json
{"proof":"real-slack-plugin-and-core-tool-policy","expected":"candidate-green","head":"a56436201cf1258e0bb6af9dad3375e00d6247a5","configuredId":"C01234567","persistedTarget":"channel:c01234567","ingressRequireMention":false,"sessionRequireMention":false,"member":{"policy":{"allow":["message","web_search"]},"tools":["message","web_search"]},"owner":{"policy":{"allow":["message","session_status"]},"tools":["message","session_status"]}}
```

<details>
<summary>Exact portable runtime-proof command</summary>

Set `OPENCLAW_POLICY_PROOF_EXPECTED=parent-red` or `candidate-green` and run
from the corresponding repository root:

```bash
node --import tsx --input-type=module -e '
import assert from "node:assert/strict";
import { execFileSync } from "node:child_process";
import { slackPlugin } from "./extensions/slack/src/channel.ts";
import { resolveSlackChannelConfig } from "./extensions/slack/src/monitor/channel-config.ts";
import { createTestRegistry, setActivePluginRegistry } from "./src/plugin-sdk/plugin-test-runtime.ts";
import { filterToolsByPolicy, resolveGroupToolPolicy } from "./src/agents/agent-tools.policy.ts";

const expected = process.env.OPENCLAW_POLICY_PROOF_EXPECTED;
assert.ok(expected === "parent-red" || expected === "candidate-green");
const configuredId = "C01234567";
const cfg = { channels: { slack: { channels: { [configuredId]: {
  requireMention: false,
  tools: { allow: ["message", "web_search"] },
  toolsBySender: { "id:owner": { allow: ["message", "session_status"] } },
} } } } };
setActivePluginRegistry(createTestRegistry([{ pluginId: "slack", source: "proof", plugin: slackPlugin }]));
const persistedTarget = slackPlugin.messaging.resolveSessionTarget({ id: configuredId });
const groupId = persistedTarget.replace(/^channel:/, "");
assert.equal(groupId, configuredId.toLowerCase());
const sessionKey = `agent:main:slack:channel:${groupId}:thread:1700000000.000001`;
const ingress = resolveSlackChannelConfig({ channelId: configuredId, channels: cfg.channels.slack.channels });
const policy = senderId => resolveGroupToolPolicy({ config: cfg, sessionKey, messageProvider: "slack", senderId });
const tools = ["message", "web_search", "session_status", "exec", "gateway"].map(name => ({ name }));
const memberPolicy = policy("member");
const ownerPolicy = policy("owner");
const memberTools = filterToolsByPolicy(tools, memberPolicy).map(tool => tool.name);
const ownerTools = filterToolsByPolicy(tools, ownerPolicy).map(tool => tool.name);
const mentionRequired = slackPlugin.groups.resolveRequireMention({ cfg, groupId });
assert.equal(ingress.requireMention, false);
if (expected === "parent-red") {
  assert.equal(memberPolicy, undefined);
  assert.equal(ownerPolicy, undefined);
  assert.equal(mentionRequired, true);
  assert.ok(memberTools.includes("exec") && memberTools.includes("session_status"));
} else {
  assert.deepEqual(memberTools, ["message", "web_search"]);
  assert.deepEqual(ownerTools, ["message", "session_status"]);
  assert.equal(mentionRequired, false);
}
console.log(JSON.stringify({
  proof: "real-slack-plugin-and-core-tool-policy",
  expected,
  head: execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim(),
  configuredId,
  persistedTarget,
  ingressRequireMention: ingress.requireMention,
  sessionRequireMention: mentionRequired,
  member: { policy: memberPolicy ?? null, tools: memberTools },
  owner: { policy: ownerPolicy ?? null, tools: ownerTools },
}));
'
```

</details>

### Regression and static verification

- `node scripts/run-vitest.mjs extensions/slack/src/group-policy.test.ts extensions/slack/src/monitor/monitor.test.ts`: **2 files passed, 38 tests passed**.
- Case directions, bare/`channel:` IDs, owner overrides, mention requirements,
  wildcard isolation, and exact-case precedence have focused regression cases.
- Scoped formatting and repository oxlint checks passed.
- The complete extensions TypeScript check produced **zero diagnostics in the
  three changed files**; unrelated existing dependency/type diagnostics remain
  outside this change.
- Fresh structured code review found no accepted or actionable findings.
- AI-assisted implementation; the author reviewed and verified the change.
