### PR TITLE
feat(security): subsystem-scoped API key names (OPENAI_TTS_API_KEY) with opt-in enforcement

### DIFF
--- a/extensions/azure-speech/speech-provider.test.ts
+++ b/extensions/azure-speech/speech-provider.test.ts
@@ -15,6 +15,11 @@ vi.mock("./tts.js", async (importOriginal) => {
   };
 });
 
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { buildAzureSpeechProvider } from "./speech-provider.js";
 
 describe("buildAzureSpeechProvider", () => {
@@ -292,5 +297,66 @@ describe("buildAzureSpeechProvider", () => {
 
     expect(listAzureSpeechVoicesMock).not.toHaveBeenCalled();
     expect(azureSpeechTTSMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("buildAzureSpeechProvider scoped env names", () => {
+  const envKeys = [
+    "AZURE_SPEECH_KEY",
+    "AZURE_SPEECH_API_KEY",
+    "AZURE_SPEECH_TTS_API_KEY",
+    "AZURE_SPEECH_REGION",
+    "SPEECH_KEY",
+  ] as const;
+
+  beforeEach(() => {
+    for (const key of envKeys) {
+      vi.stubEnv(key, undefined);
+    }
+    vi.stubEnv("AZURE_SPEECH_REGION", "eastus");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    clearRuntimeConfigSnapshot();
+  });
+
+  it("prefers AZURE_SPEECH_TTS_API_KEY over the generic names", async () => {
+    vi.stubEnv("AZURE_SPEECH_API_KEY", "generic");
+    vi.stubEnv("AZURE_SPEECH_TTS_API_KEY", "scoped");
+    const provider = buildAzureSpeechProvider();
+
+    await provider.synthesize({
+      text: "hello",
+      cfg: {},
+      providerConfig: {},
+      target: "audio-file",
+      timeoutMs: 30_000,
+    });
+
+    expect(azureSpeechTTSMock).toHaveBeenCalledWith(expect.objectContaining({ apiKey: "scoped" }));
+  });
+
+  it("still accepts AZURE_SPEECH_API_KEY by default", () => {
+    vi.stubEnv("AZURE_SPEECH_API_KEY", "generic");
+    const provider = buildAzureSpeechProvider();
+
+    expect(provider.isConfigured({ providerConfig: {}, timeoutMs: 30_000 })).toBe(true);
+  });
+
+  it("ignores AZURE_SPEECH_API_KEY when security.requireScopedApiKeys is enabled", () => {
+    vi.stubEnv("AZURE_SPEECH_API_KEY", "generic");
+    setRuntimeConfigSnapshot({ security: { requireScopedApiKeys: true } } as OpenClawConfig);
+    const provider = buildAzureSpeechProvider();
+
+    expect(provider.isConfigured({ providerConfig: {}, timeoutMs: 30_000 })).toBe(false);
+  });
+
+  it("keeps AZURE_SPEECH_KEY usable under the flag — it has no scoped form", () => {
+    vi.stubEnv("AZURE_SPEECH_KEY", "no-scoped-form");
+    setRuntimeConfigSnapshot({ security: { requireScopedApiKeys: true } } as OpenClawConfig);
+    const provider = buildAzureSpeechProvider();
+
+    expect(provider.isConfigured({ providerConfig: {}, timeoutMs: 30_000 })).toBe(true);
   });
 });

--- a/extensions/azure-speech/speech-provider.ts
+++ b/extensions/azure-speech/speech-provider.ts
@@ -13,6 +13,7 @@ import type {
 import {
   asFiniteNumber,
   asObject,
+  resolveScopedEnvApiKey,
   resolveSpeechProviderApiKey,
   trimToUndefined,
 } from "openclaw/plugin-sdk/speech-core";
@@ -48,10 +49,14 @@ type AzureSpeechProviderOverrides = {
 };
 
 function readAzureSpeechEnvApiKey(): string | undefined {
-  return (
-    trimToUndefined(process.env.AZURE_SPEECH_KEY) ??
-    trimToUndefined(process.env.AZURE_SPEECH_API_KEY) ??
-    trimToUndefined(process.env.SPEECH_KEY)
+  // AZURE_SPEECH_TTS_API_KEY wins over the generic names; with
+  // security.requireScopedApiKeys AZURE_SPEECH_API_KEY is ignored here entirely,
+  // while AZURE_SPEECH_KEY and SPEECH_KEY stay usable — neither has a scoped form.
+  return trimToUndefined(
+    resolveScopedEnvApiKey({
+      baseEnvKeys: ["AZURE_SPEECH_KEY", "AZURE_SPEECH_API_KEY", "SPEECH_KEY"],
+      scope: "tts",
+    })?.value,
   );
 }
 

--- a/extensions/deepgram/realtime-transcription-provider.test.ts
+++ b/extensions/deepgram/realtime-transcription-provider.test.ts
@@ -2,6 +2,10 @@
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type WebSocket from "ws";
 import type { RawData } from "ws";
@@ -466,5 +470,45 @@ describe("buildDeepgramRealtimeTranscriptionProvider", () => {
       ),
     );
     session.close();
+  });
+});
+
+describe("deepgram scoped env names", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    clearRuntimeConfigSnapshot();
+  });
+
+  it("prefers DEEPGRAM_TRANSCRIPTION_API_KEY over DEEPGRAM_API_KEY", async () => {
+    vi.stubEnv("DEEPGRAM_API_KEY", "generic");
+    vi.stubEnv("DEEPGRAM_TRANSCRIPTION_API_KEY", "scoped");
+    const headers: Array<Record<string, string | string[] | undefined>> = [];
+    const server = await createDeepgramRealtimeServer({
+      onRequest: (_url, requestHeaders) => headers.push(requestHeaders),
+    });
+    const session = buildDeepgramRealtimeTranscriptionProvider().createSession({
+      providerConfig: { baseUrl: server.baseUrl },
+    });
+
+    await session.connect();
+    session.close();
+
+    expect(headers[0]?.authorization).toBe("Token scoped");
+  });
+
+  it("still accepts DEEPGRAM_API_KEY by default", () => {
+    vi.stubEnv("DEEPGRAM_API_KEY", "generic");
+    const provider = buildDeepgramRealtimeTranscriptionProvider();
+    expect(provider.isConfigured?.({ providerConfig: {} })).toBe(true);
+  });
+
+  it("ignores DEEPGRAM_API_KEY when security.requireScopedApiKeys is enabled", () => {
+    vi.stubEnv("DEEPGRAM_API_KEY", "generic");
+    setRuntimeConfigSnapshot({ security: { requireScopedApiKeys: true } } as OpenClawConfig);
+    const provider = buildDeepgramRealtimeTranscriptionProvider();
+    expect(provider.isConfigured?.({ providerConfig: {} })).toBe(false);
+    expect(() => provider.createSession({ providerConfig: {} })).toThrow(
+      "Deepgram API key missing",
+    );
   });
 });

--- a/extensions/deepgram/realtime-transcription-provider.ts
+++ b/extensions/deepgram/realtime-transcription-provider.ts
@@ -1,4 +1,5 @@
 // Deepgram provider module implements model/runtime integration.
+import { resolveScopedEnvApiKey } from "openclaw/plugin-sdk/provider-auth";
 import {
   createRealtimeTranscriptionWebSocketSession,
   type RealtimeTranscriptionProviderConfig,
@@ -135,6 +136,13 @@ function toDeepgramRealtimeWsUrl(config: DeepgramRealtimeTranscriptionSessionCon
     url.searchParams.set("language", config.language);
   }
   return url.toString();
+}
+
+function resolveDeepgramEnvApiKey(): string | undefined {
+  // DEEPGRAM_TRANSCRIPTION_API_KEY wins over the generic name; with
+  // security.requireScopedApiKeys the generic name is ignored here entirely.
+  return resolveScopedEnvApiKey({ baseEnvKeys: ["DEEPGRAM_API_KEY"], scope: "transcription" })
+    ?.value;
 }
 
 function normalizeProviderConfig(
@@ -358,10 +366,10 @@ export function buildDeepgramRealtimeTranscriptionProvider(): RealtimeTranscript
     autoSelectOrder: 35,
     resolveConfig: ({ rawConfig }) => normalizeProviderConfig(rawConfig),
     isConfigured: ({ providerConfig }) =>
-      Boolean(normalizeProviderConfig(providerConfig).apiKey || process.env.DEEPGRAM_API_KEY),
+      Boolean(normalizeProviderConfig(providerConfig).apiKey || resolveDeepgramEnvApiKey()),
     createSession: (req) => {
       const config = normalizeProviderConfig(req.providerConfig);
-      const apiKey = config.apiKey || process.env.DEEPGRAM_API_KEY;
+      const apiKey = config.apiKey || resolveDeepgramEnvApiKey();
       if (!apiKey) {
         throw new Error("Deepgram API key missing");
       }

--- a/extensions/deepgram/realtime-transcription-provider.ts
+++ b/extensions/deepgram/realtime-transcription-provider.ts
@@ -1,4 +1,5 @@
 // Deepgram provider module implements model/runtime integration.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveScopedEnvApiKey } from "openclaw/plugin-sdk/provider-auth";
 import {
   createRealtimeTranscriptionWebSocketSession,
@@ -138,11 +139,14 @@ function toDeepgramRealtimeWsUrl(config: DeepgramRealtimeTranscriptionSessionCon
   return url.toString();
 }
 
-function resolveDeepgramEnvApiKey(): string | undefined {
+function resolveDeepgramEnvApiKey(cfg?: OpenClawConfig): string | undefined {
   // DEEPGRAM_TRANSCRIPTION_API_KEY wins over the generic name; with
   // security.requireScopedApiKeys the generic name is ignored here entirely.
-  return resolveScopedEnvApiKey({ baseEnvKeys: ["DEEPGRAM_API_KEY"], scope: "transcription" })
-    ?.value;
+  return resolveScopedEnvApiKey({
+    baseEnvKeys: ["DEEPGRAM_API_KEY"],
+    scope: "transcription",
+    config: cfg,
+  })?.value;
 }
 
 function normalizeProviderConfig(
@@ -365,11 +369,11 @@ export function buildDeepgramRealtimeTranscriptionProvider(): RealtimeTranscript
     defaultModel: DEFAULT_DEEPGRAM_AUDIO_MODEL,
     autoSelectOrder: 35,
     resolveConfig: ({ rawConfig }) => normalizeProviderConfig(rawConfig),
-    isConfigured: ({ providerConfig }) =>
-      Boolean(normalizeProviderConfig(providerConfig).apiKey || resolveDeepgramEnvApiKey()),
+    isConfigured: ({ cfg, providerConfig }) =>
+      Boolean(normalizeProviderConfig(providerConfig).apiKey || resolveDeepgramEnvApiKey(cfg)),
     createSession: (req) => {
       const config = normalizeProviderConfig(req.providerConfig);
-      const apiKey = config.apiKey || resolveDeepgramEnvApiKey();
+      const apiKey = config.apiKey || resolveDeepgramEnvApiKey(req.cfg);
       if (!apiKey) {
         throw new Error("Deepgram API key missing");
       }

--- a/extensions/elevenlabs/media-understanding-provider.test.ts
+++ b/extensions/elevenlabs/media-understanding-provider.test.ts
@@ -1,4 +1,9 @@
 // Elevenlabs tests cover media understanding provider plugin behavior.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { mockPinnedHostnameResolution } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -92,5 +97,73 @@ describe("elevenLabsMediaUnderstandingProvider", () => {
         fetchFn: fetchMock,
       }),
     ).rejects.toThrow("ElevenLabs audio transcription failed: malformed JSON response");
+  });
+});
+
+describe("transcribeElevenLabsAudio scoped env names", () => {
+  let ssrfMock: { mockRestore: () => void } | undefined;
+
+  beforeEach(() => {
+    ssrfMock = mockPinnedHostnameResolution();
+    vi.unstubAllEnvs();
+    for (const key of [
+      "ELEVENLABS_API_KEY",
+      "XI_API_KEY",
+      "ELEVENLABS_MEDIA_API_KEY",
+      "XI_MEDIA_API_KEY",
+    ]) {
+      vi.stubEnv(key, undefined);
+    }
+    clearRuntimeConfigSnapshot();
+  });
+
+  afterEach(() => {
+    ssrfMock?.mockRestore();
+    ssrfMock = undefined;
+    vi.unstubAllEnvs();
+    clearRuntimeConfigSnapshot();
+  });
+
+  async function transcribeWithEnvKey(fetchMock: ReturnType<typeof vi.fn>) {
+    return await transcribeElevenLabsAudio({
+      buffer: Buffer.from("audio"),
+      fileName: "voice.mp3",
+      mime: "audio/mpeg",
+      apiKey: "",
+      model: "scribe_v2",
+      timeoutMs: 1000,
+      fetchFn: fetchMock as unknown as typeof fetch,
+    });
+  }
+
+  it("prefers ELEVENLABS_MEDIA_API_KEY over the generic names", async () => {
+    vi.stubEnv("ELEVENLABS_API_KEY", "generic");
+    vi.stubEnv("ELEVENLABS_MEDIA_API_KEY", "scoped");
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ text: "hi" })));
+
+    await transcribeWithEnvKey(fetchMock);
+
+    const [, init] = requireFirstFetchCall(fetchMock);
+    expect(new Headers(init.headers).get("xi-api-key")).toBe("scoped");
+  });
+
+  it("still accepts ELEVENLABS_API_KEY by default", async () => {
+    vi.stubEnv("ELEVENLABS_API_KEY", "generic");
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ text: "hi" })));
+
+    await transcribeWithEnvKey(fetchMock);
+
+    const [, init] = requireFirstFetchCall(fetchMock);
+    expect(new Headers(init.headers).get("xi-api-key")).toBe("generic");
+  });
+
+  it("ignores the generic names when security.requireScopedApiKeys is enabled", async () => {
+    vi.stubEnv("ELEVENLABS_API_KEY", "generic");
+    vi.stubEnv("XI_API_KEY", "generic");
+    setRuntimeConfigSnapshot({ security: { requireScopedApiKeys: true } } as OpenClawConfig);
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ text: "hi" })));
+
+    await expect(transcribeWithEnvKey(fetchMock)).rejects.toThrow("ElevenLabs API key missing");
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/elevenlabs/media-understanding-provider.ts
+++ b/extensions/elevenlabs/media-understanding-provider.ts
@@ -4,6 +4,7 @@ import type {
   AudioTranscriptionResult,
   MediaUnderstandingProvider,
 } from "openclaw/plugin-sdk/media-understanding";
