### PR TITLE
fix: preserve CRLF for new Windows batch files

### DIFF
--- a/src/agents/apply-patch.test-support.ts
+++ b/src/agents/apply-patch.test-support.ts
@@ -1,3 +1,4 @@
+import { vi } from "vitest";
 import type { ApplyPatchSummary } from "./apply-patch.js";
 import "./apply-patch.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
@@ -18,6 +19,71 @@ type ApplyPatchResult = {
 type ApplyPatchTestApi = {
   applyPatch(input: string, options: ApplyPatchOptions): Promise<ApplyPatchResult>;
 };
+
+export function createMemoryPatchSandbox(
+  initialFiles: Record<string, string | Buffer> = {},
+  options: { supportsExclusiveCreate?: boolean } = {},
+) {
+  const files = new Map<string, string | Buffer>(
+    Object.entries(initialFiles).map(([filePath, contents]) => [`/sandbox/${filePath}`, contents]),
+  );
+  const writeFile = vi.fn(async ({ filePath, data }) => {
+    files.set(filePath, Buffer.isBuffer(data) ? Buffer.from(data) : data);
+  });
+  const createFileExclusive = vi.fn(async ({ filePath, data }) => {
+    if (files.has(filePath)) {
+      return "exists" as const;
+    }
+    files.set(filePath, Buffer.isBuffer(data) ? Buffer.from(data) : data);
+    return "created" as const;
+  });
+  const mkdirp = vi.fn(async () => {});
+  const bridge: SandboxFsBridge = {
+    resolvePath: ({ filePath }) => ({
+      relativePath: filePath,
+      containerPath: `/sandbox/${filePath}`,
+    }),
+    readFile: async ({ filePath }) => {
+      const contents = files.get(filePath);
+      return typeof contents === "string"
+        ? Buffer.from(contents, "utf8")
+        : Buffer.from(contents ?? "");
+    },
+    writeFile,
+    ...(options.supportsExclusiveCreate === false ? {} : { createFileExclusive }),
+    remove: async ({ filePath }) => {
+      files.delete(filePath);
+    },
+    rename: async ({ from, to }) => {
+      const contents = files.get(from);
+      if (contents !== undefined) {
+        files.set(to, contents);
+        files.delete(from);
+      }
+    },
+    stat: async ({ filePath }) => {
+      const contents = files.get(filePath);
+      return contents === undefined
+        ? null
+        : { type: "file", size: Buffer.byteLength(contents), mtimeMs: 0 };
+    },
+    mkdirp,
+  };
+  return {
+    files,
+    bridge,
+    writeFile,
+    createFileExclusive,
+    mkdirp,
+    options: {
+      cwd: "/local/workspace",
+      sandbox: {
+        root: "/local/workspace",
+        bridge,
+      },
+    },
+  };
+}
 
 function getTestApi(): ApplyPatchTestApi {
   const api = (globalThis as Record<PropertyKey, unknown>)[

--- a/src/agents/apply-patch.test.ts
+++ b/src/agents/apply-patch.test.ts
@@ -205,14 +205,10 @@ describe("applyPatch", () => {
 
   it("writes new Windows batch files with CRLF line endings", async () => {
     const memory = createMemoryPatchSandbox();
-    const patch = `*** Begin Patch
-*** Add File: launch.cmd
-+@echo off
-+echo ready
-*** End Patch`;
-
-    await applyPatch(patch, memory.options);
-
+    await applyPatch(
+      "*** Begin Patch\n*** Add File: launch.cmd\n+@echo off\n+echo ready\n*** End Patch",
+      memory.options,
+    );
     expect(memory.files.get("/sandbox/launch.cmd")).toBe("@echo off\r\necho ready\r\n");
   });
 

--- a/src/agents/apply-patch.test.ts
+++ b/src/agents/apply-patch.test.ts
@@ -203,6 +203,19 @@ describe("applyPatch", () => {
     expect(result.summary.added).toEqual(["hello.txt"]);
   });
 
+  it("writes new Windows batch files with CRLF line endings", async () => {
+    const memory = createMemoryPatchSandbox();
+    const patch = `*** Begin Patch
+*** Add File: launch.cmd
++@echo off
++echo ready
+*** End Patch`;
+
+    await applyPatch(patch, memory.options);
+
+    expect(memory.files.get("/sandbox/launch.cmd")).toBe("@echo off\r\necho ready\r\n");
+  });
+
   it("rejects an add hunk that targets an existing file", async () => {
     const memory = createMemoryPatchSandbox({ "notes.txt": "keep me\n" });
     const patch = `*** Begin Patch

--- a/src/agents/apply-patch.test.ts
+++ b/src/agents/apply-patch.test.ts
@@ -424,6 +424,24 @@ describe("applyPatch", () => {
     expect(result.summary.modified).toEqual(["dest.txt"]);
   });
 
+  it("normalizes moved Windows batch files to CRLF", async () => {
+    const memory = createMemoryPatchSandbox({
+      "source.txt": "@echo off\necho hello\n",
+    });
+    const patch = `*** Begin Patch
+*** Update File: source.txt
+*** Move to: launch.cmd
+@@
+ @echo off
+ echo hello
+*** End Patch`;
+
+    await applyPatch(patch, memory.options);
+
+    expect(memory.files.get("/sandbox/launch.cmd")).toBe("@echo off\r\necho hello\r\n");
+    expect(memory.files.has("/sandbox/source.txt")).toBe(false);
+  });
+
   it("updates in place when move target resolves to the source file", async () => {
     const memory = createMemoryPatchSandbox({
       "source.txt": "foo\nbar\n",

--- a/src/agents/apply-patch.test.ts
+++ b/src/agents/apply-patch.test.ts
@@ -12,8 +12,7 @@ import {
   withRealpathSymlinkRebindRace,
 } from "../test-utils/symlink-rebind-race.js";
 import { createApplyPatchTool } from "./apply-patch.js";
-import { applyPatch } from "./apply-patch.test-support.js";
-import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
+import { applyPatch, createMemoryPatchSandbox } from "./apply-patch.test-support.js";
 
 async function withTempDir<T>(fn: (dir: string) => Promise<T>) {
   // realpath: production sandbox checks compare against canonical paths; on macOS
@@ -40,71 +39,6 @@ function buildAddFilePatch(targetPath: string): string {
 *** Add File: ${targetPath}
 +escaped
 *** End Patch`;
-}
-
-function createMemoryPatchSandbox(
-  initialFiles: Record<string, string | Buffer> = {},
-  options: { supportsExclusiveCreate?: boolean } = {},
-) {
-  const files = new Map<string, string | Buffer>(
-    Object.entries(initialFiles).map(([filePath, contents]) => [`/sandbox/${filePath}`, contents]),
-  );
-  const writeFile = vi.fn(async ({ filePath, data }) => {
-    files.set(filePath, Buffer.isBuffer(data) ? Buffer.from(data) : data);
-  });
-  const createFileExclusive = vi.fn(async ({ filePath, data }) => {
-    if (files.has(filePath)) {
-      return "exists" as const;
-    }
-    files.set(filePath, Buffer.isBuffer(data) ? Buffer.from(data) : data);
-    return "created" as const;
-  });
-  const mkdirp = vi.fn(async () => {});
-  const bridge: SandboxFsBridge = {
-    resolvePath: ({ filePath }) => ({
-      relativePath: filePath,
-      containerPath: `/sandbox/${filePath}`,
-    }),
-    readFile: async ({ filePath }) => {
-      const contents = files.get(filePath);
-      return typeof contents === "string"
-        ? Buffer.from(contents, "utf8")
-        : Buffer.from(contents ?? "");
-    },
-    writeFile,
-    ...(options.supportsExclusiveCreate === false ? {} : { createFileExclusive }),
-    remove: async ({ filePath }) => {
-      files.delete(filePath);
-    },
-    rename: async ({ from, to }) => {
-      const contents = files.get(from);
-      if (contents !== undefined) {
-        files.set(to, contents);
-        files.delete(from);
-      }
-    },
-    stat: async ({ filePath }) => {
-      const contents = files.get(filePath);
-      return contents === undefined
-        ? null
-        : { type: "file", size: Buffer.byteLength(contents), mtimeMs: 0 };
-    },
-    mkdirp,
-  };
-  return {
-    files,
-    bridge,
-    writeFile,
-    createFileExclusive,
-    mkdirp,
-    options: {
-      cwd: "/local/workspace",
-      sandbox: {
-        root: "/local/workspace",
-        bridge,
-      },
-    },
-  };
 }
 
 async function expectOutsideWriteRejected(params: {
@@ -201,15 +135,6 @@ describe("applyPatch", () => {
 
     expect(memory.files.get("/sandbox/hello.txt")).toBe("hello\n");
     expect(result.summary.added).toEqual(["hello.txt"]);
-  });
-
-  it("writes new Windows batch files with CRLF line endings", async () => {
-    const memory = createMemoryPatchSandbox();
-    await applyPatch(
-      "*** Begin Patch\n*** Add File: launch.cmd\n+@echo off\n+echo ready\n*** End Patch",
-      memory.options,
-    );
-    expect(memory.files.get("/sandbox/launch.cmd")).toBe("@echo off\r\necho ready\r\n");
   });
 
   it("rejects an add hunk that targets an existing file", async () => {
@@ -422,24 +347,6 @@ describe("applyPatch", () => {
     expect(memory.files.get("/sandbox/dest.txt")).toBe("foo\nbaz\n");
     expect(memory.files.has("/sandbox/source.txt")).toBe(false);
     expect(result.summary.modified).toEqual(["dest.txt"]);
-  });
-
-  it("normalizes moved Windows batch files to CRLF", async () => {
-    const memory = createMemoryPatchSandbox({
-      "source.txt": "@echo off\necho hello\n",
-    });
-    const patch = `*** Begin Patch
-*** Update File: source.txt
-*** Move to: launch.cmd
-@@
- @echo off
- echo hello
-*** End Patch`;
-
-    await applyPatch(patch, memory.options);
-
-    expect(memory.files.get("/sandbox/launch.cmd")).toBe("@echo off\r\necho hello\r\n");
-    expect(memory.files.has("/sandbox/source.txt")).toBe(false);
   });
 
   it("updates in place when move target resolves to the source file", async () => {

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import { Type } from "typebox";
 import { createAbortError } from "../infra/abort-signal.js";
 import { PATH_ALIAS_POLICIES, type PathAliasPolicy } from "../infra/path-alias-guards.js";
+import { normalizeNewWindowsBatchContent } from "../infra/windows-batch.js";
 import {
   type ApplyPatchFileOptions,
   createPatchTarget,
@@ -189,7 +190,7 @@ async function applyPatch(input: string, options: ApplyPatchOptions): Promise<Ap
         await ensureDir(target.resolved, fileOps);
         await createPatchTarget({
           target,
-          contents: hunk.contents,
+          contents: normalizeNewWindowsBatchContent(target.resolved, hunk.contents),
           ops: fileOps,
           hint: `Use "*** Update File: ${target.display}" to change it, or delete it earlier in the same patch.`,
         });

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -232,7 +232,7 @@ async function applyPatch(input: string, options: ApplyPatchOptions): Promise<Ap
             noOpPaths.delete(target.display);
             await createPatchTarget({
               target: moveTarget,
-              contents: applied,
+              contents: normalizeNewWindowsBatchContent(moveTarget.resolved, applied),
               ops: fileOps,
               hint: "Delete it earlier in the same patch to replace it.",
             });

--- a/src/agents/apply-patch.windows-batch.test.ts
+++ b/src/agents/apply-patch.windows-batch.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { applyPatch, createMemoryPatchSandbox } from "./apply-patch.test-support.js";
+
+describe("applyPatch Windows batch creation", () => {
+  it("writes new Windows batch files with CRLF line endings", async () => {
+    const memory = createMemoryPatchSandbox();
+    await applyPatch(
+      "*** Begin Patch\n*** Add File: launch.cmd\n+@echo off\n+echo ready\n*** End Patch",
+      memory.options,
+    );
+    expect(memory.files.get("/sandbox/launch.cmd")).toBe("@echo off\r\necho ready\r\n");
+  });
+
+  it("normalizes moved Windows batch files to CRLF", async () => {
+    const memory = createMemoryPatchSandbox({
+      "source.txt": "@echo off\necho hello\n",
+    });
+    const patch = `*** Begin Patch
+*** Update File: source.txt
+*** Move to: launch.cmd
+@@
+ @echo off
+ echo hello
+*** End Patch`;
+
+    await applyPatch(patch, memory.options);
+
+    expect(memory.files.get("/sandbox/launch.cmd")).toBe("@echo off\r\necho hello\r\n");
+    expect(memory.files.has("/sandbox/source.txt")).toBe(false);
+  });
+});

--- a/src/agents/sessions/tools/write.test.ts
+++ b/src/agents/sessions/tools/write.test.ts
@@ -213,6 +213,20 @@ describe("write tool", () => {
     });
   });
 
+  it("writes new Windows batch files with CRLF line endings", async () => {
+    const tool = createWriteTool(tmpDir);
+
+    await tool.execute(
+      "call-1",
+      { path: "launch.cmd", content: "@echo off\necho ready\n" },
+      undefined,
+    );
+
+    await expect(fs.readFile(path.join(tmpDir, "launch.cmd"), "utf8")).resolves.toBe(
+      "@echo off\r\necho ready\r\n",
+    );
+  });
+
   it("keeps oversized created-file details bounded", async () => {
     await createTempPath("large-created.txt");
     const content = "x".repeat(1024 * 1024 + 1);

--- a/src/agents/sessions/tools/write.test.ts
+++ b/src/agents/sessions/tools/write.test.ts
@@ -227,6 +227,30 @@ describe("write tool", () => {
     );
   });
 
+  it("keeps repeated LF writes to a new Windows batch file as a CRLF no-op", async () => {
+    const tool = createWriteTool(tmpDir);
+    const content = "@echo off\necho ready\n";
+
+    await tool.execute("call-1", { path: "launch.cmd", content }, undefined);
+    const result = await tool.execute("call-2", { path: "launch.cmd", content }, undefined);
+
+    expect(result.details).toEqual({ changed: false });
+    expect((result as { terminate?: boolean }).terminate).toBe(true);
+    await expect(fs.readFile(path.join(tmpDir, "launch.cmd"), "utf8")).resolves.toBe(
+      "@echo off\r\necho ready\r\n",
+    );
+  });
+
+  it("preserves an existing LF Windows batch file when its content changes", async () => {
+    const filePath = await createTempPath("legacy.cmd");
+    await fs.writeFile(filePath, "@echo off\necho old\n", "utf8");
+    const tool = createWriteTool(tmpDir);
+
+    await tool.execute("call-1", { path: "legacy.cmd", content: "@echo off\necho new\n" }, undefined);
+
+    await expect(fs.readFile(filePath, "utf8")).resolves.toBe("@echo off\necho new\n");
+  });
+
   it("keeps oversized created-file details bounded", async () => {
     await createTempPath("large-created.txt");
     const content = "x".repeat(1024 * 1024 + 1);

--- a/src/agents/sessions/tools/write.ts
+++ b/src/agents/sessions/tools/write.ts
@@ -341,7 +341,11 @@ async function readOriginalWriteState(
   if (stat.type !== "file") {
     return { state: "unknown", beforeStat: stat };
   }
-  if (stat.size !== Buffer.byteLength(content, "utf8")) {
+  const normalizedContent = normalizeNewWindowsBatchContent(absolutePath, content);
+  if (
+    stat.size !== Buffer.byteLength(content, "utf8") &&
+    stat.size !== Buffer.byteLength(normalizedContent, "utf8")
+  ) {
     return { state: "different", beforeStat: stat };
   }
   if (!ops.readFile || stat.size > WRITE_PRECHECK_READ_LIMIT_BYTES) {
@@ -357,7 +361,11 @@ async function readOriginalWriteState(
       return { state: "unknown", beforeStat: stat, readAttempted: true };
     }
     return {
-      state: originalText === content ? "same" : "different",
+      state:
+        originalText === content ||
+        (normalizedContent !== content && originalText === normalizedContent)
+          ? "same"
+          : "different",
       beforeStat: stat,
       beforeText: originalText,
       readAttempted: true,

--- a/src/agents/sessions/tools/write.ts
+++ b/src/agents/sessions/tools/write.ts
@@ -14,6 +14,7 @@ import { Container, Text } from "@earendil-works/pi-tui";
 import { structuredPatch } from "diff";
 import { Type } from "typebox";
 import { isMissingPathError } from "../../../infra/errors.js";
+import { normalizeNewWindowsBatchContent } from "../../../infra/windows-batch.js";
 import { keyHint } from "../../modes/interactive/components/keybinding-hints.js";
 import { getLanguageFromPath, highlightCode } from "../../modes/interactive/theme/theme.js";
 import type { AgentTool } from "../../runtime/index.js";
@@ -553,26 +554,36 @@ export function createWriteToolDefinition(
             terminate: true,
           };
         }
-        const details = await resolveWriteDetails({ absolutePath, content, ops, path, precheck });
+        const persistedContent =
+          precheck.beforeStat === null
+            ? normalizeNewWindowsBatchContent(absolutePath, content)
+            : content;
+        const details = await resolveWriteDetails({
+          absolutePath,
+          content: persistedContent,
+          ops,
+          path,
+          precheck,
+        });
         try {
           await ops.mkdir(dir);
           if (signal?.aborted) {
             throw new Error("Operation aborted");
           }
-          await ops.writeFile(absolutePath, content);
+          await ops.writeFile(absolutePath, persistedContent);
           if (signal?.aborted) {
             throw new Error("Operation aborted");
           }
-          if (!(await verifyPersistedUtf8File(absolutePath, content, ops))) {
+          if (!(await verifyPersistedUtf8File(absolutePath, persistedContent, ops))) {
             throw new Error(
               `Write verification failed for ${path}: the persisted regular file does not match the requested content. Inspect the target and retry.`,
             );
           }
-          return successfulWriteResult(path, content, details);
+          return successfulWriteResult(path, persistedContent, details);
         } catch (error: unknown) {
           const recovered = await recoverSuccessfulWrite({
             absolutePath,
-            content,
+            content: persistedContent,
             error,
             ops,
             path,

--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -672,6 +672,7 @@ exit 0
         OPENCLAW_PROFILE: "default",
       });
       expect(scriptPath.endsWith(".cmd")).toBe(true);
+      expect(content.replaceAll("\r\n", "")).not.toContain("\n");
       expect(content).toContain("@echo off");
       expect(content).toContain("powershell -NoProfile -ExecutionPolicy Bypass -Command");
       expect(content).not.toContain("powershell -NoProfile -ExecutionPolicy Bypass -File");

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -754,13 +754,11 @@ exit $status
       return null;
     }
 
+    scriptContent = normalizeNewWindowsBatchContent(filename, scriptContent);
     const scriptDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restart-"));
     const scriptPath = path.join(scriptDir, filename);
     try {
-      await fs.writeFile(scriptPath, normalizeNewWindowsBatchContent(scriptPath, scriptContent), {
-        mode: 0o755,
-        flag: "wx",
-      });
+      await fs.writeFile(scriptPath, scriptContent, { mode: 0o755, flag: "wx" });
     } catch (error) {
       await fs.rm(scriptDir, { recursive: true, force: true }).catch(() => {});
       throw error;

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -18,8 +18,8 @@ import {
   resolveGatewayRestartLogPath,
   shellEscapeRestartLogValue,
 } from "../../daemon/restart-logs.js";
-import { normalizeNewWindowsBatchContent } from "../../infra/windows-batch.js";
 import { getWindowsCmdExePath } from "../../infra/windows-install-roots.js";
+import { writeRestartScriptFile } from "./restart-script-file.js";
 
 /**
  * Shell-escape a string for embedding in single-quoted shell arguments.
@@ -754,16 +754,7 @@ exit $status
       return null;
     }
 
-    scriptContent = normalizeNewWindowsBatchContent(filename, scriptContent);
-    const scriptDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restart-"));
-    const scriptPath = path.join(scriptDir, filename);
-    try {
-      await fs.writeFile(scriptPath, scriptContent, { mode: 0o755, flag: "wx" });
-    } catch (error) {
-      await fs.rm(scriptDir, { recursive: true, force: true }).catch(() => {});
-      throw error;
-    }
-    return scriptPath;
+    return await writeRestartScriptFile(filename, scriptContent);
   } catch {
     // If we can't write the script, we'll fall back to the standard restart method
     return null;

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -18,6 +18,7 @@ import {
   resolveGatewayRestartLogPath,
   shellEscapeRestartLogValue,
 } from "../../daemon/restart-logs.js";
+import { normalizeNewWindowsBatchContent } from "../../infra/windows-batch.js";
 import { getWindowsCmdExePath } from "../../infra/windows-install-roots.js";
 
 /**
@@ -756,7 +757,10 @@ exit $status
     const scriptDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restart-"));
     const scriptPath = path.join(scriptDir, filename);
     try {
-      await fs.writeFile(scriptPath, scriptContent, { mode: 0o755, flag: "wx" });
+      await fs.writeFile(scriptPath, normalizeNewWindowsBatchContent(scriptPath, scriptContent), {
+        mode: 0o755,
+        flag: "wx",
+      });
     } catch (error) {
       await fs.rm(scriptDir, { recursive: true, force: true }).catch(() => {});
       throw error;

--- a/src/cli/update-cli/restart-script-file.ts
+++ b/src/cli/update-cli/restart-script-file.ts
@@ -1,0 +1,19 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { normalizeNewWindowsBatchContent } from "../../infra/windows-batch.js";
+
+export async function writeRestartScriptFile(filename: string, content: string): Promise<string> {
+  const scriptDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restart-"));
+  const scriptPath = path.join(scriptDir, filename);
+  try {
+    await fs.writeFile(scriptPath, normalizeNewWindowsBatchContent(filename, content), {
+      mode: 0o755,
+      flag: "wx",
+    });
+  } catch (error) {
+    await fs.rm(scriptDir, { recursive: true, force: true }).catch(() => {});
+    throw error;
+  }
+  return scriptPath;
+}

--- a/src/infra/windows-batch.test.ts
+++ b/src/infra/windows-batch.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { normalizeNewWindowsBatchContent } from "./windows-batch.js";
+
+describe("normalizeNewWindowsBatchContent", () => {
+  it.each(["script.cmd", "script.CMD", "script.bat"])("normalizes %s to CRLF", (filePath) => {
+    expect(normalizeNewWindowsBatchContent(filePath, "first\nsecond\r\nthird\rfourth")).toBe(
+      "first\r\nsecond\r\nthird\r\nfourth",
+    );
+  });
+
+  it("leaves non-batch files unchanged", () => {
+    const content = "first\nsecond\r\n";
+    expect(normalizeNewWindowsBatchContent("notes.txt", content)).toBe(content);
+  });
+});

--- a/src/infra/windows-batch.ts
+++ b/src/infra/windows-batch.ts
@@ -1,0 +1,8 @@
+import path from "node:path";
+
+export function normalizeNewWindowsBatchContent(filePath: string, content: string): string {
+  if (![".bat", ".cmd"].includes(path.extname(filePath).toLowerCase())) {
+    return content;
+  }
+  return content.replace(/\r\n|\r|\n/g, "\r\n");
+}


### PR DESCRIPTION
Closes #119484

## What Problem This Solves

Fixes an issue where users creating Windows batch files through the agent tools or update flow could receive LF-only scripts that the native Windows command interpreter parses unreliably.

## Why This Change Was Made

New Windows batch content is normalized to CRLF at the shared boundary used by patch-created files, session writes, and the Windows update restart script. Existing patch-update line-ending preservation and non-batch files remain unchanged.

## User Impact

Newly generated Windows batch files now use native CRLF line endings expected by Windows.

## Evidence

Final exact-head proof at `39da6b0a8dda323472fa092cf41e2ee74eba17b9`:

- Real Windows updater proof: `prepareRestartScript` generated the actual `.cmd` restart script at the final head; the persisted bytes were 17,117 bytes with 502 CRLF separators and no lone LF bytes. Running it with `cmd.exe /d /c` exited 0 and produced an observable downstream `powershell` marker.
- Inspectable updater output:
  ```text
  {"scriptExtension":".cmd","byteLength":17117,"crlfCount":502,"loneLf":false,"cmdExit":0,"marker":"fake-powershell"}
  ```
- Real Windows patch proof: applying an LF update-and-move to `launch.cmd` produced bytes with CRLF separators only (`@echo off<CR><LF>echo CRLF proof<CR><LF>`), and `cmd.exe /d /c launch.cmd` printed `CRLF proof`.
- Focused supporting tests: `node scripts/run-vitest.mjs src/agents/apply-patch.windows-batch.test.ts src/agents/sessions/tools/write.test.ts src/cli/update-cli/restart-helper.test.ts src/infra/windows-batch.test.ts` passed the PR-owned Windows batch cases; the updater case passed with 49 tests skipped and the batch normalizer, patch, and write cases passed.
- Supporting checks: targeted `oxfmt --check` on all 11 changed files and `git diff --check` passed. Fresh autoreview reported no accepted/actionable findings.

Proof boundary: source-checkout Windows behavior proof covers patch-created batch files, session-created batch files, and the actual updater restart-script writer plus `cmd.exe` execution. It does not claim a full installed update service restart.
