### PR TITLE
feat(ui): add assistant message surface preference

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -149,7 +149,9 @@ Imported themes are stored only in the current browser profile; they are not wri
 
 Appearance also has a Text size setting. It applies to chat text, composer text, tool cards, and chat sidebars, and keeps text inputs at least 16px so mobile Safari does not auto-zoom on focus.
 
-Theme, theme mode, language, and chat display preferences sync through the gateway config (`ui.prefs`), so they follow you across devices and agents can change them through the approval gate — connected clients apply changes live via the gateway's `config.changed` notice. Each browser keeps a local mirror for instant boot. Text size remains browser-local. An explicitly read-only connection applies preference changes only in that browser and does not attempt a config write. Changes made while offline remain queued until a later connection can write config; on a read-only reconnect, they continue to behave as browser-local preferences. See [Configuration reference](/gateway/configuration-reference#ui).
+Under **Appearance → Chat**, **Assistant message surface** is browser-local and never syncs through `ui.prefs`. **Theme default** preserves the active theme's existing assistant surface. **White** uses pure white for completed assistant message bubbles in light mode; dark mode, tool cards, and the working indicator always keep the theme surface. Selecting **Theme default** resets the override.
+
+Theme, theme mode, language, and chat display preferences sync through the gateway config (`ui.prefs`), so they follow you across devices and agents can change them through the approval gate — connected clients apply changes live via the gateway's `config.changed` notice. Each browser keeps a local mirror for instant boot. Text size and Assistant message surface remain browser-local. An explicitly read-only connection applies preference changes only in that browser and does not attempt a config write. Changes made while offline remain queued until a later connection can write config; on a read-only reconnect, they continue to behave as browser-local preferences. See [Configuration reference](/gateway/configuration-reference#ui).
 
 ## OpenClaw system care
 

--- a/ui/src/app/bootstrap.test.ts
+++ b/ui/src/app/bootstrap.test.ts
@@ -21,6 +21,28 @@ import { createSkillWorkshopRevisionHandoff } from "./skill-workshop-revision-ha
 // under a loaded CI runner that budget expires before startup reaches the step.
 const STARTUP_STEP_WAIT = { timeout: 15_000 };
 
