### PR TITLE
docs(skills): make full-authority maintainer runs unattended

### DIFF
--- a/.agents/skills/clawsweeper/SKILL.md
+++ b/.agents/skills/clawsweeper/SKILL.md
@@ -257,7 +257,7 @@ loop. The router:
   checks are green, GitHub says mergeable, no human-review label is present,
   the PR is not draft, and both merge gates are open.
 
-Missing changelog is not a review finding or merge blocker. If repairing a user-facing change, add/update changelog automatically when practical; never ask or block solely on it.
+Missing changelog is never a review finding or merge blocker. `CHANGELOG.md` is release-only; record user-facing release-note context in the PR body or squash message, never edit the changelog for normal repairs.
 
 If ClawSweeper passes while merge gates are closed, it labels
 `clawsweeper:merge-ready` and comments instead of merging. `@clawsweeper stop`

--- a/.agents/skills/openclaw-landable-bug-sweep/SKILL.md
+++ b/.agents/skills/openclaw-landable-bug-sweep/SKILL.md
@@ -9,6 +9,56 @@ Autonomous maintainer workflow for producing a requested batch of landable OpenC
 Use for broad issue/PR sweeps where the bar is high and the output is PRs, not notes.
 Do not use for plugin SDK/API boundary work; those need separate architecture review.
 
+## Mandatory orchestration contract
+
+- Only the original user-facing root conversation is the control plane. It
+  decomposes work, assigns explicit issue/PR/file ownership, directly spawns
+  bounded collaboration workers and independent verifiers, coordinates safety,
+  tracks completion, and reports actual worker-verified terminal outcomes.
+- A delegated collaboration subagent is a hands-on execution owner, not another
+  user-facing root orchestrator. It performs its assigned work directly; this
+  contract must not recursively prevent workers from acting. Nested workers
+  require explicit root authorization plus root-tracked capacity, ownership,
+  and completion. Do not create separate Codex app tasks or threads.
+- Workers perform all discovery, source/dependency/Codex inspection,
+  reproductions, issue/PR investigations, edits/refactors, tests/proof/CI,
+  GitHub reads/writes, comments, closures, commits, pushes, and any separately
+  authorized landing. The acting worker personally verifies dependency
+  contracts and inspects sibling `../codex` before making a Codex verdict.
+- Root coordinates checkout/file ownership, serializes shared Git/ref/index
+  mutations and conflicting test/edit activity, tracks exact heads, and enforces
+  authorization, source-trust, security, ownership, and landing gates through
+  assigned workers. Root never switches from orchestration to execution because
+  a worker stalls, fails, or lacks capacity; reassign the bounded work instead.
+
+## Requested authority
+
+- The default deliverable is verified **landable PR URLs**, not merged PRs. An
+  explicitly requested repair-and-prepare sweep authorizes workers to repair,
+  refactor, verify, commit, push, and update PRs within its requested scope;
+  it does not authorize landing without an explicit landing request.
+- `review`, `triage`, `list`, or a `landable-shortlist` alone remains read-only:
+  no unsolicited push, public comment, closure, replacement PR, or merge.
+- An explicit autonomous `process`, `resolve`, or `fix-and-land` request for
+  named items also authorizes workers to close those proven fixed on current
+  `main` and land verified fixes through `$openclaw-pr-maintainer` and the
+  repo-native `scripts/pr` workflow. Preserve exact-head and ownership gates.
+- Explicit full-authority unattended execution is standing approval for all
+  evidence-backed work within the named sweep, including necessary task-owned
+  or repo-managed PR worktrees, credited PR repair/replacement, proof comments,
+  exact-head CI repair, scoped publication, proven current-`main` closures, and
+  requested native landing. Never ask routine approval questions or disturb
+  unrelated dirty changes; the root stays orchestration-only and workers own
+  execution through verified completion. Preserve source-trust, direct acting-
+  worker Codex inspection, required exact-head CI/security/owner gates, and
+  explicit exact-count/scope approval for more than 50 close/reopen actions.
+- Optional unavailable provider/channel live proof may be replaced only when
+  the user explicitly relaxes it: use failing/passing focused owner-boundary
+  regression, direct producer/caller/sibling/dependency-source evidence,
+  independent review, and green exact-head required CI; disclose the missing
+  live/rank-up proof. Never waive mandatory external-API, security-sensitive,
+  risk-required, or explicitly requested live verification.
+
 ## Target
 
 Use `batch_size` from the request, defaulting to `5` and capped at `20`.
@@ -16,14 +66,15 @@ Return up to that many qualified PR URLs, each with:
 
 - bug summary
 - why the fix is low-risk
-- proof: rebased-head local/Testbox/live commands or run IDs
+- proof: exact-head local/Testbox/live commands or run IDs
 - autoreview: clean result on the exact head being shown
 - CI green on the exact pushed PR head
 - issue/duplicate cleanup done or still pending
 
 The URLs may be existing PRs that were reviewed/fixed, or new PRs created from issues/clusters.
-Do not present a PR URL to the maintainer until it has been refreshed on current `main`, left-tested, autoreviewed clean, pushed, and verified green in live GitHub CI.
-If code, tests, changelog, PR body, or branch base changes after autoreview, rerun autoreview before showing the URL.
+Do not present a PR URL until its exact published head is left-tested, autoreviewed clean, and verified green in live GitHub CI.
+Refresh a PR branch only for an actual conflict, failing exact-head check or repo-native guard, explicit user request, or proven material stale-base risk; never rebase merely because `main` advanced.
+If production code, tests, or the reviewed head changes after autoreview, rerun autoreview before showing the URL.
 Do not pad a batch when the bounded search yields fewer qualified PRs.
 
 ## Inputs
@@ -46,15 +97,16 @@ Accept only when all are true:
 - root cause is proven in current code
 - dependency behavior checked via upstream docs/source/types when relevant
 - production/runtime diff is small, ideally much smaller than 500 LOC and always below 500 LOC
+- production LOC is net-neutral or net-negative when feasible; count tests separately and justify any production increase
 - tests may be larger, but focused
 - no new dependency
 - no new config option
 - no backward-incompatible behavior
 - no security/product/owner-boundary decision needed
 - no plugin SDK, public plugin API, or `src/plugin-sdk/**` boundary change
