### PR TITLE
fix(telegram): preserve controls when message content is blank

### DIFF
--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -1725,6 +1725,35 @@ describe("handleTelegramAction", () => {
     ).rejects.toThrow(/content required/i);
   });
 
+  it("rejects an empty-string content instead of sending an empty message", async () => {
+    await expect(
+      handleTelegramAction(
+        {
+          action: "sendMessage",
+          to: "123456",
+          content: "",
+        },
+        telegramConfig(),
+      ),
+    ).rejects.toThrow(/content required/i);
+    expect(sendMessageTelegram).not.toHaveBeenCalled();
+    expect(sendDurableMessageBatch).not.toHaveBeenCalled();
+  });
+
+  it("still sends media with an empty caption", async () => {
+    await handleTelegramAction(
+      {
+        action: "sendMessage",
+        to: "123456",
+        content: "",
+        mediaUrl: "https://example.com/photo.jpg",
+      },
+      telegramConfig(),
+    );
+
+    expect(sendMessageTelegram).toHaveBeenCalled();
+  });
+
   it("maps video notes through the existing durable send action", async () => {
     await handleTelegramAction(
       {

--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -1725,22 +1725,25 @@ describe("handleTelegramAction", () => {
     ).rejects.toThrow(/content required/i);
   });
 
-  it("rejects an empty-string content instead of sending an empty message", async () => {
-    await expect(
-      handleTelegramAction(
-        {
-          action: "sendMessage",
-          to: "123456",
-          content: "",
-        },
-        telegramConfig(),
-      ),
-    ).rejects.toThrow(/content required/i);
-    expect(sendMessageTelegram).not.toHaveBeenCalled();
-    expect(sendDurableMessageBatch).not.toHaveBeenCalled();
-  });
+  it.each(["", "   "])(
+    "rejects blank text-only content %j before durable delivery",
+    async (content) => {
+      await expect(
+        handleTelegramAction(
+          {
+            action: "sendMessage",
+            to: "123456",
+            content,
+          },
+          telegramConfig(),
+        ),
+      ).rejects.toThrow(/content required/i);
+      expect(sendMessageTelegram).not.toHaveBeenCalled();
+      expect(sendDurableMessageBatch).not.toHaveBeenCalled();
+    },
+  );
 
-  it("still sends media with an empty caption", async () => {
+  it("keeps an empty caption for media-only sends", async () => {
     await handleTelegramAction(
       {
         action: "sendMessage",
@@ -1751,7 +1754,15 @@ describe("handleTelegramAction", () => {
       telegramConfig(),
     );
 
-    expect(sendMessageTelegram).toHaveBeenCalled();
+    const durableCall = mockCall(sendDurableMessageBatch, 0, "empty media caption");
+    expect(requireRecord(durableCall[0], "empty media caption params")).toMatchObject({
+      payloads: [
+        {
+          text: "",
+          mediaUrls: ["https://example.com/photo.jpg"],
+        },
+      ],
+    });
   });
 
   it("maps video notes through the existing durable send action", async () => {
@@ -1779,11 +1790,12 @@ describe("handleTelegramAction", () => {
     expect(requireRecord(sendCall[2], "video note options").asVideoNote).toBe(true);
   });
 
-  it("accepts a standalone normalized location", async () => {
+  it("accepts a standalone normalized location with blank content", async () => {
     await handleTelegramAction(
       {
         action: "sendMessage",
         to: "123456",
+        content: "   ",
         location: {
           latitude: 48.858844,
           longitude: 2.294351,
@@ -1947,6 +1959,31 @@ describe("handleTelegramAction", () => {
     expect(call[0]).toBe("123456");
     expect(call[1]).toBe("- Approve");
     expect(requireRecord(call[2], "button-only fallback options").buttons).toEqual([
+      [{ text: "Approve", callback_data: "approve" }],
+    ]);
+  });
+
+  it("uses presentation button fallback when explicit content is blank", async () => {
+    await handleTelegramAction(
+      {
+        action: "sendMessage",
+        to: "123456",
+        content: "   ",
+        presentation: {
+          blocks: [
+            {
+              type: "buttons",
+              buttons: [{ label: "Approve", value: "approve" }],
+            },
+          ],
+        },
+      },
+      telegramConfig({ capabilities: { inlineButtons: "all" } }),
+    );
+
+    const call = mockCall(sendMessageTelegram, 0, "blank presentation button fallback");
+    expect(call[1]).toBe("- Approve");
+    expect(requireRecord(call[2], "blank presentation button fallback options").buttons).toEqual([
       [{ text: "Approve", callback_data: "approve" }],
     ]);
   });
@@ -2494,6 +2531,25 @@ describe("handleTelegramAction", () => {
     expect(call[0]).toBe("@testchannel");
     expect(call[1]).toBe("- Retry");
     expect(requireRecord(call[2], "interactive button fallback options").buttons).toEqual([
+      [{ text: "Retry", callback_data: "cmd:retry" }],
+    ]);
+  });
+
+  it("uses interactive button fallback when explicit content is blank", async () => {
+    await handleTelegramAction(
+      {
+        action: "sendMessage",
+        to: "@testchannel",
+        content: "",
+        interactive: {
+          blocks: [{ type: "buttons", buttons: [{ label: "Retry", value: "cmd:retry" }] }],
+        },
+      },
+      telegramConfig({ capabilities: { inlineButtons: "all" } }),
+    );
+    const call = mockCall(sendMessageTelegram, 0, "blank interactive button fallback");
+    expect(call[1]).toBe("- Retry");
+    expect(requireRecord(call[2], "blank interactive button fallback options").buttons).toEqual([
       [{ text: "Retry", callback_data: "cmd:retry" }],
     ]);
   });

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -274,7 +274,12 @@ function readTelegramSendContent(params: {
       content = fallback;
     }
   }
-  if (content == null && !params.mediaUrl && !params.hasButtons && !params.hasLocation) {
+  if (
+    (content == null || content.trim().length === 0) &&
+    !params.mediaUrl &&
+    !params.hasButtons &&
+    !params.hasLocation
+  ) {
     throw new Error("content required.");
   }
   return {

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -238,7 +238,6 @@ function resolveTelegramButtonsFromParams(
 function readTelegramSendContent(params: {
   args: Record<string, unknown>;
   mediaUrl?: string;
-  hasButtons: boolean;
   hasLocation?: boolean;
   interactive?: unknown;
   presentation?: MessagePresentation;
@@ -247,44 +246,34 @@ function readTelegramSendContent(params: {
     readStringParam(params.args, "content", { allowEmpty: true }) ??
     readStringParam(params.args, "message", { allowEmpty: true }) ??
     readStringParam(params.args, "caption", { allowEmpty: true });
+  const hasExplicitContent = Boolean(explicitContent?.trim());
   const unsupportedBlocks =
     params.presentation?.blocks.filter(
       (block) => block.type === "chart" || block.type === "table",
     ) ?? [];
   const presentationText =
-    explicitContent == null && params.presentation
+    !hasExplicitContent && params.presentation
       ? renderMessagePresentationFallbackText({ presentation: params.presentation })
-      : explicitContent != null && unsupportedBlocks.length > 0
+      : hasExplicitContent && unsupportedBlocks.length > 0
         ? renderMessagePresentationFallbackText({
             text: explicitContent,
             presentation: { ...params.presentation, blocks: unsupportedBlocks },
           })
         : undefined;
   const interactiveText =
-    explicitContent == null && !params.presentation
+    !hasExplicitContent && !params.presentation
       ? resolveTelegramInteractiveTextFallback({ interactive: params.interactive })
       : undefined;
-  let content =
+  const content =
     (presentationText?.trim() ? presentationText : undefined) ??
-    explicitContent ??
+    (hasExplicitContent ? explicitContent : undefined) ??
     (interactiveText?.trim() ? interactiveText : undefined);
-  if ((content == null || content.trim().length === 0) && !params.mediaUrl && params.hasButtons) {
-    const fallback = presentationText?.trim() ? presentationText : interactiveText;
-    if (fallback?.trim()) {
-      content = fallback;
-    }
-  }
-  if (
-    (content == null || content.trim().length === 0) &&
-    !params.mediaUrl &&
-    !params.hasButtons &&
-    !params.hasLocation
-  ) {
+  if ((content == null || content.trim().length === 0) && !params.mediaUrl && !params.hasLocation) {
     throw new Error("content required.");
   }
   return {
     content: content ?? "",
-    hasExplicitContent: explicitContent != null,
+    hasExplicitContent,
   };
 }
 
@@ -552,7 +541,6 @@ export async function handleTelegramAction(
     const resolvedContent = readTelegramSendContent({
       args: params,
       mediaUrl: firstMediaUrl,
-      hasButtons: Array.isArray(buttons) && buttons.length > 0,
       hasLocation: Boolean(location),
       interactive: params.interactive,
       presentation,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Telegram `sendMessage` actions with explicit blank content and presentation or interactive controls could skip the readable control fallback and enter durable delivery with an unusable blank payload.

Current main already rejects blank text before a Telegram Bot API request. The defect is earlier in the action runtime: blank explicit content is treated as present, so it suppresses the existing button fallback and leaves error ownership to a later sender boundary.

## Why This Change Was Made

The Telegram action runtime now treats trimmed blank explicit content as absent while resolving presentation and interactive fallbacks. It rejects the action only when no usable fallback, media, or location remains.

This keeps one canonical action path: text-only blank sends fail before durable delivery, button sends produce readable fallback text plus native controls, and media or location sends may still use an empty caption.

## User Impact

Telegram actions with blank text and controls now deliver the intended readable button message instead of failing later with a blank payload. Plain blank messages still fail with `content required.`, while empty media captions and standalone locations continue to work.

## Evidence

- Exact candidate head: `c06c1c1c93a1b741bd37b84c910e96b696a86ecd`
- Focused regression suite: `extensions/telegram/src/action-runtime.test.ts` passed 112/112 tests.
- Changed-scope Blacksmith Testbox passed: https://github.com/openclaw/openclaw/actions/runs/30984806893
- Full Telegram extension Blacksmith Testbox passed 192 files and 3,267 tests: https://github.com/openclaw/openclaw/actions/runs/30985363734
- P2 autoreview found no accepted or actionable findings on the rewrite.
- Exact-head native Telegram baseline/candidate proof: pending the repository's Mantis Telegram Desktop Proof workflow.

Punchcard-Session: clear-orchard-lantern-bc
