### PR TITLE
test(providers): cover clone-tee binary rejection cleanup

### DIFF
--- a/src/agents/provider-http-errors.test.ts
+++ b/src/agents/provider-http-errors.test.ts
@@ -404,16 +404,19 @@ describe("provider error utils", () => {
     expect(streamed.getReadCount()).toBeLessThan(20);
   });
 
-  it("cancels binary response bodies rejected by content-type validation", async () => {
+  it("does not await clone-tee cancellation for rejected binary responses", async () => {
     const cancel = vi.fn();
     const response = new Response(new ReadableStream<Uint8Array>({ cancel }), {
       status: 200,
       headers: { "content-type": "application/json" },
     });
+    const captureClone = response.clone();
 
     await expect(
       readProviderBinaryResponse(response, "Provider TTS failed", "audio"),
     ).rejects.toThrow("Provider TTS failed: malformed audio response");
+    expect(cancel).not.toHaveBeenCalled();
+    await captureClone.body?.cancel();
     expect(cancel).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## What Problem This Solves

Production behavior is already fixed on `main` by #120351: MiniMax now reaches the shared binary-response reader, which starts rejected-body cancellation without awaiting a tee-dependent promise.

The remaining gap is the shared regression contract. The existing cancellation test used an unteed stream, so it would still pass if the implementation regressed to `await response.body.cancel()` and blocked malformed-response errors while a debug-capture clone remained live.

This PR adds only that missing shared-owner regression guard. The diff is one test file: production `+0/-0`; tests `+4/-1`.

## Why this test remains useful

Debug capture clones provider responses. Per the WHATWG Streams tee contract, canceling one branch returns a promise that does not settle until the other branch is canceled or the source closes.

The strengthened test:

1. creates a cloned response branch,
2. requires `readProviderBinaryResponse` to reject malformed JSON promptly while the clone is still live,
3. verifies the underlying source has not yet canceled,
4. cancels the clone and verifies underlying cancellation completes exactly once.

The test times out under the pre-#120351 awaited-cancel implementation and passes with the shared fire-and-forget lifecycle owner.

## Scope

No runtime code changes. The superseded MiniMax-local production hunk and its 49-line provider-specific test were removed in favor of the 3-line-net shared-owner guard.

## Evidence

Exact head: `dca4c7aa54c4bc3b439203e4216c9eed1466cb13`, rebased directly onto `main` at `c5d00cb47ddb7236980de8e0fbc938b23fdeaae0`.

- `git diff --check origin/main...HEAD` is clean.
- The diff remains exactly one test file, production `+0/-0`, tests `+4/-1`.
- The patch-identical prior head passed `checks-node-changed`: 1 test file, 22 tests, plus the changed-boundary, type, dependency, contract, baseline, and applicable security lanes.
- Fresh exact-head PR CI is pending after the follow-up rebase that absorbed current-main fixes for the prior inherited lint failures.

### Direct runtime transcript

A standalone Node v26.3.0 probe used only the runtime's built-in `Response` and `ReadableStream`: create a response, clone it, cancel the rejected-response branch, yield one event-loop turn, then cancel the capture clone and await both cancellations.

```text
{"phase":"rejected-branch-only","rejectedBranchCancelSettled":false,"sourceCancelCount":0}
{"phase":"after-capture-clone-release","rejectedBranchCancelSettled":true,"sourceCancelCount":1}
```

This directly demonstrates the lifecycle contract: cancellation of the rejected branch remains pending and does not reach the underlying source while its clone is live; releasing the clone settles cancellation exactly once. The exact-head test combines that real runtime topology with `readProviderBinaryResponse` and requires the malformed-response rejection before clone release.

Repository code was not executed locally because this remains contributor/fork source; repository validation is routed through secretless PR CI.
