### PR TITLE
refactor(daemon): centralize managed service lifecycle ownership

### DIFF
--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -11,9 +11,9 @@ export const GATEWAY_SERVICE_RUNTIME_PID_ENV = "OPENCLAW_GATEWAY_SERVICE_PID";
 const NODE_LAUNCH_AGENT_LABEL = "ai.openclaw.node";
 const NODE_SYSTEMD_SERVICE_NAME = "openclaw-node";
 const NODE_WINDOWS_TASK_NAME = "OpenClaw Node";
-export const NODE_SERVICE_MARKER = "openclaw";
+const NODE_SERVICE_MARKER = "openclaw";
 export const NODE_SERVICE_KIND = "node";
-export const NODE_WINDOWS_TASK_SCRIPT_NAME = "node.cmd";
+const NODE_WINDOWS_TASK_SCRIPT_NAME = "node.cmd";
 export const LEGACY_GATEWAY_SYSTEMD_SERVICE_NAMES: string[] = ["clawdbot-gateway"];
 
 function normalizeGatewayProfile(profile?: string): string | null {
@@ -135,6 +135,19 @@ export function resolveNodeSystemdServiceName(): string {
 
 export function resolveNodeWindowsTaskName(): string {
   return NODE_WINDOWS_TASK_NAME;
+}
+
+export function resolveNodeServiceIdentityEnvironment(): Record<string, string> {
+  return {
+    OPENCLAW_LAUNCHD_LABEL: resolveNodeLaunchAgentLabel(),
+    OPENCLAW_SYSTEMD_UNIT: resolveNodeSystemdServiceName(),
+    OPENCLAW_WINDOWS_TASK_NAME: resolveNodeWindowsTaskName(),
+    OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER: "1",
+    OPENCLAW_TASK_SCRIPT_NAME: NODE_WINDOWS_TASK_SCRIPT_NAME,
+    OPENCLAW_LOG_PREFIX: "node",
+    OPENCLAW_SERVICE_MARKER: NODE_SERVICE_MARKER,
+    OPENCLAW_SERVICE_KIND: NODE_SERVICE_KIND,
+  };
 }
 
 export function formatNodeServiceDescription(params?: { version?: string }): string {

--- a/src/daemon/node-service.ts
+++ b/src/daemon/node-service.ts
@@ -1,12 +1,5 @@
 /** Adapts the generic gateway service manager for OpenClaw node-host services. */
-import {
-  NODE_SERVICE_KIND,
-  NODE_SERVICE_MARKER,
-  NODE_WINDOWS_TASK_SCRIPT_NAME,
-  resolveNodeLaunchAgentLabel,
-  resolveNodeSystemdServiceName,
-  resolveNodeWindowsTaskName,
-} from "./constants.js";
+import { resolveNodeServiceIdentityEnvironment } from "./constants.js";
 import type { GatewayService, GatewayServiceInstallArgs } from "./service.js";
 import { resolveGatewayService } from "./service.js";
 
@@ -18,14 +11,7 @@ function withNodeServiceEnv(
   // node-specific labels, logs, task script, and service marker.
   return {
     ...env,
-    OPENCLAW_LAUNCHD_LABEL: resolveNodeLaunchAgentLabel(),
-    OPENCLAW_SYSTEMD_UNIT: resolveNodeSystemdServiceName(),
-    OPENCLAW_WINDOWS_TASK_NAME: resolveNodeWindowsTaskName(),
-    OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER: "1",
-    OPENCLAW_TASK_SCRIPT_NAME: NODE_WINDOWS_TASK_SCRIPT_NAME,
-    OPENCLAW_LOG_PREFIX: "node",
-    OPENCLAW_SERVICE_MARKER: NODE_SERVICE_MARKER,
-    OPENCLAW_SERVICE_KIND: NODE_SERVICE_KIND,
+    ...resolveNodeServiceIdentityEnvironment(),
   };
 }
 

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -5,11 +5,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-import {
-  normalizeStringEntries,
-  sortUniqueStrings,
-} from "@openclaw/normalization-core/string-normalization";
-import { normalizeEnvVarKey } from "../infra/host-env-security.js";
+import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { resolveInlineCommandMatch } from "../infra/shell-inline-command.js";
 import { POSIX_SHELL_WRAPPERS } from "../infra/shell-wrapper-resolution.js";
 import { parseTcpPort } from "../infra/tcp-port.js";
@@ -25,9 +21,8 @@ import { getMinimalServicePathPartsFromEnv } from "./service-env.js";
 import { SERVICE_PROXY_ENV_KEYS } from "./service-env.js";
 import {
   collectInlineManagedServiceEnvKeys,
-  hasInlineEnvironmentSource,
+  collectInlineServiceEnvKeys,
   isEnvironmentFileOnlySource,
-  readEnvironmentValueSource,
 } from "./service-managed-env.js";
 import { isNonMinimalServicePathEntry, normalizeServicePathEntry } from "./service-path-policy.js";
 import type { GatewayServiceEnvironmentValueSource } from "./service-types.js";
@@ -390,47 +385,11 @@ function auditManagedServiceEnvironment(
   });
 }
 
-function normalizeServiceEnvKey(key: string): string | null {
-  return normalizeEnvVarKey(key, { portable: true })?.toUpperCase() ?? null;
-}
-
-const SERVICE_PROXY_ENV_KEY_SET = new Set(
-  SERVICE_PROXY_ENV_KEYS.flatMap((key) => {
-    const normalized = normalizeServiceEnvKey(key);
-    return normalized ? [normalized] : [];
-  }),
-);
-
-function collectInlineProxyEnvKeys(command: GatewayServiceCommand): string[] {
-  if (!command?.environment) {
-    return [];
-  }
-  const inlineKeys: string[] = [];
-  for (const [rawKey, value] of Object.entries(command.environment)) {
-    if (typeof value !== "string" || !value.trim()) {
-      continue;
-    }
-    const normalized = normalizeServiceEnvKey(rawKey);
-    if (!normalized || !SERVICE_PROXY_ENV_KEY_SET.has(normalized)) {
-      continue;
-    }
-    if (
-      !hasInlineEnvironmentSource(
-        readEnvironmentValueSource(command.environmentValueSources, normalized),
-      )
-    ) {
-      continue;
-    }
-    inlineKeys.push(normalized);
-  }
-  return sortUniqueStrings(inlineKeys);
-}
-
 function auditProxyServiceEnvironment(
   command: GatewayServiceCommand,
   issues: ServiceConfigIssue[],
 ) {
-  const inlineKeys = collectInlineProxyEnvKeys(command);
+  const inlineKeys = collectInlineServiceEnvKeys(command, SERVICE_PROXY_ENV_KEYS);
   if (inlineKeys.length === 0) {
     return;
   }

--- a/src/daemon/service-env-plan.ts
+++ b/src/daemon/service-env-plan.ts
@@ -1,5 +1,5 @@
 /** Builds normalized environment plans for managed daemon service rendering. */
-import { normalizeEnvVarKey } from "../infra/host-env-security.js";
+import { normalizeServiceEnvKey } from "./service-managed-env.js";
 import type { GatewayServiceEnvironmentValueSource } from "./service-types.js";
 
 export type MutableServiceEnvPlan = {
@@ -12,10 +12,6 @@ export function createMutableServiceEnvPlan(): MutableServiceEnvPlan {
     environment: {},
     environmentValueSources: {},
   };
-}
-
-export function normalizeServiceEnvPlanKey(rawKey: string): string | undefined {
-  return normalizeEnvVarKey(rawKey, { portable: true })?.toUpperCase();
 }
 
 export function addServiceEnvPlanEntries(
@@ -42,7 +38,7 @@ export function addServiceEnvPlanEntries(
       continue;
     }
     const value = rawValue;
-    const normalizedKey = normalizeServiceEnvPlanKey(rawKey);
+    const normalizedKey = normalizeServiceEnvKey(rawKey);
     if (!normalizedKey) {
       continue;
     }

--- a/src/daemon/service-env-render-policy.ts
+++ b/src/daemon/service-env-render-policy.ts
@@ -1,6 +1,7 @@
 /** Applies platform render policy for managed daemon service environment values. */
-import { normalizeServiceEnvPlanKey, type MutableServiceEnvPlan } from "./service-env-plan.js";
+import type { MutableServiceEnvPlan } from "./service-env-plan.js";
 import {
+  normalizeServiceEnvKey,
   readManagedServiceEnvKeysFromEnvironment,
   writeManagedServiceEnvKeysToEnvironment,
 } from "./service-managed-env.js";
@@ -26,7 +27,7 @@ function addManagedServiceEnvEntries(params: {
     if (typeof value !== "string" || !value.trim()) {
       continue;
     }
-    const key = normalizeServiceEnvPlanKey(rawKey);
+    const key = normalizeServiceEnvKey(rawKey);
     if (!key || !params.managedKeys.has(key)) {
       continue;
     }

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -11,12 +11,7 @@ import {
   resolveGatewayLaunchAgentLabel,
   resolveGatewaySystemdServiceName,
   resolveGatewayWindowsTaskName,
-  NODE_SERVICE_KIND,
-  NODE_SERVICE_MARKER,
-  NODE_WINDOWS_TASK_SCRIPT_NAME,
-  resolveNodeLaunchAgentLabel,
-  resolveNodeSystemdServiceName,
-  resolveNodeWindowsTaskName,
+  resolveNodeServiceIdentityEnvironment,
 } from "./constants.js";
 import { resolveGatewayHeapNodeOptions } from "./gateway-heap.js";
 import { resolveGatewayStateDir } from "./paths.js";
@@ -395,14 +390,7 @@ export function buildNodeServiceEnvironment(params: {
     OPENCLAW_GATEWAY_TOKEN: gatewayToken,
     OPENCLAW_GATEWAY_PASSWORD: gatewayPassword,
     OPENCLAW_ALLOW_INSECURE_PRIVATE_WS: allowInsecurePrivateWs,
-    OPENCLAW_LAUNCHD_LABEL: resolveNodeLaunchAgentLabel(),
-    OPENCLAW_SYSTEMD_UNIT: resolveNodeSystemdServiceName(),
-    OPENCLAW_WINDOWS_TASK_NAME: resolveNodeWindowsTaskName(),
-    OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER: "1",
-    OPENCLAW_TASK_SCRIPT_NAME: NODE_WINDOWS_TASK_SCRIPT_NAME,
-    OPENCLAW_LOG_PREFIX: "node",
-    OPENCLAW_SERVICE_MARKER: NODE_SERVICE_MARKER,
-    OPENCLAW_SERVICE_KIND: NODE_SERVICE_KIND,
+    ...resolveNodeServiceIdentityEnvironment(),
     OPENCLAW_SERVICE_VERSION: VERSION,
   };
 }

--- a/src/daemon/service-managed-env.ts
+++ b/src/daemon/service-managed-env.ts
@@ -11,8 +11,17 @@ type ServiceEnvCommand = {
   environmentValueSources?: Record<string, GatewayServiceEnvironmentValueSource | undefined>;
 } | null;
 
-function normalizeServiceEnvKey(key: string): string | null {
+export function normalizeServiceEnvKey(key: string): string | null {
   return normalizeEnvVarKey(key, { portable: true })?.toUpperCase() ?? null;
+}
+
+export function normalizeServiceEnvKeys(keys: Iterable<string>): Set<string> {
+  return new Set(
+    [...keys].flatMap((key) => {
+      const normalized = normalizeServiceEnvKey(key);
+      return normalized ? [normalized] : [];
+    }),
+  );
 }
 
 export function hasInlineEnvironmentSource(
@@ -34,34 +43,17 @@ export function hasEnvironmentFileSource(
 }
 
 function parseManagedServiceEnvKeys(value: string | undefined): Set<string> {
-  const keys = new Set<string>();
-  for (const entry of value?.split(",") ?? []) {
-    const key = normalizeServiceEnvKey(entry.trim());
-    if (key) {
-      keys.add(key);
-    }
-  }
-  return keys;
+  return normalizeServiceEnvKeys(value?.split(",") ?? []);
 }
 
 export function formatManagedServiceEnvKeys(
   managedEnvironment: Record<string, string | undefined>,
   options?: { omitKeys?: Iterable<string> },
 ): string | undefined {
-  const omitKeys = new Set(
-    [...(options?.omitKeys ?? [])].flatMap((key) => {
-      const normalized = normalizeServiceEnvKey(key);
-      return normalized ? [normalized] : [];
-    }),
-  );
+  const omitKeys = normalizeServiceEnvKeys(options?.omitKeys ?? []);
   const keys = Object.keys(managedEnvironment)
-    .flatMap((key) => {
-      const normalized = normalizeServiceEnvKey(key);
-      if (!normalized || omitKeys.has(normalized)) {
-        return [];
-      }
-      return [normalized];
-    })
+    .map(normalizeServiceEnvKey)
+    .filter((key): key is string => Boolean(key && !omitKeys.has(key)))
     .toSorted();
   return keys.length > 0 ? keys.join(",") : undefined;
 }
@@ -84,12 +76,7 @@ function deleteManagedServiceEnvKeys(
   environment: Record<string, string | undefined>,
   keys: Iterable<string>,
 ): void {
-  const normalizedKeys = new Set(
-    [...keys].flatMap((key) => {
-      const normalized = normalizeServiceEnvKey(key);
-      return normalized ? [normalized] : [];
-    }),
-  );
+  const normalizedKeys = normalizeServiceEnvKeys(keys);
   if (normalizedKeys.size === 0) {
     return;
   }
@@ -140,13 +127,21 @@ export function collectInlineManagedServiceEnvKeys(
     return [];
   }
   const managedKeys = parseManagedServiceEnvKeys(command.environment[MANAGED_SERVICE_ENV_KEYS_VAR]);
-  for (const key of expectedManagedKeys ?? []) {
-    const normalized = normalizeServiceEnvKey(key);
-    if (normalized) {
-      managedKeys.add(normalized);
-    }
+  for (const key of normalizeServiceEnvKeys(expectedManagedKeys ?? [])) {
+    managedKeys.add(key);
   }
-  if (managedKeys.size === 0) {
+  return collectInlineServiceEnvKeys(command, managedKeys);
+}
+
+export function collectInlineServiceEnvKeys(
+  command: ServiceEnvCommand,
+  expectedKeys: Iterable<string>,
+): string[] {
+  if (!command?.environment) {
+    return [];
+  }
+  const normalizedKeys = normalizeServiceEnvKeys(expectedKeys);
+  if (normalizedKeys.size === 0) {
     return [];
   }
   const inlineKeys: string[] = [];
@@ -155,7 +150,7 @@ export function collectInlineManagedServiceEnvKeys(
       continue;
     }
     const normalized = normalizeServiceEnvKey(rawKey);
-    if (!normalized || !managedKeys.has(normalized)) {
+    if (!normalized || !normalizedKeys.has(normalized)) {
       continue;
     }
     if (normalized === MANAGED_SERVICE_ENV_KEYS_VAR) {

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -380,54 +380,31 @@ const GATEWAY_SERVICE_REGISTRY: Record<SupportedGatewayServicePlatform, GatewayS
   },
 };
 
-function assertGatewayServiceMutationOwnedByOpenClaw(
+function guardGatewayServiceMutation<TArgs extends { env?: GatewayServiceEnv }, TResult>(
   action: string,
-  env?: GatewayServiceEnv,
-): void {
-  assertGatewayServiceMutationAllowed(action, process.env);
-  if (env && env !== process.env) {
-    assertGatewayServiceMutationAllowed(action, env);
-  }
+  mutate: (args: TArgs) => Promise<TResult>,
+): (args: TArgs) => Promise<TResult> {
+  return async (args) => {
+    // Mutations must satisfy both lifecycle ownership and durable-config
+    // version guards before invoking any platform service manager.
+    assertGatewayServiceMutationAllowed(action, process.env);
+    if (args.env && args.env !== process.env) {
+      assertGatewayServiceMutationAllowed(action, args.env);
+    }
+    await assertFutureConfigActionAllowed(action);
+    return await mutate(args);
+  };
 }
 
 function withGatewayServiceMutationGuards(service: GatewayService): GatewayService {
   return {
     ...service,
-    stage: async (args) => {
-      // Service mutations rewrite durable launchd/systemd/schtasks files, so
-      // block them when config was produced by a newer OpenClaw.
-      assertGatewayServiceMutationOwnedByOpenClaw("rewrite the gateway service", args.env);
-      await assertFutureConfigActionAllowed("rewrite the gateway service");
-      return await service.stage(args);
-    },
-    install: async (args) => {
-      assertGatewayServiceMutationOwnedByOpenClaw(
-        "install or rewrite the gateway service",
-        args.env,
-      );
-      await assertFutureConfigActionAllowed("install or rewrite the gateway service");
-      return await service.install(args);
-    },
-    uninstall: async (args) => {
-      assertGatewayServiceMutationOwnedByOpenClaw("uninstall the gateway service", args.env);
-      await assertFutureConfigActionAllowed("uninstall the gateway service");
-      return await service.uninstall(args);
-    },
-    start: async (args) => {
-      assertGatewayServiceMutationOwnedByOpenClaw("start the gateway service", args.env);
-      await assertFutureConfigActionAllowed("start the gateway service");
-      return await service.start(args);
-    },
-    stop: async (args) => {
-      assertGatewayServiceMutationOwnedByOpenClaw("stop the gateway service", args.env);
-      await assertFutureConfigActionAllowed("stop the gateway service");
-      return await service.stop(args);
-    },
-    restart: async (args) => {
-      assertGatewayServiceMutationOwnedByOpenClaw("restart the gateway service", args.env);
-      await assertFutureConfigActionAllowed("restart the gateway service");
-      return await service.restart(args);
-    },
+    stage: guardGatewayServiceMutation("rewrite the gateway service", service.stage),
+    install: guardGatewayServiceMutation("install or rewrite the gateway service", service.install),
+    uninstall: guardGatewayServiceMutation("uninstall the gateway service", service.uninstall),
+    start: guardGatewayServiceMutation("start the gateway service", service.start),
+    stop: guardGatewayServiceMutation("stop the gateway service", service.stop),
+    restart: guardGatewayServiceMutation("restart the gateway service", service.restart),
   };
 }
 

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -12,7 +12,6 @@ import {
   readStateDirDotEnvFromStateDir,
 } from "../config/state-dir-dotenv.js";
 import { formatErrorMessage } from "../infra/errors.js";
-import { normalizeEnvVarKey } from "../infra/host-env-security.js";
 import {
   parseStrictInteger,
   parseStrictNonNegativeInteger,
@@ -33,6 +32,8 @@ import {
   hasEnvironmentFileSource,
   hasInlineEnvironmentSource,
   isEnvironmentFileOnlySource,
+  normalizeServiceEnvKey,
+  normalizeServiceEnvKeys,
   readEnvironmentValueSource,
   readManagedServiceEnvKeysFromEnvironment,
 } from "./service-managed-env.js";
@@ -386,10 +387,6 @@ function mergeEnvironmentValueSources(
   return sources;
 }
 
-function normalizeSystemdEnvironmentKey(key: string): string | null {
-  return normalizeEnvVarKey(key, { portable: true })?.toUpperCase() ?? null;
-}
-
 function collectSystemdInlineManagedKeys(params: {
   environment?: GatewayServiceEnv;
   environmentValueSources?: Record<string, GatewayServiceEnvironmentValueSource | undefined>;
@@ -404,7 +401,7 @@ function collectSystemdInlineManagedKeys(params: {
     if (typeof value !== "string" || !value.trim()) {
       continue;
     }
-    const key = normalizeSystemdEnvironmentKey(rawKey);
+    const key = normalizeServiceEnvKey(rawKey);
     if (!key) {
       continue;
     }
@@ -421,7 +418,7 @@ function collectSystemdFileManagedKeys(params: {
 }): Set<string> {
   const keys = new Set<string>();
   for (const [rawKey, source] of Object.entries(params.environmentValueSources ?? {})) {
-    const key = normalizeSystemdEnvironmentKey(rawKey);
+    const key = normalizeServiceEnvKey(rawKey);
     if (key && isEnvironmentFileOnlySource(source)) {
       keys.add(key);
     }
@@ -441,7 +438,7 @@ function collectSystemdFileBackedEnvironment(params: {
     if (typeof rawValue !== "string" || !rawValue.trim()) {
       continue;
     }
-    const key = normalizeSystemdEnvironmentKey(rawKey);
+    const key = normalizeServiceEnvKey(rawKey);
     if (key && params.fileManagedKeys.has(key) && !isUnresolvedShellReference(rawValue)) {
       environment[rawKey] = rawValue;
     }
@@ -471,7 +468,7 @@ function sanitizeSystemdUnitBackupContent(params: {
       continue;
     }
     const keptAssignments = assignments.filter(({ key }) => {
-      const normalizedKey = normalizeSystemdEnvironmentKey(key);
+      const normalizedKey = normalizeServiceEnvKey(key);
       return !normalizedKey || !params.fileManagedKeys.has(normalizedKey);
     });
     if (keptAssignments.length === assignments.length) {
@@ -1178,7 +1175,7 @@ async function writeSystemdUnit({
         if (hasEnvironmentFileSource(source) && isUnresolvedShellReference(value)) {
           return false;
         }
-        const normalizedKey = normalizeSystemdEnvironmentKey(key);
+        const normalizedKey = normalizeServiceEnvKey(key);
         if (
           normalizedKey &&
           environmentFileResult.environmentKeys.has(normalizedKey) &&
@@ -1366,17 +1363,14 @@ async function writeSystemdGatewayEnvironmentFile(params: {
       // File does not exist yet — nothing to preserve.
     }
   }
-  const managedKeysToDrop = new Set([
+  const managedKeysToDrop = normalizeServiceEnvKeys([
     ...(params.inlineManagedKeys ?? []),
     ...(params.fileManagedKeys ?? []),
-    ...[...(params.skippedManagedKeys ?? [])].flatMap((key) => {
-      const normalized = normalizeSystemdEnvironmentKey(key);
-      return normalized ? [normalized] : [];
-    }),
+    ...(params.skippedManagedKeys ?? []),
   ]);
   const operatorOnly = Object.fromEntries(
     Object.entries(existing).filter(([key, value]) => {
-      const normalized = normalizeSystemdEnvironmentKey(key);
+      const normalized = normalizeServiceEnvKey(key);
       if (normalized && managedKeysToDrop.has(normalized)) {
         return false;
       }
@@ -1386,12 +1380,7 @@ async function writeSystemdGatewayEnvironmentFile(params: {
     }),
   );
   const merged = { ...operatorOnly, ...incoming };
-  const environmentKeys = new Set(
-    Object.keys(merged).flatMap((key) => {
-      const normalized = normalizeSystemdEnvironmentKey(key);
-      return normalized ? [normalized] : [];
-    }),
-  );
+  const environmentKeys = normalizeServiceEnvKeys(Object.keys(merged));
 
   // If the merged result is empty there is nothing to write and no file needed.
   if (Object.keys(merged).length === 0) {
@@ -1424,7 +1413,7 @@ async function removeNodeSystemdManagedEnvironmentKeys(env: GatewayServiceEnv): 
   const managedKeys = new Set(["OPENCLAW_GATEWAY_TOKEN", "OPENCLAW_GATEWAY_PASSWORD"]);
   const remaining = Object.fromEntries(
     Object.entries(existingFile.environment).filter(([key, value]) => {
-      const normalized = normalizeSystemdEnvironmentKey(key);
+      const normalized = normalizeServiceEnvKey(key);
       if (normalized && managedKeys.has(normalized)) {
         return false;
       }
@@ -1600,35 +1589,27 @@ async function runSystemdServiceAction(params: {
   const env = params.env ?? process.env;
   const installed = await findInstalledSystemdGatewayScope(env);
   const unitName = installed?.unitName ?? `${resolveSystemdServiceName(env)}.service`;
+  let runSystemctl: (args: string[]) => ReturnType<typeof execSystemctl>;
   if (installed?.scope === "system") {
     if (!isRunningAsRoot()) {
       throw new Error(
         `${unitName} is a system-scope unit (${installed.unitPath}); run \`sudo systemctl ${params.action} ${unitName}\` to ${params.action} it`,
       );
     }
+    runSystemctl = (args) => execSystemctl(args, env);
+  } else {
+    await assertSystemdAvailable(env);
     if (params.action !== "stop") {
-      // systemd latches a unit into failed/start-limit-hit after it crashes faster
-      // than StartLimitBurst allows and then stops auto-restarting it. Clear the
-      // latch before start/restart so an operator can recover a crash-looped
-      // gateway with the natural start command. Idempotent on healthy units.
-      await execSystemctl(["reset-failed", unitName], env);
+      await assertNoSystemGatewayOwnership(env);
     }
-    const res = await execSystemctl([params.action, unitName], env);
-    if (res.code !== 0) {
-      throw new Error(`systemctl ${params.action} failed: ${res.stderr || res.stdout}`.trim());
-    }
-    params.onMutation?.();
-    params.stdout.write(`${formatLine(params.label, unitName)}\n`);
-    return;
+    runSystemctl = (args) => execSystemctlUser(env, args);
   }
-  await assertSystemdAvailable(env);
   if (params.action !== "stop") {
-    await assertNoSystemGatewayOwnership(env);
-    // Clear the same latch for user-scope start/restart after the ownership
-    // guard, so a conflicting system unit is never mutated.
-    await execSystemctlUser(env, ["reset-failed", unitName]);
+    // Clear crash-loop start-limit latches only after scope ownership is proven;
+    // otherwise resetting a conflicting manager could mutate the wrong service.
+    await runSystemctl(["reset-failed", unitName]);
   }
-  const res = await execSystemctlUser(env, [params.action, unitName]);
+  const res = await runSystemctl([params.action, unitName]);
   if (res.code !== 0) {
     throw new Error(`systemctl ${params.action} failed: ${res.stderr || res.stdout}`.trim());
   }


### PR DESCRIPTION
## What Problem This Solves

Managed gateway and node services repeated lifecycle-ownership checks, portable environment-key normalization, inline secret/proxy auditing, and native service identity in separate implementation paths. That duplication made launchd, systemd, and Windows Scheduled Task behavior harder to keep aligned while maintaining service-account, secret, and mutation safety.

## Why This Change Was Made

This maintainer-requested refactor establishes one canonical node-service identity, managed service environment-key/source policy, guarded gateway mutation flow, and scope-aware systemd action dispatcher. It removes 104 production lines (98 additions and 202 deletions across nine daemon files) while preserving ambient and explicit supervision checks, future-config guards, portable case-insensitive key validation, exact platform identities, system/root ownership authorization, reset-failed ordering, mutation notifications, operator output, rollback behavior, PATH sanitization, symlink safety, and 0600 secret-file permissions.

## User Impact

No intended user-visible, configuration, default, public API, or service-management behavior changes. Gateway and node install, repair, start, stop, restart, status, and environment auditing retain their existing behavior on macOS launchd, Linux user/system systemd scopes, and Windows Scheduled Tasks.

## Evidence

- Trusted Blacksmith Testbox `tbx_01kz93h6y9kazx4ycmy32f8c1h`: https://github.com/openclaw/openclaw/actions/runs/31012882109. The single owned lease was stopped and verified `completed`.
- Focused existing coverage: **574 tests passed across 13 files**, with **24 existing platform-specific skips**. Command: `pnpm test src/daemon/constants.test.ts src/daemon/service.test.ts src/daemon/service-env.test.ts src/daemon/service-audit.test.ts src/daemon/systemd.test.ts src/daemon/systemd-system.test.ts src/daemon/launchd-system.test.ts src/daemon/launchd.test.ts src/daemon/schtasks.install.test.ts src/infra/host-env-security.test.ts src/infra/gateway-supervision.test.ts src/commands/daemon-install-helpers.test.ts src/commands/node-daemon-install-helpers.test.ts`.
- Unmodified full `pnpm check:changed` passed, including production/full-tree/script dead-export scans, core and core-test `tsgo`, changed-file lint, formatting, plugin boundaries, import cycles, dependency/security guards, and native schema safeguards.
- **207 baseline-versus-refactor source differential comparisons** covered invalid/mixed-case keys, managed secrets, inline/file proxy sources, exact node identities on all three platforms, all six mutation guards and their failures, and system/user systemd ownership, reset, action, callback, output, and failure ordering.
- Fresh independent `.agents/skills/autoreview/scripts/autoreview --mode local --engine codex --model gpt-5.6-sol --thinking xhigh`: **clean; zero actionable findings; confidence 0.97**.
- Production LOC: **-104**; test LOC: **0**. AI-assisted, maintainer-requested owner-boundary cleanup; no operator gateway or service action was executed.

- **Controlled committed-production Linux service lifecycle:** Executed the actual `stageSystemdService`, `readSystemdServiceExecStart`, `startSystemdService`, `stopSystemdService`, and `restartSystemdService` production owners against real isolated temporary service/config artifacts and a real spawned, fail-closed synthetic `systemctl` executable. The production system-scope ownership guard also executed against that synthetic manager. No native operator service manager, gateway, real credentials, tracked source, or PR head was touched; temporary artifacts were removed afterward.

```text
head=5cf860d274bd2dd0afe0c6e737b319bd4944cd86
entrypoints=stageSystemdService,startSystemdService,stopSystemdService,restartSystemdService,readSystemdServiceExecStart
isolation=real temporary HOME/state/unit/env files; real child-process synthetic systemctl; no native manager/operator credentials
gateway.unit=openclaw-gateway-proof.service
gateway.marker=openclaw/gateway
gateway.environmentFile.mode=600
gateway.environmentFile.token=[redacted]; source=file; inlineUnitLeak=false
node.identity=ai.openclaw.node | openclaw-node | OpenClaw Node
systemOwnership.probes=10
start: inactive -> active
stop: active -> inactive
restart: inactive -> active (completed)
commands=--user reset-failed openclaw-gateway-proof.service ; --user start openclaw-gateway-proof.service ; --user stop openclaw-gateway-proof.service ; --user reset-failed openclaw-gateway-proof.service ; --user restart openclaw-gateway-proof.service
mutationCallbacks=systemctl-start,systemctl-stop,systemctl-restart
operatorOutput=Staged systemd service: <isolated>/home/.config/systemd/user/openclaw-gateway-proof.service
operatorOutput=Started systemd service: openclaw-gateway-proof.service
operatorOutput=Stopped systemd service: openclaw-gateway-proof.service
operatorOutput=Restarted systemd service: openclaw-gateway-proof.service
result=PASS
```


