### PR TITLE
refactor(skills): consolidate workshop transcript and record normalization

### DIFF
--- a/src/skills/lifecycle/skill-change-hook.ts
+++ b/src/skills/lifecycle/skill-change-hook.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { sha256Hex } from "../../infra/crypto-digest.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import type {
@@ -22,14 +23,6 @@ type SkillTreeFile = {
   sha256: string;
   sizeBytes: number;
 };
-
-function normalizeOptionalString(value: unknown): string | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const normalized = value.trim();
-  return normalized || undefined;
-}
 
 async function collectSkillTreeFiles(skillDir: string, relativeDir = ""): Promise<SkillTreeFile[]> {
   const entries = await fs.readdir(path.join(skillDir, relativeDir), { withFileTypes: true });

--- a/src/skills/research/autocapture.ts
+++ b/src/skills/research/autocapture.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { resolveStorePath } from "../../config/sessions/paths.js";
 import {
   claimSessionSkillCaptureSignals,
@@ -14,6 +15,7 @@ import { KeyedAsyncQueue } from "../../plugin-sdk/keyed-async-queue.js";
 import { readWorkspaceSkillFile } from "../lifecycle/workspace-skill-write.js";
 import { autoApplySkillProposal } from "../workshop/auto-apply.js";
 import { resolveSkillWorkshopConfig } from "../workshop/config.js";
+import { selectCurrentSkillTurnMessages } from "../workshop/experience-review-prompt.js";
 import { stripProposalFrontmatterForSkill } from "../workshop/frontmatter.js";
 import {
   inspectSkillProposal,
@@ -91,31 +93,24 @@ function readToolCallAction(value: unknown): string | undefined {
       return undefined;
     }
   }
-  if (!input || typeof input !== "object" || Array.isArray(input)) {
+  if (!isRecord(input)) {
     return undefined;
   }
-  const action = (input as { action?: unknown }).action;
+  const action = input.action;
   return typeof action === "string" ? action.trim().toLowerCase() : undefined;
 }
 
-function isSkillWorkshopMutationBlock(value: unknown): boolean {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
+function isSkillWorkshopMutationBlock(value: unknown): value is Record<string, unknown> {
+  if (!isRecord(value)) {
     return false;
   }
-  const block = value as {
-    type?: unknown;
-    name?: unknown;
-    arguments?: unknown;
-    input?: unknown;
-    args?: unknown;
-  };
-  if (!TOOL_CALL_BLOCK_TYPES.has(String(block.type))) {
+  if (!TOOL_CALL_BLOCK_TYPES.has(String(value.type))) {
     return false;
   }
-  if (typeof block.name !== "string" || block.name.trim().toLowerCase() !== "skill_workshop") {
+  if (typeof value.name !== "string" || value.name.trim().toLowerCase() !== "skill_workshop") {
     return false;
   }
-  const action = readToolCallAction(block.arguments ?? block.input ?? block.args);
+  const action = readToolCallAction(value.arguments ?? value.input ?? value.args);
   return action ? SKILL_WORKSHOP_MUTATING_ACTIONS.has(action) : false;
 }
 
@@ -123,19 +118,16 @@ function hasUnfailedSkillWorkshopMutationCall(messages: readonly unknown[]): boo
   const callIds = new Set<string>();
   let hasUnidentifiedCall = false;
   for (const message of messages) {
-    if (!message || typeof message !== "object" || Array.isArray(message)) {
+    if (!isRecord(message)) {
       continue;
     }
-    const content = (message as { content?: unknown }).content;
+    const content = message.content;
     const blocks = Array.isArray(content) ? content : [content];
     for (const block of blocks) {
       if (!isSkillWorkshopMutationBlock(block)) {
         continue;
       }
-      const id =
-        block && typeof block === "object" && !Array.isArray(block)
-          ? (block as { id?: unknown }).id
-          : undefined;
+      const id = block.id;
       if (typeof id === "string" && id) {
         callIds.add(id);
       } else {
@@ -147,34 +139,18 @@ function hasUnfailedSkillWorkshopMutationCall(messages: readonly unknown[]): boo
     return true;
   }
   for (const message of messages) {
-    if (!message || typeof message !== "object" || Array.isArray(message)) {
+    if (!isRecord(message)) {
       continue;
     }
-    const result = message as { role?: unknown; toolCallId?: unknown; isError?: unknown };
     if (
-      result.role === "toolResult" &&
-      result.isError === true &&
-      typeof result.toolCallId === "string"
+      message.role === "toolResult" &&
+      message.isError === true &&
+      typeof message.toolCallId === "string"
     ) {
-      callIds.delete(result.toolCallId);
+      callIds.delete(message.toolCallId);
     }
   }
   return callIds.size > 0;
-}
-
-function currentTurnMessages(messages: readonly unknown[]): readonly unknown[] {
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    const message = messages[index];
-    if (
-      message &&
-      typeof message === "object" &&
-      !Array.isArray(message) &&
-      (message as { role?: unknown }).role === "user"
-    ) {
-      return messages.slice(index);
-    }
-  }
-  return messages;
 }
 
 function fingerprintInstructions(instructions: readonly string[]): string {
@@ -239,7 +215,7 @@ export async function runSkillResearchAutoCapture(params: {
   // Proposals are workspace-scoped, so different sessions must not inspect and revise the same
   // pending draft concurrently from stale content.
   await skillCaptureQueue.enqueue(workspaceDir, async () => {
-    const turnMessages = currentTurnMessages(params.event.messages);
+    const turnMessages = selectCurrentSkillTurnMessages(params.event.messages);
     if (hasUnfailedSkillWorkshopMutationCall(turnMessages)) {
       const signalHashes = extractDurableInstructions([...turnMessages]).map((instruction) =>
         fingerprintInstructions([instruction]),

--- a/src/skills/workshop/experience-review-prompt.ts
+++ b/src/skills/workshop/experience-review-prompt.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { SKILL_AUTHORING_STANDARDS_PROMPT } from "./skill-authoring-standards.js";
 
@@ -18,6 +19,23 @@ function safeJson(value: unknown): string {
   }
 }
 
+export function selectCurrentSkillTurnMessages(messages: readonly unknown[]): readonly unknown[] {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (isRecord(message) && message.role === "user") {
+      return messages.slice(index);
+    }
+  }
+  return messages;
+}
+
+export function countSkillModelIterations(messages: readonly unknown[]): number {
+  return messages.reduce<number>(
+    (count, message) => count + (isRecord(message) && message.role === "assistant" ? 1 : 0),
+    0,
+  );
+}
+
 function renderContent(content: unknown): string {
   if (typeof content === "string") {
     return content;
@@ -30,17 +48,16 @@ function renderContent(content: unknown): string {
       if (typeof block === "string") {
         return block;
       }
-      if (!block || typeof block !== "object" || Array.isArray(block)) {
+      if (!isRecord(block)) {
         return safeJson(block);
       }
-      const record = block as Record<string, unknown>;
-      if (record.type === "text" && typeof record.text === "string") {
-        return record.text;
+      if (block.type === "text" && typeof block.text === "string") {
+        return block.text;
       }
-      if (["toolCall", "tool_use", "function_call"].includes(String(record.type))) {
-        const toolName = typeof record.name === "string" ? record.name : "unknown";
+      if (["toolCall", "tool_use", "function_call"].includes(String(block.type))) {
+        const toolName = typeof block.name === "string" ? block.name : "unknown";
         return `[tool call: ${toolName}] ${safeJson(
-          record.arguments ?? record.input ?? record.args ?? {},
+          block.arguments ?? block.input ?? block.args ?? {},
         )}`;
       }
       return safeJson(block);
@@ -49,14 +66,13 @@ function renderContent(content: unknown): string {
 }
 
 function renderMessage(message: unknown): string {
-  if (!message || typeof message !== "object" || Array.isArray(message)) {
+  if (!isRecord(message)) {
     return `[unknown]\n${safeJson(message)}`;
   }
-  const record = message as Record<string, unknown>;
-  const role = typeof record.role === "string" ? record.role : "unknown";
-  const error = record.isError === true ? " error" : "";
-  const toolName = typeof record.toolName === "string" ? ` ${record.toolName}` : "";
-  return `[${role}${toolName}${error}]\n${renderContent(record.content)}`;
+  const role = typeof message.role === "string" ? message.role : "unknown";
+  const error = message.isError === true ? " error" : "";
+  const toolName = typeof message.toolName === "string" ? ` ${message.toolName}` : "";
+  return `[${role}${toolName}${error}]\n${renderContent(message.content)}`;
 }
 
 export function formatSkillExperienceReviewTranscript(messages: readonly unknown[]): string {

--- a/src/skills/workshop/experience-review.ts
+++ b/src/skills/workshop/experience-review.ts
@@ -9,7 +9,9 @@ import { autoApplySkillProposal } from "./auto-apply.js";
 import { resolveSkillWorkshopConfig } from "./config.js";
 import {
   buildSkillExperienceReviewPrompt,
+  countSkillModelIterations,
   formatSkillExperienceReviewTranscript,
+  selectCurrentSkillTurnMessages,
 } from "./experience-review-prompt.js";
 import type { SkillWorkshopProposalMutationBudget } from "./types.js";
 
@@ -132,30 +134,6 @@ function isEligibleContext(ctx: ExperienceReviewAgentContext): boolean {
   return !sessionKey
     .split(":")
     .some((segment) => EXPERIENCE_REVIEW_BLOCKED_SESSION_SEGMENTS.has(segment));
-}
-
-function currentTurnMessages(messages: readonly unknown[]): readonly unknown[] {
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    const message = messages[index];
-    if (
-      message &&
-      typeof message === "object" &&
-      !Array.isArray(message) &&
-      (message as { role?: unknown }).role === "user"
-    ) {
-      return messages.slice(index);
-    }
-  }
-  return messages;
-}
-
-function countModelIterations(messages: readonly unknown[]): number {
-  return messages.reduce<number>((count, message) => {
-    if (!message || typeof message !== "object" || Array.isArray(message)) {
-      return count;
-    }
-    return count + ((message as { role?: unknown }).role === "assistant" ? 1 : 0);
-  }, 0);
 }
 
 export async function prepareSkillExperienceReviewCandidate(
@@ -336,13 +314,13 @@ export function createSkillExperienceReviewScheduler(deps: ExperienceReviewSched
         return;
       }
 
-      const turnMessages = currentTurnMessages(params.event.messages);
+      const turnMessages = selectCurrentSkillTurnMessages(params.event.messages);
       // Native harnesses can report exact provider iterations even when their
       // transcript projection has a different assistant-message cardinality.
       const reportedModelIterations = params.ctx.modelIterations;
       const modelIterations =
         reportedModelIterations === undefined
-          ? countModelIterations(turnMessages)
+          ? countSkillModelIterations(turnMessages)
           : Number.isSafeInteger(reportedModelIterations) && reportedModelIterations >= 0
             ? reportedModelIterations
             : 0;

--- a/src/skills/workshop/history-scan-state.ts
+++ b/src/skills/workshop/history-scan-state.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import path from "node:path";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { resolveStorePath } from "../../config/sessions/paths.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
@@ -88,12 +89,7 @@ export function emptyHistoryScanResult(): SkillHistoryScanResult {
 }
 
 export function isStoredHistoryScanState(value: unknown): value is StoredSkillHistoryScanState {
-  return Boolean(
-    value &&
-    typeof value === "object" &&
-    !Array.isArray(value) &&
-    (value as { schema?: unknown }).schema === HISTORY_SCAN_SCHEMA,
-  );
+  return isRecord(value) && value.schema === HISTORY_SCAN_SCHEMA;
 }
 
 function loadHistoryScanState(params: Omit<SkillHistoryScanScope, "direction">) {

--- a/src/skills/workshop/history-scan-transcript-content.ts
+++ b/src/skills/workshop/history-scan-transcript-content.ts
@@ -1,19 +1,14 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { filterHeartbeatTranscriptTurns } from "../../auto-reply/heartbeat-transcript-turns.js";
 import { redactSensitiveText } from "../../logging/redact.js";
-import { formatSkillExperienceReviewTranscript } from "./experience-review-prompt.js";
+import {
+  countSkillModelIterations,
+  formatSkillExperienceReviewTranscript,
+} from "./experience-review-prompt.js";
 
 const HISTORY_SCAN_MAX_RECENT_MESSAGES = 80;
 const HISTORY_SCAN_MAX_LOCAL_TRANSCRIPT_BYTES = 8 * 1024 * 1024;
-
-function countModelIterations(messages: readonly unknown[]): number {
-  return messages.reduce<number>((count, message) => {
-    if (!message || typeof message !== "object" || Array.isArray(message)) {
-      return count;
-    }
-    return count + ((message as { role?: unknown }).role === "assistant" ? 1 : 0);
-  }, 0);
-}
 
 function capSessionTranscript(transcript: string, maxChars: number): string {
   if (transcript.length <= maxChars) {
@@ -32,12 +27,7 @@ function capSessionTranscript(transcript: string, maxChars: number): string {
 
 function hasLegacyHookTranscriptContent(messages: readonly unknown[]): boolean {
   return messages.some((message) => {
-    if (
-      !message ||
-      typeof message !== "object" ||
-      Array.isArray(message) ||
-      (message as { role?: unknown }).role !== "user"
-    ) {
+    if (!isRecord(message) || message.role !== "user") {
       return false;
     }
     const rendered = formatSkillExperienceReviewTranscript([message]);
@@ -56,13 +46,9 @@ function filterSkillHistoryScanReviewMessages(
   if (hasLegacyHookTranscriptContent(messages)) {
     return undefined;
   }
-  const roleMessages = messages.filter((message): message is { role: string; content?: unknown } =>
-    Boolean(
-      message &&
-      typeof message === "object" &&
-      !Array.isArray(message) &&
-      typeof (message as { role?: unknown }).role === "string",
-    ),
+  const roleMessages = messages.filter(
+    (message): message is { role: string; content?: unknown } =>
+      isRecord(message) && typeof message.role === "string",
   );
   return filterHeartbeatTranscriptTurns(roleMessages, heartbeatPrompt);
 }
@@ -77,7 +63,7 @@ export function prepareSkillHistoryScanReviewMessages(
   }
   return {
     messages: filtered.slice(-HISTORY_SCAN_MAX_RECENT_MESSAGES),
-    modelIterations: countModelIterations(filtered),
+    modelIterations: countSkillModelIterations(filtered),
   };
 }
 

--- a/src/skills/workshop/proposal-origin-validation.ts
+++ b/src/skills/workshop/proposal-origin-validation.ts
@@ -1,15 +1,15 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { MAX_SKILL_PROPOSAL_ORIGIN_RUN_IDS } from "./types.js";
 
 function isValidOrigin(value: unknown): boolean {
   if (value === undefined) {
     return true;
   }
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
+  if (!isRecord(value)) {
     return false;
   }
-  const origin = value as Record<string, unknown>;
   return ["agentId", "sessionKey", "runId", "messageId"].every((key) => {
-    const item = origin[key];
+    const item = value[key];
     return item === undefined || typeof item === "string";
   });
 }
@@ -35,7 +35,7 @@ function isValidMutationCounts(value: unknown, originRunIds: string[] | undefine
   if (value === undefined) {
     return true;
   }
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
+  if (!isRecord(value)) {
     return false;
   }
   const allowedIds = new Set(originRunIds);

--- a/src/skills/workshop/store-record.ts
+++ b/src/skills/workshop/store-record.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { err, ok, type Result } from "@openclaw/normalization-core/result";
 import type {
   PluginHookSkillEvaluationFinding,
@@ -48,8 +49,8 @@ export function assertProposalId(proposalId: string): void {
 export function validateSkillProposalRecord(
   raw: unknown,
 ): Result<SkillProposalRecord, SkillProposalRecordValidationError> {
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
-    return invalidProposalMetadata();
+  if (!isRecord(raw)) {
+    return invalidMetadata("proposal");
   }
   const record = raw as SkillProposalRecord;
   if (
@@ -76,7 +77,7 @@ export function validateSkillProposalRecord(
     !record.scan ||
     typeof record.scan !== "object"
   ) {
-    return invalidProposalMetadata();
+    return invalidMetadata("proposal");
   }
   return ok(record);
 }
@@ -87,7 +88,7 @@ export function parseSkillProposalRecord(raw: unknown): SkillProposalRecord | nu
 }
 
 export function parseSkillProposalEvaluation(raw: unknown): SkillProposalEvaluation | null {
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+  if (!isRecord(raw)) {
     return null;
   }
   const value = raw as SkillProposalEvaluation;
@@ -120,7 +121,7 @@ export function parseSkillProposalEvaluation(raw: unknown): SkillProposalEvaluat
 function isValidEvaluationOutcome(
   value: unknown,
 ): value is PluginHookSkillProposalEvaluationOutcome {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
+  if (!isRecord(value)) {
     return false;
   }
   const outcome = value as PluginHookSkillProposalEvaluationOutcome;
@@ -146,7 +147,7 @@ function isValidEvaluationOutcome(
 }
 
 function isValidEvaluationResult(value: unknown): value is PluginHookSkillProposalEvaluateResult {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
+  if (!isRecord(value)) {
     return false;
   }
   const result = value as PluginHookSkillProposalEvaluateResult;
@@ -195,7 +196,7 @@ function isValidEvaluationMetrics(
   if (value === undefined) {
     return true;
   }
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
+  if (!isRecord(value)) {
     return false;
   }
   const entries = Object.entries(value);
@@ -221,7 +222,7 @@ function isValidSupportFileList(value: unknown): boolean {
   }
   const seen = new Set<string>();
   for (const item of value) {
-    if (!item || typeof item !== "object" || Array.isArray(item)) {
+    if (!isRecord(item)) {
       return false;
     }
     const file = item as SkillProposalSupportFile;
@@ -257,8 +258,8 @@ function isValidSupportFileList(value: unknown): boolean {
 export function validateSkillProposalRollback(
   raw: unknown,
 ): Result<SkillProposalRollback, SkillProposalRecordValidationError> {
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
-    return invalidRollbackMetadata();
+  if (!isRecord(raw)) {
+    return invalidMetadata("rollback");
   }
   const rollback = raw as SkillProposalRollback;
   if (
@@ -273,7 +274,7 @@ export function validateSkillProposalRollback(
     (rollback.previousContent !== undefined && typeof rollback.previousContent !== "string") ||
     (rollback.supportFiles !== undefined && !Array.isArray(rollback.supportFiles))
   ) {
-    return invalidRollbackMetadata();
+    return invalidMetadata("rollback");
   }
   return ok(rollback);
 }
@@ -283,22 +284,11 @@ export function parseSkillProposalRollback(raw: unknown): SkillProposalRollback 
   return result.ok ? result.value : null;
 }
 
-function invalidProposalMetadata(): Result<
-  SkillProposalRecord,
-  SkillProposalRecordValidationError
-> {
+function invalidMetadata<T>(
+  kind: "proposal" | "rollback",
+): Result<T, SkillProposalRecordValidationError> {
   return err({
-    code: "invalid-proposal-metadata",
-    message: "invalid proposal metadata",
-  });
-}
-
-function invalidRollbackMetadata(): Result<
-  SkillProposalRollback,
-  SkillProposalRecordValidationError
-> {
-  return err({
-    code: "invalid-rollback-metadata",
-    message: "invalid rollback metadata",
+    code: `invalid-${kind}-metadata`,
+    message: `invalid ${kind} metadata`,
   });
 }

--- a/src/skills/workshop/store-sqlite-record.ts
+++ b/src/skills/workshop/store-sqlite-record.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
+import { safeParseJson } from "@openclaw/normalization-core";
 import type { Insertable } from "kysely";
 import {
   executeSqliteQuerySync,
@@ -16,14 +17,7 @@ import {
 import type { SkillProposalRecord } from "./types.js";
 
 export function parseJson(value: string | null): unknown {
-  if (value === null) {
-    return undefined;
-  }
-  try {
-    return JSON.parse(value) as unknown;
-  } catch {
-    return undefined;
-  }
+  return value === null ? undefined : safeParseJson(value);
 }
 
 export function parseSkillProposalRow(row: SkillProposalRow): SkillProposalRecord | null {


### PR DESCRIPTION
## What Problem This Solves

Skills research autocapture, live workshop review, and historical scanning independently selected the current user turn and counted assistant/model iterations. Workshop state, proposal provenance, and persisted proposal/rollback records separately implemented record guards, JSON parsing, metadata normalization, and invalid-record errors.

## Why This Change Was Made

Make the existing workshop transcript owner canonical for current-turn selection and model-iteration counting. Reuse the existing public normalization-core record, string, and JSON helpers across lifecycle, provenance, and persistence boundaries; preserve hostile-array rejection, originating-run validation, mutation-replay suppression, and persisted proposal/rollback discriminators while removing connected duplicate paths.

## User Impact

Research autocapture, experience review, history scanning/resume, evaluation/auto-apply, lifecycle hooks, provenance checks, and persisted rollback retain their existing behavior. Model-visible transcript and prompt bytes remain unchanged, with no additional or unbounded model context. Nine production files change by +87/-158 (**71 fewer production lines**); there are no test, config, schema, package-export, or public API changes.

## Evidence

- Exact before/after transpiled-production-source differential proof: **10,822 comparisons**, comprising 9,001 current-turn selection, assistant/model counts, transcript rendering, and prompt-byte vectors plus 1,821 hostile record/array, provenance, replay suppression, JSON, and persisted proposal/rollback vectors.
- One trusted Blacksmith Testbox lease (`tbx_01kz92zzzprgzcbhk4qz5wcwng`): **14 focused suites, 172 tests passed**, covering lifecycle, research autocapture/auto-apply, experience review/auto-apply, history scan/resume, record/store persistence, service/evaluation/lifecycle, and prompt authoring.
- Full unchanged remote `pnpm check:changed` passed on the same lease, including core and core-test typechecks, formatting, lint, plugin boundaries, all three dead-export scans, database/schema guards, and zero runtime import cycles: https://github.com/openclaw/openclaw/actions/runs/31012107778
- Independent structured autoreview using Codex `gpt-5.6-sol` with `xhigh` reasoning: clean, confidence 0.97; no actionable findings.
- Scoped canonical formatting, strict generic/result-type semantic checks, and `git diff --check` passed; the sole owned Testbox lease was stopped and independently verified completed.
- AI-assisted implementation and independent review.

