### PR TITLE
feat(security): add allowAmbientProviderKeys flag to refuse credentials not directly specified in config

### DIFF
--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -46,6 +46,28 @@ Sentinels reduce plaintext exposure across the model-call chain, but they are no
 
 Set `OPENCLAW_SECRET_SENTINELS=off` (also accepts `0` or `false`, case-insensitive) to disable sentinel minting during incident response or compatibility troubleshooting. The kill switch does not disable exact-value redaction registration.
 
+## Ambient provider credentials
+
+A provider credential present in the environment but named by no configuration is still eligible for use by default. This is the documented zero-config `PROVIDER_API_KEY` path, and it is why the paragraph above matters: such a credential is outside the SecretRef sentinel mechanism.
+
+Operators who want a credential used only where configuration references it can opt out:
+
+```json
+{
+  "security": {
+    "allowAmbientProviderKeys": false
+  }
+}
+```
+
+With this set, a credential is eligible only where a provider entry, an auth profile, or a SecretRef names it. Environment variables remain a fully supported place to store keys, alongside file- and command-backed providers; the setting governs whether a key may be consumed without a configuration reference authorizing it, not where it is stored.
+
+Detection is deliberately unaffected. `doctor`, `models list`, and usage reporting continue to observe an ambient credential and report it as present, so opting out makes the credential ineligible rather than invisible.
+
+Opting out also covers platform credential providers, not just `PROVIDER_API_KEY` variables: `AWS_PROFILE`, AWS IAM key pairs, Bedrock bearer tokens, ECS and IRSA container credentials, and Google Application Default Credentials for Vertex. These are ambient in the same sense — the process environment selects them and no configuration names them. Operators on AWS or Vertex who set `allowAmbientProviderKeys: false` should name the provider in configuration first.
+
+The default remains `true`; existing installations are unchanged until they opt in.
+
 ## Agent-access boundary
 
 SecretRefs stop credentials from being persisted in config and generated model files, but they are not a process-isolation boundary. A plaintext credential left on disk in a path the agent can read is still readable via file or shell tools, bypassing API-level redaction.

--- a/packages/ai/src/env-api-keys.ambient-gate.test.ts
+++ b/packages/ai/src/env-api-keys.ambient-gate.test.ts
@@ -1,0 +1,56 @@
+// Covers the host-owned ambient-credential gate on the inference lookup path.
+import { afterEach, describe, expect, it } from "vitest";
+import { getEnvApiKey, findEnvKeys } from "./env-api-keys.js";
+import { configureAiTransportHost } from "./host.js";
+
+const ORIGINAL_OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+
+afterEach(() => {
+  configureAiTransportHost({ allowAmbientProviderKey: () => true });
+  if (ORIGINAL_OPENAI_API_KEY === undefined) {
+    delete process.env.OPENAI_API_KEY;
+  } else {
+    process.env.OPENAI_API_KEY = ORIGINAL_OPENAI_API_KEY;
+  }
+});
+
+describe("getEnvApiKey ambient gate", () => {
+  it("returns the credential when the host allows ambient keys", () => {
+    process.env.OPENAI_API_KEY = "sk-ambient-value";
+    configureAiTransportHost({ allowAmbientProviderKey: () => true });
+    expect(getEnvApiKey("openai")).toBe("sk-ambient-value");
+  });
+
+  it("withholds the credential when the host refuses ambient keys", () => {
+    process.env.OPENAI_API_KEY = "sk-ambient-value";
+    configureAiTransportHost({ allowAmbientProviderKey: () => false });
+    expect(getEnvApiKey("openai")).toBeUndefined();
+  });
+
+  it("keeps the variable visible to reporting even when refused", () => {
+    process.env.OPENAI_API_KEY = "sk-ambient-value";
+    configureAiTransportHost({ allowAmbientProviderKey: () => false });
+    // findEnvKeys reports presence; only value resolution is gated.
+    expect(findEnvKeys("openai")).toEqual(["OPENAI_API_KEY"]);
+  });
+
+  // Platform credential providers are ambient in the same sense: the process
+  // environment selects them and no configuration names them.
+  it("refuses AWS platform credentials for bedrock when the host refuses ambient keys", () => {
+    const originalProfile = process.env.AWS_PROFILE;
+    process.env.AWS_PROFILE = "default";
+    try {
+      configureAiTransportHost({ allowAmbientProviderKey: () => true });
+      expect(getEnvApiKey("amazon-bedrock")).toBe("<authenticated>");
+
+      configureAiTransportHost({ allowAmbientProviderKey: () => false });
+      expect(getEnvApiKey("amazon-bedrock")).toBeUndefined();
+    } finally {
+      if (originalProfile === undefined) {
+        delete process.env.AWS_PROFILE;
+      } else {
+        process.env.AWS_PROFILE = originalProfile;
+      }
+    }
+  });
+});

