### PR TITLE
fix(qa): reject silent and out-of-character persona conversations

### DIFF
--- a/extensions/qa-lab/src/scenario-flow-runner-character-safety.test.ts
+++ b/extensions/qa-lab/src/scenario-flow-runner-character-safety.test.ts
@@ -5,6 +5,24 @@ import { runLoadedScenarioFlow } from "./scenario-flow-runner.test-support.js";
 import { waitForOutboundMessage } from "./suite-runtime-transport.js";
 
 const characterScenarioIds = ["character-vibes-gollum", "character-vibes-c3po"] as const;
+const classifiedFailureReplies = [
+  {
+    failureName: "provider failure",
+    failureText: '⚠️ No API key found for provider "openai".',
+  },
+  {
+    failureName: "delivery failure",
+    failureText: "⚠️ ✉️ Message failed",
+  },
+  {
+    failureName: "missing tool failure",
+    failureText: "Read: AGENT.md\nEvidence snippet: Tool read not found\nStatus: blocked",
+  },
+  {
+    failureName: "internal coordination leak",
+    failureText: "checking thread context; then post a tight progress reply here.",
+  },
+] as const;
 
 function createCharacterScenarioApi(
   onWaitForOutboundMessage?: (state: ReturnType<typeof createQaBusState>) => void,
@@ -61,6 +79,39 @@ describe("character scenario transcript safety", () => {
       true,
     );
   });