+describe("appearance presentation", () => {
+  it("applies and resets the assistant message surface live", () => {
+    const previousSettings = loadSettings();
+    const runtime = bootstrapApplication({ sessionPathBuilderReady: Promise.resolve() });
+
+    try {
+      expect(document.documentElement.dataset.assistantMessageSurface).toBe("theme-default");
+      saveSettings({ ...loadSettings(), assistantMessageSurface: "white" });
+      runtime.context.theme.refresh();
+      expect(document.documentElement.dataset.assistantMessageSurface).toBe("white");
+
+      saveSettings({ ...loadSettings(), assistantMessageSurface: "theme-default" });
+      runtime.context.theme.refresh();
+      expect(document.documentElement.dataset.assistantMessageSurface).toBe("theme-default");
+    } finally {
+      runtime.stop();
+      saveSettings(previousSettings);
+      runtime.context.theme.refresh();
+    }
+  });
+});
+
 function deferred<T>() {
   let resolve!: (value: T) => void;
   const promise = new Promise<T>((resolvePromise) => {

--- a/ui/src/app/bootstrap.ts
+++ b/ui/src/app/bootstrap.ts
@@ -71,6 +71,7 @@ function applyThemePresentation(settings: ReturnType<typeof loadSettings>): void
   // Carapace CSS (openclaw/carapace) selects on [data-theme-resolved]; keep it
   // in lockstep with data-theme-mode so its stylesheets work unmodified here.
   root.dataset.themeResolved = root.dataset.themeMode;
+  root.dataset.assistantMessageSurface = settings.assistantMessageSurface ?? "theme-default";
   root.classList.toggle("wa-light", root.dataset.themeMode === "light");
   root.classList.toggle("wa-dark", root.dataset.themeMode === "dark");
   root.style.colorScheme = root.dataset.themeMode;

--- a/ui/src/app/settings.assistant-message-surface.node.test.ts
+++ b/ui/src/app/settings.assistant-message-surface.node.test.ts
@@ -1,0 +1,46 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createStorageMock } from "../test-helpers/storage.ts";
+import { loadSettings, normalizeAssistantMessageSurface, saveSettings } from "./settings.ts";
+
+function setTestLocation(params: { protocol: string; host: string; pathname: string }) {
+  vi.stubGlobal("location", {
+    protocol: params.protocol,
+    host: params.host,
+    hostname: params.host.replace(/:\d+$/, ""),
+    pathname: params.pathname,
+  } as Location);
+}
+
+describe("assistant message surface settings", () => {
+  beforeEach(() => {
+    vi.stubGlobal("window", {});
+    vi.stubGlobal("localStorage", createStorageMock());
+    vi.stubGlobal("sessionStorage", createStorageMock());
+    setTestLocation({ protocol: "https:", host: "gateway.example:8443", pathname: "/" });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("defaults, normalizes, persists, and resets the preference", () => {
+    const gatewayUrl = "wss://gateway.example:8443";
+    const scopedKey = `openclaw.control.settings.v1:${gatewayUrl}`;
+
+    expect(loadSettings().assistantMessageSurface).toBe("theme-default");
+    expect(normalizeAssistantMessageSurface("white")).toBe("white");
+    expect(normalizeAssistantMessageSurface("invalid")).toBe("theme-default");
+
+    saveSettings({ ...loadSettings(), assistantMessageSurface: "white" });
+    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}").assistantMessageSurface).toBe(
+      "white",
+    );
+    expect(loadSettings().assistantMessageSurface).toBe("white");
+
+    saveSettings({ ...loadSettings(), assistantMessageSurface: "theme-default" });
+    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}")).not.toHaveProperty(
+      "assistantMessageSurface",
+    );
+  });
+});

