### PR TITLE
fix(ui): keep new-session model availability truthful

### DIFF
--- a/ui/src/e2e/new-session-page.catalog-reconnect.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.catalog-reconnect.e2e.test.ts
@@ -12,6 +12,73 @@ import {
 const suite = createNewSessionPageE2eSuite();
 
 suite.define(() => {
+  it("shows metadata failure truthfully and recovers the full catalog on retry", async () => {
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const models = [
+      {
+        available: true,
+        id: "gpt-5.6-luna",
+        name: "GPT-5.6 Luna",
+        provider: "openai",
+      },
+      {
+        available: true,
+        id: "gpt-5.6-sol",
+        name: "GPT-5.6 Sol",
+        provider: "openai",
+      },
+      {
+        available: true,
+        id: "gpt-5.6-terra",
+        name: "GPT-5.6 Terra",
+        provider: "openai",
+      },
+    ];
+    const gateway = await installMockGateway(page, {
+      agentModel: "openai/gpt-5.6-luna",
+      methodResponses: {
+        "chat.metadata": {
+          sequence: [
+            {
+              __mockError: {
+                code: "UNAVAILABLE",
+                message: "metadata request timed out",
+              },
+            },
+            { commands: [], models },
+          ],
+        },
+      },
+      models,
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}new`);
+      await gateway.waitForRequest("chat.metadata");
+
+      const modelSelect = page.locator('[data-chat-model-select="true"]');
+      await expect.poll(() => modelSelect.textContent()).toContain("Models unavailable");
+      await modelSelect.click();
+      await expect
+        .poll(() => page.locator('[data-chat-model-catalog-state="error"]').isVisible())
+        .toBe(true);
+      expect(await page.locator("[data-chat-model-option]").count()).toBe(0);
+
+      await page.locator('[data-chat-model-catalog-retry="true"]').click();
+
+      await expect.poll(async () => (await gateway.getRequests("chat.metadata")).length).toBe(2);
+      await expect.poll(() => page.locator("[data-chat-model-option]").count()).toBe(3);
+      expect(await page.locator('[data-chat-model-catalog-state="error"]').count()).toBe(0);
+    } finally {
+      await context.close();
+    }
+  });
+
   it("restores the model picker after startup-sidecars metadata becomes available", async () => {
     const context = await suite.browser.newContext({
       locale: "en-US",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4950,6 +4950,11 @@ export const en: TranslationMap = {
       chatOnly: "Chat only",
       chatOnlyHelp:
         "This model can chat, but it cannot use tools. Choose another model for files, commands, web, or media tasks.",
+      loadingModels: "Loading models…",
+      refreshingModels: "Refreshing models…",
+      modelsUnavailable: "Models unavailable",
+      modelsRefreshFailed: "Couldn’t refresh models",
+      noModelsAvailable: "No models available",
       providerModels: "{provider} models",
       resetReasoning: "Reset to default ({level})",
       useDefaultReasoning: "Use default reasoning ({level})",

--- a/ui/src/lib/chat/model-select-state.test.ts
+++ b/ui/src/lib/chat/model-select-state.test.ts
@@ -186,6 +186,21 @@ describe("chat-model-select-state", () => {
     ]);
   });
 
+  it("does not synthesize configured models when options are restricted to catalog results", () => {
+    const state = createChatModelState({
+      restrictOptionsToCatalog: true,
+      sessionsResult: createSessionsListResult({
+        model: "openai/gpt-5-mini",
+        modelProvider: "openai",
+      }),
+    });
+
+    const resolved = resolveChatModelSelectState(state);
+    expect(resolved.currentOverride).toBe("openai/gpt-5-mini");
+    expect(resolved.defaultSelectable).toBe(false);
+    expect(resolved.options).toEqual([]);
+  });
+
   it("builds picker options without introducing a bare duplicate", () => {
     const state = createChatModelState({
       chatModelCatalog: createModelCatalog(...DEFAULT_CHAT_MODEL_CATALOG),

--- a/ui/src/lib/chat/model-select-state.ts
+++ b/ui/src/lib/chat/model-select-state.ts
@@ -22,6 +22,7 @@ type ChatModelSelectStateInput = {
   agentDefaultModel?: string;
   chatModelCatalog: ModelCatalogEntry[];
   modelOverrides: Readonly<Record<string, string | null | undefined>>;
+  restrictOptionsToCatalog?: boolean;
   sessionKey: string;
   sessionsResult: SessionsListResult | null;
 };
@@ -180,6 +181,7 @@ function buildChatModelOptions(
   displayLookup: ReturnType<typeof buildCatalogDisplayLookup>,
   currentOverride: string,
   defaultModel: string,
+  restrictOptionsToCatalog: boolean,
 ): ChatModelSelectOption[] {
   const seen = new Set<string>();
   const options: ChatModelSelectOption[] = [];
@@ -202,13 +204,13 @@ function buildChatModelOptions(
     addOption(option.value, option.label);
   }
 
-  if (currentOverride) {
+  if (!restrictOptionsToCatalog && currentOverride) {
     addAvailableOption(
       currentOverride,
       formatCatalogChatModelDisplayFromLookup(currentOverride, displayLookup),
     );
   }
-  if (defaultModel) {
+  if (!restrictOptionsToCatalog && defaultModel) {
     addAvailableOption(
       defaultModel,
       formatCatalogChatModelDisplayFromLookup(defaultModel, displayLookup),
@@ -236,8 +238,23 @@ export function resolveChatModelSelectState(
   );
   const defaultDisplay = formatCatalogChatModelDisplayFromLookup(defaultModel, displayLookup);
   const unavailableValues = buildUnavailableChatModelValues(catalog, displayLookup);
-  const defaultSelectable =
-    !defaultModel || !unavailableValues.has(normalizeChatModelAvailabilityKey(defaultModel));
+  const options = buildChatModelOptions(
+    catalog,
+    displayLookup,
+    currentOverride,
+    defaultModel,
+    state.restrictOptionsToCatalog === true,
+  );
+  const defaultSelectable = state.restrictOptionsToCatalog
+    ? Boolean(
+        defaultModel &&
+        options.some(
+          (option) =>
+            normalizeChatModelAvailabilityKey(option.value) ===
+            normalizeChatModelAvailabilityKey(defaultModel),
+        ),
+      )
+    : !defaultModel || !unavailableValues.has(normalizeChatModelAvailabilityKey(defaultModel));
 
   return {
     currentOverride,
@@ -245,7 +262,7 @@ export function resolveChatModelSelectState(
     defaultModel,
     defaultDisplay,
     defaultLabel: defaultModel ? `Default (${defaultDisplay})` : "Default model",
-    options: buildChatModelOptions(catalog, displayLookup, currentOverride, defaultModel),
+    options,
   };
 }
 

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -37,6 +37,7 @@ export type ChatModelControlsProps = {
   gatewayAvailable: boolean;
   loading: boolean;
   modelCatalog: ModelCatalogEntry[];
+  modelCatalogState?: ChatModelCatalogState;
   modelOverrides?: Readonly<Record<string, string | null | undefined>>;
   modelSelectionLocked?: boolean;
   modelSelectionRuntimeId?: string;
@@ -54,6 +55,12 @@ export type ChatModelControlsProps = {
   onModelSelect?: (value: string, sessionKey: string) => unknown;
   onRequestUpdate?: () => void;
   onThinkingSelect?: (value: string, sessionKey: string) => unknown;
+};
+
+export type ChatModelCatalogState = {
+  hasSnapshot: boolean;
+  onRetry?: () => void;
+  status: "idle" | "loading" | "refreshing" | "ready" | "error";
 };
 
 type ChatModelProviderOption = ChatModelSelectOption & {
@@ -164,6 +171,7 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
     agentDefaultModel: props.agentDefaultModel,
     chatModelCatalog: props.modelCatalog,
     modelOverrides: props.modelOverrides ?? {},
+    restrictOptionsToCatalog: props.modelCatalogState !== undefined,
     sessionKey: props.sessionKey,
     sessionsResult: props.sessionsResult,
   });
@@ -248,13 +256,31 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
       ? thinking.defaultLabel
       : (thinking.options.find((entry) => entry.value === thinking.currentOverride)?.label ??
         thinking.currentOverride);
+  const managedCatalog = props.modelCatalogState;
+  const catalogLoadingWithoutSnapshot =
+    managedCatalog !== undefined &&
+    !managedCatalog.hasSnapshot &&
+    (managedCatalog.status === "idle" ||
+      managedCatalog.status === "loading" ||
+      managedCatalog.status === "refreshing");
+  const catalogErrorWithoutSnapshot =
+    managedCatalog?.status === "error" && !managedCatalog.hasSnapshot;
+  const catalogSnapshotEmpty = managedCatalog?.hasSnapshot === true && modelOptions.length === 0;
+  const catalogTriggerStatus = catalogLoadingWithoutSnapshot
+    ? t("chat.modelControls.loadingModels")
+    : catalogErrorWithoutSnapshot
+      ? t("chat.modelControls.modelsUnavailable")
+      : catalogSnapshotEmpty
+        ? t("chat.modelControls.noModelsAvailable")
+        : undefined;
   const busy =
     props.loading || props.sending || Boolean(props.activeRunId) || props.stream !== null;
   const disabled =
     !props.connected ||
     busy ||
     props.modelSwitching ||
-    (props.modelsLoading && selectOptions.length === 0) ||
+    catalogLoadingWithoutSnapshot ||
+    (managedCatalog === undefined && props.modelsLoading && selectOptions.length === 0) ||
     !props.gatewayAvailable ||
     Boolean(props.mutationDisabledReason);
   const thinkingDisabled =
@@ -262,6 +288,7 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
     busy ||
     props.modelSwitching ||
     !props.gatewayAvailable ||
+    (managedCatalog !== undefined && !managedCatalog.hasSnapshot) ||
     (thinking.options.length === 0 && thinking.currentOverride === "") ||
     Boolean(props.mutationDisabledReason);
   return renderChatModelReasoningSelect({
@@ -269,6 +296,7 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
     disabled,
     disabledReason: props.mutationDisabledReason,
     fastMode: { ...fastMode, disabled: fastMode.disabled || disabled },
+    modelCatalogState: managedCatalog,
     modelSelectionLocked: props.modelSelectionLocked === true,
     modelOptions,
     onRequestUpdate: props.onRequestUpdate,
@@ -280,6 +308,7 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
     thinkingDisabled,
     thinkingOptions: [{ value: "", label: thinking.defaultLabel }, ...thinking.options],
     triggerModelLabel: committedModelLabel,
+    triggerStatusLabel: catalogTriggerStatus,
     triggerThinkingLabel: committedThinkingLabel,
     onFastModeSelect: async (next, targetSessionKey) =>
       props.onFastModeSelect?.(next, targetSessionKey),
@@ -374,6 +403,7 @@ function renderChatModelReasoningSelect(params: {
   fastMode: ChatFastModeSelectState;
   disabled: boolean;
   disabledReason?: string;
+  modelCatalogState?: ChatModelCatalogState;
   modelSelectionLocked: boolean;
   modelOptions: ChatModelProviderOption[];
   selectedModelValue: string;
@@ -384,6 +414,7 @@ function renderChatModelReasoningSelect(params: {
   thinkingDisabled: boolean;
   thinkingOptions: ChatModelSelectOption[];
   triggerModelLabel: string;
+  triggerStatusLabel?: string;
   triggerThinkingLabel: string;
   onFastModeSelect: (value: ChatFastModeSelectValue, sessionKey: string) => Promise<unknown>;
   onModelSelect: (value: string, sessionKey: string) => Promise<unknown>;
@@ -395,6 +426,7 @@ function renderChatModelReasoningSelect(params: {
     disabled,
     disabledReason,
     fastMode,
+    modelCatalogState,
     modelSelectionLocked,
     modelOptions,
     selectedModelValue,
@@ -405,6 +437,7 @@ function renderChatModelReasoningSelect(params: {
     thinkingDisabled,
     thinkingOptions,
     triggerModelLabel,
+    triggerStatusLabel,
     triggerThinkingLabel,
     onFastModeSelect,
     onModelSelect,
@@ -421,13 +454,13 @@ function renderChatModelReasoningSelect(params: {
   const selectedModelOption = activeModelOption ?? modelOptions[0];
   const modelToolsUnavailable = activeModelOption?.supportsTools === false;
   const triggerTitle = [
-    triggerModel,
-    triggerThinking,
+    triggerStatusLabel ?? triggerModel,
+    triggerStatusLabel ? "" : triggerThinking,
     modelToolsUnavailable ? t("chat.modelControls.chatOnly") : "",
   ]
     .filter(Boolean)
     .join(" · ");
-  const triggerLabel = `${triggerModel} · ${triggerThinking}`;
+  const triggerLabel = triggerStatusLabel ?? `${triggerModel} · ${triggerThinking}`;
   const sliderStops = thinkingOptions.filter((option) => option.value !== "");
   const defaultStopIndex = sliderStops.findIndex((option) => option.value === thinkingDefaultValue);
   const hasThinkingOverride = selectedThinkingValue !== "";
@@ -543,7 +576,10 @@ function renderChatModelReasoningSelect(params: {
   const onlyStop = sliderStops.length === 1 ? sliderStops[0] : undefined;
   const effectiveThinkingValue = selectedThinkingValue || thinkingDefaultValue;
   const onlyStopSelected = onlyStop?.value === effectiveThinkingValue;
-  const showReasoningPanel = showReasoning || showFastMode;
+  const catalogHasNoUsableSnapshot =
+    modelCatalogState !== undefined &&
+    (!modelCatalogState.hasSnapshot || modelOptions.length === 0);
+  const showReasoningPanel = (showReasoning || showFastMode) && !catalogHasNoUsableSnapshot;
   const providerGroups = new Map<string, ChatModelProviderOption[]>();
   for (const option of modelOptions) {
     const existing = providerGroups.get(option.provider);
@@ -565,6 +601,56 @@ function renderChatModelReasoningSelect(params: {
   }
   const selectedProvider =
     selectedModelOption?.provider ?? orderedProviderGroups[0]?.[0] ?? "other";
+  const renderCatalogState = () => {
+    if (!modelCatalogState) {
+      return nothing;
+    }
+    const hasOptions = modelOptions.length > 0;
+    const status = modelCatalogState.status;
+    if (status === "ready" && hasOptions) {
+      return nothing;
+    }
+    const label =
+      status === "refreshing"
+        ? t("chat.modelControls.refreshingModels")
+        : status === "error"
+          ? modelCatalogState.hasSnapshot
+            ? t("chat.modelControls.modelsRefreshFailed")
+            : t("chat.modelControls.modelsUnavailable")
+          : status === "ready"
+            ? t("chat.modelControls.noModelsAvailable")
+            : t("chat.modelControls.loadingModels");
+    return html`
+      <div
+        class="chat-controls__model-catalog-state ${hasOptions
+          ? ""
+          : "chat-controls__model-catalog-state--empty"}"
+        data-chat-model-catalog-state=${status}
+        aria-live="polite"
+      >
+        <span class="chat-controls__model-catalog-state-label">
+          ${status === "error" ? icons.alertTriangle : nothing}
+          <span>${label}</span>
+        </span>
+        ${status === "error" && modelCatalogState.onRetry
+          ? html`
+              <button
+                class="chat-controls__model-catalog-retry"
+                data-chat-model-catalog-retry="true"
+                type="button"
+                @click=${(event: MouseEvent) => {
+                  event.stopPropagation();
+                  modelCatalogState.onRetry?.();
+                }}
+              >
+                ${icons.refresh}
+                <span>${t("common.retry")}</span>
+              </button>
+            `
+          : nothing}
+      </div>
+    `;
+  };
   const renderModelOption = (entry: ChatModelProviderOption) => {
     const selected =
       entry.value === selectedModelValue || (entry.isDefault && selectedModelValue === "");
@@ -689,97 +775,109 @@ function renderChatModelReasoningSelect(params: {
               </div>
             `
           : html`
-              ${renderModelProvenanceRow({
-                defaultModelLabel,
-                disabled,
-                hasModelOverride: selectedModelValue !== "",
-                onReset: () => commitModel(""),
-              })}
-              <div
-                class="chat-controls__model-browser"
-                @mouseleave=${(event: MouseEvent) => {
-                  const browser = event.currentTarget as HTMLElement;
-                  if (browser.contains(document.activeElement)) {
-                    return;
-                  }
-                  selectChatModelProvider(event, selectedProvider);
-                }}
-                @focusout=${(event: FocusEvent) => {
-                  const browser = event.currentTarget as HTMLElement;
-                  if (
-                    event.relatedTarget instanceof Node &&
-                    browser.contains(event.relatedTarget)
-                  ) {
-                    return;
-                  }
-                  selectChatModelProvider(event, selectedProvider);
-                }}
-              >
-                <div class="chat-controls__provider-list" aria-label=${t("sessionsView.provider")}>
-                  <div class="chat-controls__inline-select-section-label">
-                    ${t("sessionsView.provider")}
-                  </div>
-                  ${repeat(
-                    orderedProviderGroups,
-                    ([provider]) => provider,
-                    ([provider]) => {
-                      const active = provider === selectedProvider;
-                      return html`
-                        <button
-                          class="chat-controls__provider-option"
-                          data-chat-model-provider=${provider}
-                          type="button"
-                          aria-pressed=${active ? "true" : "false"}
-                          tabindex=${active ? "0" : "-1"}
-                          @click=${(event: MouseEvent) => selectChatModelProvider(event, provider)}
-                          @mouseenter=${(event: MouseEvent) => {
-                            const browser = (event.currentTarget as HTMLElement).closest(
-                              ".chat-controls__model-browser",
-                            );
-                            // Keyboard focus owns the active tab until it leaves; hover must
-                            // not hide the panel containing the focused model option.
-                            if (browser?.contains(document.activeElement)) {
-                              return;
-                            }
-                            selectChatModelProvider(event, provider);
-                          }}
-                          @focus=${(event: FocusEvent) => selectChatModelProvider(event, provider)}
-                          @keydown=${moveChatModelProviderFocus}
-                        >
-                          ${renderChatModelProviderIcon(provider)}
-                          <span>${providerDisplayLabel(provider)}</span>
-                        </button>
-                      `;
-                    },
-                  )}
-                </div>
-                <div
-                  class="chat-controls__provider-models"
-                  role="listbox"
-                  aria-label=${t("chat.selectors.model")}
-                >
-                  ${repeat(
-                    orderedProviderGroups,
-                    ([provider]) => provider,
-                    ([provider, options]) => html`
+              ${modelOptions.length > 0
+                ? renderModelProvenanceRow({
+                    defaultModelLabel,
+                    disabled,
+                    hasModelOverride: selectedModelValue !== "",
+                    onReset: () => commitModel(""),
+                  })
+                : nothing}
+              ${renderCatalogState()}
+              ${modelOptions.length > 0
+                ? html`
+                    <div
+                      class="chat-controls__model-browser"
+                      @mouseleave=${(event: MouseEvent) => {
+                        const browser = event.currentTarget as HTMLElement;
+                        if (browser.contains(document.activeElement)) {
+                          return;
+                        }
+                        selectChatModelProvider(event, selectedProvider);
+                      }}
+                      @focusout=${(event: FocusEvent) => {
+                        const browser = event.currentTarget as HTMLElement;
+                        if (
+                          event.relatedTarget instanceof Node &&
+                          browser.contains(event.relatedTarget)
+                        ) {
+                          return;
+                        }
+                        selectChatModelProvider(event, selectedProvider);
+                      }}
+                    >
                       <div
-                        class="chat-controls__provider-model-group"
-                        data-chat-model-provider-group=${provider}
-                        aria-label=${t("chat.modelControls.providerModels", {
-                          provider: providerDisplayLabel(provider),
-                        })}
-                        ?hidden=${provider !== selectedProvider}
+                        class="chat-controls__provider-list"
+                        aria-label=${t("sessionsView.provider")}
                       >
+                        <div class="chat-controls__inline-select-section-label">
+                          ${t("sessionsView.provider")}
+                        </div>
                         ${repeat(
-                          options,
-                          (entry) => entry.value,
-                          (entry) => renderModelOption(entry),
+                          orderedProviderGroups,
+                          ([provider]) => provider,
+                          ([provider]) => {
+                            const active = provider === selectedProvider;
+                            return html`
+                              <button
+                                class="chat-controls__provider-option"
+                                data-chat-model-provider=${provider}
+                                type="button"
+                                aria-pressed=${active ? "true" : "false"}
+                                tabindex=${active ? "0" : "-1"}
+                                @click=${(event: MouseEvent) =>
+                                  selectChatModelProvider(event, provider)}
+                                @mouseenter=${(event: MouseEvent) => {
+                                  const browser = (event.currentTarget as HTMLElement).closest(
+                                    ".chat-controls__model-browser",
+                                  );
+                                  // Keyboard focus owns the active tab until it leaves; hover must
+                                  // not hide the panel containing the focused model option.
+                                  if (browser?.contains(document.activeElement)) {
+                                    return;
+                                  }
+                                  selectChatModelProvider(event, provider);
+                                }}
+                                @focus=${(event: FocusEvent) =>
+                                  selectChatModelProvider(event, provider)}
+                                @keydown=${moveChatModelProviderFocus}
+                              >
+                                ${renderChatModelProviderIcon(provider)}
+                                <span>${providerDisplayLabel(provider)}</span>
+                              </button>
+                            `;
+                          },
                         )}
                       </div>
-                    `,
-                  )}
-                </div>
-              </div>
+                      <div
+                        class="chat-controls__provider-models"
+                        role="listbox"
+                        aria-label=${t("chat.selectors.model")}
+                      >
+                        ${repeat(
+                          orderedProviderGroups,
+                          ([provider]) => provider,
+                          ([provider, options]) => html`
+                            <div
+                              class="chat-controls__provider-model-group"
+                              data-chat-model-provider-group=${provider}
+                              aria-label=${t("chat.modelControls.providerModels", {
+                                provider: providerDisplayLabel(provider),
+                              })}
+                              ?hidden=${provider !== selectedProvider}
+                            >
+                              ${repeat(
+                                options,
+                                (entry) => entry.value,
+                                (entry) => renderModelOption(entry),
+                              )}
+                            </div>
+                          `,
+                        )}
+                      </div>
+                    </div>
+                  `
+                : nothing}
             `}
         ${showReasoningPanel
           ? html`

--- a/ui/src/pages/new-session/model-control.test.ts
+++ b/ui/src/pages/new-session/model-control.test.ts
@@ -2,6 +2,7 @@ import {
   DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
   gatewayStartupUnavailableDetails,
 } from "@openclaw/gateway-client/browser";
+import { render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { GatewayRequestError } from "../../api/gateway.ts";
 import type { GatewayAgentRow, ModelCatalogEntry } from "../../api/types.ts";
@@ -25,6 +26,7 @@ function contextWith(models: ModelCatalogEntry[], runtime = "openclaw") {
             modelProvider: "openai",
             agentRuntime: { id: runtime, source: "defaults" },
           },
+          sessions: [],
         },
       },
     },
@@ -40,6 +42,33 @@ function startupUnavailableError(retryAfterMs = 250): GatewayRequestError {
     retryable: true,
     retryAfterMs,
   });
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+function renderControl(
+  control: NewSessionModelControl,
+  context: ApplicationContext,
+  agentId = "main",
+) {
+  const container = document.createElement("div");
+  render(
+    control.render({
+      agentId,
+      context,
+      sending: false,
+    }),
+    container,
+  );
+  return container;
 }
 
 afterEach(() => {
@@ -80,6 +109,134 @@ describe("new-session model runtime", () => {
     await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
   });
 
+  it("renders initial metadata loading without synthesizing the configured default", async () => {
+    const pending = deferred<{ models: ModelCatalogEntry[] }>();
+    const { context, request } = contextWith([]);
+    request.mockReturnValueOnce(pending.promise);
+    const control = new NewSessionModelControl(() => undefined);
+
+    control.load(context, "main", true);
+
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    const container = renderControl(control, context);
+    expect(container.querySelector('[data-chat-model-select="true"]')?.textContent).toContain(
+      "Loading models",
+    );
+    expect(
+      container.querySelector('[data-chat-model-select="true"]')?.getAttribute("aria-disabled"),
+    ).toBe("true");
+    expect(container.querySelectorAll("[data-chat-model-option]")).toHaveLength(0);
+    pending.resolve({ models: [] });
+  });
+
+  it.each([
+    ["generic transport error", new Error("metadata unavailable")],
+    ["request timeout", new Error("gateway request timeout for chat.metadata")],
+  ])("renders %s as unavailable instead of a default-only catalog", async (_label, error) => {
+    const { context, request } = contextWith([]);
+    request.mockRejectedValueOnce(error);
+    const control = new NewSessionModelControl(() => undefined);
+
+    control.load(context, "main", true);
+
+    await vi.waitFor(() => {
+      const container = renderControl(control, context);
+      expect(
+        container
+          .querySelector("[data-chat-model-catalog-state]")
+          ?.getAttribute("data-chat-model-catalog-state"),
+      ).toBe("error");
+    });
+    const container = renderControl(control, context);
+    expect(container.querySelector('[data-chat-model-select="true"]')?.textContent).toContain(
+      "Models unavailable",
+    );
+    expect(container.querySelectorAll("[data-chat-model-option]")).toHaveLength(0);
+    expect(container.querySelector('[data-chat-model-catalog-retry="true"]')).not.toBeNull();
+  });
+
+  it("recovers the complete catalog after retrying an initial failure", async () => {
+    const models: ModelCatalogEntry[] = [
+      { id: "gpt-5.6-luna", name: "GPT-5.6 Luna", provider: "openai" },
+      { id: "gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "openai" },
+      { id: "gpt-5.6-terra", name: "GPT-5.6 Terra", provider: "openai" },
+    ];
+    const { context, request } = contextWith(models);
+    request.mockRejectedValueOnce(new Error("metadata unavailable"));
+    const control = new NewSessionModelControl(() => undefined);
+
+    control.load(context, "main", true);
+    await vi.waitFor(() =>
+      expect(
+        renderControl(control, context).querySelector('[data-chat-model-catalog-state="error"]'),
+      ).not.toBeNull(),
+    );
+
+    renderControl(control, context)
+      .querySelector<HTMLButtonElement>('[data-chat-model-catalog-retry="true"]')
+      ?.click();
+
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() =>
+      expect(
+        renderControl(control, context).querySelectorAll("[data-chat-model-option]"),
+      ).toHaveLength(3),
+    );
+  });
+
+  it("renders a successful empty catalog as an explicit empty result", async () => {
+    const { context, request } = contextWith([]);
+    const control = new NewSessionModelControl(() => undefined);
+
+    control.load(context, "main", true);
+
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    await vi.waitFor(() => {
+      const container = renderControl(control, context);
+      expect(
+        container
+          .querySelector("[data-chat-model-catalog-state]")
+          ?.getAttribute("data-chat-model-catalog-state"),
+      ).toBe("ready");
+      expect(container.querySelector('[data-chat-model-select="true"]')?.textContent).toContain(
+        "No models available",
+      );
+    });
+    const container = renderControl(control, context);
+    expect(container.querySelectorAll("[data-chat-model-option]")).toHaveLength(0);
+    expect(container.querySelector('[data-chat-model-catalog-retry="true"]')).toBeNull();
+  });
+
+  it("keeps a successful empty catalog explicit when its refresh fails", async () => {
+    const refresh = deferred<{ models: ModelCatalogEntry[] }>();
+    const { context, request } = contextWith([]);
+    const control = new NewSessionModelControl(() => undefined);
+
+    control.load(context, "main", true);
+    await vi.waitFor(() =>
+      expect(
+        renderControl(control, context).querySelector('[data-chat-model-catalog-state="ready"]'),
+      ).not.toBeNull(),
+    );
+    request.mockReturnValueOnce(refresh.promise);
+
+    control.load(context, "main", true);
+    expect(renderControl(control, context).textContent).toContain("No models available");
+
+    refresh.reject(new Error("refresh failed"));
+    await vi.waitFor(() =>
+      expect(
+        renderControl(control, context).querySelector('[data-chat-model-catalog-state="error"]'),
+      ).not.toBeNull(),
+    );
+    const container = renderControl(control, context);
+    expect(container.querySelectorAll("[data-chat-model-option]")).toHaveLength(0);
+    expect(container.querySelector('[data-chat-model-select="true"]')?.textContent).toContain(
+      "No models available",
+    );
+    expect(container.textContent).not.toContain("GPT-5.6 Luna");
+  });
+
   it("preserves the remembered pair when metadata validation fails", async () => {
     const { context, request } = contextWith([]);
     request.mockRejectedValueOnce(new Error("metadata unavailable"));
@@ -116,6 +273,148 @@ describe("new-session model runtime", () => {
     });
     expect(control.selected).toBe("anthropic/claude-sonnet-4-6");
     expect(control.thinkingLevel).toBe("high");
+  });
+
+  it("retains a successful same-agent catalog through refresh failure and recovery", async () => {
+    const models: ModelCatalogEntry[] = [
+      { id: "gpt-5.6-luna", name: "GPT-5.6 Luna", provider: "openai" },
+      { id: "gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "openai" },
+    ];
+    const refresh = deferred<{ models: ModelCatalogEntry[] }>();
+    const { context, request } = contextWith(models);
+    const control = new NewSessionModelControl(() => undefined);
+
+    control.load(context, "main", true);
+    await vi.waitFor(() =>
+      expect(
+        renderControl(control, context).querySelectorAll("[data-chat-model-option]"),
+      ).toHaveLength(2),
+    );
+    request.mockReturnValueOnce(refresh.promise);
+
+    control.load(context, "main", true);
+
+    let container = renderControl(control, context);
+    expect(container.querySelector('[data-chat-model-catalog-state="refreshing"]')).not.toBeNull();
+    expect(container.querySelectorAll("[data-chat-model-option]")).toHaveLength(2);
+
+    refresh.reject(new Error("refresh failed"));
+    await vi.waitFor(() =>
+      expect(
+        renderControl(control, context).querySelector('[data-chat-model-catalog-state="error"]'),
+      ).not.toBeNull(),
+    );
+    container = renderControl(control, context);
+    expect(container.querySelectorAll("[data-chat-model-option]")).toHaveLength(2);
+    expect(container.textContent).toContain("Couldn’t refresh models");
+
+    container.querySelector<HTMLButtonElement>('[data-chat-model-catalog-retry="true"]')?.click();
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(3));
+    await vi.waitFor(() =>
+      expect(
+        renderControl(control, context).querySelector("[data-chat-model-catalog-state]"),
+      ).toBeNull(),
+    );
+    expect(
+      renderControl(control, context).querySelectorAll("[data-chat-model-option]"),
+    ).toHaveLength(2);
+  });
+
+  it("keeps stale same-agent data across reconnect invalidation until replacement arrives", async () => {
+    const oldModels: ModelCatalogEntry[] = [
+      { id: "gpt-5.6-luna", name: "GPT-5.6 Luna", provider: "openai" },
+    ];
+    const newModels: ModelCatalogEntry[] = [
+      { id: "gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "openai" },
+      { id: "gpt-5.6-terra", name: "GPT-5.6 Terra", provider: "openai" },
+    ];
+    const reconnect = deferred<{ models: ModelCatalogEntry[] }>();
+    const { context, request } = contextWith(oldModels);
+    const control = new NewSessionModelControl(() => undefined);
+
+    control.load(context, "main", true);
+    await vi.waitFor(() =>
+      expect(
+        renderControl(control, context).querySelector(
+          '[data-chat-model-option="openai/gpt-5.6-luna"]',
+        ),
+      ).not.toBeNull(),
+    );
+
+    control.invalidate(false);
+    request.mockReturnValueOnce(reconnect.promise);
+    control.load(context, "main", true);
+
+    expect(
+      renderControl(control, context).querySelector(
+        '[data-chat-model-option="openai/gpt-5.6-luna"]',
+      ),
+    ).not.toBeNull();
+    reconnect.resolve({ models: newModels });
+    await vi.waitFor(() =>
+      expect(
+        renderControl(control, context).querySelectorAll("[data-chat-model-option]"),
+      ).toHaveLength(2),
+    );
+    const container = renderControl(control, context);
+    expect(container.querySelector('[data-chat-model-option="openai/gpt-5.6-luna"]')).toBeNull();
+    expect(container.querySelector('[data-chat-model-option="openai/gpt-5.6-sol"]')).not.toBeNull();
+  });
+
+  it("clears the old catalog on agent switch and ignores the late old-agent result", async () => {
+    const main = deferred<{ models: ModelCatalogEntry[] }>();
+    const { context, request } = contextWith([]);
+    request.mockImplementation((_method, params: { agentId?: string }) =>
+      params.agentId === "main"
+        ? main.promise
+        : Promise.resolve({
+            models: [
+              {
+                id: "claude-sonnet-5",
+                name: "Claude Sonnet 5",
+                provider: "anthropic",
+              },
+            ],
+          }),
+    );
+    const control = new NewSessionModelControl(() => undefined);
+
+    control.load(context, "main", true);
+    control.load(context, "research", true);
+
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() =>
+      expect(
+        renderControl(control, context, "research").querySelector(
+          '[data-chat-model-option="anthropic/claude-sonnet-5"]',
+        ),
+      ).not.toBeNull(),
+    );
+
+    main.resolve({
+      models: [{ id: "gpt-5.6-luna", name: "GPT-5.6 Luna", provider: "openai" }],
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const container = renderControl(control, context, "research");
+    expect(
+      container.querySelector('[data-chat-model-option="anthropic/claude-sonnet-5"]'),
+    ).not.toBeNull();
+    expect(container.querySelector('[data-chat-model-option="openai/gpt-5.6-luna"]')).toBeNull();
+  });
+
+  it("coalesces equivalent concurrent metadata loads", async () => {
+    const pending = deferred<{ models: ModelCatalogEntry[] }>();
+    const { context, request } = contextWith([]);
+    request.mockReturnValueOnce(pending.promise);
+    const control = new NewSessionModelControl(() => undefined);
+
+    control.load(context, "main", true);
+    control.load(context, "main", true);
+
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    pending.resolve({ models: [] });
   });
 
   it("drops a stored model and its reasoning override when the model is unavailable", async () => {

--- a/ui/src/pages/new-session/model-control.ts
+++ b/ui/src/pages/new-session/model-control.ts
@@ -1,9 +1,7 @@
-import { initialState, Task, TaskStatus } from "@lit/task";
 import {
   DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
   resolveGatewayStartupRetryAfterMs,
 } from "@openclaw/gateway-client/browser";
-import type { ReactiveController, ReactiveControllerHost } from "lit";
 import type { GatewayAgentRow, GatewaySessionRow, ModelCatalogEntry } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import {
@@ -13,12 +11,31 @@ import {
 } from "../../lib/chat/model-ref.ts";
 import { resolveChatThinkingSelectState } from "../../lib/chat/thinking.ts";
 import { normalizeAgentId } from "../../lib/sessions/session-key.ts";
-import { renderChatModelControls } from "../chat/components/chat-model-controls.ts";
+import {
+  renderChatModelControls,
+  type ChatModelCatalogState,
+} from "../chat/components/chat-model-controls.ts";
 import type { NewSessionPreference } from "./preferences.ts";
 
 const NEW_SESSION_METADATA_RETRY_WINDOW_MS = 60_000;
 
 type NewSessionMetadataClient = NonNullable<ApplicationContext["gateway"]["snapshot"]["client"]>;
+type NewSessionMetadataStatus = ChatModelCatalogState["status"];
+type NewSessionMetadataState = {
+  catalog: ModelCatalogEntry[];
+  hasSnapshot: boolean;
+  status: NewSessionMetadataStatus;
+};
+type NewSessionMetadataLoadOptions = {
+  agent?: GatewayAgentRow;
+  preference?: NewSessionPreference | null;
+};
+type NewSessionMetadataLoad = {
+  agentId: string;
+  context: ApplicationContext;
+  options: NewSessionMetadataLoadOptions;
+  selectionGeneration: number;
+};
 
 function abortError(signal: AbortSignal): Error {
   return signal.reason instanceof Error
@@ -144,43 +161,29 @@ function resolveDraftModelTarget(
   };
 }
 
-export class NewSessionModelControl implements ReactiveControllerHost {
+export class NewSessionModelControl {
   private selectionGeneration = 0;
   private agentId = "";
-  private catalog: ModelCatalogEntry[] = [];
+  private metadataState: NewSessionMetadataState = {
+    catalog: [],
+    hasSnapshot: false,
+    status: "idle",
+  };
+  private metadataRequestId = 0;
+  private activeMetadataRequest:
+    | {
+        agentId: string;
+        client: NewSessionMetadataClient;
+        controller: AbortController;
+        id: number;
+      }
+    | undefined;
+  private lastMetadataLoad: NewSessionMetadataLoad | undefined;
   private restoringPreference = false;
   private pendingPreference: NewSessionPreference | null | undefined;
   private pendingAgent: GatewayAgentRow | undefined;
   private pendingContext: ApplicationContext | undefined;
   private pendingSelectionGeneration = 0;
-  private readonly catalogTask = new Task(this, {
-    autoRun: false,
-    args: () =>
-      [null as ApplicationContext["gateway"]["snapshot"]["client"], "" as string] as const,
-    task: ([client, agentId], { signal }) =>
-      client ? requestNewSessionMetadata(client, agentId, signal) : initialState,
-    onComplete: (result) => {
-      this.catalog = Array.isArray(result.models) ? result.models : [];
-      if (this.pendingSelectionGeneration === this.selectionGeneration) {
-        this.restorePreference(this.pendingPreference, this.pendingAgent, this.pendingContext);
-      }
-      this.restoringPreference = false;
-    },
-    onError: () => {
-      this.catalog = [];
-      if (
-        this.pendingSelectionGeneration === this.selectionGeneration &&
-        (this.pendingPreference?.model || this.pendingPreference?.thinkingLevel)
-      ) {
-        // A transport failure says nothing about current availability.
-        // Preserve the requested pair so sessions.create remains the
-        // authoritative validator instead of silently using defaults.
-        this.selected = this.pendingPreference.model ?? "";
-        this.thinkingLevel = this.pendingPreference.thinkingLevel ?? "";
-      }
-      this.restoringPreference = false;
-    },
-  });
   selected = "";
   thinkingLevel = "";
 
@@ -192,54 +195,164 @@ export class NewSessionModelControl implements ReactiveControllerHost {
     }) => void = () => undefined,
   ) {}
 
-  readonly updateComplete = Promise.resolve(true);
+  private get catalog(): ModelCatalogEntry[] {
+    return this.metadataState.catalog;
+  }
 
-  addController(_controller: ReactiveController): void {}
+  private cancelMetadataRequest() {
+    const active = this.activeMetadataRequest;
+    if (!active) {
+      return;
+    }
+    this.activeMetadataRequest = undefined;
+    this.metadataRequestId += 1;
+    active.controller.abort();
+  }
 
-  removeController(_controller: ReactiveController): void {}
-
-  requestUpdate(): void {
+  private updateMetadataState(next: NewSessionMetadataState) {
+    this.metadataState = next;
     this.notify();
   }
 
+  private startMetadataRequest(client: NewSessionMetadataClient, agentId: string) {
+    this.cancelMetadataRequest();
+    const controller = new AbortController();
+    const requestId = ++this.metadataRequestId;
+    this.activeMetadataRequest = {
+      agentId,
+      client,
+      controller,
+      id: requestId,
+    };
+    this.updateMetadataState({
+      ...this.metadataState,
+      status: this.metadataState.hasSnapshot ? "refreshing" : "loading",
+    });
+
+    void requestNewSessionMetadata(client, agentId, controller.signal).then(
+      (result) => {
+        // Aborted transports may still resolve. Only the request that still
+        // owns the control may publish catalog data or restore preferences.
+        if (this.activeMetadataRequest?.id !== requestId) {
+          return;
+        }
+        this.activeMetadataRequest = undefined;
+        this.metadataState = {
+          catalog: Array.isArray(result.models) ? result.models : [],
+          hasSnapshot: true,
+          status: "ready",
+        };
+        if (this.pendingSelectionGeneration === this.selectionGeneration) {
+          this.restorePreference(this.pendingPreference, this.pendingAgent, this.pendingContext);
+        }
+        this.restoringPreference = false;
+        this.notify();
+      },
+      () => {
+        if (this.activeMetadataRequest?.id !== requestId) {
+          return;
+        }
+        this.activeMetadataRequest = undefined;
+        this.metadataState = {
+          ...this.metadataState,
+          status: "error",
+        };
+        if (
+          this.pendingSelectionGeneration === this.selectionGeneration &&
+          (this.pendingPreference?.model || this.pendingPreference?.thinkingLevel)
+        ) {
+          // A transport failure says nothing about current availability.
+          // Preserve the requested pair so sessions.create remains the
+          // authoritative validator instead of silently using defaults.
+          this.selected = this.pendingPreference.model ?? "";
+          this.thinkingLevel = this.pendingPreference.thinkingLevel ?? "";
+        }
+        this.restoringPreference = false;
+        this.notify();
+      },
+    );
+  }
+
+  private readonly retryMetadata = () => {
+    const pending = this.lastMetadataLoad;
+    if (!pending) {
+      return;
+    }
+    this.load(pending.context, pending.agentId, true, {
+      ...pending.options,
+      ...(pending.selectionGeneration === this.selectionGeneration
+        ? {}
+        : { preference: undefined }),
+    });
+  };
+
   invalidate(resetSelection = false) {
-    void this.catalogTask.run([null, ""]);
+    this.cancelMetadataRequest();
     this.restoringPreference = false;
-    this.catalog = [];
     if (resetSelection) {
       this.agentId = "";
       this.selected = "";
       this.thinkingLevel = "";
+      this.lastMetadataLoad = undefined;
+      this.updateMetadataState({
+        catalog: [],
+        hasSnapshot: false,
+        status: "idle",
+      });
+      return;
     }
+    this.updateMetadataState({
+      ...this.metadataState,
+      status: this.metadataState.hasSnapshot ? "error" : "idle",
+    });
   }
 
   reset() {
     this.invalidate(true);
-    this.notify();
   }
 
   load(
     context: ApplicationContext | undefined,
     agentId: string,
     enabled: boolean,
-    options: { agent?: GatewayAgentRow; preference?: NewSessionPreference | null } = {},
+    options: NewSessionMetadataLoadOptions = {},
   ) {
     const snapshot = context?.gateway.snapshot;
     const client = snapshot?.client;
     const normalizedAgentId = normalizeAgentId(agentId);
     if (this.agentId !== normalizedAgentId) {
+      // Catalog availability belongs to an agent. A real owner change clears
+      // the snapshot; same-agent refreshes retain it until replacement.
+      this.cancelMetadataRequest();
       this.agentId = normalizedAgentId;
       this.selected = "";
       this.thinkingLevel = "";
+      this.lastMetadataLoad = undefined;
+      this.metadataState = {
+        catalog: [],
+        hasSnapshot: false,
+        status: "idle",
+      };
     }
     const selectionGeneration = this.selectionGeneration;
-    this.catalog = [];
-    if (snapshot?.phase !== "connected" || !client || !normalizedAgentId || !enabled) {
-      void this.catalogTask.run([null, ""]);
+    if (!context || snapshot?.phase !== "connected" || !client || !normalizedAgentId || !enabled) {
+      this.cancelMetadataRequest();
       this.restoringPreference = false;
+      if (snapshot?.phase !== "connected" && this.metadataState.hasSnapshot) {
+        this.metadataState = {
+          ...this.metadataState,
+          status: "error",
+        };
+      }
       this.notify();
       return;
     }
+    this.lastMetadataLoad = {
+      agentId: normalizedAgentId,
+      context,
+      options,
+      selectionGeneration,
+    };
     this.pendingPreference = options.preference;
     this.pendingAgent = options.agent;
     this.pendingContext = context;
@@ -247,7 +360,14 @@ export class NewSessionModelControl implements ReactiveControllerHost {
     this.restoringPreference = Boolean(
       options.preference?.model || options.preference?.thinkingLevel,
     );
-    void this.catalogTask.run([client, normalizedAgentId]);
+    if (
+      this.activeMetadataRequest?.client === client &&
+      this.activeMetadataRequest.agentId === normalizedAgentId
+    ) {
+      this.notify();
+      return;
+    }
+    this.startMetadataRequest(client, normalizedAgentId);
   }
 
   isRestoringPreference(): boolean {
@@ -392,9 +512,13 @@ export class NewSessionModelControl implements ReactiveControllerHost {
       gatewayAvailable: Boolean(snapshot?.client),
       loading: false,
       modelCatalog: this.catalog,
+      modelCatalogState: {
+        hasSnapshot: this.metadataState.hasSnapshot,
+        ...(this.metadataState.status === "error" ? { onRetry: this.retryMetadata } : {}),
+        status: this.metadataState.status,
+      },
       modelOverrides: { [sessionKey]: this.selected },
       modelSwitching: false,
-      modelsLoading: this.catalogTask.status === TaskStatus.PENDING,
       sending: options.sending,
       sessionKey,
       sessionsResult: sourceResult,

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -4672,6 +4672,60 @@ openclaw-chat-video-player {
   color: var(--muted);
 }
 
+.chat-controls__model-catalog-state {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-height: 36px;
+  padding: 6px 10px;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 55%, transparent);
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.chat-controls__model-catalog-state--empty {
+  min-height: 72px;
+  border-bottom: 0;
+}
+
+.chat-controls__model-catalog-state-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.chat-controls__model-catalog-state-label svg,
+.chat-controls__model-catalog-retry svg {
+  width: 14px;
+  height: 14px;
+  flex: 0 0 14px;
+}
+
+.chat-controls__model-catalog-retry {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  min-height: 28px;
+  padding: 0 8px;
+  border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.chat-controls__model-catalog-retry:hover,
+.chat-controls__model-catalog-retry:focus-visible {
+  border-color: color-mix(in srgb, var(--text) 28%, var(--border));
+  background: var(--bg-hover);
+  outline: none;
+}
+
 .chat-controls__model-reset {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users starting a new Control UI session could see a
plausible one-model picker when `chat.metadata` timed out or failed, even
though model availability was unknown and the Gateway catalog contained more
models.

## Why This Change Was Made

The new-session model control now owns an explicit metadata state machine for
loading, refreshing, ready, empty, and error states. It preserves a successful
same-agent catalog during refresh, clears it at agent/owner boundaries,
coalesces equivalent in-flight loads, and keeps configured preferences without
presenting them as fetched availability.

The `chat.metadata` RPC contract and Gateway metadata ownership are unchanged.

## User Impact

The model picker now reports loading and failure states truthfully, offers a
compact retry action, keeps valid stale results during same-agent refresh, and
recovers to the complete catalog after metadata becomes available.

## Evidence

AI-assisted: Codex.

- Red browser proof on canonical base
  `50c7444edf4be40a075d3689bec8fd5b676c2843`: an actual Gateway response
  containing three models was delayed beyond the browser timeout, and the UI
  rendered one selectable configured-default model.
  - Provider: Crabbox wrapper with Blacksmith Testbox backend
  - Lease: `tbx_01kz7xdf4z3d1480qqrf2mdbwg`
  - Run: https://github.com/openclaw/openclaw/actions/runs/30970629933
- Green browser proof at
  `94e5bb8d207e4452619c27b7839f0cc838f590ff`: the same delayed three-model
  response rendered `Models unavailable` with zero options; retry issued one
  second request and rendered all three models. Desktop and mobile screenshots
  and a raw browser recording were captured.
  - Provider: Crabbox wrapper with Blacksmith Testbox backend
  - Lease: `tbx_01kz8011xnh9addq3ebm6bq65z`
  - Run: https://github.com/openclaw/openclaw/actions/runs/30972852721
  - Final branch head `47dcbb57ddf958ac4804d4405f82b5ac035a1455`
    has the identical stable patch ID; the intervening canonical commit only
    changed daemon service-path and usage-rollup files.
- Focused Vitest: 51 passed across
  `ui/src/lib/chat/model-select-state.test.ts` and
  `ui/src/pages/new-session/model-control.test.ts`.
- Focused Playwright: 6 passed in
  `ui/src/e2e/new-session-page.catalog-reconnect.e2e.test.ts`.
- Changed-surface gate passed formatting, i18n verification, core/UI
  typechecks, dead-export scans, and lint.
- Final autoreview: clean, no accepted/actionable findings; TruffleHog clean.
