### PR TITLE
fix(telegram): show failed final slash-command responses

### DIFF
--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -1538,6 +1538,37 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     expect(deliveryMocks.deliverReplies).toHaveBeenCalledOnce();
   });
 
+  it("preserves a suppressed final after a non-final delivery failure", async () => {
+    dispatchChannelInboundTurnMock.mockImplementationOnce(async (plan) => {
+      plan.delivery.onError?.(new Error("Telegram tool delivery failed"), {
+        kind: "tool",
+      });
+      await plan.delivery.onDelivered?.(
+        { text: "cancelled final reply" },
+        { kind: "final" },
+        {
+          visibleReplySent: false,
+          suppression: { reason: "cancelled_by_reply_payload_sending_hook" },
+        },
+      );
+      return {
+        admission: { kind: "dispatch" },
+        dispatched: true,
+        ctxPayload: plan.ctxPayload,
+        routeSessionKey: plan.route.sessionKey,
+        dispatchResult: {
+          queuedFinal: false,
+          counts: { block: 0, final: 0, tool: 0 },
+        },
+      };
+    });
+    const { handler } = registerAndResolveStatusHandler({ cfg: {} });
+
+    await handler(createTelegramPrivateCommandContext());
+
+    expect(deliveryMocks.deliverReplies).not.toHaveBeenCalled();
+  });
+
   it("retains the empty fallback for a true non-silent metadata-only native reply", async () => {
     dispatchChannelInboundTurnMock.mockImplementationOnce(async (plan) => {
       plan.dispatcherOptions?.onSkip?.({}, { kind: "final", reason: "empty" });

--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -1440,6 +1440,104 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     );
   });
 
+  it("emits the fallback when a non-final suppression precedes a final failure", async () => {
+    dispatchChannelInboundTurnMock.mockImplementationOnce(async (plan) => {
+      await plan.delivery.onDelivered?.(
+        { text: "cancelled tool reply" },
+        { kind: "tool" },
+        {
+          visibleReplySent: false,
+          suppression: { reason: "cancelled_by_reply_payload_sending_hook" },
+        },
+      );
+      plan.delivery.onError?.(new Error("Telegram final delivery failed"), {
+        kind: "final",
+      });
+      return {
+        admission: { kind: "dispatch" },
+        dispatched: true,
+        ctxPayload: plan.ctxPayload,
+        routeSessionKey: plan.route.sessionKey,
+        dispatchResult: {
+          queuedFinal: false,
+          counts: { block: 0, final: 0, tool: 0 },
+        },
+      };
+    });
+    const { handler } = registerAndResolveStatusHandler({ cfg: {} });
+
+    await handler(createTelegramPrivateCommandContext());
+
+    expect(deliveryMocks.deliverReplies).toHaveBeenCalledOnce();
+    expect(deliveryMocks.deliverReplies).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replies: [{ text: "No response generated. Please try again." }],
+      }),
+    );
+  });
+
+  it("emits the fallback when a suppressed block reply precedes a final failure", async () => {
+    dispatchChannelInboundTurnMock.mockImplementationOnce(async (plan) => {
+      await plan.delivery.onDelivered?.(
+        { text: "cancelled block reply" },
+        { kind: "block" },
+        {
+          visibleReplySent: false,
+          suppression: { reason: "empty_after_reply_payload_sending_hook" },
+        },
+      );
+      plan.delivery.onError?.(new Error("Telegram final delivery failed"), {
+        kind: "final",
+      });
+      return {
+        admission: { kind: "dispatch" },
+        dispatched: true,
+        ctxPayload: plan.ctxPayload,
+        routeSessionKey: plan.route.sessionKey,
+        dispatchResult: {
+          queuedFinal: false,
+          counts: { block: 0, final: 0, tool: 0 },
+        },
+      };
+    });
+    const { handler } = registerAndResolveStatusHandler({ cfg: {} });
+
+    await handler(createTelegramPrivateCommandContext());
+
+    expect(deliveryMocks.deliverReplies).toHaveBeenCalledOnce();
+  });
+
+  it("emits the fallback when a final failure precedes a later suppressed final", async () => {
+    dispatchChannelInboundTurnMock.mockImplementationOnce(async (plan) => {
+      plan.delivery.onError?.(new Error("Telegram final delivery failed"), {
+        kind: "final",
+      });
+      await plan.delivery.onDelivered?.(
+        { text: "cancelled final reply" },
+        { kind: "final" },
+        {
+          visibleReplySent: false,
+          suppression: { reason: "cancelled_by_reply_payload_sending_hook" },
+        },
+      );
+      return {
+        admission: { kind: "dispatch" },
+        dispatched: true,
+        ctxPayload: plan.ctxPayload,
+        routeSessionKey: plan.route.sessionKey,
+        dispatchResult: {
+          queuedFinal: false,
+          counts: { block: 0, final: 0, tool: 0 },
+        },
+      };
+    });
+    const { handler } = registerAndResolveStatusHandler({ cfg: {} });
+
+    await handler(createTelegramPrivateCommandContext());
+
+    expect(deliveryMocks.deliverReplies).toHaveBeenCalledOnce();
+  });
+
   it("retains the empty fallback for a true non-silent metadata-only native reply", async () => {
     dispatchChannelInboundTurnMock.mockImplementationOnce(async (plan) => {
       plan.dispatcherOptions?.onSkip?.({}, { kind: "final", reason: "empty" });

--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -1,4 +1,5 @@
 // Telegram tests cover bot native commands.session meta plugin behavior.
+import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";
 import { resolveChunkMode } from "openclaw/plugin-sdk/reply-dispatch-runtime";
@@ -1550,6 +1551,32 @@ describe("registerTelegramNativeCommands — session metadata", () => {
           visibleReplySent: false,
           suppression: { reason: "cancelled_by_reply_payload_sending_hook" },
         },
+      );
+      return {
+        admission: { kind: "dispatch" },
+        dispatched: true,
+        ctxPayload: plan.ctxPayload,
+        routeSessionKey: plan.route.sessionKey,
+        dispatchResult: {
+          queuedFinal: false,
+          counts: { block: 0, final: 0, tool: 0 },
+        },
+      };
+    });
+    const { handler } = registerAndResolveStatusHandler({ cfg: {} });
+
+    await handler(createTelegramPrivateCommandContext());
+
+    expect(deliveryMocks.deliverReplies).not.toHaveBeenCalled();
+  });
+
+  it("does not emit the fallback after a partially delivered final", async () => {
+    dispatchChannelInboundTurnMock.mockImplementationOnce(async (plan) => {
+      plan.delivery.onError?.(
+        createChannelPartialDeliveryError(new Error("Telegram final delivery failed"), {
+          visibleReplySent: true,
+        }),
+        { kind: "final" },
       );
       return {
         admission: { kind: "dispatch" },

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -1683,10 +1683,10 @@ export const registerTelegramNativeCommands = ({
           resolveTelegramNativeCommandDisableBlockStreaming(runtimeTelegramCfg);
         const deliveryState = {
           delivered: false,
-          intentionallySuppressed: false,
           skippedNonSilent: 0,
           failedNonSilent: 0,
         };
+        let finalReplyOutcome: "failed" | "suppressed" | undefined;
 
         const { deliverReplies } = await loadTelegramNativeCommandDeliveryRuntime();
         let recordSessionMetaTask: Promise<unknown> | undefined;
@@ -1762,24 +1762,21 @@ export const registerTelegramNativeCommands = ({
                   };
             },
             onDelivered: (_payload, info, result) => {
-              // Only a final suppression may suppress the fallback; tool/block
-              // suppressions must not erase a later final failure's visible
-              // outcome. A failed final outweighs later suppression.
               const reason = result?.suppression?.reason;
               if (
                 info.kind === "final" &&
-                deliveryState.failedNonSilent === 0 &&
+                finalReplyOutcome !== "failed" &&
                 (reason === "cancelled_by_reply_payload_sending_hook" ||
                   reason === "empty_after_reply_payload_sending_hook")
               ) {
-                deliveryState.intentionallySuppressed = true;
+                finalReplyOutcome = "suppressed";
               }
             },
             onError: (err, info) => {
               deliveryState.failedNonSilent += 1;
               if (info.kind === "final") {
                 // A failed final outweighs any earlier suppression until a final delivers.
-                deliveryState.intentionallySuppressed = false;
+                finalReplyOutcome = "failed";
               }
               runtime.error?.(danger(`telegram slash ${info.kind} reply failed: ${String(err)}`));
             },
@@ -1795,7 +1792,7 @@ export const registerTelegramNativeCommands = ({
         )(turnPlan);
         if (
           !deliveryState.delivered &&
-          !deliveryState.intentionallySuppressed &&
+          finalReplyOutcome !== "suppressed" &&
           (deliveryState.skippedNonSilent > 0 || deliveryState.failedNonSilent > 0) &&
           (!turnResult.dispatched ||
             turnResult.dispatchResult.sourceReplyDeliveryMode !== "message_tool_only" ||

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -1761,17 +1761,26 @@ export const registerTelegramNativeCommands = ({
                     suppression: { reason: "no_visible_result" as const },
                   };
             },
-            onDelivered: (_payload, _info, result) => {
+            onDelivered: (_payload, info, result) => {
+              // Only a final suppression may suppress the fallback; tool/block
+              // suppressions must not erase a later final failure's visible
+              // outcome. A failed final outweighs later suppression.
               const reason = result?.suppression?.reason;
               if (
-                reason === "cancelled_by_reply_payload_sending_hook" ||
-                reason === "empty_after_reply_payload_sending_hook"
+                info.kind === "final" &&
+                deliveryState.failedNonSilent === 0 &&
+                (reason === "cancelled_by_reply_payload_sending_hook" ||
+                  reason === "empty_after_reply_payload_sending_hook")
               ) {
                 deliveryState.intentionallySuppressed = true;
               }
             },
             onError: (err, info) => {
               deliveryState.failedNonSilent += 1;
+              if (info.kind === "final") {
+                // A failed final outweighs any earlier suppression until a final delivers.
+                deliveryState.intentionallySuppressed = false;
+              }
               runtime.error?.(danger(`telegram slash ${info.kind} reply failed: ${String(err)}`));
             },
           },
@@ -1787,7 +1796,7 @@ export const registerTelegramNativeCommands = ({
         if (
           !deliveryState.delivered &&
           !deliveryState.intentionallySuppressed &&
-          deliveryState.skippedNonSilent > 0 &&
+          (deliveryState.skippedNonSilent > 0 || deliveryState.failedNonSilent > 0) &&
           (!turnResult.dispatched ||
             turnResult.dispatchResult.sourceReplyDeliveryMode !== "message_tool_only" ||
             deliveryState.failedNonSilent > 0)

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -8,7 +8,10 @@ import {
   resolveDefaultModelForAgent,
   resolveThinkingDefaultWithRuntimeCatalog,
 } from "openclaw/plugin-sdk/agent-runtime";
-import type { ChannelInboundTurnPlan } from "openclaw/plugin-sdk/channel-inbound";
+import {
+  isChannelPartialDeliveryError,
+  type ChannelInboundTurnPlan,
+} from "openclaw/plugin-sdk/channel-inbound";
 import { resolveChannelStreamingBlockEnabled } from "openclaw/plugin-sdk/channel-outbound";
 import { resolveNativeCommandSessionTargets } from "openclaw/plugin-sdk/command-auth-native";
 import {
@@ -1686,7 +1689,7 @@ export const registerTelegramNativeCommands = ({
           skippedNonSilent: 0,
           failedNonSilent: 0,
         };
-        let finalReplyOutcome: "failed" | "suppressed" | undefined;
+        let finalReplyOutcome: "accepted" | "failed" | "suppressed" | undefined;
 
         const { deliverReplies } = await loadTelegramNativeCommandDeliveryRuntime();
         let recordSessionMetaTask: Promise<unknown> | undefined;
@@ -1763,6 +1766,9 @@ export const registerTelegramNativeCommands = ({
             },
             onDelivered: (_payload, info, result) => {
               const reason = result?.suppression?.reason;
+              if (info.kind === "final" && result?.visibleReplySent) {
+                finalReplyOutcome = "accepted";
+              }
               if (
                 info.kind === "final" &&
                 finalReplyOutcome !== "failed" &&
@@ -1774,9 +1780,14 @@ export const registerTelegramNativeCommands = ({
             },
             onError: (err, info) => {
               deliveryState.failedNonSilent += 1;
+              const partialDelivery = isChannelPartialDeliveryError(err);
+              if (partialDelivery) {
+                deliveryState.delivered = true;
+                logVerbose("telegram slash reply partially delivered before failure");
+              }
               if (info.kind === "final") {
                 // A failed final outweighs any earlier suppression until a final delivers.
-                finalReplyOutcome = "failed";
+                finalReplyOutcome = partialDelivery ? "accepted" : "failed";
               }
               runtime.error?.(danger(`telegram slash ${info.kind} reply failed: ${String(err)}`));
             },


### PR DESCRIPTION
Related: #118545

Relates to gap finding: B3 (confirmed, medium)

## What Problem This Solves

Telegram native slash commands could end silently when a non-final reply was intentionally suppressed and the final reply then failed. The user saw neither the requested result nor an actionable failure.

## Why This Change Was Made

The Telegram native-command delivery owner now records the final reply outcome independently from aggregate tool/block/final delivery failures. Only a deliberately suppressed final may suppress the empty-response fallback. A failed final shows the fallback. Non-final failures do not override a later deliberate final suppression.

This matches the final-only outcome model already used by Discord native interactions in #118545.

## User Impact

Telegram slash-command users now receive `No response generated. Please try again.` when the final response cannot be delivered. Successfully delivered responses and deliberately suppressed finals remain unchanged.

## Evidence

- Current `main` reproduction: 49/50 focused tests passed; the regression failed because no fallback was delivered.
- Exact head `c506cab8f227eda3a32b7cc1e2ad33149e16718d`: 52/52 focused native-command tests and 87/87 Telegram delivery tests passed.
- Callback-order coverage includes non-final suppression → final failure and non-final failure → final suppression.
- Partial-final coverage proves accepted Telegram chunks prevent an incorrect empty-response fallback.
- Autoreview: clean; no findings.
- Oxfmt, scoped Oxlint, and `git diff --check`: clean.
- Full changed gate stopped on pre-existing max-lines baseline failures in unrelated Signal, voice-call, and speech-core files; Telegram lanes were not implicated.

### Real behavior proof

`telegram-e2e-userbot` drove a real Telegram user through the real Bot API against exact head `c506cab8f227eda3a32b7cc1e2ad33149e16718d` with a deterministic mock provider and ephemeral Gateway.

1. Baseline native `/status`: one visible Telegram response.
2. Fault scenario: a temporary `reply_payload_sending` hook intentionally suppressed the block reply, then forced the final reply delivery to fail through a disallowed local media path.
3. Observed Gateway order: `suppressing block` → `final reply failed` → Telegram `sendMessage ok`.
4. User-visible result: exactly one SUT message, `No response generated. Please try again.` No silent turn.

```json
{
  "schema": "openclaw.real-behavior-proof.v1",
  "head": "c506cab8f227eda3a32b7cc1e2ad33149e16718d",
  "channel": "telegram",
  "driver": "telegram-e2e-userbot",
  "transport": "real Telegram user and Bot API",
  "provider": "deterministic mock",
  "scenario": "native slash command: suppressed block then failed final",
  "observed": {
    "block": "suppressed_by_reply_payload_hook",
    "final": "delivery_failed",
    "visible_messages": ["No response generated. Please try again."],
    "silent_turn": false
  },
  "verdict": "pass"
}
```
