### PR TITLE
fix(codex): prefer native image viewing when available

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -276,6 +276,30 @@ describe("Codex app-server dynamic tool build", () => {
     ]);
   });
 
+  it.each([
+    { nativeToolSurfaceEnabled: true, expected: ["message"] },
+    { nativeToolSurfaceEnabled: false, expected: ["image", "message"] },
+  ])(
+    "uses the available image viewer when native tools are $nativeToolSurfaceEnabled",
+    async ({ nativeToolSurfaceEnabled, expected }) => {
+      const workspaceDir = path.join(tempDir, "workspace");
+      const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+      params.disableTools = false;
+      params.model = createCodexTestModel("codex", ["text", "image"]);
+      params.runtimePlan = createCodexRuntimePlanFixture();
+      setOpenClawCodingToolsFactoryForTests(() => [
+        createRuntimeDynamicTool("image"),
+        createRuntimeDynamicTool("message"),
+      ]);
+
+      const tools = await buildDynamicToolsForTest(params, workspaceDir, {
+        nativeToolSurfaceEnabled,
+      });
+
+      expect(tools.map((tool) => tool.name)).toEqual(expected);
+    },
+  );
+
   it("removes managed web_search when domain-restricted Codex hosted search is active", async () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -45,7 +45,7 @@ import {
   createNodeProcessDynamicTool,
   isCodexDynamicToolExcluded,
 } from "./shell-dynamic-tools.js";
-import { filterToolsForVisionInputs } from "./vision-tools.js";
+import { filterCodexVisionTools } from "./vision-tools.js";
 import { resolveCodexWebSearchPlan, type CodexNativeWebSearchSupport } from "./web-search.js";
 
 type OpenClawCodingToolsOptions = NonNullable<
@@ -375,9 +375,10 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
     nativeExecutionPolicy,
   );
   toolBuildStages.mark("codex-filtering");
-  const visionFilteredTools = filterToolsForVisionInputs(codexFilteredTools, {
+  const visionFilteredTools = filterCodexVisionTools(codexFilteredTools, {
     modelHasVision,
     hasInboundImages: (params.images?.length ?? 0) > 0,
+    nativeToolSurfaceEnabled: input.nativeToolSurfaceEnabled === true,
   });
   toolBuildStages.mark("vision-filtering");
   const webSearchPresent = visionFilteredTools.some((tool) => tool.name === "web_search");

--- a/extensions/codex/src/app-server/run-attempt.vision-tools.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.vision-tools.test.ts
@@ -1,14 +1,15 @@
 // Codex tests cover run attempt.vision tools plugin behavior.
 import { describe, expect, it } from "vitest";
-import { filterToolsForVisionInputs } from "./vision-tools.js";
+import { filterCodexVisionTools } from "./vision-tools.js";
 
 describe("Codex dynamic tool filtering", () => {
   it("drops the image tool when the model already has inbound vision input", () => {
-    const toolNames = filterToolsForVisionInputs(
+    const toolNames = filterCodexVisionTools(
       [{ name: "image" }, { name: "read" }, { name: "write" }],
       {
         modelHasVision: true,
         hasInboundImages: true,
+        nativeToolSurfaceEnabled: false,
       },
     ).map((tool) => tool.name);
 
@@ -17,19 +18,33 @@ describe("Codex dynamic tool filtering", () => {
     expect(toolNames).not.toContain("image");
   });
 
-  it("keeps the image tool unless both model vision and inbound images are present", () => {
+  it("uses native Codex image viewing even when the turn begins without images", () => {
+    const tools = [{ name: "image" }, { name: "message" }];
+
+    expect(
+      filterCodexVisionTools(tools, {
+        modelHasVision: true,
+        hasInboundImages: false,
+        nativeToolSurfaceEnabled: true,
+      }),
+    ).toEqual([{ name: "message" }]);
+  });
+
+  it("keeps OpenClaw image analysis when Codex cannot inspect the image itself", () => {
     const tools = [{ name: "image" }, { name: "read" }];
 
     expect(
-      filterToolsForVisionInputs(tools, {
+      filterCodexVisionTools(tools, {
         modelHasVision: false,
         hasInboundImages: true,
+        nativeToolSurfaceEnabled: true,
       }),
     ).toBe(tools);
     expect(
-      filterToolsForVisionInputs(tools, {
+      filterCodexVisionTools(tools, {
         modelHasVision: true,
         hasInboundImages: false,
+        nativeToolSurfaceEnabled: false,
       }),
     ).toBe(tools);
   });

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -116,7 +116,7 @@ import {
   resolveCodexBindingModelProviderFallback,
   resolveReasoningEffort,
 } from "./thread-lifecycle.js";
-import { filterToolsForVisionInputs } from "./vision-tools.js";
+import { filterCodexVisionTools } from "./vision-tools.js";
 import {
   resolveCodexWebSearchPlan,
   type CodexNativeWebSearchSupport,
@@ -1022,9 +1022,10 @@ async function createCodexSideToolBridge(input: {
       requireExplicitMessageTarget: true,
     });
     const codexFilteredTools = filterCodexDynamicTools(allTools, input.pluginConfig);
-    tools = filterToolsForVisionInputs(codexFilteredTools, {
+    tools = filterCodexVisionTools(codexFilteredTools, {
       modelHasVision: runtimeModel.input?.includes("image") ?? false,
       hasInboundImages: false,
+      nativeToolSurfaceEnabled: input.nativeToolSurfaceEnabled,
     });
   }
   const requestedWebSearchPlan = resolveCodexWebSearchPlan({

--- a/extensions/codex/src/app-server/vision-tools.ts
+++ b/extensions/codex/src/app-server/vision-tools.ts
@@ -1,16 +1,13 @@
-/**
- * Filters Codex dynamic tools for turns that already contain image inputs so
- * models with native vision do not get redundant image-inspection tools.
- */
-/** Removes the image tool when the model can directly consume inbound images. */
-export function filterToolsForVisionInputs<T extends { name?: string }>(
+/** Keeps OpenClaw's image tool only when Codex cannot inspect images itself. */
+export function filterCodexVisionTools<T extends { name?: string }>(
   tools: T[],
   params: {
     modelHasVision: boolean;
     hasInboundImages: boolean;
+    nativeToolSurfaceEnabled: boolean;
   },
 ): T[] {
-  if (!params.modelHasVision || !params.hasInboundImages) {
+  if (!params.modelHasVision || !(params.hasInboundImages || params.nativeToolSurfaceEnabled)) {
     return tools;
   }
   return tools.filter((tool) => tool.name !== "image");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Codex-backed agents inspecting a local image could choose a duplicate OpenClaw image tool even though Codex already provided a native viewer attached to its execution environment. When the gateway and execution environment have different filesystem or network access, the duplicate tool can fail unnecessarily or send the agent down a more complicated path.

## Why This Change Was Made

Hide the redundant OpenClaw image tool whenever an image-capable Codex model has its native tool surface available. Preserve the OpenClaw image tool for text-only models and for environments where native image viewing is unavailable, while keeping the existing direct-image-input behavior intact.

## User Impact

Codex-backed agents inspect local images directly in their actual execution environment, without duplicate image tools, gateway network failures, or avoidable image-transfer workarounds.

## Evidence

Focused coverage proves the native-viewer path, the text-only fallback, missing native environments, direct inbound images, and both normal and side-conversation tool construction. The affected suites passed 66 focused tests. Codex core also registers its native image viewer only when an execution environment exists, and its own integration coverage proves local and remote image paths. AI-assisted.