### PR TITLE
docs(platforms/android): clarify fork and local build signing boundary

### DIFF
--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -62,6 +62,10 @@ gh attestation verify OpenClaw-Android.apk \
 Google Play and standalone APK installs use different update channels and may have different signing identities. Android may require uninstalling the existing app before switching channels, which removes its local app data. Stay on one channel for normal updates.
 </Warning>
 
+<Note>
+The sideload verification steps above apply to the official `OpenClaw-Android.apk` published by the OpenClaw project. If you build from source, maintain a fork, or distribute a local build, you must sign it with your own Android signing identity. Do not copy or reuse OpenClaw's release signing credentials. See the [release-owner signing guidance](https://github.com/openclaw/openclaw/blob/main/apps/android/README.md) in `apps/android/README.md`.
+</Note>
+
 ## Mirror and control Android from a remote Mac
 
 [scrcpy](https://github.com/Genymobile/scrcpy) mirrors an Android screen in a macOS window and


### PR DESCRIPTION
[AI-assisted]

## What Problem This Solves

The public Android docs page explains how to download and verify the official signed `OpenClaw-Android.apk`, but does not clarify that source, fork, or local distributors must use their own Android signing identity and should not copy OpenClaw's release signing credentials. A fork or local builder following the current docs could incorrectly assume the official signing key applies to their build.

## Why This Change Was Made

Issue openclaw/openclaw#119609 identified the gap. The fix is a short `<Note>` in the **Install outside Google Play** section of `docs/platforms/android.md` that distinguishes official APK verification from fork/local builds, pointing to the existing release-owner signing guidance in `apps/android/README.md` without exposing private credentials.

## Evidence

- Read `docs/platforms/android.md` and `apps/android/README.md` to identify the existing release-owner guidance.
- The diff is a one-file, 4-line insertion — no code, config, or credential changes.
- `node scripts/check-docs-mdx.mjs docs/platforms/android.md` passed (docs MDX check).
- The note links to the existing `apps/android/README.md` signing section rather than duplicating or exposing credentials.

## Summary

- Add a short `<Note>` in the **Install outside Google Play** section of `docs/platforms/android.md` that distinguishes official APK verification from fork/local builds.
- Point to the existing release-owner signing guidance in `apps/android/README.md` without exposing private credentials.

Fixes openclaw/openclaw#119609.

## Test plan

- [x] Read `docs/platforms/android.md` and `apps/android/README.md` to identify the existing release-owner guidance.
- [x] Added the clarification note with no private credential exposure.
- [x] Ran `node scripts/check-docs-mdx.mjs docs/platforms/android.md` from the repo root; docs MDX check passed.
- [x] Verified the diff is a one-file, 4-line insertion.