+import { resolveScopedEnvApiKey } from "openclaw/plugin-sdk/provider-auth";
 import {
   assertOkOrThrowHttpError,
   buildAudioTranscriptionFormData,
@@ -20,7 +21,14 @@ export async function transcribeElevenLabsAudio(
   req: AudioTranscriptionRequest,
 ): Promise<AudioTranscriptionResult> {
   const fetchFn = req.fetchFn ?? fetch;
-  const apiKey = req.apiKey || process.env.ELEVENLABS_API_KEY || process.env.XI_API_KEY;
+  // ELEVENLABS_MEDIA_API_KEY / XI_MEDIA_API_KEY win over the generic names; with
+  // security.requireScopedApiKeys the generic names are ignored here entirely.
+  const apiKey =
+    req.apiKey ||
+    resolveScopedEnvApiKey({
+      baseEnvKeys: ["ELEVENLABS_API_KEY", "XI_API_KEY"],
+      scope: "media",
+    })?.value;
   if (!apiKey) {
     throw new Error("ElevenLabs API key missing");
   }

--- a/extensions/elevenlabs/realtime-transcription-provider.ts
+++ b/extensions/elevenlabs/realtime-transcription-provider.ts
@@ -1,4 +1,5 @@
 // Elevenlabs provider module implements model/runtime integration.
+import { resolveScopedEnvApiKey } from "openclaw/plugin-sdk/provider-auth";
 import {
   createRealtimeTranscriptionWebSocketSession,
   type RealtimeTranscriptionProviderConfig,
@@ -250,10 +251,14 @@ function createElevenLabsRealtimeTranscriptionSession(
 function resolveElevenLabsRealtimeApiKey(
   config: ElevenLabsRealtimeTranscriptionProviderConfig,
 ): string | null | undefined {
+  // XI_TRANSCRIPTION_API_KEY wins over the generic name; with
+  // security.requireScopedApiKeys the generic name is ignored here entirely.
   return (
     config.apiKey ??
     resolveElevenLabsApiKeyWithProfileFallback() ??
-    normalizeOptionalString(process.env.XI_API_KEY)
+    normalizeOptionalString(
+      resolveScopedEnvApiKey({ baseEnvKeys: ["XI_API_KEY"], scope: "transcription" })?.value,
+    )
   );
 }
 

--- a/extensions/elevenlabs/speech-provider.ts
+++ b/extensions/elevenlabs/speech-provider.ts
@@ -24,7 +24,10 @@ import {
   requireInRange,
   trimToUndefined,
 } from "openclaw/plugin-sdk/speech";
-import { resolveSpeechProviderApiKey } from "openclaw/plugin-sdk/speech-core";
+import {
+  resolveScopedEnvApiKey,
+  resolveSpeechProviderApiKey,
+} from "openclaw/plugin-sdk/speech-core";
 import {
   fetchWithSsrFGuard,
   ssrfPolicyFromHttpBaseUrlAllowedHostname,
@@ -181,10 +184,12 @@ function readElevenLabsProviderConfig(config: SpeechProviderConfig): ElevenLabsP
 }
 
 function resolveElevenLabsApiKey(...candidates: Array<string | undefined>): string | undefined {
+  // XI_TTS_API_KEY wins over the generic name; with
+  // security.requireScopedApiKeys the generic name is ignored here entirely.
   return resolveSpeechProviderApiKey(
     ...candidates,
     resolveElevenLabsApiKeyWithProfileFallback() ?? undefined,
-    process.env.XI_API_KEY,
+    resolveScopedEnvApiKey({ baseEnvKeys: ["XI_API_KEY"], scope: "tts" })?.value,
   );
 }
 

--- a/extensions/fish-audio/speech-provider.ts
+++ b/extensions/fish-audio/speech-provider.ts
@@ -14,6 +14,7 @@ import {
   asFiniteNumber,
   asObject,
   parseSpeechDirectiveNumberOverride,
+  resolveScopedEnvApiKey,
   resolveSpeechProviderApiKey,
   trimToUndefined,
 } from "openclaw/plugin-sdk/speech-core";
@@ -130,10 +131,14 @@ function readOverrides(overrides: SpeechProviderOverrides | undefined): FishAudi
 }
 
 function resolveApiKey(configValue?: string): string | undefined {
+  // FISH_TTS_API_KEY / FISH_AUDIO_TTS_API_KEY win over the generic names; with
+  // security.requireScopedApiKeys the generic names are ignored here entirely.
   return resolveSpeechProviderApiKey(
     configValue,
-    process.env.FISH_API_KEY,
-    process.env.FISH_AUDIO_API_KEY,
+    resolveScopedEnvApiKey({
+      baseEnvKeys: ["FISH_API_KEY", "FISH_AUDIO_API_KEY"],
+      scope: "tts",
+    })?.value,
   );
 }
 

--- a/extensions/google/index.ts
+++ b/extensions/google/index.ts
@@ -3,6 +3,7 @@ import type { ImageGenerationProvider } from "openclaw/plugin-sdk/image-generati
 import type { MediaUnderstandingProvider } from "openclaw/plugin-sdk/media-understanding";
 import type { MusicGenerationProvider } from "openclaw/plugin-sdk/music-generation";
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { resolveScopedEnvApiKey } from "openclaw/plugin-sdk/provider-auth";
 import type {
   RealtimeVoiceBridge,
   RealtimeVoiceBridgeCreateRequest,
@@ -196,9 +197,13 @@ function resolveGoogleRealtimeProviderConfig(
 }
 
 function resolveGoogleRealtimeEnvApiKey(): string | undefined {
-  return (
-    normalizeOptionalString(process.env.GEMINI_API_KEY) ??
-    normalizeOptionalString(process.env.GOOGLE_API_KEY)
+  // GEMINI_REALTIME_API_KEY / GOOGLE_REALTIME_API_KEY win over the generic names; with
+  // security.requireScopedApiKeys the generic names are ignored here entirely.
+  return normalizeOptionalString(
+    resolveScopedEnvApiKey({
+      baseEnvKeys: ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
+      scope: "realtime",
+    })?.value,
   );
 }
 

--- a/extensions/google/realtime-voice-provider.test.ts
+++ b/extensions/google/realtime-voice-provider.test.ts
@@ -1,9 +1,14 @@
 // Google tests cover realtime voice provider plugin behavior.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
   resamplePcm,
 } from "openclaw/plugin-sdk/realtime-voice";
 import type { RealtimeVoiceTool } from "openclaw/plugin-sdk/realtime-voice";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildGoogleRealtimeVoiceProvider } from "./realtime-voice-provider.js";
 
@@ -2380,3 +2385,60 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */
+
+describe("buildGoogleRealtimeVoiceProvider scoped env names", () => {
+  const SCOPED_ENV_KEYS = [
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "GEMINI_REALTIME_API_KEY",
+    "GOOGLE_REALTIME_API_KEY",
+  ] as const;
+
+  beforeEach(() => {
+    createGoogleGenAIMock.mockClear();
+    for (const key of SCOPED_ENV_KEYS) {
+      vi.stubEnv(key, undefined);
+    }
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    clearRuntimeConfigSnapshot();
+  });
+
+  it("prefers GEMINI_REALTIME_API_KEY over the generic names", async () => {
+    vi.stubEnv("GEMINI_API_KEY", "generic");
+    vi.stubEnv("GEMINI_REALTIME_API_KEY", "scoped");
+    const provider = buildGoogleRealtimeVoiceProvider();
+
+    await provider.createBrowserSession?.({ providerConfig: {} });
+
+    expect(requireFirstMockArg(createGoogleGenAIMock, "GoogleGenAI config")).toMatchObject({
+      apiKey: "scoped",
+    });
+  });
+
+  it("still accepts GEMINI_API_KEY by default", () => {
+    vi.stubEnv("GEMINI_API_KEY", "generic");
+    const provider = buildGoogleRealtimeVoiceProvider();
+
+    expect(provider.isConfigured?.({ providerConfig: {} })).toBe(true);
+  });
+
+  it("ignores the generic names when security.requireScopedApiKeys is enabled", () => {
+    vi.stubEnv("GEMINI_API_KEY", "generic");
+    vi.stubEnv("GOOGLE_API_KEY", "generic");
+    setRuntimeConfigSnapshot({ security: { requireScopedApiKeys: true } } as OpenClawConfig);
+    const provider = buildGoogleRealtimeVoiceProvider();
+
+    expect(provider.isConfigured?.({ providerConfig: {} })).toBe(false);
+    expect(() =>
+      provider.createBridge({
+        providerConfig: {},
+        tools: [],
+        onAudio: vi.fn(),
+        onClearAudio: vi.fn(),
+      }),
+    ).toThrow("Google Gemini API key missing");
+  });
+});

--- a/extensions/google/realtime-voice-provider.ts
+++ b/extensions/google/realtime-voice-provider.ts
@@ -47,6 +47,7 @@ import {
 } from "openclaw/plugin-sdk/realtime-voice";
 import { warn } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
+import { resolveScopedEnvApiKey } from "openclaw/plugin-sdk/speech-core";
 import {
   asBoolean,
   asFiniteNumber,
@@ -268,7 +269,14 @@ function normalizeProviderConfig(
 }
 
 function resolveEnvApiKey(): string | undefined {
-  return trimToUndefined(process.env.GEMINI_API_KEY) ?? trimToUndefined(process.env.GOOGLE_API_KEY);
+  // GEMINI_REALTIME_API_KEY / GOOGLE_REALTIME_API_KEY win over the generic names; with
+  // security.requireScopedApiKeys the generic names are ignored here entirely.
+  return trimToUndefined(
+    resolveScopedEnvApiKey({
+      baseEnvKeys: ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
+      scope: "realtime",
+    })?.value,
+  );
 }
 
 // Gemini 3.1 Live replaces client-content text and async tools with realtime text

--- a/extensions/google/speech-provider.ts
+++ b/extensions/google/speech-provider.ts
@@ -8,6 +8,7 @@ import {
 } from "openclaw/plugin-sdk/provider-http";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/provider-onboard";
 import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
+import { resolveScopedEnvApiKey } from "openclaw/plugin-sdk/speech-core";
 import type {
   SpeechDirectiveTokenParseContext,
   SpeechProviderConfig,
@@ -156,10 +157,12 @@ function normalizeGooglePromptTemplate(
 }
 
 function resolveGoogleTtsEnvApiKey(): string | undefined {
-  return (
-    normalizeOptionalString(process.env.GEMINI_API_KEY) ??
-    normalizeOptionalString(process.env.GOOGLE_API_KEY)
-  );
+  // GEMINI_TTS_API_KEY / GOOGLE_TTS_API_KEY win over the generic names; with
+  // security.requireScopedApiKeys the generic names are ignored here entirely.
+  return resolveScopedEnvApiKey({
+    baseEnvKeys: ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
+    scope: "tts",
+  })?.value;
 }
 
 function resolveGoogleTtsModelProviderApiKey(cfg?: OpenClawConfig): string | undefined {

--- a/extensions/gradium/speech-provider.ts
+++ b/extensions/gradium/speech-provider.ts
@@ -7,7 +7,10 @@ import type {
   SpeechProviderPlugin,
 } from "openclaw/plugin-sdk/speech";
 import { asObject, trimToUndefined } from "openclaw/plugin-sdk/speech";
-import { resolveSpeechProviderApiKey } from "openclaw/plugin-sdk/speech-core";
+import {
+  resolveScopedEnvApiKey,
+  resolveSpeechProviderApiKey,
+} from "openclaw/plugin-sdk/speech-core";
 import { DEFAULT_GRADIUM_VOICE_ID, GRADIUM_VOICES, normalizeGradiumBaseUrl } from "./shared.js";
 import { gradiumTTS } from "./tts.js";
 
@@ -40,7 +43,12 @@ function readGradiumProviderConfig(config: SpeechProviderConfig): GradiumProvide
 }
 
 function resolveGradiumApiKey(configApiKey: unknown): string | undefined {
-  return resolveSpeechProviderApiKey(trimToUndefined(configApiKey), process.env.GRADIUM_API_KEY);
+  // GRADIUM_TTS_API_KEY wins over the generic name; with
+  // security.requireScopedApiKeys the generic name is ignored here entirely.
+  return resolveSpeechProviderApiKey(
+    trimToUndefined(configApiKey),
+    resolveScopedEnvApiKey({ baseEnvKeys: ["GRADIUM_API_KEY"], scope: "tts" })?.value,
+  );
 }
 
 function isGradiumProviderConfigured(config: SpeechProviderConfig): boolean {

--- a/extensions/inworld/speech-provider.ts
+++ b/extensions/inworld/speech-provider.ts
@@ -9,6 +9,7 @@ import type {
 import {
   asObject,
   parseSpeechDirectiveNumberOverride,
+  resolveScopedEnvApiKey,
   resolveSpeechProviderApiKey,
   trimToUndefined,
 } from "openclaw/plugin-sdk/speech-core";
@@ -68,7 +69,13 @@ function readInworldProviderConfig(config: SpeechProviderConfig): InworldProvide
 }
 
 function resolveInworldApiKey(primary?: string, fallback?: string): string | undefined {
-  return resolveSpeechProviderApiKey(primary, fallback, process.env.INWORLD_API_KEY);
+  // INWORLD_TTS_API_KEY wins over the generic name; with
+  // security.requireScopedApiKeys the generic name is ignored here entirely.
+  return resolveSpeechProviderApiKey(
+    primary,
+    fallback,
+    resolveScopedEnvApiKey({ baseEnvKeys: ["INWORLD_API_KEY"], scope: "tts" })?.value,
+  );
 }
 
 function readInworldOverrides(

--- a/extensions/minimax/speech-provider.ts
+++ b/extensions/minimax/speech-provider.ts
@@ -15,6 +15,7 @@ import type {
 import {
   asObject,
   parseSpeechDirectiveNumberOverride,
+  resolveScopedEnvApiKey,
   resolveSpeechProviderApiKey,
   trimToUndefined,
 } from "openclaw/plugin-sdk/speech-core";
@@ -86,10 +87,12 @@ async function resolveMinimaxTtsApiKey(params: {
 }
 
 function resolveMinimaxDirectTtsApiKey(configApiKey?: string): string | undefined {
+  // MINIMAX_TTS_API_KEY wins over the generic name; with
+  // security.requireScopedApiKeys the generic name is ignored here entirely.
   return resolveSpeechProviderApiKey(
     configApiKey,
     resolveMinimaxTokenPlanEnvKey(),
-    process.env.MINIMAX_API_KEY,
+    resolveScopedEnvApiKey({ baseEnvKeys: ["MINIMAX_API_KEY"], scope: "tts" })?.value,
   );
 }
 

--- a/extensions/mistral/realtime-transcription-provider.ts
+++ b/extensions/mistral/realtime-transcription-provider.ts
@@ -1,4 +1,5 @@
 // Mistral provider module implements model/runtime integration.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveScopedEnvApiKey } from "openclaw/plugin-sdk/provider-auth";
 import {
   createRealtimeTranscriptionWebSocketSession,
@@ -152,11 +153,15 @@ function normalizeMistralApiKey(value: unknown): string | undefined {
   return normalizeSecretInput(resolved) || undefined;
 }
 
-function resolveMistralTranscriptionEnvApiKey(): string | undefined {
+function resolveMistralTranscriptionEnvApiKey(cfg?: OpenClawConfig): string | undefined {
   // MISTRAL_TRANSCRIPTION_API_KEY wins over the generic name; with
   // security.requireScopedApiKeys the generic name is ignored here entirely.
   return normalizeMistralApiKey(
-    resolveScopedEnvApiKey({ baseEnvKeys: ["MISTRAL_API_KEY"], scope: "transcription" })?.value,
+    resolveScopedEnvApiKey({
+      baseEnvKeys: ["MISTRAL_API_KEY"],
+      scope: "transcription",
+      config: cfg,
+    })?.value,
   );
 }
 
@@ -324,13 +329,13 @@ export function buildMistralRealtimeTranscriptionProvider(): RealtimeTranscripti
     defaultModel: MISTRAL_REALTIME_DEFAULT_MODEL,
     autoSelectOrder: 45,
     resolveConfig: ({ rawConfig }) => normalizeProviderConfig(rawConfig),
-    isConfigured: ({ providerConfig }) =>
+    isConfigured: ({ cfg, providerConfig }) =>
       Boolean(
-        normalizeProviderConfig(providerConfig).apiKey || resolveMistralTranscriptionEnvApiKey(),
+        normalizeProviderConfig(providerConfig).apiKey || resolveMistralTranscriptionEnvApiKey(cfg),
       ),
     createSession: (req) => {
       const config = normalizeProviderConfig(req.providerConfig);
-      const apiKey = config.apiKey || resolveMistralTranscriptionEnvApiKey();
+      const apiKey = config.apiKey || resolveMistralTranscriptionEnvApiKey(req.cfg);
       if (!apiKey) {
         throw new Error("Mistral API key missing");
       }

--- a/extensions/mistral/realtime-transcription-provider.ts
+++ b/extensions/mistral/realtime-transcription-provider.ts
@@ -1,4 +1,5 @@
 // Mistral provider module implements model/runtime integration.
+import { resolveScopedEnvApiKey } from "openclaw/plugin-sdk/provider-auth";
 import {
   createRealtimeTranscriptionWebSocketSession,
   type RealtimeTranscriptionProviderConfig,
@@ -149,6 +150,14 @@ function normalizeMistralApiKey(value: unknown): string | undefined {
     path: "plugins.entries.voice-call.config.streaming.providers.mistral.apiKey",
   });
   return normalizeSecretInput(resolved) || undefined;
+}
+
+function resolveMistralTranscriptionEnvApiKey(): string | undefined {
+  // MISTRAL_TRANSCRIPTION_API_KEY wins over the generic name; with
+  // security.requireScopedApiKeys the generic name is ignored here entirely.
+  return normalizeMistralApiKey(
+    resolveScopedEnvApiKey({ baseEnvKeys: ["MISTRAL_API_KEY"], scope: "transcription" })?.value,
+  );
 }
 
 function readErrorDetail(event: MistralRealtimeTranscriptionEvent): string {
@@ -317,12 +326,11 @@ export function buildMistralRealtimeTranscriptionProvider(): RealtimeTranscripti
     resolveConfig: ({ rawConfig }) => normalizeProviderConfig(rawConfig),
     isConfigured: ({ providerConfig }) =>
       Boolean(
-        normalizeProviderConfig(providerConfig).apiKey ||
-        normalizeMistralApiKey(process.env.MISTRAL_API_KEY),
+        normalizeProviderConfig(providerConfig).apiKey || resolveMistralTranscriptionEnvApiKey(),
       ),
     createSession: (req) => {
       const config = normalizeProviderConfig(req.providerConfig);
-      const apiKey = config.apiKey || normalizeMistralApiKey(process.env.MISTRAL_API_KEY);
+      const apiKey = config.apiKey || resolveMistralTranscriptionEnvApiKey();
       if (!apiKey) {
         throw new Error("Mistral API key missing");
       }

--- a/extensions/openai/image-generation-provider.test.ts
+++ b/extensions/openai/image-generation-provider.test.ts
@@ -1,5 +1,9 @@
 // Openai tests cover image generation provider plugin behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildOpenAIImageGenerationProvider } from "./image-generation-provider.js";
 
@@ -2749,4 +2753,61 @@ describe("openai image generation provider", () => {
     });
   });
 });
+
+describe("openai image generation provider scoped env names", () => {
+  // A custom (non-public) OpenAI base URL is the path where the env credential
+  // itself decides configuration, so it isolates the scoped-name behavior.
+  const CUSTOM_ENDPOINT_CFG = {
+    models: {
+      providers: {
+        openai: {
+          baseUrl: "https://openai-compatible.example.test/v1",
+          models: [],
+        },
+      },
+    },
+  } as OpenClawConfig;
+
+  afterEach(() => {
+    ensureAuthProfileStoreMock.mockReset();
+    ensureAuthProfileStoreMock.mockReturnValue({ version: 1, profiles: {} });
+    isProviderApiKeyConfiguredMock.mockReset();
+    isProviderApiKeyConfiguredMock.mockReturnValue(false);
+    vi.unstubAllEnvs();
+    clearRuntimeConfigSnapshot();
+  });
+
+  it("accepts OPENAI_IMAGE_API_KEY on its own", () => {
+    vi.stubEnv("OPENAI_API_KEY", "");
+    vi.stubEnv("OPENAI_IMAGE_API_KEY", "scoped");
+    isProviderApiKeyConfiguredMock.mockReturnValue(true);
+    const provider = buildOpenAIImageGenerationProvider();
+
+    expect(provider.isConfigured?.({ agentDir: "/tmp/agent", cfg: CUSTOM_ENDPOINT_CFG })).toBe(
+      true,
+    );
+  });
+
+  it("still accepts OPENAI_API_KEY by default", () => {
+    vi.stubEnv("OPENAI_API_KEY", "generic");
+    isProviderApiKeyConfiguredMock.mockReturnValue(true);
+    const provider = buildOpenAIImageGenerationProvider();
+
+    expect(provider.isConfigured?.({ agentDir: "/tmp/agent", cfg: CUSTOM_ENDPOINT_CFG })).toBe(
+      true,
+    );
+  });
+
+  it("ignores OPENAI_API_KEY when security.requireScopedApiKeys is enabled", () => {
+    vi.stubEnv("OPENAI_API_KEY", "generic");
+    isProviderApiKeyConfiguredMock.mockReturnValue(true);
+    setRuntimeConfigSnapshot({ security: { requireScopedApiKeys: true } } as OpenClawConfig);
+    const provider = buildOpenAIImageGenerationProvider();
+
+    expect(provider.isConfigured?.({ agentDir: "/tmp/agent", cfg: CUSTOM_ENDPOINT_CFG })).toBe(
+      false,
+    );
+  });
+});
+
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/openai/image-generation-provider.test.ts
+++ b/extensions/openai/image-generation-provider.test.ts
@@ -1,9 +1,5 @@
 // Openai tests cover image generation provider plugin behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import {
-  clearRuntimeConfigSnapshot,
-  setRuntimeConfigSnapshot,
-} from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildOpenAIImageGenerationProvider } from "./image-generation-provider.js";
 
@@ -2751,62 +2747,6 @@ describe("openai image generation provider", () => {
       expect(httpConfigCall().defaultHeaders).toEqual({ Authorization: "Bearer openai-key" });
       expect(jsonRequestCall().url).toBe("https://api.openai.com/v1/images/generations");
     });
-  });
-});
-
-describe("openai image generation provider scoped env names", () => {
-  // A custom (non-public) OpenAI base URL is the path where the env credential
-  // itself decides configuration, so it isolates the scoped-name behavior.
-  const CUSTOM_ENDPOINT_CFG = {
-    models: {
-      providers: {
-        openai: {
-          baseUrl: "https://openai-compatible.example.test/v1",
-          models: [],
-        },
-      },
-    },
-  } as OpenClawConfig;
-
-  afterEach(() => {
-    ensureAuthProfileStoreMock.mockReset();
-    ensureAuthProfileStoreMock.mockReturnValue({ version: 1, profiles: {} });
-    isProviderApiKeyConfiguredMock.mockReset();
-    isProviderApiKeyConfiguredMock.mockReturnValue(false);
-    vi.unstubAllEnvs();
-    clearRuntimeConfigSnapshot();
-  });
-
-  it("accepts OPENAI_IMAGE_API_KEY on its own", () => {
-    vi.stubEnv("OPENAI_API_KEY", "");
-    vi.stubEnv("OPENAI_IMAGE_API_KEY", "scoped");
-    isProviderApiKeyConfiguredMock.mockReturnValue(true);
-    const provider = buildOpenAIImageGenerationProvider();
-
-    expect(provider.isConfigured?.({ agentDir: "/tmp/agent", cfg: CUSTOM_ENDPOINT_CFG })).toBe(
-      true,
-    );
-  });
-
-  it("still accepts OPENAI_API_KEY by default", () => {
-    vi.stubEnv("OPENAI_API_KEY", "generic");
-    isProviderApiKeyConfiguredMock.mockReturnValue(true);
-    const provider = buildOpenAIImageGenerationProvider();
-
-    expect(provider.isConfigured?.({ agentDir: "/tmp/agent", cfg: CUSTOM_ENDPOINT_CFG })).toBe(
-      true,
-    );
-  });
-
-  it("ignores OPENAI_API_KEY when security.requireScopedApiKeys is enabled", () => {
-    vi.stubEnv("OPENAI_API_KEY", "generic");
-    isProviderApiKeyConfiguredMock.mockReturnValue(true);
-    setRuntimeConfigSnapshot({ security: { requireScopedApiKeys: true } } as OpenClawConfig);
-    const provider = buildOpenAIImageGenerationProvider();
-
-    expect(provider.isConfigured?.({ agentDir: "/tmp/agent", cfg: CUSTOM_ENDPOINT_CFG })).toBe(
-      false,
-    );
   });
 });
 

--- a/extensions/openai/image-generation-provider.ts
+++ b/extensions/openai/image-generation-provider.ts
@@ -23,6 +23,7 @@ import {
   hasConfiguredSecretInput,
   isProviderApiKeyConfigured,
   listProfilesForProvider,
+  resolveScopedEnvApiKey,
   type AuthProfileStore,
 } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
@@ -369,7 +370,9 @@ function hasDirectOpenAIImageApiKeyAuth(params: {
   if (hasExplicitOpenAIImageApiKeyConfig(params.cfg)) {
     return true;
   }
-  if (process.env.OPENAI_API_KEY?.trim()) {
+  // OPENAI_IMAGE_API_KEY wins over the generic name; with
+  // security.requireScopedApiKeys the generic name is ignored here entirely.
+  if (resolveScopedEnvApiKey({ baseEnvKeys: ["OPENAI_API_KEY"], scope: "image" })?.value) {
     return true;
   }
   const store = params.agentDir

--- a/extensions/openai/image-generation-provider.ts
+++ b/extensions/openai/image-generation-provider.ts
@@ -23,7 +23,6 @@ import {
   hasConfiguredSecretInput,
   isProviderApiKeyConfigured,
   listProfilesForProvider,
-  resolveScopedEnvApiKey,
   type AuthProfileStore,
 } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
@@ -370,9 +369,7 @@ function hasDirectOpenAIImageApiKeyAuth(params: {
   if (hasExplicitOpenAIImageApiKeyConfig(params.cfg)) {
     return true;
   }
-  // OPENAI_IMAGE_API_KEY wins over the generic name; with
-  // security.requireScopedApiKeys the generic name is ignored here entirely.
-  if (resolveScopedEnvApiKey({ baseEnvKeys: ["OPENAI_API_KEY"], scope: "image" })?.value) {
+  if (process.env.OPENAI_API_KEY?.trim()) {
     return true;
   }
   const store = params.agentDir

--- a/extensions/openai/realtime-transcription-provider.test.ts
+++ b/extensions/openai/realtime-transcription-provider.test.ts
@@ -68,9 +68,12 @@ vi.mock("ws", () => ({
   default: FakeWebSocket,
 }));
 
-vi.mock("openclaw/plugin-sdk/provider-auth", () => ({
+vi.mock("openclaw/plugin-sdk/provider-auth", async (importOriginal) => ({
   isProviderAuthProfileConfigured: providerAuthMocks.isProviderAuthProfileConfigured,
   resolveProviderAuthProfileApiKey: providerAuthMocks.resolveProviderAuthProfileApiKey,
+  resolveScopedEnvApiKey: (
+    await importOriginal<typeof import("openclaw/plugin-sdk/provider-auth")>()
+  ).resolveScopedEnvApiKey,
 }));
 
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({

--- a/extensions/openai/realtime-transcription-provider.ts
+++ b/extensions/openai/realtime-transcription-provider.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   isProviderAuthProfileConfigured,
   resolveProviderAuthProfileApiKey,
+  resolveScopedEnvApiKey,
 } from "openclaw/plugin-sdk/provider-auth";
 import { resolveProviderRequestHeaders } from "openclaw/plugin-sdk/provider-http";
 import {
@@ -173,6 +174,12 @@ function buildOpenAIRealtimeTranscriptionSessionPayload(
   };
 }
 
+function resolveOpenAITranscriptionEnvApiKey(): string | undefined {
+  // OPENAI_TRANSCRIPTION_API_KEY wins over the generic name; with
+  // security.requireScopedApiKeys the generic name is ignored here entirely.
+  return resolveScopedEnvApiKey({ baseEnvKeys: ["OPENAI_API_KEY"], scope: "transcription" })?.value;
+}
+
 async function resolveOpenAIRealtimeTranscriptionAuthorization(
   config: OpenAIRealtimeTranscriptionSessionConfig,
 ): Promise<string> {
@@ -193,7 +200,7 @@ async function resolveOpenAIRealtimeTranscriptionAuthorization(
     });
     return clientSecret.value;
   }
-  const envApiKey = process.env.OPENAI_API_KEY?.trim();
+  const envApiKey = resolveOpenAITranscriptionEnvApiKey();
   if (envApiKey) {
     return envApiKey;
   }
@@ -604,7 +611,7 @@ export function buildOpenAIRealtimeTranscriptionProvider(): RealtimeTranscriptio
     isConfigured: ({ cfg, providerConfig }) =>
       Boolean(
         normalizeProviderConfig(providerConfig).apiKey ||
-        process.env.OPENAI_API_KEY?.trim() ||
+        resolveOpenAITranscriptionEnvApiKey() ||
         isProviderAuthProfileConfigured({ provider: "openai", cfg, profileTypes: ["api_key"] }),
       ),
     createSession: (req) => {

--- a/extensions/openai/realtime-transcription-provider.ts
+++ b/extensions/openai/realtime-transcription-provider.ts
@@ -174,10 +174,14 @@ function buildOpenAIRealtimeTranscriptionSessionPayload(
   };
 }
 
-function resolveOpenAITranscriptionEnvApiKey(): string | undefined {
+function resolveOpenAITranscriptionEnvApiKey(cfg: OpenClawConfig | undefined): string | undefined {
   // OPENAI_TRANSCRIPTION_API_KEY wins over the generic name; with
   // security.requireScopedApiKeys the generic name is ignored here entirely.
-  return resolveScopedEnvApiKey({ baseEnvKeys: ["OPENAI_API_KEY"], scope: "transcription" })?.value;
+  return resolveScopedEnvApiKey({
+    baseEnvKeys: ["OPENAI_API_KEY"],
+    scope: "transcription",
+    config: cfg,
+  })?.value;
 }
 
 async function resolveOpenAIRealtimeTranscriptionAuthorization(
@@ -200,7 +204,7 @@ async function resolveOpenAIRealtimeTranscriptionAuthorization(
     });
     return clientSecret.value;
   }
-  const envApiKey = resolveOpenAITranscriptionEnvApiKey();
+  const envApiKey = resolveOpenAITranscriptionEnvApiKey(config.cfg);
   if (envApiKey) {
     return envApiKey;
   }
@@ -611,7 +615,7 @@ export function buildOpenAIRealtimeTranscriptionProvider(): RealtimeTranscriptio
     isConfigured: ({ cfg, providerConfig }) =>
       Boolean(
         normalizeProviderConfig(providerConfig).apiKey ||
-        resolveOpenAITranscriptionEnvApiKey() ||
+        resolveOpenAITranscriptionEnvApiKey(cfg) ||
         isProviderAuthProfileConfigured({ provider: "openai", cfg, profileTypes: ["api_key"] }),
       ),
     createSession: (req) => {

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -38,6 +38,7 @@ import {
   normalizeResolvedSecretInputString,
   normalizeSecretInputString,
 } from "openclaw/plugin-sdk/secret-input";
+import { resolveScopedEnvApiKey } from "openclaw/plugin-sdk/speech-core";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import WebSocket from "ws";
 import {
@@ -377,7 +378,10 @@ function resolveOpenAIRealtimeSecretInput(
 }
 
 function resolveOpenAIRealtimeEnvApiKey(): OpenAIRealtimeApiKeyResolution {
-  const envValue = normalizeSecretInputString(process.env.OPENAI_API_KEY);
+  // OPENAI_REALTIME_API_KEY wins over the generic name; with
+  // security.requireScopedApiKeys the generic name is ignored here entirely.
+  const scoped = resolveScopedEnvApiKey({ baseEnvKeys: ["OPENAI_API_KEY"], scope: "realtime" });
+  const envValue = normalizeSecretInputString(scoped?.value);
   if (!envValue) {
     return { status: "missing" };
   }
@@ -416,7 +420,7 @@ function hasOpenAIRealtimeConfiguredApiKeyInput(configuredApiKey: string | undef
 function hasOpenAIRealtimeApiKeyInput(configuredApiKey: string | undefined): boolean {
   return Boolean(
     normalizeSecretInputString(configuredApiKey) ??
-    normalizeSecretInputString(process.env.OPENAI_API_KEY),
+    resolveScopedEnvApiKey({ baseEnvKeys: ["OPENAI_API_KEY"], scope: "realtime" })?.value,
   );
 }
 

--- a/extensions/openai/speech-provider.ts
+++ b/extensions/openai/speech-provider.ts
@@ -8,7 +8,10 @@ import type {
   SpeechProviderOverrides,
   SpeechProviderPlugin,
 } from "openclaw/plugin-sdk/speech-core";
-import { parseSpeechDirectiveNumberOverride } from "openclaw/plugin-sdk/speech-core";
+import {
+  parseSpeechDirectiveNumberOverride,
+  resolveScopedEnvApiKey,
+} from "openclaw/plugin-sdk/speech-core";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
@@ -51,7 +54,12 @@ type OpenAITtsProviderOverrides = {
 };
 
 function resolveOpenAISpeechApiKey(config: OpenAITtsProviderConfig): string | undefined {
-  return trimToUndefined(config.apiKey) ?? trimToUndefined(process.env.OPENAI_API_KEY);
+  // OPENAI_TTS_API_KEY wins over the generic name; with
+  // security.requireScopedApiKeys the generic name is ignored here entirely.
+  return (
+    trimToUndefined(config.apiKey) ??
+    resolveScopedEnvApiKey({ baseEnvKeys: ["OPENAI_API_KEY"], scope: "tts" })?.value
+  );
 }
 
 function normalizeOpenAISpeechResponseFormat(

--- a/extensions/tavily/src/config.test.ts
+++ b/extensions/tavily/src/config.test.ts
@@ -113,3 +113,30 @@ describe("resolveTavilyApiKey", () => {
     expect(resolveTavilyApiKey(configWithApiKey(apiKey, extra))).toBeUndefined();
   });
 });
+
+describe("resolveTavilyApiKey scoped env names", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("prefers TAVILY_SEARCH_API_KEY over TAVILY_API_KEY", () => {
+    vi.stubEnv("TAVILY_API_KEY", "generic");
+    vi.stubEnv("TAVILY_SEARCH_API_KEY", "scoped");
+
+    expect(resolveTavilyApiKey({} as OpenClawConfig)).toBe("scoped");
+  });
+
+  it("still accepts TAVILY_API_KEY by default", () => {
+    vi.stubEnv("TAVILY_API_KEY", "generic");
+
+    expect(resolveTavilyApiKey({} as OpenClawConfig)).toBe("generic");
+  });
+
+  it("ignores TAVILY_API_KEY when security.requireScopedApiKeys is enabled", () => {
+    vi.stubEnv("TAVILY_API_KEY", "generic");
+
+    expect(
+      resolveTavilyApiKey({ security: { requireScopedApiKeys: true } } as OpenClawConfig),
+    ).toBeUndefined();
+  });
+});

--- a/extensions/tavily/src/config.ts
+++ b/extensions/tavily/src/config.ts
@@ -1,6 +1,7 @@
 // Tavily helper module supports config behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { canResolveEnvSecretRefInReadOnlyPath } from "openclaw/plugin-sdk/extension-shared";
+import { resolveScopedEnvApiKey } from "openclaw/plugin-sdk/provider-auth";
 import { resolvePositiveTimeoutSeconds } from "openclaw/plugin-sdk/provider-web-search";
 import { resolveSecretInputString, normalizeSecretInput } from "openclaw/plugin-sdk/secret-input";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -90,7 +91,14 @@ export function resolveTavilyApiKey(cfg?: OpenClawConfig): string | undefined {
   if (resolved.status === "blocked") {
     return undefined;
   }
-  return normalizeSecretInput(process.env.TAVILY_API_KEY) || undefined;
+  // TAVILY_SEARCH_API_KEY wins over the generic name; with
+  // security.requireScopedApiKeys the generic name is ignored here entirely.
+  return (
+    normalizeSecretInput(
+      resolveScopedEnvApiKey({ baseEnvKeys: ["TAVILY_API_KEY"], scope: "search", config: cfg })
+        ?.value,
+    ) || undefined
+  );
 }
 
 export function resolveTavilyBaseUrl(cfg?: OpenClawConfig): string {

--- a/extensions/volcengine/speech-provider.ts
+++ b/extensions/volcengine/speech-provider.ts
@@ -9,6 +9,7 @@ import type {
 import {
   asObject,
   parseSpeechDirectiveNumberOverride,
+  resolveScopedEnvApiKey,
   resolveSpeechProviderApiKey,
   trimToUndefined,
 } from "openclaw/plugin-sdk/speech-core";
@@ -94,10 +95,15 @@ function normalizeVolcengineProviderConfig(
 }
 
 function resolveSeedSpeechApiKey(configApiKey?: string): string | undefined {
+  // VOLCENGINE_TTS_API_KEY already names its subsystem, so it is used as-is;
+  // BYTEPLUS_SEED_SPEECH_TTS_API_KEY wins over the generic BytePlus name, which
+  // security.requireScopedApiKeys ignores here entirely.
   return resolveSpeechProviderApiKey(
     configApiKey,
-    process.env.VOLCENGINE_TTS_API_KEY,
-    process.env.BYTEPLUS_SEED_SPEECH_API_KEY,
+    resolveScopedEnvApiKey({
+      baseEnvKeys: ["VOLCENGINE_TTS_API_KEY", "BYTEPLUS_SEED_SPEECH_API_KEY"],
+      scope: "tts",
+    })?.value,
   );
 }
 
@@ -107,7 +113,11 @@ function resolveLegacyVolcengineCredentials(config: {
 }): Pick<VolcengineTtsProviderConfig, "appId" | "token"> {
   return {
     appId: trimToUndefined(config.appId) ?? trimToUndefined(process.env.VOLCENGINE_TTS_APPID),
-    token: resolveSpeechProviderApiKey(config.token, process.env.VOLCENGINE_TTS_TOKEN),
+    // VOLCENGINE_TTS_TOKEN already names its subsystem and is used as-is.
+    token: resolveSpeechProviderApiKey(
+      config.token,
+      resolveScopedEnvApiKey({ baseEnvKeys: ["VOLCENGINE_TTS_TOKEN"], scope: "tts" })?.value,
+    ),
   };
 }
 

--- a/extensions/vydra/speech-provider.ts
+++ b/extensions/vydra/speech-provider.ts
@@ -1,4 +1,5 @@
 // Vydra provider module implements model/runtime integration.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
 import {
   assertOkOrThrowHttpError,
@@ -73,10 +74,11 @@ function readVydraSpeechConfig(config: SpeechProviderConfig): VydraSpeechConfig 
   };
 }
 
-function resolveVydraEnvApiKey(): string | undefined {
+function resolveVydraEnvApiKey(cfg?: OpenClawConfig): string | undefined {
   // VYDRA_TTS_API_KEY wins over the generic name; with
   // security.requireScopedApiKeys the generic name is ignored here entirely.
-  return resolveScopedEnvApiKey({ baseEnvKeys: ["VYDRA_API_KEY"], scope: "tts" })?.value;
+  return resolveScopedEnvApiKey({ baseEnvKeys: ["VYDRA_API_KEY"], scope: "tts", config: cfg })
+    ?.value;
 }
 
 function readVydraOverrides(overrides: SpeechProviderOverrides | undefined): {
@@ -100,17 +102,17 @@ export function buildVydraSpeechProvider(): SpeechProviderPlugin {
     voices: VYDRA_SPEECH_VOICES.map((voice) => voice.id),
     resolveConfig: ({ rawConfig }) => normalizeVydraSpeechConfig(rawConfig),
     listVoices: async () => VYDRA_SPEECH_VOICES.map((voice) => Object.assign({}, voice)),
-    isConfigured: ({ providerConfig }) =>
+    isConfigured: ({ cfg, providerConfig }) =>
       Boolean(
         resolveSpeechProviderApiKey(
           readVydraSpeechConfig(providerConfig).apiKey,
-          resolveVydraEnvApiKey(),
+          resolveVydraEnvApiKey(cfg),
         ),
       ),
     synthesize: async (req) => {
       const config = readVydraSpeechConfig(req.providerConfig);
       const overrides = readVydraOverrides(req.providerOverrides);
-      const apiKey = resolveSpeechProviderApiKey(config.apiKey, resolveVydraEnvApiKey());
+      const apiKey = resolveSpeechProviderApiKey(config.apiKey, resolveVydraEnvApiKey(req.cfg));
       if (!apiKey) {
         throw new Error("Vydra API key missing");
       }

--- a/extensions/vydra/speech-provider.ts
+++ b/extensions/vydra/speech-provider.ts
@@ -12,7 +12,11 @@ import type {
   SpeechProviderOverrides,
   SpeechProviderPlugin,
 } from "openclaw/plugin-sdk/speech-core";
-import { asObject, resolveSpeechProviderApiKey } from "openclaw/plugin-sdk/speech-core";
+import {
+  asObject,
+  resolveScopedEnvApiKey,
+  resolveSpeechProviderApiKey,
+} from "openclaw/plugin-sdk/speech-core";
 import {
   DEFAULT_VYDRA_BASE_URL,
   DEFAULT_VYDRA_SPEECH_MODEL,
@@ -69,6 +73,12 @@ function readVydraSpeechConfig(config: SpeechProviderConfig): VydraSpeechConfig 
   };
 }
 
+function resolveVydraEnvApiKey(): string | undefined {
+  // VYDRA_TTS_API_KEY wins over the generic name; with
+  // security.requireScopedApiKeys the generic name is ignored here entirely.
+  return resolveScopedEnvApiKey({ baseEnvKeys: ["VYDRA_API_KEY"], scope: "tts" })?.value;
+}
+
 function readVydraOverrides(overrides: SpeechProviderOverrides | undefined): {
   model?: string;
   voiceId?: string;
@@ -94,13 +104,13 @@ export function buildVydraSpeechProvider(): SpeechProviderPlugin {
       Boolean(
         resolveSpeechProviderApiKey(
           readVydraSpeechConfig(providerConfig).apiKey,
-          process.env.VYDRA_API_KEY,
+          resolveVydraEnvApiKey(),
         ),
       ),
     synthesize: async (req) => {
       const config = readVydraSpeechConfig(req.providerConfig);
       const overrides = readVydraOverrides(req.providerOverrides);
-      const apiKey = resolveSpeechProviderApiKey(config.apiKey, process.env.VYDRA_API_KEY);
+      const apiKey = resolveSpeechProviderApiKey(config.apiKey, resolveVydraEnvApiKey());
       if (!apiKey) {
         throw new Error("Vydra API key missing");
       }

--- a/extensions/xai/realtime-transcription-provider.test.ts
+++ b/extensions/xai/realtime-transcription-provider.test.ts
@@ -13,8 +13,11 @@ const { isProviderAuthProfileConfiguredMock, resolveApiKeyForProviderMock } = vi
   ),
 }));
 
-vi.mock("openclaw/plugin-sdk/provider-auth", () => ({
+vi.mock("openclaw/plugin-sdk/provider-auth", async (importOriginal) => ({
   isProviderAuthProfileConfigured: isProviderAuthProfileConfiguredMock,
+  resolveScopedEnvApiKey: (
+    await importOriginal<typeof import("openclaw/plugin-sdk/provider-auth")>()
+  ).resolveScopedEnvApiKey,
 }));
 
 vi.mock("openclaw/plugin-sdk/provider-auth-runtime", () => ({

--- a/extensions/xai/realtime-transcription-provider.ts
+++ b/extensions/xai/realtime-transcription-provider.ts
@@ -1,6 +1,7 @@
 // Xai provider module implements model/runtime integration.
 import {
   isProviderAuthProfileConfigured,
+  resolveScopedEnvApiKey,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
@@ -241,13 +242,14 @@ export function buildXaiRealtimeTranscriptionProvider(): RealtimeTranscriptionPr
     isConfigured: ({ providerConfig, cfg }) =>
       Boolean(
         normalizeProviderConfig(providerConfig).apiKey ??
-        normalizeOptionalString(process.env.XAI_API_KEY),
+        normalizeOptionalString(resolveXaiTranscriptionEnvApiKey()),
       ) || isProviderAuthProfileConfigured({ provider: "xai", cfg }),
     createSession: (req) => {
       const config = normalizeProviderConfig(req.providerConfig);
       // createSession must stay sync per RealtimeTranscriptionProviderPlugin; bearer is resolved lazily in headers().
       const seedApiKey =
-        normalizeOptionalString(config.apiKey) ?? normalizeOptionalString(process.env.XAI_API_KEY);
+        normalizeOptionalString(config.apiKey) ??
+        normalizeOptionalString(resolveXaiTranscriptionEnvApiKey());
       return createXaiRealtimeTranscriptionSession({
         ...req,
         apiKey: seedApiKey ?? "",
@@ -263,16 +265,23 @@ export function buildXaiRealtimeTranscriptionProvider(): RealtimeTranscriptionPr
   };
 }
 
+function resolveXaiTranscriptionEnvApiKey(): string | undefined {
+  // XAI_TRANSCRIPTION_API_KEY wins over the generic name; with
+  // security.requireScopedApiKeys the generic name is ignored here entirely.
+  return resolveScopedEnvApiKey({ baseEnvKeys: ["XAI_API_KEY"], scope: "transcription" })?.value;
+}
+
 // Resolve an xAI bearer for the realtime `/stt` WebSocket:
 // 1. Configured `plugins.entries.voice-call.config.streaming.providers.xai.apiKey`
-// 2. `XAI_API_KEY` env var
+// 2. `XAI_TRANSCRIPTION_API_KEY`, then `XAI_API_KEY` env var
 // 3. xAI OAuth auth profile (cfg-scoped)
 async function resolveXaiRealtimeApiKey(
   configApiKey: string | undefined,
   cfg: OpenClawConfig | undefined,
 ): Promise<string> {
   const direct =
-    normalizeOptionalString(configApiKey) ?? normalizeOptionalString(process.env.XAI_API_KEY);
+    normalizeOptionalString(configApiKey) ??
+    normalizeOptionalString(resolveXaiTranscriptionEnvApiKey());
   if (direct) {
     return direct;
   }

--- a/extensions/xai/realtime-transcription-provider.ts
+++ b/extensions/xai/realtime-transcription-provider.ts
@@ -242,14 +242,14 @@ export function buildXaiRealtimeTranscriptionProvider(): RealtimeTranscriptionPr
     isConfigured: ({ providerConfig, cfg }) =>
       Boolean(
         normalizeProviderConfig(providerConfig).apiKey ??
-        normalizeOptionalString(resolveXaiTranscriptionEnvApiKey()),
+        normalizeOptionalString(resolveXaiTranscriptionEnvApiKey(cfg)),
       ) || isProviderAuthProfileConfigured({ provider: "xai", cfg }),
     createSession: (req) => {
       const config = normalizeProviderConfig(req.providerConfig);
       // createSession must stay sync per RealtimeTranscriptionProviderPlugin; bearer is resolved lazily in headers().
       const seedApiKey =
         normalizeOptionalString(config.apiKey) ??
-        normalizeOptionalString(resolveXaiTranscriptionEnvApiKey());
+        normalizeOptionalString(resolveXaiTranscriptionEnvApiKey(req.cfg));
       return createXaiRealtimeTranscriptionSession({
         ...req,
         apiKey: seedApiKey ?? "",
@@ -265,10 +265,14 @@ export function buildXaiRealtimeTranscriptionProvider(): RealtimeTranscriptionPr
   };
 }
 
-function resolveXaiTranscriptionEnvApiKey(): string | undefined {
+function resolveXaiTranscriptionEnvApiKey(cfg: OpenClawConfig | undefined): string | undefined {
   // XAI_TRANSCRIPTION_API_KEY wins over the generic name; with
   // security.requireScopedApiKeys the generic name is ignored here entirely.
-  return resolveScopedEnvApiKey({ baseEnvKeys: ["XAI_API_KEY"], scope: "transcription" })?.value;
+  return resolveScopedEnvApiKey({
+    baseEnvKeys: ["XAI_API_KEY"],
+    scope: "transcription",
+    config: cfg,
+  })?.value;
 }
 
 // Resolve an xAI bearer for the realtime `/stt` WebSocket:
@@ -281,7 +285,7 @@ async function resolveXaiRealtimeApiKey(
 ): Promise<string> {
   const direct =
     normalizeOptionalString(configApiKey) ??
-    normalizeOptionalString(resolveXaiTranscriptionEnvApiKey());
+    normalizeOptionalString(resolveXaiTranscriptionEnvApiKey(cfg));
   if (direct) {
     return direct;
   }

--- a/extensions/xai/realtime-voice-config.ts
+++ b/extensions/xai/realtime-voice-config.ts
@@ -1,5 +1,6 @@
 import {
   isProviderAuthProfileConfigured,
+  resolveScopedEnvApiKey,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
@@ -228,12 +229,18 @@ export function toXaiRealtimeWsUrl(
   return url.toString();
 }
 
+function resolveXaiRealtimeEnvApiKey(): string | undefined {
+  return resolveScopedEnvApiKey({ baseEnvKeys: ["XAI_API_KEY"], scope: "realtime" })?.value;
+}
+
 export async function resolveXaiRealtimeApiKey(
   configApiKey: string | undefined,
   cfg: OpenClawConfig | undefined,
 ): Promise<string> {
+  // XAI_REALTIME_API_KEY wins over the generic name; with
+  // security.requireScopedApiKeys the generic name is ignored here entirely.
   const direct =
-    normalizeOptionalString(configApiKey) ?? normalizeOptionalString(process.env.XAI_API_KEY);
+    normalizeOptionalString(configApiKey) ?? normalizeOptionalString(resolveXaiRealtimeEnvApiKey());
   if (direct) {
     return direct;
   }
@@ -251,7 +258,10 @@ export function hasXaiRealtimeApiKeyInput(
   configApiKey: string | undefined,
   cfg: OpenClawConfig | undefined,
 ): boolean {
-  if (normalizeOptionalString(configApiKey) || normalizeOptionalString(process.env.XAI_API_KEY)) {
+  if (
+    normalizeOptionalString(configApiKey) ||
+    normalizeOptionalString(resolveXaiRealtimeEnvApiKey())
+  ) {
     return true;
   }
   return isProviderAuthProfileConfigured({ provider: "xai", cfg });

--- a/extensions/xai/realtime-voice-config.ts
+++ b/extensions/xai/realtime-voice-config.ts
@@ -229,8 +229,9 @@ export function toXaiRealtimeWsUrl(
   return url.toString();
 }
 
-function resolveXaiRealtimeEnvApiKey(): string | undefined {
-  return resolveScopedEnvApiKey({ baseEnvKeys: ["XAI_API_KEY"], scope: "realtime" })?.value;
+function resolveXaiRealtimeEnvApiKey(cfg: OpenClawConfig | undefined): string | undefined {
+  return resolveScopedEnvApiKey({ baseEnvKeys: ["XAI_API_KEY"], scope: "realtime", config: cfg })
+    ?.value;
 }
 
 export async function resolveXaiRealtimeApiKey(
@@ -240,7 +241,8 @@ export async function resolveXaiRealtimeApiKey(
   // XAI_REALTIME_API_KEY wins over the generic name; with
   // security.requireScopedApiKeys the generic name is ignored here entirely.
   const direct =
-    normalizeOptionalString(configApiKey) ?? normalizeOptionalString(resolveXaiRealtimeEnvApiKey());
+    normalizeOptionalString(configApiKey) ??
+    normalizeOptionalString(resolveXaiRealtimeEnvApiKey(cfg));
   if (direct) {
     return direct;
   }
@@ -260,7 +262,7 @@ export function hasXaiRealtimeApiKeyInput(
 ): boolean {
   if (
     normalizeOptionalString(configApiKey) ||
-    normalizeOptionalString(resolveXaiRealtimeEnvApiKey())
+    normalizeOptionalString(resolveXaiRealtimeEnvApiKey(cfg))
   ) {
     return true;
   }

--- a/extensions/xai/realtime-voice-provider.test.ts
+++ b/extensions/xai/realtime-voice-provider.test.ts
@@ -91,8 +91,11 @@ vi.mock("ws", () => ({
   default: FakeWebSocket,
 }));
 
-vi.mock("openclaw/plugin-sdk/provider-auth", () => ({
+vi.mock("openclaw/plugin-sdk/provider-auth", async (importOriginal) => ({
   isProviderAuthProfileConfigured: isProviderAuthProfileConfiguredMock,
+  resolveScopedEnvApiKey: (
+    await importOriginal<typeof import("openclaw/plugin-sdk/provider-auth")>()
+  ).resolveScopedEnvApiKey,
 }));
 
 vi.mock("openclaw/plugin-sdk/provider-auth-runtime", () => ({

--- a/extensions/xai/speech-provider.test.ts
+++ b/extensions/xai/speech-provider.test.ts
@@ -1,3 +1,8 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
 // Xai tests cover speech provider plugin behavior.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildXaiSpeechProvider } from "./speech-provider.js";
@@ -422,5 +427,68 @@ describe("xai speech provider", () => {
     });
     expect(resolveApiKeyForProviderMock).toHaveBeenCalledWith({ provider: "xai", cfg });
     expect(requireLastTtsCall().apiKey).toBe("oauth-bearer");
+  });
+});
+
+describe("xai speech provider scoped env names", () => {
+  afterEach(() => {
+    xaiTTSMock.mockClear();
+    isProviderAuthProfileConfiguredMock.mockReset();
+    isProviderAuthProfileConfiguredMock.mockReturnValue(false);
+    resolveApiKeyForProviderMock.mockReset();
+    resolveApiKeyForProviderMock.mockResolvedValue({ apiKey: undefined });
+    delete process.env.XAI_API_KEY;
+    delete process.env.XAI_TTS_API_KEY;
+    clearRuntimeConfigSnapshot();
+  });
+
+  it("prefers XAI_TTS_API_KEY over XAI_API_KEY", async () => {
+    process.env.XAI_API_KEY = "generic";
+    process.env.XAI_TTS_API_KEY = "scoped";
+    const provider = buildXaiSpeechProvider();
+
+    await provider.synthesize({
+      text: "hello",
+      cfg: {},
+      providerConfig: {},
+      target: "audio-file",
+      timeoutMs: 5_000,
+    });
+
+    expect(requireLastTtsCall().apiKey).toBe("scoped");
+  });
+
+  it("still accepts XAI_API_KEY by default", async () => {
+    process.env.XAI_API_KEY = "generic";
+    const provider = buildXaiSpeechProvider();
+
+    expect(provider.isConfigured({ cfg: {}, providerConfig: {}, timeoutMs: 5_000 })).toBe(true);
+    await provider.synthesize({
+      text: "hello",
+      cfg: {},
+      providerConfig: {},
+      target: "audio-file",
+      timeoutMs: 5_000,
+    });
+
+    expect(requireLastTtsCall().apiKey).toBe("generic");
+  });
+
+  it("ignores XAI_API_KEY when security.requireScopedApiKeys is enabled", async () => {
+    process.env.XAI_API_KEY = "generic";
+    setRuntimeConfigSnapshot({ security: { requireScopedApiKeys: true } } as OpenClawConfig);
+    const provider = buildXaiSpeechProvider();
+
+    expect(provider.isConfigured({ cfg: {}, providerConfig: {}, timeoutMs: 5_000 })).toBe(false);
+    await expect(
+      provider.synthesize({
+        text: "hello",
+        cfg: {},
+        providerConfig: {},
+        target: "audio-file",
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow("xAI credentials missing for TTS");
+    expect(xaiTTSMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/xai/speech-provider.ts
+++ b/extensions/xai/speech-provider.ts
@@ -15,7 +15,10 @@ import {
   type SpeechSynthesisRequest,
   type SpeechSynthesisTarget,
 } from "openclaw/plugin-sdk/speech";
-import { resolveSpeechProviderApiKey } from "openclaw/plugin-sdk/speech-core";
+import {
+  resolveScopedEnvApiKey,
+  resolveSpeechProviderApiKey,
+} from "openclaw/plugin-sdk/speech-core";
 import {
   asFiniteNumberInRange,
   normalizeLowercaseStringOrEmpty,
@@ -139,7 +142,12 @@ function readXaiOverrides(overrides: SpeechProviderOverrides | undefined): XaiTt
 }
 
 function resolveDirectXaiAudioApiKey(configApiKey?: string): string | undefined {
-  return resolveSpeechProviderApiKey(configApiKey, process.env.XAI_API_KEY);
+  // XAI_TTS_API_KEY wins over the generic name; with
+  // security.requireScopedApiKeys the generic name is ignored here entirely.
+  return resolveSpeechProviderApiKey(
+    configApiKey,
+    resolveScopedEnvApiKey({ baseEnvKeys: ["XAI_API_KEY"], scope: "tts" })?.value,
+  );
 }
 
 async function resolveXaiSpeechSynthesisRequest(

--- a/extensions/xiaomi/speech-provider.ts
+++ b/extensions/xiaomi/speech-provider.ts
@@ -14,6 +14,7 @@ import type {
 } from "openclaw/plugin-sdk/speech-core";
 import {
   asObject,
+  resolveScopedEnvApiKey,
   resolveSpeechProviderApiKey,
   trimToUndefined,
 } from "openclaw/plugin-sdk/speech-core";
@@ -135,9 +136,11 @@ function readXiaomiTtsProviderConfig(config: SpeechProviderConfig): XiaomiTtsPro
 
 function resolveXiaomiTtsProviderConfig(config: SpeechProviderConfig): XiaomiTtsProviderConfig {
   const providerConfig = readXiaomiTtsProviderConfig(config);
+  // XIAOMI_TTS_API_KEY wins over the generic name; with
+  // security.requireScopedApiKeys the generic name is ignored here entirely.
   const resolvedKey = resolveSpeechProviderApiKey(
     providerConfig.apiKey,
-    process.env.XIAOMI_API_KEY,
+    resolveScopedEnvApiKey({ baseEnvKeys: ["XIAOMI_API_KEY"], scope: "tts" })?.value,
   );
   return {
     ...providerConfig,

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -44,6 +44,17 @@ export type SecurityConfig = {
     /** Accepted security audit findings to omit from active summary/findings. */
     suppressions?: SecurityAuditSuppression[];
   };
+  /**
+   * Require subsystem-scoped environment key names where a subsystem defines one.
+   *
+   * Defaults to false. Subsystems that recognize a scoped variable — for example
+   * OPENAI_TTS_API_KEY for TTS or OPENAI_REALTIME_API_KEY for realtime voice —
+   * always prefer it over the generic PROVIDER_API_KEY. When this is true, the
+   * generic name is ignored for those subsystems entirely: a credential is used
+   * only when the scoped name or explicit configuration provides one. Model
+   * inference keeps the generic name either way; it is the primary consumer.
+   */
+  requireScopedApiKeys?: boolean;
   installPolicy?: {
     /**
      * Enable operator-owned install policy. When true without an exec command,

--- a/src/config/zod-schema.root-support.ts
+++ b/src/config/zod-schema.root-support.ts
@@ -39,6 +39,7 @@ export const TailscaleServiceNameSchema = z
 
 export const SecuritySchema = z
   .strictObject({
+    requireScopedApiKeys: z.boolean().optional(),
     audit: z
       .strictObject({
         suppressions: z

--- a/src/plugin-sdk/provider-auth.ts
+++ b/src/plugin-sdk/provider-auth.ts
@@ -110,6 +110,12 @@ export {
 export { createProviderApiKeyAuthMethod } from "../plugins/provider-api-key-auth.js";
 export { coerceSecretRef, hasConfiguredSecretInput } from "../config/types.secrets.js";
 export { resolveDefaultSecretProviderAlias } from "../secrets/ref-contract.js";
+export {
+  deriveScopedEnvKeyName,
+  resolveScopedEnvApiKey,
+  type EnvKeyScope,
+  type ScopedEnvApiKeyResult,
+} from "../secrets/scoped-env-keys.js";
 export { resolveRequiredHomeDir } from "../infra/home-dir.js";
 export {
   normalizeOptionalSecretInput,

--- a/src/plugin-sdk/speech-core.ts
+++ b/src/plugin-sdk/speech-core.ts
@@ -1,5 +1,11 @@
 // Shared speech-provider implementation helpers for bundled and third-party plugins.
 
+export {
+  deriveScopedEnvKeyName,
+  resolveScopedEnvApiKey,
+  type EnvKeyScope,
+  type ScopedEnvApiKeyResult,
+} from "../secrets/scoped-env-keys.js";
 export type { SpeechProviderPlugin } from "../plugins/types.js";
 export type { ResolvedTtsConfig, ResolvedTtsModelOverrides } from "../tts/tts-types.js";
 export type {

--- a/src/secrets/scoped-env-keys.test.ts
+++ b/src/secrets/scoped-env-keys.test.ts
@@ -1,0 +1,90 @@
+// Covers subsystem-scoped env key derivation, precedence, and the require-scoped flag.
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { deriveScopedEnvKeyName, resolveScopedEnvApiKey } from "./scoped-env-keys.js";
+
+const REQUIRE_SCOPED = { security: { requireScopedApiKeys: true } } as OpenClawConfig;
+const ALLOW_GENERIC = { security: { requireScopedApiKeys: false } } as OpenClawConfig;
+
+describe("deriveScopedEnvKeyName", () => {
+  it("inserts the subsystem token before the _API_KEY suffix", () => {
+    expect(deriveScopedEnvKeyName("OPENAI_API_KEY", "tts")).toBe("OPENAI_TTS_API_KEY");
+    expect(deriveScopedEnvKeyName("GEMINI_API_KEY", "embedding")).toBe("GEMINI_EMBEDDING_API_KEY");
+    expect(deriveScopedEnvKeyName("OPENAI_API_KEY", "realtime")).toBe("OPENAI_REALTIME_API_KEY");
+  });
+
+  it("returns undefined for names without the generic suffix", () => {
+    expect(deriveScopedEnvKeyName("ANTHROPIC_OAUTH_TOKEN", "tts")).toBeUndefined();
+  });
+});
+
+describe("resolveScopedEnvApiKey", () => {
+  it("prefers the scoped name over the generic one", () => {
+    const resolved = resolveScopedEnvApiKey({
+      baseEnvKeys: ["OPENAI_API_KEY"],
+      scope: "tts",
+      env: { OPENAI_API_KEY: "sk-generic", OPENAI_TTS_API_KEY: "sk-tts" } as NodeJS.ProcessEnv,
+      config: ALLOW_GENERIC,
+    });
+    expect(resolved).toEqual({ value: "sk-tts", envVar: "OPENAI_TTS_API_KEY", scoped: true });
+  });
+
+  it("consults every scoped candidate before any generic one", () => {
+    // GEMINI_API_KEY (generic) is set, but GOOGLE_TTS_API_KEY (scoped, lower base
+    // precedence) must still win: scoped names always outrank generic names.
+    const resolved = resolveScopedEnvApiKey({
+      baseEnvKeys: ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
+      scope: "tts",
+      env: { GEMINI_API_KEY: "sk-generic", GOOGLE_TTS_API_KEY: "sk-tts" } as NodeJS.ProcessEnv,
+      config: ALLOW_GENERIC,
+    });
+    expect(resolved).toEqual({ value: "sk-tts", envVar: "GOOGLE_TTS_API_KEY", scoped: true });
+  });
+
+  it("falls back to the generic name by default", () => {
+    const resolved = resolveScopedEnvApiKey({
+      baseEnvKeys: ["OPENAI_API_KEY"],
+      scope: "tts",
+      env: { OPENAI_API_KEY: "sk-generic" } as NodeJS.ProcessEnv,
+      config: ALLOW_GENERIC,
+    });
+    expect(resolved).toEqual({ value: "sk-generic", envVar: "OPENAI_API_KEY", scoped: false });
+  });
+
+  it("ignores the generic name when scoped keys are required", () => {
+    const resolved = resolveScopedEnvApiKey({
+      baseEnvKeys: ["OPENAI_API_KEY"],
+      scope: "tts",
+      env: { OPENAI_API_KEY: "sk-generic" } as NodeJS.ProcessEnv,
+      config: REQUIRE_SCOPED,
+    });
+    expect(resolved).toBeUndefined();
+  });
+
+  it("still resolves the scoped name when scoped keys are required", () => {
+    const resolved = resolveScopedEnvApiKey({
+      baseEnvKeys: ["OPENAI_API_KEY"],
+      scope: "realtime",
+      env: {
+        OPENAI_API_KEY: "sk-generic",
+        OPENAI_REALTIME_API_KEY: "sk-realtime",
+      } as NodeJS.ProcessEnv,
+      config: REQUIRE_SCOPED,
+    });
+    expect(resolved).toEqual({
+      value: "sk-realtime",
+      envVar: "OPENAI_REALTIME_API_KEY",
+      scoped: true,
+    });
+  });
+
+  it("returns undefined when nothing is set", () => {
+    const resolved = resolveScopedEnvApiKey({
+      baseEnvKeys: ["OPENAI_API_KEY"],
+      scope: "tts",
+      env: {} as NodeJS.ProcessEnv,
+      config: ALLOW_GENERIC,
+    });
+    expect(resolved).toBeUndefined();
+  });
+});

--- a/src/secrets/scoped-env-keys.test.ts
+++ b/src/secrets/scoped-env-keys.test.ts
@@ -13,8 +13,19 @@ describe("deriveScopedEnvKeyName", () => {
     expect(deriveScopedEnvKeyName("OPENAI_API_KEY", "realtime")).toBe("OPENAI_REALTIME_API_KEY");
   });
 
+  it("supports the media and search subsystem tokens", () => {
+    expect(deriveScopedEnvKeyName("ELEVENLABS_API_KEY", "media")).toBe("ELEVENLABS_MEDIA_API_KEY");
+    expect(deriveScopedEnvKeyName("TAVILY_API_KEY", "search")).toBe("TAVILY_SEARCH_API_KEY");
+  });
+
+  it("returns an already-scoped name unchanged instead of deriving again", () => {
+    expect(deriveScopedEnvKeyName("VOLCENGINE_TTS_API_KEY", "tts")).toBe("VOLCENGINE_TTS_API_KEY");
+    expect(deriveScopedEnvKeyName("VOLCENGINE_TTS_TOKEN", "tts")).toBe("VOLCENGINE_TTS_TOKEN");
+  });
+
   it("returns undefined for names without the generic suffix", () => {
     expect(deriveScopedEnvKeyName("ANTHROPIC_OAUTH_TOKEN", "tts")).toBeUndefined();
+    expect(deriveScopedEnvKeyName("AZURE_SPEECH_KEY", "tts")).toBeUndefined();
   });
 });
 
@@ -76,6 +87,45 @@ describe("resolveScopedEnvApiKey", () => {
       envVar: "OPENAI_REALTIME_API_KEY",
       scoped: true,
     });
+  });
+
+  it("uses an already-scoped name directly, even when scoped keys are required", () => {
+    const resolved = resolveScopedEnvApiKey({
+      baseEnvKeys: ["VOLCENGINE_TTS_API_KEY"],
+      scope: "tts",
+      env: { VOLCENGINE_TTS_API_KEY: "sk-volc" } as NodeJS.ProcessEnv,
+      config: REQUIRE_SCOPED,
+    });
+    expect(resolved).toEqual({
+      value: "sk-volc",
+      envVar: "VOLCENGINE_TTS_API_KEY",
+      scoped: true,
+    });
+  });
+
+  it("keeps a non-derivable name usable when scoped keys are required", () => {
+    // AZURE_SPEECH_KEY has no scoped form to express, so requiring one cannot
+    // exclude it — otherwise the credential would be unreachable under the flag.
+    const resolved = resolveScopedEnvApiKey({
+      baseEnvKeys: ["AZURE_SPEECH_KEY"],
+      scope: "tts",
+      env: { AZURE_SPEECH_KEY: "sk-azure" } as NodeJS.ProcessEnv,
+      config: REQUIRE_SCOPED,
+    });
+    expect(resolved).toEqual({ value: "sk-azure", envVar: "AZURE_SPEECH_KEY", scoped: false });
+  });
+
+  it("still drops derivable generic names alongside a non-derivable one", () => {
+    const resolved = resolveScopedEnvApiKey({
+      baseEnvKeys: ["AZURE_SPEECH_API_KEY", "AZURE_SPEECH_KEY"],
+      scope: "tts",
+      env: {
+        AZURE_SPEECH_API_KEY: "sk-generic",
+        AZURE_SPEECH_KEY: "sk-azure",
+      } as NodeJS.ProcessEnv,
+      config: REQUIRE_SCOPED,
+    });
+    expect(resolved).toEqual({ value: "sk-azure", envVar: "AZURE_SPEECH_KEY", scoped: false });
   });
 
   it("returns undefined when nothing is set", () => {

--- a/src/secrets/scoped-env-keys.ts
+++ b/src/secrets/scoped-env-keys.ts
@@ -1,0 +1,84 @@
+/**
+ * Subsystem-scoped environment key names.
+ *
+ * A generic variable such as OPENAI_API_KEY is ambiguous: model inference, TTS,
+ * realtime voice, transcription, and embeddings can all consume it. A scoped name
+ * such as OPENAI_TTS_API_KEY states the intended consumer in the name itself.
+ *
+ * Lookup order: every scoped candidate is consulted before any generic one, so
+ * setting a scoped variable always wins. With `security.requireScopedApiKeys`
+ * enabled, generic names are ignored entirely for subsystems that define a scope —
+ * a subsystem then uses a credential only when its scoped name (or explicit
+ * configuration) provides one.
+ */
+import { getRuntimeConfigSnapshot } from "../config/runtime-snapshot.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { normalizeOptionalSecretInput } from "../utils/normalize-secret-input.js";
+
+/** Subsystem tokens that may appear inside a scoped variable name. */
+export type EnvKeyScope = "tts" | "realtime" | "transcription" | "embedding" | "image" | "video";
+
+const GENERIC_SUFFIX = "_API_KEY";
+
+/**
+ * Derives the scoped variable name for a generic one.
+ * `OPENAI_API_KEY` + `tts` → `OPENAI_TTS_API_KEY`. Names that do not end in
+ * `_API_KEY` have no derivable scoped form and return undefined.
+ */
+export function deriveScopedEnvKeyName(baseEnvKey: string, scope: EnvKeyScope): string | undefined {
+  if (!baseEnvKey.endsWith(GENERIC_SUFFIX)) {
+    return undefined;
+  }
+  const prefix = baseEnvKey.slice(0, -GENERIC_SUFFIX.length);
+  return `${prefix}_${scope.toUpperCase()}${GENERIC_SUFFIX}`;
+}
+
+export type ScopedEnvApiKeyResult = {
+  value: string;
+  /** The variable the value came from. */
+  envVar: string;
+  /** True when a scoped name supplied the value. */
+  scoped: boolean;
+};
+
+function requireScopedApiKeys(config?: OpenClawConfig): boolean {
+  const cfg = config ?? getRuntimeConfigSnapshot() ?? undefined;
+  return cfg?.security?.requireScopedApiKeys === true;
+}
+
+/**
+ * Resolves a credential for one subsystem from environment state.
+ *
+ * All scoped candidates are consulted before any generic candidate. When
+ * `security.requireScopedApiKeys` is enabled, generic candidates are skipped —
+ * explicit configuration remains unaffected because callers consult it before
+ * reaching environment fallback at all.
+ */
+export function resolveScopedEnvApiKey(params: {
+  baseEnvKeys: readonly string[];
+  scope: EnvKeyScope;
+  env?: NodeJS.ProcessEnv;
+  config?: OpenClawConfig;
+}): ScopedEnvApiKeyResult | undefined {
+  const env = params.env ?? process.env;
+  for (const baseEnvKey of params.baseEnvKeys) {
+    const scopedName = deriveScopedEnvKeyName(baseEnvKey, params.scope);
+    if (!scopedName) {
+      continue;
+    }
+    const value = normalizeOptionalSecretInput(env[scopedName]);
+    if (value) {
+      return { value, envVar: scopedName, scoped: true };
+    }
+  }
+  if (requireScopedApiKeys(params.config)) {
+    return undefined;
+  }
+  for (const baseEnvKey of params.baseEnvKeys) {
+    const value = normalizeOptionalSecretInput(env[baseEnvKey]);
+    if (value) {
+      return { value, envVar: baseEnvKey, scoped: false };
+    }
+  }
+  return undefined;
+}

--- a/src/secrets/scoped-env-keys.ts
+++ b/src/secrets/scoped-env-keys.ts
@@ -21,7 +21,6 @@ export type EnvKeyScope =
   | "realtime"
   | "transcription"
   | "embedding"
-  | "image"
   | "video"
   | "media"
   | "search";

--- a/src/secrets/scoped-env-keys.ts
+++ b/src/secrets/scoped-env-keys.ts
@@ -16,16 +16,41 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeOptionalSecretInput } from "../utils/normalize-secret-input.js";
 
 /** Subsystem tokens that may appear inside a scoped variable name. */
-export type EnvKeyScope = "tts" | "realtime" | "transcription" | "embedding" | "image" | "video";
+export type EnvKeyScope =
+  | "tts"
+  | "realtime"
+  | "transcription"
+  | "embedding"
+  | "image"
+  | "video"
+  | "media"
+  | "search";
 
 const GENERIC_SUFFIX = "_API_KEY";
 
+/** True when the name already carries the subsystem token, e.g. VOLCENGINE_TTS_TOKEN under `tts`. */
+function hasScopeToken(baseEnvKey: string, scope: EnvKeyScope): boolean {
+  const token = scope.toUpperCase();
+  return baseEnvKey.split("_").includes(token);
+}
+
 /**
- * Derives the scoped variable name for a generic one.
- * `OPENAI_API_KEY` + `tts` → `OPENAI_TTS_API_KEY`. Names that do not end in
- * `_API_KEY` have no derivable scoped form and return undefined.
+ * Derives the scoped variable name for a base one.
+ *
+ * `OPENAI_API_KEY` + `tts` → `OPENAI_TTS_API_KEY`. A name that already carries the
+ * subsystem token (`VOLCENGINE_TTS_API_KEY`, `VOLCENGINE_TTS_TOKEN`) is returned
+ * unchanged — it is already scoped, and deriving again would invent
+ * `VOLCENGINE_TTS_TTS_API_KEY`.
+ *
+ * A name with neither the `_API_KEY` suffix nor the subsystem token (`AZURE_SPEECH_KEY`,
+ * `SPEECH_KEY`) has no scoped form at all and returns undefined. Such names stay usable
+ * even when `security.requireScopedApiKeys` is enabled: a scoped name cannot be required
+ * where none can be expressed.
  */
 export function deriveScopedEnvKeyName(baseEnvKey: string, scope: EnvKeyScope): string | undefined {
+  if (hasScopeToken(baseEnvKey, scope)) {
+    return baseEnvKey;
+  }
   if (!baseEnvKey.endsWith(GENERIC_SUFFIX)) {
     return undefined;
   }
@@ -52,7 +77,8 @@ function requireScopedApiKeys(config?: OpenClawConfig): boolean {
  * All scoped candidates are consulted before any generic candidate. When
  * `security.requireScopedApiKeys` is enabled, generic candidates are skipped —
  * explicit configuration remains unaffected because callers consult it before
- * reaching environment fallback at all.
+ * reaching environment fallback at all. A base name with no expressible scoped
+ * form is exempt from that rule and stays usable.
  */
 export function resolveScopedEnvApiKey(params: {
   baseEnvKeys: readonly string[];
@@ -71,10 +97,12 @@ export function resolveScopedEnvApiKey(params: {
       return { value, envVar: scopedName, scoped: true };
     }
   }
-  if (requireScopedApiKeys(params.config)) {
-    return undefined;
-  }
+  const requireScoped = requireScopedApiKeys(params.config);
   for (const baseEnvKey of params.baseEnvKeys) {
+    // Under the flag only names with no expressible scoped form remain eligible.
+    if (requireScoped && deriveScopedEnvKeyName(baseEnvKey, params.scope)) {
+      continue;
+    }
     const value = normalizeOptionalSecretInput(env[baseEnvKey]);
     if (value) {
       return { value, envVar: baseEnvKey, scoped: false };

--- a/src/tts/openai-compatible-speech-provider.ts
+++ b/src/tts/openai-compatible-speech-provider.ts
@@ -9,6 +9,7 @@ import {
   resolveProviderHttpRequestConfig,
 } from "../plugin-sdk/provider-http.js";
 import type { SpeechProviderPlugin } from "../plugins/types.js";
+import { resolveScopedEnvApiKey } from "../secrets/scoped-env-keys.js";
 import type {
   SpeechDirectiveTokenParseContext,
   SpeechProviderConfig,
@@ -268,7 +269,9 @@ export function createOpenAiCompatibleSpeechProvider<
         value: readModelProviderConfig(params.cfg, providerConfigKey)?.apiKey,
         path: `models.providers.${providerConfigKey}.apiKey`,
       }) ??
-      trimToUndefined(process.env[options.envKey])
+      // e.g. OPENROUTER_TTS_API_KEY wins over OPENROUTER_API_KEY; with
+      // security.requireScopedApiKeys the generic name is ignored here entirely.
+      resolveScopedEnvApiKey({ baseEnvKeys: [options.envKey], scope: "tts" })?.value
     );
   }
 


### PR DESCRIPTION
Related: #119074

## What Problem This Solves

`OPENAI_API_KEY` is one name with many consumers — inference, TTS, realtime voice, transcription — and the name carries no statement of intent. There is no way to hand a subsystem its own key through the environment.

This PR makes the name carry the intent. `OPENAI_TTS_API_KEY` feeds TTS; `OPENAI_REALTIME_API_KEY` feeds realtime voice; a scoped name always beats the generic one; the generic name keeps working unchanged for anyone who sets no scoped names. No configuration involved — the workflow stays entirely environment-side.

One opt-in flag (`security.requireScopedApiKeys`, default `false`) makes scoped names mandatory: subsystems defining a scope stop reading the generic name. Model inference is unaffected in both modes — it is the primary documented consumer of the generic name.

This implements the scoped-names direction suggested by a maintainer in #119074, built out in full so the two candidate designs there compare as code rather than sketches.

## Why This Change Was Made

One helper owns the rule (`src/secrets/scoped-env-keys.ts`): all scoped candidates are consulted before any generic candidate. Scoped names derive mechanically — subsystem token before the `_API_KEY` suffix (`GEMINI_API_KEY` → `GEMINI_TTS_API_KEY`). Scopes: `tts`, `realtime`, `transcription`, `media`, `search`.

Two guards forced by real provider names:

- **Already-scoped:** `VOLCENGINE_TTS_API_KEY` / `VOLCENGINE_TTS_TOKEN` carry their token; deriving again would invent `VOLCENGINE_TTS_TTS_API_KEY`. Token-bearing names count as scoped as-is.
- **Non-derivable:** names with neither the suffix nor the token (`AZURE_SPEECH_KEY`) have no scoped form, so the flag cannot exclude them — a scoped name cannot be required where none can be expressed.

No central resolver knows which subsystem a lookup serves, so the token is threaded per consumption point: 33 direct credential env reads replaced by 21 resolver call sites across 20 production files, covering 13 TTS providers, realtime voice (openai, google, xai), transcription (openai, mistral, deepgram, xai, elevenlabs), media understanding, and web search.

Excluded, each needing a design decision rather than a rename: model discovery (inference keeps the generic name); image generation (credential resolves through the central model-auth path — scoped naming cannot reach it without deeper surgery); the `acpx` cross-vendor fallback; channel bot tokens; variables shared verbatim across subsystems (minimax token-plan vars — under the flag, those remain reachable by TTS, a disclosed hole in the guarantee).

## User Impact

- No flag, no scoped names set: zero change; all existing suites pass unmodified.
- No flag, scoped name set: that subsystem uses the scoped key — additive capability.
- Flag on: generic names ignored wherever a scoped form is expressible. A migration: affected keys renamed in shell, `env.vars`, and secret-store entry IDs.
- Generic values now pass through secret-input normalization (trimmed; whitespace-only rejected) at converted sites that previously read `process.env` raw — padded values fail earlier with a clearer error instead of at the vendor.
- New documentation/support surface: one variable name per converted subsystem × provider pair.

## Comparison with the alternative (PR #119476)

Both candidate designs from #119074 are complete, gate-green implementations against the same base:

| | Declared-only flag (PR #119476) | Scoped names (this PR) |
|---|---|---|
| Files | 14 | 40 |
| Production lines | +59 | +367 −53 |
| Code paths altered | 2 central resolvers | 21 resolver sites (33 env reads) across 20 files |
| New env-var names | none | one per subsystem × provider |
| Covers AWS/IAM/ADC mechanisms | yes | no — nothing to rename |
| Covers image generation | yes | no — centrally resolved credential |
| Env-only per-subsystem keys | no | yes |
| Migration at flag-on | author config entries/refs | rename vars in shell, `env.vars`, secret-store IDs |
| Tests | 13 new; 447 neighbors green | 35 new; 8,154-test sweep green |
| `check.mjs` | green | green |

Structural difference: the declared-only flag gates at the central resolvers; this PR threads the subsystem token to every consumption point. What this PR uniquely offers is env-only per-subsystem keys, with no configuration authoring — a useful convenience layer even if its flag never ships. The two compose: this PR's lookup order as convenience, the other's flag as the security boundary.

## Evidence

Full sweep across all touched extensions plus `src/secrets/`, `src/tts/`, `src/plugin-sdk/` (at the feature commit): `8154 passed, 5 skipped, 2 failed` — both failures pre-existing (`src/tts/tts-runtime-fallbacks.test.ts` fails identically with this branch's entire diff stashed; passes in isolation — parallel-load flakiness). The review-fix commit re-validated all affected suites: 1,597 tests, zero failures.

New tests: helper-level (derivation, precedence, both guards, flag semantics) plus wire-in-level per scope, each proving scoped-beats-generic, flag-on-ignores-generic, and default unchanged. `node scripts/check.mjs` exits 0 — all typecheck stages, lint, format, repository guards.

Adversarial review (Codex, read-only, full diff): 3 HIGH, 1 LOW. Two fixed in the follow-up commit — image generation's conversion moved only a readiness check while request auth stayed on the central model-auth path (coverage without protection; resolved by excluding image generation), and explicit config threading through the six helpers this PR introduces. One rejected as the documented minimax cross-subsystem exclusion (disclosed above). One disclosed: generic-value normalization (User Impact).

---

🤖 AI-assisted: authored with Claude Code (Opus); adversarial review by Codex.
