### PR TITLE
fix(diagnostics): preserve telemetry during service shutdown

### DIFF
--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -1034,7 +1034,7 @@ describe("diagnostics-otel service", () => {
     sdkShutdown.mockRejectedValueOnce(sdkError);
     const { service, ctx } = await startOtelService({ traces: true, metrics: true, logs: true });
 
-    const stopError = await service.stop?.(ctx).catch((error: unknown) => error);
+    const stopError = await Promise.resolve(service.stop?.(ctx)).catch((error: unknown) => error);
 
     expect(logShutdown).toHaveBeenCalledTimes(1);
     expect(sdkShutdown).toHaveBeenCalledTimes(1);

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -1027,6 +1027,27 @@ describe("diagnostics-otel service", () => {
     expect(telemetryState.tracer.startSpan).not.toHaveBeenCalled();
   });
 
+  test("attempts every provider shutdown and reports every failure", async () => {
+    const logError = new Error("log provider failed");
+    const sdkError = new Error("SDK providers failed");
+    logShutdown.mockRejectedValueOnce(logError);
+    sdkShutdown.mockRejectedValueOnce(sdkError);
+    const { service, ctx } = await startOtelService({ traces: true, metrics: true, logs: true });
+
+    const stopError = await service.stop?.(ctx).catch((error: unknown) => error);
+
+    expect(logShutdown).toHaveBeenCalledTimes(1);
+    expect(sdkShutdown).toHaveBeenCalledTimes(1);
+    expect(stopError).toBeInstanceOf(AggregateError);
+    expect(stopError).toMatchObject({
+      errors: [logError, sdkError],
+      message: expect.stringContaining("log provider failed"),
+    });
+    expect(stopError).toMatchObject({
+      message: expect.stringContaining("SDK providers failed"),
+    });
+  });
+
   test("registers and removes an OTLP exporter unhandled rejection handler", async () => {
     const { service, ctx } = await startOtelService({ traces: true, metrics: true, logs: true });
 
@@ -1056,6 +1077,38 @@ describe("diagnostics-otel service", () => {
 
     await service.stop?.(ctx);
     expect(unhandledRejectionHandlerState.getHandlers()).toHaveLength(0);
+  });
+
+  test("cleans up existing providers and does not reinitialize without capability", async () => {
+    const service = createDiagnosticsOtelService();
+    const enabledCtx = createOtelContext(OTEL_TEST_ENDPOINT, {
+      traces: true,
+      metrics: true,
+      logs: true,
+    });
+    await service.start(enabledCtx);
+
+    sdkCtor.mockClear();
+    sdkStart.mockClear();
+    logExporterCtor.mockClear();
+    const deniedCtx = createOtelContext(OTEL_TEST_ENDPOINT, {
+      traces: true,
+      metrics: true,
+      logs: true,
+    });
+    delete deniedCtx.internalDiagnostics;
+
+    await service.start(deniedCtx);
+    await service.stop?.(deniedCtx);
+
+    expect(deniedCtx.logger.error).toHaveBeenCalledWith(
+      "diagnostics-otel: internal diagnostics capability unavailable",
+    );
+    expect(sdkCtor).not.toHaveBeenCalled();
+    expect(sdkStart).not.toHaveBeenCalled();
+    expect(logExporterCtor).not.toHaveBeenCalled();
+    expect(sdkShutdown).toHaveBeenCalledOnce();
+    expect(logShutdown).toHaveBeenCalledOnce();
   });
 
   test("does not retain an OTLP exporter handler when startup setup fails", async () => {

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -67,14 +67,28 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
     stopActiveTrustedSpans = null;
     unregisterUnhandledRejectionHandler = null;
 
-    currentUnregisterUnhandledRejectionHandler?.();
-    currentUnsubscribe?.();
-    currentStopActiveTrustedSpans?.();
-    if (currentLogProvider) {
-      await currentLogProvider.shutdown().catch(() => undefined);
+    const settle = async (...stops: Array<(() => void | Promise<void>) | null>) =>
+      (
+        await Promise.allSettled(stops.map((stop) => Promise.resolve().then(() => stop?.())))
+      ).flatMap((result) => (result.status === "rejected" ? [result.reason] : []));
+    // Preserve cleanup -> provider flush -> handler removal while attempting every step per phase.
+    const failures = await settle(currentUnsubscribe, currentStopActiveTrustedSpans);
+    failures.push(
+      ...(await settle(
+        currentLogProvider ? () => currentLogProvider.shutdown() : null,
+        currentSdk ? () => currentSdk.shutdown() : null,
+      )),
+      ...(await settle(currentUnregisterUnhandledRejectionHandler)),
+    );
+
+    if (failures.length === 1) {
+      throw failures[0];
     }
-    if (currentSdk) {
-      await currentSdk.shutdown().catch(() => undefined);
+    if (failures.length > 1) {
+      throw new AggregateError(
+        failures,
+        `diagnostics-otel shutdown failed: ${failures.join("; ")}`,
+      );
     }
   };
 
@@ -126,6 +140,12 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         ...(logsEnabled ? (["logs"] as const) : []),
       ];
       if (enabledSignals.length === 0) {
+        return;
+      }
+      // This capability is the admission gate; no exporter may outlive a denied start.
+      const subscribe = ctx.internalDiagnostics?.onEvent;
+      if (!subscribe) {
+        ctx.logger.error("diagnostics-otel: internal diagnostics capability unavailable");
         return;
       }
 
@@ -308,11 +328,6 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         ...createModelRecorders(recorderRuntime),
         ...createToolAndSystemRecorders(recorderRuntime),
       };
-      const subscribe = ctx.internalDiagnostics?.onEvent;
-      if (!subscribe) {
-        ctx.logger.error("diagnostics-otel: internal diagnostics capability unavailable");
-        return;
-      }
 
       unsubscribe = subscribe(
         createDiagnosticsEventHandler({

--- a/src/infra/diagnostic-events.test.ts
+++ b/src/infra/diagnostic-events.test.ts
@@ -630,6 +630,46 @@ describe("diagnostic-events", () => {
     expect(events).toHaveLength(250);
   });
 
+  it("does not extend a drain barrier for events queued after it starts", async () => {
+    const callIds: string[] = [];
+    onDiagnosticEvent((event) => {
+      if (event.type === "model.call.started") {
+        callIds.push(event.callId);
+      }
+    });
+
+    emitDiagnosticEvent({
+      type: "model.call.started",
+      runId: "run-before-barrier",
+      callId: "before-barrier",
+      provider: "openai",
+      model: "gpt-5.4",
+    });
+    const drained = waitForDiagnosticEventsDrained();
+    for (let index = 0; index < 250; index += 1) {
+      emitDiagnosticEvent({
+        type: "model.call.started",
+        runId: `run-after-${index}`,
+        callId: `after-${index}`,
+        provider: "openai",
+        model: "gpt-5.4",
+      });
+    }
+
+    await drained;
+
+    expect(callIds).toHaveLength(100);
+    expect(callIds[0]).toBe("before-barrier");
+    expect(
+      hasPendingInternalDiagnosticEvent(
+        (event) => event.type === "model.call.started" && event.callId === "after-249",
+      ),
+    ).toBe(true);
+
+    await waitForDiagnosticEventsDrained();
+    expect(callIds).toHaveLength(251);
+  });
+
   it("reports pending async diagnostic events before they drain", async () => {
     emitTrustedDiagnosticEvent({
       type: "tool.execution.error",

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -1216,10 +1216,15 @@ function dispatchAsyncDiagnosticDropSummary(state: DiagnosticEventsGlobalState):
   dispatchDiagnosticEvent(state, event, createInternalDiagnosticMetadata(false));
 }
 
-/** Waits until queued async diagnostic events have been delivered to listeners. */
+/** Waits until async diagnostic events queued when called are no longer pending. */
 export async function waitForDiagnosticEventsDrained(): Promise<void> {
   const state = getDiagnosticEventsState();
-  while (state.asyncDrainScheduled || state.asyncQueue.length > 0) {
+  const targetSeq = state.asyncQueue.at(-1)?.event.seq;
+  if (targetSeq === undefined) {
+    return;
+  }
+  // The queue is append-ordered by seq, so a newer head means this snapshot drained or dropped.
+  while ((state.asyncQueue[0]?.event.seq ?? Number.POSITIVE_INFINITY) <= targetSeq) {
     await new Promise<void>((resolve) => {
       setImmediate(resolve);
     });

--- a/src/plugins/services.test.ts
+++ b/src/plugins/services.test.ts
@@ -171,8 +171,10 @@ describe("startPluginServices", () => {
     expectServiceLifecycleState({ starts, stops, contexts, config });
   });
 
-  it("drains diagnostics after producers stop and before exporters detach", async () => {
+  it("drains producer diagnostics before exporters stop and propagates exporter failures", async () => {
     const order: string[] = [];
+    const producerError = new Error("producer stop failed");
+    const exporterError = new Error("exporter stop failed");
     let unsubscribe: () => void = () => undefined;
     const registry = createRegistry(
       [
@@ -186,6 +188,7 @@ describe("startPluginServices", () => {
               level: "INFO",
               message: "queued during producer shutdown",
             });
+            throw producerError;
           },
         },
       ],
@@ -193,6 +196,19 @@ describe("startPluginServices", () => {
       "workspace",
     );
     registry.services.push(
+      ...createRegistry(
+        [
+          {
+            id: "diagnostics-prometheus",
+            start: () => undefined,
+            stop: () => {
+              order.push("prometheus");
+            },
+          },
+        ],
+        "diagnostics-prometheus",
+        "bundled",
+      ).services,
       ...createRegistry(
         [
           {
@@ -205,8 +221,9 @@ describe("startPluginServices", () => {
               });
             },
             stop: () => {
-              order.push("exporter");
+              order.push("otel");
               unsubscribe();
+              throw exporterError;
             },
           },
         ],
@@ -219,10 +236,15 @@ describe("startPluginServices", () => {
       registry,
       config: createServiceConfig(),
     });
-    await handle.stop();
+
+    await expect(handle.stop()).rejects.toBe(exporterError);
     await waitForDiagnosticEventsDrained();
 
-    expect(order).toEqual(["producer", "event", "exporter"]);
+    expect(order).toEqual(["producer", "event", "otel", "prometheus"]);
+    expect(mockedLogger.warn.mock.calls).toEqual([
+      ["plugin service stop failed (producer): Error: producer stop failed"],
+      ["plugin service stop failed (diagnostics-otel): Error: exporter stop failed"],
+    ]);
   });
 
   it("rolls back partially started services before starting their siblings", async () => {
@@ -534,7 +556,7 @@ describe("startPluginServices", () => {
     await handle.stop();
   });
 
-  it("attempts every service stop and reports independent failures", async () => {
+  it("attempts every ordinary service stop and preserves warn-and-continue failures", async () => {
     const stopOk = vi.fn();
     const firstError = new Error("first stop failed");
     const secondError = new Error("second stop failed");
@@ -557,7 +579,7 @@ describe("startPluginServices", () => {
       ],
     });
 
-    const stopError = await handle.stop().catch((error: unknown) => error);
+    await expect(handle.stop()).resolves.toBeUndefined();
 
     expect(mockedLogger.error.mock.calls).toEqual([
       [
@@ -572,10 +594,6 @@ describe("startPluginServices", () => {
     expect(stopOk).toHaveBeenCalledOnce();
     expect(stopFirst).toHaveBeenCalledOnce();
     expect(stopSecond).toHaveBeenCalledOnce();
-    expect(stopError).toBeInstanceOf(AggregateError);
-    expect(stopError).toMatchObject({
-      errors: [secondError, firstError],
-    });
   });
 
   it("continues starting siblings when rollback also fails", async () => {

--- a/src/plugins/services.test.ts
+++ b/src/plugins/services.test.ts
@@ -17,6 +17,11 @@ vi.mock("../logging/subsystem.js", () => ({
 }));
 
 import { STATE_DIR } from "../config/paths.js";
+import {
+  emitTrustedDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  waitForDiagnosticEventsDrained,
+} from "../infra/diagnostic-events.js";
 import { queuePluginSessionsChanged, subscribePluginSessionsChanged } from "./gateway-events.js";
 import { registerPluginHttpRoute } from "./http-registry.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "./runtime.js";
@@ -142,6 +147,7 @@ function createTrackingService(
 describe("startPluginServices", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetDiagnosticEventsForTest();
     resetPluginRuntimeStateForTest();
   });
 
@@ -163,6 +169,60 @@ describe("startPluginServices", () => {
     await handle.stop();
 
     expectServiceLifecycleState({ starts, stops, contexts, config });
+  });
+
+  it("drains diagnostics after producers stop and before exporters detach", async () => {
+    const order: string[] = [];
+    let unsubscribe = () => undefined;
+    const registry = createRegistry(
+      [
+        {
+          id: "producer",
+          start: () => undefined,
+          stop: () => {
+            order.push("producer");
+            emitTrustedDiagnosticEvent({
+              type: "log.record",
+              level: "INFO",
+              message: "queued during producer shutdown",
+            });
+          },
+        },
+      ],
+      "plugin:test",
+      "workspace",
+    );
+    registry.services.push(
+      ...createRegistry(
+        [
+          {
+            id: "diagnostics-otel",
+            start: (ctx) => {
+              unsubscribe = ctx.internalDiagnostics!.onEvent((event) => {
+                if (event.type === "log.record") {
+                  order.push("event");
+                }
+              });
+            },
+            stop: () => {
+              order.push("exporter");
+              unsubscribe();
+            },
+          },
+        ],
+        "diagnostics-otel",
+        "bundled",
+      ).services,
+    );
+
+    const handle = await startPluginServices({
+      registry,
+      config: createServiceConfig(),
+    });
+    await handle.stop();
+    await waitForDiagnosticEventsDrained();
+
+    expect(order).toEqual(["producer", "event", "exporter"]);
   });
 
   it("rolls back partially started services before starting their siblings", async () => {
@@ -474,10 +534,15 @@ describe("startPluginServices", () => {
     await handle.stop();
   });
 
-  it("logs start/stop failures and continues", async () => {
+  it("attempts every service stop and reports independent failures", async () => {
     const stopOk = vi.fn();
-    const stopThrows = vi.fn(() => {
-      throw new Error("stop failed");
+    const firstError = new Error("first stop failed");
+    const secondError = new Error("second stop failed");
+    const stopFirst = vi.fn(() => {
+      throw firstError;
+    });
+    const stopSecond = vi.fn(() => {
+      throw secondError;
     });
 
     const handle = await startTrackingServices({
@@ -486,12 +551,13 @@ describe("startPluginServices", () => {
           failOnStart: true,
           stopSpy: vi.fn(),
         }),
+        createTrackingService("service-stop-first", { stopSpy: stopFirst }),
         createTrackingService("service-ok", { stopSpy: stopOk }),
-        createTrackingService("service-stop-fail", { stopSpy: stopThrows }),
+        createTrackingService("service-stop-second", { stopSpy: stopSecond }),
       ],
     });
 
-    await handle.stop();
+    const stopError = await handle.stop().catch((error: unknown) => error);
 
     expect(mockedLogger.error.mock.calls).toEqual([
       [
@@ -500,10 +566,16 @@ describe("startPluginServices", () => {
     ]);
     expect(requireLoggerErrorMessage()).not.toContain("\n");
     expect(mockedLogger.warn.mock.calls).toEqual([
-      ["plugin service stop failed (service-stop-fail): Error: stop failed"],
+      ["plugin service stop failed (service-stop-second): Error: second stop failed"],
+      ["plugin service stop failed (service-stop-first): Error: first stop failed"],
     ]);
     expect(stopOk).toHaveBeenCalledOnce();
-    expect(stopThrows).toHaveBeenCalledOnce();
+    expect(stopFirst).toHaveBeenCalledOnce();
+    expect(stopSecond).toHaveBeenCalledOnce();
+    expect(stopError).toBeInstanceOf(AggregateError);
+    expect(stopError).toMatchObject({
+      errors: [secondError, firstError],
+    });
   });
 
   it("continues starting siblings when rollback also fails", async () => {

--- a/src/plugins/services.test.ts
+++ b/src/plugins/services.test.ts
@@ -173,7 +173,7 @@ describe("startPluginServices", () => {
 
   it("drains diagnostics after producers stop and before exporters detach", async () => {
     const order: string[] = [];
-    let unsubscribe = () => undefined;
+    let unsubscribe: () => void = () => undefined;
     const registry = createRegistry(
       [
         {

--- a/src/plugins/services.ts
+++ b/src/plugins/services.ts
@@ -241,8 +241,8 @@ export async function startPluginServices(params: {
       (stopPromise ??= Promise.resolve().then(async () => {
         const reversed = running.toReversed();
         const diagnosticsExporters = reversed.filter((entry) => entry.diagnosticsExporter);
-        const failures: unknown[] = [];
-        const stopServices = async (services: typeof reversed) => {
+        const exporterFailures: unknown[] = [];
+        const stopServices = async (services: typeof reversed, failures?: unknown[]) => {
           for (const entry of services) {
             await stopService(entry, failures);
           }
@@ -252,12 +252,17 @@ export async function startPluginServices(params: {
           // Producers stop first; this barrier preserves their queued tail before exporters detach.
           await waitForDiagnosticEventsDrained();
         }
-        await stopServices(diagnosticsExporters);
-        if (failures.length === 1) {
-          throw failures[0];
+        // Ordinary plugin cleanup stays warn-and-continue. Trusted diagnostics
+        // exporter failures propagate because they can mean telemetry was lost.
+        await stopServices(diagnosticsExporters, exporterFailures);
+        if (exporterFailures.length === 1) {
+          throw exporterFailures[0];
         }
-        if (failures.length > 1) {
-          throw new AggregateError(failures, "multiple plugin services failed to stop");
+        if (exporterFailures.length > 1) {
+          throw new AggregateError(
+            exporterFailures,
+            "multiple diagnostics exporters failed to stop",
+          );
         }
       })),
   };

--- a/src/plugins/services.ts
+++ b/src/plugins/services.ts
@@ -5,6 +5,7 @@ import type { GatewayPluginEventBroadcastFn } from "../gateway/server-broadcast-
 import {
   emitTrustedDiagnosticEventWithPrivateData,
   onTrustedInternalDiagnosticEvent,
+  waitForDiagnosticEventsDrained,
 } from "../infra/diagnostic-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { subscribePluginSessionsChanged } from "./gateway-events.js";
@@ -171,16 +172,18 @@ export async function startPluginServices(params: {
 }): Promise<PluginServicesHandle> {
   const running: Array<{
     id: string;
+    diagnosticsExporter: boolean;
     stop?: () => void | Promise<void>;
     revokeGatewayEvents: () => void;
   }> = [];
-  const stopService = async (entry: (typeof running)[number]) => {
+  const stopService = async (entry: (typeof running)[number], failures?: unknown[]) => {
     try {
       if (entry.stop) {
         await withPluginHttpRouteRegistry(params.registry, () => entry.stop?.());
       }
     } catch (err) {
       log.warn(`plugin service stop failed (${entry.id}): ${String(err)}`);
+      failures?.push(err);
     } finally {
       entry.revokeGatewayEvents();
     }
@@ -202,6 +205,7 @@ export async function startPluginServices(params: {
     });
     const runningService = {
       id: service.id,
+      diagnosticsExporter: serviceContext.internalDiagnostics !== undefined,
       stop: service.stop ? () => service.stop?.(serviceContext) : undefined,
       revokeGatewayEvents: scopedGatewayEvents.revoke,
     };
@@ -235,8 +239,25 @@ export async function startPluginServices(params: {
     stop: () =>
       // Store the shared promise before plugin cleanup runs so shutdown cannot start twice.
       (stopPromise ??= Promise.resolve().then(async () => {
-        for (const entry of running.toReversed()) {
-          await stopService(entry);
+        const reversed = running.toReversed();
+        const diagnosticsExporters = reversed.filter((entry) => entry.diagnosticsExporter);
+        const failures: unknown[] = [];
+        const stopServices = async (services: typeof reversed) => {
+          for (const entry of services) {
+            await stopService(entry, failures);
+          }
+        };
+        await stopServices(reversed.filter((entry) => !entry.diagnosticsExporter));
+        if (diagnosticsExporters.length > 0) {
+          // Producers stop first; this barrier preserves their queued tail before exporters detach.
+          await waitForDiagnosticEventsDrained();
+        }
+        await stopServices(diagnosticsExporters);
+        if (failures.length === 1) {
+          throw failures[0];
+        }
+        if (failures.length > 1) {
+          throw new AggregateError(failures, "multiple plugin services failed to stop");
         }
       })),
   };


### PR DESCRIPTION
Fixes #119694

## What Problem This Solves

The diagnostics OTEL service could detach exporters before other plugin services finished emitting their final queued diagnostics. Its own exporter cleanup failures were also swallowed, so shutdown and reload could appear successful after telemetry cleanup failed.

## Why This Change Was Made

- Stop ordinary diagnostic producers before services that receive the trusted `internalDiagnostics` capability.
- Drain the diagnostics queue snapshot before stopping those trusted diagnostics exporters.
- Preserve existing warn-and-continue behavior for ordinary plugin service stop failures.
- Attempt every trusted diagnostics exporter stop and propagate only those exporter failures.
- Attempt every OTEL cleanup step and report one failure or an `AggregateError`.
- Reject diagnostics-otel startup before provider construction when the required capability is unavailable.

The generic plugin-service lifecycle owns producer/exporter ordering and trusted exporter failure propagation. The diagnostics-otel service owns provider cleanup. No gateway recovery behavior, config, protocol, endpoint, storage, or payload contract changes are included.

## User Impact

Final diagnostics emitted during shutdown or reload are delivered before OTEL listeners detach. Ordinary plugin stop failures still warn and continue, while a trusted diagnostics exporter cleanup failure reaches the existing host lifecycle handling after all service stops have run.

## Verification

- `node scripts/run-vitest.mjs extensions/diagnostics-otel/src/service.test.ts src/infra/diagnostic-events.test.ts src/plugins/services.test.ts`: 200 passed
- Tests prove an ordinary producer stop failure does not reject, a trusted diagnostics exporter stop failure does reject, every stop still runs, and producer -> drain -> exporter ordering remains intact
- `node_modules/.bin/oxfmt --check` on all six changed files: passed
- Path-scoped `node_modules/.bin/oxlint` on the compatibility fix: passed
- `git diff --check origin/main...HEAD`: passed
- Exact-head branch autoreview at `4b7d6fec9fd5b924df34588231a6c38ea8cbb3d8`: clean, no P0-P2 findings
- AWS Crabbox `run_5574cea54e2a` at `4b7d6fec9fd5b924df34588231a6c38ea8cbb3d8`: 291 tests passed, including real OTLP exporter and sibling one-shot lifecycle coverage
- `pnpm qa:otel:smoke -- --collector local --logs-exporter both`: passed with 5 spans, 6 metrics, one OTLP log, one stdout log, and one request for each OTLP signal
- `pnpm check:test-types`, `pnpm tsgo:scripts`, and `pnpm tsgo:test:root`: passed on the exact PR head

Production delta: +63/-17, net +46. Test delta: +190/-7, net +183.
