### PR TITLE
refactor(ui): share sidebar conversation menu rendering

### DIFF
--- a/ui/src/components/app-sidebar-session-menu-renderers.ts
+++ b/ui/src/components/app-sidebar-session-menu-renderers.ts
@@ -21,6 +21,68 @@ import {
 
 type SidebarSessionGroupMenuAction = "rename-group" | "new-group" | "delete-group";
 
+function renderSidebarMenuTrigger(position: { x: number; y: number }, label: string) {
+  return html`
+    <button
+      slot="trigger"
+      type="button"
+      tabindex="-1"
+      aria-hidden="true"
+      aria-label=${label}
+      style="position: fixed; left: ${position.x}px; top: ${position.y}px; width: 1px; height: 1px; opacity: 0; pointer-events: none;"
+    ></button>
+  `;
+}
+
+function renderSidebarMenuRadioItem(params: {
+  value: string;
+  checked: boolean;
+  label: string;
+  creator?: SessionCreatorOption;
+}) {
+  return html`
+    <wa-dropdown-item
+      class="sidebar-session-sort-menu__item"
+      value=${params.value}
+      role="menuitemradio"
+      aria-checked=${String(params.checked)}
+      ${ref((element) => syncDropdownItemRadio(element, params.checked))}
+    >
+      <span slot="details" class="session-menu__check" aria-hidden="true"
+        >${params.checked ? icons.check : nothing}</span
+      >
+      ${params.creator ? renderSessionOwnerChip(params.creator, "row", "created") : nothing}
+      <span class="session-menu__text">${params.label}</span>
+    </wa-dropdown-item>
+  `;
+}
+
+function renderSidebarCreatorFilter(
+  creators: readonly SessionCreatorOption[],
+  creatorFilterId: string | null,
+) {
+  if (creators.length < 2) {
+    return nothing;
+  }
+  return html`
+    <div class="session-menu__separator" role="separator"></div>
+    <div class="sidebar-session-sort-menu__title">${t("sessionsView.people")}</div>
+    ${renderSidebarMenuRadioItem({
+      value: "creator:",
+      checked: creatorFilterId === null,
+      label: t("sessionsView.allCreators"),
+    })}
+    ${creators.map((creator) =>
+      renderSidebarMenuRadioItem({
+        value: `creator:${creator.id}`,
+        checked: creatorFilterId === creator.id,
+        label: creator.label ?? creator.id,
+        creator,
+      }),
+    )}
+  `;
+}
+
 export function renderSidebarSessionGroupMenu(params: {
   menu: SidebarSessionGroupMenuState | null;
   trigger: HTMLElement | null;
@@ -58,14 +120,7 @@ export function renderSidebarSessionGroupMenu(params: {
           @wa-after-hide=${(event: Event) =>
             params.onClose(consumeDropdownKeyboardDismissal(event))}
         >
-          <button
-            slot="trigger"
-            type="button"
-            tabindex="-1"
-            aria-hidden="true"
-            aria-label=${t("sessionsView.groupMenu", { group: menu.group })}
-            style="position: fixed; left: ${menu.x}px; top: ${menu.y}px; width: 1px; height: 1px; opacity: 0; pointer-events: none;"
-          ></button>
+          ${renderSidebarMenuTrigger(menu, t("sessionsView.groupMenu", { group: menu.group }))}
           <wa-dropdown-item
             class="session-menu__item"
             value="rename-group"
@@ -149,72 +204,16 @@ export function renderSidebarCatalogViewMenu(params: {
           @wa-after-hide=${(event: Event) =>
             params.onClose(consumeDropdownKeyboardDismissal(event))}
         >
-          <button
-            slot="trigger"
-            type="button"
-            tabindex="-1"
-            aria-hidden="true"
-            aria-label=${t("chat.sidebar.catalogViewOptions")}
-            style="position: fixed; left: ${position.x}px; top: ${position.y}px; width: 1px; height: 1px; opacity: 0; pointer-events: none;"
-          ></button>
+          ${renderSidebarMenuTrigger(position, t("chat.sidebar.catalogViewOptions"))}
           <div class="sidebar-session-sort-menu__title">${t("sessionsView.groupBy")}</div>
-          ${groupingOptions.map(
-            (option) => html`
-              <wa-dropdown-item
-                class="sidebar-session-sort-menu__item"
-                value=${`grouping:${option.grouping}`}
-                role="menuitemradio"
-                aria-checked=${String(params.grouping === option.grouping)}
-                ${ref((element) =>
-                  syncDropdownItemRadio(element, params.grouping === option.grouping),
-                )}
-              >
-                <span slot="details" class="session-menu__check" aria-hidden="true"
-                  >${params.grouping === option.grouping ? icons.check : nothing}</span
-                >
-                <span class="session-menu__text">${option.label}</span>
-              </wa-dropdown-item>
-            `,
+          ${groupingOptions.map((option) =>
+            renderSidebarMenuRadioItem({
+              value: `grouping:${option.grouping}`,
+              checked: params.grouping === option.grouping,
+              label: option.label,
+            }),
           )}
-          ${params.creators.length >= 2
-            ? html`
-                <div class="session-menu__separator" role="separator"></div>
-                <div class="sidebar-session-sort-menu__title">${t("sessionsView.people")}</div>
-                <wa-dropdown-item
-                  class="sidebar-session-sort-menu__item"
-                  value="creator:"
-                  role="menuitemradio"
-                  aria-checked=${String(params.creatorFilterId === null)}
-                  ${ref((element) =>
-                    syncDropdownItemRadio(element, params.creatorFilterId === null),
-                  )}
-                >
-                  <span slot="details" class="session-menu__check" aria-hidden="true"
-                    >${params.creatorFilterId === null ? icons.check : nothing}</span
-                  >
-                  <span class="session-menu__text">${t("sessionsView.allCreators")}</span>
-                </wa-dropdown-item>
-                ${params.creators.map(
-                  (creator) => html`
-                    <wa-dropdown-item
-                      class="sidebar-session-sort-menu__item"
-                      value=${`creator:${creator.id}`}
-                      role="menuitemradio"
-                      aria-checked=${String(params.creatorFilterId === creator.id)}
-                      ${ref((element) =>
-                        syncDropdownItemRadio(element, params.creatorFilterId === creator.id),
-                      )}
-                    >
-                      <span slot="details" class="session-menu__check" aria-hidden="true"
-                        >${params.creatorFilterId === creator.id ? icons.check : nothing}</span
-                      >
-                      ${renderSessionOwnerChip(creator, "row", "created")}
-                      <span class="session-menu__text">${creator.label ?? creator.id}</span>
-                    </wa-dropdown-item>
-                  `,
-                )}
-              `
-            : nothing}
+          ${renderSidebarCreatorFilter(params.creators, params.creatorFilterId)}
           <div class="session-menu__separator" role="separator"></div>
           <wa-dropdown-item class="sidebar-session-sort-menu__item" value="hide-catalog">
             <span class="session-menu__text">${t("chat.sidebar.hideFromSidebar")}</span>
@@ -281,116 +280,39 @@ export function renderSidebarSessionSortMenu(params: {
           @wa-after-hide=${(event: Event) =>
             params.onClose(consumeDropdownKeyboardDismissal(event))}
         >
-          <button
-            slot="trigger"
-            type="button"
-            tabindex="-1"
-            aria-hidden="true"
-            aria-label=${t("chat.sidebar.sortSessions")}
-            style="position: fixed; left: ${position.x}px; top: ${position.y}px; width: 1px; height: 1px; opacity: 0; pointer-events: none;"
-          ></button>
+          ${renderSidebarMenuTrigger(position, t("chat.sidebar.sortSessions"))}
           <div class="sidebar-session-sort-menu__title">${t("sessionsView.groupBy")}</div>
-          ${groupingOptions.map(
-            (option) => html`
-              <wa-dropdown-item
-                class="sidebar-session-sort-menu__item"
-                value=${`grouping:${option.grouping}`}
-                role="menuitemradio"
-                aria-checked=${String(params.grouping === option.grouping)}
-                ${ref((element) =>
-                  syncDropdownItemRadio(element, params.grouping === option.grouping),
-                )}
-              >
-                <span slot="details" class="session-menu__check" aria-hidden="true"
-                  >${params.grouping === option.grouping ? icons.check : nothing}</span
-                >
-                <span class="session-menu__text">${option.label}</span>
-              </wa-dropdown-item>
-            `,
+          ${groupingOptions.map((option) =>
+            renderSidebarMenuRadioItem({
+              value: `grouping:${option.grouping}`,
+              checked: params.grouping === option.grouping,
+              label: option.label,
+            }),
           )}
           <div class="session-menu__separator" role="separator"></div>
           <div class="sidebar-session-sort-menu__title">${t("chat.sidebar.sortBy")}</div>
-          ${SIDEBAR_SESSION_SORT_OPTIONS.map(
-            (option) => html`
-              <wa-dropdown-item
-                class="sidebar-session-sort-menu__item"
-                value=${`sort:${option.mode}`}
-                role="menuitemradio"
-                aria-checked=${String(params.sortMode === option.mode)}
-                ${ref((element) => syncDropdownItemRadio(element, params.sortMode === option.mode))}
-              >
-                <span slot="details" class="session-menu__check" aria-hidden="true"
-                  >${params.sortMode === option.mode ? icons.check : nothing}</span
-                >
-                <span class="session-menu__text">${t(option.labelKey)}</span>
-              </wa-dropdown-item>
-            `,
+          ${SIDEBAR_SESSION_SORT_OPTIONS.map((option) =>
+            renderSidebarMenuRadioItem({
+              value: `sort:${option.mode}`,
+              checked: params.sortMode === option.mode,
+              label: t(option.labelKey),
+            }),
           )}
           <div class="session-menu__separator" role="separator"></div>
           <div class="sidebar-session-sort-menu__title">${t("sessionsView.status")}</div>
-          ${SIDEBAR_SESSION_STATUS_OPTIONS.map(
-            (statusFilter) => html`
-              <wa-dropdown-item
-                class="sidebar-session-sort-menu__item"
-                value=${`status:${statusFilter}`}
-                role="menuitemradio"
-                aria-checked=${String(params.statusFilter === statusFilter)}
-                ${ref((element) =>
-                  syncDropdownItemRadio(element, params.statusFilter === statusFilter),
-                )}
-              >
-                <span slot="details" class="session-menu__check" aria-hidden="true"
-                  >${params.statusFilter === statusFilter ? icons.check : nothing}</span
-                >
-                <span class="session-menu__text"
-                  >${statusFilter === "active"
-                    ? t("common.active")
-                    : statusFilter === "archived"
-                      ? t("sessionsView.archived")
-                      : t("sessionsView.all")}</span
-                >
-              </wa-dropdown-item>
-            `,
+          ${SIDEBAR_SESSION_STATUS_OPTIONS.map((statusFilter) =>
+            renderSidebarMenuRadioItem({
+              value: `status:${statusFilter}`,
+              checked: params.statusFilter === statusFilter,
+              label:
+                statusFilter === "active"
+                  ? t("common.active")
+                  : statusFilter === "archived"
+                    ? t("sessionsView.archived")
+                    : t("sessionsView.all"),
+            }),
           )}
-          ${params.creators.length >= 2
-            ? html`
-                <div class="session-menu__separator" role="separator"></div>
-                <div class="sidebar-session-sort-menu__title">${t("sessionsView.people")}</div>
-                <wa-dropdown-item
-                  class="sidebar-session-sort-menu__item"
-                  value="creator:"
-                  role="menuitemradio"
-                  aria-checked=${String(params.creatorFilterId === null)}
-                  ${ref((element) =>
-                    syncDropdownItemRadio(element, params.creatorFilterId === null),
-                  )}
-                >
-                  <span slot="details" class="session-menu__check" aria-hidden="true"
-                    >${params.creatorFilterId === null ? icons.check : nothing}</span
-                  >
-                  <span class="session-menu__text">${t("sessionsView.allCreators")}</span>
-                </wa-dropdown-item>
-                ${params.creators.map(
-                  (creator) => html`
-                    <wa-dropdown-item
-                      class="sidebar-session-sort-menu__item"
-                      value=${`creator:${creator.id}`}
-                      role="menuitemradio"
-                      aria-checked=${String(params.creatorFilterId === creator.id)}
-                      ${ref((element) =>
-                        syncDropdownItemRadio(element, params.creatorFilterId === creator.id),
-                      )}
-                    >
-                      <span slot="details" class="session-menu__check" aria-hidden="true"
-                        >${params.creatorFilterId === creator.id ? icons.check : nothing}</span
-                      >
-                      ${renderSessionOwnerChip(creator, "row", "created")}
-                      <span class="session-menu__text">${creator.label ?? creator.id}</span>
-                    </wa-dropdown-item>
-                  `,
-                )}
-              `
-            : nothing}
+          ${renderSidebarCreatorFilter(params.creators, params.creatorFilterId)}
           <div class="session-menu__separator" role="separator"></div>
           <wa-dropdown-item
             class="sidebar-session-sort-menu__item"


### PR DESCRIPTION
## What Problem This Solves

The Control UI conversation sidebar repeated hidden dropdown anchors, accessible radio rows, and collaborator filters across its group, catalog, and sorting menus. Maintaining those copies independently made it easier for equivalent conversation controls to drift.

## Why This Change Was Made

Use one owner-local renderer for sidebar menu triggers, checked radio choices, and collaborator-filter sections while preserving each menu’s existing actions, visibility rules, translations, and DOM structure. This removes 78 production lines without changing configuration, dependencies, or public contracts.

## User Impact

No visual or behavioral changes. Conversation grouping, sorting, status and collaborator filters, owner avatars, separators, localization, keyboard navigation, focus restoration, accessible radio roles and checked states, and dropdown placement behave exactly as before.

## Evidence

- 254 baseline-versus-refactor DOM and action equivalence scenarios passed, covering visible element structure, hidden anchors, accessibility attributes, checked-state synchronization, owner avatars, filters, localization, separators, and selection dispatch.
- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30971028532
- 243 focused tests passed across three existing suites: 233 sidebar integration tests, 8 Web Awesome keyboard/focus/accessibility tests, and 2 real Chromium sidebar menu top-layer and divider hit-testing regressions.
- Full unchanged `pnpm check:changed` passed remotely, including repository guards, dead-code scans, Control UI localization, core-test and UI typechecks, and changed-file lint with zero warnings or errors.
- Structured autoreview with `--engine codex --model gpt-5.6-sol --thinking xhigh` passed with no actionable findings.
- Production diff: 96 additions, 174 deletions; net 78 fewer lines. No test changes.

## Real Browser Evidence (Exact PR Head)

Captured at `926e5476b29d589ff46e76a9183c658c710a0547` in Google Chrome `150.0.7871.187`, using the actual production Lit sidebar renderers, Web Awesome dropdown custom elements, and checked-in Control UI styles:

- **Conversation group menu:** visible rename/new/delete actions, keyboard focus ring, and destructive-action styling. SHA-256: `ae5caed3721dd11a5a8cb13468e69eecd876e30025d30db3a001f2d45d39f153`.
- **Catalog view menu:** project/person/none grouping, People section, checked creator filter, accessible owner avatars, and Hide from sidebar. SHA-256: `dc5511d88070c0c54a6f601964835a970c868aefb3c34d13e6009367dd09c080`.
- **Conversation sort menu:** grouping, created/updated sorting, active/archived/all status, People filtering, owner avatars, and checked automation toggle. SHA-256: `dcb34702bd7ab4a35328961a32d76634e5d5702273c113cbd48b7af8c8a5c673`.

Each screenshot uses a real open dropdown in the browser popover top layer. Hidden anchors remain `aria-hidden="true"`, `tabindex="-1"`, and `pointer-events: none`; actual radio rows expose `role="menuitemradio"` and the expected `aria-checked` values, and owner avatars retain descriptive accessible names.

### Group, catalog, and sort browser captures
<img width="920" height="920" alt="group-menu" src="https://github.com/user-attachments/assets/de5b6f25-401f-4f80-85ab-3e139062694d" />
<img width="920" height="920" alt="catalog-menu" src="https://github.com/user-attachments/assets/7a3a2934-fc5e-4499-9bf8-d9e588362f5d" />
<img width="920" height="920" alt="sort-menu" src="https://github.com/user-attachments/assets/b3ff564e-703f-4e1c-9205-08dbb1daa65e" />