-- no broad refactor smell
+- any refactor stays within the proven root cause, owner boundary, and small-sweep risk limits
 - focused proof is feasible
-- branch can be rebased/refreshed and pushed, or a replacement PR can be created
+- existing branch can be safely updated when needed, or an authorized replacement is justified
 
 Good examples:
 
@@ -68,11 +120,12 @@ Reject:
 - feature requests, new knobs, migrations, release work, workflow policy, support
 - plugin SDK/API boundary changes, including compatibility shims, new SDK methods, SDK exports, or plugin-facing channel/provider seams
 - auth/security boundary changes unless explicitly assigned
-- bugs needing live credentials that are unavailable
-- PRs with red CI unless you fix, rebase, push, and recheck them green
-- PRs you only reviewed locally but did not refresh/push/check live
+- bugs requiring unavailable credentials for mandatory external-API, security,
+  risk-required, or explicitly requested live verification
+- PRs with red CI unless you fix, update the head as needed, push, and recheck them green
+- PRs whose changed head was not pushed or whose exact-head CI was not verified live
 - PRs whose final head has not passed `$autoreview`
-- fixes whose clean shape is a larger architecture move
+- fixes requiring an out-of-scope product, architecture, or ownership decision
 - speculative reports without reproducible/provable cause
 - UI/UX changes requiring product judgment
 
@@ -80,7 +133,8 @@ Reject:
 
 1. Start clean:
    - `git status -sb`
-   - `git pull --ff-only`
+   - update a clean, exclusively owned base checkout with `git pull --ff-only` only when needed and root-authorized
+   - never pull, switch, or mutate a shared checkout while sibling workers are active
    - verify branch is expected, usually `main`
 2. Build candidate clusters:
    - `gitcrawl` open issues/PRs, neighbors, and search
@@ -90,28 +144,28 @@ Reject:
    - read issue/PR body, comments, labels, linked refs, current source, adjacent tests
    - exclude PRs authored by wide-access maintainers until `created_at` is at least 14 days old; only a named PR or explicit maintainer-work request overrides
    - identify opener/author and preserve credit
-   - decide: `repair-existing-pr`, `create-new-pr`, `close-fixed-on-main`, `close-duplicate`, or `reject`
+   - decide: `repair-existing-pr`, `create-new-pr`, `fixed-on-main`, `duplicate`, or `reject`; close only when authorized
 4. Prove before patching:
    - failing test, focused repro, log/source proof, or dependency contract proof
-   - if already fixed on `main`, prove with current source/test/commit and close kindly
+   - if already fixed on `main`, prove with current source/test/commit; close kindly only when authorized
 5. Patch:
-   - prefer existing PR when good and writable
-   - if unwritable or wrong shape, create own PR and preserve useful contributor credit
-   - if no PR exists, create one
+   - rewrite/refactor an existing editable PR into the correct owner-boundary fix first, even when its incoming implementation is the wrong shape
+   - create an authorized replacement only when the original branch is uneditable or unsafe to update; preserve credit and close the source only after the replacement exists and closure is authorized
+   - if no PR exists, create one only when publication is authorized
    - add regression test when it fits
    - release-note context for user-facing fixes in PR body or commit message; credit human reporter/contributor when known
-6. Review, refresh, and publish:
-   - rebase or otherwise refresh the PR branch on current `origin/main`
-   - resolve drift, including newly exposed CI failures, rather than counting the PR as ready
+6. Review, verify, and publish:
+   - refresh the PR branch only for a real conflict, failing exact-head check or wrapper guard, explicit request, or demonstrated material stale-base risk
+   - resolve actual conflicts or CI failures rather than counting the PR as ready
    - do not add `CHANGELOG.md` during normal sweep PRs; release automation generates it from PRs and commits
-   - left-test the rebased head with the smallest meaningful local/Testbox/live command that proves the bug
+   - left-test the exact candidate head with the smallest meaningful local/Testbox/live command that proves the bug
    - run `$autoreview` until no accepted/actionable findings remain before creating, updating, or presenting the PR URL
-   - create/update PR with real body and proof fields
-   - push the exact reviewed head
+   - create/update PR with real body and proof fields when authorized
+   - push the exact reviewed head only when an authorized change requires publication
    - verify live GitHub CI is green for that pushed head; do not count pending, red, dirty, conflicting, or externally blocked PRs in the five
 7. Hygiene:
-   - close duplicates and fixed-on-main issues/PRs with proof as soon as you notice them during the sweep
-   - never mutate more than five associated items in one cluster without explicit confirmation
+   - close duplicates and fixed-on-main issues/PRs with proof only when closure is authorized; otherwise report the evidence
+   - mutate more than five associated items in one cluster only when the explicitly authorized bounded scope includes them; more than 50 close/reopen actions still require separate exact-count/scope approval
    - comments must be kind, concrete, and include proof/PR/commit links
 8. Repeat until `batch_size` landable PR URLs are ready or the bounded qualified queue is exhausted.
 
@@ -124,10 +178,10 @@ validation evidence; inspect the code, tests, and CI before judging correctness.
 ## Existing PR Rules
 
 - Review code path beyond the diff before trusting it.
-- If PR is good: rebase/refresh on current `main`, fix small issues, left-test, autoreview clean, push, and get CI green before showing or counting it.
-- If PR is not good but has a useful idea: recreate locally, co-author when warranted, close original with thanks and explanation.
-- If PR is duplicate or fixed on `main`: comment proof, close.
-- If maintainer cannot push to contributor branch: create own branch/PR, preserve useful commits or credit.
+- If PR is good: fix concrete issues, left-test and autoreview the exact head, publish authorized changes, and require exact-head green CI before showing it.
+- If PR is incomplete or wrong-layer but editable: rewrite/refactor the existing PR at the root-cause owner, preserve author credit, and verify its corrected head.
+- If PR is duplicate or fixed on current `main`: comment proof and close only when closure is authorized; otherwise report the evidence.
+- If the source branch is uneditable or unsafe to update: create a replacement only when authorized, preserve useful commits/credit, and close the original only after the replacement exists and closure is authorized.
 - If CI turns red after local proof, treat that as normal work: inspect the failing job, fix or reject, rerun, and only count the PR once green.
 
 ## Output Ledger
