### PR TITLE
refactor(telegram): consolidate outbound contracts and targets

### DIFF
--- a/extensions/telegram/src/bot/body-helpers.ts
+++ b/extensions/telegram/src/bot/body-helpers.ts
@@ -101,10 +101,6 @@ type TelegramTextMessage = Pick<
   "text" | "caption" | "entities" | "caption_entities" | "poll"
 > & { rich_message?: unknown };
 
-function hasTelegramRichMessage(value: unknown): boolean {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 function compactRichText(value: string): string {
   return value
     .split("\n")
@@ -187,11 +183,11 @@ function renderRichBlocks(value: unknown): string {
 export function resolveTelegramRichMessagePlaceholder(
   msg: TelegramTextMessage,
 ): string | undefined {
-  return hasTelegramRichMessage(msg.rich_message) ? TELEGRAM_RICH_MESSAGE_PLACEHOLDER : undefined;
+  return isRecord(msg.rich_message) ? TELEGRAM_RICH_MESSAGE_PLACEHOLDER : undefined;
 }
 
 export function resolveTelegramRichMessageText(msg: TelegramTextMessage): string | undefined {
-  if (!hasTelegramRichMessage(msg.rich_message)) {
+  if (!isRecord(msg.rich_message)) {
     return undefined;
   }
   return compactRichText(renderRichBlocks(msg.rich_message)) || undefined;

--- a/extensions/telegram/src/send-actions.ts
+++ b/extensions/telegram/src/send-actions.ts
@@ -1,5 +1,4 @@
 import type { ReactionType, ReactionTypeEmoji } from "grammy/types";
-import type { RetryConfig } from "openclaw/plugin-sdk/retry-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { buildTypingThreadParams } from "./bot/helpers.js";
@@ -12,32 +11,21 @@ import {
   withTelegramApiContextLease,
   type TelegramApi,
   type TelegramApiContext,
-  type TelegramApiOverride,
 } from "./send-context.js";
+import type {
+  TelegramApiCallOpts,
+  TelegramMessageActionOpts,
+  TelegramSendOpts,
+} from "./send-message-types.js";
 import { prepareTelegramOutbound } from "./send-outbound.js";
-import type { OpenClawConfig } from "./send.runtime.js";
 import { parseTelegramTarget } from "./targets.js";
 
-type TelegramReactionOpts = {
-  cfg: OpenClawConfig;
-  token?: string;
-  accountId?: string;
-  api?: TelegramApiOverride;
+type TelegramReactionOpts = TelegramApiCallOpts & {
   remove?: boolean;
-  verbose?: boolean;
-  retry?: RetryConfig;
-  gatewayClientScopes?: readonly string[];
 };
 
-type TelegramTypingOpts = {
-  cfg: OpenClawConfig;
-  token?: string;
-  accountId?: string;
-  verbose?: boolean;
-  api?: TelegramApiOverride;
-  retry?: RetryConfig;
-  messageThreadId?: number;
-};
+type TelegramTypingOpts = Omit<TelegramApiCallOpts, "gatewayClientScopes"> &
+  Pick<TelegramSendOpts, "messageThreadId">;
 
 export async function sendTypingTelegram(
   to: string,
@@ -135,21 +123,10 @@ async function reactMessageTelegramWithContext(
   return { ok: true };
 }
 
-type TelegramDeleteOpts = {
-  cfg: OpenClawConfig;
-  token?: string;
-  accountId?: string;
-  notify?: boolean;
-  verbose?: boolean;
-  api?: TelegramApiOverride;
-  retry?: RetryConfig;
-  gatewayClientScopes?: readonly string[];
-};
-
 export async function deleteMessageTelegram(
   chatIdInput: string | number,
   messageIdInput: string | number,
-  opts: TelegramDeleteOpts,
+  opts: TelegramMessageActionOpts,
 ): Promise<{ ok: true } | { ok: false; warning: string }> {
   const context = resolveTelegramApiContext(opts);
   return withTelegramApiContextLease(
@@ -161,7 +138,7 @@ export async function deleteMessageTelegram(
 async function deleteMessageTelegramWithContext(
   chatIdInput: string | number,
   messageIdInput: string | number,
-  opts: TelegramDeleteOpts,
+  opts: TelegramMessageActionOpts,
   context: TelegramApiContext,
 ): Promise<{ ok: true } | { ok: false; warning: string }> {
   const { api } = context;
@@ -197,7 +174,7 @@ async function deleteMessageTelegramWithContext(
 export async function pinMessageTelegram(
   chatIdInput: string | number,
   messageIdInput: string | number,
-  opts: TelegramDeleteOpts,
+  opts: TelegramMessageActionOpts,
 ): Promise<{ ok: true; messageId: string; chatId: string }> {
   const context = resolveTelegramApiContext(opts);
   return withTelegramApiContextLease(
@@ -209,7 +186,7 @@ export async function pinMessageTelegram(
 async function pinMessageTelegramWithContext(
   chatIdInput: string | number,
   messageIdInput: string | number,
-  opts: TelegramDeleteOpts,
+  opts: TelegramMessageActionOpts,
   context: TelegramApiContext,
 ): Promise<{ ok: true; messageId: string; chatId: string }> {
   const { api } = context;
@@ -234,7 +211,7 @@ async function pinMessageTelegramWithContext(
 export async function unpinMessageTelegram(
   chatIdInput: string | number,
   messageIdInput: string | number | undefined,
-  opts: TelegramDeleteOpts,
+  opts: TelegramMessageActionOpts,
 ): Promise<{ ok: true; chatId: string; messageId?: string }> {
   const context = resolveTelegramApiContext(opts);
   return withTelegramApiContextLease(
@@ -246,7 +223,7 @@ export async function unpinMessageTelegram(
 async function unpinMessageTelegramWithContext(
   chatIdInput: string | number,
   messageIdInput: string | number | undefined,
-  opts: TelegramDeleteOpts,
+  opts: TelegramMessageActionOpts,
   context: TelegramApiContext,
 ): Promise<{ ok: true; chatId: string; messageId?: string }> {
   const { api } = context;

--- a/extensions/telegram/src/send-edit.ts
+++ b/extensions/telegram/src/send-edit.ts
@@ -1,4 +1,3 @@
-import type { RetryConfig } from "openclaw/plugin-sdk/retry-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import type { TelegramInlineButtons } from "./button-types.js";
 import { renderTelegramHtmlText, telegramHtmlToPlainTextFallback } from "./format.js";
@@ -25,10 +24,9 @@ import {
   withTelegramApiContextLease,
   withTelegramHtmlParseFallback,
   type TelegramApiContext,
-  type TelegramApiOverride,
 } from "./send-context.js";
+import type { TelegramApiCallOpts, TelegramSendOpts } from "./send-message-types.js";
 import { prepareTelegramOutbound } from "./send-outbound.js";
-import type { OpenClawConfig } from "./send.runtime.js";
 import { resolveMarkdownTableMode } from "./send.runtime.js";
 import { resolveTelegramBotUserIdFromToken } from "./token.js";
 
@@ -37,36 +35,15 @@ type TelegramEditMessageCaptionParams = Parameters<
   TelegramApiContext["api"]["editMessageCaption"]
 >[2];
 
-type TelegramEditOpts = {
-  token?: string;
-  accountId?: string;
-  verbose?: boolean;
-  api?: TelegramApiOverride;
-  retry?: RetryConfig;
-  gatewayClientScopes?: readonly string[];
-  textMode?: "markdown" | "html";
-  /** Controls whether link previews are shown in the edited message. */
-  linkPreview?: boolean;
-  /** Inline keyboard buttons (reply markup). Pass empty array to remove buttons. */
-  buttons?: TelegramInlineButtons;
-  /** Use Telegram's media-caption edit endpoint, or fall back to it when text edits target media. */
-  editMode?: "text" | "caption" | "auto";
-  /** Resolved runtime config from the command or gateway boundary. */
-  cfg: OpenClawConfig;
-};
+type TelegramEditReplyMarkupOpts = TelegramApiCallOpts & Pick<TelegramSendOpts, "buttons">;
 
-type TelegramEditReplyMarkupOpts = {
-  token?: string;
-  accountId?: string;
-  verbose?: boolean;
-  api?: TelegramApiOverride;
-  retry?: RetryConfig;
-  gatewayClientScopes?: readonly string[];
-  /** Inline keyboard buttons (reply markup). Pass empty array to remove buttons. */
-  buttons?: TelegramInlineButtons;
-  /** Resolved runtime config from the command or gateway boundary. */
-  cfg: OpenClawConfig;
-};
+type TelegramEditOpts = TelegramEditReplyMarkupOpts &
+  Pick<TelegramSendOpts, "textMode"> & {
+    /** Controls whether link previews are shown in the edited message. */
+    linkPreview?: boolean;
+    /** Use Telegram's media-caption edit endpoint, or fall back to it when text edits target media. */
+    editMode?: "text" | "caption" | "auto";
+  };
 
 export async function editMessageReplyMarkupTelegram(
   chatIdInput: string | number,

--- a/extensions/telegram/src/send-forum-topics.ts
+++ b/extensions/telegram/src/send-forum-topics.ts
@@ -1,5 +1,4 @@
 import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
-import type { RetryConfig } from "openclaw/plugin-sdk/retry-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import {
   createTelegramNonIdempotentRequestWithDiag,
@@ -9,26 +8,15 @@ import {
   resolveTelegramApiContext,
   withTelegramApiContextLease,
   type TelegramApiContext,
-  type TelegramApiOverride,
 } from "./send-context.js";
-import type { OpenClawConfig } from "./send.runtime.js";
+import type { TelegramApiCallOpts, TelegramMessageActionOpts } from "./send-message-types.js";
 import { parseTelegramTarget } from "./targets.js";
 
-type TelegramDeleteOpts = {
-  cfg: OpenClawConfig;
-  token?: string;
-  accountId?: string;
-  notify?: boolean;
-  verbose?: boolean;
-  api?: TelegramApiOverride;
-  retry?: RetryConfig;
-  gatewayClientScopes?: readonly string[];
-};
 type TelegramCreateForumTopicParams = NonNullable<
   Parameters<TelegramApiContext["api"]["createForumTopic"]>[2]
 >;
 
-type TelegramEditForumTopicOpts = TelegramDeleteOpts & {
+type TelegramEditForumTopicOpts = TelegramMessageActionOpts & {
   name?: string;
   iconCustomEmojiId?: string;
 };
@@ -122,7 +110,7 @@ export async function renameForumTopicTelegram(
   chatIdInput: string | number,
   messageThreadIdInput: string | number,
   name: string,
-  opts: TelegramDeleteOpts,
+  opts: TelegramMessageActionOpts,
 ): Promise<{ ok: true; chatId: string; messageThreadId: number; name: string }> {
   const result = await editForumTopicTelegram(chatIdInput, messageThreadIdInput, {
     ...opts,
@@ -140,14 +128,7 @@ export async function renameForumTopicTelegram(
 // Forum topic creation
 // ---------------------------------------------------------------------------
 
-type TelegramCreateForumTopicOpts = {
-  cfg: OpenClawConfig;
-  token?: string;
-  accountId?: string;
-  api?: TelegramApiOverride;
-  verbose?: boolean;
-  retry?: RetryConfig;
-  gatewayClientScopes?: readonly string[];
+type TelegramCreateForumTopicOpts = TelegramApiCallOpts & {
   /** Icon color for the topic (must be one of 0x6FB9F0, 0xFFD67E, 0xCB86DB, 0x8EEE98, 0xFF93B2, 0xFB6F5F). */
   iconColor?: TelegramCreateForumTopicParams["icon_color"];
   /** Custom emoji ID for the topic icon. */

--- a/extensions/telegram/src/send-message-types.ts
+++ b/extensions/telegram/src/send-message-types.ts
@@ -51,6 +51,16 @@ export type TelegramSendOpts = {
   onDeliveryResult?: (result: TelegramSendResult) => Promise<void> | void;
 };
 
+export type TelegramApiCallOpts = Pick<
+  TelegramSendOpts,
+  "cfg" | "token" | "accountId" | "verbose" | "api" | "retry" | "gatewayClientScopes"
+>;
+
+export type TelegramThreadedSendOpts = TelegramApiCallOpts &
+  Pick<TelegramSendOpts, "replyToMessageId" | "messageThreadId">;
+
+export type TelegramMessageActionOpts = TelegramApiCallOpts & { notify?: boolean };
+
 export type TelegramSendMessageParams = Parameters<TelegramApi["sendMessage"]>[2];
 
 export type TelegramSendResult = {
@@ -63,20 +73,8 @@ export type TelegramSendResult = {
   };
 };
 
-export type TelegramLocationSendOpts = Pick<
-  TelegramSendOpts,
-  | "cfg"
-  | "token"
-  | "accountId"
-  | "verbose"
-  | "api"
-  | "retry"
-  | "gatewayClientScopes"
-  | "replyToMessageId"
-  | "messageThreadId"
-  | "buttons"
-  | "quoteText"
-  | "promptContextProjectionPlan"
-  | "silent"
-  | "onDeliveryResult"
->;
+export type TelegramLocationSendOpts = TelegramThreadedSendOpts &
+  Pick<
+    TelegramSendOpts,
+    "buttons" | "quoteText" | "promptContextProjectionPlan" | "silent" | "onDeliveryResult"
+  >;

--- a/extensions/telegram/src/send-special.ts
+++ b/extensions/telegram/src/send-special.ts
@@ -1,29 +1,17 @@
-import type { RetryConfig } from "openclaw/plugin-sdk/retry-runtime";
 import {
   resolveTelegramApiContext,
   withTelegramApiContextLease,
   type TelegramApiContext,
-  type TelegramApiOverride,
 } from "./send-context.js";
-import type { TelegramSendResult } from "./send-message-types.js";
+import type {
+  TelegramSendOpts,
+  TelegramSendResult,
+  TelegramThreadedSendOpts,
+} from "./send-message-types.js";
 import { finalizeTelegramOutbound, prepareTelegramOutbound } from "./send-outbound.js";
-import { normalizePollInput, type OpenClawConfig, type PollInput } from "./send.runtime.js";
+import { normalizePollInput, type PollInput } from "./send.runtime.js";
 
 type TelegramSendPollParams = Parameters<TelegramApiContext["api"]["sendPoll"]>[3];
-
-type TelegramStickerOpts = {
-  cfg: OpenClawConfig;
-  token?: string;
-  accountId?: string;
-  verbose?: boolean;
-  api?: TelegramApiOverride;
-  retry?: RetryConfig;
-  gatewayClientScopes?: readonly string[];
-  /** Message ID to reply to (for threading) */
-  replyToMessageId?: number;
-  /** Forum topic thread ID (for forum supergroups) */
-  messageThreadId?: number;
-};
 
 /**
  * Send a sticker to a Telegram chat by file_id.
@@ -34,7 +22,7 @@ type TelegramStickerOpts = {
 export async function sendStickerTelegram(
   to: string,
   fileId: string,
-  opts: TelegramStickerOpts,
+  opts: TelegramThreadedSendOpts,
 ): Promise<TelegramSendResult> {
   if (!fileId?.trim()) {
     throw new Error("Telegram sticker file_id is required");
@@ -50,7 +38,7 @@ export async function sendStickerTelegram(
 async function sendStickerTelegramWithContext(
   to: string,
   fileId: string,
-  opts: TelegramStickerOpts,
+  opts: TelegramThreadedSendOpts,
   context: TelegramApiContext,
 ): Promise<TelegramSendResult> {
   const { api } = context;
@@ -79,23 +67,11 @@ async function sendStickerTelegramWithContext(
   });
 }
 
-type TelegramPollOpts = {
-  cfg: OpenClawConfig;
-  token?: string;
-  accountId?: string;
-  verbose?: boolean;
-  api?: TelegramApiOverride;
-  retry?: RetryConfig;
-  gatewayClientScopes?: readonly string[];
-  /** Message ID to reply to (for threading) */
-  replyToMessageId?: number;
-  /** Forum topic thread ID (for forum supergroups) */
-  messageThreadId?: number;
-  /** Send message silently (no notification). Defaults to false. */
-  silent?: boolean;
-  /** Whether votes are anonymous. Defaults to true (Telegram default). */
-  isAnonymous?: boolean;
-};
+type TelegramPollOpts = TelegramThreadedSendOpts &
+  Pick<TelegramSendOpts, "silent"> & {
+    /** Whether votes are anonymous. Defaults to true (Telegram default). */
+    isAnonymous?: boolean;
+  };
 
 /**
  * Send a poll to a Telegram chat.

--- a/extensions/telegram/src/targets.ts
+++ b/extensions/telegram/src/targets.ts
@@ -102,49 +102,17 @@ function resolveTelegramChatType(chatId: string): "direct" | "group" | "unknown"
 
 export function parseTelegramTarget(to: string): TelegramTarget {
   const normalized = stripTelegramInternalPrefixes(to);
-
-  const topicMatch = /^(.+?):topic:(\d+)$/.exec(normalized);
-  if (topicMatch) {
-    const chatId = topicMatch[1];
-    const threadIdText = topicMatch[2];
-    if (chatId === undefined || threadIdText === undefined) {
-      return { chatId: normalized, chatType: resolveTelegramChatType(normalized) };
+  const match = /^(.+?):topic:(\d+)$/.exec(normalized) ?? /^(.+):(\d+)$/.exec(normalized);
+  if (match) {
+    const chatId = match[1];
+    const threadIdText = match[2];
+    if (chatId !== undefined && threadIdText !== undefined) {
+      const messageThreadId = parseStrictNonNegativeInteger(threadIdText);
+      if (messageThreadId !== undefined) {
+        return { chatId, messageThreadId, chatType: resolveTelegramChatType(chatId) };
+      }
     }
-    const messageThreadId = parseStrictNonNegativeInteger(threadIdText);
-    if (messageThreadId === undefined) {
-      return {
-        chatId: normalized,
-        chatType: resolveTelegramChatType(normalized),
-      };
-    }
-    return {
-      chatId,
-      messageThreadId,
-      chatType: resolveTelegramChatType(chatId),
-    };
   }
-
-  const colonMatch = /^(.+):(\d+)$/.exec(normalized);
-  if (colonMatch) {
-    const chatId = colonMatch[1];
-    const threadIdText = colonMatch[2];
-    if (chatId === undefined || threadIdText === undefined) {
-      return { chatId: normalized, chatType: resolveTelegramChatType(normalized) };
-    }
-    const messageThreadId = parseStrictNonNegativeInteger(threadIdText);
-    if (messageThreadId === undefined) {
-      return {
-        chatId: normalized,
-        chatType: resolveTelegramChatType(normalized),
-      };
-    }
-    return {
-      chatId,
-      messageThreadId,
-      chatType: resolveTelegramChatType(chatId),
-    };
-  }
-
   return {
     chatId: normalized,
     chatType: resolveTelegramChatType(normalized),


### PR DESCRIPTION
## What Problem This Solves

Telegram outbound actions, edits, forum topics, and rich-message handling duplicated equivalent option contracts and target parsing. This is part of a maintainer-requested project-wide production LOC reduction campaign.

## Why This Change Was Made

Move equivalent outbound options to their canonical Telegram owner and share behavior-identical target/record parsing without changing the plugin public surface.

## User Impact

Telegram sending, editing, unsafe-topic rejection, reply threading, and rich-message formatting remain unchanged; removes 127 production lines.

## Evidence

- Nine focused Telegram suites; 427 tests covering outbound delivery, actions, target validation, forum replies, body rendering, captions, and mutation targets.
- Full remote changed-file validation on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30969281524
- Independent structured autoreview: Codex `gpt-5.6-sol` with `xhigh` reasoning; no accepted or actionable findings.
- `git diff --check`, scoped formatting, and direct before/after behavioral equivalence checks passed.
- AI-assisted implementation and independent review.

### Exact-head Telegram mock-gateway delivery proof

An isolated in-memory mock gateway loaded nine actual committed production modules, verified their exact Git object IDs, and executed the real Telegram outbound adapter through the real send owner and text sender into a synthetic Bot API. No Telegram token, network, operator gateway, or live account was used. The following JSON was actually observed and asserted:

~~~json
{
  "verdict": "PASS",
  "head": "38250ac3b0afe00f5fcee841df82a291a64fa8bd",
  "execution": "real Telegram outbound adapter -> real sendMessageTelegram -> real text sender -> synthetic Bot API; no token or network",
  "cases": [
    {
      "scenario": "target-qualified direct chat",
      "target": "telegram:123456789",
      "parsed": {"chatId":"123456789","chatType":"direct"},
      "botApiRequest": {"method":"sendMessage","chat_id":"123456789","text":"direct target-qualified delivery","parse_mode":"HTML"},
      "gatewayDelivery": {"channel":"telegram","messageId":"9001","chatId":"123456789","meta":{"telegramDeliveredText":"direct target-qualified delivery","telegramHasInlineKeyboard":false}},
      "result": {"channel":"telegram","messageId":"9001","chatId":"123456789"}
    },
    {
      "scenario": "target-qualified forum topic",
      "target": "telegram:group:-1001234567890:topic:77",
      "parsed": {"chatId":"-1001234567890","messageThreadId":77,"chatType":"group"},
      "botApiRequest": {"method":"sendMessage","chat_id":"-1001234567890","text":"forum target-qualified delivery","parse_mode":"HTML","message_thread_id":77},
      "gatewayDelivery": {"channel":"telegram","messageId":"9002","chatId":"-1001234567890","meta":{"telegramDeliveredText":"forum target-qualified delivery","telegramHasInlineKeyboard":false}},
      "result": {"channel":"telegram","messageId":"9002","chatId":"-1001234567890"}
    },
    {
      "scenario": "unsafe topic suffix rejected before Bot API",
      "target": "telegram:group:-1001234567890:topic:9007199254740992",
      "parsed": {"chatId":"-1001234567890:topic:9007199254740992","chatType":"unknown"},
      "rejection": "Telegram recipient target is not a valid numeric chat ID",
      "botApiCallsBefore": 2,
      "botApiCallsAfter": 2
    }
  ]
}
~~~

All production-path assertions passed at the exact reviewed commit. Direct chat, group forum-thread propagation, mock-gateway delivery metadata, and rejection before any unsafe Bot API call are demonstrated without external side effects.


**Base-refresh disposition:** Current main has not changed any of the seven touched Telegram production paths since this branch diverged. A rebase is therefore intentionally skipped: it would replace the already-reviewed exact commit and invalidate its 427 passing focused tests, full remote changed gate, exact-head hosted ci-gate, and production mock-gateway proof without addressing a conflict. The canonical maintainer merge workflow rechecks current-main drift immediately before landing and treats it as advisory.

