### PR TITLE
fix(cli): keep read commands off the writable shared state DB

### DIFF
--- a/src/cli/plugins-cli.runtime.ts
+++ b/src/cli/plugins-cli.runtime.ts
@@ -9,6 +9,7 @@ import {
 import {
   assertConfigWriteAllowedInCurrentMode,
   getRuntimeConfig,
+  getRuntimeConfigForInspection,
   readConfigFileSnapshot,
   replaceConfigFile,
 } from "../config/config.js";
@@ -331,7 +332,9 @@ export async function runPluginsRegistryCommand(opts: PluginRegistryOptions): Pr
     });
   }
 
-  const inspection = await inspectPluginRegistry({ config: getRuntimeConfig() });
+  const inspection = await inspectPluginRegistry({
+    config: getRuntimeConfigForInspection({ skipPluginValidation: true }),
+  });
   if (opts.json) {
     defaultRuntime.writeJson({
       state: inspection.state,

--- a/src/cli/plugins-inspect-command.ts
+++ b/src/cli/plugins-inspect-command.ts
@@ -1,7 +1,7 @@
 // `openclaw plugins inspect`: renders plugin registry shape, capabilities, policy, diagnostics, and install records.
 import { getTerminalTableWidth, renderTable } from "../../packages/terminal-core/src/table.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
-import { getRuntimeConfig } from "../config/config.js";
+import { getRuntimeConfig, getRuntimeConfigForInspection } from "../config/config.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import {
   tracePluginLifecyclePhase,
@@ -119,16 +119,21 @@ export async function runPluginsInspectCommand(
   } = await import("../plugins/status.js");
   const { loadInstalledPluginIndexInstallRecords } =
     await import("../plugins/installed-plugin-index-records.js");
-  const cfg = tracePluginLifecyclePhase("config read", () => getRuntimeConfig(), {
-    command: "inspect",
-  });
+  const runtimeInspect = opts.runtime === true;
+  const cfg = tracePluginLifecyclePhase(
+    "config read",
+    () =>
+      runtimeInspect
+        ? getRuntimeConfig()
+        : getRuntimeConfigForInspection({ skipPluginValidation: true }),
+    { command: "inspect" },
+  );
   const installRecords = await tracePluginLifecyclePhaseAsync(
     "install records load",
     () => loadInstalledPluginIndexInstallRecords(),
     { command: "inspect" },
   );
   const loggerParams = opts.json ? { logger: quietPluginJsonLogger } : {};
-  const runtimeInspect = opts.runtime === true;
   if (opts.all) {
     if (id) {
       defaultRuntime.error("Pass either a plugin id or --all, not both.");

--- a/src/cli/plugins-list-command.test.ts
+++ b/src/cli/plugins-list-command.test.ts
@@ -33,6 +33,7 @@ function mockPluginListSnapshot(
 ): void {
   vi.doMock("../config/config.js", () => ({
     getRuntimeConfig: () => config,
+    getRuntimeConfigForInspection: () => config,
   }));
   vi.doMock("../plugins/status-snapshot.js", () => ({
     buildPluginRegistrySnapshotReport: () => ({
@@ -105,6 +106,7 @@ describe("runPluginsListCommand", () => {
 
     vi.doMock("../config/config.js", () => ({
       getRuntimeConfig: () => ({}),
+      getRuntimeConfigForInspection: () => ({}),
     }));
     vi.doMock("../plugins/status.js", () => {
       throw new Error("plugins list JSON must use the snapshot status module");

--- a/src/cli/plugins-list-command.ts
+++ b/src/cli/plugins-list-command.ts
@@ -1,5 +1,5 @@
 // `openclaw plugins list`: builds registry reports and defers terminal-only formatting modules.
-import { getRuntimeConfig } from "../config/config.js";
+import { getRuntimeConfigForInspection } from "../config/config.js";
 import type { PluginRecord } from "../plugins/registry.js";
 import { defaultRuntime, writeRuntimeJson, type RuntimeEnv } from "../runtime.js";
 import { quietPluginJsonLogger } from "./plugins-json-logger.js";
@@ -45,7 +45,7 @@ export async function runPluginsListCommand(
 ): Promise<void> {
   const { buildPluginRegistrySnapshotReport } = await import("../plugins/status-snapshot.js");
   // The inventory projector owns plugin metadata validation from the installed index.
-  const cfg = getRuntimeConfig({ skipPluginValidation: true });
+  const cfg = getRuntimeConfigForInspection({ skipPluginValidation: true });
   const report = buildPluginRegistrySnapshotReport({
     config: cfg,
     ...(opts.json ? { logger: quietPluginJsonLogger } : {}),

--- a/src/commands/channels.status.command-flow.test.ts
+++ b/src/commands/channels.status.command-flow.test.ts
@@ -36,11 +36,12 @@ vi.mock("../cli/command-config-resolution.js", () => ({
 }));
 
 vi.mock("../config/config.js", () => ({
-  readConfigFileSnapshot: () => mocks.readConfigFileSnapshot(),
+  readConfigFileSnapshot: (options: unknown) => mocks.readConfigFileSnapshot(options),
 }));
 
 vi.mock("./config-validation.js", () => ({
-  requireValidConfig: (runtime: unknown) => mocks.requireValidConfig(runtime),
+  requireValidConfig: (runtime: unknown, options: unknown) =>
+    mocks.requireValidConfig(runtime, options),
 }));
 
 vi.mock("../plugins/channel-plugin-ids.js", () => ({
@@ -285,6 +286,8 @@ describe("channelsStatusCommand SecretRef fallback flow", () => {
 
     expect(errors.join("\n")).toContain("Gateway not reachable");
     expect(mocks.resolveCommandConfigWithSecrets).toHaveBeenCalledOnce();
+    expect(mocks.requireValidConfig).toHaveBeenCalledWith(runtime, { observe: false });
+    expect(mocks.readConfigFileSnapshot).toHaveBeenCalledWith({ observe: false });
     const configResolutionRequest = mocks.resolveCommandConfigWithSecrets.mock.calls[0]?.[0];
     expect(configResolutionRequest?.commandName).toBe("channels status");
     expect(configResolutionRequest?.mode).toBe("read_only_status");

--- a/src/commands/flows.test.ts
+++ b/src/commands/flows.test.ts
@@ -1,8 +1,14 @@
 // Flows command tests cover task creation, task execution, and runtime command output.
+import { DatabaseSync } from "node:sqlite";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { visibleWidth } from "../../packages/terminal-core/src/ansi.js";
 import { runCommandWithRuntime } from "../cli/cli-utils.js";
 import type { RuntimeEnv } from "../runtime.js";
+import {
+  OPENCLAW_STATE_SCHEMA_VERSION,
+  closeOpenClawStateDatabaseForTest,
+} from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { createRunningTaskRunCore as createRunningTaskRunOrNull } from "../tasks/task-executor.js";
 import { createManagedTaskFlow as createManagedTaskFlowOrNull } from "../tasks/task-flow-registry.js";
 import type { TaskFlowRecord } from "../tasks/task-flow-registry.types.js";
@@ -62,6 +68,28 @@ function createRuntime(): TestRuntime {
     writeStdout: vi.fn(),
     writeJson: vi.fn(),
   };
+}
+
+function setStateSchemaVersion(databasePath: string, version: number): void {
+  const database = new DatabaseSync(databasePath);
+  try {
+    database.exec(`
+      PRAGMA user_version = ${version};
+      UPDATE schema_meta SET schema_version = ${version} WHERE meta_key = 'primary';
+    `);
+  } finally {
+    database.close();
+  }
+}
+
+function readStateSchemaVersion(databasePath: string): number {
+  const database = new DatabaseSync(databasePath, { readOnly: true });
+  try {
+    const row = database.prepare("PRAGMA user_version").get() as { user_version: number };
+    return row.user_version;
+  } finally {
+    database.close();
+  }
 }
 
 async function withTaskFlowCommandStateDir(run: (root: string) => Promise<void>): Promise<void> {
@@ -709,6 +737,41 @@ describe("flows commands", () => {
           }),
         ],
       });
+    });
+  });
+
+  it("keeps old-schema flow inspection read-only, then migrates through cancellation", async () => {
+    await withTaskFlowCommandStateDir(async () => {
+      const flow = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/flows-old-schema",
+        goal: "Exercise old-schema flow command routing",
+        status: "running",
+      });
+      resetTaskRegistryForTests({ persist: false });
+      resetTaskFlowRegistryForTests({ persist: false });
+      closeOpenClawStateDatabaseForTest();
+      const databasePath = resolveOpenClawStateSqlitePath();
+      const oldVersion = OPENCLAW_STATE_SCHEMA_VERSION - 1;
+      setStateSchemaVersion(databasePath, oldVersion);
+      const runtime = createRuntime();
+
+      await expect(flowsListCommand({ json: true }, runtime)).rejects.toThrow(
+        new RegExp(
+          `older schema version ${oldVersion}.*will not migrate it.*openclaw doctor --fix`,
+          "u",
+        ),
+      );
+      expect(readStateSchemaVersion(databasePath)).toBe(oldVersion);
+
+      await flowsCancelCommand({ lookup: flow.flowId }, runtime);
+
+      expect(runtime.error).not.toHaveBeenCalled();
+      expect(runtime.exit).not.toHaveBeenCalled();
+      expect(runtime.log).toHaveBeenCalledWith(
+        `Cancelled ${flow.flowId} (managed) with status cancelled.`,
+      );
+      expect(readStateSchemaVersion(databasePath)).toBe(OPENCLAW_STATE_SCHEMA_VERSION);
     });
   });
 });

--- a/src/commands/flows.ts
+++ b/src/commands/flows.ts
@@ -11,7 +11,11 @@ import { getRuntimeConfig } from "../config/config.js";
 import { info } from "../globals.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { writeRuntimeJson } from "../runtime.js";
-import { listTasksForFlowId } from "../tasks/runtime-internal.js";
+import {
+  ensureTaskRuntimeStateReady,
+  ensureTaskRuntimeStateReadyForInspection,
+  listTasksForFlowId,
+} from "../tasks/runtime-internal.js";
 import { cancelFlowById, getFlowTaskSummary } from "../tasks/task-executor.js";
 import {
   TASK_FLOW_STATUSES,
@@ -166,6 +170,7 @@ export async function flowsListCommand(
   opts: { json?: boolean; status?: string },
   runtime: RuntimeEnv,
 ) {
+  ensureTaskRuntimeStateReadyForInspection();
   const statusFilter = parseCliEnumFilter(opts.status, "--status", TASK_FLOW_STATUSES);
   const flows = listTaskFlowRecords().filter((flow) => {
     if (statusFilter && flow.status !== statusFilter) {
@@ -209,6 +214,7 @@ export async function flowsShowCommand(
   opts: { json?: boolean; lookup: string },
   runtime: RuntimeEnv,
 ) {
+  ensureTaskRuntimeStateReadyForInspection();
   const flow = resolveTaskFlowForLookupToken(opts.lookup);
   if (!flow) {
     runtime.error(formatFlowLookupMiss(opts.lookup));
@@ -267,6 +273,7 @@ export async function flowsShowCommand(
 
 /** Requests cancellation for one TaskFlow selected by id or lookup token. */
 export async function flowsCancelCommand(opts: { lookup: string }, runtime: RuntimeEnv) {
+  ensureTaskRuntimeStateReady();
   const flow = resolveTaskFlowForLookupToken(opts.lookup);
   if (!flow) {
     runtime.error(formatFlowLookupMiss(opts.lookup));

--- a/src/commands/tasks.readonly-state.test.ts
+++ b/src/commands/tasks.readonly-state.test.ts
@@ -1,0 +1,127 @@
+// Task read-command regressions cover fresh shared-state behavior.
+import fs from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it, vi } from "vitest";
+import {
+  OPENCLAW_STATE_SCHEMA_VERSION,
+  closeOpenClawStateDatabaseForTest,
+} from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import { createTaskRecord } from "../tasks/task-registry.js";
+import {
+  resetTaskFlowRegistryForTests,
+  resetTaskRegistryForTests,
+} from "../tasks/task-runtime.test-helpers.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import {
+  tasksAuditCommand,
+  tasksListCommand,
+  tasksMaintenanceCommand,
+  tasksNotifyCommand,
+} from "./tasks.js";
+
+function setStateSchemaVersion(databasePath: string, version: number): void {
+  const database = new DatabaseSync(databasePath);
+  try {
+    database.exec(`
+      PRAGMA user_version = ${version};
+      UPDATE schema_meta SET schema_version = ${version} WHERE meta_key = 'primary';
+    `);
+  } finally {
+    database.close();
+  }
+}
+
+function readStateSchemaVersion(databasePath: string): number {
+  const database = new DatabaseSync(databasePath, { readOnly: true });
+  try {
+    const row = database.prepare("PRAGMA user_version").get() as { user_version: number };
+    return row.user_version;
+  } finally {
+    database.close();
+  }
+}
+
+function createRuntime() {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+    writeJson: vi.fn(),
+    writeStdout: vi.fn(),
+  };
+}
+
+describe("task inspection shared-state access", () => {
+  it("lists, audits, and previews maintenance without creating the shared database", async () => {
+    await withOpenClawTestState(
+      { label: "tasks-readonly-state", layout: "state-only", scenario: "minimal" },
+      async (state) => {
+        resetTaskRegistryForTests({ persist: false });
+        resetTaskFlowRegistryForTests({ persist: false });
+        const databasePath = resolveOpenClawStateSqlitePath(state.env);
+        const runtime = createRuntime();
+
+        expect(fs.existsSync(databasePath)).toBe(false);
+        await tasksListCommand({ json: true }, runtime);
+        expect(fs.existsSync(databasePath)).toBe(false);
+        await tasksAuditCommand({ json: true }, runtime);
+        expect(fs.existsSync(databasePath)).toBe(false);
+        await tasksMaintenanceCommand({ json: true, apply: false }, runtime);
+
+        expect(fs.existsSync(databasePath)).toBe(false);
+        expect(runtime.writeJson).toHaveBeenCalledTimes(3);
+      },
+    );
+  });
+
+  it("refuses an old schema during inspection, then lets a mutation migrate", async () => {
+    await withOpenClawTestState(
+      { label: "tasks-old-schema", layout: "state-only", scenario: "minimal" },
+      async (state) => {
+        resetTaskRegistryForTests({ persist: false });
+        resetTaskFlowRegistryForTests({ persist: false });
+        const task = createTaskRecord({
+          runtime: "cli",
+          ownerKey: "agent:main:main",
+          scopeKind: "session",
+          status: "running",
+          deliveryStatus: "not_applicable",
+          notifyPolicy: "silent",
+          task: "Exercise old-schema command routing",
+        });
+        expect(task).toBeTruthy();
+        if (!task) {
+          return;
+        }
+
+        resetTaskRegistryForTests({ persist: false });
+        resetTaskFlowRegistryForTests({ persist: false });
+        closeOpenClawStateDatabaseForTest();
+        const databasePath = resolveOpenClawStateSqlitePath(state.env);
+        const oldVersion = OPENCLAW_STATE_SCHEMA_VERSION - 1;
+        setStateSchemaVersion(databasePath, oldVersion);
+        const runtime = createRuntime();
+
+        await expect(tasksListCommand({ json: true }, runtime)).rejects.toThrow(
+          new RegExp(
+            `older schema version ${oldVersion}.*will not migrate it.*openclaw doctor --fix`,
+            "u",
+          ),
+        );
+        expect(readStateSchemaVersion(databasePath)).toBe(oldVersion);
+
+        await expect(
+          tasksMaintenanceCommand({ json: true, apply: false }, runtime),
+        ).rejects.toThrow(/older schema version/u);
+        expect(readStateSchemaVersion(databasePath)).toBe(oldVersion);
+
+        await tasksNotifyCommand({ lookup: task.taskId, notify: "state_changes" }, runtime);
+
+        expect(runtime.error).not.toHaveBeenCalled();
+        expect(runtime.exit).not.toHaveBeenCalled();
+        expect(readStateSchemaVersion(databasePath)).toBe(OPENCLAW_STATE_SCHEMA_VERSION);
+      },
+    );
+  });
+});

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -9,15 +9,20 @@ import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { parseCliEnumFilter } from "../cli/enum-filter.js";
 import { formatLookupMiss } from "../cli/error-format.js";
-import { getRuntimeConfig } from "../config/config.js";
+import { getRuntimeConfig, getRuntimeConfigForInspection } from "../config/config.js";
 import {
   resolveAllAgentSessionStoreTargetsSync,
   runSessionRegistryMaintenanceForStore,
 } from "../config/sessions.js";
 import { normalizeCronLaneSegment } from "../cron/service/task-runs.js";
-import { loadCronJobsStoreSync, resolveCronJobsStorePath } from "../cron/store.js";
+import * as cronStore from "../cron/store.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
-import { getTaskById, updateTaskNotifyPolicyById } from "../tasks/runtime-internal.js";
+import {
+  ensureTaskRuntimeStateReady,
+  ensureTaskRuntimeStateReadyForInspection,
+  getTaskById,
+  updateTaskNotifyPolicyById,
+} from "../tasks/runtime-internal.js";
 import { cancelDetachedTaskRunById } from "../tasks/task-executor.js";
 import { listTaskFlowAuditFindings } from "../tasks/task-flow-registry.audit.js";
 import {
@@ -154,12 +159,15 @@ function resolveExplicitCronSessionSegment(sessionKey: string | undefined): stri
   return match?.[1]?.toLowerCase();
 }
 
-function readRunningCronJobIds(): { ids: Set<string>; count: number } {
+async function readRunningCronJobIds(params: {
+  readOnly: boolean;
+}): Promise<{ ids: Set<string>; count: number }> {
   try {
-    const cronStorePath = resolveCronJobsStorePath();
-    const runningJobs = loadCronJobsStoreSync(cronStorePath).jobs.filter(
-      (job) => typeof job.state?.runningAtMs === "number",
-    );
+    const cronStorePath = cronStore.resolveCronJobsStorePath();
+    const store = params.readOnly
+      ? (await cronStore.loadCronJobsStoreWithConfigJobsReadOnly(cronStorePath)).store
+      : cronStore.loadCronJobsStoreSync(cronStorePath);
+    const runningJobs = store.jobs.filter((job) => typeof job.state?.runningAtMs === "number");
     return {
       // A running job may have been retargeted after its session was created. Keep both historical
       // shapes; the registry has no producer metadata, so retaining an ambiguous alias is safer
@@ -185,8 +193,8 @@ function readRunningCronJobIds(): { ids: Set<string>; count: number } {
 async function runSessionRegistryMaintenance(params: {
   apply: boolean;
 }): Promise<SessionRegistryMaintenanceSummary> {
-  const cfg = getRuntimeConfig();
-  const runningCronJobs = readRunningCronJobIds();
+  const cfg = params.apply ? getRuntimeConfig() : getRuntimeConfigForInspection();
+  const runningCronJobs = await readRunningCronJobIds({ readOnly: !params.apply });
   const stores: SessionRegistryMaintenanceStoreSummary[] = [];
   for (const target of resolveAllAgentSessionStoreTargetsSync(cfg)) {
     const result = await runSessionRegistryMaintenanceForStore({
@@ -454,6 +462,7 @@ export async function tasksNotifyCommand(
   opts: { lookup: string; notify: TaskNotifyPolicy },
   runtime: RuntimeEnv,
 ) {
+  ensureTaskRuntimeStateReady();
   const task = reconcileTaskLookupToken(opts.lookup);
   if (!task) {
     runtime.error(formatTaskLookupMiss(opts.lookup));
@@ -476,6 +485,7 @@ export async function tasksNotifyCommand(
 
 /** Cancels a detached task run by lookup token. */
 export async function tasksCancelCommand(opts: { lookup: string }, runtime: RuntimeEnv) {
+  ensureTaskRuntimeStateReady();
   const task = reconcileTaskLookupToken(opts.lookup);
   if (!task) {
     runtime.error(formatTaskLookupMiss(opts.lookup));
@@ -542,6 +552,7 @@ async function runTaskRecoveryCommand(
     runtime.exit(1);
     return;
   }
+  ensureTaskRuntimeStateReady();
   const tasks: TaskRecord[] = [];
   for (const lookup of lookups) {
     const task = reconcileTaskLookupToken(lookup);
@@ -606,6 +617,7 @@ export async function tasksAuditCommand(
   },
   runtime: RuntimeEnv,
 ) {
+  ensureTaskRuntimeStateReadyForInspection();
   const severityFilter = parseCliEnumFilter(
     opts.severity,
     "--severity",
@@ -671,29 +683,35 @@ export async function tasksMaintenanceCommand(
   runtime: RuntimeEnv,
 ) {
   configureTaskMaintenanceFromConfig();
+  const apply = Boolean(opts.apply);
+  if (apply) {
+    ensureTaskRuntimeStateReady();
+  } else {
+    ensureTaskRuntimeStateReadyForInspection();
+  }
   assertTaskFlowRegistryMaintenanceReady();
   const auditBefore = getInspectableTaskAuditSummary();
   const flowAuditBefore = getInspectableTaskFlowAuditSummary();
-  const taskMaintenance = opts.apply
+  const taskMaintenance = apply
     ? await runTaskRegistryMaintenance()
     : previewTaskRegistryMaintenance();
   // JSON diagnostics explain the task-maintenance decision above, before the
   // separate session-registry sweep can prune backing session rows.
   const diagnostics = opts.json ? getTaskRegistryMaintenanceDiagnostics() : undefined;
-  const flowMaintenance = opts.apply
+  const flowMaintenance = apply
     ? await runTaskFlowRegistryMaintenance()
     : previewTaskFlowRegistryMaintenance();
-  const sessionMaintenance = await runSessionRegistryMaintenance({ apply: Boolean(opts.apply) });
+  const sessionMaintenance = await runSessionRegistryMaintenance({ apply });
   const summary = getInspectableTaskRegistrySummary();
-  const auditAfter = opts.apply ? getInspectableTaskAuditSummary() : auditBefore;
-  const flowAuditAfter = opts.apply ? getInspectableTaskFlowAuditSummary() : flowAuditBefore;
+  const auditAfter = apply ? getInspectableTaskAuditSummary() : auditBefore;
+  const flowAuditAfter = apply ? getInspectableTaskFlowAuditSummary() : flowAuditBefore;
   const retainedLostAfter = summarizeRetainedLostTaskAuditFindings(
     listTaskAuditFindings({ tasks: reconcileInspectableTasks() }),
   );
 
   if (opts.json) {
     writeRuntimeJson(runtime, {
-      mode: opts.apply ? "apply" : "preview",
+      mode: apply ? "apply" : "preview",
       maintenance: {
         tasks: taskMaintenance,
         taskFlows: flowMaintenance,

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -6,6 +6,7 @@ export {
   registerConfigWriteListener,
   createConfigIO,
   getRuntimeConfig,
+  getRuntimeConfigForInspection,
   getRuntimeConfigSnapshotMetadata,
   getRuntimeConfigSnapshot,
   getRuntimeConfigSourceSnapshot,

--- a/src/config/io.runtime.ts
+++ b/src/config/io.runtime.ts
@@ -82,17 +82,29 @@ export function registerConfigWriteListener(
   };
 }
 
+type InternalRuntimeConfigLoadOptions = {
+  observe?: boolean;
+  skipPluginValidation?: boolean;
+  pin?: boolean;
+  skipShellEnvFallback?: boolean;
+};
+
+function loadConfigInternal(options?: InternalRuntimeConfigLoadOptions): OpenClawConfig {
+  const loadFresh = () =>
+    createConfigIO({
+      ...(options?.observe === false ? { observe: false } : {}),
+      ...(options?.skipPluginValidation ? { pluginValidation: "skip" as const } : {}),
+      ...(options?.skipShellEnvFallback ? { shellEnvFallback: "defer" as const } : {}),
+    }).loadConfig();
+  return options?.pin === false ? loadFresh() : loadPinnedRuntimeConfig(loadFresh);
+}
+
 export function loadConfig(options?: {
   skipPluginValidation?: boolean;
   pin?: boolean;
   skipShellEnvFallback?: boolean;
 }): OpenClawConfig {
-  const loadFresh = () =>
-    createConfigIO({
-      ...(options?.skipPluginValidation ? { pluginValidation: "skip" as const } : {}),
-      ...(options?.skipShellEnvFallback ? { shellEnvFallback: "defer" as const } : {}),
-    }).loadConfig();
-  return options?.pin === false ? loadFresh() : loadPinnedRuntimeConfig(loadFresh);
+  return loadConfigInternal(options);
 }
 
 export function getRuntimeConfig(options?: {
@@ -101,6 +113,15 @@ export function getRuntimeConfig(options?: {
   skipShellEnvFallback?: boolean;
 }): OpenClawConfig {
   return loadConfig(options);
+}
+
+/** Reads runtime config without recording CLI observation side effects. Core-only inspection seam. */
+export function getRuntimeConfigForInspection(options?: {
+  skipPluginValidation?: boolean;
+  pin?: boolean;
+  skipShellEnvFallback?: boolean;
+}): OpenClawConfig {
+  return loadConfigInternal({ ...options, observe: false });
 }
 
 export async function readBestEffortConfig(options?: {

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -9,6 +9,7 @@ export {
 export {
   clearConfigCache,
   getRuntimeConfig,
+  getRuntimeConfigForInspection,
   loadConfig,
   preserveConfigSnapshotAsClobbered,
   promoteConfigSnapshotToLastKnownGood,

--- a/src/state/openclaw-state-db-readonly.ts
+++ b/src/state/openclaw-state-db-readonly.ts
@@ -52,6 +52,18 @@ function assertSupportedSchemaVersion(db: DatabaseSync, pathname: string): void 
   }
 }
 
+function assertCurrentSchemaVersion(db: DatabaseSync, pathname: string): void {
+  const userVersion = readSqliteUserVersion(db);
+  if (userVersion < OPENCLAW_STATE_SCHEMA_VERSION) {
+    const error = new Error(
+      `OpenClaw state database ${pathname} uses older schema version ${userVersion}; this read-only command requires ${OPENCLAW_STATE_SCHEMA_VERSION} and will not migrate it. ` +
+        "Start the gateway or run openclaw doctor --fix, then retry.",
+    );
+    error.name = "SqliteSchemaVersionError";
+    throw error;
+  }
+}
+
 function withOpenClawStateDatabaseReadOnlyIfOpen<T>(
   operation: (database: OpenClawStateReadOnlyDatabase) => T,
   options: OpenClawStateDatabaseOptions,
@@ -131,4 +143,15 @@ export function withExistingOpenClawStateDatabaseReadOnly<T>(
         { ...options, path: existingPath },
         existingPath,
       );
+}
+
+/** Read existing shared state only when its schema is already current. */
+export function withExistingCurrentOpenClawStateDatabaseReadOnly<T>(
+  operation: (database: OpenClawStateReadOnlyDatabase) => T,
+  options: OpenClawStateDatabaseOptions = {},
+): T | undefined {
+  return withExistingOpenClawStateDatabaseReadOnly((database) => {
+    assertCurrentSchemaVersion(database.db, database.path);
+    return operation(database);
+  }, options);
 }

--- a/src/tasks/runtime-internal.ts
+++ b/src/tasks/runtime-internal.ts
@@ -1,16 +1,23 @@
 // Internal task registry facade used by runtime modules without exposing public SDK surface.
 import {
   ensureTaskFlowRegistryReady,
+  ensureTaskFlowRegistryReadyForInspection,
   reloadTaskFlowRegistryFromStore,
 } from "./task-flow-runtime-internal.js";
 import {
   ensureTaskRegistryReady as ensureTaskRegistryReadyInternal,
+  ensureTaskRegistryReadyForInspection,
   reloadTaskRegistryFromStore as reloadTaskRegistryFromStoreInternal,
-} from "./task-registry.js";
+} from "./task-registry-state.js";
 
 export function ensureTaskRuntimeStateReady(): void {
   ensureTaskFlowRegistryReady();
   ensureTaskRegistryReadyInternal();
+}
+
+export function ensureTaskRuntimeStateReadyForInspection(): void {
+  ensureTaskFlowRegistryReadyForInspection();
+  ensureTaskRegistryReadyForInspection();
 }
 
 export function reloadTaskRuntimeStateFromStore(): void {

--- a/src/tasks/task-flow-registry.maintenance.ts
+++ b/src/tasks/task-flow-registry.maintenance.ts
@@ -8,6 +8,7 @@ import {
 } from "./task-flow-registry.audit.js";
 import {
   deleteTaskFlowRecordById,
+  ensureTaskFlowRegistryReadyForInspection,
   getTaskFlowById,
   getTaskFlowRegistryRestoreFailure,
   listTaskFlowRecords,
@@ -139,6 +140,7 @@ export function getInspectableTaskFlowAuditSummary(): TaskFlowAuditSummary {
 }
 
 export function previewTaskFlowRegistryMaintenance(): TaskFlowRegistryMaintenanceSummary {
+  ensureTaskFlowRegistryReadyForInspection();
   const now = Date.now();
   let reconciled = 0;
   let pruned = 0;

--- a/src/tasks/task-flow-registry.store.sqlite.ts
+++ b/src/tasks/task-flow-registry.store.sqlite.ts
@@ -3,7 +3,7 @@ import type { DatabaseSync } from "node:sqlite";
 import type { Insertable, Selectable } from "kysely";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { normalizeSqliteNumber } from "../infra/sqlite-number.js";
-import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
+import { withExistingCurrentOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   closeOpenClawStateDatabase,
@@ -218,7 +218,7 @@ export function loadTaskFlowRegistryStateFromSqlite(): TaskFlowRegistryStoreSnap
 /** Loads task flows without creating or migrating shared state. */
 export function loadTaskFlowRegistryStateFromSqliteReadOnly(): TaskFlowRegistryStoreSnapshot {
   return (
-    withExistingOpenClawStateDatabaseReadOnly(({ db }) => {
+    withExistingCurrentOpenClawStateDatabaseReadOnly(({ db }) => {
       const rows = selectFlowRows(db);
       return {
         flows: new Map(rows.map((row) => [row.flow_id, rowToFlowRecord(row)])),

--- a/src/tasks/task-flow-registry.store.ts
+++ b/src/tasks/task-flow-registry.store.ts
@@ -3,6 +3,7 @@ import {
   closeTaskFlowRegistryDatabase,
   deleteTaskFlowRegistryRecordFromSqlite,
   loadTaskFlowRegistryStateFromSqlite,
+  loadTaskFlowRegistryStateFromSqliteReadOnly,
   saveTaskFlowRegistryStateToSqlite,
   upsertTaskFlowRegistryRecordToSqlite,
 } from "./task-flow-registry.store.sqlite.js";
@@ -11,6 +12,7 @@ import type { TaskFlowRecord } from "./task-flow-registry.types.js";
 
 type TaskFlowRegistryStore = {
   loadSnapshot: () => TaskFlowRegistryStoreSnapshot;
+  loadSnapshotReadOnly?: () => TaskFlowRegistryStoreSnapshot;
   saveSnapshot: (snapshot: TaskFlowRegistryStoreSnapshot) => void;
   upsertFlow?: (flow: TaskFlowRecord) => void;
   deleteFlow?: (flowId: string) => void;
@@ -40,6 +42,7 @@ type TaskFlowRegistryObservers = {
 
 const defaultFlowRegistryStore: TaskFlowRegistryStore = {
   loadSnapshot: loadTaskFlowRegistryStateFromSqlite,
+  loadSnapshotReadOnly: loadTaskFlowRegistryStateFromSqliteReadOnly,
   saveSnapshot: saveTaskFlowRegistryStateToSqlite,
   upsertFlow: upsertTaskFlowRegistryRecordToSqlite,
   deleteFlow: deleteTaskFlowRegistryRecordFromSqlite,

--- a/src/tasks/task-flow-registry.ts
+++ b/src/tasks/task-flow-registry.ts
@@ -21,9 +21,10 @@ const log = createSubsystemLogger("tasks/task-flow-registry");
 let flows = new Map<string, TaskFlowRecord>();
 type TaskFlowRegistryRestoreState =
   | { status: "uninitialized" }
-  | { status: "restoring" }
+  | { status: "restoring"; access: TaskFlowRegistryRestoreAccess }
   | { status: "ready" }
-  | { status: "failed"; error: Error; message: string };
+  | { status: "failed"; access: TaskFlowRegistryRestoreAccess; error: Error; message: string };
+type TaskFlowRegistryRestoreAccess = "read-only" | "read-write";
 let taskFlowRegistryRestoreState: TaskFlowRegistryRestoreState = { status: "uninitialized" };
 
 type FlowRecordPatch = Omit<
@@ -248,20 +249,27 @@ function resolveTaskMirroredFlowTiming(
   return { updatedAt: endedAt, endedAt };
 }
 
-function restoreTaskFlowRegistryOnce(): void {
+function restoreTaskFlowRegistryOnce(access: TaskFlowRegistryRestoreAccess = "read-write"): void {
   switch (taskFlowRegistryRestoreState.status) {
     case "ready":
       return;
     case "failed":
-      throw taskFlowRegistryRestoreState.error;
+      if (taskFlowRegistryRestoreState.access === "read-write" || access === "read-only") {
+        throw taskFlowRegistryRestoreState.error;
+      }
+      break;
     case "restoring":
       throw new Error("Task-flow registry restore is already in progress.");
     case "uninitialized":
       break;
   }
-  taskFlowRegistryRestoreState = { status: "restoring" };
+  taskFlowRegistryRestoreState = { status: "restoring", access };
   try {
-    const restored = getTaskFlowRegistryStore().loadSnapshot();
+    const store = getTaskFlowRegistryStore();
+    const restored =
+      access === "read-only" && store.loadSnapshotReadOnly
+        ? store.loadSnapshotReadOnly()
+        : store.loadSnapshot();
     const restoredFlows = new Map<string, TaskFlowRecord>();
     for (const [flowId, flow] of restored.flows) {
       restoredFlows.set(flowId, normalizeRestoredFlowRecord(flow));
@@ -276,6 +284,7 @@ function restoreTaskFlowRegistryOnce(): void {
     });
     taskFlowRegistryRestoreState = {
       status: "failed",
+      access,
       error: restoreError,
       message,
     };
@@ -293,6 +302,10 @@ function restoreTaskFlowRegistryOnce(): void {
 
 export function ensureTaskFlowRegistryReady(): void {
   restoreTaskFlowRegistryOnce();
+}
+
+export function ensureTaskFlowRegistryReadyForInspection(): void {
+  restoreTaskFlowRegistryOnce("read-only");
 }
 
 export function getTaskFlowRegistryRestoreFailure(): string | null {

--- a/src/tasks/task-flow-runtime-internal.ts
+++ b/src/tasks/task-flow-runtime-internal.ts
@@ -4,6 +4,7 @@ export {
   createManagedTaskFlow,
   deleteTaskFlowRecordById,
   ensureTaskFlowRegistryReady,
+  ensureTaskFlowRegistryReadyForInspection,
   failFlow,
   finishFlow,
   getTaskFlowById,

--- a/src/tasks/task-registry-state.ts
+++ b/src/tasks/task-registry-state.ts
@@ -32,9 +32,10 @@ export const tasksWithPendingDelivery = taskRegistryProcessState.tasksWithPendin
 export const taskActivityByTaskId = taskRegistryProcessState.taskActivityByTaskId;
 type TaskRegistryRestoreState =
   | { status: "uninitialized" }
-  | { status: "restoring" }
+  | { status: "restoring"; access: TaskRegistryRestoreAccess }
   | { status: "ready" }
-  | { status: "failed"; error: Error };
+  | { status: "failed"; access: TaskRegistryRestoreAccess; error: Error };
+type TaskRegistryRestoreAccess = "read-only" | "read-write";
 let taskRegistryRestoreState: TaskRegistryRestoreState = { status: "uninitialized" };
 export const taskFlowSyncRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
 export type TaskRegistryDeliveryRuntime = Pick<
@@ -494,20 +495,27 @@ export function compareTasksNewestFirst(
   return (right.insertionIndex ?? 0) - (left.insertionIndex ?? 0);
 }
 
-export function restoreTaskRegistryOnce() {
+export function restoreTaskRegistryOnce(access: TaskRegistryRestoreAccess = "read-write") {
   switch (taskRegistryRestoreState.status) {
     case "ready":
       return;
     case "failed":
-      throw taskRegistryRestoreState.error;
+      if (taskRegistryRestoreState.access === "read-write" || access === "read-only") {
+        throw taskRegistryRestoreState.error;
+      }
+      break;
     case "restoring":
       throw new Error("Task registry restore is already in progress.");
     case "uninitialized":
       break;
   }
-  taskRegistryRestoreState = { status: "restoring" };
+  taskRegistryRestoreState = { status: "restoring", access };
   try {
-    const restored = getTaskRegistryStore().loadSnapshot();
+    const store = getTaskRegistryStore();
+    const restored =
+      access === "read-only" && store.loadSnapshotReadOnly
+        ? store.loadSnapshotReadOnly()
+        : store.loadSnapshot();
     const restoredTasks = new Map<string, TaskRecord>();
     for (const [taskId, task] of restored.tasks.entries()) {
       restoredTasks.set(taskId, normalizeTaskTimestamps(task));
@@ -536,7 +544,7 @@ export function restoreTaskRegistryOnce() {
     clearTaskRegistryMemory();
     const message = formatErrorMessage(error);
     const restoreError = new Error(`Task registry restore failed: ${message}`, { cause: error });
-    taskRegistryRestoreState = { status: "failed", error: restoreError };
+    taskRegistryRestoreState = { status: "failed", access, error: restoreError };
     // Compact console logs omit structured metadata, so keep the rejected value visible there too.
     taskRegistryLog.warn("Failed to restore task registry", {
       error: message,
@@ -549,6 +557,10 @@ export function restoreTaskRegistryOnce() {
 export function ensureTaskRegistryReady(): void {
   restoreTaskRegistryOnce();
   listenerStarter();
+}
+
+export function ensureTaskRegistryReadyForInspection(): void {
+  restoreTaskRegistryOnce("read-only");
 }
 
 export function reloadTaskRegistryFromStore(): void {

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -54,6 +54,7 @@ import {
   resolveTaskForLookupToken,
   setTaskCleanupAfterById,
 } from "./runtime-internal.js";
+import { ensureTaskRegistryReadyForInspection } from "./task-registry-state.js";
 import {
   configureTaskAuditTaskProvider,
   listTaskAuditFindings,
@@ -107,6 +108,7 @@ type TaskRegistryMaintenanceRuntime = {
   hasActiveTaskForChildSessionKey: typeof hasActiveTaskForChildSessionKey;
   deleteTaskRecordById: typeof deleteTaskRecordById;
   ensureTaskRegistryReady: typeof ensureTaskRegistryReady;
+  ensureTaskRegistryReadyForInspection?: typeof ensureTaskRegistryReadyForInspection;
   getTaskById: typeof getTaskById;
   listTaskRecords: typeof listTaskRecords;
   markTaskLostById: typeof markTaskLostById;
@@ -146,6 +148,7 @@ const defaultTaskRegistryMaintenanceRuntime: TaskRegistryMaintenanceRuntime = {
   hasActiveTaskForChildSessionKey,
   deleteTaskRecordById,
   ensureTaskRegistryReady,
+  ensureTaskRegistryReadyForInspection,
   getTaskById,
   listTaskRecords,
   markTaskLostById,
@@ -811,7 +814,10 @@ function reconcileTaskRecordsForOperatorInspection(tasks: TaskRecord[]): TaskRec
 }
 
 export function reconcileInspectableTasks(): TaskRecord[] {
-  taskRegistryMaintenanceRuntime.ensureTaskRegistryReady();
+  (
+    taskRegistryMaintenanceRuntime.ensureTaskRegistryReadyForInspection ??
+    taskRegistryMaintenanceRuntime.ensureTaskRegistryReady
+  )();
   return reconcileTaskRecordsForOperatorInspection(
     taskRegistryMaintenanceRuntime.listTaskRecords(),
   );
@@ -884,7 +890,10 @@ export function getInspectableTaskAuditFindings(
 }
 
 export function reconcileTaskLookupToken(token: string): TaskRecord | undefined {
-  taskRegistryMaintenanceRuntime.ensureTaskRegistryReady();
+  (
+    taskRegistryMaintenanceRuntime.ensureTaskRegistryReadyForInspection ??
+    taskRegistryMaintenanceRuntime.ensureTaskRegistryReady
+  )();
   const task = taskRegistryMaintenanceRuntime.resolveTaskForLookupToken(token);
   return task ? reconcileTaskRecordForOperatorInspection(task) : undefined;
 }
@@ -893,7 +902,10 @@ export function reconcileTaskLookupToken(token: string): TaskRecord | undefined 
 // so hook-recovered tasks are counted under reconciled here. Durable cron
 // recovery is synchronous and can be previewed exactly.
 export function previewTaskRegistryMaintenance(): TaskRegistryMaintenanceSummary {
-  taskRegistryMaintenanceRuntime.ensureTaskRegistryReady();
+  (
+    taskRegistryMaintenanceRuntime.ensureTaskRegistryReadyForInspection ??
+    taskRegistryMaintenanceRuntime.ensureTaskRegistryReady
+  )();
   const now = Date.now();
   let reconciled = 0;
   let recovered = 0;
@@ -960,7 +972,10 @@ function explainActiveTaskRetention(params: {
 }
 
 export function getTaskRegistryMaintenanceDiagnostics(): TaskRegistryMaintenanceDiagnostics {
-  taskRegistryMaintenanceRuntime.ensureTaskRegistryReady();
+  (
+    taskRegistryMaintenanceRuntime.ensureTaskRegistryReadyForInspection ??
+    taskRegistryMaintenanceRuntime.ensureTaskRegistryReady
+  )();
   const now = Date.now();
   const cronRecoveryContext = createCronRecoveryContext();
   const backingSessionContext = createBackingSessionLookupContext();

--- a/src/tasks/task-registry.store.sqlite.ts
+++ b/src/tasks/task-registry.store.sqlite.ts
@@ -5,7 +5,7 @@ import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-syn
 import { assertSqliteTableIntegrity } from "../infra/sqlite-integrity.js";
 import { normalizeSqliteNumber } from "../infra/sqlite-number.js";
 import { runSqliteDeferredTransactionSync } from "../infra/sqlite-transaction.js";
-import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
+import { withExistingCurrentOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   closeOpenClawStateDatabase,
@@ -363,7 +363,7 @@ export function loadTaskRegistryStateFromSqlite(): TaskRegistryStoreSnapshot {
 /** Loads task records without creating or migrating shared state. */
 export function loadTaskRegistryStateFromSqliteReadOnly(): TaskRegistryStoreSnapshot {
   return (
-    withExistingOpenClawStateDatabaseReadOnly(readTaskRegistrySnapshot) ?? {
+    withExistingCurrentOpenClawStateDatabaseReadOnly(readTaskRegistrySnapshot) ?? {
       tasks: new Map(),
       deliveryStates: new Map(),
     }
@@ -389,7 +389,7 @@ export function listTaskRegistryRecordsByRuntimeSourceIdFromSqlite(params: {
     return [];
   }
   return (
-    withExistingOpenClawStateDatabaseReadOnly(({ db }) =>
+    withExistingCurrentOpenClawStateDatabaseReadOnly(({ db }) =>
       selectTaskRowsByRuntimeSourceId(db, params.runtime, sourceId).map(rowToTaskRecord),
     ) ?? []
   );

--- a/src/tasks/task-registry.store.ts
+++ b/src/tasks/task-registry.store.ts
@@ -5,6 +5,7 @@ import {
   deleteTaskDeliveryStateFromSqlite,
   deleteTaskRegistryRecordFromSqlite,
   loadTaskRegistryStateFromSqlite,
+  loadTaskRegistryStateFromSqliteReadOnly,
   listTaskRegistryRecordsByOwnerKeyFromSqlite,
   saveTaskRegistryStateToSqlite,
   upsertTaskWithDeliveryStateToSqlite,
@@ -18,6 +19,7 @@ export type { TaskRegistryStoreSnapshot } from "./task-registry.store.types.js";
 
 export type TaskRegistryStore = {
   loadSnapshot: () => TaskRegistryStoreSnapshot;
+  loadSnapshotReadOnly?: () => TaskRegistryStoreSnapshot;
   saveSnapshot: (snapshot: TaskRegistryStoreSnapshot) => void;
   listTasksForOwnerKey?: (ownerKey: string) => TaskRecord[];
   upsertTaskWithDeliveryState?: (params: {
@@ -55,6 +57,7 @@ type TaskRegistryObservers = {
 
 const defaultTaskRegistryStore: TaskRegistryStore = {
   loadSnapshot: loadTaskRegistryStateFromSqlite,
+  loadSnapshotReadOnly: loadTaskRegistryStateFromSqliteReadOnly,
   saveSnapshot: saveTaskRegistryStateToSqlite,
   listTasksForOwnerKey: listTaskRegistryRecordsByOwnerKeyFromSqlite,
   upsertTaskWithDeliveryState: upsertTaskWithDeliveryStateToSqlite,


### PR DESCRIPTION
## What Problem This Solves

Several CLI inspection paths could re-enter task and TaskFlow runtime restore through writable state owners. On a host with a running Gateway, commands such as task listing/audit, maintenance preview, TaskFlow inspection, and default plugin inventory could therefore create or migrate the shared state database, or record configuration observation, despite being read-only operations.

This change makes those inspection restores fail closed when the existing state DB is older than the current schema, rather than opening it writable. It preserves the writable migration path for explicit mutations.

## Why This Change Was Made

#124110 now owns the generic non-creating, non-migrating state/doctor loaders. This PR has been reshaped after it and drops the overlapping work.

The remaining scope is limited to the unique guarantees:

- task and TaskFlow runtime inspection restores use a current-schema read-only state DB path;
- explicit task and flow mutations still restore writable state and may migrate it;
- plugin/task inspection config reads use an internal non-observing config seam;
- channels status has regression coverage for its non-observing fallback config reads;
- task maintenance preview does not promote a failed read-only restore into a writable migration.

No schema version, public config option, or CLI flag is added.

Refs: #119583, #120222

#120222 is retained as resilience context only. This PR does not change Gateway startup ordering or claim to resolve that open product decision.

## User Impact

Read-only CLI inspection no longer creates or migrates `state/openclaw.sqlite`. If a task or TaskFlow inspection encounters an older state schema, it explains how to repair it (`openclaw doctor --fix` or starting the Gateway) without changing the DB.

Explicit mutation commands, including task notification/cancellation and flow cancellation, retain their existing writable migration behavior.

## Evidence

- Rebased and narrowed on current `openclaw/main` after #124110.
- Focused tests: 98/98 passing across 7 files, including old-schema assertions that inspection leaves `user_version` unchanged and mutations can then migrate.
- Targeted formatting and `git diff --check` passed.
- `CI=true pnpm build` completed.
- Local autoreview completed clean.
