### PR TITLE
fix(ui): observe the active service worker after asset refresh

### DIFF
--- a/ui/src/e2e/service-worker-update.e2e.test.ts
+++ b/ui/src/e2e/service-worker-update.e2e.test.ts
@@ -115,27 +115,13 @@ async function fetchControlledAsset(
   assetPath: string,
 ): Promise<{ controllerState: string | null; sha256: string }> {
   return page.evaluate(async (relativePath) => {
-    const controller = navigator.serviceWorker.controller;
-    if (controller && controller.state !== "activated") {
-      await new Promise<void>((resolve) => {
-        controller.addEventListener(
-          "statechange",
-          () => {
-            if (controller.state === "activated") {
-              resolve();
-            }
-          },
-          { once: true },
-        );
-      });
-    }
     const response = await fetch(new URL(relativePath, window.location.href));
     if (!response.ok) {
       throw new Error(`Build asset request failed with HTTP ${response.status}`);
     }
     const digest = await crypto.subtle.digest("SHA-256", await response.arrayBuffer());
     return {
-      controllerState: controller?.state ?? null,
+      controllerState: navigator.serviceWorker.controller?.state ?? null,
       sha256: [...new Uint8Array(digest)]
         .map((byte) => byte.toString(16).padStart(2, "0"))
         .join(""),


### PR DESCRIPTION
## What Problem This Solves

The real Chromium production service-worker update test could fail even when worker replacement and asset refresh behaved correctly. Its asset observer captured the old controller before asynchronous fetch, response-body, and SHA-256 digest work; a legitimate worker takeover could make that captured worker `redundant` before the assertion.

## Why This Change Was Made

The W3C service-worker activation lifecycle permits the previous active worker to become `redundant` while `navigator.serviceWorker.controller` reflects the current controlling worker. Read the authoritative live controller after hashing the controlled asset, and delete the obsolete captured-worker `{ once: true }` state-change listener. The existing controller-readiness helper and exact `activated` and old/new SHA-256 assertions remain unchanged; no retries, timeout increases, weaker assertions, production changes, or compatibility paths are introduced.

## User Impact

No production behavior changes. Browser users retain the same `skipWaiting()`, `clients.claim()`, update notification, page reload, build-specific cache, and refreshed-asset behavior. CI now observes the actual controlling service worker after a real ownership handoff instead of reporting a stale controller as a product regression. Net change: 14 fewer test lines, zero production lines.

## Evidence

- Real Chromium Control UI E2E: 1/1 passed with two independently built production bundles, real service-worker registration/update/claim, `activated` assertions for both observations, exact expected old/new asset SHA-256 hashes, and distinct refreshed hashes.
- Existing service-worker cache/activation suite: 50/50 passed, including versioned registration, `skipWaiting()`, `clients.claim()`, retained caches, and notification scope.
- Full unchanged `pnpm check:changed` passed on the same trusted Blacksmith Testbox, including formatting, repository guards, duplicate/dead-export scans, UI localization verification, core-test typechecking, and changed-file lint (zero warnings/errors).
- Exact structured Codex autoreview: `gpt-5.6-sol`, `xhigh`, clean, confidence 0.99.
- Remote proof: https://github.com/openclaw/openclaw/actions/runs/31008918735

