### PR TITLE
fix(agents): detect reworded sessions_send floods via semantic loop-hash normalization

### DIFF
--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -17,6 +17,7 @@ import { reconcileToolCallExecutionParams } from "./tool-loop-call-reconciliatio
 import {
   UNKNOWN_TOOL_THRESHOLD,
   detectToolCallLoop,
+  hashToolCall,
   recordToolCall,
   recordToolCallOutcome,
 } from "./tool-loop-detection.js";
@@ -1765,6 +1766,101 @@ describe("tool-loop-detection", () => {
         .map((call) => call.resultHash);
       expect(hashes?.[0]).toBeTypeOf("string");
       expect(hashes?.[0]).not.toBe(hashes?.[1]);
+    });
+
+    it("hashes sessions_send calls to one target identically despite reworded bodies", () => {
+      const hashA = hashToolCall("sessions_send", {
+        sessionKey: "agent:main:peer",
+        message: "check-in variant A",
+      });
+      const hashB = hashToolCall("sessions_send", {
+        sessionKey: "agent:main:peer",
+        message: "entirely different wording, same target",
+      });
+      expect(hashA).toBe(hashB);
+    });
+
+    it("keeps sessions_send calls to different targets distinct", () => {
+      const hashA = hashToolCall("sessions_send", { sessionKey: "agent:a:peer", message: "hi" });
+      const hashB = hashToolCall("sessions_send", { sessionKey: "agent:b:peer", message: "hi" });
+      expect(hashA).not.toBe(hashB);
+    });
+
+    it("escalates reworded sessions_send floods to critical via generic_repeat", () => {
+      const state = createState();
+      for (let i = 0; i < CRITICAL_THRESHOLD; i += 1) {
+        recordSend(
+          state,
+          "sessions_send",
+          { sessionKey: "agent:main:peer", message: `reworded check-in variant ${i}` },
+          { ok: true, runId: `run_${i}` },
+          i,
+        );
+      }
+      const loopResult = detectToolCallLoop(
+        state,
+        "sessions_send",
+        { sessionKey: "agent:main:peer", message: "yet another reworded variant" },
+        enabledLoopDetectionConfig,
+      );
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("critical");
+        expect(loopResult.detector).toBe("generic_repeat");
+      }
+    });
+
+    it("allows mixed-target sessions_send fan-out below threshold", () => {
+      const state = createState();
+      for (let i = 0; i < 10; i += 1) {
+        recordSend(
+          state,
+          "sessions_send",
+          { sessionKey: `agent:target-${i}:peer`, message: "one-shot update" },
+          { ok: true, runId: `run_${i}` },
+          i,
+        );
+      }
+      const loopResult = detectToolCallLoop(
+        state,
+        "sessions_send",
+        { sessionKey: "agent:target-10:peer", message: "one-shot update" },
+        enabledLoopDetectionConfig,
+      );
+      expect(loopResult.stuck).toBe(false);
+    });
+
+    it("keeps conversations_send and conversations_turn text-sensitive (external channel delivery)", () => {
+      // Conversation tools deliver directly to an external channel conversation;
+      // reworded texts to one conversationRef are legitimate distinct messages
+      // and must keep distinct hashes (same contract as the message tool).
+      for (const toolName of ["conversations_send", "conversations_turn"] as const) {
+        const hashA = hashToolCall(toolName, {
+          conversationRef: "channel:telegram:123",
+          message: "first distinct update",
+        });
+        const hashB = hashToolCall(toolName, {
+          conversationRef: "channel:telegram:123",
+          message: "second distinct update, different words",
+        });
+        expect(hashA).not.toBe(hashB);
+      }
+    });
+
+    it("does not change message-tool hashing for reworded channel sends", () => {
+      // Channel message sends with different texts remain distinct calls; the
+      // semantic collapse is scoped to inter-agent send tools only.
+      const hashA = hashToolCall("message", {
+        action: "send",
+        target: "feishu:oc_chat",
+        text: "line 1",
+      });
+      const hashB = hashToolCall("message", {
+        action: "send",
+        target: "feishu:oc_chat",
+        text: "line 2",
+      });
+      expect(hashA).not.toBe(hashB);
     });
 
     it("keeps full result hashing for administrative message mutations", () => {

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -105,14 +105,52 @@ function resolveLoopDetectionConfig(config?: ToolLoopDetectionConfig): ResolvedL
 /**
  * Hash a tool call for pattern matching.
  * Uses tool name + deterministic JSON serialization digest of params.
+ * Inter-agent session sends are normalized semantically first so reworded
+ * message bodies to the same session share one hash.
  */
 export function hashToolCall(toolName: string, params: unknown): string {
-  return `${toolName}:${digestStable(params)}`;
+  return `${toolName}:${digestStable(normalizeSessionsSendParamsForLoopHash(toolName, params))}`;
 }
 
 function digestStable(value: unknown): string {
   const serialized = stableStringify(value);
   return createHash("sha256").update(serialized).digest("hex");
+}
+
+/**
+ * Free-text body keys on inter-agent session sends. Collapsing them lets the loop
+ * detector treat repeated sends to one target as one semantic call even when the
+ * model rewords the body on every attempt (same evasion class as #117637, send
+ * side: exact-argument streaks never build when each call differs).
+ * The sessionKey routing field stays intact so sends to different sessions never
+ * collide.
+ *
+ * Scoped to `sessions_send` only: `conversations_send`/`conversations_turn` are
+ * direct external-channel delivery (they require a conversationRef and deliver to
+ * a channel conversation, like the `message` tool), so reworded texts to one
+ * conversation are legitimate distinct messages that must stay text-sensitive.
+ * Their volatile delivery ids are already stripped from outcome hashes.
+ */
+const SESSIONS_SEND_TEXT_PARAM_KEYS = new Set(["message", "text"]);
+const SEMANTIC_SEND_TEXT_PLACEHOLDER = "semantic:send-text";
+
+function normalizeSessionsSendParamsForLoopHash(toolName: string, params: unknown): unknown {
+  if (toolName !== "sessions_send") {
+    return params;
+  }
+  if (!isPlainObject(params)) {
+    return params;
+  }
+  let changed = false;
+  const normalized: Record<string, unknown> = { ...params };
+  for (const key of Object.keys(normalized)) {
+    const value = normalized[key];
+    if (SESSIONS_SEND_TEXT_PARAM_KEYS.has(key) && typeof value === "string") {
+      normalized[key] = SEMANTIC_SEND_TEXT_PLACEHOLDER;
+      changed = true;
+    }
+  }
+  return changed ? normalized : params;
 }
 
 function extractTextContent(result: unknown): string {

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -118,39 +118,26 @@ function digestStable(value: unknown): string {
 }
 
 /**
- * Free-text body keys on inter-agent session sends. Collapsing them lets the loop
- * detector treat repeated sends to one target as one semantic call even when the
- * model rewords the body on every attempt (same evasion class as #117637, send
- * side: exact-argument streaks never build when each call differs).
- * The sessionKey routing field stays intact so sends to different sessions never
- * collide.
+ * Collapse free-text body keys for `sessions_send` so reworded sends to one session share a
+ * hash. `sessionKey` stays intact, so different targets remain distinct.
  *
- * Scoped to `sessions_send` only: `conversations_send`/`conversations_turn` are
- * direct external-channel delivery (they require a conversationRef and deliver to
- * a channel conversation, like the `message` tool), so reworded texts to one
- * conversation are legitimate distinct messages that must stay text-sensitive.
- * Their volatile delivery ids are already stripped from outcome hashes.
+ * Do not apply this to `conversations_send` or `conversations_turn`: they deliver directly to
+ * external conversations, where distinct text is legitimate and must stay text-sensitive.
  */
-const SESSIONS_SEND_TEXT_PARAM_KEYS = new Set(["message", "text"]);
 const SEMANTIC_SEND_TEXT_PLACEHOLDER = "semantic:send-text";
 
 function normalizeSessionsSendParamsForLoopHash(toolName: string, params: unknown): unknown {
-  if (toolName !== "sessions_send") {
+  if (toolName !== "sessions_send" || !isPlainObject(params)) {
     return params;
   }
-  if (!isPlainObject(params)) {
-    return params;
-  }
-  let changed = false;
-  const normalized: Record<string, unknown> = { ...params };
-  for (const key of Object.keys(normalized)) {
-    const value = normalized[key];
-    if (SESSIONS_SEND_TEXT_PARAM_KEYS.has(key) && typeof value === "string") {
-      normalized[key] = SEMANTIC_SEND_TEXT_PLACEHOLDER;
-      changed = true;
-    }
-  }
-  return changed ? normalized : params;
+  return Object.fromEntries(
+    Object.entries(params).map(([key, value]) => [
+      key,
+      (key === "message" || key === "text") && typeof value === "string"
+        ? SEMANTIC_SEND_TEXT_PLACEHOLDER
+        : value,
+    ]),
+  );
 }
 
 function extractTextContent(result: unknown): string {

--- a/src/agents/tools/sessions-send-tool.test.ts
+++ b/src/agents/tools/sessions-send-tool.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { hashToolCall } from "../tool-loop-detection.js";
+import { createSessionsSendTool } from "./sessions-send-tool.js";
+
+function makeConfig(opts?: { agentToAgentEnabled?: boolean }): OpenClawConfig {
+  return {
+    agents: { entries: { main: {}, peer: {} } },
+    tools: {
+      agentToAgent: { enabled: opts?.agentToAgentEnabled ?? false },
+    },
+  } as unknown as OpenClawConfig;
+}
+
+type GatewayCall = {
+  method: string;
+  params?: unknown;
+  timeoutMs?: number | null;
+};
+
+type RealGatewayCaller = typeof import("../../gateway/call.js").callGateway;
+
+function makeTool(opts?: {
+  gatewayKey?: string;
+  gatewayError?: unknown;
+  sandboxed?: boolean;
+  agentToAgentEnabled?: boolean;
+}) {
+  const calls: GatewayCall[] = [];
+  const callGateway = vi.fn(async (call: GatewayCall) => {
+    calls.push(call);
+    if (opts?.gatewayError) {
+      throw opts.gatewayError;
+    }
+    return { key: opts?.gatewayKey ?? "" };
+  });
+  const tool = createSessionsSendTool({
+    agentSessionKey: "agent:main:main",
+    sandboxed: opts?.sandboxed,
+    config: makeConfig({ agentToAgentEnabled: opts?.agentToAgentEnabled }),
+    callGateway: callGateway as unknown as RealGatewayCaller,
+  });
+  return { tool, calls };
+}
+
+async function prepare(
+  tool: ReturnType<typeof createSessionsSendTool>,
+  args: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const prepareFn = tool.prepareBeforeToolCallParams;
+  expect(prepareFn).toBeTypeOf("function");
+  const result = (await prepareFn?.(args, {
+    toolCallId: "call-1",
+    hookContext: { sessionKey: "agent:main:main" },
+  } as never)) as Record<string, unknown>;
+  return result;
+}
+
+describe("sessions_send selector canonicalization before loop admission", () => {
+  it("passes sessionKey-form calls through untouched", async () => {
+    const { tool, calls } = makeTool();
+    const result = await prepare(tool, {
+      sessionKey: "agent:peer:main",
+      message: "hello",
+    });
+    expect(result).toEqual({ sessionKey: "agent:peer:main", message: "hello" });
+    expect(calls).toEqual([]);
+  });
+
+  it("canonicalizes agentId-form calls to the agent main session key", async () => {
+    const { tool, calls } = makeTool();
+    const result = await prepare(tool, { agentId: "peer", message: "hello" });
+    expect(result).toEqual({ sessionKey: "agent:peer:main", message: "hello" });
+    expect(calls).toEqual([]);
+  });
+
+  it("canonicalizes label-form calls via gateway sessions.resolve", async () => {
+    const { tool, calls } = makeTool({ gatewayKey: "agent:peer:main" });
+    const result = await prepare(tool, { label: "peer-main", message: "hello" });
+    expect(result).toEqual({ sessionKey: "agent:peer:main", message: "hello" });
+    expect(calls).toEqual([
+      { method: "sessions.resolve", params: { label: "peer-main" }, timeoutMs: 10_000 },
+    ]);
+  });
+
+  it("leaves unknown agentId calls untouched so execute reports the same error", async () => {
+    const { tool, calls } = makeTool();
+    const result = await prepare(tool, { agentId: "ghost", message: "hello" });
+    expect(result).toEqual({ agentId: "ghost", message: "hello" });
+    expect(calls).toEqual([]);
+  });
+
+  it("leaves unresolvable label calls untouched on gateway failure", async () => {
+    const { tool, calls } = makeTool({ gatewayError: new Error("gateway down") });
+    const result = await prepare(tool, { label: "peer-main", message: "hello" });
+    expect(result).toEqual({ label: "peer-main", message: "hello" });
+    expect(calls).toHaveLength(1);
+  });
+
+  it("leaves label calls untouched when the gateway resolves to no key", async () => {
+    const { tool } = makeTool({ gatewayKey: "" });
+    const result = await prepare(tool, { label: "peer-main", message: "hello" });
+    expect(result).toEqual({ label: "peer-main", message: "hello" });
+  });
+
+  it("does not canonicalize cross-agent label sends when agent-to-agent messaging is disabled", async () => {
+    const { tool, calls } = makeTool({
+      gatewayKey: "agent:peer:main",
+      agentToAgentEnabled: false,
+    });
+    const result = await prepare(tool, {
+      label: "peer-main",
+      agentId: "peer",
+      message: "hello",
+    });
+    expect(result).toEqual({ label: "peer-main", agentId: "peer", message: "hello" });
+    expect(calls).toEqual([]);
+  });
+
+  it("does not canonicalize cross-agent label sends from sandboxed sessions", async () => {
+    const { tool, calls } = makeTool({
+      gatewayKey: "agent:peer:main",
+      sandboxed: true,
+      agentToAgentEnabled: true,
+    });
+    const result = await prepare(tool, {
+      label: "peer-main",
+      agentId: "peer",
+      message: "hello",
+    });
+    expect(result).toEqual({ label: "peer-main", agentId: "peer", message: "hello" });
+    expect(calls).toEqual([]);
+  });
+
+  it("gives equivalent selector forms one loop-detection hash across reworded bodies", async () => {
+    const { tool } = makeTool({ gatewayKey: "agent:peer:main" });
+    const bySessionKey = await prepare(tool, {
+      sessionKey: "agent:peer:main",
+      message: "first rewording",
+    });
+    const byLabel = await prepare(tool, {
+      label: "peer-main",
+      message: "second rewording",
+    });
+    const byAgentId = await prepare(tool, {
+      agentId: "peer",
+      message: "third rewording",
+    });
+    const hashByKey = hashToolCall("sessions_send", bySessionKey);
+    expect(hashToolCall("sessions_send", byLabel)).toBe(hashByKey);
+    expect(hashToolCall("sessions_send", byAgentId)).toBe(hashByKey);
+  });
+
+  it("keeps sends to different targets hash-distinct after canonicalization", async () => {
+    const { tool } = makeTool({ gatewayKey: "agent:peer:main" });
+    const toPeer = await prepare(tool, { agentId: "peer", message: "hello" });
+    const toMain = await prepare(tool, {
+      sessionKey: "agent:main:other",
+      message: "hello",
+    });
+    expect(hashToolCall("sessions_send", toPeer)).not.toBe(hashToolCall("sessions_send", toMain));
+  });
+});

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -437,13 +437,219 @@ async function startAgentRun(params: {
   }
 }
 
-export function createSessionsSendTool(opts?: {
+type SessionsSendToolOptions = {
   agentSessionKey?: string;
   agentChannel?: GatewayMessageChannel;
   sandboxed?: boolean;
   config?: OpenClawConfig;
   callGateway?: GatewayCaller;
-}): AnyAgentTool {
+};
+
+type SessionsSendTargetResolution =
+  | { ok: true; sessionKey: string }
+  | { ok: false; result: ReturnType<typeof jsonResult> };
+
+/**
+ * Resolve a sessions_send target selector (label / agentId) to a canonical session key.
+ * Extracted so admission preparation and execution share one resolution and
+ * authorization path (loop-detection canonicalization reuses the result instead of
+ * resolving twice and diverging).
+ */
+async function resolveSessionsSendTargetSessionKey(params: {
+  label?: string;
+  agentId?: string;
+  cfg: OpenClawConfig;
+  mainKey: string;
+  effectiveRequesterKey?: string;
+  restrictToSpawned: boolean;
+  a2aPolicy: ReturnType<typeof createAgentToAgentPolicy>;
+  gatewayCall: GatewayCaller;
+}): Promise<SessionsSendTargetResolution> {
+  const {
+    label: labelParam,
+    agentId: labelAgentIdParam,
+    cfg,
+    mainKey,
+    effectiveRequesterKey,
+    restrictToSpawned,
+    a2aPolicy,
+    gatewayCall,
+  } = params;
+  if (!labelParam && labelAgentIdParam) {
+    const agentMainKey = resolveConfiguredAgentMainSessionKey({
+      cfg,
+      agentId: labelAgentIdParam,
+      mainKey,
+    });
+    if (!agentMainKey) {
+      return {
+        ok: false,
+        result: jsonResult({
+          runId: crypto.randomUUID(),
+          status: "error",
+          error: `agent not found: ${labelAgentIdParam}`,
+        }),
+      };
+    }
+    return { ok: true, sessionKey: agentMainKey };
+  }
+  if (labelParam) {
+    const requesterAgentId = resolveAgentIdFromSessionKey(
+      effectiveRequesterKey,
+      resolveDefaultAgentId(cfg),
+    );
+    const requestedAgentId = labelAgentIdParam ? normalizeAgentId(labelAgentIdParam) : undefined;
+
+    if (restrictToSpawned && requestedAgentId && requestedAgentId !== requesterAgentId) {
+      return {
+        ok: false,
+        result: jsonResult({
+          runId: crypto.randomUUID(),
+          status: "forbidden",
+          error: "Sandboxed sessions_send label lookup is limited to this agent",
+        }),
+      };
+    }
+
+    if (requesterAgentId && requestedAgentId && requestedAgentId !== requesterAgentId) {
+      if (!a2aPolicy.enabled) {
+        return {
+          ok: false,
+          result: jsonResult({
+            runId: crypto.randomUUID(),
+            status: "forbidden",
+            error:
+              "Agent-to-agent messaging is disabled. Set tools.agentToAgent.enabled=true to allow cross-agent sends.",
+          }),
+        };
+      }
+      if (!a2aPolicy.isAllowed(requesterAgentId, requestedAgentId)) {
+        return {
+          ok: false,
+          result: jsonResult({
+            runId: crypto.randomUUID(),
+            status: "forbidden",
+            error: "Agent-to-agent messaging denied by tools.agentToAgent.allow.",
+          }),
+        };
+      }
+    }
+
+    const resolveParams: Record<string, unknown> = {
+      label: labelParam,
+      ...(requestedAgentId ? { agentId: requestedAgentId } : {}),
+      ...(restrictToSpawned ? { spawnedBy: effectiveRequesterKey } : {}),
+    };
+    let resolvedKey;
+    try {
+      const resolved = await gatewayCall<{ key: string }>({
+        method: "sessions.resolve",
+        params: resolveParams,
+        timeoutMs: 10_000,
+      });
+      resolvedKey = normalizeOptionalString(resolved?.key) ?? "";
+    } catch (err) {
+      const msg = formatErrorMessage(err);
+      if (restrictToSpawned) {
+        return {
+          ok: false,
+          result: jsonResult({
+            runId: crypto.randomUUID(),
+            status: "forbidden",
+            error: "Session not visible from this sandboxed agent session.",
+          }),
+        };
+      }
+      return {
+        ok: false,
+        result: jsonResult({
+          runId: crypto.randomUUID(),
+          status: "error",
+          error: msg || `No session found with label: ${labelParam}`,
+        }),
+      };
+    }
+
+    if (!resolvedKey) {
+      if (restrictToSpawned) {
+        return {
+          ok: false,
+          result: jsonResult({
+            runId: crypto.randomUUID(),
+            status: "forbidden",
+            error: "Session not visible from this sandboxed agent session.",
+          }),
+        };
+      }
+      return {
+        ok: false,
+        result: jsonResult({
+          runId: crypto.randomUUID(),
+          status: "error",
+          error: `No session found with label: ${labelParam}`,
+        }),
+      };
+    }
+    return { ok: true, sessionKey: resolvedKey };
+  }
+  return {
+    ok: false,
+    result: jsonResult({
+      runId: crypto.randomUUID(),
+      status: "error",
+      error: "Either sessionKey or label is required",
+    }),
+  };
+}
+
+/**
+ * Canonicalize equivalent target selectors (`sessionKey`, `label`, `agentId`) to the
+ * resolved canonical sessionKey before loop admission hashes the call, so rotating
+ * selector forms for one target session share one loop-detection hash. Uses the same
+ * resolution and authorization path as execute(); any failure passes the original
+ * params through unchanged so execute() reports the same error result.
+ */
+async function canonicalizeSessionsSendSelectorForLoopAdmission(
+  args: unknown,
+  opts?: SessionsSendToolOptions,
+): Promise<unknown> {
+  const params = normalizeSessionsSendArguments(args);
+  const sessionKeyParam = readStringParam(params, "sessionKey");
+  if (sessionKeyParam) {
+    return params;
+  }
+  const labelParam = normalizeOptionalString(readStringParam(params, "label"));
+  const labelAgentIdParam = normalizeOptionalString(readStringParam(params, "agentId"));
+  if (!labelParam && !labelAgentIdParam) {
+    return params;
+  }
+  try {
+    const { cfg, mainKey, effectiveRequesterKey, restrictToSpawned } =
+      resolveSessionToolContext(opts);
+    const resolved = await resolveSessionsSendTargetSessionKey({
+      label: labelParam,
+      agentId: labelAgentIdParam,
+      cfg,
+      mainKey,
+      effectiveRequesterKey,
+      restrictToSpawned,
+      a2aPolicy: createAgentToAgentPolicy(cfg),
+      gatewayCall: opts?.callGateway ?? callGateway,
+    });
+    if (!resolved.ok) {
+      return params;
+    }
+    const next: Record<string, unknown> = { ...params, sessionKey: resolved.sessionKey };
+    delete next.label;
+    delete next.agentId;
+    return next;
+  } catch {
+    // Admission preparation must never fail the call; execute() resolves identically.
+    return params;
+  }
+}
+
+export function createSessionsSendTool(opts?: SessionsSendToolOptions): AnyAgentTool {
   return {
     label: "Session Send",
     name: "sessions_send",
@@ -452,6 +658,8 @@ export function createSessionsSendTool(opts?: {
     parameters: SessionsSendToolSchema,
     outputSchema: SessionsSendOutputSchema,
     prepareArguments: normalizeSessionsSendArguments,
+    prepareBeforeToolCallParams: (args) =>
+      canonicalizeSessionsSendSelectorForLoopAdmission(args, opts),
     execute: async (_toolCallId, args) => {
       const params = normalizeSessionsSendArguments(args);
       const gatewayCall = opts?.callGateway ?? callGateway;
@@ -471,108 +679,21 @@ export function createSessionsSendTool(opts?: {
       const labelAgentIdParam = normalizeOptionalString(readStringParam(params, "agentId"));
 
       let sessionKey = sessionKeyParam;
-      if (!sessionKey && !labelParam && labelAgentIdParam) {
-        const agentMainKey = resolveConfiguredAgentMainSessionKey({
-          cfg,
-          agentId: labelAgentIdParam,
-          mainKey,
-        });
-        if (!agentMainKey) {
-          return jsonResult({
-            runId: crypto.randomUUID(),
-            status: "error",
-            error: `agent not found: ${labelAgentIdParam}`,
-          });
-        }
-        sessionKey = agentMainKey;
-      }
-      if (!sessionKey && labelParam) {
-        const requesterAgentId = resolveAgentIdFromSessionKey(
-          effectiveRequesterKey,
-          resolveDefaultAgentId(cfg),
-        );
-        const requestedAgentId = labelAgentIdParam
-          ? normalizeAgentId(labelAgentIdParam)
-          : undefined;
-
-        if (restrictToSpawned && requestedAgentId && requestedAgentId !== requesterAgentId) {
-          return jsonResult({
-            runId: crypto.randomUUID(),
-            status: "forbidden",
-            error: "Sandboxed sessions_send label lookup is limited to this agent",
-          });
-        }
-
-        if (requesterAgentId && requestedAgentId && requestedAgentId !== requesterAgentId) {
-          if (!a2aPolicy.enabled) {
-            return jsonResult({
-              runId: crypto.randomUUID(),
-              status: "forbidden",
-              error:
-                "Agent-to-agent messaging is disabled. Set tools.agentToAgent.enabled=true to allow cross-agent sends.",
-            });
-          }
-          if (!a2aPolicy.isAllowed(requesterAgentId, requestedAgentId)) {
-            return jsonResult({
-              runId: crypto.randomUUID(),
-              status: "forbidden",
-              error: "Agent-to-agent messaging denied by tools.agentToAgent.allow.",
-            });
-          }
-        }
-
-        const resolveParams: Record<string, unknown> = {
-          label: labelParam,
-          ...(requestedAgentId ? { agentId: requestedAgentId } : {}),
-          ...(restrictToSpawned ? { spawnedBy: effectiveRequesterKey } : {}),
-        };
-        let resolvedKey;
-        try {
-          const resolved = await gatewayCall<{ key: string }>({
-            method: "sessions.resolve",
-            params: resolveParams,
-            timeoutMs: 10_000,
-          });
-          resolvedKey = normalizeOptionalString(resolved?.key) ?? "";
-        } catch (err) {
-          const msg = formatErrorMessage(err);
-          if (restrictToSpawned) {
-            return jsonResult({
-              runId: crypto.randomUUID(),
-              status: "forbidden",
-              error: "Session not visible from this sandboxed agent session.",
-            });
-          }
-          return jsonResult({
-            runId: crypto.randomUUID(),
-            status: "error",
-            error: msg || `No session found with label: ${labelParam}`,
-          });
-        }
-
-        if (!resolvedKey) {
-          if (restrictToSpawned) {
-            return jsonResult({
-              runId: crypto.randomUUID(),
-              status: "forbidden",
-              error: "Session not visible from this sandboxed agent session.",
-            });
-          }
-          return jsonResult({
-            runId: crypto.randomUUID(),
-            status: "error",
-            error: `No session found with label: ${labelParam}`,
-          });
-        }
-        sessionKey = resolvedKey;
-      }
-
       if (!sessionKey) {
-        return jsonResult({
-          runId: crypto.randomUUID(),
-          status: "error",
-          error: "Either sessionKey or label is required",
+        const resolvedTarget = await resolveSessionsSendTargetSessionKey({
+          label: labelParam,
+          agentId: labelAgentIdParam,
+          cfg,
+          mainKey,
+          effectiveRequesterKey,
+          restrictToSpawned,
+          a2aPolicy,
+          gatewayCall,
         });
+        if (!resolvedTarget.ok) {
+          return resolvedTarget.result;
+        }
+        sessionKey = resolvedTarget.sessionKey;
       }
       const resolvedSession = await resolveSessionReference({
         sessionKey,


### PR DESCRIPTION
## What Problem This Solves

Fixes #119600.

The tool-loop detector hashes full `sessions_send` params, including the free-text body. A model that rewords every attempt therefore produces a new argument hash, preventing a repeat streak from forming even when it repeatedly targets the same peer session with stable outcomes. In the reported incident this allowed a semantic send flood to continue while the detector remained silent.

This is the send-side counterpart of #117637 (exec argument churn) and complements #89090, which stabilized send *outcome* hashes; this PR stabilizes the internal-session send *argument* hash.

## Change

`src/agents/tool-loop-detection.ts`:

- Normalize free-text `message`/`text` fields for `sessions_send` before hashing.
- Preserve `sessionKey`, so different peer sessions remain distinct.
- Keep `conversations_send`, `conversations_turn`, and `message` fully text-sensitive because they deliver directly to external conversations/channels where distinct text is legitimate.

## Tests

Regression coverage in `src/agents/tool-loop-detection.test.ts` verifies:

- reworded `sessions_send` bodies to one session hash identically;
- sends to different sessions stay distinct;
- 20 stable same-target outcomes cause the next reworded `sessions_send` admission to return critical `generic_repeat`;
- mixed-target fan-out remains allowed;
- `conversations_send`, `conversations_turn`, and `message` remain text-sensitive.

## Evidence

### Exact-head runtime proof

A redacted runnable harness and its clean-worktree output are attached here:

- `https://github.com/openclaw/openclaw/pull/119604#issuecomment-5231243497`
- reviewed head: `6e727cb08b0c4408f239607b935e49e40caa43ce`

The harness imports the reviewed head's source module and exercises `hashToolCall`, `recordToolCall`, `recordToolCallOutcome`, and `detectToolCallLoop`. It refuses to run unless tracked files are clean and `HEAD` matches the supplied SHA.

Observed boundary:

```text
{
  "reviewedHead": "6e727cb08b0c4408f239607b935e49e40caa43ce",
  "sourceModule": "src/agents/tool-loop-detection.ts",
  "assertions": {
    "rewordedSessionsSendSameTargetHashesEqual": true,
    "rewordedSessionsSendTextAliasSameTargetHashesEqual": true,
    "sessionsSendDifferentTargetsRemainDistinct": true,
    "nextSessionsSendAfterTwentyStableOutcomes": {
      "stuck": true,
      "level": "critical",
      "detector": "generic_repeat",
      "count": 20
    },
    "rewordedConversationsSendRemainsTextSensitive": true,
    "rewordedConversationsTurnRemainsTextSensitive": true,
    "nextDistinctConversationSendAfterTwentyOutcomes": {
      "stuck": false
    },
    "rewordedMessageToolSendsRemainTextSensitive": true
  }
}
```

This demonstrates:

- same-target reworded `sessions_send`: critical `generic_repeat` after 20 stable outcomes;
- different internal targets: distinct hashes;
- distinct external conversation/channel text: remains allowed and text-sensitive.

### Integrated admission/outcome proof

A second redacted exact-head harness closes the production-lifecycle boundary identified by ClawSweeper:

- proof comment: `https://github.com/openclaw/openclaw/pull/119604#issuecomment-5233962446`
- selector-canonicalization follow-up proof (covers `prepareBeforeToolCallParams` selector resolution and the rotation block): `https://github.com/openclaw/openclaw/pull/119604#issuecomment-5381049977`
- reviewed head: `be424e866abae3a1eba1ab5de0cb87cd7ad84cc6`
- real `agent-core` tool-call loop and schema validation;
- actual `sessions_send.prepareArguments` alias canonicalization;
- real wrapped before-tool admission and outcome recording;
- actual `conversations_send` production execution with an injected contract-valid no-network gateway.

Observed integrated boundary:

```text
same-target sessions_send:
  model attempts: 21
  synthetic executor invocations: 20
  admission/history records: 21
  executed outcome records: 20
  prepared argument hash count: 1
  stable normalized result hash count with unique run IDs: 1
  prospective attempt 21: blocked (generic_repeat, count 20)

target-separated sessions_send:
  target-A synthetic executions: 20
  identical target-B call after target-A threshold: allowed
  next target-A call: blocked
  prepared argument hash count: 2

external conversations_send:
  model attempts: 21
  injected fake-gateway invocations: 21
  admission/history records: 21
  executed outcome records: 21
  prepared argument hash count: 21
  critical generic-repeat events: 0
  network delivery performed: false
```

The detector evaluates completed prior outcomes before execution; therefore the event reports `count: 20` while blocking the prospective 21st same-target attempt. The production `sessions_send` delivery body is replaced by a contract-shaped synthetic executor, and the external tool uses its production dependency-injection seam. No real inter-agent or external-channel messages are emitted by this proof.

### Local validation

```text
Focused Vitest: 178/178 passed across agents-core and agents-support
oxfmt (changed files): passed
type-aware oxlint (changed files): 0 warnings, 0 errors
tsgo:core: passed
tsgo:core:test: passed
```

The earlier full legacy `tsc --noEmit` command now exceeds even an 8 GB Node heap on the expanded repository; the maintained `tsgo:core` and `tsgo:core:test` project checks pass.

### Shipped beta.7 corroboration

A behaviorally equivalent normalization for the canonical runtime `message` shape was ported to the installed `2026.7.2-beta.7` loop-detector bundle and exercised through its shipped detector exports. It produced the same critical `generic_repeat` boundary for reworded same-session sends while 20 distinct-text external conversation deliveries remained allowed. The beta.7 port did not separately normalize the pre-canonicalization `text` alias, so it is corroborating operator evidence rather than a byte-for-byte copy of the PR helper. The exact-head harness above is the inspectable proof for both `message` and defensive `text` handling.

## Scope Note

Loop history is per run, so this closes the within-run evasion class. Cross-run loops driven by heartbeats, recall cycles, or separate autonomous runs additionally need session-level budgeting/policy containment and remain out of scope.

