### PR TITLE
fix(gateway): keep RPCs responsive during context prewarm

### DIFF
--- a/src/agents/context-cache-projection.test.ts
+++ b/src/agents/context-cache-projection.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { prepareContextWindowCaches } from "./context-cache-projection.js";
+import {
+  lookupCachedContextTokens,
+  lookupCachedContextWindow,
+  replaceContextWindowCaches,
+} from "./context-cache.js";
+import { resetContextWindowCacheForTest } from "./context-runtime-state.js";
+
+function publishConfiguredModel(model: string, contextWindow: number): void {
+  replaceContextWindowCaches({
+    configuredTokenCache: new Map([[model, contextWindow]]),
+    discoveredTokenCache: new Map(),
+    contextWindowCache: new Map(),
+  });
+}
+
+function createLargeCatalog(prefix: string, count: number) {
+  return {
+    entries: Array.from({ length: count }, (_, index) => ({
+      id: `${prefix}-${index}`,
+      provider: "synthetic",
+      contextWindow: 64_000,
+    })),
+    staticEntries: [],
+  };
+}
+
+describe("context cache projection", () => {
+  afterEach(() => {
+    resetContextWindowCacheForTest();
+  });
+
+  it("keeps the prior generation visible until a cooperative projection is complete", async () => {
+    publishConfiguredModel("prior-model", 48_000);
+
+    const pending = prepareContextWindowCaches({
+      config: {
+        models: {
+          providers: {
+            synthetic: {
+              baseUrl: "https://example.invalid",
+              models: [{ id: "next-model", contextWindow: 96_000 } as never],
+            },
+          },
+        },
+      },
+      modelCatalog: createLargeCatalog("discovered", 600),
+    });
+
+    expect(lookupCachedContextTokens("prior-model")).toBe(48_000);
+    expect(lookupCachedContextTokens("next-model")).toBeUndefined();
+
+    replaceContextWindowCaches(await pending);
+    expect(lookupCachedContextTokens("prior-model")).toBeUndefined();
+    expect(lookupCachedContextWindow("next-model")).toBe(96_000);
+    expect(lookupCachedContextTokens("discovered-599")).toBe(64_000);
+  });
+
+  it("does not publish a superseded cooperative projection", async () => {
+    publishConfiguredModel("prior-model", 48_000);
+    let current = true;
+    const pending = prepareContextWindowCaches({
+      config: {},
+      modelCatalog: createLargeCatalog("superseded", 1_024),
+      assertCurrent: () => {
+        if (!current) {
+          throw new Error("projection superseded");
+        }
+      },
+    });
+    current = false;
+
+    await expect(pending).rejects.toThrow("projection superseded");
+    expect(lookupCachedContextTokens("prior-model")).toBe(48_000);
+    expect(lookupCachedContextTokens("superseded-1023")).toBeUndefined();
+  });
+});

--- a/src/agents/context-cache-projection.ts
+++ b/src/agents/context-cache-projection.ts
@@ -1,0 +1,261 @@
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { providerContextTokenCacheKey } from "./context-cache.js";
+import { type ModelsConfig, resolveAnthropicFixedContextWindow } from "./context-resolution.js";
+import { normalizeProviderId } from "./model-selection.js";
+
+const CONTEXT_PROJECTION_BATCH_SIZE = 512;
+
+type ContextWindowModelEntry = {
+  id: string;
+  provider?: string;
+  contextWindow?: number;
+  contextTokens?: number;
+};
+
+export type ContextWindowCatalog = {
+  entries: ContextWindowModelEntry[];
+  staticEntries?: ContextWindowModelEntry[];
+};
+
+type PreparedContextWindowCaches = {
+  configuredTokenCache: Map<string, number>;
+  discoveredTokenCache: Map<string, number>;
+  contextWindowCache: Map<string, number>;
+};
+
+type ConfiguredProvider = NonNullable<ModelsConfig["providers"]>[string];
+type ConfiguredModel = NonNullable<NonNullable<ConfiguredProvider>["models"]>[number];
+
+function cacheMinimum(cache: Map<string, number>, key: string, contextTokens: number): void {
+  const existing = cache.get(key);
+  if (existing === undefined || contextTokens < existing) {
+    cache.set(key, contextTokens);
+  }
+}
+
+function applyDiscoveredContextWindow(
+  cache: Map<string, number>,
+  model: ContextWindowModelEntry,
+): void {
+  if (!model?.id) {
+    return;
+  }
+  const discoveredContextTokens =
+    typeof model.contextTokens === "number"
+      ? Math.trunc(model.contextTokens)
+      : typeof model.contextWindow === "number"
+        ? Math.trunc(model.contextWindow)
+        : undefined;
+  const contextTokens =
+    resolveDiscoveredAnthropicFixedContextWindow(model) ?? discoveredContextTokens;
+  if (!contextTokens || contextTokens <= 0) {
+    return;
+  }
+
+  cacheMinimum(cache, model.id, contextTokens);
+  if (typeof model.provider !== "string") {
+    return;
+  }
+  const provider = normalizeProviderId(model.provider);
+  if (!provider) {
+    return;
+  }
+  cacheMinimum(cache, providerContextTokenCacheKey(provider, model.id), contextTokens);
+  const slash = model.id.indexOf("/");
+  const prefixedProvider = slash > 0 ? normalizeProviderId(model.id.slice(0, slash)) : "";
+  const bareModelId = slash > 0 ? model.id.slice(slash + 1).trim() : "";
+  if (prefixedProvider === provider && bareModelId) {
+    cacheMinimum(cache, providerContextTokenCacheKey(provider, bareModelId), contextTokens);
+  }
+}
+
+export function applyDiscoveredContextWindows(params: {
+  cache: Map<string, number>;
+  models: ContextWindowModelEntry[];
+}): void {
+  for (const model of params.models) {
+    applyDiscoveredContextWindow(params.cache, model);
+  }
+}
+
+export function applyConfiguredContextWindows(params: {
+  cache: Map<string, number>;
+  windowCache: Map<string, number>;
+  modelsConfig: ModelsConfig | undefined;
+}): void {
+  const providers = params.modelsConfig?.providers;
+  if (!providers || typeof providers !== "object") {
+    return;
+  }
+  for (const [providerId, provider] of Object.entries(providers)) {
+    if (!Array.isArray(provider?.models)) {
+      continue;
+    }
+    for (const model of provider.models) {
+      applyConfiguredContextWindow({
+        cache: params.cache,
+        windowCache: params.windowCache,
+        providerId,
+        provider,
+        model,
+      });
+    }
+  }
+}
+
+function applyConfiguredContextWindow(params: {
+  cache: Map<string, number>;
+  windowCache: Map<string, number>;
+  providerId: string;
+  provider: NonNullable<ConfiguredProvider>;
+  model: ConfiguredModel;
+}): void {
+  const modelId = typeof params.model?.id === "string" ? params.model.id : undefined;
+  const contextTokens =
+    typeof params.model?.contextTokens === "number"
+      ? params.model.contextTokens
+      : typeof params.provider.contextTokens === "number"
+        ? params.provider.contextTokens
+        : undefined;
+  const contextWindow =
+    typeof params.model?.contextWindow === "number"
+      ? params.model.contextWindow
+      : typeof params.provider.contextWindow === "number"
+        ? params.provider.contextWindow
+        : undefined;
+  const configuredValue =
+    contextTokens && contextTokens > 0
+      ? { cache: params.cache, value: contextTokens }
+      : contextWindow && contextWindow > 0
+        ? { cache: params.windowCache, value: contextWindow }
+        : undefined;
+  if (!modelId || !configuredValue) {
+    return;
+  }
+  const provider = normalizeProviderId(params.providerId);
+  configuredValue.cache.set(modelId, configuredValue.value);
+  configuredValue.cache.set(providerContextTokenCacheKey(provider, modelId), configuredValue.value);
+  const slash = modelId.indexOf("/");
+  const prefixedProvider = slash > 0 ? normalizeProviderId(modelId.slice(0, slash)) : "";
+  const bareModelId = slash > 0 ? modelId.slice(slash + 1).trim() : "";
+  if (provider && prefixedProvider === provider && bareModelId) {
+    configuredValue.cache.set(
+      providerContextTokenCacheKey(provider, bareModelId),
+      configuredValue.value,
+    );
+  }
+}
+
+function resolveDiscoveredAnthropicFixedContextWindow(
+  model: ContextWindowModelEntry,
+): number | undefined {
+  const provider =
+    typeof model.provider === "string" ? normalizeProviderId(model.provider) : undefined;
+  if (provider) {
+    return resolveAnthropicFixedContextWindow(provider, model.id);
+  }
+  const normalized = normalizeLowercaseStringOrEmpty(model.id);
+  const slash = normalized.indexOf("/");
+  if (slash < 0) {
+    return undefined;
+  }
+  const inferredProvider = normalizeProviderId(normalized.slice(0, slash));
+  const inferredModel = normalized.slice(slash + 1);
+  return inferredProvider === "claude-cli"
+    ? resolveAnthropicFixedContextWindow(inferredProvider, inferredModel)
+    : undefined;
+}
+
+function yieldToGateway(): Promise<void> {
+  return new Promise<void>((resolve) => {
+    setImmediate(resolve);
+  });
+}
+
+async function projectModels(params: {
+  cache: Map<string, number>;
+  models: ContextWindowModelEntry[];
+  processed: { count: number };
+  assertCurrent?: () => void;
+}): Promise<void> {
+  for (const model of params.models) {
+    applyDiscoveredContextWindow(params.cache, model);
+    params.processed.count += 1;
+    if (params.processed.count % CONTEXT_PROJECTION_BATCH_SIZE === 0) {
+      await yieldToGateway();
+      params.assertCurrent?.();
+    }
+  }
+}
+
+export async function prepareContextWindowCaches(params: {
+  config: OpenClawConfig;
+  modelCatalog: ContextWindowCatalog;
+  assertCurrent?: () => void;
+}): Promise<PreparedContextWindowCaches> {
+  const caches: PreparedContextWindowCaches = {
+    configuredTokenCache: new Map(),
+    discoveredTokenCache: new Map(),
+    contextWindowCache: new Map(),
+  };
+  const processed = { count: 0 };
+  const providers = (params.config.models as ModelsConfig | undefined)?.providers;
+  if (providers && typeof providers === "object") {
+    for (const [providerId, provider] of Object.entries(providers)) {
+      if (!Array.isArray(provider?.models)) {
+        continue;
+      }
+      for (const model of provider.models) {
+        applyConfiguredContextWindow({
+          cache: caches.configuredTokenCache,
+          windowCache: caches.contextWindowCache,
+          providerId,
+          provider,
+          model,
+        });
+        processed.count += 1;
+        if (processed.count % CONTEXT_PROJECTION_BATCH_SIZE === 0) {
+          await yieldToGateway();
+          params.assertCurrent?.();
+        }
+      }
+    }
+  }
+  await projectModels({
+    cache: caches.discoveredTokenCache,
+    models: params.modelCatalog.entries,
+    processed,
+    assertCurrent: params.assertCurrent,
+  });
+  await projectModels({
+    cache: caches.discoveredTokenCache,
+    models: params.modelCatalog.staticEntries ?? [],
+    processed,
+    assertCurrent: params.assertCurrent,
+  });
+  params.assertCurrent?.();
+  return caches;
+}
+
+export async function prepareDiscoveredContextTokenCache(params: {
+  modelCatalog: ContextWindowCatalog;
+  assertCurrent?: () => void;
+}): Promise<Map<string, number>> {
+  const cache = new Map<string, number>();
+  const processed = { count: 0 };
+  await projectModels({
+    cache,
+    models: params.modelCatalog.entries,
+    processed,
+    assertCurrent: params.assertCurrent,
+  });
+  await projectModels({
+    cache,
+    models: params.modelCatalog.staticEntries ?? [],
+    processed,
+    assertCurrent: params.assertCurrent,
+  });
+  params.assertCurrent?.();
+  return cache;
+}

