### PR TITLE
fix(memory): allow retry after search timeout

### DIFF
--- a/extensions/memory-core/src/memory/search-deadline.test.ts
+++ b/extensions/memory-core/src/memory/search-deadline.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { runMemorySearchWithDeadline } from "./search-deadline.js";
+import { isMemorySearchTimeoutError, runMemorySearchWithDeadline } from "./search-deadline.js";
 
 describe("runMemorySearchWithDeadline", () => {
   afterEach(() => {
@@ -38,7 +38,11 @@ describe("runMemorySearchWithDeadline", () => {
 
     await resultAssertion;
     expect(taskSignal?.aborted).toBe(true);
-    expect(taskSignal?.reason).toEqual(new Error("memory_search timed out after 15s"));
+    expect(taskSignal?.reason).toMatchObject({
+      name: "MemorySearchTimeoutError",
+      message: "memory_search timed out after 15s",
+    });
+    expect(isMemorySearchTimeoutError(taskSignal?.reason)).toBe(true);
     expect(vi.getTimerCount()).toBe(0);
   });
 
@@ -62,6 +66,7 @@ describe("runMemorySearchWithDeadline", () => {
 
     await resultAssertion;
     expect(taskSignal?.reason).toBe(reason);
+    expect(isMemorySearchTimeoutError(taskSignal?.reason)).toBe(false);
     expect(removeEventListener).toHaveBeenCalledOnce();
     expect(vi.getTimerCount()).toBe(0);
   });

--- a/extensions/memory-core/src/memory/search-deadline.ts
+++ b/extensions/memory-core/src/memory/search-deadline.ts
@@ -1,4 +1,15 @@
 export const DEFAULT_MEMORY_SEARCH_TIMEOUT_MS = 15_000;
+class MemorySearchTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`memory_search timed out after ${Math.round(timeoutMs / 1000)}s`);
+    this.name = "MemorySearchTimeoutError";
+  }
+}
+
+export function isMemorySearchTimeoutError(error: unknown): boolean {
+  return error instanceof MemorySearchTimeoutError;
+}
+
 export function resolveMemorySearchAbortError(signal: AbortSignal): Error {
   const { reason } = signal;
   if (reason instanceof Error) {
@@ -8,7 +19,7 @@ export function resolveMemorySearchAbortError(signal: AbortSignal): Error {
 }
 
 function createMemorySearchTimeoutError(timeoutMs: number): Error {
-  return new Error(`memory_search timed out after ${Math.round(timeoutMs / 1000)}s`);
+  return new MemorySearchTimeoutError(timeoutMs);
 }
 
 export async function runMemorySearchWithDeadline<T>(params: {

--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -608,8 +608,9 @@ describe("memory tools", () => {
       const stalledAllResult = await stalledAllResultPromise;
       expectUnavailableMemorySearchDetails(stalledAllResult.details, {
         error: "memory_search timed out after 15s",
-        warning: "Memory search is unavailable due to an embedding/provider error.",
-        action: "Check embedding provider configuration and retry memory_search.",
+        warning: "Memory search timed out before it could complete.",
+        action:
+          "Retry memory_search. If timeouts continue, run openclaw memory status --deep and check for indexing or maintenance delays.",
       });
 
       const memoryResult = await tool.execute("call_memory_after_stalled_wiki", {
@@ -625,13 +626,25 @@ describe("memory tools", () => {
     }
   });
 
-  it("cooldowns primary memory when corpus=all memory search stalls", async () => {
+  it("does not cooldown primary memory when corpus=all memory search times out", async () => {
     vi.useFakeTimers();
     try {
       let searchCalls = 0;
       setMemorySearchImpl(async () => {
         searchCalls += 1;
-        return await new Promise(() => {});
+        if (searchCalls === 1) {
+          return await new Promise(() => {});
+        }
+        return [
+          {
+            path: "MEMORY.md",
+            startLine: 5,
+            endLine: 7,
+            score: 0.9,
+            snippet: "@@ -5,3 @@\nAssistant: noted",
+            source: "memory" as const,
+          },
+        ];
       });
       registerMemoryCorpusSupplement("memory-wiki", {
         search: async () => [
@@ -656,21 +669,23 @@ describe("memory tools", () => {
       const stalledAllResult = await stalledAllResultPromise;
       expectUnavailableMemorySearchDetails(stalledAllResult.details, {
         error: "memory_search timed out after 15s",
-        warning: "Memory search is unavailable due to an embedding/provider error.",
-        action: "Check embedding provider configuration and retry memory_search.",
+        warning: "Memory search timed out before it could complete.",
+        action:
+          "Retry memory_search. If timeouts continue, run openclaw memory status --deep and check for indexing or maintenance delays.",
       });
 
-      const wikiOnlyResult = await tool.execute("call_all_after_stalled_memory", {
+      const retryResult = await tool.execute("call_all_after_stalled_memory", {
         query: "alpha",
         corpus: "all",
       });
-      const details = wikiOnlyResult.details as {
+      const details = retryResult.details as {
         results: Array<{ corpus: string; path: string }>;
       };
       expect(details.results.map((entry) => [entry.corpus, entry.path])).toEqual([
         ["wiki", "entities/alpha.md"],
+        ["memory", "MEMORY.md"],
       ]);
-      expect(searchCalls).toBe(1);
+      expect(searchCalls).toBe(2);
     } finally {
       vi.useRealTimers();
     }

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -42,7 +42,6 @@ const sessionStore = vi.hoisted(() => ({
     chatType: "direct" as const,
   },
 }));
-
 vi.mock("openclaw/plugin-sdk/session-transcript-hit", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("openclaw/plugin-sdk/session-transcript-hit")>();
@@ -284,7 +283,9 @@ describe("memory_search unavailable payloads", () => {
   });
 
   it("returns explicit unavailable metadata for non-quota failures", async () => {
+    let searchCalls = 0;
     setMemorySearchImpl(async () => {
+      searchCalls += 1;
       throw new Error("embedding provider timeout");
     });
 
@@ -295,17 +296,36 @@ describe("memory_search unavailable payloads", () => {
       warning: "Memory search is unavailable due to an embedding/provider error.",
       action: "Check embedding provider configuration and retry memory_search.",
     });
+    const cooldownResult = await tool.execute("generic-cooldown", { query: "hello again" });
+    expectUnavailableMemorySearchDetails(cooldownResult.details, {
+      error: "embedding provider timeout",
+      warning: "Memory search is unavailable due to an embedding/provider error.",
+      action: "Check embedding provider configuration and retry memory_search.",
+    });
+    expect(searchCalls).toBe(1);
   });
 
-  it("returns unavailable metadata when memory search does not settle", async () => {
+  it("returns timeout metadata without entering provider cooldown", async () => {
     vi.useFakeTimers();
     try {
       let searchCalls = 0;
       let searchSignal: AbortSignal | undefined;
       setMemorySearchImpl(async (opts) => {
         searchCalls += 1;
-        searchSignal = opts?.signal;
-        return await new Promise(() => {});
+        if (searchCalls === 1) {
+          searchSignal = opts?.signal;
+          return await new Promise(() => {});
+        }
+        return [
+          {
+            path: "MEMORY.md",
+            startLine: 1,
+            endLine: 1,
+            score: 0.9,
+            snippet: "retry after timeout",
+            source: "memory" as const,
+          },
+        ];
       });
       const tool = createMemorySearchToolOrThrow();
 
@@ -315,18 +335,16 @@ describe("memory_search unavailable payloads", () => {
       const result = await resultPromise;
       expectUnavailableMemorySearchDetails(result.details, {
         error: "memory_search timed out after 15s",
-        warning: "Memory search is unavailable due to an embedding/provider error.",
-        action: "Check embedding provider configuration and retry memory_search.",
+        warning: "Memory search timed out before it could complete.",
+        action:
+          "Retry memory_search. If timeouts continue, run openclaw memory status --deep and check for indexing or maintenance delays.",
       });
       // The deadline must abort the orphaned search, not just race past it.
       expect(searchSignal?.aborted).toBe(true);
-      const cooldownResult = await tool.execute("search-cooldown", { query: "hello again" });
-      expectUnavailableMemorySearchDetails(cooldownResult.details, {
-        error: "memory_search timed out after 15s",
-        warning: "Memory search is unavailable due to an embedding/provider error.",
-        action: "Check embedding provider configuration and retry memory_search.",
-      });
-      expect(searchCalls).toBe(1);
+      const retryResult = await tool.execute("search-retry", { query: "hello again" });
+      const retryDetails = retryResult.details as { results: Array<{ path: string }> };
+      expect(retryDetails.results.map((entry) => entry.path)).toEqual(["MEMORY.md"]);
+      expect(searchCalls).toBe(2);
     } finally {
       vi.useRealTimers();
     }
@@ -353,8 +371,9 @@ describe("memory_search unavailable payloads", () => {
       const result = await resultPromise;
       expectUnavailableMemorySearchDetails(result.details, {
         error: "memory_search timed out after 15s",
-        warning: "Memory search is unavailable due to an embedding/provider error.",
-        action: "Check embedding provider configuration and retry memory_search.",
+        warning: "Memory search timed out before it could complete.",
+        action:
+          "Retry memory_search. If timeouts continue, run openclaw memory status --deep and check for indexing or maintenance delays.",
       });
     } finally {
       vi.useRealTimers();

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -30,6 +30,7 @@ import { asRecord } from "./dreaming-shared.js";
 import type { MemoryCoreAcquireLocalService } from "./memory/embedding-local-service.js";
 import {
   DEFAULT_MEMORY_SEARCH_TIMEOUT_MS,
+  isMemorySearchTimeoutError,
   resolveMemorySearchAbortError,
   runMemorySearchWithDeadline,
 } from "./memory/search-deadline.js";
@@ -61,6 +62,9 @@ type MemoryManagerSearchOptions = NonNullable<
 >;
 
 const MEMORY_SEARCH_TOOL_COOLDOWN_MS = 60_000;
+const MEMORY_SEARCH_TIMEOUT_WARNING = "Memory search timed out before it could complete.";
+const MEMORY_SEARCH_TIMEOUT_ACTION =
+  "Retry memory_search. If timeouts continue, run openclaw memory status --deep and check for indexing or maintenance delays.";
 
 const memorySearchToolCooldowns = new Map<string, { until: number; error: string }>();
 
@@ -779,10 +783,21 @@ export function createMemorySearchTool(options: {
             requestedCorpus !== "wiki" &&
             (requestedCorpus !== "all" || unavailablePhase === "memory");
           const message = formatErrorMessage(error);
-          if (shouldRecordCooldown) {
+          const timedOut = isMemorySearchTimeoutError(error);
+          if (shouldRecordCooldown && !timedOut) {
             recordMemorySearchToolCooldown(cooldownKey, message);
           }
-          return jsonResult(buildMemorySearchUnavailableResult(message));
+          return jsonResult(
+            buildMemorySearchUnavailableResult(
+              message,
+              timedOut
+                ? {
+                    warning: MEMORY_SEARCH_TIMEOUT_WARNING,
+                    action: MEMORY_SEARCH_TIMEOUT_ACTION,
+                  }
+                : undefined,
+            ),
+          );
         }
       },
   });


### PR DESCRIPTION
Related: #93199

## What Problem This Solves

Fixes an issue where users retrying `memory_search` after its 15-second deadline would receive an embedding/provider error and remain blocked by a 60-second provider cooldown, even though the provider had not failed.

This is the narrow timeout/cooldown repair related to #93199. It does not resolve that issue's separate non-default-agent/session-status inconsistency, so the issue remains open.

## Why This Change Was Made

The memory-core deadline now uses a dedicated timeout error so the tool can distinguish its own deadline from genuine provider failures. Deadline timeouts return timeout-specific recovery guidance and do not create a provider cooldown; actual embedding/provider errors keep the existing cooldown behavior.

## User Impact

Users can retry `memory_search` immediately after a tool deadline. The response now identifies the timeout accurately and suggests checking memory status for persistent indexing or maintenance delays, while provider outage protection remains unchanged.

## Evidence

- Regression test: the timeout test advances through the 15-second deadline, verifies that the orphaned search is aborted, then executes a second search and confirms the backend is called again and returns a result.
- Corpus regression: the `corpus=all` test confirms a timed-out primary-memory search can be retried and combined with wiki results.
- Provider regression: the provider-error test confirms genuine failures still use the existing cooldown and do not call the backend again.
- Focused timeout/cooldown/cancellation selection across `search-deadline.test.ts`, `tools.test.ts`, and `tools.citations.test.ts`: 10 passed, 56 skipped.
- Full three-file run: 65 passed; the unrelated short-term-recall persistence test failed at its existing current-main boundary. That same test previously failed unchanged on the exact upstream base, and no intervening `main` commit changed the affected Memory Core files.
- `oxfmt --check` and focused oxlint on all 5 changed files: passed.
- Production and extension-test tsgo checks with `scripts/run-tsgo.mjs`: passed.
- `git diff --check origin/main...HEAD`: passed.

## Real behavior proof

After-fix runtime proof against branch head `cca783dc532834f06074292703c6e971a397ecb7` (Node 24.15.0):

- Started an isolated localhost OpenClaw gateway with the real Memory Core plugin and `/tools/invoke` endpoint.
- Indexed a real `MEMORY.md` into the builtin SQLite/vector store with `node scripts/run-node.mjs memory index --force --agent main`.
- Used a deterministic localhost OpenAI-compatible embedding endpoint so no production credentials or user data were involved.
- The endpoint deliberately held only the first query request. The actual Memory Core deadline aborted it; the next `/tools/invoke` request was sent immediately and reached the provider again.
- The proof ran with `fnm exec --using=v24.15.0 node .local/pr119525-memory-timeout-proof.mjs`; the temporary harness was removed after the run and is not part of the PR diff.

Redacted terminal transcript:

```json
{
  "head": "cca783dc532834f06074292703c6e971a397ecb7",
  "environment": "isolated localhost gateway + real memory-core tool + indexed SQLite/vector store",
  "node": "v24.15.0",
  "firstCall": {
    "durationMs": 16369,
    "providerQueryAttempts": 1,
    "unavailable": true,
    "error": "memory_search timed out after 15s",
    "warning": "Memory search timed out before it could complete."
  },
  "immediateRetry": {
    "startedWithinMs": 0,
    "durationMs": 663,
    "providerQueryAttempts": 1,
    "resultCount": 1,
    "firstResultPath": "MEMORY.md"
  },
  "providerEvents": [
    { "event": "query_received", "attempt": 1, "at": "2026-08-10T07:12:47.872Z" },
    { "event": "query_aborted", "attempt": 1, "at": "2026-08-10T07:13:02.699Z" },
    { "event": "query_received", "attempt": 2, "at": "2026-08-10T07:13:03.219Z" }
  ],
  "assertions": {
    "firstTimedOut": true,
    "firstReportedTimeoutGuidance": true,
    "providerSawFirstAbort": true,
    "retryReachedProvider": true,
    "noCooldownOnRetry": true,
    "retrySucceeded": true
  },
  "passed": true
}
```

The second provider query occurring immediately after the first deadline is the runtime proof that the tool did not serve the retry from its 60-second provider cooldown. Genuine provider-failure cooldown behavior is covered separately by the focused regression test above.

Not tested here: the broader non-default-agent/session-status behavior reported in #93199.

Reported by @chaboncarpentier-blip.

