### PR TITLE
fix(ci): keep release UI E2E on Blacksmith

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1445,7 +1445,7 @@ jobs:
     # Chromium, Vite, and the Vitest coordinator share this runner even though
     # files are serial. Four-vCPU runners let host-side CDP polling starve while
     # the browser kept making progress, producing rotating timeout failures.
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'blacksmith-8vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.dispatch_id == '' && !inputs.release_gate && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'blacksmith-8vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
     # Keep Chromium ownership serial within each independently required shard.
     timeout-minutes: 25
     strategy:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -180,7 +180,7 @@ for commands and recovery.
 
 | Runner                          | Jobs                                                                                                                                                                                                                                                                              |
 | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ubuntu-24.04`                  | `security-fast`, manual CI dispatch and non-canonical repository fallbacks, the QA Smoke aggregate, CodeQL security and quality scans, workflow-sanity, labeler, auto-response, the standalone Docs workflow, and the whole Install Smoke workflow                                |
+| `ubuntu-24.04`                  | `security-fast`, ordinary manual CI dispatch and non-canonical repository fallbacks, the QA Smoke aggregate, CodeQL security and quality scans, workflow-sanity, labeler, auto-response, the standalone Docs workflow, and the whole Install Smoke workflow                       |
 | `blacksmith-4vcpu-ubuntu-2404`  | `preflight`, `pnpm-store-warmup`, `native-i18n`, `checks-fast-core` except QA Smoke CI, plugin/channel contract shards, most bundled/lower-weight Linux Node shards, `check-*` lanes except `check-lint`, selected `check-additional-*` shards, `check-docs`, and `skills-python` |
 | `blacksmith-8vcpu-ubuntu-2404`  | Retained heavy Linux Node suites, the serial Chromium/Vite `checks-ui-e2e` lane, boundary/extension-heavy `check-additional-*` shards, and `android`                                                                                                                              |
 | `blacksmith-16vcpu-ubuntu-2404` | Automatic QA Smoke CI shards, `build-artifacts` in CI and Testbox, and `check-lint` (CPU-sensitive enough that 8 vCPU cost more than they saved)                                                                                                                                  |
@@ -208,7 +208,7 @@ concurrent repositories, retries, and burst overlap.
 
 The changed-target PR plan reduces the common Node test burst from 14 Blacksmith registrations to one. Broad-risk PRs keep the 14-registration compact fallback, so the worst case does not increase.
 
-Canonical-repo CI keeps Blacksmith as the default runner path for normal push and pull-request runs. `workflow_dispatch` and non-canonical repository runs use GitHub-hosted runners, but normal canonical runs do not currently probe Blacksmith queue health or automatically fall back to GitHub-hosted labels when Blacksmith is unavailable.
+Canonical-repo CI keeps Blacksmith as the default runner path for normal push and pull-request runs. Ordinary `workflow_dispatch` and non-canonical repository runs use GitHub-hosted runners. Trusted parent dispatches and exact release gates keep `checks-ui-e2e` on `blacksmith-8vcpu-ubuntu-2404` because Chromium, Vite, and CDP polling require more than the hosted four-vCPU capacity. Normal canonical runs do not currently probe Blacksmith queue health or automatically fall back to GitHub-hosted labels when Blacksmith is unavailable.
 
 ## Surface ratchets
 

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -4652,7 +4652,9 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     expect(uiE2e.if).toBe(
       "needs.preflight.outputs.run_ui_tests == 'true' && needs.preflight.outputs.compatibility_target != 'true'",
     );
-    expect(uiE2e["runs-on"]).toContain("blacksmith-8vcpu-ubuntu-2404");
+    expect(uiE2e["runs-on"]).toBe(
+      "${{ github.event_name == 'workflow_dispatch' && inputs.dispatch_id == '' && !inputs.release_gate && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'openclaw/openclaw') && 'blacksmith-8vcpu-ubuntu-2404' || 'ubuntu-24.04') }}",
+    );
     expect(uiE2e["runs-on"]).not.toBe(ui["runs-on"]);
     // Each Chromium worker keeps serial file ownership while all four shards
     // together remain required by the aggregate CI gate.


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where exact release-gate and parent-dispatched CI runs could time out in Control UI E2E while using the four-vCPU GitHub-hosted fallback, even though the same shard passed on the canonical eight-vCPU runner.

## Why This Change Was Made

Trusted parent dispatches and exact release gates now keep `checks-ui-e2e` on `blacksmith-8vcpu-ubuntu-2404`. Ordinary manual dispatches and non-canonical repositories still use GitHub-hosted runners.

## User Impact

No product behavior changes. Maintainers get reliable exact-head Control UI E2E evidence during release validation without broadening Blacksmith use for ordinary manual CI.

## Evidence

- Frozen release CI attempt 1 and its exact failed-job rerun both timed out in `config-safe-write.e2e.test.ts` on `ubuntu-24.04`: https://github.com/openclaw/openclaw/actions/runs/30978189930
- The same base SHA passed normal canonical CI on Blacksmith: https://github.com/openclaw/openclaw/actions/runs/30985443951
- Exact shard 4 proof on Blacksmith Testbox passed 37 files and 134 tests: https://github.com/openclaw/openclaw/actions/runs/30986568821
- Workflow guard, workflow sanity, docs inventory, and `check:changed` passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30986959762
- Fresh autoreview reported no accepted or actionable findings.

Punchcard-Session: amber-workshop-river-yr
