### PR TITLE
refactor(google-meet): unify gateway and tool dispatch

### DIFF
--- a/extensions/google-meet/index.ts
+++ b/extensions/google-meet/index.ts
@@ -11,8 +11,6 @@ import { GOOGLE_MEET_CLI_DESCRIPTOR } from "./src/cli-output-mode.js";
 import {
   buildGoogleMeetPreflightReport,
   endGoogleMeetActiveConference,
-  fetchGoogleMeetArtifacts,
-  fetchGoogleMeetAttendance,
   fetchLatestGoogleMeetConferenceRecord,
 } from "./src/meet.js";
 import { handleGoogleMeetNodeHostCommand } from "./src/node-host.js";
@@ -28,6 +26,8 @@ import {
   createGoogleMeetRuntimeAccessor,
   createMeetFromParams,
   exportGoogleMeetBundleFromParams,
+  fetchResolvedGoogleMeetArtifacts,
+  fetchResolvedGoogleMeetAttendance,
   formatGoogleMeetGatewayError,
   keepTrustedToolAgentId,
   loadGoogleMeetCliModule,
@@ -57,6 +57,63 @@ export default definePluginEntry({
   register(api: OpenClawPluginApi) {
     const config = googleMeetConfigSchema.parse(api.pluginConfig);
     const ensureRuntime = createGoogleMeetRuntimeAccessor({ api, config });
+    const registerGatewayMethod = (
+      method: string,
+      handler: (options: GatewayRequestHandlerOptions) => Promise<void>,
+    ) => {
+      api.registerGatewayMethod(method, async (options) => {
+        try {
+          await handler(options);
+        } catch (err) {
+          sendGoogleMeetGatewayError(options.respond, err);
+        }
+      });
+    };
+    const resolveTrustedJoinParams = ({ params, client }: GatewayRequestHandlerOptions) => {
+      const trustedParams = keepTrustedToolAgentId(asParamRecord(params), client);
+      return {
+        url: resolveMeetingInput(config, trustedParams.url),
+        transport: normalizeTransport(trustedParams.transport),
+        mode: normalizeMode(trustedParams.mode),
+        dialInNumber: normalizeOptionalString(trustedParams.dialInNumber),
+        pin: normalizeOptionalString(trustedParams.pin),
+        dtmfSequence: normalizeOptionalString(trustedParams.dtmfSequence),
+        message: normalizeOptionalString(trustedParams.message),
+        requesterSessionKey: normalizeOptionalString(trustedParams.requesterSessionKey),
+        agentId: normalizeOptionalString(trustedParams.agentId),
+      };
+    };
+    const queryActions = {
+      latest: async (raw: Record<string, unknown>) => {
+        const token = await resolveGoogleMeetTokenFromParams(config, raw);
+        const resolved = await resolveMeetingFromParams({
+          config,
+          raw,
+          accessToken: token.accessToken,
+        });
+        return {
+          ...(await fetchLatestGoogleMeetConferenceRecord({
+            accessToken: token.accessToken,
+            meeting: resolved.meeting,
+          })),
+          ...(resolved.calendarEvent ? { calendarEvent: resolved.calendarEvent } : {}),
+        };
+      },
+      calendar_events: async (raw: Record<string, unknown>) => {
+        const token = await resolveGoogleMeetTokenFromParams(config, raw);
+        const window = raw.today === true ? buildGoogleMeetCalendarDayWindow() : {};
+        return listGoogleMeetCalendarEvents({
+          accessToken: token.accessToken,
+          calendarId: normalizeOptionalString(raw.calendarId),
+          eventQuery: normalizeOptionalString(raw.event),
+          ...window,
+        });
+      },
+      artifacts: async (raw: Record<string, unknown>) =>
+        fetchResolvedGoogleMeetArtifacts(await resolveArtifactQueryFromParams(config, raw)),
+      attendance: async (raw: Record<string, unknown>) =>
+        fetchResolvedGoogleMeetAttendance(await resolveArtifactQueryFromParams(config, raw)),
+    };
     api.registerTranscriptSourceProvider(
       createMeetingTranscriptSourceProvider({
         id: "google-meet",
@@ -66,347 +123,157 @@ export default definePluginEntry({
       }),
     );
 
-    api.registerGatewayMethod(
-      "googlemeet.join",
-      async ({ params, client, respond }: GatewayRequestHandlerOptions) => {
-        try {
-          const trustedParams = keepTrustedToolAgentId(asParamRecord(params), client);
-          const rt = await ensureRuntime();
-          const result = await rt.join({
-            url: resolveMeetingInput(config, trustedParams.url),
-            transport: normalizeTransport(trustedParams.transport),
-            mode: normalizeMode(trustedParams.mode),
-            dialInNumber: normalizeOptionalString(trustedParams.dialInNumber),
-            pin: normalizeOptionalString(trustedParams.pin),
-            dtmfSequence: normalizeOptionalString(trustedParams.dtmfSequence),
-            message: normalizeOptionalString(trustedParams.message),
-            requesterSessionKey: normalizeOptionalString(trustedParams.requesterSessionKey),
-            agentId: normalizeOptionalString(trustedParams.agentId),
-          });
-          respond(true, result);
-        } catch (err) {
-          sendGoogleMeetGatewayError(respond, err);
-        }
-      },
-    );
+    registerGatewayMethod("googlemeet.join", async (options) => {
+      const runtime = await ensureRuntime();
+      options.respond(true, await runtime.join(resolveTrustedJoinParams(options)));
+    });
 
-    api.registerGatewayMethod(
-      "googlemeet.create",
-      async ({ params, client, respond }: GatewayRequestHandlerOptions) => {
-        try {
-          const raw = keepTrustedToolAgentId(asParamRecord(params), client);
-          respond(
-            true,
-            shouldJoinCreatedMeet(raw)
-              ? await createAndJoinMeetFromParams({
-                  config,
-                  runtime: api.runtime,
-                  raw,
-                  ensureRuntime,
-                })
-              : await createMeetFromParams({ config, runtime: api.runtime, raw }),
-          );
-        } catch (err) {
-          sendGoogleMeetGatewayError(respond, err);
-        }
-      },
-    );
+    registerGatewayMethod("googlemeet.create", async ({ params, client, respond }) => {
+      const raw = keepTrustedToolAgentId(asParamRecord(params), client);
+      respond(
+        true,
+        shouldJoinCreatedMeet(raw)
+          ? await createAndJoinMeetFromParams({
+              config,
+              runtime: api.runtime,
+              raw,
+              ensureRuntime,
+            })
+          : await createMeetFromParams({ config, runtime: api.runtime, raw }),
+      );
+    });
 
-    api.registerGatewayMethod(
-      "googlemeet.status",
-      async ({ params, respond }: GatewayRequestHandlerOptions) => {
-        try {
-          const rt = await ensureRuntime();
-          respond(true, await rt.status(normalizeOptionalString(params?.sessionId)));
-        } catch (err) {
-          sendGoogleMeetGatewayError(respond, err);
-        }
-      },
-    );
+    registerGatewayMethod("googlemeet.status", async ({ params, respond }) => {
+      const runtime = await ensureRuntime();
+      respond(true, await runtime.status(normalizeOptionalString(params?.sessionId)));
+    });
 
-    api.registerGatewayMethod(
-      "googlemeet.transcript",
-      async ({ params, respond }: GatewayRequestHandlerOptions) => {
-        try {
-          const sessionId = normalizeOptionalString(params?.sessionId);
-          if (!sessionId) {
-            sendGoogleMeetGatewayError(
-              respond,
-              new Error("sessionId required"),
-              ErrorCodes.INVALID_REQUEST,
-            );
-            return;
-          }
-          const sinceIndex = (params as { sinceIndex?: unknown } | undefined)?.sinceIndex;
-          if (
-            sinceIndex !== undefined &&
-            (typeof sinceIndex !== "number" || !Number.isSafeInteger(sinceIndex) || sinceIndex < 0)
-          ) {
-            sendGoogleMeetGatewayError(
-              respond,
-              new Error("sinceIndex must be a non-negative safe integer"),
-              ErrorCodes.INVALID_REQUEST,
-            );
-            return;
-          }
-          const rt = await ensureRuntime();
-          respond(
-            true,
-            await rt.transcript(sessionId, sinceIndex === undefined ? {} : { sinceIndex }),
-          );
-        } catch (err) {
-          sendGoogleMeetGatewayError(respond, err);
-        }
-      },
-    );
+    registerGatewayMethod("googlemeet.transcript", async ({ params, respond }) => {
+      const sessionId = normalizeOptionalString(params?.sessionId);
+      if (!sessionId) {
+        sendGoogleMeetGatewayError(
+          respond,
+          new Error("sessionId required"),
+          ErrorCodes.INVALID_REQUEST,
+        );
+        return;
+      }
+      const sinceIndex = (params as { sinceIndex?: unknown } | undefined)?.sinceIndex;
+      if (
+        sinceIndex !== undefined &&
+        (typeof sinceIndex !== "number" || !Number.isSafeInteger(sinceIndex) || sinceIndex < 0)
+      ) {
+        sendGoogleMeetGatewayError(
+          respond,
+          new Error("sinceIndex must be a non-negative safe integer"),
+          ErrorCodes.INVALID_REQUEST,
+        );
+        return;
+      }
+      const runtime = await ensureRuntime();
+      respond(
+        true,
+        await runtime.transcript(sessionId, sinceIndex === undefined ? {} : { sinceIndex }),
+      );
+    });
 
-    api.registerGatewayMethod(
-      "googlemeet.recoverCurrentTab",
-      async ({ params, respond }: GatewayRequestHandlerOptions) => {
-        try {
-          const rt = await ensureRuntime();
-          respond(
-            true,
-            await rt.recoverCurrentTab({
-              url: normalizeOptionalString(params?.url),
-              transport: normalizeTransport(params?.transport),
-            }),
-          );
-        } catch (err) {
-          sendGoogleMeetGatewayError(respond, err);
-        }
-      },
-    );
+    registerGatewayMethod("googlemeet.recoverCurrentTab", async ({ params, respond }) => {
+      const runtime = await ensureRuntime();
+      respond(
+        true,
+        await runtime.recoverCurrentTab({
+          url: normalizeOptionalString(params?.url),
+          transport: normalizeTransport(params?.transport),
+        }),
+      );
+    });
 
-    api.registerGatewayMethod(
-      "googlemeet.setup",
-      async ({ params, respond }: GatewayRequestHandlerOptions) => {
-        try {
-          const rt = await ensureRuntime();
-          respond(
-            true,
-            await rt.setupStatus({
-              transport: normalizeTransport(params?.transport),
-              mode: normalizeMode(params?.mode),
-              dialInNumber: normalizeOptionalString(params?.dialInNumber),
-            }),
-          );
-        } catch (err) {
-          sendGoogleMeetGatewayError(respond, err);
-        }
-      },
-    );
+    registerGatewayMethod("googlemeet.setup", async ({ params, respond }) => {
+      const runtime = await ensureRuntime();
+      respond(
+        true,
+        await runtime.setupStatus({
+          transport: normalizeTransport(params?.transport),
+          mode: normalizeMode(params?.mode),
+          dialInNumber: normalizeOptionalString(params?.dialInNumber),
+        }),
+      );
+    });
 
-    api.registerGatewayMethod(
-      "googlemeet.latest",
-      async ({ params, respond }: GatewayRequestHandlerOptions) => {
-        try {
-          const raw = asParamRecord(params);
-          const token = await resolveGoogleMeetTokenFromParams(config, raw);
-          const resolved = await resolveMeetingFromParams({
-            config,
-            raw,
-            accessToken: token.accessToken,
-          });
-          respond(true, {
-            ...(await fetchLatestGoogleMeetConferenceRecord({
-              accessToken: token.accessToken,
-              meeting: resolved.meeting,
-            })),
-            ...(resolved.calendarEvent ? { calendarEvent: resolved.calendarEvent } : {}),
-          });
-        } catch (err) {
-          sendGoogleMeetGatewayError(respond, err);
-        }
-      },
-    );
+    for (const [method, action] of [
+      ["googlemeet.latest", "latest"],
+      ["googlemeet.calendarEvents", "calendar_events"],
+      ["googlemeet.artifacts", "artifacts"],
+      ["googlemeet.attendance", "attendance"],
+    ] as const) {
+      registerGatewayMethod(method, async ({ params, respond }) => {
+        respond(true, await queryActions[action](asParamRecord(params)));
+      });
+    }
 
-    api.registerGatewayMethod(
-      "googlemeet.calendarEvents",
-      async ({ params, respond }: GatewayRequestHandlerOptions) => {
-        try {
-          const raw = asParamRecord(params);
-          const token = await resolveGoogleMeetTokenFromParams(config, raw);
-          const window = raw.today === true ? buildGoogleMeetCalendarDayWindow() : {};
-          respond(
-            true,
-            await listGoogleMeetCalendarEvents({
-              accessToken: token.accessToken,
-              calendarId: normalizeOptionalString(raw.calendarId),
-              eventQuery: normalizeOptionalString(raw.event),
-              ...window,
-            }),
-          );
-        } catch (err) {
-          sendGoogleMeetGatewayError(respond, err);
-        }
-      },
-    );
+    registerGatewayMethod("googlemeet.export", async ({ params, respond }) => {
+      respond(true, await exportGoogleMeetBundleFromParams(config, asParamRecord(params)));
+    });
 
-    api.registerGatewayMethod(
-      "googlemeet.artifacts",
-      async ({ params, respond }: GatewayRequestHandlerOptions) => {
-        try {
-          const raw = asParamRecord(params);
-          const resolved = await resolveArtifactQueryFromParams(config, raw);
-          respond(
-            true,
-            await fetchGoogleMeetArtifacts({
-              accessToken: resolved.token.accessToken,
-              meeting: resolved.meeting,
-              conferenceRecord: resolved.conferenceRecord,
-              pageSize: resolved.pageSize,
-              includeTranscriptEntries: resolved.includeTranscriptEntries,
-              includeDocumentBodies: resolved.includeDocumentBodies,
-              allConferenceRecords: resolved.allConferenceRecords,
-            }),
-          );
-        } catch (err) {
-          sendGoogleMeetGatewayError(respond, err);
-        }
-      },
-    );
+    registerGatewayMethod("googlemeet.leave", async ({ params, respond }) => {
+      const sessionId = normalizeOptionalString(params?.sessionId);
+      if (!sessionId) {
+        sendGoogleMeetGatewayError(
+          respond,
+          new Error("sessionId required"),
+          ErrorCodes.INVALID_REQUEST,
+        );
+        return;
+      }
+      const runtime = await ensureRuntime();
+      respond(true, await runtime.leave(sessionId));
+    });
 
-    api.registerGatewayMethod(
-      "googlemeet.attendance",
-      async ({ params, respond }: GatewayRequestHandlerOptions) => {
-        try {
-          const raw = asParamRecord(params);
-          const resolved = await resolveArtifactQueryFromParams(config, raw);
-          respond(
-            true,
-            await fetchGoogleMeetAttendance({
-              accessToken: resolved.token.accessToken,
-              meeting: resolved.meeting,
-              conferenceRecord: resolved.conferenceRecord,
-              pageSize: resolved.pageSize,
-              allConferenceRecords: resolved.allConferenceRecords,
-              mergeDuplicateParticipants: resolved.mergeDuplicateParticipants,
-              lateAfterMinutes: resolved.lateAfterMinutes,
-              earlyBeforeMinutes: resolved.earlyBeforeMinutes,
-            }),
-          );
-        } catch (err) {
-          sendGoogleMeetGatewayError(respond, err);
-        }
-      },
-    );
+    registerGatewayMethod("googlemeet.endActiveConference", async ({ params, respond }) => {
+      const raw = asParamRecord(params);
+      const token = await resolveGoogleMeetTokenFromParams(config, raw);
+      respond(
+        true,
+        await endGoogleMeetActiveConference({
+          accessToken: token.accessToken,
+          meeting: resolveMeetingInput(config, raw.meeting),
+        }),
+      );
+    });
 
-    api.registerGatewayMethod(
-      "googlemeet.export",
-      async ({ params, respond }: GatewayRequestHandlerOptions) => {
-        try {
-          respond(true, await exportGoogleMeetBundleFromParams(config, asParamRecord(params)));
-        } catch (err) {
-          sendGoogleMeetGatewayError(respond, err);
-        }
-      },
-    );
+    registerGatewayMethod("googlemeet.speak", async ({ params, respond }) => {
+      const sessionId = normalizeOptionalString(params?.sessionId);
+      if (!sessionId) {
+        sendGoogleMeetGatewayError(
+          respond,
+          new Error("sessionId required"),
+          ErrorCodes.INVALID_REQUEST,
+        );
+        return;
+      }
+      const runtime = await ensureRuntime();
+      respond(true, await runtime.speak(sessionId, normalizeOptionalString(params?.message)));
+    });
 
-    api.registerGatewayMethod(
-      "googlemeet.leave",
-      async ({ params, respond }: GatewayRequestHandlerOptions) => {
-        try {
-          const sessionId = normalizeOptionalString(params?.sessionId);
-          if (!sessionId) {
-            sendGoogleMeetGatewayError(
-              respond,
-              new Error("sessionId required"),
-              ErrorCodes.INVALID_REQUEST,
-            );
-            return;
-          }
-          const rt = await ensureRuntime();
-          respond(true, await rt.leave(sessionId));
-        } catch (err) {
-          sendGoogleMeetGatewayError(respond, err);
-        }
-      },
-    );
+    registerGatewayMethod("googlemeet.testSpeech", async (options) => {
+      const runtime = await ensureRuntime();
+      options.respond(true, await runtime.testSpeech(resolveTrustedJoinParams(options)));
+    });
 
-    api.registerGatewayMethod(
-      "googlemeet.endActiveConference",
-      async ({ params, respond }: GatewayRequestHandlerOptions) => {
-        try {
-          const raw = asParamRecord(params);
-          const token = await resolveGoogleMeetTokenFromParams(config, raw);
-          respond(
-            true,
-            await endGoogleMeetActiveConference({
-              accessToken: token.accessToken,
-              meeting: resolveMeetingInput(config, raw.meeting),
-            }),
-          );
-        } catch (err) {
-          sendGoogleMeetGatewayError(respond, err);
-        }
-      },
-    );
-
-    api.registerGatewayMethod(
-      "googlemeet.speak",
-      async ({ params, respond }: GatewayRequestHandlerOptions) => {
-        try {
-          const sessionId = normalizeOptionalString(params?.sessionId);
-          if (!sessionId) {
-            sendGoogleMeetGatewayError(
-              respond,
-              new Error("sessionId required"),
-              ErrorCodes.INVALID_REQUEST,
-            );
-            return;
-          }
-          const rt = await ensureRuntime();
-          respond(true, await rt.speak(sessionId, normalizeOptionalString(params?.message)));
-        } catch (err) {
-          sendGoogleMeetGatewayError(respond, err);
-        }
-      },
-    );
-
-    api.registerGatewayMethod(
-      "googlemeet.testSpeech",
-      async ({ params, client, respond }: GatewayRequestHandlerOptions) => {
-        try {
-          const trustedParams = keepTrustedToolAgentId(asParamRecord(params), client);
-          const rt = await ensureRuntime();
-          const result = await rt.testSpeech({
-            url: resolveMeetingInput(config, trustedParams.url),
-            transport: normalizeTransport(trustedParams.transport),
-            mode: normalizeMode(trustedParams.mode),
-            dialInNumber: normalizeOptionalString(trustedParams.dialInNumber),
-            pin: normalizeOptionalString(trustedParams.pin),
-            dtmfSequence: normalizeOptionalString(trustedParams.dtmfSequence),
-            message: normalizeOptionalString(trustedParams.message),
-            requesterSessionKey: normalizeOptionalString(trustedParams.requesterSessionKey),
-            agentId: normalizeOptionalString(trustedParams.agentId),
-          });
-          respond(true, result);
-        } catch (err) {
-          sendGoogleMeetGatewayError(respond, err);
-        }
-      },
-    );
-
-    api.registerGatewayMethod(
-      "googlemeet.testListen",
-      async ({ params, client, respond }: GatewayRequestHandlerOptions) => {
-        try {
-          const trustedParams = keepTrustedToolAgentId(asParamRecord(params), client);
-          const rt = await ensureRuntime();
-          const result = await rt.testListen({
-            url: resolveMeetingInput(config, trustedParams.url),
-            transport: normalizeTransport(trustedParams.transport),
-            mode: normalizeMode(trustedParams.mode),
-            agentId: normalizeOptionalString(trustedParams.agentId),
-            timeoutMs: readPositiveIntegerParam(trustedParams, "timeoutMs"),
-          });
-          respond(true, result);
-        } catch (err) {
-          sendGoogleMeetGatewayError(respond, err);
-        }
-      },
-    );
+    registerGatewayMethod("googlemeet.testListen", async ({ params, client, respond }) => {
+      const trustedParams = keepTrustedToolAgentId(asParamRecord(params), client);
+      const runtime = await ensureRuntime();
+      respond(
+        true,
+        await runtime.testListen({
+          url: resolveMeetingInput(config, trustedParams.url),
+          transport: normalizeTransport(trustedParams.transport),
+          mode: normalizeMode(trustedParams.mode),
+          agentId: normalizeOptionalString(trustedParams.agentId),
+          timeoutMs: readPositiveIntegerParam(trustedParams, "timeoutMs"),
+        }),
+      );
+    });
 
     api.registerTool(
       (toolContext) => ({
@@ -440,68 +307,27 @@ export default definePluginEntry({
             };
             assertGoogleMeetAgentToolActionSupported({ config, raw });
             switch (raw.action) {
-              case "join": {
-                return json(
-                  await callGoogleMeetGatewayFromTool({
-                    config,
-                    action: "join",
-                    raw: rawWithRequester,
-                    runtime: useTrustedRuntime ? api.runtime : undefined,
-                  }),
-                );
-              }
-              case "create": {
-                return json(
-                  await callGoogleMeetGatewayFromTool({
-                    config,
-                    action: "create",
-                    raw: rawWithRequester,
-                    runtime: useTrustedRuntime ? api.runtime : undefined,
-                  }),
-                );
-              }
-              case "test_speech": {
-                return json(
-                  await callGoogleMeetGatewayFromTool({
-                    config,
-                    action: "test_speech",
-                    raw: rawWithRequester,
-                    runtime: useTrustedRuntime ? api.runtime : undefined,
-                  }),
-                );
-              }
+              case "join":
+              case "create":
+              case "test_speech":
               case "test_listen": {
                 return json(
                   await callGoogleMeetGatewayFromTool({
                     config,
-                    action: "test_listen",
+                    action: raw.action,
                     raw: rawWithRequester,
                     runtime: useTrustedRuntime ? api.runtime : undefined,
                   }),
                 );
               }
-              case "status": {
-                return json(await callGoogleMeetGatewayFromTool({ config, action: "status", raw }));
-              }
-              case "transcript": {
+              case "status":
+              case "transcript":
+              case "recover_current_tab":
+              case "setup_status":
+              case "end_active_conference":
                 return json(
-                  await callGoogleMeetGatewayFromTool({ config, action: "transcript", raw }),
+                  await callGoogleMeetGatewayFromTool({ config, action: raw.action, raw }),
                 );
-              }
-              case "recover_current_tab": {
-                return json(
-                  await callGoogleMeetGatewayFromTool({
-                    config,
-                    action: "recover_current_tab",
-                    raw,
-                  }),
-                );
-              }
-              case "setup_status": {
-                return json(
-                  await callGoogleMeetGatewayFromTool({ config, action: "setup_status", raw }),
-                );
-              }
               case "resolve_space": {
                 const { token: _token, ...result } = await resolveSpaceFromParams(config, raw);
                 return json(result);
@@ -517,87 +343,23 @@ export default definePluginEntry({
                   }),
                 );
               }
-              case "latest": {
-                const token = await resolveGoogleMeetTokenFromParams(config, raw);
-                const resolved = await resolveMeetingFromParams({
-                  config,
-                  raw,
-                  accessToken: token.accessToken,
-                });
-                return json({
-                  ...(await fetchLatestGoogleMeetConferenceRecord({
-                    accessToken: token.accessToken,
-                    meeting: resolved.meeting,
-                  })),
-                  ...(resolved.calendarEvent ? { calendarEvent: resolved.calendarEvent } : {}),
-                });
-              }
-              case "calendar_events": {
-                const token = await resolveGoogleMeetTokenFromParams(config, raw);
-                const window = raw.today === true ? buildGoogleMeetCalendarDayWindow() : {};
-                return json(
-                  await listGoogleMeetCalendarEvents({
-                    accessToken: token.accessToken,
-                    calendarId: normalizeOptionalString(raw.calendarId),
-                    eventQuery: normalizeOptionalString(raw.event),
-                    ...window,
-                  }),
-                );
-              }
-              case "artifacts": {
-                const resolved = await resolveArtifactQueryFromParams(config, raw);
-                return json(
-                  await fetchGoogleMeetArtifacts({
-                    accessToken: resolved.token.accessToken,
-                    meeting: resolved.meeting,
-                    conferenceRecord: resolved.conferenceRecord,
-                    pageSize: resolved.pageSize,
-                    includeTranscriptEntries: resolved.includeTranscriptEntries,
-                    includeDocumentBodies: resolved.includeDocumentBodies,
-                    allConferenceRecords: resolved.allConferenceRecords,
-                  }),
-                );
-              }
-              case "attendance": {
-                const resolved = await resolveArtifactQueryFromParams(config, raw);
-                return json(
-                  await fetchGoogleMeetAttendance({
-                    accessToken: resolved.token.accessToken,
-                    meeting: resolved.meeting,
-                    conferenceRecord: resolved.conferenceRecord,
-                    pageSize: resolved.pageSize,
-                    allConferenceRecords: resolved.allConferenceRecords,
-                    mergeDuplicateParticipants: resolved.mergeDuplicateParticipants,
-                    lateAfterMinutes: resolved.lateAfterMinutes,
-                    earlyBeforeMinutes: resolved.earlyBeforeMinutes,
-                  }),
-                );
-              }
+              case "latest":
+              case "calendar_events":
+              case "artifacts":
+              case "attendance":
+                return json(await queryActions[raw.action](raw));
               case "export": {
                 return json(await exportGoogleMeetBundleFromParams(config, raw));
               }
-              case "leave": {
-                const sessionId = normalizeOptionalString(raw.sessionId);
-                if (!sessionId) {
-                  throw new Error("sessionId required");
-                }
-                return json(await callGoogleMeetGatewayFromTool({ config, action: "leave", raw }));
-              }
-              case "end_active_conference": {
-                return json(
-                  await callGoogleMeetGatewayFromTool({
-                    config,
-                    action: "end_active_conference",
-                    raw,
-                  }),
-                );
-              }
+              case "leave":
               case "speak": {
                 const sessionId = normalizeOptionalString(raw.sessionId);
                 if (!sessionId) {
                   throw new Error("sessionId required");
                 }
-                return json(await callGoogleMeetGatewayFromTool({ config, action: "speak", raw }));
+                return json(
+                  await callGoogleMeetGatewayFromTool({ config, action: raw.action, raw }),
+                );
               }
               default:
                 throw new Error("unknown google_meet action");

--- a/extensions/google-meet/src/cli-artifact-commands.ts
+++ b/extensions/google-meet/src/cli-artifact-commands.ts
@@ -19,8 +19,11 @@ import {
   writeStdoutJson,
   writeStdoutLine,
 } from "./cli-shared.js";
-import { fetchGoogleMeetArtifacts, fetchGoogleMeetAttendance } from "./meet.js";
-import { resolveArtifactQueryFromParams } from "./plugin-helpers.js";
+import {
+  fetchResolvedGoogleMeetArtifacts,
+  fetchResolvedGoogleMeetAttendance,
+  resolveArtifactQueryFromParams,
+} from "./plugin-helpers.js";
 
 async function resolveCliArtifactQuery(
   context: GoogleMeetCliCommandContext,
@@ -51,15 +54,7 @@ export function registerGoogleMeetArtifactCommands(context: GoogleMeetCliCommand
     .option("--json", "Print JSON output", false)
     .action(async (options: MeetArtifactOptions) => {
       const resolved = await resolveCliArtifactQuery(params, options);
-      const result = await fetchGoogleMeetArtifacts({
-        accessToken: resolved.token.accessToken,
-        meeting: resolved.meeting,
-        conferenceRecord: resolved.conferenceRecord,
-        pageSize: resolved.pageSize,
-        includeTranscriptEntries: resolved.includeTranscriptEntries,
-        allConferenceRecords: resolved.allConferenceRecords,
-        includeDocumentBodies: resolved.includeDocumentBodies,
-      });
+      const result = await fetchResolvedGoogleMeetArtifacts(resolved);
       if (options.json) {
         await writeCliOutput(
           options,
@@ -99,16 +94,7 @@ export function registerGoogleMeetArtifactCommands(context: GoogleMeetCliCommand
     .option("--json", "Print JSON output", false)
     .action(async (options: MeetArtifactOptions) => {
       const resolved = await resolveCliArtifactQuery(params, options);
-      const result = await fetchGoogleMeetAttendance({
-        accessToken: resolved.token.accessToken,
-        meeting: resolved.meeting,
-        conferenceRecord: resolved.conferenceRecord,
-        pageSize: resolved.pageSize,
-        allConferenceRecords: resolved.allConferenceRecords,
-        mergeDuplicateParticipants: resolved.mergeDuplicateParticipants,
-        lateAfterMinutes: resolved.lateAfterMinutes,
-        earlyBeforeMinutes: resolved.earlyBeforeMinutes,
-      });
+      const result = await fetchResolvedGoogleMeetAttendance(resolved);
       if (options.json) {
         await writeCliOutput(
           options,
@@ -157,25 +143,8 @@ export function registerGoogleMeetArtifactCommands(context: GoogleMeetCliCommand
     .option("--json", "Print JSON output", false)
     .action(async (options: MeetArtifactOptions) => {
       const resolved = await resolveCliArtifactQuery(params, options);
-      const artifacts = await fetchGoogleMeetArtifacts({
-        accessToken: resolved.token.accessToken,
-        meeting: resolved.meeting,
-        conferenceRecord: resolved.conferenceRecord,
-        pageSize: resolved.pageSize,
-        includeTranscriptEntries: resolved.includeTranscriptEntries,
-        allConferenceRecords: resolved.allConferenceRecords,
-        includeDocumentBodies: resolved.includeDocumentBodies,
-      });
-      const attendance = await fetchGoogleMeetAttendance({
-        accessToken: resolved.token.accessToken,
-        meeting: resolved.meeting,
-        conferenceRecord: resolved.conferenceRecord,
-        pageSize: resolved.pageSize,
-        allConferenceRecords: resolved.allConferenceRecords,
-        mergeDuplicateParticipants: resolved.mergeDuplicateParticipants,
-        lateAfterMinutes: resolved.lateAfterMinutes,
-        earlyBeforeMinutes: resolved.earlyBeforeMinutes,
-      });
+      const artifacts = await fetchResolvedGoogleMeetArtifacts(resolved);
+      const attendance = await fetchResolvedGoogleMeetAttendance(resolved);
       const request: GoogleMeetExportRequest = {
         ...(resolved.meeting ? { meeting: resolved.meeting } : {}),
         ...(resolved.conferenceRecord ? { conferenceRecord: resolved.conferenceRecord } : {}),

--- a/extensions/google-meet/src/plugin-helpers.ts
+++ b/extensions/google-meet/src/plugin-helpers.ts
@@ -9,7 +9,7 @@ import {
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { MeetingPlatformAdapter } from "openclaw/plugin-sdk/meeting-runtime";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
-import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { isRecord, normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   buildGoogleMeetCalendarDayWindow,
   findGoogleMeetCalendarEvent,
@@ -34,9 +34,7 @@ const loadGoogleMeetCreateModule = createLazyRuntimeModule(() => import("./creat
 export const loadGoogleMeetCliModule = createLazyRuntimeModule(() => import("./cli.js"));
 
 export function asParamRecord(params: unknown): Record<string, unknown> {
-  return params && typeof params === "object" && !Array.isArray(params)
-    ? (params as Record<string, unknown>)
-    : {};
+  return isRecord(params) ? params : {};
 }
 
 export function normalizeTransport(value: unknown): GoogleMeetTransport | undefined {
@@ -304,31 +302,41 @@ export async function resolveArtifactQueryFromParams(
   };
 }
 
+type ResolvedGoogleMeetArtifactQuery = Awaited<ReturnType<typeof resolveArtifactQueryFromParams>>;
+
+export function fetchResolvedGoogleMeetArtifacts(query: ResolvedGoogleMeetArtifactQuery) {
+  return fetchGoogleMeetArtifacts({
+    accessToken: query.token.accessToken,
+    meeting: query.meeting,
+    conferenceRecord: query.conferenceRecord,
+    pageSize: query.pageSize,
+    includeTranscriptEntries: query.includeTranscriptEntries,
+    includeDocumentBodies: query.includeDocumentBodies,
+    allConferenceRecords: query.allConferenceRecords,
+  });
+}
+
+export function fetchResolvedGoogleMeetAttendance(query: ResolvedGoogleMeetArtifactQuery) {
+  return fetchGoogleMeetAttendance({
+    accessToken: query.token.accessToken,
+    meeting: query.meeting,
+    conferenceRecord: query.conferenceRecord,
+    pageSize: query.pageSize,
+    allConferenceRecords: query.allConferenceRecords,
+    mergeDuplicateParticipants: query.mergeDuplicateParticipants,
+    lateAfterMinutes: query.lateAfterMinutes,
+    earlyBeforeMinutes: query.earlyBeforeMinutes,
+  });
+}
+
 export async function exportGoogleMeetBundleFromParams(
   config: GoogleMeetConfig,
   raw: Record<string, unknown>,
 ) {
   const resolved = await resolveArtifactQueryFromParams(config, raw);
   const [artifacts, attendance] = await Promise.all([
-    fetchGoogleMeetArtifacts({
-      accessToken: resolved.token.accessToken,
-      meeting: resolved.meeting,
-      conferenceRecord: resolved.conferenceRecord,
-      pageSize: resolved.pageSize,
-      includeTranscriptEntries: resolved.includeTranscriptEntries,
-      includeDocumentBodies: resolved.includeDocumentBodies,
-      allConferenceRecords: resolved.allConferenceRecords,
-    }),
-    fetchGoogleMeetAttendance({
-      accessToken: resolved.token.accessToken,
-      meeting: resolved.meeting,
-      conferenceRecord: resolved.conferenceRecord,
-      pageSize: resolved.pageSize,
-      allConferenceRecords: resolved.allConferenceRecords,
-      mergeDuplicateParticipants: resolved.mergeDuplicateParticipants,
-      lateAfterMinutes: resolved.lateAfterMinutes,
-      earlyBeforeMinutes: resolved.earlyBeforeMinutes,
-    }),
+    fetchResolvedGoogleMeetArtifacts(resolved),
+    fetchResolvedGoogleMeetAttendance(resolved),
   ]);
   const { buildGoogleMeetExportManifest, googleMeetExportFileNames, writeMeetExportBundle } =
     await loadGoogleMeetCliModule();


### PR DESCRIPTION
## What Problem This Solves

Google Meet repeated gateway error adapters, trusted tool dispatch, and artifact request projection across its gateway, tool, and CLI entry points. This is part of a maintainer-requested project-wide production LOC reduction campaign.

## Why This Change Was Made

Centralize equivalent Google Meet gateway/tool dispatch and artifact request construction while preserving trusted agent ownership, spoof rejection, request validation, and all 16 gateway methods.

## User Impact

Google Meet users see the same meeting, transcript, artifact, and export behavior with 261 fewer production lines.

## Evidence

- Six focused Google Meet suites; 226 tests covering gateway methods, trusted routing, meeting creation, transcripts, CLI exports, and node-invoke policy.
- Full remote changed-file validation on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30967980030
- Independent structured autoreview: Codex `gpt-5.6-sol` with `xhigh` reasoning; no accepted or actionable findings.
- `git diff --check`, scoped formatting, and direct before/after behavioral equivalence checks passed.
- AI-assisted implementation and independent review.

### Exact-head gateway and CLI transcript

Observed at PR head `54f9c43fd4bfb3743c0626f88061ed3bf9db578b` on isolated Blacksmith Testbox `tbx_01kz7t9nxe1982y00tt47f5k06`. Google APIs are controlled integration-test fixtures; no live account, credentials, meeting, or operator gateway was used.

```text
$ CI=1 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm test extensions/google-meet/index.test.ts extensions/google-meet/index.create.test.ts extensions/google-meet/index.transcripts.test.ts extensions/google-meet/src/cli-artifacts.test.ts extensions/google-meet/src/cli-runtime.test.ts extensions/google-meet/src/node-invoke-policy.test.ts
✓ extensions/google-meet/index.test.ts (162 tests)
✓ extensions/google-meet/index.create.test.ts (10 tests)
✓ extensions/google-meet/src/cli-artifacts.test.ts (17 tests)
✓ extensions/google-meet/src/cli-runtime.test.ts (28 tests)
✓ extensions/google-meet/src/node-invoke-policy.test.ts (8 tests)
✓ extensions/google-meet/index.transcripts.test.ts (1 test)
Test Files  6 passed (6)
Tests       226 passed (226)
```

Actual CLI output captured by the passing integration tests:

```text
$ openclaw googlemeet transcript meet_gateway --since 3
# 2 earlier lines dropped by the transcript cap
Alice: fourth line
# nextIndex: 4

$ openclaw googlemeet attendance --access-token [REDACTED] --conference-record rec-1
attendance rows: 1
participant: Alice
```

Trusted routing assertions on the running gateway/tool boundary:

- Trusted caller with `sessionKey=agent:support:pr103522-live` and spoofed model-supplied `agentId=spoofed`: gateway receives canonical `agentId=support`, the original requester session, and scope `operator.admin`.
- Untrusted external caller with `agentId=spoofed`: downstream Meet runtime receives `agentId=undefined`; spoofing is rejected.
- CLI export manifest order remains `summary.md`, `attendance.csv`, `transcript.md`, `artifacts.json`, `attendance.json`, `manifest.json`.

A live Google Meet account was not exercised because no user-approved live account, meeting, or operator-gateway mutation is needed for this behavior-neutral owner refactor.

