### PR TITLE
fix(qa): isolate Matrix wrong-key recovery accounts

### DIFF
--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-destructive.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-destructive.test.ts
@@ -5,11 +5,20 @@ import {
   createPluginStateSyncKeyedStoreForTests,
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { assertMatrixQaCliBackupRestoreFailed } from "./scenario-runtime-e2ee-destructive-recovery.js";
 import { mutateMatrixQaCliStateLoss } from "./scenario-runtime-e2ee-state.js";
+import type { MatrixQaScenarioContext } from "./scenario-runtime-shared.js";
 
 const testing = { assertMatrixQaCliBackupRestoreFailed };
+
+const destructiveScenarioMocks = vi.hoisted(() => ({
+  createMatrixQaClient: vi.fn(),
+  createMatrixQaE2eeScenarioClient: vi.fn(),
+  createMatrixQaRecoveryCliRuntime: vi.fn(),
+  loginMatrixQaRecoveryDevice: vi.fn(),
+  runMatrixQaCliJson: vi.fn(),
+}));
 
 const storageMetadataRuntime = vi.hoisted(() => ({
   normalizeMatrixStorageMetadata(value: unknown) {
@@ -31,7 +40,12 @@ const storageMetadataRuntime = vi.hoisted(() => ({
   },
 }));
 
+vi.mock("../substrate/client.js", () => ({
+  createMatrixQaClient: destructiveScenarioMocks.createMatrixQaClient,
+}));
+
 vi.mock("../substrate/e2ee-client.js", () => ({
+  createMatrixQaE2eeScenarioClient: destructiveScenarioMocks.createMatrixQaE2eeScenarioClient,
   loadMatrixQaE2eeRuntime: async () => ({
     ...storageMetadataRuntime,
     openMatrixRecoveryKeyStoreOptions: (storageRootDir: string) => ({
@@ -41,6 +55,85 @@ vi.mock("../substrate/e2ee-client.js", () => ({
     }),
   }),
 }));
+
+vi.mock("./scenario-runtime-e2ee-destructive-recovery.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./scenario-runtime-e2ee-destructive-recovery.js")>()),
+  createMatrixQaRecoveryCliRuntime: destructiveScenarioMocks.createMatrixQaRecoveryCliRuntime,
+  loginMatrixQaRecoveryDevice: destructiveScenarioMocks.loginMatrixQaRecoveryDevice,
+  runMatrixQaCliJson: destructiveScenarioMocks.runMatrixQaCliJson,
+}));
+
+import { runMatrixQaE2eeWrongAccountRecoveryKeyScenario } from "./scenario-runtime-e2ee-destructive.js";
+
+function createDisposableOwner(params: {
+  backupVersion: string;
+  cleanupOrder?: string[];
+  encodedRecoveryKey: string;
+  failCleanup?: boolean;
+  label: string;
+}) {
+  return {
+    bootstrapOwnDeviceVerification: vi.fn(async () => ({
+      success: true,
+      verification: {
+        backupVersion: params.backupVersion,
+        crossSigningVerified: true,
+        verified: true,
+      },
+    })),
+    deleteOwnDevices: vi.fn(async (deviceIds: string[]) => {
+      params.cleanupOrder?.push(`${params.label}:delete:${deviceIds.join(",")}`);
+      if (params.failCleanup) {
+        throw new Error(`${params.label} device cleanup failed`);
+      }
+      return {};
+    }),
+    getRecoveryKey: vi.fn(async () => ({
+      encodedPrivateKey: params.encodedRecoveryKey,
+      keyId: `${params.label}-key`,
+    })),
+    sendTextMessage: vi.fn(async () => `$${params.label}-seed`),
+    stop: vi.fn(async () => {
+      params.cleanupOrder?.push(`${params.label}:stop`);
+      if (params.failCleanup) {
+        throw new Error(`${params.label} stop failed`);
+      }
+    }),
+  };
+}
+
+function createWrongAccountContext(): MatrixQaScenarioContext {
+  const context = {
+    baseUrl: "http://127.0.0.1:28123",
+    driverAccessToken: "unused-driver-token",
+    driverUserId: "@unused-driver:matrix-qa.test",
+    observedEvents: [],
+    observerAccessToken: "must-not-read",
+    observerDeviceId: "must-not-read",
+    observerPassword: "must-not-read",
+    observerUserId: "must-not-read",
+    outputDir: "/tmp/matrix-qa-output",
+    registrationToken: "registration-token",
+    roomId: "!unused:matrix-qa.test",
+    sutAccessToken: "unused-sut-token",
+    sutUserId: "@unused-sut:matrix-qa.test",
+    syncState: {},
+    timeoutMs: 30_000,
+    topology: { rooms: [] },
+  } as unknown as MatrixQaScenarioContext;
+  return new Proxy(context, {
+    get(target, property, receiver) {
+      if (typeof property === "string" && property.startsWith("observer")) {
+        throw new Error(`observer credential read: ${property}`);
+      }
+      return Reflect.get(target, property, receiver);
+    },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 describe("Matrix destructive E2EE storage discovery", () => {
   const tempDirs: string[] = [];
@@ -71,6 +164,133 @@ describe("Matrix destructive E2EE storage discovery", () => {
         userId: "@owner:matrix-qa.test",
       }),
     ).resolves.toMatchObject({ accountRoot });
+  });
+});
+
+describe("Matrix wrong-account recovery-key isolation", () => {
+  it("uses disposable source and target owners without reading observer credentials", async () => {
+    const cleanupOrder: string[] = [];
+    const sourceOwner = createDisposableOwner({
+      backupVersion: "source-backup",
+      cleanupOrder,
+      encodedRecoveryKey: "source-recovery-key",
+      failCleanup: true,
+      label: "source",
+    });
+    const targetOwner = createDisposableOwner({
+      backupVersion: "target-backup",
+      cleanupOrder,
+      encodedRecoveryKey: "target-recovery-key",
+      failCleanup: true,
+      label: "target",
+    });
+    const registerWithToken = vi
+      .fn()
+      .mockResolvedValueOnce({
+        accessToken: "source-token",
+        deviceId: "SOURCE-DEVICE",
+        password: "source-password",
+        userId: "@source:matrix-qa.test",
+      })
+      .mockResolvedValueOnce({
+        accessToken: "target-token",
+        deviceId: "TARGET-DEVICE",
+        password: "target-password",
+        userId: "@target:matrix-qa.test",
+      });
+    destructiveScenarioMocks.createMatrixQaClient.mockReturnValue({
+      createPrivateRoom: vi
+        .fn()
+        .mockResolvedValueOnce("!source:matrix-qa.test")
+        .mockResolvedValueOnce("!target:matrix-qa.test"),
+      registerWithToken,
+    });
+    destructiveScenarioMocks.createMatrixQaE2eeScenarioClient
+      .mockResolvedValueOnce(sourceOwner)
+      .mockResolvedValueOnce(targetOwner);
+    destructiveScenarioMocks.loginMatrixQaRecoveryDevice.mockResolvedValue({
+      accessToken: "target-recovery-token",
+      deviceId: "TARGET-RECOVERY-DEVICE",
+      userId: "@target:matrix-qa.test",
+    });
+    destructiveScenarioMocks.createMatrixQaRecoveryCliRuntime.mockResolvedValue({
+      dispose: vi.fn(async () => {
+        cleanupOrder.push("cli:dispose");
+        throw new Error("CLI cleanup failed");
+      }),
+    });
+    destructiveScenarioMocks.runMatrixQaCliJson.mockResolvedValue({
+      artifacts: { stderrPath: "/tmp/stderr", stdoutPath: "/tmp/stdout" },
+      payload: {
+        backup: {
+          decryptionKeyCached: false,
+          keyLoadError: "bad MAC",
+          matchesDecryptionKey: false,
+        },
+        backupVersion: "target-backup",
+        error: "bad MAC",
+        success: false,
+      },
+      result: { exitCode: 1 },
+    });
+
+    const result = await runMatrixQaE2eeWrongAccountRecoveryKeyScenario(
+      createWrongAccountContext(),
+    );
+
+    expect(registerWithToken).toHaveBeenCalledTimes(2);
+    expect(destructiveScenarioMocks.createMatrixQaE2eeScenarioClient).toHaveBeenCalledTimes(2);
+    expect(destructiveScenarioMocks.loginMatrixQaRecoveryDevice).toHaveBeenCalledWith(
+      expect.objectContaining({
+        password: "target-password",
+        userId: "@target:matrix-qa.test",
+      }),
+    );
+    expect(destructiveScenarioMocks.runMatrixQaCliJson).toHaveBeenCalledWith(
+      expect.objectContaining({ stdin: "source-recovery-key\n" }),
+    );
+    expect(result.artifacts).toMatchObject({
+      restoreExitCode: 1,
+      targetRecoveryDeviceId: "TARGET-RECOVERY-DEVICE",
+    });
+    expect(cleanupOrder).toEqual([
+      "cli:dispose",
+      "target:delete:TARGET-RECOVERY-DEVICE",
+      "target:stop",
+      "source:stop",
+    ]);
+    expect(targetOwner.deleteOwnDevices).toHaveBeenCalledOnce();
+    expect(targetOwner.stop).toHaveBeenCalledOnce();
+    expect(sourceOwner.stop).toHaveBeenCalledOnce();
+  });
+
+  it("releases the source owner when target setup fails", async () => {
+    const sourceOwner = createDisposableOwner({
+      backupVersion: "source-backup",
+      encodedRecoveryKey: "source-recovery-key",
+      label: "source",
+    });
+    const registerWithToken = vi
+      .fn()
+      .mockResolvedValueOnce({
+        accessToken: "source-token",
+        deviceId: "SOURCE-DEVICE",
+        password: "source-password",
+        userId: "@source:matrix-qa.test",
+      })
+      .mockRejectedValueOnce(new Error("target registration failed"));
+    destructiveScenarioMocks.createMatrixQaClient.mockReturnValue({
+      createPrivateRoom: vi.fn().mockResolvedValue("!source:matrix-qa.test"),
+      registerWithToken,
+    });
+    destructiveScenarioMocks.createMatrixQaE2eeScenarioClient.mockResolvedValueOnce(sourceOwner);
+
+    await expect(
+      runMatrixQaE2eeWrongAccountRecoveryKeyScenario(createWrongAccountContext()),
+    ).rejects.toThrow("target registration failed");
+
+    expect(sourceOwner.stop).toHaveBeenCalledOnce();
+    expect(destructiveScenarioMocks.createMatrixQaRecoveryCliRuntime).not.toHaveBeenCalled();
   });
 });
 

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-destructive.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-destructive.ts
@@ -1167,90 +1167,74 @@ export async function runMatrixQaE2eeSyncStateLossCryptoIntactScenario(
 export async function runMatrixQaE2eeWrongAccountRecoveryKeyScenario(
   context: MatrixQaScenarioContext,
 ): Promise<MatrixQaScenarioExecution> {
-  const observerPassword = requireMatrixQaPassword(context, "observer");
-  const driverSetup = await prepareMatrixQaDestructiveSetup(
+  const sourceSetup = await prepareMatrixQaDestructiveSetup(
     context,
     "matrix-e2ee-wrong-account-recovery-key",
   );
-  const observer = await createMatrixQaE2eeScenarioClient({
-    accessToken: context.observerAccessToken,
-    actorId: `driver-destructive-${randomUUID().slice(0, 8)}`,
-    baseUrl: context.baseUrl,
-    deviceId: context.observerDeviceId,
-    observedEvents: context.observedEvents,
-    outputDir: requireMatrixQaE2eeOutputDir(context),
-    password: context.observerPassword,
-    scenarioId: "matrix-e2ee-wrong-account-recovery-key",
-    timeoutMs: context.timeoutMs,
-    userId: context.observerUserId,
-  });
+  let targetSetup: MatrixQaDestructiveSetup | undefined;
+  let device: Awaited<ReturnType<typeof loginMatrixQaRecoveryDevice>> | undefined;
+  let cli: Awaited<ReturnType<typeof createMatrixQaRecoveryCliRuntime>> | undefined;
   try {
-    const observerReady = await ensureMatrixQaOwnerReady({
-      allowCrossSigningResetOnRepair: true,
-      client: observer,
-      label: "observer",
+    targetSetup = await prepareMatrixQaDestructiveSetup(
+      context,
+      "matrix-e2ee-wrong-account-recovery-key",
+    );
+    device = await loginMatrixQaRecoveryDevice({
+      context,
+      deviceName: "OpenClaw Matrix QA Wrong Account Key",
+      password: targetSetup.ownerPassword,
+      userId: targetSetup.ownerUserId,
     });
-    let device: Awaited<ReturnType<typeof loginMatrixQaRecoveryDevice>> | undefined;
-    let cli: Awaited<ReturnType<typeof createMatrixQaRecoveryCliRuntime>> | undefined;
-    try {
-      device = await loginMatrixQaRecoveryDevice({
-        context,
-        deviceName: "OpenClaw Matrix QA Wrong Account Key",
-        password: observerPassword,
-        userId: context.observerUserId,
-      });
-      cli = await createMatrixQaRecoveryCliRuntime({
-        accountId: "wrong-account",
-        accessToken: device.accessToken,
-        context,
-        deviceId: device.deviceId,
-        label: "wrong-account-recovery-key",
-        userId: device.userId,
-      });
-      const restored = await runMatrixQaCliJson<MatrixQaCliBackupStatus>({
-        allowNonZero: true,
-        args: [
-          "matrix",
-          "verify",
-          "backup",
-          "restore",
-          "--account",
-          "wrong-account",
-          "--recovery-key-stdin",
-          "--json",
-        ],
-        label: "restore-with-wrong-account-key",
-        runtime: cli,
-        stdin: `${driverSetup.encodedRecoveryKey}\n`,
-        timeoutMs: context.timeoutMs,
-      });
-      assertMatrixQaCliBackupRestoreFailed(restored, {
-        expectedBackupVersion: observerReady.backupVersion,
-        failureKind: "rejected-recovery-key",
-        label: "wrong-account recovery-key restore",
-      });
-      return {
-        artifacts: {
-          observerRecoveryDeviceId: device.deviceId,
-          restoreError: restored.payload.error,
-          restoreExitCode: restored.result.exitCode,
-        },
-        details: [
-          "driver recovery key was rejected for observer account backup",
-          `restore exit code: ${restored.result.exitCode}`,
-          `restore error: ${restored.payload.error}`,
-        ].join("\n"),
-      };
-    } finally {
-      await cli?.dispose().catch(() => undefined);
-      await observer.stop().catch(() => undefined);
-      if (device) {
-        await observer.deleteOwnDevices([device.deviceId]).catch(() => undefined);
-      }
-    }
+    cli = await createMatrixQaRecoveryCliRuntime({
+      accountId: "wrong-account",
+      accessToken: device.accessToken,
+      context,
+      deviceId: device.deviceId,
+      label: "wrong-account-recovery-key",
+      userId: device.userId,
+    });
+    const restored = await runMatrixQaCliJson<MatrixQaCliBackupStatus>({
+      allowNonZero: true,
+      args: [
+        "matrix",
+        "verify",
+        "backup",
+        "restore",
+        "--account",
+        "wrong-account",
+        "--recovery-key-stdin",
+        "--json",
+      ],
+      label: "restore-with-wrong-account-key",
+      runtime: cli,
+      stdin: `${sourceSetup.encodedRecoveryKey}\n`,
+      timeoutMs: context.timeoutMs,
+    });
+    assertMatrixQaCliBackupRestoreFailed(restored, {
+      expectedBackupVersion: targetSetup.backupVersion,
+      failureKind: "rejected-recovery-key",
+      label: "wrong-account recovery-key restore",
+    });
+    const artifacts = {
+      restoreError: restored.payload.error,
+      restoreExitCode: restored.result.exitCode,
+      targetRecoveryDeviceId: device.deviceId,
+    };
+    return {
+      artifacts,
+      details: [
+        "source-owner recovery key was rejected for target-owner account backup",
+        `restore exit code: ${restored.result.exitCode}`,
+        `restore error: ${restored.payload.error}`,
+      ].join("\n"),
+    };
   } finally {
-    await observer.stop().catch(() => undefined);
-    await driverSetup.owner.stop().catch(() => undefined);
+    await cli?.dispose().catch(() => undefined);
+    if (targetSetup && device) {
+      await targetSetup.owner.deleteOwnDevices([device.deviceId]).catch(() => undefined);
+    }
+    await targetSetup?.owner.stop().catch(() => undefined);
+    await sourceSetup.owner.stop().catch(() => undefined);
   }
 }
 

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-destructive.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-destructive.ts
@@ -76,14 +76,6 @@ async function cleanupMatrixQaTempDevices(
   }
 }
 
-function requireMatrixQaPassword(context: MatrixQaScenarioContext, actor: "driver" | "observer") {
-  const password = actor === "driver" ? context.driverPassword : context.observerPassword;
-  if (!password) {
-    throw new Error(`Matrix E2EE destructive ${actor} password is required`);
-  }
-  return password;
-}
-
 function requireMatrixQaRegistrationToken(context: MatrixQaScenarioContext) {
   const token = context.registrationToken?.trim();
   if (!token) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Matrix wrong-account recovery-key QA scenario used the shared observer account as its target and could reset that account's cross-signing or backup state for later scenarios.

## Why This Change Was Made

The scenario now creates separate disposable source and target owners. The source owns the deliberately wrong recovery key, while the target owns the backup and temporary recovery device. Cleanup releases the CLI, temporary device, target client, and source client independently.

This change is limited to QA scenario ownership and does not change production Matrix behavior.

## User Impact

Matrix QA scenarios no longer inherit durable observer-account mutations from the wrong-key recovery test, making serial and full-profile results reproducible.

## Evidence

- `node scripts/run-vitest.mjs extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-destructive.test.ts`
- 9 focused tests passed.
- Tests fail on any observer credential access and verify disposable-account cleanup order.
- `git diff --check`
- Structured autoreview: clean.
- Production delta: -17 lines; tests: +220 lines.



Punchcard-Session: silver-valley-valley-dt
