### PR TITLE
fix(doctor): resolve legacy systemd unit for the target profile (#119648)

### DIFF
--- a/src/daemon/constants.test.ts
+++ b/src/daemon/constants.test.ts
@@ -9,6 +9,7 @@ import {
   resolveGatewayServiceDescription,
   resolveGatewaySystemdServiceName,
   resolveGatewayWindowsTaskName,
+  resolveLegacyGatewaySystemdServiceName,
 } from "./constants.js";
 
 describe("resolveGatewayLaunchAgentLabel", () => {
@@ -33,6 +34,23 @@ describe("resolveGatewaySystemdServiceName", () => {
   it("returns profile-specific service name when profile is set", () => {
     const result = resolveGatewaySystemdServiceName("dev");
     expect(result).toBe("openclaw-gateway-dev");
+  });
+});
+
+describe("resolveLegacyGatewaySystemdServiceName", () => {
+  it("returns the unqualified legacy name for the default profile", () => {
+    const result = resolveLegacyGatewaySystemdServiceName();
+    expect(result).toBe("openclaw");
+  });
+
+  it("returns the openclaw-<profile> legacy name for a named profile", () => {
+    const result = resolveLegacyGatewaySystemdServiceName("lisa");
+    expect(result).toBe("openclaw-lisa");
+  });
+
+  it("normalizes the default profile to the unqualified legacy name", () => {
+    const result = resolveLegacyGatewaySystemdServiceName("default");
+    expect(result).toBe("openclaw");
   });
 });
 

--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -51,6 +51,17 @@ export function resolveGatewaySystemdServiceName(profile?: string): string {
   return `openclaw-gateway${suffix}`;
 }
 
+/**
+ * Legacy systemd service name (`openclaw[-<profile>]`), used by installs that
+ * predate the `openclaw-gateway-` rename. The default profile maps to
+ * `openclaw`; the pre-rename Clawdbot era is covered separately by
+ * {@link LEGACY_GATEWAY_SYSTEMD_SERVICE_NAMES}.
+ */
+export function resolveLegacyGatewaySystemdServiceName(profile?: string): string {
+  const normalized = normalizeGatewayProfile(profile);
+  return normalized ? `openclaw-${normalized}` : "openclaw";
+}
+
 export function resolveGatewayWindowsTaskName(profile?: string): string {
   const normalized = normalizeGatewayProfile(profile);
   if (!normalized) {

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -733,6 +733,80 @@ describe("system-scope gateway unit detection (openclaw#87577)", () => {
     });
   });
 
+  it("findInstalledSystemdGatewayScope resolves the legacy openclaw-<profile> system unit for a named profile", async () => {
+    mockUnitFileLayout({ system: "/etc/systemd/system/openclaw-lisa.service" });
+    const result = await findInstalledSystemdGatewayScope({
+      HOME: TEST_MANAGED_HOME,
+      OPENCLAW_PROFILE: "lisa",
+    });
+    expect(result).toEqual({
+      scope: "system",
+      unitName: "openclaw-lisa.service",
+      unitPath: "/etc/systemd/system/openclaw-lisa.service",
+    });
+  });
+
+  it("refuses to borrow an unrelated marker-owned unit as the target profile's gateway (#119648)", async () => {
+    mockUnitFileLayout({ system: false });
+    findSystemGatewayServicesMock.mockResolvedValueOnce([
+      {
+        platform: "linux",
+        label: "openclaw-darlene.service",
+        detail: "unit: /etc/systemd/system/openclaw-darlene.service",
+        scope: "system",
+        marker: "openclaw",
+      },
+    ]);
+    const result = await findInstalledSystemdGatewayScope({
+      HOME: TEST_MANAGED_HOME,
+      OPENCLAW_PROFILE: "lisa",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("accepts a marker-owned unit matching the target profile's legacy name", async () => {
+    mockUnitFileLayout({ system: false });
+    findSystemGatewayServicesMock.mockResolvedValueOnce([
+      {
+        platform: "linux",
+        label: "openclaw-lisa.service",
+        detail: "unit: /etc/systemd/system/openclaw-lisa.service",
+        scope: "system",
+        marker: "openclaw",
+      },
+    ]);
+    const result = await findInstalledSystemdGatewayScope({
+      HOME: TEST_MANAGED_HOME,
+      OPENCLAW_PROFILE: "lisa",
+    });
+    expect(result).toEqual({
+      scope: "system",
+      unitName: "openclaw-lisa.service",
+      unitPath: "/etc/systemd/system/openclaw-lisa.service",
+    });
+  });
+
+  it("readSystemdServiceRuntime reads the legacy unit's own status instead of an unrelated agent's (#119648)", async () => {
+    mockUnitFileLayout({ system: "/etc/systemd/system/openclaw-lisa.service" });
+    execFileMock.mockImplementationOnce((_cmd, args, _opts, cb) => {
+      expect(args[0]).toBe("show");
+      expect(args).toContain("openclaw-lisa.service");
+      cb(
+        null,
+        ["Id=openclaw-lisa.service", "ActiveState=inactive", "SubState=dead", "MainPID=0"].join(
+          "\n",
+        ),
+        "",
+      );
+    });
+    const runtime = await readSystemdServiceRuntime({
+      HOME: TEST_MANAGED_HOME,
+      OPENCLAW_PROFILE: "lisa",
+    });
+    expect(runtime.status).toBe("stopped");
+    expect(runtime.systemd?.unit).toBe("openclaw-lisa.service");
+  });
+
   it("findInstalledSystemdGatewayScope ignores legacy clawdbot system units in the marker fallback", async () => {
     mockUnitFileLayout({ system: false });
     findSystemGatewayServicesMock.mockResolvedValueOnce([

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -24,6 +24,7 @@ import {
   LEGACY_GATEWAY_SYSTEMD_SERVICE_NAMES,
   resolveGatewayServiceDescription,
   resolveGatewaySystemdServiceName,
+  resolveLegacyGatewaySystemdServiceName,
 } from "./constants.js";
 import { execFileUtf8 } from "./exec-file.js";
 import { formatLine, toPosixPath, writeFormattedLines } from "./output.js";
@@ -93,8 +94,11 @@ const SYSTEM_SYSTEMD_UNIT_DIRS = [
   "/lib/systemd/system",
 ] as const;
 
-async function findSystemSystemdUnitPath(env: GatewayServiceEnv): Promise<string | null> {
-  const serviceFile = `${resolveSystemdServiceName(env)}.service`;
+async function findSystemSystemdUnitPath(
+  env: GatewayServiceEnv,
+  name = resolveSystemdServiceName(env),
+): Promise<string | null> {
+  const serviceFile = `${name}.service`;
   for (const dir of SYSTEM_SYSTEMD_UNIT_DIRS) {
     const candidate = path.posix.join(dir, serviceFile);
     try {
@@ -142,6 +146,30 @@ async function findMarkerOwnedSystemSystemdUnit(): Promise<{
     }
   }
   return null;
+}
+
+/**
+ * True when a scanned system unit name belongs to the gateway of THIS profile.
+ *
+ * The system-wide marker scan (`findSystemGatewayServices`) collects every
+ * `openclaw-*` unit on the host; on multi-agent hosts that includes unrelated
+ * running agents. A unit must match the canonical (`openclaw-gateway[-profile]`)
+ * or legacy (`openclaw-<profile>`) name for the target profile before it may be
+ * treated as the target's installation — otherwise doctor could report another
+ * agent's PID as this gateway's runtime and recommend restarting the wrong
+ * service (#119648).
+ */
+function isSystemdGatewayUnitNameForProfile(
+  unitName: string,
+  canonicalName: string,
+  profile: string | undefined,
+): boolean {
+  const normalized = unitName.replace(/\.service$/i, "");
+  if (normalized === canonicalName) {
+    return true;
+  }
+  const legacyName = resolveLegacyGatewaySystemdServiceName(profile);
+  return legacyName !== null && normalized === legacyName;
 }
 
 /**
@@ -193,10 +221,36 @@ async function findSystemSystemdGatewayScope(
   if (systemPath) {
     return { scope: "system", unitName: canonicalUnitName, unitPath: systemPath };
   }
+  // Older installs predate the `openclaw-gateway-` rename and use
+  // `openclaw-<profile>`; resolve the same profile under that convention
+  // before scanning system-wide (#119648).
+  const hasUnitOverride = Boolean(env.OPENCLAW_SYSTEMD_UNIT?.trim());
+  const legacyName = hasUnitOverride
+    ? null
+    : resolveLegacyGatewaySystemdServiceName(env.OPENCLAW_PROFILE);
+  if (legacyName) {
+    const legacyPath = await findSystemSystemdUnitPath(env, legacyName);
+    if (legacyPath) {
+      return { scope: "system", unitName: `${legacyName}.service`, unitPath: legacyPath };
+    }
+  }
   // System-scope installs may use a non-canonical unit name; fall back to a
-  // marker-owned lookup before declaring no system unit exists.
+  // marker-owned lookup, but only accept a unit that plausibly belongs to THIS
+  // profile. An unrelated running `openclaw-*` unit (another agent on the same
+  // host) must never be reported as this gateway's runtime, and doctor must
+  // never recommend restarting it (#119648).
   const owned = await findMarkerOwnedSystemSystemdUnit();
-  return owned ? { scope: "system", unitName: owned.unitName, unitPath: owned.unitPath } : null;
+  if (
+    owned &&
+    isSystemdGatewayUnitNameForProfile(
+      owned.unitName,
+      resolveSystemdServiceName(env),
+      env.OPENCLAW_PROFILE,
+    )
+  ) {
+    return { scope: "system", unitName: owned.unitName, unitPath: owned.unitPath };
+  }
+  return null;
 }
 
 /**


### PR DESCRIPTION
## What Problem This Solves

`openclaw --profile <name> doctor` misreported a stopped agent's gateway as running and recommended restarting an unrelated agent's service. Reproduction: host runs several per-profile gateway services; `openclaw-lisa.service` (legacy naming, pre-`openclaw-gateway-` rename) is stopped while `openclaw-darlene.service` runs. Doctor resolved the target installation by scanning every `openclaw-*` system unit and picking the first marker-owned one — Darlene's — then reported that PID as Lisa's runtime and suggested `sudo systemctl restart openclaw-darlene.service`. Following that advice takes an unrelated agent offline during an outage.

## Why

`findSystemSystemdGatewayScope` (`src/daemon/systemd.ts`) tried only the canonical unit name (`openclaw-gateway-<profile>.service`) and then fell back to `findMarkerOwnedSystemSystemdUnit()`, a system-wide scan with no profile filter. On multi-agent hosts that scan legitimately returns other agents' units, and the first match was treated as the target's installation. Two compounding gaps: (1) the legacy `openclaw-<profile>` naming convention was never tried, and (2) the marker fallback never verified the unit belongs to the target profile.

## User Impact

Doctor now reports the truth in the outage scenario: a legacy-named unit is resolved as the target's own service (so `Runtime: stopped` is shown with the correct unit), and when the target's unit genuinely cannot be located, doctor refuses to guess instead of borrowing another agent's running unit. It can no longer recommend restarting a different agent's service.

## Evidence

- [AI-assisted] `src/daemon/constants.ts`: added `resolveLegacyGatewaySystemdServiceName(profile)` → `openclaw-<profile>` (named profiles) / `openclaw` (default), matching the pre-rename convention from the report.
- [AI-assisted] `src/daemon/systemd.ts`:
  - `findSystemSystemdGatewayScope` now tries the canonical name, then the legacy name for the same profile (skipped when `OPENCLAW_SYSTEMD_UNIT` overrides the unit), before any scan;
  - the marker-owned fallback now only accepts a unit whose name matches the target profile's canonical or legacy name (`isSystemdGatewayUnitNameForProfile`); unrelated units (e.g. `openclaw-darlene.service` for profile `lisa`) are rejected and resolution returns null — doctor then reports stopped/not-found instead of guessing. The intentional "separate gateway with a different name" case (issue #79375 dueling test) is preserved.
- Tests (`src/daemon/systemd.test.ts`, `src/daemon/constants.test.ts`):
  - legacy `openclaw-<profile>` system unit resolves for a named profile;
  - unrelated marker-owned unit is refused for the target profile;
  - marker-owned unit matching the profile's legacy name is accepted;
  - `readSystemdServiceRuntime` reads the legacy unit's own `systemctl show` (inactive → `stopped`, unit `openclaw-lisa.service`);
  - legacy-name resolver unit tests (default/named/"default" normalization).
- `pnpm vitest run src/daemon/systemd.test.ts` → 145 passed; `src/daemon/constants.test.ts` → 24 passed; `tsgo` core typecheck clean.
