### PR TITLE
refactor(media): unify provider discovery across media capabilities

### DIFF
--- a/src/image-generation/model-ref.ts
+++ b/src/image-generation/model-ref.ts
@@ -1,10 +1,1 @@
-/** Parses image-generation model references into provider/model components. */
-import { parseGenerationModelRef } from "../../packages/media-generation-core/src/model-ref.js";
-
-// Image model refs share the generic media-generation provider/model grammar:
-// "provider/model" when explicit, otherwise null for default resolution.
-export function parseImageGenerationModelRef(
-  raw: string | undefined,
-): { provider: string; model: string } | null {
-  return parseGenerationModelRef(raw);
-}
+export { parseGenerationModelRef as parseImageGenerationModelRef } from "../../packages/media-generation-core/src/model-ref.js";

--- a/src/image-generation/provider-registry.ts
+++ b/src/image-generation/provider-registry.ts
@@ -1,40 +1,7 @@
+import { createMediaProviderRegistry } from "../media-generation/provider-registry.js";
+
 /** Registry for image-generation providers contributed by plugin capabilities. */
-import type { OpenClawConfig } from "../config/types.openclaw.js";
-import * as capabilityProviderRuntime from "../plugins/capability-provider-runtime.js";
-import {
-  buildCapabilityProviderMaps,
-  normalizeCapabilityProviderId,
-} from "../plugins/provider-registry-shared.js";
-import type { ImageGenerationProviderPlugin } from "../plugins/types.js";
-
-function buildProviderMaps(cfg?: OpenClawConfig): {
-  canonical: Map<string, ImageGenerationProviderPlugin>;
-  aliases: Map<string, ImageGenerationProviderPlugin>;
-} {
-  return buildCapabilityProviderMaps(
-    capabilityProviderRuntime.resolvePluginCapabilityProviders({
-      key: "imageGenerationProviders",
-      cfg,
-    }),
-    normalizeCapabilityProviderId,
-  );
-}
-
-/** Lists canonical image-generation providers visible for config. */
-export function listImageGenerationProviders(
-  cfg?: OpenClawConfig,
-): ImageGenerationProviderPlugin[] {
-  return [...buildProviderMaps(cfg).canonical.values()];
-}
-
-/** Resolves an image-generation provider by canonical id or alias. */
-export function getImageGenerationProvider(
-  providerId: string | undefined,
-  cfg?: OpenClawConfig,
-): ImageGenerationProviderPlugin | undefined {
-  const normalized = normalizeCapabilityProviderId(providerId);
-  if (!normalized) {
-    return undefined;
-  }
-  return buildProviderMaps(cfg).aliases.get(normalized);
-}
+export const {
+  listProviders: listImageGenerationProviders,
+  getProvider: getImageGenerationProvider,
+} = createMediaProviderRegistry("imageGenerationProviders");

--- a/src/media-generation/provider-registry.ts
+++ b/src/media-generation/provider-registry.ts
@@ -1,0 +1,49 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import * as capabilityProviderRuntime from "../plugins/capability-provider-runtime.js";
+import {
+  buildCapabilityProviderMaps,
+  normalizeCapabilityProviderId,
+} from "../plugins/provider-registry-shared.js";
+import type { PluginRegistry } from "../plugins/registry-types.js";
+
+type MediaProviderRegistryKey =
+  | "imageGenerationProviders"
+  | "videoGenerationProviders"
+  | "musicGenerationProviders"
+  | "realtimeTranscriptionProviders"
+  | "transcriptSourceProviders";
+
+type MediaProvider<TKey extends MediaProviderRegistryKey> =
+  PluginRegistry[TKey][number]["provider"];
+
+/** Shares normalized provider listing while preserving targeted transcription lookup. */
+export function createMediaProviderRegistry<TKey extends MediaProviderRegistryKey>(
+  key: TKey,
+  options: { directLookup?: boolean } = {},
+) {
+  const buildProviderMaps = (cfg?: OpenClawConfig) =>
+    buildCapabilityProviderMaps(
+      // The capability runtime's private provider type uses this same registry mapping.
+      capabilityProviderRuntime.resolvePluginCapabilityProviders({
+        key,
+        cfg,
+      }) as MediaProvider<TKey>[],
+    );
+
+  return {
+    listProviders: (cfg?: OpenClawConfig) => [...buildProviderMaps(cfg).canonical.values()],
+    getProvider: (providerId: string | undefined, cfg?: OpenClawConfig) => {
+      const normalized = normalizeCapabilityProviderId(providerId);
+      if (!normalized) {
+        return undefined;
+      }
+      return options.directLookup
+        ? capabilityProviderRuntime.resolvePluginCapabilityProvider({
+            key,
+            providerId: normalized,
+            cfg,
+          })
+        : buildProviderMaps(cfg).aliases.get(normalized);
+    },
+  };
+}

