### PR TITLE
fix(agents): strip echoed base64 image payloads so photo-heavy turns no longer hit the per-turn output cap

### DIFF
--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -3509,7 +3509,10 @@ describe("createCliJsonlStreamingParser", () => {
     }
   });
 
-  it("counts raw Claude lines claimed by plugin parsers before dispatching their events", () => {
+  it.each([
+    { name: "echoed media bytes", padded: false },
+    { name: "surrounding raw whitespace", padded: true },
+  ])("counts $name claimed by Claude plugin parsers before dispatch", ({ padded }) => {
     const pluginLines: string[] = [];
     const assistantDeltas: string[] = [];
     const parser = createCliJsonlStreamingParser({
@@ -3521,7 +3524,7 @@ describe("createCliJsonlStreamingParser", () => {
       },
       onAssistantDelta: (delta) => assistantDeltas.push(delta.delta),
     });
-    const rawLine = JSON.stringify({
+    const semanticLine = JSON.stringify({
       type: "user",
       message: {
         content: [
@@ -3534,7 +3537,7 @@ describe("createCliJsonlStreamingParser", () => {
                 source: {
                   type: "base64",
                   media_type: "image/png",
-                  data: "a".repeat(4_300_000),
+                  data: padded ? "YQ==" : "a".repeat(4_300_000),
                 },
               },
             ],
@@ -3542,12 +3545,118 @@ describe("createCliJsonlStreamingParser", () => {
         ],
       },
     });
+    const rawLine = padded ? `${" ".repeat(4_300_000)}${semanticLine}` : semanticLine;
 
     parser.push(`${rawLine}\n${rawLine}\n`);
 
-    expect(pluginLines).toEqual([rawLine, rawLine]);
+    expect(pluginLines).toEqual([semanticLine, semanticLine]);
     expect(assistantDeltas).toEqual(["claimed"]);
     expect(parser.getErrorText()).toContain("JSONL output exceeded");
+  });
+
+  it("counts actual blank Claude frames without invoking hooks or inventing a finish frame", () => {
+    const parseJsonlEvent = vi.fn(() => null);
+    const createParser = () =>
+      createCliJsonlStreamingParser({
+        backend: { command: "claude", output: "jsonl", jsonlDialect: "claude-stream-json" },
+        providerId: "claude-cli",
+        parseJsonlEvent,
+        onAssistantDelta: () => {},
+      });
+    const completeParser = createParser();
+    completeParser.push("\r\n".repeat(20_000));
+    completeParser.finish();
+
+    expect(completeParser.getErrorText()).toBeNull();
+    expect(parseJsonlEvent).not.toHaveBeenCalled();
+
+    const overflowParser = createParser();
+    overflowParser.push("\n".repeat(20_001));
+
+    expect(overflowParser.getErrorText()).toContain("exceeded 20000 lines");
+    expect(parseJsonlEvent).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: "whitespace-only records",
+      createLine: () => " ".repeat(4_300_000),
+    },
+    {
+      name: "padding around valid JSON",
+      createLine: () => `${" ".repeat(4_300_000)}{}`,
+    },
+    {
+      name: "formatting inside a compacted media record",
+      createLine: () =>
+        JSON.stringify({
+          type: "user",
+          message: {
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "padded-image",
+                content: [
+                  {
+                    type: "image",
+                    source: { type: "base64", media_type: "image/png", data: "YQ==" },
+                  },
+                ],
+              },
+            ],
+          },
+        }).replace('"message":', `"message":${" ".repeat(4_300_000)}`),
+    },
+  ])("charges $name against the Claude raw-output budget", ({ createLine }) => {
+    const parser = createCliJsonlStreamingParser({
+      backend: { command: "claude", output: "jsonl", jsonlDialect: "claude-stream-json" },
+      providerId: "claude-cli",
+      onAssistantDelta: () => {},
+    });
+    const line = createLine();
+
+    parser.push(`${line}\n${line}\n`);
+
+    expect(parser.getErrorText()).toContain("JSONL output exceeded 8388608 characters");
+  });
+
+  it("normalizes empty Claude image data without treating zero omitted bytes as unchanged", () => {
+    const results: CliToolResultDelta[] = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: { command: "claude", output: "jsonl", jsonlDialect: "claude-stream-json" },
+      providerId: "claude-cli",
+      onAssistantDelta: () => {},
+      onToolResult: (result) => results.push(result),
+    });
+
+    parser.push(
+      `${JSON.stringify({
+        type: "user",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "empty-image",
+              content: [
+                {
+                  type: "image",
+                  source: { type: "base64", media_type: "image/png", data: "" },
+                },
+              ],
+            },
+          ],
+        },
+      })}\n`,
+    );
+
+    expect(results[0]?.result).toEqual([
+      {
+        type: "image",
+        source: { type: "base64", media_type: "image/png" },
+        omitted: true,
+        bytes: 0,
+      },
+    ]);
   });
 
   it("still enforces raw Claude line and retained-text limits", () => {
@@ -3649,7 +3758,7 @@ describe("createCliJsonlStreamingParser", () => {
         ],
       },
     });
-    parser.push(`${rawLine}\n`);
+    parser.push(`\n \t\r\n${rawLine}\n`);
 
     expect(observedLines).toEqual([rawLine]);
   });

--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -3423,7 +3423,7 @@ describe("createCliJsonlStreamingParser", () => {
     ]);
   });
 
