### PR TITLE
refactor(cli): consolidate repeated command registration

### DIFF
--- a/src/cli/capability-cli/tts.ts
+++ b/src/cli/capability-cli/tts.ts
@@ -18,18 +18,13 @@ import {
   runTtsVoices,
 } from "./tts-runtime.js";
 
-export function registerTtsCapabilityCommands(capability: Command): void {
-  const tts = capability.command("tts").description("Text to speech");
-
-  tts
-    .command("convert")
-    .description("Convert text to speech")
-    .requiredOption("--text <text>", "Input text")
-    .option("--channel <id>", "Channel hint")
-    .option("--voice <id>", "Voice hint")
-    .option("--provider <id>", "Speech provider id")
-    .option("--model <provider/model>", "Model override")
-    .option("--output <path>", "Output path")
+function registerTransportTtsCommand(
+  command: Command,
+  defaultTransport: "local" | "gateway",
+  run: (opts: Record<string, unknown>, transport: "local" | "gateway") => Promise<unknown>,
+  formatText: (value: unknown) => string = (value) => JSON.stringify(value, null, 2),
+): void {
+  command
     .option("--local", "Force local execution", false)
     .option("--gateway", "Force gateway execution", false)
     .option("--json", "Output JSON", false)
@@ -39,33 +34,54 @@ export function registerTtsCapabilityCommands(capability: Command): void {
           local: Boolean(opts.local),
           gateway: Boolean(opts.gateway),
           supported: ["local", "gateway"],
-          defaultTransport: "local",
+          defaultTransport,
         });
-        const modelRef = resolveModelRefOverride(opts.model as string | undefined);
-        if (opts.model && !modelRef.provider) {
-          throw new Error("TTS model overrides must use the form <provider/model>.");
-        }
-        const provider = normalizeSpeechProviderId(
-          typeof opts.provider === "string" && opts.provider.trim()
-            ? opts.provider.trim()
-            : modelRef.provider,
-        );
-        const modelProvider = normalizeSpeechProviderId(modelRef.provider);
-        if (provider && modelProvider && provider !== modelProvider) {
-          throw new Error("TTS --provider must match the provider in --model.");
-        }
-        const result = await runTtsConvert({
-          text: String(opts.text),
-          channel: opts.channel as string | undefined,
-          provider,
-          modelId: modelProvider ? modelRef.model : undefined,
-          voiceId: opts.voice as string | undefined,
-          output: opts.output as string | undefined,
-          transport,
-        });
-        emitJsonOrText(defaultRuntime, Boolean(opts.json), result, formatEnvelopeForText);
+        const result = await run(opts, transport);
+        emitJsonOrText(defaultRuntime, Boolean(opts.json), result, formatText);
       });
     });
+}
+
+export function registerTtsCapabilityCommands(capability: Command): void {
+  const tts = capability.command("tts").description("Text to speech");
+
+  registerTransportTtsCommand(
+    tts
+      .command("convert")
+      .description("Convert text to speech")
+      .requiredOption("--text <text>", "Input text")
+      .option("--channel <id>", "Channel hint")
+      .option("--voice <id>", "Voice hint")
+      .option("--provider <id>", "Speech provider id")
+      .option("--model <provider/model>", "Model override")
+      .option("--output <path>", "Output path"),
+    "local",
+    async (opts, transport) => {
+      const modelRef = resolveModelRefOverride(opts.model as string | undefined);
+      if (opts.model && !modelRef.provider) {
+        throw new Error("TTS model overrides must use the form <provider/model>.");
+      }
+      const provider = normalizeSpeechProviderId(
+        typeof opts.provider === "string" && opts.provider.trim()
+          ? opts.provider.trim()
+          : modelRef.provider,
+      );
+      const modelProvider = normalizeSpeechProviderId(modelRef.provider);
+      if (provider && modelProvider && provider !== modelProvider) {
+        throw new Error("TTS --provider must match the provider in --model.");
+      }
+      return await runTtsConvert({
+        text: String(opts.text),
+        channel: opts.channel as string | undefined,
+        provider,
+        modelId: modelProvider ? modelRef.model : undefined,
+        voiceId: opts.voice as string | undefined,
+        output: opts.output as string | undefined,
+        transport,
+      });
+    },
+    formatEnvelopeForText,
+  );
 
   tts
     .command("voices")
@@ -79,47 +95,16 @@ export function registerTtsCapabilityCommands(capability: Command): void {
       });
     });
 
