### PR TITLE
fix(comfy): detect SaveVideo outputs

### DIFF
--- a/extensions/comfy/video-generation-provider.test.ts
+++ b/extensions/comfy/video-generation-provider.test.ts
@@ -72,7 +72,7 @@ describe("comfy video-generation provider", () => {
             "local-video-1": {
               outputs: {
                 "9": {
-                  gifs: [{ filename: "generated.mp4", subfolder: "", type: "output" }],
+                  images: [{ filename: "generated.mp4", subfolder: "", type: "output" }],
                 },
               },
             },

--- a/extensions/comfy/video-generation-provider.ts
+++ b/extensions/comfy/video-generation-provider.ts
@@ -75,7 +75,7 @@ export function buildComfyVideoGenerationProvider(): VideoGenerationProvider {
         model: req.model,
         timeoutMs: req.timeoutMs,
         capability: "video",
-        outputKinds: ["gifs", "videos"],
+        outputKinds: ["gifs", "images", "videos"],
         inputImage: toComfyInputImage(req.inputImages?.[0]),
       });
 


### PR DESCRIPTION
## Summary

- accept Comfy workflow video files from the `images` history bucket
- retain existing `gifs` and `videos` support
- cover the core `SaveVideo` response shape in the focused provider test

Fixes #119468.

## Root cause

The Comfy video provider passed only `["gifs", "videos"]` to the shared workflow output collector. ComfyUI's core `SaveVideo` node can report the saved MP4 through `outputs.<nodeId>.images`, so OpenClaw discarded the generated file and returned a false “completed without video outputs” failure.

## User impact

Workflows using ComfyUI's core `SaveVideo` node can now return their generated MP4 to OpenClaw.

## Validation

- `git diff --check`
- Focused Vitest attempted with `node scripts/run-vitest.mjs extensions/comfy/video-generation-provider.test.ts`, but the existing dependency install was missing `p-map`.
- `pnpm install` was retried once and remained blocked because npm did not provide the repository-pinned `@pnpm/exe@11.15.1`.
