### PR TITLE
test(system-agent): reduce suite setup overhead

### DIFF
--- a/src/system-agent/assistant.ts
+++ b/src/system-agent/assistant.ts
@@ -3,7 +3,7 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { SessionManager } from "../agents/sessions/index.js";
+import { SessionManager } from "../agents/sessions/session-manager.js";
 import {
   SYSTEM_AGENT_ASSISTANT_SYSTEM_PROMPT,
   SYSTEM_AGENT_GREETING_SYSTEM_PROMPT,

--- a/src/system-agent/operations-execute.ts
+++ b/src/system-agent/operations-execute.ts
@@ -1,6 +1,5 @@
 // Public operation dispatcher. Parsing and mutation helpers live in focused modules.
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import { createAgent } from "../agents/agent-create.js";
 import { buildAgentMainSessionKey, normalizeAgentId } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveUserPath, shortenHomePath } from "../utils.js";
@@ -407,8 +406,10 @@ export async function executeSystemAgentOperation(
         runtime,
         opts,
         run: async (ctx) => {
+          const createAgentForOperation =
+            ctx.deps?.createAgent ?? (await import("../agents/agent-create.js")).createAgent;
           const result = await ctx.commit(async () => {
-            return await (ctx.deps?.createAgent ?? createAgent)({
+            return await createAgentForOperation({
               name: operation.agentId,
               ...(operation.workspace ? { workspace: operation.workspace } : {}),
             });

--- a/src/system-agent/operations-setup-flows.test.ts
+++ b/src/system-agent/operations-setup-flows.test.ts
@@ -5,7 +5,7 @@ import {
   isPersistentSystemAgentOperation,
   parseSystemAgentOperation,
 } from "./operations.js";
-import { createSystemAgentTestRuntime } from "./system-agent.test-helpers.js";
+import { createSystemAgentTestRuntime } from "./system-agent.runtime.test-support.js";
 
 describe("system agent setup-flow operations", () => {
   it("parses channel listing and connect requests", () => {

--- a/src/system-agent/operations.setup-transaction.test.ts
+++ b/src/system-agent/operations.setup-transaction.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resetPluginStateStoreForTests } from "../plugin-state/plugin-state-store.js";
@@ -7,7 +7,11 @@ import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { SystemAgentInferenceUnavailableError } from "./inference-error.js";
 import { executeSystemAgentOperation, type SystemAgentCommandDeps } from "./operations.js";
 import type { SystemAgentSetupApplyResult } from "./setup-apply.js";
-import { createSystemAgentTestRuntime } from "./system-agent.test-helpers.js";
+import { createSystemAgentTestRuntime } from "./system-agent.runtime.test-support.js";
+import {
+  installSystemAgentPluginMetadataTestSnapshot,
+  type SystemAgentPluginMetadataTestSnapshot,
+} from "./system-agent.test-helpers.js";
 
 const mocks = vi.hoisted(() => ({ ensureOnboardingAgent: vi.fn() }));
 
@@ -43,8 +47,10 @@ const mockConfig = vi.hoisted(() => {
     exists: true,
     config: { agents: { entries: { main: { default: true } } } } as OpenClawConfig,
   };
+  let bindPluginMetadata = (_config: OpenClawConfig) => {};
   const snapshot = () => {
     const config = structuredClone(state.config);
+    bindPluginMetadata(config);
     return {
       exists: state.exists,
       valid: state.exists,
@@ -66,6 +72,7 @@ const mockConfig = vi.hoisted(() => {
       state.path = "/tmp/openclaw.json";
       state.exists = true;
       state.config = { agents: { entries: { main: { default: true } } } };
+      bindPluginMetadata(state.config);
       readConfigFileSnapshot.mockReset().mockImplementation(async () => snapshot());
       withConfigMutationExclusive
         .mockReset()
@@ -74,9 +81,17 @@ const mockConfig = vi.hoisted(() => {
     missing(configPath: string) {
       state.path = configPath;
       state.exists = false;
+      bindPluginMetadata(state.config);
     },
     setConfig(config: OpenClawConfig) {
       state.config = structuredClone(config);
+      bindPluginMetadata(state.config);
+    },
+    bindPluginMetadata(config: OpenClawConfig) {
+      bindPluginMetadata(config);
+    },
+    setPluginMetadataBinder(binder: (config: OpenClawConfig) => void) {
+      bindPluginMetadata = binder;
     },
     readConfigFileSnapshot,
     withConfigMutationExclusive,
@@ -160,6 +175,20 @@ function createRecoverySetupDeps(
 }
 
 const opTempDirs = useAutoCleanupTempDirTracker(afterEach);
+let pluginMetadataSnapshot: SystemAgentPluginMetadataTestSnapshot | undefined;
+
+beforeAll(() => {
+  pluginMetadataSnapshot = installSystemAgentPluginMetadataTestSnapshot();
+  mockConfig.setPluginMetadataBinder((config) => {
+    pluginMetadataSnapshot?.bindForConfig(config);
+  });
+  mockConfig.reset();
+});
+
+afterAll(() => {
+  mockConfig.setPluginMetadataBinder(() => {});
+  pluginMetadataSnapshot?.restore();
+});
 
 describe("system-agent setup transaction", () => {
   let stateDirSnapshot: ReturnType<typeof captureEnv> | undefined;
@@ -188,6 +217,7 @@ describe("system-agent setup transaction", () => {
         list: [{ id: "main", default: true }],
       },
     } satisfies OpenClawConfig;
+    mockConfig.bindPluginMetadata(config);
     mockConfig.readConfigFileSnapshot.mockResolvedValue({
       exists: true,
       valid: true,

--- a/src/system-agent/operations.setup.test.ts
+++ b/src/system-agent/operations.setup.test.ts
@@ -9,13 +9,15 @@ import { resetPluginStateStoreForTests } from "../plugin-state/plugin-state-stor
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { SystemAgentInferenceUnavailableError } from "./inference-error.js";
 import { executeSystemAgentOperation, type SystemAgentCommandDeps } from "./operations.js";
+import { createSystemAgentTestRuntime } from "./system-agent.runtime.test-support.js";
 import {
-  createSystemAgentTestRuntime,
   expectSystemAgentAuditRecord as expectAuditRecord,
   expectTestRecordFields as expectRecordFields,
   installSystemAgentClaudeCliBackendTestFixture,
+  installSystemAgentPluginMetadataTestSnapshot,
   readLastSystemAgentAuditEntry as readLastAuditEntry,
   requireTestRecord as requireRecord,
+  type SystemAgentPluginMetadataTestSnapshot,
 } from "./system-agent.test-helpers.js";
 
 type TestConfig = Record<string, unknown>;
@@ -29,8 +31,10 @@ const mockConfig = vi.hoisted(() => {
     hash: "mock-hash-0" as string | undefined,
   };
   const cloneConfig = () => structuredClone(state.config);
+  let bindPluginMetadata = (_config: TestConfig) => {};
   const snapshot = () => {
     const config = cloneConfig();
+    bindPluginMetadata(config);
     return {
       path: state.path,
       exists: state.exists,
@@ -53,18 +57,24 @@ const mockConfig = vi.hoisted(() => {
       state.exists = true;
       state.config = { agents: { entries: { main: { default: true } } } };
       state.hash = "mock-hash-0";
+      bindPluginMetadata(state.config);
     },
     missing(pathLocal: string) {
       state.path = pathLocal;
       state.exists = false;
       state.config = { agents: { entries: { main: { default: true } } } };
       state.hash = undefined;
+      bindPluginMetadata(state.config);
     },
     currentConfig() {
       return cloneConfig();
     },
     setConfig(config: TestConfig) {
       state.config = structuredClone(config);
+      bindPluginMetadata(state.config);
+    },
+    setPluginMetadataBinder(binder: (config: TestConfig) => void) {
+      bindPluginMetadata = binder;
     },
     readConfigFileSnapshot: vi.fn(async () => snapshot()),
     mutateConfigFile: vi.fn(
@@ -80,10 +90,12 @@ const mockConfig = vi.hoisted(() => {
         const before = snapshot();
         const draft = cloneConfig();
         await params.mutate(draft, { snapshot: before });
+        bindPluginMetadata(draft);
         await params.writeOptions?.preCommitRuntimePreflight?.(structuredClone(draft));
         state.exists = true;
         state.config = draft;
         state.hash = "mock-hash-1";
+        bindPluginMetadata(state.config);
         return {
           path: state.path,
           previousHash: before.hash ?? null,
@@ -148,12 +160,20 @@ vi.mock("../state/local-onboarding-state.js", () => ({
 
 const opTempDirs = useAutoCleanupTempDirTracker(afterEach);
 let restoreCliBackendFixture: (() => void) | undefined;
+let pluginMetadataSnapshot: SystemAgentPluginMetadataTestSnapshot | undefined;
 
 beforeAll(() => {
   restoreCliBackendFixture = installSystemAgentClaudeCliBackendTestFixture();
+  pluginMetadataSnapshot = installSystemAgentPluginMetadataTestSnapshot();
+  mockConfig.setPluginMetadataBinder((config) => {
+    pluginMetadataSnapshot?.bindForConfig(config as OpenClawConfig);
+  });
+  mockConfig.reset();
 });
 
 afterAll(() => {
+  mockConfig.setPluginMetadataBinder(() => {});
+  pluginMetadataSnapshot?.restore();
   restoreCliBackendFixture?.();
 });
 

--- a/src/system-agent/operations.test.ts
+++ b/src/system-agent/operations.test.ts
@@ -14,7 +14,7 @@ import {
   isPersistentSystemAgentOperation,
   parseSystemAgentOperation,
 } from "./operations.js";
-import { createSystemAgentTestRuntime } from "./system-agent.test-helpers.js";
+import { createSystemAgentTestRuntime } from "./system-agent.runtime.test-support.js";
 
 type TestConfig = Record<string, unknown>;
 

--- a/src/system-agent/operations.tui.test.ts
+++ b/src/system-agent/operations.tui.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { withTempHome } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it, vi } from "vitest";
 import { executeSystemAgentOperation, isPersistentSystemAgentOperation } from "./operations.js";
-import { createSystemAgentTestRuntime } from "./system-agent.test-helpers.js";
+import { createSystemAgentTestRuntime } from "./system-agent.runtime.test-support.js";
 
 describe("system-agent TUI operations", () => {
   it("refuses doctor repairs before any write or audit", async () => {

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -17,11 +17,8 @@ import { detectInferenceBackends } from "../commands/onboard-inference.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
-import { setCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
-import { resolveInstalledPluginIndexPolicyHash } from "../plugins/installed-plugin-index-policy.js";
 import { withoutPluginInstallRecords } from "../plugins/installed-plugin-index-records.js";
 import { hasRetainedManagedNpmInstallMarker } from "../plugins/managed-npm-retention.js";
-import { resolvePluginControlPlaneFingerprint } from "../plugins/plugin-control-plane-context.js";
 import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import type { ProviderAuthChoiceMetadata } from "../plugins/provider-auth-choices.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
@@ -137,17 +134,12 @@ const suiteTempRootTracker = createSuiteTempRootTracker({
   prefix: "setup-inference-test-",
 });
 let pluginMetadataSnapshot: SystemAgentPluginMetadataTestSnapshot | undefined;
-let preparedPluginMetadataSnapshot: ReturnType<typeof resolvePluginMetadataSnapshot> | undefined;
 let inMemoryAuthProfileStores = new Map<string, AuthProfileStore>();
 
 beforeAll(async () => {
   pluginMetadataSnapshot = installSystemAgentPluginMetadataTestSnapshot(
     materializedMainRuntimeConfig,
   );
-  preparedPluginMetadataSnapshot = resolvePluginMetadataSnapshot({
-    config: materializedMainRuntimeConfig,
-    env: process.env,
-  });
   cliBackendsTesting.setDepsForTest({
     resolvePluginSetupCliBackend: () => undefined,
     resolvePluginSetupRegistry: () => ({ cliBackends: [] }) as never,
@@ -302,7 +294,7 @@ function withSuiteFixtures<
   if (!deps.readCodexCliActiveApiKey) {
     deps.readCodexCliActiveApiKey = () => null;
   }
-  deps.resolvePluginMetadataSnapshot ??= bindPreparedPluginMetadataSnapshot;
+  deps.resolvePluginMetadataSnapshot ??= pluginMetadataSnapshot?.bind;
   if (!useRealAuthProfileStore) {
     deps.updateAuthProfileStoreWithLock ??= updateInMemoryAuthProfileStoreWithLock;
     deps.loadPersistedAuthProfileStore ??= loadInMemoryPersistedAuthProfileStore;
@@ -313,7 +305,7 @@ function withSuiteFixtures<
     const readConfigFileSnapshot = deps.readConfigFileSnapshot;
     deps.readConfigFileSnapshot = (async (...args: Parameters<typeof readConfigFileSnapshot>) => {
       const snapshot = await readConfigFileSnapshot(...args);
-      bindPreparedPluginMetadataSnapshot({
+      pluginMetadataSnapshot?.bind({
         config: snapshot.runtimeConfig ?? snapshot.config,
         env: process.env,
       });
@@ -440,7 +432,7 @@ async function verifySetupInferenceConfig(
   },
 ): ReturnType<typeof verifySetupInferenceConfigImpl> {
   const { useRealAuthProfileStore = false, ...verifyParams } = params;
-  bindPreparedPluginMetadataSnapshot({ config: verifyParams.config, env: process.env });
+  pluginMetadataSnapshot?.bind({ config: verifyParams.config, env: process.env });
   return verifySetupInferenceConfigImpl({
     runtime,
     ...verifyParams,
@@ -533,41 +525,6 @@ function mockCodexRuntimeInstall(installRecord?: PluginInstallRecord) {
     installed: true,
     status: "installed" as const,
   })) as never;
-}
-
-function requirePreparedPluginMetadataSnapshot() {
-  if (!preparedPluginMetadataSnapshot) {
-    throw new Error("setup inference plugin metadata fixture was not initialized");
-  }
-  return preparedPluginMetadataSnapshot;
-}
-
-function bindPreparedPluginMetadataSnapshot(
-  params: Parameters<typeof resolvePluginMetadataSnapshot>[0],
-) {
-  const prepared = requirePreparedPluginMetadataSnapshot();
-  const policyHash = resolveInstalledPluginIndexPolicyHash(params.config);
-  const index =
-    prepared.index.policyHash === policyHash ? prepared.index : { ...prepared.index, policyHash };
-  const snapshot = {
-    ...prepared,
-    index,
-    policyHash,
-    configFingerprint: resolvePluginControlPlaneFingerprint({
-      config: params.config,
-      env: params.env,
-      index,
-      policyHash,
-      workspaceDir: params.workspaceDir,
-    }),
-    ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
-  };
-  setCurrentPluginMetadataSnapshot(snapshot, {
-    config: params.config,
-    env: params.env,
-    workspaceDir: params.workspaceDir,
-  });
-  return snapshot;
 }
 
 function activateCodexSetup(params: Omit<TestSetupInferenceActivationParams, "kind">) {

--- a/src/system-agent/system-agent.runtime.test-support.ts
+++ b/src/system-agent/system-agent.runtime.test-support.ts
@@ -1,0 +1,16 @@
+import type { RuntimeEnv } from "../runtime.js";
+
+/** Create a RuntimeEnv that records log/error lines for tests. */
+export function createSystemAgentTestRuntime(): { runtime: RuntimeEnv; lines: string[] } {
+  const lines: string[] = [];
+  return {
+    lines,
+    runtime: {
+      log: (...args) => lines.push(args.join(" ")),
+      error: (...args) => lines.push(args.join(" ")),
+      exit: (code) => {
+        throw new Error(`exit ${code}`);
+      },
+    },
+  };
+}

--- a/src/system-agent/system-agent.test-helpers.ts
+++ b/src/system-agent/system-agent.test-helpers.ts
@@ -13,8 +13,9 @@ import { resolveCliRuntimeExecutionProvider } from "../agents/model-runtime-alia
 import { resolveSimpleCompletionSelectionForAgent } from "../agents/simple-completion-runtime.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { installTemporaryCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
+import { resolveInstalledPluginIndexPolicyHash } from "../plugins/installed-plugin-index-policy.js";
+import { resolvePluginControlPlaneFingerprint } from "../plugins/plugin-control-plane-context.js";
 import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
-import type { RuntimeEnv } from "../runtime.js";
 import { listSystemAgentAuditEntriesForTests } from "./audit.test-support.js";
 import { resolveSystemAgentConfiguredRouteFromConfig } from "./inference-route.js";
 import {
@@ -29,6 +30,14 @@ type SystemAgentVerifiedInferenceTestFixture = {
 };
 
 export type SystemAgentPluginMetadataTestSnapshot = {
+  /** Rebind one prepared inventory to the exact authored config under test. */
+  bind: (
+    params: Parameters<typeof resolvePluginMetadataSnapshot>[0],
+  ) => ReturnType<typeof resolvePluginMetadataSnapshot>;
+  bindForConfig: (
+    config: OpenClawConfig,
+    workspaceDir?: string,
+  ) => ReturnType<typeof resolvePluginMetadataSnapshot>;
   /** Rebind after a test redirects to another empty state root with the same plugin inventory. */
   rebindForCurrentEnv: () => void;
   restore: () => void;
@@ -67,17 +76,41 @@ export function installSystemAgentClaudeCliBackendTestFixture(): () => void {
 export function installSystemAgentPluginMetadataTestSnapshot(
   config: OpenClawConfig = {},
 ): SystemAgentPluginMetadataTestSnapshot {
-  const snapshot = resolvePluginMetadataSnapshot({ config, env: process.env });
+  const prepared = resolvePluginMetadataSnapshot({ config, env: process.env });
   let releaseCurrentSnapshot: () => boolean = () => false;
-  const rebindForCurrentEnv = () => {
+  const bind = (params: Parameters<typeof resolvePluginMetadataSnapshot>[0]) => {
     releaseCurrentSnapshot();
+    const policyHash = resolveInstalledPluginIndexPolicyHash(params.config);
+    const index =
+      prepared.index.policyHash === policyHash ? prepared.index : { ...prepared.index, policyHash };
+    const snapshot = {
+      ...prepared,
+      index,
+      policyHash,
+      configFingerprint: resolvePluginControlPlaneFingerprint({
+        config: params.config,
+        env: params.env,
+        index,
+        policyHash,
+        workspaceDir: params.workspaceDir,
+      }),
+      ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+    };
     releaseCurrentSnapshot = installTemporaryCurrentPluginMetadataSnapshot(snapshot, {
-      config,
-      env: process.env,
+      config: params.config,
+      env: params.env,
+      workspaceDir: params.workspaceDir,
     }).release;
+    return snapshot;
+  };
+  const rebindForCurrentEnv = () => {
+    bind({ config, env: process.env });
   };
   rebindForCurrentEnv();
   return {
+    bind,
+    bindForConfig: (nextConfig, workspaceDir) =>
+      bind({ config: nextConfig, env: process.env, workspaceDir }),
     rebindForCurrentEnv,
     restore: () => {
       releaseCurrentSnapshot();
@@ -295,25 +328,4 @@ export async function createSystemAgentVerifiedInferenceTestFixture(
     deps,
   });
   return { binding, deps };
-}
-
-/**
- * Test helpers for capturing OpenClaw runtime output.
- *
- * Tests use this lightweight runtime instead of the real CLI runtime so exits
- * become thrown errors and logs are easy to assert.
- */
-/** Create a RuntimeEnv that records log/error lines for tests. */
-export function createSystemAgentTestRuntime(): { runtime: RuntimeEnv; lines: string[] } {
-  const lines: string[] = [];
-  return {
-    lines,
-    runtime: {
-      log: (...args) => lines.push(args.join(" ")),
-      error: (...args) => lines.push(args.join(" ")),
-      exit: (code) => {
-        throw new Error(`exit ${code}`);
-      },
-    },
-  };
 }

--- a/src/system-agent/system-agent.test.ts
+++ b/src/system-agent/system-agent.test.ts
@@ -5,10 +5,8 @@ import { SystemAgentInferenceUnavailableError } from "./inference-error.js";
 import type { SystemAgentCommandDeps } from "./operations.js";
 import type { SystemAgentOverview } from "./overview.js";
 import { runSystemAgent, type RunSystemAgentOptions } from "./system-agent.js";
-import {
-  createSystemAgentTestRuntime,
-  createSystemAgentVerifiedInferenceTestFixture,
-} from "./system-agent.test-helpers.js";
+import { createSystemAgentTestRuntime } from "./system-agent.runtime.test-support.js";
+import { createSystemAgentVerifiedInferenceTestFixture } from "./system-agent.test-helpers.js";
 import type { SystemAgentVerifiedInferenceBinding } from "./verified-inference.js";
 
 const inferenceMocks = vi.hoisted(() => ({

--- a/src/system-agent/tui-backend.test.ts
+++ b/src/system-agent/tui-backend.test.ts
@@ -8,18 +8,34 @@ import type { SystemAgentCommandDeps, SystemAgentOperation } from "./operations.
 import type { SystemAgentOverview } from "./overview.js";
 import { createSystemAgentVerifiedInferenceTestFixture } from "./system-agent.test-helpers.js";
 import { runSystemAgentTui, type SystemAgentTuiOptions } from "./tui-backend.js";
+import { resolveSystemAgentVerifiedInferenceRoute } from "./verified-inference.js";
+
+const verifiedInferenceMocks = vi.hoisted(() => ({
+  preparedBindings: new WeakSet<object>(),
+}));
 
 vi.mock("../plugins/providers.js", () => ({
   resolveOwningPluginIdsForModelRefs: vi.fn(() => []),
   resolveOwningPluginIdsForProviderRef: vi.fn(() => []),
 }));
 
-vi.mock("../agents/prepared-model-catalog.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("../agents/prepared-model-catalog.js")>()),
+vi.mock("../agents/prepared-model-catalog.js", () => ({
   // These tests exercise the TUI boundary, not filesystem-backed catalog discovery.
   getPreparedModelCatalogSnapshot: vi.fn(() => undefined),
   loadPreparedModelCatalog: vi.fn(async () => []),
 }));
+
+vi.mock("./verified-inference.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./verified-inference.js")>();
+  return {
+    ...original,
+    resolveSystemAgentVerifiedInferenceRoute: vi.fn(async (binding, deps) =>
+      verifiedInferenceMocks.preparedBindings.has(binding)
+        ? binding.execution
+        : await original.resolveSystemAgentVerifiedInferenceRoute(binding, deps),
+    ),
+  };
+});
 
 const overview: SystemAgentOverview = {
   defaultAgentId: "main",
@@ -82,11 +98,15 @@ beforeAll(async () => {
 async function createVerifiedTuiOptions(
   deps: SystemAgentCommandDeps = {},
   config: OpenClawConfig = verifiedConfig,
+  useRealVerification = false,
 ) {
   const fixture =
     config === verifiedConfig
       ? sharedVerifiedFixture
       : await createSystemAgentVerifiedInferenceTestFixture(config);
+  if (!useRealVerification) {
+    verifiedInferenceMocks.preparedBindings.add(fixture.binding);
+  }
   return {
     verifiedInference: fixture.binding,
     deps: {
@@ -136,21 +156,35 @@ describe("runSystemAgentTui", () => {
   it("runs OpenClaw inside the shared TUI shell", async () => {
     let runTuiCalls = 0;
     let runTuiOptions: unknown;
-    const verified = await createVerifiedTuiOptions({ loadOverview: async () => overview });
+    const verified = await createVerifiedTuiOptions(
+      { loadOverview: async () => overview },
+      verifiedConfig,
+      true,
+    );
+    const resolveVerifiedRoute = vi.mocked(resolveSystemAgentVerifiedInferenceRoute);
+    resolveVerifiedRoute.mockClear();
+    const runTui = vi.fn(
+      async (opts: Parameters<NonNullable<SystemAgentTuiOptions["runTui"]>>[0]) => {
+        runTuiCalls += 1;
+        runTuiOptions = opts;
+        return { exitReason: "exit" as const };
+      },
+    );
 
     await runSystemAgentTui(
       {
         ...verified,
-        runTui: async (opts) => {
-          runTuiCalls += 1;
-          runTuiOptions = opts;
-          return { exitReason: "exit" };
-        },
+        runTui,
       },
       createRuntime(),
     );
 
     expect(runTuiCalls).toBe(1);
+    expect(resolveVerifiedRoute).toHaveBeenCalledOnce();
+    expect(resolveVerifiedRoute).toHaveBeenCalledWith(verified.verifiedInference, verified.deps);
+    expect(resolveVerifiedRoute.mock.invocationCallOrder[0]).toBeLessThan(
+      runTui.mock.invocationCallOrder[0],
+    );
     const options = runTuiOptions as {
       local?: boolean;
       session?: string;

--- a/src/system-agent/tui-backend.test.ts
+++ b/src/system-agent/tui-backend.test.ts
@@ -182,9 +182,12 @@ describe("runSystemAgentTui", () => {
     expect(runTuiCalls).toBe(1);
     expect(resolveVerifiedRoute).toHaveBeenCalledOnce();
     expect(resolveVerifiedRoute).toHaveBeenCalledWith(verified.verifiedInference, verified.deps);
-    expect(resolveVerifiedRoute.mock.invocationCallOrder[0]).toBeLessThan(
-      runTui.mock.invocationCallOrder[0],
-    );
+    const [resolveOrder] = resolveVerifiedRoute.mock.invocationCallOrder;
+    const [runTuiOrder] = runTui.mock.invocationCallOrder;
+    if (resolveOrder === undefined || runTuiOrder === undefined) {
+      throw new Error("expected verified route resolution before TUI startup");
+    }
+    expect(resolveOrder).toBeLessThan(runTuiOrder);
     const options = runTuiOptions as {
       local?: boolean;
       session?: string;

--- a/src/system-agent/tui-backend.ts
+++ b/src/system-agent/tui-backend.ts
@@ -17,7 +17,6 @@ import type {
   TuiSessionList,
   TuiSessionCreateOptions,
 } from "../tui/tui-backend.js";
-import { runTui as defaultRunTui } from "../tui/tui.js";
 import { SYSTEM_AGENT_ID } from "./agent-id.js";
 import type { SystemAgentAssistantPlanner } from "./assistant.js";
 import {
@@ -42,7 +41,7 @@ import {
   type SystemAgentVerifiedInferenceBinding,
 } from "./verified-inference.js";
 
-type RunTui = typeof defaultRunTui;
+type RunTui = typeof import("../tui/tui.js").runTui;
 
 export type SystemAgentTuiOptions = {
   yes?: boolean;
@@ -557,7 +556,7 @@ export async function runSystemAgentTui(
     // an agent handoff uses the normal repair-oriented startup message.
     welcomeVariant = undefined;
     const backend = new SystemAgentTuiBackend(boundOpts, welcome, engine, route);
-    const runTui = boundOpts.runTui ?? defaultRunTui;
+    const runTui = boundOpts.runTui ?? (await import("../tui/tui.js")).runTui;
     try {
       await runTui({
         local: true,


### PR DESCRIPTION
## Summary

- reuse one prepared plugin-metadata inventory across system-agent setup projections while rebinding the exact config, environment, workspace, and policy fingerprint
- keep expensive default TUI, agent-creation, and session-barrel imports out of injected test paths
- move the output-capturing runtime fixture into a dependency-light support module and retain one explicit real TUI route-verification sentinel

## Performance

- focused four-file hotspot: 90/90 tests, 14.54s to 7.22s Vitest wall time (50.3% faster)
- paired Linux CI groups on one c7a.8xlarge with four Vitest workers and shared caches:
  - isolated + fake timers: 48.944s to 47.898s
  - unit-src + security: 98.165s to 93.967s
  - combined sequential wall: 147.109s to 141.865s (5.244s faster)
- exact passing/skipped membership was preserved in every paired group

## Proof

- focused system-agent suites: 254/254 tests
- metadata lease, verified-inference, audit, and restart owner suites: 72/72 tests
- paired Linux groups: 5,997 passing tests and 36 skips in both baseline and candidate
- formatting, diff checks, and Codex autoreview clean

No changelog entry: this is test-performance work plus behavior-preserving lazy imports.
