### PR TITLE
fix(qa): release failed transport leases and always stop owned labs

### DIFF
--- a/extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts
+++ b/extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from "vitest";
+import { createQaBusState } from "./bus-state.js";
+import type { QaLabServerHandle } from "./lab-server.types.js";
+import type { QaTransportAdapterFactory } from "./qa-transport-registry.js";
+import { runQaFlowSuiteIsolated } from "./suite-run-isolated.js";
+import { makeQaSuiteTestScenario } from "./suite-test-helpers.js";
+import type { QaSuiteResolvedRunContext, QaSuiteRunner } from "./suite-types.js";
+
+function createCleanupTestLab(): QaLabServerHandle {
+  return {
+    baseUrl: "http://127.0.0.1:43123",
+    listenUrl: "http://127.0.0.1:43123",
+    state: createQaBusState(),
+    setControlUi: vi.fn(),
+    setScenarioRun: vi.fn(),
+    setLatestReport: vi.fn(),
+    runSelfCheck: vi.fn(),
+    stop: vi.fn(async () => {}),
+  };
+}
+
+function createCleanupTestContext(): QaSuiteResolvedRunContext {
+  return {
+    startedAt: new Date("2026-08-04T00:00:00.000Z"),
+    repoRoot: "/qa-repo",
+    outputDir: "/qa-output",
+    transportId: "qa-channel",
+    selectedScenarios: [makeQaSuiteTestScenario("leased-channel-scenario")],
+    providerMode: "mock-openai",
+    primaryModel: "mock-openai/test-model",
+    alternateModel: "mock-openai/test-model-alt",
+    fastMode: true,
+    channelDriver: "live",
+    enabledPluginIds: [],
+    gatewayConfigPatch: undefined,
+    gatewayRuntimeOptions: undefined,
+    concurrency: 1,
+    progressEnabled: false,
+    gatewayHeapCheckpointsEnabled: false,
+  };
+}
+
+describe("isolated QA suite transport cleanup", () => {
+  it.each(["cleanup", "cleanupAfterGatewayStop"] as const)(
+    "retries a failed parent %s phase before disposing its owned lab",
+    async (cleanupPhase) => {
+      const lab = createCleanupTestLab();
+      const releaseError = new Error("credential release failed");
+      const release = vi
+        .fn<() => Promise<void>>()
+        .mockRejectedValueOnce(releaseError)
+        .mockResolvedValueOnce(undefined);
+      const factory: QaTransportAdapterFactory = {
+        id: "leased",
+        matches: ({ channelId, driver }) => channelId === "leased" && driver === "live",
+        async create() {
+          return {
+            id: "leased",
+            label: "Leased channel",
+            accountId: "sut",
+            requiredPluginIds: [],
+            supportedActions: [],
+            sendInbound: async (input) => lab.state.addInboundMessage(input),
+            createGatewayConfig: () => ({}),
+            async waitReady() {},
+            buildAgentDelivery: ({ target }) => ({
+              channel: "leased",
+              to: target,
+              replyChannel: "leased",
+              replyTo: target,
+            }),
+            async handleAction() {},
+            createReportNotes: () => [],
+            [cleanupPhase]: release,
+          };
+        },
+      };
+      const runChild = vi.fn<QaSuiteRunner>();
+
+      await expect(
+        runQaFlowSuiteIsolated(
+          {
+            adapterFactories: [factory],
+            channelDriver: "live",
+            channelId: "leased",
+            startLab: async () => lab,
+          },
+          createCleanupTestContext(),
+          runChild,
+        ),
+      ).rejects.toBe(releaseError);
+
+      expect(release).toHaveBeenCalledTimes(2);
+      expect(runChild).not.toHaveBeenCalled();
+      expect(lab.stop).toHaveBeenCalledOnce();
+    },
+  );
+});

