### PR TITLE
refactor(discord): consolidate interactive response handling

### DIFF
--- a/extensions/discord/src/monitor/agent-components-context.ts
+++ b/extensions/discord/src/monitor/agent-components-context.ts
@@ -66,6 +66,17 @@ export async function ackComponentInteraction(params: {
   }
 }
 
+export async function replyUnavailableComponentInteraction(
+  interaction: AgentComponentInteraction,
+  content: string,
+): Promise<void> {
+  try {
+    await interaction.reply({ content, ephemeral: true });
+  } catch {
+    // The interaction may have expired before its failure reply could be delivered.
+  }
+}
+
 export function resolveDiscordChannelContext(
   interaction: AgentComponentInteraction,
 ): DiscordChannelContext {

--- a/extensions/discord/src/monitor/agent-components-helpers.ts
+++ b/extensions/discord/src/monitor/agent-components-helpers.ts
@@ -2,7 +2,11 @@
 export const AGENT_BUTTON_KEY = "agent";
 export const AGENT_SELECT_KEY = "agentsel";
 
-export { ackComponentInteraction, resolveAgentComponentRoute } from "./agent-components-context.js";
+export {
+  ackComponentInteraction,
+  replyUnavailableComponentInteraction,
+  resolveAgentComponentRoute,
+} from "./agent-components-context.js";
 export {
   ensureAgentComponentInteractionAllowed,
   ensureComponentUserAllowed,

--- a/extensions/discord/src/monitor/agent-components.handlers.ts
+++ b/extensions/discord/src/monitor/agent-components.handlers.ts
@@ -12,6 +12,7 @@ import {
   ensureComponentUserAllowed,
   mapSelectValues,
   parseDiscordComponentData,
+  replyUnavailableComponentInteraction,
   resolveAuthorizedComponentInteraction,
   resolveInteractionCustomId,
 } from "./agent-components-helpers.js";
@@ -35,14 +36,10 @@ async function handleDiscordComponentEvent(params: {
   );
   if (!parsed) {
     logError(`${params.label}: failed to parse component data`);
-    try {
-      await params.interaction.reply({
-        content: "This component is no longer valid.",
-        ephemeral: true,
-      });
-    } catch {
-      // Interaction may have expired
-    }
+    await replyUnavailableComponentInteraction(
+      params.interaction,
+      "This component is no longer valid.",
+    );
     return;
   }
 
@@ -51,14 +48,7 @@ async function handleDiscordComponentEvent(params: {
     consume: false,
   });
   if (!entry) {
-    try {
-      await params.interaction.reply({
-        content: "This component has expired.",
-        ephemeral: true,
-      });
-    } catch {
-      // Interaction may have expired
-    }
+    await replyUnavailableComponentInteraction(params.interaction, "This component has expired.");
     return;
   }
 
@@ -101,26 +91,15 @@ async function handleDiscordComponentEvent(params: {
     consume: !entry.reusable,
   });
   if (!consumed) {
-    try {
-      await params.interaction.reply({
-        content: "This component has expired.",
-        ephemeral: true,
-      });
-    } catch {
-      // Interaction may have expired
-    }
+    await replyUnavailableComponentInteraction(params.interaction, "This component has expired.");
     return;
   }
 
   if (consumed.kind === "modal-trigger") {
-    try {
-      await params.interaction.reply({
-        content: "This form is no longer available.",
-        ephemeral: true,
-      });
-    } catch {
-      // Interaction may have expired
-    }
+    await replyUnavailableComponentInteraction(
+      params.interaction,
+      "This form is no longer available.",
+    );
     return;
   }
 
@@ -203,14 +182,10 @@ async function handleDiscordModalTrigger(params: {
   );
   if (!parsed) {
     logError(`${params.label}: failed to parse modal trigger data`);
-    try {
-      await params.interaction.reply({
-        content: "This button is no longer valid.",
-        ephemeral: true,
-      });
-    } catch {
-      // Interaction may have expired
-    }
+    await replyUnavailableComponentInteraction(
+      params.interaction,
+      "This button is no longer valid.",
+    );
     return;
   }
   const entry = await resolveDiscordComponentEntryWithPersistence({
@@ -218,27 +193,16 @@ async function handleDiscordModalTrigger(params: {
     consume: false,
   });
   if (!entry || entry.kind !== "modal-trigger") {
-    try {
-      await params.interaction.reply({
-        content: "This button has expired.",
-        ephemeral: true,
-      });
-    } catch {
-      // Interaction may have expired
-    }
+    await replyUnavailableComponentInteraction(params.interaction, "This button has expired.");
     return;
   }
 
   const modalId = entry.modalId ?? parsed.modalId;
   if (!modalId) {
-    try {
-      await params.interaction.reply({
-        content: "This form is no longer available.",
-        ephemeral: true,
-      });
-    } catch {
-      // Interaction may have expired
-    }
+    await replyUnavailableComponentInteraction(
+      params.interaction,
+      "This form is no longer available.",
+    );
     return;
   }
 
@@ -274,14 +238,7 @@ async function handleDiscordModalTrigger(params: {
     consume: !entry.reusable,
   });
   if (!consumed) {
-    try {
-      await params.interaction.reply({
-        content: "This form has expired.",
-        ephemeral: true,
-      });
-    } catch {
-      // Interaction may have expired
-    }
+    await replyUnavailableComponentInteraction(params.interaction, "This form has expired.");
     return;
   }
 
@@ -291,14 +248,7 @@ async function handleDiscordModalTrigger(params: {
     consume: false,
   });
   if (!modalEntry) {
-    try {
-      await params.interaction.reply({
-        content: "This form has expired.",
-        ephemeral: true,
-      });
-    } catch {
-      // Interaction may have expired
-    }
+    await replyUnavailableComponentInteraction(params.interaction, "This form has expired.");
     return;
   }
 

--- a/extensions/discord/src/monitor/agent-components.modal.ts
+++ b/extensions/discord/src/monitor/agent-components.modal.ts
@@ -8,6 +8,7 @@ import {
   ensureComponentUserAllowed,
   formatModalSubmissionText,
   parseDiscordModalId,
+  replyUnavailableComponentInteraction,
   resolveAuthorizedComponentInteraction,
   resolveInteractionCustomId,
   resolveModalFieldValues,
@@ -31,14 +32,7 @@ export class DiscordComponentModal extends Modal {
     const modalId = parseDiscordModalId(data, resolveInteractionCustomId(interaction));
     if (!modalId) {
       logError("discord component modal: missing modal id");
-      try {
-        await interaction.reply({
-          content: "This form is no longer valid.",
-          ephemeral: true,
-        });
-      } catch {
-        // Interaction may have expired
-      }
+      await replyUnavailableComponentInteraction(interaction, "This form is no longer valid.");
       return;
     }
 
@@ -47,14 +41,7 @@ export class DiscordComponentModal extends Modal {
       consume: false,
     });
     if (!modalEntry) {
-      try {
-        await interaction.reply({
-          content: "This form has expired.",
-          ephemeral: true,
-        });
-      } catch {
-        // Interaction may have expired
-      }
+      await replyUnavailableComponentInteraction(interaction, "This form has expired.");
       return;
     }
 
@@ -103,14 +90,7 @@ export class DiscordComponentModal extends Modal {
       consume: !modalEntry.reusable,
     });
     if (!consumed) {
-      try {
-        await interaction.reply({
-          content: "This form has expired.",
-          ephemeral: true,
-        });
-      } catch {
-        // Interaction may have expired
-      }
+      await replyUnavailableComponentInteraction(interaction, "This form has expired.");
       return;
     }
 

--- a/extensions/discord/src/monitor/agent-components.system-controls.ts
+++ b/extensions/discord/src/monitor/agent-components.system-controls.ts
@@ -15,6 +15,7 @@ import {
   ackComponentInteraction,
   ensureAgentComponentInteractionAllowed,
   parseAgentComponentData,
+  replyUnavailableComponentInteraction,
   resolveAgentComponentRoute,
   resolveInteractionContextWithDmAuth,
   type AgentComponentContext,
@@ -39,14 +40,7 @@ async function runAgentSystemControlInteraction(params: AgentSystemControlParams
   const parsed = parseAgentComponentData(params.data);
   if (!parsed) {
     logError(`${params.label}: failed to parse component data`);
-    try {
-      await params.interaction.reply({
-        content: params.invalidReply,
-        ephemeral: true,
-      });
-    } catch {
-      // Interaction may have expired
-    }
+    await replyUnavailableComponentInteraction(params.interaction, params.invalidReply);
     return;
   }
 

--- a/extensions/discord/src/shared-interactive.ts
+++ b/extensions/discord/src/shared-interactive.ts
@@ -1,6 +1,7 @@
 // Discord plugin module implements shared interactive behavior.
 import {
   reduceLegacyInteractiveReply,
+  resolveMessagePresentationActionValue,
   resolveMessagePresentationButtonAction,
   resolveMessagePresentationOptionAction,
 } from "openclaw/plugin-sdk/interactive-runtime";
@@ -10,6 +11,7 @@ import type {
   MessagePresentation,
   MessagePresentationButton,
   MessagePresentationOption,
+  MessagePresentationSelectBlock,
 } from "openclaw/plugin-sdk/interactive-runtime";
 import { buildDiscordApprovalCustomId } from "./approval-custom-id.js";
 import {
@@ -30,30 +32,20 @@ function resolveDiscordInteractiveButtonStyle(
 }
 
 function resolveDiscordSelectOptionValue(option: MessagePresentationOption): string | undefined {
-  const action = resolveMessagePresentationOptionAction(option);
-  if (action?.type === "command") {
-    return action.command;
-  }
-  if (action?.type === "callback") {
-    return action.value;
-  }
-  return undefined;
+  return resolveMessagePresentationActionValue(resolveMessagePresentationOptionAction(option));
 }
 
 function resolveDiscordSelectCallbackDataKind(
   options: MessagePresentationOption[],
 ): "command" | "callback" | "mixed" | undefined {
   const renderableOptions = options.filter((option) => resolveDiscordSelectOptionValue(option));
-  if (
-    renderableOptions.length > 0 &&
-    renderableOptions.every((option) => option.action?.type === "command")
-  ) {
+  if (renderableOptions.length === 0) {
+    return undefined;
+  }
+  if (renderableOptions.every((option) => option.action?.type === "command")) {
     return "command";
   }
-  if (
-    renderableOptions.length > 0 &&
-    renderableOptions.every((option) => option.action?.type === "callback")
-  ) {
+  if (renderableOptions.every((option) => option.action?.type === "callback")) {
     return "callback";
   }
   if (renderableOptions.some((option) => option.action)) {
@@ -154,6 +146,34 @@ function appendDiscordButtonBlocks(
   }
 }
 
+function appendDiscordSelectBlock(
+  blocks: NonNullable<DiscordComponentMessageSpec["blocks"]>,
+  block: MessagePresentationSelectBlock,
+): void {
+  const options = block.options
+    .map((option) => ({
+      label: option.label,
+      value: resolveDiscordSelectOptionValue(option),
+    }))
+    .filter((option): option is { label: string; value: string } => Boolean(option.value));
+  if (options.length === 0) {
+    return;
+  }
+  const callbackDataKind = resolveDiscordSelectCallbackDataKind(block.options);
+  if (callbackDataKind === "mixed") {
+    return;
+  }
+  blocks.push({
+    type: "actions",
+    select: {
+      type: "string",
+      placeholder: block.placeholder,
+      options,
+      callbackDataKind,
+    },
+  });
+}
+
 /**
  * @deprecated Use buildDiscordPresentationComponents with MessagePresentation.
  */
@@ -175,29 +195,8 @@ export function buildDiscordInteractiveComponents(
         appendDiscordButtonBlocks(state, block.buttons);
         return state;
       }
-      if (block.type === "select" && block.options.length > 0) {
-        const options = block.options
-          .map((option) => ({
-            label: option.label,
-            value: resolveDiscordSelectOptionValue(option),
-          }))
-          .filter((option): option is { label: string; value: string } => Boolean(option.value));
-        if (options.length === 0) {
-          return state;
-        }
-        const callbackDataKind = resolveDiscordSelectCallbackDataKind(block.options);
-        if (callbackDataKind === "mixed") {
-          return state;
-        }
-        state.push({
-          type: "actions",
-          select: {
-            type: "string",
-            placeholder: block.placeholder,
-            options,
-            callbackDataKind,
-          },
-        });
+      if (block.type === "select") {
+        appendDiscordSelectBlock(state, block);
       }
       return state;
     },
@@ -211,15 +210,15 @@ export function buildDiscordPresentationComponents(
   if (!presentation) {
     return undefined;
   }
-  const spec: DiscordComponentMessageSpec = { blocks: [] };
+  const blocks: NonNullable<DiscordComponentMessageSpec["blocks"]> = [];
   if (presentation.title) {
-    spec.blocks?.push({ type: "text", text: presentation.title });
+    blocks.push({ type: "text", text: presentation.title });
   }
   for (const block of presentation.blocks) {
     if (block.type === "text" || block.type === "context") {
       const text = block.text.trim();
       if (text) {
-        spec.blocks?.push({
+        blocks.push({
           type: "text",
           text: block.type === "context" ? `-# ${text}` : text,
         });
@@ -227,48 +226,18 @@ export function buildDiscordPresentationComponents(
       continue;
     }
     if (block.type === "divider") {
-      spec.blocks?.push({ type: "separator" });
+      blocks.push({ type: "separator" });
       continue;
     }
   }
   for (const block of presentation.blocks) {
     if (block.type === "buttons") {
-      appendDiscordPresentationButtonBlocks(spec, block.buttons);
+      appendDiscordButtonBlocks(blocks, block.buttons);
       continue;
     }
-    if (block.type === "select" && block.options.length > 0) {
-      const options = block.options
-        .map((option) => ({
-          label: option.label,
-          value: resolveDiscordSelectOptionValue(option),
-        }))
-        .filter((option): option is { label: string; value: string } => Boolean(option.value));
-      if (options.length === 0) {
-        continue;
-      }
-      const callbackDataKind = resolveDiscordSelectCallbackDataKind(block.options);
-      if (callbackDataKind === "mixed") {
-        continue;
-      }
-      spec.blocks?.push({
-        type: "actions",
-        select: {
-          type: "string",
-          placeholder: block.placeholder,
-          options,
-          callbackDataKind,
-        },
-      });
+    if (block.type === "select") {
+      appendDiscordSelectBlock(blocks, block);
     }
   }
-  return spec.blocks?.length ? spec : undefined;
-}
-
-function appendDiscordPresentationButtonBlocks(
-  spec: DiscordComponentMessageSpec,
-  buttons: readonly MessagePresentationButton[],
-) {
-  if (spec.blocks) {
-    appendDiscordButtonBlocks(spec.blocks, buttons);
-  }
+  return blocks.length ? { blocks } : undefined;
 }


### PR DESCRIPTION
## What Problem This Solves

Discord interactive replies duplicated private invalid/expired-component failure handling across buttons, selects, modal triggers, modal submissions, and system controls. The legacy interactive and current presentation renderers also maintained duplicate select construction and action-value logic, increasing maintenance risk for interaction behavior.

## Why This Change Was Made

Consolidate private interaction failure replies in one Discord-owned helper and reuse the canonical presentation action-value resolver plus shared Discord select/button builders. Preserve authorization and per-user allowlist checks before consuming persisted interactions, existing ephemeral failure text and expired-interaction handling, exact command-versus-callback isolation, mixed-action rejection, modal behavior, authored component ordering, and five-button action rows. No public plugin SDK or configuration contracts change.

## User Impact

No intended user-visible behavior change: Discord buttons, selects, modal forms, authorization denials, and private invalid/expired interaction responses continue behaving exactly as before. The Discord plugin loses 92 production lines (+90/-182 across six files) while retaining the same component rendering and delivery semantics.

## Evidence

- Trusted Blacksmith Testbox proof: https://github.com/openclaw/openclaw/actions/runs/30970879382
- 16 existing focused Discord interaction, component, action, and monitor suites: **261/261 tests passed**.
- Full, unchanged `pnpm check:changed`: **passed**, including extension production/test typechecks, formatting, plugin/API boundaries, dead-export scan, dependency guards, changed-file lint (0 warnings/errors), database/media/runtime sidecar guards, and runtime import-cycle checks.
- Independent structured autoreview of the frozen change: engine `codex`, model `gpt-5.6-sol`, thinking `xhigh`; **no accepted/actionable findings**, patch correctness confidence **0.99**.
- Direct dependency-contract inspection confirmed private Discord responses use the ephemeral message flag, command/callback select actions remain distinct, and existing component/action-row behavior is preserved.

### Exact-head Discord interaction production proof

Twelve actual committed production modules were checked against their exact Git object bytes, source-transpiled, and executed through the real Discord DM authorization owner, allowed-user enforcement, component/modal handlers, registry consumption, and canonical presentation normalization. Interaction objects and Discord transport were synthetic in-memory fixtures; no live account, credentials, network, or gateway were touched.

~~~json
{
  "head":"c0dbcc586f9ff0ce9e5d4bb883fa1b350291237b",
  "committedProductionModulesVerified":12,
  "authorizedCommand":{"dmAuth":"allow","allowedUsers":["111"],"consume":[false,true],"reply":{"content":"✓","ephemeral":true},"dispatched":"/status","pluginCallbackAuthorized":true},
  "expiredComponent":{"reply":{"content":"This component has expired.","ephemeral":true},"dispatched":false},
  "unauthorizedDm":{"reply":{"content":"You are not authorized to use this button.","ephemeral":true},"consumed":false},
  "deniedAllowedUsers":{"reply":{"content":"You are not authorized to use this button.","ephemeral":true},"consumed":false},
  "modalTrigger":{"shown":"Deploy configuration","componentConsumed":true},
  "modalSubmission":{"callback":"deploy:confirm","event":"Form \"Deploy configuration\" submitted.\n- Environment: production","consumed":true},
  "expiredModal":{"reply":{"content":"This form has expired.","ephemeral":true}},
  "expiredReplyRejection":"swallowed",
  "mixedCommandCallbackSelect":"rejected",
  "buttonRows":[5,2],
  "assertions":"PASS"
}
~~~

All actual production handler assertions passed: successful authorized component dispatch, private expiration and unauthorized replies, modal submission, authorization-before-consumption, mixed action rejection, and safe button-row splitting. This directly fulfills the requested redacted after-fix Discord interaction proof at the unchanged reviewed commit.


