### PR TITLE
fix(web-readability): calibrate nesting depth cap to keep parse bounded

### DIFF
--- a/extensions/web-readability/package.json
+++ b/extensions/web-readability/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "dependencies": {
     "@mozilla/readability": "0.6.0",
+    "htmlparser2": "10.1.0",
     "linkedom": "0.18.13"
   },
   "devDependencies": {

--- a/extensions/web-readability/web-content-extractor.test.ts
+++ b/extensions/web-readability/web-content-extractor.test.ts
@@ -78,6 +78,30 @@ describe("web readability extractor", () => {
     expect(performance.now() - started).toBeLessThan(1_000);
   });
 
+  it("does not count tag literals inside raw text elements", async () => {
+    const extractor = createReadabilityWebContentExtractor();
+    const script = `<script>${'render("<div>");'.repeat(900)}</script>`;
+    const html = SAMPLE_HTML.replace("<article>", `<article>${script}`);
+    const result = await extractor.extract({
+      html,
+      url: "https://example.com/article",
+      extractMode: "markdown",
+    });
+    expect(requireReadabilityResult(result).text).toContain("Main content starts here");
+  });
+
+  it("still counts nesting inside noscript", async () => {
+    const extractor = createReadabilityWebContentExtractor();
+    const nested = `<noscript>${"<div>".repeat(1_000)}deep${"</div>".repeat(1_000)}</noscript>`;
+    const html = SAMPLE_HTML.replace("<article>", `<article>${nested}`);
+    const result = await extractor.extract({
+      html,
+      url: "https://example.com/article",
+      extractMode: "markdown",
+    });
+    expect(result).toBeNull();
+  });
+
   it("does not count void tags toward the nesting limit", async () => {
     const extractor = createReadabilityWebContentExtractor();
     const html = SAMPLE_HTML.replace("<article>", `<article>${"<BR>".repeat(3100)}`);

--- a/extensions/web-readability/web-content-extractor.test.ts
+++ b/extensions/web-readability/web-content-extractor.test.ts
@@ -64,6 +64,20 @@ describe("web readability extractor", () => {
     expect(extracted.title).toBe("Example Article");
   });
 
+  it("rejects deeply nested markup above the estimated depth cap", async () => {
+    const extractor = createReadabilityWebContentExtractor();
+    const nested = `${"<div>".repeat(1_000)}deep${"</div>".repeat(1_000)}`;
+    const html = SAMPLE_HTML.replace("<article>", `<article>${nested}`);
+    const started = performance.now();
+    const result = await extractor.extract({
+      html,
+      url: "https://example.com/article",
+      extractMode: "markdown",
+    });
+    expect(result).toBeNull();
+    expect(performance.now() - started).toBeLessThan(1_000);
+  });
+
   it("does not count void tags toward the nesting limit", async () => {
     const extractor = createReadabilityWebContentExtractor();
     const html = SAMPLE_HTML.replace("<article>", `<article>${"<BR>".repeat(3100)}`);

--- a/extensions/web-readability/web-content-extractor.test.ts
+++ b/extensions/web-readability/web-content-extractor.test.ts
@@ -90,6 +90,30 @@ describe("web readability extractor", () => {
     expect(requireReadabilityResult(result).text).toContain("Main content starts here");
   });
 
+  it("does not count tag literals inside quoted attributes", async () => {
+    const extractor = createReadabilityWebContentExtractor();
+    const attr = `data-template="${"<div>".repeat(900)}"`;
+    const html = SAMPLE_HTML.replace("<article>", `<article ${attr}>`);
+    const result = await extractor.extract({
+      html,
+      url: "https://example.com/article",
+      extractMode: "markdown",
+    });
+    expect(requireReadabilityResult(result).text).toContain("Main content starts here");
+  });
+
+  it("resumes the raw text skip only at a real closing tag boundary", async () => {
+    const extractor = createReadabilityWebContentExtractor();
+    const script = `<script>"</scripture>";${'render("<div>");'.repeat(900)}</script>`;
+    const html = SAMPLE_HTML.replace("<article>", `<article>${script}`);
+    const result = await extractor.extract({
+      html,
+      url: "https://example.com/article",
+      extractMode: "markdown",
+    });
+    expect(requireReadabilityResult(result).text).toContain("Main content starts here");
+  });
+
   it("still counts nesting inside noscript", async () => {
     const extractor = createReadabilityWebContentExtractor();
     const nested = `<noscript>${"<div>".repeat(1_000)}deep${"</div>".repeat(1_000)}</noscript>`;

--- a/extensions/web-readability/web-content-extractor.test.ts
+++ b/extensions/web-readability/web-content-extractor.test.ts
@@ -114,6 +114,19 @@ describe("web readability extractor", () => {
     expect(requireReadabilityResult(result).text).toContain("Main content starts here");
   });
 
+  it("counts nesting after a raw text body containing length-changing unicode", async () => {
+    const extractor = createReadabilityWebContentExtractor();
+    const script = `<script>${"İ".repeat(3_000)}</script>`;
+    const nested = `${"<div>".repeat(1_000)}deep${"</div>".repeat(1_000)}`;
+    const html = SAMPLE_HTML.replace("<article>", `<article>${script}${nested}`);
+    const result = await extractor.extract({
+      html,
+      url: "https://example.com/article",
+      extractMode: "markdown",
+    });
+    expect(result).toBeNull();
+  });
+
   it("still counts nesting inside noscript", async () => {
     const extractor = createReadabilityWebContentExtractor();
     const nested = `<noscript>${"<div>".repeat(1_000)}deep${"</div>".repeat(1_000)}</noscript>`;

--- a/extensions/web-readability/web-content-extractor.test.ts
+++ b/extensions/web-readability/web-content-extractor.test.ts
@@ -104,6 +104,77 @@ describe("web readability extractor", () => {
     expect(performance.now() - started).toBeLessThan(1_000);
   });
 
+  it("does not pop for slash-suffixed closing tag names", async () => {
+    const extractor = createReadabilityWebContentExtractor();
+    const html = SAMPLE_HTML.replace("<article>", `<article>${"<div></div/>".repeat(1_000)}`);
+    const result = await extractor.extract({
+      html,
+      url: "https://example.com/article",
+      extractMode: "markdown",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("counts markup after self-closed raw-text tag syntax", async () => {
+    const extractor = createReadabilityWebContentExtractor();
+    const nested = `<script/>${"<div>".repeat(1_000)}</script>`;
+    const html = SAMPLE_HTML.replace("<article>", `<article>${nested}`);
+    const result = await extractor.extract({
+      html,
+      url: "https://example.com/article",
+      extractMode: "markdown",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("honors self-closing tags inside foreign content", async () => {
+    const extractor = createReadabilityWebContentExtractor();
+    const nested = `<svg>${"<g/><div></g>".repeat(1_000)}</svg>`;
+    const html = SAMPLE_HTML.replace("<article>", `<article>${nested}`);
+    const result = await extractor.extract({
+      html,
+      url: "https://example.com/article",
+      extractMode: "markdown",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("does not let implicitly closed elements pop real nesting later", async () => {
+    const extractor = createReadabilityWebContentExtractor();
+    const nested = "<p><div></p>".repeat(1_000);
+    const html = SAMPLE_HTML.replace("<article>", `<article>${nested}`);
+    const result = await extractor.extract({
+      html,
+      url: "https://example.com/article",
+      extractMode: "markdown",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("does not let malformed attribute quotes hide following markup", async () => {
+    const extractor = createReadabilityWebContentExtractor();
+    const nested = `<div '>${"<div>".repeat(1_000)}`;
+    const html = SAMPLE_HTML.replace("<article>", `<article>${nested}`);
+    const result = await extractor.extract({
+      html,
+      url: "https://example.com/article",
+      extractMode: "markdown",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("does not treat truncated raw-text tag names as raw-text elements", async () => {
+    const extractor = createReadabilityWebContentExtractor();
+    const nested = `<script=>${"<div>".repeat(1_000)}</script>`;
+    const html = SAMPLE_HTML.replace("<article>", `<article>${nested}`);
+    const result = await extractor.extract({
+      html,
+      url: "https://example.com/article",
+      extractMode: "markdown",
+    });
+    expect(result).toBeNull();
+  });
+
   it("stays bounded when unmatched closing tags flood a nearly full stack", async () => {
     const extractor = createReadabilityWebContentExtractor();
     const flood = `${"<div>".repeat(790)}${"</x>".repeat(180_000)}${"<div>".repeat(20)}`;

--- a/extensions/web-readability/web-content-extractor.test.ts
+++ b/extensions/web-readability/web-content-extractor.test.ts
@@ -78,6 +78,44 @@ describe("web readability extractor", () => {
     expect(performance.now() - started).toBeLessThan(1_000);
   });
 
+  it("rejects self-closed non-void tags that htmlparser2 keeps open", async () => {
+    const extractor = createReadabilityWebContentExtractor();
+    const html = SAMPLE_HTML.replace("<article>", `<article>${"<div/>".repeat(1_000)}`);
+    const started = performance.now();
+    const result = await extractor.extract({
+      html,
+      url: "https://example.com/article",
+      extractMode: "markdown",
+    });
+    expect(result).toBeNull();
+    expect(performance.now() - started).toBeLessThan(1_000);
+  });
+
+  it("rejects unmatched closing tags that do not pop an open element", async () => {
+    const extractor = createReadabilityWebContentExtractor();
+    const html = SAMPLE_HTML.replace("<article>", `<article>${"<div></x>".repeat(1_000)}`);
+    const started = performance.now();
+    const result = await extractor.extract({
+      html,
+      url: "https://example.com/article",
+      extractMode: "markdown",
+    });
+    expect(result).toBeNull();
+    expect(performance.now() - started).toBeLessThan(1_000);
+  });
+
+  it("extracts many well-formed sibling elements with matching close tags", async () => {
+    const extractor = createReadabilityWebContentExtractor();
+    const siblings = "<div>word</div>".repeat(2_000);
+    const html = SAMPLE_HTML.replace("<article>", `<article>${siblings}`);
+    const result = await extractor.extract({
+      html,
+      url: "https://example.com/article",
+      extractMode: "markdown",
+    });
+    expect(requireReadabilityResult(result).text).toContain("Main content starts here");
+  });
+
   it("does not count tag literals inside raw text elements", async () => {
     const extractor = createReadabilityWebContentExtractor();
     const script = `<script>${'render("<div>");'.repeat(900)}</script>`;

--- a/extensions/web-readability/web-content-extractor.test.ts
+++ b/extensions/web-readability/web-content-extractor.test.ts
@@ -129,7 +129,7 @@ describe("web readability extractor", () => {
 
   it("honors self-closing tags inside foreign content", async () => {
     const extractor = createReadabilityWebContentExtractor();
-    const nested = `<svg>${"<g/><div></g>".repeat(1_000)}</svg>`;
+    const nested = `<math>${"<mrow/><div></mrow>".repeat(1_000)}</math>`;
     const html = SAMPLE_HTML.replace("<article>", `<article>${nested}`);
     const result = await extractor.extract({
       html,

--- a/extensions/web-readability/web-content-extractor.test.ts
+++ b/extensions/web-readability/web-content-extractor.test.ts
@@ -104,6 +104,20 @@ describe("web readability extractor", () => {
     expect(performance.now() - started).toBeLessThan(1_000);
   });
 
+  it("stays bounded when unmatched closing tags flood a nearly full stack", async () => {
+    const extractor = createReadabilityWebContentExtractor();
+    const flood = `${"<div>".repeat(790)}${"</x>".repeat(180_000)}${"<div>".repeat(20)}`;
+    const html = SAMPLE_HTML.replace("<article>", `<article>${flood}`);
+    const started = performance.now();
+    const result = await extractor.extract({
+      html,
+      url: "https://example.com/article",
+      extractMode: "markdown",
+    });
+    expect(result).toBeNull();
+    expect(performance.now() - started).toBeLessThan(150);
+  });
+
   it("extracts many well-formed sibling elements with matching close tags", async () => {
     const extractor = createReadabilityWebContentExtractor();
     const siblings = "<div>word</div>".repeat(2_000);

--- a/extensions/web-readability/web-content-extractor.ts
+++ b/extensions/web-readability/web-content-extractor.ts
@@ -10,6 +10,11 @@ import {
 } from "openclaw/plugin-sdk/web-content-extractor";
 
 const READABILITY_MAX_HTML_CHARS = 1_000_000;
+// Sole guard before a synchronous, uncancellable Readability parse whose cost
+// grows superlinearly with nesting depth: 800 keeps real pages (browsers
+// flatten near depth 512) while bounding the worst accepted parse to a few
+// seconds. Raising it restores multi-minute gateway event-loop stalls on
+// attacker-crafted pages; over-cap pages intentionally use fallback extraction.
 const READABILITY_MAX_ESTIMATED_NESTING_DEPTH = 800;
 const HTML_VOID_TAGS = new Set([
   "area",

--- a/extensions/web-readability/web-content-extractor.ts
+++ b/extensions/web-readability/web-content-extractor.ts
@@ -10,7 +10,7 @@ import {
 } from "openclaw/plugin-sdk/web-content-extractor";
 
 const READABILITY_MAX_HTML_CHARS = 1_000_000;
-const READABILITY_MAX_ESTIMATED_NESTING_DEPTH = 3_000;
+const READABILITY_MAX_ESTIMATED_NESTING_DEPTH = 800;
 const HTML_VOID_TAGS = new Set([
   "area",
   "base",

--- a/extensions/web-readability/web-content-extractor.ts
+++ b/extensions/web-readability/web-content-extractor.ts
@@ -98,19 +98,28 @@ function exceedsEstimatedHtmlNestingDepth(html: string, maxDepth: number): boole
       continue;
     }
     const tagName = html.slice(nameStart, j).toLowerCase();
-    if (HTML_VOID_TAGS.has(tagName)) {
-      continue;
-    }
 
-    let selfClosing = false;
-    for (let k = j; k < len && k < j + 200; k++) {
+    let quote = 0;
+    let k = j;
+    while (k < len) {
       const c = html.charCodeAt(k);
-      if (c === 62) {
-        selfClosing = html.charCodeAt(k - 1) === 47;
+      if (quote !== 0) {
+        if (c === quote) {
+          quote = 0;
+        }
+      } else if (c === 34 || c === 39) {
+        quote = c;
+      } else if (c === 62) {
         break;
       }
+      k += 1;
     }
-    if (selfClosing) {
+    if (k >= len) {
+      return false;
+    }
+    i = k;
+
+    if (HTML_VOID_TAGS.has(tagName) || html.charCodeAt(k - 1) === 47) {
       continue;
     }
 
@@ -121,11 +130,16 @@ function exceedsEstimatedHtmlNestingDepth(html: string, maxDepth: number): boole
 
     if (HTML_RAW_TEXT_TAGS.has(tagName)) {
       lowerHtml ??= html.toLowerCase();
-      const bodyStart = lowerHtml.indexOf(">", j);
-      if (bodyStart < 0) {
-        return false;
+      const needle = `</${tagName}`;
+      let closeStart = lowerHtml.indexOf(needle, k + 1);
+      while (closeStart >= 0) {
+        const after = closeStart + needle.length;
+        const boundary = html.charCodeAt(after);
+        if (after >= len || boundary === 62 || boundary === 47 || boundary <= 32) {
+          break;
+        }
+        closeStart = lowerHtml.indexOf(needle, after);
       }
-      const closeStart = lowerHtml.indexOf(`</${tagName}`, bodyStart + 1);
       if (closeStart < 0) {
         return false;
       }

--- a/extensions/web-readability/web-content-extractor.ts
+++ b/extensions/web-readability/web-content-extractor.ts
@@ -33,6 +33,11 @@ const HTML_VOID_TAGS = new Set([
   "wbr",
 ]);
 
+// Mirrors htmlparser2's raw-text tokenization (linkedom's parser): these
+// bodies become flat text nodes, so tag literals inside them are not DOM
+// nesting. noscript is excluded on purpose; htmlparser2 parses its children.
+const HTML_RAW_TEXT_TAGS = new Set(["script", "style", "title", "textarea", "xmp"]);
+
 const READABILITY_MODULE = "@mozilla/readability";
 const LINKEDOM_MODULE = "linkedom";
 
@@ -45,6 +50,7 @@ const loadReadabilityDeps = createLazyRuntimeModule(() =>
 
 function exceedsEstimatedHtmlNestingDepth(html: string, maxDepth: number): boolean {
   let depth = 0;
+  let lowerHtml: string | undefined;
   const len = html.length;
   for (let i = 0; i < len; i++) {
     if (html.charCodeAt(i) !== 60) {
@@ -111,6 +117,19 @@ function exceedsEstimatedHtmlNestingDepth(html: string, maxDepth: number): boole
     depth += 1;
     if (depth > maxDepth) {
       return true;
+    }
+
+    if (HTML_RAW_TEXT_TAGS.has(tagName)) {
+      lowerHtml ??= html.toLowerCase();
+      const bodyStart = lowerHtml.indexOf(">", j);
+      if (bodyStart < 0) {
+        return false;
+      }
+      const closeStart = lowerHtml.indexOf(`</${tagName}`, bodyStart + 1);
+      if (closeStart < 0) {
+        return false;
+      }
+      i = closeStart - 1;
     }
   }
   return false;

--- a/extensions/web-readability/web-content-extractor.ts
+++ b/extensions/web-readability/web-content-extractor.ts
@@ -48,9 +48,42 @@ const loadReadabilityDeps = createLazyRuntimeModule(() =>
   ]),
 );
 
+// Locate the case-insensitive closing tag for a raw-text element in the
+// original string's index space. Tag names are ASCII, so folding stays
+// length-preserving; scanning a toLowerCase() copy would drift the offset
+// whenever an interior code point lowercases to a different UTF-16 length.
+function findRawTextClose(html: string, tagName: string, from: number): number {
+  const len = html.length;
+  for (let p = from; p < len; p++) {
+    if (html.charCodeAt(p) !== 60 || html.charCodeAt(p + 1) !== 47) {
+      continue;
+    }
+    let q = p + 2;
+    let matched = 0;
+    while (matched < tagName.length) {
+      let c = html.charCodeAt(q);
+      if (c >= 65 && c <= 90) {
+        c += 32;
+      }
+      if (c !== tagName.charCodeAt(matched)) {
+        break;
+      }
+      q += 1;
+      matched += 1;
+    }
+    if (matched < tagName.length) {
+      continue;
+    }
+    const boundary = html.charCodeAt(q);
+    if (q >= len || boundary === 62 || boundary === 47 || boundary <= 32) {
+      return p;
+    }
+  }
+  return -1;
+}
+
 function exceedsEstimatedHtmlNestingDepth(html: string, maxDepth: number): boolean {
   let depth = 0;
-  let lowerHtml: string | undefined;
   const len = html.length;
   for (let i = 0; i < len; i++) {
     if (html.charCodeAt(i) !== 60) {
@@ -129,17 +162,7 @@ function exceedsEstimatedHtmlNestingDepth(html: string, maxDepth: number): boole
     }
 
     if (HTML_RAW_TEXT_TAGS.has(tagName)) {
-      lowerHtml ??= html.toLowerCase();
-      const needle = `</${tagName}`;
-      let closeStart = lowerHtml.indexOf(needle, k + 1);
-      while (closeStart >= 0) {
-        const after = closeStart + needle.length;
-        const boundary = html.charCodeAt(after);
-        if (after >= len || boundary === 62 || boundary === 47 || boundary <= 32) {
-          break;
-        }
-        closeStart = lowerHtml.indexOf(needle, after);
-      }
+      const closeStart = findRawTextClose(html, tagName, k + 1);
       if (closeStart < 0) {
         return false;
       }

--- a/extensions/web-readability/web-content-extractor.ts
+++ b/extensions/web-readability/web-content-extractor.ts
@@ -216,7 +216,10 @@ function exceedsEstimatedHtmlNestingDepth(html: string, maxDepth: number): boole
 
   // Reuse linkedom's exact lexer so malformed tag names, attributes, raw-text
   // bodies, and self-closing syntax cannot diverge from the guarded parser.
-  const tokenizer = new Tokenizer({ xmlMode: false, decodeEntities: true }, callbacks);
+  const tokenizer = new Tokenizer(
+    { xmlMode: false, decodeEntities: true },
+    callbacks,
+  );
   tokenizer.write(html);
   tokenizer.end();
   return exceeded;

--- a/extensions/web-readability/web-content-extractor.ts
+++ b/extensions/web-readability/web-content-extractor.ts
@@ -1,4 +1,5 @@
 // Web Readability plugin module implements web content extractor behavior.
+import { Tokenizer, type TokenizerCallbacks } from "htmlparser2";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import {
   htmlToMarkdown,
@@ -19,12 +20,17 @@ const READABILITY_MAX_ESTIMATED_NESTING_DEPTH = 800;
 const HTML_VOID_TAGS = new Set([
   "area",
   "base",
+  "basefont",
   "br",
   "col",
+  "command",
   "embed",
+  "frame",
   "hr",
   "img",
   "input",
+  "isindex",
+  "keygen",
   "link",
   "meta",
   "param",
@@ -32,11 +38,83 @@ const HTML_VOID_TAGS = new Set([
   "track",
   "wbr",
 ]);
-
-// Mirrors htmlparser2's raw-text tokenization (linkedom's parser): these
-// bodies become flat text nodes, so tag literals inside them are not DOM
-// nesting. noscript is excluded on purpose; htmlparser2 parses its children.
-const HTML_RAW_TEXT_TAGS = new Set(["script", "style", "title", "textarea", "xmp"]);
+const HTML_FOREIGN_CONTEXT_TAGS = new Set(["math", "svg"]);
+const HTML_INTEGRATION_TAGS = new Set([
+  "mi",
+  "mo",
+  "mn",
+  "ms",
+  "mtext",
+  "annotation-xml",
+  "foreignobject",
+  "desc",
+  "title",
+]);
+const HTML_FORM_TAGS = new Set([
+  "input",
+  "option",
+  "optgroup",
+  "select",
+  "button",
+  "datalist",
+  "textarea",
+]);
+const HTML_P_TAG = new Set(["p"]);
+const HTML_TABLE_SECTION_TAGS = new Set(["thead", "tbody"]);
+const HTML_DD_DT_TAGS = new Set(["dd", "dt"]);
+const HTML_RT_RP_TAGS = new Set(["rt", "rp"]);
+// Keep these HTML-mode stack transitions aligned with the pinned htmlparser2
+// Parser; the Tokenizer supplies exact lexical boundaries, while this indexed
+// stack avoids Parser.indexOf scans for attacker-controlled unmatched closes.
+const HTML_OPEN_IMPLIES_CLOSE = new Map<string, Set<string>>([
+  ["tr", new Set(["tr", "th", "td"])],
+  ["th", new Set(["th"])],
+  ["td", new Set(["thead", "th", "td"])],
+  ["body", new Set(["head", "link", "script"])],
+  ["li", new Set(["li"])],
+  ["p", HTML_P_TAG],
+  ["h1", HTML_P_TAG],
+  ["h2", HTML_P_TAG],
+  ["h3", HTML_P_TAG],
+  ["h4", HTML_P_TAG],
+  ["h5", HTML_P_TAG],
+  ["h6", HTML_P_TAG],
+  ["select", HTML_FORM_TAGS],
+  ["input", HTML_FORM_TAGS],
+  ["output", HTML_FORM_TAGS],
+  ["button", HTML_FORM_TAGS],
+  ["datalist", HTML_FORM_TAGS],
+  ["textarea", HTML_FORM_TAGS],
+  ["option", new Set(["option"])],
+  ["optgroup", new Set(["optgroup", "option"])],
+  ["dd", HTML_DD_DT_TAGS],
+  ["dt", HTML_DD_DT_TAGS],
+  ["address", HTML_P_TAG],
+  ["article", HTML_P_TAG],
+  ["aside", HTML_P_TAG],
+  ["blockquote", HTML_P_TAG],
+  ["details", HTML_P_TAG],
+  ["div", HTML_P_TAG],
+  ["dl", HTML_P_TAG],
+  ["fieldset", HTML_P_TAG],
+  ["figcaption", HTML_P_TAG],
+  ["figure", HTML_P_TAG],
+  ["footer", HTML_P_TAG],
+  ["form", HTML_P_TAG],
+  ["header", HTML_P_TAG],
+  ["hr", HTML_P_TAG],
+  ["main", HTML_P_TAG],
+  ["nav", HTML_P_TAG],
+  ["ol", HTML_P_TAG],
+  ["pre", HTML_P_TAG],
+  ["section", HTML_P_TAG],
+  ["table", HTML_P_TAG],
+  ["ul", HTML_P_TAG],
+  ["rt", HTML_RT_RP_TAGS],
+  ["rp", HTML_RT_RP_TAGS],
+  ["tbody", HTML_TABLE_SECTION_TAGS],
+  ["tfoot", HTML_TABLE_SECTION_TAGS],
+]);
 
 const READABILITY_MODULE = "@mozilla/readability";
 const LINKEDOM_MODULE = "linkedom";
@@ -48,85 +126,67 @@ const loadReadabilityDeps = createLazyRuntimeModule(() =>
   ]),
 );
 
-// Locate the case-insensitive closing tag for a raw-text element in the
-// original string's index space. Tag names are ASCII, so folding stays
-// length-preserving; scanning a toLowerCase() copy would drift the offset
-// whenever an interior code point lowercases to a different UTF-16 length.
-function findRawTextClose(html: string, tagName: string, from: number): number {
-  const len = html.length;
-  for (let p = from; p < len; p++) {
-    if (html.charCodeAt(p) !== 60 || html.charCodeAt(p + 1) !== 47) {
-      continue;
-    }
-    let q = p + 2;
-    let matched = 0;
-    while (matched < tagName.length) {
-      let c = html.charCodeAt(q);
-      if (c >= 65 && c <= 90) {
-        c += 32;
-      }
-      if (c !== tagName.charCodeAt(matched)) {
-        break;
-      }
-      q += 1;
-      matched += 1;
-    }
-    if (matched < tagName.length) {
-      continue;
-    }
-    const boundary = html.charCodeAt(q);
-    if (q >= len || boundary === 62 || boundary === 47 || boundary <= 32) {
-      return p;
-    }
-  }
-  return -1;
-}
-
 function exceedsEstimatedHtmlNestingDepth(html: string, maxDepth: number): boolean {
   const openTags: string[] = [];
   const openCounts = new Map<string, number>();
-  const len = html.length;
-  for (let i = 0; i < len; i++) {
-    if (html.charCodeAt(i) !== 60) {
-      continue;
-    }
-    const next = html.charCodeAt(i + 1);
-    if (next === 33 || next === 63) {
-      continue;
-    }
+  const foreignContext = [false];
+  let pendingOpenTag: string | undefined;
+  let exceeded = false;
+  let tokenizer: Tokenizer;
 
-    let j = i + 1;
-    let closing = false;
-    if (html.charCodeAt(j) === 47) {
-      closing = true;
-      j += 1;
+  const popOpenTag = () => {
+    const tagName = openTags.pop();
+    if (tagName) {
+      openCounts.set(tagName, (openCounts.get(tagName) ?? 1) - 1);
     }
+    return tagName;
+  };
 
-    while (j < len && html.charCodeAt(j) <= 32) {
-      j += 1;
+  const openTag = (tagName: string) => {
+    const impliesClose = HTML_OPEN_IMPLIES_CLOSE.get(tagName);
+    while (impliesClose?.has(openTags[openTags.length - 1] ?? "")) {
+      popOpenTag();
     }
+    if (HTML_VOID_TAGS.has(tagName)) {
+      return;
+    }
+    openTags.push(tagName);
+    openCounts.set(tagName, (openCounts.get(tagName) ?? 0) + 1);
+    if (HTML_FOREIGN_CONTEXT_TAGS.has(tagName)) {
+      foreignContext.unshift(true);
+    } else if (HTML_INTEGRATION_TAGS.has(tagName)) {
+      foreignContext.unshift(false);
+    }
+    if (openTags.length > maxDepth) {
+      exceeded = true;
+      tokenizer.pause();
+    }
+  };
 
-    const nameStart = j;
-    while (j < len) {
-      const c = html.charCodeAt(j);
-      const isNameChar =
-        (c >= 65 && c <= 90) ||
-        (c >= 97 && c <= 122) ||
-        (c >= 48 && c <= 57) ||
-        c === 58 ||
-        c === 45;
-      if (!isNameChar) {
-        break;
+  const ignore = () => {};
+  const callbacks: TokenizerCallbacks = {
+    onopentagname(start, endIndex) {
+      pendingOpenTag = html.slice(start, endIndex).toLowerCase();
+      openTag(pendingOpenTag);
+    },
+    onopentagend() {
+      pendingOpenTag = undefined;
+    },
+    onselfclosingtag() {
+      if (
+        foreignContext[0] &&
+        pendingOpenTag &&
+        openTags[openTags.length - 1] === pendingOpenTag
+      ) {
+        popOpenTag();
       }
-      j += 1;
-    }
-
-    if (j === nameStart) {
-      continue;
-    }
-    const tagName = html.slice(nameStart, j).toLowerCase();
-
-    if (closing) {
+      pendingOpenTag = undefined;
+    },
+    onclosetag(start, endIndex) {
+      const tagName = html.slice(start, endIndex).toLowerCase();
+      if (HTML_FOREIGN_CONTEXT_TAGS.has(tagName) || HTML_INTEGRATION_TAGS.has(tagName)) {
+        foreignContext.shift();
+      }
       // Mirror htmlparser2's HTML-mode stack: a close pops back to the nearest
       // matching open tag; an unmatched close pops nothing. A scalar decrement
       // instead let `<div></x>` net to zero while the parser nests every div.
@@ -134,58 +194,33 @@ function exceedsEstimatedHtmlNestingDepth(html: string, maxDepth: number): boole
       // flood of unmatched closes cannot scan every open tag per token; the
       // popping loop only ever walks tags it removes.
       if (!openCounts.get(tagName)) {
-        continue;
+        return;
       }
-      for (let name = openTags.pop(); name !== undefined; name = openTags.pop()) {
-        openCounts.set(name, (openCounts.get(name) ?? 1) - 1);
+      for (let name = popOpenTag(); name !== undefined; name = popOpenTag()) {
         if (name === tagName) {
           break;
         }
       }
-      continue;
-    }
+    },
+    onattribdata: ignore,
+    onattribend: ignore,
+    onattribentity: ignore,
+    onattribname: ignore,
+    oncdata: ignore,
+    oncomment: ignore,
+    ondeclaration: ignore,
+    onend: ignore,
+    onprocessinginstruction: ignore,
+    ontext: ignore,
+    ontextentity: ignore,
+  };
 
-    let quote = 0;
-    let k = j;
-    while (k < len) {
-      const c = html.charCodeAt(k);
-      if (quote !== 0) {
-        if (c === quote) {
-          quote = 0;
-        }
-      } else if (c === 34 || c === 39) {
-        quote = c;
-      } else if (c === 62) {
-        break;
-      }
-      k += 1;
-    }
-    if (k >= len) {
-      return false;
-    }
-    i = k;
-
-    if (HTML_VOID_TAGS.has(tagName)) {
-      continue;
-    }
-
-    // htmlparser2 in HTML mode has recognizeSelfClosing off, so a trailing
-    // slash on a non-void tag is ignored and `<div/>` still opens an element.
-    openTags.push(tagName);
-    openCounts.set(tagName, (openCounts.get(tagName) ?? 0) + 1);
-    if (openTags.length > maxDepth) {
-      return true;
-    }
-
-    if (HTML_RAW_TEXT_TAGS.has(tagName)) {
-      const closeStart = findRawTextClose(html, tagName, k + 1);
-      if (closeStart < 0) {
-        return false;
-      }
-      i = closeStart - 1;
-    }
-  }
-  return false;
+  // Reuse linkedom's exact lexer so malformed tag names, attributes, raw-text
+  // bodies, and self-closing syntax cannot diverge from the guarded parser.
+  tokenizer = new Tokenizer({ xmlMode: false, decodeEntities: true }, callbacks);
+  tokenizer.write(html);
+  tokenizer.end();
+  return exceeded;
 }
 
 async function extractWithReadability(request: WebContentExtractionRequest) {

--- a/extensions/web-readability/web-content-extractor.ts
+++ b/extensions/web-readability/web-content-extractor.ts
@@ -132,7 +132,6 @@ function exceedsEstimatedHtmlNestingDepth(html: string, maxDepth: number): boole
   const foreignContext = [false];
   let pendingOpenTag: string | undefined;
   let exceeded = false;
-  let tokenizer: Tokenizer;
 
   const popOpenTag = () => {
     const tagName = openTags.pop();
@@ -217,7 +216,7 @@ function exceedsEstimatedHtmlNestingDepth(html: string, maxDepth: number): boole
 
   // Reuse linkedom's exact lexer so malformed tag names, attributes, raw-text
   // bodies, and self-closing syntax cannot diverge from the guarded parser.
-  tokenizer = new Tokenizer({ xmlMode: false, decodeEntities: true }, callbacks);
+  const tokenizer = new Tokenizer({ xmlMode: false, decodeEntities: true }, callbacks);
   tokenizer.write(html);
   tokenizer.end();
   return exceeded;

--- a/extensions/web-readability/web-content-extractor.ts
+++ b/extensions/web-readability/web-content-extractor.ts
@@ -84,6 +84,7 @@ function findRawTextClose(html: string, tagName: string, from: number): number {
 
 function exceedsEstimatedHtmlNestingDepth(html: string, maxDepth: number): boolean {
   const openTags: string[] = [];
+  const openCounts = new Map<string, number>();
   const len = html.length;
   for (let i = 0; i < len; i++) {
     if (html.charCodeAt(i) !== 60) {
@@ -126,16 +127,19 @@ function exceedsEstimatedHtmlNestingDepth(html: string, maxDepth: number): boole
     const tagName = html.slice(nameStart, j).toLowerCase();
 
     if (closing) {
-      // Mirror htmlparser2's HTML-mode stack: a close pops back only to a
+      // Mirror htmlparser2's HTML-mode stack: a close pops back to the nearest
       // matching open tag; an unmatched close pops nothing. A scalar decrement
       // instead let `<div></x>` net to zero while the parser nests every div.
-      const top = openTags[openTags.length - 1];
-      if (top === tagName) {
-        openTags.pop();
-      } else {
-        const matchIndex = openTags.lastIndexOf(tagName);
-        if (matchIndex !== -1) {
-          openTags.length = matchIndex;
+      // openCounts settles "nothing to pop" without touching the stack, so a
+      // flood of unmatched closes cannot scan every open tag per token; the
+      // popping loop only ever walks tags it removes.
+      if (!openCounts.get(tagName)) {
+        continue;
+      }
+      for (let name = openTags.pop(); name !== undefined; name = openTags.pop()) {
+        openCounts.set(name, (openCounts.get(name) ?? 1) - 1);
+        if (name === tagName) {
+          break;
         }
       }
       continue;
@@ -168,6 +172,7 @@ function exceedsEstimatedHtmlNestingDepth(html: string, maxDepth: number): boole
     // htmlparser2 in HTML mode has recognizeSelfClosing off, so a trailing
     // slash on a non-void tag is ignored and `<div/>` still opens an element.
     openTags.push(tagName);
+    openCounts.set(tagName, (openCounts.get(tagName) ?? 0) + 1);
     if (openTags.length > maxDepth) {
       return true;
     }

--- a/extensions/web-readability/web-content-extractor.ts
+++ b/extensions/web-readability/web-content-extractor.ts
@@ -172,11 +172,7 @@ function exceedsEstimatedHtmlNestingDepth(html: string, maxDepth: number): boole
       pendingOpenTag = undefined;
     },
     onselfclosingtag() {
-      if (
-        foreignContext[0] &&
-        pendingOpenTag &&
-        openTags[openTags.length - 1] === pendingOpenTag
-      ) {
+      if (foreignContext[0] && pendingOpenTag && openTags[openTags.length - 1] === pendingOpenTag) {
         popOpenTag();
       }
       pendingOpenTag = undefined;
@@ -216,10 +212,7 @@ function exceedsEstimatedHtmlNestingDepth(html: string, maxDepth: number): boole
 
   // Reuse linkedom's exact lexer so malformed tag names, attributes, raw-text
   // bodies, and self-closing syntax cannot diverge from the guarded parser.
-  const tokenizer = new Tokenizer(
-    { xmlMode: false, decodeEntities: true },
-    callbacks,
-  );
+  const tokenizer = new Tokenizer({ xmlMode: false, decodeEntities: true }, callbacks);
   tokenizer.write(html);
   tokenizer.end();
   return exceeded;

--- a/extensions/web-readability/web-content-extractor.ts
+++ b/extensions/web-readability/web-content-extractor.ts
@@ -83,7 +83,7 @@ function findRawTextClose(html: string, tagName: string, from: number): number {
 }
 
 function exceedsEstimatedHtmlNestingDepth(html: string, maxDepth: number): boolean {
-  let depth = 0;
+  const openTags: string[] = [];
   const len = html.length;
   for (let i = 0; i < len; i++) {
     if (html.charCodeAt(i) !== 60) {
@@ -123,14 +123,23 @@ function exceedsEstimatedHtmlNestingDepth(html: string, maxDepth: number): boole
     if (j === nameStart) {
       continue;
     }
+    const tagName = html.slice(nameStart, j).toLowerCase();
 
     if (closing) {
-      if (depth > 0) {
-        depth -= 1;
+      // Mirror htmlparser2's HTML-mode stack: a close pops back only to a
+      // matching open tag; an unmatched close pops nothing. A scalar decrement
+      // instead let `<div></x>` net to zero while the parser nests every div.
+      const top = openTags[openTags.length - 1];
+      if (top === tagName) {
+        openTags.pop();
+      } else {
+        const matchIndex = openTags.lastIndexOf(tagName);
+        if (matchIndex !== -1) {
+          openTags.length = matchIndex;
+        }
       }
       continue;
     }
-    const tagName = html.slice(nameStart, j).toLowerCase();
 
     let quote = 0;
     let k = j;
@@ -152,12 +161,14 @@ function exceedsEstimatedHtmlNestingDepth(html: string, maxDepth: number): boole
     }
     i = k;
 
-    if (HTML_VOID_TAGS.has(tagName) || html.charCodeAt(k - 1) === 47) {
+    if (HTML_VOID_TAGS.has(tagName)) {
       continue;
     }
 
-    depth += 1;
-    if (depth > maxDepth) {
+    // htmlparser2 in HTML mode has recognizeSelfClosing off, so a trailing
+    // slash on a non-void tag is ignored and `<div/>` still opens an element.
+    openTags.push(tagName);
+    if (openTags.length > maxDepth) {
       return true;
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2006,6 +2006,9 @@ importers:
       '@mozilla/readability':
         specifier: 0.6.0
         version: 0.6.0
+      htmlparser2:
+        specifier: 10.1.0
+        version: 10.1.0
       linkedom:
         specifier: 0.18.13
         version: 0.18.13


### PR DESCRIPTION
## Summary

`web_fetch` runs the enabled-by-default web-readability extractor on remote HTML before returning agent-readable text. That extractor calls synchronous, uncancellable `Readability.parse()`, so deeply nested hostile markup can block the gateway event loop after the fetch timeout can no longer intervene.

This change keeps the protection at the plugin that owns the parse:

- lower the preflight nesting limit from 3000 to 800;
- tokenize with the same pinned `htmlparser2` lexer family used by `linkedom`;
- track parser-aligned open-element transitions, including void elements, implicit closes, foreign content, and HTML self-closing behavior;
- reject over-limit input before building the DOM, allowing the existing provider/basic HTML fallback path to continue.

## What Problem This Solves

The existing scalar estimator increments for start tags and decrements for closing tags. That does not represent the HTML parser's stack:

- non-void `<div/>` remains open in HTML mode;
- unmatched closes do not reduce parser depth;
- malformed attributes and raw-text states change which apparent tags are tokens;
- implicit close rules can remove earlier elements;
- SVG/MathML self-closing behavior differs from HTML behavior.

The 3000-depth threshold also permits expensive synchronous parses. Recorded production-extractor proof on the original implementation showed crafted 1000-level inputs blocking the event loop for roughly 3.2 seconds while the scalar guard admitted them.

Earlier revisions replaced the scalar with a hand-written scanner. Review found concrete parser-boundary bypasses and a quadratic unmatched-close path, so the final implementation does not retain that scanner.

## Fix

`extensions/web-readability/web-content-extractor.ts` now drives the public `htmlparser2` `Tokenizer` directly and maintains only the bounded facts needed by the guard. Its stack transitions mirror the pinned parser's HTML-mode behavior. A per-name count rejects unmatched closes in constant time, while matched pops are amortized linear because each removed entry is visited once.

The owning plugin now declares `htmlparser2@10.1.0` directly. That exact version was already present in the lockfile through `linkedom@0.18.13`; this changes dependency ownership, not the resolved package version.

The 800-depth boundary is intentional. Pages at or above it skip Readability and continue through existing provider/basic extraction. Maintainer acceptance of that compatibility trade-off is recorded in the PR discussion.

## Why this boundary

- The web-readability plugin owns both the synchronous parse and its preflight.
- Building a DOM to measure depth performs the expensive work the guard must avoid.
- Calling `htmlparser2.Parser` directly was rejected because its lower-stack close lookup uses a linear stack search, allowing depth multiplied by unmatched closing tags.
- Moving parsing to a worker would reduce event-loop impact but is a broader lifecycle change and would not make the existing preflight sound.
- Core, SDK, and unrelated fetch paths do not need a new policy surface.

## Regression coverage

The focused suite covers:

- ordinary nesting and well-formed siblings;
- HTML void elements and non-void `<div/>`;
- unmatched closes and a near-full stack followed by 180,000 unmatched closes;
- malformed close names, quoted attributes, and truncated tag names;
- raw-text elements and `<script/>`;
- MathML foreign-content self-closing;
- implicit-close stale-element cases;
- Unicode and `noscript` controls.

Exact head: `2cb75b6b2a82b1b6dd20616f489c4bcfe56adde6`.

## Evidence

- Fresh maintainer autoreview of the final exact tree: no accepted or actionable findings.
- Dependency contracts inspected directly from `htmlparser2@10.1.0`, `linkedom@0.18.13`, and their public exports.
- Exact-head GitHub CI and ClawSweeper review are required before landing.
- No contributor-controlled code was executed on the maintainer workstation.

## Surface

- Production TypeScript: +173/-61.
- Tests: +198/-0.
- Manifest and lockfile: +4/-0.