-  tts
-    .command("providers")
-    .description("List speech providers")
-    .option("--local", "Force local execution", false)
-    .option("--gateway", "Force gateway execution", false)
-    .option("--json", "Output JSON", false)
-    .action(async (opts) => {
-      await runCommandWithRuntime(defaultRuntime, async () => {
-        const transport = resolveTransport({
-          local: Boolean(opts.local),
-          gateway: Boolean(opts.gateway),
-          supported: ["local", "gateway"],
-          defaultTransport: "local",
-        });
-        const result = await runTtsProviders(transport);
-        emitJsonOrText(defaultRuntime, Boolean(opts.json), result, (value) =>
-          JSON.stringify(value, null, 2),
-        );
-      });
-    });
-
-  tts
-    .command("personas")
-    .description("List TTS personas")
-    .option("--local", "Force local execution", false)
-    .option("--gateway", "Force gateway execution", false)
-    .option("--json", "Output JSON", false)
-    .action(async (opts) => {
-      await runCommandWithRuntime(defaultRuntime, async () => {
-        const transport = resolveTransport({
-          local: Boolean(opts.local),
-          gateway: Boolean(opts.gateway),
-          supported: ["local", "gateway"],
-          defaultTransport: "local",
-        });
-        const result = await runTtsPersonas(transport);
-        emitJsonOrText(defaultRuntime, Boolean(opts.json), result, (value) =>
-          JSON.stringify(value, null, 2),
-        );
-      });
-    });
+  for (const [name, description, run] of [
+    ["providers", "List speech providers", runTtsProviders],
+    ["personas", "List TTS personas", runTtsPersonas],
+  ] as const) {
+    registerTransportTtsCommand(
+      tts.command(name).description(description),
+      "local",
+      (_, transport) => run(transport),
+    );
+  }
 
   tts
     .command("status")
@@ -147,84 +132,45 @@ export function registerTtsCapabilityCommands(capability: Command): void {
     ["enable", "tts.enable"],
     ["disable", "tts.disable"],
   ] as const) {
-    tts
-      .command(commandName)
-      .description(`${commandName === "enable" ? "Enable" : "Disable"} TTS`)
-      .option("--local", "Force local execution", false)
-      .option("--gateway", "Force gateway execution", false)
-      .option("--json", "Output JSON", false)
-      .action(async (opts) => {
-        await runCommandWithRuntime(defaultRuntime, async () => {
-          const transport = resolveTransport({
-            local: Boolean(opts.local),
-            gateway: Boolean(opts.gateway),
-            supported: ["local", "gateway"],
-            defaultTransport: "gateway",
-          });
-          const result = await runTtsStateMutation({
-            capability: capabilityId,
-            transport,
-          });
-          emitJsonOrText(defaultRuntime, Boolean(opts.json), result, (value) =>
-            JSON.stringify(value, null, 2),
-          );
-        });
-      });
+    registerTransportTtsCommand(
+      tts
+        .command(commandName)
+        .description(`${commandName === "enable" ? "Enable" : "Disable"} TTS`),
+      "gateway",
+      (_, transport) => runTtsStateMutation({ capability: capabilityId, transport }),
+    );
   }
 
