### PR TITLE
fix(acp): pass agent configured model to runtime session initialization

### DIFF
--- a/src/acp/persistent-bindings.lifecycle.test.ts
+++ b/src/acp/persistent-bindings.lifecycle.test.ts
@@ -171,4 +171,28 @@ describe("ensureConfiguredAcpBindingSession", () => {
     const initializeArgs = expectInitializeArgs();
     expect(initializeArgs.agent).toBe("codex");
   });
+
+  it("initializes ACP session with configured model runtime option", async () => {
+    const spec = createPersistentSpec({
+      agentId: "claude",
+    });
+    managerMocks.resolveSession.mockReturnValue({ kind: "none" });
+
+    const cfgWithModel = {
+      ...baseCfg,
+      agents: {
+        list: [{ id: "claude", model: "anthropic/claude-3-opus" }],
+      },
+    };
+
+    const ensured = await ensureConfiguredAcpBindingSession({
+      cfg: cfgWithModel as any,
+      spec,
+    });
+
+    expect(ensured.ok).toBe(true);
+    const initializeArgs = expectInitializeArgs();
+    expect(initializeArgs.agent).toBe("claude");
+    expect(initializeArgs.runtimeOptions).toEqual({ model: "anthropic/claude-3-opus" });
+  });
 });

--- a/src/acp/persistent-bindings.lifecycle.test.ts
+++ b/src/acp/persistent-bindings.lifecycle.test.ts
@@ -60,6 +60,7 @@ function mockReadySession(params: {
   spec: ConfiguredAcpBindingSpec;
   cwd: string;
   state?: "idle" | "running" | "error";
+  model?: string;
 }) {
   const sessionKey = buildConfiguredAcpSessionKey(params.spec);
   managerMocks.resolveSession.mockReturnValue({
@@ -70,7 +71,7 @@ function mockReadySession(params: {
       agent: params.spec.acpAgentId ?? params.spec.agentId,
       runtimeSessionName: "existing",
       mode: params.spec.mode,
-      runtimeOptions: { cwd: params.cwd },
+      runtimeOptions: { cwd: params.cwd, ...(params.model ? { model: params.model } : {}) },
       state: params.state ?? "idle",
       lastActivityAt: Date.now(),
     },
@@ -183,10 +184,10 @@ describe("ensureConfiguredAcpBindingSession", () => {
       agents: {
         list: [{ id: "claude", model: "anthropic/claude-3-opus" }],
       },
-    };
+    } as OpenClawConfig;
 
     const ensured = await ensureConfiguredAcpBindingSession({
-      cfg: cfgWithModel as any,
+      cfg: cfgWithModel,
       spec,
     });
 
@@ -194,5 +195,89 @@ describe("ensureConfiguredAcpBindingSession", () => {
     const initializeArgs = expectInitializeArgs();
     expect(initializeArgs.agent).toBe("claude");
     expect(initializeArgs.runtimeOptions).toEqual({ model: "anthropic/claude-3-opus" });
+  });
+
+  it("resolves model from owning agent, not harness override", async () => {
+    const spec = createPersistentSpec({
+      agentId: "coding",
+      acpAgentId: "codex",
+    });
+    managerMocks.resolveSession.mockReturnValue({ kind: "none" });
+
+    const cfgWithModel = {
+      ...baseCfg,
+      agents: {
+        list: [{ id: "coding", model: "anthropic/claude-3-opus" }],
+      },
+    } as OpenClawConfig;
+
+    const ensured = await ensureConfiguredAcpBindingSession({
+      cfg: cfgWithModel,
+      spec,
+    });
+
+    expect(ensured.ok).toBe(true);
+    const initializeArgs = expectInitializeArgs();
+    // Session agent is the harness override
+    expect(initializeArgs.agent).toBe("codex");
+    // Model is resolved from the owning agent, not the harness
+    expect(initializeArgs.runtimeOptions).toEqual({ model: "anthropic/claude-3-opus" });
+  });
+
+  it("reinitializes a ready session when model differs from configured", async () => {
+    const spec = createPersistentSpec({
+      agentId: "claude",
+    });
+
+    const cfgWithModel = {
+      ...baseCfg,
+      agents: {
+        list: [{ id: "claude", model: "anthropic/claude-3-opus" }],
+      },
+    } as OpenClawConfig;
+
+    // Ready session has no model set (pre-existing session from before the patch)
+    const sessionKey = mockReadySession({
+      spec,
+      cwd: "/workspace/openclaw",
+    });
+
+    const ensured = await ensureConfiguredAcpBindingSession({
+      cfg: cfgWithModel,
+      spec,
+    });
+
+    expect(ensured).toEqual({ ok: true, sessionKey });
+    expect(managerMocks.closeSession).toHaveBeenCalledTimes(1);
+    const initializeArgs = expectInitializeArgs();
+    expect(initializeArgs.runtimeOptions).toEqual({ model: "anthropic/claude-3-opus" });
+  });
+
+  it("keeps a ready session when model matches configured", async () => {
+    const spec = createPersistentSpec({
+      agentId: "claude",
+    });
+
+    const cfgWithModel = {
+      ...baseCfg,
+      agents: {
+        list: [{ id: "claude", model: "anthropic/claude-3-opus" }],
+      },
+    } as OpenClawConfig;
+
+    const sessionKey = mockReadySession({
+      spec,
+      cwd: "/workspace/openclaw",
+      model: "anthropic/claude-3-opus",
+    });
+
+    const ensured = await ensureConfiguredAcpBindingSession({
+      cfg: cfgWithModel,
+      spec,
+    });
+
+    expect(ensured).toEqual({ ok: true, sessionKey });
+    expect(managerMocks.closeSession).not.toHaveBeenCalled();
+    expect(managerMocks.initializeSession).not.toHaveBeenCalled();
   });
 });

--- a/src/acp/persistent-bindings.lifecycle.ts
+++ b/src/acp/persistent-bindings.lifecycle.ts
@@ -4,6 +4,7 @@ import type { SessionAcpMeta } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { logVerbose } from "../globals.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { resolveAgentExplicitModelPrimary } from "../agents/agent-scope.js";
 import { getAcpSessionManager } from "./control-plane/manager.js";
 import {
   buildConfiguredAcpSessionKey,
@@ -90,13 +91,17 @@ export async function ensureConfiguredAcpBindingSession(params: {
       });
     }
 
+    const agentId = params.spec.acpAgentId ?? params.spec.agentId;
+    const resolvedModel = resolveAgentExplicitModelPrimary(params.cfg, agentId);
+
     await acpManager.initializeSession({
       cfg: params.cfg,
       sessionKey,
-      agent: params.spec.acpAgentId ?? params.spec.agentId,
+      agent: agentId,
       mode: params.spec.mode,
       cwd: params.spec.cwd,
       backendId: params.spec.backend,
+      runtimeOptions: resolvedModel ? { model: resolvedModel } : undefined,
     });
 
     return {

--- a/src/acp/persistent-bindings.lifecycle.ts
+++ b/src/acp/persistent-bindings.lifecycle.ts
@@ -83,6 +83,9 @@ export async function ensureConfiguredAcpBindingSession(params: {
         meta: resolution.meta,
       })
     ) {
+      logVerbose(
+        `acp-binding: reusing ready session ${sessionKey} (agent=${params.spec.agentId}, model=${resolution.meta.runtimeOptions?.model ?? "none"})`,
+      );
       return {
         ok: true,
         sessionKey,
@@ -90,6 +93,9 @@ export async function ensureConfiguredAcpBindingSession(params: {
     }
 
     if (resolution.kind !== "none") {
+      logVerbose(
+        `acp-binding: closing ${resolution.kind} session ${sessionKey} (configured model mismatch or state change)`,
+      );
       await acpManager.closeSession({
         cfg: params.cfg,
         sessionKey,
@@ -103,6 +109,10 @@ export async function ensureConfiguredAcpBindingSession(params: {
     // Model is resolved from the owning OpenClaw agent, not the ACP harness override.
     const sessionAgentId = params.spec.acpAgentId ?? params.spec.agentId;
     const resolvedModel = resolveAgentExplicitModelPrimary(params.cfg, params.spec.agentId);
+
+    logVerbose(
+      `acp-binding: initializing session ${sessionKey} (agent=${sessionAgentId}, model=${resolvedModel ?? "none"})`,
+    );
 
     await acpManager.initializeSession({
       cfg: params.cfg,

--- a/src/acp/persistent-bindings.lifecycle.ts
+++ b/src/acp/persistent-bindings.lifecycle.ts
@@ -1,10 +1,10 @@
 /** Ensures configured channel-to-ACP bindings have live sessions and matching runtime options. */
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { resolveAgentExplicitModelPrimary } from "../agents/agent-scope.js";
 import type { SessionAcpMeta } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { logVerbose } from "../globals.js";
 import { formatErrorMessage } from "../infra/errors.js";
-import { resolveAgentExplicitModelPrimary } from "../agents/agent-scope.js";
 import { getAcpSessionManager } from "./control-plane/manager.js";
 import {
   buildConfiguredAcpSessionKey,
@@ -51,6 +51,15 @@ function sessionMatchesConfiguredBinding(params: {
       return false;
     }
   }
+
+  // Reconcile model metadata so a ready session created before a model edit
+  // (or before this patch existed) is not silently reused with the wrong model.
+  const desiredModel = resolveAgentExplicitModelPrimary(params.cfg, params.spec.agentId);
+  const currentModel = params.meta.runtimeOptions?.model;
+  if (desiredModel !== currentModel) {
+    return false;
+  }
+
   return true;
 }
 
@@ -91,13 +100,14 @@ export async function ensureConfiguredAcpBindingSession(params: {
       });
     }
 
-    const agentId = params.spec.acpAgentId ?? params.spec.agentId;
-    const resolvedModel = resolveAgentExplicitModelPrimary(params.cfg, agentId);
+    // Model is resolved from the owning OpenClaw agent, not the ACP harness override.
+    const sessionAgentId = params.spec.acpAgentId ?? params.spec.agentId;
+    const resolvedModel = resolveAgentExplicitModelPrimary(params.cfg, params.spec.agentId);
 
     await acpManager.initializeSession({
       cfg: params.cfg,
       sessionKey,
-      agent: agentId,
+      agent: sessionAgentId,
       mode: params.spec.mode,
       cwd: params.spec.cwd,
       backendId: params.spec.backend,


### PR DESCRIPTION
## What Problem This Solves

ACP configured binding sessions do not pass the agent's explicitly configured model to runtime session initialization. When an agent has a specific model configured (e.g., anthropic/claude-3-opus), the runtime session starts without the model override.

## Changes Made

1. Resolve model from owning agent, not harness override (P1 fix): resolveAgentExplicitModelPrimary now receives params.spec.agentId (the owning agent) instead of acpAgentId (the harness override).

2. Reconcile model metadata before accepting a ready binding (P1 fix): sessionMatchesConfiguredBinding now compares the desired model against the current session's runtime options. A ready session whose persisted model differs is reinitialized.

3. Test coverage: 3 new test cases for owner/harness resolution, model-diff reinit, and model-match keep.

## CI Status

All 81 CI checks passing. All 8 lifecycle tests pass.

## Files Changed

- src/acp/persistent-bindings.lifecycle.ts
- src/acp/persistent-bindings.lifecycle.test.ts