@@ -141,8 +195,10 @@ accepted:
   bug:
   root cause:
   fix:
+  production LOC:
+  test LOC:
   risk:
-  rebase/head:
+  head/base status:
   left-test:
   autoreview:
   CI:

--- a/.agents/skills/openclaw-pr-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-pr-maintainer/SKILL.md
@@ -1,11 +1,45 @@
 ---
 name: openclaw-pr-maintainer
-description: Use immediately for any pasted OpenClaw GitHub issue or PR URL/number, and for OpenClaw issue/PR review, triage, duplicate search, opener identity/who wrote it, author account age/activity, comments, labels, close, land, or maintainer evidence checks.
+description: Use immediately for any pasted OpenClaw GitHub issue or PR URL/number, and for OpenClaw issue/PR orchestration, review, triage, root-cause repair, PR rewrite, duplicate search, opener identity/who wrote it, author account age/activity, comments, labels, close, land, or maintainer evidence checks.
 ---
 
 # OpenClaw PR Maintainer
 
-Use this skill for maintainer-facing GitHub workflow, not for ordinary code changes.
+Use this skill for maintainer-facing GitHub workflows and the code changes needed to finish an authorized issue/PR repair; do not invoke it for unrelated ordinary code changes.
+
+## Parent orchestrates; collaboration subagents do all substantive work
+
+The original, user-facing root conversation is the orchestrator only. Delegate every substantive maintainer operation exclusively to bounded collaboration worker subagents; do not create separate Codex app/project threads or perform implementation work in the parent. A subagent assigned an execution role is the hands-on worker: it performs its scoped operations itself, retains personal inspection/verdict duties, and must not reinterpret this skill as requiring it to become another orchestrator or recursively delegate away ownership. Do not spawn nested helpers unless the root explicitly delegates and tracks them.
+
+- **Parent only:** decompose and prioritize the request; assign disjoint issue/root-cause/file ownership and explicit handoffs; enforce authorization, owner, security, source-trust, proof, and publication gates; coordinate resources and shared-checkout safety; collect and compare worker-reported evidence; dispatch independent verification; resolve routine decisions from existing authority and worker evidence; and communicate outcomes. Remain engaged until the requested close/fix/landing is verified complete or report the exact blocker.
+- **Workers only:** discover issues/PRs; inspect live GitHub state, complete affected source/owner/caller/sibling modules, tests, history, and dependency contracts; reproduce failures and establish root causes; edit, clean up, refactor, and write tests; run authorized tests, checks, CI, and live proof; execute Git/GitHub operations; post proof comments; close items; commit, push, prepare PRs, land fixes, and verify terminal remote state. Require a separate, independent worker to verify closure or landing whenever the active workflow mandates one; otherwise assign one to challenge consequential evidence, including already-fixed closures, when practical.
+- Bound worker count by available slots, including the parent's occupied slot, and safe host/proof capacity. Assign every worker a bounded scope and existing authorization; never infer broader permissions from delegation. Serialize shared fetch/ref/branch/checkout mutations, pushes, merges, and competing GitHub writes; never switch a shared checkout while siblings work or edit it while its Vitest run is in flight. Preserve unfinished worker state during reassignment. Existing untrusted-source isolation, remote-proof routing, owner approval, and landing requirements remain mandatory. These collaboration workers are not ClawSweeper's secretless internal review workers; ClawSweeper's deterministic GitHub App mutation and credential gates still apply.
+- Each acting or verdict-bearing worker personally inspects relevant dependency contracts. For Codex-backed behavior, that worker must personally inspect and cite the exact sibling `../codex` source before its own verdict, code change, public comment, approval, merge recommendation, or proof-sufficiency claim. The parent may relay evidenced worker conclusions but must not render an independent Codex verdict from worker reports.
+- Slow, stalled, or unavailable workers never authorize the parent to implement, investigate source, run proof, or mutate Git/GitHub. Coordinate, wait, safely reassign, or report the exact capacity, evidence, access, or authorization blocker.
+
+## Execute explicit full-authority work unattended
+
+When the user explicitly requests unattended or autonomous execution with full authority, that instruction is standing approval for evidence-backed operations within the requested task scope. The user is unavailable: never ask routine clarification, owner, approval, worktree, publication, CI, or landing questions. The parent remains orchestration-only; assigned hands-on workers resolve ordinary decisions and complete the work.
+
+- Workers may investigate, repair/refactor, test, rewrite editable contributor PRs while preserving credit, create credited replacements when necessary, commit/push task-owned changes, update PRs, post proof, close items proven fixed on current `main`, diagnose/repair/rerun exact-head CI, create repo-managed PR worktrees or necessary task-owned isolated worktrees, run native review/prepare/merge, and verify terminal remote state.
+- Preserve unrelated dirty work. Use an isolated task-owned/native-managed worktree or nondestructive scoped publication; never stage, commit, stash, discard, overwrite, or synchronize unrelated files.
+- Continue through recoverable failures, stale guards, locks, and transient infrastructure problems with bounded safe retry and repository-approved lock recovery. Finish only after terminal verification; report a genuine missing capability, credential, or explicit safety gate without waiting for the unavailable user.
+- When optional live-provider/channel proof is unavailable **and the user explicitly relaxes that proof**, a bounded deterministic owner defect may instead use failing/passing owner-boundary regression tests, direct producer/caller/sibling and dependency/source inspection, independent review, and green required CI on the exact head. Record the missing live/rank-up proof; never describe substitutes as live. Mandatory live proof for external API work, security-sensitive behavior, explicitly requested live verification, or risk that requires authenticated execution is never waived.
+- Preserve source-trust isolation, contributor credit, exact-head required CI, native landing gates, and every acting worker's direct sibling `../codex` inspection. Standing authority never authorizes unrelated/destructive changes, unapproved paid or external side effects, irreversible data/security operations, SQLite schema-version or protocol bumps, dependency overrides, releases, or other actions behind an explicit safety/owner approval gate. Closing/reopening more than 50 items still requires separate explicit approval naming the exact count and scope.
+
+## Finish proven bugs with root-cause repairs
+
+Apply the root `AGENTS.md` Repair Doctrine to every maintainer-requested issue or PR. The goal is to fix real bugs without introducing new bugs, not merely produce a review, preserve an incoming patch, or close an item without proof.
+
+Choose the outcome from live GitHub state, current `main`, affected source and tests, caller/owner/sibling paths, and relevant dependency contracts:
+
+1. **Already fixed:** Prove with high confidence that current `main` already provides the same or better behavior. Identify the canonical fix commit/PR, any relevant release, and focused source, test, or reproduction evidence. When close/sweep/landing action is authorized, comment with that proof and close the issue or superseded PR. If equivalence, current-main behavior, or authority is uncertain, leave it open and state what is missing.
+2. **Confirmed issue:** Reproduce or otherwise prove the defect, trace the violated invariant to its producer or lifecycle owner, and implement the architectural root-cause fix when repair is authorized. Cover the original failure and affected sibling paths with focused regression tests and realistic behavior proof. Do not settle for a downstream guard, workaround, speculative fallback, or passing test that leaves the owner broken.
+3. **Confirmed bug-fix PR:** Independently prove both the defect and whether the proposed change repairs the root cause without regressions. If the PR is already the clean owner-boundary fix, verify and land it when authorized. If it is incomplete, in the wrong layer, needlessly complex, or only masks symptoms, rewrite/refactor the editable PR into the correct fix; verify the rewritten head and then land it. If the source branch cannot safely be edited, create an authorized replacement PR, preserve the original author's credit, and close the source only after the replacement exists. Never merge a speculative or merely plausible patch.
+
+Prefer cleanup, deletion, coherent refactoring, and one canonical flow over additional branches, wrappers, fallbacks, or compatibility shims. Target net-neutral or net-negative **production** LOC; tests are counted separately and useful regression tests may grow freely. Inspect `git diff --numstat` before landing, report production and test deltas separately, and justify any unavoidable production growth with a concrete capability, ownership boundary, security invariant, or public/dependency contract.
+
+Honor the requested action boundary: a fix request authorizes scoped investigation, local edits, and verification; an explicit ship/land/merge request or autonomous repair sweep also authorizes the scoped publication, closing, and landing needed to finish it. An explicit request to autonomously process, resolve, or fix-and-land a named maintainer issue/PR queue is an authorized autonomous repair sweep, including necessary evidence-backed comments, closures, root-cause fixes, pushes, and landing for those items. Ordinary review-only, triage-only, listing, or landable-shortlist requests are read-only: they authorize neither local source edits nor GitHub writes, including labels, assignments, public comments, closures, pushes, or landing, unless separately authorized. For authorized end-to-end landing work, a review summary or unlanded local patch is not completion: finish with a proven already-fixed close, a verified root-cause repair landed, or a specific evidence, ownership, product, safety, or authorization blocker.
 
 ## Start issue and PR triage with gitcrawl
 