--- a/src/music-generation/model-ref.ts
+++ b/src/music-generation/model-ref.ts
@@ -1,15 +1,1 @@
-// Parses model references for music generation requests.
-import { parseGenerationModelRef } from "../../packages/media-generation-core/src/model-ref.js";
-
-/**
- * Model reference parsing for music generation.
- *
- * Music generation uses the same provider/model ref grammar as other media
- * capabilities, but keeps this wrapper for a dedicated capability boundary.
- */
-/** Parse a music generation model ref into provider and model ids. */
-export function parseMusicGenerationModelRef(
-  raw: string | undefined,
-): { provider: string; model: string } | null {
-  return parseGenerationModelRef(raw);
-}
+export { parseGenerationModelRef as parseMusicGenerationModelRef } from "../../packages/media-generation-core/src/model-ref.js";

--- a/src/music-generation/provider-registry.ts
+++ b/src/music-generation/provider-registry.ts
@@ -1,54 +1,7 @@
-// Registers music generation provider runtimes by normalized provider id.
-import type { OpenClawConfig } from "../config/types.js";
-import { resolvePluginCapabilityProviders } from "../plugins/capability-provider-runtime.js";
-import {
-  buildCapabilityProviderMaps,
-  normalizeCapabilityProviderId,
-} from "../plugins/provider-registry-shared.js";
-import type { MusicGenerationProviderPlugin } from "../plugins/types.js";
+import { createMediaProviderRegistry } from "../media-generation/provider-registry.js";
 
-/**
- * Registry for music generation providers.
- *
- * Built-ins and plugin-provided capability providers share one alias map while
- * rejecting unsafe object keys before they reach Maps or config-derived lookups.
- */
-const BUILTIN_MUSIC_GENERATION_PROVIDERS: readonly MusicGenerationProviderPlugin[] = [];
-
-function resolvePluginMusicGenerationProviders(
-  cfg?: OpenClawConfig,
-): MusicGenerationProviderPlugin[] {
-  return resolvePluginCapabilityProviders({
-    key: "musicGenerationProviders",
-    cfg,
-  });
-}
-
-function buildProviderMaps(cfg?: OpenClawConfig): {
-  canonical: Map<string, MusicGenerationProviderPlugin>;
-  aliases: Map<string, MusicGenerationProviderPlugin>;
-} {
-  return buildCapabilityProviderMaps(
-    [...BUILTIN_MUSIC_GENERATION_PROVIDERS, ...resolvePluginMusicGenerationProviders(cfg)],
-    normalizeCapabilityProviderId,
-  );
-}
-
-/** List canonical music generation providers available for the current config. */
-export function listMusicGenerationProviders(
-  cfg?: OpenClawConfig,
-): MusicGenerationProviderPlugin[] {
-  return [...buildProviderMaps(cfg).canonical.values()];
-}
-
-/** Resolve a music generation provider by canonical id or alias. */
-export function getMusicGenerationProvider(
-  providerId: string | undefined,
-  cfg?: OpenClawConfig,
-): MusicGenerationProviderPlugin | undefined {
-  const normalized = normalizeCapabilityProviderId(providerId);
-  if (!normalized) {
-    return undefined;
-  }
-  return buildProviderMaps(cfg).aliases.get(normalized);
-}
+/** Registry for music-generation providers contributed by plugin capabilities. */
+export const {
+  listProviders: listMusicGenerationProviders,
+  getProvider: getMusicGenerationProvider,
+} = createMediaProviderRegistry("musicGenerationProviders");

