### PR TITLE
refactor(codex): consolidate approval and elicitation ownership

### DIFF
--- a/extensions/codex/src/app-server/approval-bridge.ts
+++ b/extensions/codex/src/app-server/approval-bridge.ts
@@ -16,7 +16,7 @@ import {
   runBeforeToolCallHook,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { normalizeTrimmedStringList } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { sliceUtf16Safe, truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { formatCodexDisplayText } from "../command-formatters.js";
 import { resolveCodexToolAbortTerminalReason } from "./dynamic-tool-execution.js";
 import { buildCodexHookRequester } from "./hook-requester.js";
@@ -24,6 +24,9 @@ import {
   approvalRequestExplicitlyUnavailable,
   mapExecDecisionToOutcome,
   requestPluginApproval,
+  sanitizeCodexApprovalVisibleText,
+  stripDanglingCodexApprovalTerminalSequence,
+  truncateCodexApprovalDisplayText as truncate,
   type AppServerApprovalOutcome,
   waitForPluginApprovalDecision,
 } from "./plugin-approval-roundtrip.js";
@@ -41,22 +44,6 @@ const CONCRETE_TOOL_AUTO_APPROVAL_METHODS = new Set([
   "item/commandExecution/requestApproval",
   "item/fileChange/requestApproval",
 ]);
-const ANSI_OSC_SEQUENCE_RE = new RegExp(
-  String.raw`(?:\u001b]|\u009d)[^\u001b\u009c\u0007]*(?:\u0007|\u001b\\|\u009c)`,
-  "g",
-);
-const ANSI_CONTROL_SEQUENCE_RE = new RegExp(
-  String.raw`(?:\u001b\[[0-?]*[ -/]*[@-~]|\u009b[0-?]*[ -/]*[@-~]|\u001b[@-Z\\-_])`,
-  "g",
-);
-const CONTROL_CHARACTER_RE = new RegExp(String.raw`[\u0000-\u001f\u007f-\u009f]+`, "g");
-const INVISIBLE_FORMATTING_CONTROL_RE = new RegExp(
-  String.raw`[\u00ad\u034f\u061c\u200b-\u200f\u202a-\u202e\u2060-\u206f\ufeff\ufe00-\ufe0f\u{e0100}-\u{e01ef}]`,
-  "gu",
-);
-const DANGLING_TERMINAL_SEQUENCE_SUFFIX_RE = new RegExp(
-  String.raw`(?:\u001b\][^\u001b\u009c\u0007]*|\u009d[^\u001b\u009c\u0007]*|\u001b\[[0-?]*[ -/]*|\u009b[0-?]*[ -/]*|\u001b)$`,
-);
 
 type ApprovalPreviewSource = {
   value: string;
@@ -99,6 +86,21 @@ export async function handleCodexAppServerApprovalRequest(params: {
     requestParams,
     paramsForRun: params.paramsForRun,
   });
+  const resolvePolicyApproval = (
+    outcome: Extract<AppServerApprovalOutcome, "denied" | "approved-once" | "approved-session">,
+    message = approvalResolutionMessage(outcome),
+  ): JsonValue => {
+    emitApprovalEvent(params.paramsForRun, {
+      phase: "resolved",
+      kind: context.kind,
+      status: outcome === "denied" ? "denied" : "approved",
+      title: context.title,
+      ...context.eventDetails,
+      ...approvalEventScope(params.method, outcome),
+      message,
+    });
+    return buildApprovalResponse(params.method, context.requestParams, outcome);
+  };
 
   try {
     const policyOutcome = await runOpenClawToolPolicyForApprovalRequest({
@@ -112,31 +114,13 @@ export async function handleCodexAppServerApprovalRequest(params: {
     });
     if (policyOutcome?.outcome === "denied") {
       recordNativeToolFailureDisposition(params, context, policyOutcome.failureDisposition);
-      emitApprovalEvent(params.paramsForRun, {
-        phase: "resolved",
-        kind: context.kind,
-        status: "denied",
-        title: context.title,
-        ...context.eventDetails,
-        ...approvalEventScope(params.method, "denied"),
-        message: policyOutcome.reason,
-      });
-      return buildApprovalResponse(params.method, context.requestParams, "denied");
+      return resolvePolicyApproval("denied", policyOutcome.reason);
     }
     if (
       policyOutcome?.outcome === "approved-once" ||
       policyOutcome?.outcome === "approved-session"
     ) {
-      emitApprovalEvent(params.paramsForRun, {
-        phase: "resolved",
-        kind: context.kind,
-        status: "approved",
-        title: context.title,
-        ...context.eventDetails,
-        ...approvalEventScope(params.method, policyOutcome.outcome),
-        message: approvalResolutionMessage(policyOutcome.outcome),
-      });
-      return buildApprovalResponse(params.method, context.requestParams, policyOutcome.outcome);
+      return resolvePolicyApproval(policyOutcome.outcome);
     }
     const canAutoApproveConcreteToolCall = CONCRETE_TOOL_AUTO_APPROVAL_METHODS.has(params.method);
     if (
@@ -144,28 +128,16 @@ export async function handleCodexAppServerApprovalRequest(params: {
       params.autoApproveOpenClawToolPolicy === true &&
       policyOutcome?.outcome === "allowed"
     ) {
-      emitApprovalEvent(params.paramsForRun, {
-        phase: "resolved",
-        kind: context.kind,
-        status: "approved",
-        title: context.title,
-        ...context.eventDetails,
-        ...approvalEventScope(params.method, "approved-once"),
-        message: "Codex app-server approval accepted by OpenClaw tool policy.",
-      });
-      return buildApprovalResponse(params.method, context.requestParams, "approved-once");
+      return resolvePolicyApproval(
+        "approved-once",
+        "Codex app-server approval accepted by OpenClaw tool policy.",
+      );
     }
     if (canAutoApproveConcreteToolCall && params.autoApprove === true) {
-      emitApprovalEvent(params.paramsForRun, {
-        phase: "resolved",
-        kind: context.kind,
-        status: "approved",
-        title: context.title,
-        ...context.eventDetails,
-        ...approvalEventScope(params.method, "approved-session"),
-        message: "Codex app-server approval auto-approved by runtime policy.",
-      });
-      return buildApprovalResponse(params.method, context.requestParams, "approved-session");
+      return resolvePolicyApproval(
+        "approved-session",
+        "Codex app-server approval auto-approved by runtime policy.",
+      );
     }
     // Codex app-server approval requests do not expose an enforceable resolved
     // executable, so unresolved requests must stay on the human approval route.
@@ -551,11 +523,12 @@ async function runNativeRelayToolPolicyForApprovalRequest(params: {
     }
   | undefined
 > {
+  const nativeHookRelay = params.nativeHookRelay;
   // Only command approvals correspond to Codex PreToolUse execution. File-change
   // and permission approvals stay on the app-server approval route below.
   if (
     params.method !== "item/commandExecution/requestApproval" ||
-    !params.nativeHookRelay?.allowedEvents.includes("pre_tool_use")
+    !nativeHookRelay?.allowedEvents.includes("pre_tool_use")
   ) {
     return undefined;
   }
@@ -568,15 +541,9 @@ async function runNativeRelayToolPolicyForApprovalRequest(params: {
   if (!payload) {
     return undefined;
   }
-  if (
-    hasNativeHookRelayInvocation({
-      relayId: params.nativeHookRelay.relayId,
-      event: "pre_tool_use",
-      toolUseId: params.context.approvalId,
-    })
-  ) {
+  const resolveDeferredApproval = async () => {
     const approvalOutcome = await resolveNativeHookRelayDeferredToolApproval({
-      relayId: params.nativeHookRelay.relayId,
+      relayId: nativeHookRelay.relayId,
       toolUseId: params.context.approvalId,
       signal: params.signal,
     });
@@ -588,18 +555,26 @@ async function runNativeRelayToolPolicyForApprovalRequest(params: {
         ...(approvalOutcome.failureDisposition
           ? { failureDisposition: approvalOutcome.failureDisposition }
           : {}),
-      };
+      } as const;
     }
-    if (approvalOutcome?.outcome === "approved-once") {
-      return { handled: true, outcome: approvalOutcome.outcome };
-    }
-    return { handled: true };
+    return approvalOutcome?.outcome === "approved-once"
+      ? ({ handled: true, outcome: approvalOutcome.outcome } as const)
+      : ({ handled: true } as const);
+  };
+  if (
+    hasNativeHookRelayInvocation({
+      relayId: nativeHookRelay.relayId,
+      event: "pre_tool_use",
+      toolUseId: params.context.approvalId,
+    })
+  ) {
+    return resolveDeferredApproval();
   }
   try {
     const response = await invokeNativeHookRelay({
       provider: "codex",
-      relayId: params.nativeHookRelay.relayId,
-      generation: params.nativeHookRelay.generation,
+      relayId: nativeHookRelay.relayId,
+      generation: nativeHookRelay.generation,
       event: "pre_tool_use",
       rawPayload: payload,
       requireGeneration: true,
@@ -613,32 +588,14 @@ async function runNativeRelayToolPolicyForApprovalRequest(params: {
         ...(decision.failureDisposition ? { failureDisposition: decision.failureDisposition } : {}),
       };
     }
-    const approvalOutcome = await resolveNativeHookRelayDeferredToolApproval({
-      relayId: params.nativeHookRelay.relayId,
-      toolUseId: params.context.approvalId,
-      signal: params.signal,
-    });
-    if (approvalOutcome?.outcome === "denied") {
-      return {
-        handled: true,
-        blocked: true,
-        reason: approvalOutcome.reason,
-        ...(approvalOutcome.failureDisposition
-          ? { failureDisposition: approvalOutcome.failureDisposition }
-          : {}),
-      };
-    }
-    if (approvalOutcome?.outcome === "approved-once") {
-      return { handled: true, outcome: approvalOutcome.outcome };
-    }
-    return { handled: true };
+    return await resolveDeferredApproval();
   } catch (error) {
     // Only a relay that failed before invocation is unavailable. Once invoked,
     // handler failures join explicit denials and malformed replies in failing closed.
     if (
       params.autoApprove === true &&
       !hasNativeHookRelayInvocation({
-        relayId: params.nativeHookRelay.relayId,
+        relayId: nativeHookRelay.relayId,
         event: "pre_tool_use",
         toolUseId: params.context.approvalId,
       })
@@ -787,7 +744,7 @@ function stableJsonText(value: unknown): string | undefined {
       ? `[${items.join(",")}]`
       : undefined;
   }
-  if (isPlainRecord(value)) {
+  if (isJsonObject(value)) {
     const entries = Object.entries(value)
       .toSorted(([left], [right]) => left.localeCompare(right))
       .map(([key, item]) => {
@@ -799,10 +756,6 @@ function stableJsonText(value: unknown): string | undefined {
       : undefined;
   }
   return undefined;
-}
-
-function isPlainRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
 function commandApprovalDecision(
@@ -1028,14 +981,12 @@ function summarizePermissionRecord(
   risks: Set<string>,
   descriptors: readonly PermissionArrayDescriptor[],
 ): string | undefined {
-  const details: string[] = [];
-  for (const descriptor of descriptors) {
-    const summary = summarizePermissionArray(permission, descriptor, risks);
-    if (summary) {
-      details.push(summary);
-    }
-  }
-  return details.length > 0 ? details.join("; ") : undefined;
+  return (
+    descriptors
+      .map((descriptor) => summarizePermissionArray(permission, descriptor, risks))
+      .filter(Boolean)
+      .join("; ") || undefined
+  );
 }
 
 function summarizePermissionArray(
@@ -1043,7 +994,7 @@ function summarizePermissionArray(
   descriptor: PermissionArrayDescriptor,
   risks: Set<string>,
 ): string | undefined {
-  const values = readStringArray(record, descriptor.key);
+  const values = normalizeTrimmedStringList(record[descriptor.key]);
   if (values.length === 0) {
     return undefined;
   }
@@ -1111,10 +1062,6 @@ function summarizeNetworkPolicyAmendments(value: JsonValue | undefined): string 
   return `Proposed network policy: ${samples.join(", ")}${remainderSuffix}`;
 }
 
-function readStringArray(record: JsonObject, key: string): string[] {
-  return normalizeTrimmedStringList(record[key]);
-}
-
 function sanitizePermissionHostValue(value: string): string {
   const compact = sanitizePermissionScalar(value).toLowerCase();
   const withoutScheme = compact.replace(/^[a-z][a-z0-9+.-]*:\/\//, "");
@@ -1133,7 +1080,7 @@ function sanitizePermissionPathValue(value: string): string {
 }
 
 function sanitizePermissionScalar(value: string): string {
-  return sanitizeVisibleScalar(value);
+  return sanitizeCodexApprovalVisibleText(value);
 }
 
 function permissionHostRisks(value: string): string[] {
@@ -1245,16 +1192,12 @@ function approvalResolutionMessage(outcome: AppServerApprovalOutcome): string {
   return "Codex app-server approval denied.";
 }
 
-function approvalScopeForOutcome(outcome: AppServerApprovalOutcome): "turn" | "session" {
-  return outcome === "approved-session" ? "session" : "turn";
-}
-
 function approvalEventScope(
   method: string,
   outcome: AppServerApprovalOutcome,
 ): Pick<AgentApprovalEventData, "scope"> {
   return method === "item/permissions/requestApproval"
-    ? { scope: approvalScopeForOutcome(outcome) }
+    ? { scope: outcome === "approved-session" ? "session" : "turn" }
     : {};
 }
 
@@ -1357,10 +1300,6 @@ function readString(record: JsonObject | undefined, key: string): string | undef
   return typeof value === "string" ? value : undefined;
 }
 
-function truncate(value: string, maxLength: number): string {
-  return value.length <= maxLength ? value : `${truncateUtf16Safe(value, maxLength - 3)}...`;
-}
-
 function previewSource(value: string): ApprovalPreviewSource {
   return {
     value: sliceUtf16Safe(value, 0, APPROVAL_PREVIEW_SCAN_MAX_LENGTH),
@@ -1389,22 +1328,12 @@ function sanitizeApprovalPreview(
   if (!source || !source.value) {
     return { omitted: false };
   }
-  const rawPreview = source.value.replace(DANGLING_TERMINAL_SEQUENCE_SUFFIX_RE, "");
-  const sanitized = sanitizeVisibleScalar(rawPreview);
+  const rawPreview = stripDanglingCodexApprovalTerminalSequence(source.value);
+  const sanitized = sanitizeCodexApprovalVisibleText(rawPreview);
   if (!sanitized) {
     return { omitted: true };
   }
   return { text: formatCodexDisplayText(truncate(sanitized, maxLength)), omitted: source.clipped };
-}
-
-function sanitizeVisibleScalar(value: string): string {
-  return value
-    .replace(ANSI_OSC_SEQUENCE_RE, "")
-    .replace(ANSI_CONTROL_SEQUENCE_RE, "")
-    .replace(INVISIBLE_FORMATTING_CONTROL_RE, " ")
-    .replace(CONTROL_CHARACTER_RE, " ")
-    .replace(/\s+/g, " ")
-    .trim();
 }
 
 function formatApprovalPreviewSubject(text: string, omitted: boolean): string {

--- a/extensions/codex/src/app-server/elicitation-bridge.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.ts
@@ -3,12 +3,14 @@ import {
   embeddedAgentLog,
   type EmbeddedRunAttemptParams,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
-import { sliceUtf16Safe, truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { formatCodexDisplayText } from "../command-formatters.js";
 import {
   approvalRequestExplicitlyUnavailable,
   mapExecDecisionToOutcome,
   requestPluginApproval,
+  sanitizeCodexApprovalVisibleText,
+  truncateCodexApprovalDisplayText as truncateDisplayText,
   type AppServerApprovalOutcome,
   type ExecApprovalDecision,
   waitForPluginApprovalDecision,
@@ -67,22 +69,6 @@ const MAX_DISPLAY_VALUE_ARRAY_ITEMS = 8;
 const MAX_DISPLAY_VALUE_OBJECT_KEYS = 8;
 const MAX_DISPLAY_VALUE_DEPTH = 3;
 const DISPLAY_TEXT_SCAN_MAX_LENGTH = 4096;
-const ANSI_OSC_SEQUENCE_RE = new RegExp(
-  String.raw`(?:\u001b]|\u009d)[^\u001b\u009c\u0007]*(?:\u0007|\u001b\\|\u009c)`,
-  "g",
-);
-const ANSI_CONTROL_SEQUENCE_RE = new RegExp(
-  String.raw`(?:\u001b\[[0-?]*[ -/]*[@-~]|\u009b[0-?]*[ -/]*[@-~]|\u001b[@-Z\\-_])`,
-  "g",
-);
-const CONTROL_CHARACTER_RE = new RegExp(String.raw`[\u0000-\u001f\u007f-\u009f]+`, "g");
-const INVISIBLE_FORMATTING_CONTROL_RE = new RegExp(
-  String.raw`[\u00ad\u034f\u061c\u200b-\u200f\u202a-\u202e\u2060-\u206f\ufeff\ufe00-\ufe0f\u{e0100}-\u{e01ef}]`,
-  "gu",
-);
-const DANGLING_TERMINAL_SEQUENCE_SUFFIX_RE = new RegExp(
-  String.raw`(?:\u001b\][^\u001b\u009c\u0007]*|\u009d[^\u001b\u009c\u0007]*|\u001b\[[0-?]*[ -/]*|\u009b[0-?]*[ -/]*|\u001b)$`,
-);
 
 export async function handleCodexAppServerElicitationRequest(params: {
   requestParams: JsonValue | undefined;
@@ -94,13 +80,11 @@ export async function handleCodexAppServerElicitationRequest(params: {
   signal?: AbortSignal;
 }): Promise<JsonValue | undefined> {
   const requestParams = isJsonObject(params.requestParams) ? params.requestParams : undefined;
-  if (!requestParams) {
+  if (!requestParams || readString(requestParams, "threadId") !== params.threadId) {
     return undefined;
   }
-  if (!matchesCurrentThread(requestParams, params.threadId)) {
-    return undefined;
-  }
-  if (turnIdMismatches(requestParams, params.turnId)) {
+  const requestTurnId = requestParams.turnId;
+  if (requestTurnId !== null && requestTurnId !== undefined && requestTurnId !== params.turnId) {
     return undefined;
   }
   const pluginResolution = resolvePluginElicitation({
@@ -112,7 +96,7 @@ export async function handleCodexAppServerElicitationRequest(params: {
       logPluginElicitationDecline(pluginResolution.reason, requestParams);
       return declineElicitationResponse();
     }
-    if (!hasExactTurnId(requestParams, params.turnId)) {
+    if (requestTurnId !== params.turnId) {
       logPluginElicitationDecline("missing_active_turn", requestParams);
       return declineElicitationResponse();
     }
@@ -141,31 +125,11 @@ export async function handleCodexAppServerElicitationRequest(params: {
   return buildElicitationResponse(approvalPrompt, outcome);
 }
 
-function matchesCurrentThread(requestParams: JsonObject | undefined, threadId: string): boolean {
-  if (!requestParams) {
-    return false;
-  }
-  const requestThreadId = readString(requestParams, "threadId");
-  return requestThreadId === threadId;
-}
-
-function turnIdMismatches(requestParams: JsonObject | undefined, turnId: string): boolean {
-  const rawTurnId = requestParams?.turnId;
-  return rawTurnId !== null && rawTurnId !== undefined && rawTurnId !== turnId;
-}
-
-function hasExactTurnId(requestParams: JsonObject | undefined, turnId: string): boolean {
-  return requestParams?.turnId === turnId;
-}
-
 function resolvePluginElicitation(params: {
-  requestParams: JsonObject | undefined;
+  requestParams: JsonObject;
   pluginAppPolicyContext?: PluginAppPolicyContext;
 }): PluginElicitationResolution {
   const requestParams = params.requestParams;
-  if (!requestParams) {
-    return { kind: "not_plugin" };
-  }
   const meta = isJsonObject(requestParams["_meta"]) ? requestParams["_meta"] : {};
   const context = params.pluginAppPolicyContext;
   const entries = context ? Object.values(context.apps) : [];
@@ -668,20 +632,11 @@ function sanitizeOptionalDisplayText(value: string | undefined): string | undefi
 function sanitizeDisplayText(value: string): string {
   const scanned = sliceUtf16Safe(value, 0, DISPLAY_TEXT_SCAN_MAX_LENGTH);
   const clipped = value.length > DISPLAY_TEXT_SCAN_MAX_LENGTH;
-  const sanitized = scanned
-    .replace(ANSI_OSC_SEQUENCE_RE, "")
-    .replace(ANSI_CONTROL_SEQUENCE_RE, "")
-    .replace(DANGLING_TERMINAL_SEQUENCE_SUFFIX_RE, "")
-    .replace(INVISIBLE_FORMATTING_CONTROL_RE, " ")
-    .replace(CONTROL_CHARACTER_RE, " ")
-    .replace(/\s+/g, " ")
-    .trim();
+  const sanitized = sanitizeCodexApprovalVisibleText(scanned, {
+    stripDanglingTerminalSequence: true,
+  });
   const escaped = sanitized ? formatCodexDisplayText(sanitized) : "";
   return clipped && escaped ? `${escaped}...` : escaped;
-}
-
-function truncateDisplayText(value: string, maxLength: number): string {
-  return value.length <= maxLength ? value : `${truncateUtf16Safe(value, maxLength - 3)}...`;
 }
 
 async function requestPluginApprovalOutcome(params: {
@@ -731,24 +686,17 @@ function buildElicitationResponse(
   }
 
   const content = buildAcceptedContent(approvalPrompt, outcome);
-  if (!content) {
-    if (hasNoSchemaProperties(requestedSchema)) {
-      return {
-        action: "accept",
-        content: null,
-        _meta: buildAcceptedMeta(meta, outcome, approvalPrompt.persistHintsMode ?? "legacy"),
-      };
-    }
+  if (!content && !hasNoSchemaProperties(requestedSchema)) {
     embeddedAgentLog.warn("codex MCP approval elicitation approved without a mappable response", {
       approvalKind: meta[MCP_TOOL_APPROVAL_KIND_KEY],
       fields: Object.keys(requestedSchema.properties ?? {}),
       outcome,
     });
-    return { action: "decline", content: null, _meta: null };
+    return declineElicitationResponse();
   }
   return {
     action: "accept",
-    content,
+    content: content ?? null,
     _meta: buildAcceptedMeta(meta, outcome, approvalPrompt.persistHintsMode ?? "legacy"),
   };
 }
@@ -856,10 +804,6 @@ function readPersistFieldValue(
   return undefined;
 }
 
-function readDefaultValue(schema: JsonObject): JsonValue | undefined {
-  return schema.default as JsonValue | undefined;
-}
-
 function readFallbackFieldValue(
   property: ApprovalPropertyContext,
   outcome: AppServerApprovalOutcome,
@@ -867,7 +811,7 @@ function readFallbackFieldValue(
   if (outcome === "approved-once" && isPersistField(property)) {
     return undefined;
   }
-  return readDefaultValue(property.schema);
+  return property.schema.default as JsonValue | undefined;
 }
 
 function isApprovalField(property: ApprovalPropertyContext): boolean {

--- a/extensions/codex/src/app-server/plugin-approval-roundtrip.ts
+++ b/extensions/codex/src/app-server/plugin-approval-roundtrip.ts
@@ -6,13 +6,29 @@ import {
   callGatewayTool,
   type EmbeddedRunAttemptParams,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
-import { isApprovalNotFoundError } from "openclaw/plugin-sdk/error-runtime";
+import { isApprovalNotFoundError, toErrorObject } from "openclaw/plugin-sdk/error-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveCodexGatewayTimeoutWithGraceMs } from "./attempt-timeouts.js";
 
 const DEFAULT_CODEX_APPROVAL_TIMEOUT_MS = 120_000;
 const MAX_PLUGIN_APPROVAL_TITLE_LENGTH = 80;
 const MAX_PLUGIN_APPROVAL_DESCRIPTION_LENGTH = 256;
+const ANSI_OSC_SEQUENCE_RE = new RegExp(
+  String.raw`(?:\u001b]|\u009d)[^\u001b\u009c\u0007]*(?:\u0007|\u001b\\|\u009c)`,
+  "g",
+);
+const ANSI_CONTROL_SEQUENCE_RE = new RegExp(
+  String.raw`(?:\u001b\[[0-?]*[ -/]*[@-~]|\u009b[0-?]*[ -/]*[@-~]|\u001b[@-Z\\-_])`,
+  "g",
+);
+const CONTROL_CHARACTER_RE = new RegExp(String.raw`[\u0000-\u001f\u007f-\u009f]+`, "g");
+const INVISIBLE_FORMATTING_CONTROL_RE = new RegExp(
+  String.raw`[\u00ad\u034f\u061c\u200b-\u200f\u202a-\u202e\u2060-\u206f\ufeff\ufe00-\ufe0f\u{e0100}-\u{e01ef}]`,
+  "gu",
+);
+const DANGLING_TERMINAL_SEQUENCE_SUFFIX_RE = new RegExp(
+  String.raw`(?:\u001b\][^\u001b\u009c\u0007]*|\u009d[^\u001b\u009c\u0007]*|\u001b\[[0-?]*[ -/]*|\u009b[0-?]*[ -/]*|\u001b)$`,
+);
 
 export type ExecApprovalDecision = "allow-once" | "allow-always" | "deny";
 
@@ -25,11 +41,6 @@ export type AppServerApprovalOutcome =
   | "cancelled";
 
 type ApprovalRequestResult = {
-  id?: string;
-  decision?: ExecApprovalDecision | null;
-};
-
-type ApprovalWaitResult = {
   id?: string;
   decision?: ExecApprovalDecision | null;
 };
@@ -50,8 +61,11 @@ export async function requestPluginApproval(params: {
     { timeoutMs: resolveCodexGatewayTimeoutWithGraceMs(timeoutMs) },
     {
       pluginId: "openclaw-codex-app-server",
-      title: truncateForGateway(params.title, MAX_PLUGIN_APPROVAL_TITLE_LENGTH),
-      description: truncateForGateway(params.description, MAX_PLUGIN_APPROVAL_DESCRIPTION_LENGTH),
+      title: truncateCodexApprovalDisplayText(params.title, MAX_PLUGIN_APPROVAL_TITLE_LENGTH),
+      description: truncateCodexApprovalDisplayText(
+        params.description,
+        MAX_PLUGIN_APPROVAL_DESCRIPTION_LENGTH,
+      ),
       severity: params.severity,
       toolName: params.toolName,
       toolCallId: params.toolCallId,
@@ -89,7 +103,7 @@ export async function waitForPluginApprovalDecision(params: {
   signal?: AbortSignal;
 }): Promise<ExecApprovalDecision | null | undefined> {
   const timeoutMs = DEFAULT_CODEX_APPROVAL_TIMEOUT_MS;
-  const waitPromise: Promise<ApprovalWaitResult | null | undefined> = callGatewayTool(
+  const waitPromise: Promise<ApprovalRequestResult | null | undefined> = callGatewayTool(
     "plugin.approval.waitDecision",
     { timeoutMs: resolveCodexGatewayTimeoutWithGraceMs(timeoutMs) },
     { id: params.approvalId },
@@ -102,7 +116,7 @@ export async function waitForPluginApprovalDecision(params: {
   // Bind the verdict to the approval that parked this prompt. A stale or
   // misrouted reply maps to "unavailable" instead of releasing another gate.
   const bindDecision = (
-    result: ApprovalWaitResult | null | undefined,
+    result: ApprovalRequestResult | null | undefined,
   ): ExecApprovalDecision | null | undefined =>
     result === null ? null : result?.id === params.approvalId ? result.decision : undefined;
   if (!params.signal) {
@@ -111,10 +125,10 @@ export async function waitForPluginApprovalDecision(params: {
   let onAbort: (() => void) | undefined;
   const abortPromise = new Promise<never>((_, reject) => {
     if (params.signal!.aborted) {
-      reject(toLintErrorObject(params.signal!.reason, "Non-Error rejection"));
+      reject(toErrorObject(params.signal!.reason, "Non-Error rejection"));
       return;
     }
-    onAbort = () => reject(toLintErrorObject(params.signal!.reason, "Non-Error rejection"));
+    onAbort = () => reject(toErrorObject(params.signal!.reason, "Non-Error rejection"));
     params.signal!.addEventListener("abort", onAbort, { once: true });
   });
   try {
@@ -142,20 +156,27 @@ export function mapExecDecisionToOutcome(
   return "denied";
 }
 
-function truncateForGateway(value: string, maxLength: number): string {
+export function truncateCodexApprovalDisplayText(value: string, maxLength: number): string {
   return value.length <= maxLength ? value : `${truncateUtf16Safe(value, maxLength - 3)}...`;
 }
 
-function toLintErrorObject(value: unknown, fallbackMessage: string): Error {
-  if (value instanceof Error) {
-    return value;
-  }
-  if (typeof value === "string") {
-    return new Error(value);
-  }
-  const error = new Error(fallbackMessage, { cause: value });
-  if ((typeof value === "object" && value !== null) || typeof value === "function") {
-    Object.assign(error, value);
-  }
-  return error;
+export function stripDanglingCodexApprovalTerminalSequence(value: string): string {
+  return value.replace(DANGLING_TERMINAL_SEQUENCE_SUFFIX_RE, "");
+}
+
+export function sanitizeCodexApprovalVisibleText(
+  value: string,
+  options: { stripDanglingTerminalSequence?: boolean } = {},
+): string {
+  const terminalSafe = value
+    .replace(ANSI_OSC_SEQUENCE_RE, "")
+    .replace(ANSI_CONTROL_SEQUENCE_RE, "");
+  const visible = options.stripDanglingTerminalSequence
+    ? stripDanglingCodexApprovalTerminalSequence(terminalSafe)
+    : terminalSafe;
+  return visible
+    .replace(INVISIBLE_FORMATTING_CONTROL_RE, " ")
+    .replace(CONTROL_CHARACTER_RE, " ")
+    .replace(/\s+/g, " ")
+    .trim();
 }

--- a/extensions/codex/src/app-server/run-attempt-server-requests.ts
+++ b/extensions/codex/src/app-server/run-attempt-server-requests.ts
@@ -1,4 +1,5 @@
 import { onInternalDiagnosticEvent } from "openclaw/plugin-sdk/diagnostic-runtime";
+import { handleCodexAppServerApprovalRequest } from "./approval-bridge.js";
 import { isCodexAppServerApprovalRequest } from "./client.js";
 import { shouldAutoApproveCodexAppServerApprovals } from "./config.js";
 import {
@@ -24,7 +25,7 @@ import type { JsonValue } from "./protocol.js";
 import type { CodexAttemptLifecycleController } from "./run-attempt-lifecycle-controller.js";
 import { emitCodexAppServerEvent } from "./run-attempt-lifecycle.js";
 import type { CodexAttemptResources } from "./run-attempt-resources.js";
-import { handleApprovalRequest, toTranscriptToolResult } from "./run-attempt-tools.js";
+import { toTranscriptToolResult } from "./run-attempt-tools.js";
 import type { CodexAttemptTurnState } from "./run-attempt-turn-state.js";
 import {
   inferCodexDynamicToolMeta,
@@ -124,9 +125,9 @@ export function createCodexAttemptServerRequestController(
             armCompletionWatchOnResponse = true;
             markCurrentTurnRequestProgress();
           }
-          return handleApprovalRequest({
+          return handleCodexAppServerApprovalRequest({
             method: request.method,
-            params: request.params,
+            requestParams: request.params,
             paramsForRun: params,
             threadId: resourceState.thread.threadId,
             turnId,

--- a/extensions/codex/src/app-server/run-attempt-tools.ts
+++ b/extensions/codex/src/app-server/run-attempt-tools.ts
@@ -1,15 +1,7 @@
-import type {
-  EmbeddedRunAttemptParams,
-  NativeHookRelayRegistrationHandle,
-} from "openclaw/plugin-sdk/agent-harness-runtime";
+import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
-import { handleCodexAppServerApprovalRequest } from "./approval-bridge.js";
 import { isSystemAgentOnlyCodexDynamicToolAllowlist } from "./dynamic-tool-profile.js";
-import type {
-  CodexDynamicToolCallParams,
-  CodexDynamicToolCallResponse,
-  JsonValue,
-} from "./protocol.js";
+import type { CodexDynamicToolCallParams, CodexDynamicToolCallResponse } from "./protocol.js";
 import { sanitizeCodexToolResponse } from "./tool-progress-normalization.js";
 
 export function toTranscriptToolResult(
@@ -78,34 +70,6 @@ export function createCodexDynamicToolExecutionRegistry() {
       return { execution, replayed: false } as const;
     },
   };
-}
-
-export function handleApprovalRequest(params: {
-  method: string;
-  params: JsonValue | undefined;
-  paramsForRun: EmbeddedRunAttemptParams;
-  threadId: string;
-  turnId: string;
-  nativeHookRelay?: NativeHookRelayRegistrationHandle;
-  autoApprove?: boolean;
-  autoApproveOpenClawToolPolicy?: boolean;
-  signal?: AbortSignal;
-  onNativeToolFailureDisposition?: Parameters<
-    typeof handleCodexAppServerApprovalRequest
-  >[0]["onNativeToolFailureDisposition"];
-}): Promise<JsonValue | undefined> {
-  return handleCodexAppServerApprovalRequest({
-    method: params.method,
-    requestParams: params.params,
-    paramsForRun: params.paramsForRun,
-    threadId: params.threadId,
-    turnId: params.turnId,
-    nativeHookRelay: params.nativeHookRelay,
-    autoApprove: params.autoApprove,
-    autoApproveOpenClawToolPolicy: params.autoApproveOpenClawToolPolicy,
-    signal: params.signal,
-    onNativeToolFailureDisposition: params.onNativeToolFailureDisposition,
-  });
 }
 
 export function resolveCodexDynamicToolDirectNames(


### PR DESCRIPTION
## What Problem This Solves

Codex app-server approvals and MCP elicitations repeated security-sensitive presentation sanitization, native-relay verdict handling, approval audit construction, gateway error coercion, and request forwarding across their owner boundary. Repeating those paths made explicit approval scope, cancellation, and operator-visible auditing harder to keep consistent as the upstream Codex protocol evolves.

## Why This Change Was Made

This maintainer-requested, AI-assisted refactor consolidates equivalent approval/elicitation sanitization and UTF-16-safe truncation under the existing gateway-roundtrip owner, reuses the canonical Plugin SDK error normalizer, emits policy decisions through one audit path, and shares native-relay deferred-verdict handling. It removes a pass-through approval adapter and unreachable private wrappers while preserving the original incomplete-terminal-sequence ordering, two-phase approval binding, requester provenance, strict thread/turn correlation, distinct callback approval IDs, permission-grant scope, cancellation, and fail-closed outcomes.

Production delta: **129 additions, 270 deletions: -141 lines** across five Codex plugin files. No tests, public config/defaults, protocol schemas, or dependencies changed.

## User Impact

No intended user-visible behavior change. Codex command, file, permission, MCP-app, and computer-use approvals retain the same explicit authorization, one-shot/session restrictions, denial/cancellation behavior, bounded sanitized descriptions, and approval activity events; the shared ownership reduces the risk of sibling security paths drifting apart.

## Evidence

- Personally inspected the exact upstream Codex contract at `openai/codex@07490c75234ed3c63291a8eb7629f04f647038fa`:
  - [Typed string-or-integer JSON-RPC request IDs and response identity](https://github.com/openai/codex/blob/07490c75234ed3c63291a8eb7629f04f647038fa/codex-rs/app-server-protocol/src/rpc.rs#L13-L20).
  - [Distinct per-callback `approvalId`, command approval fields, and offered decisions](https://github.com/openai/codex/blob/07490c75234ed3c63291a8eb7629f04f647038fa/codex-rs/app-server-protocol/src/protocol/v2/item.rs#L1430-L1490); [approval, session, decline, and cancellation variants](https://github.com/openai/codex/blob/07490c75234ed3c63291a8eb7629f04f647038fa/codex-rs/app-server-protocol/src/protocol/v2/item.rs#L57-L114).
  - [Explicit turn/session permission grants](https://github.com/openai/codex/blob/07490c75234ed3c63291a8eb7629f04f647038fa/codex-rs/app-server-protocol/src/protocol/v2/permissions.rs#L761-L794).
  - [Exactly-once callback removal, rejected stale responses, and cancellation](https://github.com/openai/codex/blob/07490c75234ed3c63291a8eb7629f04f647038fa/codex-rs/app-server/src/outgoing_message.rs#L374-L452); [fail-closed command approval response mapping](https://github.com/openai/codex/blob/07490c75234ed3c63291a8eb7629f04f647038fa/codex-rs/app-server/src/bespoke_event_handling.rs#L1973-L2039).
- Dedicated trusted Blacksmith Testbox run: https://github.com/openclaw/openclaw/actions/runs/31009847663.
- Focused grouped command: `OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 OPENCLAW_VITEST_MAX_WORKERS=2 pnpm test extensions/codex/src/app-server/approval-bridge.test.ts extensions/codex/src/app-server/elicitation-bridge.test.ts extensions/codex/src/app-server/client.test.ts extensions/codex/src/app-server/turn-router.test.ts extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts extensions/codex/src/app-server/run-attempt.turn-watches.test.ts` — **323/323 tests passed across seven files** (87 approval, 53 elicitation, 36 client, 24 router, 20 native relay, 9 dynamic tools, 94 turn watches).
- Full same-lease unchanged gate: `CI=1 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm check:changed` — **passed**, including production/test extension typechecks, 245-rule changed-file lint with zero warnings/errors, formatting, Plugin SDK/ownership boundaries, production/full-tree/script Knip scans with zero unused exports, import cycles, sidecar loaders, and security/ratchet guards.
- Fresh independent review: `.agents/skills/autoreview/scripts/autoreview --mode local --engine codex --model gpt-5.6-sol --thinking xhigh` — **clean**, patch-correct confidence **0.98**, no accepted/actionable findings.
- Testbox lease was stopped and independently verified `completed`; no live operator approvals, account credentials, or external user actions were used.

**Observed exact-head production JSON-RPC security trace (2026-08-05)**

The automated reviewer explicitly lacked direct access to the sibling Codex checkout, so its upstream-source gap is real; its statement is **not** used as Codex protocol proof. The acting patch owner and the independent acting reviewer each personally inspected the actual sibling Codex source at immutable commit `07490c75234ed3c63291a8eb7629f04f647038fa` before reaching a verdict. Exact upstream owner evidence:

- [Typed string/integer RequestId and response identity](https://github.com/openai/codex/blob/07490c75234ed3c63291a8eb7629f04f647038fa/codex-rs/app-server-protocol/src/rpc.rs#L13-L20), [distinct command approvalId versus parent itemId](https://github.com/openai/codex/blob/07490c75234ed3c63291a8eb7629f04f647038fa/codex-rs/app-server-protocol/src/protocol/v2/item.rs#L1430-L1472), and [turn-default versus session permission grant scope](https://github.com/openai/codex/blob/07490c75234ed3c63291a8eb7629f04f647038fa/codex-rs/app-server-protocol/src/protocol/v2/permissions.rs#L761-L794).
- [App-server callback insertion before dispatch](https://github.com/openai/codex/blob/07490c75234ed3c63291a8eb7629f04f647038fa/codex-rs/app-server/src/outgoing_message.rs#L287-L307), [response/error/cancellation remove callbacks exactly once](https://github.com/openai/codex/blob/07490c75234ed3c63291a8eb7629f04f647038fa/codex-rs/app-server/src/outgoing_message.rs#L374-L452), [core callback identity and insertion](https://github.com/openai/codex/blob/07490c75234ed3c63291a8eb7629f04f647038fa/codex-rs/core/src/session/mod.rs#L2320-L2337), [core callback remove-once resolution](https://github.com/openai/codex/blob/07490c75234ed3c63291a8eb7629f04f647038fa/codex-rs/core/src/session/mod.rs#L2894-L2910), and [abort versus approval dispatch](https://github.com/openai/codex/blob/07490c75234ed3c63291a8eb7629f04f647038fa/codex-rs/core/src/session/handlers.rs#L393-L405).

For the exact PR head, the harness verified the Git blob hash of every executed production owner, then connected the **actual** [JSON-RPC client](https://github.com/openclaw/openclaw/blob/9c5d942e17d149fdf0576f2a3af46627e71b7b6e/extensions/codex/src/app-server/client.ts#L825-L935), [thread/turn router](https://github.com/openclaw/openclaw/blob/9c5d942e17d149fdf0576f2a3af46627e71b7b6e/extensions/codex/src/app-server/turn-router.ts#L380-L441), [approval bridge](https://github.com/openclaw/openclaw/blob/9c5d942e17d149fdf0576f2a3af46627e71b7b6e/extensions/codex/src/app-server/approval-bridge.ts#L62-L235), [elicitation bridge](https://github.com/openclaw/openclaw/blob/9c5d942e17d149fdf0576f2a3af46627e71b7b6e/extensions/codex/src/app-server/elicitation-bridge.ts#L73-L130), and [two-phase plugin approval owner](https://github.com/openclaw/openclaw/blob/9c5d942e17d149fdf0576f2a3af46627e71b7b6e/extensions/codex/src/app-server/plugin-approval-roundtrip.ts#L49-L145) using in-memory PassThrough streams and a synthetic gateway. No Codex subprocess, network, live operator approval, authentication, credential, token, or account was used. Every frame below was emitted by the committed production client; the synthetic server consumed each of its 12 callbacks exactly once. Runtime assertions also proved owner-proven requester propagation, stale thread/turn denial without any gateway call, exact approval-id binding, final-decision precedence, explicit cancellation, turn/session grant isolation, permission-denial empty grants, MCP accept/decline/cancel, duplicate response suppression, and ANSI/Bidi control removal.

<details><summary>Redacted observed JSON-RPC verdict frames and security assertions</summary>

```json
{
  "head": "9c5d942e17d149fdf0576f2a3af46627e71b7b6e",
  "transport": "in-memory PassThrough JSON-RPC; no subprocess, network, credentials, or live approvals",
  "productionOwners": [
    "client.ts",
    "turn-router.ts",
    "approval-bridge.ts",
    "elicitation-bridge.ts",
    "plugin-approval-roundtrip.ts"
  ],
  "typedClientResponseCorrelation": {
    "numericRequestId": 1,
    "rejectedStringId": "1",
    "wrongTypedResponseIgnored": true,
    "acceptedResponse": {
      "models": [
        "correct-numeric-id"
      ]
    },
    "duplicateResponseIgnored": true
  },
  "observedPolicyActor": {
    "channel": "synthetic",
    "accountId": "synthetic-account",
    "senderId": "[redacted]",
    "senderIsOwner": true
  },
  "serverCallbacks": {
    "observed": 12,
    "allRemovedExactlyOnce": true
  },
  "observedVerdicts": [
    {
      "case": "numeric-command-allow-once-distinct-approval-callback",
      "requestIdType": "number",
      "itemId": "parent-command-item",
      "approvalId": "distinct-execve-callback-a",
      "gatewayToolCallId": "distinct-execve-callback-a",
      "twoPhase": true,
      "gatewayCalls": 2,
      "routedHandlerCalls": 1,
      "callbackRemovedOnce": true,
      "response": {
        "id": 41,
        "result": {
          "decision": "accept"
        }
      },
      "audit": [
        {
          "phase": "requested",
          "status": "pending"
        },
        {
          "phase": "resolved",
          "status": "approved"
        }
      ]
    },
    {
      "case": "string-command-deny-final-decision-overrides-request-hint",
      "requestIdType": "string",
      "itemId": "parent-command-item",
      "approvalId": "distinct-execve-callback-b",
      "gatewayToolCallId": "distinct-execve-callback-b",
      "twoPhase": true,
      "gatewayCalls": 2,
      "routedHandlerCalls": 1,
      "callbackRemovedOnce": true,
      "response": {
        "id": "rpc-deny-42",
        "result": {
          "decision": "decline"
        }
      },
      "audit": [
        {
          "phase": "requested",
          "status": "pending"
        },
        {
          "phase": "resolved",
          "status": "denied"
        }
      ]
    },
    {
      "case": "command-turn-cancellation-fails-closed",
      "requestIdType": "number",
      "itemId": "parent-command-item",
      "approvalId": "distinct-execve-callback-c",
      "gatewayToolCallId": "distinct-execve-callback-c",
      "twoPhase": true,
      "gatewayCalls": 2,
      "routedHandlerCalls": 1,
      "callbackRemovedOnce": true,
      "response": {
        "id": 43,
        "result": {
          "decision": "cancel"
        }
      },
      "audit": [
        {
          "phase": "requested",
          "status": "pending"
        },
        {
          "phase": "resolved",
          "status": "failed"
        }
      ]
    },
    {
      "case": "stale-thread-default-deny-without-gateway",
      "requestIdType": "string",
      "itemId": "parent-command-item",
      "approvalId": "distinct-execve-callback-a",
      "gatewayCalls": 0,
      "routedHandlerCalls": 0,
      "callbackRemovedOnce": true,
      "response": {
        "id": "rpc-stale-thread",
        "result": {
          "decision": "decline"
        }
      }
    },
    {
      "case": "stale-turn-default-deny-without-gateway",
      "requestIdType": "number",
      "itemId": "parent-command-item",
      "approvalId": "distinct-execve-callback-a",
      "gatewayCalls": 0,
      "routedHandlerCalls": 0,
      "callbackRemovedOnce": true,
      "response": {
        "id": 45,
        "result": {
          "decision": "decline"
        }
      }
    },
    {
      "case": "wrong-gateway-approval-id-fails-closed",
      "requestIdType": "string",
      "itemId": "parent-command-item",
      "approvalId": "distinct-execve-callback-d",
      "gatewayToolCallId": "distinct-execve-callback-d",
      "twoPhase": true,
      "gatewayCalls": 2,
      "routedHandlerCalls": 1,
      "callbackRemovedOnce": true,
      "response": {
        "id": "rpc-mismatched-46",
        "result": {
          "decision": "decline"
        }
      },
      "audit": [
        {
          "phase": "requested",
          "status": "pending"
        },
        {
          "phase": "resolved",
          "status": "unavailable"
        }
      ]
    },
    {
      "case": "permission-allow-once-turn-scope",
      "requestIdType": "number",
      "twoPhase": true,
      "gatewayCalls": 2,
      "routedHandlerCalls": 1,
      "callbackRemovedOnce": true,
      "response": {
        "id": 47,
        "result": {
          "permissions": {
            "network": {
              "enabled": true
            },
            "fileSystem": {
              "write": [
                "/workspace"
              ]
            }
          },
          "scope": "turn"
        }
      },
      "audit": [
        {
          "phase": "requested",
          "status": "pending"
        },
        {
          "phase": "resolved",
          "status": "approved",
          "scope": "turn"
        }
      ]
    },
    {
      "case": "permission-allow-always-session-scope",
      "requestIdType": "string",
      "twoPhase": true,
      "gatewayCalls": 2,
      "routedHandlerCalls": 1,
      "callbackRemovedOnce": true,
      "response": {
        "id": "rpc-session-48",
        "result": {
          "permissions": {
            "network": {
              "enabled": true
            },
            "fileSystem": {
              "write": [
                "/workspace"
              ]
            }
          },
          "scope": "session"
        }
      },
      "audit": [
        {
          "phase": "requested",
          "status": "pending"
        },
        {
          "phase": "resolved",
          "status": "approved",
          "scope": "session"
        }
      ]
    },
    {
      "case": "permission-deny-empty-turn-grant",
      "requestIdType": "number",
      "twoPhase": true,
      "gatewayCalls": 2,
      "routedHandlerCalls": 1,
      "callbackRemovedOnce": true,
      "response": {
        "id": 49,
        "result": {
          "permissions": {},
          "scope": "turn"
        }
      },
      "audit": [
        {
          "phase": "requested",
          "status": "pending"
        },
        {
          "phase": "resolved",
          "status": "denied",
          "scope": "turn"
        }
      ]
    },
    {
      "case": "elicitation-allow-once",
      "requestIdType": "string",
      "twoPhase": true,
      "gatewayCalls": 2,
      "routedHandlerCalls": 1,
      "callbackRemovedOnce": true,
      "response": {
        "id": "rpc-elicit-allow",
        "result": {
          "action": "accept",
          "content": {
            "approve": true
          },
          "_meta": null
        }
      }
    },
    {
      "case": "elicitation-request-hint-allow-final-deny",
      "requestIdType": "number",
      "twoPhase": true,
      "gatewayCalls": 2,
      "routedHandlerCalls": 1,
      "callbackRemovedOnce": true,
      "response": {
        "id": 51,
        "result": {
          "action": "decline",
          "content": null,
          "_meta": null
        }
      }
    },
    {
      "case": "elicitation-cancellation",
      "requestIdType": "string",
      "twoPhase": true,
      "gatewayCalls": 2,
      "routedHandlerCalls": 1,
      "callbackRemovedOnce": true,
      "response": {
        "id": "rpc-elicit-cancel",
        "result": {
          "action": "cancel",
          "content": null,
          "_meta": null
        }
      }
    }
  ],
  "sanitizedVisibleText": "red reversed"
}
```

</details>


