### PR TITLE
fix(qa): recognize portable Slack commentary lane

### DIFF
--- a/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
@@ -697,6 +697,52 @@ describe("Slack live QA runtime helpers", () => {
     }
   });
 
+  it("classifies only exact Slack commentary lane presentations", () => {
+    const scenario = testing.findScenario(["slack-progress-commentary-true"])[0];
+    const run = scenario?.buildRun("U999999999");
+    const input = run && "input" in run ? run.input : "";
+    const commentaryMarker = input.match(/SLACK-QA-COMMENTARY-[0-9A-F]{8}/u)?.[0];
+    const finalMarker = input.match(/SLACK-QA-COMMENTARY-DONE-[0-9A-F]{8}/u)?.[0];
+    const verifyObserved = run && "verifyObserved" in run ? run.verifyObserved : undefined;
+    if (!commentaryMarker || !finalMarker || !verifyObserved) {
+      throw new Error("missing Slack progress commentary lane verifier");
+    }
+    const verifyCommentaryMessage = (message: { blockText?: string[]; text: string }) =>
+      verifyObserved({
+        finalMessage: { text: finalMarker, ts: "2.000000" },
+        messages: [
+          {
+            channelId: "C123456789",
+            ...message,
+            ts: "1.500000",
+          },
+          {
+            channelId: "C123456789",
+            text: finalMarker,
+            ts: "2.000000",
+          },
+        ],
+      });
+
+    for (const message of [
+      { text: `_${commentaryMarker}_` },
+      { text: ` \n_${commentaryMarker}_\t` },
+      { text: `💬 ${commentaryMarker}` },
+      { blockText: ["Update", commentaryMarker], text: "Working…" },
+    ]) {
+      expect(() => verifyCommentaryMessage(message)).not.toThrow();
+    }
+    for (const text of [
+      commentaryMarker,
+      `prefix _${commentaryMarker}_ suffix`,
+      `_${commentaryMarker}_\nmore`,
+    ]) {
+      expect(() => verifyCommentaryMessage({ text })).toThrow(
+        "expected commentary in the Slack progress commentary lane",
+      );
+    }
+  });
+
   it("rejects commentary when false and mismatched tool progress", () => {
     const verify = (
       scenarioId: string,

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-fixtures.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-fixtures.ts
@@ -85,7 +85,7 @@ function hasSlackCommentaryLaneMarker(
   message: { blockText?: string[]; text: string },
   marker: string,
 ) {
-  if (message.text.includes(`💬 ${marker}`)) {
+  if (message.text.includes(`💬 ${marker}`) || message.text.trim() === `_${marker}_`) {
     return true;
   }
   const blockText = message.blockText ?? [];


### PR DESCRIPTION
Related: #119480

## What Problem This Solves

Fixes an issue where the release-style Slack QA lane reported a commentary failure even though Slack delivered the current portable commentary presentation correctly.

The exact live run passed 21 of 22 Slack scenarios, but `slack-progress-commentary-true` failed twice because QA recognized only older glyph and rich-block forms.

## Why This Change Was Made

The Slack QA verifier now recognizes the exact portable italic commentary form while retaining the existing legacy glyph and rich-block paths. Matching remains strict so a plain status headline or marker embedded in unrelated text cannot be mistaken for the commentary lane.

This changes only QA classification. It does not alter Slack runtime output, compositor behavior, verbosity semantics, config, or dependencies.

## User Impact

Release validation now accepts the Slack commentary format the product actually ships, avoiding a false red lane while preserving coverage that commentary, status headlines, tool progress, and final replies stay distinct.

## Evidence

- Exact head: `ba82c3c08b2d5240b295e688efdb3f14ead78b46`.
- Exact fetched base: `397a60582a109489d7dd4f1be1136251c10dc1b9` (`main`).
- Reproduced on QA-Lab run https://github.com/openclaw/openclaw/actions/runs/31029147516 at `a3419d4a4b4c894b47a9273181735d091f4d502f`: 21 passed, 1 failed, with the same assertion after retry.
- Deterministic verifier regression failed before the classifier repair.
- `node scripts/run-vitest.mjs extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts`: 50 passed on the exact head.
- `./node_modules/.bin/oxfmt --check` on both changed files: passed on the exact head.
- `git diff --check origin/main...HEAD`: passed on the exact head.
- Autoreview: clean.
- Production delta: 0. QA/test delta: +47/-1.

Punchcard-Session: silver-meadow-lantern-vx
Punchcard-Receipt: att_01KZ9WFRB529T1ZWHJVN65ZVCN


