### PR TITLE
fix: improve Custodian setup control affordances

### DIFF
--- a/ui/src/components/wizard-step-controls.ts
+++ b/ui/src/components/wizard-step-controls.ts
@@ -21,6 +21,7 @@ type WizardStepControlsProps = {
   presentation?: "channels";
   answerLabel?: string;
   confirmAffirmativeLabel?: string;
+  leadingAction?: TemplateResult;
   sensitiveRevealed?: boolean;
   onToggleSensitiveVisibility?: () => void;
 };
@@ -98,8 +99,13 @@ function renderAnswerButton(
       ${props.answerLabel ?? label}
     </button>
   `;
-  return props.presentation === "channels"
-    ? html`<div class="channels-wizard__footer">${button}</div>`
+  if (props.presentation === "channels") {
+    return html`<div class="channels-wizard__footer">${button}</div>`;
+  }
+  return props.leadingAction
+    ? html`<div class="wizard-step__actions wizard-step__actions--split">
+        ${props.leadingAction}${button}
+      </div>`
     : button;
 }
 
@@ -170,6 +176,11 @@ function renderProgressStep(props: WizardStepControlsProps) {
       <span class="wizard-step__spinner" aria-hidden="true"></span>
       ${renderMessage(props)}
     </div>
+    ${props.leadingAction
+      ? html`<div class="wizard-step__actions wizard-step__actions--split">
+          ${props.leadingAction}
+        </div>`
+      : nothing}
   `;
 }
 
