### PR TITLE
fix: startup plugin verification suggests restarting a container

### DIFF
--- a/src/commands/doctor-config-preflight-plugin-verification.test.ts
+++ b/src/commands/doctor-config-preflight-plugin-verification.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { formatStartupPluginVerificationFailure } from "./doctor-config-preflight-plugin-verification.js";
+
+describe("formatStartupPluginVerificationFailure", () => {
+  it("uses install-neutral gateway restart guidance", () => {
+    expect(
+      formatStartupPluginVerificationFailure({
+        kind: "plugin-verification",
+        messages: ['Plugin "discord" has no install path.'],
+      }),
+    ).toBe(
+      [
+        "OpenClaw plugin verification failed; refusing to report the gateway ready.",
+        '- Plugin "discord" has no install path.',
+        "Resolve the plugin verification errors above, then restart the gateway.",
+      ].join("\n"),
+    );
+  });
+});

--- a/src/commands/doctor-config-preflight-plugin-verification.ts
+++ b/src/commands/doctor-config-preflight-plugin-verification.ts
@@ -221,6 +221,6 @@ export function formatStartupPluginVerificationFailure(
   return [
     "OpenClaw plugin verification failed; refusing to report the gateway ready.",
     ...diagnostic.messages.map((message) => `- ${message}`),
-    "Resolve the plugin verification errors above, then restart the container.",
+    "Resolve the plugin verification errors above, then restart the gateway.",
   ].join("\n");
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators on native or service installs were told to restart a container after gateway startup plugin verification failed.

## Why This Change Was Made

The recovery guidance now asks operators to restart the gateway, matching the install-neutral wording established by #119406. Container-specific daemon guidance remains unchanged.

## User Impact

Operators receive a recovery step that applies to container, native, and service-managed gateways.

## Evidence

- The same production formatter and diagnostic input were run at pinned base `75ef5aebecb8e808eaa8a0503fb4b466703c5306` and head `edb593f4e8a38cbdb20ade3c6be0edb9f0ca60d6`.
- `node_modules/.bin/vitest run src/commands/doctor-config-preflight-plugin-verification.test.ts src/commands/doctor-config-preflight.state-migration.test.ts`: 30 passed.

```text
$ pnpm exec tsx proof-live.ts
before: {"sha":"75ef5aebecb8e808eaa8a0503fb4b466703c5306","recovery":"Resolve the plugin verification errors above, then restart the container.","diagnosticPreserved":true}
after: {"sha":"edb593f4e8a38cbdb20ade3c6be0edb9f0ca60d6","recovery":"Resolve the plugin verification errors above, then restart the gateway.","diagnosticPreserved":true}
```

<details>
<summary>proof-live.ts</summary>

```ts
import { execFileSync } from "node:child_process";
import path from "node:path";
import { pathToFileURL } from "node:url";

async function main() {
  const moduleUrl = pathToFileURL(
    path.resolve("src/commands/doctor-config-preflight-plugin-verification.ts"),
  ).href;
  const { formatStartupPluginVerificationFailure } = await import(moduleUrl);
  const diagnostic = 'Plugin "demo": invalid payload. Run `openclaw update repair` to retry.';
  const output = formatStartupPluginVerificationFailure({
    kind: "plugin-verification",
    messages: [diagnostic],
  });

  console.log(
    JSON.stringify({
      sha: execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim(),
      recovery: output.split("\n").at(-1),
      diagnosticPreserved: output.includes(`- ${diagnostic}`),
    }),
  );
}

void main();
```

</details>

AI-assisted: built with Codex



Punchcard-Session: clear-orchard-lantern-bc


