### PR TITLE
fix(reef): redact relay errors containing credentials

### DIFF
--- a/extensions/reef/src/transport.test.ts
+++ b/extensions/reef/src/transport.test.ts
@@ -339,6 +339,126 @@ describe("ReefTransportClient response body bounds", () => {
   });
 });
 
+describe("ReefTransportClient credential redaction", () => {
+  it("redacts setup tokens and bearer sessions from loopback relay errors", async () => {
+    const setupToken = "reef.token[abc]+?/";
+    const session = `reef-session-${"a".repeat(96)}-tail`;
+    const sessionPrefix = session.slice(0, 6);
+    const sessionSuffix = session.slice(-4);
+    const receivedAuthorization: string[] = [];
+    const receivedSignatures: string[] = [];
+    const receivedTokens: string[] = [];
+    const server = http.createServer((request, response) => {
+      const chunks: Buffer[] = [];
+      request.on("data", (chunk: Buffer) => chunks.push(chunk));
+      request.on("end", () => {
+        const authorization = request.headers.authorization ?? "";
+        receivedAuthorization.push(authorization);
+        const signatureHeader = request.headers["x-reef-sig"];
+        const signature = typeof signatureHeader === "string" ? signatureHeader : "";
+        if (signature) {
+          receivedSignatures.push(signature);
+        }
+        const body = Buffer.concat(chunks).toString("utf8");
+        const token = body ? (JSON.parse(body) as { token?: unknown }).token : undefined;
+        if (typeof token === "string") {
+          receivedTokens.push(token);
+        }
+        const reflectedCredential =
+          authorization || (typeof token === "string" ? token : "") || signature;
+        response.writeHead(401, { "content-type": "application/json" });
+        response.end(
+          JSON.stringify({ error: `${reflectedCredential} relay rejected`, marker: "safe" }),
+        );
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Reef credential redaction test server did not bind a TCP port");
+    }
+
+    const client = createClient(fetch, () => ts, `http://127.0.0.1:${address.port}`);
+    try {
+      const tokenError = await client.authComplete(setupToken).catch((error: unknown) => error);
+      const createHandleError = await client
+        .createHandle(session, "approve")
+        .catch((error: unknown) => error);
+      const sessionError = await client.listOwnHandles(session).catch((error: unknown) => error);
+      const signedError = await client.listFriends().catch((error: unknown) => error);
+
+      expect(tokenError).toMatchObject({ name: "ReefRelayError", status: 401 });
+      expect(createHandleError).toMatchObject({ name: "ReefRelayError", status: 401 });
+      expect(sessionError).toMatchObject({ name: "ReefRelayError", status: 401 });
+      expect(tokenError).toMatchObject({ message: expect.stringContaining("relay rejected") });
+      expect(createHandleError).toMatchObject({
+        message: expect.stringContaining("relay rejected"),
+      });
+      expect(sessionError).toMatchObject({ message: expect.stringContaining("relay rejected") });
+      expect(signedError).toMatchObject({
+        name: "ReefRelayError",
+        status: 401,
+        message: expect.stringContaining("relay rejected"),
+      });
+      expect((tokenError as Error).message).not.toContain(setupToken);
+      expect((createHandleError as Error).message).not.toContain(session);
+      expect((sessionError as Error).message).not.toContain(session);
+      expect((createHandleError as Error).message).not.toContain(sessionPrefix);
+      expect((createHandleError as Error).message).not.toContain(sessionSuffix);
+      expect((sessionError as Error).message).not.toContain(sessionPrefix);
+      expect((sessionError as Error).message).not.toContain(sessionSuffix);
+      expect(receivedAuthorization).toContain(`Bearer ${session}`);
+      expect(receivedSignatures).toHaveLength(1);
+      expect(receivedSignatures[0]).toBeTruthy();
+      expect((signedError as Error).message).not.toContain(receivedSignatures[0]);
+      expect(receivedTokens).toContain(setupToken);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  it("redacts signed body credentials across bounded error text", async () => {
+    const code = "friend.code[123]+?/";
+    const prefix = "x".repeat(32_760);
+    const suffix = "y".repeat(32);
+    const receivedBodies: string[] = [];
+    const client = createClient(async (_url, init) => {
+      const body = init?.body;
+      receivedBodies.push(
+        body instanceof Uint8Array
+          ? new TextDecoder().decode(body)
+          : typeof body === "string"
+            ? body
+            : "",
+      );
+      const responseBody = JSON.stringify({ error: `${prefix}${code}${suffix}` });
+      const splitAt = responseBody.indexOf(code) + Math.floor(code.length / 2);
+      return new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(responseBody.slice(0, splitAt)));
+            controller.enqueue(new TextEncoder().encode(responseBody.slice(splitAt)));
+            controller.close();
+          },
+        }),
+        { status: 401, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    const error = await client.requestFriend("bob", code).catch((failure: unknown) => failure);
+
+    expect(error).toMatchObject({ name: "ReefRelayError", status: 401 });
+    expect(receivedBodies).toHaveLength(1);
+    expect(receivedBodies[0]).toContain(`"code":"${code}"`);
+    expect((error as Error).message).not.toContain(code);
+  });
+});
+
 const INBOX_WEBSOCKET_MAX_PAYLOAD_BYTES = 64 * 1024;
 
 class ControlledSocket {
@@ -587,12 +707,16 @@ describe("ReefInboxConnection recovery", () => {
     const socket = new ControlledSocket();
     const states: string[] = [];
     const errors: string[] = [];
+    let socketUrl = "";
     const client = createClient(async () => Response.json({ entries: [], cursor: 0 }));
     const abort = new AbortController();
     const inbox = new ReefInboxConnection(
       client,
       async () => {},
-      () => socket as unknown as WebSocketLike,
+      (url) => {
+        socketUrl = url;
+        return socket as unknown as WebSocketLike;
+      },
       {
         onState: (state) => states.push(state),
         onError: (error) => {
@@ -604,11 +728,17 @@ describe("ReefInboxConnection recovery", () => {
 
     const running = inbox.start(abort.signal);
     socket.emit("open");
-    socket.emit("close", { code: 1008, reason: "policy" });
+    const signature = new URL(socketUrl).searchParams.get("sig");
+    if (!signature) {
+      throw new Error("Reef WebSocket test URL did not contain a signature");
+    }
+    socket.emit("close", { code: 1008, reason: `policy ${signature}` });
     await running;
 
     expect(states).toEqual(["connected", "disconnected"]);
-    expect(errors).toEqual(["reef inbox socket closed unexpectedly code=1008 reason=policy"]);
+    expect(errors).toEqual([
+      "reef inbox socket closed unexpectedly code=1008 reason=policy <redacted>",
+    ]);
   });
 
   it("resets reconnect backoff after a socket completes catch-up", async () => {

--- a/extensions/reef/src/transport.ts
+++ b/extensions/reef/src/transport.ts
@@ -1,5 +1,6 @@
 import { toStringifiedError as asError } from "openclaw/plugin-sdk/error-runtime";
 import { buildTimeoutAbortSignal } from "openclaw/plugin-sdk/extension-shared";
+import { redactSensitiveText } from "openclaw/plugin-sdk/logging-core";
 import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import WebSocket from "ws";
 import { sha256Hex, signDeviceRequest, utf8 } from "../protocol/index.js";
@@ -26,6 +27,16 @@ const REEF_WS_HANDSHAKE_MS = 30_000;
 // Cover headers and body consumption. A relay that accepts the request but
 // stops producing bytes must not pin inbox recovery forever.
 const REEF_RELAY_REQUEST_TIMEOUT_MS = 15_000;
+
+function redactReefRelayErrorMessage(message: string, secrets: readonly string[]): string {
+  let redacted = message;
+  for (const secret of secrets) {
+    if (secret.length > 0) {
+      redacted = redacted.replaceAll(secret, "<redacted>");
+    }
+  }
+  return redactSensitiveText(redacted, { mode: "tools" });
+}
 
 export class ReefRelayError extends Error {
   constructor(
@@ -106,7 +117,7 @@ export class ReefTransportClient {
   }
 
   async authComplete(token: string): Promise<{ session: string; expires: number }> {
-    return await this.unsigned("POST", "/v1/auth/complete", { token });
+    return await this.unsigned("POST", "/v1/auth/complete", { token }, {}, [token]);
   }
 
   async createHandle(
@@ -123,20 +134,29 @@ export class ReefTransportClient {
         request_policy: requestPolicy,
       },
       { authorization: `Bearer ${session}` },
+      [session],
     );
   }
 
   listOwnHandles(
     session: string,
   ): Promise<{ handles: Array<{ handle: string; key_epoch: number; request_policy: string }> }> {
-    return this.unsigned("GET", "/v1/handles", undefined, { authorization: `Bearer ${session}` });
+    return this.unsigned("GET", "/v1/handles", undefined, { authorization: `Bearer ${session}` }, [
+      session,
+    ]);
   }
 
   mintFriendCode(): Promise<{ code: string; expires: number }> {
     return this.signed("POST", "/v1/friend-codes");
   }
   requestFriend(to: string, code?: string): Promise<{ status: string }> {
-    return this.signed("POST", "/v1/friends/request", code ? { to, code } : { to });
+    return this.signed(
+      "POST",
+      "/v1/friends/request",
+      code ? { to, code } : { to },
+      undefined,
+      code ? [code] : [],
+    );
   }
   respondFriend(friend: RelayFriend, accept: boolean): Promise<{ peer: string; status: string }> {
     return this.signed("POST", "/v1/friends/respond", {
@@ -174,7 +194,13 @@ export class ReefTransportClient {
     return url.toString();
   }
 
-  async signed<T>(method: string, path: string, body?: unknown, signal?: AbortSignal): Promise<T> {
+  async signed<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    signal?: AbortSignal,
+    secrets: readonly string[] = [],
+  ): Promise<T> {
     const bytes = body === undefined ? new Uint8Array() : utf8(JSON.stringify(body));
     const auth = this.auth(path, bytes, method);
     return await this.request(
@@ -187,6 +213,7 @@ export class ReefTransportClient {
         "x-reef-sig": auth.signature,
       },
       signal,
+      [auth.signature, ...secrets],
     );
   }
 
@@ -210,9 +237,10 @@ export class ReefTransportClient {
     path: string,
     body?: unknown,
     headers: Record<string, string> = {},
+    secrets: readonly string[] = [],
   ): Promise<T> {
     const bytes = body === undefined ? new Uint8Array() : utf8(JSON.stringify(body));
-    return await this.request(method, path, bytes, headers);
+    return await this.request(method, path, bytes, headers, undefined, secrets);
   }
 
   private async request<T>(
@@ -221,6 +249,7 @@ export class ReefTransportClient {
     bytes: Uint8Array,
     headers: Record<string, string>,
     signal?: AbortSignal,
+    secrets: readonly string[] = [],
   ): Promise<T> {
     const url = new URL(path, this.relayUrl).toString();
     const timeout = buildTimeoutAbortSignal({
@@ -253,7 +282,7 @@ export class ReefTransportClient {
             { maxBytes: REEF_RELAY_ERROR_JSON_MAX_BYTES },
           );
           if (typeof parsed.error === "string" && parsed.error) {
-            message = parsed.error;
+            message = redactReefRelayErrorMessage(parsed.error, secrets);
           }
         } catch {
           if (timeout.signal?.aborted) {
@@ -440,7 +469,9 @@ export class ReefInboxConnection {
 
   private live(signal?: AbortSignal, onReady?: () => void): Promise<void> {
     return new Promise((resolve, reject) => {
-      const socket = this.webSocketFactory(this.client.websocketUrl());
+      const url = this.client.websocketUrl();
+      const signature = new URL(url).searchParams.get("sig") ?? "";
+      const socket = this.webSocketFactory(url);
       const workAbort = new AbortController();
       // Emit each state transition at most once per socket and never after this
       // invocation settles, so late events from an abandoned socket cannot
@@ -579,7 +610,7 @@ export class ReefInboxConnection {
         if (aborting || finished) {
           return;
         }
-        disconnect(reefInboxCloseError(event));
+        disconnect(reefInboxCloseError(event, [signature]));
       });
       socket.addEventListener("error", (event) =>
         disconnect(new Error(event.message?.trim() || "reef inbox socket error")),
@@ -591,8 +622,13 @@ export class ReefInboxConnection {
   }
 }
 
-function reefInboxCloseError(event: { code?: number; reason?: string }): Error {
+function reefInboxCloseError(
+  event: { code?: number; reason?: string },
+  secrets: readonly string[] = [],
+): Error {
   const code = Number.isInteger(event.code) ? ` code=${event.code}` : "";
-  const reason = event.reason?.trim() ? ` reason=${event.reason.trim()}` : "";
+  const reason = event.reason?.trim()
+    ? ` reason=${redactReefRelayErrorMessage(event.reason.trim(), secrets)}`
+    : "";
   return new Error(`reef inbox socket closed unexpectedly${code}${reason}`);
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users completing Reef authentication, managing handles, or receiving inbox updates could see setup tokens, bearer sessions, request signatures, or WebSocket close reasons in surfaced diagnostics.

## Why This Change Was Made

Reef now removes exact request credentials before applying the public plugin SDK redactor to relay-controlled HTTP errors and WebSocket close reasons. The same request signature generated for the WebSocket URL is carried into close-reason sanitization, while status codes and safe diagnostic context remain available.

## User Impact

Reef relay failures no longer expose credential values or fragments through typed errors, channel diagnostics, or inbox reconnect errors.

## Evidence

- Real production path: `node_modules/.bin/tsx proof-live.ts` imports `ReefTransportClient`, `ReefInboxConnection`, and `createReefWebSocket`, then exercises loopback HTTP and WebSocket relay boundaries.
- Exact-head proof at `443a0f37a492`: long bearer values and their preserved prefix/suffix are absent; HTTP and WebSocket signatures are absent; HTTP status `401` and WebSocket close code `1008` remain visible.
- Focused validation: `node scripts/run-vitest.mjs extensions/reef/src/transport.test.ts --reporter=verbose` — 30 tests passed.

```text
$ node_modules/.bin/tsx proof-live.ts
head 443a0f37a492: {"setupTokenPresent":false,"longSessionPresent":false,"longSessionPrefixPresent":false,"longSessionSuffixPresent":false,"friendCodePresent":false,"signedStatus":401,"httpSignatureAbsent":true,"webSocketSignatureAbsent":true,"webSocketCloseCodePresent":true,"webSocketReasonRedacted":true,"safeMarkerPresent":true}
negative-control: signedStatus=401; webSocketCloseCodePresent=true; webSocketReasonRedacted=true; safeMarkerPresent=true
```

<details>
<summary>proof-live.ts</summary>

```ts
import http from "node:http";
import { WebSocketServer } from "ws";
import {
  createReefWebSocket,
  ReefInboxConnection,
  ReefTransportClient,
} from "./extensions/reef/src/transport.ts";

const setupToken = "proof.reef.token[abc]+?/";
const session = `reef-session-${"a".repeat(96)}-tail`;
const friendCode = "proof.friend[code]+?/";
const keys = {
  signing: {
    secretKey: "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8",
    publicKey: "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg",
  },
  encryption: {
    secretKey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
    publicKey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
  },
  auditKey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
  replayKey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
  keyEpoch: 1,
};

const errorMessage = (value: unknown): string =>
  value instanceof Error ? value.message : String(value);
let httpSignature = "";
const server = http.createServer((request, response) => {
  if (request.url?.startsWith("/v1/mail?after=")) {
    response.writeHead(200, { "content-type": "application/json" });
    response.end(JSON.stringify({ entries: [], cursor: 0 }));
    return;
  }
  const chunks: Buffer[] = [];
  request.on("data", (chunk: Buffer) => chunks.push(chunk));
  request.on("end", () => {
    const authorization = request.headers.authorization ?? "";
    const signatureHeader = request.headers["x-reef-sig"];
    const signature = typeof signatureHeader === "string" ? signatureHeader : "";
    httpSignature = signature;
    const body = Buffer.concat(chunks).toString("utf8");
    const parsed = body ? (JSON.parse(body) as { code?: unknown; token?: unknown }) : {};
    const token = typeof parsed.token === "string" ? parsed.token : "";
    const code = typeof parsed.code === "string" ? parsed.code : "";
    const reflectedCredential = authorization || token || code || signature;
    response.writeHead(401, { "content-type": "application/json" });
    response.end(JSON.stringify({ error: `${reflectedCredential} safe relay rejected` }));
  });
});

await new Promise<void>((resolve, reject) => {
  server.once("error", reject);
  server.listen(0, "127.0.0.1", resolve);
});
const address = server.address();
if (!address || typeof address === "string") throw new Error("proof server did not bind");

const webSocketServer = new WebSocketServer({ server });
let webSocketSignature = "";
webSocketServer.on("connection", (socket, request) => {
  webSocketSignature =
    new URL(request.url ?? "/", "http://127.0.0.1").searchParams.get("sig") ?? "";
  socket.close(1008, `relay ${webSocketSignature}`);
});

const client = new ReefTransportClient(
  `http://127.0.0.1:${address.port}`,
  "alice",
  keys,
  fetch,
  () => 1_752_300_000,
);
const authCompleteError = await client.authComplete(setupToken).catch((error: unknown) => error);
const createHandleError = await client
  .createHandle(session, "approve")
  .catch((error: unknown) => error);
const sessionError = await client.listOwnHandles(session).catch((error: unknown) => error);
const friendCodeError = await client
  .requestFriend("bob", friendCode)
  .catch((error: unknown) => error);
const signedError = await client.listFriends().catch((error: unknown) => error);

let closeError: Error | undefined;
const abort = new AbortController();
const inbox = new ReefInboxConnection(client, async () => {}, createReefWebSocket, {
  onError: (error) => {
    closeError = error;
    abort.abort();
  },
});
await inbox.start(abort.signal);

const messages = [
  errorMessage(authCompleteError),
  errorMessage(createHandleError),
  errorMessage(sessionError),
  errorMessage(friendCodeError),
  errorMessage(signedError),
];
const prefix = session.slice(0, 6);
const suffix = session.slice(-4);
console.log(
  `head ${process.env.OPENCLAW_PROOF_HEAD ?? "unknown"}: ${JSON.stringify({
    setupTokenPresent: messages[0].includes(setupToken),
    longSessionPresent: messages[1].includes(session) || messages[2].includes(session),
    longSessionPrefixPresent: messages[1].includes(prefix) || messages[2].includes(prefix),
    longSessionSuffixPresent: messages[1].includes(suffix) || messages[2].includes(suffix),
    friendCodePresent: messages[3].includes(friendCode),
    signedStatus: (signedError as { status?: number }).status,
    httpSignatureAbsent: !messages[4].includes(httpSignature),
    webSocketSignatureAbsent: !(closeError?.message.includes(webSocketSignature) ?? false),
    webSocketCloseCodePresent: closeError?.message.includes("code=1008") ?? false,
    webSocketReasonRedacted: closeError?.message.includes("reason=relay <redacted>") ?? false,
    safeMarkerPresent: messages.every((message) => message.includes("safe relay rejected")),
  })}`,
);
console.log(
  `negative-control: signedStatus=${(signedError as { status?: number }).status}; webSocketCloseCodePresent=${
    closeError?.message.includes("code=1008") ?? false
  }; webSocketReasonRedacted=${closeError?.message.includes("reason=relay <redacted>") ?? false}; safeMarkerPresent=${messages.every((message) => message.includes("safe relay rejected"))}`,
);

await new Promise<void>((resolve) => webSocketServer.close(() => resolve()));
await new Promise<void>((resolve, reject) => {
  server.close((error) => (error ? reject(error) : resolve()));
});
```

</details>

Canonical invariant: request-specific credentials are removed at Reef's transport boundary before generic SDK redaction, while status and safe diagnostic context are preserved.

AI-assisted: built with Codex
