### PR TITLE
fix(venice): tool calls continue after Gemini responses

### DIFF
--- a/extensions/venice/index.test.ts
+++ b/extensions/venice/index.test.ts
@@ -115,4 +115,123 @@ describe("venice provider plugin", () => {
       },
     ]);
   });
+
+  it("replays Gemini tool-call thought signatures in Venice's top-level wire field", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const capturedPayloads: Record<string, unknown>[] = [];
+    const baseStreamFn = (_model: unknown, _context: unknown, options: unknown) => {
+      const payload = {
+        model: "gemini-3-6-flash",
+        messages: [
+          { role: "user", content: "echo" },
+          {
+            role: "assistant",
+            tool_calls: [
+              {
+                id: "call_1",
+                type: "function",
+                function: { name: "echo_value", arguments: '{"value":"repro"}' },
+              },
+            ],
+          },
+          { role: "tool", tool_call_id: "call_1", content: "ok" },
+        ],
+      };
+      (options as { onPayload?: (payload: Record<string, unknown>) => void })?.onPayload?.(payload);
+      capturedPayloads.push(payload);
+      return {} as never;
+    };
+
+    const streamFn = provider.wrapStreamFn?.({
+      streamFn: baseStreamFn as never,
+      providerId: "venice",
+      modelId: "gemini-3-6-flash",
+      thinkingLevel: "high",
+    } as never);
+
+    expect(streamFn).toBeTypeOf("function");
+    await streamFn?.(
+      { api: "openai-completions", provider: "venice", id: "gemini-3-6-flash" } as never,
+      {
+        messages: [
+          { role: "user", content: "echo" },
+          {
+            role: "assistant",
+            api: "openai-completions",
+            provider: "venice",
+            model: "gemini-3-6-flash",
+            content: [
+              {
+                type: "toolCall",
+                id: "call_1",
+                name: "echo_value",
+                arguments: { value: "repro" },
+                thoughtSignature: "SIG-VENICE-OPAQUE-ABC==",
+              },
+            ],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            toolName: "echo_value",
+            content: [{ type: "text", text: "ok" }],
+            isError: false,
+          },
+        ],
+      } as never,
+      {},
+    );
+
+    expect(capturedPayloads[0]).toMatchObject({
+      messages: [
+        { role: "user", content: "echo" },
+        {
+          role: "assistant",
+          tool_calls: [
+            {
+              id: "call_1",
+              thought_signature: "SIG-VENICE-OPAQUE-ABC==",
+            },
+          ],
+        },
+        { role: "tool", tool_call_id: "call_1", content: "ok" },
+      ],
+    });
+    const replayedToolCall = (
+      (capturedPayloads[0]!.messages as Array<Record<string, unknown>>)[1]!.tool_calls as Array<
+        Record<string, unknown>
+      >
+    )[0];
+    expect(replayedToolCall).not.toHaveProperty("extra_content");
+
+    await streamFn?.(
+      { api: "openai-completions", provider: "venice", id: "gemini-3-6-flash" } as never,
+      {
+        messages: [
+          {
+            role: "assistant",
+            api: "google-generative-ai",
+            provider: "google",
+            model: "gemini-3-6-flash",
+            content: [
+              {
+                type: "toolCall",
+                id: "call_1",
+                name: "echo_value",
+                arguments: {},
+                thoughtSignature: "SIG-CROSS-ROUTE",
+              },
+            ],
+          },
+        ],
+      } as never,
+      {},
+    );
+    const crossRouteToolCall = (
+      (capturedPayloads[1]!.messages as Array<Record<string, unknown>>)[1]!.tool_calls as Array<
+        Record<string, unknown>
+      >
+    )[0];
+    expect(crossRouteToolCall).not.toHaveProperty("thought_signature");
+  });
 });

--- a/extensions/venice/index.test.ts
+++ b/extensions/venice/index.test.ts
@@ -116,7 +116,7 @@ describe("venice provider plugin", () => {
     ]);
   });
 
