### PR TITLE
fix(cli): meter base64 image payloads as stubs in Claude live session turns

### DIFF
--- a/src/agents/cli-runner/claude-live-session.image-payload.test.ts
+++ b/src/agents/cli-runner/claude-live-session.image-payload.test.ts
@@ -1,0 +1,304 @@
+/** Claude live session: base64 image payloads in tool_result lines are metered as stubs. */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  setDiagnosticsEnabledForProcess,
+  waitForDiagnosticEventsDrained,
+} from "../../infra/diagnostic-events.js";
+import {
+  resetDiagnosticRunActivityForTest,
+  startDiagnosticRunActivityTracking,
+} from "../../logging/diagnostic-run-activity.js";
+import type { getProcessSupervisor } from "../../process/supervisor/index.js";
+import type { CliToolResultDelta } from "../cli-output.js";
+import {
+  restoreCliRunnerPrepareTestDeps,
+  supervisorSpawnMock,
+} from "../cli-runner.test-support.js";
+import { runClaudeLiveSessionTurn } from "./claude-live-session.js";
+import { resetClaudeLiveSessionsForTest } from "./claude-live-session.test-support.js";
+import { setCliRunnerExecuteTestDeps } from "./execute.test-support.js";
+import { writeCliSystemPromptFile } from "./helpers.js";
+import type { PreparedCliRunContext } from "./types.js";
+
+vi.mock("../../plugin-sdk/anthropic-cli.js", () => ({
+  CLAUDE_CLI_BACKEND_ID: "claude-cli",
+  isClaudeCliProvider: (providerId: string) => providerId === "claude-cli",
+}));
+
+type ProcessSupervisor = ReturnType<typeof getProcessSupervisor>;
+type SupervisorSpawnFn = ProcessSupervisor["spawn"];
+
+beforeEach(() => {
+  setDiagnosticsEnabledForProcess(true);
+  resetDiagnosticRunActivityForTest();
+  startDiagnosticRunActivityTracking();
+  resetClaudeLiveSessionsForTest();
+  restoreCliRunnerPrepareTestDeps();
+  setCliRunnerExecuteTestDeps({ writeCliSystemPromptFile });
+  supervisorSpawnMock.mockClear();
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+  resetDiagnosticRunActivityForTest();
+  resetClaudeLiveSessionsForTest();
+  await waitForDiagnosticEventsDrained();
+});
+
+function buildPreparedCliRunContext(params: {
+  runId: string;
+  sessionId?: string;
+  sessionKey?: string;
+}): PreparedCliRunContext {
+  const backend = {
+    command: "claude",
+    args: ["-p", "--output-format", "stream-json"],
+    output: "jsonl" as const,
+    input: "stdin" as const,
+    modelArg: "--model",
+    sessionArgs: ["--session-id", "{sessionId}"],
+    sessionMode: "always" as const,
+    systemPromptFileArg: "--append-system-prompt-file",
+    systemPromptWhen: "first" as const,
+    serialize: true,
+    liveSession: "claude-stdio" as const,
+  };
+  return {
+    params: {
+      sessionId: params.sessionId ?? "s-img",
+      sessionKey: params.sessionKey ?? "agent:main:img",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      prompt: "hi",
+      provider: "claude-cli",
+      model: "sonnet",
+      timeoutMs: 60_000,
+      runId: params.runId,
+    },
+    started: Date.now(),
+    workspaceDir: "/tmp",
+    backendResolved: {
+      id: "claude-cli",
+      config: backend,
+      bundleMcp: true,
+      pluginId: "anthropic",
+    },
+    preparedBackend: {
+      backend,
+      env: {},
+    },
+    reusableCliSession: { mode: "none" },
+    hadSessionFile: false,
+    contextEngineConfig: {},
+    modelId: "sonnet",
+    normalizedModel: "sonnet",
+    systemPrompt: "You are a helpful assistant.",
+    systemPromptReport: {} as PreparedCliRunContext["systemPromptReport"],
+    bootstrapPromptWarningLines: [],
+    authEpochVersion: 2,
+  };
+}
+
+function getProcessSupervisorForTest() {
+  return {
+    spawn: (params: Parameters<SupervisorSpawnFn>[0]) =>
+      supervisorSpawnMock(params) as ReturnType<SupervisorSpawnFn>,
+    cancel: vi.fn(),
+    cancelScope: vi.fn(),
+    getRecord: vi.fn(),
+  };
+}
+
+function installLiveStdoutDriver(): {
+  cancel: ReturnType<typeof vi.fn>;
+  userInputUuids: string[];
+  stdout: {
+    emit: (chunk: string) => void;
+    waitReady: () => Promise<void>;
+  };
+} {
+  let stdoutListener: ((chunk: string) => void) | undefined;
+  const cancel = vi.fn();
+  const userInputUuids: string[] = [];
+  let markReady: (() => void) | undefined;
+  const ready = new Promise<void>((resolve) => {
+    markReady = resolve;
+  });
+  const stdin = {
+    write: vi.fn((data: string, cb?: (err?: Error | null) => void) => {
+      const parsed = JSON.parse(data) as { type?: string; uuid?: string };
+      if (parsed.type === "user" && typeof parsed.uuid === "string") {
+        userInputUuids.push(parsed.uuid);
+        stdoutListener?.(
+          jsonl([{ type: "command_lifecycle", command_uuid: parsed.uuid, state: "started" }]),
+        );
+      }
+      cb?.();
+      markReady?.();
+    }),
+    end: vi.fn(),
+  };
+  supervisorSpawnMock.mockImplementation(async (...args: unknown[]) => {
+    const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
+    stdoutListener = input.onStdout;
+    return {
+      runId: "live-img-run",
+      pid: 4242,
+      startedAtMs: Date.now(),
+      stdin,
+      wait: vi.fn(() => new Promise(() => {})),
+      cancel,
+    };
+  });
+  return {
+    cancel,
+    userInputUuids,
+    stdout: {
+      emit: (chunk: string) => {
+        stdoutListener?.(chunk);
+      },
+      waitReady: () => ready,
+    },
+  };
+}
+
+function jsonl(lines: unknown[]): string {
+  return lines.map((line) => JSON.stringify(line)).join("\n") + "\n";
+}
+
+function startLiveTurn(params: {
+  runId: string;
+  onToolResult?: (delta: CliToolResultDelta) => void;
+}) {
+  const context = buildPreparedCliRunContext({ runId: params.runId });
+  return runClaudeLiveSessionTurn({
+    context,
+    args: context.preparedBackend.backend.args ?? [],
+    env: {},
+    prompt: "hi",
+    useResume: false,
+    noOutputTimeoutMs: 5_000,
+    getProcessSupervisor: getProcessSupervisorForTest,
+    onAssistantDelta: () => {},
+    onToolResult: params.onToolResult,
+    cleanup: async () => {},
+  });
+}
+
+function imageToolResultLine(params: {
+  toolCallId: string;
+  base64: string;
+}): Record<string, unknown> {
+  return {
+    type: "user",
+    session_id: "live-img",
+    message: {
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: params.toolCallId,
+          content: [
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: "image/jpeg",
+                data: params.base64,
+              },
+            },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+describe("claude live session image payload metering", () => {
+  it("completes a photo-heavy turn instead of tripping the raw-chars output cap", async () => {
+    const driver = installLiveStdoutDriver();
+    const resultPromise = startLiveTurn({ runId: "run-img-over-cap" });
+    await driver.stdout.waitReady();
+
+    // Three tool_result lines carrying ~3 MiB of base64 image data each: the
+    // turn-level raw-chars cap is 8 MiB, so without stub metering the turn
+    // would abort with "Claude CLI turn output exceeded limit". Lines are
+    // emitted one per chunk, as the CLI writes them; a single multi-MiB chunk
+    // would instead trip the pending-line buffer cap.
+    const bigImage = "A".repeat(3 * 1024 * 1024);
+    for (const line of [
+      { type: "system", subtype: "init", session_id: "live-img" },
+      {
+        type: "assistant",
+        session_id: "live-img",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Reading photos." }],
+        },
+      },
+      imageToolResultLine({ toolCallId: "tool-img-1", base64: bigImage }),
+      imageToolResultLine({ toolCallId: "tool-img-2", base64: bigImage }),
+      imageToolResultLine({ toolCallId: "tool-img-3", base64: bigImage }),
+      {
+        type: "assistant",
+        session_id: "live-img",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Summarized the photos." }],
+        },
+      },
+      {
+        type: "result",
+        subtype: "success",
+        session_id: "live-img",
+        result: "Summarized the photos.",
+        stop_reason: "end_turn",
+      },
+    ]) {
+      driver.stdout.emit(`${JSON.stringify(line)}\n`);
+    }
+
+    const result = await resultPromise;
+    expect(result.output.text).toContain("Summarized the photos.");
+    expect(driver.cancel).not.toHaveBeenCalled();
+  });
+
+  it("feeds the streaming parser stubbed image payloads instead of raw base64", async () => {
+    const driver = installLiveStdoutDriver();
+    const onToolResult = vi.fn();
+    const resultPromise = startLiveTurn({ runId: "run-img-stub", onToolResult });
+    await driver.stdout.waitReady();
+
+    const bigImage = "A".repeat(1024 * 1024);
+    driver.stdout.emit(
+      jsonl([
+        { type: "system", subtype: "init", session_id: "live-img" },
+        imageToolResultLine({ toolCallId: "tool-img-stub", base64: bigImage }),
+        {
+          type: "assistant",
+          session_id: "live-img",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "Done." }],
+          },
+        },
+        {
+          type: "result",
+          subtype: "success",
+          session_id: "live-img",
+          result: "Done.",
+          stop_reason: "end_turn",
+        },
+      ]),
+    );
+
+    await resultPromise;
+    const delta = onToolResult.mock.calls[0]?.[0];
+    expect(delta).toMatchObject({ toolCallId: "tool-img-stub" });
+    const blocks = delta?.result as Array<Record<string, unknown>>;
+    expect(Array.isArray(blocks)).toBe(true);
+    const source = blocks[0]?.source as Record<string, unknown> | undefined;
+    expect(source?.data).toBe(`[image: ${bigImage.length} base64 chars omitted]`);
+  });
+});

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -1330,6 +1330,44 @@ function handleClaudeLiveControlRequest(
   })();
 }
 
