### PR TITLE
fix(discord): preserve authored block order in presentation components

### DIFF
--- a/extensions/discord/src/shared-interactive.test.ts
+++ b/extensions/discord/src/shared-interactive.test.ts
@@ -223,6 +223,30 @@ describe("buildDiscordInteractiveComponents", () => {
     expect(buildDiscordPresentationComponents(presentation)).toBeUndefined();
   });
 
+  it("preserves authored block order around controls", () => {
+    expect(
+      buildDiscordPresentationComponents({
+        blocks: [
+          { type: "text", text: "First" },
+          {
+            type: "buttons",
+            buttons: [{ label: "Approve", value: "approve", style: "success" }],
+          },
+          { type: "text", text: "Last" },
+        ],
+      }),
+    ).toEqual({
+      blocks: [
+        { type: "text", text: "First" },
+        {
+          type: "actions",
+          buttons: [{ label: "Approve", style: "success", callbackData: "approve" }],
+        },
+        { type: "text", text: "Last" },
+      ],
+    });
+  });
+
   it("renders typed approvals as actionable transport-private Discord controls", () => {
     const rendered = buildDiscordPresentationComponents({
       blocks: [

--- a/extensions/discord/src/shared-interactive.ts
+++ b/extensions/discord/src/shared-interactive.ts
@@ -229,8 +229,6 @@ export function buildDiscordPresentationComponents(
       blocks.push({ type: "separator" });
       continue;
     }
-  }
-  for (const block of presentation.blocks) {
     if (block.type === "buttons") {
       appendDiscordButtonBlocks(blocks, block.buttons);
       continue;


### PR DESCRIPTION
## Summary

`fix(discord): preserve authored block order in presentation components instead of sinking buttons below all text`

## What Problem This Solves

`buildDiscordPresentationComponents` (`extensions/discord/src/shared-interactive.ts`) turns an agent's authored `MessagePresentation` — an ordered list of text, context, divider, button, and select blocks — into Discord Components V2 layout. The Discord V2 protocol allows text, separators, and action rows to interleave arbitrarily, so the authored order is the message layout.

The builder however runs **two passes**: it first collects every text/context/divider block (in order), then appends every buttons/select block. A presentation authored as `[text "构建结果", buttons […], text "3 个测试被跳过"]` renders as `[text 构建结果, text 3 个测试被跳过, actions]` — the trailing note jumps above the buttons and the buttons sink below all text. Selects written before buttons get moved after them too. Users see a scrambled message whose controls no longer sit where the author placed them.

**代码证据**: in `extensions/discord/src/shared-interactive.ts` (main), `buildDiscordPresentationComponents` (`:207-241`) iterates `presentation.blocks` twice — the first `for` loop (`:217`) emits only text/context/divider, the second (`:235`) appends buttons/select — so output order can never interleave. Meanwhile the `@deprecated` sibling `buildDiscordInteractiveComponents` (`:183-205`) renders the same block kinds in a single order-preserving pass, and its test `preserves authored shared text blocks around controls` (`shared-interactive.test.ts:57`) pins interleaving as the intended contract. The outbound path (`outbound-components.ts:135`) sends the spec verbatim as a V2 layout, so the reordering is user-visible.

## Root Cause

- Bug introduced by commit `fd0970c077377a30847efb3d118bac7dd093891b` on 2026-04-21, which introduced the order-breaking split between prose and controls. Commit `b78c2ee8c850` only made the second pass explicit while carrying the existing ordering bug forward.
- Violated invariant: "presentation block order is the message layout." The two-pass implementation silently reinterprets the block list as "all prose first, all controls last" — an ordering rule that exists nowhere in the Discord V2 protocol or in the deprecated renderer it replaced.
- Trigger condition: any presentation that places a text/context/divider block after a buttons or select block — e.g. a result summary followed by action buttons followed by a footnote.

## Why This Change Was Made

- Option A (chosen): merge the two passes into one order-preserving loop (title still pinned first) — restores the invariant at the single place it is violated, matches the deprecated renderer's proven semantics, and changes nothing for presentations that are already prose-then-controls.
- Option B: document the reordering as intended — rejected: it contradicts the V2 layout model and the deprecated function's pinned contract, and gives authors no way to place controls mid-message.
- Option C: annotate blocks with explicit positions — rejected: inventing a new ordering mechanism to work around a broken default, instead of fixing the default.

## User Impact

- Affected scenario: Discord messages built from presentations that interleave text and controls (result cards with footnotes, multi-section approval prompts, select-then-button forms).
- Before: controls always render below all prose regardless of authored order; trailing notes and dividers float above them.
- After: blocks render in authored order, identical to the deprecated renderer's behavior.
- Behavior change: only presentations with text/context/divider blocks positioned after buttons/select change (they now render as authored); prose-then-controls presentations produce byte-identical output.

## Evidence

Setup: the **real** `buildDiscordPresentationComponents` executed via `node --import tsx` with an authored `[text, buttons, text]` presentation; the produced layout is printed and checked against the authored order. No mocks anywhere.

### Before (on main)

```bash
$ node --import tsx proof-discord-order.mjs   # main version
[proof] authored order: [text(Build finished), actions, text(3 tests were skipped)]
[proof] produced layout: ["text(\"Build finished\")","text(\"3 tests were skipped\")","actions"]
[proof] RESULT: FAIL - authored order broken: buttons moved to the end, trailing note jumped above them (actions at index 2)
exit=1
```

### After (with fix)

```bash
$ node --import tsx proof-discord-order.mjs   # with fix
[proof] authored order: [text(Build finished), actions, text(3 tests were skipped)]
[proof] produced layout: ["text(\"Build finished\")","actions","text(\"3 tests were skipped\")"]
[proof] RESULT: PASS - authored order preserved; trailing note stays after the buttons
exit=0
```

## Tests and Validation

- `node node_modules/vitest/vitest.mjs run extensions/discord/src/shared-interactive.test.ts` — 21 passed (20 existing + 1 new: `preserves authored block order around controls` for the presentation builder)
- Red-green check: with the source change stashed, the new test fails; with the fix, the full file passes.
- Manual verification is the proof above (same script on main vs fixed code).


Punchcard-Session: clear-orchard-lantern-bc
