### PR TITLE
fix: agent runs stay active and duplicate timeout alerts

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -383,6 +383,8 @@ const config = {
     "src/tasks/detached-task-runtime-state.ts": ["exports"],
     // Focused media tests consume these explicit seams; production uses the helpers in-module.
     "src/agents/embedded-agent-subscribe.handlers.lifecycle.ts": ["exports"],
+    "src/agents/embedded-agent-runner/run/terminal-timeout.ts": ["exports"],
+    "src/gateway/server-methods/agent-run-dispatch.ts": ["exports"],
     "src/gateway/server-methods/chat-webchat-media.ts": ["exports"],
     // Greeting cache/fact contracts (hash, alert text, store shapes) are
     // asserted by the focused greeting unit tests, not by another prod module.

--- a/qa/scenarios/agents/subagent-completion-direct-fallback.yaml
+++ b/qa/scenarios/agents/subagent-completion-direct-fallback.yaml
@@ -24,7 +24,7 @@ scenario:
     - Visible completion output reaches the originating QA DM exactly once.
     - Exact NO_REPLY completion output produces no channel delivery.
     - Genuinely empty completion output is represented intentionally once.
-    - Gateway restart does not replay prior terminal payloads, represents the interrupted handoff explicitly, and a post-restart completion is delivered exactly once.
+    - Gateway restart does not replay prior terminal payloads or fabricate interruption alerts for already-settled handoffs, and a post-restart completion is delivered exactly once.
     - Direct fallback strips protected internal metadata before one channel delivery.
   docsRefs:
     - docs/tools/subagents.md
@@ -179,12 +179,6 @@ flow:
           args:
             - ref: env
             - 180000
-        - call: waitForCondition
-          args:
-            - lambda:
-                expr: "state.getSnapshot().messages.find((message) => message.direction === 'outbound' && verdicts.some((verdict) => verdict.conversationId === message.conversation.id) && !preRestartOutbound.some((before) => before.id === message.id) && String(message.text ?? '').includes('interrupted by a gateway restart'))"
-            - 60000
-            - 250
         - set: postRestartOutbound
           value:
             expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound' && verdicts.some((verdict) => verdict.conversationId === message.conversation.id)).map((message) => ({ id: message.id, conversationId: message.conversation.id, text: String(message.text ?? '') }))"
@@ -199,9 +193,9 @@ flow:
             message:
               expr: "`Gateway restart replayed or lost a prior terminal payload: before=${JSON.stringify(preRestartTerminalPayloads)} after=${JSON.stringify(postRestartTerminalPayloads)}`"
         - assert:
-            expr: "restartInterruptionPayloads.length === 1 && restartInterruptionPayloads.every((message) => message.text.includes('interrupted by a gateway restart'))"
+            expr: "restartInterruptionPayloads.length === 0"
             message:
-              expr: "`Gateway restart did not represent the interrupted completion handoff exactly once: ${JSON.stringify(restartInterruptionPayloads)}`"
+              expr: "`Gateway restart fabricated an interruption for an already-settled completion handoff: ${JSON.stringify(restartInterruptionPayloads)}`"
         - set: restartStartIndex
           value:
             expr: state.getSnapshot().messages.length
@@ -243,7 +237,7 @@ flow:
               expr: "`restart completion task lifecycle did not settle authoritatively; task=${JSON.stringify(restartTask)}`"
         - set: appendRestartVerdict
           value:
-            expr: "verdicts.push({ case: 'restart', conversationId: restartConversationId, taskId: restartTask.taskId, taskDeliveryStatus: restartTask.deliveryStatus, inputDisposition: 'visible', restart: true, fallback: true, preRestartTerminalMessageCount: preRestartTerminalPayloads.length, postRestartTerminalPayloadCount: postRestartTerminalPayloads.length, priorTerminalPayloadReplayCount: postRestartTerminalPayloads.length - preRestartTerminalPayloads.length, interruptedHandoffRepresentationCount: restartInterruptionPayloads.length, interruptedHandoffPayloads: restartInterruptionPayloads.map((message) => message.text), expectedTerminalSendCount: 1, actualTerminalSendCount: restartMatches.length, capturedTerminalPayloads: restartMatches.map((message) => String(message.text ?? '')), silenceTokenLeaked: false, internalMetadataLeak: false, pass: true })"
+            expr: "verdicts.push({ case: 'restart', conversationId: restartConversationId, taskId: restartTask.taskId, taskDeliveryStatus: restartTask.deliveryStatus, inputDisposition: 'visible', restart: true, fallback: true, preRestartTerminalMessageCount: preRestartTerminalPayloads.length, postRestartTerminalPayloadCount: postRestartTerminalPayloads.length, priorTerminalPayloadReplayCount: postRestartTerminalPayloads.length - preRestartTerminalPayloads.length, fabricatedInterruptedHandoffCount: restartInterruptionPayloads.length, expectedTerminalSendCount: 1, actualTerminalSendCount: restartMatches.length, capturedTerminalPayloads: restartMatches.map((message) => String(message.text ?? '')), silenceTokenLeaked: false, internalMetadataLeak: false, pass: true })"
         - set: emptyStartIndex
           value:
             expr: state.getSnapshot().messages.length

--- a/src/agents/embedded-agent-runner/run/terminal-timeout.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-timeout.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { buildPromptTimeoutPayloads } from "./terminal-timeout.js";
+import { __testing } from "./terminal-timeout.js";
+
+const { buildPromptTimeoutPayloads } = __testing;
 
 describe("buildPromptTimeoutPayloads", () => {
   it("replaces an earlier generic timeout error with one actionable final error", () => {

--- a/src/agents/embedded-agent-runner/run/terminal-timeout.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-timeout.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { buildPromptTimeoutPayloads } from "./terminal-timeout.js";
+
+describe("buildPromptTimeoutPayloads", () => {
+  it("replaces an earlier generic timeout error with one actionable final error", () => {
+    expect(
+      buildPromptTimeoutPayloads({
+        hasPartialAssistantTextAfterPromptTimeout: false,
+        payloadsWithToolMedia: [
+          { text: "LLM request timed out.", isError: true },
+          { mediaUrl: "https://example.invalid/evidence.png" },
+        ],
+        timeoutText: "The model did not produce a response before the model idle timeout.",
+      }),
+    ).toEqual([
+      { mediaUrl: "https://example.invalid/evidence.png" },
+      {
+        text: "The model did not produce a response before the model idle timeout.",
+        isError: true,
+      },
+    ]);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/terminal-timeout.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-timeout.ts
@@ -10,6 +10,17 @@ import {
 import { copyAttemptDeliveryState } from "./terminal-resolution.js";
 import type { EmbeddedRunAttemptResult } from "./types.js";
 
+export function buildPromptTimeoutPayloads(params: {
+  hasPartialAssistantTextAfterPromptTimeout: boolean;
+  payloadsWithToolMedia: EmbeddedAgentRunResult["payloads"];
+  timeoutText: string;
+}): EmbeddedAgentRunResult["payloads"] {
+  const preservedPayloads = params.hasPartialAssistantTextAfterPromptTimeout
+    ? []
+    : (params.payloadsWithToolMedia ?? []).filter((payload) => payload.isError !== true);
+  return [...preservedPayloads, { text: params.timeoutText, isError: true }];
+}
+
 export function resolveEmbeddedRunTerminalTimeout(input: {
   timedOutDuringPrompt: boolean;
   hasSuccessfulFinalAssistantAfterPromptTimeout: boolean;
@@ -69,10 +80,11 @@ export function resolveEmbeddedRunTerminalTimeout(input: {
   };
   input.setTerminalLifecycleMeta({ replayInvalid, livenessState, ...timeoutAttribution });
   return {
-    payloads: [
-      ...(input.hasPartialAssistantTextAfterPromptTimeout ? [] : input.payloadsWithToolMedia || []),
-      { text: timeoutText, isError: true },
-    ],
+    payloads: buildPromptTimeoutPayloads({
+      hasPartialAssistantTextAfterPromptTimeout: input.hasPartialAssistantTextAfterPromptTimeout,
+      payloadsWithToolMedia: input.payloadsWithToolMedia,
+      timeoutText,
+    }),
     meta: {
       durationMs: Date.now() - input.startedAtMs,
       agentMeta: input.agentMeta,

--- a/src/agents/embedded-agent-runner/run/terminal-timeout.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-timeout.ts
@@ -10,7 +10,7 @@ import {
 import { copyAttemptDeliveryState } from "./terminal-resolution.js";
 import type { EmbeddedRunAttemptResult } from "./types.js";
 
-export function buildPromptTimeoutPayloads(params: {
+function buildPromptTimeoutPayloads(params: {
   hasPartialAssistantTextAfterPromptTimeout: boolean;
   payloadsWithToolMedia: EmbeddedAgentRunResult["payloads"];
   timeoutText: string;
@@ -20,6 +20,9 @@ export function buildPromptTimeoutPayloads(params: {
     : (params.payloadsWithToolMedia ?? []).filter((payload) => payload.isError !== true);
   return [...preservedPayloads, { text: params.timeoutText, isError: true }];
 }
+
+const testing = { buildPromptTimeoutPayloads };
+export { testing as __testing };
 
 export function resolveEmbeddedRunTerminalTimeout(input: {
   timedOutDuringPrompt: boolean;

--- a/src/auto-reply/reply/dispatch-from-config.pending-final.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.pending-final.test.ts
@@ -63,11 +63,9 @@ describe("pending final delivery restart proof", () => {
       expect(entry?.restartRecoveryBeforeAgentReplyState).toBeUndefined();
       expect(entry?.restartRecoveryForceSafeTools).toBeUndefined();
       expect(entry?.restartRecoverySourceIngress).toBeUndefined();
-      expect(entry?.status).toBe(beforeAgentReplyState === "handled-reply" ? "done" : "running");
-      if (beforeAgentReplyState === "handled-reply") {
-        expect(entry?.endedAt).toBeTypeOf("number");
-        expect(entry?.runtimeMs).toBeGreaterThanOrEqual(0);
-      }
+      expect(entry?.status).toBe("done");
+      expect(entry?.endedAt).toBeTypeOf("number");
+      expect(entry?.runtimeMs).toBeGreaterThanOrEqual(0);
     },
   );
 

--- a/src/auto-reply/reply/dispatch-from-config.pending-final.ts
+++ b/src/auto-reply/reply/dispatch-from-config.pending-final.ts
@@ -25,15 +25,18 @@ type PendingFinalDeliveryIdentity = {
 };
 
 function buildPendingFinalDeliveryCleanupPatch(entry: SessionEntry): Partial<SessionEntry> {
-  // An active receipt/claim may outlive outer reply settlement. Only claimless pending finals
-  // borrow hook provenance until their exact transport intent settles.
+  // An active receipt/claim may outlive outer reply settlement. A claimless
+  // pending final is the last owner of the visible turn, so its exact transport
+  // settlement must also close the session lifecycle.
   const clearsRestartRecoveryProof =
     normalizeOptionalString(entry.restartRecoveryDeliveryRunId) === undefined;
-  const completesHookHandledTurn =
+  const completesSettledTurn =
     clearsRestartRecoveryProof &&
-    (entry.restartRecoveryBeforeAgentReplyState === "handled-reply" ||
+    entry.status === "running" &&
+    (entry.restartRecoveryBeforeAgentReplyState === "continue" ||
+      entry.restartRecoveryBeforeAgentReplyState === "handled-reply" ||
       entry.restartRecoveryBeforeAgentReplyState === "handled-unrecoverable");
-  const endedAt = completesHookHandledTurn ? Date.now() : undefined;
+  const endedAt = completesSettledTurn ? Date.now() : undefined;
   return {
     pendingFinalDelivery: undefined,
     ...(clearsRestartRecoveryProof

--- a/src/auto-reply/reply/restart-recovery-claim.test.ts
+++ b/src/auto-reply/reply/restart-recovery-claim.test.ts
@@ -38,6 +38,45 @@ function replaceSessionEntryFromIndependentConnection(params: {
 }
 
 describe("createReplyRestartRecoveryClaimController", () => {
+  it("settles a successful non-delivered turn after clearing its claim", async () => {
+    const root = tempDirs.make("openclaw-reply-no-delivery-settlement-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:cli:acceptance";
+    const sessionId = "session";
+    const startedAt = Date.now() - 100;
+    let entry: SessionEntry = {
+      abortedLastRun: false,
+      restartRecoveryBeforeAgentReplyState: "continue",
+      restartRecoveryDeliveryRunId: "cli-run",
+      sessionId,
+      startedAt,
+      status: "running",
+      updatedAt: startedAt,
+    };
+    await replaceSessionEntry({ storePath, sessionKey }, entry);
+    const controller = createReplyRestartRecoveryClaimController({
+      admissionRunId: "cli-run",
+      beforeAgentReplyState: "continue",
+      getEntry: () => entry,
+      getSessionId: () => sessionId,
+      isRestartAbort: () => false,
+      resolveDeliveryContext: () => undefined,
+      sessionKey,
+      setEntry: (next) => {
+        entry = next;
+      },
+      storePath,
+    });
+
+    await expect(controller.admitUserTurn()).resolves.toBe("admitted");
+    await controller.clear();
+
+    const persisted = loadSessionEntry({ storePath, sessionKey, readConsistency: "latest" });
+    expect(persisted).toMatchObject({ abortedLastRun: false, status: "done" });
+    expect(persisted?.endedAt).toBeTypeOf("number");
+    expect(persisted?.runtimeMs).toBeGreaterThanOrEqual(0);
+  });
+
   it("retargets durable user-turn admission to the prepared reply session", async () => {
     const root = tempDirs.make("openclaw-reply-admission-");
     const storePath = path.join(root, "sessions.json");

--- a/src/auto-reply/reply/restart-recovery-claim.ts
+++ b/src/auto-reply/reply/restart-recovery-claim.ts
@@ -509,10 +509,13 @@ export function createReplyRestartRecoveryClaimController(params: {
           };
         }
         const preservesPendingFinal = current.pendingFinalDelivery !== undefined;
-        const completesHandledSilent =
-          current.restartRecoveryBeforeAgentReplyState === "handled-silent" &&
-          !preservesPendingFinal;
-        const endedAt = completesHandledSilent ? Date.now() : undefined;
+        const beforeAgentReplyState = current.restartRecoveryBeforeAgentReplyState;
+        const completesWithoutPendingFinal =
+          !preservesPendingFinal &&
+          beforeAgentReplyState !== undefined &&
+          beforeAgentReplyState !== "admitted" &&
+          beforeAgentReplyState !== "pending";
+        const endedAt = completesWithoutPendingFinal ? Date.now() : undefined;
         return {
           ...buildRestartRecoveryClaimCleanupPatch({
             entry: current,

--- a/src/gateway/server-methods/agent-run-dispatch.test.ts
+++ b/src/gateway/server-methods/agent-run-dispatch.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
-import { persistAgentRunTerminalSession } from "./agent-run-dispatch.js";
+import { __testing } from "./agent-run-dispatch.js";
+
+const { persistAgentRunTerminalSession } = __testing;
 
 describe("persistAgentRunTerminalSession", () => {
   it("projects a successful suppressed agent RPC into its owned session", async () => {

--- a/src/gateway/server-methods/agent-run-dispatch.test.ts
+++ b/src/gateway/server-methods/agent-run-dispatch.test.ts
@@ -1,13 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
-import { persistNonDeliveredAgentRunTerminalSession } from "./agent-run-dispatch.js";
+import { persistAgentRunTerminalSession } from "./agent-run-dispatch.js";
 
-describe("persistNonDeliveredAgentRunTerminalSession", () => {
+describe("persistAgentRunTerminalSession", () => {
   it("projects a successful suppressed agent RPC into its owned session", async () => {
     const persist = vi.fn(async () => undefined);
 
-    await persistNonDeliveredAgentRunTerminalSession({
+    await persistAgentRunTerminalSession({
       agentId: "main",
-      deliver: false,
       persist,
       runId: "run-1",
       sessionId: "session-1",
@@ -27,11 +26,10 @@ describe("persistNonDeliveredAgentRunTerminalSession", () => {
     });
   });
 
-  it("leaves delivered runs to transport settlement", async () => {
+  it("projects a delivered run after transport settlement returns", async () => {
     const persist = vi.fn(async () => undefined);
 
-    await persistNonDeliveredAgentRunTerminalSession({
-      deliver: true,
+    await persistAgentRunTerminalSession({
       persist,
       runId: "run-1",
       sessionId: "session-1",
@@ -39,6 +37,6 @@ describe("persistNonDeliveredAgentRunTerminalSession", () => {
       terminalOutcome: { reason: "completed", status: "ok" },
     });
 
-    expect(persist).not.toHaveBeenCalled();
+    expect(persist).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/gateway/server-methods/agent-run-dispatch.test.ts
+++ b/src/gateway/server-methods/agent-run-dispatch.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import { persistNonDeliveredAgentRunTerminalSession } from "./agent-run-dispatch.js";
+
+describe("persistNonDeliveredAgentRunTerminalSession", () => {
+  it("projects a successful suppressed agent RPC into its owned session", async () => {
+    const persist = vi.fn(async () => undefined);
+
+    await persistNonDeliveredAgentRunTerminalSession({
+      agentId: "main",
+      deliver: false,
+      persist,
+      runId: "run-1",
+      sessionId: "session-1",
+      sessionKey: "agent:main:cli-check",
+      terminalOutcome: { reason: "completed", status: "ok", endedAt: 2_000 },
+    });
+
+    expect(persist).toHaveBeenCalledWith({
+      agentId: "main",
+      sessionKey: "agent:main:cli-check",
+      event: {
+        runId: "run-1",
+        sessionId: "session-1",
+        ts: 2_000,
+        data: { phase: "end", endedAt: 2_000 },
+      },
+    });
+  });
+
+  it("leaves delivered runs to transport settlement", async () => {
+    const persist = vi.fn(async () => undefined);
+
+    await persistNonDeliveredAgentRunTerminalSession({
+      deliver: true,
+      persist,
+      runId: "run-1",
+      sessionId: "session-1",
+      sessionKey: "agent:main:telegram:direct:1",
+      terminalOutcome: { reason: "completed", status: "ok" },
+    });
+
+    expect(persist).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/server-methods/agent-run-dispatch.ts
+++ b/src/gateway/server-methods/agent-run-dispatch.ts
@@ -28,16 +28,15 @@ import type { GatewayRequestContext, GatewayRequestHandlerOptions } from "./type
 
 type PersistGatewaySessionLifecycleEvent = typeof persistGatewaySessionLifecycleEvent;
 
-export async function persistNonDeliveredAgentRunTerminalSession(params: {
+export async function persistAgentRunTerminalSession(params: {
   agentId?: string;
-  deliver?: boolean;
   persist?: PersistGatewaySessionLifecycleEvent;
   runId: string;
   sessionId?: string;
   sessionKey?: string;
   terminalOutcome: AgentRunTerminalOutcome;
 }): Promise<void> {
-  if (params.deliver === true || !params.sessionKey || !params.sessionId) {
+  if (!params.sessionKey || !params.sessionId) {
     return;
   }
   const endedAt = params.terminalOutcome.endedAt ?? Date.now();
@@ -239,9 +238,8 @@ export function dispatchAgentRunFromGateway(params: {
           ? resultAgentMeta.sessionId
           : params.ingressOpts.sessionId;
       try {
-        await persistNonDeliveredAgentRunTerminalSession({
+        await persistAgentRunTerminalSession({
           agentId: params.ingressOpts.agentId,
-          deliver: params.ingressOpts.deliver,
           runId: params.runId,
           sessionId: terminalSessionId,
           sessionKey: params.ingressOpts.sessionKey,
@@ -249,7 +247,7 @@ export function dispatchAgentRunFromGateway(params: {
         });
       } catch (error) {
         params.context.logGateway.warn(
-          `failed to persist non-delivered agent session terminal state ${params.runId}: ${formatForLog(error)}`,
+          `failed to persist agent session terminal state ${params.runId}: ${formatForLog(error)}`,
         );
       }
       const responseStatus =

--- a/src/gateway/server-methods/agent-run-dispatch.ts
+++ b/src/gateway/server-methods/agent-run-dispatch.ts
@@ -28,7 +28,7 @@ import type { GatewayRequestContext, GatewayRequestHandlerOptions } from "./type
 
 type PersistGatewaySessionLifecycleEvent = typeof persistGatewaySessionLifecycleEvent;
 
-export async function persistAgentRunTerminalSession(params: {
+async function persistAgentRunTerminalSession(params: {
   agentId?: string;
   persist?: PersistGatewaySessionLifecycleEvent;
   runId: string;
@@ -67,6 +67,9 @@ export async function persistAgentRunTerminalSession(params: {
     },
   });
 }
+
+const testing = { persistAgentRunTerminalSession };
+export { testing as __testing };
 
 function resolveResolvedAgentTimeoutStopReason(
   meta: unknown,

--- a/src/gateway/server-methods/agent-run-dispatch.ts
+++ b/src/gateway/server-methods/agent-run-dispatch.ts
@@ -17,6 +17,7 @@ import { createRunningTaskRun } from "../../tasks/detached-task-runtime.js";
 import { mapAgentRunTerminalOutcomeToTaskStatus } from "../../tasks/task-registry-common.js";
 import { normalizeDeliveryContext } from "../../utils/delivery-context.shared.js";
 import type { ChatAbortControllerEntry } from "../chat-abort.js";
+import { persistGatewaySessionLifecycleEvent } from "../session-lifecycle-state.js";
 import { formatForLog } from "../ws-log.js";
 import { setGatewayDedupeEntries } from "./agent-dedupe.js";
 import {
@@ -24,6 +25,49 @@ import {
   type GatewayAgentTaskTrackingMode,
 } from "./agent-task-tracking.js";
 import type { GatewayRequestContext, GatewayRequestHandlerOptions } from "./types.js";
+
+type PersistGatewaySessionLifecycleEvent = typeof persistGatewaySessionLifecycleEvent;
+
+export async function persistNonDeliveredAgentRunTerminalSession(params: {
+  agentId?: string;
+  deliver?: boolean;
+  persist?: PersistGatewaySessionLifecycleEvent;
+  runId: string;
+  sessionId?: string;
+  sessionKey?: string;
+  terminalOutcome: AgentRunTerminalOutcome;
+}): Promise<void> {
+  if (params.deliver === true || !params.sessionKey || !params.sessionId) {
+    return;
+  }
+  const endedAt = params.terminalOutcome.endedAt ?? Date.now();
+  const phase = params.terminalOutcome.status === "ok" ? "end" : "error";
+  await (params.persist ?? persistGatewaySessionLifecycleEvent)({
+    sessionKey: params.sessionKey,
+    ...(params.agentId ? { agentId: params.agentId } : {}),
+    event: {
+      runId: params.runId,
+      sessionId: params.sessionId,
+      ts: endedAt,
+      data: {
+        phase,
+        endedAt,
+        ...(phase === "error" && params.terminalOutcome.error
+          ? { error: params.terminalOutcome.error }
+          : {}),
+        ...(params.terminalOutcome.stopReason
+          ? { stopReason: params.terminalOutcome.stopReason }
+          : {}),
+        ...(params.terminalOutcome.livenessState
+          ? { livenessState: params.terminalOutcome.livenessState }
+          : {}),
+        ...(params.terminalOutcome.timeoutPhase
+          ? { timeoutPhase: params.terminalOutcome.timeoutPhase }
+          : {}),
+      },
+    },
+  });
+}
 
 function resolveResolvedAgentTimeoutStopReason(
   meta: unknown,
@@ -189,6 +233,25 @@ export function dispatchAgentRunFromGateway(params: {
         timeoutPhase,
         providerStarted: result?.meta?.providerStarted,
       });
+      const resultAgentMeta = result?.meta?.agentMeta as { sessionId?: unknown } | null | undefined;
+      const terminalSessionId =
+        typeof resultAgentMeta?.sessionId === "string"
+          ? resultAgentMeta.sessionId
+          : params.ingressOpts.sessionId;
+      try {
+        await persistNonDeliveredAgentRunTerminalSession({
+          agentId: params.ingressOpts.agentId,
+          deliver: params.ingressOpts.deliver,
+          runId: params.runId,
+          sessionId: terminalSessionId,
+          sessionKey: params.ingressOpts.sessionKey,
+          terminalOutcome,
+        });
+      } catch (error) {
+        params.context.logGateway.warn(
+          `failed to persist non-delivered agent session terminal state ${params.runId}: ${formatForLog(error)}`,
+        );
+      }
       const responseStatus =
         RESOLVED_GATEWAY_STATUS_BY_TERMINAL_CLASSIFICATION[
           classifyAgentRunTerminalOutcome(terminalOutcome)


### PR DESCRIPTION
Closes #119714
Closes #119715

## What Problem This Solves

Fixes issues where users running an agent turn through the Gateway could see a completed session remain active indefinitely, and where one provider idle timeout could generate two delivered error alerts.

## Why This Change Was Made

Gateway-owned agent RPC completion now projects its terminal outcome into the exact owned session after the command (including delivery) settles. Pending-final and restart-recovery cleanup also terminalize every completed reply state, while still preserving admitted/pending and unresolved delivery states. Prompt-timeout finalization replaces an earlier generic error payload with the single actionable timeout payload while retaining non-error media.

## User Impact

Completed or timed-out Gateway agent runs now expose a terminal status, end time, and runtime instead of appearing active after completion or restart. A provider idle timeout produces one final user-facing alert rather than two.

## Evidence

- Current upstream `main`: 5 focused test files, 43 tests passed.
- Current upstream affected runtime bundle built successfully with `OPENCLAW_RUN_NODE_SKIP_DTS_BUILD=1`.
- Raspberry Pi production: 7 focused files, 45 tests passed.
- Live non-delivered production turn: `done`, `endedAt`, `runtimeMs`, zero pending delivery.
- Live Telegram/Notion production closeout: real Kanban mutation and readback, 30.7 s agent duration, zero tool failures, session `done`, exactly one Telegram `sendMessage`.
- Failure-path reproduction before the coalescing fix recorded two Telegram message IDs for one idle timeout; regression coverage now requires one final timeout error payload.