-  it("omits echoed Claude image and PDF bytes before accumulating tool results", () => {
+  it("frames coalesced Claude image and PDF lines before omitting retained binary bytes", () => {
     const results: CliToolResultDelta[] = [];
     const pluginLines: string[] = [];
     const parser = createCliJsonlStreamingParser({
@@ -3437,12 +3437,13 @@ describe("createCliJsonlStreamingParser", () => {
       onToolResult: (result) => results.push(result),
     });
     const base64 = "a".repeat(4_300_000);
+    const rawLines: string[] = [];
     for (const [type, mediaType] of [
       ["image", "image/png"],
       ["document", "application/pdf"],
     ] as const) {
-      parser.push(
-        `${JSON.stringify({
+      rawLines.push(
+        JSON.stringify({
           type: "user",
           message: {
             role: "user",
@@ -3470,18 +3471,17 @@ describe("createCliJsonlStreamingParser", () => {
               },
             ],
           },
-        })}\n`,
+        }),
       );
     }
-    parser.push(`${JSON.stringify({ type: "result", result: "both attachments read" })}\n`);
+    const resultLine = JSON.stringify({ type: "result", result: "both attachments read" });
+    parser.push(`${[...rawLines, resultLine].join("\n")}\n`);
     parser.finish();
 
     expect(parser.getErrorText()).toBeNull();
     expect(parser.getOutput()?.text).toBe("both attachments read");
     expect(results).toHaveLength(2);
-    expect(pluginLines).toHaveLength(3);
-    expect(pluginLines[0]).toContain('"omitted":true');
-    expect(pluginLines[0]).not.toContain(base64.slice(0, 64));
+    expect(pluginLines).toEqual([...rawLines, resultLine]);
     for (const [index, type, mediaType] of [
       [0, "image", "image/png"],
       [1, "document", "application/pdf"],
@@ -3507,6 +3507,47 @@ describe("createCliJsonlStreamingParser", () => {
         ],
       });
     }
+  });
+
+  it("counts raw Claude lines claimed by plugin parsers before dispatching their events", () => {
+    const pluginLines: string[] = [];
+    const assistantDeltas: string[] = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: { command: "claude", output: "jsonl", jsonlDialect: "claude-stream-json" },
+      providerId: "claude-cli",
+      parseJsonlEvent: (line) => {
+        pluginLines.push(line);
+        return { kind: "text", text: "claimed" };
+      },
+      onAssistantDelta: (delta) => assistantDeltas.push(delta.delta),
+    });
+    const rawLine = JSON.stringify({
+      type: "user",
+      message: {
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "claimed-image",
+            content: [
+              {
+                type: "image",
+                source: {
+                  type: "base64",
+                  media_type: "image/png",
+                  data: "a".repeat(4_300_000),
+                },
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    parser.push(`${rawLine}\n${rawLine}\n`);
+
+    expect(pluginLines).toEqual([rawLine, rawLine]);
+    expect(assistantDeltas).toEqual(["claimed"]);
+    expect(parser.getErrorText()).toContain("JSONL output exceeded");
   });
 
   it("still enforces raw Claude line and retained-text limits", () => {
@@ -3541,6 +3582,12 @@ describe("createCliJsonlStreamingParser", () => {
       })}\n`,
     );
     expect(oversizedLineParser.getErrorText()).toContain("JSONL line exceeded");
+
+    const growingPartialLineParser = createParser();
+    growingPartialLineParser.push("a".repeat(4_300_000));
+    expect(growingPartialLineParser.getErrorText()).toBeNull();
+    growingPartialLineParser.push("a".repeat(4_300_000));
+    expect(growingPartialLineParser.getErrorText()).toContain("JSONL line exceeded");
 
     const oversizedTextParser = createParser();
     for (const toolCallId of ["first", "second"]) {

--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -2,9 +2,11 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import {
+  CLI_STREAM_JSON_DEFAULT_MAX_TURN_RAW_CHARS,
   createCliJsonlStreamingParser,
   extractCliErrorMessage,
   formatCliOutputError,
+  normalizeClaudeStreamJsonImagePayload,
   parseCliOutput,
   type CliThinkingProgress,
   type CliToolResultDelta,
@@ -3938,6 +3940,139 @@ describe("createCliJsonlStreamingParser", () => {
     parser.finish();
 
     expect(commentaryTexts).toEqual(["Reading the file now.", "Now searching."]);
+  });
+});
+
+describe("normalizeClaudeStreamJsonImagePayload", () => {
+  it("strips base64 image source.data and retains omitted, bytes, and MIME metadata", () => {
+    const line = JSON.stringify({
+      type: "user",
+      message: {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "toolu_1",
+            is_error: false,
+            content: [
+              { type: "image", source: { type: "base64", media_type: "image/jpeg", data: "AAAA" } },
+              { type: "text", text: "photo 1" },
+            ],
+          },
+        ],
+      },
+    });
+    const normalized = normalizeClaudeStreamJsonImagePayload(line);
+    const parsed = JSON.parse(normalized);
+    const imageBlock = parsed.message.content[0].content[0];
+    expect(imageBlock.type).toBe("image");
+    expect(imageBlock.source).toEqual({ type: "base64", media_type: "image/jpeg" });
+    expect(imageBlock.source.data).toBeUndefined();
+    expect(imageBlock.omitted).toBe(true);
+    expect(imageBlock.bytes).toBeGreaterThan(0);
+    // Text sibling, tool id, and tool state are preserved.
+    expect(parsed.message.content[0].content[1]).toEqual({ type: "text", text: "photo 1" });
+    expect(parsed.message.content[0].tool_use_id).toBe("toolu_1");
+    expect(parsed.message.content[0].is_error).toBe(false);
+  });
+
+  it("shrinks a photo-bearing line below the per-turn cap so the parser no longer aborts", () => {
+    const cap = CLI_STREAM_JSON_DEFAULT_MAX_TURN_RAW_CHARS;
+    const imageBase64 = "B".repeat(cap + 1024);
+    const line = JSON.stringify({
+      type: "user",
+      message: {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "toolu_img",
+            content: [
+              {
+                type: "image",
+                source: { type: "base64", media_type: "image/png", data: imageBase64 },
+              },
+            ],
+          },
+        ],
+      },
+    });
+    // The raw line exceeds the 8 MiB cap and trips the parser's aggregate guard.
+    expect(line.length).toBeGreaterThan(cap);
+    const rawParser = createCliJsonlStreamingParser({
+      backend: {
+        command: "claude",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "claude-cli",
+      onAssistantDelta: () => undefined,
+    });
+    rawParser.push(`${line}\n`);
+    rawParser.finish();
+    expect(rawParser.getErrorText()).toMatch(/exceeded .* characters/);
+
+    // After normalization the line is far below the cap and parses cleanly.
+    const normalized = normalizeClaudeStreamJsonImagePayload(line);
+    expect(normalized.length).toBeLessThan(cap);
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "claude",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "claude-cli",
+      onAssistantDelta: () => undefined,
+    });
+    parser.push(`${normalized}\n`);
+    parser.finish();
+    expect(parser.getErrorText()).toBeNull();
+  });
+
+  it("leaves bare-array text tool results, non-image JSON, and unparseable lines intact", () => {
+    const textOnly = JSON.stringify({
+      type: "user",
+      message: {
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: "toolu_2", content: "plain text result" }],
+      },
+    });
+    expect(normalizeClaudeStreamJsonImagePayload(textOnly)).toBe(textOnly);
+
+    const controlLine = JSON.stringify({ type: "system", subtype: "init", session_id: "s" });
+    expect(normalizeClaudeStreamJsonImagePayload(controlLine)).toBe(controlLine);
+
+    const unparseable = "{ not json at all base64";
+    expect(normalizeClaudeStreamJsonImagePayload(unparseable)).toBe(unparseable);
+  });
+
+  it("strips every image block in a multi-image tool_result", () => {
+    const line = JSON.stringify({
+      type: "user",
+      message: {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "toolu_multi",
+            content: [
+              { type: "image", source: { type: "base64", media_type: "image/jpeg", data: "AAAA" } },
+              { type: "image", source: { type: "base64", media_type: "image/png", data: "BBBB" } },
+            ],
+          },
+        ],
+      },
+    });
+    const blocks = JSON.parse(normalizeClaudeStreamJsonImagePayload(line)).message.content[0]
+      .content;
+    expect(blocks[0].source.data).toBeUndefined();
+    expect(blocks[0].omitted).toBe(true);
+    expect(blocks[0].source.media_type).toBe("image/jpeg");
+    expect(blocks[1].source.data).toBeUndefined();
+    expect(blocks[1].omitted).toBe(true);
+    expect(blocks[1].source.media_type).toBe("image/png");
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -1,12 +1,10 @@
 /** Tests CLI JSON/JSONL output parsing, streamed deltas, and error extraction. */
 import { readFileSync } from "node:fs";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
-  CLI_STREAM_JSON_DEFAULT_MAX_TURN_RAW_CHARS,
   createCliJsonlStreamingParser,
   extractCliErrorMessage,
   formatCliOutputError,
-  normalizeClaudeStreamJsonImagePayload,
   parseCliOutput,
   type CliThinkingProgress,
   type CliToolResultDelta,
@@ -3069,6 +3067,46 @@ describe("createCliJsonlStreamingParser", () => {
     });
   });
 
+  it("lets plugin parsers own their frames before lazily parsing fallback JSON", () => {
+    const parseSpy = vi.spyOn(JSON, "parse");
+    const parseCountsAtPluginEntry: number[] = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: { command: "acme", output: "jsonl" },
+      providerId: "acme-cli",
+      parseJsonlEvent: (line) => {
+        parseCountsAtPluginEntry.push(parseSpy.mock.calls.length);
+        if (line === "plain provider frame") {
+          return { kind: "text", text: "plain" };
+        }
+        if (line.includes('"item.completed"')) {
+          return null;
+        }
+        const event = JSON.parse(line) as { text: string };
+        return { kind: "text", text: event.text };
+      },
+      onAssistantDelta: () => {},
+    });
+
+    try {
+      parser.push("plain provider frame\n");
+      expect(parseSpy).not.toHaveBeenCalled();
+
+      parser.push(`${JSON.stringify({ text: " provider JSON" })}\n`);
+      expect(parseSpy).toHaveBeenCalledTimes(1);
+
+      parser.push(
+        `${JSON.stringify({
+          type: "item.completed",
+          item: { type: "agent_message", text: "fallback" },
+        })}\n`,
+      );
+      expect(parseCountsAtPluginEntry).toEqual([0, 0, 1]);
+      expect(parseSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      parseSpy.mockRestore();
+    }
+  });
+
   it("turns plugin-owned JSONL parser exceptions into bounded provider errors", () => {
     let calls = 0;
     const parser = createCliJsonlStreamingParser({
@@ -3383,6 +3421,190 @@ describe("createCliJsonlStreamingParser", () => {
     expect(results).toEqual([
       { toolCallId: "toolu_1", name: "Bash", isError: false, result: "total 0\n" },
     ]);
+  });
+
+  it("omits echoed Claude image and PDF bytes before accumulating tool results", () => {
+    const results: CliToolResultDelta[] = [];
+    const pluginLines: string[] = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: { command: "claude", output: "jsonl", jsonlDialect: "claude-stream-json" },
+      providerId: "claude-cli",
+      parseJsonlEvent: (line) => {
+        pluginLines.push(line);
+        return null;
+      },
+      onAssistantDelta: () => {},
+      onToolResult: (result) => results.push(result),
+    });
+    const base64 = "a".repeat(4_300_000);
+    for (const [type, mediaType] of [
+      ["image", "image/png"],
+      ["document", "application/pdf"],
+    ] as const) {
+      parser.push(
+        `${JSON.stringify({
+          type: "user",
+          message: {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: `read-${type}`,
+                is_error: type === "document",
+                content: [
+                  { type: "text", text: `Read ${type}` },
+                  {
+                    type,
+                    title: `${type} attachment`,
+                    source: { type: "base64", media_type: mediaType, data: base64 },
+                  },
+                  {
+                    type: "image",
+                    source: { type: "url", url: "https://example.test/keep.png" },
+                  },
+                  {
+                    type: "document",
+                    source: { type: "text", media_type: "text/plain", data: "keep text" },
+                  },
+                ],
+              },
+            ],
+          },
+        })}\n`,
+      );
+    }
+    parser.push(`${JSON.stringify({ type: "result", result: "both attachments read" })}\n`);
+    parser.finish();
+
+    expect(parser.getErrorText()).toBeNull();
+    expect(parser.getOutput()?.text).toBe("both attachments read");
+    expect(results).toHaveLength(2);
+    expect(pluginLines).toHaveLength(3);
+    expect(pluginLines[0]).toContain('"omitted":true');
+    expect(pluginLines[0]).not.toContain(base64.slice(0, 64));
+    for (const [index, type, mediaType] of [
+      [0, "image", "image/png"],
+      [1, "document", "application/pdf"],
+    ] as const) {
+      expect(results[index]).toEqual({
+        toolCallId: `read-${type}`,
+        name: "",
+        isError: type === "document",
+        result: [
+          { type: "text", text: `Read ${type}` },
+          {
+            type,
+            title: `${type} attachment`,
+            source: { type: "base64", media_type: mediaType },
+            omitted: true,
+            bytes: 3_225_000,
+          },
+          { type: "image", source: { type: "url", url: "https://example.test/keep.png" } },
+          {
+            type: "document",
+            source: { type: "text", media_type: "text/plain", data: "keep text" },
+          },
+        ],
+      });
+    }
+  });
+
+  it("still enforces raw Claude line and retained-text limits", () => {
+    const createParser = () =>
+      createCliJsonlStreamingParser({
+        backend: { command: "claude", output: "jsonl", jsonlDialect: "claude-stream-json" },
+        providerId: "claude-cli",
+        onAssistantDelta: () => {},
+      });
+    const oversizedLineParser = createParser();
+    oversizedLineParser.push(
+      `${JSON.stringify({
+        type: "user",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "oversized-image",
+              content: [
+                {
+                  type: "image",
+                  source: {
+                    type: "base64",
+                    media_type: "image/png",
+                    data: "a".repeat(8 * 1024 * 1024),
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      })}\n`,
+    );
+    expect(oversizedLineParser.getErrorText()).toContain("JSONL line exceeded");
+
+    const oversizedTextParser = createParser();
+    for (const toolCallId of ["first", "second"]) {
+      oversizedTextParser.push(
+        `${JSON.stringify({
+          type: "user",
+          message: {
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: toolCallId,
+                content: [{ type: "text", text: "a".repeat(4_300_000) }],
+              },
+            ],
+          },
+        })}\n`,
+      );
+    }
+    expect(oversizedTextParser.getErrorText()).toContain("JSONL output exceeded");
+
+    const excessiveLinesParser = createParser();
+    excessiveLinesParser.push("{}\n".repeat(20_001));
+    expect(excessiveLinesParser.getErrorText()).toContain("exceeded 20000 lines");
+  });
+
+  it.each([
+    { providerId: "codex-cli", jsonlDialect: undefined },
+    { providerId: "pi-cli", jsonlDialect: undefined },
+    { providerId: "google-gemini-cli", jsonlDialect: "gemini-stream-json" as const },
+  ])("preserves $providerId binary tool payloads byte-for-byte", ({ providerId, jsonlDialect }) => {
+    const observedLines: string[] = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: { command: providerId, output: "jsonl", ...(jsonlDialect ? { jsonlDialect } : {}) },
+      providerId,
+      parseJsonlEvent: (line) => {
+        observedLines.push(line);
+        return null;
+      },
+      onAssistantDelta: () => {},
+    });
+    const rawLine = JSON.stringify({
+      type: "user",
+      item: {
+        type: "mcp_tool_call",
+        result: { content: [{ type: "image", data: "aGVsbG8=", mimeType: "image/png" }] },
+      },
+      message: {
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "keep-binary",
+            content: [
+              {
+                type: "image",
+                source: { type: "base64", media_type: "image/png", data: "aGVsbG8=" },
+              },
+            ],
+          },
+        ],
+      },
+    });
+    parser.push(`${rawLine}\n`);
+
+    expect(observedLines).toEqual([rawLine]);
   });
 
   it("reassembles streamed tool args from input_json_delta chunks", () => {
@@ -3940,139 +4162,6 @@ describe("createCliJsonlStreamingParser", () => {
     parser.finish();
 
     expect(commentaryTexts).toEqual(["Reading the file now.", "Now searching."]);
-  });
-});
-
-describe("normalizeClaudeStreamJsonImagePayload", () => {
-  it("strips base64 image source.data and retains omitted, bytes, and MIME metadata", () => {
-    const line = JSON.stringify({
-      type: "user",
-      message: {
-        role: "user",
-        content: [
-          {
-            type: "tool_result",
-            tool_use_id: "toolu_1",
-            is_error: false,
-            content: [
-              { type: "image", source: { type: "base64", media_type: "image/jpeg", data: "AAAA" } },
-              { type: "text", text: "photo 1" },
-            ],
-          },
-        ],
-      },
-    });
-    const normalized = normalizeClaudeStreamJsonImagePayload(line);
-    const parsed = JSON.parse(normalized);
-    const imageBlock = parsed.message.content[0].content[0];
-    expect(imageBlock.type).toBe("image");
-    expect(imageBlock.source).toEqual({ type: "base64", media_type: "image/jpeg" });
-    expect(imageBlock.source.data).toBeUndefined();
-    expect(imageBlock.omitted).toBe(true);
-    expect(imageBlock.bytes).toBeGreaterThan(0);
-    // Text sibling, tool id, and tool state are preserved.
-    expect(parsed.message.content[0].content[1]).toEqual({ type: "text", text: "photo 1" });
-    expect(parsed.message.content[0].tool_use_id).toBe("toolu_1");
-    expect(parsed.message.content[0].is_error).toBe(false);
-  });
-
-  it("shrinks a photo-bearing line below the per-turn cap so the parser no longer aborts", () => {
-    const cap = CLI_STREAM_JSON_DEFAULT_MAX_TURN_RAW_CHARS;
-    const imageBase64 = "B".repeat(cap + 1024);
-    const line = JSON.stringify({
-      type: "user",
-      message: {
-        role: "user",
-        content: [
-          {
-            type: "tool_result",
-            tool_use_id: "toolu_img",
-            content: [
-              {
-                type: "image",
-                source: { type: "base64", media_type: "image/png", data: imageBase64 },
-              },
-            ],
-          },
-        ],
-      },
-    });
-    // The raw line exceeds the 8 MiB cap and trips the parser's aggregate guard.
-    expect(line.length).toBeGreaterThan(cap);
-    const rawParser = createCliJsonlStreamingParser({
-      backend: {
-        command: "claude",
-        output: "jsonl",
-        jsonlDialect: "claude-stream-json",
-        sessionIdFields: ["session_id"],
-      },
-      providerId: "claude-cli",
-      onAssistantDelta: () => undefined,
-    });
-    rawParser.push(`${line}\n`);
-    rawParser.finish();
-    expect(rawParser.getErrorText()).toMatch(/exceeded .* characters/);
-
-    // After normalization the line is far below the cap and parses cleanly.
-    const normalized = normalizeClaudeStreamJsonImagePayload(line);
-    expect(normalized.length).toBeLessThan(cap);
-    const parser = createCliJsonlStreamingParser({
-      backend: {
-        command: "claude",
-        output: "jsonl",
-        jsonlDialect: "claude-stream-json",
-        sessionIdFields: ["session_id"],
-      },
-      providerId: "claude-cli",
-      onAssistantDelta: () => undefined,
-    });
-    parser.push(`${normalized}\n`);
-    parser.finish();
-    expect(parser.getErrorText()).toBeNull();
-  });
-
-  it("leaves bare-array text tool results, non-image JSON, and unparseable lines intact", () => {
-    const textOnly = JSON.stringify({
-      type: "user",
-      message: {
-        role: "user",
-        content: [{ type: "tool_result", tool_use_id: "toolu_2", content: "plain text result" }],
-      },
-    });
-    expect(normalizeClaudeStreamJsonImagePayload(textOnly)).toBe(textOnly);
-
-    const controlLine = JSON.stringify({ type: "system", subtype: "init", session_id: "s" });
-    expect(normalizeClaudeStreamJsonImagePayload(controlLine)).toBe(controlLine);
-
-    const unparseable = "{ not json at all base64";
-    expect(normalizeClaudeStreamJsonImagePayload(unparseable)).toBe(unparseable);
-  });
-
-  it("strips every image block in a multi-image tool_result", () => {
-    const line = JSON.stringify({
-      type: "user",
-      message: {
-        role: "user",
-        content: [
-          {
-            type: "tool_result",
-            tool_use_id: "toolu_multi",
-            content: [
-              { type: "image", source: { type: "base64", media_type: "image/jpeg", data: "AAAA" } },
-              { type: "image", source: { type: "base64", media_type: "image/png", data: "BBBB" } },
-            ],
-          },
-        ],
-      },
-    });
-    const blocks = JSON.parse(normalizeClaudeStreamJsonImagePayload(line)).message.content[0]
-      .content;
-    expect(blocks[0].source.data).toBeUndefined();
-    expect(blocks[0].omitted).toBe(true);
-    expect(blocks[0].source.media_type).toBe("image/jpeg");
-    expect(blocks[1].source.data).toBeUndefined();
-    expect(blocks[1].omitted).toBe(true);
-    expect(blocks[1].source.media_type).toBe("image/png");
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -3,6 +3,7 @@
  * JSONL streaming, Claude stream-json dialects, usage metadata, and tool event
  * reconstruction.
  */
+import { estimateBase64DecodedBytes } from "@openclaw/media-core/base64";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
@@ -575,6 +576,88 @@ function streamJsonOutputLimitErrorText(kind: "raw" | "line" | "lines", limit: n
     return `CLI JSONL output exceeded ${limit} lines; refusing to parse output.`;
   }
   return `CLI JSONL output exceeded ${limit} characters; refusing to parse output.`;
+}
+
+/**
+ * Strips base64 image payloads from a Claude stream-json line so echoed image
+ * tool_result data does not count toward the per-turn output cap or survive in
+ * the retained raw-line buffer. The CLI has already sent the image to the model
+ * by the time these bytes are streamed back, and no downstream openclaw reader
+ * consumes `source.data`, so the base64 is dead weight that only inflates the
+ * cap and aborts photo-heavy turns (#119445). Uses the same reduced
+ * representation as the gateway display projection: `source.data` removed,
+ * `block.omitted` + `block.bytes` retained, preserving block type, tool state,
+ * and MIME metadata. Bare-array text tool results and every non-image field are
+ * left untouched. Returns the line unchanged when it is not a JSON record
+ * carrying such a payload, so the pre-parse hostile-input line ceiling and
+ * unparseable-line handling stay intact.
+ */
+export function normalizeClaudeStreamJsonImagePayload(line: string): string {
+  if (!line.includes('"base64"')) {
+    return line;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return line;
+  }
+  const { value, changed } = stripImageBase64Payloads(parsed);
+  return changed ? JSON.stringify(value) : line;
+}
+
+function stripImageBase64Payloads(value: unknown): {
+  value: unknown;
+  changed: boolean;
+} {
+  if (Array.isArray(value)) {
+    let changed = false;
+    const mapped = value.map((item) => {
+      const res = stripImageBase64Payloads(item);
+      changed ||= res.changed;
+      return res.value;
+    });
+    return { value: changed ? mapped : value, changed };
+  }
+  if (!isRecord(value)) {
+    return { value, changed: false };
+  }
+  if (value.type === "image") {
+    const stripped = stripImageBlockBase64(value);
+    if (stripped) {
+      return { value: stripped, changed: true };
+    }
+  }
+  let changed = false;
+  const out: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value)) {
+    const res = stripImageBase64Payloads(val);
+    changed ||= res.changed;
+    out[key] = res.value;
+  }
+  return { value: changed ? out : value, changed };
+}
+
+function stripImageBlockBase64(entry: Record<string, unknown>): Record<string, unknown> | null {
+  let imageData = typeof entry.data === "string" ? entry.data : undefined;
+  const source = isRecord(entry.source) ? entry.source : undefined;
+  let projectedSource: Record<string, unknown> | undefined;
+  if (source && source.type === "base64" && typeof source.data === "string") {
+    imageData ??= source.data;
+    projectedSource = { ...source };
+    delete projectedSource.data;
+  }
+  if (imageData === undefined) {
+    return null;
+  }
+  const out: Record<string, unknown> = { ...entry };
+  if (projectedSource) {
+    out.source = projectedSource;
+  }
+  delete out.data;
+  out.omitted = true;
+  out.bytes = estimateBase64DecodedBytes(imageData);
+  return out;
 }
 
 function hasExplicitCliErrorPayload(parsed: Record<string, unknown>): boolean {

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -568,6 +568,35 @@ export function resolveCliStreamJsonOutputLimits(
   };
 }
 
+/** Frames arbitrary stdout chunks while bounding each individual raw JSONL line. */
+export function frameBoundedCliJsonlChunk(
+  state: { pending: string },
+  chunk: string,
+  maxLineChars: number,
+  onLine: (line: string) => boolean | void,
+): boolean {
+  for (let offset = 0; offset < chunk.length;) {
+    const newlineIndex = chunk.indexOf("\n", offset);
+    const lineEnd = newlineIndex === -1 ? chunk.length : newlineIndex;
+    if (state.pending.length + (lineEnd - offset) > maxLineChars) {
+      state.pending = "";
+      return false;
+    }
+    state.pending += chunk.slice(offset, lineEnd);
+    if (newlineIndex === -1) {
+      return true;
+    }
+    const line = state.pending;
+    // Control-response writes can synchronously reenter stdout framing.
+    state.pending = "";
+    offset = newlineIndex + 1;
+    if (onLine(line) === false) {
+      return true;
+    }
+  }
+  return true;
+}
+
 /** Drops Claude's echoed binary bytes before they enter retained tool/transcript state. */
 export function normalizeClaudeCliStreamJsonRecord(
   parsed: Record<string, unknown>,
@@ -1385,7 +1414,7 @@ export function createCliJsonlStreamingParser(params: {
   onAssistantMessage?: (message: unknown) => void;
   onUsage?: (usage: CliUsage, terminal: boolean) => void;
 }) {
-  let lineBuffer = "";
+  const lineBuffer = { pending: "" };
   let assistantText = "";
   let customThinkingText = "";
   let pendingClaudeText = "";
@@ -1610,6 +1639,16 @@ export function createCliJsonlStreamingParser(params: {
     };
   };
 
+  const accountClaudeJsonlLine = (line: string): boolean => {
+    rawChars += line.length + 1;
+    if (rawChars <= outputLimits.maxTurnRawChars) {
+      return true;
+    }
+    parseErrorText = streamJsonOutputLimitErrorText("raw", outputLimits.maxTurnRawChars);
+    lineBuffer.pending = "";
+    return false;
+  };
+
   const handleCustomJsonlLine = (line: string): boolean => {
     if (parseErrorText) {
       return true;
@@ -1632,6 +1671,9 @@ export function createCliJsonlStreamingParser(params: {
     }
     if (parsed == null) {
       return false;
+    }
+    if (claudeStreamJson && !accountClaudeJsonlLine(line)) {
+      return true;
     }
     for (const event of Array.isArray(parsed) ? parsed : [parsed]) {
       handleCustomJsonlEvent(event);
@@ -1902,50 +1944,26 @@ export function createCliJsonlStreamingParser(params: {
     rawLines += 1;
     if (rawLines > outputLimits.maxTurnLines) {
       parseErrorText = streamJsonOutputLimitErrorText("lines", outputLimits.maxTurnLines);
-      lineBuffer = "";
+      lineBuffer.pending = "";
       return;
     }
-    const parsedRecords = claudeStreamJson ? parseJsonRecordCandidates(line) : undefined;
-    const normalizedLine =
-      parsedRecords?.length === 1
-        ? (normalizeClaudeCliStreamJsonRecord(parsedRecords[0]!) ?? line)
-        : line;
+    if (handleCustomJsonlLine(line)) {
+      return;
+    }
+    const parsedRecords = parseJsonRecordCandidates(line);
     if (claudeStreamJson) {
+      const normalizedLine =
+        parsedRecords.length === 1
+          ? (normalizeClaudeCliStreamJsonRecord(parsedRecords[0]!) ?? line)
+          : line;
       // Claude repeats tool-returned media in stdout; only retained normalized bytes count.
-      rawChars += normalizedLine.length + 1;
-      if (rawChars > outputLimits.maxTurnRawChars) {
-        parseErrorText = streamJsonOutputLimitErrorText("raw", outputLimits.maxTurnRawChars);
-        lineBuffer = "";
+      if (!accountClaudeJsonlLine(normalizedLine)) {
         return;
       }
     }
-    if (handleCustomJsonlLine(normalizedLine)) {
-      return;
-    }
-    for (const parsed of parsedRecords ?? parseJsonRecordCandidates(line)) {
+    for (const parsed of parsedRecords) {
       handleParsedRecord(parsed);
     }
-  };
-
-  const flushLines = (flushPartial: boolean) => {
-    while (true) {
-      if (parseErrorText) {
-        return;
-      }
-      const newlineIndex = lineBuffer.indexOf("\n");
-      if (newlineIndex < 0) {
-        break;
-      }
-      const line = lineBuffer.slice(0, newlineIndex);
-      lineBuffer = lineBuffer.slice(newlineIndex + 1);
-      handleJsonlLine(line);
-    }
-    if (!flushPartial) {
-      return;
-    }
-    const tail = lineBuffer;
-    lineBuffer = "";
-    handleJsonlLine(tail);
   };
 
   return {
@@ -1957,23 +1975,26 @@ export function createCliJsonlStreamingParser(params: {
         rawChars += chunk.length;
         if (rawChars > outputLimits.maxTurnRawChars) {
           parseErrorText = streamJsonOutputLimitErrorText("raw", outputLimits.maxTurnRawChars);
-          lineBuffer = "";
+          lineBuffer.pending = "";
           return;
         }
       }
-      if (lineBuffer.length + chunk.length > outputLimits.maxPendingLineChars) {
+      if (
+        !frameBoundedCliJsonlChunk(lineBuffer, chunk, outputLimits.maxPendingLineChars, (line) => {
+          handleJsonlLine(line);
+          return !parseErrorText;
+        })
+      ) {
         parseErrorText = streamJsonOutputLimitErrorText("line", outputLimits.maxPendingLineChars);
-        lineBuffer = "";
-        return;
       }
-      lineBuffer += chunk;
-      flushLines(false);
     },
     finish() {
       if (parseErrorText) {
         return;
       }
-      flushLines(true);
+      const tail = lineBuffer.pending;
+      lineBuffer.pending = "";
+      handleJsonlLine(tail);
       finishTaggedReasoningMessage();
       if (classifyClaudeCommentary) {
         flushPendingClaudeAssistantText();

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -4,6 +4,7 @@
  * reconstruction.
  */
 import { estimateBase64DecodedBytes } from "@openclaw/media-core/base64";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
@@ -20,7 +21,6 @@ import type {
   CliBackendParsedJsonlEvent,
 } from "../plugins/cli-backend.types.js";
 import { extractBalancedJsonFragments } from "../shared/balanced-json.js";
-import { isRecord } from "../utils.js";
 import type {
   MessagingToolSend,
   MessagingToolSourceReplyPayload,
@@ -568,6 +568,42 @@ export function resolveCliStreamJsonOutputLimits(
   };
 }
 
+/** Drops Claude's echoed binary bytes before they enter retained tool/transcript state. */
+export function normalizeClaudeCliStreamJsonRecord(
+  parsed: Record<string, unknown>,
+): string | undefined {
+  if (parsed.type !== "user" || !isRecord(parsed.message)) {
+    return undefined;
+  }
+  const content = Array.isArray(parsed.message.content) ? parsed.message.content : [];
+  let normalized = false;
+  for (const result of content) {
+    if (!isRecord(result) || result.type !== "tool_result" || !Array.isArray(result.content)) {
+      continue;
+    }
+    for (const block of result.content) {
+      if (!isRecord(block) || !isRecord(block.source) || block.source.type !== "base64") {
+        continue;
+      }
+      if (
+        block.type !== "image" &&
+        !(block.type === "document" && block.source.media_type === "application/pdf")
+      ) {
+        continue;
+      }
+      const { data, ...source } = block.source;
+      if (typeof data !== "string") {
+        continue;
+      }
+      block.source = source;
+      block.omitted = true;
+      block.bytes = estimateBase64DecodedBytes(data);
+      normalized = true;
+    }
+  }
+  return normalized ? JSON.stringify(parsed) : undefined;
+}
+
 function streamJsonOutputLimitErrorText(kind: "raw" | "line" | "lines", limit: number): string {
   if (kind === "line") {
     return `CLI JSONL line exceeded ${limit} characters; refusing to parse output.`;
@@ -576,88 +612,6 @@ function streamJsonOutputLimitErrorText(kind: "raw" | "line" | "lines", limit: n
     return `CLI JSONL output exceeded ${limit} lines; refusing to parse output.`;
   }
   return `CLI JSONL output exceeded ${limit} characters; refusing to parse output.`;
-}
-
-/**
- * Strips base64 image payloads from a Claude stream-json line so echoed image
- * tool_result data does not count toward the per-turn output cap or survive in
- * the retained raw-line buffer. The CLI has already sent the image to the model
- * by the time these bytes are streamed back, and no downstream openclaw reader
- * consumes `source.data`, so the base64 is dead weight that only inflates the
- * cap and aborts photo-heavy turns (#119445). Uses the same reduced
- * representation as the gateway display projection: `source.data` removed,
- * `block.omitted` + `block.bytes` retained, preserving block type, tool state,
- * and MIME metadata. Bare-array text tool results and every non-image field are
- * left untouched. Returns the line unchanged when it is not a JSON record
- * carrying such a payload, so the pre-parse hostile-input line ceiling and
- * unparseable-line handling stay intact.
- */
-export function normalizeClaudeStreamJsonImagePayload(line: string): string {
-  if (!line.includes('"base64"')) {
-    return line;
-  }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(line);
-  } catch {
-    return line;
-  }
-  const { value, changed } = stripImageBase64Payloads(parsed);
-  return changed ? JSON.stringify(value) : line;
-}
-
-function stripImageBase64Payloads(value: unknown): {
-  value: unknown;
-  changed: boolean;
-} {
-  if (Array.isArray(value)) {
-    let changed = false;
-    const mapped = value.map((item) => {
-      const res = stripImageBase64Payloads(item);
-      changed ||= res.changed;
-      return res.value;
-    });
-    return { value: changed ? mapped : value, changed };
-  }
-  if (!isRecord(value)) {
-    return { value, changed: false };
-  }
-  if (value.type === "image") {
-    const stripped = stripImageBlockBase64(value);
-    if (stripped) {
-      return { value: stripped, changed: true };
-    }
-  }
-  let changed = false;
-  const out: Record<string, unknown> = {};
-  for (const [key, val] of Object.entries(value)) {
-    const res = stripImageBase64Payloads(val);
-    changed ||= res.changed;
-    out[key] = res.value;
-  }
-  return { value: changed ? out : value, changed };
-}
-
-function stripImageBlockBase64(entry: Record<string, unknown>): Record<string, unknown> | null {
-  let imageData = typeof entry.data === "string" ? entry.data : undefined;
-  const source = isRecord(entry.source) ? entry.source : undefined;
-  let projectedSource: Record<string, unknown> | undefined;
-  if (source && source.type === "base64" && typeof source.data === "string") {
-    imageData ??= source.data;
-    projectedSource = { ...source };
-    delete projectedSource.data;
-  }
-  if (imageData === undefined) {
-    return null;
-  }
-  const out: Record<string, unknown> = { ...entry };
-  if (projectedSource) {
-    out.source = projectedSource;
-  }
-  delete out.data;
-  out.omitted = true;
-  out.bytes = estimateBase64DecodedBytes(imageData);
-  return out;
 }
 
 function hasExplicitCliErrorPayload(parsed: Record<string, unknown>): boolean {
@@ -1940,6 +1894,39 @@ export function createCliJsonlStreamingParser(params: {
     emitClaudeVisibleText(delta.delta);
   };
 
+  const handleJsonlLine = (rawLine: string) => {
+    const line = rawLine.trim();
+    if (!line || parseErrorText) {
+      return;
+    }
+    rawLines += 1;
+    if (rawLines > outputLimits.maxTurnLines) {
+      parseErrorText = streamJsonOutputLimitErrorText("lines", outputLimits.maxTurnLines);
+      lineBuffer = "";
+      return;
+    }
+    const parsedRecords = claudeStreamJson ? parseJsonRecordCandidates(line) : undefined;
+    const normalizedLine =
+      parsedRecords?.length === 1
+        ? (normalizeClaudeCliStreamJsonRecord(parsedRecords[0]!) ?? line)
+        : line;
+    if (claudeStreamJson) {
+      // Claude repeats tool-returned media in stdout; only retained normalized bytes count.
+      rawChars += normalizedLine.length + 1;
+      if (rawChars > outputLimits.maxTurnRawChars) {
+        parseErrorText = streamJsonOutputLimitErrorText("raw", outputLimits.maxTurnRawChars);
+        lineBuffer = "";
+        return;
+      }
+    }
+    if (handleCustomJsonlLine(normalizedLine)) {
+      return;
+    }
+    for (const parsed of parsedRecords ?? parseJsonRecordCandidates(line)) {
+      handleParsedRecord(parsed);
+    }
+  };
+
   const flushLines = (flushPartial: boolean) => {
     while (true) {
       if (parseErrorText) {
@@ -1949,38 +1936,16 @@ export function createCliJsonlStreamingParser(params: {
       if (newlineIndex < 0) {
         break;
       }
-      const line = lineBuffer.slice(0, newlineIndex).trim();
+      const line = lineBuffer.slice(0, newlineIndex);
       lineBuffer = lineBuffer.slice(newlineIndex + 1);
-      if (!line) {
-        continue;
-      }
-      rawLines += 1;
-      if (rawLines > outputLimits.maxTurnLines) {
-        parseErrorText = streamJsonOutputLimitErrorText("lines", outputLimits.maxTurnLines);
-        lineBuffer = "";
-        return;
-      }
-      if (handleCustomJsonlLine(line)) {
-        continue;
-      }
-      for (const parsed of parseJsonRecordCandidates(line)) {
-        handleParsedRecord(parsed);
-      }
+      handleJsonlLine(line);
     }
     if (!flushPartial) {
       return;
     }
-    const tail = lineBuffer.trim();
+    const tail = lineBuffer;
     lineBuffer = "";
-    if (!tail) {
-      return;
-    }
-    if (handleCustomJsonlLine(tail)) {
-      return;
-    }
-    for (const parsed of parseJsonRecordCandidates(tail)) {
-      handleParsedRecord(parsed);
-    }
+    handleJsonlLine(tail);
   };
 
   return {
@@ -1988,11 +1953,13 @@ export function createCliJsonlStreamingParser(params: {
       if (!chunk || parseErrorText) {
         return;
       }
-      rawChars += chunk.length;
-      if (rawChars > outputLimits.maxTurnRawChars) {
-        parseErrorText = streamJsonOutputLimitErrorText("raw", outputLimits.maxTurnRawChars);
-        lineBuffer = "";
-        return;
+      if (!claudeStreamJson) {
+        rawChars += chunk.length;
+        if (rawChars > outputLimits.maxTurnRawChars) {
+          parseErrorText = streamJsonOutputLimitErrorText("raw", outputLimits.maxTurnRawChars);
+          lineBuffer = "";
+          return;
+        }
       }
       if (lineBuffer.length + chunk.length > outputLimits.maxPendingLineChars) {
         parseErrorText = streamJsonOutputLimitErrorText("line", outputLimits.maxPendingLineChars);

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -600,12 +600,13 @@ export function frameBoundedCliJsonlChunk(
 /** Drops Claude's echoed binary bytes before they enter retained tool/transcript state. */
 export function normalizeClaudeCliStreamJsonRecord(
   parsed: Record<string, unknown>,
-): string | undefined {
+): { line: string; omittedRawChars: number } | undefined {
   if (parsed.type !== "user" || !isRecord(parsed.message)) {
     return undefined;
   }
   const content = Array.isArray(parsed.message.content) ? parsed.message.content : [];
   let normalized = false;
+  let omittedRawChars = 0;
   for (const result of content) {
     if (!isRecord(result) || result.type !== "tool_result" || !Array.isArray(result.content)) {
       continue;
@@ -627,10 +628,11 @@ export function normalizeClaudeCliStreamJsonRecord(
       block.source = source;
       block.omitted = true;
       block.bytes = estimateBase64DecodedBytes(data);
+      omittedRawChars += data.length;
       normalized = true;
     }
   }
-  return normalized ? JSON.stringify(parsed) : undefined;
+  return normalized ? { line: JSON.stringify(parsed), omittedRawChars } : undefined;
 }
 
 function streamJsonOutputLimitErrorText(kind: "raw" | "line" | "lines", limit: number): string {
@@ -1639,8 +1641,8 @@ export function createCliJsonlStreamingParser(params: {
     };
   };
 
-  const accountClaudeJsonlLine = (line: string): boolean => {
-    rawChars += line.length + 1;
+  const accountClaudeJsonlLine = (lineChars: number): boolean => {
+    rawChars += lineChars + 1;
     if (rawChars <= outputLimits.maxTurnRawChars) {
       return true;
     }
@@ -1649,7 +1651,7 @@ export function createCliJsonlStreamingParser(params: {
     return false;
   };
 
-  const handleCustomJsonlLine = (line: string): boolean => {
+  const handleCustomJsonlLine = (line: string, rawLine: string): boolean => {
     if (parseErrorText) {
       return true;
     }
@@ -1672,7 +1674,7 @@ export function createCliJsonlStreamingParser(params: {
     if (parsed == null) {
       return false;
     }
-    if (claudeStreamJson && !accountClaudeJsonlLine(line)) {
+    if (claudeStreamJson && !accountClaudeJsonlLine(rawLine.length)) {
       return true;
     }
     for (const event of Array.isArray(parsed) ? parsed : [parsed]) {
@@ -1937,8 +1939,11 @@ export function createCliJsonlStreamingParser(params: {
   };
 
   const handleJsonlLine = (rawLine: string) => {
+    if (parseErrorText) {
+      return;
+    }
     const line = rawLine.trim();
-    if (!line || parseErrorText) {
+    if (!line && !claudeStreamJson) {
       return;
     }
     rawLines += 1;
@@ -1947,17 +1952,24 @@ export function createCliJsonlStreamingParser(params: {
       lineBuffer.pending = "";
       return;
     }
-    if (handleCustomJsonlLine(line)) {
+    if (!line) {
+      accountClaudeJsonlLine(rawLine.length);
+      return;
+    }
+    if (handleCustomJsonlLine(line, rawLine)) {
       return;
     }
     const parsedRecords = parseJsonRecordCandidates(line);
     if (claudeStreamJson) {
-      const normalizedLine =
+      const normalized =
         parsedRecords.length === 1
-          ? (normalizeClaudeCliStreamJsonRecord(parsedRecords[0]!) ?? line)
-          : line;
-      // Claude repeats tool-returned media in stdout; only retained normalized bytes count.
-      if (!accountClaudeJsonlLine(normalizedLine)) {
+          ? normalizeClaudeCliStreamJsonRecord(parsedRecords[0]!)
+          : undefined;
+      // Exempt actual media bytes only; JSON serialization must not erase wire whitespace.
+      const retainedChars = normalized
+        ? Math.max(normalized.line.length, rawLine.length - normalized.omittedRawChars)
+        : rawLine.length;
+      if (!accountClaudeJsonlLine(retainedChars)) {
         return;
       }
     }
@@ -1994,7 +2006,9 @@ export function createCliJsonlStreamingParser(params: {
       }
       const tail = lineBuffer.pending;
       lineBuffer.pending = "";
-      handleJsonlLine(tail);
+      if (tail) {
+        handleJsonlLine(tail);
+      }
       finishTaggedReasoningMessage();
       if (classifyClaudeCommentary) {
         flushPendingClaudeAssistantText();

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -2735,6 +2735,54 @@ describe("runCliAgent spawn path", () => {
     );
   });
 
+  it.each([
+    {
+      name: "a coalesced blank-frame flood",
+      createChunk: () => "\n".repeat(20_001),
+    },
+    {
+      name: "whitespace-only records exceeding the raw budget",
+      createChunk: () => `${" ".repeat(4_300_000)}\n${" ".repeat(4_300_000)}\n`,
+    },
+    {
+      name: "valid JSON padded beyond the raw budget",
+      createChunk: () => `${" ".repeat(4_300_000)}{}\n${" ".repeat(4_300_000)}{}\n`,
+    },
+    {
+      name: "internal formatting around compacted Claude media",
+      createChunk: () => {
+        const line = JSON.stringify({
+          type: "user",
+          message: {
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "padded-live-image",
+                content: [
+                  {
+                    type: "image",
+                    source: { type: "base64", media_type: "image/png", data: "YQ==" },
+                  },
+                ],
+              },
+            ],
+          },
+        }).replace('"message":', `"message":${" ".repeat(4_300_000)}`);
+        return `${line}\n${line}\n`;
+      },
+    },
+  ])("rejects $name from the managed Claude live session", async ({ createChunk }) => {
+    const live: ReturnType<typeof mockClaudeLiveRun> = mockClaudeLiveRun(supervisorSpawnMock, {
+      onWrite: () => {
+        live.spawnInput.onStdout?.(createChunk());
+      },
+    });
+
+    await expect(executePreparedCliRun(buildClaudeLiveRunContext())).rejects.toThrow(
+      "Claude CLI turn output exceeded limit.",
+    );
+  });
+
   it("reports Claude live session reply backends as streaming until the turn finishes", async () => {
     let markWriteReady: (() => void) | undefined;
     const writeReady = new Promise<void>((resolve) => {

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -2629,6 +2629,84 @@ describe("runCliAgent spawn path", () => {
     expect(result.text).toBe(largeText);
   });
 
+  it("retains mixed Claude live tool results without counting echoed image and PDF bytes", async () => {
+    const toolResults: unknown[] = [];
+    const stop = onAgentEvent((event) => {
+      if (event.stream === "tool" && event.data.phase === "result") {
+        toolResults.push(event.data.result);
+      }
+    });
+    const base64 = "a".repeat(4_300_000);
+    mockClaudeLiveRun(supervisorSpawnMock, {
+      onWrite: ({ emit }) => {
+        emit([{ type: "system", subtype: "init", session_id: "live-binary-results" }]);
+        for (const [type, mediaType] of [
+          ["image", "image/png"],
+          ["document", "application/pdf"],
+        ] as const) {
+          emit([
+            {
+              type: "assistant",
+              session_id: "live-binary-results",
+              message: {
+                role: "assistant",
+                content: [{ type: "tool_use", id: `read-${type}`, name: "Read", input: {} }],
+              },
+            },
+          ]);
+          emit([
+            {
+              type: "user",
+              session_id: "live-binary-results",
+              message: {
+                role: "user",
+                content: [
+                  {
+                    type: "tool_result",
+                    tool_use_id: `read-${type}`,
+                    content: [
+                      { type: "text", text: `Read ${type}` },
+                      { type, source: { type: "base64", media_type: mediaType, data: base64 } },
+                    ],
+                  },
+                ],
+              },
+            },
+          ]);
+        }
+        emit([{ type: "result", session_id: "live-binary-results", result: "both files read" }]);
+      },
+    });
+
+    try {
+      const result = await executePreparedCliRun(buildClaudeLiveRunContext());
+
+      expect(result.text).toBe("both files read");
+      expect(toolResults).toEqual([
+        [
+          { type: "text", text: "Read image" },
+          {
+            type: "image",
+            source: { type: "base64", media_type: "image/png" },
+            omitted: true,
+            bytes: 3_225_000,
+          },
+        ],
+        [
+          { type: "text", text: "Read document" },
+          {
+            type: "document",
+            source: { type: "base64", media_type: "application/pdf" },
+            omitted: true,
+            bytes: 3_225_000,
+          },
+        ],
+      ]);
+    } finally {
+      stop();
+    }
+  });
+
   it("reports Claude live session reply backends as streaming until the turn finishes", async () => {
     let markWriteReady: (() => void) | undefined;
     const writeReady = new Promise<void>((resolve) => {
@@ -3419,6 +3497,44 @@ describe("runCliAgent spawn path", () => {
       toolUseId: "tool-allow-1",
       updatedInput: { command: "ls" },
     });
+  });
+
+  it("preserves image and PDF bytes inside approved Claude live control inputs", async () => {
+    const input = {
+      command: "process media",
+      image: {
+        type: "image",
+        source: { type: "base64", media_type: "image/png", data: "aGVsbG8=" },
+      },
+      document: {
+        type: "document",
+        source: { type: "base64", media_type: "application/pdf", data: "JVBERi0=" },
+      },
+    };
+    const live = mockClaudeLiveRun(supervisorSpawnMock, {
+      events: buildClaudeControlRequestEvents({
+        requestId: "req-allow-media",
+        toolUseId: "tool-allow-media",
+        input,
+        sessionId: "live-control-allow-media",
+      }),
+    });
+
+    const result = await executePreparedCliRun(
+      buildClaudeLiveRunContext({
+        prompt: "hello",
+        config: { tools: { exec: { security: "full", ask: "off" } } },
+      }),
+    );
+
+    expect(result.text).toBe("ok");
+    const response = expectClaudeControlDecision(live, {
+      behavior: "allow",
+      requestId: "req-allow-media",
+      toolUseId: "tool-allow-media",
+      updatedInput: input,
+    });
+    expect(JSON.stringify(response.response.response.updatedInput)).toBe(JSON.stringify(input));
   });
 
   it("honors allow-once from a Claude native tool Gateway approval", async () => {

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -2629,7 +2629,7 @@ describe("runCliAgent spawn path", () => {
     expect(result.text).toBe(largeText);
   });
 
-  it("retains mixed Claude live tool results without counting echoed image and PDF bytes", async () => {
+  it("frames coalesced Claude live image and PDF records before omitting retained bytes", async () => {
     const toolResults: unknown[] = [];
     const stop = onAgentEvent((event) => {
       if (event.stream === "tool" && event.data.phase === "result") {
@@ -2639,12 +2639,14 @@ describe("runCliAgent spawn path", () => {
     const base64 = "a".repeat(4_300_000);
     mockClaudeLiveRun(supervisorSpawnMock, {
       onWrite: ({ emit }) => {
-        emit([{ type: "system", subtype: "init", session_id: "live-binary-results" }]);
+        const events: Record<string, unknown>[] = [
+          { type: "system", subtype: "init", session_id: "live-binary-results" },
+        ];
         for (const [type, mediaType] of [
           ["image", "image/png"],
           ["document", "application/pdf"],
         ] as const) {
-          emit([
+          events.push(
             {
               type: "assistant",
               session_id: "live-binary-results",
@@ -2653,8 +2655,6 @@ describe("runCliAgent spawn path", () => {
                 content: [{ type: "tool_use", id: `read-${type}`, name: "Read", input: {} }],
               },
             },
-          ]);
-          emit([
             {
               type: "user",
               session_id: "live-binary-results",
@@ -2672,9 +2672,14 @@ describe("runCliAgent spawn path", () => {
                 ],
               },
             },
-          ]);
+          );
         }
-        emit([{ type: "result", session_id: "live-binary-results", result: "both files read" }]);
+        events.push({
+          type: "result",
+          session_id: "live-binary-results",
+          result: "both files read",
+        });
+        emit(events);
       },
     });
 
@@ -2705,6 +2710,29 @@ describe("runCliAgent spawn path", () => {
     } finally {
       stop();
     }
+  });
+
+  it.each([
+    {
+      name: "an oversized complete line",
+      chunks: () => [`${"a".repeat(8 * 1024 * 1024 + 1)}\n`],
+    },
+    {
+      name: "an oversized growing unterminated line",
+      chunks: () => ["a".repeat(4_300_000), "a".repeat(4_300_000)],
+    },
+  ])("rejects $name from Claude live stdout", async ({ chunks }) => {
+    const live: ReturnType<typeof mockClaudeLiveRun> = mockClaudeLiveRun(supervisorSpawnMock, {
+      onWrite: () => {
+        for (const chunk of chunks()) {
+          live.spawnInput.onStdout?.(chunk);
+        }
+      },
+    });
+
+    await expect(executePreparedCliRun(buildClaudeLiveRunContext())).rejects.toThrow(
+      "Claude CLI JSONL line exceeded output limit.",
+    );
   });
 
   it("reports Claude live session reply backends as streaming until the turn finishes", async () => {

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -41,6 +41,7 @@ import {
   CLI_STREAM_JSON_DEFAULT_MAX_TURN_RAW_CHARS,
   createCliJsonlStreamingParser,
   extractCliErrorMessage,
+  normalizeClaudeStreamJsonImagePayload,
   parseCliOutput,
   type CliOutput,
   type CliUsage,
@@ -1380,7 +1381,13 @@ function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
   ) {
     turn.hasReplayUnsafeActivity = true;
   }
-  turn.rawChars += trimmed.length + 1;
+  // Strip echoed base64 image payloads before aggregate accounting, the
+  // raw-line buffer, and the streaming parser. The CLI has already sent the
+  // image to the model by the time these bytes stream back, and no downstream
+  // openclaw reader consumes source.data, so the base64 only inflates the
+  // per-turn output cap that aborts photo-heavy turns (#119445).
+  const payload = normalizeClaudeStreamJsonImagePayload(trimmed);
+  turn.rawChars += payload.length + 1;
   if (
     turn.rawChars > turn.outputLimits.maxTurnRawChars ||
     turn.rawLines.length >= turn.outputLimits.maxTurnLines
@@ -1392,10 +1399,10 @@ function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
     );
     return;
   }
-  turn.rawLines.push(trimmed);
+  turn.rawLines.push(payload);
   applyBackgroundTasksChanged(session, parsed);
   const toolEventCountBefore = turn.toolEventCount;
-  turn.streamingParser.push(`${trimmed}\n`);
+  turn.streamingParser.push(`${payload}\n`);
   turn.sessionId = parsedSessionId ?? turn.sessionId;
   noteClaudeLiveProgress(turn, parsed, turn.toolEventCount !== toolEventCountBefore);
   handleClaudeLiveControlRequest(session, turn, parsed);

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -41,7 +41,7 @@ import {
   CLI_STREAM_JSON_DEFAULT_MAX_TURN_RAW_CHARS,
   createCliJsonlStreamingParser,
   extractCliErrorMessage,
-  normalizeClaudeStreamJsonImagePayload,
+  normalizeClaudeCliStreamJsonRecord,
   parseCliOutput,
   type CliOutput,
   type CliUsage,
@@ -84,7 +84,6 @@ type ClaudeLiveTurn = {
   outputLimits: ClaudeLiveOutputLimits;
   startedAtMs: number;
   rawLines: string[];
-  rawChars: number;
   sessionId?: string;
   noOutputTimer: NodeJS.Timeout | null;
   /** Last stdout/stderr time; null until the process emits anything this turn. */
@@ -1036,21 +1035,7 @@ function resolveClaudeLiveExecPermission(context: PreparedCliRunContext): Claude
   };
 }
 
-function parseClaudeLiveJsonLine(
-  session: ClaudeLiveSession,
-  trimmed: string,
-): Record<string, unknown> | null {
-  const maxPendingLineChars =
-    session.currentTurn?.outputLimits.maxPendingLineChars ??
-    CLI_STREAM_JSON_DEFAULT_MAX_TURN_RAW_CHARS;
-  if (trimmed.length > maxPendingLineChars) {
-    closeLiveSession(
-      session,
-      "abort",
-      createOutputLimitError(session, "Claude CLI JSONL line exceeded output limit."),
-    );
-    return null;
-  }
+function parseClaudeLiveJsonLine(trimmed: string): Record<string, unknown> | null {
   let parsed: unknown;
   try {
     parsed = JSON.parse(trimmed);
@@ -1337,7 +1322,7 @@ function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
   if (!trimmed) {
     return;
   }
-  const parsed = parseClaudeLiveJsonLine(session, trimmed);
+  const parsed = parseClaudeLiveJsonLine(trimmed);
   if (turn) {
     turn.observedStdout = true;
   }
@@ -1381,17 +1366,12 @@ function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
   ) {
     turn.hasReplayUnsafeActivity = true;
   }
-  // Strip echoed base64 image payloads before aggregate accounting, the
-  // raw-line buffer, and the streaming parser. The CLI has already sent the
-  // image to the model by the time these bytes stream back, and no downstream
-  // openclaw reader consumes source.data, so the base64 only inflates the
-  // per-turn output cap that aborts photo-heavy turns (#119445).
-  const payload = normalizeClaudeStreamJsonImagePayload(trimmed);
-  turn.rawChars += payload.length + 1;
-  if (
-    turn.rawChars > turn.outputLimits.maxTurnRawChars ||
-    turn.rawLines.length >= turn.outputLimits.maxTurnLines
-  ) {
+  const normalizedLine = normalizeClaudeCliStreamJsonRecord(parsed) ?? trimmed;
+  turn.rawLines.push(normalizedLine);
+  applyBackgroundTasksChanged(session, parsed);
+  const toolEventCountBefore = turn.toolEventCount;
+  turn.streamingParser.push(`${normalizedLine}\n`);
+  if (turn.streamingParser.getErrorText()) {
     closeLiveSession(
       session,
       "abort",
@@ -1399,10 +1379,6 @@ function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
     );
     return;
   }
-  turn.rawLines.push(payload);
-  applyBackgroundTasksChanged(session, parsed);
-  const toolEventCountBefore = turn.toolEventCount;
-  turn.streamingParser.push(`${payload}\n`);
   turn.sessionId = parsedSessionId ?? turn.sessionId;
   noteClaudeLiveProgress(turn, parsed, turn.toolEventCount !== toolEventCountBefore);
   handleClaudeLiveControlRequest(session, turn, parsed);
@@ -1709,7 +1685,6 @@ function createTurn(params: {
     outputLimits: resolveCliStreamJsonOutputLimits(params.context.preparedBackend.backend),
     startedAtMs: Date.now(),
     rawLines: [],
-    rawChars: 0,
     noOutputTimer: null,
     lastOutputAtMs: null,
     timeoutTimer: null,

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -1317,10 +1317,30 @@ function handleClaudeLiveControlRequest(
   })();
 }
 
+function pushClaudeLiveTurnLine(
+  session: ClaudeLiveSession,
+  turn: ClaudeLiveTurn,
+  line: string,
+): boolean {
+  turn.streamingParser.push(`${line}\n`);
+  if (!turn.streamingParser.getErrorText()) {
+    return true;
+  }
+  closeLiveSession(
+    session,
+    "abort",
+    createOutputLimitError(session, "Claude CLI turn output exceeded limit."),
+  );
+  return false;
+}
+
 function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
   const turn = session.currentTurn;
   const trimmed = line.trim();
   if (!trimmed) {
+    if (turn) {
+      pushClaudeLiveTurnLine(session, turn, line);
+    }
     return;
   }
   const parsed = parseClaudeLiveJsonLine(trimmed);
@@ -1367,17 +1387,11 @@ function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
   ) {
     turn.hasReplayUnsafeActivity = true;
   }
-  const normalizedLine = normalizeClaudeCliStreamJsonRecord(parsed) ?? trimmed;
+  const normalizedLine = normalizeClaudeCliStreamJsonRecord(parsed)?.line ?? trimmed;
   turn.rawLines.push(normalizedLine);
   applyBackgroundTasksChanged(session, parsed);
   const toolEventCountBefore = turn.toolEventCount;
-  turn.streamingParser.push(`${normalizedLine}\n`);
-  if (turn.streamingParser.getErrorText()) {
-    closeLiveSession(
-      session,
-      "abort",
-      createOutputLimitError(session, "Claude CLI turn output exceeded limit."),
-    );
+  if (!pushClaudeLiveTurnLine(session, turn, line)) {
     return;
   }
   turn.sessionId = parsedSessionId ?? turn.sessionId;

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -41,6 +41,7 @@ import {
   CLI_STREAM_JSON_DEFAULT_MAX_TURN_RAW_CHARS,
   createCliJsonlStreamingParser,
   extractCliErrorMessage,
+  frameBoundedCliJsonlChunk,
   normalizeClaudeCliStreamJsonRecord,
   parseCliOutput,
   type CliOutput,
@@ -123,7 +124,7 @@ type ClaudeLiveSession = {
   sessionId?: string;
   noOutputTimeoutMs: number;
   stderr: string;
-  stdoutBuffer: string;
+  stdoutBuffer: { pending: string };
   currentTurn: ClaudeLiveTurn | null;
   idleTimer: NodeJS.Timeout | null;
   cleanup: () => Promise<void>;
@@ -850,7 +851,7 @@ function armNoOutputTimer(session: ClaudeLiveSession, turn: ClaudeLiveTurn, dela
     }
     const retryableResumeStall =
       turn.useResume &&
-      session.stdoutBuffer.trim().length === 0 &&
+      session.stdoutBuffer.pending.trim().length === 0 &&
       !turn.hasReplayUnsafeActivity &&
       turn.toolEventCount === 0 &&
       turn.activeTools.size === 0 &&
@@ -1427,26 +1428,21 @@ function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
 function handleClaudeStdout(session: ClaudeLiveSession, chunk: string) {
   session.currentTurn?.onCliOutput?.(chunk, "stdout");
   resetNoOutputTimer(session);
-  session.stdoutBuffer += chunk;
   const maxPendingLineChars =
     session.currentTurn?.outputLimits.maxPendingLineChars ??
     CLI_STREAM_JSON_DEFAULT_MAX_TURN_RAW_CHARS;
-  if (session.stdoutBuffer.length > maxPendingLineChars) {
-    closeLiveSession(
-      session,
-      "abort",
-      createOutputLimitError(session, "Claude CLI JSONL line exceeded output limit."),
-    );
-    return;
-  }
-  const lines = session.stdoutBuffer.split(/\r?\n/g);
-  session.stdoutBuffer = lines.pop() ?? "";
   try {
-    for (const line of lines) {
-      handleClaudeLiveLine(session, line);
-      if (session.closing) {
-        break;
-      }
+    if (
+      !frameBoundedCliJsonlChunk(session.stdoutBuffer, chunk, maxPendingLineChars, (line) => {
+        handleClaudeLiveLine(session, line);
+        return !session.closing;
+      })
+    ) {
+      closeLiveSession(
+        session,
+        "abort",
+        createOutputLimitError(session, "Claude CLI JSONL line exceeded output limit."),
+      );
     }
   } catch (error) {
     closeLiveSession(session, "abort", error);
@@ -1467,15 +1463,15 @@ function handleClaudeExit(session: ClaudeLiveSession, exitCode: number | null): 
   if (!session.currentTurn) {
     return;
   }
-  if (session.stdoutBuffer.trim()) {
+  if (session.stdoutBuffer.pending.trim()) {
+    const pendingLine = session.stdoutBuffer.pending;
+    session.stdoutBuffer.pending = "";
     try {
-      handleClaudeLiveLine(session, session.stdoutBuffer);
+      handleClaudeLiveLine(session, pendingLine);
     } catch (error) {
-      session.stdoutBuffer = "";
       failTurn(session, error);
       return;
     }
-    session.stdoutBuffer = "";
   }
   if (!session.currentTurn) {
     return;
@@ -1620,7 +1616,7 @@ async function createClaudeLiveSession(params: {
     modelId: params.context.modelId,
     noOutputTimeoutMs: params.noOutputTimeoutMs,
     stderr: "",
-    stdoutBuffer: "",
+    stdoutBuffer: { pending: "" },
     currentTurn: null,
     idleTimer: null,
     cleanup: async () => {


### PR DESCRIPTION
> [AI-assisted] This PR was generated using Claude Code.
> Maintainer repair and verification were performed with Codex.

Closes #119445

Original pull request and proposal: @ml12580. Reported by @orbitingflea.

## What Problem This Solves

Fixes an issue where users asking a Claude-backed agent to read several photos or PDFs would see their turn abort with `Claude CLI turn output exceeded limit`, even though every individual JSONL record was safely bounded. The reported turn had 14 individually valid 0.2–2.4 MB records and 8.48 M aggregate characters against the 8 MiB limit; approximately 7.2 MB was already-consumed echoed base64 media. Multiple valid records can share a stdout callback, while blank lines and JSON whitespace must still count against the security budget.

## Why This Change Was Made

Use one bounded newline-cursor framer and canonical retained-output accounting owner across the generic JSONL parser and managed Claude live-session stdout path. Keep the hard 8 MiB pre-parse limit on each complete raw record and unresolved trailing partial; normalize only Anthropic `user.message.content[].tool_result.content[]` base64 image/PDF blocks; and charge every physical Claude frame, including blank, CRLF, whitespace-only, and outer/inner-padded JSON records.

For compacted media, charge `max(normalizedRetainedLength, rawFrameLength - actualRemovedImageAndPdfBase64Characters) + newline`, so only genuinely omitted media bytes are exempt and serialization cannot erase attack-controlled whitespace. Preserve synchronous-reentry-safe framing, the shipped trimmed-but-unredacted `parseJsonlEvent` hook contract, raw accounting for claimed plugin events, approval/control payloads, all line-count and text limits, and Codex/Pi/Gemini provider payloads.

## User Impact

Claude-backed agents can finish ordinary multi-photo/PDF turns even when individually valid image and PDF records arrive together in one stdout callback. Vision inputs, plugin raw-line hooks, approved tool inputs, and source MIME metadata remain intact. Oversized single records, oversized growing partial records, blank-frame floods, whitespace floods, padded JSON, oversized retained text, and excessive line counts are rejected.

## Evidence

- Fresh independently verified Blacksmith Testbox proof on this exact frozen tree: **313/313 tests passed**: `src/agents/cli-output.test.ts` **126**; `src/agents/cli-runner.spawn.test.ts` **127**; `src/agents/embedded-agent-runner/cli-backend-dispatch-transcript.test.ts` **9**; `src/agents/cli-runner/execute.supervisor-capture.test.ts` **51**.
- Command: `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --timing-json -- OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm test src/agents/cli-output.test.ts src/agents/cli-runner.spawn.test.ts src/agents/embedded-agent-runner/cli-backend-dispatch-transcript.test.ts src/agents/cli-runner/execute.supervisor-capture.test.ts`
- Exact one-shot lease `tbx_01kz8ashyg2r3c2pkhs3gnq6w1`; [backing workflow](https://github.com/openclaw/openclaw/actions/runs/30982544332). The lease was intentionally stopped after proof; its orchestration workflow may briefly remain running or display **cancelled**, while authoritative command timing reports `exitCode=0`, `runStatus=succeeded`, `commandMs=171681`, and `totalMs=173883`.
- **Previous P2 fixed in both owners.** Generic Claude parsing and managed live-session stdout now count actual blank/CRLF frames toward both the 20,000-line limit and the 8 MiB aggregate budget. `finish()` never invents a phantom blank frame; blank lines never invoke plugin hooks.
- **Whitespace and padding bypasses closed.** Both runtime paths reject two coalesced 4.3 M-character whitespace-only frames, two outer-padded valid JSON frames, and two media-bearing JSON records padded *inside* their valid JSON structure. Metering subtracts only the actual removed image/PDF `source.data` characters and still includes outer whitespace, inner JSON formatting, CRLF, and the physical newline.
- **Previous P1 framing fixes retained.** The managed-session runtime (`executePreparedCliRun` → `handleClaudeStdout`) receives **4.3 M-char image + 4.3 M-char PDF records in one mocked-supervisor stdout callback**, completes with `both files read`, and emits canonical `{omitted:true,bytes:3225000}` metadata. One generic parser `push` accepts the same coalesced records. This exercises the real OpenClaw session/dispatch seam with mocked CLI transport; no live external Claude-provider call is claimed.
- **Shipped plugin SDK contract retained.** `parseJsonlEvent` sees the original shipped trimmed, unredacted line; surrounding physical padding is charged against the untrimmed raw frame. Claimed plugin events are raw-metered before dispatch, preserving both the [shipped raw-line hook contract](https://github.com/openclaw/openclaw/blob/v2026.7.2-beta.7/docs/plugins/cli-backend-plugins.md#parsejsonlevent-provider-specific-jsonl-streams) and [public plugin SDK export](https://github.com/openclaw/openclaw/blob/v2026.7.2-beta.7/src/plugin-sdk/cli-backend.ts#L4-L14).
- Hostile-input regressions in both paths reject a single >8 MiB complete raw record, an unresolved partial growing beyond 8 MiB, aggregate retained text >8 MiB, and >20,000 frames. Empty image base64 remains canonical `{omitted:true,bytes:0}`. The real report concerns individually valid 0.2–2.4 MB records; accepting an oversized single raw line would weaken the security boundary and is intentionally not implemented.
- Approval regression proves image/PDF-containing `control_request.request.input` remains byte-for-byte identical in `control_response.response.response.updatedInput`; custom-provider frames and Codex, Pi, and Gemini payloads remain byte-for-byte unchanged.
- Direct pinned dependency contracts: [Anthropic base64 image/PDF source types](https://github.com/anthropics/anthropic-sdk-typescript/blob/sdk-v0.115.0/src/resources/messages/messages.ts#L201-L214); [Anthropic mixed tool-result media blocks](https://github.com/anthropics/anthropic-sdk-typescript/blob/sdk-v0.115.0/src/resources/messages/messages.ts#L2039-L2056); [Codex MCP result wire payload](https://github.com/openai/codex/blob/07490c75234ed3c63291a8eb7629f04f647038fa/codex-rs/exec/src/exec_events.rs#L261-L293); [Codex JSONL MCP content passthrough](https://github.com/openai/codex/blob/07490c75234ed3c63291a8eb7629f04f647038fa/codex-rs/exec/src/event_processor_with_jsonl_output.rs#L205-L229); [Codex MCP protocol result](https://github.com/openai/codex/blob/07490c75234ed3c63291a8eb7629f04f647038fa/codex-rs/protocol/src/mcp.rs#L149-L162); [Codex multimodal tool-output contract](https://github.com/openai/codex/blob/07490c75234ed3c63291a8eb7629f04f647038fa/codex-rs/protocol/src/models.rs#L1839-L1874).
- Production **+178/-101 = +77**; the added canonical framing/accounting owner is required to preserve hostile-input security limits, the shipped plugin SDK hook, and Anthropic/Codex dependency contracts while deleting duplicate accounting. Tests **+573/-1 = +572**, counted separately. `git diff --check` passed; **two independent final source reviews PASS**, no findings.
