### PR TITLE
fix(gateway): keep health responsive during context cache warmup

### DIFF
--- a/src/agents/context.lookup.test.ts
+++ b/src/agents/context.lookup.test.ts
@@ -27,6 +27,14 @@ const contextTestState = vi.hoisted(() => {
         staticEntries: state.staticCatalogModels,
       },
     })),
+    loadPublishedModelCatalogOwnerSnapshot: vi.fn(async (_params: unknown) => ({
+      config: state.loadConfigImpl() as OpenClawConfig,
+      modelCatalog: {
+        entries: state.discoveredModels,
+        routeVariants: [],
+        staticEntries: state.staticCatalogModels,
+      },
+    })),
   };
   return state;
 });
@@ -44,6 +52,8 @@ vi.mock("../config/runtime-source-projection.js", () => ({
 
 vi.mock("./prepared-model-catalog.js", () => ({
   loadPreparedModelCatalogOwnerSnapshot: contextTestState.loadModelCatalogOwnerSnapshot,
+  loadPublishedPreparedModelCatalogOwnerSnapshot:
+    contextTestState.loadPublishedModelCatalogOwnerSnapshot,
 }));
 
 function mockContextDeps(params: {
@@ -134,6 +144,15 @@ describe("lookupContextTokens", () => {
     contextTestState.runtimeConfigSourceSnapshot = null;
     contextTestState.loadModelCatalogOwnerSnapshot.mockClear();
     contextTestState.loadModelCatalogOwnerSnapshot.mockImplementation(async () => ({
+      modelCatalog: {
+        entries: contextTestState.discoveredModels,
+        routeVariants: [],
+        staticEntries: contextTestState.staticCatalogModels,
+      },
+    }));
+    contextTestState.loadPublishedModelCatalogOwnerSnapshot.mockClear();
+    contextTestState.loadPublishedModelCatalogOwnerSnapshot.mockImplementation(async () => ({
+      config: contextTestState.loadConfigImpl() as OpenClawConfig,
       modelCatalog: {
         entries: contextTestState.discoveredModels,
         routeVariants: [],
@@ -358,7 +377,7 @@ describe("lookupContextTokens", () => {
     );
   });
 
-  it("uses caller config when gateway startup starts cache warming", async () => {
+  it("keeps ordinary cache loading on the exact owner path", async () => {
     const config = createContextOverrideConfig("anthropic", "claude-opus-4.7-20260219", 200_000);
     mockDiscoveryDeps([
       {
@@ -374,9 +393,54 @@ describe("lookupContextTokens", () => {
     expect(contextTestState.loadModelCatalogOwnerSnapshot).toHaveBeenCalledWith(
       expect.objectContaining({ config, readOnly: true }),
     );
+    expect(contextTestState.loadPublishedModelCatalogOwnerSnapshot).not.toHaveBeenCalled();
     expect(
       lookupContextTokens("anthropic/claude-opus-4.7-20260219", { allowAsyncLoad: false }),
     ).toBe(ANTHROPIC_CONTEXT_1M_TOKENS);
+  });
+
+  it("warms from the current Gateway-published owner without hashing a fallback owner key", async () => {
+    const requestedConfig = createContextOverrideConfig("synthetic", "stale-model", 111_000);
+    const publishedConfig = createContextOverrideConfig("synthetic", "current-model", 222_000);
+    contextTestState.loadPublishedModelCatalogOwnerSnapshot.mockResolvedValueOnce({
+      config: publishedConfig,
+      modelCatalog: {
+        entries: [{ id: "discovered-model", provider: "synthetic", contextWindow: 64_000 }],
+        routeVariants: [],
+        staticEntries: [],
+      },
+    });
+
+    const { lookupContextTokens, prewarmContextWindowCacheAfterReady } =
+      await importContextModule();
+    await prewarmContextWindowCacheAfterReady({ config: requestedConfig });
+
+    expect(contextTestState.loadPublishedModelCatalogOwnerSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: requestedConfig,
+        allowGatewaySubagentBinding: true,
+        readOnly: true,
+      }),
+    );
+    expect(contextTestState.loadModelCatalogOwnerSnapshot).not.toHaveBeenCalled();
+    expect(
+      lookupContextTokens("current-model", {
+        allowAsyncLoad: false,
+        skipRuntimeConfigLoad: true,
+      }),
+    ).toBe(222_000);
+    expect(
+      lookupContextTokens("discovered-model", {
+        allowAsyncLoad: false,
+        skipRuntimeConfigLoad: true,
+      }),
+    ).toBe(64_000);
+    expect(
+      lookupContextTokens("stale-model", {
+        allowAsyncLoad: false,
+        skipRuntimeConfigLoad: true,
+      }),
+    ).toBeUndefined();
   });
 
   it("warms fresh caches instead of reusing a pre-generation load promise", async () => {

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -44,6 +44,13 @@ type ModelEntry = {
   contextWindow?: number;
   contextTokens?: number;
 };
+type ContextWindowCatalogOwner = {
+  config: OpenClawConfig;
+  modelCatalog: {
+    entries: ModelEntry[];
+    staticEntries?: ModelEntry[];
+  };
+};
 const CONFIG_LOAD_RETRY_POLICY: BackoffPolicy = {
   initialMs: 1_000,
   maxMs: 60_000,
@@ -186,7 +193,10 @@ function primeConfiguredContextWindows(): OpenClawConfig | undefined {
   }
 }
 
-export function ensureContextWindowCacheLoaded(cfgOverride?: OpenClawConfig): Promise<void> {
+function ensureContextWindowCacheLoadedFromOwner(params: {
+  cfgOverride?: OpenClawConfig;
+  catalogOwner?: ContextWindowCatalogOwner;
+}): Promise<void> {
   const generation = CONTEXT_WINDOW_RUNTIME_STATE.generation;
   if (
     CONTEXT_WINDOW_RUNTIME_STATE.loadPromise &&
@@ -195,9 +205,11 @@ export function ensureContextWindowCacheLoaded(cfgOverride?: OpenClawConfig): Pr
     return CONTEXT_WINDOW_RUNTIME_STATE.loadPromise;
   }
 
-  const cfg = cfgOverride
-    ? primeConfiguredContextWindowsFromConfig(cfgOverride)
-    : primeConfiguredContextWindows();
+  const cfg = params.catalogOwner
+    ? primeConfiguredContextWindowsFromConfig(params.catalogOwner.config)
+    : params.cfgOverride
+      ? primeConfiguredContextWindowsFromConfig(params.cfgOverride)
+      : primeConfiguredContextWindows();
   if (!cfg) {
     return Promise.resolve();
   }
@@ -209,17 +221,22 @@ export function ensureContextWindowCacheLoaded(cfgOverride?: OpenClawConfig): Pr
         return;
       }
       try {
-        const { loadPreparedModelCatalogOwnerSnapshot } = await loadPreparedModelCatalogRuntime();
-        const defaultAgentId = resolveDefaultAgentId(cfg);
-        const catalogResult = await loadPreparedModelCatalogOwnerSnapshot({
-          config: cfg,
-          agentId: defaultAgentId,
-          agentDir: resolveAgentDir(cfg, defaultAgentId),
-          readOnly: true,
-        }).then(
-          (value) => ({ status: "fulfilled" as const, value }),
-          (reason: unknown) => ({ status: "rejected" as const, reason }),
-        );
+        const catalogResult = params.catalogOwner
+          ? ({ status: "fulfilled" as const, value: params.catalogOwner } as const)
+          : await (async () => {
+              const { loadPreparedModelCatalogOwnerSnapshot } =
+                await loadPreparedModelCatalogRuntime();
+              const defaultAgentId = resolveDefaultAgentId(cfg);
+              return await loadPreparedModelCatalogOwnerSnapshot({
+                config: cfg,
+                agentId: defaultAgentId,
+                agentDir: resolveAgentDir(cfg, defaultAgentId),
+                readOnly: true,
+              }).then(
+                (value) => ({ status: "fulfilled" as const, value }),
+                (reason: unknown) => ({ status: "rejected" as const, reason }),
+              );
+            })();
         if (CONTEXT_WINDOW_RUNTIME_STATE.generation !== generation) {
           return;
         }
@@ -251,6 +268,53 @@ export function ensureContextWindowCacheLoaded(cfgOverride?: OpenClawConfig): Pr
     });
   CONTEXT_WINDOW_RUNTIME_STATE.loadGeneration = generation;
   return CONTEXT_WINDOW_RUNTIME_STATE.loadPromise;
+}
+
+export function ensureContextWindowCacheLoaded(cfgOverride?: OpenClawConfig): Promise<void> {
+  return ensureContextWindowCacheLoadedFromOwner({ cfgOverride });
+}
+
+/**
+ * Reuse the Gateway's published catalog generation. Omitting the Gateway binding
+ * falls through to a read-only owner whose key hashes the full model config.
+ */
+export async function prewarmContextWindowCacheAfterReady(params: {
+  config: OpenClawConfig;
+  isCancelled?: () => boolean;
+}): Promise<void> {
+  const generation = CONTEXT_WINDOW_RUNTIME_STATE.generation;
+  if (
+    CONTEXT_WINDOW_RUNTIME_STATE.loadPromise &&
+    CONTEXT_WINDOW_RUNTIME_STATE.loadGeneration === generation
+  ) {
+    return CONTEXT_WINDOW_RUNTIME_STATE.loadPromise;
+  }
+  const shouldStop = () =>
+    CONTEXT_WINDOW_RUNTIME_STATE.generation !== generation || params.isCancelled?.() === true;
+  if (shouldStop()) {
+    return;
+  }
+  try {
+    const { loadPublishedPreparedModelCatalogOwnerSnapshot } =
+      await loadPreparedModelCatalogRuntime();
+    if (shouldStop()) {
+      return;
+    }
+    const defaultAgentId = resolveDefaultAgentId(params.config);
+    const owner = await loadPublishedPreparedModelCatalogOwnerSnapshot({
+      config: params.config,
+      agentId: defaultAgentId,
+      agentDir: resolveAgentDir(params.config, defaultAgentId),
+      allowGatewaySubagentBinding: true,
+      readOnly: true,
+    });
+    if (shouldStop()) {
+      return;
+    }
+    await ensureContextWindowCacheLoadedFromOwner({ catalogOwner: owner });
+  } catch {
+    // Optional Gateway warmup is best-effort; request-time loading remains exact.
+  }
 }
 
 export async function waitForContextWindowCacheLoad(options?: {

--- a/src/gateway/server-startup-context-cache-prewarm.ts
+++ b/src/gateway/server-startup-context-cache-prewarm.ts
@@ -14,7 +14,7 @@ type ContextCachePrewarmHandle = {
 };
 
 export function scheduleContextCachePrewarm(params: {
-  cfgAtStart: OpenClawConfig;
+  getConfig: () => OpenClawConfig;
   startupTrace?: StartupTrace;
   log: { warn: (msg: string) => void };
 }): ContextCachePrewarmHandle {
@@ -23,9 +23,12 @@ export function scheduleContextCachePrewarm(params: {
     if (stopped) {
       return;
     }
-    const { ensureContextWindowCacheLoaded } = await import("../agents/context.js");
+    const { prewarmContextWindowCacheAfterReady } = await import("../agents/context.js");
     if (!stopped) {
-      await ensureContextWindowCacheLoaded(params.cfgAtStart);
+      await prewarmContextWindowCacheAfterReady({
+        config: params.getConfig(),
+        isCancelled: () => stopped,
+      });
     }
   };
 

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -67,7 +67,7 @@ const hoisted = vi.hoisted(() => {
     async (_cfg?: unknown, _options?: unknown) => {},
   );
   const loadAgentRuntimePluginRegistryHandle = vi.fn();
-  const ensureContextWindowCacheLoaded = vi.fn(async () => {});
+  const prewarmContextWindowCacheAfterReady = vi.fn(async () => {});
   const scheduleGatewayHandlerPrewarm = vi.fn(() => ({ stop: vi.fn() }));
   const clearCurrentProviderAuthState = vi.fn();
   const warmCurrentProviderAuthStateOffMainThread = vi.fn(
@@ -107,7 +107,7 @@ const hoisted = vi.hoisted(() => {
     prepareModelRuntimeSnapshot,
     refreshPreparedModelRuntimeSnapshots,
     loadAgentRuntimePluginRegistryHandle,
-    ensureContextWindowCacheLoaded,
+    prewarmContextWindowCacheAfterReady,
     scheduleGatewayHandlerPrewarm,
     clearCurrentProviderAuthState,
     warmCurrentProviderAuthStateOffMainThread,
@@ -217,7 +217,7 @@ vi.mock("../agents/runtime-plugins.js", () => ({
 }));
 
 vi.mock("../agents/context.js", () => ({
-  ensureContextWindowCacheLoaded: hoisted.ensureContextWindowCacheLoaded,
+  prewarmContextWindowCacheAfterReady: hoisted.prewarmContextWindowCacheAfterReady,
 }));
 
 vi.mock("./server-startup-handler-prewarm.js", () => ({
@@ -368,8 +368,8 @@ describe("startGatewayPostAttachRuntime", () => {
     hoisted.refreshPreparedModelRuntimeSnapshots.mockReset();
     hoisted.refreshPreparedModelRuntimeSnapshots.mockResolvedValue(undefined);
     hoisted.loadAgentRuntimePluginRegistryHandle.mockReset();
-    hoisted.ensureContextWindowCacheLoaded.mockReset();
-    hoisted.ensureContextWindowCacheLoaded.mockResolvedValue(undefined);
+    hoisted.prewarmContextWindowCacheAfterReady.mockReset();
+    hoisted.prewarmContextWindowCacheAfterReady.mockResolvedValue(undefined);
     hoisted.scheduleGatewayHandlerPrewarm.mockClear();
     hoisted.clearCurrentProviderAuthState.mockClear();
     hoisted.warmCurrentProviderAuthStateOffMainThread.mockReset();
@@ -1258,32 +1258,34 @@ describe("startGatewayPostAttachRuntime", () => {
 
   it("defers context-window cache prewarm to a post-ready sidecar", async () => {
     vi.useFakeTimers();
-    const cfg = { agents: { defaults: { model: "openai/gpt-5.5" } } } as never;
+    const startupConfig = { agents: { defaults: { model: "openai/gpt-5.5" } } };
+    const currentConfig = { ...startupConfig };
     const admission = tryBeginGatewayRootWorkAdmission();
     if (!admission) {
       throw new Error("Expected request work admission");
     }
     const sidecar = scheduleContextCachePrewarm({
-      cfgAtStart: cfg,
+      getConfig: () => currentConfig,
       log: { warn: vi.fn() },
     });
 
     try {
-      // Earlier gateway lifetimes may finish during the fake-clock window;
-      // this sidecar's captured config identifies its own prewarm precisely.
-      expect(hoisted.ensureContextWindowCacheLoaded).not.toHaveBeenCalledWith(cfg);
+      expect(hoisted.prewarmContextWindowCacheAfterReady).not.toHaveBeenCalled();
       await vi.advanceTimersByTimeAsync(4_999);
-      expect(hoisted.ensureContextWindowCacheLoaded).not.toHaveBeenCalledWith(cfg);
+      expect(hoisted.prewarmContextWindowCacheAfterReady).not.toHaveBeenCalled();
       await vi.advanceTimersByTimeAsync(1);
-      expect(hoisted.ensureContextWindowCacheLoaded).not.toHaveBeenCalledWith(cfg);
+      expect(hoisted.prewarmContextWindowCacheAfterReady).not.toHaveBeenCalled();
 
       admission.release();
       await vi.advanceTimersByTimeAsync(249);
-      expect(hoisted.ensureContextWindowCacheLoaded).not.toHaveBeenCalledWith(cfg);
+      expect(hoisted.prewarmContextWindowCacheAfterReady).not.toHaveBeenCalled();
       await vi.advanceTimersByTimeAsync(1);
       await vi.dynamicImportSettled();
       await waitForGatewayTestState(() => {
-        expect(hoisted.ensureContextWindowCacheLoaded).toHaveBeenCalledWith(cfg);
+        expect(hoisted.prewarmContextWindowCacheAfterReady).toHaveBeenCalledWith({
+          config: currentConfig,
+          isCancelled: expect.any(Function),
+        });
       });
     } finally {
       admission.release();
@@ -1294,13 +1296,13 @@ describe("startGatewayPostAttachRuntime", () => {
   it("cancels context-window cache prewarm when the gateway stops first", async () => {
     vi.useFakeTimers();
     const sidecar = scheduleContextCachePrewarm({
-      cfgAtStart: {} as never,
+      getConfig: () => ({}) as never,
       log: { warn: vi.fn() },
     });
 
     await sidecar.stop();
     await vi.runAllTimersAsync();
-    expect(hoisted.ensureContextWindowCacheLoaded).not.toHaveBeenCalled();
+    expect(hoisted.prewarmContextWindowCacheAfterReady).not.toHaveBeenCalled();
   });
 
   it("keeps provider auth prewarm alive when Gmail post-ready sidecars stop", async () => {


### PR DESCRIPTION
Closes #119375

## What Problem This Solves

Fixes an issue where a ready Gateway could delay health, readiness, RPC, and channel work while optional post-ready context-window cache warming processed a large model catalog.

## Why This Change Was Made

The post-ready warmup now reuses the Gateway-published prepared catalog owner and its committed config generation. This avoids constructing a read-only fallback owner that hashes the full model configuration, while preserving exact request-time loading, cache generation checks, and shutdown cancellation.

This is intentionally separate from #119377, which removed the sibling provider session-catalog prewarm. Fresh canonical main remained red for the context-window cache path after that merge.

## User Impact

Operators can expect health, readiness, and Gateway RPC activity to remain responsive during optional context cache warming, while model context-window metadata still converges to the configured values.

## Evidence

- Red, canonical base after #119377: Blacksmith Testbox run https://github.com/openclaw/openclaw/actions/runs/30989290947, 2 x 100,000 synthetic models. Context warmup took 6992.5 ms; health/readiness/RPC p99 were 3319/3590/2451 ms. Cache values were correct.
- Green, exact candidate `28e788b71b551785c9eccb56b9232c40ce877bfc`: Blacksmith Testbox lease `tbx_01kz8ktc8gtxsh1s3smj8qbb40`, run https://github.com/openclaw/openclaw/actions/runs/30993141380, same real Gateway fixture and observation point. Context warmup took 397.4 ms; health/readiness/RPC p99 were 59.04/58.90/53.84 ms with zero errors; metadata returned 128000/64000.
- Focused tests: 96 passed across Gateway startup and agent context coverage on Blacksmith Testbox.
- Scoped changed-surface checks passed: formatting, core/core-test typechecks, lint, boundaries, dead code, import cycles, guards, and `git diff --check`.
- Source-blind behavior-validator: all responsiveness, correctness, and real-path anti-cheat clauses passed.
- Fresh autoreview: no accepted/actionable P0/P1 findings; patch judged correct.

No config, protocol, storage, or public API surface changes.

AI-assisted: yes. I understand the change and verified the lifecycle owner, request-time fallback, generation, cancellation, and sibling startup paths.