### PR TITLE
fix(browser): preserve locale, timezone, and device overrides

### DIFF
--- a/extensions/browser/src/browser/pw-session-contracts.ts
+++ b/extensions/browser/src/browser/pw-session-contracts.ts
@@ -1,4 +1,12 @@
-import type { Browser, BrowserContext, Dialog, Frame, Page, Request } from "playwright-core";
+import type {
+  Browser,
+  BrowserContext,
+  CDPSession,
+  Dialog,
+  Frame,
+  Page,
+  Request,
+} from "playwright-core";
 import type { BrowserDownloadCandidate, BrowserDownloadResult } from "./download-types.js";
 import type { PlaywrightDownload } from "./pw-download-capture.js";
 
@@ -113,6 +121,11 @@ export type PageState = {
   recentDialogs: BrowserObservedDialogRecord[];
   armedDialogResponse?: ArmedDialogResponse;
   dialogAbortControllers: Set<AbortController>;
+  /** Persistent session and queue for page-scoped emulation overrides. */
+  emulation?: {
+    session?: Promise<CDPSession>;
+    deviceTransitionTail?: Promise<void>;
+  };
   /**
    * Role-based refs from the last role snapshot (e.g. e1/e2).
    * Mode "role" refs are generated from ariaSnapshot and resolved via getByRole.

--- a/extensions/browser/src/browser/pw-session-state.emulation.test.ts
+++ b/extensions/browser/src/browser/pw-session-state.emulation.test.ts
@@ -1,0 +1,25 @@
+import type { CDPSession, Page } from "playwright-core";
+import { describe, expect, it, vi } from "vitest";
+import { pageStates } from "./pw-session-contracts.js";
+import { ensurePageState } from "./pw-session-state.js";
+
+describe("page emulation lifecycle", () => {
+  it("detaches the persistent emulation session when the page closes", async () => {
+    const handlers = new Map<string, () => void>();
+    const page = {
+      on: vi.fn((event: string, handler: () => void) => {
+        handlers.set(event, handler);
+      }),
+    } as unknown as Page;
+    const detach = vi.fn(async () => {});
+    const state = ensurePageState(page);
+    state.emulation = {
+      session: Promise.resolve({ detach } as unknown as CDPSession),
+    };
+
+    handlers.get("close")?.();
+
+    await vi.waitFor(() => expect(detach).toHaveBeenCalledTimes(1));
+    expect(pageStates.has(page)).toBe(false);
+  });
+});

--- a/extensions/browser/src/browser/pw-session-state.ts
+++ b/extensions/browser/src/browser/pw-session-state.ts
@@ -364,6 +364,9 @@ export function ensurePageState(page: Page): PageState {
       }
     });
     page.on("close", () => {
+      const emulationSession = state.emulation?.session;
+      state.emulation = undefined;
+      void emulationSession?.then((session) => session.detach()).catch(() => {});
       clearArmedDialogResponse(state);
       for (const controller of state.dialogAbortControllers) {
         if (!controller.signal.aborted) {

--- a/extensions/browser/src/browser/pw-tools-core.state.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.state.test.ts
@@ -43,7 +43,11 @@ vi.mock("./pw-session.js", () => ({
   getPageForTargetId: stateMocks.getPageForTargetId,
 }));
 
-import { setDeviceViaPlaywright } from "./pw-tools-core.state.js";
+import {
+  setDeviceViaPlaywright,
+  setLocaleViaPlaywright,
+  setTimezoneViaPlaywright,
+} from "./pw-tools-core.state.js";
 
 function createPage() {
   const send = vi.fn(async (_method: string, _params?: Record<string, unknown>) => ({}));
@@ -61,6 +65,29 @@ describe("setDeviceViaPlaywright", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     stateMocks.ensurePageState.mockReturnValue({});
+  });
+
+  it("keeps one page-scoped CDP session attached for persistent emulation", async () => {
+    const fixture = createPage();
+    stateMocks.getPageForTargetId.mockResolvedValue(fixture.page);
+
+    await setTimezoneViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      targetId: "tab-1",
+      timezoneId: "America/New_York",
+    });
+    await setLocaleViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      targetId: "tab-1",
+      locale: "en-GB",
+    });
+
+    expect(fixture.newCDPSession).toHaveBeenCalledTimes(1);
+    expect(fixture.detach).not.toHaveBeenCalled();
+    expect(fixture.send.mock.calls).toEqual([
+      ["Emulation.setTimezoneOverride", { timezoneId: "America/New_York" }],
+      ["Emulation.setLocaleOverride", { locale: "en-GB" }],
+    ]);
   });
 
   it("fully replaces iPhone 14 emulation with Desktop Chrome", async () => {
@@ -112,7 +139,8 @@ describe("setDeviceViaPlaywright", () => {
       ],
       ["Emulation.setTouchEmulationEnabled", { enabled: false }],
     ]);
-    expect(fixture.detach).toHaveBeenCalledTimes(2);
+    expect(fixture.newCDPSession).toHaveBeenCalledTimes(1);
+    expect(fixture.detach).not.toHaveBeenCalled();
   });
 
   it("derives mobile orientation from the effective screen instead of the viewport", async () => {

--- a/extensions/browser/src/browser/pw-tools-core.state.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.state.test.ts
@@ -1,0 +1,225 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const stateMocks = vi.hoisted(() => ({
+  ensurePageState: vi.fn(),
+  getPageForTargetId: vi.fn(),
+  devices: {
+    "iPhone 14": {
+      userAgent: "iphone-14-user-agent",
+      viewport: { width: 390, height: 664 },
+      screen: { width: 390, height: 844 },
+      deviceScaleFactor: 3,
+      isMobile: true,
+      hasTouch: true,
+      defaultBrowserType: "webkit",
+    },
+    "Desktop Chrome": {
+      userAgent: "desktop-chrome-user-agent",
+      viewport: { width: 1280, height: 720 },
+      screen: { width: 1920, height: 1080 },
+      deviceScaleFactor: 1,
+      isMobile: false,
+      hasTouch: false,
+      defaultBrowserType: "chromium",
+    },
+    "iPhone 14 landscape": {
+      userAgent: "iphone-14-user-agent",
+      viewport: { width: 750, height: 340 },
+      screen: { width: 390, height: 844 },
+      deviceScaleFactor: 3,
+      isMobile: true,
+      hasTouch: true,
+      defaultBrowserType: "webkit",
+    },
+  },
+}));
+
+vi.mock("./playwright-core.runtime.js", () => ({
+  playwrightCore: { devices: stateMocks.devices },
+}));
+
+vi.mock("./pw-session.js", () => ({
+  ensurePageState: stateMocks.ensurePageState,
+  getPageForTargetId: stateMocks.getPageForTargetId,
+}));
+
+import { setDeviceViaPlaywright } from "./pw-tools-core.state.js";
+
+function createPage() {
+  const send = vi.fn(async (_method: string, _params?: Record<string, unknown>) => ({}));
+  const detach = vi.fn(async () => {});
+  const newCDPSession = vi.fn(async () => ({ send, detach }));
+  const setViewportSize = vi.fn(async () => {});
+  const page = {
+    context: () => ({ newCDPSession }),
+    setViewportSize,
+  };
+  return { page, send, detach, newCDPSession, setViewportSize };
+}
+
+describe("setDeviceViaPlaywright", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stateMocks.ensurePageState.mockReturnValue({});
+  });
+
+  it("fully replaces iPhone 14 emulation with Desktop Chrome", async () => {
+    const fixture = createPage();
+    stateMocks.getPageForTargetId.mockResolvedValue(fixture.page);
+
+    await setDeviceViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      targetId: "tab-1",
+      name: "iPhone 14",
+    });
+    await setDeviceViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      targetId: "tab-1",
+      name: "Desktop Chrome",
+    });
+
+    expect(fixture.setViewportSize.mock.calls).toEqual([
+      [{ width: 390, height: 664 }],
+      [{ width: 1280, height: 720 }],
+    ]);
+    expect(fixture.send.mock.calls).toEqual([
+      ["Emulation.setUserAgentOverride", { userAgent: "iphone-14-user-agent" }],
+      [
+        "Emulation.setDeviceMetricsOverride",
+        {
+          mobile: true,
+          width: 390,
+          height: 664,
+          deviceScaleFactor: 3,
+          screenWidth: 390,
+          screenHeight: 844,
+          screenOrientation: { angle: 0, type: "portraitPrimary" },
+        },
+      ],
+      ["Emulation.setTouchEmulationEnabled", { enabled: true }],
+      ["Emulation.setUserAgentOverride", { userAgent: "desktop-chrome-user-agent" }],
+      [
+        "Emulation.setDeviceMetricsOverride",
+        {
+          mobile: false,
+          width: 1280,
+          height: 720,
+          deviceScaleFactor: 1,
+          screenWidth: 1920,
+          screenHeight: 1080,
+          screenOrientation: { angle: 0, type: "landscapePrimary" },
+        },
+      ],
+      ["Emulation.setTouchEmulationEnabled", { enabled: false }],
+    ]);
+    expect(fixture.detach).toHaveBeenCalledTimes(2);
+  });
+
+  it("derives mobile orientation from the effective screen instead of the viewport", async () => {
+    const fixture = createPage();
+    stateMocks.getPageForTargetId.mockResolvedValue(fixture.page);
+
+    await setDeviceViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      targetId: "tab-1",
+      name: "iPhone 14 landscape",
+    });
+
+    expect(fixture.send).toHaveBeenNthCalledWith(2, "Emulation.setDeviceMetricsOverride", {
+      mobile: true,
+      width: 750,
+      height: 340,
+      deviceScaleFactor: 3,
+      screenWidth: 390,
+      screenHeight: 844,
+      screenOrientation: { angle: 0, type: "portraitPrimary" },
+    });
+  });
+
+  it("serializes overlapping descriptor transitions on the same page", async () => {
+    let releaseFirstUserAgent!: () => void;
+    const firstUserAgentBlocked = new Promise<void>((resolve) => {
+      releaseFirstUserAgent = resolve;
+    });
+    const fixture = createPage();
+    fixture.send.mockImplementation(async (method, params) => {
+      if (
+        method === "Emulation.setUserAgentOverride" &&
+        params?.userAgent === "iphone-14-user-agent"
+      ) {
+        await firstUserAgentBlocked;
+      }
+      return {};
+    });
+    stateMocks.getPageForTargetId.mockResolvedValue(fixture.page);
+
+    const phone = setDeviceViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      targetId: "tab-1",
+      name: "iPhone 14",
+    });
+    await vi.waitFor(() => expect(fixture.send).toHaveBeenCalledTimes(1));
+    const desktop = setDeviceViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      targetId: "tab-1",
+      name: "Desktop Chrome",
+    });
+
+    await Promise.resolve();
+    const viewportCallsWhileFirstDescriptorBlocked = fixture.setViewportSize.mock.calls.length;
+    const cdpCallsWhileFirstDescriptorBlocked = fixture.send.mock.calls.length;
+
+    releaseFirstUserAgent();
+    await Promise.all([phone, desktop]);
+    expect(viewportCallsWhileFirstDescriptorBlocked).toBe(1);
+    expect(cdpCallsWhileFirstDescriptorBlocked).toBe(1);
+    expect(fixture.send.mock.calls.map(([method]) => method)).toEqual([
+      "Emulation.setUserAgentOverride",
+      "Emulation.setDeviceMetricsOverride",
+      "Emulation.setTouchEmulationEnabled",
+      "Emulation.setUserAgentOverride",
+      "Emulation.setDeviceMetricsOverride",
+      "Emulation.setTouchEmulationEnabled",
+    ]);
+  });
+
+  it("skips an aborted descriptor while it is waiting for the page", async () => {
+    let releaseFirstUserAgent!: () => void;
+    const firstUserAgentBlocked = new Promise<void>((resolve) => {
+      releaseFirstUserAgent = resolve;
+    });
+    const fixture = createPage();
+    fixture.send.mockImplementation(async (method, params) => {
+      if (
+        method === "Emulation.setUserAgentOverride" &&
+        params?.userAgent === "iphone-14-user-agent"
+      ) {
+        await firstUserAgentBlocked;
+      }
+      return {};
+    });
+    stateMocks.getPageForTargetId.mockResolvedValue(fixture.page);
+
+    const phone = setDeviceViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      targetId: "tab-1",
+      name: "iPhone 14",
+    });
+    await vi.waitFor(() => expect(fixture.send).toHaveBeenCalledTimes(1));
+    const controller = new AbortController();
+    const desktop = setDeviceViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      targetId: "tab-1",
+      name: "Desktop Chrome",
+      signal: controller.signal,
+    });
+    await vi.waitFor(() => expect(stateMocks.ensurePageState).toHaveBeenCalledTimes(2));
+    controller.abort(new Error("request closed"));
+
+    releaseFirstUserAgent();
+    await phone;
+    await expect(desktop).rejects.toThrow("request closed");
+    expect(fixture.setViewportSize).toHaveBeenCalledTimes(1);
+    expect(fixture.send).toHaveBeenCalledTimes(3);
+  });
+});

--- a/extensions/browser/src/browser/pw-tools-core.state.ts
+++ b/extensions/browser/src/browser/pw-tools-core.state.ts
@@ -2,11 +2,50 @@
  * Browser context and emulation state helpers for Playwright-backed tools.
  */
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { Page } from "playwright-core";
 import { playwrightCore } from "./playwright-core.runtime.js";
 import { ensurePageState, getPageForTargetId } from "./pw-session.js";
 import { withPageScopedCdpClient } from "./pw-session.page-cdp.js";
 
 const { devices: playwrightDevices } = playwrightCore;
+const deviceTransitionTails = new WeakMap<Page, Promise<void>>();
+
+type DeviceSize = { width: number; height: number };
+
+type PlaywrightDeviceDescriptor = {
+  userAgent: string;
+  viewport: DeviceSize;
+  screen?: DeviceSize;
+  deviceScaleFactor: number;
+  isMobile: boolean;
+  hasTouch: boolean;
+};
+
+async function runDeviceTransition(params: {
+  page: Page;
+  signal?: AbortSignal;
+  run: () => Promise<void>;
+}): Promise<void> {
+  params.signal?.throwIfAborted();
+  const previous = deviceTransitionTails.get(params.page) ?? Promise.resolve();
+  const transition = previous
+    .catch(() => {})
+    .then(async () => {
+      params.signal?.throwIfAborted();
+      // Once admitted, finish the whole descriptor. Aborting between overrides would
+      // leave viewport, user agent, metrics, and touch state from different devices.
+      await params.run();
+    });
+  const tail = transition.catch(() => {});
+  deviceTransitionTails.set(params.page, tail);
+  try {
+    await transition;
+  } finally {
+    if (deviceTransitionTails.get(params.page) === tail) {
+      deviceTransitionTails.delete(params.page);
+    }
+  }
+}
 
 /** Toggles offline mode for the target page context. */
 export async function setOfflineViaPlaywright(opts: {
@@ -170,6 +209,7 @@ export async function setDeviceViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
   name: string;
+  signal?: AbortSignal;
 }): Promise<void> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
@@ -178,52 +218,51 @@ export async function setDeviceViaPlaywright(opts: {
     throw new Error("device name is required");
   }
   const descriptor = (playwrightDevices as Record<string, unknown>)[name] as
-    | {
-        userAgent?: string;
-        viewport?: { width: number; height: number };
-        deviceScaleFactor?: number;
-        isMobile?: boolean;
-        hasTouch?: boolean;
-        locale?: string;
-      }
+    | PlaywrightDeviceDescriptor
     | undefined;
   if (!descriptor) {
     throw new Error(`Unknown device "${name}".`);
   }
 
-  if (descriptor.viewport) {
-    await page.setViewportSize({
-      width: descriptor.viewport.width,
-      height: descriptor.viewport.height,
-    });
-  }
-
-  await withPageScopedCdpClient({
-    cdpUrl: opts.cdpUrl,
+  await runDeviceTransition({
     page,
-    targetId: opts.targetId,
-    fn: async (send) => {
-      if (descriptor.userAgent || descriptor.locale) {
-        await send("Emulation.setUserAgentOverride", {
-          userAgent: descriptor.userAgent ?? "",
-          acceptLanguage: descriptor.locale ?? undefined,
-        });
-      }
-      if (descriptor.viewport) {
-        await send("Emulation.setDeviceMetricsOverride", {
-          mobile: Boolean(descriptor.isMobile),
-          width: descriptor.viewport.width,
-          height: descriptor.viewport.height,
-          deviceScaleFactor: descriptor.deviceScaleFactor ?? 1,
-          screenWidth: descriptor.viewport.width,
-          screenHeight: descriptor.viewport.height,
-        });
-      }
-      if (descriptor.hasTouch) {
-        await send("Emulation.setTouchEmulationEnabled", {
-          enabled: true,
-        });
-      }
+    signal: opts.signal,
+    run: async () => {
+      const screen = descriptor.screen ?? descriptor.viewport;
+      const isLandscape = screen.width > screen.height;
+
+      // Keep Playwright's page model aligned before applying the descriptor fields
+      // that its public setViewportSize API cannot express on an attached context.
+      await page.setViewportSize({
+        width: descriptor.viewport.width,
+        height: descriptor.viewport.height,
+      });
+
+      await withPageScopedCdpClient({
+        cdpUrl: opts.cdpUrl,
+        page,
+        targetId: opts.targetId,
+        fn: async (send) => {
+          await send("Emulation.setUserAgentOverride", {
+            userAgent: descriptor.userAgent,
+          });
+          await send("Emulation.setDeviceMetricsOverride", {
+            mobile: descriptor.isMobile,
+            width: descriptor.viewport.width,
+            height: descriptor.viewport.height,
+            deviceScaleFactor: descriptor.deviceScaleFactor,
+            screenWidth: screen.width,
+            screenHeight: screen.height,
+            screenOrientation:
+              descriptor.isMobile && !isLandscape
+                ? { angle: 0, type: "portraitPrimary" }
+                : { angle: descriptor.isMobile ? 90 : 0, type: "landscapePrimary" },
+          });
+          await send("Emulation.setTouchEmulationEnabled", {
+            enabled: descriptor.hasTouch,
+          });
+        },
+      });
     },
   });
 }

--- a/extensions/browser/src/browser/pw-tools-core.state.ts
+++ b/extensions/browser/src/browser/pw-tools-core.state.ts
@@ -2,15 +2,15 @@
  * Browser context and emulation state helpers for Playwright-backed tools.
  */
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import type { Page } from "playwright-core";
+import type { CDPSession, Page } from "playwright-core";
 import { playwrightCore } from "./playwright-core.runtime.js";
+import type { PageState } from "./pw-session-contracts.js";
 import { ensurePageState, getPageForTargetId } from "./pw-session.js";
-import { withPageScopedCdpClient } from "./pw-session.page-cdp.js";
 
 const { devices: playwrightDevices } = playwrightCore;
-const deviceTransitionTails = new WeakMap<Page, Promise<void>>();
 
 type DeviceSize = { width: number; height: number };
+type PageCdpSend = (method: string, params?: Record<string, unknown>) => Promise<unknown>;
 
 type PlaywrightDeviceDescriptor = {
   userAgent: string;
@@ -21,13 +21,50 @@ type PlaywrightDeviceDescriptor = {
   hasTouch: boolean;
 };
 
+function resolvePageEmulationState(state: PageState): NonNullable<PageState["emulation"]> {
+  return (state.emulation ??= {});
+}
+
+function resolvePageEmulationSession(page: Page, state: PageState): Promise<CDPSession> {
+  const emulation = resolvePageEmulationState(state);
+  if (emulation.session) {
+    return emulation.session;
+  }
+  const pending = page.context().newCDPSession(page);
+  emulation.session = pending;
+  void pending.catch(() => {
+    if (emulation.session === pending) {
+      delete emulation.session;
+    }
+  });
+  return pending;
+}
+
+async function withPageEmulationCdpClient<T>(params: {
+  page: Page;
+  state: PageState;
+  run: (send: PageCdpSend) => Promise<T>;
+}): Promise<T> {
+  const session = await resolvePageEmulationSession(params.page, params.state);
+  return await params.run((method, values) =>
+    (
+      session.send as unknown as (
+        method: string,
+        values?: Record<string, unknown>,
+      ) => Promise<unknown>
+    )(method, values),
+  );
+}
+
 async function runDeviceTransition(params: {
   page: Page;
+  state: PageState;
   signal?: AbortSignal;
   run: () => Promise<void>;
 }): Promise<void> {
   params.signal?.throwIfAborted();
-  const previous = deviceTransitionTails.get(params.page) ?? Promise.resolve();
+  const emulation = resolvePageEmulationState(params.state);
+  const previous = emulation.deviceTransitionTail ?? Promise.resolve();
   const transition = previous
     .catch(() => {})
     .then(async () => {
@@ -37,12 +74,12 @@ async function runDeviceTransition(params: {
       await params.run();
     });
   const tail = transition.catch(() => {});
-  deviceTransitionTails.set(params.page, tail);
+  emulation.deviceTransitionTail = tail;
   try {
     await transition;
   } finally {
-    if (deviceTransitionTails.get(params.page) === tail) {
-      deviceTransitionTails.delete(params.page);
+    if (emulation.deviceTransitionTail === tail) {
+      delete emulation.deviceTransitionTail;
     }
   }
 }
@@ -149,16 +186,15 @@ export async function setLocaleViaPlaywright(opts: {
   locale: string;
 }): Promise<void> {
   const page = await getPageForTargetId(opts);
-  ensurePageState(page);
+  const pageState = ensurePageState(page);
   const locale = normalizeOptionalString(opts.locale) ?? "";
   if (!locale) {
     throw new Error("locale is required");
   }
-  await withPageScopedCdpClient({
-    cdpUrl: opts.cdpUrl,
+  await withPageEmulationCdpClient({
     page,
-    targetId: opts.targetId,
-    fn: async (send) => {
+    state: pageState,
+    run: async (send) => {
       try {
         await send("Emulation.setLocaleOverride", { locale });
       } catch (err) {
@@ -178,16 +214,15 @@ export async function setTimezoneViaPlaywright(opts: {
   timezoneId: string;
 }): Promise<void> {
   const page = await getPageForTargetId(opts);
-  ensurePageState(page);
+  const pageState = ensurePageState(page);
   const timezoneId = normalizeOptionalString(opts.timezoneId) ?? "";
   if (!timezoneId) {
     throw new Error("timezoneId is required");
   }
-  await withPageScopedCdpClient({
-    cdpUrl: opts.cdpUrl,
+  await withPageEmulationCdpClient({
     page,
-    targetId: opts.targetId,
-    fn: async (send) => {
+    state: pageState,
+    run: async (send) => {
       try {
         await send("Emulation.setTimezoneOverride", { timezoneId });
       } catch (err) {
@@ -212,7 +247,7 @@ export async function setDeviceViaPlaywright(opts: {
   signal?: AbortSignal;
 }): Promise<void> {
   const page = await getPageForTargetId(opts);
-  ensurePageState(page);
+  const pageState = ensurePageState(page);
   const name = normalizeOptionalString(opts.name) ?? "";
   if (!name) {
     throw new Error("device name is required");
@@ -226,6 +261,7 @@ export async function setDeviceViaPlaywright(opts: {
 
   await runDeviceTransition({
     page,
+    state: pageState,
     signal: opts.signal,
     run: async () => {
       const screen = descriptor.screen ?? descriptor.viewport;
@@ -238,11 +274,10 @@ export async function setDeviceViaPlaywright(opts: {
         height: descriptor.viewport.height,
       });
 
-      await withPageScopedCdpClient({
-        cdpUrl: opts.cdpUrl,
+      await withPageEmulationCdpClient({
         page,
-        targetId: opts.targetId,
-        fn: async (send) => {
+        state: pageState,
+        run: async (send) => {
           await send("Emulation.setUserAgentOverride", {
             userAgent: descriptor.userAgent,
           });

--- a/extensions/browser/src/browser/routes/agent.storage.device.test.ts
+++ b/extensions/browser/src/browser/routes/agent.storage.device.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createBrowserRouteApp, createBrowserRouteResponse } from "./test-helpers.js";
+import type { BrowserRequest } from "./types.js";
+
+const routeState = vi.hoisted(() => ({
+  setDeviceViaPlaywright: vi.fn(async () => {}),
+  withPlaywrightRouteContext: vi.fn(),
+}));
+
+vi.mock("./agent.shared.js", () => ({
+  readBody: (req: BrowserRequest) => req.body ?? {},
+  resolveTargetIdFromBody: (body: Record<string, unknown>) =>
+    typeof body.targetId === "string" ? body.targetId : undefined,
+  resolveTargetIdFromQuery: () => undefined,
+  withPlaywrightRouteContext: routeState.withPlaywrightRouteContext,
+}));
+
+const { registerBrowserAgentStorageRoutes } = await import("./agent.storage.js");
+
+type PlaywrightRouteParams = {
+  req: BrowserRequest;
+  run: (ctx: {
+    cdpUrl: string;
+    tab: { targetId: string };
+    signal: AbortSignal;
+    pw: { setDeviceViaPlaywright: typeof routeState.setDeviceViaPlaywright };
+  }) => Promise<unknown>;
+};
+
+function getSetDeviceHandler() {
+  const { app, postHandlers } = createBrowserRouteApp();
+  registerBrowserAgentStorageRoutes(app, {} as never);
+  const handler = postHandlers.get("/set/device");
+  expect(handler).toBeTypeOf("function");
+  return handler;
+}
+
+describe("browser device route", () => {
+  beforeEach(() => {
+    routeState.setDeviceViaPlaywright.mockClear();
+    routeState.withPlaywrightRouteContext
+      .mockReset()
+      .mockImplementation(async (params: PlaywrightRouteParams) => {
+        await params.run({
+          cdpUrl: "http://127.0.0.1:18800",
+          tab: { targetId: "tab-1" },
+          signal: params.req.signal ?? new AbortController().signal,
+          pw: { setDeviceViaPlaywright: routeState.setDeviceViaPlaywright },
+        });
+      });
+  });
+
+  it("forwards the route lease signal into the atomic device transition", async () => {
+    const controller = new AbortController();
+    const response = createBrowserRouteResponse();
+
+    await getSetDeviceHandler()?.(
+      {
+        params: {},
+        query: {},
+        body: { targetId: "tab-1", name: "iPhone 14" },
+        signal: controller.signal,
+      },
+      response.res,
+    );
+
+    expect(routeState.setDeviceViaPlaywright).toHaveBeenCalledWith({
+      cdpUrl: "http://127.0.0.1:18800",
+      targetId: "tab-1",
+      name: "iPhone 14",
+      signal: controller.signal,
+    });
+    expect(response.body).toEqual({ ok: true, targetId: "tab-1" });
+  });
+});

--- a/extensions/browser/src/browser/routes/agent.storage.ts
+++ b/extensions/browser/src/browser/routes/agent.storage.ts
@@ -562,6 +562,7 @@ export function registerBrowserAgentStorageRoutes(
           cdpUrl,
           targetId: tab.targetId,
           name,
+          signal,
         });
         signal.throwIfAborted();
         res.json({ ok: true, targetId: tab.targetId });

--- a/scripts/e2e/browser-plugin-profiles-docker.sh
+++ b/scripts/e2e/browser-plugin-profiles-docker.sh
@@ -127,6 +127,48 @@ kill -0 "$BROWSER_PID"
 node --input-type=module -e 'const response=await fetch(`http://127.0.0.1:${process.argv[1]}/json/version`); const body=await response.json(); if (!response.ok || typeof body.webSocketDebuggerUrl !== "string") throw new Error("CDP /json/version unavailable")' \
   "$CDP_PORT"
 
+assert_device_state() {
+  node -e '
+    const fs = require("node:fs");
+    const payload = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+    const state = payload.result;
+    const [width, height, dpr, screenWidth, screenHeight, touchPoints] = process.argv
+      .slice(3, 9)
+      .map(Number);
+    const expected = {
+      width,
+      height,
+      dpr,
+      screenWidth,
+      screenHeight,
+      touchPoints,
+      orientation: process.argv[9],
+    };
+    const actual = {
+      width: state?.width,
+      height: state?.height,
+      dpr: state?.dpr,
+      screenWidth: state?.screenWidth,
+      screenHeight: state?.screenHeight,
+      touchPoints: state?.touchPoints,
+      orientation: state?.orientation,
+    };
+    if (!state?.userAgent?.includes(process.argv[2]) || JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`device state mismatch: ${JSON.stringify({ actual, expected })}`);
+    }
+  ' "$@"
+}
+
+profile set device "iPhone 14" >/tmp/profile-device-phone.json
+profile evaluate --fn '() => ({ userAgent: navigator.userAgent, width: innerWidth, height: innerHeight, dpr: devicePixelRatio, screenWidth: screen.width, screenHeight: screen.height, touchPoints: navigator.maxTouchPoints, orientation: screen.orientation.type })' \
+  >/tmp/profile-device-phone-state.json
+assert_device_state /tmp/profile-device-phone-state.json iPhone 390 664 3 390 844 1 portrait-primary
+
+profile set device "Desktop Chrome" >/tmp/profile-device-desktop.json
+profile evaluate --fn '() => ({ userAgent: navigator.userAgent, width: innerWidth, height: innerHeight, dpr: devicePixelRatio, screenWidth: screen.width, screenHeight: screen.height, touchPoints: navigator.maxTouchPoints, orientation: screen.orientation.type })' \
+  >/tmp/profile-device-desktop-state.json
+assert_device_state /tmp/profile-device-desktop-state.json Windows 1280 720 1 1920 1080 0 landscape-primary
+
 profile stop >/tmp/profile-stopped-final.json
 for _ in $(seq 1 80); do
   if ! kill -0 "$BROWSER_PID" 2>/dev/null &&

--- a/scripts/e2e/browser-plugin-profiles-docker.sh
+++ b/scripts/e2e/browser-plugin-profiles-docker.sh
@@ -159,6 +159,21 @@ assert_device_state() {
   ' "$@"
 }
 
+profile evaluate --fn '() => { const meta = document.createElement("meta"); meta.name = "viewport"; meta.content = "width=device-width, initial-scale=1"; document.head.append(meta); return meta.content; }' \
+  >/tmp/profile-viewport-meta.json
+
+profile set timezone America/New_York >/tmp/profile-timezone.json
+profile set locale en-GB >/tmp/profile-locale.json
+profile evaluate --fn '() => ({ locale: Intl.DateTimeFormat().resolvedOptions().locale, timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone })' \
+  >/tmp/profile-locale-timezone-state.json
+node -e '
+  const fs = require("node:fs");
+  const state = JSON.parse(fs.readFileSync(process.argv[1], "utf8")).result;
+  if (state?.locale !== "en-GB" || state?.timeZone !== "America/New_York") {
+    throw new Error(`locale/timezone state mismatch: ${JSON.stringify(state)}`);
+  }
+' /tmp/profile-locale-timezone-state.json
+
 profile set device "iPhone 14" >/tmp/profile-device-phone.json
 profile evaluate --fn '() => ({ userAgent: navigator.userAgent, width: innerWidth, height: innerHeight, dpr: devicePixelRatio, screenWidth: screen.width, screenHeight: screen.height, touchPoints: navigator.maxTouchPoints, orientation: screen.orientation.type })' \
   >/tmp/profile-device-phone-state.json


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw browser set locale`, `set timezone`, and `set device` could report success but lose their direct Chrome emulation state immediately. Device changes preserved only the Playwright-owned viewport; user agent, DPR, physical screen, orientation, mobile mode, and touch state reverted when OpenClaw detached its temporary CDP session. Switching from a mobile preset to desktop also never explicitly disabled touch, and overlapping device commands could interleave fields from different presets.

## Why This Change Was Made

Persistent page emulation now has one lifecycle owner. Locale, timezone, and device commands reuse a retained page-scoped CDP session that is detached when the page closes. Device presets run through one per-page atomic queue, explicitly replacing every descriptor field; a request cancelled before admission is skipped, while an admitted descriptor completes as one transition.

This mirrors Playwright 1.62's Chromium device-context behavior and keeps ordinary one-shot CDP reads/mutations on their existing temporary-session helper.

## User Impact

Browser locale, timezone, and device overrides now remain active for the controlled page. Switching from iPhone 14 to Desktop Chrome replaces viewport, user agent, DPR, physical screen, orientation, mobile mode, and touch state without mixed or stale values.

Release-note context: fixes browser locale, timezone, and device emulation overrides that reverted or mixed state after successful CLI commands.

## Evidence

Exact head: `0b2adead84f90a7089e4bda2b747f75c32070092`.

- Source reproduction on current `main`: 4/4 focused cases failed, proving stale touch, incorrect screen/orientation, descriptor interleaving, and ignored cancellation.
- Fixed focused neighborhood: 27/27 assertions passed across persistent-session reuse, page-close detachment, device replacement/serialization/cancellation, route signal propagation, page-scoped CDP, route leases, and the packaged scenario contract.
- Packaged real-browser baseline: Testbox `tbx_01kz9hjzdws88bw65pq62pmg9g`, run https://github.com/openclaw/openclaw/actions/runs/31033035253, built `main` plus the E2E assertion. The public CLI changed only viewport; observed DPR 1, screen 800×600, touch 0, and landscape orientation instead of the iPhone preset.
- Packaged real-browser repair: branch-bound Testbox `tbx_01kz9j57v8cx2axgpg90nq699r`, run https://github.com/openclaw/openclaw/actions/runs/31033822493, synced the six final owner/test files that were then committed as this exact head. The built CLI preserved `en-GB` and `America/New_York`, applied iPhone 14 with its exact viewport/DPR/screen/touch/orientation, fully replaced it with Desktop Chrome, stopped the Chromium process, and deleted the managed profile. Marker: `BROWSER_PLUGIN_PROFILES_PACKAGED_OK`; final command 2m44s.
- The exact package build and tarball integrity gate passed in both real-browser runs, including all 149 public Plugin SDK subpaths.
- Final AutoReview on the lifecycle repair: `gpt-5.6-sol`, xhigh, clean at 0.98 with no accepted/actionable findings.
- Dependency contract: inspected pinned `playwright-core@1.62.0` device descriptors and Chromium application code:
  - https://github.com/microsoft/playwright/blob/v1.62.0/packages/playwright-core/src/server/deviceDescriptorsSource.json
  - https://github.com/microsoft/playwright/blob/v1.62.0/packages/playwright-core/src/server/chromium/crPage.ts

Production delta is +144/-53 (net +91) for the retained emulation-session lifecycle and atomic device-transition boundary. Tests and packaged E2E are +410/-0. No config, protocol, storage schema, dependency, or permission surface changes.

Docs remain accurate: the existing CLI pages already document locale, timezone, and Playwright device presets. OpenClaw changelog generation is release-owned.
