### PR TITLE
fix(whatsapp): release deferred ingress lane so debounce merges same-chat bursts (#119382)

### DIFF
--- a/extensions/whatsapp/src/inbound/durable-receive.test.ts
+++ b/extensions/whatsapp/src/inbound/durable-receive.test.ts
@@ -135,7 +135,7 @@ describe("createWhatsAppIngressMonitor", () => {
     });
   });
 
-  it("keeps a second same-lane message pending until the first turn adopts", async () => {
+  it("lets a second same-lane message reach the debouncer while the first is deferred", async () => {
     await withTempState(async (stateDir) => {
       const queue = createChannelIngressQueueForTests<WhatsAppDurableInboundPayload>({
         channelId: "whatsapp",
@@ -175,11 +175,14 @@ describe("createWhatsAppIngressMonitor", () => {
       monitor.start();
       await monitor.waitForIdle();
 
-      // Core drain serializes a conversation lane: msg-4b cannot reach the
-      // channel debouncer until msg-4a transfers into the reply lane.
-      expect(dispatched).toEqual(["msg-4a"]);
+      // Deferred means the message sits in the channel debounce window, not
+      // that the conversation lane is busy. The lane is released, so msg-4b
+      // can also reach the debouncer and merge into the same turn.
+      expect(dispatched).toEqual(["msg-4a", "msg-4b"]);
+      // msg-4a is still deferred (claim held for debounce adoption); msg-4b
+      // completed its dispatch and was tombstoned.
       expect((await queue.listClaims()).map((row) => row.id)).toEqual([firstId]);
-      expect((await queue.listPending({ limit: "all" })).map((row) => row.id)).toEqual([secondId]);
+      expect(await queue.listPending({ limit: "all" })).toEqual([]);
 
       if (!adoptFirst) {
         throw new Error("expected first adoption callback");
@@ -187,7 +190,6 @@ describe("createWhatsAppIngressMonitor", () => {
       await adoptFirst();
       await monitor.waitForIdle();
 
-      expect(dispatched).toEqual(["msg-4a", "msg-4b"]);
       expect(await queue.listClaims()).toEqual([]);
       expect(await queue.listPending({ limit: "all" })).toEqual([]);
       await monitor.stop();

--- a/extensions/whatsapp/src/inbound/durable-receive.ts
+++ b/extensions/whatsapp/src/inbound/durable-receive.ts
@@ -137,6 +137,11 @@ export function createWhatsAppIngressMonitor(params: {
       failedMaxEntries: 450,
     },
     drain: {
+      // A deferred claim means the message is sitting in the inbound debounce
+      // window, not that the conversation lane is busy. Release the lane so a
+      // same-chat burst can reach the debouncer and merge into one turn;
+      // holding it starves the merge (see Telegram's identical opt-in).
+      deferredLaneOccupancy: "release",
       resolveNonRetryableFailure: resolveWhatsAppIngressNonRetryableFailure,
       deriveLaneKey: (record) => {
         try {


### PR DESCRIPTION
## What Problem This Solves

`messages.inbound.byChannel.whatsapp` debounce never merges same-chat bursts: every message becomes its own turn and each one pays the full `debounceMs` window. This is #101335 again, on a different channel — WhatsApp moved to the shared durable-ingress drain in 2026.7.2 and inherited the core drain's default `deferredLaneOccupancy: "hold"`, while Telegram was fixed by opting into `"release"`.

## Why

When WhatsApp dispatch enqueues into the debouncer and returns `"deferred"`, the message is sitting in the merge window — the turn is *not* adopted yet. But with the default `"hold"` occupancy, the core drain keeps owning the per-conversation lane (`laneKey: remoteJid`) until `onAdopted` fires *after* the debounce flush. The start loop then refuses to admit message 2 from the same chat (`laneOwnerByKey.get(laneKey)` is still active), so message 2 enters a fresh, empty window and waits the full `debounceMs` again. The debouncer (which merges correctly in isolation) and the per-conversation lane lock are mutually exclusive as wired: the precondition for a merge (≥2 messages inside one window) can never be met.

## User Impact

Users on WhatsApp with inbound debounce configured get N separate turns spaced `debounceMs` apart instead of one merged turn per burst, and the first reply is *later* than with the debouncer disabled. The lane is released the moment a message defers, so a burst can accumulate in the debounce window and flush as a single turn — matching the Telegram behavior after #101335's fix.

## Evidence

- **Code (core drain contract)**: `src/channels/message/ingress-drain.ts:501-506` — with `deferredLaneOccupancy === "release"`, `onDeferred` deletes the lane owner and clears `occupiesLane`, freeing the conversation lane while the claim stays held for debounce adoption. WhatsApp's `createWhatsAppIngressMonitor` (`extensions/whatsapp/src/inbound/durable-receive.ts`) passed no `deferredLaneOccupancy`, so `?? "hold"` applied.
- **Code (fix)**: `extensions/whatsapp/src/inbound/durable-receive.ts` now passes `deferredLaneOccupancy: "release"` in the monitor's `drain` options — the identical opt-in Telegram uses (`extensions/telegram/src/telegram-ingress-drain.ts:391`).
- **Inline verification**: updated `extensions/whatsapp/src/inbound/durable-receive.test.ts` — the previous test asserted the *buggy* behavior ("keeps a second same-lane message pending until the first turn adopts"); it now asserts both same-lane messages reach the dispatcher while the first is deferred (`expect(dispatched).toEqual(["msg-4a", "msg-4b"])`), proving a burst can land inside one debounce window. Run: `npx vitest run extensions/whatsapp/src/inbound/durable-receive.test.ts` → 9/9 passed.

Production delta: +5 lines (one option + explanatory comment), 0 cross-module changes.

[AI-assisted]

## Local verification

- Focused unit coverage updated in `extensions/whatsapp/src/inbound/durable-receive.test.ts` to assert both same-lane messages reach the dispatch queue under `deferredLaneOccupancy: "release"` (matches the Telegram opt-in from #101335's fix).
- Static gates (check-lint, check-test-types, check-prod-types) green on this branch.
