### PR TITLE
fix(compaction): stop a large input reserve from inflating summary output cost

### DIFF
--- a/packages/agent-core/src/harness/compaction/compaction-summary-output-budget.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction-summary-output-budget.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from "vitest";
+import { createAssistantMessageEventStream } from "../../llm.js";
+import type { AssistantMessage, Model, StreamFn } from "../../llm.js";
+import { compact, generateSummary } from "./compaction.js";
+import { createFileOps } from "./utils.js";
+
+describe("generateSummary output budget", () => {
+  function createBudgetModel(): Model {
+    return {
+      id: "budget-model",
+      name: "Budget Model",
+      api: "anthropic-messages",
+      provider: "anthropic",
+      baseUrl: "https://api.anthropic.com",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 1_000_000,
+      maxTokens: 128_000,
+      params: {},
+    };
+  }
+
+  async function captureSummaryMaxTokens(reserveTokens: number): Promise<number | undefined> {
+    const model = createBudgetModel();
+    const summaryMessage: AssistantMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "summary" }],
+      api: model.api,
+      provider: model.provider,
+      model: model.id,
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: 1,
+    };
+    let observed: number | undefined;
+    const streamFn = vi.fn<StreamFn>((_model, _context, options) => {
+      observed = options?.maxTokens;
+      const stream = createAssistantMessageEventStream();
+      stream.push({ type: "done", reason: "stop", message: summaryMessage });
+      stream.end();
+      return stream;
+    });
+    const result = await generateSummary(
+      [{ role: "user", content: "hello", timestamp: 1 }],
+      model,
+      reserveTokens,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      streamFn,
+    );
+    expect(result).toEqual({ ok: true, value: "summary" });
+    return observed;
+  }
+
+  async function captureSplitTurnMaxTokens(reserveTokens: number): Promise<(number | undefined)[]> {
+    const model = createBudgetModel();
+    const observed: (number | undefined)[] = [];
+    let callCount = 0;
+    const streamFn = vi.fn<StreamFn>((_model, _context, options) => {
+      observed.push(options?.maxTokens);
+      callCount++;
+      const stream = createAssistantMessageEventStream();
+      stream.push({
+        type: "done",
+        reason: "stop",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: `summary-${callCount}` }],
+          api: model.api,
+          provider: model.provider,
+          model: model.id,
+          usage: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 0,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+          stopReason: "stop",
+          timestamp: 1,
+        },
+      });
+      stream.end();
+      return stream;
+    });
+    const result = await compact(
+      {
+        firstKeptEntryId: "kept-entry",
+        messagesToSummarize: [{ role: "user", content: "history", timestamp: 1 }],
+        turnPrefixMessages: [{ role: "user", content: "prefix", timestamp: 2 }],
+        isSplitTurn: true,
+        tokensBefore: 100,
+        fileOps: createFileOps(),
+        settings: { enabled: true, reserveTokens, keepRecentTokens: 100 },
+      },
+      model,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      streamFn,
+    );
+    expect(result.ok).toBe(true);
+    return observed;
+  }
+
+  it("keeps raised-reserve authorization caller-owned", async () => {
+    const observed = await captureSummaryMaxTokens(80_000);
+
+    expect(observed).toBe(64_000);
+  });
+
+  it("leaves the agent runtime's default reserve path unchanged", async () => {
+    // The agent layer floors the reserve at 20_000, so this is the value ordinary
+    // compaction actually runs with. Its authorization must not move.
+    const observed = await captureSummaryMaxTokens(20_000);
+
+    expect(observed).toBe(16_000);
+  });
+
+  it("leaves the harness default reserve path unchanged", async () => {
+    // The harness default sits below the floor and must be equally untouched.
+    const observed = await captureSummaryMaxTokens(16_384);
+
+    expect(observed).toBe(13_107);
+  });
+
+  it("keeps split-turn authorization caller-owned", async () => {
+    const raised = await captureSplitTurnMaxTokens(80_000);
+
+    expect(raised).toEqual([64_000, 40_000]);
+  });
+});

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -2143,6 +2143,47 @@ describe("compaction-safeguard recent-turn preservation", () => {
     mockSummarizeInStages.mockResolvedValue(summaryResult("mock summary"));
 
     const sessionManager = stubSessionManager();
+    // Keep the model output limit below the staged-summary cap so this case still
+    // proves the model-limit clamp rather than the safeguard's own ceiling.
+    const model = createAnthropicModelFixture({
+      contextWindow: 1_000_000,
+      maxTokens: 4_000,
+    });
+    setCompactionSafeguardRuntime(sessionManager, { model, recentTurnsPreserve: 0 });
+
+    const compactionHandler = createCompactionHandler();
+    const mockContext = createCompactionContext({
+      sessionManager,
+      getApiKeyMock: vi.fn().mockResolvedValue("test-key"),
+    });
+    const event = {
+      preparation: {
+        messagesToSummarize: [
+          { role: "user", content: "large history", timestamp: 1 } as AgentMessage,
+        ],
+        turnPrefixMessages: [],
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 250_000,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 8_000 },
+        previousSummary: undefined,
+        isSplitTurn: false,
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+
+    await compactionHandler(event, mockContext);
+
+    const call = requireRecord(mockCallArg(mockSummarizeInStages));
+    expect(call?.reserveTokens).toBe(4_000);
+  });
+
+  it("caps a raised reserve before safeguard staged summaries", async () => {
+    mockSummarizeInStages.mockReset();
+    mockSummarizeInStages.mockResolvedValue(summaryResult("mock summary"));
+
+    const sessionManager = stubSessionManager();
     const model = createAnthropicModelFixture({
       contextWindow: 1_000_000,
       maxTokens: 128_000,
@@ -2163,7 +2204,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
         firstKeptEntryId: "entry-1",
         tokensBefore: 250_000,
         fileOps: { read: [], edited: [], written: [] },
-        settings: { reserveTokens: 240_000 },
+        settings: { reserveTokens: 80_000 },
         previousSummary: undefined,
         isSplitTurn: false,
       },
@@ -2174,7 +2215,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
     await compactionHandler(event, mockContext);
 
     const call = requireRecord(mockCallArg(mockSummarizeInStages));
-    expect(call?.reserveTokens).toBe(128_000);
+    expect(call?.reserveTokens).toBe(20_000);
   });
 
   it("preserves provider-prepared Copilot headers in built-in compaction summarization", async () => {
@@ -2314,6 +2355,70 @@ describe("compaction-safeguard recent-turn preservation", () => {
       }
     },
   );
+
+  it("runs raised-reserve safeguard compaction with capped output and recovery", async () => {
+    testing.setSummarizeInStagesForTest(actualCompactionModule.summarizeInStages);
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture({
+      api: "test-api" as never,
+      baseUrl: "",
+      maxTokens: 128_000,
+      reasoning: true,
+    });
+    setCompactionSafeguardRuntime(sessionManager, { model, recentTurnsPreserve: 0 });
+
+    const providerPrompts: string[] = [];
+    const authorizedOutputTokens: number[] = [];
+    const streamFn: StreamFn = (_activeModel, context, options) => {
+      expect(options?.reasoning).toBe("high");
+      if (options?.maxTokens === undefined) {
+        throw new Error("Expected safeguard compaction to authorize output tokens.");
+      }
+      authorizedOutputTokens.push(options.maxTokens);
+      providerPrompts.push(JSON.stringify(context));
+      const stream = createAssistantMessageEventStream();
+      stream.push({
+        type: "done",
+        reason: "stop",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "provider summary" }],
+          api: model.api,
+          provider: model.provider,
+          model: model.id,
+          usage: createZeroUsageFixture(),
+          stopReason: "stop",
+          timestamp: 1,
+        },
+      });
+      stream.end();
+      return stream;
+    };
+    const mockContext = createCompactionContext({
+      sessionManager,
+      getApiKeyAndHeadersMock: vi.fn().mockResolvedValue({ ok: true, apiKey: "test-key" }),
+    });
+    const compactionHandler = createCompactionHandler();
+    const event = {
+      ...createCompactionEvent({ messageText: "summarize me", tokensBefore: 1_000 }),
+      thinkingLevel: "high" as const,
+      streamFn,
+    };
+    (event.preparation as { settings?: { reserveTokens: number } }).settings = {
+      reserveTokens: 80_000,
+    };
+
+    const result = (await compactionHandler(event, mockContext)) as {
+      cancel?: boolean;
+      compaction?: { summary?: string };
+    };
+
+    expect(result.cancel).not.toBe(true);
+    expect(result.compaction?.summary).toContain("provider summary");
+    expect(authorizedOutputTokens).toEqual([16_000]);
+    expect(providerPrompts).toHaveLength(1);
+    expect(providerPrompts[0]).toContain("[User]: summarize me");
+  });
 
   it("surfaces a total provider failure and leaves the safeguard transcript unchanged", async () => {
     testing.setSummarizeInStagesForTest(actualCompactionModule.summarizeInStages);

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -78,6 +78,7 @@ const missedModelWarningSessions = new WeakSet<object>();
 const SPLIT_TURN_SECTION_HEADING = "**Turn Context (split turn):**";
 const MAX_TOOL_FAILURES = 8;
 const MAX_TOOL_FAILURE_CHARS = 240;
+const MAX_STAGED_SUMMARY_RESERVE_TOKENS = 20_000;
 const CONTEXT_TRUNCATED_MARKER = "\n\n[Earlier compaction context truncated to fit budget]\n\n";
 // Split-turn context supplements the generated summary and must not claim its
 // guaranteed half of the final artifact before common finalization runs.
@@ -556,7 +557,11 @@ function resolveSummaryReserveTokens(
   requestedReserveTokens: number,
   model: NonNullable<Parameters<typeof summarizeInStages>[0]["model"]>,
 ): number {
-  const requested = Math.max(1, Math.floor(requestedReserveTokens));
+  // Safeguard owns retained-summary policy; generic callers own their output budget.
+  const requested = Math.max(
+    1,
+    Math.min(Math.floor(requestedReserveTokens), MAX_STAGED_SUMMARY_RESERVE_TOKENS),
+  );
   const modelMaxTokens = model.maxTokens;
   if (
     typeof modelMaxTokens !== "number" ||


### PR DESCRIPTION
Fixes #119404

## What Problem This Solves

A raised compaction reserve can turn safeguard-mode staged summaries into disproportionately large model-output requests. The original generic agent-core cap was too broad: it changed budgets owned by callers outside safeguard mode.

## Why This Change Was Made

Retained-summary policy belongs at the safeguard boundary. The safeguard caps only the reserve passed into its built-in `summarizeInStages()` path at 20,000 tokens; generic `generateSummary()` and split-turn `compact()` calculations continue to use the reserve supplied by their caller, subject only to the model output limit.

## User Impact

- Safeguard sessions with `reserveTokens=80,000` authorize a 16,000-token staged-summary request rather than allowing output to scale with the raised reserve.
- Generic agent-core callers retain caller-owned raised-reserve authorization: 64,000 for ordinary summaries and `[64,000, 40,000]` for split turns on the large-output test model.
- This intentionally changes persisted safeguard sessions above 20,000 only; it does not alter generic or split-turn caller budgets.

## Evidence

### Exact REST refresh and semantic preservation

- Public RED baseline: the prior PR head `1189958124784a1c81035a4cbd35f92f9963ab26` was `CONFLICTING/DIRTY`.
- Exact refreshed head: `caeb1e25a6699b760eb92591adf7ca67b1b51a6d`, parent `61bc753da306a49243525b99e3d70e12ef1e5c25`.
- Publication used the Git Database API. Immediately before the forced ref update, the fork ref was explicitly leased at the old head above; the update response returned the refreshed head.
- The API tree is `78d85cfdb9e421175ba32f1b7eca62116aee5472`. Its production `src/agents/agent-hooks/compaction-safeguard.ts` blob is `5bc70d727e07d2f6b91a25256a36245f388aa80d`, byte-identical to the prior accepted PR head's production blob.
- Current-main overlap was test-only. The generic caller-budget block is preserved in `packages/agent-core/src/harness/compaction/compaction-summary-output-budget.test.ts`; moving it avoids the current main file's 1,000-line test limit while retaining upstream's independent trailing-compaction tests.

### Local validation

```text
pnpm test packages/agent-core/src/harness/compaction/compaction.test.ts packages/agent-core/src/harness/compaction/compaction-summary-output-budget.test.ts src/agents/agent-hooks/compaction-safeguard.test.ts
48 passed (agent-core); 130 passed (safeguard)

pnpm check:changed --staged
exit 0

autoreview --mode local
clean: no accepted/actionable findings
```

### Redacted real-transport proof equivalence

ClawSweeper previously accepted redacted non-mocked Anthropic Messages proof on `1189958124784a1c81035a4cbd35f92f9963ab26` for `reserve_in=80000 -> staged_reserve=20000 -> max_tokens=16000 -> nonempty compaction`. The exact production blob containing that safeguard owner boundary is unchanged on this head (`5bc70d727e07d2f6b91a25256a36245f388aa80d`); the refresh changes only test placement around current-main test overlap.

This is proof equivalence, not a new live-run claim. The currently configured Anthropic OAuth refresh returns `invalid_grant`, so no credential, endpoint, request body, or model response is logged or claimed for this refreshed head.

### CI and review

Exact-head CI and fresh ClawSweeper review are requested for `caeb1e25a6699b760eb92591adf7ca67b1b51a6d`.
