### PR TITLE
fix(comfy): return SaveVideo outputs without image files

### DIFF
--- a/extensions/comfy/video-generation-provider.test.ts
+++ b/extensions/comfy/video-generation-provider.test.ts
@@ -26,6 +26,67 @@ function fetchGuardParams(call: number): { url?: unknown; auditContext?: unknown
   return params as { url?: unknown; auditContext?: unknown };
 }
 
+function mockLocalVideoResponses(params: {
+  promptId: string;
+  outputs: Record<string, unknown>;
+  download?: {
+    body: string;
+    contentType: string;
+  };
+}) {
+  fetchWithSsrFGuardMock
+    .mockResolvedValueOnce({
+      response: new Response(JSON.stringify({ prompt_id: params.promptId }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+      release: vi.fn(async () => {}),
+    })
+    .mockResolvedValueOnce({
+      response: new Response(
+        JSON.stringify({
+          [params.promptId]: {
+            outputs: params.outputs,
+          },
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+      release: vi.fn(async () => {}),
+    });
+
+  if (params.download) {
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(Buffer.from(params.download.body), {
+        status: 200,
+        headers: { "content-type": params.download.contentType },
+      }),
+      release: vi.fn(async () => {}),
+    });
+  }
+}
+
+function generateLocalVideo(outputNodeId?: string) {
+  const provider = buildComfyVideoGenerationProvider();
+  return provider.generateVideo({
+    provider: "comfy",
+    model: "workflow",
+    prompt: "animate a lobster",
+    cfg: buildComfyConfig({
+      video: {
+        workflow: {
+          "6": { inputs: { text: "" } },
+          "9": { inputs: {} },
+        },
+        promptNodeId: "6",
+        ...(outputNodeId ? { outputNodeId } : {}),
+      },
+    }),
+  });
+}
+
 describe("comfy video-generation provider", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -141,6 +202,119 @@ describe("comfy video-generation provider", () => {
         outputNodeIds: ["9"],
       },
     });
+  });
+
+  it("returns only MP4 video entries from mixed images buckets", async () => {
+    setComfyFetchGuardForTesting(fetchWithSsrFGuardMock);
+    mockLocalVideoResponses({
+      promptId: "local-video-mixed",
+      outputs: {
+        "2": {
+          images: [{ filename: "generated.png", subfolder: "", type: "output" }],
+        },
+        "4": {
+          images: [{ filename: "generated.mp4", subfolder: "", type: "output" }],
+        },
+      },
+      download: {
+        body: "mp4-data",
+        contentType: "video/mp4",
+      },
+    });
+
+    const result = await generateLocalVideo();
+
+    expect(fetchGuardParams(2).url).toBe(
+      "http://127.0.0.1:8188/view?filename=generated.mp4&subfolder=&type=output",
+    );
+    expect(result.videos).toEqual([
+      expect.objectContaining({
+        buffer: Buffer.from("mp4-data"),
+        mimeType: "video/mp4",
+        fileName: "generated.mp4",
+        metadata: {
+          nodeId: "4",
+          promptId: "local-video-mixed",
+        },
+      }),
+    ]);
+    expect(result.metadata?.outputNodeIds).toEqual(["4"]);
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("accepts uppercase WEBM names from the images bucket", async () => {
+    setComfyFetchGuardForTesting(fetchWithSsrFGuardMock);
+    mockLocalVideoResponses({
+      promptId: "local-video-webm",
+      outputs: {
+        "9": {
+          images: [{ name: "generated.WEBM", subfolder: "", type: "output" }],
+        },
+      },
+      download: {
+        body: "webm-data",
+        contentType: "video/webm",
+      },
+    });
+
+    const result = await generateLocalVideo();
+
+    expect(fetchGuardParams(2).url).toBe(
+      "http://127.0.0.1:8188/view?filename=generated.WEBM&subfolder=&type=output",
+    );
+    expect(result.videos[0]).toEqual(
+      expect.objectContaining({
+        buffer: Buffer.from("webm-data"),
+        mimeType: "video/webm",
+        fileName: "generated.WEBM",
+      }),
+    );
+  });
+
+  it("rejects images-only workflow output for video generation", async () => {
+    setComfyFetchGuardForTesting(fetchWithSsrFGuardMock);
+    mockLocalVideoResponses({
+      promptId: "local-video-images-only",
+      outputs: {
+        "9": {
+          images: [
+            { filename: "generated.png", subfolder: "", type: "output" },
+            { filename: "generated.jpg", subfolder: "", type: "output" },
+          ],
+        },
+      },
+    });
+
+    await expect(generateLocalVideo()).rejects.toThrow(
+      "Comfy workflow local-video-images-only completed without video outputs",
+    );
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("preserves legacy videos bucket output without filename filtering", async () => {
+    setComfyFetchGuardForTesting(fetchWithSsrFGuardMock);
+    mockLocalVideoResponses({
+      promptId: "local-video-legacy",
+      outputs: {
+        "9": {
+          videos: [{ filename: "generated.mov", subfolder: "", type: "output" }],
+        },
+      },
+      download: {
+        body: "legacy-video-data",
+        contentType: "video/quicktime",
+      },
+    });
+
+    const result = await generateLocalVideo("9");
+
+    expect(result.videos[0]).toEqual(
+      expect.objectContaining({
+        buffer: Buffer.from("legacy-video-data"),
+        mimeType: "video/quicktime",
+        fileName: "generated.mov",
+      }),
+    );
   });
 
   it("rejects generated video downloads that exceed the configured media cap", async () => {

--- a/extensions/comfy/video-generation-provider.ts
+++ b/extensions/comfy/video-generation-provider.ts
@@ -75,7 +75,7 @@ export function buildComfyVideoGenerationProvider(): VideoGenerationProvider {
         model: req.model,
         timeoutMs: req.timeoutMs,
         capability: "video",
-        outputKinds: ["gifs", "videos"],
+        outputKinds: ["images", "gifs", "videos"],
         inputImage: toComfyInputImage(req.inputImages?.[0]),
       });
 

--- a/extensions/comfy/workflow-runtime.ts
+++ b/extensions/comfy/workflow-runtime.ts
@@ -527,6 +527,7 @@ function collectOutputFiles(params: {
   history: ComfyHistoryEntry;
   outputNodeId?: string;
   outputKinds: readonly ComfyOutputKind[];
+  capability: ComfyCapability;
 }): Array<{ nodeId: string; file: ComfyOutputFile }> {
   const outputs = params.history.outputs;
   if (!outputs) {
@@ -546,6 +547,15 @@ function collectOutputFiles(params: {
         continue;
       }
       for (const file of bucket) {
+        if (params.capability === "video" && kind === "images") {
+          // Comfy SaveVideo shares the images bucket with real image outputs.
+          // Filter before download so mixed workflows cannot return images as videos.
+          const fileName =
+            normalizeOptionalString(file.filename) || normalizeOptionalString(file.name);
+          if (!fileName || !/\.(?:mp4|webm)$/i.test(fileName)) {
+            continue;
+          }
+        }
         files.push({ nodeId, file });
       }
     }
@@ -828,6 +838,7 @@ export async function runComfyWorkflow(params: {
     history: historyEntry,
     outputNodeId,
     outputKinds: params.outputKinds,
+    capability: params.capability,
   });
   if (outputFiles.length === 0) {
     throw new Error(`Comfy workflow ${promptId} completed without ${params.capability} outputs`);


### PR DESCRIPTION
Fixes #119468
Supersedes #119469

Credit to @beeven for identifying that ComfyUI's core `SaveVideo` output is reported through the `images` history bucket and for the original focused draft.

## What Problem This Solves

Fixes an issue where Comfy video workflows using core `SaveVideo` could finish successfully but OpenClaw would report that no video output was produced. Simply accepting every `images` entry was unsafe for workflows that also use `SaveImage`, because PNG or JPEG files could then be returned as generated videos.

## Why This Change Was Made

The Comfy video provider now inspects `images` alongside the existing `gifs` and `videos` buckets. Only `.mp4` and `.webm` filenames from the ambiguous `images` bucket are accepted, case-insensitively and using the same `filename`/`name` precedence as the downloader. Existing `gifs` and `videos` entries remain unrestricted.

## User Impact

ComfyUI workflows can use core `SaveVideo` without configuring a specific output node, including workflows that also save still images. OpenClaw returns only the generated video assets.

## Evidence

- Current upstream contract verified at ComfyUI commit `6f7cd7fceaaf60d2669b554936394a7412c6fde5`: `SaveVideo` uses `PreviewVideo`, whose history output key is `images`.
- Disposable real ComfyUI workflow: `EmptyImage` fed both `SaveImage` and `CreateVideo -> SaveVideo`, with no OpenClaw `outputNodeId`. Comfy history contained PNG and MP4 files together under `images`.
- Patched real-provider proof: the actual OpenClaw Comfy provider returned exactly one MP4 from node `4`; 1/1 live test passed. Crabbox run: https://crabbox.openclaw.ai/portal/runs/run_70295dce43cb
- Focused tests: `node scripts/run-vitest.mjs extensions/comfy/video-generation-provider.test.ts extensions/comfy/workflow-runtime.test.ts` - 14/14 passed.
- Blacksmith Testbox `tbx_01kz8dwwvs0h79evb2m03g67tx`: focused tests 14/14 passed; `pnpm check:changed` passed formatting, plugin boundaries, dependency guards, dead exports, extension typechecks, lint, database-first checks, media helper checks, and import-cycle checks. Workflow: https://github.com/openclaw/openclaw/actions/runs/30985977094
- Fresh Codex autoreview on the exact rebased branch: clean, no accepted/actionable findings, confidence 0.98.
- `git diff --check`

Punchcard-Session: clear-orchard-lantern-bc

Punchcard-Session: clear-orchard-lantern-bc

