### PR TITLE
fix(msteams): release capture-teed response bodies without awaiting cancellation

### DIFF
--- a/extensions/msteams/src/attachments.test.ts
+++ b/extensions/msteams/src/attachments.test.ts
@@ -4,6 +4,7 @@ import type { PluginRuntime, SsrFPolicy } from "../runtime-api.js";
 import { readRemoteMediaResponse } from "./attachments.test-helpers.js";
 import { downloadMSTeamsAttachments } from "./attachments/download.js";
 import { resolveRequestUrl } from "./attachments/shared.js";
+import { createCaptureTeedResponse, expectSettled } from "./capture-tee.test-helpers.js";
 import { setMSTeamsRuntime } from "./runtime.js";
 
 const saveResponseMediaMock = vi.hoisted(() =>
@@ -499,6 +500,35 @@ describe("msteams attachments", () => {
       expectAttachmentMediaLength(media, 1);
       expect(tokenProvider.getAccessToken).toHaveBeenCalledOnce();
       expect(fetchMock.mock.calls.map(([calledUrl]) => calledUrl)).toContain(redirectedUrl);
+    });
+
+    it("retries past a superseded attempt without awaiting a debug-capture tee", async () => {
+      // The debug proxy clones every captured response, so the 401 the retry
+      // supersedes is one branch of a live tee. Awaiting its cancel would stall
+      // the retry loop instead of releasing the attempt.
+      const captured = createCaptureTeedResponse({ status: 401 });
+      const tokenProvider = createTokenProvider((scope) => `token:${scope}`);
+      const fetchMock = vi.fn(async (_url: string, opts?: RequestInit) => {
+        if (!new Headers(opts?.headers).has("Authorization")) {
+          return captured.response;
+        }
+        return createBufferResponse(PNG_BUFFER, CONTENT_TYPE_IMAGE_PNG);
+      });
+
+      try {
+        const media = await expectSettled(
+          downloadAttachmentsWithFetch(createImageAttachments(TEST_URL_IMAGE), fetchMock, {
+            tokenProvider,
+            authAllowHosts: [TEST_HOST],
+          }),
+          "msteams attachment auth retry",
+        );
+
+        expectAttachmentMediaLength(media, 1);
+        expect(captured.cancellationSettled()).toBe(false);
+      } finally {
+        captured.releaseCaptureBranch();
+      }
     });
 
     it("continues scope fallback after non-auth failure and succeeds on later scope", async () => {

--- a/extensions/msteams/src/attachments/bot-framework.test.ts
+++ b/extensions/msteams/src/attachments/bot-framework.test.ts
@@ -1,6 +1,7 @@
 // Msteams tests cover bot framework plugin behavior.
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createCaptureTeedResponse, expectSettled } from "../capture-tee.test-helpers.js";
 import { setMSTeamsRuntime } from "../runtime.js";
 import {
   downloadMSTeamsBotFrameworkAttachments,
@@ -20,6 +21,7 @@ type MockRuntime = {
   saveCalls: SavedCall[];
   savePath: string;
   savedContentType: string;
+  saveResponseMediaError?: Error;
 };
 
 type DownloadSingleAttachmentParams = Omit<
@@ -83,6 +85,9 @@ function installRuntime(): MockRuntime {
             originalFilename?: string;
           },
         ) => {
+          if (state.saveResponseMediaError) {
+            throw state.saveResponseMediaError;
+          }
           const buffer = Buffer.from(await response.arrayBuffer());
           state.saveCalls.push({
             buffer,
@@ -271,6 +276,81 @@ describe("downloadMSTeamsBotFrameworkAttachment", () => {
 
     expectUnavailableMedia(media, "att-1");
     expect(runtime.saveCalls).toHaveLength(0);
+  });
+
+  it("releases a non-ok attachment info body without awaiting a debug-capture tee", async () => {
+    const captured = createCaptureTeedResponse({ status: 500 });
+    const fetchFn = createMockFetch([
+      {
+        match: /\/v3\/attachments\//,
+        response: captured.response,
+      },
+    ]);
+
+    try {
+      const media = await expectSettled(
+        downloadMSTeamsBotFrameworkAttachment({
+          serviceUrl: "https://smba.trafficmanager.net/amer",
+          attachmentId: "att-1",
+          tokenProvider: buildTokenProvider(),
+          maxBytes: 10_000_000,
+          fetchFn,
+          fetchFnSupportsDispatcher: true,
+          resolveFn: resolvePublicHost,
+        }),
+        "bot framework attachment download",
+      );
+
+      expectUnavailableMedia(media, "att-1");
+      expect(captured.cancellationSettled()).toBe(false);
+    } finally {
+      captured.releaseCaptureBranch();
+    }
+  });
+
+  it("releases an attachment view body when saving fails without awaiting the tee", async () => {
+    const info = {
+      name: "report.pdf",
+      type: "application/pdf",
+      views: [{ viewId: "original", size: 1024 }],
+    };
+    const captured = createCaptureTeedResponse({ status: 200 });
+    // A storage failure leaves the body unread, which is exactly when the
+    // cleanup cancel meets a live capture tee.
+    runtime.saveResponseMediaError = new Error("disk full");
+    const fetchFn = createMockFetch([
+      {
+        match: /\/v3\/attachments\/att-1$/,
+        response: new Response(JSON.stringify(info), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      },
+      {
+        match: /\/v3\/attachments\/att-1\/views\/original$/,
+        response: captured.response,
+      },
+    ]);
+
+    try {
+      const media = await expectSettled(
+        downloadMSTeamsBotFrameworkAttachment({
+          serviceUrl: "https://smba.trafficmanager.net/amer",
+          attachmentId: "att-1",
+          tokenProvider: buildTokenProvider(),
+          maxBytes: 10_000_000,
+          fetchFn,
+          fetchFnSupportsDispatcher: true,
+          resolveFn: resolvePublicHost,
+        }),
+        "bot framework attachment view save",
+      );
+
+      expectUnavailableMedia(media, "att-1");
+      expect(captured.cancellationSettled()).toBe(false);
+    } finally {
+      captured.releaseCaptureBranch();
+    }
   });
 
   it("does not send Bot Framework service tokens to non-auth-allowlisted media hosts", async () => {

--- a/extensions/msteams/src/attachments/bot-framework.ts
+++ b/extensions/msteams/src/attachments/bot-framework.ts
@@ -113,7 +113,9 @@ async function fetchBotFrameworkAttachmentInfo(params: {
     return undefined;
   }
   if (!response.ok) {
-    await response.body?.cancel().catch(() => undefined);
+    // A debug-capture clone can keep the tee open, so waiting for cancel would hang
+    // before the rejected response and its dispatcher can be released.
+    void response.body?.cancel().catch(() => undefined);
     params.logger?.warn?.("msteams botFramework attachmentInfo non-ok", {
       status: response.status,
     });
@@ -173,7 +175,7 @@ async function saveBotFrameworkAttachmentView(params: {
     return undefined;
   }
   if (!response.ok) {
-    await response.body?.cancel().catch(() => undefined);
+    void response.body?.cancel().catch(() => undefined); // Awaiting capture tees can deadlock.
     params.logger?.warn?.("msteams botFramework attachmentView non-ok", {
       status: response.status,
     });
@@ -183,14 +185,14 @@ async function saveBotFrameworkAttachmentView(params: {
   try {
     contentLength = parseMediaContentLength(response.headers.get("content-length"));
   } catch (err) {
-    await response.body?.cancel().catch(() => undefined);
+    void response.body?.cancel().catch(() => undefined); // Awaiting capture tees can deadlock.
     params.logger?.warn?.("msteams botFramework attachmentView invalid content-length", {
       error: err instanceof Error ? err.message : String(err),
     });
     return undefined;
   }
   if (contentLength !== null && contentLength > params.maxBytes) {
-    await response.body?.cancel().catch(() => undefined);
+    void response.body?.cancel().catch(() => undefined); // Awaiting capture tees can deadlock.
     return undefined;
   }
   try {
@@ -208,7 +210,8 @@ async function saveBotFrameworkAttachmentView(params: {
     });
     return undefined;
   } finally {
-    await response.body?.cancel().catch(() => undefined);
+    // A save failure leaves the body unread; awaiting capture tees can deadlock.
+    void response.body?.cancel().catch(() => undefined);
   }
 }
 

--- a/extensions/msteams/src/attachments/download.ts
+++ b/extensions/msteams/src/attachments/download.ts
@@ -199,7 +199,9 @@ async function fetchWithAuthFallback(params: {
         resolveFn: params.resolveFn,
         timeoutMs: resolveMSTeamsRequestTimeoutMs(params.deadline),
       });
-      await fallbackAttempt.body?.cancel().catch(() => undefined);
+      // A debug-capture clone can keep the tee open, so waiting for cancel would
+      // stall this retry loop before the superseded attempt can be released.
+      void fallbackAttempt.body?.cancel().catch(() => undefined);
       if (authAttempt.ok || isRedirectStatus(authAttempt.status)) {
         // Redirects in guarded fetch mode must propagate to the outer guard.
         return authAttempt;

--- a/extensions/msteams/src/attachments/remote-media.test.ts
+++ b/extensions/msteams/src/attachments/remote-media.test.ts
@@ -62,6 +62,7 @@ vi.mock("../runtime.js", () => ({
   }),
 }));
 
+import { createCaptureTeedResponse, expectSettled } from "../capture-tee.test-helpers.js";
 import { downloadAndStoreMSTeamsRemoteMedia } from "./remote-media.js";
 
 const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
@@ -162,6 +163,31 @@ describe("downloadAndStoreMSTeamsRemoteMedia", () => {
       ).rejects.toThrow("mkdir failed");
 
       expect(cancel).toHaveBeenCalledTimes(1);
+    });
+
+    it("releases a guarded response without awaiting a debug-capture tee", async () => {
+      const captured = createCaptureTeedResponse({ status: 200 });
+      const fetchImpl = vi.fn(async () => captured.response);
+      saveResponseMediaMock.mockRejectedValueOnce(new Error("mkdir failed"));
+
+      try {
+        await expectSettled(
+          expect(
+            downloadAndStoreMSTeamsRemoteMedia({
+              url: "https://graph.microsoft.com/v1.0/shares/abc/driveItem/content",
+              filePathHint: "file.png",
+              maxBytes: 1024,
+              useDirectFetch: true,
+              fetchImpl,
+            }),
+          ).rejects.toThrow("mkdir failed"),
+          "msteams remote media direct save",
+        );
+
+        expect(captured.cancellationSettled()).toBe(false);
+      } finally {
+        captured.releaseCaptureBranch();
+      }
     });
 
     it("falls back to the runtime saveRemoteMedia path when useDirectFetch is omitted", async () => {

--- a/extensions/msteams/src/attachments/remote-media.ts
+++ b/extensions/msteams/src/attachments/remote-media.ts
@@ -32,7 +32,9 @@ async function saveRemoteMediaDirect(params: {
   } finally {
     // Guarded responses release their pinned dispatcher on EOF or cancel. A
     // storage failure can happen before the body is read, so always cancel it.
-    await response.body?.cancel().catch(() => undefined);
+    // A debug-capture clone can keep the tee open, so waiting for cancel would
+    // hang this path instead of releasing the response.
+    void response.body?.cancel().catch(() => undefined);
   }
 }
 

--- a/extensions/msteams/src/capture-tee.test-helpers.ts
+++ b/extensions/msteams/src/capture-tee.test-helpers.ts
@@ -1,0 +1,76 @@
+// Msteams helper module supports capture tee behavior.
+
+/**
+ * Builds a response whose body is one branch of a live tee, the way the debug
+ * proxy leaves every captured response.
+ *
+ * `installDebugProxyFetchPatch` clones each http(s) response and reads the
+ * clone, so the caller-facing body is one branch of a `Response.clone()` tee.
+ * Cancelling such a branch settles only once both branches cancel or the source
+ * reaches EOF, so awaiting it on an error or cleanup path stalls the caller.
+ */
+export function createCaptureTeedResponse(init?: ResponseInit): {
+  response: Response;
+  cancellationSettled: () => boolean;
+  releaseCaptureBranch: () => void;
+} {
+  const response = new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("stalled body prefix"));
+      },
+    }),
+    init,
+  );
+  // clone() tees the body: `response` keeps one branch and the clone owns the
+  // other, standing in for the capture reader that never reaches EOF.
+  const captureBranch = response.clone();
+  const captureReader = captureBranch.body?.getReader();
+  void captureReader?.read();
+  const body = response.body;
+  if (!body) {
+    throw new Error("expected a readable capture-teed body");
+  }
+  let settled = false;
+  const markSettled = <T>(pending: Promise<T>): Promise<T> =>
+    pending.finally(() => {
+      settled = true;
+    });
+  // Callers reach the branch either directly or through a reader, and
+  // `reader.cancel()` does not route through `stream.cancel()`. Instrument both
+  // so the assertion holds wherever the release path lives.
+  const cancelBranch = body.cancel.bind(body);
+  body.cancel = (reason?: unknown) => markSettled(cancelBranch(reason));
+  const getBranchReader = body.getReader.bind(body);
+  body.getReader = ((...args: Parameters<typeof getBranchReader>) => {
+    const reader = getBranchReader(...args);
+    const cancelReader = reader.cancel.bind(reader);
+    reader.cancel = (reason?: unknown) => markSettled(cancelReader(reason));
+    return reader;
+  }) as typeof body.getReader;
+  return {
+    response,
+    cancellationSettled: () => settled,
+    releaseCaptureBranch: () => {
+      void captureReader?.cancel().catch(() => undefined);
+    },
+  };
+}
+
+/**
+ * Rejects instead of hanging when `operation` never settles, so a regression
+ * that restores the awaited cancellation fails fast rather than timing out.
+ */
+export async function expectSettled<T>(operation: Promise<T>, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} did not settle`)), 2_000);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/extensions/msteams/src/file-consent.test.ts
+++ b/extensions/msteams/src/file-consent.test.ts
@@ -1,5 +1,6 @@
 // Msteams tests cover file consent plugin behavior.
 import { describe, expect, it, vi } from "vitest";
+import { createCaptureTeedResponse, expectSettled } from "./capture-tee.test-helpers.js";
 import { uploadToConsentUrl } from "./file-consent.js";
 import { resolveMSTeamsSharePointUploadTimeoutMs } from "./request-timeout.js";
 import { buildUserAgent } from "./user-agent.js";
@@ -523,6 +524,29 @@ describe("uploadToConsentUrl", () => {
       }),
     ).rejects.toThrow("File upload to consent URL failed: 403 Forbidden");
     expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("reports the upload status without awaiting a debug-capture tee", async () => {
+    const captured = createCaptureTeedResponse({ status: 403, statusText: "Forbidden" });
+    const mockFetch = vi.fn<typeof fetch>(async () => captured.response);
+
+    try {
+      await expectSettled(
+        expect(
+          uploadToConsentUrl({
+            url: "https://contoso.sharepoint.com/sites/uploads/file.pdf",
+            buffer: Buffer.from("data"),
+            fetchFn: mockFetch,
+            validationOpts: { resolveFn: publicResolve },
+          }),
+        ).rejects.toThrow("File upload to consent URL failed: 403 Forbidden"),
+        "msteams consent upload",
+      );
+
+      expect(captured.cancellationSettled()).toBe(false);
+    } finally {
+      captured.releaseCaptureBranch();
+    }
   });
 
   it("blocks HTTP (non-HTTPS) upload before fetch is called", async () => {

--- a/extensions/msteams/src/file-consent.ts
+++ b/extensions/msteams/src/file-consent.ts
@@ -227,7 +227,9 @@ export async function uploadToConsentUrl(params: {
 
   // Consent uploads never consume the response payload. Cancel it on every
   // status so the fetch implementation can release the underlying connection.
-  await res.body?.cancel().catch(() => undefined);
+  // A debug-capture clone can keep the tee open, so waiting for cancel would hang
+  // the upload instead of reporting its status.
+  void res.body?.cancel().catch(() => undefined);
   if (!res.ok) {
     throw new Error(`File upload to consent URL failed: ${res.status} ${res.statusText}`);
   }

--- a/extensions/msteams/src/graph.test.ts
+++ b/extensions/msteams/src/graph.test.ts
@@ -44,6 +44,7 @@ vi.mock("../runtime-api.js", async (importOriginal) => {
   };
 });
 
+import { createCaptureTeedResponse, expectSettled } from "./capture-tee.test-helpers.js";
 import { findGraphUsersByExactIdentity, searchGraphUsers } from "./graph-users.js";
 import {
   deleteGraphRequest,
@@ -421,7 +422,36 @@ describe("msteams graph helpers", () => {
     });
 
     expect(upstreamCancel).toHaveBeenCalledTimes(1);
-    expect(release).toHaveBeenCalledTimes(1);
+    // The cancel is fire-and-forget so a debug-capture tee cannot stall the
+    // delete; `responseWithRelease` still releases once its cancel settles.
+    await vi.waitFor(() => expect(release).toHaveBeenCalledTimes(1));
+  });
+
+  it("releases a bodyful DELETE response without awaiting a debug-capture tee", async () => {
+    const captured = createCaptureTeedResponse();
+    const release = vi.fn(async () => undefined);
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: captured.response,
+      finalUrl: "https://graph.microsoft.com/v1.0/chats/chat-1/messages/msg-1",
+      release,
+    });
+
+    try {
+      await expectSettled(
+        deleteGraphRequest({
+          token: graphToken,
+          path: "/chats/chat-1/messages/msg-1",
+        }),
+        "graph DELETE",
+      );
+
+      expect(captured.cancellationSettled()).toBe(false);
+      // Release still follows the cancellation, so it is still pending here:
+      // this fix unblocks the caller, it does not release the transport sooner.
+      expect(release).not.toHaveBeenCalled();
+    } finally {
+      captured.releaseCaptureBranch();
+    }
   });
 
   it("resolves Graph tokens through the SDK auth provider", async () => {

--- a/extensions/msteams/src/graph.ts
+++ b/extensions/msteams/src/graph.ts
@@ -287,7 +287,9 @@ export async function deleteGraphRequest(params: { token: string; path: string }
     method: "DELETE",
     errorPrefix: "Graph DELETE",
   });
-  await response.body?.cancel().catch(() => undefined);
+  // A debug-capture clone can keep the tee open, so waiting for cancel would hang
+  // the delete before the response and its dispatcher can be released.
+  void response.body?.cancel().catch(() => undefined);
 }
 
 export async function listChannelsForTeam(token: string, teamId: string): Promise<GraphChannel[]> {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where, with the debug proxy enabled, three MS Teams paths
stop producing any outcome when the remote sends headers plus a partial body and
then stalls: a rejected consent upload never surfaces its HTTP status, the Bot
Framework attachment-info error path never returns, and the attachment
auth-retry loop never makes its next authenticated attempt. No result, no error.

Those three are the ones the capture below demonstrates end to end. The same
change lands on every other place in this extension that awaits such a
cancellation: a storage or stream failure after a direct media response has been
accepted, and `deleteGraphRequest`. Those stop stalling too.

Two things this PR does not do, both detailed below: it does not release the
transport any sooner, and it does not reach the route where core's
`saveResponseMedia` *rejects* a response — non-ok, or a declared length over the
cap — because that awaits a cancellation of its own and stalls upstream of
anything this diff touches.

The debug proxy patches global fetch and calls `response.clone()` on every
http(s) exchange, so the caller-facing body is one branch of a live tee. Per
WHATWG streams, cancelling one branch settles only once **both** branches
cancel or the source reaches EOF — and the capture branch is still reading. A
remote that sends headers plus a partial body and then stops without EOF leaves
that cancellation pending forever.

## Why This Change Was Made

Three terms, used consistently below. On the media path only, a response is
**accepted** once `saveResponseMedia` has passed its status and content-length
checks and has started reading the body; before that it is *rejected*, and
rejection is handled inside core. The consent upload and the Graph client do not
go through `saveResponseMedia` and are described on their own terms. **`responseWithRelease`** is the wrapper that owns the guarded
transport: it hands the caller a body, and releases the transport after that
body's cancellation settles. A **capture-teed** body is one branch of the
`response.clone()` the debug proxy makes; cancelling it settles only once both
branches cancel or the source reaches EOF.

This extension already treats an awaited cancel on a capture-teed body as a
defect. `extensions/msteams/src/attachments/graph.ts` — the attachment
downloader, not the `extensions/msteams/src/graph.ts` client this PR touches —
cancels without awaiting in `releaseGraphResponse`, with the comment *"Awaiting
capture tees can deadlock."*, and `extensions/byteplus/video-generation-provider.ts` and
`extensions/runway/video-generation-provider.ts` carry the same shape. Nine
sites in this extension still awaited it — every one of them on an error, retry
or cleanup path where no downstream read of that response is needed any more. The invariant was
therefore true in some msteams paths and false in the rest, which is what this
PR closes.

They now use the same non-awaited cancellation. **What changes is that the
caller no longer waits for the cancellation to complete — not when the
cancellation starts, and not when the transport is released**: none of these
sites owns a `release()` to sequence, because
`safeFetchWithPolicy` and `requestGraph` hand back a `responseWithRelease`
wrapper whose own `cancel()` awaits the upstream cancel and then releases
(`src/plugin-sdk/fetch-runtime.ts:81-85`). Three moments have to be kept apart:
the caller returning, the cancellation being *issued*, and the transport being
*released*. This diff moves only the first. The cancellation is issued at the
same point in both versions, and the release still waits on it, so a tee that
never settles holds the transport in both — measured below, and pinned by the
new regression in `extensions/msteams/src/graph.test.ts`, which asserts the
release has not happened at the point the call returns. That is also why the
existing bodyful-DELETE test in the same file now waits for the release instead
of asserting it synchronously. What it still guarantees is that the transport is
released exactly once and not leaked; what it no longer guarantees is that the
release has happened by the time the call returns — the one property this fix
deliberately drops.

Six new regressions keep a capture clone live while the path is rejected, using
a shared `capture-tee.test-helpers.ts` (it instruments both `stream.cancel` and
`reader.cancel`, because `responseWithRelease` cancels through a reader). They
are not one-per-site; the table below separates the sites with a dedicated tee
regression from the ones that are the same statement in the same function as a
covered site, and from what the live capture reaches.

### The fix

The inclusion rule is one invariant in one owner — the msteams extension — covering every place in
`extensions/msteams` where the only remaining job is cleanup and the code awaits
a body cancellation to do it. Most of those bodies were never read; two are
`finally` blocks that also cover the case where a save consumed part of the body
first. Either way nothing downstream reads the response again, which is what
makes the await pointless and the stall possible.

Two greps establish that. `git grep -n 'await .*\.body?\.cancel()' --
extensions/msteams/src` returns nine hits outside tests at the baseline and none
at this head. The wider `git grep -n '\.cancel(' -- extensions/msteams/src`
finds no other shape to worry about; outside tests, at this head, it is:

```
attachments/bot-framework.ts:118,178,188,195,214   void response.body?.cancel()
attachments/download.ts:204                        void fallbackAttempt.body?.cancel()
attachments/graph.ts:104                           void response.body?.cancel()   (pre-existing)
attachments/remote-media.ts:37                     void response.body?.cancel()
file-consent.ts:232                                void res.body?.cancel()
graph.ts:292                                       void response.body?.cancel()
reply-stream-controller.ts:571                     progressDraftGate.cancel()     (unrelated)
```

There is no `reader.cancel()` and no aliased response in this extension's
production code. Treating a subset is what leaves the state this
PR starts from — one file already non-awaiting, the rest still awaiting.

Every one of the nine changes from `await <response>.body?.cancel()` to
`void <response>.body?.cancel()` — a non-awaited body cancellation. The
cancellation itself, and the transport release that follows it, are untouched. Each keeps
its existing `.catch(() => undefined)`, so the promise is handled and cannot
become an unhandled rejection — including the case where the body was already
consumed and `cancel()` rejects on a locked stream, which behaved the same way
before:

- `extensions/msteams/src/attachments/bot-framework.ts` — five sites: the two
  non-ok responses, the malformed and oversized `content-length` paths, and the
  `finally` that runs when saving the attachment view fails
- `extensions/msteams/src/attachments/download.ts` — the attempt the
  authenticated retry supersedes
- `extensions/msteams/src/attachments/remote-media.ts` — the `finally` after a
  failed direct save
- `extensions/msteams/src/graph.ts` — `deleteGraphRequest`
- `extensions/msteams/src/file-consent.ts` — the consent upload's status report

### Why this is one PR and not three

Repair scope here follows the violated invariant and its owning neighbourhood,
not the paths that happen to be reproducible offline. All nine sites are one statement of one
invariant inside one owner (the msteams extension; five files), and the state this PR starts from —
one file already non-awaiting, the rest still awaiting — is what a partial fix
produces. Splitting by "has a live capture" would land the same invariant in two
or three PRs and leave the extension inconsistent in between, which is the
condition being removed. The two sites outside the capture are not extra
hardening: they are the same statement, and each carries a regression that
states its before/after.

### Non-scope

- `src/media/fetch.ts` still awaits capture-sensitive cancels of its own
  (`discardIgnoredResponseBody`, the streaming `finally`). That is core media
  and a different owner. It matters for one route: when `saveResponseMedia`
  *rejects* a response — non-ok, or a declared length over the cap — it awaits
  its own cancel before returning, so `attachments/remote-media.ts` stalls
  inside core before ever reaching the `finally` this PR changes. That route
  stays affected. The route this PR does fix on that file is the other one: a
  storage or stream failure after the response is accepted, which is what its
  existing `cancels a guarded response when storage fails before reading the
  body` test covers.
- `src/plugin-sdk/fetch-runtime.ts` `responseWithRelease` still ties the
  transport release to the tee; see the known limitation below. That wrapper is
  what `attachments/bot-framework.ts` and `attachments/download.ts` receive
  through `safeFetchWithPolicy`, and what `graph.ts` receives through
  `requestGraph`. The other two sites do not go through it at all:
  `attachments/remote-media.ts` calls the supplied `fetchImpl` directly and
  `file-consent.ts` uses `fetchWithTimeout`, so for those the caller holds a
  plain response and there is no separate transport handle to release.
- The remaining awaited cancels in other extensions and owners.
- No `CHANGELOG.md` entry, per this repo's release policy that release
  generation owns that file.

## User Impact

With the debug proxy enabled, a stalled MS Teams remote no longer wedges the paths
that were only trying to throw away an unread body: `uploadToConsentUrl` reports
its HTTP status, `downloadMSTeamsAttachments` makes its next authenticated attempt instead of
stopping inside the loop, and the Bot Framework attachment paths return
instead of hanging on cleanup. Where the body is not a tee — no debug capture —
cancelling it settles immediately, so the change is not observable there.

What does not change is resource release: the transport behind a stalled
response is not released any sooner than before, for the reason set out under
"Known limitation: the guarded transport still waits on the tee". What changes
is that the operation reports its outcome.

## Evidence

## Real behavior proof

Behavior addressed: with the debug proxy enabled, three msteams paths that only wanted to
discard an unread body never settled when the remote stalled after one chunk: the consent
upload never reported its HTTP status, the Bot Framework attachment-info error path never
returned, and the attachment auth-retry loop never made its next authenticated attempt.
Real environment tested: Linux x86_64, node v24.18.0, baseline `a1d20ae31bc57e327747ed99493faaf86339ada9`, head `47b209e7b563ea2daf623d3cab1e936bd286e03f`

Exact steps or command run after this patch:

```sh
# The scenario harness imports these production modules from whichever side it runs in
# (process.cwd()), so the two runs differ only by the fix:
#   src/proxy-capture/runtime.ts
#   extensions/msteams/src/file-consent.ts
#   extensions/msteams/src/attachments/bot-framework.ts
#   extensions/msteams/src/attachments/download.ts
clawproof work start msteams-capture-tee-cancel --baseline a1d20ae31bc57e327747ed99493faaf86339ada9
git -C ~/.clawproof/work-items/msteams-capture-tee-cancel/after reset --hard 47b209e7b563ea2daf623d3cab1e936bd286e03f
clawproof build plan msteams-capture-tee-cancel --worktree before --apply
clawproof build plan msteams-capture-tee-cancel --worktree after --apply
clawproof prove msteams-capture-tee-cancel --scenario default --final --problem-file docs/work-items/msteams-capture-tee-cancel/proof/problem.md
ocw proof import msteams-capture-tee-cancel
```

Before (pre-fix):

```text
===== BEFORE (baseline a1d20ae31bc5, unfixed source) =====
--- harness.stderr ---
[harness: running consent-upload-rejected-stalled-body]
[harness: running consent-upload-rejected-complete-body]
[harness: running consent-upload-accepted]
[harness: running attachment-info-error-stalled-body]
[harness: running auth-retry-supersedes-stalled-attempt]
--- harness.stdout ---
{
  "modulesUnderTest": [
    "extensions/msteams/src/file-consent.ts",
    "extensions/msteams/src/attachments/bot-framework.ts",
    "extensions/msteams/src/attachments/download.ts"
  ],
  "capturePatch": "src/proxy-capture/runtime.ts",
  "results": [
    {
      "case": "consent-upload-rejected-stalled-body",
      "capturePatchInstalled": true,
      "settledWithinDeadlineMs": false,
      "deadlineMs": 3000,
      "outcome": "still-pending-at-deadline",
      "detail": null
    },
    {
      "case": "consent-upload-rejected-complete-body",
      "capturePatchInstalled": true,
      "settledWithinDeadlineMs": true,
      "deadlineMs": 3000,
      "outcome": "threw",
      "detail": "File upload to consent URL failed: 403 Forbidden"
    },
    {
      "case": "consent-upload-accepted",
      "capturePatchInstalled": true,
      "settledWithinDeadlineMs": true,
      "deadlineMs": 3000,
      "outcome": "returned",
      "detail": null
    },
    {
      "case": "attachment-info-error-stalled-body",
      "capturePatchInstalled": true,
      "settledWithinDeadlineMs": false,
      "deadlineMs": 3000,
      "outcome": "still-pending-at-deadline",
      "detail": null
    },
    {
      "case": "auth-retry-supersedes-stalled-attempt",
      "capturePatchInstalled": true,
      "settledWithinDeadlineMs": false,
      "deadlineMs": 3000,
      "outcome": "still-pending-at-deadline",
      "detail": null
    }
  ],
  "capturedResponseBodies": [
    "auth-retry-supersedes-stalled-attempt: {\"error\":\"notFound\"}",
    "consent-upload-accepted: {\"ok\":true}",
    "consent-upload-rejected-complete-body: {\"error\":\"accessDenied\"}"
  ]
}

```

Evidence after fix:

```text
===== AFTER (candidate 47b209e7b563, fix applied) =====
--- harness.stderr ---
[harness: running consent-upload-rejected-stalled-body]
[harness: running consent-upload-rejected-complete-body]
[harness: running consent-upload-accepted]
[harness: running attachment-info-error-stalled-body]
[harness: running auth-retry-supersedes-stalled-attempt]
--- harness.stdout ---
{
  "modulesUnderTest": [
    "extensions/msteams/src/file-consent.ts",
    "extensions/msteams/src/attachments/bot-framework.ts",
    "extensions/msteams/src/attachments/download.ts"
  ],
  "capturePatch": "src/proxy-capture/runtime.ts",
  "results": [
    {
      "case": "consent-upload-rejected-stalled-body",
      "capturePatchInstalled": true,
      "settledWithinDeadlineMs": true,
      "deadlineMs": 3000,
      "outcome": "threw",
      "detail": "File upload to consent URL failed: 403 Forbidden"
    },
    {
      "case": "consent-upload-rejected-complete-body",
      "capturePatchInstalled": true,
      "settledWithinDeadlineMs": true,
      "deadlineMs": 3000,
      "outcome": "threw",
      "detail": "File upload to consent URL failed: 403 Forbidden"
    },
    {
      "case": "consent-upload-accepted",
      "capturePatchInstalled": true,
      "settledWithinDeadlineMs": true,
      "deadlineMs": 3000,
      "outcome": "returned",
      "detail": null
    },
    {
      "case": "attachment-info-error-stalled-body",
      "capturePatchInstalled": true,
      "settledWithinDeadlineMs": true,
      "deadlineMs": 3000,
      "outcome": "returned",
      "detail": null
    },
    {
      "case": "auth-retry-supersedes-stalled-attempt",
      "capturePatchInstalled": true,
      "settledWithinDeadlineMs": true,
      "deadlineMs": 3000,
      "outcome": "returned",
      "detail": null
    }
  ],
  "capturedResponseBodies": [
    "auth-retry-supersedes-stalled-attempt: {\"error\":\"notFound\"}",
    "auth-retry-supersedes-stalled-attempt: {\"error\":\"notFound\"}",
    "consent-upload-accepted: {\"ok\":true}",
    "consent-upload-rejected-complete-body: {\"error\":\"accessDenied\"}"
  ]
}
```

Observed result after fix: all three defect cases settle inside the 3000 ms deadline —
`consent-upload-rejected-stalled-body` now throws `File upload to consent URL failed:
403 Forbidden`, and both attachment cases return. The attachment entry points do not
throw on a failed download by design — they log a warning and return a media result
marking the attachment unavailable — so `returned` with `detail: null` is their success
condition here; before the fix they produced neither that result nor an error. The two controls
(`consent-upload-rejected-complete-body`, `consent-upload-accepted`) settle on both sides,
which is what shows the stalled body — not the capture patch by itself — is the trigger.
The list of recorded response bodies is the second observation. An entry appears only
when the capture
branch read that exchange to EOF, and each is labelled with the case that produced it. The
stalled responses are absent from both sides, as they must be. The
`auth-retry-supersedes-stalled-attempt` entries are its *authenticated* attempts, which the
harness serves complete: one Before, two After. That difference is the retry loop itself —
Before it stalls on the superseded 401 inside the first iteration and never makes another
request; After it goes on to make a second authenticated one. The capture does not record
which scope each attempt asked for, so the claim here is the count, not the scope.
What was not tested: `graph.ts` (`deleteGraphRequest`) and `attachments/remote-media.ts` are
not in this capture — the first needs a real Graph endpoint, and the second reaches
`src/media/fetch.ts`, which still awaits capture-sensitive cancels of its own
(`discardIgnoredResponseBody`, the streaming `finally`). Those core sites belong to a
different owner and are deliberately left alone here, so the real rejection path through
core media stays affected until they are treated separately. Both files are covered by the
regressions instead. The post-submit ClawSweeper exact-head verdict is not evaluated locally.

### Reproducing this without the private wrapper

The commands above drive a private harness runner; the capture itself needs
nothing but a checkout at each SHA and the repo's own dev dependencies. From a
clean checkout:

```sh
pnpm install                  # tsx comes from the repo's devDependencies
```

Save the harness at the end of this description to any path outside the repo,
then run it once per side:

```sh
# The harness installs its own capture patch with an in-memory store. The guarded
# fetch path has a second capture entry point keyed off this variable that would
# use the real SQLite capture store, so the reproduction runs without it. An
# empty value is equivalent to unset here — the capture code treats only
# 1/true/yes/on as enabled — and the harness deletes the variable anyway.
git checkout a1d20ae31bc57e327747ed99493faaf86339ada9   # Before
OPENCLAW_DEBUG_PROXY_ENABLED= node --import tsx /path/to/harness.mjs

git checkout 47b209e7b563ea2daf623d3cab1e936bd286e03f   # After
OPENCLAW_DEBUG_PROXY_ENABLED= node --import tsx /path/to/harness.mjs
```

Before prints `still-pending-at-deadline` for the three defect cases and
`threw` / `returned` for the two controls. After prints a settled outcome for
all five. Both runs print the same two control results, which is the check that
the harness itself did not change between them.

It resolves every production module from `process.cwd()` and is never told which
side it is on, so the two runs differ only by this diff.

Each case installs the transport, then the capture patch, runs, and finalizes —
so the patch is torn down and reinstalled between cases. The install flag in each
case's result is read *after* the operation and is true for all five on both
sides, which says the patch was in place when the case finished. The stronger evidence that
the operations actually went *through* it is the list of recorded response
bodies in the capture above: only a patched fetch produces capture events at
all, and they arrive labelled with the case that produced them. Three of the
five cases produce entries on each side; the two whose only response is the
stalled one produce none, which is the point.

Two details about how it turns capture on. It calls the real
`initializeDebugProxyCapture` with an explicit settings object rather than
relying on the environment, so the patched global fetch — and therefore the
`response.clone()` tee — is exactly the production one, with an in-memory store
standing in for the SQLite capture store. It then clears
`OPENCLAW_DEBUG_PROXY_ENABLED`, because the guarded fetch path has a *second*
capture entry point keyed off that variable which would open the real store as
well. One tee is what the defect needs; two would only add a database
to the reproduction.

### How many transports can be held at once

The retry loop is the only place this PR lets more requests happen than before,
and it is bounded: `scopeCandidatesForUrl`
(`extensions/msteams/src/attachments/download.ts:118-132`) returns a two-element array of
*authentication scopes* on every branch, including its `catch`. Those are the
retries; they follow the one unauthenticated attempt that produced the 401 or
403 in the first place, so one
attachment makes at most one unauthenticated plus two authenticated attempts.
Before the fix a stalling remote stopped that loop inside its first iteration,
so the same operation made one authenticated attempt instead of two — the
difference is one extra request per attachment, not an unbounded retry.

Each of those responses holds its transport until its tee settles, exactly as
it did before; the count of held transports is the count of stalled responses,
which this PR does not change for any single attempt. There is no separate cap beyond the
per-request deadline that `resolveMSTeamsRequestTimeoutMs` hands each guarded
fetch; adding one belongs with `responseWithRelease` in
`src/plugin-sdk/fetch-runtime.ts`, which is where the release coupling lives. Worth stating plainly: this whole failure mode
requires debug capture to be on, which is an opt-in diagnostic mode rather than
the default path.

### Known limitation: the guarded transport still waits on the tee

This fix unblocks the caller; it does not release the transport any sooner.
`responseWithRelease` calls `release()` only after its own `reader.cancel()`
settles (`src/plugin-sdk/fetch-runtime.ts:81-85`), and a capture tee is exactly
what stops that from settling — so a stalled response leaves its guarded
dispatcher pinned either way. Measured against the real wrapper with a real
capture tee:

| | caller returned within 1s | transport released within 1s |
|---|---|---|
| `await body.cancel()` (before) | no | no |
| `void body.cancel()` (after) | yes | no |

That table is a direct measurement of `responseWithRelease` against a real
capture tee, with a one-second window. Separately, and at a different point, the
new regression in `extensions/msteams/src/graph.test.ts` asserts that the
release has not happened when `deleteGraphRequest` returns. So "the caller
returns without the transport being released" is pinned by a test, and "it is
still not released a second later" is the measurement. Releasing independently of the tee means changing
`responseWithRelease`, whose comment says the coordination is deliberate ("so
neither can release the transport early") — a core seam and a separate change.
The one behavioural consequence worth naming: because the retry loop no longer
stops, a remote that keeps stalling now gets more attempts, each bounded by the
existing per-request MS Teams deadline.

### Regressions

`node scripts/run-vitest.mjs extensions/msteams` — 91 files, 1395 tests pass.
Those counts and the reverted-run counts below are what those exact commands
print. The six new cases are
`releases a non-ok attachment info body without awaiting a debug-capture tee`,
`releases an attachment view body when saving fails without awaiting the tee`,
`retries past a superseded attempt without awaiting a debug-capture tee`,
`releases a guarded response without awaiting a debug-capture tee`,
`releases a bodyful DELETE response without awaiting a debug-capture tee` and
`reports the upload status without awaiting a debug-capture tee`. The production
delta is `+20 / -9` in `git diff --numstat` once the `*.test.ts` and
`*.test-helpers.ts` files are excluded.
Coverage per site:

| site | in the live capture | new tee regression |
|---|---|---|
| `bot-framework.ts` non-ok attachment info | yes | yes |
| `bot-framework.ts` save-failure `finally` | no | yes |
| `bot-framework.ts` non-ok attachment view | no | no — same statement, existing behaviour tests only |
| `bot-framework.ts` malformed `content-length` | no | no — same statement, existing behaviour tests only |
| `bot-framework.ts` oversized `content-length` | no | no — same statement, existing behaviour tests only |
| `download.ts` superseded auth attempt | yes | yes |
| `file-consent.ts` consent upload | yes | yes |
| `remote-media.ts` save-failure `finally` | no | yes — the storage-failure route only |
| `graph.ts` `deleteGraphRequest` | no | yes |

`remote-media.ts` and `graph.ts` are in the change for the same reason as the
rest — they awaited the same cancellation. Their regressions assert one thing
each: that the call **returns** while the capture clone is still live. The
"releases" in those test names follows the naming already used in these files
and means "issues the cancellation and stops waiting on it" — not that the
transport came back sooner. The `graph.ts` one asserts the opposite explicitly:
that the transport has *not* been released at that point.

The three sites with no dedicated tee regression are the identical one-line
statement in the same function as one that has one; they keep their existing
behaviour tests (`skips malformed attachment view content-length before saving
media`, `skips when attachment view size exceeds maxBytes`, `logs a warning on
non-ok attachmentInfo response`).

Six new regression cases across the five changed files:

| test file | case |
|---|---|
| `extensions/msteams/src/attachments/bot-framework.test.ts` | non-ok attachment info; attachment view save failure |
| `extensions/msteams/src/attachments.test.ts` | auth retry past a superseded stalled attempt |
| `extensions/msteams/src/attachments/remote-media.test.ts` | guarded response released on save failure |
| `extensions/msteams/src/graph.test.ts` | bodyful DELETE |
| `extensions/msteams/src/file-consent.test.ts` | rejected consent upload |

Reverting only the production files and rerunning the five touched test files.
This writes to the working tree, so do it in a scratch worktree:

```sh
git worktree add /tmp/tee-teeth-check HEAD && cd /tmp/tee-teeth-check
PROD="extensions/msteams/src/attachments/bot-framework.ts \
  extensions/msteams/src/attachments/download.ts \
  extensions/msteams/src/attachments/remote-media.ts \
  extensions/msteams/src/graph.ts extensions/msteams/src/file-consent.ts"
TESTS="extensions/msteams/src/file-consent.test.ts \
  extensions/msteams/src/attachments.test.ts \
  extensions/msteams/src/attachments/bot-framework.test.ts \
  extensions/msteams/src/attachments/remote-media.test.ts \
  extensions/msteams/src/graph.test.ts"
git checkout a1d20ae31bc57e327747ed99493faaf86339ada9 -- $PROD
node scripts/run-vitest.mjs $TESTS
git checkout HEAD -- $PROD
```

takes those files from 166 pass to 160 pass / 6 fail, and all six failures are
`did not settle`. Nothing else changes.

`extensions/msteams/src/capture-tee.test-helpers.ts` is test-only support code
imported solely by `*.test.ts` in this extension, following the existing
`attachments.test-helpers.ts` / `graph-messages.test-helpers.ts` convention. It
exists because `responseWithRelease` cancels through a reader rather than
through `stream.cancel`, so a regression that only stubs `stream.cancel` would
silently observe nothing; the helper instruments both. Production behaviour
changes by 9 statements plus their comments (+20 / -9).

<details>
<summary>Harness used for the capture</summary>

```js
// Before/after harness for the ClawProof lane.
//
// Drives the REAL msteams consent-upload, Bot Framework attachment and
// attachment auth-retry paths through the REAL debug proxy capture patch
// (src/proxy-capture/runtime.ts), which clones every http(s) response. The
// caller-facing body is then one branch of a live tee, and per WHATWG streams
// cancelling one branch settles only once both branches cancel or the source
// reaches EOF.
//
// The only thing faked is the remote: an in-process transport that emits
// headers plus one chunk and then stops without EOF, which is what a stalled
// server looks like. Everything from globalThis.fetch inward is production
// code: the capture patch, its bounded capture reader, fetchWithTimeout, the
// consent URL validation, safeFetchWithPolicy / fetchWithSsrFGuard, and the
// msteams entry points themselves.
//
// Contract with ClawProof: resolve every production module from process.cwd()
// and never learn which side we are on.

import { Buffer } from "node:buffer";
import path from "node:path";
import process from "node:process";
import { pathToFileURL } from "node:url";

const CAPTURE_RUNTIME = "src/proxy-capture/runtime.ts";
const FILE_CONSENT = "extensions/msteams/src/file-consent.ts";
const BOT_FRAMEWORK = "extensions/msteams/src/attachments/bot-framework.ts";
const ATTACHMENT_DOWNLOAD = "extensions/msteams/src/attachments/download.ts";
const MODULES_UNDER_TEST = [FILE_CONSENT, BOT_FRAMEWORK, ATTACHMENT_DOWNLOAD];

// Long enough that a settling cancellation always beats it, short enough that
// the stalled case still finishes inside the scenario timeout.
const DEADLINE_MS = 3_000;
const PUBLIC_ADDRESS = "13.107.136.10";
const CONSENT_URL = "https://contoso.sharepoint.com/sites/uploads/proof.bin";
const SERVICE_URL = "https://smba.trafficmanager.net/amer";
const MEDIA_HOST = "attachments.example.com";
const MEDIA_URL = `https://${MEDIA_HOST}/img.png`;

// The guarded paths capture twice when the debug-proxy env var is set: once
// through the patched global fetch below, and once through the guard's own
// captureGuardedFetchExchange, which uses the real SQLite capture store. One
// tee is enough to show the defect, so keep the harness off the store.
delete process.env.OPENCLAW_DEBUG_PROXY_ENABLED;

const note = (msg) => process.stderr.write(`[harness: ${msg}]\n`);
const load = async (rel) => await import(pathToFileURL(path.resolve(process.cwd(), rel)).href);
const encoder = new TextEncoder();

const capture = await load(CAPTURE_RUNTIME);
const fileConsent = await load(FILE_CONSENT);
const botFramework = await load(BOT_FRAMEWORK);
const attachmentDownload = await load(ATTACHMENT_DOWNLOAD);

/** Headers plus one chunk, then the remote stops. The stream never closes. */
function stalledResponse(status, statusText, body) {
  return new Response(
    new ReadableStream({
      start(controller) {
        controller.enqueue(encoder.encode(body));
      },
    }),
    { status, statusText, headers: { "content-type": "application/json" } },
  );
}

/** A complete response: the source reaches EOF, so a teed cancel can settle. */
function completeResponse(status, statusText, body) {
  return new Response(encoder.encode(body), {
    status,
    statusText,
    headers: { "content-type": "application/json" },
  });
}

function installTransport(respond) {
  globalThis.fetch = async (input, init) => respond(input, init);
}

/**
 * fetchWithSsrFGuard only calls an injected fetchImpl when that impl is not the
 * ambient global fetch (src/infra/net/fetch-guard.ts:645-659); otherwise it goes
 * to undici directly. Channel callers pass their own wrapper, so hand the guard
 * one too — it still lands on the patched global fetch, and therefore on the tee.
 */
const guardedFetch = (input, init) => globalThis.fetch(input, init);

// Which case a capture event belongs to. The store sees only the exchange, so
// without this the recorded bodies cannot be matched back to the case that
// produced them.
let activeCase = "none";

/** Records what the capture pipeline persisted, so the tee is observable. */
function createRecordingStore() {
  const events = [];
  return {
    events,
    upsertSession() {},
    endSession() {},
    recordEvent(event) {
      events.push({ ...event, case: activeCase });
    },
  };
}

async function settlesWithin(operation, deadlineMs) {
  let timer;
  const pending = Symbol("pending");
  const outcome = await Promise.race([
    operation.then(
      () => ({ state: "returned", detail: null }),
      (error) => ({
        state: "threw",
        detail: error instanceof Error ? error.message : String(error),
      }),
    ),
    new Promise((resolve) => {
      timer = setTimeout(() => resolve(pending), deadlineMs);
    }),
  ]);
  clearTimeout(timer);
  return outcome === pending
    ? { settled: false, outcome: "still-pending-at-deadline", detail: null }
    : { settled: true, outcome: outcome.state, detail: outcome.detail };
}

const captureSettings = {
  enabled: true,
  required: false,
  proxyUrl: undefined,
  dbPath: "",
  blobDir: "",
  certDir: "",
  sessionId: "clawproof-msteams-capture-tee",
  sourceProcess: "openclaw",
};

const store = createRecordingStore();
const captureDeps = {
  getStore: () => store,
  closeStore: () => {},
  // Keep the captured prefix on the event so the harness can show that the
  // capture branch really read bytes the caller never touched.
  persistEventPayload: (_store, payload) => ({
    bodyText: Buffer.isBuffer(payload.data)
      ? payload.data.toString("utf8")
      : String(payload.data ?? ""),
    contentType: payload.contentType,
  }),
};

const results = [];

async function runCase(name, respond, operation) {
  note(`running ${name}`);
  installTransport(respond);
  activeCase = name;
  capture.initializeDebugProxyCapture("clawproof-harness", captureSettings, captureDeps);
  const observed = await settlesWithin(operation(), DEADLINE_MS);
  results.push({
    case: name,
    capturePatchInstalled: capture.isDebugProxyGlobalFetchPatchInstalled(),
    settledWithinDeadlineMs: observed.settled,
    deadlineMs: DEADLINE_MS,
    outcome: observed.outcome,
    detail: observed.detail,
  });
  capture.finalizeDebugProxyCapture(captureSettings, captureDeps);
}

const consentUpload = () =>
  fileConsent.uploadToConsentUrl({
    url: CONSENT_URL,
    buffer: Buffer.from("proof payload"),
    contentType: "application/octet-stream",
    fetchFn: globalThis.fetch,
    validationOpts: { resolveFn: async () => ({ address: PUBLIC_ADDRESS }) },
  });

// 1. Defect case (file-consent.ts): the upload is rejected and its body is never
//    read, so the status report cancels a branch whose sibling is still blocked
//    on the stalled remote.
await runCase(
  "consent-upload-rejected-stalled-body",
  () => stalledResponse(403, "Forbidden", '{"error":"accessDenied"}'),
  consentUpload,
);

// 2. Control: the same rejection with a body that reaches EOF. The teed cancel
//    can settle, so this must work on both sides — it is what shows the stall,
//    not the capture patch alone, is the trigger.
await runCase(
  "consent-upload-rejected-complete-body",
  () => completeResponse(403, "Forbidden", '{"error":"accessDenied"}'),
  consentUpload,
);

// 3. Control: the accepted upload must keep reporting success.
await runCase(
  "consent-upload-accepted",
  () => completeResponse(200, "OK", '{"ok":true}'),
  consentUpload,
);

// 4. Defect case (attachments/bot-framework.ts): the attachment-info request
//    fails, so the error path cancels a body nobody read.
await runCase(
  "attachment-info-error-stalled-body",
  () => stalledResponse(500, "Internal Server Error", '{"error":"upstream"}'),
  () =>
    botFramework.downloadMSTeamsBotFrameworkAttachments({
      serviceUrl: SERVICE_URL,
      attachmentIds: ["att-1"],
      tokenProvider: { getAccessToken: async (scope) => `token:${scope}` },
      maxBytes: 10_000_000,
      fetchFn: guardedFetch,
      fetchFnSupportsDispatcher: true,
      resolveFn: async () => ({ address: PUBLIC_ADDRESS }),
    }),
);

// 5. Defect case (attachments/download.ts): the 401 that the authenticated
//    retry supersedes is the stalled one, so the retry loop itself stops.
await runCase(
  "auth-retry-supersedes-stalled-attempt",
  (_input, init) =>
    new Headers(init?.headers).has("Authorization")
      ? completeResponse(404, "Not Found", '{"error":"notFound"}')
      : stalledResponse(401, "Unauthorized", '{"error":"unauthorized"}'),
  () =>
    attachmentDownload.downloadMSTeamsAttachments({
      attachments: [{ contentType: "image/png", contentUrl: MEDIA_URL }],
      maxBytes: 1_000_000,
      tokenProvider: { getAccessToken: async (scope) => `token:${scope}` },
      allowHosts: [MEDIA_HOST],
      authAllowHosts: [MEDIA_HOST],
      fetchFn: guardedFetch,
      fetchFnSupportsDispatcher: true,
      resolveFn: async () => ({ address: PUBLIC_ADDRESS }),
    }),
);

// The capture reader is asynchronous; give the completed bodies time to land.
await new Promise((resolve) => setTimeout(resolve, 250));

// A recorded response body means the capture branch read that exchange to EOF.
// Sorted by case then body so the two runs stay comparable, and labelled so the
// counts can be matched back to the case that produced them.
const capturedResponseBodies = store.events
  .filter((event) => event.kind === "response" && typeof event.bodyText === "string")
  .map((event) => `${event.case}: ${event.bodyText}`)
  .toSorted();

process.stdout.write(
  `${JSON.stringify(
    {
      modulesUnderTest: MODULES_UNDER_TEST,
      capturePatch: CAPTURE_RUNTIME,
      results,
      capturedResponseBodies,
    },
    null,
    2,
  )}\n`,
);

// Abandoned cancellations keep promises pending forever by design; do not let
// that hold the process open past the report.
setTimeout(() => process.exit(0), 500);
```

</details>
