### PR TITLE
fix(openai): keep active Responses streams from timing out

### DIFF
--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -9,6 +9,7 @@ import { configureAiTransportHost } from "../host.js";
 import { processResponsesStream } from "../transports/openai-responses-stream-internal.js";
 import type { AssistantMessage, AssistantMessageEvent, Context, Model, Tool } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
+import { onLlmRequestActivity } from "../utils/llm-request-activity.js";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../utils/system-prompt-cache-boundary.js";
 import {
   applyCommonResponsesParams,
@@ -926,6 +927,48 @@ describe("processResponsesStream", () => {
       expect(onFirstEventTimeout).toHaveBeenCalledWith(abortFirstEventStream.mock.calls[0]?.[0]);
     } finally {
       vi.useRealTimers();
+    }
+  });
+
+  it("reports Responses lifecycle events as activity with only the outer signal", async () => {
+    const abortController = new AbortController();
+    const onActivity = vi.fn();
+    const unsubscribe = onLlmRequestActivity(abortController.signal, onActivity);
+
+    try {
+      await runResponsesStreamLifecycle({
+        stream: new AssistantMessageEventStream(),
+        model: nativeOpenAIModel,
+        output: createAssistantOutput(),
+        options: { signal: abortController.signal },
+        createClient: () => ({
+          responses: {
+            create: () => ({
+              withResponse: async () => ({
+                data: streamResponsesEvents([
+                  {
+                    type: "response.created",
+                    sequence_number: 1,
+                    response: { id: "resp_activity", status: "in_progress" },
+                  } as ResponseStreamEvent,
+                  {
+                    type: "response.completed",
+                    sequence_number: 2,
+                    response: { id: "resp_activity", status: "completed" },
+                  } as ResponseStreamEvent,
+                ]),
+                response: new Response(null, { status: 200 }),
+              }),
+            }),
+          },
+        }),
+        buildParams: () => ({ model: nativeOpenAIModel.id, input: [], stream: true }),
+        formatError: (error) => (error instanceof Error ? error.message : String(error)),
+      });
+
+      expect(onActivity).toHaveBeenCalledTimes(2);
+    } finally {
+      unsubscribe();
     }
   });
 

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -596,7 +596,8 @@ export async function runResponsesStreamLifecycle<TApi extends Api>(params: {
     const processStreamOptions =
       params.processStreamOptions ||
       firstEventTimeoutMs !== undefined ||
-      onFirstEventTimeout !== undefined
+      onFirstEventTimeout !== undefined ||
+      options?.signal !== undefined
         ? {
             ...params.processStreamOptions,
             firstEventTimeoutMs:

--- a/packages/ai/src/transports/openai-responses-stream-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-internal.ts
@@ -20,6 +20,7 @@ import {
 } from "../providers/openai-responses-tool-call-tracker.js";
 import type { Api, AssistantMessage, Model, TextContent, ToolCall, Usage } from "../types.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
+import { notifyLlmRequestActivity } from "../utils/llm-request-activity.js";
 import {
   type FirstStreamEventInternalOptions,
   withFirstStreamEventTimeout,
@@ -294,6 +295,9 @@ export async function processResponsesStream<TApi extends Api>(
   );
   try {
     for await (const event of guardedStream) {
+      // Internal Responses events are provider progress even when they emit no
+      // public stream event, so keep the outer idle watchdog alive.
+      notifyLlmRequestActivity(options?.signal);
       if (event.type === "response.created") {
         output.responseId = event.response.id;
       } else if (event.type === "response.output_item.added") {

--- a/src/agents/openai-transport-stream.streaming.test.ts
+++ b/src/agents/openai-transport-stream.streaming.test.ts
@@ -453,6 +453,140 @@ describe("openai transport stream", () => {
     },
   );
 
+  it("keeps internal Responses web-search events alive beyond the model idle timeout", async () => {
+    const idleTimeoutMs = 1_000;
+    const internalEventDelayMs = 220;
+    let internalPhaseElapsedMs = 0;
+    const server = createServer((req, res) => {
+      req.resume();
+      req.on("end", () => {
+        res.writeHead(200, {
+          "content-type": "text/event-stream; charset=utf-8",
+          "cache-control": "no-cache",
+          connection: "keep-alive",
+        });
+
+        const item = {
+          id: "ws_internal",
+          type: "web_search_call",
+          status: "in_progress",
+          action: { type: "search", query: "idle activity proof" },
+        };
+        const internalEvents = [
+          {
+            type: "response.created",
+            response: { id: "resp_internal", status: "in_progress", output: [] },
+          },
+          { type: "response.output_item.added", output_index: 0, item },
+          {
+            type: "response.web_search_call.in_progress",
+            item_id: item.id,
+            output_index: 0,
+          },
+          {
+            type: "response.web_search_call.searching",
+            item_id: item.id,
+            output_index: 0,
+          },
+          {
+            type: "response.web_search_call.completed",
+            item_id: item.id,
+            output_index: 0,
+          },
+          {
+            type: "response.output_item.done",
+            output_index: 0,
+            item: { ...item, status: "completed" },
+          },
+        ];
+        const internalPhaseStartedAt = Date.now();
+        let eventIndex = 0;
+        const writeNextEvent = () => {
+          if (res.destroyed) {
+            return;
+          }
+          if (eventIndex < internalEvents.length) {
+            res.write(`data: ${JSON.stringify(internalEvents[eventIndex])}\n\n`);
+            eventIndex += 1;
+            setTimeout(writeNextEvent, internalEventDelayMs);
+            return;
+          }
+
+          internalPhaseElapsedMs = Date.now() - internalPhaseStartedAt;
+          res.write(
+            `data: ${JSON.stringify({
+              type: "response.output_item.added",
+              item: { id: "msg_internal", type: "message", role: "assistant", content: [] },
+            })}\n\n`,
+          );
+          res.write(
+            `data: ${JSON.stringify({ type: "response.output_text.delta", delta: "OK" })}\n\n`,
+          );
+          res.write(
+            `data: ${JSON.stringify({
+              type: "response.completed",
+              response: { id: "resp_internal", status: "completed", output: [] },
+            })}\n\n`,
+          );
+          res.end();
+        };
+
+        writeNextEvent();
+      });
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Missing loopback server address");
+      }
+      const model = {
+        id: "gpt-internal-activity",
+        name: "Internal Activity",
+        api: "openai-responses",
+        provider: "custom-openai",
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128_000,
+        maxTokens: 4_096,
+      } satisfies Model<"openai-responses">;
+      const onIdleTimeout = vi.fn();
+      const streamFn = streamWithIdleTimeout(
+        createOpenAIResponsesTransportStreamFn(),
+        idleTimeoutMs,
+        onIdleTimeout,
+      );
+      const stream = streamFn(
+        model,
+        {
+          messages: [{ role: "user", content: "Reply OK", timestamp: Date.now() }],
+          tools: [],
+        },
+        { apiKey: "test-key" },
+      );
+
+      let text = "";
+      for await (const event of stream as AsyncIterable<{ type: string; delta?: string }>) {
+        if (event.type === "text_delta") {
+          text += event.delta ?? "";
+        }
+      }
+
+      expect(text).toBe("OK");
+      expect(onIdleTimeout).not.toHaveBeenCalled();
+      expect(internalPhaseElapsedMs).toBeGreaterThan(idleTimeoutMs);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
   it("refuses ModelStudio chat streams with no user or assistant payload turns", async () => {
     const model = makeCompletionsModel({
       id: "qwen-coder-plus",


### PR DESCRIPTION
AI-assisted: This change was developed with Codex.

## What Problem This Solves

OpenAI Responses runs using hosted web search can hit the model idle timeout while the provider is continuously sending internal progress events. Those events do not always produce public stream events, so the outer watchdog can mistake a healthy active stream for a stalled request.

## Why This Change Was Made

Every received Responses event now refreshes the existing LLM request activity signal before event-specific adaptation. The shared lifecycle also forwards an outer abort signal when no other processor option is present. Event mapping, provider protocol, terminal handling, and timeout configuration are unchanged.

## User Impact

Responses runs remain alive during long hosted-search phases while provider events continue; genuinely silent streams still use the existing idle timeout.

## Evidence

- Exact PR head: `5cc68a1b967326f347819e8e15fa5675466b6aec`.
- This head is the two Alix commits replayed without conflict onto `upstream/main` `de9314301f0582d4eada9e24168b499608c51b26`. The replay was required to replace a broken CI baseline, not merely because the PR was `BEHIND`: prior PR run [31246153530](https://github.com/openclaw/openclaw/actions/runs/31246153530) shared ten failing jobs with its base-main run [31245807749](https://github.com/openclaw/openclaw/actions/runs/31245807749), while exact-main run [31253929333](https://github.com/openclaw/openclaw/actions/runs/31253929333) is green.
- Public Node 24.18.0 exact-head proof: [run 31255390333](https://github.com/Alix-007/openclaw/actions/runs/31255390333) and [terminal artifact 9021248303](https://github.com/Alix-007/openclaw/actions/runs/31255390333/artifacts/9021248303). The workflow verified the immutable target SHA, then passed the entire focused streaming file 51/51. Its marker records `loopback-sse=true`, `internal-window-exceeded=true`, `final-text=true`, and `idle-timeout=false`.
- Exact-tree local focused validation passed the shared Responses suite 73/73 and streaming suite 51/51. The existing silent-watchdog invariant was also rerun with `-t "throws on idle timeout"`; three matching tests passed and 366 nonmatching tests were skipped.
- Targeted `oxfmt`, focused `oxlint`, and `git diff --check` passed. The first lint wrapper attempt was blocked before linting by unrelated current-main declaration preparation at `packages/terminal-core/src/ansi.ts`; rerunning focused lint without that unrelated plugin-SDK artifact preparation passed.
- Local Node was v22.22.0, below the repository v22.22.3 floor, so the public Node 24 proof and repository CI are the supported-runtime evidence.
- Current exact-head CI: [run 31255355157](https://github.com/openclaw/openclaw/actions/runs/31255355157). At 11:49 UTC on August 8, every completed selected lane was green except `checks-node-compact-small-7`; that job failed only because `src/infra/state-migrations.worktree-paths.test.ts` reached its unrelated 240-second timeout. The same unrelated test timed out on the previous exact head. `check-lint` was still in progress when this evidence was recorded.
- PR surface remains production +5 lines and tests +177 lines across four files.

## Remaining Proof Gap

The exact-head runtime proof above is loopback SSE evidence, not a hosted OpenAI call. The current execution environment has no OpenAI API key and no available Crabbox/Testbox binary, so no hosted claim is made.

A true hosted OpenAI trace remains unclaimed. The exact-head real HTTP/SSE production-boundary proof below supplies reproducible changed-path evidence without a provider credential; no maintainer action is requested.


### Exact-head production HTTP/SSE boundary proof (2026-08-10)

- Exact head: `5cc68a1b967326f347819e8e15fa5675466b6aec`.
- Successful public run: https://github.com/Alix-007/openclaw/actions/runs/31374653328
- Artifact: [`openclaw-responses-5cc68a1b967326f347819e8e15fa5675466b6aec`](https://github.com/Alix-007/openclaw/actions/runs/31374653328/artifacts/9057453416), containing immutable metadata, the redacted log, and verdict.
- The proof exercised production `createOpenAIResponsesTransportStreamFn`, the production Responses SSE parser, and production `streamWithIdleTimeout` over a real ephemeral HTTP SSE connection.
- Active control: one request emitted internal parser progress beyond the idle window and then final text; it completed with zero idle timeouts. Silent control: one real HTTP request emitted no activity and hit the expected LLM idle timeout exactly once.
- This is intentionally a controlled provider fixture, not hosted OpenAI. It proves the changed production client/parser/watchdog boundary without an API key; no hosted-provider result is claimed and no maintainer action is requested.
- Verdict JSON SHA256: `df6bdbae5dd703766708b3aa2fc0662b19bde92c2d387cd764c71b2cda347528`. The artifact contains no API key, endpoint, or response payload.

```json
{"schemaVersion":1,"verdict":"pass","targetSha":"5cc68a1b967326f347819e8e15fa5675466b6aec","boundary":{"client":"production-createOpenAIResponsesTransportStreamFn","parser":"production-Responses-SSE-parser","transport":"real-loopback-HTTP-SSE","server":"controlled-provider-fixture-not-hosted-OpenAI","watchdog":"production-streamWithIdleTimeout"},"assertions":{"activeRequestCount":1,"activeInternalPhaseExceededIdleWindow":true,"activeFinalText":true,"activeIdleTimeouts":0,"silentRequestCount":1,"silentIdleTimeouts":1,"silentControlTimedOut":true},"redaction":{"apiKeyIncluded":false,"endpointIncluded":false,"responsePayloadIncluded":false}}
```
