### PR TITLE
fix(sessions): release writer lane during transcript archival

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-cleanup-race.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-cleanup-race.test.ts
@@ -468,6 +468,213 @@ describe("SQLite lifecycle cleanup races", () => {
     expect(progressedDuringMaterialization).toBe(true);
   });
 
+  it("releases the store writer while a historical generation is archived", async () => {
+    const deletedKey = "agent:main:historical-race-deleted";
+    const currentSessionId = "historical-race-current";
+    const historicalSessionId = "historical-race-unplanned";
+    const writerKey = "agent:main:historical-race-writer";
+    await replaceSessionEntry(
+      { sessionKey: deletedKey, storePath },
+      { sessionId: currentSessionId, updatedAt: Date.now() },
+    );
+    await replaceSqliteTranscriptEvents(
+      { sessionKey: deletedKey, sessionId: currentSessionId, storePath },
+      [{ type: "session", id: currentSessionId, content: "current transcript" }],
+    );
+    await replaceSqliteTranscriptEvents(
+      { sessionKey: deletedKey, sessionId: historicalSessionId, storePath },
+      [{ type: "session", id: historicalSessionId, content: "historical transcript" }],
+    );
+    await replaceSessionEntry(
+      { sessionKey: writerKey, storePath },
+      { sessionId: "historical-race-writer-session", updatedAt: Date.now() },
+    );
+
+    let markMaterializationStarted: () => void = () => undefined;
+    const materializationStarted = new Promise<void>((resolve) => {
+      markMaterializationStarted = resolve;
+    });
+    let releaseMaterialization: () => void = () => undefined;
+    const materializationGate = new Promise<void>((resolve) => {
+      releaseMaterialization = resolve;
+    });
+    archiveMaterializationHook.beforeMaterialize = async () => {
+      markMaterializationStarted();
+      await materializationGate;
+    };
+
+    const deletion = deleteSessionEntryLifecycle({
+      archiveTranscript: true,
+      storePath,
+      target: { canonicalKey: deletedKey, storeKeys: [deletedKey] },
+    });
+    await materializationStarted;
+    const writer = replaceSessionEntry(
+      { sessionKey: writerKey, storePath },
+      {
+        sessionId: "historical-race-writer-session",
+        label: "progressed",
+        updatedAt: Date.now(),
+      },
+    );
+    const progressedDuringMaterialization = await Promise.race([
+      writer.then(() => true),
+      new Promise<false>((resolve) => {
+        setTimeout(() => resolve(false), 500);
+      }),
+    ]);
+    releaseMaterialization();
+
+    await expect(deletion).resolves.toMatchObject({ deleted: true });
+    await expect(writer).resolves.toMatchObject({ label: "progressed" });
+    expect(progressedDuringMaterialization).toBe(true);
+  });
+
+  it("releases the store writer while lifecycle cleanup archives a transcript", async () => {
+    const now = Date.now();
+    const deletedKey = "agent:main:cleanup-race-archived";
+    const deletedSessionId = "cleanup-race-archived-session";
+    const writerKey = "agent:main:cleanup-race-cleanup-writer";
+    await replaceSessionEntry(
+      { sessionKey: deletedKey, storePath },
+      { sessionId: deletedSessionId, updatedAt: now - 600_000 },
+    );
+    await replaceSqliteTranscriptEvents(
+      { sessionKey: deletedKey, sessionId: deletedSessionId, storePath },
+      [
+        {
+          runId: "cleanup-race-marker-archived",
+          timestamp: new Date(now - 600_000).toISOString(),
+          type: "metadata",
+        },
+      ],
+    );
+    await replaceSessionEntry(
+      { sessionKey: writerKey, storePath },
+      { sessionId: "cleanup-race-cleanup-writer-session", updatedAt: now },
+    );
+
+    let markMaterializationStarted: () => void = () => undefined;
+    const materializationStarted = new Promise<void>((resolve) => {
+      markMaterializationStarted = resolve;
+    });
+    let releaseMaterialization: () => void = () => undefined;
+    const materializationGate = new Promise<void>((resolve) => {
+      releaseMaterialization = resolve;
+    });
+    archiveMaterializationHook.beforeMaterialize = async () => {
+      markMaterializationStarted();
+      await materializationGate;
+    };
+
+    const cleanup = cleanupSessionLifecycleArtifacts({
+      storePath,
+      sessionKeySegmentPrefix: "cleanup-race-",
+      transcriptContentMarker: "cleanup-race-marker",
+      orphanTranscriptMinAgeMs: 300_000,
+      nowMs: now,
+    });
+    await materializationStarted;
+    const writer = replaceSessionEntry(
+      { sessionKey: writerKey, storePath },
+      {
+        sessionId: "cleanup-race-cleanup-writer-session",
+        label: "progressed",
+        updatedAt: now + 1,
+      },
+    );
+    const progressedDuringMaterialization = await Promise.race([
+      writer.then(() => true),
+      new Promise<false>((resolve) => {
+        setTimeout(() => resolve(false), 500);
+      }),
+    ]);
+    releaseMaterialization();
+
+    await expect(cleanup).resolves.toEqual({
+      removedEntries: 1,
+      archivedTranscriptArtifacts: 1,
+    });
+    await expect(writer).resolves.toMatchObject({ label: "progressed" });
+    expect(progressedDuringMaterialization).toBe(true);
+  });
+
+  it("releases the store writer while a lifecycle mutation archives a transcript", async () => {
+    const removedKey = "agent:main:lifecycle-race-archived";
+    const removedEntry: SessionEntry = {
+      sessionId: "lifecycle-race-archived-session",
+      updatedAt: Date.now(),
+    };
+    const writerKey = "agent:main:lifecycle-race-writer";
+    await replaceSessionEntry({ sessionKey: removedKey, storePath }, removedEntry);
+    const persistedRemovedEntry = loadSessionEntry({ sessionKey: removedKey, storePath });
+    if (!persistedRemovedEntry) {
+      throw new Error("expected persisted lifecycle removal entry");
+    }
+    await replaceSqliteTranscriptEvents(
+      { sessionKey: removedKey, sessionId: removedEntry.sessionId, storePath },
+      [
+        {
+          type: "session",
+          id: removedEntry.sessionId,
+          content: "lifecycle mutation archive",
+        },
+      ],
+    );
+    await replaceSessionEntry(
+      { sessionKey: writerKey, storePath },
+      { sessionId: "lifecycle-race-writer-session", updatedAt: Date.now() },
+    );
+
+    let markMaterializationStarted: () => void = () => undefined;
+    const materializationStarted = new Promise<void>((resolve) => {
+      markMaterializationStarted = resolve;
+    });
+    let releaseMaterialization: () => void = () => undefined;
+    const materializationGate = new Promise<void>((resolve) => {
+      releaseMaterialization = resolve;
+    });
+    archiveMaterializationHook.beforeMaterialize = async () => {
+      markMaterializationStarted();
+      await materializationGate;
+    };
+
+    const mutation = applySessionEntryLifecycleMutation({
+      storePath,
+      removals: [
+        {
+          sessionKey: removedKey,
+          expectedEntry: persistedRemovedEntry,
+          archiveRemovedTranscript: true,
+        },
+      ],
+      skipMaintenance: true,
+    });
+    await materializationStarted;
+    const writer = replaceSessionEntry(
+      { sessionKey: writerKey, storePath },
+      {
+        sessionId: "lifecycle-race-writer-session",
+        label: "progressed",
+        updatedAt: Date.now(),
+      },
+    );
+    const progressedDuringMaterialization = await Promise.race([
+      writer.then(() => true),
+      new Promise<false>((resolve) => {
+        setTimeout(() => resolve(false), 500);
+      }),
+    ]);
+    releaseMaterialization();
+
+    await expect(mutation).resolves.toMatchObject({
+      removedEntries: 1,
+      removedSessionKeys: [removedKey],
+    });
+    await expect(writer).resolves.toMatchObject({ label: "progressed" });
+    expect(progressedDuringMaterialization).toBe(true);
+  });
+
   it("retains unplanned historical windows behind a placeholder node", async () => {
     const sessionKey = "agent:main:unplanned-history";
     const currentEntry: SessionEntry = {

--- a/src/config/sessions/session-accessor.sqlite-lifecycle.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle.ts
@@ -124,9 +124,9 @@ export async function cleanupSqliteSessionLifecycleArtifacts(
   if (!withOpenClawAgentDatabaseReadOnly(() => true, databaseOptions).found) {
     return { removedEntries: 0, archivedTranscriptArtifacts: 0 };
   }
-  return await runExclusiveSqliteSessionWrite(resolved, async () => {
+  const cleanupPlan = await runExclusiveSqliteSessionWrite(resolved, async () => {
     const database = openOpenClawAgentDatabase(databaseOptions);
-    const cleanupPlan = planSqliteSessionLifecycleArtifactCleanup(database, {
+    return planSqliteSessionLifecycleArtifactCleanup(database, {
       ...(params.agentId !== undefined ? { agentId: resolved.agentId } : {}),
       archiveRemovedEntryTranscripts: params.archiveRemovedEntryTranscripts !== false,
       archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
@@ -136,9 +136,9 @@ export async function cleanupSqliteSessionLifecycleArtifacts(
       orphanTranscriptMinAgeMs: params.orphanTranscriptMinAgeMs,
       nowMs: params.nowMs ?? Date.now(),
     });
-    const materializedPlans = await materializeSqliteSessionStateDeletePlans(
-      cleanupPlan.deletePlans,
-    );
+  });
+  const materializedPlans = await materializeSqliteSessionStateDeletePlans(cleanupPlan.deletePlans);
+  return await runExclusiveSqliteSessionWrite(resolved, async () => {
     let removedEntries = 0;
     let archivedTranscripts: SessionLifecycleArchivedTranscript[] = [];
     runOpenClawAgentWriteTransaction((transactionDb) => {
@@ -371,16 +371,28 @@ async function deleteSqliteSessionEntryLifecycleLocked(
         );
       }
     }
-    const historicalArchivedTranscripts: SessionLifecycleArchivedTranscript[] = [];
-    for (const sessionId of historicalGenerationIds) {
+    return { archiveDirectory, current, entryPlans, historicalGenerationIds, targetSnapshot };
+  });
+  if (!prepared) {
+    return { archivedTranscripts: [], deleted: false };
+  }
+
+  const historicalArchivedTranscripts: SessionLifecycleArchivedTranscript[] = [];
+  for (const sessionId of prepared.historicalGenerationIds) {
+    const plan = await runExclusiveSqliteSessionWrite(resolved, async () => {
+      const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+      assertSqliteLifecycleTargetSnapshotUnchanged(
+        prepared.targetSnapshot,
+        readSqliteLifecycleTargetSnapshot(database, params.target),
+        "delete session entry",
+      );
+      const referencedAfterDelete = readReferencedSqliteSessionIdsAfterTargetMutation(
+        database,
+        params.target,
+      );
       if (referencedAfterDelete.has(sessionId)) {
-        // Another live entry or route still owns this generation; deleting
-        // this entry must not destroy shared history.
-        continue;
+        return null;
       }
-      // Recomputed per generation so a run admitted after preflight cannot
-      // lose the generation it just adopted; such a race aborts the deletion,
-      // and since the live entry is still present a retry finishes the rest.
       const admissionProtected = collectAdmissionProtectedSessionIds({
         database,
         storePath: params.storePath,
@@ -390,25 +402,27 @@ async function deleteSqliteSessionEntryLifecycleLocked(
           `cannot delete session history while work is in flight for ${sessionId}; retry after the run completes`,
         );
       }
-      const plan = planSqliteSessionStateDeleteIfUnreferenced({
-        archiveDirectory,
+      return planSqliteSessionStateDeleteIfUnreferenced({
+        archiveDirectory: prepared.archiveDirectory,
         archiveTranscript: params.archiveTranscript,
         database,
         reason: "deleted",
         referencedSessionIds: referencedAfterDelete,
         sessionId,
       });
-      if (!plan) {
-        continue;
-      }
-      const materializedGeneration = await materializeSqliteSessionStateDeletePlans([plan]);
-      const archivedGeneration: SessionLifecycleArchivedTranscript[] = [];
+    });
+    if (!plan) {
+      continue;
+    }
+    const materializedGeneration = await materializeSqliteSessionStateDeletePlans([plan]);
+    const archivedGeneration = await runExclusiveSqliteSessionWrite(resolved, async () => {
+      let committed: SessionLifecycleArchivedTranscript[] = [];
       runOpenClawAgentWriteTransaction((transactionDb) => {
-        // Authoritative fence: admissions are process-local sync state and this
-        // callback runs synchronously, so a run admitted after the pre-checks
-        // cannot interleave past this point. An outer lifecycle-mutation hold
-        // (as eviction uses) would invert lock order against the exclusive
-        // SQLite write this function already holds.
+        assertSqliteLifecycleTargetSnapshotUnchanged(
+          prepared.targetSnapshot,
+          readSqliteLifecycleTargetSnapshot(transactionDb, params.target),
+          "delete session entry",
+        );
         const fenceAtDelete = collectAdmissionProtectedSessionIds({
           database: transactionDb,
           storePath: params.storePath,
@@ -418,20 +432,18 @@ async function deleteSqliteSessionEntryLifecycleLocked(
             `cannot delete session history while work is in flight for ${sessionId}; retry after the run completes`,
           );
         }
-        archivedGeneration.push(
-          ...deleteMaterializedSqliteSessionStatePlans(transactionDb, materializedGeneration),
+        committed = deleteMaterializedSqliteSessionStatePlans(
+          transactionDb,
+          materializedGeneration,
         );
       }, toDatabaseOptions(resolved));
-      // Publish each committed generation immediately: a later archive or
-      // transaction failure aborts the deletion, and observers must still see
-      // the removals that already happened (retry completes the remainder).
-      emitArchivedSqliteTranscriptUpdates(archivedGeneration);
-      historicalArchivedTranscripts.push(...archivedGeneration);
-    }
-    return { current, entryPlans, historicalArchivedTranscripts, targetSnapshot };
-  });
-  if (!prepared) {
-    return { archivedTranscripts: [], deleted: false };
+      return committed;
+    });
+    // Publish each committed generation immediately: a later archive or
+    // transaction failure aborts the deletion, and observers must still see
+    // the removals that already happened (retry completes the remainder).
+    emitArchivedSqliteTranscriptUpdates(archivedGeneration);
+    historicalArchivedTranscripts.push(...archivedGeneration);
   }
 
   // Archive materialization is the expensive phase. It must run between short
@@ -494,7 +506,7 @@ async function deleteSqliteSessionEntryLifecycleLocked(
   emitArchivedSqliteTranscriptUpdates(result.archivedTranscripts);
   // Historical generations were emitted per commit above; merge them into
   // the result after the final emit so callers still see every archive.
-  result.archivedTranscripts.push(...prepared.historicalArchivedTranscripts);
+  result.archivedTranscripts.push(...historicalArchivedTranscripts);
   return result;
 }
 

--- a/src/config/sessions/session-accessor.sqlite-projection.ts
+++ b/src/config/sessions/session-accessor.sqlite-projection.ts
@@ -59,7 +59,7 @@ import type {
 } from "./session-accessor.sqlite-lifecycle-types.js";
 import {
   applySqliteSessionEntryMaintenance,
-  finalizeSqliteSessionEntryMaintenancePlansBestEffort,
+  finalizeSqliteSessionEntryMaintenancePlansAfterWriterReleaseBestEffort,
 } from "./session-accessor.sqlite-maintenance.js";
 import {
   cloneSessionEntry,
@@ -102,7 +102,7 @@ export async function applySqliteSessionEntryReplacements<T>(params: {
     sessionKey: params.activeSessionKey ?? params.sessionKeys?.[0] ?? "",
     storePath: params.storePath,
   });
-  return await runExclusiveSqliteSessionWrite(resolved, async () => {
+  const committed = await runExclusiveSqliteSessionWrite(resolved, async () => {
     const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
     const selectedKeys = params.sessionKeys ? new Set(params.sessionKeys) : undefined;
     const selectedStatuses = params.statuses ? new Set(params.statuses) : undefined;
@@ -146,7 +146,7 @@ export async function applySqliteSessionEntryReplacements<T>(params: {
       throw new Error("session entry replacements did not persist any rows");
     }
     if (applicable.length === 0) {
-      return operation.result;
+      return { maintenancePlans: [], result: operation.result };
     }
 
     const maintenancePlans: SqliteSessionEntryMaintenancePlan[] = [];
@@ -194,9 +194,13 @@ export async function applySqliteSessionEntryReplacements<T>(params: {
         });
       }
     }
-    await finalizeSqliteSessionEntryMaintenancePlansBestEffort(resolved, maintenancePlans);
-    return operation.result;
+    return { maintenancePlans, result: operation.result };
   });
+  await finalizeSqliteSessionEntryMaintenancePlansAfterWriterReleaseBestEffort(
+    resolved,
+    committed.maintenancePlans,
+  );
+  return committed.result;
 }
 
 /**
@@ -221,13 +225,13 @@ export async function applySqliteSessionStoreProjection<T>(params: {
     sessionKey: params.activeSessionKey ?? "",
     storePath: params.storePath,
   });
-  return await runExclusiveSqliteSessionWrite(resolved, async () => {
+  const committed = await runExclusiveSqliteSessionWrite(resolved, async () => {
     const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
     const before = readSqliteSessionEntryStore(database);
     const projected = structuredClone(before);
     const operation = await params.update(projected);
     if (!operation.persist) {
-      return operation.result;
+      return { maintenancePlans: [], result: operation.result };
     }
     const lockedEntriesBefore = new Map(
       Object.entries(before).filter(([, entry]) => entry.modelSelectionLocked === true),
@@ -245,7 +249,7 @@ export async function applySqliteSessionStoreProjection<T>(params: {
       (sessionKey) => !sqliteSessionEntriesEqual(before[sessionKey], projected[sessionKey]),
     );
     if (changedKeys.length === 0) {
-      return operation.result;
+      return { maintenancePlans: [], result: operation.result };
     }
 
     const maintenancePlans: SqliteSessionEntryMaintenancePlan[] = [];
@@ -281,9 +285,13 @@ export async function applySqliteSessionStoreProjection<T>(params: {
       toDatabaseOptions(resolved),
       { operationLabel: "session.store-projection" },
     );
-    await finalizeSqliteSessionEntryMaintenancePlansBestEffort(resolved, maintenancePlans);
-    return operation.result;
+    return { maintenancePlans, result: operation.result };
   });
+  await finalizeSqliteSessionEntryMaintenancePlansAfterWriterReleaseBestEffort(
+    resolved,
+    committed.maintenancePlans,
+  );
+  return committed.result;
 }
 
 function readProjectedRemovalEntry(
@@ -336,35 +344,37 @@ export async function applySqliteSessionEntryLifecycleMutation(params: {
     sessionKey: "",
     storePath: params.storePath,
   });
-  return await runExclusiveSqliteSessionWrite(resolved, async () => {
-    const removals = [...(params.removals ?? [])];
-    const upserts = [...(params.upserts ?? [])];
-    const removedSessionKeys: string[] = [];
-    let archivedTranscripts: SessionLifecycleArchivedTranscript[] = [];
-    const maintenancePlans: SqliteSessionEntryMaintenancePlan[] = [];
-    let artifactCleanupError: unknown;
-    const captureArtifactCleanupError = (error: unknown): void => {
-      if (params.captureArtifactCleanupError === true) {
-        artifactCleanupError ??= error;
-        return;
-      }
-      throw error;
-    };
+  const removals = [...(params.removals ?? [])];
+  const upserts = [...(params.upserts ?? [])];
+  let artifactCleanupError: unknown;
+  const captureArtifactCleanupError = (error: unknown): void => {
+    if (params.captureArtifactCleanupError === true) {
+      artifactCleanupError ??= error;
+      return;
+    }
+    throw error;
+  };
+  const projected = await runExclusiveSqliteSessionWrite(resolved, async () => {
     const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
-    const projected = await projectSqliteSessionEntryLifecycleMutation(database, {
+    return await projectSqliteSessionEntryLifecycleMutation(database, {
       ...(params.allowCanonicalRepair ? { allowCanonicalRepair: true } : {}),
       archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
       removals,
       upserts,
     });
-    let materializedRemovalPlans: MaterializedSqliteSessionStateDeletePlan[] = [];
-    try {
-      materializedRemovalPlans = await materializeSqliteSessionStateDeletePlans(
-        projected.deletePlans,
-      );
-    } catch (error) {
-      captureArtifactCleanupError(error);
-    }
+  });
+  let materializedRemovalPlans: MaterializedSqliteSessionStateDeletePlan[] = [];
+  try {
+    materializedRemovalPlans = await materializeSqliteSessionStateDeletePlans(
+      projected.deletePlans,
+    );
+  } catch (error) {
+    captureArtifactCleanupError(error);
+  }
+  const committed = await runExclusiveSqliteSessionWrite(resolved, async () => {
+    const removedSessionKeys: string[] = [];
+    let archivedTranscripts: SessionLifecycleArchivedTranscript[] = [];
+    const maintenancePlans: SqliteSessionEntryMaintenancePlan[] = [];
     runOpenClawAgentWriteTransaction((transactionDb) => {
       const validatedRemovals = projected.removals.filter((removal) => {
         const entry = readProjectedRemovalEntry(
@@ -516,38 +526,42 @@ export async function applySqliteSessionEntryLifecycleMutation(params: {
       );
     }, toDatabaseOptions(resolved));
     emitCommittedLifecycleIdentityMutations({ projected, removedSessionKeys });
-    const maintenanceArchivedTranscripts =
-      await finalizeSqliteSessionEntryMaintenancePlansBestEffort(resolved, maintenancePlans);
-    archivedTranscripts = [...archivedTranscripts, ...maintenanceArchivedTranscripts];
-    const afterCount = readSqliteSessionEntryCount(
-      openOpenClawAgentDatabase(toDatabaseOptions(resolved)),
-    );
-    emitArchivedSqliteTranscriptUpdates(archivedTranscripts);
-    const archivedTranscriptDirectories = uniqueStrings(
-      archivedTranscripts.map((transcript) => path.dirname(transcript.archivedPath)),
-    ).toSorted();
-    if (archivedTranscriptDirectories.length > 0 && params.cleanupArchivedTranscripts) {
-      try {
-        const { cleanupArchivedSessionTranscripts } = await loadSessionArchiveRuntime();
-        await cleanupArchivedSessionTranscripts({
-          directories: archivedTranscriptDirectories,
-          rules: params.cleanupArchivedTranscripts.rules,
-          nowMs: params.cleanupArchivedTranscripts.nowMs,
-        });
-      } catch (error) {
-        captureArtifactCleanupError(error);
-      }
-    }
-    return {
-      removedEntries: removedSessionKeys.length,
-      removedSessionKeys,
-      archivedTranscriptDirectories,
-      unreferencedArtifacts: null,
-      maintenanceReport: null,
-      afterCount,
-      artifactCleanupError,
-    };
+    return { archivedTranscripts, maintenancePlans, removedSessionKeys };
   });
+  const maintenanceArchivedTranscripts =
+    await finalizeSqliteSessionEntryMaintenancePlansAfterWriterReleaseBestEffort(
+      resolved,
+      committed.maintenancePlans,
+    );
+  const archivedTranscripts = [...committed.archivedTranscripts, ...maintenanceArchivedTranscripts];
+  const afterCount = readSqliteSessionEntryCount(
+    openOpenClawAgentDatabase(toDatabaseOptions(resolved)),
+  );
+  emitArchivedSqliteTranscriptUpdates(archivedTranscripts);
+  const archivedTranscriptDirectories = uniqueStrings(
+    archivedTranscripts.map((transcript) => path.dirname(transcript.archivedPath)),
+  ).toSorted();
+  if (archivedTranscriptDirectories.length > 0 && params.cleanupArchivedTranscripts) {
+    try {
+      const { cleanupArchivedSessionTranscripts } = await loadSessionArchiveRuntime();
+      await cleanupArchivedSessionTranscripts({
+        directories: archivedTranscriptDirectories,
+        rules: params.cleanupArchivedTranscripts.rules,
+        nowMs: params.cleanupArchivedTranscripts.nowMs,
+      });
+    } catch (error) {
+      captureArtifactCleanupError(error);
+    }
+  }
+  return {
+    removedEntries: committed.removedSessionKeys.length,
+    removedSessionKeys: committed.removedSessionKeys,
+    archivedTranscriptDirectories,
+    unreferencedArtifacts: null,
+    maintenanceReport: null,
+    afterCount,
+    artifactCleanupError,
+  };
 }
 
 /** Purges entries owned by a deleted agent from SQLite session rows. */
@@ -555,7 +569,7 @@ export async function purgeSqliteDeletedAgentSessionEntries(
   params: DeletedAgentSessionEntryPurgeParams,
 ): Promise<SessionEntryLifecycleMutationResult> {
   const resolved = resolveSqliteStoreScope(params.storePath, { agentId: params.storeAgentId });
-  return await runExclusiveSqliteSessionWrite(resolved, async () => {
+  const prepared = await runExclusiveSqliteSessionWrite(resolved, async () => {
     const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
     const store = readSqliteSessionEntryStore(database);
     const remainingStore = { ...store };
@@ -592,19 +606,38 @@ export async function purgeSqliteDeletedAgentSessionEntries(
         referencedSessionIds,
       }),
     );
-    const materializedPlans = await materializeSqliteSessionStateDeletePlans(deletePlans);
-    const removedSessionKeys = entryRemovals.map((removal) => removal.sessionKey);
+    return { deletePlans, entryRemovals };
+  });
+  const materializedPlans = await materializeSqliteSessionStateDeletePlans(prepared.deletePlans);
+  const committed = await runExclusiveSqliteSessionWrite(resolved, async () => {
+    const removedSessionKeys = prepared.entryRemovals.map((removal) => removal.sessionKey);
     let archivedTranscripts: SessionLifecycleArchivedTranscript[] = [];
     const maintenancePlans: SqliteSessionEntryMaintenancePlan[] = [];
     runOpenClawAgentWriteTransaction((transactionDb) => {
-      assertPlannedSqliteLifecycleArtifactEntriesUnchanged(transactionDb, entryRemovals);
+      const currentOwnedSessionKeys = Object.keys(readSqliteSessionEntryStore(transactionDb))
+        .filter(
+          (sessionKey) =>
+            resolveStoredSessionOwnerAgentId({
+              cfg: params.cfg,
+              agentId: params.storeAgentId,
+              sessionKey,
+            }) === params.agentId,
+        )
+        .toSorted();
+      const plannedSessionKeys = prepared.entryRemovals
+        .map((removal) => removal.sessionKey)
+        .toSorted();
+      if (JSON.stringify(currentOwnedSessionKeys) !== JSON.stringify(plannedSessionKeys)) {
+        throw new Error("SQLite deleted-agent session entries changed before purge");
+      }
+      assertPlannedSqliteLifecycleArtifactEntriesUnchanged(transactionDb, prepared.entryRemovals);
       archivedTranscripts = deleteMaterializedSqliteSessionStatePlans(
         transactionDb,
         materializedPlans,
         undefined,
-        new Set(entryRemovals.map((removal) => removal.sessionKey)),
+        new Set(prepared.entryRemovals.map((removal) => removal.sessionKey)),
       );
-      deletePlannedSqliteLifecycleArtifactEntries(transactionDb, entryRemovals);
+      deletePlannedSqliteLifecycleArtifactEntries(transactionDb, prepared.entryRemovals);
       maintenancePlans.push(
         applySqliteSessionEntryMaintenance(transactionDb, {
           activeSessionKey: "",
@@ -613,26 +646,30 @@ export async function purgeSqliteDeletedAgentSessionEntries(
         }),
       );
     }, toDatabaseOptions(resolved));
-    emitCommittedSessionEntryRemovals(entryRemovals);
-    archivedTranscripts = [
-      ...archivedTranscripts,
-      ...(await finalizeSqliteSessionEntryMaintenancePlansBestEffort(resolved, maintenancePlans)),
-    ];
-    const afterCount = readSqliteSessionEntryCount(
-      openOpenClawAgentDatabase(toDatabaseOptions(resolved)),
-    );
-    emitArchivedSqliteTranscriptUpdates(archivedTranscripts);
-    return {
-      removedEntries: removedSessionKeys.length,
-      removedSessionKeys,
-      archivedTranscriptDirectories: uniqueStrings(
-        archivedTranscripts.map((transcript) => path.dirname(transcript.archivedPath)),
-      ).toSorted(),
-      unreferencedArtifacts: null,
-      maintenanceReport: null,
-      afterCount,
-    };
+    emitCommittedSessionEntryRemovals(prepared.entryRemovals);
+    return { archivedTranscripts, maintenancePlans, removedSessionKeys };
   });
+  const archivedTranscripts = [
+    ...committed.archivedTranscripts,
+    ...(await finalizeSqliteSessionEntryMaintenancePlansAfterWriterReleaseBestEffort(
+      resolved,
+      committed.maintenancePlans,
+    )),
+  ];
+  const afterCount = readSqliteSessionEntryCount(
+    openOpenClawAgentDatabase(toDatabaseOptions(resolved)),
+  );
+  emitArchivedSqliteTranscriptUpdates(archivedTranscripts);
+  return {
+    removedEntries: committed.removedSessionKeys.length,
+    removedSessionKeys: committed.removedSessionKeys,
+    archivedTranscriptDirectories: uniqueStrings(
+      archivedTranscripts.map((transcript) => path.dirname(transcript.archivedPath)),
+    ).toSorted(),
+    unreferencedArtifacts: null,
+    maintenanceReport: null,
+    afterCount,
+  };
 }
 
 /** Fully replaces rows for one transcript in the additive SQLite transcript store. */

--- a/src/config/sessions/session-history-eviction.ts
+++ b/src/config/sessions/session-history-eviction.ts
@@ -346,13 +346,13 @@ async function enforceSessionHistoryMaintenanceSerialized(
     const eviction = await runExclusiveSessionLifecycleMutation({
       scope: params.storePath,
       identities: [sessionId],
-      run: async () =>
-        await runExclusiveSqliteSessionWrite(resolved, async () => {
+      run: async () => {
+        const plan = await runExclusiveSqliteSessionWrite(resolved, async () => {
           const protectedBeforeArchive = collectProtectedHistoricalSessionIds({
             database,
             storePath: params.storePath,
           });
-          const plan = planSqliteSessionStateDeleteIfUnreferenced({
+          const candidate = planSqliteSessionStateDeleteIfUnreferenced({
             archiveDirectory,
             archiveTranscript: true,
             database,
@@ -360,13 +360,18 @@ async function enforceSessionHistoryMaintenanceSerialized(
             referencedSessionIds: protectedBeforeArchive,
             sessionId,
           });
-          if (!plan) {
+          if (!candidate) {
             return null;
           }
-
-          // Extract-before-delete is the retention invariant. Admission is fenced across archive
-          // creation, then rechecked inside the write transaction before any rows are reclaimed.
-          const materialized = await materializeSqliteSessionStateDeletePlans([plan]);
+          return candidate;
+        });
+        if (!plan) {
+          return null;
+        }
+        // Extract-before-delete is the retention invariant. The lifecycle hold
+        // fences admission while the store writer is released for archive I/O.
+        const materialized = await materializeSqliteSessionStateDeletePlans([plan]);
+        const committedArchives = await runExclusiveSqliteSessionWrite(resolved, async () => {
           let deleted = false;
           let archivedTranscripts: ReturnType<typeof deleteMaterializedSqliteSessionStatePlans> =
             [];
@@ -401,11 +406,16 @@ async function enforceSessionHistoryMaintenanceSerialized(
           } catch {
             // Best-effort reclamation only.
           }
-          return {
-            archivedTranscripts,
-            usage: await measureSessionPhysicalDiskUsage(params.storePath),
-          };
-        }),
+          return archivedTranscripts;
+        });
+        if (!committedArchives) {
+          return null;
+        }
+        return {
+          archivedTranscripts: committedArchives,
+          usage: await measureSessionPhysicalDiskUsage(params.storePath),
+        };
+      },
     });
     if (!eviction) {
       continue;


### PR DESCRIPTION
Related: #112423
Follow-up to #112424

## What Problem This Solves

Fixes an issue where SQLite session cleanup, lifecycle mutation, deleted-agent purge, or disk-budget eviction could keep the per-store writer lane occupied while a transcript archive was built. A newly arriving write to the same store then waited for archive materialization even though the CPU-heavy archive work already ran in a Worker.

## Why This Change Was Made

Archive callers now plan under a short SQLite writer section, release the writer while the archive is materialized, then reacquire it and revalidate authoritative rows, references, and admission state before deleting. Maintenance archival follows the same boundary.

This preserves extract-before-delete and lifecycle invalidation without polling, retries, request-time caches, fallback readers, config, or protocol changes.

## User Impact

Same-store session writes can continue while low-priority transcript archival is pending. Archive correctness, shared-generation protection, and disk-budget behavior are preserved.

This PR does not claim to fix cold `chat.metadata` preparation. A proof-only cold metadata probe exceeded 2 seconds while writer and `system-presence` responsiveness passed, so that remains a separate lifecycle/catalog investigation.

## Evidence

- Red proof on unmodified base: lifecycle cleanup paused in archive materialization and a same-store writer failed the 500 ms liveness bound; the ordinary direct-delete control passed. Blacksmith Testbox `tbx_01kz7hgs8vy7qx6h9cggbjhm5z`, Actions run `30959924647`.
- Exact change proof: 19/19 focused lifecycle and disk-budget tests passed, including cleanup, lifecycle mutation, historical-generation, direct-delete negative control, and eviction paths.
- Built Gateway proof: a randomized roughly 64 MiB transcript was deleted while same-store `sessions.patch` and unrelated `system-presence` RPCs remained below 500 ms; the archive byte length and SHA-256 matched, and session, transcript, FTS, and window rows were removed.
- Production build passed.
- Blacksmith Testbox `tbx_01kz7yxwa13gxb9dpxck25sfsy`, Actions run `30971926178`.
- `pnpm check:changed` passed for `core, coreTests` on the reviewed diff.
- Autoreview: clean, no accepted/actionable findings; patch correctness 0.96.
- Direct AWS Crabbox was attempted for base and head, but four fresh instances lost SSH after sync before executing repository code. Runs `run_505553e9541e` and `run_261a03a9e071`; no AWS result is claimed.

AI-assisted: yes. I reviewed the ownership boundaries, competing hypotheses, final diff, and validation results.