@@ -271,9 +282,15 @@ function renderOptionsStep(props: WizardStepControlsProps) {
 }
 
 function renderConfirmStep(props: WizardStepControlsProps) {
+  const actionClass = stepClass(props, props.presentation === "channels" ? "footer" : "actions");
   return html`
     ${renderMessage(props)}
-    <div class=${stepClass(props, props.presentation === "channels" ? "footer" : "actions")}>
+    <div
+      class=${props.presentation !== "channels" && props.leadingAction
+        ? `${actionClass} wizard-step__actions--split`
+        : actionClass}
+    >
+      ${props.presentation === "channels" ? nothing : (props.leadingAction ?? nothing)}
       ${[false, true].map(
         (answer) => html`<button
           type="button"
@@ -290,8 +307,9 @@ function renderConfirmStep(props: WizardStepControlsProps) {
 
 /**
  * Renders the interactive controls for one `WizardStep`. Container-agnostic on
- * purpose: no dialog chrome, no cancel row, no page state — callers place the
- * result wherever the step is being asked (modal, panel, or chat bubble).
+ * purpose: no dialog chrome or page state — callers place the result wherever
+ * the step is being asked (modal, panel, or chat bubble). A caller may supply a
+ * leading action so escape and answer controls share one footer row.
  */
 export function renderWizardStepControls(
   props: WizardStepControlsProps,

--- a/ui/src/e2e/custodian-event-nudge.e2e.test.ts
+++ b/ui/src/e2e/custodian-event-nudge.e2e.test.ts
@@ -349,9 +349,38 @@ suite.define(() => {
         });
 
         await page.goto(`${suite.server.baseUrl}custodian`);
+        await page.addStyleTag({
+          content: ".custodian__wizard-step * { transition: none !important; }",
+        });
         await page.getByLabel("Twitch").waitFor();
         expect(await page.locator("openclaw-option-card").count()).toBe(0);
         expect(await page.locator(".agent-chat__composer-shell").count()).toBe(0);
+
+        const twitchOption = page.locator(".wizard-step__option", { hasText: "Twitch" });
+        const continueButton = page.getByRole("button", { name: "Continue" });
+        const cancelButton = page.getByRole("button", { name: "Cancel" });
+        const readInteractionStyle = (element: Element) => {
+          const style = getComputedStyle(element);
+          return {
+            backgroundColor: style.backgroundColor,
+            borderColor: style.borderColor,
+            cursor: style.cursor,
+          };
+        };
+
+        const optionRestingStyle = await twitchOption.evaluate(readInteractionStyle);
+        await twitchOption.hover();
+        const optionHoverStyle = await twitchOption.evaluate(readInteractionStyle);
+        expect(optionRestingStyle.cursor).toBe("pointer");
+        expect(optionHoverStyle.borderColor).not.toBe(optionRestingStyle.borderColor);
+
+        const disabledContinueStyle = await continueButton.evaluate(readInteractionStyle);
+        await continueButton.hover();
+        expect(await continueButton.evaluate(readInteractionStyle)).toEqual(disabledContinueStyle);
+        expect(disabledContinueStyle.cursor).toBe("not-allowed");
+        expect(await cancelButton.evaluate((element) => getComputedStyle(element).cursor)).toBe(
+          "pointer",
+        );
 
         await gateway.setMethodResponse("openclaw.chat", {
           sessionId: "e2e-rich-wizard",
@@ -370,6 +399,9 @@ suite.define(() => {
           },
         });
         await page.getByLabel("Twitch").check();
+        expect(await continueButton.evaluate((element) => getComputedStyle(element).cursor)).toBe(
+          "pointer",
+        );
         await page.getByRole("button", { name: "Continue" }).click();
         await page.getByLabel("Announcements").waitFor();
 

--- a/ui/src/e2e/custodian-event-nudge.e2e.test.ts
+++ b/ui/src/e2e/custodian-event-nudge.e2e.test.ts
@@ -319,6 +319,9 @@ suite.define(() => {
   });
 
   it("renders rich wizard controls and sends typed answers", async () => {
+    if (captureUiProofEnabled) {
+      await mkdir(uiProofArtifactDir, { recursive: true });
+    }
     await suite.withPage(
       {
         colorScheme: "dark",
@@ -388,6 +391,33 @@ suite.define(() => {
             ),
           ),
         ).toEqual([44, 44]);
+        for (const viewport of [
+          { width: 390, height: 844, name: "phone" },
+          { width: 768, height: 1024, name: "tablet" },
+          { width: 1440, height: 900, name: "desktop" },
+        ]) {
+          await page.setViewportSize(viewport);
+          const [continueBox, cancelBox] = await Promise.all([
+            continueButton.boundingBox(),
+            cancelButton.boundingBox(),
+          ]);
+          expect(cancelBox).not.toBeNull();
+          expect(continueBox).not.toBeNull();
+          expect(cancelBox!.x).toBeLessThan(continueBox!.x);
+          expect(Math.abs(cancelBox!.y - continueBox!.y)).toBeLessThan(1);
+          expect(
+            await page.evaluate(
+              () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+            ),
+          ).toBe(true);
+          if (captureUiProofEnabled) {
+            await page.screenshot({
+              animations: "disabled",
+              fullPage: true,
+              path: path.join(uiProofArtifactDir, `05-rich-wizard-actions-${viewport.name}.png`),
+            });
+          }
+        }
 
         await gateway.setMethodResponse("openclaw.chat", {
           sessionId: "e2e-rich-wizard",

--- a/ui/src/e2e/custodian-event-nudge.e2e.test.ts
+++ b/ui/src/e2e/custodian-event-nudge.e2e.test.ts
@@ -521,7 +521,8 @@ suite.define(() => {
         await yesButton.click();
         await expect.poll(() => noButton.isDisabled()).toBe(true);
         await expect.poll(() => yesButton.isDisabled()).toBe(true);
-        for (const button of [noButton, yesButton]) {
+        await expect.poll(() => cancelButton.isDisabled()).toBe(true);
+        for (const button of [noButton, yesButton, cancelButton]) {
           const restingStyle = await button.evaluate(readInteractionStyle);
           await button.hover();
           expect(await button.evaluate(readInteractionStyle)).toEqual(restingStyle);

--- a/ui/src/e2e/custodian-event-nudge.e2e.test.ts
+++ b/ui/src/e2e/custodian-event-nudge.e2e.test.ts
@@ -381,6 +381,13 @@ suite.define(() => {
         expect(await cancelButton.evaluate((element) => getComputedStyle(element).cursor)).toBe(
           "pointer",
         );
+        expect(
+          await Promise.all(
+            [continueButton, cancelButton].map((button) =>
+              button.evaluate((element) => element.getBoundingClientRect().height),
+            ),
+          ),
+        ).toEqual([44, 44]);
 
         await gateway.setMethodResponse("openclaw.chat", {
           sessionId: "e2e-rich-wizard",

--- a/ui/src/e2e/custodian-event-nudge.e2e.test.ts
+++ b/ui/src/e2e/custodian-event-nudge.e2e.test.ts
@@ -382,7 +382,7 @@ suite.define(() => {
         expect(await continueButton.evaluate(readInteractionStyle)).toEqual(disabledContinueStyle);
         expect(disabledContinueStyle.cursor).toBe("not-allowed");
         expect(await cancelButton.evaluate((element) => getComputedStyle(element).cursor)).toBe(
-          "pointer",
+          "default",
         );
         expect(
           await Promise.all(
@@ -437,7 +437,7 @@ suite.define(() => {
         });
         await page.getByLabel("Twitch").check();
         expect(await continueButton.evaluate((element) => getComputedStyle(element).cursor)).toBe(
-          "pointer",
+          "default",
         );
         await page.getByRole("button", { name: "Continue" }).click();
         await page.getByLabel("Announcements").waitFor();
@@ -470,6 +470,30 @@ suite.define(() => {
 
         await gateway.setMethodResponse("openclaw.chat", {
           sessionId: "e2e-rich-wizard",
+          reply: "Name this connection.",
+          action: "none",
+          wizardInputPending: true,
+          step: {
+            id: "label",
+            type: "text",
+            message: "Connection name",
+          },
+        });
+        await secretInput.fill("fake-client-secret");
+        await page.getByRole("button", { name: "Submit" }).click();
+        const labelInput = page.getByRole("textbox", { name: "Connection name" });
+        await labelInput.waitFor();
+
+        await gateway.deferNext("openclaw.chat");
+        await labelInput.fill("Twitch ops");
+        await page.getByRole("button", { name: "Submit" }).click();
+        await expect.poll(() => labelInput.isDisabled()).toBe(true);
+        expect(await labelInput.evaluate((element) => getComputedStyle(element).cursor)).toBe(
+          "not-allowed",
+        );
+
+        await gateway.resolveDeferred("openclaw.chat", {
+          sessionId: "e2e-rich-wizard",
           reply: "Confirm setup.",
           action: "none",
           wizardInputPending: true,
@@ -479,8 +503,6 @@ suite.define(() => {
             message: "Connect Twitch now?",
           },
         });
-        await secretInput.fill("fake-client-secret");
-        await page.getByRole("button", { name: "Submit" }).click();
         const noButton = page.getByRole("button", { name: "No" });
         const yesButton = page.getByRole("button", { name: "Yes" });
         await noButton.waitFor();
@@ -514,6 +536,9 @@ suite.define(() => {
           }),
           expect.objectContaining({
             wizardAnswer: { stepId: "secret", value: "fake-client-secret" },
+          }),
+          expect.objectContaining({
+            wizardAnswer: { stepId: "label", value: "Twitch ops" },
           }),
           expect.objectContaining({
             wizardAnswer: { stepId: "confirm", value: true },

--- a/ui/src/e2e/custodian-event-nudge.e2e.test.ts
+++ b/ui/src/e2e/custodian-event-nudge.e2e.test.ts
@@ -3,6 +3,7 @@ import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
 import { expect, it } from "vitest";
+import { GATEWAY_SERVER_CAPS } from "../../../packages/gateway-protocol/src/index.js";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -331,6 +332,7 @@ suite.define(() => {
       },
       async ({ page }) => {
         const gateway = await installMockGateway(page, {
+          featureCapabilities: [GATEWAY_SERVER_CAPS.SYSTEM_AGENT_WIZARD_CANCEL],
           featureMethods: ["chat.metadata", "chat.startup", "openclaw.chat"],
           methodResponses: {
             "openclaw.chat": {
@@ -397,6 +399,7 @@ suite.define(() => {
           { width: 1440, height: 900, name: "desktop" },
         ]) {
           await page.setViewportSize(viewport);
+          await settleUi(page);
           const [continueBox, cancelBox] = await Promise.all([
             continueButton.boundingBox(),
             cancelButton.boundingBox(),
@@ -404,7 +407,10 @@ suite.define(() => {
           expect(cancelBox).not.toBeNull();
           expect(continueBox).not.toBeNull();
           expect(cancelBox!.x).toBeLessThan(continueBox!.x);
-          expect(Math.abs(cancelBox!.y - continueBox!.y)).toBeLessThan(1);
+          expect(
+            Math.abs(cancelBox!.y - continueBox!.y),
+            JSON.stringify({ viewport, cancelBox, continueBox }),
+          ).toBeLessThan(1);
           expect(
             await page.evaluate(
               () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,

--- a/ui/src/e2e/custodian-event-nudge.e2e.test.ts
+++ b/ui/src/e2e/custodian-event-nudge.e2e.test.ts
@@ -496,8 +496,10 @@ suite.define(() => {
           );
         } else {
           expect(
-            page.locator(".custodian__structured-response", { hasText: "Twitch ops" }),
-          ).toHaveCount(1);
+            await page
+              .locator(".custodian__structured-response", { hasText: "Twitch ops" })
+              .count(),
+          ).toBe(1);
         }
 
         await gateway.resolveDeferred("openclaw.chat", {

--- a/ui/src/e2e/custodian-event-nudge.e2e.test.ts
+++ b/ui/src/e2e/custodian-event-nudge.e2e.test.ts
@@ -440,11 +440,37 @@ suite.define(() => {
 
         await gateway.setMethodResponse("openclaw.chat", {
           sessionId: "e2e-rich-wizard",
-          reply: "Setup complete.",
+          reply: "Confirm setup.",
           action: "none",
+          wizardInputPending: true,
+          step: {
+            id: "confirm",
+            type: "confirm",
+            message: "Connect Twitch now?",
+          },
         });
         await secretInput.fill("fake-client-secret");
         await page.getByRole("button", { name: "Submit" }).click();
+        const noButton = page.getByRole("button", { name: "No" });
+        const yesButton = page.getByRole("button", { name: "Yes" });
+        await noButton.waitFor();
+
+        await gateway.deferNext("openclaw.chat");
+        await yesButton.click();
+        await expect.poll(() => noButton.isDisabled()).toBe(true);
+        await expect.poll(() => yesButton.isDisabled()).toBe(true);
+        for (const button of [noButton, yesButton]) {
+          const restingStyle = await button.evaluate(readInteractionStyle);
+          await button.hover();
+          expect(await button.evaluate(readInteractionStyle)).toEqual(restingStyle);
+          expect(restingStyle.cursor).toBe("not-allowed");
+        }
+
+        await gateway.resolveDeferred("openclaw.chat", {
+          sessionId: "e2e-rich-wizard",
+          reply: "Setup complete.",
+          action: "none",
+        });
         await page.getByText("Setup complete.").waitFor();
 
         const requests = await gateway.getRequests("openclaw.chat");
@@ -458,6 +484,9 @@ suite.define(() => {
           }),
           expect.objectContaining({
             wizardAnswer: { stepId: "secret", value: "fake-client-secret" },
+          }),
+          expect.objectContaining({
+            wizardAnswer: { stepId: "confirm", value: true },
           }),
         ]);
         expect(

--- a/ui/src/e2e/custodian-event-nudge.e2e.test.ts
+++ b/ui/src/e2e/custodian-event-nudge.e2e.test.ts
@@ -382,7 +382,7 @@ suite.define(() => {
         expect(await continueButton.evaluate(readInteractionStyle)).toEqual(disabledContinueStyle);
         expect(disabledContinueStyle.cursor).toBe("not-allowed");
         expect(await cancelButton.evaluate((element) => getComputedStyle(element).cursor)).toBe(
-          "default",
+          "pointer",
         );
         expect(
           await Promise.all(
@@ -437,7 +437,7 @@ suite.define(() => {
         });
         await page.getByLabel("Twitch").check();
         expect(await continueButton.evaluate((element) => getComputedStyle(element).cursor)).toBe(
-          "default",
+          "pointer",
         );
         await page.getByRole("button", { name: "Continue" }).click();
         await page.getByLabel("Announcements").waitFor();

--- a/ui/src/e2e/custodian-event-nudge.e2e.test.ts
+++ b/ui/src/e2e/custodian-event-nudge.e2e.test.ts
@@ -487,10 +487,18 @@ suite.define(() => {
         await gateway.deferNext("openclaw.chat");
         await labelInput.fill("Twitch ops");
         await page.getByRole("button", { name: "Submit" }).click();
-        await expect.poll(() => labelInput.isDisabled()).toBe(true);
-        expect(await labelInput.evaluate((element) => getComputedStyle(element).cursor)).toBe(
-          "not-allowed",
-        );
+        await expect
+          .poll(async () => (await labelInput.count()) === 0 || (await labelInput.isDisabled()))
+          .toBe(true);
+        if ((await labelInput.count()) > 0) {
+          expect(await labelInput.evaluate((element) => getComputedStyle(element).cursor)).toBe(
+            "not-allowed",
+          );
+        } else {
+          expect(
+            page.locator(".custodian__structured-response", { hasText: "Twitch ops" }),
+          ).toHaveCount(1);
+        }
 
         await gateway.resolveDeferred("openclaw.chat", {
           sessionId: "e2e-rich-wizard",

--- a/ui/src/pages/custodian/transcript.ts
+++ b/ui/src/pages/custodian/transcript.ts
@@ -203,7 +203,7 @@ export function renderCustodianTranscriptEntry(params: {
                 >
                   ${t("custodian.cancel")}
                 </button>`
-              : nothing,
+              : undefined,
             onToggleSensitiveVisibility: params.onToggleWizardSecretVisibility,
           })}
         </section>`

--- a/ui/src/pages/custodian/transcript.ts
+++ b/ui/src/pages/custodian/transcript.ts
@@ -194,20 +194,18 @@ export function renderCustodianTranscriptEntry(params: {
             sensitiveRevealed: params.wizardSecretVisible,
             onValueChange: params.onWizardValueChange,
             onAnswer: params.onWizardAnswer,
-            onToggleSensitiveVisibility: params.onToggleWizardSecretVisibility,
-          })}
-          ${params.showWizardCancel
-            ? html`<div class="custodian__wizard-actions">
-                <button
+            leadingAction: params.showWizardCancel
+              ? html`<button
                   class="btn btn--ghost custodian__wizard-cancel"
                   type="button"
                   ?disabled=${params.wizardDisabled}
                   @click=${params.onWizardCancel}
                 >
                   ${t("custodian.cancel")}
-                </button>
-              </div>`
-            : nothing}
+                </button>`
+              : nothing,
+            onToggleSensitiveVisibility: params.onToggleWizardSecretVisibility,
+          })}
         </section>`
       : nothing}
   `;

--- a/ui/src/styles/custodian.css
+++ b/ui/src/styles/custodian.css
@@ -296,6 +296,13 @@ openclaw-custodian-page {
   box-shadow: 0 1px 3px var(--accent-subtle);
 }
 
+.custodian__wizard-step .custodian__wizard-cancel:disabled:hover {
+  border-color: transparent;
+  background: transparent;
+  box-shadow: none;
+  color: var(--muted);
+}
+
 .custodian__wizard-cancel:not(:disabled) {
   color: var(--text);
 }

--- a/ui/src/styles/custodian.css
+++ b/ui/src/styles/custodian.css
@@ -293,6 +293,12 @@ openclaw-custodian-page {
   cursor: pointer;
 }
 
+.custodian__wizard-step .btn:disabled:hover {
+  border-color: var(--border);
+  background: var(--bg-elevated);
+  box-shadow: none;
+}
+
 .custodian__wizard-step .btn.primary:disabled:hover {
   border-color: var(--accent);
   background: var(--primary);

--- a/ui/src/styles/custodian.css
+++ b/ui/src/styles/custodian.css
@@ -285,7 +285,7 @@ openclaw-custodian-page {
   justify-content: flex-start;
 }
 
-.custodian__wizard-cancel {
+.custodian__wizard-step .btn {
   min-height: 44px;
 }
 

--- a/ui/src/styles/custodian.css
+++ b/ui/src/styles/custodian.css
@@ -284,10 +284,6 @@ openclaw-custodian-page {
   min-height: 44px;
 }
 
-.custodian__wizard-step .btn:not(:disabled) {
-  cursor: pointer;
-}
-
 .custodian__wizard-step .btn:disabled:hover {
   border-color: var(--border);
   background: var(--bg-elevated);

--- a/ui/src/styles/custodian.css
+++ b/ui/src/styles/custodian.css
@@ -280,11 +280,6 @@ openclaw-custodian-page {
   font-size: 14px;
 }
 
-.custodian__wizard-actions {
-  display: flex;
-  justify-content: flex-start;
-}
-
 .custodian__wizard-step .btn {
   min-height: 44px;
 }
@@ -307,6 +302,10 @@ openclaw-custodian-page {
 
 .custodian__wizard-cancel:not(:disabled) {
   color: var(--text);
+}
+
+.custodian__wizard-cancel {
+  margin-right: auto;
 }
 
 .custodian__thinking {

--- a/ui/src/styles/custodian.css
+++ b/ui/src/styles/custodian.css
@@ -289,6 +289,20 @@ openclaw-custodian-page {
   min-height: 44px;
 }
 
+.custodian__wizard-step .btn:not(:disabled) {
+  cursor: pointer;
+}
+
+.custodian__wizard-step .btn.primary:disabled:hover {
+  border-color: var(--accent);
+  background: var(--primary);
+  box-shadow: 0 1px 3px var(--accent-subtle);
+}
+
+.custodian__wizard-cancel:not(:disabled) {
+  color: var(--text);
+}
+
 .custodian__thinking {
   display: flex;
   flex-direction: row;

--- a/ui/src/styles/wizard-step-controls.css
+++ b/ui/src/styles/wizard-step-controls.css
@@ -68,6 +68,11 @@
   gap: 8px;
 }
 
+.wizard-step__actions--split {
+  align-items: center;
+  justify-content: flex-end;
+}
+
 .wizard-step__progress {
   display: flex;
   align-items: center;

--- a/ui/src/styles/wizard-step-controls.css
+++ b/ui/src/styles/wizard-step-controls.css
@@ -36,6 +36,25 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   cursor: var(--cursor-action);
+  transition:
+    border-color var(--duration-fast) var(--ease-out),
+    background var(--duration-fast) var(--ease-out),
+    box-shadow var(--duration-fast) var(--ease-out);
+}
+
+.wizard-step__option:has(input:not(:disabled)):hover {
+  border-color: var(--border-hover);
+  background: var(--bg-hover);
+}
+
+.wizard-step__option:has(input:focus-visible) {
+  border-color: var(--border-hover);
+  box-shadow: var(--focus-ring);
+}
+
+.wizard-step__option:has(input:disabled) {
+  cursor: not-allowed;
+  opacity: 0.5;
 }
 
 .wizard-step__option small {

--- a/ui/src/styles/wizard-step-controls.css
+++ b/ui/src/styles/wizard-step-controls.css
@@ -57,6 +57,11 @@
   opacity: 0.5;
 }
 
+.wizard-step__form > .input:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
 .wizard-step__option small {
   display: block;
   margin-top: 2px;


### PR DESCRIPTION
## New behavior

Custodian setup controls now match the approved action layout and make interaction state obvious. The typed Cancel protocol and session behavior already landed in #118953; this PR is the UI layer only.

- **Cancel sits on the left of Continue, Submit, Yes/No, or the current primary action in the same row.**
- The primary action remains anchored on the right.
- Enabled options and actions show hover feedback; keyboard-focused options receive a visible focus ring.
- Disabled options, buttons, and ordinary text inputs remain visibly blocked and use a `not-allowed` cursor.
- Enabled buttons retain the Control UI's default-arrow cursor convention.
- Wizard action buttons have a 44 px minimum touch target.

## Explicit A/B proof

| Surface | Before | This PR |
|---|---|---|
| Wizard actions | Cancel was separated from the primary action. | Cancel and the primary action share one row: Cancel left, primary right. |
| Pointer feedback | Enabled and disabled states were difficult to distinguish consistently. | Enabled controls show hover/focus feedback; disabled controls keep blocked styling without false hover feedback. |
| Touch targets | Action height was not guaranteed across wizard variants. | Both actions retain a 44 px minimum target. |
| Responsive layout | The paired action relationship was not represented. | Phone, tablet, and desktop checks prove Cancel x < primary x, matching y positions, and no horizontal overflow. |

## PR context

Standalone presentation layer based directly on `main` after #118953 merged.

Direct-base net diff: 5 files, 225 additions, 18 deletions. Current head: `6703202f`.

## UI proof

The captures use the repository's official mocked Gateway and the real Control UI. The before image shows the direct pre-presentation behavior; the after image shows the approved paired layout.

### Before

<img width="702" height="425" alt="Custodian option before presentation polish: Cancel is not paired to the left of Continue" src="https://github.com/user-attachments/assets/348476c1-2070-407c-8116-df5247eb35ea" />

The wizard actions do not form the approved left/right pair.

### After

<img width="1440" height="900" alt="Custodian channel step with Cancel on the left and Continue on the right in one action row" src="https://github.com/user-attachments/assets/17f821d8-8fd0-4d54-9acd-129cab0bea49" />

**Cancel** is left-aligned and **Continue** is right-aligned in the same row. Both targets measure 44 px high.

## How to verify

1. Open `/custodian` and start a setup step with selectable options.
2. Confirm **Cancel** and the primary action share one row, with Cancel on the left.
3. Hover and keyboard-focus an enabled option; confirm the visual feedback.
4. Hover disabled **Continue** and submit an ordinary text step while busy; confirm blocked styling without false hover feedback.
5. Repeat at phone, tablet, and desktop widths; confirm no horizontal overflow.

## Checks

- `pnpm tsgo:ui` — passed on `6703202f`.
- `pnpm test ui/src/e2e/custodian-event-nudge.e2e.test.ts --bail=1` — 1 file and 7 rendered tests passed on `6703202f`.
- `pnpm ui:build` — passed, including precompressed-asset verification and the Control UI performance budget (325,776 B startup JS gzip vs 326,656 B ceiling).
- Exact-head GitHub CI is running at [run 31377433296](https://github.com/openclaw/openclaw/actions/runs/31377433296).

The rendered suite explicitly proves phone, tablet, and desktop geometry, side-by-side ordering, 44 px targets, disabled hover behavior, and no horizontal overflow.
