### PR TITLE
refactor: simplify Google, Qwen, and xAI model catalogs

### DIFF
--- a/extensions/google/provider-catalog.ts
+++ b/extensions/google/provider-catalog.ts
@@ -14,95 +14,36 @@ const GOOGLE_GEMINI_MODELS_ENDPOINT = `${GOOGLE_GEMINI_BASE_URL}/models?pageSize
 const GOOGLE_VERTEX_BASE_URL = "https://{location}-aiplatform.googleapis.com";
 const GOOGLE_GEMINI_MODELS_CACHE_TTL_MS = 60_000;
 const GOOGLE_GEMINI_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } as const;
-const GOOGLE_GEMINI_TEXT_MODELS: ModelDefinitionConfig[] = [
-  {
-    id: "gemini-2.5-pro",
-    name: "Gemini 2.5 Pro",
-    reasoning: true,
-    input: ["text", "image"],
-    cost: GOOGLE_GEMINI_COST,
-    contextWindow: 1_048_576,
-    maxTokens: 65_536,
-  },
-  {
-    id: "gemini-2.5-flash",
-    name: "Gemini 2.5 Flash",
-    reasoning: true,
-    input: ["text", "image"],
-    cost: GOOGLE_GEMINI_COST,
-    contextWindow: 1_048_576,
-    maxTokens: 65_536,
-  },
-  {
-    id: "gemini-2.5-flash-lite",
-    name: "Gemini 2.5 Flash-Lite",
-    reasoning: true,
-    input: ["text", "image"],
-    cost: GOOGLE_GEMINI_COST,
-    contextWindow: 1_048_576,
-    maxTokens: 65_536,
-  },
-  {
-    id: "gemini-3.5-flash",
-    name: "Gemini 3.5 Flash",
-    reasoning: true,
-    input: ["text", "image"],
-    cost: GOOGLE_GEMINI_COST,
-    contextWindow: 1_048_576,
-    maxTokens: 65_536,
-    compat: { codeMode: "preferred" },
-  },
-  {
-    id: "gemini-3.6-flash",
-    name: "Gemini 3.6 Flash",
-    reasoning: true,
-    input: ["text", "image"],
-    cost: GOOGLE_GEMINI_COST,
-    contextWindow: 1_048_576,
-    maxTokens: 65_536,
-    compat: { codeMode: "preferred" },
-  },
-  {
-    id: "gemini-3.5-flash-lite",
-    name: "Gemini 3.5 Flash-Lite",
-    reasoning: true,
-    input: ["text", "image"],
-    cost: GOOGLE_GEMINI_COST,
-    contextWindow: 1_048_576,
-    maxTokens: 65_536,
-    compat: { codeMode: "preferred" },
-  },
-  {
-    id: "gemini-3.1-pro-preview",
-    name: "Gemini 3.1 Pro Preview",
-    reasoning: true,
-    input: ["text", "image"],
-    cost: GOOGLE_GEMINI_COST,
-    contextWindow: 1_048_576,
-    maxTokens: 65_536,
-    compat: { codeMode: "preferred" },
-  },
-  {
-    id: "gemini-3.1-flash-lite",
-    name: "Gemini 3.1 Flash Lite",
-    reasoning: true,
-    input: ["text", "image"],
-    cost: GOOGLE_GEMINI_COST,
-    contextWindow: 1_048_576,
-    maxTokens: 65_536,
-    compat: { codeMode: "preferred" },
-  },
-  {
-    id: "gemini-3-flash-preview",
-    name: "Gemini 3 Flash Preview",
-    reasoning: true,
-    input: ["text", "image"],
-    cost: GOOGLE_GEMINI_COST,
-    contextWindow: 1_048_576,
-    maxTokens: 65_536,
-    compat: { codeMode: "preferred" },
-  },
+const GOOGLE_GEMINI_TEXT_MODEL_ROWS: ReadonlyArray<
+  readonly [id: string, name: string, prefersCodeMode: boolean]
+> = [
+  ["gemini-2.5-pro", "Gemini 2.5 Pro", false],
+  ["gemini-2.5-flash", "Gemini 2.5 Flash", false],
+  ["gemini-2.5-flash-lite", "Gemini 2.5 Flash-Lite", false],
+  ["gemini-3.5-flash", "Gemini 3.5 Flash", true],
+  ["gemini-3.6-flash", "Gemini 3.6 Flash", true],
+  ["gemini-3.5-flash-lite", "Gemini 3.5 Flash-Lite", true],
+  ["gemini-3.1-pro-preview", "Gemini 3.1 Pro Preview", true],
+  ["gemini-3.1-flash-lite", "Gemini 3.1 Flash Lite", true],
+  ["gemini-3-flash-preview", "Gemini 3 Flash Preview", true],
 ];
+const GOOGLE_GEMINI_TEXT_MODELS: ModelDefinitionConfig[] = GOOGLE_GEMINI_TEXT_MODEL_ROWS.map(
+  ([id, name, prefersCodeMode]): ModelDefinitionConfig => {
+    const model: ModelDefinitionConfig = {
+      id,
+      name,
+      reasoning: true,
+      input: ["text", "image"],
+      cost: GOOGLE_GEMINI_COST,
+      contextWindow: 1_048_576,
+      maxTokens: 65_536,
+    };
+    if (prefersCodeMode) {
+      model.compat = { codeMode: "preferred" };
+    }
+    return model;
+  },
+);
 const GOOGLE_GEMINI_TEXT_MODEL_BY_ID = new Map(
   GOOGLE_GEMINI_TEXT_MODELS.map((model) => [model.id, model]),
 );

--- a/extensions/qwen/models.ts
+++ b/extensions/qwen/models.ts
@@ -68,175 +68,52 @@ export function resolveQwenTokenPlanBaseUrl(region: QwenTokenPlanRegion): string
   return QWEN_TOKEN_PLAN_BASE_URLS[region];
 }
 
-// Token Plan is credit-based, so per-token prices do not map to its billing model.
-// This curated picker catalog keeps current recommendations plus one selectable compatibility row.
-export const QWEN_TOKEN_PLAN_MODEL_CATALOG: ReadonlyArray<ModelDefinitionConfig> = [
-  {
-    id: QWEN_37_PLUS_MODEL_ID,
-    name: QWEN_37_PLUS_MODEL_ID,
-    reasoning: true,
-    input: ["text", "image"],
-    cost: QWEN_DEFAULT_COST,
-    contextWindow: 1_000_000,
-    maxTokens: 65_536,
-  },
-  {
-    id: QWEN_36_PLUS_MODEL_ID,
-    name: QWEN_36_PLUS_MODEL_ID,
-    reasoning: true,
-    input: ["text", "image"],
-    cost: QWEN_DEFAULT_COST,
-    contextWindow: 1_000_000,
-    maxTokens: 65_536,
-  },
-  {
-    id: "qwen3-coder-next",
-    name: "qwen3-coder-next",
-    reasoning: true,
-    input: ["text"],
-    cost: QWEN_DEFAULT_COST,
-    contextWindow: 262_144,
-    maxTokens: 65_536,
-  },
-  {
-    id: "kimi-k2.5",
-    name: "kimi-k2.5",
-    reasoning: true,
-    input: ["text", "image"],
-    cost: QWEN_DEFAULT_COST,
-    contextWindow: 262_144,
-    maxTokens: 98_304,
-  },
-  {
-    id: "glm-5",
-    name: "glm-5",
-    reasoning: true,
-    input: ["text"],
-    cost: QWEN_DEFAULT_COST,
-    contextWindow: 202_752,
-    maxTokens: 16_384,
-  },
-  {
-    id: "MiniMax-M2.5",
-    name: "MiniMax-M2.5",
-    reasoning: true,
-    input: ["text"],
-    cost: QWEN_DEFAULT_COST,
-    contextWindow: 196_608,
-    maxTokens: 32_768,
-  },
+type QwenCatalogModelRow = readonly [
+  id: string,
+  reasoning: boolean,
+  input: ModelDefinitionConfig["input"],
+  contextWindow: number,
+  maxTokens: number,
 ];
 
-export const QWEN_MODEL_CATALOG: ReadonlyArray<ModelDefinitionConfig> = [
-  {
-    id: "qwen3.5-plus",
-    name: "qwen3.5-plus",
-    reasoning: false,
-    input: ["text", "image"],
+function buildQwenCatalogModels(rows: readonly QwenCatalogModelRow[]): ModelDefinitionConfig[] {
+  return rows.map(([id, reasoning, input, contextWindow, maxTokens]) => ({
+    id,
+    name: id,
+    reasoning,
+    input,
     cost: QWEN_DEFAULT_COST,
-    contextWindow: 1_000_000,
-    maxTokens: 65_536,
-  },
-  {
-    id: QWEN_36_FLASH_MODEL_ID,
-    name: QWEN_36_FLASH_MODEL_ID,
-    reasoning: true,
-    input: ["text", "image"],
-    cost: QWEN_DEFAULT_COST,
-    contextWindow: 1_000_000,
-    maxTokens: 65_536,
-  },
-  {
-    id: QWEN_36_PLUS_MODEL_ID,
-    name: QWEN_36_PLUS_MODEL_ID,
-    reasoning: true,
-    input: ["text", "image"],
-    cost: QWEN_DEFAULT_COST,
-    contextWindow: 1_000_000,
-    maxTokens: 65_536,
-  },
-  {
-    id: QWEN_37_MAX_MODEL_ID,
-    name: QWEN_37_MAX_MODEL_ID,
-    reasoning: true,
-    input: ["text"],
-    cost: QWEN_DEFAULT_COST,
-    contextWindow: 1_000_000,
-    maxTokens: 65_536,
-  },
-  {
-    id: QWEN_37_PLUS_MODEL_ID,
-    name: QWEN_37_PLUS_MODEL_ID,
-    reasoning: true,
-    input: ["text", "image"],
-    cost: QWEN_DEFAULT_COST,
-    contextWindow: 1_000_000,
-    maxTokens: 65_536,
-  },
-  {
-    id: "qwen3-max-2026-01-23",
-    name: "qwen3-max-2026-01-23",
-    reasoning: false,
-    input: ["text"],
-    cost: QWEN_DEFAULT_COST,
-    contextWindow: 262_144,
-    maxTokens: 65_536,
-  },
-  {
-    id: "qwen3-coder-next",
-    name: "qwen3-coder-next",
-    reasoning: false,
-    input: ["text"],
-    cost: QWEN_DEFAULT_COST,
-    contextWindow: 262_144,
-    maxTokens: 65_536,
-  },
-  {
-    id: "qwen3-coder-plus",
-    name: "qwen3-coder-plus",
-    reasoning: false,
-    input: ["text"],
-    cost: QWEN_DEFAULT_COST,
-    contextWindow: 1_000_000,
-    maxTokens: 65_536,
-  },
-  {
-    id: "MiniMax-M2.5",
-    name: "MiniMax-M2.5",
-    reasoning: true,
-    input: ["text"],
-    cost: QWEN_DEFAULT_COST,
-    contextWindow: 1_000_000,
-    maxTokens: 65_536,
-  },
-  {
-    id: "glm-5",
-    name: "glm-5",
-    reasoning: false,
-    input: ["text"],
-    cost: QWEN_DEFAULT_COST,
-    contextWindow: 202_752,
-    maxTokens: 16_384,
-  },
-  {
-    id: "glm-4.7",
-    name: "glm-4.7",
-    reasoning: false,
-    input: ["text"],
-    cost: QWEN_DEFAULT_COST,
-    contextWindow: 202_752,
-    maxTokens: 16_384,
-  },
-  {
-    id: "kimi-k2.5",
-    name: "kimi-k2.5",
-    reasoning: false,
-    input: ["text", "image"],
-    cost: QWEN_DEFAULT_COST,
-    contextWindow: 262_144,
-    maxTokens: 32_768,
-  },
-];
+    contextWindow,
+    maxTokens,
+  }));
+}
+
+// Token Plan is credit-based, so per-token prices do not map to its billing model.
+// This curated picker catalog keeps current recommendations plus one selectable compatibility row.
+export const QWEN_TOKEN_PLAN_MODEL_CATALOG: ReadonlyArray<ModelDefinitionConfig> =
+  buildQwenCatalogModels([
+    [QWEN_37_PLUS_MODEL_ID, true, ["text", "image"], 1_000_000, 65_536],
+    [QWEN_36_PLUS_MODEL_ID, true, ["text", "image"], 1_000_000, 65_536],
+    ["qwen3-coder-next", true, ["text"], 262_144, 65_536],
+    ["kimi-k2.5", true, ["text", "image"], 262_144, 98_304],
+    ["glm-5", true, ["text"], 202_752, 16_384],
+    ["MiniMax-M2.5", true, ["text"], 196_608, 32_768],
+  ]);
+
+export const QWEN_MODEL_CATALOG: ReadonlyArray<ModelDefinitionConfig> = buildQwenCatalogModels([
+  [QWEN_DEFAULT_MODEL_ID, false, ["text", "image"], 1_000_000, 65_536],
+  [QWEN_36_FLASH_MODEL_ID, true, ["text", "image"], 1_000_000, 65_536],
+  [QWEN_36_PLUS_MODEL_ID, true, ["text", "image"], 1_000_000, 65_536],
+  [QWEN_37_MAX_MODEL_ID, true, ["text"], 1_000_000, 65_536],
+  [QWEN_37_PLUS_MODEL_ID, true, ["text", "image"], 1_000_000, 65_536],
+  ["qwen3-max-2026-01-23", false, ["text"], 262_144, 65_536],
+  ["qwen3-coder-next", false, ["text"], 262_144, 65_536],
+  ["qwen3-coder-plus", false, ["text"], 1_000_000, 65_536],
+  ["MiniMax-M2.5", true, ["text"], 1_000_000, 65_536],
+  ["glm-5", false, ["text"], 202_752, 16_384],
+  ["glm-4.7", false, ["text"], 202_752, 16_384],
+  ["kimi-k2.5", false, ["text", "image"], 262_144, 32_768],
+]);
 
 export function isQwenCodingPlanBaseUrl(baseUrl: string | undefined): boolean {
   const trimmed = baseUrl?.trim();

--- a/extensions/xai/model-definitions.ts
+++ b/extensions/xai/model-definitions.ts
@@ -27,6 +27,19 @@ type XaiCatalogEntry = {
   cost: XaiCost;
 };
 
+type XaiCatalogModelRow = readonly [
+  id: string,
+  name: string,
+  reasoning: boolean,
+  input: ModelDefinitionConfig["input"],
+  overrides?: {
+    contextWindow?: number;
+    maxTokens?: number;
+    omitMaxTokens?: true;
+    cost?: XaiCost;
+  },
+];
+
 const XAI_GROK_420_COST = {
   input: 1.25,
   output: 2.5,
@@ -55,142 +68,64 @@ const XAI_GROK_BUILD_COST = {
   cacheWrite: 0,
 } satisfies XaiCost;
 
-const XAI_MODEL_CATALOG = [
-  {
-    id: "grok-4.5",
-    name: "Grok 4.5",
-    reasoning: true,
-    input: ["text", "image"],
-    contextWindow: XAI_GROK_45_CONTEXT_WINDOW,
-    maxTokens: XAI_DEFAULT_MAX_TOKENS,
-    cost: XAI_GROK_45_COST,
+const XAI_MODEL_CATALOG_ROWS: readonly XaiCatalogModelRow[] = [
+  [
+    "grok-4.5",
+    "Grok 4.5",
+    true,
+    ["text", "image"],
+    { contextWindow: XAI_GROK_45_CONTEXT_WINDOW, cost: XAI_GROK_45_COST },
+  ],
+  [
+    "grok-build-0.1",
+    "Grok Build 0.1",
+    true,
+    ["text", "image"],
+    { contextWindow: XAI_CODE_CONTEXT_WINDOW, omitMaxTokens: true, cost: XAI_GROK_BUILD_COST },
+  ],
+  ["grok-3", "Grok 3", false, ["text"]],
+  ["grok-3-fast", "Grok 3 Fast", false, ["text"]],
+  ["grok-3-mini", "Grok 3 Mini", true, ["text"]],
+  ["grok-3-mini-fast", "Grok 3 Mini Fast", true, ["text"]],
+  ["grok-4.3", "Grok 4.3", true, ["text", "image"]],
+  ["grok-4", "Grok 4", true, ["text"]],
+  ["grok-4-0709", "Grok 4 0709", true, ["text"]],
+  ["grok-4-fast", "Grok 4 Fast", true, ["text", "image"]],
+  ["grok-4-fast-non-reasoning", "Grok 4 Fast (Non-Reasoning)", false, ["text", "image"]],
+  ["grok-4-1-fast", "Grok 4.1 Fast", true, ["text", "image"]],
+  ["grok-4-1-fast-non-reasoning", "Grok 4.1 Fast (Non-Reasoning)", false, ["text", "image"]],
+  [
+    "grok-4.20-0309-reasoning",
+    "Grok 4.20 0309 (Reasoning)",
+    true,
+    ["text", "image"],
+    { maxTokens: 30_000, cost: XAI_GROK_420_COST },
+  ],
+  [
+    "grok-4.20-0309-non-reasoning",
+    "Grok 4.20 0309 (Non-Reasoning)",
+    false,
+    ["text", "image"],
+    { maxTokens: 30_000, cost: XAI_GROK_420_COST },
+  ],
+];
+const XAI_MODEL_CATALOG: readonly XaiCatalogEntry[] = XAI_MODEL_CATALOG_ROWS.map(
+  ([id, name, reasoning, input, overrides]) => {
+    const model: XaiCatalogEntry = {
+      id,
+      name,
+      reasoning,
+      input,
+      contextWindow: overrides?.contextWindow ?? XAI_DEFAULT_CONTEXT_WINDOW,
+      maxTokens: overrides?.maxTokens ?? XAI_DEFAULT_MAX_TOKENS,
+      cost: overrides?.cost ?? XAI_GROK_43_COST,
+    };
+    if (overrides?.omitMaxTokens) {
+      delete model.maxTokens;
+    }
+    return model;
   },
-  {
-    id: "grok-build-0.1",
-    name: "Grok Build 0.1",
-    reasoning: true,
-    input: ["text", "image"],
-    contextWindow: XAI_CODE_CONTEXT_WINDOW,
-    cost: XAI_GROK_BUILD_COST,
-  },
-  {
-    id: "grok-3",
-    name: "Grok 3",
-    reasoning: false,
-    input: ["text"],
-    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
-    maxTokens: XAI_DEFAULT_MAX_TOKENS,
-    cost: XAI_GROK_43_COST,
-  },
-  {
-    id: "grok-3-fast",
-    name: "Grok 3 Fast",
-    reasoning: false,
-    input: ["text"],
-    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
-    maxTokens: XAI_DEFAULT_MAX_TOKENS,
-    cost: XAI_GROK_43_COST,
-  },
-  {
-    id: "grok-3-mini",
-    name: "Grok 3 Mini",
-    reasoning: true,
-    input: ["text"],
-    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
-    maxTokens: XAI_DEFAULT_MAX_TOKENS,
-    cost: XAI_GROK_43_COST,
-  },
-  {
-    id: "grok-3-mini-fast",
-    name: "Grok 3 Mini Fast",
-    reasoning: true,
-    input: ["text"],
-    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
-    maxTokens: XAI_DEFAULT_MAX_TOKENS,
-    cost: XAI_GROK_43_COST,
-  },
-  {
-    id: "grok-4.3",
-    name: "Grok 4.3",
-    reasoning: true,
-    input: ["text", "image"],
-    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
-    maxTokens: XAI_DEFAULT_MAX_TOKENS,
-    cost: XAI_GROK_43_COST,
-  },
-  {
-    id: "grok-4",
-    name: "Grok 4",
-    reasoning: true,
-    input: ["text"],
-    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
-    maxTokens: XAI_DEFAULT_MAX_TOKENS,
-    cost: XAI_GROK_43_COST,
-  },
-  {
-    id: "grok-4-0709",
-    name: "Grok 4 0709",
-    reasoning: true,
-    input: ["text"],
-    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
-    maxTokens: XAI_DEFAULT_MAX_TOKENS,
-    cost: XAI_GROK_43_COST,
-  },
-  {
-    id: "grok-4-fast",
-    name: "Grok 4 Fast",
-    reasoning: true,
-    input: ["text", "image"],
-    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
-    maxTokens: XAI_DEFAULT_MAX_TOKENS,
-    cost: XAI_GROK_43_COST,
-  },
-  {
-    id: "grok-4-fast-non-reasoning",
-    name: "Grok 4 Fast (Non-Reasoning)",
-    reasoning: false,
-    input: ["text", "image"],
-    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
-    maxTokens: XAI_DEFAULT_MAX_TOKENS,
-    cost: XAI_GROK_43_COST,
-  },
-  {
-    id: "grok-4-1-fast",
-    name: "Grok 4.1 Fast",
-    reasoning: true,
-    input: ["text", "image"],
-    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
-    maxTokens: XAI_DEFAULT_MAX_TOKENS,
-    cost: XAI_GROK_43_COST,
-  },
-  {
-    id: "grok-4-1-fast-non-reasoning",
-    name: "Grok 4.1 Fast (Non-Reasoning)",
-    reasoning: false,
-    input: ["text", "image"],
-    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
-    maxTokens: XAI_DEFAULT_MAX_TOKENS,
-    cost: XAI_GROK_43_COST,
-  },
-  {
-    id: "grok-4.20-0309-reasoning",
-    name: "Grok 4.20 0309 (Reasoning)",
-    reasoning: true,
-    input: ["text", "image"],
-    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
-    maxTokens: 30_000,
-    cost: XAI_GROK_420_COST,
-  },
-  {
-    id: "grok-4.20-0309-non-reasoning",
-    name: "Grok 4.20 0309 (Non-Reasoning)",
-    reasoning: false,
-    input: ["text", "image"],
-    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
-    maxTokens: 30_000,
-    cost: XAI_GROK_420_COST,
-  },
-] as const satisfies readonly XaiCatalogEntry[];
+);
 
 const XAI_SELECTABLE_MODEL_IDS = new Set<string>([
   "grok-4.5",


### PR DESCRIPTION
## What Problem This Solves

Bundled Google/Vertex, Qwen, and xAI catalogs repeated the same model-object assembly across 42 entries, increasing maintenance cost and the risk that equivalent provider metadata drifts.

## Why This Change Was Made

Replace duplicate provider-owned model literals with typed, provider-local catalog rows and canonical assembly. The change removes 247 production lines (+142/-389) across exactly three files while preserving the existing provider boundaries, configuration, authentication, routing, and public contracts.

## User Impact

No user-visible behavior changes: all 42 catalog records remain identical—9 Google/Vertex, 18 Qwen across Token Plan and Standard, and 15 xAI. Model IDs, ordering, object/property shapes, reasoning and input capabilities, context/output limits, pricing, public aliases, OAuth selection, and stored model preferences remain unchanged.

Google and Vertex still share their catalog; input arrays and compatibility objects retain their original independent identities; Qwen plan-specific capabilities and public catalog aliases remain distinct or shared exactly as before; and xAI preserves all four pricing-reference groups, alias resolution, and the Grok Build private maxTokens omission/public default.

## Evidence

- Exact-source before/after runtime differential passed for all 42 records, including serialized bytes, own-property order, shared/distinct object references, aliases, provider builders, and cross-plan capability differences.
- Focused trusted Blacksmith Testbox proof: **366/366 tests passed across 20 files and four Vitest shards**, covering Google/Vertex discovery and provider registration, Qwen Token Plan/Standard catalogs and routing, xAI model aliases, preferences, onboarding and OAuth, and shared provider-discovery/model-routing behavior.
- Targeted provider lint passed: **0 warnings, 0 errors across 245 rules**.
- Full unmodified `pnpm check:changed` passed, including production and test extension typechecks, formatting, plugin-boundary and dependency guards, dead-export checks, changed-file lint, database-first guards, and runtime import-cycle checks.
- Fresh exact review: `.agents/skills/autoreview/scripts/autoreview --mode local --engine codex --model gpt-5.6-sol --thinking xhigh`; **zero accepted/actionable findings, confidence 0.99**.
- Blacksmith Testbox run: https://github.com/openclaw/openclaw/actions/runs/31009450914

