### PR TITLE
Improve short-term memory promotion quality gate

### DIFF
--- a/extensions/memory-core/src/short-term-promotion-utils.ts
+++ b/extensions/memory-core/src/short-term-promotion-utils.ts
@@ -30,28 +30,28 @@ const MEMORY_FLUSH_PROMPT_RE =
   /Save important context from this session to the daily memory file\.\s*STRICT RULES:/i;
 const PROMOTION_SCORE_METADATA_RE =
   /\[\s*score=\d+(?:\.\d+)?\s+(?:signals=\d+\s+)?recalls=\d+\s+avg=\d+(?:\.\d+)?\s+source=memory\//i;
-const SECRET_LIKE_PROMOTION_RE =
-  /(?:^|[^a-z0-9_])(?:sk-[a-z0-9_-]{12,}|ghp_[a-z0-9_]{12,}|api[_ -]?key|access[_ -]?token|auth[_ -]?token|secret|passwd|password\s*[=:]|token\s*[=:]|authorization\s*[=:]|bearer\s+[a-z0-9._-]{12,})/i;
-const PRIVATE_KEY_RE = /-----BEGIN [A-Z ]*PRIVATE KEY-----/;
-const JWT_LIKE_RE = /\beyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}\b/;
-const AWS_ACCESS_KEY_RE = /\bAKIA[0-9A-Z]{16}\b/;
-const TRANSIENT_ERROR_RE =
-  /\b(?:not generated|not created|pipeline aborted|exit code\s+\d+|http\s*\d{3}|stack trace|traceback|exception|unhandledpromiserejection|econnreset|etimedout|epipe|enoent|eacces|429 too many requests|5\d\d server error|all \d+ .* retries .* failed|attempt \d+\/\d+ failed|user account is locked|incorrect username or password|authentication failure)\b/i;
-const RAW_LOG_LINE_RE =
-  /^\s*(?:\[[^\]]+\]\s*)?(?:DEBUG|INFO|WARN|ERROR|TRACE)\b[:\s]|\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.*\b(?:debug|info|warn|error|trace)\b/im;
-const STACK_FRAME_RE = /^\s*at\s+\S+\s+\(.+:\d+:\d+\)/m;
-const RAW_DUMP_RE = /```|^\s*[{[]\s*["'\w-]+["']?\s*[:=]|^\s*(?:\$|>|npm ERR!|pnpm ERR!|yarn error|curl: \(\d+\))/im;
-const LOW_VALUE_PROMOTION_LEAD_RE =
-  /^(?:output directory path|summary\.md:|worktree:|result:|error details|verdict|file state|what failed|what works)\b/i;
-const TEMP_OR_CACHE_PATH_RE =
-  /(?:^|\s)(?:\/tmp\/|\/var\/tmp\/|\/private\/var\/folders\/|\/home\/[^\s`]+\/data\/temp\/|[A-Za-z]:\\[^\s`]*\\AppData\\Local\\Temp\\)/;
+const CONCRETE_SECRET_VALUE_RE =
+  /(?:^|[^a-z0-9])(?:sk-[a-z0-9_-]{12,}|ghp_[a-z0-9_]{20,}|AKIA[0-9A-Z]{16}|eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,})/;
+const PRIVATE_KEY_BLOCK_RE = /-----BEGIN [A-Z ]*PRIVATE KEY-----/;
+const ASSIGNED_SECRET_VALUE_RE =
+  /\b(?:password|passwd|api[_ -]?key|access[_ -]?token|auth[_ -]?token|authorization|bearer)\s*[=:]\s*(?!\*{3}|\.{3})\S{6,}/i;
+// Snippet filters below match the normalized single-line form: every promotion
+// gate passes normalizeSnippet() output before this predicate runs, so
+// line-anchored shapes would never fire on real store input.
+const STACK_FRAME_RE = /(?:^|[\s,;])(?:at\s+[\w.$<>]+\s+)?\([^)\s]*\.\w{1,10}:\d+:\d+\)/;
+const ISO_TIMESTAMP_RE = /\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?\b/;
+const HTTP_STATUS_RE = /\bhttps?\s+[45]\d\d\b/i;
+const FENCED_RAW_DUMP_RE = /(?:^|\s)```[a-z]*\s*[{[]/i;
+const TEMP_DIR_RE = /(?:^|\s)\/(?:tmp|var\/tmp|private\/var\/folders)\/|\/(?:tmp|temp)\//;
 const PATH_CONTEXT_RE = /\b(?:output|directory|path|contents|file|logs?|temp|temporary)\b/i;
-const FAILURE_ARTIFACT_RE =
-  /\b(?:config\.ini|\.monorepo_worktree\.json|download_logs\.log|decompress_logs\.log|summary\.md)\b/i;
-const FAILURE_CONTEXT_RE =
-  /\b(?:failed|not generated|not created|password|token|error|aborted|download|auth)\b/i;
-const ERROR_TABLE_CONTEXT_RE =
-  /\b(?:failed|failure|error|root cause|status|result|check|method|download|auth|token|password)\b/i;
+const TRANSIENT_DIAGNOSTIC_RE =
+  /\b(?:not generated|not created|pipeline aborted|exit code\s+\d+|stack trace|traceback|unhandledpromiserejection|econnreset|etimedout|epipe|enoent|eacces|incorrect username or password|authentication failure|user account is locked|token expired|token revoked|invalid[_-]?grant|refresh[_ -]?token|credentials? expired|attempt \d+\/\d+ failed)\b/i;
+const ERROR_TABLE_CONTEXT_RE = /\b(?:failed|failure|error|root cause|exception)\b/i;
+// Snippets stating a standing preference stay eligible even when they mention
+// transient-looking vocabulary; dropping this carve-out discards durable
+// operator guidance alongside the noise (mirrors rem-evidence's carve-out).
+const DURABLE_INTENT_RE =
+  /\b(?:always use|prefers?|preferences?|standing rule|rule:|remember|should default to)\b/i;
 const DREAMING_DIFF_PREFIX_RE = /@@\s*-\d+(?:,\d+)?\s+[-*+]\s+/iy;
 const DEFAULT_PROMOTION_WEIGHTS: PromotionWeights = {
   frequency: 0.24,
@@ -178,38 +178,40 @@ function hasDreamingNarrativeLead(snippet: string): boolean {
   return /\b(?:Candidate|Reflections?):/i.test(head);
 }
 
-function isLowValueLongTermMemorySnippet(raw: string): boolean {
+function hasConcreteSecretValue(snippet: string): boolean {
+  return (
+    CONCRETE_SECRET_VALUE_RE.test(snippet) ||
+    PRIVATE_KEY_BLOCK_RE.test(snippet) ||
+    ASSIGNED_SECRET_VALUE_RE.test(snippet)
+  );
+}
+
+function isNonDurablePromotionSnippet(raw: string): boolean {
   const snippet = normalizeSnippet(raw);
   if (!snippet) {
     return true;
   }
+  if (hasConcreteSecretValue(snippet)) {
+    return true;
+  }
+  // Secret values already returned; the carve-out must not re-admit them.
+  if (DURABLE_INTENT_RE.test(snippet)) {
+    return false;
+  }
   if (
-    SECRET_LIKE_PROMOTION_RE.test(snippet) ||
-    PRIVATE_KEY_RE.test(raw) ||
-    JWT_LIKE_RE.test(raw) ||
-    AWS_ACCESS_KEY_RE.test(raw)
+    TRANSIENT_DIAGNOSTIC_RE.test(snippet) ||
+    STACK_FRAME_RE.test(snippet) ||
+    ISO_TIMESTAMP_RE.test(snippet) ||
+    HTTP_STATUS_RE.test(snippet) ||
+    FENCED_RAW_DUMP_RE.test(snippet)
   ) {
     return true;
   }
-  if (
-    TRANSIENT_ERROR_RE.test(snippet) ||
-    RAW_LOG_LINE_RE.test(raw) ||
-    STACK_FRAME_RE.test(raw) ||
-    RAW_DUMP_RE.test(raw)
-  ) {
+  if (TEMP_DIR_RE.test(snippet) && PATH_CONTEXT_RE.test(snippet)) {
     return true;
   }
   const pipeCount = (snippet.match(/\|/g) ?? []).length;
   if (pipeCount >= 8 && ERROR_TABLE_CONTEXT_RE.test(snippet)) {
-    return true;
-  }
-  if (LOW_VALUE_PROMOTION_LEAD_RE.test(snippet)) {
-    return true;
-  }
-  if (TEMP_OR_CACHE_PATH_RE.test(snippet) && PATH_CONTEXT_RE.test(snippet)) {
-    return true;
-  }
-  if (FAILURE_ARTIFACT_RE.test(snippet) && FAILURE_CONTEXT_RE.test(snippet)) {
     return true;
   }
   return false;
@@ -223,7 +225,7 @@ export function isContaminatedDreamingSnippet(
   if (!snippet) {
     return false;
   }
-  if (isLowValueLongTermMemorySnippet(raw)) {
+  if (isNonDurablePromotionSnippet(raw)) {
     return true;
   }
   if (

--- a/extensions/memory-core/src/short-term-promotion-utils.ts
+++ b/extensions/memory-core/src/short-term-promotion-utils.ts
@@ -30,6 +30,28 @@ const MEMORY_FLUSH_PROMPT_RE =
   /Save important context from this session to the daily memory file\.\s*STRICT RULES:/i;
 const PROMOTION_SCORE_METADATA_RE =
   /\[\s*score=\d+(?:\.\d+)?\s+(?:signals=\d+\s+)?recalls=\d+\s+avg=\d+(?:\.\d+)?\s+source=memory\//i;
+const SECRET_LIKE_PROMOTION_RE =
+  /(?:^|[^a-z0-9_])(?:sk-[a-z0-9_-]{12,}|ghp_[a-z0-9_]{12,}|api[_ -]?key|access[_ -]?token|auth[_ -]?token|secret|passwd|password\s*[=:]|token\s*[=:]|authorization\s*[=:]|bearer\s+[a-z0-9._-]{12,})/i;
+const PRIVATE_KEY_RE = /-----BEGIN [A-Z ]*PRIVATE KEY-----/;
+const JWT_LIKE_RE = /\beyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}\b/;
+const AWS_ACCESS_KEY_RE = /\bAKIA[0-9A-Z]{16}\b/;
+const TRANSIENT_ERROR_RE =
+  /\b(?:not generated|not created|pipeline aborted|exit code\s+\d+|http\s*\d{3}|stack trace|traceback|exception|unhandledpromiserejection|econnreset|etimedout|epipe|enoent|eacces|429 too many requests|5\d\d server error|all \d+ .* retries .* failed|attempt \d+\/\d+ failed|user account is locked|incorrect username or password|authentication failure)\b/i;
+const RAW_LOG_LINE_RE =
+  /^\s*(?:\[[^\]]+\]\s*)?(?:DEBUG|INFO|WARN|ERROR|TRACE)\b[:\s]|\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.*\b(?:debug|info|warn|error|trace)\b/im;
+const STACK_FRAME_RE = /^\s*at\s+\S+\s+\(.+:\d+:\d+\)/m;
+const RAW_DUMP_RE = /```|^\s*[{[]\s*["'\w-]+["']?\s*[:=]|^\s*(?:\$|>|npm ERR!|pnpm ERR!|yarn error|curl: \(\d+\))/im;
+const LOW_VALUE_PROMOTION_LEAD_RE =
+  /^(?:output directory path|summary\.md:|worktree:|result:|error details|verdict|file state|what failed|what works)\b/i;
+const TEMP_OR_CACHE_PATH_RE =
+  /(?:^|\s)(?:\/tmp\/|\/var\/tmp\/|\/private\/var\/folders\/|\/home\/[^\s`]+\/data\/temp\/|[A-Za-z]:\\[^\s`]*\\AppData\\Local\\Temp\\)/;
+const PATH_CONTEXT_RE = /\b(?:output|directory|path|contents|file|logs?|temp|temporary)\b/i;
+const FAILURE_ARTIFACT_RE =
+  /\b(?:config\.ini|\.monorepo_worktree\.json|download_logs\.log|decompress_logs\.log|summary\.md)\b/i;
+const FAILURE_CONTEXT_RE =
+  /\b(?:failed|not generated|not created|password|token|error|aborted|download|auth)\b/i;
+const ERROR_TABLE_CONTEXT_RE =
+  /\b(?:failed|failure|error|root cause|status|result|check|method|download|auth|token|password)\b/i;
 const DREAMING_DIFF_PREFIX_RE = /@@\s*-\d+(?:,\d+)?\s+[-*+]\s+/iy;
 const DEFAULT_PROMOTION_WEIGHTS: PromotionWeights = {
   frequency: 0.24,
@@ -156,6 +178,43 @@ function hasDreamingNarrativeLead(snippet: string): boolean {
   return /\b(?:Candidate|Reflections?):/i.test(head);
 }
 
+function isLowValueLongTermMemorySnippet(raw: string): boolean {
+  const snippet = normalizeSnippet(raw);
+  if (!snippet) {
+    return true;
+  }
+  if (
+    SECRET_LIKE_PROMOTION_RE.test(snippet) ||
+    PRIVATE_KEY_RE.test(raw) ||
+    JWT_LIKE_RE.test(raw) ||
+    AWS_ACCESS_KEY_RE.test(raw)
+  ) {
+    return true;
+  }
+  if (
+    TRANSIENT_ERROR_RE.test(snippet) ||
+    RAW_LOG_LINE_RE.test(raw) ||
+    STACK_FRAME_RE.test(raw) ||
+    RAW_DUMP_RE.test(raw)
+  ) {
+    return true;
+  }
+  const pipeCount = (snippet.match(/\|/g) ?? []).length;
+  if (pipeCount >= 8 && ERROR_TABLE_CONTEXT_RE.test(snippet)) {
+    return true;
+  }
+  if (LOW_VALUE_PROMOTION_LEAD_RE.test(snippet)) {
+    return true;
+  }
+  if (TEMP_OR_CACHE_PATH_RE.test(snippet) && PATH_CONTEXT_RE.test(snippet)) {
+    return true;
+  }
+  if (FAILURE_ARTIFACT_RE.test(snippet) && FAILURE_CONTEXT_RE.test(snippet)) {
+    return true;
+  }
+  return false;
+}
+
 export function isContaminatedDreamingSnippet(
   raw: string,
   opts: { allowTranscriptTurnSnippet?: boolean } = {},
@@ -163,6 +222,9 @@ export function isContaminatedDreamingSnippet(
   const snippet = normalizeSnippet(raw);
   if (!snippet) {
     return false;
+  }
+  if (isLowValueLongTermMemorySnippet(raw)) {
+    return true;
   }
   if (
     /<!--\s*openclaw-memory-promotion:/i.test(snippet) ||

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -591,17 +591,23 @@ describe("short-term promotion", () => {
     expect(store.entries).toEqual({});
   });
 
-  it("classifies transient diagnostics and secrets as contaminated promotion snippets", () => {
+  it("classifies non-durable promotion snippets without blocking durable guidance", () => {
     const rejected = [
       "Output Directory Path: /home/user/data/temp/feishu_project_issues/7058806450",
       "summary.md: **Not generated.** The pipeline aborted before reaching the summary step because no log files were downloaded.",
       "Worktree: **Not created.** `.monorepo_worktree.json` does not exist after step 6/9.",
       "| Method | Error | Root Cause | | drfile download | [400] incorrect username or password | password=*** placeholder |",
+      // Multiline input is normalized inside the predicate.
       "Error: boom\n    at run (/tmp/openclaw-run/index.js:1:2)",
+      // Promotion call sites pass pre-normalized single-line snippets, so the
+      // gate must also catch stack frames embedded mid-sentence.
+      "wrapper failed at run (/tmp/openclaw-run/index.js:1:2) during startup",
       "2026-08-05T03:00:00Z ERROR failed to download logs",
-      "```json\n{\"error\":\"timeout\"}\n```",
+      '```json\n{"error":"timeout"}\n```',
       "OPENAI_API_KEY=sk-proj_123456789abcdefghijklmnop",
       "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.abcdefghijklmnopqrstuvwxyz.123456789abcd",
+      "uat-client: refresh_token expired for ou_...57cdd, clearing error: need_user_authorization",
+      "The job failed with exit code 1; attempt 3/5 failed and retries are exhausted.",
     ];
     for (const snippet of rejected) {
       expect(isContaminatedDreamingSnippet(snippet), snippet).toBe(true);
@@ -610,10 +616,66 @@ describe("short-term promotion", () => {
     const retained = [
       "User prefers concise status updates during long debugging work.",
       "Analyze each driver case by downloading trip logs, creating a release worktree, and cross-checking logs with source code.",
+      // Durable guidance that discusses credentials without embedding a value
+      // stays eligible; bare-label matching used to discard it.
+      "How to store an API key: put it in ~/.openclaw/credentials/ and never commit it.",
+      "The secret for the staging env lives in the vault; do not commit it.",
+      // Durable-intent carve-out: a standing rule mentioning transient
+      // vocabulary is guidance, not a failure artifact.
+      "Standing rule: when a job exits with exit code 1, re-run the collector before reporting failure.",
+      "Remember: scratch files for analysis always use /tmp/ so they never land in the repo.",
     ];
     for (const snippet of retained) {
       expect(isContaminatedDreamingSnippet(snippet), snippet).toBe(false);
     }
+  });
+
+  it("records durable guidance but excludes non-durable snippets through record, load, and rank", async (workspaceDir) => {
+    await recordMemoryRecalls(workspaceDir, "promotion quality", [
+      memoryRecallResult(
+        "memory/2026-04-03.md",
+        1,
+        1,
+        0.92,
+        "wrapper failed at run (/tmp/openclaw-run/index.js:1:2) during startup",
+      ),
+      memoryRecallResult(
+        "memory/2026-04-03.md",
+        2,
+        2,
+        0.91,
+        "uat-client: refresh_token expired for ou_...57cdd, clearing error: need_user_authorization",
+      ),
+      memoryRecallResult(
+        "memory/2026-04-03.md",
+        3,
+        3,
+        0.9,
+        "How to store an API key: put it in ~/.openclaw/credentials/ and never commit it.",
+      ),
+      memoryRecallResult(
+        "memory/2026-04-03.md",
+        4,
+        4,
+        0.89,
+        "Standing rule: when a job exits with exit code 1, re-run the collector before reporting failure.",
+      ),
+    ]);
+
+    const durableGuidance = [
+      "How to store an API key: put it in ~/.openclaw/credentials/ and never commit it.",
+      "Standing rule: when a job exits with exit code 1, re-run the collector before reporting failure.",
+    ];
+
+    const store = await testing.readRecallStore(workspaceDir, new Date().toISOString());
+    expect(
+      Object.values(store.entries)
+        .map((entry) => entry.snippet)
+        .toSorted(),
+    ).toEqual(durableGuidance);
+
+    const ranked = await rankAllCandidates(workspaceDir);
+    expect(ranked.map((candidate) => candidate.snippet).toSorted()).toEqual(durableGuidance);
   });
 
   it("ignores raw session and transcript snippets when recording short-term recalls", async (workspaceDir) => {
@@ -1649,6 +1711,27 @@ describe("short-term promotion", () => {
         },
       ],
     });
+
+    expect(applied.applied).toBe(0);
+    expect(applied.rejectedCandidates[0]?.reason).toBe("contamination filter");
+    await expectEnoent(fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8"));
+  });
+
+  it("does not append non-durable promotion snippets during direct apply", async (workspaceDir) => {
+    const applied = await applyAllCandidates(
+      workspaceDir,
+      [
+        promotionCandidateFixture({
+          key: "memory:memory/2026-04-03.md:1:1",
+          path: "memory/2026-04-03.md",
+          startLine: 1,
+          endLine: 1,
+          source: "memory",
+          snippet: "wrapper failed at run (/tmp/openclaw-run/index.js:1:2) during startup",
+          conceptTags: ["assistant"],
+        }),
+      ],
+    );
 
     expect(applied.applied).toBe(0);
     expect(applied.rejectedCandidates[0]?.reason).toBe("contamination filter");

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -45,6 +45,7 @@ import {
   repairShortTermPromotionArtifacts,
   type ShortTermRecallEntry,
 } from "./short-term-promotion.js";
+import { isContaminatedDreamingSnippet } from "./short-term-promotion-utils.js";
 import {
   configureMemoryCoreDreamingStateForTests,
   resetMemoryCoreDreamingStateForTests,
@@ -588,6 +589,31 @@ describe("short-term promotion", () => {
     const store = await testing.readRecallStore(workspaceDir, new Date().toISOString());
     expect(store.version).toBe(1);
     expect(store.entries).toEqual({});
+  });
+
+  it("classifies transient diagnostics and secrets as contaminated promotion snippets", () => {
+    const rejected = [
+      "Output Directory Path: /home/user/data/temp/feishu_project_issues/7058806450",
+      "summary.md: **Not generated.** The pipeline aborted before reaching the summary step because no log files were downloaded.",
+      "Worktree: **Not created.** `.monorepo_worktree.json` does not exist after step 6/9.",
+      "| Method | Error | Root Cause | | drfile download | [400] incorrect username or password | password=*** placeholder |",
+      "Error: boom\n    at run (/tmp/openclaw-run/index.js:1:2)",
+      "2026-08-05T03:00:00Z ERROR failed to download logs",
+      "```json\n{\"error\":\"timeout\"}\n```",
+      "OPENAI_API_KEY=sk-proj_123456789abcdefghijklmnop",
+      "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.abcdefghijklmnopqrstuvwxyz.123456789abcd",
+    ];
+    for (const snippet of rejected) {
+      expect(isContaminatedDreamingSnippet(snippet), snippet).toBe(true);
+    }
+
+    const retained = [
+      "User prefers concise status updates during long debugging work.",
+      "Analyze each driver case by downloading trip logs, creating a release worktree, and cross-checking logs with source code.",
+    ];
+    for (const snippet of retained) {
+      expect(isContaminatedDreamingSnippet(snippet), snippet).toBe(false);
+    }
   });
 
   it("ignores raw session and transcript snippets when recording short-term recalls", async (workspaceDir) => {

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -591,7 +591,7 @@ describe("short-term promotion", () => {
     expect(store.entries).toEqual({});
   });
 
-  it("classifies non-durable promotion snippets without blocking durable guidance", () => {
+  baseIt("classifies non-durable promotion snippets without blocking durable guidance", () => {
     const rejected = [
       "Output Directory Path: /home/user/data/temp/feishu_project_issues/7058806450",
       "summary.md: **Not generated.** The pipeline aborted before reaching the summary step because no log files were downloaded.",

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -30,6 +30,7 @@ import {
   deleteShortTermLockEntryIfCurrent,
   withMemoryWorkspaceLock,
 } from "./memory-workspace-lock.js";
+import { isContaminatedDreamingSnippet } from "./short-term-promotion-utils.js";
 import {
   applyShortTermPromotions,
   auditShortTermPromotionArtifacts,
@@ -45,7 +46,6 @@ import {
   repairShortTermPromotionArtifacts,
   type ShortTermRecallEntry,
 } from "./short-term-promotion.js";
-import { isContaminatedDreamingSnippet } from "./short-term-promotion-utils.js";
 import {
   configureMemoryCoreDreamingStateForTests,
   resetMemoryCoreDreamingStateForTests,
@@ -604,8 +604,8 @@ describe("short-term promotion", () => {
       "wrapper failed at run (/tmp/openclaw-run/index.js:1:2) during startup",
       "2026-08-05T03:00:00Z ERROR failed to download logs",
       '```json\n{"error":"timeout"}\n```',
-      "OPENAI_API_KEY=sk-proj_123456789abcdefghijklmnop",
-      "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.abcdefghijklmnopqrstuvwxyz.123456789abcd",
+      "OPENAI_API_KEY=sk-proj_123456789abcdefghijklmnop", // pragma: allowlist secret
+      "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.abcdefghijklmnopqrstuvwxyz.123456789abcd", // pragma: allowlist secret
       "uat-client: refresh_token expired for ou_...57cdd, clearing error: need_user_authorization",
       "The job failed with exit code 1; attempt 3/5 failed and retries are exhausted.",
     ];
@@ -1718,20 +1718,17 @@ describe("short-term promotion", () => {
   });
 
   it("does not append non-durable promotion snippets during direct apply", async (workspaceDir) => {
-    const applied = await applyAllCandidates(
-      workspaceDir,
-      [
-        promotionCandidateFixture({
-          key: "memory:memory/2026-04-03.md:1:1",
-          path: "memory/2026-04-03.md",
-          startLine: 1,
-          endLine: 1,
-          source: "memory",
-          snippet: "wrapper failed at run (/tmp/openclaw-run/index.js:1:2) during startup",
-          conceptTags: ["assistant"],
-        }),
-      ],
-    );
+    const applied = await applyAllCandidates(workspaceDir, [
+      promotionCandidateFixture({
+        key: "memory:memory/2026-04-03.md:1:1",
+        path: "memory/2026-04-03.md",
+        startLine: 1,
+        endLine: 1,
+        source: "memory",
+        snippet: "wrapper failed at run (/tmp/openclaw-run/index.js:1:2) during startup",
+        conceptTags: ["assistant"],
+      }),
+    ]);
 
     expect(applied.applied).toBe(0);
     expect(applied.rejectedCandidates[0]?.reason).toBe("contamination filter");


### PR DESCRIPTION
## What Problem This Solves

Memory-core deep promotion can promote short-term snippets that are high-signal but non-durable for `MEMORY.md`: transient diagnostics, raw logs, temp paths, failure artifacts, and credential-bearing text pollute long-term memory and make future recall less useful.

## Why This Change Was Made

The initial broad text heuristics were rewritten after review into a structure-based gate that only fires on shapes the promotion lifecycle actually passes:

- **Value-backed secrets only.** Concrete value shapes are rejected: `sk-…`, `ghp_…`, `AKIA…`, JWT triples, PEM private-key blocks, and `label=value` assignments with a non-masked value. Bare words like "secret" no longer match, so durable guidance such as "store the API key in ~/.openclaw/credentials/" stays eligible.
- **Normalized-input matching.** Every promotion call site (record, store load, rank, apply) passes `normalizeSnippet()` output; all patterns match that single-line form. Line-anchored stack-frame patterns that could never fire on real store input are gone, replaced by an inline frame matcher (`at run (/path/file.js:1:2)` anywhere in the text).
- **Durable-intent carve-out.** Snippets stating a standing preference (`always use`, `prefers`, `standing rule`, `rule:`, `remember`, `should default to`) stay eligible even when they mention transient-looking vocabulary — mirrors `rem-evidence.ts`'s existing monitoring carve-out. Concrete secret values are never exempted.
- **Narrow error vocabulary.** HTTP status requires an `http` prefix (bare `4xx` patterns would falsely match `file.cc:486` source references), ISO timestamps are structural, fenced JSON dumps require a fence+brace shape, and the transient phrase list aligns with rem-evidence (adds the `token expired` / `refresh_token` family). Generic report headings (`Verdict:`, `What works`, `Result:`) are no longer filtered.
- **Scope note.** The gate covers English diagnostics plus language-independent structure (paths, timestamps, stack frames). Non-English diagnostic phrasing is intentionally out of scope to avoid false positives on non-English durable content.

## User Impact

- Transient diagnostics, raw dumps, temp paths, and credential values no longer enter durable promotion at record, load, rank, or apply.
- Durable guidance that merely discusses credentials keeps promoting.
- Upgrade-safe for existing stores: the narrowed gate matches 0 of 512 real recall-store entries sampled from a production store (31 of them already promoted).

## Evidence

- `git diff --check` clean; oxfmt and oxlint (extensions config) clean on both touched files; `tsgo:extensions` and `tsgo:extensions:test` pass.
- Vitest: `pnpm test extensions/memory-core/src/short-term-promotion.test.ts` — 91/91 pass. Three new tests: a table-driven predicate case (12 rejected shapes incl. pre-normalized and inline stack frames; 6 retained shapes incl. credential-mentioning guidance and the durable-intent carve-out); a record → store-load → rank lifecycle test proving transient snippets are excluded while durable guidance survives the real pipeline; a direct-apply test proving a non-durable candidate is rejected with reason `contamination filter` and `MEMORY.md` stays untouched.
- Regression tests fail on the pre-fix filter for the intended reasons: the embedded stack frame and `refresh_token expired` snippets were previously promotable, while credential-mentioning guidance and standing rules were previously rejected.
- Real-behavior trace on an isolated state copy (never the live gateway state): `OPENCLAW_STATE_DIR=<copy> pnpm openclaw memory promote --json` over a copy of the production recall store (512 entries plus one injected stack-trace entry) reports `invalidEntryCount: 4` — the three stored `refresh_token expired` auth-error snippets plus the injected stack frame — and ranks 33 candidates, none of them transient.
- Autoreview was skipped by explicit operator decision: the Codex review engine could not authenticate inside the isolated reviewer runtime (HTTP 401 on `api.openai.com`), so the operator accepted agent self-review for this update.