--- a/src/realtime-transcription/provider-registry.ts
+++ b/src/realtime-transcription/provider-registry.ts
@@ -1,71 +1,23 @@
-// Realtime transcription provider registry stores transcription provider factories.
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import {
-  resolvePluginCapabilityProvider,
-  resolvePluginCapabilityProviders,
-} from "../plugins/capability-provider-runtime.js";
-import {
-  buildCapabilityProviderMaps,
-  normalizeCapabilityProviderId,
-} from "../plugins/provider-registry-shared.js";
-import type { RealtimeTranscriptionProviderPlugin } from "../plugins/types.js";
+import { createMediaProviderRegistry } from "../media-generation/provider-registry.js";
+import { normalizeCapabilityProviderId } from "../plugins/provider-registry-shared.js";
 import type { RealtimeTranscriptionProviderId } from "./provider-types.js";
 
-// Provider registry helpers for realtime transcription. Plugin ids and aliases
-// share the generic capability-provider registry machinery.
-export function normalizeRealtimeTranscriptionProviderId(
-  providerId: string | undefined,
-): RealtimeTranscriptionProviderId | undefined {
-  return normalizeCapabilityProviderId(providerId);
-}
+export { normalizeCapabilityProviderId as normalizeRealtimeTranscriptionProviderId };
 
-function resolveRealtimeTranscriptionProviderEntries(
-  cfg?: OpenClawConfig,
-): RealtimeTranscriptionProviderPlugin[] {
-  return resolvePluginCapabilityProviders({
-    key: "realtimeTranscriptionProviders",
-    cfg,
-  });
-}
-
-function buildProviderMaps(cfg?: OpenClawConfig): {
-  canonical: Map<string, RealtimeTranscriptionProviderPlugin>;
-  aliases: Map<string, RealtimeTranscriptionProviderPlugin>;
-} {
-  return buildCapabilityProviderMaps(resolveRealtimeTranscriptionProviderEntries(cfg));
-}
-
-/** Lists canonical realtime transcription providers for the active config. */
-export function listRealtimeTranscriptionProviders(
-  cfg?: OpenClawConfig,
-): RealtimeTranscriptionProviderPlugin[] {
-  return [...buildProviderMaps(cfg).canonical.values()];
-}
-
-/** Resolves a realtime transcription provider by id or alias. */
-export function getRealtimeTranscriptionProvider(
-  providerId: string | undefined,
-  cfg?: OpenClawConfig,
-): RealtimeTranscriptionProviderPlugin | undefined {
-  const normalized = normalizeRealtimeTranscriptionProviderId(providerId);
-  if (!normalized) {
-    return undefined;
-  }
-  return resolvePluginCapabilityProvider({
-    key: "realtimeTranscriptionProviders",
-    providerId: normalized,
-    cfg,
-  });
-}
+/** Realtime transcription uses targeted lookup to avoid broad capability discovery. */
+export const {
+  listProviders: listRealtimeTranscriptionProviders,
+  getProvider: getRealtimeTranscriptionProvider,
+} = createMediaProviderRegistry("realtimeTranscriptionProviders", { directLookup: true });
 
 /** Canonicalizes a configured provider id while preserving unknown ids. */
 export function canonicalizeRealtimeTranscriptionProviderId(
   providerId: string | undefined,
   cfg?: OpenClawConfig,
 ): RealtimeTranscriptionProviderId | undefined {
-  const normalized = normalizeRealtimeTranscriptionProviderId(providerId);
-  if (!normalized) {
-    return undefined;
-  }
-  return getRealtimeTranscriptionProvider(normalized, cfg)?.id ?? normalized;
+  const normalized = normalizeCapabilityProviderId(providerId);
+  return normalized
+    ? (getRealtimeTranscriptionProvider(normalized, cfg)?.id ?? normalized)
+    : undefined;
 }

