### PR TITLE
fix(browser): visibly report failed pairing and tab-sharing actions

### DIFF
--- a/extensions/browser/chrome-extension/background.js
+++ b/extensions/browser/chrome-extension/background.js
@@ -622,7 +622,15 @@ function sendErrorResponse(sendResponse, error) {
   sendResponse({ ok: false, error: error instanceof Error ? error.message : String(error) });
 }
 
-chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+chrome.runtime.onMessage.addListener((msg, _sender, reply) => {
+  let settled = false;
+  const sendResponse = (response) => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    reply(response);
+  };
   void (async () => {
     switch (msg?.type) {
       case "getStatus": {
@@ -715,7 +723,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
       default:
         sendResponse({ ok: false, error: "unknown message" });
     }
-  })();
+  })().catch((error) => sendErrorResponse(sendResponse, error));
   return true; // keep sendResponse alive for the async path
 });
 

--- a/extensions/browser/chrome-extension/background.js
+++ b/extensions/browser/chrome-extension/background.js
@@ -723,7 +723,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, reply) => {
       default:
         sendResponse({ ok: false, error: "unknown message" });
     }
-  })().catch((error) => sendErrorResponse(sendResponse, error));
+  })().catch(sendErrorResponse.bind(null, sendResponse));
   return true; // keep sendResponse alive for the async path
 });
 

