### PR TITLE
fix(qa): prove newer session facts outrank competing durable memory

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/server.memory-ranking-proof.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.memory-ranking-proof.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { startQaMockOpenAiServer } from "./server.js";
+
+describe("QA mock OpenAI session memory ranking", () => {
+  it("plans an answer-free search across both configured memory sources", async () => {
+    const server = await startQaMockOpenAiServer({ host: "127.0.0.1", port: 0 });
+
+    try {
+      const response = await fetch(`${server.baseUrl}/v1/responses`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "gpt-5.6-luna",
+          stream: false,
+          input: [
+            {
+              role: "user",
+              content: [
+                {
+                  type: "input_text",
+                  text: "Session memory ranking check: what is the current Project Nebula codename? Use memory tools first.",
+                },
+              ],
+            },
+          ],
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      const payload = (await response.json()) as {
+        output?: Array<{ type?: string; name?: string; arguments?: string }>;
+      };
+      const searchCall = payload.output?.find(
+        (item) => item.type === "function_call" && item.name === "memory_search",
+      );
+      expect(searchCall).toBeDefined();
+      const args = JSON.parse(searchCall?.arguments ?? "null") as Record<string, unknown>;
+
+      expect(args).toEqual({
+        query: "current Project Nebula codename",
+        maxResults: 6,
+      });
+      expect(JSON.stringify(args)).not.toMatch(/ORBIT-(?:9|10)/);
+      expect(args).not.toHaveProperty("corpus");
+    } finally {
+      await server.stop();
+    }
+  });
+});

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -3752,7 +3752,7 @@ Update and merge these partial structured summaries.`,
       ],
     });
     expect(memoryText).toContain('"name":"memory_search"');
-    expect(memoryText).toContain('\\"corpus\\":\\"sessions\\"');
+    expect(memoryText).not.toContain('\\"corpus\\"');
 
     const threadMemorySearchText = await expectStreamingResponsesText(server, {
       instructions:

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -1917,9 +1917,8 @@ async function buildResponsesPayload(
   if (/session memory ranking check/i.test(prompt)) {
     if (!scenarioToolOutput) {
       return buildToolCallEventsWithArgs("memory_search", {
-        query: "current Project Nebula codename ORBIT-10",
-        maxResults: 3,
-        corpus: "sessions",
+        query: "current Project Nebula codename",
+        maxResults: 6,
       });
     }
     if (memoryToolUnavailable) {

--- a/extensions/qa-lab/src/scenario-catalog-memory-ranking-proof.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-memory-ranking-proof.test.ts
@@ -41,6 +41,7 @@ async function runSessionMemoryRankingFlow(params: {
   results: RankingResult[];
   providerMode?: ProviderMode;
   query?: string;
+  maxResults?: number;
   corpus?: "memory" | "sessions" | "all";
   includeToolCall?: boolean;
   includeToolResult?: boolean;
@@ -53,7 +54,7 @@ async function runSessionMemoryRankingFlow(params: {
   const includeToolResult = params.includeToolResult !== false;
   const plannedToolArgs = {
     query: params.query ?? searchQuery,
-    maxResults: 6,
+    maxResults: params.maxResults ?? 6,
     ...(params.corpus ? { corpus: params.corpus } : {}),
   };
   const toolResultCallId = params.resultCallId ?? searchCallId;
@@ -356,6 +357,19 @@ describe("session memory ranking scenario evidence", () => {
           results: [currentQuestionResult, staleDurableResult, currentSessionResult],
         }),
       ).rejects.toThrow(/rank|stale|durable/i);
+    },
+  );
+
+  it.each(["mock-openai", "live-frontier"] as const)(
+    "rejects a correlated memory search using less than the canonical six-result window (%s)",
+    async (providerMode) => {
+      await expect(
+        runSessionMemoryRankingFlow({
+          providerMode,
+          results: [currentSessionResult, staleDurableResult],
+          maxResults: 3,
+        }),
+      ).rejects.toThrow(/maxResults|result|six|6/i);
     },
   );
 

--- a/extensions/qa-lab/src/scenario-catalog-memory-ranking-proof.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-memory-ranking-proof.test.ts
@@ -42,6 +42,7 @@ async function runSessionMemoryRankingFlow(params: {
   providerMode?: ProviderMode;
   query?: string;
   maxResults?: number;
+  omitMaxResults?: boolean;
   corpus?: "memory" | "sessions" | "all";
   includeToolCall?: boolean;
   includeToolResult?: boolean;
@@ -54,7 +55,7 @@ async function runSessionMemoryRankingFlow(params: {
   const includeToolResult = params.includeToolResult !== false;
   const plannedToolArgs = {
     query: params.query ?? searchQuery,
-    maxResults: params.maxResults ?? 6,
+    ...(params.omitMaxResults ? {} : { maxResults: params.maxResults ?? 6 }),
     ...(params.corpus ? { corpus: params.corpus } : {}),
   };
   const toolResultCallId = params.resultCallId ?? searchCallId;
@@ -357,6 +358,24 @@ describe("session memory ranking scenario evidence", () => {
           results: [currentQuestionResult, staleDurableResult, currentSessionResult],
         }),
       ).rejects.toThrow(/rank|stale|durable/i);
+    },
+  );
+
+  it.each(["mock-openai", "live-frontier"] as const)(
+    "accepts an omitted result limit using the canonical six-result product default (%s)",
+    async (providerMode) => {
+      const { result } = await runSessionMemoryRankingFlow({
+        providerMode,
+        results: [
+          currentQuestionResult,
+          currentSessionResult,
+          evergreenUserResult,
+          staleDurableResult,
+        ],
+        omitMaxResults: true,
+      });
+
+      expect(result.status).toBe("pass");
     },
   );
 

--- a/extensions/qa-lab/src/scenario-catalog-memory-ranking-proof.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-memory-ranking-proof.test.ts
@@ -1,0 +1,387 @@
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { createQaBusState } from "./bus-state.js";
+import { runLoadedScenarioFlow } from "./scenario-flow-runner.test-support.js";
+
+const searchCallId = "call-session-memory-ranking";
+const searchQuery = "current Project Nebula codename";
+const currentQuestionResult = {
+  path: "sessions/qa/current-session-memory-ranking.jsonl",
+  source: "sessions",
+  snippet: "User: Session memory ranking check: what is the current Project Nebula codename?",
+  score: 0.98,
+};
+const currentSessionResult = {
+  path: "sessions/qa-session-memory-ranking.jsonl",
+  source: "sessions",
+  snippet: "The current Project Nebula codename is ORBIT-10.",
+  score: 0.8,
+};
+const evergreenUserResult = {
+  path: "USER.md",
+  source: "memory",
+  snippet: "About Your Human: preferred project communication style.",
+  score: 0.68,
+};
+const staleDurableResult = {
+  path: `memory/${new Date(Date.now() - 3 * 86_400_000).toISOString().slice(0, 10)}.md`,
+  source: "memory",
+  snippet: "Project Nebula current codename: ORBIT-9.",
+  score: 0.9,
+};
+
+type RankingResult =
+  | typeof currentQuestionResult
+  | typeof currentSessionResult
+  | typeof evergreenUserResult
+  | typeof staleDurableResult;
+type ProviderMode = "mock-openai" | "live-frontier";
+
+async function runSessionMemoryRankingFlow(params: {
+  results: RankingResult[];
+  providerMode?: ProviderMode;
+  query?: string;
+  corpus?: "memory" | "sessions" | "all";
+  includeToolCall?: boolean;
+  includeToolResult?: boolean;
+  resultCallId?: string;
+  resultIsError?: boolean;
+}) {
+  const state = createQaBusState();
+  const providerMode = params.providerMode ?? "mock-openai";
+  const includeToolCall = params.includeToolCall !== false;
+  const includeToolResult = params.includeToolResult !== false;
+  const plannedToolArgs = {
+    query: params.query ?? searchQuery,
+    maxResults: 6,
+    ...(params.corpus ? { corpus: params.corpus } : {}),
+  };
+  const toolResultCallId = params.resultCallId ?? searchCallId;
+  const requests = [
+    ...(includeToolCall
+      ? [
+          {
+            cursor: 41,
+            allInputText: "Session memory ranking check",
+            plannedToolName: "memory_search",
+            plannedToolCallId: searchCallId,
+            plannedToolArgs,
+          },
+        ]
+      : []),
+    ...(includeToolResult
+      ? [
+          {
+            cursor: 42,
+            allInputText: "Session memory ranking check",
+            toolOutputCallId: toolResultCallId,
+            toolOutput: JSON.stringify({ results: params.results }),
+            ...(params.resultIsError ? { toolOutputStructuredError: true } : {}),
+          },
+        ]
+      : []),
+  ];
+  const historyMessages = [
+    ...(includeToolCall
+      ? [
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "toolCall",
+                id: searchCallId,
+                name: "memory_search",
+                arguments: plannedToolArgs,
+              },
+            ],
+          },
+        ]
+      : []),
+    ...(includeToolResult
+      ? [
+          {
+            role: "toolResult",
+            toolCallId: toolResultCallId,
+            toolName: "memory_search",
+            isError: params.resultIsError === true,
+            content: [{ type: "text", text: JSON.stringify({ results: params.results }) }],
+          },
+        ]
+      : []),
+    {
+      role: "assistant",
+      content: [{ type: "text", text: "The current Project Nebula codename is ORBIT-10." }],
+    },
+  ];
+  const gatewayCall = vi.fn(
+    async (method: string, request: { sessionKey?: string; limit?: number }) => {
+      expect(method).toBe("chat.history");
+      expect(request.sessionKey).toBe("agent:qa:session-memory-ranking");
+      return { messages: historyMessages };
+    },
+  );
+  const fetchJson = vi.fn(async (input: string) => {
+    const url = new URL(input);
+    if (url.pathname === "/debug/request-cursor") {
+      return { cursor: 40 };
+    }
+    if (url.pathname === "/debug/requests") {
+      const after = Number(url.searchParams.get("after") ?? 0);
+      return requests.filter((request) => request.cursor > after);
+    }
+    throw new Error(`unexpected QA mock request: ${input}`);
+  });
+  const forceMemoryIndex = vi.fn(async () => undefined);
+  const writeFile = vi.fn(
+    async (_filePath: string, _content: string, _encoding: string) => undefined,
+  );
+  const utimes = vi.fn(
+    async (_filePath: string, _accessedAt: Date, _modifiedAt: Date) => undefined,
+  );
+  const runAgentPrompt = vi.fn(async (_env: unknown, options: { message: string }) => {
+    expect(options.message).not.toContain("ORBIT-10");
+    state.addOutboundMessage({
+      accountId: "qa-channel",
+      to: "dm:qa-operator",
+      text: "The current Project Nebula codename is ORBIT-10.",
+    });
+  });
+
+  const result = await runLoadedScenarioFlow("session-memory-ranking", {
+    state,
+    api: {
+      env: {
+        providerMode,
+        gateway: { workspaceDir: "/qa/workspace", call: gatewayCall },
+        ...(providerMode === "mock-openai" ? { mock: { baseUrl: "http://qa.mock" } } : {}),
+      },
+      path,
+      fs: {
+        mkdir: async () => undefined,
+        writeFile,
+        utimes,
+      },
+      readConfigSnapshot: async () => ({ config: {} }),
+      patchConfig: async () => undefined,
+      seedQaSessionTranscript: async () => undefined,
+      forceMemoryIndex,
+      runAgentPrompt,
+      normalizeLowercaseStringOrEmpty: (value: unknown) =>
+        typeof value === "string" ? value.trim().toLowerCase() : "",
+      fetchJson,
+    },
+  });
+
+  return { result, fetchJson, forceMemoryIndex, gatewayCall, runAgentPrompt, utimes, writeFile };
+}
+
+describe("session memory ranking scenario evidence", () => {
+  it.each(["mock-openai", "live-frontier"] as const)(
+    "accepts current session memory ranked before competing stale durable memory (%s)",
+    async (providerMode) => {
+      const { result } = await runSessionMemoryRankingFlow({
+        providerMode,
+        results: [currentSessionResult, staleDurableResult],
+      });
+
+      expect(result.status).toBe("pass");
+    },
+  );
+
+  it.each(["mock-openai", "live-frontier"] as const)(
+    "compares conflicting facts while ignoring the current question and evergreen USER note (%s)",
+    async (providerMode) => {
+      const { result } = await runSessionMemoryRankingFlow({
+        providerMode,
+        results: [
+          currentQuestionResult,
+          currentSessionResult,
+          evergreenUserResult,
+          staleDurableResult,
+        ],
+      });
+
+      expect(result.status).toBe("pass");
+    },
+  );
+
+  it.each(["mock-openai", "live-frontier"] as const)(
+    "seeds the conflicting durable fact in an authentic three-day-old daily note (%s)",
+    async (providerMode) => {
+      const startedAt = Date.now();
+      const { utimes, writeFile } = await runSessionMemoryRankingFlow({
+        providerMode,
+        results: [
+          currentQuestionResult,
+          currentSessionResult,
+          evergreenUserResult,
+          staleDurableResult,
+        ],
+      });
+      const completedAt = Date.now();
+      const [stalePath, staleContent] = writeFile.mock.calls[0] ?? [];
+      const [datedPath, accessedAt, modifiedAt] = utimes.mock.calls[0] ?? [];
+
+      expect(stalePath).toMatch(/^\/qa\/workspace\/memory\/\d{4}-\d{2}-\d{2}\.md$/);
+      expect(staleContent).toContain("Project Nebula current codename: ORBIT-9.");
+      expect(datedPath).toBe(stalePath);
+      expect(accessedAt).toBeInstanceOf(Date);
+      expect(modifiedAt).toBe(accessedAt);
+      expect(accessedAt?.getTime()).toBeGreaterThanOrEqual(startedAt - 3 * 86_400_000);
+      expect(accessedAt?.getTime()).toBeLessThanOrEqual(completedAt - 3 * 86_400_000);
+      expect(stalePath).toBe(`/qa/workspace/memory/${accessedAt?.toISOString().slice(0, 10)}.md`);
+    },
+  );
+
+  it.each(["mock-openai", "live-frontier"] as const)(
+    "requires successful provider-independent persisted search evidence (%s)",
+    async (providerMode) => {
+      const { fetchJson, gatewayCall, runAgentPrompt } = await runSessionMemoryRankingFlow({
+        providerMode,
+        results: [currentSessionResult, staleDurableResult],
+      });
+
+      expect(runAgentPrompt).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          transcriptToolName: "memory_search",
+          requireSuccessfulTranscriptToolResult: true,
+        }),
+      );
+      expect(gatewayCall).toHaveBeenCalledWith(
+        "chat.history",
+        expect.objectContaining({ sessionKey: "agent:qa:session-memory-ranking" }),
+        expect.anything(),
+      );
+      expect(fetchJson).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["mock-openai", "live-frontier"] as const)(
+    "uses an answer-free setup query and requests unfiltered memory ranking (%s)",
+    async (providerMode) => {
+      const { forceMemoryIndex, runAgentPrompt } = await runSessionMemoryRankingFlow({
+        providerMode,
+        results: [currentSessionResult, staleDurableResult],
+      });
+
+      expect(forceMemoryIndex).toHaveBeenCalledWith(
+        expect.objectContaining({ query: searchQuery, expectedNeedle: "ORBIT-10" }),
+      );
+      const options = runAgentPrompt.mock.calls[0]?.[1];
+      expect(options?.message).not.toMatch(/corpus\s*=\s*(sessions|memory)/i);
+      expect(options?.message).toMatch(/without\s+(?:a\s+)?corpus\s+filter|unfiltered/i);
+    },
+  );
+
+  it.each(["mock-openai", "live-frontier"] as const)(
+    "rejects a fabricated correct answer without a planned memory search (%s)",
+    async (providerMode) => {
+      await expect(
+        runSessionMemoryRankingFlow({
+          providerMode,
+          results: [currentSessionResult, staleDurableResult],
+          includeToolCall: false,
+        }),
+      ).rejects.toThrow(/memory_search|search|correlat/i);
+    },
+  );
+
+  it.each(["mock-openai", "live-frontier"] as const)(
+    "rejects a fabricated correct answer without a successful memory result (%s)",
+    async (providerMode) => {
+      await expect(
+        runSessionMemoryRankingFlow({
+          providerMode,
+          results: [currentSessionResult, staleDurableResult],
+          includeToolResult: false,
+        }),
+      ).rejects.toThrow(/memory_search|search|result|correlat/i);
+    },
+  );
+
+  it.each(["mock-openai", "live-frontier"] as const)(
+    "rejects a failed result even when it contains the correct answer (%s)",
+    async (providerMode) => {
+      await expect(
+        runSessionMemoryRankingFlow({
+          providerMode,
+          results: [currentSessionResult, staleDurableResult],
+          resultIsError: true,
+        }),
+      ).rejects.toThrow(/memory_search|search|result|success|correlat/i);
+    },
+  );
+
+  it.each(["mock-openai", "live-frontier"] as const)(
+    "rejects memory results belonging to a different search call (%s)",
+    async (providerMode) => {
+      await expect(
+        runSessionMemoryRankingFlow({
+          providerMode,
+          results: [currentSessionResult, staleDurableResult],
+          resultCallId: "call-unrelated-memory-search",
+        }),
+      ).rejects.toThrow(/memory_search|search|result|correlat/i);
+    },
+  );
+
+  it.each(["mock-openai", "live-frontier"] as const)(
+    "rejects session results that never compete with the stale durable fact (%s)",
+    async (providerMode) => {
+      await expect(
+        runSessionMemoryRankingFlow({ providerMode, results: [currentSessionResult] }),
+      ).rejects.toThrow(/competi|durable|stale|both/i);
+    },
+  );
+
+  it.each(["mock-openai", "live-frontier"] as const)(
+    "rejects stale durable memory ranked ahead of the current session fact (%s)",
+    async (providerMode) => {
+      await expect(
+        runSessionMemoryRankingFlow({
+          providerMode,
+          results: [staleDurableResult, currentSessionResult],
+        }),
+      ).rejects.toThrow(/rank|stale|durable/i);
+    },
+  );
+
+  it.each(["mock-openai", "live-frontier"] as const)(
+    "rejects stale facts ahead of current facts even when the current question ranks first (%s)",
+    async (providerMode) => {
+      await expect(
+        runSessionMemoryRankingFlow({
+          providerMode,
+          results: [currentQuestionResult, staleDurableResult, currentSessionResult],
+        }),
+      ).rejects.toThrow(/rank|stale|durable/i);
+    },
+  );
+
+  it.each(["mock-openai", "live-frontier"] as const)(
+    "rejects search calls that exclude either configured memory source (%s)",
+    async (providerMode) => {
+      await expect(
+        runSessionMemoryRankingFlow({
+          providerMode,
+          results: [currentSessionResult, staleDurableResult],
+          corpus: "sessions",
+        }),
+      ).rejects.toThrow(/corpus|filter|unfiltered|competi/i);
+    },
+  );
+
+  it.each(["mock-openai", "live-frontier"] as const)(
+    "rejects search queries that already reveal the expected answer (%s)",
+    async (providerMode) => {
+      await expect(
+        runSessionMemoryRankingFlow({
+          providerMode,
+          results: [currentSessionResult, staleDurableResult],
+          query: `${searchQuery} ORBIT-10`,
+        }),
+      ).rejects.toThrow(/answer|reveal|leak|query/i);
+    },
+  );
+});

--- a/qa/scenarios/memory/session-memory-ranking.yaml
+++ b/qa/scenarios/memory/session-memory-ranking.yaml
@@ -30,8 +30,7 @@ scenario:
       transcriptId: qa-session-memory-ranking
       transcriptQuestion: "What is the current Project Nebula codename?"
       transcriptAnswer: "The current Project Nebula codename is ORBIT-10."
-      prompt: "Session memory ranking check: what is the current Project Nebula codename? Use memory_search first with corpus=sessions for indexed session transcripts. If the first session search misses, retry memory_search with corpus=sessions and query 'current Project Nebula codename ORBIT-10'. If that still misses, run memory_search one more time without a corpus filter using the exact query 'current Project Nebula codename ORBIT-10'. If any result contains ORBIT-10, answer ORBIT-10. If durable notes conflict with newer indexed session transcripts, prefer the newer current fact."
-      promptSnippet: "Session memory ranking check"
+      prompt: "Session memory ranking check: what is the current Project Nebula codename? Run memory_search without a corpus filter using maxResults=6 and the answer-free query 'current Project Nebula codename' so durable notes and indexed session transcripts compete in the same ranked result. Answer with the codename from the newer indexed session transcript. If durable notes conflict with newer indexed session transcripts, prefer the newer current fact."
 
 flow:
   steps:
@@ -86,25 +85,25 @@ flow:
                 args:
                   - ref: memoryDir
                   - recursive: true
+              - set: now
+                value:
+                  expr: "Date.now()"
+              - set: staleAt
+                value:
+                  expr: "new Date(now - 3 * 86_400_000)"
               - set: staleMemoryPath
                 value:
-                  expr: "path.join(memoryDir, '2020-01-01.md')"
+                  expr: "path.join(memoryDir, `${staleAt.toISOString().slice(0, 10)}.md`)"
               - call: fs.writeFile
                 args:
                   - ref: staleMemoryPath
-                  - expr: "`${'Project Nebula stale codename: '}${staleFact}.\\n`"
+                  - expr: "`${'Project Nebula current codename: '}${staleFact}.\\n`"
                   - utf8
-              - set: staleAt
-                value:
-                  expr: "new Date('2020-01-01T00:00:00.000Z')"
               - call: fs.utimes
                 args:
                   - ref: staleMemoryPath
                   - ref: staleAt
                   - ref: staleAt
-              - set: now
-                value:
-                  expr: "Date.now()"
               - call: seedQaSessionTranscript
                 args:
                   - ref: env
@@ -130,7 +129,7 @@ flow:
                   - env:
                       ref: env
                     query:
-                      expr: "`current Project Nebula codename ${currentFact}`"
+                      expr: "'current Project Nebula codename'"
                     expectedNeedle:
                       ref: currentFact
               - call: reset
@@ -142,6 +141,8 @@ flow:
                       expr: config.prompt
                     timeoutMs:
                       expr: liveTurnTimeoutMs(env, 45000)
+                    transcriptToolName: memory_search
+                    requireSuccessfulTranscriptToolResult: true
               - call: waitForOutboundMessage
                 saveAs: outbound
                 args:
@@ -154,9 +155,6 @@ flow:
                   expr: "outbound.text.includes(currentFact)"
                   message:
                     expr: "`expected current transcript-backed fact ${currentFact}, got: ${outbound.text}`"
-              - set: lower
-                value:
-                  expr: "normalizeLowercaseStringOrEmpty(outbound.text)"
               - set: staleLeak
                 value:
                   expr: "outbound.text.includes(staleFact) && !/(stale|durable|conflict|older|previous)/i.test(outbound.text)"
@@ -164,19 +162,86 @@ flow:
                   expr: "!staleLeak"
                   message:
                     expr: "`stale durable fact leaked through: ${outbound.text}`"
-              - if:
-                  expr: "Boolean(env.mock)"
-                  then:
-                    - call: fetchJson
-                      saveAs: requests
-                      args:
-                        - expr: "`${env.mock.baseUrl}/debug/requests`"
-                    - set: relevant
-                      value:
-                        expr: "requests.filter((request) => String(request.allInputText ?? '').includes(config.promptSnippet))"
-                    - assert:
-                        expr: "relevant.some((request) => request.plannedToolName === 'memory_search')"
-                        message: expected memory_search in session memory ranking flow
+              - set: rankingHistory
+                value:
+                  expr: "await env.gateway.call('chat.history', { sessionKey: 'agent:qa:session-memory-ranking', limit: 100, maxChars: 131072 }, { timeoutMs: liveTurnTimeoutMs(env, 15000) })"
+              - set: searchCalls
+                value:
+                  expr: |-
+                    (rankingHistory.messages ?? []).flatMap((message, messageIndex) =>
+                      message?.role === 'assistant' && Array.isArray(message.content)
+                        ? message.content.flatMap((item) =>
+                            ['toolCall', 'toolUse', 'tool_use'].includes(item?.type) &&
+                            (item.name ?? item.toolName) === 'memory_search' &&
+                            typeof item.id === 'string' && item.id.length > 0
+                              ? [{ messageIndex, callId: item.id, args: item.arguments ?? item.input ?? {} }]
+                              : [])
+                        : [])
+              - assert:
+                  expr: searchCalls.length > 0
+                  message: expected a persisted planned memory_search call
+              - assert:
+                  expr: "searchCalls.every((call) => !String(call.args?.query ?? '').includes(currentFact) && !String(call.args?.query ?? '').includes(staleFact))"
+                  message: memory_search query revealed an expected answer
+              - assert:
+                  expr: "searchCalls.every((call) => !Object.hasOwn(call.args ?? {}, 'corpus'))"
+                  message: memory_search corpus filter prevented durable and session memory from competing
+              - set: correlatedSearchResults
+                value:
+                  expr: |-
+                    searchCalls.flatMap((call) => {
+                      const result = (rankingHistory.messages ?? []).find((message, messageIndex) =>
+                        messageIndex > call.messageIndex &&
+                        message?.role === 'toolResult' &&
+                        message.toolName === 'memory_search' &&
+                        message.toolCallId === call.callId &&
+                        message.isError === false);
+                      if (!result) return [];
+                      const content = typeof result.content === 'string'
+                        ? result.content
+                        : Array.isArray(result.content)
+                          ? result.content
+                              .filter((item) => ['text', 'input_text', 'output_text'].includes(item?.type))
+                              .map((item) => item.text ?? '')
+                              .join('\n')
+                          : '';
+                      try {
+                        const parsed = JSON.parse(content);
+                        return Array.isArray(parsed?.results) ? [{ ...call, results: parsed.results }] : [];
+                      } catch {
+                        return [];
+                      }
+                    })
+              - assert:
+                  expr: correlatedSearchResults.length > 0
+                  message: expected a correlated successful memory_search result
+              - set: rankedSearchResult
+                value:
+                  expr: |-
+                    correlatedSearchResults.find(({ results }) =>
+                      results.some((result) =>
+                        (result.source === 'sessions' || result.corpus === 'sessions' ||
+                          String(result.path ?? '').startsWith('sessions/')) &&
+                        String(result.snippet ?? result.text ?? '').includes(currentFact)) &&
+                      results.some((result) =>
+                        (result.source === 'memory' || result.corpus === 'memory' ||
+                          String(result.path ?? '').startsWith('memory/') ||
+                          String(result.path ?? '') === 'MEMORY.md') &&
+                        String(result.snippet ?? result.text ?? '').includes(staleFact)))
+              - assert:
+                  expr: Boolean(rankedSearchResult)
+                  message:
+                    expr: "`expected current session and stale durable memory to compete in the same search result: ${JSON.stringify(correlatedSearchResults.map(({ results }) => results.map(({ path, source, corpus, score, snippet, text }) => ({ path, source, corpus, score, snippet: String(snippet ?? text ?? '').slice(0, 140) }))))}`"
+              - set: currentFactRank
+                value:
+                  expr: "rankedSearchResult.results.findIndex((result) => (result.source === 'sessions' || result.corpus === 'sessions' || String(result.path ?? '').startsWith('sessions/')) && String(result.snippet ?? result.text ?? '').includes(currentFact))"
+              - set: staleFactRank
+                value:
+                  expr: "rankedSearchResult.results.findIndex((result) => (result.source === 'memory' || result.corpus === 'memory' || String(result.path ?? '').startsWith('memory/') || String(result.path ?? '') === 'MEMORY.md') && String(result.snippet ?? result.text ?? '').includes(staleFact))"
+              - assert:
+                  expr: "currentFactRank >= 0 && staleFactRank >= 0 && currentFactRank < staleFactRank"
+                  message:
+                    expr: "`stale durable memory outranked the current session fact: ${JSON.stringify(rankedSearchResult.results)}`"
             finally:
               - call: patchConfig
                 args:

--- a/qa/scenarios/memory/session-memory-ranking.yaml
+++ b/qa/scenarios/memory/session-memory-ranking.yaml
@@ -232,6 +232,9 @@ flow:
                   expr: Boolean(rankedSearchResult)
                   message:
                     expr: "`expected current session and stale durable memory to compete in the same search result: ${JSON.stringify(correlatedSearchResults.map(({ results }) => results.map(({ path, source, corpus, score, snippet, text }) => ({ path, source, corpus, score, snippet: String(snippet ?? text ?? '').slice(0, 140) }))))}`"
+              - assert:
+                  expr: rankedSearchResult.args?.maxResults === 6
+                  message: expected the correlated memory_search call to use maxResults=6
               - set: currentFactRank
                 value:
                   expr: "rankedSearchResult.results.findIndex((result) => (result.source === 'sessions' || result.corpus === 'sessions' || String(result.path ?? '').startsWith('sessions/')) && String(result.snippet ?? result.text ?? '').includes(currentFact))"

--- a/qa/scenarios/memory/session-memory-ranking.yaml
+++ b/qa/scenarios/memory/session-memory-ranking.yaml
@@ -233,7 +233,7 @@ flow:
                   message:
                     expr: "`expected current session and stale durable memory to compete in the same search result: ${JSON.stringify(correlatedSearchResults.map(({ results }) => results.map(({ path, source, corpus, score, snippet, text }) => ({ path, source, corpus, score, snippet: String(snippet ?? text ?? '').slice(0, 140) }))))}`"
               - assert:
-                  expr: rankedSearchResult.args?.maxResults === 6
+                  expr: "(rankedSearchResult.args?.maxResults ?? 6) === 6"
                   message: expected the correlated memory_search call to use maxResults=6
               - set: currentFactRank
                 value:


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where session-memory ranking QA could report success without executing a memory search, without searching durable memory, or even when the older durable fact outranked the current session fact. The old mock request also leaked the answer into the query and excluded durable notes with a sessions-only corpus.

## Why This Change Was Made

Require a successful persisted `memory_search` and inspect provider-independent Gateway history for an ID-correlated, unfiltered, answer-free search result containing both competing facts. Use a realistically older daily note, the existing canonical six-result default, and compare the relative ranks of the actual conflicting facts while ignoring unrelated current-turn or workspace hits. Remove the old mock-only debug inference; no production memory ranking, indexing, persistence, or configuration changes.

## User Impact

The same QA scenario now verifies real session-versus-durable memory ranking in both mock and live provider lanes and cannot pass on a fabricated final answer.

## Evidence

- Authentic parsed-scenario coverage in both provider modes rejects missing/failed/mismatched tool calls, filtered corpus, answer-bearing queries, missing durable competition, and stale-before-current ranking.
- A real HTTP mock-provider regression proves the actual search request omits the corpus filter and answer while using the product default `maxResults: 6`.
- The real Gateway + mock-provider `session-memory-ranking` scenario passes with an actual recent dated durable note, a newer session fact, and both facts in the same persisted search result.
- Trusted Blacksmith Testbox aggregate passed **916 tests across 28 files**; the final owner-adjacent rerun passed **102 tests across 6 files**.
- The mock-provider production owner is net-negative; remaining changes are QA fixtures and regression coverage. Independent structured review found no accepted actionable findings.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/30973152491

### Inspectable after-fix Gateway evidence

A real private-QA Gateway, real memory search/indexing, and the actual HTTP mock provider produced:

```text
[qa-suite] gateway ready: http://127.0.0.1:39273
[qa-suite] scenario start (1/1): session-memory-ranking
[qa-suite] scenario pass (1/1): session-memory-ranking
[qa-suite] run complete: passed=1 failed=0 skipped=0 total=1
```

The persisted successful call searched both configured memory sources, contained the newer session fact and older dated durable fact in the same result, and ranked the newer fact first among conflicting facts. The canonical optional `maxResults` argument accepts an omitted six-result default or explicit `6`; both mock/live regressions reject explicit `3`. The focused owner-adjacent proof passed 32 tests. No provider secrets or response credentials are present in this output.
