### PR TITLE
refactor(auto-reply): centralize delivery deduplication and routing

### DIFF
--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -273,22 +273,10 @@ export async function buildReplyPayloads(params: {
       });
     }),
   );
-  const replyTaggedPayloads: ReplyPayload[] = [];
-  for (const payload of replyTaggedPayloadCandidates) {
-    if (isRenderablePayload(payload)) {
-      replyTaggedPayloads.push(payload);
-    }
-  }
-  const silentFilteredPayloads: ReplyPayload[] = [];
-  if (params.silentExpected) {
-    for (const payload of replyTaggedPayloads) {
-      if (shouldKeepPayloadDuringSilentTurn(payload)) {
-        silentFilteredPayloads.push(payload);
-      }
-    }
-  } else {
-    silentFilteredPayloads.push(...replyTaggedPayloads);
-  }
+  const replyTaggedPayloads = replyTaggedPayloadCandidates.filter(isRenderablePayload);
+  const silentFilteredPayloads = params.silentExpected
+    ? replyTaggedPayloads.filter(shouldKeepPayloadDuringSilentTurn)
+    : replyTaggedPayloads;
   const threadedPayloads = params.applyReplyToMode
     ? silentFilteredPayloads.map(params.applyReplyToMode)
     : silentFilteredPayloads;
