### PR TITLE
fix(message-tool): strip HEARTBEAT_OK from send payloads (#119653)

### DIFF
--- a/src/agents/tools/message-tool-execution.ts
+++ b/src/agents/tools/message-tool-execution.ts
@@ -359,9 +359,17 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
         typeof params.final === "boolean" ? params.final : undefined;
       delete params.final;
 
+      // HEARTBEAT_OK is a send-only silence sentinel. Broadcast fans out to
+      // send actions, and reply is a sibling visible delivery action, so all
+      // three must receive the same token-only suppression decision before
+      // dispatch. Other actions can use the same parameter names for
+      // channel-owned values and must preserve them.
+      const shouldStripHeartbeatToken =
+        action === "send" || action === "broadcast" || action === "reply";
       const suppressedVisiblePayloadReason = sanitizeMessageToolVisiblePayload(
         params,
         options?.agentSessionKey,
+        { stripHeartbeatToken: shouldStripHeartbeatToken },
       );
       if (options?.sourceReplyOnly) {
         enforceSourceReplyOnlyTextDirectives(params);
@@ -369,16 +377,19 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
 
       if (
         suppressedVisiblePayloadReason &&
-        action === "send" &&
+        (action === "send" || action === "broadcast" || action === "reply") &&
         !hasSanitizedSendPayloadContent(params)
       ) {
+        const suppressedReason = suppressedVisiblePayloadReason;
         return jsonResult({
           status: "suppressed",
-          reason: suppressedVisiblePayloadReason,
+          reason: suppressedReason,
           message:
-            suppressedVisiblePayloadReason === "inbound_metadata_echo"
-              ? "Suppressed outbound message text because it matched inbound runtime metadata."
-              : "Suppressed outbound message text because it matched internal runtime context.",
+            suppressedReason === "heartbeat_token"
+              ? "Suppressed outbound message text because it was a heartbeat acknowledgement (HEARTBEAT_OK)."
+              : suppressedReason === "inbound_metadata_echo"
+                ? "Suppressed outbound message text because it matched inbound runtime metadata."
+                : "Suppressed outbound message text because it matched internal runtime context.",
         });
       }
       const requireExplicitTarget = options?.requireExplicitTarget === true;

--- a/src/agents/tools/message-tool-visible-content.ts
+++ b/src/agents/tools/message-tool-visible-content.ts
@@ -371,6 +371,21 @@ function readFirstStringParam(params: Record<string, unknown>, keys: readonly st
   return "";
 }
 
+// Media source keys accepted by the outbound send contract, including the
+// snake_case aliases some models emit into tool arguments.
+const SEND_MEDIA_SOURCE_KEYS = [
+  "media",
+  "mediaUrl",
+  "media_url",
+  "path",
+  "filePath",
+  "file_path",
+  "fileUrl",
+  "file_url",
+  "image",
+  "image_url",
+] as const;
+
 function readStructuredAttachmentMediaParams(value: unknown): string[] {
   if (!Array.isArray(value)) {
     return [];
@@ -381,7 +396,7 @@ function readStructuredAttachmentMediaParams(value: unknown): string[] {
       continue;
     }
     const record = attachment as Record<string, unknown>;
-    for (const key of ["media", "mediaUrl", "path", "filePath", "fileUrl", "url"]) {
+    for (const key of [...SEND_MEDIA_SOURCE_KEYS, "url"]) {
       const candidate = readToolStringParam(record, key);
       if (candidate) {
         values.push(candidate);
@@ -398,17 +413,24 @@ export function hasSanitizedSendPayloadContent(params: Record<string, unknown>):
     .join("\n");
   const mediaUrls = [
     ...(readStringArrayParam(params, "mediaUrls") ?? []),
+    ...(readStringArrayParam(params, "media_urls") ?? []),
     ...readStructuredAttachmentMediaParams(params.attachments),
   ];
   return hasReplyPayloadContent(
     {
       text,
-      mediaUrl: readFirstStringParam(params, ["media", "mediaUrl", "path", "filePath", "fileUrl"]),
+      mediaUrl: readFirstStringParam(params, SEND_MEDIA_SOURCE_KEYS),
       mediaUrls,
       presentation: params.presentation,
       interactive: params.interactive,
+      channelData: params.channelData,
+      location: params.location,
     },
-    { trimText: true },
+    {
+      trimText: true,
+      extraContent:
+        Boolean(readToolStringParam(params, "buffer", { trim: false })) || params.location != null,
+    },
   );
 }
 

--- a/src/agents/tools/message-tool-visible-content.ts
+++ b/src/agents/tools/message-tool-visible-content.ts
@@ -1,4 +1,5 @@
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+import { stripHeartbeatToken } from "../../auto-reply/heartbeat.js";
 import {
   hasInboundMetadataSentinel,
   stripInboundMetadata,
@@ -25,6 +26,7 @@ export function normalizeEscapedLineBreaksForVisibleText(text: string): string {
 }
 
 export type VisibleTextSuppressionReason =
+  | "heartbeat_token"
   | "internal_runtime_context_echo"
   | "inbound_metadata_echo"
   | "poll_vote_echo";
@@ -32,6 +34,7 @@ export type VisibleTextSuppressionReason =
 function sanitizeUserVisibleToolTextResult(
   text: string,
   bootPrompt: string | undefined,
+  options?: { stripHeartbeatToken?: boolean },
 ): {
   text: string;
   suppressionReason?: VisibleTextSuppressionReason;
@@ -43,18 +46,27 @@ function sanitizeUserVisibleToolTextResult(
   const strippedInbound = hasInboundMetadataSentinel(strippedBoot)
     ? stripInboundMetadata(strippedBoot)
     : strippedBoot;
-  const suppressionReason =
+  const heartbeat = options?.stripHeartbeatToken
+    ? stripHeartbeatToken(strippedInbound, { mode: "message" })
+    : undefined;
+  let suppressionReason: VisibleTextSuppressionReason | undefined;
+  if (heartbeat?.didStrip) {
+    suppressionReason = "heartbeat_token";
+  } else if (
     strippedBoot.trim().length === 0 &&
     strippedReasoning.trim().length > 0 &&
     (strippedInternal !== strippedReasoning || strippedBoot !== strippedInternal)
-      ? "internal_runtime_context_echo"
-      : strippedInbound.trim().length === 0 &&
-          strippedBoot.trim().length > 0 &&
-          strippedInbound !== strippedBoot
-        ? "inbound_metadata_echo"
-        : undefined;
+  ) {
+    suppressionReason = "internal_runtime_context_echo";
+  } else if (
+    strippedInbound.trim().length === 0 &&
+    strippedBoot.trim().length > 0 &&
+    strippedInbound !== strippedBoot
+  ) {
+    suppressionReason = "inbound_metadata_echo";
+  }
   return {
-    text: strippedInbound,
+    text: heartbeat?.text ?? strippedInbound,
     ...(suppressionReason ? { suppressionReason } : {}),
   };
 }
@@ -63,11 +75,12 @@ function sanitizeStringParam(
   params: Record<string, unknown>,
   field: string,
   bootPrompt: string | undefined,
+  options?: { stripHeartbeatToken?: boolean },
 ): VisibleTextSuppressionReason | undefined {
   if (typeof params[field] !== "string") {
     return undefined;
   }
-  const sanitized = sanitizeUserVisibleToolTextResult(params[field], bootPrompt);
+  const sanitized = sanitizeUserVisibleToolTextResult(params[field], bootPrompt, options);
   params[field] = sanitized.text;
   return sanitized.suppressionReason;
 }
@@ -76,10 +89,11 @@ function sanitizeStringArrayParam(
   params: Record<string, unknown>,
   field: string,
   bootPrompt: string | undefined,
+  options?: { stripHeartbeatToken?: boolean },
 ): VisibleTextSuppressionReason | undefined {
   const value = params[field];
   if (typeof value === "string") {
-    const sanitized = sanitizeUserVisibleToolTextResult(value, bootPrompt);
+    const sanitized = sanitizeUserVisibleToolTextResult(value, bootPrompt, options);
     params[field] = sanitized.text;
     return sanitized.suppressionReason;
   }
@@ -91,7 +105,7 @@ function sanitizeStringArrayParam(
     if (typeof entry !== "string") {
       return entry;
     }
-    const sanitized = sanitizeUserVisibleToolTextResult(entry, bootPrompt);
+    const sanitized = sanitizeUserVisibleToolTextResult(entry, bootPrompt, options);
     suppressionReason ??= sanitized.suppressionReason;
     return sanitized.text;
   });
@@ -101,6 +115,7 @@ function sanitizeStringArrayParam(
 function sanitizePresentationTextFieldsResult(
   value: unknown,
   bootPrompt: string | undefined,
+  options?: { stripHeartbeatToken?: boolean },
 ): { value: unknown; suppressionReason?: VisibleTextSuppressionReason } {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return { value };
@@ -108,7 +123,7 @@ function sanitizePresentationTextFieldsResult(
   let suppressionReason: VisibleTextSuppressionReason | undefined;
   const presentation = { ...(value as Record<string, unknown>) };
   if (typeof presentation.title === "string") {
-    const sanitized = sanitizeUserVisibleToolTextResult(presentation.title, bootPrompt);
+    const sanitized = sanitizeUserVisibleToolTextResult(presentation.title, bootPrompt, options);
     presentation.title = sanitized.text;
     suppressionReason ??= sanitized.suppressionReason;
   }
@@ -120,14 +135,22 @@ function sanitizePresentationTextFieldsResult(
       const sanitizedBlock = { ...(block as Record<string, unknown>) };
       for (const field of ["text", "placeholder", "title", "xLabel", "yLabel"]) {
         if (typeof sanitizedBlock[field] === "string") {
-          const sanitized = sanitizeUserVisibleToolTextResult(sanitizedBlock[field], bootPrompt);
+          const sanitized = sanitizeUserVisibleToolTextResult(
+            sanitizedBlock[field],
+            bootPrompt,
+            options,
+          );
           sanitizedBlock[field] = sanitized.text;
           suppressionReason ??= sanitized.suppressionReason;
         }
       }
       if (normalizeOptionalLowercaseString(sanitizedBlock.type) === "table") {
         if (typeof sanitizedBlock.caption === "string") {
-          const sanitized = sanitizeUserVisibleToolTextResult(sanitizedBlock.caption, bootPrompt);
+          const sanitized = sanitizeUserVisibleToolTextResult(
+            sanitizedBlock.caption,
+            bootPrompt,
+            options,
+          );
           sanitizedBlock.caption = sanitized.text.trim();
           suppressionReason ??= sanitized.suppressionReason;
         }
@@ -136,7 +159,7 @@ function sanitizePresentationTextFieldsResult(
             if (typeof header !== "string") {
               return header;
             }
-            const sanitized = sanitizeUserVisibleToolTextResult(header, bootPrompt);
+            const sanitized = sanitizeUserVisibleToolTextResult(header, bootPrompt, options);
             suppressionReason ??= sanitized.suppressionReason;
             return sanitized.text.trim();
           });
@@ -150,7 +173,7 @@ function sanitizePresentationTextFieldsResult(
               if (typeof cell !== "string") {
                 return cell;
               }
-              const sanitized = sanitizeUserVisibleToolTextResult(cell, bootPrompt);
+              const sanitized = sanitizeUserVisibleToolTextResult(cell, bootPrompt, options);
               suppressionReason ??= sanitized.suppressionReason;
               return sanitized.text.trim();
             });
@@ -164,12 +187,32 @@ function sanitizePresentationTextFieldsResult(
           }
           const sanitizedButton = { ...(button as Record<string, unknown>) };
           if (typeof sanitizedButton.label === "string") {
-            const sanitized = sanitizeUserVisibleToolTextResult(sanitizedButton.label, bootPrompt);
+            const sanitized = sanitizeUserVisibleToolTextResult(
+              sanitizedButton.label,
+              bootPrompt,
+              options,
+            );
             sanitizedButton.label = sanitized.text;
             suppressionReason ??= sanitized.suppressionReason;
           }
+          // Downstream normalizers accept `text` as a legacy label alias
+          // (normalizeButton: label ?? text); sanitize it too so heartbeat
+          // tokens cannot ride through a legacy-shaped button.
+          if (typeof sanitizedButton.text === "string") {
+            const sanitized = sanitizeUserVisibleToolTextResult(
+              sanitizedButton.text,
+              bootPrompt,
+              options,
+            );
+            sanitizedButton.text = sanitized.text;
+            suppressionReason ??= sanitized.suppressionReason;
+          }
           if (typeof sanitizedButton.url === "string") {
-            const sanitized = sanitizeUserVisibleToolTextResult(sanitizedButton.url, bootPrompt);
+            const sanitized = sanitizeUserVisibleToolTextResult(
+              sanitizedButton.url,
+              bootPrompt,
+              options,
+            );
             if (sanitized.text) {
               sanitizedButton.url = sanitized.text;
             } else {
@@ -186,7 +229,11 @@ function sanitizePresentationTextFieldsResult(
             if (typeof sanitizedWebApp.url !== "string") {
               continue;
             }
-            const sanitized = sanitizeUserVisibleToolTextResult(sanitizedWebApp.url, bootPrompt);
+            const sanitized = sanitizeUserVisibleToolTextResult(
+              sanitizedWebApp.url,
+              bootPrompt,
+              options,
+            );
             if (sanitized.text) {
               sanitizedWebApp.url = sanitized.text;
               sanitizedButton[webAppField] = sanitizedWebApp;
@@ -202,7 +249,11 @@ function sanitizePresentationTextFieldsResult(
               (sanitizedAction.type === "url" || sanitizedAction.type === "web-app") &&
               typeof sanitizedAction.url === "string"
             ) {
-              const sanitized = sanitizeUserVisibleToolTextResult(sanitizedAction.url, bootPrompt);
+              const sanitized = sanitizeUserVisibleToolTextResult(
+                sanitizedAction.url,
+                bootPrompt,
+                options,
+              );
               if (sanitized.text) {
                 sanitizedAction.url = sanitized.text;
                 sanitizedButton.action = sanitizedAction;
@@ -235,8 +286,24 @@ function sanitizePresentationTextFieldsResult(
           }
           const sanitizedOption = { ...(option as Record<string, unknown>) };
           if (typeof sanitizedOption.label === "string") {
-            const sanitized = sanitizeUserVisibleToolTextResult(sanitizedOption.label, bootPrompt);
+            const sanitized = sanitizeUserVisibleToolTextResult(
+              sanitizedOption.label,
+              bootPrompt,
+              options,
+            );
             sanitizedOption.label = sanitized.text;
+            suppressionReason ??= sanitized.suppressionReason;
+          }
+          // normalizeOption also accepts `text` as a legacy label alias;
+          // sanitize it so heartbeat tokens cannot ride through a
+          // legacy-shaped option.
+          if (typeof sanitizedOption.text === "string") {
+            const sanitized = sanitizeUserVisibleToolTextResult(
+              sanitizedOption.text,
+              bootPrompt,
+              options,
+            );
+            sanitizedOption.text = sanitized.text;
             suppressionReason ??= sanitized.suppressionReason;
           }
           return sanitizedOption;
@@ -247,7 +314,7 @@ function sanitizePresentationTextFieldsResult(
           if (typeof category !== "string") {
             return category;
           }
-          const sanitized = sanitizeUserVisibleToolTextResult(category, bootPrompt);
+          const sanitized = sanitizeUserVisibleToolTextResult(category, bootPrompt, options);
           suppressionReason ??= sanitized.suppressionReason;
           return sanitized.text;
         });
@@ -259,7 +326,11 @@ function sanitizePresentationTextFieldsResult(
           }
           const sanitizedSegment = { ...(segment as Record<string, unknown>) };
           if (typeof sanitizedSegment.label === "string") {
-            const sanitized = sanitizeUserVisibleToolTextResult(sanitizedSegment.label, bootPrompt);
+            const sanitized = sanitizeUserVisibleToolTextResult(
+              sanitizedSegment.label,
+              bootPrompt,
+              options,
+            );
             sanitizedSegment.label = sanitized.text;
             suppressionReason ??= sanitized.suppressionReason;
           }
@@ -273,7 +344,11 @@ function sanitizePresentationTextFieldsResult(
           }
           const sanitizedSeries = { ...(series as Record<string, unknown>) };
           if (typeof sanitizedSeries.name === "string") {
-            const sanitized = sanitizeUserVisibleToolTextResult(sanitizedSeries.name, bootPrompt);
+            const sanitized = sanitizeUserVisibleToolTextResult(
+              sanitizedSeries.name,
+              bootPrompt,
+              options,
+            );
             sanitizedSeries.name = sanitized.text;
             suppressionReason ??= sanitized.suppressionReason;
           }
@@ -340,6 +415,7 @@ export function hasSanitizedSendPayloadContent(params: Record<string, unknown>):
 export function sanitizeMessageToolVisiblePayload(
   params: Record<string, unknown>,
   agentSessionKey?: string,
+  options?: { stripHeartbeatToken?: boolean },
 ): VisibleTextSuppressionReason | undefined {
   // Sanitize outbound text fields in three layers:
   //
@@ -366,26 +442,33 @@ export function sanitizeMessageToolVisiblePayload(
     "quoteText",
     "quote_text",
   ]) {
-    const suppressionReason = sanitizeStringParam(params, field, bootPromptForSession);
+    const suppressionReason = sanitizeStringParam(params, field, bootPromptForSession, options);
     suppressedVisiblePayloadReason ??= suppressionReason;
   }
   for (const field of ["pollQuestion", "poll_question"]) {
-    const suppressionReason = sanitizeStringParam(params, field, bootPromptForSession);
+    const suppressionReason = sanitizeStringParam(params, field, bootPromptForSession, options);
     suppressedVisiblePayloadReason ??= suppressionReason;
   }
   for (const field of ["pollOption", "poll_option"]) {
-    const suppressionReason = sanitizeStringArrayParam(params, field, bootPromptForSession);
+    const suppressionReason = sanitizeStringArrayParam(
+      params,
+      field,
+      bootPromptForSession,
+      options,
+    );
     suppressedVisiblePayloadReason ??= suppressionReason;
   }
   const sanitizedPresentation = sanitizePresentationTextFieldsResult(
     params.presentation,
     bootPromptForSession,
+    options,
   );
   params.presentation = sanitizedPresentation.value;
   suppressedVisiblePayloadReason ??= sanitizedPresentation.suppressionReason;
   const sanitizedInteractive = sanitizePresentationTextFieldsResult(
     params.interactive,
     bootPromptForSession,
+    options,
   );
   params.interactive = sanitizedInteractive.value;
   suppressedVisiblePayloadReason ??= sanitizedInteractive.suppressionReason;

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -147,6 +147,7 @@ vi.mock("../../channels/plugins/bundled.js", async () => {
 });
 
 type RunMessageActionInput = {
+  action?: ChannelMessageActionName;
   actionOrigin?: "message-tool";
   agentId?: string;
   broadcastAccountPlan?: {

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -4752,6 +4752,60 @@ describe("message tool internal-runtime-context sanitization", () => {
     expect(call?.action).toBe("broadcast");
   });
 
+  it("keeps a heartbeat-captioned raw buffer send dispatching", async () => {
+    mockSendResult({ channel: "telegram", to: "telegram:123" });
+
+    const call = await executeSend({
+      action: {
+        action: "send",
+        channel: "telegram",
+        target: "telegram:123",
+        caption: "HEARTBEAT_OK",
+        buffer: "aGVsbG8=",
+      },
+    });
+
+    expect(call).toBeDefined();
+    expect(mocks.runMessageAction).toHaveBeenCalledTimes(1);
+    expect(call?.params?.caption ?? call?.params?.text).not.toContain("HEARTBEAT_OK");
+  });
+
+  it("keeps a heartbeat-captioned location send dispatching", async () => {
+    mockSendResult({ channel: "telegram", to: "telegram:123" });
+
+    const call = await executeSend({
+      action: {
+        action: "send",
+        channel: "telegram",
+        target: "telegram:123",
+        caption: "HEARTBEAT_OK",
+        location: { latitude: 31.23, longitude: 121.47 },
+      },
+    });
+
+    expect(call).toBeDefined();
+    expect(mocks.runMessageAction).toHaveBeenCalledTimes(1);
+    expect(call?.params?.caption ?? call?.params?.text).not.toContain("HEARTBEAT_OK");
+  });
+
+  it("keeps a heartbeat-captioned snake_case media send dispatching", async () => {
+    mockSendResult({ channel: "telegram", to: "telegram:123" });
+
+    const call = await executeSend({
+      action: {
+        action: "send",
+        channel: "telegram",
+        target: "telegram:123",
+        caption: "HEARTBEAT_OK",
+        media_url: "media://inbound/photo.jpg",
+      },
+    });
+
+    expect(call).toBeDefined();
+    expect(mocks.runMessageAction).toHaveBeenCalledTimes(1);
+    expect(call?.params?.caption ?? call?.params?.text).not.toContain("HEARTBEAT_OK");
+  });
+
   it("suppresses a heartbeat-only reply", async () => {
     const { call, result } = await executeSendWithResult({
       action: {

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -4525,6 +4525,265 @@ describe("message tool internal-runtime-context sanitization", () => {
     expect(call?.params?.text).toBe("");
     expect(call?.params?.message).toBe("Visible");
   });
+
+  it("suppresses a send whose text is only the heartbeat token", async () => {
+    const { call, result } = await executeSendWithResult({
+      action: {
+        channel: "telegram",
+        target: "telegram:123",
+        text: "HEARTBEAT_OK",
+      },
+    });
+
+    expect(call).toBeUndefined();
+    expect(mocks.runMessageAction).not.toHaveBeenCalled();
+    expect(result.details).toMatchObject({
+      status: "suppressed",
+      reason: "heartbeat_token",
+    });
+  });
+
+  it("suppresses heartbeat-only sends through text aliases", async () => {
+    const { call, result } = await executeSendWithResult({
+      action: {
+        channel: "telegram",
+        target: "telegram:123",
+        content: "HEARTBEAT_OK",
+      },
+    });
+
+    expect(call).toBeUndefined();
+    expect(mocks.runMessageAction).not.toHaveBeenCalled();
+    expect(result.details).toMatchObject({
+      status: "suppressed",
+      reason: "heartbeat_token",
+    });
+  });
+
+  it("strips the heartbeat token but still sends real content", async () => {
+    mockSendResult({ channel: "telegram", to: "telegram:123" });
+
+    const call = await executeSend({
+      action: {
+        channel: "telegram",
+        target: "telegram:123",
+        text: "All checks passed. HEARTBEAT_OK",
+      },
+    });
+
+    expect(call?.params?.text).toBe("All checks passed.");
+  });
+
+  it("suppresses heartbeat-only presentation sends", async () => {
+    const { call, result } = await executeSendWithResult({
+      action: {
+        channel: "slack",
+        target: "slack:C123",
+        presentation: {
+          title: "HEARTBEAT_OK",
+          blocks: [{ type: "text", text: "HEARTBEAT_OK" }],
+        },
+      },
+    });
+
+    expect(call).toBeUndefined();
+    expect(mocks.runMessageAction).not.toHaveBeenCalled();
+    expect(result.details).toMatchObject({
+      status: "suppressed",
+      reason: "heartbeat_token",
+    });
+  });
+
+  it("suppresses heartbeat-only interactive sends", async () => {
+    const { call, result } = await executeSendWithResult({
+      action: {
+        channel: "slack",
+        target: "slack:C123",
+        interactive: {
+          blocks: [{ type: "text", text: "HEARTBEAT_OK" }],
+        },
+      },
+    });
+
+    expect(call).toBeUndefined();
+    expect(mocks.runMessageAction).not.toHaveBeenCalled();
+    expect(result.details).toMatchObject({
+      status: "suppressed",
+      reason: "heartbeat_token",
+    });
+  });
+
+  it("suppresses heartbeat-only sends through legacy button and option label aliases", async () => {
+    const { call, result } = await executeSendWithResult({
+      action: {
+        channel: "slack",
+        target: "slack:C123",
+        interactive: {
+          blocks: [
+            {
+              type: "buttons",
+              buttons: [{ text: "HEARTBEAT_OK", value: "run" }],
+            },
+            {
+              type: "select",
+              options: [{ text: "HEARTBEAT_OK", value: "pick" }],
+            },
+          ],
+        },
+      },
+    });
+
+    expect(call).toBeUndefined();
+    expect(mocks.runMessageAction).not.toHaveBeenCalled();
+    expect(result.details).toMatchObject({
+      status: "suppressed",
+      reason: "heartbeat_token",
+    });
+  });
+
+  it("strips heartbeat tokens from legacy button and option label aliases with real content", async () => {
+    mockSendResult({ channel: "slack", to: "slack:C123" });
+
+    const call = await executeSend({
+      action: {
+        channel: "slack",
+        target: "slack:C123",
+        interactive: {
+          blocks: [
+            {
+              type: "buttons",
+              buttons: [{ text: "Run now HEARTBEAT_OK", value: "run" }],
+            },
+            {
+              type: "select",
+              options: [{ text: "Pick me HEARTBEAT_OK", value: "pick" }],
+            },
+          ],
+        },
+      },
+    });
+
+    expect(call?.params?.interactive).toEqual({
+      blocks: [
+        {
+          type: "buttons",
+          buttons: [{ text: "Run now", value: "run" }],
+        },
+        {
+          type: "select",
+          options: [{ text: "Pick me", value: "pick" }],
+        },
+      ],
+    });
+  });
+
+  it("strips heartbeat tokens across mixed flat and structured send text", async () => {
+    mockSendResult({ channel: "slack", to: "slack:C123" });
+
+    const call = await executeSend({
+      action: {
+        channel: "slack",
+        target: "slack:C123",
+        text: "Flat content HEARTBEAT_OK",
+        presentation: {
+          blocks: [{ type: "text", text: "Presentation content HEARTBEAT_OK" }],
+        },
+        interactive: {
+          blocks: [{ type: "text", text: "Interactive content HEARTBEAT_OK" }],
+        },
+      },
+    });
+
+    expect(call?.params?.text).toBe("Flat content");
+    expect(call?.params?.presentation).toEqual({
+      blocks: [{ type: "text", text: "Presentation content" }],
+    });
+    expect(call?.params?.interactive).toEqual({
+      blocks: [{ type: "text", text: "Interactive content" }],
+    });
+  });
+
+  it("preserves heartbeat-token text for non-send actions", async () => {
+    mockSendResult({ channel: "telegram", to: "telegram:123" });
+
+    const call = await executeSend({
+      action: {
+        action: "poll",
+        channel: "telegram",
+        target: "telegram:123",
+        pollQuestion: "HEARTBEAT_OK",
+        pollOption: ["Yes", "No"],
+      },
+    });
+
+    expect(call?.params?.pollQuestion).toBe("HEARTBEAT_OK");
+  });
+
+  it("suppresses a heartbeat-only broadcast before fan-out", async () => {
+    const { call, result } = await executeSendWithResult({
+      action: {
+        action: "broadcast",
+        targets: ["telegram:123", "slack:C123"],
+        text: "HEARTBEAT_OK",
+      },
+    });
+
+    expect(call).toBeUndefined();
+    expect(mocks.runMessageAction).not.toHaveBeenCalled();
+    expect(result.details).toMatchObject({
+      status: "suppressed",
+      reason: "heartbeat_token",
+    });
+  });
+
+  it("strips the heartbeat token from broadcast text with real content", async () => {
+    mockSendResult({ channel: "telegram", to: "telegram:123" });
+
+    const call = await executeSend({
+      action: {
+        action: "broadcast",
+        targets: ["telegram:123", "slack:C123"],
+        text: "Broadcast update HEARTBEAT_OK",
+      },
+    });
+
+    expect(call?.params?.text).toBe("Broadcast update");
+    expect(call?.action).toBe("broadcast");
+  });
+
+  it("suppresses a heartbeat-only reply", async () => {
+    const { call, result } = await executeSendWithResult({
+      action: {
+        action: "reply",
+        channel: "telegram",
+        target: "telegram:123",
+        text: "HEARTBEAT_OK",
+      },
+    });
+
+    expect(call).toBeUndefined();
+    expect(mocks.runMessageAction).not.toHaveBeenCalled();
+    expect(result.details).toMatchObject({
+      status: "suppressed",
+      reason: "heartbeat_token",
+    });
+  });
+
+  it("strips the heartbeat token from reply text with real content", async () => {
+    mockSendResult({ channel: "telegram", to: "telegram:123" });
+
+    const call = await executeSend({
+      action: {
+        action: "reply",
+        channel: "telegram",
+        target: "telegram:123",
+        text: "All checks passed. HEARTBEAT_OK",
+      },
+    });
+
+    expect(call?.params?.text).toBe("All checks passed.");
+    expect(call?.action).toBe("reply");
+  });
 });
 
 describe("message tool sandbox passthrough", () => {


### PR DESCRIPTION
## What Problem This Solves

Cron `agentTurn` runs (7.2+) append two instructions back-to-back in the same command body: the unattended-run preamble tells the agent to reply exactly `HEARTBEAT_OK` when nothing needs doing, and the delivery instruction offers the general `message` tool as a direct notification path. The `message` tool send path had no heartbeat-token strip, so an agent that followed both instructions delivered the literal string `HEARTBEAT_OK` into the user's chat. The framework's sanitizer only stripped the token from final-reply payloads, never from `message(action=send)` payloads.

## Why

`HEARTBEAT_OK` is an internal turn-protocol token, not user-facing content. Delivering it verbatim pollutes the user's chat with protocol noise and makes the cron run look like it sent a real (empty) notification. The final-reply path already strips the token (`stripHeartbeatToken` in `src/auto-reply/heartbeat.ts`); the message tool was the only outbound path where the token could leak through.

## User Impact

Cron jobs with `delivery.mode: "announce"` no longer post a literal `HEARTBEAT_OK` message into the chat when the agent decides nothing needs doing. A heartbeat-only send is now suppressed entirely (tool result tells the agent the ack was suppressed), and a send that mixes real content with the token is delivered with the token stripped — the same contract the final-reply path already honors.

## Evidence

- [AI-assisted] Change in `src/agents/tools/message-tool.ts`:
  - `execute()` now strips `HEARTBEAT_OK` from the body text fields (`text`/`content`/`message`/`caption`/`SendMessage`) via the shared `stripHeartbeatToken(..., { mode: "message" })`, mirroring the poll-vote-echo suppression pattern already in the tool.
  - When the send payload has no remaining content after stripping, the tool returns `{ status: "suppressed", reason: "heartbeat_token" }` instead of dispatching; media-only sends still go through with empty text.
- Tests added in `src/agents/tools/message-tool.test.ts`:
  - suppresses a send whose text is only `HEARTBEAT_OK` (no `runMessageAction` call),
  - suppresses heartbeat-only sends through text aliases (`content`),
  - strips a trailing token but still sends real content (`"All checks passed. HEARTBEAT_OK"` → `"All checks passed."`),
  - keeps sending media when the token is the only text.
- `pnpm vitest run src/agents/tools/message-tool.test.ts` → 466 passed (2 projects).

## QA Gateway proof

Exact-head QA Gateway + qa-channel proof passed on `35750db969056edc1918cb9d2ceeee55e2828510`:

```json
{
  "scenario": "heartbeat-message-tool-send-proof",
  "status": "pass",
  "counts": { "total": 1, "passed": 1, "failed": 0, "skipped": 0 },
  "steps": [
    { "name": "suppresses a heartbeat-only message tool send", "status": "pass", "dispatches": 0 },
    { "name": "strips the token and delivers mixed visible content", "status": "pass", "deliveredText": "QA-HEARTBEAT-CLEAN", "dispatches": 1 }
  ]
}
```

The proof used the repository QA Gateway with the mock provider and qa-channel, exercising the real message-tool-to-channel boundary without external credentials.

## Reply-action coverage (P1 finding, head `63451b54c78`)

`reply` is a sibling visible delivery action: the sanitizer predicate now includes it, so a heartbeat-only `message(action="reply")` is suppressed before dispatch and mixed-content replies are stripped, matching `send`/`broadcast`.

```text
❯ node scripts/run-vitest.mjs src/agents/tools/message-tool.test.ts
 ✓  agents-tools  src/agents/tools/message-tool.test.ts (247 tests) 23083ms
     ✓ suppresses a heartbeat-only reply
     ✓ strips the heartbeat token from reply text with real content
 Test Files  1 passed (1)
      Tests  247 passed (247)
```

## Split-owner port (P1 finding, head `60141c44b74`)

`main` split `message-tool.ts` into `message-tool-execution.ts` (dispatch) + `message-tool-visible-content.ts` (sanitization) after this branch forked, so the heartbeat strip was ported onto the split owner boundary:

- `message-tool-visible-content.ts` now owns the `HEARTBEAT_OK` strip and reports `heartbeat_token` as a suppression reason; the legacy `text` label aliases on buttons and select options are sanitized too (`normalizeButton`/`normalizeOption` accept `label ?? text`).
- `message-tool-execution.ts` applies the strip for `send`/`broadcast`/`reply` and suppresses token-only payloads before dispatch.
- Regression coverage added in `src/agents/tools/message-tool.test.ts` for send/broadcast/reply, presentation, interactive, and legacy label-alias shapes.

```text
❯ node_modules/.bin/vitest run src/agents/tools/message-tool.test.ts
 ✓  agents-core   src/agents/tools/message-tool.test.ts (243 tests)
 ✓  agents-tools  src/agents/tools/message-tool.test.ts (243 tests)
 Test Files  2 passed (2)
      Tests  486 passed (486)
```


## 2026-08-12 patrol update (head `46bc123e4d`)

- **P1 fixed — non-text heartbeat-captioned sends no longer dropped**: `hasSanitizedSendPayloadContent` recognized text, media paths, attachments, presentation, and interactive payloads but not raw `buffer` data, portable `location`, `channelData`, `image`, or snake_case media aliases (`media_url`, `file_url`, `file_path`, `image_url`, `media_urls`). A heartbeat-captioned buffer/location/media send could be suppressed after stripping the caption. The predicate now covers the full outbound send contract, with regression tests for buffer, location, and snake_case media sends.
- **check-test-types fixed**: the local `RunMessageActionInput` mock type now carries the top-level `action` field the real `MessageActionInput` contract has.

```text
❯ node_modules/.bin/vitest run src/agents/tools/message-tool.test.ts -t heartbeat
 ✓  agents-core   src/agents/tools/message-tool.test.ts (246 tests)
 ✓  agents-tools  src/agents/tools/message-tool.test.ts (246 tests)
 Test Files  2 passed (2)
      Tests  32 passed | 460 skipped (492)
```
