### PR TITLE
improve: reduce worker tool startup imports

### DIFF
--- a/src/agents/agent-tools.finalize.ts
+++ b/src/agents/agent-tools.finalize.ts
@@ -1,0 +1,60 @@
+import type { ModelCompatConfig } from "../config/types.models.js";
+import { wrapToolWithAbortSignal } from "./agent-tools.abort.js";
+import type { HookContext } from "./agent-tools.before-tool-call.types.js";
+import {
+  rewrapToolWithBeforeToolCallHook,
+  wrapToolWithBeforeToolCallHook,
+} from "./agent-tools.before-tool-call.wrapper.js";
+import { applyDeferredFollowupToolDescriptions } from "./agent-tools.deferred-followup.js";
+import { normalizeToolParameters } from "./agent-tools.schema.js";
+import type { AnyAgentTool } from "./agent-tools.types.js";
+import { isToolWrappedWithBeforeToolCallHook } from "./before-tool-call-metadata.js";
+
+type FinalizeAgentToolsOptions = {
+  tools: AnyAgentTool[];
+  modelProvider?: string;
+  modelId?: string;
+  modelCompat?: ModelCompatConfig;
+  hookContext: HookContext;
+  wrapBeforeToolCallHook?: boolean;
+  emitBeforeToolCallDiagnostics?: boolean;
+  approvalMode?: "request" | "report" | "deny";
+  abortSignal?: AbortSignal;
+  agentId?: string;
+  recordToolPrepStage?: (name: string) => void;
+};
+
+/** Apply the shared schema, hook, abort, and description wrappers to an authorized tool set. */
+export function finalizeAgentTools(options: FinalizeAgentToolsOptions): AnyAgentTool[] {
+  const normalized = options.tools.map((tool) =>
+    normalizeToolParameters(tool, {
+      modelProvider: options.modelProvider,
+      modelId: options.modelId,
+      modelCompat: options.modelCompat,
+    }),
+  );
+  options.recordToolPrepStage?.("schema-normalization");
+  const hookOptions = {
+    emitDiagnostics: options.emitBeforeToolCallDiagnostics,
+    ...(options.approvalMode ? { approvalMode: options.approvalMode } : {}),
+  };
+  const withHooks =
+    options.wrapBeforeToolCallHook === false
+      ? normalized
+      : normalized.map((tool) =>
+          isToolWrappedWithBeforeToolCallHook(tool)
+            ? rewrapToolWithBeforeToolCallHook(tool, options.hookContext, hookOptions)
+            : wrapToolWithBeforeToolCallHook(tool, options.hookContext, hookOptions),
+        );
+  options.recordToolPrepStage?.("tool-hooks");
+  const abortSignal = options.abortSignal;
+  const withAbort = abortSignal
+    ? withHooks.map((tool) => wrapToolWithAbortSignal(tool, abortSignal))
+    : withHooks;
+  options.recordToolPrepStage?.("abort-wrappers");
+  const finalized = applyDeferredFollowupToolDescriptions(withAbort, {
+    agentId: options.agentId,
+  });
+  options.recordToolPrepStage?.("deferred-followup-descriptions");
+  return finalized;
+}

--- a/src/agents/agent-tools.read.host-operations.test.ts
+++ b/src/agents/agent-tools.read.host-operations.test.ts
@@ -29,8 +29,10 @@ const mocks = vi.hoisted(() => ({
   writeOps: undefined as CapturedWriteOperations | undefined,
 }));
 
