### PR TITLE
fix(sessions): archive cron-run transcripts pruned by tasks maintenance

### DIFF
--- a/src/config/sessions/session-registry-maintenance.test.ts
+++ b/src/config/sessions/session-registry-maintenance.test.ts
@@ -4,7 +4,11 @@ import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { beginSessionWorkAdmission } from "../../sessions/session-lifecycle-admission.js";
 import { createFixtureSuite } from "../../test-utils/fixture-suite.js";
-import { loadSessionEntry, replaceSessionEntry } from "./session-accessor.js";
+import {
+  appendTranscriptEventSync,
+  loadSessionEntry,
+  replaceSessionEntry,
+} from "./session-accessor.js";
 import { runSessionRegistryMaintenanceForStore } from "./session-registry-maintenance.js";
 import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
 import type { SessionEntry } from "./types.js";
@@ -40,6 +44,23 @@ function resolveRequiredSqlitePath(storePath: string): string {
     throw new Error(`Expected a SQLite target for ${storePath}`);
   }
   return sqlitePath;
+}
+
+async function listDeletedArchiveFiles(root: string): Promise<string[]> {
+  const archives: string[] = [];
+  const walk = async (dir: string) => {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(fullPath);
+      } else if (entry.name.includes(".deleted.") && entry.name.endsWith(".zst")) {
+        archives.push(fullPath);
+      }
+    }
+  };
+  await walk(root);
+  return archives;
 }
 
 describe("runSessionRegistryMaintenanceForStore", () => {
@@ -141,6 +162,53 @@ describe("runSessionRegistryMaintenanceForStore", () => {
     expect(
       loadSessionEntry({ sessionKey: "agent:main:cron:done-job:run:recent-run", storePath }),
     ).toEqual(sessionEntry("recent-run", now));
+  });
+
+  it("archives the transcript when pruning stale cron-run sessions", async () => {
+    const now = Date.now();
+    const sessionKey = "agent:main:cron:done-job:run:old-run";
+    const sessionId = "run-1";
+    const storePath = await createStore({
+      [sessionKey]: sessionEntry(sessionId, now - 8 * DAY_MS),
+    });
+    appendTranscriptEventSync(
+      { sessionKey, sessionId, storePath },
+      { type: "proof-event", data: "cron transcript must survive pruning" },
+    );
+
+    const result = await runSessionRegistryMaintenanceForStore({
+      apply: true,
+      retentionMs: 7 * DAY_MS,
+      runningCronJobIds: new Set(),
+      storePath,
+    });
+
+    expect(result).toEqual({
+      beforeCount: 1,
+      afterCount: 0,
+      preservedRunning: 0,
+      pruned: 1,
+    });
+    expect(loadSessionEntry({ sessionKey, storePath })).toBeUndefined();
+    const archives = await listDeletedArchiveFiles(path.dirname(storePath));
+    expect(archives.length).toBeGreaterThan(0);
+  });
+
+  it("does not write transcript archives during preview", async () => {
+    const now = Date.now();
+    const storePath = await createStore({
+      "agent:main:cron:done-job:run:old-run": sessionEntry("run-1", now - 8 * DAY_MS),
+    });
+
+    const result = await runSessionRegistryMaintenanceForStore({
+      apply: false,
+      retentionMs: 7 * DAY_MS,
+      runningCronJobIds: new Set(),
+      storePath,
+    });
+
+    expect(result.pruned).toBe(1);
+    expect(await listDeletedArchiveFiles(path.dirname(storePath))).toStrictEqual([]);
   });
 
   it("applies pruning to stale cron-run descendant rows", async () => {

--- a/src/config/sessions/session-registry-maintenance.test.ts
+++ b/src/config/sessions/session-registry-maintenance.test.ts
@@ -4,10 +4,12 @@ import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { beginSessionWorkAdmission } from "../../sessions/session-lifecycle-admission.js";
 import { createFixtureSuite } from "../../test-utils/fixture-suite.js";
+import { readSessionArchiveContentSync } from "./archive-compression.js";
 import { isRetainedSessionTranscriptArchiveName } from "./artifacts.js";
 import {
   appendTranscriptEventSync,
   loadSessionEntry,
+  loadTranscriptEvents,
   replaceSessionEntry,
 } from "./session-accessor.js";
 import { runSessionRegistryMaintenanceForStore } from "./session-registry-maintenance.js";
@@ -192,14 +194,24 @@ describe("runSessionRegistryMaintenanceForStore", () => {
     });
     expect(loadSessionEntry({ sessionKey, storePath })).toBeUndefined();
     const archives = await listDeletedArchiveFiles(path.dirname(storePath));
-    expect(archives.length).toBeGreaterThan(0);
+    expect(archives).toHaveLength(1);
+    expect(readSessionArchiveContentSync(archives[0] ?? "")).toContain(
+      "cron transcript must survive pruning",
+    );
+    await expect(loadTranscriptEvents({ sessionKey, sessionId, storePath })).resolves.toEqual([]);
   });
 
   it("does not write transcript archives during preview", async () => {
     const now = Date.now();
+    const sessionKey = "agent:main:cron:done-job:run:old-run";
+    const sessionId = "run-1";
     const storePath = await createStore({
-      "agent:main:cron:done-job:run:old-run": sessionEntry("run-1", now - 8 * DAY_MS),
+      [sessionKey]: sessionEntry(sessionId, now - 8 * DAY_MS),
     });
+    appendTranscriptEventSync(
+      { sessionKey, sessionId, storePath },
+      { type: "proof-event", data: "cron transcript must survive preview" },
+    );
 
     const result = await runSessionRegistryMaintenanceForStore({
       apply: false,
@@ -209,6 +221,10 @@ describe("runSessionRegistryMaintenanceForStore", () => {
     });
 
     expect(result.pruned).toBe(1);
+    expect(loadSessionEntry({ sessionKey, storePath })).toBeDefined();
+    await expect(loadTranscriptEvents({ sessionKey, sessionId, storePath })).resolves.toHaveLength(
+      1,
+    );
     expect(await listDeletedArchiveFiles(path.dirname(storePath))).toStrictEqual([]);
   });
 

--- a/src/config/sessions/session-registry-maintenance.test.ts
+++ b/src/config/sessions/session-registry-maintenance.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { beginSessionWorkAdmission } from "../../sessions/session-lifecycle-admission.js";
 import { createFixtureSuite } from "../../test-utils/fixture-suite.js";
+import { isRetainedSessionTranscriptArchiveName } from "./artifacts.js";
 import {
   appendTranscriptEventSync,
   loadSessionEntry,
@@ -54,7 +55,7 @@ async function listDeletedArchiveFiles(root: string): Promise<string[]> {
       const fullPath = path.join(dir, entry.name);
       if (entry.isDirectory()) {
         await walk(fullPath);
-      } else if (entry.name.includes(".deleted.") && entry.name.endsWith(".zst")) {
+      } else if (isRetainedSessionTranscriptArchiveName(entry.name)) {
         archives.push(fullPath);
       }
     }

--- a/src/config/sessions/session-registry-maintenance.ts
+++ b/src/config/sessions/session-registry-maintenance.ts
@@ -79,7 +79,11 @@ function pruneSessionRegistryStore(params: {
     log: false,
     onPruned: params.removals
       ? ({ key, entry }) => {
-          params.removals?.push({ sessionKey: key, expectedEntry: entry });
+          params.removals?.push({
+            sessionKey: key,
+            expectedEntry: entry,
+            archiveRemovedTranscript: true,
+          });
         }
       : undefined,
     preserveKeys,


### PR DESCRIPTION
## What Problem This Solves

`openclaw tasks maintenance --apply` prunes stale cron-run session entries and hard-deletes their SQLite transcript rows without writing the compressed `.deleted` archive that every other production removal path writes, so the full record of what an automation did is destroyed with no warning and no cold copy.
- Problem: The removal list built in `pruneSessionRegistryStore` never sets `archiveRemovedTranscript`, so the downstream projection (`session-accessor.sqlite-lifecycle-state.ts`) plans `archiveTranscript: false`, the archive write is skipped, and the transcript rows are reclaimed unconditionally. A grep of every production removal-list construction shows this is the only outlier (cron reaper, cleanup service, heartbeat runner, and doctor all set the flag). The command reports only `pruned: 1`, so the loss is silent. Operators who explicitly configured `cron.sessionRetention: false` ("keep automation run sessions") lose those transcripts to this 7-day sweep unarchived.
- Solution: Set `archiveRemovedTranscript: true` on the removal, exactly like the cron session reaper (`src/cron/session-reaper.ts`). The existing archive machinery then writes and verifies the `.deleted.<ts>.zst` cold copy before rows are reclaimed, so the transcript survives under the archive retention policy.
- What changed: `src/config/sessions/session-registry-maintenance.ts` (removal push gains `archiveRemovedTranscript: true`), `src/config/sessions/session-registry-maintenance.test.ts` (2 regression tests: apply writes an archive, preview does not).
- What did NOT change: The archive writer, downstream lifecycle projection, retention policy, CLI output, and all other removal paths; no config surface; no behavior change for ordinary chat sessions (this sweep only owns cron-run rows).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #119269
- [x] This PR fixes a bug or regression

## Motivation

The repository already accepted the same argument as P1 at the sibling call site (#119085): reclaiming transcript content must first write the compressed archive so operators can recover after an over-eager prune. `tasks maintenance --apply` is that exact shape at a different call site: it owns only cron-run rows (`buildSessionRegistryPreserveKeys` preserves every non-cron key), the rows are reclaimed unconditionally, and the archive directory stays empty. The cron reaper already sets the flag, and the issue's own evidence shows the identical downstream removal with `archiveRemovedTranscript: true` writes `sess-*.jsonl.deleted.<ts>.zst` - the archive machinery works, this call site simply never asks for it.

## Evidence

- Behavior addressed: Pruning a stale cron-run session through `runSessionRegistryMaintenanceForStore({apply:true})` (the exact function the CLI `tasks maintenance --apply` action invokes) now writes the `.deleted.<ts>.zst` transcript archive before reclaiming the rows.
- Real environment tested: Linux x86_64, Node v22.22.3, branch `fix/tasks-maintenance-archive-119269` (head `cc5bd8992e9`, base `dc93ea6d699`). The proof script drives the real production pipeline (`replaceSessionEntry` seeding, `appendTranscriptEventSync`, `runSessionRegistryMaintenanceForStore`) against an isolated temp store, reading back SQLite transcript rows and the on-disk archive directory.
- Exact steps or command run after this patch:
  - `node --import tsx /media/vdb/code/github/contributions/pr-119269-evidence/proof-tasks-maintenance-archive.mts <checkout>` (before: `origin/main`; after: fix branch)
  - Scenario: seed `agent:main:cron:nightly-report:run:1700000000000` with `updatedAt` 30 days old + one transcript event, run `runSessionRegistryMaintenanceForStore({apply:true, retentionMs: 7d})`, then count transcript rows and archives
- Evidence after fix:

```console
=== proof run: <fix branch checkout> ===
{
  "beforeEvents": 1,
  "beforeArchives": 0,
  "result": { "afterCount": 0, "beforeCount": 1, "preservedRunning": 0, "pruned": 1 },
  "afterEvents": 0,
  "afterArchives": 1,
  "archives": ["proof-cron-run-1.jsonl.deleted.2026-08-05T05-19-14.536Z.zst"]
}
--- assertions ---
PASS  seeded transcript event is present before pruning
PASS  AFTER-FIX: rows reclaimed AND a .deleted.<ts>.zst archive was written
```

Before-fix comparison (`origin/main`, same script):

```console
=== proof run: <origin/main checkout> ===
{
  "beforeEvents": 1,
  "beforeArchives": 0,
  "result": { "afterCount": 0, "beforeCount": 1, "preservedRunning": 0, "pruned": 1 },
  "afterEvents": 0,
  "afterArchives": 0,
  "archives": []
}
--- assertions ---
PASS  seeded transcript event is present before pruning
PASS  BEFORE-FIX reproduced: rows reclaimed but no .deleted archive written (silent loss)
```

Behavior matrix (removal path => transcript archive):

```
tasks maintenance --apply (before fix)  => rows reclaimed, no .deleted archive (silent loss)
tasks maintenance --apply (after fix)   => rows reclaimed + .deleted.<ts>.zst written
cron session reaper (unchanged)         => rows reclaimed + .deleted.<ts>.zst written
cleanup --fix-missing (PR #119156)      => covered by that PR
preview (--apply not set)               => no mutation, no archive (unchanged)
```

Automated checks: `session-registry-maintenance.test.ts` 9/9 (2 new regression cases); related tasks/pruning/cleanup suites passed; CI-like shard `agentic-commands-status-tools` 744 passed (one unrelated local-env failure: `backup-sqlite.test.ts` POSIX staging-ancestor check against the container root, unrelated to this change); `oxlint` clean; `pnpm tsgo:test` clean; no lockfile changes.
- Observed result after fix:
  1. The stale cron-run session entry is removed and its transcript rows reclaimed exactly as before (`pruned: 1`).
  2. A verified `proof-cron-run-1.jsonl.deleted.<timestamp>.zst` archive is now written under the agent sessions directory before rows are reclaimed.
  3. Preview mode still performs no mutation and writes no archive.
- What was not tested: The built CLI binary end to end (the proof drives `runSessionRegistryMaintenanceForStore`, the exact function the CLI action invokes); non-SQLite (JSON-file) session stores; Windows. The archive writer is the existing production path with readback verification.

## Root Cause

- Cause: `pruneSessionRegistryStore` (`src/config/sessions/session-registry-maintenance.ts`) builds `{sessionKey, expectedEntry}` removals without `archiveRemovedTranscript`; `projectSqliteSessionEntryLifecycleMutation` strictly maps `archiveRemovedTranscript === true` to `archiveTranscript`, so the archive write is skipped while `deleteSqliteSessionStateRows` reclaims rows unconditionally. Confidence: clear.
- Provenance: `introduced by` `78451824104` (2026-06-18, #93734 task session registry maintenance seam); the flag was never set at this site; the cron reaper (`src/cron/session-reaper.ts:125`) is the sibling-correct reference.

## Regression Test Plan

- Unit: `runSessionRegistryMaintenanceForStore({apply:true})` prunes a stale cron-run session and writes a `.deleted.<ts>.zst` archive; `apply:false` preview writes none.
- CI-like: `agentic-commands-status-tools` shard (744 tests) passed locally.
- Real-pipeline: before/after harness proof (logs above) in `/media/vdb/code/github/contributions/pr-119269-evidence/`.

## User-visible / Behavior Changes

`openclaw tasks maintenance --apply` still prunes stale cron-run sessions, but now leaves a recoverable compressed transcript archive under the archive retention policy instead of silently destroying the conversation history. No CLI output shape change.

## Security Impact

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No (the fix adds a durable cold copy for content that was previously deleted)

## Repro + Verification

### Environment

- OS: Linux x86_64
- Runtime: Node v22.22.3
- Model/provider: n/a
- Integration/channel: n/a (isolated session store)
- Relevant config: `cron.sessionRetention: false` scenario included in the issue analysis (this sweep does not consult it)

### Steps

1. Run the proof script against `origin/main`: `node --import tsx proof-tasks-maintenance-archive.mts <before-checkout>`
2. Run the same script against the fix branch.
3. Compare `afterArchives` / archive file names.

### Expected

Before: rows reclaimed, archives empty. After: rows reclaimed and a `.deleted.<ts>.zst` archive written.

### Actual

As shown in the Evidence matrix above.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification

- Verified scenarios: apply prune of a 30-day-old cron-run session with one transcript event; preview mode; preservation of non-cron rows (existing tests).
- Edge cases checked: archive readback verification is the existing production path; archive naming uses the existing timestamped scheme.
- What you did NOT verify: built CLI binary end to end; Windows; non-SQLite store; how often real deployments reach the 7-day sweep with unreaped cron rows.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- [x] Backward compatible? Yes
- [x] Config/env changes? No
- [x] Migration needed? No

## Best-fix Verdict

- **Best fix**: Yes - one flag on the removal aligns this call site with the reaper and every other archive-on-prune path; the archive machinery is already correct and verified.
- **Refactor needed**: No - a one-field removal change; no larger refactor required.
- **Alternative considered**: (1) Extending PR #119156 (a-yeyang) to cover this call site - the issue reporter explicitly suggested this, but that PR only touches `cleanup-service.ts` and is owned by another contributor; a separate focused PR is cleaner. (2) Adding a try/catch or special-casing the mutation - unnecessary; the flag is the root cause.

## AI Assistance

- **AI-assisted**: Yes
- **Co-Authored-By**: Claude Opus 4.6 <noreply@anthropic.com>
- **Human confirmed understanding of code changes**: Yes
- **AI prompts / session excerpts**: Available in the contribution session log (issue #119269 workflow).

## Risks and Mitigations

**Highest risk area**: none material - the change only adds an archive write that every sibling removal path already performs; the archive machinery includes readback verification and idempotent archive reuse.

Compatibility: backward compatible; no config/env/migration changes. Operators with `cron.sessionRetention: false` keep their automation transcripts instead of losing them silently.

Fixes #119269