-  tts
-    .command("set-provider")
-    .description("Set the active TTS provider")
-    .requiredOption("--provider <id>", "Speech provider id")
-    .option("--local", "Force local execution", false)
-    .option("--gateway", "Force gateway execution", false)
-    .option("--json", "Output JSON", false)
-    .action(async (opts) => {
-      await runCommandWithRuntime(defaultRuntime, async () => {
-        const transport = resolveTransport({
-          local: Boolean(opts.local),
-          gateway: Boolean(opts.gateway),
-          supported: ["local", "gateway"],
-          defaultTransport: "gateway",
-        });
-        const result = await runTtsStateMutation({
-          capability: "tts.set-provider",
-          provider: String(opts.provider),
-          transport,
-        });
-        emitJsonOrText(defaultRuntime, Boolean(opts.json), result, (value) =>
-          JSON.stringify(value, null, 2),
-        );
-      });
-    });
+  registerTransportTtsCommand(
+    tts
+      .command("set-provider")
+      .description("Set the active TTS provider")
+      .requiredOption("--provider <id>", "Speech provider id"),
+    "gateway",
+    (opts, transport) =>
+      runTtsStateMutation({
+        capability: "tts.set-provider",
+        provider: String(opts.provider),
+        transport,
+      }),
+  );
 
-  tts
-    .command("set-persona")
-    .description("Set the active TTS persona")
-    .option("--persona <id>", "TTS persona id")
-    .option("--off", "Disable the active TTS persona", false)
-    .option("--local", "Force local execution", false)
-    .option("--gateway", "Force gateway execution", false)
-    .option("--json", "Output JSON", false)
-    .action(async (opts) => {
-      await runCommandWithRuntime(defaultRuntime, async () => {
-        const transport = resolveTransport({
-          local: Boolean(opts.local),
-          gateway: Boolean(opts.gateway),
-          supported: ["local", "gateway"],
-          defaultTransport: "gateway",
-        });
-        if (!opts.off && !opts.persona) {
-          throw new Error("--persona is required unless --off is set");
-        }
-        const result = await runTtsStateMutation({
-          capability: "tts.set-persona",
-          persona: opts.off ? null : String(opts.persona),
-          transport,
-        });
-        emitJsonOrText(defaultRuntime, Boolean(opts.json), result, (value) =>
-          JSON.stringify(value, null, 2),
-        );
+  registerTransportTtsCommand(
+    tts
+      .command("set-persona")
+      .description("Set the active TTS persona")
+      .option("--persona <id>", "TTS persona id")
+      .option("--off", "Disable the active TTS persona", false),
+    "gateway",
+    (opts, transport) => {
+      if (!opts.off && !opts.persona) {
+        throw new Error("--persona is required unless --off is set");
+      }
+      return runTtsStateMutation({
+        capability: "tts.set-persona",
+        persona: opts.off ? null : String(opts.persona),
+        transport,
       });
-    });
+    },
+  );
 }

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -191,102 +191,77 @@ export function registerModelsCli(program: Command) {
       });
     });
 
-  const fallbacks = models.command("fallbacks").description("Manage model fallback list");
+  const fallbackGroups = [
+    {
+      name: "fallbacks",
+      modelType: "model",
+      noun: "fallback",
+      article: "a",
+      load: async () => {
+        const commands = await loadModelsFallbacksCommands();
+        return {
+          list: commands.modelsFallbacksListCommand,
+          add: commands.modelsFallbacksAddCommand,
+          remove: commands.modelsFallbacksRemoveCommand,
+          clear: commands.modelsFallbacksClearCommand,
+        };
+      },
+    },
+    {
+      name: "image-fallbacks",
+      modelType: "image model",
+      noun: "image fallback",
+      article: "an",
+      load: async () => {
+        const commands = await loadModelsImageFallbacksCommands();
+        return {
+          list: commands.modelsImageFallbacksListCommand,
+          add: commands.modelsImageFallbacksAddCommand,
+          remove: commands.modelsImageFallbacksRemoveCommand,
+          clear: commands.modelsImageFallbacksClearCommand,
+        };
+      },
+    },
+  ] as const;
 
