### PR TITLE
fix(feishu): render interactive replies as cards in the reply path (#119616)

### DIFF
--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -185,7 +185,7 @@ function consumeFeishuPresentationFallbackMarker(payload: FeishuOutboundPayload)
   };
 }
 
-function buildFeishuPayloadCard(params: {
+export function buildFeishuPayloadCard(params: {
   payload: Parameters<NonNullable<ChannelOutboundAdapter["sendPayload"]>>[0]["payload"];
   text?: string;
   identity?: Parameters<NonNullable<ChannelOutboundAdapter["sendPayload"]>>[0]["identity"];

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -24,6 +24,7 @@ const getGlobalHookRunnerMock = vi.hoisted(() => vi.fn());
 const sendMessageFeishuMock = vi.hoisted(() => vi.fn());
 const sendMarkdownCardFeishuMock = vi.hoisted(() => vi.fn());
 const sendStructuredCardFeishuMock = vi.hoisted(() => vi.fn());
+const sendCardFeishuMock = vi.hoisted(() => vi.fn());
 const sendMediaFeishuMock = vi.hoisted(() => vi.fn());
 const createFeishuClientMock = vi.hoisted(() => vi.fn());
 const resolveReceiveIdTypeMock = vi.hoisted(() => vi.fn());
@@ -94,6 +95,7 @@ vi.mock("./send.js", () => ({
   sendMessageFeishu: sendMessageFeishuMock,
   sendMarkdownCardFeishu: sendMarkdownCardFeishuMock,
   sendStructuredCardFeishu: sendStructuredCardFeishuMock,
+  sendCardFeishu: sendCardFeishuMock,
 }));
 vi.mock("./media.js", () => ({
   sendMediaFeishu: sendMediaFeishuMock,
@@ -187,6 +189,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     streamingInstances.length = 0;
     sendMediaFeishuMock.mockResolvedValue(undefined);
     sendStructuredCardFeishuMock.mockResolvedValue(undefined);
+    sendCardFeishuMock.mockResolvedValue({ messageId: "om_card" });
     getGlobalHookRunnerMock.mockReturnValue(null);
 
     resolveFeishuAccountMock.mockReturnValue({
@@ -531,6 +534,72 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       to: "user:ou_sender",
       replyToMessageId: undefined,
     });
+  });
+
+  it("renders interactive replies as a button card instead of dropping the buttons", async () => {
+    useNonStreamingAutoAccount();
+    const { options } = createDispatcherHarness();
+
+    const delivery = await options.deliver(
+      {
+        text: "Plugin bind request from acme",
+        interactive: {
+          blocks: [
+            {
+              type: "buttons",
+              buttons: [
+                { label: "Allow once", value: "allow-once", style: "primary" },
+                { label: "Deny", value: "deny", style: "danger" },
+              ],
+            },
+          ],
+        },
+      },
+      { kind: "final" },
+    );
+
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(sendCardFeishuMock).toHaveBeenCalledTimes(1);
+    const cardArgs = firstMockArg(sendCardFeishuMock, "card send params");
+    expect(cardArgs).toMatchObject({ to: "oc_chat" });
+    const serialized = JSON.stringify(cardArgs.card);
+    expect(serialized).toContain("Allow once");
+    expect(serialized).toContain("Deny");
+    expect(serialized).toContain("Plugin bind request from acme");
+    expect(delivery?.visibleReplySent).toBe(true);
+  });
+
+  it("renders presentation replies as a card with title and fallback text", async () => {
+    useNonStreamingAutoAccount();
+    const { options } = createDispatcherHarness();
+
+    const delivery = await options.deliver(
+      {
+        text: "Fallback text",
+        presentation: {
+          title: "Approve?",
+          blocks: [{ type: "text", text: "Allow acme to read files?" }],
+        },
+      },
+      { kind: "final" },
+    );
+
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(sendCardFeishuMock).toHaveBeenCalledTimes(1);
+    const serialized = JSON.stringify(firstMockArg(sendCardFeishuMock, "card send params").card);
+    expect(serialized).toContain("Approve?");
+    expect(serialized).toContain("Allow acme to read files?");
+    expect(delivery?.visibleReplySent).toBe(true);
+  });
+
+  it("keeps plain text replies on the message path without a card", async () => {
+    useNonStreamingAutoAccount();
+    const { options } = createDispatcherHarness();
+
+    await options.deliver({ text: "plain text" }, { kind: "final" });
+
+    expect(sendCardFeishuMock).not.toHaveBeenCalled();
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
   });
 
   it("streams auto mode plain final text when streaming is enabled", async () => {

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -28,6 +28,7 @@ import { chunkFeishuPostMarkdown, materializeFeishuPostMarkdownSoftBreaks } from
 import { buildFeishuMediaFallbackText } from "./media-fallback.js";
 import { sendMediaFeishu, shouldSuppressFeishuTextForVoiceMedia } from "./media.js";
 import type { MentionTarget } from "./mention-target.types.js";
+import { buildFeishuPayloadCard } from "./outbound.js";
 import {
   createFeishuPartialReplyDeliveryError,
   createFeishuReplyDeliveryResult,
@@ -46,7 +47,12 @@ import {
 } from "./reply-dispatcher-runtime-api.js";
 import { streamingStartBackoffUntilByAccount } from "./reply-dispatcher-state.js";
 import { getFeishuRuntime } from "./runtime.js";
-import { sendMessageFeishu, sendStructuredCardFeishu, type CardHeaderConfig } from "./send.js";
+import {
+  sendCardFeishu,
+  sendMessageFeishu,
+  sendStructuredCardFeishu,
+  type CardHeaderConfig,
+} from "./send.js";
 import {
   FeishuStreamingFinalizationError,
   FeishuStreamingSession,
@@ -1272,6 +1278,16 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           : reply.text;
       const hasText = reply.hasText;
       const hasMedia = reply.hasMedia;
+      // Interactive/presentation replies (plugin bind approvals, exec
+      // approvals, command replies carrying buttons) must render as a Feishu
+      // card. The outbound push path already renders them via
+      // `buildFeishuPayloadCard`; the reply path used to forward only `text`
+      // and silently discard the buttons (#119616).
+      const presentationCard = buildFeishuPayloadCard({
+        payload: { ...payload, text: payloadText },
+        text: payloadText,
+        identity,
+      });
       const ttsSupplement = getReplyPayloadTtsSupplement(payload);
       const ttsTextAlreadyVisible = ttsSupplement?.visibleTextAlreadyDelivered === true;
       const hasVoiceMedia =
@@ -1341,6 +1357,41 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
 
       if (shouldDiscardStreamingPreview) {
         await discardStreamingPreview();
+      }
+
+      if (presentationCard) {
+        // Interactive content is delivered as one card; the fallback text lives
+        // inside it, so no text chunks are sent alongside. Discard any
+        // streaming preview first so the card is the single visible reply.
+        if (streaming?.isActive() || streamingStartPromise) {
+          await discardStreamingPreview();
+        }
+        deliveredResults.push(
+          createFeishuReplyDeliveryResult({
+            results: [
+              await sendCardFeishu({
+                cfg,
+                to: sendTarget,
+                card: presentationCard,
+                replyToMessageId: sendReplyToMessageId,
+                replyInThread: effectiveReplyInThread,
+                allowTopLevelReplyFallback,
+                accountId,
+              }),
+            ],
+            visibleReplySent: true,
+            content: text,
+            kind: "card",
+          }),
+        );
+        markVisibleReplySent();
+        if (info?.kind === "final") {
+          deliveredFinalTexts.add(text);
+        }
+        if (hasMedia) {
+          await collectMediaDelivery(payload);
+        }
+        return mergeFeishuReplyDeliveryResults(deliveredResults, text);
       }
 
       if (shouldDeliverText) {


### PR DESCRIPTION
## What Problem This Solves

The Feishu channel declares `presentationCapabilities.buttons: true` and registers a working `renderPresentation`, but its agent/command **reply path** never read `payload.interactive` or `payload.presentation`. Any reply carrying interactive blocks (plugin bind approval with Allow once / Always allow / Deny, exec approval, command replies returning `{ text, interactive }`) was delivered as plain text with the buttons silently discarded. The outbound push path (`sendPayload`/`renderPresentation`) rendered these correctly, so the defect was isolated to the reply path's `deliver`.

## Why

The reply dispatcher (`extensions/feishu/src/reply-dispatcher.ts`) only forwarded `text` into its chunked text/card senders, whose signatures have no place for interactive content. Core's generic delivery path renders presentations through the channel's `renderPresentation`, but this reply path bypassed it with its own send logic — so button-based approval flows on Feishu were broken end-to-end while the channel advertised button support. Sibling channels (e.g. Telegram's `bot-message-dispatch-reply.ts`) already honor `payload.presentation`/`payload.interactive` in their reply paths.

## User Impact

Plugin bind approval, exec approval, and any command reply with buttons now render as a Feishu interactive card with working buttons, matching what the channel advertises and what the push path already delivered. Plain-text replies are unchanged (still routed through the message path).

## Evidence

- [AI-assisted] `extensions/feishu/src/outbound.ts`: exported `buildFeishuPayloadCard` (previously private) so the reply path reuses the exact card renderer the working push path uses — one renderer, no drift.
- [AI-assisted] `extensions/feishu/src/reply-dispatcher.ts` (`deliver`):
  - builds the presentation card from the payload (`interactive` legacy shape or `presentation`, plus native `channelData.feishu` cards) via `buildFeishuPayloadCard`;
  - when a card is produced, discards any active streaming preview and sends it with `sendCardFeishu` as a single interactive message (fallback text lives inside the card), records a `card`-kind delivery receipt, and skips the text-chunk path.
- Tests in `extensions/feishu/src/reply-dispatcher.test.ts` (all passing):
  - interactive reply → `sendCardFeishu` called once with a card containing both button labels and the fallback text; `sendMessageFeishu` not called; `visibleReplySent: true`;
  - presentation reply → card contains title and block text;
  - plain-text reply regression guard → no card, message path used.
- `pnpm vitest run extensions/feishu/src/reply-dispatcher.test.ts` → 127 passed; `extensions/feishu/src/outbound.test.ts` → 122 passed; `tsgo` extensions typecheck clean.
