### PR TITLE
fix(qa): stop treating deleted messages and failed streams as successful replies

### DIFF
--- a/extensions/qa-lab/src/bus-state.test.ts
+++ b/extensions/qa-lab/src/bus-state.test.ts
@@ -482,6 +482,37 @@ describe("qa-bus state", () => {
     ).rejects.toThrow("qa-bus wait timeout");
   });
 
+  it("ignores deleted message matches until a visible replacement arrives", async () => {
+    const state = createQaBusState();
+    const deleted = state.addOutboundMessage({
+      to: "dm:alice",
+      text: "QA-VISIBLE-REPLACEMENT",
+    });
+    state.deleteMessage({ messageId: deleted.id });
+
+    await expect(
+      state.waitFor({
+        direction: "outbound",
+        kind: "message-text",
+        textIncludes: "QA-VISIBLE-REPLACEMENT",
+        timeoutMs: 10,
+      }),
+    ).rejects.toThrow("qa-bus wait timeout after 10ms");
+
+    const pending = state.waitFor({
+      direction: "outbound",
+      kind: "message-text",
+      textIncludes: "QA-VISIBLE-REPLACEMENT",
+      timeoutMs: 100,
+    });
+    const replacement = state.addOutboundMessage({
+      to: "dm:alice",
+      text: "QA-VISIBLE-REPLACEMENT",
+    });
+
+    await expect(pending).resolves.toMatchObject({ id: replacement.id, direction: "outbound" });
+  });
+
   it("caps oversized wait timers", async () => {
     vi.useFakeTimers();
     const timeoutSpy = vi.spyOn(globalThis, "setTimeout");

--- a/extensions/qa-lab/src/bus-waiters.ts
+++ b/extensions/qa-lab/src/bus-waiters.ts
@@ -40,6 +40,7 @@ function createQaBusMatcher(
     return (
       snapshot.messages.find(
         (message) =>
+          !message.deleted &&
           (!input.direction || message.direction === input.direction) &&
           message.text.includes(input.textIncludes),
       ) ?? null

--- a/extensions/qa-lab/src/qa-transport.test.ts
+++ b/extensions/qa-lab/src/qa-transport.test.ts
@@ -136,6 +136,105 @@ describe("waitForQaTransportOutboundSequence", () => {
     });
   });
 
+  it.each([
+    { description: "before the final marker", failureBeforeFinal: true },
+    { description: "after the final marker", failureBeforeFinal: false },
+  ])("rejects an owned-account failure reply $description", async ({ failureBeforeFinal }) => {
+    const state = createQaBusState();
+    const preview = state.addOutboundMessage({
+      accountId: "default",
+      to: "dm:alice",
+      text: "owned preview",
+    });
+    const addFailure = () =>
+      state.addOutboundMessage({
+        accountId: "default",
+        to: "dm:alice",
+        text: "⚠️ agent failed before reply: provider rejected this request",
+      });
+
+    if (failureBeforeFinal) {
+      addFailure();
+    }
+    state.editMessage({
+      accountId: "default",
+      messageId: preview.id,
+      text: "final marker",
+    });
+    if (!failureBeforeFinal) {
+      addFailure();
+    }
+
+    await expect(
+      waitForQaTransportOutboundSequence({
+        accountId: "default",
+        input: {
+          conversationId: "alice",
+          finalSettleMs: 0,
+          finalTextIncludes: "final marker",
+          minimumPreviewEvents: 1,
+          timeoutMs: 25,
+        },
+        readEvents: () => state.getSnapshot().events,
+      }),
+    ).rejects.toThrow("provider rejected this request");
+  });
+
+  it("ignores stale, foreign-account, and inbound failure replies", async () => {
+    const state = createQaBusState();
+    state.addOutboundMessage({
+      accountId: "default",
+      to: "dm:alice",
+      text: "⚠️ agent failed before reply: stale failure",
+    });
+    const sinceCursor = state.getSnapshot().cursor;
+
+    state.addOutboundMessage({
+      accountId: "other",
+      to: "dm:alice",
+      text: "⚠️ agent failed before reply: foreign account failure",
+    });
+    const inbound = state.addInboundMessage({
+      accountId: "default",
+      conversation: { id: "alice", kind: "direct" },
+      senderId: "alice",
+      text: "⚠️ agent failed before reply: inbound failure",
+    });
+    state.editMessage({
+      accountId: "default",
+      messageId: inbound.id,
+      text: "⚠️ agent failed before reply: edited inbound failure",
+    });
+    const preview = state.addOutboundMessage({
+      accountId: "default",
+      to: "dm:alice",
+      text: "owned preview",
+    });
+    state.editMessage({
+      accountId: "default",
+      messageId: preview.id,
+      text: "final marker",
+    });
+
+    await expect(
+      waitForQaTransportOutboundSequence({
+        accountId: "default",
+        input: {
+          conversationId: "alice",
+          finalSettleMs: 0,
+          finalTextIncludes: "final marker",
+          minimumPreviewEvents: 1,
+          sinceCursor,
+          timeoutMs: 25,
+        },
+        readEvents: () => state.getSnapshot().events,
+      }),
+    ).resolves.toMatchObject({
+      events: [{ kind: "sent" }, { kind: "edited" }],
+      final: { accountId: "default", direction: "outbound", id: preview.id },
+    });
+  });
+
   it("does not accept a matching preview that is deleted during final settling", async () => {
     const state = createQaBusState();
     const preview = state.addOutboundMessage({

--- a/extensions/qa-lab/src/qa-transport.ts
+++ b/extensions/qa-lab/src/qa-transport.ts
@@ -494,24 +494,29 @@ export async function waitForQaTransportOutboundSequence(params: {
   let stableCursor: number | null = null;
   let stableSince = 0;
   return await waitForQaTransportCondition(async () => {
-    const events = (await params.readEvents())
+    const ownedEvents = (await params.readEvents())
       .filter((event) => event.cursor > (params.input.sinceCursor ?? 0))
       .map((event) =>
         isQaTransportOutboundEvent(event) ? event : normalizeQaBusOutboundEvent(event),
       )
       .filter((event): event is QaTransportOutboundEvent => event !== null)
-      .filter(({ message }) => {
-        if (message.accountId !== params.accountId || message.direction !== "outbound") {
-          return false;
-        }
-        if (
-          params.input.conversationId &&
-          message.conversation.id !== params.input.conversationId
-        ) {
-          return false;
-        }
-        return !params.input.threadId || message.threadId === params.input.threadId;
-      });
+      .filter(
+        ({ message }) => message.accountId === params.accountId && message.direction === "outbound",
+      );
+    // Failures belong to the account, even when a different conversation has a matching final.
+    for (const { kind, message } of ownedEvents) {
+      const failureReply =
+        kind === "deleted" || message.deleted ? undefined : extractQaFailureReplyText(message.text);
+      if (failureReply) {
+        throw new Error(failureReply);
+      }
+    }
+    const events = ownedEvents.filter(({ message }) => {
+      if (params.input.conversationId && message.conversation.id !== params.input.conversationId) {
+        return false;
+      }
+      return !params.input.threadId || message.threadId === params.input.threadId;
+    });
     const finalIndex = events.findLastIndex(
       ({ kind, message }) =>
         kind !== "deleted" &&


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where QA channel checks could pass using a deleted reply tombstone or accept a normal-looking streaming final even though the same account emitted an actionable failure.

## Why This Change Was Made

Exclude deleted messages at the canonical bus message waiter and check canonical owned-account failure replies before applying streaming conversation/thread filters, while preserving outbound/account/cursor isolation.

## User Impact

Channel verdicts now require a genuinely visible successful reply and fail immediately with the actual provider error instead of producing a false green.

## Evidence

Authentic RED showed deleted tombstones resolving as visible messages and failure-before/failure-after streams passing. All 33 bus/transport tests now pass, including replacement delivery and stale/foreign/inbound controls. Actual mock-provider ephemeral Gateways passed `channel-message-flows` (preview -> final) and `reaction-edit-delete`, with four total Gateway scenarios passing. Full changed gate/build passed.

**Integrated trusted-Testbox proof:** 609 tests passed, including five real Chromium extension E2E cases; complete production/test typechecks, lint, plugin-boundary/generated-contract checks, private production build, and four actual ephemeral-Gateway scenarios all passed.

**Owner/risk review:** Private QA transport owner only; no plugin SDK, auth, config, public protocol, or persistence changes. Production net +6 lines justified by visible-message and account-owned failure invariants.
