### PR TITLE
fix(qa): select the scenario's required provider before its models

### DIFF
--- a/extensions/qa-lab/src/scenario-lane.test.ts
+++ b/extensions/qa-lab/src/scenario-lane.test.ts
@@ -1,7 +1,9 @@
 // Qa Lab tests cover canonical scenario lane matching behavior.
 import { describe, expect, it } from "vitest";
 import type { QaProviderMode } from "./model-selection.js";
+import { resolveQaRunProfileExecutionSelection } from "./profile-planning.js";
 import { readQaScenarioById, readQaScenarioPack } from "./scenario-catalog.js";
+import { requireFlowScenario } from "./scenario-catalog.test-utils.js";
 import {
   describeQaProviderLaneMismatches,
   resolveQaScenarioLaneChannels,
@@ -67,6 +69,86 @@ describe("QA scenario lane matching", () => {
       expect(scenarioMatchesQaProviderLane(rejected)).toBe(false);
       expect(describeQaProviderLaneMismatches(rejected)).toContain(
         `providerMode=${allowedProviderMode}`,
+      );
+    },
+  );
+
+  it.each(["matrix-room-block-streaming", "matrix-voice-preflight-mention"])(
+    "keeps the scenario-pinned provider for %s out of the live provider lane",
+    (scenarioId) => {
+      const scenario = readQaScenarioById(scenarioId);
+      const liveLane = {
+        scenario,
+        providerMode: "live-frontier" as const,
+        primaryModel: "openai/gpt-5.6-luna",
+        channelDriver: "live" as const,
+        channel: "matrix",
+      };
+
+      expect(scenarioMatchesQaProviderLane(liveLane)).toBe(false);
+      expect(describeQaProviderLaneMismatches(liveLane)).toEqual(["providerMode=mock-openai"]);
+    },
+  );
+
+  it("excludes a mock-pinned Matrix scenario from a live profile execution", () => {
+    const scenario = readQaScenarioById("matrix-room-block-streaming");
+
+    expect(
+      resolveQaRunProfileExecutionSelection({
+        scenarios: [scenario],
+        providerMode: "live-frontier",
+        primaryModel: "openai/gpt-5.6-luna",
+        channelDriver: "live",
+        channel: "matrix",
+      }),
+    ).toEqual({
+      selectedScenarios: [],
+      excludedScenarios: [{ scenario, reasons: ["providerMode=mock-openai"] }],
+    });
+  });
+
+  it("treats matching execution and config provider pins as one lane requirement", () => {
+    const scenario = requireFlowScenario(
+      makeQaSuiteTestScenario("matching-provider-modes", {
+        config: { requiredProviderMode: "mock-openai" },
+      }),
+    );
+    scenario.execution.providerMode = "mock-openai";
+
+    expect(
+      describeQaProviderLaneMismatches({
+        scenario,
+        providerMode: "live-frontier",
+        primaryModel: "openai/gpt-5.6-luna",
+      }),
+    ).toEqual(["providerMode=mock-openai"]);
+    expect(
+      scenarioMatchesQaProviderLane({
+        scenario,
+        providerMode: "mock-openai",
+        primaryModel: "mock-openai/gpt-5.6-luna",
+      }),
+    ).toBe(true);
+  });
+
+  it.each(["mock-openai", "live-frontier"] as const)(
+    "rejects conflicting execution and config provider pins on the %s lane",
+    (providerMode) => {
+      const scenario = requireFlowScenario(
+        makeQaSuiteTestScenario("conflicting-provider-modes", {
+          config: { requiredProviderMode: "live-frontier" },
+        }),
+      );
+      scenario.execution.providerMode = "mock-openai";
+
+      expect(() =>
+        describeQaProviderLaneMismatches({
+          scenario,
+          providerMode,
+          primaryModel: "openai/gpt-5.6-luna",
+        }),
+      ).toThrow(
+        "QA scenario conflicting-provider-modes declares conflicting provider modes: execution.providerMode=mock-openai, execution.config.requiredProviderMode=live-frontier",
       );
     },
   );

--- a/extensions/qa-lab/src/scenario-lane.ts
+++ b/extensions/qa-lab/src/scenario-lane.ts
@@ -1,5 +1,6 @@
 import type { QaCliBackendAuthMode } from "./gateway-child.js";
 import { splitQaModelRef, type QaProviderMode } from "./model-selection.js";
+import { isQaProviderModeInput } from "./providers/index.js";
 import type { readQaBootstrapScenarioCatalog } from "./scenario-catalog.js";
 import type { QaScorecardChannelDriver } from "./scorecard-taxonomy.js";
 
@@ -7,6 +8,22 @@ type QaSeedScenario = ReturnType<typeof readQaBootstrapScenarioCatalog>["scenari
 
 function normalizeQaConfigString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export function resolveQaScenarioRequiredProviderMode(scenario: QaSeedScenario) {
+  const configuredMode = normalizeQaConfigString(scenario.execution.config?.requiredProviderMode);
+  const executionMode =
+    scenario.execution.kind === "flow" ? scenario.execution.providerMode : undefined;
+  if (configuredMode && executionMode && configuredMode !== executionMode) {
+    throw new Error(
+      `QA scenario ${scenario.id} declares conflicting provider modes: execution.providerMode=${executionMode}, execution.config.requiredProviderMode=${configuredMode}`,
+    );
+  }
+  const providerMode = configuredMode ?? executionMode;
+  if (providerMode && !isQaProviderModeInput(providerMode)) {
+    throw new Error(`QA scenario ${scenario.id} declares unknown provider mode: ${providerMode}`);
+  }
+  return providerMode;
 }
 
 export function resolveQaScenarioLaneChannels(params: {
@@ -61,7 +78,7 @@ export function describeQaProviderLaneMismatches(params: {
 }) {
   const mismatches: string[] = [];
   const config = params.scenario.execution.config ?? {};
-  const requiredProviderMode = normalizeQaConfigString(config.requiredProviderMode);
+  const requiredProviderMode = resolveQaScenarioRequiredProviderMode(params.scenario);
   if (requiredProviderMode && params.providerMode !== requiredProviderMode) {
     mismatches.push(`providerMode=${requiredProviderMode}`);
   }

--- a/extensions/qa-lab/src/scenario-lane.ts
+++ b/extensions/qa-lab/src/scenario-lane.ts
@@ -20,7 +20,7 @@ export function resolveQaScenarioRequiredProviderMode(scenario: QaSeedScenario) 
     );
   }
   const providerMode = configuredMode ?? executionMode;
-  if (providerMode && !isQaProviderModeInput(providerMode)) {
+  if (providerMode !== undefined && !isQaProviderModeInput(providerMode)) {
     throw new Error(`QA scenario ${scenario.id} declares unknown provider mode: ${providerMode}`);
   }
   return providerMode;

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -24,7 +24,11 @@ import {
   readQaBootstrapScenarioCatalog,
   type QaSeedScenarioWithSource,
 } from "./scenario-catalog.js";
-import { resolveQaScenarioLaneChannel, resolveQaScenarioLaneChannels } from "./scenario-lane.js";
+import {
+  resolveQaScenarioLaneChannel,
+  resolveQaScenarioLaneChannels,
+  resolveQaScenarioRequiredProviderMode,
+} from "./scenario-lane.js";
 import {
   mapQaSuiteWithConcurrency,
   normalizeQaSuiteConcurrency,
@@ -675,6 +679,18 @@ async function runUnifiedQaSuite(params: {
   const startedAt = new Date();
   const repoRoot = path.resolve(params.runParams?.repoRoot ?? process.cwd());
   const outputDir = await resolveQaSuiteOutputDir(repoRoot, params.runParams?.outputDir);
+  // Only an explicitly selected single flow may replace the unified suite's mock default.
+  const [selectedScenario] = params.plan.scenarios;
+  const selectedProviderMode =
+    params.runParams?.providerMode === undefined &&
+    params.runParams?.scenarioIds?.length === 1 &&
+    params.plan.scenarios.length === 1 &&
+    selectedScenario?.execution.kind === "flow"
+      ? resolveQaScenarioRequiredProviderMode(selectedScenario)
+      : undefined;
+  const providerMode = normalizeQaProviderMode(
+    params.runParams?.providerMode ?? selectedProviderMode ?? DEFAULT_QA_PROVIDER_MODE,
+  );
   const progress = params.runParams?.lab
     ? createQaSuiteProgressController({
         lab: params.runParams.lab,
@@ -683,9 +699,6 @@ async function runUnifiedQaSuite(params: {
       })
     : undefined;
   progress?.start();
-  const providerMode = normalizeQaProviderMode(
-    params.runParams?.providerMode ?? DEFAULT_QA_PROVIDER_MODE,
-  );
   const primaryModel =
     params.runParams?.primaryModel?.trim() || defaultQaModelForMode(providerMode);
   const alternateModel =

--- a/extensions/qa-lab/src/suite-model-selection.ts
+++ b/extensions/qa-lab/src/suite-model-selection.ts
@@ -7,6 +7,7 @@ import {
 import { DEFAULT_QA_LIVE_PROVIDER_MODE } from "./providers/index.js";
 import { defaultQaModelForMode } from "./run-config.js";
 import type { QaSeedScenarioWithSource } from "./scenario-catalog.js";
+import { resolveQaScenarioRequiredProviderMode } from "./scenario-lane.js";
 
 function normalizeQaSuiteModelRef(input: string | undefined, fallback: string) {
   const model = input?.trim();
@@ -15,45 +16,32 @@ function normalizeQaSuiteModelRef(input: string | undefined, fallback: string) {
 
 export function resolveRequestedQaSuiteModels(params: {
   alternateModel?: string;
+  fastMode?: boolean;
   primaryModel?: string;
   providerMode?: QaProviderMode;
+  scenarioIds?: readonly string[];
+  scenarios: readonly QaSeedScenarioWithSource[];
 }) {
-  const providerMode = normalizeQaProviderMode(
-    params.providerMode ?? DEFAULT_QA_LIVE_PROVIDER_MODE,
-  );
-  return {
-    providerMode,
-    primaryModel: normalizeQaSuiteModelRef(
-      params.primaryModel,
-      defaultQaModelForMode(providerMode),
-    ),
-    alternateModel: normalizeQaSuiteModelRef(
-      params.alternateModel,
-      defaultQaModelForMode(providerMode, true),
-    ),
-  };
-}
-
-export function resolveSelectedQaSuiteModels(params: {
-  alternateModelExplicit: boolean;
-  fastMode?: boolean;
-  primaryModelExplicit: boolean;
-  requested: ReturnType<typeof resolveRequestedQaSuiteModels>;
-  scenarios: QaSeedScenarioWithSource[];
-}) {
-  const selectedProviderMode =
-    params.scenarios.length === 1 && params.scenarios[0]?.execution.kind === "flow"
-      ? params.scenarios[0].execution.providerMode
+  // A scenario supplies a single-run default; an explicit provider always owns the selected lane.
+  const selectedScenario =
+    params.providerMode === undefined && params.scenarioIds?.length === 1
+      ? params.scenarios.find((scenario) => scenario.id === params.scenarioIds?.[0])
       : undefined;
-  const providerMode = selectedProviderMode ?? params.requested.providerMode;
-  const primaryModel =
-    selectedProviderMode && !params.primaryModelExplicit
-      ? defaultQaModelForMode(providerMode)
-      : params.requested.primaryModel;
-  const alternateModel =
-    selectedProviderMode && !params.alternateModelExplicit
-      ? defaultQaModelForMode(providerMode, true)
-      : params.requested.alternateModel;
+  const selectedProviderMode =
+    selectedScenario?.execution.kind === "flow"
+      ? resolveQaScenarioRequiredProviderMode(selectedScenario)
+      : undefined;
+  const providerMode = normalizeQaProviderMode(
+    params.providerMode ?? selectedProviderMode ?? DEFAULT_QA_LIVE_PROVIDER_MODE,
+  );
+  const primaryModel = normalizeQaSuiteModelRef(
+    params.primaryModel,
+    defaultQaModelForMode(providerMode),
+  );
+  const alternateModel = normalizeQaSuiteModelRef(
+    params.alternateModel,
+    defaultQaModelForMode(providerMode, true),
+  );
   return {
     alternateModel,
     fastMode: params.fastMode ?? isQaFastModeEnabled({ primaryModel, alternateModel }),

--- a/extensions/qa-lab/src/suite-planning.test.ts
+++ b/extensions/qa-lab/src/suite-planning.test.ts
@@ -23,6 +23,7 @@ import {
   selectQaFlowSuiteScenarios,
   shouldUseIsolatedQaSuiteScenarioWorkers,
 } from "./suite-planning.js";
+import { runQaFlowSuiteFromRuntime } from "./suite-run.runtime.js";
 import { makeQaSuiteTestScenario } from "./suite-test-helpers.js";
 
 function makePlaywrightQaSuiteTestScenario(id: string): ReturnType<typeof makeQaSuiteTestScenario> {
@@ -321,6 +322,72 @@ describe("qa suite planning helpers", () => {
     ).toThrow(
       "selected QA scenario(s) do not match the current QA lane: mock-only (providerMode=mock-openai)",
     );
+  });
+
+  it("rejects an explicitly selected scenario whose provider pin conflicts with the requested lane", () => {
+    const scenario = makeMatrixFlowQaSuiteTestScenario("mock-selected", "mock-openai");
+
+    expect(() =>
+      selectQaFlowSuiteScenarios({
+        scenarios: [scenario],
+        scenarioIds: [scenario.id],
+        providerMode: "live-frontier",
+        primaryModel: "openai/gpt-5.6-luna",
+        channelDriver: "live",
+        channel: "matrix",
+      }),
+    ).toThrow(
+      "selected QA scenario(s) do not match the current QA lane: mock-selected (providerMode=mock-openai)",
+    );
+  });
+
+  it.each([
+    {
+      scenarioId: "matrix-room-block-streaming",
+      channelDriver: "live" as const,
+      channelId: "matrix",
+    },
+    { scenarioId: "goal-context-next-turn" },
+  ])("adopts the provider requirement for directly selected $scenarioId", async (selection) => {
+    const repoRoot = await mkdtemp(path.join(os.tmpdir(), "qa-suite-provider-lane-"));
+    const startLab = vi.fn(async () => {
+      throw new Error("selected provider lane reached lab startup");
+    });
+
+    try {
+      await expect(
+        runQaFlowSuiteFromRuntime({
+          repoRoot,
+          scenarioIds: [selection.scenarioId],
+          ...("channelDriver" in selection
+            ? { channelDriver: selection.channelDriver, channelId: selection.channelId }
+            : {}),
+          startLab,
+        }),
+      ).rejects.toThrow("selected provider lane reached lab startup");
+      expect(startLab).toHaveBeenCalledOnce();
+    } finally {
+      await rm(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects an explicit provider override that conflicts with a config-only scenario pin", async () => {
+    const repoRoot = await mkdtemp(path.join(os.tmpdir(), "qa-suite-explicit-provider-"));
+    const startLab = vi.fn();
+
+    try {
+      await expect(
+        runQaFlowSuiteFromRuntime({
+          repoRoot,
+          scenarioIds: ["goal-context-next-turn"],
+          providerMode: "live-frontier",
+          startLab,
+        }),
+      ).rejects.toThrow("goal-context-next-turn (providerMode=mock-openai)");
+      expect(startLab).not.toHaveBeenCalled();
+    } finally {
+      await rm(repoRoot, { recursive: true, force: true });
+    }
   });
 
   it("rejects an explicitly requested scenario for the wrong model", () => {

--- a/extensions/qa-lab/src/suite-planning.test.ts
+++ b/extensions/qa-lab/src/suite-planning.test.ts
@@ -23,7 +23,6 @@ import {
   selectQaFlowSuiteScenarios,
   shouldUseIsolatedQaSuiteScenarioWorkers,
 } from "./suite-planning.js";
-import { runQaFlowSuiteFromRuntime } from "./suite-run.runtime.js";
 import { makeQaSuiteTestScenario } from "./suite-test-helpers.js";
 
 function makePlaywrightQaSuiteTestScenario(id: string): ReturnType<typeof makeQaSuiteTestScenario> {
@@ -281,113 +280,6 @@ describe("qa suite planning helpers", () => {
         500,
       ),
     ).toBe(25);
-  });
-
-  it("rejects an explicitly requested scenario for the wrong provider", () => {
-    const scenarios = [
-      makeQaSuiteTestScenario("generic"),
-      makeQaSuiteTestScenario("anthropic-only", {
-        config: {
-          requiredProvider: "anthropic",
-        },
-      }),
-    ];
-
-    expect(() =>
-      selectQaFlowSuiteScenarios({
-        scenarios,
-        scenarioIds: ["anthropic-only"],
-        providerMode: "live-frontier",
-        primaryModel: "openai/gpt-5.6-luna",
-      }),
-    ).toThrow(
-      "selected QA scenario(s) do not match the current QA lane: anthropic-only (provider=anthropic)",
-    );
-  });
-
-  it("rejects an explicitly requested scenario for the wrong provider mode", () => {
-    const scenarios = [
-      makeQaSuiteTestScenario("mock-only", {
-        config: { requiredProviderMode: "mock-openai" },
-      }),
-    ];
-
-    expect(() =>
-      selectQaFlowSuiteScenarios({
-        scenarios,
-        scenarioIds: ["mock-only"],
-        providerMode: "live-frontier",
-        primaryModel: "openai/gpt-5.6-luna",
-      }),
-    ).toThrow(
-      "selected QA scenario(s) do not match the current QA lane: mock-only (providerMode=mock-openai)",
-    );
-  });
-
-  it("rejects an explicitly selected scenario whose provider pin conflicts with the requested lane", () => {
-    const scenario = makeMatrixFlowQaSuiteTestScenario("mock-selected", "mock-openai");
-
-    expect(() =>
-      selectQaFlowSuiteScenarios({
-        scenarios: [scenario],
-        scenarioIds: [scenario.id],
-        providerMode: "live-frontier",
-        primaryModel: "openai/gpt-5.6-luna",
-        channelDriver: "live",
-        channel: "matrix",
-      }),
-    ).toThrow(
-      "selected QA scenario(s) do not match the current QA lane: mock-selected (providerMode=mock-openai)",
-    );
-  });
-
-  it.each([
-    {
-      scenarioId: "matrix-room-block-streaming",
-      channelDriver: "live" as const,
-      channelId: "matrix",
-    },
-    { scenarioId: "goal-context-next-turn" },
-  ])("adopts the provider requirement for directly selected $scenarioId", async (selection) => {
-    const repoRoot = await mkdtemp(path.join(os.tmpdir(), "qa-suite-provider-lane-"));
-    const startLab = vi.fn(async () => {
-      throw new Error("selected provider lane reached lab startup");
-    });
-
-    try {
-      await expect(
-        runQaFlowSuiteFromRuntime({
-          repoRoot,
-          scenarioIds: [selection.scenarioId],
-          ...("channelDriver" in selection
-            ? { channelDriver: selection.channelDriver, channelId: selection.channelId }
-            : {}),
-          startLab,
-        }),
-      ).rejects.toThrow("selected provider lane reached lab startup");
-      expect(startLab).toHaveBeenCalledOnce();
-    } finally {
-      await rm(repoRoot, { recursive: true, force: true });
-    }
-  });
-
-  it("rejects an explicit provider override that conflicts with a config-only scenario pin", async () => {
-    const repoRoot = await mkdtemp(path.join(os.tmpdir(), "qa-suite-explicit-provider-"));
-    const startLab = vi.fn();
-
-    try {
-      await expect(
-        runQaFlowSuiteFromRuntime({
-          repoRoot,
-          scenarioIds: ["goal-context-next-turn"],
-          providerMode: "live-frontier",
-          startLab,
-        }),
-      ).rejects.toThrow("goal-context-next-turn (providerMode=mock-openai)");
-      expect(startLab).not.toHaveBeenCalled();
-    } finally {
-      await rm(repoRoot, { recursive: true, force: true });
-    }
   });
 
   it("rejects an explicitly requested scenario for the wrong model", () => {

--- a/extensions/qa-lab/src/suite-planning.ts
+++ b/extensions/qa-lab/src/suite-planning.ts
@@ -80,10 +80,6 @@ function selectQaFlowSuiteScenarios(params: {
   return params.scenarios.filter(
     (scenario) =>
       scenario.execution.kind === "flow" &&
-      // Explicit single-scenario runs adopt this provider later. Implicit suites must
-      // filter it here so a scenario-pinned provider cannot leak into another lane.
-      (scenario.execution.providerMode === undefined ||
-        scenario.execution.providerMode === params.providerMode) &&
       scenarioMatchesQaProviderLane({
         scenario,
         providerMode: params.providerMode,

--- a/extensions/qa-lab/src/suite-provider-selection.test.ts
+++ b/extensions/qa-lab/src/suite-provider-selection.test.ts
@@ -1,0 +1,121 @@
+// QA Lab suite selection keeps scenario requirements on their declared provider lane.
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { requireFlowScenario } from "./scenario-catalog.test-utils.js";
+import { selectQaFlowSuiteScenarios } from "./suite-planning.js";
+import { runQaFlowSuiteFromRuntime } from "./suite-run.runtime.js";
+import { makeQaSuiteTestScenario } from "./suite-test-helpers.js";
+
+describe("qa suite provider selection", () => {
+  it("rejects an explicitly requested scenario for the wrong provider", () => {
+    const scenarios = [
+      makeQaSuiteTestScenario("generic"),
+      makeQaSuiteTestScenario("anthropic-only", {
+        config: {
+          requiredProvider: "anthropic",
+        },
+      }),
+    ];
+
+    expect(() =>
+      selectQaFlowSuiteScenarios({
+        scenarios,
+        scenarioIds: ["anthropic-only"],
+        providerMode: "live-frontier",
+        primaryModel: "openai/gpt-5.6-luna",
+      }),
+    ).toThrow(
+      "selected QA scenario(s) do not match the current QA lane: anthropic-only (provider=anthropic)",
+    );
+  });
+
+  it("rejects an explicitly requested scenario for the wrong provider mode", () => {
+    const scenarios = [
+      makeQaSuiteTestScenario("mock-only", {
+        config: { requiredProviderMode: "mock-openai" },
+      }),
+    ];
+
+    expect(() =>
+      selectQaFlowSuiteScenarios({
+        scenarios,
+        scenarioIds: ["mock-only"],
+        providerMode: "live-frontier",
+        primaryModel: "openai/gpt-5.6-luna",
+      }),
+    ).toThrow(
+      "selected QA scenario(s) do not match the current QA lane: mock-only (providerMode=mock-openai)",
+    );
+  });
+
+  it("rejects an explicitly selected scenario whose provider pin conflicts with the requested lane", () => {
+    const scenario = requireFlowScenario(
+      makeQaSuiteTestScenario("mock-selected", { channel: "matrix" }),
+    );
+    scenario.execution.providerMode = "mock-openai";
+
+    expect(() =>
+      selectQaFlowSuiteScenarios({
+        scenarios: [scenario],
+        scenarioIds: [scenario.id],
+        providerMode: "live-frontier",
+        primaryModel: "openai/gpt-5.6-luna",
+        channelDriver: "live",
+        channel: "matrix",
+      }),
+    ).toThrow(
+      "selected QA scenario(s) do not match the current QA lane: mock-selected (providerMode=mock-openai)",
+    );
+  });
+
+  it.each([
+    {
+      scenarioId: "matrix-room-block-streaming",
+      channelDriver: "live" as const,
+      channelId: "matrix",
+    },
+    { scenarioId: "goal-context-next-turn" },
+  ])("adopts the provider requirement for directly selected $scenarioId", async (selection) => {
+    const repoRoot = await mkdtemp(path.join(os.tmpdir(), "qa-suite-provider-lane-"));
+    const startLab = vi.fn(async () => {
+      throw new Error("selected provider lane reached lab startup");
+    });
+
+    try {
+      await expect(
+        runQaFlowSuiteFromRuntime({
+          repoRoot,
+          scenarioIds: [selection.scenarioId],
+          ...("channelDriver" in selection
+            ? { channelDriver: selection.channelDriver, channelId: selection.channelId }
+            : {}),
+          startLab,
+        }),
+      ).rejects.toThrow("selected provider lane reached lab startup");
+      expect(startLab).toHaveBeenCalledOnce();
+    } finally {
+      await rm(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects an explicit provider override that conflicts with a config-only scenario pin", async () => {
+    const repoRoot = await mkdtemp(path.join(os.tmpdir(), "qa-suite-explicit-provider-"));
+    const startLab = vi.fn();
+
+    try {
+      await expect(
+        runQaFlowSuiteFromRuntime({
+          repoRoot,
+          scenarioIds: ["goal-context-next-turn"],
+          providerMode: "live-frontier",
+          startLab,
+        }),
+      ).rejects.toThrow("goal-context-next-turn (providerMode=mock-openai)");
+      expect(startLab).not.toHaveBeenCalled();
+    } finally {
+      await rm(repoRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/extensions/qa-lab/src/suite-provider-selection.test.ts
+++ b/extensions/qa-lab/src/suite-provider-selection.test.ts
@@ -1,9 +1,10 @@
 // QA Lab suite selection keeps scenario requirements on their declared provider lane.
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { requireFlowScenario } from "./scenario-catalog.test-utils.js";
+import { runQaSuite } from "./suite-launch.runtime.js";
 import { selectQaFlowSuiteScenarios } from "./suite-planning.js";
 import { runQaFlowSuiteFromRuntime } from "./suite-run.runtime.js";
 import { makeQaSuiteTestScenario } from "./suite-test-helpers.js";
@@ -95,6 +96,65 @@ describe("qa suite provider selection", () => {
         }),
       ).rejects.toThrow("selected provider lane reached lab startup");
       expect(startLab).toHaveBeenCalledOnce();
+    } finally {
+      await rm(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("adopts a single runtime-partitioned flow scenario's required provider", async () => {
+    const repoRoot = await mkdtemp(path.join(os.tmpdir(), "qa-suite-unified-provider-"));
+    const startLab = vi.fn(async () => {
+      throw new Error("selected unified provider lane reached lab startup");
+    });
+
+    try {
+      const result = await runQaSuite({
+        repoRoot,
+        scenarioIds: ["long-context-progress-watchdog"],
+        startLab,
+      });
+
+      expect(result.executionKind).toBe("suite");
+      expect(startLab).toHaveBeenCalledOnce();
+      expect(result.result.scenarios).toEqual([
+        expect.objectContaining({
+          status: "fail",
+          details: expect.stringContaining("selected unified provider lane reached lab startup"),
+        }),
+      ]);
+      const summary = JSON.parse(await readFile(result.result.summaryPath, "utf8")) as {
+        run: { providerMode: string; primaryModel: string; alternateModel: string };
+      };
+      expect(summary.run).toMatchObject({
+        providerMode: "live-frontier",
+        primaryModel: expect.stringMatching(/^openai\//),
+        alternateModel: expect.stringMatching(/^openai\//),
+      });
+    } finally {
+      await rm(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps an explicit unified provider override ahead of a scenario requirement", async () => {
+    const repoRoot = await mkdtemp(path.join(os.tmpdir(), "qa-suite-unified-override-"));
+    const startLab = vi.fn();
+
+    try {
+      const result = await runQaSuite({
+        repoRoot,
+        providerMode: "mock-openai",
+        scenarioIds: ["long-context-progress-watchdog"],
+        startLab,
+      });
+
+      expect(result.executionKind).toBe("suite");
+      expect(startLab).not.toHaveBeenCalled();
+      expect(result.result.scenarios).toEqual([
+        expect.objectContaining({
+          status: "fail",
+          details: expect.stringContaining("providerMode=live-frontier"),
+        }),
+      ]);
     } finally {
       await rm(repoRoot, { recursive: true, force: true });
     }

--- a/extensions/qa-lab/src/suite-run.runtime.ts
+++ b/extensions/qa-lab/src/suite-run.runtime.ts
@@ -4,10 +4,7 @@ import {
   normalizeQaTransportId,
 } from "./qa-transport-registry.js";
 import { readQaBootstrapScenarioCatalog } from "./scenario-catalog.js";
-import {
-  resolveRequestedQaSuiteModels,
-  resolveSelectedQaSuiteModels,
-} from "./suite-model-selection.js";
+import { resolveRequestedQaSuiteModels } from "./suite-model-selection.js";
 import {
   collectQaSuiteGatewayConfigPatch,
   collectQaSuiteGatewayRuntimeOptions,
@@ -32,10 +29,13 @@ import {
 export async function runQaFlowSuiteFromRuntime(params?: QaSuiteRunParams): Promise<QaSuiteResult> {
   const startedAt = new Date();
   const repoRoot = path.resolve(params?.repoRoot ?? process.cwd());
-  const requestedModels = resolveRequestedQaSuiteModels(params ?? {});
+  const catalog = readQaBootstrapScenarioCatalog();
+  const requestedModels = resolveRequestedQaSuiteModels({
+    ...params,
+    scenarios: catalog.scenarios,
+  });
   const transportId = normalizeQaTransportId(params?.transportId);
   const outputDir = await resolveQaSuiteOutputDir(repoRoot, params?.outputDir);
-  const catalog = readQaBootstrapScenarioCatalog();
   const channelDriver = params?.channelDriver ?? params?.channelDriverSelection?.channelDriver;
   const selectedScenarios = selectQaFlowSuiteScenarios({
     scenarios: catalog.scenarios,
@@ -51,13 +51,7 @@ export async function runQaFlowSuiteFromRuntime(params?: QaSuiteRunParams): Prom
       "QA suite selected no runnable scenarios; check the scenario catalog and provider, model, or channel filters.",
     );
   }
-  const { alternateModel, fastMode, primaryModel, providerMode } = resolveSelectedQaSuiteModels({
-    alternateModelExplicit: params?.alternateModel !== undefined,
-    fastMode: params?.fastMode,
-    primaryModelExplicit: params?.primaryModel !== undefined,
-    requested: requestedModels,
-    scenarios: selectedScenarios,
-  });
+  const { alternateModel, fastMode, primaryModel, providerMode } = requestedModels;
   if (
     params?.roundTripProbe &&
     !selectedScenarios.some((scenario) => scenario.id === params.roundTripProbe?.scenarioId)


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where selecting one QA scenario could choose the wrong provider/model or reject a supported scenario depending on which existing scenario field declared its provider lane. Explicitly conflicting lane declarations also had no single authoritative owner.

## Why This Change Was Made

Resolve both existing scenario-provider declarations in one canonical QA owner before choosing models or planning scenarios. Preserve explicit operator selections and implicit single-scenario defaults, reject conflicting declarations, and remove the old late override and duplicated lane filter. This changes private QA selection only; it adds no product configuration, provider API, persisted state, or compatibility surface.

## User Impact

QA operators get the intended mock or live provider consistently across direct runs, profile planning, and implicit single-scenario selection.

## Evidence

- Authentic pre-fix regressions reproduced mismatched Matrix lane selection, conflicting scenario declarations, and config-only mock scenarios selecting the live default.
- Focused owner coverage: `extensions/qa-lab/src/scenario-lane.test.ts` and `extensions/qa-lab/src/suite-planning.test.ts`, including explicit-override and implicit-singleton controls.
- Trusted Blacksmith Testbox aggregate: **916 passing tests across 28 files**; the final owner-adjacent rerun passed **102 tests across 6 files**.
- Independent structured review found no accepted actionable findings; Testbox run: https://github.com/openclaw/openclaw/actions/runs/30973152491
- Production owner delta: **47 additions / 52 deletions (-5 net)**; regression tests: **149 additions**. The follow-up type-narrowing correction is net-zero.

### Inspectable owner-path proof

Trusted Blacksmith Testbox exercised the real unified suite owner, not a selector-only mock:

```text
[qa-suite] run start: scenarios=1
[qa-suite] lab start
extensions/qa-lab/src/suite-provider-selection.test.ts: 8 tests passed
```

The runtime-partitioned singleton reaches the injected real lab-start boundary and records `providerMode: live-frontier` in the unified summary. Its explicit mock-override control does not start a lab and reports the actual provider-lane mismatch. Inference is limited to an omitted override plus exactly one selected flow scenario; native-only, mixed, profile, operator-explicit, and default provider behavior remain unchanged. Provider resolution happens before suite progress starts.

### Real Gateway provider-selection verdict

Trusted Testbox invoked the actual private-QA CLI with no provider override and a real config-only mock-pinned scenario:

    pnpm openclaw qa suite --scenario goal-context-next-turn --output-dir .artifacts/qa-e2e/autoqa-provider-direct-proof
    [qa-suite] provider start: mock-openai
    [qa-suite] gateway ready: http://127.0.0.1:41921
    [qa-suite] scenario start (1/1): goal-context-next-turn
    [qa-suite] scenario pass (1/1): goal-context-next-turn
    [qa-suite] run complete: passed=1 failed=0 skipped=0 total=1
    {"proof":"direct-implicit-provider-selection","run":{"providerMode":"mock-openai","primaryModel":"mock-openai/gpt-5.6-luna","alternateModel":"mock-openai/gpt-5.6-luna-alt"},"counts":{"total":1,"passed":1,"failed":0,"skipped":0}}

The same run passed the real unified-suite owner regressions (8 tests) and 154 owner/sibling tests across nine files; unified scenario summary asserts live-frontier primary and alternate OpenAI models while explicit mock remains rejected. Exact touched PR files were verified byte-identical to the integration proof checkout. Testbox run: https://github.com/openclaw/openclaw/actions/runs/30983445783

### Current-main and shipped-tag contract audit

The latest automated review's claim that merged #119519 deliberately reverted scenario-derived provider selection is factually incorrect:

- Shipped tag v2026.7.2-beta.7 already implements selected-singleton scenario provider AND primary/alternate model adoption in extensions/qa-lab/src/suite-model-selection.ts:39-55.
- Both that shipped tag and current main explicitly document the existing contract in extensions/qa-lab/src/suite-planning.ts:83-86: "Explicit single-scenario runs adopt this provider later."
- Alleged revert commit ae54355087b (#119519) touches ZERO of scenario-lane.ts, suite-model-selection.ts, suite-planning.ts, suite-run.runtime.ts, or suite-launch.runtime.ts; direct git show of all five paths is empty. Its actual changes add config-form requiredProviderMode declarations and preserve profile-selection provenance.
- This PR preserves the existing shipped single-scenario adoption contract, resolves BOTH equivalent metadata forms through one owner BEFORE eligibility filtering, and makes a single runtime-partitioned flow use the same already-supported behavior. Native-only/mixed/implicit/profile suites preserve their original defaults.
- One intentional compatibility correction is explicit: a conflicting explicitly supplied operator provider now remains authoritative and produces a clear lane-mismatch error; the old late override silently discarded the operator's explicit choice.
- The real private-Gateway verdict in this PR demonstrates the config-only mock scenario now selects mock-openai and passes, while the shipped execution-form scenario and both direct/unified paths retain explicit-override coverage.

The two automated P1 findings depend on a nonexistent "deliberate revert" and are rejected based on the exact shipped source, current source, merged commit file list, preserved operator intent, and real Gateway output. No provider-default policy or public configuration surface is added.
