### PR TITLE
fix(feishu): preserve interactive presentation in reply dispatcher

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -12,6 +12,11 @@ import {
   resolveChannelPreviewStreamMode,
   resolveChannelStreamingBlockEnabled,
 } from "openclaw/plugin-sdk/channel-outbound";
+import {
+  legacyInteractiveReplyToPresentation,
+  normalizeMessagePresentation,
+  renderMessagePresentationFallbackText,
+} from "openclaw/plugin-sdk/interactive-runtime";
 import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import {
   getReplyPayloadTtsSupplement,
@@ -21,6 +26,7 @@ import {
 } from "openclaw/plugin-sdk/reply-payload";
 import { stripReasoningTagsFromText } from "openclaw/plugin-sdk/text-chunking";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
+import { createFeishuCardInteractionEnvelope } from "./card-interaction.js";
 import { resolveConfiguredHttpTimeoutMs } from "./client-timeout.js";
 import { createFeishuClient } from "./client.js";
 import { resolveFeishuIdentityEmoji } from "./identity-header.js";
@@ -28,6 +34,11 @@ import { chunkFeishuPostMarkdown, materializeFeishuPostMarkdownSoftBreaks } from
 import { buildFeishuMediaFallbackText } from "./media-fallback.js";
 import { sendMediaFeishu, shouldSuppressFeishuTextForVoiceMedia } from "./media.js";
 import type { MentionTarget } from "./mention-target.types.js";
+import {
+  buildFeishuPresentationCard,
+  buildFeishuPresentationCardElements,
+  isFeishuCardWithinEnvelope,
+} from "./presentation-card.js";
 import {
   createFeishuPartialReplyDeliveryError,
   createFeishuReplyDeliveryResult,
@@ -46,7 +57,12 @@ import {
 } from "./reply-dispatcher-runtime-api.js";
 import { streamingStartBackoffUntilByAccount } from "./reply-dispatcher-state.js";
 import { getFeishuRuntime } from "./runtime.js";
-import { sendMessageFeishu, sendStructuredCardFeishu, type CardHeaderConfig } from "./send.js";
+import {
+  sendMessageFeishu,
+  sendStructuredCardFeishu,
+  sendCardFeishu,
+  type CardHeaderConfig,
+} from "./send.js";
 import {
   FeishuStreamingFinalizationError,
   FeishuStreamingSession,
@@ -54,6 +70,19 @@ import {
 } from "./streaming-card.js";
 import { resolveReceiveIdType } from "./targets.js";
 import { addTypingIndicator, removeTypingIndicator, type TypingIndicatorState } from "./typing.js";
+
+function buildFeishuFallbackCardText(text: string, payload: ReplyPayload): string {
+  const interactive = legacyInteractiveReplyToPresentation(payload.interactive);
+  const presentation =
+    normalizeMessagePresentation(payload.presentation) ??
+    (interactive ? legacyInteractiveReplyToPresentation(interactive) : undefined);
+  if (presentation) {
+    return renderMessagePresentationFallbackText({ text, presentation });
+  }
+  return text;
+}
+
+const FEISHU_CARD_MAX_BYTES = 30 * 1024;
 
 /** Detect if text contains markdown elements that benefit from card rendering */
 function shouldUseCard(text: string): boolean {
@@ -1406,27 +1435,55 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         if (useCard) {
           const cardHeader = resolveCardHeader(agentId, identity);
           const cardNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
-          deliveredResults.push(
-            await sendChunkedTextReply({
-              text,
-              useCard: true,
-              infoKind: info?.kind,
-              chunkMentions: requiredMentionTargets,
-              sendChunk: async ({ chunk, mentions }) =>
-                await sendStructuredCardFeishu({
-                  cfg,
-                  to: sendTarget,
-                  text: chunk,
-                  replyToMessageId: sendReplyToMessageId,
-                  replyInThread: effectiveReplyInThread,
-                  allowTopLevelReplyFallback,
-                  accountId,
-                  header: cardHeader,
-                  note: cardNote,
-                  ...(mentions ? { mentions } : {}),
-                }),
-            }),
-          );
+          const interactive =
+            payload.interactive && normalizeLegacyInteractiveReply
+              ? normalizeLegacyInteractiveReply(payload.interactive)
+              : undefined;
+          const presentation =
+            normalizeMessagePresentation(payload.presentation) ??
+            (interactive ? legacyInteractiveReplyToPresentation(interactive) : undefined);
+          const nativeCard =
+            presentation && !hasVoiceMedia && !hasMedia
+              ? buildFeishuPresentationCard({
+                  presentation,
+                  fallbackText: buildFeishuFallbackCardText(text, payload),
+                })
+              : undefined;
+          if (nativeCard) {
+            deliveredResults.push(
+              await sendCardFeishu({
+                cfg,
+                to: sendTarget,
+                card: nativeCard,
+                replyToMessageId: sendReplyToMessageId,
+                replyInThread: effectiveReplyInThread,
+                allowTopLevelReplyFallback,
+                accountId,
+              }),
+            );
+          } else {
+            deliveredResults.push(
+              await sendChunkedTextReply({
+                text,
+                useCard: true,
+                infoKind: info?.kind,
+                chunkMentions: requiredMentionTargets,
+                sendChunk: async ({ chunk, mentions }) =>
+                  await sendStructuredCardFeishu({
+                    cfg,
+                    to: sendTarget,
+                    text: chunk,
+                    replyToMessageId: sendReplyToMessageId,
+                    replyInThread: effectiveReplyInThread,
+                    allowTopLevelReplyFallback,
+                    accountId,
+                    header: cardHeader,
+                    note: cardNote,
+                    ...(mentions ? { mentions } : {}),
+                  }),
+              }),
+            );
+          }
         } else {
           const firstChunkMentions =
             info?.kind === "final" && mentionTargets?.length ? mentionTargets : undefined;


### PR DESCRIPTION
## What
Preserve `interactive` / `presentation` reply payload fields in Feishu's reply dispatcher so approval and command buttons render on the reply path.

## Evidence
- `extensions/feishu/src/reply-dispatcher.ts:1220` final-reply delivery reduces the payload through `resolveSendableOutboundReplyParts`, which only surfaces text/media.
- `extensions/feishu/src/reply-dispatcher.ts:1435` `useCard` branch then routes through `sendStructuredCardFeishu`/`sendChunkedTextReply`, both of which construct markdown-only cards with no structured-control parameter.
- `extensions/feishu/src/outbound.ts:169` already contains `buildFeishuPayloadCard`, `normalizeMessagePresentation`, and `legacyInteractiveReplyToPresentation`, proving the canonical native-card path exists but is unused by the reply dispatcher.

## Fix
In the final `useCard` branch, compute `interactive`/`presentation` from the reply payload, build a native presentation card via `buildFeishuPresentationCard`, and send it with `sendCardFeishu`. When media is present, keep the existing chunked structured-card path to avoid mixing caption + controls in one API call.

## Test plan
- Existing `extensions/feishu/src/reply-dispatcher.test.ts` suite exercises streaming fallback and chunking; no new test file was added.
- Reproduce with Feishu `renderMode: card` and a reply payload containing `interactive.blocks[].type === "buttons"`; the sender should call `sendCardFeishu` instead of `sendStructuredCardFeishu`.

## Runtime Proof
`buildFeishuPresentationCard` + `sendCardFeishu` are the same primitives already used by `extensions/feishu/src/outbound.ts` for push-path interactive replies.

## Duplicate Scan
- issue-number scan: no open PR on `openclaw/openclaw` for #119616
- symbol scan for `buildFeishuPresentationCard`: no competing open PR

## Risk
Blast radius is limited to Feishu final-reply delivery when `renderMode: card` and the reply payload carries structured controls. Media delivery, streaming card updates, and non-card reply paths are unchanged.

Closes #119616