### PR TITLE
fix(agents): seed fresh session identity before transcript append

### DIFF
--- a/src/agents/sessions/session-manager-core.ts
+++ b/src/agents/sessions/session-manager-core.ts
@@ -1,8 +1,11 @@
 import {
+  loadSessionEntry,
   loadTranscriptEventsSync,
+  replaceSessionEntrySync,
   replaceTranscriptEventsSync,
 } from "../../config/sessions/session-accessor.js";
 import type { SessionTranscriptRuntimeTarget } from "../../config/sessions/session-accessor.types.js";
+import { projectCanonicalSessionEntryShape } from "../../config/sessions/store-entry-shape.js";
 import { isSessionTranscriptSideAppendEntry } from "../../config/sessions/transcript-tree.js";
 import { CURRENT_SESSION_VERSION } from "../../config/sessions/version.js";
 import {
@@ -79,6 +82,29 @@ export class SessionManagerCore {
     if (partitioned.fileEntries.length === 0 && partitioned.opaqueEntries.length === 0) {
       this.persistenceTarget = target ? { ...target } : undefined;
       this.initializeSession({ id: target?.sessionId });
+      if (target) {
+        const updatedAt = Date.now();
+        const previousEntry = loadSessionEntry({
+          agentId: target.agentId,
+          sessionKey: target.sessionKey,
+          storePath: target.storePath,
+        });
+        const canonicalPreviousEntry = previousEntry
+          ? projectCanonicalSessionEntryShape(previousEntry as unknown as Record<string, unknown>)
+          : { updatedAt };
+        replaceSessionEntrySync(
+          {
+            agentId: target.agentId,
+            sessionKey: target.sessionKey,
+            storePath: target.storePath,
+          },
+          {
+            ...canonicalPreviousEntry,
+            sessionId: target.sessionId,
+            updatedAt,
+          },
+        );
+      }
       this.persistenceHeaderPending = target !== undefined;
       return;
     }

--- a/src/agents/sessions/session-manager-core.ts
+++ b/src/agents/sessions/session-manager-core.ts
@@ -1,11 +1,8 @@
 import {
-  loadSessionEntry,
   loadTranscriptEventsSync,
-  replaceSessionEntrySync,
   replaceTranscriptEventsSync,
 } from "../../config/sessions/session-accessor.js";
 import type { SessionTranscriptRuntimeTarget } from "../../config/sessions/session-accessor.types.js";
-import { projectCanonicalSessionEntryShape } from "../../config/sessions/store-entry-shape.js";
 import { isSessionTranscriptSideAppendEntry } from "../../config/sessions/transcript-tree.js";
 import { CURRENT_SESSION_VERSION } from "../../config/sessions/version.js";
 import {
@@ -82,29 +79,6 @@ export class SessionManagerCore {
     if (partitioned.fileEntries.length === 0 && partitioned.opaqueEntries.length === 0) {
       this.persistenceTarget = target ? { ...target } : undefined;
       this.initializeSession({ id: target?.sessionId });
-      if (target) {
-        const updatedAt = Date.now();
-        const previousEntry = loadSessionEntry({
-          agentId: target.agentId,
-          sessionKey: target.sessionKey,
-          storePath: target.storePath,
-        });
-        const canonicalPreviousEntry = previousEntry
-          ? projectCanonicalSessionEntryShape(previousEntry as unknown as Record<string, unknown>)
-          : { updatedAt };
-        replaceSessionEntrySync(
-          {
-            agentId: target.agentId,
-            sessionKey: target.sessionKey,
-            storePath: target.storePath,
-          },
-          {
-            ...canonicalPreviousEntry,
-            sessionId: target.sessionId,
-            updatedAt,
-          },
-        );
-      }
       this.persistenceHeaderPending = target !== undefined;
       return;
     }

--- a/src/agents/sessions/session-manager-persistence.ts
+++ b/src/agents/sessions/session-manager-persistence.ts
@@ -1,6 +1,8 @@
 import {
   appendTranscriptEventSync,
   appendTranscriptMessageSync,
+  loadSessionEntry,
+  replaceSessionEntrySync,
 } from "../../config/sessions/session-accessor.js";
 import { isSessionTranscriptSideAppendEntry } from "../../config/sessions/transcript-tree.js";
 import {
@@ -150,6 +152,12 @@ export class SessionManagerPersistence extends SessionManagerCore {
     }
     const scope = this.persistenceTarget;
     if (this.persistenceHeaderPending) {
+      if (!loadSessionEntry(scope)) {
+        replaceSessionEntrySync(scope, {
+          sessionId: scope.sessionId,
+          updatedAt: Date.now(),
+        });
+      }
       const header = this.fileEntries[0];
       if (!header || header.type !== "session" || !appendTranscriptEventSync(scope, header)) {
         throw new Error("Session transcript header was not persisted");

--- a/src/agents/sessions/session-manager-persistence.ts
+++ b/src/agents/sessions/session-manager-persistence.ts
@@ -1,8 +1,7 @@
 import {
   appendTranscriptEventSync,
   appendTranscriptMessageSync,
-  loadSessionEntry,
-  replaceSessionEntrySync,
+  ensureSessionEntrySync,
 } from "../../config/sessions/session-accessor.js";
 import { isSessionTranscriptSideAppendEntry } from "../../config/sessions/transcript-tree.js";
 import {
@@ -152,11 +151,13 @@ export class SessionManagerPersistence extends SessionManagerCore {
     }
     const scope = this.persistenceTarget;
     if (this.persistenceHeaderPending) {
-      if (!loadSessionEntry(scope)) {
-        replaceSessionEntrySync(scope, {
+      if (
+        !ensureSessionEntrySync(scope, {
           sessionId: scope.sessionId,
           updatedAt: Date.now(),
-        });
+        })
+      ) {
+        throw new Error("Session transcript header was not persisted");
       }
       const header = this.fileEntries[0];
       if (!header || header.type !== "session" || !appendTranscriptEventSync(scope, header)) {

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -306,6 +306,36 @@ describe("SessionManager.open", () => {
     expect(() => SessionManager.open(scope, dir)).not.toThrow();
   });
 
+  it("persists a fresh SQLite session header and first message", async () => {
+    const dir = await makeTempDir();
+    const scope = {
+      agentId: "main",
+      sessionId: "sqlite-fresh-session",
+      sessionKey: "agent:main:sqlite-fresh-session",
+      storePath: path.join(dir, "sessions.json"),
+    };
+
+    const manager = SessionManager.open(scope, dir);
+    const messageId = manager.appendMessage({
+      role: "user",
+      content: "first message",
+      timestamp: 1,
+    });
+
+    await expect(loadTranscriptEvents(scope)).resolves.toEqual([
+      expect.objectContaining({
+        id: scope.sessionId,
+        type: "session",
+        version: CURRENT_SESSION_VERSION,
+      }),
+      expect.objectContaining({
+        id: messageId,
+        message: expect.objectContaining({ content: "first message", role: "user" }),
+        type: "message",
+      }),
+    ]);
+  });
+
   it("rejects invalid entries before mutating in-memory state", () => {
     const manager = SessionManager.inMemory("/tmp");
     const entriesBefore = manager.getEntries();

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -359,6 +359,28 @@ describe("SessionManager.open", () => {
     expect(loadSessionEntry(scope)).toEqual(before);
   });
 
+  it("does not overwrite a rebound session row when the first append seeds its header", async () => {
+    const dir = await makeTempDir();
+    const scope = {
+      agentId: "main",
+      sessionId: "sqlite-stale-appender",
+      sessionKey: "agent:main:sqlite-rebound-before-header",
+      storePath: path.join(dir, "sessions.json"),
+    };
+    await upsertSessionEntry(scope, {
+      sessionId: "sqlite-current-owner",
+      updatedAt: 456,
+      label: "preserved",
+    });
+    const before = loadSessionEntry(scope);
+    const manager = SessionManager.open(scope, dir);
+
+    expect(() =>
+      manager.appendMessage({ role: "user", content: "stale message", timestamp: 1 }),
+    ).toThrow("Session transcript header was not persisted");
+    expect(loadSessionEntry(scope)).toEqual(before);
+  });
+
   it("rejects invalid entries before mutating in-memory state", () => {
     const manager = SessionManager.inMemory("/tmp");
     const entriesBefore = manager.getEntries();

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -315,7 +315,9 @@ describe("SessionManager.open", () => {
       storePath: path.join(dir, "sessions.json"),
     };
 
+    expect(loadSessionEntry(scope)).toBeUndefined();
     const manager = SessionManager.open(scope, dir);
+    expect(loadSessionEntry(scope)).toBeUndefined();
     const messageId = manager.appendMessage({
       role: "user",
       content: "first message",
@@ -334,6 +336,27 @@ describe("SessionManager.open", () => {
         type: "message",
       }),
     ]);
+    expect(loadSessionEntry(scope)).toMatchObject({ sessionId: scope.sessionId });
+  });
+
+  it("does not rewrite an existing session row when opening an empty transcript", async () => {
+    const dir = await makeTempDir();
+    const scope = {
+      agentId: "main",
+      sessionId: "sqlite-empty-existing-row-target",
+      sessionKey: "agent:main:sqlite-empty-existing-row",
+      storePath: path.join(dir, "sessions.json"),
+    };
+    await upsertSessionEntry(scope, {
+      sessionId: "sqlite-existing-row",
+      updatedAt: 123,
+      label: "preserved",
+    });
+    const before = loadSessionEntry(scope);
+
+    SessionManager.open(scope, dir);
+
+    expect(loadSessionEntry(scope)).toEqual(before);
   });
 
   it("rejects invalid entries before mutating in-memory state", () => {

--- a/src/config/sessions/session-accessor.entry.ts
+++ b/src/config/sessions/session-accessor.entry.ts
@@ -12,6 +12,7 @@ import { clearPluginOwnedSessionState } from "./plugin-host-cleanup.js";
 import {
   countSqliteSessionEntryRowsReadOnly as countSessionEntryRowsReadOnly,
   copySqliteSessionOwnedStateForCanonicalRepair as copySessionOwnedStateForCanonicalRepair,
+  ensureSqliteSessionEntrySync,
   hasSqliteSessionEntriesByStatusReadOnly as hasSessionEntriesByStatusReadOnly,
   listSqliteSessionGenerationIdsForCanonicalRepair as listSessionGenerationIdsForCanonicalRepair,
   listSqliteSessionChildEntriesReadOnly as listSessionChildEntriesReadOnly,
@@ -62,6 +63,7 @@ export { clearPluginOwnedSessionState };
 export {
   countSessionEntryRowsReadOnly,
   copySessionOwnedStateForCanonicalRepair,
+  ensureSqliteSessionEntrySync,
   hasSessionEntriesByStatusReadOnly,
   listSessionGenerationIdsForCanonicalRepair,
   listSessionChildEntriesReadOnly,

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -448,6 +448,35 @@ export function replaceSqliteSessionEntrySync(
   emitCommittedSessionIdentityDiff(previous, current);
 }
 
+/** Creates a missing session identity without replacing a concurrently owned row. */
+export function ensureSqliteSessionEntrySync(
+  scope: SessionAccessScope,
+  entry: SessionEntry,
+): boolean {
+  const resolved = resolveSqliteScope(scope);
+  assertCanonicalSessionWriteScope(resolved);
+  let owned = false;
+  let previous = new Map<string, SessionEntry>();
+  let current = new Map<string, SessionEntry>();
+  runOpenClawAgentWriteTransaction((database) => {
+    const identityKeys = collectSessionEntryLookupKeys(database, resolved.sessionKey);
+    previous = readSqliteSessionIdentitySnapshot(database, identityKeys);
+    const existing = readSessionEntryRow(database, resolved.sessionKey)?.entry;
+    if (existing) {
+      owned = existing.sessionId === entry.sessionId;
+      current = previous;
+      return;
+    }
+    writeSessionEntry(database, resolved.sessionKey, entry);
+    current = readSqliteSessionIdentitySnapshot(database, identityKeys);
+    owned = current.get(resolved.sessionKey)?.sessionId === entry.sessionId;
+  }, toDatabaseOptions(resolved));
+  if (current.size !== previous.size || owned) {
+    emitCommittedSessionIdentityDiff(previous, current);
+  }
+  return owned;
+}
+
 /** Patches one entry in the additive SQLite session store. */
 export async function patchSqliteSessionEntry(
   scope: SessionAccessScope,

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -1,6 +1,7 @@
 // Stable SQLite accessor surface. Domain owners live in the focused modules below.
 export {
   countSqliteSessionEntryRowsReadOnly,
+  ensureSqliteSessionEntrySync,
   hasSqliteSessionEntriesByStatusReadOnly,
   listSqliteSessionEntries,
   listSqliteSessionChildEntriesReadOnly,

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -120,6 +120,7 @@ export type {
 } from "./session-accessor.entry-mutation.js";
 export {
   countSessionEntryRowsReadOnly,
+  ensureSqliteSessionEntrySync as ensureSessionEntrySync,
   copySessionOwnedStateForCanonicalRepair,
   hasSessionEntriesByStatusReadOnly,
   listSessionGenerationIdsForCanonicalRepair,

--- a/test/pr119473-real-runtime-proof.e2e.test.ts
+++ b/test/pr119473-real-runtime-proof.e2e.test.ts
@@ -1,0 +1,190 @@
+import fs from "node:fs/promises";
+import { createServer } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { clearConfigCache, clearRuntimeConfigSnapshot } from "../src/config/config.js";
+import {
+  disconnectGatewayClient,
+  startGatewayWithClient,
+} from "../src/gateway/test-helpers.e2e.js";
+import { buildMockOpenAiResponsesProvider } from "../src/gateway/test-openai-responses-model.js";
+import { captureEnv, setTestEnvValue } from "../src/test-utils/env.js";
+
+const envKeys = [
+  "HOME",
+  "OPENCLAW_STATE_DIR",
+  "OPENCLAW_CONFIG_PATH",
+  "OPENCLAW_GATEWAY_TOKEN",
+  "OPENCLAW_SKIP_CHANNELS",
+  "OPENCLAW_SKIP_GMAIL_WATCHER",
+  "OPENCLAW_SKIP_CRON",
+  "OPENCLAW_SKIP_CANVAS_HOST",
+  "OPENCLAW_SKIP_BROWSER_CONTROL_SERVER",
+  "OPENCLAW_SKIP_PROVIDERS",
+  "OPENCLAW_BUNDLED_PLUGINS_DIR",
+  "OPENCLAW_DISABLE_BUNDLED_PLUGINS",
+] as const;
+
+describe("PR #119473 real gateway proof", () => {
+  let tempHome: string | undefined;
+
+  afterEach(async () => {
+    if (tempHome) {
+      await fs.rm(tempHome, { recursive: true, force: true });
+      tempHome = undefined;
+    }
+  });
+
+  it(
+    "persists the first turn of a fresh SQLite-backed session across gateway restart",
+    { timeout: 90_000 },
+    async () => {
+      const envSnapshot = captureEnv(envKeys);
+      tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-pr119473-proof-"));
+      const stateDir = path.join(tempHome, ".openclaw");
+      const workspaceDir = path.join(tempHome, "workspace");
+      const configPath = path.join(stateDir, "openclaw.json");
+      const bundledPluginsDir = path.join(tempHome, "bundled-plugins");
+      await Promise.all([
+        fs.mkdir(workspaceDir, { recursive: true }),
+        fs.mkdir(bundledPluginsDir, { recursive: true }),
+        fs.mkdir(path.dirname(configPath), { recursive: true }),
+      ]);
+      for (const [key, value] of Object.entries({
+        HOME: tempHome,
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_GATEWAY_TOKEN: "pr119473-proof-token",
+        OPENCLAW_SKIP_CHANNELS: "1",
+        OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+        OPENCLAW_SKIP_CRON: "1",
+        OPENCLAW_SKIP_CANVAS_HOST: "1",
+        OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+        OPENCLAW_SKIP_PROVIDERS: "1",
+        OPENCLAW_BUNDLED_PLUGINS_DIR: bundledPluginsDir,
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      })) {
+        setTestEnvValue(key, value);
+      }
+
+      const providerServer = createServer((_request, response) => {
+        response.writeHead(200, { "content-type": "text/event-stream" });
+        const message = {
+          type: "message",
+          id: "pr119473-proof-message",
+          role: "assistant",
+          status: "completed",
+          content: [{ type: "output_text", text: "PR119473_RUNTIME_OK", annotations: [] }],
+        };
+        response.end(
+          [
+            {
+              type: "response.output_item.added",
+              output_index: 0,
+              item: { ...message, status: "in_progress", content: [] },
+            },
+            { type: "response.output_item.done", output_index: 0, item: message },
+            {
+              type: "response.completed",
+              response: {
+                status: "completed",
+                usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+              },
+            },
+          ]
+            .map((event) => `data: ${JSON.stringify(event)}\n\n`)
+            .concat("data: [DONE]\n\n")
+            .join(""),
+        );
+      });
+      await new Promise<void>((resolve, reject) => {
+        providerServer.once("error", reject);
+        providerServer.listen(0, "127.0.0.1", resolve);
+      });
+      const providerAddress = providerServer.address();
+      if (!providerAddress || typeof providerAddress === "string") {
+        throw new Error("proof provider did not bind a loopback port");
+      }
+      const provider = buildMockOpenAiResponsesProvider(
+        `http://127.0.0.1:${providerAddress.port}/v1`,
+      );
+      const cfg = {
+        agents: {
+          defaults: {
+            workspace: workspaceDir,
+            skipBootstrap: true,
+            model: { primary: provider.modelRef },
+            models: {
+              [provider.modelRef]: { params: { transport: "sse", openaiWsWarmup: false } },
+            },
+          },
+          entries: { main: { default: true } },
+        },
+        models: { mode: "replace", providers: { [provider.providerId]: provider.config } },
+        gateway: { auth: { mode: "token", token: "pr119473-proof-token" } },
+      };
+      const sessionKey = "agent:main:pr119473-fresh-runtime";
+      const marker = "PR119473_FIRST_USER_MESSAGE";
+      let first: Awaited<ReturnType<typeof startGatewayWithClient>> | undefined;
+      let second: Awaited<ReturnType<typeof startGatewayWithClient>> | undefined;
+
+      try {
+        first = await startGatewayWithClient({
+          cfg,
+          configPath,
+          token: "pr119473-proof-token",
+          clientDisplayName: "pr119473-proof-first-start",
+        });
+        const started = await first.client.request<{ runId?: string; status?: string }>(
+          "chat.send",
+          {
+            sessionKey,
+            message: marker,
+            deliver: false,
+            idempotencyKey: "pr119473-proof-first-turn",
+          },
+        );
+        expect(started.status).toBe("started");
+        expect(started.runId).toEqual(expect.any(String));
+        await expect(
+          first.client.request(
+            "agent.wait",
+            { runId: started.runId, timeoutMs: 30_000 },
+            { timeoutMs: 35_000 },
+          ),
+        ).resolves.toMatchObject({ status: "ok" });
+        await disconnectGatewayClient(first.client);
+        await first.server.close({ reason: "PR #119473 proof restart" });
+        first = undefined;
+
+        clearRuntimeConfigSnapshot();
+        clearConfigCache();
+        second = await startGatewayWithClient({
+          cfg,
+          configPath,
+          token: "pr119473-proof-token",
+          clientDisplayName: "pr119473-proof-after-restart",
+        });
+        const history = await second.client.request<{ messages?: unknown[] }>("chat.history", {
+          sessionKey,
+          limit: 20,
+        });
+        expect(JSON.stringify(history.messages ?? [])).toContain(marker);
+      } finally {
+        if (first) {
+          await disconnectGatewayClient(first.client).catch(() => undefined);
+          await first.server.close().catch(() => undefined);
+        }
+        if (second) {
+          await disconnectGatewayClient(second.client).catch(() => undefined);
+          await second.server.close().catch(() => undefined);
+        }
+        await new Promise<void>((resolve) => {
+          providerServer.close(() => resolve());
+        });
+        envSnapshot.restore();
+      }
+    },
+  );
+});

--- a/test/pr119473-real-runtime-proof.e2e.test.ts
+++ b/test/pr119473-real-runtime-proof.e2e.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { clearConfigCache, clearRuntimeConfigSnapshot } from "../src/config/config.js";
+import { clearSessionStoreCacheForTest } from "../src/config/sessions/store-writer-state.js";
 import {
   disconnectGatewayClient,
   startGatewayWithClient,
@@ -40,96 +41,97 @@ describe("PR #119473 real gateway proof", () => {
     "persists the first turn of a fresh SQLite-backed session across gateway restart",
     { timeout: 90_000 },
     async () => {
-      const envSnapshot = captureEnv(envKeys);
-      tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-pr119473-proof-"));
-      const stateDir = path.join(tempHome, ".openclaw");
-      const workspaceDir = path.join(tempHome, "workspace");
-      const configPath = path.join(stateDir, "openclaw.json");
-      const bundledPluginsDir = path.join(tempHome, "bundled-plugins");
-      await Promise.all([
-        fs.mkdir(workspaceDir, { recursive: true }),
-        fs.mkdir(bundledPluginsDir, { recursive: true }),
-        fs.mkdir(path.dirname(configPath), { recursive: true }),
-      ]);
-      for (const [key, value] of Object.entries({
-        HOME: tempHome,
-        OPENCLAW_STATE_DIR: stateDir,
-        OPENCLAW_CONFIG_PATH: configPath,
-        OPENCLAW_GATEWAY_TOKEN: "pr119473-proof-token",
-        OPENCLAW_SKIP_CHANNELS: "1",
-        OPENCLAW_SKIP_GMAIL_WATCHER: "1",
-        OPENCLAW_SKIP_CRON: "1",
-        OPENCLAW_SKIP_CANVAS_HOST: "1",
-        OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
-        OPENCLAW_SKIP_PROVIDERS: "1",
-        OPENCLAW_BUNDLED_PLUGINS_DIR: bundledPluginsDir,
-        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
-      })) {
-        setTestEnvValue(key, value);
-      }
-
-      const providerServer = createServer((_request, response) => {
-        response.writeHead(200, { "content-type": "text/event-stream" });
-        const message = {
-          type: "message",
-          id: "pr119473-proof-message",
-          role: "assistant",
-          status: "completed",
-          content: [{ type: "output_text", text: "PR119473_RUNTIME_OK", annotations: [] }],
-        };
-        response.end(
-          [
-            {
-              type: "response.output_item.added",
-              output_index: 0,
-              item: { ...message, status: "in_progress", content: [] },
-            },
-            { type: "response.output_item.done", output_index: 0, item: message },
-            {
-              type: "response.completed",
-              response: {
-                status: "completed",
-                usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
-              },
-            },
-          ]
-            .map((event) => `data: ${JSON.stringify(event)}\n\n`)
-            .concat("data: [DONE]\n\n")
-            .join(""),
-        );
-      });
-      await new Promise<void>((resolve, reject) => {
-        providerServer.once("error", reject);
-        providerServer.listen(0, "127.0.0.1", resolve);
-      });
-      const providerAddress = providerServer.address();
-      if (!providerAddress || typeof providerAddress === "string") {
-        throw new Error("proof provider did not bind a loopback port");
-      }
-      const provider = buildMockOpenAiResponsesProvider(
-        `http://127.0.0.1:${providerAddress.port}/v1`,
-      );
-      const cfg = {
-        agents: {
-          defaults: {
-            workspace: workspaceDir,
-            skipBootstrap: true,
-            model: { primary: provider.modelRef },
-            models: {
-              [provider.modelRef]: { params: { transport: "sse", openaiWsWarmup: false } },
-            },
-          },
-          entries: { main: { default: true } },
-        },
-        models: { mode: "replace", providers: { [provider.providerId]: provider.config } },
-        gateway: { auth: { mode: "token", token: "pr119473-proof-token" } },
-      };
-      const sessionKey = "agent:main:pr119473-fresh-runtime";
-      const marker = "PR119473_FIRST_USER_MESSAGE";
+      const envSnapshot = captureEnv([...envKeys]);
+      let providerServer: ReturnType<typeof createServer> | undefined;
       let first: Awaited<ReturnType<typeof startGatewayWithClient>> | undefined;
       let second: Awaited<ReturnType<typeof startGatewayWithClient>> | undefined;
 
       try {
+        tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-pr119473-proof-"));
+        const stateDir = path.join(tempHome, ".openclaw");
+        const workspaceDir = path.join(tempHome, "workspace");
+        const configPath = path.join(stateDir, "openclaw.json");
+        const bundledPluginsDir = path.join(tempHome, "bundled-plugins");
+        await Promise.all([
+          fs.mkdir(workspaceDir, { recursive: true }),
+          fs.mkdir(bundledPluginsDir, { recursive: true }),
+          fs.mkdir(path.dirname(configPath), { recursive: true }),
+        ]);
+        for (const [key, value] of Object.entries({
+          HOME: tempHome,
+          OPENCLAW_STATE_DIR: stateDir,
+          OPENCLAW_CONFIG_PATH: configPath,
+          OPENCLAW_GATEWAY_TOKEN: "pr119473-proof-token",
+          OPENCLAW_SKIP_CHANNELS: "1",
+          OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+          OPENCLAW_SKIP_CRON: "1",
+          OPENCLAW_SKIP_CANVAS_HOST: "1",
+          OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+          OPENCLAW_SKIP_PROVIDERS: "1",
+          OPENCLAW_BUNDLED_PLUGINS_DIR: bundledPluginsDir,
+          OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+        })) {
+          setTestEnvValue(key, value);
+        }
+
+        providerServer = createServer((_request, response) => {
+          response.writeHead(200, { "content-type": "text/event-stream" });
+          const message = {
+            type: "message",
+            id: "pr119473-proof-message",
+            role: "assistant",
+            status: "completed",
+            content: [{ type: "output_text", text: "PR119473_RUNTIME_OK", annotations: [] }],
+          };
+          response.end(
+            [
+              {
+                type: "response.output_item.added",
+                output_index: 0,
+                item: { ...message, status: "in_progress", content: [] },
+              },
+              { type: "response.output_item.done", output_index: 0, item: message },
+              {
+                type: "response.completed",
+                response: {
+                  status: "completed",
+                  usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+                },
+              },
+            ]
+              .map((event) => `data: ${JSON.stringify(event)}\n\n`)
+              .concat("data: [DONE]\n\n")
+              .join(""),
+          );
+        });
+        await new Promise<void>((resolve, reject) => {
+          providerServer?.once("error", reject);
+          providerServer?.listen(0, "127.0.0.1", resolve);
+        });
+        const providerAddress = providerServer.address();
+        if (!providerAddress || typeof providerAddress === "string") {
+          throw new Error("proof provider did not bind a loopback port");
+        }
+        const provider = buildMockOpenAiResponsesProvider(
+          `http://127.0.0.1:${providerAddress.port}/v1`,
+        );
+        const cfg = {
+          agents: {
+            defaults: {
+              workspace: workspaceDir,
+              skipBootstrap: true,
+              model: { primary: provider.modelRef },
+              models: {
+                [provider.modelRef]: { params: { transport: "sse", openaiWsWarmup: false } },
+              },
+            },
+            entries: { main: { default: true } },
+          },
+          models: { mode: "replace", providers: { [provider.providerId]: provider.config } },
+          gateway: { auth: { mode: "token", token: "pr119473-proof-token" } },
+        };
+        const sessionKey = "agent:main:pr119473-fresh-runtime";
+        const marker = "PR119473_FIRST_USER_MESSAGE";
         first = await startGatewayWithClient({
           cfg,
           configPath,
@@ -180,10 +182,15 @@ describe("PR #119473 real gateway proof", () => {
           await disconnectGatewayClient(second.client).catch(() => undefined);
           await second.server.close().catch(() => undefined);
         }
-        await new Promise<void>((resolve) => {
-          providerServer.close(() => resolve());
-        });
+        if (providerServer?.listening) {
+          await new Promise<void>((resolve) => {
+            providerServer?.close(() => resolve());
+          });
+        }
         envSnapshot.restore();
+        clearRuntimeConfigSnapshot();
+        clearConfigCache();
+        clearSessionStoreCacheForTest();
       }
     },
   );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where opening a genuinely fresh persisted session could leave its SQLite session identity row absent. The first transcript header and message append then failed with `Session transcript header was not persisted` before the model was called.

## Why This Change Was Made

The session manager now creates a missing SQLite session identity row at the first real transcript write, immediately before the pending session header is appended. Opening a session for reading no longer creates or rewrites a session row, so existing metadata and session identity remain untouched on no-op probes and rollback paths.

## User Impact

Fresh SQLite-backed sessions now persist their header and first user message reliably. Existing sessions, read-only session opens, and in-memory session behavior are unchanged. No configuration changes or data migration are required.

## Evidence

Exact PR head: `d7f4978be251da00f77c3a786d8d626a7a54591c` (rebased onto `origin/main` at `0b68f8e1ed5`).

Focused validation on that exact checkout:

- `node scripts/run-vitest.mjs run src/agents/sessions/session-manager.test.ts` — 1 file, 25 tests passed.
- `node scripts/run-vitest.mjs run src/gateway/worker-environments/transcript-commit.test.ts` — 1 file, 10 tests passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts test/pr119473-real-runtime-proof.e2e.test.ts` — 1 real gateway test passed in 8.90s.
- The session regression coverage verifies that opening an empty transcript does not create a row, that the first append creates the row and header, that opening an empty transcript does not rewrite an existing row, and that a stale appender cannot overwrite a rebound SQLite identity.
- Direct oxlint on the changed session/persistence and runtime-proof files — passed.
- Oxfmt check on the changed session/persistence and runtime-proof files — passed.
- `git diff --check` — passed.
- `pnpm tsgo:test` — passed across all 175 workspace projects.

### Observed gateway proof trace

The test starts the actual gateway twice in isolated temporary state and asserts this live sequence:

```text
first start: live loopback gateway + authenticated WebSocket client
chat.send(agent:main:pr119473-fresh-runtime): status=started, runId is present
agent.wait(runId): status=ok
gateway shutdown: completed
second start: live loopback gateway + authenticated WebSocket client
chat.history(agent:main:pr119473-fresh-runtime): PR119473_FIRST_USER_MESSAGE present
```

The model response comes from a real loopback OpenAI-compatible HTTP/SSE server, not a mocked gateway client. The passing runner output from the latest exact-head execution was:

```text
RUN v4.1.10 /Users/jacquelinehenriksen/openclaw

Test Files  1 passed (1)
Tests       1 passed (1)
Start at    08:46:31
Duration    8.90s
```

AI-assisted: Yes. The implementation, regression tests, and gateway lifecycle proof were reviewed against the session persistence and transcript-write paths. The ChatGPT Codex connector review findings on the prior head were addressed by moving identity seeding to the first write and preserving existing rows.