### PR TITLE
fix(cli): parse cron scratch --expected-revision as strict decimal

### DIFF
--- a/src/cli/cron-cli/register.cron-scratch.test.ts
+++ b/src/cli/cron-cli/register.cron-scratch.test.ts
@@ -1,0 +1,86 @@
+// Cron scratch register tests cover cron scratch command option validation.
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { defaultRuntime } from "../../runtime.js";
+
+const callGatewayFromCli = vi.fn();
+
+vi.mock("../gateway-rpc.js", async () => {
+  const actual = await vi.importActual<typeof import("../gateway-rpc.js")>("../gateway-rpc.js");
+  return {
+    ...actual,
+    callGatewayFromCli: (...args: Parameters<typeof actual.callGatewayFromCli>) =>
+      callGatewayFromCli(...args),
+  };
+});
+
+const { registerCronScratchCommand } = await import("./register.cron-scratch.js");
+
+function createCronProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+  registerCronScratchCommand(program);
+  return program;
+}
+
+describe("cron scratch command", () => {
+  beforeEach(() => {
+    callGatewayFromCli.mockReset();
+    callGatewayFromCli.mockImplementation(async (method: string) => {
+      if (method === "cron.scratch.get") {
+        return {
+          scratch: { content: "note", revision: 2, updatedAtMs: 1 },
+          currentRevision: 2,
+          maxBytes: 1024,
+        };
+      }
+      return { ok: true, scratch: null, currentRevision: 3, maxBytes: 1024 };
+    });
+  });
+
+  it.each(["0x2", "1e2", "2.5", "-1", "2a"])(
+    "rejects non-decimal --expected-revision %j",
+    async (revision) => {
+      const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
+      const exitSpy = vi
+        .spyOn(defaultRuntime, "exit")
+        .mockImplementation((() => undefined) as never);
+
+      try {
+        await createCronProgram().parseAsync(
+          ["scratch", "job-1", "--set", "x", "--expected-revision", revision],
+          { from: "user" },
+        );
+
+        expect(errorSpy).toHaveBeenCalledWith(
+          expect.stringContaining("--expected-revision must be a non-negative integer"),
+        );
+        const setCalls = callGatewayFromCli.mock.calls.filter(
+          ([method]) => method === "cron.scratch.set",
+        );
+        expect(setCalls).toHaveLength(0);
+      } finally {
+        errorSpy.mockRestore();
+        exitSpy.mockRestore();
+      }
+    },
+  );
+
+  it.each([
+    ["0", 0],
+    ["42", 42],
+  ])(
+    "passes decimal --expected-revision %j through to the CAS write",
+    async (revision, expectedRevision) => {
+      await createCronProgram().parseAsync(
+        ["scratch", "job-1", "--set", "x", "--expected-revision", revision],
+        { from: "user" },
+      );
+
+      const setCall = callGatewayFromCli.mock.calls.find(
+        ([method]) => method === "cron.scratch.set",
+      );
+      expect(setCall?.[2]).toMatchObject({ expectedRevision });
+    },
+  );
+});

--- a/src/cli/cron-cli/register.cron-scratch.ts
+++ b/src/cli/cron-cli/register.cron-scratch.ts
@@ -1,5 +1,6 @@
 // Cron scratch CLI: private per-job prompt context reads and compare-and-swap writes.
 import type { Command } from "commander";
+import { parseStrictNonNegativeInteger } from "../../infra/parse-finite-number.js";
 import { addGatewayClientOptions, callGatewayFromCli } from "../gateway-rpc.js";
 import { handleCronCliError, printCronJson } from "./shared.js";
 import { readCronScratchContent } from "./trigger-options.js";
@@ -18,8 +19,8 @@ function parseExpectedRevision(value: string | undefined): number | undefined {
   if (value === undefined) {
     return undefined;
   }
-  const revision = Number(value);
-  if (!Number.isSafeInteger(revision) || revision < 0) {
+  const revision = parseStrictNonNegativeInteger(value);
+  if (revision === undefined) {
     throw new Error("--expected-revision must be a non-negative integer");
   }
   return revision;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw cron scratch <id> --set ... --expected-revision <n>` accepted unsupported hexadecimal and scientific notation. `Number()` converted values such as `0x2` and `1e2` into decimal revisions `2` and `100`, so a conditional scratch update could target a numeric value supplied in unsupported non-decimal syntax instead of rejecting the input.

## Why This Change Was Made

The command now delegates revision parsing to the existing `parseStrictNonNegativeInteger` owner instead of maintaining a looser local parser. That keeps the CLI contract aligned with sibling integer options and preserves the Gateway's numeric compare-and-swap protocol.

This deliberately rejects non-decimal spellings that current code accepts. The scratch CLI first shipped only in `v2026.7.2-beta.4` through `v2026.7.2-beta.7`; the option is documented as an integer, and no supported example uses hexadecimal or scientific notation. Maintainer decision: accept this narrow beta compatibility change rather than preserve undocumented coercion.

## User Impact

Operators get a visible validation error for non-decimal revision syntax. Decimal revisions, including `0` and `42`, continue to perform the same compare-and-swap write.

Invalid input still performs the command's initial `cron.scratch.get` read. It is rejected locally after that read and before `cron.scratch.set`, so no CAS write occurs.

## Evidence

Exact reviewed head: `00ab8e12f099a3b0695897ceecd3a30d483f22e2`.

A fresh secretless AWS Crabbox run started a real isolated Gateway and exercised the real CLI against authoritative scratch state: [run evidence](https://crabbox.openclaw.ai/portal/runs/run_5dcd743132ef).

| Case | Before | CLI result | After |
|---|---|---|---|
| `0x2` | revision `2`, content `hex-baseline-2` | exit `1`; rejected before CAS write | revision `2`, identical content |
| `1e2` | revision `100`, content `sci-baseline-100` | exit `1`; rejected before CAS write | revision `100`, identical content |
| decimal `0` | revision `0`, no scratch row | exit `0`; CAS write succeeds | revision `1`, content `decimal-zero-write` |
| decimal `42` | revision `42`, content `forty-two-baseline-42` | exit `0`; CAS write succeeds | revision `43`, content `decimal-forty-two-write` |

Additional exact-head evidence:

- `src/cli/cron-cli/register.cron-scratch.test.ts`: seven focused command-level cases covering rejected non-decimal forms and preserved decimal values.
- [`openclaw/ci-gate`](https://github.com/openclaw/openclaw/actions/runs/30981341258/job/92229181339): passed on this head.
- Fresh autoreview against current `origin/main`: clean, no accepted/actionable findings.
- Production delta: `+3/-2` (`+1` net); tests: `+86`.

## Regression Provenance

The loose parser originated with the database-backed cron scratch feature in [#112967](https://github.com/openclaw/openclaw/pull/112967), squash commit [`3e2b3ea4d5ee`](https://github.com/openclaw/openclaw/commit/3e2b3ea4d5ee6f7d3e3e7c7b168a258ae4db57ba) on 2026-07-23. The later `b82a59a798` commit only reworded the command description and did not introduce the parser.
