### PR TITLE
test(state): reuse legacy database fixtures

### DIFF
--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -71,6 +71,7 @@ type AgentDbTestDatabase = Pick<
 const agentDbTempDirs: string[] = [];
 let sharedStateDatabaseTemplatePath: string | undefined;
 let currentWorkerAgentDatabaseTemplatePath: string | undefined;
+let v13WorkerAgentDatabaseTemplatePath: string | undefined;
 
 function createTempStateDir(): string {
   return makeTempDir(agentDbTempDirs, "openclaw-agent-db-");
@@ -161,6 +162,82 @@ function materializeCurrentWorkerAgentDatabase(stateDir: string): string {
     databasePath,
     fs.constants.COPYFILE_EXCL,
   );
+  return databasePath;
+}
+
+function ensureV13WorkerAgentDatabaseTemplate(): string {
+  if (v13WorkerAgentDatabaseTemplatePath) {
+    return v13WorkerAgentDatabaseTemplatePath;
+  }
+  // Legacy migration cases mutate independent clones; keep one closed, verified v13
+  // baseline so the test-only reverse migration is not repeated for every case.
+  const stateDir = makeTempDir(agentDbTempDirs, "openclaw-agent-db-v13-worker-");
+  const databasePath = resolveOpenClawAgentSqlitePath({
+    agentId: "worker-1",
+    env: { OPENCLAW_STATE_DIR: stateDir },
+  });
+  fs.mkdirSync(path.dirname(databasePath), { recursive: true });
+  fs.copyFileSync(
+    ensureCurrentWorkerAgentDatabaseTemplate(),
+    databasePath,
+    fs.constants.COPYFILE_EXCL,
+  );
+  downgradeCurrentAgentDatabaseToV13(databasePath);
+
+  const { DatabaseSync } = requireNodeSqlite();
+  const checkpoint = new DatabaseSync(databasePath);
+  try {
+    checkpoint.exec("PRAGMA wal_checkpoint(TRUNCATE);");
+  } finally {
+    checkpoint.close();
+  }
+  const walPath = `${databasePath}-wal`;
+  if (fs.existsSync(walPath) && fs.statSync(walPath).size > 0) {
+    throw new Error("v13 worker agent database template retained WAL content");
+  }
+  for (const suffix of ["-wal", "-shm", "-journal"]) {
+    fs.rmSync(`${databasePath}${suffix}`, { force: true });
+  }
+
+  const verified = new DatabaseSync(databasePath, { readOnly: true });
+  try {
+    expect(verified.prepare("PRAGMA integrity_check").get()).toEqual({ integrity_check: "ok" });
+    expect(verified.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
+    expect(readSqliteNumberPragma(verified, "user_version")).toBe(13);
+    expect(
+      verified
+        .prepare(
+          "SELECT role, agent_id, schema_version FROM schema_meta WHERE meta_key = 'primary'",
+        )
+        .get(),
+    ).toEqual({ role: "agent", agent_id: "worker-1", schema_version: 13 });
+    expect(
+      verified
+        .prepare(
+          "SELECT name FROM sqlite_schema WHERE type = 'table' AND name IN ('sessions', 'session_entries', 'session_routes') ORDER BY name",
+        )
+        .all(),
+    ).toEqual([{ name: "session_entries" }, { name: "session_routes" }, { name: "sessions" }]);
+    expect(
+      verified
+        .prepare("SELECT name FROM sqlite_schema WHERE type = 'table' AND name = 'session_nodes'")
+        .get(),
+    ).toBeUndefined();
+  } finally {
+    verified.close();
+  }
+  v13WorkerAgentDatabaseTemplatePath = databasePath;
+  return databasePath;
+}
+
+function materializeV13WorkerAgentDatabase(stateDir: string): string {
+  const options = {
+    agentId: "worker-1",
+    env: { OPENCLAW_STATE_DIR: stateDir },
+  } as const;
+  const databasePath = resolveOpenClawAgentSqlitePath(options);
+  fs.mkdirSync(path.dirname(databasePath), { recursive: true });
+  fs.copyFileSync(ensureV13WorkerAgentDatabaseTemplate(), databasePath, fs.constants.COPYFILE_EXCL);
   return databasePath;
 }
 
@@ -737,6 +814,7 @@ function launchAgentSchemaOpener(params: {
 
 beforeAll(() => {
   ensureCurrentWorkerAgentDatabaseTemplate();
+  ensureV13WorkerAgentDatabaseTemplate();
 });
 
 afterAll(() => {
@@ -1176,10 +1254,7 @@ describe("openclaw agent database", () => {
     expect(OPENCLAW_AGENT_SCHEMA_VERSION).toBe(16);
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };
-    const opened = openOpenClawAgentDatabase({ agentId: "worker-1", env });
-    const databasePath = opened.path;
-    closeOpenClawAgentDatabasesForTest();
-    downgradeCurrentAgentDatabaseToV13(databasePath);
+    const databasePath = materializeV13WorkerAgentDatabase(stateDir);
 
     const { DatabaseSync } = requireNodeSqlite();
     const existingV13 = new DatabaseSync(databasePath);
@@ -1211,10 +1286,7 @@ describe("openclaw agent database", () => {
   it("migrates v13 session entries, routes, and generations into nodes and windows", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };
-    const databasePath = openOpenClawAgentDatabase({ agentId: "worker-1", env }).path;
-    closeOpenClawAgentDatabasesForTest();
-    closeOpenClawStateDatabaseForTest();
-    downgradeCurrentAgentDatabaseToV13(databasePath);
+    const databasePath = materializeV13WorkerAgentDatabase(stateDir);
 
     const { DatabaseSync } = requireNodeSqlite();
     const legacy = new DatabaseSync(databasePath);
@@ -1408,10 +1480,7 @@ describe("openclaw agent database", () => {
     expect(OPENCLAW_AGENT_SCHEMA_VERSION).toBe(16);
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };
-    const opened = openOpenClawAgentDatabase({ agentId: "worker-1", env });
-    const databasePath = opened.path;
-    closeOpenClawAgentDatabasesForTest();
-    downgradeCurrentAgentDatabaseToV13(databasePath);
+    const databasePath = materializeV13WorkerAgentDatabase(stateDir);
 
     const { DatabaseSync } = requireNodeSqlite();
     const existingV12 = new DatabaseSync(databasePath);
@@ -1439,11 +1508,7 @@ describe("openclaw agent database", () => {
   it("backfills one generation per existing transcript when upgrading v12", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };
-    const opened = openOpenClawAgentDatabase({ agentId: "worker-1", env });
-    const databasePath = opened.path;
-    closeOpenClawAgentDatabasesForTest();
-    closeOpenClawStateDatabaseForTest();
-    downgradeCurrentAgentDatabaseToV13(databasePath);
+    const databasePath = materializeV13WorkerAgentDatabase(stateDir);
 
     const { DatabaseSync } = requireNodeSqlite();
     const legacy = new DatabaseSync(databasePath);
@@ -1486,19 +1551,15 @@ describe("openclaw agent database", () => {
   it("upgrades version 10 with agent state intact and adds lease storage", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };
-    const opened = openOpenClawAgentDatabase({ agentId: "worker-1", env });
-    const databasePath = opened.path;
-    opened.db
+    const databasePath = materializeV13WorkerAgentDatabase(stateDir);
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const legacy = new DatabaseSync(databasePath);
+    legacy
       .prepare(
         "INSERT INTO auth_profile_state (state_key, state_json, updated_at) VALUES (?, ?, ?)",
       )
       .run("last-good", '{"profile":"primary"}', 10);
-    closeOpenClawAgentDatabasesForTest();
-    closeOpenClawStateDatabaseForTest();
-    downgradeCurrentAgentDatabaseToV13(databasePath);
-
-    const { DatabaseSync } = requireNodeSqlite();
-    const legacy = new DatabaseSync(databasePath);
     legacy.exec(`
       DROP INDEX idx_agent_state_leases_owner;
       DROP INDEX idx_agent_state_leases_expiry;
@@ -1532,19 +1593,15 @@ describe("openclaw agent database", () => {
   it("upgrades version 11 with agent state intact and adds ACP parent-stream storage", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };
-    const opened = openOpenClawAgentDatabase({ agentId: "worker-1", env });
-    const databasePath = opened.path;
-    opened.db
+    const databasePath = materializeV13WorkerAgentDatabase(stateDir);
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const legacy = new DatabaseSync(databasePath);
+    legacy
       .prepare(
         "INSERT INTO auth_profile_state (state_key, state_json, updated_at) VALUES (?, ?, ?)",
       )
       .run("last-good", '{"profile":"primary"}', 10);
-    closeOpenClawAgentDatabasesForTest();
-    closeOpenClawStateDatabaseForTest();
-    downgradeCurrentAgentDatabaseToV13(databasePath);
-
-    const { DatabaseSync } = requireNodeSqlite();
-    const legacy = new DatabaseSync(databasePath);
     legacy.exec(`
       DROP INDEX idx_agent_acp_parent_stream_run;
       DROP TABLE acp_parent_stream_events;
@@ -1585,18 +1642,15 @@ describe("openclaw agent database", () => {
   it("migrates version 8 tables to STRICT without losing agent state", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };
-    const opened = openOpenClawAgentDatabase({ agentId: "worker-1", env });
-    const databasePath = opened.path;
-    opened.db
+    const databasePath = materializeCurrentWorkerAgentDatabase(stateDir);
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const legacy = new DatabaseSync(databasePath);
+    legacy
       .prepare(
         "INSERT INTO auth_profile_state (state_key, state_json, updated_at) VALUES (?, ?, ?)",
       )
       .run("last-good", '{"profile":"primary"}', 10);
-    closeOpenClawAgentDatabasesForTest();
-    closeOpenClawStateDatabaseForTest();
-
-    const { DatabaseSync } = requireNodeSqlite();
-    const legacy = new DatabaseSync(databasePath);
     legacy.exec(`
       ALTER TABLE auth_profile_state RENAME TO auth_profile_state_strict;
       CREATE TABLE auth_profile_state (
@@ -2881,10 +2935,7 @@ describe("openclaw agent database", () => {
   it("backfills per-entry status while migrating a v6 agent database", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };
-    const database = openOpenClawAgentDatabase({ agentId: "worker-1", env });
-    const databasePath = database.path;
-    closeOpenClawAgentDatabasesForTest();
-    downgradeCurrentAgentDatabaseToV13(databasePath);
+    const databasePath = materializeV13WorkerAgentDatabase(stateDir);
 
     const { DatabaseSync } = requireNodeSqlite();
     const legacy = new DatabaseSync(databasePath);
@@ -2935,10 +2986,7 @@ describe("openclaw agent database", () => {
   it("replaces the main v5 session indexes during migration", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };
-    const database = openOpenClawAgentDatabase({ agentId: "worker-1", env });
-    const databasePath = database.path;
-    closeOpenClawAgentDatabasesForTest();
-    downgradeCurrentAgentDatabaseToV13(databasePath);
+    const databasePath = materializeV13WorkerAgentDatabase(stateDir);
 
     const { DatabaseSync } = requireNodeSqlite();
     const legacy = new DatabaseSync(databasePath);
@@ -3094,9 +3142,11 @@ describe("openclaw agent database", () => {
   it("repairs same-version additive session-key surfaces before schema validation", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };
-    const opened = openOpenClawAgentDatabase({ agentId: "worker-1", env });
-    const databasePath = opened.path;
-    opened.db
+    const databasePath = materializeCurrentWorkerAgentDatabase(stateDir);
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const shippedSchema = new DatabaseSync(databasePath);
+    shippedSchema
       .prepare(
         `INSERT INTO session_nodes (session_key, current_session_id, entry_json, updated_at)
          VALUES (?, ?, ?, ?)`,
@@ -3107,11 +3157,6 @@ describe("openclaw agent database", () => {
         JSON.stringify({ sessionId: "session-1", updatedAt: 1 }),
         1,
       );
-    closeOpenClawAgentDatabasesForTest();
-    closeOpenClawStateDatabaseForTest();
-
-    const { DatabaseSync } = requireNodeSqlite();
-    const shippedSchema = new DatabaseSync(databasePath);
     try {
       shippedSchema.exec(`
         DROP TRIGGER session_nodes_entry_valid_after_insert;
@@ -3181,9 +3226,7 @@ describe("openclaw agent database", () => {
   it("rejects a missing stable v14 table before the v15 migration", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };
-    const databasePath = openOpenClawAgentDatabase({ agentId: "worker-1", env }).path;
-    closeOpenClawAgentDatabasesForTest();
-    closeOpenClawStateDatabaseForTest();
+    const databasePath = materializeCurrentWorkerAgentDatabase(stateDir);
 
     const { DatabaseSync } = requireNodeSqlite();
     const damaged = new DatabaseSync(databasePath);
@@ -3215,9 +3258,7 @@ describe("openclaw agent database", () => {
   it("adds post-v14 suggestion tables during the v15 migration", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };
-    const databasePath = openOpenClawAgentDatabase({ agentId: "worker-1", env }).path;
-    closeOpenClawAgentDatabasesForTest();
-    closeOpenClawStateDatabaseForTest();
+    const databasePath = materializeCurrentWorkerAgentDatabase(stateDir);
 
     const { DatabaseSync } = requireNodeSqlite();
     const legacy = new DatabaseSync(databasePath);
@@ -3391,16 +3432,7 @@ describe("openclaw agent database", () => {
 
   it("adds transcript watermarks and session provenance to v4 session tables", () => {
     const stateDir = createTempStateDir();
-    const databasePath = path.join(
-      stateDir,
-      "agents",
-      "worker-1",
-      "agent",
-      "openclaw-agent.sqlite",
-    );
-    openOpenClawAgentDatabase({ agentId: "worker-1", env: { OPENCLAW_STATE_DIR: stateDir } });
-    closeOpenClawAgentDatabasesForTest();
-    downgradeCurrentAgentDatabaseToV13(databasePath);
+    const databasePath = materializeV13WorkerAgentDatabase(stateDir);
     const { DatabaseSync } = requireNodeSqlite();
     const db = new DatabaseSync(databasePath);
     db.exec(`
@@ -3490,16 +3522,7 @@ describe("openclaw agent database", () => {
 
   it("adds transcript provenance when upgrading the v7 status schema", () => {
     const stateDir = createTempStateDir();
-    const databasePath = path.join(
-      stateDir,
-      "agents",
-      "worker-1",
-      "agent",
-      "openclaw-agent.sqlite",
-    );
-    openOpenClawAgentDatabase({ agentId: "worker-1", env: { OPENCLAW_STATE_DIR: stateDir } });
-    closeOpenClawAgentDatabasesForTest();
-    downgradeCurrentAgentDatabaseToV13(databasePath);
+    const databasePath = materializeV13WorkerAgentDatabase(stateDir);
     const { DatabaseSync } = requireNodeSqlite();
     const db = new DatabaseSync(databasePath);
     db.exec(`
@@ -3560,16 +3583,7 @@ describe("openclaw agent database", () => {
 
   it("adds the active transcript projection when upgrading v9 databases", () => {
     const stateDir = createTempStateDir();
-    const databasePath = path.join(
-      stateDir,
-      "agents",
-      "worker-1",
-      "agent",
-      "openclaw-agent.sqlite",
-    );
-    openOpenClawAgentDatabase({ agentId: "worker-1", env: { OPENCLAW_STATE_DIR: stateDir } });
-    closeOpenClawAgentDatabasesForTest();
-    downgradeCurrentAgentDatabaseToV13(databasePath);
+    const databasePath = materializeV13WorkerAgentDatabase(stateDir);
     const { DatabaseSync } = requireNodeSqlite();
     const db = new DatabaseSync(databasePath);
     db.exec(`
@@ -3637,16 +3651,7 @@ describe("openclaw agent database", () => {
 
   it("adds durable conversation delivery state when upgrading the canonical v10 schema", () => {
     const stateDir = createTempStateDir();
-    const databasePath = path.join(
-      stateDir,
-      "agents",
-      "worker-1",
-      "agent",
-      "openclaw-agent.sqlite",
-    );
-    openOpenClawAgentDatabase({ agentId: "worker-1", env: { OPENCLAW_STATE_DIR: stateDir } });
-    closeOpenClawAgentDatabasesForTest();
-    downgradeCurrentAgentDatabaseToV13(databasePath);
+    const databasePath = materializeV13WorkerAgentDatabase(stateDir);
     const { DatabaseSync } = requireNodeSqlite();
     const db = new DatabaseSync(databasePath);
     db.exec(`

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -171,7 +171,7 @@ function ensureV13WorkerAgentDatabaseTemplate(): string {
   }
   // Legacy migration cases mutate independent clones; keep one closed, verified v13
   // baseline so the test-only reverse migration is not repeated for every case.
-  const stateDir = makeTempDir(agentDbTempDirs, "openclaw-agent-db-v13-worker-");
+  const stateDir = createTempStateDir();
   const databasePath = resolveOpenClawAgentSqlitePath({
     agentId: "worker-1",
     env: { OPENCLAW_STATE_DIR: stateDir },

--- a/src/state/openclaw-database-verify.test.ts
+++ b/src/state/openclaw-database-verify.test.ts
@@ -18,6 +18,7 @@ import {
   runDatabaseVerifyWorker,
 } from "./openclaw-database-verify.impl.js";
 import {
+  type OpenClawDatabaseVerifyResult,
   type OpenClawDatabaseVerifyTarget,
   verifyOpenClawDatabases,
 } from "./openclaw-database-verify.worker.js";
@@ -107,6 +108,21 @@ function quarantineStorePath(stateDir: string): string {
   return path.join(stateDir, "state", "openclaw-quarantine.sqlite");
 }
 
+function terminalVerificationResult(pathname: string): OpenClawDatabaseVerifyResult {
+  return {
+    path: pathname,
+    ok: false,
+    error: "prepared terminal integrity failure",
+    terminal: true,
+  };
+}
+
+function preparedVerificationResults(
+  targets: readonly OpenClawDatabaseVerifyTarget[],
+): OpenClawDatabaseVerifyResult[] {
+  return targets.map((target) => terminalVerificationResult(target.path));
+}
+
 function readLinuxPosixLocksForPath(pathname: string): string[] {
   if (process.platform !== "linux") {
     return [];
@@ -188,8 +204,8 @@ describe("OpenClaw database integrity verifier", () => {
       { kind: "agent", label: "OpenClaw agent database worker-1", path: agentPath },
     ];
 
-    const directResults = await verifyOpenClawDatabases(targets);
-    expect(directResults).toEqual([
+    const results = await runDatabaseVerifyWorker(targets);
+    expect(results).toEqual([
       {
         path: agentPath,
         ok: false,
@@ -197,11 +213,10 @@ describe("OpenClaw database integrity verifier", () => {
         terminal: true,
       },
     ]);
-    await expect(runDatabaseVerifyWorker(targets)).resolves.toEqual(directResults);
 
     applyOpenClawDatabaseVerificationResults({
       env,
-      results: directResults,
+      results,
       targets,
     });
     const quarantine = readOpenClawDatabaseQuarantine(agentPath, { env });
@@ -243,14 +258,7 @@ describe("OpenClaw database integrity verifier", () => {
     const targets: OpenClawDatabaseVerifyTarget[] = [
       { kind: "agent", label: "OpenClaw agent database worker-1", path: agentPath },
     ];
-    const results = await verifyOpenClawDatabases(targets);
-    expect(results).toEqual([
-      expect.objectContaining({
-        path: agentPath,
-        ok: false,
-        terminal: true,
-      }),
-    ]);
+    const results = preparedVerificationResults(targets);
 
     fs.renameSync(agentPath, corruptArchivePath);
     fs.renameSync(healthyReplacementPath, agentPath);
@@ -273,7 +281,7 @@ describe("OpenClaw database integrity verifier", () => {
       const targets: OpenClawDatabaseVerifyTarget[] = [
         { kind: "agent", label: "OpenClaw agent database worker-1", path: agent.path },
       ];
-      const results = await verifyOpenClawDatabases(targets);
+      const results = preparedVerificationResults(targets);
 
       fs.renameSync(agent.path, corruptArchivePath);
       fs.renameSync(healthyReplacementPath, agent.path);
@@ -298,7 +306,7 @@ describe("OpenClaw database integrity verifier", () => {
       const targets: OpenClawDatabaseVerifyTarget[] = [
         { kind: "state", label: "OpenClaw state database", path: state.path },
       ];
-      const results = await verifyOpenClawDatabases(targets);
+      const results = preparedVerificationResults(targets);
 
       fs.renameSync(state.path, corruptArchivePath);
       fs.renameSync(healthyReplacementPath, state.path);
@@ -320,7 +328,7 @@ describe("OpenClaw database integrity verifier", () => {
     const targets: OpenClawDatabaseVerifyTarget[] = [
       { kind: "agent", label: "OpenClaw agent database worker-1", path: agentPath },
     ];
-    const results = await verifyOpenClawDatabases(targets);
+    const results = preparedVerificationResults(targets);
 
     applyOpenClawDatabaseVerificationResults({ env, results, targets });
 
@@ -342,8 +350,7 @@ describe("OpenClaw database integrity verifier", () => {
     const targets: OpenClawDatabaseVerifyTarget[] = [
       { kind: "agent", label: "OpenClaw agent database worker-1", path: agentPath },
     ];
-    const results = await verifyOpenClawDatabases(targets);
-    expect(results[0]).toEqual(expect.objectContaining({ ok: false, terminal: true }));
+    const results = preparedVerificationResults(targets);
 
     repairUnsafeIndexDrift(agentPath);
     await expect(verifyOpenClawDatabases(targets)).resolves.toEqual([

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -4,7 +4,6 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
-import { pathToFileURL } from "node:url";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import { buildApprovalResolutionRef } from "../infra/approval-resolution-ref.js";
@@ -2636,36 +2635,6 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     );
   });
 
-  it("opens sidecar-free WAL state without creating files beside the source", async () => {
-    const stateDir = createTempStateDir();
-    const databasePath = createCanonicalAuditStateDatabase(stateDir);
-    const { DatabaseSync } = requireNodeSqlite();
-    const walHeader = new DatabaseSync(databasePath);
-    walHeader.exec("PRAGMA journal_mode = WAL; PRAGMA wal_checkpoint(TRUNCATE);");
-    walHeader.close();
-    fs.rmSync(`${databasePath}-wal`, { force: true });
-    fs.rmSync(`${databasePath}-shm`, { force: true });
-    const beforeBytes = fs.readFileSync(databasePath);
-    const beforeEntries = fs.readdirSync(stateDir).toSorted();
-
-    const database = await openExistingOpenClawStateDatabaseReadOnly({ path: databasePath });
-    expect(database).toBeDefined();
-    const openedPath = database?.db.prepare("PRAGMA database_list").get() as
-      | { file?: unknown }
-      | undefined;
-    expect(openedPath?.file).toEqual(expect.any(String));
-    expect(path.resolve(String(openedPath?.file))).not.toBe(path.resolve(databasePath));
-    expect(database?.db.prepare("PRAGMA integrity_check").get()).toEqual({
-      integrity_check: "ok",
-    });
-    const privateDirectory = path.dirname(String(openedPath?.file));
-    expect(database?.walMaintenance.close()).toBe(true);
-
-    expect(fs.existsSync(privateDirectory)).toBe(false);
-    expect(fs.readFileSync(databasePath)).toEqual(beforeBytes);
-    expect(fs.readdirSync(stateDir).toSorted()).toEqual(beforeEntries);
-  });
-
   it("reports success when retrying transient read-only snapshot cleanup", async () => {
     const stateDir = createTempStateDir();
     const databasePath = createCanonicalAuditStateDatabase(stateDir);
@@ -2724,53 +2693,6 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     expect(fs.readFileSync(`${writer.path}-wal`)).toEqual(beforeWal);
     expect(fs.statSync(`${writer.path}-shm`).size).toBe(beforeShmSize);
     expect(fs.readdirSync(stateDir).toSorted()).toEqual(beforeEntries);
-  });
-
-  it("reads committed WAL rows without recreating a missing source SHM", async () => {
-    const { DatabaseSync } = requireNodeSqlite();
-    const sourceDir = createTempStateDir();
-    const writer = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: sourceDir } });
-    writer.db.exec("PRAGMA wal_checkpoint(TRUNCATE); PRAGMA wal_autocheckpoint = 0;");
-    insertTaskRunProbe(writer.db, "task-wal-without-shm");
-    const fixtureDir = createTempStateDir();
-    const fixturePath = path.join(fixtureDir, "wal-without-shm.sqlite");
-    fs.copyFileSync(writer.path, fixturePath);
-    fs.copyFileSync(`${writer.path}-wal`, `${fixturePath}-wal`);
-    const mainOnlyPath = path.join(createTempStateDir(), "main-only.sqlite");
-    fs.copyFileSync(writer.path, mainOnlyPath);
-    closeOpenClawStateDatabaseForTest();
-    expect(fs.existsSync(`${fixturePath}-shm`)).toBe(false);
-    const immutable = new DatabaseSync(`${pathToFileURL(mainOnlyPath).href}?mode=ro&immutable=1`, {
-      readOnly: true,
-    });
-    expect(
-      immutable
-        .prepare("SELECT task_id FROM task_runs WHERE task_id = ?")
-        .get("task-wal-without-shm"),
-    ).toBeUndefined();
-    immutable.close();
-    const beforeMain = fs.readFileSync(fixturePath);
-    const beforeWal = fs.readFileSync(`${fixturePath}-wal`);
-    const beforeEntries = fs.readdirSync(fixtureDir).toSorted();
-
-    const database = await openExistingOpenClawStateDatabaseReadOnly({ path: fixturePath });
-    expect(
-      database?.db
-        .prepare("SELECT task_id FROM task_runs WHERE task_id = ?")
-        .get("task-wal-without-shm"),
-    ).toEqual({ task_id: "task-wal-without-shm" });
-    const openedPath = database?.db.prepare("PRAGMA database_list").get() as
-      | { file?: unknown }
-      | undefined;
-    const privateDirectory = path.dirname(String(openedPath?.file));
-    expect(path.resolve(String(openedPath?.file))).not.toBe(path.resolve(fixturePath));
-    expect(database?.walMaintenance.close()).toBe(true);
-
-    expect(fs.existsSync(privateDirectory)).toBe(false);
-    expect(fs.existsSync(`${fixturePath}-shm`)).toBe(false);
-    expect(fs.readFileSync(fixturePath)).toEqual(beforeMain);
-    expect(fs.readFileSync(`${fixturePath}-wal`)).toEqual(beforeWal);
-    expect(fs.readdirSync(fixtureDir).toSorted()).toEqual(beforeEntries);
   });
 
   it("rejects noncanonical indexes from read-only state without rewriting them", async () => {


### PR DESCRIPTION
## Summary

- build one closed, integrity-checked v13 agent database template and clone it for legacy migration cases
- let verifier apply-time race tests consume prepared advisory failures because the production owner always reconfirms the current pathname
- keep the live-WAL state integration while relying on the stronger readonly-location owner suite for sidecar-free and missing-SHM snapshot mechanics

## Why

The agent migration tests rebuilt the full current schema and then executed the same test-only reverse migration for every legacy case. Verifier race tests repeatedly classified corruption even though `applyOpenClawDatabaseVerificationResults` deliberately ignores advisory error details and reconfirms the authoritative file. Two state-wrapper WAL cases duplicated lower-level snapshot invariants already covered at their owning boundary.

The new template is checkpointed, sidecar-free, and verified for integrity, foreign keys, schema version, owner identity, and expected v13 tables before any clone is used. Every production migration, reopen, registration, ownership, WAL, and quarantine path remains real.

## Proof

- focused changed suites: 221 passed, 5 skipped
- readonly-location owner plus cache suite: 16 passed
- final full `core-unit-src-security`: unit-src 341 passed files, 2 skipped files, 4,227 passed tests, 12 skipped tests; unit-security 35 passed files and 254 passed tests
- controlled same-path A/B with identical source bytes, cache, configs, and three workers: 163.48s baseline to 152.41s candidate, saving 11.07s
- local fallback `check:changed`: clean
- autoreview: clean, no accepted or actionable findings

The two removed wrapper tests are duplicate integration assertions; their WAL snapshot mechanics remain covered in `src/infra/sqlite-readonly-location.test.ts`, and `src/state/openclaw-state-db.test.ts` retains the live-WAL integration. Production LOC delta is zero; the test diff is net -66 lines.

No changelog entry: test-only performance work.
