### PR TITLE
fix(doctor): capitalize Gateway in plugin restart guidance

### DIFF
--- a/src/commands/doctor-config-preflight-plugin-verification.test.ts
+++ b/src/commands/doctor-config-preflight-plugin-verification.test.ts
@@ -12,7 +12,7 @@ describe("formatStartupPluginVerificationFailure", () => {
       [
         "OpenClaw plugin verification failed; refusing to report the gateway ready.",
         '- Plugin "discord" has no install path.',
-        "Resolve the plugin verification errors above, then restart the gateway.",
+        "Resolve the plugin verification errors above, then restart the Gateway.",
       ].join("\n"),
     );
   });

--- a/src/commands/doctor-config-preflight-plugin-verification.ts
+++ b/src/commands/doctor-config-preflight-plugin-verification.ts
@@ -221,6 +221,6 @@ export function formatStartupPluginVerificationFailure(
   return [
     "OpenClaw plugin verification failed; refusing to report the gateway ready.",
     ...diagnostic.messages.map((message) => `- ${message}`),
-    "Resolve the plugin verification errors above, then restart the gateway.",
+    "Resolve the plugin verification errors above, then restart the Gateway.",
   ].join("\n");
 }

--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -926,7 +926,7 @@ describe("runDoctorConfigPreflight state migration", () => {
     expect(startupMigrationLeaseRelease).toHaveBeenCalledOnce();
   });
 
-  it("blocks gateway readiness when plugin repair warnings remain", async () => {
+  it("blocks gateway readiness with install-neutral plugin repair guidance", async () => {
     needsStartupMigrationCheckpoint.mockReturnValue(true);
     runPostCorePluginConvergence.mockResolvedValueOnce(
       makeStartupConvergenceResult({
@@ -946,7 +946,11 @@ describe("runDoctorConfigPreflight state migration", () => {
         invalidConfigNote: false,
         requireStartupMigrationCheckpoint: true,
       }),
-    ).rejects.toThrow("Configured plugin discord is not installed");
+    ).rejects.toThrow(
+      "OpenClaw plugin verification failed; refusing to report the gateway ready.\n" +
+        "- Configured plugin discord is not installed. Run `openclaw update repair` to retry plugin repair.\n" +
+        "Resolve the plugin verification errors above, then restart the Gateway.",
+    );
 
     expect(recordSuccessfulStateMigrations).toHaveBeenCalledWith({
       env: acquireStartupMigrationLease.mock.calls[0]?.[0]?.env,

--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -926,7 +926,7 @@ describe("runDoctorConfigPreflight state migration", () => {
     expect(startupMigrationLeaseRelease).toHaveBeenCalledOnce();
   });
 
-  it("blocks gateway readiness with install-neutral plugin repair guidance", async () => {
+  it("blocks gateway readiness when plugin repair warnings remain", async () => {
     needsStartupMigrationCheckpoint.mockReturnValue(true);
     runPostCorePluginConvergence.mockResolvedValueOnce(
       makeStartupConvergenceResult({
@@ -946,11 +946,7 @@ describe("runDoctorConfigPreflight state migration", () => {
         invalidConfigNote: false,
         requireStartupMigrationCheckpoint: true,
       }),
-    ).rejects.toThrow(
-      "OpenClaw plugin verification failed; refusing to report the gateway ready.\n" +
-        "- Configured plugin discord is not installed. Run `openclaw update repair` to retry plugin repair.\n" +
-        "Resolve the plugin verification errors above, then restart the Gateway.",
-    );
+    ).rejects.toThrow("Configured plugin discord is not installed");
 
     expect(recordSuccessfulStateMigrations).toHaveBeenCalledWith({
       env: acquireStartupMigrationLease.mock.calls[0]?.[0]?.env,


### PR DESCRIPTION
Related: #119508

## What Problem This Solves

Fixes an operator-visible wording inconsistency where the plugin-verification startup refusal referred to the OpenClaw Gateway as lowercase "gateway" after the install-neutral remediation landed.

## Why This Change Was Made

The recovery guidance now uses the product surface name "Gateway" while preserving #119508's install-method-agnostic restart instruction. This does not change the separate generic startup-migration wording or state-directory migration classification.

## User Impact

Operators continue to receive guidance that works for container, npm, launchd, systemd, and externally supervised installs, with consistent OpenClaw Gateway naming.

## Evidence

- `node scripts/run-vitest.mjs src/commands/doctor-config-preflight-plugin-verification.test.ts src/commands/doctor-config-preflight.state-migration.test.ts` — 30 tests passed across 2 shards.
- `node scripts/run-oxlint.mjs src/commands/doctor-config-preflight-plugin-verification.test.ts src/commands/doctor-config-preflight-plugin-verification.ts` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Codex autoreview of the exact branch diff — clean, no accepted/actionable findings.

AI-assisted: built with Claude Code and Codex autoreview.
