### PR TITLE
fix(clawrouter): show stable error for malformed usage responses

### DIFF
--- a/extensions/clawrouter/usage.test.ts
+++ b/extensions/clawrouter/usage.test.ts
@@ -222,20 +222,61 @@ describe("ClawRouter usage", () => {
     expect(snapshot.summary).toBeUndefined();
   });
 
-  it("rejects usage JSON containing invalid UTF-8", async () => {
+  it.each([
+    ["malformed JSON", new TextEncoder().encode('{"budget":')],
+    ["a non-object JSON root", new TextEncoder().encode("null")],
+  ])("reports %s as a malformed usage response", async (_label, body) => {
+    const snapshot = await fetchClawRouterUsage({
+      token: "test-token",
+      timeoutMs: 5000,
+      fetchGuard: mockFetchGuard(new Response(body)),
+    });
+
+    expect(snapshot).toEqual({
+      provider: "clawrouter",
+      displayName: "ClawRouter",
+      windows: [],
+      error: "Malformed usage response",
+    });
+  });
+
+  it("reports invalid UTF-8 as a malformed usage response", async () => {
     const prefix = new TextEncoder().encode(
       '{"budget":{"configured":true,"windowKey":"default/test-policy/2026-',
     );
     const suffix = new TextEncoder().encode('","limitMicros":1000000,"spentMicros":500000}}');
     const body = new Uint8Array([...prefix, 0xff, ...suffix]);
 
+    const snapshot = await fetchClawRouterUsage({
+      token: "test-token",
+      timeoutMs: 5000,
+      fetchGuard: mockFetchGuard(new Response(body)),
+    });
+
+    expect(snapshot).toEqual({
+      provider: "clawrouter",
+      displayName: "ClawRouter",
+      windows: [],
+      error: "Malformed usage response",
+    });
+  });
+
+  it("preserves response stream failures as transport errors", async () => {
+    const response = new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.error(new TypeError("usage stream failed"));
+        },
+      }),
+    );
+
     await expect(
       fetchClawRouterUsage({
         token: "test-token",
         timeoutMs: 5000,
-        fetchGuard: mockFetchGuard(new Response(body)),
+        fetchGuard: mockFetchGuard(response),
       }),
-    ).rejects.toThrow(TypeError);
+    ).rejects.toThrow("usage stream failed");
   });
 
   it("cancels non-OK usage response body before throwing", async () => {

--- a/extensions/clawrouter/usage.ts
+++ b/extensions/clawrouter/usage.ts
@@ -72,16 +72,21 @@ function buildSummary(payload: ClawRouterUsagePayload): string | undefined {
 async function readClawRouterUsagePayload(
   response: Response,
   timeoutMs: number,
-): Promise<ClawRouterUsagePayload> {
+): Promise<ClawRouterUsagePayload | undefined> {
   const buffer = await readResponseWithLimit(response, CLAWROUTER_USAGE_RESPONSE_MAX_BYTES, {
     chunkTimeoutMs: timeoutMs,
     onOverflow: ({ maxBytes }) => new Error(`ClawRouter usage response exceeds ${maxBytes} bytes`),
     onIdleTimeout: ({ chunkTimeoutMs }) =>
       new Error(`ClawRouter usage response stalled: no data received for ${chunkTimeoutMs}ms`),
   });
-  return JSON.parse(
-    new TextDecoder("utf-8", { fatal: true }).decode(buffer),
-  ) as ClawRouterUsagePayload;
+  try {
+    const payload: unknown = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(buffer));
+    return payload !== null && typeof payload === "object" && !Array.isArray(payload)
+      ? (payload as ClawRouterUsagePayload)
+      : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 export async function fetchClawRouterUsage(params: {
@@ -116,6 +121,14 @@ export async function fetchClawRouterUsage(params: {
       throw new Error(`ClawRouter usage request failed (HTTP ${response.status})`);
     }
     const payload = await readClawRouterUsagePayload(response, params.timeoutMs);
+    if (!payload) {
+      return {
+        provider: "clawrouter",
+        displayName: "ClawRouter",
+        windows: [],
+        error: "Malformed usage response",
+      };
+    }
     const budget = payload.budget;
     const limitMicros = asFiniteNumberInRange(budget?.limitMicros, { min: 0 });
     const spentMicros = asFiniteNumberInRange(budget?.spentMicros, { min: 0 });

--- a/extensions/clawrouter/usage.ts
+++ b/extensions/clawrouter/usage.ts
@@ -5,7 +5,7 @@ import {
   fetchWithSsrFGuard,
   ssrfPolicyFromHttpBaseUrlAllowedHostname,
 } from "openclaw/plugin-sdk/ssrf-runtime";
-import { asFiniteNumberInRange } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { asFiniteNumberInRange, asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { normalizeClawRouterRootUrl } from "./provider-catalog.js";
 
 const CLAWROUTER_USAGE_RESPONSE_MAX_BYTES = 1024 * 1024;
@@ -81,9 +81,7 @@ async function readClawRouterUsagePayload(
   });
   try {
     const payload: unknown = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(buffer));
-    return payload !== null && typeof payload === "object" && !Array.isArray(payload)
-      ? (payload as ClawRouterUsagePayload)
-      : undefined;
+    return asOptionalRecord(payload) as ClawRouterUsagePayload | undefined;
   } catch {
     return undefined;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing ClawRouter quota information would get a thrown parsing error when the usage endpoint returned malformed JSON or invalid UTF-8.

## Why This Change Was Made

ClawRouter now follows the established Venice and OpenRouter usage pattern by reporting malformed payloads as a stable provider error snapshot. Response-size, stream, HTTP, and transport failures remain distinct errors.

## User Impact

Users see “Malformed usage response” instead of a failed quota refresh when ClawRouter returns an invalid payload.

## Evidence

- `node scripts/run-vitest.mjs extensions/clawrouter/usage.test.ts`: focused tests pass, including malformed JSON, invalid UTF-8, non-object JSON, stream failure, size cap, HTTP error, and production transport cases.
- `node --import tsx proof-live.ts`: the same real production provider path ran against a loopback HTTP boundary on the validation base and exact head.
- Result: malformed payloads changed from thrown parser errors to a stable snapshot; valid and HTTP-error controls stayed unchanged.

```text
baseline c02e39345bf6946acd0635ac18732f4003dd45b5
malformed-json threw=SyntaxError
invalid-utf8 threw=TypeError
valid-control snapshot={"provider":"clawrouter","displayName":"ClawRouter","windows":[],"plan":"Unmetered proxy key"}
http-error-control threw=Error:ClawRouter usage request failed (HTTP 503)

fixed head 35a2bf736ee56bf2ff001ec7db0c96939b1e7c72
malformed-json snapshot={"provider":"clawrouter","displayName":"ClawRouter","windows":[],"error":"Malformed usage response"}
invalid-utf8 snapshot={"provider":"clawrouter","displayName":"ClawRouter","windows":[],"error":"Malformed usage response"}
valid-control snapshot={"provider":"clawrouter","displayName":"ClawRouter","windows":[],"plan":"Unmetered proxy key"}
http-error-control threw=Error:ClawRouter usage request failed (HTTP 503)
```

<details>
<summary>proof-live.ts</summary>

```ts
import { execFileSync } from "node:child_process";
import { createServer } from "node:http";
import { resolve } from "node:path";
import { pathToFileURL } from "node:url";

async function main(): Promise<void> {
  const usageModuleUrl = pathToFileURL(resolve("extensions/clawrouter/usage.ts")).href;
  const { fetchClawRouterUsage } = await import(usageModuleUrl);

  async function run(body: string | Uint8Array, status = 200): Promise<string> {
    const server = createServer((_req, res) => {
      res.writeHead(status, { "content-type": "application/json" });
      res.end(body);
    });
    await new Promise<void>((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
    const address = server.address();
    if (!address || typeof address === "string") {
      throw new Error("loopback server did not expose a TCP address");
    }
    try {
      const snapshot = await fetchClawRouterUsage({
        token: "redacted-test-token",
        baseUrl: `http://127.0.0.1:${address.port}`,
        timeoutMs: 5_000,
      });
      return `snapshot=${JSON.stringify(snapshot)}`;
    } catch (error) {
      return `threw=${error instanceof Error ? `${error.name}:${error.message}` : String(error)}`;
    } finally {
      await new Promise<void>((resolveClose, reject) =>
        server.close((error) => (error ? reject(error) : resolveClose())),
      );
    }
  }

  const invalidUtf8 = new Uint8Array([
    ...new TextEncoder().encode('{"budget":{"configured":'),
    0xff,
    ...new TextEncoder().encode("}}"),
  ]);

  console.log(`sha=${execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim()}`);
  console.log(`malformed-json ${await run('{"budget":{"configured":true}')}`);
  console.log(`invalid-utf8 ${await run(invalidUtf8)}`);
  console.log(`valid-control ${await run('{"budget":{"configured":false}}')}`);
  console.log(`http-error-control ${await run("unavailable", 503)}`);
}

void main();
```

</details>

AI-assisted: built with Codex

Maintainer exact-head validation (`a02622f369867d32180fe267b19c19e731eeb91b`):
- canonical `asOptionalRecord` repair applied without widening the response-read catch
- focused ClawRouter usage tests: 13 passed
- loopback malformed JSON, invalid UTF-8, valid JSON, HTTP 503, and broken-stream controls passed
- P1 autoreview: clean, no actionable findings

Punchcard-Session: clear-orchard-lantern-bc