--- a/ui/src/app/settings.ts
+++ b/ui/src/app/settings.ts
@@ -131,6 +131,14 @@ function normalizeChoice<T extends string>(
 
 export const normalizeChatSendShortcut = normalizeChoice(CHAT_SEND_SHORTCUTS, "enter");
 
+const ASSISTANT_MESSAGE_SURFACES = ["theme-default", "white"] as const;
+export type AssistantMessageSurface = (typeof ASSISTANT_MESSAGE_SURFACES)[number];
+
+export const normalizeAssistantMessageSurface = normalizeChoice(
+  ASSISTANT_MESSAGE_SURFACES,
+  "theme-default",
+);
+
 const CHAT_FOLLOW_UP_MODES = ["queue", "steer"] as const;
 export type ChatFollowUpMode = (typeof CHAT_FOLLOW_UP_MODES)[number];
 
@@ -174,6 +182,7 @@ export const UI_APPEARANCE_DEFAULTS = {
   textScale: 100,
   sidebarLiveActivity: true,
   chatMessageMaxWidth: "48rem",
+  assistantMessageSurface: "theme-default",
   chatSendShortcut: "enter",
   catalogOpenTarget: "viewer",
   composerHoldToRecord: true,
@@ -210,6 +219,7 @@ export type UiSettings = {
   sidebarEntries: string[]; // Ordered routes, Workboard boards, and pinned sessions below Home
   sidebarLiveActivity?: boolean; // Latest activity under running sidebar sessions (default true)
   chatMessageMaxWidth?: string; // Browser-local centered chat transcript max width
+  assistantMessageSurface?: AssistantMessageSurface; // Browser-local assistant bubble surface
   showAdvancedSettings?: boolean; // Expand advanced schema settings (default false)
   pinnedAgentIds?: string[]; // Agents surfaced first in the agent-chip quick switcher
   textScale?: TextScaleStop; // Browser-local text scale percentage
@@ -442,6 +452,7 @@ export function loadSettings(): UiSettings {
     navWidth: NAV_WIDTH_DEFAULT,
     sidebarEntries: [...DEFAULT_SIDEBAR_ENTRIES],
     sidebarLiveActivity: UI_APPEARANCE_DEFAULTS.sidebarLiveActivity,
+    assistantMessageSurface: UI_APPEARANCE_DEFAULTS.assistantMessageSurface,
     showAdvancedSettings: false,
     pinnedAgentIds: [],
     composerHoldToRecord: UI_APPEARANCE_DEFAULTS.composerHoldToRecord,
@@ -542,6 +553,7 @@ export function loadSettings(): UiSettings {
           ? parsed.sidebarLiveActivity
           : defaults.sidebarLiveActivity,
       chatMessageMaxWidth: normalizeChatMessageMaxWidth(parsed.chatMessageMaxWidth),
+      assistantMessageSurface: normalizeAssistantMessageSurface(parsed.assistantMessageSurface),
       showAdvancedSettings:
         typeof parsed.showAdvancedSettings === "boolean"
           ? parsed.showAdvancedSettings
@@ -685,6 +697,9 @@ function persistSettings(next: UiSettings, options: { selectGateway?: boolean } 
     ...(next.sidebarLiveActivity === false ? { sidebarLiveActivity: false } : {}),
     ...(normalizeChatMessageMaxWidth(next.chatMessageMaxWidth)
       ? { chatMessageMaxWidth: normalizeChatMessageMaxWidth(next.chatMessageMaxWidth) }
+      : {}),
+    ...(normalizeAssistantMessageSurface(next.assistantMessageSurface) === "white"
+      ? { assistantMessageSurface: "white" as const }
       : {}),
     ...(next.showAdvancedSettings === true ? { showAdvancedSettings: true } : {}),
     // Empty pin list is the default; only real pins persist.

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1558,6 +1558,9 @@ export const en: TranslationMap = {
         "Optional CSS width for the centered transcript, such as 960px, 82%, or min(1280px, 82%).",
       messageWidthInvalid:
         "Enter a CSS width such as 960px, 82%, min(1280px, 82%), or calc(100% - 2rem).",
+      assistantMessageSurface: "Assistant message surface",
+      assistantMessageSurfaceThemeDefault: "Theme default",
+      assistantMessageSurfaceWhite: "White",
     },
     sidebarPrefs: {
       title: "Sidebar",

--- a/ui/src/pages/chat/components/chat-message-bubble.ts
+++ b/ui/src/pages/chat/components/chat-message-bubble.ts
@@ -301,9 +301,13 @@ export function renderGroupedMessage(
   // Detect pure-JSON messages and render as collapsible block
   const jsonResult = markdown && !opts.isStreaming ? detectJson(markdown) : null;
 
+  const hasAssistantToolSurface = hasToolCards || assistantViewBlocks.length > 0;
+  const isCompletedAssistantMessage =
+    normalizedRole === "assistant" && !opts.isStreaming && !hasAssistantToolSurface;
   const bubbleClasses = [
     "chat-bubble",
     isToolShell ? "chat-bubble--tool-shell" : "",
+    isCompletedAssistantMessage ? "chat-bubble--assistant-surface" : "",
     opts.isStreaming ? "streaming" : "",
     opts.entryAnimated ? "chat-bubble--user-turn-enter" : "",
   ]

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -1503,6 +1503,7 @@ describe("grouped chat rendering", () => {
 
     const bubble = container.querySelector(".chat-bubble");
     expect(bubble?.classList.contains("streaming")).toBe(false);
+    expect(bubble?.classList.contains("chat-bubble--assistant-surface")).toBe(true);
   });
 
   it("renders streaming text through the streaming markdown renderer", () => {
@@ -1532,6 +1533,9 @@ describe("grouped chat rendering", () => {
     });
     const text = container.querySelector(".streaming-markdown");
     expect(text?.textContent).toBe("**live**\nreply");
+    expect(container.querySelector(".chat-bubble")?.classList).not.toContain(
+      "chat-bubble--assistant-surface",
+    );
   });
 
   it("renders a reading-indicator-only run without avatar or footer", () => {
@@ -2611,7 +2615,8 @@ describe("grouped chat rendering", () => {
       isToolExpanded: () => false,
     });
 
-    expectElement(container, ".chat-bubble--tool-shell", HTMLElement);
+    const toolBubble = expectElement(container, ".chat-bubble--tool-shell", HTMLElement);
+    expect(toolBubble.classList).not.toContain("chat-bubble--assistant-surface");
     const summary = container.querySelector<HTMLElement>(".chat-tool-msg-summary");
     expect(summary?.querySelector(".chat-tool-msg-summary__label")?.textContent).toBe("Sub-agent");
     expect(container.querySelector(".chat-tool-msg-body")).toBeNull();

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -26,6 +26,7 @@ import {
 } from "../../app/server-prefs.ts";
 import {
   loadSettings,
+  normalizeAssistantMessageSurface,
   normalizeCatalogOpenTarget,
   normalizeTextScale,
   normalizeChatSendShortcut,
@@ -97,6 +98,7 @@ type ConfigPageSetting =
   | "textScale"
   | "sidebarLiveActivity"
   | "chatMessageMaxWidth"
+  | "assistantMessageSurface"
   | "showAdvancedSettings"
   | "chatSendShortcut"
   | "chatFollowUpMode"
@@ -1217,6 +1219,9 @@ export class ConfigPage extends OpenClawLightDomElement {
       setSessionCatalogHidden: setStoredSessionCatalogHidden,
       chatMessageMaxWidth: this.settings.chatMessageMaxWidth,
       setChatMessageMaxWidth: (value) => this.setSetting("chatMessageMaxWidth", value),
+      assistantMessageSurface: this.settings.assistantMessageSurface ?? "theme-default",
+      setAssistantMessageSurface: (value) =>
+        this.setSetting("assistantMessageSurface", normalizeAssistantMessageSurface(value)),
       showAdvancedSettings: this.settings.showAdvancedSettings === true,
       setShowAdvancedSettings: (enabled) => this.setSetting("showAdvancedSettings", enabled),
       forceShowAdvanced: this.pageId === "advanced",

--- a/ui/src/pages/config/settings-select-row.ts
+++ b/ui/src/pages/config/settings-select-row.ts
@@ -5,7 +5,7 @@ import { renderSettingsRow } from "../../components/settings-ui.ts";
 export function renderSettingsSelectRow<T extends string>(params: {
   title: string;
   value: T;
-  setting: "send-shortcut" | "follow-up-mode" | "catalog-open-target";
+  setting: "send-shortcut" | "follow-up-mode" | "catalog-open-target" | "assistant-message-surface";
   options: ReadonlyArray<{ value: T; label: string }>;
   onChange: (value: string) => void;
   description?: unknown;
@@ -21,6 +21,7 @@ export function renderSettingsSelectRow<T extends string>(params: {
         ?data-settings-send-shortcut=${params.setting === "send-shortcut"}
         ?data-settings-follow-up-mode=${params.setting === "follow-up-mode"}
         ?data-settings-catalog-open-target=${params.setting === "catalog-open-target"}
+        ?data-settings-assistant-message-surface=${params.setting === "assistant-message-surface"}
         aria-label=${params.title}
         .value=${params.value}
         @change=${(event: Event) =>

--- a/ui/src/pages/config/settings-targets.ts
+++ b/ui/src/pages/config/settings-targets.ts
@@ -173,6 +173,9 @@ export const SETTINGS_SEARCH_TARGETS = {
     searchKeys: [
       "configView.chatPrefs.messageWidth",
       "configView.chatPrefs.messageWidthHint",
+      "configView.chatPrefs.assistantMessageSurface",
+      "configView.chatPrefs.assistantMessageSurfaceThemeDefault",
+      "configView.chatPrefs.assistantMessageSurfaceWhite",
       "chat.sendShortcut",
       "chat.sendShortcutEnter",
       "chat.sendShortcutModifierEnter",
@@ -195,7 +198,7 @@ export const SETTINGS_SEARCH_TARGETS = {
       "chat.composer.holdToRecordSettingDescription",
     ],
     aliases:
-      "keyboard enter follow-up followup steer queue microphone voice audio input codex claude terminal viewer camera dictation dictate width",
+      "keyboard enter follow-up followup steer queue microphone voice audio input codex claude terminal viewer camera dictation dictate width bubble surface white",
   },
   appearanceConnection: {
     routeId: "appearance",

--- a/ui/src/pages/config/view-appearance-preferences.ts
+++ b/ui/src/pages/config/view-appearance-preferences.ts
@@ -1,6 +1,7 @@
 import { html, nothing, type TemplateResult } from "lit";
 import type { ServerUiPrefProvenance } from "../../app/server-prefs.ts";
 import {
+  normalizeAssistantMessageSurface,
   normalizeCatalogOpenTarget,
   normalizeChatFollowUpMode,
   normalizeChatSendShortcut,
@@ -202,6 +203,11 @@ export function renderChatPreferencesSection(
     overridden: props.chatSendShortcutOverridden,
     onReset: props.resetChatSendShortcut,
   });
+  const assistantSurfaceDefaultState = renderSettingsDefaultState({
+    value: t("configView.chatPrefs.assistantMessageSurfaceThemeDefault"),
+    overridden: props.assistantMessageSurface !== UI_APPEARANCE_DEFAULTS.assistantMessageSurface,
+    onReset: () => props.setAssistantMessageSurface(UI_APPEARANCE_DEFAULTS.assistantMessageSurface),
+  });
   const sendShortcutProvenance = serverUiPrefProvenanceHint(props.chatSendShortcutProvenance);
   const followUpProvenance = serverUiPrefProvenanceHint(props.chatFollowUpModeProvenance);
   const catalogTargetDefaultState = renderSettingsDefaultState({
@@ -227,6 +233,23 @@ export function renderChatPreferencesSection(
           description: html`${t("configView.chatPrefs.messageWidthHint")}<br />
             ${messageWidthDefaultState.description} ${t("quickSettings.personal.browserOnly")}`,
           control: html` ${messageWidthDefaultState.action} ${messageWidthInput} `,
+        })}
+        ${renderSettingsSelectRow({
+          title: t("configView.chatPrefs.assistantMessageSurface"),
+          value: props.assistantMessageSurface,
+          setting: "assistant-message-surface",
+          description: html`${assistantSurfaceDefaultState.description}
+          ${t("quickSettings.personal.browserOnly")}`,
+          actions: assistantSurfaceDefaultState.action,
+          options: [
+            {
+              value: "theme-default",
+              label: t("configView.chatPrefs.assistantMessageSurfaceThemeDefault"),
+            },
+            { value: "white", label: t("configView.chatPrefs.assistantMessageSurfaceWhite") },
+          ],
+          onChange: (value) =>
+            props.setAssistantMessageSurface(normalizeAssistantMessageSurface(value)),
         })}
         ${renderSettingsSelectRow({
           title: t("chat.sendShortcut"),

--- a/ui/src/pages/config/view-types.ts
+++ b/ui/src/pages/config/view-types.ts
@@ -3,7 +3,12 @@ import type { QueueMode } from "../../../../packages/gateway-protocol/src/schema
 import type { ConfigUiHints, ModelCatalogEntry } from "../../api/types.ts";
 import type { NativeNotificationsPermission } from "../../app/native-notifications.ts";
 import type { ServerUiPrefProvenance } from "../../app/server-prefs.ts";
-import type { ChatFollowUpMode, ChatSendShortcut, CatalogOpenTarget } from "../../app/settings.ts";
+import type {
+  AssistantMessageSurface,
+  ChatFollowUpMode,
+  ChatSendShortcut,
+  CatalogOpenTarget,
+} from "../../app/settings.ts";
 import type { ThemeTransitionContext } from "../../app/theme-transition.ts";
 import type { ThemeMode, ThemeName } from "../../app/theme.ts";
 import type { JsonSchema } from "../../components/config-form.shared.ts";
@@ -132,6 +137,8 @@ export type ConfigProps = {
   setSessionCatalogHidden: (catalogId: string, hidden: boolean) => void;
   chatMessageMaxWidth?: string;
   setChatMessageMaxWidth: (value: string | undefined) => void;
+  assistantMessageSurface: AssistantMessageSurface;
+  setAssistantMessageSurface: (value: AssistantMessageSurface) => void;
   showAdvancedSettings: boolean;
   setShowAdvancedSettings: (enabled: boolean) => void;
   forceShowAdvanced?: boolean;

--- a/ui/src/pages/config/view.browser.test.ts
+++ b/ui/src/pages/config/view.browser.test.ts
@@ -89,6 +89,8 @@ describe("config view", () => {
     setSessionCatalogHidden: vi.fn(),
     chatMessageMaxWidth: undefined,
     setChatMessageMaxWidth: vi.fn(),
+    assistantMessageSurface: "theme-default" as const,
+    setAssistantMessageSurface: vi.fn(),
     showAdvancedSettings: false,
     setShowAdvancedSettings: vi.fn(),
     chatSendShortcut: "enter" as const,
@@ -1919,6 +1921,17 @@ describe("config view", () => {
       HTMLSelectElement,
     );
     expect(shortcutSelect.getAttribute("aria-label")).toBe("Send shortcut");
+    const surfaceSelect = queryRequired(
+      container,
+      "[data-settings-assistant-message-surface]",
+      HTMLSelectElement,
+    );
+    expect(surfaceSelect.getAttribute("aria-label")).toBe("Assistant message surface");
+    expect(surfaceSelect.value).toBe("theme-default");
+    expect(Array.from(surfaceSelect.options, (option) => option.value)).toEqual([
+      "theme-default",
+      "white",
+    ]);
     const followUpSelect = queryRequired(
       container,
       "[data-settings-follow-up-mode]",
@@ -1952,6 +1965,28 @@ describe("config view", () => {
     cameraSelect.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true, button: 0 }));
     expect(onMicrophoneRefresh).not.toHaveBeenCalled();
     expect(onCameraRefresh).not.toHaveBeenCalled();
+  });
+
+  it("updates the assistant message surface preference", () => {
+    const setAssistantMessageSurface = vi.fn();
+    const { container } = renderConfigView({
+      activeSection: "__appearance__",
+      includeSections: ["__appearance__"],
+      setAssistantMessageSurface,
+    });
+    const select = queryRequired(
+      container,
+      "[data-settings-assistant-message-surface]",
+      HTMLSelectElement,
+    );
+
+    select.value = "white";
+    select.dispatchEvent(new Event("change"));
+    expect(setAssistantMessageSurface).toHaveBeenCalledWith("white");
+
+    select.value = "theme-default";
+    select.dispatchEvent(new Event("change"));
+    expect(setAssistantMessageSurface).toHaveBeenLastCalledWith("theme-default");
   });
 
   it("requests media access for each native picker opening gesture", () => {

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -826,6 +826,12 @@ img.chat-avatar.chat-avatar--logo {
   box-shadow: none;
 }
 
+:root[data-theme-mode="light"][data-assistant-message-surface="white"]
+  .chat-group.assistant
+  .chat-bubble--assistant-surface {
+  background: #fff;
+}
+
 /* Per-user bubble tint: --chat-sender-hue is the sender's stable identity hue
    (same seed as their avatar initials). Only hue varies per user; saturation/
    lightness/alpha are fixed per theme mode so bubble text keeps contrast for

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -826,7 +826,7 @@ img.chat-avatar.chat-avatar--logo {
   box-shadow: none;
 }
 
-:root[data-theme-mode="light"][data-assistant-message-surface="white"]
+:root[data-theme-mode="light"]:not([data-theme="custom-light"])[data-assistant-message-surface="white"]
   .chat-group.assistant
   .chat-bubble--assistant-surface {
   background: #fff;

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -826,7 +826,9 @@ img.chat-avatar.chat-avatar--logo {
   box-shadow: none;
 }
 
-:root[data-theme-mode="light"]:not([data-theme="custom-light"])[data-assistant-message-surface="white"]
+:root[data-theme-mode="light"]:not(
+    [data-theme="custom-light"]
+  )[data-assistant-message-surface="white"]
   .chat-group.assistant
   .chat-bubble--assistant-surface {
   background: #fff;

--- a/ui/src/styles/theme-contrast.test.ts
+++ b/ui/src/styles/theme-contrast.test.ts
@@ -100,6 +100,27 @@ describe("Control UI theme contrast", () => {
   const chatLayoutCss = readFileSync(path.join(here, "chat", "layout.css"), "utf8");
   const layoutCss = readFileSync(path.join(here, "layout.css"), "utf8");
 
+  it("keeps default dark muted text tokens at WCAG AA on declared surfaces", () => {
+    const dark = readCssVarBlock(baseCss, ":root");
+    const backgrounds = [
+      requireCssColor(dark, "bg"),
+      requireCssColor(dark, "bg-elevated"),
+      requireCssColor(dark, "bg-muted"),
+      requireCssColor(dark, "card"),
+    ];
+    const foregrounds = [
+      requireCssColor(dark, "muted"),
+      requireCssColor(dark, "muted-strong"),
+      requireCssColor(dark, "muted-foreground"),
+    ];
+
+    for (const foreground of foregrounds) {
+      for (const background of backgrounds) {
+        expect(contrastRatio(foreground, background)).toBeGreaterThanOrEqual(4.5);
+      }
+    }
+  });
+
   it("keeps chat timestamps and slash-arg hints AA without opacity dimming", () => {
     const dark = readCssVarBlock(baseCss, ":root");
     const muted = requireCssColor(dark, "muted");
@@ -152,5 +173,20 @@ describe("Control UI theme contrast", () => {
         expect(contrastRatio(muted, requireCssColor(theme, surface))).toBeGreaterThanOrEqual(4.5);
       }
     }
+  });
+
+  it("limits the white assistant surface to contrast-safe light completed message bubbles", () => {
+    expect(groupedCss).toMatch(
+      /:root\[data-theme-mode="light"\]:not\(\s*\[data-theme="custom-light"\]\s*\)\[data-assistant-message-surface="white"\][^{}]*\.chat-group\.assistant[^{}]*\.chat-bubble--assistant-surface\s*\{[^{}]*background:\s*#fff;/u,
+    );
+    expect(groupedCss).not.toMatch(
+      /data-assistant-message-surface="white"[^{}]*\.chat-bubble:not/u,
+    );
+    expect(groupedCss).not.toContain(
+      ':root[data-theme-mode="dark"][data-assistant-message-surface="white"]',
+    );
+    expect(groupedCss).not.toMatch(
+      /:root\[data-theme="custom-light"\][^{}]*data-assistant-message-surface="white"/u,
+    );
   });
 });

--- a/ui/src/styles/theme-contrast.test.ts
+++ b/ui/src/styles/theme-contrast.test.ts
@@ -177,7 +177,7 @@ describe("Control UI theme contrast", () => {
 
   it("limits the white assistant surface to contrast-safe light completed message bubbles", () => {
     expect(groupedCss).toMatch(
-      /:root\[data-theme-mode="light"\]\s*:not\(\[data-theme="custom-light"\]\)\[data-assistant-message-surface="white"\][^{}]*\.chat-group\.assistant[^{}]*\.chat-bubble--assistant-surface\s*\{[^{}]*background:\s*#fff;/u,
+      /:root\[data-theme-mode="light"\]\s*:not\(\s*\[data-theme="custom-light"\]\s*\)\s*\[data-assistant-message-surface="white"\][^{}]*\.chat-group\.assistant[^{}]*\.chat-bubble--assistant-surface\s*\{[^{}]*background:\s*#fff;/u,
     );
     expect(groupedCss).not.toMatch(
       /data-assistant-message-surface="white"[^{}]*\.chat-bubble:not/u,

--- a/ui/src/styles/theme-contrast.test.ts
+++ b/ui/src/styles/theme-contrast.test.ts
@@ -177,7 +177,7 @@ describe("Control UI theme contrast", () => {
 
   it("limits the white assistant surface to contrast-safe light completed message bubbles", () => {
     expect(groupedCss).toMatch(
-      /:root\[data-theme-mode="light"\]:not\(\s*\[data-theme="custom-light"\]\s*\)\[data-assistant-message-surface="white"\][^{}]*\.chat-group\.assistant[^{}]*\.chat-bubble--assistant-surface\s*\{[^{}]*background:\s*#fff;/u,
+      /:root\[data-theme-mode="light"\]\s*:not\(\[data-theme="custom-light"\]\)\[data-assistant-message-surface="white"\][^{}]*\.chat-group\.assistant[^{}]*\.chat-bubble--assistant-surface\s*\{[^{}]*background:\s*#fff;/u,
     );
     expect(groupedCss).not.toMatch(
       /data-assistant-message-surface="white"[^{}]*\.chat-bubble:not/u,


### PR DESCRIPTION
## What Problem This Solves

Assistant messages in the default light theme use a muted, slightly warm surface. That can make copying chat content into white HTML documents feel visually inconsistent, and users currently have no focused preference for changing only the assistant bubble surface without replacing the whole theme.

## Summary

- add a browser-local **Appearance → Chat → Assistant message surface** preference
- preserve the existing theme surface by default
- allow a pure-white assistant bubble surface for completed assistant messages in light mode
- keep dark mode, tool cards, and the active working indicator theme-controlled
- document explicitly that this preference does not sync through `ui.prefs`
- add focused settings, rendering, persistence, and CSS contract tests

## Evidence

Final real-browser proof from head `15638fe5498`: [light White](https://raw.githubusercontent.com/AppleSpriter/openclaw/proof/pr-119574/pr-proof/119574/final-white-light.jpg) · [dark theme-controlled](https://raw.githubusercontent.com/AppleSpriter/openclaw/proof/pr-119574/pr-proof/119574/final-white-dark.jpg). The built Control UI was served through the repository mock Gateway and inspected in Chromium. In light mode, completed assistant text computed to `rgb(255, 255, 255)`; in dark mode, the same White preference remained theme-controlled.


- Built the Control UI from this branch with `../node_modules/.bin/vite build` — passed.
- Served the real built UI through the repository's mocked Gateway and verified in Chromium:
  - light mode + **White**: completed assistant bubbles computed to `rgb(255, 255, 255)`
  - **Theme default**: completed assistant bubbles computed to the theme-controlled transparent surface
  - dark mode has no white CSS override
  - tool shells and `.chat-reading-indicator` are explicitly excluded from the white selector
- `./node_modules/.bin/vitest run ui/src/styles/theme-contrast.test.ts ui/src/app/settings.assistant-message-surface.node.test.ts ui/src/pages/config/view.browser.test.ts` — 57 tests passed
- Earlier full focused suite: 4 test files, 100 tests passed
- OXLint on changed TypeScript: 0 errors / 0 warnings
- Oxfmt and `git diff --check` — passed
- Control UI i18n verification — passed in CI

## Notes

- This remains browser-local, never syncs through `ui.prefs`, and does not add a Gateway config field.
- The unrelated `config-safe-write.e2e.test.ts` CI failure was a single 10-second request timeout; its other shard tests passed and the changed files do not touch guarded config writes.