+/**
+ * Stubs base64 image payloads in a parsed Claude CLI stream-json line in
+ * place. Image bytes inside tool_result content blocks are dead weight for
+ * openclaw: the CLI backend already sent them to the model API and nothing
+ * downstream reads `source.data`. Metering them against maxTurnRawChars makes
+ * photo-heavy turns abort with a spurious output-limit error (#119445).
+ * Returns true when at least one payload was stubbed so callers only
+ * re-serialize lines that actually carried image data.
+ */
+function stripClaudeLiveImagePayloads(parsed: Record<string, unknown>): boolean {
+  let stubbed = false;
+  const visit = (node: unknown): void => {
+    if (Array.isArray(node)) {
+      for (const item of node) {
+        visit(item);
+      }
+      return;
+    }
+    if (!isRecord(node)) {
+      return;
+    }
+    if (
+      node.type === "image" &&
+      isRecord(node.source) &&
+      typeof node.source.data === "string" &&
+      node.source.data.length > 0
+    ) {
+      node.source.data = `[image: ${node.source.data.length} base64 chars omitted]`;
+      stubbed = true;
+    }
+    for (const value of Object.values(node)) {
+      visit(value);
+    }
+  };
+  visit(parsed);
+  return stubbed;
+}
+
 function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
   const turn = session.currentTurn;
   const trimmed = line.trim();
