### PR TITLE
fix(testing): install cold-cache Chromium into the path its runner uses

### DIFF
--- a/scripts/ensure-playwright-chromium.mjs
+++ b/scripts/ensure-playwright-chromium.mjs
@@ -2,7 +2,7 @@
 // Ensures Playwright Chromium is installed or a usable system browser is available.
 import { spawnSync as spawnSyncImpl } from "node:child_process";
 import { existsSync as existsSyncImpl, realpathSync } from "node:fs";
-import { resolve } from "node:path";
+import { isAbsolute, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { chromium } from "playwright";
 import { resolveRepoRoot } from "./lib/repo-root.mjs";
@@ -176,6 +176,18 @@ export function isDirectScriptExecution(
  */
 export function ensurePlaywrightChromium(options = {}) {
   const env = options.env ?? process.env;
+  const browserPath = env.PLAYWRIGHT_BROWSERS_PATH;
+  // pnpm --dir ui changes the installer's cwd; keep its cache aligned with the caller.
+  const installEnv =
+    browserPath && browserPath !== "0" && !isAbsolute(browserPath)
+      ? {
+          ...env,
+          PLAYWRIGHT_BROWSERS_PATH: resolve(
+            env.INIT_CWD || options.cwd || process.cwd(),
+            browserPath,
+          ),
+        }
+      : env;
   const requirePlaywrightChromium = options.requirePlaywrightChromium ?? false;
   const executableOverride =
     typeof env[executableOverrideEnvKey] === "string" ? env[executableOverrideEnvKey].trim() : "";
@@ -186,14 +198,14 @@ export function ensurePlaywrightChromium(options = {}) {
   const runPlaywrightInstall = (targets = ["chromium"], withDeps = false) => {
     const runner = resolvePlaywrightInstallRunner({
       comSpec: options.comSpec,
-      env,
+      env: installEnv,
       platform: options.platform,
       targets,
       withDeps,
     });
     const result = spawnSync(runner.command, runner.args, {
       cwd: options.cwd ?? repoRoot,
-      env,
+      env: installEnv,
       shell: runner.shell,
       stdio: options.stdio ?? "inherit",
       windowsVerbatimArguments: runner.windowsVerbatimArguments,

--- a/test/scripts/ensure-playwright-chromium.test.ts
+++ b/test/scripts/ensure-playwright-chromium.test.ts
@@ -1,4 +1,5 @@
 // Ensure Playwright Chromium tests cover ensure playwright chromium script behavior.
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   ensurePlaywrightChromium,
@@ -116,6 +117,90 @@ describe("ensurePlaywrightChromium", () => {
     expect(spawnSync).not.toHaveBeenCalledWith("/usr/bin/chromium-browser", ["--version"], {
       stdio: "ignore",
     });
+  });
+
+  it("installs a relative pinned browser cache in the caller's directory, not the UI package", () => {
+    const callerDirectory = "/repo";
+    const browserCache = path.join(callerDirectory, ".artifacts", "playwright-browsers");
+    const executablePath = path.join(browserCache, "chromium-1234", "chrome-linux64", "chrome");
+    const installedCaches: string[] = [];
+    let installedExecutable: string | undefined;
+    const spawnSync = vi.fn(
+      (command: string, args: string[], options?: Record<string, unknown>) => {
+        if (command === "pnpm" && args.includes("chromium")) {
+          const installerEnv = options?.env as NodeJS.ProcessEnv;
+          const configuredCache = installerEnv.PLAYWRIGHT_BROWSERS_PATH ?? "";
+          const installerDirectory = path.join(String(options?.cwd), "ui");
+          // pnpm --dir ui resolves a relative cache in the UI package, not the caller.
+          const installedCache = path.isAbsolute(configuredCache)
+            ? configuredCache
+            : path.resolve(installerDirectory, configuredCache);
+          installedCaches.push(installedCache);
+          installedExecutable = path.join(
+            installedCache,
+            "chromium-1234",
+            "chrome-linux64",
+            "chrome",
+          );
+          return { status: 0 };
+        }
+        return { status: command === installedExecutable ? 0 : 127 };
+      },
+    );
+
+    const status = ensurePlaywrightChromium({
+      cwd: callerDirectory,
+      env: {
+        INIT_CWD: callerDirectory,
+        OPENCLAW_TESTBOX: "1",
+        PATH: "/bin",
+        PLAYWRIGHT_BROWSERS_PATH: ".artifacts/playwright-browsers",
+      },
+      executablePath,
+      existsSync: (candidate: string) => candidate === installedExecutable,
+      getuid: () => 501,
+      log: vi.fn(),
+      platform: "linux",
+      requirePlaywrightChromium: true,
+      spawnSync,
+      stdio: "pipe",
+    });
+
+    expect({ browserCache: installedCaches[0], status }).toEqual({
+      browserCache,
+      status: 0,
+    });
+  });
+
+  it.each([
+    { configuredPath: undefined, label: "an unset cache path" },
+    { configuredPath: "", label: "an empty cache path" },
+    { configuredPath: "/shared/playwright", label: "an absolute cache path" },
+    { configuredPath: "0", label: "Playwright's package-local cache sentinel" },
+  ])("preserves $label for sibling browser dependency installs", ({ configuredPath }) => {
+    const env: NodeJS.ProcessEnv = { INIT_CWD: "/repo", PATH: "/bin" };
+    if (configuredPath !== undefined) {
+      env.PLAYWRIGHT_BROWSERS_PATH = configuredPath;
+    }
+    const spawnSync = vi.fn(() => ({ status: 0 }));
+
+    expect(
+      ensurePlaywrightChromium({
+        cwd: "/repo",
+        ensureFfmpeg: true,
+        env,
+        executablePath: "/cache/chromium/chrome",
+        existsSync: (candidate: string) => candidate === "/cache/chromium/chrome",
+        spawnSync,
+        stdio: "pipe",
+      }),
+    ).toBe(0);
+    expect(spawnSync).toHaveBeenCalledWith(
+      "pnpm",
+      ["--dir", "ui", "exec", "playwright", "install", "ffmpeg"],
+      expect.objectContaining({ env }),
+    );
+    expect(env.PLAYWRIGHT_BROWSERS_PATH).toBe(configuredPath);
   });
 
   it("installs Playwright ffmpeg when recorded UI tests request it", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where strict browser tests downloaded Chromium successfully but then failed with `refusing system fallback` on a cold cache because the UI-package installer used a different relative cache directory.

## Why This Change Was Made

Normalize only a nonempty, relative, non-sentinel PLAYWRIGHT_BROWSERS_PATH at the canonical installer boundary before handing it to the existing pnpm UI installer; preserve caller environment, unset/empty paths, absolute paths, and Playwright's `0` sentinel.

## User Impact

A fresh remote runner can install and immediately launch the Playwright-managed Chromium required by the browser E2E suite without workarounds or a second download.

## Evidence

Authentic RED reproduced `/repo/ui/.artifacts/playwright-browsers` and status 1 instead of `/repo/.artifacts/playwright-browsers` and status 0. All 26 installer tests, including four upstream-compatibility controls, passed after repair. The actual unchanged `pnpm test:e2e:browser-copilot` command downloaded Chromium into the correct repository cache on a genuinely cold runner and all five real Chromium tests passed. Full changed gate/build passed.

**Integrated trusted-Testbox proof:** 609 tests passed, including five real Chromium extension E2E cases; complete production/test typechecks, lint, plugin-boundary/generated-contract checks, private production build, and four actual ephemeral-Gateway scenarios all passed.

**Owner/risk review:** Owner-local child-process environment only; no package-script/default/config change and no exported script API or `.d.mts` change. Upstream Playwright source directly verified.
