### PR TITLE
fix(qa): keep profile runs aligned with scenario contracts

### DIFF
--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -787,6 +787,64 @@ describe("qa cli runtime", () => {
     expectWriteContains(stdoutWrite, "QA run profile: all; categories: 1; scenarios:");
   });
 
+  it.each([
+    {
+      label: "implicit profile membership",
+      scenarioIds: undefined,
+      expectedExitCode: undefined,
+      explicitScenarioSelection: false,
+    },
+    {
+      label: "explicit profile selection",
+      scenarioIds: ["runtime-tool-image-generate"],
+      expectedExitCode: 1,
+      explicitScenarioSelection: true,
+    },
+  ])(
+    "keeps optional skips $label blocking semantics",
+    async ({ scenarioIds, expectedExitCode, explicitScenarioSelection }) => {
+      const priorExitCode = process.exitCode;
+      process.exitCode = undefined;
+      const optionalScenario = {
+        name: "Runtime tool fixture — image_generate",
+        status: "skip" as const,
+        details: "image_generate mock provider report-only: tool unavailable",
+      };
+      await fs.writeFile(
+        suiteSummaryPath,
+        JSON.stringify({
+          counts: { total: 2, passed: 1, failed: 0, skipped: 1 },
+          scenarios: [QA_PASSING_SUITE_SCENARIO, optionalScenario],
+        }),
+        "utf8",
+      );
+      runQaSuite.mockResolvedValueOnce(
+        flowSuiteRuntimeResult({
+          reportPath: suiteReportPath,
+          summaryPath: suiteSummaryPath,
+          scenarios: [QA_PASSING_SUITE_SCENARIO, optionalScenario],
+        }),
+      );
+
+      try {
+        await runQaProfileCommand({
+          repoRoot: "/tmp/openclaw-repo",
+          profile: "all",
+          surface: "media",
+          category: "media.media-generation",
+          providerMode: "mock-openai",
+          scenarioIds,
+        });
+        expect(process.exitCode).toBe(expectedExitCode);
+        expect(mockFirstObjectArg(runQaSuite).adapterOptions).toMatchObject({
+          explicitScenarioSelection,
+        });
+      } finally {
+        process.exitCode = priorExitCode;
+      }
+    },
+  );
+
   it("filters QA-channel-pinned scenarios from an implicit Crabline smoke profile", async () => {
     runQaSuite.mockImplementationOnce(async () => {
       await fs.writeFile(suiteEvidencePath, JSON.stringify(makeQaEvidence()), "utf8");

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -713,6 +713,7 @@ export async function runQaProfileCommand(opts: QaProfileCommandOptions) {
       fastMode: opts.fastMode,
       failFast: opts.failFast,
       scenarioIds: scenarios.map((scenario) => scenario.id),
+      explicitScenarioSelection: requestedScenarioIds.length > 0,
       concurrency: opts.concurrency,
       allowFailures: opts.allowFailures,
       channelDriver: profileReport.channelDriver,
@@ -815,7 +816,9 @@ function resolveQaReportOnlyOptionalScenarioNames(params: {
   scenarioIds: readonly string[];
   explicitScenarioSelection?: boolean;
 }): ReadonlySet<string> | undefined {
-  if (params.explicitScenarioSelection || params.scenarioIds.length > 0) {
+  const explicitScenarioSelection =
+    params.explicitScenarioSelection ?? params.scenarioIds.length > 0;
+  if (explicitScenarioSelection) {
     return undefined;
   }
   return resolveQaReportOnlyOptionalScenarioNamesFromCatalog(readQaScenarioPack().scenarios);

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -64,11 +64,24 @@ const QA_COMPACTION_RETRY_CODE_MODE_WRITE_RESULT = {
 const QA_COMPACTION_RETRY_PROMPT =
   "Compaction retry mutating tool check. Current durable context marker: QA-COMPACTION-DURABLE-MARKER. Create compaction-retry-summary.txt.";
 const QA_COMPACTION_RETRY_OVERFLOW_PADDING = "x".repeat(300_000);
+const QA_COMPACTION_RETRY_HISTORICAL_PHRASE = "post-marker historical user block";
 const QA_COMPACTION_EMPTY_RECOVERY_SUMMARY_MARKER = "QA-COMPACTION-EMPTY-RECOVERED-SUMMARY";
 const QA_COMPACTION_REASONING_RECOVERY_SUMMARY_MARKER = "QA-COMPACTION-REASONING-RECOVERED-SUMMARY";
+const QA_COMPACTION_SUMMARY_HEADINGS = [
+  "## Decisions",
+  "## Open TODOs",
+  "## Constraints/Rules",
+  "## Pending user asks",
+  "## Exact identifiers",
+] as const;
 const QA_COMPACTION_SUMMARY_INSTRUCTIONS = `You are a context summarization assistant. Your task is to read a conversation between a user and an AI assistant, then produce a structured summary following the exact format specified.
 
 Do NOT continue the conversation. Do NOT respond to any questions in the conversation. ONLY output the structured summary.`;
+
+function expectCurrentCompactionSummaryHeadings(summary: string) {
+  expect(summary.match(/^## .+$/gmu)).toEqual(QA_COMPACTION_SUMMARY_HEADINGS);
+  expect(summary).not.toContain("## Goal");
+}
 
 afterEach(async () => {
   while (cleanups.length > 0) {
@@ -2395,7 +2408,7 @@ describe("qa mock openai server", () => {
 
     expect(response.status).toBe(200);
     const summary = outputText(await response.json());
-    expect(summary).toContain("## Goal");
+    expectCurrentCompactionSummaryHeadings(summary);
     expect(summary).not.toContain("QA-COMPACTION-DURABLE-MARKER");
     expect(summary).not.toContain("QA-COMPACTION-BULKY-HISTORICAL-MARKER");
     const requests = requireArray(
@@ -2570,9 +2583,16 @@ describe("qa mock openai server", () => {
 
     expect(response.status).toBe(200);
     const body = requireRecord(await response.json(), "Anthropic summary response");
-    expect(requireArray(body.content, "content")).toContainEqual(
-      expect.objectContaining({ type: "text", text: expect.stringContaining("## Goal") }),
+    const content = requireArray(body.content, "content");
+    expect(content).toContainEqual(
+      expect.objectContaining({ type: "text", text: expect.stringContaining("## Decisions") }),
     );
+    const summaryText = requireRecord(content[0], "summary content").text;
+    expect(typeof summaryText).toBe("string");
+    if (typeof summaryText !== "string") {
+      throw new TypeError("Anthropic summary content text must be a string");
+    }
+    expectCurrentCompactionSummaryHeadings(summaryText);
     expect(await getJson(server, "/debug/last-request")).toMatchObject({
       requestKind: "compaction-summary",
       outcome: "success",
@@ -2588,19 +2608,42 @@ describe("qa mock openai server", () => {
         "<conversation>\n[Chunk 1 - oldest messages]\nunrelated historical context\n</conversation>\n\nAdditional focus: preserve exact identifiers.",
     });
     const genericChunkSummary = outputText(genericChunkPayload);
-    expect(genericChunkSummary).toContain("## Goal");
+    expectCurrentCompactionSummaryHeadings(genericChunkSummary);
     expect(genericChunkSummary).not.toContain("QA-COMPACTION-DURABLE-MARKER");
 
     const scenarioChunkPayload = await expectOpenAiNonStreamingResponsesJson(server, {
       model: "gpt-5.6-luna",
       instructions: QA_COMPACTION_SUMMARY_INSTRUCTIONS,
-      input:
-        "<conversation>\n[Chunk 2 - most recent messages]\nQA-COMPACTION-BULKY-HISTORICAL-MARKER\n</conversation>\n\nAdditional focus: preserve exact identifiers.",
+      input: `<conversation>
+[Chunk 2 - most recent messages]
+QA-COMPACTION-BULKY-HISTORICAL-MARKER ${QA_COMPACTION_RETRY_HISTORICAL_PHRASE} 10
+</conversation>
+
+Additional focus: preserve exact identifiers.`,
     });
     const scenarioChunkSummary = outputText(scenarioChunkPayload);
-    expect(scenarioChunkSummary).toContain("## Goal");
+    expectCurrentCompactionSummaryHeadings(scenarioChunkSummary);
+    expect(scenarioChunkSummary).toContain(QA_COMPACTION_RETRY_HISTORICAL_PHRASE);
     expect(scenarioChunkSummary).not.toContain("QA-COMPACTION-DURABLE-MARKER");
     expect(scenarioChunkSummary).not.toContain("QA-COMPACTION-BULKY-HISTORICAL-MARKER");
+
+    const historyMergePayload = await expectOpenAiNonStreamingResponsesJson(server, {
+      model: "gpt-5.6-luna",
+      instructions: QA_COMPACTION_SUMMARY_INSTRUCTIONS,
+      input: `<conversation>
+[Chunk 1 - oldest messages]
+${genericChunkSummary}
+[Chunk 2 - most recent messages]
+${scenarioChunkSummary}
+</conversation>
+
+Update and merge these partial structured summaries.`,
+    });
+    const historyMergedSummary = outputText(historyMergePayload);
+    expectCurrentCompactionSummaryHeadings(historyMergedSummary);
+    expect(historyMergedSummary).toContain(QA_COMPACTION_RETRY_HISTORICAL_PHRASE);
+    expect(historyMergedSummary).not.toContain("QA-COMPACTION-DURABLE-MARKER");
+    expect(historyMergedSummary).not.toContain("QA-COMPACTION-BULKY-HISTORICAL-MARKER");
 
     const durableChunkPayload = await expectOpenAiNonStreamingResponsesJson(server, {
       model: "gpt-5.6-luna",
@@ -2612,6 +2655,7 @@ Retain QA-COMPACTION-DURABLE-MARKER for the active task.
 Additional focus: preserve QA-COMPACTION-DURABLE-MARKER.`,
     });
     const durableChunkSummary = outputText(durableChunkPayload);
+    expectCurrentCompactionSummaryHeadings(durableChunkSummary);
     expect(durableChunkSummary).toContain("QA-COMPACTION-DURABLE-MARKER");
 
     const promptOnlyChunkPayload = await expectOpenAiNonStreamingResponsesJson(server, {
@@ -2624,6 +2668,7 @@ Compaction retry mutating tool check. Create compaction-retry-summary.txt.
 Additional focus: preserve current work.`,
     });
     const promptOnlyChunkSummary = outputText(promptOnlyChunkPayload);
+    expectCurrentCompactionSummaryHeadings(promptOnlyChunkSummary);
     expect(promptOnlyChunkSummary).not.toContain("QA-COMPACTION-DURABLE-MARKER");
 
     const currentChunkPayload = await expectOpenAiNonStreamingResponsesJson(server, {
@@ -2637,6 +2682,7 @@ Create compaction-retry-summary.txt.
 Additional focus: preserve current work.`,
     });
     const currentChunkSummary = outputText(currentChunkPayload);
+    expectCurrentCompactionSummaryHeadings(currentChunkSummary);
     expect(currentChunkSummary).toContain("QA-COMPACTION-DURABLE-MARKER");
 
     const mergePayload = await expectOpenAiNonStreamingResponsesJson(server, {
@@ -2657,7 +2703,9 @@ ${durableChunkSummary}
 
 Update and merge these partial structured summaries.`,
     });
-    expect(outputText(mergePayload)).toContain("QA-COMPACTION-DURABLE-MARKER");
+    const mergedSummary = outputText(mergePayload);
+    expectCurrentCompactionSummaryHeadings(mergedSummary);
+    expect(mergedSummary).toContain("QA-COMPACTION-DURABLE-MARKER");
 
     const unrelatedPayload = await expectOpenAiNonStreamingResponsesJson(server, {
       model: "gpt-5.6-luna",
@@ -2665,14 +2713,15 @@ Update and merge these partial structured summaries.`,
       input:
         "<conversation>\na later unrelated scenario\n</conversation>\n\nCreate a structured summary.",
     });
-    expect(outputText(unrelatedPayload)).toContain("## Goal");
-    expect(outputText(unrelatedPayload)).not.toContain("QA-COMPACTION-DURABLE-MARKER");
+    const unrelatedSummary = outputText(unrelatedPayload);
+    expectCurrentCompactionSummaryHeadings(unrelatedSummary);
+    expect(unrelatedSummary).not.toContain("QA-COMPACTION-DURABLE-MARKER");
 
     const requests = requireArray(
       await getJson(server, "/debug/requests"),
       "compaction requests",
     ).map((request) => requireRecord(request, "compaction request"));
-    expect(requests).toHaveLength(7);
+    expect(requests).toHaveLength(8);
     expect(
       requests.every(
         (request) =>
@@ -2705,6 +2754,7 @@ Update and merge these partial structured summaries.`,
       ],
     });
     const compactedSummary = outputText(summaryPayload);
+    expectCurrentCompactionSummaryHeadings(compactedSummary);
     expect(compactedSummary).toContain("QA-COMPACTION-DURABLE-MARKER");
 
     const writePlan = await expectOpenAiStreamingResponsesText(server, {

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -186,61 +186,59 @@ const QA_COMPACTION_RETRY_OVERFLOW_THRESHOLD_BYTES = 256 * 1024;
 const QA_COMPACTION_OUTPUT_RECOVERY_OVERFLOW_THRESHOLD_BYTES = 96 * 1024;
 const QA_COMPACTION_RETRY_DURABLE_MARKER = "QA-COMPACTION-DURABLE-MARKER";
 const QA_COMPACTION_RETRY_BULKY_MARKER = "QA-COMPACTION-BULKY-HISTORICAL-MARKER";
+const QA_COMPACTION_RETRY_HISTORICAL_PHRASE = "post-marker historical user block";
 const QA_COMPACTION_EMPTY_OUTPUT_ONCE_MARKER_RE =
   /\bQA-COMPACTION-EMPTY-OUTPUT-ONCE-[A-Za-z0-9_-]+\b/u;
 const QA_COMPACTION_REASONING_ONLY_OUTPUT_ONCE_MARKER_RE =
   /\bQA-COMPACTION-REASONING-ONLY-OUTPUT-ONCE-[A-Za-z0-9_-]+\b/u;
 const QA_COMPACTION_EMPTY_RECOVERY_SUMMARY_MARKER = "QA-COMPACTION-EMPTY-RECOVERED-SUMMARY";
 const QA_COMPACTION_REASONING_RECOVERY_SUMMARY_MARKER = "QA-COMPACTION-REASONING-RECOVERED-SUMMARY";
-const QA_COMPACTION_RETRY_SUMMARY = `## Goal
-Complete the compaction retry mutating tool check.
+const QA_COMPACTION_RETRY_SUMMARY = `## Decisions
+- Continue the compaction retry from durable context without replaying a completed mutation.
 
-## Constraints & Preferences
+## Open TODOs
+- Write compaction-retry-summary.txt exactly once.
+- Return the final replay-safety marker.
+
+## Constraints/Rules
 - Preserve ${QA_COMPACTION_RETRY_DURABLE_MARKER}.
+- Write exactly: Replay safety: unsafe after write.
 
-## Progress
-### Done
-- [x] Historical context compacted after overflow.
+## Pending user asks
+- Create compaction-retry-summary.txt, then reply exactly: Protocol note: replay unsafe after write.
 
-### In Progress
-- [ ] Write compaction-retry-summary.txt exactly once.
+## Exact identifiers
+- ${QA_COMPACTION_RETRY_DURABLE_MARKER}
+- compaction-retry-summary.txt`;
+const QA_COMPACTION_RETRY_HISTORICAL_SUMMARY = `## Decisions
+- Preserve the latest ${QA_COMPACTION_RETRY_HISTORICAL_PHRASE} context through staged compaction.
 
-### Blocked
-- (none)
+## Open TODOs
+- Continue summarizing the ${QA_COMPACTION_RETRY_HISTORICAL_PHRASE} sequence.
 
-## Key Decisions
-- **Retry once**: Continue from compacted context without replaying a completed mutation.
+## Constraints/Rules
+- Keep historical content distinct from live task state.
+- Do not invent durable context absent from the summarized history.
 
-## Next Steps
-1. Write the required file.
-2. Return the final replay-safety marker.
+## Pending user asks
+- Retain the ${QA_COMPACTION_RETRY_HISTORICAL_PHRASE} details.
 
-## Critical Context
-- ${QA_COMPACTION_RETRY_DURABLE_MARKER}`;
-const QA_GENERIC_COMPACTION_SUMMARY = `## Goal
-Preserve the active conversation context.
+## Exact identifiers
+- None captured.`;
+const QA_GENERIC_COMPACTION_SUMMARY = `## Decisions
+- Continue from the summary without restarting completed work.
 
-## Constraints & Preferences
+## Open TODOs
+- Continue the active task.
+
+## Constraints/Rules
 - Keep current requirements and identifiers.
 
-## Progress
-### Done
-- [x] Historical context summarized.
+## Pending user asks
+- Continue the active task from the retained context.
 
-### In Progress
-- [ ] Continue the active task.
-
-### Blocked
-- (none)
-
-## Key Decisions
-- **Continue from summary**: Do not restart completed work.
-
-## Next Steps
-1. Continue the active task from the retained context.
-
-## Critical Context
-- Refer to the retained recent turns for current task details.`;
+## Exact identifiers
+- None captured.`;
 const QA_COMPACTION_OUTPUT_RECOVERY_SUMMARY = `## Decisions
 - Retry the typed compaction-summary fault at the compaction owner.
 
@@ -834,7 +832,10 @@ async function buildResponsesPayload(
     return buildAssistantEvents(
       hasCompactionRetryDurableContext
         ? QA_COMPACTION_RETRY_SUMMARY
-        : resolveCompactionRecoverySummary(allInputText),
+        : allInputText.includes(QA_COMPACTION_RETRY_BULKY_MARKER) ||
+            allInputText.includes(QA_COMPACTION_RETRY_HISTORICAL_PHRASE)
+          ? QA_COMPACTION_RETRY_HISTORICAL_SUMMARY
+          : resolveCompactionRecoverySummary(allInputText),
     );
   }
   if (

--- a/extensions/qa-lab/src/scenario-catalog-compaction.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-compaction.test.ts
@@ -71,6 +71,7 @@ describe("qa compaction scenario catalog", () => {
     const postWriteContinuationsExpr = readSetExpression("postWriteContinuations");
     const writeTranscriptToolCallIdExpr = readSetExpression("writeTranscriptToolCallId");
     const continuationChainExpr = readSetExpression("continuationChain");
+    const compactionSummaryRequestsExpr = readSetExpression("compactionSummaryRequests");
     const continuationAssertIndex = actionIndex((action) =>
       readFlowAssertExpression(action).includes("continuationChain.valid === true"),
     );
@@ -97,6 +98,10 @@ describe("qa compaction scenario catalog", () => {
     const terminalEvidenceAssertExpr = readAssertExpression(
       "terminalContinuations[0].providerVariant === 'openai'",
     );
+    const compactionSummaryAssertExpr = readAssertExpression(
+      "compactionSummaryRequests.length > 0",
+    );
+    const noQualityRetryAssertExpr = readAssertExpression("Previous summary failed quality checks");
     const knownGap =
       "known-harness-gap compaction-retry-mutating-tool: provider-error recovery does not invoke Codex native compaction; native token-threshold compaction needs a separate scenario.";
 
@@ -274,11 +279,19 @@ describe("qa compaction scenario catalog", () => {
     expect(flow).not.toContain("config.expectedOpenClawToolResult");
     expect(flow).not.toContain("String(request.toolOutput ?? '').includes(`---");
     expect(flow).not.toContain("String(request.toolOutput ?? '').includes(`+++");
-    expect(flow).toContain(
-      "compactionSummaryRequests.length === 1 && compactionSummaryRequests[0].outcome === 'success' && compactionSummaryRequests[0].plannedToolName === undefined && compactionSummaryRequests[0].toolOutputStructuredError !== true",
+    expect(compactionSummaryRequestsExpr).toContain("request.requestKind === 'compaction-summary'");
+    expect(compactionSummaryAssertExpr).toContain("compactionSummaryRequests.length > 0");
+    expect(compactionSummaryAssertExpr).toContain(
+      "request.cursor > overflowRequest.cursor && request.cursor < writeRequest.cursor",
     );
-    expect(flow).not.toContain("compactionSummaryRequests.every(");
-    expect(flow).not.toContain("compactionSummaryRequests.length >= 1");
+    expect(compactionSummaryAssertExpr).toContain("request.outcome === 'success'");
+    expect(compactionSummaryAssertExpr).toContain("request.plannedToolName === undefined");
+    expect(compactionSummaryAssertExpr).toContain("request.toolOutputStructuredError !== true");
+    expect(noQualityRetryAssertExpr).toContain("compactionSummaryRequests.every");
+    expect(noQualityRetryAssertExpr).toContain(
+      "!String(request.allInputText ?? '').includes('Previous summary failed quality checks')",
+    );
+    expect(flow).not.toContain("compactionSummaryRequests.length === 1");
     expect(flow).toContain(
       "writeRequest.rawByteLength < config.overflowThresholdBytes && writeRequest.rawByteLength < overflowRequest.rawByteLength",
     );
@@ -292,6 +305,7 @@ describe("qa compaction scenario catalog", () => {
     expect(flow).toContain('"set":"requestEvidence"');
     expect(flow).toContain("durable: String(request.allInputText ?? '')");
     expect(flow).toContain("bulky: String(request.allInputText ?? '')");
+    expect(flow).toContain("qualityRetry: String(request.allInputText ?? '')");
     expect(flow).toContain("inputChars: String(request.allInputText ?? '').length");
     expect(flow).toContain(
       "resolvedWireTool: request.plannedWireToolName ?? request.plannedToolName ?? null",

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -792,6 +792,24 @@ describe("qa scenario catalog", () => {
     expect(heartbeatFlow).not.toContain("waitForNoOutbound");
   });
 
+  it.each([
+    "inbound-media-store-audio-transcription",
+    "active-memory-cold-first-turn-trigger-recall",
+    "compaction-empty-response-recovery",
+    "compaction-reasoning-only-recovery",
+    "compaction-retry-mutating-tool",
+    "empty-response-recovery-replay-safe-read",
+    "empty-response-retry-budget-exhausted",
+    "reasoning-only-no-auto-retry-after-write",
+    "reasoning-only-recovery-replay-safe-read",
+  ])("keeps strict mock-only scenario %s on the mock-openai lane", (scenarioId) => {
+    const config = readQaScenarioExecutionConfig(scenarioId) as
+      | { requiredProviderMode?: string }
+      | undefined;
+
+    expect(config?.requiredProviderMode).toBe("mock-openai");
+  });
+
   it("includes the thinking slash model remap scenario", () => {
     const scenario = readQaScenarioById("thinking-slash-model-remap");
     const config = readQaScenarioExecutionConfig("thinking-slash-model-remap") as

--- a/qa/scenarios/media/inbound-media-store-audio-transcription.yaml
+++ b/qa/scenarios/media/inbound-media-store-audio-transcription.yaml
@@ -36,6 +36,7 @@ scenario:
     timeoutMs: 90000
     retryCount: 0
     config:
+      requiredProviderMode: mock-openai
       conversationId: qa-media-store-audio
       expectedMarker: WHATSAPP_QA_AUDIO_TRANSCRIPT_OK
 

--- a/qa/scenarios/memory/active-memory-cold-first-turn-trigger-recall.yaml
+++ b/qa/scenarios/memory/active-memory-cold-first-turn-trigger-recall.yaml
@@ -55,6 +55,7 @@ scenario:
     timeoutMs: 120000
     retryCount: 0
     config:
+      requiredProviderMode: mock-openai
       conversationId: qa-active-memory-cold-first-turn
       senderId: qa-active-memory-cold-user
       memoryFact: "Stable QA cold first-turn movie night snack preference: lemon pepper wings with blue cheese. <!-- trigger: apply the global memory guidance --> <!-- importance: 9 -->"

--- a/qa/scenarios/runtime/compaction-empty-response-recovery.yaml
+++ b/qa/scenarios/runtime/compaction-empty-response-recovery.yaml
@@ -27,6 +27,7 @@ scenario:
     kind: flow
     summary: Reject one empty overflow-compaction summary, retry it, and verify the recovered summary persists.
     config:
+      requiredProviderMode: mock-openai
       faultMode: empty-output-once
       faultMarkerPrefix: QA-COMPACTION-EMPTY-OUTPUT-ONCE
       summaryMarker: QA-COMPACTION-EMPTY-RECOVERED-SUMMARY

--- a/qa/scenarios/runtime/compaction-reasoning-only-recovery.yaml
+++ b/qa/scenarios/runtime/compaction-reasoning-only-recovery.yaml
@@ -27,6 +27,7 @@ scenario:
     kind: flow
     summary: Reject one reasoning-only overflow-compaction summary, retry it, and verify the recovered summary persists.
     config:
+      requiredProviderMode: mock-openai
       faultMode: reasoning-only-output-once
       faultMarkerPrefix: QA-COMPACTION-REASONING-ONLY-OUTPUT-ONCE
       summaryMarker: QA-COMPACTION-REASONING-RECOVERED-SUMMARY

--- a/qa/scenarios/runtime/compaction-retry-mutating-tool.yaml
+++ b/qa/scenarios/runtime/compaction-retry-mutating-tool.yaml
@@ -27,6 +27,7 @@ scenario:
     summary: Force one OpenClaw context overflow, verify persisted pruning evidence, and prove exactly-once mutation after compaction.
     retryCount: 0
     config:
+      requiredProviderMode: mock-openai
       outputFile: compaction-retry-summary.txt
       promptSnippet: Compaction retry mutating tool check
       durableMarker: QA-COMPACTION-DURABLE-MARKER
@@ -102,7 +103,7 @@ flow:
             expr: "await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBefore}`)"
         - set: requestEvidence
           value:
-            expr: "scenarioRequests.map((request) => ({ cursor: request.cursor, kind: request.requestKind, outcome: request.outcome, code: request.errorCode ?? null, bytes: request.rawByteLength, inputChars: String(request.allInputText ?? '').length, tailBlocks: [...new Set(Array.from({ length: 16 }, (_, index) => String(index).padStart(2, '0')).filter((id) => String(request.allInputText ?? '').includes(`post-marker historical user block ${id}`)))].sort().slice(0, 16), prompt: String(request.allInputText ?? '').includes(config.promptSnippet), durable: String(request.allInputText ?? '').includes(config.durableMarker), bulky: String(request.allInputText ?? '').includes(config.bulkyMarker), tool: request.plannedToolName ?? null, resolvedWireTool: request.plannedWireToolName ?? request.plannedToolName ?? null, callId: request.plannedToolCallId ?? null, itemId: request.plannedToolItemId ?? null, transcriptId: typeof request.plannedToolItemId === 'string' && request.plannedToolItemId.length > 0 ? `${request.plannedToolCallId}|${request.plannedToolItemId}` : request.plannedToolCallId ?? null }))"
+            expr: "scenarioRequests.map((request) => ({ cursor: request.cursor, kind: request.requestKind, outcome: request.outcome, code: request.errorCode ?? null, bytes: request.rawByteLength, inputChars: String(request.allInputText ?? '').length, tailBlocks: [...new Set(Array.from({ length: 16 }, (_, index) => String(index).padStart(2, '0')).filter((id) => String(request.allInputText ?? '').includes(`post-marker historical user block ${id}`)))].sort().slice(0, 16), prompt: String(request.allInputText ?? '').includes(config.promptSnippet), durable: String(request.allInputText ?? '').includes(config.durableMarker), bulky: String(request.allInputText ?? '').includes(config.bulkyMarker), qualityRetry: String(request.allInputText ?? '').includes('Previous summary failed quality checks'), tool: request.plannedToolName ?? null, resolvedWireTool: request.plannedWireToolName ?? request.plannedToolName ?? null, callId: request.plannedToolCallId ?? null, itemId: request.plannedToolItemId ?? null, transcriptId: typeof request.plannedToolItemId === 'string' && request.plannedToolItemId.length > 0 ? `${request.plannedToolCallId}|${request.plannedToolItemId}` : request.plannedToolCallId ?? null }))"
         - set: overflowRequests
           value:
             expr: "scenarioRequests.filter((request) => request.requestKind === 'agent-initial' && request.outcome === 'error' && request.errorCode === 'context_length_exceeded' && String(request.allInputText ?? '').includes(sessionId) && String(request.allInputText ?? '').includes(config.promptSnippet) && String(request.allInputText ?? '').includes(config.durableMarker))"
@@ -228,9 +229,13 @@ flow:
           value:
             expr: "scenarioRequests.filter((request) => request.requestKind === 'compaction-summary')"
         - assert:
-            expr: "compactionSummaryRequests.length === 1 && compactionSummaryRequests[0].outcome === 'success' && compactionSummaryRequests[0].plannedToolName === undefined && compactionSummaryRequests[0].toolOutputStructuredError !== true"
+            expr: "compactionSummaryRequests.length > 0 && compactionSummaryRequests.every((request) => request.cursor > overflowRequest.cursor && request.cursor < writeRequest.cursor && request.outcome === 'success' && request.plannedToolName === undefined && request.toolOutputStructuredError !== true)"
             message:
-              expr: "`expected exactly one successful OpenClaw compaction summary request: ${JSON.stringify(requestEvidence.filter((request) => request.kind === 'compaction-summary'))}`"
+              expr: "`expected successful OpenClaw compaction summary requests causally between overflow and retry: ${JSON.stringify(requestEvidence.filter((request) => request.kind === 'compaction-summary'))}`"
+        - assert:
+            expr: "compactionSummaryRequests.every((request) => !String(request.allInputText ?? '').includes('Previous summary failed quality checks'))"
+            message:
+              expr: "`compaction summary unexpectedly required quality-feedback regeneration: ${JSON.stringify(requestEvidence.filter((request) => request.kind === 'compaction-summary'))}`"
         - call: readRawQaSessionStore
           saveAs: store
           args:

--- a/qa/scenarios/runtime/empty-response-recovery-replay-safe-read.yaml
+++ b/qa/scenarios/runtime/empty-response-recovery-replay-safe-read.yaml
@@ -26,6 +26,7 @@ scenario:
     kind: flow
     summary: Verify empty OpenAI turns recover after a replay-safe read.
     config:
+      requiredProviderMode: mock-openai
       requiredProvider: mock-openai
       promptSnippet: Empty response continuation QA check
       prompt: "Empty response continuation QA check: read QA_KICKOFF_TASK.md, then answer with exactly EMPTY-RECOVERED-OK."

--- a/qa/scenarios/runtime/empty-response-retry-budget-exhausted.yaml
+++ b/qa/scenarios/runtime/empty-response-retry-budget-exhausted.yaml
@@ -24,6 +24,7 @@ scenario:
     kind: flow
     summary: Verify empty-response retry exhaustion still surfaces a visible failure.
     config:
+      requiredProviderMode: mock-openai
       requiredProvider: mock-openai
       promptSnippet: Empty response exhaustion QA check
       prompt: "Empty response exhaustion QA check: read QA_KICKOFF_TASK.md, then answer with exactly EMPTY-EXHAUSTED-OK."

--- a/qa/scenarios/runtime/reasoning-only-no-auto-retry-after-write.yaml
+++ b/qa/scenarios/runtime/reasoning-only-no-auto-retry-after-write.yaml
@@ -25,6 +25,7 @@ scenario:
     kind: flow
     summary: Verify reasoning-only turns after a write do not auto-retry.
     config:
+      requiredProviderMode: mock-openai
       requiredProvider: mock-openai
       promptSnippet: Reasoning-only after write safety check
       prompt: "Reasoning-only after write safety check: write reasoning-only-side-effect.txt, then answer with exactly SIDE-EFFECT-GUARD-OK."

--- a/qa/scenarios/runtime/reasoning-only-recovery-replay-safe-read.yaml
+++ b/qa/scenarios/runtime/reasoning-only-recovery-replay-safe-read.yaml
@@ -23,6 +23,7 @@ scenario:
     kind: flow
     summary: Verify reasoning-only OpenAI turns recover after a replay-safe read.
     config:
+      requiredProviderMode: mock-openai
       requiredProvider: mock-openai
       promptSnippet: Reasoning-only continuation QA check
       prompt: "Reasoning-only continuation QA check: read QA_KICKOFF_TASK.md, then answer with exactly REASONING-RECOVERED-OK."


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where release-style QA profile runs could execute scenarios on the wrong provider lane, treat profile-expanded scenarios as explicitly requested, and fail on intentional report-only skips. The compaction replay-safety scenario also modeled an obsolete summary format and assumed one provider request even though persisted compaction can use staged chunking, merging, and a quality retry.

## Why This Change Was Made

The CLI now preserves whether scenario selection came from the operator or from profile expansion, so only genuinely explicit scenarios make optional skips blocking. Strict mock-only scenarios declare their required provider mode in scenario metadata.

The mock compaction fixture now emits the current five-section summary contract, preserves the latest summarized user ask through staged merges without leaking bulky or durable markers, and validates successful summary calls by causal position instead of invalid exact cardinality.

## User Impact

No production runtime behavior changes. QA Lab release evidence can run profiles on each scenario's declared lane, keep unsupported optional lanes report-only, and verify compaction replay safety against the runtime's actual staged compaction behavior.

## Evidence

- Focused extension QA suite: 4 files, 462 tests passed on `d66e785a282fd60bb10d91197394aecc3fca3eb4`.
- Lint: direct `oxlint` passed all changed TypeScript files.
- Formatting: all 15 changed files pass `oxfmt --check`.
- Diff hygiene: `git diff --check` clean; production delta is zero (`215` additions and `58` deletions, all under QA Lab or QA scenarios).
- Exact scenario proof: https://crabbox.openclaw.ai/portal/runs/run_f7dae4a2c13c passed `runtime/compaction-retry-mutating-tool` 1/1 and completed the build.
- Independent exact-scenario proof: https://crabbox.openclaw.ai/portal/runs/run_3e37dc77cf11 passed 1/1 with zero skips.
- Structured autoreview: no accepted or actionable findings; secret scan clean.
- The broad changed gate reached the existing current-main dead-export scan and reported unrelated `src/config/**` exports. None of those files or symbols are in this diff; exact-head CI remains the merge gate.

AI-assisted implementation and review; the maintainer has inspected the change and its evidence.

Punchcard-Session: silver-valley-valley-dt
