### PR TITLE
fix(memory): require query diversity for promotion

### DIFF
--- a/docs/concepts/dreaming.md
+++ b/docs/concepts/dreaming.md
@@ -147,14 +147,14 @@ The Control UI exposes the same diary backfill/reset flow on the agent's Memory 
 
 Deep ranking uses six weighted base signals plus phase reinforcement:
 
-| Signal              | Weight | Description                                       |
-| ------------------- | ------ | ------------------------------------------------- |
-| Relevance           | 0.30   | Average retrieval quality for the entry           |
-| Frequency           | 0.24   | How many short-term signals the entry accumulated |
-| Query diversity     | 0.15   | Distinct query/day contexts that surfaced it      |
-| Recency             | 0.15   | Time-decayed freshness score                      |
-| Consolidation       | 0.10   | Multi-day recurrence strength                     |
-| Conceptual richness | 0.06   | Concept-tag density from snippet/path             |
+| Signal              | Weight | Description                                          |
+| ------------------- | ------ | ---------------------------------------------------- |
+| Relevance           | 0.30   | Average retrieval quality for the entry              |
+| Frequency           | 0.24   | How many short-term signals the entry accumulated    |
+| Query diversity     | 0.15   | Distinct interactive recall queries that surfaced it |
+| Recency             | 0.15   | Time-decayed freshness score                         |
+| Consolidation       | 0.10   | Multi-day recurrence strength                        |
+| Conceptual richness | 0.06   | Concept-tag density from snippet/path                |
 
 Light and REM phase hits recorded in SQLite-backed plugin state add a small recency-decayed boost.
 

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -2668,6 +2668,7 @@ describe("memory cli", () => {
         lastRecalledAt: "<now>",
         recallDays: ["<today>"],
         queryHashes: ["<hash>"],
+        userQueryHashes: ["<hash>"],
         claimHash: entry.claimHash ? "<claim>" : undefined,
         provenance: entry.provenance ? { ...entry.provenance, observedAt: 0 } : undefined,
       }).toEqual({
@@ -2685,6 +2686,7 @@ describe("memory cli", () => {
         firstRecalledAt: "<now>",
         lastRecalledAt: "<now>",
         queryHashes: ["<hash>"],
+        userQueryHashes: ["<hash>"],
         recallDays: ["<today>"],
         claimHash: "<claim>",
         conceptTags: ["backup", "backups", "glacier", "s3"],

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -3431,6 +3431,7 @@ describe("memory cli", () => {
         lastRecalledAt: "<now>",
         recallDays: ["<today>"],
         queryHashes: ["<hash>"],
+        userQueryHashes: ["<hash>"],
         claimHash: entry.claimHash ? "<claim>" : undefined,
         provenance: entry.provenance ? { ...entry.provenance, observedAt: 0 } : undefined,
       }).toEqual({
@@ -3448,6 +3449,7 @@ describe("memory cli", () => {
         firstRecalledAt: "<now>",
         lastRecalledAt: "<now>",
         queryHashes: ["<hash>"],
+        userQueryHashes: ["<hash>"],
         recallDays: ["<today>"],
         claimHash: "<claim>",
         conceptTags: ["backup", "backups", "glacier", "s3"],

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -2613,7 +2613,7 @@ describe("memory-core dreaming phases", () => {
     );
   });
 
-  it("promotes one recurring bullet across three contextualized day files", async () => {
+  it("requires real user queries before promoting a recurring daily bullet", async () => {
     const workspaceDir = await createDreamingWorkspace();
     const days = ["2026-03-25", "2026-03-30", "2026-04-04"];
     for (const day of days) {
@@ -2657,24 +2657,62 @@ describe("memory-core dreaming phases", () => {
       );
     });
 
-    const ranked = await rankShortTermPromotionCandidates({
+    await expect(
+      rankShortTermPromotionCandidates({
+        workspaceDir,
+        nowMs: Date.parse("2026-04-05T10:05:00.000Z"),
+      }),
+    ).resolves.toHaveLength(0);
+
+    const dailyOnly = await rankShortTermPromotionCandidates({
       workspaceDir,
+      minScore: 0,
+      minUniqueQueries: 0,
       nowMs: Date.parse("2026-04-05T10:05:00.000Z"),
     });
-    expect(ranked).toHaveLength(1);
-    expect(ranked[0]).toMatchObject({
+    expect(dailyOnly).toHaveLength(1);
+    expect(dailyOnly[0]).toMatchObject({
       path: "memory/2026-04-04.md",
       dailyCount: 3,
       signalCount: 3,
-      uniqueQueries: 3,
+      uniqueQueries: 0,
       recallDays: days.toReversed(),
       provenance: { originClass: "agent" },
     });
-    expect(ranked[0]?.key).toMatch(/^memory:claim:/u);
+    expect(dailyOnly[0]?.key).toMatch(/^memory:claim:/u);
+
+    for (const query of ["router backup storage", "encrypted retention", "glacier backups"]) {
+      await recordShortTermRecalls({
+        workspaceDir,
+        query,
+        dayBucket: "2026-04-05",
+        nowMs: Date.parse("2026-04-05T10:05:00.000Z"),
+        dedupeByQueryPerDay: true,
+        results: [
+          {
+            path: "memory/2026-04-04.md",
+            startLine: 5,
+            endLine: 5,
+            score: 0.92,
+            snippet: "Move router backups to S3 Glacier with encrypted retention policy.",
+            source: "memory",
+          },
+        ],
+      });
+    }
+
+    const ranked = await rankShortTermPromotionCandidates({
+      workspaceDir,
+      minScore: 0,
+      nowMs: Date.parse("2026-04-05T10:05:00.000Z"),
+    });
+    expect(ranked).toHaveLength(1);
+    expect(ranked[0]?.uniqueQueries).toBe(3);
 
     const applied = await applyShortTermPromotions({
       workspaceDir,
       candidates: ranked,
+      minScore: 0,
       nowMs: Date.parse("2026-04-05T10:05:00.000Z"),
     });
     expect(applied.applied).toBe(1);

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -2310,7 +2310,7 @@ describe("memory-core dreaming phases", () => {
     );
   });
 
-  it("promotes one recurring bullet across three contextualized day files", async () => {
+  it("requires interactive queries before promoting a recurring daily bullet", async () => {
     const workspaceDir = await createDreamingWorkspace();
     const days = ["2026-03-25", "2026-03-30", "2026-04-04"];
     for (const day of days) {
@@ -2340,24 +2340,62 @@ describe("memory-core dreaming phases", () => {
       );
     });
 
-    const ranked = await rankShortTermPromotionCandidates({
+    await expect(
+      rankShortTermPromotionCandidates({
+        workspaceDir,
+        nowMs: Date.parse("2026-04-05T10:05:00.000Z"),
+      }),
+    ).resolves.toHaveLength(0);
+
+    const dailyOnly = await rankShortTermPromotionCandidates({
       workspaceDir,
+      minScore: 0,
+      minUniqueQueries: 0,
       nowMs: Date.parse("2026-04-05T10:05:00.000Z"),
     });
-    expect(ranked).toHaveLength(1);
-    expect(ranked[0]).toMatchObject({
+    expect(dailyOnly).toHaveLength(1);
+    expect(dailyOnly[0]).toMatchObject({
       path: "memory/2026-04-04.md",
       dailyCount: 3,
       signalCount: 3,
-      uniqueQueries: 3,
+      uniqueQueries: 0,
       recallDays: days.toReversed(),
       provenance: { originClass: "agent" },
     });
-    expect(ranked[0]?.key).toMatch(/^memory:claim:/u);
+    expect(dailyOnly[0]?.key).toMatch(/^memory:claim:/u);
+
+    for (const query of ["router backup storage", "encrypted retention", "glacier backups"]) {
+      await recordShortTermRecalls({
+        workspaceDir,
+        query,
+        dayBucket: "2026-04-05",
+        nowMs: Date.parse("2026-04-05T10:05:00.000Z"),
+        dedupeByQueryPerDay: true,
+        results: [
+          {
+            path: "memory/2026-04-04.md",
+            startLine: 5,
+            endLine: 5,
+            score: 0.92,
+            snippet: "Move router backups to S3 Glacier with encrypted retention policy.",
+            source: "memory",
+          },
+        ],
+      });
+    }
+
+    const ranked = await rankShortTermPromotionCandidates({
+      workspaceDir,
+      minScore: 0,
+      nowMs: Date.parse("2026-04-05T10:05:00.000Z"),
+    });
+    expect(ranked).toHaveLength(1);
+    expect(ranked[0]?.uniqueQueries).toBe(3);
 
     const applied = await applyShortTermPromotions({
       workspaceDir,
       candidates: ranked,
+      minScore: 0,
       nowMs: Date.parse("2026-04-05T10:05:00.000Z"),
     });
     expect(applied.applied).toBe(1);

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -1091,6 +1091,10 @@ function dedupeEntries(entries: ShortTermRecallEntry[], threshold: number): Shor
       duplicate.totalScore = Math.max(duplicate.totalScore, entry.totalScore);
       duplicate.maxScore = Math.max(duplicate.maxScore, entry.maxScore);
       duplicate.queryHashes = uniqueStrings([...duplicate.queryHashes, ...entry.queryHashes]);
+      duplicate.userQueryHashes = uniqueStrings([
+        ...(duplicate.userQueryHashes ?? []),
+        ...(entry.userQueryHashes ?? []),
+      ]);
       duplicate.recallDays = [
         ...new Set([...duplicate.recallDays, ...entry.recallDays]),
       ].toSorted();

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -1128,6 +1128,10 @@ function dedupeEntries(
       duplicate.totalScore = Math.max(duplicate.totalScore, entry.totalScore);
       duplicate.maxScore = Math.max(duplicate.maxScore, entry.maxScore);
       duplicate.queryHashes = uniqueStrings([...duplicate.queryHashes, ...entry.queryHashes]);
+      duplicate.userQueryHashes = uniqueStrings([
+        ...(duplicate.userQueryHashes ?? []),
+        ...(entry.userQueryHashes ?? []),
+      ]);
       duplicate.recallDays = [
         ...new Set([...duplicate.recallDays, ...entry.recallDays]),
       ].toSorted();

--- a/extensions/memory-core/src/short-term-promotion-apply.ts
+++ b/extensions/memory-core/src/short-term-promotion-apply.ts
@@ -310,7 +310,9 @@ export async function applyShortTermPromotions(
       if (candidate.signalCount < minRecallCount) {
         return false;
       }
-      if (Math.max(candidate.uniqueQueries, candidate.recallDays.length) < minUniqueQueries) {
+      // Recheck actual query diversity at the write boundary; recall-day
+      // spacing is a separate ranking signal and cannot satisfy this gate.
+      if (candidate.uniqueQueries < minUniqueQueries) {
         return false;
       }
       if (maxAgeDays >= 0 && candidate.ageDays > maxAgeDays) {

--- a/extensions/memory-core/src/short-term-promotion-apply.ts
+++ b/extensions/memory-core/src/short-term-promotion-apply.ts
@@ -278,7 +278,6 @@ export async function applyShortTermPromotions(
   const rejectionReasons = new Map<string, string>();
   const eligible = currentCandidates.filter((candidate) => {
     const latest = store.entries[candidate.key];
-    const queryCount = Math.max(candidate.uniqueQueries, candidate.recallDays.length);
     // Explicit untrusted/system origins never promote on ANY path (append or
     // consolidation): recall frequency must never launder externally-derived
     // content into MEMORY.md. Workspace memory files index as 'agent', so
@@ -295,8 +294,8 @@ export async function applyShortTermPromotions(
               ? `score threshold (${candidate.score.toFixed(3)} < ${minScore})`
               : candidate.signalCount < minRecallCount
                 ? `signal threshold (${candidate.signalCount} < ${minRecallCount})`
-                : queryCount < minUniqueQueries
-                  ? `query threshold (${queryCount} < ${minUniqueQueries})`
+                : candidate.uniqueQueries < minUniqueQueries
+                  ? `query threshold (${candidate.uniqueQueries} < ${minUniqueQueries})`
                   : maxAgeDays >= 0 && candidate.ageDays > maxAgeDays
                     ? `age threshold (${candidate.ageDays.toFixed(1)}d > ${maxAgeDays}d)`
                     : undefined;

--- a/extensions/memory-core/src/short-term-promotion-artifacts.ts
+++ b/extensions/memory-core/src/short-term-promotion-artifacts.ts
@@ -274,6 +274,9 @@ export async function repairShortTermPromotionArtifacts(params: {
                 Math.floor((entry as { groundedCount?: number }).groundedCount ?? 0),
               ),
               queryHashes: (entry.queryHashes ?? []).slice(-MAX_QUERY_HASHES),
+              ...(entry.userQueryHashes
+                ? { userQueryHashes: entry.userQueryHashes.slice(-MAX_QUERY_HASHES) }
+                : {}),
               recallDays: mergeRecentDistinct(entry.recallDays ?? [], fallbackDay, MAX_RECALL_DAYS),
               conceptTags: conceptTags.length > 0 ? conceptTags : (entry.conceptTags ?? []),
             } satisfies ShortTermRecallEntry,

--- a/extensions/memory-core/src/short-term-promotion-record.ts
+++ b/extensions/memory-core/src/short-term-promotion-record.ts
@@ -478,6 +478,9 @@ export async function recordGroundedShortTermCandidates(params: {
         firstRecalledAt: existing?.firstRecalledAt ?? nowIso,
         lastRecalledAt,
         queryHashes,
+        // Grounded backfill is synthetic and must not add qualified queries,
+        // but a rerun must preserve interactive evidence already on the key.
+        ...(existing?.userQueryHashes ? { userQueryHashes: existing.userQueryHashes } : {}),
         recallDays,
         conceptTags: conceptTags.length > 0 ? conceptTags : (existing?.conceptTags ?? []),
         provenance,

--- a/extensions/memory-core/src/short-term-promotion-record.ts
+++ b/extensions/memory-core/src/short-term-promotion-record.ts
@@ -266,6 +266,10 @@ export async function recordShortTermRecalls(params: {
         const totalScore = Math.max(0, (existing?.totalScore ?? 0) + (dedupeSignal ? 0 : score));
         const maxScore = Math.max(existing?.maxScore ?? 0, dedupeSignal ? 0 : score);
         const queryHashes = mergeQueryHashes(existing?.queryHashes ?? [], queryHash);
+        const userQueryHashes =
+          signalType === "recall"
+            ? mergeQueryHashes(existing?.userQueryHashes ?? [], queryHash)
+            : (existing?.userQueryHashes ?? []);
         const recallDays = mergeRecentDistinct(recallDaysBase, todayBucket, MAX_RECALL_DAYS);
         const conceptTags = deriveConceptTags({ path: normalizedPath, snippet });
         const provenance = mergeRecallProvenance(existing?.provenance, result.provenance, nowMs);
@@ -304,6 +308,7 @@ export async function recordShortTermRecalls(params: {
           firstRecalledAt: existing?.firstRecalledAt ?? nowIso,
           lastRecalledAt,
           queryHashes,
+          userQueryHashes,
           recallDays,
           conceptTags: conceptTags.length > 0 ? conceptTags : (existing?.conceptTags ?? []),
           provenance,

--- a/extensions/memory-core/src/short-term-promotion-record.ts
+++ b/extensions/memory-core/src/short-term-promotion-record.ts
@@ -293,6 +293,10 @@ export async function recordShortTermRecalls(params: {
       const totalScore = Math.max(0, (existing?.totalScore ?? 0) + score * addedSignals);
       const maxScore = Math.max(existing?.maxScore ?? 0, dedupeSignal ? 0 : score);
       const queryHashes = mergeRecentDistinct(queryHashesBase, queryHash, MAX_QUERY_HASHES);
+      const userQueryHashes =
+        signalType === "recall"
+          ? mergeRecentDistinct(existing?.userQueryHashes ?? [], queryHash, MAX_QUERY_HASHES)
+          : existing?.userQueryHashes;
       const recallDays = mergeRecentDistinct(recallDaysBase, dayBucket, MAX_RECALL_DAYS);
       const conceptTags = deriveConceptTags({ path: normalizedPath, snippet });
       // Workspace-file hits without explicit provenance retain the index's
@@ -338,6 +342,7 @@ export async function recordShortTermRecalls(params: {
         firstRecalledAt: existing?.firstRecalledAt ?? nowIso,
         lastRecalledAt,
         queryHashes,
+        ...(userQueryHashes ? { userQueryHashes } : {}),
         recallDays,
         conceptTags: conceptTags.length > 0 ? conceptTags : (existing?.conceptTags ?? []),
         provenance,

--- a/extensions/memory-core/src/short-term-promotion-scoring.test.ts
+++ b/extensions/memory-core/src/short-term-promotion-scoring.test.ts
@@ -191,6 +191,44 @@ describe("short-term promotion score calibration", () => {
     });
   });
 
+  it("does not treat recall days as query diversity", async () => {
+    const workspaceDir = await createTempWorkspace("promotion-query-diversity-");
+    const repeatedQuery = createRecallEntry({
+      key: "repeated-query",
+      signalCount: 3,
+      avgScore: 1,
+      queryHashes: ["query-a"],
+      recallDays: RECALL_DAYS,
+      conceptTags: ["backup", "backups", "glacier", "s3"],
+    });
+    await shortTermTestState.writeRawRecallStore(workspaceDir, {
+      version: 1,
+      updatedAt: NOW_ISO,
+      entries: { "repeated-query": repeatedQuery },
+    });
+
+    await expect(
+      rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 2,
+        nowMs: NOW_MS,
+      }),
+    ).resolves.toHaveLength(0);
+
+    const ranked = await rankShortTermPromotionCandidates({
+      workspaceDir,
+      minScore: 0,
+      minRecallCount: 0,
+      minUniqueQueries: 1,
+      nowMs: NOW_MS,
+    });
+    expect(ranked).toHaveLength(1);
+    expect(ranked[0]?.components.diversity).toBeCloseTo(0.2);
+    expect(ranked[0]?.components.consolidation).toBeGreaterThan(0.4);
+  });
+
   it("keeps the minimum score boundary inclusive", async () => {
     const workspaceDir = await createTempWorkspace("promotion-score-boundary-");
     const boundary = createRecallEntry({

--- a/extensions/memory-core/src/short-term-promotion-scoring.test.ts
+++ b/extensions/memory-core/src/short-term-promotion-scoring.test.ts
@@ -49,6 +49,7 @@ function createRecallEntry(params: {
     firstRecalledAt: "2026-04-01T10:00:00.000Z",
     lastRecalledAt: NOW_ISO,
     queryHashes: params.queryHashes,
+    userQueryHashes: params.queryHashes,
     recallDays: params.recallDays,
     conceptTags: params.conceptTags,
   };
@@ -227,6 +228,34 @@ describe("short-term promotion score calibration", () => {
     expect(ranked).toHaveLength(1);
     expect(ranked[0]?.components.diversity).toBeCloseTo(0.2);
     expect(ranked[0]?.components.consolidation).toBeGreaterThan(0.4);
+  });
+
+  it("fails closed for legacy opaque query hashes without user-query provenance", async () => {
+    const workspaceDir = await createTempWorkspace("promotion-legacy-query-provenance-");
+    const legacy = createRecallEntry({
+      key: "legacy-opaque-queries",
+      signalCount: 3,
+      avgScore: 1,
+      queryHashes: THREE_QUERY_HASHES,
+      recallDays: RECALL_DAYS,
+      conceptTags: ["backup", "glacier"],
+    });
+    delete legacy.userQueryHashes;
+    await shortTermTestState.writeRawRecallStore(workspaceDir, {
+      version: 1,
+      updatedAt: NOW_ISO,
+      entries: { legacy },
+    });
+
+    await expect(
+      rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 1,
+        nowMs: NOW_MS,
+      }),
+    ).resolves.toHaveLength(0);
   });
 
   it("keeps the minimum score boundary inclusive", async () => {

--- a/extensions/memory-core/src/short-term-promotion-scoring.test.ts
+++ b/extensions/memory-core/src/short-term-promotion-scoring.test.ts
@@ -49,6 +49,7 @@ function createRecallEntry(params: {
     firstRecalledAt: "2026-04-01T10:00:00.000Z",
     lastRecalledAt: NOW_ISO,
     queryHashes: params.queryHashes,
+    userQueryHashes: params.queryHashes,
     recallDays: params.recallDays,
     conceptTags: params.conceptTags,
   };
@@ -232,6 +233,67 @@ describe("short-term promotion score calibration", () => {
         minRecallCount: 0,
         minUniqueQueries: 0,
         weights: relevanceOnly,
+        nowMs: NOW_MS,
+      }),
+    ).resolves.toHaveLength(0);
+  });
+
+  it("preserves unambiguous recall-only legacy query diversity", async () => {
+    const workspaceDir = await createTempWorkspace("promotion-recall-only-upgrade-");
+    const legacy = createRecallEntry({
+      key: "legacy-recall-only",
+      signalCount: 3,
+      avgScore: 1,
+      queryHashes: THREE_QUERY_HASHES,
+      recallDays: RECALL_DAYS,
+      conceptTags: ["backup", "glacier"],
+    });
+    legacy.recallCount = 3;
+    legacy.dailyCount = 0;
+    delete legacy.userQueryHashes;
+    await shortTermTestState.writeRawRecallStore(workspaceDir, {
+      version: 1,
+      updatedAt: NOW_ISO,
+      entries: { legacy },
+    });
+
+    const ranked = await rankShortTermPromotionCandidates({
+      workspaceDir,
+      minScore: 0,
+      minRecallCount: 0,
+      minUniqueQueries: 3,
+      nowMs: NOW_MS,
+    });
+
+    expect(ranked).toHaveLength(1);
+    expect(ranked[0]?.uniqueQueries).toBe(3);
+  });
+
+  it("fails closed for ambiguous mixed legacy query hashes", async () => {
+    const workspaceDir = await createTempWorkspace("promotion-mixed-upgrade-");
+    const legacy = createRecallEntry({
+      key: "legacy-mixed",
+      signalCount: 3,
+      avgScore: 1,
+      queryHashes: THREE_QUERY_HASHES,
+      recallDays: RECALL_DAYS,
+      conceptTags: ["backup", "glacier"],
+    });
+    legacy.recallCount = 1;
+    legacy.dailyCount = 2;
+    delete legacy.userQueryHashes;
+    await shortTermTestState.writeRawRecallStore(workspaceDir, {
+      version: 1,
+      updatedAt: NOW_ISO,
+      entries: { legacy },
+    });
+
+    await expect(
+      rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 1,
         nowMs: NOW_MS,
       }),
     ).resolves.toHaveLength(0);

--- a/extensions/memory-core/src/short-term-promotion-types.ts
+++ b/extensions/memory-core/src/short-term-promotion-types.ts
@@ -45,6 +45,8 @@ export type ShortTermRecallEntry = {
   firstRecalledAt: string;
   lastRecalledAt: string;
   queryHashes: string[];
+  /** Hashes from interactive recall only. Legacy stores omit this and fail closed for diversity. */
+  userQueryHashes?: string[];
   recallDays: string[];
   conceptTags: string[];
   claimHash?: string;

--- a/extensions/memory-core/src/short-term-promotion-types.ts
+++ b/extensions/memory-core/src/short-term-promotion-types.ts
@@ -40,6 +40,8 @@ export type ShortTermRecallEntry = {
   firstRecalledAt: string;
   lastRecalledAt: string;
   queryHashes: string[];
+  /** Hashes from interactive recalls only. */
+  userQueryHashes?: string[];
   recallDays: string[];
   conceptTags: string[];
   claimHash?: string;

--- a/extensions/memory-core/src/short-term-promotion-utils.ts
+++ b/extensions/memory-core/src/short-term-promotion-utils.ts
@@ -356,6 +356,12 @@ export function normalizeShortTermRecallStore(raw: unknown, nowIso: string): Sho
       const queryHashes = Array.isArray(entry.queryHashes)
         ? normalizeDistinctStrings(entry.queryHashes, MAX_QUERY_HASHES)
         : [];
+      // queryHashes historically mixed scheduler and interactive inputs, so it
+      // cannot be migrated safely. Missing provenance intentionally normalizes
+      // to no user-query evidence until fresh interactive recalls arrive.
+      const userQueryHashes = Array.isArray(entry.userQueryHashes)
+        ? normalizeDistinctStrings(entry.userQueryHashes, MAX_QUERY_HASHES)
+        : undefined;
       const recallDays = Array.isArray(entry.recallDays)
         ? entry.recallDays
             .map((recallDay) => (typeof recallDay === "string" ? normalizeIsoDay(recallDay) : null))
@@ -423,6 +429,7 @@ export function normalizeShortTermRecallStore(raw: unknown, nowIso: string): Sho
         firstRecalledAt,
         lastRecalledAt,
         queryHashes,
+        ...(userQueryHashes ? { userQueryHashes } : {}),
         recallDays: recallDays.slice(-MAX_RECALL_DAYS),
         conceptTags,
         ...(provenance ? { provenance } : {}),

--- a/extensions/memory-core/src/short-term-promotion-utils.ts
+++ b/extensions/memory-core/src/short-term-promotion-utils.ts
@@ -336,6 +336,15 @@ export function normalizeShortTermRecallStore(raw: unknown, nowIso: string): Sho
       const queryHashes = Array.isArray(entry.queryHashes)
         ? normalizeDistinctStrings(entry.queryHashes, MAX_QUERY_HASHES)
         : [];
+      const storedUserQueryHashes = Array.isArray(entry.userQueryHashes)
+        ? normalizeDistinctStrings(entry.userQueryHashes, MAX_QUERY_HASHES)
+        : undefined;
+      // Legacy rows did not retain query provenance. Rows containing only recall
+      // signals are unambiguous, so preserve their earned diversity; mixed rows
+      // stay unqualified until fresh interactive recalls arrive.
+      const userQueryHashes =
+        storedUserQueryHashes ??
+        (dailyCount === 0 && groundedCount === 0 ? queryHashes : undefined);
       const recallDays = Array.isArray(entry.recallDays)
         ? entry.recallDays
             .map((recallDay) => (typeof recallDay === "string" ? normalizeIsoDay(recallDay) : null))
@@ -403,6 +412,7 @@ export function normalizeShortTermRecallStore(raw: unknown, nowIso: string): Sho
         firstRecalledAt,
         lastRecalledAt,
         queryHashes,
+        ...(userQueryHashes ? { userQueryHashes } : {}),
         recallDays: recallDays.slice(-MAX_RECALL_DAYS),
         conceptTags,
         ...(provenance ? { provenance } : {}),

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -778,6 +778,52 @@ describe("short-term promotion", () => {
     });
   });
 
+  it("does not let recall days bypass the apply query-diversity gate", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await writeDailyMemoryNote(workspaceDir, "2026-04-01", ["Move backups to S3 Glacier."]);
+      const recallDays = ["2026-04-01", "2026-04-02", "2026-04-03"];
+      for (const day of recallDays) {
+        await recordShortTermRecalls({
+          workspaceDir,
+          query: "glacier retention",
+          dayBucket: day,
+          nowMs: Date.parse(`${day}T10:00:00.000Z`),
+          dedupeByQueryPerDay: true,
+          results: [
+            {
+              path: "memory/2026-04-01.md",
+              startLine: 1,
+              endLine: 1,
+              score: 0.96,
+              snippet: "Move backups to S3 Glacier.",
+              source: "memory",
+            },
+          ],
+        });
+      }
+
+      const candidates = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        nowMs: Date.parse("2026-04-03T10:01:00.000Z"),
+      });
+      expect(candidates).toHaveLength(1);
+      expect(candidates[0]).toMatchObject({ uniqueQueries: 1, recallDays });
+
+      const applied = await applyShortTermPromotions({
+        workspaceDir,
+        candidates,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 2,
+        nowMs: Date.parse("2026-04-03T10:01:00.000Z"),
+      });
+      expect(applied.applied).toBe(0);
+    });
+  });
+
   it("merges a repeated claim across three day files and clears the default gates", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       const queryDays = ["2026-04-01", "2026-04-02", "2026-04-03"];

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -1180,6 +1180,74 @@ describe("short-term promotion", () => {
     });
   });
 
+  it("preserves qualified user queries across a grounded backfill rerun", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const snippet = "Keep encrypted router backups in S3 Glacier.";
+      await writeDailyMemoryNote(workspaceDir, "2026-04-03", [snippet]);
+      const groundedItem = {
+        path: "memory/2026-04-03.md",
+        startLine: 1,
+        endLine: 1,
+        snippet,
+        score: 0.9,
+        query: "__dreaming_grounded_backfill__:candidate",
+        signalCount: 1,
+        dayBucket: "2026-04-03",
+      };
+
+      await recordGroundedShortTermCandidates({
+        workspaceDir,
+        query: "__dreaming_grounded_backfill__",
+        items: [groundedItem],
+        nowMs: Date.parse("2026-04-03T09:00:00.000Z"),
+      });
+      for (const query of ["router backups", "encrypted retention", "glacier storage"]) {
+        await recordShortTermRecalls({
+          workspaceDir,
+          query,
+          nowMs: Date.parse("2026-04-03T10:00:00.000Z"),
+          results: [
+            {
+              path: groundedItem.path,
+              startLine: groundedItem.startLine,
+              endLine: groundedItem.endLine,
+              snippet,
+              score: 0.92,
+              source: "memory",
+            },
+          ],
+        });
+      }
+
+      const before = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 1,
+      });
+      expect(before).toHaveLength(1);
+      expect(before[0]?.uniqueQueries).toBe(3);
+
+      await recordGroundedShortTermCandidates({
+        workspaceDir,
+        query: "__dreaming_grounded_backfill__",
+        items: [groundedItem],
+        nowMs: Date.parse("2026-04-03T11:00:00.000Z"),
+      });
+
+      const after = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 1,
+      });
+      expect(after).toHaveLength(1);
+      expect(after[0]?.key).toBe(before[0]?.key);
+      expect(after[0]?.uniqueQueries).toBe(3);
+      expect(after[0]?.groundedCount).toBe(2);
+    });
+  });
+
   it("rewards spaced recalls as consolidation instead of only raw count", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       await recordShortTermRecalls({

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -824,7 +824,7 @@ describe("short-term promotion", () => {
     });
   });
 
-  it("merges a repeated claim across three day files and clears the default gates", async () => {
+  it("merges a repeated claim across three day files without faking user-query diversity", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       const queryDays = ["2026-04-01", "2026-04-02", "2026-04-03"];
       let candidateKey;
@@ -888,6 +888,8 @@ describe("short-term promotion", () => {
 
       const ranked = await rankShortTermPromotionCandidates({
         workspaceDir,
+        minScore: 0,
+        minUniqueQueries: 0,
         nowMs: Date.parse("2026-04-03T10:01:00.000Z"),
       });
 
@@ -898,10 +900,17 @@ describe("short-term promotion", () => {
       expect(ranked[0]?.recallCount).toBe(0);
       expect(ranked[0]?.dailyCount).toBe(3);
       expect(ranked[0]?.signalCount).toBe(3);
-      expect(ranked[0]?.uniqueQueries).toBe(3);
+      expect(ranked[0]?.uniqueQueries).toBe(0);
       expect(ranked[0]?.recallDays).toEqual(queryDays);
-      expect(ranked[0]?.score).toBeGreaterThanOrEqual(0.75);
+      expect(ranked[0]?.score).toBeLessThan(0.75);
       expect(ranked[0] && isPromotionOriginBlocked(ranked[0])).toBe(false);
+
+      await expect(
+        rankShortTermPromotionCandidates({
+          workspaceDir,
+          nowMs: Date.parse("2026-04-03T10:01:00.000Z"),
+        }),
+      ).resolves.toHaveLength(0);
     });
   });
 
@@ -1028,7 +1037,7 @@ describe("short-term promotion", () => {
     });
   });
 
-  it("lets grounded durable evidence satisfy default deep thresholds", async () => {
+  it("does not let grounded backfill keys satisfy user-query diversity", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       await writeDailyMemoryNote(workspaceDir, "2026-04-03", [
         'Always use "Happy Together" calendar for flights and reservations.',
@@ -1075,17 +1084,28 @@ describe("short-term promotion", () => {
 
       const ranked = await rankShortTermPromotionCandidates({
         workspaceDir,
+        minScore: 0,
+        minUniqueQueries: 0,
         nowMs: Date.parse("2026-04-03T10:00:00.000Z"),
       });
 
       expect(ranked).toHaveLength(1);
       expect(ranked[0]?.groundedCount).toBe(3);
-      expect(ranked[0]?.uniqueQueries).toBe(3);
+      expect(ranked[0]?.uniqueQueries).toBe(0);
       expect(ranked[0]?.avgScore).toBeGreaterThan(0.85);
+
+      await expect(
+        rankShortTermPromotionCandidates({
+          workspaceDir,
+          nowMs: Date.parse("2026-04-03T10:00:00.000Z"),
+        }),
+      ).resolves.toHaveLength(0);
 
       const applied = await applyShortTermPromotions({
         workspaceDir,
         candidates: ranked,
+        minScore: 0,
+        minUniqueQueries: 0,
         nowMs: Date.parse("2026-04-03T10:00:00.000Z"),
       });
 
@@ -1779,6 +1799,7 @@ describe("short-term promotion", () => {
             firstRecalledAt: "2026-04-03T00:00:00.000Z",
             lastRecalledAt: "2026-04-04T00:00:00.000Z",
             queryHashes: ["a", "b"],
+            userQueryHashes: ["a", "b"],
             recallDays: ["2026-04-03", "2026-04-04"],
             conceptTags: ["assistant"],
           },

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -795,7 +795,7 @@ describe("short-term promotion", () => {
     expect(ranked).toHaveLength(0);
   });
 
-  it("merges a repeated claim across three day files and clears the default gates", async (workspaceDir) => {
+  it("merges a repeated claim across days without faking query diversity", async (workspaceDir) => {
     const queryDays = ["2026-04-01", "2026-04-02", "2026-04-03"];
     let candidateKey;
 
@@ -852,8 +852,17 @@ describe("short-term promotion", () => {
       }
     }
 
+    await expect(
+      rankShortTermPromotionCandidates({
+        workspaceDir,
+        nowMs: Date.parse("2026-04-03T10:01:00.000Z"),
+      }),
+    ).resolves.toHaveLength(0);
+
     const ranked = await rankShortTermPromotionCandidates({
       workspaceDir,
+      minScore: 0,
+      minUniqueQueries: 0,
       nowMs: Date.parse("2026-04-03T10:01:00.000Z"),
     });
 
@@ -864,9 +873,9 @@ describe("short-term promotion", () => {
     expect(ranked[0]?.recallCount).toBe(0);
     expect(ranked[0]?.dailyCount).toBe(3);
     expect(ranked[0]?.signalCount).toBe(3);
-    expect(ranked[0]?.uniqueQueries).toBe(3);
+    expect(ranked[0]?.uniqueQueries).toBe(0);
     expect(ranked[0]?.recallDays).toEqual(queryDays);
-    expect(ranked[0]?.score).toBeGreaterThanOrEqual(0.75);
+    expect(ranked[0]?.score).toBeLessThan(0.75);
     expect(ranked[0] && isPromotionOriginBlocked(ranked[0])).toBe(false);
   });
 
@@ -985,7 +994,7 @@ describe("short-term promotion", () => {
     );
   });
 
-  it("lets grounded durable evidence satisfy default deep thresholds", async (workspaceDir) => {
+  it("does not let grounded backfill keys satisfy query diversity", async (workspaceDir) => {
     await writeDailyMemoryNote(workspaceDir, "2026-04-03", [
       'Always use "Happy Together" calendar for flights and reservations.',
     ]);
@@ -1017,25 +1026,78 @@ describe("short-term promotion", () => {
       nowMs: Date.parse("2026-04-03T10:00:00.000Z"),
     });
 
+    await expect(
+      rankShortTermPromotionCandidates({
+        workspaceDir,
+        nowMs: Date.parse("2026-04-03T10:00:00.000Z"),
+      }),
+    ).resolves.toHaveLength(0);
+
     const ranked = await rankShortTermPromotionCandidates({
       workspaceDir,
+      minScore: 0,
+      minUniqueQueries: 0,
       nowMs: Date.parse("2026-04-03T10:00:00.000Z"),
     });
 
     expect(ranked).toHaveLength(1);
     expect(ranked[0]?.groundedCount).toBe(3);
-    expect(ranked[0]?.uniqueQueries).toBe(3);
+    expect(ranked[0]?.uniqueQueries).toBe(0);
     expect(ranked[0]?.avgScore).toBeGreaterThan(0.85);
 
     const applied = await applyShortTermPromotions({
       workspaceDir,
       candidates: ranked,
+      minScore: 0,
+      minUniqueQueries: 0,
       nowMs: Date.parse("2026-04-03T10:00:00.000Z"),
     });
 
     expect(applied.applied).toBe(1);
     const memory = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8");
     expect(memory).toContain('Always use "Happy Together" calendar');
+  });
+
+  it("preserves interactive query diversity across grounded reruns", async (workspaceDir) => {
+    const snippet = "Keep encrypted router backups in S3 Glacier.";
+    await writeDailyMemoryNote(workspaceDir, "2026-04-03", [snippet]);
+    const groundedItem = groundedCandidateFixture({
+      path: "memory/2026-04-03.md",
+      snippet,
+      query: "__dreaming_grounded_backfill__:candidate",
+    });
+
+    await recordGroundedShortTermCandidates({
+      workspaceDir,
+      query: "__dreaming_grounded_backfill__",
+      items: [groundedItem],
+      nowMs: Date.parse("2026-04-03T09:00:00.000Z"),
+    });
+    for (const query of ["router backups", "encrypted retention", "glacier storage"]) {
+      await recordMemoryRecalls(
+        workspaceDir,
+        query,
+        [memoryRecallResult("memory/2026-04-03.md", 1, 1, 0.92, snippet)],
+        { nowMs: Date.parse("2026-04-03T10:00:00.000Z") },
+      );
+    }
+
+    const before = await rankAllCandidates(workspaceDir);
+    expect(before).toHaveLength(1);
+    expect(before[0]?.uniqueQueries).toBe(3);
+
+    await recordGroundedShortTermCandidates({
+      workspaceDir,
+      query: "__dreaming_grounded_backfill__",
+      items: [groundedItem],
+      nowMs: Date.parse("2026-04-03T11:00:00.000Z"),
+    });
+
+    const after = await rankAllCandidates(workspaceDir);
+    expect(after).toHaveLength(1);
+    expect(after[0]?.key).toBe(before[0]?.key);
+    expect(after[0]?.uniqueQueries).toBe(3);
+    expect(after[0]?.groundedCount).toBe(2);
   });
 
   it("removes grounded-only staged entries without deleting mixed live entries", async (workspaceDir) => {
@@ -1495,6 +1557,45 @@ describe("short-term promotion", () => {
 
     expect(applied.applied).toBe(0);
     expect(applied.rejectedCandidates[0]?.reason).toContain("signal threshold");
+  });
+
+  it("does not let recall days satisfy the apply-time query gate", async (workspaceDir) => {
+    const nowIso = new Date().toISOString();
+    const applied = await applyShortTermPromotions({
+      workspaceDir,
+      candidates: [
+        {
+          key: "memory:memory/2026-04-03.md:1:2",
+          path: "memory/2026-04-03.md",
+          startLine: 1,
+          endLine: 2,
+          source: "memory",
+          snippet: "Move backups to S3 Glacier.",
+          recallCount: 3,
+          signalCount: 3,
+          avgScore: 0.95,
+          maxScore: 0.95,
+          uniqueQueries: 0,
+          firstRecalledAt: nowIso,
+          lastRecalledAt: nowIso,
+          ageDays: 0,
+          score: 0.95,
+          recallDays: ["2026-04-01", "2026-04-02", "2026-04-03"],
+          conceptTags: ["glacier", "backups"],
+          components: {
+            frequency: 0.6,
+            relevance: 0.95,
+            diversity: 0,
+            recency: 1,
+            consolidation: 0.6,
+            conceptual: 0.4,
+          },
+        },
+      ],
+    });
+
+    expect(applied.applied).toBe(0);
+    expect(applied.rejectedCandidates[0]?.reason).toBe("query threshold (0 < 3)");
   });
 
   it("does not rank contaminated dreaming snippets from an existing short-term store", async (workspaceDir) => {
@@ -2594,6 +2695,7 @@ describe("short-term promotion", () => {
           path: "memory/2026-04-01.md",
           endLine: 2,
           snippet,
+          userQueryHashes: ["a", "b"],
           conceptTags: deriveConceptTags({
             path: "memory/2026-04-01.md",
             snippet,

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -150,11 +150,12 @@ export async function rankShortTermPromotionCandidates(
     const avgScore = clampScore(entry.totalScore / Math.max(1, signalCount));
     const frequency = clampScore(Math.log1p(signalCount) / Math.log1p(10));
     const uniqueQueries = entry.queryHashes?.length ?? 0;
-    const contextDiversity = Math.max(uniqueQueries, entry.recallDays?.length ?? 0);
-    if (contextDiversity < minUniqueQueries) {
+    // Recall-day spacing has its own consolidation component below; it must not
+    // substitute for distinct query contexts at the query-diversity gate.
+    if (uniqueQueries < minUniqueQueries) {
       continue;
     }
-    const diversity = clampScore(contextDiversity / 5);
+    const diversity = clampScore(uniqueQueries / 5);
     const lastRecalledAtMs = Date.parse(entry.lastRecalledAt);
     const ageDays = Number.isFinite(lastRecalledAtMs)
       ? Math.max(0, (nowMs - lastRecalledAtMs) / DAY_MS)

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -149,7 +149,9 @@ export async function rankShortTermPromotionCandidates(
 
     const avgScore = clampScore(entry.totalScore / Math.max(1, signalCount));
     const frequency = clampScore(Math.log1p(signalCount) / Math.log1p(10));
-    const uniqueQueries = entry.queryHashes?.length ?? 0;
+    // Only provenance-qualified interactive recalls count as user-query
+    // diversity. Legacy queryHashes are ambiguous and therefore fail closed.
+    const uniqueQueries = entry.userQueryHashes?.length ?? 0;
     // Recall-day spacing has its own consolidation component below; it must not
     // substitute for distinct query contexts at the query-diversity gate.
     if (uniqueQueries < minUniqueQueries) {

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -154,12 +154,13 @@ export async function rankShortTermPromotionCandidates(
 
     const avgScore = clampScore(entry.totalScore / Math.max(1, signalCount));
     const frequency = clampScore(Math.log1p(signalCount) / Math.log1p(10));
-    const uniqueQueries = entry.queryHashes?.length ?? 0;
-    const contextDiversity = Math.max(uniqueQueries, entry.recallDays?.length ?? 0);
-    if (contextDiversity < minUniqueQueries) {
+    // Scheduler and grounded-backfill keys are synthetic. Only provenance-
+    // qualified interactive recalls can satisfy user-query diversity.
+    const uniqueQueries = entry.userQueryHashes?.length ?? 0;
+    if (uniqueQueries < minUniqueQueries) {
       continue;
     }
-    const diversity = clampScore(contextDiversity / 5);
+    const diversity = clampScore(uniqueQueries / 5);
     const lastRecalledAtMs = Date.parse(entry.lastRecalledAt);
     const ageDays = Number.isFinite(lastRecalledAtMs)
       ? Math.max(0, (nowMs - lastRecalledAtMs) / DAY_MS)


### PR DESCRIPTION
Related: #142393

## What Problem This Solves

Short-term promotion treated scheduler-generated daily identifiers and grounded-backfill keys as query diversity. Repeated nightly ingestion could therefore satisfy `minUniqueQueries` without any real recall query and promote operational residue into `MEMORY.md`.

## Why This Change Was Made

`minUniqueQueries` is intended to require independent recall contexts. Daily recurrence remains useful frequency and consolidation evidence, but it should not masquerade as distinct queries.

## User Impact

- Daily ingestion and grounded backfill alone no longer qualify content for automatic durable-memory promotion.
- Real recall queries establish the diversity needed for promotion.
- Existing recall-only state keeps its earned diversity; ambiguous mixed legacy state waits for fresh recall evidence.

## Summary

- record recall-path hashes separately as `userQueryHashes`
- keep daily and grounded synthetic keys out of query diversity
- enforce the same qualified diversity count during ranking and apply
- preserve unambiguous recall-only legacy hashes while failing closed for mixed legacy rows
- retain qualified recall hashes when dreaming deduplicates candidates
- document query diversity as distinct recall queries rather than query/day contexts

## Maintainer Decision

Accept the conservative mixed-legacy transition: recall-only rows retain attributable historical diversity, while mixed rows do not guess the origin of old hashes and must earn fresh recall-query evidence. This avoids laundering scheduler evidence while preserving the unambiguous upgrade path.

## Evidence

- isolated fresh-workspace runtime proof through the production SQLite store and built CLI:
  - three daily signals produced `ranked=0`
  - three distinct recall queries produced `ranked=1`, `uniqueQueries=3`, `signalCount=6`, score `0.830`
  - `openclaw memory promote --apply --json` reported `applied=1`, and the synthetic fact was present in `MEMORY.md`
- isolated upgrade runtime proof:
  - created recall-only persisted evidence, removed the new field to reproduce the legacy row shape, then reopened it through the production normalizer
  - the upgraded row retained `uniqueQueries=3`, ranked at `0.780`, and the built CLI reported `applied=1`
  - the synthetic upgraded fact was present in `MEMORY.md`
- `pnpm test:extension memory-core`: 110 files passed, 2 skipped; 1,584 tests passed, 8 skipped
- exact-head focused run over the four changed behavior suites: 4 files and 282 tests passed
- `pnpm check:changed`: passed
- `pnpm docs:check-mdx`: passed (954 files)
- fresh full build completed and the built memory CLI loaded successfully
- rebased-head GitHub CI: all checks passed or skipped as expected on 7be0cb25ee5c

## Compatibility Policy

Legacy rows with no daily or grounded signals are unambiguously recall-only, so their bounded historical query hashes seed the qualified field. Mixed rows cannot attribute old hashes safely and remain unqualified until new recall queries are recorded. Frequency, relevance, recall-day consolidation, provenance, and configured thresholds are otherwise unchanged.