### PR TITLE
fix(workboard): clear claim and terminate execution when moving to terminal status

### DIFF
--- a/extensions/workboard/src/cli.test.ts
+++ b/extensions/workboard/src/cli.test.ts
@@ -308,7 +308,9 @@ describe("registerWorkboardCli", () => {
 
     const parsed = JSON.parse(output);
     expect(parsed).toMatchObject({ card: { id: card.id, status: "review" } });
-    expect(parsed.card.metadata.claim.token).toBe("[redacted]");
+    // The terminal move (review) clears the claim, so there is no token to
+    // redact. The secret must still not appear in the output. (issue #119592)
+    expect(parsed.card.metadata?.claim).toBeUndefined();
     expect(output).not.toContain("secret-token");
   });
 

--- a/extensions/workboard/src/command.test.ts
+++ b/extensions/workboard/src/command.test.ts
@@ -318,10 +318,10 @@ describe("handleWorkboardCommand", () => {
         context: { gatewayClientScopes: ["operator.write"] },
       }),
     ).resolves.toEqual(expect.objectContaining({ text: expect.stringContaining("review") }));
-    await expect(store.get(card.id)).resolves.toMatchObject({
-      status: "review",
-      metadata: { claim: { ownerId: "worker", token: "secret-token" } },
-    });
+    const movedCard = await store.get(card.id);
+    expect(movedCard).toMatchObject({ status: "review" });
+    // The terminal move (review) clears the claim. (issue #119592)
+    expect(movedCard?.metadata?.claim).toBeUndefined();
   });
 
   it("rejects invalid slash-command move statuses", async () => {

--- a/extensions/workboard/src/store-promote.ts
+++ b/extensions/workboard/src/store-promote.ts
@@ -1,10 +1,28 @@
 import { randomUUID } from "node:crypto";
-import type { WorkboardCard } from "@openclaw/workboard-contract";
-import { assertCanMutateClaimedCard } from "./store-card-helpers.js";
+import type {
+  WorkboardCard,
+  WorkboardExecutionStatus,
+  WorkboardStatus,
+} from "@openclaw/workboard-contract";
+import { assertCanMutateClaimedCard, closeRunningAttempts } from "./store-card-helpers.js";
 import { MAX_CARD_COMMENTS } from "./store-constants.js";
 import { WorkboardEnrichmentStore } from "./store-enrichment.js";
 import type { WorkboardMutationScope, WorkboardPromoteInput } from "./store-inputs.js";
-import { clearDiagnostics, normalizeBoundedString } from "./store-normalizers.js";
+import { clearDiagnostics, normalizeBoundedString, normalizeStatus } from "./store-normalizers.js";
+
+// Statuses that end a card's active lifecycle. Moving to one of these mirrors
+// the cleanup complete()/block() apply: clear the claim, close running
+// attempts, and mark a live execution terminal (issue #119592). The terminal
+// statuses are also valid WorkboardExecutionStatus values, so the mapping is
+// identity: a card moved to "review" gets execution status "review", etc.
+function terminalExecutionStatus(
+  status: WorkboardStatus,
+): WorkboardExecutionStatus | undefined {
+  if (status === "done" || status === "blocked" || status === "review") {
+    return status;
+  }
+  return undefined;
+}
 
 export class WorkboardPromoteStore extends WorkboardEnrichmentStore {
   async promoteReady(now = Date.now()): Promise<{ cards: WorkboardCard[]; count: number }> {
@@ -34,9 +52,40 @@ export class WorkboardPromoteStore extends WorkboardEnrichmentStore {
       // Operator surfaces omit scope and may override claims. Agent tools pass scope so a
       // worker cannot move another worker's claimed card between the preflight and this write.
       assertCanMutateClaimedCard(existing, scope);
+      const targetStatus = normalizeStatus(status, existing.status);
+      const executionStatus = terminalExecutionStatus(targetStatus);
+      if (!executionStatus) {
+        return await this.updateCard(
+          id,
+          { status: targetStatus, position },
+          {
+            allowMetadataDependencyLinks: false,
+            enforceStatusHolds: true,
+          },
+        );
+      }
+      const now = Date.now();
+      // Mirror complete()/block(): a card moved to a terminal status must not
+      // keep a live claim, running execution, or open running attempt. Leaving
+      // them behind wedges the owner's dispatch slot and makes the card an
+      // active dependency target forever (issue #119592).
+      const execution =
+        existing.execution?.status === "running"
+          ? { ...existing.execution, status: executionStatus, updatedAt: now }
+          : existing.execution;
+      const attemptStatus = executionStatus === "blocked" ? "blocked" : "succeeded";
       return await this.updateCard(
         id,
-        { status, position },
+        {
+          status: targetStatus,
+          position,
+          ...(execution ? { execution } : {}),
+          metadata: {
+            ...existing.metadata,
+            claim: undefined,
+            attempts: closeRunningAttempts(existing.metadata?.attempts, now, attemptStatus),
+          },
+        },
         {
           allowMetadataDependencyLinks: false,
           enforceStatusHolds: true,

--- a/extensions/workboard/src/store-promote.ts
+++ b/extensions/workboard/src/store-promote.ts
@@ -15,9 +15,7 @@ import { clearDiagnostics, normalizeBoundedString, normalizeStatus } from "./sto
 // attempts, and mark a live execution terminal (issue #119592). The terminal
 // statuses are also valid WorkboardExecutionStatus values, so the mapping is
 // identity: a card moved to "review" gets execution status "review", etc.
-function terminalExecutionStatus(
-  status: WorkboardStatus,
-): WorkboardExecutionStatus | undefined {
+function terminalExecutionStatus(status: WorkboardStatus): WorkboardExecutionStatus | undefined {
   if (status === "done" || status === "blocked" || status === "review") {
     return status;
   }

--- a/extensions/workboard/src/workboard-move-terminal-cleanup.test.ts
+++ b/extensions/workboard/src/workboard-move-terminal-cleanup.test.ts
@@ -17,9 +17,13 @@
 // The fix mirrors `complete`/`block`: when the target status is terminal,
 // clear the claim, close running attempts, and mark a live execution terminal.
 
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { dispatchAndStartWorkboardCards } from "./dispatcher.js";
 import type { PersistedWorkboardCard, WorkboardKeyedStore } from "./persistence-types.js";
+import { createWorkboardSqliteStores } from "./sqlite-store.js";
 import { WorkboardStore } from "./store.js";
 
 function createMemoryStore(): WorkboardKeyedStore {
@@ -164,5 +168,83 @@ describe("move to a terminal status cleans up claim, execution, and running atte
     expect(moved.metadata?.attempts ?? []).not.toContainEqual(
       expect.objectContaining({ status: "running" }),
     );
+  });
+
+  it("persists the terminal cleanup through a real sqlite-backed store and frees the dispatch slot", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-workboard-terminal-proof-"));
+    const dbPath = path.join(dir, "workboard.sqlite");
+    try {
+      const stores = createWorkboardSqliteStores({ dbPath });
+      const store = new WorkboardStore(stores.cards, {
+        boards: stores.boards,
+        subscriptions: stores.subscriptions,
+        attachments: stores.attachments,
+      });
+
+      const holder = await store.create({
+        title: "Slot holder force-moved to done",
+        status: "ready",
+        agentId: "owner-sqlite",
+        workspaceAccess: { unrestricted: true },
+      });
+      const sibling = await store.create({
+        title: "Sibling of same owner",
+        status: "ready",
+        agentId: "owner-sqlite",
+        workspaceAccess: { unrestricted: true },
+      });
+
+      // Holder consumes owner-sqlite's single dispatch slot.
+      await dispatchAndStartWorkboardCards({
+        store,
+        subagent: { run: vi.fn().mockResolvedValue({ runId: "run-sqlite-holder" }) },
+        options: { now: 10, maxStarts: 2 },
+      });
+      expect(await store.get(holder.id)).toMatchObject({
+        status: "running",
+        execution: { status: "running" },
+      });
+      expect((await store.get(sibling.id))?.execution).toBeUndefined();
+
+      // Move holder to a terminal status: claim + running execution must be
+      // cleaned up and persisted, freeing the owner's dispatch slot.
+      const moved = await store.move(holder.id, "done", undefined, {
+        ownerId: "owner-sqlite",
+      });
+      expect(moved.status).toBe("done");
+      expect(moved.metadata?.claim).toBeUndefined();
+      expect(moved.execution?.status).not.toBe("running");
+
+      // Re-open the store from the same on-disk db to prove the cleanup is
+      // durable (not just in-memory state).
+      stores.close();
+      const reopenedStores = createWorkboardSqliteStores({ dbPath });
+      try {
+        const reopened = new WorkboardStore(reopenedStores.cards, {
+          boards: reopenedStores.boards,
+          subscriptions: reopenedStores.subscriptions,
+          attachments: reopenedStores.attachments,
+        });
+        const persisted = await reopened.get(holder.id);
+        expect(persisted?.status).toBe("done");
+        expect(persisted?.metadata?.claim).toBeUndefined();
+        expect(persisted?.execution?.status).not.toBe("running");
+
+        // With the phantom execution gone on disk, the sibling can finally start.
+        await dispatchAndStartWorkboardCards({
+          store: reopened,
+          subagent: { run: vi.fn().mockResolvedValue({ runId: "run-sqlite-sibling" }) },
+          options: { now: 20, maxStarts: 2 },
+        });
+        expect(await reopened.get(sibling.id)).toMatchObject({
+          status: "running",
+          execution: { status: "running" },
+        });
+      } finally {
+        reopenedStores.close();
+      }
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/extensions/workboard/src/workboard-move-terminal-cleanup.test.ts
+++ b/extensions/workboard/src/workboard-move-terminal-cleanup.test.ts
@@ -1,0 +1,168 @@
+// workboard-move-terminal-cleanup.test.ts
+// Regression test for issue #119592: `workboard_move` to a TERMINAL status
+// (done / blocked / review) must clear the card's claim, close running
+// attempts, and terminate a live execution — the same side-effect cleanup
+// that `complete()` and `block()` apply — instead of leaving the card
+// `status:"done"` with `metadata.claim` still set, `execution.status ===
+// "running"`, and an open running attempt.
+//
+// The bug: `move()` (store-promote.ts) called `updateCard({status, position})`
+// with no cleanup. A claimed, dispatched card moved to "done" kept its claim
+// (the real worker could no longer complete it — assertCanMutateClaimedCard
+// fails), kept `execution.status === "running"` (the owner's dispatch slot
+// stayed consumed, blocking all other ready cards of the same owner), and kept
+// an open running attempt, so the card was an active dependency target
+// forever.
+//
+// The fix mirrors `complete`/`block`: when the target status is terminal,
+// clear the claim, close running attempts, and mark a live execution terminal.
+
+import { describe, expect, it, vi } from "vitest";
+import { dispatchAndStartWorkboardCards } from "./dispatcher.js";
+import type { PersistedWorkboardCard, WorkboardKeyedStore } from "./persistence-types.js";
+import { WorkboardStore } from "./store.js";
+
+function createMemoryStore(): WorkboardKeyedStore {
+  const entries = new Map<string, PersistedWorkboardCard>();
+  return {
+    async register(key, value) {
+      entries.set(key, value);
+    },
+    async lookup(key) {
+      return entries.get(key);
+    },
+    async delete(key) {
+      return entries.delete(key);
+    },
+    async entries() {
+      return [...entries].map(([key, value]) => ({ key, value }));
+    },
+  };
+}
+
+describe("move to a terminal status cleans up claim, execution, and running attempts", () => {
+  it("moving a dispatched card to done clears claim, terminates execution, and closes attempts", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const card = await store.create({
+      title: "Dispatched card force-moved to done",
+      status: "ready",
+      agentId: "owner-a",
+      workspaceAccess: { unrestricted: true },
+    });
+
+    // Dispatch the card so it has a live claim + running execution + attempt.
+    await dispatchAndStartWorkboardCards({
+      store,
+      subagent: { run: vi.fn().mockResolvedValue({ runId: "run-move-done" }) },
+      options: { now: 10, maxStarts: 1 },
+    });
+
+    const afterDispatch = await store.get(card.id);
+    expect(afterDispatch).toMatchObject({
+      status: "running",
+      execution: { status: "running", runId: "run-move-done" },
+      metadata: { claim: expect.objectContaining({ ownerId: "owner-a" }) },
+    });
+    expect((afterDispatch?.metadata?.attempts ?? []).some((a) => a.status === "running")).toBe(
+      true,
+    );
+
+    // The worker force-moves the card to a terminal status via workboard_move.
+    const moved = await store.move(card.id, "done", undefined, { ownerId: "owner-a" });
+
+    expect(moved.status).toBe("done");
+    // The claim must be cleared so the card is no longer wedged.
+    expect(moved.metadata?.claim).toBeUndefined();
+    // The execution must not still be "running" — the owner's dispatch slot
+    // would otherwise stay consumed forever.
+    expect(moved.execution?.status).not.toBe("running");
+    // No running attempt may remain open.
+    expect(moved.metadata?.attempts ?? []).not.toContainEqual(
+      expect.objectContaining({ status: "running" }),
+    );
+  });
+
+  it("moving to a non-terminal status does NOT clear claim or execution (move is not complete)", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const card = await store.create({
+      title: "Dispatched card moved back to backlog",
+      status: "ready",
+      agentId: "owner-b",
+      workspaceAccess: { unrestricted: true },
+    });
+
+    await dispatchAndStartWorkboardCards({
+      store,
+      subagent: { run: vi.fn().mockResolvedValue({ runId: "run-move-backlog" }) },
+      options: { now: 10, maxStarts: 1 },
+    });
+
+    const afterDispatch = await store.get(card.id);
+    expect(afterDispatch).toMatchObject({
+      status: "running",
+      execution: { status: "running", runId: "run-move-backlog" },
+      metadata: { claim: expect.objectContaining({ ownerId: "owner-b" }) },
+    });
+
+    // Non-terminal move: the card is NOT complete, so claim + execution must
+    // survive untouched. Only terminal statuses apply the cleanup.
+    const moved = await store.move(card.id, "backlog", undefined, { ownerId: "owner-b" });
+
+    expect(moved.status).toBe("backlog");
+    expect(moved.metadata?.claim).toMatchObject({ ownerId: "owner-b" });
+    expect(moved.execution?.status).toBe("running");
+    expect((moved.metadata?.attempts ?? []).some((a) => a.status === "running")).toBe(true);
+  });
+
+  it("moving a dispatched card to blocked clears claim and closes attempts", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const card = await store.create({
+      title: "Dispatched card force-moved to blocked",
+      status: "ready",
+      agentId: "owner-c",
+      workspaceAccess: { unrestricted: true },
+    });
+
+    await dispatchAndStartWorkboardCards({
+      store,
+      subagent: { run: vi.fn().mockResolvedValue({ runId: "run-move-blocked" }) },
+      options: { now: 10, maxStarts: 1 },
+    });
+
+    const moved = await store.move(card.id, "blocked", undefined, { ownerId: "owner-c" });
+
+    expect(moved.status).toBe("blocked");
+    expect(moved.metadata?.claim).toBeUndefined();
+    expect(moved.execution?.status).toBe("blocked");
+    expect(moved.metadata?.attempts ?? []).not.toContainEqual(
+      expect.objectContaining({ status: "running" }),
+    );
+  });
+
+  it("moving a dispatched card to review clears claim and closes attempts", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const card = await store.create({
+      title: "Dispatched card force-moved to review",
+      status: "ready",
+      agentId: "owner-d",
+      workspaceAccess: { unrestricted: true },
+    });
+
+    await dispatchAndStartWorkboardCards({
+      store,
+      subagent: { run: vi.fn().mockResolvedValue({ runId: "run-move-review" }) },
+      options: { now: 10, maxStarts: 1 },
+    });
+
+    const moved = await store.move(card.id, "review", undefined, { ownerId: "owner-d" });
+
+    expect(moved.status).toBe("review");
+    expect(moved.metadata?.claim).toBeUndefined();
+    // The execution model has a "review" status; the run is over and awaiting
+    // human review, so it must not stay "running".
+    expect(moved.execution?.status).toBe("review");
+    expect(moved.metadata?.attempts ?? []).not.toContainEqual(
+      expect.objectContaining({ status: "running" }),
+    );
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

`workboard_move` lets an agent move a claimed, dispatched card to a terminal status (`done`/`blocked`/`review`) without clearing the card's claim, running execution, or open running attempt. Unlike `complete()`/`block()` — which properly clear the claim, close running attempts, and terminate execution — `move()` called `updateCard({status, position})` with no side-effect cleanup. A card left in `status: "done"` still carried `metadata.claim` (so the real worker could no longer complete it), `execution.status === "running"` (so the owner's dispatch slot stayed consumed and no other ready card of the same owner could start), and an open running attempt (the card stayed an active dependency target forever).

This is the same dispatch-starvation class as the release-claim wedge: a card that looks terminal but still occupies its owner's dispatch slot and holds a stale claim blocks the whole owner queue.

## Summary

`move()` now mirrors the existing `complete()`/`block()` cleanup when the target status is terminal: clear `metadata.claim`, close running attempts (`"succeeded"` for `done`/`review`, `"blocked"` for `blocked`), and set `execution.status` to the terminal status. Non-terminal moves (`backlog`, `todo`, `ready`, etc.) are unchanged. Only file touched by the fix: `extensions/workboard/src/store-promote.ts`.

## Evidence

- **Before (failing regression test):** `workboard-move-terminal-cleanup.test.ts` — dispatching a card (creating a claim + running execution + running attempt) then moving it to `"done"` FAILED the assertion `expect(moved.metadata?.claim).toBeUndefined()` — the claim survived the move. (`AssertionError: expected { ownerId: 'owner-a', …(4) } to be undefined` at the `metadata?.claim` check.)
- **After:** the same test PASSES — claim cleared, execution terminated (not `running`), running attempt closed.
- **Real after-fix runtime run (this head `7891dfdd`, live SQLite store + real dispatcher):** `node scripts/test-extension.mjs workboard` → **13 test files / 235 tests, all green**, including `workboard-move-terminal-cleanup.test.ts` (5 tests) exercising the real dispatch→terminal-move path. Full truncated log: 13 passed / 235 passed / 45.9s.
- **Corrected existing tests:** `cli.test.ts` and `command.test.ts` previously asserted the *buggy* behavior (that `claim.token`/`claim` survived a move to a terminal status). Updated to assert the corrected behavior (claim fully cleared) plus a raw-string secret-leak check. These are strictness *increases*, not weakenings.
- Typecheck (`tsgo:extensions` + `tsgo:extensions:test`) passes. `git diff --check` clean.

## On the P1 "centralize terminal cleanup across public writers"

ClawSweeper re-raised a P1 asking to centralize terminal cleanup at the shared status-write boundary (update/bulk, release, reassign). My scoping decision and why I keep it out of *this* PR:

- **`release`** is already covered by the separate in-flight **#119588** (releaseClaim clears phantom execution + closes running attempts when leaving `running`).
- **terminal-run reconciliation** (the background path that would otherwise strand a dead run) is covered by the in-flight **#118679** (blockTerminalRun on terminal subagent events).
- A third PR that refactors `release`/`reassign`/`update` in `store-workflow.ts`/`store-core.ts` would **collide file-wise with #119588** (which owns `store-workflow.ts` `releaseClaim` on this exact surface) and semantically overlap the release fix. Bundling that here would force a merge conflict with a PR already under review for the same invariant.

So this PR stays correctly scoped to `move()` (the reported bug, issue #119592) and is `store-promote.ts`-only, so it does not collide with the other two. A unified terminal-cleanup helper applied to `update()`/`reassign()` is the right follow-up and should land **after** #119588 and #118679 merge, so it merges cleanly and reuses whatever centralization those land with. I've added the after-fix runtime proof here; happy to fold a shared helper into this PR if a maintainer prefers it land first despite the collision.

## Changes

- `extensions/workboard/src/store-promote.ts` — `move()`: for terminal targets, clear claim, close running attempts, and set terminal execution status (mirrors `complete`/`blockDirect`).
- `extensions/workboard/src/workboard-move-terminal-cleanup.test.ts` — regression tests (mechanism, non-terminal scope guard, terminal-status mapping).
- `extensions/workboard/src/cli.test.ts` / `command.test.ts` — corrected assertions that encoded the buggy behavior.

## Agent-authored

This PR was authored by an AI agent (Moe, personal assistant of a Workboard user who runs dispatched-board workloads).

**Prompts used (condensed):**
1. **Issue:** "Overlap-checked green-field bug report for workboard_move leaving live claim + running execution on terminal moves" → filed as #119592.
2. **Implementation:** "Fix store-promote.ts move() to mirror complete()/block() cleanup (clear claim, close running attempts, terminate execution) only for terminal targets. Write the regression test FIRST, confirm it fails on current code, apply the fix, confirm it passes, run the full workboard suite. Do not commit/push/open PRs. Do not touch the unrelated dirty files in the worktree."
3. **Review gate:** "Review this workboard move-terminal fix as the maintainer who must merge it: correctness (does it free the dispatch slot, terminal status mapping, atomicity), test quality (would the regression test fail pre-fix, are the corrected existing tests strengthening not weakening), conventions (mirrors complete/block, helpers), overlap/collision risk with in-flight #118679 and #119588."
4. **Isolation:** "Candidate 2 must land as its own PR. Branch it off clean origin/main via a separate git worktree, apply only the 4 C2 files, verify zero contamination, run the suite, commit, push."

**Logs:** full agent run logs (issue → impl → review → isolation) available on request; the above is condensed.

## Checklist

- [x] One thing per PR (fix + attached regression tests + corrected encoding tests)
- [x] Tests attached to a real fix (failing-before, passing-after)
- [x] Fixes #119592 (issue filed with repro)
- [x] No CHANGELOG edits, no refactor-only changes
- [x] Overlap-checked clean: `store-promote.ts` not touched by #118679 or #119588
- [x] Isolated PR: separate branch off clean `origin/main` (worktree), zero contamination verified
- [x] Agent-authored marked in title/desc with prompts included
