### PR TITLE
fix(qa): preserve Control UI choices across isolated and paired runs

### DIFF
--- a/extensions/qa-lab/src/lab-server.test.ts
+++ b/extensions/qa-lab/src/lab-server.test.ts
@@ -457,6 +457,7 @@ describe("qa-lab server", () => {
       expect.objectContaining({
         alternateModel: "openai/gpt-5.6-luna",
         channelDriver: "crabline",
+        controlUiEnabled: true,
         primaryModel: "openai/gpt-5.6-luna",
         providerMode: "live-frontier",
         scenarioIds: ["dm-chat-baseline", "browser-talk-start-stop"],

--- a/extensions/qa-lab/src/lab-server.ts
+++ b/extensions/qa-lab/src/lab-server.ts
@@ -801,6 +801,7 @@ export async function startQaLabServer(
               const runtimeResult = await runQaSuite({
                 lab: labHandle ?? undefined,
                 startLab: startQaLabServer,
+                controlUiEnabled: true,
                 repoRoot,
                 outputDir: createQaRunOutputDir(repoRoot),
                 channelDriver: selection.channelDriver,

--- a/extensions/qa-lab/src/suite-run-standard.parity-retry.test.ts
+++ b/extensions/qa-lab/src/suite-run-standard.parity-retry.test.ts
@@ -130,6 +130,71 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
+describe("QA suite Control UI ownership", () => {
+  it.each([
+    {
+      label: "a non-Control UI scenario by default",
+      surface: "channel",
+      explicit: undefined,
+      enabled: false,
+    },
+    {
+      label: "an explicitly disabled non-Control UI scenario",
+      surface: "channel",
+      explicit: false,
+      enabled: false,
+    },
+    {
+      label: "an explicitly enabled non-Control UI scenario",
+      surface: "channel",
+      explicit: true,
+      enabled: true,
+    },
+    {
+      label: "a Control UI scenario by default",
+      surface: "control-ui",
+      explicit: undefined,
+      enabled: true,
+    },
+    {
+      label: "an explicitly disabled Control UI scenario",
+      surface: "control-ui",
+      explicit: false,
+      enabled: false,
+    },
+  ])("only starts and publishes the gateway Control UI for $label", async (testCase) => {
+    const lab = makeRetryTestLab();
+    const context = makeRetryTestContext();
+    context.selectedScenarios = [
+      makeQaSuiteTestScenario("control-ui-ownership", { surface: testCase.surface }),
+    ];
+    const runScenario = vi
+      .fn<QaSuiteScenarioRunner>()
+      .mockResolvedValue(makeRetryTestResult("pass"));
+
+    await runQaFlowSuiteStandard(
+      {
+        lab,
+        ...(testCase.explicit === undefined ? {} : { controlUiEnabled: testCase.explicit }),
+      },
+      context,
+      runScenario,
+    );
+
+    expect(mocks.startQaGatewayChild).toHaveBeenCalledWith(
+      expect.objectContaining({ controlUiEnabled: testCase.enabled }),
+    );
+    if (testCase.enabled) {
+      expect(lab.setControlUi).toHaveBeenCalledWith({
+        controlUiProxyTarget: "http://127.0.0.1:18789",
+        controlUiProxyToken: "qa-test-token",
+      });
+    } else {
+      expect(lab.setControlUi).not.toHaveBeenCalled();
+    }
+  });
+});
+
 describe("QA runtime parity scenario retry isolation", () => {
   it.each([
     { forcedRuntime: undefined, expectedRuntime: "openclaw" },

--- a/extensions/qa-lab/src/suite-run-standard.ts
+++ b/extensions/qa-lab/src/suite-run-standard.ts
@@ -15,7 +15,11 @@ import {
   type QaSuiteGatewayRssSample,
   writeQaSuiteArtifacts,
 } from "./suite-artifacts.js";
-import { applyQaMergePatch, collectQaSuiteTransportPolicy } from "./suite-planning.js";
+import {
+  applyQaMergePatch,
+  collectQaSuiteTransportPolicy,
+  scenarioRequiresControlUi,
+} from "./suite-planning.js";
 import { runQaSuiteRoundTripProbe } from "./suite-round-trip.js";
 import { waitForGatewayHealthy, waitForTransportReady } from "./suite-runtime-gateway.js";
 import {
@@ -68,6 +72,8 @@ export async function runQaFlowSuiteStandard(
   } = context;
   const ownsLab = !params?.lab;
   const startLab = params?.startLab;
+  const controlUiEnabled =
+    params?.controlUiEnabled ?? selectedScenarios.some(scenarioRequiresControlUi);
   writeQaSuiteProgress(progressEnabled, "lab start");
   const lab =
     params?.lab ??
@@ -126,7 +132,7 @@ export async function runQaFlowSuiteStandard(
       thinkingDefault: params?.thinkingDefault,
       forcedRuntime: params?.forcedRuntime,
       claudeCliAuthMode: params?.claudeCliAuthMode,
-      controlUiEnabled: params?.controlUiEnabled ?? true,
+      controlUiEnabled,
       enabledPluginIds,
       allowUnhealthyStartup: gatewayRuntimeOptions?.allowUnhealthyStartup,
       forwardHostHome: gatewayRuntimeOptions?.forwardHostHome,
@@ -144,10 +150,12 @@ export async function runQaFlowSuiteStandard(
       progressEnabled,
       `gateway ready: ${sanitizeQaSuiteProgressValue(activeGateway.baseUrl)}`,
     );
-    lab.setControlUi({
-      controlUiProxyTarget: activeGateway.baseUrl,
-      controlUiProxyToken: activeGateway.token,
-    });
+    if (controlUiEnabled) {
+      lab.setControlUi({
+        controlUiProxyTarget: activeGateway.baseUrl,
+        controlUiProxyToken: activeGateway.token,
+      });
+    }
     const activeEnv: QaSuiteEnvironment = {
       lab,
       mock: activeMock,
@@ -441,10 +449,12 @@ export async function runQaFlowSuiteStandard(
       finishLab: ownsLab
         ? () => lab.stop()
         : async () => {
-            lab.setControlUi({
-              controlUiUrl: null,
-              controlUiProxyTarget: null,
-            });
+            if (controlUiEnabled) {
+              lab.setControlUi({
+                controlUiUrl: null,
+                controlUiProxyTarget: null,
+              });
+            }
           },
     });
     throwQaSuiteCleanupErrors({ cleanupErrors, runFailed, runError });

--- a/extensions/qa-lab/src/suite-run.runtime.ts
+++ b/extensions/qa-lab/src/suite-run.runtime.ts
@@ -137,6 +137,7 @@ export async function runQaFlowSuiteFromRuntime(params?: QaSuiteRunParams): Prom
       primaryModel,
       alternateModel,
       fastMode,
+      controlUiEnabled: params.controlUiEnabled,
       thinkingDefault: params.thinkingDefault,
       claudeCliAuthMode: params.claudeCliAuthMode,
       enabledPluginIds: params.enabledPluginIds,

--- a/extensions/qa-lab/src/suite-runtime-parity-runner.control-ui.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-parity-runner.control-ui.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createQaBusState } from "./bus-state.js";
+import type { QaLabServerHandle } from "./lab-server.types.js";
+import { runQaFlowSuiteFromRuntime } from "./suite-run.runtime.js";
+import { makeQaSuiteTestScenario } from "./suite-test-helpers.js";
+import type { QaSuiteResolvedRunContext, QaSuiteRunParams } from "./suite-types.js";
+
+const mocks = vi.hoisted(() => ({
+  readQaBootstrapScenarioCatalog: vi.fn(),
+  runQaFlowSuiteStandard: vi.fn(),
+  writeQaSuiteArtifacts: vi.fn(),
+}));
+
+vi.mock("./scenario-catalog.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./scenario-catalog.js")>()),
+  readQaBootstrapScenarioCatalog: mocks.readQaBootstrapScenarioCatalog,
+}));
+
+vi.mock("./suite-planning.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./suite-planning.js")>()),
+  resolveQaSuiteOutputDir: vi.fn(
+    async (_repoRoot: string, outputDir?: string) => outputDir ?? "/qa-output",
+  ),
+}));
+
+vi.mock("./suite-run-standard.js", () => ({
+  runQaFlowSuiteStandard: mocks.runQaFlowSuiteStandard,
+}));
+
+vi.mock("./suite-artifacts.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./suite-artifacts.js")>()),
+  writeQaSuiteArtifacts: mocks.writeQaSuiteArtifacts,
+}));
+
+function createControlUiTestLab(): QaLabServerHandle {
+  return {
+    baseUrl: "http://127.0.0.1:43123",
+    listenUrl: "http://127.0.0.1:43123",
+    state: createQaBusState(),
+    setControlUi: vi.fn(),
+    setScenarioRun: vi.fn(),
+    setLatestReport: vi.fn(),
+    runSelfCheck: vi.fn(),
+    stop: vi.fn(async () => {}),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.readQaBootstrapScenarioCatalog.mockReturnValue({
+    scenarios: [
+      makeQaSuiteTestScenario("runtime-channel", { surface: "channel" }),
+      makeQaSuiteTestScenario("runtime-control-ui", { surface: "control-ui" }),
+    ],
+  });
+  mocks.runQaFlowSuiteStandard.mockImplementation(
+    async (params: QaSuiteRunParams | undefined, context: QaSuiteResolvedRunContext) => ({
+      outputDir: context.outputDir,
+      evidencePath: "/qa-output/qa-evidence.json",
+      reportPath: "/qa-output/qa-suite-report.md",
+      summaryPath: "/qa-output/qa-suite-summary.json",
+      report: "",
+      scenarios: [{ name: context.selectedScenarios[0]?.title, status: "pass", steps: [] }],
+      watchUrl: "http://127.0.0.1:43123",
+      runtimeParityCell: {
+        runtime: params?.forcedRuntime ?? "openclaw",
+        transcriptBytes: "",
+        toolCalls: [],
+        finalText: "ok",
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        wallClockMs: 1,
+        bootStateLines: [],
+      },
+    }),
+  );
+  mocks.writeQaSuiteArtifacts.mockResolvedValue({
+    evidence: undefined,
+    evidencePath: "/qa-output/qa-evidence.json",
+    report: "",
+    reportPath: "/qa-output/qa-suite-report.md",
+    summaryPath: "/qa-output/qa-suite-summary.json",
+  });
+});
+
+describe("runtime parity Control UI ownership", () => {
+  it.each([
+    {
+      label: "a non-Control UI scenario by default",
+      scenarioId: "runtime-channel",
+      explicit: undefined,
+      enabled: false,
+    },
+    {
+      label: "an interactive non-Control UI scenario",
+      scenarioId: "runtime-channel",
+      explicit: true,
+      enabled: true,
+    },
+    {
+      label: "an explicitly disabled non-Control UI scenario",
+      scenarioId: "runtime-channel",
+      explicit: false,
+      enabled: false,
+    },
+    {
+      label: "a Control UI scenario by default",
+      scenarioId: "runtime-control-ui",
+      explicit: undefined,
+      enabled: true,
+    },
+    {
+      label: "an explicitly disabled Control UI scenario",
+      scenarioId: "runtime-control-ui",
+      explicit: false,
+      enabled: false,
+    },
+  ])("preserves Control UI policy in both runtime cells for $label", async (testCase) => {
+    const lab = createControlUiTestLab();
+
+    await runQaFlowSuiteFromRuntime({
+      repoRoot: "/qa-repo",
+      outputDir: "/qa-output",
+      providerMode: "mock-openai",
+      scenarioIds: [testCase.scenarioId],
+      runtimePair: ["openclaw", "codex"],
+      lab,
+      startLab: async () => lab,
+      ...(testCase.explicit === undefined ? {} : { controlUiEnabled: testCase.explicit }),
+    });
+
+    expect(
+      mocks.runQaFlowSuiteStandard.mock.calls.map(([params]) => ({
+        runtime: params.forcedRuntime,
+        controlUiEnabled: params.controlUiEnabled,
+      })),
+    ).toEqual([
+      { runtime: "openclaw", controlUiEnabled: testCase.enabled },
+      { runtime: "codex", controlUiEnabled: testCase.enabled },
+    ]);
+  });
+});