--- a/src/transcripts/provider-registry.ts
+++ b/src/transcripts/provider-registry.ts
@@ -1,46 +1,8 @@
-// Registers transcript providers and resolves enabled source runtimes.
-import type { OpenClawConfig } from "../config/types.openclaw.js";
-import {
-  resolvePluginCapabilityProvider,
-  resolvePluginCapabilityProviders,
-} from "../plugins/capability-provider-runtime.js";
-import {
-  buildCapabilityProviderMaps,
-  normalizeCapabilityProviderId,
-} from "../plugins/provider-registry-shared.js";
-import type { TranscriptSourceProvider } from "./provider-types.js";
+import { createMediaProviderRegistry } from "../media-generation/provider-registry.js";
+export { normalizeCapabilityProviderId as normalizeTranscriptSourceProviderId } from "../plugins/provider-registry-shared.js";
 
-/**
- * Transcript source provider registry.
- *
- * Transcript providers are plugin capability providers; this module exposes
- * canonical/alias lookup through the shared capability runtime.
- */
-/** Normalize transcript source provider ids for registry lookup. */
-export function normalizeTranscriptSourceProviderId(
-  providerId: string | undefined,
-): string | undefined {
-  return normalizeCapabilityProviderId(providerId);
-}
-
-/** List canonical transcript source providers for a config snapshot. */
-export function listTranscriptSourceProviders(cfg?: OpenClawConfig): TranscriptSourceProvider[] {
-  const providers = resolvePluginCapabilityProviders({ key: "transcriptSourceProviders", cfg });
-  return [...buildCapabilityProviderMaps(providers).canonical.values()];
-}
-
-/** Resolve a transcript provider by canonical id or alias. */
-export function getTranscriptSourceProvider(
-  providerId: string | undefined,
-  cfg?: OpenClawConfig,
-): TranscriptSourceProvider | undefined {
-  const normalized = normalizeTranscriptSourceProviderId(providerId);
-  if (!normalized) {
-    return undefined;
-  }
-  return resolvePluginCapabilityProvider({
-    key: "transcriptSourceProviders",
-    providerId: normalized,
-    cfg,
-  });
-}
+/** Transcript providers use targeted lookup to avoid broad capability discovery. */
+export const {
+  listProviders: listTranscriptSourceProviders,
+  getProvider: getTranscriptSourceProvider,
+} = createMediaProviderRegistry("transcriptSourceProviders", { directLookup: true });

--- a/src/video-generation/model-ref.ts
+++ b/src/video-generation/model-ref.ts
@@ -1,10 +1,1 @@
-// Video model ref helpers parse provider-qualified video generation model ids.
-import { parseGenerationModelRef } from "../../packages/media-generation-core/src/model-ref.js";
-
-// Video model refs share the generic media-generation provider/model grammar:
-// "provider/model" when explicit, otherwise null for default resolution.
-export function parseVideoGenerationModelRef(
-  raw: string | undefined,
-): { provider: string; model: string } | null {
-  return parseGenerationModelRef(raw);
-}
+export { parseGenerationModelRef as parseVideoGenerationModelRef } from "../../packages/media-generation-core/src/model-ref.js";

--- a/src/video-generation/provider-registry.ts
+++ b/src/video-generation/provider-registry.ts
@@ -1,38 +1,7 @@
-// Video provider registry stores video generation provider factories by id.
-import type { OpenClawConfig } from "../config/types.js";
-import * as capabilityProviderRuntime from "../plugins/capability-provider-runtime.js";
-import {
-  buildCapabilityProviderMaps,
-  normalizeCapabilityProviderId,
-} from "../plugins/provider-registry-shared.js";
-import type { VideoGenerationProviderPlugin } from "../plugins/types.js";
+import { createMediaProviderRegistry } from "../media-generation/provider-registry.js";
 
