### PR TITLE
fix(qa): fail memory recall when only an earlier turn answered

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog-memory-recall-proof.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-memory-recall-proof.test.ts
@@ -1,0 +1,70 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { createQaBusState } from "./bus-state.js";
+import { runLoadedScenarioFlow } from "./scenario-flow-runner.test-support.js";
+import { waitForOutboundMessage } from "./suite-runtime-transport.js";
+
+async function runMemoryRecallScenario(recallReply?: string) {
+  const state = createQaBusState();
+  const outboundCursors: Array<number | undefined> = [];
+  let turnCount = 0;
+
+  const result = await runLoadedScenarioFlow("memory-recall", {
+    state,
+    api: {
+      env: {
+        providerMode: "mock-openai",
+        gateway: { workspaceDir: "/qa-memory-recall" },
+      },
+      fs: { rm: async () => undefined },
+      path,
+      formatMemoryDreamingDay: () => "2026-08-05",
+      normalizeLowercaseStringOrEmpty: (value: unknown) =>
+        typeof value === "string" ? value.trim().toLowerCase() : "",
+      runAgentPrompt: async (_env: unknown, params: { message: string }) => {
+        turnCount += 1;
+        state.addInboundMessage({
+          accountId: "qa-channel",
+          conversation: { id: "qa-operator", kind: "direct" },
+          senderId: "qa-operator",
+          text: params.message,
+        });
+        const text = turnCount === 1 ? "Remembered ALPHA-7." : recallReply;
+        if (text !== undefined) {
+          state.addOutboundMessage({
+            accountId: "qa-channel",
+            to: "dm:qa-operator",
+            text,
+          });
+        }
+      },
+      waitForOutboundMessage: async (...args: Parameters<typeof waitForOutboundMessage>) => {
+        const [transportState, predicate, , options] = args;
+        outboundCursors.push(options?.sinceIndex);
+        return await waitForOutboundMessage(transportState, predicate, 10, options);
+      },
+    },
+  });
+
+  return { outboundCursors, result, state };
+}
+
+describe("memory recall scenario outbound evidence", () => {
+  it("rejects the earlier remember acknowledgement when recall produces no reply", async () => {
+    await expect(runMemoryRecallScenario()).rejects.toThrow("timed out after 10ms");
+  });
+
+  it("measures the recall cursor in outbound messages despite mixed prior traffic", async () => {
+    const { outboundCursors, result, state } = await runMemoryRecallScenario("ALPHA-7.");
+
+    expect(result.status).toBe("pass");
+    expect(result.steps[1]?.details).toBe("ALPHA-7.");
+    expect(state.getSnapshot().messages.map((message) => message.direction)).toEqual([
+      "inbound",
+      "outbound",
+      "inbound",
+      "outbound",
+    ]);
+    expect(outboundCursors).toEqual([undefined, 1]);
+  });
+});

--- a/qa/scenarios/memory/memory-recall.yaml
+++ b/qa/scenarios/memory/memory-recall.yaml
@@ -94,6 +94,9 @@ flow:
       detailsExpr: outbound.text
     - name: recalls the same fact later
       actions:
+        - set: recallOutboundStartIndex
+          value:
+            expr: "state.getSnapshot().messages.filter((candidate) => candidate.direction === 'outbound').length"
         - call: runAgentPrompt
           args:
             - ref: env
@@ -105,10 +108,14 @@ flow:
         - set: recallExpectedAny
           value:
             expr: config.recallExpectedAny.map(normalizeLowercaseStringOrEmpty)
-        - call: waitForCondition
+        - call: waitForOutboundMessage
           saveAs: outbound
           args:
+            - ref: state
             - lambda:
-                expr: "state.getSnapshot().messages.filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === 'qa-operator' && recallExpectedAny.some((needle) => normalizeLowercaseStringOrEmpty(candidate.text).includes(needle))).at(-1)"
+                params: [candidate]
+                expr: "candidate.conversation.id === 'qa-operator' && recallExpectedAny.some((needle) => normalizeLowercaseStringOrEmpty(candidate.text).includes(needle))"
             - 20000
+            - sinceIndex:
+                ref: recallOutboundStartIndex
       detailsExpr: outbound.text


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the memory-recall QA scenario reported success even when the recall turn produced no answer: its assertion rediscovered the acknowledgement from the earlier remember turn.

## Why This Change Was Made

Capture the outbound-message cursor immediately before asking the recall question, then require a matching assistant reply strictly after that cursor using the existing canonical QA waiter. The cursor counts outbound messages only, as required by the waiter's contract.

## User Impact

A broken memory-recall response can no longer appear as a passing QA scenario; genuine later recall answers continue to pass.

## Evidence

- Pre-fix regression runs the complete parsed scenario with the real QA bus and production outbound waiter; an earlier `Remembered ALPHA-7.` acknowledgement but no recall answer incorrectly passed.
- The paired positive control includes mixed inbound/outbound traffic and proves the correct outbound-only cursor is `1`, not the total-message count.
- Real Gateway + mock-provider execution passed the repaired `memory-recall` scenario; trusted Blacksmith Testbox aggregate passed **916 tests across 28 files**.
- Changes are limited to one QA scenario and one new focused regression; no runtime memory behavior, storage, configuration, or external provider contract changed.
- Independent structured review found no accepted actionable findings; Testbox run: https://github.com/openclaw/openclaw/actions/runs/30973152491

### Inspectable after-fix Gateway evidence

Observed on the trusted Blacksmith Testbox using a real ephemeral OpenClaw Gateway, the qa-channel transport, and a mock OpenAI model provider:

```text
scenario: memory-recall
provider: mock-openai
Gateway: real ephemeral Gateway
result: PASS
assertion: matching assistant recall reply occurs after the outbound cursor captured for the recall turn
```

The owner-path negative regression also confirms the old remember acknowledgement alone now fails; mixed inbound/outbound history preserves the outbound-only cursor.