--- a/src/agents/context-cache.ts
+++ b/src/agents/context-cache.ts
@@ -1,7 +1,44 @@
-/** Process-local model context window cache keyed by model id. */
-export const MODEL_CONTEXT_TOKEN_CACHE = new Map<string, number>();
-export const MODEL_CONFIGURED_CONTEXT_TOKEN_CACHE = new Map<string, number>();
-export const MODEL_CONTEXT_WINDOW_CACHE = new Map<string, number>();
+type ContextWindowCacheState = {
+  configuredTokenCache: Map<string, number>;
+  discoveredTokenCache: Map<string, number>;
+  contextWindowCache: Map<string, number>;
+};
+
+const CONTEXT_WINDOW_CACHE_STATE_KEY = Symbol.for("openclaw.contextWindowCacheState");
+const contextWindowCacheGlobal = globalThis as typeof globalThis & {
+  [CONTEXT_WINDOW_CACHE_STATE_KEY]?: ContextWindowCacheState;
+};
+export const REUSED_CONTEXT_WINDOW_CACHE_STATE =
+  contextWindowCacheGlobal[CONTEXT_WINDOW_CACHE_STATE_KEY] !== undefined;
+const CONTEXT_WINDOW_CACHE_STATE = (contextWindowCacheGlobal[CONTEXT_WINDOW_CACHE_STATE_KEY] ??= {
+  configuredTokenCache: new Map(),
+  discoveredTokenCache: new Map(),
+  contextWindowCache: new Map(),
+});
+
+/** Returns the current process-global cache generation. */
+export function getContextWindowCaches(): ContextWindowCacheState {
+  return CONTEXT_WINDOW_CACHE_STATE;
+}
+
+/** Publish one complete context generation without copying it on the gateway thread. */
+export function replaceContextWindowCaches(params: ContextWindowCacheState): void {
+  CONTEXT_WINDOW_CACHE_STATE.configuredTokenCache = params.configuredTokenCache;
+  CONTEXT_WINDOW_CACHE_STATE.discoveredTokenCache = params.discoveredTokenCache;
+  CONTEXT_WINDOW_CACHE_STATE.contextWindowCache = params.contextWindowCache;
+}
+
+/** Publish one complete discovered-metadata generation. */
+export function replaceDiscoveredContextTokenCache(cache: Map<string, number>): void {
+  CONTEXT_WINDOW_CACHE_STATE.discoveredTokenCache = cache;
+}
+
+/** Clear the current process-global cache generation. */
+export function clearContextWindowCaches(): void {
+  CONTEXT_WINDOW_CACHE_STATE.configuredTokenCache.clear();
+  CONTEXT_WINDOW_CACHE_STATE.discoveredTokenCache.clear();
+  CONTEXT_WINDOW_CACHE_STATE.contextWindowCache.clear();
+}
 
 const PROVIDER_CONTEXT_TOKEN_CACHE_PREFIX = "\0provider:";
 
@@ -16,7 +53,8 @@ export function lookupCachedContextTokens(modelId?: string): number | undefined 
     return undefined;
   }
   return (
-    MODEL_CONFIGURED_CONTEXT_TOKEN_CACHE.get(modelId) ?? MODEL_CONTEXT_TOKEN_CACHE.get(modelId)
+    CONTEXT_WINDOW_CACHE_STATE.configuredTokenCache.get(modelId) ??
+    CONTEXT_WINDOW_CACHE_STATE.discoveredTokenCache.get(modelId)
   );
 }
 
@@ -25,7 +63,7 @@ export function lookupCachedContextWindow(modelId?: string): number | undefined 
   if (!modelId) {
     return undefined;
   }
-  return MODEL_CONTEXT_WINDOW_CACHE.get(modelId);
+  return CONTEXT_WINDOW_CACHE_STATE.contextWindowCache.get(modelId);
 }
 
 /** Returns the lowest positive context limit from independently sourced metadata. */

--- a/src/agents/context-runtime-state.test.ts
+++ b/src/agents/context-runtime-state.test.ts
@@ -7,15 +7,18 @@ afterEach(() => {
 });
 
 describe("context runtime state", () => {
-  it("normalizes the singleton shape held by a released gateway", () => {
+  it("invalidates a released load marker when the process-global cache is introduced", () => {
     const moduleUrl = new URL("./context-runtime-state.ts", import.meta.url).href;
     const output = execNodeEvalSync(
       `
-        const key = Symbol.for("openclaw.contextWindowRuntimeState");
+        const runtimeKey = Symbol.for("openclaw.contextWindowRuntimeState");
+        delete globalThis[Symbol.for("openclaw.contextWindowCacheState")];
         const legacyLoadPromise = Promise.resolve();
-        globalThis[key] = {
+        globalThis[runtimeKey] = {
+          generation: 7,
+          loadGeneration: 7,
           loadPromise: legacyLoadPromise,
-          configuredConfig: undefined,
+          configuredConfig: { models: {} },
           configLoadFailures: 0,
           nextConfigLoadAttemptAtMs: 0,
           modelsConfigRuntimeLoader: { clear() {} },
@@ -24,12 +27,13 @@ describe("context runtime state", () => {
         process.stdout.write([
           state.generation,
           state.loadGeneration === null,
-          state.loadPromise === legacyLoadPromise,
+          state.loadPromise === null,
+          state.configuredConfig?.models !== undefined,
         ].join(":"));
       `,
       { imports: ["tsx"] },
     );
 
-    expect(output).toBe("0:true:true");
+    expect(output).toBe("7:true:true:true");
   });
 });

--- a/src/agents/context-runtime-state.ts
+++ b/src/agents/context-runtime-state.ts
@@ -5,11 +5,7 @@
  */
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createLazyImportLoader, type LazyPromiseLoader } from "../shared/lazy-promise.js";
-import {
-  MODEL_CONFIGURED_CONTEXT_TOKEN_CACHE,
-  MODEL_CONTEXT_TOKEN_CACHE,
-  MODEL_CONTEXT_WINDOW_CACHE,
-} from "./context-cache.js";
+import { clearContextWindowCaches, REUSED_CONTEXT_WINDOW_CACHE_STATE } from "./context-cache.js";
 
 const CONTEXT_WINDOW_RUNTIME_STATE_KEY = Symbol.for("openclaw.contextWindowRuntimeState");
 
@@ -47,6 +43,12 @@ export const CONTEXT_WINDOW_RUNTIME_STATE = (() => {
     };
     globalState[CONTEXT_WINDOW_RUNTIME_STATE_KEY] = state as ContextWindowRuntimeState;
   } else {
+    if (!REUSED_CONTEXT_WINDOW_CACHE_STATE) {
+      // Released modules kept cache maps outside this singleton. Force one fresh load
+      // instead of pairing their completed marker with newly introduced empty maps.
+      state.loadPromise = null;
+      state.loadGeneration = null;
+    }
     // Normalize the exact state shape held by released gateways before this
     // module added generation tracking; otherwise refresh increments NaN.
     if (typeof state.generation !== "number") {
@@ -76,9 +78,7 @@ export function beginContextWindowCacheRefresh(): void {
 function resetContextWindowCache(): void {
   beginContextWindowCacheRefresh();
   CONTEXT_WINDOW_RUNTIME_STATE.modelsConfigRuntimeLoader.clear();
-  MODEL_CONFIGURED_CONTEXT_TOKEN_CACHE.clear();
-  MODEL_CONTEXT_TOKEN_CACHE.clear();
-  MODEL_CONTEXT_WINDOW_CACHE.clear();
+  clearContextWindowCaches();
 }
 
 /** Reset context-window runtime state and token cache for isolated tests. */

--- a/src/agents/context.lookup.test.ts
+++ b/src/agents/context.lookup.test.ts
@@ -2,6 +2,7 @@
 // model resolution.
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { replaceDiscoveredContextTokenCache } from "./context-cache.js";
 import { ANTHROPIC_CONTEXT_1M_TOKENS } from "./context-resolution.js";
 import { CONTEXT_WINDOW_RUNTIME_STATE } from "./context-runtime-state.js";
 
@@ -27,14 +28,27 @@ const contextTestState = vi.hoisted(() => {
         staticEntries: state.staticCatalogModels,
       },
     })),
-    loadPublishedModelCatalogOwnerSnapshot: vi.fn(async (_params: unknown) => ({
-      config: state.loadConfigImpl() as OpenClawConfig,
-      modelCatalog: {
-        entries: state.discoveredModels,
-        routeVariants: [],
-        staticEntries: state.staticCatalogModels,
-      },
-    })),
+    getPublishedModelCatalogOwnerSnapshot: vi.fn(
+      (
+        _params: unknown,
+      ):
+        | {
+            config: OpenClawConfig;
+            modelCatalog: {
+              entries: DiscoveredModel[];
+              routeVariants: never[];
+              staticEntries: DiscoveredModel[];
+            };
+          }
+        | undefined => ({
+        config: state.loadConfigImpl() as OpenClawConfig,
+        modelCatalog: {
+          entries: state.discoveredModels,
+          routeVariants: [],
+          staticEntries: state.staticCatalogModels,
+        },
+      }),
+    ),
   };
   return state;
 });
