### PR TITLE
refactor(plugins): consolidate lifecycle hook dispatch

### DIFF
--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -997,30 +997,6 @@ export function createHookRunner(
   }
 
   /**
-   * Run model_call_started hook.
-   * Allows plugins to observe sanitized model-call metadata.
-   * Runs in parallel (fire-and-forget).
-   */
-  async function runModelCallStarted(
-    event: PluginHookModelCallStartedEvent,
-    ctx: PluginHookAgentContext,
-  ): Promise<void> {
-    return runVoidHook("model_call_started", event, ctx);
-  }
-
-  /**
-   * Run model_call_ended hook.
-   * Allows plugins to observe sanitized terminal model-call metadata.
-   * Runs in parallel (fire-and-forget).
-   */
-  async function runModelCallEnded(
-    event: PluginHookModelCallEndedEvent,
-    ctx: PluginHookAgentContext,
-  ): Promise<void> {
-    return runVoidHook("model_call_ended", event, ctx);
-  }
-
-  /**
    * Run agent_end hook.
    * Allows plugins to analyze completed conversations.
    * Runs handlers in parallel.
@@ -1031,24 +1007,6 @@ export function createHookRunner(
     optionsLocal?: VoidHookRunOptions,
   ): Promise<void> {
     return runVoidHook("agent_end", withAgentRunId(event, ctx), ctx, optionsLocal);
-  }
-
-  /**
-   * Run llm_input hook.
-   * Allows plugins to observe the exact input payload sent to the LLM.
-   * Runs in parallel (fire-and-forget).
-   */
-  async function runLlmInput(event: PluginHookLlmInputEvent, ctx: PluginHookAgentContext) {
-    return runVoidHook("llm_input", event, ctx);
-  }
-
-  /**
-   * Run llm_output hook.
-   * Allows plugins to observe the exact output payload returned by the LLM.
-   * Runs in parallel (fire-and-forget).
-   */
-  async function runLlmOutput(event: PluginHookLlmOutputEvent, ctx: PluginHookAgentContext) {
-    return runVoidHook("llm_output", event, ctx);
   }
 
   /**
@@ -1086,18 +1044,6 @@ export function createHookRunner(
     ctx: PluginHookAgentContext,
   ): Promise<void> {
     return runVoidHook("after_compaction", event, ctx);
-  }
-
-  /**
-   * Run before_reset hook.
-   * Fired when /new or /reset clears a session, before messages are lost.
-   * Runs in parallel (fire-and-forget).
-   */
-  async function runBeforeReset(
-    event: PluginHookBeforeResetEvent,
-    ctx: PluginHookAgentContext,
-  ): Promise<void> {
-    return runVoidHook("before_reset", event, ctx);
   }
 
   // =========================================================================
@@ -1143,28 +1089,6 @@ export function createHookRunner(
       event,
       ctx,
     );
-  }
-
-  /**
-   * Run message_received hook.
-   * Runs in parallel (fire-and-forget).
-   */
-  async function runMessageReceived(
-    event: PluginHookMessageReceivedEvent,
-    ctx: PluginHookMessageContext,
-  ): Promise<void> {
-    return runVoidHook("message_received", event, ctx);
-  }
-
-  /**
-   * Run channel_pairing_requested hook.
-   * Observation-only; slow/failing handlers must not block pairing flow.
-   */
-  async function runChannelPairingRequested(
-    event: Parameters<PluginHookHandlerMap["channel_pairing_requested"]>[0],
-    ctx: Parameters<PluginHookHandlerMap["channel_pairing_requested"]>[1],
-  ): Promise<void> {
-    return runVoidHook("channel_pairing_requested", event, ctx);
   }
 
   /**
@@ -1294,17 +1218,6 @@ export function createHookRunner(
         terminalLabel: "cancel=true",
       },
     );
-  }
-
-  /**
-   * Run message_sent hook.
-   * Runs in parallel (fire-and-forget).
-   */
-  async function runMessageSent(
-    event: PluginHookMessageSentEvent,
-    ctx: PluginHookMessageContext,
-  ): Promise<void> {
-    return runVoidHook("message_sent", event, ctx);
   }
 
   /**
@@ -1525,28 +1438,6 @@ export function createHookRunner(
   // =========================================================================
 
   /**
-   * Run session_start hook.
-   * Runs in parallel (fire-and-forget).
-   */
-  async function runSessionStart(
-    event: PluginHookSessionStartEvent,
-    ctx: PluginHookSessionContext,
-  ): Promise<void> {
-    return runVoidHook("session_start", event, ctx);
-  }
-
-  /**
-   * Run session_end hook.
-   * Runs in parallel (fire-and-forget).
-   */
-  async function runSessionEnd(
-    event: PluginHookSessionEndEvent,
-    ctx: PluginHookSessionContext,
-  ): Promise<void> {
-    return runVoidHook("session_end", event, ctx);
-  }
-
-  /**
    * @deprecated Core prepares thread-bound subagent bindings through channel
    * session-binding adapters before subagent_spawned fires. This remains only
    * for older plugins that call the hook runner directly.
@@ -1579,61 +1470,9 @@ export function createHookRunner(
     );
   }
 
-  /**
-   * Run subagent_spawned hook.
-   * Runs in parallel (fire-and-forget).
-   */
-  async function runSubagentSpawned(
-    event: PluginHookSubagentSpawnedEvent,
-    ctx: PluginHookSubagentContext,
-  ): Promise<void> {
-    return runVoidHook("subagent_spawned", event, ctx);
-  }
-
-  /** Run portable subagent progress presentation hooks. */
-  async function runSubagentProgress(
-    event: PluginHookSubagentProgressEvent,
-    ctx: PluginHookSubagentContext,
-  ): Promise<void> {
-    return runVoidHook("subagent_progress", event, ctx);
-  }
-
-  /**
-   * Run subagent_ended hook.
-   * Runs in parallel (fire-and-forget).
-   */
-  async function runSubagentEnded(
-    event: PluginHookSubagentEndedEvent,
-    ctx: PluginHookSubagentContext,
-  ): Promise<void> {
-    return runVoidHook("subagent_ended", event, ctx);
-  }
-
   // =========================================================================
   // Gateway Hooks
   // =========================================================================
