### PR TITLE
fix(ci): restore package Telegram beta validation

### DIFF
--- a/.github/workflows/npm-telegram-beta-e2e.yml
+++ b/.github/workflows/npm-telegram-beta-e2e.yml
@@ -231,6 +231,22 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           install-bun: "true"
 
+      - name: Build private QA harness
+        run: OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build
+
+      - name: Preflight private QA harness
+        shell: bash
+        run: |
+          set -euo pipefail
+          for entry in \
+            dist/plugin-sdk/qa-lab.js \
+            dist/plugin-sdk/qa-runtime.js; do
+            if [[ ! -f "$entry" ]]; then
+              echo "Trusted private QA harness is missing: $entry" >&2
+              exit 1
+            fi
+          done
+
       - name: Validate inputs and secrets
         env:
           PACKAGE_SPEC: ${{ inputs.package_spec }}

--- a/.github/workflows/package-acceptance.yml
+++ b/.github/workflows/package-acceptance.yml
@@ -930,7 +930,7 @@ jobs:
       package_source_sha: ${{ needs.resolve_package.outputs.package_source_sha }}
       package_version: ${{ needs.resolve_package.outputs.package_version }}
       package_label: openclaw@${{ needs.resolve_package.outputs.package_version }}
-      harness_ref: ${{ needs.resolve_package.outputs.package_source_sha || inputs.workflow_ref }}
+      harness_ref: ${{ inputs.workflow_ref }}
       provider_mode: ${{ needs.resolve_package.outputs.telegram_mode }}
       scenario: ${{ inputs.telegram_scenarios }}
     secrets:

--- a/extensions/qa-lab/src/gateway-child.test.ts
+++ b/extensions/qa-lab/src/gateway-child.test.ts
@@ -125,6 +125,77 @@ async function writeTempProviderConfig(value: unknown) {
   return configPath;
 }
 
