### PR TITLE
fix(qa): preserve required scenario isolation in serial suites

### DIFF
--- a/extensions/qa-lab/src/suite-planning.test.ts
+++ b/extensions/qa-lab/src/suite-planning.test.ts
@@ -749,6 +749,45 @@ describe("qa suite planning helpers", () => {
     ).toBe(true);
   });
 
+  it.each([
+    {
+      reason: "explicit scenario isolation",
+      makeScenario: () => makeQaSuiteTestScenario("isolated", { suiteIsolation: "isolated" }),
+    },
+    {
+      reason: "gateway runtime changes",
+      makeScenario: () =>
+        makeQaSuiteTestScenario("runtime-options", { gatewayRuntime: { forwardHostHome: true } }),
+    },
+    {
+      reason: "scenario-owned plugins",
+      makeScenario: () => makeQaSuiteTestScenario("plugin", { plugins: ["diagnostics-otel"] }),
+    },
+    {
+      reason: "memory state",
+      makeScenario: () => makeQaSuiteTestScenario("memory", { surface: "memory" }),
+    },
+    {
+      reason: "image generation setup",
+      makeScenario: () =>
+        makeQaSuiteTestScenario("image-generation", { config: { ensureImageGeneration: true } }),
+    },
+    {
+      reason: "state-mutating flow calls",
+      makeScenario: () => readQaScenarioById("plugin-lifecycle-hot-reload"),
+    },
+  ])("isolates serial runs for $reason", ({ makeScenario }) => {
+    const scenario = makeScenario();
+
+    expect(scenarioRequiresIsolatedQaSuiteWorker(scenario)).toBe(true);
+    expect(
+      shouldUseIsolatedQaSuiteScenarioWorkers({
+        scenarios: [makeQaSuiteTestScenario("baseline"), scenario],
+        concurrency: 1,
+      }),
+    ).toBe(true);
+  });
+
   it("does not isolate plain serial scenario runs", () => {
     expect(
       shouldUseIsolatedQaSuiteScenarioWorkers({

--- a/extensions/qa-lab/src/suite-planning.ts
+++ b/extensions/qa-lab/src/suite-planning.ts
@@ -288,10 +288,8 @@ function shouldUseIsolatedQaSuiteScenarioWorkers(params: {
     (params.concurrency > 1 ||
       params.scenarios.some(
         (scenario) =>
-          isQaMergePatchObject(scenario.gatewayConfigPatch) ||
-          (scenario.execution.kind === "flow" && scenario.execution.providerMode !== undefined) ||
-          (scenario.execution.kind === "flow" && scenario.execution.runtime !== undefined) ||
-          (scenario.execution.kind === "flow" && scenario.execution.transportPolicy !== undefined),
+          scenarioRequiresIsolatedQaSuiteWorker(scenario) ||
+          (scenario.execution.kind === "flow" && scenario.execution.providerMode !== undefined),
       ))
   );
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where QA scenarios that explicitly require their own worker could silently share a Gateway and scenario state whenever suites ran serially, with fail-fast, or with concurrency one.

## Why This Change Was Made

The serial worker-selection owner now reuses the existing canonical scenario-isolation predicate instead of maintaining an incomplete second policy. Provider-mode isolation remains unchanged.

## User Impact

Plugin lifecycle, gateway runtime, memory, image-generation, mutating-flow, and explicitly isolated QA scenarios retain their promised environment isolation even in serial suites.

## Evidence

- Six authentic regression cases failed before the fix and passed afterward, including the real plugin-lifecycle-hot-reload catalog scenario.
- Full QA-focused test group passed 98 tests.
- Full pnpm check:changed passed all five typecheck lanes, lint, formatting, and architecture guards.
- Fresh isolated autoreview of this exact branch: clean.
- Production code decreases by two lines by deleting duplicate isolation policy.

### Inspectable exact-head runtime proof

Exact-head required CI passed: https://github.com/openclaw/openclaw/actions/runs/30970537417

The actual isolated-worker QA artifact is https://github.com/openclaw/openclaw/actions/runs/30970537417/artifacts/8916372622. Its primary/flow/isolated/qa-suite-summary.json proves the real plugin-lifecycle-hot-reload scenario was dispatched to its own isolated Gateway worker and passed:

~~~json
{
  "head": "cf246d5b053420cbfaf47ba8cdfb0cd676544bab",
  "artifactPath": "primary/flow/isolated/qa-suite-summary.json",
  "providerMode": "mock-openai",
  "channelDriver": "crabline",
  "scenarioIds": ["plugin-lifecycle-hot-reload"],
  "counts": {"total": 1, "passed": 1, "failed": 0, "skipped": 0}
}
~~~

The exact-head hosted runtime log also records:

~~~text
[qa-suite] scenario start (1/1): plugin-lifecycle-hot-reload
[qa-suite] scenario pass (1/1): plugin-lifecycle-hot-reload
~~~

The same artifact contains a separate six-scenario shared suite, proving the isolated plugin scenario did not share its Gateway worker with ordinary scenarios.