### PR TITLE
fix(doctor): report shadowed WhatsApp ack emoji

### DIFF
--- a/extensions/whatsapp/src/doctor.test.ts
+++ b/extensions/whatsapp/src/doctor.test.ts
@@ -79,4 +79,29 @@ describe("whatsapp doctor compatibility", () => {
       "Moved translatable channels.whatsapp.ackReaction settings to messages ack settings.",
     ]);
   });
+
+  it.each([
+    {
+      name: "normalizes an explicit blank emoji",
+      ackReaction: { emoji: "   ", direct: true, group: "never" } as const,
+      expected:
+        'channels.whatsapp.ackReaction requested acknowledgement emoji "", but the final messages.ackReaction is "🔥".',
+    },
+    {
+      name: "describes an omitted emoji as route-dependent",
+      ackReaction: { direct: true, group: "never" } as const,
+      expected:
+        'channels.whatsapp.ackReaction used a route-dependent agent identity acknowledgement emoji before migration; the final messages.ackReaction is "🔥".',
+    },
+  ])("$name in the migration receipt", ({ ackReaction, expected }) => {
+    const result = normalizeCompatibilityConfig({
+      cfg: {
+        messages: { ackReaction: "🔥", ackReactionScope: "direct" },
+        agents: { entries: { main: { identity: { emoji: "🤖" } } } },
+        channels: { whatsapp: { ackReaction } },
+      },
+    });
+
+    expect(result.changes).toContainEqual(expect.stringContaining(expected));
+  });
 });

--- a/extensions/whatsapp/src/doctor.ts
+++ b/extensions/whatsapp/src/doctor.ts
@@ -80,9 +80,22 @@ export function normalizeCompatibilityConfig({
     changes.push(`Moved translatable ${source.path} settings to messages ack settings.`);
   }
 
+  const finalEmoji = messages.ackReaction!.trim();
   const finalScope = messages.ackReactionScope ?? "group-mentions";
   const comparableFinalScope = finalScope === "none" ? "off" : finalScope;
   for (const source of sources) {
+    // The v2026.7.1 resolver returned explicit emoji.trim(), including "".
+    // Only an omitted emoji used the routed agent identity fallback.
+    const sourceEmoji = source.emoji?.trim();
+    if (source.emoji === undefined) {
+      changes.push(
+        `${source.path} used a route-dependent agent identity acknowledgement emoji before migration; the final messages.ackReaction is ${JSON.stringify(finalEmoji)}. Review messages.ackReaction.`,
+      );
+    } else if (sourceEmoji !== finalEmoji) {
+      changes.push(
+        `${source.path} requested acknowledgement emoji ${JSON.stringify(sourceEmoji)}, but the final messages.ackReaction is ${JSON.stringify(finalEmoji)}. Review messages.ackReaction.`,
+      );
+    }
     if (source.unrepresentableScope) {
       changes.push(
         `${source.path} migration cannot preserve both direct-message and mentioned-group acknowledgements; the final messages.ackReactionScope is ${JSON.stringify(finalScope)}. Review messages.ackReactionScope.`,

--- a/test/doctor-legacy-whatsapp-ack-migration.e2e.test.ts
+++ b/test/doctor-legacy-whatsapp-ack-migration.e2e.test.ts
@@ -1,0 +1,44 @@
+import fs from "node:fs/promises";
+import { expect, it } from "vitest";
+import { createOpenClawTestInstance } from "./helpers/openclaw-test-instance.js";
+
+it(
+  "reports a legacy WhatsApp acknowledgement emoji kept by canonical config",
+  { timeout: 180_000 },
+  async () => {
+    const instance = await createOpenClawTestInstance({ name: "doctor-whatsapp-ack" });
+    try {
+      const initialConfig = JSON.parse(await fs.readFile(instance.configPath, "utf8"));
+      await fs.writeFile(
+        instance.configPath,
+        JSON.stringify({
+          ...initialConfig,
+          messages: { ackReaction: "🔥" },
+          channels: {
+            whatsapp: { ackReaction: { emoji: "✅", direct: true, group: "never" } },
+          },
+        }),
+        "utf8",
+      );
+
+      const doctor = await instance.cli(
+        ["doctor", "--fix", "--non-interactive", "--yes", "--no-workspace-suggestions"],
+        { timeoutMs: 120_000 },
+      );
+
+      expect(doctor.code, `${doctor.stdout}\n${doctor.stderr}`).toBe(0);
+      const output = `${doctor.stdout}\n${doctor.stderr}`.replaceAll("│", "").replace(/\s+/gu, " ");
+      expect(output).toContain(
+        'channels.whatsapp.ackReaction requested acknowledgement emoji "✅", but the final messages.ackReaction is "🔥". Review messages.ackReaction.',
+      );
+      const migrated = JSON.parse(await fs.readFile(instance.configPath, "utf8"));
+      expect(migrated.messages).toMatchObject({
+        ackReaction: "🔥",
+        ackReactionScope: "direct",
+      });
+      expect(migrated.channels.whatsapp.ackReaction).toBeUndefined();
+    } finally {
+      await instance.cleanup();
+    }
+  },
+);


### PR DESCRIPTION
## What Problem This Solves

Doctor keeps canonical `messages.ackReaction` when it migrates a legacy WhatsApp acknowledgement block. It deleted a different legacy emoji but printed only the generic clean-move receipt, so the discarded operator value was not recoverable from the upgrade output.

PR #129825 moved this migration to the WhatsApp plugin and reports scope loss. This PR completes the same owner-boundary receipt for emoji loss.

Closes #119317.

## Root cause

The WhatsApp Doctor migration records each legacy emoji before deleting the legacy block, but its post-migration comparison only checked acknowledgement scope. A partly populated canonical destination could therefore shadow the emoji without a diagnostic.

## Fix

- Compare each legacy source emoji with the final canonical emoji after root and account migration.
- Keep the canonical value and migrated scope unchanged.
- Print the source path, discarded emoji, final emoji, and the setting to review.
- Keep the clean-move receipt when no emoji conflict exists.

## Evidence

- Exact shipped transition: installed `openclaw@2026.7.1`, verified it read the legacy state, then installed `openclaw@2026.8.1` over the same state. Doctor kept `messages.ackReactionScope: "group-mentions"`, deleted legacy scope `"direct"`, and printed only the generic move receipt.
- Red on current main `a9f9ac4d58907df89e0c115d15c88daf89ec7a81`: real `openclaw doctor --non-interactive --fix` kept `"🔥"`, applied scope `"direct"`, deleted legacy `"✅"`, and printed no emoji-loss diagnostic.
- Green on exact head `893885de97a80f3ea53f7f7d7106648e1ee1c51d`: the shipped Doctor process test printed the discarded `"✅"` and retained `"🔥"`, with the migrated config unchanged.
- Anti-cheat: the same exact-head run omitted the diagnostic when no canonical emoji shadowed the legacy value.
- Tests: `node scripts/run-vitest.mjs test/doctor-legacy-whatsapp-ack-migration.e2e.test.ts extensions/whatsapp/src/doctor.test.ts extensions/whatsapp/src/auto-reply/monitor/reactions.test.ts`.
- Checks: focused Oxlint, Oxfmt, and `git diff --check` passed.

## Attribution

The repair commit retains `Co-authored-by: harjoth <harjoth.khara@gmail.com>` for the original contributor.
