### PR TITLE
fix(sessions): maxDiskBytes 0 no longer deletes all session history

### DIFF
--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -1259,7 +1259,7 @@ See [Multi-Agent Sandbox & Tools](/tools/multi-agent-sandbox-tools) for preceden
   - Short-lived gateway model-run probe sessions use fixed `24h` retention, but cleanup is pressure-gated: it only removes stale strict model-run probe rows when session-entry maintenance/cap pressure is reached. Only strict explicit probe keys matching `agent:*:explicit:model-run-<uuid>` are eligible; normal direct, group, thread, cron, hook, heartbeat, ACP, and sub-agent sessions do not inherit this 24h retention. When model-run cleanup runs, it runs before the broader `pruneAfter` stale-entry cleanup and `maxEntries` cap.
   - Legacy `rotateBytes` is rejected by the current schema; `openclaw doctor --fix` removes it from older configs.
   - `resetArchiveRetention`: age-based retention for reset/deleted transcript archives. By default, archives remain until disk-budget eviction; set a duration to opt into wall-clock deletion, or `false` to disable it explicitly.
-  - `maxDiskBytes`: optional sessions-directory disk budget. In `warn` mode it logs warnings; in `enforce` mode it removes oldest artifacts/sessions first.
+  - `maxDiskBytes`: optional sessions-directory disk budget. In `warn` mode it logs warnings; in `enforce` mode it removes oldest artifacts/sessions first. Set `false`, `0`, or `"0"` to disable the budget entirely.
   - `highWaterBytes`: optional target after budget cleanup. Defaults to `80%` of `maxDiskBytes`.
 - **`threadBindings`**: global defaults for thread-bound session features.
   - `enabled`: master switch for supported channel thread bindings

--- a/docs/reference/session-management-compaction.md
+++ b/docs/reference/session-management-compaction.md
@@ -50,7 +50,7 @@ Per agent, on the Gateway host (resolved via `src/config/sessions.ts`):
 | `pruneAfter`            | `"30d"`               | stale-entry age cutoff                                                                      |
 | `maxEntries`            | `500`                 | cap on session entries                                                                      |
 | `resetArchiveRetention` | keep (no age cutoff)  | age cutoff for `*.reset.*`/`*.deleted.*` transcript archives; a duration opts into deletion |
-| `maxDiskBytes`          | `10gb`                | per-agent sessions disk budget; `false` disables                                            |
+| `maxDiskBytes`          | `10gb`                | per-agent sessions disk budget; `false`, `0`, or `"0"` disables                             |
 | `highWaterBytes`        | 80% of `maxDiskBytes` | target after budget cleanup                                                                 |
 
 Reset advances the live `sessionKey -> sessionId` mapping but keeps the previous SQLite session, transcript, trajectory, and search rows. That history remains searchable under the same session key; ordinary entry and session lists show only the new live mapping. Retained reset history is bounded by the disk budget, not by `resetArchiveRetention`, which only ages archive artifacts. Explicit deletion is different: it writes and verifies a compressed transcript archive (`*.jsonl.deleted.<timestamp>.zst` when zstd is available) before removing the deleted session's rows.