--- a/packages/ai/src/env-api-keys.ts
+++ b/packages/ai/src/env-api-keys.ts
@@ -1,3 +1,5 @@
+import { getAiTransportHost } from "./host.js";
+
 // NEVER convert to top-level imports - breaks browser/Vite builds
 let existsSync: typeof import("node:fs").existsSync | null = null;
 let homedir: typeof import("node:os").homedir | null = null;
@@ -222,6 +224,11 @@ export function findEnvKeys(provider: string): string[] | undefined {
  * Will not return API keys for providers that require OAuth tokens.
  */
 export function getEnvApiKey(provider: string): string | undefined {
+  // A credential the host's configuration never names is not eligible for use.
+  // `findEnvKeys` stays ungated so reporting can still show it as present.
+  if (!getAiTransportHost().allowAmbientProviderKey(provider)) {
+    return undefined;
+  }
   const envKeys = findEnvKeys(provider);
   if (envKeys?.[0]) {
     return getEnvValue(envKeys[0]);

--- a/packages/ai/src/host.ts
+++ b/packages/ai/src/host.ts
@@ -125,6 +125,12 @@ export interface AiTransportHost {
     timeoutMs?: number,
     options?: { sanitizeSse?: boolean },
   ): typeof fetch | undefined;
+  /**
+   * Reports whether a provider credential that configuration never names may be
+   * consumed. Hosts that own configuration answer from `security.allowAmbientProviderKeys`;
+   * embedding hosts without configuration keep the permissive default.
+   */
+  allowAmbientProviderKey(provider: string): boolean;
   /** Resolves host-owned process-local secret sentinel substrings immediately before egress. */
   resolveSecretSentinel(value: string): string;
   /** Redacts secrets inside structured tool-result payloads. */
@@ -217,6 +223,7 @@ type ActiveAiTransportHost = Omit<AiTransportHost, "normalizeAnthropicInlineCont
 
 const inertAiTransportHost: ActiveAiTransportHost = {
   buildModelFetch: () => undefined,
+  allowAmbientProviderKey: () => true,
   resolveSecretSentinel: (value) => value,
   redactSecrets: (value) => value,
   redactToolPayloadText: (text) => text,

--- a/src/agents/model-auth-env.ambient-gate.test.ts
+++ b/src/agents/model-auth-env.ambient-gate.test.ts
@@ -1,0 +1,52 @@
+// Covers security.allowAmbientProviderKeys: a credential configuration never names
+// is refused for use, while reporting surfaces can still observe it.
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveEnvApiKey } from "./model-auth-env.js";
+
+const AMBIENT_ENV = { OPENAI_API_KEY: "sk-ambient-value" } as NodeJS.ProcessEnv;
+
+function configWithAmbient(allow: boolean | undefined): OpenClawConfig {
+  return (
+    allow === undefined ? {} : { security: { allowAmbientProviderKeys: allow } }
+  ) as OpenClawConfig;
+}
+
+describe("resolveEnvApiKey ambient gate", () => {
+  it("resolves an ambient credential when the setting is absent (documented default)", () => {
+    const resolved = resolveEnvApiKey("openai", AMBIENT_ENV, {
+      config: configWithAmbient(undefined),
+    });
+    expect(resolved?.apiKey).toBe("sk-ambient-value");
+  });
+
+  it("resolves an ambient credential when explicitly allowed", () => {
+    const resolved = resolveEnvApiKey("openai", AMBIENT_ENV, {
+      config: configWithAmbient(true),
+    });
+    expect(resolved?.apiKey).toBe("sk-ambient-value");
+  });
+
+  it("refuses an ambient credential when the operator opts out", () => {
+    const resolved = resolveEnvApiKey("openai", AMBIENT_ENV, {
+      config: configWithAmbient(false),
+    });
+    expect(resolved).toBeNull();
+  });
+
+  it("still resolves for reporting surfaces via inspectOnly", () => {
+    const resolved = resolveEnvApiKey("openai", AMBIENT_ENV, {
+      config: configWithAmbient(false),
+      inspectOnly: true,
+    });
+    expect(resolved?.apiKey).toBe("sk-ambient-value");
+    expect(resolved?.source).toContain("OPENAI_API_KEY");
+  });
+
+  it("does not refuse when the environment holds no credential", () => {
+    const resolved = resolveEnvApiKey("openai", {} as NodeJS.ProcessEnv, {
+      config: configWithAmbient(false),
+    });
+    expect(resolved).toBeNull();
+  });
+});

--- a/src/agents/model-auth-env.ts
+++ b/src/agents/model-auth-env.ts
@@ -40,6 +40,14 @@ export type EnvApiKeyLookupOptions = {
   authEvidenceMap?: Readonly<Record<string, readonly ProviderAuthEvidence[]>>;
   setupProviderFallbackRefs?: readonly string[];
   skipSetupProviderFallback?: boolean;
+  /**
+   * Resolve the credential even when `security.allowAmbientProviderKeys` is false.
+   *
+   * For read-only surfaces — `doctor`, `models list`, usage reporting — which must keep
+   * observing an ambient credential in order to report it as present but not eligible.
+   * Never set this on a path that sends the credential to a provider.
+   */
+  inspectOnly?: boolean;
 };
 
 function resolveAuthEvidence(
@@ -158,6 +166,15 @@ export function resolveEnvApiKey(
   const normalized = aliasMap[normalizedProvider] ?? normalizedProvider;
   const candidateMap = options.candidateMap ?? lookupMaps?.envCandidateMap ?? {};
   const authEvidenceMap = options.authEvidenceMap ?? lookupMaps?.authEvidenceMap ?? {};
+  // An ambient credential is one no configuration names. Reporting surfaces opt out via
+  // `inspectOnly` so a refused credential stays visible rather than silently disappearing.
+  if (
+    options.inspectOnly !== true &&
+    options.config?.security?.allowAmbientProviderKeys === false
+  ) {
+    return null;
+  }
+
   const applied = new Set(getShellEnvAppliedKeys());
   const pick = (envVar: string): EnvApiKeyResult | null => {
     const value = normalizeOptionalSecretInput(env[envVar]);

--- a/src/agents/model-auth-label.test.ts
+++ b/src/agents/model-auth-label.test.ts
@@ -320,6 +320,9 @@ describe("resolveModelAuthLabel", () => {
     expect(label).toBe("api-key (workspace cloud credentials)");
     expect(mocks.resolveEnvApiKey).toHaveBeenCalledWith("workspace-cloud", process.env, {
       config: cfg,
+      // Labeling is a reporting surface: it must keep observing an ambient credential
+      // so it can be shown as present even when policy refuses it for use.
+      inspectOnly: true,
       workspaceDir: "/tmp/workspace",
     });
   });

--- a/src/agents/model-auth-label.ts
+++ b/src/agents/model-auth-label.ts
@@ -133,6 +133,7 @@ export function resolveModelAuthLabel(params: {
 
   const envKey = resolveEnvApiKey(providerKey, process.env, {
     config: params.cfg,
+    inspectOnly: true,
     workspaceDir: params.workspaceDir,
   });
   if (envKey?.apiKey) {

--- a/src/commands/models/list.auth-overview.ts
+++ b/src/commands/models/list.auth-overview.ts
@@ -141,6 +141,7 @@ export function resolveProviderAuthOverview(params: {
 
   const envKey = resolveEnvApiKey(provider, process.env, {
     config: cfg,
+    inspectOnly: true,
     workspaceDir: params.workspaceDir,
     aliasMap: params.aliasMap,
     candidateMap: params.envCandidateMap,

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -605,6 +605,7 @@ export async function modelsStatusCommand(
       if (
         resolveEnvApiKey(provider, process.env, {
           config: cfg,
+          inspectOnly: true,
           workspaceDir,
           aliasMap,
           candidateMap: envCandidateMap,

--- a/src/config/config.ambient-provider-keys.test.ts
+++ b/src/config/config.ambient-provider-keys.test.ts
@@ -1,0 +1,27 @@
+// Covers schema acceptance for security.allowAmbientProviderKeys.
+import { describe, expect, it } from "vitest";
+import { SecuritySchema } from "./zod-schema.root-support.js";
+
+describe("security.allowAmbientProviderKeys schema", () => {
+  it("accepts the setting when disabled", () => {
+    const parsed = SecuritySchema.parse({ allowAmbientProviderKeys: false });
+    expect(parsed).toEqual({ allowAmbientProviderKeys: false });
+  });
+
+  it("accepts the setting alongside existing security keys", () => {
+    const parsed = SecuritySchema.parse({
+      allowAmbientProviderKeys: true,
+      installPolicy: { enabled: true },
+    });
+    expect(parsed).toMatchObject({ allowAmbientProviderKeys: true });
+  });
+
+  it("stays optional so existing configs are unaffected", () => {
+    expect(SecuritySchema.parse({})).toEqual({});
+    expect(SecuritySchema.parse(undefined)).toBeUndefined();
+  });
+
+  it("rejects a non-boolean value", () => {
+    expect(() => SecuritySchema.parse({ allowAmbientProviderKeys: "false" })).toThrow();
+  });
+});

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -44,6 +44,19 @@ export type SecurityConfig = {
     /** Accepted security audit findings to omit from active summary/findings. */
     suppressions?: SecurityAuditSuppression[];
   };
+  /**
+   * Allow provider credentials that configuration never names to be used at runtime.
+   *
+   * Defaults to true, preserving the documented zero-config `PROVIDER_API_KEY` path.
+   * When false, a credential is eligible only where configuration references it —
+   * a provider entry, an auth profile, or a SecretRef. Environment variables remain
+   * a fully supported place to store keys; this setting governs whether one may be
+   * consumed without a configuration reference authorizing it.
+   *
+   * Detection is unaffected: `doctor`, `models list`, and usage reporting continue to
+   * observe ambient credentials and report them as present but not eligible.
+   */
+  allowAmbientProviderKeys?: boolean;
   installPolicy?: {
     /**
      * Enable operator-owned install policy. When true without an exec command,

--- a/src/config/zod-schema.root-support.ts
+++ b/src/config/zod-schema.root-support.ts
@@ -39,6 +39,7 @@ export const TailscaleServiceNameSchema = z
 
 export const SecuritySchema = z
   .strictObject({
+    allowAmbientProviderKeys: z.boolean().optional(),
     audit: z
       .strictObject({
         suppressions: z

--- a/src/llm/ai-transport-host.ts
+++ b/src/llm/ai-transport-host.ts
@@ -7,10 +7,20 @@ import {
   buildGuardedModelFetch,
   resolveModelRequestTimeoutMs,
 } from "../agents/provider-transport-fetch.js";
+import { getRuntimeConfigSnapshot } from "../config/runtime-snapshot.js";
 import { redactSecrets, redactToolPayloadText } from "../logging/redact.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizeAnthropicInlineContentBlocks } from "../media/anthropic-inline-images.js";
 import { swapSecretSentinelsInText } from "../secrets/sentinel.js";
+
+/**
+ * Ambient provider credentials stay eligible unless the operator opts out. Read per
+ * call rather than captured at module load: the host is configured before the runtime
+ * config snapshot is published, and the setting must follow config reloads.
+ */
+function isAmbientProviderKeyAllowed(): boolean {
+  return getRuntimeConfigSnapshot()?.security?.allowAmbientProviderKeys !== false;
+}
 
 const transportLogBySubsystem = new Map<string, ReturnType<typeof createSubsystemLogger>>();
 
@@ -25,6 +35,7 @@ function transportLog(subsystem: string): ReturnType<typeof createSubsystemLogge
 
 configureAiTransportHost({
   buildModelFetch: buildGuardedModelFetch,
+  allowAmbientProviderKey: () => isAmbientProviderKeyAllowed(),
   resolveSecretSentinel: (value) => {
     const swapped = swapSecretSentinelsInText(value);
     const unknown = swapped.unknown[0];


### PR DESCRIPTION
Related: #119074

## What Problem This Solves

An exported `OPENAI_API_KEY` is eligible for use by every subsystem that knows the name — TTS, realtime voice, transcription, media understanding — none of it configured, none of it recorded. That is documented behavior, and often exactly what is wanted. What does not exist is the off switch: a way to say "use a credential only where my configuration references it."

The stakes exceed billing. Media understanding auto-selects providers by scanning which keys exist (manifest `autoPriority`), so an unrelated export can decide which vendor receives user data. Ambient keys also sit outside SecretRef sentinel protection (`docs/gateway/secrets.md` notes this) and stay plaintext across the model-call chain.

This PR adds the off switch and nothing else: `security.allowAmbientProviderKeys`, one boolean, default `true` — no existing installation changes. The rule already exists in narrower forms: a provider pinned `auth: "oauth"` refuses an ambient API key today, and #118759 stopped credentials crossing between embedding providers. This offers the same rule — a credential must be named to be used — globally, opt-in.

## Why This Change Was Made

With the flag `false`, a credential is eligible only where a provider entry, an auth profile, or a SecretRef names it. Two properties are deliberate:

- **Storage is untouched.** Env vars remain a fully supported key store alongside `file`/`exec` providers. The setting governs consumption without a configuration reference, not where keys live.
- **Consumption is gated, not detection.** `doctor`, `models list`, and usage reporting keep observing refused credentials via a new `inspectOnly` lookup option — opting out makes a key ineligible, not invisible.

Two enforcement points, because they are parallel paths, not layers:

- `resolveEnvApiKey()` (`src/agents/model-auth-env.ts`) reads the flag from the config it already receives.
- `getEnvApiKey()` (`packages/ai/src/env-api-keys.ts`) cannot — `@openclaw/ai` has no config access — so it asks the host through the existing `AiTransportHost` seam, the same one that injects guarded fetch and sentinel resolution. The embedding-host default stays permissive. The core implementation reads the runtime config snapshot per call: the transport host is configured before the snapshot publishes, and the setting must follow config reloads.

Untouched in both modes: declared `${VAR}` markers, SecretRefs, auth profiles, OAuth, `auth.order` failover. Only the undeclared path is gated. This continues #118458 (ambient credentials no longer admitted behind declared profiles) at broader scope.

### Why a flag rather than an immediate break

#118759 took the immediate break with no new configuration — the right call at +13 lines in one subsystem. This surface spans nine subsystems, with ~20 direct `process.env` reads outside the two resolvers gated here; flipping the default now would refuse credentials in some subsystems while others silently kept accepting them. The flag is opt-in, with a view to potentially making it on by default at a later date, depending on maintainer direction. The remaining subsystems can land as separately reviewable changes either way; the staging options are laid out in #119074.

## User Impact

- Default `true`: byte-identical behavior, nothing to migrate.
- `false`: ambient credentials become ineligible; operators on the zero-config env path add a provider entry, profile, or SecretRef first.
- Reporting unchanged in both modes.
- Plugins calling the SDK-exported `resolveEnvApiKey` inherit the gate; read-only surfaces should pass `inspectOnly: true`.
- **Platform credential mechanisms are covered, deliberately:** `AWS_PROFILE`, IAM key pairs, Bedrock bearer tokens, ECS/IRSA container credentials, Google ADC. They are ambient by definition and exactly where billing surprises originate — but also platform-standard, so it is stated here rather than discovered. Exempting them is a one-line move of the check if reviewers prefer.

## Comparison with the alternative (PR #119477)

The scoped-names design suggested in #119074 (`OPENAI_TTS_API_KEY` etc.) is implemented in full as PR #119477 against the same base, so the designs compare as measurement:

| | Declared-only flag (this PR) | Scoped names (PR #119477) |
|---|---|---|
| Files | 14 | 40 |
| Production lines | +59 | +367 −53 |
| Code paths altered | 2 central resolvers | 21 resolver sites (33 env reads) across 20 files |
| New env-var names | none | one per subsystem × provider |
| Covers AWS/IAM/ADC mechanisms | yes | no — nothing to rename |
| Covers image generation | yes | no — centrally resolved credential |
| Env-only per-subsystem keys | no | yes |
| Migration at flag-on | author config entries/refs | rename vars in shell, `env.vars`, secret-store IDs |
| Tests | 13 new; 447 neighbors green | 35 new; 8,154-test sweep green |
| `check.mjs` | green | green |

Structural difference: this PR gates at the resolvers, so coverage is central; scoped names must be threaded to every consumption point, since no shared resolver knows which subsystem a lookup serves. Scoped names uniquely offer env-only per-subsystem keys — useful even without any flag. The two compose: scoped names as convenience layer, this flag as security boundary. Landing both first steps, with no mandatory phase for either, closes the gap #119074 describes for operators who opt in.

## Evidence

Red-to-green verified by stashing only the source hunks and re-running the same tests unchanged.

Stock (source reverted, tests kept):

```
FAIL packages/ai/src/env-api-keys.ambient-gate.test.ts > withholds the credential when the host refuses ambient keys
AssertionError: expected 'sk-ambient-value' to be undefined

FAIL src/agents/model-auth-env.ambient-gate.test.ts > refuses an ambient credential when the operator opts out
AssertionError: expected { apiKey: 'sk-ambient-value', …(1) } to be null

 Test Files  3 failed (3)
      Tests  3 failed | 10 passed (13)
```

The 10 passing on stock assert unchanged behavior: permissive default, explicit `true`, `inspectOnly`, no-credential-present. Only the three refusal assertions move.

Patched, with surrounding auth suites: `13 files, 447 tests, all pass`. Schema coverage: 4 tests (`security` is a `z.strictObject`; an unregistered key is rejected outright). Full gate — `node scripts/check.mjs` — exits 0: all typecheck stages, lint, format, repository guards, zero import cycles.

One pre-existing assertion updated: `src/agents/model-auth-label.test.ts` asserts the exact options object passed to `resolveEnvApiKey`, which now carries `inspectOnly: true` on that reporting path. The asserted label value is unchanged.

Scope of claim: this covers the two central resolvers. It does not close the surface — ~20 direct `process.env` reads remain (TTS, realtime, transcription, media understanding, image generation, discovery, `acpx`), tracked in #119074, and are why the default cannot flip yet.

---

🤖 AI-assisted: authored with Claude Code (Opus).
