### PR TITLE
fix(whatsapp): exercise descriptor-safe credential persistence

### DIFF
--- a/extensions/whatsapp/src/session.test.ts
+++ b/extensions/whatsapp/src/session.test.ts
@@ -4,7 +4,16 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { resetLogger, setLoggerOverride } from "openclaw/plugin-sdk/runtime-env";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from "vitest";
 import { logWebSelfId } from "./auth-store.js";
 import { enqueueCredsSave } from "./creds-persistence.js";
 import { baileys, getLastSocket, resetBaileysMocks, resetLoadConfigMock } from "./test-helpers.js";
@@ -80,56 +89,55 @@ function createTempCaFile(contents: string): string {
 function mockFsOpenForCredsWrites(params?: {
   onTempWrite?: (filePath: string) => Promise<void> | void;
 }) {
+  const open = fs.open.bind(fs);
   const writeFile = fs.writeFile.bind(fs);
-  const tempHandles: Array<{
+  type FileHandle = Awaited<ReturnType<typeof fs.open>>;
+  const handles: Array<{
     filePath: string;
-    sync: ReturnType<typeof vi.fn>;
-    close: ReturnType<typeof vi.fn>;
+    flags: string | number | undefined;
+    mode: number | undefined;
+    handle: FileHandle;
+    chmod: MockInstance<FileHandle["chmod"]>;
+    sync: MockInstance<FileHandle["sync"]>;
+    close: MockInstance<FileHandle["close"]>;
   }> = [];
-  const dirHandles: Array<{
-    filePath: string;
-    sync: ReturnType<typeof vi.fn>;
-    close: ReturnType<typeof vi.fn>;
-  }> = [];
-  const tempWrites: string[] = [];
+  const writes: Array<{ filePath: string; data: unknown }> = [];
   const writeFileSpy = vi
     .spyOn(fs, "writeFile")
-    .mockImplementation(async (filePath, data, opts) => {
-      if (typeof filePath === "string" && filePath.includes(".creds.")) {
-        tempWrites.push(filePath);
-        await params?.onTempWrite?.(filePath);
+    .mockImplementation(async (target, data, options) => {
+      const observed = handles.find(({ handle }) => handle === target);
+      if (observed && path.basename(observed.filePath).startsWith(".creds.")) {
+        writes.push({ filePath: observed.filePath, data });
+        await params?.onTempWrite?.(observed.filePath);
       }
-      return await writeFile(filePath as never, data as never, opts as never);
+      return await writeFile(target, data, options);
     });
   const openSpy = vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
-    if (typeof filePath === "string" && flags === "r+" && filePath.includes(".creds.")) {
-      const handle = {
+    const handle = await open(filePath, flags, mode);
+    if (typeof filePath === "string") {
+      handles.push({
         filePath,
-        sync: vi.fn(async () => {}),
-        close: vi.fn(async () => {}),
-      };
-      tempHandles.push(handle);
-      return handle as never;
+        flags,
+        mode: typeof mode === "number" ? mode : undefined,
+        handle,
+        chmod: vi.spyOn(handle, "chmod"),
+        sync: vi.spyOn(handle, "sync"),
+        close: vi.spyOn(handle, "close"),
+      });
     }
-    if (typeof filePath === "string" && flags === "r") {
-      const handle = {
-        filePath,
-        sync: vi.fn(async () => {}),
-        close: vi.fn(async () => {}),
-      };
-      dirHandles.push(handle);
-      return handle as never;
-    }
-    throw new Error(
-      `unexpected fs.open call: ${String(filePath)} ${String(flags)} ${String(mode)}`,
-    );
+    return handle;
   });
   return {
-    openSpy,
-    writeFileSpy,
-    tempWrites,
-    tempHandles,
-    dirHandles,
+    handles,
+    writes,
+    get tempHandles() {
+      return handles.filter(
+        ({ filePath, flags }) => flags === "wx" && path.basename(filePath).startsWith(".creds."),
+      );
+    },
+    get dirHandles() {
+      return handles.filter(({ flags }) => flags === "r");
+    },
     restore() {
       writeFileSpy.mockRestore();
       openSpy.mockRestore();
@@ -184,27 +192,6 @@ function requireValue<T>(value: T | undefined, label: string): T {
     throw new Error(`expected ${label}`);
   }
   return value;
-}
-
-function requireString(value: unknown, label: string): string {
-  if (typeof value !== "string") {
-    throw new Error(`expected ${label}`);
-  }
-  return value;
-}
-
-function firstWriteFileCall(writeFileSpy: ReturnType<typeof vi.fn>): {
-  data: unknown;
-  options: { flag?: string; mode?: number };
-  path: string;
-} {
-  const [filePath, data, options] = firstMockCall(writeFileSpy, "fs.writeFile");
-  expect(typeof filePath).toBe("string");
-  return {
-    data,
-    options: (options ?? {}) as { flag?: string; mode?: number },
-    path: filePath as string,
-  };
 }
 
 function expectRuntimeLogContaining(
@@ -275,11 +262,12 @@ describe("web session", () => {
     passedLogger.trace("ignored");
     await emitCredsUpdate(authDir);
 
-    const write = firstWriteFileCall(openMock.writeFileSpy);
-    expect(write.path).toContain(path.join(authDir, ".creds."));
+    const write = requireValue(openMock.writes[0], "WhatsApp credential write");
+    const tempHandle = requireValue(openMock.tempHandles[0], "WhatsApp credential handle");
+    expect(write.filePath).toContain(path.join(authDir, ".creds."));
     expect(typeof write.data).toBe("string");
-    expect(write.options.mode).toBe(0o600);
-    expect(write.options.flag).toBe("wx");
+    expect(tempHandle.mode).toBe(0o600);
+    expect(tempHandle.flags).toBe("wx");
     openMock.restore();
   });
 
@@ -976,46 +964,55 @@ describe("web session", () => {
   );
 
   it("writes creds.json atomically via temp file and rename", async () => {
+    const authDir = createTempAuthDir("openclaw-wa-creds-atomic-write");
+    const credsPath = path.join(authDir, "creds.json");
     const openMock = mockFsOpenForCredsWrites();
-    const renameSpy = vi.spyOn(fs, "rename").mockResolvedValue(undefined);
-    const rmSpy = vi.spyOn(fs, "rm").mockResolvedValue(undefined);
-    const chmodSpy = vi.spyOn(fs, "chmod").mockResolvedValue(undefined);
+    const renameSpy = vi.spyOn(fs, "rename");
+    const rmSpy = vi.spyOn(fs, "rm");
 
     try {
-      await writeCredsJsonAtomically("/tmp/openclaw-oauth/whatsapp/default", {
-        me: { id: "123@s.whatsapp.net" },
-      });
+      await writeCredsJsonAtomically(authDir, { me: { id: "123@s.whatsapp.net" } });
 
-      const write = firstWriteFileCall(openMock.writeFileSpy);
-      expect(write.path).toContain(
-        path.join("/tmp", "openclaw-oauth", "whatsapp", "default", ".creds."),
-      );
+      const write = requireValue(openMock.writes[0], "WhatsApp credential write");
+      const tempHandle = requireValue(openMock.tempHandles[0], "WhatsApp credential handle");
+      expect(write.filePath).toContain(path.join(authDir, ".creds."));
       expect(typeof write.data).toBe("string");
-      expect(write.options.mode).toBe(0o600);
-      expect(write.options.flag).toBe("wx");
+      expect(tempHandle.mode).toBe(0o600);
+      expect(tempHandle.flags).toBe("wx");
       expect(openMock.tempHandles).toHaveLength(1);
-      expect(openMock.tempHandles[0]?.sync).toHaveBeenCalledTimes(1);
-      expect(openMock.tempHandles[0]?.close).toHaveBeenCalledTimes(1);
-      expect(renameSpy).toHaveBeenCalledTimes(1);
+      expect(tempHandle.chmod).toHaveBeenCalledWith(0o600);
+      expect(tempHandle.sync).toHaveBeenCalledTimes(1);
+      expect(tempHandle.close).toHaveBeenCalledTimes(1);
+      expect(renameSpy).toHaveBeenCalledExactlyOnceWith(tempHandle.filePath, credsPath);
       expect(rmSpy).not.toHaveBeenCalled();
-      expect(chmodSpy).toHaveBeenCalledWith(
-        path.join("/tmp", "openclaw-oauth", "whatsapp", "default", "creds.json"),
-        0o600,
-      );
       expect(openMock.dirHandles).toHaveLength(1);
       expect(openMock.dirHandles[0]?.sync).toHaveBeenCalledTimes(1);
-      const writePath = openMock.tempHandles[0]?.filePath;
-      const [, renameTarget] = firstMockCall(renameSpy, "creds atomic rename");
-      expect(typeof writePath).toBe("string");
-      expect(writePath).toContain(".creds.");
-      expect(requireString(renameTarget, "creds rename target path")).toContain(
-        path.join("/tmp", "openclaw-oauth", "whatsapp", "default", "creds.json"),
-      );
+      expect(openMock.dirHandles[0]?.close).toHaveBeenCalledTimes(1);
+      expect(JSON.parse(fsSync.readFileSync(credsPath, "utf8"))).toEqual({
+        me: { id: "123@s.whatsapp.net" },
+      });
+      expect(fsSync.statSync(credsPath).mode & 0o777).toBe(0o600);
+      if (process.platform !== "win32") {
+        const parentHandle = requireValue(
+          openMock.handles.find(
+            ({ filePath, flags }) => filePath === authDir && typeof flags === "number",
+          ),
+          "pinned WhatsApp credential directory",
+        );
+        expect(parentHandle.flags).toBe(
+          fsSync.constants.O_RDONLY |
+            fsSync.constants.O_DIRECTORY |
+            fsSync.constants.O_NOFOLLOW |
+            fsSync.constants.O_NONBLOCK,
+        );
+        expect(parentHandle.chmod).toHaveBeenCalledWith(0o700);
+        expect(parentHandle.close).toHaveBeenCalledTimes(1);
+        expect(fsSync.statSync(authDir).mode & 0o777).toBe(0o700);
+      }
     } finally {
       openMock.restore();
       renameSpy.mockRestore();
       rmSpy.mockRestore();
-      chmodSpy.mockRestore();
     }
   });
 


### PR DESCRIPTION
## What Problem This Solves

Five existing WhatsApp credential-persistence tests failed after the pinned `@openclaw/fs-safe@0.5.2` security upgrade because their obsolete filesystem fixture rejected legitimate descriptor-based operations. This broke coverage for normal credential saves, corrupted-backup protection, serialized writes, backup rotation, and atomic credential replacement.

## Why This Change Was Made

Replace fabricated filesystem handles and obsolete pathname-based assumptions with narrowly observed real filesystem operations. The fixture now follows the actual fs-safe 0.5.2 contract: parent directories are opened using numeric `O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_NONBLOCK` flags, temporary credential files are opened exclusively with `wx`, data is written through real file descriptors, and permissions and synchronization are applied through their owning handles.

## User Impact

WhatsApp credential durability and security coverage once again exercises the real production persistence path without changing production behavior. Existing symlink protection, credential confidentiality, atomic replacement, backup recovery, and serialized writes remain enforced; no security checks were removed or weakened. Production LOC is unchanged and the test fixture is three lines smaller overall (+88/-91).

## Evidence

- All five previously failing credential cases now pass in the complete WhatsApp session suite: **40/40 passed**.
- Grouped WhatsApp owner/sibling suites: session **40**, auth-store **21**, lazy auth directories **3**, credential persistence **1**, and logout **7**: **72/72 passed across five files**.
- Real-filesystem assertions verify numeric no-follow/directory pinning, exclusive temporary-file creation, `0600` credential permissions, `0700` parent-directory permissions, descriptor `chmod`, file and directory `fsync`, real atomic rename, persisted bytes, backup preservation/rotation, queue serialization, and existing symlink defenses.
- Full unchanged remote `pnpm check:changed` passed, including extension-test typechecking, formatting, plugin boundaries, all dead-export scans, and lint with **0 warnings / 0 errors**.
- Fresh independent required autoreview: Codex engine, `gpt-5.6-sol`, `xhigh`; **clean with 0.99 confidence**.
- Testbox proof: https://github.com/openclaw/openclaw/actions/runs/31008773435

### Review clarification: two distinct parent-directory descriptors

The reported concern that `dirHandles` should include numeric directory-open flags is disproved by the exact published `@openclaw/fs-safe@0.5.2` source and by the passing production-boundary test:

1. `dist/replace-file-descriptor.js:22-37` opens the parent directory with numeric `O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_NONBLOCK`, applies descriptor `chmod(0700)`, and closes it. The fixture records this descriptor in its complete `handles` collection at `extensions/whatsapp/src/session.test.ts:115-126`; the atomic-write case separately selects the numeric descriptor and verifies the exact flag mask, descriptor chmod, close, and actual `0700` directory permissions at `extensions/whatsapp/src/session.test.ts:995-1010`.
2. `dist/replace-file.js:128-138` opens the same parent directory a second time with the literal string flag `"r"`, calls descriptor `sync()`, and closes it; `dist/replace-file.js:224-225` invokes that separate durability step. `dirHandles` intentionally selects only this distinct `"r"` fsync descriptor at `extensions/whatsapp/src/session.test.ts:138-140`, and the test verifies exactly one durability descriptor plus its sync and close calls at `extensions/whatsapp/src/session.test.ts:988-990`.

Adding the numeric chmod-only descriptor to `dirHandles` would be incorrect: that descriptor is never synced, and doing so would conflate two different security/durability lifecycles. Both descriptor paths already have explicit assertions; the full session suite passes **40/40**, all grouped owner suites pass **72/72**, and exact commit `8135d5cd868ac5ee943095c4b0fba6add08f4943` completed the hosted `openclaw/ci-gate` successfully: https://github.com/openclaw/openclaw/actions/runs/31011423891/job/92325553289.