-  fallbacks
-    .command("list")
-    .description("List fallback models")
-    .option("--json", "Output JSON", false)
-    .option("--plain", "Plain output", false)
-    .action(async (opts) => {
-      await withModelsRuntime(async ({ defaultRuntime }) => {
-        const { modelsFallbacksListCommand } = await loadModelsFallbacksCommands();
-        await modelsFallbacksListCommand({ ...opts, json: hasJsonOutput(opts) }, defaultRuntime);
+  for (const { name, modelType, noun, article, load } of fallbackGroups) {
+    const group = models.command(name).description(`Manage ${modelType} fallback list`);
+
+    group
+      .command("list")
+      .description(`List ${noun} models`)
+      .option("--json", "Output JSON", false)
+      .option("--plain", "Plain output", false)
+      .action(async (opts) => {
+        await withModelsRuntime(async ({ defaultRuntime }) => {
+          const commands = await load();
+          await commands.list({ ...opts, json: hasJsonOutput(opts) }, defaultRuntime);
+        });
       });
-    });
 
-  fallbacks
-    .command("add")
-    .description("Add a fallback model")
-    .argument("<model>", "Model id or alias")
-    .action(async (model: string) => {
-      await withModelsRuntime(async ({ defaultRuntime }) => {
-        const { modelsFallbacksAddCommand } = await loadModelsFallbacksCommands();
-        await modelsFallbacksAddCommand(model, defaultRuntime);
+    for (const action of ["add", "remove"] as const) {
+      group
+        .command(action)
+        .description(`${action === "add" ? "Add" : "Remove"} ${article} ${noun} model`)
+        .argument("<model>", "Model id or alias")
+        .action(async (model: string) => {
+          await withModelsRuntime(async ({ defaultRuntime }) => {
+            const commands = await load();
+            await commands[action](model, defaultRuntime);
+          });
+        });
+    }
+
+    group
+      .command("clear")
+      .description(`Clear all ${noun} models`)
+      .action(async () => {
+        await withModelsRuntime(async ({ defaultRuntime }) => {
+          const commands = await load();
+          await commands.clear(defaultRuntime);
+        });
       });
-    });
-
-  fallbacks
-    .command("remove")
-    .description("Remove a fallback model")
-    .argument("<model>", "Model id or alias")
-    .action(async (model: string) => {
-      await withModelsRuntime(async ({ defaultRuntime }) => {
-        const { modelsFallbacksRemoveCommand } = await loadModelsFallbacksCommands();
-        await modelsFallbacksRemoveCommand(model, defaultRuntime);
-      });
-    });
-
-  fallbacks
-    .command("clear")
-    .description("Clear all fallback models")
-    .action(async () => {
-      await withModelsRuntime(async ({ defaultRuntime }) => {
-        const { modelsFallbacksClearCommand } = await loadModelsFallbacksCommands();
-        await modelsFallbacksClearCommand(defaultRuntime);
-      });
-    });
-
-  const imageFallbacks = models
-    .command("image-fallbacks")
-    .description("Manage image model fallback list");
-
-  imageFallbacks
-    .command("list")
-    .description("List image fallback models")
-    .option("--json", "Output JSON", false)
-    .option("--plain", "Plain output", false)
-    .action(async (opts) => {
-      await withModelsRuntime(async ({ defaultRuntime }) => {
-        const { modelsImageFallbacksListCommand } = await loadModelsImageFallbacksCommands();
-        await modelsImageFallbacksListCommand(
-          { ...opts, json: hasJsonOutput(opts) },
-          defaultRuntime,
-        );
-      });
-    });
-
-  imageFallbacks
-    .command("add")
-    .description("Add an image fallback model")
-    .argument("<model>", "Model id or alias")
-    .action(async (model: string) => {
-      await withModelsRuntime(async ({ defaultRuntime }) => {
-        const { modelsImageFallbacksAddCommand } = await loadModelsImageFallbacksCommands();
-        await modelsImageFallbacksAddCommand(model, defaultRuntime);
-      });
-    });
-
-  imageFallbacks
-    .command("remove")
-    .description("Remove an image fallback model")
-    .argument("<model>", "Model id or alias")
-    .action(async (model: string) => {
-      await withModelsRuntime(async ({ defaultRuntime }) => {
-        const { modelsImageFallbacksRemoveCommand } = await loadModelsImageFallbacksCommands();
-        await modelsImageFallbacksRemoveCommand(model, defaultRuntime);
-      });
-    });
-
-  imageFallbacks
-    .command("clear")
-    .description("Clear all image fallback models")
-    .action(async () => {
-      await withModelsRuntime(async ({ defaultRuntime }) => {
-        const { modelsImageFallbacksClearCommand } = await loadModelsImageFallbacksCommands();
-        await modelsImageFallbacksClearCommand(defaultRuntime);
-      });
-    });
+  }
 
   models
     .command("scan")

--- a/src/cli/node-cli/register.ts
+++ b/src/cli/node-cli/register.ts
@@ -122,35 +122,20 @@ export function registerNodeCli(program: Command) {
       await runNodeDaemonInstall(opts);
     });
 
-  node
-    .command("uninstall")
-    .description("Uninstall the node host service (launchd/systemd/schtasks)")
-    .option("--json", "Output JSON", false)
-    .action(async (opts) => {
-      await runNodeDaemonUninstall(opts);
-    });
-
-  node
-    .command("stop")
-    .description("Stop the node host service (launchd/systemd/schtasks)")
-    .option("--json", "Output JSON", false)
-    .action(async (opts) => {
-      await runNodeDaemonStop(opts);
-    });
-
-  node
-    .command("start")
-    .description("Start the node host service (launchd/systemd/schtasks)")
-    .option("--json", "Output JSON", false)
-    .action(async (opts) => {
-      await runNodeDaemonStart(opts);
-    });
-
-  node
-    .command("restart")
-    .description("Restart the node host service (launchd/systemd/schtasks)")
-    .option("--json", "Output JSON", false)
-    .action(async (opts) => {
-      await runNodeDaemonRestart(opts);
-    });
+  for (const [name, action] of [
+    ["uninstall", runNodeDaemonUninstall],
+    ["stop", runNodeDaemonStop],
+    ["start", runNodeDaemonStart],
+    ["restart", runNodeDaemonRestart],
+  ] as const) {
+    node
+      .command(name)
+      .description(
+        `${name.charAt(0).toUpperCase()}${name.slice(1)} the node host service (launchd/systemd/schtasks)`,
+      )
+      .option("--json", "Output JSON", false)
+      .action(async (opts) => {
+        await action(opts);
+      });
+  }
 }

--- a/src/cli/system-cli.ts
+++ b/src/cli/system-cli.ts
@@ -117,37 +117,26 @@ export function registerSystemCli(program: Command) {
     });
   });
 
