### PR TITLE
fix(memory): report SQLite sessions in status totals

### DIFF
--- a/extensions/memory-core/src/cli-runtime-common.ts
+++ b/extensions/memory-core/src/cli-runtime-common.ts
@@ -2,7 +2,7 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { listAgentIds } from "openclaw/plugin-sdk/agent-runtime";
-import { isUsageCountedSessionTranscriptFileName } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
+import { listSessionTranscriptCorpusEntriesForAgent } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
 import type { PluginStateLeaseRunner } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { buildAgentSessionKey } from "openclaw/plugin-sdk/routing";
 import {
@@ -246,22 +246,20 @@ async function scanSessionFiles(agentId: string): Promise<SourceScan> {
   const issues: string[] = [];
   const sessionsDir = resolveSessionTranscriptsDirForAgent(agentId);
   try {
-    const entries = await fs.readdir(sessionsDir, { withFileTypes: true });
-    const totalFiles = entries.filter(
-      (entry) => entry.isFile() && isUsageCountedSessionTranscriptFileName(entry.name),
-    ).length;
-    return { source: "sessions", totalFiles, issues };
+    await fs.readdir(sessionsDir);
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
     if (code === "ENOENT") {
       issues.push(`sessions directory missing (${shortenHomePath(sessionsDir)})`);
-      return { source: "sessions", totalFiles: 0, issues };
+    } else {
+      issues.push(
+        `sessions directory not accessible (${shortenHomePath(sessionsDir)}): ${code ?? "error"}`,
+      );
+      return { source: "sessions", totalFiles: null, issues };
     }
-    issues.push(
-      `sessions directory not accessible (${shortenHomePath(sessionsDir)}): ${code ?? "error"}`,
-    );
-    return { source: "sessions", totalFiles: null, issues };
   }
+  const corpusEntries = await listSessionTranscriptCorpusEntriesForAgent(agentId);
+  return { source: "sessions", totalFiles: corpusEntries.length, issues };
 }
 async function scanMemoryFiles(
   workspaceDir: string,

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -4,6 +4,10 @@ import os from "node:os";
 import path from "node:path";
 import { Command } from "commander";
 import { resolveSessionTranscriptsDirForAgent as resolveTestSessionTranscriptsDirForAgent } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
+import {
+  clearConfigCache,
+  clearRuntimeConfigSnapshot,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
 import {
@@ -149,6 +153,8 @@ beforeEach(() => {
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
+  clearRuntimeConfigSnapshot();
+  clearConfigCache();
   process.exitCode = undefined;
   setVerbose(false);
 });
@@ -513,6 +519,153 @@ describe("memory cli", () => {
     expectLogged(log, "FTS: ready");
     expectLogged(log, "Embedding cache: enabled (123 entries)");
     expect(close).toHaveBeenCalled();
+  });
+
+  it("counts the canonical SQLite session corpus in overall and per-source status totals", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const stateDir = path.join(workspaceDir, "state");
+      vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+      vi.stubEnv("OPENCLAW_CONFIG_PATH", path.join(workspaceDir, "openclaw.json"));
+      clearRuntimeConfigSnapshot();
+      clearConfigCache();
+      await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "# Memory\n", "utf-8");
+
+      const agentId = "main";
+      const sessionsDir = resolveTestSessionTranscriptsDirForAgent(agentId);
+      const storePath = path.join(sessionsDir, "sessions.json");
+      const sessionId = "sqlite-status";
+      const sessionKey = `agent:${agentId}:chat:${sessionId}`;
+      await fs.mkdir(sessionsDir, { recursive: true });
+      await upsertSessionEntry({
+        agentId,
+        sessionKey,
+        storePath,
+        entry: { sessionId, updatedAt: 1 },
+      });
+      await appendSessionTranscriptMessageByIdentity({
+        agentId,
+        sessionId,
+        sessionKey,
+        storePath,
+        message: { role: "user", content: "SQLite-only status transcript" },
+      });
+      await fs.writeFile(
+        path.join(sessionsDir, `${sessionId}.jsonl.reset.2026-08-05T00-00-00.000Z`),
+        "",
+      );
+      await fs.writeFile(
+        path.join(sessionsDir, `${sessionId}.jsonl.deleted.2026-08-05T00-01-00.000Z`),
+        "",
+      );
+      await expectPathMissing(path.join(sessionsDir, `${sessionId}.jsonl`));
+
+      const close = vi.fn(async () => {});
+      mockManager({
+        status: () =>
+          makeMemoryStatus({
+            files: 4,
+            chunks: 8,
+            workspaceDir,
+            sources: ["memory", "sessions"],
+            sourceCounts: [
+              { source: "memory", files: 1, chunks: 2 },
+              { source: "sessions", files: 3, chunks: 6 },
+            ],
+          }),
+        close,
+      });
+
+      const log = spyRuntimeLogs(defaultRuntime);
+      await runMemoryCli(["status"]);
+
+      expectLogged(log, "Indexed: 4/4 files · 8 chunks");
+      expectLogged(log, "memory · 1/1 files · 2 chunks");
+      expectLogged(log, "sessions · 3/3 files · 6 chunks");
+      expect(close).toHaveBeenCalled();
+    });
+  });
+
+  it("keeps a missing sessions-directory diagnostic while counting a configured SQLite store", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const stateDir = path.join(workspaceDir, "state");
+      const storePath = path.join(workspaceDir, "configured-sessions", "sessions.json");
+      const configPath = path.join(workspaceDir, "openclaw.json");
+      vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+      vi.stubEnv("OPENCLAW_CONFIG_PATH", configPath);
+      await fs.writeFile(configPath, JSON.stringify({ session: { store: storePath } }));
+      clearRuntimeConfigSnapshot();
+      clearConfigCache();
+
+      const agentId = "main";
+      const sessionId = "configured-status";
+      const sessionKey = `agent:${agentId}:chat:${sessionId}`;
+      await upsertSessionEntry({
+        agentId,
+        sessionKey,
+        storePath,
+        entry: { sessionId, updatedAt: 1 },
+      });
+      await appendSessionTranscriptMessageByIdentity({
+        agentId,
+        sessionId,
+        sessionKey,
+        storePath,
+        message: { role: "user", content: "Configured SQLite status transcript" },
+      });
+      const sessionsDir = resolveTestSessionTranscriptsDirForAgent(agentId);
+      await expectPathMissing(sessionsDir);
+
+      const close = vi.fn(async () => {});
+      mockManager({
+        status: () =>
+          makeMemoryStatus({
+            files: 1,
+            chunks: 1,
+            workspaceDir,
+            sources: ["sessions"],
+            sourceCounts: [{ source: "sessions", files: 1, chunks: 1 }],
+          }),
+        close,
+      });
+
+      const log = spyRuntimeLogs(defaultRuntime);
+      await runMemoryCli(["status"]);
+
+      expectLogged(log, "Indexed: 1/1 files · 1 chunks");
+      expectLogged(log, "sessions · 1/1 files · 1 chunks");
+      expectLogged(log, "sessions directory missing (");
+      expect(close).toHaveBeenCalled();
+    });
+  });
+
+  it("keeps inaccessible session directories as an unknown status total", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      vi.stubEnv("OPENCLAW_STATE_DIR", path.join(workspaceDir, "state"));
+      vi.spyOn(fs, "readdir").mockRejectedValueOnce(
+        Object.assign(new Error("permission denied"), { code: "EACCES" }),
+      );
+      const close = vi.fn(async () => {});
+      mockManager({
+        status: () =>
+          makeMemoryStatus({
+            files: 1,
+            chunks: 1,
+            workspaceDir,
+            sources: ["sessions"],
+            sourceCounts: [{ source: "sessions", files: 1, chunks: 1 }],
+          }),
+        close,
+      });
+
+      const log = spyRuntimeLogs(defaultRuntime);
+      await runMemoryCli(["status"]);
+
+      expectLogged(log, "Indexed: 1/? files · 1 chunks");
+      expectLogged(log, "sessions · 1/? files · 1 chunks");
+      expectLogged(log, "sessions directory not accessible (");
+      expectLogged(log, "EACCES");
+      expect(close).toHaveBeenCalled();
+    });
   });
 
   it("still aborts status when its own memory SecretRef cannot be resolved", async () => {


### PR DESCRIPTION
Fixes #119510

## What Problem This Solves

Fixes an issue where `openclaw memory status` could report more indexed session files than total session files after active transcripts moved to SQLite. The indexer counted the canonical SQLite-plus-archive corpus, while the CLI denominator counted only files in the sessions directory.

## Why This Change Was Made

Status now uses `listSessionTranscriptCorpusEntriesForAgent()` for the sessions denominator, matching the indexer's canonical ownership boundary. The sessions-directory read remains only for diagnostics: a missing directory is reported without hiding active SQLite sessions, while an inaccessible directory keeps the total unknown.

This does not change config, Plugin SDK contracts, schemas, migrations, dependencies, or feature behavior.

## User Impact

Operators with SQLite-backed active transcripts now see accurate overall and per-source `N/M` totals. Missing or inaccessible session-directory diagnostics remain visible and actionable.

## Evidence

- Current-main regression reproduced in focused tests:
  - active SQLite transcript plus reset/deleted archives rendered `Indexed: 4/3` and `sessions · 3/2`
  - configured SQLite store with no default sessions directory rendered `Indexed: 1/0`
- `node scripts/run-vitest.mjs extensions/memory-core/src/cli.test.ts` - 85 passed
- `node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/session-files.test.ts` - 39 passed
- `node scripts/check-changed.mjs -- extensions/memory-core/src/cli-runtime-common.ts extensions/memory-core/src/cli.test.ts` - passed on Blacksmith Testbox `tbx_01kz8d3rn9teddfajasv3erc18`
- Testbox workflow: https://github.com/openclaw/openclaw/actions/runs/30985089419
- `git diff --check` - passed
- Autoreview: no P0/P1 findings; patch correct, confidence 0.94
- Production LOC: `+9/-11`; tests: `+153/-0`

Punchcard-Session: clear-orchard-lantern-bc

Punchcard-Session: clear-orchard-lantern-bc

