### PR TITLE
fix(msteams): don't await body cancel on teed capture branches (#119514)

### DIFF
--- a/extensions/msteams/src/attachments/bot-framework.ts
+++ b/extensions/msteams/src/attachments/bot-framework.ts
@@ -113,7 +113,7 @@ async function fetchBotFrameworkAttachmentInfo(params: {
     return undefined;
   }
   if (!response.ok) {
-    await response.body?.cancel().catch(() => undefined);
+    void response.body?.cancel().catch(() => undefined); // Awaiting capture tees can deadlock.
     params.logger?.warn?.("msteams botFramework attachmentInfo non-ok", {
       status: response.status,
     });
@@ -173,7 +173,7 @@ async function saveBotFrameworkAttachmentView(params: {
     return undefined;
   }
   if (!response.ok) {
-    await response.body?.cancel().catch(() => undefined);
+    void response.body?.cancel().catch(() => undefined); // Awaiting capture tees can deadlock.
     params.logger?.warn?.("msteams botFramework attachmentView non-ok", {
       status: response.status,
     });
@@ -183,14 +183,14 @@ async function saveBotFrameworkAttachmentView(params: {
   try {
     contentLength = parseMediaContentLength(response.headers.get("content-length"));
   } catch (err) {
-    await response.body?.cancel().catch(() => undefined);
+    void response.body?.cancel().catch(() => undefined); // Awaiting capture tees can deadlock.
     params.logger?.warn?.("msteams botFramework attachmentView invalid content-length", {
       error: err instanceof Error ? err.message : String(err),
     });
     return undefined;
   }
   if (contentLength !== null && contentLength > params.maxBytes) {
-    await response.body?.cancel().catch(() => undefined);
+    void response.body?.cancel().catch(() => undefined); // Awaiting capture tees can deadlock.
     return undefined;
   }
   try {
@@ -208,7 +208,7 @@ async function saveBotFrameworkAttachmentView(params: {
     });
     return undefined;
   } finally {
-    await response.body?.cancel().catch(() => undefined);
+    void response.body?.cancel().catch(() => undefined); // Awaiting capture tees can deadlock.
   }
 }
 

--- a/extensions/msteams/src/attachments/download.ts
+++ b/extensions/msteams/src/attachments/download.ts
@@ -199,7 +199,7 @@ async function fetchWithAuthFallback(params: {
         resolveFn: params.resolveFn,
         timeoutMs: resolveMSTeamsRequestTimeoutMs(params.deadline),
       });
-      await fallbackAttempt.body?.cancel().catch(() => undefined);
+      void fallbackAttempt.body?.cancel().catch(() => undefined); // Awaiting capture tees can deadlock.
       if (authAttempt.ok || isRedirectStatus(authAttempt.status)) {
         // Redirects in guarded fetch mode must propagate to the outer guard.
         return authAttempt;

--- a/extensions/msteams/src/attachments/remote-media.ts
+++ b/extensions/msteams/src/attachments/remote-media.ts
@@ -32,7 +32,7 @@ async function saveRemoteMediaDirect(params: {
   } finally {
     // Guarded responses release their pinned dispatcher on EOF or cancel. A
     // storage failure can happen before the body is read, so always cancel it.
-    await response.body?.cancel().catch(() => undefined);
+    void response.body?.cancel().catch(() => undefined); // Awaiting capture tees can deadlock.
   }
 }
 

--- a/extensions/msteams/src/file-consent.ts
+++ b/extensions/msteams/src/file-consent.ts
@@ -227,7 +227,7 @@ export async function uploadToConsentUrl(params: {
 
   // Consent uploads never consume the response payload. Cancel it on every
   // status so the fetch implementation can release the underlying connection.
-  await res.body?.cancel().catch(() => undefined);
+  void res.body?.cancel().catch(() => undefined); // Awaiting capture tees can deadlock.
   if (!res.ok) {
     throw new Error(`File upload to consent URL failed: ${res.status} ${res.statusText}`);
   }

--- a/extensions/msteams/src/graph.test.ts
+++ b/extensions/msteams/src/graph.test.ts
@@ -421,7 +421,12 @@ describe("msteams graph helpers", () => {
     });
 
     expect(upstreamCancel).toHaveBeenCalledTimes(1);
-    expect(release).toHaveBeenCalledTimes(1);
+    // The body cancel is fire-and-forget (awaiting a tee branch's cancel can
+    // deadlock under debug capture), so the dispatcher release lands on a
+    // later microtask rather than before deleteGraphRequest settles.
+    await vi.waitFor(() => {
+      expect(release).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("resolves Graph tokens through the SDK auth provider", async () => {

--- a/extensions/msteams/src/graph.ts
+++ b/extensions/msteams/src/graph.ts
@@ -287,7 +287,7 @@ export async function deleteGraphRequest(params: { token: string; path: string }
     method: "DELETE",
     errorPrefix: "Graph DELETE",
   });
-  await response.body?.cancel().catch(() => undefined);
+  void response.body?.cancel().catch(() => undefined); // Awaiting capture tees can deadlock.
 }
 
 export async function listChannelsForTeam(token: string, teamId: string): Promise<GraphChannel[]> {


### PR DESCRIPTION
## What Problem This Solves

With the debug proxy capture enabled, `installDebugProxyGlobalFetchPatch` tees every outbound response via `Response.clone()`. Nine discard paths in the MS Teams extension still `await response.body?.cancel()`. Per WHATWG streams, cancelling one branch of a tee settles only once **both** branches cancel or the source reaches EOF — so when the remote sends headers plus a partial body and then stalls (under the capture cap), the awaited cancel never settles. The affected paths then hang: a rejected consent upload never reports its HTTP status, attachment auth-retry loops never advance, and the guarded dispatcher stays pinned behind the pending cancellation (`still-pending-at-deadline` after 3000 ms, 3/3 in the captured run).

## Why

The same invariant was already fixed for `attachments/graph.ts` in #117664 ("Awaiting capture tees can deadlock.") and for other providers in #119257. This change closes the remaining nine sites in `extensions/msteams`: `bot-framework.ts` (5), `file-consent.ts` (1), `remote-media.ts` (1), `attachments/download.ts` (1), and `graph.ts` `deleteGraphRequest` (1 — its cancel flows through `responseWithRelease`, whose cancel handler awaits `reader.cancel()` on the tee branch, so it hangs identically). Body cancel here is connection cleanup only — nothing downstream depends on the cancel promise settling, so it is safe to fire-and-forget.

## User Impact

Operators running the msteams channel with debug proxy capture enabled no longer see uploads/attachments silently stall on under-cap stalled responses. Rejected consent uploads surface their HTTP status, attachment auth retries advance, and guarded dispatchers release — restoring the exact behavior observed when the same responses reach EOF (`consent-upload-rejected-complete-body` throws `File upload to consent URL failed: 403 Forbidden`).

## Evidence

- All 9 production sites converted from `await X.body?.cancel()` to `void X.body?.cancel().catch(() => undefined)` with the established repo-wide comment `// Awaiting capture tees can deadlock.` — the same pattern already shipped in `extensions/msteams/src/attachments/graph.ts:104` and across azure-speech/openai/ollama/google/byteplus/gradium providers. `grep -rn "await .*body?.cancel()" extensions/msteams/src` now matches only test helpers (plain mocked responses, where awaiting is fine).
- The capture pipeline itself documents the invariant (`src/proxy-capture/runtime.ts:41-46`): cancelling one branch of a `Response.clone()` tee "never settles (it only resolves once BOTH branches cancel)", which is why it cancels fire-and-forget there too.
- Tests: `attachments.test.ts` (23), `file-consent.test.ts` (81), `attachments.graph.test.ts` (6), `graph.test.ts` (26) — 136/136 pass on upstream `main` (80da61668). `graph.test.ts` "releases a successful bodyful DELETE response" was updated to `vi.waitFor` the dispatcher release, since the fire-and-forget cancel now lands on a later microtask; the cancel and release guarantees it asserts are unchanged.
- Lint: oxlint 0 warnings/0 errors on all changed files.

[AI-assisted]
