### PR TITLE
fix(qa): isolate Active Memory request traces

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog-causality.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-causality.test.ts
@@ -333,4 +333,62 @@ describe("qa scenario catalog causality", () => {
       }),
     ).resolves.toMatchObject({ status: "pass" });
   });
+
+  it("isolates Active Memory request traces from interleaved heartbeats", async () => {
+    const scenario = requireFlowScenario(readQaScenarioById("active-memory-preprompt-recall"));
+    const actions = scenario.execution.flow?.steps[0]?.actions ?? [];
+    const baselineTrace = actions.find(
+      (action) => (action as { set?: string }).set === "baselineMockRequests",
+    );
+    const activeTrace = actions.find(
+      (action) => (action as { set?: string }).set === "activeRequests",
+    );
+    expect(baselineTrace).toBeDefined();
+    expect(activeTrace).toBeDefined();
+    if (!baselineTrace || !activeTrace) {
+      throw new Error("active-memory-preprompt-recall request trace actions are missing");
+    }
+
+    const marker = String(scenario.execution.config?.turnMarker);
+    const heartbeat = { allInputText: "[OpenClaw heartbeat poll]" };
+    const scenarioRequest = (suffix: string) => ({ allInputText: `${marker} ${suffix}` });
+    const traces = new Map<string, unknown[]>([
+      ["10", [heartbeat, scenarioRequest("baseline main")]],
+      [
+        "20",
+        [
+          heartbeat,
+          scenarioRequest("You are a memory search agent. search plan"),
+          scenarioRequest("You are a memory search agent. search result"),
+          scenarioRequest("You are a memory search agent. memory get result"),
+          scenarioRequest("active main"),
+        ],
+      ],
+    ]);
+
+    await expect(
+      runLoadedScenarioFlow("active-memory-preprompt-recall", {
+        flow: {
+          steps: [
+            {
+              name: "filters provider-global traces before exact counts",
+              actions: [
+                { set: "requestCursorBeforeBaseline", value: { expr: "10" } },
+                baselineTrace,
+                { assert: "baselineMockRequests.length === 1" },
+                { set: "requestCursorBeforeActive", value: { expr: "20" } },
+                activeTrace,
+                { assert: "activeRequests.length === 4" },
+              ],
+            },
+          ],
+        },
+        api: {
+          env: { mock: { baseUrl: "http://mock.invalid" } },
+          fetchJson: async (url: string) =>
+            traces.get(new URL(url).searchParams.get("after") ?? "") ?? [],
+        },
+      }),
+    ).resolves.toMatchObject({ status: "pass" });
+  });
 });

--- a/qa/scenarios/memory/active-memory-preprompt-recall.yaml
+++ b/qa/scenarios/memory/active-memory-preprompt-recall.yaml
@@ -174,7 +174,7 @@ flow:
             expr: "normalizeLowercaseStringOrEmpty(baselineReply.text)"
         - set: baselineMockRequests
           value:
-            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBeforeBaseline}`))"
+            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBeforeBaseline}`)).filter((request) => String(request.allInputText ?? '').includes(config.turnMarker))"
         - assert:
             expr: baselineMockRequests.length === 1
             message:
@@ -243,7 +243,7 @@ flow:
             message: active memory recall left a transient SQLite session behind
         - set: activeRequests
           value:
-            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBeforeActive}`))"
+            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBeforeActive}`)).filter((request) => String(request.allInputText ?? '').includes(config.turnMarker))"
         - assert:
             expr: activeRequests.length === 4
             message:


### PR DESCRIPTION
Closes #119386

## What Problem This Solves

Fixes a QA false failure where an unrelated heartbeat request recorded after the mock provider's global cursor was counted as part of `active-memory-preprompt-recall`.

## Why This Change Was Made

The mock provider cursor remains the bounded retrieval boundary, but both the disabled baseline and active-turn traces now filter by the scenario's existing unique turn marker before enforcing their exact one-request and four-request contracts.

The regression executes the actual YAML trace selectors with an interleaved heartbeat. It proves the heartbeat is excluded while the marked baseline request and complete three-helper-plus-main Active Memory chain remain exact.

No heartbeat, provider, gateway, timeout, retry, or Active Memory runtime behavior changed.

## User Impact

There is no user-visible product behavior change. Maintainers get stable whole-system QA verdicts even when a legitimate heartbeat overlaps the scenario.

Production LOC delta: 0. QA scenario/tests: +60 / -2.

## Evidence

- Full-catalog reproduction before the fix: Testbox `tbx_01kz7depbpx0ysp84ccnv5j86j`, https://github.com/openclaw/openclaw/actions/runs/30955607104.
- Focused pressure reproduction before the fix: Testbox `tbx_01kz7ffteq8qkr1y201t2ecptk`, https://github.com/openclaw/openclaw/actions/runs/30957846990.
- Post-rebase focused catalog proof passed 58/58, including the interleaved-heartbeat test.
- Post-rebase full `active-memory-preprompt-recall` scenario passed 1/1.
  - Testbox `tbx_01kz86h6789ycm235p70yzrfrm`
  - Hosted run: https://github.com/openclaw/openclaw/actions/runs/30978417327
- Final branch AutoReview is clean with no accepted/actionable findings.

AI-assisted: yes. I understand the change and verified the scenario, Active Memory prompt propagation, and provider-global cursor contract directly.
