### PR TITLE
fix(gateway): chat clients lose the last streamed text when a run ends in error

### DIFF
--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -1233,6 +1233,101 @@ describe("agent event handler", () => {
     nowSpy.mockRestore();
   });
 
+  it("flushes buffered text as delta before the error terminal", () => {
+    let now = 10_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const { broadcast, chatRunState, handler } = createHarness({ lifecycleErrorRetryGraceMs: 0 });
+    registerNamedChatRun(chatRunState, "err-flush");
+
+    emitAgentEvent(handler, "run-err-flush", "assistant", { text: "Hello" });
+
+    now = 10_100;
+    emitAgentEvent(handler, "run-err-flush", "assistant", { text: "Hello world" });
+
+    emitAgentEvent(
+      handler,
+      "run-err-flush",
+      "lifecycle",
+      { phase: "error", error: "provider failed" },
+      { seq: 2 },
+    );
+
+    const chatPayloads = chatBroadcastCalls(broadcast).map(
+      ([, payload]) => payload as { state?: string; deltaText?: string },
+    );
+    expect(
+      chatPayloads
+        .filter((payload) => payload.state === "delta")
+        .map((payload) => payload.deltaText)
+        .join(""),
+    ).toBe("Hello world");
+    expect(chatPayloads.at(-1)?.state).toBe("error");
+    nowSpy.mockRestore();
+  });
+
+  it("flushes buffered text as delta before deferring a retryable error terminal", () => {
+    vi.useFakeTimers();
+    let now = 10_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const { broadcast, chatRunState, handler } = createHarness({
+      lifecycleErrorRetryGraceMs: 100,
+    });
+    registerNamedChatRun(chatRunState, "err-grace");
+
+    emitAgentEvent(handler, "run-err-grace", "assistant", { text: "Hello" });
+
+    now = 10_100;
+    emitAgentEvent(handler, "run-err-grace", "assistant", { text: "Hello world" });
+
+    emitAgentEvent(
+      handler,
+      "run-err-grace",
+      "lifecycle",
+      { phase: "error", error: "retryable provider failure" },
+      { seq: 2 },
+    );
+
+    // The terminal is still deferred behind the retry grace, but the tail the
+    // throttle withheld has already been delivered.
+    expect(vi.getTimerCount()).toBe(1);
+    expect(
+      chatBroadcastCalls(broadcast)
+        .map(([, payload]) => payload as { state?: string; deltaText?: string })
+        .filter((payload) => payload.state === "delta")
+        .map((payload) => payload.deltaText)
+        .join(""),
+    ).toBe("Hello world");
+    nowSpy.mockRestore();
+  });
+
+  it("carries buffered text in the terminal message when an error classifies as cancellation", () => {
+    let now = 10_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const { broadcast, chatRunState, handler } = createHarness({ lifecycleErrorRetryGraceMs: 0 });
+    registerNamedChatRun(chatRunState, "err-cancel");
+
+    emitAgentEvent(handler, "run-err-cancel", "assistant", { text: "Hello" });
+
+    now = 10_100;
+    emitAgentEvent(handler, "run-err-cancel", "assistant", { text: "Hello world" });
+
+    emitAgentEvent(
+      handler,
+      "run-err-cancel",
+      "lifecycle",
+      { phase: "error", aborted: true },
+      { seq: 2 },
+    );
+
+    const terminal = chatBroadcastCalls(broadcast).at(-1)?.[1] as {
+      state?: string;
+      message?: { content?: Array<{ text?: string }> };
+    };
+    expect(terminal?.state).toBe("aborted");
+    expect(terminal?.message?.content?.[0]?.text).toBe("Hello world");
+    nowSpy.mockRestore();
+  });
+
   it("preserves pre-tool assistant text when later segments stream as non-prefix snapshots", () => {
     let now = 10_500;
     const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -1636,15 +1636,31 @@ export function createAgentEventHandler({
     }
 
     if (lifecyclePhase === "error") {
-      clearBufferedChatState(clientRunId);
       const skipChatErrorFinal = isChatSendRunActive(evt.runId) && !chatLink;
       const isFallbackExhaustedFailure = evt.data?.fallbackExhaustedFailure === true;
       // Per-attempt provider errors keep the retry grace so fallback can reuse
       // the runId. Once the runner marks fallback as exhausted, clear chat state
       // immediately so webchat sessions do not stay in progress until the timer.
       if (isAborted || isFallbackExhaustedFailure || lifecycleErrorRetryGraceMs <= 0) {
+        // finalizeLifecycleEvent clears the buffer itself, after emitChatTerminal
+        // has flushed the throttled tail and resolved the terminal message.
         finalizeLifecycleEvent(evt, { skipChatErrorFinal, restartRecoveryState });
       } else {
+        // Deliver the throttled tail before isolating the buffer so a fallback
+        // attempt cannot merge onto the failed attempt's text.
+        if (sessionKey) {
+          flushBufferedChatDeltaIfNeeded(
+            sessionKey,
+            sessionAgentId,
+            clientRunId,
+            evt.runId,
+            evt.seq,
+            {
+              controlUiVisible: isControlUiVisible,
+            },
+          );
+        }
+        clearBufferedChatState(clientRunId);
         scheduleTerminalLifecycleError(evt, { skipChatErrorFinal, restartRecoveryState });
       }
       return;


### PR DESCRIPTION
Fixes #119554

## What Problem This Solves

Fixes an issue where users watching a streamed answer would see the assistant message truncated
when the run ended in an error instead of completing normally. The last chunk of text the model
produced never arrived on the `chat` channel, and on a terminal that classified as a cancellation
the final frame carried no message text at all. Nothing in the stream signalled the loss, and the
`end` terminal behaved correctly, so the gap only showed up on failed runs.

Full mechanism, version verification, and scope analysis are in #119554.

## Why This Change Was Made

`emitChatDelta` withholds a chunk that arrives inside its 150 ms window and leaves it in the run
buffer for a later event to deliver. `emitChatTerminal` is meant to be that event — it flushes the
buffer before emitting the terminal frame. On the `error` branch it could not, because
`clearBufferedChatState` ran at the top of the branch, before `finalizeLifecycleEvent`, so the
flush resolved empty text and no-opped.

Two changes, both inside that branch:

- **Immediate branch** — removed the clear. It was redundant: `finalizeLifecycleEvent` already
  calls `clearBufferedChatState` itself at `server-chat.ts:793`, *after* `emitChatTerminal` has
  flushed and resolved the terminal message. Removing it is what fixes the cancellation-classified
  terminal's missing `message`; merely adding a flush ahead of the clear would have fixed the
  delta and left `message: undefined`, because `emitChatTerminal`'s own
  `resolveBufferedChatTextState` would still have seen an empty buffer.
- **Deferred retry-grace branch** — kept the clear, so a fallback attempt still cannot merge onto
  the failed attempt's text, but flushed before it. This matches the shape already used at the
  pre-tool-broadcast and pre-item-broadcast flush sites in the same function (`:1470`, `:1547`).

Non-goals: this does not change the 150 ms throttle itself. The throttle's lack of a trailing
flush is a separate cadence/latency question and is not touched here.

## User Impact

Streaming clients now receive the complete assistant text on runs that end in an error, not just
on runs that end normally. Cancellation-classified terminals carry the partial text in `message`
instead of dropping it. Retry and fallback behavior is unchanged — the buffer is still isolated
before any fallback attempt can reuse the `runId`.

## Evidence

Three regression tests added next to the existing `end`-terminal test in
`src/gateway/server-chat.agent-events.test.ts`, covering both branches and the terminal message.

All three fail on `main` before the change, with exactly the symptom described:

```
 × flushes buffered text as delta before the error terminal
   → AssertionError: expected 'Hello' to be 'Hello world'
 × flushes buffered text as delta before deferring a retryable error terminal
   → AssertionError: expected 'Hello' to be 'Hello world'
 × carries buffered text in the terminal message when an error classifies as cancellation
   → AssertionError: expected undefined to be 'Hello world'

 Test Files  1 failed (1)
      Tests  3 failed | 134 passed (137)
```

After the change, the three gateway chat suites are green:

```
node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts \
  src/gateway/server-chat.agent-events.test.ts \
  src/gateway/server.chat.gateway-server-chat.test.ts \
  src/gateway/server.chat.gateway-server-chat-b.test.ts

 Test Files  3 passed (3)
      Tests  284 passed (284)
```

`pnpm tsgo:core`, `oxlint`, and `oxfmt --check` on the two changed files are all clean.


## Runtime proof (running Gateway + subscribed client)

Frames below come from a Gateway process started from this checkout and a real Gateway Protocol v4
client subscribed to the session, not from a handler harness.

**Rig.** `openclaw gateway run` on loopback with token auth, channels skipped, and a scrubbed
process environment so no ambient provider credential can be picked up. One model provider points
at a local OpenAI-compatible stub server; its API key is a literal placeholder string. The client is
this repository's own reference client (`packages/gateway-client`), connecting as `operator` with
`operator.read`/`operator.write`, calling `sessions.messages.subscribe` and then one `chat.send`.
Every inbound frame is logged. The same client build, stub, config, and prompt drive both runs.

**Trigger.** The stub streams `Hello`, then ` world` 30 ms later — inside the 150 ms delta throttle
window, so the tail is withheld — then destroys the connection mid-stream with no `finish_reason`
and no `[DONE]`:

```
[stub] chat.completions request received {"stream":true}
[stub] sent first content delta {"text":"Hello"}
[stub] sent second content delta {"text":" world","gapMs":30}
[stub] destroying connection mid-stream (no finish_reason, no [DONE])
```

The runtime classifies the drop, retries once, the retry is refused by the provider-failure
cooldown, and the run ends on the lifecycle error path — the branch this PR changes.

**Client subscribe transcript (abridged).** Identical on both runs; timestamps below are relative to
`chat.send`. The ~20-30 s before the first frame is first-turn workspace/context preparation on a
cold state directory, not stream latency.

```
[+    27ms] hello-ok {"protocol":4,"role":"operator","scopes":["operator.read","operator.write"]}
[+    41ms] sessions.messages.subscribe {"subscribed":true,"key":"agent:main:proof-session"}
[+     0ms] chat.send {"sessionKey":"proof-session","message":"Reply with a short greeting."}
[+   105ms] chat.send-ack {"runId":"<run-id>","status":"started"}
```

**Before — `26a58bcd`, this branch's parent.** `src/gateway/server-chat.ts` there is byte-identical to
`main` at `c02e3934`. The withheld ` world` never arrives on any frame:

```
[+ 34747ms] chat {"runId":"<run-id>","sessionKey":"agent:main:proof-session","agentId":"main","seq":5,"state":"delta","deltaText":"Hello","message":{"role":"assistant","content":[{"type":"text","text":"Hello"}],"timestamp":<ts>}}
[+ 37478ms] chat {"runId":"<run-id>","sessionKey":"agent:main:proof-session","agentId":"main","seq":9,"state":"status","phase":"preparing_workspace"}
[+ 37657ms] chat {"runId":"<run-id>","sessionKey":"agent:main:proof-session","agentId":"main","seq":10,"state":"status","phase":"preparing_context"}
[+ 37673ms] chat {"runId":"<run-id>","sessionKey":"agent:main:proof-session","agentId":"main","seq":11,"state":"error","errorMessage":"Inline API key for provider \"stubprovider\" is temporarily disabled after a provider auth/billing failure. Retry after about 1 minute, or switch to a different auth profile/API key."}
```

Last text the client ever sees: `Hello`. The model produced `Hello world`.

**After — `da5632df`, this PR.** The flush delta carrying the tail arrives before the terminal:

```
[+ 23000ms] chat {"runId":"<run-id>","sessionKey":"agent:main:proof-session","agentId":"main","seq":5,"state":"delta","deltaText":"Hello","message":{"role":"assistant","content":[{"type":"text","text":"Hello"}],"timestamp":<ts>}}
[+ 25665ms] chat {"runId":"<run-id>","sessionKey":"agent:main:proof-session","agentId":"main","seq":9,"state":"status","phase":"preparing_workspace"}
[+ 25788ms] chat {"runId":"<run-id>","sessionKey":"agent:main:proof-session","agentId":"main","seq":10,"state":"status","phase":"preparing_context"}
[+ 25804ms] chat {"runId":"<run-id>","sessionKey":"agent:main:proof-session","agentId":"main","seq":11,"state":"delta","deltaText":" world","message":{"role":"assistant","content":[{"type":"text","text":"Hello world"}],"timestamp":<ts>}}
[+ 25804ms] chat {"runId":"<run-id>","sessionKey":"agent:main:proof-session","agentId":"main","seq":11,"state":"error","errorMessage":"Inline API key for provider \"stubprovider\" is temporarily disabled after a provider auth/billing failure. Retry after about 1 minute, or switch to a different auth profile/API key."}
```

Last text the client sees: `Hello world`, delivered as a `delta` frame ahead of the terminal, with
frame ordering and the terminal itself otherwise unchanged.

Scope note: this run exercises the immediate error terminal. The cancellation-classified terminal's
`message` field is covered by the third regression test rather than by this capture.

**Reproduce.** Build both commits, point `models.providers.<name>` at a local OpenAI-compatible
server that emits two content deltas under 150 ms apart and then destroys the socket without a
finish event, start `openclaw gateway run`, connect `packages/gateway-client` as an operator, call
`sessions.messages.subscribe` then `chat.send`, and log every `chat` frame.

Run identifiers and wall-clock timestamps are redacted; frame order, relative timing, and payload
text are verbatim.
