### PR TITLE
fix(ci): stop label-driven automation churn

### DIFF
--- a/.github/workflows/auto-response.yml
+++ b/.github/workflows/auto-response.yml
@@ -12,13 +12,19 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' && github.event.action == 'synchronize' }}
 
 permissions: {}
 
 jobs:
   auto-response:
+    if: >-
+      ${{
+        github.event_name != 'pull_request_target' ||
+        (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+        (github.actor != 'clawsweeper[bot]' && github.actor != 'openclaw-clawsweeper[bot]')
+      }}
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/real-behavior-proof.yml
+++ b/.github/workflows/real-behavior-proof.yml
@@ -1,21 +1,21 @@
-name: Real behavior proof
+name: PR context and evidence
 
 on:
   pull_request_target: # zizmor: ignore[dangerous-triggers] trusted base checkout only; no untrusted PR code execution
-    types: [opened, edited, synchronize, reopened, ready_for_review, labeled, unlabeled]
+    types: [opened, edited, synchronize, reopened, ready_for_review]
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: ${{ github.event.action == 'synchronize' }}
 
 permissions: {}
 
 jobs:
   real-behavior-proof:
-    name: Real behavior proof
+    name: PR context and evidence
     if: >-
       ${{
         github.event.action != 'edited' ||
@@ -51,7 +51,7 @@ jobs:
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
           permission-issues: read
           permission-members: read
-      - name: Check real behavior proof
+      - name: Check PR context and evidence
         env:
           GH_APP_TOKEN: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}
           GITHUB_TOKEN: ${{ github.token }}

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -900,6 +900,54 @@ describe("ci workflow guards", () => {
     });
   });
 
+  it("runs the PR context and evidence gate only for relevant PR changes", () => {
+    const workflow = readRealBehaviorProofWorkflow();
+
+    expect(workflow.name).toBe("PR context and evidence");
+    expect(workflow.jobs["real-behavior-proof"].name).toBe("PR context and evidence");
+    expect(workflow.on.pull_request_target.types).toEqual([
+      "opened",
+      "edited",
+      "synchronize",
+      "reopened",
+      "ready_for_review",
+    ]);
+    expect(workflow.concurrency.group).toBe(
+      "${{ github.workflow }}-${{ github.event.pull_request.number }}",
+    );
+    expect(workflow.concurrency["cancel-in-progress"]).toBe(
+      "${{ github.event.action == 'synchronize' }}",
+    );
+  });
+
+  it("isolates auto-response per item and ignores ClawSweeper PR label feedback", () => {
+    const workflow = readWorkflow(".github/workflows/auto-response.yml");
+    const guard = workflow.jobs["auto-response"].if;
+
+    expect(workflow.on.issues.types).toEqual(["opened", "edited", "labeled"]);
+    expect(workflow.on.issue_comment.types).toEqual(["created"]);
+    expect(workflow.on.pull_request_target.types).toEqual([
+      "opened",
+      "edited",
+      "synchronize",
+      "reopened",
+      "labeled",
+      "unlabeled",
+    ]);
+    expect(workflow.concurrency.group).toBe(
+      "${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number }}",
+    );
+    expect(workflow.concurrency["cancel-in-progress"]).toBe(
+      "${{ github.event_name == 'pull_request_target' && github.event.action == 'synchronize' }}",
+    );
+    expect(guard).toContain("github.event_name != 'pull_request_target'");
+    expect(guard).toContain("github.event.action != 'labeled'");
+    expect(guard).toContain("github.event.action != 'unlabeled'");
+    expect(guard).toContain("github.actor != 'clawsweeper[bot]'");
+    expect(guard).toContain("github.actor != 'openclaw-clawsweeper[bot]'");
+    expect(guard).not.toContain("openclaw-barnacle[bot]");
+  });
+
   it("routes stale bug issues through ClawSweeper instead of Barnacle closure", () => {
     const staleWorkflow = readWorkflow(".github/workflows/stale.yml");
     const staleSteps = staleWorkflow.jobs.stale.steps as WorkflowStep[];


### PR DESCRIPTION
## What Problem This Solves

ClawSweeper rating and proof labels trigger overlapping PR automation runs. Their canceled duplicate checks leave otherwise-green PRs marked unstable, while issue/comment automation accidentally shares one concurrency lane across unrelated items. The existing Real behavior proof check only validates PR context, so its display name also overstates what it verifies.

## Why This Change Was Made

- Run the renamed PR context and evidence gate only for PR content/head events.
- Cancel superseded automation only when a PR head actually changes.
- Give auto-response each issue or PR its own concurrency lane.
- Ignore ClawSweeper-authored PR label feedback while preserving human and other bot label events.
- Preserve required ci-gate and exact-merge check names unchanged.

ClawSweeper check-name compatibility will land before this PR.

## Evidence

- node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts: 99 passed, 1 intentionally skipped.
- node scripts/run-vitest.mjs test/scripts/barnacle-auto-response.test.ts test/scripts/real-behavior-proof-policy.test.ts: 81 passed.
- Seven representative GitHub Actions event/guard scenarios passed.
- Formatter checks and git diff --check passed.
- Original regression: https://github.com/openclaw/openclaw/pull/112370