@@ -305,7 +293,6 @@ export async function buildReplyPayloads(params: {
     messagingToolSentTexts.length > 0 ||
     (params.messagingToolSentMediaUrls?.length ?? 0) > 0 ||
     messagingToolSentTargets.length > 0;
-  const sentMediaUrlFallback = params.messagingToolSentMediaUrls ?? [];
   let dedupedPayloads = threadedPayloads;
   if (shouldCheckMessagingToolDedupe) {
     const dedupeRuntime = await loadReplyPayloadsDedupeRuntime();
@@ -314,51 +301,30 @@ export async function buildReplyPayloads(params: {
     });
     dedupedPayloads = [];
     for (const payload of threadedPayloads) {
-      const payloadMetadata = getReplyPayloadMetadata(payload);
       // Source mirrors exist because an internal sink send must reach the UI and
       // transcript; that send is not outbound evidence for dropping the mirror.
-      if (payloadMetadata?.sourceReplyTranscriptMirror) {
+      if (getReplyPayloadMetadata(payload)?.sourceReplyTranscriptMirror) {
         dedupedPayloads.push(payload);
         continue;
       }
-      const decision = dedupeRuntime.resolveMessagingToolPayloadDedupe({
-        config: params.config,
-        messageProvider,
-        messagingToolSentTargets,
-        originatingTo,
-        originatingThreadId: params.originatingThreadId,
-        replyToId: payload.replyToId,
-        replyToIsExplicit: Boolean(
-          payloadMetadata?.replyToIdExplicit || payload.replyToTag || payload.replyToCurrent,
-        ),
-        replyDelivery: payloadMetadata?.replyDelivery,
-        accountId,
-      });
-      if (!decision.shouldDedupePayloads) {
-        dedupedPayloads.push(payload);
-        continue;
-      }
-      const sentMediaUrls =
-        decision.matchingRoute && !decision.useGlobalSentMediaUrlEvidenceFallback
-          ? decision.routeSentMediaUrls
-          : sentMediaUrlFallback;
-      const sentTexts =
-        decision.matchingRoute && !decision.useGlobalSentTextEvidenceFallback
-          ? decision.routeSentTexts
-          : messagingToolSentTexts;
-      const normalizedSentMediaUrls = await normalizeSentMediaUrlsForDedupe({
-        sentMediaUrls,
-        normalizeMediaPaths: params.normalizeMediaPaths,
-      });
-      const mediaFiltered = dedupeRuntime.filterMessagingToolMediaDuplicates({
-        payloads: [payload],
-        sentMediaUrls: normalizedSentMediaUrls,
-      });
-      const textFiltered = dedupeRuntime.filterMessagingToolDuplicates({
-        payloads: mediaFiltered,
-        sentTexts,
-      });
-      dedupedPayloads.push(...textFiltered);
+      dedupedPayloads.push(
+        ...(await dedupeRuntime.filterMessagingToolReplyPayload({
+          payload,
+          config: params.config,
+          messageProvider,
+          messagingToolSentTargets,
+          originatingTo,
+          originatingThreadId: params.originatingThreadId,
+          accountId,
+          sentMediaUrls: params.messagingToolSentMediaUrls,
+          sentTexts: messagingToolSentTexts,
+          normalizeSentMediaUrls: (sentMediaUrls) =>
+            normalizeSentMediaUrlsForDedupe({
+              sentMediaUrls,
+              normalizeMediaPaths: params.normalizeMediaPaths,
+            }),
+        })),
+      );
     }
   }
   const directlySentTextFragmentsByAssistantMessage = new Map<number | undefined, string[]>();
@@ -441,46 +407,19 @@ export async function buildReplyPayloads(params: {
     return preserveUnsentMediaAfterBlockSend(payload);
   };
   const contentSuppressedPayloads = shouldDropFinalPayloads
-    ? (() => {
-        const preserved: ReplyPayload[] = [];
-        for (const payload of dedupedPayloads) {
-          const next = preserveUnsentMediaAfterBlockSend(payload);
-          if (next) {
-            preserved.push(next);
-          }
-        }
-        return preserved;
-      })()
+    ? dedupedPayloads.flatMap((payload) => preserveUnsentMediaAfterBlockSend(payload) ?? [])
     : params.blockStreamingEnabled
-      ? (() => {
-          const unsent: ReplyPayload[] = [];
-          for (const payload of dedupedPayloads) {
-            if (
-              !params.blockReplyPipeline?.hasSentPayload(payload) &&
-              !isDirectlySentBlockPayload(payload)
-            ) {
-              const next = preserveDirectlyUnsentPayload(payload);
-              if (next) {
-                unsent.push(next);
-              }
-            }
-          }
-          return unsent;
-        })()
+      ? dedupedPayloads.flatMap((payload) =>
+          params.blockReplyPipeline?.hasSentPayload(payload) || isDirectlySentBlockPayload(payload)
+            ? []
+            : (preserveDirectlyUnsentPayload(payload) ?? []),
+        )
       : params.directlySentBlockKeys?.size
-        ? (() => {
-            const unsent: ReplyPayload[] = [];
-            for (const payload of dedupedPayloads) {
-              if (params.directlySentBlockKeys.has(createBlockReplyContentKey(payload))) {
-                continue;
-              }
-              const next = preserveDirectlyUnsentPayload(payload);
-              if (next) {
-                unsent.push(next);
-              }
-            }
-            return unsent;
-          })()
+        ? dedupedPayloads.flatMap((payload) =>
+            isDirectlySentBlockPayload(payload)
+              ? []
+              : (preserveDirectlyUnsentPayload(payload) ?? []),
+          )
         : dedupedPayloads;
   const blockSentMediaUrls = await normalizeSentMediaUrlsForDedupe({
     sentMediaUrls: [
@@ -500,15 +439,8 @@ export async function buildReplyPayloads(params: {
           sentMediaUrls: blockSentMediaUrls,
         })
       : contentSuppressedPayloads;
-  const replyPayloads: ReplyPayload[] = [];
-  for (const payload of filteredPayloads) {
-    if (isRenderablePayload(payload)) {
-      replyPayloads.push(payload);
-    }
-  }
-
   return {
-    replyPayloads,
+    replyPayloads: filteredPayloads.filter(isRenderablePayload),
     didLogHeartbeatStrip,
   };
 }

--- a/src/auto-reply/reply/followup-delivery-payloads.ts
+++ b/src/auto-reply/reply/followup-delivery-payloads.ts
@@ -3,11 +3,7 @@ import type { MessagingToolSend } from "../../agents/embedded-agent-messaging.ty
 import type { ReplyToMode } from "../../config/types.base.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { stripHeartbeatToken } from "../heartbeat.js";
-import {
-  copyReplyPayloadMetadata,
-  getReplyPayloadMetadata,
-  setReplyPayloadMetadata,
-} from "../reply-payload.js";
+import { copyReplyPayloadMetadata, setReplyPayloadMetadata } from "../reply-payload.js";
 import type { OriginatingChannelType } from "../templating.js";
 import type { ReplyPayload } from "../types.js";
 import {
@@ -15,12 +11,7 @@ import {
   resolveOriginMessageProvider,
   resolveOriginMessageTo,
 } from "./origin-routing.js";
-import {
-  applyReplyThreading,
-  filterMessagingToolDuplicates,
-  filterMessagingToolMediaDuplicates,
-  resolveMessagingToolPayloadDedupe,
-} from "./reply-payloads.js";
+import { applyReplyThreading, filterMessagingToolReplyPayload } from "./reply-payloads.js";
 import { createReplyDeliveryContext, resolveReplyToMode } from "./reply-threading.js";
 
 /** Strips empty/heartbeat payloads, applies threading, and dedupes message-tool sends. */
@@ -94,49 +85,20 @@ export function resolveFollowupDeliveryPayloads(params: {
       ...(replyDeliverySource ? { replyDeliverySource } : {}),
     }),
   );
-  const sentMediaUrlFallback = params.sentMediaUrls ?? [];
-  const sentTextFallback = params.sentTexts ?? [];
   const originatingTo = resolveOriginMessageTo({
     originatingTo: params.originatingTo,
   });
-  const dedupedPayloads: ReplyPayload[] = [];
-  for (const payload of replyTaggedPayloads) {
-    const decision = resolveMessagingToolPayloadDedupe({
+  return replyTaggedPayloads.flatMap((payload) =>
+    filterMessagingToolReplyPayload({
+      payload,
       config: params.cfg,
       messageProvider: replyMessageProvider,
       messagingToolSentTargets: params.sentTargets,
       originatingTo,
       originatingThreadId: params.originatingThreadId,
-      replyToId: payload.replyToId,
-      replyToIsExplicit: Boolean(
-        getReplyPayloadMetadata(payload)?.replyToIdExplicit ||
-        payload.replyToTag ||
-        payload.replyToCurrent,
-      ),
-      replyDelivery: getReplyPayloadMetadata(payload)?.replyDelivery,
       accountId,
-    });
-    if (!decision.shouldDedupePayloads) {
-      dedupedPayloads.push(payload);
-      continue;
-    }
-    const sentMediaUrls =
-      decision.matchingRoute && !decision.useGlobalSentMediaUrlEvidenceFallback
-        ? decision.routeSentMediaUrls
-        : sentMediaUrlFallback;
-    const sentTexts =
-      decision.matchingRoute && !decision.useGlobalSentTextEvidenceFallback
-        ? decision.routeSentTexts
-        : sentTextFallback;
-    const mediaFiltered = filterMessagingToolMediaDuplicates({
-      payloads: [payload],
-      sentMediaUrls,
-    });
-    const textFiltered = filterMessagingToolDuplicates({
-      payloads: mediaFiltered,
-      sentTexts,
-    });
-    dedupedPayloads.push(...textFiltered);
-  }
-  return dedupedPayloads;
+      sentMediaUrls: params.sentMediaUrls,
+      sentTexts: params.sentTexts,
+    }),
+  );
 }

--- a/src/auto-reply/reply/reply-payloads-dedupe.runtime.ts
+++ b/src/auto-reply/reply/reply-payloads-dedupe.runtime.ts
@@ -1,10 +1,9 @@
 // Runtime barrel for reply payload dedupe helpers loaded by delivery code.
 export {
-  filterMessagingToolDuplicates,
   filterMessagingToolMediaDuplicates,
+  filterMessagingToolReplyPayload,
   hasEnabledDeliveryOperation,
   hasSourceRoutedMessagingToolDelivery,
   resolveMessagingToolPayloadDedupe,
   shouldDedupeMessagingToolRepliesForRoute,
-  type MessagingToolPayloadDedupeDecision,
 } from "./reply-payloads-dedupe.js";

--- a/src/auto-reply/reply/reply-payloads-dedupe.ts
+++ b/src/auto-reply/reply/reply-payloads-dedupe.ts
@@ -16,11 +16,27 @@ import {
   type ChannelRouteTargetInput,
 } from "../../plugin-sdk/channel-route.js";
 import { normalizeOptionalAccountId } from "../../routing/account-id.js";
-import { copyReplyPayloadMetadata, type ReplyDeliveryContext } from "../reply-payload.js";
+import {
+  copyReplyPayloadMetadata,
+  getReplyPayloadMetadata,
+  type ReplyDeliveryContext,
+} from "../reply-payload.js";
 import type { ReplyPayload } from "../types.js";
 
+type MessagingToolDedupeRouteParams = {
+  config?: OpenClawConfig;
+  messageProvider?: string;
+  messagingToolSentTargets?: MessagingToolSend[];
+  originatingTo?: string;
+  originatingThreadId?: string | number;
+  replyToId?: string;
+  replyToIsExplicit?: boolean;
+  replyDelivery?: ReplyDeliveryContext;
+  accountId?: string;
+};
+
 /** Removes text payloads already sent by message tools. */
-export function filterMessagingToolDuplicates(params: {
+function filterMessagingToolDuplicates(params: {
   payloads: ReplyPayload[];
   sentTexts: string[];
 }): ReplyPayload[] {
@@ -28,12 +44,11 @@ export function filterMessagingToolDuplicates(params: {
   if (sentTexts.length === 0) {
     return payloads;
   }
-  return payloads.filter((payload) => {
-    if (payload.mediaUrl || payload.mediaUrls?.length) {
-      return true;
-    }
-    return !isMessagingToolDuplicate(payload.text ?? "", sentTexts);
-  });
+  return payloads.filter(
+    (payload) =>
+      Boolean(payload.mediaUrl || payload.mediaUrls?.length) ||
+      !isMessagingToolDuplicate(payload.text ?? "", sentTexts),
+  );
 }
 
 /** Removes media payload URLs already sent by message tools. */
@@ -123,12 +138,7 @@ function normalizeProviderForComparison(value?: string): string | undefined {
   if (!trimmed) {
     return undefined;
   }
-  const lowered = normalizeLowercaseStringOrEmpty(trimmed);
-  const normalizedChannel = normalizeAnyChannelId(trimmed);
-  if (normalizedChannel) {
-    return normalizedChannel;
-  }
-  return lowered;
+  return normalizeAnyChannelId(trimmed) || normalizeLowercaseStringOrEmpty(trimmed);
 }
 
 function normalizeThreadIdForComparison(value?: string | number | null): string | undefined {
@@ -152,10 +162,7 @@ function resolveTargetProviderForComparison(params: {
   targetProvider?: string;
 }): string {
   const targetProvider = normalizeProviderForComparison(params.targetProvider);
-  if (!targetProvider || targetProvider === "message") {
-    return params.currentProvider;
-  }
-  return targetProvider;
+  return targetProvider && targetProvider !== "message" ? targetProvider : params.currentProvider;
 }
 
 type MessagingToolDedupeRouteTarget = ChannelRouteTargetInput & {
@@ -236,32 +243,16 @@ function resolveOriginThreadIdForPayload(params: {
 }
 
 /** Returns true when message-tool route evidence says source replies should be deduped. */
-export function shouldDedupeMessagingToolRepliesForRoute(params: {
-  config?: OpenClawConfig;
-  messageProvider?: string;
-  messagingToolSentTargets?: MessagingToolSend[];
-  originatingTo?: string;
-  originatingThreadId?: string | number;
-  replyToId?: string;
-  replyToIsExplicit?: boolean;
-  replyDelivery?: ReplyDeliveryContext;
-  accountId?: string;
-}): boolean {
+export function shouldDedupeMessagingToolRepliesForRoute(
+  params: MessagingToolDedupeRouteParams,
+): boolean {
   return getMatchingMessagingToolReplyTargets(params).length > 0;
 }
 
 /** Finds message-tool sends that target the same channel/account/thread as the source reply. */
-function getMatchingMessagingToolReplyTargets(params: {
-  config?: OpenClawConfig;
-  messageProvider?: string;
-  messagingToolSentTargets?: MessagingToolSend[];
-  originatingTo?: string;
-  originatingThreadId?: string | number;
-  replyToId?: string;
-  replyToIsExplicit?: boolean;
-  replyDelivery?: ReplyDeliveryContext;
-  accountId?: string;
-}): MessagingToolSend[] {
+function getMatchingMessagingToolReplyTargets(
+  params: MessagingToolDedupeRouteParams,
+): MessagingToolSend[] {
   const provider = normalizeProviderForComparison(params.messageProvider);
   if (!provider) {
     return [];
@@ -338,7 +329,7 @@ function getMatchingMessagingToolReplyTargets(params: {
 }
 
 /** Dedupe decision plus route-specific evidence used by final payload filtering. */
-export type MessagingToolPayloadDedupeDecision = {
+type MessagingToolPayloadDedupeDecision = {
   shouldDedupePayloads: boolean;
   matchingRoute: boolean;
   routeSentTexts: string[];
@@ -348,28 +339,13 @@ export type MessagingToolPayloadDedupeDecision = {
 };
 
 /** Resolves whether and how to dedupe final payloads against message-tool sends. */
-export function resolveMessagingToolPayloadDedupe(params: {
-  config?: OpenClawConfig;
-  messageProvider?: string;
-  messagingToolSentTargets?: MessagingToolSend[];
-  originatingTo?: string;
-  originatingThreadId?: string | number;
-  replyToId?: string;
-  replyToIsExplicit?: boolean;
-  replyDelivery?: ReplyDeliveryContext;
-  accountId?: string;
-}): MessagingToolPayloadDedupeDecision {
+export function resolveMessagingToolPayloadDedupe(
+  params: MessagingToolDedupeRouteParams,
+): MessagingToolPayloadDedupeDecision {
   const sentTargets = params.messagingToolSentTargets ?? [];
   const matchingTargets = getMatchingMessagingToolReplyTargets({
-    config: params.config,
-    messageProvider: params.messageProvider,
+    ...params,
     messagingToolSentTargets: sentTargets,
-    originatingTo: params.originatingTo,
-    originatingThreadId: params.originatingThreadId,
-    replyToId: params.replyToId,
-    replyToIsExplicit: params.replyToIsExplicit,
-    replyDelivery: params.replyDelivery,
-    accountId: params.accountId,
   });
   const matchingRoute = matchingTargets.length > 0;
   const routeSentTexts = matchingTargets.flatMap((target) =>
@@ -402,27 +378,76 @@ export function resolveMessagingToolPayloadDedupe(params: {
   };
 }
 
+type FilterMessagingToolReplyPayloadParams = Omit<
+  MessagingToolDedupeRouteParams,
+  "replyToId" | "replyToIsExplicit" | "replyDelivery"
+> & {
+  payload: ReplyPayload;
+  sentMediaUrls?: string[];
+  sentTexts?: string[];
+};
+
+/** Applies route-scoped media and text dedupe in the same order for every reply owner. */
+export function filterMessagingToolReplyPayload(
+  params: FilterMessagingToolReplyPayloadParams & {
+    normalizeSentMediaUrls: (sentMediaUrls: string[]) => Promise<string[]>;
+  },
+): Promise<ReplyPayload[]>;
+export function filterMessagingToolReplyPayload(
+  params: FilterMessagingToolReplyPayloadParams,
+): ReplyPayload[];
+export function filterMessagingToolReplyPayload(
+  params: FilterMessagingToolReplyPayloadParams & {
+    normalizeSentMediaUrls?: (sentMediaUrls: string[]) => Promise<string[]>;
+  },
+): ReplyPayload[] | Promise<ReplyPayload[]> {
+  const metadata = getReplyPayloadMetadata(params.payload);
+  const decision = resolveMessagingToolPayloadDedupe({
+    ...params,
+    replyToId: params.payload.replyToId,
+    replyToIsExplicit: Boolean(
+      metadata?.replyToIdExplicit || params.payload.replyToTag || params.payload.replyToCurrent,
+    ),
+    replyDelivery: metadata?.replyDelivery,
+  });
+  if (!decision.shouldDedupePayloads) {
+    const payloads = [params.payload];
+    return params.normalizeSentMediaUrls ? Promise.resolve(payloads) : payloads;
+  }
+  const sentMediaUrls =
+    decision.matchingRoute && !decision.useGlobalSentMediaUrlEvidenceFallback
+      ? decision.routeSentMediaUrls
+      : (params.sentMediaUrls ?? []);
+  const sentTexts =
+    decision.matchingRoute && !decision.useGlobalSentTextEvidenceFallback
+      ? decision.routeSentTexts
+      : (params.sentTexts ?? []);
+  const filterPayload = (normalizedSentMediaUrls: string[]) =>
+    filterMessagingToolDuplicates({
+      payloads: filterMessagingToolMediaDuplicates({
+        payloads: [params.payload],
+        sentMediaUrls: normalizedSentMediaUrls,
+      }),
+      sentTexts,
+    });
+  return params.normalizeSentMediaUrls
+    ? params.normalizeSentMediaUrls(sentMediaUrls).then(filterPayload)
+    : filterPayload(sentMediaUrls);
+}
+
 /** True when a message-tool send visibly delivered to the source conversation.
  * Route matching keeps cross-provider or unrelated-target tool sends from
  * counting as the source reply. */
-export function hasSourceRoutedMessagingToolDelivery(params: {
-  config?: OpenClawConfig;
-  messageProvider?: string;
-  messagingToolSentTargets?: MessagingToolSend[];
-  messagingToolSentTexts?: string[];
-  messagingToolSentMediaUrls?: string[];
-  originatingTo?: string;
-  originatingThreadId?: string | number;
-  accountId?: string;
-}): boolean {
-  const decision = resolveMessagingToolPayloadDedupe({
-    config: params.config,
-    messageProvider: params.messageProvider,
-    messagingToolSentTargets: params.messagingToolSentTargets,
-    originatingTo: params.originatingTo,
-    originatingThreadId: params.originatingThreadId,
-    accountId: params.accountId,
-  });
+export function hasSourceRoutedMessagingToolDelivery(
+  params: Omit<
+    MessagingToolDedupeRouteParams,
+    "replyToId" | "replyToIsExplicit" | "replyDelivery"
+  > & {
+    messagingToolSentTexts?: string[];
+    messagingToolSentMediaUrls?: string[];
+  },
+): boolean {
+  const decision = resolveMessagingToolPayloadDedupe(params);
   if (!decision.matchingRoute) {
     return false;
   }

--- a/src/auto-reply/reply/reply-payloads.test.ts
+++ b/src/auto-reply/reply/reply-payloads.test.ts
@@ -4,11 +4,11 @@ import { describe, expect, it, vi } from "vitest";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { getReplyPayloadMetadata, setReplyPayloadMetadata } from "../reply-payload.js";
-import { shouldDedupeMessagingToolRepliesForRoute } from "./reply-payloads-dedupe.js";
 import {
   filterMessagingToolMediaDuplicates,
   resolveMessagingToolPayloadDedupe,
-} from "./reply-payloads.js";
+  shouldDedupeMessagingToolRepliesForRoute,
+} from "./reply-payloads-dedupe.js";
 
 function targetsMatchTelegramReplySuppression(params: {
   originTarget: string;

--- a/src/auto-reply/reply/reply-payloads.ts
+++ b/src/auto-reply/reply/reply-payloads.ts
@@ -6,8 +6,4 @@ export {
   isRenderablePayload,
   shouldSuppressReasoningPayload,
 } from "./reply-payloads-base.js";
-export {
-  filterMessagingToolDuplicates,
-  filterMessagingToolMediaDuplicates,
-  resolveMessagingToolPayloadDedupe,
-} from "./reply-payloads-dedupe.js";
+export { filterMessagingToolReplyPayload } from "./reply-payloads-dedupe.js";

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -16,7 +16,6 @@ import { peerKindMatches } from "./peer-kind-match.js";
 import {
   buildAgentMainSessionKey,
   buildAgentPeerSessionKey,
-  DEFAULT_ACCOUNT_ID,
   DEFAULT_AGENT_ID,
   DEFAULT_MAIN_KEY,
   normalizeAccountId,
@@ -85,14 +84,6 @@ export function resolveInboundLastRouteSessionKey(params: {
   return params.route.lastRoutePolicy === "main" ? params.route.mainSessionKey : params.sessionKey;
 }
 
-function normalizeToken(value: string | undefined | null): string {
-  return normalizeLowercaseStringOrEmpty(value);
-}
-
-function normalizeId(value: unknown): string {
-  return normalizeRouteBindingId(value);
-}
-
 export function buildAgentSessionKey(params: {
   agentId: string;
   mainKey?: string;
@@ -103,7 +94,7 @@ export function buildAgentSessionKey(params: {
   dmScope?: "main" | "per-peer" | "per-channel-peer" | "per-account-channel-peer";
   identityLinks?: Record<string, string[]>;
 }): string {
-  const channel = normalizeToken(params.channel) || "unknown";
+  const channel = normalizeLowercaseStringOrEmpty(params.channel) || "unknown";
   const peer = params.peer;
   return buildAgentPeerSessionKey({
     agentId: params.agentId,
@@ -111,14 +102,10 @@ export function buildAgentSessionKey(params: {
     channel,
     accountId: params.accountId,
     peerKind: peer?.kind ?? "direct",
-    peerId: peer ? normalizeId(peer.id) || "unknown" : null,
+    peerId: peer ? normalizeRouteBindingId(peer.id) || "unknown" : null,
     dmScope: params.dmScope,
     identityLinks: params.identityLinks,
   });
-}
-
-function listAgents(cfg: OpenClawConfig) {
-  return listAgentEntries(cfg);
 }
 
 type AgentLookupCache = {
@@ -137,7 +124,7 @@ function resolveAgentLookupCache(cfg: OpenClawConfig): AgentLookupCache {
   }
 
   const byNormalizedId = new Map<string, string>();
-  for (const agent of listAgents(cfg)) {
+  for (const agent of listAgentEntries(cfg)) {
     const rawId = agent.id?.trim();
     if (!rawId) {
       continue;
@@ -235,13 +222,6 @@ type EvaluatedBindingsByChannel = {
   byAnyAccount: EvaluatedBinding[];
 };
 
-function resolveAccountPatternKey(accountPattern: string): string {
-  if (!accountPattern.trim()) {
-    return DEFAULT_ACCOUNT_ID;
-  }
-  return normalizeAccountId(accountPattern);
-}
-
 function buildEvaluatedBindingsByChannel(
   cfg: OpenClawConfig,
 ): Map<string, EvaluatedBindingsByChannel> {
@@ -251,7 +231,7 @@ function buildEvaluatedBindingsByChannel(
     if (!binding || typeof binding !== "object") {
       continue;
     }
-    const channel = normalizeToken(binding.match?.channel);
+    const channel = normalizeLowercaseStringOrEmpty(binding.match?.channel);
     if (!channel) {
       continue;
     }
@@ -274,7 +254,7 @@ function buildEvaluatedBindingsByChannel(
       bucket.byAnyAccount.push(evaluated);
       continue;
     }
-    const accountKey = resolveAccountPatternKey(match.accountPattern);
+    const accountKey = normalizeAccountId(match.accountPattern);
     const existing = bucket.byAccount.get(accountKey);
     if (existing) {
       existing.push(evaluated);
@@ -493,7 +473,7 @@ function normalizePeerConstraint(
     return { state: "none" };
   }
   const kind = normalizeChatType(peer.kind);
-  const id = normalizeId(peer.id);
+  const id = normalizeRouteBindingId(peer.id);
   if (!kind || !id) {
     return { state: "invalid" };
   }
@@ -518,8 +498,8 @@ function normalizeBindingMatch(
   return {
     accountPattern: (match?.accountId ?? "").trim(),
     peer: normalizePeerConstraint(match?.peer),
-    guildId: normalizeId(match?.guildId) || null,
-    teamId: normalizeId(match?.teamId) || null,
+    guildId: normalizeRouteBindingId(match?.guildId) || null,
+    teamId: normalizeRouteBindingId(match?.teamId) || null,
     roles: normalizeRouteBindingRoles(rawRoles),
   };
 }
@@ -573,18 +553,6 @@ function buildResolvedRouteCacheKey(params: {
   ]);
 }
 
-function hasGuildConstraint(match: NormalizedBindingMatch): boolean {
-  return Boolean(match.guildId);
-}
-
-function hasTeamConstraint(match: NormalizedBindingMatch): boolean {
-  return Boolean(match.teamId);
-}
-
-function hasRolesConstraint(match: NormalizedBindingMatch): boolean {
-  return Boolean(match.roles);
-}
-
 function matchesBindingScope(match: NormalizedBindingMatch, scope: BindingScope): boolean {
   if (match.peer.state === "invalid") {
     return false;
@@ -607,16 +575,16 @@ function matchesBindingScope(match: NormalizedBindingMatch, scope: BindingScope)
 }
 
 export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentRoute {
-  const channel = normalizeToken(input.channel);
+  const channel = normalizeLowercaseStringOrEmpty(input.channel);
   const accountId = normalizeAccountId(input.accountId);
   const peer = input.peer
     ? {
         kind: normalizeChatType(input.peer.kind) ?? input.peer.kind,
-        id: normalizeId(input.peer.id),
+        id: normalizeRouteBindingId(input.peer.id),
       }
     : null;
-  const guildId = normalizeId(input.guildId);
-  const teamId = normalizeId(input.teamId);
+  const guildId = normalizeRouteBindingId(input.guildId);
+  const teamId = normalizeRouteBindingId(input.teamId);
   const memberRoleIds = input.memberRoleIds ?? [];
   const memberRoleIdSet = new Set(memberRoleIds);
   const dmScope = input.dmScope ?? input.cfg.session?.dmScope ?? "main";
@@ -625,7 +593,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   const parentPeer = input.parentPeer
     ? {
         kind: normalizeChatType(input.parentPeer.kind) ?? input.parentPeer.kind,
-        id: normalizeId(input.parentPeer.id),
+        id: normalizeRouteBindingId(input.parentPeer.id),
       }
     : null;
 
@@ -732,65 +700,54 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
     enabled: boolean;
     scopePeer: RoutePeer | null;
     candidates: EvaluatedBinding[];
-    predicate: (candidate: EvaluatedBinding) => boolean;
   }> = [
     {
       matchedBy: "binding.peer",
       enabled: Boolean(peer),
       scopePeer: peer,
       candidates: collectPeerIndexedBindings(bindingsIndex, peer),
-      predicate: (candidate) => candidate.match.peer.state === "valid",
     },
     {
       matchedBy: "binding.peer.parent",
       enabled: Boolean(parentPeer && parentPeer.id),
       scopePeer: parentPeer && parentPeer.id ? parentPeer : null,
       candidates: collectPeerIndexedBindings(bindingsIndex, parentPeer),
-      predicate: (candidate) => candidate.match.peer.state === "valid",
     },
     {
       matchedBy: "binding.peer.wildcard",
       enabled: Boolean(peer),
       scopePeer: peer,
       candidates: bindingsIndex.byPeerWildcard,
-      predicate: (candidate) => candidate.match.peer.state === "wildcard-kind",
     },
     {
       matchedBy: "binding.guild+roles",
       enabled: Boolean(guildId && memberRoleIds.length > 0),
       scopePeer: peer,
       candidates: guildId ? (bindingsIndex.byGuildWithRoles.get(guildId) ?? []) : [],
-      predicate: (candidate) =>
-        hasGuildConstraint(candidate.match) && hasRolesConstraint(candidate.match),
     },
     {
       matchedBy: "binding.guild",
       enabled: Boolean(guildId),
       scopePeer: peer,
       candidates: guildId ? (bindingsIndex.byGuild.get(guildId) ?? []) : [],
-      predicate: (candidate) =>
-        hasGuildConstraint(candidate.match) && !hasRolesConstraint(candidate.match),
     },
     {
       matchedBy: "binding.team",
       enabled: Boolean(teamId),
       scopePeer: peer,
       candidates: teamId ? (bindingsIndex.byTeam.get(teamId) ?? []) : [],
-      predicate: (candidate) => hasTeamConstraint(candidate.match),
     },
     {
       matchedBy: "binding.account",
       enabled: true,
       scopePeer: peer,
       candidates: bindingsIndex.byAccount,
-      predicate: (candidate) => candidate.match.accountPattern !== "*",
     },
     {
       matchedBy: "binding.channel",
       enabled: true,
       scopePeer: peer,
       candidates: bindingsIndex.byChannel,
-      predicate: (candidate) => candidate.match.accountPattern === "*",
     },
   ];
 
@@ -798,13 +755,13 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
     if (!tier.enabled) {
       continue;
     }
-    const matched = tier.candidates.find(
-      (candidate) =>
-        tier.predicate(candidate) &&
-        matchesBindingScope(candidate.match, {
-          ...baseScope,
-          peer: tier.scopePeer,
-        }),
+    // Index buckets already enforce tier membership; only route scope still
+    // needs validation against this inbound peer, guild, team, and roles.
+    const matched = tier.candidates.find((candidate) =>
+      matchesBindingScope(candidate.match, {
+        ...baseScope,
+        peer: tier.scopePeer,
+      }),
     );
     if (matched) {
       if (shouldLogDebug) {


### PR DESCRIPTION
## What Problem This Solves

Primary replies, follow-up delivery, and route selection independently repeated message-tool payload deduplication and redundant route-tier predicates. This is part of a maintainer-requested project-wide production LOC reduction campaign.

## Why This Change Was Made

Use the canonical route-aware reply dedupe owner for primary/follow-up delivery, remove obsolete private re-export wrappers, and simplify routing buckets that already encode precedence.

## User Impact

Reply visibility, threading, account routing, media ordering, source mirrors, and wildcard/exact precedence remain unchanged; removes 129 production lines.

## Evidence

- Seven focused suites; 289 tests covering routing, direct agent delivery, primary replies, followups, payload dedupe, and visible delivery results.
- Full remote changed-file validation on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30969192971
- Independent structured autoreview: Codex `gpt-5.6-sol` with `xhigh` reasoning; no accepted or actionable findings.
- `git diff --check`, scoped formatting, and direct before/after behavioral equivalence checks passed.
- AI-assisted implementation and independent review.

