### PR TITLE
fix(agents): resume parent after late subagent completion

### DIFF
--- a/src/agents/subagent-announce.requester-settle-wake.ts
+++ b/src/agents/subagent-announce.requester-settle-wake.ts
@@ -221,6 +221,7 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(params: {
   if (!requesterSessionKey || !initialState) {
     return false;
   }
+  const admittedRearmGeneration = initialState.rearmGeneration;
   if (isCronSessionKey(requesterSessionKey)) {
     completeRequesterSettleWakeBatch({
       runIds: [params.settledEntry.runId],
@@ -235,14 +236,17 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(params: {
   const requesterRuns = Array.isArray(listedRuns) ? listedRuns : [];
   const currentSettledEntry =
     requesterRuns.find((entry) => entry.runId === params.settledEntry.runId) ?? params.settledEntry;
-  if (!currentSettledEntry.requesterSettleWake) {
+  const currentState = currentSettledEntry.requesterSettleWake;
+  // A requester yield may re-arm this row while runtime loading is in flight.
+  // Only the admitted generation may inspect descendants or mutate its batch.
+  if (!currentState || currentState.rearmGeneration !== admittedRearmGeneration) {
     return false;
   }
   const requesterHasUnsettledDescendants = () =>
     registryRuntime.hasDescendantRunAwaitingSettle(requesterSessionKey, currentSettledEntry.runId);
 
-  const frozenBatchRunIds = currentSettledEntry.requesterSettleWake.batchRunIds;
-  const currentRearmGeneration = currentSettledEntry.requesterSettleWake.rearmGeneration;
+  const frozenBatchRunIds = currentState.batchRunIds;
+  const currentRearmGeneration = currentState.rearmGeneration;
   const hasUnsettledDescendants = requesterHasUnsettledDescendants();
   if ((!frozenBatchRunIds || frozenBatchRunIds.length === 0) && hasUnsettledDescendants) {
     return false;

--- a/src/agents/subagent-registry-requester-yield.test.ts
+++ b/src/agents/subagent-registry-requester-yield.test.ts
@@ -169,6 +169,45 @@ describe("settleRequesterTurnAfterSessionSpawns", () => {
     expect(schedule).not.toHaveBeenCalled();
   });
 
+  it("persists a mixed delivered and in-progress yielded batch without scheduling", () => {
+    const alpha = makeRun("run-alpha");
+    const beta = makeRun("run-beta");
+    beta.delivery = { status: "in_progress" };
+    const calls: string[] = [];
+    const persistOrThrow = vi.fn(() => calls.push("persist"));
+    const schedule = vi.fn(() => calls.push("schedule"));
+
+    expect(
+      settleRequesterTurnAfterSessionSpawns({
+        requesterSessionKey: REQUESTER,
+        requesterTurnRunId: REQUESTER_TURN,
+        requesterYielded: true,
+        acceptedSessionSpawns: [accepted(alpha), accepted(beta)],
+        runs: new Map([
+          [alpha.runId, alpha],
+          [beta.runId, beta],
+        ]),
+        persistOrThrow,
+        schedule,
+      }),
+    ).toBe(true);
+
+    const frozenState = {
+      status: "pending",
+      attemptCount: 0,
+      batchRunIds: ["run-alpha", "run-beta"],
+      requesterYieldBatch: true,
+      afterRequesterYield: true,
+      rearmGeneration: 1,
+    } as const;
+    expect(alpha.requesterSettleWake).toEqual(frozenState);
+    expect(beta.requesterSettleWake).toEqual(frozenState);
+    expect(alpha.requesterTurnRunId).toBeUndefined();
+    expect(beta.requesterTurnRunId).toBeUndefined();
+    expect(calls).toEqual(["persist"]);
+    expect(schedule).not.toHaveBeenCalled();
+  });
+
   it.each([true, false])(
     "ignores same-turn non-completion spawns during settlement (yielded: %s)",
     (requesterYielded) => {

--- a/src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts
+++ b/src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts
@@ -58,6 +58,7 @@ type GatewayRequest = {
 
 let lifecycleHandler: ((evt: LifecycleEvent) => void) | undefined;
 let agentCallPlan: Array<"ok" | "throw"> = [];
+let agentCallGates = new Map<string, Promise<void>>();
 let chatHistoryBySessionKey = new Map<string, Array<Record<string, unknown>>>();
 let sessionStore: Record<string, SessionStoreEntry> = {};
 
@@ -75,6 +76,11 @@ const callGatewayMock = vi.fn(async (request: GatewayRequest) => {
     };
   }
   if (method === "agent") {
+    const sourceSessionKey = request.params?.inputProvenance?.sourceSessionKey;
+    const gate = sourceSessionKey ? agentCallGates.get(sourceSessionKey) : undefined;
+    if (gate) {
+      await gate;
+    }
     const next = agentCallPlan.shift() ?? "ok";
     if (next === "throw") {
       throw new Error("announce delivery failed");
@@ -118,6 +124,20 @@ vi.mock("./subagent-depth.js", () => ({
   getSubagentDepthFromSessionStore: () => 0,
 }));
 
+const loadSubagentRegistryRuntimeForTest = async () =>
+  ({
+    countActiveDescendantRuns: mod.countActiveDescendantRuns,
+    countPendingDescendantRuns: mod.countPendingDescendantRuns,
+    countPendingDescendantRunsExcludingRun: mod.countPendingDescendantRunsExcludingRun,
+    hasDescendantRunAwaitingSettle: announceRead.hasDescendantRunAwaitingSettle,
+    getLatestSubagentRunByChildSessionKey: mod.getLatestSubagentRunByChildSessionKey,
+    isSubagentSessionRunActive: mod.isSubagentSessionRunActive,
+    listSubagentRunsForRequester: mod.listSubagentRunsForRequester,
+    replaceSubagentRunAfterSteer: mod.replaceSubagentRunAfterSteer,
+    resolveRequesterForChildSession: mod.resolveRequesterForChildSession,
+    shouldIgnorePostCompletionAnnounceForSession: mod.shouldIgnorePostCompletionAnnounceForSession,
+  }) as unknown as typeof import("./subagent-registry-runtime.js");
+
 describe("subagent registry lifecycle error grace", () => {
   let previousFastTestEnv: string | undefined;
 
@@ -132,6 +152,7 @@ describe("subagent registry lifecycle error grace", () => {
       session: { mainKey: "main", scope: "per-sender" },
     });
     agentCallPlan = [];
+    agentCallGates = new Map();
     chatHistoryBySessionKey = new Map();
     sessionStore = new Proxy<Record<string, SessionStoreEntry>>(
       {
@@ -163,20 +184,6 @@ describe("subagent registry lifecycle error grace", () => {
       onAgentEvent:
         onAgentEventMock as unknown as typeof import("../infra/agent-events.js").onAgentEvent,
     });
-    const loadSubagentRegistryRuntimeForTest = async () =>
-      ({
-        countActiveDescendantRuns: mod.countActiveDescendantRuns,
-        countPendingDescendantRuns: mod.countPendingDescendantRuns,
-        countPendingDescendantRunsExcludingRun: mod.countPendingDescendantRunsExcludingRun,
-        hasDescendantRunAwaitingSettle: announceRead.hasDescendantRunAwaitingSettle,
-        getLatestSubagentRunByChildSessionKey: mod.getLatestSubagentRunByChildSessionKey,
-        isSubagentSessionRunActive: mod.isSubagentSessionRunActive,
-        listSubagentRunsForRequester: mod.listSubagentRunsForRequester,
-        replaceSubagentRunAfterSteer: mod.replaceSubagentRunAfterSteer,
-        resolveRequesterForChildSession: mod.resolveRequesterForChildSession,
-        shouldIgnorePostCompletionAnnounceForSession:
-          mod.shouldIgnorePostCompletionAnnounceForSession,
-      }) as unknown as typeof import("./subagent-registry-runtime.js");
     subagentAnnounceTesting.setDepsForTest({
       callGateway: callGatewayMock as typeof import("../gateway/call.js").callGateway,
       getRuntimeConfig: loadConfigMock as typeof import("../config/config.js").getRuntimeConfig,
@@ -294,9 +301,15 @@ describe("subagent registry lifecycle error grace", () => {
     throw new Error(`run ${runId} frozen result did not refresh`);
   };
 
-  function registerCompletionRun(runId: string, childSuffix: string, task: string) {
+  function registerCompletionRun(
+    runId: string,
+    childSuffix: string,
+    task: string,
+    requesterTurnRunId?: string,
+  ) {
     mod.registerSubagentRun({
       runId,
+      requesterTurnRunId,
       childSessionKey: `agent:main:subagent:${childSuffix}`,
       requesterSessionKey: MAIN_REQUESTER_SESSION_KEY,
       requesterDisplayKey: MAIN_REQUESTER_DISPLAY_KEY,
@@ -369,6 +382,131 @@ describe("subagent registry lifecycle error grace", () => {
         return typeof event?.result === "string" ? [event.result] : [];
       });
   }
+
+  it("lets the delivered cleanup own a yielded batch after a stale wake loses generation", async () => {
+    const requesterTurnRunId = "run-requester-yield-race";
+    const alphaSessionKey = "agent:main:subagent:yield-alpha";
+    const betaSessionKey = "agent:main:subagent:yield-beta";
+    registerCompletionRun("run-yield-alpha", "yield-alpha", "yield alpha", requesterTurnRunId);
+    registerCompletionRun("run-yield-beta", "yield-beta", "yield beta", requesterTurnRunId);
+    setAssistantOutput(alphaSessionKey, "alpha complete");
+    setAssistantOutput(betaSessionKey, "beta complete");
+
+    let releaseAlphaWakeRuntime: (() => void) | undefined;
+    const alphaWakeRuntimeGate = new Promise<void>((resolve) => {
+      releaseAlphaWakeRuntime = resolve;
+    });
+    let settleWakeRuntimeLoads = 0;
+    settleWakeTesting.setDepsForTest({
+      loadSubagentRegistryRuntime: async () => {
+        settleWakeRuntimeLoads += 1;
+        if (settleWakeRuntimeLoads === 1) {
+          await alphaWakeRuntimeGate;
+        }
+        return await loadSubagentRegistryRuntimeForTest();
+      },
+    });
+
+    let releaseBetaDelivery: (() => void) | undefined;
+    agentCallGates.set(
+      betaSessionKey,
+      new Promise<void>((resolve) => {
+        releaseBetaDelivery = resolve;
+      }),
+    );
+
+    emitLifecycleEvent("run-yield-alpha", { phase: "end", endedAt: Date.now() });
+    await waitForAgentCallCount(1);
+    await vi.waitFor(() => expect(settleWakeRuntimeLoads).toBe(1));
+
+    emitLifecycleEvent("run-yield-beta", { phase: "end", endedAt: Date.now() + 1 });
+    await waitForAgentCallCount(2);
+    const betaBeforeYield = mod
+      .listSubagentRunsForRequester(MAIN_REQUESTER_SESSION_KEY)
+      .find((run) => run.runId === "run-yield-beta");
+    if (!betaBeforeYield) {
+      throw new Error("expected beta run before requester yield");
+    }
+    betaBeforeYield.delivery = { ...betaBeforeYield.delivery, status: "in_progress" };
+
+    expect(
+      mod.markRequesterTurnYielded({
+        requesterSessionKey: MAIN_REQUESTER_SESSION_KEY,
+        requesterTurnRunId,
+      }),
+    ).toBe(2);
+    expect(
+      mod.settleRequesterAfterSessionSpawns({
+        requesterSessionKey: MAIN_REQUESTER_SESSION_KEY,
+        requesterTurnRunId,
+        requesterYielded: true,
+        acceptedSessionSpawns: [
+          { runId: "run-yield-alpha", childSessionKey: alphaSessionKey },
+          { runId: "run-yield-beta", childSessionKey: betaSessionKey },
+        ],
+      }),
+    ).toBe(true);
+
+    releaseAlphaWakeRuntime?.();
+    await vi.advanceTimersByTimeAsync(0);
+    await flushAsync();
+
+    const yieldedBatch = mod.listSubagentRunsForRequester(MAIN_REQUESTER_SESSION_KEY);
+    expect(
+      yieldedBatch.map((run) => ({
+        runId: run.runId,
+        delivery: run.delivery?.status,
+        nextAttemptAt: run.requesterSettleWake?.nextAttemptAt,
+        rearmGeneration: run.requesterSettleWake?.rearmGeneration,
+      })),
+    ).toEqual([
+      {
+        runId: "run-yield-alpha",
+        delivery: "delivered",
+        nextAttemptAt: undefined,
+        rearmGeneration: 1,
+      },
+      {
+        runId: "run-yield-beta",
+        delivery: "in_progress",
+        nextAttemptAt: undefined,
+        rearmGeneration: 1,
+      },
+    ]);
+    const requesterWakeCalls = () =>
+      getAgentCalls().filter((request) => {
+        const idempotencyKey = (request.params as Record<string, unknown> | undefined)
+          ?.idempotencyKey;
+        return (
+          typeof idempotencyKey === "string" &&
+          idempotencyKey.startsWith("announce:requester-settle:")
+        );
+      });
+    expect(requesterWakeCalls()).toHaveLength(0);
+
+    agentCallGates.delete(betaSessionKey);
+    releaseBetaDelivery?.();
+    await waitForAgentCallCount(3);
+    await waitForDeliveredCleanup("run-yield-alpha");
+    await waitForDeliveredCleanup("run-yield-beta");
+
+    expect(requesterWakeCalls()).toHaveLength(1);
+    const requesterWakeParams = requesterWakeCalls()[0]?.params as
+      | Record<string, unknown>
+      | undefined;
+    expect(requesterWakeParams?.idempotencyKey).toContain(":yield-1");
+    expect(requesterWakeParams?.message).toContain("visible final answer");
+    expect(
+      mod
+        .listSubagentRunsForRequester(MAIN_REQUESTER_SESSION_KEY)
+        .filter((run) => run.runId === "run-yield-alpha" || run.runId === "run-yield-beta")
+        .every((run) => run.requesterSettleWake === undefined),
+    ).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    await flushAsync();
+    expect(requesterWakeCalls()).toHaveLength(1);
+  });
 
   it("ignores transient lifecycle errors when run retries and then ends successfully", async () => {
     registerCompletionRun("run-transient-error", "transient-error", "transient error test");


### PR DESCRIPTION
Related: #110922
Related: #118703
Related: #92433

## What Problem This Solves

Fixes a timing race where a parent agent could remain silent after all delegated subagents completed when a requester yield crossed child completion delivery.

The exact `subagent-fanout-synthesis` QA lane completed both child tasks but never produced the parent's final synthesis.

## Root Cause

An alpha-child cleanup could admit a requester wake before `sessions_yield`. While that wake awaited registry runtime loading, requester settlement replaced the row with a new yielded-batch generation. The stale alpha wake then adopted the newer generation, saw beta still settling, and persisted a 30-second defer. Beta cleanup correctly honored that durable deadline, delaying the only valid final wake.

## Why This Change Was Made

Requester wakes are now fenced to the rearm generation they admitted before their first await. A stale wake returns before descendant inspection or batch mutation when requester settlement has installed a newer generation.

Settlement still marks delivered or in-progress completions as requiring a visible reply after yield, but it schedules immediately only when every ended delivery is fully delivered. Mixed batches remain owned by the normal delivery cleanup boundary. Existing transport retry deadlines and descendant defers are unchanged.

## User Impact

Parents resume once, promptly, after late subagent delivery completes instead of hanging or waiting on a stale 30-second deadline. Duplicate-wake protection and legitimate retry backoff remain intact.

## Evidence

- Reproduced on QA Lab run https://github.com/openclaw/openclaw/actions/runs/31029147516 at `a3419d4a4b4c894b47a9273181735d091f4d502f`.
- Added a production-composition lifecycle regression that gates the stale alpha wake across requester yield, proves it cannot write `nextAttemptAt`, and proves beta cleanup owns one immediate final wake.
- Focused requester-yield, requester-wake, lifecycle, retry-grace, announce-delivery, and overflow-compaction suites: 352 passed.
- Exact behavior head `ee74ca5554f9d6e2be355353c3a196a206c36c6c` passed `subagent-fanout-synthesis` on direct AWS: Anthropic 3/3 and OpenAI 1/1; every report passed, every CLI exit was 0, and aggregate exit was 0.
- Current exact head `fa6f97d5fdcfaf34de8a765600a639f7e843266a` adds only the test type narrowing required by `check-test-types`; its focused lifecycle file passes 10/10.
- Direct Codex contract check at `bb1af235ea2822d7a40f75ef52e4d6a2cde84da2`: `codex-rs/core/src/agent/status.rs`, `session_prefix.rs`, `agent/control.rs`, `tools/handlers/multi_agents/wait.rs`, and `multi_agents_spec.rs` confirm completed child final messages are surfaced to the parent and wait reports terminal status.
- `git diff --check`: passed.
- Autoreview: clean, correctness 0.98.
- Production delta: +7/-3. Tests: +192/-15.

Punchcard-Session: silver-valley-valley-dt
