### PR TITLE
refactor(gateway): consolidate usage reporting and caches

### DIFF
--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -71,10 +71,8 @@ import { loadUsageStatusStaleWhileRevalidate } from "./models-auth-status-usage-
 import type { GatewayRequestHandlers, RespondFn } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
-const COST_USAGE_CACHE_TTL_MS = 30_000;
-const COST_USAGE_CACHE_MAX = 256;
-const SESSIONS_USAGE_CACHE_TTL_MS = 30_000;
-const SESSIONS_USAGE_CACHE_MAX = 256;
+const USAGE_CACHE_TTL_MS = 30_000;
+const USAGE_CACHE_MAX = 256;
 const USAGE_AGENT_LOAD_CONCURRENCY = 12;
 
 async function runUsageAgentTasks<T>(tasks: Array<() => Promise<T>>): Promise<T[]> {
@@ -110,22 +108,15 @@ type DateParts = { year: number; monthIndex: number; day: number };
 
 const MAX_CONSECUTIVE_SKIPPED_TIME_ZONE_DAYS = 1;
 
-type CostUsageCacheEntry = {
-  summary?: CostUsageSummary;
+type UsageCacheEntry<T extends object> = {
+  configRef?: object;
+  value?: T;
   updatedAt?: number;
-  inFlight?: Promise<CostUsageSummary>;
+  inFlight?: Promise<T>;
 };
 
-const costUsageCache = new Map<string, CostUsageCacheEntry>();
-
-type SessionsUsageCacheEntry = {
-  configRef: object;
-  result?: SessionsUsageResult;
-  updatedAt?: number;
-  inFlight?: Promise<SessionsUsageResult>;
-};
-
-const sessionsUsageCache = new Map<string, SessionsUsageCacheEntry>();
+const costUsageCache = new Map<string, UsageCacheEntry<CostUsageSummary>>();
+const sessionsUsageCache = new Map<string, UsageCacheEntry<SessionsUsageResult>>();
 
 class SessionsUsageInvalidRequestError extends Error {}
 
@@ -171,48 +162,78 @@ function resolveSessionUsageTarget(
   return sessionFile ? { entry, agentId, sessionId, sessionFile } : undefined;
 }
 
-function findCostUsageCacheEvictionKey(): string | undefined {
-  for (const [key, entry] of costUsageCache) {
-    // Prefer evicting settled entries so duplicate callers can still join active loads.
-    if (!entry.inFlight) {
-      return key;
+function setUsageCache<T extends object>(
+  cache: Map<string, UsageCacheEntry<T>>,
+  cacheKey: string,
+  entry: UsageCacheEntry<T>,
+): void {
+  if (!cache.has(cacheKey) && cache.size >= USAGE_CACHE_MAX) {
+    let evictionKey = cache.keys().next().value;
+    // Preserve active loads whenever a settled entry can be evicted instead.
+    for (const [key, candidate] of cache) {
+      if (!candidate.inFlight) {
+        evictionKey = key;
+        break;
+      }
+    }
+    if (evictionKey !== undefined) {
+      cache.delete(evictionKey);
     }
   }
-  return costUsageCache.keys().next().value;
+  cache.set(cacheKey, entry);
 }
 
-// Keep the cache bounded while preserving in-flight request coalescing when a
-// settled entry is available to evict.
-function setCostUsageCache(cacheKey: string, entry: CostUsageCacheEntry): void {
-  if (!costUsageCache.has(cacheKey) && costUsageCache.size >= COST_USAGE_CACHE_MAX) {
-    const evictKey = findCostUsageCacheEvictionKey();
-    if (evictKey !== undefined) {
-      costUsageCache.delete(evictKey);
-    }
+async function loadUsageResultCached<T extends object>(params: {
+  cache: Map<string, UsageCacheEntry<T>>;
+  cacheKey: string;
+  configRef?: object;
+  load: () => Promise<T>;
+  isComplete?: (value: T) => boolean;
+}): Promise<T> {
+  const { cache, cacheKey, configRef } = params;
+  const candidate = cache.get(cacheKey);
+  const cached =
+    configRef === undefined || candidate?.configRef === configRef ? candidate : undefined;
+  if (cached?.value && cached.updatedAt && Date.now() - cached.updatedAt < USAGE_CACHE_TTL_MS) {
+    return cached.value;
   }
-  costUsageCache.set(cacheKey, entry);
-}
+  if (cached?.inFlight) {
+    return cached.value && cached.updatedAt ? cached.value : await cached.inFlight;
+  }
 
-function findSessionsUsageCacheEvictionKey(): string | undefined {
-  for (const [key, entry] of sessionsUsageCache) {
-    // Prefer evicting settled entries so duplicate callers can still join active loads.
-    if (!entry.inFlight) {
-      return key;
-    }
-  }
-  return sessionsUsageCache.keys().next().value;
-}
+  const entry: UsageCacheEntry<T> = cached ?? { ...(configRef && { configRef }) };
+  const inFlight = params
+    .load()
+    .then((value) => {
+      if (cache.get(cacheKey) !== entry) {
+        return value;
+      }
+      if (params.isComplete?.(value) ?? true) {
+        entry.value = value;
+        entry.updatedAt = Date.now();
+      } else if (!entry.value) {
+        // Partial snapshots serve cold callers without masking the next refresh.
+        entry.value = value;
+        delete entry.updatedAt;
+      }
+      return value;
+    })
+    .catch((error: unknown) => {
+      if (entry.value) {
+        return entry.value;
+      }
+      throw error;
+    })
+    .finally(() => {
+      const current = cache.get(cacheKey);
+      if (current === entry && current.inFlight === inFlight) {
+        current.inFlight = undefined;
+      }
+    });
 
-// Session reports have high-cardinality date and grouping axes. Bound the
-// short-lived result cache without breaking in-flight request coalescing.
-function setSessionsUsageCache(cacheKey: string, entry: SessionsUsageCacheEntry): void {
-  if (!sessionsUsageCache.has(cacheKey) && sessionsUsageCache.size >= SESSIONS_USAGE_CACHE_MAX) {
-    const evictKey = findSessionsUsageCacheEvictionKey();
-    if (evictKey !== undefined) {
-      sessionsUsageCache.delete(evictKey);
-    }
-  }
-  sessionsUsageCache.set(cacheKey, entry);
+  entry.inFlight = inFlight;
+  setUsageCache(cache, cacheKey, entry);
+  return entry.value && entry.updatedAt ? entry.value : await inFlight;
 }
 
 function usageDayBucketCacheKey(dayBucket: UsageDailyBucket | undefined): string {
@@ -258,62 +279,14 @@ async function loadSessionsUsageResultCached(
     load: () => Promise<SessionsUsageResult>;
   },
 ): Promise<SessionsUsageResult> {
-  const cacheKey = sessionsUsageCacheKey(params);
-  const now = Date.now();
-  const candidate = sessionsUsageCache.get(cacheKey);
-  const cached = candidate?.configRef === params.configRef ? candidate : undefined;
-  if (cached?.result && cached.updatedAt && now - cached.updatedAt < SESSIONS_USAGE_CACHE_TTL_MS) {
-    return cached.result;
-  }
-
-  if (cached?.inFlight) {
-    if (cached.result && cached.updatedAt) {
-      return cached.result;
-    }
-    return await cached.inFlight;
-  }
-
-  const entry: SessionsUsageCacheEntry = cached ?? { configRef: params.configRef };
-  const inFlight = params
-    .load()
-    .then((result) => {
-      if (sessionsUsageCache.get(cacheKey) !== entry) {
-        return result;
-      }
-      // The lower cache returns partial rows while its own refresh runs. Do not
-      // pin that intentionally incomplete snapshot behind the outer 30s TTL.
-      const isComplete = !result.cacheStatus || result.cacheStatus.status === "fresh";
-      if (isComplete) {
-        entry.result = result;
-        entry.updatedAt = Date.now();
-      } else if (!entry.result) {
-        // Cold callers still need the partial response, but a stale complete
-        // result remains the safer SWR value until a complete refresh lands.
-        entry.result = result;
-        delete entry.updatedAt;
-      }
-      return result;
-    })
-    .catch((err: unknown) => {
-      if (entry.result) {
-        return entry.result;
-      }
-      throw err;
-    })
-    .finally(() => {
-      const current = sessionsUsageCache.get(cacheKey);
-      if (current === entry && current.inFlight === inFlight) {
-        current.inFlight = undefined;
-      }
-    });
-
-  entry.inFlight = inFlight;
-  setSessionsUsageCache(cacheKey, entry);
-
-  if (entry.result && entry.updatedAt) {
-    return entry.result;
-  }
-  return await inFlight;
+  return await loadUsageResultCached({
+    cache: sessionsUsageCache,
+    cacheKey: sessionsUsageCacheKey(params),
+    configRef: params.configRef,
+    load: params.load,
+    // Incomplete lower-cache snapshots must not acquire the outer freshness TTL.
+    isComplete: (result) => !result.cacheStatus || result.cacheStatus.status === "fresh",
+  });
 }
 
 function resolveSessionUsageFileOrRespond(
@@ -690,6 +663,24 @@ const resolveDateRange = (
   return resolveTrailingDays(todayDateParts, 30, interpretation);
 };
 
+function resolveUsageDateRangeOrRespond(
+  params: Parameters<typeof resolveDateRange>[0],
+  respond: RespondFn,
+): { interpretation: DateInterpretation; range: DateRange } | null {
+  const interpretation = resolveDateInterpretation(params);
+  if (!interpretation.ok) {
+    respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, interpretation.error));
+    return null;
+  }
+
+  const range = resolveDateRange(params, interpretation.value);
+  if (!range.ok) {
+    respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, range.error));
+    return null;
+  }
+  return { interpretation: interpretation.value, range: range.value };
+}
+
 type DiscoveredSessionWithAgent = DiscoveredSession & { agentId: string };
 type UsageGroupingMode = "instance" | "family";
 
@@ -796,14 +787,6 @@ function resolveUsageFamilySessionIds(entry: SessionEntry | undefined, currentSe
   return addUniqueSessionIds([], [currentSessionId, ...(entry?.usageFamilySessionIds ?? [])]);
 }
 
-function resolveUsageFamilyKey(params: {
-  key: string;
-  entry: SessionEntry | undefined;
-  sessionId: string;
-}): string {
-  return params.entry?.usageFamilyKey ?? params.key ?? params.sessionId;
-}
-
 function maybeMergeFamilyEntry(params: {
   mergedEntries: MergedEntry[];
   base: MergedEntry;
@@ -819,24 +802,13 @@ function maybeMergeFamilyEntry(params: {
     params.base.sessionId,
   );
   // Family rows keep historical transcript ids so usage survives session resets.
-  const sessionFamilyKey = resolveUsageFamilyKey({
-    key: params.base.key,
-    entry: params.base.storeEntry,
-    sessionId: params.base.sessionId,
-  });
   params.mergedEntries.push({
     ...params.base,
     scope: "family",
-    sessionFamilyKey,
+    sessionFamilyKey: params.base.storeEntry?.usageFamilyKey ?? params.base.key,
     currentSessionId: params.base.sessionId,
     includedSessionIds,
   });
-}
-
-function createEmptySessionCostSummary(): SessionCostSummary {
-  return {
-    ...createEmptyCostUsageTotals(),
-  };
 }
 
 function mergeSessionUsageInto(target: SessionCostSummary, source: SessionCostSummary): void {
@@ -862,11 +834,11 @@ function mergeSessionUsageInto(target: SessionCostSummary, source: SessionCostSu
     target.activityDates = Array.from(activityDates).toSorted();
   }
 
-  target.dailyBreakdown = mergeDailyRows(target.dailyBreakdown, source.dailyBreakdown, [
+  target.dailyBreakdown = mergeUsageRows(target.dailyBreakdown, source.dailyBreakdown, [
     "tokens",
     "cost",
   ]);
-  target.dailyMessageCounts = mergeDailyRows(target.dailyMessageCounts, source.dailyMessageCounts, [
+  target.dailyMessageCounts = mergeUsageRows(target.dailyMessageCounts, source.dailyMessageCounts, [
     "total",
     "user",
     "assistant",
@@ -874,12 +846,12 @@ function mergeSessionUsageInto(target: SessionCostSummary, source: SessionCostSu
     "toolResults",
     "errors",
   ]);
-  target.utcQuarterHourMessageCounts = mergeQuarterRows(
+  target.utcQuarterHourMessageCounts = mergeUsageRows(
     target.utcQuarterHourMessageCounts,
     source.utcQuarterHourMessageCounts,
     ["total", "user", "assistant", "toolCalls", "toolResults", "errors"],
   );
-  target.utcQuarterHourTokenUsage = mergeQuarterRows(
+  target.utcQuarterHourTokenUsage = mergeUsageRows(
     target.utcQuarterHourTokenUsage,
     source.utcQuarterHourTokenUsage,
     ["input", "output", "cacheRead", "cacheWrite", "totalTokens", "totalCost"],
@@ -892,36 +864,14 @@ function mergeSessionUsageInto(target: SessionCostSummary, source: SessionCostSu
   target.latency = mergeLatency(target.latency, source.latency);
 }
 
-function mergeDailyRows<T extends { date: string }>(
+function mergeUsageRows<T extends { date: string; quarterIndex?: number }>(
   left: T[] | undefined,
   right: T[] | undefined,
   fields: Array<keyof T>,
 ): T[] | undefined {
   const map = new Map<string, T>();
   for (const row of [...(left ?? []), ...(right ?? [])]) {
-    const existing = map.get(row.date);
-    if (!existing) {
-      map.set(row.date, { ...row });
-      continue;
-    }
-    for (const field of fields) {
-      existing[field] = (((existing[field] as number | undefined) ?? 0) +
-        ((row[field] as number | undefined) ?? 0)) as T[keyof T];
-    }
-  }
-  return map.size > 0
-    ? Array.from(map.values()).toSorted((a, b) => a.date.localeCompare(b.date))
-    : undefined;
-}
-
-function mergeQuarterRows<T extends { date: string; quarterIndex: number }>(
-  left: T[] | undefined,
-  right: T[] | undefined,
-  fields: Array<keyof T>,
-): T[] | undefined {
-  const map = new Map<string, T>();
-  for (const row of [...(left ?? []), ...(right ?? [])]) {
-    const key = `${row.date}:${row.quarterIndex}`;
+    const key = row.quarterIndex === undefined ? row.date : `${row.date}:${row.quarterIndex}`;
     const existing = map.get(key);
     if (!existing) {
       map.set(key, { ...row });
@@ -934,7 +884,7 @@ function mergeQuarterRows<T extends { date: string; quarterIndex: number }>(
   }
   return map.size > 0
     ? Array.from(map.values()).toSorted(
-        (a, b) => a.date.localeCompare(b.date) || a.quarterIndex - b.quarterIndex,
+        (a, b) => a.date.localeCompare(b.date) || (a.quarterIndex ?? 0) - (b.quarterIndex ?? 0),
       )
     : undefined;
 }
@@ -988,7 +938,7 @@ function mergeModelUsage(
         provider: entry.provider,
         model: entry.model,
         count: 0,
-        totals: createEmptySessionCostSummary(),
+        totals: createEmptyCostUsageTotals(),
       } as SessionModelUsage);
     existing.count += entry.count;
     addCostUsageTotals(existing.totals, entry.totals);
@@ -1079,69 +1029,27 @@ async function loadCostUsageSummaryCached(params: {
     : normalizeAgentId(params.agentId ?? resolveDefaultAgentId(params.config));
   const dayBucketKey = usageDayBucketCacheKey(params.dayBucket);
   const cacheKey = `${allAgents ? "all" : `agent:${agentId}`}:${params.startMs}-${params.endMs}:${dayBucketKey}`;
-  const now = Date.now();
-  const cached = costUsageCache.get(cacheKey);
-  if (cached?.summary && cached.updatedAt && now - cached.updatedAt < COST_USAGE_CACHE_TTL_MS) {
-    return cached.summary;
-  }
-
-  if (cached?.inFlight) {
-    if (cached.summary) {
-      return cached.summary;
-    }
-    return await cached.inFlight;
-  }
-
-  const entry: CostUsageCacheEntry = cached ?? {};
-  const inFlight = (
-    allAgents
-      ? loadAllAgentCostUsageSummary({
-          startMs: params.startMs,
-          endMs: params.endMs,
-          dayBucket: params.dayBucket,
-          config: params.config,
-        })
-      : loadCostUsageSummaryFromCache({
-          startMs: params.startMs,
-          endMs: params.endMs,
-          dayBucket: params.dayBucket,
-          config: params.config,
-          agentId: expectDefined(agentId, "non-aggregate usage agent id"),
-          requestRefresh: true,
-          refreshMode: "background",
-        })
-  )
-    .then((summary) => {
-      // Refresh work is independent; retaining freshness prevents fleet rescans while it runs.
-      // The short TTL still picks up a completed refresh promptly.
-      setCostUsageCache(cacheKey, {
-        summary,
-        updatedAt: Date.now(),
-      });
-      return summary;
-    })
-    .catch((err: unknown) => {
-      if (entry.summary) {
-        // Serve the stale summary if background refresh fails; callers asked for usage, not repair.
-        return entry.summary;
-      }
-      throw err;
-    })
-    .finally(() => {
-      const current = costUsageCache.get(cacheKey);
-      if (current?.inFlight === inFlight) {
-        current.inFlight = undefined;
-        setCostUsageCache(cacheKey, current);
-      }
-    });
-
-  entry.inFlight = inFlight;
-  setCostUsageCache(cacheKey, entry);
-
-  if (entry.summary) {
-    return entry.summary;
-  }
-  return await inFlight;
+  return await loadUsageResultCached({
+    cache: costUsageCache,
+    cacheKey,
+    load: () =>
+      allAgents
+        ? loadAllAgentCostUsageSummary({
+            startMs: params.startMs,
+            endMs: params.endMs,
+            dayBucket: params.dayBucket,
+            config: params.config,
+          })
+        : loadCostUsageSummaryFromCache({
+            startMs: params.startMs,
+            endMs: params.endMs,
+            dayBucket: params.dayBucket,
+            config: params.config,
+            agentId: expectDefined(agentId, "non-aggregate usage agent id"),
+            requestRefresh: true,
+            refreshMode: "background",
+          }),
+  });
 }
 
 async function loadAllAgentCostUsageSummary(params: {
@@ -1244,38 +1152,13 @@ export const usageHandlers: GatewayRequestHandlers = {
     respond(true, summary, undefined);
   },
   "usage.cost": async ({ respond, params, context }) => {
-    const dateInterpretationResolution = resolveDateInterpretation({
-      mode: params?.mode,
-      utcOffset: params?.utcOffset,
-      timeZone: params?.timeZone,
-    });
-    if (!dateInterpretationResolution.ok) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, dateInterpretationResolution.error),
-      );
+    const dateRange = resolveUsageDateRangeOrRespond(params ?? {}, respond);
+    if (!dateRange) {
       return;
     }
-    const dateInterpretation = dateInterpretationResolution.value;
-    const dateRange = resolveDateRange(
-      {
-        startDate: params?.startDate,
-        endDate: params?.endDate,
-        days: params?.days,
-        range: params?.range,
-        mode: params?.mode,
-        utcOffset: params?.utcOffset,
-        timeZone: params?.timeZone,
-      },
-      dateInterpretation,
-    );
-    if (!dateRange.ok) {
-      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, dateRange.error));
-      return;
-    }
+    const { interpretation: dateInterpretation, range } = dateRange;
     const config = context.getRuntimeConfig();
-    const { startMs, endMs } = dateRange.value;
+    const { startMs, endMs } = range;
     const agentId = normalizeOptionalString(params?.agentId);
     const agentScope = params?.agentScope === "all" && !agentId ? "all" : undefined;
     const summary = await loadCostUsageSummaryCached({
@@ -1294,37 +1177,13 @@ export const usageHandlers: GatewayRequestHandlers = {
     }
 
     const p = params;
-    const dateInterpretationResolution = resolveDateInterpretation({
-      mode: p.mode,
-      utcOffset: p.utcOffset,
-      timeZone: p.timeZone,
-    });
-    if (!dateInterpretationResolution.ok) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, dateInterpretationResolution.error),
-      );
+    const dateRange = resolveUsageDateRangeOrRespond(p, respond);
+    if (!dateRange) {
       return;
     }
-    const dateInterpretation = dateInterpretationResolution.value;
-    const dateRange = resolveDateRange(
-      {
-        startDate: p.startDate,
-        endDate: p.endDate,
-        range: p.range,
-        mode: p.mode,
-        utcOffset: p.utcOffset,
-        timeZone: p.timeZone,
-      },
-      dateInterpretation,
-    );
-    if (!dateRange.ok) {
-      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, dateRange.error));
-      return;
-    }
+    const { interpretation: dateInterpretation, range } = dateRange;
     const config = context.getRuntimeConfig();
-    const { startMs, endMs, includeUntimestamped } = dateRange.value;
+    const { startMs, endMs, includeUntimestamped } = range;
     const dayBucket = resolveDayBucket(dateInterpretation);
     const limit = typeof p.limit === "number" && Number.isFinite(p.limit) ? p.limit : 50;
     const includeContextWeight = p.includeContextWeight ?? false;
@@ -1626,8 +1485,8 @@ export const usageHandlers: GatewayRequestHandlers = {
                 mergedEntries[session.entryIndex],
                 "merged entries entry at session.entry index",
               );
-              const usage =
-                usageByEntryIndex[session.entryIndex] ?? createEmptySessionCostSummary();
+              const usage: SessionCostSummary =
+                usageByEntryIndex[session.entryIndex] ?? createEmptyCostUsageTotals();
               usage.sessionId = merged.sessionId;
               usage.sessionFile = merged.sessionFile;
               mergeSessionUsageInto(usage, summary);


### PR DESCRIPTION
## What Problem This Solves

Gateway usage reports independently implemented the same bounded stale-while-revalidate cache, date validation, and report aggregation behavior. This is part of a maintainer-requested project-wide production LOC reduction campaign.

## Why This Change Was Made

Use one generic usage cache and shared date/report aggregation owners while preserving cost/session cache isolation, configuration identity, incomplete-snapshot handling, in-flight coalescing, TTL, and eviction.

## User Impact

No changes to gateway usage RPC responses or caching semantics. Removes 141 production lines.

## Evidence

- Four focused gateway usage suites; 83 tests covering cost reports, session reports, partial snapshots, cache expiry, and concurrent refresh.
- Full remote changed-file validation on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30967898984
- Independent structured autoreview: Codex `gpt-5.6-sol` with `xhigh` reasoning; no accepted or actionable findings.
- `git diff --check`, scoped formatting, and direct before/after behavioral equivalence checks passed.
- AI-assisted implementation and independent review.

