### PR TITLE
fix(gateway): give reloaded plugin routes their current registry

### DIFF
--- a/src/gateway/server/plugins-http.runtime-scopes.test.ts
+++ b/src/gateway/server/plugins-http.runtime-scopes.test.ts
@@ -2,6 +2,7 @@
  * Plugin HTTP runtime-scope integration tests.
  */
 import type { IncomingMessage, ServerResponse } from "node:http";
+import type { Duplex } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SubsystemLogger } from "../../logging/subsystem.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry.js";
@@ -14,7 +15,10 @@ import { isApprovalRecordVisibleToClient } from "../server-methods/approval-shar
 import type { GatewayRequestContext } from "../server-methods/types.js";
 import { makeMockHttpResponse } from "../test-http-response.js";
 import { createTestRegistry } from "./__tests__/test-utils.js";
-import { createGatewayPluginRequestHandler } from "./plugins-http.js";
+import {
+  createGatewayPluginRequestHandler,
+  createGatewayPluginUpgradeHandler,
+} from "./plugins-http.js";
 
 const SECURE_HOOK_PATH = "/secure-hook";
 const SECURE_ADMIN_HOOK_PATH = "/secure-admin-hook";
@@ -30,6 +34,11 @@ function createRoute(params: {
   gatewayRuntimeScopeSurface?: "write-default" | "trusted-operator";
   gatewayMethodDispatchAllowed?: boolean;
   handler?: (req: IncomingMessage, res: ServerResponse) => boolean | Promise<boolean>;
+  handleUpgrade?: (
+    req: IncomingMessage,
+    socket: Duplex,
+    head: Buffer,
+  ) => boolean | Promise<boolean>;
 }) {
   return {
     pluginId: "route",
@@ -39,6 +48,7 @@ function createRoute(params: {
     gatewayMethodDispatchAllowed: params.gatewayMethodDispatchAllowed,
     match: params.match ?? "exact",
     handler: params.handler ?? (() => true),
+    handleUpgrade: params.handleUpgrade,
     source: "route",
   };
 }
@@ -318,6 +328,69 @@ describe("plugin HTTP route runtime scopes", () => {
       { route: "server-a", context: serverAContext },
       { route: "server-b", context: serverBContext },
     ]);
+  });
+
+  it("binds reloaded HTTP route handlers to their current registry", async () => {
+    const startupRegistry = createTestRegistry();
+    let observedRegistry: ReturnType<typeof createTestRegistry> | undefined;
+    const currentRegistry = createTestRegistry({
+      httpRoutes: [
+        createRoute({
+          path: SECURE_HOOK_PATH,
+          auth: "gateway",
+          handler: () => {
+            observedRegistry = getPluginRuntimeGatewayRequestScope()?.pluginRegistry;
+            return true;
+          },
+        }),
+      ],
+    });
+    const handler = createGatewayPluginRequestHandler({
+      registry: startupRegistry,
+      getRouteRegistry: () => currentRegistry,
+      log: createMockLogger(),
+    });
+
+    const response = await dispatchTrustedGatewayRequest(handler, SECURE_HOOK_PATH);
+
+    expect(response.handled).toBe(true);
+    expect(observedRegistry).toBe(currentRegistry);
+  });
+
+  it("binds reloaded WebSocket upgrade handlers to their current registry", async () => {
+    const startupRegistry = createTestRegistry();
+    let observedRegistry: ReturnType<typeof createTestRegistry> | undefined;
+    const currentRegistry = createTestRegistry({
+      httpRoutes: [
+        createRoute({
+          path: SECURE_HOOK_PATH,
+          auth: "gateway",
+          handleUpgrade: () => {
+            observedRegistry = getPluginRuntimeGatewayRequestScope()?.pluginRegistry;
+            return true;
+          },
+        }),
+      ],
+    });
+    const handler = createGatewayPluginUpgradeHandler({
+      registry: startupRegistry,
+      getRouteRegistry: () => currentRegistry,
+      log: createMockLogger(),
+    });
+
+    const handled = await handler(
+      { url: SECURE_HOOK_PATH } as IncomingMessage,
+      {} as Duplex,
+      Buffer.alloc(0),
+      undefined,
+      {
+        gatewayAuthSatisfied: true,
+        gatewayRequestOperatorScopes: ["operator.write"],
+      },
+    );
+
+    expect(handled).toBe(true);
+    expect(observedRegistry).toBe(currentRegistry);
   });
 
   it("does not give approval-scoped gateway-auth routes global approval visibility", async () => {

--- a/src/gateway/server/plugins-http.ts
+++ b/src/gateway/server/plugins-http.ts
@@ -256,7 +256,7 @@ export function createGatewayPluginRequestHandler(params: {
         const runRoute = async () =>
           (await withPluginRuntimeGatewayRequestScope(
             createPluginRouteRuntimeScope({
-              registry: params.registry,
+              registry,
               route,
               req,
               gatewayRequestContext,
@@ -336,7 +336,7 @@ export function createGatewayPluginUpgradeHandler(params: {
           async () =>
             (await withPluginRuntimeGatewayRequestScope(
               createPluginRouteRuntimeScope({
-                registry: params.registry,
+                registry,
                 route,
                 req,
                 gatewayRequestContext,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where plugin HTTP requests and WebSocket upgrades continued to execute with a stale startup plugin registry after plugin routes were reloaded, hiding current hooks, providers, and commands until the Gateway restarted.

## Why This Change Was Made

Both route-dispatch siblings now bind the request scope to the same current registry that already selected the HTTP or upgrade route. The lifecycle owner no longer mixes a reloaded route with its obsolete startup registry.

## User Impact

Reloaded plugin HTTP endpoints and WebSocket routes immediately receive their actual current plugin runtime instead of silently observing obsolete or missing plugin capabilities.

## Evidence

- Two authentic owner-boundary regressions failed before the fix and now pass: real HTTP route dispatch and WebSocket upgrade dispatch each observe the reloaded registry.
- Full gateway-focused test group passed 80 tests.
- Full pnpm check:changed passed all five typecheck lanes, formatting, lint, import-cycle, and architecture guards.
- Fresh isolated autoreview of this exact branch: clean.
- Production code delta is zero: two existing registry bindings are corrected.