### PR TITLE
refactor(outbound): unify conversation binding ownership

### DIFF
--- a/src/infra/outbound/account-scoped-conversation-bindings.ts
+++ b/src/infra/outbound/account-scoped-conversation-bindings.ts
@@ -9,6 +9,7 @@ import {
 } from "../../channels/thread-bindings-policy.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { normalizeAccountId, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
 import {
   registerSessionBindingAdapter,
   unregisterSessionBindingAdapter,
@@ -62,23 +63,14 @@ type AccountScopedConversationBindingsState<TKind extends string> = {
 function getState<TKind extends string>(
   stateKey: symbol,
 ): AccountScopedConversationBindingsState<TKind> {
-  const globalStore = globalThis as Record<PropertyKey, unknown>;
-  const existing = globalStore[stateKey] as
-    | AccountScopedConversationBindingsState<TKind>
-    | undefined;
-  if (existing) {
-    return existing;
-  }
-  const next: AccountScopedConversationBindingsState<TKind> = {
+  return resolveGlobalSingleton(stateKey, () => ({
     managersByAccountId: new Map(),
     bindingsByAccountConversation: new Map(),
-  };
-  globalStore[stateKey] = next;
-  return next;
+  }));
 }
 
-function resolveBindingKey(params: { accountId: string; conversationId: string }): string {
-  return `${params.accountId}:${params.conversationId}`;
+function resolveBindingKey(accountId: string, conversationId: string): string {
+  return `${accountId}:${conversationId}`;
 }
 
 function toSessionBindingRecord<TKind extends string>(params: {
@@ -96,10 +88,7 @@ function toSessionBindingRecord<TKind extends string>(params: {
       ? Math.min(idleExpiresAt, maxAgeExpiresAt)
       : (idleExpiresAt ?? maxAgeExpiresAt);
   return {
-    bindingId: resolveBindingKey({
-      accountId: params.record.accountId,
-      conversationId: params.record.conversationId,
-    }),
+    bindingId: resolveBindingKey(params.record.accountId, params.record.conversationId),
     targetSessionKey: params.record.targetSessionKey,
     targetKind: params.toSessionBindingTargetKind(params.record.targetKind),
     conversation: {
@@ -149,6 +138,16 @@ export function createAccountScopedConversationBindingManager<TKind extends stri
     channel: params.channel,
     accountId,
   });
+  const asSessionBindingRecord = (
+    record: AccountScopedConversationBindingRecord<TKind>,
+  ): SessionBindingRecord =>
+    toSessionBindingRecord({
+      channel: params.channel,
+      record,
+      idleTimeoutMs,
+      maxAgeMs,
+      toSessionBindingTargetKind: params.toSessionBindingTargetKind,
+    });
   const resolveActiveBinding = (
     record: AccountScopedConversationBindingRecord<TKind> | undefined,
     now = Date.now(),
@@ -156,28 +155,20 @@ export function createAccountScopedConversationBindingManager<TKind extends stri
     if (!record) {
       return undefined;
     }
-    const { expiresAt } = toSessionBindingRecord({
-      channel: params.channel,
-      record,
-      idleTimeoutMs,
-      maxAgeMs,
-      toSessionBindingTargetKind: params.toSessionBindingTargetKind,
-    });
+    const { expiresAt } = asSessionBindingRecord(record);
     if (expiresAt === undefined || isFutureDateTimestampMs(expiresAt, { nowMs: now })) {
       return record;
     }
 
     // Prune at the account owner so SDK lookups and touches cannot revive stale bindings.
-    state.bindingsByAccountConversation.delete(
-      resolveBindingKey({ accountId, conversationId: record.conversationId }),
-    );
+    state.bindingsByAccountConversation.delete(resolveBindingKey(accountId, record.conversationId));
     return undefined;
   };
   const manager: AccountScopedConversationBindingManager<TKind> = {
     accountId,
     getByConversationId: (conversationId) =>
       resolveActiveBinding(
-        state.bindingsByAccountConversation.get(resolveBindingKey({ accountId, conversationId })),
+        state.bindingsByAccountConversation.get(resolveBindingKey(accountId, conversationId)),
       ),
     listBySessionKey: (targetSessionKey) => {
       const now = Date.now();
@@ -220,55 +211,51 @@ export function createAccountScopedConversationBindingManager<TKind extends stri
         boundAt: now,
         lastActivityAt: now,
       };
-      getState<TKind>(params.stateKey).bindingsByAccountConversation.set(
-        resolveBindingKey({ accountId, conversationId: normalizedConversationId }),
+      state.bindingsByAccountConversation.set(
+        resolveBindingKey(accountId, normalizedConversationId),
         record,
       );
       return record;
     },
     touchConversation: (conversationId, at = Date.now()) => {
-      const key = resolveBindingKey({ accountId, conversationId });
+      const key = resolveBindingKey(accountId, conversationId);
       const existingRecord = manager.getByConversationId(conversationId);
       if (!existingRecord) {
         return null;
       }
       const updated = { ...existingRecord, lastActivityAt: at };
-      getState<TKind>(params.stateKey).bindingsByAccountConversation.set(key, updated);
+      state.bindingsByAccountConversation.set(key, updated);
       return updated;
     },
     unbindConversation: (conversationId) => {
-      const key = resolveBindingKey({ accountId, conversationId });
-      const existingRecord = getState<TKind>(params.stateKey).bindingsByAccountConversation.get(
-        key,
-      );
+      const key = resolveBindingKey(accountId, conversationId);
+      const existingRecord = state.bindingsByAccountConversation.get(key);
       if (!existingRecord) {
         return null;
       }
-      getState<TKind>(params.stateKey).bindingsByAccountConversation.delete(key);
+      state.bindingsByAccountConversation.delete(key);
       return existingRecord;
     },
     unbindBySessionKey: (targetSessionKey) => {
       const removed: AccountScopedConversationBindingRecord<TKind>[] = [];
-      for (const record of getState<TKind>(
-        params.stateKey,
-      ).bindingsByAccountConversation.values()) {
+      for (const record of state.bindingsByAccountConversation.values()) {
         if (record.accountId !== accountId || record.targetSessionKey !== targetSessionKey) {
           continue;
         }
-        getState<TKind>(params.stateKey).bindingsByAccountConversation.delete(
-          resolveBindingKey({ accountId, conversationId: record.conversationId }),
+        state.bindingsByAccountConversation.delete(
+          resolveBindingKey(accountId, record.conversationId),
         );
         removed.push(record);
       }
       return removed;
     },
     stop: () => {
-      for (const key of getState<TKind>(params.stateKey).bindingsByAccountConversation.keys()) {
+      for (const key of state.bindingsByAccountConversation.keys()) {
         if (key.startsWith(`${accountId}:`)) {
-          getState<TKind>(params.stateKey).bindingsByAccountConversation.delete(key);
+          state.bindingsByAccountConversation.delete(key);
         }
       }
-      getState<TKind>(params.stateKey).managersByAccountId.delete(accountId);
+      state.managersByAccountId.delete(accountId);
       unregisterSessionBindingAdapter({
         channel: params.channel,
         accountId,
@@ -293,40 +280,16 @@ export function createAccountScopedConversationBindingManager<TKind extends stri
         targetSessionKey: input.targetSessionKey,
         metadata: input.metadata,
       });
-      return bound
-        ? toSessionBindingRecord({
-            channel: params.channel,
-            record: bound,
-            idleTimeoutMs,
-            maxAgeMs,
-            toSessionBindingTargetKind: params.toSessionBindingTargetKind,
-          })
-        : null;
+      return bound ? asSessionBindingRecord(bound) : null;
     },
     listBySession: (targetSessionKey) =>
-      manager.listBySessionKey(targetSessionKey).map((entry) =>
-        toSessionBindingRecord({
-          channel: params.channel,
-          record: entry,
-          idleTimeoutMs,
-          maxAgeMs,
-          toSessionBindingTargetKind: params.toSessionBindingTargetKind,
-        }),
-      ),
+      manager.listBySessionKey(targetSessionKey).map(asSessionBindingRecord),
     resolveByConversation: (ref) => {
       if (ref.channel !== params.channel) {
         return null;
       }
       const found = manager.getByConversationId(ref.conversationId);
-      return found
-        ? toSessionBindingRecord({
-            channel: params.channel,
-            record: found,
-            idleTimeoutMs,
-            maxAgeMs,
-            toSessionBindingTargetKind: params.toSessionBindingTargetKind,
-          })
-        : null;
+      return found ? asSessionBindingRecord(found) : null;
     },
     touch: (bindingId, at) => {
       const conversationId = resolveThreadBindingConversationIdFromBindingId({
@@ -339,15 +302,9 @@ export function createAccountScopedConversationBindingManager<TKind extends stri
     },
     unbind: async (input) => {
       if (input.targetSessionKey?.trim()) {
-        return manager.unbindBySessionKey(input.targetSessionKey.trim()).map((entry) =>
-          toSessionBindingRecord({
-            channel: params.channel,
-            record: entry,
-            idleTimeoutMs,
-            maxAgeMs,
-            toSessionBindingTargetKind: params.toSessionBindingTargetKind,
-          }),
-        );
+        return manager
+          .unbindBySessionKey(input.targetSessionKey.trim())
+          .map(asSessionBindingRecord);
       }
       const conversationId = resolveThreadBindingConversationIdFromBindingId({
         accountId,
@@ -357,22 +314,12 @@ export function createAccountScopedConversationBindingManager<TKind extends stri
         return [];
       }
       const removed = manager.unbindConversation(conversationId);
-      return removed
-        ? [
-            toSessionBindingRecord({
-              channel: params.channel,
-              record: removed,
-              idleTimeoutMs,
-              maxAgeMs,
-              toSessionBindingTargetKind: params.toSessionBindingTargetKind,
-            }),
-          ]
-        : [];
+      return removed ? [asSessionBindingRecord(removed)] : [];
     },
   };
 
   registerSessionBindingAdapter(sessionBindingAdapter);
-  getState<TKind>(params.stateKey).managersByAccountId.set(accountId, manager);
+  state.managersByAccountId.set(accountId, manager);
   return manager;
 }
 

--- a/src/infra/outbound/session-binding-service.ts
+++ b/src/infra/outbound/session-binding-service.ts
@@ -79,10 +79,6 @@ export type SessionBindingAdapter = {
   unbind?: (input: SessionBindingUnbindInput) => Promise<SessionBindingRecord[]>;
 };
 
-function toAdapterKey(params: { channel: string; accountId: string }): string {
-  return buildChannelAccountKey(params);
-}
-
 function normalizePlacement(raw: unknown): SessionBindingPlacement | undefined {
   return raw === "current" || raw === "child" ? raw : undefined;
 }
@@ -133,11 +129,6 @@ const ADAPTERS_BY_CHANNEL_ACCOUNT = resolveGlobalMap<string, SessionBindingAdapt
   SESSION_BINDING_ADAPTERS_KEY,
 );
 
-function getActiveAdapterForKey(key: string): SessionBindingAdapter | null {
-  const registrations = ADAPTERS_BY_CHANNEL_ACCOUNT.get(key);
-  return registrations?.at(-1)?.normalizedAdapter ?? null;
-}
-
 export function registerSessionBindingAdapter(adapter: SessionBindingAdapter): void {
   const normalizedAdapter = {
     ...adapter,
@@ -147,10 +138,7 @@ export function registerSessionBindingAdapter(adapter: SessionBindingAdapter): v
       conversationId: "unused",
     }),
   };
-  const key = toAdapterKey({
-    channel: normalizedAdapter.channel,
-    accountId: normalizedAdapter.accountId,
-  });
+  const key = buildChannelAccountKey(normalizedAdapter);
   const existing = ADAPTERS_BY_CHANNEL_ACCOUNT.get(key);
   const registrations = existing ? [...existing] : [];
   // Registrations are stacked so duplicate module graphs can temporarily
@@ -167,7 +155,7 @@ export function unregisterSessionBindingAdapter(params: {
   accountId: string;
   adapter?: SessionBindingAdapter;
 }): void {
-  const key = toAdapterKey(params);
+  const key = buildChannelAccountKey(params);
   const registrations = ADAPTERS_BY_CHANNEL_ACCOUNT.get(key);
   if (!registrations || registrations.length === 0) {
     return;
@@ -192,22 +180,14 @@ export function unregisterSessionBindingAdapter(params: {
   ADAPTERS_BY_CHANNEL_ACCOUNT.set(key, nextRegistrations);
 }
 
-function resolveAdapterForConversation(ref: ConversationRef): SessionBindingAdapter | null {
-  return resolveAdapterForChannelAccount({
-    channel: ref.channel,
-    accountId: ref.accountId,
-  });
-}
-
 function resolveAdapterForChannelAccount(params: {
   channel: string;
   accountId: string;
 }): SessionBindingAdapter | null {
-  const key = toAdapterKey({
-    channel: params.channel,
-    accountId: params.accountId,
-  });
-  return getActiveAdapterForKey(key);
+  return (
+    ADAPTERS_BY_CHANNEL_ACCOUNT.get(buildChannelAccountKey(params))?.at(-1)?.normalizedAdapter ??
+    null
+  );
 }
 
 function getActiveRegisteredAdapters(): SessionBindingAdapter[] {
@@ -231,44 +211,11 @@ function createDefaultSessionBindingService(): SessionBindingService {
   return {
     bind: async (input) => {
       const normalizedConversation = normalizeConversationRef(input.conversation);
-      const adapter = resolveAdapterForConversation(normalizedConversation);
-      if (!adapter) {
-        const genericCapabilities = getGenericCurrentConversationBindingCapabilities({
-          channel: normalizedConversation.channel,
-          accountId: normalizedConversation.accountId,
-        });
-        if (genericCapabilities?.bindSupported) {
-          const placement =
-            normalizePlacement(input.placement) ?? inferDefaultPlacement(normalizedConversation);
-          if (placement !== "current") {
-            throw new SessionBindingError(
-              "BINDING_CAPABILITY_UNSUPPORTED",
-              `Session binding placement "${placement}" is not supported for ${normalizedConversation.channel}:${normalizedConversation.accountId}`,
-              {
-                channel: normalizedConversation.channel,
-                accountId: normalizedConversation.accountId,
-                placement,
-              },
-            );
-          }
-          const bound = await bindGenericCurrentConversation({
-            ...input,
-            conversation: normalizedConversation,
-            placement,
-          });
-          if (!bound) {
-            throw new SessionBindingError(
-              "BINDING_CREATE_FAILED",
-              "Session binding adapter failed to bind target conversation",
-              {
-                channel: normalizedConversation.channel,
-                accountId: normalizedConversation.accountId,
-                placement,
-              },
-            );
-          }
-          return bound;
-        }
+      const adapter = resolveAdapterForChannelAccount(normalizedConversation);
+      const genericCapabilities = adapter
+        ? null
+        : getGenericCurrentConversationBindingCapabilities(normalizedConversation);
+      if (!adapter && !genericCapabilities?.bindSupported) {
         throw new SessionBindingError(
           "BINDING_ADAPTER_UNAVAILABLE",
           `Session binding adapter unavailable for ${normalizedConversation.channel}:${normalizedConversation.accountId}`,
@@ -278,7 +225,7 @@ function createDefaultSessionBindingService(): SessionBindingService {
           },
         );
       }
-      if (!adapter.bind) {
+      if (adapter && !adapter.bind) {
         throw new SessionBindingError(
           "BINDING_CAPABILITY_UNSUPPORTED",
           `Session binding adapter does not support binding for ${normalizedConversation.channel}:${normalizedConversation.accountId}`,
@@ -290,7 +237,9 @@ function createDefaultSessionBindingService(): SessionBindingService {
       }
       const placement =
         normalizePlacement(input.placement) ?? inferDefaultPlacement(normalizedConversation);
-      const supportedPlacements = resolveAdapterPlacements(adapter);
+      const supportedPlacements = adapter
+        ? resolveAdapterPlacements(adapter)
+        : genericCapabilities!.placements;
       if (!supportedPlacements.includes(placement)) {
         throw new SessionBindingError(
           "BINDING_CAPABILITY_UNSUPPORTED",
@@ -302,11 +251,14 @@ function createDefaultSessionBindingService(): SessionBindingService {
           },
         );
       }
-      const bound = await adapter.bind({
+      const bindInput = {
         ...input,
         conversation: normalizedConversation,
         placement,
-      });
+      };
+      const bound = adapter
+        ? await adapter.bind!(bindInput)
+        : await bindGenericCurrentConversation(bindInput);
       if (!bound) {
         throw new SessionBindingError(
           "BINDING_CREATE_FAILED",
@@ -321,18 +273,11 @@ function createDefaultSessionBindingService(): SessionBindingService {
       return bound;
     },
     getCapabilities: (params) => {
-      const adapter = resolveAdapterForChannelAccount({
-        channel: params.channel,
-        accountId: params.accountId,
-      });
+      const adapter = resolveAdapterForChannelAccount(params);
       if (!adapter) {
         return (
-          getGenericCurrentConversationBindingCapabilities(params) ?? {
-            adapterAvailable: false,
-            bindSupported: false,
-            unbindSupported: false,
-            placements: [],
-          }
+          getGenericCurrentConversationBindingCapabilities(params) ??
+          resolveAdapterCapabilities(null)
         );
       }
       return resolveAdapterCapabilities(adapter);
@@ -357,7 +302,7 @@ function createDefaultSessionBindingService(): SessionBindingService {
       if (!normalized.channel || !normalized.conversationId) {
         return null;
       }
-      const adapter = resolveAdapterForConversation(normalized);
+      const adapter = resolveAdapterForChannelAccount(normalized);
       if (!adapter) {
         return resolveGenericCurrentConversationBinding(normalized);
       }


### PR DESCRIPTION
## What Problem This Solves

Conversation bindings keep channel conversations attached to the right account and agent session. Their shared service and account-scoped manager duplicated binding placement, failure handling, registration lookups, and record conversion, making security-sensitive ownership rules harder to audit and maintain.

## Why This Change Was Made

Use one canonical account-scoped state and record-conversion path, and route generic and channel-specific binding creation through the same placement and failure policy. Preserve normalized account ownership, adapter method receivers, newest-registration precedence across duplicate module graphs, existing expiry and metadata behavior, synchronous SQLite publication, and every public plugin-SDK contract.

## User Impact

No intended user-visible behavior or configuration change. Conversation routing, account isolation, approval boundaries, binding expiration, privacy, and operator-visible failures remain unchanged while removing 108 production lines.

## Evidence

- Production: +64/-172 across two files; **108 fewer lines**, no test churn, no configuration/schema/default changes.
- Actual-source old-versus-new differential: **34 behavioral cases passed**, covering account isolation, exact generic/custom placement errors, adapter receivers, registration stacks, idle/max-age expiry, metadata inheritance, unbinding, and lifecycle cleanup.
- Duplicate-module differential: two independent service modules and two account-manager modules preserve shared singleton identity, newest-adapter ownership, restoration after unregister, and account-local cleanup.
- Trusted Blacksmith Testbox: **60 tests passed across nine focused files and five Vitest shards**, including generic SQLite persistence, registry-backed channel contracts, routing, account expiry, and iMessage conversation-routing/approval-control security.
- Full remote `pnpm check:changed` passed: protected plugin-SDK API baseline unchanged, production and test typechecking, zero-warning lint, database-first/schema guards, zero runtime import cycles, and pairing-account/webhook-auth security guards.
- Independent `gpt-5.6-sol`/`xhigh` autoreview: no findings (confidence 0.98).
- Remote validation: https://github.com/openclaw/openclaw/actions/runs/31011292672

### Observed redacted production-boundary lifecycle

Executed the actual production account-scoped manager, session binding service, generic conversation binding owner, and synchronous Kysely owner from unchanged reviewed head `e92bea876e848224cd6f0bb7f04494f75f4a762a`. The fixture used Node's real `node:sqlite` `:memory:` database initialized with the exact-head canonical production `STRICT` schema. All identities, conversation identifiers, metadata, and session keys below are synthetic; no network, user state, credentials, or real conversation data were accessed. SQLite transaction callbacks were asserted synchronous.

```json
{
  "exactHead": "e92bea876e848224cd6f0bb7f04494f75f4a762a",
  "fixture": {
    "identities": "synthetic redacted account-a/account-b only",
    "stateDatabase": "node:sqlite :memory:",
    "schema": "exact-head canonical current_conversation_bindings STRICT table",
    "productionOwners": [
      "account-scoped-conversation-bindings",
      "session-binding-service",
      "current-conversation-bindings",
      "kysely-sync"
    ],
    "network": "none",
    "userState": "untouched"
  },
  "steps": [
    {
      "event": "create_account_a",
      "accountId": "account-a",
      "bindingId": "account-a:synthetic-room",
      "targetSessionKey": "agent:alpha:session:synthetic-a"
    },
    {
      "event": "deny_account_b_cross_account_lookup",
      "requestAccountId": "account-b",
      "targetConversationId": "synthetic-room",
      "resolved": null
    },
    {
      "event": "create_account_b_same_conversation",
      "accountId": "account-b",
      "targetSessionKey": "agent:beta:session:synthetic-b",
      "isolatedFromAccountA": true
    },
    {
      "event": "resolve_account_a_owner_metadata",
      "accountId": "account-a",
      "targetSessionKey": "agent:alpha:session:synthetic-a",
      "metadata": {
        "agentId": "alpha",
        "label": "synthetic-owner-a",
        "boundBy": "synthetic-operator-a"
      },
      "expiresAt": 1700000001000
    },
    {
      "event": "generic_binding_persisted_in_isolated_sqlite",
      "accountId": "account-a",
      "bindingId": "generic:workspace␟account-a␟␟synthetic-workspace-room",
      "sqliteRows": 1,
      "sqliteAccountIds": [
        "account-a"
      ],
      "crossAccountResolve": null,
      "synchronousCommits": 1
    },
    {
      "event": "custom_adapter_registration_stack",
      "newestAdapterBindingId": "synthetic-overlay-binding",
      "methodReceiverAccountId": "account-a",
      "restoredOwnerBindingId": "account-a:synthetic-room",
      "genericSqliteRowsUnaffected": 1
    },
    {
      "event": "expire_account_a_and_generic_without_cross_account_leakage",
      "now": 1700000001000,
      "accountAResolved": null,
      "accountBStillActive": true,
      "genericResolved": null,
      "sqliteRowsAfterExpiry": 0,
      "synchronousCommits": 2
    },
    {
      "event": "unbind_account_b_only",
      "removedAccounts": [
        "account-b"
      ],
      "accountBResolvedAfterUnbind": null
    },
    {
      "event": "owner_registry_and_sqlite_cleanup",
      "remainingAdapterKeys": [],
      "remainingSqliteRows": 0,
      "synchronousCommits": 2
    }
  ]
}
```

### Observed exact-head channel-routing and transport trace

This is an actual **channel-routing production-boundary run**, not merely a binding-store probe. Exact committed `src/channels/plugins/binding-routing.ts` rewrites inbound channel routes, exact committed `src/infra/outbound/bound-delivery-router.ts` authorizes task-completion destinations, and the resulting allowed destination reaches a synthetic channel `sendText` transport. Both account-scoped manager bindings and real `node:sqlite` `:memory:` generic bindings use their unchanged production owners and exact-head canonical `STRICT` schema. Account B receives no transport call; expired routes fall back without delivery; account B's independent route remains active; all registries and SQLite rows are cleaned. No gateway/provider/network/user-state access occurred.

```json
{
  "exactHead": "e92bea876e848224cd6f0bb7f04494f75f4a762a",
  "boundary": "actual channel inbound binding router -> actual bound completion delivery router -> synthetic channel transport",
  "productionModules": [
    "src/channels/plugins/binding-routing.ts",
    "src/infra/outbound/bound-delivery-router.ts",
    "src/infra/outbound/account-scoped-conversation-bindings.ts",
    "src/infra/outbound/session-binding-service.ts",
    "src/infra/outbound/current-conversation-bindings.ts",
    "src/infra/kysely-sync.ts"
  ],
  "fixture": {
    "channelApi": "synthetic sendText transport, provider/network disabled",
    "identities": "synthetic account-a/account-b only",
    "state": "real node:sqlite :memory: with exact-head canonical STRICT schema",
    "userState": "untouched"
  },
  "steps": [
    {
      "event": "channel_runtime_route_account_isolation",
      "channel": "imessage",
      "accountARoute": {
        "accountId": "account-a",
        "matchedBy": "binding.channel",
        "sessionKey": "agent:alpha:session:synthetic-a",
        "agentId": "alpha",
        "bindingId": "account-a:synthetic-room"
      },
      "accountBRoute": {
        "accountId": "account-b",
        "matchedBy": "default",
        "sessionKey": "agent:main:main",
        "agentId": "main",
        "bindingId": null
      },
      "crossAccountSessionLeak": false
    },
    {
      "event": "outbound_bound_delivery_channel_transport",
      "accountA": {
        "requesterAccountId": "account-a",
        "mode": "bound",
        "reason": "requester-match",
        "transportCalled": true,
        "transportAccountId": "account-a",
        "conversationId": "synthetic-room",
        "messageId": "synthetic-delivery-1"
      },
      "accountBAttempt": {
        "requesterAccountId": "account-b",
        "mode": "fallback",
        "reason": "no-requester-match",
        "transportCalled": false
      },
      "transportDeliveries": 1
    },
    {
      "event": "same_conversation_independent_account_routes",
      "accountAExpectedSession": "agent:alpha:session:synthetic-a",
      "accountBRoute": {
        "accountId": "account-b",
        "matchedBy": "binding.channel",
        "sessionKey": "agent:beta:session:synthetic-b",
        "agentId": "beta",
        "bindingId": "account-b:synthetic-room"
      },
      "accountBAgainstAccountASession": {
        "requesterAccountId": "account-b",
        "mode": "fallback",
        "reason": "no-requester-match",
        "transportCalled": false
      },
      "transportDeliveries": 1
    },
    {
      "event": "sqlite_generic_binding_routes_to_synthetic_channel_transport",
      "sqliteRows": 1,
      "sqliteAccountId": "account-a",
      "accountARoute": {
        "accountId": "account-a",
        "matchedBy": "binding.channel",
        "sessionKey": "agent:alpha:session:synthetic-workspace",
        "agentId": "alpha",
        "bindingId": "generic:workspace␟account-a␟␟synthetic-workspace-room"
      },
      "accountBRoute": {
        "accountId": "account-b",
        "matchedBy": "default",
        "sessionKey": "agent:main:main",
        "agentId": "main",
        "bindingId": null
      },
      "accountADelivery": {
        "requesterAccountId": "account-a",
        "mode": "bound",
        "reason": "requester-match",
        "transportCalled": true,
        "transportAccountId": "account-a",
        "conversationId": "synthetic-workspace-room",
        "messageId": "synthetic-delivery-2"
      },
      "accountBAttempt": {
        "requesterAccountId": "account-b",
        "mode": "fallback",
        "reason": "no-requester-match",
        "transportCalled": false
      },
      "transportDeliveries": 2,
      "synchronousCommits": 2
    },
    {
      "event": "expired_bindings_stop_channel_routing_and_transport",
      "now": 1700000001000,
      "expiredAccountARoute": {
        "accountId": "account-a",
        "matchedBy": "default",
        "sessionKey": "agent:main:main",
        "agentId": "main",
        "bindingId": null
      },
      "unaffectedAccountBRoute": {
        "accountId": "account-b",
        "matchedBy": "binding.channel",
        "sessionKey": "agent:beta:session:synthetic-b",
        "agentId": "beta",
        "bindingId": "account-b:synthetic-room"
      },
      "expiredGenericRoute": {
        "accountId": "account-a",
        "matchedBy": "default",
        "sessionKey": "agent:main:main",
        "agentId": "main",
        "bindingId": null
      },
      "accountADeliveryAfterExpiry": {
        "requesterAccountId": "account-a",
        "mode": "fallback",
        "reason": "no-active-binding",
        "transportCalled": false
      },
      "genericDeliveryAfterExpiry": {
        "requesterAccountId": "account-a",
        "mode": "fallback",
        "reason": "no-active-binding",
        "transportCalled": false
      },
      "sqliteRowsAfterExpiry": 0,
      "transportDeliveriesStill": 2
    },
    {
      "event": "channel_owner_cleanup",
      "removedAccounts": [
        "account-b"
      ],
      "remainingAdapterKeys": [],
      "remainingSqliteRows": 0,
      "totalSyntheticTransportDeliveries": 2,
      "transportDeliveryAccounts": [
        "account-a",
        "account-a"
      ],
      "synchronousSqliteCommits": 3
    }
  ]
}
```

### Reviewed-head landing posture

The immutable reviewed head `e92bea876e848224cd6f0bb7f04494f75f4a762a` already has exact-head hosted CI gate and build checks **SUCCESS**; the observed production channel-routing and synthetic-transport trace above remains intact. The branch is mergeable when GitHub recomputes mergeability. Advancement of `main` alone is advisory, not a conflict or a reason to rewrite this reviewed head. **No rebase and no bot review refresh:** the reviewed head and its evidence are unchanged.

