### PR TITLE
fix(cron): remove deleted job sessions

### DIFF
--- a/src/cron/active-jobs.test.ts
+++ b/src/cron/active-jobs.test.ts
@@ -1,5 +1,5 @@
 // Unit coverage for the active-job accounting the heartbeat busy guard depends on.
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   clearCronJobActive,
   hasActiveCronJobs,
@@ -8,6 +8,7 @@ import {
   noteActiveCronJobRemoval,
   noteActiveCronJobScheduleMutation,
   noteActiveCronJobTriggerMutation,
+  onCronJobInactive,
   resetCronActiveJobs,
 } from "./active-jobs.js";
 
@@ -50,6 +51,19 @@ describe("hasActiveCronJobsExceptMarker", () => {
 });
 
 describe("active cron schedule ownership", () => {
+  it("notifies only the removed marker when a same-id run replaces it", () => {
+    const removedMarker = markCronJobActive("reused-job");
+    const onRemovedInactive = vi.fn();
+    onCronJobInactive(noteActiveCronJobRemoval("reused-job"), onRemovedInactive);
+    const replacementMarker = markCronJobActive("reused-job");
+
+    clearCronJobActive("reused-job", replacementMarker);
+    expect(onRemovedInactive).not.toHaveBeenCalled();
+
+    clearCronJobActive("reused-job", removedMarker);
+    expect(onRemovedInactive).toHaveBeenCalledOnce();
+  });
+
   it("records durable job removal without releasing the active run marker", () => {
     const marker = markCronJobActive("removed-job");
 

--- a/src/cron/active-jobs.ts
+++ b/src/cron/active-jobs.ts
@@ -18,6 +18,7 @@ export type CronActiveJobMarker = {
   triggerMutated?: true;
   jobRemoved?: true;
   preserveAcrossGenerationAdvance?: boolean;
+  onInactive?: Set<() => void>;
 };
 
 function getCronActiveJobState(): CronActiveJobState {
@@ -60,6 +61,12 @@ function notifyActiveCronJobWaitersIfEmpty(state: CronActiveJobState) {
   state.emptyWaiters.clear();
 }
 
+function notifyCronJobInactive(marker: CronActiveJobMarker) {
+  for (const callback of marker.onInactive ?? []) {
+    callback();
+  }
+}
+
 /** Marks a cron job id as currently executing for duplicate-run suppression. */
 export function markCronJobActive(
   jobId: string,
@@ -93,6 +100,7 @@ export function clearCronJobActive(jobId: string, marker?: CronActiveJobMarker) 
     (!marker || (marker.jobId === jobId && marker.token === activeMarker.token))
   ) {
     state.activeJobs.delete(jobId);
+    notifyCronJobInactive(activeMarker);
   }
   notifyActiveCronJobWaitersIfEmpty(state);
 }
@@ -148,6 +156,18 @@ export function isCronJobActive(jobId: string) {
   const state = getCronActiveJobState();
   const marker = state.activeJobs.get(jobId);
   return marker ? isMarkerActiveInGeneration(marker, state.generation) : false;
+}
+
+/** Runs a callback when the exact cron job no longer has an active in-process run. */
+export function onCronJobInactive(jobId: string, callback: () => void): void {
+  const state = getCronActiveJobState();
+  const marker = state.activeJobs.get(jobId);
+  if (!marker || !isMarkerActiveInGeneration(marker, state.generation)) {
+    callback();
+    return;
+  }
+  marker.onInactive ??= new Set<() => void>();
+  marker.onInactive.add(callback);
 }
 
 export function isCronActiveJobMarkerCurrent(marker: CronActiveJobMarker | undefined) {
@@ -226,6 +246,7 @@ export function advanceCronActiveJobGeneration() {
     }
     if (marker.generation < state.generation - 1) {
       state.activeJobs.delete(jobId);
+      notifyCronJobInactive(marker);
     }
   }
   notifyActiveCronJobWaitersIfEmpty(state);
@@ -235,6 +256,9 @@ export function advanceCronActiveJobGeneration() {
 export function resetCronActiveJobs() {
   const state = getCronActiveJobState();
   state.generation += 1;
+  for (const marker of state.activeJobs.values()) {
+    notifyCronJobInactive(marker);
+  }
   state.activeJobs.clear();
   notifyActiveCronJobWaitersIfEmpty(state);
 }

--- a/src/cron/active-jobs.ts
+++ b/src/cron/active-jobs.ts
@@ -19,6 +19,7 @@ export type CronActiveJobMarker = {
   jobRemoved?: true;
   preserveAcrossGenerationAdvance?: boolean;
   onInactive?: Set<() => void>;
+  inactiveNotified?: true;
 };
 
 function getCronActiveJobState(): CronActiveJobState {
@@ -62,9 +63,14 @@ function notifyActiveCronJobWaitersIfEmpty(state: CronActiveJobState) {
 }
 
 function notifyCronJobInactive(marker: CronActiveJobMarker) {
+  if (marker.inactiveNotified) {
+    return;
+  }
+  marker.inactiveNotified = true;
   for (const callback of marker.onInactive ?? []) {
     callback();
   }
+  marker.onInactive?.clear();
 }
 
 /** Marks a cron job id as currently executing for duplicate-run suppression. */
@@ -101,6 +107,10 @@ export function clearCronJobActive(jobId: string, marker?: CronActiveJobMarker) 
   ) {
     state.activeJobs.delete(jobId);
     notifyCronJobInactive(activeMarker);
+  } else if (marker?.jobId === jobId) {
+    // The caller is finalizing this exact run even when a same-id replacement
+    // now owns the map slot. Notify only the retired marker's listeners.
+    notifyCronJobInactive(marker);
   }
   notifyActiveCronJobWaitersIfEmpty(state);
 }
@@ -134,9 +144,9 @@ export function noteActiveCronJobTriggerMutation(jobId: string): void {
 }
 
 /** Retires the admitted job identity after its deletion becomes durable. */
-export function noteActiveCronJobRemoval(jobId: string): void {
+export function noteActiveCronJobRemoval(jobId: string): CronActiveJobMarker | undefined {
   if (!jobId) {
-    return;
+    return undefined;
   }
   const state = getCronActiveJobState();
   const marker = state.activeJobs.get(jobId);
@@ -145,7 +155,9 @@ export function noteActiveCronJobRemoval(jobId: string): void {
     // Keep its marker until completion so duplicate-run guards remain intact.
     marker.scheduleMutated = true;
     marker.jobRemoved = true;
+    return marker;
   }
+  return undefined;
 }
 
 /** Returns whether the given cron job id is currently executing in this process. */
@@ -159,10 +171,11 @@ export function isCronJobActive(jobId: string) {
 }
 
 /** Runs a callback when the exact cron job no longer has an active in-process run. */
-export function onCronJobInactive(jobId: string, callback: () => void): void {
-  const state = getCronActiveJobState();
-  const marker = state.activeJobs.get(jobId);
-  if (!marker || !isMarkerActiveInGeneration(marker, state.generation)) {
+export function onCronJobInactive(
+  marker: CronActiveJobMarker | undefined,
+  callback: () => void,
+): void {
+  if (!marker || marker.inactiveNotified) {
     callback();
     return;
   }

--- a/src/cron/service.remove-session-cleanup.test.ts
+++ b/src/cron/service.remove-session-cleanup.test.ts
@@ -10,8 +10,8 @@ const { logger, makeStorePath } = setupCronServiceSuite({
   prefix: "cron-remove-session-cleanup-",
 });
 
-afterEach(async () => {
-  await closeOpenClawAgentDatabasesForTest();
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
 });
 
 describe("CronService.remove session cleanup", () => {

--- a/src/cron/service.remove-session-cleanup.test.ts
+++ b/src/cron/service.remove-session-cleanup.test.ts
@@ -91,7 +91,15 @@ describe("CronService.remove session cleanup", () => {
     const sessionKey = `agent:main:cron:${job.id}`;
     const marker = markCronJobActive(job.id);
 
+    await replaceSessionEntry(
+      { agentId: "main", storePath: sessionStorePath, sessionKey },
+      { sessionId: "active-session", updatedAt: Date.now() },
+    );
+
     await cron.remove(job.id);
+    expect(loadExactSessionEntry({ storePath: sessionStorePath, sessionKey })).toMatchObject({
+      entry: { sessionId: "active-session" },
+    });
     await replaceSessionEntry(
       { agentId: "main", storePath: sessionStorePath, sessionKey },
       { sessionId: "late-session", updatedAt: Date.now() },
@@ -128,24 +136,38 @@ describe("CronService.remove session cleanup", () => {
     const sessionKey = `agent:main:cron:${original.id}`;
     const originalMarker = markCronJobActive(original.id);
 
+    await replaceSessionEntry(
+      { agentId: "main", storePath: sessionStorePath, sessionKey },
+      { sessionId: "original-session", updatedAt: Date.now() },
+    );
+
     await cron.remove(original.id);
-    await cron.add({
-      id: original.id,
-      name: "replacement job",
-      enabled: true,
-      schedule: { kind: "every", everyMs: 120_000 },
-      sessionTarget: "isolated",
-      wakeMode: "next-heartbeat",
-      payload: { kind: "agentTurn", message: "replacement" },
-    });
-    const replacementMarker = markCronJobActive(original.id);
+    let replacementAdded = false;
+    const replacementPromise = cron
+      .add({
+        id: original.id,
+        name: "replacement job",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 120_000 },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "replacement" },
+      })
+      .then((job) => {
+        replacementAdded = true;
+        return job;
+      });
+    await vi.advanceTimersByTimeAsync(50);
+    expect(replacementAdded).toBe(false);
+
+    clearCronJobActive(original.id, originalMarker);
+    await replacementPromise;
+    expect(loadExactSessionEntry({ storePath: sessionStorePath, sessionKey })).toBeUndefined();
     await replaceSessionEntry(
       { agentId: "main", storePath: sessionStorePath, sessionKey },
       { sessionId: "replacement-session", updatedAt: Date.now() },
     );
 
-    clearCronJobActive(original.id, replacementMarker);
-    clearCronJobActive(original.id, originalMarker);
     await Promise.resolve();
     await Promise.resolve();
 

--- a/src/cron/service.remove-session-cleanup.test.ts
+++ b/src/cron/service.remove-session-cleanup.test.ts
@@ -1,0 +1,140 @@
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadExactSessionEntry, replaceSessionEntry } from "../config/sessions/session-accessor.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { clearCronJobActive, markCronJobActive } from "./active-jobs.js";
+import { CronService } from "./service.js";
+import { setupCronServiceSuite } from "./service.test-harness.js";
+
+const { logger, makeStorePath } = setupCronServiceSuite({
+  prefix: "cron-remove-session-cleanup-",
+});
+
+afterEach(async () => {
+  await closeOpenClawAgentDatabasesForTest();
+});
+
+describe("CronService.remove session cleanup", () => {
+  it("removes only the deleted isolated job's base session", async () => {
+    const { storePath } = await makeStorePath();
+    const sessionStorePath = path.join(path.dirname(storePath), "sessions.json");
+    const cron = new CronService({
+      storePath,
+      cronEnabled: true,
+      defaultAgentId: "main",
+      resolveSessionStorePath: () => sessionStorePath,
+      log: logger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+    const job = await cron.add({
+      id: "deleted-job",
+      name: "deleted job",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "work" },
+    });
+    const baseSessionKey = `agent:main:cron:${job.id}`;
+    const runSessionKey = `${baseSessionKey}:run:retained-run`;
+    const otherSessionKey = "agent:main:cron:other-job";
+    await replaceSessionEntry(
+      { agentId: "main", storePath: sessionStorePath, sessionKey: baseSessionKey },
+      { sessionId: "base-session", updatedAt: Date.now() },
+    );
+    await replaceSessionEntry(
+      { agentId: "main", storePath: sessionStorePath, sessionKey: runSessionKey },
+      { sessionId: "run-session", updatedAt: Date.now() },
+    );
+    await replaceSessionEntry(
+      { agentId: "main", storePath: sessionStorePath, sessionKey: otherSessionKey },
+      { sessionId: "other-session", updatedAt: Date.now() },
+    );
+
+    await expect(cron.remove(job.id)).resolves.toEqual({ ok: true, removed: true });
+
+    expect(loadExactSessionEntry({ storePath: sessionStorePath, sessionKey: baseSessionKey })).toBe(
+      undefined,
+    );
+    expect(
+      loadExactSessionEntry({ storePath: sessionStorePath, sessionKey: runSessionKey }),
+    ).toMatchObject({ entry: { sessionId: "run-session" } });
+    expect(
+      loadExactSessionEntry({ storePath: sessionStorePath, sessionKey: otherSessionKey }),
+    ).toMatchObject({ entry: { sessionId: "other-session" } });
+  });
+
+  it("removes a base session recreated by an already-admitted run", async () => {
+    const { storePath } = await makeStorePath();
+    const sessionStorePath = path.join(path.dirname(storePath), "sessions.json");
+    const cron = new CronService({
+      storePath,
+      cronEnabled: true,
+      defaultAgentId: "main",
+      resolveSessionStorePath: () => sessionStorePath,
+      log: logger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+    const job = await cron.add({
+      id: "active-deleted-job",
+      name: "active deleted job",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "work" },
+    });
+    const sessionKey = `agent:main:cron:${job.id}`;
+    const marker = markCronJobActive(job.id);
+
+    await cron.remove(job.id);
+    await replaceSessionEntry(
+      { agentId: "main", storePath: sessionStorePath, sessionKey },
+      { sessionId: "late-session", updatedAt: Date.now() },
+    );
+    clearCronJobActive(job.id, marker);
+
+    await vi.waitFor(() => {
+      expect(loadExactSessionEntry({ storePath: sessionStorePath, sessionKey })).toBeUndefined();
+    });
+  });
+
+  it("does not delete a shared main session", async () => {
+    const { storePath } = await makeStorePath();
+    const sessionStorePath = path.join(path.dirname(storePath), "sessions.json");
+    const cron = new CronService({
+      storePath,
+      cronEnabled: true,
+      defaultAgentId: "main",
+      resolveSessionStorePath: () => sessionStorePath,
+      log: logger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+    const job = await cron.add({
+      id: "main-session-job",
+      name: "main session job",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "work" },
+    });
+    const sessionKey = "agent:main:main";
+    await replaceSessionEntry(
+      { agentId: "main", storePath: sessionStorePath, sessionKey },
+      { sessionId: "main-session", updatedAt: Date.now() },
+    );
+
+    await cron.remove(job.id);
+
+    expect(loadExactSessionEntry({ storePath: sessionStorePath, sessionKey })).toMatchObject({
+      entry: { sessionId: "main-session" },
+    });
+  });
+});

--- a/src/cron/service.remove-session-cleanup.test.ts
+++ b/src/cron/service.remove-session-cleanup.test.ts
@@ -103,6 +103,57 @@ describe("CronService.remove session cleanup", () => {
     });
   });
 
+  it("preserves the session of a replacement job with the same id", async () => {
+    const { storePath } = await makeStorePath();
+    const sessionStorePath = path.join(path.dirname(storePath), "sessions.json");
+    const cron = new CronService({
+      storePath,
+      cronEnabled: true,
+      defaultAgentId: "main",
+      resolveSessionStorePath: () => sessionStorePath,
+      log: logger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+    const original = await cron.add({
+      id: "reused-job-id",
+      name: "original job",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "original" },
+    });
+    const sessionKey = `agent:main:cron:${original.id}`;
+    const originalMarker = markCronJobActive(original.id);
+
+    await cron.remove(original.id);
+    await cron.add({
+      id: original.id,
+      name: "replacement job",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 120_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "replacement" },
+    });
+    const replacementMarker = markCronJobActive(original.id);
+    await replaceSessionEntry(
+      { agentId: "main", storePath: sessionStorePath, sessionKey },
+      { sessionId: "replacement-session", updatedAt: Date.now() },
+    );
+
+    clearCronJobActive(original.id, replacementMarker);
+    clearCronJobActive(original.id, originalMarker);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(loadExactSessionEntry({ storePath: sessionStorePath, sessionKey })).toMatchObject({
+      entry: { sessionId: "replacement-session" },
+    });
+  });
+
   it("does not delete a shared main session", async () => {
     const { storePath } = await makeStorePath();
     const sessionStorePath = path.join(path.dirname(storePath), "sessions.json");

--- a/src/cron/service.remove-session-cleanup.test.ts
+++ b/src/cron/service.remove-session-cleanup.test.ts
@@ -176,6 +176,71 @@ describe("CronService.remove session cleanup", () => {
     });
   });
 
+  it("fences same-id replacement across services sharing one store", async () => {
+    const { storePath } = await makeStorePath();
+    const sessionStorePath = path.join(path.dirname(storePath), "sessions.json");
+    const createCron = () =>
+      new CronService({
+        storePath,
+        cronEnabled: true,
+        defaultAgentId: "main",
+        resolveSessionStorePath: () => sessionStorePath,
+        log: logger,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+      });
+    const removingCron = createCron();
+    const replacementCron = createCron();
+    const original = await removingCron.add({
+      id: "cross-service-reused-id",
+      name: "original job",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "original" },
+    });
+    const sessionKey = `agent:main:cron:${original.id}`;
+    const originalMarker = markCronJobActive(original.id);
+    await replaceSessionEntry(
+      { agentId: "main", storePath: sessionStorePath, sessionKey },
+      { sessionId: "original-session", updatedAt: Date.now() },
+    );
+
+    await removingCron.remove(original.id);
+    let replacementAdded = false;
+    const replacementPromise = replacementCron
+      .add({
+        id: original.id,
+        name: "replacement job",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 120_000 },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "replacement" },
+      })
+      .then((job) => {
+        replacementAdded = true;
+        return job;
+      });
+    await vi.advanceTimersByTimeAsync(50);
+    expect(replacementAdded).toBe(false);
+
+    clearCronJobActive(original.id, originalMarker);
+    await replacementPromise;
+    await replaceSessionEntry(
+      { agentId: "main", storePath: sessionStorePath, sessionKey },
+      { sessionId: "replacement-session", updatedAt: Date.now() },
+    );
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(loadExactSessionEntry({ storePath: sessionStorePath, sessionKey })).toMatchObject({
+      entry: { sessionId: "replacement-session" },
+    });
+  });
+
   it("does not delete a shared main session", async () => {
     const { storePath } = await makeStorePath();
     const sessionStorePath = path.join(path.dirname(storePath), "sessions.json");

--- a/src/cron/service.remove-session-cleanup.test.ts
+++ b/src/cron/service.remove-session-cleanup.test.ts
@@ -1,10 +1,14 @@
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { loadExactSessionEntry, replaceSessionEntry } from "../config/sessions/session-accessor.js";
+import {
+  resolveSqliteScope,
+  runExclusiveSqliteSessionWrite,
+} from "../config/sessions/session-accessor.sqlite-scope.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { clearCronJobActive, markCronJobActive } from "./active-jobs.js";
 import { CronService } from "./service.js";
-import { setupCronServiceSuite } from "./service.test-harness.js";
+import { createDeferred, setupCronServiceSuite } from "./service.test-harness.js";
 
 const { logger, makeStorePath } = setupCronServiceSuite({
   prefix: "cron-remove-session-cleanup-",
@@ -64,6 +68,75 @@ describe("CronService.remove session cleanup", () => {
     expect(
       loadExactSessionEntry({ storePath: sessionStorePath, sessionKey: otherSessionKey }),
     ).toMatchObject({ entry: { sessionId: "other-session" } });
+  });
+
+  it("releases the cron lock before waiting for the session lifecycle writer", async () => {
+    const { storePath } = await makeStorePath();
+    const sessionStorePath = path.join(path.dirname(storePath), "sessions.json");
+    const cron = new CronService({
+      storePath,
+      cronEnabled: true,
+      defaultAgentId: "main",
+      resolveSessionStorePath: () => sessionStorePath,
+      log: logger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+    const job = await cron.add({
+      id: "contended-session-writer",
+      name: "contended session writer",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "work" },
+    });
+    const sessionKey = `agent:main:cron:${job.id}`;
+    await replaceSessionEntry(
+      { agentId: "main", storePath: sessionStorePath, sessionKey },
+      { sessionId: "contended-session", updatedAt: Date.now() },
+    );
+
+    const writerEntered = createDeferred<void>();
+    const releaseWriter = createDeferred<void>();
+    const resolvedSessionScope = resolveSqliteScope({
+      agentId: "main",
+      sessionKey,
+      storePath: sessionStorePath,
+    });
+    const heldWriter = runExclusiveSqliteSessionWrite(resolvedSessionScope, async () => {
+      writerEntered.resolve();
+      await releaseWriter.promise;
+    });
+    await writerEntered.promise;
+
+    const removal = cron.remove(job.id);
+    let unrelatedAdded = false;
+    const unrelatedAdd = cron
+      .add({
+        id: "unrelated-during-session-cleanup",
+        name: "unrelated during session cleanup",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 120_000 },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "unrelated" },
+      })
+      .then(() => {
+        unrelatedAdded = true;
+      });
+
+    try {
+      await vi.advanceTimersByTimeAsync(50);
+      expect(unrelatedAdded).toBe(true);
+    } finally {
+      releaseWriter.resolve();
+      await heldWriter;
+      await Promise.all([removal, unrelatedAdd]);
+    }
+
+    expect(loadExactSessionEntry({ storePath: sessionStorePath, sessionKey })).toBeUndefined();
   });
 
   it("removes a base session recreated by an already-admitted run", async () => {

--- a/src/cron/service.remove-session-cleanup.test.ts
+++ b/src/cron/service.remove-session-cleanup.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { loadExactSessionEntry, replaceSessionEntry } from "../config/sessions/session-accessor.js";
@@ -5,7 +6,10 @@ import {
   resolveSqliteScope,
   runExclusiveSqliteSessionWrite,
 } from "../config/sessions/session-accessor.sqlite-scope.js";
-import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  listOpenClawAgentDatabasesForTest,
+} from "../state/openclaw-agent-db.js";
 import { clearCronJobActive, markCronJobActive } from "./active-jobs.js";
 import { CronService } from "./service.js";
 import { createDeferred, setupCronServiceSuite } from "./service.test-harness.js";
@@ -19,6 +23,45 @@ afterEach(() => {
 });
 
 describe("CronService.remove session cleanup", () => {
+  it("does not materialize a session database when the deleted job never ran", async () => {
+    const { storePath } = await makeStorePath();
+    const sessionStorePath = path.join(path.dirname(storePath), "sessions.json");
+    const cron = new CronService({
+      storePath,
+      cronEnabled: true,
+      defaultAgentId: "main",
+      resolveSessionStorePath: () => sessionStorePath,
+      log: logger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+    const job = await cron.add({
+      id: "never-ran",
+      name: "never ran",
+      enabled: false,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "work" },
+    });
+    const sessionKey = `agent:main:cron:${job.id}`;
+    const databasePath = resolveSqliteScope({
+      agentId: "main",
+      sessionKey,
+      storePath: sessionStorePath,
+    }).path!;
+
+    expect(fs.existsSync(databasePath)).toBe(false);
+
+    await expect(cron.remove(job.id)).resolves.toEqual({ ok: true, removed: true });
+
+    expect(fs.existsSync(databasePath)).toBe(false);
+    expect(
+      listOpenClawAgentDatabasesForTest().some((database) => database.path === databasePath),
+    ).toBe(false);
+  });
+
   it("removes only the deleted isolated job's base session", async () => {
     const { storePath } = await makeStorePath();
     const sessionStorePath = path.join(path.dirname(storePath), "sessions.json");

--- a/src/cron/service.test-harness.ts
+++ b/src/cron/service.test-harness.ts
@@ -264,7 +264,6 @@ export function createMockCronStateForJobs(params: {
     manualSetupTimeoutNotified: false,
     runAdmission: { active: 0, waiters: [] },
     queuedRunReservationsByJobId: new Map(),
-    pendingSessionCleanupByJobId: new Map(),
     timer: null,
     storeLoadedAtMs: nowMs,
     op: Promise.resolve(),

--- a/src/cron/service.test-harness.ts
+++ b/src/cron/service.test-harness.ts
@@ -264,6 +264,7 @@ export function createMockCronStateForJobs(params: {
     manualSetupTimeoutNotified: false,
     runAdmission: { active: 0, waiters: [] },
     queuedRunReservationsByJobId: new Map(),
+    pendingSessionCleanupByJobId: new Map(),
     timer: null,
     storeLoadedAtMs: nowMs,
     op: Promise.resolve(),

--- a/src/cron/service/locked.ts
+++ b/src/cron/service/locked.ts
@@ -4,6 +4,39 @@ import { cronStoreKey } from "../store/key.js";
 import type { CronServiceState } from "./state.js";
 
 const cronOperations = new KeyedAsyncQueue();
+const pendingSessionCleanups = new Map<string, Map<string, Promise<void>>>();
+
+/** Returns cleanup that must finish before the same durable job identity can be reused. */
+export function getPendingCronSessionCleanup(
+  state: CronServiceState,
+  jobId: string,
+): Promise<void> | undefined {
+  return pendingSessionCleanups.get(cronStoreKey(state.deps.storePath))?.get(jobId);
+}
+
+/** Registers cleanup at the store-partition owner shared by sibling service instances. */
+export function registerPendingCronSessionCleanup(
+  state: CronServiceState,
+  jobId: string,
+  done: Promise<void>,
+): () => void {
+  const storeKey = cronStoreKey(state.deps.storePath);
+  let byJobId = pendingSessionCleanups.get(storeKey);
+  if (!byJobId) {
+    byJobId = new Map<string, Promise<void>>();
+    pendingSessionCleanups.set(storeKey, byJobId);
+  }
+  byJobId.set(jobId, done);
+  return () => {
+    if (byJobId.get(jobId) !== done) {
+      return;
+    }
+    byJobId.delete(jobId);
+    if (byJobId.size === 0) {
+      pendingSessionCleanups.delete(storeKey);
+    }
+  };
+}
 
 const resolveChain = (promise: Promise<unknown>) =>
   promise.then(

--- a/src/cron/service/ops-mutations.ts
+++ b/src/cron/service/ops-mutations.ts
@@ -9,9 +9,11 @@ import {
   noteActiveCronJobRemoval,
   noteActiveCronJobScheduleMutation,
   noteActiveCronJobTriggerMutation,
+  onCronJobInactive,
 } from "../active-jobs.js";
 import { cronSchedulingInputsEqual } from "../schedule-identity.js";
 import { deleteCronJobScratch } from "../scratch-store.js";
+import { removeCronJobBaseSession } from "../session-reaper.js";
 import { removeStaleCronJobFamilyRows } from "../store.js";
 import { createCronStreamSourceIdentity, cronStreamScheduleKey } from "../stream-schedule.js";
 import { normalizeCronTaskRunJobId } from "../task-run-history.js";
@@ -442,7 +444,10 @@ export async function remove(
   id: string,
   opts?: { systemOwned?: boolean },
 ) {
-  return await locked(state, async () => {
+  let sessionCleanup:
+    | { agentId: string; sessionStorePath: string; waitForActiveRun: boolean }
+    | undefined;
+  const result = await locked(state, async () => {
     warnIfDisabled(state, "remove");
     await ensureLoaded(state, { skipRecompute: true });
     const before = state.store?.jobs.length ?? 0;
@@ -471,7 +476,20 @@ export async function remove(
       postPersistNotifications,
       suppressScheduledJobId: id,
     });
-    if (removed) {
+    if (removed && removedJob) {
+      const agentId = resolveEffectiveJobAgentId(removedJob, resolveCurrentDefaultAgentId(state));
+      const sessionStorePath =
+        state.deps.resolveSessionStorePath?.(agentId) ?? state.deps.sessionStorePath;
+      if (
+        sessionStorePath &&
+        (removedJob.sessionTarget === "isolated" || removedJob.sessionTarget === "current")
+      ) {
+        sessionCleanup = {
+          agentId,
+          sessionStorePath,
+          waitForActiveRun: isCronJobActive(id),
+        };
+      }
       noteActiveCronJobRemoval(id);
       try {
         deleteCronJobScratch(state.deps.storePath, id);
@@ -487,6 +505,26 @@ export async function remove(
     }
     return { ok: true, removed } as const;
   });
+  if (!sessionCleanup) {
+    return result;
+  }
+  const { agentId, sessionStorePath, waitForActiveRun } = sessionCleanup;
+  const cleanup = async () => {
+    try {
+      await removeCronJobBaseSession({
+        agentId,
+        jobId: id,
+        sessionStorePath,
+      });
+    } catch (error) {
+      state.deps.log.warn({ jobId: id, err: String(error) }, "cron: session cleanup failed");
+    }
+  };
+  await cleanup();
+  if (waitForActiveRun) {
+    onCronJobInactive(id, () => void cleanup());
+  }
+  return result;
 }
 
 /** Remove one agent's jobs while holding the cron lock across an external roster commit. */

--- a/src/cron/service/ops-mutations.ts
+++ b/src/cron/service/ops-mutations.ts
@@ -31,7 +31,11 @@ import {
   nextWakeAtMs,
   recomputeNextRunsForMaintenance,
 } from "./jobs.js";
-import { locked } from "./locked.js";
+import {
+  getPendingCronSessionCleanup,
+  locked,
+  registerPendingCronSessionCleanup,
+} from "./locked.js";
 import { normalizeOptionalAgentId } from "./normalize.js";
 import { resolveCurrentDefaultAgentId, resolveEffectiveJobAgentId } from "./ops-shared.js";
 import type {
@@ -247,7 +251,7 @@ export async function add(
     }
     if (normalizedId) {
       normalizeCronTaskRunJobId(normalizedId);
-      pendingSessionCleanup = state.pendingSessionCleanupByJobId.get(normalizedId);
+      pendingSessionCleanup = getPendingCronSessionCleanup(state, normalizedId);
       if (pendingSessionCleanup) {
         throw RETRY_ADD_AFTER_SESSION_CLEANUP;
       }
@@ -470,6 +474,7 @@ export async function remove(
         sessionStorePath: string;
         done: Promise<void>;
         finish: () => void;
+        release: () => void;
       }
     | undefined;
   const result = await locked(state, async () => {
@@ -514,13 +519,14 @@ export async function remove(
         const done = new Promise<void>((resolve) => {
           finish = resolve;
         });
-        state.pendingSessionCleanupByJobId.set(id, done);
+        const release = registerPendingCronSessionCleanup(state, id, done);
         sessionCleanup = {
           activeMarker,
           agentId,
           sessionStorePath,
           done,
           finish,
+          release,
         };
       }
       try {
@@ -540,23 +546,24 @@ export async function remove(
   if (!sessionCleanup) {
     return result;
   }
-  const { activeMarker, agentId, sessionStorePath, done, finish } = sessionCleanup;
+  const { activeMarker, agentId, sessionStorePath, finish, release } = sessionCleanup;
   const cleanup = async () => {
     try {
-      await removeCronJobBaseSession({
-        agentId,
-        jobId: id,
-        sessionStorePath,
-        // Re-check after the session snapshot is loaded. A same-id replacement
-        // keeps its row, while expectedEntry protects writes racing this delete.
-        shouldRemove: () => !state.store?.jobs.some((job) => job.id === id),
+      await locked(state, async () => {
+        await ensureLoaded(state, { skipRecompute: true });
+        if (state.store?.jobs.some((job) => job.id === id)) {
+          return;
+        }
+        await removeCronJobBaseSession({
+          agentId,
+          jobId: id,
+          sessionStorePath,
+        });
       });
     } catch (error) {
       state.deps.log.warn({ jobId: id, err: String(error) }, "cron: session cleanup failed");
     } finally {
-      if (state.pendingSessionCleanupByJobId.get(id) === done) {
-        state.pendingSessionCleanupByJobId.delete(id);
-      }
+      release();
       finish();
     }
   };

--- a/src/cron/service/ops-mutations.ts
+++ b/src/cron/service/ops-mutations.ts
@@ -35,6 +35,7 @@ import { locked } from "./locked.js";
 import { normalizeOptionalAgentId } from "./normalize.js";
 import { resolveCurrentDefaultAgentId, resolveEffectiveJobAgentId } from "./ops-shared.js";
 import type {
+  CronAddResult,
   CronAddOptions,
   CronServiceState,
   CronUpdateOptions,
@@ -52,6 +53,8 @@ import {
   warnIfDisabled,
 } from "./store.js";
 import { armTimer } from "./timer.js";
+
+const RETRY_ADD_AFTER_SESSION_CLEANUP = new Error("retry add after session cleanup");
 
 async function resolveConfiguredChannelsForValidation(
   state: CronServiceState,
@@ -219,7 +222,12 @@ function declarativeFields(job: CronStoredJob, includeEnabled: boolean) {
 }
 
 /** Adds or converges a declaration-keyed cron job inside one store lock and write transaction. */
-export async function add(state: CronServiceState, input: CronJobCreate, opts?: CronAddOptions) {
+export async function add(
+  state: CronServiceState,
+  input: CronJobCreate,
+  opts?: CronAddOptions,
+): Promise<CronAddResult> {
+  let pendingSessionCleanup: Promise<void> | undefined;
   return await locked(state, async () => {
     warnIfDisabled(state, "add");
     // Heartbeat monitors are gateway-converged system jobs; without this
@@ -239,6 +247,10 @@ export async function add(state: CronServiceState, input: CronJobCreate, opts?: 
     }
     if (normalizedId) {
       normalizeCronTaskRunJobId(normalizedId);
+      pendingSessionCleanup = state.pendingSessionCleanupByJobId.get(normalizedId);
+      if (pendingSessionCleanup) {
+        throw RETRY_ADD_AFTER_SESSION_CLEANUP;
+      }
     }
     const normalizedInput = normalizedId ? { ...input, id: normalizedId } : input;
     const declarationKey = normalizeOptionalString(input.declarationKey);
@@ -339,6 +351,12 @@ export async function add(state: CronServiceState, input: CronJobCreate, opts?: 
       nextRunAtMs: job.state.nextRunAtMs,
     });
     return declarationKey ? { ...job, created: true, job } : job;
+  }).catch(async (error: unknown) => {
+    if (error !== RETRY_ADD_AFTER_SESSION_CLEANUP || !pendingSessionCleanup) {
+      throw error;
+    }
+    await pendingSessionCleanup;
+    return await add(state, input, opts);
   });
 }
 
@@ -446,7 +464,13 @@ export async function remove(
   opts?: { systemOwned?: boolean },
 ) {
   let sessionCleanup:
-    | { activeMarker: CronActiveJobMarker | undefined; agentId: string; sessionStorePath: string }
+    | {
+        activeMarker: CronActiveJobMarker | undefined;
+        agentId: string;
+        sessionStorePath: string;
+        done: Promise<void>;
+        finish: () => void;
+      }
     | undefined;
   const result = await locked(state, async () => {
     warnIfDisabled(state, "remove");
@@ -486,10 +510,17 @@ export async function remove(
         sessionStorePath &&
         (removedJob.sessionTarget === "isolated" || removedJob.sessionTarget === "current")
       ) {
+        let finish!: () => void;
+        const done = new Promise<void>((resolve) => {
+          finish = resolve;
+        });
+        state.pendingSessionCleanupByJobId.set(id, done);
         sessionCleanup = {
           activeMarker,
           agentId,
           sessionStorePath,
+          done,
+          finish,
         };
       }
       try {
@@ -509,7 +540,7 @@ export async function remove(
   if (!sessionCleanup) {
     return result;
   }
-  const { activeMarker, agentId, sessionStorePath } = sessionCleanup;
+  const { activeMarker, agentId, sessionStorePath, done, finish } = sessionCleanup;
   const cleanup = async () => {
     try {
       await removeCronJobBaseSession({
@@ -522,10 +553,16 @@ export async function remove(
       });
     } catch (error) {
       state.deps.log.warn({ jobId: id, err: String(error) }, "cron: session cleanup failed");
+    } finally {
+      if (state.pendingSessionCleanupByJobId.get(id) === done) {
+        state.pendingSessionCleanupByJobId.delete(id);
+      }
+      finish();
     }
   };
   if (activeMarker) {
     onCronJobInactive(activeMarker, () => void cleanup());
+    return result;
   }
   await cleanup();
   return result;

--- a/src/cron/service/ops-mutations.ts
+++ b/src/cron/service/ops-mutations.ts
@@ -549,17 +549,17 @@ export async function remove(
   const { activeMarker, agentId, sessionStorePath, finish, release } = sessionCleanup;
   const cleanup = async () => {
     try {
-      await locked(state, async () => {
+      const shouldRemove = await locked(state, async () => {
         await ensureLoaded(state, { skipRecompute: true });
-        if (state.store?.jobs.some((job) => job.id === id)) {
-          return;
-        }
+        return !state.store?.jobs.some((job) => job.id === id);
+      });
+      if (shouldRemove) {
         await removeCronJobBaseSession({
           agentId,
           jobId: id,
           sessionStorePath,
         });
-      });
+      }
     } catch (error) {
       state.deps.log.warn({ jobId: id, err: String(error) }, "cron: session cleanup failed");
     } finally {

--- a/src/cron/service/ops-mutations.ts
+++ b/src/cron/service/ops-mutations.ts
@@ -5,6 +5,7 @@ import {
   AgentDeletionCommitUncertainError,
 } from "../../agents/agent-lifecycle-registry.js";
 import {
+  type CronActiveJobMarker,
   isCronJobActive,
   noteActiveCronJobRemoval,
   noteActiveCronJobScheduleMutation,
@@ -445,7 +446,7 @@ export async function remove(
   opts?: { systemOwned?: boolean },
 ) {
   let sessionCleanup:
-    | { agentId: string; sessionStorePath: string; waitForActiveRun: boolean }
+    | { activeMarker: CronActiveJobMarker | undefined; agentId: string; sessionStorePath: string }
     | undefined;
   const result = await locked(state, async () => {
     warnIfDisabled(state, "remove");
@@ -477,6 +478,7 @@ export async function remove(
       suppressScheduledJobId: id,
     });
     if (removed && removedJob) {
+      const activeMarker = noteActiveCronJobRemoval(id);
       const agentId = resolveEffectiveJobAgentId(removedJob, resolveCurrentDefaultAgentId(state));
       const sessionStorePath =
         state.deps.resolveSessionStorePath?.(agentId) ?? state.deps.sessionStorePath;
@@ -485,12 +487,11 @@ export async function remove(
         (removedJob.sessionTarget === "isolated" || removedJob.sessionTarget === "current")
       ) {
         sessionCleanup = {
+          activeMarker,
           agentId,
           sessionStorePath,
-          waitForActiveRun: isCronJobActive(id),
         };
       }
-      noteActiveCronJobRemoval(id);
       try {
         deleteCronJobScratch(state.deps.storePath, id);
       } catch (error) {
@@ -508,22 +509,25 @@ export async function remove(
   if (!sessionCleanup) {
     return result;
   }
-  const { agentId, sessionStorePath, waitForActiveRun } = sessionCleanup;
+  const { activeMarker, agentId, sessionStorePath } = sessionCleanup;
   const cleanup = async () => {
     try {
       await removeCronJobBaseSession({
         agentId,
         jobId: id,
         sessionStorePath,
+        // Re-check after the session snapshot is loaded. A same-id replacement
+        // keeps its row, while expectedEntry protects writes racing this delete.
+        shouldRemove: () => !state.store?.jobs.some((job) => job.id === id),
       });
     } catch (error) {
       state.deps.log.warn({ jobId: id, err: String(error) }, "cron: session cleanup failed");
     }
   };
-  await cleanup();
-  if (waitForActiveRun) {
-    onCronJobInactive(id, () => void cleanup());
+  if (activeMarker) {
+    onCronJobInactive(activeMarker, () => void cleanup());
   }
+  await cleanup();
   return result;
 }
 

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -23,6 +23,7 @@ import type {
   CronRunOutcome,
   CronRunStatus,
   CronRunTelemetry,
+  CronStoredJob,
   CronStoreFile,
   CronToolsAllowProvenance,
 } from "../types.js";
@@ -365,12 +366,12 @@ export type CronRunResult =
 export type CronRemoveResult = { ok: true; removed: boolean } | { ok: false; removed: false };
 
 /** Created cron job returned by service mutation calls. */
-type CronDeclarativeAddResult = CronJob & {
+type CronDeclarativeAddResult = CronStoredJob & {
   created: boolean;
   updated?: boolean;
-  job: CronJob;
+  job: CronStoredJob;
 };
-export type CronAddResult = CronJob | CronDeclarativeAddResult;
+export type CronAddResult = CronStoredJob | CronDeclarativeAddResult;
 /** Updated cron job returned by service mutation calls. */
 export type CronUpdateResult = CronJob;
 

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -280,6 +280,8 @@ export type CronServiceState = {
   runAdmission: CronRunAdmission;
   /** Durable markers for cron runs that are waiting for the shared admission limit. */
   queuedRunReservationsByJobId: Map<string, QueuedCronRunReservation>;
+  /** Prevents a reused job id from overtaking deletion of its prior base session. */
+  pendingSessionCleanupByJobId: Map<string, Promise<void>>;
   /** Serializes mutating service operations so store writes and timers stay ordered. */
   op: Promise<unknown>;
   warnedDisabled: boolean;
@@ -313,6 +315,7 @@ export function createCronServiceState(deps: CronServiceDeps): CronServiceState 
     manualSetupTimeoutNotified: false,
     runAdmission: { active: 0, waiters: [] },
     queuedRunReservationsByJobId: new Map<string, QueuedCronRunReservation>(),
+    pendingSessionCleanupByJobId: new Map<string, Promise<void>>(),
     op: Promise.resolve(),
     warnedDisabled: false,
     warnedInvalidPersistedJobKeys: new Set<string>(),

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -280,8 +280,6 @@ export type CronServiceState = {
   runAdmission: CronRunAdmission;
   /** Durable markers for cron runs that are waiting for the shared admission limit. */
   queuedRunReservationsByJobId: Map<string, QueuedCronRunReservation>;
-  /** Prevents a reused job id from overtaking deletion of its prior base session. */
-  pendingSessionCleanupByJobId: Map<string, Promise<void>>;
   /** Serializes mutating service operations so store writes and timers stay ordered. */
   op: Promise<unknown>;
   warnedDisabled: boolean;
@@ -315,7 +313,6 @@ export function createCronServiceState(deps: CronServiceDeps): CronServiceState 
     manualSetupTimeoutNotified: false,
     runAdmission: { active: 0, waiters: [] },
     queuedRunReservationsByJobId: new Map<string, QueuedCronRunReservation>(),
-    pendingSessionCleanupByJobId: new Map<string, Promise<void>>(),
     op: Promise.resolve(),
     warnedDisabled: false,
     warnedInvalidPersistedJobKeys: new Set<string>(),

--- a/src/cron/session-reaper.ts
+++ b/src/cron/session-reaper.ts
@@ -12,6 +12,7 @@ import { formatErrorMessage } from "../infra/errors.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
 import { buildPendingGeneratedMediaSessionKeySet } from "../tasks/task-status-access.js";
+import { resolveCronAgentSessionKey } from "./isolated-agent/session-key.js";
 import type { Logger } from "./service/state.js";
 
 const DEFAULT_RETENTION_MS = 24 * 3_600_000; // 24 hours
@@ -53,6 +54,24 @@ type ReaperResult = {
   swept: boolean;
   pruned: number;
 };
+
+/** Removes the reusable base session whose owning isolated cron job was deleted. */
+export async function removeCronJobBaseSession(params: {
+  agentId: string;
+  jobId: string;
+  sessionStorePath: string;
+}): Promise<boolean> {
+  const sessionKey = resolveCronAgentSessionKey({
+    agentId: params.agentId,
+    sessionKey: `cron:${params.jobId}`,
+  });
+  const result = await applySessionEntryLifecycleMutation({
+    agentId: params.agentId,
+    storePath: params.sessionStorePath,
+    removals: [{ sessionKey, archiveRemovedTranscript: true }],
+  });
+  return result.removedEntries > 0;
+}
 
 /**
  * Sweeps completed isolated cron run sessions while preserving base cron sessions.

--- a/src/cron/session-reaper.ts
+++ b/src/cron/session-reaper.ts
@@ -4,6 +4,7 @@ import { parseDurationMs } from "../cli/parse-duration.js";
 import {
   applySessionEntryLifecycleMutation,
   listSessionEntries,
+  loadExactSessionEntry,
   type SessionEntryLifecycleRemoval,
 } from "../config/sessions/session-accessor.js";
 import { resolveMaintenanceConfig } from "../config/sessions/store-maintenance-runtime.js";
@@ -60,15 +61,23 @@ export async function removeCronJobBaseSession(params: {
   agentId: string;
   jobId: string;
   sessionStorePath: string;
+  shouldRemove?: () => boolean;
 }): Promise<boolean> {
   const sessionKey = resolveCronAgentSessionKey({
     agentId: params.agentId,
     sessionKey: `cron:${params.jobId}`,
   });
+  const existing = loadExactSessionEntry({
+    storePath: params.sessionStorePath,
+    sessionKey,
+  })?.entry;
+  if (!existing || params.shouldRemove?.() === false) {
+    return false;
+  }
   const result = await applySessionEntryLifecycleMutation({
     agentId: params.agentId,
     storePath: params.sessionStorePath,
-    removals: [{ sessionKey, archiveRemovedTranscript: true }],
+    removals: [{ sessionKey, archiveRemovedTranscript: true, expectedEntry: existing }],
   });
   return result.removedEntries > 0;
 }

--- a/src/cron/session-reaper.ts
+++ b/src/cron/session-reaper.ts
@@ -61,7 +61,6 @@ export async function removeCronJobBaseSession(params: {
   agentId: string;
   jobId: string;
   sessionStorePath: string;
-  shouldRemove?: () => boolean;
 }): Promise<boolean> {
   const sessionKey = resolveCronAgentSessionKey({
     agentId: params.agentId,
@@ -71,7 +70,7 @@ export async function removeCronJobBaseSession(params: {
     storePath: params.sessionStorePath,
     sessionKey,
   })?.entry;
-  if (!existing || params.shouldRemove?.() === false) {
+  if (!existing) {
     return false;
   }
   const result = await applySessionEntryLifecycleMutation({

--- a/src/cron/session-reaper.ts
+++ b/src/cron/session-reaper.ts
@@ -4,7 +4,7 @@ import { parseDurationMs } from "../cli/parse-duration.js";
 import {
   applySessionEntryLifecycleMutation,
   listSessionEntries,
-  loadExactSessionEntry,
+  loadExactSessionEntryReadOnly,
   type SessionEntryLifecycleRemoval,
 } from "../config/sessions/session-accessor.js";
 import { resolveMaintenanceConfig } from "../config/sessions/store-maintenance-runtime.js";
@@ -66,7 +66,7 @@ export async function removeCronJobBaseSession(params: {
     agentId: params.agentId,
     sessionKey: `cron:${params.jobId}`,
   });
-  const existing = loadExactSessionEntry({
+  const existing = loadExactSessionEntryReadOnly({
     storePath: params.sessionStorePath,
     sessionKey,
   })?.entry;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators deleting an isolated cron job would still see its reusable `agent:<agent>:cron:<jobId>` base session in session-management surfaces.

Closes #46369.

## Why This Change Was Made

Cleanup now runs after the cron definition is durably removed and uses the canonical session lifecycle mutation, including transcript archival. If a run was already admitted, deletion waits for that exact active marker to clear, preserving the run's lifecycle claim.

A per-store, per-job cleanup fence makes same-ID creation release the shared cron-store lock, wait through the asynchronous session mutation, and retry afterward. The fence lives beside the canonical store-partition operation queue, so sibling `CronService` instances cannot overtake each other's cleanup or make the remover trust a stale service-local job snapshot. Cleanup reacquires that lock and reloads committed cron state before deleting the guarded session row.

Per-run history remains owned by cron retention, and shared `main` sessions are not removed.

## User Impact

Deleted isolated/current cron jobs no longer leave ghost base sessions in the session store or Control UI. Active-run deletion, same-ID job replacement, sibling service instances, unrelated jobs, shared sessions, and retained run history preserve their existing behavior.

## Evidence

Real behavior proof on implementation head `ee789bb` used an isolated loopback gateway and its SQLite-backed session store:

```text
openclaw_version=2026.7.2 (ee789bb)
cron_add={name:"proof-cleanup",enabled:false,sessionTarget:"isolated"}
before={job_present:true,base_session_present:true,session_kind:"cron"}
cron_rm={ok:true,removed:true}
after={job_present:false,base_session_present:false}
gateway_shutdown=clean
```

The disposable job was created and removed through the real CLI/gateway flow. Its canonical base-session fixture was inserted through the runtime session accessor before removal; this proof does not depend on an external model or channel provider.

Fresh final-head proof on `066a4673ae81e4f07beb38b18bd6f702441c08f2` repeated that flow against an isolated dev Gateway and SQLite state directory:

```text
openclaw_version=2026.8.1 (066a467)
cron_add={enabled:false,sessionTarget:"isolated"}
before={job_present:true,base_session_count:1,session_kind:"cron"}
cron_rm={ok:true,removed:true}
after={job_present:false,base_session_count:0}
gateway_shutdown=clean
```

The final-head run also used the runtime session accessor to seed the canonical row, invoked no provider or channel, and retained private mode-0600 raw artifacts locally.

The current head `b8e3c03d77f76e97b2dba6dd9cce1b321c620627` is a patch-identical rebase of that reviewed cron repair onto main after CI fixture fix #120847; no cron/session runtime content changed after the trace.

The final concurrency regression uses two `CronService` instances sharing one SQLite cron partition. It removes an active job through one service, attempts a same-ID replacement through the other, proves creation remains fenced until exact-marker cleanup finishes, then verifies the replacement session survives.

Validation on final source head `b8e3c03d77f76e97b2dba6dd9cce1b321c620627`, rebased onto current main with CI watchdog fix #120700 and config-recovery fixture fix #120847:

```text
node scripts/run-vitest.mjs src/cron/service.remove-session-cleanup.test.ts src/cron/active-jobs.test.ts src/cron/active-jobs-manual-run.test.ts src/cron/session-reaper.test.ts src/cron/service/ops.test.ts src/cron/service.one-shot-schedule-ownership.test.ts src/cron/service.removal-postcommit.test.ts
# 7 files / 138 tests passed, including held session-writer lock-order proof and the read-only missing-database regression

.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --engine codex --model gpt-5.6-sol --thinking high
# clean: no accepted/actionable findings

git diff --check origin/main...HEAD
# passed

node scripts/run-tsgo.mjs -p tsconfig.plugin-sdk.dts.json --declaration true
# passed
```

Exact-head hosted CI is required before landing. Per-run session rows intentionally remain governed by cron retention. A session-cleanup failure is logged and does not roll back an already-durable job deletion, preventing retry ambiguity.

## Contributor Credit

The original repair and concurrency coverage are by @goutamadwant. The maintainer follow-up keeps the contributor's four authored commits and credits Goutam on every maintainer-authored repair commit.

Disclosure: AI was used to understand the codebase and review the fix.
