### PR TITLE
fix(scripts): reject unsafe web-fetch benchmark counts

### DIFF
--- a/scripts/bench-web-fetch.ts
+++ b/scripts/bench-web-fetch.ts
@@ -156,6 +156,9 @@ function parsePositiveInteger(flag: string, fallback: number, args: string[]): n
     return fallback;
   }
   const raw = args[index + 1];
+  if (!/^\d+$/u.test(raw ?? "")) {
+    throw new CliArgumentError(`${flag} must be a positive integer`);
+  }
   const value = Number(raw);
   if (!Number.isInteger(value) || value <= 0) {
     throw new CliArgumentError(`${flag} must be a positive integer`);
@@ -169,6 +172,9 @@ function parseNonNegativeInteger(flag: string, fallback: number, args: string[])
     return fallback;
   }
   const raw = args[index + 1];
+  if (!/^\d+$/u.test(raw ?? "")) {
+    throw new CliArgumentError(`${flag} must be a non-negative integer`);
+  }
   const value = Number(raw);
   if (!Number.isInteger(value) || value < 0) {
     throw new CliArgumentError(`${flag} must be a non-negative integer`);

--- a/scripts/bench-web-fetch.ts
+++ b/scripts/bench-web-fetch.ts
@@ -160,7 +160,7 @@ function parsePositiveInteger(flag: string, fallback: number, args: string[]): n
     throw new CliArgumentError(`${flag} must be a positive integer`);
   }
   const value = Number(raw);
-  if (!Number.isInteger(value) || value <= 0) {
+  if (!Number.isSafeInteger(value) || value <= 0) {
     throw new CliArgumentError(`${flag} must be a positive integer`);
   }
   return value;
@@ -176,7 +176,7 @@ function parseNonNegativeInteger(flag: string, fallback: number, args: string[])
     throw new CliArgumentError(`${flag} must be a non-negative integer`);
   }
   const value = Number(raw);
-  if (!Number.isInteger(value) || value < 0) {
+  if (!Number.isSafeInteger(value) || value < 0) {
     throw new CliArgumentError(`${flag} must be a non-negative integer`);
   }
   return value;

--- a/test/scripts/bench-web-fetch.test.ts
+++ b/test/scripts/bench-web-fetch.test.ts
@@ -51,12 +51,17 @@ describe("web fetch benchmark script", () => {
     expect(result.stderr).not.toContain("\n    at ");
   });
 
-  it("rejects non-decimal run counts instead of expanding the benchmark", () => {
-    const result = runBenchWebFetch("--runs", "1e3");
+  it.each([
+    ["--runs", "1e3", "--runs must be a positive integer"],
+    ["--warmup", "1e3", "--warmup must be a non-negative integer"],
+    ["--runs", "9007199254740993", "--runs must be a positive integer"],
+    ["--warmup", "9007199254740993", "--warmup must be a non-negative integer"],
+  ])("rejects invalid benchmark count %s %s", (flag, value, expectedError) => {
+    const result = runBenchWebFetch(flag, value);
 
     expect(result.status).toBe(2);
     expect(result.stdout).toBe("");
-    expect(result.stderr.trim()).toBe("--runs must be a positive integer");
+    expect(result.stderr.trim()).toBe(expectedError);
     expect(result.stderr).not.toContain("\n    at ");
   });
 });

--- a/test/scripts/bench-web-fetch.test.ts
+++ b/test/scripts/bench-web-fetch.test.ts
@@ -50,4 +50,13 @@ describe("web fetch benchmark script", () => {
     expect(result.stderr.trim()).toBe("--runs was provided more than once");
     expect(result.stderr).not.toContain("\n    at ");
   });
+
+  it("rejects non-decimal run counts instead of expanding the benchmark", () => {
+    const result = runBenchWebFetch("--runs", "1e3");
+
+    expect(result.status).toBe(2);
+    expect(result.stdout).toBe("");
+    expect(result.stderr.trim()).toBe("--runs must be a positive integer");
+    expect(result.stderr).not.toContain("\n    at ");
+  });
 });


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/98559

## What Problem This Solves

Fixes an issue where operators running the web-fetch benchmark could pass scientific notation or decimal counts outside JavaScript's safe-integer range. Numeric coercion could otherwise expand or round the requested workload instead of rejecting invalid CLI input.

## Why This Change Was Made

The benchmark now accepts only decimal digit text whose numeric value is a safe integer. Validation stays at the existing `--runs` and `--warmup` parser boundary, preserving positive-run and non-negative-warmup semantics plus the existing stack-free `CliArgumentError` exit-code-2 behavior.

## User Impact

Invalid benchmark counts such as `1e3` and `9007199254740993` now fail immediately with the existing flag-specific error. Valid decimal counts continue to behave unchanged.

## Evidence

- Blacksmith Testbox `tbx_01kz8k3bns979q040h9pnxq5g9`: `pnpm test test/scripts/bench-web-fetch.test.ts` passed all 6 process tests, including `--runs` and `--warmup` coverage for scientific notation and the rounded unsafe decimal. Run: https://github.com/openclaw/openclaw/actions/runs/30992243935
- P1 autoreview passed with no accepted or actionable findings; confidence 0.99.
- `oxfmt` passed for both changed files.
- `git diff --check` passed.

## Provenance

The benchmark parser was introduced by PR #98559, squash commit `2f6459093ad3abe4369f686b517b5d78568af35a`, merged on July 4, 2026. The affected implementation shipped in `v2026.7.1-2` and `v2026.7.2-beta.7`.

Punchcard-Session: clear-orchard-lantern-bc