-  it("replays Gemini tool-call thought signatures in Venice's top-level wire field", async () => {
+  it("replays Gemini signatures and marks foreign history in Venice's top-level field", async () => {
     const provider = await registerSingleProviderPlugin(plugin);
     const capturedPayloads: Record<string, unknown>[] = [];
     const baseStreamFn = (_model: unknown, _context: unknown, options: unknown) => {
@@ -232,6 +232,115 @@ describe("venice provider plugin", () => {
         Record<string, unknown>
       >
     )[0];
-    expect(crossRouteToolCall).not.toHaveProperty("thought_signature");
+    expect(crossRouteToolCall).toMatchObject({
+      thought_signature: "skip_thought_signature_validator",
+    });
+  });
+
+  it("marks unsigned mixed-model and parallel Gemini history for validation bypass", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    let capturedPayload: Record<string, unknown> | undefined;
+    const baseStreamFn = (_model: unknown, _context: unknown, options: unknown) => {
+      const payload = {
+        model: "gemini-3-6-flash",
+        messages: [
+          {
+            role: "assistant",
+            tool_calls: [
+              { id: "foreign_call", type: "function", function: { name: "web_fetch" } },
+              { id: "legacy_call", type: "function", function: { name: "read" } },
+              { id: "signed_call", type: "function", function: { name: "read" } },
+            ],
+          },
+        ],
+      };
+      (options as { onPayload?: (payload: Record<string, unknown>) => void })?.onPayload?.(payload);
+      capturedPayload = payload;
+      return {} as never;
+    };
+    const streamFn = provider.wrapStreamFn?.({
+      streamFn: baseStreamFn as never,
+      providerId: "venice",
+      modelId: "gemini-3-6-flash",
+      thinkingLevel: "high",
+    } as never);
+
+    await streamFn?.(
+      { api: "openai-completions", provider: "venice", id: "gemini-3-6-flash" } as never,
+      {
+        messages: [
+          {
+            role: "assistant",
+            api: "openai-chatgpt-responses",
+            provider: "openai",
+            model: "gpt-5.6-sol",
+            content: [{ type: "toolCall", id: "foreign_call", name: "web_fetch", arguments: {} }],
+          },
+          {
+            role: "assistant",
+            api: "openai-completions",
+            provider: "venice",
+            model: "gemini-3-6-flash",
+            content: [
+              { type: "toolCall", id: "legacy_call", name: "read", arguments: {} },
+              {
+                type: "toolCall",
+                id: "signed_call",
+                name: "read",
+                arguments: {},
+                thoughtSignature: "SIG-EXACT-SAME-ROUTE==",
+              },
+            ],
+          },
+        ],
+      } as never,
+      {},
+    );
+
+    const toolCalls = (capturedPayload!.messages as Array<Record<string, unknown>>)[0]!
+      .tool_calls as Array<Record<string, unknown>>;
+    expect(toolCalls.map((toolCall) => toolCall.thought_signature)).toEqual([
+      "skip_thought_signature_validator",
+      "skip_thought_signature_validator",
+      "SIG-EXACT-SAME-ROUTE==",
+    ]);
+  });
+
+  it("does not add the Gemini 3 validator bypass to unsigned Gemini 2.5 history", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    let capturedPayload: Record<string, unknown> | undefined;
+    const baseStreamFn = (_model: unknown, _context: unknown, options: unknown) => {
+      const payload = {
+        model: "gemini-2.5-flash",
+        messages: [
+          {
+            role: "assistant",
+            tool_calls: [{ id: "call_1", type: "function", function: { name: "read" } }],
+          },
+        ],
+      };
+      (options as { onPayload?: (payload: Record<string, unknown>) => void })?.onPayload?.(payload);
+      capturedPayload = payload;
+      return {} as never;
+    };
+    const streamFn = provider.wrapStreamFn?.({
+      streamFn: baseStreamFn as never,
+      providerId: "venice",
+      modelId: "gemini-2.5-flash",
+      thinkingLevel: "high",
+    } as never);
+
+    await streamFn?.(
+      { api: "openai-completions", provider: "venice", id: "gemini-2.5-flash" } as never,
+      { messages: [] } as never,
+      {},
+    );
+
+    const toolCall = (
+      (capturedPayload!.messages as Array<Record<string, unknown>>)[0]!.tool_calls as Array<
+        Record<string, unknown>
+      >
+    )[0];
+    expect(toolCall).not.toHaveProperty("thought_signature");
   });
 });

--- a/extensions/venice/index.test.ts
+++ b/extensions/venice/index.test.ts
@@ -116,7 +116,7 @@ describe("venice provider plugin", () => {
     ]);
   });
 
