### PR TITLE
fix(qa): require a fresh reply and real tool use after switching models

### DIFF
--- a/extensions/codex/src/app-server/event-projector-assistant.ts
+++ b/extensions/codex/src/app-server/event-projector-assistant.ts
@@ -36,6 +36,7 @@ export class CodexAssistantProjection {
   // would drop legitimate verbatim answers ("reply with exactly the command output").
   private readonly rawPromotedAssistantItemIds = new Set<string>();
   private assistantStarted = false;
+  private responseModel: string | undefined;
   private streamedPartialAssistantItemId: string | undefined;
   private streamedPartialAssistantItemReplaceable = false;
 
@@ -83,6 +84,12 @@ export class CodexAssistantProjection {
       this.latestTerminalAssistantCandidateCanReleaseAfterToolHandoff &&
       this.hasLatestTerminalAssistantCandidateText()
     );
+  }
+
+  handleNotification(method: string, params: JsonObject): void {
+    if (method === "model/rerouted") {
+      this.responseModel = readString(params, "toModel") ?? this.responseModel;
+    }
   }
 
   async handleAssistantDelta(params: JsonObject): Promise<void> {
@@ -397,7 +404,8 @@ export class CodexAssistantProjection {
   }
 
   createAssistantMessage(text: string, options: AssistantMessageOptions): AssistantMessage {
-    return buildAssistantMessage(this.params, text, options);
+    const message = buildAssistantMessage(this.params, text, options);
+    return this.responseModel ? { ...message, responseModel: this.responseModel } : message;
   }
 
   createAssistantMirrorMessage(title: string, text: string): AssistantMessage {

--- a/extensions/codex/src/app-server/event-projector-tool-progress.ts
+++ b/extensions/codex/src/app-server/event-projector-tool-progress.ts
@@ -7,6 +7,7 @@ import {
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { EmbeddedRunAttemptResult } from "./attempt-terminal.js";
 import {
+  auditNativeToolTerminalStatus,
   isMutatingNativeToolItem,
   isNonSuccessItemStatus,
   isSideEffectingNativeToolItem,
@@ -167,7 +168,7 @@ export class CodexToolProgressProjection {
       toolName: existing?.toolName ?? params.tool,
       ...(existing?.meta ? { meta: existing.meta } : {}),
       ...(params.asyncStarted === true ? { asyncStarted: true } : {}),
-      ...(!params.success ? { isError: true } : {}),
+      isError: !params.success,
     });
     if (params.terminalResolution) {
       this.lastNativeToolError = params.terminalResolution.lastToolError;
@@ -347,13 +348,21 @@ export class CodexToolProgressProjection {
       return;
     }
     const meta = itemMeta(item, this.toolProgressDetailMode());
-    const status = itemStatus(item);
     const existing = this.metas.get(item.id);
+    const terminalStatus = auditNativeToolTerminalStatus(item);
+    const isError =
+      typeof existing?.isError === "boolean"
+        ? existing.isError
+        : terminalStatus === "completed"
+          ? false
+          : terminalStatus === "failed" || terminalStatus === "blocked"
+            ? true
+            : undefined;
     this.metas.set(item.id, {
       toolName,
       ...(meta ? { meta } : {}),
       ...(existing?.asyncStarted ? { asyncStarted: true } : {}),
-      ...(status !== "running" && isNonSuccessItemStatus(status) ? { isError: true } : {}),
+      ...(isError === undefined ? {} : { isError }),
     });
   }
 

--- a/extensions/codex/src/app-server/event-projector.assistant.test.ts
+++ b/extensions/codex/src/app-server/event-projector.assistant.test.ts
@@ -86,6 +86,28 @@ describe("CodexAppServerEventProjector assistant projection", () => {
     expect(result.replayMetadata.replaySafe).toBe(true);
   });
 
+  it("projects a current-turn model reroute onto the terminal assistant", async () => {
+    const projector = await createProjector();
+    await projector.handleNotification(
+      forCurrentTurn("model/rerouted", {
+        fromModel: "gpt-5.4-codex",
+        toModel: "gpt-5.4-codex-mini",
+        reason: "high_risk_cyber_activity",
+      }),
+    );
+    await projector.handleNotification(
+      turnCompleted([{ type: "agentMessage", id: "msg-rerouted", text: "done" }]),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+
+    expect(result.currentAttemptAssistant?.responseModel).toBe("gpt-5.4-codex-mini");
+    expect(result.lastAssistant?.responseModel).toBe("gpt-5.4-codex-mini");
+    expect(result).toMatchObject({
+      terminalTurnId: "turn-1",
+    });
+  });
+
   it("keeps reopened final answers as Activity candidates until turn completion selects one", async () => {
     const onAgentEvent = vi.fn();
     const projector = await createProjector({

--- a/extensions/codex/src/app-server/event-projector.dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/event-projector.dynamic-tools.test.ts
@@ -39,6 +39,7 @@ describe("CodexAppServerEventProjector dynamic tool projection", () => {
 
     const result = projector.buildResult(buildEmptyToolTelemetry());
 
+    expect(result.toolMetas).toEqual([{ toolName: "browser", isError: false }]);
     expect(result.messagesSnapshot.map((message) => message.role)).toEqual([
       "user",
       "assistant",
@@ -219,6 +220,7 @@ describe("CodexAppServerEventProjector dynamic tool projection", () => {
         toolName: "image_generate",
         meta: "lighthouse",
         asyncStarted: true,
+        isError: false,
       },
     ]);
     expect(result.replayMetadata).toEqual({

--- a/extensions/codex/src/app-server/event-projector.native-finalization.test.ts
+++ b/extensions/codex/src/app-server/event-projector.native-finalization.test.ts
@@ -23,6 +23,35 @@ import {
 registerCodexEventProjectorTestLifecycle();
 
 describe("CodexAppServerEventProjector native tool finalization", () => {
+  it("marks only explicitly completed native tool metadata with false", async () => {
+    const projector = await createProjector();
+    const command = {
+      type: "commandExecution",
+      command: "pnpm test extensions/codex",
+      cwd: "/workspace",
+      processId: null,
+      source: "agent",
+      commandActions: [],
+      aggregatedOutput: null,
+      exitCode: null,
+      durationMs: null,
+    };
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: { ...command, id: "cmd-started-only", status: "inProgress" },
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: { ...command, id: "cmd-completed", status: "completed" },
+      }),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    expect(result.toolMetas.map((meta) => meta.isError)).toEqual([undefined, false]);
+  });
+
   it("keeps raw open-page status unknown until explicit completion", async () => {
     const diagnosticEvents: DiagnosticEventPayload[] = [];
     const unsubscribe = onInternalDiagnosticEvent((event) => diagnosticEvents.push(event));

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -222,7 +222,7 @@ export class CodexAppServerEventProjector {
     if (!params) {
       return;
     }
-    if (isHookNotificationMethod(notification.method)) {
+    if (notification.method === "hook/started" || notification.method === "hook/completed") {
       if (!this.isHookNotificationForCurrentThread(params)) {
         return;
       }
@@ -235,6 +235,7 @@ export class CodexAppServerEventProjector {
       return;
     }
     this.nativeToolLifecycleProjector.handleNotification(notification);
+    this.assistantProjection.handleNotification(notification.method, params);
 
     switch (notification.method) {
       case "item/agentMessage/delta":
@@ -317,7 +318,7 @@ export class CodexAppServerEventProjector {
   buildResult(
     toolTelemetry: CodexAppServerToolTelemetry,
     options?: { yieldDetected?: boolean },
-  ): EmbeddedRunAttemptResult {
+  ): EmbeddedRunAttemptResult & { terminalTurnId: string } {
     // Result construction runs after the notification queue drains. Close any
     // tool lacking a terminal item so audit consumers never retain an open action.
     this.nativeToolLifecycleProjector.finalizeActive();
@@ -413,6 +414,7 @@ export class CodexAppServerEventProjector {
         promptErrorSource: promptError ? this.promptErrorSource || "prompt" : null,
       }),
       sessionIdUsed: this.params.sessionId,
+      terminalTurnId: this.turnId,
       ...(agentHarnessResultClassification ? { agentHarnessResultClassification } : {}),
       bootstrapPromptWarningSignaturesSeen: this.params.bootstrapPromptWarningSignaturesSeen,
       bootstrapPromptWarningSignature: this.params.bootstrapPromptWarningSignature,
@@ -758,8 +760,4 @@ export class CodexAppServerEventProjector {
     const turnId = params.turnId;
     return threadId === this.threadId && (turnId === this.turnId || turnId === null);
   }
-}
-
-function isHookNotificationMethod(method: string): method is "hook/started" | "hook/completed" {
-  return method === "hook/started" || method === "hook/completed";
 }

--- a/extensions/copilot/src/attempt.test.ts
+++ b/extensions/copilot/src/attempt.test.ts
@@ -1506,7 +1506,7 @@ describe("runCopilotAttempt", () => {
 
     const result = await runCopilotAttempt(makeParams(), { pool });
 
-    expect(result.toolMetas).toEqual([{ meta: "wrote file", toolName: "write" }]);
+    expect(result.toolMetas).toEqual([{ meta: "wrote file", toolName: "write", isError: false }]);
     expect(result.replayMetadata).toEqual({
       hadPotentialSideEffects: true,
       replaySafe: false,

--- a/extensions/copilot/src/event-bridge.test.ts
+++ b/extensions/copilot/src/event-bridge.test.ts
@@ -195,7 +195,9 @@ describe("attachEventBridge", () => {
 
     expect(bridge.snapshot().assistantTexts).toEqual(["root"]);
     expect(bridge.snapshot().startedCount).toBe(0);
-    expect(bridge.snapshot().toolMetas).toEqual([{ meta: "child write", toolName: "write" }]);
+    expect(bridge.snapshot().toolMetas).toEqual([
+      { meta: "child write", toolName: "write", isError: false },
+    ]);
     expect(
       bridge.recordSendResult({
         ...makeAssistantMessageEvent("child final"),
@@ -797,7 +799,7 @@ describe("attachEventBridge", () => {
     );
 
     expect(bridge.snapshot().toolMetas).toEqual([
-      { meta: "details", toolName: "bash" },
+      { meta: "details", toolName: "bash", isError: false },
       { meta: "failed", toolName: "read", isError: true },
     ]);
   });

--- a/extensions/copilot/src/event-bridge.ts
+++ b/extensions/copilot/src/event-bridge.ts
@@ -350,7 +350,7 @@ export function attachEventBridge(
       toolMetas[toolMetaIndex] = {
         ...(meta ? { meta } : {}),
         toolName,
-        ...(event.data.success ? {} : { isError: true }),
+        isError: !event.data.success,
       };
     }
     const projection = options.transcriptProjection;

--- a/extensions/qa-lab/src/crabline-transport.test.ts
+++ b/extensions/qa-lab/src/crabline-transport.test.ts
@@ -28,6 +28,31 @@ function requireString(value: unknown, label: string): string {
   return value;
 }
 
+type CrablineTransport = Awaited<ReturnType<typeof createQaCrablineTransportAdapter>>;
+
+function resolveTelegramApi(transport: CrablineTransport) {
+  const config = transport.createGatewayConfig({ baseUrl: "http://127.0.0.1:1" });
+  const telegram = config.channels?.telegram as { apiRoot?: string; botToken?: string } | undefined;
+  return {
+    apiRoot: requireString(telegram?.apiRoot, "Telegram API root"),
+    botToken: requireString(telegram?.botToken, "Telegram bot token"),
+  };
+}
+
+async function postTelegram(
+  api: ReturnType<typeof resolveTelegramApi>,
+  method: string,
+  body: Record<string, unknown>,
+) {
+  const response = await fetch(`${api.apiRoot}/bot${api.botToken}/${method}`, {
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  });
+  expect(response.ok).toBe(true);
+  return (await response.json()) as { result: { message_id: number } };
+}
+
 describe("crabline transport", () => {
   it("cancels a failed inbound response before surfacing the provider error", async () => {
     await withTempDir("qa-crabline-transport-", async (outputDir) => {
@@ -149,13 +174,8 @@ describe("crabline transport", () => {
           text: "driver",
         });
 
-        const config = transport.createGatewayConfig({ baseUrl: "http://127.0.0.1:1" });
-        const telegram = config.channels?.telegram as
-          | { apiRoot?: string; botToken?: string }
-          | undefined;
-        const apiRoot = requireString(telegram?.apiRoot, "Telegram API root");
-        const botToken = requireString(telegram?.botToken, "Telegram bot token");
-        const response = await fetch(`${apiRoot}/bot${botToken}/getUpdates`);
+        const api = resolveTelegramApi(transport);
+        const response = await fetch(`${api.apiRoot}/bot${api.botToken}/getUpdates`);
         const payload = (await response.json()) as {
           result?: Array<{ message?: { from?: { id?: number }; text?: string } }>;
         };
@@ -203,13 +223,8 @@ describe("crabline transport", () => {
           nativeCommand: { name: "status" },
         });
 
-        const config = transport.createGatewayConfig({ baseUrl: "http://127.0.0.1:1" });
-        const telegram = config.channels?.telegram as
-          | { apiRoot?: string; botToken?: string }
-          | undefined;
-        const apiRoot = requireString(telegram?.apiRoot, "Telegram API root");
-        const botToken = requireString(telegram?.botToken, "Telegram bot token");
-        const response = await fetch(`${apiRoot}/bot${botToken}/getUpdates`);
+        const api = resolveTelegramApi(transport);
+        const response = await fetch(`${api.apiRoot}/bot${api.botToken}/getUpdates`);
         await expect(response.json()).resolves.toMatchObject({
           result: [
             {
@@ -232,6 +247,63 @@ describe("crabline transport", () => {
     });
   });
 
+  it("projects Telegram HTML as visible text without changing raw recorder events", async () => {
+    await withTempDir("qa-crabline-transport-", async (outputDir) => {
+      const transport = await createQaCrablineTransportAdapter({
+        outputDir,
+        selection: createSelection(),
+        state: createQaBusState(),
+      });
+
+      try {
+        const api = resolveTelegramApi(transport);
+        const html = "Use <code>QA_KICKOFF_TASK.md</code> &amp; continue";
+        const raw = "Raw <code>QA_KICKOFF_TASK.md</code> &amp; unchanged";
+        const cases = [
+          { text: html, parseMode: "hTmL", expected: "Use QA_KICKOFF_TASK.md & continue" },
+          { text: raw, parseMode: undefined, expected: raw },
+        ] as const;
+        for (const testCase of cases) {
+          await transport.state.reset();
+          await postTelegram(api, "sendMessage", {
+            chat_id: "-1001234567890",
+            ...(testCase.parseMode ? { parse_mode: testCase.parseMode } : {}),
+            text: testCase.text,
+          });
+          expect(transport.state.getSnapshot().messages.at(-1)?.text).toBe(testCase.expected);
+          await expect(
+            transport.waitForOutboundSequence!({
+              conversationId: "-1001234567890",
+              finalSettleMs: 0,
+              finalTextIncludes: testCase.expected,
+              minimumPreviewEvents: 0,
+              timeoutMs: 1_000,
+            }),
+          ).resolves.toMatchObject({
+            events: [{ message: { text: testCase.expected } }],
+            final: { text: testCase.expected },
+          });
+        }
+        const recorderEvents = (
+          await fs.readFile(
+            path.join(outputDir, "artifacts", "crabline", "telegram-fake-provider.jsonl"),
+            "utf8",
+          )
+        )
+          .trim()
+          .split(/\r?\n/u)
+          .map((line) => JSON.parse(line) as unknown);
+        expect(recorderEvents).toContainEqual(
+          expect.objectContaining({
+            body: expect.objectContaining({ parse_mode: "hTmL", text: html }),
+          }),
+        );
+      } finally {
+        await transport.cleanup?.();
+      }
+    });
+  });
+
   it("observes Telegram preview edits through the shared transport adapter", async () => {
     await withTempDir("qa-crabline-transport-", async (outputDir) => {
       const transport = await createQaCrablineTransportAdapter({
@@ -241,22 +313,8 @@ describe("crabline transport", () => {
       });
 
       try {
-        const config = transport.createGatewayConfig({ baseUrl: "http://127.0.0.1:1" });
-        const telegram = config.channels?.telegram as
-          | { apiRoot?: string; botToken?: string }
-          | undefined;
-        const apiRoot = requireString(telegram?.apiRoot, "Telegram API root");
-        const botToken = requireString(telegram?.botToken, "Telegram bot token");
-        const postTelegram = async (method: string, body: Record<string, unknown>) => {
-          const response = await fetch(`${apiRoot}/bot${botToken}/${method}`, {
-            body: JSON.stringify(body),
-            headers: { "content-type": "application/json" },
-            method: "POST",
-          });
-          expect(response.ok).toBe(true);
-          return (await response.json()) as { result: { message_id: number } };
-        };
-        const sent = await postTelegram("sendMessage", {
+        const api = resolveTelegramApi(transport);
+        const sent = await postTelegram(api, "sendMessage", {
           chat_id: "-1001234567890",
           message_thread_id: 42,
           text: "preview text",
@@ -264,7 +322,7 @@ describe("crabline transport", () => {
         expect(transport.state.searchMessages({ query: "preview text" })).toEqual([
           expect.objectContaining({ text: "preview text" }),
         ]);
-        await postTelegram("editMessageText", {
+        await postTelegram(api, "editMessageText", {
           chat_id: "-1001234567890",
           message_id: sent.result.message_id,
           text: "final marker",
@@ -932,14 +990,9 @@ describe("crabline transport", () => {
           text: "Channel baseline marker check.",
         });
 
-        const config = transport.createGatewayConfig({ baseUrl: "http://127.0.0.1:1" });
-        const telegram = config.channels?.telegram as
-          | { apiRoot?: string; botToken?: string }
-          | undefined;
-        expect(telegram?.apiRoot).toBeTruthy();
-        expect(telegram?.botToken).toBeTruthy();
+        const api = resolveTelegramApi(transport);
         const { response, release } = await fetchWithSsrFGuard({
-          url: `${telegram?.apiRoot}/bot${telegram?.botToken}/sendMessage`,
+          url: `${api.apiRoot}/bot${api.botToken}/sendMessage`,
           init: {
             body: JSON.stringify({
               chat_id: inbound.conversation.id,
@@ -972,7 +1025,7 @@ describe("crabline transport", () => {
         await transport.state.reset();
         const delivery = transport.buildAgentDelivery({ target: "dm:qa-operator" });
         const { response: directResponse, release: directRelease } = await fetchWithSsrFGuard({
-          url: `${telegram?.apiRoot}/bot${telegram?.botToken}/sendMessage`,
+          url: `${api.apiRoot}/bot${api.botToken}/sendMessage`,
           init: {
             body: JSON.stringify({
               chat_id: delivery.to,

--- a/extensions/qa-lab/src/crabline-transport.test.ts
+++ b/extensions/qa-lab/src/crabline-transport.test.ts
@@ -28,31 +28,6 @@ function requireString(value: unknown, label: string): string {
   return value;
 }
 
-type CrablineTransport = Awaited<ReturnType<typeof createQaCrablineTransportAdapter>>;
-
-function resolveTelegramApi(transport: CrablineTransport) {
-  const config = transport.createGatewayConfig({ baseUrl: "http://127.0.0.1:1" });
-  const telegram = config.channels?.telegram as { apiRoot?: string; botToken?: string } | undefined;
-  return {
-    apiRoot: requireString(telegram?.apiRoot, "Telegram API root"),
-    botToken: requireString(telegram?.botToken, "Telegram bot token"),
-  };
-}
-
-async function postTelegram(
-  api: ReturnType<typeof resolveTelegramApi>,
-  method: string,
-  body: Record<string, unknown>,
-) {
-  const response = await fetch(`${api.apiRoot}/bot${api.botToken}/${method}`, {
-    body: JSON.stringify(body),
-    headers: { "content-type": "application/json" },
-    method: "POST",
-  });
-  expect(response.ok).toBe(true);
-  return (await response.json()) as { result: { message_id: number } };
-}
-
 describe("crabline transport", () => {
   it("cancels a failed inbound response before surfacing the provider error", async () => {
     await withTempDir("qa-crabline-transport-", async (outputDir) => {
@@ -174,8 +149,13 @@ describe("crabline transport", () => {
           text: "driver",
         });
 
-        const api = resolveTelegramApi(transport);
-        const response = await fetch(`${api.apiRoot}/bot${api.botToken}/getUpdates`);
+        const config = transport.createGatewayConfig({ baseUrl: "http://127.0.0.1:1" });
+        const telegram = config.channels?.telegram as
+          | { apiRoot?: string; botToken?: string }
+          | undefined;
+        const apiRoot = requireString(telegram?.apiRoot, "Telegram API root");
+        const botToken = requireString(telegram?.botToken, "Telegram bot token");
+        const response = await fetch(`${apiRoot}/bot${botToken}/getUpdates`);
         const payload = (await response.json()) as {
           result?: Array<{ message?: { from?: { id?: number }; text?: string } }>;
         };
@@ -223,8 +203,13 @@ describe("crabline transport", () => {
           nativeCommand: { name: "status" },
         });
 
-        const api = resolveTelegramApi(transport);
-        const response = await fetch(`${api.apiRoot}/bot${api.botToken}/getUpdates`);
+        const config = transport.createGatewayConfig({ baseUrl: "http://127.0.0.1:1" });
+        const telegram = config.channels?.telegram as
+          | { apiRoot?: string; botToken?: string }
+          | undefined;
+        const apiRoot = requireString(telegram?.apiRoot, "Telegram API root");
+        const botToken = requireString(telegram?.botToken, "Telegram bot token");
+        const response = await fetch(`${apiRoot}/bot${botToken}/getUpdates`);
         await expect(response.json()).resolves.toMatchObject({
           result: [
             {
@@ -247,63 +232,6 @@ describe("crabline transport", () => {
     });
   });
 
-  it("projects Telegram HTML as visible text without changing raw recorder events", async () => {
-    await withTempDir("qa-crabline-transport-", async (outputDir) => {
-      const transport = await createQaCrablineTransportAdapter({
-        outputDir,
-        selection: createSelection(),
-        state: createQaBusState(),
-      });
-
-      try {
-        const api = resolveTelegramApi(transport);
-        const html = "Use <code>QA_KICKOFF_TASK.md</code> &amp; continue";
-        const raw = "Raw <code>QA_KICKOFF_TASK.md</code> &amp; unchanged";
-        const cases = [
-          { text: html, parseMode: "hTmL", expected: "Use QA_KICKOFF_TASK.md & continue" },
-          { text: raw, parseMode: undefined, expected: raw },
-        ] as const;
-        for (const testCase of cases) {
-          await transport.state.reset();
-          await postTelegram(api, "sendMessage", {
-            chat_id: "-1001234567890",
-            ...(testCase.parseMode ? { parse_mode: testCase.parseMode } : {}),
-            text: testCase.text,
-          });
-          expect(transport.state.getSnapshot().messages.at(-1)?.text).toBe(testCase.expected);
-          await expect(
-            transport.waitForOutboundSequence!({
-              conversationId: "-1001234567890",
-              finalSettleMs: 0,
-              finalTextIncludes: testCase.expected,
-              minimumPreviewEvents: 0,
-              timeoutMs: 1_000,
-            }),
-          ).resolves.toMatchObject({
-            events: [{ message: { text: testCase.expected } }],
-            final: { text: testCase.expected },
-          });
-        }
-        const recorderEvents = (
-          await fs.readFile(
-            path.join(outputDir, "artifacts", "crabline", "telegram-fake-provider.jsonl"),
-            "utf8",
-          )
-        )
-          .trim()
-          .split(/\r?\n/u)
-          .map((line) => JSON.parse(line) as unknown);
-        expect(recorderEvents).toContainEqual(
-          expect.objectContaining({
-            body: expect.objectContaining({ parse_mode: "hTmL", text: html }),
-          }),
-        );
-      } finally {
-        await transport.cleanup?.();
-      }
-    });
-  });
-
   it("observes Telegram preview edits through the shared transport adapter", async () => {
     await withTempDir("qa-crabline-transport-", async (outputDir) => {
       const transport = await createQaCrablineTransportAdapter({
@@ -313,8 +241,22 @@ describe("crabline transport", () => {
       });
 
       try {
-        const api = resolveTelegramApi(transport);
-        const sent = await postTelegram(api, "sendMessage", {
+        const config = transport.createGatewayConfig({ baseUrl: "http://127.0.0.1:1" });
+        const telegram = config.channels?.telegram as
+          | { apiRoot?: string; botToken?: string }
+          | undefined;
+        const apiRoot = requireString(telegram?.apiRoot, "Telegram API root");
+        const botToken = requireString(telegram?.botToken, "Telegram bot token");
+        const postTelegram = async (method: string, body: Record<string, unknown>) => {
+          const response = await fetch(`${apiRoot}/bot${botToken}/${method}`, {
+            body: JSON.stringify(body),
+            headers: { "content-type": "application/json" },
+            method: "POST",
+          });
+          expect(response.ok).toBe(true);
+          return (await response.json()) as { result: { message_id: number } };
+        };
+        const sent = await postTelegram("sendMessage", {
           chat_id: "-1001234567890",
           message_thread_id: 42,
           text: "preview text",
@@ -322,7 +264,7 @@ describe("crabline transport", () => {
         expect(transport.state.searchMessages({ query: "preview text" })).toEqual([
           expect.objectContaining({ text: "preview text" }),
         ]);
-        await postTelegram(api, "editMessageText", {
+        await postTelegram("editMessageText", {
           chat_id: "-1001234567890",
           message_id: sent.result.message_id,
           text: "final marker",
@@ -990,9 +932,14 @@ describe("crabline transport", () => {
           text: "Channel baseline marker check.",
         });
 
-        const api = resolveTelegramApi(transport);
+        const config = transport.createGatewayConfig({ baseUrl: "http://127.0.0.1:1" });
+        const telegram = config.channels?.telegram as
+          | { apiRoot?: string; botToken?: string }
+          | undefined;
+        expect(telegram?.apiRoot).toBeTruthy();
+        expect(telegram?.botToken).toBeTruthy();
         const { response, release } = await fetchWithSsrFGuard({
-          url: `${api.apiRoot}/bot${api.botToken}/sendMessage`,
+          url: `${telegram?.apiRoot}/bot${telegram?.botToken}/sendMessage`,
           init: {
             body: JSON.stringify({
               chat_id: inbound.conversation.id,
@@ -1025,7 +972,7 @@ describe("crabline transport", () => {
         await transport.state.reset();
         const delivery = transport.buildAgentDelivery({ target: "dm:qa-operator" });
         const { response: directResponse, release: directRelease } = await fetchWithSsrFGuard({
-          url: `${api.apiRoot}/bot${api.botToken}/sendMessage`,
+          url: `${telegram?.apiRoot}/bot${telegram?.botToken}/sendMessage`,
           init: {
             body: JSON.stringify({
               chat_id: delivery.to,

--- a/extensions/qa-lab/src/crabline-transport.ts
+++ b/extensions/qa-lab/src/crabline-transport.ts
@@ -7,7 +7,6 @@ import {
   type OpenClawCrablineInbound,
   type StartedOpenClawCrablineAdapter,
 } from "@openclaw/crabline";
-import { sanitizeForPlainText } from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
@@ -15,7 +14,6 @@ import {
   normalizeStringifiedOptionalString,
   readStringValue,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { stripMarkdown } from "openclaw/plugin-sdk/text-chunking";
 import { createQaBusState, type QaBusState } from "./bus-state.js";
 import {
   createCrablineProviderDelivery,
@@ -92,20 +90,7 @@ function formatLogicalQaTarget({ conversation, threadId }: QaBusInboundMessageIn
 
 const TELEGRAM_LIFECYCLE_METHOD_RE = /\/(sendMessage|editMessageText|deleteMessage)$/u;
 
-function projectCrablineObservedText(channel: string, event: unknown, text: string): string {
-  if (
-    channel !== "telegram" ||
-    !isRecord(event) ||
-    !isRecord(event.body) ||
-    readStringValue(event.body.parse_mode)?.toLowerCase() !== "html"
-  ) {
-    return text;
-  }
-  return stripMarkdown(sanitizeForPlainText(text));
-}
-
 function readTelegramLifecycleEvent(params: {
-  channel: string;
   cursor: number;
   event: unknown;
   messageByProviderId: Map<string, QaBusMessage>;
@@ -139,11 +124,7 @@ function readTelegramLifecycleEvent(params: {
       params.pendingByChat.delete(chatId);
     }
   }
-  const observedText = readStringValue(params.event.body.text);
-  const text =
-    observedText === undefined
-      ? (previous?.text ?? "")
-      : projectCrablineObservedText(params.channel, params.event, observedText);
+  const text = readStringValue(params.event.body.text) ?? previous?.text ?? "";
   if (!text && method !== "deleteMessage") {
     return null;
   }
@@ -250,7 +231,6 @@ function createCrablineState(params: {
     observeEvent(event) {
       if (params.adapter.channel === "telegram") {
         const lifecycle = readTelegramLifecycleEvent({
-          channel: params.adapter.channel,
           cursor: outboundEvents.length + 1,
           event,
           messageByProviderId: telegramMessageByProviderId,
@@ -278,10 +258,7 @@ function createCrablineState(params: {
         targetByProviderTarget,
       }) as QaBusOutboundMessageInput | null;
       if (outbound) {
-        baseState.addOutboundMessage({
-          ...outbound,
-          text: projectCrablineObservedText(params.adapter.channel, event, outbound.text),
-        });
+        baseState.addOutboundMessage(outbound);
       }
     },
     async addInboundMessage(input: QaBusInboundMessageInput) {

--- a/extensions/qa-lab/src/crabline-transport.ts
+++ b/extensions/qa-lab/src/crabline-transport.ts
@@ -7,6 +7,7 @@ import {
   type OpenClawCrablineInbound,
   type StartedOpenClawCrablineAdapter,
 } from "@openclaw/crabline";
+import { sanitizeForPlainText } from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
@@ -14,6 +15,7 @@ import {
   normalizeStringifiedOptionalString,
   readStringValue,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { stripMarkdown } from "openclaw/plugin-sdk/text-chunking";
 import { createQaBusState, type QaBusState } from "./bus-state.js";
 import {
   createCrablineProviderDelivery,
@@ -90,7 +92,20 @@ function formatLogicalQaTarget({ conversation, threadId }: QaBusInboundMessageIn
 
 const TELEGRAM_LIFECYCLE_METHOD_RE = /\/(sendMessage|editMessageText|deleteMessage)$/u;
 
+function projectCrablineObservedText(channel: string, event: unknown, text: string): string {
+  if (
+    channel !== "telegram" ||
+    !isRecord(event) ||
+    !isRecord(event.body) ||
+    readStringValue(event.body.parse_mode)?.toLowerCase() !== "html"
+  ) {
+    return text;
+  }
+  return stripMarkdown(sanitizeForPlainText(text));
+}
+
 function readTelegramLifecycleEvent(params: {
+  channel: string;
   cursor: number;
   event: unknown;
   messageByProviderId: Map<string, QaBusMessage>;
@@ -124,7 +139,11 @@ function readTelegramLifecycleEvent(params: {
       params.pendingByChat.delete(chatId);
     }
   }
-  const text = readStringValue(params.event.body.text) ?? previous?.text ?? "";
+  const observedText = readStringValue(params.event.body.text);
+  const text =
+    observedText === undefined
+      ? (previous?.text ?? "")
+      : projectCrablineObservedText(params.channel, params.event, observedText);
   if (!text && method !== "deleteMessage") {
     return null;
   }
@@ -231,6 +250,7 @@ function createCrablineState(params: {
     observeEvent(event) {
       if (params.adapter.channel === "telegram") {
         const lifecycle = readTelegramLifecycleEvent({
+          channel: params.adapter.channel,
           cursor: outboundEvents.length + 1,
           event,
           messageByProviderId: telegramMessageByProviderId,
@@ -258,7 +278,10 @@ function createCrablineState(params: {
         targetByProviderTarget,
       }) as QaBusOutboundMessageInput | null;
       if (outbound) {
-        baseState.addOutboundMessage(outbound);
+        baseState.addOutboundMessage({
+          ...outbound,
+          text: projectCrablineObservedText(params.adapter.channel, event, outbound.text),
+        });
       }
     },
     async addInboundMessage(input: QaBusInboundMessageInput) {

--- a/extensions/qa-lab/src/runtime-parity.test.ts
+++ b/extensions/qa-lab/src/runtime-parity.test.ts
@@ -1045,4 +1045,17 @@ describe("runtime parity", () => {
       "tool-result-missing",
     ]);
   });
+
+  it("copies model-switch evidence into the runtime parity cell", async () => {
+    const modelSwitchEvidence = {
+      primary: { runId: "run-1", responseModel: "primary-model" },
+      alternate: { runId: "run-2", responseModel: "alternate-model" },
+    };
+    const cell = await captureRuntimeParityWithMockRequests({
+      requests: [],
+      scenarioResult: { status: "pass", modelSwitchEvidence },
+    });
+
+    expect(cell.modelSwitchEvidence).toEqual(modelSwitchEvidence);
+  });
 });

--- a/extensions/qa-lab/src/runtime-parity.ts
+++ b/extensions/qa-lab/src/runtime-parity.ts
@@ -62,6 +62,7 @@ export type RuntimeParityCell = {
   runtimeErrorClass?: string;
   bootStateLines: string[];
   sentinelFindings?: GatewayLogSentinelFinding[];
+  modelSwitchEvidence?: Record<string, unknown>;
 };
 
 type RuntimeParityResultCell = RuntimeParityCell & {
@@ -154,6 +155,7 @@ type QaSuiteScenarioLike = {
   details?: string;
   status: "pass" | "fail" | "skip";
   steps?: Array<{ details?: string; status?: "pass" | "fail" | "skip" }>;
+  modelSwitchEvidence?: Record<string, unknown>;
 };
 
 type RuntimeParityCaptureParams = {
@@ -1510,6 +1512,9 @@ export async function captureRuntimeParityCell(
       : {}),
     bootStateLines: extractBootStateLines(gatewayLogs),
     ...(sentinelFindings.length > 0 ? { sentinelFindings } : {}),
+    ...(params.scenarioResult.modelSwitchEvidence
+      ? { modelSwitchEvidence: params.scenarioResult.modelSwitchEvidence }
+      : {}),
   };
 }
 

--- a/extensions/qa-lab/src/scenario-catalog-model-switch-follow-up-proof.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-model-switch-follow-up-proof.test.ts
@@ -1,6 +1,17 @@
-import { describe, expect, it } from "vitest";
+import path from "node:path";
+import { parseModelRef } from "openclaw/plugin-sdk/agent-runtime";
+import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import { afterEach, describe, expect, it } from "vitest";
 import { createQaBusState } from "./bus-state.js";
 import { runLoadedScenarioFlow } from "./scenario-flow-runner.test-support.js";
+import { readRawQaSessionStore } from "./suite-runtime-agent-session.js";
+import { createTempDirHarness } from "./temp-dir.test-helper.js";
+
+const { cleanup, makeTempDir } = createTempDirHarness();
+const sessionKey = "agent:qa:model-switch";
+const sessionId = "model-switch-follow-up";
+
+afterEach(cleanup);
 
 type ProviderMode = "mock-openai" | "live-frontier";
 
@@ -8,15 +19,32 @@ async function runModelSwitchFollowUpScenario(params: {
   providerMode: ProviderMode;
   initialReply: string;
   followUpReply?: string;
+  followUpDelivery?: "visible" | "deleted-only" | "deleted-preview-then-visible";
+  alternateModel?: string;
+  persistedFollowUpModel?: { provider: string; model: string };
 }) {
+  const tempRoot = await makeTempDir("qa-model-switch-follow-up-");
+  const runtimeEnv = { ...process.env, OPENCLAW_STATE_DIR: path.join(tempRoot, "state") };
   const state = createQaBusState();
   const requests: Array<{ allInputText: string; body: { model: string }; model: string }> = [];
   const primaryModel = "openai/primary-model";
-  const alternateModel = "openai/alternate-model";
+  const alternateModel = params.alternateModel ?? "openai/alternate-model";
+  const normalizeModelRef = (raw: string) =>
+    parseModelRef(raw, raw.slice(0, raw.indexOf("/")), {
+      allowPluginNormalization: false,
+      manifestPlugins: [
+        {
+          modelIdNormalization: {
+            providers: { anthropic: { aliases: { opus: "claude-opus-5" } } },
+          },
+        },
+      ],
+    });
   const env = {
     providerMode: params.providerMode,
     primaryModel,
     alternateModel,
+    gateway: { tempRoot },
     ...(params.providerMode === "mock-openai" ? { mock: { baseUrl: "http://mock.invalid" } } : {}),
   };
 
@@ -28,8 +56,10 @@ async function runModelSwitchFollowUpScenario(params: {
         const slash = ref.indexOf("/");
         return slash > 0 ? { provider: ref.slice(0, slash), model: ref.slice(slash + 1) } : null;
       },
+      normalizeModelRef,
       normalizeLowercaseStringOrEmpty: (value: unknown) =>
         typeof value === "string" ? value.trim().toLowerCase() : "",
+      readRawQaSessionStore,
       resolveQaLiveTurnTimeoutMs: (_env: unknown, timeoutMs: number) => timeoutMs,
       fetchJson: async (rawUrl: string) => {
         const url = new URL(rawUrl);
@@ -44,29 +74,63 @@ async function runModelSwitchFollowUpScenario(params: {
         }
         throw new Error(`unexpected mock provider endpoint: ${url.pathname}`);
       },
-      runAgentPrompt: async (_env: unknown, prompt: { message: string; model?: string }) => {
+      runAgentPrompt: async (
+        _env: unknown,
+        prompt: { message: string; model?: string; provider?: string },
+      ) => {
         state.addInboundMessage({
           accountId: "qa-channel",
           conversation: { id: "qa-operator", kind: "direct" },
           senderId: "qa-operator",
           text: prompt.message,
         });
-        const model = prompt.model ?? "primary-model";
+        const requestedModel = prompt.model ?? "primary-model";
+        const resolvedModel = normalizeModelRef(`${prompt.provider ?? "openai"}/${requestedModel}`);
+        const model = resolvedModel?.model ?? requestedModel;
         requests.push({ allInputText: prompt.message, body: { model }, model });
 
-        const reply = requests.length === 1 ? params.initialReply : params.followUpReply;
+        const isFollowUp = requests.length > 1;
+        const actualModel =
+          isFollowUp && params.persistedFollowUpModel
+            ? params.persistedFollowUpModel
+            : { provider: resolvedModel?.provider ?? prompt.provider ?? "openai", model };
+        await upsertSessionEntry({
+          agentId: "qa",
+          env: runtimeEnv,
+          sessionKey,
+          entry: {
+            sessionId,
+            updatedAt: Date.now(),
+            modelProvider: actualModel.provider,
+            model: actualModel.model,
+          },
+        });
+
+        const reply = isFollowUp ? params.followUpReply : params.initialReply;
         if (reply !== undefined) {
-          state.addOutboundMessage({
+          const outbound = state.addOutboundMessage({
             accountId: "qa-channel",
             to: "dm:qa-operator",
             text: reply,
           });
+          if (isFollowUp && params.followUpDelivery !== undefined) {
+            if (params.followUpDelivery !== "visible") {
+              state.deleteMessage({ accountId: "qa-channel", messageId: outbound.id });
+            }
+            if (params.followUpDelivery === "deleted-preview-then-visible") {
+              state.addOutboundMessage({
+                accountId: "qa-channel",
+                to: "dm:qa-operator",
+                text: reply,
+              });
+            }
+          }
         }
       },
     },
   });
 
-  return { requests, result, state };
+  return { env, requests, result, state };
 }
 
 describe("model-switch follow-up scenario outbound evidence", () => {
@@ -106,6 +170,86 @@ describe("model-switch follow-up scenario outbound evidence", () => {
         "inbound",
         "outbound",
       ]);
+    },
+  );
+
+  it.each([
+    ["mock-openai", "anthropic/opus", "anthropic"],
+    ["live-frontier", "anthropic/opus", "anthropic"],
+    ["mock-openai", "Anthropic/opus", "ANTHROPIC"],
+    ["live-frontier", "Anthropic/opus", "ANTHROPIC"],
+  ] as const)(
+    "accepts the canonical persisted model for %s alias %s with provider %s",
+    async (providerMode, alternateModel, persistedProvider) => {
+      const { env, requests, result } = await runModelSwitchFollowUpScenario({
+        providerMode,
+        alternateModel,
+        initialReply: "The requested handoff comes next.",
+        followUpReply: "The alternate-model handoff completed successfully.",
+        persistedFollowUpModel: { provider: persistedProvider, model: "claude-opus-5" },
+      });
+
+      expect(result.status).toBe("pass");
+      expect(requests.at(-1)?.model).toBe("claude-opus-5");
+      expect(await readRawQaSessionStore(env)).toMatchObject({
+        [sessionKey]: { modelProvider: persistedProvider, model: "claude-opus-5" },
+      });
+    },
+  );
+
+  it.each([
+    ["mock-openai", "openai", "primary-model"],
+    ["mock-openai", "anthropic", "alternate-model"],
+    ["live-frontier", "openai", "primary-model"],
+    ["live-frontier", "anthropic", "alternate-model"],
+  ] as const)(
+    "rejects a fresh handoff when the persisted %s run used %s/%s",
+    async (providerMode, provider, model) => {
+      await expect(
+        runModelSwitchFollowUpScenario({
+          providerMode,
+          initialReply: "The requested handoff comes next.",
+          followUpReply: "The alternate-model handoff completed successfully.",
+          persistedFollowUpModel: { provider, model },
+        }),
+      ).rejects.toThrow(/alternate.*model|persisted.*model|model.*switch/i);
+    },
+  );
+
+  it.each(["mock-openai", "live-frontier"] as const)(
+    "rejects a deleted fresh handoff when no visible final reply remains (%s)",
+    async (providerMode) => {
+      await expect(
+        runModelSwitchFollowUpScenario({
+          providerMode,
+          initialReply: "The requested handoff comes next.",
+          followUpReply: "The alternate-model handoff completed successfully.",
+          followUpDelivery: "deleted-only",
+        }),
+      ).rejects.toThrow("test condition was not met");
+    },
+  );
+
+  it.each(["mock-openai", "live-frontier"] as const)(
+    "accepts a visible final handoff after its streaming preview was deleted (%s)",
+    async (providerMode) => {
+      const { env, result, state } = await runModelSwitchFollowUpScenario({
+        providerMode,
+        initialReply: "The requested handoff comes next.",
+        followUpReply: "The alternate-model handoff completed successfully.",
+        followUpDelivery: "deleted-preview-then-visible",
+      });
+
+      expect(result.status).toBe("pass");
+      expect(await readRawQaSessionStore(env)).toMatchObject({
+        [sessionKey]: { modelProvider: "openai", model: "alternate-model" },
+      });
+      expect(
+        state
+          .getSnapshot()
+          .messages.filter((message) => message.direction === "outbound")
+          .map((message) => message.deleted === true),
+      ).toEqual([false, true, false]);
     },
   );
 });

--- a/extensions/qa-lab/src/scenario-catalog-model-switch-follow-up-proof.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-model-switch-follow-up-proof.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { createQaBusState } from "./bus-state.js";
+import { runLoadedScenarioFlow } from "./scenario-flow-runner.test-support.js";
+
+type ProviderMode = "mock-openai" | "live-frontier";
+
+async function runModelSwitchFollowUpScenario(params: {
+  providerMode: ProviderMode;
+  initialReply: string;
+  followUpReply?: string;
+}) {
+  const state = createQaBusState();
+  const requests: Array<{ allInputText: string; body: { model: string }; model: string }> = [];
+  const primaryModel = "openai/primary-model";
+  const alternateModel = "openai/alternate-model";
+  const env = {
+    providerMode: params.providerMode,
+    primaryModel,
+    alternateModel,
+    ...(params.providerMode === "mock-openai" ? { mock: { baseUrl: "http://mock.invalid" } } : {}),
+  };
+
+  const result = await runLoadedScenarioFlow("model-switch-follow-up", {
+    state,
+    api: {
+      env,
+      splitModelRef: (ref: string) => {
+        const slash = ref.indexOf("/");
+        return slash > 0 ? { provider: ref.slice(0, slash), model: ref.slice(slash + 1) } : null;
+      },
+      normalizeLowercaseStringOrEmpty: (value: unknown) =>
+        typeof value === "string" ? value.trim().toLowerCase() : "",
+      resolveQaLiveTurnTimeoutMs: (_env: unknown, timeoutMs: number) => timeoutMs,
+      fetchJson: async (rawUrl: string) => {
+        const url = new URL(rawUrl);
+        if (url.pathname === "/debug/last-request") {
+          return requests.at(-1);
+        }
+        if (url.pathname === "/debug/request-cursor") {
+          return { cursor: requests.length };
+        }
+        if (url.pathname === "/debug/requests") {
+          return requests.slice(Number(url.searchParams.get("after") ?? "0"));
+        }
+        throw new Error(`unexpected mock provider endpoint: ${url.pathname}`);
+      },
+      runAgentPrompt: async (_env: unknown, prompt: { message: string; model?: string }) => {
+        state.addInboundMessage({
+          accountId: "qa-channel",
+          conversation: { id: "qa-operator", kind: "direct" },
+          senderId: "qa-operator",
+          text: prompt.message,
+        });
+        const model = prompt.model ?? "primary-model";
+        requests.push({ allInputText: prompt.message, body: { model }, model });
+
+        const reply = requests.length === 1 ? params.initialReply : params.followUpReply;
+        if (reply !== undefined) {
+          state.addOutboundMessage({
+            accountId: "qa-channel",
+            to: "dm:qa-operator",
+            text: reply,
+          });
+        }
+      },
+    },
+  });
+
+  return { requests, result, state };
+}
+
+describe("model-switch follow-up scenario outbound evidence", () => {
+  it.each([
+    ["mock-openai", "The requested handoff comes next."],
+    ["mock-openai", "The requested model switch comes next."],
+    ["live-frontier", "The requested handoff comes next."],
+    ["live-frontier", "The requested model switch comes next."],
+  ] as const)(
+    "rejects a stale first-turn handoff signal when %s produces no follow-up reply",
+    async (providerMode, initialReply) => {
+      await expect(runModelSwitchFollowUpScenario({ providerMode, initialReply })).rejects.toThrow(
+        "test condition was not met",
+      );
+    },
+  );
+
+  it.each(["mock-openai", "live-frontier"] as const)(
+    "accepts a fresh alternate-model reply after mixed first-turn traffic (%s)",
+    async (providerMode) => {
+      const followUpReply = "The alternate-model handoff completed successfully.";
+      const { requests, result, state } = await runModelSwitchFollowUpScenario({
+        providerMode,
+        initialReply: "The requested handoff comes next.",
+        followUpReply,
+      });
+
+      expect(result.status).toBe("pass");
+      expect(result.steps[1]?.details).toBe(followUpReply);
+      expect(requests.map((request) => request.model)).toEqual([
+        "primary-model",
+        "alternate-model",
+      ]);
+      expect(state.getSnapshot().messages.map((message) => message.direction)).toEqual([
+        "inbound",
+        "outbound",
+        "inbound",
+        "outbound",
+      ]);
+    },
+  );
+});

--- a/extensions/qa-lab/src/scenario-catalog-model-switch-follow-up-proof.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-model-switch-follow-up-proof.test.ts
@@ -1,255 +1,117 @@
-import path from "node:path";
-import { parseModelRef } from "openclaw/plugin-sdk/agent-runtime";
-import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createQaBusState } from "./bus-state.js";
 import { runLoadedScenarioFlow } from "./scenario-flow-runner.test-support.js";
-import { readRawQaSessionStore } from "./suite-runtime-agent-session.js";
-import { createTempDirHarness } from "./temp-dir.test-helper.js";
 
-const { cleanup, makeTempDir } = createTempDirHarness();
-const sessionKey = "agent:qa:model-switch";
-const sessionId = "model-switch-follow-up";
+function splitModelRef(raw: string) {
+  const [provider, ...model] = raw.split("/");
+  return provider && model.length
+    ? { provider: provider.toLowerCase(), model: model.join("/") }
+    : null;
+}
 
-afterEach(cleanup);
-
-type ProviderMode = "mock-openai" | "live-frontier";
-
-async function runModelSwitchFollowUpScenario(params: {
-  providerMode: ProviderMode;
-  initialReply: string;
-  followUpReply?: string;
-  followUpDelivery?: "visible" | "deleted-only" | "deleted-preview-then-visible";
-  alternateModel?: string;
-  persistedFollowUpModel?: { provider: string; model: string };
+function terminalReceipt(params: {
+  runId: string;
+  provider: string;
+  model: string;
+  responseModel?: string;
 }) {
-  const tempRoot = await makeTempDir("qa-model-switch-follow-up-");
-  const runtimeEnv = { ...process.env, OPENCLAW_STATE_DIR: path.join(tempRoot, "state") };
-  const state = createQaBusState();
-  const requests: Array<{ allInputText: string; body: { model: string }; model: string }> = [];
-  const primaryModel = "openai/primary-model";
-  const alternateModel = params.alternateModel ?? "openai/alternate-model";
-  const normalizeModelRef = (raw: string) =>
-    parseModelRef(raw, raw.slice(0, raw.indexOf("/")), {
-      allowPluginNormalization: false,
-      manifestPlugins: [
-        {
-          modelIdNormalization: {
-            providers: { anthropic: { aliases: { opus: "claude-opus-5" } } },
-          },
-        },
-      ],
-    });
-  const env = {
-    providerMode: params.providerMode,
-    primaryModel,
-    alternateModel,
-    gateway: { tempRoot },
-    ...(params.providerMode === "mock-openai" ? { mock: { baseUrl: "http://mock.invalid" } } : {}),
+  const responseModel = params.responseModel ?? params.model;
+  return {
+    runId: params.runId,
+    sessionId: "session-model-switch",
+    turnId: `turn-${params.runId}`,
+    requested: { provider: params.provider, model: params.model },
+    effective: { provider: params.provider, model: responseModel, responseModel },
+    successfulToolNames: [],
+    rerouted: responseModel !== params.model,
+    terminalDisposition: "visible",
   };
+}
 
+async function runFollowUp(params?: {
+  alternateModel?: string;
+  alternateReceiptRunId?: string;
+  deleteAlternateReply?: boolean;
+  onRun?: () => void;
+}) {
+  const state = createQaBusState();
+  let call = 0;
+  const runAgentPrompt = vi.fn(
+    async (_env: unknown, prompt: { provider?: string; model?: string; message: string }) => {
+      params?.onRun?.();
+      call += 1;
+      const runId = `run-${call}`;
+      const provider = prompt.provider ?? "openai";
+      const model = prompt.model ?? "primary-model";
+      const outbound = state.addOutboundMessage({
+        accountId: "qa-channel",
+        to: "dm:qa-operator",
+        text: call === 1 ? "hello from the primary model" : "the model switch handoff completed",
+      });
+      if (call === 2 && params?.deleteAlternateReply) {
+        state.deleteMessage({ accountId: "qa-channel", messageId: outbound.id });
+      }
+      return {
+        started: { runId },
+        waited: {
+          status: "ok",
+          terminalReceipt: terminalReceipt({
+            runId: call === 2 ? (params?.alternateReceiptRunId ?? runId) : runId,
+            provider,
+            model,
+          }),
+        },
+      };
+    },
+  );
   const result = await runLoadedScenarioFlow("model-switch-follow-up", {
     state,
     api: {
-      env,
-      splitModelRef: (ref: string) => {
-        const slash = ref.indexOf("/");
-        return slash > 0 ? { provider: ref.slice(0, slash), model: ref.slice(slash + 1) } : null;
+      env: {
+        providerMode: "mock-openai",
+        primaryModel: "openai/primary-model",
+        alternateModel: params?.alternateModel ?? "openai/alternate-model",
+        gateway: {},
       },
-      normalizeModelRef,
+      runAgentPrompt,
+      splitModelRef,
+      normalizeModelRef: splitModelRef,
       normalizeLowercaseStringOrEmpty: (value: unknown) =>
         typeof value === "string" ? value.trim().toLowerCase() : "",
-      readRawQaSessionStore,
       resolveQaLiveTurnTimeoutMs: (_env: unknown, timeoutMs: number) => timeoutMs,
-      fetchJson: async (rawUrl: string) => {
-        const url = new URL(rawUrl);
-        if (url.pathname === "/debug/last-request") {
-          return requests.at(-1);
-        }
-        if (url.pathname === "/debug/request-cursor") {
-          return { cursor: requests.length };
-        }
-        if (url.pathname === "/debug/requests") {
-          return requests.slice(Number(url.searchParams.get("after") ?? "0"));
-        }
-        throw new Error(`unexpected mock provider endpoint: ${url.pathname}`);
-      },
-      runAgentPrompt: async (
-        _env: unknown,
-        prompt: { message: string; model?: string; provider?: string },
-      ) => {
-        state.addInboundMessage({
-          accountId: "qa-channel",
-          conversation: { id: "qa-operator", kind: "direct" },
-          senderId: "qa-operator",
-          text: prompt.message,
-        });
-        const requestedModel = prompt.model ?? "primary-model";
-        const resolvedModel = normalizeModelRef(`${prompt.provider ?? "openai"}/${requestedModel}`);
-        const model = resolvedModel?.model ?? requestedModel;
-        requests.push({ allInputText: prompt.message, body: { model }, model });
-
-        const isFollowUp = requests.length > 1;
-        const actualModel =
-          isFollowUp && params.persistedFollowUpModel
-            ? params.persistedFollowUpModel
-            : { provider: resolvedModel?.provider ?? prompt.provider ?? "openai", model };
-        await upsertSessionEntry({
-          agentId: "qa",
-          env: runtimeEnv,
-          sessionKey,
-          entry: {
-            sessionId,
-            updatedAt: Date.now(),
-            modelProvider: actualModel.provider,
-            model: actualModel.model,
-          },
-        });
-
-        const reply = isFollowUp ? params.followUpReply : params.initialReply;
-        if (reply !== undefined) {
-          const outbound = state.addOutboundMessage({
-            accountId: "qa-channel",
-            to: "dm:qa-operator",
-            text: reply,
-          });
-          if (isFollowUp && params.followUpDelivery !== undefined) {
-            if (params.followUpDelivery !== "visible") {
-              state.deleteMessage({ accountId: "qa-channel", messageId: outbound.id });
-            }
-            if (params.followUpDelivery === "deleted-preview-then-visible") {
-              state.addOutboundMessage({
-                accountId: "qa-channel",
-                to: "dm:qa-operator",
-                text: reply,
-              });
-            }
-          }
-        }
-      },
     },
   });
-
-  return { env, requests, result, state };
+  return { result, runAgentPrompt };
 }
 
-describe("model-switch follow-up scenario outbound evidence", () => {
-  it.each([
-    ["mock-openai", "The requested handoff comes next."],
-    ["mock-openai", "The requested model switch comes next."],
-    ["live-frontier", "The requested handoff comes next."],
-    ["live-frontier", "The requested model switch comes next."],
-  ] as const)(
-    "rejects a stale first-turn handoff signal when %s produces no follow-up reply",
-    async (providerMode, initialReply) => {
-      await expect(runModelSwitchFollowUpScenario({ providerMode, initialReply })).rejects.toThrow(
-        "test condition was not met",
-      );
-    },
-  );
+describe("model-switch follow-up terminal evidence", () => {
+  it("records exact receipts for both visible model runs", async () => {
+    const { result } = await runFollowUp();
 
-  it.each(["mock-openai", "live-frontier"] as const)(
-    "accepts a fresh alternate-model reply after mixed first-turn traffic (%s)",
-    async (providerMode) => {
-      const followUpReply = "The alternate-model handoff completed successfully.";
-      const { requests, result, state } = await runModelSwitchFollowUpScenario({
-        providerMode,
-        initialReply: "The requested handoff comes next.",
-        followUpReply,
-      });
+    expect(result.status).toBe("pass");
+    expect(result.modelSwitchEvidence).toMatchObject({
+      primary: { runId: "run-1", effective: { responseModel: "primary-model" } },
+      alternate: { runId: "run-2", effective: { responseModel: "alternate-model" } },
+    });
+  });
 
-      expect(result.status).toBe("pass");
-      expect(result.steps[1]?.details).toBe(followUpReply);
-      expect(requests.map((request) => request.model)).toEqual([
-        "primary-model",
-        "alternate-model",
-      ]);
-      expect(state.getSnapshot().messages.map((message) => message.direction)).toEqual([
-        "inbound",
-        "outbound",
-        "inbound",
-        "outbound",
-      ]);
-    },
-  );
+  it("rejects a delayed prior-run receipt", async () => {
+    await expect(runFollowUp({ alternateReceiptRunId: "run-1" })).rejects.toThrow(
+      "alternate-model run did not return distinct exact owned model evidence",
+    );
+  });
 
-  it.each([
-    ["mock-openai", "anthropic/opus", "anthropic"],
-    ["live-frontier", "anthropic/opus", "anthropic"],
-    ["mock-openai", "Anthropic/opus", "ANTHROPIC"],
-    ["live-frontier", "Anthropic/opus", "ANTHROPIC"],
-  ] as const)(
-    "accepts the canonical persisted model for %s alias %s with provider %s",
-    async (providerMode, alternateModel, persistedProvider) => {
-      const { env, requests, result } = await runModelSwitchFollowUpScenario({
-        providerMode,
-        alternateModel,
-        initialReply: "The requested handoff comes next.",
-        followUpReply: "The alternate-model handoff completed successfully.",
-        persistedFollowUpModel: { provider: persistedProvider, model: "claude-opus-5" },
-      });
+  it("rejects normalized-identical refs before starting an agent run", async () => {
+    const onRun = vi.fn();
+    await expect(runFollowUp({ alternateModel: "OPENAI/primary-model", onRun })).rejects.toThrow(
+      "primary and alternate models must normalize to different refs",
+    );
+    expect(onRun).not.toHaveBeenCalled();
+  });
 
-      expect(result.status).toBe("pass");
-      expect(requests.at(-1)?.model).toBe("claude-opus-5");
-      expect(await readRawQaSessionStore(env)).toMatchObject({
-        [sessionKey]: { modelProvider: persistedProvider, model: "claude-opus-5" },
-      });
-    },
-  );
-
-  it.each([
-    ["mock-openai", "openai", "primary-model"],
-    ["mock-openai", "anthropic", "alternate-model"],
-    ["live-frontier", "openai", "primary-model"],
-    ["live-frontier", "anthropic", "alternate-model"],
-  ] as const)(
-    "rejects a fresh handoff when the persisted %s run used %s/%s",
-    async (providerMode, provider, model) => {
-      await expect(
-        runModelSwitchFollowUpScenario({
-          providerMode,
-          initialReply: "The requested handoff comes next.",
-          followUpReply: "The alternate-model handoff completed successfully.",
-          persistedFollowUpModel: { provider, model },
-        }),
-      ).rejects.toThrow(/alternate.*model|persisted.*model|model.*switch/i);
-    },
-  );
-
-  it.each(["mock-openai", "live-frontier"] as const)(
-    "rejects a deleted fresh handoff when no visible final reply remains (%s)",
-    async (providerMode) => {
-      await expect(
-        runModelSwitchFollowUpScenario({
-          providerMode,
-          initialReply: "The requested handoff comes next.",
-          followUpReply: "The alternate-model handoff completed successfully.",
-          followUpDelivery: "deleted-only",
-        }),
-      ).rejects.toThrow("test condition was not met");
-    },
-  );
-
-  it.each(["mock-openai", "live-frontier"] as const)(
-    "accepts a visible final handoff after its streaming preview was deleted (%s)",
-    async (providerMode) => {
-      const { env, result, state } = await runModelSwitchFollowUpScenario({
-        providerMode,
-        initialReply: "The requested handoff comes next.",
-        followUpReply: "The alternate-model handoff completed successfully.",
-        followUpDelivery: "deleted-preview-then-visible",
-      });
-
-      expect(result.status).toBe("pass");
-      expect(await readRawQaSessionStore(env)).toMatchObject({
-        [sessionKey]: { modelProvider: "openai", model: "alternate-model" },
-      });
-      expect(
-        state
-          .getSnapshot()
-          .messages.filter((message) => message.direction === "outbound")
-          .map((message) => message.deleted === true),
-      ).toEqual([false, true, false]);
-    },
-  );
+  it("rejects a deleted alternate reply", async () => {
+    await expect(runFollowUp({ deleteAlternateReply: true })).rejects.toThrow(
+      "test condition was not met",
+    );
+  });
 });

--- a/extensions/qa-lab/src/scenario-catalog-model-switch-follow-up-proof.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-model-switch-follow-up-proof.test.ts
@@ -9,6 +9,16 @@ function splitModelRef(raw: string) {
     : null;
 }
 
+function normalizeModelRef(raw: string) {
+  const split = splitModelRef(raw);
+  if (!split) {
+    return null;
+  }
+  return split.provider === "openai" && split.model.toLowerCase() === "alternate-alias"
+    ? { provider: "openai", model: "alternate-model" }
+    : split;
+}
+
 function terminalReceipt(params: {
   runId: string;
   provider: string;
@@ -32,8 +42,9 @@ async function runFollowUp(params?: {
   alternateModel?: string;
   alternateReceiptRunId?: string;
   alternateReplyText?: string;
+  alternateOutboundText?: string;
+  alternateDelivery?: { status: string; resultCount: number } | null;
   unrelatedLaterOutboundText?: string;
-  deleteAlternateReply?: boolean;
   onRun?: () => void;
 }) {
   const state = createQaBusState();
@@ -49,14 +60,14 @@ async function runFollowUp(params?: {
         call === 1
           ? "hello from the primary model"
           : (params?.alternateReplyText ?? "the model switch handoff completed");
-      const outbound = state.addOutboundMessage({
+      state.addOutboundMessage({
         accountId: "qa-channel",
         to: "dm:qa-operator",
-        text: replyText,
+        text:
+          call === 2
+            ? (params?.alternateOutboundText ?? replyText)
+            : "hello from the primary model",
       });
-      if (call === 2 && params?.deleteAlternateReply) {
-        state.deleteMessage({ accountId: "qa-channel", messageId: outbound.id });
-      }
       if (call === 2 && params?.unrelatedLaterOutboundText) {
         state.addOutboundMessage({
           accountId: "qa-channel",
@@ -68,6 +79,14 @@ async function runFollowUp(params?: {
         started: { runId },
         waited: {
           status: "ok",
+          ...(call === 2 && params?.alternateDelivery === null
+            ? {}
+            : {
+                terminalDelivery:
+                  call === 2
+                    ? (params?.alternateDelivery ?? { status: "sent", resultCount: 1 })
+                    : { status: "sent", resultCount: 1 },
+              }),
           terminalReply: { disposition: "visible", text: replyText },
           terminalReceipt: terminalReceipt({
             runId: call === 2 ? (params?.alternateReceiptRunId ?? runId) : runId,
@@ -84,12 +103,12 @@ async function runFollowUp(params?: {
       env: {
         providerMode: "mock-openai",
         primaryModel: "openai/primary-model",
-        alternateModel: params?.alternateModel ?? "openai/alternate-model",
+        alternateModel: params?.alternateModel ?? "OPENAI/alternate-alias",
         gateway: {},
       },
       runAgentPrompt,
       splitModelRef,
-      normalizeModelRef: splitModelRef,
+      normalizeModelRef,
       normalizeLowercaseStringOrEmpty: (value: unknown) =>
         typeof value === "string" ? value.trim().toLowerCase() : "",
       resolveQaLiveTurnTimeoutMs: (_env: unknown, timeoutMs: number) => timeoutMs,
@@ -99,16 +118,27 @@ async function runFollowUp(params?: {
 }
 
 describe("model-switch follow-up terminal evidence", () => {
-  it("records exact receipts for both visible model runs", async () => {
-    const { result } = await runFollowUp();
+  it("invokes the canonical alias target and records exact run-owned evidence", async () => {
+    const { result, runAgentPrompt } = await runFollowUp({
+      alternateReplyText: "the **model switch** handoff completed",
+      alternateOutboundText: "the model switch handoff completed",
+    });
 
     expect(result.status).toBe("pass");
+    expect(runAgentPrompt.mock.calls[1]?.[1]).toMatchObject({
+      provider: "openai",
+      model: "alternate-model",
+    });
     expect(result.modelSwitchEvidence).toMatchObject({
       primary: { runId: "run-1", effective: { responseModel: "primary-model" } },
       alternate: { runId: "run-2", effective: { responseModel: "alternate-model" } },
-      terminalReply: { disposition: "visible", text: "the model switch handoff completed" },
+      terminalReply: {
+        disposition: "visible",
+        text: "the **model switch** handoff completed",
+      },
+      terminalDelivery: { status: "sent", resultCount: 1 },
     });
-    expect(result.steps[1]?.details).toBe("the model switch handoff completed");
+    expect(result.steps[1]?.details).toBe("the **model switch** handoff completed");
   });
 
   it("rejects a delayed prior-run receipt", async () => {
@@ -125,12 +155,6 @@ describe("model-switch follow-up terminal evidence", () => {
     expect(onRun).not.toHaveBeenCalled();
   });
 
-  it("rejects a deleted alternate reply", async () => {
-    await expect(runFollowUp({ deleteAlternateReply: true })).rejects.toThrow(
-      "test condition was not met",
-    );
-  });
-
   it("rejects unrelated later continuity text when the alternate reply lacks it", async () => {
     await expect(
       runFollowUp({
@@ -139,4 +163,20 @@ describe("model-switch follow-up terminal evidence", () => {
       }),
     ).rejects.toThrow("alternate-model terminal reply missed switch continuity");
   });
+
+  it.each([
+    ["missing", null],
+    ["suppressed", { status: "suppressed", resultCount: 0 }],
+    ["zero-count", { status: "sent", resultCount: 0 }],
+  ] as const)(
+    "rejects %s delivery evidence despite an identical bus message",
+    async (_, evidence) => {
+      await expect(
+        runFollowUp({
+          alternateDelivery: evidence,
+          alternateOutboundText: "the model switch handoff completed",
+        }),
+      ).rejects.toThrow("alternate-model run did not return owned sent delivery evidence");
+    },
+  );
 });

--- a/extensions/qa-lab/src/scenario-catalog-model-switch-follow-up-proof.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-model-switch-follow-up-proof.test.ts
@@ -31,6 +31,8 @@ function terminalReceipt(params: {
 async function runFollowUp(params?: {
   alternateModel?: string;
   alternateReceiptRunId?: string;
+  alternateReplyText?: string;
+  unrelatedLaterOutboundText?: string;
   deleteAlternateReply?: boolean;
   onRun?: () => void;
 }) {
@@ -43,18 +45,30 @@ async function runFollowUp(params?: {
       const runId = `run-${call}`;
       const provider = prompt.provider ?? "openai";
       const model = prompt.model ?? "primary-model";
+      const replyText =
+        call === 1
+          ? "hello from the primary model"
+          : (params?.alternateReplyText ?? "the model switch handoff completed");
       const outbound = state.addOutboundMessage({
         accountId: "qa-channel",
         to: "dm:qa-operator",
-        text: call === 1 ? "hello from the primary model" : "the model switch handoff completed",
+        text: replyText,
       });
       if (call === 2 && params?.deleteAlternateReply) {
         state.deleteMessage({ accountId: "qa-channel", messageId: outbound.id });
+      }
+      if (call === 2 && params?.unrelatedLaterOutboundText) {
+        state.addOutboundMessage({
+          accountId: "qa-channel",
+          to: "dm:qa-operator",
+          text: params.unrelatedLaterOutboundText,
+        });
       }
       return {
         started: { runId },
         waited: {
           status: "ok",
+          terminalReply: { disposition: "visible", text: replyText },
           terminalReceipt: terminalReceipt({
             runId: call === 2 ? (params?.alternateReceiptRunId ?? runId) : runId,
             provider,
@@ -92,7 +106,9 @@ describe("model-switch follow-up terminal evidence", () => {
     expect(result.modelSwitchEvidence).toMatchObject({
       primary: { runId: "run-1", effective: { responseModel: "primary-model" } },
       alternate: { runId: "run-2", effective: { responseModel: "alternate-model" } },
+      terminalReply: { disposition: "visible", text: "the model switch handoff completed" },
     });
+    expect(result.steps[1]?.details).toBe("the model switch handoff completed");
   });
 
   it("rejects a delayed prior-run receipt", async () => {
@@ -113,5 +129,14 @@ describe("model-switch follow-up terminal evidence", () => {
     await expect(runFollowUp({ deleteAlternateReply: true })).rejects.toThrow(
       "test condition was not met",
     );
+  });
+
+  it("rejects unrelated later continuity text when the alternate reply lacks it", async () => {
+    await expect(
+      runFollowUp({
+        alternateReplyText: "the alternate run completed",
+        unrelatedLaterOutboundText: "the model switch handoff completed",
+      }),
+    ).rejects.toThrow("alternate-model terminal reply missed switch continuity");
   });
 });

--- a/extensions/qa-lab/src/scenario-catalog-model-switch-follow-up-proof.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-model-switch-follow-up-proof.test.ts
@@ -41,9 +41,13 @@ function terminalReceipt(params: {
 async function runFollowUp(params?: {
   alternateModel?: string;
   alternateReceiptRunId?: string;
+  primaryReplyText?: string;
+  primaryOutboundText?: string;
+  primaryDelivery?: { status: string; resultCount: number } | null;
   alternateReplyText?: string;
   alternateOutboundText?: string;
   alternateDelivery?: { status: string; resultCount: number } | null;
+  unrelatedPrimaryOutboundText?: string;
   unrelatedLaterOutboundText?: string;
   onRun?: () => void;
 }) {
@@ -58,16 +62,23 @@ async function runFollowUp(params?: {
       const model = prompt.model ?? "primary-model";
       const replyText =
         call === 1
-          ? "hello from the primary model"
+          ? (params?.primaryReplyText ?? "hello from the primary model")
           : (params?.alternateReplyText ?? "the model switch handoff completed");
       state.addOutboundMessage({
         accountId: "qa-channel",
         to: "dm:qa-operator",
         text:
-          call === 2
-            ? (params?.alternateOutboundText ?? replyText)
-            : "hello from the primary model",
+          call === 1
+            ? (params?.primaryOutboundText ?? replyText)
+            : (params?.alternateOutboundText ?? replyText),
       });
+      if (call === 1 && params?.unrelatedPrimaryOutboundText) {
+        state.addOutboundMessage({
+          accountId: "qa-channel",
+          to: "dm:qa-operator",
+          text: params.unrelatedPrimaryOutboundText,
+        });
+      }
       if (call === 2 && params?.unrelatedLaterOutboundText) {
         state.addOutboundMessage({
           accountId: "qa-channel",
@@ -75,17 +86,15 @@ async function runFollowUp(params?: {
           text: params.unrelatedLaterOutboundText,
         });
       }
+      const terminalDelivery = call === 1 ? params?.primaryDelivery : params?.alternateDelivery;
       return {
         started: { runId },
         waited: {
           status: "ok",
-          ...(call === 2 && params?.alternateDelivery === null
+          ...(terminalDelivery === null
             ? {}
             : {
-                terminalDelivery:
-                  call === 2
-                    ? (params?.alternateDelivery ?? { status: "sent", resultCount: 1 })
-                    : { status: "sent", resultCount: 1 },
+                terminalDelivery: terminalDelivery ?? { status: "sent", resultCount: 1 },
               }),
           terminalReply: { disposition: "visible", text: replyText },
           terminalReceipt: terminalReceipt({
@@ -120,6 +129,8 @@ async function runFollowUp(params?: {
 describe("model-switch follow-up terminal evidence", () => {
   it("invokes the canonical alias target and records exact run-owned evidence", async () => {
     const { result, runAgentPrompt } = await runFollowUp({
+      primaryReplyText: "hello **from the primary model**",
+      primaryOutboundText: "hello from the primary model",
       alternateReplyText: "the **model switch** handoff completed",
       alternateOutboundText: "the model switch handoff completed",
     });
@@ -138,6 +149,7 @@ describe("model-switch follow-up terminal evidence", () => {
       },
       terminalDelivery: { status: "sent", resultCount: 1 },
     });
+    expect(result.steps[0]?.details).toBe("hello **from the primary model**");
     expect(result.steps[1]?.details).toBe("the **model switch** handoff completed");
   });
 
@@ -163,6 +175,23 @@ describe("model-switch follow-up terminal evidence", () => {
       }),
     ).rejects.toThrow("alternate-model terminal reply missed switch continuity");
   });
+
+  it.each([
+    ["missing", null],
+    ["suppressed", { status: "suppressed", resultCount: 0 }],
+    ["zero-count", { status: "sent", resultCount: 0 }],
+  ] as const)(
+    "rejects %s primary delivery evidence despite identical and unrelated bus messages",
+    async (_, evidence) => {
+      await expect(
+        runFollowUp({
+          primaryDelivery: evidence,
+          primaryOutboundText: "hello from the primary model",
+          unrelatedPrimaryOutboundText: "an unrelated run also replied",
+        }),
+      ).rejects.toThrow("default-model run did not return owned sent delivery evidence");
+    },
+  );
 
   it.each([
     ["missing", null],

--- a/extensions/qa-lab/src/scenario-catalog-model-switch-tool-continuity-proof.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-model-switch-tool-continuity-proof.test.ts
@@ -1,0 +1,168 @@
+import path from "node:path";
+import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createQaBusState } from "./bus-state.js";
+import { hasModelSwitchContinuitySignal } from "./model-switch-eval.js";
+import { runLoadedScenarioFlow } from "./scenario-flow-runner.test-support.js";
+import { readSessionTranscriptSummary } from "./suite-runtime-agent-session.js";
+import { createTempDirHarness } from "./temp-dir.test-helper.js";
+
+const { cleanup, makeTempDir } = createTempDirHarness();
+const sessionKey = "agent:qa:model-switch-tools";
+const sessionId = "model-switch-tool-continuity";
+const oldCallId = "read-before-switch";
+const newCallId = "read-after-switch";
+
+afterEach(cleanup);
+
+type ProviderMode = "mock-openai" | "live-frontier";
+type ToolEvidence = "successful" | "failed" | "planned-only" | "old-only";
+
+async function runModelSwitchToolContinuityFlow(params: {
+  providerMode: ProviderMode;
+  evidence: ToolEvidence;
+}) {
+  const tempRoot = await makeTempDir("qa-model-switch-tool-continuity-");
+  const runtimeEnv = { ...process.env, OPENCLAW_STATE_DIR: path.join(tempRoot, "state") };
+  await upsertSessionEntry({
+    agentId: "qa",
+    env: runtimeEnv,
+    sessionKey,
+    entry: { sessionId, updatedAt: Date.now() },
+  });
+
+  const state = createQaBusState();
+  const requests: Array<{
+    allInputText: string;
+    model: string;
+    plannedToolCallId: string;
+    plannedToolName: string;
+  }> = [];
+  const readTranscriptSummary = vi.fn(readSessionTranscriptSummary);
+  const env = {
+    providerMode: params.providerMode,
+    primaryModel: "openai/primary-model",
+    alternateModel: "openai/alternate-model",
+    gateway: { tempRoot },
+    ...(params.providerMode === "mock-openai" ? { mock: { baseUrl: "http://qa.mock" } } : {}),
+  };
+  const appendMessage = async (message: unknown) =>
+    await appendSessionTranscriptMessageByIdentity({
+      agentId: "qa",
+      env: runtimeEnv,
+      sessionId,
+      sessionKey,
+      message,
+    });
+  const appendToolCall = async (toolCallId: string) =>
+    await appendMessage({
+      role: "assistant",
+      content: [{ type: "toolCall", id: toolCallId, name: "read", arguments: {} }],
+    });
+  const appendToolResult = async (toolCallId: string, isError = false) =>
+    await appendMessage({
+      role: "toolResult",
+      toolCallId,
+      toolName: "read",
+      isError,
+      timestamp: Date.now(),
+      content: [{ type: "text", text: isError ? "read failed" : "QA scenario pack mission" }],
+    });
+
+  const result = await runLoadedScenarioFlow("model-switch-tool-continuity", {
+    state,
+    api: {
+      env,
+      hasModelSwitchContinuitySignal,
+      readSessionTranscriptSummary: readTranscriptSummary,
+      resolveQaLiveTurnTimeoutMs: (_env: unknown, timeoutMs: number) => timeoutMs,
+      splitModelRef: (ref: string) => {
+        const slash = ref.indexOf("/");
+        return { provider: ref.slice(0, slash), model: ref.slice(slash + 1) };
+      },
+      fetchJson: async (input: string) => {
+        const url = new URL(input);
+        if (url.pathname === "/debug/request-cursor") {
+          return { cursor: requests.length };
+        }
+        if (url.pathname === "/debug/requests") {
+          return requests.slice(Number(url.searchParams.get("after") ?? 0));
+        }
+        throw new Error(`unexpected mock provider endpoint: ${url.pathname}`);
+      },
+      runAgentPrompt: async (_env: unknown, prompt: { message: string; model?: string }) => {
+        const isFollowup = requests.length > 0;
+        const callId = isFollowup ? newCallId : oldCallId;
+        requests.push({
+          allInputText: prompt.message,
+          model: prompt.model ?? "primary-model",
+          plannedToolCallId: callId,
+          plannedToolName: "read",
+        });
+
+        await appendMessage({ role: "user", content: prompt.message });
+        if (!isFollowup || params.evidence !== "old-only") {
+          await appendToolCall(callId);
+        }
+        if (!isFollowup || params.evidence === "successful" || params.evidence === "failed") {
+          await appendToolResult(callId, isFollowup && params.evidence === "failed");
+        }
+        const reply = isFollowup
+          ? "The model handoff preserved the QA mission after rereading the scenario pack."
+          : "The QA scenario pack mission is to verify source and docs.";
+        await appendMessage({ role: "assistant", content: reply });
+        state.addOutboundMessage({ accountId: "qa-channel", to: "dm:qa-operator", text: reply });
+      },
+    },
+  });
+
+  return { result, readTranscriptSummary };
+}
+
+describe("model-switch tool continuity scenario persisted evidence", () => {
+  it.each(["mock-openai", "live-frontier"] as const)(
+    "accepts only a successful correlated read from after the model switch (%s)",
+    async (providerMode) => {
+      const { result, readTranscriptSummary } = await runModelSwitchToolContinuityFlow({
+        providerMode,
+        evidence: "successful",
+      });
+
+      expect(result.status).toBe("pass");
+      expect(readTranscriptSummary).toHaveBeenCalledWith(expect.anything(), sessionKey);
+      expect(readTranscriptSummary).toHaveBeenCalledWith(
+        expect.anything(),
+        sessionKey,
+        expect.objectContaining({ afterEventCursor: expect.any(Number) }),
+      );
+    },
+  );
+
+  it.each(["mock-openai", "live-frontier"] as const)(
+    "rejects a fabricated handoff when only the prior turn successfully read (%s)",
+    async (providerMode) => {
+      await expect(
+        runModelSwitchToolContinuityFlow({ providerMode, evidence: "old-only" }),
+      ).rejects.toThrow(/read.*switch|switch.*read/i);
+    },
+  );
+
+  it.each(["mock-openai", "live-frontier"] as const)(
+    "rejects a planned post-switch read that returned an error (%s)",
+    async (providerMode) => {
+      await expect(
+        runModelSwitchToolContinuityFlow({ providerMode, evidence: "failed" }),
+      ).rejects.toThrow(/read.*switch|switch.*read/i);
+    },
+  );
+
+  it.each(["mock-openai", "live-frontier"] as const)(
+    "rejects a planned post-switch read without a correlated result (%s)",
+    async (providerMode) => {
+      await expect(
+        runModelSwitchToolContinuityFlow({ providerMode, evidence: "planned-only" }),
+      ).rejects.toThrow(/read.*switch|switch.*read/i);
+    },
+  );
+});

--- a/extensions/qa-lab/src/scenario-catalog-model-switch-tool-continuity-proof.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-model-switch-tool-continuity-proof.test.ts
@@ -1,11 +1,15 @@
 import path from "node:path";
+import { parseModelRef } from "openclaw/plugin-sdk/agent-runtime";
 import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createQaBusState } from "./bus-state.js";
 import { hasModelSwitchContinuitySignal } from "./model-switch-eval.js";
 import { runLoadedScenarioFlow } from "./scenario-flow-runner.test-support.js";
-import { readSessionTranscriptSummary } from "./suite-runtime-agent-session.js";
+import {
+  readRawQaSessionStore,
+  readSessionTranscriptSummary,
+} from "./suite-runtime-agent-session.js";
 import { createTempDirHarness } from "./temp-dir.test-helper.js";
 
 const { cleanup, makeTempDir } = createTempDirHarness();
@@ -17,11 +21,21 @@ const newCallId = "read-after-switch";
 afterEach(cleanup);
 
 type ProviderMode = "mock-openai" | "live-frontier";
-type ToolEvidence = "successful" | "delayed-success" | "failed" | "planned-only" | "old-only";
+type ToolEvidence =
+  | "successful"
+  | "delayed-success"
+  | "delayed-initial-only"
+  | "failed"
+  | "planned-only"
+  | "old-only";
 
 async function runModelSwitchToolContinuityFlow(params: {
   providerMode: ProviderMode;
   evidence: ToolEvidence;
+  alternateModel?: string;
+  previousAttemptSuccessfulRead?: boolean;
+  followupDelivery?: "visible" | "deleted-only" | "deleted-preview-then-visible";
+  persistedFollowUpModel?: { provider: string; model: string };
 }) {
   const tempRoot = await makeTempDir("qa-model-switch-tool-continuity-");
   const runtimeEnv = { ...process.env, OPENCLAW_STATE_DIR: path.join(tempRoot, "state") };
@@ -42,8 +56,14 @@ async function runModelSwitchToolContinuityFlow(params: {
   const env = {
     providerMode: params.providerMode,
     primaryModel: "openai/primary-model",
-    alternateModel: "openai/alternate-model",
-    gateway: { tempRoot },
+    alternateModel: params.alternateModel ?? "openai/alternate-model",
+    gateway: {
+      baseUrl: "http://qa.gateway",
+      tempRoot,
+      workspaceDir: path.join(tempRoot, "workspace"),
+      runtimeEnv,
+      call: async () => undefined,
+    },
     ...(params.providerMode === "mock-openai" ? { mock: { baseUrl: "http://qa.mock" } } : {}),
   };
   const appendMessage = async (message: unknown) =>
@@ -68,18 +88,32 @@ async function runModelSwitchToolContinuityFlow(params: {
       timestamp: Date.now(),
       content: [{ type: "text", text: isError ? "read failed" : "QA scenario pack mission" }],
     });
+  if (params.previousAttemptSuccessfulRead) {
+    await appendToolCall("read-previous-attempt");
+    await appendToolResult("read-previous-attempt");
+  }
   const scopedSuccessfulReadCounts: number[] = [];
   let delayedReadPersisted = false;
+  let initialReadPersisted = false;
   const readTranscriptSummary = vi.fn(
     async (
       summaryEnv: Parameters<typeof readSessionTranscriptSummary>[0],
       requestedSessionKey: string,
       options?: Parameters<typeof readSessionTranscriptSummary>[2],
     ) => {
+      if (
+        options?.afterEventCursor !== undefined &&
+        params.evidence === "delayed-initial-only" &&
+        !initialReadPersisted
+      ) {
+        initialReadPersisted = true;
+        await appendToolCall(oldCallId);
+        await appendToolResult(oldCallId);
+      }
       const summary = await readSessionTranscriptSummary(summaryEnv, requestedSessionKey, options);
       if (options?.afterEventCursor !== undefined) {
         scopedSuccessfulReadCounts.push(summary.successfulToolCallCounts.read ?? 0);
-        if (params.evidence === "delayed-success" && !delayedReadPersisted) {
+        if (params.evidence === "delayed-success" && requests.length > 1 && !delayedReadPersisted) {
           const wholeSession = await readSessionTranscriptSummary(summaryEnv, requestedSessionKey);
           expect(wholeSession.successfulToolCallCounts.read).toBe(1);
           expect(summary.successfulToolCallCounts.read ?? 0).toBe(0);
@@ -90,12 +124,15 @@ async function runModelSwitchToolContinuityFlow(params: {
       return summary;
     },
   );
-
   const result = await runLoadedScenarioFlow("model-switch-tool-continuity", {
     state,
     api: {
       env,
       hasModelSwitchContinuitySignal,
+      normalizeLowercaseStringOrEmpty: (value: unknown) =>
+        typeof value === "string" ? value.trim().toLowerCase() : "",
+      normalizeModelRef: (raw: string) => parseModelRef(raw, raw.split("/")[0] ?? ""),
+      readRawQaSessionStore,
       readSessionTranscriptSummary: readTranscriptSummary,
       resolveQaLiveTurnTimeoutMs: (_env: unknown, timeoutMs: number) => timeoutMs,
       splitModelRef: (ref: string) => {
@@ -112,28 +149,95 @@ async function runModelSwitchToolContinuityFlow(params: {
         }
         throw new Error(`unexpected mock provider endpoint: ${url.pathname}`);
       },
-      runAgentPrompt: async (_env: unknown, prompt: { message: string; model?: string }) => {
+      runAgentPrompt: async (
+        _env: unknown,
+        prompt: {
+          message: string;
+          model?: string;
+          provider?: string;
+          transcriptToolName?: string;
+          requireSuccessfulTranscriptToolResult?: boolean;
+        },
+      ) => {
         const isFollowup = requests.length > 0;
         const callId = isFollowup ? newCallId : oldCallId;
+        const isDelayedInitialRead = !isFollowup && params.evidence === "delayed-initial-only";
         requests.push({
           allInputText: prompt.message,
-          model: prompt.model ?? "primary-model",
+          model:
+            parseModelRef(
+              `${prompt.provider ?? "openai"}/${prompt.model ?? "primary-model"}`,
+              prompt.provider ?? "openai",
+            )?.model ?? "",
           plannedToolCallId: callId,
           plannedToolName: "read",
         });
+        const actualModel =
+          isFollowup && params.persistedFollowUpModel
+            ? params.persistedFollowUpModel
+            : { provider: prompt.provider ?? "openai", model: prompt.model ?? "primary-model" };
+        await upsertSessionEntry({
+          agentId: "qa",
+          env: runtimeEnv,
+          sessionKey,
+          entry: {
+            sessionId,
+            updatedAt: Date.now(),
+            modelProvider: actualModel.provider,
+            model: actualModel.model,
+          },
+        });
 
         await appendMessage({ role: "user", content: prompt.message });
-        if (!isFollowup || params.evidence !== "old-only") {
+        if (
+          !isDelayedInitialRead &&
+          (!isFollowup ||
+            (params.evidence !== "old-only" && params.evidence !== "delayed-initial-only"))
+        ) {
           await appendToolCall(callId);
         }
-        if (!isFollowup || params.evidence === "successful" || params.evidence === "failed") {
+        if (
+          (!isFollowup && !isDelayedInitialRead) ||
+          params.evidence === "successful" ||
+          params.evidence === "failed"
+        ) {
           await appendToolResult(callId, isFollowup && params.evidence === "failed");
         }
         const reply = isFollowup
           ? "The model handoff preserved the QA mission after rereading the scenario pack."
           : "The QA scenario pack mission is to verify source and docs.";
         await appendMessage({ role: "assistant", content: reply });
-        state.addOutboundMessage({ accountId: "qa-channel", to: "dm:qa-operator", text: reply });
+        const outbound = state.addOutboundMessage({
+          accountId: "qa-channel",
+          to: "dm:qa-operator",
+          text: reply,
+        });
+        if (isFollowup && params.followupDelivery !== undefined) {
+          if (params.followupDelivery !== "visible") {
+            state.deleteMessage({ accountId: "qa-channel", messageId: outbound.id });
+          }
+          if (params.followupDelivery === "deleted-preview-then-visible") {
+            state.addOutboundMessage({
+              accountId: "qa-channel",
+              to: "dm:qa-operator",
+              text: reply,
+            });
+          }
+        }
+        if (
+          isDelayedInitialRead &&
+          prompt.transcriptToolName === "read" &&
+          prompt.requireSuccessfulTranscriptToolResult === true
+        ) {
+          const wholeSession = await readSessionTranscriptSummary(env, sessionKey, {
+            allowEmpty: true,
+          });
+          if ((wholeSession.successfulToolCallCounts.read ?? 0) === 0) {
+            initialReadPersisted = true;
+            await appendToolCall(oldCallId);
+            await appendToolResult(oldCallId);
+          }
+        }
       },
     },
   });
@@ -151,7 +255,11 @@ describe("model-switch tool continuity scenario persisted evidence", () => {
       });
 
       expect(result.status).toBe("pass");
-      expect(readTranscriptSummary).toHaveBeenCalledWith(expect.anything(), sessionKey);
+      expect(readTranscriptSummary).toHaveBeenCalledWith(
+        expect.anything(),
+        sessionKey,
+        expect.objectContaining({ allowEmpty: true }),
+      );
       expect(readTranscriptSummary).toHaveBeenCalledWith(
         expect.anything(),
         sessionKey,
@@ -169,7 +277,26 @@ describe("model-switch tool continuity scenario persisted evidence", () => {
       });
 
       expect(result.status).toBe("pass");
-      expect(scopedSuccessfulReadCounts).toEqual([0, 1]);
+      expect(scopedSuccessfulReadCounts).toEqual([1, 0, 1]);
+    },
+  );
+
+  it.each([
+    ["mock-openai", "anthropic/opus"],
+    ["live-frontier", "anthropic/opus"],
+    ["mock-openai", "Anthropic/OPUS"],
+    ["live-frontier", "Anthropic/OPUS"],
+  ] as const)(
+    "accepts the canonical persisted model for the requested %s alias %s",
+    async (providerMode, alternateModel) => {
+      const { result } = await runModelSwitchToolContinuityFlow({
+        providerMode,
+        evidence: "successful",
+        alternateModel,
+        persistedFollowUpModel: { provider: "anthropic", model: "claude-opus-5" },
+      });
+
+      expect(result.status).toBe("pass");
     },
   );
 
@@ -179,6 +306,72 @@ describe("model-switch tool continuity scenario persisted evidence", () => {
       await expect(
         runModelSwitchToolContinuityFlow({ providerMode, evidence: "old-only" }),
       ).rejects.toThrow(/read.*switch|switch.*read|test condition was not met/i);
+    },
+  );
+
+  it.each(["mock-openai", "live-frontier"] as const)(
+    "rejects an initial-turn read that persists after the baseline when the alternate never reads (%s)",
+    async (providerMode) => {
+      await expect(
+        runModelSwitchToolContinuityFlow({ providerMode, evidence: "delayed-initial-only" }),
+      ).rejects.toThrow(/read.*switch|switch.*read|test condition was not met/i);
+    },
+  );
+
+  it.each(["mock-openai", "live-frontier"] as const)(
+    "rejects a delayed current initial read when a previous attempt already persisted a read (%s)",
+    async (providerMode) => {
+      await expect(
+        runModelSwitchToolContinuityFlow({
+          providerMode,
+          evidence: "delayed-initial-only",
+          previousAttemptSuccessfulRead: true,
+        }),
+      ).rejects.toThrow(/read.*switch|switch.*read|test condition was not met/i);
+    },
+  );
+
+  it.each([
+    ["mock-openai", "openai", "primary-model"],
+    ["mock-openai", "anthropic", "alternate-model"],
+    ["live-frontier", "openai", "primary-model"],
+    ["live-frontier", "anthropic", "alternate-model"],
+  ] as const)(
+    "rejects successful continuity when the persisted %s run used %s/%s",
+    async (providerMode, provider, model) => {
+      await expect(
+        runModelSwitchToolContinuityFlow({
+          providerMode,
+          evidence: "successful",
+          persistedFollowUpModel: { provider, model },
+        }),
+      ).rejects.toThrow(/alternate.*model|persisted.*model|model.*switch/i);
+    },
+  );
+
+  it.each(["mock-openai", "live-frontier"] as const)(
+    "rejects a deleted post-switch reply when no visible final response remains (%s)",
+    async (providerMode) => {
+      await expect(
+        runModelSwitchToolContinuityFlow({
+          providerMode,
+          evidence: "successful",
+          followupDelivery: "deleted-only",
+        }),
+      ).rejects.toThrow("test condition was not met");
+    },
+  );
+
+  it.each(["mock-openai", "live-frontier"] as const)(
+    "accepts a visible post-switch response after its streaming preview was deleted (%s)",
+    async (providerMode) => {
+      const { result } = await runModelSwitchToolContinuityFlow({
+        providerMode,
+        evidence: "successful",
+        followupDelivery: "deleted-preview-then-visible",
+      });
+
+      expect(result.status).toBe("pass");
     },
   );
 

--- a/extensions/qa-lab/src/scenario-catalog-model-switch-tool-continuity-proof.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-model-switch-tool-continuity-proof.test.ts
@@ -17,7 +17,7 @@ const newCallId = "read-after-switch";
 afterEach(cleanup);
 
 type ProviderMode = "mock-openai" | "live-frontier";
-type ToolEvidence = "successful" | "failed" | "planned-only" | "old-only";
+type ToolEvidence = "successful" | "delayed-success" | "failed" | "planned-only" | "old-only";
 
 async function runModelSwitchToolContinuityFlow(params: {
   providerMode: ProviderMode;
@@ -39,7 +39,6 @@ async function runModelSwitchToolContinuityFlow(params: {
     plannedToolCallId: string;
     plannedToolName: string;
   }> = [];
-  const readTranscriptSummary = vi.fn(readSessionTranscriptSummary);
   const env = {
     providerMode: params.providerMode,
     primaryModel: "openai/primary-model",
@@ -69,6 +68,28 @@ async function runModelSwitchToolContinuityFlow(params: {
       timestamp: Date.now(),
       content: [{ type: "text", text: isError ? "read failed" : "QA scenario pack mission" }],
     });
+  const scopedSuccessfulReadCounts: number[] = [];
+  let delayedReadPersisted = false;
+  const readTranscriptSummary = vi.fn(
+    async (
+      summaryEnv: Parameters<typeof readSessionTranscriptSummary>[0],
+      requestedSessionKey: string,
+      options?: Parameters<typeof readSessionTranscriptSummary>[2],
+    ) => {
+      const summary = await readSessionTranscriptSummary(summaryEnv, requestedSessionKey, options);
+      if (options?.afterEventCursor !== undefined) {
+        scopedSuccessfulReadCounts.push(summary.successfulToolCallCounts.read ?? 0);
+        if (params.evidence === "delayed-success" && !delayedReadPersisted) {
+          const wholeSession = await readSessionTranscriptSummary(summaryEnv, requestedSessionKey);
+          expect(wholeSession.successfulToolCallCounts.read).toBe(1);
+          expect(summary.successfulToolCallCounts.read ?? 0).toBe(0);
+          delayedReadPersisted = true;
+          await appendToolResult(newCallId);
+        }
+      }
+      return summary;
+    },
+  );
 
   const result = await runLoadedScenarioFlow("model-switch-tool-continuity", {
     state,
@@ -117,7 +138,7 @@ async function runModelSwitchToolContinuityFlow(params: {
     },
   });
 
-  return { result, readTranscriptSummary };
+  return { result, readTranscriptSummary, scopedSuccessfulReadCounts };
 }
 
 describe("model-switch tool continuity scenario persisted evidence", () => {
@@ -140,11 +161,24 @@ describe("model-switch tool continuity scenario persisted evidence", () => {
   );
 
   it.each(["mock-openai", "live-frontier"] as const)(
+    "waits for the new correlated read when its SQLite result persists after agent completion (%s)",
+    async (providerMode) => {
+      const { result, scopedSuccessfulReadCounts } = await runModelSwitchToolContinuityFlow({
+        providerMode,
+        evidence: "delayed-success",
+      });
+
+      expect(result.status).toBe("pass");
+      expect(scopedSuccessfulReadCounts).toEqual([0, 1]);
+    },
+  );
+
+  it.each(["mock-openai", "live-frontier"] as const)(
     "rejects a fabricated handoff when only the prior turn successfully read (%s)",
     async (providerMode) => {
       await expect(
         runModelSwitchToolContinuityFlow({ providerMode, evidence: "old-only" }),
-      ).rejects.toThrow(/read.*switch|switch.*read/i);
+      ).rejects.toThrow(/read.*switch|switch.*read|test condition was not met/i);
     },
   );
 
@@ -153,7 +187,7 @@ describe("model-switch tool continuity scenario persisted evidence", () => {
     async (providerMode) => {
       await expect(
         runModelSwitchToolContinuityFlow({ providerMode, evidence: "failed" }),
-      ).rejects.toThrow(/read.*switch|switch.*read/i);
+      ).rejects.toThrow(/read.*switch|switch.*read|test condition was not met/i);
     },
   );
 
@@ -162,7 +196,7 @@ describe("model-switch tool continuity scenario persisted evidence", () => {
     async (providerMode) => {
       await expect(
         runModelSwitchToolContinuityFlow({ providerMode, evidence: "planned-only" }),
-      ).rejects.toThrow(/read.*switch|switch.*read/i);
+      ).rejects.toThrow(/read.*switch|switch.*read|test condition was not met/i);
     },
   );
 });

--- a/extensions/qa-lab/src/scenario-catalog-model-switch-tool-continuity-proof.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-model-switch-tool-continuity-proof.test.ts
@@ -23,9 +23,12 @@ function normalizeModelRef(raw: string) {
 async function runToolContinuity(
   alternateTools: string[],
   params?: {
+    primaryOutboundText?: string;
+    primaryDelivery?: { status: string; resultCount: number } | null;
     alternateReplyText?: string;
     alternateOutboundText?: string;
     alternateDelivery?: { status: string; resultCount: number } | null;
+    unrelatedPrimaryOutboundText?: string;
     unrelatedLaterOutboundText?: string;
   },
 ) {
@@ -45,8 +48,18 @@ async function runToolContinuity(
       state.addOutboundMessage({
         accountId: "qa-channel",
         to: "dm:qa-operator",
-        text: call === 2 ? (params?.alternateOutboundText ?? replyText) : replyText,
+        text:
+          call === 1
+            ? (params?.primaryOutboundText ?? replyText)
+            : (params?.alternateOutboundText ?? replyText),
       });
+      if (call === 1 && params?.unrelatedPrimaryOutboundText) {
+        state.addOutboundMessage({
+          accountId: "qa-channel",
+          to: "dm:qa-operator",
+          text: params.unrelatedPrimaryOutboundText,
+        });
+      }
       if (call === 2 && params?.unrelatedLaterOutboundText) {
         state.addOutboundMessage({
           accountId: "qa-channel",
@@ -54,17 +67,15 @@ async function runToolContinuity(
           text: params.unrelatedLaterOutboundText,
         });
       }
+      const terminalDelivery = call === 1 ? params?.primaryDelivery : params?.alternateDelivery;
       return {
         started: { runId },
         waited: {
           status: "ok",
-          ...(call === 2 && params?.alternateDelivery === null
+          ...(terminalDelivery === null
             ? {}
             : {
-                terminalDelivery:
-                  call === 2
-                    ? (params?.alternateDelivery ?? { status: "sent", resultCount: 1 })
-                    : { status: "sent", resultCount: 1 },
+                terminalDelivery: terminalDelivery ?? { status: "sent", resultCount: 1 },
               }),
           terminalReply: { disposition: "visible", text: replyText },
           terminalReceipt: {
@@ -145,6 +156,23 @@ describe("model-switch tool continuity terminal evidence", () => {
       }),
     ).rejects.toThrow("alternate-model terminal reply missed kickoff continuity");
   });
+
+  it.each([
+    ["missing", null],
+    ["suppressed", { status: "suppressed", resultCount: 0 }],
+    ["zero-count", { status: "sent", resultCount: 0 }],
+  ] as const)(
+    "rejects %s primary delivery evidence despite identical and unrelated bus messages",
+    async (_, evidence) => {
+      await expect(
+        runToolContinuity(["read"], {
+          primaryDelivery: evidence,
+          primaryOutboundText: "the QA scenario pack verifies source and docs",
+          unrelatedPrimaryOutboundText: "an unrelated tool run also replied",
+        }),
+      ).rejects.toThrow("default-model run did not return owned sent delivery evidence");
+    },
+  );
 
   it.each([
     ["missing", null],

--- a/extensions/qa-lab/src/scenario-catalog-model-switch-tool-continuity-proof.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-model-switch-tool-continuity-proof.test.ts
@@ -1,395 +1,81 @@
-import path from "node:path";
-import { parseModelRef } from "openclaw/plugin-sdk/agent-runtime";
-import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
-import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { createQaBusState } from "./bus-state.js";
 import { hasModelSwitchContinuitySignal } from "./model-switch-eval.js";
 import { runLoadedScenarioFlow } from "./scenario-flow-runner.test-support.js";
-import {
-  readRawQaSessionStore,
-  readSessionTranscriptSummary,
-} from "./suite-runtime-agent-session.js";
-import { createTempDirHarness } from "./temp-dir.test-helper.js";
 
-const { cleanup, makeTempDir } = createTempDirHarness();
-const sessionKey = "agent:qa:model-switch-tools";
-const sessionId = "model-switch-tool-continuity";
-const oldCallId = "read-before-switch";
-const newCallId = "read-after-switch";
-
-afterEach(cleanup);
-
-type ProviderMode = "mock-openai" | "live-frontier";
-type ToolEvidence =
-  | "successful"
-  | "delayed-success"
-  | "delayed-initial-only"
-  | "failed"
-  | "planned-only"
-  | "old-only";
-
-async function runModelSwitchToolContinuityFlow(params: {
-  providerMode: ProviderMode;
-  evidence: ToolEvidence;
-  alternateModel?: string;
-  previousAttemptSuccessfulRead?: boolean;
-  followupDelivery?: "visible" | "deleted-only" | "deleted-preview-then-visible";
-  persistedFollowUpModel?: { provider: string; model: string };
-}) {
-  const tempRoot = await makeTempDir("qa-model-switch-tool-continuity-");
-  const runtimeEnv = { ...process.env, OPENCLAW_STATE_DIR: path.join(tempRoot, "state") };
-  await upsertSessionEntry({
-    agentId: "qa",
-    env: runtimeEnv,
-    sessionKey,
-    entry: { sessionId, updatedAt: Date.now() },
-  });
-
-  const state = createQaBusState();
-  const requests: Array<{
-    allInputText: string;
-    model: string;
-    plannedToolCallId: string;
-    plannedToolName: string;
-  }> = [];
-  const env = {
-    providerMode: params.providerMode,
-    primaryModel: "openai/primary-model",
-    alternateModel: params.alternateModel ?? "openai/alternate-model",
-    gateway: {
-      baseUrl: "http://qa.gateway",
-      tempRoot,
-      workspaceDir: path.join(tempRoot, "workspace"),
-      runtimeEnv,
-      call: async () => undefined,
-    },
-    ...(params.providerMode === "mock-openai" ? { mock: { baseUrl: "http://qa.mock" } } : {}),
-  };
-  const appendMessage = async (message: unknown) =>
-    await appendSessionTranscriptMessageByIdentity({
-      agentId: "qa",
-      env: runtimeEnv,
-      sessionId,
-      sessionKey,
-      message,
-    });
-  const appendToolCall = async (toolCallId: string) =>
-    await appendMessage({
-      role: "assistant",
-      content: [{ type: "toolCall", id: toolCallId, name: "read", arguments: {} }],
-    });
-  const appendToolResult = async (toolCallId: string, isError = false) =>
-    await appendMessage({
-      role: "toolResult",
-      toolCallId,
-      toolName: "read",
-      isError,
-      timestamp: Date.now(),
-      content: [{ type: "text", text: isError ? "read failed" : "QA scenario pack mission" }],
-    });
-  if (params.previousAttemptSuccessfulRead) {
-    await appendToolCall("read-previous-attempt");
-    await appendToolResult("read-previous-attempt");
-  }
-  const scopedSuccessfulReadCounts: number[] = [];
-  let delayedReadPersisted = false;
-  let initialReadPersisted = false;
-  const readTranscriptSummary = vi.fn(
-    async (
-      summaryEnv: Parameters<typeof readSessionTranscriptSummary>[0],
-      requestedSessionKey: string,
-      options?: Parameters<typeof readSessionTranscriptSummary>[2],
-    ) => {
-      if (
-        options?.afterEventCursor !== undefined &&
-        params.evidence === "delayed-initial-only" &&
-        !initialReadPersisted
-      ) {
-        initialReadPersisted = true;
-        await appendToolCall(oldCallId);
-        await appendToolResult(oldCallId);
-      }
-      const summary = await readSessionTranscriptSummary(summaryEnv, requestedSessionKey, options);
-      if (options?.afterEventCursor !== undefined) {
-        scopedSuccessfulReadCounts.push(summary.successfulToolCallCounts.read ?? 0);
-        if (params.evidence === "delayed-success" && requests.length > 1 && !delayedReadPersisted) {
-          const wholeSession = await readSessionTranscriptSummary(summaryEnv, requestedSessionKey);
-          expect(wholeSession.successfulToolCallCounts.read).toBe(1);
-          expect(summary.successfulToolCallCounts.read ?? 0).toBe(0);
-          delayedReadPersisted = true;
-          await appendToolResult(newCallId);
-        }
-      }
-      return summary;
-    },
-  );
-  const result = await runLoadedScenarioFlow("model-switch-tool-continuity", {
-    state,
-    api: {
-      env,
-      hasModelSwitchContinuitySignal,
-      normalizeLowercaseStringOrEmpty: (value: unknown) =>
-        typeof value === "string" ? value.trim().toLowerCase() : "",
-      normalizeModelRef: (raw: string) => parseModelRef(raw, raw.split("/")[0] ?? ""),
-      readRawQaSessionStore,
-      readSessionTranscriptSummary: readTranscriptSummary,
-      resolveQaLiveTurnTimeoutMs: (_env: unknown, timeoutMs: number) => timeoutMs,
-      splitModelRef: (ref: string) => {
-        const slash = ref.indexOf("/");
-        return { provider: ref.slice(0, slash), model: ref.slice(slash + 1) };
-      },
-      fetchJson: async (input: string) => {
-        const url = new URL(input);
-        if (url.pathname === "/debug/request-cursor") {
-          return { cursor: requests.length };
-        }
-        if (url.pathname === "/debug/requests") {
-          return requests.slice(Number(url.searchParams.get("after") ?? 0));
-        }
-        throw new Error(`unexpected mock provider endpoint: ${url.pathname}`);
-      },
-      runAgentPrompt: async (
-        _env: unknown,
-        prompt: {
-          message: string;
-          model?: string;
-          provider?: string;
-          transcriptToolName?: string;
-          requireSuccessfulTranscriptToolResult?: boolean;
-        },
-      ) => {
-        const isFollowup = requests.length > 0;
-        const callId = isFollowup ? newCallId : oldCallId;
-        const isDelayedInitialRead = !isFollowup && params.evidence === "delayed-initial-only";
-        requests.push({
-          allInputText: prompt.message,
-          model:
-            parseModelRef(
-              `${prompt.provider ?? "openai"}/${prompt.model ?? "primary-model"}`,
-              prompt.provider ?? "openai",
-            )?.model ?? "",
-          plannedToolCallId: callId,
-          plannedToolName: "read",
-        });
-        const actualModel =
-          isFollowup && params.persistedFollowUpModel
-            ? params.persistedFollowUpModel
-            : { provider: prompt.provider ?? "openai", model: prompt.model ?? "primary-model" };
-        await upsertSessionEntry({
-          agentId: "qa",
-          env: runtimeEnv,
-          sessionKey,
-          entry: {
-            sessionId,
-            updatedAt: Date.now(),
-            modelProvider: actualModel.provider,
-            model: actualModel.model,
-          },
-        });
-
-        await appendMessage({ role: "user", content: prompt.message });
-        if (
-          !isDelayedInitialRead &&
-          (!isFollowup ||
-            (params.evidence !== "old-only" && params.evidence !== "delayed-initial-only"))
-        ) {
-          await appendToolCall(callId);
-        }
-        if (
-          (!isFollowup && !isDelayedInitialRead) ||
-          params.evidence === "successful" ||
-          params.evidence === "failed"
-        ) {
-          await appendToolResult(callId, isFollowup && params.evidence === "failed");
-        }
-        const reply = isFollowup
-          ? "The model handoff preserved the QA mission after rereading the scenario pack."
-          : "The QA scenario pack mission is to verify source and docs.";
-        await appendMessage({ role: "assistant", content: reply });
-        const outbound = state.addOutboundMessage({
-          accountId: "qa-channel",
-          to: "dm:qa-operator",
-          text: reply,
-        });
-        if (isFollowup && params.followupDelivery !== undefined) {
-          if (params.followupDelivery !== "visible") {
-            state.deleteMessage({ accountId: "qa-channel", messageId: outbound.id });
-          }
-          if (params.followupDelivery === "deleted-preview-then-visible") {
-            state.addOutboundMessage({
-              accountId: "qa-channel",
-              to: "dm:qa-operator",
-              text: reply,
-            });
-          }
-        }
-        if (
-          isDelayedInitialRead &&
-          prompt.transcriptToolName === "read" &&
-          prompt.requireSuccessfulTranscriptToolResult === true
-        ) {
-          const wholeSession = await readSessionTranscriptSummary(env, sessionKey, {
-            allowEmpty: true,
-          });
-          if ((wholeSession.successfulToolCallCounts.read ?? 0) === 0) {
-            initialReadPersisted = true;
-            await appendToolCall(oldCallId);
-            await appendToolResult(oldCallId);
-          }
-        }
-      },
-    },
-  });
-
-  return { result, readTranscriptSummary, scopedSuccessfulReadCounts };
+function splitModelRef(raw: string) {
+  const [provider, ...model] = raw.split("/");
+  return provider && model.length
+    ? { provider: provider.toLowerCase(), model: model.join("/") }
+    : null;
 }
 
-describe("model-switch tool continuity scenario persisted evidence", () => {
-  it.each(["mock-openai", "live-frontier"] as const)(
-    "accepts only a successful correlated read from after the model switch (%s)",
-    async (providerMode) => {
-      const { result, readTranscriptSummary } = await runModelSwitchToolContinuityFlow({
-        providerMode,
-        evidence: "successful",
-      });
-
-      expect(result.status).toBe("pass");
-      expect(readTranscriptSummary).toHaveBeenCalledWith(
-        expect.anything(),
-        sessionKey,
-        expect.objectContaining({ allowEmpty: true }),
-      );
-      expect(readTranscriptSummary).toHaveBeenCalledWith(
-        expect.anything(),
-        sessionKey,
-        expect.objectContaining({ afterEventCursor: expect.any(Number) }),
-      );
+async function runToolContinuity(alternateTools: string[]) {
+  const state = createQaBusState();
+  let call = 0;
+  return await runLoadedScenarioFlow("model-switch-tool-continuity", {
+    state,
+    api: {
+      env: {
+        providerMode: "mock-openai",
+        primaryModel: "openai/primary-model",
+        alternateModel: "openai/alternate-model",
+        gateway: {},
+      },
+      splitModelRef,
+      normalizeModelRef: splitModelRef,
+      normalizeLowercaseStringOrEmpty: (value: unknown) =>
+        typeof value === "string" ? value.trim().toLowerCase() : "",
+      resolveQaLiveTurnTimeoutMs: (_env: unknown, timeoutMs: number) => timeoutMs,
+      hasModelSwitchContinuitySignal,
+      runAgentPrompt: async (_env: unknown, prompt: { provider?: string; model?: string }) => {
+        call += 1;
+        const runId = `run-${call}`;
+        const provider = prompt.provider ?? "openai";
+        const model = prompt.model ?? "primary-model";
+        state.addOutboundMessage({
+          accountId: "qa-channel",
+          to: "dm:qa-operator",
+          text:
+            call === 1
+              ? "the QA scenario pack verifies source and docs"
+              : "the model handoff preserved the QA mission after rereading the scenario pack",
+        });
+        return {
+          started: { runId },
+          waited: {
+            status: "ok",
+            terminalReceipt: {
+              runId,
+              sessionId: "session-tools",
+              turnId: `turn-${call}`,
+              requested: { provider, model },
+              effective: { provider, model, responseModel: model },
+              successfulToolNames: call === 1 ? ["read"] : alternateTools,
+              rerouted: false,
+              terminalDisposition: "visible",
+            },
+          },
+        };
+      },
     },
-  );
+  });
+}
 
-  it.each(["mock-openai", "live-frontier"] as const)(
-    "waits for the new correlated read when its SQLite result persists after agent completion (%s)",
-    async (providerMode) => {
-      const { result, scopedSuccessfulReadCounts } = await runModelSwitchToolContinuityFlow({
-        providerMode,
-        evidence: "delayed-success",
-      });
+describe("model-switch tool continuity terminal evidence", () => {
+  it("accepts a successful read owned by the alternate run", async () => {
+    const result = await runToolContinuity(["read"]);
 
-      expect(result.status).toBe("pass");
-      expect(scopedSuccessfulReadCounts).toEqual([1, 0, 1]);
-    },
-  );
+    expect(result.status).toBe("pass");
+    expect(result.modelSwitchEvidence).toMatchObject({
+      primary: { runId: "run-1", successfulToolNames: ["read"] },
+      alternate: { runId: "run-2", successfulToolNames: ["read"] },
+    });
+  });
 
-  it.each([
-    ["mock-openai", "anthropic/opus"],
-    ["live-frontier", "anthropic/opus"],
-    ["mock-openai", "Anthropic/OPUS"],
-    ["live-frontier", "Anthropic/OPUS"],
-  ] as const)(
-    "accepts the canonical persisted model for the requested %s alias %s",
-    async (providerMode, alternateModel) => {
-      const { result } = await runModelSwitchToolContinuityFlow({
-        providerMode,
-        evidence: "successful",
-        alternateModel,
-        persistedFollowUpModel: { provider: "anthropic", model: "claude-opus-5" },
-      });
-
-      expect(result.status).toBe("pass");
-    },
-  );
-
-  it.each(["mock-openai", "live-frontier"] as const)(
-    "rejects a fabricated handoff when only the prior turn successfully read (%s)",
-    async (providerMode) => {
-      await expect(
-        runModelSwitchToolContinuityFlow({ providerMode, evidence: "old-only" }),
-      ).rejects.toThrow(/read.*switch|switch.*read|test condition was not met/i);
-    },
-  );
-
-  it.each(["mock-openai", "live-frontier"] as const)(
-    "rejects an initial-turn read that persists after the baseline when the alternate never reads (%s)",
-    async (providerMode) => {
-      await expect(
-        runModelSwitchToolContinuityFlow({ providerMode, evidence: "delayed-initial-only" }),
-      ).rejects.toThrow(/read.*switch|switch.*read|test condition was not met/i);
-    },
-  );
-
-  it.each(["mock-openai", "live-frontier"] as const)(
-    "rejects a delayed current initial read when a previous attempt already persisted a read (%s)",
-    async (providerMode) => {
-      await expect(
-        runModelSwitchToolContinuityFlow({
-          providerMode,
-          evidence: "delayed-initial-only",
-          previousAttemptSuccessfulRead: true,
-        }),
-      ).rejects.toThrow(/read.*switch|switch.*read|test condition was not met/i);
-    },
-  );
-
-  it.each([
-    ["mock-openai", "openai", "primary-model"],
-    ["mock-openai", "anthropic", "alternate-model"],
-    ["live-frontier", "openai", "primary-model"],
-    ["live-frontier", "anthropic", "alternate-model"],
-  ] as const)(
-    "rejects successful continuity when the persisted %s run used %s/%s",
-    async (providerMode, provider, model) => {
-      await expect(
-        runModelSwitchToolContinuityFlow({
-          providerMode,
-          evidence: "successful",
-          persistedFollowUpModel: { provider, model },
-        }),
-      ).rejects.toThrow(/alternate.*model|persisted.*model|model.*switch/i);
-    },
-  );
-
-  it.each(["mock-openai", "live-frontier"] as const)(
-    "rejects a deleted post-switch reply when no visible final response remains (%s)",
-    async (providerMode) => {
-      await expect(
-        runModelSwitchToolContinuityFlow({
-          providerMode,
-          evidence: "successful",
-          followupDelivery: "deleted-only",
-        }),
-      ).rejects.toThrow("test condition was not met");
-    },
-  );
-
-  it.each(["mock-openai", "live-frontier"] as const)(
-    "accepts a visible post-switch response after its streaming preview was deleted (%s)",
-    async (providerMode) => {
-      const { result } = await runModelSwitchToolContinuityFlow({
-        providerMode,
-        evidence: "successful",
-        followupDelivery: "deleted-preview-then-visible",
-      });
-
-      expect(result.status).toBe("pass");
-    },
-  );
-
-  it.each(["mock-openai", "live-frontier"] as const)(
-    "rejects a planned post-switch read that returned an error (%s)",
-    async (providerMode) => {
-      await expect(
-        runModelSwitchToolContinuityFlow({ providerMode, evidence: "failed" }),
-      ).rejects.toThrow(/read.*switch|switch.*read|test condition was not met/i);
-    },
-  );
-
-  it.each(["mock-openai", "live-frontier"] as const)(
-    "rejects a planned post-switch read without a correlated result (%s)",
-    async (providerMode) => {
-      await expect(
-        runModelSwitchToolContinuityFlow({ providerMode, evidence: "planned-only" }),
-      ).rejects.toThrow(/read.*switch|switch.*read|test condition was not met/i);
-    },
-  );
+  it("does not let a successful prior-run read satisfy the alternate run", async () => {
+    await expect(runToolContinuity([])).rejects.toThrow(
+      "alternate-model run did not return exact owned successful read evidence",
+    );
+  });
 });

--- a/extensions/qa-lab/src/scenario-catalog-model-switch-tool-continuity-proof.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-model-switch-tool-continuity-proof.test.ts
@@ -10,7 +10,10 @@ function splitModelRef(raw: string) {
     : null;
 }
 
-async function runToolContinuity(alternateTools: string[]) {
+async function runToolContinuity(
+  alternateTools: string[],
+  params?: { alternateReplyText?: string; unrelatedLaterOutboundText?: string },
+) {
   const state = createQaBusState();
   let call = 0;
   return await runLoadedScenarioFlow("model-switch-tool-continuity", {
@@ -33,18 +36,28 @@ async function runToolContinuity(alternateTools: string[]) {
         const runId = `run-${call}`;
         const provider = prompt.provider ?? "openai";
         const model = prompt.model ?? "primary-model";
+        const replyText =
+          call === 1
+            ? "the QA scenario pack verifies source and docs"
+            : (params?.alternateReplyText ??
+              "the model handoff preserved the QA mission after rereading the scenario pack");
         state.addOutboundMessage({
           accountId: "qa-channel",
           to: "dm:qa-operator",
-          text:
-            call === 1
-              ? "the QA scenario pack verifies source and docs"
-              : "the model handoff preserved the QA mission after rereading the scenario pack",
+          text: replyText,
         });
+        if (call === 2 && params?.unrelatedLaterOutboundText) {
+          state.addOutboundMessage({
+            accountId: "qa-channel",
+            to: "dm:qa-operator",
+            text: params.unrelatedLaterOutboundText,
+          });
+        }
         return {
           started: { runId },
           waited: {
             status: "ok",
+            terminalReply: { disposition: "visible", text: replyText },
             terminalReceipt: {
               runId,
               sessionId: "session-tools",
@@ -70,12 +83,29 @@ describe("model-switch tool continuity terminal evidence", () => {
     expect(result.modelSwitchEvidence).toMatchObject({
       primary: { runId: "run-1", successfulToolNames: ["read"] },
       alternate: { runId: "run-2", successfulToolNames: ["read"] },
+      terminalReply: {
+        disposition: "visible",
+        text: "the model handoff preserved the QA mission after rereading the scenario pack",
+      },
     });
+    expect(result.steps[0]?.details).toBe(
+      "the model handoff preserved the QA mission after rereading the scenario pack",
+    );
   });
 
   it("does not let a successful prior-run read satisfy the alternate run", async () => {
     await expect(runToolContinuity([])).rejects.toThrow(
       "alternate-model run did not return exact owned successful read evidence",
     );
+  });
+
+  it("rejects unrelated later continuity text when the alternate reply lacks it", async () => {
+    await expect(
+      runToolContinuity(["read"], {
+        alternateReplyText: "the alternate tool run completed",
+        unrelatedLaterOutboundText:
+          "the model handoff preserved the QA mission after rereading the scenario pack",
+      }),
+    ).rejects.toThrow("alternate-model terminal reply missed kickoff continuity");
   });
 });

--- a/extensions/qa-lab/src/scenario-catalog-model-switch-tool-continuity-proof.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-model-switch-tool-continuity-proof.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createQaBusState } from "./bus-state.js";
 import { hasModelSwitchContinuitySignal } from "./model-switch-eval.js";
 import { runLoadedScenarioFlow } from "./scenario-flow-runner.test-support.js";
@@ -10,86 +10,123 @@ function splitModelRef(raw: string) {
     : null;
 }
 
+function normalizeModelRef(raw: string) {
+  const split = splitModelRef(raw);
+  if (!split) {
+    return null;
+  }
+  return split.provider === "openai" && split.model.toLowerCase() === "alternate-alias"
+    ? { provider: "openai", model: "alternate-model" }
+    : split;
+}
+
 async function runToolContinuity(
   alternateTools: string[],
-  params?: { alternateReplyText?: string; unrelatedLaterOutboundText?: string },
+  params?: {
+    alternateReplyText?: string;
+    alternateOutboundText?: string;
+    alternateDelivery?: { status: string; resultCount: number } | null;
+    unrelatedLaterOutboundText?: string;
+  },
 ) {
   const state = createQaBusState();
   let call = 0;
-  return await runLoadedScenarioFlow("model-switch-tool-continuity", {
+  const runAgentPrompt = vi.fn(
+    async (_env: unknown, prompt: { provider?: string; model?: string }) => {
+      call += 1;
+      const runId = `run-${call}`;
+      const provider = prompt.provider ?? "openai";
+      const model = prompt.model ?? "primary-model";
+      const replyText =
+        call === 1
+          ? "the QA scenario pack verifies source and docs"
+          : (params?.alternateReplyText ??
+            "the model handoff preserved the QA mission after rereading the scenario pack");
+      state.addOutboundMessage({
+        accountId: "qa-channel",
+        to: "dm:qa-operator",
+        text: call === 2 ? (params?.alternateOutboundText ?? replyText) : replyText,
+      });
+      if (call === 2 && params?.unrelatedLaterOutboundText) {
+        state.addOutboundMessage({
+          accountId: "qa-channel",
+          to: "dm:qa-operator",
+          text: params.unrelatedLaterOutboundText,
+        });
+      }
+      return {
+        started: { runId },
+        waited: {
+          status: "ok",
+          ...(call === 2 && params?.alternateDelivery === null
+            ? {}
+            : {
+                terminalDelivery:
+                  call === 2
+                    ? (params?.alternateDelivery ?? { status: "sent", resultCount: 1 })
+                    : { status: "sent", resultCount: 1 },
+              }),
+          terminalReply: { disposition: "visible", text: replyText },
+          terminalReceipt: {
+            runId,
+            sessionId: "session-tools",
+            turnId: `turn-${call}`,
+            requested: { provider, model },
+            effective: { provider, model, responseModel: model },
+            successfulToolNames: call === 1 ? ["read"] : alternateTools,
+            rerouted: false,
+            terminalDisposition: "visible",
+          },
+        },
+      };
+    },
+  );
+  const result = await runLoadedScenarioFlow("model-switch-tool-continuity", {
     state,
     api: {
       env: {
         providerMode: "mock-openai",
         primaryModel: "openai/primary-model",
-        alternateModel: "openai/alternate-model",
+        alternateModel: "OPENAI/alternate-alias",
         gateway: {},
       },
       splitModelRef,
-      normalizeModelRef: splitModelRef,
+      normalizeModelRef,
       normalizeLowercaseStringOrEmpty: (value: unknown) =>
         typeof value === "string" ? value.trim().toLowerCase() : "",
       resolveQaLiveTurnTimeoutMs: (_env: unknown, timeoutMs: number) => timeoutMs,
       hasModelSwitchContinuitySignal,
-      runAgentPrompt: async (_env: unknown, prompt: { provider?: string; model?: string }) => {
-        call += 1;
-        const runId = `run-${call}`;
-        const provider = prompt.provider ?? "openai";
-        const model = prompt.model ?? "primary-model";
-        const replyText =
-          call === 1
-            ? "the QA scenario pack verifies source and docs"
-            : (params?.alternateReplyText ??
-              "the model handoff preserved the QA mission after rereading the scenario pack");
-        state.addOutboundMessage({
-          accountId: "qa-channel",
-          to: "dm:qa-operator",
-          text: replyText,
-        });
-        if (call === 2 && params?.unrelatedLaterOutboundText) {
-          state.addOutboundMessage({
-            accountId: "qa-channel",
-            to: "dm:qa-operator",
-            text: params.unrelatedLaterOutboundText,
-          });
-        }
-        return {
-          started: { runId },
-          waited: {
-            status: "ok",
-            terminalReply: { disposition: "visible", text: replyText },
-            terminalReceipt: {
-              runId,
-              sessionId: "session-tools",
-              turnId: `turn-${call}`,
-              requested: { provider, model },
-              effective: { provider, model, responseModel: model },
-              successfulToolNames: call === 1 ? ["read"] : alternateTools,
-              rerouted: false,
-              terminalDisposition: "visible",
-            },
-          },
-        };
-      },
+      runAgentPrompt,
     },
   });
+  return { result, runAgentPrompt };
 }
 
 describe("model-switch tool continuity terminal evidence", () => {
-  it("accepts a successful read owned by the alternate run", async () => {
-    const result = await runToolContinuity(["read"]);
+  it("invokes the canonical alias target and accepts run-owned delivery", async () => {
+    const { result, runAgentPrompt } = await runToolContinuity(["read"], {
+      alternateReplyText:
+        "the **model handoff** preserved the QA mission after rereading the scenario pack",
+      alternateOutboundText:
+        "the model handoff preserved the QA mission after rereading the scenario pack",
+    });
 
     expect(result.status).toBe("pass");
+    expect(runAgentPrompt.mock.calls[1]?.[1]).toMatchObject({
+      provider: "openai",
+      model: "alternate-model",
+    });
     expect(result.modelSwitchEvidence).toMatchObject({
       primary: { runId: "run-1", successfulToolNames: ["read"] },
       alternate: { runId: "run-2", successfulToolNames: ["read"] },
       terminalReply: {
         disposition: "visible",
-        text: "the model handoff preserved the QA mission after rereading the scenario pack",
+        text: "the **model handoff** preserved the QA mission after rereading the scenario pack",
       },
+      terminalDelivery: { status: "sent", resultCount: 1 },
     });
     expect(result.steps[0]?.details).toBe(
-      "the model handoff preserved the QA mission after rereading the scenario pack",
+      "the **model handoff** preserved the QA mission after rereading the scenario pack",
     );
   });
 
@@ -108,4 +145,21 @@ describe("model-switch tool continuity terminal evidence", () => {
       }),
     ).rejects.toThrow("alternate-model terminal reply missed kickoff continuity");
   });
+
+  it.each([
+    ["missing", null],
+    ["suppressed", { status: "suppressed", resultCount: 0 }],
+    ["zero-count", { status: "sent", resultCount: 0 }],
+  ] as const)(
+    "rejects %s delivery evidence despite an identical bus message",
+    async (_, evidence) => {
+      await expect(
+        runToolContinuity(["read"], {
+          alternateDelivery: evidence,
+          alternateOutboundText:
+            "the model handoff preserved the QA mission after rereading the scenario pack",
+        }),
+      ).rejects.toThrow("alternate-model run did not return owned sent delivery evidence");
+    },
+  );
 });

--- a/extensions/qa-lab/src/scenario-flow-runner.ts
+++ b/extensions/qa-lab/src/scenario-flow-runner.ts
@@ -17,6 +17,7 @@ type QaSuiteScenarioResult = {
     details?: string;
   }>;
   details?: string;
+  modelSwitchEvidence?: Record<string, unknown>;
 };
 
 type QaFlowApi = Record<string, unknown> & {
@@ -369,5 +370,8 @@ export async function runScenarioFlow(params: {
       return formatFlowDetails(details);
     },
   }));
-  return await params.api.runScenario(params.scenarioTitle, steps);
+  const result = await params.api.runScenario(params.scenarioTitle, steps);
+  return isPlainObject(vars.modelSwitchEvidence)
+    ? { ...result, modelSwitchEvidence: vars.modelSwitchEvidence }
+    : result;
 }

--- a/extensions/qa-lab/src/scenario-runtime-api.test.ts
+++ b/extensions/qa-lab/src/scenario-runtime-api.test.ts
@@ -81,6 +81,7 @@ describe("createQaScenarioRuntimeApi", () => {
       waitForTransportReady: vi.fn(),
       waitForAgentHistoryReply: vi.fn(),
       browserRequest: vi.fn(),
+      normalizeModelRef: vi.fn(),
     };
 
     const api = createQaScenarioRuntimeApi({

--- a/extensions/qa-lab/src/scenario-runtime-api.ts
+++ b/extensions/qa-lab/src/scenario-runtime-api.ts
@@ -94,6 +94,7 @@ export type QaScenarioRuntimeDeps = {
   formatErrorMessage: QaScenarioRuntimeFunction;
   liveTurnTimeoutMs: QaScenarioRuntimeFunction;
   resolveQaLiveTurnTimeoutMs: QaScenarioRuntimeFunction;
+  normalizeModelRef: QaScenarioRuntimeFunction;
   splitModelRef: QaScenarioRuntimeFunction;
   hasDiscoveryLabels: QaScenarioRuntimeFunction;
   reportsDiscoveryScopeLeak: QaScenarioRuntimeFunction;

--- a/extensions/qa-lab/src/suite-runtime-agent-process.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-process.test.ts
@@ -536,10 +536,11 @@ describe("qa suite runtime agent process helpers", () => {
   });
 
   it("accepts completed agent wait status as a successful terminal run", async () => {
+    const terminalReply = { disposition: "visible" as const, text: "completed reply" };
     const gatewayCall = vi
       .fn()
       .mockResolvedValueOnce({ runId: "run-completed" })
-      .mockResolvedValueOnce({ status: "completed" });
+      .mockResolvedValueOnce({ status: "completed", terminalReply });
     const env = createAgentPromptEnv(gatewayCall);
 
     await expect(
@@ -549,7 +550,7 @@ describe("qa suite runtime agent process helpers", () => {
       }),
     ).resolves.toEqual({
       started: { runId: "run-completed" },
-      waited: { status: "completed" },
+      waited: { status: "completed", terminalReply },
     });
   });
 

--- a/extensions/qa-lab/src/suite-runtime-agent-process.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-process.test.ts
@@ -537,10 +537,11 @@ describe("qa suite runtime agent process helpers", () => {
 
   it("accepts completed agent wait status as a successful terminal run", async () => {
     const terminalReply = { disposition: "visible" as const, text: "completed reply" };
+    const terminalDelivery = { status: "sent" as const, resultCount: 1 };
     const gatewayCall = vi
       .fn()
       .mockResolvedValueOnce({ runId: "run-completed" })
-      .mockResolvedValueOnce({ status: "completed", terminalReply });
+      .mockResolvedValueOnce({ status: "completed", terminalDelivery, terminalReply });
     const env = createAgentPromptEnv(gatewayCall);
 
     await expect(
@@ -550,7 +551,7 @@ describe("qa suite runtime agent process helpers", () => {
       }),
     ).resolves.toEqual({
       started: { runId: "run-completed" },
-      waited: { status: "completed", terminalReply },
+      waited: { status: "completed", terminalDelivery, terminalReply },
     });
   });
 

--- a/extensions/qa-lab/src/suite-runtime-agent-process.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-process.ts
@@ -53,6 +53,10 @@ type QaAgentWaitResult = {
   status?: string;
   error?: string;
   stopReason?: string;
+  terminalDelivery?: {
+    status: "sent" | "suppressed" | "partial_failed" | "failed";
+    resultCount: number;
+  };
   terminalReceipt?: Record<string, unknown>;
   terminalReply?: QaAgentTerminalReply;
 };

--- a/extensions/qa-lab/src/suite-runtime-agent-process.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-process.ts
@@ -44,11 +44,17 @@ type QaChatHistoryResponse = {
   messages?: unknown[];
 };
 
+type QaAgentTerminalReply =
+  | { disposition: "visible"; text: string }
+  | { disposition: "silent" }
+  | { disposition: "empty" };
+
 type QaAgentWaitResult = {
   status?: string;
   error?: string;
   stopReason?: string;
   terminalReceipt?: Record<string, unknown>;
+  terminalReply?: QaAgentTerminalReply;
 };
 
 const ANSI_ESCAPE_PATTERN = new RegExp(String.raw`\x1B\[[0-?]*[ -/]*[@-~]`, "g");

--- a/extensions/qa-lab/src/suite-runtime-agent-process.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-process.ts
@@ -48,6 +48,7 @@ type QaAgentWaitResult = {
   status?: string;
   error?: string;
   stopReason?: string;
+  terminalReceipt?: Record<string, unknown>;
 };
 
 const ANSI_ESCAPE_PATTERN = new RegExp(String.raw`\x1B\[[0-?]*[ -/]*[@-~]`, "g");

--- a/extensions/qa-lab/src/suite-runtime-flow.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.test.ts
@@ -216,14 +216,17 @@ describe("qa suite runtime flow", () => {
       raw: "anthropic/opus",
       defaultProvider: "anthropic",
     })?.ref;
+    const normalizeModelRef = call.deps.normalizeModelRef as (
+      raw: string,
+    ) => { provider: string; model: string } | null;
     expect(canonicalOpus).toEqual({ provider: "anthropic", model: "claude-opus-5" });
-    expect(call.deps.normalizeModelRef("anthropic/opus")).toEqual(canonicalOpus);
-    expect(call.deps.normalizeModelRef("AnThRoPiC/OPUS")).toEqual(canonicalOpus);
-    expect(call.deps.normalizeModelRef("OPENAI/gpt-5.6-luna")).toEqual({
+    expect(normalizeModelRef("anthropic/opus")).toEqual(canonicalOpus);
+    expect(normalizeModelRef("AnThRoPiC/OPUS")).toEqual(canonicalOpus);
+    expect(normalizeModelRef("OPENAI/gpt-5.6-luna")).toEqual({
       provider: "openai",
       model: "gpt-5.6-luna",
     });
-    expect(call.deps.normalizeModelRef("")).toBeNull();
+    expect(normalizeModelRef("")).toBeNull();
     expect(call.deps.waitForOutboundMessage).toBeTypeOf("function");
     const outboundPredicate = vi.fn();
     call.deps.waitForOutboundMessage(env.transport.state, outboundPredicate, 123);

--- a/extensions/qa-lab/src/suite-runtime-flow.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.test.ts
@@ -1,4 +1,5 @@
 // Qa Lab tests cover suite runtime flow plugin behavior.
+import { parseModelRef, resolveModelRefFromString } from "openclaw/plugin-sdk/agent-runtime";
 import { describe, expect, it, vi } from "vitest";
 
 const createQaScenarioRuntimeApi = vi.hoisted(() => vi.fn());
@@ -110,7 +111,15 @@ describe("qa suite runtime flow", () => {
       primaryModel: "openai/gpt-5.6-luna",
       alternateModel: "openai/gpt-5.6-luna-mini",
       mock: null,
-      cfg: {} as QaSuiteRuntimeEnv["cfg"],
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "anthropic/claude-opus-5": { alias: "opus" },
+            },
+          },
+        },
+      },
     } satisfies Parameters<typeof runQaSuiteScenarioDefinition>[0]["env"];
     const scenario = {
       id: "session-memory-ranking",
@@ -126,7 +135,7 @@ describe("qa suite runtime flow", () => {
       },
     };
     const runScenario = vi.fn();
-    const splitModelRef = vi.fn();
+    const splitModelRef = vi.fn((raw: string) => parseModelRef(raw, "openai"));
     const formatErrorMessage = vi.fn();
     const liveTurnTimeoutMs = vi.fn();
     const resolveQaLiveTurnTimeoutMs = vi.fn();
@@ -202,6 +211,19 @@ describe("qa suite runtime flow", () => {
     for (const [name, helper] of Object.entries(aliasedDependencies)) {
       expect((call.deps as Record<string, unknown>)[name]).toBe(helper);
     }
+    const canonicalOpus = resolveModelRefFromString({
+      cfg: env.cfg,
+      raw: "anthropic/opus",
+      defaultProvider: "anthropic",
+    })?.ref;
+    expect(canonicalOpus).toEqual({ provider: "anthropic", model: "claude-opus-5" });
+    expect(call.deps.normalizeModelRef("anthropic/opus")).toEqual(canonicalOpus);
+    expect(call.deps.normalizeModelRef("AnThRoPiC/OPUS")).toEqual(canonicalOpus);
+    expect(call.deps.normalizeModelRef("OPENAI/gpt-5.6-luna")).toEqual({
+      provider: "openai",
+      model: "gpt-5.6-luna",
+    });
+    expect(call.deps.normalizeModelRef("")).toBeNull();
     expect(call.deps.waitForOutboundMessage).toBeTypeOf("function");
     const outboundPredicate = vi.fn();
     call.deps.waitForOutboundMessage(env.transport.state, outboundPredicate, 123);

--- a/extensions/qa-lab/src/suite-runtime-flow.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.ts
@@ -3,6 +3,7 @@ import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
+import { resolveModelRefFromString } from "openclaw/plugin-sdk/agent-runtime";
 import { formatErrorMessage as formatQaErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { formatMemoryDreamingDay } from "openclaw/plugin-sdk/memory-core-host-status";
 import { resolveSessionTranscriptsDirForAgent } from "openclaw/plugin-sdk/memory-host-core";
@@ -219,6 +220,16 @@ function createQaSuiteScenarioDeps(params: QaSuiteScenarioDepsParams) {
     formatErrorMessage: params.formatErrorMessage,
     liveTurnTimeoutMs: params.liveTurnTimeoutMs,
     resolveQaLiveTurnTimeoutMs: params.resolveQaLiveTurnTimeoutMs,
+    normalizeModelRef: (raw: string) => {
+      const split = params.splitModelRef(raw);
+      return split
+        ? (resolveModelRefFromString({
+            cfg: params.env.cfg,
+            raw,
+            defaultProvider: split.provider,
+          })?.ref ?? null)
+        : null;
+    },
     splitModelRef: params.splitModelRef,
   } satisfies QaScenarioRuntimeDeps;
 }

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -71,6 +71,7 @@ export type QaSuiteScenarioResult = {
   details?: string;
   timing?: QaEvidenceTiming;
   runtimeParity?: RuntimeParityResult;
+  modelSwitchEvidence?: Record<string, unknown>;
 };
 
 type QaSuiteEnvironment = {

--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -969,6 +969,28 @@ describe("processResponsesStream", () => {
     expect(output.stopReason).toBe("stop");
   });
 
+  it("records the effective model from the terminal response", async () => {
+    const output = createAssistantOutput();
+
+    await processResponsesStream(
+      responseEvents([
+        {
+          type: "response.completed",
+          response: {
+            id: "resp_rerouted",
+            status: "completed",
+            model: "gpt-5.5-rerouted",
+          },
+        },
+      ]),
+      output,
+      new AssistantMessageEventStream(),
+      nativeOpenAIModel,
+    );
+
+    expect(output.responseModel).toBe("gpt-5.5-rerouted");
+  });
+
   it("keeps interleaved reasoning items bound to their output indices", async () => {
     const output = createAssistantOutput();
     const { stream, events } = createCapturedAssistantMessageEventStream();

--- a/packages/ai/src/transports/openai-responses-stream-terminal-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-terminal-internal.ts
@@ -43,6 +43,7 @@ type TerminalOutput = {
   content: Array<TextContent | ThinkingContent | ToolCall>;
   usage: Usage & { reasoningTokens?: number };
   stopReason: string;
+  responseModel?: string;
   responseId?: string;
   errorMessage?: string;
 };
@@ -279,6 +280,7 @@ export function createResponsesTerminalController(params: {
     params.markFinalized();
     backfillReasoning(response.output ?? []);
     output.responseId = response.id || output.responseId;
+    output.responseModel = response.model?.trim() || undefined;
     const usage = mapResponsesTerminalUsage(response.usage);
     const reasoningTokens = readResponsesReasoningTokens(response.usage);
     if (usage) {

--- a/qa/scenarios/models/model-switch-follow-up.yaml
+++ b/qa/scenarios/models/model-switch-follow-up.yaml
@@ -54,6 +54,9 @@ flow:
         - set: switchRequestCursor
           value:
             expr: "env.mock ? (await fetchJson(`${env.mock.baseUrl}/debug/request-cursor`)).cursor : 0"
+        - set: beforeSwitchCursor
+          value:
+            expr: state.getSnapshot().messages.length
         - call: runAgentPrompt
           args:
             - ref: env
@@ -70,7 +73,7 @@ flow:
           saveAs: outbound
           args:
             - lambda:
-                expr: "state.getSnapshot().messages.filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === 'qa-operator' && (() => { const lower = normalizeLowercaseStringOrEmpty(candidate.text); return lower.includes('switch') || lower.includes('handoff'); })()).at(-1)"
+                expr: "state.getSnapshot().messages.slice(beforeSwitchCursor).filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === 'qa-operator' && (() => { const lower = normalizeLowercaseStringOrEmpty(candidate.text); return lower.includes('switch') || lower.includes('handoff'); })()).at(-1)"
             - expr: resolveQaLiveTurnTimeoutMs(env, 20000, env.alternateModel)
         - if:
             expr: "Boolean(env.mock)"

--- a/qa/scenarios/models/model-switch-follow-up.yaml
+++ b/qa/scenarios/models/model-switch-follow-up.yaml
@@ -51,6 +51,9 @@ flow:
         - set: alternate
           value:
             expr: splitModelRef(env.alternateModel)
+        - set: expectedAlternate
+          value:
+            expr: normalizeModelRef(env.alternateModel)
         - set: switchRequestCursor
           value:
             expr: "env.mock ? (await fetchJson(`${env.mock.baseUrl}/debug/request-cursor`)).cursor : 0"
@@ -69,11 +72,22 @@ flow:
                 expr: alternate?.model
               timeoutMs:
                 expr: resolveQaLiveTurnTimeoutMs(env, 30000, env.alternateModel)
+        - call: readRawQaSessionStore
+          saveAs: sessionStore
+          args:
+            - ref: env
+        - set: sessionEntry
+          value:
+            expr: "sessionStore['agent:qa:model-switch']"
+        - assert:
+            expr: "normalizeLowercaseStringOrEmpty(sessionEntry?.modelProvider) === expectedAlternate?.provider && sessionEntry?.model === expectedAlternate?.model"
+            message:
+              expr: "`expected persisted alternate model ${String(expectedAlternate?.provider ?? '')}/${String(expectedAlternate?.model ?? '')}, got ${String(sessionEntry?.modelProvider ?? '')}/${String(sessionEntry?.model ?? '')}`"
         - call: waitForCondition
           saveAs: outbound
           args:
             - lambda:
-                expr: "state.getSnapshot().messages.slice(beforeSwitchCursor).filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === 'qa-operator' && (() => { const lower = normalizeLowercaseStringOrEmpty(candidate.text); return lower.includes('switch') || lower.includes('handoff'); })()).at(-1)"
+                expr: "state.getSnapshot().messages.slice(beforeSwitchCursor).filter((candidate) => candidate.direction === 'outbound' && !candidate.deleted && candidate.conversation.id === 'qa-operator' && (() => { const lower = normalizeLowercaseStringOrEmpty(candidate.text); return lower.includes('switch') || lower.includes('handoff'); })()).at(-1)"
             - expr: resolveQaLiveTurnTimeoutMs(env, 20000, env.alternateModel)
         - if:
             expr: "Boolean(env.mock)"
@@ -85,7 +99,7 @@ flow:
                 value:
                   expr: "switchDebugRequests.find((request) => String(request.allInputText ?? '').includes(config.followupPrompt))"
               - assert:
-                  expr: "String(switchRequest?.model ?? '') === String(alternate?.model ?? '')"
+                  expr: "String(switchRequest?.model ?? '') === String(expectedAlternate?.model ?? '')"
                   message:
-                    expr: "`expected alternate model ${String(alternate?.model ?? '')}, got ${String(switchRequest?.model ?? '')}`"
+                    expr: "`expected alternate model ${String(expectedAlternate?.model ?? '')}, got ${String(switchRequest?.model ?? '')}`"
       detailsExpr: outbound.text

--- a/qa/scenarios/models/model-switch-follow-up.yaml
+++ b/qa/scenarios/models/model-switch-follow-up.yaml
@@ -29,8 +29,18 @@ flow:
   steps:
     - name: runs on the default configured model
       actions:
+        - set: alternate
+          value:
+            expr: splitModelRef(env.alternateModel)
+        - set: expectedAlternate
+          value:
+            expr: normalizeModelRef(env.alternateModel)
+        - assert:
+            expr: "normalizeModelRef(env.primaryModel) && expectedAlternate && (normalizeModelRef(env.primaryModel).provider !== expectedAlternate.provider || normalizeModelRef(env.primaryModel).model !== expectedAlternate.model)"
+            message: primary and alternate models must normalize to different refs
         - call: reset
         - call: runAgentPrompt
+          saveAs: primaryRun
           args:
             - ref: env
             - sessionKey: agent:qa:model-switch
@@ -38,6 +48,9 @@ flow:
                 expr: config.initialPrompt
               timeoutMs:
                 expr: liveTurnTimeoutMs(env, 30000)
+        - assert:
+            expr: "(() => { const expected = normalizeModelRef(env.primaryModel); const receipt = primaryRun?.waited?.terminalReceipt; return receipt?.runId === primaryRun?.started?.runId && Boolean(receipt.sessionId) && Boolean(receipt.turnId) && normalizeLowercaseStringOrEmpty(receipt.requested?.provider) === expected.provider && receipt.requested?.model === expected.model && receipt.effective?.model === receipt.effective?.responseModel && receipt.terminalDisposition === 'visible' && typeof receipt.rerouted === 'boolean'; })()"
+            message: default-model run did not return an exact owned terminal receipt
         - call: waitForOutboundMessage
           saveAs: outbound
           args:
@@ -45,22 +58,14 @@ flow:
             - lambda:
                 params: [candidate]
                 expr: "candidate.conversation.id === 'qa-operator'"
-      detailsExpr: "env.mock ? String((await fetchJson(`${env.mock.baseUrl}/debug/last-request`))?.body?.model ?? '') : outbound.text"
+      detailsExpr: outbound.text
     - name: switches to the alternate model and continues
       actions:
-        - set: alternate
-          value:
-            expr: splitModelRef(env.alternateModel)
-        - set: expectedAlternate
-          value:
-            expr: normalizeModelRef(env.alternateModel)
-        - set: switchRequestCursor
-          value:
-            expr: "env.mock ? (await fetchJson(`${env.mock.baseUrl}/debug/request-cursor`)).cursor : 0"
         - set: beforeSwitchCursor
           value:
             expr: state.getSnapshot().messages.length
         - call: runAgentPrompt
+          saveAs: alternateRun
           args:
             - ref: env
             - sessionKey: agent:qa:model-switch
@@ -72,34 +77,19 @@ flow:
                 expr: alternate?.model
               timeoutMs:
                 expr: resolveQaLiveTurnTimeoutMs(env, 30000, env.alternateModel)
-        - call: readRawQaSessionStore
-          saveAs: sessionStore
-          args:
-            - ref: env
-        - set: sessionEntry
-          value:
-            expr: "sessionStore['agent:qa:model-switch']"
         - assert:
-            expr: "normalizeLowercaseStringOrEmpty(sessionEntry?.modelProvider) === expectedAlternate?.provider && sessionEntry?.model === expectedAlternate?.model"
-            message:
-              expr: "`expected persisted alternate model ${String(expectedAlternate?.provider ?? '')}/${String(expectedAlternate?.model ?? '')}, got ${String(sessionEntry?.modelProvider ?? '')}/${String(sessionEntry?.model ?? '')}`"
+            expr: "(() => { const receipt = alternateRun?.waited?.terminalReceipt; return receipt?.runId === alternateRun?.started?.runId && Boolean(receipt.sessionId) && Boolean(receipt.turnId) && normalizeLowercaseStringOrEmpty(receipt.requested?.provider) === expectedAlternate.provider && receipt.requested?.model === expectedAlternate.model && receipt.effective?.model === receipt.effective?.responseModel && receipt.terminalDisposition === 'visible' && typeof receipt.rerouted === 'boolean' && `${receipt.effective?.provider}/${receipt.effective?.responseModel}` !== `${primaryRun.waited.terminalReceipt.effective?.provider}/${primaryRun.waited.terminalReceipt.effective?.responseModel}`; })()"
+            message: alternate-model run did not return distinct exact owned model evidence
         - call: waitForCondition
           saveAs: outbound
           args:
             - lambda:
                 expr: "state.getSnapshot().messages.slice(beforeSwitchCursor).filter((candidate) => candidate.direction === 'outbound' && !candidate.deleted && candidate.conversation.id === 'qa-operator' && (() => { const lower = normalizeLowercaseStringOrEmpty(candidate.text); return lower.includes('switch') || lower.includes('handoff'); })()).at(-1)"
             - expr: resolveQaLiveTurnTimeoutMs(env, 20000, env.alternateModel)
-        - if:
-            expr: "Boolean(env.mock)"
-            then:
-              - set: switchDebugRequests
-                value:
-                  expr: "await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${switchRequestCursor}`)"
-              - set: switchRequest
-                value:
-                  expr: "switchDebugRequests.find((request) => String(request.allInputText ?? '').includes(config.followupPrompt))"
-              - assert:
-                  expr: "String(switchRequest?.model ?? '') === String(expectedAlternate?.model ?? '')"
-                  message:
-                    expr: "`expected alternate model ${String(expectedAlternate?.model ?? '')}, got ${String(switchRequest?.model ?? '')}`"
+        - set: modelSwitchEvidence
+          value:
+            primary:
+              ref: primaryRun.waited.terminalReceipt
+            alternate:
+              ref: alternateRun.waited.terminalReceipt
       detailsExpr: outbound.text

--- a/qa/scenarios/models/model-switch-follow-up.yaml
+++ b/qa/scenarios/models/model-switch-follow-up.yaml
@@ -80,11 +80,14 @@ flow:
         - assert:
             expr: "(() => { const receipt = alternateRun?.waited?.terminalReceipt; return receipt?.runId === alternateRun?.started?.runId && Boolean(receipt.sessionId) && Boolean(receipt.turnId) && normalizeLowercaseStringOrEmpty(receipt.requested?.provider) === expectedAlternate.provider && receipt.requested?.model === expectedAlternate.model && receipt.effective?.model === receipt.effective?.responseModel && receipt.terminalDisposition === 'visible' && typeof receipt.rerouted === 'boolean' && `${receipt.effective?.provider}/${receipt.effective?.responseModel}` !== `${primaryRun.waited.terminalReceipt.effective?.provider}/${primaryRun.waited.terminalReceipt.effective?.responseModel}`; })()"
             message: alternate-model run did not return distinct exact owned model evidence
+        - assert:
+            expr: "(() => { const reply = alternateRun?.waited?.terminalReply; if (reply?.disposition !== 'visible') return false; const lower = normalizeLowercaseStringOrEmpty(reply.text); return lower.includes('switch') || lower.includes('handoff'); })()"
+            message: alternate-model terminal reply missed switch continuity
         - call: waitForCondition
           saveAs: outbound
           args:
             - lambda:
-                expr: "state.getSnapshot().messages.slice(beforeSwitchCursor).filter((candidate) => candidate.direction === 'outbound' && !candidate.deleted && candidate.conversation.id === 'qa-operator' && (() => { const lower = normalizeLowercaseStringOrEmpty(candidate.text); return lower.includes('switch') || lower.includes('handoff'); })()).at(-1)"
+                expr: "state.getSnapshot().messages.slice(beforeSwitchCursor).filter((candidate) => candidate.direction === 'outbound' && !candidate.deleted && candidate.conversation.id === 'qa-operator' && alternateRun?.waited?.terminalReply?.disposition === 'visible' && candidate.text === alternateRun.waited.terminalReply.text).at(-1)"
             - expr: resolveQaLiveTurnTimeoutMs(env, 20000, env.alternateModel)
         - set: modelSwitchEvidence
           value:
@@ -92,4 +95,6 @@ flow:
               ref: primaryRun.waited.terminalReceipt
             alternate:
               ref: alternateRun.waited.terminalReceipt
-      detailsExpr: outbound.text
+            terminalReply:
+              ref: alternateRun.waited.terminalReply
+      detailsExpr: alternateRun.waited.terminalReply.text

--- a/qa/scenarios/models/model-switch-follow-up.yaml
+++ b/qa/scenarios/models/model-switch-follow-up.yaml
@@ -48,14 +48,13 @@ flow:
         - assert:
             expr: "(() => { const expected = normalizeModelRef(env.primaryModel); const receipt = primaryRun?.waited?.terminalReceipt; return receipt?.runId === primaryRun?.started?.runId && Boolean(receipt.sessionId) && Boolean(receipt.turnId) && normalizeLowercaseStringOrEmpty(receipt.requested?.provider) === expected.provider && receipt.requested?.model === expected.model && receipt.effective?.model === receipt.effective?.responseModel && receipt.terminalDisposition === 'visible' && typeof receipt.rerouted === 'boolean'; })()"
             message: default-model run did not return an exact owned terminal receipt
-        - call: waitForOutboundMessage
-          saveAs: outbound
-          args:
-            - ref: state
-            - lambda:
-                params: [candidate]
-                expr: "candidate.conversation.id === 'qa-operator'"
-      detailsExpr: outbound.text
+        - assert:
+            expr: "primaryRun?.waited?.terminalReply?.disposition === 'visible'"
+            message: default-model run did not return an owned visible terminal reply
+        - assert:
+            expr: "primaryRun?.waited?.terminalDelivery?.status === 'sent' && typeof primaryRun.waited.terminalDelivery.resultCount === 'number' && primaryRun.waited.terminalDelivery.resultCount > 0"
+            message: default-model run did not return owned sent delivery evidence
+      detailsExpr: primaryRun.waited.terminalReply.text
     - name: switches to the alternate model and continues
       actions:
         - call: runAgentPrompt

--- a/qa/scenarios/models/model-switch-follow-up.yaml
+++ b/qa/scenarios/models/model-switch-follow-up.yaml
@@ -29,9 +29,6 @@ flow:
   steps:
     - name: runs on the default configured model
       actions:
-        - set: alternate
-          value:
-            expr: splitModelRef(env.alternateModel)
         - set: expectedAlternate
           value:
             expr: normalizeModelRef(env.alternateModel)
@@ -61,9 +58,6 @@ flow:
       detailsExpr: outbound.text
     - name: switches to the alternate model and continues
       actions:
-        - set: beforeSwitchCursor
-          value:
-            expr: state.getSnapshot().messages.length
         - call: runAgentPrompt
           saveAs: alternateRun
           args:
@@ -72,9 +66,9 @@ flow:
               message:
                 expr: config.followupPrompt
               provider:
-                expr: alternate?.provider
+                expr: expectedAlternate.provider
               model:
-                expr: alternate?.model
+                expr: expectedAlternate.model
               timeoutMs:
                 expr: resolveQaLiveTurnTimeoutMs(env, 30000, env.alternateModel)
         - assert:
@@ -83,12 +77,9 @@ flow:
         - assert:
             expr: "(() => { const reply = alternateRun?.waited?.terminalReply; if (reply?.disposition !== 'visible') return false; const lower = normalizeLowercaseStringOrEmpty(reply.text); return lower.includes('switch') || lower.includes('handoff'); })()"
             message: alternate-model terminal reply missed switch continuity
-        - call: waitForCondition
-          saveAs: outbound
-          args:
-            - lambda:
-                expr: "state.getSnapshot().messages.slice(beforeSwitchCursor).filter((candidate) => candidate.direction === 'outbound' && !candidate.deleted && candidate.conversation.id === 'qa-operator' && alternateRun?.waited?.terminalReply?.disposition === 'visible' && candidate.text === alternateRun.waited.terminalReply.text).at(-1)"
-            - expr: resolveQaLiveTurnTimeoutMs(env, 20000, env.alternateModel)
+        - assert:
+            expr: "alternateRun?.waited?.terminalDelivery?.status === 'sent' && typeof alternateRun.waited.terminalDelivery.resultCount === 'number' && alternateRun.waited.terminalDelivery.resultCount > 0"
+            message: alternate-model run did not return owned sent delivery evidence
         - set: modelSwitchEvidence
           value:
             primary:
@@ -97,4 +88,6 @@ flow:
               ref: alternateRun.waited.terminalReceipt
             terminalReply:
               ref: alternateRun.waited.terminalReply
+            terminalDelivery:
+              ref: alternateRun.waited.terminalDelivery
       detailsExpr: alternateRun.waited.terminalReply.text

--- a/qa/scenarios/models/model-switch-tool-continuity.yaml
+++ b/qa/scenarios/models/model-switch-tool-continuity.yaml
@@ -71,13 +71,14 @@ flow:
                 expr: alternate?.model
               timeoutMs:
                 expr: resolveQaLiveTurnTimeoutMs(env, 30000, env.alternateModel)
-        - call: readSessionTranscriptSummary
+        - call: waitForCondition
           saveAs: afterSwitchTranscript
           args:
-            - ref: env
-            - agent:qa:model-switch-tools
-            - afterEventCursor:
-                expr: beforeSwitchTranscript.eventCursor
+            - lambda:
+                async: true
+                expr: "readSessionTranscriptSummary(env, 'agent:qa:model-switch-tools', { afterEventCursor: beforeSwitchTranscript.eventCursor, allowEmpty: true }).then((summary) => (summary.successfulToolCallCounts.read ?? 0) >= 1 ? summary : undefined)"
+            - 5000
+            - 50
         - assert:
             expr: "(afterSwitchTranscript.successfulToolCallCounts.read ?? 0) >= 1"
             message:

--- a/qa/scenarios/models/model-switch-tool-continuity.yaml
+++ b/qa/scenarios/models/model-switch-tool-continuity.yaml
@@ -37,6 +37,12 @@ flow:
             - ref: env
             - 60000
         - call: reset
+        - call: readSessionTranscriptSummary
+          saveAs: beforeAttemptTranscript
+          args:
+            - ref: env
+            - agent:qa:model-switch-tools
+            - allowEmpty: true
         - call: runAgentPrompt
           args:
             - ref: env
@@ -45,14 +51,20 @@ flow:
                 expr: config.initialPrompt
               timeoutMs:
                 expr: liveTurnTimeoutMs(env, 30000)
-        - call: readSessionTranscriptSummary
+        - call: waitForCondition
           saveAs: beforeSwitchTranscript
           args:
-            - ref: env
-            - agent:qa:model-switch-tools
+            - lambda:
+                async: true
+                expr: "readSessionTranscriptSummary(env, 'agent:qa:model-switch-tools', { afterEventCursor: beforeAttemptTranscript.eventCursor, allowEmpty: true }).then((summary) => (summary.successfulToolCallCounts.read ?? 0) >= 1 ? summary : undefined)"
+            - 5000
+            - 50
         - set: alternate
           value:
             expr: splitModelRef(env.alternateModel)
+        - set: expectedAlternate
+          value:
+            expr: normalizeModelRef(env.alternateModel)
         - set: beforeSwitchCursor
           value:
             expr: state.getSnapshot().messages.length
@@ -71,6 +83,17 @@ flow:
                 expr: alternate?.model
               timeoutMs:
                 expr: resolveQaLiveTurnTimeoutMs(env, 30000, env.alternateModel)
+        - call: readRawQaSessionStore
+          saveAs: afterSwitchSessions
+          args:
+            - ref: env
+        - set: afterSwitchSession
+          value:
+            expr: "afterSwitchSessions['agent:qa:model-switch-tools']"
+        - assert:
+            expr: "normalizeLowercaseStringOrEmpty(afterSwitchSession?.modelProvider) === normalizeLowercaseStringOrEmpty(expectedAlternate?.provider) && String(afterSwitchSession?.model ?? '') === String(expectedAlternate?.model ?? '')"
+            message:
+              expr: "`expected alternate persisted model ${String(expectedAlternate?.provider ?? '')}/${String(expectedAlternate?.model ?? '')}, got ${String(afterSwitchSession?.modelProvider ?? '')}/${String(afterSwitchSession?.model ?? '')}`"
         - call: waitForCondition
           saveAs: afterSwitchTranscript
           args:
@@ -87,7 +110,7 @@ flow:
           saveAs: outbound
           args:
             - lambda:
-                expr: "state.getSnapshot().messages.slice(beforeSwitchCursor).filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === 'qa-operator' && hasModelSwitchContinuitySignal(candidate.text)).at(-1)"
+                expr: "state.getSnapshot().messages.slice(beforeSwitchCursor).filter((candidate) => candidate.direction === 'outbound' && !candidate.deleted && candidate.conversation.id === 'qa-operator' && hasModelSwitchContinuitySignal(candidate.text)).at(-1)"
             - expr: resolveQaLiveTurnTimeoutMs(env, 20000, env.alternateModel)
         - assert:
             expr: hasModelSwitchContinuitySignal(outbound.text)
@@ -103,7 +126,7 @@ flow:
                 value:
                   expr: "switchDebugRequests.find((request) => String(request.allInputText ?? '').includes(config.promptSnippet))"
               - assert:
-                  expr: "String(switchRequest?.model ?? '') === String(alternate?.model ?? '')"
+                  expr: "String(switchRequest?.model ?? '') === String(expectedAlternate?.model ?? '')"
                   message:
                     expr: "`expected alternate model, got ${String(switchRequest?.model ?? '')}`"
       detailsExpr: outbound.text

--- a/qa/scenarios/models/model-switch-tool-continuity.yaml
+++ b/qa/scenarios/models/model-switch-tool-continuity.yaml
@@ -45,6 +45,11 @@ flow:
                 expr: config.initialPrompt
               timeoutMs:
                 expr: liveTurnTimeoutMs(env, 30000)
+        - call: readSessionTranscriptSummary
+          saveAs: beforeSwitchTranscript
+          args:
+            - ref: env
+            - agent:qa:model-switch-tools
         - set: alternate
           value:
             expr: splitModelRef(env.alternateModel)
@@ -66,6 +71,17 @@ flow:
                 expr: alternate?.model
               timeoutMs:
                 expr: resolveQaLiveTurnTimeoutMs(env, 30000, env.alternateModel)
+        - call: readSessionTranscriptSummary
+          saveAs: afterSwitchTranscript
+          args:
+            - ref: env
+            - agent:qa:model-switch-tools
+            - afterEventCursor:
+                expr: beforeSwitchTranscript.eventCursor
+        - assert:
+            expr: "(afterSwitchTranscript.successfulToolCallCounts.read ?? 0) >= 1"
+            message:
+              expr: "`expected a successful read after the model switch; successfulTools=${JSON.stringify(afterSwitchTranscript.successfulToolCallCounts ?? {})}`"
         - call: waitForCondition
           saveAs: outbound
           args:
@@ -85,10 +101,6 @@ flow:
               - set: switchRequest
                 value:
                   expr: "switchDebugRequests.find((request) => String(request.allInputText ?? '').includes(config.promptSnippet))"
-              - assert:
-                  expr: "switchRequest?.plannedToolName === 'read'"
-                  message:
-                    expr: "`expected read after switch, got ${String(switchRequest?.plannedToolName ?? '')}`"
               - assert:
                   expr: "String(switchRequest?.model ?? '') === String(alternate?.model ?? '')"
                   message:

--- a/qa/scenarios/models/model-switch-tool-continuity.yaml
+++ b/qa/scenarios/models/model-switch-tool-continuity.yaml
@@ -55,6 +55,9 @@ flow:
         - assert:
             expr: "(() => { const expected = normalizeModelRef(env.primaryModel); const receipt = primaryRun?.waited?.terminalReceipt; return receipt?.runId === primaryRun?.started?.runId && normalizeLowercaseStringOrEmpty(receipt.requested?.provider) === expected.provider && receipt.requested?.model === expected.model && receipt.successfulToolNames?.includes('read') && receipt.terminalDisposition === 'visible'; })()"
             message: default-model run did not return owned successful read evidence
+        - assert:
+            expr: "primaryRun?.waited?.terminalDelivery?.status === 'sent' && typeof primaryRun.waited.terminalDelivery.resultCount === 'number' && primaryRun.waited.terminalDelivery.resultCount > 0"
+            message: default-model run did not return owned sent delivery evidence
         - call: runAgentPrompt
           saveAs: alternateRun
           args:

--- a/qa/scenarios/models/model-switch-tool-continuity.yaml
+++ b/qa/scenarios/models/model-switch-tool-continuity.yaml
@@ -32,9 +32,6 @@ flow:
   steps:
     - name: keeps using tools after switching models
       actions:
-        - set: alternate
-          value:
-            expr: splitModelRef(env.alternateModel)
         - set: expectedAlternate
           value:
             expr: normalizeModelRef(env.alternateModel)
@@ -58,9 +55,6 @@ flow:
         - assert:
             expr: "(() => { const expected = normalizeModelRef(env.primaryModel); const receipt = primaryRun?.waited?.terminalReceipt; return receipt?.runId === primaryRun?.started?.runId && normalizeLowercaseStringOrEmpty(receipt.requested?.provider) === expected.provider && receipt.requested?.model === expected.model && receipt.successfulToolNames?.includes('read') && receipt.terminalDisposition === 'visible'; })()"
             message: default-model run did not return owned successful read evidence
-        - set: beforeSwitchCursor
-          value:
-            expr: state.getSnapshot().messages.length
         - call: runAgentPrompt
           saveAs: alternateRun
           args:
@@ -69,9 +63,9 @@ flow:
               message:
                 expr: config.followupPrompt
               provider:
-                expr: alternate?.provider
+                expr: expectedAlternate.provider
               model:
-                expr: alternate?.model
+                expr: expectedAlternate.model
               timeoutMs:
                 expr: resolveQaLiveTurnTimeoutMs(env, 30000, env.alternateModel)
         - assert:
@@ -80,12 +74,9 @@ flow:
         - assert:
             expr: "alternateRun?.waited?.terminalReply?.disposition === 'visible' && hasModelSwitchContinuitySignal(alternateRun.waited.terminalReply.text)"
             message: alternate-model terminal reply missed kickoff continuity
-        - call: waitForCondition
-          saveAs: outbound
-          args:
-            - lambda:
-                expr: "state.getSnapshot().messages.slice(beforeSwitchCursor).filter((candidate) => candidate.direction === 'outbound' && !candidate.deleted && candidate.conversation.id === 'qa-operator' && alternateRun?.waited?.terminalReply?.disposition === 'visible' && candidate.text === alternateRun.waited.terminalReply.text).at(-1)"
-            - expr: resolveQaLiveTurnTimeoutMs(env, 20000, env.alternateModel)
+        - assert:
+            expr: "alternateRun?.waited?.terminalDelivery?.status === 'sent' && typeof alternateRun.waited.terminalDelivery.resultCount === 'number' && alternateRun.waited.terminalDelivery.resultCount > 0"
+            message: alternate-model run did not return owned sent delivery evidence
         - set: modelSwitchEvidence
           value:
             primary:
@@ -94,4 +85,6 @@ flow:
               ref: alternateRun.waited.terminalReceipt
             terminalReply:
               ref: alternateRun.waited.terminalReply
+            terminalDelivery:
+              ref: alternateRun.waited.terminalDelivery
       detailsExpr: alternateRun.waited.terminalReply.text

--- a/qa/scenarios/models/model-switch-tool-continuity.yaml
+++ b/qa/scenarios/models/model-switch-tool-continuity.yaml
@@ -32,18 +32,22 @@ flow:
   steps:
     - name: keeps using tools after switching models
       actions:
+        - set: alternate
+          value:
+            expr: splitModelRef(env.alternateModel)
+        - set: expectedAlternate
+          value:
+            expr: normalizeModelRef(env.alternateModel)
+        - assert:
+            expr: "normalizeModelRef(env.primaryModel) && expectedAlternate && (normalizeModelRef(env.primaryModel).provider !== expectedAlternate.provider || normalizeModelRef(env.primaryModel).model !== expectedAlternate.model)"
+            message: primary and alternate models must normalize to different refs
         - call: waitForGatewayHealthy
           args:
             - ref: env
             - 60000
         - call: reset
-        - call: readSessionTranscriptSummary
-          saveAs: beforeAttemptTranscript
-          args:
-            - ref: env
-            - agent:qa:model-switch-tools
-            - allowEmpty: true
         - call: runAgentPrompt
+          saveAs: primaryRun
           args:
             - ref: env
             - sessionKey: agent:qa:model-switch-tools
@@ -51,27 +55,14 @@ flow:
                 expr: config.initialPrompt
               timeoutMs:
                 expr: liveTurnTimeoutMs(env, 30000)
-        - call: waitForCondition
-          saveAs: beforeSwitchTranscript
-          args:
-            - lambda:
-                async: true
-                expr: "readSessionTranscriptSummary(env, 'agent:qa:model-switch-tools', { afterEventCursor: beforeAttemptTranscript.eventCursor, allowEmpty: true }).then((summary) => (summary.successfulToolCallCounts.read ?? 0) >= 1 ? summary : undefined)"
-            - 5000
-            - 50
-        - set: alternate
-          value:
-            expr: splitModelRef(env.alternateModel)
-        - set: expectedAlternate
-          value:
-            expr: normalizeModelRef(env.alternateModel)
+        - assert:
+            expr: "(() => { const expected = normalizeModelRef(env.primaryModel); const receipt = primaryRun?.waited?.terminalReceipt; return receipt?.runId === primaryRun?.started?.runId && normalizeLowercaseStringOrEmpty(receipt.requested?.provider) === expected.provider && receipt.requested?.model === expected.model && receipt.successfulToolNames?.includes('read') && receipt.terminalDisposition === 'visible'; })()"
+            message: default-model run did not return owned successful read evidence
         - set: beforeSwitchCursor
           value:
             expr: state.getSnapshot().messages.length
-        - set: beforeSwitchRequestCursor
-          value:
-            expr: "env.mock ? (await fetchJson(`${env.mock.baseUrl}/debug/request-cursor`)).cursor : 0"
         - call: runAgentPrompt
+          saveAs: alternateRun
           args:
             - ref: env
             - sessionKey: agent:qa:model-switch-tools
@@ -83,29 +74,9 @@ flow:
                 expr: alternate?.model
               timeoutMs:
                 expr: resolveQaLiveTurnTimeoutMs(env, 30000, env.alternateModel)
-        - call: readRawQaSessionStore
-          saveAs: afterSwitchSessions
-          args:
-            - ref: env
-        - set: afterSwitchSession
-          value:
-            expr: "afterSwitchSessions['agent:qa:model-switch-tools']"
         - assert:
-            expr: "normalizeLowercaseStringOrEmpty(afterSwitchSession?.modelProvider) === normalizeLowercaseStringOrEmpty(expectedAlternate?.provider) && String(afterSwitchSession?.model ?? '') === String(expectedAlternate?.model ?? '')"
-            message:
-              expr: "`expected alternate persisted model ${String(expectedAlternate?.provider ?? '')}/${String(expectedAlternate?.model ?? '')}, got ${String(afterSwitchSession?.modelProvider ?? '')}/${String(afterSwitchSession?.model ?? '')}`"
-        - call: waitForCondition
-          saveAs: afterSwitchTranscript
-          args:
-            - lambda:
-                async: true
-                expr: "readSessionTranscriptSummary(env, 'agent:qa:model-switch-tools', { afterEventCursor: beforeSwitchTranscript.eventCursor, allowEmpty: true }).then((summary) => (summary.successfulToolCallCounts.read ?? 0) >= 1 ? summary : undefined)"
-            - 5000
-            - 50
-        - assert:
-            expr: "(afterSwitchTranscript.successfulToolCallCounts.read ?? 0) >= 1"
-            message:
-              expr: "`expected a successful read after the model switch; successfulTools=${JSON.stringify(afterSwitchTranscript.successfulToolCallCounts ?? {})}`"
+            expr: "(() => { const receipt = alternateRun?.waited?.terminalReceipt; return receipt?.runId === alternateRun?.started?.runId && Boolean(receipt.sessionId) && Boolean(receipt.turnId) && normalizeLowercaseStringOrEmpty(receipt.requested?.provider) === expectedAlternate.provider && receipt.requested?.model === expectedAlternate.model && receipt.effective?.model === receipt.effective?.responseModel && receipt.successfulToolNames?.includes('read') && receipt.terminalDisposition === 'visible' && typeof receipt.rerouted === 'boolean' && `${receipt.effective?.provider}/${receipt.effective?.responseModel}` !== `${primaryRun.waited.terminalReceipt.effective?.provider}/${primaryRun.waited.terminalReceipt.effective?.responseModel}`; })()"
+            message: alternate-model run did not return exact owned successful read evidence
         - call: waitForCondition
           saveAs: outbound
           args:
@@ -116,17 +87,10 @@ flow:
             expr: hasModelSwitchContinuitySignal(outbound.text)
             message:
               expr: "`switch reply missed kickoff continuity: ${outbound.text}`"
-        - if:
-            expr: "Boolean(env.mock)"
-            then:
-              - set: switchDebugRequests
-                value:
-                  expr: "await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${beforeSwitchRequestCursor}`)"
-              - set: switchRequest
-                value:
-                  expr: "switchDebugRequests.find((request) => String(request.allInputText ?? '').includes(config.promptSnippet))"
-              - assert:
-                  expr: "String(switchRequest?.model ?? '') === String(expectedAlternate?.model ?? '')"
-                  message:
-                    expr: "`expected alternate model, got ${String(switchRequest?.model ?? '')}`"
+        - set: modelSwitchEvidence
+          value:
+            primary:
+              ref: primaryRun.waited.terminalReceipt
+            alternate:
+              ref: alternateRun.waited.terminalReceipt
       detailsExpr: outbound.text

--- a/qa/scenarios/models/model-switch-tool-continuity.yaml
+++ b/qa/scenarios/models/model-switch-tool-continuity.yaml
@@ -77,20 +77,21 @@ flow:
         - assert:
             expr: "(() => { const receipt = alternateRun?.waited?.terminalReceipt; return receipt?.runId === alternateRun?.started?.runId && Boolean(receipt.sessionId) && Boolean(receipt.turnId) && normalizeLowercaseStringOrEmpty(receipt.requested?.provider) === expectedAlternate.provider && receipt.requested?.model === expectedAlternate.model && receipt.effective?.model === receipt.effective?.responseModel && receipt.successfulToolNames?.includes('read') && receipt.terminalDisposition === 'visible' && typeof receipt.rerouted === 'boolean' && `${receipt.effective?.provider}/${receipt.effective?.responseModel}` !== `${primaryRun.waited.terminalReceipt.effective?.provider}/${primaryRun.waited.terminalReceipt.effective?.responseModel}`; })()"
             message: alternate-model run did not return exact owned successful read evidence
+        - assert:
+            expr: "alternateRun?.waited?.terminalReply?.disposition === 'visible' && hasModelSwitchContinuitySignal(alternateRun.waited.terminalReply.text)"
+            message: alternate-model terminal reply missed kickoff continuity
         - call: waitForCondition
           saveAs: outbound
           args:
             - lambda:
-                expr: "state.getSnapshot().messages.slice(beforeSwitchCursor).filter((candidate) => candidate.direction === 'outbound' && !candidate.deleted && candidate.conversation.id === 'qa-operator' && hasModelSwitchContinuitySignal(candidate.text)).at(-1)"
+                expr: "state.getSnapshot().messages.slice(beforeSwitchCursor).filter((candidate) => candidate.direction === 'outbound' && !candidate.deleted && candidate.conversation.id === 'qa-operator' && alternateRun?.waited?.terminalReply?.disposition === 'visible' && candidate.text === alternateRun.waited.terminalReply.text).at(-1)"
             - expr: resolveQaLiveTurnTimeoutMs(env, 20000, env.alternateModel)
-        - assert:
-            expr: hasModelSwitchContinuitySignal(outbound.text)
-            message:
-              expr: "`switch reply missed kickoff continuity: ${outbound.text}`"
         - set: modelSwitchEvidence
           value:
             primary:
               ref: primaryRun.waited.terminalReceipt
             alternate:
               ref: alternateRun.waited.terminalReceipt
-      detailsExpr: outbound.text
+            terminalReply:
+              ref: alternateRun.waited.terminalReply
+      detailsExpr: alternateRun.waited.terminalReply.text

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -1475,6 +1475,41 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     );
   });
 
+  it("preserves bounded delivery evidence when strict post-turn delivery throws", async () => {
+    setupSingleAttemptFallback();
+    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
+    const secret = ["sk", "strict-delivery-secret-value"].join("-");
+    state.deliverAgentCommandResultMock.mockImplementation(async (params: unknown) => {
+      (
+        params as {
+          onDeliveryResult?: (result: { deliveryStatus: Record<string, unknown> }) => void;
+        }
+      ).onDeliveryResult?.({
+        deliveryStatus: {
+          status: "failed",
+          errorMessage: `Authorization: Bearer ${secret}`,
+          target: "discord:dm:private",
+        },
+      });
+      throw new Error("strict delivery failed");
+    });
+
+    await expect(runDiscordDelivery()).rejects.toThrow("strict delivery failed");
+
+    const lifecycleError = state.emitAgentEventMock.mock.calls
+      .map((call) => call[0] as { stream?: string; data?: Record<string, unknown> })
+      .find((event) => event.stream === "lifecycle" && event.data?.phase === "error");
+    expect(lifecycleError?.data?.terminalDelivery).toEqual({
+      status: "failed",
+      resultCount: 0,
+    });
+    for (const field of ["stopReason", "terminalReceipt", "terminalReply"]) {
+      expect(lifecycleError?.data).not.toHaveProperty(field);
+    }
+    expect(JSON.stringify(lifecycleError)).not.toContain(secret);
+    expect(JSON.stringify(lifecycleError)).not.toContain("discord:dm:private");
+  });
+
   it("preserves restart ownership when an aborted attempt resolves normally", async () => {
     setupSingleAttemptFallback();
     const controller = new AbortController();

--- a/src/agents/agent-run-terminal-delivery.ts
+++ b/src/agents/agent-run-terminal-delivery.ts
@@ -1,0 +1,30 @@
+export type AgentRunTerminalDeliverySnapshot = {
+  status: "sent" | "suppressed" | "partial_failed" | "failed";
+  resultCount: number;
+};
+
+/** Rejects malformed lifecycle/RPC input and projects only the bounded delivery fact. */
+export function normalizeAgentRunTerminalDeliverySnapshot(
+  value: unknown,
+): AgentRunTerminalDeliverySnapshot | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const delivery = value as { status?: unknown; resultCount?: unknown };
+  if (
+    typeof delivery.resultCount !== "number" ||
+    !Number.isSafeInteger(delivery.resultCount) ||
+    delivery.resultCount < 0
+  ) {
+    return undefined;
+  }
+  switch (delivery.status) {
+    case "sent":
+    case "suppressed":
+    case "partial_failed":
+    case "failed":
+      return { status: delivery.status, resultCount: delivery.resultCount };
+    default:
+      return undefined;
+  }
+}

--- a/src/agents/agent-run-terminal-receipt.ts
+++ b/src/agents/agent-run-terminal-receipt.ts
@@ -1,0 +1,27 @@
+type AgentRunTerminalModelRef = { provider: string; model: string };
+
+export type AgentRunTerminalReceipt = {
+  runId: string;
+  sessionId: string;
+  turnId: string;
+  requested: AgentRunTerminalModelRef;
+  effective: AgentRunTerminalModelRef & { responseModel: string };
+  successfulToolNames: string[];
+  rerouted: boolean;
+  terminalDisposition: "visible" | "not-visible";
+};
+
+export function normalizeAgentRunTerminalReceipt(
+  value: unknown,
+): AgentRunTerminalReceipt | undefined {
+  const receipt = value as AgentRunTerminalReceipt | undefined;
+  return receipt &&
+    typeof receipt.runId === "string" &&
+    typeof receipt.sessionId === "string" &&
+    typeof receipt.turnId === "string" &&
+    receipt.requested &&
+    receipt.effective &&
+    Array.isArray(receipt.successfulToolNames)
+    ? receipt
+    : undefined;
+}

--- a/src/agents/command/lifecycle.test.ts
+++ b/src/agents/command/lifecycle.test.ts
@@ -149,6 +149,7 @@ describe("createAgentCommandLifecycle", () => {
           providerStarted: malicious,
           livenessState: malicious,
           replayInvalid: malicious,
+          terminalReceipt: malicious,
           error: malicious,
           unknownMetadata: malicious,
         },
@@ -172,6 +173,7 @@ describe("createAgentCommandLifecycle", () => {
         "providerStarted",
         "livenessState",
         "replayInvalid",
+        "terminalReceipt",
         "unknownMetadata",
       ]) {
         expect(event.data).not.toHaveProperty(field);

--- a/src/agents/command/lifecycle.test.ts
+++ b/src/agents/command/lifecycle.test.ts
@@ -24,6 +24,12 @@ describe("createAgentCommandLifecycle", () => {
         yielded: true,
         replayInvalid: true,
         error: { message: `Authorization: Bearer ${secret}`, nested: { secret } },
+        terminalDelivery: {
+          status: "sent",
+          resultCount: 2,
+          errorMessage: secret,
+          target: "private-target",
+        },
         unsafeMetadata: { credential: secret },
       };
       const lifecycle = createAgentCommandLifecycle({
@@ -76,8 +82,10 @@ describe("createAgentCommandLifecycle", () => {
           }),
         }),
       );
-      expect(JSON.stringify(emitAgentEvent.mock.calls[0]?.[0])).not.toContain(secret);
-      expect(emitAgentEvent.mock.calls[0]?.[0]?.data).not.toHaveProperty("unsafeMetadata");
+      const event = emitAgentEvent.mock.calls[0]?.[0];
+      expect(event.data.terminalDelivery).toEqual({ status: "sent", resultCount: 2 });
+      expect(JSON.stringify(event)).not.toContain(secret);
+      expect(event.data).not.toHaveProperty("unsafeMetadata");
     },
   );
 
@@ -105,7 +113,7 @@ describe("createAgentCommandLifecycle", () => {
       };
 
       if (source === "post-turn error") {
-        lifecycle.emitPostTurnError(new Error(error));
+        lifecycle.emitPostTurnError(new Error(error), terminal);
       } else {
         lifecycle.emitResultError(
           {
@@ -123,6 +131,60 @@ describe("createAgentCommandLifecycle", () => {
       expect(JSON.stringify(event)).not.toContain(secret);
     },
   );
+
+  it("keeps post-turn errors narrow while publishing bounded delivery evidence", () => {
+    emitAgentEvent.mockClear();
+    const secret = ["sk", "abcdefghijklmnopqrstuv"].join("-");
+    const lifecycle = createAgentCommandLifecycle({
+      runId: "post-turn-delivery-owner",
+      lifecycleGeneration: () => "test-generation",
+      startedAt: 100,
+      state: {
+        currentTurnUserMessagePersisted: true,
+        lifecycleFinishing: false,
+        lifecycleEnded: false,
+      },
+    });
+    lifecycle.emitPostTurnError(new Error("delivery failed"), {
+      metadata: {
+        terminalDelivery: {
+          status: "failed",
+          resultCount: 0,
+          errorMessage: secret,
+        },
+        terminalReceipt: { runId: "unrelated-receipt", secret },
+        terminalReply: { disposition: "visible", text: secret },
+        unsafeMetadata: { secret },
+      },
+      outcome: buildAgentRunTerminalOutcome({
+        status: "timeout",
+        stopReason: "timeout",
+        livenessState: "blocked",
+        timeoutPhase: "provider",
+        providerStarted: true,
+      }),
+    });
+
+    const event = emitAgentEvent.mock.calls[0]?.[0];
+    expect(event.data).toMatchObject({
+      phase: "error",
+      error: "delivery failed",
+      terminalDelivery: { status: "failed", resultCount: 0 },
+    });
+    expect(JSON.stringify(event)).not.toContain(secret);
+    for (const field of [
+      "aborted",
+      "stopReason",
+      "livenessState",
+      "timeoutPhase",
+      "providerStarted",
+      "terminalReceipt",
+      "terminalReply",
+      "unsafeMetadata",
+    ]) {
+      expect(event.data).not.toHaveProperty(field);
+    }
+  });
 
   it.each(["finishing", "end", "error"] as const)(
     "rejects malformed canonical metadata on %s events",
@@ -150,6 +212,7 @@ describe("createAgentCommandLifecycle", () => {
           livenessState: malicious,
           replayInvalid: malicious,
           terminalReceipt: malicious,
+          terminalDelivery: malicious,
           error: malicious,
           unknownMetadata: malicious,
         },
@@ -173,6 +236,7 @@ describe("createAgentCommandLifecycle", () => {
         "providerStarted",
         "livenessState",
         "replayInvalid",
+        "terminalDelivery",
         "terminalReceipt",
         "unknownMetadata",
       ]) {

--- a/src/agents/command/lifecycle.ts
+++ b/src/agents/command/lifecycle.ts
@@ -1,6 +1,7 @@
 import { emitAgentEvent } from "../../infra/agent-events.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { normalizeAgentRunTerminalDeliverySnapshot } from "../agent-run-terminal-delivery.js";
 import {
   buildAgentRunTerminalOutcomeFromLifecycleEvent,
   type AgentRunTerminalOutcome,
@@ -80,6 +81,9 @@ export function createAgentCommandLifecycle(params: {
     fallbackExhausted?: boolean,
   ) => {
     const { aborted, yielded, replayInvalid, terminalReply } = terminal.metadata;
+    const terminalDelivery = normalizeAgentRunTerminalDeliverySnapshot(
+      terminal.metadata.terminalDelivery,
+    );
     const terminalReceipt = normalizeAgentRunTerminalReceipt(terminal.metadata.terminalReceipt);
     const { stopReason, livenessState, timeoutPhase, providerStarted } = terminal.outcome;
     emitAgentEvent({
@@ -99,6 +103,7 @@ export function createAgentCommandLifecycle(params: {
         ...(providerStarted !== undefined ? { providerStarted } : {}),
         ...(error ? { error: formatErrorMessage(error) } : {}),
         ...(fallbackExhausted ? { fallbackExhaustedFailure: true } : {}),
+        ...(terminalDelivery ? { terminalDelivery } : {}),
         ...(terminalReceipt ? { terminalReceipt } : {}),
         ...(terminalReply ? { terminalReply } : {}),
         ...resolveAgentRunAbortLifecycleFields(params.abortSignal),
@@ -146,11 +151,14 @@ export function createAgentCommandLifecycle(params: {
         (fallbackExhausted ? "All model fallback candidates failed" : "Agent run failed");
       emitTerminalPhase("error", terminal, error, fallbackExhausted);
     },
-    emitPostTurnError(error: unknown) {
+    emitPostTurnError(error: unknown, terminal: EmbeddedAgentRunEntryTerminal) {
       if (params.state.lifecycleEnded) {
         return;
       }
       params.state.lifecycleEnded = true;
+      const terminalDelivery = normalizeAgentRunTerminalDeliverySnapshot(
+        terminal.metadata.terminalDelivery,
+      );
       emitAgentEvent({
         runId: params.runId,
         lifecycleGeneration: params.lifecycleGeneration(),
@@ -160,6 +168,7 @@ export function createAgentCommandLifecycle(params: {
           startedAt: params.startedAt,
           endedAt: Date.now(),
           error: formatErrorMessage(error),
+          ...(terminalDelivery ? { terminalDelivery } : {}),
           ...resolveAgentRunErrorLifecycleFields(error, params.abortSignal),
         },
       });

--- a/src/agents/command/lifecycle.ts
+++ b/src/agents/command/lifecycle.ts
@@ -5,6 +5,7 @@ import {
   buildAgentRunTerminalOutcomeFromLifecycleEvent,
   type AgentRunTerminalOutcome,
 } from "../agent-run-terminal-outcome.js";
+import { normalizeAgentRunTerminalReceipt } from "../agent-run-terminal-receipt.js";
 import type { EmbeddedAgentRunEntryTerminal } from "../embedded-agent-runner/run-entry.js";
 import {
   resolveAgentRunAbortLifecycleFields,
@@ -79,6 +80,7 @@ export function createAgentCommandLifecycle(params: {
     fallbackExhausted?: boolean,
   ) => {
     const { aborted, yielded, replayInvalid, terminalReply } = terminal.metadata;
+    const terminalReceipt = normalizeAgentRunTerminalReceipt(terminal.metadata.terminalReceipt);
     const { stopReason, livenessState, timeoutPhase, providerStarted } = terminal.outcome;
     emitAgentEvent({
       runId: params.runId,
@@ -97,6 +99,7 @@ export function createAgentCommandLifecycle(params: {
         ...(providerStarted !== undefined ? { providerStarted } : {}),
         ...(error ? { error: formatErrorMessage(error) } : {}),
         ...(fallbackExhausted ? { fallbackExhaustedFailure: true } : {}),
+        ...(terminalReceipt ? { terminalReceipt } : {}),
         ...(terminalReply ? { terminalReply } : {}),
         ...resolveAgentRunAbortLifecycleFields(params.abortSignal),
       },

--- a/src/agents/command/post-run.ts
+++ b/src/agents/command/post-run.ts
@@ -13,6 +13,7 @@ import {
   constrainRestartRecoveryDeliveryPayloads,
   shouldPersistCurrentRunSessionCleanup,
 } from "../agent-command-restart-recovery.js";
+import { normalizeAgentRunTerminalDeliverySnapshot } from "../agent-run-terminal-delivery.js";
 import { isHeartbeatLifecycleRunKind } from "../bootstrap-mode.js";
 import { persistPendingFinalDeliveryMarker } from "../pending-final-delivery-marker.js";
 import type { AgentRunSessionTarget } from "../run-session-target.js";
@@ -340,6 +341,16 @@ export async function finalizeEmbeddedAgentCommand(params: {
           NonNullable<Parameters<typeof deliverAgentCommandResult>[0]["onDeliveryResult"]>
         >[0],
       ) => {
+        const deliveryStatus = deliveryResult.deliveryStatus;
+        const terminalDelivery = normalizeAgentRunTerminalDeliverySnapshot(
+          deliveryStatus && {
+            status: deliveryStatus.status,
+            resultCount: deliveryStatus.resultCount ?? 0,
+          },
+        );
+        if (terminalDelivery) {
+          terminal.metadata.terminalDelivery = terminalDelivery;
+        }
         params.onTerminalDeliveryEvidenceChanged(
           buildRestartRecoveryTerminalDeliveryEvidence(deliveryResult),
         );
@@ -396,7 +407,7 @@ export async function finalizeEmbeddedAgentCommand(params: {
       sessionReboundDuringRun,
     };
   } catch (error) {
-    lifecycle.emitPostTurnError(error);
+    lifecycle.emitPostTurnError(error, terminal);
     throw error;
   }
 }

--- a/src/agents/embedded-agent-runner/run-entry.test.ts
+++ b/src/agents/embedded-agent-runner/run-entry.test.ts
@@ -780,6 +780,7 @@ describe("runEmbeddedAgentEntry", () => {
       expected: { disposition: "empty" },
     },
   ])("records the producer-owned terminal snapshot for $name", async ({ name, meta, expected }) => {
+    const runId = `terminal-${name}`;
     state.runWithModelFallback.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
       outcome: "completed" as const,
       result: await params.run(params.provider, params.model),
@@ -790,7 +791,7 @@ describe("runEmbeddedAgentEntry", () => {
     const { runEmbeddedAgentEntry } = await import("./run-entry.js");
     const result = await runEmbeddedAgentEntry({
       selection: { cfg: {}, provider: "provider", model: "model" },
-      identity: { runId: `terminal-${name}`, agentId: "main", sessionId: "session-1" },
+      identity: { runId, agentId: "main", sessionId: "session-1" },
       harness: {
         workspaceDir: "/tmp/workspace",
         preparation: { kind: "direct" },
@@ -800,10 +801,35 @@ describe("runEmbeddedAgentEntry", () => {
       sessionOverride: { kind: "preserve" },
       runCandidate: async (provider, model) => ({
         ...makeResult({ provider, model }),
-        meta: { ...makeResult({ provider, model }).meta, ...meta },
+        meta: {
+          ...makeResult({ provider, model }).meta,
+          ...meta,
+          agentMeta: Object.assign(
+            {
+              sessionId: "session-1",
+              provider,
+              model,
+            },
+            {
+              terminalReceipt: {
+                runId,
+                sessionId: "session-1",
+                turnId: "turn-1",
+                requested: { provider, model },
+                effective: { provider, model, responseModel: model },
+                successfulToolNames: ["read"],
+                rerouted: false,
+              },
+            },
+          ),
+        },
       }),
     });
 
     expect(result.terminal.metadata.terminalReply).toEqual(expected);
+    expect(result.terminal.metadata.terminalReceipt).toMatchObject({
+      runId,
+      terminalDisposition: expected.disposition === "visible" ? "visible" : "not-visible",
+    });
   });
 });

--- a/src/agents/embedded-agent-runner/run-entry.ts
+++ b/src/agents/embedded-agent-runner/run-entry.ts
@@ -2,6 +2,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ContextEngineHostSupport } from "../../context-engine/host-compat.js";
 import { requireActivePluginRegistry } from "../../plugins/runtime.js";
 import { buildAgentRunTerminalOutcome } from "../agent-run-terminal-outcome.js";
+import { normalizeAgentRunTerminalReceipt } from "../agent-run-terminal-receipt.js";
 import {
   buildAgentRunTerminalReplySnapshot,
   normalizeAgentRunTerminalReplySnapshot,
@@ -189,6 +190,7 @@ function buildTerminal(params: {
   result: EmbeddedAgentRunResult;
   fallbackExhausted: boolean;
   behavior: RunEntryBehavior;
+  runId: string;
 }): EmbeddedAgentRunEntryTerminal {
   const meta = params.result.meta;
   const outcome = buildAgentRunTerminalOutcome({
@@ -200,6 +202,12 @@ function buildTerminal(params: {
     providerStarted: meta.providerStarted,
   });
   const metadata: Record<string, unknown> = {};
+  const terminalReceipt = normalizeAgentRunTerminalReceipt(
+    (meta.agentMeta as { terminalReceipt?: unknown } | undefined)?.terminalReceipt,
+  );
+  if (terminalReceipt?.runId === params.runId) {
+    metadata.terminalReceipt = terminalReceipt;
+  }
   metadata.terminalReply =
     normalizeAgentRunTerminalReplySnapshot(meta.terminalReply) ??
     buildAgentRunTerminalReplySnapshot({
@@ -447,6 +455,7 @@ export async function runEmbeddedAgentEntry<T extends EmbeddedAgentRunResult>(
       result,
       fallbackExhausted: settledResult.outcome === "exhausted",
       behavior: params.behavior,
+      runId: params.identity.runId,
     });
     if (fallbackResult.result.turnAttempt) {
       if (

--- a/src/agents/embedded-agent-runner/run-entry.ts
+++ b/src/agents/embedded-agent-runner/run-entry.ts
@@ -201,20 +201,23 @@ function buildTerminal(params: {
     timeoutPhase: meta.timeoutPhase,
     providerStarted: meta.providerStarted,
   });
-  const metadata: Record<string, unknown> = {};
-  const terminalReceipt = normalizeAgentRunTerminalReceipt(
-    (meta.agentMeta as { terminalReceipt?: unknown } | undefined)?.terminalReceipt,
-  );
-  if (terminalReceipt?.runId === params.runId) {
-    metadata.terminalReceipt = terminalReceipt;
-  }
-  metadata.terminalReply =
+  const terminalReply =
     normalizeAgentRunTerminalReplySnapshot(meta.terminalReply) ??
     buildAgentRunTerminalReplySnapshot({
       visibleText: meta.finalAssistantVisibleText,
       rawText: meta.finalAssistantRawText,
       terminalReplyKind: meta.terminalReplyKind,
     });
+  const metadata: Record<string, unknown> = { terminalReply };
+  const terminalReceipt = normalizeAgentRunTerminalReceipt(
+    (meta.agentMeta as { terminalReceipt?: unknown } | undefined)?.terminalReceipt,
+  );
+  if (terminalReceipt?.runId === params.runId) {
+    metadata.terminalReceipt = {
+      ...terminalReceipt,
+      terminalDisposition: terminalReply.disposition === "visible" ? "visible" : "not-visible",
+    };
+  }
   if (params.behavior.kind === "channel-delivery" || params.behavior.kind === "followup-delivery") {
     for (const key of [
       "stopReason",

--- a/src/agents/embedded-agent-runner/run/attempt-result.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-result.test.ts
@@ -14,7 +14,7 @@ function completeResult(params?: {
     toolName: string;
     meta?: string;
     replaySafe?: boolean;
-    isError?: true;
+    isError?: boolean;
     asyncStarted?: boolean;
     asyncTaskRunId?: string;
     asyncTaskId?: string;
@@ -97,6 +97,7 @@ describe("attempt result projection", () => {
       completeResult({
         toolMetas: [
           { toolName: "", replaySafe: true },
+          { toolName: "read", isError: false },
           {
             toolName: "exec",
             meta: "done",
@@ -109,6 +110,12 @@ describe("attempt result projection", () => {
         ],
       }).toolMetas,
     ).toEqual([
+      {
+        toolName: "read",
+        meta: undefined,
+        replaySafe: false,
+        isError: false,
+      },
       {
         toolName: "exec",
         meta: "done",

--- a/src/agents/embedded-agent-runner/run/attempt-result.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-result.ts
@@ -94,7 +94,7 @@ function normalizeEmbeddedAttemptToolMetas(
         toolName: string;
         meta?: string;
         replaySafe?: boolean;
-        isError?: true;
+        isError?: boolean;
         asyncStarted?: boolean;
         asyncTaskRunId?: string;
         asyncTaskId?: string;
@@ -106,8 +106,8 @@ function normalizeEmbeddedAttemptToolMetas(
         meta: entry.meta,
         replaySafe: entry.replaySafe === true,
       };
-      if (entry.isError === true) {
-        normalized.isError = true;
+      if (typeof entry.isError === "boolean") {
+        normalized.isError = entry.isError;
       }
       if (entry.asyncStarted === true) {
         normalized.asyncStarted = true;

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
@@ -112,12 +112,15 @@ describe("prepareEmbeddedRunTerminal", () => {
 
 describe("prepareEmbeddedRunTerminal run stats", () => {
   type StatsInput = {
-    attempt?: Partial<EmbeddedRunAttemptResult>;
+    attempt?: Partial<EmbeddedRunAttemptResult> & {
+      terminalTurnId?: string;
+    };
     assistantTurns?: number;
     bridgeCalls?: { search: number; describe: number; call: number };
     config?: unknown;
     provider?: string;
     model?: string;
+    responseModel?: string;
     usage?: Partial<
       Pick<
         ReturnType<typeof createUsageAccumulator>,
@@ -134,6 +137,7 @@ describe("prepareEmbeddedRunTerminal run stats", () => {
       ...assistantMessage("stop"),
       provider,
       model,
+      ...(statsInput.responseModel ? { responseModel: statsInput.responseModel } : {}),
     };
     const usageAccumulator = createUsageAccumulator();
     Object.assign(usageAccumulator, statsInput.usage);
@@ -242,5 +246,36 @@ describe("prepareEmbeddedRunTerminal run stats", () => {
   it("omits costUsd when the run reported no usage", async () => {
     const prepared = await prepareStats({ config: COST_CONFIG });
     expect(prepared.agentMeta).not.toHaveProperty("costUsd");
+  });
+
+  it("builds exact terminal model and successful-tool evidence", async () => {
+    const prepared = await prepareStats({
+      responseModel: "cost-model-rerouted",
+      attempt: {
+        terminalTurnId: "turn-7",
+        toolMetas: [
+          { toolName: "read" },
+          { toolName: "read" },
+          { toolName: "write", isError: true },
+        ],
+      },
+    });
+
+    expect(
+      (prepared.agentMeta as { terminalReceipt?: Record<string, unknown> }).terminalReceipt,
+    ).toMatchObject({
+      runId: "run-1",
+      sessionId: "session-1",
+      turnId: "turn-7",
+      requested: { provider: "cost-test-provider", model: "cost-model" },
+      effective: {
+        provider: "cost-test-provider",
+        model: "cost-model-rerouted",
+        responseModel: "cost-model-rerouted",
+      },
+      successfulToolNames: ["read"],
+      rerouted: true,
+      terminalDisposition: "visible",
+    });
   });
 });

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
@@ -277,7 +277,9 @@ describe("prepareEmbeddedRunTerminal run stats", () => {
       },
       successfulToolNames: ["read"],
       rerouted: true,
-      terminalDisposition: "visible",
     });
+    expect(
+      (prepared.agentMeta as { terminalReceipt?: Record<string, unknown> }).terminalReceipt,
+    ).not.toHaveProperty("terminalDisposition");
   });
 });

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
@@ -254,9 +254,11 @@ describe("prepareEmbeddedRunTerminal run stats", () => {
       attempt: {
         terminalTurnId: "turn-7",
         toolMetas: [
-          { toolName: "read" },
-          { toolName: "read" },
+          { toolName: "started" },
+          { toolName: "unknown" },
           { toolName: "write", isError: true },
+          { toolName: "read", isError: false },
+          { toolName: "read", isError: false },
         ],
       },
     });

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.ts
@@ -132,9 +132,7 @@ export function prepareEmbeddedRunTerminal(input: {
   const finalAssistantRawText = terminalAssistantCanOwnFinalText
     ? (resolveFinalAssistantRawText(terminalAssistant) ?? attemptFinalText)
     : undefined;
-  const attemptEvidence = attempt as EmbeddedRunAttemptResult & {
-    terminalTurnId?: string;
-  };
+  const terminalTurnId = (attempt as { terminalTurnId?: string }).terminalTurnId;
   const successfulToolNames = [
     ...new Set(
       attempt.toolMetas
@@ -147,7 +145,7 @@ export function prepareEmbeddedRunTerminal(input: {
     terminalReceipt: {
       runId: runParams.runId,
       sessionId: input.sessionIdUsed,
-      turnId: attemptEvidence.terminalTurnId?.trim() || runParams.runId,
+      turnId: terminalTurnId?.trim() || runParams.runId,
       requested: { provider: input.provider, model: input.model },
       effective: {
         provider: reportedModelRef.provider,
@@ -156,8 +154,7 @@ export function prepareEmbeddedRunTerminal(input: {
       },
       successfulToolNames,
       rerouted: responseModel !== input.model,
-      terminalDisposition: finalAssistantVisibleText ? "visible" : "not-visible",
-    } satisfies AgentRunTerminalReceipt,
+    } satisfies Omit<AgentRunTerminalReceipt, "terminalDisposition">,
   });
   // A yielded attempt ends before message_end. Its aborted tool-call assistant,
   // not an earlier completed cycle, owns paused-turn classification.

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.ts
@@ -2,6 +2,7 @@ import { copyReplyPayloadMetadata } from "../../../auto-reply/reply-payload.js";
 import type { AssistantMessage } from "../../../llm/types.js";
 import { estimateUsageCost, resolveModelCostConfig } from "../../../utils/usage-format.js";
 import { projectAgentRunAttemptTerminal } from "../../agent-run-terminal-outcome.js";
+import type { AgentRunTerminalReceipt } from "../../agent-run-terminal-receipt.js";
 import type { AuthProfileStore } from "../../auth-profiles.js";
 import type { NormalizedUsage, UsageLike } from "../../usage.js";
 import { resolveEmbeddedRunFailureSignal } from "../failure-signal.js";
@@ -72,11 +73,13 @@ export function prepareEmbeddedRunTerminal(input: {
     lastAssistantUsage: terminalAssistant?.usage as UsageLike | undefined,
     lastRunPromptUsage: input.lastRunPromptUsage,
   });
-  const reportedModelRef = resolveReportedModelRef({
+  const resolvedModelRef = resolveReportedModelRef({
     provider: input.provider,
     model: input.model,
     assistant: terminalAssistant,
   });
+  const responseModel = terminalAssistant?.responseModel?.trim() || resolvedModelRef.model;
+  const reportedModelRef = { ...resolvedModelRef, model: responseModel };
   const finalAssistantStopReason = (terminalAssistant?.stopReason ?? "").trim().toLowerCase();
   const terminalAssistantCanOwnFinalText =
     finalAssistantStopReason !== "error" && finalAssistantStopReason !== "aborted";
@@ -129,6 +132,33 @@ export function prepareEmbeddedRunTerminal(input: {
   const finalAssistantRawText = terminalAssistantCanOwnFinalText
     ? (resolveFinalAssistantRawText(terminalAssistant) ?? attemptFinalText)
     : undefined;
+  const attemptEvidence = attempt as EmbeddedRunAttemptResult & {
+    terminalTurnId?: string;
+  };
+  const successfulToolNames = [
+    ...new Set(
+      attempt.toolMetas
+        .filter((entry) => entry.isError !== true)
+        .map((entry) => entry.toolName.trim())
+        .filter(Boolean),
+    ),
+  ];
+  Object.assign(agentMeta, {
+    terminalReceipt: {
+      runId: runParams.runId,
+      sessionId: input.sessionIdUsed,
+      turnId: attemptEvidence.terminalTurnId?.trim() || runParams.runId,
+      requested: { provider: input.provider, model: input.model },
+      effective: {
+        provider: reportedModelRef.provider,
+        model: reportedModelRef.model,
+        responseModel,
+      },
+      successfulToolNames,
+      rerouted: responseModel !== input.model,
+      terminalDisposition: finalAssistantVisibleText ? "visible" : "not-visible",
+    } satisfies AgentRunTerminalReceipt,
+  });
   // A yielded attempt ends before message_end. Its aborted tool-call assistant,
   // not an earlier completed cycle, owns paused-turn classification.
   const payloadAssistant = attempt.yieldDetected

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.ts
@@ -138,7 +138,7 @@ export function prepareEmbeddedRunTerminal(input: {
   const successfulToolNames = [
     ...new Set(
       attempt.toolMetas
-        .filter((entry) => entry.isError !== true)
+        .filter((entry) => entry.isError === false)
         .map((entry) => entry.toolName.trim())
         .filter(Boolean),
     ),

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -2401,6 +2401,64 @@ describe("handleToolExecutionEnd exec approval prompts", () => {
       }),
       isError: true,
     });
+    expect(ctx.state.toolMetas).toEqual([
+      expect.objectContaining({ toolName: "exec", isError: true }),
+    ]);
+    const [
+      { normalizeAgentRunTerminalReceipt },
+      { createUsageAccumulator },
+      { createEmbeddedRunContextRecoveryState },
+      { prepareEmbeddedRunTerminal },
+    ] = await Promise.all([
+      import("./agent-run-terminal-receipt.js"),
+      import("./embedded-agent-runner/usage-accumulator.js"),
+      import("./embedded-agent-runner/run/context-recovery-state.js"),
+      import("./embedded-agent-runner/run/terminal-preparation.js"),
+    ]);
+    const prepared = prepareEmbeddedRunTerminal({
+      runParams: {
+        sessionId: "session-test-id",
+        runId: "run-test",
+        workspaceDir: "/tmp/openclaw-test",
+        prompt: "run",
+        trigger: "user",
+        timeoutMs: 60_000,
+      },
+      attempt: {
+        terminal: { kind: "ok" },
+        sessionIdUsed: "session-test-id",
+        messagesSnapshot: [],
+        assistantTexts: [],
+        toolMetas: ctx.state.toolMetas.flatMap(({ toolName, ...entry }) =>
+          toolName ? [{ ...entry, toolName }] : [],
+        ),
+        lastAssistant: undefined,
+        didSendViaMessagingTool: false,
+        messagingToolSentTexts: [],
+        messagingToolSentMediaUrls: [],
+        messagingToolSentTargets: [],
+        cloudCodeAssistFormatError: false,
+        replayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
+        itemLifecycle: { startedCount: 0, completedCount: 0, activeCount: 0 },
+      },
+      provider: "openai",
+      model: "gpt-5.4",
+      activeErrorContext: { provider: "openai", model: "gpt-5.4" },
+      authProfileStore: { version: 1, profiles: {} },
+      sessionIdUsed: "session-test-id",
+      outerContextTokenMeta: {},
+      usageAccumulator: createUsageAccumulator(),
+      contextRecoveryState: createEmbeddedRunContextRecoveryState(),
+      resolvedToolResultFormat: "markdown",
+      terminalState: {
+        outcome: { reason: "completed", status: "ok", stopReason: "stop" },
+        signalOwnedInterruption: false,
+      },
+    });
+    expect(
+      normalizeAgentRunTerminalReceipt(Reflect.get(prepared.agentMeta, "terminalReceipt"))
+        ?.successfulToolNames,
+    ).toEqual([]);
     expect(ctx.state.deterministicApprovalPromptSent).toBe(true);
   });
 

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -1977,6 +1977,48 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
 });
 
 describe("handleToolExecutionEnd timeout metadata", () => {
+  it("marks every finalized built-in call with its explicit outcome", async () => {
+    const { ctx } = createTestContext();
+
+    await endTool(ctx, {
+      toolName: "read",
+      toolCallId: "tool-read-complete",
+      isError: false,
+      result: { content: "ok" },
+    });
+    await endTool(ctx, {
+      toolName: "process",
+      toolCallId: "tool-process-running",
+      isError: false,
+      result: { details: { status: "running" } },
+    });
+    await endTool(ctx, {
+      toolName: "image_generate",
+      toolCallId: "tool-image-async-started",
+      isError: false,
+      result: { details: { async: true, status: "started" } },
+    });
+    await endTool(ctx, {
+      toolName: "write",
+      toolCallId: "tool-write-failed",
+      isError: true,
+      result: { error: "failed" },
+    });
+
+    expect(
+      ctx.state.toolMetas.map(({ toolName, isError }) => ({
+        toolName,
+        isError,
+      })),
+    ).toEqual([
+      { toolName: "read", isError: false },
+      { toolName: "process", isError: false },
+      { toolName: "image_generate", isError: false },
+      { toolName: "write", isError: true },
+    ]);
+    expect(ctx.state.toolMetas[2]?.asyncStarted).toBe(true);
+  });
+
   it("retains every failed call after later successes change the last-error slot", async () => {
     const { ctx } = createTestContext();
 
@@ -1995,7 +2037,7 @@ describe("handleToolExecutionEnd timeout metadata", () => {
 
     expect(ctx.state.toolMetas.map(({ toolName, isError }) => ({ toolName, isError }))).toEqual([
       { toolName: "read", isError: true },
-      { toolName: "read", isError: undefined },
+      { toolName: "read", isError: false },
       { toolName: "exec", isError: true },
     ]);
   });

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -1467,7 +1467,7 @@ export async function handleToolExecutionEnd(
     toolName,
     meta,
     replaySafe: callSummary.replaySafe,
-    ...(isToolError ? { isError: true } : {}),
+    isError: isToolError,
     ...(asyncStarted ? { asyncStarted: true, ...asyncTaskIds } : {}),
   });
   const acceptedSessionSpawn =

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -1467,7 +1467,7 @@ export async function handleToolExecutionEnd(
     toolName,
     meta,
     replaySafe: callSummary.replaySafe,
-    isError: isToolError,
+    isError: observerIsError,
     ...(asyncStarted ? { asyncStarted: true, ...asyncTaskIds } : {}),
   });
   const acceptedSessionSpawn =

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -75,7 +75,7 @@ export type EmbeddedAgentSubscribeState = {
     toolName?: string;
     meta?: string;
     replaySafe?: boolean;
-    isError?: true;
+    isError?: boolean;
     asyncStarted?: boolean;
     asyncTaskRunId?: string;
     asyncTaskId?: string;

--- a/src/gateway/server-methods/agent-job.ts
+++ b/src/gateway/server-methods/agent-job.ts
@@ -3,6 +3,10 @@
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import {
+  normalizeAgentRunTerminalDeliverySnapshot,
+  type AgentRunTerminalDeliverySnapshot,
+} from "../../agents/agent-run-terminal-delivery.js";
+import {
   AGENT_RUN_TERMINAL_RETRY_GRACE_MS,
   buildAgentRunTerminalOutcome,
   buildAgentRunTerminalOutcomeFromLifecycleEvent,
@@ -39,6 +43,7 @@ type AgentJobTerminalSnapshot = {
   pendingError?: boolean;
   timeoutPhase?: AgentRunTerminalOutcome["timeoutPhase"];
   providerStarted?: boolean;
+  terminalDelivery?: AgentRunTerminalDeliverySnapshot;
   terminalReceipt?: AgentRunTerminalReceipt;
   terminalReply?: AgentRunTerminalReplySnapshot;
 };
@@ -173,12 +178,14 @@ function mergeSnapshot(
     existing.terminalReply,
     incoming.terminalReply,
   );
+  const terminalDelivery = incoming.terminalDelivery ?? existing.terminalDelivery;
   const terminalReceipt = incoming.terminalReceipt ?? existing.terminalReceipt;
   const canonical = shouldPreserveTerminalSnapshot(existing, incoming) ? existing : incoming;
   // Terminal status precedence and producer reply evidence are independent;
   // a late sticky timeout must not erase the final reply (or vice versa).
   return {
     ...canonical,
+    ...(terminalDelivery ? { terminalDelivery } : {}),
     ...(terminalReceipt ? { terminalReceipt } : {}),
     ...(terminalReply ? { terminalReply } : {}),
     cachedAt: incoming.cachedAt,
@@ -284,6 +291,7 @@ function createPendingErrorTimeoutSnapshot(
     ...(snapshot.providerStarted !== undefined
       ? { providerStarted: snapshot.providerStarted }
       : {}),
+    ...(snapshot.terminalDelivery ? { terminalDelivery: snapshot.terminalDelivery } : {}),
   };
 }
 
@@ -306,6 +314,7 @@ function createSnapshotFromLifecycleEvent(params: {
   // Modern explicit stop reasons keep the canonical cancellation projection.
   const legacyBareAbort =
     terminalOutcome.reason === "aborted" && data?.stopReason == null && data?.status == null;
+  const terminalDelivery = normalizeAgentRunTerminalDeliverySnapshot(data?.terminalDelivery);
   const terminalReply = normalizeAgentRunTerminalReplySnapshot(data?.terminalReply);
   const normalizedTerminalReceipt = normalizeAgentRunTerminalReceipt(data?.terminalReceipt);
   const terminalReceipt =
@@ -325,6 +334,7 @@ function createSnapshotFromLifecycleEvent(params: {
     ...(terminalOutcome.providerStarted !== undefined
       ? { providerStarted: terminalOutcome.providerStarted }
       : {}),
+    ...(terminalDelivery ? { terminalDelivery } : {}),
     ...(terminalReply ? { terminalReply } : {}),
     ...(terminalReceipt ? { terminalReceipt } : {}),
     version: nextAgentRunVersion(),
@@ -571,6 +581,7 @@ function publicSnapshot(snapshot: AgentRunObservation): AgentJobTerminalSnapshot
     pendingError: snapshot.pendingError,
     timeoutPhase: snapshot.timeoutPhase,
     providerStarted: snapshot.providerStarted,
+    ...(snapshot.terminalDelivery ? { terminalDelivery: snapshot.terminalDelivery } : {}),
     terminalReceipt: snapshot.terminalReceipt,
     terminalReply: snapshot.terminalReply,
   };

--- a/src/gateway/server-methods/agent-job.ts
+++ b/src/gateway/server-methods/agent-job.ts
@@ -11,6 +11,10 @@ import {
   type AgentRunTerminalOutcome,
 } from "../../agents/agent-run-terminal-outcome.js";
 import {
+  normalizeAgentRunTerminalReceipt,
+  type AgentRunTerminalReceipt,
+} from "../../agents/agent-run-terminal-receipt.js";
+import {
   mergeAgentRunTerminalReplySnapshot,
   normalizeAgentRunTerminalReplySnapshot,
   type AgentRunTerminalReplySnapshot,
@@ -35,6 +39,7 @@ type AgentJobTerminalSnapshot = {
   pendingError?: boolean;
   timeoutPhase?: AgentRunTerminalOutcome["timeoutPhase"];
   providerStarted?: boolean;
+  terminalReceipt?: AgentRunTerminalReceipt;
   terminalReply?: AgentRunTerminalReplySnapshot;
 };
 
@@ -168,11 +173,13 @@ function mergeSnapshot(
     existing.terminalReply,
     incoming.terminalReply,
   );
+  const terminalReceipt = incoming.terminalReceipt ?? existing.terminalReceipt;
   const canonical = shouldPreserveTerminalSnapshot(existing, incoming) ? existing : incoming;
   // Terminal status precedence and producer reply evidence are independent;
   // a late sticky timeout must not erase the final reply (or vice versa).
   return {
     ...canonical,
+    ...(terminalReceipt ? { terminalReceipt } : {}),
     ...(terminalReply ? { terminalReply } : {}),
     cachedAt: incoming.cachedAt,
     recordedAt: incoming.recordedAt,
@@ -300,6 +307,9 @@ function createSnapshotFromLifecycleEvent(params: {
   const legacyBareAbort =
     terminalOutcome.reason === "aborted" && data?.stopReason == null && data?.status == null;
   const terminalReply = normalizeAgentRunTerminalReplySnapshot(data?.terminalReply);
+  const normalizedTerminalReceipt = normalizeAgentRunTerminalReceipt(data?.terminalReceipt);
+  const terminalReceipt =
+    normalizedTerminalReceipt?.runId === runId ? normalizedTerminalReceipt : undefined;
   return {
     runId,
     source: "lifecycle",
@@ -316,6 +326,7 @@ function createSnapshotFromLifecycleEvent(params: {
       ? { providerStarted: terminalOutcome.providerStarted }
       : {}),
     ...(terminalReply ? { terminalReply } : {}),
+    ...(terminalReceipt ? { terminalReceipt } : {}),
     version: nextAgentRunVersion(),
   };
 }
@@ -560,6 +571,7 @@ function publicSnapshot(snapshot: AgentRunObservation): AgentJobTerminalSnapshot
     pendingError: snapshot.pendingError,
     timeoutPhase: snapshot.timeoutPhase,
     providerStarted: snapshot.providerStarted,
+    terminalReceipt: snapshot.terminalReceipt,
     terminalReply: snapshot.terminalReply,
   };
 }

--- a/src/gateway/server-methods/agent-wait-dedupe.test.ts
+++ b/src/gateway/server-methods/agent-wait-dedupe.test.ts
@@ -157,7 +157,7 @@ describe("agent.wait gateway dedupe observations", () => {
   });
 
   it.each(["lifecycle-first", "dedupe-first"] as const)(
-    "keeps reply evidence when sticky status arrives $0",
+    "keeps terminal evidence when sticky status arrives $0",
     async (order) => {
       const runId = `run-reply-merge-${order}`;
       const dedupe = new Map<string, DedupeEntry>();
@@ -174,6 +174,11 @@ describe("agent.wait gateway dedupe observations", () => {
             phase: "end",
             startedAt: 100,
             endedAt: 300,
+            terminalDelivery: {
+              status: "sent",
+              resultCount: 1,
+              target: "private-target",
+            },
             terminalReceipt: terminalReceipt(runId),
             terminalReply: { disposition: "visible", text: "canonical reply" },
           },
@@ -208,10 +213,12 @@ describe("agent.wait gateway dedupe observations", () => {
         expect.objectContaining({
           runId,
           status: "timeout",
+          terminalDelivery: { status: "sent", resultCount: 1 },
           terminalReceipt: terminalReceipt(runId),
           terminalReply: { disposition: "visible", text: "canonical reply" },
         }),
       );
+      expect(JSON.stringify(waiter.respond.mock.calls[0]?.[1])).not.toContain("private-target");
     },
   );
 });

--- a/src/gateway/server-methods/agent-wait-dedupe.test.ts
+++ b/src/gateway/server-methods/agent-wait-dedupe.test.ts
@@ -33,6 +33,19 @@ function completeRun(dedupe: Map<string, DedupeEntry>, runId: string): void {
   });
 }
 
+function terminalReceipt(runId: string) {
+  return {
+    runId,
+    sessionId: "session-1",
+    turnId: "turn-1",
+    requested: { provider: "openai", model: "gpt-primary" },
+    effective: { provider: "openai", model: "gpt-alternate", responseModel: "gpt-alternate" },
+    successfulToolNames: ["read"],
+    rerouted: true,
+    terminalDisposition: "visible",
+  };
+}
+
 afterEach(() => {
   vi.useRealTimers();
 });
@@ -161,6 +174,7 @@ describe("agent.wait gateway dedupe observations", () => {
             phase: "end",
             startedAt: 100,
             endedAt: 300,
+            terminalReceipt: terminalReceipt(runId),
             terminalReply: { disposition: "visible", text: "canonical reply" },
           },
         });
@@ -194,6 +208,7 @@ describe("agent.wait gateway dedupe observations", () => {
         expect.objectContaining({
           runId,
           status: "timeout",
+          terminalReceipt: terminalReceipt(runId),
           terminalReply: { disposition: "visible", text: "canonical reply" },
         }),
       );

--- a/src/gateway/server-methods/agent-wait.ts
+++ b/src/gateway/server-methods/agent-wait.ts
@@ -47,6 +47,7 @@ export const agentWaitHandler: GatewayRequestHandlers["agent.wait"] = async ({
     pendingError: snapshot.pendingError,
     timeoutPhase: snapshot.timeoutPhase,
     providerStarted: snapshot.providerStarted,
+    ...(snapshot.terminalDelivery ? { terminalDelivery: snapshot.terminalDelivery } : {}),
     terminalReceipt: snapshot.terminalReceipt,
     terminalReply: snapshot.terminalReply,
   });

--- a/src/gateway/server-methods/agent-wait.ts
+++ b/src/gateway/server-methods/agent-wait.ts
@@ -47,6 +47,7 @@ export const agentWaitHandler: GatewayRequestHandlers["agent.wait"] = async ({
     pendingError: snapshot.pendingError,
     timeoutPhase: snapshot.timeoutPhase,
     providerStarted: snapshot.providerStarted,
+    terminalReceipt: snapshot.terminalReceipt,
     terminalReply: snapshot.terminalReply,
   });
 };


### PR DESCRIPTION
## What Problem This Solves

Model-switch QA could falsely pass when evidence from a prior reply or attempt was mistaken for evidence from the exact run that selected the alternate model. The original contribution and investigation are credited to @steipete.

## Root Cause

The inherited implementation inferred ownership from transcript cursors and persisted history. That could not prove that a delayed result, effective model, successful tool call, or visible terminal reply belonged to the current run.

Independent follow-up review found a second producer-boundary bug: the terminal receipt treated any tool metadata without `isError: true` as successful. Start-only or otherwise nonterminal metadata could therefore satisfy model-switch tool continuity without an observed successful completion.

A later review found one remaining split-outcome case: `approval-unavailable` is correctly normalized as `observerIsError: true`, while `isToolError` intentionally remains false to preserve recovery-oriented approval UX. Built-in receipt metadata used the presentation/recovery flag and therefore certified an exec that never ran.

Independent exact-head review then found that receipt visibility was derived from truthiness of `finalAssistantVisibleText`. Canonical exact `NO_REPLY` is silent, but the raw marker is truthy, so both model-switch scenarios could falsely accept a deliberately silent terminal.

The latest independent reviews found that delivery ownership was still split between exact-run terminal evidence and QA-bus observations. Alternate-run continuity initially depended on post-cursor bus text, while the follow-up scenario's primary step still accepted any outbound message for the operator. Neither bus text nor a cursor proves which run delivered the reply.

The delivery lifecycle already owns the authoritative result. It now records a bounded `terminalDelivery` snapshot containing only normalized status and aggregate result count, including the strict-delivery callback-before-throw path. Both primary and alternate scenario runs must provide their own visible reply, exact receipt, and sent delivery evidence with a positive result count.

The architectural owners are:

- provider/plugin adapters, which observe the effective response model and Codex reroute event;
- the agent terminal boundary, which owns run/session/turn identity and terminal disposition;
- QA Lab, which consumes that run-owned receipt without inspecting provider internals or storage.

## Canonical Fix

- Add one internal terminal receipt containing exact run/session/turn identity, requested provider/model, effective provider/model and `AssistantMessage.responseModel`, successful tool names, reroute state, and visible terminal disposition.
- Propagate direct OpenAI terminal `response.model`.
- Project current-turn Codex `model/rerouted` into the terminal assistant response model.
- Return the receipt through existing agent lifecycle and `agent.wait` paths.
- Expose the existing canonical `agent.wait.terminalReply` as a bounded QA wait-result union.
- Capture bounded run-owned `terminalDelivery` at the delivery callback and project it independently through lifecycle, gateway job state, `agent.wait`, and QA Lab.
- Require both primary and alternate model-switch runs to provide exact-run terminal receipts, visible terminal replies where consumed, and `terminalDelivery.status === "sent"` with a positive `resultCount`.
- Evaluate continuity and step details from the exact run's `terminalReply.text`; do not use QA-bus text or cursors for ownership or delivery certification.
- Reject normalized-identical primary/alternate references before execution.
- Preserve fresh-visible-reply and successful-tool-result checks.
- Preserve the shared `isError` tri-state across every harness producer: `false` for an observed successful completion, `true` for terminal failure, and absent for started/running/unknown native state.
- Record finalized built-in receipt metadata from the normalized observer outcome, including successful calls whose result payload represents async/running work, while retaining `isToolError` for recovery and presentation; record Copilot `tool.execution_complete` booleans while keeping start-only metadata unknown; audit Codex native completion status before setting a boolean.
- Count only `isError === false` entries as successful terminal tool evidence.
- Leave receipt disposition unset during attempt preparation and finalize it in `run-entry` from the canonical terminal reply snapshot, so `NO_REPLY` and empty terminals are `not-visible`.
- Remove cursor-based and QA-bus text ownership inference. No evidence schema v2, public SDK/protocol, config, storage, or SQLite change.

Service-tier certification is explicitly out of scope for this PR.

## Rebase and Scope

- Source branch: `codex/autoqa-model-switch-authentic-evidence-20260805`
- Original source head: `d0d3273e1c3e2b0f739ba8aeeb8f5ec3dbf19d3a`
- Rebased base: `01cc71060d6c57eff142cfc210685c651ccb6397`
- Published head: `720a252555fac8aa4dfc710be28d1de23e2d7df0`
- Current `main` at publication preflight: `c25671cf275a4b5a339db182a5ba8bffc2e73c11` with zero touched-file overlap and a clean merge-tree.

LOC versus merge base `01cc71060d6c57eff142cfc210685c651ccb6397`:

- Runtime production: `+182/-21`, net `+161`
- QA production/plumbing: `+109/-75`, net `+34`
- Tests: `+833/-16`, net `+817`

Run-owned terminal-delivery correction `89598fab1bf4f6eba61305887d52bb89073e5c11`:

- Runtime production: `+64/-2`, net `+62`
- QA production/plumbing: `+20/-53`, net `-33`
- Tests: `+313/-165`, net `+148`

Primary-run delivery binding correction `720a252555fac8aa4dfc710be28d1de23e2d7df0`:

- QA production/plumbing: `+10/-8`, net `+2`
- Tests: `+72/-15`, net `+57`

## Codex Contract Checked

Sibling Codex source was inspected at `a7dcd20d3895ec4c9cbdde534745bbffbc2d2e28`:

- `codex-rs/app-server-protocol/src/protocol/v2/model.rs:137-146`
- `codex-rs/protocol/src/protocol.rs:1949-1954`
- `codex-rs/core/src/session/mod.rs:3126-3153`
- `codex-rs/app-server/src/bespoke_event_handling.rs:351-361`
- `codex-rs/app-server/tests/suite/v2/safety_check_downgrade.rs:344-379`

These establish that `model/rerouted` carries thread/turn ownership plus requested/effective models, and is emitted before `turn/completed`.

Tool terminal ownership was also checked directly:

- `codex-rs/app-server/README.md:1445`, `1481-1482`, `1548-1552`, `1680-1683`
- `codex-rs/protocol/src/items.rs:164-180`, `241-264`, `415-422`
- `codex-rs/core/src/tools/handlers/dynamic.rs:196-244`

These establish that Codex start events are nonterminal, while completed command/dynamic/MCP items carry the explicit terminal status or success fact used by the adapter.

## Other Producer Contracts Checked

- `packages/agent-core/src/types.ts:32-33`, `321-322`, `622-628`
- `packages/agent-core/src/agent-loop.ts:1524-1537`
- `@github/copilot-sdk@1.0.7` `dist/generated/session-events.d.ts:3978-4051`, `4186-4257`

The built-in loop emits `tool_execution_end` only after finalization with a required boolean. Copilot separates start from completion and supplies a required completion `success` boolean.

## Evidence

Historical contributor proof on the pre-repair head remains useful context: 126 focused tests and two mock-provider model-switch scenarios passed in Blacksmith Actions run https://github.com/openclaw/openclaw/actions/runs/31030726338. That proof did not close the cursor-ownership gap and is superseded for the final verdict.

Current and historical proof:

- Focused local suites: 191 tests passed across OpenAI response handling, terminal receipt/lifecycle, gateway wait, Codex projection, model-switch scenarios, suite summary, and runtime parity.
- Final affected reruns: QA runtime flow 2/2; Codex assistant projection 13/13.
- Follow-up review correction: 394 focused tests passed across receipt normalization, built-in tools, Codex native/dynamic projection, Copilot event/attempt projection, and both model-switch continuity proofs.
- Approval-unavailable correction: the new regression failed before the fix with `toolMetas.isError: false`, then 147 full handler tests and 11 terminal-preparation tests passed. Targeted oxfmt, oxlint, and `git diff --check` passed.
- Canonical `NO_REPLY` correction: 19 `run-entry` tests and 11 terminal-preparation tests passed; both model-switch proof suites passed 6/6 tests. Targeted oxfmt, oxlint, and `git diff --check` passed.
- Run-owned terminal-reply correction: 35 QA agent-process tests, 5 follow-up proof tests, and 3 tool-continuity proof tests passed, including regressions where an unrelated later outbound contains continuity text. Targeted oxfmt, oxlint, and `git diff --check` passed.
- The default oxlint wrapper stopped before lint on the known untouched stale local signature mismatch at `packages/terminal-core/src/ansi.ts:194`; targeted lint then passed with the wrapper's `OPENCLAW_OXLINT_SKIP_PREPARE=1` path. No dependency reconciliation was performed.
- Targeted formatting, `git diff --check`, producer audit, and syntax/style lint passed.
- Run-owned terminal-delivery correction `89598fab1bf4f6eba61305887d52bb89073e5c11`: 203 focused tests passed across lifecycle, strict delivery failure propagation, gateway wait projection, QA wait preservation, Crabline restoration, and both model-switch proof suites. Targeted formatting, oxlint, max-lines, and `git diff --check` passed; Sol high autoreview was clean at `0.98`.
- Primary-run delivery binding correction `720a252555fac8aa4dfc710be28d1de23e2d7df0`: both model-switch proof suites passed 19/19 focused tests, including missing, suppressed, and zero-count primary delivery with identical and unrelated bus messages. Targeted formatting, oxlint, max-lines, and `git diff --check` passed; Sol high autoreview was clean at `0.99`.
- Independent exact-head review of `720a252555fac8aa4dfc710be28d1de23e2d7df0` was clean.
- The Crabline transport source and test were restored exactly to `df9c30fe7e6cf54fc09b4f8fb8d08717e8cc763f`; Telegram visible-text projection is not part of this PR.
- Targeted remote Codex lint: Crabbox `run_2b83302392a4`, exit 0, 0 warnings/errors.
- Prior repaired head changed gate plus `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build`: Crabbox `run_ff4540f35d60`, exit 0.
- Prior published head `fb23c3d7cc3572a3685d8398f32ddae14076f549` changed gate, full lint/import-cycle checks, and `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build`: Crabbox `run_4645d5ddd1a4`, exit 0.
- Head `71831a46b755bb020712606766187293aa7d2cde`: Crabbox `run_8722b1431469` exited 2 before tests because `--fresh-pr` bypassed workspace sync and omitted `.openclaw-crabbox-changed-gate.bundle`.
- The corrected normal-sync AWS run `run_a6a9212514f8` became obsolete when independent review invalidated that head; its exact task-owned lease `cbx_1c9495799c89` was released and it is not proof for this PR head.
- Prior head `21cf1af5e1e2648105b34c6a6881d449c07801c1`: the single authorized exact-head Testbox attempt stopped before dispatch because the local Blacksmith CLI requires `blacksmith auth login`. No remote run ID, changed-gate result, or build result exists, and no retry was started.
- The changed gate omitted only the known main-wide dead-export baseline in untouched `src/config/**`, diagnosed separately in `run_73884564e548`; all remaining changed lanes passed.

## Punchcard

- `Punchcard-Session: golden-valley-workshop-br`
- `6a629ce048f5b219611bf71b68010b4de92f70a2`: `att_01KZE7ZBZKJ1PE9H6QR2CRMW8B`
- `8933cd9bd2a4506e321f52c706fb25f3d0d5f835`: `att_01KZE7ZCCAGJAKSC63RX6KZ5QT`
- `f630f9411ed0ee57b5342e410c398255e2173154`: `att_01KZE7ZCXDQ39YHPSVNV506HM2`
- `fb23c3d7cc3572a3685d8398f32ddae14076f549`: `att_01KZEBYY7QQQ170RK2RR07F063`
- `71831a46b755bb020712606766187293aa7d2cde`: `att_01KZEE74EH7NV86M3EREYX0B7R`
- Prior PR head `71831a46b755bb020712606766187293aa7d2cde`: `att_01KZEE77MQMRV4163ZRCPQTE68`
- `21cf1af5e1e2648105b34c6a6881d449c07801c1`: `att_01KZEFPXC3RB5S340YWDXN1PCH`
- Prior PR head `21cf1af5e1e2648105b34c6a6881d449c07801c1`: `att_01KZEFPXR0PBRKRW7H921N13K0`
- `df9c30fe7e6cf54fc09b4f8fb8d08717e8cc763f`: `att_01KZEJ8P6JVCZZFND3PVK5Y6YP`
- Prior PR head `df9c30fe7e6cf54fc09b4f8fb8d08717e8cc763f`: `att_01KZEJ8WJ9XDSX89TV5C24VX6F`
- `9b81dae7d4d501ce0cb71a51b5b118d787214630`: `att_01KZEMEXT2SZPVJ373Y79SE8NR`
- Prior PR head `9b81dae7d4d501ce0cb71a51b5b118d787214630`: `att_01KZEMEY5235M1CWCSFSX7A5HN`
- `89598fab1bf4f6eba61305887d52bb89073e5c11`: `att_01KZEQ0B7KDSQB4QSPV1ZE7300`
- `720a252555fac8aa4dfc710be28d1de23e2d7df0`: `att_01KZEQMCQHH9F4Q6Q1WPGSQJMT`
- Current PR head `720a252555fac8aa4dfc710be28d1de23e2d7df0`: `att_01KZEQT5BP9CERGCGK8WQHGT0B`

Prior PR receipt for `df9c30fe7e6cf54fc09b4f8fb8d08717e8cc763f`:

`pc1.cHVuY2hjYXJkLXNlcnZlci1yZWNlaXB0LXYxAGF0dF8wMUtaRUo4V0o5WERTWDg5VFY1QzI0Vlg2RgB0bnRfMDFKMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAAdXNyXzAxSjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxAGRldl9FMDNCQTNBOENDNzdGOUQ5QjFCRTI3RTE5MgB3cmtfMDFLWkFCN1pDVzBHRktKTVI5QTdKRjA2MlQAc2VzXzAxS1pETTlQMDdINzVBOTlWSENSN1pOUzg0AGdvbGRlbi12YWxsZXktd29ya3Nob3AtYnIAb3BlbmNsYXcvb3BlbmNsYXcAADExOTY2MgA5Y2EyNjE3MTY3N2RjNWE1N2MwY2RmYjcwZjIxNDMzZGVmMjg3OWM0MzkzNjE3NWNkYzhlNTA2ZmY5NjJlOGYxAHNpZ25pbmctdjEAenpGQm9ZOVlBQWZHVzBQNXFMTmR3RmpoUDZ2dnhZTWJ2Z1c5U1ZiTFJ2djUzai1oQkVRTzBPUmpfSTJGZndNaXhFaVlwZ2FFNWRTMEwxRkhRUEU3Q0EAMjAyNi0wOC0wN1QxNjo1MzowMS4xMjlaAA.2qF4Wjt12TQxl-h1PnAUVkDlmtcKC4Y7fekptQjqRUVbapQ4g3FrJ8z9tNlmFMZDwGlrxMiJBiactMxEjdCNAA`

Preserved prior PR receipt for `21cf1af5e1e2648105b34c6a6881d449c07801c1`:

`pc1.cHVuY2hjYXJkLXNlcnZlci1yZWNlaXB0LXYxAGF0dF8wMUtaRUZQWFIwUEJSS1JXN0g5MjFOMTNLMAB0bnRfMDFKMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAAdXNyXzAxSjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxAGRldl9FMDNCQTNBOENDNzdGOUQ5QjFCRTI3RTE5MgB3cmtfMDFLWkFCN1pDVzBHRktKTVI5QTdKRjA2MlQAc2VzXzAxS1pETTlQMDdINzVBOTlWSENSN1pOUzg0AGdvbGRlbi12YWxsZXktd29ya3Nob3AtYnIAb3BlbmNsYXcvb3BlbmNsYXcAADExOTY2MgA5Y2EyNjE3MTY3N2RjNWE1N2MwY2RmYjcwZjIxNDMzZGVmMjg3OWM0MzkzNjE3NWNkYzhlNTA2ZmY5NjJlOGYxAHNpZ25pbmctdjEAenpGQm9ZOVlBQWZHVzBQNXFMTmR3RmpoUDZ2dnhZTWJ2Z1c5U1ZiTFJ2djUzai1oQkVRTzBPUmpfSTJGZndNaXhFaVlwZ2FFNWRTMEwxRkhRUEU3Q0EAMjAyNi0wOC0wN1QxNjowODoxNS4zNjBaAA.DNGquTRKd1UqjEXR0f-ZKF86kLeqBd7wjyBoEGSiwZvV_mr7f7WWF3uSiZs-uxhTiM2gyW59s_RLkZY5UQllAw`

Preserved prior PR receipt for `71831a46b755bb020712606766187293aa7d2cde`:

`pc1.cHVuY2hjYXJkLXNlcnZlci1yZWNlaXB0LXYxAGF0dF8wMUtaRUU3N01RTVJWNDE2M1pSQ1BRVEU2OAB0bnRfMDFKMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAAdXNyXzAxSjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxAGRldl9FMDNCQTNBOENDNzdGOUQ5QjFCRTI3RTE5MgB3cmtfMDFLWkFCN1pDVzBHRktKTVI5QTdKRjA2MlQAc2VzXzAxS1pETTlQMDdINzVBOTlWSENSN1pOUzg0AGdvbGRlbi12YWxsZXktd29ya3Nob3AtYnIAb3BlbmNsYXcvb3BlbmNsYXcAADExOTY2MgA5Y2EyNjE3MTY3N2RjNWE1N2MwY2RmYjcwZjIxNDMzZGVmMjg3OWM0MzkzNjE3NWNkYzhlNTA2ZmY5NjJlOGYxAHNpZ25pbmctdjEAenpGQm9ZOVlBQWZHVzBQNXFMTmR3RmpoUDZ2dnhZTWJ2Z1c5U1ZiTFJ2djUzai1oQkVRTzBPUmpfSTJGZndNaXhFaVlwZ2FFNWRTMEwxRkhRUEU3Q0EAMjAyNi0wOC0wN1QxNTo0MjoxMi42MzFaAA.-lyNX7bdgaI82dSbW3H3LljJkd4yV44bsYVHWXaQs_w9_qT-oS8JpPyrchntIKJb2pvki-uVuM89dUmoq5HKAQ`

Preserved prior PR receipt:

`pc1.cHVuY2hjYXJkLXNlcnZlci1yZWNlaXB0LXYxAGF0dF8wMUtaRUJZWUtKWFZDNFpIWThLSk5KQUs5SAB0bnRfMDFKMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAAdXNyXzAxSjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxAGRldl9FMDNCQTNBOENDNzdGOUQ5QjFCRTI3RTE5MgB3cmtfMDFLWkFCN1pDVzBHRktKTVI5QTdKRjA2MlQAc2VzXzAxS1pETTlQMDdINzVBOTlWSENSN1pOUzg0AGdvbGRlbi12YWxsZXktd29ya3Nob3AtYnIAb3BlbmNsYXcvb3BlbmNsYXcAADExOTY2MgA5Y2EyNjE3MTY3N2RjNWE1N2MwY2RmYjcwZjIxNDMzZGVmMjg3OWM0MzkzNjE3NWNkYzhlNTA2ZmY5NjJlOGYxAHNpZ25pbmctdjEAenpGQm9ZOVlBQWZHVzBQNXFMTmR3RmpoUDZ2dnhZTWJ2Z1c5U1ZiTFJ2djUzai1oQkVRTzBPUmpfSTJGZndNaXhFaVlwZ2FFNWRTMEwxRkhRUEU3Q0EAMjAyNi0wOC0wN1QxNTowMjo0NC4wODJaAA.xeIhPpskoY4co6WBOIww76C-CT0e9nUD6CVZ27Uo-6Yr44Z-vtInMXfJLmKiSUCdLTfb89IspDLGWoY-gaFgAg`

Preserved earlier PR receipt:

`pc1.cHVuY2hjYXJkLXNlcnZlci1yZWNlaXB0LXYxAGF0dF8wMUtaRUE0Q0gzNFpOS0VZNlhIRTRSMUJRRAB0bnRfMDFKMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAAdXNyXzAxSjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxAGRldl9FMDNCQTNBOENDNzdGOUQ5QjFCRTI3RTE5MgB3cmtfMDFLWkFCN1pDVzBHRktKTVI5QTdKRjA2MlQAc2VzXzAxS1pETTlQMDdINzVBOTlWSENSN1pOUzg0AGdvbGRlbi12YWxsZXktd29ya3Nob3AtYnIAb3BlbmNsYXcvb3BlbmNsYXcAADExOTY2MgA5Y2EyNjE3MTY3N2RjNWE1N2MwY2RmYjcwZjIxNDMzZGVmMjg3OWM0MzkzNjE3NWNkYzhlNTA2ZmY5NjJlOGYxAHNpZ25pbmctdjEAenpGQm9ZOVlBQWZHVzBQNXFMTmR3RmpoUDZ2dnhZTWJ2Z1c5U1ZiTFJ2djUzai1oQkVRTzBPUmpfSTJGZndNaXhFaVlwZ2FFNWRTMEwxRkhRUEU3Q0EAMjAyNi0wOC0wN1QxNDozMDo0NS4wMjdaAA.d6fXdo2oeWp6o1GjBVY8J-wWcynfacAPtoNzRVwZSvZ0VD-Poddg4zkYaW0fccO94QIzSE52y7lRBR2dI5v0BA`

Commit receipt for `9b81dae7d4d501ce0cb71a51b5b118d787214630`:

`pc1.cHVuY2hjYXJkLXNlcnZlci1yZWNlaXB0LXYxAGF0dF8wMUtaRU1FWFQyU1pQVkozNzNZNzlTRThOUgB0bnRfMDFKMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAAdXNyXzAxSjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxAGRldl9FMDNCQTNBOENDNzdGOUQ5QjFCRTI3RTE5MgB3cmtfMDFLWkFCN1pDVzBHRktKTVI5QTdKRjA2MlQAc2VzXzAxS1pETTlQMDdINzVBOTlWSENSN1pOUzg0AGdvbGRlbi12YWxsZXktd29ya3Nob3AtYnIAb3BlbmNsYXcvb3BlbmNsYXcAOWI4MWRhZTdkNGQ1MDFjZTBjYjcxYTUxYjViMTE4ZDc4NzIxNDYzMAAAMTliMWEyNThiNTMyMTI5Y2IxMGI2NGRjZjAwYmEzZDlmODA3MWNiMzYzOGViNTY3YmYzM2Y2YTNjOGY4NGJhZABzaWduaW5nLXYxAF84eVdUTFUzTkpQakVBdXRRbUZUWkJ3RUczVWNSSy1nNGEtazRscDE3ODg5cGx6ek95b3FHc0tBM1ZUNmJJZ0N0ZEpmdm5Pd2lhZFhCX0dnWHpzNkJBADIwMjYtMDgtMDdUMTc6MzE6MTYuMTYyWgA.jlrmB2gddR6Q7bw5eObC6Iu6KfJ-hsRZR13soqYhf9_2KxtKPjoGmRugLWY9wVT3m60nwELVlhcGMor2x9INAA`

Preserved prior PR receipt for `9b81dae7d4d501ce0cb71a51b5b118d787214630`:

`pc1.cHVuY2hjYXJkLXNlcnZlci1yZWNlaXB0LXYxAGF0dF8wMUtaRU1FWTUyMzVNMUNXQ1NGU1g3QTVITgB0bnRfMDFKMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAAdXNyXzAxSjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxAGRldl9FMDNCQTNBOENDNzdGOUQ5QjFCRTI3RTE5MgB3cmtfMDFLWkFCN1pDVzBHRktKTVI5QTdKRjA2MlQAc2VzXzAxS1pETTlQMDdINzVBOTlWSENSN1pOUzg0AGdvbGRlbi12YWxsZXktd29ya3Nob3AtYnIAb3BlbmNsYXcvb3BlbmNsYXcAADExOTY2MgA5Y2EyNjE3MTY3N2RjNWE1N2MwY2RmYjcwZjIxNDMzZGVmMjg3OWM0MzkzNjE3NWNkYzhlNTA2ZmY5NjJlOGYxAHNpZ25pbmctdjEAenpGQm9ZOVlBQWZHVzBQNXFMTmR3RmpoUDZ2dnhZTWJ2Z1c5U1ZiTFJ2djUzai1oQkVRTzBPUmpfSTJGZndNaXhFaVlwZ2FFNWRTMEwxRkhRUEU3Q0EAMjAyNi0wOC0wN1QxNzozMToxNi41MTRaAA.APt1UE98tF0tTb_aZ6nU_cJaKSEv490X07cMR6v_WObmCHa9GEopWjkFH8S8YtZ9dY0zHlHCaBYN8IGpJfB9CQ`

Current PR receipt for `720a252555fac8aa4dfc710be28d1de23e2d7df0`:

`pc1.cHVuY2hjYXJkLXNlcnZlci1yZWNlaXB0LXYxAGF0dF8wMUtaRVFUNUJQOUNFUkdDR0s4V1FIR1QwQgB0bnRfMDFKMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAAdXNyXzAxSjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxAGRldl9FMDNCQTNBOENDNzdGOUQ5QjFCRTI3RTE5MgB3cmtfMDFLWkFCN1pDVzBHRktKTVI5QTdKRjA2MlQAc2VzXzAxS1pETTlQMDdINzVBOTlWSENSN1pOUzg0AGdvbGRlbi12YWxsZXktd29ya3Nob3AtYnIAb3BlbmNsYXcvb3BlbmNsYXcAADExOTY2MgA5Y2EyNjE3MTY3N2RjNWE1N2MwY2RmYjcwZjIxNDMzZGVmMjg3OWM0MzkzNjE3NWNkYzhlNTA2ZmY5NjJlOGYxAHNpZ25pbmctdjEAenpGQm9ZOVlBQWZHVzBQNXFMTmR3RmpoUDZ2dnhZTWJ2Z1c5U1ZiTFJ2djUzai1oQkVRTzBPUmpfSTJGZndNaXhFaVlwZ2FFNWRTMEwxRkhRUEU3Q0EAMjAyNi0wOC0wN1QxODoyOTo1MC4wNzBaAA.4Lc0SjTrxbDH7EPu6ytk1lROJ8ChWzkS2RH5kNpVZN_TeNp9fVTiSaNfxSwlwh4LitWZCmKLojHiP1EauBUKAw`

## Remaining Gates

The PR remains open. Remaining gates are hosted exact-head CI, exact-head ClawSweeper review, remote changed-gate/private-QA build proof, and repo-native maintainer landing.
