### PR TITLE
fix(qqbot): reject open HTTP error bodies during debug capture

### DIFF
--- a/extensions/qqbot/src/engine/api/media.test.ts
+++ b/extensions/qqbot/src/engine/api/media.test.ts
@@ -451,4 +451,45 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
     expect(tokenManager["getAccessToken"]).not.toHaveBeenCalled();
     expect(client["request"]).not.toHaveBeenCalled();
   });
+
+  it("does not hang when the rejected response body cancel never settles", async () => {
+    fetchWithSsrFGuardMock.mockReset();
+    const { response, release } = mockGuardedResponse("server error", { status: 500 });
+    const captureClone = response.clone();
+    let cancelStarted = false;
+    vi.spyOn(response.body!, "cancel").mockImplementation(() => {
+      cancelStarted = true;
+      // Mimic a debug-capture tee branch: cancellation only settles after the
+      // sibling clone branch is cancelled.
+      return new Promise<void>((resolve) => {
+        void captureClone.body
+          ?.cancel()
+          .catch(() => undefined)
+          .then(resolve);
+      });
+    });
+
+    const client = mockApiClient();
+    const tokenManager = mockTokenManager();
+    const api = new MediaApi(client, tokenManager);
+
+    const start = Date.now();
+    await expect(
+      api.uploadMedia(
+        "c2c",
+        "user-openid",
+        MediaFileType.IMAGE,
+        { appId: "app-id", clientSecret: "client-secret" },
+        { url: "https://cdn.example.com/server-error.png" },
+      ),
+    ).rejects.toThrow("Direct-upload media URL returned HTTP 500");
+
+    // The rejection must return promptly; without the fire-and-forget fix this
+    // would wait indefinitely for the capture sibling branch to cancel.
+    expect(Date.now() - start).toBeLessThan(1000);
+    expect(cancelStarted).toBe(true);
+    expect(release).toHaveBeenCalledOnce();
+    expect(tokenManager["getAccessToken"]).not.toHaveBeenCalled();
+    expect(client["request"]).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/qqbot/src/engine/api/media.test.ts
+++ b/extensions/qqbot/src/engine/api/media.test.ts
@@ -452,44 +452,71 @@ describe("MediaApi.uploadMedia direct URL uploads", () => {
     expect(client["request"]).not.toHaveBeenCalled();
   });
 
-  it("does not hang when the rejected response body cancel never settles", async () => {
+  it("rejects promptly when a capture clone keeps body cancellation pending", async () => {
     fetchWithSsrFGuardMock.mockReset();
-    const { response, release } = mockGuardedResponse("server error", { status: 500 });
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("server error"));
+        },
+      }),
+      { status: 500 },
+    );
     const captureClone = response.clone();
-    let cancelStarted = false;
-    vi.spyOn(response.body!, "cancel").mockImplementation(() => {
-      cancelStarted = true;
-      // Mimic a debug-capture tee branch: cancellation only settles after the
-      // sibling clone branch is cancelled.
-      return new Promise<void>((resolve) => {
-        void captureClone.body
-          ?.cancel()
-          .catch(() => undefined)
-          .then(resolve);
+    const release = vi.fn(async () => {});
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({ response, release });
+
+    const body = response.body!;
+    const originalCancel = body.cancel.bind(body);
+    let cancellation: Promise<void> | undefined;
+    let cancellationSettled = false;
+    const cancellationStarted = new Promise<void>((resolve) => {
+      vi.spyOn(body, "cancel").mockImplementation((reason) => {
+        cancellation = originalCancel(reason).finally(() => {
+          cancellationSettled = true;
+        });
+        resolve();
+        return cancellation;
       });
     });
 
     const client = mockApiClient();
     const tokenManager = mockTokenManager();
     const api = new MediaApi(client, tokenManager);
+    const upload = api.uploadMedia(
+      "c2c",
+      "user-openid",
+      MediaFileType.IMAGE,
+      { appId: "app-id", clientSecret: "client-secret" },
+      { url: "https://cdn.example.com/server-error.png" },
+    );
+    const cancellationPending = Symbol("capture cancellation pending");
 
-    const start = Date.now();
-    await expect(
-      api.uploadMedia(
-        "c2c",
-        "user-openid",
-        MediaFileType.IMAGE,
-        { appId: "app-id", clientSecret: "client-secret" },
-        { url: "https://cdn.example.com/server-error.png" },
-      ),
-    ).rejects.toThrow("Direct-upload media URL returned HTTP 500");
+    try {
+      await cancellationStarted;
+      expect(cancellationSettled).toBe(false);
 
-    // The rejection must return promptly; without the fire-and-forget fix this
-    // would wait indefinitely for the capture sibling branch to cancel.
-    expect(Date.now() - start).toBeLessThan(1000);
-    expect(cancelStarted).toBe(true);
-    expect(release).toHaveBeenCalledOnce();
-    expect(tokenManager["getAccessToken"]).not.toHaveBeenCalled();
-    expect(client["request"]).not.toHaveBeenCalled();
+      const result = await Promise.race([
+        upload.then(
+          () => undefined,
+          (error: unknown) => error,
+        ),
+        new Promise<symbol>((resolve) => {
+          setImmediate(() => resolve(cancellationPending));
+        }),
+      ]);
+
+      expect(result).not.toBe(cancellationPending);
+      expect(result).toMatchObject({
+        message: "Direct-upload media URL returned HTTP 500",
+      });
+      expect(release).toHaveBeenCalledOnce();
+      expect(tokenManager["getAccessToken"]).not.toHaveBeenCalled();
+      expect(client["request"]).not.toHaveBeenCalled();
+    } finally {
+      void captureClone.body?.cancel().catch(() => undefined);
+      await cancellation?.catch(() => undefined);
+      await upload.catch(() => undefined);
+    }
   });
 });

--- a/extensions/qqbot/src/engine/api/media.ts
+++ b/extensions/qqbot/src/engine/api/media.ts
@@ -161,7 +161,10 @@ export async function downloadDirectUploadUrl(
   const { response, release } = await fetchDirectUploadDownload(parsed.toString());
   try {
     if (!response.ok) {
-      await response.body?.cancel().catch(() => undefined);
+      // A debug-capture clone can keep the tee open, so waiting for cancel would
+      // hang before the error is returned. Fire-and-forget matches the timeout
+      // path above and the pattern used across other plugins.
+      void response.body?.cancel().catch(() => undefined);
       throw new Error(`Direct-upload media URL returned HTTP ${response.status}`);
     }
     return await readDirectUploadResponse(response, opts.maxBytes ?? MAX_UPLOAD_SIZE);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where QQ Bot media uploads from a URL could hang instead of returning an upstream HTTP error when debug proxy capture retained an open clone of the response body.

## Why This Change Was Made

`downloadDirectUploadUrl` now starts cancellation of a non-OK response body without awaiting the tee-bound cancellation promise, then throws the HTTP error while the existing `finally` block releases the guarded dispatcher. The regression test uses a native open `ReadableStream`, `Response.clone()`, and the original `cancel()` implementation to prove the capture sibling cannot block the caller.

Regression provenance: #110008, squash commit `17643f385085d68d104d216eae1a08785da4b3ec`, added the awaited cancellation that becomes pending when debug capture owns the sibling tee branch.

## User Impact

Operators using QQ Bot URL media uploads receive the upstream HTTP 4xx/5xx failure promptly under debug capture instead of an indefinitely pending upload. No QQ API request or token lookup runs after the download error.

## Evidence

- Deterministic red/green tee proof:
  - With the repaired fire-and-forget cancellation, the focused QQ Bot suite passes.
  - Temporarily restoring `await response.body?.cancel()` makes the regression test fail on the next `setImmediate` turn because the native tee cancellation is still pending.
- Real debug-capture proof:
  - A local HTTP server returned an HTTP 500 body and intentionally kept it open.
  - `downloadDirectUploadUrl` rejected with `Direct-upload media URL returned HTTP 500` in 182 ms.
  - At rejection time, capture contained only the redacted request event; after the server ended the body, the response event completed and remained redacted.
- Local focused proof:
  - `node scripts/run-vitest.mjs extensions/qqbot/src/engine/api/media.test.ts src/proxy-capture/runtime.test.ts`
  - 40 tests passed across 2 Vitest shards.
  - `oxfmt --check` and `git diff --check` passed.
- Blacksmith Testbox:
  - Lease `tbx_01kz8d7ynjgbv4q2qdangbbc9b`
  - Run: https://github.com/openclaw/openclaw/actions/runs/30985236695
  - Fresh Linux install; the same 40 focused tests passed.
- P1 autoreview: no findings; patch correct with 0.96 confidence.

Production delta: `+4/-1`. Test delta: `+68/-0`. No config, SDK, protocol, storage, migration, or product-boundary change.

Punchcard-Session: clear-orchard-lantern-bc
