### PR TITLE
fix(discord): explain failed form openings instead of silently doing nothing

### DIFF
--- a/extensions/discord/src/monitor/agent-components.handlers.ts
+++ b/extensions/discord/src/monitor/agent-components.handlers.ts
@@ -258,6 +258,14 @@ async function handleDiscordModalTrigger(params: {
     );
   } catch (err) {
     logError(`${params.label}: failed to show modal: ${String(err)}`);
+    try {
+      await params.interaction.reply({
+        content: "Could not open this form. Request a new form and try again.",
+        ephemeral: true,
+      });
+    } catch {
+      // Interaction may have expired
+    }
   }
 }
 

--- a/extensions/discord/src/monitor/agent-components.handlers.ts
+++ b/extensions/discord/src/monitor/agent-components.handlers.ts
@@ -258,14 +258,10 @@ async function handleDiscordModalTrigger(params: {
     );
   } catch (err) {
     logError(`${params.label}: failed to show modal: ${String(err)}`);
-    try {
-      await params.interaction.reply({
-        content: "Could not open this form. Request a new form and try again.",
-        ephemeral: true,
-      });
-    } catch {
-      // Interaction may have expired
-    }
+    await replyUnavailableComponentInteraction(
+      params.interaction,
+      "Could not open this form. Request a new form and try again.",
+    );
   }
 }
 

--- a/extensions/discord/src/monitor/agent-components.modal-presentation-failure.test.ts
+++ b/extensions/discord/src/monitor/agent-components.modal-presentation-failure.test.ts
@@ -1,0 +1,112 @@
+import { ChannelType } from "discord-api-types/v10";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  registerDiscordComponentEntries,
+  resolveDiscordComponentEntryWithPersistence,
+  resolveDiscordModalEntryWithPersistence,
+} from "../components-registry.js";
+import { clearDiscordComponentEntriesForTest } from "../components-registry.test-support.js";
+import type { DiscordComponentEntry, DiscordModalEntry } from "../components.js";
+import type { ButtonInteraction, ComponentData } from "../internal/discord.js";
+import { resetDiscordComponentRuntimeMocks } from "../test-support/component-runtime.js";
+import { createDiscordComponentControls } from "./agent-components.js";
+
+describe("Discord modal presentation failures", () => {
+  beforeEach(() => {
+    clearDiscordComponentEntriesForTest();
+    resetDiscordComponentRuntimeMocks();
+  });
+
+  it.each([{ replyRejects: false }, { replyRejects: true }])(
+    "handles a rejected modal callback with replyRejects=$replyRejects",
+    async ({ replyRejects }) => {
+      const sharedComponent = {
+        messageId: "msg-1",
+        sessionKey: "session-1",
+        agentId: "agent-1",
+        accountId: "default",
+        consumptionGroupId: "group-1",
+        consumptionGroupEntryIds: ["btn_1", "btn_cancel"],
+      };
+      const modalTrigger: DiscordComponentEntry = {
+        ...sharedComponent,
+        id: "btn_1",
+        kind: "modal-trigger",
+        label: "Open form",
+        modalId: "mdl_1",
+      };
+      const siblingButton: DiscordComponentEntry = {
+        ...sharedComponent,
+        id: "btn_cancel",
+        kind: "button",
+        label: "Cancel",
+      };
+      const modal: DiscordModalEntry = {
+        id: "mdl_1",
+        title: "Details",
+        messageId: "msg-1",
+        sessionKey: "session-1",
+        agentId: "agent-1",
+        accountId: "default",
+        fields: [{ id: "fld_1", name: "name", label: "Name", type: "text" }],
+      };
+      registerDiscordComponentEntries({ entries: [modalTrigger, siblingButton], modals: [modal] });
+
+      const createButton = createDiscordComponentControls[0];
+      if (!createButton) {
+        throw new Error("expected Discord component button factory");
+      }
+      const cfg: OpenClawConfig = {
+        channels: { discord: { replyToMode: "first" } },
+      };
+      const button = createButton({
+        cfg,
+        accountId: "default",
+        dmPolicy: "allowlist",
+        allowFrom: ["123456789"],
+        discordConfig: { replyToMode: "first" },
+        token: "token",
+      });
+      const showModal = vi.fn().mockRejectedValue(new Error("Discord rejected the modal"));
+      const reply = replyRejects
+        ? vi.fn().mockRejectedValue(new Error("Discord rejected the recovery reply"))
+        : vi.fn().mockResolvedValue(undefined);
+      const interaction = {
+        rawData: { channel_id: "dm-channel", id: "interaction-1" },
+        customId: "occomp:cid=btn_1",
+        client: {
+          rest: {
+            get: vi.fn().mockResolvedValue({ type: ChannelType.DM }),
+            post: vi.fn().mockResolvedValue({}),
+            patch: vi.fn().mockResolvedValue({}),
+            delete: vi.fn().mockResolvedValue(undefined),
+          },
+        },
+        user: { id: "123456789", username: "AgentUser", discriminator: "0001" },
+        message: { id: "msg-1" },
+        defer: vi.fn().mockResolvedValue(undefined),
+        showModal,
+        reply,
+      } as unknown as ButtonInteraction;
+
+      await button.run(interaction, { cid: "btn_1", mid: "mdl_1" } as ComponentData);
+
+      expect(showModal).toHaveBeenCalledOnce();
+      expect(reply).toHaveBeenCalledOnce();
+      expect(reply).toHaveBeenCalledWith({
+        content: "Could not open this form. Request a new form and try again.",
+        ephemeral: true,
+      });
+      await expect(
+        resolveDiscordComponentEntryWithPersistence({ id: "btn_1", consume: false }),
+      ).resolves.toBeNull();
+      await expect(
+        resolveDiscordComponentEntryWithPersistence({ id: "btn_cancel", consume: false }),
+      ).resolves.toBeNull();
+      await expect(
+        resolveDiscordModalEntryWithPersistence({ id: "mdl_1", consume: false }),
+      ).resolves.toEqual(expect.objectContaining({ id: "mdl_1" }));
+    },
+  );
+});

