### PR TITLE
fix(worktrees): keep worktrees placed directly under the worktrees root (#119691)

### DIFF
--- a/src/agents/worktrees/service.orphans.test.ts
+++ b/src/agents/worktrees/service.orphans.test.ts
@@ -1,0 +1,149 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { listGitWorktrees } from "./git.js";
+import { ManagedWorktreeService } from "./service.js";
+
+const execFileAsync = promisify(execFile);
+
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync("git", ["-C", cwd, ...args], {
+    encoding: "utf8",
+  });
+  return stdout.trim();
+}
+
+describe("ManagedWorktreeService orphan reconciliation", () => {
+  let root: string;
+  let repo: string;
+  let stateDir: string;
+  let env: NodeJS.ProcessEnv;
+  let service: ManagedWorktreeService;
+  let branchOrdinal = 0;
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(
+      path.join(await fs.realpath(os.tmpdir()), "openclaw-worktree-orphans-"),
+    );
+    repo = path.join(root, "repo");
+    stateDir = path.join(root, "state");
+    await fs.mkdir(repo, { recursive: true });
+    await fs.mkdir(stateDir, { recursive: true });
+    await git(repo, "init", "-b", "main");
+    await git(repo, "config", "user.name", "OpenClaw Test");
+    await git(repo, "config", "user.email", "openclaw-test@example.invalid");
+    await fs.writeFile(path.join(repo, "README.md"), "base\n");
+    await git(repo, "add", "README.md");
+    await git(repo, "commit", "-m", "initial");
+    env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    service = new ManagedWorktreeService({ env });
+  });
+
+  afterEach(async () => {
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  async function addRegisteredWorktree(
+    target: string,
+    kind: "committed" | "unborn",
+  ): Promise<void> {
+    const branch = `orphan-reconcile-${branchOrdinal++}`;
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    if (kind === "unborn") {
+      await git(repo, "worktree", "add", "--orphan", "-b", branch, target);
+    } else {
+      await git(repo, "worktree", "add", "-b", branch, target, "HEAD");
+    }
+    await fs.mkdir(path.join(target, "payload"), { recursive: true });
+    await fs.writeFile(path.join(target, "payload", "keep.txt"), `${kind}\n`);
+  }
+
+  async function expectRegisteredWorktreePreserved(
+    target: string,
+    kind: "committed" | "unborn",
+  ): Promise<void> {
+    const result = await service.gc();
+
+    expect(result.orphansDeleted).toBe(0);
+    await expect(fs.readFile(path.join(target, "payload", "keep.txt"), "utf8")).resolves.toBe(
+      `${kind}\n`,
+    );
+    const canonicalTarget = await fs.realpath(target);
+    const listed = await listGitWorktrees(repo);
+    await expect(
+      Promise.all(listed.map(async (entry) => await fs.realpath(entry.path))),
+    ).resolves.toContain(canonicalTarget);
+  }
+
+  it("preserves a committed worktree directly under the worktrees root", async () => {
+    const target = path.join(stateDir, "worktrees", "direct-committed");
+    await addRegisteredWorktree(target, "committed");
+
+    await expectRegisteredWorktreePreserved(target, "committed");
+  });
+
+  it("preserves an unborn worktree directly under the worktrees root", async () => {
+    const target = path.join(stateDir, "worktrees", "direct-unborn");
+    await addRegisteredWorktree(target, "unborn");
+
+    await expectRegisteredWorktreePreserved(target, "unborn");
+  });
+
+  it("preserves a committed worktree under a fingerprint directory", async () => {
+    const target = path.join(stateDir, "worktrees", "fingerprint", "nested-committed");
+    await addRegisteredWorktree(target, "committed");
+
+    await expectRegisteredWorktreePreserved(target, "committed");
+  });
+
+  it("preserves an unborn worktree under a fingerprint directory", async () => {
+    const target = path.join(stateDir, "worktrees", "fingerprint", "nested-unborn");
+    await addRegisteredWorktree(target, "unborn");
+
+    await expectRegisteredWorktreePreserved(target, "unborn");
+  });
+
+  it("deletes unregistered debris under a fingerprint directory", async () => {
+    const debris = path.join(stateDir, "worktrees", "fingerprint", "debris");
+    await fs.mkdir(debris, { recursive: true });
+    await fs.writeFile(path.join(debris, "remove.txt"), "debris\n");
+
+    const result = await service.gc();
+
+    expect(result.orphansDeleted).toBe(1);
+    await expect(fs.stat(debris)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("defers cleanup when checkout metadata cannot be inspected", async () => {
+    const target = path.join(stateDir, "worktrees", "fingerprint", "broken-checkout");
+    await fs.mkdir(path.join(target, "payload"), { recursive: true });
+    await fs.writeFile(path.join(target, ".git"), "gitdir: /missing/openclaw-worktree-control\n");
+    await fs.writeFile(path.join(target, "payload", "keep.txt"), "uncertain\n");
+
+    await expect(service.gc()).rejects.toThrow("git worktree list");
+    await expect(fs.readFile(path.join(target, "payload", "keep.txt"), "utf8")).resolves.toBe(
+      "uncertain\n",
+    );
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "canonicalizes a symlinked state root before matching registered paths",
+    async () => {
+      const realStateDir = path.join(root, "real-state");
+      const linkedStateDir = path.join(root, "linked-state");
+      await fs.mkdir(realStateDir);
+      await fs.symlink(realStateDir, linkedStateDir, "dir");
+      env = { ...process.env, OPENCLAW_STATE_DIR: linkedStateDir };
+      service = new ManagedWorktreeService({ env });
+      const target = path.join(realStateDir, "worktrees", "fingerprint", "nested-via-symlink");
+      await addRegisteredWorktree(target, "committed");
+
+      await expectRegisteredWorktreePreserved(target, "committed");
+    },
+  );
+});

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -212,6 +212,43 @@ async function resolveRepository(repoRoot: string): Promise<ResolvedRepository> 
   return await resolveRepositoryFromRealPath(requested, repoRoot);
 }
 
+async function canonicalPathKey(target: string): Promise<string> {
+  const canonical = await fs.realpath(target);
+  return process.platform === "win32" ? canonical.toLowerCase() : canonical;
+}
+
+async function shouldPreserveOrphanCandidate(
+  target: string,
+  managedPaths: ReadonlySet<string>,
+): Promise<boolean> {
+  const targetKey = await canonicalPathKey(target);
+  if (managedPaths.has(targetKey)) {
+    return true;
+  }
+  const hasOwnGitMarker = await pathExists(path.join(target, ".git"));
+  if (!hasOwnGitMarker) {
+    return false;
+  }
+  // Query from the checkout itself so registered unborn worktrees do not pass
+  // through resolveRepository's intentional HEAD commit requirement.
+  const listed = await listGitWorktrees(target);
+  for (const entry of listed) {
+    let listedKey: string;
+    try {
+      listedKey = await canonicalPathKey(entry.path);
+    } catch (error) {
+      if (isMissingFileError(error)) {
+        continue;
+      }
+      throw error;
+    }
+    if (listedKey === targetKey) {
+      return true;
+    }
+  }
+  return false;
+}
+
 async function cleanupFailedCreate(repoRoot: string, worktreePath: string, branch: string) {
   const removed = await runGit(repoRoot, ["worktree", "remove", "--force", worktreePath]);
   const deletedBranch = await runGit(repoRoot, ["branch", "-D", branch]);
@@ -1236,7 +1273,16 @@ export class ManagedWorktreeService {
   }
 
   private async reconcileOrphans(records: ManagedWorktreeRecord[]): Promise<number> {
-    const managedPaths = new Set(records.map((record) => path.resolve(record.path)));
+    const managedPaths = new Set<string>();
+    for (const record of records) {
+      try {
+        managedPaths.add(await canonicalPathKey(record.path));
+      } catch (error) {
+        if (!isMissingFileError(error)) {
+          throw error;
+        }
+      }
+    }
     const worktreesRoot = path.join(resolveStateDir(this.env), "worktrees");
     const fingerprints = await fs.readdir(worktreesRoot, { withFileTypes: true }).catch(() => []);
     let deleted = 0;
@@ -1245,21 +1291,19 @@ export class ManagedWorktreeService {
         continue;
       }
       const fingerprintPath = path.join(worktreesRoot, fingerprint.name);
+      // A root entry can be a checkout, not a fingerprint container; descending
+      // before applying the same preservation rule would expose its contents to deletion.
+      if (await shouldPreserveOrphanCandidate(fingerprintPath, managedPaths)) {
+        continue;
+      }
       const names = await fs.readdir(fingerprintPath, { withFileTypes: true }).catch(() => []);
       for (const name of names) {
         if (!name.isDirectory()) {
           continue;
         }
         const candidate = path.join(fingerprintPath, name.name);
-        if (managedPaths.has(path.resolve(candidate))) {
+        if (await shouldPreserveOrphanCandidate(candidate, managedPaths)) {
           continue;
-        }
-        const repository = await resolveRepository(candidate).catch(() => undefined);
-        if (repository) {
-          const listed = await listGitWorktrees(repository.repoRoot).catch(() => []);
-          if (listed.some((entry) => path.resolve(entry.path) === path.resolve(candidate))) {
-            continue;
-          }
         }
         await fs.rm(candidate, { recursive: true, force: true });
         deleted += 1;


### PR DESCRIPTION
Fixes #119691

## What Problem This Solves

Fixes an issue where operators with a Git worktree placed directly under OpenClaw's worktrees state root could have that checkout's child directories recursively deleted by orphan garbage collection. The same risk also affected registered unborn worktrees and path aliases such as a symlinked state root.

## Why This Change Was Made

Orphan reconciliation now classifies each top-level and nested candidate with one preservation rule before descending or deleting. It uses Git's stable `worktree list --porcelain -z` registry from checkout roots, canonicalizes target and listed paths, preserves committed and unborn worktrees, and aborts cleanup when checkout metadata cannot be inspected safely. The existing commit-required repository resolver remains unchanged.

## User Impact

Registered Git worktrees remain intact whether they use OpenClaw's fingerprint layout or live directly below the worktrees root. Genuine unregistered debris still gets removed.

## Evidence

Before the repair on `origin/main` baseline `a20746e3abf7`:

```text
Test Files  1 failed (1)
Tests       4 failed | 2 passed (6)
```

The failing cases were direct committed, direct unborn, nested unborn, and symlinked-state-root worktrees.

After the repair at `7aa31a2ae395`:

```text
macOS real-Git regression suite: 7/7 passed, repeated 3 times
macOS existing worktree service suite: 48/48 passed
Linux Blacksmith Testbox: check-changed passed; focused suites 55/55 passed
Autoreview (Codex, max P1): no accepted/actionable findings
```

Linux proof: https://github.com/openclaw/openclaw/actions/runs/31059656680

The new failure-path regression also verifies that a broken checkout control path aborts garbage collection before its payload can be deleted.

Release note: prevent managed-worktree orphan cleanup from recursively deleting registered direct-root or unborn Git worktrees.

[AI-assisted]

Punchcard-Session: amber-meadow-timber-8r
