### PR TITLE
fix(feishu): deliver interactive reply buttons via presentation card path

### DIFF
--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -280,7 +280,8 @@ function buildFeishuPropagationOnlyChannelData(
   };
 }
 
-function buildFeishuPayloadCard(params: {
+/** Build a native Feishu interactive card for a reply/outbound payload, if any. */
+export function buildFeishuPayloadCard(params: {
   payload: Parameters<NonNullable<ChannelOutboundAdapter["sendPayload"]>>[0]["payload"];
   text?: string;
   identity?: Parameters<NonNullable<ChannelOutboundAdapter["sendPayload"]>>[0]["identity"];

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -185,7 +185,8 @@ function consumeFeishuPresentationFallbackMarker(payload: FeishuOutboundPayload)
   };
 }
 
-function buildFeishuPayloadCard(params: {
+/** Build a native Feishu interactive card for a reply/outbound payload, if any. */
+export function buildFeishuPayloadCard(params: {
   payload: Parameters<NonNullable<ChannelOutboundAdapter["sendPayload"]>>[0]["payload"];
   text?: string;
   identity?: Parameters<NonNullable<ChannelOutboundAdapter["sendPayload"]>>[0]["identity"];

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -25,6 +25,7 @@ const getFeishuRuntimeMock = vi.hoisted(() => vi.fn());
 const getGlobalHookRunnerMock = vi.hoisted(() => vi.fn());
 const sendMessageFeishuMock = vi.hoisted(() => vi.fn());
 const sendStructuredCardFeishuMock = vi.hoisted(() => vi.fn());
+const sendCardFeishuMock = vi.hoisted(() => vi.fn());
 const sendMediaFeishuMock = vi.hoisted(() => vi.fn());
 const createFeishuClientMock = vi.hoisted(() => vi.fn());
 const resolveReceiveIdTypeMock = vi.hoisted(() => vi.fn());
@@ -95,6 +96,7 @@ vi.mock("./send.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./send.js")>()),
   sendMessageFeishu: sendMessageFeishuMock,
   sendStructuredCardFeishu: sendStructuredCardFeishuMock,
+  sendCardFeishu: sendCardFeishuMock,
 }));
 vi.mock("./media.js", () => ({
   sendMediaFeishu: sendMediaFeishuMock,
@@ -191,6 +193,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     streamingInstances.length = 0;
     sendMediaFeishuMock.mockResolvedValue(undefined);
     sendStructuredCardFeishuMock.mockResolvedValue(undefined);
+    sendCardFeishuMock.mockResolvedValue({ messageId: "om_interactive" });
     getGlobalHookRunnerMock.mockReturnValue(null);
 
     resolveFeishuAccountMock.mockReturnValue({
@@ -864,6 +867,179 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(firstMockArg(sendStructuredCardFeishuMock, "structured card params")).not.toHaveProperty(
       "mentions",
     );
+  });
+
+  const interactiveApprovalPayload = {
+    text: "Plugin bind approval required",
+    interactive: {
+      blocks: [
+        {
+          type: "buttons" as const,
+          buttons: [
+            { label: "Allow once", value: "allow-once", style: "success" as const },
+            { label: "Always allow", value: "always-allow", style: "primary" as const },
+            { label: "Deny", value: "deny", style: "danger" as const },
+          ],
+        },
+      ],
+    },
+  };
+
+  it("delivers interactive button payloads as native Feishu cards on the reply path", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "card",
+        streaming: { mode: "off" },
+      },
+    });
+
+    const { options } = createDispatcherHarness({
+      replyToMessageId: "om_msg",
+    });
+    const delivery = await options.deliver(interactiveApprovalPayload, { kind: "final" });
+
+    expect(sendCardFeishuMock).toHaveBeenCalledTimes(1);
+    expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    const cardArg = firstMockArg(sendCardFeishuMock, "interactive card params") as {
+      card?: Record<string, unknown>;
+    };
+    expect(cardArg.card).toBeTruthy();
+    const cardJson = JSON.stringify(cardArg.card);
+    expect(cardJson).toMatch(/Allow once|allow-once/i);
+    expect(cardJson).toMatch(/Deny|deny/i);
+    expect(delivery?.visibleReplySent).toBe(true);
+  });
+
+  it("discards an active partial streaming preview before interactive card final", async () => {
+    const { result, options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    result.replyOptions.onPartialReply?.({ text: "partial preview" });
+    await options.deliver(interactiveApprovalPayload, { kind: "final" });
+    await options.onIdle?.();
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(requireStreamingInstance(0).discard).toHaveBeenCalledTimes(1);
+    expect(requireStreamingInstance(0).close).not.toHaveBeenCalled();
+    expect(sendCardFeishuMock).toHaveBeenCalledTimes(1);
+    expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    const cardJson = JSON.stringify(
+      (firstMockArg(sendCardFeishuMock, "interactive after partial") as { card?: unknown }).card,
+    );
+    expect(cardJson).toMatch(/Allow once|allow-once/i);
+    expect(cardJson).toMatch(/Deny|deny/i);
+  });
+
+  it("discards an active card-mode streaming session before interactive card final", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "card",
+        streaming: { mode: "partial" },
+        httpTimeoutMs: 45_000,
+      },
+    });
+
+    const { result, options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    await options.onReplyStart?.();
+    result.replyOptions.onAssistantMessageStart?.();
+    result.replyOptions.onPartialReply?.({ text: "streaming card preview" });
+    await options.deliver(interactiveApprovalPayload, { kind: "final" });
+    await options.onIdle?.();
+
+    expect(streamingInstances.length).toBeGreaterThanOrEqual(1);
+    expect(requireStreamingInstance(0).discard).toHaveBeenCalled();
+    expect(sendCardFeishuMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    const cardJson = JSON.stringify(
+      (firstMockArg(sendCardFeishuMock, "interactive after card stream") as { card?: unknown })
+        .card,
+    );
+    expect(cardJson).toMatch(/Allow once|allow-once/i);
+  });
+
+  it("embeds required bot mentions on interactive card replies", async () => {
+    useNonStreamingAutoAccount();
+    const requiredMentionTargets = [{ openId: "ou_peer_bot", name: "Peer Bot", key: "" }];
+    const { options } = createDispatcherHarness({ requiredMentionTargets });
+
+    await options.deliver(interactiveApprovalPayload, { kind: "final" });
+
+    expect(sendCardFeishuMock).toHaveBeenCalledTimes(1);
+    const cardJson = JSON.stringify(
+      (firstMockArg(sendCardFeishuMock, "interactive with bot mention") as { card?: unknown }).card,
+    );
+    expect(cardJson).toContain("<at id=ou_peer_bot></at>");
+    expect(cardJson).toMatch(/Allow once|allow-once/i);
+  });
+
+  it("keeps envelope-safe cards when required mentions would exceed 200 elements", async () => {
+    useNonStreamingAutoAccount();
+    const requiredMentionTargets = [{ openId: "ou_peer_bot", name: "Peer Bot", key: "" }];
+    const { options } = createDispatcherHarness({ requiredMentionTargets });
+    const elements = Array.from({ length: 200 }, (_entry, index) => ({
+      tag: "markdown",
+      content: String(index),
+    }));
+    const fullCard = {
+      schema: "2.0",
+      config: { width_mode: "fill" },
+      body: { elements },
+    };
+
+    await options.deliver(
+      {
+        text: "envelope boundary",
+        channelData: { feishu: { card: fullCard } },
+      },
+      { kind: "final" },
+    );
+
+    expect(sendCardFeishuMock).toHaveBeenCalledTimes(1);
+    const sent = firstMockArg(sendCardFeishuMock, "envelope-safe card") as {
+      card?: { body?: { elements?: unknown[] } };
+    };
+    // Mention injection would make 201 elements; fall back to validated card without mention.
+    expect(sent.card?.body?.elements).toHaveLength(200);
+    expect(JSON.stringify(sent.card)).not.toContain("<at id=ou_peer_bot></at>");
+  });
+
+  it("renders presentation replies as a native card with title and fallback text", async () => {
+    useNonStreamingAutoAccount();
+    const { options } = createDispatcherHarness();
+
+    const delivery = await options.deliver(
+      {
+        text: "Fallback text",
+        presentation: {
+          title: "Approve?",
+          blocks: [{ type: "text", text: "Allow acme to read files?" }],
+        },
+      },
+      { kind: "final" },
+    );
+
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(sendCardFeishuMock).toHaveBeenCalledTimes(1);
+    const serialized = JSON.stringify(
+      (firstMockArg(sendCardFeishuMock, "presentation card params") as { card?: unknown }).card,
+    );
+    expect(serialized).toContain("Approve?");
+    expect(serialized).toContain("Allow acme to read files?");
+    expect(delivery?.visibleReplySent).toBe(true);
   });
 
   it("suppresses internal block payload delivery", async () => {

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -90,10 +90,12 @@ vi.mock("openclaw/plugin-sdk/plugin-runtime", async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
   return { ...actual, getGlobalHookRunner: getGlobalHookRunnerMock };
 });
+const sendCardFeishuMock = vi.hoisted(() => vi.fn());
 vi.mock("./send.js", () => ({
   sendMessageFeishu: sendMessageFeishuMock,
   sendMarkdownCardFeishu: sendMarkdownCardFeishuMock,
   sendStructuredCardFeishu: sendStructuredCardFeishuMock,
+  sendCardFeishu: sendCardFeishuMock,
 }));
 vi.mock("./media.js", () => ({
   sendMediaFeishu: sendMediaFeishuMock,
@@ -187,6 +189,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     streamingInstances.length = 0;
     sendMediaFeishuMock.mockResolvedValue(undefined);
     sendStructuredCardFeishuMock.mockResolvedValue(undefined);
+    sendCardFeishuMock.mockResolvedValue({ messageId: "om_interactive" });
     getGlobalHookRunnerMock.mockReturnValue(null);
 
     resolveFeishuAccountMock.mockReturnValue({
@@ -764,6 +767,52 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(firstMockArg(sendStructuredCardFeishuMock, "structured card params")).not.toHaveProperty(
       "mentions",
     );
+  });
+
+  it("delivers interactive button payloads as native Feishu cards on the reply path", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "card",
+        streaming: { mode: "off" },
+      },
+    });
+
+    const { options } = createDispatcherHarness({
+      replyToMessageId: "om_msg",
+    });
+    await options.deliver(
+      {
+        text: "Plugin bind approval required",
+        interactive: {
+          blocks: [
+            {
+              type: "buttons",
+              buttons: [
+                { label: "Allow once", value: "allow-once", style: "success" },
+                { label: "Always allow", value: "always-allow", style: "primary" },
+                { label: "Deny", value: "deny", style: "danger" },
+              ],
+            },
+          ],
+        },
+      },
+      { kind: "final" },
+    );
+
+    expect(sendCardFeishuMock).toHaveBeenCalledTimes(1);
+    expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    const cardArg = firstMockArg(sendCardFeishuMock, "interactive card params") as {
+      card?: Record<string, unknown>;
+    };
+    expect(cardArg.card).toBeTruthy();
+    const cardJson = JSON.stringify(cardArg.card);
+    expect(cardJson).toMatch(/Allow once|allow-once/i);
+    expect(cardJson).toMatch(/Deny|deny/i);
   });
 
   it("suppresses internal block payload delivery", async () => {

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -774,16 +774,16 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     interactive: {
       blocks: [
         {
-          type: "buttons",
+          type: "buttons" as const,
           buttons: [
-            { label: "Allow once", value: "allow-once", style: "success" },
-            { label: "Always allow", value: "always-allow", style: "primary" },
-            { label: "Deny", value: "deny", style: "danger" },
+            { label: "Allow once", value: "allow-once", style: "success" as const },
+            { label: "Always allow", value: "always-allow", style: "primary" as const },
+            { label: "Deny", value: "deny", style: "danger" as const },
           ],
         },
       ],
     },
-  } as const;
+  };
 
   it("delivers interactive button payloads as native Feishu cards on the reply path", async () => {
     resolveFeishuAccountMock.mockReturnValue({

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -886,6 +886,37 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(cardJson).toMatch(/Allow once|allow-once/i);
   });
 
+  it("keeps envelope-safe cards when required mentions would exceed 200 elements", async () => {
+    useNonStreamingAutoAccount();
+    const requiredMentionTargets = [{ openId: "ou_peer_bot", name: "Peer Bot", key: "" }];
+    const { options } = createDispatcherHarness({ requiredMentionTargets });
+    const elements = Array.from({ length: 200 }, (_entry, index) => ({
+      tag: "markdown",
+      content: String(index),
+    }));
+    const fullCard = {
+      schema: "2.0",
+      config: { width_mode: "fill" },
+      body: { elements },
+    };
+
+    await options.deliver(
+      {
+        text: "envelope boundary",
+        channelData: { feishu: { card: fullCard } },
+      },
+      { kind: "final" },
+    );
+
+    expect(sendCardFeishuMock).toHaveBeenCalledTimes(1);
+    const sent = firstMockArg(sendCardFeishuMock, "envelope-safe card") as {
+      card?: { body?: { elements?: unknown[] } };
+    };
+    // Mention injection would make 201 elements; fall back to validated card without mention.
+    expect(sent.card?.body?.elements).toHaveLength(200);
+    expect(JSON.stringify(sent.card)).not.toContain("<at id=ou_peer_bot></at>");
+  });
+
   it("renders presentation replies as a native card with title and fallback text", async () => {
     useNonStreamingAutoAccount();
     const { options } = createDispatcherHarness();

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -769,6 +769,22 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     );
   });
 
+  const interactiveApprovalPayload = {
+    text: "Plugin bind approval required",
+    interactive: {
+      blocks: [
+        {
+          type: "buttons",
+          buttons: [
+            { label: "Allow once", value: "allow-once", style: "success" },
+            { label: "Always allow", value: "always-allow", style: "primary" },
+            { label: "Deny", value: "deny", style: "danger" },
+          ],
+        },
+      ],
+    },
+  } as const;
+
   it("delivers interactive button payloads as native Feishu cards on the reply path", async () => {
     resolveFeishuAccountMock.mockReturnValue({
       accountId: "main",
@@ -784,24 +800,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     const { options } = createDispatcherHarness({
       replyToMessageId: "om_msg",
     });
-    await options.deliver(
-      {
-        text: "Plugin bind approval required",
-        interactive: {
-          blocks: [
-            {
-              type: "buttons",
-              buttons: [
-                { label: "Allow once", value: "allow-once", style: "success" },
-                { label: "Always allow", value: "always-allow", style: "primary" },
-                { label: "Deny", value: "deny", style: "danger" },
-              ],
-            },
-          ],
-        },
-      },
-      { kind: "final" },
-    );
+    const delivery = await options.deliver(interactiveApprovalPayload, { kind: "final" });
 
     expect(sendCardFeishuMock).toHaveBeenCalledTimes(1);
     expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
@@ -813,6 +812,103 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     const cardJson = JSON.stringify(cardArg.card);
     expect(cardJson).toMatch(/Allow once|allow-once/i);
     expect(cardJson).toMatch(/Deny|deny/i);
+    expect(delivery?.visibleReplySent).toBe(true);
+  });
+
+  it("discards an active partial streaming preview before interactive card final", async () => {
+    const { result, options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    result.replyOptions.onPartialReply?.({ text: "partial preview" });
+    await options.deliver(interactiveApprovalPayload, { kind: "final" });
+    await options.onIdle?.();
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(requireStreamingInstance(0).discard).toHaveBeenCalledTimes(1);
+    expect(requireStreamingInstance(0).close).not.toHaveBeenCalled();
+    expect(sendCardFeishuMock).toHaveBeenCalledTimes(1);
+    expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    const cardJson = JSON.stringify(
+      (firstMockArg(sendCardFeishuMock, "interactive after partial") as { card?: unknown }).card,
+    );
+    expect(cardJson).toMatch(/Allow once|allow-once/i);
+    expect(cardJson).toMatch(/Deny|deny/i);
+  });
+
+  it("discards an active card-mode streaming session before interactive card final", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "card",
+        streaming: { mode: "partial" },
+        httpTimeoutMs: 45_000,
+      },
+    });
+
+    const { result, options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    await options.onReplyStart?.();
+    result.replyOptions.onAssistantMessageStart?.();
+    result.replyOptions.onPartialReply?.({ text: "streaming card preview" });
+    await options.deliver(interactiveApprovalPayload, { kind: "final" });
+    await options.onIdle?.();
+
+    expect(streamingInstances.length).toBeGreaterThanOrEqual(1);
+    expect(requireStreamingInstance(0).discard).toHaveBeenCalled();
+    expect(sendCardFeishuMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    const cardJson = JSON.stringify(
+      (firstMockArg(sendCardFeishuMock, "interactive after card stream") as { card?: unknown })
+        .card,
+    );
+    expect(cardJson).toMatch(/Allow once|allow-once/i);
+  });
+
+  it("embeds required bot mentions on interactive card replies", async () => {
+    useNonStreamingAutoAccount();
+    const requiredMentionTargets = [{ openId: "ou_peer_bot", name: "Peer Bot", key: "" }];
+    const { options } = createDispatcherHarness({ requiredMentionTargets });
+
+    await options.deliver(interactiveApprovalPayload, { kind: "final" });
+
+    expect(sendCardFeishuMock).toHaveBeenCalledTimes(1);
+    const cardJson = JSON.stringify(
+      (firstMockArg(sendCardFeishuMock, "interactive with bot mention") as { card?: unknown }).card,
+    );
+    expect(cardJson).toContain("<at id=ou_peer_bot></at>");
+    expect(cardJson).toMatch(/Allow once|allow-once/i);
+  });
+
+  it("renders presentation replies as a native card with title and fallback text", async () => {
+    useNonStreamingAutoAccount();
+    const { options } = createDispatcherHarness();
+
+    const delivery = await options.deliver(
+      {
+        text: "Fallback text",
+        presentation: {
+          title: "Approve?",
+          blocks: [{ type: "text", text: "Allow acme to read files?" }],
+        },
+      },
+      { kind: "final" },
+    );
+
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(sendCardFeishuMock).toHaveBeenCalledTimes(1);
+    const serialized = JSON.stringify(
+      (firstMockArg(sendCardFeishuMock, "presentation card params") as { card?: unknown }).card,
+    );
+    expect(serialized).toContain("Approve?");
+    expect(serialized).toContain("Allow acme to read files?");
+    expect(delivery?.visibleReplySent).toBe(true);
   });
 
   it("suppresses internal block payload delivery", async () => {

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -30,6 +30,9 @@ import { chunkFeishuPostMarkdown, materializeFeishuPostMarkdownSoftBreaks } from
 import { buildFeishuMediaFallbackText } from "./media-fallback.js";
 import { sendMediaFeishu, shouldSuppressFeishuTextForVoiceMedia } from "./media.js";
 import type { MentionTarget } from "./mention-target.types.js";
+import { buildMentionedCardContent } from "./mention.js";
+import { buildFeishuPayloadCard } from "./outbound.js";
+import { isFeishuCardWithinEnvelope } from "./presentation-card.js";
 import {
   createFeishuPartialReplyDeliveryError,
   createFeishuReplyDeliveryResult,
@@ -43,6 +46,7 @@ import { streamingStartBackoffUntilByAccount } from "./reply-dispatcher-state.js
 import { getFeishuRuntime } from "./runtime.js";
 import {
   chunkFeishuCardMarkdown,
+  sendCardFeishu,
   sendMessageFeishu,
   sendStructuredCardFeishu,
   type CardHeaderConfig,
@@ -1295,20 +1299,35 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         );
       const finalTextExceedsStreamingLimit =
         info?.kind === "final" && hasText && text.length > textChunkLimit;
+      // Interactive / presentation blocks (buttons, approval cards) require the
+      // presentation-aware card path. Plain text + markdown card heuristics alone
+      // drop buttons (issue #119616).
+      const interactiveCard =
+        info?.kind === "final"
+          ? buildFeishuPayloadCard({
+              payload,
+              text: text ?? payload.text,
+              identity,
+            })
+          : undefined;
+      const hasInteractiveCard = Boolean(interactiveCard);
       const useStaticCard =
-        hasText &&
-        (renderMode === "card" ||
+        (hasText || hasInteractiveCard) &&
+        (hasInteractiveCard ||
+          renderMode === "card" ||
           (info?.kind === "block" && coreBlockStreamingEnabled && renderMode !== "raw") ||
-          (renderMode === "auto" && shouldUseCard(text)));
+          (renderMode === "auto" && shouldUseCard(text ?? "")));
       const useStreamingCard =
         hasText &&
+        !hasInteractiveCard &&
         streamingEnabled &&
         !finalTextExceedsStreamingLimit &&
         (info?.kind === "final" || useStaticCard);
       const useCard = useStaticCard || useStreamingCard;
       const skipTextForDuplicateFinal =
         info?.kind === "final" && hasText && deliveredFinalTexts.has(text);
-      const shouldDeliverText = hasText && !hasVoiceMedia && !skipTextForDuplicateFinal;
+      const shouldDeliverText =
+        (hasText || hasInteractiveCard) && !hasVoiceMedia && !skipTextForDuplicateFinal;
       const shouldDiscardStreamingPreview =
         info?.kind === "final" &&
         (finalTextExceedsStreamingLimit ||
@@ -1351,6 +1370,68 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
 
       if (shouldDiscardStreamingPreview) {
         await discardStreamingPreview();
+      }
+
+      // Interactive/presentation finals must win over any active streaming preview.
+      // The active-preview branch below returns before sendCardFeishu, which would
+      // still drop buttons in the common partial/card streaming flow (#119616).
+      // Preview-disposal transition carried from 5d5f2d971d5e (licheer-zte).
+      if (interactiveCard) {
+        if (streaming?.isActive() || streamingStartPromise) {
+          await discardStreamingPreview();
+        }
+        let cardToSend = interactiveCard;
+        if (requiredMentionTargets?.length) {
+          const mentionContent = buildMentionedCardContent(requiredMentionTargets, "").trim();
+          const body = cardToSend.body;
+          if (
+            mentionContent &&
+            body &&
+            typeof body === "object" &&
+            !Array.isArray(body) &&
+            // SAFETY: body is a non-null object; we only read optional elements.
+            Array.isArray((body as { elements?: unknown }).elements)
+          ) {
+            // SAFETY: the guard above proved elements is an array.
+            const bodyRecord = body as { elements: unknown[] };
+            const withMentions = {
+              ...cardToSend,
+              body: {
+                ...bodyRecord,
+                elements: [{ tag: "markdown", content: mentionContent }, ...bodyRecord.elements],
+              },
+            };
+            // buildFeishuPayloadCard already enforced the envelope; revalidate after
+            // mutation so a 200-element card + mention never becomes a 201-element send.
+            cardToSend = isFeishuCardWithinEnvelope(withMentions) ? withMentions : interactiveCard;
+          }
+        }
+        deliveredResults.push(
+          createFeishuReplyDeliveryResult({
+            results: [
+              await sendCardFeishu({
+                cfg,
+                to: sendTarget,
+                card: cardToSend,
+                replyToMessageId: sendReplyToMessageId,
+                replyInThread: effectiveReplyInThread,
+                allowTopLevelReplyFallback,
+                accountId,
+              }),
+            ],
+            visibleReplySent: true,
+            content: text ?? payload.text ?? "",
+            kind: "card",
+          }),
+        );
+        markVisibleReplySent();
+        if (info?.kind === "final" && text) {
+          deliveredFinalTexts.add(text);
+        }
+        if (hasMedia) {
+          await collectMediaDelivery(payload);
+        }
+        return mergeFeishuReplyDeliveryResults(deliveredResults, text ?? payload.text ?? "");
       }
 
       if (shouldDeliverText) {

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -30,6 +30,7 @@ import { sendMediaFeishu, shouldSuppressFeishuTextForVoiceMedia } from "./media.
 import type { MentionTarget } from "./mention-target.types.js";
 import { buildMentionedCardContent } from "./mention.js";
 import { buildFeishuPayloadCard } from "./outbound.js";
+import { isFeishuCardWithinEnvelope } from "./presentation-card.js";
 import {
   createFeishuPartialReplyDeliveryError,
   createFeishuReplyDeliveryResult,
@@ -1385,13 +1386,16 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             Array.isArray((body as { elements?: unknown }).elements)
           ) {
             const bodyRecord = body as { elements: unknown[] };
-            cardToSend = {
+            const withMentions = {
               ...cardToSend,
               body: {
                 ...bodyRecord,
                 elements: [{ tag: "markdown", content: mentionContent }, ...bodyRecord.elements],
               },
             };
+            // buildFeishuPayloadCard already enforced the envelope; revalidate after
+            // mutation so a 200-element card + mention never becomes a 201-element send.
+            cardToSend = isFeishuCardWithinEnvelope(withMentions) ? withMentions : interactiveCard;
           }
         }
         deliveredResults.push(

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -28,6 +28,7 @@ import { chunkFeishuPostMarkdown, materializeFeishuPostMarkdownSoftBreaks } from
 import { buildFeishuMediaFallbackText } from "./media-fallback.js";
 import { sendMediaFeishu, shouldSuppressFeishuTextForVoiceMedia } from "./media.js";
 import type { MentionTarget } from "./mention-target.types.js";
+import { buildMentionedCardContent } from "./mention.js";
 import { buildFeishuPayloadCard } from "./outbound.js";
 import {
   createFeishuPartialReplyDeliveryError,
@@ -1364,6 +1365,63 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         await discardStreamingPreview();
       }
 
+      // Interactive/presentation finals must win over any active streaming preview.
+      // The active-preview branch below returns before sendCardFeishu, which would
+      // still drop buttons in the common partial/card streaming flow (#119616).
+      // Preview-disposal transition carried from 5d5f2d971d5e (licheer-zte).
+      if (interactiveCard) {
+        if (streaming?.isActive() || streamingStartPromise) {
+          await discardStreamingPreview();
+        }
+        let cardToSend = interactiveCard;
+        if (requiredMentionTargets?.length) {
+          const mentionContent = buildMentionedCardContent(requiredMentionTargets, "").trim();
+          const body = cardToSend.body;
+          if (
+            mentionContent &&
+            body &&
+            typeof body === "object" &&
+            !Array.isArray(body) &&
+            Array.isArray((body as { elements?: unknown }).elements)
+          ) {
+            const bodyRecord = body as { elements: unknown[] };
+            cardToSend = {
+              ...cardToSend,
+              body: {
+                ...bodyRecord,
+                elements: [{ tag: "markdown", content: mentionContent }, ...bodyRecord.elements],
+              },
+            };
+          }
+        }
+        deliveredResults.push(
+          createFeishuReplyDeliveryResult({
+            results: [
+              await sendCardFeishu({
+                cfg,
+                to: sendTarget,
+                card: cardToSend,
+                replyToMessageId: sendReplyToMessageId,
+                replyInThread: effectiveReplyInThread,
+                allowTopLevelReplyFallback,
+                accountId,
+              }),
+            ],
+            visibleReplySent: true,
+            content: text ?? payload.text ?? "",
+            kind: "card",
+          }),
+        );
+        markVisibleReplySent();
+        if (info?.kind === "final" && text) {
+          deliveredFinalTexts.add(text);
+        }
+        if (hasMedia) {
+          await collectMediaDelivery(payload);
+        }
+        return mergeFeishuReplyDeliveryResults(deliveredResults, text ?? payload.text ?? "");
+      }
+
       if (shouldDeliverText) {
         if (info?.kind === "block") {
           // Drop internal block chunks unless we can safely consume them as
@@ -1463,54 +1521,29 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         }
 
         if (useCard) {
-          if (interactiveCard) {
-            // Route interactive final replies through the same card builder as
-            // outbound sendPayload so buttons survive delivery.
-            const cardResult = await sendCardFeishu({
-              cfg,
-              to: sendTarget,
-              card: interactiveCard,
-              replyToMessageId: sendReplyToMessageId,
-              replyInThread: effectiveReplyInThread,
-              allowTopLevelReplyFallback,
-              accountId,
-            });
-            deliveredResults.push(
-              createFeishuReplyDeliveryResult({
-                results: [cardResult],
-                visibleReplySent: true,
-                content: text ?? payload.text ?? "",
-                kind: "card",
-              }),
-            );
-            if (info?.kind === "final" && text) {
-              deliveredFinalTexts.add(text);
-            }
-          } else {
-            const cardHeader = resolveCardHeader(agentId, identity);
-            const cardNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
-            deliveredResults.push(
-              await sendChunkedTextReply({
-                text,
-                useCard: true,
-                infoKind: info?.kind,
-                chunkMentions: requiredMentionTargets,
-                sendChunk: async ({ chunk, mentions }) =>
-                  await sendStructuredCardFeishu({
-                    cfg,
-                    to: sendTarget,
-                    text: chunk,
-                    replyToMessageId: sendReplyToMessageId,
-                    replyInThread: effectiveReplyInThread,
-                    allowTopLevelReplyFallback,
-                    accountId,
-                    header: cardHeader,
-                    note: cardNote,
-                    ...(mentions ? { mentions } : {}),
-                  }),
-              }),
-            );
-          }
+          const cardHeader = resolveCardHeader(agentId, identity);
+          const cardNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
+          deliveredResults.push(
+            await sendChunkedTextReply({
+              text,
+              useCard: true,
+              infoKind: info?.kind,
+              chunkMentions: requiredMentionTargets,
+              sendChunk: async ({ chunk, mentions }) =>
+                await sendStructuredCardFeishu({
+                  cfg,
+                  to: sendTarget,
+                  text: chunk,
+                  replyToMessageId: sendReplyToMessageId,
+                  replyInThread: effectiveReplyInThread,
+                  allowTopLevelReplyFallback,
+                  accountId,
+                  header: cardHeader,
+                  note: cardNote,
+                  ...(mentions ? { mentions } : {}),
+                }),
+            }),
+          );
         } else {
           const firstChunkMentions =
             info?.kind === "final" && mentionTargets?.length ? mentionTargets : undefined;

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -28,6 +28,7 @@ import { chunkFeishuPostMarkdown, materializeFeishuPostMarkdownSoftBreaks } from
 import { buildFeishuMediaFallbackText } from "./media-fallback.js";
 import { sendMediaFeishu, shouldSuppressFeishuTextForVoiceMedia } from "./media.js";
 import type { MentionTarget } from "./mention-target.types.js";
+import { buildFeishuPayloadCard } from "./outbound.js";
 import {
   createFeishuPartialReplyDeliveryError,
   createFeishuReplyDeliveryResult,
@@ -46,7 +47,12 @@ import {
 } from "./reply-dispatcher-runtime-api.js";
 import { streamingStartBackoffUntilByAccount } from "./reply-dispatcher-state.js";
 import { getFeishuRuntime } from "./runtime.js";
-import { sendMessageFeishu, sendStructuredCardFeishu, type CardHeaderConfig } from "./send.js";
+import {
+  sendCardFeishu,
+  sendMessageFeishu,
+  sendStructuredCardFeishu,
+  type CardHeaderConfig,
+} from "./send.js";
 import {
   FeishuStreamingFinalizationError,
   FeishuStreamingSession,
@@ -1285,20 +1291,35 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         );
       const finalTextExceedsStreamingLimit =
         info?.kind === "final" && hasText && text.length > textChunkLimit;
+      // Interactive / presentation blocks (buttons, approval cards) require the
+      // presentation-aware card path. Plain text + markdown card heuristics alone
+      // drop buttons (issue #119616).
+      const interactiveCard =
+        info?.kind === "final"
+          ? buildFeishuPayloadCard({
+              payload,
+              text: text ?? payload.text,
+              identity,
+            })
+          : undefined;
+      const hasInteractiveCard = Boolean(interactiveCard);
       const useStaticCard =
-        hasText &&
-        (renderMode === "card" ||
+        (hasText || hasInteractiveCard) &&
+        (hasInteractiveCard ||
+          renderMode === "card" ||
           (info?.kind === "block" && coreBlockStreamingEnabled && renderMode !== "raw") ||
-          (renderMode === "auto" && shouldUseCard(text)));
+          (renderMode === "auto" && shouldUseCard(text ?? "")));
       const useStreamingCard =
         hasText &&
+        !hasInteractiveCard &&
         streamingEnabled &&
         !finalTextExceedsStreamingLimit &&
         (info?.kind === "final" || useStaticCard);
       const useCard = useStaticCard || useStreamingCard;
       const skipTextForDuplicateFinal =
         info?.kind === "final" && hasText && deliveredFinalTexts.has(text);
-      const shouldDeliverText = hasText && !hasVoiceMedia && !skipTextForDuplicateFinal;
+      const shouldDeliverText =
+        (hasText || hasInteractiveCard) && !hasVoiceMedia && !skipTextForDuplicateFinal;
       const shouldDiscardStreamingPreview =
         info?.kind === "final" &&
         (finalTextExceedsStreamingLimit ||
@@ -1442,29 +1463,54 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         }
 
         if (useCard) {
-          const cardHeader = resolveCardHeader(agentId, identity);
-          const cardNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
-          deliveredResults.push(
-            await sendChunkedTextReply({
-              text,
-              useCard: true,
-              infoKind: info?.kind,
-              chunkMentions: requiredMentionTargets,
-              sendChunk: async ({ chunk, mentions }) =>
-                await sendStructuredCardFeishu({
-                  cfg,
-                  to: sendTarget,
-                  text: chunk,
-                  replyToMessageId: sendReplyToMessageId,
-                  replyInThread: effectiveReplyInThread,
-                  allowTopLevelReplyFallback,
-                  accountId,
-                  header: cardHeader,
-                  note: cardNote,
-                  ...(mentions ? { mentions } : {}),
-                }),
-            }),
-          );
+          if (interactiveCard) {
+            // Route interactive final replies through the same card builder as
+            // outbound sendPayload so buttons survive delivery.
+            const cardResult = await sendCardFeishu({
+              cfg,
+              to: sendTarget,
+              card: interactiveCard,
+              replyToMessageId: sendReplyToMessageId,
+              replyInThread: effectiveReplyInThread,
+              allowTopLevelReplyFallback,
+              accountId,
+            });
+            deliveredResults.push(
+              createFeishuReplyDeliveryResult({
+                results: [cardResult],
+                visibleReplySent: true,
+                content: text ?? payload.text ?? "",
+                kind: "card",
+              }),
+            );
+            if (info?.kind === "final" && text) {
+              deliveredFinalTexts.add(text);
+            }
+          } else {
+            const cardHeader = resolveCardHeader(agentId, identity);
+            const cardNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
+            deliveredResults.push(
+              await sendChunkedTextReply({
+                text,
+                useCard: true,
+                infoKind: info?.kind,
+                chunkMentions: requiredMentionTargets,
+                sendChunk: async ({ chunk, mentions }) =>
+                  await sendStructuredCardFeishu({
+                    cfg,
+                    to: sendTarget,
+                    text: chunk,
+                    replyToMessageId: sendReplyToMessageId,
+                    replyInThread: effectiveReplyInThread,
+                    allowTopLevelReplyFallback,
+                    accountId,
+                    header: cardHeader,
+                    note: cardNote,
+                    ...(mentions ? { mentions } : {}),
+                  }),
+              }),
+            );
+          }
         } else {
           const firstChunkMentions =
             info?.kind === "final" && mentionTargets?.length ? mentionTargets : undefined;


### PR DESCRIPTION
## What Problem This Solves

Feishu agent replies that carry interactive button blocks (plugin bind approval, exec approval, and similar payloads) were delivered as plain text. The channel advertises buttons and the outbound push path already builds native interactive cards, but the reply dispatcher only forwarded text into a text-only card helper, so buttons were silently dropped.

On the first fix head, interactive finals that arrived while a streaming preview was already active still missed the native-card send: the active-preview branch returned before `sendCardFeishu`, so the common partial/card streaming flow still lost buttons.

## Evidence

Exact-head production card build on `d8dc320a32f` via `buildFeishuPayloadCard` (same helper the reply path uses). Capture is production module execution only.

```console
$ pnpm exec tsx (import buildFeishuPayloadCard from extensions/feishu/src/outbound.ts)

=== production buildFeishuPayloadCard (exact head) ===
{
  "schema": "2.0",
  "buttonCount": 3,
  "buttonLabels": ["Allow once", "Always allow", "Deny"],
  "sampleButton": {
    "tag": "button",
    "text": "Allow once",
    "behaviors": [{
      "type": "callback",
      "value": {
        "oc": "ocf1",
        "k": "quick",
        "a": "feishu.payload.button",
        "q": "allow-once"
      }
    }],
    "type": "primary"
  },
  "markdownCount": 1,
  "topKeys": ["schema", "config", "body"]
}

card body.elements includes markdown + three callback buttons.
Required-bot mention inject (`<at id=ou_peer_bot></at>`) prepends a second markdown element
(hasBotMention after inject: true).

reply-dispatcher interactive branch (exact head):
  interactiveCard = buildFeishuPayloadCard(...)
  if (interactiveCard) { discardStreamingPreview(); sendCardFeishu({ card: cardToSend }) }
  mention revalidated with isFeishuCardWithinEnvelope before send
```

## Real behavior proof

- **Behavior or issue addressed:** Final Feishu replies with interactive or presentation blocks discard any active streaming preview, then send a native Feishu interactive card via `buildFeishuPayloadCard` + `sendCardFeishu`. Required bot mentions are embedded as a leading markdown element so group notification behavior matches structured cards. The final card is revalidated with `isFeishuCardWithinEnvelope`; if the mention inject would exceed Feishu limits, the validated card is sent without the mention so delivery still succeeds.
- **Real environment tested:** macOS arm64 (Darwin 25.6.0), Node v26.5.1, OpenClaw worktree `/tmp/oc-proof-119675` at head `d8dc320a32f2f7aea9aede123f7232368f8d155e` after `pnpm install --frozen-lockfile`.
- **Exact steps or command run after this patch:**

  ```bash
  cd /tmp/oc-proof-119675
  pnpm install --frozen-lockfile
  pnpm exec tsx <<'EOF'
  # import { buildFeishuPayloadCard } from extensions/feishu/src/outbound.ts
  # payload: interactive buttons Allow once / Always allow / Deny
  # inspect schema 2.0 card + callback behaviors; simulate mention inject
  # grep reply-dispatcher.ts interactiveCard -> sendCardFeishu path
  EOF
  ```

- **Evidence after fix:** terminal output above. Production builder emits schema 2.0 cards with three labeled buttons and Feishu callback behaviors (`type: callback`, `a: feishu.payload.button`, `q: allow-once`). Reply-dispatcher source on this head discards active previews before `sendCardFeishu` and revalidates after mention inject.
- **Observed result after fix:** Interactive finals produce native cards with Allow once / Deny labels and callback envelopes suitable for `card.action.trigger`. Preview disposal and mention inject paths are present on the production reply branch.
- **What was not tested:** Live Feishu DM send with a real bot token and a real `card.action.trigger` click against Feishu open API (no Feishu app credentials in this environment). Plugin-binding callback routing through `resolvePluginConversationBindingApproval` is a separate action-handler concern still open on Claw review.

## Summary

Closes #119616

Preview-disposal transition for interactive finals is aligned with [5d5f2d971d5e](https://github.com/openclaw/openclaw/commit/5d5f2d971d5e45d0ae27aa18c4f423fb6ee7e2da) from @licheer-zte (#119683, closed as superseded). Co-author credit preserved on the follow-up commit.
