### PR TITLE
improve: speed up skills test fixtures

### DIFF
--- a/src/skills/research/autocapture-auto-apply.test.ts
+++ b/src/skills/research/autocapture-auto-apply.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import { expectDefined } from "@openclaw/normalization-core";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { loadSessionEntry, upsertSessionEntry } from "../../config/sessions/session-accessor.js";
 import {
   createOpenClawTestState,
@@ -11,26 +11,35 @@ import { inspectSkillProposal, listSkillProposals } from "../workshop/service.js
 import { runSkillResearchAutoCapture } from "./autocapture.js";
 
 const tempDirs = createTrackedTempDirs();
-const SESSION_KEY = "agent:main:main";
 let testState: OpenClawTestState;
+let sessionKeyIndex = 0;
+let SESSION_KEY = "";
 
-beforeEach(async () => {
+beforeAll(async () => {
   testState = await createOpenClawTestState({
     layout: "state-only",
     prefix: "openclaw-skill-autocapture-auto-state-",
   });
-  await upsertSessionEntry(
-    { agentId: "main", sessionKey: SESSION_KEY },
-    { sessionId: "session-autocapture-auto", updatedAt: 1 },
-  );
+});
+
+beforeEach(() => {
+  testState.applyEnv();
+  SESSION_KEY = `agent:main:autocapture-auto-test-${String(++sessionKeyIndex)}`;
 });
 
 afterEach(async () => {
-  await testState.cleanup();
   await tempDirs.cleanup();
 });
 
+afterAll(async () => {
+  await testState.cleanup();
+});
+
 async function makeWorkspace(): Promise<string> {
+  await upsertSessionEntry(
+    { agentId: "main", sessionKey: SESSION_KEY },
+    { sessionId: `session-${SESSION_KEY}`, updatedAt: 1 },
+  );
   return await tempDirs.make("openclaw-skill-autocapture-auto-");
 }
 

--- a/src/skills/research/autocapture.test.ts
+++ b/src/skills/research/autocapture.test.ts
@@ -2,12 +2,9 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { loadSessionEntry, upsertSessionEntry } from "../../config/sessions/session-accessor.js";
-import {
-  consumeSessionSkillSuggestion,
-  recordSessionSkillCaptureSignals,
-} from "../../config/sessions/skill-suggestions.js";
+import * as skillSuggestions from "../../config/sessions/skill-suggestions.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
@@ -25,33 +22,45 @@ import { runSkillResearchAutoCapture } from "./autocapture.js";
 
 const tempDirs = createTrackedTempDirs();
 let testState: OpenClawTestState;
-const SESSION_KEY = "agent:main:main";
+let sessionKeyIndex = 0;
+let SESSION_KEY = "";
 
-async function seedSession(sessionKey = SESSION_KEY): Promise<void> {
+async function seedSession(key = SESSION_KEY): Promise<void> {
   await upsertSessionEntry(
-    { agentId: "main", sessionKey },
-    { sessionId: `session-${sessionKey}`, updatedAt: 1 },
+    { agentId: "main", sessionKey: key },
+    { sessionId: `session-${key}`, updatedAt: 1 },
   );
 }
 
-function readSession(sessionKey = SESSION_KEY) {
-  return loadSessionEntry({ agentId: "main", sessionKey, readConsistency: "latest" });
+function readSession(key = SESSION_KEY) {
+  return loadSessionEntry({ agentId: "main", sessionKey: key, readConsistency: "latest" });
 }
 
-beforeEach(async () => {
+beforeAll(async () => {
   testState = await createOpenClawTestState({
     layout: "state-only",
     prefix: "openclaw-skill-workshop-state-",
   });
-  await seedSession();
+});
+
+beforeEach(() => {
+  testState.applyEnv();
+  SESSION_KEY = `agent:main:autocapture-test-${String(++sessionKeyIndex)}`;
 });
 
 afterEach(async () => {
-  await testState.cleanup();
+  vi.restoreAllMocks();
   await tempDirs.cleanup();
 });
 
-async function makeWorkspace(): Promise<string> {
+afterAll(async () => {
+  await testState.cleanup();
+});
+
+async function makeWorkspace(options: { seedSession?: boolean } = {}): Promise<string> {
+  if (options.seedSession !== false) {
+    await seedSession();
+  }
   return await tempDirs.make("openclaw-skill-workshop-");
 }
 
@@ -142,7 +151,10 @@ describe("skill research auto-capture", () => {
     });
     expect(readSession()?.skillCaptureSignalHashes?.length).toBeGreaterThan(0);
 
-    await consumeSessionSkillSuggestion({ agentId: "main", sessionKey: SESSION_KEY });
+    await skillSuggestions.consumeSessionSkillSuggestion({
+      agentId: "main",
+      sessionKey: SESSION_KEY,
+    });
     await runSkillResearchAutoCapture({ event, ctx, config });
     expect(readSession()?.pendingSkillSuggestion).toBeUndefined();
   });
@@ -181,8 +193,8 @@ describe("skill research auto-capture", () => {
       ctx: { trigger: "manual", sessionKey: "active-memory-recall-87504" },
     },
   ])("skips $name before queuing proposals", async ({ ctx }) => {
-    const workspaceDir = await makeWorkspace();
-    await seedSession(ctx.sessionKey);
+    const workspaceDir = await makeWorkspace({ seedSession: false });
+    const sessionRead = vi.spyOn(skillSuggestions, "readSessionSkillCaptureSignalHashes");
 
     await runSkillResearchAutoCapture({
       event: {
@@ -208,6 +220,7 @@ describe("skill research auto-capture", () => {
     });
 
     expect((await listSkillProposals({ workspaceDir })).proposals).toHaveLength(0);
+    expect(sessionRead).not.toHaveBeenCalled();
   });
 
   it("preserves existing skill content when auto-capturing an update", async () => {
@@ -950,7 +963,8 @@ describe("skill research auto-capture", () => {
   });
 
   it("bounds captured signal fingerprints to the newest 32", async () => {
-    await recordSessionSkillCaptureSignals({
+    await seedSession();
+    await skillSuggestions.recordSessionSkillCaptureSignals({
       agentId: "main",
       sessionKey: SESSION_KEY,
       signalHashes: Array.from({ length: 40 }, (_, index) => `hash-${index}`),
@@ -978,7 +992,7 @@ describe("skill research auto-capture", () => {
     await runSkillResearchAutoCapture({ event, ctx, config });
     expect(
       (
-        await consumeSessionSkillSuggestion({
+        await skillSuggestions.consumeSessionSkillSuggestion({
           agentId: "main",
           sessionKey: SESSION_KEY,
         })

--- a/src/skills/workshop/service-evaluation.test.ts
+++ b/src/skills/workshop/service-evaluation.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginHookSkillProposalEvaluateEvent } from "../../plugins/hook-types.js";
 import {
   createOpenClawTestState,
@@ -36,18 +36,25 @@ import { prepareSkillProposalSupportFiles } from "./store.js";
 const tempDirs = createTrackedTempDirs();
 let testState: OpenClawTestState;
 
-beforeEach(async () => {
+beforeAll(async () => {
   testState = await createOpenClawTestState({
     layout: "state-only",
     prefix: "openclaw-skill-evaluation-state-",
   });
+});
+
+beforeEach(() => {
+  testState.applyEnv();
   hookMocks.evaluate.mockReset();
   hookMocks.hasEvaluators = true;
 });
 
 afterEach(async () => {
-  await testState.cleanup();
   await tempDirs.cleanup();
+});
+
+afterAll(async () => {
+  await testState.cleanup();
 });
 
 describe("Skill Workshop proposal evaluation", () => {

--- a/src/skills/workshop/service.test.ts
+++ b/src/skills/workshop/service.test.ts
@@ -1,8 +1,13 @@
 // Workshop service tests cover skill workshop generation, storage, and validation behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  closeOpenClawStateDatabaseByPath,
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
@@ -38,8 +43,24 @@ import {
 import { SKILL_WORKSHOP_ROLLBACK_SCHEMA, type SkillProposalRollback } from "./types.js";
 
 const tempDirs = createTrackedTempDirs();
+let stateDatabaseTemplate: OpenClawTestState | undefined;
+let stateDatabaseTemplatePath = "";
 let testState: OpenClawTestState;
 let stateDir = "";
+
+beforeAll(async () => {
+  const template = await createOpenClawTestState({
+    applyEnv: false,
+    layout: "state-only",
+    prefix: "openclaw-skill-workshop-template-",
+  });
+  stateDatabaseTemplate = template;
+  await listSkillProposals({ env: template.env });
+  const database = openOpenClawStateDatabase({ env: template.env });
+  database.db.exec("PRAGMA wal_checkpoint(TRUNCATE);");
+  stateDatabaseTemplatePath = database.path;
+  closeOpenClawStateDatabaseByPath(stateDatabaseTemplatePath);
+});
 
 beforeEach(async () => {
   testState = await createOpenClawTestState({
@@ -47,12 +68,19 @@ beforeEach(async () => {
     prefix: "openclaw-skill-workshop-state-",
   });
   stateDir = testState.stateDir;
+  const databasePath = resolveOpenClawStateSqlitePath(testState.env);
+  await fs.mkdir(path.dirname(databasePath), { recursive: true });
+  await fs.copyFile(stateDatabaseTemplatePath, databasePath);
 });
 
 afterEach(async () => {
   await testState.cleanup();
   resetSkillsRefreshStateForTest();
   await tempDirs.cleanup();
+});
+
+afterAll(async () => {
+  await stateDatabaseTemplate?.cleanup();
 });
 
 async function makeWorkspace(): Promise<string> {


### PR DESCRIPTION
## What Problem This Solves

Workshop and skill-research tests repeatedly create and tear down complete OpenClaw state databases even when their rows are already isolated by workspace or session identity. Across four files, 103 cases paid 103 state lifecycles and canonical schema creations.

## Why This Change Was Made

Workshop service cases retain isolated per-test roots but clone one closed production-created current-state database template. Evaluation and autocapture suites reuse one suite state while assigning unique workspaces and session identities. The eight autocapture eligibility cases now prove they return before session reads and therefore do not seed sessions they cannot consume.

No test declarations, shard topology, worker counts, scheduling, concurrency, or timeout settings change. Real SQLite persistence, routing, revision, auto-apply, and concurrency cases remain intact.

## User Impact

There is no product behavior change. Contributors and maintainers get faster skills/workshop test feedback with the same 103 expanded cases.

## Evidence

- Focused run: `node scripts/run-vitest.mjs src/skills/workshop/service.test.ts src/skills/workshop/service-evaluation.test.ts src/skills/research/autocapture.test.ts src/skills/research/autocapture-auto-apply.test.ts`
- Result: 4 files passed; 103/103 tests passed; Vitest duration 13.56s.
- OpenClaw test-state lifecycles: 103 → 51. Canonical state schema creation/open ownership: 103 → 4. Autocapture agent-database ownership: 35 → 2.
- Topology unchanged: 88 test declarations and 103 expanded runtime cases.
- Production delta: 0. Test delta: +91/−33.
- Direct `oxlint`, `oxfmt --check`, and `git diff --check` passed.
- Autoreview: clean, no accepted/actionable findings (`gpt-5.6-sol`, high reasoning).

This is an incremental step toward the frozen raw full-suite target; it does not claim normalized or final 30% success.
