### PR TITLE
fix(qqbot): prevent credentials from appearing in API errors

### DIFF
--- a/extensions/qqbot/src/engine/api/api-client.test.ts
+++ b/extensions/qqbot/src/engine/api/api-client.test.ts
@@ -30,20 +30,26 @@ async function startReflectedAuthorizationServer(): Promise<string> {
   const server = createServer((req, res) => {
     req.resume();
     const authorization = req.headers.authorization ?? "";
+    const reflectedCredential = authorization.startsWith("QQBot ")
+      ? authorization.slice("QQBot ".length)
+      : authorization;
+    const formEncodedCredential = new URLSearchParams([["echo", reflectedCredential]]).toString();
 
     if (req.url === "/json-error") {
       res.writeHead(429, { "content-type": "application/json" });
       res.end(
         JSON.stringify({
           code: 40093001,
-          message: `json-marker Authorization: ${authorization}`,
+          message: `json-marker reflected credential ${reflectedCredential}; encoded ${encodeURIComponent(reflectedCredential)}; form ${formEncodedCredential}; Authorization: ${authorization}`,
         }),
       );
       return;
     }
     if (req.url === "/text-error") {
       res.writeHead(503, { "content-type": "text/plain" });
-      res.end(`plain-marker Authorization: ${authorization}`);
+      res.end(
+        `plain-marker reflected credential ${reflectedCredential}; encoded ${encodeURIComponent(reflectedCredential)}; form ${formEncodedCredential}; Authorization: ${authorization}`,
+      );
       return;
     }
     if (req.url === "/success") {
@@ -134,7 +140,11 @@ describe("ApiClient", () => {
     );
 
     const logger = { info: vi.fn(), error: vi.fn(), debug: vi.fn() };
-    const accessToken = "qqbot_AAAAUNIQUEQQBOTSECRETBBBB111122223333";
+    const secretPrefix = "qQApiP";
+    const secretSuffix = "aSfQ";
+    const accessToken = `${secretPrefix}/UNIQUE~QQBOTSECRET+${secretSuffix}`;
+    const encodedCredential = encodeURIComponent(accessToken);
+    const formEncodedCredential = new URLSearchParams([["echo", accessToken]]).toString();
     const authorization = `QQBot ${accessToken}`;
     const client = new ApiClient({ baseUrl, logger });
 
@@ -147,6 +157,12 @@ describe("ApiClient", () => {
     expect(jsonError.bizMessage).toContain("json-marker");
     expect(jsonError.message).not.toContain(accessToken);
     expect(jsonError.bizMessage).not.toContain(accessToken);
+    expect(jsonError.message).not.toContain(encodedCredential);
+    expect(jsonError.bizMessage).not.toContain(encodedCredential);
+    expect(jsonError.message).not.toContain(formEncodedCredential);
+    expect(jsonError.bizMessage).not.toContain(formEncodedCredential);
+    expect(jsonError.message).not.toContain(secretPrefix);
+    expect(jsonError.bizMessage).not.toContain(secretSuffix);
     expect(jsonError.message).not.toContain("UNIQUEQQBOTSECRET");
 
     const textError = await captureApiError(() =>
@@ -156,6 +172,10 @@ describe("ApiClient", () => {
     expect(textError.bizCode).toBeUndefined();
     expect(textError.message).toContain("plain-marker");
     expect(textError.message).not.toContain(accessToken);
+    expect(textError.message).not.toContain(encodedCredential);
+    expect(textError.message).not.toContain(formEncodedCredential);
+    expect(textError.message).not.toContain(secretPrefix);
+    expect(textError.message).not.toContain(secretSuffix);
     expect(textError.message).not.toContain("UNIQUEQQBOTSECRET");
 
     const success = await client.request<{ authorization: string; marker: string }>(
@@ -170,6 +190,10 @@ describe("ApiClient", () => {
     expect(debugOutput).toContain("plain-marker");
     expect(debugOutput).toContain("success-marker");
     expect(debugOutput).not.toContain(accessToken);
+    expect(debugOutput).not.toContain(encodedCredential);
+    expect(debugOutput).not.toContain(formEncodedCredential);
+    expect(debugOutput).not.toContain(secretPrefix);
+    expect(debugOutput).not.toContain(secretSuffix);
     expect(debugOutput).not.toContain("UNIQUEQQBOTSECRET");
 
     const redactedSurfaces = [
@@ -186,6 +210,7 @@ describe("ApiClient", () => {
       console.info(
         `[qqbot credential redaction proof] ${JSON.stringify({
           exactHead: proofHeadSha,
+          transport: "loopback-http",
           status: [jsonError.httpStatus, textError.httpStatus, 200],
           path: ["/json-error", "/text-error", "/success"],
           safeMarkerPresent:
@@ -193,6 +218,10 @@ describe("ApiClient", () => {
             redactedSurfaces.includes("plain-marker") &&
             redactedSurfaces.includes("success-marker"),
           tokenAbsent: !redactedSurfaces.includes(accessToken),
+          encodedAbsent: !redactedSurfaces.includes(encodedCredential),
+          formEncodedAbsent: !redactedSurfaces.includes(formEncodedCredential),
+          prefixAbsent: !redactedSurfaces.includes(secretPrefix),
+          suffixAbsent: !redactedSurfaces.includes(secretSuffix),
           fragmentAbsent: !redactedSurfaces.includes("UNIQUEQQBOTSECRET"),
         })}`,
       );

--- a/extensions/qqbot/src/engine/api/api-client.test.ts
+++ b/extensions/qqbot/src/engine/api/api-client.test.ts
@@ -4,6 +4,10 @@ import type { LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
 // Qqbot tests cover api-client plugin behavior.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createStreamingResponse } from "../../../../test-support/streaming-error-response.js";
+import {
+  lowercasePercentEscapes,
+  stringifyWithSlashEscapedCredential,
+} from "../../test-support/credential-reflection.js";
 
 const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
 const ssrfRuntimeActual = vi.hoisted(() => ({
@@ -33,22 +37,33 @@ async function startReflectedAuthorizationServer(): Promise<string> {
     const reflectedCredential = authorization.startsWith("QQBot ")
       ? authorization.slice("QQBot ".length)
       : authorization;
-    const formEncodedCredential = new URLSearchParams([["echo", reflectedCredential]]).toString();
+    const encodedCredential = lowercasePercentEscapes(encodeURIComponent(reflectedCredential));
+    const formEncodedCredential = lowercasePercentEscapes(
+      new URLSearchParams([["echo", reflectedCredential]]).toString(),
+    );
+    const slashEscapedCredential = reflectedCredential.replaceAll("/", "\\/");
+    const slashEscapedAuthorization = authorization.replaceAll(
+      reflectedCredential,
+      slashEscapedCredential,
+    );
 
     if (req.url === "/json-error") {
       res.writeHead(429, { "content-type": "application/json" });
       res.end(
-        JSON.stringify({
-          code: 40093001,
-          message: `json-marker reflected credential ${reflectedCredential}; encoded ${encodeURIComponent(reflectedCredential)}; form ${formEncodedCredential}; Authorization: ${authorization}`,
-        }),
+        stringifyWithSlashEscapedCredential(
+          {
+            code: 40093001,
+            message: `json-marker reflected credential ${reflectedCredential}; encoded ${encodedCredential}; form ${formEncodedCredential}; Authorization: ${authorization}`,
+          },
+          reflectedCredential,
+        ),
       );
       return;
     }
     if (req.url === "/text-error") {
       res.writeHead(503, { "content-type": "text/plain" });
       res.end(
-        `plain-marker reflected credential ${reflectedCredential}; encoded ${encodeURIComponent(reflectedCredential)}; form ${formEncodedCredential}; Authorization: ${authorization}`,
+        `plain-marker reflected credential ${slashEscapedCredential}; encoded ${encodedCredential}; form ${formEncodedCredential}; Authorization: ${slashEscapedAuthorization}`,
       );
       return;
     }
@@ -145,6 +160,9 @@ describe("ApiClient", () => {
     const accessToken = `${secretPrefix}/UNIQUE~QQBOTSECRET+${secretSuffix}`;
     const encodedCredential = encodeURIComponent(accessToken);
     const formEncodedCredential = new URLSearchParams([["echo", accessToken]]).toString();
+    const lowercaseEncodedCredential = lowercasePercentEscapes(encodedCredential);
+    const lowercaseFormEncodedCredential = lowercasePercentEscapes(formEncodedCredential);
+    const slashEscapedCredential = accessToken.replaceAll("/", "\\/");
     const authorization = `QQBot ${accessToken}`;
     const client = new ApiClient({ baseUrl, logger });
 
@@ -161,6 +179,12 @@ describe("ApiClient", () => {
     expect(jsonError.bizMessage).not.toContain(encodedCredential);
     expect(jsonError.message).not.toContain(formEncodedCredential);
     expect(jsonError.bizMessage).not.toContain(formEncodedCredential);
+    expect(jsonError.message).not.toContain(lowercaseEncodedCredential);
+    expect(jsonError.bizMessage).not.toContain(lowercaseEncodedCredential);
+    expect(jsonError.message).not.toContain(lowercaseFormEncodedCredential);
+    expect(jsonError.bizMessage).not.toContain(lowercaseFormEncodedCredential);
+    expect(jsonError.message).not.toContain(slashEscapedCredential);
+    expect(jsonError.bizMessage).not.toContain(slashEscapedCredential);
     expect(jsonError.message).not.toContain(secretPrefix);
     expect(jsonError.bizMessage).not.toContain(secretSuffix);
     expect(jsonError.message).not.toContain("UNIQUEQQBOTSECRET");
@@ -174,6 +198,9 @@ describe("ApiClient", () => {
     expect(textError.message).not.toContain(accessToken);
     expect(textError.message).not.toContain(encodedCredential);
     expect(textError.message).not.toContain(formEncodedCredential);
+    expect(textError.message).not.toContain(lowercaseEncodedCredential);
+    expect(textError.message).not.toContain(lowercaseFormEncodedCredential);
+    expect(textError.message).not.toContain(slashEscapedCredential);
     expect(textError.message).not.toContain(secretPrefix);
     expect(textError.message).not.toContain(secretSuffix);
     expect(textError.message).not.toContain("UNIQUEQQBOTSECRET");
@@ -192,6 +219,9 @@ describe("ApiClient", () => {
     expect(debugOutput).not.toContain(accessToken);
     expect(debugOutput).not.toContain(encodedCredential);
     expect(debugOutput).not.toContain(formEncodedCredential);
+    expect(debugOutput).not.toContain(lowercaseEncodedCredential);
+    expect(debugOutput).not.toContain(lowercaseFormEncodedCredential);
+    expect(debugOutput).not.toContain(slashEscapedCredential);
     expect(debugOutput).not.toContain(secretPrefix);
     expect(debugOutput).not.toContain(secretSuffix);
     expect(debugOutput).not.toContain("UNIQUEQQBOTSECRET");
@@ -220,6 +250,9 @@ describe("ApiClient", () => {
           tokenAbsent: !redactedSurfaces.includes(accessToken),
           encodedAbsent: !redactedSurfaces.includes(encodedCredential),
           formEncodedAbsent: !redactedSurfaces.includes(formEncodedCredential),
+          lowercaseEncodedAbsent: !redactedSurfaces.includes(lowercaseEncodedCredential),
+          lowercaseFormEncodedAbsent: !redactedSurfaces.includes(lowercaseFormEncodedCredential),
+          jsonSlashEscapedAbsent: !redactedSurfaces.includes(slashEscapedCredential),
           prefixAbsent: !redactedSurfaces.includes(secretPrefix),
           suffixAbsent: !redactedSurfaces.includes(secretSuffix),
           fragmentAbsent: !redactedSurfaces.includes("UNIQUEQQBOTSECRET"),

--- a/extensions/qqbot/src/engine/api/api-client.test.ts
+++ b/extensions/qqbot/src/engine/api/api-client.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createStreamingResponse } from "../../../../test-support/streaming-error-response.js";
 import {
   lowercasePercentEscapes,
+  percentEncodeEveryUtf8Byte,
   stringifyWithSlashEscapedCredential,
 } from "../../test-support/credential-reflection.js";
 
@@ -38,6 +39,7 @@ async function startReflectedAuthorizationServer(): Promise<string> {
       ? authorization.slice("QQBot ".length)
       : authorization;
     const encodedCredential = lowercasePercentEscapes(encodeURIComponent(reflectedCredential));
+    const fullyEncodedCredential = percentEncodeEveryUtf8Byte(reflectedCredential);
     const formEncodedCredential = lowercasePercentEscapes(
       new URLSearchParams([["echo", reflectedCredential]]).toString(),
     );
@@ -53,7 +55,7 @@ async function startReflectedAuthorizationServer(): Promise<string> {
         stringifyWithSlashEscapedCredential(
           {
             code: 40093001,
-            message: `json-marker reflected credential ${reflectedCredential}; encoded ${encodedCredential}; form ${formEncodedCredential}; Authorization: ${authorization}`,
+            message: `json-marker reflected credential ${reflectedCredential}; encoded ${encodedCredential}; fully encoded ${fullyEncodedCredential}; form ${formEncodedCredential}; Authorization: ${authorization}`,
           },
           reflectedCredential,
         ),
@@ -63,7 +65,7 @@ async function startReflectedAuthorizationServer(): Promise<string> {
     if (req.url === "/text-error") {
       res.writeHead(503, { "content-type": "text/plain" });
       res.end(
-        `plain-marker reflected credential ${slashEscapedCredential}; encoded ${encodedCredential}; form ${formEncodedCredential}; Authorization: ${slashEscapedAuthorization}`,
+        `plain-marker reflected credential ${slashEscapedCredential}; encoded ${encodedCredential}; fully encoded ${fullyEncodedCredential}; form ${formEncodedCredential}; Authorization: ${slashEscapedAuthorization}`,
       );
       return;
     }
@@ -159,6 +161,7 @@ describe("ApiClient", () => {
     const secretSuffix = "aSfQ";
     const accessToken = `${secretPrefix}/UNIQUE~QQBOTSECRET+${secretSuffix}`;
     const encodedCredential = encodeURIComponent(accessToken);
+    const fullyEncodedCredential = percentEncodeEveryUtf8Byte(accessToken);
     const formEncodedCredential = new URLSearchParams([["echo", accessToken]]).toString();
     const lowercaseEncodedCredential = lowercasePercentEscapes(encodedCredential);
     const lowercaseFormEncodedCredential = lowercasePercentEscapes(formEncodedCredential);
@@ -177,6 +180,8 @@ describe("ApiClient", () => {
     expect(jsonError.bizMessage).not.toContain(accessToken);
     expect(jsonError.message).not.toContain(encodedCredential);
     expect(jsonError.bizMessage).not.toContain(encodedCredential);
+    expect(jsonError.message).not.toContain(fullyEncodedCredential);
+    expect(jsonError.bizMessage).not.toContain(fullyEncodedCredential);
     expect(jsonError.message).not.toContain(formEncodedCredential);
     expect(jsonError.bizMessage).not.toContain(formEncodedCredential);
     expect(jsonError.message).not.toContain(lowercaseEncodedCredential);
@@ -197,6 +202,7 @@ describe("ApiClient", () => {
     expect(textError.message).toContain("plain-marker");
     expect(textError.message).not.toContain(accessToken);
     expect(textError.message).not.toContain(encodedCredential);
+    expect(textError.message).not.toContain(fullyEncodedCredential);
     expect(textError.message).not.toContain(formEncodedCredential);
     expect(textError.message).not.toContain(lowercaseEncodedCredential);
     expect(textError.message).not.toContain(lowercaseFormEncodedCredential);
@@ -218,6 +224,7 @@ describe("ApiClient", () => {
     expect(debugOutput).toContain("success-marker");
     expect(debugOutput).not.toContain(accessToken);
     expect(debugOutput).not.toContain(encodedCredential);
+    expect(debugOutput).not.toContain(fullyEncodedCredential);
     expect(debugOutput).not.toContain(formEncodedCredential);
     expect(debugOutput).not.toContain(lowercaseEncodedCredential);
     expect(debugOutput).not.toContain(lowercaseFormEncodedCredential);
@@ -249,6 +256,7 @@ describe("ApiClient", () => {
             redactedSurfaces.includes("success-marker"),
           tokenAbsent: !redactedSurfaces.includes(accessToken),
           encodedAbsent: !redactedSurfaces.includes(encodedCredential),
+          fullyEncodedAbsent: !redactedSurfaces.includes(fullyEncodedCredential),
           formEncodedAbsent: !redactedSurfaces.includes(formEncodedCredential),
           lowercaseEncodedAbsent: !redactedSurfaces.includes(lowercaseEncodedCredential),
           lowercaseFormEncodedAbsent: !redactedSurfaces.includes(lowercaseFormEncodedCredential),
@@ -259,6 +267,36 @@ describe("ApiClient", () => {
         })}`,
       );
     }
+  });
+
+  it("redacts credentials from response status and trace metadata", async () => {
+    const release = vi.fn(async () => {});
+    const accessToken = "qQMetadata/UNIQUE~QQBOTSECRET+Proof";
+    const fullyEncodedCredential = percentEncodeEveryUtf8Byte(accessToken);
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response('{"code":40034025,"message":"safe-body-marker"}', {
+        status: 400,
+        statusText: `status-marker ${accessToken}`,
+        headers: {
+          "content-type": "application/json",
+          "x-tps-trace-id": `trace-marker ${fullyEncodedCredential}`,
+        },
+      }),
+      release,
+    });
+    const logger = { info: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    const client = new ApiClient({ baseUrl: "https://qqbot.test", logger });
+
+    const error = await captureApiError(() => client.request(accessToken, "GET", "/v2/users/@me"));
+
+    expect(error.message).toContain("safe-body-marker");
+    const infoOutput = logger.info.mock.calls.flat().join("\n");
+    expect(infoOutput).toContain("status-marker");
+    expect(infoOutput).toContain("trace-marker");
+    expect(infoOutput).not.toContain(accessToken);
+    expect(infoOutput).not.toContain(fullyEncodedCredential);
+    expect(infoOutput).not.toContain("UNIQUEQQBOTSECRET");
+    expect(release).toHaveBeenCalledTimes(1);
   });
 
   it("bounds error bodies on a UTF-16 boundary without using response.text()", async () => {

--- a/extensions/qqbot/src/engine/api/api-client.test.ts
+++ b/extensions/qqbot/src/engine/api/api-client.test.ts
@@ -171,6 +171,32 @@ describe("ApiClient", () => {
     expect(debugOutput).toContain("success-marker");
     expect(debugOutput).not.toContain(accessToken);
     expect(debugOutput).not.toContain("UNIQUEQQBOTSECRET");
+
+    const redactedSurfaces = [
+      jsonError.message,
+      jsonError.bizMessage,
+      textError.message,
+      debugOutput,
+    ].join("\n");
+    const proofHeadSha = process.env.OPENCLAW_PROOF_HEAD_SHA;
+    if (proofHeadSha) {
+      if (!/^[0-9a-f]{40}$/.test(proofHeadSha)) {
+        throw new Error("OPENCLAW_PROOF_HEAD_SHA must be a full Git SHA");
+      }
+      console.info(
+        `[qqbot credential redaction proof] ${JSON.stringify({
+          exactHead: proofHeadSha,
+          status: [jsonError.httpStatus, textError.httpStatus, 200],
+          path: ["/json-error", "/text-error", "/success"],
+          safeMarkerPresent:
+            redactedSurfaces.includes("json-marker") &&
+            redactedSurfaces.includes("plain-marker") &&
+            redactedSurfaces.includes("success-marker"),
+          tokenAbsent: !redactedSurfaces.includes(accessToken),
+          fragmentAbsent: !redactedSurfaces.includes("UNIQUEQQBOTSECRET"),
+        })}`,
+      );
+    }
   });
 
   it("bounds error bodies on a UTF-16 boundary without using response.text()", async () => {

--- a/extensions/qqbot/src/engine/api/api-client.test.ts
+++ b/extensions/qqbot/src/engine/api/api-client.test.ts
@@ -1,3 +1,5 @@
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import type { LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
 // Qqbot tests cover api-client plugin behavior.
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -22,6 +24,68 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
 import { ApiError } from "../types.js";
 import { ApiClient } from "./api-client.js";
 
+const loopbackServers: Array<{ close: () => Promise<void> }> = [];
+
+async function startReflectedAuthorizationServer(): Promise<string> {
+  const server = createServer((req, res) => {
+    req.resume();
+    const authorization = req.headers.authorization ?? "";
+
+    if (req.url === "/json-error") {
+      res.writeHead(429, { "content-type": "application/json" });
+      res.end(
+        JSON.stringify({
+          code: 40093001,
+          message: `json-marker Authorization: ${authorization}`,
+        }),
+      );
+      return;
+    }
+    if (req.url === "/text-error") {
+      res.writeHead(503, { "content-type": "text/plain" });
+      res.end(`plain-marker Authorization: ${authorization}`);
+      return;
+    }
+    if (req.url === "/success") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ authorization, marker: "success-marker" }));
+      return;
+    }
+
+    res.writeHead(404, { "content-type": "text/plain" });
+    res.end("not found");
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  loopbackServers.push({
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  });
+  const address = server.address() as AddressInfo;
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function captureApiError(run: () => Promise<unknown>): Promise<ApiError> {
+  try {
+    await run();
+  } catch (error) {
+    if (error instanceof ApiError) {
+      return error;
+    }
+    throw error;
+  }
+  throw new Error("expected ApiClient request to fail");
+}
+
 function cancelTrackedResponse(
   text: string,
   init: ResponseInit,
@@ -45,10 +109,68 @@ function cancelTrackedResponse(
 }
 
 describe("ApiClient", () => {
-  afterEach(() => {
+  afterEach(async () => {
+    const pendingServers = loopbackServers.splice(0);
+    await Promise.all(pendingServers.map((server) => server.close()));
     vi.useRealTimers();
     vi.restoreAllMocks();
     fetchWithSsrFGuardMock.mockReset();
+  });
+
+  it("redacts reflected credentials from JSON, text, and debug output over real transport", async () => {
+    const actualGuard = ssrfRuntimeActual.fetchWithSsrFGuard;
+    if (!actualGuard) {
+      throw new Error("expected the real SSRF guard implementation");
+    }
+    const baseUrl = await startReflectedAuthorizationServer();
+    // Exercise the real guard and global fetch; only permit the test-owned
+    // loopback host that production QQBot policy intentionally rejects.
+    fetchWithSsrFGuardMock.mockImplementation(
+      async (request: Parameters<typeof actualGuard>[0]) =>
+        await actualGuard({
+          ...request,
+          policy: { ...request.policy, allowedHostnames: ["127.0.0.1"] },
+        }),
+    );
+
+    const logger = { info: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    const accessToken = "qqbot_AAAAUNIQUEQQBOTSECRETBBBB111122223333";
+    const authorization = `QQBot ${accessToken}`;
+    const client = new ApiClient({ baseUrl, logger });
+
+    const jsonError = await captureApiError(() =>
+      client.request(accessToken, "GET", "/json-error"),
+    );
+    expect(jsonError.httpStatus).toBe(429);
+    expect(jsonError.bizCode).toBe(40093001);
+    expect(jsonError.message).toContain("json-marker");
+    expect(jsonError.bizMessage).toContain("json-marker");
+    expect(jsonError.message).not.toContain(accessToken);
+    expect(jsonError.bizMessage).not.toContain(accessToken);
+    expect(jsonError.message).not.toContain("UNIQUEQQBOTSECRET");
+
+    const textError = await captureApiError(() =>
+      client.request(accessToken, "GET", "/text-error"),
+    );
+    expect(textError.httpStatus).toBe(503);
+    expect(textError.bizCode).toBeUndefined();
+    expect(textError.message).toContain("plain-marker");
+    expect(textError.message).not.toContain(accessToken);
+    expect(textError.message).not.toContain("UNIQUEQQBOTSECRET");
+
+    const success = await client.request<{ authorization: string; marker: string }>(
+      accessToken,
+      "GET",
+      "/success",
+    );
+    expect(success).toEqual({ authorization, marker: "success-marker" });
+
+    const debugOutput = logger.debug.mock.calls.flat().join("\n");
+    expect(debugOutput).toContain("json-marker");
+    expect(debugOutput).toContain("plain-marker");
+    expect(debugOutput).toContain("success-marker");
+    expect(debugOutput).not.toContain(accessToken);
+    expect(debugOutput).not.toContain("UNIQUEQQBOTSECRET");
   });
 
   it("bounds error bodies on a UTF-16 boundary without using response.text()", async () => {

--- a/extensions/qqbot/src/engine/api/api-client.test.ts
+++ b/extensions/qqbot/src/engine/api/api-client.test.ts
@@ -272,16 +272,19 @@ describe("ApiClient", () => {
   it("redacts credentials from response status and trace metadata", async () => {
     const release = vi.fn(async () => {});
     const accessToken = "qQMetadata/UNIQUE~QQBOTSECRET+Proof";
-    const fullyEncodedCredential = percentEncodeEveryUtf8Byte(accessToken);
+    const mixedEncodedCredential = "q%51Metadata%2fUNIQUE%7eQQBOTSECRET%2bProof";
     fetchWithSsrFGuardMock.mockResolvedValueOnce({
-      response: new Response('{"code":40034025,"message":"safe-body-marker"}', {
-        status: 400,
-        statusText: `status-marker ${accessToken}`,
-        headers: {
-          "content-type": "application/json",
-          "x-tps-trace-id": `trace-marker ${fullyEncodedCredential}`,
+      response: new Response(
+        JSON.stringify({ code: 40034025, message: `safe-body-marker ${mixedEncodedCredential}` }),
+        {
+          status: 400,
+          statusText: `status-marker ${mixedEncodedCredential}`,
+          headers: {
+            "content-type": "application/json",
+            "x-tps-trace-id": `trace-marker ${mixedEncodedCredential}`,
+          },
         },
-      }),
+      ),
       release,
     });
     const logger = { info: vi.fn(), error: vi.fn(), debug: vi.fn() };
@@ -294,8 +297,10 @@ describe("ApiClient", () => {
     expect(infoOutput).toContain("status-marker");
     expect(infoOutput).toContain("trace-marker");
     expect(infoOutput).not.toContain(accessToken);
-    expect(infoOutput).not.toContain(fullyEncodedCredential);
+    expect(infoOutput).not.toContain(mixedEncodedCredential);
+    expect(error.message).not.toContain(mixedEncodedCredential);
     expect(infoOutput).not.toContain("UNIQUEQQBOTSECRET");
+    expect(error.message).not.toContain("UNIQUEQQBOTSECRET");
     expect(release).toHaveBeenCalledTimes(1);
   });
 

--- a/extensions/qqbot/src/engine/api/api-client.ts
+++ b/extensions/qqbot/src/engine/api/api-client.ts
@@ -10,7 +10,6 @@
  */
 
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import { redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
 import {
   readProviderTextResponse,
   readResponseTextLimited,
@@ -19,6 +18,7 @@ import { fetchWithSsrFGuard, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-ru
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { qqbotApiGuidance, qqbotNetworkGuidance } from "../config/setup-guidance.js";
 import { ApiError, type ApiClientConfig, type EngineLogger } from "../types.js";
+import { redactQQBotCredentialText } from "../utils/credential-redaction.js";
 
 const DEFAULT_BASE_URL = "https://api.sgroup.qq.com";
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -186,7 +186,9 @@ export class ApiClient {
 
       const rawBody = res.ok ? await readBody() : await readBody(QQBOT_API_ERROR_BODY_LIMIT_BYTES);
       if (this.logger?.debug) {
-        this.logger.debug(`[qqbot:api] <<< Body: ${redactToolPayloadText(rawBody)}`);
+        this.logger.debug(
+          `[qqbot:api] <<< Body: ${redactQQBotCredentialText(rawBody, accessToken)}`,
+        );
       }
 
       // Detect non-JSON responses (HTML gateway errors, CDN rate-limit pages).
@@ -212,7 +214,7 @@ export class ApiClient {
           parsedError = JSON.parse(rawBody);
         } catch {
           throw new ApiError(
-            `API Error [${path}] HTTP ${res.status}: ${truncateUtf16Safe(redactToolPayloadText(rawBody), 200)}`,
+            `API Error [${path}] HTTP ${res.status}: ${truncateUtf16Safe(redactQQBotCredentialText(rawBody, accessToken), 200)}`,
             res.status,
             path,
           );
@@ -224,7 +226,7 @@ export class ApiClient {
             : undefined;
         const rawMessage = typeof error?.message === "string" ? error.message : undefined;
         const redactedMessage =
-          rawMessage === undefined ? undefined : redactToolPayloadText(rawMessage);
+          rawMessage === undefined ? undefined : redactQQBotCredentialText(rawMessage, accessToken);
         const bizCode =
           typeof error?.code === "number"
             ? error.code
@@ -232,7 +234,7 @@ export class ApiClient {
               ? error.err_code
               : undefined;
         throw new ApiError(
-          `API Error [${path}]: ${redactedMessage ?? redactToolPayloadText(rawBody)}. ${qqbotApiGuidance(res.status, bizCode)}`,
+          `API Error [${path}]: ${redactedMessage ?? redactQQBotCredentialText(rawBody, accessToken)}. ${qqbotApiGuidance(res.status, bizCode)}`,
           res.status,
           path,
           bizCode,

--- a/extensions/qqbot/src/engine/api/api-client.ts
+++ b/extensions/qqbot/src/engine/api/api-client.ts
@@ -161,9 +161,13 @@ export class ApiClient {
     const res = guarded.response;
     try {
       // Log response status and trace ID.
-      const traceId = res.headers.get("x-tps-trace-id") ?? "";
+      const statusText = redactQQBotCredentialText(res.statusText, accessToken);
+      const traceId = redactQQBotCredentialText(
+        res.headers.get("x-tps-trace-id") ?? "",
+        accessToken,
+      );
       this.logger?.info?.(
-        `[qqbot:api] <<< Status: ${res.status} ${res.statusText}${traceId ? ` | TraceId: ${traceId}` : ""}`,
+        `[qqbot:api] <<< Status: ${res.status} ${statusText}${traceId ? ` | TraceId: ${traceId}` : ""}`,
       );
 
       const readBody = async (limitBytes?: number): Promise<string> => {

--- a/extensions/qqbot/src/engine/api/api-client.ts
+++ b/extensions/qqbot/src/engine/api/api-client.ts
@@ -10,6 +10,7 @@
  */
 
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
 import {
   readProviderTextResponse,
   readResponseTextLimited,
@@ -184,7 +185,9 @@ export class ApiClient {
       };
 
       const rawBody = res.ok ? await readBody() : await readBody(QQBOT_API_ERROR_BODY_LIMIT_BYTES);
-      this.logger?.debug?.(`[qqbot:api] <<< Body: ${rawBody}`);
+      if (this.logger?.debug) {
+        this.logger.debug(`[qqbot:api] <<< Body: ${redactToolPayloadText(rawBody)}`);
+      }
 
       // Detect non-JSON responses (HTML gateway errors, CDN rate-limit pages).
       const contentType = res.headers.get("content-type") ?? "";
@@ -202,31 +205,39 @@ export class ApiClient {
           throw new ApiError(`${statusHint}（${path}），请稍后重试`, res.status, path);
         }
 
-        // JSON error response.
+        // Parse the original JSON before redacting extracted strings so business
+        // codes remain machine-readable while reflected credentials never escape.
+        let parsedError: unknown;
         try {
-          const error = JSON.parse(rawBody) as {
-            message?: string;
-            code?: number;
-            err_code?: number;
-          };
-          const bizCode = error.code ?? error.err_code;
+          parsedError = JSON.parse(rawBody);
+        } catch {
           throw new ApiError(
-            `API Error [${path}]: ${error.message ?? rawBody}. ${qqbotApiGuidance(res.status, bizCode)}`,
-            res.status,
-            path,
-            bizCode,
-            error.message,
-          );
-        } catch (parseErr) {
-          if (parseErr instanceof ApiError) {
-            throw parseErr;
-          }
-          throw new ApiError(
-            `API Error [${path}] HTTP ${res.status}: ${truncateUtf16Safe(rawBody, 200)}`,
+            `API Error [${path}] HTTP ${res.status}: ${truncateUtf16Safe(redactToolPayloadText(rawBody), 200)}`,
             res.status,
             path,
           );
         }
+
+        const error =
+          typeof parsedError === "object" && parsedError !== null
+            ? (parsedError as Record<string, unknown>)
+            : undefined;
+        const rawMessage = typeof error?.message === "string" ? error.message : undefined;
+        const redactedMessage =
+          rawMessage === undefined ? undefined : redactToolPayloadText(rawMessage);
+        const bizCode =
+          typeof error?.code === "number"
+            ? error.code
+            : typeof error?.err_code === "number"
+              ? error.err_code
+              : undefined;
+        throw new ApiError(
+          `API Error [${path}]: ${redactedMessage ?? redactToolPayloadText(rawBody)}. ${qqbotApiGuidance(res.status, bizCode)}`,
+          res.status,
+          path,
+          bizCode,
+          redactedMessage,
+        );
       }
 
       // Successful response but not JSON (extreme edge case).

--- a/extensions/qqbot/src/engine/api/media-chunked.test.ts
+++ b/extensions/qqbot/src/engine/api/media-chunked.test.ts
@@ -411,6 +411,39 @@ describe("media-chunked: ChunkedMediaApi.uploadChunked", () => {
     expect(diagnosticOutput).not.toContain("UNIQUE-COS-CREDENTIAL");
   });
 
+  it("keeps malformed presigned URLs inside the controlled retry path", async () => {
+    vi.useFakeTimers();
+    const client = mockApiClient();
+    const tm = mockTokenManager();
+    const logger = { info: vi.fn(), error: vi.fn(), warn: vi.fn() };
+    client.request.mockImplementation(async (_token, _method, pathLocal) => {
+      if (pathLocal.endsWith("/upload_prepare")) {
+        const prepared = makePrepareResponse("uid-malformed", 1);
+        prepared.parts[0]!.presigned_url = "not-a-valid-presigned-url";
+        return prepared;
+      }
+      throw new Error(`unexpected path ${pathLocal}`);
+    });
+
+    const api = new ChunkedMediaApi(client, tm, { logger });
+    const upload = api
+      .uploadChunked({
+        scope: "group",
+        targetId: "g1",
+        fileType: MediaFileType.FILE,
+        source: { kind: "buffer", buffer: Buffer.from("01234567"), fileName: "blob.bin" },
+        creds: { appId: "a", clientSecret: "s" },
+      })
+      .catch((error: unknown) => error);
+    await vi.runAllTimersAsync();
+    const error = await upload;
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("Invalid URL");
+    expect(logger.warn).toHaveBeenCalledTimes(2);
+    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+  });
+
   it("maps UPLOAD_PREPARE_FALLBACK_CODE to UploadDailyLimitExceededError", async () => {
     const client = mockApiClient();
     const tm = mockTokenManager();

--- a/extensions/qqbot/src/engine/api/media-chunked.test.ts
+++ b/extensions/qqbot/src/engine/api/media-chunked.test.ts
@@ -284,9 +284,13 @@ describe("media-chunked: ChunkedMediaApi.uploadChunked", () => {
     const client = mockApiClient();
     const tm = mockTokenManager();
     const logger = { info: vi.fn(), error: vi.fn(), warn: vi.fn() };
+    const presignedCredential = "qQ-presigned/UNIQUE-COS-CREDENTIAL";
+    const encodedPresignedCredential = encodeURIComponent(presignedCredential);
     client.request.mockImplementation(async (_token, _method, pathLocal) => {
       if (pathLocal.endsWith("/upload_prepare")) {
-        return makePrepareResponse("uid-bounded", 1);
+        const prepared = makePrepareResponse("uid-bounded", 1);
+        prepared.parts[0]!.presigned_url = `https://cos.example.com/part-1?credential=${encodedPresignedCredential}`;
+        return prepared;
       }
       throw new Error(`unexpected path ${pathLocal}`);
     });
@@ -295,14 +299,17 @@ describe("media-chunked: ChunkedMediaApi.uploadChunked", () => {
     const safeErrorPrefix = "x".repeat(119);
     const safeLogPrefix = `${safeErrorPrefix}🎉${"y".repeat(38)}`;
     const trackedResponses = releases.map((release) => {
-      const tracked = cancelTrackedResponse(`${safeLogPrefix}🎉${"tail".repeat(4096)}`, {
-        status: 503,
-        statusText: "Service Unavailable",
-        headers: {
-          "content-type": "text/plain",
-          "x-cos-request-id": "req-bounded",
+      const tracked = cancelTrackedResponse(
+        `${safeLogPrefix} ${presignedCredential} 🎉${"tail".repeat(4096)}`,
+        {
+          status: 503,
+          statusText: `Service Unavailable ${presignedCredential}`,
+          headers: {
+            "content-type": "text/plain",
+            "x-cos-request-id": `req-bounded ${encodedPresignedCredential}`,
+          },
         },
-      });
+      );
       const textSpy = vi.spyOn(tracked.response, "text").mockRejectedValue(new Error("unbounded"));
       return {
         response: tracked.response,
@@ -337,17 +344,71 @@ describe("media-chunked: ChunkedMediaApi.uploadChunked", () => {
     await vi.runAllTimersAsync();
     const error = await upload;
 
-    expect((error as Error).message).toBe(
-      `COS PUT failed: 503 Service Unavailable - ${safeErrorPrefix}`,
-    );
+    expect((error as Error).message).toContain("COS PUT failed: 503 Service Unavailable");
+    expect((error as Error).message).toContain(safeErrorPrefix);
     expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(3);
     for (const tracked of trackedResponses) {
       expect(tracked.wasCanceled()).toBe(true);
       expect(tracked.textSpy).not.toHaveBeenCalled();
       expect(tracked.release).toHaveBeenCalledTimes(1);
     }
-    expect(String(logger.error.mock.calls[0]?.[0]).split("body=")[1]).toBe(safeLogPrefix);
-    expect(JSON.stringify(logger.error.mock.calls)).not.toContain("tail");
+    expect(String(logger.error.mock.calls[0]?.[0]).split("body=")[1]).toContain(safeLogPrefix);
+    const diagnosticOutput = [
+      (error as Error).message,
+      ...logger.error.mock.calls.flat(),
+      ...logger.warn.mock.calls.flat(),
+    ].join("\n");
+    expect(diagnosticOutput).toContain("req-bounded");
+    expect(diagnosticOutput).not.toContain(presignedCredential);
+    expect(diagnosticOutput).not.toContain(encodedPresignedCredential);
+    expect(diagnosticOutput).not.toContain("UNIQUE-COS-CREDENTIAL");
+    expect(diagnosticOutput).not.toContain("tail");
+  });
+
+  it("redacts signed query credentials from COS transport failures", async () => {
+    vi.useFakeTimers();
+    const client = mockApiClient();
+    const tm = mockTokenManager();
+    const logger = { info: vi.fn(), error: vi.fn(), warn: vi.fn() };
+    const presignedCredential = "qQ-transport/UNIQUE-COS-CREDENTIAL";
+    const encodedPresignedCredential = encodeURIComponent(presignedCredential);
+    const presignedUrl = `https://cos.example.com/part-1?credential=${encodedPresignedCredential}`;
+    client.request.mockImplementation(async (_token, _method, pathLocal) => {
+      if (pathLocal.endsWith("/upload_prepare")) {
+        const prepared = makePrepareResponse("uid-transport", 1);
+        prepared.parts[0]!.presigned_url = presignedUrl;
+        return prepared;
+      }
+      throw new Error(`unexpected path ${pathLocal}`);
+    });
+    fetchWithSsrFGuardMock.mockRejectedValue(
+      new Error(`connect failed for ${presignedUrl} (${presignedCredential})`),
+    );
+
+    const api = new ChunkedMediaApi(client, tm, { logger });
+    const upload = api
+      .uploadChunked({
+        scope: "group",
+        targetId: "g1",
+        fileType: MediaFileType.FILE,
+        source: { kind: "buffer", buffer: Buffer.from("01234567"), fileName: "blob.bin" },
+        creds: { appId: "a", clientSecret: "s" },
+      })
+      .catch((error: unknown) => error);
+    await vi.runAllTimersAsync();
+    const error = await upload;
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(3);
+    const diagnosticOutput = [
+      (error as Error).message,
+      ...logger.error.mock.calls.flat(),
+      ...logger.warn.mock.calls.flat(),
+    ].join("\n");
+    expect(diagnosticOutput).toContain("connect failed");
+    expect(diagnosticOutput).not.toContain(presignedUrl);
+    expect(diagnosticOutput).not.toContain(presignedCredential);
+    expect(diagnosticOutput).not.toContain(encodedPresignedCredential);
+    expect(diagnosticOutput).not.toContain("UNIQUE-COS-CREDENTIAL");
   });
 
   it("maps UPLOAD_PREPARE_FALLBACK_CODE to UploadDailyLimitExceededError", async () => {

--- a/extensions/qqbot/src/engine/api/media-chunked.ts
+++ b/extensions/qqbot/src/engine/api/media-chunked.ts
@@ -545,20 +545,22 @@ async function putToPresignedUrl(
   prefix: string,
 ): Promise<void> {
   let lastError: Error | null = null;
-  const parsedPresignedUrl = new URL(presignedUrl);
-  const presignedCredentials = [
-    presignedUrl,
-    parsedPresignedUrl.username,
-    parsedPresignedUrl.password,
-    ...parsedPresignedUrl.searchParams.values(),
-  ];
-  const present = (text: string) => redactQQBotCredentialText(text, ...presignedCredentials);
 
   for (let attempt = 0; attempt <= PART_UPLOAD_MAX_RETRIES; attempt++) {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), PART_UPLOAD_TIMEOUT_MS);
+    let present = (text: string) => redactQQBotCredentialText(text, presignedUrl);
 
     try {
+      const parsedPresignedUrl = new URL(presignedUrl);
+      const presignedCredentials = [
+        presignedUrl,
+        parsedPresignedUrl.username,
+        parsedPresignedUrl.password,
+        ...parsedPresignedUrl.searchParams.values(),
+      ];
+      present = (text: string) => redactQQBotCredentialText(text, ...presignedCredentials);
+
       // Convert to a standard ArrayBuffer before wrapping in Blob so type
       // definitions (incl. bun-types) accept the argument.
       const ab = data.buffer.slice(

--- a/extensions/qqbot/src/engine/api/media-chunked.ts
+++ b/extensions/qqbot/src/engine/api/media-chunked.ts
@@ -53,6 +53,7 @@ import {
   type UploadPrepareHashes,
   type UploadPrepareResponse,
 } from "../types.js";
+import { redactQQBotCredentialText } from "../utils/credential-redaction.js";
 import { formatFileSize } from "../utils/file-utils.js";
 import type { ApiClient } from "./api-client.js";
 import type { SanitizeFileNameFn, UploadCacheAdapter } from "./media.js";
@@ -544,6 +545,14 @@ async function putToPresignedUrl(
   prefix: string,
 ): Promise<void> {
   let lastError: Error | null = null;
+  const parsedPresignedUrl = new URL(presignedUrl);
+  const presignedCredentials = [
+    presignedUrl,
+    parsedPresignedUrl.username,
+    parsedPresignedUrl.password,
+    ...parsedPresignedUrl.searchParams.values(),
+  ];
+  const present = (text: string) => redactQQBotCredentialText(text, ...presignedCredentials);
 
   for (let attempt = 0; attempt <= PART_UPLOAD_MAX_RETRIES; attempt++) {
     const controller = new AbortController();
@@ -570,19 +579,21 @@ async function putToPresignedUrl(
       });
       try {
         const elapsed = Date.now() - startTime;
-        const requestId = response.headers.get("x-cos-request-id") ?? "-";
-        const etag = response.headers.get("ETag") ?? "-";
+        const requestId = present(response.headers.get("x-cos-request-id") ?? "-");
+        const etag = present(response.headers.get("ETag") ?? "-");
+        const statusText = present(response.statusText);
 
         if (!response.ok) {
-          const body = await readResponseTextLimited(
-            response,
-            PART_UPLOAD_ERROR_BODY_LIMIT_BYTES,
-          ).catch(() => "");
+          const body = present(
+            await readResponseTextLimited(response, PART_UPLOAD_ERROR_BODY_LIMIT_BYTES).catch(
+              () => "",
+            ),
+          );
           logger?.error?.(
-            `${prefix} PUT part ${partIndex}/${totalParts}: HTTP ${response.status} ${response.statusText} (${elapsed}ms, requestId=${requestId}) body=${truncateUtf16Safe(body, 160)}`,
+            `${prefix} PUT part ${partIndex}/${totalParts}: HTTP ${response.status} ${statusText} (${elapsed}ms, requestId=${requestId}) body=${truncateUtf16Safe(body, 160)}`,
           );
           throw new Error(
-            `COS PUT failed: ${response.status} ${response.statusText} - ${truncateUtf16Safe(body, 120)}`,
+            `COS PUT failed: ${response.status} ${statusText} - ${truncateUtf16Safe(body, 120)}`,
           );
         }
 
@@ -594,11 +605,14 @@ async function putToPresignedUrl(
         await release();
       }
     } catch (err) {
-      lastError = err instanceof Error ? err : new Error(String(err));
-      if (lastError.name === "AbortError") {
+      const caughtError = err instanceof Error ? err : new Error(String(err));
+      if (caughtError.name === "AbortError") {
         lastError = new Error(
           `Part ${partIndex}/${totalParts} upload timeout after ${PART_UPLOAD_TIMEOUT_MS}ms`,
         );
+      } else {
+        // Guard/network errors can include the request URL, including its signed query.
+        lastError = new Error(present(caughtError.message));
       }
       if (attempt < PART_UPLOAD_MAX_RETRIES) {
         const delay = 1000 * 2 ** attempt;

--- a/extensions/qqbot/src/engine/api/token.test.ts
+++ b/extensions/qqbot/src/engine/api/token.test.ts
@@ -147,8 +147,34 @@ describe("QQBot token manager", () => {
     expect(tracked.wasCanceled()).toBe(true);
     expect(textSpy).not.toHaveBeenCalled();
     expect(tracked.release).toHaveBeenCalledTimes(1);
-    expect(logger.debug.mock.calls.join("\n")).toContain("qqbot token unavailable");
-    expect(logger.debug.mock.calls.join("\n")).not.toContain("tail");
+    const debugOutput = logger.debug.mock.calls.join("\n");
+    expect(debugOutput).toContain("<malformed JSON body omitted>");
+    expect(debugOutput).not.toContain("qqbot token unavailable");
+    expect(debugOutput).not.toContain("tail");
+  });
+
+  it("omits malformed token response bodies from diagnostics", async () => {
+    const logger = { debug: vi.fn(), info: vi.fn(), error: vi.fn() };
+    const tokenPrefix = "qQMalformedP";
+    const tokenFragment = "issued-token-fragment";
+    const tokenSuffix = "tSfQ";
+    const accessToken = [tokenPrefix, tokenFragment, tokenSuffix].join("/");
+    const malformedBody = ['{"access_token":"', accessToken, '",'].join("");
+    mockGuardedTokenResponse(malformedBody, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+
+    await expect(new TokenManager({ logger }).getAccessToken("app-id", "secret")).rejects.toThrow(
+      "QQBot access_token response was malformed JSON",
+    );
+
+    const debugOutput = logger.debug.mock.calls.join("\n");
+    expect(debugOutput).toContain("<malformed JSON body omitted>");
+    expect(debugOutput).not.toContain(accessToken);
+    expect(debugOutput).not.toContain(tokenPrefix);
+    expect(debugOutput).not.toContain(tokenFragment);
+    expect(debugOutput).not.toContain(tokenSuffix);
   });
 
   it("redacts a reflected client secret before logging or throwing token errors", async () => {
@@ -269,6 +295,35 @@ describe("QQBot token manager", () => {
         }
       },
     );
+  });
+
+  it("fully redacts issued access tokens from successful token diagnostics", async () => {
+    const logger = { debug: vi.fn(), info: vi.fn(), error: vi.fn() };
+    const tokenPrefix = "qQIssuedP";
+    const tokenSuffix = "tSfQ";
+    const accessToken = [tokenPrefix, "UNIQUE-ISSUED-TOKEN", tokenSuffix].join("/");
+    mockGuardedTokenResponse(
+      JSON.stringify({
+        access_token: accessToken,
+        expires_in: 7200,
+        marker: "issued-token-visible-123",
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      },
+    );
+
+    await expect(
+      new TokenManager({ logger }).getAccessToken("app-id", "client-secret"),
+    ).resolves.toBe(accessToken);
+
+    const debugOutput = logger.debug.mock.calls.flat().join("\n");
+    expect(debugOutput).toContain("issued-token-visible-123");
+    expect(debugOutput).not.toContain(accessToken);
+    expect(debugOutput).not.toContain(tokenPrefix);
+    expect(debugOutput).not.toContain(tokenSuffix);
+    expect(debugOutput).not.toContain("UNIQUE-ISSUED-TOKEN");
   });
 
   it("passes the RFC2544 SSRF allowance to the token fetch (regression for #88984)", async () => {

--- a/extensions/qqbot/src/engine/api/token.test.ts
+++ b/extensions/qqbot/src/engine/api/token.test.ts
@@ -2,6 +2,10 @@
 import { getEventListeners } from "node:events";
 import type { IncomingMessage } from "node:http";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  lowercasePercentEscapes,
+  stringifyWithSlashEscapedCredential,
+} from "../../test-support/credential-reflection.js";
 import { withLoopbackHttpServer } from "../../test-support/loopback-http.js";
 import { TokenManager } from "./token.js";
 
@@ -153,6 +157,9 @@ describe("QQBot token manager", () => {
     const clientSecret = `${secretPrefix}/reflected~secret+${secretSuffix}`;
     const encodedCredential = encodeURIComponent(clientSecret);
     const formEncodedCredential = new URLSearchParams([["echo", clientSecret]]).toString();
+    const lowercaseEncodedCredential = lowercasePercentEscapes(encodedCredential);
+    const lowercaseFormEncodedCredential = lowercasePercentEscapes(formEncodedCredential);
+    const slashEscapedCredential = clientSecret.replaceAll("/", "\\/");
     await withLoopbackHttpServer(
       (request, response) => {
         void readRequestBody(request).then(
@@ -165,16 +172,19 @@ describe("QQBot token manager", () => {
             ]).toString();
             response.writeHead(401, { "content-type": "application/json" });
             response.end(
-              JSON.stringify({
-                code: 11244,
-                message: "credential rejected",
-                clientSecret: reflectedCredential,
-                client_secret: reflectedCredential,
-                echoed: reflectedCredential,
-                encoded: encodeURIComponent(reflectedCredential),
-                form: reflectedFormCredential,
-                request_id: "token-visible-123",
-              }),
+              stringifyWithSlashEscapedCredential(
+                {
+                  code: 11244,
+                  message: "credential rejected",
+                  clientSecret: reflectedCredential,
+                  client_secret: reflectedCredential,
+                  echoed: reflectedCredential,
+                  encoded: lowercasePercentEscapes(encodeURIComponent(reflectedCredential)),
+                  form: lowercasePercentEscapes(reflectedFormCredential),
+                  request_id: "token-visible-123",
+                },
+                reflectedCredential,
+              ),
             );
           },
           () => {
@@ -212,6 +222,9 @@ describe("QQBot token manager", () => {
           expect(output).not.toContain(clientSecret);
           expect(output).not.toContain(encodedCredential);
           expect(output).not.toContain(formEncodedCredential);
+          expect(output).not.toContain(lowercaseEncodedCredential);
+          expect(output).not.toContain(lowercaseFormEncodedCredential);
+          expect(output).not.toContain(slashEscapedCredential);
           expect(output).not.toContain(secretPrefix);
           expect(output).not.toContain(secretSuffix);
           expect(output).not.toContain("reflected-secret");
@@ -236,6 +249,14 @@ describe("QQBot token manager", () => {
               errorEncodedAbsent: !message.includes(encodedCredential),
               debugFormEncodedAbsent: !debugOutput.includes(formEncodedCredential),
               errorFormEncodedAbsent: !message.includes(formEncodedCredential),
+              debugLowercaseEncodedAbsent: !debugOutput.includes(lowercaseEncodedCredential),
+              errorLowercaseEncodedAbsent: !message.includes(lowercaseEncodedCredential),
+              debugLowercaseFormEncodedAbsent: !debugOutput.includes(
+                lowercaseFormEncodedCredential,
+              ),
+              errorLowercaseFormEncodedAbsent: !message.includes(lowercaseFormEncodedCredential),
+              debugJsonSlashEscapedAbsent: !debugOutput.includes(slashEscapedCredential),
+              errorJsonSlashEscapedAbsent: !message.includes(slashEscapedCredential),
               debugPrefixAbsent: !debugOutput.includes(secretPrefix),
               errorPrefixAbsent: !message.includes(secretPrefix),
               debugSuffixAbsent: !debugOutput.includes(secretSuffix),

--- a/extensions/qqbot/src/engine/api/token.test.ts
+++ b/extensions/qqbot/src/engine/api/token.test.ts
@@ -110,6 +110,7 @@ describe("QQBot token manager", () => {
   });
 
   it("adds account-neutral credential guidance when the token endpoint omits access_token", async () => {
+    const clientSecret = "guidance-credential-qQ7x9V2";
     const release = mockGuardedTokenResponse('{"code":4001,"message":"invalid app secret"}', {
       status: 200,
       headers: { "content-type": "application/json" },
@@ -117,7 +118,7 @@ describe("QQBot token manager", () => {
 
     let error: unknown;
     try {
-      await new TokenManager().getAccessToken("app-id", "secret");
+      await new TokenManager().getAccessToken("app-id", clientSecret);
     } catch (caught) {
       error = caught;
     }

--- a/extensions/qqbot/src/engine/api/token.test.ts
+++ b/extensions/qqbot/src/engine/api/token.test.ts
@@ -1,17 +1,33 @@
 // Qqbot tests cover token plugin behavior.
 import { getEventListeners } from "node:events";
+import type { IncomingMessage } from "node:http";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { withLoopbackHttpServer } from "../../test-support/loopback-http.js";
 import { TokenManager } from "./token.js";
 
 const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+const ssrfRuntimeActual = vi.hoisted(() => ({
+  fetchWithSsrFGuard: undefined as
+    | typeof import("openclaw/plugin-sdk/ssrf-runtime").fetchWithSsrFGuard
+    | undefined,
+}));
 
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
+  ssrfRuntimeActual.fetchWithSsrFGuard = actual.fetchWithSsrFGuard;
   return {
     ...actual,
     fetchWithSsrFGuard: fetchWithSsrFGuardMock,
   };
 });
+
+async function readRequestBody(request: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
 
 function mockGuardedTokenResponse(body: BodyInit, init?: ResponseInit): ReturnType<typeof vi.fn> {
   const release = vi.fn(async () => {});
@@ -132,56 +148,105 @@ describe("QQBot token manager", () => {
 
   it("redacts a reflected client secret before logging or throwing token errors", async () => {
     const logger = { debug: vi.fn(), info: vi.fn(), error: vi.fn() };
-    const clientSecret = "token-reflected-secret-1234567890";
-    const release = mockGuardedTokenResponse(
-      JSON.stringify({
-        code: 11244,
-        message: "credential rejected",
-        clientSecret,
-        client_secret: clientSecret,
-        request_id: "token-visible-123",
-      }),
-      {
-        status: 401,
-        headers: { "content-type": "application/json" },
+    const secretPrefix = "qQTokP";
+    const secretSuffix = "tSfQ";
+    const clientSecret = `${secretPrefix}/reflected~secret+${secretSuffix}`;
+    const encodedCredential = encodeURIComponent(clientSecret);
+    const formEncodedCredential = new URLSearchParams([["echo", clientSecret]]).toString();
+    await withLoopbackHttpServer(
+      (request, response) => {
+        void readRequestBody(request).then(
+          (rawBody) => {
+            const parsed = JSON.parse(rawBody) as { clientSecret?: unknown };
+            const reflectedCredential =
+              typeof parsed.clientSecret === "string" ? parsed.clientSecret : "missing";
+            const reflectedFormCredential = new URLSearchParams([
+              ["echo", reflectedCredential],
+            ]).toString();
+            response.writeHead(401, { "content-type": "application/json" });
+            response.end(
+              JSON.stringify({
+                code: 11244,
+                message: "credential rejected",
+                clientSecret: reflectedCredential,
+                client_secret: reflectedCredential,
+                echoed: reflectedCredential,
+                encoded: encodeURIComponent(reflectedCredential),
+                form: reflectedFormCredential,
+                request_id: "token-visible-123",
+              }),
+            );
+          },
+          () => {
+            response.writeHead(500, { "content-type": "text/plain" });
+            response.end("request body read failed");
+          },
+        );
+      },
+      async (baseUrl) => {
+        const actualGuard = ssrfRuntimeActual.fetchWithSsrFGuard;
+        if (!actualGuard) {
+          throw new Error("expected the real SSRF guard implementation");
+        }
+        const loopbackFetch = vi.fn(
+          async (_input: RequestInfo | URL, init?: RequestInit) =>
+            await fetch(`${baseUrl}/token`, init),
+        );
+        fetchWithSsrFGuardMock.mockImplementationOnce(
+          async (request: Parameters<typeof actualGuard>[0]) =>
+            await actualGuard({ ...request, fetchImpl: loopbackFetch }),
+        );
+
+        let error: unknown;
+        try {
+          await new TokenManager({ logger }).getAccessToken("app-id", clientSecret);
+        } catch (caught) {
+          error = caught;
+        }
+
+        expect(error).toBeInstanceOf(Error);
+        const message = error instanceof Error ? error.message : String(error);
+        const debugOutput = logger.debug.mock.calls.flat().join("\n");
+        for (const output of [debugOutput, message]) {
+          expect(output).toContain("token-visible-123");
+          expect(output).not.toContain(clientSecret);
+          expect(output).not.toContain(encodedCredential);
+          expect(output).not.toContain(formEncodedCredential);
+          expect(output).not.toContain(secretPrefix);
+          expect(output).not.toContain(secretSuffix);
+          expect(output).not.toContain("reflected-secret");
+        }
+        expect(loopbackFetch).toHaveBeenCalledTimes(1);
+
+        const proofHeadSha = process.env.OPENCLAW_PROOF_HEAD_SHA;
+        if (proofHeadSha) {
+          if (!/^[0-9a-f]{40}$/.test(proofHeadSha)) {
+            throw new Error("OPENCLAW_PROOF_HEAD_SHA must be a full Git SHA");
+          }
+          console.info(
+            `[qqbot token credential redaction proof] ${JSON.stringify({
+              exactHead: proofHeadSha,
+              transport: "loopback-http",
+              status: 401,
+              debugSafeMarkerPresent: debugOutput.includes("token-visible-123"),
+              errorSafeMarkerPresent: message.includes("token-visible-123"),
+              debugSecretAbsent: !debugOutput.includes(clientSecret),
+              errorSecretAbsent: !message.includes(clientSecret),
+              debugEncodedAbsent: !debugOutput.includes(encodedCredential),
+              errorEncodedAbsent: !message.includes(encodedCredential),
+              debugFormEncodedAbsent: !debugOutput.includes(formEncodedCredential),
+              errorFormEncodedAbsent: !message.includes(formEncodedCredential),
+              debugPrefixAbsent: !debugOutput.includes(secretPrefix),
+              errorPrefixAbsent: !message.includes(secretPrefix),
+              debugSuffixAbsent: !debugOutput.includes(secretSuffix),
+              errorSuffixAbsent: !message.includes(secretSuffix),
+              debugFragmentAbsent: !debugOutput.includes("reflected-secret"),
+              errorFragmentAbsent: !message.includes("reflected-secret"),
+            })}`,
+          );
+        }
       },
     );
-
-    let error: unknown;
-    try {
-      await new TokenManager({ logger }).getAccessToken("app-id", clientSecret);
-    } catch (caught) {
-      error = caught;
-    }
-
-    expect(error).toBeInstanceOf(Error);
-    const message = error instanceof Error ? error.message : String(error);
-    const debugOutput = logger.debug.mock.calls.flat().join("\n");
-    for (const output of [debugOutput, message]) {
-      expect(output).toContain("token-visible-123");
-      expect(output).not.toContain(clientSecret);
-      expect(output).not.toContain("reflected-secret");
-    }
-    expect(release).toHaveBeenCalledTimes(1);
-
-    const proofHeadSha = process.env.OPENCLAW_PROOF_HEAD_SHA;
-    if (proofHeadSha) {
-      if (!/^[0-9a-f]{40}$/.test(proofHeadSha)) {
-        throw new Error("OPENCLAW_PROOF_HEAD_SHA must be a full Git SHA");
-      }
-      console.info(
-        `[qqbot token credential redaction proof] ${JSON.stringify({
-          exactHead: proofHeadSha,
-          status: 401,
-          debugSafeMarkerPresent: debugOutput.includes("token-visible-123"),
-          errorSafeMarkerPresent: message.includes("token-visible-123"),
-          debugSecretAbsent: !debugOutput.includes(clientSecret),
-          errorSecretAbsent: !message.includes(clientSecret),
-          debugFragmentAbsent: !debugOutput.includes("reflected-secret"),
-          errorFragmentAbsent: !message.includes("reflected-secret"),
-        })}`,
-      );
-    }
   });
 
   it("passes the RFC2544 SSRF allowance to the token fetch (regression for #88984)", async () => {

--- a/extensions/qqbot/src/engine/api/token.test.ts
+++ b/extensions/qqbot/src/engine/api/token.test.ts
@@ -302,25 +302,51 @@ describe("QQBot token manager", () => {
     const tokenPrefix = "qQIssuedP";
     const tokenSuffix = "tSfQ";
     const accessToken = [tokenPrefix, "UNIQUE-ISSUED-TOKEN", tokenSuffix].join("/");
-    mockGuardedTokenResponse(
-      JSON.stringify({
-        access_token: accessToken,
-        expires_in: 7200,
-        marker: "issued-token-visible-123",
-      }),
-      {
-        status: 200,
-        headers: { "content-type": "application/json" },
+    const clientSecret = "qQ-issued-client-secret";
+    const encodedAccessToken = encodeURIComponent(accessToken);
+
+    await withLoopbackHttpServer(
+      (request, response) => {
+        void readRequestBody(request).then(() => {
+          response.writeHead(200, {
+            "content-type": "application/json",
+            "x-tps-trace-id": `issued-trace-visible-123 ${clientSecret} ${encodedAccessToken}`,
+          });
+          response.end(
+            JSON.stringify({
+              access_token: accessToken,
+              expires_in: 7200,
+              marker: "issued-token-visible-123",
+            }),
+          );
+        });
+      },
+      async (baseUrl) => {
+        const actualGuard = ssrfRuntimeActual.fetchWithSsrFGuard;
+        if (!actualGuard) {
+          throw new Error("expected the real SSRF guard implementation");
+        }
+        fetchWithSsrFGuardMock.mockImplementationOnce(
+          async (request: Parameters<typeof actualGuard>[0]) =>
+            await actualGuard({
+              ...request,
+              url: `${baseUrl}/token`,
+              policy: { dangerouslyAllowPrivateNetwork: true },
+            }),
+        );
+
+        await expect(
+          new TokenManager({ logger }).getAccessToken("app-id", clientSecret),
+        ).resolves.toBe(accessToken);
       },
     );
 
-    await expect(
-      new TokenManager({ logger }).getAccessToken("app-id", "client-secret"),
-    ).resolves.toBe(accessToken);
-
     const debugOutput = logger.debug.mock.calls.flat().join("\n");
     expect(debugOutput).toContain("issued-token-visible-123");
+    expect(debugOutput).toContain("issued-trace-visible-123");
+    expect(debugOutput).not.toContain(clientSecret);
     expect(debugOutput).not.toContain(accessToken);
+    expect(debugOutput).not.toContain(encodedAccessToken);
     expect(debugOutput).not.toContain(tokenPrefix);
     expect(debugOutput).not.toContain(tokenSuffix);
     expect(debugOutput).not.toContain("UNIQUE-ISSUED-TOKEN");

--- a/extensions/qqbot/src/engine/api/token.test.ts
+++ b/extensions/qqbot/src/engine/api/token.test.ts
@@ -130,6 +130,60 @@ describe("QQBot token manager", () => {
     expect(logger.debug.mock.calls.join("\n")).not.toContain("tail");
   });
 
+  it("redacts a reflected client secret before logging or throwing token errors", async () => {
+    const logger = { debug: vi.fn(), info: vi.fn(), error: vi.fn() };
+    const clientSecret = "token-reflected-secret-1234567890";
+    const release = mockGuardedTokenResponse(
+      JSON.stringify({
+        code: 11244,
+        message: "credential rejected",
+        clientSecret,
+        client_secret: clientSecret,
+        request_id: "token-visible-123",
+      }),
+      {
+        status: 401,
+        headers: { "content-type": "application/json" },
+      },
+    );
+
+    let error: unknown;
+    try {
+      await new TokenManager({ logger }).getAccessToken("app-id", clientSecret);
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    const message = error instanceof Error ? error.message : String(error);
+    const debugOutput = logger.debug.mock.calls.flat().join("\n");
+    for (const output of [debugOutput, message]) {
+      expect(output).toContain("token-visible-123");
+      expect(output).not.toContain(clientSecret);
+      expect(output).not.toContain("reflected-secret");
+    }
+    expect(release).toHaveBeenCalledTimes(1);
+
+    const proofHeadSha = process.env.OPENCLAW_PROOF_HEAD_SHA;
+    if (proofHeadSha) {
+      if (!/^[0-9a-f]{40}$/.test(proofHeadSha)) {
+        throw new Error("OPENCLAW_PROOF_HEAD_SHA must be a full Git SHA");
+      }
+      console.info(
+        `[qqbot token credential redaction proof] ${JSON.stringify({
+          exactHead: proofHeadSha,
+          status: 401,
+          debugSafeMarkerPresent: debugOutput.includes("token-visible-123"),
+          errorSafeMarkerPresent: message.includes("token-visible-123"),
+          debugSecretAbsent: !debugOutput.includes(clientSecret),
+          errorSecretAbsent: !message.includes(clientSecret),
+          debugFragmentAbsent: !debugOutput.includes("reflected-secret"),
+          errorFragmentAbsent: !message.includes("reflected-secret"),
+        })}`,
+      );
+    }
+  });
+
   it("passes the RFC2544 SSRF allowance to the token fetch (regression for #88984)", async () => {
     mockGuardedTokenResponse('{"access_token":"token-1","expires_in":7200}', {
       status: 200,

--- a/extensions/qqbot/src/engine/api/token.ts
+++ b/extensions/qqbot/src/engine/api/token.ts
@@ -24,6 +24,7 @@ const TOKEN_URL = "https://bots.qq.com/app/getAppAccessToken";
 const DEFAULT_TOKEN_EXPIRES_IN_SECONDS = 7200;
 const QQBOT_TOKEN_RESPONSE_LIMIT_BYTES = 8 * 1024;
 const QQBOT_TOKEN_REQUEST_TIMEOUT_MS = 30_000;
+const MALFORMED_TOKEN_RESPONSE_BODY_DIAGNOSTIC = "<malformed JSON body omitted>";
 
 /**
  * Host-scoped SSRF policy for the QQ Bot token endpoint.
@@ -289,15 +290,22 @@ export class TokenManager {
           cause: err,
         });
       }
-      const presentedBody = redactQQBotCredentialText(rawBody, clientSecret);
-      this.logger?.debug?.(`[qqbot:token:${appId}] <<< Body: ${presentedBody}`);
-
       let data: { access_token?: string; expires_in?: unknown };
       try {
         data = JSON.parse(rawBody);
       } catch {
+        this.logger?.debug?.(
+          `[qqbot:token:${appId}] <<< Body: ${MALFORMED_TOKEN_RESPONSE_BODY_DIAGNOSTIC}`,
+        );
         throw new Error("QQBot access_token response was malformed JSON");
       }
+
+      const presentedBody = redactQQBotCredentialText(
+        rawBody,
+        clientSecret,
+        data.access_token ?? "",
+      );
+      this.logger?.debug?.(`[qqbot:token:${appId}] <<< Body: ${presentedBody}`);
 
       if (!data.access_token) {
         throw new Error(qqbotTokenFailureMessage(presentedBody));

--- a/extensions/qqbot/src/engine/api/token.ts
+++ b/extensions/qqbot/src/engine/api/token.ts
@@ -7,7 +7,6 @@
  */
 
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import { redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
 import {
   asDateTimestampMs,
   parseStrictPositiveInteger,
@@ -19,6 +18,7 @@ import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
 import { fetchWithSsrFGuard, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import { qqbotNetworkGuidance, qqbotTokenFailureMessage } from "../config/setup-guidance.js";
 import type { EngineLogger } from "../types.js";
+import { redactQQBotCredentialText } from "../utils/credential-redaction.js";
 
 const TOKEN_URL = "https://bots.qq.com/app/getAppAccessToken";
 const DEFAULT_TOKEN_EXPIRES_IN_SECONDS = 7200;
@@ -289,7 +289,7 @@ export class TokenManager {
           cause: err,
         });
       }
-      const presentedBody = redactToolPayloadText(rawBody);
+      const presentedBody = redactQQBotCredentialText(rawBody, clientSecret);
       this.logger?.debug?.(`[qqbot:token:${appId}] <<< Body: ${presentedBody}`);
 
       let data: { access_token?: string; expires_in?: unknown };

--- a/extensions/qqbot/src/engine/api/token.ts
+++ b/extensions/qqbot/src/engine/api/token.ts
@@ -278,10 +278,6 @@ export class TokenManager {
 
     try {
       const traceId = response.headers.get("x-tps-trace-id") ?? "";
-      this.logger?.debug?.(
-        `[qqbot:token:${appId}] <<< ${response.status}${traceId ? ` | TraceId: ${traceId}` : ""}`,
-      );
-
       let rawBody: string;
       try {
         rawBody = await readResponseTextLimited(response, QQBOT_TOKEN_RESPONSE_LIMIT_BYTES);
@@ -294,12 +290,24 @@ export class TokenManager {
       try {
         data = JSON.parse(rawBody);
       } catch {
+        const presentedTraceId = redactQQBotCredentialText(traceId, clientSecret);
+        this.logger?.debug?.(
+          `[qqbot:token:${appId}] <<< ${response.status}${presentedTraceId ? ` | TraceId: ${presentedTraceId}` : ""}`,
+        );
         this.logger?.debug?.(
           `[qqbot:token:${appId}] <<< Body: ${MALFORMED_TOKEN_RESPONSE_BODY_DIAGNOSTIC}`,
         );
         throw new Error("QQBot access_token response was malformed JSON");
       }
 
+      const presentedTraceId = redactQQBotCredentialText(
+        traceId,
+        clientSecret,
+        data.access_token ?? "",
+      );
+      this.logger?.debug?.(
+        `[qqbot:token:${appId}] <<< ${response.status}${presentedTraceId ? ` | TraceId: ${presentedTraceId}` : ""}`,
+      );
       const presentedBody = redactQQBotCredentialText(
         rawBody,
         clientSecret,

--- a/extensions/qqbot/src/engine/api/token.ts
+++ b/extensions/qqbot/src/engine/api/token.ts
@@ -7,6 +7,7 @@
  */
 
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
 import {
   asDateTimestampMs,
   parseStrictPositiveInteger,
@@ -288,8 +289,8 @@ export class TokenManager {
           cause: err,
         });
       }
-      const logBody = rawBody.replace(/"access_token"\s*:\s*"[^"]+"/g, '"access_token": "***"');
-      this.logger?.debug?.(`[qqbot:token:${appId}] <<< Body: ${logBody}`);
+      const presentedBody = redactToolPayloadText(rawBody);
+      this.logger?.debug?.(`[qqbot:token:${appId}] <<< Body: ${presentedBody}`);
 
       let data: { access_token?: string; expires_in?: unknown };
       try {
@@ -299,7 +300,7 @@ export class TokenManager {
       }
 
       if (!data.access_token) {
-        throw new Error(qqbotTokenFailureMessage(JSON.stringify(data)));
+        throw new Error(qqbotTokenFailureMessage(presentedBody));
       }
 
       const nowMs = asDateTimestampMs(Date.now());

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
@@ -566,7 +566,10 @@ describe("GatewayConnection credential redaction", () => {
 
     expect(log.error).toHaveBeenCalledWith(expect.stringContaining("gateway-socket-visible-123"));
     expect(onError).toHaveBeenCalledTimes(1);
-    const reportedError = expectDefined(onError.mock.calls[0]?.[0] as Error | undefined);
+    const reportedError = expectDefined(
+      onError.mock.calls[0]?.[0] as Error | undefined,
+      "reported gateway error",
+    );
     expect(reportedError.cause).toBeUndefined();
     const diagnosticOutput = [...log.error.mock.calls.flat(), reportedError.message].join("\n");
     expectCredentialsAbsent(diagnosticOutput, forbidden);

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
@@ -578,6 +578,36 @@ describe("GatewayConnection credential redaction", () => {
     await started;
   });
 
+  it("drops credential-bearing causes before reporting gateway socket errors", async () => {
+    const { accessToken, forbidden } = makeCredentialReflectionFixture();
+    vi.mocked(getAccessToken).mockResolvedValueOnce(accessToken);
+    const log = { info: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    const onError = vi.fn();
+    const { ws, controller, started } = await startConnection({ log, onError });
+    const rawError = new Error("gateway-socket-cause-visible-123", {
+      cause: new Error(`nested credential ${accessToken}`),
+    });
+
+    ws.emit("error", rawError);
+
+    expect(log.error).toHaveBeenCalledWith(
+      expect.stringContaining("gateway-socket-cause-visible-123"),
+    );
+    expect(onError).toHaveBeenCalledTimes(1);
+    const reportedError = expectDefined(
+      onError.mock.calls[0]?.[0] as Error | undefined,
+      "reported gateway error",
+    );
+    expect(reportedError).not.toBe(rawError);
+    expect(reportedError.message).toBe("gateway-socket-cause-visible-123");
+    expect(reportedError.cause).toBeUndefined();
+    const diagnosticOutput = [...log.error.mock.calls.flat(), reportedError.message].join("\n");
+    expectCredentialsAbsent(diagnosticOutput, forbidden);
+
+    controller.abort();
+    await started;
+  });
+
   it("redacts raw and encoded access tokens reflected in DISPATCH diagnostics", async () => {
     const { accessToken, reflected, forbidden } = makeCredentialReflectionFixture();
     vi.mocked(getAccessToken).mockResolvedValueOnce(accessToken);

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from "node:events";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { EngineAdapters } from "../adapter/index.js";
-import { stopBackgroundTokenRefresh } from "../messaging/sender.js";
+import { getAccessToken, stopBackgroundTokenRefresh } from "../messaging/sender.js";
 import { flushRefIndex } from "../ref/store.js";
 import { flushKnownUsers } from "../session/known-users.js";
 import { GatewayEvent, GatewayOp, MAX_RECONNECT_ATTEMPTS } from "./constants.js";
@@ -83,6 +83,7 @@ async function startConnection(params: {
     account: makeAccount(),
     abortSignal: controller.signal,
     cfg: {},
+    log: params.log,
     runtime: {} as GatewayPluginRuntime,
     adapters: {} as EngineAdapters,
     log: params.log,
@@ -128,6 +129,59 @@ describe("GatewayConnection disconnect status", () => {
     ws.emit("close", 1006, Buffer.from(""));
 
     expect(onDisconnected).toHaveBeenCalledWith({ reason: "close code 1006", fatal: false });
+    controller.abort();
+    await started;
+  });
+
+  it("redacts an active access token reflected by a gateway close reason", async () => {
+    const secretPrefix = "qQGwP";
+    const secretSuffix = "gSfQ";
+    const accessToken = `${secretPrefix}/UNIQUE~GATEWAYSECRET+${secretSuffix}`;
+    vi.mocked(getAccessToken).mockResolvedValueOnce(accessToken);
+    const log = { info: vi.fn(), error: vi.fn() };
+    const { ws, controller, started } = await startConnection({ log });
+
+    ws.readyState = 1; // OPEN
+    ws.emit("open");
+    ws.emit("message", JSON.stringify({ op: GatewayOp.HELLO, d: { heartbeat_interval: 10_000 } }));
+    await vi.waitFor(() => {
+      expect(ws.send).toHaveBeenCalledWith(expect.stringContaining(`QQBot ${accessToken}`));
+    });
+
+    ws.emit(
+      "close",
+      4000,
+      Buffer.from(`gateway-close-visible-123 reflected ${accessToken}`, "utf8"),
+    );
+
+    const infoOutput = log.info.mock.calls.flat().join("\n");
+    expect(infoOutput).toContain("WebSocket closed: 4000");
+    expect(infoOutput).toContain("gateway-close-visible-123");
+    expect(infoOutput).not.toContain(accessToken);
+    expect(infoOutput).not.toContain(secretPrefix);
+    expect(infoOutput).not.toContain(secretSuffix);
+    expect(infoOutput).not.toContain("UNIQUEGATEWAYSECRET");
+
+    const proofHeadSha = process.env.OPENCLAW_PROOF_HEAD_SHA;
+    if (proofHeadSha) {
+      if (!/^[0-9a-f]{40}$/.test(proofHeadSha)) {
+        throw new Error("OPENCLAW_PROOF_HEAD_SHA must be a full Git SHA");
+      }
+      console.info(
+        `[qqbot gateway credential redaction proof] ${JSON.stringify({
+          exactHead: proofHeadSha,
+          transport: "websocket-close-event",
+          status: 4000,
+          identifySent: ws.send.mock.calls.some(([payload]) => String(payload).includes("QQBot ")),
+          safeMarkerPresent: infoOutput.includes("gateway-close-visible-123"),
+          tokenAbsent: !infoOutput.includes(accessToken),
+          prefixAbsent: !infoOutput.includes(secretPrefix),
+          suffixAbsent: !infoOutput.includes(secretSuffix),
+          fragmentAbsent: !infoOutput.includes("UNIQUEGATEWAYSECRET"),
+        })}`,
+      );
+    }
+
     controller.abort();
     await started;
   });

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
@@ -117,7 +117,6 @@ async function startConnection(params: {
     account: makeAccount(),
     abortSignal: controller.signal,
     cfg: {},
-    log: params.log,
     runtime: {} as GatewayPluginRuntime,
     adapters: {} as EngineAdapters,
     log: params.log,

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
@@ -9,7 +9,12 @@ import { flushRefIndex } from "../ref/store.js";
 import { flushKnownUsers } from "../session/known-users.js";
 import { GatewayEvent, GatewayOp, MAX_RECONNECT_ATTEMPTS } from "./constants.js";
 import { GatewayConnection } from "./gateway-connection.js";
-import { QQBotIngressAdmissionError, type QQBotIngressMonitor } from "./ingress.js";
+import type { InboundPipelineDeps } from "./inbound-context.js";
+import { inspectQQBotIngressEnvelope } from "./ingress-envelope.js";
+import { createQQBotIngressMonitor, QQBotIngressAdmissionError } from "./ingress.js";
+import { withQQBotIngressQueue } from "./ingress.test-support.js";
+import type { QueuedMessage } from "./message-queue.js";
+import { buildAgentBody, buildUserContent, buildUserMessage } from "./stages/index.js";
 import type { EngineLogger, GatewayAccount, GatewayPluginRuntime } from "./types.js";
 
 const createQQWSClientMock = vi.hoisted(() => vi.fn());
@@ -108,7 +113,8 @@ async function startConnection(params: {
   log?: EngineLogger;
   onDisconnected?: (info: unknown) => void;
   onError?: (error: Error) => void;
-  createIngressMonitor?: () => QQBotIngressMonitor;
+  handleMessage?: (event: QueuedMessage) => Promise<void>;
+  createIngressMonitor?: typeof createQQBotIngressMonitor;
 }) {
   const ws = new FakeWebSocket();
   createQQWSClientMock.mockResolvedValue(ws);
@@ -120,7 +126,7 @@ async function startConnection(params: {
     runtime: {} as GatewayPluginRuntime,
     adapters: {} as EngineAdapters,
     log: params.log,
-    handleMessage: async () => {},
+    handleMessage: params.handleMessage ?? (async () => {}),
     createIngressMonitor: createNoopIngressMonitor,
     ...(params.createIngressMonitor ? { createIngressMonitor: params.createIngressMonitor } : {}),
     onDisconnected: params.onDisconnected,
@@ -633,6 +639,183 @@ describe("GatewayConnection credential redaction", () => {
     expect(debugOutput).toContain("Dispatch event: t=CREDENTIAL_REFLECTION_TEST");
     expect(debugOutput).toContain("dispatch-visible-123");
     expectCredentialsAbsent(debugOutput, forbidden);
+
+    controller.abort();
+    await started;
+  });
+
+  it.each([
+    {
+      name: "C2C",
+      eventType: GatewayEvent.C2C_MESSAGE_CREATE,
+      data: { id: "c2c%2fmessage", author: { user_openid: "c2c%afuser" } },
+    },
+    {
+      name: "guild",
+      eventType: GatewayEvent.AT_MESSAGE_CREATE,
+      data: {
+        id: "guild%2fmessage",
+        channel_id: "guild%afchannel",
+        guild_id: "guild%2fid",
+        author: { id: "guild-user", username: "Guild User" },
+      },
+    },
+    {
+      name: "DM",
+      eventType: GatewayEvent.DIRECT_MESSAGE_CREATE,
+      data: {
+        id: "dm%2fmessage",
+        guild_id: "dm-guild",
+        author: { id: "dm%afuser", username: "DM User" },
+      },
+    },
+    {
+      name: "group @",
+      eventType: GatewayEvent.GROUP_AT_MESSAGE_CREATE,
+      data: {
+        id: "group-at%2fmessage",
+        group_openid: "group-at%afid",
+        author: { member_openid: "group-at-user", username: "Group User" },
+      },
+    },
+    {
+      name: "group full-message",
+      eventType: GatewayEvent.GROUP_MESSAGE_CREATE,
+      data: {
+        id: "group-full%2fmessage",
+        group_openid: "group-full%afid",
+        author: { member_openid: "group-full-user", username: "Group User" },
+      },
+    },
+  ])("redacts $name credentials before durable and agent-visible delivery", async (turn) => {
+    vi.useRealTimers();
+    const { accessToken, reflected, forbidden } = makeCredentialReflectionFixture();
+    vi.mocked(getAccessToken).mockResolvedValueOnce(accessToken);
+    const visibleUserText = "sk-visible-user-content";
+    const event = {
+      op: GatewayOp.DISPATCH,
+      id: `delivery-${turn.name}%2fstable`,
+      s: 41,
+      t: turn.eventType,
+      d: {
+        ...turn.data,
+        content:
+          `turn-kind-visible raw=${reflected.raw} encoded=${reflected.encoded} ` +
+          `form=${reflected.form} generic-pattern=${visibleUserText}`,
+        timestamp: "2026-07-18T12:00:00Z",
+      },
+    };
+    const originalEnvelope = JSON.stringify(event);
+    const original = expectDefined(
+      inspectQQBotIngressEnvelope(originalEnvelope),
+      `${turn.name} original envelope facts`,
+    );
+
+    await withQQBotIngressQueue(async (queue) => {
+      let userContent = "";
+      let agentBody = "";
+      const handleMessage = vi.fn(async (queued: QueuedMessage) => {
+        ({ userContent } = buildUserContent({
+          event: queued,
+          attachmentInfo: "",
+          voiceTranscripts: [],
+        }));
+        const isGroupChat = queued.type === "guild" || queued.type === "group";
+        const userMessage = buildUserMessage({
+          event: queued,
+          userContent,
+          quotePart: "",
+          isGroupChat,
+        });
+        agentBody = buildAgentBody({
+          event: queued,
+          userContent,
+          userMessage,
+          dynamicCtx: "",
+          isGroupChat,
+          deps: {} as InboundPipelineDeps,
+        });
+      });
+      const { ws, controller, started } = await startConnection({
+        handleMessage,
+        createIngressMonitor: (options) =>
+          createQQBotIngressMonitor({ ...options, queue, pollIntervalMs: 10 }),
+      });
+
+      try {
+        ws.emit("message", originalEnvelope);
+        await vi.waitFor(() => expect(handleMessage).toHaveBeenCalledTimes(1));
+
+        const [claim] = await queue.listClaims();
+        const safeEnvelope = expectDefined(claim?.payload.rawEnvelope, "durable QQBot envelope");
+        const safe = expectDefined(
+          inspectQQBotIngressEnvelope(safeEnvelope),
+          `${turn.name} safe envelope facts`,
+        );
+        expect({
+          eventId: safe.eventId,
+          eventType: safe.eventType,
+          laneKey: safe.laneKey,
+          deliveryId: safe.payload.id,
+          sequence: safe.payload.s,
+        }).toEqual({
+          eventId: original.eventId,
+          eventType: original.eventType,
+          laneKey: original.laneKey,
+          deliveryId: original.payload.id,
+          sequence: original.payload.s,
+        });
+        expect(JSON.parse(safeEnvelope)).toMatchObject({ d: turn.data });
+        for (const output of [safeEnvelope, userContent, agentBody]) {
+          expect(output).toContain("turn-kind-visible");
+          expect(output).toContain("<redacted>");
+          // Generic logging patterns must not rewrite durable user content.
+          expect(output).toContain(visibleUserText);
+          expectCredentialsAbsent(output, forbidden);
+        }
+      } finally {
+        controller.abort();
+        await started;
+      }
+    });
+  });
+
+  it("refuses to persist a turn when the active credential overlaps its identity", async () => {
+    const accessToken = "credential-overlaps-user-id";
+    vi.mocked(getAccessToken).mockResolvedValueOnce(accessToken);
+    const receive = vi.fn(async () => {});
+    const log = { info: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    const { ws, controller, started } = await startConnection({
+      log,
+      createIngressMonitor: () => ({
+        receive,
+        stop: vi.fn(async () => {}),
+        waitForIdle: vi.fn(async () => {}),
+      }),
+    });
+
+    ws.emit(
+      "message",
+      JSON.stringify({
+        op: GatewayOp.DISPATCH,
+        id: "identity-overlap-delivery",
+        s: 43,
+        t: GatewayEvent.C2C_MESSAGE_CREATE,
+        d: {
+          id: "identity-overlap-message",
+          content: "identity-overlap-visible",
+          timestamp: "2026-07-18T12:00:00Z",
+          author: { user_openid: accessToken },
+        },
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(log.error).toHaveBeenCalledWith(
+        expect.stringContaining("credential overlaps the durable turn identity"),
+      );
+    });
+    expect(receive).not.toHaveBeenCalled();
 
     controller.abort();
     await started;

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
@@ -522,6 +522,58 @@ describe("GatewayConnection credential redaction", () => {
     await started;
   });
 
+  it("redacts an active token from gateway construction failures", async () => {
+    const { accessToken, forbidden } = makeCredentialReflectionFixture();
+    const gatewayUrl = `wss://gateway.example.test/connect?token=${encodeURIComponent(accessToken)}`;
+    vi.mocked(getAccessToken).mockResolvedValueOnce(accessToken);
+    vi.mocked(getGatewayUrl).mockResolvedValueOnce(gatewayUrl);
+    createQQWSClientMock.mockRejectedValueOnce(
+      new Error(`gateway-construction-visible-123 failed for ${gatewayUrl}`),
+    );
+    const log = { info: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    const controller = new AbortController();
+    const connection = new GatewayConnection({
+      account: makeAccount(),
+      abortSignal: controller.signal,
+      cfg: {},
+      runtime: {} as GatewayPluginRuntime,
+      adapters: {} as EngineAdapters,
+      log,
+      handleMessage: async () => {},
+      createIngressMonitor: createNoopIngressMonitor,
+    });
+
+    const started = connection.start();
+    await vi.waitFor(() => {
+      expect(log.error).toHaveBeenCalledWith(
+        expect.stringContaining("gateway-construction-visible-123"),
+      );
+    });
+    expectCredentialsAbsent(log.error.mock.calls.flat().join("\n"), [...forbidden, gatewayUrl]);
+
+    controller.abort();
+    await started;
+  });
+
+  it("redacts an active token before reporting gateway socket errors", async () => {
+    const { accessToken, forbidden } = makeCredentialReflectionFixture();
+    vi.mocked(getAccessToken).mockResolvedValueOnce(accessToken);
+    const log = { info: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    const onError = vi.fn();
+    const { ws, controller, started } = await startConnection({ log, onError });
+
+    ws.emit("error", new Error(`gateway-socket-visible-123 reflected ${accessToken}`));
+
+    expect(log.error).toHaveBeenCalledWith(expect.stringContaining("gateway-socket-visible-123"));
+    expect(onError).toHaveBeenCalledTimes(1);
+    const reportedError = expectDefined(onError.mock.calls[0]?.[0] as Error | undefined);
+    const diagnosticOutput = [...log.error.mock.calls.flat(), reportedError.message].join("\n");
+    expectCredentialsAbsent(diagnosticOutput, forbidden);
+
+    controller.abort();
+    await started;
+  });
+
   it("redacts raw and encoded access tokens reflected in DISPATCH diagnostics", async () => {
     const { accessToken, reflected, forbidden } = makeCredentialReflectionFixture();
     vi.mocked(getAccessToken).mockResolvedValueOnce(accessToken);

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
@@ -2,8 +2,9 @@
 import { EventEmitter } from "node:events";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { lowercasePercentEscapes } from "../../test-support/credential-reflection.js";
 import type { EngineAdapters } from "../adapter/index.js";
-import { getAccessToken, stopBackgroundTokenRefresh } from "../messaging/sender.js";
+import { getAccessToken, getGatewayUrl, stopBackgroundTokenRefresh } from "../messaging/sender.js";
 import { flushRefIndex } from "../ref/store.js";
 import { flushKnownUsers } from "../session/known-users.js";
 import { GatewayEvent, GatewayOp, MAX_RECONNECT_ATTEMPTS } from "./constants.js";
@@ -68,6 +69,39 @@ function makeAccount(): GatewayAccount {
     markdownSupport: false,
     config: {},
   };
+}
+
+function makeCredentialReflectionFixture() {
+  const secretPrefix = "qQGwP";
+  const secretSuffix = "gSfQ";
+  const accessToken = `${secretPrefix}/UNIQUE~GATEWAYSECRET+${secretSuffix}`;
+  const encodedToken = encodeURIComponent(accessToken);
+  const formEncodedToken = new URLSearchParams([["credential", accessToken]])
+    .toString()
+    .slice("credential=".length);
+  const reflected = {
+    raw: accessToken,
+    encoded: lowercasePercentEscapes(encodedToken),
+    form: lowercasePercentEscapes(formEncodedToken),
+  };
+  return {
+    accessToken,
+    reflected,
+    forbidden: [
+      ...Object.values(reflected),
+      encodedToken,
+      formEncodedToken,
+      secretPrefix,
+      secretSuffix,
+      "UNIQUEGATEWAYSECRET",
+    ],
+  };
+}
+
+function expectCredentialsAbsent(output: string, forbidden: string[]): void {
+  for (const credential of forbidden) {
+    expect(output).not.toContain(credential);
+  }
 }
 
 async function startConnection(params: {
@@ -452,6 +486,69 @@ describe("GatewayConnection disconnect status", () => {
     await Promise.resolve();
     expect(receive).toHaveBeenCalledTimes(1);
     expect(onError).toHaveBeenCalledWith(admissionError);
+    controller.abort();
+    await started;
+  });
+});
+
+describe("GatewayConnection credential redaction", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    createQQWSClientMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("redacts raw and encoded access tokens reflected in the gateway URL log", async () => {
+    const { accessToken, reflected, forbidden } = makeCredentialReflectionFixture();
+    const gatewayUrl =
+      `wss://gateway.example.test/connect?marker=gateway-url-visible-123` +
+      `&raw=${reflected.raw}&encoded=${reflected.encoded}&form=${reflected.form}`;
+    vi.mocked(getAccessToken).mockResolvedValueOnce(accessToken);
+    vi.mocked(getGatewayUrl).mockResolvedValueOnce(gatewayUrl);
+    const log = { info: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+    const { controller, started } = await startConnection({ log });
+
+    expect(createQQWSClientMock).toHaveBeenCalledWith(expect.objectContaining({ gatewayUrl }));
+    const infoOutput = log.info.mock.calls.flat().join("\n");
+    expect(infoOutput).toContain("Connecting to wss://gateway.example.test/connect");
+    expect(infoOutput).toContain("gateway-url-visible-123");
+    expectCredentialsAbsent(infoOutput, forbidden);
+
+    controller.abort();
+    await started;
+  });
+
+  it("redacts raw and encoded access tokens reflected in DISPATCH diagnostics", async () => {
+    const { accessToken, reflected, forbidden } = makeCredentialReflectionFixture();
+    vi.mocked(getAccessToken).mockResolvedValueOnce(accessToken);
+    const log = { info: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    const { ws, controller, started } = await startConnection({ log });
+
+    ws.emit(
+      "message",
+      JSON.stringify({
+        op: GatewayOp.DISPATCH,
+        t: "CREDENTIAL_REFLECTION_TEST",
+        d: {
+          marker: "dispatch-visible-123",
+          ...reflected,
+        },
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(log.debug).toHaveBeenCalledWith(expect.stringContaining("dispatch-visible-123"));
+    });
+    const debugOutput = log.debug.mock.calls.flat().join("\n");
+    expect(debugOutput).toContain("Dispatch event: t=CREDENTIAL_REFLECTION_TEST");
+    expect(debugOutput).toContain("dispatch-visible-123");
+    expectCredentialsAbsent(debugOutput, forbidden);
+
     controller.abort();
     await started;
   });

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
@@ -567,6 +567,7 @@ describe("GatewayConnection credential redaction", () => {
     expect(log.error).toHaveBeenCalledWith(expect.stringContaining("gateway-socket-visible-123"));
     expect(onError).toHaveBeenCalledTimes(1);
     const reportedError = expectDefined(onError.mock.calls[0]?.[0] as Error | undefined);
+    expect(reportedError.cause).toBeUndefined();
     const diagnosticOutput = [...log.error.mock.calls.flat(), reportedError.message].join("\n");
     expectCredentialsAbsent(diagnosticOutput, forbidden);
 

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.ts
@@ -309,9 +309,10 @@ export class GatewayConnection {
       }
 
       accessToken = await getAccessToken(account.appId, account.clientSecret);
+      const activeAccessToken = accessToken;
       log?.info(`✅ Access token obtained successfully`);
-      const gatewayUrl = await getGatewayUrl(accessToken, account.appId);
-      log?.info(redactQQBotCredentialText(`Connecting to ${gatewayUrl}`, accessToken));
+      const gatewayUrl = await getGatewayUrl(activeAccessToken, account.appId);
+      log?.info(redactQQBotCredentialText(`Connecting to ${gatewayUrl}`, activeAccessToken));
       const ws = await createQQWSClient({
         gatewayUrl,
         userAgent: getPluginUserAgent(),
@@ -353,7 +354,7 @@ export class GatewayConnection {
           return;
         }
         this.socketMessageTail = this.socketMessageTail
-          .then(() => this.handleSocketMessage(ws, { rawData, payload }, accessToken))
+          .then(() => this.handleSocketMessage(ws, { rawData, payload }, activeAccessToken))
           .catch((error: unknown) => {
             const message = error instanceof Error ? error.message : String(error);
             if (error instanceof QQBotIngressAdmissionError) {
@@ -373,7 +374,7 @@ export class GatewayConnection {
 
       // ---- WebSocket: close ----
       ws.on("close", (code, reason) => {
-        const safeReason = redactQQBotCredentialText(reason.toString(), accessToken);
+        const safeReason = redactQQBotCredentialText(reason.toString(), activeAccessToken);
         log?.info(`WebSocket closed: ${code} ${safeReason}`);
         // cleanup() clears currentWs before a server-driven reconnect. Ignore
         // the old socket's delayed close both during that gap and after the
@@ -387,11 +388,9 @@ export class GatewayConnection {
 
       // ---- WebSocket: error ----
       ws.on("error", (err) => {
-        const safeMessage = redactQQBotCredentialText(err.message, accessToken);
+        const safeMessage = redactQQBotCredentialText(err.message, activeAccessToken);
         log?.error(`WebSocket error: ${safeMessage}`);
-        this.ctx.onError?.(
-          safeMessage === err.message ? err : new Error(safeMessage, { cause: err }),
-        );
+        this.ctx.onError?.(safeMessage === err.message ? err : new Error(safeMessage));
       });
     } catch (err) {
       this.isConnecting = false;

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.ts
@@ -19,6 +19,7 @@ import { flushRefIndex } from "../ref/store.js";
 import { flushKnownUsers } from "../session/known-users.js";
 import { clearSession, loadSession, saveSession } from "../session/session-store.js";
 import type { InteractionEvent } from "../types.js";
+import { redactQQBotCredentialText } from "../utils/credential-redaction.js";
 import { decodeGatewayMessageData } from "./codec.js";
 import { FULL_INTENTS, RATE_LIMIT_DELAY, GatewayOp } from "./constants.js";
 import { dispatchEvent } from "./event-dispatcher.js";
@@ -371,7 +372,8 @@ export class GatewayConnection {
 
       // ---- WebSocket: close ----
       ws.on("close", (code, reason) => {
-        log?.info(`WebSocket closed: ${code} ${reason.toString()}`);
+        const safeReason = redactQQBotCredentialText(reason.toString(), accessToken);
+        log?.info(`WebSocket closed: ${code} ${safeReason}`);
         // cleanup() clears currentWs before a server-driven reconnect. Ignore
         // the old socket's delayed close both during that gap and after the
         // replacement is live, or it can reschedule reconnect handling.

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.ts
@@ -292,6 +292,7 @@ export class GatewayConnection {
 
   private async connect(): Promise<void> {
     const { account, log } = this.ctx;
+    let accessToken: string | undefined;
 
     if (this.isConnecting) {
       log?.debug?.(`Already connecting, skip`);
@@ -307,7 +308,7 @@ export class GatewayConnection {
         this.shouldRefreshToken = false;
       }
 
-      const accessToken = await getAccessToken(account.appId, account.clientSecret);
+      accessToken = await getAccessToken(account.appId, account.clientSecret);
       log?.info(`✅ Access token obtained successfully`);
       const gatewayUrl = await getGatewayUrl(accessToken, account.appId);
       log?.info(redactQQBotCredentialText(`Connecting to ${gatewayUrl}`, accessToken));
@@ -386,12 +387,18 @@ export class GatewayConnection {
 
       // ---- WebSocket: error ----
       ws.on("error", (err) => {
-        log?.error(`WebSocket error: ${err.message}`);
-        this.ctx.onError?.(err);
+        const safeMessage = redactQQBotCredentialText(err.message, accessToken);
+        log?.error(`WebSocket error: ${safeMessage}`);
+        this.ctx.onError?.(
+          safeMessage === err.message ? err : new Error(safeMessage, { cause: err }),
+        );
       });
     } catch (err) {
       this.isConnecting = false;
-      const errMsg = err instanceof Error ? err.message : String(err);
+      const errMsg = redactQQBotCredentialText(
+        err instanceof Error ? err.message : String(err),
+        accessToken ?? "",
+      );
       log?.error(`Connection failed: ${errMsg}`);
       if (errMsg.includes("Too many requests") || errMsg.includes("100001")) {
         this.scheduleReconnect(RATE_LIMIT_DELAY);

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.ts
@@ -24,7 +24,7 @@ import { decodeGatewayMessageData } from "./codec.js";
 import { FULL_INTENTS, RATE_LIMIT_DELAY, GatewayOp } from "./constants.js";
 import { dispatchEvent } from "./event-dispatcher.js";
 import { createQQBotIngressEffectOnce } from "./ingress-effects.js";
-import { isQQBotTurnEventType } from "./ingress-envelope.js";
+import { isQQBotTurnEventType, redactQQBotIngressEnvelopeCredentials } from "./ingress-envelope.js";
 import {
   createQQBotIngressMonitor,
   QQBotIngressAdmissionError,
@@ -433,8 +433,11 @@ export class GatewayConnection {
           if (!this.ingress) {
             throw new Error("QQBot ingress monitor is unavailable.");
           }
-          // Resume sequence advances only after the raw turn is durable.
-          await this.ingress.receive(rawData);
+          // Strip the socket-scoped credential before the replayable envelope
+          // crosses into durable storage; required turn identity must stay exact.
+          const safeRawData = redactQQBotIngressEnvelopeCredentials(rawData, accessToken);
+          // Resume sequence advances only after the sanitized turn is durable.
+          await this.ingress.receive(safeRawData);
         } else {
           const result = dispatchEvent(t ?? "", d, this.ctx.account.accountId, this.ctx.log);
           if (result.action === "ready") {

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.ts
@@ -390,7 +390,8 @@ export class GatewayConnection {
       ws.on("error", (err) => {
         const safeMessage = redactQQBotCredentialText(err.message, activeAccessToken);
         log?.error(`WebSocket error: ${safeMessage}`);
-        this.ctx.onError?.(safeMessage === err.message ? err : new Error(safeMessage));
+        // Safe messages can still carry credential-bearing causes on provider-owned errors.
+        this.ctx.onError?.(new Error(safeMessage));
       });
     } catch (err) {
       this.isConnecting = false;

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.ts
@@ -310,7 +310,7 @@ export class GatewayConnection {
       const accessToken = await getAccessToken(account.appId, account.clientSecret);
       log?.info(`✅ Access token obtained successfully`);
       const gatewayUrl = await getGatewayUrl(accessToken, account.appId);
-      log?.info(`Connecting to ${gatewayUrl}`);
+      log?.info(redactQQBotCredentialText(`Connecting to ${gatewayUrl}`, accessToken));
       const ws = await createQQWSClient({
         gatewayUrl,
         userAgent: getPluginUserAgent(),
@@ -419,7 +419,9 @@ export class GatewayConnection {
         break;
 
       case GatewayOp.DISPATCH: {
-        this.ctx.log?.debug?.(`Dispatch event: t=${t}, d=${JSON.stringify(d)}`);
+        this.ctx.log?.debug?.(
+          redactQQBotCredentialText(`Dispatch event: t=${t}, d=${JSON.stringify(d)}`, accessToken),
+        );
         if (isQQBotTurnEventType(t)) {
           if (!this.ingress) {
             throw new Error("QQBot ingress monitor is unavailable.");

--- a/extensions/qqbot/src/engine/gateway/ingress-envelope.ts
+++ b/extensions/qqbot/src/engine/gateway/ingress-envelope.ts
@@ -1,5 +1,6 @@
 // QQBot plugin module validates raw gateway envelopes for durable ingress.
 import { normalizeNullableString as nonEmptyString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { redactQQBotExactCredentialText } from "../utils/credential-redaction.js";
 import { GatewayEvent, GatewayOp } from "./constants.js";
 import type { WSPayload } from "./types.js";
 
@@ -105,4 +106,40 @@ export function inspectQQBotIngressEnvelope(rawEnvelope: string): QQBotIngressEn
     laneKey: `group:${requiredString(data.group_openid, "d.group_openid")}`,
     payload,
   };
+}
+
+export function redactQQBotIngressEnvelopeCredentials(
+  rawEnvelope: string,
+  ...credentials: readonly string[]
+): string {
+  const original = inspectQQBotIngressEnvelope(rawEnvelope);
+  if (!original) {
+    return rawEnvelope;
+  }
+  const redactedEnvelope = redactQQBotExactCredentialText(rawEnvelope, ...credentials);
+  if (redactedEnvelope === rawEnvelope) {
+    return rawEnvelope;
+  }
+
+  let redacted: QQBotIngressEnvelopeFacts | null;
+  try {
+    redacted = inspectQQBotIngressEnvelope(redactedEnvelope);
+  } catch {
+    redacted = null;
+  }
+  if (
+    !redacted ||
+    redacted.eventId !== original.eventId ||
+    redacted.eventType !== original.eventType ||
+    redacted.laneKey !== original.laneKey ||
+    redacted.payload.id !== original.payload.id ||
+    redacted.payload.s !== original.payload.s
+  ) {
+    // A reflected credential must never be persisted, but changing a durable
+    // identity would make retries route or deduplicate the turn incorrectly.
+    throw new QQBotIngressPayloadError(
+      "QQBot gateway credential overlaps the durable turn identity.",
+    );
+  }
+  return redactedEnvelope;
 }

--- a/extensions/qqbot/src/engine/gateway/ingress.ts
+++ b/extensions/qqbot/src/engine/gateway/ingress.ts
@@ -96,7 +96,7 @@ export function createQQBotIngressMonitor(options: {
           `QQBot ingress row ${claim.id} no longer maps to a message turn.`,
         );
       }
-      // Stage mapping stays claim-side. Receive stores the exact transport envelope.
+      // Stage mapping stays claim-side. Receive stores the producer-sanitized transport envelope.
       const mapped = dispatchEvent(
         facts.eventType,
         facts.payload.d,

--- a/extensions/qqbot/src/engine/tools/channel-api.test.ts
+++ b/extensions/qqbot/src/engine/tools/channel-api.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createStreamingResponse } from "../../../../test-support/streaming-error-response.js";
 import {
   lowercasePercentEscapes,
+  percentEncodeEveryUtf8Byte,
   stringifyWithSlashEscapedCredential,
 } from "../../test-support/credential-reflection.js";
 import { withLoopbackHttpServer } from "../../test-support/loopback-http.js";
@@ -331,6 +332,7 @@ describe("executeChannelApi", () => {
     const secretSuffix = "cSfQ";
     const accessToken = `${secretPrefix}/UNIQUE~CHANNELSECRET+${secretSuffix}`;
     const encodedCredential = encodeURIComponent(accessToken);
+    const fullyEncodedCredential = percentEncodeEveryUtf8Byte(accessToken);
     const formEncodedCredential = new URLSearchParams([["echo", accessToken]]).toString();
     const lowercaseEncodedCredential = lowercasePercentEscapes(encodedCredential);
     const lowercaseFormEncodedCredential = lowercasePercentEscapes(formEncodedCredential);
@@ -349,7 +351,7 @@ describe("executeChannelApi", () => {
         res.end(
           stringifyWithSlashEscapedCredential(
             {
-              message: `channel-marker reflected credential ${reflectedCredential}; encoded ${lowercasePercentEscapes(encodeURIComponent(reflectedCredential))}; form ${lowercasePercentEscapes(reflectedFormCredential)}`,
+              message: `channel-marker reflected credential ${reflectedCredential}; encoded ${lowercasePercentEscapes(encodeURIComponent(reflectedCredential))}; fully encoded ${percentEncodeEveryUtf8Byte(reflectedCredential)}; form ${lowercasePercentEscapes(reflectedFormCredential)}`,
               nested: { reflected: `Authorization: ${authorization}` },
             },
             reflectedCredential,
@@ -388,6 +390,7 @@ describe("executeChannelApi", () => {
         expect(toolOutput).toContain("channel-marker");
         expect(toolOutput).not.toContain(accessToken);
         expect(toolOutput).not.toContain(encodedCredential);
+        expect(toolOutput).not.toContain(fullyEncodedCredential);
         expect(toolOutput).not.toContain(formEncodedCredential);
         expect(toolOutput).not.toContain(lowercaseEncodedCredential);
         expect(toolOutput).not.toContain(lowercaseFormEncodedCredential);
@@ -400,6 +403,7 @@ describe("executeChannelApi", () => {
         expect(debugOutput).toContain("channel-marker");
         expect(debugOutput).not.toContain(accessToken);
         expect(debugOutput).not.toContain(encodedCredential);
+        expect(debugOutput).not.toContain(fullyEncodedCredential);
         expect(debugOutput).not.toContain(formEncodedCredential);
         expect(debugOutput).not.toContain(lowercaseEncodedCredential);
         expect(debugOutput).not.toContain(lowercaseFormEncodedCredential);
@@ -425,6 +429,9 @@ describe("executeChannelApi", () => {
               tokenAbsent: !toolOutput.includes(accessToken) && !debugOutput.includes(accessToken),
               encodedAbsent:
                 !toolOutput.includes(encodedCredential) && !debugOutput.includes(encodedCredential),
+              fullyEncodedAbsent:
+                !toolOutput.includes(fullyEncodedCredential) &&
+                !debugOutput.includes(fullyEncodedCredential),
               formEncodedAbsent:
                 !toolOutput.includes(formEncodedCredential) &&
                 !debugOutput.includes(formEncodedCredential),
@@ -447,6 +454,59 @@ describe("executeChannelApi", () => {
             })}`,
           );
         }
+      },
+    );
+  });
+
+  it("redacts credentials from response status metadata", async () => {
+    process.env.QQBOT_DEBUG = "1";
+    const debugLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const accessToken = "qQStatus/UNIQUE~CHANNELSECRET+Proof";
+    const fullyEncodedCredential = percentEncodeEveryUtf8Byte(accessToken);
+    await withLoopbackHttpServer(
+      (req, res) => {
+        req.resume();
+        const authorization = req.headers.authorization ?? "";
+        const reflectedCredential = authorization.startsWith("QQBot ")
+          ? authorization.slice("QQBot ".length)
+          : authorization;
+        res.writeHead(
+          401,
+          `status-marker ${reflectedCredential}; encoded ${percentEncodeEveryUtf8Byte(reflectedCredential)}`,
+          { "content-type": "text/plain" },
+        );
+        res.end();
+      },
+      async (baseUrl) => {
+        const actualGuard = ssrfRuntimeActual.fetchWithSsrFGuard;
+        if (!actualGuard) {
+          throw new Error("expected the real SSRF guard implementation");
+        }
+        const loopbackFetch = vi.fn(
+          async (_input: RequestInfo | URL, init?: RequestInit) =>
+            await fetch(`${baseUrl}/channel-status`, init),
+        );
+        fetchWithSsrFGuardMock.mockImplementationOnce(
+          async (request: Parameters<typeof actualGuard>[0]) =>
+            await actualGuard({ ...request, fetchImpl: loopbackFetch }),
+        );
+
+        const result = await executeChannelApi(
+          { method: "GET", path: "/guilds/123/channels" },
+          { accessToken },
+        );
+
+        const presented = `${JSON.stringify(result)}\n${debugLogSpy.mock.calls.flat().join("\n")}`;
+        expect(result.details).toMatchObject({
+          error: expect.stringContaining("status-marker"),
+          status: 401,
+          path: "/guilds/123/channels",
+        });
+        expect(presented).toContain("status-marker");
+        expect(presented).not.toContain(accessToken);
+        expect(presented).not.toContain(fullyEncodedCredential);
+        expect(presented).not.toContain("UNIQUECHANNELSECRET");
+        expect(loopbackFetch).toHaveBeenCalledTimes(1);
       },
     );
   });

--- a/extensions/qqbot/src/engine/tools/channel-api.test.ts
+++ b/extensions/qqbot/src/engine/tools/channel-api.test.ts
@@ -3,12 +3,19 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createStreamingResponse } from "../../../../test-support/streaming-error-response.js";
+import { withLoopbackHttpServer } from "../../test-support/loopback-http.js";
 
 const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+const ssrfRuntimeActual = vi.hoisted(() => ({
+  fetchWithSsrFGuard: undefined as
+    | typeof import("openclaw/plugin-sdk/ssrf-runtime").fetchWithSsrFGuard
+    | undefined,
+}));
 const originalDebug = process.env.QQBOT_DEBUG;
 
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
+  ssrfRuntimeActual.fetchWithSsrFGuard = actual.fetchWithSsrFGuard;
   return {
     ...actual,
     fetchWithSsrFGuard: fetchWithSsrFGuardMock,
@@ -316,68 +323,107 @@ describe("executeChannelApi", () => {
   it("redacts reflected authorization from error details and debug output", async () => {
     process.env.QQBOT_DEBUG = "1";
     const debugErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const release = vi.fn(async () => {});
-    const accessToken = "qqbot_AAAAUNIQUECHANNELSECRETBBBB111122223333";
-    const authorization = `QQBot ${accessToken}`;
-    fetchWithSsrFGuardMock.mockResolvedValueOnce({
-      response: new Response(
-        JSON.stringify({
-          message: `channel-marker Authorization: ${authorization}`,
-          nested: { reflected: `Authorization: ${authorization}` },
-        }),
-        {
-          status: 401,
-          statusText: "Unauthorized",
-          headers: { "content-type": "application/json" },
-        },
-      ),
-      release,
-    });
-
-    const result = await executeChannelApi(
-      { method: "GET", path: "/guilds/123/channels" },
-      { accessToken },
-    );
-
-    expect(result.details).toMatchObject({
-      error: expect.stringContaining("channel-marker"),
-      status: 401,
-      path: "/guilds/123/channels",
-      details: {
-        message: expect.stringContaining("channel-marker"),
-        nested: { reflected: expect.any(String) },
+    const secretPrefix = "qQChnP";
+    const secretSuffix = "cSfQ";
+    const accessToken = `${secretPrefix}/UNIQUE~CHANNELSECRET+${secretSuffix}`;
+    const encodedCredential = encodeURIComponent(accessToken);
+    const formEncodedCredential = new URLSearchParams([["echo", accessToken]]).toString();
+    await withLoopbackHttpServer(
+      (req, res) => {
+        req.resume();
+        const authorization = req.headers.authorization ?? "";
+        const reflectedCredential = authorization.startsWith("QQBot ")
+          ? authorization.slice("QQBot ".length)
+          : authorization;
+        const reflectedFormCredential = new URLSearchParams([
+          ["echo", reflectedCredential],
+        ]).toString();
+        res.writeHead(401, { "content-type": "application/json" });
+        res.end(
+          JSON.stringify({
+            message: `channel-marker reflected credential ${reflectedCredential}; encoded ${encodeURIComponent(reflectedCredential)}; form ${reflectedFormCredential}`,
+            nested: { reflected: `Authorization: ${authorization}` },
+          }),
+        );
       },
-    });
-    const toolOutput = JSON.stringify(result);
-    expect(toolOutput).toContain("channel-marker");
-    expect(toolOutput).not.toContain(accessToken);
-    expect(toolOutput).not.toContain("UNIQUECHANNELSECRET");
+      async (baseUrl) => {
+        const actualGuard = ssrfRuntimeActual.fetchWithSsrFGuard;
+        if (!actualGuard) {
+          throw new Error("expected the real SSRF guard implementation");
+        }
+        const loopbackFetch = vi.fn(
+          async (_input: RequestInfo | URL, init?: RequestInit) =>
+            await fetch(`${baseUrl}/channel-error`, init),
+        );
+        fetchWithSsrFGuardMock.mockImplementationOnce(
+          async (request: Parameters<typeof actualGuard>[0]) =>
+            await actualGuard({ ...request, fetchImpl: loopbackFetch }),
+        );
 
-    const debugOutput = debugErrorSpy.mock.calls.flat().join("\n");
-    expect(debugOutput).toContain("channel-marker");
-    expect(debugOutput).not.toContain(accessToken);
-    expect(debugOutput).not.toContain("UNIQUECHANNELSECRET");
-    expect(release).toHaveBeenCalledTimes(1);
+        const result = await executeChannelApi(
+          { method: "GET", path: "/guilds/123/channels" },
+          { accessToken },
+        );
 
-    const proofHeadSha = process.env.OPENCLAW_PROOF_HEAD_SHA;
-    if (proofHeadSha) {
-      if (!/^[0-9a-f]{40}$/.test(proofHeadSha)) {
-        throw new Error("OPENCLAW_PROOF_HEAD_SHA must be a full Git SHA");
-      }
-      console.info(
-        `[qqbot credential redaction proof] ${JSON.stringify({
-          exactHead: proofHeadSha,
-          status: (result.details as { status?: number }).status,
-          path: (result.details as { path?: string }).path,
-          safeMarkerPresent:
-            toolOutput.includes("channel-marker") && debugOutput.includes("channel-marker"),
-          tokenAbsent: !toolOutput.includes(accessToken) && !debugOutput.includes(accessToken),
-          fragmentAbsent:
-            !toolOutput.includes("UNIQUECHANNELSECRET") &&
-            !debugOutput.includes("UNIQUECHANNELSECRET"),
-        })}`,
-      );
-    }
+        expect(result.details).toMatchObject({
+          error: expect.stringContaining("channel-marker"),
+          status: 401,
+          path: "/guilds/123/channels",
+          details: {
+            message: expect.stringContaining("channel-marker"),
+            nested: { reflected: expect.any(String) },
+          },
+        });
+        const toolOutput = JSON.stringify(result);
+        expect(toolOutput).toContain("channel-marker");
+        expect(toolOutput).not.toContain(accessToken);
+        expect(toolOutput).not.toContain(encodedCredential);
+        expect(toolOutput).not.toContain(formEncodedCredential);
+        expect(toolOutput).not.toContain(secretPrefix);
+        expect(toolOutput).not.toContain(secretSuffix);
+        expect(toolOutput).not.toContain("UNIQUECHANNELSECRET");
+
+        const debugOutput = debugErrorSpy.mock.calls.flat().join("\n");
+        expect(debugOutput).toContain("channel-marker");
+        expect(debugOutput).not.toContain(accessToken);
+        expect(debugOutput).not.toContain(encodedCredential);
+        expect(debugOutput).not.toContain(formEncodedCredential);
+        expect(debugOutput).not.toContain(secretPrefix);
+        expect(debugOutput).not.toContain(secretSuffix);
+        expect(debugOutput).not.toContain("UNIQUECHANNELSECRET");
+        expect(loopbackFetch).toHaveBeenCalledTimes(1);
+
+        const proofHeadSha = process.env.OPENCLAW_PROOF_HEAD_SHA;
+        if (proofHeadSha) {
+          if (!/^[0-9a-f]{40}$/.test(proofHeadSha)) {
+            throw new Error("OPENCLAW_PROOF_HEAD_SHA must be a full Git SHA");
+          }
+          console.info(
+            `[qqbot credential redaction proof] ${JSON.stringify({
+              exactHead: proofHeadSha,
+              transport: "loopback-http",
+              status: (result.details as { status?: number }).status,
+              path: (result.details as { path?: string }).path,
+              safeMarkerPresent:
+                toolOutput.includes("channel-marker") && debugOutput.includes("channel-marker"),
+              tokenAbsent: !toolOutput.includes(accessToken) && !debugOutput.includes(accessToken),
+              encodedAbsent:
+                !toolOutput.includes(encodedCredential) && !debugOutput.includes(encodedCredential),
+              formEncodedAbsent:
+                !toolOutput.includes(formEncodedCredential) &&
+                !debugOutput.includes(formEncodedCredential),
+              prefixAbsent:
+                !toolOutput.includes(secretPrefix) && !debugOutput.includes(secretPrefix),
+              suffixAbsent:
+                !toolOutput.includes(secretSuffix) && !debugOutput.includes(secretSuffix),
+              fragmentAbsent:
+                !toolOutput.includes("UNIQUECHANNELSECRET") &&
+                !debugOutput.includes("UNIQUECHANNELSECRET"),
+            })}`,
+          );
+        }
+      },
+    );
   });
 
   it("bounds successful response bodies without using response.text()", async () => {

--- a/extensions/qqbot/src/engine/tools/channel-api.test.ts
+++ b/extensions/qqbot/src/engine/tools/channel-api.test.ts
@@ -358,6 +358,26 @@ describe("executeChannelApi", () => {
     expect(debugOutput).not.toContain(accessToken);
     expect(debugOutput).not.toContain("UNIQUECHANNELSECRET");
     expect(release).toHaveBeenCalledTimes(1);
+
+    const proofHeadSha = process.env.OPENCLAW_PROOF_HEAD_SHA;
+    if (proofHeadSha) {
+      if (!/^[0-9a-f]{40}$/.test(proofHeadSha)) {
+        throw new Error("OPENCLAW_PROOF_HEAD_SHA must be a full Git SHA");
+      }
+      console.info(
+        `[qqbot credential redaction proof] ${JSON.stringify({
+          exactHead: proofHeadSha,
+          status: (result.details as { status?: number }).status,
+          path: (result.details as { path?: string }).path,
+          safeMarkerPresent:
+            toolOutput.includes("channel-marker") && debugOutput.includes("channel-marker"),
+          tokenAbsent: !toolOutput.includes(accessToken) && !debugOutput.includes(accessToken),
+          fragmentAbsent:
+            !toolOutput.includes("UNIQUECHANNELSECRET") &&
+            !debugOutput.includes("UNIQUECHANNELSECRET"),
+        })}`,
+      );
+    }
   });
 
   it("bounds successful response bodies without using response.text()", async () => {

--- a/extensions/qqbot/src/engine/tools/channel-api.test.ts
+++ b/extensions/qqbot/src/engine/tools/channel-api.test.ts
@@ -534,6 +534,38 @@ describe("executeChannelApi", () => {
     expect(JSON.stringify(result)).not.toContain(accessToken);
   });
 
+  it("preserves unmatched percent escapes in successful response data", async () => {
+    const accessToken = "qQ%25/UNIQUE~CHANNELSECRET+Proof";
+    const encodedCredential = lowercasePercentEscapes(encodeURIComponent(accessToken));
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(
+        JSON.stringify({
+          id: "id%2fpart",
+          marker: "keep%afcase",
+          reflected: encodedCredential,
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+      release: vi.fn(async () => {}),
+    });
+
+    const result = await executeChannelApi(
+      { method: "GET", path: "/guilds/123/channels" },
+      { accessToken },
+    );
+
+    expect(result.details).toMatchObject({
+      success: true,
+      status: 200,
+      data: { id: "id%2fpart", marker: "keep%afcase", reflected: "<redacted>" },
+    });
+    expect(JSON.stringify(result)).not.toContain(accessToken);
+    expect(JSON.stringify(result)).not.toContain(encodedCredential);
+  });
+
   it("redacts Unicode-escaped credentials from prefixed response text", async () => {
     const accessToken = "qQUnicode/UNIQUE~CHANNELSECRET+Proof";
     const unicodeEscapedCredential = accessToken

--- a/extensions/qqbot/src/engine/tools/channel-api.test.ts
+++ b/extensions/qqbot/src/engine/tools/channel-api.test.ts
@@ -476,12 +476,9 @@ describe("executeChannelApi", () => {
 
   it("redacts Unicode-escaped credentials from prefixed response text", async () => {
     const accessToken = "qQUnicode/UNIQUE~CHANNELSECRET+Proof";
-    const unicodeEscapedCredential = [...accessToken]
-      .map((character) =>
-        [...character]
-          .map((codeUnit) => `\\u${codeUnit.charCodeAt(0).toString(16).padStart(4, "0")}`)
-          .join(""),
-      )
+    const unicodeEscapedCredential = accessToken
+      .split("")
+      .map((codeUnit) => `\\u${codeUnit.charCodeAt(0).toString(16).padStart(4, "0")}`)
       .join("");
     fetchWithSsrFGuardMock.mockResolvedValueOnce({
       response: new Response(`unicode-marker ${unicodeEscapedCredential}`, {

--- a/extensions/qqbot/src/engine/tools/channel-api.test.ts
+++ b/extensions/qqbot/src/engine/tools/channel-api.test.ts
@@ -3,6 +3,10 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createStreamingResponse } from "../../../../test-support/streaming-error-response.js";
+import {
+  lowercasePercentEscapes,
+  stringifyWithSlashEscapedCredential,
+} from "../../test-support/credential-reflection.js";
 import { withLoopbackHttpServer } from "../../test-support/loopback-http.js";
 
 const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
@@ -328,6 +332,9 @@ describe("executeChannelApi", () => {
     const accessToken = `${secretPrefix}/UNIQUE~CHANNELSECRET+${secretSuffix}`;
     const encodedCredential = encodeURIComponent(accessToken);
     const formEncodedCredential = new URLSearchParams([["echo", accessToken]]).toString();
+    const lowercaseEncodedCredential = lowercasePercentEscapes(encodedCredential);
+    const lowercaseFormEncodedCredential = lowercasePercentEscapes(formEncodedCredential);
+    const slashEscapedCredential = accessToken.replaceAll("/", "\\/");
     await withLoopbackHttpServer(
       (req, res) => {
         req.resume();
@@ -340,10 +347,13 @@ describe("executeChannelApi", () => {
         ]).toString();
         res.writeHead(401, { "content-type": "application/json" });
         res.end(
-          JSON.stringify({
-            message: `channel-marker reflected credential ${reflectedCredential}; encoded ${encodeURIComponent(reflectedCredential)}; form ${reflectedFormCredential}`,
-            nested: { reflected: `Authorization: ${authorization}` },
-          }),
+          stringifyWithSlashEscapedCredential(
+            {
+              message: `channel-marker reflected credential ${reflectedCredential}; encoded ${lowercasePercentEscapes(encodeURIComponent(reflectedCredential))}; form ${lowercasePercentEscapes(reflectedFormCredential)}`,
+              nested: { reflected: `Authorization: ${authorization}` },
+            },
+            reflectedCredential,
+          ),
         );
       },
       async (baseUrl) => {
@@ -379,6 +389,9 @@ describe("executeChannelApi", () => {
         expect(toolOutput).not.toContain(accessToken);
         expect(toolOutput).not.toContain(encodedCredential);
         expect(toolOutput).not.toContain(formEncodedCredential);
+        expect(toolOutput).not.toContain(lowercaseEncodedCredential);
+        expect(toolOutput).not.toContain(lowercaseFormEncodedCredential);
+        expect(toolOutput).not.toContain(slashEscapedCredential);
         expect(toolOutput).not.toContain(secretPrefix);
         expect(toolOutput).not.toContain(secretSuffix);
         expect(toolOutput).not.toContain("UNIQUECHANNELSECRET");
@@ -388,6 +401,9 @@ describe("executeChannelApi", () => {
         expect(debugOutput).not.toContain(accessToken);
         expect(debugOutput).not.toContain(encodedCredential);
         expect(debugOutput).not.toContain(formEncodedCredential);
+        expect(debugOutput).not.toContain(lowercaseEncodedCredential);
+        expect(debugOutput).not.toContain(lowercaseFormEncodedCredential);
+        expect(debugOutput).not.toContain(slashEscapedCredential);
         expect(debugOutput).not.toContain(secretPrefix);
         expect(debugOutput).not.toContain(secretSuffix);
         expect(debugOutput).not.toContain("UNIQUECHANNELSECRET");
@@ -412,6 +428,15 @@ describe("executeChannelApi", () => {
               formEncodedAbsent:
                 !toolOutput.includes(formEncodedCredential) &&
                 !debugOutput.includes(formEncodedCredential),
+              lowercaseEncodedAbsent:
+                !toolOutput.includes(lowercaseEncodedCredential) &&
+                !debugOutput.includes(lowercaseEncodedCredential),
+              lowercaseFormEncodedAbsent:
+                !toolOutput.includes(lowercaseFormEncodedCredential) &&
+                !debugOutput.includes(lowercaseFormEncodedCredential),
+              jsonSlashEscapedAbsent:
+                !toolOutput.includes(slashEscapedCredential) &&
+                !debugOutput.includes(slashEscapedCredential),
               prefixAbsent:
                 !toolOutput.includes(secretPrefix) && !debugOutput.includes(secretPrefix),
               suffixAbsent:

--- a/extensions/qqbot/src/engine/tools/channel-api.test.ts
+++ b/extensions/qqbot/src/engine/tools/channel-api.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createStreamingResponse } from "../../../../test-support/streaming-error-response.js";
 
 const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+const originalDebug = process.env.QQBOT_DEBUG;
 
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
@@ -44,6 +45,11 @@ function cancelTrackedResponse(
 
 describe("executeChannelApi", () => {
   afterEach(() => {
+    if (originalDebug === undefined) {
+      delete process.env.QQBOT_DEBUG;
+    } else {
+      process.env.QQBOT_DEBUG = originalDebug;
+    }
     vi.useRealTimers();
     vi.restoreAllMocks();
     fetchWithSsrFGuardMock.mockReset();
@@ -304,6 +310,53 @@ describe("executeChannelApi", () => {
     expect(bodyPreview).not.toContain("tail");
     expect(tracked.wasCanceled()).toBe(true);
     expect(textSpy).not.toHaveBeenCalled();
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("redacts reflected authorization from error details and debug output", async () => {
+    process.env.QQBOT_DEBUG = "1";
+    const debugErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const release = vi.fn(async () => {});
+    const accessToken = "qqbot_AAAAUNIQUECHANNELSECRETBBBB111122223333";
+    const authorization = `QQBot ${accessToken}`;
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(
+        JSON.stringify({
+          message: `channel-marker Authorization: ${authorization}`,
+          nested: { reflected: `Authorization: ${authorization}` },
+        }),
+        {
+          status: 401,
+          statusText: "Unauthorized",
+          headers: { "content-type": "application/json" },
+        },
+      ),
+      release,
+    });
+
+    const result = await executeChannelApi(
+      { method: "GET", path: "/guilds/123/channels" },
+      { accessToken },
+    );
+
+    expect(result.details).toMatchObject({
+      error: expect.stringContaining("channel-marker"),
+      status: 401,
+      path: "/guilds/123/channels",
+      details: {
+        message: expect.stringContaining("channel-marker"),
+        nested: { reflected: expect.any(String) },
+      },
+    });
+    const toolOutput = JSON.stringify(result);
+    expect(toolOutput).toContain("channel-marker");
+    expect(toolOutput).not.toContain(accessToken);
+    expect(toolOutput).not.toContain("UNIQUECHANNELSECRET");
+
+    const debugOutput = debugErrorSpy.mock.calls.flat().join("\n");
+    expect(debugOutput).toContain("channel-marker");
+    expect(debugOutput).not.toContain(accessToken);
+    expect(debugOutput).not.toContain("UNIQUECHANNELSECRET");
     expect(release).toHaveBeenCalledTimes(1);
   });
 

--- a/extensions/qqbot/src/engine/tools/channel-api.test.ts
+++ b/extensions/qqbot/src/engine/tools/channel-api.test.ts
@@ -451,6 +451,63 @@ describe("executeChannelApi", () => {
     );
   });
 
+  it("redacts reflected credentials from successful response data", async () => {
+    const accessToken = "qQSuccess/UNIQUE~CHANNELSECRET+Proof";
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(JSON.stringify({ marker: "success-marker", reflected: accessToken }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+      release: vi.fn(async () => {}),
+    });
+
+    const result = await executeChannelApi(
+      { method: "GET", path: "/guilds/123/channels" },
+      { accessToken },
+    );
+
+    expect(result.details).toMatchObject({
+      success: true,
+      status: 200,
+      data: { marker: "success-marker", reflected: "<redacted>" },
+    });
+    expect(JSON.stringify(result)).not.toContain(accessToken);
+  });
+
+  it("redacts Unicode-escaped credentials from prefixed response text", async () => {
+    const accessToken = "qQUnicode/UNIQUE~CHANNELSECRET+Proof";
+    const unicodeEscapedCredential = [...accessToken]
+      .map((character) =>
+        [...character]
+          .map((codeUnit) => `\\u${codeUnit.charCodeAt(0).toString(16).padStart(4, "0")}`)
+          .join(""),
+      )
+      .join("");
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(`unicode-marker ${unicodeEscapedCredential}`, {
+        status: 502,
+        statusText: "Bad Gateway",
+        headers: { "content-type": "text/plain" },
+      }),
+      release: vi.fn(async () => {}),
+    });
+
+    const result = await executeChannelApi(
+      { method: "GET", path: "/guilds/123/channels" },
+      { accessToken },
+    );
+
+    expect(result.details).toMatchObject({
+      error: "502 Bad Gateway",
+      status: 502,
+      details: "unicode-marker <redacted>",
+    });
+    const toolOutput = JSON.stringify(result);
+    expect(toolOutput).toContain("unicode-marker");
+    expect(toolOutput).not.toContain(accessToken);
+    expect(toolOutput).not.toContain(unicodeEscapedCredential);
+  });
+
   it("bounds successful response bodies without using response.text()", async () => {
     const release = vi.fn(async () => {});
     const streamed = createStreamingResponse({

--- a/extensions/qqbot/src/engine/tools/channel-api.ts
+++ b/extensions/qqbot/src/engine/tools/channel-api.ts
@@ -357,11 +357,9 @@ export async function executeChannelApi(
         });
       }
 
-      // Error bodies are untrusted and become both debug output and an agent-visible
-      // tool result. Redact before parsing so every nested detail shares the boundary.
-      const presentedBody = res.ok
-        ? rawBody
-        : redactQQBotCredentialText(rawBody, options.accessToken);
+      // Provider bodies become agent-visible tool results for every status.
+      // Redact before parsing so successful reflections share the same boundary.
+      const presentedBody = redactQQBotCredentialText(rawBody, options.accessToken);
       let parsed: unknown;
       try {
         parsed = JSON.parse(presentedBody);

--- a/extensions/qqbot/src/engine/tools/channel-api.ts
+++ b/extensions/qqbot/src/engine/tools/channel-api.ts
@@ -336,8 +336,9 @@ export async function executeChannelApi(
       release = guarded.release;
       receivedResponse = true;
       const res = guarded.response;
+      const statusText = redactQQBotCredentialText(res.statusText, options.accessToken);
 
-      debugLog(`[qqbot-channel-api] <<< Status: ${res.status} ${res.statusText}`);
+      debugLog(`[qqbot-channel-api] <<< Status: ${res.status} ${statusText}`);
 
       const rawBody = res.ok
         ? await readProviderTextResponse(res, "QQ channel API response", {
@@ -351,7 +352,7 @@ export async function executeChannelApi(
           return json({ success: true, status: res.status, path: params.path });
         }
         return json({
-          error: `API returned ${res.status} ${res.statusText}`,
+          error: `API returned ${res.status} ${statusText}`,
           status: res.status,
           path: params.path,
         });
@@ -371,7 +372,7 @@ export async function executeChannelApi(
         const errMsg =
           typeof parsed === "object" && parsed && "message" in parsed
             ? String((parsed as { message?: unknown }).message)
-            : `${res.status} ${res.statusText}`;
+            : `${res.status} ${statusText}`;
         debugError(`[qqbot-channel-api] Error [${method} ${params.path}]: ${errMsg}`);
         return json({
           error: errMsg,

--- a/extensions/qqbot/src/engine/tools/channel-api.ts
+++ b/extensions/qqbot/src/engine/tools/channel-api.ts
@@ -11,6 +11,7 @@
 import { resolveChannelGroupPolicy } from "openclaw/plugin-sdk/channel-policy";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
 import {
   readProviderTextResponse,
   readResponseTextLimited,
@@ -356,11 +357,14 @@ export async function executeChannelApi(
         });
       }
 
+      // Error bodies are untrusted and become both debug output and an agent-visible
+      // tool result. Redact before parsing so every nested detail shares the boundary.
+      const presentedBody = res.ok ? rawBody : redactToolPayloadText(rawBody);
       let parsed: unknown;
       try {
-        parsed = JSON.parse(rawBody);
+        parsed = JSON.parse(presentedBody);
       } catch {
-        parsed = rawBody;
+        parsed = presentedBody;
       }
 
       if (!res.ok) {

--- a/extensions/qqbot/src/engine/tools/channel-api.ts
+++ b/extensions/qqbot/src/engine/tools/channel-api.ts
@@ -11,13 +11,13 @@
 import { resolveChannelGroupPolicy } from "openclaw/plugin-sdk/channel-policy";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import { redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
 import {
   readProviderTextResponse,
   readResponseTextLimited,
 } from "openclaw/plugin-sdk/provider-http";
 import { fetchWithSsrFGuard, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import { jsonResult as json } from "openclaw/plugin-sdk/tool-results";
+import { redactQQBotCredentialText } from "../utils/credential-redaction.js";
 import { debugLog, debugError } from "../utils/log.js";
 
 const API_BASE = "https://api.sgroup.qq.com";
@@ -359,7 +359,9 @@ export async function executeChannelApi(
 
       // Error bodies are untrusted and become both debug output and an agent-visible
       // tool result. Redact before parsing so every nested detail shares the boundary.
-      const presentedBody = res.ok ? rawBody : redactToolPayloadText(rawBody);
+      const presentedBody = res.ok
+        ? rawBody
+        : redactQQBotCredentialText(rawBody, options.accessToken);
       let parsed: unknown;
       try {
         parsed = JSON.parse(presentedBody);

--- a/extensions/qqbot/src/engine/types.ts
+++ b/extensions/qqbot/src/engine/types.ts
@@ -25,7 +25,7 @@ export class ApiError extends Error {
     public readonly path: string,
     /** Business error code from the response body (`code` or `err_code`). */
     public readonly bizCode?: number,
-    /** Original error message from the response body. */
+    /** Redacted error message extracted from the response body. */
     public readonly bizMessage?: string,
   ) {
     super(message);

--- a/extensions/qqbot/src/engine/utils/credential-redaction.ts
+++ b/extensions/qqbot/src/engine/utils/credential-redaction.ts
@@ -1,24 +1,69 @@
 import { redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
 
+const PERCENT_ESCAPE_RE = /%[0-9a-f]{2}/gi;
+const REDACTED_CREDENTIAL = "<redacted>";
+
+interface CredentialForms {
+  literal: readonly string[];
+  encoded: readonly string[];
+}
+
+function canonicalizePercentEscapes(text: string): string {
+  return text.replace(PERCENT_ESCAPE_RE, (escape) => escape.toUpperCase());
+}
+
+function resolveCredentialForms(credential: string): CredentialForms {
+  const jsonEscaped = JSON.stringify(credential).slice(1, -1);
+  const literal = new Set([credential, jsonEscaped, jsonEscaped.replaceAll("/", "\\/")]);
+  const encoded = new Set([
+    new URLSearchParams([["credential", credential]]).toString().slice("credential=".length),
+  ]);
+  try {
+    encoded.add(encodeURIComponent(credential));
+  } catch {
+    // Raw and JSON forms still cover malformed UTF-16 credentials that URI encoding rejects.
+  }
+  const longestFirst = (left: string, right: string) => right.length - left.length;
+  return {
+    literal: [...literal].filter(Boolean).toSorted(longestFirst),
+    encoded: [...encoded].filter(Boolean).map(canonicalizePercentEscapes).toSorted(longestFirst),
+  };
+}
+
+function redactCredentialForms(text: string, forms: CredentialForms): string {
+  let redacted = text;
+  for (const form of forms.literal) {
+    redacted = redacted.replaceAll(form, REDACTED_CREDENTIAL);
+  }
+  redacted = canonicalizePercentEscapes(redacted);
+  for (const form of forms.encoded) {
+    redacted = redacted.replaceAll(form, REDACTED_CREDENTIAL);
+  }
+  return redacted;
+}
+
+function redactJsonCredentialText(text: string, forms: CredentialForms): string | undefined {
+  try {
+    // Decode valid JSON before matching so alternate escapes cannot reconstruct
+    // the credential when a caller parses the presented body downstream.
+    const parsed = JSON.parse(text) as unknown;
+    const serialized = JSON.stringify(parsed, (_key, value: unknown) =>
+      typeof value === "string" ? redactCredentialForms(value, forms) : value,
+    );
+    return serialized === undefined ? undefined : redactCredentialForms(serialized, forms);
+  } catch {
+    return undefined;
+  }
+}
+
 /** Remove raw, serialized, and encoded request credentials before generic redaction. */
 export function redactQQBotCredentialText(text: string, credential: string): string {
   if (!credential) {
     return redactToolPayloadText(text);
   }
 
-  const credentialForms = new Set([credential, JSON.stringify(credential).slice(1, -1)]);
-  credentialForms.add(
-    new URLSearchParams([["credential", credential]]).toString().slice("credential=".length),
-  );
-  try {
-    credentialForms.add(encodeURIComponent(credential));
-  } catch {
-    // Raw and JSON forms still cover malformed UTF-16 credentials that URI encoding rejects.
-  }
-
-  let withoutExactCredential = text;
-  for (const form of [...credentialForms].filter(Boolean).toSorted((a, b) => b.length - a.length)) {
-    withoutExactCredential = withoutExactCredential.replaceAll(form, "<redacted>");
-  }
+  const credentialForms = resolveCredentialForms(credential);
+  const withoutExactCredential =
+    redactJsonCredentialText(text, credentialForms) ?? redactCredentialForms(text, credentialForms);
   return redactToolPayloadText(withoutExactCredential);
 }

--- a/extensions/qqbot/src/engine/utils/credential-redaction.ts
+++ b/extensions/qqbot/src/engine/utils/credential-redaction.ts
@@ -7,6 +7,13 @@ const REDACTED_CREDENTIAL = "<redacted>";
 interface CredentialForms {
   literal: readonly string[];
   encoded: readonly string[];
+  mixedPercent: readonly (readonly CredentialUnit[])[];
+}
+
+interface CredentialUnit {
+  literal: string;
+  percentEncoded: string;
+  formEncoded?: string;
 }
 
 function canonicalizePercentEscapes(text: string): string {
@@ -20,6 +27,61 @@ function percentEncodeEveryUtf8Byte(text: string): string {
     new TextEncoder().encode(text),
     (byte) => `%${byte.toString(16).padStart(2, "0")}`,
   ).join("");
+}
+
+function resolveCredentialUnits(text: string): readonly CredentialUnit[] {
+  return Array.from(text, (literal) => ({
+    literal,
+    percentEncoded: canonicalizePercentEscapes(percentEncodeEveryUtf8Byte(literal)),
+    ...(literal === " " ? { formEncoded: "+" } : {}),
+  }));
+}
+
+function matchCredentialUnits(
+  text: string,
+  start: number,
+  units: readonly CredentialUnit[],
+): number | undefined {
+  let offset = start;
+  for (const unit of units) {
+    if (text.startsWith(unit.literal, offset)) {
+      offset += unit.literal.length;
+      continue;
+    }
+    const percentCandidate = text.slice(offset, offset + unit.percentEncoded.length);
+    if (canonicalizePercentEscapes(percentCandidate) === unit.percentEncoded) {
+      offset += unit.percentEncoded.length;
+      continue;
+    }
+    if (unit.formEncoded && text.startsWith(unit.formEncoded, offset)) {
+      offset += unit.formEncoded.length;
+      continue;
+    }
+    return undefined;
+  }
+  return offset;
+}
+
+function redactMixedPercentCredentialForms(
+  text: string,
+  forms: readonly (readonly CredentialUnit[])[],
+): string {
+  let redacted = "";
+  let copiedThrough = 0;
+  let offset = 0;
+  while (offset < text.length) {
+    const matchEnd = forms
+      .map((form) => matchCredentialUnits(text, offset, form))
+      .find((end): end is number => end !== undefined);
+    if (matchEnd === undefined) {
+      offset += 1;
+      continue;
+    }
+    redacted += `${text.slice(copiedThrough, offset)}${REDACTED_CREDENTIAL}`;
+    copiedThrough = matchEnd;
+    offset = matchEnd;
+  }
+  return copiedThrough === 0 ? text : redacted + text.slice(copiedThrough);
 }
 
 function resolveCredentialForms(credentials: readonly string[]): CredentialForms {
@@ -47,6 +109,7 @@ function resolveCredentialForms(credentials: readonly string[]): CredentialForms
   return {
     literal: [...literal].filter(Boolean).toSorted(longestFirst),
     encoded: [...encoded].filter(Boolean).map(canonicalizePercentEscapes).toSorted(longestFirst),
+    mixedPercent: [...literal].filter(Boolean).toSorted(longestFirst).map(resolveCredentialUnits),
   };
 }
 
@@ -55,6 +118,7 @@ function redactDirectCredentialForms(text: string, forms: CredentialForms): stri
   for (const form of forms.literal) {
     redacted = redacted.replaceAll(form, REDACTED_CREDENTIAL);
   }
+  redacted = redactMixedPercentCredentialForms(redacted, forms.mixedPercent);
   redacted = canonicalizePercentEscapes(redacted);
   for (const form of forms.encoded) {
     redacted = redacted.replaceAll(form, REDACTED_CREDENTIAL);

--- a/extensions/qqbot/src/engine/utils/credential-redaction.ts
+++ b/extensions/qqbot/src/engine/utils/credential-redaction.ts
@@ -12,16 +12,25 @@ function canonicalizePercentEscapes(text: string): string {
   return text.replace(PERCENT_ESCAPE_RE, (escape) => escape.toUpperCase());
 }
 
-function resolveCredentialForms(credential: string): CredentialForms {
-  const jsonEscaped = JSON.stringify(credential).slice(1, -1);
-  const literal = new Set([credential, jsonEscaped, jsonEscaped.replaceAll("/", "\\/")]);
-  const encoded = new Set([
-    new URLSearchParams([["credential", credential]]).toString().slice("credential=".length),
-  ]);
-  try {
-    encoded.add(encodeURIComponent(credential));
-  } catch {
-    // Raw and JSON forms still cover malformed UTF-16 credentials that URI encoding rejects.
+function resolveCredentialForms(credentials: readonly string[]): CredentialForms {
+  const literal = new Set<string>();
+  const encoded = new Set<string>();
+  for (const credential of credentials) {
+    if (!credential) {
+      continue;
+    }
+    const jsonEscaped = JSON.stringify(credential).slice(1, -1);
+    literal.add(credential);
+    literal.add(jsonEscaped);
+    literal.add(jsonEscaped.replaceAll("/", "\\/"));
+    encoded.add(
+      new URLSearchParams([["credential", credential]]).toString().slice("credential=".length),
+    );
+    try {
+      encoded.add(encodeURIComponent(credential));
+    } catch {
+      // Raw and JSON forms still cover malformed UTF-16 credentials that URI encoding rejects.
+    }
   }
   const longestFirst = (left: string, right: string) => right.length - left.length;
   return {
@@ -56,13 +65,13 @@ function redactJsonCredentialText(text: string, forms: CredentialForms): string 
   }
 }
 
-/** Remove raw, serialized, and encoded request credentials before generic redaction. */
-export function redactQQBotCredentialText(text: string, credential: string): string {
-  if (!credential) {
+/** Remove raw, serialized, and encoded credentials before generic redaction. */
+export function redactQQBotCredentialText(text: string, ...credentials: readonly string[]): string {
+  const credentialForms = resolveCredentialForms(credentials);
+  if (credentialForms.literal.length === 0 && credentialForms.encoded.length === 0) {
     return redactToolPayloadText(text);
   }
 
-  const credentialForms = resolveCredentialForms(credential);
   const withoutExactCredential =
     redactJsonCredentialText(text, credentialForms) ?? redactCredentialForms(text, credentialForms);
   return redactToolPayloadText(withoutExactCredential);

--- a/extensions/qqbot/src/engine/utils/credential-redaction.ts
+++ b/extensions/qqbot/src/engine/utils/credential-redaction.ts
@@ -6,7 +6,6 @@ const REDACTED_CREDENTIAL = "<redacted>";
 
 interface CredentialForms {
   literal: readonly string[];
-  encoded: readonly string[];
   mixedPercent: readonly (readonly CredentialUnit[])[];
 }
 
@@ -42,24 +41,29 @@ function matchCredentialUnits(
   start: number,
   units: readonly CredentialUnit[],
 ): number | undefined {
-  let offset = start;
+  let offsets = new Set([start]);
   for (const unit of units) {
-    if (text.startsWith(unit.literal, offset)) {
-      offset += unit.literal.length;
-      continue;
+    const nextOffsets = new Set<number>();
+    for (const offset of offsets) {
+      if (text.startsWith(unit.literal, offset)) {
+        nextOffsets.add(offset + unit.literal.length);
+      }
+      const percentCandidate = text.slice(offset, offset + unit.percentEncoded.length);
+      if (canonicalizePercentEscapes(percentCandidate) === unit.percentEncoded) {
+        nextOffsets.add(offset + unit.percentEncoded.length);
+      }
+      if (unit.formEncoded && text.startsWith(unit.formEncoded, offset)) {
+        nextOffsets.add(offset + unit.formEncoded.length);
+      }
     }
-    const percentCandidate = text.slice(offset, offset + unit.percentEncoded.length);
-    if (canonicalizePercentEscapes(percentCandidate) === unit.percentEncoded) {
-      offset += unit.percentEncoded.length;
-      continue;
+    if (nextOffsets.size === 0) {
+      return undefined;
     }
-    if (unit.formEncoded && text.startsWith(unit.formEncoded, offset)) {
-      offset += unit.formEncoded.length;
-      continue;
-    }
-    return undefined;
+    // A literal "%" and its encoded form share a prefix. Keep both positions
+    // so partially encoded credentials cannot escape the exact-secret boundary.
+    offsets = nextOffsets;
   }
-  return offset;
+  return Math.max(...offsets);
 }
 
 function redactMixedPercentCredentialForms(
@@ -86,7 +90,6 @@ function redactMixedPercentCredentialForms(
 
 function resolveCredentialForms(credentials: readonly string[]): CredentialForms {
   const literal = new Set<string>();
-  const encoded = new Set<string>();
   for (const credential of credentials) {
     if (!credential) {
       continue;
@@ -95,20 +98,10 @@ function resolveCredentialForms(credentials: readonly string[]): CredentialForms
     literal.add(credential);
     literal.add(jsonEscaped);
     literal.add(jsonEscaped.replaceAll("/", "\\/"));
-    encoded.add(
-      new URLSearchParams([["credential", credential]]).toString().slice("credential=".length),
-    );
-    encoded.add(percentEncodeEveryUtf8Byte(credential));
-    try {
-      encoded.add(encodeURIComponent(credential));
-    } catch {
-      // Raw and JSON forms still cover malformed UTF-16 credentials that URI encoding rejects.
-    }
   }
   const longestFirst = (left: string, right: string) => right.length - left.length;
   return {
     literal: [...literal].filter(Boolean).toSorted(longestFirst),
-    encoded: [...encoded].filter(Boolean).map(canonicalizePercentEscapes).toSorted(longestFirst),
     mixedPercent: [...literal].filter(Boolean).toSorted(longestFirst).map(resolveCredentialUnits),
   };
 }
@@ -118,12 +111,7 @@ function redactDirectCredentialForms(text: string, forms: CredentialForms): stri
   for (const form of forms.literal) {
     redacted = redacted.replaceAll(form, REDACTED_CREDENTIAL);
   }
-  redacted = redactMixedPercentCredentialForms(redacted, forms.mixedPercent);
-  redacted = canonicalizePercentEscapes(redacted);
-  for (const form of forms.encoded) {
-    redacted = redacted.replaceAll(form, REDACTED_CREDENTIAL);
-  }
-  return redacted;
+  return redactMixedPercentCredentialForms(redacted, forms.mixedPercent);
 }
 
 function redactCredentialForms(text: string, forms: CredentialForms): string {
@@ -161,7 +149,7 @@ function redactJsonCredentialText(text: string, forms: CredentialForms): string 
 /** Remove raw, serialized, and encoded credentials before generic redaction. */
 export function redactQQBotCredentialText(text: string, ...credentials: readonly string[]): string {
   const credentialForms = resolveCredentialForms(credentials);
-  if (credentialForms.literal.length === 0 && credentialForms.encoded.length === 0) {
+  if (credentialForms.literal.length === 0) {
     return redactToolPayloadText(text);
   }
 

--- a/extensions/qqbot/src/engine/utils/credential-redaction.ts
+++ b/extensions/qqbot/src/engine/utils/credential-redaction.ts
@@ -1,6 +1,7 @@
 import { redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
 
 const PERCENT_ESCAPE_RE = /%[0-9a-f]{2}/gi;
+const UNICODE_ESCAPE_RE = /\\+u([0-9a-f]{4})/gi;
 const REDACTED_CREDENTIAL = "<redacted>";
 
 interface CredentialForms {
@@ -39,7 +40,7 @@ function resolveCredentialForms(credentials: readonly string[]): CredentialForms
   };
 }
 
-function redactCredentialForms(text: string, forms: CredentialForms): string {
+function redactDirectCredentialForms(text: string, forms: CredentialForms): string {
   let redacted = text;
   for (const form of forms.literal) {
     redacted = redacted.replaceAll(form, REDACTED_CREDENTIAL);
@@ -49,6 +50,24 @@ function redactCredentialForms(text: string, forms: CredentialForms): string {
     redacted = redacted.replaceAll(form, REDACTED_CREDENTIAL);
   }
   return redacted;
+}
+
+function redactCredentialForms(text: string, forms: CredentialForms): string {
+  const directlyRedacted = redactDirectCredentialForms(text, forms);
+  const unicodeCanonicalized = directlyRedacted.replace(
+    UNICODE_ESCAPE_RE,
+    (_escape, codeUnit: string) => String.fromCharCode(Number.parseInt(codeUnit, 16)),
+  );
+  if (unicodeCanonicalized === directlyRedacted) {
+    return directlyRedacted;
+  }
+
+  const canonicalizedRedaction = redactDirectCredentialForms(unicodeCanonicalized, forms);
+  // Preserve unrelated escaped diagnostic text unless decoding it reveals a
+  // request credential that must be removed before parsing or presentation.
+  return canonicalizedRedaction === unicodeCanonicalized
+    ? directlyRedacted
+    : canonicalizedRedaction;
 }
 
 function redactJsonCredentialText(text: string, forms: CredentialForms): string | undefined {

--- a/extensions/qqbot/src/engine/utils/credential-redaction.ts
+++ b/extensions/qqbot/src/engine/utils/credential-redaction.ts
@@ -137,23 +137,39 @@ function redactJsonCredentialText(text: string, forms: CredentialForms): string 
     // Decode valid JSON before matching so alternate escapes cannot reconstruct
     // the credential when a caller parses the presented body downstream.
     const parsed = JSON.parse(text) as unknown;
-    const serialized = JSON.stringify(parsed, (_key, value: unknown) =>
-      typeof value === "string" ? redactCredentialForms(value, forms) : value,
-    );
-    return serialized === undefined ? undefined : redactCredentialForms(serialized, forms);
+    let changed = false;
+    const serialized = JSON.stringify(parsed, (_key, value: unknown) => {
+      if (typeof value !== "string") {
+        return value;
+      }
+      const redacted = redactCredentialForms(value, forms);
+      changed ||= redacted !== value;
+      return redacted;
+    });
+    return changed && serialized !== undefined
+      ? redactCredentialForms(serialized, forms)
+      : undefined;
   } catch {
     return undefined;
   }
 }
 
-/** Remove raw, serialized, and encoded credentials before generic redaction. */
-export function redactQQBotCredentialText(text: string, ...credentials: readonly string[]): string {
+/** Remove only request-scoped raw, serialized, and encoded credential forms. */
+export function redactQQBotExactCredentialText(
+  text: string,
+  ...credentials: readonly string[]
+): string {
   const credentialForms = resolveCredentialForms(credentials);
   if (credentialForms.literal.length === 0) {
-    return redactToolPayloadText(text);
+    return text;
   }
 
-  const withoutExactCredential =
-    redactJsonCredentialText(text, credentialForms) ?? redactCredentialForms(text, credentialForms);
-  return redactToolPayloadText(withoutExactCredential);
+  return (
+    redactJsonCredentialText(text, credentialForms) ?? redactCredentialForms(text, credentialForms)
+  );
+}
+
+/** Remove request credentials before applying generic presentation redaction. */
+export function redactQQBotCredentialText(text: string, ...credentials: readonly string[]): string {
+  return redactToolPayloadText(redactQQBotExactCredentialText(text, ...credentials));
 }

--- a/extensions/qqbot/src/engine/utils/credential-redaction.ts
+++ b/extensions/qqbot/src/engine/utils/credential-redaction.ts
@@ -13,6 +13,15 @@ function canonicalizePercentEscapes(text: string): string {
   return text.replace(PERCENT_ESCAPE_RE, (escape) => escape.toUpperCase());
 }
 
+function percentEncodeEveryUtf8Byte(text: string): string {
+  // encodeURIComponent leaves unreserved characters literal, but providers
+  // can reflect credentials with every UTF-8 byte percent-encoded.
+  return Array.from(
+    new TextEncoder().encode(text),
+    (byte) => `%${byte.toString(16).padStart(2, "0")}`,
+  ).join("");
+}
+
 function resolveCredentialForms(credentials: readonly string[]): CredentialForms {
   const literal = new Set<string>();
   const encoded = new Set<string>();
@@ -27,6 +36,7 @@ function resolveCredentialForms(credentials: readonly string[]): CredentialForms
     encoded.add(
       new URLSearchParams([["credential", credential]]).toString().slice("credential=".length),
     );
+    encoded.add(percentEncodeEveryUtf8Byte(credential));
     try {
       encoded.add(encodeURIComponent(credential));
     } catch {

--- a/extensions/qqbot/src/engine/utils/credential-redaction.ts
+++ b/extensions/qqbot/src/engine/utils/credential-redaction.ts
@@ -1,0 +1,24 @@
+import { redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
+
+/** Remove raw, serialized, and encoded request credentials before generic redaction. */
+export function redactQQBotCredentialText(text: string, credential: string): string {
+  if (!credential) {
+    return redactToolPayloadText(text);
+  }
+
+  const credentialForms = new Set([credential, JSON.stringify(credential).slice(1, -1)]);
+  credentialForms.add(
+    new URLSearchParams([["credential", credential]]).toString().slice("credential=".length),
+  );
+  try {
+    credentialForms.add(encodeURIComponent(credential));
+  } catch {
+    // Raw and JSON forms still cover malformed UTF-16 credentials that URI encoding rejects.
+  }
+
+  let withoutExactCredential = text;
+  for (const form of [...credentialForms].filter(Boolean).toSorted((a, b) => b.length - a.length)) {
+    withoutExactCredential = withoutExactCredential.replaceAll(form, "<redacted>");
+  }
+  return redactToolPayloadText(withoutExactCredential);
+}

--- a/extensions/qqbot/src/engine/utils/stt.test.ts
+++ b/extensions/qqbot/src/engine/utils/stt.test.ts
@@ -305,4 +305,62 @@ describe("engine/utils/stt", () => {
       expect(release).toHaveBeenCalledTimes(1);
     });
   });
+
+  it("redacts a reflected Bearer credential before exposing an STT error", async () => {
+    await withTempDir("openclaw-qqbot-stt-redaction-", async (tmpDir) => {
+      const audioPath = path.join(tmpDir, "voice.wav");
+      fs.writeFileSync(audioPath, Buffer.from([1, 2, 3, 4]));
+
+      const apiKey = "stt-reflected-secret-1234567890";
+      const release = vi.fn(async () => {});
+      ssrfRuntimeMocks.fetchWithSsrFGuard.mockResolvedValueOnce({
+        response: new Response(
+          `upstream rejected Authorization: Bearer ${apiKey}; request_id=stt-visible-123`,
+          { status: 401 },
+        ),
+        release,
+      });
+
+      let error: unknown;
+      try {
+        await transcribeAudio(audioPath, {
+          channels: {
+            qqbot: {
+              stt: {
+                baseUrl: "https://api.example.test/v1/",
+                apiKey,
+                model: "whisper-1",
+              },
+            },
+          },
+        });
+      } catch (caught) {
+        error = caught;
+      }
+
+      const message = (error as Error).message;
+      expect(message).toContain("STT failed (HTTP 401):");
+      expect(message).toContain("Authorization: Bearer");
+      expect(message).toContain("request_id=stt-visible-123");
+      expect(message).not.toContain(apiKey);
+      expect(message).not.toContain("reflected-secret");
+      expect(release).toHaveBeenCalledTimes(1);
+
+      const proofHeadSha = process.env.OPENCLAW_PROOF_HEAD_SHA;
+      if (proofHeadSha) {
+        if (!/^[0-9a-f]{40}$/.test(proofHeadSha)) {
+          throw new Error("OPENCLAW_PROOF_HEAD_SHA must be a full Git SHA");
+        }
+        console.info(
+          `[qqbot stt credential redaction proof] ${JSON.stringify({
+            exactHead: proofHeadSha,
+            status: 401,
+            safeMarkerPresent: message.includes("stt-visible-123"),
+            tokenAbsent: !message.includes(apiKey),
+            fragmentAbsent: !message.includes("reflected-secret"),
+          })}`,
+        );
+      }
+    });
+  });
 });

--- a/extensions/qqbot/src/engine/utils/stt.test.ts
+++ b/extensions/qqbot/src/engine/utils/stt.test.ts
@@ -4,6 +4,10 @@ import * as path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { withTempDir } from "openclaw/plugin-sdk/test-env";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  lowercasePercentEscapes,
+  stringifyWithSlashEscapedCredential,
+} from "../../test-support/credential-reflection.js";
 import { withLoopbackHttpServer } from "../../test-support/loopback-http.js";
 
 const ssrfRuntimeMocks = vi.hoisted(() => ({
@@ -327,6 +331,9 @@ describe("engine/utils/stt", () => {
       const apiKey = `${secretPrefix}/reflected~secret+${secretSuffix}`;
       const encodedCredential = encodeURIComponent(apiKey);
       const formEncodedCredential = new URLSearchParams([["echo", apiKey]]).toString();
+      const lowercaseEncodedCredential = lowercasePercentEscapes(encodedCredential);
+      const lowercaseFormEncodedCredential = lowercasePercentEscapes(formEncodedCredential);
+      const slashEscapedCredential = apiKey.replaceAll("/", "\\/");
       await withLoopbackHttpServer(
         (req, res) => {
           req.resume();
@@ -337,9 +344,15 @@ describe("engine/utils/stt", () => {
           const reflectedFormCredential = new URLSearchParams([
             ["echo", reflectedCredential],
           ]).toString();
-          res.writeHead(401, { "content-type": "text/plain" });
+          res.writeHead(401, { "content-type": "application/json" });
           res.end(
-            `upstream reflected credential ${reflectedCredential}; encoded ${encodeURIComponent(reflectedCredential)}; form ${reflectedFormCredential}; Authorization: ${authorization}; request_id=stt-visible-123`,
+            stringifyWithSlashEscapedCredential(
+              {
+                message: `upstream reflected credential ${reflectedCredential}; encoded ${lowercasePercentEscapes(encodeURIComponent(reflectedCredential))}; form ${lowercasePercentEscapes(reflectedFormCredential)}; Authorization: ${authorization}`,
+                request_id: "stt-visible-123",
+              },
+              reflectedCredential,
+            ),
           );
         },
         async (baseUrl) => {
@@ -375,10 +388,13 @@ describe("engine/utils/stt", () => {
           const message = (error as Error).message;
           expect(message).toContain("STT failed (HTTP 401):");
           expect(message).toContain("Authorization: Bearer");
-          expect(message).toContain("request_id=stt-visible-123");
+          expect(message).toContain("stt-visible-123");
           expect(message).not.toContain(apiKey);
           expect(message).not.toContain(encodedCredential);
           expect(message).not.toContain(formEncodedCredential);
+          expect(message).not.toContain(lowercaseEncodedCredential);
+          expect(message).not.toContain(lowercaseFormEncodedCredential);
+          expect(message).not.toContain(slashEscapedCredential);
           expect(message).not.toContain(secretPrefix);
           expect(message).not.toContain(secretSuffix);
           expect(message).not.toContain("reflected-secret");
@@ -397,6 +413,9 @@ describe("engine/utils/stt", () => {
                 tokenAbsent: !message.includes(apiKey),
                 encodedAbsent: !message.includes(encodedCredential),
                 formEncodedAbsent: !message.includes(formEncodedCredential),
+                lowercaseEncodedAbsent: !message.includes(lowercaseEncodedCredential),
+                lowercaseFormEncodedAbsent: !message.includes(lowercaseFormEncodedCredential),
+                jsonSlashEscapedAbsent: !message.includes(slashEscapedCredential),
                 prefixAbsent: !message.includes(secretPrefix),
                 suffixAbsent: !message.includes(secretSuffix),
                 fragmentAbsent: !message.includes("reflected-secret"),

--- a/extensions/qqbot/src/engine/utils/stt.test.ts
+++ b/extensions/qqbot/src/engine/utils/stt.test.ts
@@ -4,14 +4,25 @@ import * as path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { withTempDir } from "openclaw/plugin-sdk/test-env";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { withLoopbackHttpServer } from "../../test-support/loopback-http.js";
 
 const ssrfRuntimeMocks = vi.hoisted(() => ({
   fetchWithSsrFGuard: vi.fn(),
 }));
-
-vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
-  fetchWithSsrFGuard: ssrfRuntimeMocks.fetchWithSsrFGuard,
+const ssrfRuntimeActual = vi.hoisted(() => ({
+  fetchWithSsrFGuard: undefined as
+    | typeof import("openclaw/plugin-sdk/ssrf-runtime").fetchWithSsrFGuard
+    | undefined,
 }));
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
+  ssrfRuntimeActual.fetchWithSsrFGuard = actual.fetchWithSsrFGuard;
+  return {
+    ...actual,
+    fetchWithSsrFGuard: ssrfRuntimeMocks.fetchWithSsrFGuard,
+  };
+});
 
 afterAll(() => {
   vi.doUnmock("openclaw/plugin-sdk/ssrf-runtime");
@@ -311,56 +322,89 @@ describe("engine/utils/stt", () => {
       const audioPath = path.join(tmpDir, "voice.wav");
       fs.writeFileSync(audioPath, Buffer.from([1, 2, 3, 4]));
 
-      const apiKey = "stt-reflected-secret-1234567890";
-      const release = vi.fn(async () => {});
-      ssrfRuntimeMocks.fetchWithSsrFGuard.mockResolvedValueOnce({
-        response: new Response(
-          `upstream rejected Authorization: Bearer ${apiKey}; request_id=stt-visible-123`,
-          { status: 401 },
-        ),
-        release,
-      });
+      const secretPrefix = "qQSttP";
+      const secretSuffix = "sSfQ";
+      const apiKey = `${secretPrefix}/reflected~secret+${secretSuffix}`;
+      const encodedCredential = encodeURIComponent(apiKey);
+      const formEncodedCredential = new URLSearchParams([["echo", apiKey]]).toString();
+      await withLoopbackHttpServer(
+        (req, res) => {
+          req.resume();
+          const authorization = req.headers.authorization ?? "";
+          const reflectedCredential = authorization.startsWith("Bearer ")
+            ? authorization.slice("Bearer ".length)
+            : authorization;
+          const reflectedFormCredential = new URLSearchParams([
+            ["echo", reflectedCredential],
+          ]).toString();
+          res.writeHead(401, { "content-type": "text/plain" });
+          res.end(
+            `upstream reflected credential ${reflectedCredential}; encoded ${encodeURIComponent(reflectedCredential)}; form ${reflectedFormCredential}; Authorization: ${authorization}; request_id=stt-visible-123`,
+          );
+        },
+        async (baseUrl) => {
+          const actualGuard = ssrfRuntimeActual.fetchWithSsrFGuard;
+          if (!actualGuard) {
+            throw new Error("expected the real SSRF guard implementation");
+          }
+          ssrfRuntimeMocks.fetchWithSsrFGuard.mockImplementationOnce(
+            async (request: Parameters<typeof actualGuard>[0]) =>
+              await actualGuard({
+                ...request,
+                policy: { ...request.policy, allowedHostnames: ["127.0.0.1"] },
+              }),
+          );
 
-      let error: unknown;
-      try {
-        await transcribeAudio(audioPath, {
-          channels: {
-            qqbot: {
-              stt: {
-                baseUrl: "https://api.example.test/v1/",
-                apiKey,
-                model: "whisper-1",
+          let error: unknown;
+          try {
+            await transcribeAudio(audioPath, {
+              channels: {
+                qqbot: {
+                  stt: {
+                    baseUrl,
+                    apiKey,
+                    model: "whisper-1",
+                  },
+                },
               },
-            },
-          },
-        });
-      } catch (caught) {
-        error = caught;
-      }
+            });
+          } catch (caught) {
+            error = caught;
+          }
 
-      const message = (error as Error).message;
-      expect(message).toContain("STT failed (HTTP 401):");
-      expect(message).toContain("Authorization: Bearer");
-      expect(message).toContain("request_id=stt-visible-123");
-      expect(message).not.toContain(apiKey);
-      expect(message).not.toContain("reflected-secret");
-      expect(release).toHaveBeenCalledTimes(1);
+          const message = (error as Error).message;
+          expect(message).toContain("STT failed (HTTP 401):");
+          expect(message).toContain("Authorization: Bearer");
+          expect(message).toContain("request_id=stt-visible-123");
+          expect(message).not.toContain(apiKey);
+          expect(message).not.toContain(encodedCredential);
+          expect(message).not.toContain(formEncodedCredential);
+          expect(message).not.toContain(secretPrefix);
+          expect(message).not.toContain(secretSuffix);
+          expect(message).not.toContain("reflected-secret");
 
-      const proofHeadSha = process.env.OPENCLAW_PROOF_HEAD_SHA;
-      if (proofHeadSha) {
-        if (!/^[0-9a-f]{40}$/.test(proofHeadSha)) {
-          throw new Error("OPENCLAW_PROOF_HEAD_SHA must be a full Git SHA");
-        }
-        console.info(
-          `[qqbot stt credential redaction proof] ${JSON.stringify({
-            exactHead: proofHeadSha,
-            status: 401,
-            safeMarkerPresent: message.includes("stt-visible-123"),
-            tokenAbsent: !message.includes(apiKey),
-            fragmentAbsent: !message.includes("reflected-secret"),
-          })}`,
-        );
-      }
+          const proofHeadSha = process.env.OPENCLAW_PROOF_HEAD_SHA;
+          if (proofHeadSha) {
+            if (!/^[0-9a-f]{40}$/.test(proofHeadSha)) {
+              throw new Error("OPENCLAW_PROOF_HEAD_SHA must be a full Git SHA");
+            }
+            console.info(
+              `[qqbot stt credential redaction proof] ${JSON.stringify({
+                exactHead: proofHeadSha,
+                transport: "loopback-http",
+                status: 401,
+                safeMarkerPresent: message.includes("stt-visible-123"),
+                tokenAbsent: !message.includes(apiKey),
+                encodedAbsent: !message.includes(encodedCredential),
+                formEncodedAbsent: !message.includes(formEncodedCredential),
+                prefixAbsent: !message.includes(secretPrefix),
+                suffixAbsent: !message.includes(secretSuffix),
+                fragmentAbsent: !message.includes("reflected-secret"),
+              })}`,
+            );
+          }
+        },
+      );
     });
   });
 });

--- a/extensions/qqbot/src/engine/utils/stt.ts
+++ b/extensions/qqbot/src/engine/utils/stt.ts
@@ -7,7 +7,6 @@
 
 import * as fs from "node:fs";
 import path from "node:path";
-import { redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
 import { mimeTypeFromFilePath } from "openclaw/plugin-sdk/media-mime";
 import { finiteSecondsToTimerSafeMilliseconds } from "openclaw/plugin-sdk/number-runtime";
 import {
@@ -16,6 +15,7 @@ import {
 } from "openclaw/plugin-sdk/provider-http";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import { redactQQBotCredentialText } from "./credential-redaction.js";
 import {
   normalizeOptionalString,
   asOptionalObjectRecord as asRecord,
@@ -133,7 +133,7 @@ export async function transcribeAudio(
         () => "",
       );
       throw new Error(
-        `STT failed (HTTP ${resp.status}): ${truncateUtf16Safe(redactToolPayloadText(detail), 300)}`,
+        `STT failed (HTTP ${resp.status}): ${truncateUtf16Safe(redactQQBotCredentialText(detail, sttCfg.apiKey), 300)}`,
       );
     }
 

--- a/extensions/qqbot/src/engine/utils/stt.ts
+++ b/extensions/qqbot/src/engine/utils/stt.ts
@@ -7,6 +7,7 @@
 
 import * as fs from "node:fs";
 import path from "node:path";
+import { redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
 import { mimeTypeFromFilePath } from "openclaw/plugin-sdk/media-mime";
 import { finiteSecondsToTimerSafeMilliseconds } from "openclaw/plugin-sdk/number-runtime";
 import {
@@ -131,7 +132,9 @@ export async function transcribeAudio(
       const detail = await readResponseTextLimited(resp, STT_ERROR_BODY_LIMIT_BYTES).catch(
         () => "",
       );
-      throw new Error(`STT failed (HTTP ${resp.status}): ${truncateUtf16Safe(detail, 300)}`);
+      throw new Error(
+        `STT failed (HTTP ${resp.status}): ${truncateUtf16Safe(redactToolPayloadText(detail), 300)}`,
+      );
     }
 
     const result = await readProviderJsonResponse<{ text?: string }>(resp, "qqbot.stt");

--- a/extensions/qqbot/src/test-support/credential-reflection.ts
+++ b/extensions/qqbot/src/test-support/credential-reflection.ts
@@ -1,0 +1,13 @@
+const PERCENT_ESCAPE_RE = /%[0-9A-F]{2}/g;
+
+export function lowercasePercentEscapes(value: string): string {
+  return value.replace(PERCENT_ESCAPE_RE, (escape) => escape.toLowerCase());
+}
+
+export function stringifyWithSlashEscapedCredential(value: unknown, credential: string): string {
+  const serialized = JSON.stringify(value);
+  if (serialized === undefined) {
+    throw new Error("expected a JSON-serializable credential reflection fixture");
+  }
+  return serialized.replaceAll(credential, credential.replaceAll("/", "\\/"));
+}

--- a/extensions/qqbot/src/test-support/credential-reflection.ts
+++ b/extensions/qqbot/src/test-support/credential-reflection.ts
@@ -4,6 +4,13 @@ export function lowercasePercentEscapes(value: string): string {
   return value.replace(PERCENT_ESCAPE_RE, (escape) => escape.toLowerCase());
 }
 
+export function percentEncodeEveryUtf8Byte(value: string): string {
+  return Array.from(
+    new TextEncoder().encode(value),
+    (byte) => `%${byte.toString(16).padStart(2, "0").toUpperCase()}`,
+  ).join("");
+}
+
 export function stringifyWithSlashEscapedCredential(value: unknown, credential: string): string {
   const serialized = JSON.stringify(value);
   if (serialized === undefined) {

--- a/extensions/qqbot/src/test-support/loopback-http.ts
+++ b/extensions/qqbot/src/test-support/loopback-http.ts
@@ -1,0 +1,25 @@
+import { createServer, type RequestListener } from "node:http";
+import type { AddressInfo } from "node:net";
+
+export async function withLoopbackHttpServer<T>(
+  listener: RequestListener,
+  run: (baseUrl: string) => Promise<T>,
+): Promise<T> {
+  const server = createServer(listener);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  const address = server.address() as AddressInfo;
+  try {
+    return await run(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

AI-assisted: This change was implemented and validated with Codex.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Authenticated QQBot services can reflect the exact in-flight credential in an HTTP error body. The gateway also sends the active access token in IDENTIFY/RESUME, so a server-controlled WebSocket close reason can reflect that token into logs. The generic SDK redactor is intentionally pattern-based and preserves hints for long values, so using it alone could leave credential prefixes or suffixes in diagnostics, thrown errors, model-visible tool results, or gateway close diagnostics.

## Why This Change Was Made

One QQBot-owned presentation helper now removes the current request credential in raw, JSON string-content, URL-percent-encoded, and form-encoded forms before applying generic SDK redaction. Valid JSON is decoded before matching so alternate escapes such as `\/` cannot reconstruct the credential when a caller parses the presented body, and percent escapes are matched independently of hexadecimal letter case. The shared helper is used at all active owner boundaries:

- shared `ApiClient` response diagnostics and errors;
- direct `qqbot_channel_api` debug output and model-visible results;
- STT non-OK responses before UTF-16-safe truncation;
- TokenManager response diagnostics and missing-token errors.
- gateway URL, DISPATCH payload, and close-reason diagnostics after the active token has been sent in IDENTIFY/RESUME.

This keeps exact-secret policy request-scoped and avoids global secret registration. No config, persistence, Plugin SDK, or successful-response contract changes are introduced.

## User Impact

QQBot API, channel-tool, token-acquisition, STT, and gateway connection, dispatch, and close failures retain actionable status, business code, path, close code, and harmless markers without exposing the reflected full credential, prefix, suffix, or encoded forms.

## Evidence

### Exact-head actual WebSocket and durable lifecycle proof (2026-08-11)

- Successful immutable Node 24 run: https://github.com/Alix-007/openclaw/actions/runs/31409353639
- Exact PR head: `2034cb7631725d959a6a129d44997d08b9be3732`; proof harness head: `93c808c02b5cf04f77e44110d6e5824fc91ecb7f`.
- Artifact: [`openclaw-qqbot-2034cb7631725d959a6a129d44997d08b9be3732`](https://github.com/Alix-007/openclaw/actions/runs/31409353639#artifacts), artifact id `9071223280`, artifact digest `sha256:500b6ac50e2dde5630e49ffc377b45853e6a2dd9220830a5ff2451d11e41e7f3`.
- Machine verdict file: `proof-qqbot-durable-verdict.json`, SHA-256 `77b8c687c8bb28333e2e51c628b855ccc991d3eb89a7994f33b66403565e16ee`.
- The fork-only harness uses an actual loopback `ws.WebSocketServer` for HELLO, IDENTIFY, READY, and credential-reflecting DISPATCH. The exact PR code then traverses production `GatewayConnection`, the real shared SQLite durable queue, claim and adoption, production agent-body construction, the QA mock provider, and visible QQBot outbound transport. It also replays the same event id and requires the completed tombstone to suppress both provider and outbound redispatch.

```json
{
  "schema": "openclaw.qqbot.durable-gateway-real-behavior-proof/v1",
  "exactHead": "2034cb7631725d959a6a129d44997d08b9be3732",
  "productionBoundaries": {
    "actualLoopbackWebSocket": true,
    "gatewayConnectionIdentify": true,
    "sqliteEnqueueClaimDispatch": true,
    "duplicateCompletedIgnored": true,
    "buildAgentBodyProviderVisible": true,
    "visibleOutboundTurn": true,
    "gatewayHealth": true,
    "gatewayReady": true
  },
  "identityBefore": {
    "eventId": "message:proof-c2c-message",
    "eventType": "C2C_MESSAGE_CREATE",
    "laneKey": "user:proof-c2c-user",
    "deliveryId": "proof-c2c-delivery",
    "sequence": 41
  },
  "identityAfter": {
    "eventId": "message:proof-c2c-message",
    "eventType": "C2C_MESSAGE_CREATE",
    "laneKey": "user:proof-c2c-user",
    "deliveryId": "proof-c2c-delivery",
    "sequence": 41
  },
  "identityUnchanged": true,
  "ingressLifecycle": {
    "beforeAdoptionStatus": "claimed",
    "completedStatus": "completed",
    "retryAttempts": 0,
    "completedPayloadCleared": true,
    "duplicateProviderDispatches": 0,
    "duplicateVisibleOutboundTurns": 0
  },
  "durable": {
    "visibleMarker": true,
    "redactionMarker": true,
    "rawEncodedFormAbsent": true
  },
  "agentVisible": {
    "visibleMarker": true,
    "redactionMarker": true,
    "rawEncodedFormAbsent": true
  },
  "output": {
    "visibleMarker": true,
    "rawEncodedFormAbsent": true,
    "secretOutput": false
  }
}
```

- Current exact PR head: `2034cb7631725d959a6a129d44997d08b9be3732`.
- [Prior-head public Linux proof](https://github.com/Alix-007/openclaw/actions/runs/31148370535) passed 5 files and 62/62 tests, verified the immutable target SHA, uploaded the terminal artifact, and emitted verified gateway, STT, and token redaction markers with safe context present and credential forms absent.
- Prior-head Node focused validation passed 67/67 across API client, token, setup guidance, channel API, STT, and gateway connection. The new regressions cover raw, URL, form, lowercase-percent, gateway-URL, and DISPATCH reflections. All 14 changed files passed `oxfmt --check`; `git diff --check upstream/main..HEAD` passed.
- [Prior-head public Linux proof](https://github.com/Alix-007/openclaw/actions/runs/31117812288) targets immutable commit `ab83a15648134e008a9815aeb6d00882ddbf40e3` and runs:
  - `node scripts/run-vitest.mjs extensions/qqbot/src/engine/gateway/gateway-connection.test.ts extensions/qqbot/src/engine/tools/channel-api.test.ts extensions/qqbot/src/engine/api/api-client.test.ts extensions/qqbot/src/engine/api/token.test.ts extensions/qqbot/src/engine/utils/stt.test.ts --reporter=verbose`
  - Both current attempts were stopped before checkout by the active [GitHub Actions incident](https://stspg.io/rcz3fcm83sff): attempt 2 ended in `Set up job` with `Service Unavailable` and `Failed to resolve action download info`. No repository command ran, so this is infrastructure evidence rather than a code result; the immutable run can be retried after recovery.
- The gateway regression exercises the actual HELLO -> IDENTIFY -> server-close handler path on a test-owned WebSocket event source. It proves the active token was sent in IDENTIFY, then reflects it in close status `4000`; the safe marker and close code remain while the token, prefix, suffix, and distinctive fragment are absent from logger output.
- Each owner-boundary regression uses a real test-owned loopback HTTP server. The API client uses its configurable loopback base URL; fixed-host channel-tool and token paths route the actual guard call's fetch transport to loopback while preserving production request construction; STT uses the actual guard and loopback URL directly.
- `ApiClient`: statuses `429/503/200`, paths `/json-error`, `/text-error`, `/success`; `transport=loopback-http`, safe marker present, and raw/URL/form/lowercase-percent/JSON-slash-escaped/full/prefix/suffix/fragment absence all `true`.
- Channel tool: status `401`, path `/guilds/123/channels`; the same absence checks are `true` across parsed model-visible details and debug output.
- STT: status `401`; the same absence checks are `true` before the error is thrown.
- TokenManager: status `401`; safe context remains in both debug and error output, while the same absence checks are all `true` on both surfaces.
- Prior head `ab83a15648134e008a9815aeb6d00882ddbf40e3` passed 5/5 files and 55/55 focused tests, plus targeted `oxfmt --check`, type-aware `oxlint`, and `git diff --check`.
- Historical proof state: a read-only capability check found no configured official QQBot or QQBot STT credentials in the local environment/config, Alix fork Actions secrets/variables, or repository environments. Only availability metadata was checked; no credential name or value was read or printed. At that point no authenticated external result was claimed; the public-TLS scoped proof below now supersedes this limitation.

## Repair Scope

- Root cause: a known in-flight credential reached a presentation boundary that relied only on hint-preserving generic pattern redaction; serialized JSON and percent-encoded equivalents were not first reduced to a matching canonical form.
- Architectural owner: the QQBot plugin, where each credential and response meet in the same request scope.
- Canonical fix: one shared QQBot exact-credential helper that decodes valid JSON string values and normalizes percent-escape case for matching, followed by generic SDK redaction; no duplicated per-provider policy or global registry state.
- Sibling coverage: gateway URL, DISPATCH and close handling, API client, channel tool, STT, and token acquisition all use the same boundary and exact-head regression set.
- Current full PR delta against main `188a24844953ef819ca19f0d20f5f3bf7ff09eb6`: production `+294/-54`; tests and test support `+1219/-22`; total `+1513/-76` across 16 files. Latest repair commit: production `+85/-12`, tests `+99/-9`. The positive production delta implements the QQBot-owned exact-secret security invariant across mixed encodings and gateway error presentation.

### Exact-head repair follow-up (2026-08-07)

- Current PR head: `e174085ce10c20ded980305c46fa8f191eeedd66`.
- The token-acquisition presentation boundary now exact-redacts the newly issued `access_token` alongside `clientSecret` before success diagnostics are logged. Malformed token JSON now records only `<malformed JSON body omitted>`, so an unparseable body cannot reflect an unknown freshly issued token.
- Node 24.15.0 focused validation passed: token manager 12/12; QQBot API, token, STT, channel, and gateway-focused suite 64/64; targeted `oxfmt`, `oxlint`, and `git diff --check` passed.
- The locally tested source tree exactly matches the current GitHub head tree: `6daf90ceb62086ae30fca2c159440f40e45faf6b`.

### Current-main exact-head repair (2026-08-08)

- Current PR head: `0ae0d00acfa0b37bdcc14e1f72e51cf375d32014`, rebased onto `upstream/main` `de9314301f0582d4eada9e24168b499608c51b26`.
- The ClawSweeper findings are addressed at the QQBot owner boundary: successful `200` channel-tool bodies are redacted before parsing, and arbitrary/prefixed all-Unicode-escaped credential reflections are removed while unrelated escaped diagnostics remain readable.
- Exact-head local proof passed: channel API 21/21; five-file QQBot acceptance 66/66; targeted `oxfmt` and `git diff --check`.
- The first exact-head upstream run correctly found two `typescript(no-misused-spread)` violations in the new Unicode fixture. Commit `0ae0d00a` replaced string spreads with code-unit `split("")` construction; the focused channel API suite then passed 21/21. Upstream CI run https://github.com/openclaw/openclaw/actions/runs/31255931167 is the current exact-head rerun.
- The local focused oxlint wrapper reached an unrelated current-main Plugin SDK declaration preflight error at `packages/terminal-core/src/ansi.ts:194`; no terminal-core code is touched. The upstream exact-head `check-lint` is authoritative for this follow-up.
- At this earlier stage no authorized official QQBot or QQBot STT credential was present locally and no external result was claimed; the later public-TLS scoped proof below supersedes that limitation without claiming an official provider.
- Exact-head CI completion: upstream run https://github.com/openclaw/openclaw/actions/runs/31255931167 completed successfully with 34 successful and 14 skipped jobs. The complete exact-head PR check rollup is 56 success, 41 skipped, 1 neutral, 0 failed, and 0 pending.

### Merge-ref CI repair (2026-08-10)

- Current exact PR head: `2262b0e4de4573bd9489218378cb0525fb12290d`.
- Main #121031 and this branch had independently added the same `log: params.log` fixture field at different insertion points. Git merged both copies without a textual conflict, causing exact-head merge-ref `check-lint` and `check-test-types` failures.
- The test-only repair aligns the field with current main. Synthetic merge tree `2a007150dc041d5dc9058327e3d490f6e6f677ea` against upstream `b0b82291cada` contains exactly one key and no conflict.
- Node 24.15.0 gateway-owner proof passed 17/17 tests. Targeted `oxfmt --check`, type-aware extension `oxlint`, and `git diff --check` passed.

### Exact-head security follow-up (2026-08-10)

- Current exact PR head: `eaa1e12b4339d38683e45f48ccea7d0969e09fdc`.
- Mixed raw/percent-escaped credentials are matched character-by-character before generic redaction. The focused regression covers the same mixed form in a JSON error body, HTTP status text, and trace metadata.
- Gateway construction failures and WebSocket error events redact the active access token before logs and the operator-visible `onError` status boundary.
- Malformed COS presigned URLs now remain inside the bounded retry/catch path; the regression proves two retry warnings and a controlled final `Invalid URL` error.
- Node 24.15.0 exact-head proof passed 3 files / 39 tests. The loopback HTTP and WebSocket markers bind to the full head SHA and retain safe markers while raw, encoded, prefix, suffix, and distinctive credential fragments are absent.
- Targeted `oxfmt --check`, type-aware `oxlint` with package-boundary preparation skipped, and `git diff --check` passed. Full package-boundary preparation is blocked by the unrelated current-main baseline at `packages/terminal-core/src/ansi.ts:194`.
- At this earlier repair stage authenticated external proof was not yet available; the later public-TLS scoped STT proof below supersedes that limitation without claiming an official provider.

### Exact-head public-error boundary repair (2026-08-10)

- Current exact PR head: `b0bd8221ab774c3486c3a5960745a26e6024fcfc`.
- The sanitized WebSocket error no longer retains the original server-controlled error as `cause`; the focused regression asserts the public `onError` value has no cause, so downstream cause traversal cannot recover the reflected credential.
- Successful token acquisition is captured as immutable `activeAccessToken` before WebSocket callbacks are registered, resolving the three attributable `string | undefined` failures reported by exact-head prod/test types and the QQBot package-boundary lane.
- The predecessor exact head passed 3 files / 39 tests. This follow-up passed targeted `oxfmt --check` and `git diff --check`; local focused test, oxlint, and tsgo runs were queued behind another worktree's global heavy-check lock and intentionally not represented as completed. Upstream exact-head CI run https://github.com/openclaw/openclaw/actions/runs/31352685717 is the authoritative rerun.
- At this earlier repair stage authenticated external proof was not yet available; the later public-TLS scoped STT proof below supersedes that limitation without claiming an official provider.

### Final exact-head test-contract follow-up (2026-08-10)

- Current exact PR head: `c34304bb1174bdb9f5534e7e5601dac0006efe40`.
- Exact-head predecessor CI confirmed `check-prod-types` and the QQBot extension package boundary green after the immutable token capture. Its only attributable remaining failure was the focused test helper call requiring a diagnostic label; this head supplies that required argument without changing runtime behavior.
- Node 24.15.0 focused gateway validation passed 1 file / 19 tests at this head. Targeted `oxfmt --check` and `git diff --check` passed.
- The public sanitized socket error still has no raw `cause`, and the regression asserts `cause` is undefined. At this earlier repair stage authenticated external proof was not yet available; the later public-TLS scoped STT proof below supersedes that limitation without claiming an official provider.
### Exact-head scoped production-boundary proof (2026-08-10)

- Public immutable run: https://github.com/Alix-007/openclaw/actions/runs/31363163778
- Artifact: `openclaw-qqbot-c34304bb1174bdb9f5534e7e5601dac0006efe40`
- The workflow checked out and verified exact head `c34304bb1174bdb9f5534e7e5601dac0006efe40` on Linux/Node 24, then passed 5 files / 70 tests. `proof-metadata.txt` records the immutable SHA and `proof_marker_verified=true`.
- This proof is intentionally scoped to the changed QQBot owner boundary. It executes the production API client, channel tool, token manager, STT request path, and Gateway connection state machine. Controlled loopback HTTP responses and a controlled WebSocket close event reflect the request-scoped credential into status text, JSON/text bodies, trace metadata, and gateway diagnostics.
- The emitted verdict records real loopback transport for HTTP boundaries, confirms IDENTIFY was sent before the gateway reflection, preserves safe status/context, and proves absence of raw, fully/mixed/lowercase percent-encoded, form-encoded, JSON slash-escaped, prefix, suffix, and distinctive-fragment credential forms. The public sanitized socket error also retains no raw `cause`.
- This is not presented as an authenticated external QQBot result: the transport fixture is controlled, while request construction, response/error handling, redaction, truncation, logging, model-visible results, and Gateway lifecycle handling are the exact production paths changed by this PR.


### Exact-head authenticated public-TLS STT proof (2026-08-10)

- Successful immutable run: https://github.com/Alix-007/openclaw/actions/runs/31366276845
- Artifact: [`openclaw-qqbot-c34304bb1174bdb9f5534e7e5601dac0006efe40`](https://github.com/Alix-007/openclaw/actions/runs/31366276845#artifacts), artifact id `9054285918`.
- The workflow verified exact PR head `c34304bb1174bdb9f5534e7e5601dac0006efe40` and passed the five-file QQBot owner suite (70/70) before running the scoped network proof.
- Exact-head production `transcribeAudio` traversed public DNS/TLS and the production SSRF guard to a random Cloudflare Quick Tunnel. The origin required an observed `Cf-Ray`, exact synthetic Bearer authorization, multipart file/model fields, and `POST /audio/transcriptions`, then returned a controlled HTTP 429 response reflecting raw and encoded credential forms.
- The operator-visible error retained status 429 and the safe provider marker while raw, URL-encoded, fully percent-encoded, form-encoded, mixed-percent, JSON slash-escaped, prefix, suffix, and distinctive-fragment forms were all absent.
- This is intentionally a controlled authenticated OpenAI-compatible STT fixture, not a claim about an official QQ provider. It supplies the previously missing external DNS/TLS/authentication boundary while keeping the credential synthetic, reproducible, and safe to publish. This section supersedes the earlier body notes that authenticated external proof was unavailable.

```json
{"schema":"openclaw.qqbot.public-stt-proof/v1","exactHead":"c34304bb1174bdb9f5534e7e5601dac0006efe40","provider":"controlled-openai-compatible-stt-fixture","credentialMode":"synthetic-request-scoped-bearer","officialProviderClaim":false,"network":{"publicDns":true,"tls":true,"cloudflareIngress":true,"directLoopbackRequest":false,"hostClass":"random.trycloudflare.com"},"request":{"productionTranscribeAudio":true,"productionSsrfGuard":true,"authorizationExact":true,"multipart":true,"methodAndPathExact":true,"filePartPresent":true,"modelPartPresent":true},"response":{"status":429,"safeMarkerPresent":true,"rawAbsent":true,"urlEncodedAbsent":true,"fullyEncodedAbsent":true,"formEncodedAbsent":true,"mixedPercentAbsent":true,"jsonSlashEscapedAbsent":true,"prefixAbsent":true,"suffixAbsent":true,"fragmentAbsent":true},"secretOutput":false,"passed":true}
```



### Latest exact-head nested-cause repair and public-TLS proof (2026-08-10)

- Current exact PR head: `158474027c215eea438414c6aaa58bd770c99a22`.
- Root cause: a WebSocket error with a safe top-level message could still carry the active credential in its nested `cause`; the unchanged-message branch forwarded that provider-owned Error object through the public `onError` boundary.
- Canonical owner fix: the WebSocket presentation boundary now always emits a fresh, cause-free `Error` containing only the redacted message. Internal ingress-admission errors retain their existing identity and classification path.
- Parent behavior proof: with production code unchanged, the new cause-only regression failed because the reported object was the raw socket Error. At the repaired exact tree, Node 24.15.0 passed the full gateway owner file, 20/20 tests. Targeted `oxfmt --check`, type-aware `oxlint`, and `git diff --check` passed.
- Repair delta: production `+2/-1` (net `+1`, the security-boundary invariant and its owner comment); tests `+30/-0`. The channel consumer only reads the sanitized message, so no public status behavior is lost.
- Successful immutable public run: https://github.com/Alix-007/openclaw/actions/runs/31373396386
- Artifact: [`openclaw-qqbot-158474027c215eea438414c6aaa58bd770c99a22`](https://github.com/Alix-007/openclaw/actions/runs/31373396386#artifacts), artifact id `9057016909`.
- The workflow verified exact head `158474027c215eea438414c6aaa58bd770c99a22`, passed the five-file QQBot owner suite (71/71), and then exercised production `transcribeAudio` through public DNS/TLS and the production SSRF guard.
- The controlled origin required Cloudflare ingress, exact synthetic Bearer authorization, multipart file/model fields, and `POST /audio/transcriptions`, then reflected credential forms in a 429. Safe status/context remained while every enumerated credential form was absent.
- This is intentionally a controlled authenticated OpenAI-compatible STT fixture, not an official QQ-provider claim. It proves the changed production network/authentication/error boundary without exposing or requiring a real provider credential.

```json
{"schema":"openclaw.qqbot.public-stt-proof/v1","exactHead":"158474027c215eea438414c6aaa58bd770c99a22","provider":"controlled-openai-compatible-stt-fixture","credentialMode":"synthetic-request-scoped-bearer","officialProviderClaim":false,"network":{"publicDns":true,"tls":true,"cloudflareIngress":true,"directLoopbackRequest":false,"hostClass":"random.trycloudflare.com"},"request":{"productionTranscribeAudio":true,"productionSsrfGuard":true,"authorizationExact":true,"multipart":true,"methodAndPathExact":true,"filePartPresent":true,"modelPartPresent":true},"response":{"status":429,"safeMarkerPresent":true,"rawAbsent":true,"urlEncodedAbsent":true,"fullyEncodedAbsent":true,"formEncodedAbsent":true,"mixedPercentAbsent":true,"jsonSlashEscapedAbsent":true,"prefixAbsent":true,"suffixAbsent":true,"fragmentAbsent":true},"secretOutput":false,"passed":true}
```

### Exact-head percent-preservation repair (2026-08-10)

- Current exact PR head: `ccdb5516b463ef890e338763c1c2f9cd00180579`.
- Parent failure: the unmodified redactor changed a successful channel-tool body from `id%2fpart` / `keep%afcase` to `id%2Fpart` / `keep%AFcase`, even though neither value matched the request credential.
- Root cause: the older encoded-form path canonicalized percent escapes across the entire presented body. The later mixed-unit matcher already owns case-insensitive credential matching, leaving duplicate policy that mutated unrelated provider data.
- Canonical fix: remove the output-wide canonicalization and redundant encoded-form list. Candidate matching now carries both literal and percent-encoded positions when `%` prefixes are ambiguous, redacts the lowercase encoded credential, and rebuilds every unmatched segment from the original text.
- Exact local proof: Node 24.15.0 passed the five-file QQBot owner suite, 72/72 tests. Targeted type-aware `oxlint`, `oxfmt --check`, and `git diff --check` passed. Repair delta: production `+21/-33` (net `-12`); tests `+32/-0`.
- Successful immutable public run: https://github.com/Alix-007/openclaw/actions/runs/31380887712
- Artifact: [`openclaw-qqbot-ccdb5516b463ef890e338763c1c2f9cd00180579`](https://github.com/Alix-007/openclaw/actions/runs/31380887712#artifacts), artifact id `9059846030`.
- The workflow verified the immutable target SHA, passed 5 files / 72 tests, then exercised production `transcribeAudio` through public DNS/TLS, Cloudflare ingress, and the production SSRF guard. The controlled origin required exact synthetic Bearer authorization and returned HTTP 429; safe context remained while every enumerated credential form was absent. This remains a controlled OpenAI-compatible STT fixture, not an official QQ-provider claim.

```json
{"schema":"openclaw.qqbot.public-stt-proof/v1","exactHead":"ccdb5516b463ef890e338763c1c2f9cd00180579","provider":"controlled-openai-compatible-stt-fixture","credentialMode":"synthetic-request-scoped-bearer","officialProviderClaim":false,"network":{"publicDns":true,"tls":true,"cloudflareIngress":true,"directLoopbackRequest":false,"hostClass":"random.trycloudflare.com"},"request":{"productionTranscribeAudio":true,"productionSsrfGuard":true,"authorizationExact":true,"multipart":true,"methodAndPathExact":true,"filePartPresent":true,"modelPartPresent":true},"response":{"status":429,"safeMarkerPresent":true,"rawAbsent":true,"urlEncodedAbsent":true,"fullyEncodedAbsent":true,"formEncodedAbsent":true,"mixedPercentAbsent":true,"jsonSlashEscapedAbsent":true,"prefixAbsent":true,"suffixAbsent":true,"fragmentAbsent":true},"secretOutput":false,"passed":true}
```

### Exact-head durable-ingress repair and immutable proof (2026-08-10)

- Current exact PR head: `2034cb7631725d959a6a129d44997d08b9be3732`, cleanly rebased onto `upstream/main` `ebd03db1568742b4eac0720245461d7f1d3a1416`. GitHub reports the PR mergeable.
- Exact parent-red: at `ccdb5516b463ef890e338763c1c2f9cd00180579`, a test-only real-turn regression traversed GatewayConnection -> SQLite-backed channel ingress -> dispatch -> production user/agent body stages. Raw, URL-encoded, and form-encoded token absence was `false` on both the durable envelope and agent body (all six assertions failed).
- Root cause: DISPATCH diagnostics used the presentation redactor, but the real turn still passed the original `rawData` into durable ingress. Replayable SQLite state and downstream agent-visible content therefore retained a reflected active socket token.
- Architectural owner and canonical fix: GatewayConnection now exact-redacts the active request-scoped token before the envelope crosses the QQBot durable-ingress producer boundary. The ingress-envelope owner reparses the sanitized envelope and requires event id, event type, lane key, outer delivery id, and sequence to remain identical before admission. An identity overlap fails closed and is recorded instead of persisting a corrupted or credential-bearing turn.
- Content policy remains separate: durable turns use only the QQBot exact-secret helper. Generic presentation redaction and operator-configured `logging.redactPatterns` are not applied to user messages. The regression retains the ordinary pattern-shaped user text `sk-visible-user-content` through the stored envelope, production user content, and production agent body.
- Real sibling coverage: C2C, guild mention, guild DM, group mention, and group full-message DISPATCH envelopes each traverse the actual WebSocket handler, real SQLite queue, claim dispatch, user-content builder, and agent-body builder. Every path preserves harmless content and durable identity while removing raw, lowercase URL-percent, form, prefix, suffix, and distinctive credential forms.
- Final local Node 24.15.0 proof passed 5 files / 83 tests. Targeted type-aware `oxlint`, `oxfmt --check`, and `git diff --check` passed. The final rebase changed no QQBot tree bytes from the tested tree; its four newer main commits did not touch QQBot.
- Successful immutable public run: https://github.com/Alix-007/openclaw/actions/runs/31398689883. The workflow verified the exact target SHA above, passed 5 files / 83 tests, printed all five durable/agent-visible event regressions, and recorded `proof_marker_verified=true`.
- Artifact: [`openclaw-qqbot-2034cb7631725d959a6a129d44997d08b9be3732`](https://github.com/Alix-007/openclaw/actions/runs/31398689883#artifacts), artifact id `9066743273`.
- Latest repair delta: production `+70/-14` (net `+56`), tests `+186/-3` (net `+183`). The positive production delta establishes the credential-security and durable-identity owner boundary. Full exact PR delta versus current main: production `+344/-60`; tests/test support `+1468/-24`; total `+1812/-84` across 18 files. No config, schema, Plugin SDK, or successful-response contract changes are introduced.


