### PR TITLE
fix(tooling): balance constrained tsgo CPU usage

### DIFF
--- a/scripts/lib/local-heavy-check-runtime.mjs
+++ b/scripts/lib/local-heavy-check-runtime.mjs
@@ -6,7 +6,7 @@ import path from "node:path";
 
 const GIB = 1024 ** 3;
 const DEFAULT_LOCAL_GO_GC = "30";
-const DEFAULT_LOCAL_GO_MAX_PROCS = "1";
+const DEFAULT_LOCAL_GO_MAX_PROCS = 2;
 const DEFAULT_LOCAL_GO_MEMORY_LIMIT = "3GiB";
 const DEFAULT_LOCAL_TSGO_BUILD_INFO_FILE = ".artifacts/tsgo-cache/root.tsbuildinfo";
 const DEFAULT_LOCK_TIMEOUT_MS = 10 * 60 * 1000;
@@ -138,12 +138,15 @@ export function applyLocalTsgoPolicy(args, env, hostResources) {
     );
   }
 
-  if (shouldThrottleLocalHeavyChecks(nextEnv, hostResources, "auto")) {
+  const resolvedHostResources = resolveHostResources(hostResources);
+  if (shouldThrottleLocalHeavyChecks(nextEnv, resolvedHostResources, "auto")) {
     insertBeforeSeparator(nextArgs, "--singleThreaded");
     insertBeforeSeparator(nextArgs, "--checkers", "1");
 
     if (!nextEnv.GOMAXPROCS) {
-      nextEnv.GOMAXPROCS = DEFAULT_LOCAL_GO_MAX_PROCS;
+      nextEnv.GOMAXPROCS = String(
+        Math.min(DEFAULT_LOCAL_GO_MAX_PROCS, Math.max(1, resolvedHostResources.logicalCpuCount)),
+      );
     }
     if (!nextEnv.GOGC) {
       nextEnv.GOGC = DEFAULT_LOCAL_GO_GC;

--- a/test/scripts/local-heavy-check-runtime.test.ts
+++ b/test/scripts/local-heavy-check-runtime.test.ts
@@ -148,7 +148,7 @@ describe("local-heavy-check-runtime", () => {
       "--checkers",
       "1",
     ]);
-    expect(env.GOMAXPROCS).toBe("1");
+    expect(env.GOMAXPROCS).toBe("2");
     expect(env.GOGC).toBe("30");
     expect(env.GOMEMLIMIT).toBe("3GiB");
   });
@@ -257,9 +257,18 @@ describe("local-heavy-check-runtime", () => {
       "--checkers",
       "1",
     ]);
-    expect(env.GOMAXPROCS).toBe("1");
+    expect(env.GOMAXPROCS).toBe("2");
     expect(env.GOGC).toBe("30");
     expect(env.GOMEMLIMIT).toBe("3GiB");
+  });
+
+  it("does not oversubscribe a single-CPU host", () => {
+    const { env } = applyLocalTsgoPolicy([], makeEnv({ OPENCLAW_LOCAL_CHECK_MODE: "throttled" }), {
+      logicalCpuCount: 1,
+      totalMemoryBytes: 16 * 1024 ** 3,
+    });
+
+    expect(env.GOMAXPROCS).toBe("1");
   });
 
   it("allows forcing full-speed tsgo runs on roomy hosts", () => {


### PR DESCRIPTION
## Summary

- adjust the constrained local `tsgo` scheduler cap from one CPU to at most two CPUs
- keep single-CPU hosts at one slot and preserve explicit `GOMAXPROCS` overrides
- leave roomy/full-speed runs and CI uncapped

## Why

PR #119517 fixed 300-500% local CPU saturation by setting `GOMAXPROCS=1`. Follow-up benchmarking on the same 4-vCPU, 16-GiB Testbox showed that value overcorrects:

| Core-test graph | Wall time | CPU |
| --- | ---: | ---: |
| `GOMAXPROCS=1` | 177.4s average | 100% |
| `GOMAXPROCS=2` | 114.3s average | 195-196% |
| uncapped | 86.0s average | 377-378% |

A two-slot cap keeps roughly half of a constrained host available while recovering about 36% of the time lost by the one-slot cap. An exact wrapper run completed in 96.8s at 192% CPU and reported `gomaxprocs=2`.

## Validation

- focused policy tests: 36/36 passed
- actual wrapper: constrained=2, explicit override=3, full mode=host default
- single-CPU policy test: capped at 1
- formatter and focused oxlint: passed
- structured autoreview: clean, 0.99 correctness
- Blacksmith Testbox `pnpm check:changed`: passed, including full typecheck and lint

Provider: Blacksmith Testbox; lease `tbx_01kz8d7tne07p0k222fkewxdz8`; run `30985232438`.

No agent transcript included.