--- a/src/config/schema.help.automation.ts
+++ b/src/config/schema.help.automation.ts
@@ -81,7 +81,7 @@ export const AUTOMATION_FIELD_HELP: Record<string, string> = {
   "session.maintenance.resetArchiveRetention":
     "Age-based retention for archived transcripts (`*.reset.<timestamp>` and `*.deleted.<timestamp>`). Defaults to keeping archives until the disk budget evicts them oldest-first; set a duration (for example `30d`) to opt into wall-clock deletion, or `false` to disable it explicitly.",
   "session.maintenance.maxDiskBytes":
-    "Per-agent sessions-directory disk budget (for example `500mb`). Defaults to `10gb`; when exceeded, warn mode reports pressure and enforce mode performs oldest-first cleanup (archived transcripts before live sessions). Set `false` to disable.",
+    'Per-agent sessions-directory disk budget (for example `500mb`). Defaults to `10gb`; when exceeded, warn mode reports pressure and enforce mode performs oldest-first cleanup (archived transcripts before live sessions). Set `false`, `0`, or `"0"` to disable.',
   "session.maintenance.highWaterBytes":
     "Target size after disk-budget cleanup (high-water mark). Defaults to 80% of maxDiskBytes; set explicitly for tighter reclaim behavior on constrained disks.",
   cron: "Global scheduler settings for stored automations, run concurrency, delivery fallback, and run-session retention. Keep defaults unless you are scaling automation volume or integrating external webhook receivers.",

--- a/src/config/sessions/store-maintenance.ts
+++ b/src/config/sessions/store-maintenance.ts
@@ -102,7 +102,13 @@ function resolveMaxDiskBytes(maintenance?: SessionMaintenanceConfig): number | n
     return DEFAULT_SESSION_MAX_DISK_BYTES;
   }
   try {
-    return parseByteSize(normalized, { defaultUnit: "b" });
+    const bytes = parseByteSize(normalized, { defaultUnit: "b" });
+    // A zero or negative budget is not a usable cap; treat it the same as an
+    // explicit disable so maintenance does not delete every session artifact.
+    if (bytes <= 0) {
+      return null;
+    }
+    return bytes;
   } catch {
     // A malformed explicit value must not opt the user into destructive
     // budget cleanup they never chose; disable the budget instead.

--- a/src/config/sessions/store.pruning.test.ts
+++ b/src/config/sessions/store.pruning.test.ts
@@ -987,6 +987,20 @@ describe("resolveMaintenanceConfigFromInput", () => {
     expect(maintenance.highWaterBytes).toBeNull();
   });
 
+  it("disables the disk budget when maxDiskBytes is 0", () => {
+    const maintenance = resolveMaintenanceConfigFromInput({ maxDiskBytes: 0 });
+
+    expect(maintenance.maxDiskBytes).toBeNull();
+    expect(maintenance.highWaterBytes).toBeNull();
+  });
+
+  it("disables the disk budget when maxDiskBytes is the string '0'", () => {
+    const maintenance = resolveMaintenanceConfigFromInput({ maxDiskBytes: "0" });
+
+    expect(maintenance.maxDiskBytes).toBeNull();
+    expect(maintenance.highWaterBytes).toBeNull();
+  });
+
   it("force-gates the unset model-run prune default to the cap-eviction threshold", () => {
     const defaultMaintenance = resolveMaintenanceConfigFromInput({ maxEntries: 50 });
     expect(resolveSessionEntryMaintenanceHighWater(50)).toBe(75);

--- a/src/config/sessions/store.pruning.test.ts
+++ b/src/config/sessions/store.pruning.test.ts
@@ -3,7 +3,9 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { saveLegacySessionStore as saveSessionStore } from "../../infra/state-migrations.legacy-session-store.js";
 import { beginSessionWorkAdmission } from "../../sessions/session-lifecycle-admission.js";
+import { withTempDir } from "../../test-helpers/temp-dir.js";
 import { createFixtureSuite } from "../../test-utils/fixture-suite.js";
 import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shared.js";
 import { enforceSessionDiskBudget } from "./disk-budget.js";
@@ -999,6 +1001,38 @@ describe("resolveMaintenanceConfigFromInput", () => {
 
     expect(maintenance.maxDiskBytes).toBeNull();
     expect(maintenance.highWaterBytes).toBeNull();
+  });
+
+  it("retains session history when a zero maxDiskBytes disables the budget", async () => {
+    await withTempDir({ prefix: "openclaw-zero-disk-budget-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const transcriptPath = path.join(dir, "old-session.jsonl");
+      await fs.writeFile(transcriptPath, JSON.stringify({ role: "user", content: "hello" }));
+      const store: Record<string, SessionEntry> = {
+        "agent:main:subagent:old-worker": {
+          sessionId: "old-session",
+          updatedAt: 1,
+          transcriptPath,
+        },
+      };
+      await saveSessionStore(storePath, store, { skipMaintenance: true });
+
+      const maintenance = resolveMaintenanceConfigFromInput({ maxDiskBytes: 0 });
+      const result = await enforceSessionDiskBudget({
+        store,
+        storePath,
+        maintenance: {
+          maxDiskBytes: maintenance.maxDiskBytes,
+          highWaterBytes: maintenance.highWaterBytes,
+        },
+        warnOnly: false,
+      });
+
+      expect(maintenance.maxDiskBytes).toBeNull();
+      expect(maintenance.highWaterBytes).toBeNull();
+      expect(result).toBeNull();
+      await expect(fs.access(transcriptPath)).resolves.toBeUndefined();
+    });
   });
 
   it("force-gates the unset model-run prune default to the cap-eviction threshold", () => {

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -263,7 +263,7 @@ export type SessionMaintenanceConfig = {
   /**
    * Per-agent sessions-directory disk budget (e.g. "500mb"). Default: "10gb".
    * When exceeded, warn (mode=warn) or enforce oldest-first cleanup
-   * (mode=enforce). Set `false` to disable the budget entirely.
+   * (mode=enforce). Set `false`, `0`, or `"0"` to disable the budget entirely.
    */
   maxDiskBytes?: number | string | false;
   /**


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who set `session.maintenance.maxDiskBytes` to `0` or `"0"` in `openclaw.json` would have all removable session history and prompt blobs silently deleted by gateway maintenance. A zero budget leaves `highWaterBytes` at `0`, so the cleanup loop's stop condition (`total <= highWaterBytes`) is never reached while any data remains.

## Why This Change Was Made

The disk budget parser now treats a zero (or negative) byte cap the same as `false` or a malformed value: it disables the budget. The guard lives in `resolveMaxDiskBytes` because that function already owns the "explicit but unusable value → disable" decision. Type help, schema help, and session-management docs were updated to state that `false`, `0`, and `"0"` all disable the budget, so the behavior is part of the public config contract rather than an undocumented side effect.

## User Impact

Operators who previously wrote `maxDiskBytes: 0` no longer risk silent data loss. The budget can now be disabled with `false` (existing documented spelling), `0`, or `"0"`.

## Evidence

### Before fix

- `resolveMaintenanceConfigFromInput({ maxDiskBytes: 0 })` returned `{ maxDiskBytes: 0, highWaterBytes: 0 }`.
- With a synthetic non-primary session and `commitEvictedIndex` provided, `enforceSessionDiskBudget` removed the session entry and its transcript/artifacts because `total <= 0` was unreachable.

### After fix

- `resolveMaintenanceConfigFromInput({ maxDiskBytes: 0 })` returns `{ maxDiskBytes: null, highWaterBytes: null }`.
- `enforceSessionDiskBudget` short-circuits on `null` and deletes nothing.
- Added an integration test that creates a real temp session store with an old session transcript, resolves a zero budget, runs `enforceSessionDiskBudget`, and asserts the transcript is retained and the sweep result is `null`.

## Real behavior proof

Isolated maintenance run on real temp files:

```bash
npx tsx .tmp/proof-maxdiskbytes-zero.mts
```

Output:

```
Resolved maxDiskBytes: null
Resolved highWaterBytes: null
enforceSessionDiskBudget result: null
Transcript retained: true
PROOF PASSED
```

### Focused tests

```bash
node scripts/run-vitest.mjs \
  src/config/sessions/disk-budget.test.ts \
  src/config/sessions/session-history-eviction.test.ts \
  src/config/sessions/store.pruning.test.ts
# Test Files  3 passed (3)
# Tests  79 passed (79)
```

### Checks

- Core typecheck: `pnpm tsgo:core:test` exits 0.
- Lint: `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/config/sessions/store-maintenance.ts src/config/sessions/store.pruning.test.ts src/config/types.base.ts src/config/schema.help.automation.ts` reports 0 warnings/errors.
- Format: `pnpm format:check <changed-files>` clean.
