### PR TITLE
fix(memory): keep gateway responsive after startup

### DIFF
--- a/extensions/memory-core/index.test.ts
+++ b/extensions/memory-core/index.test.ts
@@ -3,7 +3,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { OpenClawPluginApi, OpenClawPluginCommandDefinition } from "openclaw/plugin-sdk/core";
 import type { MemoryPluginRuntime } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { buildMemoryFlushPlan } from "./src/flush-plan.js";
 import type { MemoryCoreRuntimeHost } from "./src/memory/runtime-host.js";
 import { buildPromptSection } from "./src/prompt-section.js";
@@ -112,10 +112,6 @@ describe("memory-core plugin runtime registration", () => {
     vi.clearAllMocks();
   });
 
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
   it("registers the dreaming runtime slash command", () => {
     let command: OpenClawPluginCommandDefinition | undefined;
     plugin.register(
@@ -199,228 +195,14 @@ describe("memory-core plugin runtime registration", () => {
     expect(intentFactory({ config: {}, senderIsOwner: true })).toMatchObject({ name: "intent" });
   });
 
-  it("warms each configured memory manager at gateway start and logs failures at debug", async () => {
-    vi.useFakeTimers();
-    const gatewayStartHandlers: Array<(event: unknown, ctx: { config: OpenClawConfig }) => void> =
-      [];
-    const syncMain = vi.fn(async () => {});
-    const syncWork = vi.fn(async () => {
-      throw new Error("warmup failed");
-    });
-    const debug = vi.fn();
-    getMemorySearchManagerMock
-      .mockResolvedValueOnce({ manager: { sync: syncMain } } as never)
-      .mockResolvedValueOnce({ manager: { sync: syncWork } } as never);
-    const config = {
-      agents: { entries: { main: { default: true }, work: {} } },
-    } as OpenClawConfig;
-    const testApi = createTestPluginApi({
-      config,
-      logger: { debug, info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      runtime: hostRuntime,
-      on(hookName, handler) {
-        if (hookName === "gateway_start") {
-          gatewayStartHandlers.push(
-            handler as unknown as (event: unknown, ctx: { config: OpenClawConfig }) => void,
-          );
-        }
-      },
-    });
-
-    plugin.register(testApi);
-    const warmup = gatewayStartHandlers.at(-1);
-    if (!warmup) {
-      throw new Error("expected memory warmup gateway_start hook");
-    }
-    warmup({}, { config });
-
-    expect(getMemorySearchManagerMock).not.toHaveBeenCalled();
-    await vi.runOnlyPendingTimersAsync();
-    await vi.waitFor(() => {
-      expect(getMemorySearchManagerMock).toHaveBeenCalledTimes(2);
-      expect(syncMain).toHaveBeenCalledWith({ reason: "startup-warmup" });
-      expect(syncWork).toHaveBeenCalledWith({ reason: "startup-warmup" });
-      expect(debug).toHaveBeenCalledWith(
-        "memory-core: startup index warmup failed for work: warmup failed",
-      );
-    });
-  });
-
-  it("defers memory manager initialization until after the gateway start turn", async () => {
-    vi.useFakeTimers();
-    const gatewayStartHandlers: Array<(event: unknown, ctx: { config: OpenClawConfig }) => void> =
-      [];
-    getMemorySearchManagerMock.mockResolvedValue({ manager: null } as never);
-    const config = {} as OpenClawConfig;
+  it("keeps memory manager initialization demand-driven", () => {
     plugin.register(
       createTestPluginApi({
-        config,
         runtime: hostRuntime,
-        on(hookName, handler) {
-          if (hookName === "gateway_start") {
-            gatewayStartHandlers.push(
-              handler as unknown as (event: unknown, ctx: { config: OpenClawConfig }) => void,
-            );
-          }
-        },
       }),
     );
-    const warmup = gatewayStartHandlers.at(-1);
-    if (!warmup) {
-      throw new Error("expected memory warmup gateway_start hook");
-    }
 
-    warmup({}, { config });
-
-    expect(getMemorySearchManagerMock).not.toHaveBeenCalled();
-    await vi.runOnlyPendingTimersAsync();
-    await vi.waitFor(() => expect(getMemorySearchManagerMock).toHaveBeenCalledTimes(1));
-  });
-
-  it("cancels deferred memory warmup when the gateway stops", async () => {
-    vi.useFakeTimers();
-    const gatewayStartHandlers: Array<(event: unknown, ctx: { config: OpenClawConfig }) => void> =
-      [];
-    const gatewayStopHandlers: Array<() => void> = [];
-    const config = {} as OpenClawConfig;
-    plugin.register(
-      createTestPluginApi({
-        config,
-        runtime: hostRuntime,
-        on(hookName, handler) {
-          if (hookName === "gateway_start") {
-            gatewayStartHandlers.push(
-              handler as unknown as (event: unknown, ctx: { config: OpenClawConfig }) => void,
-            );
-          }
-          if (hookName === "gateway_stop") {
-            gatewayStopHandlers.push(handler as unknown as () => void);
-          }
-        },
-      }),
-    );
-    const warmup = gatewayStartHandlers.at(-1);
-    const stop = gatewayStopHandlers.at(-1);
-    if (!warmup || !stop) {
-      throw new Error("expected memory warmup lifecycle hooks");
-    }
-
-    warmup({}, { config });
-    stop();
-    await vi.runOnlyPendingTimersAsync();
-
-    expect(getMemorySearchManagerMock).not.toHaveBeenCalled();
-  });
-
-  it("prevents a restarted gateway generation from syncing a stale manager", async () => {
-    vi.useFakeTimers();
-    const gatewayStartHandlers: Array<(event: unknown, ctx: { config: OpenClawConfig }) => void> =
-      [];
-    let resolveStaleManager:
-      | ((value: { manager: { sync: () => Promise<void> } }) => void)
-      | undefined;
-    const staleManagerResult = new Promise<{ manager: { sync: () => Promise<void> } }>(
-      (resolve) => {
-        resolveStaleManager = resolve;
-      },
-    );
-    const staleSync = vi.fn(async () => {});
-    const currentSync = vi.fn(async () => {});
-    getMemorySearchManagerMock
-      .mockReturnValueOnce(staleManagerResult as never)
-      .mockResolvedValueOnce({ manager: { sync: currentSync } } as never);
-    const config = {} as OpenClawConfig;
-    plugin.register(
-      createTestPluginApi({
-        config,
-        runtime: hostRuntime,
-        on(hookName, handler) {
-          if (hookName === "gateway_start") {
-            gatewayStartHandlers.push(
-              handler as unknown as (event: unknown, ctx: { config: OpenClawConfig }) => void,
-            );
-          }
-        },
-      }),
-    );
-    const warmup = gatewayStartHandlers.at(-1);
-    if (!warmup) {
-      throw new Error("expected memory warmup gateway_start hook");
-    }
-
-    warmup({}, { config });
-    await vi.runOnlyPendingTimersAsync();
-    await vi.waitFor(() => expect(getMemorySearchManagerMock).toHaveBeenCalledTimes(1));
-
-    warmup({}, { config });
-    await vi.runOnlyPendingTimersAsync();
-    await vi.waitFor(() => expect(currentSync).toHaveBeenCalledWith({ reason: "startup-warmup" }));
-
-    resolveStaleManager?.({ manager: { sync: staleSync } });
-    await vi.waitFor(() => expect(getMemorySearchManagerMock).toHaveBeenCalledTimes(2));
-    expect(staleSync).not.toHaveBeenCalled();
-  });
-
-  it("leaves QMD startup synchronization to the backend boot policy", async () => {
-    vi.useFakeTimers();
-    const gatewayStartHandlers: Array<(event: unknown, ctx: { config: OpenClawConfig }) => void> =
-      [];
-    const sync = vi.fn(async () => {});
-    getMemorySearchManagerMock.mockResolvedValueOnce({ manager: { sync } } as never);
-    const config = {
-      memory: { backend: "qmd", qmd: { update: { onBoot: false } } },
-    } as OpenClawConfig;
-    plugin.register(
-      createTestPluginApi({
-        config,
-        runtime: hostRuntime,
-        on(hookName, handler) {
-          if (hookName === "gateway_start") {
-            gatewayStartHandlers.push(
-              handler as unknown as (event: unknown, ctx: { config: OpenClawConfig }) => void,
-            );
-          }
-        },
-      }),
-    );
-    const warmup = gatewayStartHandlers.at(-1);
-    if (!warmup) {
-      throw new Error("expected memory warmup gateway_start hook");
-    }
-
-    warmup({}, { config });
-
-    await vi.runOnlyPendingTimersAsync();
-    await vi.waitFor(() => expect(getMemorySearchManagerMock).toHaveBeenCalledTimes(1));
-    expect(sync).not.toHaveBeenCalled();
-  });
-
-  it("does not warm memory-core when another plugin owns the memory slot", async () => {
-    const gatewayStartHandlers: Array<(event: unknown, ctx: { config: OpenClawConfig }) => void> =
-      [];
-    const config = {
-      plugins: { slots: { memory: "memory-lancedb" } },
-    } as OpenClawConfig;
-    plugin.register(
-      createTestPluginApi({
-        config,
-        runtime: hostRuntime,
-        on(hookName, handler) {
-          if (hookName === "gateway_start") {
-            gatewayStartHandlers.push(
-              handler as unknown as (event: unknown, ctx: { config: OpenClawConfig }) => void,
-            );
-          }
-        },
-      }),
-    );
-    const warmup = gatewayStartHandlers.at(-1);
-    if (!warmup) {
-      throw new Error("expected memory warmup gateway_start hook");
-    }
-
-    warmup({}, { config });
-
+    expect(createMemoryRuntimeMock).not.toHaveBeenCalled();
     expect(getMemorySearchManagerMock).not.toHaveBeenCalled();
   });
 

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -2,18 +2,15 @@ import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 // Memory Core plugin entrypoint registers its OpenClaw integration.
 import {
   jsonResult,
-  listAgentIds,
   resolveMemorySearchConfig,
   resolveSessionAgentIds,
   type MemoryPluginRuntime,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import { resolveMemoryBackendConfig } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
-import { normalizePluginsConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
 import {
   definePluginEntry,
   type AnyAgentTool,
-  type OpenClawPluginApi,
   type OpenClawPluginToolContext,
 } from "openclaw/plugin-sdk/plugin-entry";
 import type {
@@ -56,8 +53,6 @@ const loadStandingIntentToolModule = createLazyRuntimeModule(
 const loadRuntimeProviderModule = createLazyRuntimeModule(
   () => import("./src/runtime-provider.js"),
 );
-
-const MEMORY_MANAGER_WARMUP_DELAY_MS = 5_000;
 
 function getToolConfig(options: MemoryToolOptions): OpenClawConfig | undefined {
   return options.getConfig?.() ?? options.config;
@@ -277,72 +272,6 @@ function createLazyMemoryRuntime(host: MemoryCoreRuntimeHost): MemoryPluginRunti
   };
 }
 
-function registerMemoryManagerWarmup(
-  api: OpenClawPluginApi,
-  memoryRuntime: MemoryPluginRuntime,
-): void {
-  let lifecycleGeneration = 0;
-  let warmupTimer: ReturnType<typeof setTimeout> | null = null;
-
-  const cancelWarmup = () => {
-    lifecycleGeneration += 1;
-    if (warmupTimer) {
-      clearTimeout(warmupTimer);
-      warmupTimer = null;
-    }
-  };
-
-  api.on("gateway_start", (_event, ctx) => {
-    cancelWarmup();
-    const generation = lifecycleGeneration;
-    const config = (api.runtime.config?.current?.() ?? ctx.config ?? api.config) as OpenClawConfig;
-    if (normalizePluginsConfig(config.plugins).slots.memory !== "memory-core") {
-      return;
-    }
-
-    // Leave a bounded idle window for initial post-ready RPCs before loading the manager.
-    const timer = setTimeout(() => {
-      if (warmupTimer !== timer || generation !== lifecycleGeneration) {
-        return;
-      }
-      warmupTimer = null;
-      for (const agentId of listAgentIds(config)) {
-        const backend = memoryRuntime.resolveMemoryBackendConfig({ cfg: config, agentId });
-        void memoryRuntime
-          .getMemorySearchManager({ cfg: config, agentId })
-          .then(async ({ manager, error }) => {
-            if (generation !== lifecycleGeneration) {
-              return;
-            }
-            if (!manager) {
-              if (error) {
-                api.logger.debug?.(`memory-core: startup index warmup unavailable: ${error}`);
-              }
-              return;
-            }
-            if (backend.backend === "builtin") {
-              await manager.sync?.({ reason: "startup-warmup" });
-            }
-          })
-          .catch((error: unknown) => {
-            if (generation !== lifecycleGeneration) {
-              return;
-            }
-            api.logger.debug?.(
-              `memory-core: startup index warmup failed for ${agentId}: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            );
-          });
-      }
-    }, MEMORY_MANAGER_WARMUP_DELAY_MS);
-    warmupTimer = timer;
-    warmupTimer.unref?.();
-  });
-
-  api.on("gateway_stop", cancelWarmup);
-}
-
 export default definePluginEntry({
   id: "memory-core",
   name: "OpenClaw Memory",
@@ -358,7 +287,6 @@ export default definePluginEntry({
     const memoryRuntime = createLazyMemoryRuntime(host);
     registerShortTermPromotionDreaming(api);
     registerSessionBackfillGatewayMethods(api);
-    registerMemoryManagerWarmup(api, memoryRuntime);
     api.registerMemoryCapability({
       promptBuilder: buildPromptSection,
       flushPlanResolver: buildMemoryFlushPlan,

--- a/src/plugins/contracts/boundary-invariants.test.ts
+++ b/src/plugins/contracts/boundary-invariants.test.ts
@@ -42,12 +42,7 @@ const BUNDLED_TYPED_HOOK_REGISTRATION_GUARDS = {
   "extensions/feishu/subagent-hooks-api.ts": ["subagent_delivery_target", "subagent_ended"],
   "extensions/matrix/subagent-hooks-api.ts": ["subagent_delivery_target", "subagent_ended"],
   "extensions/memory-core/src/dreaming.ts": ["before_agent_reply", "gateway_start", "gateway_stop"],
-  "extensions/memory-core/index.ts": [
-    "before_agent_reply",
-    "before_prompt_build",
-    "gateway_start",
-    "gateway_stop",
-  ],
+  "extensions/memory-core/index.ts": ["before_agent_reply", "before_prompt_build"],
   "extensions/memory-lancedb/index.ts": ["agent_end", "before_prompt_build", "session_end"],
   "extensions/onepassword/index.ts": ["before_tool_call", "tool_result_persist"],
   "extensions/thread-ownership/index.ts": ["message_received", "message_sending"],


### PR DESCRIPTION
Related: #119087

Follow-up to #119676.

## What Problem This Solves

Fixes an issue where operators could see multi-second `health`, first-device, and `config.get` RPC stalls after the Gateway reported ready because `memory-core` started unsolicited index initialization five seconds later.

## Why This Change Was Made

The prior delay moved the contention window but did not remove it. This change deletes the startup memory-manager warmup and keeps initialization demand-driven at the memory owner boundary.

Builtin memory search already performs a synchronous bootstrap when its index is empty and always schedules dirty refresh on search. QMD keeps its existing backend-owned boot policy. No memory configuration, storage, or search contract changes.

Repair summary:

- root cause: the post-ready startup hook loaded and synchronized every configured builtin memory manager without a memory operation
- architectural owner: `memory-core` manager lifecycle
- canonical fix: initialize the manager only when a memory operation requests it
- removed paths: startup timer, lifecycle generation guards, warmup sync, and their obsolete tests
- production delta: -72 lines
- sibling coverage: builtin first-search bootstrap and QMD boot policy remain unchanged

This PR was prepared with AI assistance. I reviewed the code, owner contracts, and runtime evidence.

## User Impact

The Gateway remains responsive after readiness instead of pausing later for background memory initialization. The first real memory search owns any required index bootstrap through the existing search contract.

## Evidence

Matched packaged `sourcePerformance` probe, exact latest main `e69c3df2361b38285917c29b0c90867c75b8ebe9` versus this branch, five measured samples plus one warmup per case:

| RPC | latest main p50 / max | candidate p50 / max |
|---|---:|---:|
| connected `health --json` | 3,110 / 9,208 ms | 801 / 847 ms |
| fresh-device `health --json` | 1,499 / 3,077 ms | 767 / 823 ms |
| `config get gateway.port` | 5,249 / 6,769 ms | 1,113 / 1,638 ms |

- All 15 candidate samples passed; the Gateway stayed responsive through the post-ready window and shut down cleanly.
- Exact-head GitHub performance proof passed:
  - https://github.com/openclaw/openclaw/actions/runs/31036424116
  - Kova diagnostic repeat-3: 6/6 selected records passed; gateway ready median 6,087 ms, Gateway RSS median 970 MB and max 1,023 MB.
  - Source-performance CLI probe: connected health 3/3 at 1,042 ms p50, fresh-device health 3/3 at 1,100 ms p50, and config get 3/3 at 1,368 ms p50; zero timeouts.
- The unchanged Kova source-performance probe reproduced the worse form of the bug on both the startup-stack head and its parent: later first-device RPCs timed out while memory warmup drove event-loop and RSS pressure.
  - https://github.com/openclaw/openclaw/actions/runs/31033749633
  - https://github.com/openclaw/openclaw/actions/runs/31033854332
- Focused tests: 45 assertions passed across plugin registration, boundary invariants, async search synchronization, and first-search preflight.
- Packaged `sourcePerformance` build passed with private QA artifacts enabled.
- `oxfmt`, `oxlint`, and `git diff --check` passed.
- Structured autoreview: clean, no accepted/actionable findings, 0.99 correctness confidence.
- Exact-head PR CI: 75 passed, 0 failed.

Punchcard-Session: coral-workshop-workshop-3f