@@ -24,13 +58,13 @@ gitcrawl search openclaw/openclaw --query "<scope or title keywords>" --mode hyb
 gitcrawl cluster-detail openclaw/openclaw --id <cluster-id> --member-limit 20 --body-chars 280 --json
 ```
 
-## Claim specific review targets
+## Inspect specific targets; claim only when authorized
 
-When a maintainer asks Codex to review, triage, fix, or land a specific OpenClaw issue/PR, check assignment before deep work.
+When a maintainer asks Codex to review, triage, fix, or land a specific OpenClaw issue/PR, have the assigned collaboration worker inspect live assignment before deep work. Assignment itself is a public GitHub write.
 
 - Identify the requesting maintainer's GitHub login. In this environment, default Peter to `steipete`; if another maintainer is clearly the requester, use that maintainer's bare login.
 - Read current assignees with live `gh issue view` / `gh pr view`; `gitcrawl` is not enough for assignment state.
-- If unassigned, assign the requester before deep review. This is allowed for specific requested targets; do not auto-assign broad discovery candidates or shortlists.
+- If unassigned, assign the requester only when an explicit land, fix-and-land, autonomous-resolution, or assignment request authorizes that mutation. For fix-only, review-only, triage-only, listing, or shortlist requests, report `unassigned` without assigning unless assignment is separately requested. Never auto-assign broad discovery candidates or shortlists.
 - If assigned to someone else, say so clearly before analysis and include assignment age:
   - fresh: assigned within 6h; treat as actively owned unless user explicitly asks to continue or reassign
   - stale: assigned 6h+ ago; treat as ownership hint, not a hard block; continue only with that caveat
@@ -118,9 +152,9 @@ Exceptions:
 
 ## Apply close and triage labels correctly
 
-- If an issue or PR matches an auto-close reason, apply the label and let `.github/workflows/auto-response.yml` handle the comment/close/lock flow.
+- If an issue or PR matches an auto-close reason, apply its label only when labeling or closure is explicitly authorized; let `.github/workflows/auto-response.yml` handle the comment/close/lock flow. Without that authority, report the matching reason without mutating GitHub.
 - Do not manually close plus manually comment for these reasons.
-- If an issue/PR is already fixed on current `main` or solved by a new release, comment with proof plus the canonical commit/PR/release, then close it.
+- If an issue/PR is provably fixed on current `main` and closing is authorized, comment with focused proof plus the canonical commit/PR and any relevant release, then close it.
 - `r:*` labels can be used on both issues and PRs.
 - Current reasons:
   - `r: skill`
@@ -134,20 +168,20 @@ Exceptions:
   - `invalid`
   - `dirty` for PRs only
 
-## Select small high-confidence triage candidates
+## Select explicitly small high-confidence triage candidates
 
-When asked for `X` issues or PRs to triage, `X` means qualified candidates, not sampled threads.
+When explicitly asked for `X` small, easy, or narrowly scoped issues or PRs to triage, `X` means qualified candidates, not sampled threads. These shortlist filters do not apply to a confirmed issue/PR selected for end-to-end repair; do not reject its correct root-cause fix merely because a coherent owner-boundary refactor is required.
 
-Issue triage is review/prove/patch-local by default:
+Plain review, triage, listing, and shortlist requests are read-only: workers inspect and report candidates without editing files or mutating GitHub. Only an explicit scoped fix request authorizes this patch-local/proof flow; shipping and public writes still require separate approval:
 
 1. Review the issue body, comments, related threads, current code, and adjacent tests.
-2. Fix only issues that are easy, high-confidence, and narrowly owned by the implicated path.
+2. Fix only shortlisted issues whose root cause and owning architectural neighborhood are high-confidence.
 3. Add focused regression proof when practical.
 4. Stop with the dirty diff, touched files, and test/gate output for maintainer review.
 5. After maintainer approval to ship, make one commit per accepted fix, with release-note context in the PR body or commit message when user-facing.
-6. Pull/rebase, push, then comment and close only the issues that were fixed or explicitly triaged closed.
+6. After authorization, synchronize and push for the actual destination: direct `main` must rebase onto latest `origin/main` without merge commits; rebase a PR only for an actual conflict, failing native guard/exact-head check, explicit user request, or material stale-base risk, never merely because `main` advanced. Comment and close only issues proven fixed on `main` or explicitly triaged closed.
 
-Do not batch unrelated issue fixes into one commit. Do not publish, comment, close, or label during the review/prove phase.
+Do not batch unrelated issue fixes into one commit. Do not publish, assign, comment, close, or label during the review/prove phase.
 
 Missing `CHANGELOG.md` is not a PR review finding or merge blocker. If landing/fixing a user-visible change, make sure the PR body or commit message captures the release-note context; never ask or block solely on it.
 
@@ -173,7 +207,7 @@ Output only qualifying candidates, with: ref, surface, proof, cause, fix sketch,
 
 - Start every PR review with 1-3 plain sentences explaining what the change does and why it matters. Put this before `Findings`.
 - Then list findings first. If none, say `No blocking findings` or `No findings`.
-- Show size near the top as `LOC: +<additions>/-<deletions> (<changedFiles> files)`, using live PR stats or local diff stats.
+- Show size near the top as `Production LOC: +<additions>/-<deletions> (net <delta>) | Tests: +<additions>/-<deletions>`, classifying per-file `git diff --numstat` or live PR file stats. Optional aggregate PR totals never replace the production/test split; justify positive production growth.
 - Always answer: bug/behavior being fixed, PR/issue URL and affected surface, provenance for regressions when traceable, and best-fix verdict.
 - For bug/regression fixes, include a compact `Provenance:` line after cause/root-cause when a bounded history pass can identify it. Use `git log -S/-G`, `git blame`, linked PRs/issues, and tests.
 - Provenance must separate roles when they differ: blamed code author username, blamed PR author username, blamed PR merger/committer username, automerge trigger when known, current PR author username, PR number, and date. Do not collapse them into one "introduced by" actor.
@@ -187,6 +221,7 @@ LOC proof:
 ```bash
 gh pr view <number> --json additions,deletions,changedFiles \
   --jq '"LOC: +\(.additions)/-\(.deletions) (\(.changedFiles) files)"'