@@ -1346,6 +1384,11 @@ function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
     }
     return;
   }
+  // Meter base64 image payloads as stubs: image bytes inside tool_result
+  // content blocks are never consumed by openclaw (the CLI backend already
+  // sent them to the model API), but they dominate maxTurnRawChars accounting
+  // and abort photo-heavy turns with a spurious output-limit error (#119445).
+  const meteredLine = stripClaudeLiveImagePayloads(parsed) ? JSON.stringify(parsed) : trimmed;
   const parsedSessionId = parseSessionId(parsed);
   if (parsedSessionId) {
     session.sessionId = parsedSessionId;
@@ -1380,7 +1423,7 @@ function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
   ) {
     turn.hasReplayUnsafeActivity = true;
   }
-  turn.rawChars += trimmed.length + 1;
+  turn.rawChars += meteredLine.length + 1;
   if (
     turn.rawChars > turn.outputLimits.maxTurnRawChars ||
     turn.rawLines.length >= turn.outputLimits.maxTurnLines
@@ -1392,10 +1435,10 @@ function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
     );
     return;
   }
-  turn.rawLines.push(trimmed);
+  turn.rawLines.push(meteredLine);
   applyBackgroundTasksChanged(session, parsed);
   const toolEventCountBefore = turn.toolEventCount;
