### PR TITLE
fix(tool-search): preserve dotted target arguments

### DIFF
--- a/src/agents/tool-search-runtime.test.ts
+++ b/src/agents/tool-search-runtime.test.ts
@@ -64,6 +64,24 @@ describe("Tool Search flattened call arguments", () => {
       expected: { command: "list", timeout_ms: 5_000 },
     },
     {
+      label: "dotted args from compatibility providers",
+      arguments: {
+        id: "inspect_resource",
+        "args.path": "projects/example.md",
+        "args.limit": 20,
+      },
+      expected: { path: "projects/example.md", limit: 20 },
+    },
+    {
+      label: "ordinary flattened args precedence over dotted args",
+      arguments: {
+        id: "inspect_resource",
+        "args.path": "projects/dotted.md",
+        path: "projects/flattened.md",
+      },
+      expected: { path: "projects/flattened.md" },
+    },
+    {
       label: "toolId selector with a target id",
       arguments: { toolId: "inspect_resource", id: "record-7" },
       expected: { id: "record-7" },
@@ -84,8 +102,10 @@ describe("Tool Search flattened call arguments", () => {
         id: "inspect_resource",
         args: { command: "nested" },
         command: "flattened",
+        "args.command": "dotted",
+        "args.path": "projects/dotted.md",
       },
-      expected: { command: "nested" },
+      expected: { command: "nested", path: "projects/dotted.md" },
     },
     {
       label: "explicit input precedence",

--- a/src/agents/tool-search-runtime.ts
+++ b/src/agents/tool-search-runtime.ts
@@ -241,9 +241,17 @@ export function readToolSearchCallArgs(
   catalog?: ToolSearchCatalogSession,
 ): { id: string; input: unknown } {
   const params = asToolParamsRecord(args);
+  const dottedInput = Object.fromEntries(
+    Object.entries(params)
+      .filter(([key]) => key.startsWith("args.") && key.length > 5)
+      .map(([key, value]) => [key.slice(5), value]),
+  );
   const nestedInput = params.args ?? params.input;
   if (nestedInput != null) {
-    return { id: readToolSearchId(params), input: nestedInput };
+    return {
+      id: readToolSearchId(params),
+      input: isRecord(nestedInput) ? { ...dottedInput, ...nestedInput } : nestedInput,
+    };
   }
 
   const selectorKeys = ["id", "toolId", "name"] as const;
@@ -279,10 +287,11 @@ export function readToolSearchCallArgs(
     ...matchingSelectors.map(({ key }) => key),
     ...(matchingSelector ? [] : [selector ?? "id"]),
   ]);
+  const targetInputEntries = Object.entries(params).filter(([key]) => !wrapperKeys.has(key));
   const flattenedInput = Object.fromEntries(
-    Object.entries(params).filter(([key]) => !wrapperKeys.has(key)),
+    targetInputEntries.filter(([key]) => !(key.startsWith("args.") && key.length > 5)),
   );
-  return { id, input: flattenedInput };
+  return { id, input: { ...dottedInput, ...flattenedInput } };
 }
 
 function getTelemetry(catalog: ToolSearchCatalogSession) {


### PR DESCRIPTION
Closes #119418

## What Problem This Solves

Fixes an issue where users running Tool Search with providers that flatten nested tool arguments could enter repeated missing-parameter failures. GitHub Copilot Gemini emitted fields such as `args.path` and `args.command`, which reached the selected target tool with the prefix still attached instead of as `path` and `command`.

## Why This Change Was Made

The shared Tool Search call decoder now normalizes non-empty `args.*` compatibility fields at the wrapper boundary. Canonical nested `args` values retain precedence, and the existing ordinary flattened-argument behavior remains unchanged.

## User Impact

Tool Search calls from affected providers can execute the selected target tool instead of retrying until timeout. Correctly nested calls and existing flattened calls continue to behave as before.

## Evidence

- Reproduced before the fix with `github-copilot/gemini-3.1-pro-preview`: 172 tool calls followed by a 300-second timeout.
- Live patched flow completed in 8-17 seconds with 2-3 tool calls, zero failures, and no provider fallback.
- `pnpm test src/agents/tool-search-runtime.test.ts`: 45 tests passed.
- `pnpm exec oxfmt --check src/agents/tool-search-runtime.ts src/agents/tool-search-runtime.test.ts`: passed.
- `pnpm exec oxlint src/agents/tool-search-runtime.ts src/agents/tool-search-runtime.test.ts`: passed.

## AI Assistance

- [x] This change was AI-assisted.
- [x] I reviewed and understand the implementation.
- [x] The focused regression suite was run on the exact submitted commit.


Punchcard-Session: clear-orchard-lantern-bc
