### PR TITLE
fix(acp): pass configured agent model to ACP session runtime (#119551)

### DIFF
--- a/src/acp/persistent-bindings.lifecycle.test.ts
+++ b/src/acp/persistent-bindings.lifecycle.test.ts
@@ -59,6 +59,7 @@ function createPersistentSpec(
 function mockReadySession(params: {
   spec: ConfiguredAcpBindingSpec;
   cwd: string;
+  model?: string;
   state?: "idle" | "running" | "error";
 }) {
   const sessionKey = buildConfiguredAcpSessionKey(params.spec);
@@ -70,7 +71,10 @@ function mockReadySession(params: {
       agent: params.spec.acpAgentId ?? params.spec.agentId,
       runtimeSessionName: "existing",
       mode: params.spec.mode,
-      runtimeOptions: { cwd: params.cwd },
+      runtimeOptions: {
+        cwd: params.cwd,
+        ...(params.model ? { model: params.model } : {}),
+      },
       state: params.state ?? "idle",
       lastActivityAt: Date.now(),
     },
@@ -170,5 +174,93 @@ describe("ensureConfiguredAcpBindingSession", () => {
     expect(ensured.ok).toBe(true);
     const initializeArgs = expectInitializeArgs();
     expect(initializeArgs.agent).toBe("codex");
+  });
+
+  it("passes the agent's explicit model as runtimeOptions.model when initializing", async () => {
+    const spec = createPersistentSpec();
+    managerMocks.resolveSession.mockReturnValue({ kind: "none" });
+    const cfg = {
+      ...baseCfg,
+      agents: {
+        list: [{ id: "codex", model: { primary: "deepseek/deepseek-v4-pro" } }, { id: "claude" }],
+      },
+    } satisfies OpenClawConfig;
+
+    const ensured = await ensureConfiguredAcpBindingSession({
+      cfg,
+      spec,
+    });
+
+    expect(ensured.ok).toBe(true);
+    const initializeArgs = expectInitializeArgs();
+    expect(initializeArgs.runtimeOptions).toEqual({
+      model: "deepseek/deepseek-v4-pro",
+    });
+  });
+
+  it("does not set runtimeOptions.model when the agent has no explicit model config", async () => {
+    const spec = createPersistentSpec();
+    managerMocks.resolveSession.mockReturnValue({ kind: "none" });
+
+    const ensured = await ensureConfiguredAcpBindingSession({
+      cfg: baseCfg,
+      spec,
+    });
+
+    expect(ensured.ok).toBe(true);
+    const initializeArgs = expectInitializeArgs();
+    expect(initializeArgs.runtimeOptions).toBeUndefined();
+  });
+
+  it("keeps a ready session whose runtime model matches the configured explicit model", async () => {
+    const spec = createPersistentSpec();
+    const sessionKey = mockReadySession({
+      spec,
+      cwd: "/workspace/openclaw",
+      model: "deepseek/deepseek-v4-pro",
+    });
+    const cfg = {
+      ...baseCfg,
+      agents: {
+        list: [{ id: "codex", model: { primary: "deepseek/deepseek-v4-pro" } }, { id: "claude" }],
+      },
+    } satisfies OpenClawConfig;
+
+    const ensured = await ensureConfiguredAcpBindingSession({
+      cfg,
+      spec,
+    });
+
+    expect(ensured).toEqual({ ok: true, sessionKey });
+    expect(managerMocks.closeSession).not.toHaveBeenCalled();
+    expect(managerMocks.initializeSession).not.toHaveBeenCalled();
+  });
+
+  it("reinitializes a ready session when the configured explicit model differs from the runtime model", async () => {
+    const spec = createPersistentSpec();
+    const sessionKey = mockReadySession({
+      spec,
+      cwd: "/workspace/openclaw",
+      model: "mimo-v2.5-pro",
+    });
+    const cfg = {
+      ...baseCfg,
+      agents: {
+        list: [{ id: "codex", model: { primary: "deepseek/deepseek-v4-pro" } }, { id: "claude" }],
+      },
+    } satisfies OpenClawConfig;
+
+    const ensured = await ensureConfiguredAcpBindingSession({
+      cfg,
+      spec,
+    });
+
+    expect(ensured).toEqual({ ok: true, sessionKey });
+    const closeArgs = expectCloseArgs();
+    expect(closeArgs.sessionKey).toBe(sessionKey);
+    const initializeArgs = expectInitializeArgs();
+    expect(initializeArgs.runtimeOptions).toEqual({
+      model: "deepseek/deepseek-v4-pro",
+    });
   });
 });

--- a/src/acp/persistent-bindings.lifecycle.ts
+++ b/src/acp/persistent-bindings.lifecycle.ts
@@ -1,5 +1,6 @@
 /** Ensures configured channel-to-ACP bindings have live sessions and matching runtime options. */
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { resolveAgentExplicitModelPrimary } from "../agents/agent-scope.js";
 import type { SessionAcpMeta } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { logVerbose } from "../globals.js";
@@ -50,6 +51,16 @@ function sessionMatchesConfiguredBinding(params: {
       return false;
     }
   }
+
+  const desiredModel = normalizeText(
+    resolveAgentExplicitModelPrimary(params.cfg, params.spec.acpAgentId ?? params.spec.agentId),
+  );
+  if (desiredModel !== undefined) {
+    const currentModel = (params.meta.runtimeOptions?.model ?? "").trim();
+    if (desiredModel !== currentModel) {
+      return false;
+    }
+  }
   return true;
 }
 
@@ -90,13 +101,16 @@ export async function ensureConfiguredAcpBindingSession(params: {
       });
     }
 