-function buildProviderMaps(cfg?: OpenClawConfig): {
-  canonical: Map<string, VideoGenerationProviderPlugin>;
-  aliases: Map<string, VideoGenerationProviderPlugin>;
-} {
-  return buildCapabilityProviderMaps(
-    capabilityProviderRuntime.resolvePluginCapabilityProviders({
-      key: "videoGenerationProviders",
-      cfg,
-    }),
-    normalizeCapabilityProviderId,
-  );
-}
-
-export function listVideoGenerationProviders(
-  cfg?: OpenClawConfig,
-): VideoGenerationProviderPlugin[] {
-  return [...buildProviderMaps(cfg).canonical.values()];
-}
-
-export function getVideoGenerationProvider(
-  providerId: string | undefined,
-  cfg?: OpenClawConfig,
-): VideoGenerationProviderPlugin | undefined {
-  const normalized = normalizeCapabilityProviderId(providerId);
-  if (!normalized) {
-    return undefined;
-  }
-  return buildProviderMaps(cfg).aliases.get(normalized);
-}
+/** Registry for video-generation providers contributed by plugin capabilities. */
+export const {
+  listProviders: listVideoGenerationProviders,
+  getProvider: getVideoGenerationProvider,
+} = createMediaProviderRegistry("videoGenerationProviders");


### PR DESCRIPTION
## What Problem This Solves

Image, video, music, realtime-transcription, and transcript-source capabilities maintained separate copies of provider lookup and listing policy. Their duplicated model-reference parsers and registry rules made provider aliases, targeted discovery, ordering, and model selection easier to accidentally diverge.

## Why This Change Was Made

Introduce one internal media-provider registry owner for all five capability families. Image, video, and music retain normalized canonical/alias maps and existing loaded/configured-provider behavior; realtime transcription and transcript sources retain targeted direct lookup instead of triggering broad provider discovery. The registry derives each exact provider type from `PluginRegistry[TKey][number]["provider"]`, preserving existing consumer and SDK contracts. Re-export the canonical generation model parser under the existing image/video/music public names and remove the empty obsolete music built-in registry.

The change removes **180 production lines** (**+89/-269**) across nine production files; it changes no tests, config, schema, defaults, public SDK exports, account selection, or path-access boundaries.

## User Impact

No intended user-visible behavior change. Existing provider IDs, aliases, model references, alias precedence, deterministic ordering, configured-versus-loaded distinctions, targeted transcription discovery, hostile/prototype-key handling, partial capability-runtime mocks, and image/video/music/transcript provider results remain unchanged.

## Evidence

- **205 source-executed before/after comparisons** covered all five provider families, aliases, canonical precedence, ordering, blocked/prototype keys, absent IDs, configured/loaded and targeted discovery, and existing partial runtime mocks.
- **209 existing focused tests passed across 13 files and six Vitest shards** on the final frozen patch, including 62 capability-provider runtime cases, 31 video-generation runtime cases, 26 realtime-transcription cases, 21 image-generation runtime cases, 20 transcript-store cases, 18 transcript-tool cases, 11 music-generation runtime cases, both generation registry suites, canonical model parsing, provider capability contracts, shared alias-map security, and existing TTS registry coverage.
- Remote `pnpm tsgo:core` passed with the precise provider-family return types preserved.
- The complete remote `pnpm check:changed` passed: core and core-test typechecks; type-aware lint on all nine files with **0 warnings and 0 errors**; unchanged public plugin SDK API manifest; plugin boundaries; production/full-tree/script dead-export scans with **0 entries**; formatting; database/security guards; and **0 runtime import cycles**.
- Mandatory independent `.agents/skills/autoreview/scripts/autoreview --mode local --engine codex --model gpt-5.6-sol --thinking xhigh` was clean with no accepted/actionable findings (**0.98** confidence).
- Trusted Blacksmith Testbox evidence: https://github.com/openclaw/openclaw/actions/runs/31013072522 (the delegated wrapper reported `exitCode: 0` and `runStatus: succeeded`; the lease was stopped and independently verified absent afterward).

Observed final production-path proof:

```text
src/plugins/capability-provider-runtime.test.ts      62 passed
src/video-generation/runtime.test.ts                31 passed
src/realtime-transcription/websocket-session.test.ts 26 passed
src/image-generation/runtime.test.ts                21 passed
src/transcripts/store.test.ts                       20 passed
src/agents/tools/transcripts-tool.test.ts           18 passed
src/music-generation/runtime.test.ts                11 passed
[deadcode] production/full-tree/script unused exports: 0
Found 0 warnings and 0 errors. (all 9 changed files)
Import cycle check: 0 runtime value cycle(s).
blacksmith run summary ... exit=0
```

