### PR TITLE
fix(qa): verify Matrix DM rooms really share or isolate their sessions

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog-matrix-session-identity-proof.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-matrix-session-identity-proof.test.ts
@@ -47,6 +47,8 @@ function createMatrixSessionEntry(sessionId: string, roomId: string, updatedAt: 
 async function runMatrixSessionScenario(params: {
   scenarioId: MatrixScenarioId;
   sharedSessionIdentity: boolean;
+  sharedSessionKey?: boolean;
+  sharedTranscriptId?: boolean;
 }) {
   const scenario = readQaScenarioById(params.scenarioId);
   const config = scenario.execution.config as {
@@ -56,16 +58,16 @@ async function runMatrixSessionScenario(params: {
     secondaryMarker: string;
   };
   const state = createQaBusState();
-  const primarySessionKey = params.sharedSessionIdentity
+  const usesSharedSessionKey = params.sharedSessionKey ?? params.sharedSessionIdentity;
+  const usesSharedTranscriptId = params.sharedTranscriptId ?? params.sharedSessionIdentity;
+  const primarySessionKey = usesSharedSessionKey
     ? sharedSessionKey
     : `agent:qa:matrix:channel:${primaryRoomId}`;
-  const secondarySessionKey = params.sharedSessionIdentity
+  const secondarySessionKey = usesSharedSessionKey
     ? sharedSessionKey
     : `agent:qa:matrix:channel:${secondaryRoomId}`;
   const primarySessionId = "matrix-session-primary";
-  const secondarySessionId = params.sharedSessionIdentity
-    ? primarySessionId
-    : "matrix-session-secondary";
+  const secondarySessionId = usesSharedTranscriptId ? primarySessionId : "matrix-session-secondary";
 
   const readRawQaSessionStore = vi.fn(async () => {
     const inboundMessages = state
@@ -79,9 +81,9 @@ async function runMatrixSessionScenario(params: {
         [primarySessionKey]: createMatrixSessionEntry(primarySessionId, primaryRoomId, 1),
       };
     }
-    if (params.sharedSessionIdentity) {
+    if (usesSharedSessionKey) {
       return {
-        [sharedSessionKey]: createMatrixSessionEntry(primarySessionId, secondaryRoomId, 2),
+        [sharedSessionKey]: createMatrixSessionEntry(secondarySessionId, secondaryRoomId, 2),
       };
     }
     return {
@@ -180,6 +182,17 @@ describe("Matrix DM scenario session identity evidence", () => {
     ).rejects.toThrow(/session|room|isolat|shared/i);
   });
 
+  it("rejects a reused per-room session key even when its transcript id rotates", async () => {
+    await expect(
+      runMatrixSessionScenario({
+        scenarioId: "dm-per-room-session",
+        sharedSessionIdentity: false,
+        sharedSessionKey: true,
+        sharedTranscriptId: false,
+      }),
+    ).rejects.toThrow(/session|room|isolat|shared/i);
+  });
+
   it("accepts one shared user-owned session when both rooms receive the notice and replies", async () => {
     await expect(
       runMatrixSessionScenario({
@@ -194,6 +207,17 @@ describe("Matrix DM scenario session identity evidence", () => {
       runMatrixSessionScenario({
         scenarioId: "dm-shared-session",
         sharedSessionIdentity: false,
+      }),
+    ).rejects.toThrow(/session|room|isolat|shared/i);
+  });
+
+  it("rejects distinct shared-mode session keys even when they alias one transcript id", async () => {
+    await expect(
+      runMatrixSessionScenario({
+        scenarioId: "dm-shared-session",
+        sharedSessionIdentity: true,
+        sharedSessionKey: false,
+        sharedTranscriptId: true,
       }),
     ).rejects.toThrow(/session|room|isolat|shared/i);
   });

--- a/extensions/qa-lab/src/scenario-catalog-matrix-session-identity-proof.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-matrix-session-identity-proof.test.ts
@@ -10,7 +10,12 @@ const sharedSessionKey = `agent:qa:matrix:direct:${matrixDriverId}`;
 
 type MatrixScenarioId = "dm-per-room-session" | "dm-shared-session";
 
-function createMatrixSessionEntry(sessionId: string, roomId: string, updatedAt: number) {
+function createMatrixSessionEntry(
+  sessionId: string,
+  roomId: string,
+  updatedAt: number,
+  nativeDirectUserId = matrixDriverId,
+) {
   return {
     sessionId,
     updatedAt,
@@ -35,10 +40,10 @@ function createMatrixSessionEntry(sessionId: string, roomId: string, updatedAt: 
         surface: "matrix",
         accountId: "sut",
         chatType: "direct",
-        from: `matrix:${matrixDriverId}`,
+        from: `matrix:${nativeDirectUserId}`,
         to: `room:${roomId}`,
         nativeChannelId: roomId,
-        nativeDirectUserId: matrixDriverId,
+        nativeDirectUserId,
       },
     },
   };
@@ -49,6 +54,8 @@ async function runMatrixSessionScenario(params: {
   sharedSessionIdentity: boolean;
   sharedSessionKey?: boolean;
   sharedTranscriptId?: boolean;
+  returnedSenderId?: string;
+  secondaryNativeSenderId?: string;
 }) {
   const scenario = readQaScenarioById(params.scenarioId);
   const config = scenario.execution.config as {
@@ -83,12 +90,22 @@ async function runMatrixSessionScenario(params: {
     }
     if (usesSharedSessionKey) {
       return {
-        [sharedSessionKey]: createMatrixSessionEntry(secondarySessionId, secondaryRoomId, 2),
+        [sharedSessionKey]: createMatrixSessionEntry(
+          secondarySessionId,
+          secondaryRoomId,
+          2,
+          params.secondaryNativeSenderId,
+        ),
       };
     }
     return {
       [primarySessionKey]: createMatrixSessionEntry(primarySessionId, primaryRoomId, 1),
-      [secondarySessionKey]: createMatrixSessionEntry(secondarySessionId, secondaryRoomId, 2),
+      [secondarySessionKey]: createMatrixSessionEntry(
+        secondarySessionId,
+        secondaryRoomId,
+        2,
+        params.secondaryNativeSenderId,
+      ),
     };
   });
 
@@ -104,7 +121,7 @@ async function runMatrixSessionScenario(params: {
       state.addInboundMessage({
         ...input,
         accountId: "sut",
-        senderId: matrixDriverId,
+        senderId: params.returnedSenderId ?? matrixDriverId,
       }),
     waitForOutbound: async (input: {
       conversation?: { id: string; kind: string };
@@ -164,14 +181,21 @@ async function runMatrixSessionScenario(params: {
 }
 
 describe("Matrix DM scenario session identity evidence", () => {
-  it("accepts distinct room-owned sessions when per-room replies have no shared notice", async () => {
-    await expect(
-      runMatrixSessionScenario({
-        scenarioId: "dm-per-room-session",
-        sharedSessionIdentity: false,
-      }),
-    ).resolves.toMatchObject({ status: "pass" });
-  });
+  it.each([
+    { lane: "live", returnedSenderId: matrixDriverId },
+    { lane: "crabline", returnedSenderId: "driver" },
+  ])(
+    "accepts distinct room-owned sessions on the $lane Matrix lane",
+    async ({ returnedSenderId }) => {
+      await expect(
+        runMatrixSessionScenario({
+          scenarioId: "dm-per-room-session",
+          sharedSessionIdentity: false,
+          returnedSenderId,
+        }),
+      ).resolves.toMatchObject({ status: "pass" });
+    },
+  );
 
   it("rejects a shared session in per-room mode even when both replies and notice policy pass", async () => {
     await expect(
@@ -193,14 +217,21 @@ describe("Matrix DM scenario session identity evidence", () => {
     ).rejects.toThrow(/session|room|isolat|shared/i);
   });
 
-  it("accepts one shared user-owned session when both rooms receive the notice and replies", async () => {
-    await expect(
-      runMatrixSessionScenario({
-        scenarioId: "dm-shared-session",
-        sharedSessionIdentity: true,
-      }),
-    ).resolves.toMatchObject({ status: "pass" });
-  });
+  it.each([
+    { lane: "live", returnedSenderId: matrixDriverId },
+    { lane: "crabline", returnedSenderId: "driver" },
+  ])(
+    "accepts one shared user-owned session on the $lane Matrix lane",
+    async ({ returnedSenderId }) => {
+      await expect(
+        runMatrixSessionScenario({
+          scenarioId: "dm-shared-session",
+          sharedSessionIdentity: true,
+          returnedSenderId,
+        }),
+      ).resolves.toMatchObject({ status: "pass" });
+    },
+  );
 
   it("rejects separate sessions in shared mode even when the expected notice is emitted", async () => {
     await expect(
@@ -218,6 +249,19 @@ describe("Matrix DM scenario session identity evidence", () => {
         sharedSessionIdentity: true,
         sharedSessionKey: false,
         sharedTranscriptId: true,
+      }),
+    ).rejects.toThrow(/session|room|isolat|shared/i);
+  });
+
+  it.each([
+    { scenarioId: "dm-per-room-session" as const, sharedSessionIdentity: false },
+    { scenarioId: "dm-shared-session" as const, sharedSessionIdentity: true },
+  ])("rejects a different persisted Matrix sender in $scenarioId", async (scenario) => {
+    await expect(
+      runMatrixSessionScenario({
+        ...scenario,
+        returnedSenderId: "driver",
+        secondaryNativeSenderId: "@intruder:matrix.test",
       }),
     ).rejects.toThrow(/session|room|isolat|shared/i);
   });

--- a/extensions/qa-lab/src/scenario-catalog-matrix-session-identity-proof.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-matrix-session-identity-proof.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it, vi } from "vitest";
+import { createQaBusState } from "./bus-state.js";
+import { readQaScenarioById } from "./scenario-catalog.js";
+import { runLoadedScenarioFlow } from "./scenario-flow-runner.test-support.js";
+
+const matrixDriverId = "@driver:matrix.test";
+const primaryRoomId = "!primary:matrix.test";
+const secondaryRoomId = "!secondary:matrix.test";
+const sharedSessionKey = `agent:qa:matrix:direct:${matrixDriverId}`;
+
+type MatrixScenarioId = "dm-per-room-session" | "dm-shared-session";
+
+function createMatrixSessionEntry(sessionId: string, roomId: string, updatedAt: number) {
+  return {
+    sessionId,
+    updatedAt,
+    chatType: "direct",
+    delivery: {
+      kind: "external",
+      route: {
+        channel: "matrix",
+        accountId: "sut",
+        target: {
+          to: `room:${roomId}`,
+          chatType: "direct",
+        },
+      },
+      context: {
+        channel: "matrix",
+        to: `room:${roomId}`,
+        accountId: "sut",
+      },
+      origin: {
+        provider: "matrix",
+        surface: "matrix",
+        accountId: "sut",
+        chatType: "direct",
+        from: `matrix:${matrixDriverId}`,
+        to: `room:${roomId}`,
+        nativeChannelId: roomId,
+        nativeDirectUserId: matrixDriverId,
+      },
+    },
+  };
+}
+
+async function runMatrixSessionScenario(params: {
+  scenarioId: MatrixScenarioId;
+  sharedSessionIdentity: boolean;
+}) {
+  const scenario = readQaScenarioById(params.scenarioId);
+  const config = scenario.execution.config as {
+    primaryConversationId: string;
+    secondaryConversationId: string;
+    primaryMarker: string;
+    secondaryMarker: string;
+  };
+  const state = createQaBusState();
+  const primarySessionKey = params.sharedSessionIdentity
+    ? sharedSessionKey
+    : `agent:qa:matrix:channel:${primaryRoomId}`;
+  const secondarySessionKey = params.sharedSessionIdentity
+    ? sharedSessionKey
+    : `agent:qa:matrix:channel:${secondaryRoomId}`;
+  const primarySessionId = "matrix-session-primary";
+  const secondarySessionId = params.sharedSessionIdentity
+    ? primarySessionId
+    : "matrix-session-secondary";
+
+  const readRawQaSessionStore = vi.fn(async () => {
+    const inboundMessages = state
+      .getSnapshot()
+      .messages.filter((message) => message.direction === "inbound");
+    if (inboundMessages.length === 0) {
+      return {};
+    }
+    if (inboundMessages.length === 1) {
+      return {
+        [primarySessionKey]: createMatrixSessionEntry(primarySessionId, primaryRoomId, 1),
+      };
+    }
+    if (params.sharedSessionIdentity) {
+      return {
+        [sharedSessionKey]: createMatrixSessionEntry(primarySessionId, secondaryRoomId, 2),
+      };
+    }
+    return {
+      [primarySessionKey]: createMatrixSessionEntry(primarySessionId, primaryRoomId, 1),
+      [secondarySessionKey]: createMatrixSessionEntry(secondarySessionId, secondaryRoomId, 2),
+    };
+  });
+
+  let outboundWaitCount = 0;
+  const transport = {
+    id: "matrix",
+    accountId: "sut",
+    state,
+    reset: async () => {
+      state.reset();
+    },
+    sendInbound: async (input: Parameters<typeof state.addInboundMessage>[0]) =>
+      state.addInboundMessage({
+        ...input,
+        accountId: "sut",
+        senderId: matrixDriverId,
+      }),
+    waitForOutbound: async (input: {
+      conversation?: { id: string; kind: string };
+      sinceIndex?: number;
+      textIncludes?: string;
+      timeoutMs?: number;
+    }) => {
+      outboundWaitCount += 1;
+      if (outboundWaitCount === 1) {
+        state.addOutboundMessage({
+          accountId: "sut",
+          to: `dm:${config.primaryConversationId}`,
+          text: config.primaryMarker,
+        });
+      } else if (outboundWaitCount === 2) {
+        if (params.scenarioId === "dm-shared-session") {
+          state.addOutboundMessage({
+            accountId: "sut",
+            to: `dm:${config.secondaryConversationId}`,
+            text: "This Matrix DM is sharing a session with another room. Set channels.matrix.dm.sessionScope to per-room to isolate it.",
+          });
+        }
+        state.addOutboundMessage({
+          accountId: "sut",
+          to: `dm:${config.secondaryConversationId}`,
+          text: config.secondaryMarker,
+        });
+      }
+      const match = state
+        .getSnapshot()
+        .messages.filter((message) => message.direction === "outbound")
+        .slice(input.sinceIndex ?? 0)
+        .find(
+          (message) =>
+            (!input.conversation || message.conversation.id === input.conversation.id) &&
+            (!input.conversation || message.conversation.kind === input.conversation.kind) &&
+            (!input.textIncludes || message.text.includes(input.textIncludes)),
+        );
+      if (!match) {
+        throw new Error(`timed out after ${input.timeoutMs}ms waiting for Matrix outbound marker`);
+      }
+      return match;
+    },
+  };
+
+  return await runLoadedScenarioFlow(params.scenarioId, {
+    state,
+    api: {
+      env: {
+        providerMode: "mock-openai",
+        gateway: { tempRoot: "/qa-matrix-session-identity" },
+      },
+      transport,
+      readRawQaSessionStore,
+    },
+  });
+}
+
+describe("Matrix DM scenario session identity evidence", () => {
+  it("accepts distinct room-owned sessions when per-room replies have no shared notice", async () => {
+    await expect(
+      runMatrixSessionScenario({
+        scenarioId: "dm-per-room-session",
+        sharedSessionIdentity: false,
+      }),
+    ).resolves.toMatchObject({ status: "pass" });
+  });
+
+  it("rejects a shared session in per-room mode even when both replies and notice policy pass", async () => {
+    await expect(
+      runMatrixSessionScenario({
+        scenarioId: "dm-per-room-session",
+        sharedSessionIdentity: true,
+      }),
+    ).rejects.toThrow(/session|room|isolat|shared/i);
+  });
+
+  it("accepts one shared user-owned session when both rooms receive the notice and replies", async () => {
+    await expect(
+      runMatrixSessionScenario({
+        scenarioId: "dm-shared-session",
+        sharedSessionIdentity: true,
+      }),
+    ).resolves.toMatchObject({ status: "pass" });
+  });
+
+  it("rejects separate sessions in shared mode even when the expected notice is emitted", async () => {
+    await expect(
+      runMatrixSessionScenario({
+        scenarioId: "dm-shared-session",
+        sharedSessionIdentity: false,
+      }),
+    ).rejects.toThrow(/session|room|isolat|shared/i);
+  });
+});

--- a/qa/scenarios/channels/dm-per-room-session.yaml
+++ b/qa/scenarios/channels/dm-per-room-session.yaml
@@ -48,7 +48,6 @@ flow:
             senderName: QA Driver
             text:
               expr: "`Reply exactly: ${config.primaryMarker}`"
-          saveAs: primaryInbound
         - waitForOutbound:
             conversation:
               id:
@@ -71,7 +70,8 @@ flow:
                   entry.delivery.context?.channel === 'matrix' &&
                   entry.delivery.context?.accountId === transport.accountId &&
                   entry.delivery.origin?.chatType === 'direct' &&
-                  entry.delivery.origin?.nativeDirectUserId === primaryInbound.senderId &&
+                  typeof entry.delivery.origin?.nativeDirectUserId === 'string' &&
+                  entry.delivery.origin.nativeDirectUserId.length > 0 &&
                   typeof entry.delivery.origin?.nativeChannelId === 'string' &&
                   typeof entry.sessionId === 'string')
                 .toSorted(([, left], [, right]) => Number(right.updatedAt ?? 0) - Number(left.updatedAt ?? 0))[0]
@@ -115,7 +115,7 @@ flow:
                   entry.delivery.context?.channel === 'matrix' &&
                   entry.delivery.context?.accountId === transport.accountId &&
                   entry.delivery.origin?.chatType === 'direct' &&
-                  entry.delivery.origin?.nativeDirectUserId === primaryInbound.senderId &&
+                  entry.delivery.origin?.nativeDirectUserId === primarySession[1].delivery.origin.nativeDirectUserId &&
                   entry.delivery.origin?.nativeChannelId !== primarySession[1].delivery.origin.nativeChannelId &&
                   typeof entry.delivery.origin?.nativeChannelId === 'string' &&
                   typeof entry.sessionId === 'string')

--- a/qa/scenarios/channels/dm-per-room-session.yaml
+++ b/qa/scenarios/channels/dm-per-room-session.yaml
@@ -124,9 +124,9 @@ flow:
             expr: Boolean(secondarySession)
             message: second Matrix DM turn did not create a persisted session for a distinct room
         - assert:
-            expr: secondarySession[1].sessionId !== primarySession[1].sessionId
+            expr: "secondarySession[0] !== primarySession[0] && secondarySession[1].sessionId !== primarySession[1].sessionId"
             message:
-              expr: "`Matrix per-room DM sessions share one transcript: ${JSON.stringify({ primaryKey: primarySession[0], secondaryKey: secondarySession[0], sessionId: primarySession[1].sessionId })}`"
+              expr: "`Matrix per-room DM rooms must own distinct session keys and transcripts: ${JSON.stringify({ primaryKey: primarySession[0], secondaryKey: secondarySession[0], primarySessionId: primarySession[1].sessionId, secondarySessionId: secondarySession[1].sessionId })}`"
         - call: sleep
           args:
             - 1500

--- a/qa/scenarios/channels/dm-per-room-session.yaml
+++ b/qa/scenarios/channels/dm-per-room-session.yaml
@@ -48,6 +48,7 @@ flow:
             senderName: QA Driver
             text:
               expr: "`Reply exactly: ${config.primaryMarker}`"
+          saveAs: primaryInbound
         - waitForOutbound:
             conversation:
               id:
@@ -57,6 +58,26 @@ flow:
               ref: config.primaryMarker
             timeoutMs:
               expr: liveTurnTimeoutMs(env, 45000)
+        - call: readRawQaSessionStore
+          saveAs: primarySessionStore
+          args:
+            - ref: env
+        - set: primarySession
+          value:
+            expr: |-
+              Object.entries(primarySessionStore)
+                .filter(([, entry]) =>
+                  entry?.delivery?.kind === 'external' &&
+                  entry.delivery.context?.channel === 'matrix' &&
+                  entry.delivery.context?.accountId === transport.accountId &&
+                  entry.delivery.origin?.chatType === 'direct' &&
+                  entry.delivery.origin?.nativeDirectUserId === primaryInbound.senderId &&
+                  typeof entry.delivery.origin?.nativeChannelId === 'string' &&
+                  typeof entry.sessionId === 'string')
+                .toSorted(([, left], [, right]) => Number(right.updatedAt ?? 0) - Number(left.updatedAt ?? 0))[0]
+        - assert:
+            expr: Boolean(primarySession)
+            message: first Matrix DM turn did not create a persisted account-scoped direct session
         - set: secondaryStartIndex
           value:
             expr: state.getSnapshot().messages.filter((candidate) => candidate.direction === 'outbound').length
@@ -81,6 +102,31 @@ flow:
             timeoutMs:
               expr: liveTurnTimeoutMs(env, 45000)
           saveAs: reply
+        - call: readRawQaSessionStore
+          saveAs: secondarySessionStore
+          args:
+            - ref: env
+        - set: secondarySession
+          value:
+            expr: |-
+              Object.entries(secondarySessionStore)
+                .filter(([, entry]) =>
+                  entry?.delivery?.kind === 'external' &&
+                  entry.delivery.context?.channel === 'matrix' &&
+                  entry.delivery.context?.accountId === transport.accountId &&
+                  entry.delivery.origin?.chatType === 'direct' &&
+                  entry.delivery.origin?.nativeDirectUserId === primaryInbound.senderId &&
+                  entry.delivery.origin?.nativeChannelId !== primarySession[1].delivery.origin.nativeChannelId &&
+                  typeof entry.delivery.origin?.nativeChannelId === 'string' &&
+                  typeof entry.sessionId === 'string')
+                .toSorted(([, left], [, right]) => Number(right.updatedAt ?? 0) - Number(left.updatedAt ?? 0))[0]
+        - assert:
+            expr: Boolean(secondarySession)
+            message: second Matrix DM turn did not create a persisted session for a distinct room
+        - assert:
+            expr: secondarySession[1].sessionId !== primarySession[1].sessionId
+            message:
+              expr: "`Matrix per-room DM sessions share one transcript: ${JSON.stringify({ primaryKey: primarySession[0], secondaryKey: secondarySession[0], sessionId: primarySession[1].sessionId })}`"
         - call: sleep
           args:
             - 1500

--- a/qa/scenarios/channels/dm-shared-session.yaml
+++ b/qa/scenarios/channels/dm-shared-session.yaml
@@ -42,7 +42,6 @@ flow:
             senderName: QA Driver
             text:
               expr: "`Reply exactly: ${config.primaryMarker}`"
-          saveAs: primaryInbound
         - waitForOutbound:
             conversation:
               id:
@@ -65,7 +64,8 @@ flow:
                   entry.delivery.context?.channel === 'matrix' &&
                   entry.delivery.context?.accountId === transport.accountId &&
                   entry.delivery.origin?.chatType === 'direct' &&
-                  entry.delivery.origin?.nativeDirectUserId === primaryInbound.senderId &&
+                  typeof entry.delivery.origin?.nativeDirectUserId === 'string' &&
+                  entry.delivery.origin.nativeDirectUserId.length > 0 &&
                   typeof entry.delivery.origin?.nativeChannelId === 'string' &&
                   typeof entry.sessionId === 'string')
                 .toSorted(([, left], [, right]) => Number(right.updatedAt ?? 0) - Number(left.updatedAt ?? 0))[0]
@@ -109,7 +109,7 @@ flow:
                   entry.delivery.context?.channel === 'matrix' &&
                   entry.delivery.context?.accountId === transport.accountId &&
                   entry.delivery.origin?.chatType === 'direct' &&
-                  entry.delivery.origin?.nativeDirectUserId === primaryInbound.senderId &&
+                  entry.delivery.origin?.nativeDirectUserId === primarySession[1].delivery.origin.nativeDirectUserId &&
                   entry.delivery.origin?.nativeChannelId !== primarySession[1].delivery.origin.nativeChannelId &&
                   typeof entry.delivery.origin?.nativeChannelId === 'string' &&
                   typeof entry.sessionId === 'string')

--- a/qa/scenarios/channels/dm-shared-session.yaml
+++ b/qa/scenarios/channels/dm-shared-session.yaml
@@ -118,7 +118,7 @@ flow:
             expr: Boolean(secondarySession)
             message: second Matrix DM turn did not update the persisted session for its distinct room
         - assert:
-            expr: secondarySession[1].sessionId === primarySession[1].sessionId
+            expr: "secondarySession[0] === primarySession[0] && secondarySession[1].sessionId === primarySession[1].sessionId"
             message:
               expr: "`Matrix per-user DM rooms unexpectedly use separate sessions: ${JSON.stringify({ primaryKey: primarySession[0], secondaryKey: secondarySession[0], primarySessionId: primarySession[1].sessionId, secondarySessionId: secondarySession[1].sessionId })}`"
         - waitForOutbound:

--- a/qa/scenarios/channels/dm-shared-session.yaml
+++ b/qa/scenarios/channels/dm-shared-session.yaml
@@ -42,6 +42,7 @@ flow:
             senderName: QA Driver
             text:
               expr: "`Reply exactly: ${config.primaryMarker}`"
+          saveAs: primaryInbound
         - waitForOutbound:
             conversation:
               id:
@@ -51,6 +52,26 @@ flow:
               ref: config.primaryMarker
             timeoutMs:
               expr: liveTurnTimeoutMs(env, 45000)
+        - call: readRawQaSessionStore
+          saveAs: primarySessionStore
+          args:
+            - ref: env
+        - set: primarySession
+          value:
+            expr: |-
+              Object.entries(primarySessionStore)
+                .filter(([, entry]) =>
+                  entry?.delivery?.kind === 'external' &&
+                  entry.delivery.context?.channel === 'matrix' &&
+                  entry.delivery.context?.accountId === transport.accountId &&
+                  entry.delivery.origin?.chatType === 'direct' &&
+                  entry.delivery.origin?.nativeDirectUserId === primaryInbound.senderId &&
+                  typeof entry.delivery.origin?.nativeChannelId === 'string' &&
+                  typeof entry.sessionId === 'string')
+                .toSorted(([, left], [, right]) => Number(right.updatedAt ?? 0) - Number(left.updatedAt ?? 0))[0]
+        - assert:
+            expr: Boolean(primarySession)
+            message: first Matrix DM turn did not create a persisted account-scoped direct session
         - set: secondaryStartIndex
           value:
             expr: state.getSnapshot().messages.filter((candidate) => candidate.direction === 'outbound').length
@@ -75,6 +96,31 @@ flow:
             timeoutMs:
               expr: liveTurnTimeoutMs(env, 45000)
           saveAs: reply
+        - call: readRawQaSessionStore
+          saveAs: secondarySessionStore
+          args:
+            - ref: env
+        - set: secondarySession
+          value:
+            expr: |-
+              Object.entries(secondarySessionStore)
+                .filter(([, entry]) =>
+                  entry?.delivery?.kind === 'external' &&
+                  entry.delivery.context?.channel === 'matrix' &&
+                  entry.delivery.context?.accountId === transport.accountId &&
+                  entry.delivery.origin?.chatType === 'direct' &&
+                  entry.delivery.origin?.nativeDirectUserId === primaryInbound.senderId &&
+                  entry.delivery.origin?.nativeChannelId !== primarySession[1].delivery.origin.nativeChannelId &&
+                  typeof entry.delivery.origin?.nativeChannelId === 'string' &&
+                  typeof entry.sessionId === 'string')
+                .toSorted(([, left], [, right]) => Number(right.updatedAt ?? 0) - Number(left.updatedAt ?? 0))[0]
+        - assert:
+            expr: Boolean(secondarySession)
+            message: second Matrix DM turn did not update the persisted session for its distinct room
+        - assert:
+            expr: secondarySession[1].sessionId === primarySession[1].sessionId
+            message:
+              expr: "`Matrix per-user DM rooms unexpectedly use separate sessions: ${JSON.stringify({ primaryKey: primarySession[0], secondaryKey: secondarySession[0], primarySessionId: primarySession[1].sessionId, secondarySessionId: secondarySession[1].sessionId })}`"
         - waitForOutbound:
             conversation:
               id:


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Matrix direct-message QA scenarios could pass based on correct-looking replies and notices even when room routing actually shared a supposedly isolated session or split a supposedly shared session.

## Why This Change Was Made

After each actual Matrix turn, inspect authoritative persisted direct-session records scoped to the selected account, first-turn canonical native sender, and distinct native rooms; require both the routing session key and transcript session ID to follow the configured per-room or per-user policy across live and Crabline drivers.

## User Impact

Matrix QA now detects real cross-room routing and transcript-isolation regressions while retaining existing notices, visible replies, and top-level threading checks.

## Evidence

Ten complete parsed Matrix scenario runs passed, covering live native sender IDs, actual Crabline logical sender aliases, intruder rejection, correct isolated/shared routing, rotated transcript IDs, and distinct routing keys aliased to one transcript. Stronger operator-visible proof then launched two actual ephemeral OpenClaw Gateways against a real local Crabline Matrix server and mock model: both `dm-per-room-session` and `dm-shared-session` passed, with aggregate artifact `{total:2,passed:2,failed:0,channelDriver:"crabline"}`. Trusted Testbox run: https://github.com/openclaw/openclaw/actions/runs/31016463287. The broader integration passed 609 tests, full changed gate, private production build, and four additional real Gateway scenarios.

**Integrated trusted-Testbox proof:** 609 tests passed, including five real Chromium extension E2E cases; complete production/test typechecks, lint, plugin-boundary/generated-contract checks, private production build, and four actual ephemeral-Gateway scenarios all passed.

**Owner/risk review:** QA scenario assertions only; no Matrix channel runtime, credentials, configuration defaults, security, persisted schema, or SDK changes. Separate named follow-up: unified QA aggregate summaries should preserve an explicit single selected channel while retaining null for intentionally mixed-channel runs.