@@ -52,8 +66,8 @@ vi.mock("../config/runtime-source-projection.js", () => ({
 
 vi.mock("./prepared-model-catalog.js", () => ({
   loadPreparedModelCatalogOwnerSnapshot: contextTestState.loadModelCatalogOwnerSnapshot,
-  loadPublishedPreparedModelCatalogOwnerSnapshot:
-    contextTestState.loadPublishedModelCatalogOwnerSnapshot,
+  getPublishedPreparedModelCatalogOwnerSnapshot:
+    contextTestState.getPublishedModelCatalogOwnerSnapshot,
 }));
 
 function mockContextDeps(params: {
@@ -150,8 +164,8 @@ describe("lookupContextTokens", () => {
         staticEntries: contextTestState.staticCatalogModels,
       },
     }));
-    contextTestState.loadPublishedModelCatalogOwnerSnapshot.mockClear();
-    contextTestState.loadPublishedModelCatalogOwnerSnapshot.mockImplementation(async () => ({
+    contextTestState.getPublishedModelCatalogOwnerSnapshot.mockClear();
+    contextTestState.getPublishedModelCatalogOwnerSnapshot.mockImplementation(() => ({
       config: contextTestState.loadConfigImpl() as OpenClawConfig,
       modelCatalog: {
         entries: contextTestState.discoveredModels,
@@ -393,7 +407,7 @@ describe("lookupContextTokens", () => {
     expect(contextTestState.loadModelCatalogOwnerSnapshot).toHaveBeenCalledWith(
       expect.objectContaining({ config, readOnly: true }),
     );
-    expect(contextTestState.loadPublishedModelCatalogOwnerSnapshot).not.toHaveBeenCalled();
+    expect(contextTestState.getPublishedModelCatalogOwnerSnapshot).not.toHaveBeenCalled();
     expect(
       lookupContextTokens("anthropic/claude-opus-4.7-20260219", { allowAsyncLoad: false }),
     ).toBe(ANTHROPIC_CONTEXT_1M_TOKENS);
@@ -402,7 +416,7 @@ describe("lookupContextTokens", () => {
   it("warms from the current Gateway-published owner without hashing a fallback owner key", async () => {
     const requestedConfig = createContextOverrideConfig("synthetic", "stale-model", 111_000);
     const publishedConfig = createContextOverrideConfig("synthetic", "current-model", 222_000);
-    contextTestState.loadPublishedModelCatalogOwnerSnapshot.mockResolvedValueOnce({
+    contextTestState.getPublishedModelCatalogOwnerSnapshot.mockReturnValueOnce({
       config: publishedConfig,
       modelCatalog: {
         entries: [{ id: "discovered-model", provider: "synthetic", contextWindow: 64_000 }],
@@ -415,13 +429,15 @@ describe("lookupContextTokens", () => {
       await importContextModule();
     await prewarmContextWindowCacheAfterReady({ config: requestedConfig });
 
-    expect(contextTestState.loadPublishedModelCatalogOwnerSnapshot).toHaveBeenCalledWith(
+    expect(contextTestState.getPublishedModelCatalogOwnerSnapshot).toHaveBeenCalledWith(
       expect.objectContaining({
         config: requestedConfig,
         allowGatewaySubagentBinding: true,
-        readOnly: true,
       }),
     );
+    expect(
+      contextTestState.getPublishedModelCatalogOwnerSnapshot.mock.calls[0]?.[0],
+    ).not.toHaveProperty("readOnly");
     expect(contextTestState.loadModelCatalogOwnerSnapshot).not.toHaveBeenCalled();
     expect(
       lookupContextTokens("current-model", {
@@ -441,6 +457,56 @@ describe("lookupContextTokens", () => {
         skipRuntimeConfigLoad: true,
       }),
     ).toBeUndefined();
+  });
+
+  it("retires a failed published-owner load so exact request-time loading can recover", async () => {
+    contextTestState.getPublishedModelCatalogOwnerSnapshot.mockReturnValueOnce(undefined);
+    const config = createContextOverrideConfig("synthetic", "recovered-model", 96_000);
+    contextTestState.loadConfigImpl = () => config;
+
+    const { ensureContextWindowCacheLoaded, prewarmContextWindowCacheAfterReady } =
+      await importContextModule();
+    await expect(prewarmContextWindowCacheAfterReady({ config })).resolves.toBeUndefined();
+    expect(CONTEXT_WINDOW_RUNTIME_STATE.loadPromise).toBeNull();
+    expect(CONTEXT_WINDOW_RUNTIME_STATE.loadGeneration).toBeNull();
+    expect(CONTEXT_WINDOW_RUNTIME_STATE.configuredConfig).toBeUndefined();
+
+    await ensureContextWindowCacheLoaded();
+    expect(contextTestState.loadModelCatalogOwnerSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({ config, readOnly: true }),
+    );
+  });
+
+  it("retires stale discovered metadata when exact catalog loading fails", async () => {
+    replaceDiscoveredContextTokenCache(new Map([["stale-model", 999_000]]));
+    contextTestState.loadModelCatalogOwnerSnapshot.mockRejectedValueOnce(
+      new Error("catalog unavailable"),
+    );
+
+    const { ensureContextWindowCacheLoaded, lookupContextTokens } = await importContextModule();
+    await ensureContextWindowCacheLoaded(
+      createContextOverrideConfig("synthetic", "current-model", 96_000),
+    );
+
+    expect(
+      lookupContextTokens("stale-model", {
+        allowAsyncLoad: false,
+        skipRuntimeConfigLoad: true,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("retires an unpublished prewarm marker when shutdown cancels during import", async () => {
+    let cancelled = false;
+    const pending = contextModule.prewarmContextWindowCacheAfterReady({
+      config: {},
+      isCancelled: () => cancelled,
+    });
+    cancelled = true;
+
+    await pending;
+    expect(CONTEXT_WINDOW_RUNTIME_STATE.loadPromise).toBeNull();
+    expect(CONTEXT_WINDOW_RUNTIME_STATE.loadGeneration).toBeNull();
   });
 
   it("warms fresh caches instead of reusing a pre-generation load promise", async () => {

--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -2,12 +2,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSessionManagerRuntimeRegistry } from "./agent-hooks/session-manager-runtime-registry.js";
-import {
-  MODEL_CONFIGURED_CONTEXT_TOKEN_CACHE,
-  MODEL_CONTEXT_TOKEN_CACHE,
-  MODEL_CONTEXT_WINDOW_CACHE,
-  providerContextTokenCacheKey,
-} from "./context-cache.js";
+import { getContextWindowCaches, providerContextTokenCacheKey } from "./context-cache.js";
 import {
   ANTHROPIC_CONTEXT_1M_TOKENS,
   ANTHROPIC_FABLE_CONTEXT_TOKENS,
@@ -315,8 +310,8 @@ describe("resolveContextTokensForModel", () => {
   ])("resolves the corrected %s/%s context window", (provider, model) => {
     resetContextWindowCacheForTest();
     try {
-      MODEL_CONTEXT_TOKEN_CACHE.set(model, 200_000);
-      MODEL_CONTEXT_TOKEN_CACHE.set(
+      getContextWindowCaches().discoveredTokenCache.set(model, 200_000);
+      getContextWindowCaches().discoveredTokenCache.set(
         providerContextTokenCacheKey(provider, model),
         ANTHROPIC_CONTEXT_1M_TOKENS,
       );
@@ -338,7 +333,10 @@ describe("resolveContextTokensForModel", () => {
     (model) => {
       resetContextWindowCacheForTest();
       try {
-        MODEL_CONTEXT_TOKEN_CACHE.set(providerContextTokenCacheKey("claude-cli", model), 200_000);
+        getContextWindowCaches().discoveredTokenCache.set(
+          providerContextTokenCacheKey("claude-cli", model),
+          200_000,
+        );
         expect(
           resolveContextTokensForModel({
             provider: "claude-cli",
@@ -369,7 +367,7 @@ describe("resolveContextTokensForModel", () => {
     resetContextWindowCacheForTest();
     try {
       applyDiscoveredContextWindows({
-        cache: MODEL_CONTEXT_TOKEN_CACHE,
+        cache: getContextWindowCaches().discoveredTokenCache,
         models: [{ id: "large", contextTokens: 32_000 }],
       });
 
@@ -933,7 +931,7 @@ describe("resolveContextTokensForModel", () => {
     resetContextWindowCacheForTest();
     try {
       applyDiscoveredContextWindows({
-        cache: MODEL_CONTEXT_TOKEN_CACHE,
+        cache: getContextWindowCaches().discoveredTokenCache,
         models: [
           { id: "gpt-5.5", contextWindow: 272_000 },
           {
@@ -958,7 +956,7 @@ describe("resolveContextTokensForModel", () => {
 
       resetContextWindowCacheForTest();
       applyDiscoveredContextWindows({
-        cache: MODEL_CONTEXT_TOKEN_CACHE,
+        cache: getContextWindowCaches().discoveredTokenCache,
         models: [{ id: "google/gemini-2.5-pro", contextWindow: 128_000 }],
       });
       expect(resolveCached("openrouter", "google/gemini-2.5-pro")).toBe(1_000_000);
@@ -971,12 +969,12 @@ describe("resolveContextTokensForModel", () => {
     resetContextWindowCacheForTest();
     try {
       applyDiscoveredContextWindows({
-        cache: MODEL_CONTEXT_TOKEN_CACHE,
+        cache: getContextWindowCaches().discoveredTokenCache,
         models: [{ provider: "openai", id: "gpt-5.5", contextWindow: 272_000 }],
       });
       applyConfiguredContextWindows({
-        cache: MODEL_CONFIGURED_CONTEXT_TOKEN_CACHE,
-        windowCache: MODEL_CONTEXT_WINDOW_CACHE,
+        cache: getContextWindowCaches().configuredTokenCache,
+        windowCache: getContextWindowCaches().contextWindowCache,
         modelsConfig: {
           providers: {
             openai: {
@@ -1003,7 +1001,7 @@ describe("resolveContextTokensForModel", () => {
     resetContextWindowCacheForTest();
     try {
       applyDiscoveredContextWindows({
-        cache: MODEL_CONTEXT_TOKEN_CACHE,
+        cache: getContextWindowCaches().discoveredTokenCache,
         models: [{ provider: "openai", id: "gpt-5.5", contextTokens: 200_000 }],
       });
 
@@ -1026,7 +1024,7 @@ describe("resolveContextTokensForModel", () => {
     resetContextWindowCacheForTest();
     try {
       applyDiscoveredContextWindows({
-        cache: MODEL_CONTEXT_TOKEN_CACHE,
+        cache: getContextWindowCaches().discoveredTokenCache,
         models: [{ provider: "openai", id: "gpt-5.5", contextTokens: 200_000 }],
       });
 
@@ -1058,8 +1056,8 @@ describe("resolveContextTokensForModel", () => {
     resetContextWindowCacheForTest();
     try {
       applyConfiguredContextWindows({
-        cache: MODEL_CONTEXT_TOKEN_CACHE,
-        windowCache: MODEL_CONTEXT_WINDOW_CACHE,
+        cache: getContextWindowCaches().discoveredTokenCache,
+        windowCache: getContextWindowCaches().contextWindowCache,
         modelsConfig: {
           providers: {
             openai: {
@@ -1087,8 +1085,8 @@ describe("resolveContextTokensForModel", () => {
     resetContextWindowCacheForTest();
     try {
       applyConfiguredContextWindows({
-        cache: MODEL_CONTEXT_TOKEN_CACHE,
-        windowCache: MODEL_CONTEXT_WINDOW_CACHE,
+        cache: getContextWindowCaches().discoveredTokenCache,
+        windowCache: getContextWindowCaches().contextWindowCache,
         modelsConfig: {
           providers: {
             openai: {

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -1,32 +1,34 @@
 // Load session runtime model metadata so we can infer context windows when the
 // agent reports a model id. This includes custom models.json entries.
 
-import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { getRuntimeConfig } from "../config/config.js";
 import { projectConfigOntoRuntimeSourceSnapshot } from "../config/runtime-source-projection.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { computeBackoff, type BackoffPolicy } from "../infra/backoff.js";
 import { resolveAgentDir, resolveDefaultAgentId } from "./agent-scope.js";
 import {
+  applyConfiguredContextWindows,
+  type ContextWindowCatalog,
+  prepareContextWindowCaches,
+  prepareDiscoveredContextTokenCache,
+} from "./context-cache-projection.js";
+import {
+  getContextWindowCaches,
   lookupCachedContextTokens,
   lookupCachedContextWindow,
   minPositiveContextTokens,
-  MODEL_CONFIGURED_CONTEXT_TOKEN_CACHE,
-  MODEL_CONTEXT_TOKEN_CACHE,
-  MODEL_CONTEXT_WINDOW_CACHE,
-  providerContextTokenCacheKey,
+  replaceContextWindowCaches,
+  replaceDiscoveredContextTokenCache,
 } from "./context-cache.js";
 import {
   type ContextTokenResolutionParams,
   type ModelsConfig,
-  resolveAnthropicFixedContextWindow,
   resolveContextTokensForModelFromCache,
 } from "./context-resolution.js";
 import {
   beginContextWindowCacheRefresh,
   CONTEXT_WINDOW_RUNTIME_STATE,
 } from "./context-runtime-state.js";
-import { normalizeProviderId } from "./model-selection.js";
 
 export {
   ANTHROPIC_CONTEXT_1M_TOKENS,
@@ -37,19 +39,13 @@ export {
   ANTHROPIC_VERTEX_CONTEXT_1M_TOKENS,
 } from "./context-resolution.js";
 export { resetContextWindowCacheForTest } from "./context-runtime-state.js";
-
-type ModelEntry = {
-  id: string;
-  provider?: string;
-  contextWindow?: number;
-  contextTokens?: number;
-};
+export {
+  applyConfiguredContextWindows,
+  applyDiscoveredContextWindows,
+} from "./context-cache-projection.js";
 type ContextWindowCatalogOwner = {
   config: OpenClawConfig;
-  modelCatalog: {
-    entries: ModelEntry[];
-    staticEntries?: ModelEntry[];
-  };
+  modelCatalog: ContextWindowCatalog;
 };
 const CONFIG_LOAD_RETRY_POLICY: BackoffPolicy = {
   initialMs: 1_000,
@@ -59,111 +55,13 @@ const CONFIG_LOAD_RETRY_POLICY: BackoffPolicy = {
 };
 const loadPreparedModelCatalogRuntime = () => import("./prepared-model-catalog.js");
 
-export function applyDiscoveredContextWindows(params: {
-  cache: Map<string, number>;
-  models: ModelEntry[];
-}) {
-  const cacheMinimum = (key: string, contextTokens: number) => {
-    const existing = params.cache.get(key);
-    if (existing === undefined || contextTokens < existing) {
-      params.cache.set(key, contextTokens);
-    }
-  };
-
-  for (const model of params.models) {
-    if (!model?.id) {
-      continue;
-    }
-    const discoveredContextTokens =
-      typeof model.contextTokens === "number"
-        ? Math.trunc(model.contextTokens)
-        : typeof model.contextWindow === "number"
-          ? Math.trunc(model.contextWindow)
-          : undefined;
-    const contextTokens =
-      resolveDiscoveredAnthropicFixedContextWindow(model) ?? discoveredContextTokens;
-    if (!contextTokens || contextTokens <= 0) {
-      continue;
-    }
-    // Cache the most conservative effective limit. Provider/runtime callers that
-    // know the active provider prefer the provider-owned entry below.
-    cacheMinimum(model.id, contextTokens);
-    if (typeof model.provider === "string") {
-      const provider = normalizeProviderId(model.provider);
-      if (provider) {
-        cacheMinimum(providerContextTokenCacheKey(provider, model.id), contextTokens);
-        const slash = model.id.indexOf("/");
-        const prefixedProvider = slash > 0 ? normalizeProviderId(model.id.slice(0, slash)) : "";
-        const bareModelId = slash > 0 ? model.id.slice(slash + 1).trim() : "";
-        // Some registries preserve a self-prefixed id alongside provider ownership.
-        // Cache its bare form without stripping cross-provider ids such as OpenRouter rows.
-        if (prefixedProvider === provider && bareModelId) {
-          cacheMinimum(providerContextTokenCacheKey(provider, bareModelId), contextTokens);
-        }
-      }
-    }
-  }
-}
-
-export function applyConfiguredContextWindows(params: {
-  cache: Map<string, number>;
-  windowCache: Map<string, number>;
-  modelsConfig: ModelsConfig | undefined;
-}) {
-  const providers = params.modelsConfig?.providers;
-  if (!providers || typeof providers !== "object") {
-    return;
-  }
-  for (const [providerId, provider] of Object.entries(providers)) {
-    if (!Array.isArray(provider?.models)) {
-      continue;
-    }
-    for (const model of provider.models) {
-      const modelId = typeof model?.id === "string" ? model.id : undefined;
-      const contextTokens =
-        typeof model?.contextTokens === "number"
-          ? model.contextTokens
-          : typeof provider?.contextTokens === "number"
-            ? provider.contextTokens
-            : undefined;
-      const contextWindow =
-        typeof model?.contextWindow === "number"
-          ? model.contextWindow
-          : typeof provider?.contextWindow === "number"
-            ? provider.contextWindow
-            : undefined;
-      const configuredValue =
-        contextTokens && contextTokens > 0
-          ? { cache: params.cache, value: contextTokens }
-          : contextWindow && contextWindow > 0
-            ? { cache: params.windowCache, value: contextWindow }
-            : undefined;
-      if (!modelId || !configuredValue) {
-        continue;
-      }
-      configuredValue.cache.set(modelId, configuredValue.value);
-      configuredValue.cache.set(
-        providerContextTokenCacheKey(normalizeProviderId(providerId), modelId),
-        configuredValue.value,
-      );
-      const normalizedProvider = normalizeProviderId(providerId);
-      const slash = modelId.indexOf("/");
-      const prefixedProvider = slash > 0 ? normalizeProviderId(modelId.slice(0, slash)) : "";
-      const bareModelId = slash > 0 ? modelId.slice(slash + 1).trim() : "";
-      if (normalizedProvider && prefixedProvider === normalizedProvider && bareModelId) {
-        configuredValue.cache.set(
-          providerContextTokenCacheKey(normalizedProvider, bareModelId),
-          configuredValue.value,
-        );
-      }
-    }
-  }
-}
+class ContextWindowCachePrewarmCancelledError extends Error {}
 
 function primeConfiguredContextWindowsFromConfig(cfg: OpenClawConfig): OpenClawConfig {
+  const caches = getContextWindowCaches();
   applyConfiguredContextWindows({
-    cache: MODEL_CONFIGURED_CONTEXT_TOKEN_CACHE,
-    windowCache: MODEL_CONTEXT_WINDOW_CACHE,
+    cache: caches.configuredTokenCache,
+    windowCache: caches.contextWindowCache,
     modelsConfig: cfg.models as ModelsConfig | undefined,
   });
   CONTEXT_WINDOW_RUNTIME_STATE.configuredConfig = cfg;
@@ -213,13 +111,12 @@ function ensureContextWindowCacheLoadedFromOwner(params: {
   if (!cfg) {
     return Promise.resolve();
   }
-  const stagedTokenCache = new Map<string, number>();
-
   CONTEXT_WINDOW_RUNTIME_STATE.loadPromise = Promise.resolve()
     .then(async () => {
       if (CONTEXT_WINDOW_RUNTIME_STATE.generation !== generation) {
         return;
       }
+      let stagedTokenCache = new Map<string, number>();
       try {
         const catalogResult = params.catalogOwner
           ? ({ status: "fulfilled" as const, value: params.catalogOwner } as const)
@@ -240,27 +137,22 @@ function ensureContextWindowCacheLoadedFromOwner(params: {
         if (CONTEXT_WINDOW_RUNTIME_STATE.generation !== generation) {
           return;
         }
-        const models =
-          catalogResult.status === "fulfilled" ? catalogResult.value.modelCatalog.entries : [];
-        const providerStaticModels =
-          catalogResult.status === "fulfilled"
-            ? (catalogResult.value.modelCatalog.staticEntries ?? [])
-            : [];
-        applyDiscoveredContextWindows({
-          cache: stagedTokenCache,
-          models: [...models, ...providerStaticModels],
-        });
+        if (catalogResult.status === "fulfilled") {
+          stagedTokenCache = await prepareDiscoveredContextTokenCache({
+            modelCatalog: catalogResult.value.modelCatalog,
+            assertCurrent: () => {
+              if (CONTEXT_WINDOW_RUNTIME_STATE.generation !== generation) {
+                throw new Error("context window cache generation was superseded");
+              }
+            },
+          });
+        }
       } catch {
         // Static and discovered rows belong to one atomic generation. If its owner fails, keep
         // config overrides only instead of mixing in independently rediscovered static metadata.
       }
-
-      if (CONTEXT_WINDOW_RUNTIME_STATE.generation !== generation) {
-        return;
-      }
-      MODEL_CONTEXT_TOKEN_CACHE.clear();
-      for (const [key, value] of stagedTokenCache) {
-        MODEL_CONTEXT_TOKEN_CACHE.set(key, value);
+      if (CONTEXT_WINDOW_RUNTIME_STATE.generation === generation) {
+        replaceDiscoveredContextTokenCache(stagedTokenCache);
       }
     })
     .catch(() => {
@@ -282,38 +174,71 @@ export async function prewarmContextWindowCacheAfterReady(params: {
   config: OpenClawConfig;
   isCancelled?: () => boolean;
 }): Promise<void> {
+  // Post-ready warmup owns a published-owner generation. Do not reuse a request-time
+  // load that may have completed before Gateway catalog publication.
+  beginContextWindowCacheRefresh();
   const generation = CONTEXT_WINDOW_RUNTIME_STATE.generation;
-  if (
-    CONTEXT_WINDOW_RUNTIME_STATE.loadPromise &&
-    CONTEXT_WINDOW_RUNTIME_STATE.loadGeneration === generation
-  ) {
-    return CONTEXT_WINDOW_RUNTIME_STATE.loadPromise;
-  }
   const shouldStop = () =>
     CONTEXT_WINDOW_RUNTIME_STATE.generation !== generation || params.isCancelled?.() === true;
   if (shouldStop()) {
     return;
   }
-  try {
-    const { loadPublishedPreparedModelCatalogOwnerSnapshot } =
+  let published = false;
+  const loadPromise = (async () => {
+    const { getPublishedPreparedModelCatalogOwnerSnapshot } =
       await loadPreparedModelCatalogRuntime();
     if (shouldStop()) {
       return;
     }
     const defaultAgentId = resolveDefaultAgentId(params.config);
-    const owner = await loadPublishedPreparedModelCatalogOwnerSnapshot({
+    const owner = getPublishedPreparedModelCatalogOwnerSnapshot({
       config: params.config,
       agentId: defaultAgentId,
       agentDir: resolveAgentDir(params.config, defaultAgentId),
       allowGatewaySubagentBinding: true,
-      readOnly: true,
+    });
+    if (!owner) {
+      throw new Error("published Gateway model catalog owner is unavailable");
+    }
+    if (shouldStop()) {
+      return;
+    }
+    // Gateway publication intentionally exposes configured/static turn facts. Full catalog
+    // inventory is a separate control-plane load and must not run in post-ready warmup.
+    const caches = await prepareContextWindowCaches({
+      config: owner.config,
+      modelCatalog: owner.modelCatalog,
+      assertCurrent: () => {
+        if (shouldStop()) {
+          throw new ContextWindowCachePrewarmCancelledError();
+        }
+      },
     });
     if (shouldStop()) {
       return;
     }
-    await ensureContextWindowCacheLoadedFromOwner({ catalogOwner: owner });
+    replaceContextWindowCaches(caches);
+    CONTEXT_WINDOW_RUNTIME_STATE.configuredConfig = owner.config;
+    CONTEXT_WINDOW_RUNTIME_STATE.configLoadFailures = 0;
+    CONTEXT_WINDOW_RUNTIME_STATE.nextConfigLoadAttemptAtMs = 0;
+    published = true;
+  })();
+  const trackedLoadPromise = loadPromise.catch(() => {});
+  CONTEXT_WINDOW_RUNTIME_STATE.loadPromise = trackedLoadPromise;
+  CONTEXT_WINDOW_RUNTIME_STATE.loadGeneration = generation;
+  try {
+    await loadPromise;
   } catch {
     // Optional Gateway warmup is best-effort; request-time loading remains exact.
+  } finally {
+    if (
+      !published &&
+      CONTEXT_WINDOW_RUNTIME_STATE.generation === generation &&
+      CONTEXT_WINDOW_RUNTIME_STATE.loadPromise === trackedLoadPromise
+    ) {
+      CONTEXT_WINDOW_RUNTIME_STATE.loadPromise = null;
+      CONTEXT_WINDOW_RUNTIME_STATE.loadGeneration = null;
+    }
   }
 }
 
@@ -352,8 +277,9 @@ export async function waitForContextWindowCacheLoad(options?: {
 /** Replace cached model context metadata for the active runtime configuration. */
 export async function refreshContextWindowCache(cfg: OpenClawConfig): Promise<void> {
   beginContextWindowCacheRefresh();
-  MODEL_CONFIGURED_CONTEXT_TOKEN_CACHE.clear();
-  MODEL_CONTEXT_WINDOW_CACHE.clear();
+  const caches = getContextWindowCaches();
+  caches.configuredTokenCache.clear();
+  caches.contextWindowCache.clear();
   primeConfiguredContextWindowsFromConfig(cfg);
   await ensureContextWindowCacheLoaded();
 }
@@ -387,25 +313,6 @@ export function lookupContextTokens(
     lookupCachedContextTokens(modelId),
     lookupCachedContextWindow(modelId),
   );
-}
-
-function resolveDiscoveredAnthropicFixedContextWindow(model: ModelEntry): number | undefined {
-  const provider =
-    typeof model.provider === "string" ? normalizeProviderId(model.provider) : undefined;
-  const modelId = model.id;
-  if (provider) {
-    return resolveAnthropicFixedContextWindow(provider, modelId);
-  }
-  const normalized = normalizeLowercaseStringOrEmpty(modelId);
-  const slash = normalized.indexOf("/");
-  if (slash < 0) {
-    return undefined;
-  }
-  const inferredProvider = normalizeProviderId(normalized.slice(0, slash));
-  const inferredModel = normalized.slice(slash + 1);
-  return inferredProvider === "claude-cli"
-    ? resolveAnthropicFixedContextWindow(inferredProvider, inferredModel)
-    : undefined;
 }
 
 export function resolveContextTokensForModel(

--- a/src/agents/prepared-model-catalog.test.ts
+++ b/src/agents/prepared-model-catalog.test.ts
@@ -58,6 +58,7 @@ vi.mock("./prepared-model-runtime.scoped-catalog.js", () => ({
 
 import { PreparedModelCatalogConfigReplacedError } from "./prepared-model-catalog.errors.js";
 import {
+  getPublishedPreparedModelCatalogOwnerSnapshot,
   getPreparedModelCatalogSnapshot,
   loadPreparedModelCatalogSnapshot,
   loadResolvedPublishedModelCatalogOwner,
@@ -103,6 +104,26 @@ describe("prepared model catalog access", () => {
     expect(mocks.getSnapshot).toHaveBeenLastCalledWith(
       expect.objectContaining({ config: mocks.config, readOnly: true }),
     );
+  });
+
+  it("returns the published owner without config matching or catalog materialization", () => {
+    const committedSnapshot = {
+      ...fullSnapshot,
+      config: { agents: { defaults: { model: "openai/committed" } } },
+      loadFullModelCatalog: vi.fn(),
+    };
+    mocks.getSnapshot.mockReturnValue(committedSnapshot);
+
+    expect(
+      getPublishedPreparedModelCatalogOwnerSnapshot({
+        config: { agents: { defaults: { model: "openai/requested" } } },
+        allowGatewaySubagentBinding: true,
+      }),
+    ).toBe(committedSnapshot);
+    expect(mocks.getSnapshot).toHaveBeenCalledOnce();
+    expect(mocks.getSnapshot.mock.calls[0]?.[0]).not.toHaveProperty("readOnly");
+    expect(committedSnapshot.loadFullModelCatalog).not.toHaveBeenCalled();
+    expect(mocks.prepareSnapshot).not.toHaveBeenCalled();
   });
 
   it("prefers the full lifecycle generation for read-only catalog loads", async () => {

--- a/src/agents/prepared-model-catalog.ts
+++ b/src/agents/prepared-model-catalog.ts
@@ -37,6 +37,11 @@ export type LoadPreparedModelCatalogParams = {
   allowGatewaySubagentBinding?: boolean;
 };
 
+export type GetPublishedPreparedModelCatalogOwnerParams = Omit<
+  LoadPreparedModelCatalogParams,
+  "readOnly"
+>;
+
 type PreparedModelCatalogConfigPolicy = "exact" | "published";
 
 async function materializeRequestedModelCatalog(
@@ -140,6 +145,24 @@ export function getPreparedModelCatalogOwnerSnapshot(
   return activatedExact && preparedModelRuntimeConfigsMatch(activatedExact.config, exact.config)
     ? activatedExact
     : undefined;
+}
+
+/**
+ * Returns the currently published lifecycle owner and its configured/static turn facts without
+ * config hashing, fallback construction, or full control-plane catalog materialization.
+ */
+export function getPublishedPreparedModelCatalogOwnerSnapshot(
+  params: GetPublishedPreparedModelCatalogOwnerParams = {},
+): PreparedModelRuntimeSnapshot | undefined {
+  const { activationFull, full } = resolveInputs(params);
+  const published = getPreparedModelRuntimeSnapshot(full);
+  if (published) {
+    return published;
+  }
+  if (activationFull.workspaceDir === full.workspaceDir) {
+    return undefined;
+  }
+  return getPreparedModelRuntimeSnapshot(activationFull);
 }
 
 /** Returns the configured catalog for the current generation without starting discovery. */

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { testing as cliBackendsTesting } from "../../agents/cli-backends.test-support.js";
 import {
-  MODEL_CONTEXT_TOKEN_CACHE,
+  getContextWindowCaches,
   providerContextTokenCacheKey,
 } from "../../agents/context-cache.js";
 import {
@@ -116,7 +116,7 @@ vi.mock("../../agents/auth-profiles/order.js", () => ({
 }));
 
 afterEach(() => {
-  MODEL_CONTEXT_TOKEN_CACHE.clear();
+  getContextWindowCaches().discoveredTokenCache.clear();
   cliBackendsTesting.resetDepsForTest();
   vi.mocked(loadManifestModelCatalog).mockReset();
   vi.mocked(loadManifestModelCatalog).mockReturnValue([]);
@@ -749,8 +749,8 @@ describe("createModelSelectionState catalog loading", () => {
 
 describe("resolveContextTokens", () => {
   it("prefers provider-qualified cache keys over bare model ids", () => {
-    MODEL_CONTEXT_TOKEN_CACHE.set("gemini-3.1-pro-preview", 200_000);
-    MODEL_CONTEXT_TOKEN_CACHE.set(
+    getContextWindowCaches().discoveredTokenCache.set("gemini-3.1-pro-preview", 200_000);
+    getContextWindowCaches().discoveredTokenCache.set(
       providerContextTokenCacheKey("google-gemini-cli", "gemini-3.1-pro-preview"),
       1_000_000,
     );
@@ -766,7 +766,10 @@ describe("resolveContextTokens", () => {
   });
 
   it("treats agent contextTokens as a cap, not an expansion beyond the model window", () => {
-    MODEL_CONTEXT_TOKEN_CACHE.set(providerContextTokenCacheKey("openai", "gpt-5.5"), 272_000);
+    getContextWindowCaches().discoveredTokenCache.set(
+      providerContextTokenCacheKey("openai", "gpt-5.5"),
+      272_000,
+    );
 
     const result = resolveContextTokens({
       cfg: {} as OpenClawConfig,
@@ -779,7 +782,10 @@ describe("resolveContextTokens", () => {
   });
 
   it("allows agent contextTokens to lower a larger model window", () => {
-    MODEL_CONTEXT_TOKEN_CACHE.set(providerContextTokenCacheKey("qwen", "qwen3.6-plus"), 1_000_000);
+    getContextWindowCaches().discoveredTokenCache.set(
+      providerContextTokenCacheKey("qwen", "qwen3.6-plus"),
+      1_000_000,
+    );
 
     const result = resolveContextTokens({
       cfg: {} as OpenClawConfig,

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -3,10 +3,7 @@ import { withTempHome } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { normalizeTestText } from "../../test/helpers/normalize-text.js";
 import { testing as cliBackendsTesting } from "../agents/cli-backends.test-support.js";
-import {
-  MODEL_CONTEXT_TOKEN_CACHE,
-  providerContextTokenCacheKey,
-} from "../agents/context-cache.js";
+import { getContextWindowCaches, providerContextTokenCacheKey } from "../agents/context-cache.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
 import {
@@ -57,7 +54,7 @@ afterEach(() => {
   cliBackendsTesting.resetDepsForTest();
   listPluginCommands.mockReset();
   listPluginCommands.mockImplementation(() => []);
-  MODEL_CONTEXT_TOKEN_CACHE.clear();
+  getContextWindowCaches().discoveredTokenCache.clear();
 });
 
 function registerAnthropicCliBackendForTest(): void {
@@ -2352,7 +2349,7 @@ describe("buildStatusMessage", () => {
   it("keeps transcript-derived slash model ids on model-only context lookup", async () => {
     await withTempHome(
       async (dir) => {
-        MODEL_CONTEXT_TOKEN_CACHE.set("google/gemini-2.5-pro", 999_000);
+        getContextWindowCaches().discoveredTokenCache.set("google/gemini-2.5-pro", 999_000);
 
         const sessionId = "sess-openrouter-google";
         writeTranscriptUsageLog({
@@ -2403,7 +2400,7 @@ describe("buildStatusMessage", () => {
   });
 
   it("keeps runtime slash model ids on model-only context lookup when modelProvider is missing", () => {
-    MODEL_CONTEXT_TOKEN_CACHE.set("google/gemini-2.5-pro", 999_000);
+    getContextWindowCaches().discoveredTokenCache.set("google/gemini-2.5-pro", 999_000);
 
     const text = buildStatusMessage({
       config: {
@@ -2437,7 +2434,7 @@ describe("buildStatusMessage", () => {
   });
 
   it("keeps provider-aware lookup for legacy fallback runtime slash ids", () => {
-    MODEL_CONTEXT_TOKEN_CACHE.clear();
+    getContextWindowCaches().discoveredTokenCache.clear();
 
     const text = buildStatusMessage({
       config: {
@@ -2484,7 +2481,7 @@ describe("buildStatusMessage", () => {
   });
 
   it("keeps provider-aware lookup for non-fallback runtime slash ids", () => {
-    MODEL_CONTEXT_TOKEN_CACHE.clear();
+    getContextWindowCaches().discoveredTokenCache.clear();
 
     const text = buildStatusMessage({
       config: {
@@ -2521,8 +2518,8 @@ describe("buildStatusMessage", () => {
   it("keeps provider-aware lookup for bare transcript model ids", async () => {
     await withTempHome(
       async (dir) => {
-        MODEL_CONTEXT_TOKEN_CACHE.set("gemini-2.5-pro", 128_000);
-        MODEL_CONTEXT_TOKEN_CACHE.set(
+        getContextWindowCaches().discoveredTokenCache.set("gemini-2.5-pro", 128_000);
+        getContextWindowCaches().discoveredTokenCache.set(
           providerContextTokenCacheKey("google-gemini-cli", "gemini-2.5-pro"),
           1_000_000,
         );
@@ -2567,8 +2564,8 @@ describe("buildStatusMessage", () => {
   });
 
   it("prefers provider-qualified context windows for fresh bare model ids", () => {
-    MODEL_CONTEXT_TOKEN_CACHE.set("claude-opus-4-6", 200_000);
-    MODEL_CONTEXT_TOKEN_CACHE.set(
+    getContextWindowCaches().discoveredTokenCache.set("claude-opus-4-6", 200_000);
+    getContextWindowCaches().discoveredTokenCache.set(
       providerContextTokenCacheKey("anthropic", "claude-opus-4-6"),
       1_000_000,
     );
@@ -2595,7 +2592,10 @@ describe("buildStatusMessage", () => {
   });
 
   it("does not let agent contextTokens inflate status above the model window", () => {
-    MODEL_CONTEXT_TOKEN_CACHE.set(providerContextTokenCacheKey("openai", "gpt-5.5"), 272_000);
+    getContextWindowCaches().discoveredTokenCache.set(
+      providerContextTokenCacheKey("openai", "gpt-5.5"),
+      272_000,
+    );
 
     const text = buildStatusMessage({
       agent: {

--- a/src/gateway/server-idle-task.test.ts
+++ b/src/gateway/server-idle-task.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { scheduleGatewayIdleTask } from "./server-idle-task.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("scheduleGatewayIdleTask", () => {
+  it("still completes ordinary idle work", async () => {
+    vi.useFakeTimers();
+    const run = vi.fn(async () => {});
+    const handle = scheduleGatewayIdleTask({
+      delayMs: 10,
+      retryDelayMs: 5,
+      isClosing: () => false,
+      isBusy: () => false,
+      run,
+      log: { warn: vi.fn() },
+      errorMessage: "idle task failed",
+    });
+
+    await vi.advanceTimersByTimeAsync(10);
+    await Promise.resolve();
+    expect(run).toHaveBeenCalledOnce();
+    handle.stop();
+  });
+});

--- a/src/gateway/server.context-prewarm.remote-proof.test.ts
+++ b/src/gateway/server.context-prewarm.remote-proof.test.ts
@@ -1,0 +1,288 @@
+import {
+  monitorEventLoopDelay,
+  performance,
+  PerformanceObserver,
+  type PerformanceEntry,
+} from "node:perf_hooks";
+import { afterEach, describe, expect, it } from "vitest";
+import { prepareContextWindowCaches } from "../agents/context-cache-projection.js";
+import { getContextWindowCaches, replaceContextWindowCaches } from "../agents/context-cache.js";
+import { resetContextWindowCacheForTest } from "../agents/context-runtime-state.js";
+import { resetPreparedModelRuntimeSnapshotsForTest } from "../agents/prepared-model-runtime.test-support.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { connectGatewayClient, disconnectGatewayClient } from "./test-helpers.e2e.js";
+import { getFreePort, installGatewayTestHooks, startGatewayServer } from "./test-helpers.js";
+
+installGatewayTestHooks();
+
+afterEach(() => {
+  resetContextWindowCacheForTest();
+  resetPreparedModelRuntimeSnapshotsForTest();
+});
+
+describe("Gateway context cache remote proof", () => {
+  it("keeps unrelated work responsive during the real post-ready warmup", async () => {
+    const modelCount = Number.parseInt(process.env.SYNTHETIC_MODEL_COUNT ?? "2000", 10);
+    const makeModels = (provider: string, baseWindow: number) =>
+      Array.from({ length: modelCount }, (_, index) => ({
+        id: index === 0 ? "shared-model" : `${provider}-model-${index}`,
+        name: `${provider} model ${index}`,
+        reasoning: false,
+        input: ["text" as const],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: baseWindow + (index % 17),
+        maxTokens: 8_192,
+      }));
+    const port = await getFreePort();
+    const token = "context-prewarm-proof-token";
+    const server = await startGatewayServer(port, {
+      bind: "loopback",
+      auth: { mode: "token", token },
+      controlUiEnabled: false,
+      sidecarStartup: "defer",
+    });
+    const client = await connectGatewayClient({
+      url: `ws://127.0.0.1:${port}`,
+      token,
+      clientDisplayName: "context-prewarm-proof",
+      requestTimeoutMs: 10_000,
+      scopes: ["operator.read", "operator.write", "operator.admin"],
+    });
+    try {
+      const warmConfig = {
+        agents: {
+          defaults: {
+            workspace: process.cwd(),
+            model: { primary: "synthetic-a/shared-model" },
+            models: {
+              "synthetic-a/shared-model": { agentRuntime: { id: "openclaw" } },
+              "synthetic-b/shared-model": { agentRuntime: { id: "openclaw" } },
+            },
+          },
+        },
+        models: {
+          providers: {
+            "synthetic-a": {
+              baseUrl: "http://127.0.0.1:1/v1",
+              api: "openai-completions" as const,
+              models: makeModels("synthetic-a", 128_000),
+            },
+            "synthetic-b": {
+              baseUrl: "http://127.0.0.1:2/v1",
+              api: "openai-completions" as const,
+              models: makeModels("synthetic-b", 64_000),
+            },
+          },
+        },
+      } satisfies OpenClawConfig;
+      const { refreshPreparedModelRuntimeSnapshots } =
+        await import("../agents/prepared-model-runtime.js");
+      await refreshPreparedModelRuntimeSnapshots(warmConfig, {
+        gatewayLifecycle: true,
+        catalogMode: "static",
+        defaultWorkspaceDir: process.cwd(),
+        allowGatewaySubagentBinding: true,
+      });
+      const { getPublishedPreparedModelCatalogOwnerSnapshot } =
+        await import("../agents/prepared-model-catalog.js");
+      const publishedOwner = getPublishedPreparedModelCatalogOwnerSnapshot({
+        config: structuredClone(warmConfig),
+        allowGatewaySubagentBinding: true,
+      });
+      if (!publishedOwner) {
+        throw new Error("synthetic Gateway model catalog owner was not published");
+      }
+      await Promise.all([
+        client.request("health", { probe: true }),
+        client.request("chat.metadata", {}),
+        client.request("worktrees.branches", { repoRoot: process.cwd() }),
+      ]);
+
+      const contextModule = await import("../agents/context.js");
+      contextModule.resetContextWindowCacheForTest();
+
+      const heartbeatGaps: number[] = [];
+      let lastHeartbeatAt = performance.now();
+      const heartbeat = setInterval(() => {
+        const now = performance.now();
+        heartbeatGaps.push(now - lastHeartbeatAt);
+        lastHeartbeatAt = now;
+      }, 20);
+      const delayMonitor = monitorEventLoopDelay({ resolution: 20 });
+      delayMonitor.enable();
+      const eluStart = performance.eventLoopUtilization();
+      const cpuStart = process.cpuUsage();
+      const memoryStart = process.memoryUsage();
+      const resourceStart = process.resourceUsage();
+      const gcDurationsMs: number[] = [];
+      const gcObserver = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries() as PerformanceEntry[]) {
+          gcDurationsMs.push(entry.duration);
+        }
+      });
+      gcObserver.observe({ entryTypes: ["gc"] });
+      const latencies = {
+        healthz: [] as number[],
+        readyz: [] as number[],
+        healthRpc: [] as number[],
+        metadataRpc: [] as number[],
+        branchesRpc: [] as number[],
+      };
+      const errors: string[] = [];
+      const probeRpc = async (
+        name: "healthRpc" | "metadataRpc" | "branchesRpc",
+        method: string,
+        params: Record<string, unknown>,
+      ) => {
+        const startedAt = performance.now();
+        try {
+          await client.request(method, params);
+        } catch (error) {
+          errors.push(`${name}:${String(error)}`);
+        } finally {
+          latencies[name].push(performance.now() - startedAt);
+        }
+      };
+      let probing = true;
+
+      const contextPreparationStartedAt = performance.now();
+      const activeContextPreparation = prepareContextWindowCaches({
+        config: publishedOwner.config,
+        modelCatalog: publishedOwner.modelCatalog,
+      }).then((caches) => {
+        replaceContextWindowCaches(caches);
+      });
+      const probeLoop = (async () => {
+        while (true) {
+          await Promise.all([
+            ...(["healthz", "readyz"] as const).map(async (name) => {
+              const startedAt = performance.now();
+              try {
+                const response = await fetch(`http://127.0.0.1:${port}/${name}`);
+                if (response.status !== 200) {
+                  errors.push(`${name}:${response.status}`);
+                }
+                await response.arrayBuffer();
+              } catch (error) {
+                errors.push(`${name}:${String(error)}`);
+              } finally {
+                latencies[name].push(performance.now() - startedAt);
+              }
+            }),
+            probeRpc("healthRpc", "health", { probe: true }),
+            probeRpc("metadataRpc", "chat.metadata", {}),
+            probeRpc("branchesRpc", "worktrees.branches", { repoRoot: process.cwd() }),
+          ]);
+          if (!probing) {
+            break;
+          }
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, 40);
+          });
+        }
+      })();
+      const contextPreparationOutcome = await activeContextPreparation.then(
+        () => ({ status: "loaded" as const }),
+        (error: unknown) => ({ status: "rejected" as const, error: String(error) }),
+      );
+      const contextPreparationDurationMs = performance.now() - contextPreparationStartedAt;
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 100);
+      });
+      probing = false;
+      await probeLoop;
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 40);
+      });
+      const elu = performance.eventLoopUtilization(performance.eventLoopUtilization(), eluStart);
+      const cpu = process.cpuUsage(cpuStart);
+      const memoryEnd = process.memoryUsage();
+      const resourceEnd = process.resourceUsage();
+      delayMonitor.disable();
+      clearInterval(heartbeat);
+      gcObserver.disconnect();
+
+      const result = {
+        modelCount,
+        maxHeartbeatGapMs: Math.max(...heartbeatGaps),
+        delayMaxMs: delayMonitor.max / 1_000_000,
+        delayP99Ms: delayMonitor.percentile(99) / 1_000_000,
+        eventLoopUtilization: elu.utilization,
+        cpu: { userMs: cpu.user / 1_000, systemMs: cpu.system / 1_000 },
+        memory: {
+          rssStartMiB: memoryStart.rss / 1024 / 1024,
+          rssEndMiB: memoryEnd.rss / 1024 / 1024,
+          heapUsedStartMiB: memoryStart.heapUsed / 1024 / 1024,
+          heapUsedEndMiB: memoryEnd.heapUsed / 1024 / 1024,
+          maxRssDeltaMiB: (resourceEnd.maxRSS - resourceStart.maxRSS) / 1024,
+        },
+        gc: {
+          count: gcDurationsMs.length,
+          totalMs: gcDurationsMs.reduce((total, duration) => total + duration, 0),
+          maxMs: Math.max(0, ...gcDurationsMs),
+        },
+        maxHealthzMs: Math.max(...latencies.healthz),
+        maxReadyzMs: Math.max(...latencies.readyz),
+        maxHealthRpcMs: Math.max(...latencies.healthRpc),
+        maxMetadataRpcMs: Math.max(...latencies.metadataRpc),
+        maxBranchesRpcMs: Math.max(...latencies.branchesRpc),
+        probeCounts: Object.fromEntries(
+          Object.entries(latencies).map(([name, values]) => [name, values.length]),
+        ),
+        errors,
+        contextPreparationOutcome,
+        contextPreparationDurationMs,
+        cacheSizes: (() => {
+          const caches = getContextWindowCaches();
+          return {
+            configured: caches.configuredTokenCache.size,
+            discovered: caches.discoveredTokenCache.size,
+            windows: caches.contextWindowCache.size,
+          };
+        })(),
+        publishedOwner: {
+          configuredModelCount: Object.values(publishedOwner.config.models?.providers ?? {}).reduce(
+            (count, provider) => count + (provider.models?.length ?? 0),
+            0,
+          ),
+          catalogEntryCount: publishedOwner.modelCatalog.entries.length,
+          staticEntryCount: publishedOwner.modelCatalog.staticEntries?.length ?? 0,
+        },
+        sharedBare: contextModule.lookupContextTokens("shared-model", {
+          allowAsyncLoad: false,
+          skipRuntimeConfigLoad: true,
+        }),
+        providerA: contextModule.resolveContextTokensForModel({
+          cfg: warmConfig,
+          provider: "synthetic-a",
+          model: "shared-model",
+          allowAsyncLoad: false,
+        }),
+        providerB: contextModule.resolveContextTokensForModel({
+          cfg: warmConfig,
+          provider: "synthetic-b",
+          model: "shared-model",
+          allowAsyncLoad: false,
+        }),
+      };
+      console.log(`CONTEXT_PREWARM_GATEWAY_PROOF ${JSON.stringify(result)}`);
+
+      expect(result.errors).toEqual([]);
+      expect(result.contextPreparationOutcome).toEqual({ status: "loaded" });
+      expect(result.cacheSizes.discovered).toBeGreaterThan(modelCount * 2);
+      expect(result.cacheSizes.windows).toBeGreaterThan(modelCount * 2);
+      expect(result.sharedBare).toBe(64_000);
+      expect(result.providerA).toBe(128_000);
+      expect(result.providerB).toBe(64_000);
+      expect(result.maxHeartbeatGapMs).toBeLessThan(500);
+      expect(result.maxHealthzMs).toBeLessThan(1_000);
+      expect(result.maxReadyzMs).toBeLessThan(1_000);
+      expect(result.maxHealthRpcMs).toBeLessThan(1_000);
+      expect(result.maxMetadataRpcMs).toBeLessThan(1_000);
+      expect(result.maxBranchesRpcMs).toBeLessThan(1_000);
+    } finally {
+      await disconnectGatewayClient(client);
+      await server.close({ reason: "context prewarm remote proof complete" });
+    }
+  }, 120_000);
+});


### PR DESCRIPTION
Related: #119375
Follow-up to #119562

## What Problem This Solves

Fixes an issue where a ready Gateway could stop servicing health checks,
metadata requests, and unrelated RPCs for several seconds while optional
post-ready context-window preparation processed a large model catalog.

## Why This Change Was Made

The post-ready path now consumes the Gateway's already-published configured and
static turn facts without hashing the full config or constructing a fallback
catalog owner. Context projection yields between bounded batches and publishes
all cache maps atomically only after the generation is complete.

Ordinary request-time loading remains exact and read-only. Full control-plane
catalog inventory stays outside the Gateway startup publication boundary, so
this does not restore source-backed provider discovery in low-priority
post-ready work.

Changing only idle-task admission was rejected because admission cannot preempt
CPU work after it starts. Moving full catalog discovery into startup publication
was also rejected because it widens the lifecycle contract and recreates the
stall at a different boundary.

## User Impact

Operators can continue using health, readiness, chat metadata, worktree, and
other Gateway RPCs while large context metadata projections complete in the
background. Context values remain generation-consistent, and ordinary idle work
still completes.

## Evidence

### Current-main red proof

Exact SHA `637de7d37945b2416ea9614955325d5f95165b15`, real Gateway, two
100,000-model providers:

- [Testbox run 30997022922](https://github.com/openclaw/openclaw/actions/runs/30997022922):
  same config object, maximum heartbeat gap **5922.76 ms**, event-loop delay
  **5934.94 ms**, and maximum GC pause only **18.83 ms**.
- Focused timing in that run attributed **5106.5 ms** to published-owner lookup;
  configured and discovered projection added **168.1 ms** and **174.8 ms**.
- [Testbox run 30996743232](https://github.com/openclaw/openclaw/actions/runs/30996743232):
  cloned equivalent config, maximum heartbeat gap **4516.06 ms**, CPU user
  **6317 ms**, RSS increase **613.5 MiB**, heap increase **599 MiB**, and maximum
  GC pause **17.36 ms**.

The same-object result falsifies config cloning as the sole cause. The short GC
pauses falsify GC as the multi-second owner.

### Proposed-head green proof

[Testbox run 31005978221](https://github.com/openclaw/openclaw/actions/runs/31005978221),
real Gateway, the same two 100,000-model providers:

- maximum heartbeat gap **27.06 ms**
- event-loop delay maximum/p99 **27.07 ms**
- maximum `/healthz` **18.77 ms**, `/readyz` **18.53 ms**
- maximum `health` RPC **10.63 ms**, `chat.metadata` **10.52 ms**,
  `worktrees.branches` **88.67 ms**
- eight successful samples of every HTTP/RPC surface, zero errors
- context preparation **788.30 ms** with 399,999 discovered/window entries
- context correctness: shared bare model 64,000; provider A 128,000;
  provider B 64,000
- CPU user/system **668.36/255.12 ms**
- RSS increase **93.04 MiB**
- four observed GC events, maximum pause **12.23 ms**

The same run passed:

- 122 focused Gateway/agent tests plus the real Gateway proof
- full `pnpm check:changed`
- full packaged `pnpm build`

Source-blind behavior validation reran the operator-visible Gateway scenario and
the supersession negative control on the unchanged Testbox lease. All seven
contract clauses passed: liveness, unrelated RPC latency, cache readiness,
catalog/context correctness, CPU/memory/GC bounds, ordinary idle completion, and
atomic cancellation/supersession behavior.

Regression coverage includes atomic publication, superseded-generation
cancellation, published-owner misses and no-argument recovery, an adjacent
request-time guard, in-place runtime reload state, and the negative control that
ordinary idle work completes.

Fresh autoreview found no accepted actionable defect. A repeated suggestion to
materialize the full catalog was rejected against the lifecycle contract:
context loading is intentionally read-only and full inventory is a separate
control-plane operation.

## AI Assistance

Codex assisted with investigation, implementation, tests, review, and proof
execution under maintainer direction.
