### PR TITLE
refactor(qa): consolidate scenario runtime helpers

### DIFF
--- a/extensions/qa-lab/src/crabline-transport.ts
+++ b/extensions/qa-lab/src/crabline-transport.ts
@@ -29,7 +29,6 @@ import {
 } from "./qa-transport.js";
 import type {
   QaTransportActionName,
-  QaTransportGatewayClient,
   QaTransportGatewayConfig,
   QaTransportNativeCommandInput,
   QaTransportOutboundEvent,
@@ -383,11 +382,7 @@ class QaCrablineTransport extends QaStateBackedTransportAdapter {
     } as QaTransportGatewayConfig;
   };
 
-  waitReady = (params: {
-    gateway: QaTransportGatewayClient;
-    timeoutMs?: number;
-    pollIntervalMs?: number;
-  }) =>
+  waitReady = (params: Parameters<QaStateBackedTransportAdapter["waitReady"]>[0]) =>
     waitForQaTransportAccountReady({
       ...params,
       accountId: this.#adapter.accountId,

--- a/extensions/qa-lab/src/errors.ts
+++ b/extensions/qa-lab/src/errors.ts
@@ -41,17 +41,3 @@ export class QaSuiteScenarioSkipError extends Error {
     this.name = "QaSuiteScenarioSkipError";
   }
 }
-
-export function toQaErrorObject(value: unknown, fallbackMessage: string): Error {
-  if (value instanceof Error) {
-    return value;
-  }
-  if (typeof value === "string") {
-    return new Error(value);
-  }
-  const error = new Error(fallbackMessage, { cause: value });
-  if ((typeof value === "object" && value !== null) || typeof value === "function") {
-    Object.assign(error, value);
-  }
-  return error;
-}

--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -15,7 +15,7 @@ import path from "node:path";
 import { finished } from "node:stream/promises";
 import { setTimeout as sleep } from "node:timers/promises";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { formatErrorMessage, toErrorObject } from "openclaw/plugin-sdk/error-runtime";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
@@ -44,7 +44,7 @@ import {
 } from "./child-output.js";
 import { assertRepoBoundPath, ensureRepoBoundDirectory } from "./cli-paths.js";
 import { buildQaCodexAppServerArgs } from "./codex-app-server-args.js";
-import { QaSuiteInfraError, toQaErrorObject } from "./errors.js";
+import { QaSuiteInfraError } from "./errors.js";
 import { formatQaGatewayLogsForError, redactQaGatewayDebugText } from "./gateway-log-redaction.js";
 import {
   createQaGatewayProcessBoundaryController,
@@ -217,7 +217,7 @@ async function readQaGatewayCliCommand(child: ChildProcess): Promise<string> {
   const exitCode = await new Promise<number>((resolve, reject) => {
     monitorQaChildFailure(child, (failure) => {
       if (failure.source === "process") {
-        reject(toQaErrorObject(failure.error, "OpenClaw CLI process failed"));
+        reject(toErrorObject(failure.error, "OpenClaw CLI process failed"));
         return;
       }
       if (!hasChildExited(child) && !child.killed) {
@@ -1565,7 +1565,7 @@ export async function startQaGatewayChild(params: {
             }
           }
           if (!rpcReady) {
-            throw toQaErrorObject(
+            throw toErrorObject(
               lastRpcStartupError ?? new Error("qa gateway rpc client failed to start"),
               "Non-Error thrown",
             );
@@ -1673,7 +1673,7 @@ export async function startQaGatewayChild(params: {
             }
           }
           if (!rpcReady) {
-            throw toQaErrorObject(
+            throw toErrorObject(
               lastRpcStartupError ?? new Error("qa gateway rpc client failed to start"),
               "Non-Error thrown",
             );

--- a/extensions/qa-lab/src/qa-channel-transport.ts
+++ b/extensions/qa-lab/src/qa-channel-transport.ts
@@ -10,7 +10,6 @@ import {
 import type {
   QaTransportActionName,
   QaTransportGatewayConfig,
-  QaTransportGatewayClient,
   QaTransportNativeCommandInput,
   QaTransportOutboundSequenceMatch,
   QaTransportPolicy,
@@ -109,11 +108,7 @@ class QaChannelTransport extends QaStateBackedTransportAdapter {
 
   createGatewayConfig = ({ baseUrl }: { baseUrl: string }) =>
     createQaChannelGatewayConfig({ baseUrl, transportPolicy: this.#transportPolicy });
-  waitReady = (params: {
-    gateway: QaTransportGatewayClient;
-    timeoutMs?: number;
-    pollIntervalMs?: number;
-  }) =>
+  waitReady = (params: Parameters<QaStateBackedTransportAdapter["waitReady"]>[0]) =>
     waitForQaTransportAccountReady({
       ...params,
       accountId: QA_CHANNEL_ACCOUNT_ID,

--- a/extensions/qa-lab/src/qa-transport.ts
+++ b/extensions/qa-lab/src/qa-transport.ts
@@ -19,7 +19,7 @@ import type {
   QaBusWaitForInput,
 } from "./runtime-api.js";
 
-export type QaTransportGatewayClient = {
+type QaTransportGatewayClient = {
   call: (
     method: string,
     params?: unknown,

--- a/extensions/qa-lab/src/scenario-runtime-api.test.ts
+++ b/extensions/qa-lab/src/scenario-runtime-api.test.ts
@@ -29,7 +29,6 @@ function createDeps(overrides?: Partial<QaScenarioRuntimeDeps>): QaScenarioRunti
     fetchJson: fn,
     waitForGatewayHealthy: fn,
     waitForTransportReady: fn,
-    waitForQaChannelReady: fn,
     browserRequest: fn,
     waitForBrowserReady: fn,
     browserOpenTab: fn,
@@ -188,6 +187,7 @@ describe("createQaScenarioRuntimeApi", () => {
     expect(api.config).toEqual({ expected: "value" });
     expect(api.waitForCondition).toBe(waitForCondition);
     expect(api.waitForChannelReady).toBe(api.waitForTransportReady);
+    expect(api.waitForQaChannelReady).toBe(api.waitForTransportReady);
     expect(api.waitForAgentHistoryReply).toBe(deps.waitForAgentHistoryReply);
     expect(api.markGatewayLogCursor).toBe(deps.markGatewayLogCursor);
     expect(api.assertNoGatewayLogSentinels).toBe(deps.assertNoGatewayLogSentinels);

--- a/extensions/qa-lab/src/scenario-runtime-api.ts
+++ b/extensions/qa-lab/src/scenario-runtime-api.ts
@@ -41,7 +41,6 @@ type QaScenarioRuntimeDeps = {
   fetchJson: QaScenarioRuntimeFunction;
   waitForGatewayHealthy: QaScenarioRuntimeFunction;
   waitForTransportReady: QaScenarioRuntimeFunction;
-  waitForQaChannelReady: QaScenarioRuntimeFunction;
   browserRequest: QaScenarioRuntimeFunction;
   waitForBrowserReady: QaScenarioRuntimeFunction;
   browserOpenTab: QaScenarioRuntimeFunction;
@@ -111,89 +110,16 @@ type QaScenarioRuntimeConstants = {
 type QaScenarioRuntimeApi<
   TEnv extends QaScenarioRuntimeEnv = QaScenarioRuntimeEnv,
   TDeps extends QaScenarioRuntimeDeps = QaScenarioRuntimeDeps,
-> = {
+> = TDeps & {
   env: TEnv;
   lab: TEnv["lab"];
   transport: TEnv["transport"];
   state: TEnv["transport"]["state"];
   scenario: QaSeedScenarioWithSource;
   config: Record<string, unknown>;
-  fs: typeof NodeFs;
-  path: typeof NodePath;
-  sleep: (ms?: number) => Promise<unknown>;
-  randomUUID: () => string;
-  runScenario: TDeps["runScenario"];
   waitForCondition: TEnv["transport"]["waitForCondition"];
-  waitForOutboundMessage: TDeps["waitForOutboundMessage"];
-  waitForNoOutbound: TDeps["waitForNoOutbound"];
-  waitForNoTransportOutbound: TDeps["waitForNoTransportOutbound"];
-  recentOutboundSummary: TDeps["recentOutboundSummary"];
-  formatConversationTranscript: TDeps["formatConversationTranscript"];
-  readTransportTranscript: TDeps["readTransportTranscript"];
-  formatTransportTranscript: TDeps["formatTransportTranscript"];
-  fetchJson: TDeps["fetchJson"];
-  waitForGatewayHealthy: TDeps["waitForGatewayHealthy"];
-  waitForTransportReady: TDeps["waitForTransportReady"];
   waitForChannelReady: TDeps["waitForTransportReady"];
-  waitForQaChannelReady: TDeps["waitForQaChannelReady"];
-  browserRequest: TDeps["browserRequest"];
-  waitForBrowserReady: TDeps["waitForBrowserReady"];
-  browserOpenTab: TDeps["browserOpenTab"];
-  browserSnapshot: TDeps["browserSnapshot"];
-  browserAct: TDeps["browserAct"];
-  webOpenPage: TDeps["webOpenPage"];
-  webWait: TDeps["webWait"];
-  webType: TDeps["webType"];
-  webSnapshot: TDeps["webSnapshot"];
-  webEvaluate: TDeps["webEvaluate"];
-  waitForConfigRestartSettle: TDeps["waitForConfigRestartSettle"];
-  patchConfig: TDeps["patchConfig"];
-  applyConfig: TDeps["applyConfig"];
-  readConfigSnapshot: TDeps["readConfigSnapshot"];
-  restartGatewayWithConfigPatch: TDeps["restartGatewayWithConfigPatch"];
-  createSession: TDeps["createSession"];
-  readEffectiveTools: TDeps["readEffectiveTools"];
-  readSkillStatus: TDeps["readSkillStatus"];
-  readRawQaSessionStore: TDeps["readRawQaSessionStore"];
-  seedQaSessionTranscript: TDeps["seedQaSessionTranscript"];
-  readGatewayLogs: TDeps["readGatewayLogs"];
-  markGatewayLogCursor: TDeps["markGatewayLogCursor"];
-  scanGatewayLogSentinels: TDeps["scanGatewayLogSentinels"];
-  assertNoGatewayLogSentinels: TDeps["assertNoGatewayLogSentinels"];
-  readSessionTranscriptSummary: TDeps["readSessionTranscriptSummary"];
-  runQaCli: TDeps["runQaCli"];
-  extractMediaPathFromText: TDeps["extractMediaPathFromText"];
-  resolveGeneratedImagePath: TDeps["resolveGeneratedImagePath"];
-  startAgentRun: TDeps["startAgentRun"];
-  waitForAgentRun: TDeps["waitForAgentRun"];
-  waitForAgentHistoryReply: TDeps["waitForAgentHistoryReply"];
-  listCronJobs: TDeps["listCronJobs"];
-  findManagedDreamingCronJob: TDeps["findManagedDreamingCronJob"];
-  waitForCronRunCompletion: TDeps["waitForCronRunCompletion"];
-  readDoctorMemoryStatus: TDeps["readDoctorMemoryStatus"];
-  forceMemoryIndex: TDeps["forceMemoryIndex"];
-  findSkill: TDeps["findSkill"];
-  writeWorkspaceSkill: TDeps["writeWorkspaceSkill"];
-  callPluginToolsMcp: TDeps["callPluginToolsMcp"];
-  runAgentPrompt: TDeps["runAgentPrompt"];
-  ensureImageGenerationConfigured: TDeps["ensureImageGenerationConfigured"];
-  handleQaAction: TDeps["handleQaAction"];
-  runRuntimeToolFixture: TDeps["runRuntimeToolFixture"];
-  extractQaToolPayload: TDeps["extractQaToolPayload"];
-  formatMemoryDreamingDay: TDeps["formatMemoryDreamingDay"];
-  resolveSessionTranscriptsDirForAgent: TDeps["resolveSessionTranscriptsDirForAgent"];
-  activeMemoryToggleKey: TDeps["activeMemoryToggleKey"];
-  setActiveMemorySessionDisabled: TDeps["setActiveMemorySessionDisabled"];
-  buildAgentSessionKey: TDeps["buildAgentSessionKey"];
-  normalizeLowercaseStringOrEmpty: TDeps["normalizeLowercaseStringOrEmpty"];
-  formatErrorMessage: TDeps["formatErrorMessage"];
-  liveTurnTimeoutMs: TDeps["liveTurnTimeoutMs"];
-  resolveQaLiveTurnTimeoutMs: TDeps["resolveQaLiveTurnTimeoutMs"];
-  splitModelRef: TDeps["splitModelRef"];
-  hasDiscoveryLabels: TDeps["hasDiscoveryLabels"];
-  reportsDiscoveryScopeLeak: TDeps["reportsDiscoveryScopeLeak"];
-  reportsMissingDiscoveryFiles: TDeps["reportsMissingDiscoveryFiles"];
-  hasModelSwitchContinuitySignal: TDeps["hasModelSwitchContinuitySignal"];
+  waitForQaChannelReady: TDeps["waitForTransportReady"];
   imageUnderstandingPngBase64: string;
   imageUnderstandingLargePngBase64: string;
   imageUnderstandingValidPngBase64: string;
@@ -222,98 +148,45 @@ export function createQaScenarioRuntimeApi<
     await params.deps.sleep(100);
   };
 
-  return {
-    env: params.env,
-    lab: params.env.lab,
-    transport,
-    state: transportState,
-    scenario: params.scenario,
-    config: params.scenario.execution.config ?? {},
-    fs: params.deps.fs,
-    path: params.deps.path,
-    sleep: params.deps.sleep,
-    randomUUID: params.deps.randomUUID,
-    runScenario: params.deps.runScenario,
-    waitForCondition: transport.waitForCondition,
-    waitForOutboundMessage: params.deps.waitForOutboundMessage,
-    waitForNoOutbound: params.deps.waitForNoOutbound,
-    waitForNoTransportOutbound: params.deps.waitForNoTransportOutbound,
-    recentOutboundSummary: params.deps.recentOutboundSummary,
-    formatConversationTranscript: params.deps.formatConversationTranscript,
-    readTransportTranscript: params.deps.readTransportTranscript,
-    formatTransportTranscript: params.deps.formatTransportTranscript,
-    fetchJson: params.deps.fetchJson,
-    waitForGatewayHealthy: params.deps.waitForGatewayHealthy,
-    waitForTransportReady: params.deps.waitForTransportReady,
-    waitForChannelReady: params.deps.waitForTransportReady,
-    waitForQaChannelReady: params.deps.waitForQaChannelReady,
-    browserRequest: params.deps.browserRequest,
-    waitForBrowserReady: params.deps.waitForBrowserReady,
-    browserOpenTab: params.deps.browserOpenTab,
-    browserSnapshot: params.deps.browserSnapshot,
-    browserAct: params.deps.browserAct,
-    webOpenPage: params.deps.webOpenPage,
-    webWait: params.deps.webWait,
-    webType: params.deps.webType,
-    webSnapshot: params.deps.webSnapshot,
-    webEvaluate: params.deps.webEvaluate,
-    waitForConfigRestartSettle: params.deps.waitForConfigRestartSettle,
-    patchConfig: params.deps.patchConfig,
-    applyConfig: params.deps.applyConfig,
-    readConfigSnapshot: params.deps.readConfigSnapshot,
-    restartGatewayWithConfigPatch: params.deps.restartGatewayWithConfigPatch,
-    createSession: params.deps.createSession,
-    readEffectiveTools: params.deps.readEffectiveTools,
-    readSkillStatus: params.deps.readSkillStatus,
-    readRawQaSessionStore: params.deps.readRawQaSessionStore,
-    seedQaSessionTranscript: params.deps.seedQaSessionTranscript,
-    readGatewayLogs: params.deps.readGatewayLogs,
-    markGatewayLogCursor: params.deps.markGatewayLogCursor,
-    scanGatewayLogSentinels: params.deps.scanGatewayLogSentinels,
-    assertNoGatewayLogSentinels: params.deps.assertNoGatewayLogSentinels,
-    readSessionTranscriptSummary: params.deps.readSessionTranscriptSummary,
-    runQaCli: params.deps.runQaCli,
-    extractMediaPathFromText: params.deps.extractMediaPathFromText,
-    resolveGeneratedImagePath: params.deps.resolveGeneratedImagePath,
-    startAgentRun: params.deps.startAgentRun,
-    waitForAgentRun: params.deps.waitForAgentRun,
-    waitForAgentHistoryReply: params.deps.waitForAgentHistoryReply,
-    listCronJobs: params.deps.listCronJobs,
-    findManagedDreamingCronJob: params.deps.findManagedDreamingCronJob,
-    waitForCronRunCompletion: params.deps.waitForCronRunCompletion,
-    readDoctorMemoryStatus: params.deps.readDoctorMemoryStatus,
-    forceMemoryIndex: params.deps.forceMemoryIndex,
-    findSkill: params.deps.findSkill,
-    writeWorkspaceSkill: params.deps.writeWorkspaceSkill,
-    callPluginToolsMcp: params.deps.callPluginToolsMcp,
-    runAgentPrompt: params.deps.runAgentPrompt,
-    ensureImageGenerationConfigured: params.deps.ensureImageGenerationConfigured,
-    handleQaAction: params.deps.handleQaAction,
-    runRuntimeToolFixture: params.deps.runRuntimeToolFixture,
-    extractQaToolPayload: params.deps.extractQaToolPayload,
-    formatMemoryDreamingDay: params.deps.formatMemoryDreamingDay,
-    resolveSessionTranscriptsDirForAgent: params.deps.resolveSessionTranscriptsDirForAgent,
-    activeMemoryToggleKey: params.deps.activeMemoryToggleKey,
-    setActiveMemorySessionDisabled: params.deps.setActiveMemorySessionDisabled,
-    buildAgentSessionKey: params.deps.buildAgentSessionKey,
-    normalizeLowercaseStringOrEmpty: params.deps.normalizeLowercaseStringOrEmpty,
-    formatErrorMessage: params.deps.formatErrorMessage,
-    liveTurnTimeoutMs: params.deps.liveTurnTimeoutMs,
-    resolveQaLiveTurnTimeoutMs: params.deps.resolveQaLiveTurnTimeoutMs,
-    splitModelRef: params.deps.splitModelRef,
-    hasDiscoveryLabels: params.deps.hasDiscoveryLabels,
-    reportsDiscoveryScopeLeak: params.deps.reportsDiscoveryScopeLeak,
-    reportsMissingDiscoveryFiles: params.deps.reportsMissingDiscoveryFiles,
-    hasModelSwitchContinuitySignal: params.deps.hasModelSwitchContinuitySignal,
-    imageUnderstandingPngBase64: params.constants.imageUnderstandingPngBase64,
-    imageUnderstandingLargePngBase64: params.constants.imageUnderstandingLargePngBase64,
-    imageUnderstandingValidPngBase64: params.constants.imageUnderstandingValidPngBase64,
-    getTransportSnapshot: transportState.getSnapshot.bind(transportState),
-    resetTransport: resetTransportState,
-    injectInboundMessage: transportState.addInboundMessage.bind(transportState),
-    injectOutboundMessage: transportState.addOutboundMessage.bind(transportState),
-    readTransportMessage: transportState.readMessage.bind(transportState),
-    resetBus: resetTransportState,
-    reset: resetTransportState,
-  };
+  return Object.assign(
+    {
+      env: params.env,
+      lab: params.env.lab,
+      transport,
+      state: transportState,
+      scenario: params.scenario,
+      config: params.scenario.execution.config ?? {},
+      fs: params.deps.fs,
+      path: params.deps.path,
+      sleep: params.deps.sleep,
+      randomUUID: params.deps.randomUUID,
+      runScenario: params.deps.runScenario,
+      waitForCondition: transport.waitForCondition,
+      waitForOutboundMessage: params.deps.waitForOutboundMessage,
+      waitForNoOutbound: params.deps.waitForNoOutbound,
+      waitForNoTransportOutbound: params.deps.waitForNoTransportOutbound,
+      recentOutboundSummary: params.deps.recentOutboundSummary,
+      formatConversationTranscript: params.deps.formatConversationTranscript,
+      readTransportTranscript: params.deps.readTransportTranscript,
+      formatTransportTranscript: params.deps.formatTransportTranscript,
+      fetchJson: params.deps.fetchJson,
+      waitForGatewayHealthy: params.deps.waitForGatewayHealthy,
+      waitForTransportReady: params.deps.waitForTransportReady,
+      waitForChannelReady: params.deps.waitForTransportReady,
+      waitForQaChannelReady: params.deps.waitForTransportReady,
+    },
+    params.deps,
+    {
+      imageUnderstandingPngBase64: params.constants.imageUnderstandingPngBase64,
+      imageUnderstandingLargePngBase64: params.constants.imageUnderstandingLargePngBase64,
+      imageUnderstandingValidPngBase64: params.constants.imageUnderstandingValidPngBase64,
+      getTransportSnapshot: transportState.getSnapshot.bind(transportState),
+      resetTransport: resetTransportState,
+      injectInboundMessage: transportState.addInboundMessage.bind(transportState),
+      injectOutboundMessage: transportState.addOutboundMessage.bind(transportState),
+      readTransportMessage: transportState.readMessage.bind(transportState),
+      resetBus: resetTransportState,
+      reset: resetTransportState,
+    },
+  );
 }

--- a/extensions/qa-lab/src/suite-runtime-flow.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.test.ts
@@ -13,7 +13,6 @@ const formatTransportTranscript = vi.hoisted(() => vi.fn());
 const fetchJson = vi.hoisted(() => vi.fn());
 const waitForGatewayHealthy = vi.hoisted(() => vi.fn());
 const waitForTransportReady = vi.hoisted(() => vi.fn());
-const waitForQaChannelReady = vi.hoisted(() => vi.fn());
 const patchConfig = vi.hoisted(() => vi.fn());
 const applyConfig = vi.hoisted(() => vi.fn());
 const readConfigSnapshot = vi.hoisted(() => vi.fn());
@@ -83,7 +82,6 @@ vi.mock("./suite-runtime-gateway.js", () => ({
   fetchJson,
   waitForGatewayHealthy,
   waitForTransportReady,
-  waitForQaChannelReady,
   waitForConfigRestartSettle,
   patchConfig,
   applyConfig,
@@ -273,7 +271,7 @@ describe("qa suite runtime flow", () => {
       scenario: typeof scenario;
       deps: {
         runScenario: typeof runScenario;
-        waitForQaChannelReady: typeof waitForQaChannelReady;
+        waitForTransportReady: typeof waitForTransportReady;
         waitForOutboundMessage: typeof waitForOutboundMessage;
         markGatewayLogCursor: () => number;
         assertNoGatewayLogSentinels: typeof assertNoGatewayLogSentinels;
@@ -298,7 +296,7 @@ describe("qa suite runtime flow", () => {
     expect(call.env).toBe(env);
     expect(call.scenario).toBe(scenario);
     expect(call.deps.runScenario).toBe(runScenario);
-    expect(call.deps.waitForQaChannelReady).toBe(waitForQaChannelReady);
+    expect(call.deps.waitForTransportReady).toBe(waitForTransportReady);
     expect(call.deps.waitForOutboundMessage).toBeTypeOf("function");
     const outboundPredicate = vi.fn();
     call.deps.waitForOutboundMessage(env.transport.state, outboundPredicate, 123);

--- a/extensions/qa-lab/src/suite-runtime-flow.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.ts
@@ -63,7 +63,6 @@ import {
   restartGatewayWithConfigPatch,
   waitForConfigRestartSettle,
   waitForGatewayHealthy,
-  waitForQaChannelReady,
   waitForTransportReady,
 } from "./suite-runtime-gateway.js";
 import {
@@ -225,7 +224,6 @@ function createQaSuiteScenarioDeps(params: QaSuiteScenarioDepsParams) {
     fetchJson,
     waitForGatewayHealthy,
     waitForTransportReady,
-    waitForQaChannelReady,
     browserRequest: callQaBrowserRequest,
     waitForBrowserReady: waitForQaBrowserReady,
     browserOpenTab: qaBrowserOpenTab,

--- a/extensions/qa-lab/src/suite-runtime-gateway.ts
+++ b/extensions/qa-lab/src/suite-runtime-gateway.ts
@@ -1,11 +1,11 @@
 // Qa Lab plugin module implements suite runtime gateway behavior.
 import { setTimeout as sleep } from "node:timers/promises";
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { formatErrorMessage, toErrorObject } from "openclaw/plugin-sdk/error-runtime";
 import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { writeGatewayRestartIntentSync } from "openclaw/plugin-sdk/qa-runtime";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { isRecord as isPlainObject } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { QaSuiteInfraError, toQaErrorObject } from "./errors.js";
+import { QaSuiteInfraError } from "./errors.js";
 import { discardIgnoredResponseBody } from "./ignored-response-body.js";
 import { applyQaMergePatch } from "./suite-merge-patch.js";
 import { liveTurnTimeoutMs } from "./suite-runtime-agent-common.js";
@@ -75,13 +75,6 @@ async function waitForTransportReady(
     gateway: env.gateway,
     timeoutMs,
   });
-}
-
-async function waitForQaChannelReady(
-  env: Pick<QaSuiteRuntimeEnv, "gateway" | "transport">,
-  timeoutMs = 45_000,
-) {
-  await waitForTransportReady(env, timeoutMs);
 }
 
 async function waitForConfigRestartSettle(
@@ -368,7 +361,7 @@ async function runConfigMutation(params: {
       continue;
     }
   }
-  throw toQaErrorObject(
+  throw toErrorObject(
     lastConflict ?? new Error(`${params.action} failed after retrying config hash conflicts`),
     "Non-Error thrown",
   );
@@ -448,6 +441,5 @@ export {
   restartGatewayWithConfigPatch,
   waitForConfigRestartSettle,
   waitForGatewayHealthy,
-  waitForQaChannelReady,
   waitForTransportReady,
 };


### PR DESCRIPTION
## Summary

- Consolidate the QA scenario runtime around its existing dependency owner instead of maintaining duplicate dependency declarations and property mappings.
- Remove redundant private readiness wrappers and error-conversion code without changing QA scenario or transport behavior.
- Production delta: **-161 lines**; test delta: **-2 lines** across 10 files.

## Root cause and architecture

The QA runtime mirrored each dependency in both its public scenario-context type and its constructed context, while carrying a separate readiness wrapper and a local error converter identical to the existing plugin SDK implementation. The scenario runtime now derives its dependency surface directly from the typed dependency owner; QA Channel and Crabline derive readiness parameter types from their shared adapter; gateway failures use the canonical SDK `toErrorObject`; and the gateway-client type remains private to its only production consumer.

## Compatibility and safety

- Strict transport readiness continues to require the exact account, connected/running state, ready lifecycle, and no pending restart; no Crabline account fallback was restored.
- All **81 existing `waitForQaChannelReady` YAML calls** retain their public scenario alias and now use the same canonical transport-ready function.
- The complete **92-property scenario API and its exact property order** are preserved.
- The removed QA error converter and canonical SDK converter have byte-identical function bodies, preserving error identity, fallback messages, causes, and enumerable structured properties.
- The full gate exposed one now-unused exported gateway-client type; it was correctly demoted to a module-private type after confirming its only two consumers are in the same module.

## Validation

- Final focused remote run: **146/146 tests passed across 7 QA suites**, covering scenario API aliases, scenario-flow wiring, gateway restarts and errors, gateway-child lifecycle, QA Channel, strict account ownership, and Crabline readiness.
- Final full remote gate: **`pnpm check:changed` passed**, including production and extension-test typechecking, formatting, lint, zero dead exports, plugin boundaries, SDK contracts, and runtime import-cycle checks.
- Fresh exact-head structured review: `.agents/skills/autoreview/scripts/autoreview --mode local --engine codex --model gpt-5.6-sol --thinking xhigh` — **clean, confidence 0.98**.
- Trusted Blacksmith Testbox: `tbx_01kz914prh51ny526hbz9eb658`; [remote validation run](https://github.com/openclaw/openclaw/actions/runs/31009503043); lease stopped and independently verified completed.

### After-fix gateway and strict transport-readiness artifact

Executed the actual repo-backed `channel-chat-baseline` scenario on exact PR head `deacd676bd72a86da9d5c492a5e5244fc3375c24` after independently verifying all 10 changed Git blobs. The scenario starts a real ephemeral QA Lab, mock OpenAI provider, Gateway, and QA Channel; its existing YAML calls `waitForGatewayHealthy` and `waitForQaChannelReady` in **both** scenario steps. Loopback ports and runner paths below are redacted; no external provider, personal gateway, or real account was used.

```text
$ OPENCLAW_BUILD_PRIVATE_QA=1 OPENCLAW_QA_DEBUG=1 \
    pnpm openclaw qa suite --provider-mode mock-openai \
    --scenario channel-chat-baseline --concurrency 1 --fast \
    --output-dir .artifacts/qa-e2e/pr119623

{"proofPhase":"exact-published-source","head":"deacd676bd72a86da9d5c492a5e5244fc3375c24","verifiedChangedBlobs":10,"scenario":"channel-chat-baseline","providerMode":"mock-openai","transport":"qa-channel"}
[qa-suite] run start: scenarios=1 concurrency=1 transport=qa-channel
[qa-suite] lab ready: http://127.0.0.1:<redacted>
[qa-suite] provider ready: http://127.0.0.1:<redacted>
[qa-suite] gateway ready: http://127.0.0.1:<redacted>
[qa-suite] scenario start (1/1): channel-chat-baseline
[qa-suite] start scenario="Channel baseline conversation" step="ignores unmentioned channel chatter"
[qa-suite] pass scenario="Channel baseline conversation" step="ignores unmentioned channel chatter"
[qa-suite] start scenario="Channel baseline conversation" step="replies when mentioned in channel"
[qa-suite] pass scenario="Channel baseline conversation" step="replies when mentioned in channel"
[qa-suite] scenario pass (1/1): channel-chat-baseline
[qa-suite] run complete: passed=1 failed=0 skipped=0 total=1

qa-suite-summary.json:
{"scenarioCount":1,"scenarios":[{"name":"Channel baseline conversation","status":"pass","steps":[{"name":"ignores unmentioned channel chatter","status":"pass"},{"name":"replies when mentioned in channel","status":"pass","marker":"QA-CHANNEL-BASELINE-OK"}]}]}
```

The same exact-head Testbox also exercised the real production readiness adapter with focused negative/positive lifecycle fixtures:

```text
✓ qa channel transport > waits until the qa-channel default account is connected and ready
✓ qa channel transport > does not report another running account as the default account
Test Files  1 passed (1)
     Tests  2 passed | 16 skipped (18)
```

Runtime proof: trusted Blacksmith Testbox `tbx_01kz95e4r9765tv6mqk3t3hw3s`; [after-fix gateway scenario run](https://github.com/openclaw/openclaw/actions/runs/31015721854); lease stopped and independently verified completed.

