### PR TITLE
improve: speed up Code Mode budget test

### DIFF
--- a/src/agents/code-mode-headless.test.ts
+++ b/src/agents/code-mode-headless.test.ts
@@ -672,8 +672,12 @@ describe("headless Code Mode", () => {
       await runCodeModeScriptHeadless({
         ctx: createHeadlessHarness([tool]),
         code: `
-          for (let index = 0; index < 129; index += 1) {
-            await tools.call("openclaw:core:budgeted", {});
+          const calls = Array.from({ length: 129 }, () => () =>
+            tools.call("openclaw:core:budgeted", {}),
+          );
+          // Keep each leg within the default 16-call pending cap while proving the cumulative budget.
+          for (let offset = 0; offset < calls.length; offset += 16) {
+            await Promise.all(calls.slice(offset, offset + 16).map((call) => call()));
           }
           return true;
         `,


### PR DESCRIPTION
## What Problem This Solves

The Code Mode headless budget test spent most of its runtime crossing the worker bridge 129 times sequentially, making one unchanged cumulative-budget assertion cost roughly 10 extra seconds in CI.

## Why This Change Was Made

The test still issues and asserts all 129 tool calls, but batches them into groups of 16. That preserves the production default pending-call cap while exercising the cumulative 200-call cron budget across multiple worker legs.

## User Impact

No user-visible behavior changes. The same coverage completes substantially faster.

## Evidence

- Before: `src/agents/code-mode-headless.test.ts` completed 65 tests in 17.35s in CI run 31029017326.
- After: the same 65 tests completed in 7.66s in CI run 31030954873.
- The complete compact-large count/topology ledger remained unchanged.
- Autoreview: clean, no accepted/actionable findings.