--- a/extensions/qa-lab/src/suite-runtime-parity-runner.ts
+++ b/extensions/qa-lab/src/suite-runtime-parity-runner.ts
@@ -55,6 +55,7 @@ export async function runQaRuntimeParitySuite(params: {
   primaryModel: string;
   alternateModel: string;
   fastMode: boolean;
+  controlUiEnabled?: boolean;
   thinkingDefault?: QaThinkingLevel;
   claudeCliAuthMode?: QaCliBackendAuthMode;
   enabledPluginIds?: string[];
@@ -175,7 +176,7 @@ export async function runQaRuntimeParitySuite(params: {
               concurrency: 1,
               enabledPluginIds: params.enabledPluginIds,
               startLab,
-              controlUiEnabled: scenarioRequiresControlUi(scenario),
+              controlUiEnabled: params.controlUiEnabled ?? scenarioRequiresControlUi(scenario),
               forcedRuntime: runtime,
               captureRuntimeParityCell: true,
               writeEvidenceFile: params.writeEvidenceFile,

--- a/extensions/qa-lab/src/suite-support.ts
+++ b/extensions/qa-lab/src/suite-support.ts
@@ -93,7 +93,7 @@ export function buildQaIsolatedScenarioWorkerParams(params: {
     enabledPluginIds: params.input?.enabledPluginIds,
     concurrency: 1,
     startLab: params.startLab,
-    controlUiEnabled: scenarioRequiresControlUi(params.scenario),
+    controlUiEnabled: params.input?.controlUiEnabled ?? scenarioRequiresControlUi(params.scenario),
     transportReadyTimeoutMs: params.input?.transportReadyTimeoutMs,
     workerStartStaggerMs: params.input?.workerStartStaggerMs,
     forcedRuntime: params.input?.forcedRuntime,

--- a/extensions/qa-lab/src/suite.test.ts
+++ b/extensions/qa-lab/src/suite.test.ts
@@ -869,6 +869,33 @@ describe("qa suite", () => {
     });
   });
 
+  it.each([
+    { surface: "channel", explicit: undefined, expected: false },
+    { surface: "channel", explicit: true, expected: true },
+    { surface: "control-ui", explicit: undefined, expected: true },
+    { surface: "control-ui", explicit: false, expected: false },
+  ])(
+    "preserves an explicit Control UI override for isolated $surface scenarios",
+    ({ surface, explicit, expected }) => {
+      const scenario = makeQaSuiteTestScenario("isolated-control-ui-ownership", { surface });
+
+      expect(
+        qaSuiteProgressTesting.buildQaIsolatedScenarioWorkerParams({
+          repoRoot: "/repo",
+          outputDir: "/repo/.artifacts/qa-e2e/scenarios/isolated-control-ui-ownership",
+          providerMode: "mock-openai",
+          transportId: "qa-channel",
+          primaryModel: "mock-openai/gpt-5.6-luna",
+          alternateModel: "mock-openai/gpt-5.6-luna-alt",
+          fastMode: true,
+          scenario,
+          startLab: vi.fn(),
+          ...(explicit === undefined ? {} : { input: { controlUiEnabled: explicit } }),
+        }).controlUiEnabled,
+      ).toBe(expected);
+    },
+  );
+
   it("enables Control UI only for Control UI scenarios unless explicitly overridden", () => {
     const channelScenario = makeQaSuiteTestScenario("channel-baseline", { surface: "channel" });
     const controlUiScenario = makeQaSuiteTestScenario("control-ui-roundtrip", {
@@ -891,6 +918,12 @@ describe("qa suite", () => {
         scenarios: [channelScenario],
       }),
     ).toBe(true);
+    expect(
+      qaSuiteProgressTesting.resolveQaSuiteControlUiEnabled({
+        explicit: false,
+        scenarios: [controlUiScenario],
+      }),
+    ).toBe(false);
   });
 
   it("keeps caller-owned serial labs on shared workers without a launcher", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where QA suites could start or expose the Control UI for scenarios that did not need it, or drop an explicit enable/disable choice when scenarios ran in isolated workers or paired runtimes.

## Why This Change Was Made

Resolve Control UI ownership once from the explicit caller choice or actual scenario requirements, propagate that choice through standard, isolated, and both runtime-pair cells, and explicitly preserve the interactive Lab's documented enabled UI.

## User Impact

Headless QA remains headless, UI scenarios reliably receive a Control UI, explicit operator overrides survive every suite execution shape, and interactive Lab behavior stays unchanged.

## Evidence

QA focused suites: 132 tests passed, including five real paired-runtime enable/disable/default combinations, standard/isolated suite branches, interactive Lab, and credential-cleanup compatibility. Four actual ephemeral-Gateway mock-provider scenarios passed after a private production build. Full changed gate passed.

**Integrated trusted-Testbox proof:** 609 tests passed, including five real Chromium extension E2E cases; complete production/test typechecks, lint, plugin-boundary/generated-contract checks, private production build, and four actual ephemeral-Gateway scenarios all passed.

**Owner/risk review:** Private QA ownership only; existing internal controlUiEnabled option preserved, with no new configuration/default/public SDK/protocol surface. Production +13 lines justified by canonical UI/proxy exposure ownership.
