### PR TITLE
fix(qa): preserve native channel message IDs and slash-command arguments

### DIFF
--- a/extensions/qa-channel/src/inbound.test.ts
+++ b/extensions/qa-channel/src/inbound.test.ts
@@ -469,32 +469,41 @@ describe("handleQaInbound", () => {
     expect(ctxPayload?.SenderId).toBe("alice");
   });
 
-  it("routes native commands through a separate slash session to the conversation session", async () => {
-    const runtime = createPluginRuntimeMock();
-    setQaChannelRuntime(runtime);
+  it.each([
+    { name: "stop", text: "/stop" },
+    { name: "queue", text: "/queue Can you diagnose this?" },
+    { name: "think", text: "/think high" },
+  ])(
+    "preserves the complete /$name native command in its slash session",
+    async ({ name, text }) => {
+      const runtime = createPluginRuntimeMock();
+      setQaChannelRuntime(runtime);
 
-    await handleQaInbound(
-      createQaInboundParams({
-        message: {
-          text: "/stop",
-          nativeCommand: { name: "stop" },
+      await handleQaInbound(
+        createQaInboundParams({
+          message: {
+            text,
+            nativeCommand: { name },
+          },
+        }),
+      );
+
+      const assembled = firstRunAssembledParams(runtime);
+      expect(assembled.ctxPayload).toMatchObject({
+        BodyForCommands: text,
+        CommandAuthorized: true,
+        CommandBody: text,
+        CommandSource: "native",
+        CommandTargetSessionKey: assembled.route.sessionKey,
+        CommandTurn: {
+          body: text,
+          source: "native",
         },
-      }),
-    );
-
-    const assembled = firstRunAssembledParams(runtime);
-    expect(assembled.ctxPayload).toMatchObject({
-      CommandAuthorized: true,
-      CommandSource: "native",
-      CommandTargetSessionKey: assembled.route.sessionKey,
-      CommandTurn: {
-        body: "/stop",
-        source: "native",
-      },
-    });
-    expect(assembled.ctxPayload.SessionKey).toContain("qa-channel:slash:alice");
-    expect(assembled.ctxPayload.SessionKey).not.toBe(assembled.route.sessionKey);
-  });
+      });
+      expect(assembled.ctxPayload.SessionKey).toContain("qa-channel:slash:alice");
+      expect(assembled.ctxPayload.SessionKey).not.toBe(assembled.route.sessionKey);
+    },
+  );
 
   it("skips malformed inline attachment base64 without dropping the message", async () => {
     const runtime = createPluginRuntimeMock();

--- a/extensions/qa-channel/src/inbound.ts
+++ b/extensions/qa-channel/src/inbound.ts
@@ -356,8 +356,6 @@ export async function handleQaInbound(params: {
         targetSessionKey: route.sessionKey,
       })
     : undefined;
-  const commandBody = nativeCommand ? `/${nativeCommand.name}` : inbound.text;
-
   const sessionKey = commandTargets?.sessionKey ?? route.sessionKey;
   const ctxPayload = buildChannelInboundEventContext({
     channel: params.channelId,
@@ -392,14 +390,14 @@ export async function handleQaInbound(params: {
       messageThreadId: inbound.threadId,
       threadParentId: inbound.threadId ? inbound.conversation.id : undefined,
     },
-    message: { body, bodyForAgent: inbound.text, rawBody: inbound.text, commandBody },
+    message: { body, bodyForAgent: inbound.text, rawBody: inbound.text, commandBody: inbound.text },
     media,
     access: {
       commands: { authorized: true },
       mentions: { canDetectMention: isGroup, wasMentioned: Boolean(wasMentioned) },
     },
     command: nativeCommand
-      ? { kind: "native", name: nativeCommand.name, body: commandBody, authorized: true }
+      ? { kind: "native", name: nativeCommand.name, body: inbound.text, authorized: true }
       : undefined,
     extra: {
       CommandTargetSessionKey: commandTargets?.commandTargetSessionKey,

--- a/extensions/qa-lab/src/bus-queries.ts
+++ b/extensions/qa-lab/src/bus-queries.ts
@@ -92,11 +92,24 @@ export function requireQaBusMessageForAccount(params: {
   messages: Map<string, QaBusMessage>;
   input: Pick<QaBusReadMessageInput, "accountId" | "messageId">;
 }): QaBusMessage {
-  const message = params.messages.get(params.input.messageId);
-  if (!message || message.accountId !== normalizeAccountId(params.input.accountId)) {
+  const accountId = normalizeAccountId(params.input.accountId);
+  let match: QaBusMessage | undefined;
+  for (const message of params.messages.values()) {
+    if (message.id !== params.input.messageId || message.accountId !== accountId) {
+      continue;
+    }
+    // Reads have no conversation selector, so never guess which chat to mutate.
+    if (match) {
+      throw new Error(
+        `qa-bus message id is ambiguous for selected account: ${params.input.messageId}`,
+      );
+    }
+    match = message;
+  }
+  if (!match) {
     throw new Error(`qa-bus message not found: ${params.input.messageId}`);
   }
-  return message;
+  return match;
 }
 
 export function readQaBusMessage(params: {

--- a/extensions/qa-lab/src/bus-state.test.ts
+++ b/extensions/qa-lab/src/bus-state.test.ts
@@ -46,6 +46,129 @@ describe("qa-bus state", () => {
     expect(snapshot.messages.map((message) => message.id)).toEqual([inbound.id, outbound.id]);
   });
 
+  it("records provider-native inbound IDs before indexing and publishing messages", () => {
+    const state = createQaBusState();
+    const providerMessageId = "$provider-event:matrix.test";
+
+    const inbound = state.addInboundMessage(
+      {
+        conversation: { id: "qa-room", kind: "group" },
+        senderId: "alice",
+        text: "provider-native identity",
+      },
+      providerMessageId,
+    );
+    const snapshot = state.getSnapshot();
+
+    expect(inbound.id).toBe(providerMessageId);
+    expect(snapshot.messages[0]?.id).toBe(providerMessageId);
+    expect(snapshot.events[0]).toMatchObject({
+      kind: "inbound-message",
+      message: { id: providerMessageId },
+    });
+    expect(state.poll().events[0]).toMatchObject({
+      kind: "inbound-message",
+      message: { id: providerMessageId },
+    });
+    expect(state.readMessage({ messageId: providerMessageId })).toMatchObject({
+      id: providerMessageId,
+      text: "provider-native identity",
+    });
+  });
+
+  it("keeps identical provider-native message IDs isolated by account", () => {
+    const state = createQaBusState();
+    const messageId = "42";
+
+    for (const accountId of ["account-a", "account-b"]) {
+      state.addInboundMessage(
+        {
+          accountId,
+          conversation: { id: `${accountId}-room`, kind: "group" },
+          senderId: accountId,
+          text: `${accountId} original`,
+        },
+        messageId,
+      );
+    }
+
+    const snapshot = state.getSnapshot();
+    expect(snapshot.messages.map((message) => [message.accountId, message.id])).toEqual([
+      ["account-a", messageId],
+      ["account-b", messageId],
+    ]);
+    expect(snapshot.events.map((event) => event.accountId)).toEqual(["account-a", "account-b"]);
+
+    for (const accountId of ["account-a", "account-b"]) {
+      expect(state.readMessage({ accountId, messageId })).toMatchObject({
+        accountId,
+        id: messageId,
+        text: `${accountId} original`,
+      });
+      expect(state.searchMessages({ accountId })).toEqual([
+        expect.objectContaining({ accountId, id: messageId }),
+      ]);
+      expect(state.poll({ accountId }).events).toEqual([
+        expect.objectContaining({ accountId, message: expect.objectContaining({ id: messageId }) }),
+      ]);
+    }
+
+    state.editMessage({ accountId: "account-a", messageId, text: "account-a edited" });
+    state.reactToMessage({ accountId: "account-b", messageId, emoji: "eyes" });
+    expect(state.readMessage({ accountId: "account-a", messageId })).toMatchObject({
+      text: "account-a edited",
+      reactions: [],
+    });
+    expect(state.readMessage({ accountId: "account-b", messageId })).toMatchObject({
+      text: "account-b original",
+      reactions: [expect.objectContaining({ emoji: "eyes" })],
+    });
+  });
+
+  it("rejects ambiguous provider-native IDs instead of selecting the wrong conversation", () => {
+    const state = createQaBusState();
+    const accountId = "account-a";
+    const messageId = "42";
+
+    for (const conversationId of ["first-room", "second-room"]) {
+      state.addInboundMessage(
+        {
+          accountId,
+          conversation: { id: conversationId, kind: "group" },
+          senderId: "alice",
+          text: `${conversationId} original`,
+        },
+        messageId,
+      );
+    }
+
+    const originalSnapshot = state.getSnapshot();
+    expect(originalSnapshot.messages.map((message) => message.conversation.id)).toEqual([
+      "first-room",
+      "second-room",
+    ]);
+    expect(originalSnapshot.events.map((event) => event.accountId)).toEqual([accountId, accountId]);
+    for (const conversationId of ["first-room", "second-room"]) {
+      expect(state.searchMessages({ accountId, conversationId })).toEqual([
+        expect.objectContaining({
+          id: messageId,
+          conversation: expect.objectContaining({ id: conversationId }),
+        }),
+      ]);
+    }
+
+    const ambiguousMessage = "qa-bus message id is ambiguous for selected account: 42";
+    expect(() => state.readMessage({ accountId, messageId })).toThrow(ambiguousMessage);
+    expect(() => state.editMessage({ accountId, messageId, text: "wrong conversation" })).toThrow(
+      ambiguousMessage,
+    );
+    expect(() => state.reactToMessage({ accountId, messageId, emoji: "eyes" })).toThrow(
+      ambiguousMessage,
+    );
+    expect(() => state.deleteMessage({ accountId, messageId })).toThrow(ambiguousMessage);
+    expect(state.getSnapshot()).toEqual(originalSnapshot);
+  });
+
   it("normalizes the dm ingress alias before channel routing", () => {
     const state = createQaBusState();
 

--- a/extensions/qa-lab/src/bus-state.ts
+++ b/extensions/qa-lab/src/bus-state.ts
@@ -135,6 +135,7 @@ export function createQaBusState() {
   const createMessage = (params: {
     direction: QaBusMessage["direction"];
     accountId: string;
+    messageId?: string;
     conversation: QaBusConversation;
     senderId: string;
     senderName?: string;
@@ -161,7 +162,8 @@ export function createQaBusState() {
     const storedConversation = ensureConversation(params.accountId, params.conversation);
     const toolCalls = sanitizeQaBusToolCalls(params.toolCalls);
     const message: QaBusMessage = {
-      id: randomUUID(),
+      // Adopt native identity before indexing or publishing any message clone.
+      id: params.messageId ?? randomUUID(),
       accountId: params.accountId,
       direction: params.direction,
       conversation: {
@@ -181,7 +183,9 @@ export function createQaBusState() {
       ...(toolCalls ? { toolCalls } : {}),
       reactions: [],
     };
-    messages.set(message.id, message);
+    // Provider IDs are conversation-local and must never replace another chat's message.
+    const { accountId, conversation, id } = message;
+    messages.set(JSON.stringify([accountId, conversation.kind, conversation.id, id]), message);
     return message;
   };
 
@@ -204,11 +208,12 @@ export function createQaBusState() {
         events,
       });
     },
-    addInboundMessage(input: QaBusInboundMessageInput) {
+    addInboundMessage(input: QaBusInboundMessageInput, messageId?: string) {
       const accountId = normalizeAccountId(input.accountId);
       const message = createMessage({
         direction: "inbound",
         accountId,
+        messageId,
         // `dm:` is the canonical target spelling and is also used by manual
         // QA-bus clients. Normalize its matching ingress alias before routing
         // so a DM can never silently acquire group/channel privacy semantics.

--- a/extensions/qa-lab/src/crabline-transport-message-id.test.ts
+++ b/extensions/qa-lab/src/crabline-transport-message-id.test.ts
@@ -1,0 +1,142 @@
+import { withTempDir } from "openclaw/plugin-sdk/test-env";
+import { describe, expect, it } from "vitest";
+import { createQaBusState } from "./bus-state.js";
+import { createQaCrablineTransportAdapter } from "./crabline-transport.js";
+
+const PROVIDER_CASES = [
+  {
+    channel: "telegram",
+    conversation: { id: "-1001234567890", kind: "group" },
+    senderId: "100001",
+    nativeMessageId: /^\d+$/u,
+  },
+  {
+    channel: "slack",
+    conversation: { id: "D12345678", kind: "direct" },
+    senderId: "U12345678",
+    nativeMessageId: /^\d+\.\d+$/u,
+  },
+  {
+    channel: "matrix",
+    conversation: { id: "main", kind: "group" },
+    senderId: "driver",
+    nativeMessageId: /^\$[a-f0-9]{16}:matrix\.test$/u,
+  },
+] as const;
+
+describe("Crabline provider-native inbound message identity", () => {
+  it.each(PROVIDER_CASES)(
+    "keeps $channel message IDs consistent across the returned message and bus state",
+    async ({ channel, conversation, senderId, nativeMessageId }) => {
+      await withTempDir("qa-crabline-message-id-", async (outputDir) => {
+        const busState = createQaBusState();
+        const transport = await createQaCrablineTransportAdapter({
+          outputDir,
+          selection: {
+            capabilityMatrixPath: "crabline-fake-provider-capabilities.json",
+            channel,
+            channelDriver: "crabline",
+            smokeArtifactPath: "crabline-fake-provider-smoke.json",
+          },
+          state: busState,
+        });
+
+        try {
+          const inbound = await transport.sendInbound({
+            conversation,
+            senderId,
+            senderName: "Alice",
+            text: `${channel} provider-native identity`,
+          });
+          const snapshot = transport.state.getSnapshot();
+
+          expect(inbound.id).toMatch(nativeMessageId);
+          expect(snapshot.messages).toContainEqual(
+            expect.objectContaining({ direction: "inbound", id: inbound.id }),
+          );
+          expect(snapshot.events).toContainEqual(
+            expect.objectContaining({
+              kind: "inbound-message",
+              message: expect.objectContaining({ id: inbound.id }),
+            }),
+          );
+          expect(busState.poll().events).toContainEqual(
+            expect.objectContaining({
+              kind: "inbound-message",
+              message: expect.objectContaining({ id: inbound.id }),
+            }),
+          );
+          expect(transport.state.readMessage({ messageId: inbound.id })).toMatchObject({
+            direction: "inbound",
+            id: inbound.id,
+          });
+        } finally {
+          await transport.cleanup?.();
+        }
+      });
+    },
+  );
+
+  it("preserves Telegram message IDs repeated across independent chats", async () => {
+    await withTempDir("qa-crabline-colliding-message-ids-", async (outputDir) => {
+      const busState = createQaBusState();
+      const createTelegramTransport = async (name: string) =>
+        await createQaCrablineTransportAdapter({
+          outputDir: `${outputDir}/${name}`,
+          selection: {
+            capabilityMatrixPath: "crabline-fake-provider-capabilities.json",
+            channel: "telegram",
+            channelDriver: "crabline",
+            smokeArtifactPath: "crabline-fake-provider-smoke.json",
+          },
+          state: busState,
+        });
+      const firstTransport = await createTelegramTransport("first");
+
+      try {
+        const secondTransport = await createTelegramTransport("second");
+
+        try {
+          const first = await firstTransport.sendInbound({
+            conversation: { id: "-1001234567890", kind: "group" },
+            senderId: "100001",
+            text: "first Telegram chat",
+          });
+          const second = await secondTransport.sendInbound({
+            conversation: { id: "-1001234567891", kind: "group" },
+            senderId: "100001",
+            text: "second Telegram chat",
+          });
+          const snapshot = busState.getSnapshot();
+
+          expect(first.id).toBe(second.id);
+          expect(snapshot.messages.map((message) => message.conversation.id)).toEqual([
+            first.conversation.id,
+            second.conversation.id,
+          ]);
+          expect(snapshot.events).toEqual([
+            expect.objectContaining({
+              message: expect.objectContaining({
+                id: first.id,
+                conversation: expect.objectContaining({ id: first.conversation.id }),
+              }),
+            }),
+            expect.objectContaining({
+              message: expect.objectContaining({
+                id: second.id,
+                conversation: expect.objectContaining({ id: second.conversation.id }),
+              }),
+            }),
+          ]);
+          expect(() => busState.readMessage({ messageId: first.id })).toThrow(
+            `qa-bus message id is ambiguous for selected account: ${first.id}`,
+          );
+        } finally {
+          await secondTransport.cleanup?.();
+        }
+      } finally {
+        await firstTransport.cleanup?.();
+      }
+    });
+  });
+});

--- a/extensions/qa-lab/src/crabline-transport-native-command.test.ts
+++ b/extensions/qa-lab/src/crabline-transport-native-command.test.ts
@@ -1,0 +1,62 @@
+import { withTempDir } from "openclaw/plugin-sdk/test-env";
+import { describe, expect, it } from "vitest";
+import { createQaBusState } from "./bus-state.js";
+import { createQaCrablineTransportAdapter } from "./crabline-transport.js";
+
+const NATIVE_COMMAND_CASES = [
+  { command: "stop", name: "stop" },
+  { command: "queue collect please help", name: "queue" },
+  { command: "think high", name: "think" },
+] as const;
+
+describe("Crabline Telegram native command arguments", () => {
+  it("preserves full command text while restricting native names and entities to the command token", async () => {
+    await withTempDir("qa-crabline-native-command-", async (outputDir) => {
+      const transport = await createQaCrablineTransportAdapter({
+        outputDir,
+        selection: {
+          capabilityMatrixPath: "crabline-fake-provider-capabilities.json",
+          channel: "telegram",
+          channelDriver: "crabline",
+          smokeArtifactPath: "crabline-fake-provider-smoke.json",
+        },
+        state: createQaBusState(),
+      });
+
+      try {
+        for (const { command } of NATIVE_COMMAND_CASES) {
+          await transport.sendNativeCommand?.({
+            command,
+            conversation: { id: "alice", kind: "direct" },
+            senderId: "alice",
+            senderName: "Alice",
+          });
+        }
+
+        expect(transport.state.getSnapshot().messages).toMatchObject(
+          NATIVE_COMMAND_CASES.map(({ command, name }) => ({
+            text: `/${command}`,
+            nativeCommand: { name },
+          })),
+        );
+
+        const telegram = transport.createGatewayConfig({ baseUrl: "http://127.0.0.1:1" }).channels
+          ?.telegram as { apiRoot?: string; botToken?: string } | undefined;
+        if (!telegram?.apiRoot || !telegram.botToken) {
+          throw new Error("Crabline Telegram API root and bot token are required");
+        }
+        const response = await fetch(`${telegram.apiRoot}/bot${telegram.botToken}/getUpdates`);
+        await expect(response.json()).resolves.toMatchObject({
+          result: NATIVE_COMMAND_CASES.map(({ command, name }) => ({
+            message: {
+              entities: [{ length: name.length + 1, offset: 0, type: "bot_command" }],
+              text: `/${command}`,
+            },
+          })),
+        });
+      } finally {
+        await transport.cleanup?.();
+      }
+    });
+  });
+});

--- a/extensions/qa-lab/src/crabline-transport.ts
+++ b/extensions/qa-lab/src/crabline-transport.ts
@@ -273,19 +273,18 @@ function createCrablineState(params: {
         adapter: params.adapter,
         providerInbound,
       });
-      const message = baseState.addInboundMessage({
-        ...input,
-        conversation: resolveCrablineStateConversation({
-          adapter: params.adapter,
-          input,
-          providerInbound,
-        }),
-        ...(providerInbound.threadId ? { threadId: providerInbound.threadId } : {}),
-      });
-      if (providerMessageId) {
-        message.id = providerMessageId;
-      }
-      return message;
+      return baseState.addInboundMessage(
+        {
+          ...input,
+          conversation: resolveCrablineStateConversation({
+            adapter: params.adapter,
+            input,
+            providerInbound,
+          }),
+          ...(providerInbound.threadId ? { threadId: providerInbound.threadId } : {}),
+        },
+        providerMessageId,
+      );
     },
     rememberProviderTarget(providerTargetKey, qaTarget) {
       targetByProviderTarget.set(providerTargetKey, qaTarget);
@@ -334,7 +333,7 @@ class QaCrablineTransport extends QaStateBackedTransportAdapter {
         await this.sendInbound({
           ...message,
           text: `/${command}`,
-          nativeCommand: { name: command },
+          nativeCommand: { name: command.split(/\s+/u, 1)[0] ?? command },
         });
       };
       this.waitForOutboundSequence = async (input) =>

--- a/extensions/qa-lab/src/qa-channel-transport.test.ts
+++ b/extensions/qa-lab/src/qa-channel-transport.test.ts
@@ -246,21 +246,28 @@ describe("qa channel transport", () => {
     ).resolves.toBe("owned condition completed");
   });
 
-  it("injects native commands with transport metadata", async () => {
-    const transport = createQaChannelTransport(createQaBusState());
+  it.each([
+    { command: "stop", name: "stop" },
+    { command: "queue collect please help", name: "queue" },
+    { command: "think high", name: "think" },
+  ])(
+    "injects /$name with its complete command and token-only metadata",
+    async ({ command, name }) => {
+      const transport = createQaChannelTransport(createQaBusState());
 
-    await transport.sendNativeCommand({
-      command: "stop",
-      conversation: { id: "alice", kind: "direct" },
-      senderId: "alice",
-    });
+      await transport.sendNativeCommand({
+        command,
+        conversation: { id: "alice", kind: "direct" },
+        senderId: "alice",
+      });
 
-    const [message] = transport.state.getSnapshot().messages;
-    expect(message).toMatchObject({
-      text: "/stop",
-      nativeCommand: { name: "stop" },
-    });
-  });
+      const [message] = transport.state.getSnapshot().messages;
+      expect(message).toMatchObject({
+        text: `/${command}`,
+        nativeCommand: { name },
+      });
+    },
+  );
 
   it("inherits the shared failure-aware wait helper", async () => {
     const transport = createQaChannelTransport(createQaBusState());

--- a/extensions/qa-lab/src/qa-channel-transport.ts
+++ b/extensions/qa-lab/src/qa-channel-transport.ts
@@ -129,7 +129,7 @@ class QaChannelTransport extends QaStateBackedTransportAdapter {
     await this.sendInbound({
       ...message,
       text: `/${command}`,
-      nativeCommand: { name: command },
+      nativeCommand: { name: command.split(/\s+/u, 1)[0] ?? command },
     });
   }
   async waitForOutboundSequence(input: QaTransportOutboundSequenceMatch) {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where QA channel simulations returned provider-native Telegram/Slack/Matrix message IDs that did not match their persisted bus messages, and identical native IDs from different chats could overwrite one another. Argument-bearing native slash commands also lost their arguments or exposed the entire argument string as the command name.

## Why This Change Was Made

Assign the authoritative native ID before the QA bus persists or emits a message, key private bus storage by account and conversation, and fail closed when an account-only lookup is genuinely ambiguous. Preserve the complete slash-command body while deriving only the first command token for native-command metadata in both synthetic transport owners. Public plugin SDK contracts, real channel providers, persisted product state, and authorization are unchanged.

## User Impact

QA channel scenarios now observe consistent message IDs across returned messages, snapshots, events, and lookups; independent chats cannot overwrite each other; argument-bearing slash commands behave like their real provider counterparts.

## Evidence

- Real Crabline Telegram, Slack, and Matrix provider simulations verify each native message ID across return, persisted state, events, polling, and reads.
- Two independent real Telegram provider simulations intentionally reuse the same native ID; both conversations survive and ambiguous account-only reads/mutations fail before changing either message.
- Actual Telegram `getUpdates` responses prove full `/queue ...` and `/think ...` bodies, token-only native names, and correct command-entity lengths; existing `/stop` behavior is preserved.
- Trusted Blacksmith Testbox aggregate passed **916 tests across 28 files**.
- Production delta: **40 additions / 25 deletions (+15 net)**, justified by scoped message identity and unambiguous ownership; regression tests: **382 additions / 39 deletions**.
- Independent structured review found no accepted actionable findings; Testbox run: https://github.com/openclaw/openclaw/actions/runs/30973152491

### Real Telegram/Crabline Gateway verdict

Trusted Blacksmith Testbox built the private-QA runtime and invoked the actual Gateway, actual Crabline Telegram transport, and HTTP mock provider:

    pnpm openclaw qa suite --provider-mode mock-openai --channel-driver crabline --channel telegram --scenario telegram-queue-invalid-mode
    [qa-suite] run start: scenarios=1 concurrency=1 transport=qa-channel channelDriver=crabline channel=telegram
    [qa-suite] provider start: mock-openai
    [qa-suite] gateway ready: http://127.0.0.1:32773
    [qa-suite] scenario start (1/1): telegram-queue-invalid-mode
    [qa-suite] scenario pass (1/1): telegram-queue-invalid-mode
    [qa-suite] run complete: passed=1 failed=0 skipped=0 total=1
    {"proof":"crabline-native-command-gateway","run":{"providerMode":"mock-openai","primaryModel":"mock-openai/gpt-5.6-luna","channelDriver":"crabline"},"counts":{"total":1,"passed":1,"failed":0,"skipped":0}}

The executed scenario covers complete slash arguments and explicit queue/thinking-command errors without invoking the model. The same Testbox run passed real Telegram/Slack/Matrix native-ID transport tests, the two-server cross-conversation collision regression, and real Telegram getUpdates command entities: 154 passing tests across nine files. All touched runtime owner files were verified byte-identical to the exact PR head. Testbox run: https://github.com/openclaw/openclaw/actions/runs/30983445783