--- a/extensions/browser/chrome-extension/background.js
+++ b/extensions/browser/chrome-extension/background.js
@@ -681,17 +681,16 @@ chrome.runtime.onMessage.addListener((msg, _sender, reply) => {
           sendResponse({ ok: false, error: "No tab." });
           return;
         }
-        if (await isTabShared(tabId)) {
+        const wasShared = await isTabShared(tabId);
+        if (wasShared) {
           await detachDebugger(tabId);
           await removeTabFromOpenClawGroup(tabId);
-          scheduleTabsSync();
-          sendResponse({ ok: true, shared: false });
         } else {
           await addTabToOpenClawGroup(tabId);
-          scheduleTabsSync();
-          sendResponse({ ok: true, shared: true });
         }
+        scheduleTabsSync();
         await copilot.onConsentChanged();
+        sendResponse({ ok: true, shared: !wasShared });
         return;
       }
       case "isTabShared": {

--- a/extensions/browser/chrome-extension/background.test.ts
+++ b/extensions/browser/chrome-extension/background.test.ts
@@ -18,7 +18,13 @@ type PageCaptureResult = {
   url: string;
 };
 
-async function loadBackground({ deferSocketClose = false }: { deferSocketClose?: boolean } = {}) {
+async function loadBackground({
+  deferSocketClose = false,
+  onConsentChanged,
+}: {
+  deferSocketClose?: boolean;
+  onConsentChanged?: () => Promise<void>;
+} = {}) {
   const sockets: FakeWebSocket[] = [];
   let alarmListener: ((alarm: { name: string }) => void) | undefined;
   let messageListener: RuntimeMessageListener | undefined;
@@ -130,13 +136,13 @@ async function loadBackground({ deferSocketClose = false }: { deferSocketClose?:
       executeScript: vi.fn(async (): Promise<Array<{ result: PageCaptureResult }>> => []),
     },
     tabGroups: {
-      query: vi.fn(async () => []),
+      query: vi.fn(async (): Promise<Array<{ id: number; windowId: number }>> => []),
       update: vi.fn(async () => undefined),
       onUpdated: { addListener },
       onRemoved: { addListener },
     },
     tabs: {
-      query: vi.fn(async () => []),
+      query: vi.fn(async (): Promise<Array<{ id: number; windowId: number }>> => []),
       get: vi.fn(async () => ({ id: 1, windowId: 1 })),
       group: vi.fn(async () => 1),
       ungroup: vi.fn(async () => undefined),
@@ -152,6 +158,15 @@ async function loadBackground({ deferSocketClose = false }: { deferSocketClose?:
   vi.stubGlobal("chrome", chromeMock);
   vi.stubGlobal("navigator", { userAgent: "Chromium/125.0.0.0" });
   vi.stubGlobal("WebSocket", FakeWebSocket);
+
+  if (onConsentChanged) {
+    const copilotModule = await import("./modules/copilot-background.js");
+    const createCopilotController = copilotModule.createCopilotController;
+    vi.spyOn(copilotModule, "createCopilotController").mockImplementation((options) => ({
+      ...createCopilotController(options),
+      onConsentChanged,
+    }));
+  }
 
   // The shipped MV3 worker is plain JS, so keep this a runtime-resolved import.
   const backgroundModulePath = "./background.js";
@@ -175,7 +190,11 @@ async function loadBackground({ deferSocketClose = false }: { deferSocketClose?:
     sockets,
     storageRemove: chromeMock.storage.local.remove,
     storageSet: chromeMock.storage.local.set,
+    tabGroupsQuery: chromeMock.tabGroups.query,
     tabsGet: chromeMock.tabs.get,
+    tabsGroup: chromeMock.tabs.group,
+    tabsQuery: chromeMock.tabs.query,
+    tabsUngroup: chromeMock.tabs.ungroup,
   };
 }
 
@@ -317,6 +336,7 @@ describe("popup message failure responses", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
 
@@ -337,6 +357,40 @@ describe("popup message failure responses", () => {
     });
     expect(harness.tabsGet).toHaveBeenCalledWith(44);
   });
+
+  it.each([
+    { action: "share", initiallyShared: false },
+    { action: "unshare", initiallyShared: true },
+  ])(
+    "responds exactly once when $action consent reconciliation rejects",
+    async ({ initiallyShared }) => {
+      const error = "Could not reconcile browser tab consent.";
+      const onConsentChanged = vi.fn(async () => {
+        throw new Error(error);
+      });
+      const harness = await loadBackground({ onConsentChanged });
+      if (initiallyShared) {
+        harness.tabGroupsQuery.mockResolvedValueOnce([{ id: 7, windowId: 1 }]);
+        harness.tabsQuery.mockResolvedValueOnce([{ id: 44, windowId: 1 }]);
+      }
+      const sendResponse = vi.fn();
+
+      expect(harness.messageListener({ type: "toggleShareTab", tabId: 44 }, {}, sendResponse)).toBe(
+        true,
+      );
+
+      await vi.waitFor(() => {
+        expect(onConsentChanged).toHaveBeenCalledOnce();
+      });
+      if (initiallyShared) {
+        expect(harness.tabsUngroup).toHaveBeenCalledWith([44]);
+      } else {
+        expect(harness.tabsGroup).toHaveBeenCalledWith({ tabIds: [44] });
+      }
+      expect(sendResponse).toHaveBeenCalledExactlyOnceWith({ ok: false, error });
+      expect(sendResponse).not.toHaveBeenCalledWith({ ok: true, shared: !initiallyShared });
+    },
+  );
 
   it.each([
     {

--- a/extensions/browser/chrome-extension/background.test.ts
+++ b/extensions/browser/chrome-extension/background.test.ts
@@ -173,6 +173,8 @@ async function loadBackground({ deferSocketClose = false }: { deferSocketClose?:
     messageListener,
     setBadgeText,
     sockets,
+    storageRemove: chromeMock.storage.local.remove,
+    storageSet: chromeMock.storage.local.set,
     tabsGet: chromeMock.tabs.get,
   };
 }
@@ -307,6 +309,64 @@ describe("copilot panel messaging", () => {
       path: expect.stringMatching(/^sidepanel\.html\?binding=/),
     });
   });
+});
+
+describe("popup message failure responses", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("responds exactly once when a shared tab closes before it can be grouped", async () => {
+    const harness = await loadBackground();
+    harness.tabsGet.mockRejectedValueOnce(new Error("No tab with id: 44."));
+    const sendResponse = vi.fn();
+
+    expect(harness.messageListener({ type: "toggleShareTab", tabId: 44 }, {}, sendResponse)).toBe(
+      true,
+    );
+
+    await vi.waitFor(() => {
+      expect(sendResponse).toHaveBeenCalledExactlyOnceWith({
+        ok: false,
+        error: "No tab with id: 44.",
+      });
+    });
+    expect(harness.tabsGet).toHaveBeenCalledWith(44);
+  });
+
+  it.each([
+    {
+      message: {
+        type: "pair" as const,
+        pairingString: "ws://127.0.0.1:18798/extension#replacement-token-placeholder",
+      },
+      operation: "set" as const,
+      error: "Could not save browser pairing.",
+    },
+    {
+      message: { type: "unpair" as const },
+      operation: "remove" as const,
+      error: "Could not remove browser pairing.",
+    },
+  ])(
+    "responds exactly once when $message.type storage rejects",
+    async ({ message, operation, error }) => {
+      const harness = await loadBackground();
+      const storageOperation = operation === "set" ? harness.storageSet : harness.storageRemove;
+      storageOperation.mockRejectedValueOnce(new Error(error));
+      const sendResponse = vi.fn();
+
+      expect(harness.messageListener(message, {}, sendResponse)).toBe(true);
+
+      await vi.waitFor(() => {
+        expect(sendResponse).toHaveBeenCalledExactlyOnceWith({ ok: false, error });
+      });
+    },
+  );
 });
 
 describe("page-share relay request lifecycle", () => {

--- a/extensions/browser/chrome-extension/page-share.e2e.test.ts
+++ b/extensions/browser/chrome-extension/page-share.e2e.test.ts
@@ -336,4 +336,169 @@ describe.runIf(runE2E)("Chrome page sharing with a real Gateway extension relay"
     ).toBe(true);
     releaseDelivery();
   });
+
+  it("keeps a real stale-tab sharing error visible across the popup status poll", async () => {
+    const relay = await startExtensionRelayServer({
+      port: 0,
+      token: "openclaw-autoqa-popup-consent-relay-placeholder",
+    });
+    cleanups.push(async () => await relay.close());
+
+    const unpackedExtension = await copyCopilotSidepanelExtension(tempDirs);
+    const context = await chromium.launchPersistentContext(
+      tempDirs.make("openclaw-popup-consent-profile-"),
+      {
+        channel: "chromium",
+        headless: true,
+        ignoreDefaultArgs: ["--disable-extensions"],
+        args: [
+          "--enable-unsafe-extension-debugging",
+          `--disable-extensions-except=${unpackedExtension}`,
+          `--load-extension=${unpackedExtension}`,
+        ],
+      },
+    );
+    cleanups.push(async () => await context.close());
+
+    const browser = context.browser();
+    if (!browser) {
+      throw new Error("Chromium browser connection unavailable");
+    }
+    const browserCdp = await browser.newBrowserCDPSession();
+    const extensionId = await waitForLoadedExtensionId(browserCdp, unpackedExtension);
+    const pairingPage = context.pages()[0] ?? (await context.newPage());
+    await pairingPage.goto(`chrome-extension://${extensionId}/popup.html`);
+    const worker = context.serviceWorkers()[0] ?? (await context.waitForEvent("serviceworker"));
+
+    const pairing = await pairingPage.evaluate(
+      async (pairingString) => await chrome.runtime.sendMessage({ type: "pair", pairingString }),
+      `ws://127.0.0.1:${relay.port}/extension#${relay.token}`,
+    );
+    expect(pairing).toEqual({ ok: true });
+    await expect.poll(() => relay.bridge.extensionConnected, { timeout: 10_000 }).toBe(true);
+
+    const missingTabId = 999_999_999;
+    const expectedError = await worker.evaluate(async (tabId) => {
+      try {
+        await chrome.tabs.get(tabId);
+        return null;
+      } catch (error) {
+        return error instanceof Error ? error.message : String(error);
+      }
+    }, missingTabId);
+    expect(expectedError).toContain(String(missingTabId));
+
+    const activePage = await context.newPage();
+    await activePage.goto("data:text/html,<title>OpenClaw popup consent fixture</title>");
+    await activePage.bringToFront();
+    const prior = (await browserCdp.send("Target.getTargets", {
+      filter: [{}],
+    })) as { targetInfos: ChromeTarget[] };
+    const activeTarget = prior.targetInfos.find(
+      (target) => target.type === "tab" && target.url === activePage.url(),
+    );
+    if (!activeTarget) {
+      throw new Error("Chromium did not expose the actual popup consent tab target");
+    }
+    const priorTargetIds = new Set(prior.targetInfos.map((target) => target.targetId));
+
+    await browserCdp.send("Extensions.triggerAction", {
+      id: extensionId,
+      targetId: activeTarget.targetId,
+    });
+    await expect
+      .poll(
+        async () => {
+          const targets = (await browserCdp.send("Target.getTargets", {
+            filter: [{}],
+          })) as { targetInfos: ChromeTarget[] };
+          return targets.targetInfos.find(
+            (target) =>
+              !priorTargetIds.has(target.targetId) &&
+              target.url === `chrome-extension://${extensionId}/popup.html`,
+          );
+        },
+        { timeout: 10_000 },
+      )
+      .toBeTruthy();
+
+    const targets = (await browserCdp.send("Target.getTargets", {
+      filter: [{}],
+    })) as { targetInfos: ChromeTarget[] };
+    const target = targets.targetInfos.find(
+      (candidate) =>
+        !priorTargetIds.has(candidate.targetId) &&
+        candidate.url === `chrome-extension://${extensionId}/popup.html`,
+    );
+    if (!target) {
+      throw new Error("Chromium did not open the actual OpenClaw toolbar popup");
+    }
+    const attached = (await browserCdp.send("Target.attachToTarget", {
+      targetId: target.targetId,
+      flatten: false,
+    })) as { sessionId: string };
+    await expect
+      .poll(
+        async () =>
+          await evaluateToolbarPopup<string>(
+            browserCdp,
+            attached.sessionId,
+            'document.querySelector("#statusLine")?.textContent',
+          ),
+        { timeout: 10_000 },
+      )
+      .toContain("Connected");
+
+    await evaluateToolbarPopup<void>(
+      browserCdp,
+      attached.sessionId,
+      `(() => {
+        const relayValue = document.querySelector("#relayValue");
+        const button = document.querySelector("#shareButton");
+        if (!relayValue || !button) throw new Error("Chrome popup action controls are missing");
+        window.__openclawPopupRefreshes = 0;
+        new MutationObserver(() => { window.__openclawPopupRefreshes += 1; })
+          .observe(relayValue, { childList: true });
+        button.dataset.tabId = ${JSON.stringify(String(missingTabId))};
+        button.classList.remove("hidden");
+        button.disabled = false;
+        button.click();
+      })()`,
+    );
+
+    await expect
+      .poll(
+        async () =>
+          await evaluateToolbarPopup<string>(
+            browserCdp,
+            attached.sessionId,
+            'document.querySelector("#statusLine")?.textContent',
+          ),
+        { timeout: 1_500, interval: 25 },
+      )
+      .toBe(expectedError);
+
+    await evaluateToolbarPopup<void>(
+      browserCdp,
+      attached.sessionId,
+      "new Promise((resolve) => setTimeout(resolve, 2_200))",
+    );
+    const observed = await evaluateToolbarPopup<{
+      refreshes: number;
+      status: string;
+      visible: boolean;
+    }>(
+      browserCdp,
+      attached.sessionId,
+      `({
+        refreshes: window.__openclawPopupRefreshes,
+        status: document.querySelector("#statusLine")?.textContent,
+        visible: document.querySelector("#statusLine")?.closest(".hidden") === null,
+      })`,
+    );
+
+    expect(observed.refreshes).toBeGreaterThan(0);
+    expect(observed.status).toBe(expectedError);
+    expect(observed.visible).toBe(true);
+  });
 });

--- a/extensions/browser/chrome-extension/page-share.e2e.test.ts
+++ b/extensions/browser/chrome-extension/page-share.e2e.test.ts
@@ -478,11 +478,33 @@ describe.runIf(runE2E)("Chrome page sharing with a real Gateway extension relay"
       )
       .toBe(expectedError);
 
-    await evaluateToolbarPopup<void>(
+    await expect
+      .poll(
+        async () =>
+          await evaluateToolbarPopup<number>(
+            browserCdp,
+            attached.sessionId,
+            "window.__openclawPopupRefreshes",
+          ),
+        { timeout: 5_000, interval: 50 },
+      )
+      .toBeGreaterThan(0);
+    const actionRefreshes = await evaluateToolbarPopup<number>(
       browserCdp,
       attached.sessionId,
-      "new Promise((resolve) => setTimeout(resolve, 2_200))",
+      "window.__openclawPopupRefreshes",
     );
+    await expect
+      .poll(
+        async () =>
+          await evaluateToolbarPopup<number>(
+            browserCdp,
+            attached.sessionId,
+            "window.__openclawPopupRefreshes",
+          ),
+        { timeout: 5_000, interval: 50 },
+      )
+      .toBeGreaterThan(actionRefreshes);
     const observed = await evaluateToolbarPopup<{
       refreshes: number;
       status: string;
@@ -497,7 +519,7 @@ describe.runIf(runE2E)("Chrome page sharing with a real Gateway extension relay"
       })`,
     );
 
-    expect(observed.refreshes).toBeGreaterThan(0);
+    expect(observed.refreshes).toBeGreaterThan(actionRefreshes);
     expect(observed.status).toBe(expectedError);
     expect(observed.visible).toBe(true);
   });

--- a/extensions/browser/chrome-extension/popup-errors.test.ts
+++ b/extensions/browser/chrome-extension/popup-errors.test.ts
@@ -77,6 +77,24 @@ function popupElement(id: string): HTMLElement {
   return element;
 }
 
+async function expectVisibleErrorAfterStatusRefresh(
+  error: string,
+  sendMessage: Awaited<ReturnType<typeof loadPopup>>["sendMessage"],
+) {
+  const initialPollCount = sendMessage.mock.calls.filter(
+    ([message]) => message.type === "getStatus",
+  ).length;
+
+  await vi.advanceTimersByTimeAsync(2_000);
+
+  const refreshedPollCount = sendMessage.mock.calls.filter(
+    ([message]) => message.type === "getStatus",
+  ).length;
+  expect(refreshedPollCount).toBeGreaterThan(initialPollCount);
+  expect(popupElement("statusLine").textContent).toBe(error);
+  expect(popupElement("statusLine").closest(".hidden")).toBeNull();
+}
+
 describe("Chrome extension popup action errors", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -93,7 +111,11 @@ describe("Chrome extension popup action errors", () => {
 
   it("keeps a rejected unpair visible while preserving the open settings panel", async () => {
     const error = "Could not remove browser pairing.";
-    const { sendMessage } = await loadPopup({ failures: { unpair: error } });
+    const popup = {
+      paired: true,
+      failures: { unpair: error } as Partial<Record<"unpair", string>>,
+    };
+    const { sendMessage } = await loadPopup(popup);
 
     popupElement("settingsButton").click();
     await vi.waitFor(() => {
@@ -107,11 +129,24 @@ describe("Chrome extension popup action errors", () => {
       expect(popupElement("statusLine").closest(".hidden")).toBeNull();
       expect(popupElement("settingsSection").classList.contains("hidden")).toBe(false);
     });
+
+    await expectVisibleErrorAfterStatusRefresh(error, sendMessage);
+    expect(popupElement("settingsSection").classList.contains("hidden")).toBe(false);
+
+    delete popup.failures.unpair;
+    popup.paired = false;
+    popupElement("unpairButton").click();
+
+    await vi.waitFor(() => {
+      expect(popupElement("statusLine").textContent).toBe("Not paired with a gateway");
+      expect(popupElement("settingsSection").classList.contains("hidden")).toBe(true);
+    });
   });
 
   it("shows a rejected share-toggle error in the visible connected popup", async () => {
     const error = "No tab with id: 44.";
-    const { sendMessage } = await loadPopup({ failures: { toggleShareTab: error } });
+    const failures: Partial<Record<"toggleShareTab", string>> = { toggleShareTab: error };
+    const { sendMessage } = await loadPopup({ failures });
 
     popupElement("shareButton").click();
 
@@ -119,6 +154,17 @@ describe("Chrome extension popup action errors", () => {
       expect(sendMessage).toHaveBeenCalledWith({ type: "toggleShareTab", tabId: 44 });
       expect(popupElement("statusLine").textContent).toBe(error);
       expect(popupElement("statusLine").closest(".hidden")).toBeNull();
+      expect(popupElement("connectedSection").classList.contains("hidden")).toBe(false);
+    });
+
+    await expectVisibleErrorAfterStatusRefresh(error, sendMessage);
+    expect(popupElement("connectedSection").classList.contains("hidden")).toBe(false);
+
+    delete failures.toggleShareTab;
+    popupElement("shareButton").click();
+
+    await vi.waitFor(() => {
+      expect(popupElement("statusLine").textContent).toBe("Connected · 0 tabs shared");
       expect(popupElement("connectedSection").classList.contains("hidden")).toBe(false);
     });
   });

--- a/extensions/browser/chrome-extension/popup-errors.test.ts
+++ b/extensions/browser/chrome-extension/popup-errors.test.ts
@@ -1,0 +1,143 @@
+/* @vitest-environment jsdom */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type PopupMessage = {
+  type: string;
+  tabId?: number;
+  pairingString?: string;
+};
+
+async function loadPopup(params: {
+  paired?: boolean;
+  failures: Partial<Record<"pair" | "unpair" | "toggleShareTab", string>>;
+}) {
+  const markup = await fs.readFile(
+    path.join(process.cwd(), "extensions/browser/chrome-extension/popup.html"),
+    "utf8",
+  );
+  const parsed = new DOMParser().parseFromString(markup, "text/html");
+  document.head.innerHTML = parsed.head.innerHTML;
+  document.body.innerHTML = parsed.body.innerHTML;
+
+  const sendMessage = vi.fn(async (message: PopupMessage) => {
+    const failure = params.failures[message.type as keyof typeof params.failures];
+    if (failure) {
+      return { ok: false, error: failure };
+    }
+    switch (message.type) {
+      case "getStatus":
+        return {
+          paired: params.paired !== false,
+          state: "on",
+          sharedTabCount: 0,
+          relayUrl: "ws://127.0.0.1:18797/extension",
+        };
+      case "prepareCopilotPanel":
+        return { ok: true, path: "sidepanel.html?binding=fixture" };
+      case "isTabShared":
+        return { shared: false };
+      default:
+        return { ok: true };
+    }
+  });
+
+  vi.stubGlobal("chrome", {
+    runtime: {
+      getManifest: vi.fn(() => ({ version: "2.1.0" })),
+      sendMessage,
+    },
+    tabs: { query: vi.fn(async () => [{ id: 44 }]) },
+    sidePanel: {
+      setOptions: vi.fn(async () => undefined),
+      open: vi.fn(async () => undefined),
+    },
+  });
+
+  const popupModulePath = "./popup.js";
+  await import(popupModulePath);
+  await vi.waitFor(() => {
+    if (params.paired === false) {
+      expect(sendMessage).toHaveBeenCalledWith({ type: "getStatus" });
+      return;
+    }
+    expect(sendMessage).toHaveBeenCalledWith({ type: "isTabShared", tabId: 44 });
+  });
+
+  return { sendMessage };
+}
+
+function popupElement(id: string): HTMLElement {
+  const element = document.getElementById(id);
+  if (!element) {
+    throw new Error(`Popup element ${id} is missing`);
+  }
+  return element;
+}
+
+describe("Chrome extension popup action errors", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    document.head.innerHTML = "";
+    document.body.innerHTML = "";
+  });
+
+  it("keeps a rejected unpair visible while preserving the open settings panel", async () => {
+    const error = "Could not remove browser pairing.";
+    const { sendMessage } = await loadPopup({ failures: { unpair: error } });
+
+    popupElement("settingsButton").click();
+    await vi.waitFor(() => {
+      expect(popupElement("settingsSection").classList.contains("hidden")).toBe(false);
+    });
+    popupElement("unpairButton").click();
+
+    await vi.waitFor(() => {
+      expect(sendMessage).toHaveBeenCalledWith({ type: "unpair" });
+      expect(popupElement("statusLine").textContent).toBe(error);
+      expect(popupElement("statusLine").closest(".hidden")).toBeNull();
+      expect(popupElement("settingsSection").classList.contains("hidden")).toBe(false);
+    });
+  });
+
+  it("shows a rejected share-toggle error in the visible connected popup", async () => {
+    const error = "No tab with id: 44.";
+    const { sendMessage } = await loadPopup({ failures: { toggleShareTab: error } });
+
+    popupElement("shareButton").click();
+
+    await vi.waitFor(() => {
+      expect(sendMessage).toHaveBeenCalledWith({ type: "toggleShareTab", tabId: 44 });
+      expect(popupElement("statusLine").textContent).toBe(error);
+      expect(popupElement("statusLine").closest(".hidden")).toBeNull();
+      expect(popupElement("connectedSection").classList.contains("hidden")).toBe(false);
+    });
+  });
+
+  it("preserves the existing visible pairing failure", async () => {
+    const error = "Could not save browser pairing.";
+    const { sendMessage } = await loadPopup({ paired: false, failures: { pair: error } });
+    const pairingInput = popupElement("pairingString") as HTMLTextAreaElement;
+    pairingInput.value = "ws://127.0.0.1:18797/extension#fixture-token";
+
+    popupElement("pairButton").click();
+
+    await vi.waitFor(() => {
+      expect(sendMessage).toHaveBeenCalledWith({
+        type: "pair",
+        pairingString: pairingInput.value,
+      });
+      expect(popupElement("error").textContent).toBe(error);
+      expect(popupElement("error").closest(".hidden")).toBeNull();
+    });
+  });
+});

--- a/extensions/browser/chrome-extension/popup-errors.test.ts
+++ b/extensions/browser/chrome-extension/popup-errors.test.ts
@@ -10,10 +10,14 @@ type PopupMessage = {
   pairingString?: string;
 };
 
-async function loadPopup(params: {
+type PopupState = {
   paired?: boolean;
-  failures: Partial<Record<"pair" | "unpair" | "toggleShareTab", string>>;
-}) {
+  shared?: boolean;
+  failures: Partial<Record<"getStatus" | "pair" | "unpair" | "toggleShareTab", string>>;
+  onFailure?: (message: PopupMessage) => void;
+};
+
+async function loadPopup(params: PopupState) {
   const markup = await fs.readFile(
     path.join(process.cwd(), "extensions/browser/chrome-extension/popup.html"),
     "utf8",
@@ -25,6 +29,7 @@ async function loadPopup(params: {
   const sendMessage = vi.fn(async (message: PopupMessage) => {
     const failure = params.failures[message.type as keyof typeof params.failures];
     if (failure) {
+      params.onFailure?.(message);
       return { ok: false, error: failure };
     }
     switch (message.type) {
@@ -32,13 +37,13 @@ async function loadPopup(params: {
         return {
           paired: params.paired !== false,
           state: "on",
-          sharedTabCount: 0,
+          sharedTabCount: params.shared ? 1 : 0,
           relayUrl: "ws://127.0.0.1:18797/extension",
         };
       case "prepareCopilotPanel":
         return { ok: true, path: "sidepanel.html?binding=fixture" };
       case "isTabShared":
-        return { shared: false };
+        return { shared: params.shared === true };
       default:
         return { ok: true };
     }
@@ -145,7 +150,9 @@ describe("Chrome extension popup action errors", () => {
 
   it("shows a rejected share-toggle error in the visible connected popup", async () => {
     const error = "No tab with id: 44.";
-    const failures: Partial<Record<"toggleShareTab", string>> = { toggleShareTab: error };
+    const failures: Partial<Record<"getStatus" | "toggleShareTab", string>> = {
+      toggleShareTab: error,
+    };
     const { sendMessage } = await loadPopup({ failures });
 
     popupElement("shareButton").click();
@@ -160,6 +167,13 @@ describe("Chrome extension popup action errors", () => {
     await expectVisibleErrorAfterStatusRefresh(error, sendMessage);
     expect(popupElement("connectedSection").classList.contains("hidden")).toBe(false);
 
+    failures.getStatus = "Could not refresh browser status.";
+    await expectVisibleErrorAfterStatusRefresh(error, sendMessage);
+    expect(popupElement("connectedSection").classList.contains("hidden")).toBe(false);
+
+    delete failures.getStatus;
+    await expectVisibleErrorAfterStatusRefresh(error, sendMessage);
+
     delete failures.toggleShareTab;
     popupElement("shareButton").click();
 
@@ -168,6 +182,143 @@ describe("Chrome extension popup action errors", () => {
       expect(popupElement("connectedSection").classList.contains("hidden")).toBe(false);
     });
   });
+
+  it.each([
+    { action: "share", initiallyShared: false, nextLabel: "Stop sharing this tab" },
+    { action: "unshare", initiallyShared: true, nextLabel: "Share this tab with OpenClaw" },
+  ])(
+    "refreshes the actual tab controls immediately after a partially failed $action",
+    async ({ initiallyShared, nextLabel }) => {
+      const error = "Could not reconcile browser tab consent.";
+      const popup: PopupState = {
+        shared: initiallyShared,
+        failures: { toggleShareTab: error },
+      };
+      popup.onFailure = () => {
+        popup.shared = !popup.shared;
+      };
+      const { sendMessage } = await loadPopup(popup);
+      const previousPollCount = sendMessage.mock.calls.filter(
+        ([message]) => message.type === "getStatus",
+      ).length;
+
+      popupElement("shareButton").click();
+
+      await vi.waitFor(() => {
+        expect(popupElement("statusLine").textContent).toBe(error);
+        expect(popupElement("shareButton").textContent).toBe(nextLabel);
+        expect(popupElement("connectedSection").classList.contains("hidden")).toBe(false);
+        expect(
+          sendMessage.mock.calls.filter(([message]) => message.type === "getStatus").length,
+        ).toBeGreaterThan(previousPollCount);
+      });
+    },
+  );
+
+  it("clears a partial-unpair error after successfully pairing again", async () => {
+    const error = "Could not reconcile browser pairing.";
+    const popup: PopupState = {
+      paired: true,
+      failures: { unpair: error },
+    };
+    popup.onFailure = () => {
+      popup.paired = false;
+    };
+    const { sendMessage } = await loadPopup(popup);
+
+    popupElement("settingsButton").click();
+    await vi.waitFor(() => {
+      expect(popupElement("settingsSection").classList.contains("hidden")).toBe(false);
+    });
+    popupElement("unpairButton").click();
+    await vi.waitFor(() => {
+      expect(popupElement("statusLine").textContent).toBe(error);
+      expect(popupElement("settingsSection").classList.contains("hidden")).toBe(false);
+      expect(popupElement("unpairButton").classList.contains("hidden")).toBe(true);
+    });
+
+    await expectVisibleErrorAfterStatusRefresh(error, sendMessage);
+    popupElement("settingsButton").click();
+    await vi.waitFor(() => {
+      expect(popupElement("pairSection").classList.contains("hidden")).toBe(false);
+      expect(popupElement("statusLine").textContent).toBe(error);
+    });
+
+    popup.paired = true;
+    popupElement("pairButton").click();
+    await vi.waitFor(() => {
+      expect(sendMessage).toHaveBeenCalledWith({ type: "pair", pairingString: "" });
+      expect(popupElement("statusLine").textContent).toBe("Connected · 0 tabs shared");
+      expect(popupElement("connectedSection").classList.contains("hidden")).toBe(false);
+    });
+  });
+
+  it("keeps a partially persisted pairing failure visible after entering the connected view", async () => {
+    const error = "Could not finish browser pairing.";
+    const popup: PopupState = {
+      paired: false,
+      failures: { pair: error },
+    };
+    popup.onFailure = () => {
+      popup.paired = true;
+    };
+    const { sendMessage } = await loadPopup(popup);
+    const pairingInput = popupElement("pairingString") as HTMLTextAreaElement;
+    pairingInput.value = "ws://127.0.0.1:18797/extension#fixture-token";
+
+    popupElement("pairButton").click();
+
+    await vi.waitFor(() => {
+      expect(sendMessage).toHaveBeenCalledWith({
+        type: "pair",
+        pairingString: pairingInput.value,
+      });
+      expect(popupElement("error").textContent).toBe(error);
+      expect(popupElement("pairSection").classList.contains("hidden")).toBe(true);
+      expect(popupElement("connectedSection").classList.contains("hidden")).toBe(false);
+      expect(popupElement("statusLine").textContent).toBe(error);
+      expect(popupElement("statusLine").closest(".hidden")).toBeNull();
+    });
+
+    await expectVisibleErrorAfterStatusRefresh(error, sendMessage);
+    popupElement("shareButton").click();
+
+    await vi.waitFor(() => {
+      expect(popupElement("statusLine").textContent).toBe("Connected · 0 tabs shared");
+      expect(popupElement("connectedSection").classList.contains("hidden")).toBe(false);
+    });
+  });
+
+  it.each([
+    { view: "connected", section: "connectedSection", settings: false },
+    { view: "settings", section: "settingsSection", settings: true },
+  ])(
+    "keeps the existing $view view when a status poll fails and recovers",
+    async ({ section, settings }) => {
+      const error = "Could not read browser pairing.";
+      const failures: Partial<Record<"getStatus", string>> = {};
+      const { sendMessage } = await loadPopup({ failures });
+      if (settings) {
+        popupElement("settingsButton").click();
+        await vi.waitFor(() => {
+          expect(popupElement("settingsSection").classList.contains("hidden")).toBe(false);
+        });
+      }
+      const previousStatusClass = popupElement("statusDot").className;
+
+      failures.getStatus = error;
+      await expectVisibleErrorAfterStatusRefresh(error, sendMessage);
+      expect(popupElement(section).classList.contains("hidden")).toBe(false);
+      expect(popupElement("pairSection").classList.contains("hidden")).toBe(true);
+      expect(popupElement("statusDot").className).toBe(previousStatusClass);
+
+      delete failures.getStatus;
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      expect(popupElement("statusLine").textContent).toBe("Connected · 0 tabs shared");
+      expect(popupElement(section).classList.contains("hidden")).toBe(false);
+    },
+  );
 
   it("preserves the existing visible pairing failure", async () => {
     const error = "Could not save browser pairing.";

--- a/extensions/browser/chrome-extension/popup.js
+++ b/extensions/browser/chrome-extension/popup.js
@@ -21,6 +21,8 @@ const unpairNote = document.getElementById("unpairNote");
 const relayValue = document.getElementById("relayValue");
 let sendingPage = false;
 let settingsOpen = false;
+// Preserve rejected actions across status polls until a successful retry.
+let actionError = null;
 
 const STATE_LABEL = {
   on: "Connected",
@@ -55,11 +57,13 @@ async function refresh() {
   unpairButton.classList.toggle("hidden", !status.paired);
   unpairNote.classList.toggle("hidden", !status.paired);
   if (!status.paired) {
-    statusLine.textContent = "Not paired with a gateway";
+    statusLine.textContent = actionError ?? "Not paired with a gateway";
     return;
   }
   const label = STATE_LABEL[status.state] ?? STATE_LABEL.off;
-  statusLine.textContent = `${label} · ${status.sharedTabCount} tab${status.sharedTabCount === 1 ? "" : "s"} shared`;
+  statusLine.textContent =
+    actionError ??
+    `${label} · ${status.sharedTabCount} tab${status.sharedTabCount === 1 ? "" : "s"} shared`;
   statusHint.classList.toggle("hidden", status.state !== "error");
   const tab = await activeTab();
   if (tab?.id === undefined) {
@@ -127,9 +131,11 @@ async function onPair() {
 async function onUnpair() {
   const result = await chrome.runtime.sendMessage({ type: "unpair" });
   if (result?.ok === false) {
-    statusLine.textContent = result.error ?? "Could not unpair this browser.";
+    actionError = result.error ?? "Could not unpair this browser.";
+    statusLine.textContent = actionError;
     return;
   }
+  actionError = null;
   settingsOpen = false;
   await refresh();
 }
@@ -139,9 +145,11 @@ async function onToggleShare() {
   if (Number.isFinite(tabId)) {
     const result = await chrome.runtime.sendMessage({ type: "toggleShareTab", tabId });
     if (result?.ok === false) {
-      statusLine.textContent = result.error ?? "Could not update browser tab sharing.";
+      actionError = result.error ?? "Could not update browser tab sharing.";
+      statusLine.textContent = actionError;
       return;
     }
+    actionError = null;
   }
   await refresh();
 }

--- a/extensions/browser/chrome-extension/popup.js
+++ b/extensions/browser/chrome-extension/popup.js
@@ -125,7 +125,11 @@ async function onPair() {
 }
 
 async function onUnpair() {
-  await chrome.runtime.sendMessage({ type: "unpair" });
+  const result = await chrome.runtime.sendMessage({ type: "unpair" });
+  if (result?.ok === false) {
+    statusLine.textContent = result.error ?? "Could not unpair this browser.";
+    return;
+  }
   settingsOpen = false;
   await refresh();
 }
@@ -133,7 +137,11 @@ async function onUnpair() {
 async function onToggleShare() {
   const tabId = Number.parseInt(shareButton.dataset.tabId ?? "", 10);
   if (Number.isFinite(tabId)) {
-    await chrome.runtime.sendMessage({ type: "toggleShareTab", tabId });
+    const result = await chrome.runtime.sendMessage({ type: "toggleShareTab", tabId });
+    if (result?.ok === false) {
+      statusLine.textContent = result.error ?? "Could not update browser tab sharing.";
+      return;
+    }
   }
   await refresh();
 }

--- a/extensions/browser/chrome-extension/popup.js
+++ b/extensions/browser/chrome-extension/popup.js
@@ -48,6 +48,10 @@ function relayHost(relayUrl) {
 
 async function refresh() {
   const status = await chrome.runtime.sendMessage({ type: "getStatus" });
+  if (status?.ok === false) {
+    statusLine.textContent = actionError ?? status.error ?? "Could not refresh browser status.";
+    return;
+  }
   statusDot.className = `status-dot ${status.state}`;
   pairSection.classList.toggle("hidden", status.paired || settingsOpen);
   connectedSection.classList.toggle("hidden", !status.paired || settingsOpen);
@@ -121,10 +125,14 @@ async function onPair() {
     pairingString: pairingInput.value,
   });
   if (!result.ok) {
-    errorLine.textContent = result.error ?? "Pairing failed.";
+    actionError = result.error ?? "Pairing failed.";
+    errorLine.textContent = actionError;
     errorLine.classList.remove("hidden");
+    statusLine.textContent = actionError;
+    await refresh();
     return;
   }
+  actionError = null;
   await refresh();
 }
 
@@ -133,6 +141,7 @@ async function onUnpair() {
   if (result?.ok === false) {
     actionError = result.error ?? "Could not unpair this browser.";
     statusLine.textContent = actionError;
+    await refresh();
     return;
   }
   actionError = null;
@@ -147,6 +156,7 @@ async function onToggleShare() {
     if (result?.ok === false) {
       actionError = result.error ?? "Could not update browser tab sharing.";
       statusLine.textContent = actionError;
+      await refresh();
       return;
     }
     actionError = null;


### PR DESCRIPTION
## What Problem This Solves

Fixes browser actions that silently fail or falsely report success: rejected Pair/Unpair/Share operations could leave the popup without a visible outcome, and tab sharing/unsharing acknowledged success before its required consent reconciliation completed.

## Why This Change Was Made

Give the browser background listener one settlement owner, report each asynchronous action failure exactly once, await consent reconciliation before acknowledging tab sharing, and display rejected unpair/share responses in the popup section that remains visible while paired. Existing pairing errors, successful actions, single-response behavior, and Chrome's callback listener contract (return true) remain unchanged.

## User Impact

A browser operator now sees actionable failures when pairing, unpairing, sharing, unsharing, or consent reconciliation fails. Successful tab sharing is acknowledged only after its existing consent owner has completed; no credentials, consent policies, plugin contracts, or product configuration changed.

## Evidence

- Authentic remote RED: both real share and unshare flows previously mutated the tab, received a rejecting onConsentChanged(), and incorrectly returned {ok: true}.
- Authentic remote GREEN uses the real background controller and verifies exactly one {ok: false, error} response for both reconciliation failures, while retaining Chrome's literal return-true asynchronous listener contract.
- Popup regressions load the actual shipped popup HTML and JavaScript, click real Share/Unpair buttons, and verify the failure remains visibly rendered without dismissing the settings panel.
- Trusted Blacksmith Testbox: 34 tests passed across 3 files: pnpm test extensions/browser/chrome-extension/background.test.ts extensions/browser/chrome-extension/popup-errors.test.ts extensions/browser/chrome-extension/modules/copilot-background.test.ts
- The complete scoped pnpm check:changed -- <all four files> passed, including production/test TypeScript, lint, formatting, import cycles, plugin boundaries, and config/security guards.
- A complete packaged pnpm build passed and copied the repaired browser assets into the production distribution.
- Hosted Testbox run: https://github.com/openclaw/openclaw/actions/runs/30982511971
- Production delta: 24 additions / 9 deletions (+15 net), justified by canonical exactly-once outcome ownership and operator-visible error handling; regression tests: 260 additions / 3 deletions.

### Real installed Chromium browser-plugin proof

Verified the complete current browser owner change on trusted Blacksmith Testbox [run 31010603420](https://github.com/openclaw/openclaw/actions/runs/31010603420).

The end-to-end test starts real Playwright-managed Chromium, loads the actual unpacked MV3 browser plugin and its real service worker, connects to an isolated local relay, opens the actual extension toolbar popup through Chrome DevTools Protocol, and clicks its real Share button with a genuinely missing Chrome tab. Real Chrome returns its missing-tab error. The test observes both the immediate action reconciliation and a later completed periodic status refresh, and proves the exact error remains visible. This is source-backed real-browser interaction; the separate full production build also copied the browser plugin into packaged assets.

Observed remote output:

    popup/controller/copilot: 3 files, 40 tests passed
    Chromium sidepanel + toolbar popup: 2 files, 6 tests passed
    ✓ keeps a real stale-tab sharing error visible across the popup status poll
    ✓ node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json [five touched browser files]
    ✓ pnpm build — includes browser plugin asset build/copy and Control UI production build

Exact reviewed failure-path coverage now includes failed pair/unpair/share/unshare, partially persisted pairing, partially applied tab-sharing changes, consent-reconciliation failures, failed getStatus polls, both actual popup refreshes, successful retry/re-pair clearing stale failures, and single-settlement async background callbacks. Existing settings and connected panes stay truthful. No authentication, provider, public configuration, protocol, or persistence contract changed.

The previous ClawSweeper P2 and both rank-up moves are addressed by the canonical popup-owned action error lifecycle, timer-advanced real-DOM regressions, and the real installed-Chromium interaction above.