--- a/extensions/qa-lab/src/suite-run-isolated.ts
+++ b/extensions/qa-lab/src/suite-run-isolated.ts
@@ -139,8 +139,8 @@ export async function runQaFlowSuiteIsolated(
     if (params?.channelDriver === "live") {
       // The parent only renders aggregate artifacts. Release its live credentials
       // before child workers acquire the same exclusive transport lease.
-      parentTransportCleaned = true;
       await transportFactoryResult.cleanupWithoutGateway();
+      parentTransportCleaned = true;
     }
     updateScenarioRun();
     const workerStartStaggerMs =

--- a/extensions/qa-lab/src/suite-runtime-parity-runner.cleanup.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-parity-runner.cleanup.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+import { createQaBusState } from "./bus-state.js";
+import type { QaLabServerHandle } from "./lab-server.types.js";
+import type { QaTransportAdapterFactory } from "./qa-transport-registry.js";
+import { runQaRuntimeParitySuite } from "./suite-runtime-parity-runner.js";
+import { makeQaSuiteTestScenario } from "./suite-test-helpers.js";
+import type { QaSuiteRunner } from "./suite-types.js";
+
+function createCleanupTestLab(): QaLabServerHandle {
+  return {
+    baseUrl: "http://127.0.0.1:43123",
+    listenUrl: "http://127.0.0.1:43123",
+    state: createQaBusState(),
+    setControlUi: vi.fn(),
+    setScenarioRun: vi.fn(),
+    setLatestReport: vi.fn(),
+    runSelfCheck: vi.fn(),
+    stop: vi.fn(async () => {}),
+  };
+}
+
+describe("runtime parity suite transport cleanup", () => {
+  it("stops its owned lab and preserves the scenario error when transport cleanup fails", async () => {
+    const lab = createCleanupTestLab();
+    const scenarioError = new Error("runtime scenario failed");
+    const cleanupError = new Error("credential release failed");
+    const cleanup = vi.fn(async () => {
+      throw cleanupError;
+    });
+    const factory: QaTransportAdapterFactory = {
+      id: "leased",
+      matches: ({ channelId, driver }) => channelId === "leased" && driver === "live",
+      async create() {
+        return {
+          id: "leased",
+          label: "Leased channel",
+          accountId: "sut",
+          requiredPluginIds: [],
+          supportedActions: [],
+          sendInbound: async (input) => lab.state.addInboundMessage(input),
+          createGatewayConfig: () => ({}),
+          async waitReady() {},
+          buildAgentDelivery: ({ target }) => ({
+            channel: "leased",
+            to: target,
+            replyChannel: "leased",
+            replyTo: target,
+          }),
+          async handleAction() {},
+          createReportNotes: () => [],
+          cleanup,
+        };
+      },
+    };
+    const runChild = vi.fn<QaSuiteRunner>().mockRejectedValueOnce(scenarioError);
+
+    await expect(
+      runQaRuntimeParitySuite({
+        runQaFlowSuite: runChild,
+        adapterFactories: [factory],
+        channelDriver: "live",
+        channelId: "leased",
+        repoRoot: "/qa-repo",
+        outputDir: "/qa-output",
+        startedAt: new Date("2026-08-04T00:00:00.000Z"),
+        providerMode: "mock-openai",
+        transportId: "qa-channel",
+        primaryModel: "mock-openai/test-model",
+        alternateModel: "mock-openai/test-model-alt",
+        fastMode: true,
+        concurrency: 1,
+        selectedScenarios: [makeQaSuiteTestScenario("runtime-cleanup")],
+        startLab: async () => lab,
+        progressEnabled: false,
+        runtimePair: ["openclaw", "codex"],
+      }),
+    ).rejects.toMatchObject({
+      message: "QA suite and cleanup failed",
+      cause: scenarioError,
+      errors: [scenarioError, cleanupError],
+    });
+
+    expect(runChild).toHaveBeenCalledOnce();
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(lab.stop).toHaveBeenCalledOnce();
+  });
+});

--- a/extensions/qa-lab/src/suite-runtime-parity-runner.ts
+++ b/extensions/qa-lab/src/suite-runtime-parity-runner.ts
@@ -36,6 +36,8 @@ import type {
 import {
   createQaSuiteTransportAdapter,
   requireQaSuiteStartLab,
+  runQaSuiteCleanupSteps,
+  throwQaSuiteCleanupErrors,
   writeQaSuiteProgress,
 } from "./suite.js";
 
@@ -102,6 +104,8 @@ export async function runQaRuntimeParitySuite(params: {
     scenarios: [...liveScenarioOutcomes],
   });
 
+  let runFailed = false;
+  let runError: unknown;
   try {
     const scenarios = await mapQaSuiteWithConcurrency(
       params.selectedScenarios,
@@ -283,10 +287,15 @@ export async function runQaRuntimeParitySuite(params: {
       scenarios,
       watchUrl: lab.baseUrl,
     } satisfies QaSuiteResult;
+  } catch (error) {
+    runFailed = true;
+    runError = error;
+    throw error;
   } finally {
-    await transportFactoryResult.cleanupWithoutGateway();
-    if (ownsLab) {
-      await lab.stop();
-    }
+    const cleanupErrors = await runQaSuiteCleanupSteps([
+      () => transportFactoryResult.cleanupWithoutGateway(),
+      ...(ownsLab ? [() => lab.stop()] : []),
+    ]);
+    throwQaSuiteCleanupErrors({ cleanupErrors, runFailed, runError });
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where isolated QA runs could permanently leak a channel credential lease after one transient cleanup failure, and runtime-parity runs could leave their owned lab server running while hiding the original scenario failure.

## Why This Change Was Made

The isolated-suite owner records transport cleanup only after it succeeds, preserving the registry retry contract. The runtime-parity owner now uses the existing canonical cleanup aggregation so every owned resource is released and primary failures retain their causal cleanup errors.

## User Impact

Repeated QA runs recover transient credential-release failures, stop owned labs reliably, and report scenario plus cleanup errors instead of exhausting shared transport pools or leaking background servers.

## Evidence

- Authentic pre-fix failures cover both pre/post credential cleanup phases and parity lab disposal; all three lifecycle regressions now pass.
- Full QA-focused group passed 98 tests; synthetic and Crabline channel scenarios passed 1/1.
- Full pnpm check:changed passed all five typecheck lanes, lint, formatting, and architecture guards.
- Fresh isolated autoreview of this exact branch: clean.
- Production delta: +9 lines, justified by the canonical resource ownership and error-causality invariant.

### Inspectable exact-head runtime proof

Exact-head required CI passed: https://github.com/openclaw/openclaw/actions/runs/30970694620

The downloadable real isolated-suite runtime artifact is https://github.com/openclaw/openclaw/actions/runs/30970694620/artifacts/8916439102. Its primary/flow/isolated-1/qa-suite-summary.json records a live owned Gateway/Crabline lifecycle and successful terminal completion:

~~~json
{
  "head": "507b9dfe4a5961a260c9d549ced8706d873fa235",
  "artifactPath": "primary/flow/isolated-1/qa-suite-summary.json",
  "providerMode": "mock-openai",
  "channelDriver": "crabline",
  "scenarioIds": ["subagent-completion-direct-fallback"],
  "counts": {"total": 1, "passed": 1, "failed": 0, "skipped": 0}
}
~~~

The same artifact records three independently isolated worker lifecycles and a six-scenario aggregate with passed=6 and failed=0. The added authentic cleanup tests inject a one-time rejection into the actual registered adapter: both pre-stop and post-stop credential cleanup retry successfully, and runtime-parity cleanup stops its owned lab while preserving both the original scenario failure and the cleanup error.