+
+  it.each(
+    characterScenarioIds.flatMap((scenarioId) =>
+      classifiedFailureReplies.map((failure) => ({ scenarioId, ...failure })),
+    ),
+  )(
+    "rejects a $failureName after an actual reply in $scenarioId",
+    async ({ scenarioId, failureText }) => {
+      const state = createQaBusState();
+      const firstReply = "The build is green, and I am here.";
+      let waitCount = 0;
+
+      await expect(
+        runLoadedScenarioFlow(scenarioId, {
+          state,
+          api: createCharacterScenarioApi((currentState) => {
+            currentState.addOutboundMessage({
+              accountId: "qa-channel",
+              to: "dm:alice",
+              text: waitCount++ === 0 ? firstReply : failureText,
+            });
+          }),
+        }),
+      ).rejects.toThrow(failureText);
+
+      expect(
+        state
+          .getSnapshot()
+          .messages.filter((message) => message.direction === "outbound")
+          .map((message) => message.text),
+      ).toEqual([firstReply, failureText]);
+    },
+  );
 
   it.each(characterScenarioIds)(
     "rejects an entirely unanswered character conversation in %s",

--- a/extensions/qa-lab/src/scenario-flow-runner-character-safety.test.ts
+++ b/extensions/qa-lab/src/scenario-flow-runner-character-safety.test.ts
@@ -113,7 +113,11 @@ describe("character scenario transcript safety", () => {
 
   it.each(
     characterScenarioIds.flatMap((scenarioId) =>
-      classifiedFailureReplies.map((failure) => ({ scenarioId, ...failure })),
+      classifiedFailureReplies.map(({ failureName, failureText }) => ({
+        scenarioId,
+        failureName,
+        failureText,
+      })),
     ),
   )(
     "rejects a $failureName after an actual reply in $scenarioId",

--- a/extensions/qa-lab/src/scenario-flow-runner-character-safety.test.ts
+++ b/extensions/qa-lab/src/scenario-flow-runner-character-safety.test.ts
@@ -1,7 +1,9 @@
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { createQaBusState } from "./bus-state.js";
+import { readQaScenarioById } from "./scenario-catalog.js";
 import { runLoadedScenarioFlow } from "./scenario-flow-runner.test-support.js";
+import { selectQaFlowSuiteScenarios } from "./suite-planning.js";
 import { waitForOutboundMessage } from "./suite-runtime-transport.js";
 
 const characterScenarioIds = ["character-vibes-gollum", "character-vibes-c3po"] as const;
@@ -29,7 +31,7 @@ function createCharacterScenarioApi(
 ) {
   return {
     env: {
-      providerMode: "mock-openai",
+      providerMode: "live-frontier",
       gateway: {
         workspaceDir: "/qa-character-workspace",
       },
@@ -59,6 +61,35 @@ function createCharacterScenarioApi(
 }
 
 describe("character scenario transcript safety", () => {
+  it.each(characterScenarioIds)("requires a live provider for %s", (scenarioId) => {
+    const scenario = readQaScenarioById(scenarioId);
+
+    expect(scenario.execution.config?.requiredProviderMode).toBe("live-frontier");
+    expect(() =>
+      selectQaFlowSuiteScenarios({
+        scenarios: [scenario],
+        scenarioIds: [scenarioId],
+        providerMode: "mock-openai",
+        primaryModel: "mock-openai/gpt-5.6-luna",
+      }),
+    ).toThrow(`${scenarioId} (providerMode=live-frontier)`);
+    expect(
+      selectQaFlowSuiteScenarios({
+        scenarios: [scenario],
+        providerMode: "mock-openai",
+        primaryModel: "mock-openai/gpt-5.6-luna",
+      }),
+    ).toEqual([]);
+    expect(
+      selectQaFlowSuiteScenarios({
+        scenarios: [scenario],
+        scenarioIds: [scenarioId],
+        providerMode: "live-frontier",
+        primaryModel: "openai/gpt-5.6-luna",
+      }),
+    ).toEqual([scenario]);
+  });
+
   it.each(characterScenarioIds)("rejects forbidden model internals in %s", async (scenarioId) => {
     const state = createQaBusState();
 

--- a/extensions/qa-lab/src/scenario-flow-runner-character-safety.test.ts
+++ b/extensions/qa-lab/src/scenario-flow-runner-character-safety.test.ts
@@ -1,0 +1,113 @@
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { createQaBusState } from "./bus-state.js";
+import { runLoadedScenarioFlow } from "./scenario-flow-runner.test-support.js";
+import { waitForOutboundMessage } from "./suite-runtime-transport.js";
+
+const characterScenarioIds = ["character-vibes-gollum", "character-vibes-c3po"] as const;
+
+function createCharacterScenarioApi(
+  onWaitForOutboundMessage?: (state: ReturnType<typeof createQaBusState>) => void,
+) {
+  return {
+    env: {
+      providerMode: "mock-openai",
+      gateway: {
+        workspaceDir: "/qa-character-workspace",
+      },
+    },
+    fs: {
+      writeFile: async () => undefined,
+    },
+    path: { join },
+    normalizeLowercaseStringOrEmpty: (value: unknown) =>
+      typeof value === "string" ? value.trim().toLowerCase() : "",
+    resolveQaLiveTurnTimeoutMs: () => 10,
+    waitForOutboundMessage: async (
+      state: ReturnType<typeof createQaBusState>,
+      predicate: Parameters<typeof waitForOutboundMessage>[1],
+      timeoutMs: number,
+      options?: Parameters<typeof waitForOutboundMessage>[3],
+    ) => {
+      onWaitForOutboundMessage?.(state);
+      return await waitForOutboundMessage(state, predicate, timeoutMs, options);
+    },
+    formatConversationTranscript: (state: ReturnType<typeof createQaBusState>) =>
+      state
+        .getSnapshot()
+        .messages.map((message) => `${message.direction}:${message.text}`)
+        .join("\n"),
+  };
+}
+
+describe("character scenario transcript safety", () => {
+  it.each(characterScenarioIds)("rejects forbidden model internals in %s", async (scenarioId) => {
+    const state = createQaBusState();
+
+    await expect(
+      runLoadedScenarioFlow(scenarioId, {
+        state,
+        api: createCharacterScenarioApi((currentState) => {
+          currentState.addOutboundMessage({
+            accountId: "qa-channel",
+            to: "dm:alice",
+            text: "As an AI, I cannot stay in character.",
+          });
+        }),
+      }),
+    ).rejects.toThrow("hit fallback/error text: As an AI, I cannot stay in character.");
+
+    expect(state.getSnapshot().messages.some((message) => message.direction === "outbound")).toBe(
+      true,
+    );
+  });
+
+  it.each(characterScenarioIds)(
+    "rejects an entirely unanswered character conversation in %s",
+    async (scenarioId) => {
+      const state = createQaBusState();
+
+      await expect(
+        runLoadedScenarioFlow(scenarioId, {
+          state,
+          api: createCharacterScenarioApi(),
+        }),
+      ).rejects.toThrow("no assistant replies");
+
+      expect(state.getSnapshot().messages).toHaveLength(4);
+      expect(state.getSnapshot().messages.every((message) => message.direction === "inbound")).toBe(
+        true,
+      );
+    },
+  );
+
+  it.each(characterScenarioIds)(
+    "keeps partially missing replies visible without aborting %s",
+    async (scenarioId) => {
+      const state = createQaBusState();
+      const reply = "The build is green, and I am here.";
+      const result = await runLoadedScenarioFlow(scenarioId, {
+        state,
+        api: createCharacterScenarioApi((currentState) => {
+          if (
+            currentState.getSnapshot().messages.some((message) => message.direction === "outbound")
+          ) {
+            return;
+          }
+          currentState.addOutboundMessage({
+            accountId: "qa-channel",
+            to: "dm:alice",
+            text: reply,
+          });
+        }),
+      });
+
+      expect(result.status).toBe("pass");
+      expect(result.steps[0]?.details).toContain("inbound:");
+      expect(result.steps[0]?.details).toContain(`outbound:${reply}`);
+      const messages = state.getSnapshot().messages;
+      expect(messages.filter((message) => message.direction === "inbound")).toHaveLength(4);
+      expect(messages.filter((message) => message.direction === "outbound")).toHaveLength(1);
+    },
+  );
+});

--- a/qa/scenarios/character/character-vibes-c3po.yaml
+++ b/qa/scenarios/character/character-vibes-c3po.yaml
@@ -118,6 +118,11 @@ flow:
                             ref: beforeOutboundCount
                   catchAs: turnError
                   catch:
+                    - if:
+                        expr: "!(turnError instanceof Error) || turnError.message !== `timed out after ${resolveQaLiveTurnTimeoutMs(env, 45000)}ms`"
+                        then:
+                          - throw:
+                              expr: turnError
                     - set: latestTurnError
                       value:
                         ref: turnError

--- a/qa/scenarios/character/character-vibes-c3po.yaml
+++ b/qa/scenarios/character/character-vibes-c3po.yaml
@@ -25,6 +25,7 @@ scenario:
     kind: flow
     summary: Capture a raw natural C-3PO character transcript for later quality grading.
     config:
+      requiredProviderMode: live-frontier
       conversationId: alice
       senderName: Alice
       workspaceFiles:

--- a/qa/scenarios/character/character-vibes-c3po.yaml
+++ b/qa/scenarios/character/character-vibes-c3po.yaml
@@ -81,6 +81,8 @@ flow:
                   - expr: "path.join(env.gateway.workspaceDir, String(workspaceFile[0]))"
                   - expr: "`${String(workspaceFile[1] ?? '').trimEnd()}\\n`"
                   - utf8
+        - set: assistantReplyCount
+          value: 0
         - forEach:
             items:
               ref: config.turns
@@ -100,6 +102,8 @@ flow:
                     ref: config.senderName
                   text:
                     expr: turn.text
+              - set: latestOutbound
+                value: null
               - try:
                   actions:
                     - call: waitForOutboundMessage
@@ -112,13 +116,26 @@ flow:
                         - expr: resolveQaLiveTurnTimeoutMs(env, 45000)
                         - sinceIndex:
                             ref: beforeOutboundCount
-                    - assert:
-                        expr: "!config.forbiddenNeedles.some((needle) => normalizeLowercaseStringOrEmpty(latestOutbound.text).includes(needle))"
-                        message:
-                          expr: "`C-3PO natural chat turn ${String(turnIndex)} hit fallback/error text: ${latestOutbound.text}`"
                   catchAs: turnError
                   catch:
                     - set: latestTurnError
                       value:
                         ref: turnError
-      detailsExpr: "formatConversationTranscript(state, { conversationId: config.conversationId })"
+              - if:
+                  expr: latestOutbound != null
+                  then:
+                    - assert:
+                        expr: "!config.forbiddenNeedles.some((needle) => normalizeLowercaseStringOrEmpty(latestOutbound.text).includes(needle))"
+                        message:
+                          expr: "`C-3PO natural chat turn ${String(turnIndex)} hit fallback/error text: ${latestOutbound.text}`"
+                    - set: assistantReplyCount
+                      value:
+                        expr: assistantReplyCount + 1
+        - set: conversationTranscript
+          value:
+            expr: "formatConversationTranscript(state, { conversationId: config.conversationId })"
+        - assert:
+            expr: assistantReplyCount >= 1
+            message:
+              expr: "`C-3PO natural chat produced no assistant replies; transcript: ${conversationTranscript}`"
+      detailsExpr: conversationTranscript

--- a/qa/scenarios/character/character-vibes-gollum.yaml
+++ b/qa/scenarios/character/character-vibes-gollum.yaml
@@ -101,6 +101,8 @@ flow:
                   - expr: "path.join(env.gateway.workspaceDir, String(workspaceFile[0]))"
                   - expr: "`${String(workspaceFile[1] ?? '').trimEnd()}\\n`"
                   - utf8
+        - set: assistantReplyCount
+          value: 0
         - forEach:
             items:
               ref: config.turns
@@ -120,6 +122,8 @@ flow:
                     ref: config.senderName
                   text:
                     expr: turn.text
+              - set: latestOutbound
+                value: null
               - try:
                   actions:
                     - call: waitForOutboundMessage
@@ -132,13 +136,26 @@ flow:
                         - expr: resolveQaLiveTurnTimeoutMs(env, 45000)
                         - sinceIndex:
                             ref: beforeOutboundCount
-                    - assert:
-                        expr: "!config.forbiddenNeedles.some((needle) => normalizeLowercaseStringOrEmpty(latestOutbound.text).includes(needle))"
-                        message:
-                          expr: "`gollum natural chat turn ${String(turnIndex)} hit fallback/error text: ${latestOutbound.text}`"
                   catchAs: turnError
                   catch:
                     - set: latestTurnError
                       value:
                         ref: turnError
-      detailsExpr: "formatConversationTranscript(state, { conversationId: config.conversationId })"
+              - if:
+                  expr: latestOutbound != null
+                  then:
+                    - assert:
+                        expr: "!config.forbiddenNeedles.some((needle) => normalizeLowercaseStringOrEmpty(latestOutbound.text).includes(needle))"
+                        message:
+                          expr: "`gollum natural chat turn ${String(turnIndex)} hit fallback/error text: ${latestOutbound.text}`"
+                    - set: assistantReplyCount
+                      value:
+                        expr: assistantReplyCount + 1
+        - set: conversationTranscript
+          value:
+            expr: "formatConversationTranscript(state, { conversationId: config.conversationId })"
+        - assert:
+            expr: assistantReplyCount >= 1
+            message:
+              expr: "`gollum natural chat produced no assistant replies; transcript: ${conversationTranscript}`"
+      detailsExpr: conversationTranscript

--- a/qa/scenarios/character/character-vibes-gollum.yaml
+++ b/qa/scenarios/character/character-vibes-gollum.yaml
@@ -138,6 +138,11 @@ flow:
                             ref: beforeOutboundCount
                   catchAs: turnError
                   catch:
+                    - if:
+                        expr: "!(turnError instanceof Error) || turnError.message !== `timed out after ${resolveQaLiveTurnTimeoutMs(env, 45000)}ms`"
+                        then:
+                          - throw:
+                              expr: turnError
                     - set: latestTurnError
                       value:
                         ref: turnError

--- a/qa/scenarios/character/character-vibes-gollum.yaml
+++ b/qa/scenarios/character/character-vibes-gollum.yaml
@@ -24,6 +24,7 @@ scenario:
     kind: flow
     summary: Capture a raw natural character transcript for later quality grading.
     config:
+      requiredProviderMode: live-frontier
       conversationId: alice
       senderName: Alice
       workspaceFiles:


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where both persona QA conversations passed when the assistant emitted forbidden fallback text, and even when every conversation turn received no assistant reply.

## Why This Change Was Made

Catch only the intentionally tolerated per-turn wait failure, validate actual replies outside that catch, and require at least one genuine assistant reply after collecting the complete conversation transcript. Partial conversations remain supported; forbidden replies and completely unanswered conversations now fail visibly.

## User Impact

Character/persona QA no longer reports a healthy conversation for a silent model, broken delivery, or an out-of-character fallback response.

## Evidence

- Table-driven regressions execute both real parsed character scenarios through the production outbound waiter.
- Forbidden actual assistant replies fail, four genuinely timed-out turns fail with the captured transcript, and one valid reply followed by missing turns still passes with all conversation turns preserved.
- Trusted Blacksmith Testbox aggregate passed **916 tests across 28 files**.
- Changes are limited to QA scenario fixtures and a focused regression; no production model behavior, tools, configuration, or channel transport is modified.
- Independent structured review found no accepted actionable findings; Testbox run: https://github.com/openclaw/openclaw/actions/runs/30973152491

### Classified failures and truthful provider-lane proof

Both scenarios now tolerate only the production waiter's exact real timeout; provider, delivery, missing-tool, and coordination failures are rethrown unchanged. The focused parsed-scenario suite covers all four classified failure families for both personas, actual forbidden replies, all-missing conversations, and partial conversations with preserved transcripts.

A real Gateway run exposed why mock providers cannot truthfully evaluate qualitative personas:

```text
[qa-suite] scenario start: character-vibes-gollum
gollum natural chat turn 0 hit fallback/error text:
Protocol note: acknowledged. Continue with the QA scenario plan and report worked, failed, and blocked items.
```

The shared mock provider intentionally emits that generic QA-planning fallback, which contains prohibited `qa scenario` text. The existing character-evaluation candidate and judge already require `live-frontier`; therefore both persona scenarios now declare their documented existing live-only lane instead of inventing canned mock personalities. Authentic catalog/planning controls reject explicit mock selection, exclude the scenarios from implicit mock suites, and admit them on the live lane. No user-facing provider defaults, product configuration, provider transport, or model behavior changed.

### Real live-model persona Gateway verdict

Trusted Blacksmith Testbox used its already-configured OpenAI credentials (no secrets copied or logged), the real private-QA Gateway, and the actual live GPT-5.4 provider:

    pnpm openclaw qa suite --provider-mode live-frontier --model openai/gpt-5.4 --alt-model openai/gpt-5.4 --scenario character-vibes-gollum --scenario character-vibes-c3po --fast --concurrency 1
    [qa-suite] provider start: live-frontier
    [qa-suite] provider ready: live
    [qa-suite] gateway ready: http://127.0.0.1:36961
    [qa-suite] scenario start (1/2): character-vibes-gollum
    [qa-suite] scenario pass (1/2): character-vibes-gollum
    [qa-suite] scenario start (2/2): character-vibes-c3po
    [qa-suite] scenario pass (2/2): character-vibes-c3po
    [qa-suite] run complete: passed=2 failed=0 skipped=0 total=2

All 16 authentic parsed-flow negative/control tests also pass, and both scenario YAMLs plus the focused test were verified byte-identical to the exact PR head. Testbox run: https://github.com/openclaw/openclaw/actions/runs/30983445783
