### PR TITLE
fix: remove bodyless 400/413 from overflow patterns to prevent false compaction

### DIFF
--- a/packages/ai/src/utils/overflow.test.ts
+++ b/packages/ai/src/utils/overflow.test.ts
@@ -64,6 +64,16 @@ describe("provider overflow messages", () => {
   });
 });
 
+describe("bodyless HTTP errors", () => {
+  it("does not treat an ambiguous 400 as context overflow", () => {
+    expect(isContextOverflow(errorMessage("400 status code (no body)"), 262_144)).toBe(false);
+  });
+
+  it("preserves Cerebras 413 overflow recovery", () => {
+    expect(isContextOverflow(errorMessage("413 status code (no body)"), 262_144)).toBe(true);
+  });
+});
+
 describe("usage-based overflow", () => {
   it("prefers an available context snapshot over aggregate billing usage", () => {
     expect(

--- a/packages/ai/src/utils/overflow.ts
+++ b/packages/ai/src/utils/overflow.ts
@@ -31,6 +31,7 @@ export function isConfiguredContextSizeOverflowError(errorMessage: string): bool
  * - GitHub Copilot: "prompt token count of X exceeds the limit of Y"
  * - MiniMax: "invalid params, context window exceeds limit"
  * - Kimi For Coding: "Your request exceeded model token limit: X (requested: Y)"
+ * - Cerebras: "413 status code (no body)"
  * - Mistral: "Prompt contains X tokens ... too large for model with Y maximum context length"
  * - z.ai: May return "tokens in request more than max tokens allowed" (code 1210),
  *   "Prompt exceeds max length" (code 1261), or accept overflow silently; handled via the
@@ -66,6 +67,7 @@ const OVERFLOW_PATTERNS = [
   /context[_ ]length[_ ]exceeded/i, // Generic fallback
   /too many tokens/i, // Generic fallback
   /token limit exceeded/i, // Generic fallback
+  /^413\s*(?:status code)?\s*\(no body\)/i, // Cerebras: 413 with no body
 ];
 
 /**
@@ -113,7 +115,7 @@ function resolveContextInputTokens(message: AssistantMessage): number | undefine
  * - Google Gemini: "input token count exceeds the maximum"
  * - xAI (Grok): "maximum prompt length is X but request contains Y"
  * - Groq: "reduce the length of the messages"
- * - Cerebras: 400/413 status code (no body)
+ * - Cerebras: 413 status code (no body)
  * - Mistral: "Prompt contains X tokens ... too large for model with Y maximum context length"
  * - OpenRouter (all backends): "maximum context length is X tokens"
  * - Together AI: "The input (X tokens) is longer than the model's context length (Y tokens)."

--- a/packages/ai/src/utils/overflow.ts
+++ b/packages/ai/src/utils/overflow.ts
@@ -31,7 +31,6 @@ export function isConfiguredContextSizeOverflowError(errorMessage: string): bool
  * - GitHub Copilot: "prompt token count of X exceeds the limit of Y"
  * - MiniMax: "invalid params, context window exceeds limit"
  * - Kimi For Coding: "Your request exceeded model token limit: X (requested: Y)"
- * - Cerebras: "400/413 status code (no body)"
  * - Mistral: "Prompt contains X tokens ... too large for model with Y maximum context length"
  * - z.ai: May return "tokens in request more than max tokens allowed" (code 1210),
  *   "Prompt exceeds max length" (code 1261), or accept overflow silently; handled via the
@@ -67,7 +66,6 @@ const OVERFLOW_PATTERNS = [
   /context[_ ]length[_ ]exceeded/i, // Generic fallback
   /too many tokens/i, // Generic fallback
   /token limit exceeded/i, // Generic fallback
-  /^4(?:00|13)\s*(?:status code)?\s*\(no body\)/i, // Cerebras: 400/413 with no body
 ];
 
 /**

--- a/src/agents/embedded-agent-runner/run.overflow-context-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-context-recovery.test.ts
@@ -201,6 +201,32 @@ describe("recoverEmbeddedRunOverflow", () => {
     expect(mocks.warn).toHaveBeenCalledWith(expect.stringContaining("source=assistantError"));
   });
 
+  it("does not compact after an ambiguous bodyless 400", async () => {
+    const assistantOverflowCandidate = makeAssistantMessage({
+      stopReason: "error",
+      errorMessage: "400 status code (no body)",
+    });
+    const result = await recoverEmbeddedRunOverflow(
+      makeInput({ promptError: null, assistantOverflowCandidate }),
+    );
+
+    expect(result).toEqual({ action: "none" });
+    expect(mocks.compact).not.toHaveBeenCalled();
+  });
+
+  it("preserves compaction recovery after a bodyless 413", async () => {
+    const assistantOverflowCandidate = makeAssistantMessage({
+      stopReason: "error",
+      errorMessage: "413 status code (no body)",
+    });
+    const result = await recoverEmbeddedRunOverflow(
+      makeInput({ promptError: null, assistantOverflowCandidate }),
+    );
+
+    expect(result).toEqual({ action: "retry" });
+    expect(mocks.compact).toHaveBeenCalledOnce();
+  });
+
   it("recovers a canonical zero-output length overflow", async () => {
     const assistantOverflowCandidate = makeAssistantMessage({
       stopReason: "length",


### PR DESCRIPTION
Closes #119595

## What Problem This Solves

Bodyless HTTP 400 responses are ambiguous, but OpenClaw classified them as context overflow. In the embedded runner that false classification triggers compaction and retry, wasting time and tokens without addressing the provider error.

Bodyless HTTP 413 is different: Cerebras uses `413 status code (no body)` as an overflow signal. The repaired change therefore removes only bodyless 400 from overflow classification and preserves the established 413 recovery path.

## Root Cause and Fix

`packages/ai/src/utils/overflow.ts` used one pattern for both statuses:

```text
^4(?:00|13) ... (no body)
```

That collapsed two different HTTP semantics into one compaction decision. The fix narrows the pattern to 413, keeps descriptive 400 overflow messages covered by the existing provider-specific patterns, and adds regression tests at both the classifier and embedded-runner recovery boundaries.

## User Impact

- `400 status code (no body)` now surfaces normally instead of compacting and retrying.
- `413 status code (no body)` still triggers context-overflow compaction for Cerebras.
- Descriptive 400 overflow errors with provider error text remain recognized by their existing patterns.

## Evidence

Sanitized AWS proof on the repaired tree:

- `pnpm test packages/ai/src/utils/overflow.test.ts src/agents/embedded-agent-runner/run.overflow-context-recovery.test.ts -- --reporter=verbose`
- 2 test files passed, 37 tests passed.
- Focused formatting check passed for all three changed files.
- Fresh autoreview reported no actionable findings and judged the patch correct.

The embedded-runner tests directly prove that bodyless 400 returns `action: "none"` without calling compaction, while bodyless 413 returns `action: "retry"` and calls compaction once.

## Provenance

The combined 400/413 matcher was carried into OpenClaw by #85341 and remained in the canonical overflow classifier. #67024 corrected a related failover-classification path, but not this compaction trigger. Related reports: #66462, #74239, and #119595.

AI-assisted; repaired and validated by maintainers while preserving the contributor's original diagnosis and credit.
