### PR TITLE
fix(diagnostics): stop labeling stale phases as recent

### DIFF
--- a/src/logging/diagnostic-phase.test.ts
+++ b/src/logging/diagnostic-phase.test.ts
@@ -1,6 +1,7 @@
 // Diagnostic phase tests cover phase timing and diagnostic event emission.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
+  getCurrentDiagnosticPhase,
   getRecentDiagnosticPhases,
   resetDiagnosticPhasesForTest,
   withDiagnosticPhase,
@@ -26,5 +27,43 @@ describe("getRecentDiagnosticPhases", () => {
     const recent = getRecentDiagnosticPhases(1);
     expect(recent).toHaveLength(1);
     expect(recent[0]?.name).toBe("phase-b");
+  });
+
+  it("filters completed phases by attribution time without discarding retained history", async () => {
+    resetDiagnosticPhasesForTest();
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    try {
+      await withDiagnosticPhase("phase-a", () => undefined);
+
+      expect(getRecentDiagnosticPhases(1, { completedAfter: 1_001 })).toEqual([]);
+      expect(getRecentDiagnosticPhases(1)).toEqual([
+        expect.objectContaining({ name: "phase-a", endedAt: 1_000 }),
+      ]);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it("does not apply completed-phase recency filtering to active phases", async () => {
+    resetDiagnosticPhasesForTest();
+    let releasePhase: (() => void) | undefined;
+    const phase = withDiagnosticPhase(
+      "legitimate.long-running-work",
+      () =>
+        new Promise<void>((resolve) => {
+          releasePhase = resolve;
+        }),
+    );
+    if (!releasePhase) {
+      throw new Error("Expected diagnostic phase release callback to be initialized");
+    }
+
+    try {
+      expect(getRecentDiagnosticPhases(1, { completedAfter: Date.now() })).toEqual([]);
+      expect(getCurrentDiagnosticPhase()).toBe("legitimate.long-running-work");
+    } finally {
+      releasePhase();
+      await phase;
+    }
   });
 });

--- a/src/logging/diagnostic-phase.ts
+++ b/src/logging/diagnostic-phase.ts
@@ -47,12 +47,22 @@ function resolveRecentPhaseLimit(limit: number): number | null {
   return Math.floor(limit);
 }
 
-export function getRecentDiagnosticPhases(limit = 8): DiagnosticPhaseSnapshot[] {
+export function getRecentDiagnosticPhases(
+  limit = 8,
+  options?: { completedAfter?: number },
+): DiagnosticPhaseSnapshot[] {
   const resolved = resolveRecentPhaseLimit(limit);
   if (resolved === null) {
     return [];
   }
-  return recentPhases.slice(-resolved).map((phase) => Object.assign({}, phase));
+  const completedAfter = options?.completedAfter;
+  const eligiblePhases =
+    completedAfter === undefined
+      ? recentPhases
+      : recentPhases.filter(
+          (phase) => phase.endedAt !== undefined && phase.endedAt >= completedAfter,
+        );
+  return eligiblePhases.slice(-resolved).map((phase) => Object.assign({}, phase));
 }
 
 /** Records a completed phase in memory and emits it when diagnostics are enabled. */

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -2408,6 +2408,52 @@ describe("stuck session diagnostics threshold", () => {
     ).toBe(true);
   });
 
+  it("attributes only phases completed during the measured liveness interval", async () => {
+    const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
+    const events: DiagnosticEventPayload[] = [];
+    const unsubscribe = onDiagnosticEvent((event) => events.push(event));
+
+    await withDiagnosticPhase("stale.phase", () => undefined);
+    vi.advanceTimersByTime(60_000);
+    await withDiagnosticPhase("recent.phase", () => undefined);
+
+    try {
+      startDiagnosticHeartbeat(
+        {
+          diagnostics: {
+            enabled: true,
+          },
+        },
+        {
+          emitMemorySample: createEmitMemorySampleMock(),
+          sampleLiveness: () => ({
+            reasons: ["event_loop_delay"],
+            intervalMs: 30_000,
+            eventLoopDelayP99Ms: 1_500,
+            eventLoopDelayMaxMs: 2_000,
+          }),
+        },
+      );
+
+      logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test" });
+      vi.advanceTimersByTime(30_000);
+    } finally {
+      unsubscribe();
+    }
+
+    expectLoggerMessageContaining(warnSpy, "recentPhases=recent.phase:");
+    expectNoLoggerMessageContaining(warnSpy, "stale.phase");
+    const warning = requireRecord(
+      events.findLast((event) => event.type === "diagnostic.liveness.warning"),
+      "liveness warning event",
+    );
+    expect(warning.recentPhases).toEqual([
+      expect.objectContaining({
+        name: "recent.phase",
+      }),
+    ]);
+  });
+
   it("keeps transient event-loop max spikes debug-only when only background work is active", () => {
     const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
 

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -421,9 +421,14 @@ function shouldEmitDiagnosticLivenessWarning(now: number, work: DiagnosticWorkSn
 function emitDiagnosticLivenessWarning(
   sample: DiagnosticLivenessSample,
   work: DiagnosticWorkSnapshot,
+  now: number,
 ): void {
   const phase = getCurrentDiagnosticPhase();
-  const recentPhases = getRecentDiagnosticPhases(6);
+  // Attribute only phases completed during this measured liveness interval.
+  // The retained ring is capacity-bounded history, not a temporal recency signal.
+  const recentPhases = getRecentDiagnosticPhases(6, {
+    completedAfter: now - Math.max(0, sample.intervalMs),
+  });
   const recentPhaseSummary = formatRecentDiagnosticPhases(recentPhases);
   const workLabelSummary = formatDiagnosticWorkLabels(work);
   const message = `liveness warning: reasons=${sample.reasons.join(",")} interval=${Math.round(
@@ -1269,7 +1274,7 @@ export function startDiagnosticHeartbeat(
     }
 
     if (shouldEmitLivenessReport && livenessSample) {
-      emitDiagnosticLivenessWarning(livenessSample, work);
+      emitDiagnosticLivenessWarning(livenessSample, work, now);
     }
 
     diag.debug(


### PR DESCRIPTION
Related: #119607

Prior active-phase eviction attempt: #83669

## What Problem This Solves

Fixes an issue where operators investigating a Gateway liveness warning could
see an old completed phase labeled as `recentPhases` merely because fewer than
40 newer phases had completed. During the August 5, 2026 Gateway stall
investigation, that made a historical `post-ready.context-window-cache` timing
look causally related even though the retained ring had no age filter.

## Why This Change Was Made

Liveness warnings now attribute only phases completed during that liveness
sample's actual interval. The bounded phase ring remains available as retained
history, and long-running active phases remain visible; this deliberately avoids
the arbitrary global active-phase timeout proposed in #83669.

## User Impact

Gateway liveness diagnostics no longer imply that capacity-retained historical
work was recent. Operators still receive complete timing, CPU, and detail fields
for phases that completed during the measured interval.

AI-assisted change; I reviewed the owner boundary, tests, and runtime evidence.

## Evidence

- Red on unmodified `bf7840f5391a`: ten minutes after completion,
  `post-ready.context-window-cache` was still returned as recent; a separate
  one-hour active phase remained active.
- Head opaque probe on Blacksmith Testbox
  [`31010388554`](https://github.com/openclaw/openclaw/actions/runs/31010388554):
  the rendered warning and structured liveness event contained only
  `recent.phase`, omitted `stale.phase`, preserved timestamps, duration, CPU,
  ratio, and details, and kept the one-hour active phase visible.
- Focused exact-base Testbox proof: 84/84 logging tests passed.
- Exact-base `pnpm check:changed`: passed.
- Autoreview: clean, no accepted/actionable findings.
- Source-blind behavior validation: clauses for stale exclusion, retained
  history, structured/log attribution, field preservation, and active-phase
  visibility passed; implementation-only cost and unrelated Gateway surfaces
  remained outside black-box observability.