-  it("replays Gemini signatures and marks foreign history in Venice's top-level field", async () => {
+  it("replays Gemini signatures and downgrades foreign tool history to text", async () => {
     const provider = await registerSingleProviderPlugin(plugin);
     const capturedPayloads: Record<string, unknown>[] = [];
     const baseStreamFn = (_model: unknown, _context: unknown, options: unknown) => {
@@ -227,17 +227,20 @@ describe("venice provider plugin", () => {
       } as never,
       {},
     );
-    const crossRouteToolCall = (
-      (capturedPayloads[1]!.messages as Array<Record<string, unknown>>)[1]!.tool_calls as Array<
-        Record<string, unknown>
-      >
-    )[0];
-    expect(crossRouteToolCall).toMatchObject({
-      thought_signature: "skip_thought_signature_validator",
+    const crossRouteMessages = capturedPayloads[1]!.messages as Array<Record<string, unknown>>;
+    expect(crossRouteMessages[1]).toMatchObject({
+      role: "assistant",
+      content: expect.stringContaining("[Historical tool call: echo_value("),
     });
+    expect(crossRouteMessages[1]).not.toHaveProperty("tool_calls");
+    expect(crossRouteMessages[2]).toMatchObject({
+      role: "user",
+      content: "[Historical tool result for echo_value:\nok]",
+    });
+    expect(crossRouteMessages[2]).not.toHaveProperty("tool_call_id");
   });
 
-  it("marks unsigned mixed-model and parallel Gemini history for validation bypass", async () => {
+  it("downgrades mixed signed and unsigned Gemini tool batches to text history", async () => {
     const provider = await registerSingleProviderPlugin(plugin);
     let capturedPayload: Record<string, unknown> | undefined;
     const baseStreamFn = (_model: unknown, _context: unknown, options: unknown) => {
@@ -252,6 +255,10 @@ describe("venice provider plugin", () => {
               { id: "signed_call", type: "function", function: { name: "read" } },
             ],
           },
+          { role: "tool", tool_call_id: "foreign_call", content: "foreign result" },
+          { role: "tool", tool_call_id: "legacy_call", content: "legacy result" },
+          { role: "tool", tool_call_id: "signed_call", content: "signed result" },
+          { role: "user", content: "current prompt" },
         ],
       };
       (options as { onPayload?: (payload: Record<string, unknown>) => void })?.onPayload?.(payload);
@@ -297,16 +304,21 @@ describe("venice provider plugin", () => {
       {},
     );
 
-    const toolCalls = (capturedPayload!.messages as Array<Record<string, unknown>>)[0]!
-      .tool_calls as Array<Record<string, unknown>>;
-    expect(toolCalls.map((toolCall) => toolCall.thought_signature)).toEqual([
-      "skip_thought_signature_validator",
-      "skip_thought_signature_validator",
-      "SIG-EXACT-SAME-ROUTE==",
+    const messages = capturedPayload!.messages as Array<Record<string, unknown>>;
+    expect(messages[0]).toMatchObject({
+      role: "assistant",
+      content: expect.stringContaining("[Historical tool call: web_fetch("),
+    });
+    expect(messages[0]).not.toHaveProperty("tool_calls");
+    expect(messages.slice(1, 4)).toEqual([
+      { role: "user", content: "[Historical tool result for web_fetch:\nforeign result]" },
+      { role: "user", content: "[Historical tool result for read:\nlegacy result]" },
+      { role: "user", content: "[Historical tool result for read:\nsigned result]" },
     ]);
+    expect(messages[4]).toEqual({ role: "user", content: "current prompt" });
   });
 
-  it("does not add the Gemini 3 validator bypass to unsigned Gemini 2.5 history", async () => {
+  it("leaves unsigned Gemini 2.5 history unchanged", async () => {
     const provider = await registerSingleProviderPlugin(plugin);
     let capturedPayload: Record<string, unknown> | undefined;
     const baseStreamFn = (_model: unknown, _context: unknown, options: unknown) => {

--- a/extensions/venice/index.test.ts
+++ b/extensions/venice/index.test.ts
@@ -278,17 +278,11 @@ describe("venice provider plugin", () => {
         messages: [
           {
             role: "assistant",
-            api: "openai-chatgpt-responses",
-            provider: "openai",
-            model: "gpt-5.6-sol",
-            content: [{ type: "toolCall", id: "foreign_call", name: "web_fetch", arguments: {} }],
-          },
-          {
-            role: "assistant",
             api: "openai-completions",
             provider: "venice",
             model: "gemini-3-6-flash",
             content: [
+              { type: "toolCall", id: "foreign_call", name: "web_fetch", arguments: {} },
               { type: "toolCall", id: "legacy_call", name: "read", arguments: {} },
               {
                 type: "toolCall",
@@ -316,6 +310,163 @@ describe("venice provider plugin", () => {
       { role: "user", content: "[Historical tool result for read:\nsigned result]" },
     ]);
     expect(messages[4]).toEqual({ role: "user", content: "current prompt" });
+  });
+
+  it("pairs reused Gemini tool-call ids by assistant occurrence", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const capturedPayloads: Record<string, unknown>[] = [];
+    const payloads = [
+      {
+        model: "gemini-3-6-flash",
+        messages: [
+          {
+            role: "assistant",
+            tool_calls: [
+              { id: "call_0", type: "function", function: { name: "read", arguments: "{}" } },
+            ],
+          },
+          { role: "tool", tool_call_id: "call_0", content: "read result" },
+          {
+            role: "assistant",
+            tool_calls: [
+              { id: "call_0", type: "function", function: { name: "write", arguments: "{}" } },
+            ],
+          },
+          { role: "tool", tool_call_id: "call_0", content: "write result" },
+          { role: "user", content: "current prompt" },
+        ],
+      },
+      {
+        model: "gemini-3-6-flash",
+        messages: [
+          {
+            role: "assistant",
+            tool_calls: [
+              { id: "call_0", type: "function", function: { name: "read", arguments: "{}" } },
+            ],
+          },
+          { role: "tool", tool_call_id: "call_0", content: "legacy result" },
+          {
+            role: "assistant",
+            tool_calls: [
+              { id: "call_0", type: "function", function: { name: "write", arguments: "{}" } },
+            ],
+          },
+          { role: "tool", tool_call_id: "call_0", content: "signed result" },
+          { role: "user", content: "current prompt" },
+        ],
+      },
+    ];
+    const baseStreamFn = (_model: unknown, _context: unknown, options: unknown) => {
+      const payload = structuredClone(payloads[capturedPayloads.length]!);
+      (options as { onPayload?: (payload: Record<string, unknown>) => void })?.onPayload?.(payload);
+      capturedPayloads.push(payload);
+      return {} as never;
+    };
+    const streamFn = provider.wrapStreamFn?.({
+      streamFn: baseStreamFn as never,
+      providerId: "venice",
+      modelId: "gemini-3-6-flash",
+      thinkingLevel: "high",
+    } as never);
+
+    await streamFn?.(
+      { api: "openai-completions", provider: "venice", id: "gemini-3-6-flash" } as never,
+      {
+        messages: [
+          {
+            role: "assistant",
+            api: "openai-completions",
+            provider: "venice",
+            model: "gemini-3-6-flash",
+            content: [
+              {
+                type: "toolCall",
+                id: "call_0",
+                name: "read",
+                arguments: {},
+                thoughtSignature: "SIG-READ",
+              },
+            ],
+          },
+          {
+            role: "assistant",
+            api: "openai-completions",
+            provider: "venice",
+            model: "gemini-3-6-flash",
+            content: [
+              {
+                type: "toolCall",
+                id: "call_0",
+                name: "write",
+                arguments: {},
+                thoughtSignature: "SIG-WRITE",
+              },
+            ],
+          },
+        ],
+      } as never,
+      {},
+    );
+
+    const signedMessages = capturedPayloads[0]!.messages as Array<Record<string, unknown>>;
+    expect(signedMessages[0]).toMatchObject({
+      tool_calls: [{ id: "call_0", thought_signature: "SIG-READ" }],
+    });
+    expect(signedMessages[2]).toMatchObject({
+      tool_calls: [{ id: "call_0", thought_signature: "SIG-WRITE" }],
+    });
+
+    await streamFn?.(
+      { api: "openai-completions", provider: "venice", id: "gemini-3-6-flash" } as never,
+      {
+        messages: [
+          {
+            role: "assistant",
+            api: "openai-completions",
+            provider: "venice",
+            model: "gemini-3-6-flash",
+            content: [{ type: "toolCall", id: "call_0", name: "read", arguments: {} }],
+          },
+          {
+            role: "assistant",
+            api: "openai-completions",
+            provider: "venice",
+            model: "gemini-3-6-flash",
+            content: [
+              {
+                type: "toolCall",
+                id: "call_0",
+                name: "write",
+                arguments: {},
+                thoughtSignature: "SIG-WRITE",
+              },
+            ],
+          },
+        ],
+      } as never,
+      {},
+    );
+
+    const mixedMessages = capturedPayloads[1]!.messages as Array<Record<string, unknown>>;
+    expect(mixedMessages[0]).toMatchObject({
+      role: "assistant",
+      content: expect.stringContaining("[Historical tool call: read("),
+    });
+    expect(mixedMessages[0]).not.toHaveProperty("tool_calls");
+    expect(mixedMessages[1]).toEqual({
+      role: "user",
+      content: "[Historical tool result for read:\nlegacy result]",
+    });
+    expect(mixedMessages[2]).toMatchObject({
+      role: "assistant",
+      tool_calls: [{ id: "call_0", thought_signature: "SIG-WRITE" }],
+    });
+    expect(mixedMessages[3]).toEqual({
+      role: "tool",
+      tool_call_id: "call_0",
+      content: "signed result",
+    });
   });
 
   it("leaves unsigned Gemini 2.5 history unchanged", async () => {

--- a/extensions/venice/index.ts
+++ b/extensions/venice/index.ts
@@ -9,7 +9,7 @@ import { VENICE_MODEL_DISCOVERY_OPTIONS } from "./models.js";
 import { applyVeniceConfig } from "./onboard.js";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 import { buildStaticVeniceProvider } from "./provider-catalog.js";
-import { createVeniceDeepSeekV4Wrapper } from "./stream.js";
+import { createVeniceStreamWrapper } from "./stream.js";
 import { fetchVeniceUsage } from "./usage.js";
 
 const PROVIDER_ID = "venice";
@@ -57,7 +57,7 @@ export default defineSingleProviderPluginEntry({
     },
     normalizeResolvedModel: ({ modelId, model }) =>
       isXaiBackedVeniceModel(modelId) ? applyXaiModelCompat(model) : undefined,
-    wrapStreamFn: (ctx) => createVeniceDeepSeekV4Wrapper(ctx.streamFn, ctx.thinkingLevel),
+    wrapStreamFn: (ctx) => createVeniceStreamWrapper(ctx.streamFn, ctx.thinkingLevel),
     resolveUsageAuth: async (ctx) => {
       const apiKey = ctx.resolveApiKeyFromConfigAndStore({
         envDirect: [ctx.env.VENICE_API_KEY],

--- a/extensions/venice/stream.ts
+++ b/extensions/venice/stream.ts
@@ -17,9 +17,39 @@ function isVeniceGemini3ModelId(modelId: unknown): boolean {
   return typeof modelId === "string" && /^gemini-3(?:[.-]|$)/.test(modelId.trim().toLowerCase());
 }
 
-const GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP = "skip_thought_signature_validator";
+function stringifyHistoricalValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (value === null || value === undefined) {
+    return "";
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
 
-function applyVeniceGeminiThoughtSignatures(
+function describeHistoricalToolCall(toolCall: Record<string, unknown>): {
+  id?: string;
+  name: string;
+  text: string;
+} {
+  const fn =
+    toolCall.function && typeof toolCall.function === "object"
+      ? (toolCall.function as Record<string, unknown>)
+      : {};
+  const name = typeof fn.name === "string" && fn.name.length > 0 ? fn.name : "unknown_tool";
+  const args = stringifyHistoricalValue(fn.arguments) || "{}";
+  return {
+    ...(typeof toolCall.id === "string" ? { id: toolCall.id } : {}),
+    name,
+    text: `[Historical tool call: ${name}(${args})]`,
+  };
+}
+
+function applyVeniceGeminiToolHistoryCompatibility(
   payload: Record<string, unknown>,
   context: Parameters<NonNullable<ProviderWrapStreamFnContext["streamFn"]>>[1],
   model: Parameters<NonNullable<ProviderWrapStreamFnContext["streamFn"]>>[0],
@@ -28,9 +58,7 @@ function applyVeniceGeminiThoughtSignatures(
     return;
   }
   const signaturesByToolCallId = new Map<string, string>();
-  const fallbackSignature = isVeniceGemini3ModelId(model.id)
-    ? GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP
-    : undefined;
+  const requiresUnsignedCallFallback = isVeniceGemini3ModelId(model.id);
   for (const message of context.messages ?? []) {
     if (message.role !== "assistant") {
       continue;
@@ -54,11 +82,12 @@ function applyVeniceGeminiThoughtSignatures(
     }
   }
   if (
-    (signaturesByToolCallId.size === 0 && !fallbackSignature) ||
+    (signaturesByToolCallId.size === 0 && !requiresUnsignedCallFallback) ||
     !Array.isArray(payload.messages)
   ) {
     return;
   }
+  const downgradedToolCalls = new Map<string, string>();
   for (const message of payload.messages) {
     if (!message || typeof message !== "object") {
       continue;
@@ -67,6 +96,8 @@ function applyVeniceGeminiThoughtSignatures(
     if (record.role !== "assistant" || !Array.isArray(record.tool_calls)) {
       continue;
     }
+    let shouldDowngradeBatch = false;
+    const describedCalls: Array<ReturnType<typeof describeHistoricalToolCall>> = [];
     for (const toolCall of record.tool_calls) {
       if (!toolCall || typeof toolCall !== "object") {
         continue;
@@ -78,16 +109,44 @@ function applyVeniceGeminiThoughtSignatures(
           : undefined;
       if (signature) {
         toolCallRecord.thought_signature = signature;
-      } else if (
-        fallbackSignature &&
-        (typeof toolCallRecord.thought_signature !== "string" ||
-          toolCallRecord.thought_signature.length === 0)
-      ) {
-        // Gemini 3 validates every historical function call, including calls
-        // imported from another provider or recorded before signature capture.
-        toolCallRecord.thought_signature = fallbackSignature;
+      } else if (requiresUnsignedCallFallback) {
+        shouldDowngradeBatch = true;
+      }
+      describedCalls.push(describeHistoricalToolCall(toolCallRecord));
+    }
+    if (!shouldDowngradeBatch) {
+      continue;
+    }
+    for (const call of describedCalls) {
+      if (call.id) {
+        downgradedToolCalls.set(call.id, call.name);
       }
     }
+    const existingContent = stringifyHistoricalValue(record.content);
+    record.content = [existingContent, ...describedCalls.map((call) => call.text)]
+      .filter((part) => part.length > 0)
+      .join("\n");
+    delete record.tool_calls;
+  }
+  if (downgradedToolCalls.size === 0) {
+    return;
+  }
+  for (const message of payload.messages) {
+    if (!message || typeof message !== "object") {
+      continue;
+    }
+    const record = message as Record<string, unknown>;
+    const toolCallId = typeof record.tool_call_id === "string" ? record.tool_call_id : undefined;
+    const toolName = toolCallId ? downgradedToolCalls.get(toolCallId) : undefined;
+    if (record.role !== "tool" || !toolName) {
+      continue;
+    }
+    const result = stringifyHistoricalValue(record.content);
+    for (const key of Object.keys(record)) {
+      delete record[key];
+    }
+    record.role = "user";
+    record.content = `[Historical tool result for ${toolName}:\n${result}]`;
   }
 }
 
@@ -106,6 +165,6 @@ export function createVeniceStreamWrapper(
         replaceNullReasoningContent: true,
       });
     }
-    applyVeniceGeminiThoughtSignatures(payload, context, model);
+    applyVeniceGeminiToolHistoryCompatibility(payload, context, model);
   });
 }

--- a/extensions/venice/stream.ts
+++ b/extensions/venice/stream.ts
@@ -112,13 +112,23 @@ function applyVeniceGeminiToolHistoryCompatibility(
     const record = message as Record<string, unknown>;
     if (record.role === "tool") {
       const toolCallId = typeof record.tool_call_id === "string" ? record.tool_call_id : undefined;
-      const toolNames = toolCallId ? pendingDowngradedToolCalls?.get(toolCallId) : undefined;
-      const toolName = toolNames?.shift();
+      if (!toolCallId) {
+        continue;
+      }
+      const pendingCalls = pendingDowngradedToolCalls;
+      if (!pendingCalls) {
+        continue;
+      }
+      const toolNames = pendingCalls.get(toolCallId);
+      if (!toolNames) {
+        continue;
+      }
+      const toolName = toolNames.shift();
       if (!toolName) {
         continue;
       }
       if (toolNames.length === 0) {
-        pendingDowngradedToolCalls?.delete(toolCallId);
+        pendingCalls.delete(toolCallId);
       }
       const result = stringifyHistoricalValue(record.content);
       for (const key of Object.keys(record)) {
@@ -146,7 +156,9 @@ function applyVeniceGeminiToolHistoryCompatibility(
       const historicalCall = historicalBatch?.[toolCallIndex];
       const describedCall = describeHistoricalToolCall(toolCallRecord);
       const signature =
-        historicalCall?.id === toolCallRecord.id && historicalCall.name === describedCall.name
+        historicalCall &&
+        historicalCall.id === toolCallRecord.id &&
+        historicalCall.name === describedCall.name
           ? historicalCall.thoughtSignature
           : undefined;
       if (signature) {

--- a/extensions/venice/stream.ts
+++ b/extensions/venice/stream.ts
@@ -27,7 +27,7 @@ function stringifyHistoricalValue(value: unknown): string {
   try {
     return JSON.stringify(value);
   } catch {
-    return String(value);
+    return "[Unserializable historical value]";
   }
 }
 
@@ -57,69 +57,114 @@ function applyVeniceGeminiToolHistoryCompatibility(
   if (model.provider !== "venice" || !isVeniceGeminiModelId(model.id)) {
     return;
   }
-  const signaturesByToolCallId = new Map<string, string>();
+  const historicalToolCallBatches: Array<
+    Array<{ id: string; name: string; thoughtSignature?: string }>
+  > = [];
+  let hasHistoricalSignature = false;
   const requiresUnsignedCallFallback = isVeniceGemini3ModelId(model.id);
   for (const message of context.messages ?? []) {
-    if (message.role !== "assistant") {
-      continue;
-    }
     if (
-      message.api !== model.api ||
-      message.provider !== model.provider ||
-      message.model !== model.id
+      message.role !== "assistant" ||
+      message.stopReason === "error" ||
+      message.stopReason === "aborted"
     ) {
       continue;
     }
+    const isExactRoute =
+      message.api === model.api &&
+      message.provider === model.provider &&
+      message.model === model.id;
+    const batch: Array<{ id: string; name: string; thoughtSignature?: string }> = [];
     for (const block of message.content) {
-      if (
-        block.type === "toolCall" &&
-        typeof block.id === "string" &&
+      if (block.type !== "toolCall" || typeof block.id !== "string") {
+        continue;
+      }
+      const thoughtSignature =
+        isExactRoute &&
         typeof block.thoughtSignature === "string" &&
         block.thoughtSignature.length > 0
-      ) {
-        signaturesByToolCallId.set(block.id, block.thoughtSignature);
-      }
+          ? block.thoughtSignature
+          : undefined;
+      hasHistoricalSignature ||= thoughtSignature !== undefined;
+      batch.push({
+        id: block.id,
+        name: block.name,
+        ...(thoughtSignature ? { thoughtSignature } : {}),
+      });
+    }
+    if (batch.length > 0) {
+      historicalToolCallBatches.push(batch);
     }
   }
   if (
-    (signaturesByToolCallId.size === 0 && !requiresUnsignedCallFallback) ||
+    (!hasHistoricalSignature && !requiresUnsignedCallFallback) ||
     !Array.isArray(payload.messages)
   ) {
     return;
   }
-  const downgradedToolCalls = new Map<string, string>();
+  let historicalBatchIndex = 0;
+  let pendingDowngradedToolCalls: Map<string, string[]> | undefined;
   for (const message of payload.messages) {
     if (!message || typeof message !== "object") {
+      pendingDowngradedToolCalls = undefined;
       continue;
     }
     const record = message as Record<string, unknown>;
+    if (record.role === "tool") {
+      const toolCallId = typeof record.tool_call_id === "string" ? record.tool_call_id : undefined;
+      const toolNames = toolCallId ? pendingDowngradedToolCalls?.get(toolCallId) : undefined;
+      const toolName = toolNames?.shift();
+      if (!toolName) {
+        continue;
+      }
+      if (toolNames.length === 0) {
+        pendingDowngradedToolCalls?.delete(toolCallId);
+      }
+      const result = stringifyHistoricalValue(record.content);
+      for (const key of Object.keys(record)) {
+        delete record[key];
+      }
+      record.role = "user";
+      record.content = `[Historical tool result for ${toolName}:\n${result}]`;
+      continue;
+    }
+    pendingDowngradedToolCalls = undefined;
     if (record.role !== "assistant" || !Array.isArray(record.tool_calls)) {
       continue;
     }
+
+    // Tool-call ids are provider-local and can be reused on later turns. Match
+    // signature metadata and result rewriting to this assistant occurrence.
+    const historicalBatch = historicalToolCallBatches[historicalBatchIndex++];
     let shouldDowngradeBatch = false;
     const describedCalls: Array<ReturnType<typeof describeHistoricalToolCall>> = [];
-    for (const toolCall of record.tool_calls) {
+    for (const [toolCallIndex, toolCall] of record.tool_calls.entries()) {
       if (!toolCall || typeof toolCall !== "object") {
         continue;
       }
       const toolCallRecord = toolCall as Record<string, unknown>;
+      const historicalCall = historicalBatch?.[toolCallIndex];
+      const describedCall = describeHistoricalToolCall(toolCallRecord);
       const signature =
-        typeof toolCallRecord.id === "string"
-          ? signaturesByToolCallId.get(toolCallRecord.id)
+        historicalCall?.id === toolCallRecord.id && historicalCall.name === describedCall.name
+          ? historicalCall.thoughtSignature
           : undefined;
       if (signature) {
         toolCallRecord.thought_signature = signature;
       } else if (requiresUnsignedCallFallback) {
         shouldDowngradeBatch = true;
       }
-      describedCalls.push(describeHistoricalToolCall(toolCallRecord));
+      describedCalls.push(describedCall);
     }
     if (!shouldDowngradeBatch) {
       continue;
     }
+    pendingDowngradedToolCalls = new Map<string, string[]>();
     for (const call of describedCalls) {
       if (call.id) {
-        downgradedToolCalls.set(call.id, call.name);
+        const names = pendingDowngradedToolCalls.get(call.id) ?? [];
+        names.push(call.name);
+        pendingDowngradedToolCalls.set(call.id, names);
       }
     }
     const existingContent = stringifyHistoricalValue(record.content);
@@ -127,26 +172,6 @@ function applyVeniceGeminiToolHistoryCompatibility(
       .filter((part) => part.length > 0)
       .join("\n");
     delete record.tool_calls;
-  }
-  if (downgradedToolCalls.size === 0) {
-    return;
-  }
-  for (const message of payload.messages) {
-    if (!message || typeof message !== "object") {
-      continue;
-    }
-    const record = message as Record<string, unknown>;
-    const toolCallId = typeof record.tool_call_id === "string" ? record.tool_call_id : undefined;
-    const toolName = toolCallId ? downgradedToolCalls.get(toolCallId) : undefined;
-    if (record.role !== "tool" || !toolName) {
-      continue;
-    }
-    const result = stringifyHistoricalValue(record.content);
-    for (const key of Object.keys(record)) {
-      delete record[key];
-    }
-    record.role = "user";
-    record.content = `[Historical tool result for ${toolName}:\n${result}]`;
   }
 }
 

--- a/extensions/venice/stream.ts
+++ b/extensions/venice/stream.ts
@@ -13,7 +13,13 @@ function isVeniceGeminiModelId(modelId: unknown): boolean {
   return typeof modelId === "string" && modelId.trim().toLowerCase().startsWith("gemini-");
 }
 
-function replayVeniceGeminiThoughtSignatures(
+function isVeniceGemini3ModelId(modelId: unknown): boolean {
+  return typeof modelId === "string" && /^gemini-3(?:[.-]|$)/.test(modelId.trim().toLowerCase());
+}
+
+const GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP = "skip_thought_signature_validator";
+
+function applyVeniceGeminiThoughtSignatures(
   payload: Record<string, unknown>,
   context: Parameters<NonNullable<ProviderWrapStreamFnContext["streamFn"]>>[1],
   model: Parameters<NonNullable<ProviderWrapStreamFnContext["streamFn"]>>[0],
@@ -22,6 +28,9 @@ function replayVeniceGeminiThoughtSignatures(
     return;
   }
   const signaturesByToolCallId = new Map<string, string>();
+  const fallbackSignature = isVeniceGemini3ModelId(model.id)
+    ? GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP
+    : undefined;
   for (const message of context.messages ?? []) {
     if (message.role !== "assistant") {
       continue;
@@ -44,7 +53,10 @@ function replayVeniceGeminiThoughtSignatures(
       }
     }
   }
-  if (signaturesByToolCallId.size === 0 || !Array.isArray(payload.messages)) {
+  if (
+    (signaturesByToolCallId.size === 0 && !fallbackSignature) ||
+    !Array.isArray(payload.messages)
+  ) {
     return;
   }
   for (const message of payload.messages) {
@@ -66,6 +78,14 @@ function replayVeniceGeminiThoughtSignatures(
           : undefined;
       if (signature) {
         toolCallRecord.thought_signature = signature;
+      } else if (
+        fallbackSignature &&
+        (typeof toolCallRecord.thought_signature !== "string" ||
+          toolCallRecord.thought_signature.length === 0)
+      ) {
+        // Gemini 3 validates every historical function call, including calls
+        // imported from another provider or recorded before signature capture.
+        toolCallRecord.thought_signature = fallbackSignature;
       }
     }
   }
@@ -86,6 +106,6 @@ export function createVeniceStreamWrapper(
         replaceNullReasoningContent: true,
       });
     }
-    replayVeniceGeminiThoughtSignatures(payload, context, model);
+    applyVeniceGeminiThoughtSignatures(payload, context, model);
   });
 }

--- a/extensions/venice/stream.ts
+++ b/extensions/venice/stream.ts
@@ -9,12 +9,74 @@ function isVeniceDeepSeekV4ModelId(modelId: unknown): boolean {
   return modelId === "deepseek-v4-flash" || modelId === "deepseek-v4-pro";
 }
 
-export function createVeniceDeepSeekV4Wrapper(
+function isVeniceGeminiModelId(modelId: unknown): boolean {
+  return typeof modelId === "string" && modelId.trim().toLowerCase().startsWith("gemini-");
+}
+
+function replayVeniceGeminiThoughtSignatures(
+  payload: Record<string, unknown>,
+  context: Parameters<NonNullable<ProviderWrapStreamFnContext["streamFn"]>>[1],
+  model: Parameters<NonNullable<ProviderWrapStreamFnContext["streamFn"]>>[0],
+): void {
+  if (model.provider !== "venice" || !isVeniceGeminiModelId(model.id)) {
+    return;
+  }
+  const signaturesByToolCallId = new Map<string, string>();
+  for (const message of context.messages ?? []) {
+    if (message.role !== "assistant") {
+      continue;
+    }
+    if (
+      message.api !== model.api ||
+      message.provider !== model.provider ||
+      message.model !== model.id
+    ) {
+      continue;
+    }
+    for (const block of message.content) {
+      if (
+        block.type === "toolCall" &&
+        typeof block.id === "string" &&
+        typeof block.thoughtSignature === "string" &&
+        block.thoughtSignature.length > 0
+      ) {
+        signaturesByToolCallId.set(block.id, block.thoughtSignature);
+      }
+    }
+  }
+  if (signaturesByToolCallId.size === 0 || !Array.isArray(payload.messages)) {
+    return;
+  }
+  for (const message of payload.messages) {
+    if (!message || typeof message !== "object") {
+      continue;
+    }
+    const record = message as Record<string, unknown>;
+    if (record.role !== "assistant" || !Array.isArray(record.tool_calls)) {
+      continue;
+    }
+    for (const toolCall of record.tool_calls) {
+      if (!toolCall || typeof toolCall !== "object") {
+        continue;
+      }
+      const toolCallRecord = toolCall as Record<string, unknown>;
+      const signature =
+        typeof toolCallRecord.id === "string"
+          ? signaturesByToolCallId.get(toolCallRecord.id)
+          : undefined;
+      if (signature) {
+        toolCallRecord.thought_signature = signature;
+      }
+    }
+  }
+}
+
+export function createVeniceStreamWrapper(
   baseStreamFn: ProviderWrapStreamFnContext["streamFn"],
   thinkingLevel: ProviderWrapStreamFnContext["thinkingLevel"],
 ): ProviderWrapStreamFnContext["streamFn"] {
   void thinkingLevel;
-  return createPayloadPatchStreamWrapper(baseStreamFn, ({ payload, model }) => {
+  return createPayloadPatchStreamWrapper(baseStreamFn, ({ payload, context, model }) => {
     if (model.provider === "venice" && isVeniceDeepSeekV4ModelId(model.id)) {
       delete payload.thinking;
       delete payload.reasoning;
@@ -24,5 +86,6 @@ export function createVeniceDeepSeekV4Wrapper(
         replaceNullReasoningContent: true,
       });
     }
+    replayVeniceGeminiThoughtSignatures(payload, context, model);
   });
 }

--- a/packages/ai/src/transports/openai-completions-transport.ts
+++ b/packages/ai/src/transports/openai-completions-transport.ts
@@ -772,7 +772,7 @@ async function processOpenAICompletionsStream(
               currentBlock = null;
               flushPendingPostToolCallDeltas();
             }
-            const initialSig = extractGoogleThoughtSignature(toolCall);
+            const initialSig = extractToolCallThoughtSignature(toolCall);
             block = {
               type: "toolCall",
               id: toolCall.id || "",
@@ -800,7 +800,7 @@ async function processOpenAICompletionsStream(
           if (toolCall.function?.name) {
             block.name = toolCall.function.name;
           }
-          const deltaSig = extractGoogleThoughtSignature(toolCall);
+          const deltaSig = extractToolCallThoughtSignature(toolCall);
           if (deltaSig) {
             block.thoughtSignature = deltaSig;
           }
@@ -1557,7 +1557,7 @@ function convertTools(
   };
 }
 
-function extractGoogleThoughtSignature(toolCall: unknown): string | undefined {
+function extractToolCallThoughtSignature(toolCall: unknown): string | undefined {
   const tc = toolCall as Record<string, unknown> | undefined;
   if (!tc) {
     return undefined;
@@ -1571,7 +1571,11 @@ function extractGoogleThoughtSignature(toolCall: unknown): string | undefined {
   }
   const fromFunction = (tc.function as { thought_signature?: unknown } | undefined)
     ?.thought_signature;
-  return typeof fromFunction === "string" && fromFunction.length > 0 ? fromFunction : undefined;
+  if (typeof fromFunction === "string" && fromFunction.length > 0) {
+    return fromFunction;
+  }
+  const fromToolCall = tc.thought_signature;
+  return typeof fromToolCall === "string" && fromToolCall.length > 0 ? fromToolCall : undefined;
 }
 
 function isGoogleOpenAICompatModel(model: OpenAIModeModel): boolean {

--- a/src/agents/openai-transport-stream.usage-and-calls.test.ts
+++ b/src/agents/openai-transport-stream.usage-and-calls.test.ts
@@ -777,6 +777,48 @@ describe("openai transport stream", () => {
       });
     });
 
+    it("captures a top-level thought_signature from streamed OpenAI-compatible tool_calls", async () => {
+      const veniceGeminiModel = makeCompletionsModel({
+        id: "gemini-3-6-flash",
+        name: "Gemini 3.6 Flash",
+        provider: "venice",
+        baseUrl: "https://api.venice.ai/api/v1",
+        contextWindow: 1_000_000,
+      });
+      const output = createAssistantOutput(veniceGeminiModel);
+      const chunks = [
+        makeCompletionsChunk({
+          tool_calls: [
+            {
+              index: 0,
+              id: "call_abc",
+              type: "function",
+              function: { name: "echo_value", arguments: '{"value":"repro"}' },
+              thought_signature: "SIG-VENICE-OPAQUE-ABC==",
+            },
+          ],
+        }),
+        makeCompletionsChunk({}, "tool_calls" as const),
+      ] as const;
+      async function* mockStream() {
+        for (const chunk of chunks) {
+          yield chunk as never;
+        }
+      }
+
+      await testing.processOpenAICompletionsStream(mockStream(), output, veniceGeminiModel, {
+        push() {},
+      });
+
+      expectRecordFields(output.content[0], {
+        type: "toolCall",
+        id: "call_abc",
+        name: "echo_value",
+        arguments: { value: "repro" },
+        thoughtSignature: "SIG-VENICE-OPAQUE-ABC==",
+      });
+    });
+
     it("re-emits captured thought_signature for same Google route tool-call replay", () => {
       const params = buildOpenAICompletionsParams(
         geminiModel,

--- a/src/agents/transcript-redact.test.ts
+++ b/src/agents/transcript-redact.test.ts
@@ -686,6 +686,21 @@ describe("redactTranscriptMessage", () => {
         },
       ],
     } as unknown as AgentMessage;
+    const veniceGeminiMsg = {
+      role: "assistant",
+      api: "openai-completions",
+      model: "gemini-3-6-flash",
+      provider: "venice",
+      content: [
+        {
+          type: "toolCall",
+          id: "call_venice",
+          name: "send_request",
+          arguments: {},
+          thoughtSignature: OPENAI_COMPAT_OPAQUE_COLLISION,
+        },
+      ],
+    } as unknown as AgentMessage;
     const openAIResponsesMsg = {
       role: "assistant",
       api: "openai-responses",
@@ -753,6 +768,16 @@ describe("redactTranscriptMessage", () => {
       "( msgContent(redactTranscriptMessage(googleOpenAICompletionsMsg, goog... test invariant",
     );
     expect(googleCompletionsBlock.thoughtSignature).toBe(OPENAI_COMPAT_OPAQUE_COLLISION);
+
+    const veniceGeminiBlock = expectDefined(
+      (
+        msgContent(redactTranscriptMessage(veniceGeminiMsg, cfg("tools"))) as Array<{
+          thoughtSignature: string;
+        }>
+      )[0],
+      "Venice Gemini tool-call block",
+    );
+    expect(veniceGeminiBlock.thoughtSignature).toBe(OPENAI_COMPAT_OPAQUE_COLLISION);
 
     const responsesBlock = expectDefined(
       (

--- a/src/agents/transcript-redact.ts
+++ b/src/agents/transcript-redact.ts
@@ -129,6 +129,17 @@ function isGoogleOpenAICompletionsRoute(route: TranscriptAssistantRoute | undefi
   );
 }
 
+function isVeniceGeminiOpenAICompletionsRoute(
+  route: TranscriptAssistantRoute | undefined,
+): boolean {
+  return (
+    isOpenAICompletionsRoute(route) &&
+    route?.provider === "venice" &&
+    typeof route.model === "string" &&
+    /(?:^|\/)gemini-/.test(route.model.trim().toLowerCase())
+  );
+}
+
 function isCustomProviderRoute(route: TranscriptAssistantRoute | undefined): boolean {
   return (
     Boolean(route?.api && route.model && route.provider) &&
@@ -330,7 +341,11 @@ function shouldPreserveOpaqueProviderPayload(
   if (isGoogleReasoningRoute(route) && isGoogleSlot) {
     return isGoogleThoughtSignature(item);
   }
-  if (isGoogleOpenAICompletionsRoute(route) && type === "toolCall" && key === "thoughtSignature") {
+  if (
+    (isGoogleOpenAICompletionsRoute(route) || isVeniceGeminiOpenAICompletionsRoute(route)) &&
+    type === "toolCall" &&
+    key === "thoughtSignature"
+  ) {
     // The OpenAI-compatible transport captures provider-owned opaque signatures
     // such as SIG-OPAQUE-ABC==; native Google routes require standard base64.
     return isStructurallyValidOpaqueReplayToken(item);


### PR DESCRIPTION
Closes #119591

## What Problem This Solves

Fixes an issue where users selecting a Gemini model through Venice could chat normally, but the agent turn failed with HTTP 400 immediately after any OpenClaw tool completed.

## Why This Change Was Made

Venice currently emits Gemini tool-call `thought_signature` values as a top-level field on each OpenAI-compatible tool call and requires the exact opaque value on the continuation request. The generic completions transport now retains that returned shape, while the Venice provider wrapper replays it only for same-route Gemini turns; existing Google nested-signature and cross-route behavior is unchanged.

## User Impact

Venice Gemini users can complete browsing and other tool-using turns instead of receiving a generic processing error after the tool runs. Other Venice models and other OpenAI-compatible providers are unaffected.

## Evidence

- Before fix, a live `venice/gemini-3-6-flash` tool turn completed the tool and the continuation failed with HTTP 400 for missing `thought_signature`.
- A direct two-request Venice API probe reproduced the contract: missing replay failed with HTTP 400; replaying the exact returned top-level signature succeeded with HTTP 200 and the expected answer.
- After the patch was applied to a build of the installed 2026.7.1-2 release, an isolated OpenClaw turn at `thinking=high` called the `read` tool and completed successfully: both Venice requests returned HTTP 200, `toolSummary.calls=1`, `failures=0`, and the final answer was `openclaw`.
- `node scripts/run-vitest.mjs src/agents/openai-transport-stream.usage-and-calls.test.ts` (45 passed)
- `pnpm exec vitest run --config test/vitest/vitest.full-extensions.config.ts extensions/venice/index.test.ts` (4 passed)
- `pnpm check`
- `pnpm build`
- `git diff --check`

AI assistance: Codex was used to trace the transport path, implement the focused change, and draft tests/PR text. The behavior and API contract were independently verified with the live Venice endpoint; all changed code was reviewed and the commands above were run locally.