### PR TITLE
fix(qa): release the parent channel lease before runtime-parity workers

### DIFF
--- a/extensions/qa-lab/src/suite-runtime-parity-runner.cleanup.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-parity-runner.cleanup.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import { createQaBusState } from "./bus-state.js";
 import type { QaLabServerHandle } from "./lab-server.types.js";
-import type { QaTransportAdapterFactory } from "./qa-transport-registry.js";
+import {
+  createQaTransportAdapter,
+  type QaTransportAdapterFactory,
+} from "./qa-transport-registry.js";
 import { runQaRuntimeParitySuite } from "./suite-runtime-parity-runner.js";
 import { makeQaSuiteTestScenario } from "./suite-test-helpers.js";
 import type { QaSuiteRunner } from "./suite-types.js";
@@ -19,62 +22,82 @@ function createCleanupTestLab(): QaLabServerHandle {
   };
 }
 
+type CleanupPhases = {
+  cleanup?: () => Promise<void>;
+  cleanupAfterGatewayStop?: () => Promise<void>;
+};
+
+function createCleanupTestFactory(
+  lab: QaLabServerHandle,
+  createCleanupPhases: () => CleanupPhases | Promise<CleanupPhases>,
+): QaTransportAdapterFactory {
+  return {
+    id: "leased",
+    matches: ({ channelId, driver }) => channelId === "leased" && driver === "live",
+    async create() {
+      const cleanupPhases = await createCleanupPhases();
+      return {
+        id: "leased",
+        label: "Leased channel",
+        accountId: "sut",
+        requiredPluginIds: [],
+        supportedActions: [],
+        sendInbound: async (input) => lab.state.addInboundMessage(input),
+        createGatewayConfig: () => ({}),
+        async waitReady() {},
+        buildAgentDelivery: ({ target }) => ({
+          channel: "leased",
+          to: target,
+          replyChannel: "leased",
+          replyTo: target,
+        }),
+        async handleAction() {},
+        createReportNotes: () => [],
+        ...cleanupPhases,
+      };
+    },
+  };
+}
+
+function runCleanupTestSuite(params: {
+  factory: QaTransportAdapterFactory;
+  lab: QaLabServerHandle;
+  runChild: QaSuiteRunner;
+}) {
+  return runQaRuntimeParitySuite({
+    runQaFlowSuite: params.runChild,
+    adapterFactories: [params.factory],
+    channelDriver: "live",
+    channelId: "leased",
+    repoRoot: "/qa-repo",
+    outputDir: "/qa-output",
+    startedAt: new Date("2026-08-04T00:00:00.000Z"),
+    providerMode: "mock-openai",
+    transportId: "qa-channel",
+    primaryModel: "mock-openai/test-model",
+    alternateModel: "mock-openai/test-model-alt",
+    fastMode: true,
+    concurrency: 1,
+    selectedScenarios: [makeQaSuiteTestScenario("runtime-cleanup")],
+    startLab: async () => params.lab,
+    progressEnabled: false,
+    runtimePair: ["openclaw", "codex"],
+  });
+}
+
 describe("runtime parity suite transport cleanup", () => {
-  it("stops its owned lab and preserves the scenario error when transport cleanup fails", async () => {
+  it("preserves the scenario error when its owned lab cleanup fails", async () => {
     const lab = createCleanupTestLab();
     const scenarioError = new Error("runtime scenario failed");
-    const cleanupError = new Error("credential release failed");
-    const cleanup = vi.fn(async () => {
+    const cleanupError = new Error("owned lab shutdown failed");
+    lab.stop = vi.fn(async () => {
       throw cleanupError;
     });
-    const factory: QaTransportAdapterFactory = {
-      id: "leased",
-      matches: ({ channelId, driver }) => channelId === "leased" && driver === "live",
-      async create() {
-        return {
-          id: "leased",
-          label: "Leased channel",
-          accountId: "sut",
-          requiredPluginIds: [],
-          supportedActions: [],
-          sendInbound: async (input) => lab.state.addInboundMessage(input),
-          createGatewayConfig: () => ({}),
-          async waitReady() {},
-          buildAgentDelivery: ({ target }) => ({
-            channel: "leased",
-            to: target,
-            replyChannel: "leased",
-            replyTo: target,
-          }),
-          async handleAction() {},
-          createReportNotes: () => [],
-          cleanup,
-        };
-      },
-    };
+    const cleanup = vi.fn(async () => {});
+    const factory = createCleanupTestFactory(lab, () => ({ cleanup }));
     const runChild = vi.fn<QaSuiteRunner>().mockRejectedValueOnce(scenarioError);
 
-    await expect(
-      runQaRuntimeParitySuite({
-        runQaFlowSuite: runChild,
-        adapterFactories: [factory],
-        channelDriver: "live",
-        channelId: "leased",
-        repoRoot: "/qa-repo",
-        outputDir: "/qa-output",
-        startedAt: new Date("2026-08-04T00:00:00.000Z"),
-        providerMode: "mock-openai",
-        transportId: "qa-channel",
-        primaryModel: "mock-openai/test-model",
-        alternateModel: "mock-openai/test-model-alt",
-        fastMode: true,
-        concurrency: 1,
-        selectedScenarios: [makeQaSuiteTestScenario("runtime-cleanup")],
-        startLab: async () => lab,
-        progressEnabled: false,
-        runtimePair: ["openclaw", "codex"],
-      }),
-    ).rejects.toMatchObject({
+    await expect(runCleanupTestSuite({ factory, lab, runChild })).rejects.toMatchObject({
       message: "QA suite and cleanup failed",
       cause: scenarioError,
       errors: [scenarioError, cleanupError],
@@ -84,4 +107,79 @@ describe("runtime parity suite transport cleanup", () => {
     expect(cleanup).toHaveBeenCalledOnce();
     expect(lab.stop).toHaveBeenCalledOnce();
   });
+
+  it("releases an exclusive parent lease before its first runtime child acquires it", async () => {
+    const lab = createCleanupTestLab();
+    const events: string[] = [];
+    const childError = new Error("first runtime child completed");
+    let activeOwner: "parent" | "child" | undefined;
+    let leaseCount = 0;
+    lab.stop = vi.fn(async () => {
+      events.push("lab:stop");
+    });
+    const factory = createCleanupTestFactory(lab, () => {
+      if (activeOwner) {
+        throw new Error("exclusive credential pool exhausted");
+      }
+      const owner = leaseCount++ === 0 ? "parent" : "child";
+      activeOwner = owner;
+      events.push(`${owner}:acquire`);
+      return {
+        cleanup: async () => {
+          events.push(`${owner}:cleanup-before`);
+        },
+        cleanupAfterGatewayStop: async () => {
+          events.push(`${owner}:cleanup-after`);
+          activeOwner = undefined;
+        },
+      };
+    });
+    const runChild = vi.fn<QaSuiteRunner>().mockImplementation(async () => {
+      const childTransport = await createQaTransportAdapter(
+        {
+          channelId: "leased",
+          driver: "live",
+          outputDir: "/qa-child",
+          state: createQaBusState(),
+        },
+        [factory],
+      );
+      await childTransport.cleanupWithoutGateway();
+      throw childError;
+    });
+
+    await expect(runCleanupTestSuite({ factory, lab, runChild })).rejects.toBe(childError);
+
+    expect(runChild).toHaveBeenCalledOnce();
+    expect(events).toEqual([
+      "parent:acquire",
+      "parent:cleanup-before",
+      "parent:cleanup-after",
+      "child:acquire",
+      "child:cleanup-before",
+      "child:cleanup-after",
+      "lab:stop",
+    ]);
+    expect(activeOwner).toBeUndefined();
+  });
+
+  it.each(["cleanup", "cleanupAfterGatewayStop"] as const)(
+    "retries failed parent %s before stopping its owned lab",
+    async (cleanupPhase) => {
+      const lab = createCleanupTestLab();
+      const cleanupError = new Error("credential release failed");
+      const cleanup = vi
+        .fn<() => Promise<void>>()
+        .mockRejectedValueOnce(cleanupError)
+        .mockResolvedValueOnce(undefined);
+      const factory = createCleanupTestFactory(lab, () => ({ [cleanupPhase]: cleanup }));
+      const runChild = vi.fn<QaSuiteRunner>();
+
+      await expect(runCleanupTestSuite({ factory, lab, runChild })).rejects.toBe(cleanupError);
+
+      expect(cleanup).toHaveBeenCalledTimes(2);
+      expect(runChild).not.toHaveBeenCalled();
+      expect(lab.stop).toHaveBeenCalledOnce();
+    },
+  );
 });

--- a/extensions/qa-lab/src/suite-runtime-parity-runner.ts
+++ b/extensions/qa-lab/src/suite-runtime-parity-runner.ts
@@ -106,7 +106,14 @@ export async function runQaRuntimeParitySuite(params: {
 
   let runFailed = false;
   let runError: unknown;
+  let parentTransportCleaned = false;
   try {
+    if (params.channelDriver === "live") {
+      // The parent only contributes aggregate metadata; release its exclusive
+      // live credential before runtime cells acquire the same transport lease.
+      await transportFactoryResult.cleanupWithoutGateway();
+      parentTransportCleaned = true;
+    }
     const scenarios = await mapQaSuiteWithConcurrency(
       params.selectedScenarios,
       params.concurrency,
@@ -293,7 +300,7 @@ export async function runQaRuntimeParitySuite(params: {
     throw error;
   } finally {
     const cleanupErrors = await runQaSuiteCleanupSteps([
-      () => transportFactoryResult.cleanupWithoutGateway(),
+      ...(!parentTransportCleaned ? [() => transportFactoryResult.cleanupWithoutGateway()] : []),
       ...(ownsLab ? [() => lab.stop()] : []),
     ]);
     throwQaSuiteCleanupErrors({ cleanupErrors, runFailed, runError });


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where a QA runtime-parity run could deadlock when its parent retained the only live channel credential while its first worker tried to acquire that same credential. Failures during parent cleanup could also leave the owned lab running or prevent a safe cleanup retry.

## Why This Change Was Made

Release the parent-owned transport before starting either parity worker, record cleanup completion only after both release phases succeed, and reuse the existing final cleanup owner for retries and lab shutdown. The worker sequence, provider configuration, runtime protocols, persisted state, and Codex behavior are unchanged.

## User Impact

Runtime-parity QA runs can exercise a channel with a single available account or credential without hanging, and failed setup releases its resources reliably.

## Evidence

- Original-order regression uses a real single-credential transport registry: the parent owns the sole lease, the first worker acquires it only after both parent cleanup phases, and both workers execute in order.
- Separate regressions cover failure and retry of each parent cleanup phase, exactly-once shutdown, and preservation of the original scenario error.
- Trusted Blacksmith Testbox aggregate: **916 passing tests across 28 files**; the final runtime-parity/UI owner rerun passed **102 tests across 6 files**.
- Production delta: **8 additions / 1 deletion (+7 net)**, justified by the parent-owned exclusive-resource lifecycle boundary; regression tests: **148 additions / 50 deletions**.
- Reviewed the upstream Codex completion contract directly in `codex-rs/core/src/session/turn.rs` and `codex-rs/protocol/src/protocol.rs`; this generic transport lifecycle fix does not change it.
- Independent structured review found no accepted actionable findings; Testbox run: https://github.com/openclaw/openclaw/actions/runs/30973152491

### Inspectable exclusive-credential lifecycle evidence

The actual `runQaRuntimeParitySuite` owner was exercised with the production QA transport registry containing exactly one available credential. The passing regression asserts this original-order event trace:

```text
parent:acquire
parent:cleanup-before
parent:cleanup-after
child:acquire
child:cleanup-before
child:cleanup-after
```

A child attempting acquisition before the two parent release phases rejects with `exclusive credential pool exhausted`; both real registry owners complete once after the fix. Additional passing cases reject the first parent cleanup phase or the post-Gateway cleanup phase, retry the failed phase through the existing finalizer, and still stop the owned lab.

The upstream Codex contract was inspected directly in sibling source at `codex-rs/core/src/session/turn.rs:256-265`, `codex-rs/core/src/session/turn.rs:460-470`, and `codex-rs/protocol/src/protocol.rs:1988-1995`: terminal completion remains `last_agent_message: Option<String>`. This QA transport-ownership repair does not modify the Codex protocol, provider, runtime lifecycle, or completion value.