### PR TITLE
fix(status): resolve channels.modelByChannel in plugin direct status path

### DIFF
--- a/extensions/discord/src/monitor/native-command-status.ts
+++ b/extensions/discord/src/monitor/native-command-status.ts
@@ -16,6 +16,19 @@ import {
 } from "./native-command-reply.js";
 import type { DiscordConfig } from "./native-command.types.js";
 
+function resolveDiscordChatTypeLabel(channel?: { type?: number } | null): string | undefined {
+  if (!channel) {
+    return undefined;
+  }
+  if (channel.type === 1) {
+    return "dm";
+  }
+  if (channel.type === 3) {
+    return "group";
+  }
+  return "channel";
+}
+
 type ResolveDirectStatusReplyForSession = typeof resolveDirectStatusReplyForSession;
 
 export async function maybeDeliverDiscordDirectStatus(params: {
@@ -43,6 +56,7 @@ export async function maybeDeliverDiscordDirectStatus(params: {
   if (params.suppressReplies || params.commandName !== "status") {
     return null;
   }
+  const interactionChannel = params.interaction.channel;
   const statusReply = await params.resolveDirectStatusReplyForSession({
     cfg: params.cfg,
     sessionKey: params.commandTargetSessionKey?.trim() || params.sessionKey,
@@ -52,6 +66,9 @@ export async function maybeDeliverDiscordDirectStatus(params: {
     isAuthorizedSender: params.isAuthorizedSender,
     isGroup: params.isGroup,
     defaultGroupActivation: params.defaultGroupActivation,
+    targetChannelId: interactionChannel?.id ?? null,
+    targetGuildId: params.interaction.guild?.id ?? null,
+    chatType: resolveDiscordChatTypeLabel(interactionChannel),
   });
   if (statusReply && hasRenderableReplyPayload(statusReply)) {
     await deliverDiscordInteractionReply({

--- a/src/plugin-sdk/command-status.runtime.test.ts
+++ b/src/plugin-sdk/command-status.runtime.test.ts
@@ -25,9 +25,15 @@ vi.mock("../agents/agent-scope.js", () => ({
   resolveSessionAgentId,
 }));
 
-vi.mock("../agents/model-selection.js", () => ({
-  resolveDefaultModelForAgent,
-}));
+vi.mock("../agents/model-selection.js", async () => {
+  const actual = await vi.importActual<typeof import("../agents/model-selection.js")>(
+    "../agents/model-selection.js",
+  );
+  return {
+    ...actual,
+    resolveDefaultModelForAgent,
+  };
+});
 
 vi.mock("../auto-reply/reply/directive-handling.defaults.js", () => ({
   resolveDefaultModel,
@@ -252,5 +258,134 @@ describe("resolveDirectStatusReplyForSession", () => {
     });
 
     expectResolvedReasoningLevel(result, "stream");
+  });
+
+  it("applies channels.modelByChannel before building the status reply", async () => {
+    loadSessionEntry.mockReturnValue({
+      cfg: {
+        agents: {
+          defaults: {
+            reasoningDefault: "off",
+          },
+        },
+        channels: {
+          modelByChannel: {
+            discord: {
+              "*": "anthropic/claude-fable-5",
+            },
+          },
+        },
+      },
+      canonicalKey: "main",
+      entry: {
+        sessionId: "sess-main",
+      },
+      store: {},
+      storePath: "/tmp/sessions.json",
+    });
+
+    await resolveDirectStatusReplyForSession({
+      cfg: {},
+      sessionKey: "main",
+      channel: "discord",
+      senderIsOwner: true,
+      isAuthorizedSender: true,
+      isGroup: true,
+      defaultGroupActivation: () => "always",
+    });
+
+    const statusCall = requireBuildStatusReplyParams(0) as {
+      provider?: string;
+      model?: string;
+    };
+    expect(statusCall.provider).toBe("anthropic");
+    expect(statusCall.model).toBe("claude-fable-5");
+  });
+
+  it("preserves explicit session model override over channels.modelByChannel", async () => {
+    loadSessionEntry.mockReturnValue({
+      cfg: {
+        agents: {
+          defaults: {
+            reasoningDefault: "off",
+          },
+        },
+        channels: {
+          modelByChannel: {
+            discord: {
+              "*": "anthropic/claude-fable-5",
+            },
+          },
+        },
+      },
+      canonicalKey: "main",
+      entry: {
+        sessionId: "sess-main",
+        providerOverride: "xai",
+        modelOverride: "grok-4.3",
+      },
+      store: {},
+      storePath: "/tmp/sessions.json",
+    });
+
+    await resolveDirectStatusReplyForSession({
+      cfg: {},
+      sessionKey: "main",
+      channel: "discord",
+      senderIsOwner: true,
+      isAuthorizedSender: true,
+      isGroup: true,
+      defaultGroupActivation: () => "always",
+    });
+
+    const statusCall = requireBuildStatusReplyParams(0) as {
+      provider?: string;
+      model?: string;
+    };
+    expect(statusCall.provider).toBe("xai");
+    expect(statusCall.model).toBe("grok-4.3");
+  });
+
+  it("skips channels.modelByChannel when model selection is locked", async () => {
+    loadSessionEntry.mockReturnValue({
+      cfg: {
+        agents: {
+          defaults: {
+            reasoningDefault: "off",
+          },
+        },
+        channels: {
+          modelByChannel: {
+            discord: {
+              "*": "anthropic/claude-fable-5",
+            },
+          },
+        },
+      },
+      canonicalKey: "main",
+      entry: {
+        sessionId: "sess-main",
+        modelSelectionLocked: true,
+      },
+      store: {},
+      storePath: "/tmp/sessions.json",
+    });
+
+    await resolveDirectStatusReplyForSession({
+      cfg: {},
+      sessionKey: "main",
+      channel: "discord",
+      senderIsOwner: true,
+      isAuthorizedSender: true,
+      isGroup: true,
+      defaultGroupActivation: () => "always",
+    });
+
+    const statusCall = requireBuildStatusReplyParams(0) as {
+      provider?: string;
+      model?: string;
+    };
+    expect(statusCall.provider).toBe("openai");
+    expect(statusCall.model).toBe("gpt-5.4");
   });
 });

--- a/src/plugin-sdk/command-status.runtime.test.ts
+++ b/src/plugin-sdk/command-status.runtime.test.ts
@@ -484,7 +484,7 @@ describe("resolveDirectStatusReplyForSession", () => {
     expect(statusCall.model).toBe("claude-fable-5");
   });
 
-  it("preserves cached non-default model over channel override", async () => {
+  it("lets channel model override outrank cached last-run model", async () => {
     resolveDefaultModelForAgent.mockReturnValue({
       provider: "openai",
       model: "gpt-5.4",
@@ -493,7 +493,8 @@ describe("resolveDirectStatusReplyForSession", () => {
       defaultProvider: "openai",
       defaultModel: "gpt-5.4",
     });
-    // Cached fields differ from the default — a real prior user choice.
+    // Cached fields differ from the default, but they are last-run artifacts,
+    // not explicit user choices. The channel model override takes precedence.
     loadSessionEntry.mockReturnValue({
       cfg: {
         agents: { defaults: { reasoningDefault: "off" } },
@@ -527,7 +528,98 @@ describe("resolveDirectStatusReplyForSession", () => {
       provider?: string;
       model?: string;
     };
-    // Cached non-default wins over channel model.
+    // Channel model override wins over cached last-run fields.
+    expect(statusCall.provider).toBe("anthropic");
+    expect(statusCall.model).toBe("claude-fable-5");
+  });
+
+  it("preserves cached last-run model when no channel override resolves", async () => {
+    resolveDefaultModelForAgent.mockReturnValue({
+      provider: "openai",
+      model: "gpt-5.4",
+    });
+    resolveDefaultModel.mockReturnValue({
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.4",
+    });
+    loadSessionEntry.mockReturnValue({
+      cfg: {
+        agents: { defaults: { reasoningDefault: "off" } },
+      },
+      canonicalKey: "main",
+      entry: {
+        sessionId: "sess-main",
+        modelProvider: "google",
+        model: "gemini-flash-3",
+      },
+      store: {},
+      storePath: "/tmp/sessions.json",
+    });
+
+    await resolveDirectStatusReplyForSession({
+      cfg: {},
+      sessionKey: "main",
+      channel: "discord",
+      senderIsOwner: true,
+      isAuthorizedSender: true,
+      isGroup: true,
+      defaultGroupActivation: () => "always",
+    });
+
+    const statusCall = requireBuildStatusReplyParams(0) as {
+      provider?: string;
+      model?: string;
+    };
+    // No channel override — cached last-run fields are used.
+    expect(statusCall.provider).toBe("google");
+    expect(statusCall.model).toBe("gemini-flash-3");
+  });
+
+  it("uses live channel ID as groupId for non-DM channel model matching", async () => {
+    resolveDefaultModelForAgent.mockReturnValue({
+      provider: "openai",
+      model: "gpt-5.4",
+    });
+    resolveDefaultModel.mockReturnValue({
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.4",
+    });
+    loadSessionEntry.mockReturnValue({
+      cfg: {
+        agents: { defaults: { reasoningDefault: "off" } },
+        channels: {
+          modelByChannel: {
+            discord: {
+              "chan-456": "google/gemini-flash-3",
+              "*": "anthropic/claude-fable-5",
+            },
+          },
+        },
+      },
+      canonicalKey: "main",
+      entry: { sessionId: "sess-main" },
+      store: {},
+      storePath: "/tmp/sessions.json",
+    });
+
+    await resolveDirectStatusReplyForSession({
+      cfg: {},
+      sessionKey: "main",
+      channel: "discord",
+      senderIsOwner: true,
+      isAuthorizedSender: true,
+      isGroup: true,
+      defaultGroupActivation: () => "always",
+      targetChannelId: "chan-456",
+      targetGuildId: "guild-123",
+      chatType: "channel",
+    });
+
+    const statusCall = requireBuildStatusReplyParams(0) as {
+      provider?: string;
+      model?: string;
+    };
+    // Live channel ID is the modelByChannel key for guild channels.
     expect(statusCall.provider).toBe("google");
     expect(statusCall.model).toBe("gemini-flash-3");
   });

--- a/src/plugin-sdk/command-status.runtime.test.ts
+++ b/src/plugin-sdk/command-status.runtime.test.ts
@@ -388,4 +388,147 @@ describe("resolveDirectStatusReplyForSession", () => {
     expect(statusCall.provider).toBe("openai");
     expect(statusCall.model).toBe("gpt-5.4");
   });
+
+  it("uses live conversation facts for channel model matching via groupId", async () => {
+    resolveDefaultModelForAgent.mockReturnValue({
+      provider: "openai",
+      model: "gpt-5.4",
+    });
+    resolveDefaultModel.mockReturnValue({
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.4",
+    });
+    loadSessionEntry.mockReturnValue({
+      cfg: {
+        agents: { defaults: { reasoningDefault: "off" } },
+        channels: {
+          modelByChannel: {
+            discord: {
+              "guild-123": "google/gemini-flash-3",
+              "*": "anthropic/claude-fable-5",
+            },
+          },
+        },
+      },
+      canonicalKey: "main",
+      entry: { sessionId: "sess-main" },
+      store: {},
+      storePath: "/tmp/sessions.json",
+    });
+
+    await resolveDirectStatusReplyForSession({
+      cfg: {},
+      sessionKey: "main",
+      channel: "discord",
+      senderIsOwner: true,
+      isAuthorizedSender: true,
+      isGroup: true,
+      defaultGroupActivation: () => "always",
+      targetGuildId: "guild-123",
+    });
+
+    const statusCall = requireBuildStatusReplyParams(0) as {
+      provider?: string;
+      model?: string;
+    };
+    // Live guild id matched the specific guild key in the config.
+    expect(statusCall.provider).toBe("google");
+    expect(statusCall.model).toBe("gemini-flash-3");
+  });
+
+  it("lets channel model override cached last-run default fields", async () => {
+    resolveDefaultModelForAgent.mockReturnValue({
+      provider: "openai",
+      model: "gpt-5.4",
+    });
+    resolveDefaultModel.mockReturnValue({
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.4",
+    });
+    // Cached fields match the default — they are not a real user choice.
+    loadSessionEntry.mockReturnValue({
+      cfg: {
+        agents: { defaults: { reasoningDefault: "off" } },
+        channels: {
+          modelByChannel: {
+            discord: { "*": "anthropic/claude-fable-5" },
+          },
+        },
+      },
+      canonicalKey: "main",
+      entry: {
+        sessionId: "sess-main",
+        modelProvider: "openai",
+        model: "gpt-5.4",
+      },
+      store: {},
+      storePath: "/tmp/sessions.json",
+    });
+
+    await resolveDirectStatusReplyForSession({
+      cfg: {},
+      sessionKey: "main",
+      channel: "discord",
+      senderIsOwner: true,
+      isAuthorizedSender: true,
+      isGroup: true,
+      defaultGroupActivation: () => "always",
+    });
+
+    const statusCall = requireBuildStatusReplyParams(0) as {
+      provider?: string;
+      model?: string;
+    };
+    // Channel model wins over cached defaults.
+    expect(statusCall.provider).toBe("anthropic");
+    expect(statusCall.model).toBe("claude-fable-5");
+  });
+
+  it("preserves cached non-default model over channel override", async () => {
+    resolveDefaultModelForAgent.mockReturnValue({
+      provider: "openai",
+      model: "gpt-5.4",
+    });
+    resolveDefaultModel.mockReturnValue({
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.4",
+    });
+    // Cached fields differ from the default — a real prior user choice.
+    loadSessionEntry.mockReturnValue({
+      cfg: {
+        agents: { defaults: { reasoningDefault: "off" } },
+        channels: {
+          modelByChannel: {
+            discord: { "*": "anthropic/claude-fable-5" },
+          },
+        },
+      },
+      canonicalKey: "main",
+      entry: {
+        sessionId: "sess-main",
+        modelProvider: "google",
+        model: "gemini-flash-3",
+      },
+      store: {},
+      storePath: "/tmp/sessions.json",
+    });
+
+    await resolveDirectStatusReplyForSession({
+      cfg: {},
+      sessionKey: "main",
+      channel: "discord",
+      senderIsOwner: true,
+      isAuthorizedSender: true,
+      isGroup: true,
+      defaultGroupActivation: () => "always",
+    });
+
+    const statusCall = requireBuildStatusReplyParams(0) as {
+      provider?: string;
+      model?: string;
+    };
+    // Cached non-default wins over channel model.
+    expect(statusCall.provider).toBe("google");
+    expect(statusCall.model).toBe("gemini-flash-3");
+  });
 });

--- a/src/plugin-sdk/command-status.runtime.ts
+++ b/src/plugin-sdk/command-status.runtime.ts
@@ -101,11 +101,15 @@ export async function resolveDirectStatusReplyForSession(
   const liveGroupId = params.targetGuildId ?? statusEntry?.groupId;
   const liveChatType = params.chatType ?? statusEntry?.chatType;
   const liveChannelId = params.targetChannelId;
+  // For non-DM conversations, modelByChannel keys are channel/conversation IDs,
+  // not guild/server IDs.  Pass the live channel ID as the resolver groupId so
+  // exact channel-ID config keys match instead of falling back to the wildcard.
+  const resolvedGroupId = liveChatType !== "dm" && liveChannelId ? liveChannelId : liveGroupId;
   const channelModelOverride = canApplyChannelModel
     ? resolveChannelModelOverride({
         cfg: statusCfg,
         channel: params.channel,
-        groupId: liveGroupId,
+        groupId: resolvedGroupId,
         groupChatType: liveChatType,
         groupChannel: statusEntry?.groupChannel,
         groupSubject: statusEntry?.subject,
@@ -133,22 +137,18 @@ export async function resolveDirectStatusReplyForSession(
     : null;
   const effectiveProvider = resolvedChannelModel?.ref.provider ?? statusModel.provider;
   const effectiveModel = resolvedChannelModel?.ref.model ?? statusModel.model;
-  // Cached last-run fields are not user selection; a default cache must not
-  // block a resolved channel model override. Only non-default cached values
-  // represent a prior explicit choice that should outrank the channel default.
-  const cachedProvider = statusEntry?.modelProvider?.trim();
-  const cachedModel = statusEntry?.model?.trim();
-  const cachedDiffersFromDefault =
-    (cachedProvider && cachedProvider !== defaultProvider) ||
-    (cachedModel && cachedModel !== defaultModel);
+  // Cached last-run fields (modelProvider / model) record the last executed
+  // route, not a user choice.  A resolved channel model override outranks
+  // them; use cached fields only when no channel override resolved.
+  const channelModelResolved = channelModelOverride != null;
   const selectedProvider =
     statusEntry?.providerOverride?.trim() ||
-    (cachedDiffersFromDefault ? cachedProvider : undefined) ||
-    effectiveProvider;
+    (channelModelResolved
+      ? effectiveProvider
+      : statusEntry?.modelProvider?.trim() || effectiveProvider);
   const selectedModel =
     statusEntry?.modelOverride?.trim() ||
-    (cachedDiffersFromDefault ? cachedModel : undefined) ||
-    effectiveModel;
+    (channelModelResolved ? effectiveModel : statusEntry?.model?.trim() || effectiveModel);
   const modelState = await createModelSelectionState({
     cfg: statusCfg,
     agentId: statusAgentId,

--- a/src/plugin-sdk/command-status.runtime.ts
+++ b/src/plugin-sdk/command-status.runtime.ts
@@ -37,6 +37,12 @@ export type ResolveDirectStatusReplyForSessionParams = {
   isGroup: boolean;
   /** Channel default activation mode used by the status renderer for groups. */
   defaultGroupActivation: () => "always" | "mention";
+  /** Live channel/DM id from the calling interaction, used for channel model matching. */
+  targetChannelId?: string | null;
+  /** Live guild/server id from the calling interaction, used for channel model matching. */
+  targetGuildId?: string | null;
+  /** Live chat type from the calling interaction ("dm", "group", "channel"). */
+  chatType?: string | null;
 };
 
 /**
@@ -89,16 +95,23 @@ export async function resolveDirectStatusReplyForSession(
     deliveryChannel && deliveryChannel === normalizeMessageChannel(params.channel)
       ? sessionDeliveryOrigin(statusEntry)
       : undefined;
+  // Live conversation facts from the caller supplement persisted session data
+  // so a first-time /status with an exact channel or DM modelByChannel key can
+  // match without a pre-existing persisted entry.
+  const liveGroupId = params.targetGuildId ?? statusEntry?.groupId;
+  const liveChatType = params.chatType ?? statusEntry?.chatType;
+  const liveChannelId = params.targetChannelId;
   const channelModelOverride = canApplyChannelModel
     ? resolveChannelModelOverride({
         cfg: statusCfg,
         channel: params.channel,
-        groupId: statusEntry?.groupId,
-        groupChatType: statusEntry?.chatType,
+        groupId: liveGroupId,
+        groupChatType: liveChatType,
         groupChannel: statusEntry?.groupChannel,
         groupSubject: statusEntry?.subject,
         parentSessionKey: statusEntry?.parentSessionKey,
         directUserIds: [
+          liveChannelId,
           deliveryOrigin?.nativeDirectUserId,
           deliveryOrigin?.from,
           deliveryOrigin?.to,
@@ -120,12 +133,22 @@ export async function resolveDirectStatusReplyForSession(
     : null;
   const effectiveProvider = resolvedChannelModel?.ref.provider ?? statusModel.provider;
   const effectiveModel = resolvedChannelModel?.ref.model ?? statusModel.model;
+  // Cached last-run fields are not user selection; a default cache must not
+  // block a resolved channel model override. Only non-default cached values
+  // represent a prior explicit choice that should outrank the channel default.
+  const cachedProvider = statusEntry?.modelProvider?.trim();
+  const cachedModel = statusEntry?.model?.trim();
+  const cachedDiffersFromDefault =
+    (cachedProvider && cachedProvider !== defaultProvider) ||
+    (cachedModel && cachedModel !== defaultModel);
   const selectedProvider =
     statusEntry?.providerOverride?.trim() ||
-    statusEntry?.modelProvider?.trim() ||
+    (cachedDiffersFromDefault ? cachedProvider : undefined) ||
     effectiveProvider;
   const selectedModel =
-    statusEntry?.modelOverride?.trim() || statusEntry?.model?.trim() || effectiveModel;
+    statusEntry?.modelOverride?.trim() ||
+    (cachedDiffersFromDefault ? cachedModel : undefined) ||
+    effectiveModel;
   const modelState = await createModelSelectionState({
     cfg: statusCfg,
     agentId: statusAgentId,

--- a/src/plugin-sdk/command-status.runtime.ts
+++ b/src/plugin-sdk/command-status.runtime.ts
@@ -1,14 +1,23 @@
 // Command status runtime helpers collect agent/session state for plugin command status output.
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { listAgentEntries, resolveSessionAgentId } from "../agents/agent-scope.js";
-import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
+import {
+  buildModelAliasIndex,
+  resolveDefaultModelForAgent,
+  resolveModelRefFromString,
+} from "../agents/model-selection.js";
 import { buildStatusReply } from "../auto-reply/reply/commands-status.js";
 import type { CommandContext } from "../auto-reply/reply/commands-types.js";
 import { resolveDefaultModel } from "../auto-reply/reply/directive-handling.defaults.js";
 import { resolveCurrentDirectiveLevels } from "../auto-reply/reply/directive-handling.levels.js";
 import { createModelSelectionState } from "../auto-reply/reply/model-selection.js";
 import type { ReplyPayload } from "../auto-reply/types.js";
+import { resolveChannelModelOverride } from "../channels/model-overrides.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { loadSessionEntryReadOnly } from "../gateway/session-utils.js";
+import { isModelSelectionLocked } from "../sessions/model-overrides.js";
+import { sessionDeliveryChannel, sessionDeliveryOrigin } from "../utils/delivery-context.shared.js";
+import { normalizeMessageChannel } from "../utils/message-channel.js";
 
 /** Inputs for rendering direct-session status replies outside the active channel turn. */
 export type ResolveDirectStatusReplyForSessionParams = {
@@ -63,12 +72,60 @@ export async function resolveDirectStatusReplyForSession(
     cfg: statusCfg,
     agentId: statusAgentId,
   });
+  // Native status returns before the ordinary reply pipeline reaches
+  // channel-model routing, so resolve the effective channel model here before
+  // preparing model-bound thinking, runtime, auth, context, and fast-mode facts.
+  const canApplyChannelModel =
+    statusCfg.channels?.modelByChannel != null &&
+    !isModelSelectionLocked(statusEntry) &&
+    !normalizeOptionalString(statusEntry?.modelOverride) &&
+    !normalizeOptionalString(statusEntry?.providerOverride) &&
+    statusModel.provider === defaultProvider &&
+    statusModel.model === defaultModel;
+  const deliveryChannel = normalizeMessageChannel(sessionDeliveryChannel(statusEntry));
+  // Shared sessions can retain another channel's peer; never let that stale
+  // identity outrank the authorized current command's live sender.
+  const deliveryOrigin =
+    deliveryChannel && deliveryChannel === normalizeMessageChannel(params.channel)
+      ? sessionDeliveryOrigin(statusEntry)
+      : undefined;
+  const channelModelOverride = canApplyChannelModel
+    ? resolveChannelModelOverride({
+        cfg: statusCfg,
+        channel: params.channel,
+        groupId: statusEntry?.groupId,
+        groupChatType: statusEntry?.chatType,
+        groupChannel: statusEntry?.groupChannel,
+        groupSubject: statusEntry?.subject,
+        parentSessionKey: statusEntry?.parentSessionKey,
+        directUserIds: [
+          deliveryOrigin?.nativeDirectUserId,
+          deliveryOrigin?.from,
+          deliveryOrigin?.to,
+          params.senderId,
+        ],
+      })
+    : null;
+  const resolvedChannelModel = channelModelOverride
+    ? resolveModelRefFromString({
+        cfg: statusCfg,
+        raw: channelModelOverride.model,
+        defaultProvider,
+        aliasIndex: buildModelAliasIndex({
+          cfg: statusCfg,
+          agentId: statusAgentId,
+          defaultProvider,
+        }),
+      })
+    : null;
+  const effectiveProvider = resolvedChannelModel?.ref.provider ?? statusModel.provider;
+  const effectiveModel = resolvedChannelModel?.ref.model ?? statusModel.model;
   const selectedProvider =
     statusEntry?.providerOverride?.trim() ||
     statusEntry?.modelProvider?.trim() ||
-    statusModel.provider;
+    effectiveProvider;
   const selectedModel =
-    statusEntry?.modelOverride?.trim() || statusEntry?.model?.trim() || statusModel.model;
+    statusEntry?.modelOverride?.trim() || statusEntry?.model?.trim() || effectiveModel;
   const modelState = await createModelSelectionState({
     cfg: statusCfg,
     agentId: statusAgentId,


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

Related: follow-up to #118548

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users running the native `/status` command in a Discord channel, guild, or direct message that has a configured `channels.modelByChannel` override would see the agent's default model and its associated runtime settings instead of the effective model configured for that conversation.

Before the fix, a Discord conversation configured via `channels.modelByChannel.discord.<id>` would still report the default model and stale thinking, fast-mode, runtime, and context information.

This is the Discord follow-up explicitly called out in #118548 (which fixed the same issue for Telegram). #118548 resolved channel model overrides at the Telegram native status producer; this change resolves them inside the shared `resolveDirectStatusReplyForSession` runtime used by Discord's direct status path.

## Why This Change Was Made

Two root causes prevented `channels.modelByChannel` from working in Discord native `/status`:

1. **Wrong group identity for non-DM channel matching**: For guild channels and group DMs, `modelByChannel` keys are channel/conversation IDs, but the resolver was given the guild/server ID as `groupId`. Exact channel-ID config keys therefore missed and fell back to the wildcard `*`. The fix passes the live channel ID as the `groupId` for non-DM conversations so channel-ID keys match correctly.

2. **Cached last-run model outranked channel override**: `modelProvider` and `model` on `SessionEntry` are persisted last-run fields (not user choices). A shared session last used in channel A with a non-default model could suppress channel B's current override. The fix defers to the resolved channel model override when one exists; cached fields are used only when no channel override resolves.

Session-level explicit overrides (`providerOverride`/`modelOverride`) and model-selection locks still take highest priority.

## User Impact

Discord users with `channels.modelByChannel` overrides now see the correct effective model, alias, thinking level, fast-mode state, reasoning level, and context-window information in `/status` output, even on a first `/status` with no persisted session entry.

## Evidence

### Test results

All 49 tests pass across 4 test suites:

```
$ node scripts/run-vitest.mjs src/plugin-sdk/command-status.runtime.test.ts

 ✓ |plugin-sdk| src/plugin-sdk/command-status.runtime.test.ts (13 tests) 1280ms
     ✓ treats agentCfg reasoningDefault as explicit for direct /status
     ✓ allows configured reasoning defaults for authorized direct /status senders
     ✓ hides configured reasoning defaults from unauthorized direct /status senders
     ✓ hides session reasoning state from unauthorized direct /status senders
     ✓ allows session reasoning state for authorized direct /status senders
     ✓ applies channels.modelByChannel before building the status reply
     ✓ preserves explicit session model override over channels.modelByChannel
     ✓ skips channels.modelByChannel when model selection is locked
     ✓ uses live conversation facts for channel model matching via groupId
     ✓ lets channel model override cached last-run default fields
     ✓ lets channel model override outrank cached last-run model
     ✓ preserves cached last-run model when no channel override resolves
     ✓ uses live channel ID as groupId for non-DM channel model matching

 Test Files  1 passed (1)
      Tests  13 passed (13)
```

```
$ node scripts/run-vitest.mjs extensions/discord/src/monitor/native-command.status-direct.test.ts

 ✓ |extension-discord| extensions/discord/.../native-command.status-direct.test.ts (5 tests) 996ms
     ✓ returns a direct status reply without falling through the generic dispatcher
     ✓ prioritizes direct status replies over matching plugin commands
     ✓ keeps every direct status chunk ephemeral
     ✓ keeps direct status media follow-up chunks ephemeral
     ✓ passes through the effective guild activation when requireMention is disabled

 Test Files  1 passed (1)
      Tests  5 passed (5)
```

```
$ node scripts/run-vitest.mjs src/channels/model-overrides.test.ts

 ✓ |channels| src/channels/model-overrides.test.ts (19 tests) 1887ms

 Test Files  1 passed (1)
      Tests  19 passed (19)
```

```
$ node scripts/run-vitest.mjs src/auto-reply/reply/get-reply-native-slash-fast-path.status.test.ts

 ✓ |auto-reply| src/auto-reply/reply/.../get-reply-native-slash-fast-path.status.test.ts (12 tests) 3252ms

 Test Files  1 passed (1)
      Tests  12 passed (12)
```

### Lint & format

```
$ node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json \
    src/plugin-sdk/command-status.runtime.ts src/plugin-sdk/command-status.runtime.test.ts
Found 0 warnings and 0 errors.

$ node_modules/.bin/oxfmt --check src/plugin-sdk/command-status.runtime.ts \
    src/plugin-sdk/command-status.runtime.test.ts
All matched files use the correct format.
```

### ClawSweeper findings addressed

- [P1] **Use the live channel ID for non-DM overrides** — `resolvedGroupId` now passes the live channel ID (not guild ID) as `groupId` for non-DM conversations, so exact channel-ID `modelByChannel` keys match correctly.
- [P1] **Do not promote a last-run cache to a session override** — `selectedProvider`/`selectedModel` now defer to the channel model override when one resolves; cached last-run fields (`modelProvider`/`model`) are used only when no channel override resolves.

### Precedence behavior (after fix)

1. `providerOverride` / `modelOverride` — explicit user session overrides
2. Channel model override from `channels.modelByChannel` config (when it resolves)
3. Cached last-run fields (`modelProvider` / `model`) — only when no channel override
4. Agent default model — final fallback

### CI

All CI checks pass on the latest commit:
https://github.com/openclaw/openclaw/pull/119548/checks
