### PR TITLE
fix(skills): keep installed verdicts scoped to publisher

### DIFF
--- a/packages/gateway-protocol/src/schema/agents-models-skills.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.ts
@@ -478,6 +478,7 @@ export const SkillsSecurityVerdictsResultSchema = closedObject({
       decision: NonEmptyString,
       reasons: Type.Array(Type.String()),
       requestedSlug: NonEmptyString,
+      requestedOwnerHandle: Type.Optional(NonEmptyString),
       requestedVersion: NonEmptyString,
       slug: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
       version: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),

--- a/src/gateway/server-methods/skills.clawhub.test.ts
+++ b/src/gateway/server-methods/skills.clawhub.test.ts
@@ -11,7 +11,8 @@ const resolveAgentWorkspaceDirMock = vi.fn<(_cfg: unknown, _agentId: string) => 
 );
 const buildWorkspaceSkillStatusMock = vi.fn();
 const readLocalSkillCardContentSyncMock = vi.fn();
-const fetchClawHubSkillSecurityVerdictsMock = vi.fn();
+const fetchExactClawHubSkillSecurityVerdictsMock = vi.fn();
+const resolveClawHubBaseUrlMock = vi.fn(() => "https://clawhub.ai");
 const installSkillFromClawHubMock = vi.fn();
 const installSkillMock = vi.fn();
 const updateSkillsFromClawHubMock = vi.fn();