+async function writePackagedGatewayFixture(root: string): Promise<string> {
+  const fixturePath = path.join(root, "packaged-gateway-fixture.mjs");
+  await writeFile(
+    fixturePath,
+    `import fs from "node:fs";
+import path from "node:path";
+
+const args = process.argv.slice(2);
+const recordPath = process.env.QA_RECORD_PATH;
+const configPath = process.env.OPENCLAW_CONFIG_PATH;
+const stateDir = process.env.OPENCLAW_STATE_DIR;
+if (!recordPath || !configPath || !stateDir) {
+  throw new Error("missing fixture environment");
+}
+const record = (value) => fs.appendFileSync(recordPath, JSON.stringify(value) + "\\n");
+if (args[0] === "models") {
+  let stdin = "";
+  process.stdin.setEncoding("utf8");
+  for await (const chunk of process.stdin) stdin += chunk;
+  const provider = args[args.indexOf("--provider") + 1];
+  record({
+    kind: "auth",
+    args,
+    stdin,
+    dbExists: fs.existsSync(path.join(stateDir, "agents", "qa", "agent", "openclaw-agent.sqlite")),
+    env: {
+      OPENCLAW_CLI: process.env.OPENCLAW_CLI,
+      OPENCLAW_CONFIG_PATH: configPath,
+      OPENCLAW_STATE_DIR: stateDir,
+    },
+  });
+  if (process.env.QA_FAIL_PROVIDER === provider) {
+    process.stderr.write("Authorization: Bearer " + stdin.trim());
+    process.exit(9);
+  }
+  const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+  config.fixtureProfiles = [...(config.fixtureProfiles ?? []), provider];
+  fs.writeFileSync(configPath, JSON.stringify(config));
+  process.exit(0);
+}
+const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+record({ kind: "gateway", args, fixtureProfiles: config.fixtureProfiles });
+process.stderr.write("fixture gateway exit");
+process.exit(17);
+`,
+    "utf8",
+  );
+  return fixturePath;
+}
+
+async function readJsonLines(filePath: string): Promise<Array<Record<string, unknown>>> {
+  const contents = await readFile(filePath, "utf8");
+  return contents
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+function collectErrorChainMessages(error: unknown): string {
+  const messages: string[] = [];
+  const seen = new Set<Error>();
+  let current = error;
+  while (current instanceof Error && !seen.has(current)) {
+    seen.add(current);
+    messages.push(current.message);
+    current = current.cause;
+  }
+  return messages.join("\n");
+}
+
 describe("runQaGatewayCliCommand", () => {
   it("runs CLI commands with the Gateway fixture environment", async () => {
     const output = await testing.runQaGatewayCliCommand({
@@ -139,6 +210,23 @@ describe("runQaGatewayCliCommand", () => {
     });
 
     expect(output).toBe("1:fixture:voicecall,start");
+  });
+
+  it("pipes bounded command input through stdin", async () => {
+    const output = await testing.runQaGatewayCliCommand({
+      executablePath: process.execPath,
+      argsPrefix: [
+        "--input-type=module",
+        "--eval",
+        'let input = ""; for await (const chunk of process.stdin) input += chunk; process.stdout.write(input)',
+      ],
+      args: [],
+      cwd: process.cwd(),
+      env: process.env,
+      stdin: "fixture-input\n",
+    });
+
+    expect(output).toBe("fixture-input\n");
   });
 
   it("reports CLI stderr when a fixture command fails", async () => {
@@ -493,7 +581,7 @@ describe("buildQaRuntimeEnv", () => {
         },
         transportBaseUrl: "http://127.0.0.1:43123",
       }),
-    ).rejects.toThrow(/gateway failed to spawn: .*ENOENT/u);
+    ).rejects.toThrow(/installed package mock auth bootstrap failed for openai: .*ENOENT/u);
 
     await expect(readdir(preferredTempParent)).resolves.toStrictEqual([]);
     await expect(readdir(commandTempParent)).resolves.toStrictEqual([]);
@@ -1284,6 +1372,161 @@ describe("buildQaRuntimeEnv", () => {
       expect(anthropicStoreProfile.provider).toBe("anthropic");
       expect(anthropicStoreProfile.key).toBe("qa-mock-not-a-real-key");
     }
+  });
+
+  it("builds mock auth config without creating agent state", async () => {
+    const stateDir = await tempDirs.makeTempDir("qa-mock-auth-config-only-");
+
+    const cfg = testing.applyQaMockAuthProfileConfig({
+      cfg: {},
+      providers: ["openai"],
+    });
+
+    expect(cfg.auth?.profiles?.["qa-mock-openai"]).toMatchObject({
+      provider: "openai",
+      mode: "api_key",
+    });
+    await expectPathMissing(path.join(stateDir, "agents", "qa", "agent", "openclaw-agent.sqlite"));
+  });
+
+  it("lets an explicit packaged command own mock auth state before gateway spawn", async () => {
+    const fixtureRoot = await tempDirs.makeTempDir("qa-packaged-auth-");
+    const tempParentDir = path.join(fixtureRoot, "gateway-temp");
+    const recordPath = path.join(fixtureRoot, "commands.jsonl");
+    const fixturePath = await writePackagedGatewayFixture(fixtureRoot);
+    await mkdir(tempParentDir);
+
+    await expect(
+      startQaGatewayChild({
+        repoRoot: process.cwd(),
+        command: {
+          executablePath: process.execPath,
+          argsPrefix: [fixturePath],
+          tempParentDir,
+          usePackagedPlugins: true,
+        },
+        providerMode: "mock-openai",
+        transportBaseUrl: "http://127.0.0.1:43123",
+        runtimeEnvPatch: { QA_RECORD_PATH: recordPath },
+      }),
+    ).rejects.toThrow("fixture gateway exit");
+
+    const records = await readJsonLines(recordPath);
+    const authRecords = records.filter((record) => record.kind === "auth");
+    expect(authRecords).toHaveLength(2);
+    expect(authRecords.map((record) => record.args)).toEqual([
+      [
+        "models",
+        "auth",
+        "--agent",
+        "qa",
+        "paste-api-key",
+        "--provider",
+        "openai",
+        "--profile-id",
+        "qa-mock-openai",
+      ],
+      [
+        "models",
+        "auth",
+        "--agent",
+        "qa",
+        "paste-api-key",
+        "--provider",
+        "anthropic",
+        "--profile-id",
+        "qa-mock-anthropic",
+      ],
+    ]);
+    for (const record of authRecords) {
+      expect(record.dbExists).toBe(false);
+      expect(record.stdin).toMatch(/^sk-qa-mock-[a-f0-9]{32}\n$/u);
+      expect(record.env).toMatchObject({
+        OPENCLAW_CLI: "1",
+      });
+    }
+    expect(records.at(-1)).toMatchObject({
+      kind: "gateway",
+      fixtureProfiles: ["openai", "anthropic"],
+    });
+  });
+
+  it("blocks packaged gateway spawn when candidate auth bootstrap fails", async () => {
+    const fixtureRoot = await tempDirs.makeTempDir("qa-packaged-auth-fail-");
+    const tempParentDir = path.join(fixtureRoot, "gateway-temp");
+    const recordPath = path.join(fixtureRoot, "commands.jsonl");
+    const fixturePath = await writePackagedGatewayFixture(fixtureRoot);
+    await mkdir(tempParentDir);
+
+    const result = startQaGatewayChild({
+      repoRoot: process.cwd(),
+      command: {
+        executablePath: process.execPath,
+        argsPrefix: [fixturePath],
+        tempParentDir,
+        usePackagedPlugins: true,
+      },
+      providerMode: "mock-openai",
+      transportBaseUrl: "http://127.0.0.1:43123",
+      runtimeEnvPatch: {
+        QA_FAIL_PROVIDER: "openai",
+        QA_RECORD_PATH: recordPath,
+      },
+    });
+
+    const error = await result.catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(Error);
+    if (!(error instanceof Error)) {
+      throw new Error("expected package auth bootstrap error");
+    }
+    expect(error.message).toContain(
+      "installed package mock auth bootstrap failed for openai: OpenClaw CLI exited 9: Authorization: Bearer <redacted>",
+    );
+    const records = await readJsonLines(recordPath);
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({ kind: "auth", dbExists: false });
+    const submittedKey = String(records[0]?.stdin).trim();
+    expect(submittedKey).toMatch(/^sk-qa-mock-[a-f0-9]{32}$/u);
+    expect(collectErrorChainMessages(error)).not.toContain(submittedKey);
+    expect(records.some((record) => record.kind === "gateway")).toBe(false);
+  });
+
+  it("drops the raw candidate API key and cause at the packaged auth boundary", async () => {
+    const fixtureRoot = await tempDirs.makeTempDir("qa-packaged-auth-redaction-");
+    const recordPath = path.join(fixtureRoot, "commands.jsonl");
+    const fixturePath = await writePackagedGatewayFixture(fixtureRoot);
+    const configPath = path.join(fixtureRoot, "openclaw.json");
+    const stateDir = path.join(fixtureRoot, "state");
+    await writeFile(configPath, "{}\n", "utf8");
+    await mkdir(stateDir);
+
+    const result = testing.stageQaPackagedMockAuthProfiles({
+      command: {
+        executablePath: process.execPath,
+        argsPrefix: [fixturePath],
+        usePackagedPlugins: true,
+      },
+      cwd: fixtureRoot,
+      env: {
+        ...process.env,
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_STATE_DIR: stateDir,
+        QA_FAIL_PROVIDER: "openai",
+        QA_RECORD_PATH: recordPath,
+      },
+      providers: ["openai"],
+    });
+
+    const error = await result.catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(Error);
+    if (!(error instanceof Error)) {
+      throw new Error("expected packaged auth boundary error");
+    }
+    const records = await readJsonLines(recordPath);
+    const submittedKey = String(records[0]?.stdin).trim();
+    expect(error.message).toContain("Authorization: Bearer <redacted>");
+    expect(collectErrorChainMessages(error)).not.toContain(submittedKey);
+    expect(error.cause).toBeUndefined();
   });
 
   it("stages mock profiles only for the requested agents and providers when callers override the defaults", async () => {

--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -70,7 +70,11 @@ import {
   stageQaLiveApiKeyProfiles,
   stageQaLiveAnthropicSetupToken,
 } from "./providers/live-frontier/auth.js";
-import { stageQaMockAuthProfiles } from "./providers/shared/mock-auth.js";
+import {
+  applyQaMockAuthProfileConfig,
+  buildQaMockProfileId,
+  stageQaMockAuthProfiles,
+} from "./providers/shared/mock-auth.js";
 import { listMockCodexModelInfos } from "./providers/shared/mock-model-config.js";
 import { seedQaAgentWorkspace } from "./qa-agent-workspace.js";
 import { buildQaGatewayConfig, type QaThinkingLevel } from "./qa-gateway-config.js";
@@ -90,6 +94,7 @@ const QA_GATEWAY_CHILD_GRACEFUL_SHUTDOWN_TIMEOUT_MS = 30_000;
 const QA_GATEWAY_CHILD_FORCE_SHUTDOWN_TIMEOUT_MS = 10_000;
 const QA_GATEWAY_LOG_CLOSE_TIMEOUT_MS = 5_000;
 const QA_GATEWAY_PROCESS_TREE_DIAGNOSTIC_MAX_CHARS = 2_048;
+const QA_PACKAGE_AUTH_FAILURE_MAX_CHARS = 2_048;
 const QA_MOCK_OPENAI_API_KEY = ["qa", "mock", "openai", "key"].join("-");
 const QA_GATEWAY_CHILD_BLOCKED_SECRET_ENV_VARS = Object.freeze([
   "OPENCLAW_QA_CONVEX_SECRET_CI",
@@ -181,13 +186,64 @@ async function runQaGatewayCliCommand(params: {
   args: readonly string[];
   cwd: string;
   env: NodeJS.ProcessEnv;
+  stdin?: string;
 }): Promise<string> {
+  const hasStdin = params.stdin !== undefined;
   const child = spawn(params.executablePath, [...params.argsPrefix, ...params.args], {
     cwd: params.cwd,
     env: { ...params.env, OPENCLAW_CLI: "1" },
-    stdio: ["ignore", "pipe", "pipe"],
+    stdio: [hasStdin ? "pipe" : "ignore", "pipe", "pipe"],
   });
-  return await readQaGatewayCliCommand(child);
+  const result = readQaGatewayCliCommand(child);
+  if (hasStdin) {
+    child.stdin?.once("error", () => {});
+    child.stdin?.end(params.stdin);
+  }
+  return await result;
+}
+
+function createQaPackagedMockApiKey(): string {
+  const prefix = ["s", "k"].join("");
+  return `${prefix}-${["qa", "mock", randomUUID().replaceAll("-", "")].join("-")}`;
+}
+
+async function stageQaPackagedMockAuthProfiles(params: {
+  command: QaGatewayChildCommand;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  providers: readonly string[];
+}): Promise<void> {
+  for (const provider of uniqueStrings(params.providers)) {
+    try {
+      await runQaGatewayCliCommand({
+        executablePath: params.command.executablePath,
+        argsPrefix: params.command.argsPrefix ?? [],
+        args: [
+          "models",
+          "auth",
+          "--agent",
+          "qa",
+          "paste-api-key",
+          "--provider",
+          provider,
+          "--profile-id",
+          buildQaMockProfileId(provider),
+        ],
+        cwd: params.command.cwd ?? params.cwd,
+        env: params.env,
+        stdin: `${createQaPackagedMockApiKey()}\n`,
+      });
+    } catch (error) {
+      const errorMessage = toErrorObject(error, "installed package auth command failed").message;
+      const details = sliceUtf16Safe(
+        redactQaGatewayDebugText(errorMessage),
+        0,
+        QA_PACKAGE_AUTH_FAILURE_MAX_CHARS,
+      );
+      // oxlint-disable-next-line preserve-caught-error -- Candidate CLI errors can contain the submitted API key; only the redacted message crosses this boundary.
+      throw new Error(`installed package mock auth bootstrap failed for ${provider}: ${details}`);
+    }
+  }
 }
 
 type QaChildFailure = {
@@ -712,7 +768,9 @@ export const testing = {
   assertQaLiveCodexAuthAvailable,
   stageQaLiveApiKeyProfiles,
   stageQaLiveAnthropicSetupToken,
+  applyQaMockAuthProfileConfig,
   stageQaMockAuthProfiles,
+  stageQaPackagedMockAuthProfiles,
   stageQaCodexMockModelCatalog,
   resolveQaLiveCliAuthEnv,
   waitForQaGatewayRestartBoundary,
@@ -1219,6 +1277,7 @@ export async function startQaGatewayChild(params: {
     const gatewayCommand =
       params.command ??
       (params.useRepoCli ? resolveQaGatewayChildCommand(params.repoRoot) : undefined);
+    const usesPackagedCandidate = params.command?.usePackagedPlugins === true;
     const gatewayExecutablePath = gatewayCommand?.executablePath;
     const gatewayArgsPrefix = gatewayCommand?.argsPrefix ?? [];
     const gatewayArgsSuffix = gatewayCommand?.argsSuffix ?? [];
@@ -1312,12 +1371,14 @@ export async function startQaGatewayChild(params: {
       });
       const mockAuthProviders = getQaProvider(providerMode).mockAuthProviders;
       if (mockAuthProviders && mockAuthProviders.length > 0) {
-        cfg = await stageQaMockAuthProfiles({
-          cfg,
-          stateDir,
-          agentIds: params.mockAuthAgentIds,
-          providers: mockAuthProviders,
-        });
+        cfg = usesPackagedCandidate
+          ? applyQaMockAuthProfileConfig({ cfg, providers: mockAuthProviders })
+          : await stageQaMockAuthProfiles({
+              cfg,
+              stateDir,
+              agentIds: params.mockAuthAgentIds,
+              providers: mockAuthProviders,
+            });
       }
       return params.mutateConfig ? params.mutateConfig(cfg) : cfg;
     };
@@ -1536,6 +1597,15 @@ export async function startQaGatewayChild(params: {
           encoding: "utf8",
           mode: 0o600,
         });
+        const mockAuthProviders = getQaProvider(providerMode).mockAuthProviders;
+        if (usesPackagedCandidate && gatewayCommand && mockAuthProviders?.length) {
+          await stageQaPackagedMockAuthProfiles({
+            command: gatewayCommand,
+            cwd: gatewayCwd,
+            env,
+            providers: mockAuthProviders,
+          });
+        }
       }
       if (!env) {
         throw new Error("qa gateway runtime env not initialized");

--- a/extensions/qa-lab/src/providers/shared/mock-auth.ts
+++ b/extensions/qa-lab/src/providers/shared/mock-auth.ts
@@ -10,8 +10,25 @@ const QA_MOCK_AUTH_PROVIDERS = Object.freeze(["openai", "anthropic"] as const);
 /** Agent IDs the mock harness stages credentials under. */
 const QA_MOCK_AUTH_AGENT_IDS = Object.freeze(["main", "qa"] as const);
 
-function buildQaMockProfileId(provider: string): string {
+export function buildQaMockProfileId(provider: string): string {
   return `qa-mock-${provider}`;
+}
+
+export function applyQaMockAuthProfileConfig(params: {
+  cfg: OpenClawConfig;
+  providers?: readonly string[];
+}): OpenClawConfig {
+  const providers = uniqueStrings(params.providers ?? QA_MOCK_AUTH_PROVIDERS);
+  let next = params.cfg;
+  for (const provider of providers) {
+    next = applyAuthProfileConfig(next, {
+      profileId: buildQaMockProfileId(provider),
+      provider,
+      mode: "api_key",
+      displayName: `QA mock ${provider} credential`,
+    });
+  }
+  return next;
 }
 
 /**
@@ -41,7 +58,6 @@ export async function stageQaMockAuthProfiles(params: {
 }): Promise<OpenClawConfig> {
   const agentIds = uniqueStrings(params.agentIds ?? QA_MOCK_AUTH_AGENT_IDS);
   const providers = uniqueStrings(params.providers ?? QA_MOCK_AUTH_PROVIDERS);
-  let next = params.cfg;
   for (const agentId of agentIds) {
     await writeQaAuthProfiles({
       agentDir: resolveQaAgentAuthDir({ stateDir: params.stateDir, agentId }),
@@ -58,13 +74,5 @@ export async function stageQaMockAuthProfiles(params: {
       ),
     });
   }
-  for (const provider of providers) {
-    next = applyAuthProfileConfig(next, {
-      profileId: buildQaMockProfileId(provider),
-      provider,
-      mode: "api_key",
-      displayName: `QA mock ${provider} credential`,
-    });
-  }
-  return next;
+  return applyQaMockAuthProfileConfig({ cfg: params.cfg, providers });
 }

--- a/scripts/e2e/lib/npm-telegram-live/prepare-package.mjs
+++ b/scripts/e2e/lib/npm-telegram-live/prepare-package.mjs
@@ -1,14 +1,29 @@
-// Prepares package manifests for npm Telegram live E2E scenarios.
+// Prepares the trusted harness manifest for npm Telegram live E2E scenarios.
 import fs from "node:fs";
 
-for (const packageJsonPath of process.argv.slice(2)) {
-  const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
-  pkg.exports = pkg.exports && typeof pkg.exports === "object" ? pkg.exports : {};
-  if (!pkg.exports["./plugin-sdk/gateway-runtime"]) {
-    pkg.exports["./plugin-sdk/gateway-runtime"] = {
-      types: "./dist/plugin-sdk/gateway-runtime.d.ts",
-      default: "./dist/plugin-sdk/gateway-runtime.js",
+const packageJsonPaths = process.argv.slice(2);
+if (packageJsonPaths.length !== 1) {
+  throw new Error("expected exactly one trusted harness package.json path");
+}
+
+const privatePluginSdkSubpaths = JSON.parse(
+  fs.readFileSync(
+    new URL("../../../lib/plugin-sdk-private-local-only-subpaths.json", import.meta.url),
+    "utf8",
+  ),
+);
+const packageJsonPath = packageJsonPaths[0];
+const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+pkg.exports = pkg.exports && typeof pkg.exports === "object" ? pkg.exports : {};
+
+for (const subpath of [...privatePluginSdkSubpaths, "gateway-runtime"]) {
+  const exportPath = `./plugin-sdk/${subpath}`;
+  if (!pkg.exports[exportPath]) {
+    pkg.exports[exportPath] = {
+      types: `./dist/plugin-sdk/${subpath}.d.ts`,
+      default: `./dist/plugin-sdk/${subpath}.js`,
     };
   }
-  fs.writeFileSync(packageJsonPath, `${JSON.stringify(pkg, null, 2)}\n`);
 }
+
+fs.writeFileSync(packageJsonPath, `${JSON.stringify(pkg, null, 2)}\n`);

--- a/scripts/e2e/npm-telegram-live-docker.sh
+++ b/scripts/e2e/npm-telegram-live-docker.sh
@@ -213,11 +213,16 @@ docker_e2e_build_or_reuse "$IMAGE_NAME" npm-telegram-live "$ROOT_DIR/scripts/e2e
 mkdir -p "$ROOT_DIR/.artifacts/qa-e2e"
 mkdir -p "$OUTPUT_DIR_HOST"
 npm_prefix_host="$(mktemp -d "$ROOT_DIR/.artifacts/qa-e2e/npm-telegram-live-prefix.XXXXXX")"
+harness_root="$(mktemp -d "$ROOT_DIR/.artifacts/qa-e2e/npm-telegram-live-harness.XXXXXX")"
+harness_package_json="$harness_root/package.json"
+cp "$ROOT_DIR/package.json" "$harness_package_json"
+node "$ROOT_DIR/scripts/e2e/lib/npm-telegram-live/prepare-package.mjs" "$harness_package_json"
 cleanup() {
   local rc=$?
   trap - EXIT
   printf 'schema=1\nexit_code=%s\nlive_output=job_log\n' "$rc" > "$OUTPUT_DIR_HOST/run-metadata.txt"
   rm -rf "$npm_prefix_host"
+  rm -rf "$harness_root"
   exit "$rc"
 }
 trap cleanup EXIT
@@ -408,13 +413,18 @@ command -v openclaw
 openclaw --version
 EOF
 
-# Mount only QA harness source; the SUT itself, including bundled plugin runtime,
-# is the installed package candidate.
+# Mount the trusted current-source QA harness separately from the installed
+# package candidate. The candidate remains the absolute CLI/runtime SUT.
 run_logged_print_heartbeat "npm-telegram-live-suite" 60 docker_e2e_run_with_harness \
   "${docker_env[@]}" \
   -v "$ROOT_DIR/.artifacts:/app/.artifacts" \
   -v "$OUTPUT_DIR_HOST:$OUTPUT_DIR_CONTAINER" \
-  -v "$ROOT_DIR/extensions/qa-lab:/app/extensions/qa-lab:ro" \
+  -v "$harness_package_json:/app/package.json:ro" \
+  -v "$ROOT_DIR/dist:/app/dist:ro" \
+  -v "$ROOT_DIR/node_modules:/trusted-harness/node_modules:ro" \
+  -v "$ROOT_DIR/packages:/app/packages:ro" \
+  -v "$ROOT_DIR/extensions:/app/extensions:ro" \
+  -v "$ROOT_DIR/taxonomy.yaml:/app/taxonomy.yaml:ro" \
   -v "$ROOT_DIR/qa/scenarios:/app/qa/scenarios:ro" \
   -v "$npm_prefix_host:/npm-global" \
   -i "$IMAGE_NAME" bash -s <<'EOF'
@@ -426,6 +436,7 @@ export HOME="$runtime_home"
 export NPM_CONFIG_PREFIX="/npm-global"
 export PATH="$NPM_CONFIG_PREFIX/bin:$PATH"
 export OPENCLAW_NPM_TELEGRAM_REPO_ROOT="/app"
+sut_command="/npm-global/bin/openclaw"
 
 dump_hotpath_logs() {
   local status="$1"
@@ -443,67 +454,52 @@ dump_hotpath_logs() {
 }
 trap 'status=$?; dump_hotpath_logs "$status"; exit "$status"' ERR
 
-command -v openclaw
-openclaw_e2e_run_command openclaw --version
+test -x "$sut_command"
+openclaw_e2e_run_command "$sut_command" --version
 mkdir -p /app/node_modules
-openclaw_package_dir="/npm-global/lib/node_modules/openclaw"
-# The mounted QA harness imports openclaw/plugin-sdk and package dependencies;
-# point those imports at the installed package without copying source plugins into the test image.
-rm -rf /app/node_modules/openclaw
-ln -sfnT "$openclaw_package_dir" /app/node_modules/openclaw
-rm -rf /app/dist
-ln -sfnT "$openclaw_package_dir/dist" /app/dist
-cp "$openclaw_package_dir/package.json" /app/package.json
-node scripts/e2e/lib/npm-telegram-live/prepare-package.mjs \
-  /app/package.json \
-  /app/node_modules/openclaw/package.json
-for deps_dir in "$openclaw_package_dir/node_modules" /npm-global/lib/node_modules; do
-  [ -d "$deps_dir" ] || continue
-  for dependency_dir in "$deps_dir"/*; do
-    [ -e "$dependency_dir" ] || continue
-    dependency_name="$(basename "$dependency_dir")"
-    case "$dependency_name" in
-      .bin | openclaw)
-        continue
-        ;;
-      @*)
-        [ -d "$dependency_dir" ] || continue
-        mkdir -p "/app/node_modules/$dependency_name"
-        for scoped_dependency_dir in "$dependency_dir"/*; do
-          [ -e "$scoped_dependency_dir" ] || continue
-          scoped_dependency_name="$(basename "$scoped_dependency_dir")"
-          rm -rf "/app/node_modules/$dependency_name/$scoped_dependency_name"
-          ln -sfnT "$scoped_dependency_dir" "/app/node_modules/$dependency_name/$scoped_dependency_name"
-        done
-        ;;
-      *)
-        rm -rf "/app/node_modules/$dependency_name"
-        ln -sfnT "$dependency_dir" "/app/node_modules/$dependency_name"
-        ;;
-    esac
-  done
-done
-
-link_installed_package_dependency() {
-  local name="$1"
-  local source="/npm-global/lib/node_modules/openclaw/node_modules/$name"
+link_harness_dependency() {
+  local source="$1"
+  local name="$2"
   local target="/app/node_modules/$name"
-  if [ ! -e "$source" ]; then
-    echo "Installed package dependency is missing: $name" >&2
-    return 1
-  fi
   mkdir -p "$(dirname "$target")"
-  ln -sfn "$source" "$target"
+  ln -sfnT "$source" "$target"
 }
 
-# QA Lab is intentionally mounted as harness source, so its package-local
-# runtime imports must resolve from the installed package dependency tree.
-for dependency in \
-  @modelcontextprotocol/sdk \
-  yaml \
-  zod; do
-  link_installed_package_dependency "$dependency"
+# External dependencies resolve from the trusted install, not the candidate.
+for dependency_dir in /trusted-harness/node_modules/* /trusted-harness/node_modules/.[!.]*; do
+  [ -e "$dependency_dir" ] || continue
+  dependency_name="$(basename "$dependency_dir")"
+  case "$dependency_name" in
+    .bin | openclaw)
+      continue
+      ;;
+    @*)
+      [ -d "$dependency_dir" ] || continue
+      for scoped_dependency_dir in "$dependency_dir"/*; do
+        [ -e "$scoped_dependency_dir" ] || continue
+        scoped_dependency_name="$(basename "$scoped_dependency_dir")"
+        link_harness_dependency \
+          "$scoped_dependency_dir" \
+          "$dependency_name/$scoped_dependency_name"
+      done
+      ;;
+    *)
+      link_harness_dependency "$dependency_dir" "$dependency_name"
+      ;;
+  esac
 done
+
+# Workspace links must resolve under /app even when pnpm linked them relative to
+# the checkout path used by the workflow.
+for workspace_dir in /app/packages/* /app/extensions/*; do
+  [ -f "$workspace_dir/package.json" ] || continue
+  workspace_name="$(node -e \
+    'const fs = require("node:fs"); const pkg = JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(pkg.name || "");' \
+    "$workspace_dir/package.json")"
+  [ -n "$workspace_name" ] || continue
+  link_harness_dependency "$workspace_dir" "$workspace_name"
+done
+link_harness_dependency /app openclaw
 
 if [ "${OPENCLAW_NPM_TELEGRAM_SKIP_HOTPATH:-0}" != "1" ]; then
   hotpath_home="$(mktemp -d "/tmp/openclaw-npm-telegram-hotpath.XXXXXX")"
@@ -515,7 +511,7 @@ if [ "${OPENCLAW_NPM_TELEGRAM_SKIP_HOTPATH:-0}" != "1" ]; then
     hotpath_model_value="$OPENAI_API_KEY"
   fi
   hotpath_channel_value="$(printf '%s:%s' 123456 "$hotpath_placeholder")"
-  OPENAI_API_KEY="$hotpath_model_value" openclaw_e2e_run_command openclaw onboard \
+  OPENAI_API_KEY="$hotpath_model_value" openclaw_e2e_run_command "$sut_command" onboard \
     --non-interactive --accept-risk \
     --mode local \
     --auth-choice openai-api-key \
@@ -528,13 +524,13 @@ if [ "${OPENCLAW_NPM_TELEGRAM_SKIP_HOTPATH:-0}" != "1" ]; then
     --skip-health \
     --json >/tmp/openclaw-npm-telegram-onboard.json </dev/null
 
-  openclaw_e2e_run_command openclaw channels add --channel telegram --token "$hotpath_channel_value" >/tmp/openclaw-npm-telegram-channel-add.log 2>&1 </dev/null
-  openclaw_e2e_run_command openclaw doctor --fix --non-interactive >/tmp/openclaw-npm-telegram-doctor-fix.log 2>&1 </dev/null
-  openclaw_e2e_run_command openclaw doctor --non-interactive >/tmp/openclaw-npm-telegram-doctor-check.log 2>&1 </dev/null
+  openclaw_e2e_run_command "$sut_command" channels add --channel telegram --token "$hotpath_channel_value" >/tmp/openclaw-npm-telegram-channel-add.log 2>&1 </dev/null
+  openclaw_e2e_run_command "$sut_command" doctor --fix --non-interactive >/tmp/openclaw-npm-telegram-doctor-fix.log 2>&1 </dev/null
+  openclaw_e2e_run_command "$sut_command" doctor --non-interactive >/tmp/openclaw-npm-telegram-doctor-check.log 2>&1 </dev/null
   export HOME="$runtime_home"
 fi
 
-export OPENCLAW_NPM_TELEGRAM_SUT_COMMAND="$(command -v openclaw)"
+export OPENCLAW_NPM_TELEGRAM_SUT_COMMAND="$sut_command"
 trap - ERR
 tsx scripts/e2e/npm-telegram-live-runner.ts
 EOF

--- a/scripts/e2e/npm-telegram-live-runner.ts
+++ b/scripts/e2e/npm-telegram-live-runner.ts
@@ -98,6 +98,16 @@ function createRoundTripProbe(
   };
 }
 
+function includeRoundTripProbeScenario(
+  scenarioIds: readonly string[],
+  options: ReturnType<typeof resolveRttOptions>,
+) {
+  if (!options || scenarioIds.includes(options.scenarioId)) {
+    return [...scenarioIds];
+  }
+  return [...scenarioIds, options.scenarioId];
+}
+
 async function shouldFailPackageTelegramRun(
   result: { summaryPath: string },
   env: NodeJS.ProcessEnv = process.env,
@@ -141,8 +151,15 @@ async function resolveTrustedOpenClawCommand(
 }
 
 async function main() {
-  const { runQaTelegramSuite } =
-    await import("../../extensions/qa-lab/src/live-transports/telegram/cli.runtime.ts");
+  const [
+    { runQaTelegramSuite },
+    { resolveTelegramQaScenarioIds },
+    { DEFAULT_QA_LIVE_PROVIDER_MODE },
+  ] = await Promise.all([
+    import("../../extensions/qa-lab/src/live-transports/telegram/cli.runtime.ts"),
+    import("../../extensions/qa-lab/src/live-transports/telegram/scenario-selection.ts"),
+    import("../../extensions/qa-lab/src/providers/index.ts"),
+  ]);
   const rawSutOpenClawCommand = process.env.OPENCLAW_NPM_TELEGRAM_SUT_COMMAND?.trim();
   if (!rawSutOpenClawCommand) {
     throw new Error("Missing OPENCLAW_NPM_TELEGRAM_SUT_COMMAND.");
@@ -152,18 +169,29 @@ async function main() {
   const repoRoot = path.resolve(process.env.OPENCLAW_NPM_TELEGRAM_REPO_ROOT ?? process.cwd());
   const outputDir = resolvePackageTelegramOutputDir(process.env, repoRoot);
   const scenarioIds = splitCsv(process.env.OPENCLAW_NPM_TELEGRAM_SCENARIOS);
+  const providerMode =
+    (process.env.OPENCLAW_NPM_TELEGRAM_PROVIDER_MODE as QaProviderMode | undefined) ??
+    DEFAULT_QA_LIVE_PROVIDER_MODE;
+  const primaryModel = process.env.OPENCLAW_NPM_TELEGRAM_MODEL;
+  const resolvedScenarioIds = resolveTelegramQaScenarioIds({
+    providerMode,
+    primaryModel,
+    scenarioIds,
+  });
+  const rttOptions = resolveRttOptions(process.env, scenarioIds);
   const result = await runQaTelegramSuite({
     allowFailures: true,
     failFast: true,
     repoRoot,
     outputDir,
     sutOpenClawCommand,
-    providerMode: process.env.OPENCLAW_NPM_TELEGRAM_PROVIDER_MODE as QaProviderMode | undefined,
-    primaryModel: process.env.OPENCLAW_NPM_TELEGRAM_MODEL,
+    providerMode,
+    primaryModel,
     alternateModel: process.env.OPENCLAW_NPM_TELEGRAM_ALT_MODEL,
     fastMode: parseBoolean(process.env.OPENCLAW_NPM_TELEGRAM_FAST),
     scenarioIds,
-    roundTripProbe: createRoundTripProbe(resolveRttOptions(process.env, scenarioIds)),
+    resolvedScenarioIds: includeRoundTripProbeScenario(resolvedScenarioIds, rttOptions),
+    roundTripProbe: createRoundTripProbe(rttOptions),
     sutAccountId: process.env.OPENCLAW_NPM_TELEGRAM_SUT_ACCOUNT,
     credentialSource: resolveCredentialSource(process.env),
     credentialRole: resolveCredentialRole(process.env),
@@ -209,6 +237,7 @@ export const testing = {
   resolveCredentialRole,
   resolveCredentialSource,
   createRoundTripProbe,
+  includeRoundTripProbeScenario,
   resolveRttOptions,
   resolveTrustedOpenClawCommand,
   shouldFailPackageTelegramRun,

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -196,6 +196,7 @@ describe("production lint suppressions", () => {
         "extensions/discord/src/test-support/provider.test-support.ts|typescript/no-unnecessary-type-parameters|1",
         "extensions/feishu/src/bitable.ts|typescript/no-unnecessary-type-parameters|1",
         "extensions/matrix/src/onboarding.test-harness.ts|typescript/no-unnecessary-type-parameters|1",
+        "extensions/qa-lab/src/gateway-child.ts|preserve-caught-error|1",
         "extensions/slack/src/monitor/provider-support.ts|typescript/no-unnecessary-type-parameters|1",
         "scripts/changed-lanes.mjs|typescript/no-base-to-string|2",
         "scripts/changed-lanes.mjs|typescript/restrict-template-expressions|2",

--- a/test/scripts/npm-telegram-live.test.ts
+++ b/test/scripts/npm-telegram-live.test.ts
@@ -17,6 +17,7 @@ const PRIVATE_PLUGIN_SDK_SUBPATHS_PATH = path.resolve(
   TEST_DIR,
   "../../scripts/lib/plugin-sdk-private-local-only-subpaths.json",
 );
+const GATEWAY_CHILD_PATH = path.resolve(TEST_DIR, "../../extensions/qa-lab/src/gateway-child.ts");
 const tempRoots: string[] = [];
 
 function mkTempRoot() {
@@ -247,6 +248,11 @@ describe("package Telegram live Docker E2E", () => {
       executablePath: command,
       usePackagedPlugins: true,
     });
+
+    const gatewayChild = readFileSync(GATEWAY_CHILD_PATH, "utf8");
+    expect(gatewayChild).toContain("params.command?.usePackagedPlugins === true");
+    expect(gatewayChild).toContain("stageQaPackagedMockAuthProfiles");
+    expect(gatewayChild).toContain('"paste-api-key"');
   });
 
   it("mounts configured output paths before entering the container", () => {

--- a/test/scripts/npm-telegram-live.test.ts
+++ b/test/scripts/npm-telegram-live.test.ts
@@ -1,4 +1,5 @@
 // Npm Telegram Live tests cover npm telegram live script behavior.
+import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -11,6 +12,10 @@ const DOCKER_SCRIPT_PATH = path.resolve(TEST_DIR, "../../scripts/e2e/npm-telegra
 const PREPARE_PACKAGE_PATH = path.resolve(
   TEST_DIR,
   "../../scripts/e2e/lib/npm-telegram-live/prepare-package.mjs",
+);
+const PRIVATE_PLUGIN_SDK_SUBPATHS_PATH = path.resolve(
+  TEST_DIR,
+  "../../scripts/lib/plugin-sdk-private-local-only-subpaths.json",
 );
 const tempRoots: string[] = [];
 
@@ -50,7 +55,7 @@ describe("package Telegram live Docker E2E", () => {
   it("installs the package candidate before forwarding runtime secrets", () => {
     const script = readFileSync(DOCKER_SCRIPT_PATH, "utf8");
     const installRunStart = script.indexOf('echo "Running package Telegram live Docker E2E');
-    const installRunEnd = script.indexOf("# Mount only QA harness source");
+    const installRunEnd = script.indexOf("# Mount the trusted current-source QA harness");
     const installRun = script.slice(installRunStart, installRunEnd);
 
     expect(installRunStart).toBeGreaterThanOrEqual(0);
@@ -94,7 +99,7 @@ describe("package Telegram live Docker E2E", () => {
 
   it("bounds installed-package hot path OpenClaw commands", () => {
     const script = readFileSync(DOCKER_SCRIPT_PATH, "utf8");
-    const runtimeRunStart = script.indexOf("# Mount only QA harness source");
+    const runtimeRunStart = script.indexOf("# Mount the trusted current-source QA harness");
     const runtimeRun = script.slice(runtimeRunStart);
 
     expect(runtimeRunStart).toBeGreaterThanOrEqual(0);
@@ -102,15 +107,19 @@ describe("package Telegram live Docker E2E", () => {
       '-e OPENCLAW_E2E_COMMAND_TIMEOUT="${OPENCLAW_E2E_COMMAND_TIMEOUT:-300s}"',
     );
     expect(runtimeRun).toContain("source scripts/lib/openclaw-e2e-instance.sh");
-    expect(runtimeRun).toContain("openclaw_e2e_run_command openclaw --version");
-    expect(runtimeRun).toContain("openclaw_e2e_run_command openclaw onboard");
+    expect(runtimeRun).toContain('sut_command="/npm-global/bin/openclaw"');
+    expect(runtimeRun).toContain('openclaw_e2e_run_command "$sut_command" --version');
+    expect(runtimeRun).toContain('openclaw_e2e_run_command "$sut_command" onboard');
     expect(runtimeRun).toContain(
-      'OPENAI_API_KEY="$hotpath_model_value" openclaw_e2e_run_command openclaw onboard',
+      'OPENAI_API_KEY="$hotpath_model_value" openclaw_e2e_run_command "$sut_command" onboard',
     );
     expect(runtimeRun).not.toContain("export OPENAI_API_KEY=");
-    expect(runtimeRun).toContain("openclaw_e2e_run_command openclaw channels add");
-    expect(runtimeRun).toContain("openclaw_e2e_run_command openclaw doctor --fix");
-    expect(runtimeRun).toContain("openclaw_e2e_run_command openclaw doctor --non-interactive");
+    expect(runtimeRun).toContain('openclaw_e2e_run_command "$sut_command" channels add');
+    expect(runtimeRun).toContain('openclaw_e2e_run_command "$sut_command" doctor --fix');
+    expect(runtimeRun).toContain(
+      'openclaw_e2e_run_command "$sut_command" doctor --non-interactive',
+    );
+    expect(runtimeRun).toContain('export OPENCLAW_NPM_TELEGRAM_SUT_COMMAND="$sut_command"');
     expect(runtimeRun).toContain('openclaw_e2e_print_log "$file"');
     expect(runtimeRun).not.toContain("sed -n '1,220p'");
     expect(runtimeRun).not.toMatch(/^\s*openclaw (onboard|channels add|doctor )/mu);
@@ -267,9 +276,8 @@ describe("package Telegram live Docker E2E", () => {
     expect(script).toContain("OPENCLAW_NPM_TELEGRAM_RTT_CHECKS");
   });
 
-  it("keeps private QA harness imports local while using the installed package dist", () => {
+  it("isolates the trusted private QA harness from the installed package candidate", () => {
     const script = readFileSync(DOCKER_SCRIPT_PATH, "utf8");
-    const preparePackage = readFileSync(PREPARE_PACKAGE_PATH, "utf8");
     const gatewayRpcClient = readFileSync(
       path.resolve(TEST_DIR, "../../extensions/qa-lab/src/gateway-rpc-client.ts"),
       "utf8",
@@ -286,15 +294,25 @@ describe("package Telegram live Docker E2E", () => {
       "extensions/qa-lab/src/suite.ts",
     ].map((relativePath) => readFileSync(path.resolve(TEST_DIR, "../..", relativePath), "utf8"));
 
-    expect(script).toContain('ln -sfnT "$openclaw_package_dir/dist" /app/dist');
-    expect(script).toContain('cp "$openclaw_package_dir/package.json" /app/package.json');
-    expect(script).toContain('-v "$ROOT_DIR/extensions/qa-lab:/app/extensions/qa-lab:ro"');
+    expect(script).toContain('cp "$ROOT_DIR/package.json" "$harness_package_json"');
+    expect(script).toContain(
+      'node "$ROOT_DIR/scripts/e2e/lib/npm-telegram-live/prepare-package.mjs" "$harness_package_json"',
+    );
+    expect(script).toContain('-v "$harness_package_json:/app/package.json:ro"');
+    expect(script).toContain('-v "$ROOT_DIR/dist:/app/dist:ro"');
+    expect(script).toContain('-v "$ROOT_DIR/node_modules:/trusted-harness/node_modules:ro"');
+    expect(script).toContain('-v "$ROOT_DIR/packages:/app/packages:ro"');
+    expect(script).toContain('-v "$ROOT_DIR/extensions:/app/extensions:ro"');
+    expect(script).toContain('-v "$ROOT_DIR/taxonomy.yaml:/app/taxonomy.yaml:ro"');
     expect(script).toContain('-v "$ROOT_DIR/qa/scenarios:/app/qa/scenarios:ro"');
-    expect(script).not.toContain('ln -sfnT /app/extensions "$openclaw_package_dir/extensions"');
-    expect(script).toContain("node scripts/e2e/lib/npm-telegram-live/prepare-package.mjs");
-    expect(script).toContain("/app/node_modules/openclaw/package.json");
-    expect(preparePackage).toContain('pkg.exports["./plugin-sdk/gateway-runtime"]');
-    expect(preparePackage).toContain('"./dist/plugin-sdk/gateway-runtime.js"');
+    expect(script).toContain("for dependency_dir in /trusted-harness/node_modules/*");
+    expect(script).toContain("for workspace_dir in /app/packages/* /app/extensions/*");
+    expect(script).toContain('link_harness_dependency "$workspace_dir" "$workspace_name"');
+    expect(script).toContain("link_harness_dependency /app openclaw");
+    expect(script).not.toContain('openclaw_package_dir="/npm-global/lib/node_modules/openclaw"');
+    expect(script).not.toContain('cp "$openclaw_package_dir/package.json" /app/package.json');
+    expect(script).not.toContain("/app/node_modules/openclaw/package.json");
+    expect(script).not.toContain("link_installed_package_dependency");
     expect(gatewayRpcClient).toContain('from "openclaw/plugin-sdk/gateway-runtime"');
     expect(qaRuntimeApi).toContain('from "openclaw/plugin-sdk/gateway-runtime"');
     for (const source of qaHarnessSources) {
@@ -302,18 +320,44 @@ describe("package Telegram live Docker E2E", () => {
     }
   });
 
-  it("exposes installed package dependencies to the mounted QA harness", () => {
-    const script = readFileSync(DOCKER_SCRIPT_PATH, "utf8");
-
-    expect(script).toContain("link_installed_package_dependency()");
-    expect(script).toContain(
-      'local source="/npm-global/lib/node_modules/openclaw/node_modules/$name"',
+  it("adds private SDK exports only to the trusted harness manifest", () => {
+    const root = mkTempRoot();
+    const harnessManifestPath = path.join(root, "harness-package.json");
+    const candidateManifestPath = path.join(root, "candidate-package.json");
+    const existingGatewayExport = {
+      types: "./existing/gateway-runtime.d.ts",
+      default: "./existing/gateway-runtime.js",
+    };
+    writeFileSync(
+      harnessManifestPath,
+      `${JSON.stringify({
+        name: "openclaw",
+        exports: {
+          "./kept": "./dist/kept.js",
+          "./plugin-sdk/gateway-runtime": existingGatewayExport,
+        },
+      })}\n`,
     );
-    expect(script).toContain('ln -sfn "$source" "$target"');
-    expect(script).toContain('link_installed_package_dependency "$dependency"');
-    expect(script).toContain("@modelcontextprotocol/sdk");
-    expect(script).toContain("yaml");
-    expect(script).toContain("zod");
+    writeFileSync(candidateManifestPath, '{"name":"candidate","exports":{}}\n');
+    const candidateBefore = readFileSync(candidateManifestPath, "utf8");
+
+    execFileSync(process.execPath, [PREPARE_PACKAGE_PATH, harnessManifestPath]);
+
+    const prepared = JSON.parse(readFileSync(harnessManifestPath, "utf8")) as {
+      exports: Record<string, unknown>;
+    };
+    const privateSubpaths = JSON.parse(
+      readFileSync(PRIVATE_PLUGIN_SDK_SUBPATHS_PATH, "utf8"),
+    ) as string[];
+    expect(prepared.exports["./kept"]).toBe("./dist/kept.js");
+    expect(prepared.exports["./plugin-sdk/gateway-runtime"]).toEqual(existingGatewayExport);
+    for (const subpath of privateSubpaths) {
+      expect(prepared.exports[`./plugin-sdk/${subpath}`]).toEqual({
+        types: `./dist/plugin-sdk/${subpath}.d.ts`,
+        default: `./dist/plugin-sdk/${subpath}.js`,
+      });
+    }
+    expect(readFileSync(candidateManifestPath, "utf8")).toBe(candidateBefore);
   });
 
   it("lets npm-specific credential aliases override shared QA env", () => {

--- a/test/scripts/npm-telegram-live.test.ts
+++ b/test/scripts/npm-telegram-live.test.ts
@@ -147,6 +147,19 @@ describe("package Telegram live Docker E2E", () => {
     expect(runner).toContain("failFast: true");
   });
 
+  it("adds RTT probes to the canonical Telegram scenario selection", () => {
+    const runner = readFileSync(
+      path.resolve(TEST_DIR, "../../scripts/e2e/npm-telegram-live-runner.ts"),
+      "utf8",
+    );
+
+    expect(runner).toContain("resolveTelegramQaScenarioIds");
+    expect(runner).toContain(
+      "resolvedScenarioIds: includeRoundTripProbeScenario(resolvedScenarioIds, rttOptions)",
+    );
+    expect(runner).toContain("roundTripProbe: createRoundTripProbe(rttOptions)");
+  });
+
   it("can install a resolved package tarball instead of a registry spec", () => {
     const script = readFileSync(DOCKER_SCRIPT_PATH, "utf8");
 
@@ -418,6 +431,39 @@ describe("package Telegram live Docker E2E", () => {
         conversation: { id: "telegram-rtt-room", kind: "group" },
       },
     });
+  });
+
+  it("adds the default RTT canary to an empty canonical selection", () => {
+    const options = testing.resolveRttOptions({});
+
+    expect(testing.includeRoundTripProbeScenario([], options)).toEqual(["channel-canary"]);
+  });
+
+  it("keeps focused non-RTT selections unchanged", () => {
+    const scenarioIds = ["telegram-status-command"];
+    const options = testing.resolveRttOptions({}, scenarioIds);
+
+    expect(testing.includeRoundTripProbeScenario(scenarioIds, options)).toEqual(scenarioIds);
+  });
+
+  it("appends an explicit RTT canary to a focused non-canary selection", () => {
+    const scenarioIds = ["telegram-status-command"];
+    const options = testing.resolveRttOptions(
+      { OPENCLAW_NPM_TELEGRAM_RTT_CHECKS: "channel-canary" },
+      scenarioIds,
+    );
+
+    expect(testing.includeRoundTripProbeScenario(scenarioIds, options)).toEqual([
+      "telegram-status-command",
+      "channel-canary",
+    ]);
+  });
+
+  it("does not duplicate an already selected RTT canary", () => {
+    const scenarioIds = ["channel-canary", "telegram-status-command"];
+    const options = testing.resolveRttOptions({}, scenarioIds);
+
+    expect(testing.includeRoundTripProbeScenario(scenarioIds, options)).toEqual(scenarioIds);
   });
 
   it("rejects retired RTT scenario ids", () => {

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1635,12 +1635,25 @@ describe("package acceptance workflow", () => {
     expect(npmTelegramWorkflow).toContain("Download package-under-test artifact from release run");
     expect(npmTelegramWorkflow).toContain("run-id: ${{ inputs.package_artifact_run_id }}");
     expect(npmTelegramWorkflow).toContain("github-token: ${{ github.token }}");
+    expect(npmTelegramWorkflow).toContain("name: Build private QA harness");
+    expect(npmTelegramWorkflow).toContain("OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build");
+    expect(npmTelegramWorkflow).toContain("name: Preflight private QA harness");
+    expect(npmTelegramWorkflow).toContain("dist/plugin-sdk/qa-lab.js");
+    expect(npmTelegramWorkflow).toContain("dist/plugin-sdk/qa-runtime.js");
+    const buildPrivateQaIndex = npmTelegramWorkflow.indexOf("name: Build private QA harness");
+    const preflightPrivateQaIndex = npmTelegramWorkflow.indexOf(
+      "name: Preflight private QA harness",
+    );
+    const runPackageTelegramIndex = npmTelegramWorkflow.indexOf(
+      "- name: Run package Telegram E2E",
+      preflightPrivateQaIndex,
+    );
+    expect(buildPrivateQaIndex).toBeLessThan(preflightPrivateQaIndex);
+    expect(preflightPrivateQaIndex).toBeLessThan(runPackageTelegramIndex);
     expect(workflow).toContain(
       "package_source_sha: ${{ steps.resolve.outputs.package_source_sha }}",
     );
-    expect(workflow).toContain(
-      "harness_ref: ${{ needs.resolve_package.outputs.package_source_sha || inputs.workflow_ref }}",
-    );
+    expect(workflow).toContain("harness_ref: ${{ inputs.workflow_ref }}");
     expect(workflow).toContain('fallback_version="$(npm view openclaw@latest version)"');
     expect(workflow).toContain('echo "baseline=$fallback_baseline" >> "$GITHUB_OUTPUT"');
     expect(workflow).toContain(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the package Telegram beta acceptance lane could not validate the installed package after heredoc stdin handling was repaired and the QA suite began executing. The published package intentionally excludes private QA SDK exports, but the lane was resolving its trusted source-checkout harness through the installed package boundary.

## Why This Change Was Made

Package Acceptance now builds private QA artifacts from the exact trusted workflow ref and runs them as a separate harness. `/npm-global/bin/openclaw` remains the absolute installed-package system under test.

The package candidate also owns its persisted auth state: package mode writes configuration first, invokes the installed candidate CLI over stdin to create its mock auth profiles, and only then starts that candidate's Gateway. Repo mode retains the existing direct state writer.

This removes the candidate manifest rewrite, candidate `dist` replacement, and dependency fan-out into the harness. `harness_ref` remains pinned to `workflow_ref`, so a package SHA cannot silently select another harness implementation.

## User Impact

No product runtime or published package API changes. Maintainers get package Telegram acceptance that genuinely exercises the selected package while keeping private QA code and package-owned persisted state on their correct sides of the boundary.

## Evidence

- Original failing execution: https://github.com/openclaw/openclaw/actions/runs/31022866685
- Exact changed gate: https://github.com/openclaw/openclaw/actions/runs/31050696693 (Testbox lease `tbx_01kz9ysc45tfpq4hw27zk7efsp`, exit 0)
- Structured branch autoreview on `fbc6b2691753ae93b9637b218b22f64a7828e665`: clean, no actionable findings
- Focused QA Gateway tests: `extensions/qa-lab/src/gateway-child.test.ts` (109 passed)
- Focused package Telegram tests: `test/scripts/npm-telegram-live.test.ts` (34 passed)
- Lint suppression contract tests: `test/scripts/lint-suppressions.test.ts` (4 passed)
- `git diff --check`: clean
- Signed exact head: `fbc6b2691753ae93b9637b218b22f64a7828e665`

### Installed beta proof and external blocker

Exact-head live package run: https://github.com/openclaw/openclaw/actions/runs/31051483121

- Installed SUT: `/npm-global/bin/openclaw`
- Installed version: `OpenClaw 2026.7.2-beta.7 (dabe191)`
- Trusted private harness build and preflight passed.
- The candidate-owned auth bootstrap passed: the Gateway reached ready and `channel-message-flows` passed. This proves the package/harness separation and candidate-owned SQLite/auth repair.
- `channel-workspace-relative-media` then failed only on `message.action` with `FsSafeError: file not found`; the direct Telegram `sendPhoto` in the same scenario succeeded.

That remaining failure is a published beta.7 product defect, not a regression in this PR. Beta.7 commit `dabe1915362e20c25704af91612a32a8f4c96e83` predates `28e681c92f0c1894244fb5a89978badcfeb7faf5` from https://github.com/openclaw/openclaw/pull/117711, which introduced both the workspace-media acceptance scenario and the missing reader-free `{ localRoots, workspaceDir }` propagation through Gateway `message.action`.

The acceptance lane should remain red for beta.7 on that product defect. The canonical external unblock is testing a beta containing `28e681c92f0c1894244fb5a89978badcfeb7faf5` or newer; this PR deliberately does not copy media into the candidate cwd or skip the scenario.

### Review accounting

- Architectural owner: Package Acceptance owns the trusted harness/candidate boundary; each candidate CLI owns its persisted auth schema.
- Canonical fix: separate the trusted harness, preserve the absolute installed-package command, and let that command create package-mode auth state.
- Removed paths: package manifest rewrite, candidate `dist` graft, and candidate dependency fan-out into the harness.
- Sibling coverage: package mode exercises the candidate CLI path; repo mode retains and tests direct auth staging.
- Production/harness delta: +215/-97; tests +386/-33; workflow config +17/-1. Positive runtime growth establishes the explicit harness/SUT ownership and secret-redaction boundaries.
- No SQLite schema version, migration, product config, or published package surface changes.

### ClawSweeper rank-up moves

- Diagnosed the failed exact-head package job from its uploaded `qa-evidence.json` and report.
- Added the redacted installed-package execution trace and classified the remaining beta.7 failure above.