-
-  /**
-   * Run gateway_start hook.
-   * Runs in parallel (fire-and-forget).
-   */
-  async function runGatewayStart(
-    event: PluginHookGatewayStartEvent,
-    ctx: PluginHookGatewayContext,
-  ): Promise<void> {
-    return runVoidHook("gateway_start", event, ctx);
-  }
-
-  /**
-   * Run gateway_stop hook.
-   * Runs in parallel (fire-and-forget).
-   */
-  async function runGatewayStop(
-    event: PluginHookGatewayStopEvent,
-    ctx: PluginHookGatewayContext,
-  ): Promise<void> {
-    return runVoidHook("gateway_stop", event, ctx);
-  }
 
   async function runHeartbeatPromptContribution(
     event: PluginHeartbeatPromptContributionEvent,
@@ -1643,26 +1482,6 @@ export function createHookRunner(
       "heartbeat_prompt_contribution",
       PluginHeartbeatPromptContributionResult
     >("heartbeat_prompt_contribution", event, ctx, { mergeResults: mergeAgentTurnPrepare });
-  }
-
-  /**
-   * Run cron_reconciled after the Gateway scheduler reaches a complete state.
-   */
-  async function runCronReconciled(
-    event: PluginHookCronReconciledEvent,
-    ctx: PluginHookCronReconciledContext,
-  ): Promise<void> {
-    return runVoidHook("cron_reconciled", event, ctx);
-  }
-
-  /**
-   * Run cron_changed hook for gateway-owned cron lifecycle changes.
-   */
-  async function runCronChanged(
-    event: PluginHookCronChangedEvent,
-    ctx: PluginHookGatewayContext,
-  ): Promise<void> {
-    return runVoidHook("cron_changed", event, ctx);
   }
 
   // =========================================================================
@@ -1810,28 +1629,52 @@ export function createHookRunner(
     runAgentTurnPrepare,
     runBeforePromptBuild,
     runBeforeAgentReply,
-    runModelCallStarted,
-    runModelCallEnded,
-    runLlmInput,
-    runLlmOutput,
+    runModelCallStarted: async (
+      event: PluginHookModelCallStartedEvent,
+      ctx: PluginHookAgentContext,
+    ): Promise<void> => runVoidHook("model_call_started", event, ctx),
+    runModelCallEnded: async (
+      event: PluginHookModelCallEndedEvent,
+      ctx: PluginHookAgentContext,
+    ): Promise<void> => runVoidHook("model_call_ended", event, ctx),
+    runLlmInput: async (
+      event: PluginHookLlmInputEvent,
+      ctx: PluginHookAgentContext,
+    ): Promise<void> => runVoidHook("llm_input", event, ctx),
+    runLlmOutput: async (
+      event: PluginHookLlmOutputEvent,
+      ctx: PluginHookAgentContext,
+    ): Promise<void> => runVoidHook("llm_output", event, ctx),
     runBeforeAgentFinalize,
     runAgentEnd,
     runBeforeCompaction,
     runAfterCompaction,
-    runBeforeReset,
+    runBeforeReset: async (
+      event: PluginHookBeforeResetEvent,
+      ctx: PluginHookAgentContext,
+    ): Promise<void> => runVoidHook("before_reset", event, ctx),
     // Lifecycle gate hooks
     runBeforeAgentRun,
     // Message hooks
     runInboundClaim,
     runInboundClaimForPlugin,
     runInboundClaimForPluginOutcome,
-    runChannelPairingRequested,
-    runMessageReceived,
+    runChannelPairingRequested: async (
+      event: Parameters<PluginHookHandlerMap["channel_pairing_requested"]>[0],
+      ctx: Parameters<PluginHookHandlerMap["channel_pairing_requested"]>[1],
+    ): Promise<void> => runVoidHook("channel_pairing_requested", event, ctx),
+    runMessageReceived: async (
+      event: PluginHookMessageReceivedEvent,
+      ctx: PluginHookMessageContext,
+    ): Promise<void> => runVoidHook("message_received", event, ctx),
     runBeforeDispatch,
     runReplyDispatch,
     runReplyPayloadSending,
     runMessageSending,
-    runMessageSent,
+    runMessageSent: async (
+      event: PluginHookMessageSentEvent,
+      ctx: PluginHookMessageContext,
+    ): Promise<void> => runVoidHook("message_sent", event, ctx),
     // Tool hooks
     runBeforeToolCall,
     runAfterToolCall,
@@ -1839,19 +1682,46 @@ export function createHookRunner(
     // Message write hooks
     runBeforeMessageWrite,
     // Session hooks
-    runSessionStart,
-    runSessionEnd,
+    runSessionStart: async (
+      event: PluginHookSessionStartEvent,
+      ctx: PluginHookSessionContext,
+    ): Promise<void> => runVoidHook("session_start", event, ctx),
+    runSessionEnd: async (
+      event: PluginHookSessionEndEvent,
+      ctx: PluginHookSessionContext,
+    ): Promise<void> => runVoidHook("session_end", event, ctx),
     runSubagentSpawning,
     runSubagentDeliveryTarget,
-    runSubagentSpawned,
-    runSubagentProgress,
-    runSubagentEnded,
+    runSubagentSpawned: async (
+      event: PluginHookSubagentSpawnedEvent,
+      ctx: PluginHookSubagentContext,
+    ): Promise<void> => runVoidHook("subagent_spawned", event, ctx),
+    runSubagentProgress: async (
+      event: PluginHookSubagentProgressEvent,
+      ctx: PluginHookSubagentContext,
+    ): Promise<void> => runVoidHook("subagent_progress", event, ctx),
+    runSubagentEnded: async (
+      event: PluginHookSubagentEndedEvent,
+      ctx: PluginHookSubagentContext,
+    ): Promise<void> => runVoidHook("subagent_ended", event, ctx),
     // Gateway hooks
-    runGatewayStart,
-    runGatewayStop,
+    runGatewayStart: async (
+      event: PluginHookGatewayStartEvent,
+      ctx: PluginHookGatewayContext,
+    ): Promise<void> => runVoidHook("gateway_start", event, ctx),
+    runGatewayStop: async (
+      event: PluginHookGatewayStopEvent,
+      ctx: PluginHookGatewayContext,
+    ): Promise<void> => runVoidHook("gateway_stop", event, ctx),
     runHeartbeatPromptContribution,
-    runCronReconciled,
-    runCronChanged,
+    runCronReconciled: async (
+      event: PluginHookCronReconciledEvent,
+      ctx: PluginHookCronReconciledContext,
+    ): Promise<void> => runVoidHook("cron_reconciled", event, ctx),
+    runCronChanged: async (
+      event: PluginHookCronChangedEvent,
+      ctx: PluginHookGatewayContext,
+    ): Promise<void> => runVoidHook("cron_changed", event, ctx),
     // Skill hooks
     runSkillProposalEvaluate,
     runSkillProposalChanged,


### PR DESCRIPTION
## What Problem This Solves

Plugin lifecycle observation hooks repeated the same dispatch wrapper 17 times, increasing maintenance cost and the risk of inconsistent hook behavior. This is part of a maintainer-requested project-wide production LOC reduction campaign.

## Why This Change Was Made

Route equivalent observation hooks directly through the existing typed lifecycle dispatcher while preserving every published hook signature, including the pairing hook indexed-access spelling required by the Plugin SDK API contract.

## User Impact

No operator-visible behavior change; plugin event ordering, timeout handling, error isolation, and public types are unchanged. Removes 130 production lines.

## Evidence

- Six focused plugin hook suites; 36 tests covering gateway, cron, message, session, subagent, and model events.
- Full remote changed-file validation on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30968016880
- Independent structured autoreview: Codex `gpt-5.6-sol` with `xhigh` reasoning; no accepted or actionable findings.
- `git diff --check`, scoped formatting, and direct before/after behavioral equivalence checks passed.
- AI-assisted implementation and independent review.