@@ -46,9 +47,12 @@ vi.mock("../../skills/lifecycle/install.js", () => ({
 
 vi.mock("../../infra/clawhub.js", () => ({
   fetchClawHubSkillDetail: vi.fn(),
-  fetchClawHubSkillSecurityVerdicts: (...args: unknown[]) =>
-    fetchClawHubSkillSecurityVerdictsMock(...args),
-  resolveClawHubBaseUrl: () => "https://clawhub.ai",
+  resolveClawHubBaseUrl: () => resolveClawHubBaseUrlMock(),
+}));
+
+vi.mock("../../infra/clawhub-skill-security.js", () => ({
+  fetchExactClawHubSkillSecurityVerdicts: (...args: unknown[]) =>
+    fetchExactClawHubSkillSecurityVerdictsMock(...args),
 }));
 
 const { skillsHandlers } = await import("./skills.js");
@@ -79,7 +83,7 @@ async function expectEmptySecurityVerdictsWithoutFetch(): Promise<void> {
 
   expect(error).toBeUndefined();
   expect(ok).toBe(true);
-  expect(fetchClawHubSkillSecurityVerdictsMock).not.toHaveBeenCalled();
+  expect(fetchExactClawHubSkillSecurityVerdictsMock).not.toHaveBeenCalled();
   expectEmptySecurityVerdicts(response);
 }
 
@@ -91,7 +95,8 @@ describe("skills gateway handlers (clawhub)", () => {
     resolveAgentWorkspaceDirMock.mockReset();
     buildWorkspaceSkillStatusMock.mockReset();
     readLocalSkillCardContentSyncMock.mockReset();
-    fetchClawHubSkillSecurityVerdictsMock.mockReset();
+    fetchExactClawHubSkillSecurityVerdictsMock.mockReset();
+    resolveClawHubBaseUrlMock.mockReset();
     installSkillFromClawHubMock.mockReset();
     installSkillMock.mockReset();
     updateSkillsFromClawHubMock.mockReset();
@@ -101,6 +106,7 @@ describe("skills gateway handlers (clawhub)", () => {
     resolveDefaultAgentIdMock.mockReturnValue("main");
     resolveAgentWorkspaceDirMock.mockReturnValue("/tmp/workspace");
     buildWorkspaceSkillStatusMock.mockReturnValue(emptySkillStatusReport());
+    resolveClawHubBaseUrlMock.mockReturnValue("https://clawhub.ai");
   });
 
   it("returns an empty verdict batch without calling ClawHub when no skills are linked", async () => {
@@ -152,30 +158,27 @@ describe("skills gateway handlers (clawhub)", () => {
         },
       ],
     });
-    fetchClawHubSkillSecurityVerdictsMock.mockResolvedValue({
-      schema: "clawhub.skill.security-verdicts.v1",
-      items: [
-        {
-          ok: true,
-          decision: "pass",
-          reasons: [],
-          requestedSlug: "agentreceipt",
-          slug: "agentreceipt",
-          requestedVersion: "1.2.3",
-          version: "1.2.3",
-          securityAuditUrl:
-            "https://clawhub.ai/openclaw/skills/agentreceipt/security-audit?version=1.2.3",
-          security: { status: "clean", passed: true },
-          scannerPayload: { ignored: true },
-        },
-      ],
-    });
+    fetchExactClawHubSkillSecurityVerdictsMock.mockResolvedValue([
+      {
+        ok: true,
+        decision: "pass",
+        reasons: [],
+        requestedSlug: "agentreceipt",
+        slug: "agentreceipt",
+        requestedVersion: "1.2.3",
+        version: "1.2.3",
+        securityAuditUrl:
+          "https://clawhub.ai/openclaw/skills/agentreceipt/security-audit?version=1.2.3",
+        security: { status: "clean", passed: true },
+        scannerPayload: { ignored: true },
+      },
+    ]);
 
     const { ok, response, error } = await callSkillsHandler("skills.securityVerdicts", {});
 
     expect(error).toBeUndefined();
-    expect(fetchClawHubSkillSecurityVerdictsMock).toHaveBeenCalledTimes(1);
-    expect(fetchClawHubSkillSecurityVerdictsMock).toHaveBeenCalledWith({
+    expect(fetchExactClawHubSkillSecurityVerdictsMock).toHaveBeenCalledTimes(1);
+    expect(fetchExactClawHubSkillSecurityVerdictsMock).toHaveBeenCalledWith({
       baseUrl: "https://clawhub.ai",
       items: [{ slug: "agentreceipt", version: "1.2.3" }],
       skipAuth: true,
@@ -199,7 +202,152 @@ describe("skills gateway handlers (clawhub)", () => {
     expect(JSON.stringify(response)).not.toContain('"security":');
   });
 
-  it("does not passively fetch verdicts from a non-default registry", async () => {
+  it("keeps owner-qualified verdict targets distinct for shared slugs", async () => {
+    buildWorkspaceSkillStatusMock.mockReturnValue({
+      workspaceDir: "/tmp/workspace",
+      managedSkillsDir: "/tmp/openclaw/skills",
+      skills: [
+        {
+          name: "alice-weather",
+          skillKey: "alice-weather",
+          clawhub: {
+            status: "linked",
+            valid: true,
+            registry: "https://clawhub.ai",
+            slug: "weather",
+            ownerHandle: "alice",
+            installedVersion: "1.2.3",
+            installedAt: 123,
+          },
+        },
+        {
+          name: "bob-weather",
+          skillKey: "bob-weather",
+          clawhub: {
+            status: "linked",
+            valid: true,
+            registry: "https://clawhub.ai",
+            slug: "weather",
+            ownerHandle: "bob",
+            installedVersion: "1.2.3",
+            installedAt: 456,
+          },
+        },
+      ],
+    });
+    fetchExactClawHubSkillSecurityVerdictsMock.mockResolvedValue([
+      {
+        ok: true,
+        decision: "pass",
+        reasons: [],
+        requestedSlug: "weather",
+        requestedOwnerHandle: "alice",
+        requestedVersion: "1.2.3",
+        slug: "weather",
+        version: "1.2.3",
+        publisherHandle: "alice",
+        security: { status: "clean", passed: true },
+      },
+      {
+        ok: false,
+        decision: "fail",
+        reasons: ["security.suspicious"],
+        requestedSlug: "weather",
+        requestedOwnerHandle: "bob",
+        requestedVersion: "1.2.3",
+        slug: "weather",
+        version: "1.2.3",
+        publisherHandle: "bob",
+        security: { status: "suspicious", passed: false },
+      },
+    ]);
+
+    const { ok, response, error } = await callSkillsHandler("skills.securityVerdicts", {});
+
+    expect(error).toBeUndefined();
+    expect(fetchExactClawHubSkillSecurityVerdictsMock).toHaveBeenCalledTimes(1);
+    expect(fetchExactClawHubSkillSecurityVerdictsMock).toHaveBeenCalledWith({
+      baseUrl: "https://clawhub.ai",
+      items: [
+        { slug: "weather", ownerHandle: "alice", version: "1.2.3" },
+        { slug: "weather", ownerHandle: "bob", version: "1.2.3" },
+      ],
+      skipAuth: true,
+    });
+    expect(ok).toBe(true);
+    expect(response).toEqual({
+      schema: "openclaw.skills.security-verdicts.v1",
+      items: [
+        expect.objectContaining({
+          requestedSlug: "weather",
+          requestedOwnerHandle: "alice",
+          requestedVersion: "1.2.3",
+          publisherHandle: "alice",
+        }),
+        expect.objectContaining({
+          requestedSlug: "weather",
+          requestedOwnerHandle: "bob",
+          requestedVersion: "1.2.3",
+          publisherHandle: "bob",
+        }),
+      ],
+    });
+  });
+
+  it("passively fetches verdicts from the configured custom registry without auth", async () => {
+    resolveClawHubBaseUrlMock.mockReturnValue("https://registry.example/base/");
+    buildWorkspaceSkillStatusMock.mockReturnValue({
+      workspaceDir: "/tmp/workspace",
+      managedSkillsDir: "/tmp/openclaw/skills",
+      skills: [
+        {
+          name: "agentreceipt",
+          skillKey: "agentreceipt",
+          clawhub: {
+            status: "linked",
+            valid: true,
+            registry: "https://registry.example/base",
+            slug: "agentreceipt",
+            ownerHandle: "openclaw",
+            installedVersion: "1.2.3",
+            installedAt: 123,
+          },
+        },
+      ],
+    });
+    fetchExactClawHubSkillSecurityVerdictsMock.mockResolvedValue([
+      {
+        ok: true,
+        decision: "pass",
+        reasons: [],
+        requestedSlug: "agentreceipt",
+        requestedOwnerHandle: "openclaw",
+        requestedVersion: "1.2.3",
+        slug: "agentreceipt",
+        version: "1.2.3",
+        publisherHandle: "openclaw",
+        security: { status: "clean", passed: true },
+      },
+    ]);
+
+    const { ok, error } = await callSkillsHandler("skills.securityVerdicts", {});
+
+    expect(ok).toBe(true);
+    expect(error).toBeUndefined();
+    expect(fetchExactClawHubSkillSecurityVerdictsMock).toHaveBeenCalledWith({
+      baseUrl: "https://registry.example/base",
+      items: [
+        {
+          slug: "agentreceipt",
+          ownerHandle: "openclaw",
+          version: "1.2.3",
+        },
+      ],
+      skipAuth: true,
+    });
+  });
+
+  it("does not passively fetch verdicts from a non-configured registry", async () => {
     buildWorkspaceSkillStatusMock.mockReturnValue({
       workspaceDir: "/tmp/workspace",
       managedSkillsDir: "/tmp/openclaw/skills",

--- a/src/infra/clawhub-install-trust.ts
+++ b/src/infra/clawhub-install-trust.ts
@@ -5,15 +5,13 @@ import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text
 import { formatTerminalLink } from "../../packages/terminal-core/src/terminal-link.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
 import { quoteCliArg } from "../cli/quote-cli-arg.js";
+import { fetchExactClawHubSkillSecurityVerdicts } from "./clawhub-skill-security.js";
 import {
   fetchClawHubPackageSecurity,
-  fetchClawHubSkillVerification,
-  fetchClawHubSkillSecurityVerdicts,
   resolveClawHubBaseUrl,
   type ClawHubPackageSecurityResponse,
   type ClawHubPackageSecurityTrust,
   type ClawHubSkillSecurityVerdictItem,
-  type ClawHubSkillVerificationResponse,
 } from "./clawhub.js";
 import { formatErrorMessage } from "./errors.js";
 
@@ -100,7 +98,6 @@ const CLAWHUB_NON_RISK_REASONS = new Set([
   "scan:stale",
   "stale_scan",
 ]);
-const CLAWHUB_NON_SECURITY_SKILL_VERIFY_REASONS = new Set(["card.missing", "card_missing"]);
 const CLAWHUB_EVIDENCE_LABEL_WIDTH = 15;
 const CLAWHUB_RAW_LINK_LABEL_WIDTH = 16;
 
@@ -768,154 +765,6 @@ function resolveSkillSecurityLinks(
   };
 }
 
-function readObject(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
-}
-
-function readOptionalStringField(value: unknown, field: string): string | undefined {
-  const record = readObject(value);
-  return normalizeOptionalString(record?.[field]);
-}
-
-function readOptionalNumberField(value: unknown, field: string): number | undefined {
-  const record = readObject(value);
-  const raw = record?.[field];
-  return typeof raw === "number" && Number.isFinite(raw) ? raw : undefined;
-}
-
-function mapSkillVerificationSecurityForVerdict(
-  verification: ClawHubSkillVerificationResponse,
-  opts?: { allowCleanCardOnlyPass?: boolean },
-): unknown {
-  const security = readObject(verification.security);
-  if (!security || Object.hasOwn(security, "passed")) {
-    return verification.security;
-  }
-  const status =
-    normalizeOptionalString(security.status) ?? normalizeOptionalString(security.rawStatus);
-  const decisionPass =
-    verification.ok && normalizeClawHubTrustToken(verification.decision) === "pass";
-  if (!status || (!decisionPass && opts?.allowCleanCardOnlyPass !== true)) {
-    return verification.security;
-  }
-  // The owner-qualified fallback uses the older verify endpoint, whose pass
-  // decision plus concrete status predates the batched verdict `passed` flag.
-  return { ...security, passed: true };
-}
-
-function hasOnlyNonSecuritySkillVerifyReasons(reasons: readonly string[]): boolean {
-  return (
-    reasons.length > 0 &&
-    reasons.every((reason) =>
-      CLAWHUB_NON_SECURITY_SKILL_VERIFY_REASONS.has(normalizeClawHubTrustToken(reason)),
-    )
-  );
-}
-
-function isOwnerQualifiedSkillNotFoundVerdict(item: ClawHubSkillSecurityVerdictItem): boolean {
-  return item.error?.code === "skill_not_found";
-}
-
-function mapSkillVerificationToSecurityVerdictItem(params: {
-  verification: ClawHubSkillVerificationResponse;
-  slug: string;
-  ownerHandle: string;
-  version: string;
-}): ClawHubSkillSecurityVerdictItem {
-  const skill = readObject(params.verification.skill);
-  const publisher = readObject(params.verification.publisher);
-  const versionRecord = readObject(params.verification.version);
-  const pageUrl = normalizeOptionalString(params.verification.pageUrl);
-  const reasons = params.verification.reasons
-    .map((reason) => normalizeOptionalString(reason))
-    .filter((reason): reason is string => Boolean(reason));
-  const securityStatus = normalizeClawHubTrustToken(
-    readOptionalStringField(params.verification.security, "status") ??
-      readOptionalStringField(params.verification.security, "rawStatus"),
-  );
-  const cardOnlyCleanFailure =
-    !params.verification.ok &&
-    securityStatus === "clean" &&
-    hasOnlyNonSecuritySkillVerifyReasons(reasons);
-  const verifiedVersion =
-    normalizeOptionalString(params.verification.version) ??
-    readOptionalStringField(versionRecord, "version");
-  return {
-    ok: cardOnlyCleanFailure ? true : params.verification.ok,
-    decision: cardOnlyCleanFailure ? "pass" : params.verification.decision,
-    reasons: cardOnlyCleanFailure ? [] : reasons,
-    requestedSlug: params.slug,
-    requestedVersion: params.version,
-    slug:
-      normalizeOptionalString(params.verification.slug) ?? readOptionalStringField(skill, "slug"),
-    version: verifiedVersion ?? (cardOnlyCleanFailure ? params.version : null),
-    displayName:
-      normalizeOptionalString(params.verification.displayName) ??
-      readOptionalStringField(skill, "displayName"),
-    publisherHandle:
-      normalizeOptionalString(params.verification.publisherHandle) ??
-      readOptionalStringField(publisher, "handle") ??
-      params.ownerHandle,
-    publisherDisplayName:
-      normalizeOptionalString(params.verification.publisherDisplayName) ??
-      readOptionalStringField(publisher, "displayName"),
-    createdAt:
-      params.verification.createdAt ?? readOptionalNumberField(versionRecord, "createdAt") ?? null,
-    checkedAt: readOptionalNumberField(params.verification.security, "checkedAt") ?? null,
-    ...(pageUrl ? { skillUrl: pageUrl } : {}),
-    ...(pageUrl
-      ? {
-          securityAuditUrl: `${pageUrl}/security-audit?version=${encodeURIComponent(params.version)}`,
-        }
-      : {}),
-    security: mapSkillVerificationSecurityForVerdict(params.verification, {
-      allowCleanCardOnlyPass: cardOnlyCleanFailure,
-    }),
-  };
-}
-
-async function fetchOwnerQualifiedSkillSecurityFallback(params: {
-  subject: {
-    kind: "skill";
-    packageName: string;
-    ownerHandle?: string;
-  };
-  version: string;
-  baseUrl?: string;
-  token?: string;
-  timeoutMs?: number;
-}): Promise<ClawHubFetchedSubjectSecurity> {
-  const ownerHandle = params.subject.ownerHandle;
-  if (!ownerHandle) {
-    throw new Error("owner-qualified skill fallback requires ownerHandle");
-  }
-  const verification = await fetchClawHubSkillVerification({
-    slug: params.subject.packageName,
-    ownerHandle,
-    version: params.version,
-    baseUrl: params.baseUrl,
-    token: params.token,
-    timeoutMs: params.timeoutMs,
-  });
-  const item = mapSkillVerificationToSecurityVerdictItem({
-    verification,
-    slug: params.subject.packageName,
-    ownerHandle,
-    version: params.version,
-  });
-  return {
-    security: mapSkillSecurityVerdictToPackageSecurity({
-      item,
-      packageName: params.subject.packageName,
-      ownerHandle,
-      version: params.version,
-    }),
-    links: resolveSkillSecurityLinks(item),
-  };
-}
-
 async function fetchClawHubSubjectSecurity(params: {
   subject: ClawHubTrustSubject;
   version: string;
@@ -934,7 +783,7 @@ async function fetchClawHubSubjectSecurity(params: {
       }),
     };
   }
-  const response = await fetchClawHubSkillSecurityVerdicts({
+  const [item] = await fetchExactClawHubSkillSecurityVerdicts({
     items: [
       {
         slug: params.subject.packageName,
@@ -946,29 +795,10 @@ async function fetchClawHubSubjectSecurity(params: {
     token: params.token,
     timeoutMs: params.timeoutMs,
   });
-  if (response.items.length !== 1) {
-    throw new Error(
-      `ClawHub skill trust check for "${formatClawHubReleaseLabel(params.subject.packageName, params.version)}" returned ${response.items.length} verdicts.`,
-    );
-  }
-  const item = response.items[0];
   if (!item) {
     throw new Error(
       `ClawHub skill trust check for "${formatClawHubReleaseLabel(params.subject.packageName, params.version)}" returned no verdict.`,
     );
-  }
-  if (params.subject.ownerHandle && isOwnerQualifiedSkillNotFoundVerdict(item)) {
-    return await fetchOwnerQualifiedSkillSecurityFallback({
-      subject: {
-        kind: "skill",
-        packageName: params.subject.packageName,
-        ownerHandle: params.subject.ownerHandle,
-      },
-      version: params.version,
-      baseUrl: params.baseUrl,
-      token: params.token,
-      timeoutMs: params.timeoutMs,
-    });
   }
   return {
     security: mapSkillSecurityVerdictToPackageSecurity({

--- a/src/infra/clawhub-skill-security.test.ts
+++ b/src/infra/clawhub-skill-security.test.ts
@@ -95,6 +95,76 @@ describe("fetchExactClawHubSkillSecurityVerdicts", () => {
     expect(items.map((item) => item.requestedOwnerHandle)).toEqual(["alice", "bob"]);
   });
 
+  it("bounds concurrent exact verify fallbacks on older registries", async () => {
+    let activeFallbacks = 0;
+    let maxActiveFallbacks = 0;
+    let releaseFallbacks: (() => void) | undefined;
+    const fallbackGate = new Promise<void>((resolve) => {
+      releaseFallbacks = resolve;
+    });
+    mocks.fetchClawHubSkillSecurityVerdicts.mockImplementation(
+      async ({ items }: { items: Array<{ slug: string; version: string }> }) => ({
+        schema: "clawhub.skill.security-verdicts.v1",
+        items: items.map((item) => ({
+          ok: false,
+          decision: "fail",
+          reasons: ["skill.not_found"],
+          requestedSlug: item.slug,
+          requestedVersion: item.version,
+          slug: item.slug,
+          version: null,
+          error: { code: "skill_not_found", message: "Skill not found" },
+        })),
+      }),
+    );
+    mocks.fetchClawHubSkillVerification.mockImplementation(
+      async ({
+        slug,
+        ownerHandle,
+        version,
+      }: {
+        slug: string;
+        ownerHandle: string;
+        version: string;
+      }) => {
+        activeFallbacks += 1;
+        maxActiveFallbacks = Math.max(maxActiveFallbacks, activeFallbacks);
+        await fallbackGate;
+        activeFallbacks -= 1;
+        return {
+          schema: "clawhub.skill.verify.v1",
+          ok: true,
+          decision: "pass",
+          reasons: [],
+          slug,
+          publisherHandle: ownerHandle,
+          version,
+          skill: null,
+          publisher: null,
+          card: null,
+          artifact: null,
+          provenance: null,
+          security: { status: "clean", passed: true },
+          signature: null,
+        };
+      },
+    );
+    const targets = Array.from({ length: 8 }, (_, index) => ({
+      slug: `skill-${index}`,
+      ownerHandle: `owner-${index}`,
+      version: "1.0.0",
+    }));
+
+    const resultPromise = fetchExactClawHubSkillSecurityVerdicts({ items: targets });
+    await vi.waitFor(() => expect(mocks.fetchClawHubSkillVerification).toHaveBeenCalledTimes(6));
+    expect(maxActiveFallbacks).toBe(6);
+    releaseFallbacks?.();
+
+    await expect(resultPromise).resolves.toHaveLength(8);
+    expect(mocks.fetchClawHubSkillVerification).toHaveBeenCalledTimes(8);
+    expect(maxActiveFallbacks).toBe(6);
+  });
+
   it("correlates reordered batches and fails closed on publisher mismatches", async () => {
     mocks.fetchClawHubSkillSecurityVerdicts.mockResolvedValue({
       schema: "clawhub.skill.security-verdicts.v1",

--- a/src/infra/clawhub-skill-security.test.ts
+++ b/src/infra/clawhub-skill-security.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  fetchClawHubSkillSecurityVerdicts: vi.fn(),
+  fetchClawHubSkillVerification: vi.fn(),
+}));
+
+vi.mock("./clawhub.js", () => ({
+  fetchClawHubSkillSecurityVerdicts: mocks.fetchClawHubSkillSecurityVerdicts,
+  fetchClawHubSkillVerification: mocks.fetchClawHubSkillVerification,
+}));
+
+import { fetchExactClawHubSkillSecurityVerdicts } from "./clawhub-skill-security.js";
+
+describe("fetchExactClawHubSkillSecurityVerdicts", () => {
+  beforeEach(() => {
+    mocks.fetchClawHubSkillSecurityVerdicts.mockReset();
+    mocks.fetchClawHubSkillVerification.mockReset();
+  });
+
+  it("uses exact unauthenticated verify fallbacks for owner collisions on older registries", async () => {
+    mocks.fetchClawHubSkillSecurityVerdicts.mockImplementation(
+      async ({ items }: { items: Array<{ slug: string; version: string }> }) => ({
+        schema: "clawhub.skill.security-verdicts.v1",
+        items: items.map((item) => ({
+          ok: false,
+          decision: "fail",
+          reasons: ["skill.not_found"],
+          requestedSlug: item.slug,
+          requestedVersion: item.version,
+          slug: item.slug,
+          version: null,
+          error: { code: "skill_not_found", message: "Skill not found" },
+        })),
+      }),
+    );
+    mocks.fetchClawHubSkillVerification.mockImplementation(
+      async ({ ownerHandle }: { ownerHandle: string }) => ({
+        schema: "clawhub.skill.verify.v1",
+        ok: true,
+        decision: "pass",
+        reasons: [],
+        slug: "weather",
+        displayName: `${ownerHandle} Weather`,
+        pageUrl: `https://clawhub.ai/${ownerHandle}/skills/weather`,
+        publisherHandle: ownerHandle,
+        publisherDisplayName: ownerHandle,
+        createdAt: 1,
+        skill: null,
+        publisher: null,
+        version: "1.2.3",
+        card: null,
+        artifact: null,
+        provenance: null,
+        security: { status: "clean", passed: true, checkedAt: 2 },
+        signature: null,
+      }),
+    );
+
+    const items = await fetchExactClawHubSkillSecurityVerdicts({
+      baseUrl: "https://clawhub.ai",
+      items: [
+        { slug: "weather", ownerHandle: "@Alice", version: "1.2.3" },
+        { slug: "weather", ownerHandle: "bob", version: "1.2.3" },
+      ],
+      skipAuth: true,
+    });
+
+    expect(mocks.fetchClawHubSkillSecurityVerdicts).toHaveBeenCalledTimes(2);
+    expect(mocks.fetchClawHubSkillSecurityVerdicts).toHaveBeenNthCalledWith(1, {
+      baseUrl: "https://clawhub.ai",
+      items: [{ slug: "weather", ownerHandle: "alice", version: "1.2.3" }],
+      skipAuth: true,
+      timeoutMs: undefined,
+      token: undefined,
+    });
+    expect(mocks.fetchClawHubSkillSecurityVerdicts).toHaveBeenNthCalledWith(2, {
+      baseUrl: "https://clawhub.ai",
+      items: [{ slug: "weather", ownerHandle: "bob", version: "1.2.3" }],
+      skipAuth: true,
+      timeoutMs: undefined,
+      token: undefined,
+    });
+    expect(mocks.fetchClawHubSkillVerification).toHaveBeenCalledTimes(2);
+    expect(mocks.fetchClawHubSkillVerification).toHaveBeenNthCalledWith(1, {
+      baseUrl: "https://clawhub.ai",
+      ownerHandle: "alice",
+      skipAuth: true,
+      slug: "weather",
+      timeoutMs: undefined,
+      token: undefined,
+      version: "1.2.3",
+    });
+    expect(items.map((item) => item.publisherHandle)).toEqual(["alice", "bob"]);
+    expect(items.map((item) => item.requestedOwnerHandle)).toEqual(["alice", "bob"]);
+  });
+
+  it("correlates reordered batches and fails closed on publisher mismatches", async () => {
+    mocks.fetchClawHubSkillSecurityVerdicts.mockResolvedValue({
+      schema: "clawhub.skill.security-verdicts.v1",
+      items: [
+        {
+          ok: true,
+          decision: "pass",
+          reasons: [],
+          requestedSlug: "calendar",
+          requestedOwnerHandle: "bob",
+          requestedVersion: "2.0.0",
+          slug: "calendar",
+          version: "2.0.0",
+          publisherHandle: "mallory",
+          security: { status: "clean", passed: true },
+        },
+        {
+          ok: true,
+          decision: "pass",
+          reasons: [],
+          requestedSlug: "weather",
+          requestedOwnerHandle: "alice",
+          requestedVersion: "1.2.3",
+          slug: "weather",
+          version: "1.2.3",
+          publisherHandle: "alice",
+          security: { status: "clean", passed: true },
+        },
+      ],
+    });
+
+    const items = await fetchExactClawHubSkillSecurityVerdicts({
+      items: [
+        { slug: "weather", ownerHandle: "alice", version: "1.2.3" },
+        { slug: "calendar", ownerHandle: "bob", version: "2.0.0" },
+      ],
+      skipAuth: true,
+    });
+
+    expect(mocks.fetchClawHubSkillSecurityVerdicts).toHaveBeenCalledTimes(1);
+    expect(items[0]).toMatchObject({
+      ok: true,
+      requestedOwnerHandle: "alice",
+      publisherHandle: "alice",
+    });
+    expect(items[1]).toMatchObject({
+      ok: false,
+      requestedOwnerHandle: "bob",
+      reasons: ["security.identity_mismatch"],
+      error: { code: "identity_mismatch" },
+    });
+    expect(mocks.fetchClawHubSkillVerification).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when a successful verdict returns a different exact version", async () => {
+    mocks.fetchClawHubSkillSecurityVerdicts.mockResolvedValue({
+      schema: "clawhub.skill.security-verdicts.v1",
+      items: [
+        {
+          ok: true,
+          decision: "pass",
+          reasons: [],
+          requestedSlug: "weather",
+          requestedOwnerHandle: "alice",
+          requestedVersion: "1.2.3",
+          slug: "weather",
+          version: "1.2.4",
+          publisherHandle: "alice",
+          security: { status: "clean", passed: true },
+        },
+      ],
+    });
+
+    const [item] = await fetchExactClawHubSkillSecurityVerdicts({
+      items: [{ slug: "weather", ownerHandle: "alice", version: "1.2.3" }],
+    });
+
+    expect(item).toMatchObject({
+      ok: false,
+      requestedOwnerHandle: "alice",
+      requestedVersion: "1.2.3",
+      reasons: ["security.identity_mismatch"],
+      error: { code: "identity_mismatch" },
+    });
+  });
+});

--- a/src/infra/clawhub-skill-security.ts
+++ b/src/infra/clawhub-skill-security.ts
@@ -1,0 +1,334 @@
+// Shared owner-qualified ClawHub security verdict resolution.
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import {
+  fetchClawHubSkillSecurityVerdicts,
+  fetchClawHubSkillVerification,
+  type ClawHubSkillSecurityVerdictItem,
+  type ClawHubSkillVerificationResponse,
+} from "./clawhub.js";
+
+const MAX_SECURITY_VERDICT_BATCH_SIZE = 100;
+const NON_SECURITY_VERIFY_REASONS = new Set(["card.missing", "card_missing"]);
+
+export type ClawHubExactSkillSecurityTarget = {
+  slug: string;
+  ownerHandle?: string;
+  version: string;
+};
+
+type FetchExactSkillSecurityParams = {
+  items: ClawHubExactSkillSecurityTarget[];
+  baseUrl?: string;
+  token?: string;
+  skipAuth?: boolean;
+  timeoutMs?: number;
+};
+
+function normalizeOwnerHandle(ownerHandle: string | null | undefined): string | undefined {
+  const normalized = normalizeOptionalString(ownerHandle)?.replace(/^@+/, "").toLowerCase();
+  return normalized || undefined;
+}
+
+function normalizeTarget(target: ClawHubExactSkillSecurityTarget): ClawHubExactSkillSecurityTarget {
+  const slug = target.slug.trim();
+  const ownerHandle = normalizeOwnerHandle(target.ownerHandle);
+  const version = target.version.trim();
+  return { slug, ...(ownerHandle ? { ownerHandle } : {}), version };
+}
+
+function normalizeSlug(slug: string): string {
+  return slug.trim().toLowerCase();
+}
+
+function targetKey(target: ClawHubExactSkillSecurityTarget): string {
+  return `${target.ownerHandle ?? ""}\0${normalizeSlug(target.slug)}\0${target.version}`;
+}
+
+function legacyTargetKey(
+  target: Pick<ClawHubExactSkillSecurityTarget, "slug" | "version">,
+): string {
+  return `${normalizeSlug(target.slug)}\0${target.version}`;
+}
+
+function partitionCompatibleBatches(
+  targets: ClawHubExactSkillSecurityTarget[],
+): ClawHubExactSkillSecurityTarget[][] {
+  const batches: Array<{
+    items: ClawHubExactSkillSecurityTarget[];
+    legacyKeys: Set<string>;
+  }> = [];
+  for (const target of targets) {
+    const legacyKey = legacyTargetKey(target);
+    let batch = batches.find(
+      (candidate) =>
+        candidate.items.length < MAX_SECURITY_VERDICT_BATCH_SIZE &&
+        !candidate.legacyKeys.has(legacyKey),
+    );
+    if (!batch) {
+      batch = { items: [], legacyKeys: new Set() };
+      batches.push(batch);
+    }
+    batch.items.push(target);
+    batch.legacyKeys.add(legacyKey);
+  }
+  return batches.map((batch) => batch.items);
+}
+
+function readObject(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function readOptionalStringField(value: unknown, field: string): string | undefined {
+  return normalizeOptionalString(readObject(value)?.[field]);
+}
+
+function readOptionalNumberField(value: unknown, field: string): number | undefined {
+  const raw = readObject(value)?.[field];
+  return typeof raw === "number" && Number.isFinite(raw) ? raw : undefined;
+}
+
+function normalizeReason(reason: string): string {
+  return normalizeOptionalString(reason)?.toLowerCase() ?? "";
+}
+
+function hasOnlyNonSecurityVerifyReasons(reasons: readonly string[]): boolean {
+  return (
+    reasons.length > 0 &&
+    reasons.every((reason) => NON_SECURITY_VERIFY_REASONS.has(normalizeReason(reason)))
+  );
+}
+
+function mapVerificationSecurity(
+  verification: ClawHubSkillVerificationResponse,
+  allowCleanCardOnlyPass: boolean,
+): unknown {
+  const security = readObject(verification.security);
+  if (!security || Object.hasOwn(security, "passed")) {
+    return verification.security;
+  }
+  const status =
+    normalizeOptionalString(security.status) ?? normalizeOptionalString(security.rawStatus);
+  const decisionPass = verification.ok && normalizeReason(verification.decision) === "pass";
+  if (!status || (!decisionPass && !allowCleanCardOnlyPass)) {
+    return verification.security;
+  }
+  // Older exact-verify responses predate the batched verdict `passed` flag.
+  return { ...security, passed: true };
+}
+
+function mapVerificationToVerdict(params: {
+  verification: ClawHubSkillVerificationResponse;
+  target: ClawHubExactSkillSecurityTarget & { ownerHandle: string };
+}): ClawHubSkillSecurityVerdictItem {
+  const skill = readObject(params.verification.skill);
+  const publisher = readObject(params.verification.publisher);
+  const versionRecord = readObject(params.verification.version);
+  const pageUrl = normalizeOptionalString(params.verification.pageUrl);
+  const reasons = params.verification.reasons
+    .map((reason) => normalizeOptionalString(reason))
+    .filter((reason): reason is string => Boolean(reason));
+  const securityStatus = normalizeReason(
+    readOptionalStringField(params.verification.security, "status") ??
+      readOptionalStringField(params.verification.security, "rawStatus"),
+  );
+  const cardOnlyCleanFailure =
+    !params.verification.ok &&
+    securityStatus === "clean" &&
+    hasOnlyNonSecurityVerifyReasons(reasons);
+  const verifiedVersion =
+    normalizeOptionalString(params.verification.version) ??
+    readOptionalStringField(versionRecord, "version");
+  return {
+    ok: cardOnlyCleanFailure ? true : params.verification.ok,
+    decision: cardOnlyCleanFailure ? "pass" : params.verification.decision,
+    reasons: cardOnlyCleanFailure ? [] : reasons,
+    requestedSlug: params.target.slug,
+    requestedOwnerHandle: params.target.ownerHandle,
+    requestedVersion: params.target.version,
+    slug:
+      normalizeOptionalString(params.verification.slug) ?? readOptionalStringField(skill, "slug"),
+    version: verifiedVersion ?? (cardOnlyCleanFailure ? params.target.version : null),
+    displayName:
+      normalizeOptionalString(params.verification.displayName) ??
+      readOptionalStringField(skill, "displayName"),
+    publisherHandle:
+      normalizeOptionalString(params.verification.publisherHandle) ??
+      readOptionalStringField(publisher, "handle"),
+    publisherDisplayName:
+      normalizeOptionalString(params.verification.publisherDisplayName) ??
+      readOptionalStringField(publisher, "displayName"),
+    createdAt:
+      params.verification.createdAt ?? readOptionalNumberField(versionRecord, "createdAt") ?? null,
+    checkedAt: readOptionalNumberField(params.verification.security, "checkedAt") ?? null,
+    ...(pageUrl ? { skillUrl: pageUrl } : {}),
+    ...(pageUrl
+      ? {
+          securityAuditUrl: `${pageUrl}/security-audit?version=${encodeURIComponent(params.target.version)}`,
+        }
+      : {}),
+    security: mapVerificationSecurity(params.verification, cardOnlyCleanFailure),
+  };
+}
+
+function identityFailure(
+  target: ClawHubExactSkillSecurityTarget,
+  message: string,
+): ClawHubSkillSecurityVerdictItem {
+  return {
+    ok: false,
+    decision: "fail",
+    reasons: ["security.identity_mismatch"],
+    requestedSlug: target.slug,
+    ...(target.ownerHandle ? { requestedOwnerHandle: target.ownerHandle } : {}),
+    requestedVersion: target.version,
+    slug: null,
+    version: null,
+    publisherHandle: null,
+    security: null,
+    error: { code: "identity_mismatch", message },
+  };
+}
+
+function validateVerdictIdentity(
+  target: ClawHubExactSkillSecurityTarget,
+  item: ClawHubSkillSecurityVerdictItem,
+): ClawHubSkillSecurityVerdictItem {
+  const requestedSlug = normalizeOptionalString(item.requestedSlug)?.toLowerCase();
+  if (requestedSlug !== normalizeSlug(target.slug)) {
+    return identityFailure(
+      target,
+      `ClawHub returned requested slug ${requestedSlug ?? "unknown"}.`,
+    );
+  }
+  if (normalizeOptionalString(item.requestedVersion) !== target.version) {
+    return identityFailure(target, "ClawHub returned a different requested version.");
+  }
+  const requestedOwnerHandle = normalizeOwnerHandle(item.requestedOwnerHandle);
+  if (requestedOwnerHandle && requestedOwnerHandle !== target.ownerHandle) {
+    return identityFailure(target, `ClawHub returned requested owner ${requestedOwnerHandle}.`);
+  }
+  const resolvedSlug = normalizeOptionalString(item.slug)?.toLowerCase();
+  if (resolvedSlug && resolvedSlug !== normalizeSlug(target.slug)) {
+    return identityFailure(target, `ClawHub resolved skill ${resolvedSlug}.`);
+  }
+  const resolvedVersion = normalizeOptionalString(item.version);
+  if (resolvedVersion && resolvedVersion !== target.version) {
+    return identityFailure(target, `ClawHub resolved version ${resolvedVersion}.`);
+  }
+  if (item.ok && resolvedVersion !== target.version) {
+    return identityFailure(target, "ClawHub did not return the exact requested version.");
+  }
+  const publisherHandle = normalizeOwnerHandle(item.publisherHandle);
+  if (target.ownerHandle && item.version !== null && publisherHandle !== target.ownerHandle) {
+    return identityFailure(target, `ClawHub resolved publisher ${publisherHandle ?? "unknown"}.`);
+  }
+  return item;
+}
+
+function correlateBatchItems(
+  targets: ClawHubExactSkillSecurityTarget[],
+  items: ClawHubSkillSecurityVerdictItem[],
+): Map<string, ClawHubSkillSecurityVerdictItem> {
+  if (items.length !== targets.length) {
+    throw new Error(
+      `ClawHub skill security verdict request returned ${items.length} verdicts for ${targets.length} targets.`,
+    );
+  }
+  const byKey = new Map(targets.map((target) => [targetKey(target), target]));
+  const byLegacyKey = new Map(targets.map((target) => [legacyTargetKey(target), target]));
+  const correlated = new Map<string, ClawHubSkillSecurityVerdictItem>();
+  for (const item of items) {
+    const requestedSlug = normalizeOptionalString(item.requestedSlug)?.toLowerCase();
+    const requestedVersion = normalizeOptionalString(item.requestedVersion);
+    const requestedOwnerHandle = normalizeOwnerHandle(item.requestedOwnerHandle);
+    if (!requestedSlug || !requestedVersion) {
+      throw new Error("ClawHub skill security verdict response omitted request identity.");
+    }
+    const target = requestedOwnerHandle
+      ? byKey.get(
+          targetKey({
+            slug: requestedSlug,
+            ownerHandle: requestedOwnerHandle,
+            version: requestedVersion,
+          }),
+        )
+      : byLegacyKey.get(legacyTargetKey({ slug: requestedSlug, version: requestedVersion }));
+    if (!target || correlated.has(targetKey(target))) {
+      throw new Error("ClawHub skill security verdict response could not be correlated safely.");
+    }
+    correlated.set(targetKey(target), item);
+  }
+  return correlated;
+}
+
+async function resolveOwnerQualifiedFallback(params: {
+  target: ClawHubExactSkillSecurityTarget & { ownerHandle: string };
+  baseUrl?: string;
+  token?: string;
+  skipAuth?: boolean;
+  timeoutMs?: number;
+}): Promise<ClawHubSkillSecurityVerdictItem> {
+  const verification = await fetchClawHubSkillVerification({
+    slug: params.target.slug,
+    ownerHandle: params.target.ownerHandle,
+    version: params.target.version,
+    baseUrl: params.baseUrl,
+    token: params.token,
+    ...(params.skipAuth !== undefined ? { skipAuth: params.skipAuth } : {}),
+    timeoutMs: params.timeoutMs,
+  });
+  return mapVerificationToVerdict({ verification, target: params.target });
+}
+
+export async function fetchExactClawHubSkillSecurityVerdicts(
+  params: FetchExactSkillSecurityParams,
+): Promise<ClawHubSkillSecurityVerdictItem[]> {
+  const targets = params.items.map(normalizeTarget);
+  const keys = new Set<string>();
+  for (const target of targets) {
+    const key = targetKey(target);
+    if (keys.has(key)) {
+      throw new Error("ClawHub skill security verdict request contains duplicate targets.");
+    }
+    keys.add(key);
+  }
+
+  const resolved = new Map<string, ClawHubSkillSecurityVerdictItem>();
+  for (const batch of partitionCompatibleBatches(targets)) {
+    const response = await fetchClawHubSkillSecurityVerdicts({
+      items: batch,
+      baseUrl: params.baseUrl,
+      token: params.token,
+      ...(params.skipAuth !== undefined ? { skipAuth: params.skipAuth } : {}),
+      timeoutMs: params.timeoutMs,
+    });
+    const correlated = correlateBatchItems(batch, response.items);
+    for (const target of batch) {
+      const key = targetKey(target);
+      const item = correlated.get(key);
+      if (!item) {
+        throw new Error("ClawHub skill security verdict response omitted a target.");
+      }
+      const fallbackItem =
+        target.ownerHandle && item.error?.code === "skill_not_found"
+          ? await resolveOwnerQualifiedFallback({
+              target: { ...target, ownerHandle: target.ownerHandle },
+              baseUrl: params.baseUrl,
+              token: params.token,
+              ...(params.skipAuth !== undefined ? { skipAuth: params.skipAuth } : {}),
+              timeoutMs: params.timeoutMs,
+            })
+          : item;
+      resolved.set(key, validateVerdictIdentity(target, fallbackItem));
+    }
+  }
+  return targets.map((target) => {
+    const item = resolved.get(targetKey(target));
+    if (!item) {
+      throw new Error("ClawHub skill security verdict resolution omitted a target.");
+    }
+    return item;
+  });
+}

--- a/src/infra/clawhub-skill-security.ts
+++ b/src/infra/clawhub-skill-security.ts
@@ -1,5 +1,6 @@
 // Shared owner-qualified ClawHub security verdict resolution.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import pLimit from "p-limit";
 import {
   fetchClawHubSkillSecurityVerdicts,
   fetchClawHubSkillVerification,
@@ -8,6 +9,7 @@ import {
 } from "./clawhub.js";
 
 const MAX_SECURITY_VERDICT_BATCH_SIZE = 100;
+const OWNER_QUALIFIED_FALLBACK_CONCURRENCY = 6;
 const NON_SECURITY_VERIFY_REASONS = new Set(["card.missing", "card_missing"]);
 
 type ClawHubExactSkillSecurityTarget = {
@@ -305,23 +307,32 @@ export async function fetchExactClawHubSkillSecurityVerdicts(
       timeoutMs: params.timeoutMs,
     });
     const correlated = correlateBatchItems(batch, response.items);
-    for (const target of batch) {
-      const key = targetKey(target);
-      const item = correlated.get(key);
-      if (!item) {
-        throw new Error("ClawHub skill security verdict response omitted a target.");
-      }
-      const fallbackItem =
-        target.ownerHandle && item.error?.code === "skill_not_found"
-          ? await resolveOwnerQualifiedFallback({
-              target: { ...target, ownerHandle: target.ownerHandle },
-              baseUrl: params.baseUrl,
-              token: params.token,
-              ...(params.skipAuth !== undefined ? { skipAuth: params.skipAuth } : {}),
-              timeoutMs: params.timeoutMs,
-            })
-          : item;
-      resolved.set(key, validateVerdictIdentity(target, fallbackItem));
+    const fallbackLimit = pLimit(OWNER_QUALIFIED_FALLBACK_CONCURRENCY);
+    const resolvedBatch = await Promise.all(
+      batch.map(async (target) => {
+        const key = targetKey(target);
+        const item = correlated.get(key);
+        if (!item) {
+          throw new Error("ClawHub skill security verdict response omitted a target.");
+        }
+        const ownerHandle = target.ownerHandle;
+        const fallbackItem =
+          ownerHandle && item.error?.code === "skill_not_found"
+            ? await fallbackLimit(() =>
+                resolveOwnerQualifiedFallback({
+                  target: { ...target, ownerHandle },
+                  baseUrl: params.baseUrl,
+                  token: params.token,
+                  ...(params.skipAuth !== undefined ? { skipAuth: params.skipAuth } : {}),
+                  timeoutMs: params.timeoutMs,
+                }),
+              )
+            : item;
+        return [key, validateVerdictIdentity(target, fallbackItem)] as const;
+      }),
+    );
+    for (const [key, item] of resolvedBatch) {
+      resolved.set(key, item);
     }
   }
   return targets.map((target) => {

--- a/src/infra/clawhub-skill-security.ts
+++ b/src/infra/clawhub-skill-security.ts
@@ -10,7 +10,7 @@ import {
 const MAX_SECURITY_VERDICT_BATCH_SIZE = 100;
 const NON_SECURITY_VERIFY_REASONS = new Set(["card.missing", "card_missing"]);
 
-export type ClawHubExactSkillSecurityTarget = {
+type ClawHubExactSkillSecurityTarget = {
   slug: string;
   ownerHandle?: string;
   version: string;
@@ -89,7 +89,7 @@ function readOptionalNumberField(value: unknown, field: string): number | undefi
   return typeof raw === "number" && Number.isFinite(raw) ? raw : undefined;
 }
 
-function normalizeReason(reason: string): string {
+function normalizeReason(reason: string | null | undefined): string {
   return normalizeOptionalString(reason)?.toLowerCase() ?? "";
 }
 

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -743,16 +743,20 @@ describe("clawhub helpers", () => {
     expect(url.searchParams.has("tag")).toBe(false);
   });
 
-  it("sends owner-qualified skill verification lookups as slug plus ownerHandle", async () => {
+  it("sends owner-qualified skill verification lookups without resolved auth when requested", async () => {
+    process.env.CLAWHUB_TOKEN = "env-token-123";
     let requestedUrl = "";
+    let requestedInit: RequestInit | undefined;
 
     await expect(
       fetchClawHubSkillVerification({
         slug: "weather",
         ownerHandle: "demo-owner",
         version: "1.0.0",
-        fetchImpl: async (input) => {
+        skipAuth: true,
+        fetchImpl: async (input, init) => {
           requestedUrl = input instanceof Request ? input.url : String(input);
+          requestedInit = init;
           return new Response(
             JSON.stringify({
               schema: "clawhub.skill.verify.v1",
@@ -778,6 +782,7 @@ describe("clawhub helpers", () => {
     expect(url.pathname).toBe("/api/v1/skills/weather/verify");
     expect(url.searchParams.get("ownerHandle")).toBe("demo-owner");
     expect(url.searchParams.get("version")).toBe("1.0.0");
+    expect(new Headers(requestedInit?.headers).get("Authorization")).toBeNull();
   });
 
   it("posts bulk skill security verdict requests", async () => {
@@ -801,7 +806,7 @@ describe("clawhub helpers", () => {
 
     await expect(
       fetchClawHubSkillSecurityVerdicts({
-        items: [{ slug: "agentreceipt", version: "1.2.3" }],
+        items: [{ slug: "agentreceipt", ownerHandle: "openclaw", version: "1.2.3" }],
         fetchImpl: async (input, init) => {
           requestedUrl = input instanceof Request ? input.url : String(input);
           requestedInit = init;
@@ -818,7 +823,9 @@ describe("clawhub helpers", () => {
     expect(requestedInit?.method).toBe("POST");
     expect(requestedInit?.headers).toMatchObject({ "Content-Type": "application/json" });
     expect(requestedInit?.body).toBe(
-      JSON.stringify({ items: [{ slug: "agentreceipt", version: "1.2.3" }] }),
+      JSON.stringify({
+        items: [{ slug: "agentreceipt", ownerHandle: "openclaw", version: "1.2.3" }],
+      }),
     );
   });
 

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -390,6 +390,7 @@ export type ClawHubSkillSecurityVerdictItem = {
   decision: ClawHubSkillVerificationDecision;
   reasons: string[];
   requestedSlug: string;
+  requestedOwnerHandle?: string;
   requestedVersion: string;
   slug?: string | null;
   version?: string | null;
@@ -1320,6 +1321,7 @@ export async function fetchClawHubSkillVerification(params: {
   tag?: string;
   baseUrl?: string;
   token?: string;
+  skipAuth?: boolean;
   timeoutMs?: number;
   fetchImpl?: FetchLike;
 }): Promise<ClawHubSkillVerificationResponse> {
@@ -1327,6 +1329,7 @@ export async function fetchClawHubSkillVerification(params: {
     baseUrl: params.baseUrl,
     path: `/api/v1/skills/${encodeURIComponent(params.slug)}/verify`,
     token: params.token,
+    skipAuth: params.skipAuth,
     timeoutMs: params.timeoutMs,
     fetchImpl: params.fetchImpl,
     search: {

--- a/src/skills/lifecycle/clawhub.test.ts
+++ b/src/skills/lifecycle/clawhub.test.ts
@@ -3134,6 +3134,7 @@ describe("ClawHub origin provenance readback", () => {
         slug: "agentreceipt",
         installedVersion: "1.0.0",
         installedAt: 123,
+        ownerHandle: "acme",
         sourceUrl,
         artifact,
         skillFile,
@@ -3146,6 +3147,7 @@ describe("ClawHub origin provenance readback", () => {
           version: "1.0.0",
           installedAt: 123,
           registry: "https://clawhub.ai",
+          ownerHandle: "acme",
           sourceUrl,
           artifact,
           skillFile,
@@ -3163,6 +3165,7 @@ describe("ClawHub origin provenance readback", () => {
       if (link?.status !== "linked") {
         throw new Error(`expected linked status, got ${link?.status}`);
       }
+      expect(link.ownerHandle).toBe("acme");
       expect(link.artifact).toEqual(artifact);
       expect(link.skillFile).toEqual(skillFile);
       expect(link.sourceUrl).toBe(sourceUrl);

--- a/src/skills/security/clawhub-verdicts.ts
+++ b/src/skills/security/clawhub-verdicts.ts
@@ -1,18 +1,26 @@
+import { fetchExactClawHubSkillSecurityVerdicts } from "../../infra/clawhub-skill-security.js";
 // ClawHub verdict helpers normalize skill security verdicts from registry metadata.
 import {
-  fetchClawHubSkillSecurityVerdicts,
   resolveClawHubBaseUrl,
   type ClawHubSkillSecurityVerdictItem,
 } from "../../infra/clawhub.js";
 import type { buildWorkspaceSkillStatus } from "../discovery/status.js";
 
 /** ClawHub verdict item shape projected into local security scan verdicts. */
+type ClawHubVerdictTarget = {
+  registry: string;
+  slug: string;
+  ownerHandle?: string;
+  version: string;
+};
+
 type OpenClawSkillSecurityVerdictItem = Omit<
   ClawHubSkillSecurityVerdictItem,
   "decision" | "error" | "security"
 > & {
   registry: string;
   decision: string;
+  requestedOwnerHandle?: string;
   securityStatus?: string | null;
   securityPassed?: boolean | null;
   error?: {
@@ -39,15 +47,16 @@ function readSecurityPassed(security: unknown): boolean | null | undefined {
 
 function projectClawHubVerdictItem(
   item: ClawHubSkillSecurityVerdictItem,
-  registry: string,
+  target: ClawHubVerdictTarget,
 ): OpenClawSkillSecurityVerdictItem {
   const projected: OpenClawSkillSecurityVerdictItem = {
-    registry,
+    registry: target.registry,
     ok: item.ok,
     decision: item.decision,
     reasons: item.reasons,
-    requestedSlug: item.requestedSlug,
-    requestedVersion: item.requestedVersion,
+    requestedSlug: target.slug,
+    requestedVersion: target.version,
+    ...(target.ownerHandle ? { requestedOwnerHandle: target.ownerHandle } : {}),
   };
   if (item.slug !== undefined) {
     projected.slug = item.slug;
@@ -117,8 +126,8 @@ function canAutoFetchVerdictRegistry(registry: string): boolean {
 
 export function collectClawHubVerdictTargets(
   report: ReturnType<typeof buildWorkspaceSkillStatus>,
-): Array<{ registry: string; slug: string; version: string }> {
-  const targets = new Map<string, { registry: string; slug: string; version: string }>();
+): ClawHubVerdictTarget[] {
+  const targets = new Map<string, ClawHubVerdictTarget>();
   for (const skill of report.skills) {
     const link = skill.clawhub;
     if (!link || link.status !== "linked" || !link.valid) {
@@ -127,10 +136,11 @@ export function collectClawHubVerdictTargets(
     if (!canAutoFetchVerdictRegistry(link.registry)) {
       continue;
     }
-    const key = `${link.registry}\0${link.slug}\0${link.installedVersion}`;
+    const key = `${link.registry}\0${link.ownerHandle ?? ""}\0${link.slug}\0${link.installedVersion}`;
     targets.set(key, {
       registry: link.registry,
       slug: link.slug,
+      ...(link.ownerHandle ? { ownerHandle: link.ownerHandle } : {}),
       version: link.installedVersion,
     });
   }
@@ -138,24 +148,28 @@ export function collectClawHubVerdictTargets(
 }
 
 export async function fetchOpenClawSkillSecurityVerdicts(
-  targets: Array<{ registry: string; slug: string; version: string }>,
+  targets: ClawHubVerdictTarget[],
 ): Promise<OpenClawSkillSecurityVerdictItem[]> {
-  const byRegistry = new Map<string, Array<{ slug: string; version: string }>>();
+  const byRegistry = new Map<string, ClawHubVerdictTarget[]>();
   for (const target of targets) {
     const registryTargets = byRegistry.get(target.registry) ?? [];
-    registryTargets.push({ slug: target.slug, version: target.version });
+    registryTargets.push(target);
     byRegistry.set(target.registry, registryTargets);
   }
 
   const items: OpenClawSkillSecurityVerdictItem[] = [];
   for (const [registry, registryTargets] of byRegistry) {
-    const response = await fetchClawHubSkillSecurityVerdicts({
+    const verdicts = await fetchExactClawHubSkillSecurityVerdicts({
       baseUrl: registry,
-      items: registryTargets,
+      items: registryTargets.map(({ slug, ownerHandle, version }) => ({
+        slug,
+        ...(ownerHandle ? { ownerHandle } : {}),
+        version,
+      })),
       skipAuth: true,
     });
-    for (const item of response.items) {
-      items.push(projectClawHubVerdictItem(item, registry));
+    for (const [index, item] of verdicts.entries()) {
+      items.push(projectClawHubVerdictItem(item, registryTargets[index]!));
     }
   }
   return items;

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -811,6 +811,7 @@ export type SkillClawHubLink =
       valid: true;
       registry: string;
       slug: string;
+      ownerHandle?: string;
       installedVersion: string;
       installedAt: number;
       originPath?: string;

--- a/ui/src/lib/skills/index.test.ts
+++ b/ui/src/lib/skills/index.test.ts
@@ -6,6 +6,7 @@ import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { createRuntimeConfigCapability } from "../config/index.ts";
 import { searchClawHub } from "./clawhub-search.ts";
 import {
+  clawhubVerdictKey,
   installFromClawHub,
   installSkill,
   loadSkills,
@@ -188,7 +189,11 @@ describe("loadSkills", () => {
     expect(request).toHaveBeenNthCalledWith(1, "skills.status", {});
     expect(request).toHaveBeenNthCalledWith(2, "skills.securityVerdicts", {});
     expect(state.clawhubVerdicts).toEqual({
-      "https://clawhub.ai\u0000agentreceipt\u00001.2.3": expect.objectContaining({
+      [clawhubVerdictKey({
+        registry: "https://clawhub.ai",
+        slug: "agentreceipt",
+        version: "1.2.3",
+      })]: expect.objectContaining({
         ok: true,
         decision: "pass",
         securityStatus: "clean",
@@ -197,6 +202,99 @@ describe("loadSkills", () => {
     });
     expect(state.clawhubVerdictsLoading).toBe(false);
     expect(state.clawhubVerdictsError).toBeNull();
+  });
+
+  it("keeps verdicts for the same slug distinct by installed owner", async () => {
+    const { state, request } = createState();
+    request.mockImplementation(async (method: string) => {
+      if (method === "skills.status") {
+        return {
+          workspaceDir: "/tmp/workspace",
+          managedSkillsDir: "/tmp/skills",
+          skills: [
+            {
+              name: "Alice Weather",
+              skillKey: "alice-weather",
+              source: "workspace",
+              clawhub: {
+                status: "linked",
+                valid: true,
+                registry: "https://clawhub.ai",
+                slug: "weather",
+                ownerHandle: "alice",
+                installedVersion: "1.2.3",
+                installedAt: 123,
+              },
+            },
+            {
+              name: "Bob Weather",
+              skillKey: "bob-weather",
+              source: "workspace",
+              clawhub: {
+                status: "linked",
+                valid: true,
+                registry: "https://clawhub.ai",
+                slug: "weather",
+                ownerHandle: "bob",
+                installedVersion: "1.2.3",
+                installedAt: 456,
+              },
+            },
+          ],
+        };
+      }
+      if (method === "skills.securityVerdicts") {
+        return {
+          schema: "openclaw.skills.security-verdicts.v1",
+          items: [
+            {
+              registry: "https://clawhub.ai",
+              ok: true,
+              decision: "pass",
+              reasons: [],
+              requestedSlug: "weather",
+              requestedOwnerHandle: "alice",
+              requestedVersion: "1.2.3",
+              publisherHandle: "alice",
+              securityStatus: "clean",
+              securityPassed: true,
+            },
+            {
+              registry: "https://clawhub.ai",
+              ok: false,
+              decision: "fail",
+              reasons: ["security.suspicious"],
+              requestedSlug: "weather",
+              requestedOwnerHandle: "bob",
+              requestedVersion: "1.2.3",
+              publisherHandle: "bob",
+              securityStatus: "suspicious",
+              securityPassed: false,
+            },
+          ],
+        };
+      }
+      return {};
+    });
+
+    await loadSkills(state);
+
+    const aliceKey = clawhubVerdictKey({
+      registry: "https://clawhub.ai",
+      slug: "weather",
+      ownerHandle: "alice",
+      version: "1.2.3",
+    });
+    const bobKey = clawhubVerdictKey({
+      registry: "https://clawhub.ai",
+      slug: "weather",
+      ownerHandle: "bob",
+      version: "1.2.3",
+    });
+    expect(aliceKey).not.toBe(bobKey);
+    expect(Object.keys(state.clawhubVerdicts)).toHaveLength(2);
+    expect(state.clawhubVerdicts[aliceKey]?.publisherHandle).toBe("alice");
+    expect(state.clawhubVerdicts[bobKey]?.publisherHandle).toBe("bob");
   });
 
   it("loads selected agent skills and verdicts with the agent id", async () => {

--- a/ui/src/lib/skills/index.ts
+++ b/ui/src/lib/skills/index.ts
@@ -56,6 +56,7 @@ export type ClawHubSkillSecurityVerdict = {
   decision: string;
   reasons: string[];
   requestedSlug: string;
+  requestedOwnerHandle?: string;
   requestedVersion: string;
   slug?: string | null;
   version?: string | null;
@@ -168,9 +169,10 @@ function formatClawHubAcknowledgementMessage(warning?: string): string {
 export function clawhubVerdictKey(target: {
   registry: string;
   slug: string;
+  ownerHandle?: string;
   version: string;
 }): string {
-  return `${target.registry}\0${target.slug}\0${target.version}`;
+  return `${target.registry}\0${target.ownerHandle ?? ""}\0${target.slug}\0${target.version}`;
 }
 
 function isValidClawHubLink(
@@ -480,6 +482,7 @@ async function loadClawHubSecurityVerdicts(state: SkillsState, report: SkillStat
         clawhubVerdictKey({
           registry: item.registry,
           slug: item.requestedSlug,
+          ownerHandle: item.requestedOwnerHandle,
           version: item.requestedVersion,
         }),
         item,

--- a/ui/src/pages/skills/view.test.ts
+++ b/ui/src/pages/skills/view.test.ts
@@ -5,6 +5,7 @@ import { render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentsListResult, SkillStatusEntry, SkillStatusReport } from "../../api/types.ts";
 import { i18n } from "../../i18n/index.ts";
+import { clawhubVerdictKey } from "../../lib/skills/index.ts";
 import { getRenderedModalDialog } from "../../test-helpers/modal-dialog.ts";
 import { renderSkills } from "./view.ts";
 
@@ -851,6 +852,7 @@ describe("renderSkills", () => {
         valid: true,
         registry: "https://clawhub.ai",
         slug: "agentreceipt",
+        ownerHandle: "openclaw",
         installedVersion: "1.2.3",
         installedAt: 123,
       },
@@ -865,7 +867,12 @@ describe("renderSkills", () => {
       managedSkillsDir: "/tmp/skills",
       skills: [linkedSkill],
     };
-    const verdictKey = "https://clawhub.ai\u0000agentreceipt\u00001.2.3";
+    const verdictKey = clawhubVerdictKey({
+      registry: "https://clawhub.ai",
+      slug: "agentreceipt",
+      ownerHandle: "openclaw",
+      version: "1.2.3",
+    });
     const onDetailTabChange = vi.fn();
 
     render(
@@ -881,6 +888,7 @@ describe("renderSkills", () => {
               decision: "fail",
               reasons: ["security.suspicious"],
               requestedSlug: "agentreceipt",
+              requestedOwnerHandle: "openclaw",
               requestedVersion: "1.2.3",
               slug: "agentreceipt",
               version: "1.2.3",
@@ -897,6 +905,7 @@ describe("renderSkills", () => {
     await Promise.resolve();
 
     expect(normalizeText(container)).toContain("Review");
+    expect(normalizeText(container)).toContain("@openclaw/agentreceipt@1.2.3");
     expect(normalizeText(container)).toContain("security.suspicious");
     expect(
       container.querySelector<HTMLAnchorElement>('a[href*="security-audit"]')?.textContent?.trim(),
@@ -925,6 +934,7 @@ describe("renderSkills", () => {
               decision: "fail",
               reasons: ["security.suspicious"],
               requestedSlug: "agentreceipt",
+              requestedOwnerHandle: "openclaw",
               requestedVersion: "1.2.3",
               securityAuditUrl:
                 "https://clawhub.ai/openclaw/skills/agentreceipt/security-audit?version=1.2.3",
@@ -968,7 +978,11 @@ describe("renderSkills", () => {
       managedSkillsDir: "/tmp/skills",
       skills: [linkedSkill],
     };
-    const verdictKey = "https://clawhub.ai\u0000agentreceipt\u00001.2.3";
+    const verdictKey = clawhubVerdictKey({
+      registry: "https://clawhub.ai",
+      slug: "agentreceipt",
+      version: "1.2.3",
+    });
 
     render(
       renderSkills(

--- a/ui/src/pages/skills/view.ts
+++ b/ui/src/pages/skills/view.ts
@@ -158,6 +158,7 @@ function verdictForSkill(skill: SkillStatusEntry, verdicts: SkillsProps["clawhub
       clawhubVerdictKey({
         registry: link.registry,
         slug: link.slug,
+        ownerHandle: link.ownerHandle,
         version: link.installedVersion,
       })
     ] ?? null
@@ -818,6 +819,7 @@ function renderInstalledClawHubOverview(
   }
   const auditHref = safeExternalHref(verdict?.securityAuditUrl ?? undefined);
   const reasonText = verdict?.reasons?.length ? verdict.reasons.join(", ") : null;
+  const installedRef = `${link.ownerHandle ? `@${link.ownerHandle}/` : ""}${link.slug}@${link.installedVersion}`;
   return html`
     <div
       class="callout"
@@ -825,7 +827,7 @@ function renderInstalledClawHubOverview(
     >
       <div style="display: flex; align-items: center; gap: 8px; flex-wrap: wrap;">
         <span class="chip ${verdictChipClass(verdict)}">${verdictLabel(verdict)}</span>
-        <span class="muted" style="font-size: 12px;">${link.slug}@${link.installedVersion}</span>
+        <span class="muted" style="font-size: 12px;">${installedRef}</span>
         ${props.clawhubVerdictsLoading
           ? html`<span class="muted">${t("skillsPage.refreshing")}</span>`
           : nothing}


### PR DESCRIPTION
Related: #117681
Related: https://github.com/openclaw/clawhub/pull/3409

## What Problem This Solves

Fixes an issue where Control UI could lose or misattribute the security verdict for an installed ClawHub skill when another publisher used the same slug and version. Installed provenance already recorded the trusted publisher, but the passive verdict path dropped that owner before batching and keyed UI state only by registry, slug, and version.

## Why This Change Was Made

OpenClaw now carries the installed `ownerHandle` through target collection, the shared exact-skill verdict resolver, Gateway protocol projection, Control UI keys, and the installed-skill detail view. One canonical resolver is shared with install/update trust: it safely correlates batch responses by request identity, keeps owner-collision requests compatible with older registries by separating legacy-conflicting batches, uses the existing exact owner-qualified `/verify` fallback only for `skill_not_found`, preserves unauthenticated passive reads, and fails closed on publisher or exact-version mismatch.

The additive ClawHub API support landed first in openclaw/clawhub#3409 (`f9ea25e14f14c05f9544d3878d1626d0dcec4b7a`). Older/custom registries remain compatible through the exact `/verify` fallback. Passive reads still run only against the currently configured registry; unrelated installed registry records remain skipped.

This is independent of #117681: that PR preserves publisher identity during search/detail/install selection, while this PR preserves the installed publisher identity during later security-verdict reads.

## User Impact

Operators see and evaluate the verdict for the exact installed publisher. The installed overview now renders the complete reference, such as `@openclaw/agentreceipt@1.2.3`, and a malformed, reordered, mismatched, or older-registry response cannot silently attach another publisher's clean verdict.

No config surface, protocol version, schema version, release, or changelog change is introduced. The Gateway field is optional for compatibility with older clients.

## Evidence

- Focused regression proof after rebasing onto current main at the time of implementation:
  - `node scripts/run-vitest.mjs src/infra/clawhub-skill-security.test.ts src/infra/clawhub.test.ts src/skills/lifecycle/clawhub.test.ts src/gateway/server-methods/skills.clawhub.test.ts ui/src/lib/skills/index.test.ts ui/src/pages/skills/view.test.ts`
  - 4 Vitest shards passed: 6 files, 273 tests.
  - Final helper-only rerun passed: 1 file, 3 tests.
- Changed-lane proof:
  - The repository's changed-check delegated route was unavailable because the local Crabbox/Testbox broker was not authenticated.
  - Trusted-source fallback ran locally and passed formatting, conflict/env/max-lines guards, dependency/patch/boundary guards, dead-code export checks, UI i18n, `tsgo:core`, `tsgo:core:test`, `tsgo:ui`, targeted oxlint, native schema guard, database-first/storage/media/sidecar checks, import-cycle check, webhook body-order guard, and pairing auth guards.
- Real UI proof from an isolated dev gateway and temporary workspace: the actual Skills detail dialog rendered `@openclaw/agentreceipt@1.2.3` and issued the owner-qualified exact `/verify` compatibility request. A sanitized dialog-only screenshot contains no user session data and will be attached to the PR.
- Codex autoreview (`gpt-5.6-sol`, high reasoning) on the final branch reported no accepted/actionable findings.
- `git diff --check` passed.
- ClawSweeper's exact-head review found that older-registry `/verify` fallbacks were serial. The follow-up commit bounds that path to six concurrent requests per batch and adds a regression proving eight fallbacks complete with exactly six in flight while preserving result order and identity checks.
- Production/test delta after the bounded-fallback repair: production +385/-193 (net +192), tests +568/-34 (net +534). The production growth establishes one canonical security owner boundary, response-correlation contract, and explicit compatibility-path capacity limit while deleting the previous 170-line install-only fallback implementation.

AI-assisted: yes. I understand and can maintain this change.
