### PR TITLE
refactor(transcripts): consolidate persistence and export ownership

### DIFF
--- a/src/transcripts/store-export-jsonl.ts
+++ b/src/transcripts/store-export-jsonl.ts
@@ -8,7 +8,11 @@ import {
 } from "../state/openclaw-state-db.js";
 import type { TranscriptSessionDescriptor } from "./provider-types.js";
 import { ensureMeetingTranscriptsSchema } from "./sqlite-schema.js";
-import { meetingTranscriptDb, utteranceFromRow } from "./store-sqlite.js";
+import {
+  meetingTranscriptSessionQuery,
+  meetingTranscriptUtteranceQuery,
+  utteranceFromRow,
+} from "./store-sqlite.js";
 
 const TRANSCRIPT_EXPORT_ROW_BATCH_SIZE = 64;
 
@@ -21,11 +25,7 @@ export async function writeTranscriptJsonlArtifact(params: {
   const database = openOpenClawStateDatabase(params.databaseOptions);
   const sequenceHead = executeSqliteQueryTakeFirstSync(
     database.db,
-    meetingTranscriptDb(database.db)
-      .selectFrom("meeting_transcript_sessions")
-      .select("next_utterance_seq")
-      .where("session_id", "=", params.session.sessionId)
-      .where("started_at", "=", params.session.startedAt),
+    meetingTranscriptSessionQuery(database.db, params.session).select("next_utterance_seq"),
   )?.next_utterance_seq;
   if (sequenceHead === undefined) {
     throw new Error(`transcripts session not found: ${params.session.sessionId}`);
@@ -41,11 +41,8 @@ export async function writeTranscriptJsonlArtifact(params: {
         while (nextSequence < sequenceHead) {
           const rows = executeSqliteQuerySync(
             database.db,
-            meetingTranscriptDb(database.db)
-              .selectFrom("meeting_transcript_utterances")
+            meetingTranscriptUtteranceQuery(database.db, params.session)
               .selectAll()
-              .where("session_id", "=", params.session.sessionId)
-              .where("session_started_at", "=", params.session.startedAt)
               .where("sequence", ">=", nextSequence)
               .where("sequence", "<", sequenceHead)
               .orderBy("sequence", "asc")

--- a/src/transcripts/store-export-ownership.ts
+++ b/src/transcripts/store-export-ownership.ts
@@ -16,7 +16,7 @@ import {
   transcriptSessionExportKey,
   transcriptSessionSelector,
 } from "./store-artifacts.js";
-import { meetingTranscriptDb } from "./store-sqlite.js";
+import { meetingTranscriptDb, type MeetingTranscriptSessionRow } from "./store-sqlite.js";
 
 type ExportOwnershipParams = {
   session: TranscriptSessionDescriptor;
@@ -27,6 +27,31 @@ type ExportOwnershipParams = {
 function database(options: OpenClawStateDatabaseOptions) {
   ensureMeetingTranscriptsSchema(options);
   return openOpenClawStateDatabase(options);
+}
+
+async function transcriptArtifactsMatchOwner(
+  sessionDir: string,
+  artifacts: Array<{ entry: { name: string }; canonicalName: string }>,
+  owner: Pick<MeetingTranscriptSessionRow, "export_manifest_json" | "export_pending_json">,
+): Promise<boolean> {
+  const manifest = JSON.parse(owner.export_manifest_json) as Record<string, string>;
+  const pending = new Set(JSON.parse(owner.export_pending_json) as string[]);
+  // Pending, altered, or symlinked artifacts must never establish aliased ownership.
+  for (const { entry, canonicalName } of artifacts) {
+    const artifactPath = path.join(sessionDir, entry.name);
+    const stat = await fs.lstat(artifactPath);
+    const expectedHash = manifest[canonicalName];
+    if (
+      stat.isSymbolicLink() ||
+      !stat.isFile() ||
+      pending.has(canonicalName) ||
+      !expectedHash ||
+      (await sha256File(artifactPath)) !== expectedHash
+    ) {
+      return false;
+    }
+  }
+  return artifacts.length > 0;
 }
 
 export async function assertTranscriptExportPathAvailable(
@@ -133,7 +158,6 @@ export async function hasAliasedCanonicalTranscriptExportPathOwner(
     return true;
   }
   let owner;
-  let identityVerified = false;
   const metadataArtifact = artifacts.find(({ canonicalName }) => canonicalName === "metadata.json");
   if (metadataArtifact) {
     const metadataPath = path.join(sessionDir, metadataArtifact.entry.name);
@@ -151,7 +175,6 @@ export async function hasAliasedCanonicalTranscriptExportPathOwner(
       owner = owners.find(
         (row) => row.session_id === metadata.sessionId && row.started_at === metadata.startedAt,
       );
-      identityVerified = owner !== undefined;
     } catch {
       return false;
     } finally {
@@ -161,55 +184,11 @@ export async function hasAliasedCanonicalTranscriptExportPathOwner(
   if (!owner && !metadataArtifact) {
     const manifestMatches = [];
     for (const candidate of owners) {
-      const candidateManifest = JSON.parse(candidate.export_manifest_json) as Record<
-        string,
-        string
-      >;
-      const candidatePending = new Set(JSON.parse(candidate.export_pending_json) as string[]);
-      let verified = 0;
-      let matches = true;
-      for (const { entry, canonicalName } of artifacts) {
-        const artifactPath = path.join(sessionDir, entry.name);
-        const stat = await fs.lstat(artifactPath);
-        const expectedHash = candidateManifest[canonicalName];
-        if (
-          stat.isSymbolicLink() ||
-          !stat.isFile() ||
-          candidatePending.has(canonicalName) ||
-          !expectedHash ||
-          (await sha256File(artifactPath)) !== expectedHash
-        ) {
-          matches = false;
-          break;
-        }
-        verified += 1;
-      }
-      if (matches && verified > 0) {
+      if (await transcriptArtifactsMatchOwner(sessionDir, artifacts, candidate)) {
         manifestMatches.push(candidate);
       }
     }
     owner = manifestMatches.length === 1 ? manifestMatches[0] : undefined;
   }
-  if (!owner) {
-    return false;
-  }
-  const manifest = JSON.parse(owner.export_manifest_json) as Record<string, string>;
-  const pending = new Set(JSON.parse(owner.export_pending_json) as string[]);
-  let verifiedArtifactCount = 0;
-  for (const { entry, canonicalName } of artifacts) {
-    const artifactPath = path.join(sessionDir, entry.name);
-    const stat = await fs.lstat(artifactPath);
-    if (stat.isSymbolicLink() || !stat.isFile()) {
-      return false;
-    }
-    if (pending.has(canonicalName)) {
-      return false;
-    }
-    const expectedHash = manifest[canonicalName];
-    if (!expectedHash || (await sha256File(artifactPath)) !== expectedHash) {
-      return false;
-    }
-    verifiedArtifactCount += 1;
-  }
-  return identityVerified || verifiedArtifactCount > 0;
+  return owner !== undefined && (await transcriptArtifactsMatchOwner(sessionDir, artifacts, owner));
 }

--- a/src/transcripts/store-sqlite.ts
+++ b/src/transcripts/store-sqlite.ts
@@ -29,21 +29,36 @@ export function meetingTranscriptDb(db: DatabaseSync) {
   return getNodeSqliteKysely<MeetingTranscriptsDatabase>(db);
 }
 
+export function meetingTranscriptSessionQuery(
+  database: DatabaseSync,
+  session: Pick<TranscriptSessionDescriptor, "sessionId" | "startedAt">,
+) {
+  return meetingTranscriptDb(database)
+    .selectFrom("meeting_transcript_sessions")
+    .where("session_id", "=", session.sessionId)
+    .where("started_at", "=", session.startedAt);
+}
+
+export function meetingTranscriptUtteranceQuery(
+  database: DatabaseSync,
+  session: Pick<TranscriptSessionDescriptor, "sessionId" | "startedAt">,
+) {
+  return meetingTranscriptDb(database)
+    .selectFrom("meeting_transcript_utterances")
+    .where("session_id", "=", session.sessionId)
+    .where("session_started_at", "=", session.startedAt);
+}
+
 function hasExactMeetingTranscriptUtterance(params: {
   database: DatabaseSync;
   metadataJson: string | null;
-  sessionId: string;
-  sessionStartedAt: string;
+  session: TranscriptSessionDescriptor;
   utterance: TranscriptUtterance & { id: string };
 }): boolean {
-  const db = meetingTranscriptDb(params.database);
   const rows = executeSqliteQuerySync(
     params.database,
-    db
-      .selectFrom("meeting_transcript_utterances")
+    meetingTranscriptUtteranceQuery(params.database, params.session)
       .selectAll()
-      .where("session_id", "=", params.sessionId)
-      .where("session_started_at", "=", params.sessionStartedAt)
       .where("utterance_id", "=", params.utterance.id),
   ).rows;
   const utterance = params.utterance;
@@ -73,8 +88,7 @@ export function appendMeetingTranscriptUtterance(params: {
     hasExactMeetingTranscriptUtterance({
       database,
       metadataJson: params.metadataJson,
-      sessionId: session.sessionId,
-      sessionStartedAt: session.startedAt,
+      session,
       utterance: { ...utterance, id: utterance.id },
     })
   ) {
@@ -82,11 +96,7 @@ export function appendMeetingTranscriptUtterance(params: {
   }
   const stored = executeSqliteQueryTakeFirstSync(
     database,
-    db
-      .selectFrom("meeting_transcript_sessions")
-      .select("next_utterance_seq")
-      .where("session_id", "=", session.sessionId)
-      .where("started_at", "=", session.startedAt),
+    meetingTranscriptSessionQuery(database, session).select("next_utterance_seq"),
   );
   if (!stored) {
     throw new Error(`transcripts session not found: ${session.sessionId}`);

--- a/src/transcripts/store.ts
+++ b/src/transcripts/store.ts
@@ -38,6 +38,8 @@ import {
 import {
   appendMeetingTranscriptUtterance,
   meetingTranscriptDb,
+  meetingTranscriptSessionQuery,
+  meetingTranscriptUtteranceQuery,
   type MeetingTranscriptSessionRow,
   sessionFromRow,
   summaryFromRow,
@@ -62,23 +64,29 @@ export class TranscriptsStore {
     return openOpenClawStateDatabase(this.databaseOptions);
   }
 
+  private transaction(
+    operationLabel: string,
+    operation: (database: OpenClawStateDatabase) => void,
+  ): void {
+    runOpenClawStateWriteTransaction(operation, this.databaseOptions, { operationLabel });
+  }
+
   sessionDir(session: TranscriptSessionDescriptor): string {
     return path.join(this.exportRootDir, transcriptSessionSelector(session));
   }
 
   private entryFromRow(
     row: MeetingTranscriptSessionRow,
-    summaryKeys: ReadonlySet<string>,
+    hasSummary: boolean,
   ): StoreTypes.TranscriptsSessionEntry {
     const session = sessionFromRow(row);
     const sessionDir = this.sessionDir(session);
-    const key = `${session.sessionId}\0${session.startedAt}`;
     return {
       session,
       sessionDir,
       selector: row.selector,
       summaryPath: path.join(sessionDir, "summary.md"),
-      hasSummary: summaryKeys.has(key),
+      hasSummary,
     };
   }
 
@@ -113,11 +121,10 @@ export class TranscriptsStore {
     const database = this.database();
     const row = executeSqliteQueryTakeFirstSync(
       database.db,
-      meetingTranscriptDb(database.db)
-        .selectFrom("meeting_transcript_sessions")
-        .select(["export_manifest_json", "export_pending_json"])
-        .where("session_id", "=", session.sessionId)
-        .where("started_at", "=", session.startedAt),
+      meetingTranscriptSessionQuery(database.db, session).select([
+        "export_manifest_json",
+        "export_pending_json",
+      ]),
     );
     return row
       ? {
@@ -133,11 +140,7 @@ export class TranscriptsStore {
     const database = this.database();
     const row = executeSqliteQueryTakeFirstSync(
       database.db,
-      meetingTranscriptDb(database.db)
-        .selectFrom("meeting_transcript_sessions")
-        .selectAll()
-        .where("session_id", "=", session.sessionId)
-        .where("started_at", "=", session.startedAt),
+      meetingTranscriptSessionQuery(database.db, session).selectAll(),
     );
     return row ? sessionFromRow(row) : undefined;
   }
@@ -146,11 +149,8 @@ export class TranscriptsStore {
     const database = this.database();
     return {
       database,
-      query: meetingTranscriptDb(database.db)
-        .selectFrom("meeting_transcript_utterances")
+      query: meetingTranscriptUtteranceQuery(database.db, session)
         .selectAll()
-        .where("session_id", "=", session.sessionId)
-        .where("session_started_at", "=", session.startedAt)
         .orderBy("sequence", "asc"),
     };
   }
@@ -173,8 +173,8 @@ export class TranscriptsStore {
     }
     const hashes: Record<string, string> = {
       "metadata.json": sha256Hex(`${JSON.stringify(storedSession, null, 2)}\n`),
+      "transcript.jsonl": this.transcriptJsonlDigest(storedSession),
     };
-    hashes["transcript.jsonl"] = this.transcriptJsonlDigest(storedSession);
     const summary = await this.readSummary(storedSession);
     if (summary.summary) {
       hashes["summary.json"] = sha256Hex(`${JSON.stringify(summary.summary, null, 2)}\n`);
@@ -185,80 +185,68 @@ export class TranscriptsStore {
     return hashes;
   }
 
+  private updateExportState(
+    session: TranscriptSessionDescriptor,
+    operationLabel: string,
+    update: (
+      stored:
+        | Pick<MeetingTranscriptSessionRow, "export_manifest_json" | "export_pending_json">
+        | undefined,
+    ) => { export_pending_json: string; export_manifest_json?: string },
+  ): void {
+    this.transaction(operationLabel, ({ db: database }) => {
+      const stored = executeSqliteQueryTakeFirstSync(
+        database,
+        meetingTranscriptSessionQuery(database, session).select([
+          "export_manifest_json",
+          "export_pending_json",
+        ]),
+      );
+      executeSqliteQuerySync(
+        database,
+        meetingTranscriptDb(database)
+          .updateTable("meeting_transcript_sessions")
+          .set(update(stored))
+          .where("session_id", "=", session.sessionId)
+          .where("started_at", "=", session.startedAt),
+      );
+    });
+  }
+
   private updateExportManifest(
     session: TranscriptSessionDescriptor,
     exportedHashes: Readonly<Record<string, string>>,
     removedExports: ReadonlySet<string> = new Set(),
   ): void {
-    runOpenClawStateWriteTransaction(
-      ({ db: database }) => {
-        const db = meetingTranscriptDb(database);
-        const stored = executeSqliteQueryTakeFirstSync(
-          database,
-          db
-            .selectFrom("meeting_transcript_sessions")
-            .select(["export_manifest_json", "export_pending_json"])
-            .where("session_id", "=", session.sessionId)
-            .where("started_at", "=", session.startedAt),
-        );
-        const manifest = stored
-          ? (JSON.parse(stored.export_manifest_json) as Record<string, string>)
-          : {};
-        const pending = new Set(stored ? (JSON.parse(stored.export_pending_json) as string[]) : []);
-        for (const fileName of removedExports) {
-          delete manifest[fileName];
-        }
-        for (const fileName of [...Object.keys(exportedHashes), ...removedExports]) {
-          pending.delete(fileName);
-        }
-        executeSqliteQuerySync(
-          database,
-          db
-            .updateTable("meeting_transcript_sessions")
-            .set({
-              export_manifest_json: JSON.stringify({ ...manifest, ...exportedHashes }),
-              export_pending_json: JSON.stringify([...pending].toSorted()),
-            })
-            .where("session_id", "=", session.sessionId)
-            .where("started_at", "=", session.startedAt),
-        );
-      },
-      this.databaseOptions,
-      { operationLabel: "meeting-transcripts.export.record" },
-    );
+    this.updateExportState(session, "meeting-transcripts.export.record", (stored) => {
+      const manifest = stored
+        ? (JSON.parse(stored.export_manifest_json) as Record<string, string>)
+        : {};
+      const pending = new Set(stored ? (JSON.parse(stored.export_pending_json) as string[]) : []);
+      for (const fileName of removedExports) {
+        delete manifest[fileName];
+      }
+      for (const fileName of [...Object.keys(exportedHashes), ...removedExports]) {
+        pending.delete(fileName);
+      }
+      return {
+        export_manifest_json: JSON.stringify({ ...manifest, ...exportedHashes }),
+        export_pending_json: JSON.stringify([...pending].toSorted()),
+      };
+    });
   }
 
   private markPendingExports(session: TranscriptSessionDescriptor, fileNames: string[]): void {
-    runOpenClawStateWriteTransaction(
-      ({ db: database }) => {
-        const db = meetingTranscriptDb(database);
-        const stored = executeSqliteQueryTakeFirstSync(
-          database,
-          db
-            .selectFrom("meeting_transcript_sessions")
-            .select("export_pending_json")
-            .where("session_id", "=", session.sessionId)
-            .where("started_at", "=", session.startedAt),
-        );
-        if (!stored) {
-          throw new Error(`transcripts session not found: ${session.sessionId}`);
-        }
-        const pending = new Set(JSON.parse(stored.export_pending_json) as string[]);
-        for (const fileName of fileNames) {
-          pending.add(fileName);
-        }
-        executeSqliteQuerySync(
-          database,
-          db
-            .updateTable("meeting_transcript_sessions")
-            .set({ export_pending_json: JSON.stringify([...pending].toSorted()) })
-            .where("session_id", "=", session.sessionId)
-            .where("started_at", "=", session.startedAt),
-        );
-      },
-      this.databaseOptions,
-      { operationLabel: "meeting-transcripts.export.pending" },
-    );
+    this.updateExportState(session, "meeting-transcripts.export.pending", (stored) => {
+      if (!stored) {
+        throw new Error(`transcripts session not found: ${session.sessionId}`);
+      }
+      const pending = new Set(JSON.parse(stored.export_pending_json) as string[]);
+      for (const fileName of fileNames) {
+        pending.add(fileName);
+      }
+      return { export_pending_json: JSON.stringify([...pending].toSorted()) };
+    });
   }
 
   private async assertExportDestinationOwned(
@@ -321,7 +309,9 @@ export class TranscriptsStore {
         .orderBy("session_id", "asc"),
     ).rows;
     const summaryKeys = this.readSummaryKeys(database);
-    return rows.map((row) => this.entryFromRow(row, summaryKeys));
+    return rows.map((row) =>
+      this.entryFromRow(row, summaryKeys.has(`${row.session_id}\0${row.started_at}`)),
+    );
   }
 
   async writeSession(session: TranscriptSessionDescriptor): Promise<void> {
@@ -350,52 +340,40 @@ export class TranscriptsStore {
         await this.assertExportDestinationOwned(session, legacySessionDir);
       }
     }
-    const selector = transcriptSessionSelector(session);
-    const sourceJson = JSON.stringify(session.source);
-    const metadataJson = session.metadata ? JSON.stringify(session.metadata) : null;
+    const sessionValues = {
+      selector: transcriptSessionSelector(session),
+      export_key: transcriptSessionExportKey(session),
+      session_slug: safeTranscriptPathSegment(session.sessionId),
+      provider_id: session.source.providerId,
+      title: session.title ?? null,
+      source_json: JSON.stringify(session.source),
+      stopped_at: session.stoppedAt ?? null,
+      metadata_json: session.metadata ? JSON.stringify(session.metadata) : null,
+    };
     const now = Date.now();
-    runOpenClawStateWriteTransaction(
-      ({ db: database }) => {
-        const db = meetingTranscriptDb(database);
-        executeSqliteQuerySync(
-          database,
-          db
-            .insertInto("meeting_transcript_sessions")
-            .values({
-              session_id: session.sessionId,
-              started_at: session.startedAt,
-              selector,
-              export_key: transcriptSessionExportKey(session),
-              session_slug: safeTranscriptPathSegment(session.sessionId),
-              provider_id: session.source.providerId,
-              title: session.title ?? null,
-              source_json: sourceJson,
-              stopped_at: session.stoppedAt ?? null,
-              metadata_json: metadataJson,
-              export_manifest_json: "{}",
-              export_pending_json: "[]",
-              next_utterance_seq: 0,
-              created_at_ms: now,
+    this.transaction("meeting-transcripts.session.write", ({ db: database }) => {
+      executeSqliteQuerySync(
+        database,
+        meetingTranscriptDb(database)
+          .insertInto("meeting_transcript_sessions")
+          .values({
+            session_id: session.sessionId,
+            started_at: session.startedAt,
+            ...sessionValues,
+            export_manifest_json: "{}",
+            export_pending_json: "[]",
+            next_utterance_seq: 0,
+            created_at_ms: now,
+            updated_at_ms: now,
+          })
+          .onConflict((conflict) =>
+            conflict.columns(["session_id", "started_at"]).doUpdateSet({
+              ...sessionValues,
               updated_at_ms: now,
-            })
-            .onConflict((conflict) =>
-              conflict.columns(["session_id", "started_at"]).doUpdateSet({
-                selector,
-                export_key: transcriptSessionExportKey(session),
-                session_slug: safeTranscriptPathSegment(session.sessionId),
-                provider_id: session.source.providerId,
-                title: session.title ?? null,
-                source_json: sourceJson,
-                stopped_at: session.stoppedAt ?? null,
-                metadata_json: metadataJson,
-                updated_at_ms: now,
-              }),
-            ),
-        );
-      },
-      this.databaseOptions,
-      { operationLabel: "meeting-transcripts.session.write" },
-    );
+            }),
+          ),
+      );
+    });
   }
 
   async readSession(sessionSelector: string): Promise<TranscriptSessionDescriptor | undefined> {
@@ -408,34 +386,18 @@ export class TranscriptsStore {
     const database = this.database();
     const db = meetingTranscriptDb(database.db);
     const qualified = /^\d{4}-\d{2}-\d{2}\//u.test(sessionSelector);
-    const exactRows = qualified
-      ? executeSqliteQuerySync(
-          database.db,
-          db
-            .selectFrom("meeting_transcript_sessions")
-            .selectAll()
-            .where("selector", "=", sessionSelector),
-        ).rows
-      : executeSqliteQuerySync(
-          database.db,
-          db
-            .selectFrom("meeting_transcript_sessions")
-            .selectAll()
-            .where("session_id", "=", sessionSelector)
-            .orderBy("started_at", "desc")
-            .limit(2),
-        ).rows;
-    const slugRows = qualified
-      ? []
-      : executeSqliteQuerySync(
-          database.db,
-          db
-            .selectFrom("meeting_transcript_sessions")
-            .selectAll()
-            .where("session_slug", "=", sessionSelector)
-            .orderBy("started_at", "desc")
-            .limit(2),
-        ).rows;
+    const matchingRows = (column: "selector" | "session_id" | "session_slug") => {
+      let query = db
+        .selectFrom("meeting_transcript_sessions")
+        .selectAll()
+        .where(column, "=", sessionSelector);
+      if (column !== "selector") {
+        query = query.orderBy("started_at", "desc").limit(2);
+      }
+      return executeSqliteQuerySync(database.db, query).rows;
+    };
+    const exactRows = matchingRows(qualified ? "selector" : "session_id");
+    const slugRows = qualified ? [] : matchingRows("session_slug");
     const rows = [
       ...new Map(
         [...exactRows, ...slugRows].map((row) => [`${row.session_id}\0${row.started_at}`, row]),
@@ -452,10 +414,7 @@ export class TranscriptsStore {
     if (!row) {
       return undefined;
     }
-    const summaryKeys = this.hasSummary(database, row)
-      ? new Set([`${row.session_id}\0${row.started_at}`])
-      : new Set<string>();
-    return this.entryFromRow(row, summaryKeys);
+    return this.entryFromRow(row, this.hasSummary(database, row));
   }
 
   async appendUtteranceForSession(
@@ -465,11 +424,8 @@ export class TranscriptsStore {
     const metadataJson = utterance.metadata ? JSON.stringify(utterance.metadata) : null;
     const now = Date.now();
     ensureMeetingTranscriptsSchema(this.databaseOptions);
-    runOpenClawStateWriteTransaction(
-      ({ db: database }) =>
-        appendMeetingTranscriptUtterance({ database, metadataJson, now, session, utterance }),
-      this.databaseOptions,
-      { operationLabel: "meeting-transcripts.utterance.append" },
+    this.transaction("meeting-transcripts.utterance.append", ({ db: database }) =>
+      appendMeetingTranscriptUtterance({ database, metadataJson, now, session, utterance }),
     );
   }
 
@@ -479,11 +435,7 @@ export class TranscriptsStore {
   ): Promise<TranscriptUtterance[]> {
     const database = this.database();
     const maxUtterances = resolveOptionalIntegerOption(options.maxUtterances, { min: 1 });
-    const query = meetingTranscriptDb(database.db)
-      .selectFrom("meeting_transcript_utterances")
-      .selectAll()
-      .where("session_id", "=", session.sessionId)
-      .where("session_started_at", "=", session.startedAt);
+    const query = meetingTranscriptUtteranceQuery(database.db, session).selectAll();
     if (maxUtterances === undefined) {
       return executeSqliteQuerySync(database.db, query.orderBy("sequence", "asc")).rows.map(
         utteranceFromRow,
@@ -515,35 +467,28 @@ export class TranscriptsStore {
     }
     const summaryJson = JSON.stringify(summary);
     const markdown = renderTranscriptsMarkdown(summary);
+    const summaryValues = {
+      generated_at: summary.generatedAt,
+      summary_json: summaryJson,
+      markdown,
+      utterance_count: summary.utteranceCount,
+    };
     ensureMeetingTranscriptsSchema(this.databaseOptions);
-    runOpenClawStateWriteTransaction(
-      ({ db: database }) => {
-        const db = meetingTranscriptDb(database);
-        executeSqliteQuerySync(
-          database,
-          db
-            .insertInto("meeting_transcript_summaries")
-            .values({
-              session_id: resolved.sessionId,
-              session_started_at: resolved.startedAt,
-              generated_at: summary.generatedAt,
-              summary_json: summaryJson,
-              markdown,
-              utterance_count: summary.utteranceCount,
-            })
-            .onConflict((conflict) =>
-              conflict.columns(["session_id", "session_started_at"]).doUpdateSet({
-                generated_at: summary.generatedAt,
-                summary_json: summaryJson,
-                markdown,
-                utterance_count: summary.utteranceCount,
-              }),
-            ),
-        );
-      },
-      this.databaseOptions,
-      { operationLabel: "meeting-transcripts.summary.write" },
-    );
+    this.transaction("meeting-transcripts.summary.write", ({ db: database }) => {
+      executeSqliteQuerySync(
+        database,
+        meetingTranscriptDb(database)
+          .insertInto("meeting_transcript_summaries")
+          .values({
+            session_id: resolved.sessionId,
+            session_started_at: resolved.startedAt,
+            ...summaryValues,
+          })
+          .onConflict((conflict) =>
+            conflict.columns(["session_id", "session_started_at"]).doUpdateSet(summaryValues),
+          ),
+      );
+    });
     return path.join(this.sessionDir(resolved), "summary.md");
   }
 
@@ -601,10 +546,6 @@ export class TranscriptsStore {
     kind: StoreTypes.TranscriptArtifactKind,
   ): Promise<StoreTypes.MaterializedTranscriptArtifacts> {
     const sessionDir = this.sessionDir(session);
-    const metadataPath = path.join(sessionDir, "metadata.json");
-    const transcriptPath = path.join(sessionDir, "transcript.jsonl");
-    const summaryJsonPath = path.join(sessionDir, "summary.json");
-    const summaryPath = path.join(sessionDir, "summary.md");
     const includeTranscript = kind === "all" || kind === "transcript";
     const includeSummary = kind === "all" || kind === "summary";
     const storedSummary = includeSummary ? await this.readSummary(session) : {};
@@ -668,10 +609,10 @@ export class TranscriptsStore {
     this.updateExportManifest(session, exportedHashes, removedExports);
     return {
       sessionDir,
-      metadataPath,
-      transcriptPath,
-      summaryJsonPath,
-      summaryPath,
+      metadataPath: path.join(sessionDir, "metadata.json"),
+      transcriptPath: path.join(sessionDir, "transcript.jsonl"),
+      summaryJsonPath: path.join(sessionDir, "summary.json"),
+      summaryPath: path.join(sessionDir, "summary.md"),
       hasSummary: storedSummary.summary !== undefined || storedSummary.markdown !== undefined,
     };
   }


### PR DESCRIPTION
## What Problem This Solves

Meeting-transcript persistence and exports repeated composite-session queries, synchronous SQLite transaction scaffolding, export manifest/pending updates, selector lookup, upsert payloads, and artifact-ownership verification. Duplicated ownership checks make privacy-sensitive collision handling harder to audit and keep consistent.

## Why This Change Was Made

Move those decisions into the existing transcript SQLite/export owners: share `(session_id, started_at)` session and utterance queries, use one synchronous labeled transaction boundary, consolidate pending/manifest mutation, and verify every candidate and the final selected owner with the same artifact verifier. Reuse canonical selector matching and identical session/summary upsert values.

Production code changes from 280 removed lines to 207 added lines: **73 fewer production LOC** across exactly four transcript-owner files. No test, public API, configuration, default, or SQLite schema changes.

## User Impact

No intentional behavior change. Repeated session IDs still require their complete identity; exact utterance retries remain deduplicated while same-ID revisions survive; bounded JSONL exports retain sequence order. Agent ownership/privacy, date-qualified selectors, case-sensitive/case-insensitive collisions, Doctor/archive restoration, missing metadata, interrupted-export recovery, and concurrent export leases remain unchanged.

Metadata ownership keeps `O_NOFOLLOW`; pending, missing, changed, non-file, and symlinked artifacts cannot establish ownership. Candidate ownership is still verified and the uniquely selected owner is verified a second time. Transaction labels, synchronous commit/rollback boundaries, missing-session errors, and persisted manifest ordering remain unchanged.

## Evidence

- Independent exact `gpt-5.6-sol` / `xhigh` autoreview: **clean, 0 findings, confidence 0.97**.
- Direct installed Kysely dependency inspection plus **12 byte-identical before/after compiled SQL and binding comparisons** covering composite session queries, ordered/bounded/revision utterance queries, three selector paths, and session/summary upserts.
- Source audit confirms all four SQLite transaction callbacks stay synchronous, all transaction/lease labels remain unchanged, metadata `O_NOFOLLOW` and all symlink/non-file/pending/hash/unique-owner guards remain, and selected-owner verification still runs twice.
- Trusted Blacksmith Testbox `tbx_01kz927dq5pfwjt8z54y7rm07b`: **8 suites, 155 tests, 5 Vitest shards, all passing**: transcript store (20), agent transcript tool/ownership (18), Doctor meeting-transcript migration/export restoration (27), transcript summary (3), source-locator credential privacy (1), transcript redaction (53), synchronous Kysely helpers (21), and SQLite transactions/rollback (12).
- The same Testbox passed the complete unchanged **`pnpm check:changed`** gate, including production/core-test typechecks, zero-warning lint, formatting, all zero-entry dead-export scans, SDK/boundary checks, unchanged native SQLite schema version, database-first policy, zero runtime import cycles, and security guards.
- Remote proof: https://github.com/openclaw/openclaw/actions/runs/31011015066. The sole lease was stopped and independently verified `completed`.

