### PR TITLE
fix(plugins): keep install fixtures registry-valid

### DIFF
--- a/src/plugins/install-persistence.test.ts
+++ b/src/plugins/install-persistence.test.ts
@@ -22,6 +22,7 @@ import {
 } from "../cli/plugins-cli-test-helpers.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { hasRetainedManagedNpmInstallMarker } from "./managed-npm-retention.js";
+import type { PluginManifestRecord } from "./manifest-registry.js";
 
 function requireMockCallArg(
   mockFn: { mock: { calls: unknown[][] } },
@@ -37,6 +38,26 @@ function requireMockCallArg(
 
 function expectRuntimeLogIncludes(fragment: string) {
   expect(runtimeLogs.join("\n")).toContain(fragment);
+}
+
+function createManifestRecord(
+  id: string,
+  overrides: Partial<PluginManifestRecord> = {},
+): PluginManifestRecord {
+  const rootDir = path.join(os.tmpdir(), "openclaw-plugin-fixtures", id);
+  return {
+    id,
+    channels: [],
+    providers: [],
+    cliBackends: [],
+    skills: [],
+    hooks: [],
+    origin: "config",
+    rootDir,
+    source: path.join(rootDir, "index.ts"),
+    manifestPath: path.join(rootDir, "openclaw.plugin.json"),
+    ...overrides,
+  };
 }
 
 const installWriteOptions = {
@@ -646,7 +667,7 @@ describe("persistPluginInstall", () => {
     } as OpenClawConfig;
     enablePluginInConfig.mockReturnValue({ config: enabledConfig });
     loadPluginManifestRegistry.mockReturnValue({
-      plugins: [{ id: "legacy-memory" }],
+      plugins: [createManifestRecord("legacy-memory")],
       diagnostics: [],
     });
     buildPluginDiagnosticsReport.mockReturnValueOnce({
@@ -723,7 +744,7 @@ describe("persistPluginInstall", () => {
     } as OpenClawConfig;
     enablePluginInConfig.mockReturnValue({ config: enabledConfig });
     loadPluginManifestRegistry.mockReturnValue({
-      plugins: [{ id: "memory-b", kind: "memory" }],
+      plugins: [createManifestRecord("memory-b", { kind: "memory" })],
       diagnostics: [],
     });
     applyExclusiveSlotSelection.mockImplementation(((params: {
@@ -789,7 +810,7 @@ describe("persistPluginInstall", () => {
     } as OpenClawConfig;
     enablePluginInConfig.mockReturnValue({ config: enabledConfig });
     loadPluginManifestRegistry.mockReturnValue({
-      plugins: [{ id: "plain" }],
+      plugins: [createManifestRecord("plain")],
       diagnostics: [],
     });
     buildPluginDiagnosticsReport.mockReturnValue({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Beta 8 plugin prerelease lane failed while exercising plugin install persistence after normalized manifest records gained additional required metadata.

## Why This Change Was Made

The affected tests now build typed, structurally complete `PluginManifestRecord` fixtures. Production metadata and installed-index behavior remain unchanged; the test doubles now honor the same contract as the registry they replace.

## User Impact

No runtime behavior change. Release validation can exercise the install persistence path without crashing on impossible partial registry records.

## Evidence

- Before: plugin prerelease run https://github.com/openclaw/openclaw/actions/runs/30973556697 failed 3 install-persistence tests with `ERR_INVALID_ARG_TYPE` from a missing fixture `rootDir`.
- Focused local proof: `node scripts/run-vitest.mjs src/plugins/install-persistence.test.ts` (18 passed).
- Exact-head Testbox: https://github.com/openclaw/openclaw/actions/runs/30976745625 (focused test 18 passed; changed gate exit 0).
- Fresh uncommitted and committed autoreview: clean, no findings, confidence 0.99.

AI-assisted: yes. The change and evidence were reviewed by the maintainer.

Punchcard-Session: amber-workshop-river-yr
