### PR TITLE
refactor(msteams): consolidate channel action target resolution

### DIFF
--- a/docs/channels/msteams.md
+++ b/docs/channels/msteams.md
@@ -165,6 +165,9 @@ Example:
 - Scope group/channel replies by listing teams and channels under `channels.msteams.teams`.
 - Use stable Teams conversation IDs from Teams links as keys, not mutable display names (see [Team and Channel IDs](#team-and-channel-ids-common-gotcha)).
 - When `groupPolicy="allowlist"` and a teams allowlist is present, only listed teams/channels are accepted (mention-gated).
+- `groupAllowFrom` authorizes group senders, not delegated Graph reads of other channels. If an existing configuration only sets `groupAllowFrom`, keep the default `groupPolicy: "allowlist"` and configure the target under `channels.msteams.teams.<team>.channels`.
+- Alternatively, deliberately set `groupPolicy: "open"` for broader delegated reads. This also admits **any group sender** (still mention-gated by default), so it is less restrictive than a scoped team/channel route.
+- Direct-operator reads and reads in the current conversation do not require an additional team/channel route.
 - The configure wizard accepts `Team/Channel` entries and stores them for you.
 - On startup, OpenClaw resolves team/channel and user allowlist names to IDs (when Graph permissions allow) and logs the mapping. Unresolved names are kept as typed but ignored for routing unless `channels.msteams.dangerouslyAllowNameMatching: true` is set.
 
@@ -175,10 +178,11 @@ Example:
   channels: {
     msteams: {
       groupPolicy: "allowlist",
+      groupAllowFrom: ["00000000-0000-0000-0000-000000000000"],
       teams: {
-        "My Team": {
+        "19:team-id@thread.tacv2": {
           channels: {
-            General: { requireMention: true },
+            "19:channel-id@thread.tacv2": { requireMention: true },
           },
         },
       },

--- a/extensions/msteams/src/channel.actions.test.ts
+++ b/extensions/msteams/src/channel.actions.test.ts
@@ -1255,28 +1255,33 @@ describe("msteamsPlugin message actions", () => {
 
   it.each([
     {
+      action: "read",
+      params: { to: graphChannelTarget, messageId: "msg-1" },
+      runtimeMock: getMessageMSTeamsMock,
+    },
+    {
       action: "edit",
-      params: { to: targetChannelId, messageId: "msg-1", content: "updated" },
+      params: { to: graphChannelTarget, messageId: "msg-1", content: "updated" },
       runtimeMock: editMessageMSTeamsMock,
     },
     {
       action: "delete",
-      params: { to: targetChannelId, messageId: "msg-1" },
+      params: { to: graphChannelTarget, messageId: "msg-1" },
       runtimeMock: deleteMessageMSTeamsMock,
     },
     {
       action: "pin",
-      params: { to: targetChannelId, messageId: "msg-1" },
+      params: { to: graphChannelTarget, messageId: "msg-1" },
       runtimeMock: pinMessageMSTeamsMock,
     },
     {
       action: "unpin",
-      params: { to: targetChannelId, pinnedMessageId: "pin-1" },
+      params: { to: graphChannelTarget, pinnedMessageId: "pin-1" },
       runtimeMock: unpinMessageMSTeamsMock,
     },
     {
       action: "react",
-      params: { to: targetChannelId, messageId: "msg-1", emoji: "like" },
+      params: { to: graphChannelTarget, messageId: "msg-1", emoji: "like" },
       runtimeMock: reactMessageMSTeamsMock,
     },
   ])("rejects a blocked $action target before the provider operation", async (testCase) => {

--- a/extensions/msteams/src/channel.ts
+++ b/extensions/msteams/src/channel.ts
@@ -263,15 +263,17 @@ function resolveActionUploadFilePath(params: Record<string, unknown>): string | 
   return undefined;
 }
 
-function resolveRequiredActionTarget(params: {
+type MSTeamsActionTargetParams = {
   actionLabel: string;
   toolParams: Record<string, unknown>;
   currentChannelId?: string | null;
   currentGraphChannelId?: string | null;
   currentChatType?: "direct" | "group" | "channel" | null;
   graphOnly?: boolean;
-}): string | ReturnType<typeof actionError> {
-  const to = params.graphOnly
+};
+
+function resolveMSTeamsActionTarget(params: MSTeamsActionTargetParams): string {
+  return params.graphOnly
     ? resolveGraphActionTarget(
         params.toolParams,
         params.currentChannelId,
@@ -279,125 +281,42 @@ function resolveRequiredActionTarget(params: {
         params.currentChatType,
       )
     : resolveActionTarget(params.toolParams, params.currentChannelId);
+}
+
+async function runWithRequiredActionTarget<T>(
+  params: MSTeamsActionTargetParams & { run: (to: string) => Promise<T> },
+): Promise<T | ReturnType<typeof actionError>> {
+  const to = resolveMSTeamsActionTarget(params);
   if (!to) {
     return actionError(`${params.actionLabel} requires a target (to).`);
-  }
-  return to;
-}
-
-function resolveRequiredActionMessageTarget(params: {
-  actionLabel: string;
-  toolParams: Record<string, unknown>;
-  currentChannelId?: string | null;
-  currentGraphChannelId?: string | null;
-  currentChatType?: "direct" | "group" | "channel" | null;
-  graphOnly?: boolean;
-}): { to: string; messageId: string } | ReturnType<typeof actionError> {
-  const to = params.graphOnly
-    ? resolveGraphActionTarget(
-        params.toolParams,
-        params.currentChannelId,
-        params.currentGraphChannelId,
-        params.currentChatType,
-      )
-    : resolveActionTarget(params.toolParams, params.currentChannelId);
-  const messageId = resolveActionMessageId(params.toolParams);
-  if (!to || !messageId) {
-    return actionError(`${params.actionLabel} requires a target (to) and messageId.`);
-  }
-  return { to, messageId };
-}
-
-function resolveRequiredActionPinnedMessageTarget(params: {
-  actionLabel: string;
-  toolParams: Record<string, unknown>;
-  currentChannelId?: string | null;
-  currentGraphChannelId?: string | null;
-  currentChatType?: "direct" | "group" | "channel" | null;
-  graphOnly?: boolean;
-}): { to: string; pinnedMessageId: string } | ReturnType<typeof actionError> {
-  const to = params.graphOnly
-    ? resolveGraphActionTarget(
-        params.toolParams,
-        params.currentChannelId,
-        params.currentGraphChannelId,
-        params.currentChatType,
-      )
-    : resolveActionTarget(params.toolParams, params.currentChannelId);
-  const pinnedMessageId = resolveActionPinnedMessageId(params.toolParams);
-  if (!to || !pinnedMessageId) {
-    return actionError(`${params.actionLabel} requires a target (to) and pinnedMessageId.`);
-  }
-  return { to, pinnedMessageId };
-}
-
-async function runWithRequiredActionTarget<T>(params: {
-  actionLabel: string;
-  toolParams: Record<string, unknown>;
-  currentChannelId?: string | null;
-  currentGraphChannelId?: string | null;
-  currentChatType?: "direct" | "group" | "channel" | null;
-  graphOnly?: boolean;
-  run: (to: string) => Promise<T>;
-}): Promise<T | ReturnType<typeof actionError>> {
-  const to = resolveRequiredActionTarget({
-    actionLabel: params.actionLabel,
-    toolParams: params.toolParams,
-    currentChannelId: params.currentChannelId,
-    currentGraphChannelId: params.currentGraphChannelId,
-    currentChatType: params.currentChatType,
-    graphOnly: params.graphOnly,
-  });
-  if (typeof to !== "string") {
-    return to;
   }
   return await params.run(to);
 }
 
-async function runWithRequiredActionMessageTarget<T>(params: {
-  actionLabel: string;
-  toolParams: Record<string, unknown>;
-  currentChannelId?: string | null;
-  currentGraphChannelId?: string | null;
-  currentChatType?: "direct" | "group" | "channel" | null;
-  graphOnly?: boolean;
-  run: (target: { to: string; messageId: string }) => Promise<T>;
-}): Promise<T | ReturnType<typeof actionError>> {
-  const target = resolveRequiredActionMessageTarget({
-    actionLabel: params.actionLabel,
-    toolParams: params.toolParams,
-    currentChannelId: params.currentChannelId,
-    currentGraphChannelId: params.currentGraphChannelId,
-    currentChatType: params.currentChatType,
-    graphOnly: params.graphOnly,
-  });
-  if ("isError" in target) {
-    return target;
+async function runWithRequiredActionMessageTarget<T>(
+  params: MSTeamsActionTargetParams & {
+    run: (target: { to: string; messageId: string }) => Promise<T>;
+  },
+): Promise<T | ReturnType<typeof actionError>> {
+  const to = resolveMSTeamsActionTarget(params);
+  const messageId = resolveActionMessageId(params.toolParams);
+  if (!to || !messageId) {
+    return actionError(`${params.actionLabel} requires a target (to) and messageId.`);
   }
-  return await params.run(target);
+  return await params.run({ to, messageId });
 }
 
-async function runWithRequiredActionPinnedMessageTarget<T>(params: {
-  actionLabel: string;
-  toolParams: Record<string, unknown>;
-  currentChannelId?: string | null;
-  currentGraphChannelId?: string | null;
-  currentChatType?: "direct" | "group" | "channel" | null;
-  graphOnly?: boolean;
-  run: (target: { to: string; pinnedMessageId: string }) => Promise<T>;
-}): Promise<T | ReturnType<typeof actionError>> {
-  const target = resolveRequiredActionPinnedMessageTarget({
-    actionLabel: params.actionLabel,
-    toolParams: params.toolParams,
-    currentChannelId: params.currentChannelId,
-    currentGraphChannelId: params.currentGraphChannelId,
-    currentChatType: params.currentChatType,
-    graphOnly: params.graphOnly,
-  });
-  if ("isError" in target) {
-    return target;
+async function runWithRequiredActionPinnedMessageTarget<T>(
+  params: MSTeamsActionTargetParams & {
+    run: (target: { to: string; pinnedMessageId: string }) => Promise<T>;
+  },
+): Promise<T | ReturnType<typeof actionError>> {
+  const to = resolveMSTeamsActionTarget(params);
+  const pinnedMessageId = resolveActionPinnedMessageId(params.toolParams);
+  if (!to || !pinnedMessageId) {
+    return actionError(`${params.actionLabel} requires a target (to) and pinnedMessageId.`);
   }
-  return await params.run(target);
+  return await params.run({ to, pinnedMessageId });
 }
 
 function describeMSTeamsMessageTool({
@@ -737,6 +656,8 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
               return authError;
             }
           }
+          const authorizeActionTarget = (target: string) =>
+            assertMSTeamsReadTargetAllowed({ cfg: ctx.cfg, ctx, target });
           const presentation =
             ctx.action === "send"
               ? normalizeMessagePresentation(ctx.params.presentation)
@@ -820,11 +741,7 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
               toolParams: ctx.params,
               currentChannelId: ctx.toolContext?.currentChannelId,
               run: async (target) => {
-                const to = await assertMSTeamsReadTargetAllowed({
-                  cfg: ctx.cfg,
-                  ctx,
-                  target: target.to,
-                });
+                const to = await authorizeActionTarget(target.to);
                 const { editMessageMSTeams } = await loadMSTeamsChannelRuntime();
                 const result = await editMessageMSTeams({
                   cfg: ctx.cfg,
@@ -843,11 +760,7 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
               toolParams: ctx.params,
               currentChannelId: ctx.toolContext?.currentChannelId,
               run: async (target) => {
-                const to = await assertMSTeamsReadTargetAllowed({
-                  cfg: ctx.cfg,
-                  ctx,
-                  target: target.to,
-                });
+                const to = await authorizeActionTarget(target.to);
                 const { deleteMessageMSTeams } = await loadMSTeamsChannelRuntime();
                 const result = await deleteMessageMSTeams({
                   cfg: ctx.cfg,
@@ -859,20 +772,20 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
             });
           }
 
+          const graphActionTarget = {
+            toolParams: ctx.params,
+            currentChannelId: ctx.toolContext?.currentChannelId,
+            currentGraphChannelId: resolveCurrentGraphActionTarget(ctx.toolContext),
+            currentChatType: ctx.toolContext?.currentChatType,
+            graphOnly: true,
+          };
+
           if (ctx.action === "read") {
             return await runWithRequiredActionMessageTarget({
               actionLabel: "Read",
-              toolParams: ctx.params,
-              currentChannelId: ctx.toolContext?.currentChannelId,
-              currentGraphChannelId: resolveCurrentGraphActionTarget(ctx.toolContext),
-              currentChatType: ctx.toolContext?.currentChatType,
-              graphOnly: true,
+              ...graphActionTarget,
               run: async (target) => {
-                const to = await assertMSTeamsReadTargetAllowed({
-                  cfg: ctx.cfg,
-                  ctx,
-                  target: target.to,
-                });
+                const to = await authorizeActionTarget(target.to);
                 const { getMessageMSTeams } = await loadMSTeamsChannelRuntime();
                 const message = await getMessageMSTeams({
                   cfg: ctx.cfg,
@@ -887,17 +800,9 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
           if (ctx.action === "pin") {
             return await runWithRequiredActionMessageTarget({
               actionLabel: "Pin",
-              toolParams: ctx.params,
-              currentChannelId: ctx.toolContext?.currentChannelId,
-              currentGraphChannelId: resolveCurrentGraphActionTarget(ctx.toolContext),
-              currentChatType: ctx.toolContext?.currentChatType,
-              graphOnly: true,
+              ...graphActionTarget,
               run: async (target) => {
-                const to = await assertMSTeamsReadTargetAllowed({
-                  cfg: ctx.cfg,
-                  ctx,
-                  target: target.to,
-                });
+                const to = await authorizeActionTarget(target.to);
                 const { pinMessageMSTeams } = await loadMSTeamsChannelRuntime();
                 const result = await pinMessageMSTeams({
                   cfg: ctx.cfg,
@@ -912,17 +817,9 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
           if (ctx.action === "unpin") {
             return await runWithRequiredActionPinnedMessageTarget({
               actionLabel: "Unpin",
-              toolParams: ctx.params,
-              currentChannelId: ctx.toolContext?.currentChannelId,
-              currentGraphChannelId: resolveCurrentGraphActionTarget(ctx.toolContext),
-              currentChatType: ctx.toolContext?.currentChatType,
-              graphOnly: true,
+              ...graphActionTarget,
               run: async (target) => {
-                const to = await assertMSTeamsReadTargetAllowed({
-                  cfg: ctx.cfg,
-                  ctx,
-                  target: target.to,
-                });
+                const to = await authorizeActionTarget(target.to);
                 const { unpinMessageMSTeams } = await loadMSTeamsChannelRuntime();
                 const result = await unpinMessageMSTeams({
                   cfg: ctx.cfg,
@@ -937,17 +834,9 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
           if (ctx.action === "list-pins") {
             return await runWithRequiredActionTarget({
               actionLabel: "List-pins",
-              toolParams: ctx.params,
-              currentChannelId: ctx.toolContext?.currentChannelId,
-              currentGraphChannelId: resolveCurrentGraphActionTarget(ctx.toolContext),
-              currentChatType: ctx.toolContext?.currentChatType,
-              graphOnly: true,
+              ...graphActionTarget,
               run: async (to) => {
-                const allowedTarget = await assertMSTeamsReadTargetAllowed({
-                  cfg: ctx.cfg,
-                  ctx,
-                  target: to,
-                });
+                const allowedTarget = await authorizeActionTarget(to);
                 const { listPinsMSTeams } = await loadMSTeamsChannelRuntime();
                 const result = await listPinsMSTeams({ cfg: ctx.cfg, to: allowedTarget });
                 return jsonMSTeamsOkActionResult("list-pins", result);
@@ -958,11 +847,7 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
           if (ctx.action === "react") {
             return await runWithRequiredActionMessageTarget({
               actionLabel: "React",
-              toolParams: ctx.params,
-              currentChannelId: ctx.toolContext?.currentChannelId,
-              currentGraphChannelId: resolveCurrentGraphActionTarget(ctx.toolContext),
-              currentChatType: ctx.toolContext?.currentChatType,
-              graphOnly: true,
+              ...graphActionTarget,
               run: async (target) => {
                 const emoji = typeof ctx.params.emoji === "string" ? ctx.params.emoji.trim() : "";
                 const remove = typeof ctx.params.remove === "boolean" ? ctx.params.remove : false;
@@ -981,11 +866,7 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
                     },
                   };
                 }
-                const to = await assertMSTeamsReadTargetAllowed({
-                  cfg: ctx.cfg,
-                  ctx,
-                  target: target.to,
-                });
+                const to = await authorizeActionTarget(target.to);
                 if (remove) {
                   const { unreactMessageMSTeams } = await loadMSTeamsChannelRuntime();
                   const result = await unreactMessageMSTeams({
@@ -1018,17 +899,9 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
           if (ctx.action === "reactions") {
             return await runWithRequiredActionMessageTarget({
               actionLabel: "Reactions",
-              toolParams: ctx.params,
-              currentChannelId: ctx.toolContext?.currentChannelId,
-              currentGraphChannelId: resolveCurrentGraphActionTarget(ctx.toolContext),
-              currentChatType: ctx.toolContext?.currentChatType,
-              graphOnly: true,
+              ...graphActionTarget,
               run: async (target) => {
-                const to = await assertMSTeamsReadTargetAllowed({
-                  cfg: ctx.cfg,
-                  ctx,
-                  target: target.to,
-                });
+                const to = await authorizeActionTarget(target.to);
                 const { listReactionsMSTeams } = await loadMSTeamsChannelRuntime();
                 const result = await listReactionsMSTeams({
                   cfg: ctx.cfg,
@@ -1043,17 +916,9 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
           if (ctx.action === "search") {
             return await runWithRequiredActionTarget({
               actionLabel: "Search",
-              toolParams: ctx.params,
-              currentChannelId: ctx.toolContext?.currentChannelId,
-              currentGraphChannelId: resolveCurrentGraphActionTarget(ctx.toolContext),
-              currentChatType: ctx.toolContext?.currentChatType,
-              graphOnly: true,
+              ...graphActionTarget,
               run: async (to) => {
-                const allowedTarget = await assertMSTeamsReadTargetAllowed({
-                  cfg: ctx.cfg,
-                  ctx,
-                  target: to,
-                });
+                const allowedTarget = await authorizeActionTarget(to);
                 const query = resolveActionQuery(ctx.params);
                 if (!query) {
                   return actionError("Search requires a target (to) and query.");
@@ -1081,13 +946,9 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
             }
             return await runWithRequiredActionTarget({
               actionLabel: "member-info",
-              toolParams: ctx.params,
-              currentChannelId: ctx.toolContext?.currentChannelId,
-              currentGraphChannelId: resolveCurrentGraphActionTarget(ctx.toolContext),
-              currentChatType: ctx.toolContext?.currentChatType,
-              graphOnly: true,
+              ...graphActionTarget,
               run: async (target) => {
-                const to = await assertMSTeamsReadTargetAllowed({ cfg: ctx.cfg, ctx, target });
+                const to = await authorizeActionTarget(target);
                 const currentRequesterId = isCurrentMSTeamsReadTarget({ ctx, target: to })
                   ? ctx.requesterSenderId
                   : undefined;
@@ -1124,11 +985,7 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
             if (!teamId || !channelId) {
               return actionError("channel-info requires teamId and channelId.");
             }
-            const graphTarget = await assertMSTeamsReadTargetAllowed({
-              cfg: ctx.cfg,
-              ctx,
-              target: `${teamId}/${channelId}`,
-            });
+            const graphTarget = await authorizeActionTarget(`${teamId}/${channelId}`);
             const [graphTeamId, graphChannelId] = graphTarget.split("/", 2);
             if (!graphTeamId || !graphChannelId) {
               throw new Error("Authorized Microsoft Teams channel target is invalid.");

--- a/extensions/msteams/src/read-policy.test.ts
+++ b/extensions/msteams/src/read-policy.test.ts
@@ -66,6 +66,57 @@ describe("Microsoft Teams read policy", () => {
     expect(mocks.resolveGraphToken).not.toHaveBeenCalled();
   });
 
+  it.each([
+    { name: "default sender-only policy", groupPolicy: undefined, configuredRoute: false },
+    { name: "explicit sender-only allowlist", groupPolicy: "allowlist", configuredRoute: false },
+    { name: "configured team/channel route", groupPolicy: "allowlist", configuredRoute: true },
+    { name: "explicit open group policy", groupPolicy: "open", configuredRoute: false },
+  ])("recovers existing groupAllowFrom configurations with $name", async (testCase) => {
+    const teamId = "19:team@thread.tacv2";
+    const channelId = "19:roadmap@thread.tacv2";
+    const target = `11111111-1111-1111-1111-111111111111/${channelId}`;
+    const cfg = {
+      channels: {
+        msteams: {
+          groupAllowFrom: ["aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"],
+          ...(testCase.groupPolicy ? { groupPolicy: testCase.groupPolicy } : {}),
+          ...(testCase.configuredRoute
+            ? { teams: { [teamId]: { channels: { [channelId]: {} } } } }
+            : {}),
+        },
+      },
+    } as OpenClawConfig;
+
+    mocks.listChannelsForTeamWithPageInfo.mockResolvedValue({
+      items: [{ id: teamId }, { id: channelId }],
+      truncated: false,
+    });
+
+    const result = assertMSTeamsReadTargetAllowed({ cfg, ctx, target });
+    if (testCase.configuredRoute || testCase.groupPolicy === "open") {
+      await expect(result).resolves.toBe(target);
+      return;
+    }
+
+    await expect(result).rejects.toThrow(
+      'Microsoft Teams read target is not allowed. Configure channels.msteams.teams.<team>.channels for this channel, or deliberately set channels.msteams.groupPolicy to "open".',
+    );
+    expect(mocks.resolveGraphToken).not.toHaveBeenCalled();
+  });
+
+  it("keeps unresolved channel targets on the generic authorization error", async () => {
+    const cfg = {
+      channels: {
+        msteams: { groupAllowFrom: ["aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"] },
+      },
+    } as OpenClawConfig;
+
+    await expect(
+      assertMSTeamsReadTargetAllowed({ cfg, ctx, target: "Product/Roadmap" }),
+    ).rejects.toThrow(/^Microsoft Teams read target is not allowed\.$/);
+    expect(mocks.resolveGraphToken).not.toHaveBeenCalled();
+  });
+
   it("uses startup-equivalent resolved channel policy for stable action targets", async () => {
     const cfg = {
       channels: {

--- a/extensions/msteams/src/read-policy.test.ts
+++ b/extensions/msteams/src/read-policy.test.ts
@@ -45,6 +45,27 @@ beforeEach(() => {
 });
 
 describe("Microsoft Teams read policy", () => {
+  it.each([
+    { groupPolicy: undefined, allowed: false },
+    { groupPolicy: "allowlist", allowed: false },
+    { groupPolicy: "open", allowed: true },
+  ])("applies the $groupPolicy group policy to unconfigured channel targets", async (testCase) => {
+    const cfg = {
+      channels: {
+        msteams: testCase.groupPolicy ? { groupPolicy: testCase.groupPolicy } : {},
+      },
+    } as OpenClawConfig;
+    const target = "11111111-1111-1111-1111-111111111111/19:roadmap@thread.tacv2";
+    const result = assertMSTeamsReadTargetAllowed({ cfg, ctx, target });
+
+    if (testCase.allowed) {
+      await expect(result).resolves.toBe(target);
+    } else {
+      await expect(result).rejects.toThrow("Microsoft Teams read target is not allowed.");
+    }
+    expect(mocks.resolveGraphToken).not.toHaveBeenCalled();
+  });
+
   it("uses startup-equivalent resolved channel policy for stable action targets", async () => {
     const cfg = {
       channels: {

--- a/extensions/msteams/src/read-policy.ts
+++ b/extensions/msteams/src/read-policy.ts
@@ -233,11 +233,11 @@ async function resolveAllowedChannelTarget(
     allowNameMatching: isDangerousNameMatchingEnabled(teams),
   });
   const stableTarget = await resolveStableChannelTarget(cfg, target);
-  if (directRoute.allowed) {
-    return stableTarget;
-  }
   if (!directRoute.allowlistConfigured) {
     return groupPolicy === "open" ? stableTarget : undefined;
+  }
+  if (directRoute.allowed) {
+    return stableTarget;
   }
   if (!stableTarget || !teams?.teams) {
     return undefined;

--- a/extensions/msteams/src/read-policy.ts
+++ b/extensions/msteams/src/read-policy.ts
@@ -233,8 +233,10 @@ async function resolveAllowedChannelTarget(
     allowNameMatching: isDangerousNameMatchingEnabled(teams),
   });
   const stableTarget = await resolveStableChannelTarget(cfg, target);
-  if (!directRoute.allowlistConfigured) {
-    return groupPolicy === "open" ? stableTarget : undefined;
+  if (!directRoute.allowlistConfigured && groupPolicy !== "open" && stableTarget) {
+    throw new ToolAuthorizationError(
+      'Microsoft Teams read target is not allowed. Configure channels.msteams.teams.<team>.channels for this channel, or deliberately set channels.msteams.groupPolicy to "open".',
+    );
   }
   if (directRoute.allowed) {
     return stableTarget;


### PR DESCRIPTION
## What Problem This Solves

Microsoft Teams channel actions repeated target resolution, Graph-routing preparation, validation, and provider-owned security-policy calls across several helper layers and action branches. The duplication made the provider owner larger and increased the chance that sibling actions would drift in routing or authorization behavior.

## Why This Change Was Made

Consolidate Microsoft Teams action targets behind one provider-owned resolver, keep explicit target/message/pinned-message validation and existing errors, prepare the canonical Graph target once, and reuse the existing read-policy owner with the same trusted configuration and action context. Align the provider-owned group-allowlist decision with its existing team-enumeration sibling, and make the sender-only upgrade case actionable with a targeted trusted authorization error plus public Teams documentation. Across the complete change, production is **141 lines smaller** (`+60/-201`); focused policy/action regressions add **77 test lines** (`+82/-5`), and the existing Teams documentation grows by four net lines. No public contract, configuration surface, dependency ownership, or database schema changes.

## User Impact

Existing legitimate Teams actions continue to work. Owner and `operator.admin` group-management requirements, trusted requester/account isolation, fail-closed authorization before provider access, Graph-versus-Bot Framework routing, explicit-target precedence, pinned-resource identity, thread routing, and host-owned media authority are preserved.

For existing installations configured only with `groupAllowFrom`, delegated reads of other Teams channels require an explicitly allowed route. **Recommended:** configure `channels.msteams.teams.<team>.channels` using stable Teams conversation IDs. Alternatively, deliberately select the existing `groupPolicy: "open"` setting; this also admits **any group sender** (still mention-gated by default), so it is broader than a scoped route. Direct-operator reads, the current conversation, and configured routes remain unchanged. See the updated [Microsoft Teams access-control documentation](https://docs.openclaw.ai/channels/msteams).

Upgrade policy confirmed: `groupAllowFrom` authorizes incoming senders/conversations only; it never grants delegated reads of other Teams channels. Existing `groupAllowFrom`-only deployments intentionally fail closed for non-current delegated Graph reads. Restore scoped access by configuring the allowed team/channel route; the existing `groupPolicy: "open"` alternative is deliberate broader sender access. Direct operator/current-conversation reads remain unchanged.

## Evidence

- **1,398 tests passed across all 91 Microsoft Teams suites** on one trusted Blacksmith Testbox, covering action dispatch, read policy, provider/account contracts, Bot Framework attachment handling, outbound delivery, inbound authorization, conversation authorization, Graph reads/actions/search/group management, trusted requester identity, threading, SDK delivery, team identity, and media authority.
- **95 focused read-policy/action tests passed** on the exact committed source, including legacy `groupAllowFrom`-only configurations under default and explicit allowlists, the targeted actionable 403 and zero Graph access, stable Bot Framework team/channel route recovery, explicit open-policy recovery, malformed-target generic denial, and all six Graph-backed action rejection paths.
- Full, unmodified `corepack pnpm check:changed` passed on the exact committed source across plugin production, plugin tests, and docs: plugin and plugin-test type checks, changed-file format/lint (**0 warnings and 0 errors**), SDK baseline and provider boundaries, dead-export scans, dependency guards, database-first storage and media guards, runtime sidecar checks, and zero runtime import cycles.
- Executed the original and refactored channel source modules side by side: **51 identical action scenarios**, **20 trusted-requester authority checks**, and **three threading contexts**, including blocked/cross-account targets, owner/admin enforcement, Graph/Bot Framework behavior, pinned-ID precedence, and media propagation.
- Independent final **full-branch** `gpt-5.6-sol` / `xhigh` autoreview: **clean, score 0.97** across all five production, test, and documentation files. Formatting and `git diff --check` passed.
- Exact committed-head private-QA build, both test suites, unchanged repository gate, and genuine Gateway proof ran in [one isolated Blacksmith Testbox validation](https://github.com/openclaw/openclaw/actions/runs/31026587231); the owned lease was stopped and independently verified `completed`.

### Exact-head real Gateway, mock-channel, and mock-provider verdict

Observed at committed head `3364819722782ead0f5eea3fb26ffe2e47c20161` using the real ephemeral OpenClaw Gateway, authenticated loopback Gateway WebSocket, actual bundled Microsoft Teams plugin and Bot Framework webhook/connector, repository mock OpenAI provider, and synthetic loopback Microsoft Graph API. Git verified the exact committed source blobs before launching the private-QA build. The Gateway used isolated temporary state; the run used no live Teams credentials, no operator state, and blocked all external network access. Direct-operator, scoped configured-route, and explicitly open-policy reads reached the mock Graph API; both `groupAllowFrom`-only delegated denials returned actionable recovery guidance before any additional Graph request.

```json
{
  "verdict": "PASS",
  "commit": "3364819722782ead0f5eea3fb26ffe2e47c20161",
  "committedChannelBlob": "402ddaf602b819412ac07dfdab17072827e0ff76",
  "committedReadPolicyBlob": "c899b8c521af510b67f9704e6e7c00b9261c98fc",
  "harness": {
    "gateway": "real isolated ephemeral OpenClaw Gateway",
    "gatewayTransport": "authenticated loopback WebSocket message.action",
    "channelPlugin": "actual bundled Microsoft Teams plugin",
    "modelProvider": "loopback mock-openai",
    "botFramework": "nonce-protected loopback Teams connector",
    "graphApi": "loopback synthetic Microsoft Graph",
    "externalNetwork": "blocked by private per-run bootstrap",
    "operatorState": "isolated temporary HOME/state/config"
  },
  "channelRoundTrip": {
    "inboundWebhookActivities": 1,
    "mockProviderRequests": 1,
    "outboundBotFrameworkActivities": 3,
    "deliveredSyntheticReply": "QA_MSTEAMS_REAL_GATEWAY_OK"
  },
  "authorized": {
    "directOperator": {
      "gatewayMethod": "message.action",
      "action": "read",
      "origin": "direct-operator",
      "target": "00000000-0000-4000-8000-000000000001/19:qa-proof-channel@thread.tacv2",
      "graphRequest": {
        "method": "GET",
        "path": "/v1.0/teams/00000000-0000-4000-8000-000000000001/channels/19%3Aqa-proof-channel%40thread.tacv2/messages/msg-proof-42",
        "authorizationPresent": true
      },
      "gatewayResultContainsSyntheticMessage": true
    },
    "configuredDelegatedRoute": {
      "gatewayMethod": "message.action",
      "action": "read",
      "origin": "delegated with explicitly configured team/channel route",
      "target": "00000000-0000-4000-8000-000000000001/19:qa-proof-channel@thread.tacv2",
      "graphRequest": {
        "method": "GET",
        "path": "/v1.0/teams/00000000-0000-4000-8000-000000000001/channels/19%3Aqa-proof-channel%40thread.tacv2/messages/msg-proof-42",
        "authorizationPresent": true
      },
      "gatewayResultContainsSyntheticMessage": true
    },
    "explicitlyOpenPolicy": {
      "gatewayMethod": "message.action",
      "action": "read",
      "origin": "delegated after deliberately selecting existing groupPolicy: \"open\"",
      "senderAdmissionTradeoff": "open also admits any group sender, subject to normal mention gating",
      "target": "00000000-0000-4000-8000-000000000001/19:qa-proof-channel@thread.tacv2",
      "graphRequest": {
        "method": "GET",
        "path": "/v1.0/teams/00000000-0000-4000-8000-000000000001/channels/19%3Aqa-proof-channel%40thread.tacv2/messages/msg-proof-42",
        "authorizationPresent": true
      },
      "gatewayResultContainsSyntheticMessage": true
    }
  },
  "denied": {
    "explicitAllowlist": {
      "policy": "explicit allowlist, groupAllowFrom only, no team routes",
      "gatewayMethod": "message.action",
      "action": "read",
      "origin": "groupAllowFrom-only delegated requester; unsigned owner/current-context claims rejected",
      "target": "00000000-0000-4000-8000-000000000001/19:qa-proof-channel@thread.tacv2",
      "error": "ToolAuthorizationError: Microsoft Teams read target is not allowed. Configure channels.msteams.teams.<team>.channels for this channel, or deliberately set channels.msteams.groupPolicy to \"open\".",
      "operatorRecovery": {
        "recommended": "configure the specific Teams team/channel route",
        "broaderAlternative": "deliberately set groupPolicy to \"open\"; this also admits any group sender"
      },
      "graphRequestsBefore": 1,
      "graphRequestsAfter": 1,
      "rejectedBeforeGraphApi": true
    },
    "implicitDefaultAllowlist": {
      "policy": "implicit default allowlist, groupAllowFrom only, no team routes",
      "gatewayMethod": "message.action",
      "action": "read",
      "origin": "groupAllowFrom-only delegated requester; unsigned owner/current-context claims rejected",
      "target": "00000000-0000-4000-8000-000000000001/19:qa-proof-channel@thread.tacv2",
      "error": "ToolAuthorizationError: Microsoft Teams read target is not allowed. Configure channels.msteams.teams.<team>.channels for this channel, or deliberately set channels.msteams.groupPolicy to \"open\".",
      "operatorRecovery": {
        "recommended": "configure the specific Teams team/channel route",
        "broaderAlternative": "deliberately set groupPolicy to \"open\"; this also admits any group sender"
      },
      "graphRequestsBefore": 1,
      "graphRequestsAfter": 1,
      "rejectedBeforeGraphApi": true
    }
  }
}
```