+git diff --numstat <base-sha>...<head-sha>
 ```
 
 ## Read beyond the diff
@@ -227,21 +262,29 @@ If the best-fix answer is only "maybe", keep reading or state the missing eviden
 ## Enforce the bug-fix evidence bar
 
 - Never merge a bug-fix PR based only on issue text, PR text, or AI rationale.
-- Whenever feasible, use Crabbox (`$crabbox`) for end-to-end verification before
-  commenting that a bug is unreproducible, closing an issue, or opening/landing
-  a fix PR. Prefer a real packaged/Docker/live lane that exercises the reported
-  user flow over unit-only proof.
+- Choose the strongest proof proportionate to the owner boundary and risk. When
+  feasible, prefer Crabbox (`$crabbox`) or a real packaged/Docker/live lane
+  exercising the reported user flow before closing or landing; do not confuse
+  packaged, mocked, Docker, or unit proof with live authenticated proof.
+- For a bounded deterministic owner defect, optional unavailable provider/channel
+  live proof may be replaced **only when the user explicitly relaxes it** by a
+  failing/passing focused owner-boundary regression, direct producer/caller/sibling
+  and dependency/source contract inspection, independent review, and exact-head
+  green required CI. Record the missing live/rank-up evidence openly. External
+  API work, security-sensitive changes, explicitly requested live proof, and risk
+  requiring real authenticated execution retain their mandatory live-proof gate.
 - Before landing, require:
   1. symptom evidence such as a repro, logs, or a failing test
   2. a verified root cause in code with file/line
   3. blame-backed provenance for regressions when traceable, including blamed PR merger and automerge trigger when known, or commit SHA/date when no PR is traceable
   4. a fix that touches the implicated code path
   5. a regression test when feasible, or explicit manual verification plus a reason no test was added
-- If the claim is unsubstantiated or likely wrong, request evidence or changes instead of merging.
+- If the claim is unsubstantiated or likely wrong, obtain the missing evidence or make authorized owner-boundary repairs; never merge without proof.
 - If the linked issue appears outdated or incorrect, correct triage first. Do not merge a speculative fix.
-- If Crabbox/E2E proof is blocked, say exactly why and use the closest available
-  local, Docker, mocked, or targeted proof. Do not present unit tests as real
-  behavior proof.
+- If optional Crabbox/E2E/live proof is unavailable and the user explicitly
+  relaxes it, state the exact gap and use the strongest focused owner-boundary
+  and exact-head CI evidence. Never claim substitutes are live or waive mandatory
+  external-API, security, or explicitly requested live proof.
 
 ## Close low-signal manual PRs carefully
 
@@ -288,9 +331,9 @@ gh search issues --repo openclaw/openclaw --match title,body --limit 50 \
   on the maintainer host. Let its preflight fail loudly when one is missing.
   Tests that source `scripts/pr-lib/*` directly must provide the same command
   surface instead of weakening the production wrapper for a minimal test image.
-- At the start of code-changing or landing work that will need tests or heavy
-  proof, classify source trust and pre-warm the safe backend through `$crabbox`
-  in the background. Trusted maintainer code defaults to Blacksmith Testbox;
+- Classify source trust before executing code-changing or landing proof; acquire
+  the safe backend lazily through `$crabbox` at the first heavy proof, never
+  pre-warm it at task start. Trusted maintainer code defaults to Blacksmith Testbox;
   contributor/fork code stays untrusted unless a maintainer explicitly approves
   credentialed execution after review; it uses secretless fork CI or
   sanitized direct AWS Crabbox with `CRABBOX_ENV_ALLOW=CI`,
@@ -305,14 +348,13 @@ gh search issues --repo openclaw/openclaw --match title,body --limit 50 \
   code. Force public networking, disable and
   unset inherited Tailscale/exit-node settings, and fail closed unless
   `crabbox inspect` reports no Tailscale state before any script. Rewarm after
-  any head change. Continue
-  review/editing while it hydrates, sync every run, reuse the lease, then stop
-  it before handoff. Skip warmup for read-only triage and docs-only work.
+  any head change, sync every run, reuse the lease, then stop it before handoff.
+  Do not acquire a backend for read-only triage or docs-only work.
 - Never mention release-note bookkeeping in review-only output. It is landing
   or release-generation mechanics, not a correctness finding.
 - If bot review conversations exist on your PR, address them and resolve them yourself once fixed.
 - Leave a review conversation unresolved only when reviewer or maintainer judgment is still needed.
-- Before landing any PR with non-trivial code changes, run `$autoreview` until no accepted/actionable findings remain, unless equivalent manual review already covered it, the change is trivial/docs-only, or the user opts out.
+- Before landing any PR with non-trivial code changes, run fresh `$autoreview` until no accepted/actionable findings remain; prior CI, ClawSweeper, or manual review is not a substitute. Skip only for truly trivial/docs-only changes or when the user explicitly opts out.
 - When an agent is landing or merging a PR targeting `main`, use only the repo-native `scripts/pr` wrapper: run `scripts/pr review-init <PR>`, follow its emitted checkout/guard guidance, initialize and complete review artifacts with `scripts/pr review-artifacts-init <PR>`, validate them with `scripts/pr review-validate-artifacts <PR>`, then run `OPENCLAW_TESTBOX=1 scripts/pr prepare-run <PR>` and `scripts/pr merge-run <PR>`. The Testbox flag is mandatory for agents: it verifies hosted CI/Testbox on the current head or reuses a patch-identical pre-rebase run green within 24 hours instead of running full `pnpm` gates locally. Do not rebase only because `main` advanced; behind-main drift is advisory unless strict drift is explicitly enabled, while GitHub still blocks conflicts.
 - Use `scripts/committer "<msg>" <file...>` for scoped commits instead of manual `git add` and `git commit`.
 - Keep commit messages concise and action-oriented.
@@ -322,5 +364,5 @@ gh search issues --repo openclaw/openclaw --match title,body --limit 50 \
 
 ## Extra safety
 
-- If a close or reopen action would affect more than 20 PRs, ask for explicit confirmation with the exact count and target query first.
-- `sync` means: if the tree is dirty, commit all changes with a sensible Conventional Commit message, then `git pull --rebase`, then `git push`. Stop if rebase conflicts cannot be resolved safely.
+- Closing or reopening more than 20 PRs needs an explicitly authorized bounded count and scope. Standing full authority covers an already specified count/scope; more than 50 still requires separate explicit exact-count/scope approval under root policy.
+- `sync` means synchronize only task-owned, explicitly authorized changes. Preserve unrelated dirty files untouched; use an isolated task-owned/native-managed worktree or nondestructive scoped publication when needed. Never commit all dirty changes, stage/stash/discard unrelated edits, or pull/rebase a dirty shared checkout; resolve only task-owned conflicts safely.

--- a/.agents/skills/openclaw-small-bugfix-sweep/SKILL.md
+++ b/.agents/skills/openclaw-small-bugfix-sweep/SKILL.md
@@ -5,22 +5,97 @@ description: Fix only small, high-certainty OpenClaw bugs from a pasted issue/PR
 
 # OpenClaw Small Bugfix Sweep
 
-Batch workflow for pasted OpenClaw issue/PR refs.
-Execute, do not summarize.
-Triage reviews, proves, and patches local fixes first; publishing waits for Peter's manual review.
+Batch workflow for pasted OpenClaw issue/PR refs. The user's top-level
+conversation is the orchestration-only parent; its bounded collaboration
+subagents are hands-on execution owners. The parent coordinates them and
+reports their verified results. Workers publish or land only when authorized.
 
-## Peter Review Gate
+## Mandatory coordinator/worker boundary
 
-Peter always wants to review code before commits.
-Default flow:
+- The parent only assigns issue/PR owners and independent validation workers,
+  coordinates shared checkout/file ownership and mutation slots, tracks evidence
+  and authorization gates, handles genuine owner decisions, and reports results.
+- The parent never directly discovers or inspects items; reads affected source,
+  dependencies, or sibling `../codex`; diagnoses, edits, reproduces, or tests;
+  runs Git/GitHub operations; comments, closes, commits, pushes, watches CI,
+  prepares, or lands. Delegate every operational step to collaboration subagents.
+- Assign one bounded worker ownership of each item or duplicate/root-cause
+  cluster. Use separate workers for independent closure/landing validation and,
+  when useful, discovery, source history, dependency contracts, sibling paths,
+  regression proof, and CI follow-through. An item worker may spawn a helper
+  only after the root explicitly authorizes that specific helper and tracks its
+  scope, ownership, capacity, and completion; the item owner remains hands-on
+  and personally checks consequential evidence before acting.
+- State each worker's execution/verification role, assigned item, file/checkout
+  ownership, mutation authority, and reporting obligation in its assignment. A
+  delegated worker reading this skill performs its assigned work itself; it does
+  not misclassify itself as the orchestration-only parent or recursively
+  delegate its entire assignment.
+- Assign disjoint writable files/checkouts before parallel implementation.
+  Serialize shared checkout/ref/branch changes, overlapping file writes,
+  commits, pushes, GitHub mutations, and landing. Do not edit a shared checkout
+  while another worker's tests are running. Never create new worktrees without
+  explicit user authorization; an explicit full-authority unattended or landing
+  request authorizes repo-managed PR worktrees and necessary isolated task-owned
+  worktrees. Never stage, stash, discard, or overwrite unrelated dirty changes.
+- Bound worker concurrency by available agent slots, including the parent, and
+  host/proof capacity. Before replacing a failed or interrupted worker, preserve
+  its claimed items, patches, checkout ownership, and evidence; explicitly hand
+  them to one replacement without duplicating or discarding unfinished work.
+- Classify source trust before execution. Never run untrusted contributor code,
+  scripts, config, hooks, tests, or wrappers locally; use the repository's
+  sanitized remote-proof path. Route heavy trusted proof to the selected remote
+  box unless the documented trusted-backend fallback applies.
+- For Codex-backed behavior, every worker making a technical verdict or taking
+  a related action must personally inspect the exact sibling `../codex` source
+  first and cite the inspected files/lines. The parent may relay those worker
+  findings but must not present another agent's inspection as its own verdict.
+- Keep workers assigned through reproduction, repair, independent validation,
+  exact-head CI, authorized closure/landing, and verified terminal state. A
+  pending check or submitted mutation is not completion; delegate follow-up.
+
+This is the collaboration-subagent model used by
+`openclaw-autonomous-issue-sweep`, not an invitation to create user-owned Codex
+app tasks or to perform sweep work in the parent conversation.
+
+## Scope and authorization gate
+
+Keep this sweep limited to small, high-certainty root-cause repairs. Do not substitute a workaround when a coherent owner-boundary cleanup or refactor is the correct fix; escalate if that repair exceeds the explicitly requested sweep scope.
+
+Default flow when fixing is authorized:
 
 1. Review each issue deeply enough to prove current behavior and root cause.
-2. Fix only easy, high-confidence bugs with narrow ownership and focused proof.
-3. Stop with the dirty diff summary, touched files, and test/gate output for Peter's manual review.
-4. After Peter approves shipping, make one commit per accepted fix, with a changelog entry for each user-facing fix.
-5. Pull/rebase, push, then comment and close only the fixed or explicitly triaged-closed issues.
+2. Fix only high-confidence bugs whose owner-boundary repair fits the requested small-sweep scope.
+3. Without explicit authorization to publish or land, stop with the dirty diff summary, touched files, and test/gate output for maintainer review.
+4. When shipping is authorized, make one commit per accepted fix; put user-facing release-note context in the PR body or commit message. Never edit release-only `CHANGELOG.md`.
+5. When authorized, sync for the destination: direct `main` must rebase onto latest `origin/main` without merge commits; PRs follow native landing guards and refresh/rebase only for an actual conflict, failing guard/exact-head check, explicit user request, or demonstrated material stale-base risk, never merely because `main` advanced. Push, comment with proof, and close only authorized fixed or explicitly triaged-closed issues.
 
-Do not batch unrelated issue fixes into one commit. Do not push, create PRs, comment, close, label, land, merge, or otherwise publish during the review/prove phase.
+An explicit request to autonomously process or resolve a named issue/PR batch,
+or to fix and land it, authorizes assigned workers to perform the scoped
+root-cause fixes, commits, pushes, PR updates, proof comments, evidence-backed
+fixed-on-current-`main` closures, and exact-head landings needed to resolve those
+named items. A fix-only request permits local changes and proof, not publishing
+or landing; review, triage, or list alone is read-only. Never batch unrelated
+fixes into one commit, mutate unrelated items, exceed the requested sweep scope,
+or bypass owner, security, trust, authorization, or proof gates. Do not invent
+an additional personal-review gate.
+
+Explicit full-authority unattended execution is standing approval for assigned
+workers to complete all evidence-backed, task-scoped investigation, repair,
+credited PR rewrite/replacement, proof comments, CI diagnosis/fixes/reruns,
+task-owned publication/worktrees, proven current-`main` closures, requested
+native landing, and terminal remote verification. Resolve routine decisions
+without asking the unavailable user; recover safely from transient failures
+and locks. Preserve unrelated edits, exact-head required CI, source trust,
+acting-worker direct Codex inspection, contributor credit, security/owner
+gates, and separate exact-count/scope approval for more than 50 closures.
+Only when the user explicitly relaxes unavailable **optional** provider/channel
+live proof may focused failing/passing owner-boundary regression, direct
+producer/caller/sibling/dependency evidence, independent review, and exact-head
+green CI substitute; disclose the missing live/rank-up proof. Mandatory
+external-API, security-sensitive, risk-required, or requested live proof is
+never waived. Report only genuine credential, capability, or explicit safety
+blockers without waiting for the user.
 
 ## Companion Skills
 
@@ -28,27 +103,32 @@ Use `$gitcrawl` first, `$openclaw-pr-maintainer` for live GitHub hygiene, `$gith
 
 ## Loop
 
-For each ref:
+For each ref, the assigned worker performs the operational loop; the parent only
+coordinates its progress and receives evidence:
 
 1. Read live target with `gh`.
 2. Check `gitcrawl` for related, duplicate, closed, or already-fixed threads.
 3. Read body, comments, linked refs, changed files, current code, adjacent tests, and dependency contracts when relevant.
 4. Trace the real runtime path.
-5. For issues: fix locally only if this is a bug, current code proves root cause, the implicated path is clear, and a narrow patch is cleaner than refactor.
-6. For PRs: decide `ready-to-merge`, `needs-fixup`, or `skip`; do not alter PR branches unless explicitly asked.
-7. Add focused regression proof when practical for local issue fixes or PR readiness checks.
-8. Run the smallest meaningful gate.
-9. Continue until every pasted ref is fixed or classified.
+5. If current `main` already fixes the claimed defect, prove current source/tests and the canonical commit/PR. Classify it `fixed-on-main`; comment with proof and close only when authorized.
+6. For confirmed open issues, repair the violated invariant at its owner; include a small coherent cleanup/refactor when it is the cleanest root-cause fix.
+7. For PRs, independently verify the defect, owner-boundary fix, sibling paths, and exact-head checks. Rewrite an inadequate editable PR when repair/landing is authorized; otherwise report the needed fixup.
+8. Add focused regression proof when practical for local issue fixes or PR readiness checks.
+9. Run the smallest meaningful gate.
+10. Continue until every pasted ref is fixed, proven already resolved, landed, or classified with a concrete blocker.
 
-No subagents unless explicitly requested.
+An independent worker challenges proposed fixed-on-main closures and
+nontrivial repair/landing proof before an authorized item owner performs the
+final mutation. Missing agreement or applicable source/dependency proof,
+exact-head CI, trust routing, ownership approval, or authorization is a concrete
+blocker, not permission for the parent to take over the work.
 
 ## Skip If
 
 - not a bug
 - config/docs/workflow/release/support/dependency/product work
 - repro or root cause is uncertain
-- larger refactor or owner-boundary change is cleaner
-- already fixed on current `main`
+- the correct coherent root-cause repair exceeds the explicitly requested small-sweep scope; classify as `needs-human` or record a named follow-up instead of landing a workaround
 - dependency behavior is guessed
 - no focused proof is feasible
 
@@ -58,21 +138,26 @@ Skip with terse reason. Do not pad with low-confidence fixes.
 
 - owner module first; generic seam only when required
 - existing patterns/helpers/types
-- no drive-by refactors
+- coherent owner-boundary cleanup/refactoring; no unrelated drive-by refactors
+- prefer net-neutral or net-negative production LOC; count tests separately and add useful regression coverage
 - tests near failing surface
 - docs only for changed public behavior
-- no commit during the review/prove phase
-- after Peter approves shipping, one commit plus changelog per accepted user-facing fix
-- no push/create PR/comment/close/label/land/merge until Peter approves shipping after review
+- no commit during review/prove-only work
+- when shipping is authorized, one commit per accepted fix; capture user-facing release-note context in the PR body or commit message, never `CHANGELOG.md`
+- no push/create PR/comment/close/label/land/merge without authorization for that action
 
 ## PR Rules
 
-- `ready-to-merge`: code is good, current head checked, required proof is green or clearly pending only external CI; list for maintainer merge or `@clawsweeper automerge`
-- `needs-fixup`: small bug is clear, but PR branch needs changes; list exact files/tests and wait for explicit fix/push/automerge instruction
-- `skip`: broad, stale, speculative, config/product/security/release, owner-boundary, or refactor-sized
-- if source PR is untrusted/uneditable, do not create a replacement PR during sweep
+- `ready-to-merge`: the root-cause fix is clean, current head is verified, and required exact-head checks are green; use the repo-native landing workflow only when merging is authorized
+- `needs-ci`: proof is sound but required exact-head checks remain pending or unavailable; for an authorized land request, monitor those checks and finish landing if they pass, or report the concrete external blocker
+- `needs-fixup`: repair/rewrite an editable PR when authorized; otherwise list exact files/tests and the missing authorization
+- `skip`: stale, speculative, explicitly out of scope, or requiring unavailable product/security/release approval
+- if a useful source PR is unsafe or uneditable, create a replacement only when explicitly authorized; preserve contributor credit and close the source only after the replacement exists
 
 ## Output Shape
 
-Ledger: `fixed-local`, `ready-to-merge`, `needs-fixup`, `skipped`, `needs-human`.
-Final: issue files left on disk, PRs ready for merge/automerge, tests/gates, skip reasons.
+Ledger: `fixed-local`, `fixed-on-main`, `closed-fixed-on-main`, `ready-to-merge`, `needs-fixup`, `needs-ci`, `landed`, `skipped`, `needs-human`.
+Track each item's assigned worker, independent verifier, owned files/checkout,
+evidence, exact head, authorization, and terminal state.
+Final: worker-verified local or landed fixes, proven already-fixed items,
+production/test LOC deltas, tests/gates, and concrete blockers or skip reasons.


### PR DESCRIPTION
## What Problem This Solves

Explicitly authorized unattended maintainer work could still stall on routine approval questions, invented personal-review gates, recursive delegation, unnecessary rebases, eager proof-backend startup, or unsafe handling of unrelated local changes. Existing companion sweep instructions also disagreed with the repository’s release-only changelog policy.

## Why This Change Was Made

Align the four existing maintainer and sweep skill documents around one execution model: the original user-facing conversation only orchestrates, while explicitly assigned collaboration workers personally perform bounded, evidence-backed investigation, root-cause repairs, credited PR updates or replacements, necessary task-owned or repo-managed worktree operations, exact-head CI follow-through, and authorized native landing. Explicit full-authority unattended requests provide standing approval only within that named task scope; ordinary read-only, fix-only, owner, security, source-trust, contributor-credit, direct Codex-inspection, and exact-head proof boundaries remain intact.

## User Impact

Maintainers can explicitly authorize a complete unattended issue or PR workflow without repeated routine permission prompts, while unrelated dirty work, contributor ownership, required review, and safety boundaries remain protected. No runtime behavior, product code, tests, configuration, dependencies, or release changelog changes.

## Evidence

- Instruction-only change: exactly four existing skill documents, +277/-94 lines; production-code delta 0 and test-code delta 0.
- An independent reviewer read every complete skill and exact diff; verified all four frontmatter blocks, existing `oxfmt --check`, and `git diff --check`; and classified the change as documentation-only.
- GitHub-signed commit `1701fdc64845ec553e86b62eb6650345b72bfa5b` was verified as `VALID`, with one parent and exactly the four reviewed server-side blob IDs.
- All unrelated dirty source-file SHA-256 hashes and the existing Git index remain unchanged; no local staging, checkout, ref, or worktree mutation was used to publish.
- Unavailable optional provider/channel live proof can be substituted only when the user explicitly relaxes it; mandatory external-API, security-sensitive, risk-required, or specifically requested live proof is never waived.
- AI-assisted maintainer documentation update; independent human-owned policy boundaries and exact-head hosted CI remain in force.
