### PR TITLE
fix(whatsapp): keep LID-addressed DMs as peers when no PN mapping exists

### DIFF
--- a/extensions/whatsapp/src/inbound/message-normalization.ts
+++ b/extensions/whatsapp/src/inbound/message-normalization.ts
@@ -11,6 +11,15 @@ import type { WhatsAppGroupMetadataCacheOwner } from "./group-metadata-cache.js"
 import { isJidGroup } from "./runtime-api.js";
 import type { WhatsAppAttachedSocketSession } from "./socket-session.js";
 
+// Direct LID chats (usernames, click-to-WhatsApp leads) use `@lid`/`@hosted.lid`
+// JIDs. WhatsApp may omit the PN mapping for these, so inbound normalization
+// must keep the LID JID itself as the peer instead of dropping the message.
+const DIRECT_LID_INBOUND_JID_RE = /^(\d+)(?::\d+)?@(?:lid|hosted\.lid)$/i;
+
+function isDirectLidJid(jid: string): boolean {
+  return DIRECT_LID_INBOUND_JID_RE.test(jid);
+}
+
 export type WhatsAppNormalizedInboundMessage = {
   id?: string;
   remoteJid: string;
@@ -75,7 +84,14 @@ export function createWhatsAppInboundMessageNormalizer(options: {
     }
 
     const participantJid = msg.key?.participant ?? undefined;
-    const from = group ? remoteJid : await socketSession.resolveInboundJid(remoteJid);
+    const resolvedFrom = group ? remoteJid : await socketSession.resolveInboundJid(remoteJid);
+    // LID-addressed DMs (usernames, CTWA ad leads) arrive with no PN mapping
+    // when WhatsApp omits sender_pn entirely. Keep the LID JID as the peer so
+    // the message is delivered instead of silently dropped (replies route back
+    // through toWhatsappJid(), which passes through any `@`-containing JID).
+    const from =
+      resolvedFrom ??
+      (group || !isDirectLidJid(remoteJid) ? null : remoteJid);
     if (!from) {
       return null;
     }

--- a/extensions/whatsapp/src/inbound/message-normalization.ts
+++ b/extensions/whatsapp/src/inbound/message-normalization.ts
@@ -89,9 +89,7 @@ export function createWhatsAppInboundMessageNormalizer(options: {
     // when WhatsApp omits sender_pn entirely. Keep the LID JID as the peer so
     // the message is delivered instead of silently dropped (replies route back
     // through toWhatsappJid(), which passes through any `@`-containing JID).
-    const from =
-      resolvedFrom ??
-      (group || !isDirectLidJid(remoteJid) ? null : remoteJid);
+    const from = resolvedFrom ?? (group || !isDirectLidJid(remoteJid) ? null : remoteJid);
     if (!from) {
       return null;
     }

--- a/extensions/whatsapp/src/monitor-inbox.reply-context.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.reply-context.test.ts
@@ -148,6 +148,32 @@ describe("web monitor inbox reply context", () => {
     await listener.close();
   });
 
+  it("keeps LID-addressed DMs when no PN mapping exists", async () => {
+    const onMessage = vi.fn(async () => {});
+
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
+    // No reverse mapping file and lidLookup.getPNForLID resolves null, so
+    // resolveInboundJid() has no PN to fall back to for the LID JID.
+    const upsert = buildNotifyMessageUpsert({
+      id: nextMessageId("lid-unmapped"),
+      remoteJid: "999@lid",
+      text: "ping",
+      timestamp: 1_700_000_000,
+      pushName: "Tester",
+    });
+
+    sock.ev.emit("messages.upsert", upsert);
+    await waitForMessageCalls(onMessage, 1);
+
+    const inbound = inboundMessage(onMessage);
+    expect(inbound.payload.body).toBe("ping");
+    // The LID JID itself becomes the peer so the DM is not silently dropped.
+    expect(inbound.admission?.conversation.id).toBe("999@lid");
+    expect(inbound.admission?.conversation.kind).toBe("direct");
+
+    await listener.close();
+  });
+
   it("resolves LID JIDs via authDir mapping files", async () => {
     const onMessage = vi.fn(async () => {});
     fsSync.writeFileSync(

--- a/extensions/whatsapp/src/targets-runtime.ts
+++ b/extensions/whatsapp/src/targets-runtime.ts
@@ -283,7 +283,7 @@ export function jidToE164(jid: string, opts?: JidToE164Options): string | null {
   }
   const shouldLog = opts?.logMissing ?? shouldLogVerbose();
   if (shouldLog) {
-    logVerbose(`LID mapping not found for ${lidMatch[1]}; skipping inbound message`);
+    logVerbose(`LID mapping not found for ${lidMatch[1]}`);
   }
   return null;
 }


### PR DESCRIPTION
## What Problem This Solves

Inbound WhatsApp DMs from **LID-addressed chats** (users created via `@username`, and every lead arriving through click-to-WhatsApp ads) are **silently dropped** whenever Baileys has no LID→PN mapping. `jidToE164()` returns `null` for `@lid`/`@hosted.lid` JIDs without a reverse mapping, and inbound normalization treats a null peer as a drop — with only a verbose-gated log line as the trace.

Measured impact (production, 2026.6.10, 24h, `logging.level=debug`): **1,532 dropped inbound events from 79 unique LID senders** on one busy instance, vs 46 delivered e164 DMs. For CTWA-fed accounts this is the majority of the inbound funnel, lost invisibly.

## Why

WhatsApp's server omits `sender_pn` for these sender classes, so `resolveInboundJid()` has nothing to resolve to. The resolver already consults the local reverse-mapping files and Baileys' `getPNForLID` (issue #415); the failure mode is specifically "no mapping exists anywhere" — first-contact leads. Dropping the event discards the conversation entirely; keeping the LID JID as the peer delivers it, and replies route back correctly because `toWhatsappJid()` passes through any `@`-containing JID (verified end-to-end on 2026.6.10 with a patched bundle per the issue reporter).

## User Impact

- CTWA ad leads and `@username` senders can now start conversations instead of being silently lost.
- Existing mapped contacts keep their current behavior: when a PN mapping exists, the resolved E164 peer is used exactly as before (the LID fallback only applies when resolution returns null).
- Known trade-off (documented in the issue): a contact whose PN becomes resolvable later gets a second LID-peer session — strictly better than losing the conversation.

## Evidence

- **Code diff**: `extensions/whatsapp/src/inbound/message-normalization.ts` — DM peer resolution now falls back to the LID JID when `resolveInboundJid()` returns null and the JID matches `/^(\d+)(?::\d+)?@(?:lid|hosted\.lid)$/i`:
  ```ts
  const resolvedFrom = group ? remoteJid : await socketSession.resolveInboundJid(remoteJid);
  const from =
    resolvedFrom ??
    (group || !isDirectLidJid(remoteJid) ? null : remoteJid);
  ```
- **Inline verification**: `monitor-inbox.reply-context.test.ts` gains `"keeps LID-addressed DMs when no PN mapping exists"` — emits a `999@lid` upsert with no reverse mapping file and `getPNForLID` resolving null, asserts the message is delivered with `conversation.id === "999@lid"` and kind `direct`. Verified passing: 10/10 in the reply-context file; full sweep of `monitor-inbox.reply-context`, `text-runtime`, and `access-control` = **99/99 passing** on Node 24.15.
- **Before/after**: before the fix the new test's upsert never reached `onMessage` (dropped at `if (!from) return null`); after the fix it is delivered with the LID peer.

[AI-assisted]

## CI status

- Latest CI on head `435795a7ffbe`: all check-runs green (latest per check).
- `Real behavior proof` check: success.