### PR TITLE
fix(clickclack): preserve MIME extension for unnamed uploads

### DIFF
--- a/extensions/clickclack/src/outbound.test.ts
+++ b/extensions/clickclack/src/outbound.test.ts
@@ -221,6 +221,11 @@ describe("sendClickClackMedia", () => {
   });
 
   it("preserves filename and MIME while uploading before channel delivery", async () => {
+    loadOutboundMediaFromUrl.mockResolvedValueOnce({
+      buffer: Buffer.from("const proof = true;"),
+      contentType: "image/png",
+      fileName: "viewer-proof.ts",
+    });
     const order: string[] = [];
     createUpload.mockImplementationOnce(async () => {
       order.push("upload");
@@ -254,7 +259,7 @@ describe("sendClickClackMedia", () => {
       workspaceId: "wsp_1",
       buffer: Buffer.from("const proof = true;"),
       filename: "viewer-proof.ts",
-      contentType: "text/typescript",
+      contentType: "image/png",
     });
     expect(createChannelMessage).toHaveBeenCalledWith(
       "general",
@@ -264,6 +269,83 @@ describe("sendClickClackMedia", () => {
     expect(attachUpload).toHaveBeenCalledWith("msg_out", "upl_1");
     expect(order).toEqual(["upload", "message", "attach"]);
     expect(messageId).toBe("msg_out");
+  });
+
+  it("derives an extension from the MIME type when media has no filename", async () => {
+    loadOutboundMediaFromUrl.mockResolvedValueOnce({
+      buffer: Buffer.from("fake png bytes"),
+      contentType: "image/png",
+    });
+
+    await sendClickClackMedia({
+      cfg,
+      to: "channel:general",
+      text: "",
+      mediaUrl: "https://files.example/unnamed",
+    });
+
+    expect(createUpload).toHaveBeenCalledWith({
+      workspaceId: "wsp_1",
+      buffer: Buffer.from("fake png bytes"),
+      filename: "attachment.png",
+      contentType: "image/png",
+    });
+    expect(createChannelMessage).toHaveBeenCalledWith(
+      "general",
+      "attachment.png",
+      expect.objectContaining({ quotedMessageId: undefined }),
+    );
+  });
+
+  it("keeps the generic fallback when MIME type has no known extension", async () => {
+    loadOutboundMediaFromUrl.mockResolvedValueOnce({
+      buffer: Buffer.from("unknown bytes"),
+      contentType: "application/x-unknown",
+    });
+
+    await sendClickClackMedia({
+      cfg,
+      to: "channel:general",
+      text: "",
+      mediaUrl: "https://files.example/unknown",
+    });
+
+    expect(createUpload).toHaveBeenCalledWith({
+      workspaceId: "wsp_1",
+      buffer: Buffer.from("unknown bytes"),
+      filename: "attachment",
+      contentType: "application/x-unknown",
+    });
+    expect(createChannelMessage).toHaveBeenCalledWith(
+      "general",
+      "attachment",
+      expect.objectContaining({ quotedMessageId: undefined }),
+    );
+  });
+
+  it("keeps the generic fallback when MIME type is missing", async () => {
+    loadOutboundMediaFromUrl.mockResolvedValueOnce({
+      buffer: Buffer.from("opaque bytes"),
+    });
+
+    await sendClickClackMedia({
+      cfg,
+      to: "channel:general",
+      text: "",
+      mediaUrl: "https://files.example/missing-type",
+    });
+
+    expect(createUpload).toHaveBeenCalledWith({
+      workspaceId: "wsp_1",
+      buffer: Buffer.from("opaque bytes"),
+      filename: "attachment",
+      contentType: "application/octet-stream",
+    });
+    expect(createChannelMessage).toHaveBeenCalledWith(
+      "general",
+      "attachment",
+      expect.objectContaining({ quotedMessageId: undefined }),
+    );
   });
 
   it("uses the filename as the minimal media-only body and routes DMs", async () => {

--- a/extensions/clickclack/src/outbound.ts
+++ b/extensions/clickclack/src/outbound.ts
@@ -8,6 +8,7 @@ import {
   type ChannelMessageUnknownSendContext,
   type ChannelMessageUnknownSendReconciliationResult,
 } from "openclaw/plugin-sdk/channel-outbound";
+import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
 import {
   loadOutboundMediaFromUrl,
   type OutboundMediaLoadOptions,
@@ -263,9 +264,9 @@ export async function sendClickClackMedia(params: {
         mediaLocalRoots: params.mediaLocalRoots,
         mediaReadFile: params.mediaReadFile,
       }));
-    const filename = media.fileName?.trim() || "attachment";
-    mediaFilename = filename;
     const contentType = media.contentType?.trim() || "application/octet-stream";
+    const filename = media.fileName?.trim() || `attachment${extensionForMime(contentType) ?? ""}`;
+    mediaFilename = filename;
     await dispatch();
     upload = await client.createUpload({
       workspaceId,


### PR DESCRIPTION
## What Problem This Solves

Unnamed ClickClack media uploads currently use the generic filename `attachment` even when the media loader provides a useful MIME type such as `image/png`. That loses the file extension in the upload and in the media-only message body, making downloaded attachments and previews less consistent.

## Why This Change Was Made

When no explicit or loader-provided filename exists, derive the filename as `attachment${extensionForMime(contentType) ?? ""}` through the public `openclaw/plugin-sdk/media-mime` helper. Existing filenames still win, known MIME types gain their extension, unknown MIME types stay on the generic `attachment` fallback, and missing MIME metadata still defaults to `application/octet-stream`.

This follows the recent MIME-derived filename precedent in Alix-007's merged [Slack upload change](https://github.com/openclaw/openclaw/pull/119399) and [Mattermost upload change](https://github.com/openclaw/openclaw/pull/119535), adapted to ClickClack's upload-first delivery path.

## User Impact

ClickClack users receive unnamed image uploads as `attachment.png` instead of `attachment`, while named files, unknown MIME types, durable retries, upload ordering, and attachment association remain unchanged.

## Evidence

- Focused validation: `node scripts/run-vitest.mjs extensions/clickclack/src/outbound.test.ts --reporter=verbose` — 28 tests passed.
- Static validation: `node scripts/run-oxlint.mjs extensions/clickclack/src/outbound.ts extensions/clickclack/src/outbound.test.ts` and `git diff --check` passed.
- Same temporary proof script, production `sendClickClackMedia`, real loopback ClickClack HTTP API, synthetic image bytes with no filename, empty media text, and upload/message/attachment requests:
  - Base `36ee98d815dbffdb233205278e91e2db86cebb88`: upload filename remained generic and media-only body was not `attachment.png`.
  - Candidate `981da82a77708e877364592a89ed7ed842387cf9`: multipart filename was `attachment.png` and media-only body was `attachment.png`.
- Negative controls: explicit `viewer-proof.ts` remains unchanged; unknown and missing MIME types retain `attachment`; durable upload/message retry cases pass.

```text
$ node_modules/.bin/tsx proof-live.ts
base 36ee98d815dbffdb233205278e91e2db86cebb88: {"uploadStatus":200,"uploadFilenameIsPng":false,"uploadFilenameIsGeneric":true,"messageStatus":200,"mediaOnlyBodyIsPng":false,"attachmentStatus":200}
head 981da82a77708e877364592a89ed7ed842387cf9: {"uploadStatus":200,"uploadFilenameIsPng":true,"uploadFilenameIsGeneric":false,"messageStatus":200,"mediaOnlyBodyIsPng":true,"attachmentStatus":200}
negative-control: 28 tests passed; explicit viewer-proof.ts retained; unknown and missing MIME retained generic attachment; durable retry coverage passed
```

<details>
<summary>proof-live.ts</summary>

```ts
import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
import { sendClickClackMedia } from "./extensions/clickclack/src/outbound.ts";
import type { CoreConfig } from "./extensions/clickclack/src/types.ts";

const PNG_BYTES = Buffer.from(
  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7Z0nQAAAAASUVORK5CYII=",
  "base64",
);

async function readBody(request: IncomingMessage): Promise<Buffer> {
  const chunks: Buffer[] = [];
  for await (const chunk of request) {
    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
  }
  return Buffer.concat(chunks);
}

function respond(response: ServerResponse, status: number, payload: unknown): void {
  const body = JSON.stringify(payload);
  response.writeHead(status, {
    "content-type": "application/json",
    "content-length": Buffer.byteLength(body),
  });
  response.end(body);
}

let uploadBody = Buffer.alloc(0);
let messageBody: string | undefined;
let uploadStatus = 0;
let messageStatus = 0;
let attachmentStatus = 0;

const server = createServer(async (request, response) => {
  if (request.method === "GET" && request.url === "/media/") {
    response.writeHead(200, {
      "content-type": "image/png",
      "content-length": PNG_BYTES.length,
    });
    response.end(PNG_BYTES);
    return;
  }

  const body = await readBody(request);
  if (request.method === "POST" && request.url?.startsWith("/api/uploads?")) {
    uploadBody = body;
    uploadStatus = 200;
    const multipart = body.toString("latin1");
    const filename = /filename="attachment\.png"/u.test(multipart)
      ? "attachment.png"
      : "attachment";
    respond(response, uploadStatus, {
      upload: {
        id: "upl_proof",
        workspace_id: "wsp_1",
        owner_id: "bot_proof",
        filename,
        content_type: "image/png",
        byte_size: PNG_BYTES.length,
        width: 1,
        height: 1,
        duration_ms: 0,
        created_at: "2026-08-05T00:00:00Z",
      },
    });
    return;
  }

  if (request.method === "POST" && request.url === "/api/channels/chn_general/messages") {
    messageBody = JSON.parse(body.toString("utf8")).body;
    messageStatus = 200;
    respond(response, messageStatus, { message: { id: "msg_proof" } });
    return;
  }

  if (request.method === "POST" && request.url === "/api/messages/msg_proof/attachments") {
    attachmentStatus = 200;
    respond(response, attachmentStatus, { ok: true });
    return;
  }

  respond(response, 404, { error: "not found" });
});

await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
const address = server.address();
if (!address || typeof address === "string") {
  throw new Error("loopback server did not expose a port");
}

try {
  const baseUrl = `http://127.0.0.1:${address.port}`;
  const cfg = {
    channels: {
      clickclack: {
        enabled: true,
        baseUrl,
        apiBaseUrl: baseUrl,
        token: "synthetic-clickclack-token",
        workspace: "wsp_1",
      },
    },
  } as CoreConfig;

  await sendClickClackMedia({
    cfg,
    to: "channel:chn_general",
    text: "",
    mediaUrl: "",
    mediaLocalRoots: "any",
    mediaReadFile: async () => PNG_BYTES,
  });

  const multipart = uploadBody.toString("latin1");
  const uploadFilenameIsPng = /filename="attachment\.png"/u.test(multipart);
  const uploadFilenameIsGeneric = /filename="attachment"/u.test(multipart);
  console.log(
    JSON.stringify({
      uploadStatus,
      uploadFilenameIsPng,
      uploadFilenameIsGeneric,
      messageStatus,
      mediaOnlyBodyIsPng: messageBody === "attachment.png",
      attachmentStatus,
    }),
  );
} finally {
  await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
}
```

</details>

Tested head SHA: 981da82a77708e877364592a89ed7ed842387cf9.
Canonical precedent: recent Alix-007 MIME-derived upload filename PRs [#119399](https://github.com/openclaw/openclaw/pull/119399) and [#119535](https://github.com/openclaw/openclaw/pull/119535) use the same narrow filename-fallback treatment; this candidate applies it to ClickClack's upload and media-only message path.

AI-assisted: built with Codex