--- a/extensions/discord/src/monitor/agent-components.modal-presentation-failure.test.ts
+++ b/extensions/discord/src/monitor/agent-components.modal-presentation-failure.test.ts
@@ -1,6 +1,7 @@
-import { ChannelType } from "discord-api-types/v10";
+import { InteractionResponseType, MessageFlags } from "discord-api-types/v10";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildDiscordComponentCustomId } from "../component-custom-id.js";
 import {
   registerDiscordComponentEntries,
   resolveDiscordComponentEntryWithPersistence,
@@ -8,7 +9,12 @@ import {
 } from "../components-registry.js";
 import { clearDiscordComponentEntriesForTest } from "../components-registry.test-support.js";
 import type { DiscordComponentEntry, DiscordModalEntry } from "../components.js";
-import type { ButtonInteraction, ComponentData } from "../internal/discord.js";
+import { ButtonInteraction, createInteraction, type ComponentData } from "../internal/discord.js";
+import {
+  attachRestMock,
+  createInternalComponentInteractionPayload,
+  createInternalTestClient,
+} from "../internal/test-builders.test-support.js";
 import { resetDiscordComponentRuntimeMocks } from "../test-support/component-runtime.js";
 import { createDiscordComponentControls } from "./agent-components.js";
 
@@ -68,35 +74,55 @@ describe("Discord modal presentation failures", () => {
         discordConfig: { replyToMode: "first" },
         token: "token",
       });
-      const showModal = vi.fn().mockRejectedValue(new Error("Discord rejected the modal"));
-      const reply = replyRejects
-        ? vi.fn().mockRejectedValue(new Error("Discord rejected the recovery reply"))
-        : vi.fn().mockResolvedValue(undefined);
-      const interaction = {
-        rawData: { channel_id: "dm-channel", id: "interaction-1" },
-        customId: "occomp:cid=btn_1",
-        client: {
-          rest: {
-            get: vi.fn().mockResolvedValue({ type: ChannelType.DM }),
-            post: vi.fn().mockResolvedValue({}),
-            patch: vi.fn().mockResolvedValue({}),
-            delete: vi.fn().mockResolvedValue(undefined),
+      const post = vi.fn().mockRejectedValueOnce(new Error("Discord rejected the modal"));
+      if (replyRejects) {
+        post.mockRejectedValueOnce(new Error("Discord rejected the recovery reply"));
+      } else {
+        post.mockResolvedValueOnce(undefined);
+      }
+      const client = createInternalTestClient();
+      attachRestMock(client, { post });
+      const interaction = createInteraction(
+        client,
+        createInternalComponentInteractionPayload({
+          id: "interaction-1",
+          token: "interaction-token",
+          channel_id: "dm-channel",
+          user: {
+            id: "123456789",
+            username: "AgentUser",
+            discriminator: "0001",
+            global_name: null,
+            avatar: null,
           },
-        },
-        user: { id: "123456789", username: "AgentUser", discriminator: "0001" },
-        message: { id: "msg-1" },
-        defer: vi.fn().mockResolvedValue(undefined),
-        showModal,
-        reply,
-      } as unknown as ButtonInteraction;
+          data: {
+            custom_id: buildDiscordComponentCustomId({ componentId: "btn_1", modalId: "mdl_1" }),
+          },
+        }),
+      );
+      if (!(interaction instanceof ButtonInteraction)) {
+        throw new Error("expected a Discord button interaction");
+      }
 
       await button.run(interaction, { cid: "btn_1", mid: "mdl_1" } as ComponentData);
 
-      expect(showModal).toHaveBeenCalledOnce();
-      expect(reply).toHaveBeenCalledOnce();
-      expect(reply).toHaveBeenCalledWith({
-        content: "Could not open this form. Request a new form and try again.",
-        ephemeral: true,
+      const callbackPath = "/interactions/interaction-1/interaction-token/callback";
+      expect(post).toHaveBeenCalledTimes(2);
+      expect(post).toHaveBeenNthCalledWith(
+        1,
+        callbackPath,
+        expect.objectContaining({
+          body: expect.objectContaining({ type: InteractionResponseType.Modal }),
+        }),
+      );
+      expect(post).toHaveBeenNthCalledWith(2, callbackPath, {
+        body: {
+          type: InteractionResponseType.ChannelMessageWithSource,
+          data: {
+            content: "Could not open this form. Request a new form and try again.",
+            flags: MessageFlags.Ephemeral,
+          },
+        },
       });
       await expect(
         resolveDiscordComponentEntryWithPersistence({ id: "btn_1", consume: false }),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where clicking a Discord form button could visibly do nothing when Discord rejected the modal presentation.

## Why This Change Was Made

At the existing component-interaction owner, log the original modal failure and reuse the canonical unavailable-interaction helper to send one actionable ephemeral response without altering acknowledgement, consumption, grouping, or persistence.

## User Impact

Users see a clear private instruction to request a new form when a modal cannot open, while expired interactions still fail safely without duplicate callbacks.

## Evidence

47 Discord tests passed, including a real internal Discord interaction and REST callback sequence: failed Modal callback type 9 followed by one ChannelMessageWithSource callback type 4 carrying ephemeral flag 64; both accepted and rejected recovery responses are covered. Sibling interaction and component suites passed. Full changed gate and packaged build passed.

**Integrated trusted-Testbox proof:** 609 tests passed, including five real Chromium extension E2E cases; complete production/test typechecks, lint, plugin-boundary/generated-contract checks, private production build, and four actual ephemeral-Gateway scenarios all passed.

**Owner/risk review:** Uses the helper consolidated on current main; no Discord auth, public SDK, provider contract, or component persistence changes. Production growth is four lines for visible outcome ownership.
