### PR TITLE
fix(qa): retain child output on CLI timeouts

### DIFF
--- a/extensions/qa-lab/src/suite-runtime-agent-process.integration.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-process.integration.test.ts
@@ -72,4 +72,46 @@ describe("qa suite runtime CLI integration", () => {
       status: "ok",
     });
   });
+
+  it("retains real child output when the qa cli times out", async () => {
+    const repoRoot = await mkdtemp(path.join(os.tmpdir(), "qa-cli-timeout-repo-"));
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), "qa-cli-timeout-runtime-"));
+    cleanups.push(async () => {
+      await rm(repoRoot, { recursive: true, force: true });
+      await rm(tempRoot, { recursive: true, force: true });
+    });
+    const distDir = path.join(repoRoot, "dist");
+    await mkdir(distDir, { recursive: true });
+    await writeFile(
+      path.join(distDir, "index.js"),
+      [
+        'process.stdout.write("timeout stdout marker\\n");',
+        'process.stderr.write("timeout stderr marker\\n");',
+        "setInterval(() => {}, 60_000);",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const error = await runQaCli(
+      {
+        repoRoot,
+        gateway: {
+          tempRoot,
+          runtimeEnv: process.env,
+        },
+        primaryModel: "openai/gpt-5.6-luna",
+        alternateModel: "openai/gpt-5.6-luna",
+        providerMode: "mock-openai",
+      } as never,
+      ["qa", "suite"],
+      { timeoutMs: 1_000 },
+    ).catch((value: unknown) => value);
+
+    expect(error).toMatchObject({ code: "qa_cli_timeout" });
+    const message = error instanceof Error ? error.message : String(error);
+    expect(message).toContain("qa cli timed out: openclaw qa suite");
+    expect(message).toContain("stdout:\ntimeout stdout marker");
+    expect(message).toContain("stderr:\ntimeout stderr marker");
+  });
 });

