### PR TITLE
fix(agents): keep exact NO_REPLY silent instead of mirroring messaging-tool text

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.messages.test-support.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.test-support.ts
@@ -39,10 +39,6 @@ type EmbeddedSubscribeMessagesTestApi = {
       visibleDelta: string;
     },
   ): { hold: boolean; text: string };
-  resolveSilentReplyFallbackText(params: {
-    text: unknown;
-    messagingToolSentTexts: string[];
-  }): string;
 };
 
 function getTestApi(): EmbeddedSubscribeMessagesTestApi {
@@ -78,11 +74,4 @@ export function resolveCurrentSourceMessagingToolPartial(
   },
 ): { hold: boolean; text: string } {
   return getTestApi().resolveCurrentSourceMessagingToolPartial(state, params);
-}
-
-export function resolveSilentReplyFallbackText(params: {
-  text: unknown;
-  messagingToolSentTexts: string[];
-}): string {
-  return getTestApi().resolveSilentReplyFallbackText(params);
 }

--- a/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
@@ -16,7 +16,6 @@ import {
   buildAssistantStreamData,
   recordPendingAssistantReplyDirectives,
   resolveCurrentSourceMessagingToolPartial,
-  resolveSilentReplyFallbackText,
 } from "./embedded-agent-subscribe.handlers.messages.test-support.js";
 import type { EmbeddedAgentSubscribeContext } from "./embedded-agent-subscribe.handlers.types.js";
 import {
@@ -236,50 +235,6 @@ function createMessageToolEnvelope(message: string, args: Record<string, unknown
     },
   });
 }
