### PR TITLE
fix(agents): bound no-op mid-turn retry at the retry-budget owner (#119313)

### DIFF
--- a/src/agents/embedded-agent-runner/run.attempt-normalization.direct.test.ts
+++ b/src/agents/embedded-agent-runner/run.attempt-normalization.direct.test.ts
@@ -181,7 +181,7 @@ describe("normalizeEmbeddedRunAttempt", () => {
     expect(state.continueFromCurrentTranscript).toHaveBeenCalledOnce();
   });
 
-  it("marks a successful no-op mid-turn retry as a progress continuation", async () => {
+  it("keeps a no-op mid-turn retry (nothing trimmed) in the recovery budget", async () => {
     const state = makePromptState();
     const attempt = makeAttempt({
       route: "truncate_tool_results_only",
@@ -199,6 +199,33 @@ describe("normalizeEmbeddedRunAttempt", () => {
     if (result.action !== "retry") {
       throw new Error(`expected retry, got ${result.action}`);
     }
+    // A mid-turn recovery that trimmed nothing (truncatedCount === 0) changed no
+    // session state, so it is a fixed-point retry that must spend budget like any
+    // other recovery — not a refunded progress continuation.
+    expect(result.retryKind).toBe("recovery");
+    expect(state.continueFromCurrentTranscript).toHaveBeenCalledOnce();
+  });
+
+  it("marks a mid-turn retry that actually trimmed content as a progress continuation", async () => {
+    const state = makePromptState();
+    const attempt = makeAttempt({
+      route: "truncate_tool_results_only",
+      source: "mid-turn",
+      handled: true,
+      truncatedCount: 2,
+    });
+    attempt.toolMetas = [{ toolName: "read", isError: false }];
+
+    const input = makeNormalizationInput(attempt, state);
+    input.lastRunPromptUsage = { input: 42_000, output: 1_000, total: 43_000 };
+    const result = await normalizeEmbeddedRunAttempt(input);
+
+    expect(result.action).toBe("retry");
+    if (result.action !== "retry") {
+      throw new Error(`expected retry, got ${result.action}`);
+    }
+    // A real truncation (truncatedCount > 0) shortened the context, so the retry
+    // is genuine progress and refunds the budget.
     expect(result.retryKind).toBe("progress_continuation");
     expect(state.continueFromCurrentTranscript).toHaveBeenCalledOnce();
   });

--- a/src/agents/embedded-agent-runner/run.proof-119313.test.ts
+++ b/src/agents/embedded-agent-runner/run.proof-119313.test.ts
@@ -1,0 +1,115 @@
+// Deterministic proof driver for #119313: a mid-turn recovery route that
+// trimmed nothing (truncatedCount === 0) changes no session state, so it is a
+// fixed-point retry that must spend the retry budget like any other recovery.
+// The run loop's retry-limit exit must fire at maxAttempts instead of looping
+// forever while refunding the only enforced counter.
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
+import {
+  mockedRunEmbeddedAttempt,
+  overflowBaseRunParams,
+  resetSharedRunIntegrationHarnessMocks,
+} from "./run.overflow-compaction.harness.js";
+import { loadSharedRunIntegrationHarness } from "./run.shared-integration-harness.test-support.js";
+
+let runEmbeddedAgent: typeof import("./run.js").runEmbeddedAgent;
+
+describe("run retry budget no-op mid-turn wall (proof #119313)", () => {
+  beforeAll(async () => {
+    runEmbeddedAgent = await loadSharedRunIntegrationHarness();
+  });
+
+  beforeEach(() => {
+    resetSharedRunIntegrationHarnessMocks();
+  });
+
+  it("stops a fixed-point no-op mid-turn loop at the 32-dispatch cap with retry_limit", async () => {
+    // Every attempt returns the mid-turn precheck no-op outcome from
+    // attempt-prompt-preflight.ts: route=truncate_tool_results_only,
+    // source=mid-turn, handled=true, truncatedCount=0, plus one non-erroring
+    // tool call. Under the corrected contract this is a recovery retry (nothing
+    // was trimmed), so it spends budget and the cap trips at maxAttempts.
+    mockedRunEmbeddedAttempt.mockImplementation(async () =>
+      makeAttemptResult({
+        preflightRecovery: {
+          route: "truncate_tool_results_only",
+          source: "mid-turn",
+          handled: true as const,
+          truncatedCount: 0,
+        },
+        toolMetas: [{ toolName: "read", meta: "step", isError: false }],
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      runId: "run-proof-119313-noop-wall",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(32);
+    expect(result.meta.error?.kind).toBe("retry_limit");
+    expect(result.meta.error?.message).toContain("after 32 attempts");
+    expect(result.meta.error?.message).toContain("max=32");
+  });
+
+  it("never dispatches a 33rd attempt even when a later attempt would complete", async () => {
+    let calls = 0;
+    mockedRunEmbeddedAttempt.mockImplementation(async () => {
+      calls += 1;
+      if (calls >= 33) {
+        return makeAttemptResult();
+      }
+      return makeAttemptResult({
+        preflightRecovery: {
+          route: "truncate_tool_results_only",
+          source: "mid-turn",
+          handled: true as const,
+          truncatedCount: 0,
+        },
+        toolMetas: [{ toolName: "read", meta: "step", isError: false }],
+      });
+    });
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      runId: "run-proof-119313-no-33rd",
+    });
+
+    // The run stops at the budget wall: a would-be completing attempt that
+    // would have been the 33rd dispatch is never reached.
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(32);
+    expect(result.meta.error?.kind).toBe("retry_limit");
+  });
+
+  it("does not bound a run whose mid-turn retries actually trim content", async () => {
+    // A real truncation (truncatedCount > 0) is genuine progress: it refunds
+    // attemptsCounted, so a long run of real truncations is never bounded by
+    // the cap and completes when the model stops returning overflow recoveries.
+    let calls = 0;
+    mockedRunEmbeddedAttempt.mockImplementation(async () => {
+      calls += 1;
+      if (calls >= 40) {
+        return makeAttemptResult();
+      }
+      return makeAttemptResult({
+        preflightRecovery: {
+          route: "truncate_tool_results_only",
+          source: "mid-turn",
+          handled: true as const,
+          truncatedCount: 2,
+        },
+        toolMetas: [{ toolName: "read", meta: "step", isError: false }],
+      });
+    });
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      runId: "run-proof-119313-real-progress",
+    });
+
+    // 40 dispatched attempts — past the 32 cap — and the run completes instead
+    // of returning retry_limit, proving real progress is not bounded.
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(40);
+    expect(result.meta.error?.kind).not.toBe("retry_limit");
+  });
+});

--- a/src/agents/embedded-agent-runner/run/retry-budget.test.ts
+++ b/src/agents/embedded-agent-runner/run/retry-budget.test.ts
@@ -8,10 +8,35 @@ import {
 } from "./retry-budget.js";
 
 describe("run retry budget", () => {
-  it("allows more than 32 progressing continuations", () => {
+  it("allows more than 32 progressing continuations that actually trimmed content", () => {
     const budget = createRunRetryBudget(32);
 
     for (let step = 0; step < 33; step += 1) {
+      beginRunAttempt(budget);
+      recordRunRetry(
+        budget,
+        resolveRunRetryKind({
+          preflightRecovery: {
+            route: "truncate_tool_results_only",
+            truncatedCount: 1,
+          },
+          retryingFromTranscript: true,
+          toolMetas: [{ toolName: "read", meta: `step=${step}`, isError: false }],
+        }),
+      );
+    }
+
+    // A real truncation (truncatedCount > 0) is genuine progress: it refunds
+    // attemptsCounted and is never bounded by the cap, so a long run of real
+    // tool-loop progress can exceed maxAttempts.
+    expect(budget).toEqual({ attemptsDispatched: 33, attemptsCounted: 0, maxAttempts: 32 });
+    expect(isRunRetryBudgetExhausted(budget)).toBe(false);
+  });
+
+  it("bounds a fixed-point run of no-op mid-turn continuations at the retry cap", () => {
+    const budget = createRunRetryBudget(32);
+
+    for (let step = 0; step < 32; step += 1) {
       beginRunAttempt(budget);
       recordRunRetry(
         budget,
@@ -24,10 +49,14 @@ describe("run retry budget", () => {
           toolMetas: [{ toolName: "read", meta: `step=${step}`, isError: false }],
         }),
       );
+      // A no-op recovery (truncatedCount === 0) changed no session state, so it
+      // spends budget like any other recovery retry and the cap trips at 32.
+      expect(isRunRetryBudgetExhausted(budget)).toBe(step >= 31);
     }
 
-    expect(budget).toEqual({ attemptsDispatched: 33, attemptsCounted: 0, maxAttempts: 32 });
-    expect(isRunRetryBudgetExhausted(budget)).toBe(false);
+    expect(budget.attemptsDispatched).toBe(32);
+    expect(budget.attemptsCounted).toBe(32);
+    expect(isRunRetryBudgetExhausted(budget)).toBe(true);
   });
 
   it("still stops 32 retries that make no progress", () => {

--- a/src/agents/embedded-agent-runner/run/retry-budget.ts
+++ b/src/agents/embedded-agent-runner/run/retry-budget.ts
@@ -24,9 +24,12 @@ export function resolveRunRetryKind(params: {
   retryingFromTranscript: boolean;
   toolMetas: Array<{ isError?: boolean; meta?: string; toolName: string }>;
 }): RunRetryKind {
+  // Only real truncation (truncatedCount > 0) is progress: a no-op recovery
+  // (truncatedCount === 0) changes no state and would otherwise refund itself
+  // into an unbounded billed loop with no retry-limit exit.
   return params.retryingFromTranscript &&
     params.preflightRecovery.route === "truncate_tool_results_only" &&
-    params.preflightRecovery.truncatedCount === 0 &&
+    (params.preflightRecovery.truncatedCount ?? 0) > 0 &&
     params.toolMetas.some((tool) => tool.isError !== true)
     ? "progress_continuation"
     : "recovery";


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users with `agents.defaults.compaction.midTurnPrecheck.enabled: true` (opt-in) would experience a long tool-heavy session looping forever — `runEmbeddedAgent` keeps dispatching billed model calls with zero backoff and never surfaces an error — when the session's context pressure comes from accumulated history rather than a few oversized tool results, so the persisted truncator has nothing to trim. The run only stops on a manual user abort.

## Why This Change Was Made

The retry budget's `progress_continuation` refund had its predicate reversed. `resolveRunRetryKind` classified a mid-turn truncate-only recovery with `truncatedCount === 0` as progress (refunding `attemptsCounted`), but `truncatedCount === 0` is exactly the case where the truncator found nothing to trim — the recovery route changed no persisted session state, so the next attempt re-derives the same inputs and the loop is a fixed point. The refund paid for itself every iteration, `attemptsCounted` stayed at zero, and the `retry_limit` exit was unreachable. This shipped in `f7434f94cfb` (#117963), whose own test asserted the unbounded refund.

The fix reverses the predicate direction: a mid-turn truncate-only retry now counts as `progress_continuation` only when the truncator actually trimmed content (`truncatedCount > 0`) — the case where the retry advances with a shorter context. A no-op recovery (`truncatedCount === 0`) spends budget like any other recovery retry, so the cap trips at `maxAttempts` and the run returns the documented `retry_limit`. This is option 2 from the issue ("only refund when the attempt actually changed persisted session state"). `isRunRetryBudgetExhausted` still bounds on `attemptsCounted`; `recordRunRetry` / `resolveRunRetryKind` signatures are unchanged. `attempt-prompt-preflight.ts` confirms the no-op route returns without calling `replaceSessionMessages`.

A maintainer commit on `main` (`a7564ee12f1`, #121657) only exports the `RunRetryBudget` type and documents the accounting owner map; it does not touch `isRunRetryBudgetExhausted`, `recordRunRetry`, or `resolveRunRetryKind`. Issue #119313 remains OPEN and the bug is still present on `main`, so this is not a duplicate.

## User Impact

With `midTurnPrecheck.enabled: true`, a session that would previously loop forever (billed calls until user abort) now terminates with the documented `retry_limit` error after `maxAttempts` dispatched attempts (32–160 depending on profile candidates). Real-truncation progress continuations are unaffected — they still refund and can run past the cap, exactly as before. No config or migration change; default installs are unaffected (the feature is opt-in, default `false`).

## Evidence

All evidence captured on PR head `cefb513aee6d` (Linux x86_64, Node v22.22.3). The proof driver and test files are committed in this PR.

### 1. Deterministic run-loop proof (drives the REAL `runEmbeddedAgent` loop)

`src/agents/embedded-agent-runner/run.proof-119313.test.ts` drives the REAL `runEmbeddedAgent` loop (`run-loop.ts`, `retry-budget.ts`, `normalizeEmbeddedRunAttempt`) through the repository's shared run-integration harness:

```console
$ node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.proof-119313.test.ts --run
 Test Files  1 passed (1)
      Tests  3 passed (3)

  ✓ stops a fixed-point no-op mid-turn loop at the 32-dispatch cap with retry_limit
  ✓ never dispatches a 33rd attempt even when a later attempt would complete
  ✓ does not bound a run whose mid-turn retries actually trim content
```

Outcome matrix:

| Scenario (real `runEmbeddedAgent` loop) | Dispatched | Terminal | Bounded? |
|---|---|---|---|
| Every attempt no-op (`truncatedCount: 0` + non-erroring tool) | 32 | `retry_limit` (after 32 attempts, max=32) | ✅ yes — bug fixed |
| No-op for 32 attempts, 33rd would complete | 32 | `retry_limit` — 33rd never dispatched | ✅ yes — wall holds |
| Real truncation (`truncatedCount: 2`) for 39, then complete | 40 | completes (no `retry_limit`) | ❌ no — real progress preserved |

The third row is the key compatibility proof: valid progress (real truncations) exceeds 32 calls and completes, while repeated no-progress is bounded.

### 2. Unit + integration coverage

```console
$ node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/retry-budget.test.ts --run
      Tests  4 passed (4)
$ node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.attempt-normalization.direct.test.ts --run
      Tests  10 passed (10)
$ node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.shared-integration.test.ts --run
      Tests  64 passed (64)
$ node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt-prompt-preflight.test.ts src/agents/embedded-agent-runner/run/attempt-prompt-context.test.ts src/agents/embedded-agent-runner/run.overflow-context-recovery.test.ts --run
      Tests  16 passed (16)
```

- `retry-budget.test.ts`: real truncation (`truncatedCount: 1`) allows 33+ continuations unbounded; no-op (`truncatedCount: 0`) trips the cap at 32; existing recovery contract unchanged.
- `attempt-normalization.direct.test.ts`: no-op mid-turn retry now classified `recovery`; real-truncation (`truncatedCount: 2`) mid-turn retry classified `progress_continuation`.

### 3. Type / format checks

- `tsgo --noEmit -p tsconfig.core.json`: clean for the changed files (the one `session-ref.ts` module-resolution error pre-exists on `origin/main` and is unrelated).
- `oxfmt --check` + `git diff --check`: clean.

## AI Assistance

- **AI-assisted**: Yes
- **Co-Authored-By**: Claude Opus 4.6 <noreply@anthropic.com>
- **Human confirmed understanding of code changes**: Yes
- **AI prompts / session excerpts**: Available in the contribution session log (issue #119313 workflow, PR #119532 iteration rounds).

Fixes #119313