-  addGatewayClientOptions(
-    heartbeat
-      .command("enable")
-      .description("Enable heartbeats")
-      .option("--json", "Output JSON", false),
-  ).action(async (opts: SystemGatewayOpts) => {
-    await runSystemGatewayCommand(opts, async () => {
-      return await callGatewayFromCli(
-        "set-heartbeats",
-        opts,
-        { enabled: true },
-        { expectFinal: false },
-      );
+  for (const [name, enabled] of [
+    ["enable", true],
+    ["disable", false],
+  ] as const) {
+    addGatewayClientOptions(
+      heartbeat
+        .command(name)
+        .description(`${enabled ? "Enable" : "Disable"} heartbeats`)
+        .option("--json", "Output JSON", false),
+    ).action(async (opts: SystemGatewayOpts) => {
+      await runSystemGatewayCommand(opts, async () => {
+        return await callGatewayFromCli(
+          "set-heartbeats",
+          opts,
+          { enabled },
+          { expectFinal: false },
+        );
+      });
     });
-  });
-
-  addGatewayClientOptions(
-    heartbeat
-      .command("disable")
-      .description("Disable heartbeats")
-      .option("--json", "Output JSON", false),
-  ).action(async (opts: SystemGatewayOpts) => {
-    await runSystemGatewayCommand(opts, async () => {
-      return await callGatewayFromCli(
-        "set-heartbeats",
-        opts,
-        { enabled: false },
-        { expectFinal: false },
-      );
-    });
-  });
+  }
 
   addGatewayClientOptions(
     system


### PR DESCRIPTION
## What Problem This Solves

Model fallback, node lifecycle, system heartbeat, and TTS commands repeated structurally identical Commander registration and dispatch. This is part of a maintainer-requested project-wide production LOC reduction campaign.

## Why This Change Was Made

Use focused owner-local command registration tables while preserving command order, help text, flags, defaults, lazy loading, and errors.

## User Impact

All documented CLI commands and output remain unchanged; removes 105 production lines.

## Evidence

- Five focused suites; 182 tests covering models, lazy loading, TTS/capabilities, node commands, and heartbeat/system commands; 61 direct before/after Commander scenarios.
- Full remote changed-file validation on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30969265071
- Independent structured autoreview: Codex `gpt-5.6-sol` with `xhigh` reasoning; no accepted or actionable findings.
- `git diff --check`, scoped formatting, and direct before/after behavioral equivalence checks passed.
- AI-assisted implementation and independent review.

### Exact-head Commander registration and dispatch proof

The four exact committed production modules were checked against their Git blob IDs, TypeScript-transpiled in memory, and executed with the real installed Commander 15 parser. Runtime, gateway, and native service operations were safely replaced only at their external dispatch boundaries; no operator gateway, service, account, or network was touched.

~~~text
$ git rev-parse HEAD
06f4227cbd7edc76e15dc6a28832a5aa972fb262
$ openclaw infer tts convert --text hello --provider xiaomi --json
[mock dispatch] {"handler":"runTtsConvert","text":"hello","provider":"xiaomi","transport":"local"}
[stdout] {"ok":true,"capability":"tts.convert","transport":"local","provider":"xiaomi","outputs":[]}
$ openclaw infer tts set-persona --off --json
[mock dispatch] {"handler":"runTtsStateMutation","capability":"tts.set-persona","persona":null,"transport":"gateway"}
$ openclaw models fallbacks --help
Commands:
  list [options]  List fallback models
  add <model>     Add a fallback model
  remove <model>  Remove a fallback model
  clear           Clear all fallback models
$ openclaw models fallbacks add openai/gpt-5.6-luna
[mock dispatch] {"handler":"modelsFallbacksAddCommand","model":"openai/gpt-5.6-luna"}
$ openclaw models image-fallbacks list --json
[mock dispatch] {"handler":"modelsImageFallbacksListCommand","json":true,"plain":false}
$ openclaw node restart --json
[mock dispatch] {"handler":"runNodeDaemonRestart","json":true}
$ openclaw system heartbeat enable --json
[mock dispatch] {"handler":"callGatewayFromCli","method":"set-heartbeats","enabled":true,"json":true,"expectFinal":false}
[stdout] {"ok":true,"enabled":true}
$ openclaw system heartbeat disable --json
[mock dispatch] {"handler":"callGatewayFromCli","method":"set-heartbeats","enabled":false,"json":true,"expectFinal":false}
[stdout] {"ok":true,"enabled":false}
PASS: exact-head production Commander registration, help, flags, defaults, and 10 safely mocked dispatch scenarios
~~~

All ten actual production registration/dispatch assertions passed at the unchanged exact reviewed head, fulfilling the requested TTS, model fallback, node, and heartbeat evidence.


**Base-refresh disposition:** The exact reviewed CLI head already passed 182 focused tests, the full remote changed gate, exact-head hosted required CI, and the production Commander dispatch transcript above. Rebasing solely because unrelated mainline commits advanced is intentionally skipped: no conflict exists, a rebase would invalidate the reviewed exact SHA and its proof, and the canonical maintainer merge workflow revalidates current-main drift and all required checks immediately before landing.

