### PR TITLE
fix(tooling): prevent local tsgo checks from saturating CPUs

### DIFF
--- a/scripts/lib/local-heavy-check-runtime.mjs
+++ b/scripts/lib/local-heavy-check-runtime.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 
 const GIB = 1024 ** 3;
 const DEFAULT_LOCAL_GO_GC = "30";
+const DEFAULT_LOCAL_GO_MAX_PROCS = "1";
 const DEFAULT_LOCAL_GO_MEMORY_LIMIT = "3GiB";
 const DEFAULT_LOCAL_TSGO_BUILD_INFO_FILE = ".artifacts/tsgo-cache/root.tsbuildinfo";
 const DEFAULT_LOCK_TIMEOUT_MS = 10 * 60 * 1000;
@@ -141,6 +142,9 @@ export function applyLocalTsgoPolicy(args, env, hostResources) {
     insertBeforeSeparator(nextArgs, "--singleThreaded");
     insertBeforeSeparator(nextArgs, "--checkers", "1");
 
+    if (!nextEnv.GOMAXPROCS) {
+      nextEnv.GOMAXPROCS = DEFAULT_LOCAL_GO_MAX_PROCS;
+    }
     if (!nextEnv.GOGC) {
       nextEnv.GOGC = DEFAULT_LOCAL_GO_GC;
     }

--- a/test/scripts/local-heavy-check-runtime.test.ts
+++ b/test/scripts/local-heavy-check-runtime.test.ts
@@ -148,6 +148,7 @@ describe("local-heavy-check-runtime", () => {
       "--checkers",
       "1",
     ]);
+    expect(env.GOMAXPROCS).toBe("1");
     expect(env.GOGC).toBe("30");
     expect(env.GOMEMLIMIT).toBe("3GiB");
   });
@@ -162,6 +163,7 @@ describe("local-heavy-check-runtime", () => {
     const { args, env } = applyLocalTsgoPolicy(
       ["--checkers", "4", "--singleThreaded", "--pprofDir", "/tmp/existing"],
       makeEnv({
+        GOMAXPROCS: "3",
         GOGC: "80",
         GOMEMLIMIT: "5GiB",
         OPENCLAW_TSGO_PPROF_DIR: "/tmp/profile",
@@ -178,6 +180,7 @@ describe("local-heavy-check-runtime", () => {
       "--declaration",
       "false",
     ]);
+    expect(env.GOMAXPROCS).toBe("3");
     expect(env.GOGC).toBe("80");
     expect(env.GOMEMLIMIT).toBe("5GiB");
   });
@@ -201,6 +204,7 @@ describe("local-heavy-check-runtime", () => {
       "--tsBuildInfoFile",
       ".artifacts/tsgo-cache/root.tsbuildinfo",
     ]);
+    expect(env.GOMAXPROCS).toBeUndefined();
     expect(env.GOGC).toBeUndefined();
     expect(env.GOMEMLIMIT).toBeUndefined();
   });
@@ -253,6 +257,7 @@ describe("local-heavy-check-runtime", () => {
       "--checkers",
       "1",
     ]);
+    expect(env.GOMAXPROCS).toBe("1");
     expect(env.GOGC).toBe("30");
     expect(env.GOMEMLIMIT).toBe("3GiB");
   });
@@ -273,6 +278,7 @@ describe("local-heavy-check-runtime", () => {
       "--tsBuildInfoFile",
       ".artifacts/tsgo-cache/root.tsbuildinfo",
     ]);
+    expect(env.GOMAXPROCS).toBeUndefined();
     expect(env.GOGC).toBeUndefined();
     expect(env.GOMEMLIMIT).toBeUndefined();
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where constrained local `tsgo` checks could consume several CPU cores even though OpenClaw's local policy already selected `--singleThreaded --checkers 1`. On a 10-core, 16 GB maintainer host, one core-test typecheck sustained 484-566% CPU and contributed to Gateway event-loop starvation.

## Why This Change Was Made

The TypeScript flags serialize compiler work groups and checker instances, but they do not limit Go runtime and garbage-collector scheduling. This change defaults `GOMAXPROCS` to `1` inside the existing throttled local `tsgo` policy, while preserving explicit operator overrides and leaving full-speed mode unchanged.

The change stays at the `run-tsgo` resource-policy owner. Separate boundary-check orchestration retains its existing concurrency ownership.

## User Impact

Developers running local OpenClaw typechecks on constrained machines should no longer have one `tsgo` process monopolize several CPU cores and degrade the Gateway or other interactive workloads.

## Evidence

- Canonical base: `f3186b0876bcf4a1dae33be674bf6a3a9136966c`
- Exact head: `2977d8724134b6af2036e37b8a8042c2b0ee1f03`
- Before: one exact `tsgo` PID sustained 484-566% CPU with `--singleThreaded --checkers 1`.
- After: the same core-test graph reported `gomaxprocs=1`; five CPU samples stayed between 96% and 101%.
- Source-blind behavior validation:
  - constrained default: `gomaxprocs=1`
  - explicit `GOMAXPROCS=3`: remains `3`
  - full-speed mode: remains host default (`10`)
- `node scripts/run-vitest.mjs test/scripts/local-heavy-check-runtime.test.ts`: 35 passed
- Blacksmith Testbox `tbx_01kz894pnayym2wp7h7c3y3gtb`: `pnpm check:changed` passed
- Fresh scheduler A/B:
  - current main, forced throttled: `gomaxprocs=4` (https://github.com/openclaw/openclaw/actions/runs/30984248942)
  - exact PR head, forced throttled: `gomaxprocs=1`; explicit override: `3`; full mode: `4` (https://github.com/openclaw/openclaw/actions/runs/30984507173)
- Fresh focused Testbox proof: `test/scripts/local-heavy-check-runtime.test.ts` passed 35/35 (https://github.com/openclaw/openclaw/actions/runs/30984667515)
- Autoreview: no accepted or actionable findings

Punchcard-Session: clear-orchard-lantern-bc
