### PR TITLE
fix(xai): report unserializable voice tool results truthfully

### DIFF
--- a/extensions/xai/lazy-capability-providers.test.ts
+++ b/extensions/xai/lazy-capability-providers.test.ts
@@ -398,6 +398,24 @@ describe("xAI lazy capability providers", () => {
     );
   });
 
+  it("reports unserializable voice tool results distinctly from overflow", async () => {
+    const lazy = await loadLazyProviders();
+    const onError = vi.fn();
+    const bridge = lazy
+      .createLazyXaiRealtimeVoiceProvider()
+      .createBridge(createVoiceRequest({ onError }));
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    await bridge.submitToolResult("call-1", circular);
+
+    expect(runtimeMocks.voiceSubmitToolResult).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError.mock.calls[0]?.[0]).toEqual(
+      new Error("xAI realtime voice tool result is not JSON-serializable"),
+    );
+  });
+
   it("bounds pending voice tool results by aggregate serialized bytes", async () => {
     const lazy = await loadLazyProviders();
     const onError = vi.fn();

--- a/extensions/xai/lazy-capability-providers.ts
+++ b/extensions/xai/lazy-capability-providers.ts
@@ -553,8 +553,11 @@ function createLazyXaiRealtimeVoiceBridge(
       }
       const pending = { callId, result, ...(options ? { options } : {}) };
       const resultBytes = serializedJsonBytes(pending);
+      if (resultBytes === undefined) {
+        req.onError?.(new Error("xAI realtime voice tool result is not JSON-serializable"));
+        return;
+      }
       if (
-        resultBytes === undefined ||
         pendingToolResultCount >= MAX_LAZY_REALTIME_VOICE_TOOL_RESULTS ||
         pendingToolResultBytes + resultBytes > MAX_LAZY_REALTIME_VOICE_TOOL_RESULT_BYTES
       ) {


### PR DESCRIPTION
## Summary

- Problem: during the xAI realtime voice bridge lazy-startup window, an unserializable tool result (circular reference / BigInt) is reported as `xAI realtime voice pending tool result overflow during lazy startup` — while the queue is empty and nothing overflowed.
- Solution: split the serialization-failure case into its own branch with a truthful message (`xAI realtime voice tool result is not JSON-serializable`); drop-and-report behavior is unchanged.
- What changed: `extensions/xai/lazy-capability-providers.ts` (+4 lines), `extensions/xai/lazy-capability-providers.test.ts` (+1 regression test).
- What did NOT change: genuine queue-overflow reporting, the user-message admission path, and the xAI wire protocol are all untouched.

## Real behavior proof

- **Behavior or issue addressed:** during the lazy-startup window of the xAI realtime voice bridge (`extensions/xai/lazy-capability-providers.ts`), `submitToolResult` serializes the pending tool result to bound queued bytes. A tool result with a circular reference or BigInt makes `JSON.stringify` throw, `serializedJsonBytes` returns `undefined`, and that case shares the queue-overflow branch — so `onError` reports an overflow that never happened while the queue is empty, and the real cause (unserializable value) is invisible to the operator.
- **Real environment tested:** this PR's worktree, real source of `extensions/xai/lazy-capability-providers.ts` executed directly with `node --import tsx` — no connect, no bridge stub, no mocks anywhere; the lazy admission logic and error reporting all run the real source. The "before" run is the identical script against `origin/main` (file introduced by commit `e35d22807e`).
- **Exact steps or command run after this patch:**
  ```bash
  # before, on origin/main
  node --import tsx proof-xai-overflow.mjs
  # after, on this PR branch (same script)
  node --import tsx proof-xai-overflow.mjs
  # regression tests
  node node_modules/vitest/vitest.mjs run extensions/xai/lazy-capability-providers.test.ts
  ```
- **Evidence after fix:**
  ```text
  $ node --import tsx proof-xai-overflow.mjs   # AFTER: this PR branch
  [proof] submitted tool result: circular reference (JSON.stringify cannot serialize)
  [proof] onError messages: ["xAI realtime voice tool result is not JSON-serializable"]
  [proof] RESULT: PASS - serialization failure reported truthfully, no overflow misdiagnosis
  exit=0
  ```
  Same script on `origin/main` (before):
  ```text
  $ node --import tsx proof-xai-overflow.mjs   # BEFORE: main version
  [proof] submitted tool result: circular reference (JSON.stringify cannot serialize)
  [proof] onError messages: ["xAI realtime voice pending tool result overflow during lazy startup"]
  [proof] RESULT: FAIL - unserializable tool result misreported as "xAI realtime voice pending tool result overflow during lazy startup" (queue was empty; nothing overflowed)
  exit=1
  ```
- **Observed result after fix:** `onError` reports `xAI realtime voice tool result is not JSON-serializable` for the circular-reference result, instead of a queue overflow that never happened. Genuine overflow reporting is unchanged: `node node_modules/vitest/vitest.mjs run extensions/xai/lazy-capability-providers.test.ts` passes 22/22 (21 existing + 1 new `reports unserializable voice tool results distinctly from overflow`, red-green verified against main).
- **What was not tested:** did not start a live OpenClaw instance or a real xAI realtime voice session — no xAI API credentials in this environment. Only the real lazy-bridge admission path (the code that produces the misreported error) was exercised locally via `node --import tsx`; the overflow path itself is covered by the existing vitest cases.

## Regression Test Plan

- Coverage level: Unit test
- Target test file: `extensions/xai/lazy-capability-providers.test.ts`
- Scenario locked in: a circular-reference tool result submitted during lazy startup raises `xAI realtime voice tool result is not JSON-serializable`, distinct from the genuine overflow message.
- Why this is the smallest reliable guardrail: the bug is a branch-condition conflation in one admission check; a single test on that branch pins the invariant "the error message names the actual failure". Red-green verified: with the source change stashed, the new test fails (old code reports overflow); with the fix, all 22 pass.

## Root Cause

- Root cause: bug introduced by commit `e35d22807e` (`perf(xai): lazy-load optional capability runtimes (#119374)`) — the file was created with `resultBytes === undefined` (serialization failure) OR-ed into the same condition as queue-count/byte-limit overflow, so both paths raise the overflow message (`extensions/xai/lazy-capability-providers.ts:554-565` on main). Violated invariant: an error message must name the actual failure; overflow ("send less / wait") and unserializable input ("fix this value") are operationally opposite.
- Missing detection / guardrail: no separate branch or message for the serialization-failure case, and no test pinning the message for unserializable results.
