### PR TITLE
fix(gateway): settle same-run terminal lifecycle events past the stale guard

### DIFF
--- a/src/agents/command/session.ts
+++ b/src/agents/command/session.ts
@@ -67,6 +67,7 @@ export function clearRotatedSessionMetadata(entry: SessionEntry): SessionEntry {
     ...entry,
     sessionFile: undefined,
     status: undefined,
+    lifecycleRunId: undefined,
     startedAt: undefined,
     endedAt: undefined,
     runtimeMs: undefined,

--- a/src/auto-reply/reply/restart-recovery-claim.ts
+++ b/src/auto-reply/reply/restart-recovery-claim.ts
@@ -333,6 +333,9 @@ export function createReplyRestartRecoveryClaimController(params: {
             sourceTurnId && params.sameChannelThreadRequired === true ? true : undefined,
           restartRecoverySourceIngress: sourceTurnId ? "channel" : undefined,
           restartRecoverySourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+          // Admission rewrites the row to running for the recovery run; the
+          // predecessor's lifecycle owner must not survive into the new turn.
+          lifecycleRunId: undefined,
           runtimeMs: undefined,
           startedAt: updatedAt,
           status: "running",

--- a/src/config/sessions/session-accessor.sqlite-checkpoint.ts
+++ b/src/config/sessions/session-accessor.sqlite-checkpoint.ts
@@ -428,6 +428,7 @@ function cloneSqliteCheckpointSessionEntry(params: {
     updatedAt: Date.now(),
     systemSent: false,
     abortedLastRun: false,
+    lifecycleRunId: undefined,
     startedAt: undefined,
     endedAt: undefined,
     runtimeMs: undefined,

--- a/src/config/sessions/session-accessor.sqlite-message-cut.ts
+++ b/src/config/sessions/session-accessor.sqlite-message-cut.ts
@@ -475,6 +475,7 @@ function cloneMessageCutSessionEntry(params: {
     updatedAt: Date.now(),
     systemSent: false,
     abortedLastRun: false,
+    lifecycleRunId: undefined,
     startedAt: undefined,
     endedAt: undefined,
     runtimeMs: undefined,

--- a/src/config/sessions/session-transcript-turn-lifecycle.types.ts
+++ b/src/config/sessions/session-transcript-turn-lifecycle.types.ts
@@ -46,6 +46,7 @@ export type SessionTranscriptTurnLifecyclePatch = {
   restartRecoveryRuns?: SessionEntry["restartRecoveryRuns"];
   /** Durable tombstones merged with the fresh row inside the SQLite write transaction. */
   restartRecoveryTerminalRunIds?: SessionRestartRecoveryState["restartRecoveryTerminalRunIds"];
+  lifecycleRunId?: SessionEntry["lifecycleRunId"];
   runtimeMs?: number;
   startedAt?: number;
   status?: SessionRunStatus;

--- a/src/config/sessions/terminal-status.ts
+++ b/src/config/sessions/terminal-status.ts
@@ -12,6 +12,7 @@ export function recoverTerminalSessionEntryForVisibleTurn(entry: SessionEntry): 
   return {
     ...entry,
     status: undefined,
+    lifecycleRunId: undefined,
     startedAt: undefined,
     endedAt: undefined,
     runtimeMs: undefined,

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -422,6 +422,8 @@ type SessionEntryCore = SessionRestartRecoveryState &
     usageFamilySessionIds?: string[];
     /** Timestamp (ms) of the last user/channel interaction that should extend idle lifetime. */
     lastInteractionAt?: number;
+    /** Run id that last wrote this row's lifecycle status; its own later events are never stale. */
+    lifecycleRunId?: string;
     /** Stable first-run start time for subagent sessions, persisted after completion. */
     startedAt?: number;
     /** Latest completed run end time for subagent sessions, persisted after completion. */

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -497,7 +497,7 @@ export function createAgentEventHandler({
       !isStaleLifecycleEventForSession({
         owningSessionId: evt.sessionId,
         currentSessionId: row?.sessionId,
-        eventRunId: evt.runId,
+        eventRunId: evt.runId?.trim() || undefined,
         currentRunId: row?.lifecycleRunId,
         eventStartedAt: evt.data?.startedAt,
         currentStartedAt: row?.startedAt,

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -497,6 +497,8 @@ export function createAgentEventHandler({
       !isStaleLifecycleEventForSession({
         owningSessionId: evt.sessionId,
         currentSessionId: row?.sessionId,
+        eventRunId: evt.runId,
+        currentRunId: row?.lifecycleRunId,
         eventStartedAt: evt.data?.startedAt,
         currentStartedAt: row?.startedAt,
       })
@@ -506,6 +508,7 @@ export function createAgentEventHandler({
                   updatedAt: row.updatedAt ?? undefined,
                   status: row.status,
                   lastRunError: row.lastRunError,
+                  lifecycleRunId: row.lifecycleRunId,
                   startedAt: row.startedAt,
                   endedAt: row.endedAt,
                   runtimeMs: row.runtimeMs,

--- a/src/gateway/server-methods/agent-session-patch.ts
+++ b/src/gateway/server-methods/agent-session-patch.ts
@@ -243,6 +243,7 @@ export function buildAgentSessionPatch(params: {
     ...(shouldClearRotatedState || shouldClearTerminalState
       ? {
           status: undefined,
+          lifecycleRunId: undefined,
           startedAt: undefined,
           endedAt: undefined,
           runtimeMs: undefined,

--- a/src/gateway/server-methods/chat-restart-recovery.ts
+++ b/src/gateway/server-methods/chat-restart-recovery.ts
@@ -356,6 +356,9 @@ export function buildRestartSafeChatTranscriptState(params: {
       restartRecoveryDeliveryReceiptState: undefined,
       restartRecoveryDeliveryToolCallId: undefined,
       status: "running",
+      // Admission rewrites the row to running for the retried turn; the
+      // predecessor's lifecycle owner must not survive into the new turn.
+      lifecycleRunId: undefined,
       startedAt: params.startedAt,
       endedAt: undefined,
       restartRecoveryDeliveryContext: undefined,

--- a/src/gateway/session-lifecycle-state.test.ts
+++ b/src/gateway/session-lifecycle-state.test.ts
@@ -191,6 +191,65 @@ describe("session lifecycle state", () => {
   );
 
   it.each([
+    { eventRunId: "run-a", currentRunId: "run-a", stale: false },
+    { eventRunId: "run-a", currentRunId: "run-b", stale: true },
+    { eventRunId: undefined, currentRunId: "run-b", stale: true },
+    { eventRunId: "run-a", currentRunId: undefined, stale: true },
+  ])(
+    "uses run identity before start-time ordering (event=$eventRunId current=$currentRunId)",
+    ({ eventRunId, currentRunId, stale }) => {
+      expect(
+        isStaleLifecycleEventForSession({
+          owningSessionId: "session-id",
+          currentSessionId: "session-id",
+          eventRunId,
+          currentRunId,
+          eventStartedAt: 1_000,
+          currentStartedAt: 1_005,
+        }),
+      ).toBe(stale);
+    },
+  );
+
+  it.each(["end", "error"] as const)(
+    "settles the same run's terminal %s even when its start persisted a later timestamp (#119407)",
+    async (phase) => {
+      // Embedded runs mint two clocks: the command attempt captures startedAt
+      // before the subscribe-layer start event stamps its own Date.now(), so
+      // the run's terminal event carries an earlier startedAt than the row's.
+      const started = await persistLifecycle(
+        { sessionId: "session-id", updatedAt: 900 },
+        {
+          ts: 1_005,
+          sessionId: "session-id",
+          runId: "run-a",
+          data: { phase: "start", startedAt: 1_005 },
+        },
+      );
+      expect(started).toMatchObject({ status: "running", lifecycleRunId: "run-a" });
+
+      const settled = await persistLifecycle(started, {
+        ts: 3_000,
+        sessionId: "session-id",
+        runId: "run-a",
+        data: {
+          phase,
+          startedAt: 1_000,
+          endedAt: 3_000,
+          ...(phase === "error" ? { error: "run failed" } : {}),
+        },
+      });
+
+      expect(settled).toMatchObject({
+        status: phase === "end" ? "done" : "failed",
+        startedAt: 1_000,
+        endedAt: 3_000,
+        runtimeMs: 2_000,
+      });
+    },
+  );
+
+  it.each([
     {
       name: "aborted",
       data: { phase: "end", endedAt: 1_800, stopReason: "aborted" },

--- a/src/gateway/session-lifecycle-state.ts
+++ b/src/gateway/session-lifecycle-state.ts
@@ -199,8 +199,8 @@ function deriveGatewaySessionLifecycleSnapshot(params: {
     updatedAt,
     status,
     lastRunError: terminal ? resolveSessionRunError(terminal, status) : undefined,
-    // Terminal events keep the last known owner when they carry no run id so a
-    // same-run late duplicate cannot be re-matched against a cleared field.
+    // Terminal events without a run id keep the last known owner so restart
+    // recovery for that run can still settle the row through the same-run branch.
     lifecycleRunId: resolveLifecycleEventRunId(params.event) ?? existing?.lifecycleRunId,
     startedAt,
     endedAt,

--- a/src/gateway/session-lifecycle-state.ts
+++ b/src/gateway/session-lifecycle-state.ts
@@ -41,7 +41,14 @@ type LifecycleEventLike = Pick<AgentEventPayload, "ts" | "sessionId"> & {
 
 type LifecycleSessionShape = Pick<
   GatewaySessionRow,
-  "updatedAt" | "status" | "lastRunError" | "startedAt" | "endedAt" | "runtimeMs" | "abortedLastRun"
+  | "updatedAt"
+  | "status"
+  | "lastRunError"
+  | "lifecycleRunId"
+  | "startedAt"
+  | "endedAt"
+  | "runtimeMs"
+  | "abortedLastRun"
 >;
 
 type PersistedLifecycleSessionShape = Pick<
@@ -49,6 +56,7 @@ type PersistedLifecycleSessionShape = Pick<
   | "updatedAt"
   | "status"
   | "lastRunError"
+  | "lifecycleRunId"
   | "startedAt"
   | "endedAt"
   | "runtimeMs"
@@ -63,6 +71,11 @@ const SESSION_RUN_ERROR_MAX_CHARS = 160;
 
 function isFiniteTimestamp(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+function resolveLifecycleEventRunId(event: Pick<LifecycleEventLike, "runId">): string | undefined {
+  const runId = event.runId?.trim();
+  return runId ? runId : undefined;
 }
 
 function resolveLifecyclePhase(event: Pick<LifecycleEventLike, "data">): LifecyclePhase | null {
@@ -157,6 +170,7 @@ function deriveGatewaySessionLifecycleSnapshot(params: {
       updatedAt,
       status: "running",
       lastRunError: undefined,
+      lifecycleRunId: resolveLifecycleEventRunId(params.event),
       startedAt,
       endedAt: undefined,
       runtimeMs: undefined,
@@ -185,6 +199,9 @@ function deriveGatewaySessionLifecycleSnapshot(params: {
     updatedAt,
     status,
     lastRunError: terminal ? resolveSessionRunError(terminal, status) : undefined,
+    // Terminal events keep the last known owner when they carry no run id so a
+    // same-run late duplicate cannot be re-matched against a cleared field.
+    lifecycleRunId: resolveLifecycleEventRunId(params.event) ?? existing?.lifecycleRunId,
     startedAt,
     endedAt,
     runtimeMs: resolveRuntimeMs({
@@ -240,18 +257,28 @@ export function isRestartRecoveryLifecycleEvent(params: {
 export function isStaleLifecycleEventForSession(params: {
   owningSessionId?: string;
   currentSessionId?: string;
+  eventRunId?: string;
+  currentRunId?: string;
   eventStartedAt?: unknown;
   currentStartedAt?: number;
 }): boolean {
+  if (
+    params.owningSessionId &&
+    params.currentSessionId &&
+    params.owningSessionId !== params.currentSessionId
+  ) {
+    return true;
+  }
+  // The row's own run is never stale: embedded runs stamp lifecycle start with
+  // a later clock than the attempt's terminal startedAt, so a timestamp-only
+  // compare would drop a successful run's end and leave the row running (#119407).
+  if (params.eventRunId && params.currentRunId && params.eventRunId === params.currentRunId) {
+    return false;
+  }
   return (
-    Boolean(
-      params.owningSessionId &&
-      params.currentSessionId &&
-      params.owningSessionId !== params.currentSessionId,
-    ) ||
-    (isFiniteTimestamp(params.eventStartedAt) &&
-      isFiniteTimestamp(params.currentStartedAt) &&
-      params.eventStartedAt < params.currentStartedAt)
+    isFiniteTimestamp(params.eventStartedAt) &&
+    isFiniteTimestamp(params.currentStartedAt) &&
+    params.eventStartedAt < params.currentStartedAt
   );
 }
 
@@ -308,6 +335,8 @@ export async function persistGatewaySessionLifecycleEvent(params: {
         isStaleLifecycleEventForSession({
           owningSessionId,
           currentSessionId: entry.sessionId,
+          eventRunId: resolveLifecycleEventRunId(params.event),
+          currentRunId: entry.lifecycleRunId,
           eventStartedAt: params.event.data?.startedAt,
           currentStartedAt: entry.startedAt,
         })

--- a/src/gateway/session-utils-row.ts
+++ b/src/gateway/session-utils-row.ts
@@ -490,6 +490,7 @@ export function buildGatewaySessionRow(params: {
     hasAutomation: sessionHasAutomation(key, cfg) ? true : undefined,
     subagentRunState,
     hasActiveSubagentRun: subagentRun ? liveSubagentRunActive : undefined,
+    lifecycleRunId: entry?.lifecycleRunId,
     startedAt: subagentRun ? subagentStartedAt : entry?.startedAt,
     endedAt: subagentRun ? subagentEndedAt : entry?.endedAt,
     runtimeMs: subagentRun ? subagentRuntimeMs : entry?.runtimeMs,

--- a/src/gateway/session-utils.types.ts
+++ b/src/gateway/session-utils.types.ts
@@ -147,6 +147,8 @@ export type GatewaySessionRow = {
   hasAutomation?: boolean;
   subagentRunState?: SubagentRunState;
   hasActiveSubagentRun?: boolean;
+  /** Run id that last wrote this row's lifecycle status; its own later events are never stale. */
+  lifecycleRunId?: string;
   startedAt?: number;
   endedAt?: number;
   runtimeMs?: number;

--- a/src/plugins/session-entry-slot-keys.ts
+++ b/src/plugins/session-entry-slot-keys.ts
@@ -63,6 +63,7 @@ const SESSION_ENTRY_RESERVED_SLOT_KEY_LIST = [
   "sessionStartedAt",
   "ambientTranscriptWatermarks",
   "lastInteractionAt",
+  "lifecycleRunId",
   "startedAt",
   "endedAt",
   "runtimeMs",


### PR DESCRIPTION
## What Problem This Solves

Fixes #119407.

Since 7c1d5dc7ef (#117731), `isStaleLifecycleEventForSession` rejects any lifecycle event whose `startedAt` is older than the row's persisted `startedAt`. But one embedded run mints two clocks: the command attempt captures the authoritative `startedAt` first (`src/agents/command/run-embedded-attempt.ts:152`), and the subscribe layer later stamps its own `Date.now()` on the lifecycle `start` event (`src/agents/embedded-agent-subscribe.handlers.lifecycle.ts:52`). The start event's later timestamp is what gets persisted, so the same run's terminal event — which carries the earlier command-layer timestamp (`src/agents/command/lifecycle.ts`) — is classified as an "older run" and dropped. The successful run stays canonically `running`, and the next gateway restart's interruption recovery rewrites it as `failed` with `transcript tail is not resumable` (3/3 repro in the issue).

## Why This Change Was Made

The guard uses `startedAt` ordering as a run-identity proxy, but every lifecycle event already carries a real `runId` — the row just never recorded which run owns its current state. This change records that fact where it happens and uses it:

- `SessionEntry`/`GatewaySessionRow` gain an optional `lifecycleRunId`: the run id that last wrote the row's lifecycle status. Persisted inside the existing SQLite `entry_json` blob — purely additive, no DDL, no schema-version bump, no doctor migration (an absent field simply keeps today's timestamp behavior).
- `isStaleLifecycleEventForSession` treats an event from the row's own run as never stale, before falling back to the existing timestamp ordering for events from other runs (the overlapping-runs protection #117731 added is unchanged — its tests still pass verbatim).
- Both guard call sites (`persistGatewaySessionLifecycleEvent` and the `server-chat` UI projection) pass run identity.
- The sibling entry-reset sites that clear `startedAt`/`status` on sessionId rotation or in-place terminal recovery (`sqlite-checkpoint`, `sqlite-message-cut`, `terminal-status`, `clearRotatedSessionMetadata`, `agent-session-patch`) clear `lifecycleRunId` with them, so a recycled row cannot inherit a stale owner.

Threading the command-layer `startedAt` into the subscribe-layer start emitter was considered and rejected: it needs 8+ files of parameter plumbing, fixes only this one producer pair, and leaves the timestamp-as-identity proxy fragile for every other lifecycle emitter (ACP, worker live runtime, dispatch-error synthesis all mint their own clocks). The dual clock at the producer remains a cosmetic oddity — while a run is live the row shows the subscribe-layer `startedAt`, and its terminal rewrites it to the earlier command-layer value — worth a follow-up only if the divergence ever becomes user-visible.

## User Impact

Successful channel-backed runs no longer stay `running` in the canonical session store after completing and delivering their reply. Gateway restarts no longer misclassify those completed sessions as interrupted, flip them to `failed`, or surface `Unknown error` in the Control UI for runs that succeeded.

Production LOC delta: +50 / −9 (guard restructure + one recorded fact at its owning boundary); tests +59.

## Evidence

Regression tests (fail on main, pass here) in `src/gateway/session-lifecycle-state.test.ts`, driven through the real `persistGatewaySessionLifecycleEvent` entry point:

```
node scripts/run-vitest.mjs src/gateway/session-lifecycle-state.test.ts
 Tests  37 passed (37)
```

Real-behavior proof: a tsx harness drives the production `persistGatewaySessionLifecycleEvent` against a real isolated SQLite session store (no product code mocked) with the exact two-clock scenario — start persists `startedAt = T+5`, the same run's terminal carries `startedAt = T`.

Unfixed `main` (negative control):

```
  [PASS] SETUP: canonical session row exists
  [PASS] START: row running with subscribe-layer startedAt — status=running startedAt=1785898374949
  [FAIL] TERMINAL: same run's end settles the row (bug: stays running) — status=running
  [FAIL] TERMINAL: endedAt recorded — endedAt=undefined
RESULT: FAIL — 2 check(s) failed (bug signature: row stays running)
```

This branch:

```
  [PASS] SETUP: canonical session row exists
  [PASS] START: row running with subscribe-layer startedAt — status=running startedAt=1785898361446
  [PASS] TERMINAL: same run's end settles the row (bug: stays running) — status=done
  [PASS] TERMINAL: endedAt recorded — endedAt=1785898421441
RESULT: PASS — same-run terminal event settles the canonical session
```

Also green locally: `pnpm tsgo:core`, `pnpm tsgo:core:test`, `node scripts/run-vitest.mjs src/gateway/server-chat.agent-events.test.ts src/gateway/server.chat.gateway-server-chat.test.ts src/gateway/session-utils.test.ts src/config/sessions.test.ts src/config/sessions/reset.test.ts`.

Not tested: a live channel-backed gateway upgrade roundtrip (the issue's original Telegram + Codex-runtime smoke path); the harness reproduces the same persisted-state transition through the same production persistence entry point.

---

This PR was AI-assisted (Claude + local review tooling); the diff was human-reviewed before opening.