-  turn.streamingParser.push(`${trimmed}\n`);
+  turn.streamingParser.push(`${meteredLine}\n`);
   turn.sessionId = parsedSessionId ?? turn.sessionId;
   noteClaudeLiveProgress(turn, parsed, turn.toolEventCount !== toolEventCountBefore);
   handleClaudeLiveControlRequest(session, turn, parsed);


### PR DESCRIPTION
Fixes #119445

[AI-assisted]

## What Problem This Solves

Photo-heavy CLI-backend turns abort with a spurious `Claude CLI turn output exceeded limit` error. The per-turn stream-json output cap (`maxTurnRawChars`, default 8 MiB, from #75838) meters the raw JSONL lines the CLI writes to stdout, and those lines embed full base64 photo payloads inside `tool_result` content blocks. A modest "read a folder of photos" task (14 JPEG/PNG photos of 0.3–2 MB each) produces ~8.48 MB of stream volume — ~7.2 MB of it base64 image data — while the assistant text for the whole turn is ~2.7 KB. The run is aborted and the user sees "Something went wrong".

## Why This Change Was Made

openclaw never consumes image `source.data` from the CLI stream: the CLI backend already sent the images to the model API (vision behavior is unaffected), and the live-session consumer only reads assistant text deltas, tool start/complete status + ids, session id, and usage. Nothing persists the payloads either — verified in the report against the agent/state SQLite stores. The image bytes' only effect is incrementing the raw-chars counter that kills the turn. The ClawSweeper review of this issue calls for normalizing echoed image tool-result blocks *before* retained aggregate accounting and parser input while preserving block type, tool state, MIME metadata, and decoded byte count — this change does exactly that:

- New `stripClaudeLiveImagePayloads` walks the parsed record recursively (image blocks appear in `tool_result` content arrays inside `user` message lines) and replaces each `source.data` with `[image: N base64 chars omitted]`, keeping the block type and MIME metadata intact.
- The stubbed serialization is used for `rawChars` accounting, the `rawLines` buffer, and the streaming parser; non-image lines are passed through byte-identical.
- The existing raw single-line safety bound (`maxPendingLineChars`) still applies to the raw line as before.

## User Impact

Photo-heavy turns complete instead of aborting mid-turn. The reported 8.48 MB turn drops to ~1.3 MB (6× under the default cap), so the default 8 MiB limit stops being a cliff for bounded photo tasks. Tool result events keep their block structure and MIME metadata with the payload replaced by a byte-count stub — no model-visible or persistence behavior changes.

## Evidence

- `src/agents/cli-runner/claude-live-session.ts` (+46/−3): `stripClaudeLiveImagePayloads` helper + `meteredLine` substituted for `trimmed` in `rawChars` accounting, `rawLines` buffering, and `streamingParser.push`.
- New `src/agents/cli-runner/claude-live-session.image-payload.test.ts` (2 tests):
  - *completes a photo-heavy turn instead of tripping the raw-chars output cap*: three `tool_result` lines carrying 3 MiB of base64 each (9 MiB total > 8 MiB cap) complete the turn successfully.
  - *feeds the streaming parser stubbed image payloads instead of raw base64*: asserts `onToolResult` receives `[image: 1048576 base64 chars omitted]` rather than the raw base64.
- Regression proof: with the production change stashed, both tests fail (`2 failed`); with it, both pass.
- Existing suites stay green: `claude-live-session.background-tasks`, `claude-live-session.capability`, `claude-live-tool-approval` — 48/48 pass under `vitest.agents-support.config.ts`. `oxlint` and `oxfmt` clean on changed files; `tsgo` typecheck clean for both changed files (only pre-existing unrelated `rejectSymlinks` drift errors remain on this checkout).
