### PR TITLE
fix(synology-chat): prevent duplicate messages after ambiguous failures

### DIFF
--- a/extensions/synology-chat/src/client.loopback.test.ts
+++ b/extensions/synology-chat/src/client.loopback.test.ts
@@ -98,6 +98,9 @@ describe("Synology Chat client loopback", () => {
     await expect(send).resolves.toBe(true);
     expect(receivedRequests).toBe(1);
     expect(timeoutSpy.mock.calls.filter(([, delay]) => delay === 300)).toHaveLength(1);
+    console.log(
+      `[synology webhook retry proof] preconnect_refusal=true retry_scheduled=true server_received=${receivedRequests} outcome=success`,
+    );
   });
 
   it("does not replay after the server receives the upload and disconnects mid-response", async () => {
@@ -135,6 +138,9 @@ describe("Synology Chat client loopback", () => {
     expect(requestCount).toBe(1);
     expect(new URLSearchParams(uploadedBody).get("payload")).toBe(
       JSON.stringify({ text: "post-upload disconnect" }),
+    );
+    console.log(
+      `[synology webhook retry proof] server_received=${requestCount} disconnect_after_upload=true replayed=${requestCount > 1} outcome=not_sent`,
     );
   });
 

--- a/extensions/synology-chat/src/client.loopback.test.ts
+++ b/extensions/synology-chat/src/client.loopback.test.ts
@@ -6,18 +6,32 @@ import { resolveLegacyWebhookNameToChatUserId, sendMessage } from "./client.js";
 
 const USER_LIST_RESPONSE_MAX_BYTES = 1 * 1024 * 1024;
 
-describe("Synology Chat user_list loopback", () => {
+describe("Synology Chat client loopback", () => {
   let server: http.Server | undefined;
 
-  async function listenLoopback(handler: http.RequestListener): Promise<number> {
+  async function listenLoopback(handler: http.RequestListener, port = 0): Promise<number> {
     server = http.createServer(handler);
     server.on("clientError", (_err, socket) => socket.destroy());
-    server.listen(0, "127.0.0.1");
+    server.listen(port, "127.0.0.1");
     await once(server, "listening");
     const address = server.address();
     if (!address || typeof address === "string") {
       throw new Error("expected loopback server address");
     }
+    return address.port;
+  }
+
+  async function reserveLoopbackPort(): Promise<number> {
+    const reservation = http.createServer();
+    reservation.listen(0, "127.0.0.1");
+    await once(reservation, "listening");
+    const address = reservation.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected reserved loopback address");
+    }
+    await new Promise<void>((resolve, reject) => {
+      reservation.close((err) => (err ? reject(err) : resolve()));
+    });
     return address.port;
   }
 
@@ -30,6 +44,98 @@ describe("Synology Chat user_list loopback", () => {
       });
       server = undefined;
     }
+  });
+
+  it("retries once when a real connection refusal occurs before the listener starts", async () => {
+    const port = await reserveLoopbackPort();
+    const nativeSetTimeout = globalThis.setTimeout;
+    let releaseRetry: (() => void) | undefined;
+    let markRetryScheduled!: () => void;
+    const retryScheduled = new Promise<void>((resolve) => {
+      markRetryScheduled = resolve;
+    });
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    timeoutSpy.mockImplementation(((
+      callback: (...args: unknown[]) => void,
+      delay?: number,
+      ...args: unknown[]
+    ) => {
+      if (delay === 300 && releaseRetry === undefined) {
+        const heldTimer = nativeSetTimeout(() => {}, 10_000);
+        heldTimer.unref?.();
+        releaseRetry = () => {
+          clearTimeout(heldTimer);
+          callback(...args);
+        };
+        markRetryScheduled();
+        return heldTimer;
+      }
+      return nativeSetTimeout(callback, delay, ...args);
+    }) as typeof setTimeout);
+
+    const incomingUrl = `http://127.0.0.1:${port}/webapi/entry.cgi`;
+    const send = sendMessage(incomingUrl, "retry after refusal");
+    const firstOutcome = await Promise.race([
+      retryScheduled.then(() => "retry-scheduled" as const),
+      send.then((sendResult) => ({ sendResult })),
+    ]);
+    expect(firstOutcome).toBe("retry-scheduled");
+
+    let receivedRequests = 0;
+    await listenLoopback((req, res) => {
+      receivedRequests += 1;
+      req.resume();
+      req.on("end", () => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ success: true }));
+      });
+    }, port);
+    if (!releaseRetry) {
+      throw new Error("expected pre-connect retry backoff");
+    }
+    releaseRetry();
+
+    await expect(send).resolves.toBe(true);
+    expect(receivedRequests).toBe(1);
+    expect(timeoutSpy.mock.calls.filter(([, delay]) => delay === 300)).toHaveLength(1);
+  });
+
+  it("does not replay after the server receives the upload and disconnects mid-response", async () => {
+    let requestCount = 0;
+    let uploadedBody = "";
+    const port = await listenLoopback((req, res) => {
+      requestCount += 1;
+      req.setEncoding("utf8");
+      req.on("data", (chunk: string) => {
+        uploadedBody += chunk;
+      });
+      req.on("end", () => {
+        res.on("error", () => {});
+        res.writeHead(200, {
+          "Content-Type": "application/json",
+          "Content-Length": "1000",
+        });
+        res.write('{"success":');
+        const dripTimer = setInterval(() => {
+          if (!res.destroyed) {
+            res.write(" ");
+          }
+        }, 10);
+        const disconnectTimer = setTimeout(() => res.destroy(), 50);
+        res.on("close", () => {
+          clearInterval(dripTimer);
+          clearTimeout(disconnectTimer);
+        });
+      });
+    });
+    const incomingUrl = `http://127.0.0.1:${port}/webapi/entry.cgi`;
+
+    await expect(sendMessage(incomingUrl, "post-upload disconnect")).resolves.toBe(false);
+
+    expect(requestCount).toBe(1);
+    expect(new URLSearchParams(uploadedBody).get("payload")).toBe(
+      JSON.stringify({ text: "post-upload disconnect" }),
+    );
   });
 
   it("delivers authenticated text and media without inventing platform message ids", async () => {
@@ -188,7 +294,7 @@ describe("Synology Chat user_list loopback", () => {
     await expect(
       synologyChatPlugin.outbound.sendText({ cfg, text: "rejected", to: "42" }),
     ).rejects.toThrow("Failed to send message to Synology Chat");
-    expect(rejectedRequests).toBe(3);
+    expect(rejectedRequests).toBe(1);
 
     await expect(
       synologyChatPlugin.outbound.sendMedia({
@@ -197,7 +303,30 @@ describe("Synology Chat user_list loopback", () => {
         to: "42",
       }),
     ).rejects.toThrow("Failed to send media to Synology Chat");
-    expect(rejectedRequests).toBe(4);
+    expect(rejectedRequests).toBe(2);
+  });
+
+  it("does not replay an HTTP-successful webhook rejection", async () => {
+    let rejectedRequests = 0;
+    const port = await listenLoopback((_req, res) => {
+      rejectedRequests += 1;
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ success: false, error: { code: 105 } }));
+    });
+    const cfg = {
+      channels: {
+        "synology-chat": {
+          enabled: true,
+          token: "synology-loopback-rejected",
+          incomingUrl: `http://127.0.0.1:${port}/webapi/entry.cgi`,
+        },
+      },
+    };
+
+    await expect(
+      synologyChatPlugin.outbound.sendText({ cfg, text: "rejected", to: "42" }),
+    ).rejects.toThrow("Failed to send message to Synology Chat");
+    expect(rejectedRequests).toBe(1);
   });
 
   it("rejects private file URLs before contacting the authenticated webhook", async () => {
@@ -344,7 +473,7 @@ describe("Synology Chat user_list loopback", () => {
     expect(elapsedMs).toBeLessThan(timeoutMs + 1_500);
   });
 
-  it("bounds a dripping chatbot response with a wall-clock deadline", async () => {
+  it("does not replay a code-less wall-clock timeout from a dripping chatbot response", async () => {
     let requestCount = 0;
     const port = await listenLoopback((_req, res) => {
       requestCount += 1;
@@ -380,9 +509,10 @@ describe("Synology Chat user_list loopback", () => {
     await expect(sendMessage(incomingUrl, "hello")).resolves.toBe(false);
     const elapsedMs = performance.now() - startedAt;
 
-    expect(requestCount).toBe(3);
+    expect(requestCount).toBe(1);
     expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 30_000);
-    expect(elapsedMs).toBeGreaterThanOrEqual(timeoutMs * 3 - 100);
-    expect(elapsedMs).toBeLessThan(3_500);
+    expect(timeoutSpy.mock.calls.filter(([, delay]) => delay === 30_000)).toHaveLength(1);
+    expect(elapsedMs).toBeGreaterThanOrEqual(timeoutMs - 50);
+    expect(elapsedMs).toBeLessThan(timeoutMs + 1_500);
   });
 });

--- a/extensions/synology-chat/src/client.loopback.test.ts
+++ b/extensions/synology-chat/src/client.loopback.test.ts
@@ -103,7 +103,7 @@ describe("Synology Chat client loopback", () => {
     );
   });
 
-  it("does not replay after the server receives the upload and disconnects mid-response", async () => {
+  it("does not replay after the server receives the upload and disconnects", async () => {
     let requestCount = 0;
     let uploadedBody = "";
     const port = await listenLoopback((req, res) => {
@@ -113,22 +113,7 @@ describe("Synology Chat client loopback", () => {
         uploadedBody += chunk;
       });
       req.on("end", () => {
-        res.on("error", () => {});
-        res.writeHead(200, {
-          "Content-Type": "application/json",
-          "Content-Length": "1000",
-        });
-        res.write('{"success":');
-        const dripTimer = setInterval(() => {
-          if (!res.destroyed) {
-            res.write(" ");
-          }
-        }, 10);
-        const disconnectTimer = setTimeout(() => res.destroy(), 50);
-        res.on("close", () => {
-          clearInterval(dripTimer);
-          clearTimeout(disconnectTimer);
-        });
+        res.destroy();
       });
     });
     const incomingUrl = `http://127.0.0.1:${port}/webapi/entry.cgi`;
@@ -310,29 +295,6 @@ describe("Synology Chat client loopback", () => {
       }),
     ).rejects.toThrow("Failed to send media to Synology Chat");
     expect(rejectedRequests).toBe(2);
-  });
-
-  it("does not replay an HTTP-successful webhook rejection", async () => {
-    let rejectedRequests = 0;
-    const port = await listenLoopback((_req, res) => {
-      rejectedRequests += 1;
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ success: false, error: { code: 105 } }));
-    });
-    const cfg = {
-      channels: {
-        "synology-chat": {
-          enabled: true,
-          token: "synology-loopback-rejected",
-          incomingUrl: `http://127.0.0.1:${port}/webapi/entry.cgi`,
-        },
-      },
-    };
-
-    await expect(
-      synologyChatPlugin.outbound.sendText({ cfg, text: "rejected", to: "42" }),
-    ).rejects.toThrow("Failed to send message to Synology Chat");
-    expect(rejectedRequests).toBe(1);
   });
 
   it("rejects private file URLs before contacting the authenticated webhook", async () => {

--- a/extensions/synology-chat/src/client.test.ts
+++ b/extensions/synology-chat/src/client.test.ts
@@ -159,22 +159,23 @@ describe("sendMessage", () => {
     expect(result).toBe(true);
   });
 
-  it("returns false on server error after retries", async () => {
+  it("returns false on server error without replaying", async () => {
     mockFailureResponse(500);
     const result = await settleTimers(sendMessage("https://nas.example.com/incoming", "Hello"));
     expect(result).toBe(false);
+    expect(vi.mocked(https.request)).toHaveBeenCalledOnce();
   });
 
   it.each([
     { name: "Synology error envelope", body: { success: false, error: { code: 105 } } },
     { name: "unrelated malformed response fields", body: { success: false, data: null } },
-  ])("retries an HTTP-successful webhook rejection ($name)", async ({ body }) => {
+  ])("does not replay an HTTP-successful webhook rejection ($name)", async ({ body }) => {
     mockResponse(200, JSON.stringify(body));
 
     const result = await settleTimers(sendMessage("https://nas.example.com/incoming", "Hello"));
 
     expect(result).toBe(false);
-    expect(vi.mocked(https.request)).toHaveBeenCalledTimes(3);
+    expect(vi.mocked(https.request)).toHaveBeenCalledOnce();
   });
 
   it.each([

--- a/extensions/synology-chat/src/client.test.ts
+++ b/extensions/synology-chat/src/client.test.ts
@@ -106,6 +106,14 @@ function mockFailureResponse(statusCode = 500) {
   mockResponse(statusCode, "error");
 }
 
+function mockRequestErrorOnce(error: Error) {
+  vi.mocked(https.request).mockImplementationOnce((() => {
+    const req = createMockRequestEmitter();
+    process.nextTick(() => req.emit("error", error));
+    return req;
+  }) as MockRequestHandler);
+}
+
 function installFakeTimerHarness() {
   beforeAll(async () => {
     ({ sendMessage, sendFileUrl, resolveLegacyWebhookNameToChatUserId } =
@@ -164,6 +172,39 @@ describe("sendMessage", () => {
     const result = await settleTimers(sendMessage("https://nas.example.com/incoming", "Hello"));
     expect(result).toBe(false);
     expect(vi.mocked(https.request)).toHaveBeenCalledOnce();
+  });
+
+  it("does not replay a mixed aggregate with an ambiguous transport leaf", async () => {
+    const mixedError = Object.assign(
+      new AggregateError([
+        Object.assign(new Error("connect refused"), { code: "ECONNREFUSED" }),
+        Object.assign(new Error("connection reset after write"), { code: "ECONNRESET" }),
+      ]),
+      { code: "ECONNREFUSED" },
+    );
+    mockRequestErrorOnce(mixedError);
+
+    const result = await settleTimers(sendMessage("https://nas.example.com/incoming", "Hello"));
+
+    expect(result).toBe(false);
+    expect(vi.mocked(https.request)).toHaveBeenCalledOnce();
+  });
+
+  it("retries when every aggregate transport leaf is pre-connect", async () => {
+    mockSuccessResponse();
+    const aggregateError = Object.assign(
+      new AggregateError([
+        Object.assign(new Error("connect refused"), { code: "ECONNREFUSED" }),
+        Object.assign(new Error("host not found"), { code: "ENOTFOUND" }),
+      ]),
+      { code: "ECONNREFUSED" },
+    );
+    mockRequestErrorOnce(new TypeError("fetch failed", { cause: aggregateError }));
+
+    const result = await settleTimers(sendMessage("https://nas.example.com/incoming", "Hello"));
+
+    expect(result).toBe(true);
+    expect(vi.mocked(https.request)).toHaveBeenCalledTimes(2);
   });
 
   it.each([

--- a/extensions/synology-chat/src/client.ts
+++ b/extensions/synology-chat/src/client.ts
@@ -5,9 +5,11 @@
 
 import * as http from "node:http";
 import * as https from "node:https";
+import { extractErrorCode } from "openclaw/plugin-sdk/error-runtime";
 import { safeParseJsonWithSchema, safeParseWithSchema } from "openclaw/plugin-sdk/extension-shared";
 import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
 import { readByteStreamWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
+import { classifyTransientNetworkErrorCode } from "openclaw/plugin-sdk/retry-runtime";
 import { sleep } from "openclaw/plugin-sdk/runtime-env";
 import {
   formatErrorMessage,
@@ -120,19 +122,19 @@ async function sendMessageChunk(
   // The @mention is optional but user_ids is mandatory
   const body = buildWebhookBody({ text }, userId);
 
-  // Retry with exponential backoff (3 attempts, 300ms base)
+  // A webhook POST is non-idempotent. Retry only when the transport proves the
+  // request never connected; replaying an ambiguous failure can duplicate a message.
   const maxRetries = 3;
   const baseDelay = 300;
 
   for (let attempt = 0; attempt < maxRetries; attempt++) {
     try {
       await waitForSendSlot();
-      const ok = await doPost(incomingUrl, body, allowInsecureSsl);
-      if (ok) {
-        return true;
+      return await doPost(incomingUrl, body, allowInsecureSsl);
+    } catch (error) {
+      if (classifyTransientNetworkErrorCode(extractErrorCode(error)) !== "pre-connect") {
+        return false;
       }
-    } catch {
-      // will retry
     }
 
     if (attempt < maxRetries - 1) {

--- a/extensions/synology-chat/src/client.ts
+++ b/extensions/synology-chat/src/client.ts
@@ -5,7 +5,7 @@
 
 import * as http from "node:http";
 import * as https from "node:https";
-import { extractErrorCode } from "openclaw/plugin-sdk/error-runtime";
+import { collectErrorGraphCandidates, extractErrorCode } from "openclaw/plugin-sdk/error-runtime";
 import { safeParseJsonWithSchema, safeParseWithSchema } from "openclaw/plugin-sdk/extension-shared";
 import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
 import { readByteStreamWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
@@ -29,6 +29,42 @@ const USER_LIST_REQUEST_TIMEOUT_MS = 15_000;
 const POST_REQUEST_TIMEOUT_MS = 30_000;
 let lastSendTime = 0;
 let sendQueue: Promise<void> = Promise.resolve();
+
+const UNPROVEN_TRANSPORT_ERROR_BRANCH = "unproven transport error branch";
+
+function nestedTransportErrorCandidates(current: Record<string, unknown>): unknown[] {
+  const aggregateBranches = Array.isArray(current.errors)
+    ? current.errors.map((branch) => branch ?? UNPROVEN_TRANSPORT_ERROR_BRANCH)
+    : [];
+  const wrappers = [current.cause, current.original, current.error, current.reason].filter(
+    (candidate) => candidate !== undefined && candidate !== null,
+  );
+  return [...aggregateBranches, ...wrappers];
+}
+
+function isProvenPreConnectFailure(error: unknown): boolean {
+  let foundPreConnectLeaf = false;
+  for (const candidate of collectErrorGraphCandidates(error, nestedTransportErrorCandidates)) {
+    const classification = classifyTransientNetworkErrorCode(extractErrorCode(candidate));
+    const nested =
+      candidate && typeof candidate === "object"
+        ? nestedTransportErrorCandidates(candidate as Record<string, unknown>)
+        : [];
+    // A webhook POST is safe to replay only when every terminal transport branch
+    // proves it failed before connect; aggregate summary codes cannot hide a reset.
+    if (nested.length > 0) {
+      if (classification === "ambiguous") {
+        return false;
+      }
+      continue;
+    }
+    if (classification !== "pre-connect") {
+      return false;
+    }
+    foundPreConnectLeaf = true;
+  }
+  return foundPreConnectLeaf;
+}
 
 // --- Chat user_id resolution ---
 // Synology Chat uses two different user_id spaces:
@@ -132,7 +168,7 @@ async function sendMessageChunk(
       await waitForSendSlot();
       return await doPost(incomingUrl, body, allowInsecureSsl);
     } catch (error) {
-      if (classifyTransientNetworkErrorCode(extractErrorCode(error)) !== "pre-connect") {
+      if (!isProvenPreConnectFailure(error)) {
         return false;
       }
     }


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

AI-assisted: This change was implemented and validated with Codex.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where sending a Synology Chat message could create a duplicate after an ambiguous network failure if the original request had already reached the server and the client automatically replayed it.

## Why This Change Was Made

Automatic retry now traverses wrapped and aggregate transport errors and proceeds only when every terminal branch proves a pre-connect failure. HTTP failures, business rejections, mixed aggregates containing an ambiguous post-send failure, and code-less failures return without replaying the non-idempotent request.

## User Impact

Clearly pre-connect failures still get a recovery attempt, while uncertain send outcomes no longer risk posting the same Chat message twice.

## Evidence

- Canonical exact-head CI: [run 31160626041](https://github.com/openclaw/openclaw/actions/runs/31160626041) checked out and verified `10a72debddea15336433d47d0a2aeb72c4169b7d`.
- Exact-head changed-tests job: [checks-node-changed](https://github.com/openclaw/openclaw/actions/runs/31160626041/job/92810022814) ran `extensions/synology-chat/src/client.test.ts` (42/42 passed) and `extensions/synology-chat/src/client.loopback.test.ts` (9/9 passed), plus the adjacent Synology channel tests.
- Focused aggregate cases prove an all-pre-connect aggregate retries, while a mixed aggregate containing `ECONNRESET` does not replay.
- Real Node HTTP loopback output at the exact head:

```text
[synology webhook retry proof] preconnect_refusal=true retry_scheduled=true server_received=1 outcome=success
[synology webhook retry proof] server_received=1 disconnect_after_upload=true replayed=false outcome=not_sent
```

- `git diff --check` passed for the published patch.
