### PR TITLE
refactor(channels): unify configured binding resolution

### DIFF
--- a/src/channels/plugins/configured-binding-compiler.ts
+++ b/src/channels/plugins/configured-binding-compiler.ts
@@ -12,27 +12,13 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { pickFirstExistingAgentId } from "../../routing/resolve-route.js";
 import { resolveChannelConfiguredBindingProvider } from "./binding-provider.js";
 import type { CompiledConfiguredBinding, ConfiguredBindingChannel } from "./binding-types.js";
-import {
-  resolveConfiguredBindingConsumer,
-  type ConfiguredBindingConsumer,
-} from "./configured-binding-consumers.js";
+import { resolveConfiguredBindingConsumer } from "./configured-binding-consumers.js";
 import { getLoadedChannelPlugin } from "./index.js";
-import type {
-  ChannelConfiguredBindingConversationRef,
-  ChannelConfiguredBindingProvider,
-} from "./types.adapters.js";
+import type { ChannelConfiguredBindingProvider } from "./types.adapters.js";
 
 export type CompiledConfiguredBindingRegistry = {
   rulesByChannel: Map<ConfiguredBindingChannel, CompiledConfiguredBinding[]>;
 };
-
-function resolveLoadedChannelPlugin(channel: string) {
-  const normalized = normalizeOptionalLowercaseString(channel);
-  if (!normalized) {
-    return undefined;
-  }
-  return getLoadedChannelPlugin(normalized as ConfiguredBindingChannel);
-}
 
 function resolveConfiguredBindingAdapter(channel: string): {
   channel: ConfiguredBindingChannel;
@@ -42,7 +28,7 @@ function resolveConfiguredBindingAdapter(channel: string): {
   if (!normalized) {
     return null;
   }
-  const plugin = resolveLoadedChannelPlugin(normalized);
+  const plugin = getLoadedChannelPlugin(normalized as ConfiguredBindingChannel);
   const provider = resolveChannelConfiguredBindingProvider(plugin);
   if (
     !plugin ||
@@ -58,81 +44,19 @@ function resolveConfiguredBindingAdapter(channel: string): {
   };
 }
 
-function resolveBindingConversationId(binding: {
-  match?: { peer?: { id?: string } };
-}): string | null {
-  return normalizeOptionalString(binding.match?.peer?.id) ?? null;
-}
-
-function compileConfiguredBindingTarget(params: {
-  provider: ChannelConfiguredBindingProvider;
-  binding: CompiledConfiguredBinding["binding"];
-  conversationId: string;
-}): ChannelConfiguredBindingConversationRef | null {
-  return params.provider.compileConfiguredBinding({
-    binding: params.binding,
-    conversationId: params.conversationId,
-  });
-}
-
-function compileConfiguredBindingRule(params: {
-  cfg: OpenClawConfig;
-  channel: ConfiguredBindingChannel;
-  binding: CompiledConfiguredBinding["binding"];
-  target: ChannelConfiguredBindingConversationRef;
-  bindingConversationId: string;
-  provider: ChannelConfiguredBindingProvider;
-  consumer: ConfiguredBindingConsumer;
-}): CompiledConfiguredBinding | null {
-  const agentId = pickFirstExistingAgentId(params.cfg, params.binding.agentId ?? "main");
-  const targetFactory = params.consumer.buildTargetFactory({
-    cfg: params.cfg,
-    binding: params.binding,
-    channel: params.channel,
-    agentId,
-    target: params.target,
-    bindingConversationId: params.bindingConversationId,
-  });
-  if (!targetFactory) {
-    return null;
-  }
-  return {
-    channel: params.channel,
-    accountPattern: normalizeOptionalString(params.binding.match.accountId),
-    binding: params.binding,
-    bindingConversationId: params.bindingConversationId,
-    target: params.target,
-    agentId,
-    provider: params.provider,
-    targetFactory,
-  };
-}
-
-function pushCompiledRule(
-  target: Map<ConfiguredBindingChannel, CompiledConfiguredBinding[]>,
-  rule: CompiledConfiguredBinding,
-) {
-  const existing = target.get(rule.channel);
-  if (existing) {
-    existing.push(rule);
-    return;
-  }
-  target.set(rule.channel, [rule]);
-}
-
-function compileConfiguredBindingRegistry(params: {
-  cfg: OpenClawConfig;
-}): CompiledConfiguredBindingRegistry {
+export function resolveCompiledBindingRegistry(
+  cfg: OpenClawConfig,
+): CompiledConfiguredBindingRegistry {
   const rulesByChannel = new Map<ConfiguredBindingChannel, CompiledConfiguredBinding[]>();
 
-  for (const binding of listConfiguredBindings(params.cfg)) {
+  for (const binding of listConfiguredBindings(cfg)) {
     // Ordinary routing bindings share the config array but have no stateful target consumer.
     // Reject them before consulting the loaded channel registry on request-time route lookups.
     const consumer = resolveConfiguredBindingConsumer(binding);
     if (!consumer) {
       continue;
     }
-    const bindingConversationId = resolveBindingConversationId(binding);
+    const bindingConversationId = normalizeOptionalString(binding.match?.peer?.id);
     if (!bindingConversationId) {
       continue;
     }
@@ -142,8 +66,7 @@ function compileConfiguredBindingRegistry(params: {
       continue;
     }
 
-    const target = compileConfiguredBindingTarget({
-      provider: resolvedChannel.provider,
+    const target = resolvedChannel.provider.compileConfiguredBinding({
       binding,
       conversationId: bindingConversationId,
     });
@@ -151,47 +74,35 @@ function compileConfiguredBindingRegistry(params: {
       continue;
     }
 
-    const rule = compileConfiguredBindingRule({
-      cfg: params.cfg,
-      channel: resolvedChannel.channel,
+    const agentId = pickFirstExistingAgentId(cfg, binding.agentId ?? "main");
+    const targetFactory = consumer.buildTargetFactory({
+      cfg,
       binding,
+      channel: resolvedChannel.channel,
+      agentId,
       target,
       bindingConversationId,
-      provider: resolvedChannel.provider,
-      consumer,
     });
-    if (!rule) {
+    if (!targetFactory) {
       continue;
     }
-    pushCompiledRule(rulesByChannel, rule);
+    const rule: CompiledConfiguredBinding = {
+      channel: resolvedChannel.channel,
+      accountPattern: normalizeOptionalString(binding.match.accountId),
+      binding,
+      bindingConversationId,
+      target,
+      agentId,
+      provider: resolvedChannel.provider,
+      targetFactory,
+    };
+    const existing = rulesByChannel.get(rule.channel);
+    if (existing) {
+      existing.push(rule);
+    } else {
+      rulesByChannel.set(rule.channel, [rule]);
+    }
   }
 
-  return {
-    rulesByChannel,
-  };
-}
-
-export function resolveCompiledBindingRegistry(
-  cfg: OpenClawConfig,
-): CompiledConfiguredBindingRegistry {
-  return compileConfiguredBindingRegistry({ cfg });
-}
-
-export function primeCompiledBindingRegistry(
-  cfg: OpenClawConfig,
-): CompiledConfiguredBindingRegistry {
-  return compileConfiguredBindingRegistry({ cfg });
-}
-
-export function countCompiledBindingRegistry(registry: CompiledConfiguredBindingRegistry): {
-  bindingCount: number;
-  channelCount: number;
-} {
-  return {
-    bindingCount: [...registry.rulesByChannel.values()].reduce(
-      (sum, rules) => sum + rules.length,
-      0,
-    ),
-    channelCount: registry.rulesByChannel.size,
-  };
+  return { rulesByChannel };
 }

--- a/src/channels/plugins/configured-binding-match.ts
+++ b/src/channels/plugins/configured-binding-match.ts
@@ -33,19 +33,6 @@ export function resolveAccountMatchPriority(match: string | undefined, actual: s
   return normalizeAccountId(trimmed) === actual ? 2 : 0;
 }
 
-function matchCompiledBindingConversation(params: {
-  rule: CompiledConfiguredBinding;
-  conversationId: string;
-  parentConversationId?: string;
-}): ChannelConfiguredBindingMatch | null {
-  return params.rule.provider.matchInboundConversation({
-    binding: params.rule.binding,
-    compiledBinding: params.rule.target,
-    conversationId: params.conversationId,
-    parentConversationId: params.parentConversationId,
-  });
-}
-
 /**
  * Normalizes a raw channel id into a configured-binding channel id.
  */
@@ -101,12 +88,10 @@ export function resolveMatchingConfiguredBinding(params: {
     return null;
   }
 
-  let wildcardMatch: {
-    rule: CompiledConfiguredBinding;
-    match: ChannelConfiguredBindingMatch;
-  } | null = null;
-  let exactMatch: { rule: CompiledConfiguredBinding; match: ChannelConfiguredBindingMatch } | null =
+  let bestMatch: { rule: CompiledConfiguredBinding; match: ChannelConfiguredBindingMatch } | null =
     null;
+  let bestAccountPriority = 0;
+  let bestMatchPriority = 0;
 
   for (const rule of params.rules) {
     const accountMatchPriority = resolveAccountMatchPriority(
@@ -118,8 +103,9 @@ export function resolveMatchingConfiguredBinding(params: {
     if (accountMatchPriority === 0) {
       continue;
     }
-    const match = matchCompiledBindingConversation({
-      rule,
+    const match = rule.provider.matchInboundConversation({
+      binding: rule.binding,
+      compiledBinding: rule.target,
       conversationId: params.conversation.conversationId,
       parentConversationId: params.conversation.parentConversationId,
     });
@@ -127,16 +113,16 @@ export function resolveMatchingConfiguredBinding(params: {
       continue;
     }
     const matchPriority = match.matchPriority ?? 0;
-    if (accountMatchPriority === 2) {
-      if (!exactMatch || matchPriority > (exactMatch.match.matchPriority ?? 0)) {
-        exactMatch = { rule, match };
-      }
-      continue;
-    }
-    if (!wildcardMatch || matchPriority > (wildcardMatch.match.matchPriority ?? 0)) {
-      wildcardMatch = { rule, match };
+    if (
+      !bestMatch ||
+      accountMatchPriority > bestAccountPriority ||
+      (accountMatchPriority === bestAccountPriority && matchPriority > bestMatchPriority)
+    ) {
+      bestMatch = { rule, match };
+      bestAccountPriority = accountMatchPriority;
+      bestMatchPriority = matchPriority;
     }
   }
 
-  return exactMatch ?? wildcardMatch;
+  return bestMatch;
 }

--- a/src/channels/plugins/configured-binding-registry.ts
+++ b/src/channels/plugins/configured-binding-registry.ts
@@ -9,11 +9,7 @@ import type {
   ConfiguredBindingRecordResolution,
   ConfiguredBindingResolution,
 } from "./binding-types.js";
-import {
-  countCompiledBindingRegistry,
-  primeCompiledBindingRegistry,
-  resolveCompiledBindingRegistry,
-} from "./configured-binding-compiler.js";
+import { resolveCompiledBindingRegistry } from "./configured-binding-compiler.js";
 import {
   materializeConfiguredBindingRecord,
   resolveMatchingConfiguredBinding,
@@ -60,7 +56,11 @@ export function primeConfiguredBindingRegistry(params: { cfg: OpenClawConfig }):
   bindingCount: number;
   channelCount: number;
 } {
-  return countCompiledBindingRegistry(primeCompiledBindingRegistry(params.cfg));
+  const { rulesByChannel } = resolveCompiledBindingRegistry(params.cfg);
+  return {
+    bindingCount: [...rulesByChannel.values()].reduce((sum, rules) => sum + rules.length, 0),
+    channelCount: rulesByChannel.size,
+  };
 }
 
 /**
@@ -73,33 +73,17 @@ export function resolveConfiguredBindingRecord(params: {
   conversationId: string;
   parentConversationId?: string;
 }): ConfiguredBindingRecordResolution | null {
-  const conversation = toConfiguredBindingConversationRef({
-    channel: params.channel,
-    accountId: params.accountId,
-    conversationId: params.conversationId,
-    parentConversationId: params.parentConversationId,
-  });
-  if (!conversation) {
-    return null;
-  }
-  return resolveConfiguredBindingRecordForConversation({
-    cfg: params.cfg,
-    conversation,
-  });
-}
-
-/**
- * Resolves a configured binding record from a normalized conversation reference.
- */
-function resolveConfiguredBindingRecordForConversation(params: {
-  cfg: OpenClawConfig;
-  conversation: ConversationRef;
-}): ConfiguredBindingRecordResolution | null {
-  const resolved = resolveMaterializedConfiguredBinding(params);
-  if (!resolved) {
-    return null;
-  }
-  return resolved.materializedTarget;
+  return (
+    resolveMaterializedConfiguredBinding({
+      cfg: params.cfg,
+      conversation: {
+        channel: params.channel,
+        accountId: params.accountId,
+        conversationId: params.conversationId,
+        parentConversationId: params.parentConversationId,
+      },
+    })?.materializedTarget ?? null
+  );
 }
 
 /**

--- a/src/channels/plugins/configured-binding-session-lookup.ts
+++ b/src/channels/plugins/configured-binding-session-lookup.ts
@@ -38,7 +38,6 @@ export function resolveConfiguredBindingRecordBySessionKeyFromRegistry(params: {
       continue;
     }
     let wildcardMatch: ConfiguredBindingRecordResolution | null = null;
-    let exactMatch: ConfiguredBindingRecordResolution | null = null;
     for (const rule of rules) {
       if (rule.targetFactory.driverId !== consumer.id) {
         continue;
@@ -67,14 +66,10 @@ export function resolveConfiguredBindingRecordBySessionKeyFromRegistry(params: {
       if (matchesSessionKey) {
         if (accountMatchPriority === 2) {
           // Exact account matches outrank wildcard account bindings for the same session key.
-          exactMatch = materializedTarget;
-          break;
+          return materializedTarget;
         }
         wildcardMatch = materializedTarget;
       }
-    }
-    if (exactMatch) {
-      return exactMatch;
     }
     if (wildcardMatch) {
       return wildcardMatch;


### PR DESCRIPTION
## What Problem This Solves

Configured channel bindings repeatedly compiled providers, normalized conversations, selected precedence, and materialized session-key lookups. This is part of a maintainer-requested project-wide production LOC reduction campaign.

## Why This Change Was Made

Use canonical loaded-plugin binding compilation, precedence selection, and exact/wildcard session lookup paths without changing public SDK contracts or provider discovery.

## User Impact

Channel and ACP routing preserve account, thread, wildcard, and exact-match behavior with 124 fewer production lines.

## Evidence

- Six focused suites; 41 tests covering configured channel bindings, persistent ACP routing, targets, lifecycle, and WhatsApp transport.
- Full remote changed-file validation on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30968000139
- Independent structured autoreview: Codex `gpt-5.6-sol` with `xhigh` reasoning; no accepted or actionable findings.
- `git diff --check`, scoped formatting, and direct before/after behavioral equivalence checks passed.
- AI-assisted implementation and independent review.

### Exact-head mock-channel binding transcript

A read-only, in-memory mock-channel harness executed nine real production modules, including all four changed configured-binding modules and the actual consumer registry. The wildcard rule was intentionally registered before the exact rule to prove precedence. Fixture identifiers only; no gateway state or credentials were used.

```text
HEAD aa7d51ed35085f55bb526b6ecdcfc99e327bbfac
PRODUCTION modules=9 changed-modules=4 mock-channel=mock-chat
REGISTRY bindings=3 channels=1 order=wildcard,exact,thread-exact
DIRECT account=work conversation=room-7 -> rule=account-exact session=agent:main:mock-chat:work:room-7
DIRECT account=guest conversation=room-7 -> rule=account-wildcard session=agent:main:mock-chat:guest:room-7
THREAD account=work conversation=thread-42 parent=room-7 -> rule=thread-exact priority=20 session=agent:main:mock-chat:work:thread-42
THREAD account=work conversation=thread-99 parent=room-7 -> rule=account-exact priority=10 session=agent:main:mock-chat:work:room-7
REVERSE session=agent:main:mock-chat:work:room-7 -> rule=account-exact
REVERSE session=agent:main:mock-chat:guest:room-7 -> rule=account-wildcard
NO_MATCH account=work conversation=unknown -> null
PASS 8 mock-channel harness checks; exact-head production compiler/matcher/registry/reverse lookup executed
```