-
-describe("resolveSilentReplyFallbackText", () => {
-  it("replaces NO_REPLY with latest messaging tool text when available", () => {
-    expect(
-      resolveSilentReplyFallbackText({
-        text: "NO_REPLY",
-        messagingToolSentTexts: ["first", "final delivered text"],
-      }),
-    ).toBe("final delivered text");
-  });
-
-  it("keeps original text when response is not NO_REPLY", () => {
-    expect(
-      resolveSilentReplyFallbackText({
-        text: "normal assistant reply",
-        messagingToolSentTexts: ["final delivered text"],
-      }),
-    ).toBe("normal assistant reply");
-  });
-
-  it("keeps NO_REPLY when there is no messaging tool text to mirror", () => {
-    expect(
-      resolveSilentReplyFallbackText({
-        text: "NO_REPLY",
-        messagingToolSentTexts: [],
-      }),
-    ).toBe("NO_REPLY");
-  });
-
-  it("tolerates malformed text payloads without throwing", () => {
-    expect(
-      resolveSilentReplyFallbackText({
-        text: undefined,
-        messagingToolSentTexts: ["final delivered text"],
-      }),
-    ).toBe("");
-    expect(
-      resolveSilentReplyFallbackText({
-        text: "NO_REPLY",
-        messagingToolSentTexts: [42 as unknown as string],
-      }),
-    ).toBe("42");
-  });
-});
 
 describe("hasAssistantVisibleReply", () => {
   it("treats audio-only payloads as visible", () => {
@@ -1704,6 +1659,74 @@ describe("handleMessageEnd", () => {
       expect(ctx.finalizeAssistantTexts).toHaveBeenCalledWith(expect.objectContaining({ text }));
     },
   );
+
+  it("keeps exact NO_REPLY silent after a user-facing message send followed by sessions_send (#119383)", () => {
+    const emitBlockReply = vi.fn();
+    const finalizeAssistantTexts = vi.fn();
+    const ctx = createMessageEndContext({
+      emitBlockReply,
+      finalizeAssistantTexts,
+      consumeReplyDirectives: vi.fn((text: string) => ({ text })),
+      state: {
+        blockBuffer: "",
+        deltaBuffer: "",
+        messagingToolSentTexts: ["<user-facing reply>", "<internal escalation note>"],
+        messagingToolSentTextsNormalized: [
+          "<user-facing reply>",
+          "<internal escalation note>",
+        ],
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "whatsapp",
+            to: "user:123",
+            text: "<user-facing reply>",
+          },
+        ],
+      },
+    });
+
+    void endMessage(ctx, {
+      message: { role: "assistant", content: [{ type: "text", text: "NO_REPLY" }] },
+    });
+
+    // The exact silent token must never be rewritten to the sessions_send body:
+    // the final assistant text keeps NO_REPLY and no block reply carries the note.
+    expect(finalizeAssistantTexts).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "NO_REPLY" }),
+    );
+    for (const call of emitBlockReply.mock.calls) {
+      expect(JSON.stringify(call)).not.toContain("<internal escalation note>");
+    }
+  });
+
+  it("keeps exact NO_REPLY silent when only sessions_send delivered (#119383)", () => {
+    const emitBlockReply = vi.fn();
+    const finalizeAssistantTexts = vi.fn();
+    const ctx = createMessageEndContext({
+      emitBlockReply,
+      finalizeAssistantTexts,
+      consumeReplyDirectives: vi.fn((text: string) => ({ text })),
+      state: {
+        blockBuffer: "",
+        deltaBuffer: "",
+        messagingToolSentTexts: ["<internal escalation note>"],
+        messagingToolSentTextsNormalized: ["<internal escalation note>"],
+        messagingToolSentTargets: [],
+      },
+    });
+
+    void endMessage(ctx, {
+      message: { role: "assistant", content: [{ type: "text", text: "NO_REPLY" }] },
+    });
+
+    expect(finalizeAssistantTexts).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "NO_REPLY" }),
+    );
+    for (const call of emitBlockReply.mock.calls) {
+      expect(JSON.stringify(call)).not.toContain("<internal escalation note>");
+    }
+  });
 
   it.each([
     {

--- a/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
@@ -1671,10 +1671,7 @@ describe("handleMessageEnd", () => {
         blockBuffer: "",
         deltaBuffer: "",
         messagingToolSentTexts: ["<user-facing reply>", "<internal escalation note>"],
-        messagingToolSentTextsNormalized: [
-          "<user-facing reply>",
-          "<internal escalation note>",
-        ],
+        messagingToolSentTextsNormalized: ["<user-facing reply>", "<internal escalation note>"],
         messagingToolSentTargets: [
           {
             tool: "message",

--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -446,23 +446,6 @@ function copyPartialBlockState(
   target.pendingTagFragment = source.pendingTagFragment;
 }
 
-/** Replaces a silent-reply token with the latest sent messaging-tool text when available. */
-function resolveSilentReplyFallbackText(params: {
-  text: unknown;
-  messagingToolSentTexts: string[];
-}): string {
-  const text = coerceChatContentText(params.text);
-  const trimmed = text.trim();
-  if (trimmed !== SILENT_REPLY_TOKEN) {
-    return text;
-  }
-  const fallback = coerceChatContentText(params.messagingToolSentTexts.at(-1)).trim();
-  if (!fallback) {
-    return text;
-  }
-  return fallback;
-}
-
 function clearPendingToolMedia(
   state: Pick<
     EmbeddedAgentSubscribeState,
@@ -1257,7 +1240,6 @@ if (process.env.VITEST || process.env.NODE_ENV === "test") {
     buildAssistantStreamData,
     recordPendingAssistantReplyDirectives,
     resolveCurrentSourceMessagingToolPartial,
-    resolveSilentReplyFallbackText,
   };
 }
 
@@ -1357,10 +1339,10 @@ export function handleMessageEnd(
     ? ctx.stripBlockTags(visibleText, { thinking: false, final: false }, { final: true })
     : visibleText;
 
-  const text = resolveSilentReplyFallbackText({
-    text: finalVisibleText,
-    messagingToolSentTexts: ctx.state.messagingToolSentTexts,
-  });
+  // Exact NO_REPLY stays silent. The legacy rewrite (silentReplyRewrite) was
+  // removed by contract; mirroring messaging-tool text here leaked internal
+  // sessions_send bodies into the originating user channel (#119383).
+  const text = finalVisibleText;
   const rawThinking =
     ctx.state.includeReasoning || ctx.state.streamReasoning
       ? extractAssistantThinking(assistantMessage) || extractThinkingFromTaggedText(rawText)

--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -1340,8 +1340,8 @@ export function handleMessageEnd(
     : visibleText;
 
   // Exact NO_REPLY stays silent. The legacy rewrite (silentReplyRewrite) was
-  // removed by contract; mirroring messaging-tool text here leaked internal
-  // sessions_send bodies into the originating user channel (#119383).
+  // removed by contract; global messaging-tool send evidence is not a
+  // user-route reply and must never be mirrored into the final payload.
   const text = finalVisibleText;
   const rawThinking =
     ctx.state.includeReasoning || ctx.state.streamReasoning


### PR DESCRIPTION
## What Problem This Solves

An agent turn that sends a user reply via the `message` tool, escalates via `sessions_send`, and ends with exact `NO_REPLY` can deliver the internal `sessions_send` body to the originating user channel.
- Problem: Exact final `NO_REPLY` is rewritten to the last global messaging-tool text (`messagingToolSentTexts.at(-1)`). Successful `sessions_send` bodies are recorded in that global list (they are "messaging sends") but carry no channel route target, so an internal escalation note becomes the final assistant text; final-payload dedupe compares against route-scoped evidence (`routeSentTexts`) and cannot suppress it, delivering confidential internal content to the user (production WhatsApp reports, booking/pricing/contact leakage).
- Solution: Remove the obsolete generic rewrite. Exact `NO_REPLY` stays silent, matching the shipped contract (`silentReplyRewrite` removed; "exact NO_REPLY is no longer rewritten to visible fallback text") and the existing final-payload normalizer, which already treats exact `NO_REPLY` as deliberate silence.
- What changed: `src/agents/embedded-agent-subscribe.handlers.messages.ts` (deleted `resolveSilentReplyFallbackText` and its call site; `handleMessageEnd` keeps `finalVisibleText`), `src/agents/embedded-agent-subscribe.handlers.messages.test-support.ts` (removed mirror export), `src/agents/embedded-agent-subscribe.handlers.messages.test.ts` (removed the unsafe-rewrite unit tests; added message-tool + `sessions_send` + `NO_REPLY` regression cases).
- What did NOT change: `messagingToolSentTexts` / `messagingToolSentTargets` evidence recording (dedupe, restart-recovery and CLI evidence keep working); dedupe and delivery modules; channel/provider/tool behavior; no config surface.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #119383
- [x] This PR fixes a bug or regression

## Motivation

Exact `NO_REPLY` is the model's explicit "stay silent" token. The legacy rewrite (`silentReplyRewrite`) was removed by the Doctor migration contract, but a carried-forward generic rewrite still mirrored the latest global messaging-tool text into the final assistant payload. Because `sessions_send` bodies are classified as messaging sends (text recorded globally) yet never get a channel route target (`extractMessagingToolSend` has no `sessions_send` branch), the escalation note became the fallback text, escaped the route-scoped final dedupe, and was delivered verbatim to the end user. ClawSweeper rates this `P1`/`impact:security`/`impact:message-loss` and recommends removing the obsolete rewrite rather than adding a `sessions_send` exception or route heuristic.

## Evidence

- Behavior addressed: An agent turn ending in exact `NO_REPLY` after `message(send)` + `sessions_send` no longer rewrites the silent token into the `sessions_send` body; the final payload normalizes to silence and nothing is delivered to the originating channel.
- Real environment tested: Linux x86_64, Node v22.22.3, branch `fix/no-reply-fallback-leak-119383` (head `701acf2802e`, base `f0a74970ecd`). The proof script drives the real production pipeline (`subscribeEmbeddedAgentSession` → `tool_execution_start/end` tracking → `handleMessageEnd`, then `resolveMessagingToolPayloadDedupe` / `filterMessagingToolDuplicates` / `normalizeReplyPayload`), running once against `origin/main` (before) and once against the fix branch (after).
- Exact steps or command run after this patch:
  - `node --import tsx /media/vdb/code/github/contributions/pr-119383-evidence/proof-no-reply-leak.mts <checkout>` (before: `origin/main`; after: fix branch)
  - Scenario: `message({action:"send", channel:"qa-channel", target:"user:1", message:"<user-facing reply>"})` → `sessions_send({agentId:"ops", sessionKey:"ops-session", message:"<internal escalation note>"})` → final assistant text `NO_REPLY`
- Evidence after fix:

```console
=== proof run: <fix branch checkout> ===
{
  "finalText": "NO_REPLY",
  "blockReplyTexts": [],
  "routeSentTexts": ["<user-facing reply>"],
  "keptPayloadTexts": ["NO_REPLY"],
  "deliveredToUser": null
}
--- assertions ---
PASS  route-scoped sent texts contain the user-facing reply but never the internal note
PASS  exact NO_REPLY is preserved as the final assistant text (no rewrite)
PASS  AFTER-FIX: final payload normalizes to silence - nothing is delivered to the user
PASS  AFTER-FIX: no block reply carries the internal note
```

Before-fix comparison (`origin/main`, same script):

```console
=== proof run: <origin/main checkout> ===
{
  "finalText": "<internal escalation note>",
  "blockReplyTexts": [],
  "routeSentTexts": ["<user-facing reply>"],
  "keptPayloadTexts": ["<internal escalation note>"],
  "deliveredToUser": "<internal escalation note>"
}
--- assertions ---
PASS  route-scoped sent texts contain the user-facing reply but never the internal note
PASS  BEFORE-FIX LEAK reproduced: internal note survives dedupe and is delivered to the user
```

Behavior matrix (final assistant text => final payload delivered to the originating user):

```
message(send) + sessions_send + NO_REPLY (before fix)  => "<internal escalation note>" delivered (LEAK)
message(send) + sessions_send + NO_REPLY (after fix)   => null (silent, only the message-tool reply was delivered)
sessions_send only + NO_REPLY (after fix)              => null (silent)
normal visible reply text (unchanged)                  => visible reply delivered as before
```

Automated checks: `embedded-agent-subscribe.handlers.messages.test.ts` 70/70 (2 new regression cases); related suites 237/237; CI-like shard `agentic-agents-core-subagents` 57 files / 1506 tests passed; `oxlint` clean; `pnpm tsgo:test` clean; no lockfile changes.
- Observed result after fix:
  1. Final assistant text stays exactly `NO_REPLY` after a successful `message` send + `sessions_send`.
  2. Route-scoped dedupe evidence contains only the user-facing reply; the internal note is never selected as a fallback.
  3. The final payload normalizes to silence (`normalizeReplyPayload` returns null), so no second message reaches the user.
  4. Block-reply path emits no payload carrying the internal note.
  5. Before the fix the same scenario produced a deliverable `<internal escalation note>` payload (leak reproduced).
- What was not tested: Live Telegram/WhatsApp production channels (no external channel credentials used; the QA-channel + real pipeline harness exercises the same reply-delivery code path); cross-provider wire variants of the tool-call envelope (behavior is independent of provider wire format).

## Root Cause

- Cause: `resolveSilentReplyFallbackText` (`src/agents/embedded-agent-subscribe.handlers.messages.ts`) rewrote exact `NO_REPLY` to `messagingToolSentTexts.at(-1)`; `sessions_send` success appends its body to that global list (`embedded-agent-subscribe.handlers.tools.ts`) while `extractMessagingToolSend` returns no route target for `sessions_send`, so final-payload dedupe (route-scoped `routeSentTexts`, `reply-payloads-dedupe.ts`) cannot suppress it. Confidence: clear.
- Provenance: `introduced by` `bb46b79d3c1` (#85341, internalize OpenClaw agent runtime); `made visible by` `43cef3a80ca` (target-evidence recording) and `9641377979f` (route-scoped final dedupe); contradicted by `445ed9b0b40` (silentReplyRewrite removal contract).

## Regression Test Plan

- Unit: `handleMessageEnd` keeps exact `NO_REPLY` (a) after `message` send + `sessions_send` and (b) after `sessions_send` only; no block reply carries the internal note.
- CI-like: `agentic-agents-core-subagents` shard (1506 tests) passed locally.
- Real-pipeline: before/after harness proof (logs above) in `/media/vdb/code/github/contributions/pr-119383-evidence/`.

## User-visible / Behavior Changes

Exact `NO_REPLY` is no longer replaced by messaging-tool text in the final assistant payload/transcript mirror. Channels still receive the actual `message`-tool sends; silence is preserved. This matches the documented `silentReplyRewrite` removal.

## Diagram (if applicable)

```
message(send,user) ──► messagingToolSentTexts + Targets(user)        routeSentTexts=[userReply]
sessions_send(note) ─► messagingToolSentTexts (no target) ✗           (note absent)
final "NO_REPLY"     ─► before: fallback=note ─► dedupe miss ─► delivered to user (LEAK)
                        after:  stays NO_REPLY ─► normalizer drop ─► silent ✓
```

## Security Impact

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No (the fix removes a cross-session content disclosure path)

## Repro + Verification

### Environment

- OS: Linux x86_64
- Runtime: Node v22.22.3
- Model/provider: n/a (scripted provider events through the real embedded-agent pipeline)
- Integration/channel: qa-channel target shape (no external credentials)
- Relevant config: none

### Steps

1. Run the proof script against `origin/main`: `node --import tsx proof-no-reply-leak.mts <before-checkout>`
2. Run the same script against the fix branch.
3. Compare `finalText` / `deliveredToUser`.

### Expected

Before: `finalText` = internal note and `deliveredToUser` = internal note (leak). After: `finalText` = `NO_REPLY` and `deliveredToUser` = null (silent).

### Actual

As shown in the Evidence matrix above.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification

- Verified scenarios: message-send followed by `sessions_send` then `NO_REPLY`; `sessions_send`-only then `NO_REPLY`; normal visible reply unaffected (existing 70 handler tests).
- Edge cases checked: ordering variants (sessions_send after message in the proof; both lists), no-target sends, existing dedupe/normalizer paths.
- What you did NOT verify: live external channels and provider-specific wire formats (not needed for this routing fix).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- [x] Backward compatible? Yes
- [x] Config/env changes? No
- [x] Migration needed? No

## Best-fix Verdict

- **Best fix**: Yes — remove the obsolete generic rewrite; the Doctor migration contract and final normalizer already define exact `NO_REPLY` as silence (ClawSweeper's recommended shape).
- **Refactor needed**: No — the change is a bounded deletion; no larger refactor is required.
- **Alternative considered**: (1) Make the fallback select the last route-evidenced target text — rejected: keeps a generic rewrite that contradicts the documented contract and still allows cross-route echoes. (2) Exclude `sessions_send` from `messagingToolSentTexts` — rejected: breaks dedupe evidence for block-reply suppression and other lifecycle consumers, and alone does not stop the leak.

## AI Assistance

- **AI-assisted**: Yes
- **Co-Authored-By**: Claude Opus 4.6 <noreply@anthropic.com>
- **Human confirmed understanding of code changes**: Yes
- **AI prompts / session excerpts**: Available in the contribution session log (issue #119383 workflow).

## Risks and Mitigations

**Highest risk area**: transcript/stream mirror change — after a `message`-tool reply the final assistant text shows `NO_REPLY` instead of the mirrored tool text. Mitigation: this is the documented `silentReplyRewrite` contract (Doctor migration + changelog); ClawSweeper explicitly endorses deletion; the `message`-tool reply itself still reaches the channel, and the existing normalizer/dedupe layers already handle exact `NO_REPLY` payloads (the no-messaging-send case shipped and worked before).

Compatibility: backward compatible, no config/env/migration changes; users relying on the leak behavior are not a supported surface (it is a confidentiality bug).

Fixes #119383
