### PR TITLE
fix(slack): hide progress for implicit thread replies

### DIFF
--- a/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
@@ -98,7 +98,10 @@ export function createSlackProgressRuntime(runtimeParams: {
   let hasStreamedMessage = false;
   const streamMode = slackStreaming.draftMode;
   const useNativeProgressStreaming = useStreaming && slackStreaming.mode === "progress";
-  const progressDraftActive = Boolean(draftStream) || useNativeProgressStreaming;
+  // Preserve answer streaming while keeping provisional progress invisible on
+  // implicit thread turns that may intentionally finish without replying.
+  const progressDraftActive =
+    !setup.suppressImplicitThreadFeedback && (Boolean(draftStream) || useNativeProgressStreaming);
   const previewToolProgressEnabled =
     progressDraftActive &&
     resolveChannelStreamingPreviewToolProgress(account.config, true, slackStreaming.mode);
@@ -435,7 +438,7 @@ export function createSlackProgressRuntime(runtimeParams: {
       await progressDraft.pushPlanProgress(steps, { explanation });
       return;
     }
-    if (previewToolProgressSuppressed || !draftStream) {
+    if (previewToolProgressSuppressed || !draftStream || !progressDraftActive) {
       return;
     }
     const text = formatChannelProgressDraftText({

--- a/extensions/slack/src/monitor/message-handler/dispatch-setup.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-setup.ts
@@ -132,7 +132,6 @@ export async function createSlackDispatchSetup(prepared: PreparedSlackMessage) {
   const incomingThreadTs = message.thread_ts;
   let didSetStatus = false;
   const statusReactionsEnabled =
-    !suppressImplicitThreadFeedback &&
     prepared.ctxPayload.InboundEventKind !== "room_event" &&
     Boolean(prepared.ackReactionPromise) &&
     Boolean(reactionMessageTs) &&

--- a/extensions/slack/src/monitor/message-handler/dispatch-setup.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-setup.ts
@@ -107,6 +107,7 @@ export async function createSlackDispatchSetup(prepared: PreparedSlackMessage) {
   });
   const sourceRepliesAreToolOnly = sourceReplyDeliveryMode === "message_tool_only";
   const suppressRoomEventTyping = prepared.ctxPayload.InboundEventKind === "room_event";
+  const suppressImplicitThreadFeedback = prepared.ctxPayload.MentionSource === "implicit_thread";
 
   // Shared context for the `message_sent` plugin hook emitted on each delivered
   // reply (both the `deliverReplies` paths and the native-streaming finalizer).
@@ -127,6 +128,7 @@ export async function createSlackDispatchSetup(prepared: PreparedSlackMessage) {
   const incomingThreadTs = message.thread_ts;
   let didSetStatus = false;
   const statusReactionsEnabled =
+    !suppressImplicitThreadFeedback &&
     prepared.ctxPayload.InboundEventKind !== "room_event" &&
     Boolean(prepared.ackReactionPromise) &&
     Boolean(reactionMessageTs) &&
@@ -276,7 +278,8 @@ export async function createSlackDispatchSetup(prepared: PreparedSlackMessage) {
     (hookRunner?.hasHooks("message_sending") ?? false);
   // Portable previews and native progress cards exist before outbound modifiers accept the
   // payload. Native answer streaming stays enabled because it begins after both hook gates.
-  const allowPreHookProviderStreaming = !modifyingHooksRegistered;
+  const allowPreHookProviderStreaming =
+    !suppressImplicitThreadFeedback && !modifyingHooksRegistered;
   const previewStreamingEnabled =
     allowPreHookProviderStreaming &&
     !sourceRepliesAreToolOnly &&
@@ -335,6 +338,7 @@ export async function createSlackDispatchSetup(prepared: PreparedSlackMessage) {
     sourceReplyDeliveryMode,
     sourceRepliesAreToolOnly,
     suppressRoomEventTyping,
+    suppressImplicitThreadFeedback,
     messageSentHookTarget,
     messageSentHookContext,
     messageSentDeliveryHookContext,

--- a/extensions/slack/src/monitor/message-handler/dispatch-setup.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-setup.ts
@@ -1,3 +1,4 @@
+import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-runtime";
 import {
   createStatusReactionController,
   DEFAULT_TIMING,
@@ -107,7 +108,10 @@ export async function createSlackDispatchSetup(prepared: PreparedSlackMessage) {
   });
   const sourceRepliesAreToolOnly = sourceReplyDeliveryMode === "message_tool_only";
   const suppressRoomEventTyping = prepared.ctxPayload.InboundEventKind === "room_event";
-  const suppressImplicitThreadFeedback = prepared.ctxPayload.MentionSource === "implicit_thread";
+  const configuredTypingMode =
+    resolveAgentConfig(cfg, route.agentId)?.typingMode ?? cfg.agents?.defaults?.typingMode;
+  const suppressImplicitThreadFeedback =
+    prepared.ctxPayload.MentionSource === "implicit_thread" && configuredTypingMode === undefined;
 
   // Shared context for the `message_sent` plugin hook emitted on each delivered
   // reply (both the `deliverReplies` paths and the native-streaming finalizer).

--- a/extensions/slack/src/monitor/message-handler/dispatch-setup.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-setup.ts
@@ -108,6 +108,8 @@ export async function createSlackDispatchSetup(prepared: PreparedSlackMessage) {
   });
   const sourceRepliesAreToolOnly = sourceReplyDeliveryMode === "message_tool_only";
   const suppressRoomEventTyping = prepared.ctxPayload.InboundEventKind === "room_event";
+  // Thread participation admits implicit follow-ups without requesting a reply;
+  // preserve existing feedback only when typing was explicitly configured.
   const configuredTypingMode =
     resolveAgentConfig(cfg, route.agentId)?.typingMode ?? cfg.agents?.defaults?.typingMode;
   const suppressImplicitThreadFeedback =
@@ -281,8 +283,7 @@ export async function createSlackDispatchSetup(prepared: PreparedSlackMessage) {
     (hookRunner?.hasHooks("message_sending") ?? false);
   // Portable previews and native progress cards exist before outbound modifiers accept the
   // payload. Native answer streaming stays enabled because it begins after both hook gates.
-  const allowPreHookProviderStreaming =
-    !suppressImplicitThreadFeedback && !modifyingHooksRegistered;
+  const allowPreHookProviderStreaming = !modifyingHooksRegistered;
   const previewStreamingEnabled =
     allowPreHookProviderStreaming &&
     !sourceRepliesAreToolOnly &&

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -1990,7 +1990,6 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
         cfg: {
           messages: {
             groupChat: { visibleReplies: "automatic" },
-            statusReactions: { enabled: true },
           },
         },
         accountConfig: {
@@ -2013,6 +2012,45 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expect(createSlackDraftStreamMock).not.toHaveBeenCalled();
     expect(startSlackStreamMock).not.toHaveBeenCalled();
     expect(deliverRepliesMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves explicitly enabled status reactions for quiet implicit thread follow-ups", async () => {
+    const setSlackThreadStatus = vi.fn(async () => undefined);
+    mockedSlackStreamingMode = "progress";
+    mockedSlackDraftMode = "status_final";
+    mockedReplyOptionEvents = [
+      { kind: "reasoning", text: "Inspecting the thread" },
+      { kind: "tool_start", name: "web_search", phase: "start" },
+    ];
+
+    await dispatchPreparedSlackMessage(
+      createPreparedSlackMessage({
+        cfg: {
+          messages: {
+            groupChat: { visibleReplies: "automatic" },
+            statusReactions: { enabled: true },
+          },
+        },
+        accountConfig: { streaming: { mode: "progress", progress: { commentary: true } } },
+        ctxPayload: { ChatType: "channel", MentionSource: "implicit_thread" },
+        ackReactionMessageTs: "171234.111",
+        ackReactionPromise: Promise.resolve(true),
+        setSlackThreadStatus,
+      }),
+    );
+
+    expect(capturedReplyOptions?.suppressTyping).toBe(true);
+    expect(capturedReplyOptions?.suppressDefaultToolProgressMessages).toBe(true);
+    expect(capturedReplyOptions?.commentaryProgressEnabled).toBeUndefined();
+    expect(capturedStatusReactionOptions?.enabled).toBe(true);
+    expect(statusReactionControllerMock.setQueued).toHaveBeenCalledTimes(1);
+    expect(statusReactionControllerMock.setThinking).toHaveBeenCalledTimes(1);
+    expect(statusReactionControllerMock.setTool).toHaveBeenCalledWith("web_search");
+    expect(statusReactionControllerMock.setDone).toHaveBeenCalledTimes(1);
+    expect(setSlackThreadStatus).not.toHaveBeenCalled();
+    expect(createSlackDraftStreamMock).not.toHaveBeenCalled();
+    expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
+    expectDeliverReplyCall(0, FINAL_REPLY_TEXT);
   });
 
   it("still delivers final replies to implicit thread follow-ups", async () => {

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -435,6 +435,22 @@ async function dispatchNativeProgressScenario(params: {
 
 vi.mock("openclaw/plugin-sdk/agent-runtime", () => ({
   resolveHumanDelayConfig: () => undefined,
+  resolveAgentConfig: (
+    cfg: {
+      agents?: {
+        defaults?: { typingMode?: string };
+        entries?: Record<string, { typingMode?: string }>;
+        list?: Array<{ id: string; typingMode?: string }>;
+      };
+    },
+    agentId: string,
+  ) => {
+    const agents = cfg.agents;
+    const entry = agents?.entries
+      ? agents.entries[agentId]
+      : agents?.list?.find((candidate) => candidate.id === agentId);
+    return entry ? { typingMode: entry.typingMode ?? agents?.defaults?.typingMode } : undefined;
+  },
 }));
 
 vi.mock("openclaw/plugin-sdk/channel-feedback", () => ({
@@ -1917,6 +1933,30 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expect(capturedReplyOptions?.suppressTyping).toBe(true);
   });
 
+  it("keeps room events silent when an agent explicitly configures typing", async () => {
+    await dispatchPreparedSlackMessage(
+      createPreparedSlackMessage({
+        cfg: {
+          agents: { defaults: { typingMode: "instant" } },
+          messages: {
+            groupChat: { visibleReplies: "automatic" },
+            statusReactions: { enabled: true },
+          },
+        },
+        ctxPayload: {
+          ChatType: "channel",
+          InboundEventKind: "room_event",
+          MentionSource: "implicit_thread",
+        },
+        ackReactionMessageTs: "171234.111",
+        ackReactionPromise: Promise.resolve(true),
+      }),
+    );
+
+    expect(capturedReplyOptions?.suppressTyping).toBe(true);
+    expect(capturedStatusReactionOptions?.enabled).toBe(false);
+  });
+
   it("leaves Slack typing unsuppressed for normal channel turns", async () => {
     await dispatchPreparedSlackMessage(
       createPreparedSlackMessage({
@@ -1990,6 +2030,90 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expect(createSlackDraftStreamMock).not.toHaveBeenCalled();
     expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
     expectDeliverReplyCall(0, FINAL_REPLY_TEXT);
+  });
+
+  it.each(
+    (["instant", "thinking", "message", "never"] as const).flatMap((typingMode) => [
+      {
+        source: "agent defaults",
+        typingMode,
+        agents: { defaults: { typingMode } },
+      },
+      {
+        source: "agent entries",
+        typingMode,
+        agents: { entries: { "agent-1": { typingMode } } },
+      },
+      {
+        source: "legacy agent list",
+        typingMode,
+        agents: { list: [{ id: "agent-1", typingMode }] },
+      },
+    ]),
+  )(
+    "preserves explicit $typingMode feedback behavior from $source in implicit threads",
+    async ({ agents }) => {
+      mockedSlackStreamingMode = "progress";
+      mockedSlackDraftMode = "status_final";
+
+      await dispatchPreparedSlackMessage(
+        createPreparedSlackMessage({
+          cfg: {
+            agents,
+            messages: { groupChat: { visibleReplies: "automatic" } },
+          },
+          accountConfig: { streaming: { mode: "progress", progress: { commentary: true } } },
+          ctxPayload: { ChatType: "channel", MentionSource: "implicit_thread" },
+        }),
+      );
+
+      expect(capturedReplyOptions?.suppressTyping).toBeUndefined();
+      expect(capturedReplyOptions?.commentaryProgressEnabled).toBe(true);
+      expect(createSlackDraftStreamMock).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("keeps implicit thread feedback silent when another agent owns the override", async () => {
+    mockedSlackStreamingMode = "progress";
+    mockedSlackDraftMode = "status_final";
+
+    await dispatchPreparedSlackMessage(
+      createPreparedSlackMessage({
+        cfg: {
+          agents: { entries: { "another-agent": { typingMode: "instant" } } },
+          messages: { groupChat: { visibleReplies: "automatic" } },
+        },
+        accountConfig: { streaming: { mode: "progress", progress: { commentary: true } } },
+        ctxPayload: { ChatType: "channel", MentionSource: "implicit_thread" },
+      }),
+    );
+
+    expect(capturedReplyOptions?.suppressTyping).toBe(true);
+    expect(capturedReplyOptions?.commentaryProgressEnabled).toBeUndefined();
+    expect(createSlackDraftStreamMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves the per-agent typing override when defaults disagree", async () => {
+    mockedSlackStreamingMode = "progress";
+    mockedSlackDraftMode = "status_final";
+
+    await dispatchPreparedSlackMessage(
+      createPreparedSlackMessage({
+        cfg: {
+          agents: {
+            defaults: { typingMode: "instant" },
+            entries: { "agent-1": { typingMode: "never" } },
+          },
+          messages: { groupChat: { visibleReplies: "automatic" } },
+        },
+        accountConfig: { streaming: { mode: "progress", progress: { commentary: true } } },
+        ctxPayload: { ChatType: "channel", MentionSource: "implicit_thread" },
+      }),
+    );
+
+    expect(capturedReplyOptions?.suppressTyping).toBeUndefined();
+    expect(capturedReplyOptions?.commentaryProgressEnabled).toBe(true);
+    expect(createSlackDraftStreamMock).toHaveBeenCalledTimes(1);
   });
 
   it("preserves final native answer streaming for implicit thread follow-ups", async () => {

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -1929,6 +1929,112 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expect(capturedReplyOptions?.suppressTyping).toBeUndefined();
   });
 
+  it("keeps silent implicit thread follow-ups free of typing and progress UI", async () => {
+    const setSlackThreadStatus = vi.fn(async () => undefined);
+    mockedNativeStreaming = true;
+    mockedSlackStreamingMode = "progress";
+    mockedSlackDraftMode = "status_final";
+    mockedDispatchSequence = [];
+    mockedReplyOptionEvents = [
+      { kind: "reasoning", text: "Deciding whether to reply" },
+      {
+        kind: "item",
+        itemKind: "preamble",
+        itemId: "preamble-1",
+        progressText: "Inspecting the active thread",
+      },
+    ];
+
+    await dispatchPreparedSlackMessage(
+      createPreparedSlackMessage({
+        cfg: {
+          messages: {
+            groupChat: { visibleReplies: "automatic" },
+            statusReactions: { enabled: true },
+          },
+        },
+        accountConfig: {
+          streaming: { mode: "progress", progress: { commentary: true, nativeTaskCards: true } },
+        },
+        ctxPayload: { ChatType: "channel", MentionSource: "implicit_thread" },
+        ackReactionMessageTs: "171234.111",
+        ackReactionPromise: Promise.resolve(true),
+        setSlackThreadStatus,
+      }),
+    );
+
+    expect(capturedReplyOptions?.suppressTyping).toBe(true);
+    expect(capturedReplyOptions?.suppressDefaultToolProgressMessages).toBe(true);
+    expect(capturedReplyOptions?.commentaryProgressEnabled).toBeUndefined();
+    expect(capturedReplyOptions?.onReasoningStream).toBeUndefined();
+    expect(setSlackThreadStatus).not.toHaveBeenCalled();
+    expect(capturedStatusReactionOptions?.enabled).toBe(false);
+    expect(statusReactionControllerMock.setQueued).not.toHaveBeenCalled();
+    expect(createSlackDraftStreamMock).not.toHaveBeenCalled();
+    expect(startSlackStreamMock).not.toHaveBeenCalled();
+    expect(deliverRepliesMock).not.toHaveBeenCalled();
+  });
+
+  it("still delivers final replies to implicit thread follow-ups", async () => {
+    mockedSlackStreamingMode = "progress";
+    mockedSlackDraftMode = "status_final";
+
+    await dispatchPreparedSlackMessage(
+      createPreparedSlackMessage({
+        cfg: { messages: { groupChat: { visibleReplies: "automatic" } } },
+        accountConfig: { streaming: { mode: "progress", progress: { commentary: true } } },
+        ctxPayload: { ChatType: "channel", MentionSource: "implicit_thread" },
+      }),
+    );
+
+    expect(createSlackDraftStreamMock).not.toHaveBeenCalled();
+    expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
+    expectDeliverReplyCall(0, FINAL_REPLY_TEXT);
+  });
+
+  it("preserves final native answer streaming for implicit thread follow-ups", async () => {
+    mockedNativeStreaming = true;
+
+    await dispatchPreparedSlackMessage(
+      createPreparedSlackMessage({
+        cfg: { messages: { groupChat: { visibleReplies: "automatic" } } },
+        ctxPayload: { ChatType: "channel", MentionSource: "implicit_thread" },
+      }),
+    );
+
+    expect(createSlackDraftStreamMock).not.toHaveBeenCalled();
+    expect(startSlackStreamMock).toHaveBeenCalledTimes(1);
+    expect(deliverRepliesMock).not.toHaveBeenCalled();
+  });
+
+  it.each(["explicit_bot", "subteam", "mention_pattern", "command_bypass"])(
+    "preserves typing and progress UI for %s thread requests",
+    async (mentionSource) => {
+      const setSlackThreadStatus = vi.fn(async () => undefined);
+      mockedSlackStreamingMode = "progress";
+      mockedSlackDraftMode = "status_final";
+
+      await dispatchPreparedSlackMessage(
+        createPreparedSlackMessage({
+          cfg: { messages: { groupChat: { visibleReplies: "automatic" } } },
+          accountConfig: { streaming: { mode: "progress", progress: { commentary: true } } },
+          ctxPayload: { ChatType: "channel", MentionSource: mentionSource },
+          setSlackThreadStatus,
+        }),
+      );
+
+      expect(capturedReplyOptions?.suppressTyping).toBeUndefined();
+      expect(capturedTyping).toBeDefined();
+      expect(createSlackDraftStreamMock).toHaveBeenCalledTimes(1);
+
+      await requireCapturedTyping().start();
+
+      expect(setSlackThreadStatus).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "is typing..." }),
+      );
+    },
+  );
+
   it("escapes Slack mrkdwn in tool progress preview labels", async () => {
     const draftStream = createDraftStreamStub();
     createSlackDraftStreamMock.mockReturnValueOnce(draftStream);

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -1983,6 +1983,12 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
         itemId: "preamble-1",
         progressText: "Inspecting the active thread",
       },
+      {
+        kind: "plan",
+        phase: "update",
+        explanation: "Inspect the thread before deciding whether to reply",
+        steps: [{ step: "Inspect the thread", status: "in_progress" }],
+      },
     ];
 
     await dispatchPreparedSlackMessage(
@@ -2014,8 +2020,47 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expect(deliverRepliesMock).not.toHaveBeenCalled();
   });
 
+  it("keeps portable implicit-thread progress drafts invisible on silent turns", async () => {
+    const draftStream = createDraftStreamStub();
+    createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
+    mockedSlackStreamingMode = "progress";
+    mockedSlackDraftMode = "status_final";
+    mockedDispatchSequence = [];
+    mockedReplyOptionEvents = [
+      { kind: "tool_start", name: "web_search", phase: "start" },
+      {
+        kind: "item",
+        itemKind: "preamble",
+        itemId: "preamble-1",
+        progressText: "Inspecting the active thread",
+      },
+      {
+        kind: "plan",
+        phase: "update",
+        explanation: "Inspect the thread before deciding whether to reply",
+        steps: [{ step: "Inspect the thread", status: "in_progress" }],
+      },
+    ];
+
+    await dispatchPreparedSlackMessage(
+      createPreparedSlackMessage({
+        cfg: { messages: { groupChat: { visibleReplies: "automatic" } } },
+        accountConfig: { streaming: { mode: "progress", progress: { commentary: true } } },
+        ctxPayload: { ChatType: "channel", MentionSource: "implicit_thread" },
+      }),
+    );
+
+    expect(createSlackDraftStreamMock).toHaveBeenCalledTimes(1);
+    expect(draftStream.update).not.toHaveBeenCalled();
+    expect(capturedReplyOptions?.suppressDefaultToolProgressMessages).toBe(true);
+    expect(capturedReplyOptions?.commentaryProgressEnabled).toBeUndefined();
+    expect(deliverRepliesMock).not.toHaveBeenCalled();
+  });
+
   it("preserves explicitly enabled status reactions for quiet implicit thread follow-ups", async () => {
     const setSlackThreadStatus = vi.fn(async () => undefined);
+    const draftStream = createDraftStreamStub();
+    createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
     mockedSlackStreamingMode = "progress";
     mockedSlackDraftMode = "status_final";
     mockedReplyOptionEvents = [
@@ -2048,47 +2093,101 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expect(statusReactionControllerMock.setTool).toHaveBeenCalledWith("web_search");
     expect(statusReactionControllerMock.setDone).toHaveBeenCalledTimes(1);
     expect(setSlackThreadStatus).not.toHaveBeenCalled();
-    expect(createSlackDraftStreamMock).not.toHaveBeenCalled();
+    expect(createSlackDraftStreamMock).toHaveBeenCalledTimes(1);
+    expect(draftStream.update).not.toHaveBeenCalled();
     expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
     expectDeliverReplyCall(0, FINAL_REPLY_TEXT);
   });
 
-  it("still delivers final replies to implicit thread follow-ups", async () => {
-    mockedSlackStreamingMode = "progress";
-    mockedSlackDraftMode = "status_final";
+  it.each([false, true])(
+    "still delivers final implicit-thread replies with native task cards set to %s",
+    async (nativeTaskCards) => {
+      const draftStream = createDraftStreamStub();
+      createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
+      mockedNativeStreaming = nativeTaskCards;
+      mockedSlackStreamingMode = "progress";
+      mockedSlackDraftMode = "status_final";
+
+      await dispatchPreparedSlackMessage(
+        createPreparedSlackMessage({
+          cfg: { messages: { groupChat: { visibleReplies: "automatic" } } },
+          accountConfig: {
+            streaming: { mode: "progress", progress: { commentary: true, nativeTaskCards } },
+          },
+          ctxPayload: { ChatType: "channel", MentionSource: "implicit_thread" },
+        }),
+      );
+
+      expect(createSlackDraftStreamMock).toHaveBeenCalledTimes(nativeTaskCards ? 0 : 1);
+      expect(draftStream.update).not.toHaveBeenCalled();
+      expect(startSlackStreamMock).not.toHaveBeenCalled();
+      expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
+      expectDeliverReplyCall(0, FINAL_REPLY_TEXT);
+    },
+  );
+
+  it("preserves actual answer previews for implicit thread follow-ups", async () => {
+    const draftStream = createDraftStreamStub();
+    createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
+    mockedReplyOptionEvents = [{ kind: "partial", text: "An answer is taking shape" }];
 
     await dispatchPreparedSlackMessage(
       createPreparedSlackMessage({
         cfg: { messages: { groupChat: { visibleReplies: "automatic" } } },
-        accountConfig: { streaming: { mode: "progress", progress: { commentary: true } } },
         ctxPayload: { ChatType: "channel", MentionSource: "implicit_thread" },
       }),
     );
 
-    expect(createSlackDraftStreamMock).not.toHaveBeenCalled();
+    expect(capturedReplyOptions?.suppressTyping).toBe(true);
+    expect(draftStream.update).toHaveBeenCalledWith("An answer is taking shape");
     expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
     expectDeliverReplyCall(0, FINAL_REPLY_TEXT);
   });
 
-  it.each(
-    (["instant", "thinking", "message", "never"] as const).flatMap((typingMode) => [
+  it("keeps configured block streaming disabled while hiding implicit-thread plan previews", async () => {
+    const draftStream = createDraftStreamStub();
+    createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
+    mockedBlockStreamingEnabled = true;
+    mockedDispatchSequence = [];
+    mockedReplyOptionEvents = [
       {
-        source: "agent defaults",
-        typingMode,
-        agents: { defaults: { typingMode } },
+        kind: "plan",
+        phase: "update",
+        explanation: "Inspect the active thread",
+        steps: [{ step: "Inspect the thread", status: "in_progress" }],
       },
-      {
-        source: "agent entries",
-        typingMode,
-        agents: { entries: { "agent-1": { typingMode } } },
-      },
-      {
-        source: "legacy agent list",
-        typingMode,
-        agents: { list: [{ id: "agent-1", typingMode }] },
-      },
-    ]),
-  )(
+    ];
+
+    await dispatchPreparedSlackMessage(
+      createPreparedSlackMessage({
+        cfg: { messages: { groupChat: { visibleReplies: "automatic" } } },
+        ctxPayload: { ChatType: "channel", MentionSource: "implicit_thread" },
+      }),
+    );
+
+    expect(createSlackDraftStreamMock).toHaveBeenCalledTimes(1);
+    expect(capturedReplyOptions?.disableBlockStreaming).toBe(true);
+    expect(draftStream.update).not.toHaveBeenCalled();
+    expect(deliverRepliesMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ...(["instant", "thinking", "message", "never"] as const).map((typingMode) => ({
+      source: "agent defaults",
+      typingMode,
+      agents: { defaults: { typingMode } },
+    })),
+    {
+      source: "agent entries",
+      typingMode: "instant",
+      agents: { entries: { "agent-1": { typingMode: "instant" } } },
+    },
+    {
+      source: "legacy agent list",
+      typingMode: "instant",
+      agents: { list: [{ id: "agent-1", typingMode: "instant" }] },
+    },
+  ])(
     "preserves explicit $typingMode feedback behavior from $source in implicit threads",
     async ({ agents }) => {
       mockedSlackStreamingMode = "progress";
@@ -2112,6 +2211,8 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
   );
 
   it("keeps implicit thread feedback silent when another agent owns the override", async () => {
+    const draftStream = createDraftStreamStub();
+    createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
     mockedSlackStreamingMode = "progress";
     mockedSlackDraftMode = "status_final";
 
@@ -2128,7 +2229,8 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
 
     expect(capturedReplyOptions?.suppressTyping).toBe(true);
     expect(capturedReplyOptions?.commentaryProgressEnabled).toBeUndefined();
-    expect(createSlackDraftStreamMock).not.toHaveBeenCalled();
+    expect(createSlackDraftStreamMock).toHaveBeenCalledTimes(1);
+    expect(draftStream.update).not.toHaveBeenCalled();
   });
 
   it("preserves the per-agent typing override when defaults disagree", async () => {

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -63,6 +63,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     statusReactions,
     statusReactionsEnabled,
     statusThreadTs,
+    suppressImplicitThreadFeedback,
     suppressRoomEventTyping,
     useStreaming,
   } = setup;
@@ -405,15 +406,17 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
           : {}),
         skillFilter: prepared.channelConfig?.skills,
         sourceReplyDeliveryMode,
-        // Room events are observe-style turns; Slack status indicators imply an
-        // automatic visible reply and can auto-open assistant threads.
-        suppressTyping: suppressRoomEventTyping ? true : undefined,
+        // Observed room events and implicit thread follow-ups can finish silently;
+        // provider status would otherwise promise a reply that never arrives.
+        suppressTyping:
+          suppressRoomEventTyping || suppressImplicitThreadFeedback ? true : undefined,
         hasRepliedRef,
         disableBlockStreaming,
         onModelSelected,
-        suppressDefaultToolProgressMessages: progress.suppressDefaultToolProgressMessages
-          ? true
-          : undefined,
+        suppressDefaultToolProgressMessages:
+          suppressImplicitThreadFeedback || progress.suppressDefaultToolProgressMessages
+            ? true
+            : undefined,
         commentaryProgressEnabled: progress.commentaryProgressEnabled ? true : undefined,
         progressPreambleEnabled:
           progress.progressDraftActive && slackStreaming.mode === "progress" ? true : undefined,


### PR DESCRIPTION
## What Problem This Solves

When a bot has already participated in a Slack thread, later messages in that
thread can wake the agent without explicitly mentioning it. The agent may
correctly decide the message was not addressed to it and return `NO_REPLY`.
However, Slack can already show typing, thread status, tool progress, or
commentary. To the user, the bot appears to think for a while and then vanish.

Thread admission is not the same as a request to publicly answer. Slack
intentionally keeps `WasMentioned: true` for implicit-thread wake compatibility
(#79025); `MentionSource: "implicit_thread"` carries the distinction that
presentation code must use.

## Why This Change Was Made

Classify a Slack turn as quiet-by-default only when both are true:

1. `MentionSource` is `"implicit_thread"`.
2. Neither the resolved agent nor global agent defaults explicitly configures
   `typingMode`.

Apply that decision at the existing owners:

- Suppress Slack typing/thread status and standalone default tool-progress
  messages for that turn.
- Keep provider streaming, answer drafts, hook gates, block-streaming ownership,
  and final-delivery transport intact.
- Disable only the existing progress compositor, so speculative reasoning,
  tool/plan commentary, and native progress cards never become visible. Actual
  assistant answer text still reaches the normal answer-preview path.
- Keep independently enabled `messages.statusReactions.enabled: true` and its
  normal lifecycle unchanged.

This avoids changing shared typing policy, `WasMentioned`, admission, model
execution, silent-reply policy, cross-channel behavior, or configuration
schemas. In particular, shared typing cannot solve this alone: #95844
intentionally allows execution activity to start typing before answer text.
The Slack-local suppression boundary follows merged #105813.

## User Impact

| Slack turn / configuration | Expected behavior |
| --- | --- |
| Explicit bot/subteam/pattern mention or command | Existing typing, progress, answer previews, and final delivery remain unchanged. |
| Implicit thread follow-up; no configured `typingMode`; agent returns `NO_REPLY` | No misleading typing/thread status, commentary, tool/plan progress, native progress card, default tool message, or reply. |
| Same implicit thread follow-up; agent produces an answer | Speculative progress stays quiet; real answer previews, eligible native answer streaming, and final reply still work. |
| Implicit thread follow-up; agent/default explicitly sets `instant`, `thinking`, `message`, or `never` | Existing configured feedback behavior is retained; agent-specific settings take precedence, and `never` still means no typing. |
| `messages.statusReactions.enabled: true` | Independently opted-in queued/thinking/tool/done reactions remain enabled, including implicit turns. |
| Direct messages, existing room-event suppression, unrelated agents, and other channels | Unchanged. |

The intended behavior change is narrow: a default implicit Slack follow-up no
longer publishes speculative feedback merely because the thread woke the bot.
An answer itself remains visible. Explicit configuration retains its current
meaning; no new setting or migration is introduced.

## Evidence

### Real Slack dispatch and progress-compositor regression coverage

```bash
node scripts/run-vitest.mjs \
  extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
```

**152 tests passed** on follow-up commit
`cde4764cb6d7826128ff38fca7c91064dbb5d09c`. These tests execute the real
production Slack dispatch and shared progress compositor with modeled provider
events and captured Slack output/status/reaction adapters.
They verify:

- Silent implicit turns do not publish portable progress drafts, native progress
  cards, typing/thread status, commentary, tool updates, plan previews, or
  standalone default tool-progress messages.
- Actual answer partials still update their normal previews; final replies and
  eligible native answer streaming remain delivered.
- Existing block-streaming suppression is preserved when draft transport is
  active, and the separate non-progress plan-update path cannot bypass the
  quiet compositor.
- An independently enabled status-reaction lifecycle still records queued →
  thinking → tool → done without re-enabling quiet-turn typing or progress.
- All four explicitly configured typing modes retain existing semantics; agent
  defaults, canonical per-agent entries, legacy agent lists, per-agent
  precedence, and unrelated-agent isolation remain covered.
- Explicit bot/subteam/pattern/command turns and existing unconditional
  room-event suppression retain their previous behavior.

For the narrower, named behavior matrix:

```bash
node scripts/run-vitest.mjs \
  extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts \
  --reporter=verbose -t 'implicit.thread|implicit thread|room events'
```

**17 targeted implicit-thread/room-event tests passed** on the same commit.

### Compatibility follow-up and static checks

ClawSweeper correctly identified that an earlier version accidentally disabled
independently opted-in status reactions. The follow-up restores the upstream
status-reaction guard and adds a direct lifecycle regression. The updated
design also preserves answer-draft allocation and block-streaming ownership
instead of suppressing the entire provider stream.

- Scoped formatting, lint, and `git diff --check` passed.
- Independent architecture review and fresh structured code review found no
  accepted or actionable findings.
- AI-assisted implementation; the author reviewed and verified the change.

Slack typing and transient thread-status visibility do not have stable Web API
readback. The evidence above is deterministic production dispatch-boundary
coverage, not a claim of a live Slack recording or a full ephemeral-gateway
verdict. A dedicated Slack app/channel can exercise the exact source checkout
without deploying or merging this branch.

The evidence above applies specifically to commit
`cde4764cb6d7826128ff38fca7c91064dbb5d09c`; confirm the public PR head
contains that commit before review or merge.
