### PR TITLE
fix(managed-child): honor process groups that vanish before cleanup

### DIFF
--- a/scripts/lib/managed-child-process.mjs
+++ b/scripts/lib/managed-child-process.mjs
@@ -144,7 +144,6 @@ export async function runManagedCommand({
   let timeoutTimer = null;
   let signalTimeout;
   let timedOut = false;
-  let childResult;
   let timeoutTermination;
   const timeoutTriggered = new Promise((resolve) => {
     signalTimeout = resolve;
@@ -222,14 +221,10 @@ export async function runManagedCommand({
       }
       throw outcome.error;
     }
-    childResult = outcome.status;
     if (requireProcessTreeExit) {
-      await ensureManagedProcessTreeExit(child, platform, {
-        rejectIfLive: true,
-        terminateIfLive: true,
-      });
+      await ensureManagedProcessTreeExit(child, platform, { terminateIfLive: true });
     }
-    return childResult;
+    return outcome.status;
   } finally {
     if (timeoutTimer) {
       clearTimeout(timeoutTimer);
@@ -276,7 +271,7 @@ function processGroupStatus(pid) {
 async function ensureManagedProcessTreeExit(
   child,
   platform,
-  { rejectIfLive = false, terminateIfLive = false, windowsTermination } = {},
+  { terminateIfLive = false, windowsTermination } = {},
 ) {
   if (platform === "win32") {
     if (windowsTermination?.processTreeState === "indeterminate") {
@@ -294,10 +289,10 @@ async function ensureManagedProcessTreeExit(
     return;
   }
   let status = initialStatus;
-  let sawLive = initialStatus === "live";
-  if (terminateIfLive) {
-    terminateManagedChild(child, "SIGKILL", { platform });
-  }
+  // A missing group at signal time supersedes the earlier racy liveness probe.
+  const termination = terminateIfLive
+    ? terminateManagedChild(child, "SIGKILL", { platform })
+    : undefined;
   const deadline = Date.now() + PROCESS_GROUP_DRAIN_TIMEOUT_MS;
   while (Date.now() < deadline) {
     await new Promise((resolve) => {
@@ -305,7 +300,7 @@ async function ensureManagedProcessTreeExit(
     });
     status = processGroupStatus(child.pid);
     if (status === "dead") {
-      if (rejectIfLive && sawLive) {
+      if (terminateIfLive && termination?.processTreeState !== "terminated") {
         throw createManagedCommandCleanupError(
           "Managed command exited while its process group remained active",
           child,
@@ -314,9 +309,6 @@ async function ensureManagedProcessTreeExit(
         );
       }
       return;
-    }
-    if (status === "live") {
-      sawLive = true;
     }
   }
   const processTreeState = status === "indeterminate" ? "indeterminate" : "live";

--- a/test/scripts/managed-child-process.test.ts
+++ b/test/scripts/managed-child-process.test.ts
@@ -418,6 +418,40 @@ setInterval(() => {}, 1_000);
     expect(isProcessAlive(childPid)).toBe(false);
   });
 
+  posixIt("accepts a process group that vanishes before its cleanup signal", async () => {
+    const originalKill = process.kill;
+    let childPid = 0;
+    let injectedLiveGroup = false;
+    process.kill = ((pid: number, signal?: NodeJS.Signals | number) => {
+      if (pid === -childPid && signal === 0 && !injectedLiveGroup) {
+        injectedLiveGroup = true;
+        return true;
+      }
+      return originalKill(pid, signal);
+    }) as typeof process.kill;
+
+    try {
+      await expect(
+        runManagedCommand({
+          bin: process.execPath,
+          args: ["-e", "process.exit(0)"],
+          onReady: (child) => {
+            childPid = expectProcessPid(child.pid);
+          },
+          requireProcessTreeExit: true,
+          shell: false,
+          stdio: "ignore",
+          timeoutMs: 1_000,
+        }),
+      ).resolves.toBe(0);
+    } finally {
+      process.kill = originalKill;
+    }
+
+    expect(injectedLiveGroup).toBe(true);
+    expect(isProcessAlive(childPid)).toBe(false);
+  });
+
   it("allows bounded retry output and normal long-running work to complete", async () => {
     await expect(
       runManagedCommand({


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where live updater operations can fail with "Git fast-forward merge process tree could not be cleaned up" after a successfully exited Git process group disappears between its liveness probe and cleanup signal, masking the actual replacement readiness failure and breaking LaunchAgent rollback.

## Why This Change Was Made

The managed-child lifecycle owner now treats Node process.kill(-pid, SIGKILL) throwing ESRCH as authoritative proof that the process group no longer exists, superseding the earlier stale liveness probe. Real lingering descendants still fail closed after cleanup; Windows behavior, timeout guarantees, and orphan draining remain unchanged. The owner implementation removes 8 net production lines.

## User Impact

Live updater users retain accurate replacement-readiness failures and reliable LaunchAgent rollback instead of false process-tree cleanup errors. Actual surviving process groups remain rejected.

## Evidence

- New deterministic POSIX regression proves a successful liveness probe followed by real ESRCH on cleanup.
- Unchanged true-orphan coverage still rejects and drains descendants; the original live updater replacement-readiness rollback scenario passes.
- Focused remote Blacksmith Testbox proof: 108/108 tests passed, comprising 19 managed-child-process, 81 openclaw-live-updater, and 8 vitest-process-group tests.
- Full unchanged pnpm check:changed passed remotely, including 252 script declaration contracts, test-root tsgo typechecking, and changed-script lint with zero warnings and zero errors.
- Independent exact gpt-5.6-sol/xhigh autoreview: confidence 0.98; no actionable findings.
- Net delta: -8 production LOC and +34 deterministic regression-test LOC.
- Blacksmith Testbox run: https://github.com/openclaw/openclaw/actions/runs/31008770672; its sole lease was independently verified completed.

### Exact-head live-updater ESRCH and rollback runtime proof

Reviewed, unchanged head: `2bcfdd5f28a01f68b9fdc6e7db34d5474a5798e8`. A remote-only, isolated fixture injected the stale liveness observation directly into the real live-updater Git merge after the kernel had already confirmed that its owned process group was absent. The unchanged production updater then preserved the original readiness error and restored the previous managed service:

```text
[runtime-proof] live-updater git merge: injected stale liveness=LIVE after verified actual process-group=ABSENT
[runtime-proof] live-updater git merge: cleanup signal=SIGKILL error.code=ESRCH authoritative process-group=ABSENT
[runtime-proof] replacement readiness failure observed: replacement readiness failed
[runtime-proof] rollback stop proof: previous gateway runtime=STOPPED port=FREE fixture=isolated
[runtime-proof] rollback restored previous LaunchAgent plist and prior gateway entrypoint
[runtime-proof] rollback bootstrapped previous LaunchAgent; old gateway safe=YES fixture=isolated
[runtime-proof] managed-child regression: cleanup signal=SIGKILL error.code=ESRCH authoritative process-group=ABSENT
```

The existing deterministic managed-child regression and the original live-updater LaunchAgent rollback scenario both passed in the same exact-head run: **2 tests passed, 98 skipped**. Remote runtime proof: https://github.com/openclaw/openclaw/actions/runs/31011790318.

**Second rank-up move disposition:** exact-head `build-artifacts` and required `openclaw/ci-gate` are already **SUCCESS**. The branch head is unchanged since the substantive ClawSweeper review, so root `AGENTS.md` explicitly forbids a review-refresh round trip on an unchanged reviewed SHA; no bot re-review is warranted.
