### PR TITLE
fix(discord): prevent credentials from appearing in non-JSON errors

### DIFF
--- a/extensions/discord/src/api.test.ts
+++ b/extensions/discord/src/api.test.ts
@@ -403,6 +403,40 @@ describe("fetchDiscord", () => {
     }
   });
 
+  it("redacts reflected bot credentials from non-JSON error bodies", async () => {
+    const uniqueSecret = "discord-loopback-secret";
+    const token = `proof-prefix-${uniqueSecret}-proof-suffix`;
+    let authorization: string | undefined;
+    const server = createServer((req, res) => {
+      authorization = req.headers.authorization;
+      res.writeHead(502, { "content-type": "text/html" });
+      res.end(
+        `<html><body>proxy failure Authorization: ${authorization}; request rejected</body></html>`,
+      );
+    });
+    const port = await listenLoopbackServer(server);
+
+    try {
+      stubDiscordFetchToLoopback(`http://127.0.0.1:${port}`);
+
+      const error = await requestDiscord("/gateway/bot", token, {
+        retry: { attempts: 1 },
+      }).catch((err: unknown) => err);
+
+      expect(error).toBeInstanceOf(DiscordApiError);
+      expect(authorization).toBe(`Bot ${token}`);
+      const message = String(error);
+      expect(message).toContain("Discord API /gateway/bot failed (502)");
+      expect(message).toContain("proxy failure");
+      expect(message).toContain("Authorization: Bot");
+      expect(message).not.toContain(token);
+      expect(message).not.toContain(uniqueSecret);
+      expect(message).not.toContain("<html");
+    } finally {
+      await closeServer(server);
+    }
+  });
+
   it("rejects oversized valid JSON requestDiscord responses from a real loopback HTTP server", async () => {
     const oversizedPayloadBytes = DISCORD_SUCCESS_RESPONSE_LIMIT_BYTES + 256 * 1024;
     let contentLength: string | null | undefined;

--- a/extensions/discord/src/api.test.ts
+++ b/extensions/discord/src/api.test.ts
@@ -432,6 +432,52 @@ describe("fetchDiscord", () => {
       expect(message).not.toContain(token);
       expect(message).not.toContain(uniqueSecret);
       expect(message).not.toContain("<html");
+      console.log(
+        `[discord credential redaction proof] format=html status=502 authorization_received=${authorization === `Bot ${token}`} token_present=${message.includes(token)} unique_fragment_present=${message.includes(uniqueSecret)} detail=${message}`,
+      );
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it("redacts reflected bot credentials from JSON error messages", async () => {
+    const uniqueSecret = "discord-json-loopback-secret";
+    const token = `proof-prefix-${uniqueSecret}-proof-suffix`;
+    let authorization: string | undefined;
+    const server = createServer((req, res) => {
+      authorization = req.headers.authorization;
+      res.writeHead(429, { "content-type": "application/json" });
+      res.end(
+        JSON.stringify({
+          message: `proxy failure Authorization: ${authorization}; request rejected`,
+          retry_after: 0,
+          global: false,
+          code: 20_028,
+        }),
+      );
+    });
+    const port = await listenLoopbackServer(server);
+
+    try {
+      stubDiscordFetchToLoopback(`http://127.0.0.1:${port}`);
+
+      const error = await requestDiscord("/gateway/bot", token, {
+        retry: { attempts: 1 },
+      }).catch((err: unknown) => err);
+
+      expect(error).toBeInstanceOf(DiscordApiError);
+      expect(authorization).toBe(`Bot ${token}`);
+      expect((error as DiscordApiError).retryAfter).toBe(0);
+      const message = String(error);
+      expect(message).toContain("Discord API /gateway/bot failed (429)");
+      expect(message).toContain("proxy failure");
+      expect(message).toContain("Authorization: Bot");
+      expect(message).toContain("retry after 0.0s");
+      expect(message).not.toContain(token);
+      expect(message).not.toContain(uniqueSecret);
+      console.log(
+        `[discord credential redaction proof] format=json status=429 authorization_received=${authorization === `Bot ${token}`} token_present=${message.includes(token)} unique_fragment_present=${message.includes(uniqueSecret)} retry_after=${(error as DiscordApiError).retryAfter} detail=${message}`,
+      );
     } finally {
       await closeServer(server);
     }

--- a/extensions/discord/src/api.ts
+++ b/extensions/discord/src/api.ts
@@ -1,5 +1,6 @@
 // Discord API module exposes the plugin public contract.
 import { resolveFetch } from "openclaw/plugin-sdk/fetch-runtime";
+import { redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
@@ -69,7 +70,7 @@ function formatRetryAfterSeconds(value: number | undefined): string | undefined 
   return `${rounded}s`;
 }
 
-function formatDiscordApiErrorText(text: string, response: Response): string | undefined {
+function formatDiscordApiErrorTextUntrusted(text: string, response: Response): string | undefined {
   const trimmed = text.trim();
   if (!trimmed) {
     return undefined;
@@ -97,6 +98,13 @@ function formatDiscordApiErrorText(text: string, response: Response): string | u
     parseDiscordRetryAfterBodySeconds(payload.retry_after),
   );
   return retryAfter ? `${message} (retry after ${retryAfter})` : message;
+}
+
+function formatDiscordApiErrorText(text: string, response: Response): string | undefined {
+  const detail = formatDiscordApiErrorTextUntrusted(text, response);
+  // Keep the final error boundary shared by JSON and text responses redacted;
+  // upstreams can reflect the request Authorization value through either shape.
+  return detail ? redactToolPayloadText(detail) : detail;
 }
 
 export class DiscordApiError extends Error {

--- a/extensions/discord/src/error-body.ts
+++ b/extensions/discord/src/error-body.ts
@@ -1,4 +1,5 @@
 // Discord plugin module implements error body behavior.
+import { redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
 const DISCORD_RESPONSE_BODY_SUMMARY_MAX_CHARS = 240;
@@ -20,7 +21,7 @@ export function summarizeDiscordResponseBody(
   if (!summary) {
     return opts.emptyText;
   }
-  return truncateUtf16Safe(summary, DISCORD_RESPONSE_BODY_SUMMARY_MAX_CHARS);
+  return truncateUtf16Safe(redactToolPayloadText(summary), DISCORD_RESPONSE_BODY_SUMMARY_MAX_CHARS);
 }
 
 export function isDiscordHtmlResponseBody(body: string, contentType?: string | null): boolean {


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

AI-assisted: This change was implemented and validated with Codex.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users troubleshooting Discord API failures could see a bot credential in surfaced error details when a proxy or upstream reflected the request authorization in either JSON or non-JSON output.

## Why This Change Was Made

Discord error details now pass through the shared forced tool-payload redactor at the final formatting boundary used by both JSON and text responses. Existing normalization, response limits, rate-limit behavior, and HTTP status reporting remain intact.

## User Impact

Discord failures retain their status and useful non-sensitive diagnostic text without exposing a reflected bot token.

## Evidence

- Public exact-head run: [Discord runtime proof](https://github.com/Alix-007/openclaw/actions/runs/30989854767) checked out and verified `2bf546d413f736cc647162b48aab36ddff1d3679`.
- Downloadable terminal artifact: [openclaw-discord-2bf546d413f736cc647162b48aab36ddff1d3679](https://github.com/Alix-007/openclaw/actions/runs/30989854767/artifacts/8923642823).
- `node scripts/run-vitest.mjs extensions/discord/src/api.test.ts --reporter=verbose` — 1 file, 21 tests passed through the real loopback `requestDiscord` path.
- Sanitized after-fix terminal output (the synthetic credential is never printed):

```text
[discord credential redaction proof] format=html status=502 authorization_received=true token_present=false unique_fragment_present=false
[discord credential redaction proof] format=json status=429 authorization_received=true token_present=false unique_fragment_present=false retry_after=0
proof_marker_verified=true
```

- Targeted `oxfmt --check`, `oxlint`, and `git diff --check` passed for the touched files.