+    const agentId = params.spec.acpAgentId ?? params.spec.agentId;
+    const configuredModel = resolveAgentExplicitModelPrimary(params.cfg, agentId);
     await acpManager.initializeSession({
       cfg: params.cfg,
       sessionKey,
-      agent: params.spec.acpAgentId ?? params.spec.agentId,
+      agent: agentId,
       mode: params.spec.mode,
       cwd: params.spec.cwd,
       backendId: params.spec.backend,
+      ...(configuredModel ? { runtimeOptions: { model: configuredModel } } : {}),
     });
 
     return {


### PR DESCRIPTION
## What Problem This Solves

When a channel-to-ACP binding (`openclaw.json` → `agents.list[].runtime.type = "acp"`) configures an explicit agent model, that model is never passed to the ACP session. `ensureConfiguredAcpBindingSession()` calls `acpManager.initializeSession()` without `runtimeOptions`, so the child process inherits `ANTHROPIC_MODEL` from the gateway environment, which overrides the agent's own model config. The configured `model.primary` is silently ignored and the wrong (often more expensive/slower) model serves the conversation.

## Why

`initializeSession()` already supports `runtimeOptions.model` end-to-end: it flows into `runtime.ensureSession({ model })`, which issues `setSessionModel` over the ACP protocol and persists the effective model in `SessionAcpMeta.runtimeOptions`. The configured-binding lifecycle was simply not passing it. `resolveAgentExplicitModelPrimary()` (not the effective variant) is used deliberately so agents **without** an explicit model config keep today's behavior (no `runtimeOptions.model`, env/default resolution untouched). The binding match check now also compares the desired explicit model against the live session's `runtimeOptions.model`, so a config model change recreates the session instead of silently keeping a stale one — matching how the same matcher already treats `cwd` and `backend`.

## User Impact

Operators running ACP agents (e.g. OpenCode via `acpx`) with a per-agent model in `openclaw.json` now get that model honored instead of whatever `ANTHROPIC_MODEL` the gateway env happens to set. Changing `model.primary` in config re-initializes the bound session with the new model. Agents with no explicit model config are unaffected (no `runtimeOptions.model` is sent).

## Evidence

- `src/acp/persistent-bindings.lifecycle.ts`: `ensureConfiguredAcpBindingSession` resolves `resolveAgentExplicitModelPrimary(cfg, agentId)` and spreads `runtimeOptions: { model }` only when a model is configured; `sessionMatchesConfiguredBinding` compares desired vs `meta.runtimeOptions?.model` (normalized, trimmed), mirroring the existing cwd/backend checks.
- The plumbing already existed: `manager.initialize-session.ts:43-62` merges `input.runtimeOptions` and forwards `model` to `runtime.ensureSession`; `manager.runtime-handle-ensure.ts:45` re-applies `runtimeOptions.model` on resume.
- Tests: `persistent-bindings.lifecycle.test.ts` — 5 new cases: runtimeOptions.model forwarded on init; not set when agent has no explicit model; ready session kept when runtime model matches; session re-initialized (close + init with new runtimeOptions.model) when configured model differs. 8/8 pass.
- `npx tsc --noEmit -p tsconfig.core.json` clean for the touched files.

[AI-assisted]
