### PR TITLE
fix(compaction): bound summarization output cap by summary-size budget (#119404)

### DIFF
--- a/packages/agent-core/src/harness/compaction/compaction.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.test.ts
@@ -442,6 +442,65 @@ describe("session-entry compaction budgeting", () => {
 });
 
 describe("generateSummary thinking options", () => {
+  it("bounds the summarization output cap by the summary-size budget, not the input reserve", async () => {
+    const model: Model = {
+      id: "gpt-5.6-sol",
+      name: "GPT 5.6 Sol",
+      api: "openai-chat-completions",
+      provider: "openai",
+      baseUrl: "https://api.openai.com",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200_000,
+      maxTokens: 128_000,
+    };
+    const summaryMessage: AssistantMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "summary" }],
+      api: model.api,
+      provider: model.provider,
+      model: model.id,
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: 1,
+    };
+    const streamFn = vi.fn<StreamFn>((_model, _context, options) => {
+      // reserveTokensFloor: 80000 with model.maxTokens: 128000 used to
+      // authorize 64,000 output tokens per call even though the final merged
+      // summary is hard-capped at 16,000 chars (~4,000 tokens). The output
+      // cap must be bounded by the summary-size budget instead.
+      expect(options?.maxTokens).toBeLessThanOrEqual(4_000);
+      const stream = createAssistantMessageEventStream();
+      stream.push({ type: "done", reason: "stop", message: summaryMessage });
+      stream.end();
+      return stream;
+    });
+
+    const result = await generateSummary(
+      [{ role: "user", content: "hello", timestamp: 1 }],
+      model,
+      80_000,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "off",
+      streamFn,
+    );
+
+    expect(result).toEqual({ ok: true, value: "summary" });
+    expect(streamFn).toHaveBeenCalledOnce();
+  });
+
   it("maps explicit Fable off to low effort for compaction", async () => {
     const model: Model = {
       id: "production-fable",

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -169,9 +169,7 @@ export const DEFAULT_COMPACTION_SETTINGS: CompactionSettings = {
  * summary-size budget, NOT from the input-side reserve floor (which is a
  * context-window holdback and can be 16x larger on high-maxTokens models).
  */
-const MAX_COMPACTION_SUMMARY_OUTPUT_TOKENS = Math.ceil(
-  16_000 / CHARS_PER_TOKEN_ESTIMATE,
-);
+const MAX_COMPACTION_SUMMARY_OUTPUT_TOKENS = Math.ceil(16_000 / CHARS_PER_TOKEN_ESTIMATE);
 
 /** Calculate total context tokens from provider usage. */
 export function calculateContextTokens(usage: Usage): number {

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -159,6 +159,20 @@ export const DEFAULT_COMPACTION_SETTINGS: CompactionSettings = {
   keepRecentTokens: 20000,
 };
 
+/**
+ * Output token budget for a single summarization LLM call.
+ *
+ * The final merged summary is hard-capped at MAX_COMPACTION_SUMMARY_CHARS
+ * (16,000 chars ≈ 4,000 tokens at the shared 4-char/token estimate) by the
+ * compaction safeguard, so authorizing more output per call than can survive
+ * only inflates cost and latency. The output cap must be derived from that
+ * summary-size budget, NOT from the input-side reserve floor (which is a
+ * context-window holdback and can be 16x larger on high-maxTokens models).
+ */
+const MAX_COMPACTION_SUMMARY_OUTPUT_TOKENS = Math.ceil(
+  16_000 / CHARS_PER_TOKEN_ESTIMATE,
+);
+
 /** Calculate total context tokens from provider usage. */
 export function calculateContextTokens(usage: Usage): number {
   if (usage.contextUsage?.state === "available") {
@@ -661,7 +675,9 @@ async function runSummarizationCompletion(params: {
 export async function generateSummary(
   currentMessages: AgentMessage[],
   model: Model,
-  reserveTokens: number,
+  // Retained for positional API compatibility; the per-call output cap is
+  // derived from the summary-size budget, not the input-side reserve.
+  _reserveTokens: number,
   apiKey: string | undefined,
   headers?: Record<string, string>,
   signal?: AbortSignal,
@@ -672,7 +688,7 @@ export async function generateSummary(
   runtime?: AgentCoreCompletionRuntimeDeps,
 ): Promise<Result<string, CompactionError>> {
   const maxTokens = Math.min(
-    Math.floor(0.8 * reserveTokens),
+    MAX_COMPACTION_SUMMARY_OUTPUT_TOKENS,
     model.maxTokens > 0 ? model.maxTokens : Number.POSITIVE_INFINITY,
   );
   let basePrompt = previousSummary ? UPDATE_SUMMARIZATION_PROMPT : SUMMARIZATION_PROMPT;
@@ -974,7 +990,9 @@ export async function compact(
 async function generateTurnPrefixSummary(
   messages: AgentMessage[],
   model: Model,
-  reserveTokens: number,
+  // Retained for positional API compatibility; the per-call output cap is
+  // derived from the summary-size budget, not the input-side reserve.
+  _reserveTokens: number,
   apiKey: string | undefined,
   headers?: Record<string, string>,
   signal?: AbortSignal,
@@ -983,7 +1001,7 @@ async function generateTurnPrefixSummary(
   runtime?: AgentCoreCompletionRuntimeDeps,
 ): Promise<Result<string, CompactionError>> {
   const maxTokens = Math.min(
-    Math.floor(0.5 * reserveTokens),
+    MAX_COMPACTION_SUMMARY_OUTPUT_TOKENS,
     model.maxTokens > 0 ? model.maxTokens : Number.POSITIVE_INFINITY,
   );
   const llmMessages = convertToLlm(messages);


### PR DESCRIPTION
## What Problem This Solves

`agents.defaults.compaction.reserveTokensFloor` is an **input-side** budget (context-window holdback), but `generateSummary` and `generateTurnPrefixSummary` in agent-core reused it as the **output** token cap (`maxTokens`) for summarization LLM calls — `Math.floor(0.8 * reserveTokens)` and `Math.floor(0.5 * reserveTokens)`, clamped only by `model.maxTokens`. On models with a large declared `maxTokens`, the summarization output budget becomes enormous while the final merged summary is hard-capped at 16,000 chars (~4,000 tokens) anyway.

## Why

Worked example from the issue (reserveTokensFloor: 80000): gpt-5.6-sol (maxTokens 128000) resolves a 64,000-token output cap per summarization call, but the final summary is truncated to 16,000 chars ≈ 4,000 tokens — ~16x more output authorized than can survive. `summarizeInStages` runs chunk calls **sequentially**, so each call licensed to ramble inflates wall-clock latency inside a single compaction timeout budget, and intermediate uncapped summaries can overflow the merge call's context window. Raising `reserveTokensFloor` to protect against prompt overflow silently made every compaction chunk call far more expensive and slower, pushing large compactions past their safety timeout.

## User Impact

Large sessions compacted faster, cheaper, and reliably. Operators who raised `reserveTokensFloor` no longer pay for ~16x the output tokens that can survive, and compaction runs are far less likely to exhaust the compaction safety timeout on high-maxTokens models.

## Evidence

- **Code (before)**: `packages/agent-core/src/harness/compaction/compaction.ts` computed `maxTokens = Math.min(Math.floor(0.8 * reserveTokens), model.maxTokens)` in `generateSummary` and `Math.floor(0.5 * reserveTokens)` in `generateTurnPrefixSummary`.
- **Code (after)**: both sites now use `MAX_COMPACTION_SUMMARY_OUTPUT_TOKENS = Math.ceil(16_000 / CHARS_PER_TOKEN_ESTIMATE)` (= 4,000 tokens), derived from the 16,000-char summary cap at the shared 4-char/token estimate, still clamped by `model.maxTokens`. The `reserveTokens` params are retained (prefixed `_`) for positional API compatibility.
- **Regression test** (`compaction.test.ts`): model `maxTokens: 128000` + reserve 80000 previously authorized 64,000 output tokens; the new test asserts `options.maxTokens <= 4_000` in the stream options. Run: `npx vitest run packages/agent-core/src/harness/compaction/compaction.test.ts` → 26/26 passed; branch-summarization + compaction-safeguard suites → 249/249 passed.

Production delta: +15 / -4 lines (constant + two one-line cap substitutions), 0 cross-module changes.

[AI-assisted]

## Local verification

- Rebased branch onto current `main` so this PR contains only the compaction change (the WhatsApp deferred-lane change now lives in #119425 only).
- `npx vitest run packages/agent-core/src/harness/compaction/compaction.test.ts` → 26/26 passed.
- oxlint clean on changed files; oxfmt clean.

## CI status

- Latest CI on head `ecd6b4a62961`: all check-runs green (latest per check).
- `Real behavior proof` check: success.