### PR TITLE
fix(agents): preserve schema-valid sessions_send timeouts

### DIFF
--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -46,9 +46,16 @@ vi.mock("../config/config.js", () => ({
 
 import "./test-helpers/fast-openclaw-tools-sessions.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { resetAdjustedParamsByToolCallIdForTests } from "./agent-tools.before-tool-call.state.js";
 import { setActiveEmbeddedRun } from "./embedded-agent-runner/runs.js";
 import { testing as embeddedRunsTesting } from "./embedded-agent-runner/runs.test-support.js";
 import { compactToolOutputHint } from "./tool-schema-hints.js";
+import {
+  createToolSearchCatalogRef,
+  registerHeadlessToolSearchCatalog,
+} from "./tool-search-catalog.js";
+import { resolveToolSearchConfig } from "./tool-search-config.js";
+import { ToolSearchRuntime } from "./tool-search-runtime.js";
 import { testing as agentStepTesting } from "./tools/agent-step.test-support.js";
 import { createSessionsHistoryTool } from "./tools/sessions-history-tool.js";
 import { createSessionsListTool } from "./tools/sessions-list-tool.js";
@@ -286,7 +293,10 @@ describe("sessions tools", () => {
       callGateway: (opts: unknown) => callGatewayMock(opts),
     });
   });
-  afterEach(resetGatewayWorkAdmission);
+  afterEach(() => {
+    resetGatewayWorkAdmission();
+    resetAdjustedParamsByToolCallIdForTests();
+  });
 
   it("uses integer schemas for session count and window parameters", () => {
     const tools = createOpenClawTools();
@@ -1954,51 +1964,87 @@ describe("sessions tools", () => {
     ).toBe(false);
   });
 
-  it("sessions_send preserves terminal timeouts without starting A2A", async () => {
-    const calls: Array<{ method?: string; params?: unknown }> = [];
-    const requesterKey = "agent:main:main";
-    const targetKey = "agent:director1:main";
-    callGatewayMock.mockImplementation(async (opts: unknown) => {
-      const request = opts as { method?: string; params?: unknown };
-      calls.push(request);
-      if (request.method === "agent") {
-        return { runId: "run-terminal", status: "accepted", acceptedAt: 2000 };
-      }
-      if (request.method === "agent.wait") {
-        return {
-          runId: "run-terminal",
-          status: "timeout",
-          endedAt: 3000,
-          stopReason: "timeout",
-          error: "agent run timed out",
-        };
-      }
-      if (request.method === "chat.history") {
-        return { messages: [] };
-      }
-      return {};
-    });
+  it.each([
+    {
+      name: "terminal timeout with an explicit diagnostic",
+      waitResult: {
+        status: "timeout",
+        endedAt: 3000,
+        stopReason: "timeout",
+        error: "agent run timed out",
+      },
+    },
+    {
+      name: "terminal timeout with a provider-specific diagnostic",
+      waitResult: {
+        status: "timeout",
+        endedAt: 3000,
+        stopReason: "timeout",
+        error: "provider request exceeded its deadline",
+      },
+    },
+    {
+      name: "provider-attributed terminal timeout without a diagnostic",
+      waitResult: {
+        status: "ok",
+        endedAt: 3000,
+        timeoutPhase: "provider",
+        providerStarted: true,
+      },
+    },
+  ] as const)(
+    "sessions_send preserves a $name through Tool Search without starting A2A",
+    async ({ waitResult }) => {
+      const calls: Array<{ method?: string; params?: unknown }> = [];
+      const requesterKey = "agent:main:main";
+      const targetKey = "agent:director1:main";
+      callGatewayMock.mockImplementation(async (opts: unknown) => {
+        const request = opts as { method?: string; params?: unknown };
+        calls.push(request);
+        if (request.method === "agent") {
+          return { runId: "run-terminal", status: "accepted", acceptedAt: 2000 };
+        }
+        if (request.method === "agent.wait") {
+          return { runId: "run-terminal", ...waitResult };
+        }
+        if (request.method === "chat.history") {
+          return { messages: [] };
+        }
+        return {};
+      });
 
-    const tool = getSessionTool("sessions_send", {
-      agentSessionKey: requesterKey,
-      agentChannel: "discord",
-    });
+      const tool = getSessionTool("sessions_send", {
+        agentSessionKey: requesterKey,
+        agentChannel: "discord",
+      });
+      const catalogRef = createToolSearchCatalogRef();
+      registerHeadlessToolSearchCatalog({ catalogRef, tools: [tool] });
+      const runtime = new ToolSearchRuntime(
+        { catalogRef },
+        resolveToolSearchConfig({ tools: { toolSearch: { enabled: true, mode: "tools" } } }),
+        { validateInput: true },
+      );
 
-    const result = await tool.execute("call-terminal", {
-      sessionKey: targetKey,
-      message: "ping",
-      timeoutSeconds: 1,
-    });
-    const details = sessionsSendDetails(result.details);
-    expect(details.status).toBe("timeout");
-    expect(details.error).toBe("agent run timed out");
-    expect(details.sentBeforeError).toBe(true);
-    expect(details.sessionKey).toBe(targetKey);
-    await new Promise<void>((resolve) => {
-      setImmediate(resolve);
-    });
-    expect(countMatching(calls, (call) => call.method === "agent")).toBe(1);
-  });
+      const details = sessionsSendDetails(
+        await runtime.callValue("sessions_send", {
+          sessionKey: targetKey,
+          message: "ping",
+          timeoutSeconds: 1,
+        }),
+      );
+      expect(details.status).toBe("timeout");
+      expect(details.error).toBe("error" in waitResult ? waitResult.error : "agent run timed out");
+      expect(details.sentBeforeError).toBe(true);
+      expect(details.sessionKey).toBe(targetKey);
+      expect(details.delivery).toBeUndefined();
+      expect(Value.Check(tool.outputSchema!, details)).toBe(true);
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(countMatching(calls, (call) => call.method === "agent")).toBe(1);
+      expect(countMatching(calls, (call) => call.method === "agent.wait")).toBe(1);
+    },
+  );
 
   it("sessions_send preserves delivery evidence for post-start agent errors", async () => {
     const targetKey = "agent:director1:main";

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -1007,7 +1007,7 @@ export function createSessionsSendTool(opts?: {
             return jsonResult({
               runId,
               status: "timeout",
-              error: result.error,
+              error: result.error ?? "agent run timed out",
               sentBeforeError: true,
               sessionKey: displayKey,
               ...watchField,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an agent sending a message to another session loses the real terminal timeout outcome when the provider reports timeout metadata without an error string. The message has already been dispatched, but Tool Search rejects the completed result against the tool's published output schema, leaving the calling agent without its timeout explanation.

## Why This Change Was Made

The canonical `sessions_send` result producer now supplies the existing generic timeout diagnosis only when the upstream terminal timeout has no diagnostic. Provider-specific diagnostics, timeout classification, session identity, successful-send evidence, delivery behavior, and the existing public output schema remain unchanged; no Gateway protocol, configuration, persistence, provider, or Codex contract changes.

## User Impact

Agents receive a truthful, schema-valid terminal timeout result after an already-dispatched inter-session message instead of losing the result to a Tool Search validation error. Existing provider-specific failure explanations remain visible, and the operation is never replayed.

## Evidence

- Frozen branch head: `1e36d86fbeb8e285f4c96c7517c4e22de551c346`; original base: `3b6cad7e31e1c2ede4727ac9e27044d609e0c206`; independently reviewed two-file binary patch SHA-256: `b5a62cd38b0fa3063b5dbb8d140d09bba9de6480297062c07171e74fd9eb38aa`.
- Authentic before-fix regression failed in both selected Vitest projects: **2 failed**, each reporting `Tool "openclaw:core:sessions_send" returned details that do not match its declared outputSchema.`
- The same focused three-file owner, upstream wait, and Tool Search suites subsequently passed **124/124 tests**, with two additional complete 124/124 reruns:

  ```bash
  node scripts/run-vitest.mjs src/agents/openclaw-tools.sessions.test.ts src/agents/run-wait.test.ts src/agents/tool-search-runtime.test.ts
  ```

- Parameterized boundary coverage exercises the actual headless Tool Search catalog, production `ToolSearchRuntime`, real input/output schema validation, canonical terminal-outcome normalization, and the real `sessions_send` producer for explicit timeout diagnostics, provider-specific diagnostics, and provider-attributed terminal timeouts without diagnostics. Assertions verify the complete published timeout result, no unwanted delivery metadata, exactly one dispatch, and exactly one wait. Gateway RPC is deliberately mocked; this is not claimed as a live Gateway or provider run.
- The underlying omitted timeout diagnosis is present in shipped stable tag `v2026.7.1`. Shipped beta tag `v2026.7.2-beta.7` additionally contains the exact required-string timeout output schema, the same defective producer, and the exact Tool Search validation rejection, proving the complete reported failure is already shipped. The exact reviewed patch applies cleanly to current `main` `392e1c0620b53b29cf98d216ce1081b9f3df4cc3`.
- Four independent owner-boundary, security, lifecycle, and shipped-contract reviews signed the same frozen two-file patch with no P0–P3 findings. Fresh structured review used the actual `gpt-5.6-sol` model with high reasoning, P3 coverage, and no web search: **0 findings, 0.99 confidence**. The pinned real TruffleHog scanner also passed.
- Codex's sibling source was inspected directly before judgment: `codex-rs/protocol/src/dynamic_tools.rs:58`, `codex-rs/core/src/tools/handlers/dynamic.rs:135`, and `codex-rs/app-server/src/dynamic_tools.rs:59`. The fix changes neither Codex's response envelope nor its transport; it repairs OpenClaw's existing declared tool result before that boundary.
- Production change: **+1/-1 lines, net zero**. Regression coverage: **+90/-44 test lines**. No configuration, auth, protocol, SQLite, SDK, dependency, or public schema change.