--- a/extensions/qa-lab/src/suite-runtime-agent-process.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-process.test.ts
@@ -174,6 +174,7 @@ describe("qa suite runtime agent process helpers", () => {
 
   it.runIf(process.platform !== "win32")("kills timed-out qa cli process groups", async () => {
     const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    vi.useFakeTimers();
     try {
       const child = createSpawnedProcess({ pid: 12345 });
       const { pending } = startMockQaCli({
@@ -181,15 +182,37 @@ describe("qa suite runtime agent process helpers", () => {
         child,
         options: { timeoutMs: 1 },
       });
-      const timeoutAssertion = expect(pending).rejects.toThrow(
-        "qa cli timed out: openclaw qa suite",
+      const errorPromise = pending.catch((value: unknown) => value);
+      await Promise.resolve();
+      expect(spawnMock).toHaveBeenCalledTimes(1);
+      child.stdout.emit(
+        "data",
+        Buffer.from(
+          `stdout-head-marker\n${"x".repeat(QA_CHILD_STDOUT_MAX_BYTES)}\nstdout-tail-marker`,
+        ),
       );
+      child.stderr.emit(
+        "data",
+        Buffer.from(
+          `stderr-head-marker\n${"x".repeat(QA_CHILD_STDERR_TAIL_BYTES)}\nstderr-tail-marker`,
+        ),
+      );
+      await vi.advanceTimersByTimeAsync(1);
 
-      await waitForSpawnCount(1);
-      await timeoutAssertion;
+      const error = await errorPromise;
+      expect(error).toMatchObject({ code: "qa_cli_timeout" });
+      const message = error instanceof Error ? error.message : String(error);
+      expect(message).toContain("qa cli timed out: openclaw qa suite");
+      expect(message).toContain("stdout:\n[qa cli stdout truncated to last");
+      expect(message).toContain("stdout-tail-marker");
+      expect(message).not.toContain("stdout-head-marker");
+      expect(message).toContain("stderr:\n[qa cli stderr truncated to last");
+      expect(message).toContain("stderr-tail-marker");
+      expect(message).not.toContain("stderr-head-marker");
       expect(killSpy).toHaveBeenCalledWith(-12345, "SIGKILL");
       expect(child.kill).not.toHaveBeenCalled();
     } finally {
+      vi.useRealTimers();
       killSpy.mockRestore();
     }
   });

--- a/extensions/qa-lab/src/suite-runtime-agent-process.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-process.ts
@@ -265,6 +265,7 @@ async function runQaCli(
   opts?: { timeoutMs?: number; json?: boolean; env?: NodeJS.ProcessEnv },
 ) {
   const stdout = createQaChildOutputCapture();
+  const stdoutTail = createQaChildOutputTail();
   const stderr = createQaChildOutputTail();
   const distEntryPath = path.join(env.repoRoot, "dist", "index.js");
   const nodeExecPath = await resolveQaNodeExecPath();
@@ -281,11 +282,25 @@ async function runQaCli(
     const timeoutMs = resolveTimerTimeoutMs(opts?.timeoutMs, 60_000);
     const timeout = setTimeout(() => {
       signalQaCliProcessTree(child, "SIGKILL");
+      const stdoutText = formatQaChildOutputTail(stdoutTail, "qa cli stdout");
+      const stderrText = formatQaChildOutputTail(stderr, "qa cli stderr");
+      const diagnostics = [
+        stdoutText ? `stdout:\n${stdoutText}` : "",
+        stderrText ? `stderr:\n${stderrText}` : "",
+      ]
+        .filter(Boolean)
+        .join("\n");
       reject(
-        new QaSuiteInfraError("qa_cli_timeout", `qa cli timed out: openclaw ${args.join(" ")}`),
+        new QaSuiteInfraError(
+          "qa_cli_timeout",
+          `qa cli timed out: openclaw ${args.join(" ")}${diagnostics ? `\n${diagnostics}` : ""}`,
+        ),
       );
     }, timeoutMs);
-    child.stdout.on("data", (chunk) => appendQaChildOutput(stdout, chunk));
+    child.stdout.on("data", (chunk) => {
+      appendQaChildOutput(stdout, chunk);
+      appendQaChildOutputTail(stdoutTail, chunk);
+    });
     child.stderr.on("data", (chunk) => appendQaChildOutputTail(stderr, chunk));
     child.once("error", (error) => {
       clearTimeout(timeout);


### PR DESCRIPTION
Closes #119385

## What Problem This Solves

Fixes an issue where a timed-out QA CLI child was killed without preserving its already-captured stdout or stderr, leaving full-catalog failures unable to identify the stalled phase.

## Why This Change Was Made

The central QA child-process owner now keeps a separate bounded stdout tail alongside the existing stderr tail and appends only nonempty diagnostics to the typed timeout error. Successful stdout parsing, the existing 60-second deadline, and cross-platform process-tree termination are unchanged.

The regression coverage includes both deterministic truncation assertions and a real spawned Node child that writes to both streams before timing out.

## User Impact

Maintainers running QA Lab can now see the final bounded child output when a CLI step times out, making pressure-sensitive failures diagnosable without raising timeouts or weakening assertions. There is no end-user runtime behavior change.

## Evidence

- Blacksmith Testbox `tbx_01kz89e309s68p3pqzrc4msw3h`: https://github.com/openclaw/openclaw/actions/runs/30981180209
  - `pnpm test extensions/qa-lab/src/suite-runtime-agent-process.test.ts extensions/qa-lab/src/suite-runtime-agent-process.integration.test.ts extensions/qa-lab/src/child-output.test.ts` — 41/41 passed.
  - `pnpm check:changed` — passed, including extension production/test typechecks, 245-rule lint, boundary guards, dead-export checks, and import-cycle checks.
  - `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm openclaw qa suite --provider-mode mock-openai --concurrency 8` — 124 passed, 1 failed, 8 skipped. The reported `active-memory-preprompt-recall` scenario passed under the original concurrency and timeout. The unrelated `compaction-retry-mutating-tool` scenario reproduced an independent existing failure and is not changed here.
- AutoReview (`gpt-5.6-sol`, high reasoning) — clean, no accepted/actionable findings, 0.99 confidence.
- `git diff --check` — passed.
- Public model identifier audit — PASS; the only added model fixture is the repository-standard public `openai/gpt-5.6-luna` identifier: https://developers.openai.com/api/docs/models/gpt-5.6-luna

AI-assisted: implementation and proof were performed with Codex under maintainer supervision.