-vi.mock("./sessions/index.js", async () => {
-  const actual = await vi.importActual<typeof import("./sessions/index.js")>("./sessions/index.js");
+vi.mock("./sessions/tools/index.js", async () => {
+  const actual = await vi.importActual<typeof import("./sessions/tools/index.js")>(
+    "./sessions/tools/index.js",
+  );
   return {
     ...actual,
     createEditTool: (_cwd: string, options?: { operations?: CapturedEditOperations }) => {

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -890,8 +890,10 @@ type SandboxToolParams = {
 };
 
 /** Create a sandbox-backed read tool with OpenClaw result normalization. */
-export function createSandboxedReadTool(params: SandboxToolParams) {
-  const base = createReadTool(params.root, {
+export function createSandboxedReadTool(
+  params: SandboxToolParams & { createTool?: typeof createReadTool },
+) {
+  const base = (params.createTool ?? createReadTool)(params.root, {
     operations: createSandboxReadOperations(params),
   }) as unknown as AnyAgentTool;
   return createOpenClawReadTool(base, {
@@ -901,16 +903,20 @@ export function createSandboxedReadTool(params: SandboxToolParams) {
 }
 
 /** Create a sandbox-backed write tool with required-parameter validation. */
-export function createSandboxedWriteTool(params: SandboxToolParams) {
-  const base = createWriteTool(params.root, {
+export function createSandboxedWriteTool(
+  params: SandboxToolParams & { createTool?: typeof createWriteTool },
+) {
+  const base = (params.createTool ?? createWriteTool)(params.root, {
     operations: createSandboxWriteOperations(params),
   }) as unknown as AnyAgentTool;
   return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.write);
 }
 
 /** Create a sandbox-backed edit tool with required-parameter validation. */
-export function createSandboxedEditTool(params: SandboxToolParams) {
-  const base = createEditTool(params.root, {
+export function createSandboxedEditTool(
+  params: SandboxToolParams & { createTool?: typeof createEditTool },
+) {
+  const base = (params.createTool ?? createEditTool)(params.root, {
     operations: createSandboxEditOperations(params),
   }) as unknown as AnyAgentTool;
   return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.edit);
@@ -922,9 +928,10 @@ export function createHostWorkspaceWriteTool(
   options?: {
     workspaceOnly?: boolean;
     memoryWriteProvenance?: MemoryWriteProvenanceObserver;
+    createTool?: typeof createWriteTool;
   },
 ) {
-  const base = createWriteTool(root, {
+  const base = (options?.createTool ?? createWriteTool)(root, {
     operations: createHostWriteOperations(root, options),
   }) as unknown as AnyAgentTool;
   return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.write);
@@ -936,9 +943,10 @@ export function createHostWorkspaceEditTool(
   options?: {
     workspaceOnly?: boolean;
     memoryWriteProvenance?: MemoryWriteProvenanceObserver;
+    createTool?: typeof createEditTool;
   },
 ) {
-  const base = createEditTool(root, {
+  const base = (options?.createTool ?? createEditTool)(root, {
     operations: createHostEditOperations(root, options),
   }) as unknown as AnyAgentTool;
   return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.edit);

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -48,7 +48,7 @@ import {
   createWriteTool,
   type ReadToolDetails,
   type ReadToolTruncationDetails,
-} from "./sessions/index.js";
+} from "./sessions/tools/index.js";
 import { sanitizeToolResultImages } from "./tool-images.js";
 
 // NOTE(steipete): Upstream read now does file-magic MIME detection; we keep the wrapper

--- a/src/agents/agent-tools.read.workspace-root-lazy.test.ts
+++ b/src/agents/agent-tools.read.workspace-root-lazy.test.ts
@@ -26,8 +26,8 @@ vi.mock("../infra/fs-safe.js", async (importOriginal) => {
 
 // Capture the operations object handed to the underlying write/edit tools so the
 // regression can drive a single workspace write operation directly.
-vi.mock("./sessions/index.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./sessions/index.js")>();
+vi.mock("./sessions/tools/index.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./sessions/tools/index.js")>();
   const stub = (name: string) => ({
     name,
     description: `test ${name} tool`,

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -3,7 +3,6 @@
  * Assembles core, shell, channel, OpenClaw, plugin, and Tool Search tools, then
  * applies sandbox, profile, provider, sender, group, and sub-agent policy.
  */
-import path from "node:path";
 import type {
   SourceReplyDeliveryMode,
   TaskSuggestionDeliveryMode,
@@ -27,44 +26,21 @@ import { appendRuntimePluginToolGrant } from "../plugins/tool-grant-allowlist.js
 import { getPluginToolMeta } from "../plugins/tools.js";
 import { GATEWAY_OWNER_ONLY_CORE_TOOLS } from "../security/dangerous-tools.js";
 import type { InputProvenance } from "../sessions/input-provenance.js";
-import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import type { SkillSnapshot, SkillUsagePath } from "../skills/types.js";
 import type { SkillWorkshopRunOptions } from "../skills/workshop/types.js";
 import { resolveGatewayMessageChannel } from "../utils/message-channel.js";
-import { wrapToolWithAbortSignal } from "./agent-tools.abort.js";
-import {
-  isToolWrappedWithBeforeToolCallHook,
-  rewrapToolWithBeforeToolCallHook,
-  type ToolOutcomeObserver,
-  wrapToolWithBeforeToolCallHook,
-} from "./agent-tools.before-tool-call.js";
-import { applyDeferredFollowupToolDescriptions } from "./agent-tools.deferred-followup.js";
+import type { ToolOutcomeObserver } from "./agent-tools.before-tool-call.js";
+import { finalizeAgentTools } from "./agent-tools.finalize.js";
 import { filterToolsByMessageProvider } from "./agent-tools.message-provider-policy.js";
-import {
-  createHostWorkspaceEditTool,
-  createHostWorkspaceWriteTool,
-  createOpenClawReadTool,
-  createSandboxedEditTool,
-  createSandboxedReadTool,
-  createSandboxedWriteTool,
-  wrapReadToolWithSkillContent,
-  wrapToolMemoryFlushAppendOnlyWrite,
-  wrapToolWorkspaceRootGuard,
-  wrapToolWorkspaceRootGuardWithOptions,
-} from "./agent-tools.read.js";
+import { wrapToolMemoryFlushAppendOnlyWrite } from "./agent-tools.read.js";
 import {
   getActiveAgentRingZeroTools,
   mergeAgentRingZeroTools,
 } from "./agent-tools.ring-zero-context.js";
-import { normalizeToolParameters } from "./agent-tools.schema.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
 import { isApplyPatchAllowedForModel } from "./apply-patch-model-policy.js";
-import { createApplyPatchTool } from "./apply-patch.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
-import { describeProcessTool } from "./bash-tools.descriptions.js";
 import type { ExecToolDefaults } from "./bash-tools.exec-types.js";
-import type { ProcessToolDefaults } from "./bash-tools.process.js";
-import { processSchema } from "./bash-tools.schemas.js";
 import { listChannelAgentTools } from "./channel-tools.js";
 import { shouldSuppressManagedWebSearchTool } from "./codex-native-web-search.js";
 import {
@@ -76,10 +52,11 @@ import {
   buildConversationToolPolicyPipelineSteps,
   resolveConversationToolPolicies,
 } from "./conversation-tool-policy-pipeline.js";
+import { createCoreCodingTools } from "./core-coding-tools.js";
 import type { OpenClawCodingToolConstructionPlan } from "./core-tool-factory-descriptors.js";
 import { applyDelegationCapability, type DelegationCapability } from "./delegation-capability.js";
 import { resolveImageSanitizationLimits } from "./image-sanitization.js";
-import { createLazyExecTool, resolveExecToolConfig } from "./lazy-exec-tool.js";
+import { resolveExecToolConfig } from "./lazy-exec-tool.js";
 import {
   filterLocalModelLeanTools,
   resolveLocalModelLeanPreserveToolNames,
@@ -90,15 +67,8 @@ import { resolveOpenClawPluginToolsForOptions } from "./openclaw-plugin-tools.js
 import { createOpenClawTools, filterToolsByClientCaps } from "./openclaw-tools.js";
 import type { PreparedModelRuntimeSnapshot } from "./prepared-model-runtime.js";
 import type { SandboxContext } from "./sandbox.js";
-import { SANDBOX_AGENT_WORKSPACE_MOUNT } from "./sandbox/constants.js";
-import {
-  resolveReadOnlyWorkspaceSkillMounts,
-  type ReadOnlyWorkspaceSkillMount,
-} from "./sandbox/workspace-mounts.js";
 import type { ScheduledToolPolicyContext } from "./scheduled-tool-policy.js";
-import { createCodingTools, createReadTool } from "./sessions/index.js";
 import type { TrustedSubagentCompletionHandoff } from "./subagent-announce-handoff.js";
-import { PROCESS_TOOL_DISPLAY_SUMMARY } from "./tool-description-presets.js";
 import { createToolFsPolicy, resolveToolFsConfig } from "./tool-fs-policy.js";
 import { resolveToolLoopDetectionConfig } from "./tool-loop-detection-config.js";
 import { buildDeclaredToolAllowlistContext } from "./tool-policy-declared-context.js";
@@ -127,84 +97,6 @@ import {
 import { wrapToolWithGatewayCallerIdentity } from "./tools/gateway-caller-context.js";
 
 const MEMORY_FLUSH_ALLOWED_TOOL_NAMES = new Set(["read", "write"]);
-
-type GuardContainerMount = {
-  containerRoot: string;
-  hostRoot: string;
-};
-
-function readOnlySandboxReadMounts(
-  sandbox: SandboxContext | null | undefined,
-  readOnlyWorkspaceSkillMounts: readonly ReadOnlyWorkspaceSkillMount[],
-): GuardContainerMount[] | undefined {
-  if (!sandbox) {
-    return undefined;
-  }
-  const mounts: GuardContainerMount[] = [];
-  if (sandbox.workspaceAccess === "ro" && sandbox.agentWorkspaceDir !== sandbox.workspaceDir) {
-    mounts.push({
-      containerRoot: SANDBOX_AGENT_WORKSPACE_MOUNT,
-      hostRoot: sandbox.agentWorkspaceDir,
-    });
-  }
-  if (sandbox.workspaceAccess === "rw") {
-    mounts.push(
-      ...readOnlyWorkspaceSkillMounts.map((mount) => ({
-        containerRoot: mount.containerPath,
-        hostRoot: mount.hostPath,
-      })),
-    );
-  }
-  return mounts.length > 0 ? mounts : undefined;
-}
-
-function resolveSkillReadRoots(skillsSnapshot?: SkillSnapshot): string[] | undefined {
-  const roots = new Set<string>();
-  for (const skill of skillsSnapshot?.resolvedSkills ?? []) {
-    const baseDir = typeof skill.baseDir === "string" ? skill.baseDir.trim() : "";
-    const filePath = typeof skill.filePath === "string" ? skill.filePath.trim() : "";
-    const root = baseDir || (filePath ? path.dirname(filePath) : "");
-    if (!root || !path.isAbsolute(root)) {
-      continue;
-    }
-    roots.add(path.resolve(root));
-  }
-  if (roots.size === 0) {
-    return undefined;
-  }
-  return Array.from(roots);
-}
-
-type BashToolsModule = typeof import("./bash-tools.js");
-
-const bashToolsModuleLoader = createLazyImportLoader<BashToolsModule>(
-  () => import("./bash-tools.js"),
-);
-
-function loadBashToolsModule(): Promise<BashToolsModule> {
-  return bashToolsModuleLoader.load();
-}
-
-function createLazyProcessTool(defaults?: ProcessToolDefaults): AnyAgentTool {
-  let loadedTool: AnyAgentTool | undefined;
-  const loadTool = async () => {
-    if (!loadedTool) {
-      const { createProcessTool } = await loadBashToolsModule();
-      loadedTool = createProcessTool(defaults) as unknown as AnyAgentTool;
-    }
-    return loadedTool;
-  };
-
-  return {
-    name: "process",
-    label: "process",
-    displaySummary: PROCESS_TOOL_DISPLAY_SUMMARY,
-    description: describeProcessTool({ hasCronTool: defaults?.hasCronTool === true }),
-    parameters: processSchema,
-    execute: async (...args: Parameters<AnyAgentTool["execute"]>) =>
-      (await loadTool()).execute(...args),
-  } as AnyAgentTool;
-}
 
 /** Resolve the process-tool isolation key for exec/process session state. */
 export function resolveProcessToolScopeKey(params: {
@@ -476,7 +368,6 @@ type OpenClawCodingToolsOptions = {
 };
 
 function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions): AnyAgentTool[] {
-  const execToolName = "exec";
   const sandbox = options?.sandbox?.enabled ? options.sandbox : undefined;
   const isMemoryFlushRun = options?.trigger === "memory";
   if (isMemoryFlushRun && !options?.memoryFlushWritePath) {
@@ -640,19 +531,6 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
   const includeChannelTools = toolConstructionPlan.includeChannelTools;
   const includePluginTools = toolConstructionPlan.includePluginTools;
   const workspaceOnly = fsPolicy.workspaceOnly;
-  const skillReadRoots = sandboxRoot ? undefined : resolveSkillReadRoots(options?.skillsSnapshot);
-  const needsReadOnlyWorkspaceSkillMounts =
-    includeShellTools || (includeBaseCodingTools && workspaceOnly);
-  const readOnlyWorkspaceSkillMounts =
-    sandbox && needsReadOnlyWorkspaceSkillMounts
-      ? resolveReadOnlyWorkspaceSkillMounts({
-          workspaceDir: sandbox.workspaceDir,
-          agentWorkspaceDir: sandbox.agentWorkspaceDir,
-          skillsWorkspaceDir: sandbox.skillsWorkspaceDir,
-          workdir: sandbox.containerWorkdir,
-          workspaceAccess: sandbox.workspaceAccess,
-        })
-      : [];
   const applyPatchConfig = execConfig.applyPatch;
   // Secure by default: apply_patch is workspace-contained unless explicitly disabled.
   // (tools.fs.workspaceOnly is a separate umbrella flag for read/write/edit/apply_patch.)
@@ -665,176 +543,76 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
       allowModels: applyPatchConfig?.allowModels,
     });
 
-  if (sandboxRoot && !sandboxFsBridge) {
-    throw new Error("Sandbox filesystem bridge is unavailable.");
-  }
   const imageSanitization = resolveImageSanitizationLimits(options?.config);
   options?.recordToolPrepStage?.("workspace-policy");
-
-  const base: AnyAgentTool[] = [];
-  if (includeBaseCodingTools) {
-    for (const tool of createCodingTools(codingRoot) as unknown as AnyAgentTool[]) {
-      if (tool.name === "read") {
-        if (sandboxRoot) {
-          const sandboxed = createSandboxedReadTool({
-            root: sandboxRoot,
-            bridge: sandboxFsBridge!,
-            modelContextWindowTokens: options?.modelContextWindowTokens,
-            imageSanitization,
-          });
-          const guarded = workspaceOnly
-            ? wrapToolWorkspaceRootGuardWithOptions(sandboxed, sandboxRoot, {
-                additionalContainerMounts: readOnlySandboxReadMounts(
-                  sandbox,
-                  readOnlyWorkspaceSkillMounts,
-                ),
-                containerWorkdir: sandbox.containerWorkdir,
-              })
-            : sandboxed;
-          base.push(
-            wrapReadToolWithSkillContent(guarded, options?.skillsSnapshot?.resolvedSkills, {
-              modelContextWindowTokens: options?.modelContextWindowTokens,
-              imageSanitization,
-            }),
-          );
-          continue;
-        }
-        const freshReadTool = createReadTool(codingRoot);
-        const wrapped = createOpenClawReadTool(freshReadTool, {
-          modelContextWindowTokens: options?.modelContextWindowTokens,
-          imageSanitization,
-        });
-        const guarded = workspaceOnly
-          ? wrapToolWorkspaceRootGuardWithOptions(wrapped, codingRoot, {
-              additionalRoots: skillReadRoots,
-            })
-          : wrapped;
-        base.push(
-          wrapReadToolWithSkillContent(guarded, options?.skillsSnapshot?.resolvedSkills, {
-            modelContextWindowTokens: options?.modelContextWindowTokens,
-            imageSanitization,
-          }),
-        );
-        continue;
-      }
-      if (tool.name === "bash" || tool.name === execToolName) {
-        continue;
-      }
-      if (tool.name === "write") {
-        if (sandboxRoot) {
-          continue;
-        }
-        const wrapped = createHostWorkspaceWriteTool(codingRoot, {
-          workspaceOnly,
-          memoryWriteProvenance,
-        });
-        base.push(workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, codingRoot) : wrapped);
-        continue;
-      }
-      if (tool.name === "edit") {
-        if (sandboxRoot) {
-          continue;
-        }
-        const wrapped = createHostWorkspaceEditTool(codingRoot, {
-          workspaceOnly,
-          memoryWriteProvenance,
-        });
-        base.push(workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, codingRoot) : wrapped);
-        continue;
-      }
-      base.push(tool);
-    }
-  }
-  options?.recordToolPrepStage?.("base-coding-tools");
   const { cleanupMs: cleanupMsOverride, ...execDefaults } = options?.exec ?? {};
   const effectiveExecPolicy = applyExecPolicyLayer(execConfig, options?.exec);
-  const execTool = includeShellTools
-    ? createLazyExecTool({
-        ...execDefaults,
-        host: options?.exec?.host ?? execConfig.host,
-        mode: effectiveExecPolicy.mode,
-        security: effectiveExecPolicy.security,
-        ask: effectiveExecPolicy.ask,
-        config: options?.exec?.config ?? options?.config,
-        reviewer: options?.exec?.reviewer ?? execConfig.reviewer,
-        trigger: options?.trigger,
-        node: options?.exec?.node ?? execConfig.node,
-        pathPrepend: options?.exec?.pathPrepend ?? execConfig.pathPrepend,
-        safeBins: options?.exec?.safeBins ?? execConfig.safeBins,
-        strictInlineEval: options?.exec?.strictInlineEval ?? execConfig.strictInlineEval,
-        commandHighlighting: options?.exec?.commandHighlighting ?? execConfig.commandHighlighting,
-        safeBinTrustedDirs: options?.exec?.safeBinTrustedDirs ?? execConfig.safeBinTrustedDirs,
-        safeBinProfiles: options?.exec?.safeBinProfiles ?? execConfig.safeBinProfiles,
-        agentId,
-        cwd: codingRoot,
-        allowBackground,
-        scopeKey,
-        sessionKey: options?.sessionKey,
-        runId: options?.runId,
-        // Detached completions return to the live session, not the sandbox policy scope.
-        notifySessionKey: options?.runSessionKey ?? options?.sessionKey,
-        sessionId: options?.sessionId,
-        sessionStore: options?.config?.session?.store,
-        mainKey: options?.config?.session?.mainKey,
-        sessionScope: options?.config?.session?.scope,
-        eventRouting: resolveEventSessionRoutingPolicy({
-          cfg: options?.config,
-          sessionKey: options?.runSessionKey ?? options?.sessionKey,
-          channel: options?.messageProvider,
-          accountId: options?.agentAccountId,
-        }),
-        messageProvider: options?.messageProvider,
-        currentChannelId: options?.currentChannelId,
-        currentThreadTs: options?.currentThreadTs,
-        channelContext: options?.channelContext,
+  const coreTools = createCoreCodingTools({
+    codingRoot,
+    includeBaseCodingTools,
+    includeShellTools,
+    workspaceOnly,
+    sandbox,
+    skillsSnapshot: options?.skillsSnapshot,
+    modelContextWindowTokens: options?.modelContextWindowTokens,
+    imageSanitization,
+    memoryWriteProvenance,
+    applyPatchEnabled,
+    applyPatchWorkspaceOnly,
+    execDefaults: {
+      ...execDefaults,
+      host: options?.exec?.host ?? execConfig.host,
+      mode: effectiveExecPolicy.mode,
+      security: effectiveExecPolicy.security,
+      ask: effectiveExecPolicy.ask,
+      config: options?.exec?.config ?? options?.config,
+      reviewer: options?.exec?.reviewer ?? execConfig.reviewer,
+      trigger: options?.trigger,
+      node: options?.exec?.node ?? execConfig.node,
+      pathPrepend: options?.exec?.pathPrepend ?? execConfig.pathPrepend,
+      safeBins: options?.exec?.safeBins ?? execConfig.safeBins,
+      strictInlineEval: options?.exec?.strictInlineEval ?? execConfig.strictInlineEval,
+      commandHighlighting: options?.exec?.commandHighlighting ?? execConfig.commandHighlighting,
+      safeBinTrustedDirs: options?.exec?.safeBinTrustedDirs ?? execConfig.safeBinTrustedDirs,
+      safeBinProfiles: options?.exec?.safeBinProfiles ?? execConfig.safeBinProfiles,
+      agentId,
+      allowBackground,
+      scopeKey,
+      sessionKey: options?.sessionKey,
+      runId: options?.runId,
+      // Detached completions return to the live session, not the sandbox policy scope.
+      notifySessionKey: options?.runSessionKey ?? options?.sessionKey,
+      sessionId: options?.sessionId,
+      sessionStore: options?.config?.session?.store,
+      mainKey: options?.config?.session?.mainKey,
+      sessionScope: options?.config?.session?.scope,
+      eventRouting: resolveEventSessionRoutingPolicy({
+        cfg: options?.config,
+        sessionKey: options?.runSessionKey ?? options?.sessionKey,
+        channel: options?.messageProvider,
         accountId: options?.agentAccountId,
-        approvalReviewerDeviceId: options?.approvalReviewerDeviceId,
-        nonInteractiveApproval: options?.swarmCollector,
-        backgroundMs: options?.exec?.backgroundMs ?? execConfig.backgroundMs,
-        timeoutSec: options?.exec?.timeoutSec ?? execConfig.timeoutSec,
-        approvalRunningNoticeMs:
-          options?.exec?.approvalRunningNoticeMs ?? execConfig.approvalRunningNoticeMs,
-        notifyOnExit: options?.exec?.notifyOnExit ?? execConfig.notifyOnExit,
-        notifyOnExitEmptySuccess:
-          options?.exec?.notifyOnExitEmptySuccess ?? execConfig.notifyOnExitEmptySuccess,
-        sandbox: sandbox
-          ? {
-              containerName: sandbox.containerName,
-              workspaceDir: sandbox.workspaceDir,
-              containerWorkdir: sandbox.containerWorkdir,
-              workdirValidation: sandbox.backend?.workdirValidation,
-              validateWorkdir: sandbox.backend?.validateWorkdir?.bind(sandbox.backend),
-              discardPreparedWorkdir: sandbox.backend?.discardPreparedWorkdir?.bind(
-                sandbox.backend,
-              ),
-              workdirRoots: sandbox.backend?.workdirRoots,
-              readOnlyWorkspaceSkillMounts,
-              env: sandbox.backend?.env ?? sandbox.docker.env,
-              buildExecSpec: sandbox.backend?.buildExecSpec.bind(sandbox.backend),
-              finalizeExec: sandbox.backend?.finalizeExec?.bind(sandbox.backend),
-            }
-          : undefined,
-      })
-    : null;
-  const processTool = includeShellTools
-    ? createLazyProcessTool({
-        cleanupMs: cleanupMsOverride ?? execConfig.cleanupMs,
-        scopeKey,
-      })
-    : null;
-  const applyPatchTool =
-    !includeShellTools || !applyPatchEnabled || (sandboxRoot && !allowWorkspaceWrites)
-      ? null
-      : createApplyPatchTool({
-          cwd: codingRoot,
-          sandbox:
-            sandboxRoot && allowWorkspaceWrites
-              ? { root: sandboxRoot, bridge: sandboxFsBridge! }
-              : undefined,
-          workspaceOnly: applyPatchWorkspaceOnly,
-          memoryWriteProvenance,
-        });
-  options?.recordToolPrepStage?.("shell-tools");
+      }),
+      messageProvider: options?.messageProvider,
+      currentChannelId: options?.currentChannelId,
+      currentThreadTs: options?.currentThreadTs,
+      channelContext: options?.channelContext,
+      accountId: options?.agentAccountId,
+      approvalReviewerDeviceId: options?.approvalReviewerDeviceId,
+      nonInteractiveApproval: options?.swarmCollector,
+      backgroundMs: options?.exec?.backgroundMs ?? execConfig.backgroundMs,
+      timeoutSec: options?.exec?.timeoutSec ?? execConfig.timeoutSec,
+      approvalRunningNoticeMs:
+        options?.exec?.approvalRunningNoticeMs ?? execConfig.approvalRunningNoticeMs,
+      notifyOnExit: options?.exec?.notifyOnExit ?? execConfig.notifyOnExit,
+      notifyOnExitEmptySuccess:
+        options?.exec?.notifyOnExitEmptySuccess ?? execConfig.notifyOnExitEmptySuccess,
+    },
+    processDefaults: {
+      cleanupMs: cleanupMsOverride ?? execConfig.cleanupMs,
+      scopeKey,
+    },
+    recordToolPrepStage: options?.recordToolPrepStage,
+  });
   const ownerOnlyCoreToolDenylist =
     options?.senderIsOwner === false ? [...GATEWAY_OWNER_ONLY_CORE_TOOLS] : [];
   const ownerOnlyCoreToolPolicy =
@@ -936,50 +714,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
         })
       : [];
   const tools: AnyAgentTool[] = [
-    ...base,
-    ...(includeBaseCodingTools && sandboxRoot
-      ? allowWorkspaceWrites
-        ? [
-            workspaceOnly
-              ? wrapToolWorkspaceRootGuardWithOptions(
-                  createSandboxedEditTool({
-                    root: sandboxRoot,
-                    bridge: sandboxFsBridge!,
-                    memoryWriteProvenance,
-                  }),
-                  sandboxRoot,
-                  {
-                    containerWorkdir: sandbox.containerWorkdir,
-                  },
-                )
-              : createSandboxedEditTool({
-                  root: sandboxRoot,
-                  bridge: sandboxFsBridge!,
-                  memoryWriteProvenance,
-                }),
-            workspaceOnly
-              ? wrapToolWorkspaceRootGuardWithOptions(
-                  createSandboxedWriteTool({
-                    root: sandboxRoot,
-                    bridge: sandboxFsBridge!,
-                    memoryWriteProvenance,
-                  }),
-                  sandboxRoot,
-                  {
-                    containerWorkdir: sandbox.containerWorkdir,
-                  },
-                )
-              : createSandboxedWriteTool({
-                  root: sandboxRoot,
-                  bridge: sandboxFsBridge!,
-                  memoryWriteProvenance,
-                }),
-          ]
-        : []
-      : []),
-    ...(includeShellTools && applyPatchTool ? [applyPatchTool as unknown as AnyAgentTool] : []),
-    ...(execTool ? [execTool as unknown as AnyAgentTool] : []),
-    ...(processTool ? [processTool as unknown as AnyAgentTool] : []),
+    ...coreTools,
     // Channel docking: include channel-defined agent tools (login, etc.).
     ...(includeChannelTools ? listChannelAgentTools({ cfg: options?.config }) : []),
     ...(includeOpenClawTools
@@ -1173,17 +908,6 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
     getPluginToolMeta(tool),
   );
   options?.recordToolPrepStage?.("authorization-policy");
-  // Always normalize tool JSON Schemas before handing them to OpenClaw model runtime.
-  // Without this, some providers (notably OpenAI) will reject root-level union schemas.
-  // Provider-specific cleaning: Gemini needs constraint keywords stripped, but Anthropic expects them.
-  const normalized = authorizedTools.map((tool) =>
-    normalizeToolParameters(tool, {
-      modelProvider: options?.modelProvider,
-      modelId: options?.modelId,
-      modelCompat: options?.modelCompat,
-    }),
-  );
-  options?.recordToolPrepStage?.("schema-normalization");
   const turnSourceChannel = options?.messageChannel ?? options?.messageProvider;
   const turnSourceTo = options?.currentMessagingTarget ?? options?.currentChannelId;
   const requester = {
@@ -1220,34 +944,20 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
     onToolOutcome: options?.onToolOutcome,
     allocateToolOutcomeOrdinal: options?.allocateToolOutcomeOrdinal,
   };
-  const hookOptions = {
-    emitDiagnostics: options?.emitBeforeToolCallDiagnostics,
+  // NOTE: Keep canonical (lowercase) tool names here. Provider transports remap on the wire.
+  return finalizeAgentTools({
+    tools: authorizedTools,
+    modelProvider: options?.modelProvider,
+    modelId: options?.modelId,
+    modelCompat: options?.modelCompat,
+    hookContext,
+    wrapBeforeToolCallHook: options?.wrapBeforeToolCallHook,
+    emitBeforeToolCallDiagnostics: options?.emitBeforeToolCallDiagnostics,
     ...(options?.swarmCollector ? { approvalMode: "deny" as const } : {}),
-  };
-  // MCP and other outer dispatchers execute hooks at their shared call boundary.
-  // Rewrapping here would run plugin authorization and mutation hooks twice.
-  const withHooks =
-    options?.wrapBeforeToolCallHook === false
-      ? normalized
-      : normalized.map((tool) =>
-          isToolWrappedWithBeforeToolCallHook(tool)
-            ? rewrapToolWithBeforeToolCallHook(tool, hookContext, hookOptions)
-            : wrapToolWithBeforeToolCallHook(tool, hookContext, hookOptions),
-        );
-  options?.recordToolPrepStage?.("tool-hooks");
-  const withAbort = options?.abortSignal
-    ? withHooks.map((tool) => wrapToolWithAbortSignal(tool, options.abortSignal))
-    : withHooks;
-  options?.recordToolPrepStage?.("abort-wrappers");
-  const withDeferredFollowupDescriptions = applyDeferredFollowupToolDescriptions(withAbort, {
+    abortSignal: options?.abortSignal,
     agentId,
+    recordToolPrepStage: options?.recordToolPrepStage,
   });
-  options?.recordToolPrepStage?.("deferred-followup-descriptions");
-
-  // NOTE: Keep canonical (lowercase) tool names here.
-  // shared model runtime's Anthropic OAuth transport remaps tool names to Claude Code-style names
-  // on the wire and maps them back for tool dispatch.
-  return withDeferredFollowupDescriptions;
 }
 
 /** Build the runtime tool list exposed through the public agent harness SDK. */

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -41,6 +41,7 @@ import type { AnyAgentTool } from "./agent-tools.types.js";
 import { isApplyPatchAllowedForModel } from "./apply-patch-model-policy.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
 import type { ExecToolDefaults } from "./bash-tools.exec-types.js";
+import type { ProcessToolDefaults } from "./bash-tools.process.js";
 import { listChannelAgentTools } from "./channel-tools.js";
 import { shouldSuppressManagedWebSearchTool } from "./codex-native-web-search.js";
 import {
@@ -68,6 +69,12 @@ import { createOpenClawTools, filterToolsByClientCaps } from "./openclaw-tools.j
 import type { PreparedModelRuntimeSnapshot } from "./prepared-model-runtime.js";
 import type { SandboxContext } from "./sandbox.js";
 import type { ScheduledToolPolicyContext } from "./scheduled-tool-policy.js";
+import {
+  createCodingTools,
+  createEditTool,
+  createReadTool,
+  createWriteTool,
+} from "./sessions/index.js";
 import type { TrustedSubagentCompletionHandoff } from "./subagent-announce-handoff.js";
 import { createToolFsPolicy, resolveToolFsConfig } from "./tool-fs-policy.js";
 import { resolveToolLoopDetectionConfig } from "./tool-loop-detection-config.js";
@@ -557,6 +564,14 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
     modelContextWindowTokens: options?.modelContextWindowTokens,
     imageSanitization,
     memoryWriteProvenance,
+    ...(includeBaseCodingTools
+      ? { baseToolNames: createCodingTools(codingRoot).map((tool) => tool.name) }
+      : {}),
+    baseToolFactories: {
+      createEditTool,
+      createReadTool,
+      createWriteTool,
+    },
     applyPatchEnabled,
     applyPatchWorkspaceOnly,
     execDefaults: {

--- a/src/agents/core-coding-tools.ts
+++ b/src/agents/core-coding-tools.ts
@@ -25,6 +25,11 @@ import {
   resolveReadOnlyWorkspaceSkillMounts,
   type ReadOnlyWorkspaceSkillMount,
 } from "./sandbox/workspace-mounts.js";
+import type {
+  createEditTool,
+  createReadTool as CreateReadTool,
+  createWriteTool,
+} from "./sessions/tools/index.js";
 import { createReadTool } from "./sessions/tools/read.js";
 
 function readOnlySandboxReadMounts(
@@ -63,7 +68,7 @@ function resolveSkillReadRoots(skillsSnapshot?: SkillSnapshot): string[] | undef
   return roots.size > 0 ? Array.from(roots) : undefined;
 }
 
-export type CoreCodingToolsOptions = {
+type CoreCodingToolsOptions = {
   codingRoot: string;
   includeBaseCodingTools: boolean;
   includeShellTools: boolean;
@@ -73,6 +78,12 @@ export type CoreCodingToolsOptions = {
   modelContextWindowTokens?: number;
   imageSanitization?: ImageSanitizationLimits;
   memoryWriteProvenance?: MemoryWriteProvenanceObserver;
+  baseToolNames?: readonly string[];
+  baseToolFactories?: {
+    createEditTool: typeof createEditTool;
+    createReadTool: typeof CreateReadTool;
+    createWriteTool: typeof createWriteTool;
+  };
   applyPatchEnabled: boolean;
   applyPatchWorkspaceOnly: boolean;
   execDefaults: ExecToolDefaults;
@@ -106,37 +117,38 @@ export function createCoreCodingTools(options: CoreCodingToolsOptions): AnyAgent
 
   const base: AnyAgentTool[] = [];
   if (options.includeBaseCodingTools) {
-    if (sandboxRoot) {
-      const sandboxed = createSandboxedReadTool({
-        root: sandboxRoot,
-        bridge: sandboxFsBridge!,
-        modelContextWindowTokens: options.modelContextWindowTokens,
-        imageSanitization: options.imageSanitization,
-      });
-      const guarded = options.workspaceOnly
-        ? wrapToolWorkspaceRootGuardWithOptions(sandboxed, sandboxRoot, {
-            additionalContainerMounts: readOnlySandboxReadMounts(
-              sandbox,
-              readOnlyWorkspaceSkillMounts,
-            ),
-            containerWorkdir: sandbox.containerWorkdir,
+    const baseToolNames = new Set(options.baseToolNames ?? ["read", "edit", "write"]);
+    if (baseToolNames.has("read")) {
+      const wrapped = sandboxRoot
+        ? createSandboxedReadTool({
+            root: sandboxRoot,
+            bridge: sandboxFsBridge!,
+            modelContextWindowTokens: options.modelContextWindowTokens,
+            imageSanitization: options.imageSanitization,
+            createTool: options.baseToolFactories?.createReadTool,
           })
-        : sandboxed;
-      base.push(
-        wrapReadToolWithSkillContent(guarded, options.skillsSnapshot?.resolvedSkills, {
-          modelContextWindowTokens: options.modelContextWindowTokens,
-          imageSanitization: options.imageSanitization,
-        }),
-      );
-    } else {
-      const wrapped = createOpenClawReadTool(createReadTool(options.codingRoot), {
-        modelContextWindowTokens: options.modelContextWindowTokens,
-        imageSanitization: options.imageSanitization,
-      });
+        : createOpenClawReadTool(
+            options.baseToolFactories?.createReadTool(options.codingRoot) ??
+              createReadTool(options.codingRoot),
+            {
+              modelContextWindowTokens: options.modelContextWindowTokens,
+              imageSanitization: options.imageSanitization,
+            },
+          );
       const guarded = options.workspaceOnly
-        ? wrapToolWorkspaceRootGuardWithOptions(wrapped, options.codingRoot, {
-            additionalRoots: skillReadRoots,
-          })
+        ? wrapToolWorkspaceRootGuardWithOptions(
+            wrapped,
+            sandboxRoot ?? options.codingRoot,
+            sandboxRoot
+              ? {
+                  additionalContainerMounts: readOnlySandboxReadMounts(
+                    sandbox,
+                    readOnlyWorkspaceSkillMounts,
+                  ),
+                  containerWorkdir: sandbox.containerWorkdir,
+                }
+              : { additionalRoots: skillReadRoots },
+          )
         : wrapped;
       base.push(
         wrapReadToolWithSkillContent(guarded, options.skillsSnapshot?.resolvedSkills, {
@@ -144,16 +156,24 @@ export function createCoreCodingTools(options: CoreCodingToolsOptions): AnyAgent
           imageSanitization: options.imageSanitization,
         }),
       );
+    }
+    if (!sandboxRoot && baseToolNames.has("edit")) {
       const edit = createHostWorkspaceEditTool(options.codingRoot, {
         workspaceOnly: options.workspaceOnly,
         memoryWriteProvenance: options.memoryWriteProvenance,
-      });
-      const write = createHostWorkspaceWriteTool(options.codingRoot, {
-        workspaceOnly: options.workspaceOnly,
-        memoryWriteProvenance: options.memoryWriteProvenance,
+        createTool: options.baseToolFactories?.createEditTool,
       });
       base.push(
         options.workspaceOnly ? wrapToolWorkspaceRootGuard(edit, options.codingRoot) : edit,
+      );
+    }
+    if (!sandboxRoot && baseToolNames.has("write")) {
+      const write = createHostWorkspaceWriteTool(options.codingRoot, {
+        workspaceOnly: options.workspaceOnly,
+        memoryWriteProvenance: options.memoryWriteProvenance,
+        createTool: options.baseToolFactories?.createWriteTool,
+      });
+      base.push(
         options.workspaceOnly ? wrapToolWorkspaceRootGuard(write, options.codingRoot) : write,
       );
     }
@@ -165,8 +185,14 @@ export function createCoreCodingTools(options: CoreCodingToolsOptions): AnyAgent
       bridge: sandboxFsBridge!,
       memoryWriteProvenance: options.memoryWriteProvenance,
     };
-    const edit = createSandboxedEditTool(toolOptions);
-    const write = createSandboxedWriteTool(toolOptions);
+    const edit = createSandboxedEditTool({
+      ...toolOptions,
+      createTool: options.baseToolFactories?.createEditTool,
+    });
+    const write = createSandboxedWriteTool({
+      ...toolOptions,
+      createTool: options.baseToolFactories?.createWriteTool,
+    });
     base.push(
       options.workspaceOnly
         ? wrapToolWorkspaceRootGuardWithOptions(edit, sandboxRoot, {

--- a/src/agents/core-coding-tools.ts
+++ b/src/agents/core-coding-tools.ts
@@ -1,0 +1,228 @@
+import path from "node:path";
+import type { SkillSnapshot } from "../skills/types.js";
+import {
+  createHostWorkspaceEditTool,
+  createHostWorkspaceWriteTool,
+  createOpenClawReadTool,
+  createSandboxedEditTool,
+  createSandboxedReadTool,
+  createSandboxedWriteTool,
+  wrapReadToolWithSkillContent,
+  wrapToolWorkspaceRootGuard,
+  wrapToolWorkspaceRootGuardWithOptions,
+} from "./agent-tools.read.js";
+import type { AnyAgentTool } from "./agent-tools.types.js";
+import { createApplyPatchTool } from "./apply-patch.js";
+import type { ExecToolDefaults } from "./bash-tools.exec-types.js";
+import type { ProcessToolDefaults } from "./bash-tools.process.js";
+import type { ImageSanitizationLimits } from "./image-sanitization.js";
+import { createLazyExecTool } from "./lazy-exec-tool.js";
+import { createLazyProcessTool } from "./lazy-process-tool.js";
+import type { MemoryWriteProvenanceObserver } from "./memory-write-provenance.js";
+import type { SandboxContext } from "./sandbox.js";
+import { SANDBOX_AGENT_WORKSPACE_MOUNT } from "./sandbox/constants.js";
+import {
+  resolveReadOnlyWorkspaceSkillMounts,
+  type ReadOnlyWorkspaceSkillMount,
+} from "./sandbox/workspace-mounts.js";
+import { createReadTool } from "./sessions/tools/read.js";
+
+function readOnlySandboxReadMounts(
+  sandbox: SandboxContext,
+  readOnlyWorkspaceSkillMounts: readonly ReadOnlyWorkspaceSkillMount[],
+): Array<{ containerRoot: string; hostRoot: string }> | undefined {
+  const mounts: Array<{ containerRoot: string; hostRoot: string }> = [];
+  if (sandbox.workspaceAccess === "ro" && sandbox.agentWorkspaceDir !== sandbox.workspaceDir) {
+    mounts.push({
+      containerRoot: SANDBOX_AGENT_WORKSPACE_MOUNT,
+      hostRoot: sandbox.agentWorkspaceDir,
+    });
+  }
+  if (sandbox.workspaceAccess === "rw") {
+    mounts.push(
+      ...readOnlyWorkspaceSkillMounts.map((mount) => ({
+        containerRoot: mount.containerPath,
+        hostRoot: mount.hostPath,
+      })),
+    );
+  }
+  return mounts.length > 0 ? mounts : undefined;
+}
+
+function resolveSkillReadRoots(skillsSnapshot?: SkillSnapshot): string[] | undefined {
+  const roots = new Set<string>();
+  for (const skill of skillsSnapshot?.resolvedSkills ?? []) {
+    const baseDir = typeof skill.baseDir === "string" ? skill.baseDir.trim() : "";
+    const filePath = typeof skill.filePath === "string" ? skill.filePath.trim() : "";
+    const root = baseDir || (filePath ? path.dirname(filePath) : "");
+    if (!root || !path.isAbsolute(root)) {
+      continue;
+    }
+    roots.add(path.resolve(root));
+  }
+  return roots.size > 0 ? Array.from(roots) : undefined;
+}
+
+export type CoreCodingToolsOptions = {
+  codingRoot: string;
+  includeBaseCodingTools: boolean;
+  includeShellTools: boolean;
+  workspaceOnly: boolean;
+  sandbox?: SandboxContext;
+  skillsSnapshot?: SkillSnapshot;
+  modelContextWindowTokens?: number;
+  imageSanitization?: ImageSanitizationLimits;
+  memoryWriteProvenance?: MemoryWriteProvenanceObserver;
+  applyPatchEnabled: boolean;
+  applyPatchWorkspaceOnly: boolean;
+  execDefaults: ExecToolDefaults;
+  processDefaults: ProcessToolDefaults;
+  recordToolPrepStage?: (name: string) => void;
+};
+
+/** Materialize only the core file and shell families selected by the runtime owner. */
+export function createCoreCodingTools(options: CoreCodingToolsOptions): AnyAgentTool[] {
+  const sandbox = options.sandbox;
+  const sandboxRoot = sandbox?.workspaceDir;
+  const sandboxFsBridge = sandbox?.fsBridge;
+  const allowWorkspaceWrites = sandbox?.workspaceAccess !== "ro";
+  if (sandboxRoot && !sandboxFsBridge) {
+    throw new Error("Sandbox filesystem bridge is unavailable.");
+  }
+
+  const skillReadRoots = sandboxRoot ? undefined : resolveSkillReadRoots(options.skillsSnapshot);
+  const needsReadOnlyWorkspaceSkillMounts =
+    options.includeShellTools || (options.includeBaseCodingTools && options.workspaceOnly);
+  const readOnlyWorkspaceSkillMounts =
+    sandbox && needsReadOnlyWorkspaceSkillMounts
+      ? resolveReadOnlyWorkspaceSkillMounts({
+          workspaceDir: sandbox.workspaceDir,
+          agentWorkspaceDir: sandbox.agentWorkspaceDir,
+          skillsWorkspaceDir: sandbox.skillsWorkspaceDir,
+          workdir: sandbox.containerWorkdir,
+          workspaceAccess: sandbox.workspaceAccess,
+        })
+      : [];
+
+  const base: AnyAgentTool[] = [];
+  if (options.includeBaseCodingTools) {
+    if (sandboxRoot) {
+      const sandboxed = createSandboxedReadTool({
+        root: sandboxRoot,
+        bridge: sandboxFsBridge!,
+        modelContextWindowTokens: options.modelContextWindowTokens,
+        imageSanitization: options.imageSanitization,
+      });
+      const guarded = options.workspaceOnly
+        ? wrapToolWorkspaceRootGuardWithOptions(sandboxed, sandboxRoot, {
+            additionalContainerMounts: readOnlySandboxReadMounts(
+              sandbox,
+              readOnlyWorkspaceSkillMounts,
+            ),
+            containerWorkdir: sandbox.containerWorkdir,
+          })
+        : sandboxed;
+      base.push(
+        wrapReadToolWithSkillContent(guarded, options.skillsSnapshot?.resolvedSkills, {
+          modelContextWindowTokens: options.modelContextWindowTokens,
+          imageSanitization: options.imageSanitization,
+        }),
+      );
+    } else {
+      const wrapped = createOpenClawReadTool(createReadTool(options.codingRoot), {
+        modelContextWindowTokens: options.modelContextWindowTokens,
+        imageSanitization: options.imageSanitization,
+      });
+      const guarded = options.workspaceOnly
+        ? wrapToolWorkspaceRootGuardWithOptions(wrapped, options.codingRoot, {
+            additionalRoots: skillReadRoots,
+          })
+        : wrapped;
+      base.push(
+        wrapReadToolWithSkillContent(guarded, options.skillsSnapshot?.resolvedSkills, {
+          modelContextWindowTokens: options.modelContextWindowTokens,
+          imageSanitization: options.imageSanitization,
+        }),
+      );
+      const edit = createHostWorkspaceEditTool(options.codingRoot, {
+        workspaceOnly: options.workspaceOnly,
+        memoryWriteProvenance: options.memoryWriteProvenance,
+      });
+      const write = createHostWorkspaceWriteTool(options.codingRoot, {
+        workspaceOnly: options.workspaceOnly,
+        memoryWriteProvenance: options.memoryWriteProvenance,
+      });
+      base.push(
+        options.workspaceOnly ? wrapToolWorkspaceRootGuard(edit, options.codingRoot) : edit,
+        options.workspaceOnly ? wrapToolWorkspaceRootGuard(write, options.codingRoot) : write,
+      );
+    }
+  }
+
+  if (options.includeBaseCodingTools && sandboxRoot && allowWorkspaceWrites) {
+    const toolOptions = {
+      root: sandboxRoot,
+      bridge: sandboxFsBridge!,
+      memoryWriteProvenance: options.memoryWriteProvenance,
+    };
+    const edit = createSandboxedEditTool(toolOptions);
+    const write = createSandboxedWriteTool(toolOptions);
+    base.push(
+      options.workspaceOnly
+        ? wrapToolWorkspaceRootGuardWithOptions(edit, sandboxRoot, {
+            containerWorkdir: sandbox.containerWorkdir,
+          })
+        : edit,
+      options.workspaceOnly
+        ? wrapToolWorkspaceRootGuardWithOptions(write, sandboxRoot, {
+            containerWorkdir: sandbox.containerWorkdir,
+          })
+        : write,
+    );
+  }
+  options.recordToolPrepStage?.("base-coding-tools");
+
+  const shell: AnyAgentTool[] = [];
+  if (options.includeShellTools) {
+    if (options.applyPatchEnabled && (!sandboxRoot || allowWorkspaceWrites)) {
+      shell.push(
+        createApplyPatchTool({
+          cwd: options.codingRoot,
+          sandbox:
+            sandboxRoot && allowWorkspaceWrites
+              ? { root: sandboxRoot, bridge: sandboxFsBridge! }
+              : undefined,
+          workspaceOnly: options.applyPatchWorkspaceOnly,
+          memoryWriteProvenance: options.memoryWriteProvenance,
+        }) as unknown as AnyAgentTool,
+      );
+    }
+    shell.push(
+      createLazyExecTool({
+        ...options.execDefaults,
+        cwd: options.codingRoot,
+        sandbox: sandbox
+          ? {
+              containerName: sandbox.containerName,
+              workspaceDir: sandbox.workspaceDir,
+              containerWorkdir: sandbox.containerWorkdir,
+              workdirValidation: sandbox.backend?.workdirValidation,
+              validateWorkdir: sandbox.backend?.validateWorkdir?.bind(sandbox.backend),
+              discardPreparedWorkdir: sandbox.backend?.discardPreparedWorkdir?.bind(
+                sandbox.backend,
+              ),
+              workdirRoots: sandbox.backend?.workdirRoots,
+              readOnlyWorkspaceSkillMounts,
+              env: sandbox.backend?.env ?? sandbox.docker.env,
+              buildExecSpec: sandbox.backend?.buildExecSpec.bind(sandbox.backend),
+              finalizeExec: sandbox.backend?.finalizeExec?.bind(sandbox.backend),
+            }
+          : undefined,
+      }) as unknown as AnyAgentTool,
+      createLazyProcessTool(options.processDefaults),
+    );
+  }
+  options.recordToolPrepStage?.("shell-tools");
+
+  return [...base, ...shell];
+}

--- a/src/agents/lazy-process-tool.ts
+++ b/src/agents/lazy-process-tool.ts
@@ -1,0 +1,34 @@
+import { createLazyImportLoader } from "../shared/lazy-promise.js";
+import type { AnyAgentTool } from "./agent-tools.types.js";
+import { describeProcessTool } from "./bash-tools.descriptions.js";
+import type { ProcessToolDefaults } from "./bash-tools.process.js";
+import { processSchema } from "./bash-tools.schemas.js";
+import { PROCESS_TOOL_DISPLAY_SUMMARY } from "./tool-description-presets.js";
+
+type BashToolsModule = typeof import("./bash-tools.js");
+
+const bashToolsModuleLoader = createLazyImportLoader<BashToolsModule>(
+  () => import("./bash-tools.js"),
+);
+
+/** Build process lazily so tool discovery does not load the shell runtime. */
+export function createLazyProcessTool(defaults?: ProcessToolDefaults): AnyAgentTool {
+  let loadedTool: AnyAgentTool | undefined;
+  const loadTool = async () => {
+    if (!loadedTool) {
+      const { createProcessTool } = await bashToolsModuleLoader.load();
+      loadedTool = createProcessTool(defaults) as unknown as AnyAgentTool;
+    }
+    return loadedTool;
+  };
+
+  return {
+    name: "process",
+    label: "process",
+    displaySummary: PROCESS_TOOL_DISPLAY_SUMMARY,
+    description: describeProcessTool({ hasCronTool: defaults?.hasCronTool === true }),
+    parameters: processSchema,
+    execute: async (...args: Parameters<AnyAgentTool["execute"]>) =>
+      (await loadTool()).execute(...args),
+  } as AnyAgentTool;
+}

--- a/src/worker/embedded-agent.runtime.ts
+++ b/src/worker/embedded-agent.runtime.ts
@@ -8,8 +8,10 @@ import type {
   WorkerInferenceOptions,
 } from "../../packages/gateway-protocol/src/schema/worker-inference.js";
 import { toToolDefinitions } from "../agents/agent-tool-definition-adapter.js";
-import { createOpenClawCodingTools } from "../agents/agent-tools.js";
+import { finalizeAgentTools } from "../agents/agent-tools.finalize.js";
+import { isApplyPatchAllowedForModel } from "../agents/apply-patch-model-policy.js";
 import { buildBootstrapContextForFiles } from "../agents/bootstrap-files.js";
+import { createCoreCodingTools } from "../agents/core-coding-tools.js";
 import { createNativeModelOwnedRuntimeModel } from "../agents/embedded-agent-runner/run/setup.js";
 import { guardSessionManager } from "../agents/session-tool-result-guard-wrapper.js";
 import { AuthStorage } from "../agents/sessions/auth-storage.js";
@@ -18,9 +20,12 @@ import { DefaultResourceLoader } from "../agents/sessions/resource-loader.js";
 import { createAgentSession } from "../agents/sessions/sdk.js";
 import { SessionManager } from "../agents/sessions/session-manager.js";
 import { SettingsManager } from "../agents/sessions/settings-manager.js";
+import { resolveToolLoopDetectionConfig } from "../agents/tool-loop-detection-config.js";
 import { DEFAULT_AGENTS_FILENAME, loadWorkspaceBootstrapFiles } from "../agents/workspace.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { AssistantMessage, AssistantMessageEventStreamLike } from "../llm/types.js";
 import { getProcessSupervisor } from "../process/supervisor/index.js";
+import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import { createWorkerLiveRuntime } from "./embedded-agent-live.runtime.js";
 import {
   createWorkerTranscriptRuntime,
@@ -78,6 +83,8 @@ type RunWorkerEmbeddedTurnResult = {
   messages: WorkerTranscriptMessage[];
 };
 
+const WORKER_TOOL_CONFIG = { plugins: { enabled: false } } satisfies OpenClawConfig;
+
 export async function runWorkerEmbeddedTurn(
   params: RunWorkerEmbeddedTurnParams,
 ): Promise<RunWorkerEmbeddedTurnResult> {
@@ -123,30 +130,54 @@ export async function runWorkerEmbeddedTurn(
   const allowedToolNameSet = new Set<string>(params.allowedToolNames);
   const activeToolNames = WORKER_LOCAL_TOOL_NAMES.filter((name) => allowedToolNameSet.has(name));
   const localToolNameSet = new Set<string>(WORKER_LOCAL_TOOL_NAMES);
-  const localTools = createOpenClawCodingTools({
-    cwd: params.cwd,
-    workspaceDir: params.cwd,
-    sessionId: params.sessionId,
-    sessionKey: params.sessionKey,
-    runSessionKey: params.sessionKey,
-    runId: params.runId,
-    oneShotCliRun: true,
-    senderIsOwner: true,
-    disableMessageTool: true,
-    runtimeToolAllowlist: [...WORKER_LOCAL_TOOL_NAMES],
+  const coreTools = createCoreCodingTools({
+    codingRoot: params.cwd,
+    includeBaseCodingTools: true,
+    includeShellTools: true,
+    workspaceOnly: false,
+    modelContextWindowTokens: model.contextWindow,
+    imageSanitization: {},
+    applyPatchEnabled: isApplyPatchAllowedForModel({
+      modelProvider: params.modelRef.provider,
+      modelId: params.modelRef.model,
+    }),
+    applyPatchWorkspaceOnly: true,
+    execDefaults: {
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      config: WORKER_TOOL_CONFIG,
+      commandHighlighting: false,
+      agentId: DEFAULT_AGENT_ID,
+      allowBackground: true,
+      scopeKey: params.sessionKey,
+      sessionKey: params.sessionKey,
+      runId: params.runId,
+      notifySessionKey: params.sessionKey,
+      sessionId: params.sessionId,
+      eventRouting: { preserveSessionKey: false },
+    },
+    processDefaults: { scopeKey: params.sessionKey },
+  });
+  const localTools = finalizeAgentTools({
+    tools: coreTools,
     modelProvider: params.modelRef.provider,
     modelId: params.modelRef.model,
-    modelApi: model.api,
-    modelContextWindowTokens: model.contextWindow,
-    config: { plugins: { enabled: false } },
-    exec: { host: "gateway", security: "full", ask: "off" },
-    toolConstructionPlan: {
-      includeBaseCodingTools: true,
-      includeShellTools: true,
-      includeChannelTools: false,
-      includeOpenClawTools: false,
-      includePluginTools: false,
+    hookContext: {
+      agentId: DEFAULT_AGENT_ID,
+      config: WORKER_TOOL_CONFIG,
+      cwd: params.cwd,
+      workspaceDir: params.cwd,
+      sessionKey: params.sessionKey,
+      sessionId: params.sessionId,
+      runId: params.runId,
+      requester: { senderIsOwner: true },
+      loopDetection: resolveToolLoopDetectionConfig({
+        cfg: WORKER_TOOL_CONFIG,
+        agentId: DEFAULT_AGENT_ID,
+      }),
     },
+    agentId: DEFAULT_AGENT_ID,
   }).filter((tool) => localToolNameSet.has(tool.name));
   const discoveredToolNames = new Set(localTools.map((tool) => tool.name));
   for (const toolName of WORKER_LOCAL_TOOL_NAMES) {


### PR DESCRIPTION
## What Problem This Solves

Restricted workers currently cold-load the generic agent tool assembly graph before their first inference even though the Gateway has already authorized a fixed six-tool surface: `read`, `write`, `edit`, `apply_patch`, `exec`, and `process`. That generic graph reaches channel, plugin, message, system-agent, TUI, and other runtime families the worker cannot expose, making the worker integration test and real worker startup unnecessarily import-bound.

## Why This Change Was Made

This extracts one canonical core coding/shell materializer and one canonical tool-finalization pipeline from the generic agent factory. Both normal agents and workers now use those same owners. The worker supplies its Gateway-authorized six-tool policy directly, while retaining OpenClaw read/write/edit behavior, workspace-contained apply-patch, lazy scoped exec/process tools, schema normalization, before-tool hooks, abort wrapping, and deferred follow-up descriptions.

No worker authority, tool names, test declarations, shard topology, worker counts, scheduling, concurrency, or timeout settings change.

## User Impact

Worker turns start with a substantially smaller eager module graph. Normal agent tool construction keeps the same policy and wrapper pipeline.

Production delta is +112 lines: the positive delta creates the shared owner boundary used by both generic agents and restricted workers, replacing a worker dependency on the much broader policy/materialization graph while preserving the generic factory's existing constructor seams.

## Evidence

- AWS Crabbox `cbx_abb114186b2c`, run `run_553b7ac6714b`: all 28 worker runtime integration tests and 118 representative generic tool-construction tests passed (146 total).
- Same-host exact before/after benchmark, AWS Crabbox run `run_81a913e2023c`: alternating baseline → candidate → candidate → baseline with separate cold compile/module caches. Worker-file duration averaged 18.415s → 15.295s (16.9% faster); the cold full embedded turn averaged 13.282s → 8.550s (35.6% faster); maximum RSS averaged 2,288,830 KiB → 2,176,298 KiB (4.9%, about 110 MiB lower).
- AWS Crabbox run `run_5d694621081d`: the corrected follow-up passed all 159 focused cases, including the two filesystem-constructor suites that CI had caught.
- AWS Crabbox run `run_592d9b6c8abb`: `pnpm tsgo:prod` passed after the follow-up.
- AWS Crabbox run `run_523a08a4b914`: full `pnpm build` passed in 4m36.951s, including CLI bootstrap import, plugin SDK export, runtime postbuild, and Control UI performance gates.
- Direct `oxlint`, `oxfmt --check`, and `git diff --check` passed for all eight changed files.
- Autoreview: clean, no accepted/actionable findings (`gpt-5.6-sol`, high reasoning).

This is an incremental step toward the frozen raw full-suite target; it does not claim normalized or final 30% success.
