### PR TITLE
fix: preserve paragraph boundaries across streamed replies

### DIFF
--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -837,6 +837,108 @@ describe("runBtwSideQuestion", () => {
     });
   });
 
+  it("delivers a paragraph separator between forced BTW blocks", async () => {
+    const onBlockReply = vi.fn().mockResolvedValue(undefined);
+    streamSimpleMock.mockReturnValue(
+      makeAsyncEvents([
+        {
+          type: "text_delta",
+          delta: "abcdefghij\n\n",
+          partial: {
+            role: "assistant",
+            content: [],
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+          },
+        },
+        {
+          type: "text_end",
+          content: "abcdefghij\n\n",
+          contentIndex: 0,
+          partial: {
+            role: "assistant",
+            content: [],
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+          },
+        },
+        {
+          type: "text_delta",
+          delta: "Next paragraph.",
+          partial: {
+            role: "assistant",
+            content: [],
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+          },
+        },
+        {
+          type: "text_end",
+          content: "Next paragraph.",
+          contentIndex: 0,
+          partial: {
+            role: "assistant",
+            content: [],
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+          },
+        },
+        {
+          type: "done",
+          reason: "stop",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "abcdefghij\n\nNext paragraph." }],
+            provider: "anthropic",
+            api: "anthropic-messages",
+            model: "claude-sonnet-4-6",
+            stopReason: "stop",
+            usage: {
+              input: 1,
+              output: 2,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 3,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            timestamp: Date.now(),
+          },
+        },
+      ]),
+    );
+
+    const result = await runBtwSideQuestion({
+      cfg: { agents: { entries: { main: { default: true } } } } as never,
+      agentDir: DEFAULT_AGENT_DIR,
+      provider: DEFAULT_PROVIDER,
+      model: DEFAULT_MODEL,
+      question: DEFAULT_QUESTION,
+      sessionEntry: createSessionEntry(),
+      sessionStore: {},
+      sessionKey: DEFAULT_SESSION_KEY,
+      storePath: DEFAULT_STORE_PATH,
+      resolvedThinkLevel: "low",
+      resolvedReasoningLevel: DEFAULT_REASONING_LEVEL,
+      blockReplyChunking: {
+        minChars: 1,
+        maxChars: 10,
+        breakPreference: "paragraph",
+        flushOnParagraph: true,
+      },
+      resolvedBlockStreamingBreak: "text_end",
+      opts: { onBlockReply },
+      isNewSession: false,
+    });
+
+    expect(result).toBeUndefined();
+    expect(onBlockReply.mock.calls.map(([payload]) => payload.text)).toEqual([
+      "abcdefghij",
+      "\n\n",
+      "Next",
+      "paragraph.",
+    ]);
+  });
+
   it("returns a final payload when block streaming is unavailable", async () => {
     mockDoneAnswer("Final answer.");
 

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -1289,7 +1289,8 @@ export async function runBtwSideQuestion(
 
   const emitBlockChunk = async (text: string) => {
     const trimmed = text.trim();
-    if (!trimmed || !params.opts?.onBlockReply) {
+    const isParagraphSeparator = /^\n[\t ]*\n+$/.test(text);
+    if ((!trimmed && !isParagraphSeparator) || !params.opts?.onBlockReply) {
       return;
     }
     emittedBlocks += 1;

--- a/src/agents/embedded-agent-block-chunker.test.ts
+++ b/src/agents/embedded-agent-block-chunker.test.ts
@@ -160,6 +160,99 @@ describe("EmbeddedBlockChunker", () => {
     expect(chunker.bufferedText).toBe("");
   });
 
+  it("retains a separator-only streamed delta until the next text delta", () => {
+    const chunker = createFlushOnParagraphChunker({ minChars: 1, maxChars: 10 });
+
+    chunker.append("abcdefghij\n\n");
+
+    expect(drainChunks(chunker)).toEqual(["abcdefghij"]);
+    expect(chunker.bufferedText).toBe("\n\n");
+
+    chunker.append("Rest");
+
+    expect(drainChunks(chunker)).toEqual(["\n\nRest"]);
+    expect(chunker.bufferedText).toBe("");
+  });
+
+  it("force flushes a separator-only tail at the end of the stream", () => {
+    const chunker = createFlushOnParagraphChunker({ minChars: 1, maxChars: 10 });
+
+    chunker.append("\n\n");
+
+    expect(drainChunks(chunker, true)).toEqual(["\n\n"]);
+    expect(chunker.bufferedText).toBe("");
+  });
+
+  it("does not stall when whitespace after a separator exceeds maxChars", () => {
+    const chunker = createFlushOnParagraphChunker({ minChars: 1, maxChars: 6 });
+    const input = "\n\n     x";
+
+    chunker.append(input);
+
+    const chunks = drainChunks(chunker, true);
+
+    expect(chunks).toEqual(["\n\n    ", " x"]);
+    expectChunksWithinLength(chunks, 6);
+    expect(chunker.bufferedText).toBe("");
+  });
+
+  it("retains non-paragraph whitespace across forced splits", () => {
+    const chunker = createFlushOnParagraphChunker({ minChars: 1, maxChars: 6 });
+    const input = "\n     x";
+
+    chunker.append(input);
+
+    const chunks = drainChunks(chunker, true);
+
+    expect(chunks.join("")).toBe(input);
+    expectChunksWithinLength(chunks, 6);
+    expect(chunker.bufferedText).toBe("");
+  });
+
+  it("force flushes indentation before a paragraph separator", () => {
+    const chunker = createFlushOnParagraphChunker({ minChars: 1, maxChars: 6 });
+    const input = "    \n\nx";
+
+    chunker.append(input);
+
+    const chunks = drainChunks(chunker, true);
+
+    expect(chunks.join("")).toBe(input);
+    expectChunksWithinLength(chunks, 6);
+    expect(chunker.bufferedText).toBe("");
+  });
+
+  it("retains indentation after a paragraph boundary when maxChars forces a whitespace split", () => {
+    const chunker = createFlushOnParagraphChunker({ minChars: 1, maxChars: 6 });
+
+    chunker.append("a\n\n    code");
+
+    expect(drainChunks(chunker)).toEqual(["a\n\n", "    co"]);
+    expect(chunker.bufferedText).toBe("de");
+    expect(drainChunks(chunker, true)).toEqual(["de"]);
+
+    const forcedChunker = createFlushOnParagraphChunker({ minChars: 1, maxChars: 6 });
+    const forcedInput = "a".repeat(10) + "\n\n    code";
+    forcedChunker.append(forcedInput);
+    const forcedChunks = drainChunks(forcedChunker, true);
+    expect(forcedChunks).toEqual(["aaaaaa", "aaaa\n\n", "    co", "de"]);
+    expect(forcedChunks.join("")).toBe(forcedInput);
+  });
+
+  it("keeps reopened fence state across leading blank lines after a forced split", () => {
+    const chunker = createFlushOnParagraphChunker({ minChars: 1, maxChars: 16 });
+
+    chunker.append("```js\nxxxxxxxxxx\n\nyyyyyyyyyyyyyyyyyyyy\n```");
+
+    const chunks = drainChunks(chunker, true);
+
+    expect(chunks).toEqual([
+      "```js\nxxxxxxxxxx\n```\n",
+      "```js\n\n\nyyyyyyyyyyyyyy\n```\n",
+      "```js\nyyyyyy\n```",
+    ]);
+  });
+
   it("ignores paragraph breaks inside fences when flushOnParagraph is set", () => {
     // Blank lines inside fenced code are content, not paragraph boundaries.
     const chunker = new EmbeddedBlockChunker({

--- a/src/agents/embedded-agent-block-chunker.test.ts
+++ b/src/agents/embedded-agent-block-chunker.test.ts
@@ -52,7 +52,7 @@ describe("EmbeddedBlockChunker", () => {
 
     expect(chunks.length).toBe(1);
     expect(chunks[0]).toContain("console.log");
-    expect(chunks[0]).toMatch(/```\n?$/);
+    expect(chunks[0]).toMatch(/```\n\n$/);
     expect(chunks[0]).not.toContain("After");
     expect(chunker.bufferedText).toMatch(/^After/);
   });
@@ -64,7 +64,7 @@ describe("EmbeddedBlockChunker", () => {
 
     const chunks = drainChunks(chunker);
 
-    expect(chunks).toEqual(["First paragraph.\n\nSecond paragraph."]);
+    expect(chunks).toEqual(["First paragraph.\n\nSecond paragraph.\n\n"]);
     expect(chunker.bufferedText).toBe("Third paragraph.");
   });
 
@@ -139,7 +139,7 @@ describe("EmbeddedBlockChunker", () => {
     const chunks = drainChunks(chunker);
 
     expectChunksWithinLength(chunks, 10);
-    expect(chunks).toEqual(["abcdefghij", "k"]);
+    expect(chunks).toEqual(["abcdefghij", "k\n\n"]);
     expect(chunker.bufferedText).toBe("Rest");
   });
 
@@ -167,7 +167,7 @@ describe("EmbeddedBlockChunker", () => {
 
     const chunks = drainChunks(chunker);
 
-    expect(chunks).toEqual(["Intro\n```js\nconst a = 1;\n\nconst b = 2;\n```"]);
+    expect(chunks).toEqual(["Intro\n```js\nconst a = 1;\n\nconst b = 2;\n```\n\n"]);
     expect(chunker.bufferedText).toBe("After fence");
   });
 

--- a/src/agents/embedded-agent-block-chunker.test.ts
+++ b/src/agents/embedded-agent-block-chunker.test.ts
@@ -143,6 +143,23 @@ describe("EmbeddedBlockChunker", () => {
     expect(chunker.bufferedText).toBe("Rest");
   });
 
+  it("does not exceed maxChars when the paragraph starts at the limit", () => {
+    const chunker = new EmbeddedBlockChunker({
+      minChars: 1,
+      maxChars: 10,
+      breakPreference: "paragraph",
+      flushOnParagraph: true,
+    });
+
+    chunker.append("abcdefghij\n\nRest");
+
+    const chunks = drainChunks(chunker);
+
+    expectChunksWithinLength(chunks, 10);
+    expect(chunks).toEqual(["abcdefghij"]);
+    expect(chunker.bufferedText).toBe("Rest");
+  });
+
   it("ignores paragraph breaks inside fences when flushOnParagraph is set", () => {
     // Blank lines inside fenced code are content, not paragraph boundaries.
     const chunker = new EmbeddedBlockChunker({

--- a/src/agents/embedded-agent-block-chunker.test.ts
+++ b/src/agents/embedded-agent-block-chunker.test.ts
@@ -206,6 +206,15 @@ describe("EmbeddedBlockChunker", () => {
     expect(chunker.bufferedText).toBe("");
   });
 
+  it("force flushes a separator tail after a max-sized chunk", () => {
+    const chunker = createFlushOnParagraphChunker({ minChars: 1, maxChars: 10 });
+
+    chunker.append("abcdefghij\n\n");
+
+    expect(drainChunks(chunker, true)).toEqual(["abcdefghij", "\n\n"]);
+    expect(chunker.bufferedText).toBe("");
+  });
+
   it("does not stall when whitespace after a separator exceeds maxChars", () => {
     const chunker = createFlushOnParagraphChunker({ minChars: 1, maxChars: 6 });
     const input = "\n\n     x";

--- a/src/agents/embedded-agent-block-chunker.test.ts
+++ b/src/agents/embedded-agent-block-chunker.test.ts
@@ -160,6 +160,29 @@ describe("EmbeddedBlockChunker", () => {
     expect(chunker.bufferedText).toBe("");
   });
 
+  it("preserves whitespace-bearing paragraph separators at the size boundary", () => {
+    const chunker = createFlushOnParagraphChunker({ minChars: 1, maxChars: 10 });
+
+    chunker.append("abcdefgh\n \nRest");
+
+    expect(drainChunks(chunker, true)).toEqual(["abcdefgh", "\n \nRest"]);
+    expect(chunker.bufferedText).toBe("");
+  });
+
+  it("retains an incomplete whitespace-bearing separator across streamed deltas", () => {
+    const chunker = createFlushOnParagraphChunker({ minChars: 1, maxChars: 10 });
+
+    chunker.append("abcdefgh\n ");
+
+    expect(drainChunks(chunker)).toEqual(["abcdefgh"]);
+    expect(chunker.bufferedText).toBe("\n ");
+
+    chunker.append("\nRest");
+
+    expect(drainChunks(chunker, true)).toEqual(["\n \nRest"]);
+    expect(chunker.bufferedText).toBe("");
+  });
+
   it("retains a separator-only streamed delta until the next text delta", () => {
     const chunker = createFlushOnParagraphChunker({ minChars: 1, maxChars: 10 });
 

--- a/src/agents/embedded-agent-block-chunker.test.ts
+++ b/src/agents/embedded-agent-block-chunker.test.ts
@@ -156,8 +156,8 @@ describe("EmbeddedBlockChunker", () => {
     const chunks = drainChunks(chunker);
 
     expectChunksWithinLength(chunks, 10);
-    expect(chunks).toEqual(["abcdefghij"]);
-    expect(chunker.bufferedText).toBe("Rest");
+    expect(chunks).toEqual(["abcdefghij", "\n\nRest"]);
+    expect(chunker.bufferedText).toBe("");
   });
 
   it("ignores paragraph breaks inside fences when flushOnParagraph is set", () => {

--- a/src/agents/embedded-agent-block-chunker.ts
+++ b/src/agents/embedded-agent-block-chunker.ts
@@ -422,7 +422,18 @@ export class EmbeddedBlockChunker {
       return { index: -1 };
     }
 
+    const firstVisibleIndex = buffer.search(/\S/);
+    const firstVisibleInFence =
+      firstVisibleIndex >= 0 &&
+      firstVisibleIndex < window.length &&
+      fenceSpans.some((fence) => {
+        const absoluteIndex = offset + firstVisibleIndex;
+        return absoluteIndex >= fence.start && absoluteIndex < fence.end;
+      });
     for (let i = window.length - 1; i >= minChars; i--) {
+      if (firstVisibleInFence && window.slice(0, i).trim().length === 0) {
+        continue;
+      }
       if (/\s/.test(window.charAt(i)) && isSafeFenceBreak(fenceSpans, offset + i)) {
         return { index: i };
       }

--- a/src/agents/embedded-agent-block-chunker.ts
+++ b/src/agents/embedded-agent-block-chunker.ts
@@ -174,7 +174,7 @@ export class EmbeddedBlockChunker {
         break;
       }
 
-      if (this.#chunking.flushOnParagraph) {
+      if (this.#chunking.flushOnParagraph && !reopenFence) {
         const leadingParagraphSeparator = findLeadingParagraphSeparator(source, start);
         if (leadingParagraphSeparator) {
           const paragraphLimit = Math.max(1, maxChars - reopenPrefix.length);
@@ -182,9 +182,18 @@ export class EmbeddedBlockChunker {
           if (chunk.length === 0) {
             break;
           }
-          if (chunk.trim().length > 0) {
-            emit(`${reopenPrefix}${chunk}`);
+          if (chunk.trim().length === 0) {
+            // Text that fits is handled above; only advance this bounded whitespace
+            // prefix when later visible text would otherwise remain blocked.
+            if (!force && source.slice(start + chunk.length).trim().length === 0) {
+              break;
+            }
+            emit(chunk);
+            start += chunk.length;
+            reopenFence = undefined;
+            continue;
           }
+          emit(`${reopenPrefix}${chunk}`);
           start += chunk.length;
           reopenFence = undefined;
           continue;
@@ -236,7 +245,7 @@ export class EmbeddedBlockChunker {
         start,
       });
       if (consumed === null) {
-        continue;
+        break;
       }
       start = consumed.start;
       reopenFence = consumed.reopenFence;
@@ -274,7 +283,15 @@ export class EmbeddedBlockChunker {
     const absoluteBreakIdx = start + breakIdx;
     let rawChunk = `${reopenPrefix}${source.slice(start, absoluteBreakIdx)}`;
     if (rawChunk.trim().length === 0) {
-      return { start: skipLeadingNewlines(source, absoluteBreakIdx), reopenFence: undefined };
+      if (
+        this.#chunking.flushOnParagraph &&
+        hasTrailingParagraphSeparator(source, absoluteBreakIdx) &&
+        rawChunk.startsWith("\n")
+      ) {
+        return null;
+      }
+      emit(rawChunk);
+      return { start: absoluteBreakIdx, reopenFence: undefined };
     }
 
     const fenceSplit = breakResult.fenceSplit;
@@ -293,7 +310,8 @@ export class EmbeddedBlockChunker {
 
     const preserveParagraphSeparator =
       this.#chunking.flushOnParagraph &&
-      Boolean(findLeadingParagraphSeparator(source, absoluteBreakIdx));
+      (Boolean(findLeadingParagraphSeparator(source, absoluteBreakIdx)) ||
+        hasTrailingParagraphSeparator(source, absoluteBreakIdx));
     const nextStart = preserveParagraphSeparator
       ? absoluteBreakIdx
       : absoluteBreakIdx < source.length && /\s/.test(source.charAt(absoluteBreakIdx))
@@ -464,6 +482,14 @@ function stripLeadingNewlines(value: string): string {
 
 function findLeadingParagraphSeparator(value: string, start = 0): string | null {
   return value.slice(start).match(/^\n[\t ]*\n+/)?.[0] ?? null;
+}
+
+function hasTrailingParagraphSeparator(value: string, end: number): boolean {
+  let start = end - 1;
+  while (start >= 0 && (value[start] === "\n" || value[start] === "\t" || value[start] === " ")) {
+    start--;
+  }
+  return /\n[\t ]*\n+[\t ]*$/.test(value.slice(start + 1, end));
 }
 
 function findNextParagraphBreak(

--- a/src/agents/embedded-agent-block-chunker.ts
+++ b/src/agents/embedded-agent-block-chunker.ts
@@ -63,22 +63,22 @@ function findSafeParagraphBreakIndex(params: {
   offset?: number;
 }): number {
   const { text, fenceSpans, minChars, reverse, offset = 0 } = params;
-  let paragraphIdx = reverse ? text.lastIndexOf("\n\n") : text.indexOf("\n\n");
-  while (reverse ? paragraphIdx >= minChars : paragraphIdx !== -1) {
-    const separator = text.slice(paragraphIdx).match(/^\n[\t ]*\n+/)?.[0];
-    const boundary = paragraphIdx + (separator?.length ?? 0);
+  let lastSafeBoundary = -1;
+  for (const match of text.matchAll(/\n[\t ]*\n+/g)) {
+    const paragraphIdx = match.index ?? -1;
+    const boundary = paragraphIdx + match[0].length;
     if (
       boundary >= minChars &&
       boundary <= text.length &&
       isSafeFenceBreak(fenceSpans, offset + boundary)
     ) {
-      return boundary;
+      if (!reverse) {
+        return boundary;
+      }
+      lastSafeBoundary = boundary;
     }
-    paragraphIdx = reverse
-      ? text.lastIndexOf("\n\n", paragraphIdx - 1)
-      : text.indexOf("\n\n", paragraphIdx + 2);
   }
-  return -1;
+  return lastSafeBoundary;
 }
 
 function findSafeNewlineBreakIndex(params: {
@@ -154,7 +154,7 @@ export class EmbeddedBlockChunker {
     }
 
     if (force && this.#buffer.length <= maxChars) {
-      if (this.#buffer.trim().length > 0) {
+      if (this.#buffer.trim().length > 0 || hasParagraphSeparatorPrefix(this.#buffer)) {
         emit(this.#buffer);
       }
       this.#buffer = "";
@@ -262,7 +262,7 @@ export class EmbeddedBlockChunker {
     const remaining = source.slice(start);
     this.#buffer = reopenFence
       ? `${reopenFence.openLine}\n${remaining}`
-      : findLeadingParagraphSeparator(remaining)
+      : hasParagraphSeparatorPrefix(remaining)
         ? remaining
         : stripLeadingNewlines(remaining);
   }
@@ -309,9 +309,11 @@ export class EmbeddedBlockChunker {
     }
 
     const preserveParagraphSeparator =
-      this.#chunking.flushOnParagraph &&
-      (Boolean(findLeadingParagraphSeparator(source, absoluteBreakIdx)) ||
-        hasTrailingParagraphSeparator(source, absoluteBreakIdx));
+      (this.#chunking.flushOnParagraph &&
+        (hasParagraphSeparatorPrefix(source, absoluteBreakIdx) ||
+          hasTrailingParagraphSeparator(source, absoluteBreakIdx))) ||
+      (hasTrailingParagraphSeparator(source, absoluteBreakIdx) &&
+        /^[\t ]/.test(source.slice(absoluteBreakIdx)));
     const nextStart = preserveParagraphSeparator
       ? absoluteBreakIdx
       : absoluteBreakIdx < source.length && /\s/.test(source.charAt(absoluteBreakIdx))
@@ -431,7 +433,10 @@ export class EmbeddedBlockChunker {
         return absoluteIndex >= fence.start && absoluteIndex < fence.end;
       });
     for (let i = window.length - 1; i >= minChars; i--) {
-      if (firstVisibleInFence && window.slice(0, i).trim().length === 0) {
+      if (
+        (firstVisibleInFence || this.#chunking.flushOnParagraph) &&
+        window.slice(0, i).trim().length === 0
+      ) {
         continue;
       }
       if (/\s/.test(window.charAt(i)) && isSafeFenceBreak(fenceSpans, offset + i)) {
@@ -493,6 +498,11 @@ function stripLeadingNewlines(value: string): string {
 
 function findLeadingParagraphSeparator(value: string, start = 0): string | null {
   return value.slice(start).match(/^\n[\t ]*\n+/)?.[0] ?? null;
+}
+
+function hasParagraphSeparatorPrefix(value: string, start = 0): boolean {
+  const remaining = value.slice(start);
+  return findLeadingParagraphSeparator(remaining) !== null || /^\n[\t ]*$/.test(remaining);
 }
 
 function hasTrailingParagraphSeparator(value: string, end: number): boolean {

--- a/src/agents/embedded-agent-block-chunker.ts
+++ b/src/agents/embedded-agent-block-chunker.ts
@@ -174,6 +174,23 @@ export class EmbeddedBlockChunker {
         break;
       }
 
+      if (this.#chunking.flushOnParagraph) {
+        const leadingParagraphSeparator = findLeadingParagraphSeparator(source, start);
+        if (leadingParagraphSeparator) {
+          const paragraphLimit = Math.max(1, maxChars - reopenPrefix.length);
+          const chunk = sliceUtf16Safe(source.slice(start), 0, paragraphLimit);
+          if (chunk.length === 0) {
+            break;
+          }
+          if (chunk.trim().length > 0) {
+            emit(`${reopenPrefix}${chunk}`);
+          }
+          start += chunk.length;
+          reopenFence = undefined;
+          continue;
+        }
+      }
+
       if (this.#chunking.flushOnParagraph && !force) {
         const paragraphBreak = findNextParagraphBreak(source, fenceSpans, start, minChars);
         const paragraphLimit = Math.max(1, maxChars - reopenPrefix.length);
@@ -233,9 +250,12 @@ export class EmbeddedBlockChunker {
         break;
       }
     }
+    const remaining = source.slice(start);
     this.#buffer = reopenFence
-      ? `${reopenFence.openLine}\n${source.slice(start)}`
-      : stripLeadingNewlines(source.slice(start));
+      ? `${reopenFence.openLine}\n${remaining}`
+      : findLeadingParagraphSeparator(remaining)
+        ? remaining
+        : stripLeadingNewlines(remaining);
   }
 
   #emitBreakResult(params: {
@@ -271,11 +291,18 @@ export class EmbeddedBlockChunker {
       return { start: absoluteBreakIdx, reopenFence: fenceSplit.fence };
     }
 
-    const nextStart =
-      absoluteBreakIdx < source.length && /\s/.test(source.charAt(absoluteBreakIdx))
+    const preserveParagraphSeparator =
+      this.#chunking.flushOnParagraph &&
+      Boolean(findLeadingParagraphSeparator(source, absoluteBreakIdx));
+    const nextStart = preserveParagraphSeparator
+      ? absoluteBreakIdx
+      : absoluteBreakIdx < source.length && /\s/.test(source.charAt(absoluteBreakIdx))
         ? absoluteBreakIdx + 1
         : absoluteBreakIdx;
-    return { start: skipLeadingNewlines(source, nextStart), reopenFence: undefined };
+    return {
+      start: preserveParagraphSeparator ? nextStart : skipLeadingNewlines(source, nextStart),
+      reopenFence: undefined,
+    };
   }
 
   #pickSoftBreakIndex(
@@ -433,6 +460,10 @@ function skipLeadingNewlines(value: string, start = 0): number {
 function stripLeadingNewlines(value: string): string {
   const start = skipLeadingNewlines(value);
   return start > 0 ? value.slice(start) : value;
+}
+
+function findLeadingParagraphSeparator(value: string, start = 0): string | null {
+  return value.slice(start).match(/^\n[\t ]*\n+/)?.[0] ?? null;
 }
 
 function findNextParagraphBreak(

--- a/src/agents/embedded-agent-block-chunker.ts
+++ b/src/agents/embedded-agent-block-chunker.ts
@@ -65,17 +65,14 @@ function findSafeParagraphBreakIndex(params: {
   const { text, fenceSpans, minChars, reverse, offset = 0 } = params;
   let paragraphIdx = reverse ? text.lastIndexOf("\n\n") : text.indexOf("\n\n");
   while (reverse ? paragraphIdx >= minChars : paragraphIdx !== -1) {
-    const candidates = [paragraphIdx, paragraphIdx + 1];
-    for (const candidate of candidates) {
-      if (candidate < minChars) {
-        continue;
-      }
-      if (candidate < 0 || candidate >= text.length) {
-        continue;
-      }
-      if (isSafeFenceBreak(fenceSpans, offset + candidate)) {
-        return candidate;
-      }
+    const separator = text.slice(paragraphIdx).match(/^\n[\t ]*\n+/)?.[0];
+    const boundary = paragraphIdx + (separator?.length ?? 0);
+    if (
+      boundary >= minChars &&
+      boundary <= text.length &&
+      isSafeFenceBreak(fenceSpans, offset + boundary)
+    ) {
+      return boundary;
     }
     paragraphIdx = reverse
       ? text.lastIndexOf("\n\n", paragraphIdx - 1)
@@ -181,11 +178,14 @@ export class EmbeddedBlockChunker {
         const paragraphBreak = findNextParagraphBreak(source, fenceSpans, start, minChars);
         const paragraphLimit = Math.max(1, maxChars - reopenPrefix.length);
         if (paragraphBreak && paragraphBreak.index - start <= paragraphLimit) {
-          const chunk = `${reopenPrefix}${source.slice(start, paragraphBreak.index)}`;
+          const chunk = `${reopenPrefix}${source.slice(
+            start,
+            paragraphBreak.index + paragraphBreak.length,
+          )}`;
           if (chunk.trim().length > 0) {
             emit(chunk);
           }
-          start = skipLeadingNewlines(source, paragraphBreak.index + paragraphBreak.length);
+          start = paragraphBreak.index + paragraphBreak.length;
           reopenFence = undefined;
           continue;
         }

--- a/src/agents/embedded-agent-block-chunker.ts
+++ b/src/agents/embedded-agent-block-chunker.ts
@@ -177,7 +177,10 @@ export class EmbeddedBlockChunker {
       if (this.#chunking.flushOnParagraph && !force) {
         const paragraphBreak = findNextParagraphBreak(source, fenceSpans, start, minChars);
         const paragraphLimit = Math.max(1, maxChars - reopenPrefix.length);
-        if (paragraphBreak && paragraphBreak.index - start <= paragraphLimit) {
+        if (
+          paragraphBreak &&
+          paragraphBreak.index - start + paragraphBreak.length <= paragraphLimit
+        ) {
           const chunk = `${reopenPrefix}${source.slice(
             start,
             paragraphBreak.index + paragraphBreak.length,

--- a/src/agents/embedded-agent-block-chunker.ts
+++ b/src/agents/embedded-agent-block-chunker.ts
@@ -240,6 +240,7 @@ export class EmbeddedBlockChunker {
       const consumed = this.#emitBreakResult({
         breakResult,
         emit,
+        force,
         reopenPrefix,
         source,
         start,
@@ -270,11 +271,12 @@ export class EmbeddedBlockChunker {
   #emitBreakResult(params: {
     breakResult: BreakResult;
     emit: (chunk: string) => void;
+    force: boolean;
     reopenPrefix: string;
     source: string;
     start: number;
   }): { start: number; reopenFence?: FenceSpan } | null {
-    const { breakResult, emit, reopenPrefix, source, start } = params;
+    const { breakResult, emit, force, reopenPrefix, source, start } = params;
     const breakIdx = breakResult.index;
     if (breakIdx <= 0) {
       return null;
@@ -285,6 +287,7 @@ export class EmbeddedBlockChunker {
     if (rawChunk.trim().length === 0) {
       if (
         this.#chunking.flushOnParagraph &&
+        !force &&
         hasTrailingParagraphSeparator(source, absoluteBreakIdx) &&
         rawChunk.startsWith("\n")
       ) {

--- a/src/agents/embedded-agent-subscribe.stream-rendering.ts
+++ b/src/agents/embedded-agent-subscribe.stream-rendering.ts
@@ -357,12 +357,15 @@ export function createStreamRendering({
     }
     // Strip <think> and <final> blocks across chunk boundaries to avoid leaking reasoning.
     // Also strip downgraded tool call text ([Tool Call: ...], [Historical context: ...], etc.).
-    const blockReplyText = stripDowngradedToolCallText(
+    const rawBlockReplyText = stripDowngradedToolCallText(
       stripBlockTags(text, state.blockState, {
         final: options?.final === true,
         completeMarkdownChunk: options?.completeMarkdownChunk === true,
       }),
-    ).trimEnd();
+    );
+    const blockReplyText = params.blockReplyChunking?.flushOnParagraph
+      ? trimBlockReplyTextPreservingParagraphSuffix(rawBlockReplyText)
+      : rawBlockReplyText.trimEnd();
     if (!blockReplyText) {
       return;
     }
@@ -474,6 +477,14 @@ export function createStreamRendering({
     );
     markBlockReplyTextHandled();
   };
+
+function trimBlockReplyTextPreservingParagraphSuffix(text: string): string {
+  const paragraphSuffix = text.match(/\n[\t ]*\n+$/)?.[0];
+  if (!paragraphSuffix) {
+    return text.trimEnd();
+  }
+  return `${text.slice(0, -paragraphSuffix.length).trimEnd()}${paragraphSuffix}`;
+}
 
   const consumeReplyDirectives = (text: string, options?: { final?: boolean }) =>
     replyDirectiveAccumulator.consume(text, options);

--- a/src/agents/embedded-agent-subscribe.stream-rendering.ts
+++ b/src/agents/embedded-agent-subscribe.stream-rendering.ts
@@ -478,13 +478,13 @@ export function createStreamRendering({
     markBlockReplyTextHandled();
   };
 
-function trimBlockReplyTextPreservingParagraphSuffix(text: string): string {
-  const paragraphSuffix = text.match(/\n[\t ]*\n+$/)?.[0];
-  if (!paragraphSuffix) {
-    return text.trimEnd();
+  function trimBlockReplyTextPreservingParagraphSuffix(text: string): string {
+    const paragraphSuffix = text.match(/\n[\t ]*\n+$/)?.[0];
+    if (!paragraphSuffix) {
+      return text.trimEnd();
+    }
+    return `${text.slice(0, -paragraphSuffix.length).trimEnd()}${paragraphSuffix}`;
   }
-  return `${text.slice(0, -paragraphSuffix.length).trimEnd()}${paragraphSuffix}`;
-}
 
   const consumeReplyDirectives = (text: string, options?: { final?: boolean }) =>
     replyDirectiveAccumulator.consume(text, options);

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.chunking-fences.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.chunking-fences.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   createParagraphChunkedBlockReplyHarness,
+  createSubscribedSessionHarness,
   emitAssistantTextDeltaAndEnd,
   expectFencedChunks,
   extractTextPayloads,
@@ -55,6 +56,33 @@ describe("paragraph and whole-fence chunking", () => {
     if ("expectAssistantTexts" in testCase) {
       expect(subscription.assistantTexts).toEqual(expected);
     }
+  });
+});
+
+describe("paragraph separator delivery", () => {
+  it("preserves paragraph separators through subscriber delivery", () => {
+    const onBlockReply = vi.fn();
+    const { emit } = createSubscribedSessionHarness({
+      runId: "run",
+      onBlockReply,
+      blockReplyBreak: "message_end",
+      blockReplyChunking: {
+        minChars: 1,
+        maxChars: 30,
+        breakPreference: "paragraph",
+        flushOnParagraph: true,
+      },
+    });
+
+    emitAssistantTextDeltaAndEnd({
+      emit,
+      text: "First paragraph.\n \nSecond paragraph.",
+    });
+
+    expect(extractTextPayloads(onBlockReply.mock.calls)).toEqual([
+      "First paragraph.\n \n",
+      "Second paragraph.",
+    ]);
   });
 });
 

--- a/src/auto-reply/reply/block-reply-coalescer.ts
+++ b/src/auto-reply/reply/block-reply-coalescer.ts
@@ -174,10 +174,15 @@ export function createBlockReplyCoalescer(params: {
       return;
     }
     if (!hasText) {
-      if (bufferText && leadingParagraphSeparatorPattern.test(text)) {
-        // Preserve a forced paragraph tail inside the renderable payload; ordinary
-        // whitespace-only payloads remain suppressed before outbound delivery.
-        bufferText = joinBufferedText(text);
+      if (leadingParagraphSeparatorPattern.test(text)) {
+        // Preserve a forced paragraph tail even when the preceding max-sized block
+        // already flushed; dropping it collapses the next delivered paragraph.
+        if (!bufferText) {
+          startBufferFromPayload(payload);
+          bufferText = text;
+        } else {
+          bufferText = joinBufferedText(text);
+        }
       }
       return;
     }

--- a/src/auto-reply/reply/block-reply-coalescer.ts
+++ b/src/auto-reply/reply/block-reply-coalescer.ts
@@ -174,6 +174,11 @@ export function createBlockReplyCoalescer(params: {
       return;
     }
     if (!hasText) {
+      if (bufferText && leadingParagraphSeparatorPattern.test(text)) {
+        // Preserve a forced paragraph tail inside the renderable payload; ordinary
+        // whitespace-only payloads remain suppressed before outbound delivery.
+        bufferText = joinBufferedText(text);
+      }
       return;
     }
 

--- a/src/auto-reply/reply/block-reply-coalescer.ts
+++ b/src/auto-reply/reply/block-reply-coalescer.ts
@@ -24,6 +24,7 @@ export function createBlockReplyCoalescer(params: {
   const idleMs = Math.max(0, Math.floor(config.idleMs));
   const joiner = config.joiner ?? "";
   const flushOnEnqueue = config.flushOnEnqueue === true;
+  const paragraphSeparatorPattern = /\n[\t ]*\n+$/;
 
   let bufferText = "";
   let bufferReplyToId: ReplyPayload["replyToId"];
@@ -40,7 +41,12 @@ export function createBlockReplyCoalescer(params: {
     if (!text) {
       return bufferText;
     }
-    if (!joiner || bufferText.endsWith(joiner) || text.startsWith(joiner)) {
+    if (
+      !joiner ||
+      bufferText.endsWith(joiner) ||
+      paragraphSeparatorPattern.test(bufferText) ||
+      text.startsWith(joiner)
+    ) {
       return `${bufferText}${text}`;
     }
     return `${bufferText}${joiner}${text}`;

--- a/src/auto-reply/reply/block-reply-coalescer.ts
+++ b/src/auto-reply/reply/block-reply-coalescer.ts
@@ -25,6 +25,7 @@ export function createBlockReplyCoalescer(params: {
   const joiner = config.joiner ?? "";
   const flushOnEnqueue = config.flushOnEnqueue === true;
   const paragraphSeparatorPattern = /\n[\t ]*\n+$/;
+  const leadingParagraphSeparatorPattern = /^\n[\t ]*\n+/;
 
   let bufferText = "";
   let bufferReplyToId: ReplyPayload["replyToId"];
@@ -45,6 +46,7 @@ export function createBlockReplyCoalescer(params: {
       !joiner ||
       bufferText.endsWith(joiner) ||
       paragraphSeparatorPattern.test(bufferText) ||
+      leadingParagraphSeparatorPattern.test(text) ||
       text.startsWith(joiner)
     ) {
       return `${bufferText}${text}`;

--- a/src/auto-reply/reply/block-reply-coalescer.ts
+++ b/src/auto-reply/reply/block-reply-coalescer.ts
@@ -36,6 +36,16 @@ export function createBlockReplyCoalescer(params: {
   let bufferMetadataSource: ReplyPayload | undefined;
   let idleTimer: NodeJS.Timeout | undefined;
 
+  const joinBufferedText = (text: string) => {
+    if (!text) {
+      return bufferText;
+    }
+    if (!joiner || bufferText.endsWith(joiner) || text.startsWith(joiner)) {
+      return `${bufferText}${text}`;
+    }
+    return `${bufferText}${joiner}${text}`;
+  };
+
   const clearIdleTimer = () => {
     if (!idleTimer) {
       return;
@@ -124,7 +134,7 @@ export function createBlockReplyCoalescer(params: {
 
   /** Merges buffered text into a media payload without changing media metadata. */
   const mergeBufferedTextWithMedia = (payload: ReplyPayload, text: string): ReplyPayload => {
-    const mergedText = text ? `${bufferText}${joiner}${text}` : bufferText;
+    const mergedText = joinBufferedText(text);
     const mergedPayload: ReplyPayload = {
       ...payload,
       text: mergedText,
@@ -199,7 +209,7 @@ export function createBlockReplyCoalescer(params: {
       startBufferFromPayload(payload);
     }
 
-    const nextText = bufferText ? `${bufferText}${joiner}${text}` : text;
+    const nextText = bufferText ? joinBufferedText(text) : text;
     if (nextText.length > maxChars) {
       if (bufferText) {
         void flush({ force: true });

--- a/src/auto-reply/reply/block-reply-pipeline.test.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.test.ts
@@ -1,6 +1,7 @@
 /** Tests block reply pipeline buffering, dedupe, and final flush behavior. */
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EmbeddedBlockChunker } from "../../agents/embedded-agent-block-chunker.js";
 import { getReplyPayloadMetadata, setReplyPayloadMetadata } from "../reply-payload.js";
 import { createBlockReplyContentKey, createBlockReplyPipeline } from "./block-reply-pipeline.js";
 
@@ -55,6 +56,36 @@ describe("createBlockReplyContentKey", () => {
 });
 
 describe("createBlockReplyPipeline dedup with threading", () => {
+  it("reconstructs paragraph separators that start at maxChars", async () => {
+    const chunker = new EmbeddedBlockChunker({
+      minChars: 1,
+      maxChars: 10,
+      breakPreference: "paragraph",
+      flushOnParagraph: true,
+    });
+    chunker.append("abcdefghij\n\nRest");
+    const chunks: string[] = [];
+    chunker.drain({ force: false, emit: (chunk) => chunks.push(chunk) });
+
+    const delivered: string[] = [];
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async (payload) => {
+        delivered.push(payload.text ?? "");
+      },
+      timeoutMs: 5000,
+      coalescing: { minChars: 1, maxChars: 200, idleMs: 0, joiner: "\n\n" },
+    });
+
+    for (const chunk of chunks) {
+      pipeline.enqueue({ text: chunk });
+    }
+    await pipeline.flush({ force: true });
+
+    expect(chunks).toEqual(["abcdefghij", "\n\nRest"]);
+    expect(chunks.every((chunk) => chunk.length <= 10)).toBe(true);
+    expect(delivered).toEqual(["abcdefghij\n\nRest"]);
+  });
+
   it("keeps an un-aborted delivery signal when timeouts are disabled", async () => {
     let deliverySignal: AbortSignal | undefined;
     const pipeline = createBlockReplyPipeline({

--- a/src/auto-reply/reply/block-reply-pipeline.test.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.test.ts
@@ -117,6 +117,36 @@ describe("createBlockReplyPipeline dedup with threading", () => {
     expect(delivered).toEqual(["abcdefghij\n\n"]);
   });
 
+  it("keeps a separator-only chunk sendable at the effective coalescing cap", async () => {
+    const chunker = new EmbeddedBlockChunker({
+      minChars: 1,
+      maxChars: 10,
+      breakPreference: "paragraph",
+      flushOnParagraph: true,
+    });
+    chunker.append("abcdefghij\n\n");
+    const chunks: string[] = [];
+    chunker.drain({ force: false, emit: (chunk) => chunks.push(chunk) });
+    chunker.drain({ force: true, emit: (chunk) => chunks.push(chunk) });
+
+    const delivered: string[] = [];
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async (payload) => {
+        delivered.push(payload.text ?? "");
+      },
+      timeoutMs: 5000,
+      coalescing: { minChars: 1, maxChars: 10, idleMs: 0, joiner: "\n\n" },
+    });
+
+    for (const chunk of chunks) {
+      pipeline.enqueue({ text: chunk });
+    }
+    await pipeline.flush({ force: true });
+
+    expect(chunks).toEqual(["abcdefghij", "\n\n"]);
+    expect(delivered).toEqual(["abcdefghij", "\n\n"]);
+  });
+
   it("keeps an un-aborted delivery signal when timeouts are disabled", async () => {
     let deliverySignal: AbortSignal | undefined;
     const pipeline = createBlockReplyPipeline({

--- a/src/auto-reply/reply/block-reply-pipeline.test.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.test.ts
@@ -86,6 +86,37 @@ describe("createBlockReplyPipeline dedup with threading", () => {
     expect(delivered).toEqual(["abcdefghij\n\nRest"]);
   });
 
+  it("carries a separator-only final chunk into the preceding delivery", async () => {
+    const chunker = new EmbeddedBlockChunker({
+      minChars: 1,
+      maxChars: 10,
+      breakPreference: "paragraph",
+      flushOnParagraph: true,
+    });
+    chunker.append("abcdefghij\n\n");
+    const chunks: string[] = [];
+    chunker.drain({ force: false, emit: (chunk) => chunks.push(chunk) });
+    chunker.drain({ force: true, emit: (chunk) => chunks.push(chunk) });
+
+    const delivered: string[] = [];
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async (payload) => {
+        delivered.push(payload.text ?? "");
+      },
+      timeoutMs: 5000,
+      coalescing: { minChars: 1, maxChars: 200, idleMs: 0, joiner: "\n\n" },
+    });
+
+    for (const chunk of chunks) {
+      pipeline.enqueue({ text: chunk });
+    }
+    pipeline.enqueue({ text: " " });
+    await pipeline.flush({ force: true });
+
+    expect(chunks).toEqual(["abcdefghij", "\n\n"]);
+    expect(delivered).toEqual(["abcdefghij\n\n"]);
+  });
+
   it("keeps an un-aborted delivery signal when timeouts are disabled", async () => {
     let deliverySignal: AbortSignal | undefined;
     const pipeline = createBlockReplyPipeline({

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -1153,6 +1153,23 @@ describe("block reply coalescer", () => {
     coalescer.stop();
   });
 
+  it("preserves a paragraph tail after an equal-cap flush", async () => {
+    const { flushes, coalescer } = createBlockCoalescerHarness({
+      minChars: 1,
+      maxChars: 10,
+      idleMs: 0,
+      joiner: "\n\n",
+    });
+
+    coalescer.enqueue({ text: "abcdefghij" });
+    coalescer.enqueue({ text: "\n\n" });
+    coalescer.enqueue({ text: "Next paragraph." });
+    await coalescer.flush({ force: true });
+
+    expect(flushes).toEqual(["abcdefghij", "\n\n", "Next paragraph."]);
+    coalescer.stop();
+  });
+
   it("keeps buffering newline-style chunks until minChars is reached", async () => {
     vi.useFakeTimers();
     const { flushes, coalescer } = createBlockCoalescerHarness({

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -1137,6 +1137,22 @@ describe("block reply coalescer", () => {
     coalescer.stop();
   });
 
+  it("does not duplicate an incoming whitespace-bearing paragraph boundary", async () => {
+    const { flushes, coalescer } = createBlockCoalescerHarness({
+      minChars: 1,
+      maxChars: 2000,
+      idleMs: 0,
+      joiner: "\n\n",
+    });
+
+    coalescer.enqueue({ text: "First paragraph." });
+    coalescer.enqueue({ text: "\n \nSecond paragraph." });
+    await coalescer.flush({ force: true });
+
+    expect(flushes).toEqual(["First paragraph.\n \nSecond paragraph."]);
+    coalescer.stop();
+  });
+
   it("keeps buffering newline-style chunks until minChars is reached", async () => {
     vi.useFakeTimers();
     const { flushes, coalescer } = createBlockCoalescerHarness({

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -1121,6 +1121,22 @@ describe("block reply coalescer", () => {
     coalescer.stop();
   });
 
+  it("does not duplicate a whitespace-bearing paragraph boundary", async () => {
+    const { flushes, coalescer } = createBlockCoalescerHarness({
+      minChars: 1,
+      maxChars: 2000,
+      idleMs: 0,
+      joiner: "\n\n",
+    });
+
+    coalescer.enqueue({ text: "First paragraph.\n \n" });
+    coalescer.enqueue({ text: "Second paragraph." });
+    await coalescer.flush({ force: true });
+
+    expect(flushes).toEqual(["First paragraph.\n \nSecond paragraph."]);
+    coalescer.stop();
+  });
+
   it("keeps buffering newline-style chunks until minChars is reached", async () => {
     vi.useFakeTimers();
     const { flushes, coalescer } = createBlockCoalescerHarness({

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -1105,6 +1105,22 @@ describe("block reply coalescer", () => {
     coalescer.stop();
   });
 
+  it("does not duplicate a preserved paragraph boundary", async () => {
+    const { flushes, coalescer } = createBlockCoalescerHarness({
+      minChars: 1,
+      maxChars: 2000,
+      idleMs: 0,
+      joiner: "\n\n",
+    });
+
+    coalescer.enqueue({ text: "First paragraph.\n\n" });
+    coalescer.enqueue({ text: "Second paragraph." });
+    await coalescer.flush({ force: true });
+
+    expect(flushes).toEqual(["First paragraph.\n\nSecond paragraph."]);
+    coalescer.stop();
+  });
+
   it("keeps buffering newline-style chunks until minChars is reached", async () => {
     vi.useFakeTimers();
     const { flushes, coalescer } = createBlockCoalescerHarness({


### PR DESCRIPTION
Closes #42106

## What Problem This Solves

Fixes an issue where users receiving block-streamed replies could see paragraph boundaries disappear when a reply crossed multiple streamed deliveries.

## Why This Change Was Made

Paragraph separators are preserved on the delivery that ends a paragraph, while coalescing avoids adding a second separator when that boundary is already present. Equal-cap separator tails remain sendable, and BTW delivery admits recognized paragraph separators without forwarding ordinary whitespace-only payloads.

## User Impact

Streamed Markdown keeps its paragraph structure when the client reconstructs successive reply deliveries without exceeding the configured outbound chunk limit, including BTW side-question deliveries.

## Evidence

- Current head: `a56e0cd477deb1afea0c56dd8151708c3b5ad1d5`.
- Final equal-cap production runtime proof: `EmbeddedBlockChunker` plus `createBlockReplyPipeline` with `maxChars=10` processed `abcdefghij\n\n` into bounded chunks `["abcdefghij", "\\n\\n"]` and delivered the same two payloads.
- Inspectable output: `{"chunks":["abcdefghij","\\n\\n"],"delivered":["abcdefghij","\\n\\n"],"lengths":[10,4]}`.
- BTW production runtime regression proof: `runBtwSideQuestion` with `maxChars=10` delivered `["abcdefghij", "\\n\\n", "Next", "paragraph."]`, preserving the separator between forced blocks while respecting the cap.
- Supporting checks: `reply-utils.test.ts` 109/109, `block-reply-pipeline.test.ts` 25/25, the focused BTW separator test 1/1, chunker/subscriber boundary tests 27/27; targeted `oxfmt --check`, `oxlint`, and `git diff --check` passed.
- Proof boundary: local production chunker/coalescer/pipeline and BTW delivery paths using synthetic assistant stream text; no external channel was contacted.