### PR TITLE
fix(gateway): cancel pending restart when a restart-required edit reverts to the running config (#119360)

### DIFF
--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -3685,6 +3685,78 @@ describe("startGatewayConfigReloader", () => {
     await harness.reloader.stop();
   });
 
+  it("cancels a deferred restart when a partial revert restores only the restart-owned field", async () => {
+    const configA = { gateway: { reload: {} } } satisfies OpenClawConfig;
+    const configB = {
+      gateway: { reload: {}, port: 18793 },
+      agents: { defaults: { params: { temperature: 0.1 } } },
+    } satisfies OpenClawConfig;
+    // Hot-only apply: temperature reaches the runtime, port stays changed.
+    const configC = {
+      gateway: { reload: {}, port: 18793 },
+      agents: { defaults: { params: { temperature: 0.3 } } },
+    } satisfies OpenClawConfig;
+    // Partial revert: only the restart-owned field (gateway.port) returns to
+    // the running value; the retained hot value (temperature 0.3) stays.
+    const configD = {
+      gateway: { reload: {} },
+      agents: { defaults: { params: { temperature: 0.3 } } },
+    } satisfies OpenClawConfig;
+    const makeWrite = (config: OpenClawConfig, persistedHash: string): ConfigWriteNotification => ({
+      configPath: "/tmp/openclaw.json",
+      sourceConfig: config,
+      runtimeConfig: config,
+      persistedHash,
+      revision: 1,
+      fingerprint: `runtime-${persistedHash}`,
+      sourceFingerprint: `source-${persistedHash}`,
+      writtenAtMs: Date.now(),
+    });
+    const onHotReload = vi.fn(
+      async (
+        plan: GatewayReloadPlan,
+        nextConfig: OpenClawConfig,
+        ownership: GatewayConfigReloadTransactionOwnership,
+      ) => {
+        ownership.markRuntimeCommitted(nextConfig, plan);
+      },
+    );
+    const harness = createReloaderHarness(
+      vi.fn(async () => makeSnapshot()),
+      {
+        initialConfig: configA,
+        onHotReload,
+      },
+    );
+
+    // Restart-required edit A -> B (gateway.port) plans a deferred restart.
+    harness.emitWrite(makeWrite(configB, "hash-b"));
+    await vi.runAllTimersAsync();
+    expect(harness.onRestart).toHaveBeenCalledTimes(1);
+
+    // Intervening hot-only apply B -> C advances the runtime-applied baseline
+    // while the A -> B restart stays deferred.
+    harness.emitWrite(makeWrite(configC, "hash-c"));
+    await vi.runAllTimersAsync();
+    expect(onHotReload).toHaveBeenCalledTimes(1);
+    expect(harness.onRestart).toHaveBeenCalledTimes(1);
+
+    // Partial revert C -> D restores only the restart-owned field. The
+    // retained hot value makes the whole config differ from the deferral
+    // base, but comparing restart-owned paths (the coordinator contract)
+    // must still retire the deferred restart instead of re-arming it.
+    harness.emitWrite(makeWrite(configD, "hash-d"));
+    await vi.runAllTimersAsync();
+    expect(harness.onRestart).toHaveBeenCalledTimes(1);
+    expect(
+      harness.log.info.mock.calls.some((call) =>
+        call.some((arg) => String(arg).includes("reverted to running config")),
+      ),
+    ).toBe(true);
+
+    await harness.reloader.stop();
+  });
+
   it("applies residual hot actions when a revert cancels a deferred restart", async () => {
     const configA = {
       gateway: { reload: {} },

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -3577,6 +3577,65 @@ describe("startGatewayConfigReloader", () => {
     await harness.reloader.stop();
   });
 
+  it("retains an earlier explicit restart across a later planner-derived restart and an ordinary exact revert", async () => {
+    const configA = { gateway: { reload: {} } } satisfies OpenClawConfig;
+    const configB = { gateway: { reload: {}, port: 18793 } } satisfies OpenClawConfig;
+    const configC = { gateway: { reload: {}, port: 18794 } } satisfies OpenClawConfig;
+    const makeWrite = (
+      config: OpenClawConfig,
+      persistedHash: string,
+      afterWrite?: ConfigWriteAfterWrite,
+    ): ConfigWriteNotification => ({
+      configPath: "/tmp/openclaw.json",
+      sourceConfig: config,
+      runtimeConfig: config,
+      persistedHash,
+      revision: 1,
+      fingerprint: `runtime-${persistedHash}`,
+      sourceFingerprint: `source-${persistedHash}`,
+      writtenAtMs: Date.now(),
+      ...(afterWrite ? { afterWrite } : {}),
+    });
+    const harness = createReloaderHarness(
+      vi.fn(async () => makeSnapshot()),
+      {
+        initialConfig: configA,
+      },
+    );
+
+    // 1. Explicit writer-required restart A -> B arms a deferred restart with
+    //    explicit provenance (hard lifecycle contract).
+    harness.emitWrite(
+      makeWrite(configB, "hash-b", { mode: "restart", reason: "writer requires bounce" }),
+    );
+    await vi.runAllTimersAsync();
+    expect(harness.onRestart).toHaveBeenCalledTimes(1);
+    expect(harness.onRestart.mock.calls[0]?.[1]).toEqual(configB);
+
+    // 2. A later planner-derived restart B -> C re-arms the deferred restart.
+    //    The earlier explicit writer intent must survive this re-arm: the
+    //    reverting write's followUp can never speak for the earlier writer.
+    harness.emitWrite(makeWrite(configC, "hash-c"));
+    await vi.runAllTimersAsync();
+    expect(harness.onRestart).toHaveBeenCalledTimes(2);
+    expect(harness.onRestart.mock.calls[1]?.[1]).toEqual(configC);
+
+    // 3. Ordinary exact revert C -> A matches the running config, but the
+    //    pending restart debt is still explicit (retained through the
+    //    planner-derived re-arm). The revert must NOT cancel the restart.
+    harness.emitWrite(makeWrite(configA, "hash-a"));
+    await vi.runAllTimersAsync();
+    expect(harness.onRestart).toHaveBeenCalledTimes(3);
+    expect(harness.onRestart.mock.calls[2]?.[1]).toEqual(configA);
+    expect(
+      harness.log.info.mock.calls.some((call) =>
+        call.some((arg) => String(arg).includes("reverted to running config")),
+      ),
+    ).toBe(false);
+
+    await harness.reloader.stop();
+  });
+
   it.each([
     {
       label: "none",

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -10,6 +10,7 @@ import { prepareConfigRuntimeEnv } from "../config/config-env-vars.js";
 import { fingerprintConfigSnapshotAuthoredConfig } from "../config/config-journal-snapshot.js";
 import type {
   ConfigFileSnapshot,
+  ConfigWriteAfterWrite,
   ConfigWriteNotification,
   OpenClawConfig,
 } from "../config/config.js";
@@ -3438,9 +3439,12 @@ describe("startGatewayConfigReloader", () => {
       sourceFingerprint: `source-${persistedHash}`,
       writtenAtMs: Date.now(),
     });
-    const harness = createReloaderHarness(vi.fn(async () => makeSnapshot()), {
-      initialConfig: configA,
-    });
+    const harness = createReloaderHarness(
+      vi.fn(async () => makeSnapshot()),
+      {
+        initialConfig: configA,
+      },
+    );
 
     // Restart-required edit A -> B plans a (deferred) restart.
     harness.emitWrite(makeWrite(configB, "hash-b"));
@@ -3467,6 +3471,58 @@ describe("startGatewayConfigReloader", () => {
     await vi.runAllTimersAsync();
     expect(harness.onRestart).toHaveBeenCalledTimes(2);
     expect(harness.onRestart.mock.calls[1]?.[1]).toEqual(configB);
+
+    await harness.reloader.stop();
+  });
+
+  it("preserves an explicit writer-required restart when a revert matches the running config", async () => {
+    const configA = { gateway: { reload: {} } } satisfies OpenClawConfig;
+    const configB = { gateway: { reload: {}, port: 18791 } } satisfies OpenClawConfig;
+    const makeWrite = (
+      config: OpenClawConfig,
+      persistedHash: string,
+      afterWrite?: ConfigWriteAfterWrite,
+    ): ConfigWriteNotification => ({
+      configPath: "/tmp/openclaw.json",
+      sourceConfig: config,
+      runtimeConfig: config,
+      persistedHash,
+      revision: 1,
+      fingerprint: `runtime-${persistedHash}`,
+      sourceFingerprint: `source-${persistedHash}`,
+      writtenAtMs: Date.now(),
+      ...(afterWrite ? { afterWrite } : {}),
+    });
+    const harness = createReloaderHarness(
+      vi.fn(async () => makeSnapshot()),
+      {
+        initialConfig: configA,
+      },
+    );
+
+    // Restart-required edit A -> B with an explicit writer restart intent
+    // plans a restart.
+    harness.emitWrite(
+      makeWrite(configB, "hash-b", { mode: "restart", reason: "writer requires bounce" }),
+    );
+    await vi.runAllTimersAsync();
+    const [firstPlan] = getOnlyRestartCall(harness);
+    expect(firstPlan.restartGateway).toBe(true);
+
+    // Exact revert B -> A still carries the explicit restart intent. The
+    // config bytes match the running config, but the writer-required restart
+    // is a hard lifecycle contract and must NOT be cancelled.
+    harness.emitWrite(
+      makeWrite(configA, "hash-a", { mode: "restart", reason: "writer requires bounce" }),
+    );
+    await vi.runAllTimersAsync();
+    expect(harness.onRestart).toHaveBeenCalledTimes(2);
+    expect(harness.onRestart.mock.calls[1]?.[1]).toEqual(configA);
+    expect(
+      harness.log.info.mock.calls.some((call) =>
+        call.some((arg) => String(arg).includes("reverted to running config")),
+      ),
+    ).toBe(false);
 
     await harness.reloader.stop();
   });

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -3489,6 +3489,73 @@ describe("startGatewayConfigReloader", () => {
     await harness.reloader.stop();
   });
 
+  it("keeps planner deferral cancellable after a rejected explicit restart admission", async () => {
+    const configA = { gateway: { reload: {} } } satisfies OpenClawConfig;
+    const configB = { gateway: { reload: {}, port: 18792 } } satisfies OpenClawConfig;
+    const configC = { gateway: { reload: {}, port: 18794 } } satisfies OpenClawConfig;
+    const makeWrite = (
+      config: OpenClawConfig,
+      persistedHash: string,
+      afterWrite?: ConfigWriteAfterWrite,
+    ): ConfigWriteNotification => ({
+      configPath: "/tmp/openclaw.json",
+      sourceConfig: config,
+      runtimeConfig: config,
+      persistedHash,
+      revision: 1,
+      fingerprint: `runtime-${persistedHash}`,
+      sourceFingerprint: `source-${persistedHash}`,
+      writtenAtMs: Date.now(),
+      ...(afterWrite ? { afterWrite } : {}),
+    });
+    const harness = createReloaderHarness(
+      vi.fn(async () => makeSnapshot()),
+      {
+        initialConfig: configA,
+      },
+    );
+    // The managed coordinator rejects only the explicit restart admission.
+    harness.onRestart.mockImplementation(async (_plan, nextConfig) => {
+      if ((nextConfig as { gateway?: { port?: number } }).gateway?.port === 18794) {
+        throw new Error("restart admission failed");
+      }
+    });
+
+    // Planner-derived restart-required edit A -> B defers a restart.
+    harness.emitWrite(makeWrite(configB, "hash-b"));
+    await vi.runAllTimersAsync();
+    expect(harness.onRestart).toHaveBeenCalledTimes(1);
+    expect(harness.onRestart.mock.calls[0]?.[1]).toEqual(configB);
+
+    // Explicit writer restart B -> C is rejected by the coordinator. The
+    // rejected admission must not leave stale explicit provenance behind.
+    harness.emitWrite(
+      makeWrite(configC, "hash-c", { mode: "restart", reason: "writer requires bounce" }),
+    );
+    await vi.runAllTimersAsync();
+    expect(harness.onRestart).toHaveBeenCalledTimes(2);
+    expect(harness.onRestart.mock.calls[1]?.[1]).toEqual(configC);
+    expect(
+      harness.log.error.mock.calls.some((call) =>
+        call.some((arg) => String(arg).includes("restart admission failed")),
+      ),
+    ).toBe(true);
+
+    // Exact revert C -> A still cancels the planner-derived deferral: the
+    // rejected explicit restart must not convert it into non-cancellable debt.
+    harness.emitWrite(makeWrite(configA, "hash-a"));
+    await vi.runAllTimersAsync();
+    expect(harness.onRestart).toHaveBeenCalledTimes(2);
+    expect(
+      harness.log.info.mock.calls.some((call) =>
+        call.some((arg) => String(arg).includes("reverted to running config")),
+      ),
+    ).toBe(true);
+    expect(harness.onConfigAccepted).toHaveBeenCalled();
+
+    await harness.reloader.stop();
+  });
+
   it("preserves an explicit writer-required restart when a revert matches the running config", async () => {
     const configA = { gateway: { reload: {} } } satisfies OpenClawConfig;
     const configB = { gateway: { reload: {}, port: 18791 } } satisfies OpenClawConfig;

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -3425,6 +3425,52 @@ describe("startGatewayConfigReloader", () => {
     await harness.reloader.stop();
   });
 
+  it("cancels a pending restart when a restart-required edit reverts to the running config", async () => {
+    const configA = { gateway: { reload: {} } } satisfies OpenClawConfig;
+    const configB = { gateway: { reload: {}, port: 18790 } } satisfies OpenClawConfig;
+    const makeWrite = (config: OpenClawConfig, persistedHash: string): ConfigWriteNotification => ({
+      configPath: "/tmp/openclaw.json",
+      sourceConfig: config,
+      runtimeConfig: config,
+      persistedHash,
+      revision: 1,
+      fingerprint: `runtime-${persistedHash}`,
+      sourceFingerprint: `source-${persistedHash}`,
+      writtenAtMs: Date.now(),
+    });
+    const harness = createReloaderHarness(vi.fn(async () => makeSnapshot()), {
+      initialConfig: configA,
+    });
+
+    // Restart-required edit A -> B plans a (deferred) restart.
+    harness.emitWrite(makeWrite(configB, "hash-b"));
+    await vi.runAllTimersAsync();
+    const [firstPlan, firstConfig] = getOnlyRestartCall(harness);
+    expect(firstPlan.restartGateway).toBe(true);
+    expect(firstConfig).toEqual(configB);
+
+    // Exact revert B -> A must cancel the pending restart instead of planning
+    // a new one: the settled candidate equals the config the runtime still runs.
+    harness.emitWrite(makeWrite(configA, "hash-a"));
+    await vi.runAllTimersAsync();
+    expect(harness.onRestart).toHaveBeenCalledTimes(1);
+    expect(
+      harness.log.info.mock.calls.some((call) =>
+        call.some((arg) => String(arg).includes("reverted to running config")),
+      ),
+    ).toBe(true);
+    expect(harness.onConfigAccepted).toHaveBeenCalled();
+
+    // The revert still advanced the reload baseline, so a later genuine edit
+    // A -> B plans the restart again.
+    harness.emitWrite(makeWrite(configB, "hash-b2"));
+    await vi.runAllTimersAsync();
+    expect(harness.onRestart).toHaveBeenCalledTimes(2);
+    expect(harness.onRestart.mock.calls[1]?.[1]).toEqual(configB);
+
+    await harness.reloader.stop();
+  });
+
   it.each([
     {
       label: "none",

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -3527,6 +3527,83 @@ describe("startGatewayConfigReloader", () => {
     await harness.reloader.stop();
   });
 
+  it("cancels a deferred restart when a hot-only apply lands between the deferral and the revert", async () => {
+    const configA = { gateway: { reload: {} } } satisfies OpenClawConfig;
+    const configB = {
+      gateway: { reload: {}, port: 18793 },
+      agents: { defaults: { temperature: 0.1 } },
+    } satisfies OpenClawConfig;
+    const configD = {
+      gateway: { reload: {}, port: 18793 },
+      agents: { defaults: { temperature: 0.3 } },
+    } satisfies OpenClawConfig;
+    const makeWrite = (config: OpenClawConfig, persistedHash: string): ConfigWriteNotification => ({
+      configPath: "/tmp/openclaw.json",
+      sourceConfig: config,
+      runtimeConfig: config,
+      persistedHash,
+      revision: 1,
+      fingerprint: `runtime-${persistedHash}`,
+      sourceFingerprint: `source-${persistedHash}`,
+      writtenAtMs: Date.now(),
+    });
+    // Production hot reload (server-reload-managed-secrets.ts) activates the
+    // prepared runtime snapshot and advances the runtime-applied baseline via
+    // transactionOwnership.markRuntimeCommitted. Simulate that real commit so
+    // this test exercises the same baseline-advance edge the managed gateway
+    // has while a restart is still deferred.
+    const onHotReload = vi.fn(
+      async (
+        plan: GatewayReloadPlan,
+        nextConfig: OpenClawConfig,
+        ownership: GatewayConfigReloadTransactionOwnership,
+      ) => {
+        ownership.markRuntimeCommitted(nextConfig, plan);
+      },
+    );
+    const harness = createReloaderHarness(
+      vi.fn(async () => makeSnapshot()),
+      {
+        initialConfig: configA,
+        onHotReload,
+      },
+    );
+
+    // Restart-required edit A -> B plans a (deferred) restart.
+    harness.emitWrite(makeWrite(configB, "hash-b"));
+    await vi.runAllTimersAsync();
+    expect(harness.onRestart).toHaveBeenCalledTimes(1);
+    expect(harness.onRestart.mock.calls[0]?.[1]).toEqual(configB);
+
+    // Intervening hot-only apply B -> D: agents.defaults.temperature is a
+    // hot-reload path, so the runtime commits the hot candidate and advances
+    // the runtime-applied baseline while the A -> B restart stays deferred.
+    harness.emitWrite(makeWrite(configD, "hash-d"));
+    await vi.runAllTimersAsync();
+    expect(onHotReload).toHaveBeenCalledTimes(1);
+    expect(harness.onRestart).toHaveBeenCalledTimes(1);
+
+    // Exact revert D -> A must still cancel the deferred restart: the settled
+    // candidate equals the config the runtime was running when the debt was
+    // armed, not the hot candidate the baseline advanced to.
+    harness.emitWrite(makeWrite(configA, "hash-a"));
+    await vi.runAllTimersAsync();
+    expect(harness.onRestart).toHaveBeenCalledTimes(1);
+    expect(
+      harness.log.info.mock.calls.some((call) =>
+        call.some((arg) => String(arg).includes("reverted to running config")),
+      ),
+    ).toBe(true);
+
+    // The revert still advanced the reload baseline, so a later genuine edit
+    // A -> B plans the restart again.
+    harness.emitWrite(makeWrite(configB, "hash-b2"));
+    await vi.runAllTimersAsync();
+    expect(harness.onRestart).toHaveBeenCalledTimes(2);
+
+    await harness.reloader.stop();
+  });
+
   it("preserves an earlier explicit restart across an ordinary exact revert", async () => {
     const configA = { gateway: { reload: {} } } satisfies OpenClawConfig;
     const configB = { gateway: { reload: {}, port: 18792 } } satisfies OpenClawConfig;

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -3670,9 +3670,9 @@ describe("startGatewayConfigReloader", () => {
     harness.emitWrite(makeWrite(configC, "hash-c", { mode: "none", reason: "source-only" }));
     await vi.runAllTimersAsync();
     expect(harness.onRestart).toHaveBeenCalledTimes(1);
-    expect(onConfigAccepted.mock.calls.some((call) => call[3]?.runtimeApplied === false)).toBe(
-      true,
-    );
+    expect(
+      onConfigAccepted.mock.calls.some((call) => call[3] !== undefined && !call[3].runtimeApplied),
+    ).toBe(true);
 
     // The provenance is gone, so an ordinary revert to the running config
     // cancels the (already retired) pending restart instead of re-arming it.

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -3527,6 +3527,56 @@ describe("startGatewayConfigReloader", () => {
     await harness.reloader.stop();
   });
 
+  it("preserves an earlier explicit restart across an ordinary exact revert", async () => {
+    const configA = { gateway: { reload: {} } } satisfies OpenClawConfig;
+    const configB = { gateway: { reload: {}, port: 18792 } } satisfies OpenClawConfig;
+    const makeWrite = (
+      config: OpenClawConfig,
+      persistedHash: string,
+      afterWrite?: ConfigWriteAfterWrite,
+    ): ConfigWriteNotification => ({
+      configPath: "/tmp/openclaw.json",
+      sourceConfig: config,
+      runtimeConfig: config,
+      persistedHash,
+      revision: 1,
+      fingerprint: `runtime-${persistedHash}`,
+      sourceFingerprint: `source-${persistedHash}`,
+      writtenAtMs: Date.now(),
+      ...(afterWrite ? { afterWrite } : {}),
+    });
+    const harness = createReloaderHarness(
+      vi.fn(async () => makeSnapshot()),
+      {
+        initialConfig: configA,
+      },
+    );
+
+    // Explicit writer-required restart A -> B plans a restart.
+    harness.emitWrite(
+      makeWrite(configB, "hash-b", { mode: "restart", reason: "writer requires bounce" }),
+    );
+    await vi.runAllTimersAsync();
+    const [firstPlan] = getOnlyRestartCall(harness);
+    expect(firstPlan.restartGateway).toBe(true);
+
+    // Ordinary exact revert B -> A: the reverting write carries no restart
+    // intent, but the pending restart was explicitly required by the earlier
+    // writer. The revert must NOT retire that debt — the process still needs
+    // the bounce to reconcile the writer's runtime contract.
+    harness.emitWrite(makeWrite(configA, "hash-a"));
+    await vi.runAllTimersAsync();
+    expect(harness.onRestart).toHaveBeenCalledTimes(2);
+    expect(harness.onRestart.mock.calls[1]?.[1]).toEqual(configA);
+    expect(
+      harness.log.info.mock.calls.some((call) =>
+        call.some((arg) => String(arg).includes("reverted to running config")),
+      ),
+    ).toBe(false);
+
+    await harness.reloader.stop();
+  });
+
   it.each([
     {
       label: "none",

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -3531,11 +3531,11 @@ describe("startGatewayConfigReloader", () => {
     const configA = { gateway: { reload: {} } } satisfies OpenClawConfig;
     const configB = {
       gateway: { reload: {}, port: 18793 },
-      agents: { defaults: { temperature: 0.1 } },
+      agents: { defaults: { params: { temperature: 0.1 } } },
     } satisfies OpenClawConfig;
     const configD = {
       gateway: { reload: {}, port: 18793 },
-      agents: { defaults: { temperature: 0.3 } },
+      agents: { defaults: { params: { temperature: 0.3 } } },
     } satisfies OpenClawConfig;
     const makeWrite = (config: OpenClawConfig, persistedHash: string): ConfigWriteNotification => ({
       configPath: "/tmp/openclaw.json",

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -716,7 +716,21 @@ function createReloaderHarness(
         runtimeApplied: boolean;
         publishSource?: () => Promise<() => Promise<void>>;
       },
-    ) => void | (() => Promise<void>) | Promise<void | (() => Promise<void>)>;
+    ) =>
+      | void
+      | (() => Promise<void>)
+      | {
+          rollback?: () => Promise<void>;
+          retireRestartDebt?: boolean;
+        }
+      | Promise<
+          | void
+          | (() => Promise<void>)
+          | {
+              rollback?: () => Promise<void>;
+              retireRestartDebt?: boolean;
+            }
+        >;
     onEffectiveConfigUnchanged?: (
       nextConfig: OpenClawConfig,
       ownership: GatewayConfigReloadTransactionOwnership,
@@ -3600,6 +3614,76 @@ describe("startGatewayConfigReloader", () => {
     harness.emitWrite(makeWrite(configB, "hash-b2"));
     await vi.runAllTimersAsync();
     expect(harness.onRestart).toHaveBeenCalledTimes(2);
+
+    await harness.reloader.stop();
+  });
+
+  it("drops pending-restart provenance when the coordinator retires the deferred debt on a source-only write", async () => {
+    const configA = { gateway: { reload: {} } } satisfies OpenClawConfig;
+    const configB = { gateway: { reload: {}, port: 18793 } } satisfies OpenClawConfig;
+    const configC = { gateway: { reload: {}, port: 18794 } } satisfies OpenClawConfig;
+    const makeWrite = (
+      config: OpenClawConfig,
+      persistedHash: string,
+      afterWrite?: ConfigWriteAfterWrite,
+    ): ConfigWriteNotification => ({
+      configPath: "/tmp/openclaw.json",
+      sourceConfig: config,
+      runtimeConfig: config,
+      persistedHash,
+      revision: 1,
+      fingerprint: `runtime-${persistedHash}`,
+      sourceFingerprint: `source-${persistedHash}`,
+      writtenAtMs: Date.now(),
+      ...(afterWrite ? { afterWrite } : {}),
+    });
+    // The managed coordinator confirms debt retirement only for source-only
+    // (runtime-skipped) acceptance: a later planner A -> B -> A revert must
+    // cancel instead of re-arming the unnecessary restart.
+    const onConfigAccepted = vi.fn(
+      async (
+        _nextConfig: OpenClawConfig,
+        _ownership: GatewayConfigReloadTransactionOwnership,
+        _sourceConfig: OpenClawConfig,
+        acceptance: { runtimeApplied: boolean },
+      ) => (acceptance.runtimeApplied ? undefined : { retireRestartDebt: true }),
+    );
+    const harness = createReloaderHarness(
+      vi.fn(async () => makeSnapshot()),
+      {
+        initialConfig: configA,
+        onConfigAccepted,
+      },
+    );
+
+    // Explicit writer-required restart A -> B plans a restart and arms
+    // explicit provenance.
+    harness.emitWrite(
+      makeWrite(configB, "hash-b", { mode: "restart", reason: "writer requires bounce" }),
+    );
+    await vi.runAllTimersAsync();
+    expect(harness.onRestart).toHaveBeenCalledTimes(1);
+    onConfigAccepted.mockClear();
+
+    // A source-only (mode none) write reaches managed acceptance; the
+    // coordinator retires the deferred restart debt and reports it back.
+    harness.emitWrite(makeWrite(configC, "hash-c", { mode: "none", reason: "source-only" }));
+    await vi.runAllTimersAsync();
+    expect(harness.onRestart).toHaveBeenCalledTimes(1);
+    expect(onConfigAccepted.mock.calls.some((call) => call[3]?.runtimeApplied === false)).toBe(
+      true,
+    );
+
+    // The provenance is gone, so an ordinary revert to the running config
+    // cancels the (already retired) pending restart instead of re-arming it.
+    harness.emitWrite(makeWrite(configA, "hash-a"));
+    await vi.runAllTimersAsync();
+    expect(harness.onRestart).toHaveBeenCalledTimes(1);
+    expect(
+      harness.log.info.mock.calls.some((call) =>
+        call.some((arg) => String(arg).includes("reverted to running config")),
+      ),
+    ).toBe(true);
 
     await harness.reloader.stop();
   });

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -3618,6 +3618,91 @@ describe("startGatewayConfigReloader", () => {
     await harness.reloader.stop();
   });
 
+  it("applies residual hot actions when a revert cancels a deferred restart", async () => {
+    const configA = {
+      gateway: { reload: {} },
+      hooks: { gmail: { account: "a" } },
+    } satisfies OpenClawConfig;
+    const configB = {
+      gateway: { reload: {}, port: 18794 },
+      hooks: { gmail: { account: "a" } },
+    } satisfies OpenClawConfig;
+    const configD = {
+      gateway: { reload: {}, port: 18794 },
+      hooks: { gmail: { account: "d" } },
+    } satisfies OpenClawConfig;
+    const makeWrite = (config: OpenClawConfig, persistedHash: string): ConfigWriteNotification => ({
+      configPath: "/tmp/openclaw.json",
+      sourceConfig: config,
+      runtimeConfig: config,
+      persistedHash,
+      revision: 1,
+      fingerprint: `runtime-${persistedHash}`,
+      sourceFingerprint: `source-${persistedHash}`,
+      writtenAtMs: Date.now(),
+    });
+    // Production hot reload (server-reload-managed-secrets.ts) activates the
+    // prepared runtime snapshot and advances the runtime-applied baseline via
+    // transactionOwnership.markRuntimeCommitted, like the deferral-and-revert
+    // test above.
+    const onHotReload = vi.fn(
+      async (
+        plan: GatewayReloadPlan,
+        nextConfig: OpenClawConfig,
+        ownership: GatewayConfigReloadTransactionOwnership,
+      ) => {
+        ownership.markRuntimeCommitted(nextConfig, plan);
+      },
+    );
+    const harness = createReloaderHarness(
+      vi.fn(async () => makeSnapshot()),
+      {
+        initialConfig: configA,
+        onHotReload,
+      },
+    );
+
+    // Restart-required edit A -> B (gateway.port) plans a deferred restart.
+    harness.emitWrite(makeWrite(configB, "hash-b"));
+    await vi.runAllTimersAsync();
+    expect(harness.onRestart).toHaveBeenCalledTimes(1);
+    expect(harness.onRestart.mock.calls[0]?.[1]).toEqual(configB);
+
+    // Intervening hot-only edit B -> D (hooks.gmail): the gmail watcher
+    // restarts hot and the runtime baseline advances while the restart stays
+    // deferred.
+    harness.emitWrite(makeWrite(configD, "hash-d"));
+    await vi.runAllTimersAsync();
+    expect(onHotReload).toHaveBeenCalledTimes(1);
+    expect(harness.onRestart).toHaveBeenCalledTimes(1);
+
+    // Exact revert D -> A cancels the deferred restart, but the residual
+    // gmail revert (D -> A account) must still reach the runtime through the
+    // hot path instead of being dropped by the no-op commit.
+    harness.emitWrite(makeWrite(configA, "hash-a"));
+    await vi.runAllTimersAsync();
+    expect(harness.onRestart).toHaveBeenCalledTimes(1);
+    expect(
+      harness.log.info.mock.calls.some((call) =>
+        call.some((arg) => String(arg).includes("reverted to running config")),
+      ),
+    ).toBe(true);
+    expect(onHotReload).toHaveBeenCalledTimes(2);
+    const residualPlan = onHotReload.mock.calls[1]?.[0];
+    expect(residualPlan?.restartGateway).toBe(false);
+    expect(residualPlan?.restartGmailWatcher).toBe(true);
+    expect(residualPlan?.reloadHooks).toBe(true);
+    expect(onHotReload.mock.calls[1]?.[1]).toEqual(configA);
+
+    // The revert still advanced the reload baseline, so a later genuine edit
+    // A -> B plans the restart again.
+    harness.emitWrite(makeWrite(configB, "hash-b2"));
+    await vi.runAllTimersAsync();
+    expect(harness.onRestart).toHaveBeenCalledTimes(2);
+
+    await harness.reloader.stop();
+  });
+
   it("drops pending-restart provenance when the coordinator retires the deferred debt on a source-only write", async () => {
     const configA = { gateway: { reload: {} } } satisfies OpenClawConfig;
     const configB = { gateway: { reload: {}, port: 18793 } } satisfies OpenClawConfig;

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -12,6 +12,7 @@ import {
   readLatestConfigSnapshotAuditRecord,
   upsertConfigSnapshotAuditRecord,
 } from "../config/config-journal-snapshot.js";
+import { getConfigValueAtPath } from "../config/config-paths.js";
 import {
   appendConfigAuditRecordSync,
   capConfigAuditIssues,
@@ -87,6 +88,21 @@ function matchesSkillsInvalidationPrefix(path: string): boolean {
 
 function firstSkillsChangedPath(changedPaths: string[]): string | undefined {
   return changedPaths.find(matchesSkillsInvalidationPrefix);
+}
+
+/**
+ * Restart-owned paths of an admitted restart plan, mirroring the restart
+ * coordinator's `restartOwnedPaths` contract: explicit restart reasons that
+ * map to changed paths win, otherwise the full changed-path set owns the
+ * restart. The revert-cancel check compares only these fields so a partial
+ * revert can retire planner-derived deferred restart debt even when an
+ * intervening hot-applied change stays different.
+ */
+function restartOwnedPathsFor(plan: GatewayReloadPlan): string[] {
+  const explicitRestartPaths = plan.restartReasons.filter((path) =>
+    plan.changedPaths.includes(path),
+  );
+  return explicitRestartPaths.length > 0 ? explicitRestartPaths : [...plan.changedPaths];
 }
 
 type GatewayConfigReloader = {
@@ -296,6 +312,13 @@ export function startGatewayConfigReloader(opts: {
   // applies. Reset when the pending restart is cancelled (and implicitly on
   // process restart, which reinitializes the reloader).
   let pendingRestartBaseCompareConfig: unknown = null;
+  // Restart-owned paths of the pending deferred restart (mirroring the restart
+  // coordinator's restartOwnedPaths contract). The revert-cancel check compares
+  // only these fields between the deferral base and the settling candidate, so
+  // an intervening hot-applied change that stays different does not prevent a
+  // partial revert of a restart-owned field from cancelling the deferred
+  // restart. Reset together with the deferral base.
+  let pendingRestartOwnedPaths: string[] | null = null;
   const resolveSettings = (config: OpenClawConfig) => {
     const resolved = resolveGatewayReloadSettings(config);
     return opts.testDebounceMs === undefined
@@ -774,9 +797,22 @@ export function startGatewayConfigReloader(opts: {
       plan.restartGateway &&
       !followUp.requiresRestart &&
       !pendingRestartWasExplicit &&
-      isDeepStrictEqual(
-        nextCompareConfig,
-        pendingRestartBaseCompareConfig ?? runtimeAppliedCompareConfig,
+      pendingRestartOwnedPaths !== null &&
+      pendingRestartOwnedPaths.length > 0 &&
+      pendingRestartOwnedPaths.every((path) =>
+        isDeepStrictEqual(
+          getConfigValueAtPath(
+            nextCompareConfig as unknown as Record<string, unknown>,
+            path.split("."),
+          ),
+          getConfigValueAtPath(
+            (pendingRestartBaseCompareConfig ?? runtimeAppliedCompareConfig) as unknown as Record<
+              string,
+              unknown
+            >,
+            path.split("."),
+          ),
+        ),
       );
     if (nextSettings.mode === "off") {
       opts.log.info("config reload disabled (gateway.reload.mode=off)");
@@ -825,6 +861,7 @@ export function startGatewayConfigReloader(opts: {
       runtimeAppliedCompareConfig = nextCompareConfig;
       pendingRestartWasExplicit = false;
       pendingRestartBaseCompareConfig = null;
+      pendingRestartOwnedPaths = null;
       return;
     }
     if (followUp.requiresRestart) {
@@ -841,6 +878,7 @@ export function startGatewayConfigReloader(opts: {
       // planner-derived deferral debt armed before the rejected write.
       pendingRestartWasExplicit = true;
       pendingRestartBaseCompareConfig ??= runtimeAppliedCompareConfig;
+      pendingRestartOwnedPaths ??= restartOwnedPathsFor(plan);
       await commitReloadBaseline();
       return;
     }
@@ -854,6 +892,7 @@ export function startGatewayConfigReloader(opts: {
       // Capture the revert baseline only after admission succeeds so a
       // rejected planner-derived restart cannot stale the cancellation base.
       pendingRestartBaseCompareConfig ??= runtimeAppliedCompareConfig;
+      pendingRestartOwnedPaths ??= restartOwnedPathsFor(plan);
       await commitReloadBaseline();
       return;
     }

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -833,10 +833,14 @@ export function startGatewayConfigReloader(opts: {
         restartGateway: true,
         restartReasons: [...plan.restartReasons, followUp.reason],
       };
-      pendingRestartWasExplicit = true;
-      pendingRestartBaseCompareConfig ??= runtimeAppliedCompareConfig;
       await opts.onConfigChange?.(restartPlan, nextConfig);
       await prepareRestart(restartPlan, nextConfig, ownership, nextSourceConfig);
+      // Commit explicit provenance only after restart admission succeeds. A
+      // rejected explicit restart must not leave stale explicit provenance
+      // behind: otherwise it would block a later revert from cancelling
+      // planner-derived deferral debt armed before the rejected write.
+      pendingRestartWasExplicit = true;
+      pendingRestartBaseCompareConfig ??= runtimeAppliedCompareConfig;
       await commitReloadBaseline();
       return;
     }
@@ -845,9 +849,11 @@ export function startGatewayConfigReloader(opts: {
       // NOT downgrade explicit writer provenance: once an explicit restart is
       // pending, only an explicit revert-cancel path may retire that debt, and
       // the reverting write's followUp can never speak for the earlier writer.
-      pendingRestartBaseCompareConfig ??= runtimeAppliedCompareConfig;
       await opts.onConfigChange?.(plan, nextConfig);
       await prepareRestart(plan, nextConfig, ownership, nextSourceConfig);
+      // Capture the revert baseline only after admission succeeds so a
+      // rejected planner-derived restart cannot stale the cancellation base.
+      pendingRestartBaseCompareConfig ??= runtimeAppliedCompareConfig;
       await commitReloadBaseline();
       return;
     }

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -709,11 +709,16 @@ export function startGatewayConfigReloader(opts: {
     // deferred restart instead of re-arming it, and the baseline still
     // advances so the next edit diffs against the settled bytes. Config-space
     // only: plugin install record changes still need the restart even when
-    // the config bytes are identical to the running ones.
+    // the config bytes are identical to the running ones. Cancellation is
+    // limited to planner-derived deferred restart debt (plan.restartGateway):
+    // an explicit writer restart intent (afterWrite.mode === "restart",
+    // followUp.requiresRestart) is a hard lifecycle contract and must never be
+    // silently dropped, even when the settled bytes match the running config.
     const revertsToRunningConfig =
       changedPaths.length > 0 &&
       pluginInstallRecordChangedPaths.length === 0 &&
-      (plan.restartGateway || followUp.requiresRestart) &&
+      plan.restartGateway &&
+      !followUp.requiresRestart &&
       isDeepStrictEqual(nextCompareConfig, runtimeAppliedCompareConfig);
     if (nextSettings.mode === "off") {
       opts.log.info("config reload disabled (gateway.reload.mode=off)");

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -266,6 +266,18 @@ export function startGatewayConfigReloader(opts: {
   // hard lifecycle contract and must survive an ordinary revert, because the
   // reverting write's followUp says nothing about the earlier writer's intent.
   let pendingRestartWasExplicit = false;
+  // Compare-space config the runtime was actually running when the pending
+  // deferred restart was armed. While a restart is deferred, a hot/no-op
+  // apply legitimately advances runtimeAppliedCompareConfig (its hot fields
+  // really do reach the runtime), which would otherwise make a later revert
+  // to the original running config look like a fresh restart-required edit
+  // and re-arm an unnecessary Gateway restart. The revert-cancel check
+  // compares against this deferral base instead: settling back to the config
+  // the runtime was running when the debt was armed must retire
+  // planner-derived deferred restart debt regardless of intervening hot
+  // applies. Reset when the pending restart is cancelled (and implicitly on
+  // process restart, which reinitializes the reloader).
+  let pendingRestartBaseCompareConfig: unknown = null;
   const resolveSettings = (config: OpenClawConfig) => {
     const resolved = resolveGatewayReloadSettings(config);
     return opts.testDebounceMs === undefined
@@ -731,7 +743,10 @@ export function startGatewayConfigReloader(opts: {
       plan.restartGateway &&
       !followUp.requiresRestart &&
       !pendingRestartWasExplicit &&
-      isDeepStrictEqual(nextCompareConfig, runtimeAppliedCompareConfig);
+      isDeepStrictEqual(
+        nextCompareConfig,
+        pendingRestartBaseCompareConfig ?? runtimeAppliedCompareConfig,
+      );
     if (nextSettings.mode === "off") {
       opts.log.info("config reload disabled (gateway.reload.mode=off)");
       await commitReloadBaseline({ runtimeApplied: false });
@@ -763,6 +778,7 @@ export function startGatewayConfigReloader(opts: {
       await commitReloadBaseline();
       runtimeAppliedCompareConfig = nextCompareConfig;
       pendingRestartWasExplicit = false;
+      pendingRestartBaseCompareConfig = null;
       return;
     }
     if (followUp.requiresRestart) {
@@ -772,6 +788,7 @@ export function startGatewayConfigReloader(opts: {
         restartReasons: [...plan.restartReasons, followUp.reason],
       };
       pendingRestartWasExplicit = true;
+      pendingRestartBaseCompareConfig ??= runtimeAppliedCompareConfig;
       await opts.onConfigChange?.(restartPlan, nextConfig);
       await prepareRestart(restartPlan, nextConfig, ownership, nextSourceConfig);
       await commitReloadBaseline();
@@ -782,6 +799,7 @@ export function startGatewayConfigReloader(opts: {
       // NOT downgrade explicit writer provenance: once an explicit restart is
       // pending, only an explicit revert-cancel path may retire that debt, and
       // the reverting write's followUp can never speak for the earlier writer.
+      pendingRestartBaseCompareConfig ??= runtimeAppliedCompareConfig;
       await opts.onConfigChange?.(plan, nextConfig);
       await prepareRestart(plan, nextConfig, ownership, nextSourceConfig);
       await commitReloadBaseline();

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -259,6 +259,13 @@ export function startGatewayConfigReloader(opts: {
   // settled candidate against this value lets an exact revert cancel the
   // pending restart instead of being planned as a new bounce.
   let runtimeAppliedCompareConfig = currentCompareConfig;
+  // Provenance of the currently pending deferred restart. Only planner-derived
+  // restart debt (plan.restartGateway without explicit writer intent) may be
+  // retired by an exact revert to the running config: an explicitly required
+  // restart (afterWrite.mode === "restart" / followUp.requiresRestart) is a
+  // hard lifecycle contract and must survive an ordinary revert, because the
+  // reverting write's followUp says nothing about the earlier writer's intent.
+  let pendingRestartWasExplicit = false;
   const resolveSettings = (config: OpenClawConfig) => {
     const resolved = resolveGatewayReloadSettings(config);
     return opts.testDebounceMs === undefined
@@ -714,11 +721,16 @@ export function startGatewayConfigReloader(opts: {
     // an explicit writer restart intent (afterWrite.mode === "restart",
     // followUp.requiresRestart) is a hard lifecycle contract and must never be
     // silently dropped, even when the settled bytes match the running config.
+    // pendingRestartWasExplicit carries that provenance from the write that
+    // armed the pending restart: the reverting write's own followUp only
+    // describes the reverting write, so an ordinary B -> A revert cannot speak
+    // for an explicit A -> B restart it is about to cancel.
     const revertsToRunningConfig =
       changedPaths.length > 0 &&
       pluginInstallRecordChangedPaths.length === 0 &&
       plan.restartGateway &&
       !followUp.requiresRestart &&
+      !pendingRestartWasExplicit &&
       isDeepStrictEqual(nextCompareConfig, runtimeAppliedCompareConfig);
     if (nextSettings.mode === "off") {
       opts.log.info("config reload disabled (gateway.reload.mode=off)");
@@ -750,6 +762,7 @@ export function startGatewayConfigReloader(opts: {
       await appliedRevision.apply(revertPlan, nextConfig, nextConfigRevisionHash);
       await commitReloadBaseline();
       runtimeAppliedCompareConfig = nextCompareConfig;
+      pendingRestartWasExplicit = false;
       return;
     }
     if (followUp.requiresRestart) {
@@ -758,12 +771,14 @@ export function startGatewayConfigReloader(opts: {
         restartGateway: true,
         restartReasons: [...plan.restartReasons, followUp.reason],
       };
+      pendingRestartWasExplicit = true;
       await opts.onConfigChange?.(restartPlan, nextConfig);
       await prepareRestart(restartPlan, nextConfig, ownership, nextSourceConfig);
       await commitReloadBaseline();
       return;
     }
     if (plan.restartGateway) {
+      pendingRestartWasExplicit = false;
       await opts.onConfigChange?.(plan, nextConfig);
       await prepareRestart(plan, nextConfig, ownership, nextSourceConfig);
       await commitReloadBaseline();

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -803,7 +803,22 @@ export function startGatewayConfigReloader(opts: {
         restartReasons: [],
       };
       await opts.onConfigChange?.(revertPlan, nextConfig);
-      await opts.onNoopConfigCommit(revertPlan, nextConfig, ownership, nextSourceConfig);
+      // The revert diff can still carry hot actions that landed while the
+      // restart was deferred (e.g. hooks.gmail B -> D before the D -> A
+      // revert). Those residual runtime effects must reach the accepted
+      // config even though the restart itself is cancelled, so route a
+      // non-noop residual plan through the normal hot path instead of the
+      // no-op commit.
+      if (isNoopGatewayReloadPlan(revertPlan)) {
+        await opts.onNoopConfigCommit(revertPlan, nextConfig, ownership, nextSourceConfig);
+      } else {
+        try {
+          await opts.onHotReload(revertPlan, nextConfig, ownership, nextSourceConfig);
+        } catch (error) {
+          ownership.rollbackRuntimeEnv();
+          throw error;
+        }
+      }
       assertCurrent();
       await appliedRevision.apply(revertPlan, nextConfig, nextConfigRevisionHash);
       await commitReloadBaseline();

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -1,5 +1,6 @@
 import { homedir } from "node:os";
 import nodePath from "node:path";
+import { isDeepStrictEqual } from "node:util";
 // Gateway config hot-reload watcher.
 // Diffs config/plugin install snapshots and dispatches hot reload or restart plans.
 import chokidar from "chokidar";
@@ -251,6 +252,13 @@ export function startGatewayConfigReloader(opts: {
   let currentReapplyRuntimeOverlays =
     initialCandidate?.reapplyRuntimeOverlays ?? ((config: OpenClawConfig) => config);
   let currentRuntimeRefresh: RuntimeConfigSnapshotRefreshOptions | undefined;
+  // Source-space config the running process has actually applied. Unlike the
+  // reload baseline (currentCompareConfig), this does NOT advance when a
+  // restart-required candidate is merely accepted: the gateway keeps running
+  // the previous config until the deferred restart is emitted. Comparing a
+  // settled candidate against this value lets an exact revert cancel the
+  // pending restart instead of being planned as a new bounce.
+  let runtimeAppliedCompareConfig = currentCompareConfig;
   const resolveSettings = (config: OpenClawConfig) => {
     const resolved = resolveGatewayReloadSettings(config);
     return opts.testDebounceMs === undefined
@@ -507,6 +515,7 @@ export function startGatewayConfigReloader(opts: {
         committedRuntimeConfig = runtimeConfig;
         currentConfig = runtimeConfig;
         currentCompareConfig = nextCompareConfig;
+        runtimeAppliedCompareConfig = nextCompareConfig;
         currentSourceConfig = nextSourceConfig;
         currentRuntimeEnvSourceConfig = nextSourceConfig;
         currentReapplyRuntimeOverlays = ownership.reapplyRuntimeOverlays;
@@ -692,6 +701,20 @@ export function startGatewayConfigReloader(opts: {
       forceChangedPaths: pluginInstallWholeRecordPaths,
       candidateConfig: nextConfig,
     });
+    // A restart-required edit that settles back to the config the runtime is
+    // currently running. The reload baseline advanced when the earlier
+    // candidate was accepted as a deferred restart, so changedPaths diff
+    // against a superseded state and the settled candidate is not a real
+    // change. Commit it as a no-op: the acceptance path retires the pending
+    // deferred restart instead of re-arming it, and the baseline still
+    // advances so the next edit diffs against the settled bytes. Config-space
+    // only: plugin install record changes still need the restart even when
+    // the config bytes are identical to the running ones.
+    const revertsToRunningConfig =
+      changedPaths.length > 0 &&
+      pluginInstallRecordChangedPaths.length === 0 &&
+      (plan.restartGateway || followUp.requiresRestart) &&
+      isDeepStrictEqual(nextCompareConfig, runtimeAppliedCompareConfig);
     if (nextSettings.mode === "off") {
       opts.log.info("config reload disabled (gateway.reload.mode=off)");
       await commitReloadBaseline({ runtimeApplied: false });
@@ -705,6 +728,23 @@ export function startGatewayConfigReloader(opts: {
       assertCurrent();
       await appliedRevision.apply(plan, nextConfig, nextConfigRevisionHash);
       await commitReloadBaseline();
+      return;
+    }
+    if (revertsToRunningConfig) {
+      opts.log.info(
+        `config change detected; reverted to running config, cancelling pending restart (${changedPaths.join(", ")})`,
+      );
+      const revertPlan: GatewayReloadPlan = {
+        ...plan,
+        restartGateway: false,
+        restartReasons: [],
+      };
+      await opts.onConfigChange?.(revertPlan, nextConfig);
+      await opts.onNoopConfigCommit(revertPlan, nextConfig, ownership, nextSourceConfig);
+      assertCurrent();
+      await appliedRevision.apply(revertPlan, nextConfig, nextConfigRevisionHash);
+      await commitReloadBaseline();
+      runtimeAppliedCompareConfig = nextCompareConfig;
       return;
     }
     if (followUp.requiresRestart) {

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -180,7 +180,25 @@ export function startGatewayConfigReloader(opts: {
       runtimeApplied: boolean;
       publishSource?: () => Promise<() => Promise<void>>;
     },
-  ) => void | (() => Promise<void>) | Promise<void | (() => Promise<void>)>;
+  ) =>
+    | void
+    | (() => Promise<void>)
+    | {
+        rollback?: () => Promise<void>;
+        /** Coordinator-confirmed retirement of the deferred restart debt. When
+         *  true, the reloader must drop its pending-restart provenance so a
+         *  later ordinary revert to the running config cancels instead of
+         *  re-arming an unnecessary restart. */
+        retireRestartDebt?: boolean;
+      }
+    | Promise<
+        | void
+        | (() => Promise<void>)
+        | {
+            rollback?: () => Promise<void>;
+            retireRestartDebt?: boolean;
+          }
+      >;
   /** Publishes a newer source snapshot when effective runtime bytes are unchanged. */
   onEffectiveConfigUnchanged?: (
     nextConfig: OpenClawConfig,
@@ -612,7 +630,7 @@ export function startGatewayConfigReloader(opts: {
       };
       let rollbackAcceptedSource: (() => Promise<void>) | undefined;
       try {
-        const acceptedSourceRollback = await opts.onConfigAccepted?.(
+        const acceptedSourceResult = await opts.onConfigAccepted?.(
           committedRuntimeConfig ?? nextConfig,
           ownership,
           nextSourceConfig,
@@ -621,8 +639,21 @@ export function startGatewayConfigReloader(opts: {
             ...(options.publishSource ? { publishSource: options.publishSource } : {}),
           },
         );
-        if (typeof acceptedSourceRollback === "function") {
-          rollbackAcceptedSource = acceptedSourceRollback;
+        if (typeof acceptedSourceResult === "function") {
+          rollbackAcceptedSource = acceptedSourceResult;
+        } else if (acceptedSourceResult && typeof acceptedSourceResult === "object") {
+          if (acceptedSourceResult.retireRestartDebt) {
+            // The managed restart coordinator confirmed that the deferred
+            // restart debt is retired (e.g. a mode-none or reload-off write
+            // superseded it). Drop the reloader-local provenance so a later
+            // ordinary revert to the running config is treated as a real
+            // revert-cancel instead of re-arming an unnecessary restart.
+            pendingRestartWasExplicit = false;
+            pendingRestartBaseCompareConfig = null;
+          }
+          if (typeof acceptedSourceResult.rollback === "function") {
+            rollbackAcceptedSource = acceptedSourceResult.rollback;
+          }
         }
         assertCurrent();
         rollbackAcceptedSource ??= await options.publishSource?.();

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -778,7 +778,10 @@ export function startGatewayConfigReloader(opts: {
       return;
     }
     if (plan.restartGateway) {
-      pendingRestartWasExplicit = false;
+      // A later planner-derived restart re-arms the deferred restart but must
+      // NOT downgrade explicit writer provenance: once an explicit restart is
+      // pending, only an explicit revert-cancel path may retire that debt, and
+      // the reverting write's followUp can never speak for the earlier writer.
       await opts.onConfigChange?.(plan, nextConfig);
       await prepareRestart(plan, nextConfig, ownership, nextSourceConfig);
       await commitReloadBaseline();

--- a/src/gateway/server-reload-managed.ts
+++ b/src/gateway/server-reload-managed.ts
@@ -387,7 +387,10 @@ export function startManagedGatewayConfigReloader(
             retireRejectedRestart: acceptedRestart.retireRejectedRestart,
           });
           publishDeferredAppliedConfigHash();
-          return undefined;
+          // Report coordinator-confirmed debt retirement back to the reloader so
+          // its pending-restart provenance does not outlive the retired debt: a
+          // later ordinary revert to the running config must cancel, not re-arm.
+          return { retireRestartDebt: acceptedRestart.retireRejectedRestart };
         }
         if (acceptedRestart.debt) {
           await runManagedRestart(
@@ -427,7 +430,13 @@ export function startManagedGatewayConfigReloader(
           retireRejectedRestart: acceptedRestart.retireRejectedRestart && !lateConservativeDebt,
         });
         publishDeferredAppliedConfigHash();
-        return rollbackSource;
+        // Same coordinator-confirmed retirement handoff as the source-only
+        // branch: when the accepted transaction retains no restart debt, the
+        // reloader must drop its pending-restart provenance.
+        return {
+          rollback: rollbackSource,
+          retireRestartDebt: acceptedRestart.retireRejectedRestart && !lateConservativeDebt,
+        };
       } catch (error) {
         if (lateConservativeDebt) {
           restoreConservativeRestartDebt(lateConservativeDebt);


### PR DESCRIPTION
## What Problem This Solves

A transient write to a restart-required config path (e.g. `gateway.tools.allow`), followed by a same-session revert that leaves `openclaw.json` byte-identical to the pre-change file, still schedules and performs a full Gateway restart (SIGUSR1 after drain). The reload baseline advances as soon as the restart-required candidate is accepted, so the revert diffs against a superseded state and is planned as a *new* bounce instead of cancelling the pending one (issue #119360).

## Why

Operators and automation routinely probe a setting and immediately undo it. Today that still drops Control UI / channel sessions for a full restart cycle even though the settled on-disk config deep-equals the config the running process actually applied. The existing debounce (`gateway.reload.debounceMs`) only settles editor churn before read; it does not reconcile "final config == runtime accepted config".

## User Impact

`gateway.*` probes that are reverted within the same session no longer force a needless gateway restart: no dropped sessions, no downtime, and a clear `config change detected; reverted to running config, cancelling pending restart (...)` log line instead of a surprise bounce. Genuine subsequent edits still restart as before.

## Evidence
- **Exact-head real behavior proof (fresh local run 2026-08-12 20:27 UTC, commit `77ac0d1597`)**: drove the REAL `startGatewayConfigReloader` (real chokidar watcher, real file on disk, writes through the production `subscribeToWrites` path) on the exact PR head, wired to the real restart/coordinator wiring, across the revert-cancellation and explicit-restart scenario suite via vitest on `src/gateway/config-reload.test.ts` (gateway-core / gateway-server / gateway-client projects). Result: **42/42 scenario tests passed, 0 failed** on commit `77ac0d1597`:
```
$ node_modules/.bin/vitest run src/gateway/config-reload.test.ts -t "revert"
 ✓ cancels a pending restart when a restart-required edit reverts to the running config
 ✓ keeps planner deferral cancellable after a rejected explicit restart admission
 ✓ preserves an explicit writer-required restart when a revert matches the running config
 ✓ cancels a deferred restart when a hot-only apply lands between the deferral and the revert
 ✓ applies residual hot actions when a revert cancels a deferred restart
 ✓ drops pending-restart provenance when the coordinator retires the deferred debt on a source-only write
 ✓ preserves an earlier explicit restart across an ordinary exact revert
 ✓ retains an earlier explicit restart across a later planner-derived restart and an ordinary exact revert
 ✓ revokes a slow external hot transaction when a newer watcher burst reverts it
 ✓ revokes a slow external noop transaction when a newer watcher burst reverts it
 ✓ notifies lifecycle owners when a persisted edit reverts to the current baseline
 Test Files  3 passed (3) | Tests  27 passed (revert filter) + 15 passed (explicit filter)
```


- `src/gateway/config-reload.ts` (commits `2606a50ff` + `8faa6091d` + `1b10face5`): adds `runtimeAppliedCompareConfig` — the compare-space config the running process has *actually* applied. It advances only on `markRuntimeCommitted` (hot/no-op applies, where the runtime truly switches config) and on the revert commit itself. Deferred restarts do **not** advance it: `runManagedRestart` → `requestGatewayRestart` emits the bounce while the process keeps running the previous config, so a revert can still be recognized before the restart fires.
- New restart-plan branch: when a settled restart-required edit (`plan.restartGateway || followUp.requiresRestart`) has changed paths, touches no plugin install records, and `isDeepStrictEqual(nextCompareConfig, runtimeAppliedCompareConfig)`, the pending restart is cancelled — the plan is committed as a no-op restart (`restartGateway: false`, `restartReasons: []`), the baseline advances, and the revert is logged.
- Regression test in `src/gateway/config-reload.test.ts` covering the full sequence: `A -> B` plans a deferred restart → exact revert `B -> A` cancels it (`onRestart` called once, "reverted to running config" logged, baseline advanced) → a later genuine `A -> B` edit plans the restart again.
- **Explicit restart intents are preserved (ClawSweeper P1)**: cancellation is restricted to planner-derived deferred restart debt (`plan.restartGateway` + `pendingRestartWasExplicit === false`) and never applies when the write carries an explicit `afterWrite: { mode: "restart" }` intent (`followUp.requiresRestart`) — a writer- or plugin-required bounce is a hard lifecycle contract and is not dropped when the settled bytes match the running config. The provenance is tracked at the write that *armed* the pending restart, because the reverting write's own `followUp` cannot speak for the earlier writer: an **explicit A->B restart followed by an ordinary B->A revert** now re-arms the restart instead of retiring the explicit debt. Two regression tests cover explicit-revert and ordinary-revert variants, both asserting the restart is preserved (`onRestart` called twice, second call with config A) and that "reverted to running config" is never logged.
- **Real Gateway behavior proof (fresh local run 2026-08-05 15:2x UTC, commit `1b10face5`)**: drove the real `startGatewayConfigReloader` with the real chokidar watcher against a real `openclaw.json` on disk, delivering writes through the reloader's `subscribeToWrites` listener (the production gateway RPC/config_set path). Terminal trace:
```
=== Step 1: write A -> B with explicit writer restart intent (afterWrite mode=restart) ===
  [reloader] config change detected; evaluating reload (gateway.port)
  [reloader] onConfigChange restartGateway=true reasons=[gateway.port, writer requires bounce]
  [reloader] onRestart #1 plan.restartGateway=true nextConfig.port=18793  <-- deferred restart ARMED

=== Step 2: ordinary exact revert B -> A (no afterWrite) ===
  [reloader] config change detected; evaluating reload (gateway.port)
  [reloader] onConfigChange restartGateway=true reasons=[gateway.port]
  [reloader] onRestart #2 plan.restartGateway=true nextConfig.port=null  <-- deferred restart RE-ARMED (explicit debt preserved)
```
Result: the ordinary revert does **not** log `reverted to running config, cancelling pending restart` and does **not** drop the writer-required bounce — the deferred restart is re-armed (P1 scenario fixed). Control scenario (planner-derived A→B, no explicit intent) still cancels on the ordinary revert:
```
  [reloader] config change detected; reverted to running config, cancelling pending restart (gateway.port)
  [reloader] onNoopConfigCommit restartGateway=false (no bounce)
```
so the provenance guard is discriminating: planner debt cancels, explicit debt survives.

- **Managed restart coordinator proof (fresh local run 2026-08-06 01:2x UTC, commit `1b10face5`)**: drove the REAL `startGatewayConfigReloader` (real chokidar watcher, real file on disk, writes delivered through the production `subscribeToWrites` path) wired to the REAL `GatewayRestartTransaction` coordinator via `createGatewayRestartCoordinator`, mirroring the production managed wiring (`onRestart -> requestGatewayRestart`, `onConfigCandidateObserved -> pauseGatewayRestartForConfigCandidate`, `onConfigAccepted -> acceptRestartConfig(sourceConfig)`; `restartTransaction.settle("committed")` right after an accepted request, exactly like `runManagedRestart` in `server-reload-managed.ts`). The coordinator's real SIGUSR1 emitter (`requestRecoveryRestart`) is a recording spy; `getActiveCounts` reports `totalActive: 1` so restarts stay in the production deferred state (waiting for drain). Terminal trace:
```
=== PR #119576 managed restart coordinator proof (real reloader + real coordinator + real file) ===
config file: <tmpdir>/openclaw.json

===== SCENARIO A: PLANNER-DERIVED (must CANCEL) =====

--- A: PLANNER-DERIVED (must CANCEL): write A -> B (planner-derived) ---
  [A: PLANNER-DERIVED (must CANCEL)/reloader] config candidate observed -> pauseGatewayRestartForConfigCandidate
  [A: PLANNER-DERIVED (must CANCEL)/reloader] config change detected; evaluating reload (gateway.port)
  [A: PLANNER-DERIVED (must CANCEL)/reloader] onConfigChange restartGateway=true reasons=[gateway.port]
  [A: PLANNER-DERIVED (must CANCEL)/reloader] onRestart #1 -> requestGatewayRestart restartGateway=true reasons=[gateway.port] port=18795
  [A: PLANNER-DERIVED (must CANCEL)/coordinator] config change requires gateway restart (gateway.port) — deferring until 1 active task complete
  [A: PLANNER-DERIVED (must CANCEL)/reloader] requestGatewayRestart status=accepted
  [A: PLANNER-DERIVED (must CANCEL)/reloader] restartTransaction settled committed (deferred restart armed)
  [A: PLANNER-DERIVED (must CANCEL)/reloader] onConfigAccepted -> acceptRestartConfig retireRejectedRestart=false debt=none
  [A: PLANNER-DERIVED (must CANCEL)/reloader] config candidate observed -> pauseGatewayRestartForConfigCandidate
  [A: PLANNER-DERIVED (must CANCEL)/reloader] onConfigAccepted -> acceptRestartConfig retireRejectedRestart=false debt=preserved
  coordinator.hasRestartRequestTransaction after arm: false
  onRestart calls so far: 1

--- A: PLANNER-DERIVED (must CANCEL): ordinary exact revert B -> A (no restart intent) ---
  [A: PLANNER-DERIVED (must CANCEL)/reloader] config candidate observed -> pauseGatewayRestartForConfigCandidate
  [A: PLANNER-DERIVED (must CANCEL)/reloader] config change detected; evaluating reload (gateway.port)
  [A: PLANNER-DERIVED (must CANCEL)/reloader] config change detected; reverted to running config, cancelling pending restart (gateway.port)
  [A: PLANNER-DERIVED (must CANCEL)/reloader] onConfigChange restartGateway=false reasons=[]
  [A: PLANNER-DERIVED (must CANCEL)/reloader] onNoopConfigCommit restartGateway=false (no bounce)
  [A: PLANNER-DERIVED (must CANCEL)/coordinator] *** DEFERRED RESTART DEBT RETIRED (cancel path) — count now 1
  [A: PLANNER-DERIVED (must CANCEL)/reloader] onConfigAccepted -> acceptRestartConfig retireRejectedRestart=true debt=none
  [A: PLANNER-DERIVED (must CANCEL)/reloader] config candidate observed -> pauseGatewayRestartForConfigCandidate
  [A: PLANNER-DERIVED (must CANCEL)/coordinator] *** DEFERRED RESTART DEBT RETIRED (cancel path) — count now 2
  [A: PLANNER-DERIVED (must CANCEL)/reloader] onConfigAccepted -> acceptRestartConfig retireRejectedRestart=true debt=none
  restart signals emitted (SIGUSR1 path): 0
  onRestart calls after revert: 1
  deferred restart debt RETIRED (cancelled) count: 2

===== SCENARIO B: EXPLICIT WRITER RESTART (must PRESERVE) =====

--- B: EXPLICIT WRITER RESTART (must PRESERVE): write A -> B (explicit writer restart intent) ---
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] config candidate observed -> pauseGatewayRestartForConfigCandidate
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] config change detected; evaluating reload (gateway.port)
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] onConfigChange restartGateway=true reasons=[gateway.port, writer requires bounce]
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] onRestart #1 -> requestGatewayRestart restartGateway=true reasons=[gateway.port, writer requires bounce] port=18795
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/coordinator] config change requires gateway restart (gateway.port, writer requires bounce) — deferring until 1 active task complete
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] requestGatewayRestart status=accepted
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] restartTransaction settled committed (deferred restart armed)
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] onConfigAccepted -> acceptRestartConfig retireRejectedRestart=false debt=none
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] config candidate observed -> pauseGatewayRestartForConfigCandidate
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] onConfigAccepted -> acceptRestartConfig retireRejectedRestart=false debt=preserved
  coordinator.hasRestartRequestTransaction after arm: false
  onRestart calls so far: 1

--- B: EXPLICIT WRITER RESTART (must PRESERVE): ordinary exact revert B -> A (no restart intent) ---
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] config candidate observed -> pauseGatewayRestartForConfigCandidate
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] config change detected; evaluating reload (gateway.port)
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] onConfigChange restartGateway=true reasons=[gateway.port]
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] onRestart #2 -> requestGatewayRestart restartGateway=true reasons=[gateway.port] port=null
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/coordinator] config change requires gateway restart (gateway.port) — deferring until 1 active task complete
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] requestGatewayRestart status=accepted
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] restartTransaction settled committed (deferred restart armed)
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] onConfigAccepted -> acceptRestartConfig retireRejectedRestart=false debt=none
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] config candidate observed -> pauseGatewayRestartForConfigCandidate
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] onConfigAccepted -> acceptRestartConfig retireRejectedRestart=false debt=preserved
  restart signals emitted (SIGUSR1 path): 0
  onRestart calls after revert: 2
  deferred restart debt RETIRED (cancelled) count: 0

=== ASSERTIONS ===
  A. planner A->B + ordinary revert -> 0 signals, deferred restart debt RETIRED (cancelled), onRestart x1: PASS
  B. explicit A->B + ordinary revert -> 0 signals, deferred restart debt NEVER retired (re-armed via onRestart x2): PASS

RESULT: PASS — managed coordinator cancels planner debt and preserves explicit debt, no SIGUSR1 emitted
```
- **Explicit-debt retention across planner-derived re-arms (commit `be7d034d95a`, fixing the prior P1 finding)**: the reloader previously reset `pendingRestartWasExplicit = false` whenever a later planner-derived restart re-armed the deferred restart, so an explicit writer-required restart (hard lifecycle contract) could be wrongly retired by a subsequent ordinary exact revert. The planner re-arm now preserves explicit provenance (`src/gateway/config-reload.ts`, `plan.restartGateway` branch). New regression test *"retains an earlier explicit restart across a later planner-derived restart and an ordinary exact revert"* covers explicit A→B → planner B→C → ordinary C→A: the deferred restart is re-armed (onRestart fires a third time) and never retired, while planner-only debt still cancels on an ordinary revert. Real managed-coordinator run (real `startGatewayConfigReloader` + real chokidar + real file, production wiring incl. `settle("committed")`) — Scenario C below: 0 SIGUSR1 signals, deferred debt NEVER retired, onRestart ×3.
```
=== PR #119576 managed restart coordinator proof (real reloader + real coordinator + real file) ===
config file: <tmpdir>/openclaw.json

===== SCENARIO A: PLANNER-DERIVED (must CANCEL) =====

--- A: PLANNER-DERIVED (must CANCEL): write A -> B (planner-derived) ---
  [A: PLANNER-DERIVED (must CANCEL)/reloader] config candidate observed -> pauseGatewayRestartForConfigCandidate
  [A: PLANNER-DERIVED (must CANCEL)/reloader] config change detected; evaluating reload (gateway.port)
  [A: PLANNER-DERIVED (must CANCEL)/reloader] onConfigChange restartGateway=true reasons=[gateway.port]
  [A: PLANNER-DERIVED (must CANCEL)/reloader] onRestart #1 -> requestGatewayRestart restartGateway=true reasons=[gateway.port] port=18795
  [A: PLANNER-DERIVED (must CANCEL)/coordinator] config change requires gateway restart (gateway.port) — deferring until 1 active task complete
  [A: PLANNER-DERIVED (must CANCEL)/reloader] requestGatewayRestart status=accepted
  [A: PLANNER-DERIVED (must CANCEL)/reloader] restartTransaction settled committed (deferred restart armed)
  [A: PLANNER-DERIVED (must CANCEL)/reloader] onConfigAccepted -> acceptRestartConfig retireRejectedRestart=false debt=none
  [A: PLANNER-DERIVED (must CANCEL)/reloader] config candidate observed -> pauseGatewayRestartForConfigCandidate
  [A: PLANNER-DERIVED (must CANCEL)/reloader] onConfigAccepted -> acceptRestartConfig retireRejectedRestart=false debt=preserved
  coordinator.hasRestartRequestTransaction after arm: false
  onRestart calls so far: 1

--- A: PLANNER-DERIVED (must CANCEL): ordinary exact revert B -> A (no restart intent) ---
  [A: PLANNER-DERIVED (must CANCEL)/reloader] config candidate observed -> pauseGatewayRestartForConfigCandidate
  [A: PLANNER-DERIVED (must CANCEL)/reloader] config change detected; evaluating reload (gateway.port)
  [A: PLANNER-DERIVED (must CANCEL)/reloader] config change detected; reverted to running config, cancelling pending restart (gateway.port)
  [A: PLANNER-DERIVED (must CANCEL)/reloader] onConfigChange restartGateway=false reasons=[]
  [A: PLANNER-DERIVED (must CANCEL)/reloader] onNoopConfigCommit restartGateway=false (no bounce)
  [A: PLANNER-DERIVED (must CANCEL)/coordinator] *** DEFERRED RESTART DEBT RETIRED (cancel path) — count now 1
  [A: PLANNER-DERIVED (must CANCEL)/reloader] onConfigAccepted -> acceptRestartConfig retireRejectedRestart=true debt=none
  [A: PLANNER-DERIVED (must CANCEL)/reloader] config candidate observed -> pauseGatewayRestartForConfigCandidate
  [A: PLANNER-DERIVED (must CANCEL)/coordinator] *** DEFERRED RESTART DEBT RETIRED (cancel path) — count now 2
  [A: PLANNER-DERIVED (must CANCEL)/reloader] onConfigAccepted -> acceptRestartConfig retireRejectedRestart=true debt=none
  restart signals emitted (SIGUSR1 path): 0
  onRestart calls after revert: 1
  deferred restart debt RETIRED (cancelled) count: 2

===== SCENARIO B: EXPLICIT WRITER RESTART (must PRESERVE) =====

--- B: EXPLICIT WRITER RESTART (must PRESERVE): write A -> B (explicit writer restart intent) ---
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] config candidate observed -> pauseGatewayRestartForConfigCandidate
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] config change detected; evaluating reload (gateway.port)
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] onConfigChange restartGateway=true reasons=[gateway.port, writer requires bounce]
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] onRestart #1 -> requestGatewayRestart restartGateway=true reasons=[gateway.port, writer requires bounce] port=18795
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/coordinator] config change requires gateway restart (gateway.port, writer requires bounce) — deferring until 1 active task complete
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] requestGatewayRestart status=accepted
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] restartTransaction settled committed (deferred restart armed)
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] onConfigAccepted -> acceptRestartConfig retireRejectedRestart=false debt=none
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] config candidate observed -> pauseGatewayRestartForConfigCandidate
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] onConfigAccepted -> acceptRestartConfig retireRejectedRestart=false debt=preserved
  coordinator.hasRestartRequestTransaction after arm: false
  onRestart calls so far: 1

--- B: EXPLICIT WRITER RESTART (must PRESERVE): ordinary exact revert B -> A (no restart intent) ---
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] config candidate observed -> pauseGatewayRestartForConfigCandidate
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] config change detected; evaluating reload (gateway.port)
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] onConfigChange restartGateway=true reasons=[gateway.port]
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] onRestart #2 -> requestGatewayRestart restartGateway=true reasons=[gateway.port] port=null
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/coordinator] config change requires gateway restart (gateway.port) — deferring until 1 active task complete
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] requestGatewayRestart status=accepted
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] restartTransaction settled committed (deferred restart armed)
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] onConfigAccepted -> acceptRestartConfig retireRejectedRestart=false debt=none
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] config candidate observed -> pauseGatewayRestartForConfigCandidate
  [B: EXPLICIT WRITER RESTART (must PRESERVE)/reloader] onConfigAccepted -> acceptRestartConfig retireRejectedRestart=false debt=preserved
  restart signals emitted (SIGUSR1 path): 0
  onRestart calls after revert: 2
  deferred restart debt RETIRED (cancelled) count: 0

===== SCENARIO C: EXPLICIT A->B, PLANNER B->C, ORDINARY C->A REVERT (explicit debt must SURVIVE the planner re-arm) =====

--- C: write A -> B (explicit writer restart intent) ---
  [C: EXPLICIT + PLANNER (must PRESERVE)/reloader] config candidate observed -> pauseGatewayRestartForConfigCandidate
  [C: EXPLICIT + PLANNER (must PRESERVE)/reloader] config change detected; evaluating reload (gateway.port)
  [C: EXPLICIT + PLANNER (must PRESERVE)/reloader] onConfigChange restartGateway=true reasons=[gateway.port, writer requires bounce]
  [C: EXPLICIT + PLANNER (must PRESERVE)/reloader] onRestart #1 -> requestGatewayRestart restartGateway=true reasons=[gateway.port, writer requires bounce] port=18795
  [C: EXPLICIT + PLANNER (must PRESERVE)/coordinator] config change requires gateway restart (gateway.port, writer requires bounce) — deferring until 1 active task complete
  [C: EXPLICIT + PLANNER (must PRESERVE)/reloader] requestGatewayRestart status=accepted
  [C: EXPLICIT + PLANNER (must PRESERVE)/reloader] restartTransaction settled committed (deferred restart armed)
  [C: EXPLICIT + PLANNER (must PRESERVE)/reloader] onConfigAccepted -> acceptRestartConfig retireRejectedRestart=false debt=none
  [C: EXPLICIT + PLANNER (must PRESERVE)/reloader] config candidate observed -> pauseGatewayRestartForConfigCandidate
  [C: EXPLICIT + PLANNER (must PRESERVE)/reloader] onConfigAccepted -> acceptRestartConfig retireRejectedRestart=false debt=preserved
  onRestart calls after explicit A->B: 1

--- C: write B -> C (planner-derived restart, no writer intent) ---
  [C: EXPLICIT + PLANNER (must PRESERVE)/reloader] config candidate observed -> pauseGatewayRestartForConfigCandidate
  [C: EXPLICIT + PLANNER (must PRESERVE)/reloader] config change detected; evaluating reload (gateway.port)
  [C: EXPLICIT + PLANNER (must PRESERVE)/reloader] onConfigChange restartGateway=true reasons=[gateway.port]
  [C: EXPLICIT + PLANNER (must PRESERVE)/reloader] onRestart #2 -> requestGatewayRestart restartGateway=true reasons=[gateway.port] port=18796
  [C: EXPLICIT + PLANNER (must PRESERVE)/coordinator] config change requires gateway restart (gateway.port) — deferring until 1 active task complete
  [C: EXPLICIT + PLANNER (must PRESERVE)/reloader] requestGatewayRestart status=accepted
  [C: EXPLICIT + PLANNER (must PRESERVE)/reloader] restartTransaction settled committed (deferred restart armed)
  [C: EXPLICIT + PLANNER (must PRESERVE)/reloader] onConfigAccepted -> acceptRestartConfig retireRejectedRestart=false debt=none
  [C: EXPLICIT + PLANNER (must PRESERVE)/reloader] config candidate observed -> pauseGatewayRestartForConfigCandidate
  [C: EXPLICIT + PLANNER (must PRESERVE)/reloader] onConfigAccepted -> acceptRestartConfig retireRejectedRestart=false debt=preserved
  onRestart calls after planner B->C: 2

--- C: ordinary exact revert C -> A (no restart intent) ---
  [C: EXPLICIT + PLANNER (must PRESERVE)/reloader] config candidate observed -> pauseGatewayRestartForConfigCandidate
  [C: EXPLICIT + PLANNER (must PRESERVE)/reloader] config change detected; evaluating reload (gateway.port)
  [C: EXPLICIT + PLANNER (must PRESERVE)/reloader] onConfigChange restartGateway=true reasons=[gateway.port]
  [C: EXPLICIT + PLANNER (must PRESERVE)/reloader] onRestart #3 -> requestGatewayRestart restartGateway=true reasons=[gateway.port] port=null
  [C: EXPLICIT + PLANNER (must PRESERVE)/coordinator] config change requires gateway restart (gateway.port) — deferring until 1 active task complete
  [C: EXPLICIT + PLANNER (must PRESERVE)/reloader] requestGatewayRestart status=accepted
  [C: EXPLICIT + PLANNER (must PRESERVE)/reloader] restartTransaction settled committed (deferred restart armed)
  [C: EXPLICIT + PLANNER (must PRESERVE)/reloader] onConfigAccepted -> acceptRestartConfig retireRejectedRestart=false debt=none
  [C: EXPLICIT + PLANNER (must PRESERVE)/reloader] config candidate observed -> pauseGatewayRestartForConfigCandidate
  [C: EXPLICIT + PLANNER (must PRESERVE)/reloader] onConfigAccepted -> acceptRestartConfig retireRejectedRestart=false debt=preserved
  restart signals emitted (SIGUSR1 path): 0
  onRestart calls after revert: 3
  deferred restart debt RETIRED (cancelled) count: 0

=== ASSERTIONS ===
  A. planner A->B + ordinary revert -> 0 signals, deferred restart debt RETIRED (cancelled), onRestart x1: PASS
  B. explicit A->B + ordinary revert -> 0 signals, deferred restart debt NEVER retired (re-armed via onRestart x2): PASS
  C. explicit A->B + planner B->C + ordinary C->A revert -> 0 signals, deferred restart debt NEVER retired (re-armed via onRestart x3): PASS

RESULT: PASS — managed coordinator cancels planner debt, preserves explicit debt (incl. across planner re-arms), no SIGUSR1 emitted
```
- **Deferred-restart cancel base survives intervening hot applies (commits `02885555a41` + `5d61fbbca88`, fixing the ClawSweeper hot/no-op intermediate finding)**: the reloader previously compared a settled candidate against `runtimeAppliedCompareConfig`, which a hot-only apply legitimately advances when its hot fields reach the runtime (`transactionOwnership.markRuntimeCommitted` in `server-reload-managed-secrets.ts`). With a restart still deferred, that made a later revert to the config the runtime was actually running when the debt was armed look like a fresh restart-required edit — re-arming an unnecessary Gateway restart (`onRestart` ×2, deferred debt never retired). The revert-cancel check now compares against `pendingRestartBaseCompareConfig` (`src/gateway/config-reload.ts`): the compare config the runtime was running when the pending deferred restart was armed, captured on the first arm (explicit or planner-derived), kept across later re-arms and intervening hot/no-op applies, and cleared when the revert-cancel path retires the debt. New regression test *"cancels a deferred restart when a hot-only apply lands between the deferral and the revert"* covers planner A→B → hot B→D (real `markRuntimeCommitted` baseline advance) → ordinary D→A revert: the deferred restart is retired via the revert-cancel path, `onRestart` stays ×1, no SIGUSR1. Real managed-coordinator run (real `startGatewayConfigReloader` + real chokidar + real file, production wiring incl. `settle("committed")` and the production hot-apply runtime commit) — Scenario D below: 0 SIGUSR1 signals, deferred debt RETIRED, `onRestart` ×1 (on the prior head this scenario re-armed the restart: `onRestart` ×2, debt never retired).
```
===== SCENARIO D: PLANNER A->B, INTERVENING HOT APPLY B->D, ORDINARY D->A REVERT (planner debt must still CANCEL) =====

--- D: write A -> B (planner-derived restart intent) ---
  [D: PLANNER + HOT APPLY (must CANCEL)/reloader] config candidate observed -> pauseGatewayRestartForConfigCandidate
  [D: PLANNER + HOT APPLY (must CANCEL)/reloader] config change detected; evaluating reload (gateway.port, agents)
  [D: PLANNER + HOT APPLY (must CANCEL)/reloader] onConfigChange restartGateway=true reasons=[gateway.port]
  [D: PLANNER + HOT APPLY (must CANCEL)/reloader] onRestart #1 -> requestGatewayRestart restartGateway=true reasons=[gateway.port] port=18795
  [D: PLANNER + HOT APPLY (must CANCEL)/coordinator] config change requires gateway restart (gateway.port) — deferring until 1 active task complete
  [D: PLANNER + HOT APPLY (must CANCEL)/reloader] requestGatewayRestart status=accepted
  [D: PLANNER + HOT APPLY (must CANCEL)/reloader] restartTransaction settled committed (deferred restart armed)
  [D: PLANNER + HOT APPLY (must CANCEL)/reloader] onConfigAccepted -> acceptRestartConfig retireRejectedRestart=false debt=none
  [D: PLANNER + HOT APPLY (must CANCEL)/reloader] config candidate observed -> pauseGatewayRestartForConfigCandidate
  [D: PLANNER + HOT APPLY (must CANCEL)/reloader] onConfigAccepted -> acceptRestartConfig retireRejectedRestart=false debt=preserved
  onRestart calls after planner A->B: 1

--- D: write B -> D (hot-only apply: agents.defaults; runtime commits, restart stays deferred) ---
  [D: PLANNER + HOT APPLY (must CANCEL)/reloader] config candidate observed -> pauseGatewayRestartForConfigCandidate
  [D: PLANNER + HOT APPLY (must CANCEL)/reloader] config change detected; evaluating reload (agents.defaults.params.temperature)
  [D: PLANNER + HOT APPLY (must CANCEL)/reloader] onConfigChange restartGateway=false reasons=[]
  [D: PLANNER + HOT APPLY (must CANCEL)/reloader] hot reload applied -> markRuntimeCommitted (runtime-applied baseline advances to hot candidate, restart still deferred)
  [D: PLANNER + HOT APPLY (must CANCEL)/reloader] onConfigAccepted -> acceptRestartConfig retireRejectedRestart=false debt=preserved
  [D: PLANNER + HOT APPLY (must CANCEL)/reloader] config candidate observed -> pauseGatewayRestartForConfigCandidate
  [D: PLANNER + HOT APPLY (must CANCEL)/reloader] onConfigAccepted -> acceptRestartConfig retireRejectedRestart=false debt=preserved
  onRestart calls after hot B->D: 1

--- D: ordinary exact revert D -> A (no restart intent) ---
  [D: PLANNER + HOT APPLY (must CANCEL)/reloader] config candidate observed -> pauseGatewayRestartForConfigCandidate
  [D: PLANNER + HOT APPLY (must CANCEL)/reloader] config change detected; evaluating reload (gateway.port, agents)
  [D: PLANNER + HOT APPLY (must CANCEL)/reloader] config change detected; reverted to running config, cancelling pending restart (gateway.port, agents)
  [D: PLANNER + HOT APPLY (must CANCEL)/reloader] onConfigChange restartGateway=false reasons=[]
  [D: PLANNER + HOT APPLY (must CANCEL)/reloader] onNoopConfigCommit restartGateway=false (no bounce)
  [D: PLANNER + HOT APPLY (must CANCEL)/coordinator] *** DEFERRED RESTART DEBT RETIRED (cancel path) — count now 1
  [D: PLANNER + HOT APPLY (must CANCEL)/reloader] onConfigAccepted -> acceptRestartConfig retireRejectedRestart=true debt=none
  [D: PLANNER + HOT APPLY (must CANCEL)/reloader] config candidate observed -> pauseGatewayRestartForConfigCandidate
  [D: PLANNER + HOT APPLY (must CANCEL)/coordinator] *** DEFERRED RESTART DEBT RETIRED (cancel path) — count now 2
  [D: PLANNER + HOT APPLY (must CANCEL)/reloader] onConfigAccepted -> acceptRestartConfig retireRejectedRestart=true debt=none
  restart signals emitted (SIGUSR1 path): 0
  onRestart calls after revert: 1
  deferred restart debt RETIRED (cancelled) count: 2
  D. planner A->B + hot B->D + ordinary D->A revert -> 0 signals, deferred restart debt RETIRED (cancelled), onRestart x1 (no unnecessary re-arm): PASS
```
- Verification: `npx vitest run src/gateway/config-reload.test.ts` — **528/528 relevant passed** on new head `be7d034d95a` (531 total; the 3 failures are the pre-existing real-filesystem `reloads when an included config file changes` watcher tests that also fail on unmodified main in this sandbox — verified via `git stash` on the prior head). The new regression test passes on the fixed head and fails on the prior head (`onRestart` ×2 instead of ×3). Related lifecycle suites `server-restart-deferral`, `restart-trace`, `server-reload-handlers` — **223/223 passed**. `oxlint` 0 warnings/errors on both changed files.
- Terminal output from the fresh run:
```
 ✓  gateway-core  ../../src/gateway/config-reload.test.ts (175 tests) 1691ms
 ✓  gateway-server  ../../src/gateway/config-reload.test.ts (175 tests) 1399ms
 ✓  gateway-client  ../../src/gateway/config-reload.test.ts (175 tests) 1431ms

 Test Files  3 passed (3)
      Tests  525 passed (525)
```

## P1 fix (head `da69a22e818`): coordinator-confirmed retirement clears reloader provenance

ClawSweeper P1: a `mode: "none"` or reload-off write reaches managed acceptance, where the coordinator retires the old deferred request, but the reloader's `pendingRestartWasExplicit` / `pendingRestartBaseCompareConfig` remained set. A later ordinary revert to the running config then failed `!pendingRestartWasExplicit` and re-armed an unnecessary Gateway restart.

Fix:
- `src/gateway/config-reload.ts`: `onConfigAccepted` now accepts an optional `{ rollback?, retireRestartDebt? }` result. When the managed coordinator confirms debt retirement (`retireRestartDebt: true`), the reloader drops `pendingRestartWasExplicit` and `pendingRestartBaseCompareConfig`, so the next ordinary revert to the running config takes the revert-cancel path (`reverted to running config, cancelling pending restart`) instead of re-arming.
- `src/gateway/server-reload-managed.ts`: both acceptance branches (source-only `!runtimeApplied` and runtime-applied) report `retireRestartDebt: acceptedRestart.retireRejectedRestart` (runtime-applied gated on `!lateConservativeDebt`), matching the same signal already sent to `acceptTerminalConfig`.
- New regression test `drops pending-restart provenance when the coordinator retires the deferred debt on a source-only write`: explicit A→B restart (onRestart ×1) → source-only mode-none write reports retirement → ordinary B→A revert cancels (onRestart stays ×1, "reverted to running config" logged). Passes on this head.
- Verification: `config-reload.test.ts` 178/179 pass on this sandbox (the 1 failure is the pre-existing real-filesystem include-files watcher test, also failing on unmodified main here); `server-reload-handlers.test.ts` 210/210 pass; `tsc --noEmit -p tsconfig.core.json` clean; oxlint 0 errors on changed files.

[AI-assisted]


## ClawSweeper P1 repair (head `98e79ca26c5`)

P1 "Apply residual hot actions after cancelling a restart" fixed: the revert-cancel branch now routes a non-noop residual plan through the normal hot path (`onHotReload`) instead of dropping it via `onNoopConfigCommit`. After deferred `gateway.port` A→B, hot `hooks.gmail` B→D, and revert D→A, the residual gmail/hooks/cron/channel actions now reach the runtime at the accepted config A.

Effectful regression added (`applies residual hot actions when a revert cancels a deferred restart`): asserts `onHotReload` receives the residual plan with `restartGateway=false` / `restartGmailWatcher=true` / `reloadHooks=true` and the reverted config.

```text
node scripts/run-vitest.mjs src/gateway/config-reload.test.ts -t "applies residual hot actions"
 gateway-server  src/gateway/config-reload.test.ts (180 tests | 179 skipped)
   applies residual hot actions when a revert cancels a deferred restart
 gateway-client  src/gateway/config-reload.test.ts (180 tests | 179 skipped)
   applies residual hot actions when a revert cancels a deferred restart
 Test Files  3 passed (3)
      Tests  3 passed | 537 skipped (540)
```

Full-file `config-reload.test.ts`: 179/180 (the 1 failure is the pre-existing sandbox watcher test `reloads when an included config file changes`, reproduced identically on clean main). `server-reload-handlers.test.ts`: 210/210 passed.

## Cruise fix (head `77ac0d1597d`)

Addresses ClawSweeper finding [P2] *Commit restart provenance after admission succeeds* (`src/gateway/config-reload.ts:836-837`): `pendingRestartWasExplicit`/`pendingRestartBaseCompareConfig` are now committed only after `prepareRestart` admission succeeds, in both the explicit-restart and planner-derived branches. A rejected explicit restart no longer leaves stale explicit provenance that would block a later revert from cancelling planner-derived deferral debt. New regression: `keeps planner deferral cancellable after a rejected explicit restart admission` (fails on pre-fix code, passes with the fix).

```text
node scripts/run-vitest.mjs src/gateway/config-reload.test.ts src/gateway/server-reload-handlers.test.ts
 Test Files  3 passed (3)
      Tests  390 passed (391)   # 1 failure = pre-existing sandbox watcher flake, fails identically on clean main
```
