### PR TITLE
fix(gateway): claim malformed plugin icon routes

### DIFF
--- a/src/gateway/plugin-icon-http.test.ts
+++ b/src/gateway/plugin-icon-http.test.ts
@@ -56,6 +56,15 @@ const ICON_ROUTES = [
     pathname: `/__openclaw__/catalog-icon/${encodeURIComponent(CATALOG_ICON_URL)}`,
   },
 ] as const;
+const INVALID_ICON_ROUTES = [
+  { label: "blank plugin id", pathname: "/__openclaw__/plugin-icon/" },
+  { label: "invalid plugin id", pathname: "/__openclaw__/plugin-icon/%20" },
+  { label: "malformed plugin id", pathname: "/__openclaw__/plugin-icon/%zz" },
+  { label: "nested plugin id", pathname: "/__openclaw__/plugin-icon/one/two" },
+  { label: "blank catalog URL", pathname: "/__openclaw__/catalog-icon/" },
+  { label: "malformed catalog URL", pathname: "/__openclaw__/catalog-icon/%zz" },
+  { label: "nested catalog URL", pathname: "/__openclaw__/catalog-icon/one/two" },
+] as const;
 
 let port = 0;
 let server: ReturnType<typeof createServer>;
@@ -122,6 +131,20 @@ function request(pathname: string, options?: { token?: string; method?: string }
 }
 
 describe("Control UI plugin and catalog icon routes", () => {
+  it.each(INVALID_ICON_ROUTES)(
+    "claims $label instead of falling through to the Control UI",
+    async ({ pathname }) => {
+      const response = await request(pathname);
+
+      expect(response.status).toBe(404);
+      await expect(response.text()).resolves.toBe("Not Found");
+      expect(mocks.authorize).toHaveBeenCalledOnce();
+      expect(mocks.resolveIconUrl).not.toHaveBeenCalled();
+      expect(mocks.resolveCatalogIconUrl).not.toHaveBeenCalled();
+      expect(mocks.readRemoteMediaBuffer).not.toHaveBeenCalled();
+    },
+  );
+
   it.each(
     ICON_ROUTES.flatMap(({ label, pathname }) =>
       (["GET", "HEAD"] as const).map((method) => ({ label, method, pathname })),

--- a/src/gateway/plugin-icon-http.ts
+++ b/src/gateway/plugin-icon-http.ts
@@ -66,45 +66,47 @@ export function resolvePluginIconRoutePrefix(basePath?: string): string {
   return `${normalizeBasePath(basePath)}${CONTROL_UI_PLUGIN_ICON_PATH_PREFIX}/`;
 }
 
-function parsePluginIconRequest(urlRaw: string | undefined, basePath?: string): string | null {
+type IconRequestPathResolution = { matched: false } | { matched: true; value: string | null };
+
+function parseIconRequestPath(
+  urlRaw: string | undefined,
+  prefix: string,
+  isValid: (value: string) => boolean = Boolean,
+): IconRequestPathResolution {
   if (!urlRaw) {
-    return null;
+    return { matched: false };
   }
   const pathname = new URL(urlRaw, "http://localhost").pathname;
-  const prefix = resolvePluginIconRoutePrefix(basePath);
   if (!pathname.startsWith(prefix)) {
-    return null;
+    return { matched: false };
   }
-  const encodedPluginId = pathname.slice(prefix.length);
-  if (!encodedPluginId || encodedPluginId.includes("/")) {
-    return null;
+  const encodedValue = pathname.slice(prefix.length);
+  if (!encodedValue || encodedValue.includes("/")) {
+    return { matched: true, value: null };
   }
   try {
-    const pluginId = decodeURIComponent(encodedPluginId);
-    return PLUGIN_ID_RE.test(pluginId) ? pluginId : null;
+    const value = decodeURIComponent(encodedValue);
+    return { matched: true, value: isValid(value) ? value : null };
   } catch {
-    return null;
+    return { matched: true, value: null };
   }
 }
 
-function parseCatalogIconRequest(urlRaw: string | undefined, basePath?: string): string | null {
-  if (!urlRaw) {
-    return null;
-  }
-  const pathname = new URL(urlRaw, "http://localhost").pathname;
+function parsePluginIconRequest(
+  urlRaw: string | undefined,
+  basePath?: string,
+): IconRequestPathResolution {
+  return parseIconRequestPath(urlRaw, resolvePluginIconRoutePrefix(basePath), (value) =>
+    PLUGIN_ID_RE.test(value),
+  );
+}
+
+function parseCatalogIconRequest(
+  urlRaw: string | undefined,
+  basePath?: string,
+): IconRequestPathResolution {
   const prefix = `${normalizeBasePath(basePath)}${CONTROL_UI_CATALOG_ICON_PATH_PREFIX}/`;
-  if (!pathname.startsWith(prefix)) {
-    return null;
-  }
-  const encodedIconUrl = pathname.slice(prefix.length);
-  if (!encodedIconUrl || encodedIconUrl.includes("/")) {
-    return null;
-  }
-  try {
-    return decodeURIComponent(encodedIconUrl) || null;
-  } catch {
-    return null;
-  }
+  return parseIconRequestPath(urlRaw, prefix);
 }
 
 function normalizeMimeType(contentType: string | undefined): string | undefined {
@@ -259,11 +261,13 @@ export async function handlePluginIconHttpRequest(
     rateLimiter?: AuthRateLimiter;
   },
 ): Promise<boolean> {
-  const pluginId = parsePluginIconRequest(req.url, opts.basePath);
-  const catalogIconUrl = parseCatalogIconRequest(req.url, opts.basePath);
-  if (!pluginId && !catalogIconUrl) {
+  const pluginRequest = parsePluginIconRequest(req.url, opts.basePath);
+  const catalogRequest = parseCatalogIconRequest(req.url, opts.basePath);
+  if (!pluginRequest.matched && !catalogRequest.matched) {
     return false;
   }
+  const pluginId = pluginRequest.matched ? pluginRequest.value : null;
+  const catalogIconUrl = catalogRequest.matched ? catalogRequest.value : null;
   const method = req.method;
   if (method !== "GET" && method !== "HEAD") {
     sendMethodNotAllowed(res, "GET, HEAD");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where malformed plugin and catalog icon URLs could fall through to the Control UI and return the SPA HTML with a `200` response.

## Why This Change Was Made

Icon route parsing now distinguishes an unrelated path from a matched route with invalid input, while preserving the existing method and authentication checks. Both icon route variants use the same closed parser state, following the route-ownership pattern established by #85261.

## User Impact

Malformed icon URLs now receive the route-owned `404 Not Found` response instead of the Control UI HTML.

## Evidence

- `pnpm test src/gateway/plugin-icon-http.test.ts`: 32 focused tests passed.
- `pnpm exec tsx proof-live.ts`: the same loopback HTTP call chain ran the production icon handler followed by the production Control UI handler on the pinned base and exact head.

```text
$ pnpm exec tsx proof-live.ts
base 26a58bcd92baeb8ed6595d5202b16bd4e08be704
malformed-plugin=200 owner=control-ui
malformed-catalog=200 owner=control-ui
negative-control=200 owner=control-ui

head 8bd8703d75af93a0ede3ffcc8bd7dfb474142705
malformed-plugin=404 owner=Not Found
malformed-catalog=404 owner=Not Found
negative-control=200 owner=control-ui
```

<details>
<summary>proof-live.ts</summary>

```ts
import { execFileSync } from "node:child_process";
import { mkdtemp, rm, writeFile } from "node:fs/promises";
import { createServer } from "node:http";
import { tmpdir } from "node:os";
import { join } from "node:path";

const uiRoot = await mkdtemp(join(tmpdir(), "openclaw-icon-route-proof-"));
await writeFile(join(uiRoot, "index.html"), "<!doctype html><title>control-ui-fallback</title>");
await writeFile(join(uiRoot, "openclaw.json"), "{}\n");
process.env.OPENCLAW_CONFIG_PATH = join(uiRoot, "openclaw.json");
process.env.OPENCLAW_STATE_DIR = uiRoot;

const { handleControlUiHttpRequest } = await import("./src/gateway/control-ui.ts");
const { handlePluginIconHttpRequest } = await import("./src/gateway/plugin-icon-http.ts");

const server = createServer(async (req, res) => {
  try {
    const handled = await handlePluginIconHttpRequest(req, res, {
      auth: { mode: "none" },
      config: {},
    });
    if (!handled) {
      await handleControlUiHttpRequest(req, res, {
        auth: { mode: "none" },
        config: {},
        root: { kind: "resolved", path: uiRoot },
      });
    }
  } catch (error) {
    res.statusCode = 500;
    res.end(error instanceof Error ? error.message : String(error));
  }
});

await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
const address = server.address();
if (!address || typeof address === "string") {
  throw new Error("loopback server did not expose a TCP address");
}

async function request(path: string): Promise<{ status: number; owner: string }> {
  const response = await fetch(`http://127.0.0.1:${address.port}${path}`);
  const body = await response.text();
  return {
    status: response.status,
    owner: body.includes("control-ui-fallback") ? "control-ui" : body,
  };
}

try {
  const sha = execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim();
  const plugin = await request("/__openclaw__/plugin-icon/%zz");
  const catalog = await request("/__openclaw__/catalog-icon/%zz");
  const negativeControl = await request("/settings");
  console.log(`sha=${sha}`);
  console.log(`malformed-plugin=${plugin.status} owner=${plugin.owner}`);
  console.log(`malformed-catalog=${catalog.status} owner=${catalog.owner}`);
  console.log(`negative-control=${negativeControl.status} owner=${negativeControl.owner}`);
  if (
    !([200, 404].includes(plugin.status) && [200, 404].includes(catalog.status)) ||
    negativeControl.status !== 200 ||
    negativeControl.owner !== "control-ui"
  ) {
    process.exitCode = 1;
  }
} finally {
  await new Promise<void>((resolve, reject) =>
    server.close((error) => (error ? reject(error) : resolve())),
  );
  await rm(uiRoot, { recursive: true, force: true });
}
```

</details>

AI-assisted: built with Codex

Punchcard-Session: clear-orchard-lantern-bc
