### PR TITLE
fix(gateway): reject invalid session history cursor with 400

### DIFF
--- a/src/gateway/session-history-state.ts
+++ b/src/gateway/session-history-state.ts
@@ -84,7 +84,7 @@ export function resolveSessionHistoryTailReadOptions(limit: number): {
   };
 }
 
-function resolveCursorSeq(cursor: string | undefined): number | undefined {
+export function resolveCursorSeq(cursor: string | undefined): number | undefined {
   if (!cursor) {
     return undefined;
   }

--- a/src/gateway/sessions-history-http.revocation.test.ts
+++ b/src/gateway/sessions-history-http.revocation.test.ts
@@ -114,6 +114,11 @@ vi.mock("./session-history-state.js", () => ({
   buildSessionHistorySnapshot: () => ({
     history: { items: [], nextCursor: null, messages: [] },
   }),
+  resolveCursorSeq: (_cursor: string | undefined) => undefined,
+  resolveSessionHistoryTailReadOptions: (limit: number) => ({
+    maxMessages: limit * 20 + 20,
+    maxLines: limit * 20 + 20,
+  }),
   SessionHistorySseState: {
     fromRawSnapshot: (_params: unknown) => ({
       snapshot: () => ({ items: [], nextCursor: null, messages: [] }),

--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -681,7 +681,7 @@ describe("session history HTTP endpoints", () => {
     });
   });
 
-  test.each(["", "?cursor=", "?cursor=%20"])("returns session history for query %j", async (query) => {
+  test.each(["", "?cursor=", "?cursor=%20"])("returns history for query %j", async (query) => {
     await seedSession({ text: "hello from history" });
     await withGatewayHarness(async (harness) => {
       const body = await readSessionHistoryBody(harness.port, "agent:main:main", { query });

--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -1112,7 +1112,7 @@ describe("session history HTTP endpoints", () => {
     },
   );
 
-  test.each(["garbage", "seq:garbage", "seq:0", "seq:99999999999999999999", "0", "-1", "1.5"])(
+  test.each(["", " ", "garbage", "seq:", "seq:0", "seq:99999999999999999999", "-1", "1.5"])(
     "rejects invalid cursor %j with 400",
     async (cursor) => {
       await seedSession({ text: "first message" });

--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -681,10 +681,10 @@ describe("session history HTTP endpoints", () => {
     });
   });
 
-  test("returns session history over direct REST", async () => {
+  test.each(["", "?cursor=", "?cursor=%20"])("returns session history for query %j", async (query) => {
     await seedSession({ text: "hello from history" });
     await withGatewayHarness(async (harness) => {
-      const body = await readSessionHistoryBody(harness.port, "agent:main:main");
+      const body = await readSessionHistoryBody(harness.port, "agent:main:main", { query });
       expect(body.sessionKey).toBe("agent:main:main");
       expect(body.messages).toHaveLength(1);
       expect(body.messages?.[0]?.content?.[0]?.text).toBe("hello from history");
@@ -1112,7 +1112,7 @@ describe("session history HTTP endpoints", () => {
     },
   );
 
-  test.each(["", " ", "garbage", "seq:", "seq:0", "seq:99999999999999999999", "-1", "1.5"])(
+  test.each(["garbage", "seq:garbage", "seq:0", "seq:99999999999999999999", "0", "-1", "1.5"])(
     "rejects invalid cursor %j with 400",
     async (cursor) => {
       await seedSession({ text: "first message" });

--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -1112,6 +1112,22 @@ describe("session history HTTP endpoints", () => {
     },
   );
 
+  test.each(["garbage", "seq:garbage", "seq:0", "seq:99999999999999999999", "0", "-1", "1.5"])(
+    "rejects invalid cursor %j with 400",
+    async (cursor) => {
+      await seedSession({ text: "first message" });
+      await withGatewayHarness(async (harness) => {
+        const res = await fetchSessionHistory(harness.port, "agent:main:main", {
+          query: `?cursor=${encodeURIComponent(cursor)}`,
+        });
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.error?.type).toBe("invalid_request_error");
+        expect(body.error?.message).toBe("cursor must be a positive integer");
+      });
+    },
+  );
+
   test.each(["1", "+1"])(
     "returns the requested bounded history for valid limit %s",
     async (limit) => {

--- a/src/gateway/sessions-history-http.ts
+++ b/src/gateway/sessions-history-http.ts
@@ -29,6 +29,7 @@ import {
 import { authorizeOperatorScopesForMethod } from "./method-scopes.js";
 import {
   buildSessionHistorySnapshot,
+  resolveCursorSeq,
   resolveSessionHistoryTailReadOptions,
   SessionHistorySseState,
 } from "./session-history-state.js";
@@ -178,6 +179,10 @@ export async function handleSessionHistoryHttpRequest(
   }
   const limit = limitResult.value;
   const cursor = normalizeOptionalString(getRequestUrl(req).searchParams.get("cursor"));
+  if (cursor !== undefined && resolveCursorSeq(cursor) === undefined) {
+    sendInvalidRequest(res, "cursor must be a positive integer");
+    return true;
+  }
   const effectiveMaxChars = DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS;
   let boundedSnapshot:
     | Awaited<ReturnType<typeof readRecentSessionMessagesWithStatsAsync>>

--- a/src/gateway/sessions-history-http.ts
+++ b/src/gateway/sessions-history-http.ts
@@ -178,7 +178,7 @@ export async function handleSessionHistoryHttpRequest(
     return true;
   }
   const limit = limitResult.value;
-  const cursor = getRequestUrl(req).searchParams.get("cursor")?.trim();
+  const cursor = normalizeOptionalString(getRequestUrl(req).searchParams.get("cursor"));
   if (cursor !== undefined && resolveCursorSeq(cursor) === undefined) {
     sendInvalidRequest(res, "cursor must be a positive integer");
     return true;

--- a/src/gateway/sessions-history-http.ts
+++ b/src/gateway/sessions-history-http.ts
@@ -178,7 +178,7 @@ export async function handleSessionHistoryHttpRequest(
     return true;
   }
   const limit = limitResult.value;
-  const cursor = normalizeOptionalString(getRequestUrl(req).searchParams.get("cursor"));
+  const cursor = getRequestUrl(req).searchParams.get("cursor")?.trim();
   if (cursor !== undefined && resolveCursorSeq(cursor) === undefined) {
     sendInvalidRequest(res, "cursor must be a positive integer");
     return true;


### PR DESCRIPTION
<!--
Related: gap finding: invalid session history cursor
-->

## What Problem This Solves

Fixes an issue where calling `GET /sessions/<sessionKey>/history` with an invalid `cursor` query parameter (for example `cursor=garbage` or `cursor=seq:99999999999999999999`) would silently return the entire session history instead of an error.

## Why This Change Was Made

The handler only performed a bounded read when `cursor === undefined`; any non-empty cursor fell through to a full transcript read. `resolveCursorSeq` already rejected malformed cursors by returning `undefined`, but the HTTP path never acted on that signal. The fix exports `resolveCursorSeq` and validates the cursor before reading, returning `400 invalid_request_error` for malformed input, matching the existing `limit` validation behavior.

## User Impact

Clients sending an invalid cursor now receive a clear 400 error rather than a misleading full-history response. Valid cursor pagination is unchanged.

## Evidence

### Before fix
`GET /sessions/agent:main:main/history?cursor=garbage` returns `200` with the full session history and no `nextCursor`.

### After fix — real behavior proof

Real gateway started via `createGatewaySuiteHarness` on port 31000 with `auth: { mode: "none" }`, agent session `agent:main:main` seeded with a session entry. Endpoint exercised with `fetch()`; output formatted as equivalent `curl -si` commands:

#### Invalid cursor `garbage` returns 400

```
$ curl -si 'http://127.0.0.1:31000/sessions/agent%3Amain%3Amain/history?cursor=garbage' \
  -H 'x-openclaw-scopes: operator.read'

HTTP/1.1 400 Bad Request
connection: keep-alive
content-length: 88
content-type: application/json; charset=utf-8
date: Thu, 06 Aug 2026 03:04:49 GMT
keep-alive: timeout=5
permissions-policy: camera=(), microphone=(self), geolocation=()
referrer-policy: no-referrer
x-content-type-options: nosniff

{"error":{"message":"cursor must be a positive integer","type":"invalid_request_error"}}
```

#### Invalid cursor `seq:garbage` returns 400

```
$ curl -si 'http://127.0.0.1:31000/sessions/agent%3Amain%3Amain/history?cursor=seq%3Agarbage' \
  -H 'x-openclaw-scopes: operator.read'

HTTP/1.1 400 Bad Request
connection: keep-alive
content-length: 88
content-type: application/json; charset=utf-8
date: Thu, 06 Aug 2026 03:04:49 GMT
keep-alive: timeout=5
permissions-policy: camera=(), microphone=(self), geolocation=()
referrer-policy: no-referrer
x-content-type-options: nosniff

{"error":{"message":"cursor must be a positive integer","type":"invalid_request_error"}}
```

#### Invalid cursor `seq:0` returns 400

```
$ curl -si 'http://127.0.0.1:31000/sessions/agent%3Amain%3Amain/history?cursor=seq%3A0' \
  -H 'x-openclaw-scopes: operator.read'

HTTP/1.1 400 Bad Request
connection: keep-alive
content-length: 88
content-type: application/json; charset=utf-8
date: Thu, 06 Aug 2026 03:04:49 GMT
keep-alive: timeout=5
permissions-policy: camera=(), microphone=(self), geolocation=()
referrer-policy: no-referrer
x-content-type-options: nosniff

{"error":{"message":"cursor must be a positive integer","type":"invalid_request_error"}}
```

#### Invalid cursor `-1` returns 400

```
$ curl -si 'http://127.0.0.1:31000/sessions/agent%3Amain%3Amain/history?cursor=-1' \
  -H 'x-openclaw-scopes: operator.read'

HTTP/1.1 400 Bad Request
connection: keep-alive
content-length: 88
content-type: application/json; charset=utf-8
date: Thu, 06 Aug 2026 03:04:49 GMT
keep-alive: timeout=5
permissions-policy: camera=(), microphone=(self), geolocation=()
referrer-policy: no-referrer
x-content-type-options: nosniff

{"error":{"message":"cursor must be a positive integer","type":"invalid_request_error"}}
```

#### Invalid cursor `1.5` returns 400

```
$ curl -si 'http://127.0.0.1:31000/sessions/agent%3Amain%3Amain/history?cursor=1.5' \
  -H 'x-openclaw-scopes: operator.read'

HTTP/1.1 400 Bad Request
connection: keep-alive
content-length: 88
content-type: application/json; charset=utf-8
date: Thu, 06 Aug 2026 03:04:49 GMT
keep-alive: timeout=5
permissions-policy: camera=(), microphone=(self), geolocation=()
referrer-policy: no-referrer
x-content-type-options: nosniff

{"error":{"message":"cursor must be a positive integer","type":"invalid_request_error"}}
```

#### Valid request (no cursor) returns 200

```
$ curl -si 'http://127.0.0.1:31000/sessions/agent%3Amain%3Amain/history' \
  -H 'x-openclaw-scopes: operator.read'

HTTP/1.1 200 OK
...
```

### Automated tests

- Focused invalid-cursor tests: 7/7 pass.
- Full `src/gateway/sessions-history-http.test.ts`: 79/79 pass.
- `src/gateway/sessions-history-http.revocation.test.ts`: all pass (mock fixed to export `resolveCursorSeq` and `resolveSessionHistoryTailReadOptions`).
- `oxlint` and `oxfmt --check` clean on changed files.



### proof: refreshed exact-head real Gateway HTTP capture

Validated the current PR head with a real Gateway server and raw HTTP requests in a secretless GitHub-hosted workflow.

- **Before SHA:** `22de30f998216c0c480b8858f9185d9829d90bae`
- **After / PR head:** `42b3ddc670c1073b425e874c72903ecc0db32397`
- **Proof run:** https://github.com/RomneyDa/openclaw/actions/runs/31300586737
- **Evidence artifact:** https://github.com/RomneyDa/openclaw/actions/runs/31300586737/artifacts/9034437246
- **Exact-head required CI:** https://github.com/openclaw/openclaw/actions/runs/31299149533 (`openclaw/ci-gate` passed on attempt 2)

| Cursor query | Before | Exact head |
|---|---:|---:|
| absent | 200 | 200 |
| empty (`?cursor=`) | — | 200 |
| whitespace (`?cursor=%20`) | — | 200 |
| `garbage` | 200 | 400 |
| `seq:garbage` | 200 | 400 |
| `seq:0` | 200 | 400 |
| `-1` | 200 | 400 |
| `1.5` | 200 | 400 |

Focused results: baseline 4 files / 99 tests passed; exact head 4 files / 110 tests passed; raw exact-head Gateway capture 3 files / 3 tests passed. The artifact contains the redacted request/status/body-length capture and focused suite logs.
