### PR TITLE
fix(browser): honor explicit navigation timeouts across browser drivers

### DIFF
--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -2467,6 +2467,67 @@ describe("browser tool url alias support", () => {
     expect(request.profile).toBeUndefined();
   });
 
+  it("forwards an explicit navigation timeout to the host browser client", async () => {
+    const tool = createBrowserTool();
+
+    await tool.execute?.("call-1", {
+      action: "navigate",
+      target: "host",
+      url: "https://example.com/slow",
+      targetId: "tab-1",
+      timeoutMs: 45_000,
+    });
+
+    expect(browserActionsMocks.browserNavigate).toHaveBeenCalledWith(undefined, {
+      url: "https://example.com/slow",
+      targetId: "tab-1",
+      timeoutMs: 45_000,
+      profile: undefined,
+    });
+  });
+
+  it("preserves an explicit navigation timeout across node and Gateway watchdogs", async () => {
+    mockSingleBrowserProxyNode();
+    gatewayMocks.callGatewayTool
+      .mockResolvedValueOnce({
+        ok: true,
+        payload: {
+          result: { ok: true, targetId: "tab-1", url: "https://example.com/slow" },
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        payload: {
+          result: {
+            ok: true,
+            format: "ai",
+            targetId: "tab-1",
+            url: "https://example.com/slow",
+            snapshot: "slow page",
+          },
+        },
+      });
+    const tool = createBrowserTool();
+
+    await tool.execute?.("call-1", {
+      action: "navigate",
+      target: "node",
+      url: "https://example.com/slow",
+      targetId: "tab-1",
+      timeoutMs: 45_000,
+    });
+
+    const { options, request } = nodeInvokeCall(0);
+    expect(options.timeoutMs).toBe(55_000);
+    expect(request.timeoutMs).toBe(50_000);
+    expect(request.params?.timeoutMs).toBe(45_000);
+    expect(request.params?.body).toEqual({
+      url: "https://example.com/slow",
+      targetId: "tab-1",
+      timeoutMs: 45_000,
+    });
+  });
+
   it("returns inline page state after navigate", async () => {
     browserActionsMocks.browserNavigate.mockResolvedValueOnce({
       ok: true,

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -2486,6 +2486,28 @@ describe("browser tool url alias support", () => {
     });
   });
 
+  it.each([
+    { requestedTimeoutMs: 10, expectedTimeoutMs: 1_000 },
+    { requestedTimeoutMs: 180_000, expectedTimeoutMs: 120_000 },
+    { requestedTimeoutMs: Number.MAX_SAFE_INTEGER, expectedTimeoutMs: 120_000 },
+  ])(
+    "normalizes host navigation timeout $requestedTimeoutMs before browser dispatch",
+    async ({ requestedTimeoutMs, expectedTimeoutMs }) => {
+      await createBrowserTool().execute?.("call-1", {
+        action: "navigate",
+        target: "host",
+        url: "https://example.com/slow",
+        targetId: "tab-1",
+        timeoutMs: requestedTimeoutMs,
+      });
+
+      expect(browserActionsMocks.browserNavigate).toHaveBeenCalledWith(
+        undefined,
+        expect.objectContaining({ timeoutMs: expectedTimeoutMs }),
+      );
+    },
+  );
+
   it("preserves an explicit navigation timeout across node and Gateway watchdogs", async () => {
     mockSingleBrowserProxyNode();
     gatewayMocks.callGatewayTool
@@ -2527,6 +2549,54 @@ describe("browser tool url alias support", () => {
       timeoutMs: 45_000,
     });
   });
+
+  it.each([
+    { requestedTimeoutMs: 10, expectedTimeoutMs: 1_000 },
+    { requestedTimeoutMs: 180_000, expectedTimeoutMs: 120_000 },
+    { requestedTimeoutMs: Number.MAX_SAFE_INTEGER, expectedTimeoutMs: 120_000 },
+  ])(
+    "keeps normalized node navigation timeout $requestedTimeoutMs inside nested watchdogs",
+    async ({ requestedTimeoutMs, expectedTimeoutMs }) => {
+      mockSingleBrowserProxyNode();
+      gatewayMocks.callGatewayTool
+        .mockResolvedValueOnce({
+          ok: true,
+          payload: {
+            result: { ok: true, targetId: "tab-1", url: "https://example.com/slow" },
+          },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          payload: {
+            result: {
+              ok: true,
+              format: "ai",
+              targetId: "tab-1",
+              url: "https://example.com/slow",
+              snapshot: "slow page",
+            },
+          },
+        });
+
+      await createBrowserTool().execute?.("call-1", {
+        action: "navigate",
+        target: "node",
+        url: "https://example.com/slow",
+        targetId: "tab-1",
+        timeoutMs: requestedTimeoutMs,
+      });
+
+      const { options, request } = nodeInvokeCall(0);
+      expect(options.timeoutMs).toBe(expectedTimeoutMs + 10_000);
+      expect(request.timeoutMs).toBe(expectedTimeoutMs + 5_000);
+      expect(request.params?.timeoutMs).toBe(expectedTimeoutMs);
+      expect(request.params?.body).toEqual({
+        url: "https://example.com/slow",
+        targetId: "tab-1",
+        timeoutMs: expectedTimeoutMs,
+      });
+    },
+  );
 
   it("returns inline page state after navigate", async () => {
     browserActionsMocks.browserNavigate.mockResolvedValueOnce({

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -854,11 +854,14 @@ export function createBrowserTool(opts?: {
                 body: {
                   url: targetUrl,
                   targetId,
+                  timeoutMs: requestedTimeoutMs,
                 },
+                timeoutMs: requestedTimeoutMs,
               })
             : await browserToolDeps.browserNavigate(baseUrl, {
                 url: targetUrl,
                 targetId,
+                timeoutMs: requestedTimeoutMs,
                 profile,
               });
           const navigatedTargetId =

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -69,6 +69,7 @@ import {
   validateJsonSchemaValue,
 } from "./browser-tool.runtime.js";
 import { appendNavigatedPageState, executeSnapshotAction } from "./browser-tool.snapshot.js";
+import { resolveBrowserNavigationTimeoutMs } from "./browser/act-policy.js";
 import { DEFAULT_BROWSER_SCREENSHOT_TIMEOUT_MS } from "./browser/constants.js";
 import { parseBrowserNavigationUrl } from "./browser/navigation-guard.js";
 import { normalizeBrowserScreenshot } from "./browser/screenshot.js";
@@ -846,6 +847,10 @@ export function createBrowserTool(opts?: {
         case "navigate": {
           const targetUrl = readTargetUrlParam(params);
           const targetId = readStringParam(params, "targetId");
+          const timeoutMs =
+            requestedTimeoutMs === undefined
+              ? undefined
+              : resolveBrowserNavigationTimeoutMs(requestedTimeoutMs);
           const result = proxyRequest
             ? await proxyRequest({
                 method: "POST",
@@ -854,14 +859,14 @@ export function createBrowserTool(opts?: {
                 body: {
                   url: targetUrl,
                   targetId,
-                  timeoutMs: requestedTimeoutMs,
+                  timeoutMs,
                 },
-                timeoutMs: requestedTimeoutMs,
+                timeoutMs,
               })
             : await browserToolDeps.browserNavigate(baseUrl, {
                 url: targetUrl,
                 targetId,
-                timeoutMs: requestedTimeoutMs,
+                timeoutMs,
                 profile,
               });
           const navigatedTargetId =

--- a/extensions/browser/src/browser/act-policy.ts
+++ b/extensions/browser/src/browser/act-policy.ts
@@ -36,6 +36,11 @@ export const BROWSER_ACTION_TRANSPORT_SLACK_MS = 5_000;
 /** Post-action window that keeps navigation policy interception active. */
 export const BROWSER_ACTION_NAVIGATION_GRACE_MS = 250;
 
+/** Keep navigation timeouts consistent across transports and browser backends. */
+export function resolveBrowserNavigationTimeoutMs(timeoutMs?: number): number {
+  return Math.min(120_000, resolveTimerTimeoutMs(timeoutMs, 20_000, 1_000));
+}
+
 export function normalizeActBoundedNonNegativeMs(
   value: number | undefined,
   fieldName: string,

--- a/extensions/browser/src/browser/chrome-mcp-actions.ts
+++ b/extensions/browser/src/browser/chrome-mcp-actions.ts
@@ -8,8 +8,8 @@ import {
 } from "openclaw/plugin-sdk/number-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
+import { resolveBrowserNavigationTimeoutMs } from "./act-policy.js";
 import {
-  CHROME_MCP_NAVIGATE_TIMEOUT_MS,
   rethrowChromeMcpDocumentError,
   type ChromeMcpOperationOptions,
   type ChromeMcpProfileOptions,
@@ -104,7 +104,7 @@ export async function navigateChromeMcpPage(params: {
   timeoutMs?: number;
   signal?: AbortSignal;
 }): Promise<{ url: string }> {
-  const resolvedTimeoutMs = params.timeoutMs ?? CHROME_MCP_NAVIGATE_TIMEOUT_MS;
+  const resolvedTimeoutMs = resolveBrowserNavigationTimeoutMs(params.timeoutMs);
   const callTimeoutMs = resolveChromeMcpNavigateCallTimeoutMs(resolvedTimeoutMs);
   return await withChromeMcpTarget({ ...params, timeoutMs: callTimeoutMs }, async (target) => {
     await callTool(

--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -2881,11 +2881,34 @@ describe("chrome MCP page parsing", () => {
     });
 
     const callToolMock = session.client["callTool"] as unknown as ToolCallMock;
-    const navigateCall = callToolMock.mock.calls.find(
-      ([call]) => call.name === "navigate_page",
-    )?.[0];
-    expect(navigateCall?.arguments?.timeout).toBe(20_000);
+    const navigateCall = callToolMock.mock.calls.find(([call]) => call.name === "navigate_page");
+    expect(navigateCall?.[0].arguments?.timeout).toBe(20_000);
+    expect(navigateCall?.[2]?.timeout).toBe(25_000);
   });
+
+  it.each([
+    { requestedTimeoutMs: 10, expectedTimeoutMs: 1_000 },
+    { requestedTimeoutMs: 180_000, expectedTimeoutMs: 120_000 },
+    { requestedTimeoutMs: Number.MAX_SAFE_INTEGER, expectedTimeoutMs: 120_000 },
+  ])(
+    "normalizes Chrome MCP navigation timeout $requestedTimeoutMs before SDK watchdog grace",
+    async ({ requestedTimeoutMs, expectedTimeoutMs }) => {
+      const session = createFakeSession();
+      setChromeMcpSessionFactoryForTest(async () => session);
+
+      await navigateChromeMcpPage({
+        profileName: "chrome-live",
+        targetId: FAKE_TARGET_1,
+        url: "https://example.com",
+        timeoutMs: requestedTimeoutMs,
+      });
+
+      const callToolMock = session.client["callTool"] as unknown as ToolCallMock;
+      const navigateCall = callToolMock.mock.calls.find(([call]) => call.name === "navigate_page");
+      expect(navigateCall?.[0].arguments?.timeout).toBe(expectedTimeoutMs);
+      expect(navigateCall?.[2]?.timeout).toBe(expectedTimeoutMs + 5_000);
+    },
+  );
 
   it("caps the navigate_page safety-net timeout", () => {
     expect(resolveChromeMcpNavigateCallTimeoutMs(10_000)).toBe(15_000);

--- a/extensions/browser/src/browser/client-actions-core.navigation.test.ts
+++ b/extensions/browser/src/browser/client-actions-core.navigation.test.ts
@@ -45,6 +45,29 @@ describe("browser navigation client actions", () => {
     });
   });
 
+  it.each([
+    { requestedTimeoutMs: 10, expectedTimeoutMs: 1_000 },
+    { requestedTimeoutMs: 180_000, expectedTimeoutMs: 120_000 },
+    { requestedTimeoutMs: Number.MAX_SAFE_INTEGER, expectedTimeoutMs: 120_000 },
+  ])(
+    "normalizes navigation timeout $requestedTimeoutMs before arming its transport watchdog",
+    async ({ requestedTimeoutMs, expectedTimeoutMs }) => {
+      await browserNavigate(undefined, {
+        url: "https://example.com/slow",
+        targetId: "tab-1",
+        timeoutMs: requestedTimeoutMs,
+      });
+
+      const request = lastNavigationRequest();
+      expect(request.options.timeoutMs).toBe(expectedTimeoutMs + 5_000);
+      expect(JSON.parse(request.options.body ?? "{}")).toEqual({
+        url: "https://example.com/slow",
+        targetId: "tab-1",
+        timeoutMs: expectedTimeoutMs,
+      });
+    },
+  );
+
   it("preserves the existing navigation watchdog when no timeout is requested", async () => {
     await browserNavigate(undefined, { url: "https://example.com" });
 

--- a/extensions/browser/src/browser/client-actions-core.navigation.test.ts
+++ b/extensions/browser/src/browser/client-actions-core.navigation.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const clientFetchMocks = vi.hoisted(() => ({
+  fetchBrowserJson: vi.fn(async (..._args: unknown[]) => ({ ok: true, targetId: "tab-1" })),
+}));
+
+vi.mock("./client-fetch.js", () => clientFetchMocks);
+
+import { browserNavigate } from "./client-actions-core.js";
+
+function lastNavigationRequest(): {
+  url: string;
+  options: { body?: string; timeoutMs?: number };
+} {
+  const call = clientFetchMocks.fetchBrowserJson.mock.calls.at(-1);
+  if (!call) {
+    throw new Error("fetchBrowserJson was not called");
+  }
+  return {
+    url: String(call[0]),
+    options: call[1] as { body?: string; timeoutMs?: number },
+  };
+}
+
+describe("browser navigation client actions", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("forwards an explicit operation timeout and leaves transport watchdog grace", async () => {
+    const options = {
+      url: "https://example.com/slow",
+      targetId: "tab-1",
+      timeoutMs: 45_000,
+      profile: "openclaw",
+    };
+
+    await browserNavigate(undefined, options);
+
+    const request = lastNavigationRequest();
+    expect(request.url).toBe("/navigate?profile=openclaw");
+    expect(request.options.timeoutMs).toBe(50_000);
+    expect(JSON.parse(request.options.body ?? "{}")).toEqual({
+      url: "https://example.com/slow",
+      targetId: "tab-1",
+      timeoutMs: 45_000,
+    });
+  });
+
+  it("preserves the existing navigation watchdog when no timeout is requested", async () => {
+    await browserNavigate(undefined, { url: "https://example.com" });
+
+    const request = lastNavigationRequest();
+    expect(request.options.timeoutMs).toBe(20_000);
+    expect(JSON.parse(request.options.body ?? "{}")).toEqual({ url: "https://example.com" });
+  });
+});

--- a/extensions/browser/src/browser/client-actions-core.ts
+++ b/extensions/browser/src/browser/client-actions-core.ts
@@ -12,6 +12,7 @@ import {
 import {
   BROWSER_ACTION_TRANSPORT_SLACK_MS,
   resolveBrowserActRequestTimeoutMs,
+  resolveBrowserNavigationTimeoutMs,
 } from "./act-policy.js";
 import type {
   BrowserActionOk,
@@ -84,14 +85,14 @@ export async function browserNavigate(
   },
 ): Promise<BrowserActionTabResult> {
   const q = buildProfileQuery(opts.profile);
+  const timeoutMs =
+    opts.timeoutMs === undefined ? undefined : resolveBrowserNavigationTimeoutMs(opts.timeoutMs);
   return await fetchBrowserJson<BrowserActionTabResult>(withBaseUrl(baseUrl, `/navigate${q}`), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ url: opts.url, targetId: opts.targetId, timeoutMs: opts.timeoutMs }),
+    body: JSON.stringify({ url: opts.url, targetId: opts.targetId, timeoutMs }),
     timeoutMs:
-      opts.timeoutMs === undefined
-        ? 20_000
-        : resolveBrowserOperationRequestTimeoutMs(opts.timeoutMs),
+      timeoutMs === undefined ? 20_000 : resolveBrowserOperationRequestTimeoutMs(timeoutMs),
   });
 }
 

--- a/extensions/browser/src/browser/client-actions-core.ts
+++ b/extensions/browser/src/browser/client-actions-core.ts
@@ -79,6 +79,7 @@ export async function browserNavigate(
   opts: {
     url: string;
     targetId?: string;
+    timeoutMs?: number;
     profile?: string;
   },
 ): Promise<BrowserActionTabResult> {
@@ -86,8 +87,11 @@ export async function browserNavigate(
   return await fetchBrowserJson<BrowserActionTabResult>(withBaseUrl(baseUrl, `/navigate${q}`), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ url: opts.url, targetId: opts.targetId }),
-    timeoutMs: 20000,
+    body: JSON.stringify({ url: opts.url, targetId: opts.targetId, timeoutMs: opts.timeoutMs }),
+    timeoutMs:
+      opts.timeoutMs === undefined
+        ? 20_000
+        : resolveBrowserOperationRequestTimeoutMs(opts.timeoutMs),
   });
 }
 

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts
@@ -86,6 +86,32 @@ describe("pw-tools-core.snapshot navigate guard", () => {
     expect(result.url).toBe("https://example.com");
   });
 
+  it.each([
+    { requestedTimeoutMs: undefined, expectedTimeoutMs: 20_000 },
+    { requestedTimeoutMs: 180_000, expectedTimeoutMs: 120_000 },
+    { requestedTimeoutMs: Number.MAX_SAFE_INTEGER, expectedTimeoutMs: 120_000 },
+  ])(
+    "applies the shipped navigation timeout contract to Playwright timeout $requestedTimeoutMs",
+    async ({ requestedTimeoutMs, expectedTimeoutMs }) => {
+      const goto = vi.fn(async () => {});
+      setPwToolsCoreCurrentPage({
+        goto,
+        url: vi.fn(() => "https://example.com"),
+      });
+
+      await mod.navigateViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        url: "https://example.com",
+        timeoutMs: requestedTimeoutMs,
+      });
+
+      expect(goto).toHaveBeenCalledWith("https://example.com", { timeout: expectedTimeoutMs });
+      expect(getPwToolsCoreSessionMocks().gotoPageWithNavigationGuard).toHaveBeenCalledWith(
+        expect.objectContaining({ timeoutMs: expectedTimeoutMs }),
+      );
+    },
+  );
+
   it("returns managed download metadata when navigation starts an attachment download", async () => {
     const download = {
       url: "https://example.com/export.csv",

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.ts
@@ -10,7 +10,7 @@ import {
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { Frame, Page } from "playwright-core";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
-import { ACT_MAX_VIEWPORT_DIMENSION } from "./act-policy.js";
+import { ACT_MAX_VIEWPORT_DIMENSION, resolveBrowserNavigationTimeoutMs } from "./act-policy.js";
 import { type AriaSnapshotNode, formatAriaSnapshot, type RawAXNode } from "./cdp.js";
 import type { BrowserDownloadResult } from "./download-types.js";
 import {
@@ -54,10 +54,6 @@ function resolveBoundedTimeoutMs(
 
 function resolveSnapshotTimeoutMs(timeoutMs: number | undefined): number {
   return resolveBoundedTimeoutMs(timeoutMs, 5_000, 500, 60_000);
-}
-
-function resolveNavigationTimeoutMs(timeoutMs: number | undefined): number {
-  return resolveBoundedTimeoutMs(timeoutMs, 20_000, 1000, 120_000);
 }
 
 function resolveViewportDimension(value: unknown, label: "width" | "height"): number {
@@ -509,7 +505,7 @@ export async function navigateViaPlaywright(opts: {
     url,
     ...navigationPolicy,
   });
-  const timeout = resolveNavigationTimeoutMs(opts.timeoutMs);
+  const timeout = resolveBrowserNavigationTimeoutMs(opts.timeoutMs);
   let page = await getPageForTargetId(opts);
   let pageState = ensurePageState(page);
   const navigate = async () =>

--- a/extensions/browser/src/browser/routes/agent.snapshot.ts
+++ b/extensions/browser/src/browser/routes/agent.snapshot.ts
@@ -65,7 +65,7 @@ import {
   shouldUsePlaywrightForScreenshot,
 } from "./agent.snapshot.plan.js";
 import { EXISTING_SESSION_LIMITS } from "./existing-session-limits.js";
-import { readRoutePositiveInteger } from "./route-numeric.js";
+import { readRoutePositiveInteger, readRouteTimerTimeoutMs } from "./route-numeric.js";
 import type { BrowserResponse, BrowserRouteRegistrar } from "./types.js";
 import { jsonError, runProfileRouteOperation, toBoolean, toStringOrEmpty } from "./utils.js";
 
@@ -329,6 +329,12 @@ export function registerBrowserAgentSnapshotRoutes(
     if (!url) {
       return jsonError(res, 400, "url is required");
     }
+    let timeoutMs: number | undefined;
+    try {
+      timeoutMs = readRouteTimerTimeoutMs(body.timeoutMs);
+    } catch (err) {
+      return jsonError(res, 400, String(err instanceof Error ? err.message : err));
+    }
     await withRouteTabContext({
       req,
       res,
@@ -343,6 +349,7 @@ export function registerBrowserAgentSnapshotRoutes(
             profile: profileCtx.profile,
             targetId: tab.targetId,
             url,
+            timeoutMs,
             signal,
           });
           await assertBrowserNavigationResultAllowed({ url: result.url, ...ssrfPolicyOpts });
@@ -356,6 +363,7 @@ export function registerBrowserAgentSnapshotRoutes(
           cdpUrl,
           targetId: tab.targetId,
           url,
+          timeoutMs,
           ...browserNavigationPolicyForProfile(ctx, profileCtx),
         });
         const currentTargetId = await resolveTargetIdAfterNavigate({

--- a/extensions/browser/src/browser/routes/agent.snapshot.ts
+++ b/extensions/browser/src/browser/routes/agent.snapshot.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { getImageMetadata } from "../../media/media-services.js";
 import { ensureMediaDir, saveMediaBuffer } from "../../media/store.js";
+import { resolveBrowserNavigationTimeoutMs } from "../act-policy.js";
 import {
   captureScreenshot,
   getMainFrameDocumentIdentityViaCdp,
@@ -331,7 +332,11 @@ export function registerBrowserAgentSnapshotRoutes(
     }
     let timeoutMs: number | undefined;
     try {
-      timeoutMs = readRouteTimerTimeoutMs(body.timeoutMs);
+      const requestedTimeoutMs = readRouteTimerTimeoutMs(body.timeoutMs);
+      timeoutMs =
+        requestedTimeoutMs === undefined
+          ? undefined
+          : resolveBrowserNavigationTimeoutMs(requestedTimeoutMs);
     } catch (err) {
       return jsonError(res, 400, String(err instanceof Error ? err.message : err));
     }

--- a/extensions/browser/src/browser/server.agent-contract-core.test.ts
+++ b/extensions/browser/src/browser/server.agent-contract-core.test.ts
@@ -30,8 +30,10 @@ import { getBrowserTestFetch } from "./test-support/fetch.js";
 
 const BROWSER_NAVIGATION_BLOCKED_MESSAGE = "browser navigation blocked by policy";
 const NAVIGATION_TIMEOUT_CASES = [
+  { requestedTimeoutMs: 10, expectedTimeoutMs: 1_000 },
   { requestedTimeoutMs: 45_000, expectedTimeoutMs: 45_000 },
-  { requestedTimeoutMs: 3_000_000_000, expectedTimeoutMs: 2_147_483_647 },
+  { requestedTimeoutMs: 180_000, expectedTimeoutMs: 120_000 },
+  { requestedTimeoutMs: 3_000_000_000, expectedTimeoutMs: 120_000 },
 ] as const;
 
 type ActErrorResponse = {

--- a/extensions/browser/src/browser/server.agent-contract-core.test.ts
+++ b/extensions/browser/src/browser/server.agent-contract-core.test.ts
@@ -29,6 +29,10 @@ import {
 import { getBrowserTestFetch } from "./test-support/fetch.js";
 
 const BROWSER_NAVIGATION_BLOCKED_MESSAGE = "browser navigation blocked by policy";
+const NAVIGATION_TIMEOUT_CASES = [
+  { requestedTimeoutMs: 45_000, expectedTimeoutMs: 45_000 },
+  { requestedTimeoutMs: 3_000_000_000, expectedTimeoutMs: 2_147_483_647 },
+] as const;
 
 type ActErrorResponse = {
   error?: string;
@@ -592,6 +596,53 @@ describe("browser control server", () => {
       limit: 25,
     });
   });
+
+  it.each(NAVIGATION_TIMEOUT_CASES)(
+    "forwards timer-safe navigation timeout $requestedTimeoutMs to the Playwright backend",
+    async ({ requestedTimeoutMs, expectedTimeoutMs }) => {
+      const base = await startServerAndBase();
+
+      const response = await postJson<{ ok: boolean }>(`${base}/navigate`, {
+        url: "https://example.com/slow",
+        timeoutMs: requestedTimeoutMs,
+      });
+
+      expect(response.ok).toBe(true);
+      expect(requirePwMock("navigateViaPlaywright")).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://example.com/slow",
+          timeoutMs: expectedTimeoutMs,
+        }),
+      );
+    },
+  );
+
+  it.each(NAVIGATION_TIMEOUT_CASES)(
+    "forwards timer-safe navigation timeout $requestedTimeoutMs to the Chrome MCP backend",
+    async ({ requestedTimeoutMs, expectedTimeoutMs }) => {
+      setBrowserControlServerProfiles({
+        openclaw: { color: "#FF4500", driver: "existing-session" },
+      });
+      const base = await startServerAndBase();
+
+      const response = await postJson<{ ok: boolean }>(`${base}/navigate`, {
+        url: "https://example.com/slow",
+        targetId: "7",
+        timeoutMs: requestedTimeoutMs,
+      });
+
+      expect(response.ok).toBe(true);
+      const chromeMcp = await vi.importMock<typeof import("./chrome-mcp.js")>("./chrome-mcp.js");
+      expect(chromeMcp.navigateChromeMcpPage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          profileName: "openclaw",
+          targetId: "7",
+          url: "https://example.com/slow",
+          timeoutMs: expectedTimeoutMs,
+        }),
+      );
+    },
+  );
 
   it("agent contract: navigation + common act commands", async () => {
     const base = await startServerAndBase();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where browser navigation with an explicitly requested longer timeout could still abort at the default transport deadline, and oversized timeouts reached driver timers without the canonical safe cap.

## Why This Change Was Made

Carry the existing navigation timeout through its actual tool, host/node client, authenticated HTTP route, Playwright, and Chrome MCP owners; normalize all navigation through the already-shipped 1,000–120,000 ms contract, preserve the 20,000 ms default, and keep +5,000/+10,000 ms watchdog grace.

## User Impact

Longer browser navigations honor the requested operation budget, invalid values fail clearly, and oversized values are safely bounded for both browser drivers.

## Evidence

Original integrated Testbox proof passed 187 browser-owner tests, five real Chromium plugin E2E cases, the full changed gate, and the private packaged build. Exact reviewer-finding RED then reproduced 18 failures across real Playwright and Chrome MCP helpers, host/node producers, authenticated HTTP routes, and nested watchdogs. The repaired owner matrix passed all 298 focused tests, including minimum 1,000 ms, default 20,000 ms, normal 45,000 ms, 180,000 ms and extreme values clamped to the shipped 120,000 ms cap, plus 125,000/130,000 ms watchdog grace. Blacksmith Testbox had an organization-wide 16-vCPU capacity outage; the documented trusted-source fallback used the canonical checkout's existing dependencies without installing any.

**Integrated trusted-Testbox proof:** 609 tests passed, including five real Chromium extension E2E cases; complete production/test typechecks, lint, plugin-boundary/generated-contract checks, private production build, and four actual ephemeral-Gateway scenarios all passed.

**Owner/risk review:** No new config, provider, auth, public protocol, SDK, or dependency surface; production delta +27 lines for end-to-end timeout ownership and one canonical shipped navigation budget; generic timer and non-navigation behavior remain unchanged.

### Exact-head review resolution

The existing tagged-release Playwright owner already enforces a 1–120 second navigation policy; Playwright itself accepts arbitrary explicit timeouts, while the MCP SDK arms a real JavaScript timer. The fix therefore preserves the shipped OpenClaw ceiling and shares it across both drivers instead of expanding navigation into multi-day timers or changing unrelated generic timer contracts. All prior ClawSweeper rank-up moves are addressed by the actual 180-second/extreme cross-driver and watchdog regression matrix.

**Current-main refresh rank-up:** Intentionally skipped: the canonical merge-base-to-current-main comparison has no overlap with any changed browser owner; the current exact head already has a clean automated review and passing required CI. Repository policy treats unrelated behind-main drift as advisory, and the canonical maintainer merge verifier will recheck overlap. Rebasing solely to refresh unrelated history would invalidate already-verified exact-head CI and review without improving the repair.

**Dependency contract proof:** Directly inspected installed `playwright-core/lib/coreBundle.js` (explicit navigation timeout forwarded unchanged) and `@modelcontextprotocol/sdk/dist/esm/shared/protocol.js` (actual `setTimeout` watchdog). No persisted model, schema, migration, or configuration is changed; reported serialized-state risk describes transient HTTP JSON only.
