### PR TITLE
refactor(gateway): consolidate chat abort authorization

### DIFF
--- a/src/gateway/server-methods/chat-abort-authorization.ts
+++ b/src/gateway/server-methods/chat-abort-authorization.ts
@@ -3,7 +3,6 @@ import { uniqueStrings } from "@openclaw/normalization-core/string-normalization
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
 import type { ChatAbortControllerEntry } from "../chat-abort.js";
-import type { QueuedChatTurnEntry } from "../chat-queued-turns.js";
 import { ADMIN_SCOPE } from "../method-scopes.js";
 import { createChatAbortMarker } from "../server-chat-state.js";
 import { pendingChatSendDedupeKey } from "../server-shared.js";
@@ -67,29 +66,9 @@ export function resolveChatAbortRequester(
 }
 
 export function canRequesterAbortChatRun(
-  entry: ChatAbortControllerEntry,
+  entry: Pick<ChatAbortControllerEntry, "ownerDeviceId" | "ownerConnId">,
   requester: ChatAbortRequester,
-): boolean {
-  if (requester.isAdmin) {
-    return true;
-  }
-  const ownerDeviceId = normalizeOptionalText(entry.ownerDeviceId);
-  const ownerConnId = normalizeOptionalText(entry.ownerConnId);
-  if (!ownerDeviceId && !ownerConnId) {
-    return true;
-  }
-  if (ownerDeviceId && requester.deviceId && ownerDeviceId === requester.deviceId) {
-    return true;
-  }
-  if (ownerConnId && requester.connId && ownerConnId === requester.connId) {
-    return true;
-  }
-  return false;
-}
-
-export function canRequesterAbortChatRunWithoutSessionMatch(
-  entry: ChatAbortControllerEntry,
-  requester: ChatAbortRequester,
+  options: { requireOwnerMatch?: boolean } = {},
 ): boolean {
   if (requester.isAdmin) {
     return true;
@@ -97,6 +76,7 @@ export function canRequesterAbortChatRunWithoutSessionMatch(
   const ownerDeviceId = normalizeOptionalText(entry.ownerDeviceId);
   const ownerConnId = normalizeOptionalText(entry.ownerConnId);
   return Boolean(
+    (!options.requireOwnerMatch && !ownerDeviceId && !ownerConnId) ||
     (ownerDeviceId && requester.deviceId && ownerDeviceId === requester.deviceId) ||
     (ownerConnId && requester.connId && ownerConnId === requester.connId),
   );
@@ -188,15 +168,8 @@ export function canRequesterAbortPreRegisteredRun(
 ): boolean {
   return canRequesterAbortChatRun(
     {
-      controller: new AbortController(),
-      sessionId: "",
-      sessionKey: normalizeUnknownText(payload.sessionKey) ?? "",
-      startedAtMs: 0,
-      expiresAtMs: 0,
       ownerConnId: normalizeUnknownText(payload.ownerConnId),
       ownerDeviceId: normalizeUnknownText(payload.ownerDeviceId),
-      controlUiVisible: payload.controlUiVisible === false ? false : undefined,
-      kind: "agent",
     },
     requester,
   );
@@ -438,41 +411,4 @@ export function resolveAuthorizedRunsForSessionKeys(params: {
     hasUnauthorizedProtectedRuns,
     hasProtectedRuns,
   };
-}
-
-export function canRequesterAbortQueuedChatTurn(
-  entry: QueuedChatTurnEntry,
-  requester: ChatAbortRequester,
-): boolean {
-  // Same ownership rules as active chat runs.
-  if (requester.isAdmin) {
-    return true;
-  }
-  const ownerDeviceId = normalizeOptionalText(entry.ownerDeviceId);
-  const ownerConnId = normalizeOptionalText(entry.ownerConnId);
-  if (!ownerDeviceId && !ownerConnId) {
-    return true;
-  }
-  if (ownerDeviceId && requester.deviceId && ownerDeviceId === requester.deviceId) {
-    return true;
-  }
-  if (ownerConnId && requester.connId && ownerConnId === requester.connId) {
-    return true;
-  }
-  return false;
-}
-
-export function canRequesterAbortQueuedChatTurnWithoutSessionMatch(
-  entry: QueuedChatTurnEntry,
-  requester: ChatAbortRequester,
-): boolean {
-  if (requester.isAdmin) {
-    return true;
-  }
-  const ownerDeviceId = normalizeOptionalText(entry.ownerDeviceId);
-  const ownerConnId = normalizeOptionalText(entry.ownerConnId);
-  return Boolean(
-    (ownerDeviceId && requester.deviceId && ownerDeviceId === requester.deviceId) ||
-    (ownerConnId && requester.connId && ownerConnId === requester.connId),
-  );
 }

--- a/src/gateway/server-methods/chat-abort-handler.ts
+++ b/src/gateway/server-methods/chat-abort-handler.ts
@@ -7,17 +7,14 @@ import {
 import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
-import { abortChatRunById } from "../chat-abort.js";
-import { abortQueuedChatTurnById } from "../chat-queued-turns.js";
+import { abortChatRunById, type ChatAbortControllerEntry } from "../chat-abort.js";
+import { abortQueuedChatTurnById, type QueuedChatTurnEntry } from "../chat-queued-turns.js";
 import { pendingChatSendDedupeKey } from "../server-shared.js";
 import { loadSessionEntry, resolveSessionStoreKey } from "../session-utils.js";
 import { asWorkerInferenceControl } from "../worker-environments/inference-control.js";
 import {
   canRequesterAbortChatRun,
-  canRequesterAbortChatRunWithoutSessionMatch,
   canRequesterAbortPreRegisteredRun,
-  canRequesterAbortQueuedChatTurn,
-  canRequesterAbortQueuedChatTurnWithoutSessionMatch,
   readPreRegisteredAgentDedupePayloadForSession,
   resolveChatAbortRequester,
   resolveStoredGlobalRunAgentId,
@@ -28,7 +25,6 @@ import {
   abortChatRunsForSessionKeyWithPartials,
   cancelWorkerInferenceForSession,
   createChatAbortOps,
-  ensureChatQueuedTurns,
   persistAbortedPartials,
 } from "./chat-abort-runtime.js";
 import {
@@ -42,6 +38,11 @@ type ChatAbortLifecycle = {
   onAuthorizedAfterQueuedAbort?: () => boolean;
   excludeRunIds?: ReadonlySet<string>;
 };
+
+type ChatAbortTarget = Pick<
+  ChatAbortControllerEntry | QueuedChatTurnEntry,
+  "sessionKey" | "agentId" | "ownerConnId" | "ownerDeviceId"
+>;
 
 export async function handleChatAbortRequestWithLifecycle(
   { params, respond, context, client }: GatewayRequestHandlerOptions,
@@ -130,45 +131,60 @@ export async function handleChatAbortRequestWithLifecycle(
     return;
   }
   const normalizedAgentIdOverride = abortAgentId?.toLowerCase();
+  const authorizeRunTarget = (target: ChatAbortTarget): boolean => {
+    if (
+      target.sessionKey !== rawSessionKey &&
+      target.sessionKey !== canonicalAbortSessionKey &&
+      !canRequesterAbortChatRun(target, requester, { requireOwnerMatch: true })
+    ) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "runId does not match sessionKey"),
+      );
+      return false;
+    }
+    if (
+      normalizedAgentIdOverride &&
+      target.sessionKey === "global" &&
+      resolveStoredGlobalRunAgentId(target.agentId, defaultAgentId) !== normalizedAgentIdOverride
+    ) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "runId does not match agentId"),
+      );
+      return false;
+    }
+    if (!canRequesterAbortChatRun(target, requester)) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unauthorized"));
+      return false;
+    }
+    return true;
+  };
 
   const active = context.chatAbortControllers.get(runId);
   if (!active) {
     const readPendingRunForAbort = (
       entry: GatewayRequestContext["dedupe"] extends Map<string, infer T> ? T | undefined : never,
     ) => {
-      const canonicalMatch = readPreRegisteredAgentDedupePayloadForSession({
-        entry,
-        runId,
-        sessionKey: canonicalAbortSessionKey,
-        agentId: abortAgentId,
-        defaultAgentId,
-        includeHidden: true,
-      });
-      if (canonicalMatch) {
-        return {
-          sessionKey: normalizeUnknownText(canonicalMatch.sessionKey)
-            ? canonicalAbortSessionKey
-            : undefined,
-          payload: canonicalMatch,
-        };
+      for (const sessionKey of new Set([canonicalAbortSessionKey, rawSessionKey])) {
+        const payload = readPreRegisteredAgentDedupePayloadForSession({
+          entry,
+          runId,
+          sessionKey,
+          agentId: abortAgentId,
+          defaultAgentId,
+          includeHidden: true,
+        });
+        if (payload) {
+          return {
+            sessionKey: normalizeUnknownText(payload.sessionKey) ? sessionKey : undefined,
+            payload,
+          };
+        }
       }
-      if (rawSessionKey === canonicalAbortSessionKey) {
-        return undefined;
-      }
-      const aliasMatch = readPreRegisteredAgentDedupePayloadForSession({
-        entry,
-        runId,
-        sessionKey: rawSessionKey,
-        agentId: abortAgentId,
-        defaultAgentId,
-        includeHidden: true,
-      });
-      return aliasMatch
-        ? {
-            sessionKey: normalizeUnknownText(aliasMatch.sessionKey) ? rawSessionKey : undefined,
-            payload: aliasMatch,
-          }
-        : undefined;
+      return undefined;
     };
     const pendingChatMatch = readPendingRunForAbort(
       context.dedupe.get(pendingChatSendDedupeKey(runId)),
@@ -207,35 +223,10 @@ export async function handleChatAbortRequestWithLifecycle(
     }
     // Queued followup/collect turns keep a cancel identity after chat.send
     // terminalizes; abort them here so Esc cannot report done while they run.
-    const chatQueuedTurns = ensureChatQueuedTurns(context);
+    const chatQueuedTurns = context.chatQueuedTurns;
     const queued = chatQueuedTurns.get(runId);
     if (queued) {
-      const abortSessionKeysForQueued = new Set([rawSessionKey, canonicalAbortSessionKey]);
-      if (
-        !abortSessionKeysForQueued.has(queued.sessionKey) &&
-        !canRequesterAbortQueuedChatTurnWithoutSessionMatch(queued, requester)
-      ) {
-        respond(
-          false,
-          undefined,
-          errorShape(ErrorCodes.INVALID_REQUEST, "runId does not match sessionKey"),
-        );
-        return;
-      }
-      if (
-        normalizedAgentIdOverride &&
-        queued.sessionKey === "global" &&
-        resolveStoredGlobalRunAgentId(queued.agentId, defaultAgentId) !== normalizedAgentIdOverride
-      ) {
-        respond(
-          false,
-          undefined,
-          errorShape(ErrorCodes.INVALID_REQUEST, "runId does not match agentId"),
-        );
-        return;
-      }
-      if (!canRequesterAbortQueuedChatTurn(queued, requester)) {
-        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unauthorized"));
+      if (!authorizeRunTarget(queued)) {
         return;
       }
       const queuedRes = abortQueuedChatTurnById(chatQueuedTurns, {
@@ -265,32 +256,7 @@ export async function handleChatAbortRequestWithLifecycle(
     respondWithWorkerRuns([]);
     return;
   }
-  const abortSessionKeysForRun = new Set([rawSessionKey, canonicalAbortSessionKey]);
-  if (
-    !abortSessionKeysForRun.has(active.sessionKey) &&
-    !canRequesterAbortChatRunWithoutSessionMatch(active, requester)
-  ) {
-    respond(
-      false,
-      undefined,
-      errorShape(ErrorCodes.INVALID_REQUEST, "runId does not match sessionKey"),
-    );
-    return;
-  }
-  if (
-    normalizedAgentIdOverride &&
-    active.sessionKey === "global" &&
-    resolveStoredGlobalRunAgentId(active.agentId, defaultAgentId) !== normalizedAgentIdOverride
-  ) {
-    respond(
-      false,
-      undefined,
-      errorShape(ErrorCodes.INVALID_REQUEST, "runId does not match agentId"),
-    );
-    return;
-  }
-  if (!canRequesterAbortChatRun(active, requester)) {
-    respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unauthorized"));
+  if (!authorizeRunTarget(active)) {
     return;
   }
 

--- a/src/gateway/server-methods/chat-abort-runtime.ts
+++ b/src/gateway/server-methods/chat-abort-runtime.ts
@@ -3,17 +3,13 @@ import {
   type ChatAbortControllerEntry,
   type ChatAbortOps,
 } from "../chat-abort.js";
-import {
-  abortQueuedChatTurns,
-  listQueuedChatTurnsForSession,
-  type QueuedChatTurnMap,
-} from "../chat-queued-turns.js";
+import { abortQueuedChatTurns, listQueuedChatTurnsForSession } from "../chat-queued-turns.js";
 import { PENDING_CHAT_SEND_DEDUPE_PREFIX } from "../server-shared.js";
 // Cancellation orchestration across active, queued, pending, and worker runs.
 import { loadSessionEntry } from "../session-utils.js";
 import { asWorkerInferenceControl } from "../worker-environments/inference-control.js";
 import {
-  canRequesterAbortQueuedChatTurn,
+  canRequesterAbortChatRun,
   resolveAuthorizedPreRegisteredRunsForSessionKeys,
   resolveAuthorizedRunsForSessionKeys,
   writePreRegisteredAgentAbort,
@@ -114,10 +110,6 @@ export function createChatAbortOps(context: GatewayRequestContext): ChatAbortOps
   };
 }
 
-export function ensureChatQueuedTurns(context: GatewayRequestContext): QueuedChatTurnMap {
-  return context.chatQueuedTurns;
-}
-
 function resolveAuthorizedQueuedTurnsForSession(params: {
   context: GatewayRequestContext;
   sessionKeys: string[];
@@ -126,19 +118,15 @@ function resolveAuthorizedQueuedTurnsForSession(params: {
   defaultAgentId: string;
   requester: ChatAbortRequester;
 }) {
-  const chatQueuedTurns = ensureChatQueuedTurns(params.context);
   const matches = listQueuedChatTurnsForSession({
-    chatQueuedTurns,
+    chatQueuedTurns: params.context.chatQueuedTurns,
     sessionKeys: params.sessionKeys,
     sessionIds: [params.sessionId],
     agentId: params.agentId,
     defaultAgentId: params.defaultAgentId,
   });
-  if (matches.length === 0) {
-    return { authorized: [], hasUnauthorizedRuns: false };
-  }
-  const authorized = matches.filter((m) =>
-    canRequesterAbortQueuedChatTurn(m.entry, params.requester),
+  const authorized = matches.filter((match) =>
+    canRequesterAbortChatRun(match.entry, params.requester),
   );
   return {
     authorized,
@@ -310,7 +298,7 @@ export async function abortChatRunsForSessionKeyWithPartials(params: {
   // Abort queued owners before any active-work signal can promote a successor.
   // Keep them first in the response to preserve the established runIds ordering.
   const runIds: string[] = abortQueuedChatTurns(
-    ensureChatQueuedTurns(params.context),
+    params.context.chatQueuedTurns,
     queuedPlan.authorized,
     params.stopReason,
   );

--- a/src/gateway/server-methods/chat-send-handler.ts
+++ b/src/gateway/server-methods/chat-send-handler.ts
@@ -26,7 +26,6 @@ import {
 import type { ChatRunTiming } from "../server-chat-state.js";
 import { formatForLog } from "../ws-log.js";
 import { setGatewayDedupeEntry } from "./agent-job.js";
-import { ensureChatQueuedTurns } from "./chat-abort-runtime.js";
 import { broadcastChatError, broadcastChatFinal } from "./chat-broadcast.js";
 import { hasGatewayAdminScope } from "./chat-origin-routing.js";
 import { terminalizeRestartSafeChatAdmission } from "./chat-restart-recovery.js";
@@ -417,7 +416,7 @@ export async function handleChatSend(
                   onAdopted: async () => {},
                   onDeferred: () => {
                     queuedFollowupEnqueued = registerQueuedChatTurn({
-                      chatQueuedTurns: ensureChatQueuedTurns(context),
+                      chatQueuedTurns: context.chatQueuedTurns,
                       runId: clientRunId,
                       controller: activeRunAbort.controller,
                       sessionId: backingSessionId ?? clientRunId,
@@ -430,14 +429,14 @@ export async function handleChatSend(
                   },
                   onCancellationRetired: () => {
                     retireQueuedChatTurnCancellation(
-                      ensureChatQueuedTurns(context),
+                      context.chatQueuedTurns,
                       clientRunId,
                       activeRunAbort.controller,
                     );
                   },
                   onSettled: () => {
                     completeQueuedChatTurn(
-                      ensureChatQueuedTurns(context),
+                      context.chatQueuedTurns,
                       clientRunId,
                       activeRunAbort.controller,
                     );


### PR DESCRIPTION
## What Problem This Solves

Gateway chat cancellation maintained separate authorization and lifecycle paths for active, queued, and preregistered runs, making connection/device ownership and agent-scoped session checks harder to keep consistent.

## Why This Change Was Made

Route active and queued cancellation through one canonical owner-level authorization decision, reuse the lifecycle-owned queue map and pending ownership metadata, and remove duplicate exact-run validators, obsolete wrappers, and synthetic pending-run controllers. The shared target explicitly models `ChatAbortControllerEntry | QueuedChatTurnEntry`, preserving the existing queue-entry production contract.

## User Impact

No intended behavior change. Administrator privileges, same-device reconnect and connection ownership, ownerless same-session access with fail-closed cross-session rejection, selected global-agent isolation, canonical/session aliases, hidden/internal/side-run exclusion, partial persistence, and queued-before-active cancellation order remain unchanged. Production change: **69 additions, 180 deletions; net -111 lines across four files**.

## Evidence

- Trusted Blacksmith Testbox `tbx_01kz92dt9nvd6bh3xpj8d4bagx`: **19 gateway test files and 341 tests passed**, including authorization (32), abort persistence (28), selected-agent scope (29), queued turns (14), chat abort (46), full gateway chat integration (96), and sibling ownership/dispatch coverage.
- Full, unfiltered `pnpm check:changed` passed: production and full-tree dead-export scans, public Plugin SDK API manifest, core and core-test TypeScript checks, formatting, lint with zero warnings/errors, import-cycle checks, and security guards.
- Fresh independent structured review: `.agents/skills/autoreview/scripts/autoreview --mode local --engine codex --model gpt-5.6-sol --thinking xhigh` passed with no actionable findings and **0.97 confidence**.
- Remote proof: https://github.com/openclaw/openclaw/actions/runs/31011294284. The sole Testbox lease was stopped and independently verified `completed`.

### Exact-head redacted Gateway client trace

Observed by executing the committed `chat.abort` RPC handler, authorization owner, cancellation runtime, active-run abort owner, and queued-turn abort owner at `8d1afa5395b821e3013f558100e08d6c7c11ff07`. The fixture uses synthetic client/device IDs and isolated in-memory session registries; it does not start a listener or access the network, credentials, or operator state.

```json
[
  {
    "scenario": "same-connection-active",
    "request": {
      "sessionKey": "main",
      "connection": "conn-owner",
      "device": "device-other",
      "scopes": [
        "operator.write"
      ]
    },
    "response": {
      "ok": true,
      "aborted": true,
      "runIds": [
        "same-connection-active"
      ]
    },
    "stateAfter": {
      "registry": "active",
      "runRegistered": false,
      "signalAborted": true
    }
  },
  {
    "scenario": "same-device-reconnected-active",
    "request": {
      "sessionKey": "main",
      "connection": "conn-new",
      "device": "device-owner",
      "scopes": [
        "operator.write"
      ]
    },
    "response": {
      "ok": true,
      "aborted": true,
      "runIds": [
        "same-device-reconnected-active"
      ]
    },
    "stateAfter": {
      "registry": "active",
      "runRegistered": false,
      "signalAborted": true
    }
  },
  {
    "scenario": "foreign-active",
    "request": {
      "sessionKey": "main",
      "connection": "conn-foreign",
      "device": "device-foreign",
      "scopes": [
        "operator.write"
      ]
    },
    "response": {
      "ok": false,
      "code": "INVALID_REQUEST",
      "error": "unauthorized"
    },
    "stateAfter": {
      "registry": "active",
      "runRegistered": true,
      "signalAborted": false
    }
  },
  {
    "scenario": "ownerless-cross-session-active",
    "request": {
      "sessionKey": "other",
      "connection": "conn-foreign",
      "device": "device-foreign",
      "scopes": [
        "operator.write"
      ]
    },
    "response": {
      "ok": false,
      "code": "INVALID_REQUEST",
      "error": "runId does not match sessionKey"
    },
    "stateAfter": {
      "registry": "active",
      "runRegistered": true,
      "signalAborted": false
    }
  },
  {
    "scenario": "same-device-reconnected-queued",
    "request": {
      "sessionKey": "main",
      "connection": "conn-new",
      "device": "device-owner",
      "scopes": [
        "operator.write"
      ]
    },
    "response": {
      "ok": true,
      "aborted": true,
      "runIds": [
        "same-device-reconnected-queued"
      ]
    },
    "stateAfter": {
      "registry": "queued",
      "runRegistered": false,
      "signalAborted": true
    }
  },
  {
    "scenario": "foreign-queued",
    "request": {
      "sessionKey": "main",
      "connection": "conn-foreign",
      "device": "device-foreign",
      "scopes": [
        "operator.write"
      ]
    },
    "response": {
      "ok": false,
      "code": "INVALID_REQUEST",
      "error": "unauthorized"
    },
    "stateAfter": {
      "registry": "queued",
      "runRegistered": true,
      "signalAborted": false
    }
  },
  {
    "scenario": "ownerless-cross-session-queued",
    "request": {
      "sessionKey": "other",
      "connection": "conn-foreign",
      "device": "device-foreign",
      "scopes": [
        "operator.write"
      ]
    },
    "response": {
      "ok": false,
      "code": "INVALID_REQUEST",
      "error": "runId does not match sessionKey"
    },
    "stateAfter": {
      "registry": "queued",
      "runRegistered": true,
      "signalAborted": false
    }
  },
  {
    "scenario": "admin-cross-session-active",
    "request": {
      "sessionKey": "other",
      "connection": "conn-admin",
      "device": "device-admin",
      "scopes": [
        "operator.admin"
      ]
    },
    "response": {
      "ok": true,
      "aborted": true,
      "runIds": [
        "admin-cross-session-active"
      ]
    },
    "stateAfter": {
      "registry": "active",
      "runRegistered": false,
      "signalAborted": true
    }
  },
  {
    "scenario": "global-agent-mismatch",
    "request": {
      "sessionKey": "global",
      "connection": "conn-owner",
      "device": "device-owner",
      "scopes": [
        "operator.write"
      ]
    },
    "response": {
      "ok": false,
      "code": "INVALID_REQUEST",
      "error": "runId does not match agentId"
    },
    "stateAfter": {
      "registry": "active",
      "runRegistered": true,
      "signalAborted": false
    }
  }
]
```

Foreign and ownerless cross-session requests leave their original active/queued run registered and unaborted; the same connection, a reconnected paired device, and the authorized administrator cancel successfully. The global-session agent mismatch remains rejected. This adds observed evidence to the PR body only: the reviewed commit SHA is unchanged, so the existing exact-head review remains valid and no re-review is requested.

### Genuine production Gateway listener + GatewayClient WebSocket verdict (exact head)

The existing `setupGatewaySessionsTestHarness` started the **actual production `startGatewayServer` listener on isolated loopback port 63000**. Three independent **production `GatewayClient` instances** completed real `hello-ok` WebSocket handshakes (protocol 4); they then sent **six actual `chat.abort` RPCs over their WebSocket connections** to the committed production listener, request dispatch, authorization owner, runtime owner, and queued-turn owner. The fixture used only synthetic isolated temporary session state; the real listener, network transport, Gateway clients, RPC dispatch, authorization, and cancellation handlers were not mocked. A passive in-memory runtime observer inspected the real Gateway-owned maps, and queued entries were registered through production `registerQueuedChatTurn`.

```json
{
  "head": "8d1afa5395b821e3013f558100e08d6c7c11ff07",
  "productionClient": "src/gateway/client.ts:GatewayClient",
  "productionListener": "src/gateway/server-start.ts:startGatewayServer",
  "productionOwners": [
    "src/gateway/server-methods/chat-abort-handler.ts",
    "src/gateway/server-methods/chat-abort-authorization.ts",
    "src/gateway/server-methods/chat-abort-runtime.ts",
    "src/gateway/chat-queued-turns.ts"
  ],
  "transport": {
    "scheme": "ws",
    "host": "127.0.0.1",
    "listenerPort": 63000,
    "connectedProductionGatewayClients": 3,
    "hello": [
      "hello-ok",
      "hello-ok",
      "hello-ok"
    ],
    "protocol": 4,
    "websocketRequests": 6
  },
  "state": "synthetic isolated temporary Gateway session state; no operator data",
  "cases": [
    {
      "kind": "queued",
      "requester": "foreign",
      "websocketRequest": {
        "method": "chat.abort",
        "sessionKey": "main",
        "runId": "synthetic-owned-queued-turn"
      },
      "productionClientResponse": {
        "ok": false,
        "errorClass": "GatewayClientRequestError",
        "code": "INVALID_REQUEST",
        "message": "unauthorized"
      },
      "serverStateAfterResponse": {
        "remainsRegistered": true,
        "signalAborted": false
      }
    },
    {
      "kind": "queued",
      "requester": "owner",
      "websocketRequest": {
        "method": "chat.abort",
        "sessionKey": "main",
        "runId": "synthetic-owned-queued-turn"
      },
      "productionClientResponse": {
        "ok": true,
        "payload": {
          "ok": true,
          "aborted": true,
          "runIds": [
            "synthetic-owned-queued-turn"
          ]
        }
      },
      "serverStateAfterResponse": {
        "remainsRegistered": false,
        "signalAborted": true
      }
    },
    {
      "kind": "queued",
      "requester": "foreign",
      "websocketRequest": {
        "method": "chat.abort",
        "sessionKey": "other",
        "runId": "synthetic-ownerless-queued-turn"
      },
      "productionClientResponse": {
        "ok": false,
        "errorClass": "GatewayClientRequestError",
        "code": "INVALID_REQUEST",
        "message": "runId does not match sessionKey"
      },
      "serverStateAfterResponse": {
        "remainsRegistered": true,
        "signalAborted": false
      }
    },
    {
      "kind": "queued",
      "requester": "admin",
      "websocketRequest": {
        "method": "chat.abort",
        "sessionKey": "other",
        "runId": "synthetic-ownerless-queued-turn"
      },
      "productionClientResponse": {
        "ok": true,
        "payload": {
          "ok": true,
          "aborted": true,
          "runIds": [
            "synthetic-ownerless-queued-turn"
          ]
        }
      },
      "serverStateAfterResponse": {
        "remainsRegistered": false,
        "signalAborted": true
      }
    },
    {
      "kind": "active",
      "requester": "foreign",
      "websocketRequest": {
        "method": "chat.abort",
        "sessionKey": "main",
        "runId": "synthetic-owned-active-turn"
      },
      "productionClientResponse": {
        "ok": false,
        "errorClass": "GatewayClientRequestError",
        "code": "INVALID_REQUEST",
        "message": "unauthorized"
      },
      "serverStateAfterResponse": {
        "remainsRegistered": true,
        "signalAborted": false
      }
    },
    {
      "kind": "active",
      "requester": "owner",
      "websocketRequest": {
        "method": "chat.abort",
        "sessionKey": "main",
        "runId": "synthetic-owned-active-turn"
      },
      "productionClientResponse": {
        "ok": true,
        "payload": {
          "ok": true,
          "aborted": true,
          "runIds": [
            "synthetic-owned-active-turn"
          ]
        }
      },
      "serverStateAfterResponse": {
        "remainsRegistered": true,
        "signalAborted": true,
        "registrationLifecycle": "terminal-persistence-pending"
      }
    }
  ]
}
```

Observed outcomes: a foreign non-admin client cannot cancel another connection's queued **or** active run; both remain registered and unaborted. The owning connection successfully cancels both. An ownerless queued run rejects a foreign cross-session request and remains queued; an admin can explicitly authorize its cross-session cancellation. The successful active cancellation intentionally retains its aborted registration while terminal persistence is pending, preserving the existing lifecycle-ordering contract.

Focused real-listener result: **1 passed, 7 unrelated existing cases skipped by the explicit name filter**. All production clients and the isolated listener were shut down; the temporary dependency link was removed and the source worktree remained clean. Reviewed head remains `8d1afa5395b821e3013f558100e08d6c7c11ff07`; this is additional exact-head evidence only, so the existing exact-head review remains valid and no re-review is requested.


