### PR TITLE
fix(gateway): strip internal runtime scaffolding from inbound user-te…

### DIFF
--- a/src/gateway/chat-display-projection.sanitize.ts
+++ b/src/gateway/chat-display-projection.sanitize.ts
@@ -6,6 +6,7 @@ import {
   resolveAssistantMessagePhase,
 } from "../shared/chat-message-content.js";
 import { stripInlineDirectiveTagsForDisplay } from "../utils/directive-tags.js";
+import { stripInternalRuntimeScaffolding } from "../infra/outbound/protocol-scaffolding.js";
 import {
   isToolHistoryBlockType,
   isToolResultHistoryBlockType,
@@ -52,7 +53,9 @@ export function sanitizeChatHistoryContentBlock(
     changed = true;
   }
   if (typeof entry.text === "string") {
-    const stripped = stripInlineDirectiveTagsForDisplay(entry.text);
+    const stripped = stripInlineDirectiveTagsForDisplay(
+      stripInternalRuntimeScaffolding(entry.text),
+    );
     if (preserveExactToolPayload) {
       entry.text = stripped.text;
       changed ||= stripped.changed;
@@ -63,7 +66,9 @@ export function sanitizeChatHistoryContentBlock(
     }
   }
   if (typeof entry.content === "string") {
-    const stripped = stripInlineDirectiveTagsForDisplay(entry.content);
+    const stripped = stripInlineDirectiveTagsForDisplay(
+      stripInternalRuntimeScaffolding(entry.content),
+    );
     if (preserveExactToolPayload) {
       entry.content = stripped.text;
       changed ||= stripped.changed;
@@ -361,7 +366,9 @@ export function sanitizeChatHistoryMessage(
     role === "assistant" && !shouldPreserveAssistantControlReplyText(entry);
 
   if (typeof entry.content === "string") {
-    const stripped = stripInlineDirectiveTagsForDisplay(entry.content);
+    const stripped = stripInlineDirectiveTagsForDisplay(
+      stripInternalRuntimeScaffolding(entry.content),
+    );
     const controlStripped = stripAssistantControlTokens
       ? stripSuppressedControlReplyToken(stripped.text)
       : stripped.text;
@@ -420,7 +427,9 @@ export function sanitizeChatHistoryMessage(
   }
 
   if (typeof entry.text === "string") {
-    const stripped = stripInlineDirectiveTagsForDisplay(entry.text);
+    const stripped = stripInlineDirectiveTagsForDisplay(
+      stripInternalRuntimeScaffolding(entry.text),
+    );
     const controlStripped = stripAssistantControlTokens
       ? stripSuppressedControlReplyToken(stripped.text)
       : stripped.text;


### PR DESCRIPTION
…xt display

<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

<!--
Describe the concrete user, product, or operational problem.
For fixes, begin with:
"Fixes an issue where users <do X> would <experience Y> when <condition>."
or:
"Resolves a problem where..."

Name the affected UI surface or workflow. Do not describe the code-level cause here.
-->

## Why This Change Was Made

<!--
In one or two sentences, explain the complete shipped solution, key design
decisions, and relevant boundaries or non-goals. Include implementation detail
only when it helps reviewers understand user-visible behavior or risk.
Avoid file-by-file narration.
-->

## User Impact

<!--
State what users, operators, or developers can now do or expect. Lead with the
concrete benefit and use user-facing language. If there is no user-visible
impact, say so plainly.
-->

## Evidence

<!--
Show the most useful proof that this change works. Screenshots, screencasts,
terminal output, focused tests, CI results, live observations, redacted logs,
and artifact links are all useful. Include before/after evidence for visual
changes when it clarifies the result.

Reviewers will inspect the code, tests, and CI. Use this section to make the
validation easy to understand, not to restate the diff.
-->
