### PR TITLE
fix: keep completed actions visible after settled finalization

### DIFF
--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -1247,7 +1247,11 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         ] as unknown as EmbeddedRunAttemptResult["messagesSnapshot"],
         lastAssistant: toolUseAssistant,
         currentAttemptAssistant: toolUseAssistant,
-        lastToolError: { toolName: "exec", error: "post-processing error" },
+        lastToolError: {
+          toolName: "exec",
+          error: "post-processing error",
+          errorCode: "SYSTEM_RUN_DENIED",
+        },
       });
     });
     const finalAssistant = {
@@ -1285,6 +1289,18 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(finalizationCall.prompt).toContain(SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION);
     expect(finalizationCall.prompt).toContain(
       "If any tool failed, state that failure plainly and do not claim it succeeded.",
+    );
+    expect(result.meta.failureSignal).toEqual(
+      runPolicy.trigger === "cron"
+        ? {
+            kind: "execution_denied",
+            source: "tool",
+            toolName: "exec",
+            code: "SYSTEM_RUN_DENIED",
+            message: "post-processing error",
+            fatalForCron: true,
+          }
+        : undefined,
     );
   });
 

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -1088,27 +1088,56 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   });
 
   it("continues once after settled side-effecting tools finish without a final answer", async () => {
+    const acceptedSessionSpawns = [
+      { runId: "child-run", childSessionKey: "agent:main:subagent:child" },
+    ];
     const toolUseAssistant = {
       role: "assistant",
       stopReason: "toolUse",
       provider: "openai",
       model: "gpt-5.5",
-      content: [{ type: "toolCall", id: "tool_1", name: "write", arguments: { path: "note.txt" } }],
+      content: [
+        { type: "toolCall", id: "tool_write", name: "write", arguments: { path: "note.txt" } },
+        { type: "toolCall", id: "tool_cron", name: "cron", arguments: { action: "add" } },
+        {
+          type: "toolCall",
+          id: "tool_spawn",
+          name: "sessions_spawn",
+          arguments: { task: "follow up" },
+        },
+      ],
     } as unknown as NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
     const settledToolResults = [
       toolUseAssistant,
-      { role: "toolResult", toolCallId: "tool_1", toolName: "write", isError: false },
+      { role: "toolResult", toolCallId: "tool_write", toolName: "write", isError: false },
+      { role: "toolResult", toolCallId: "tool_cron", toolName: "cron", isError: false },
+      {
+        role: "toolResult",
+        toolCallId: "tool_spawn",
+        toolName: "sessions_spawn",
+        isError: false,
+      },
     ] as unknown as EmbeddedRunAttemptResult["messagesSnapshot"];
     mockedClassifyFailoverReason.mockReturnValue(null);
     mockedRunEmbeddedAttempt.mockImplementationOnce(async (attemptParams) => {
       markUserMessagePersisted(attemptParams);
       return makeAttemptResult({
         assistantTexts: [],
-        toolMetas: [{ toolName: "write", meta: "path=note.txt" }],
-        itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
+        latestMcpAppChannelView: { viewId: "view-after-tools" },
+        toolMetas: [
+          { toolName: "write", meta: "path=note.txt" },
+          { toolName: "cron" },
+          { toolName: "sessions_spawn" },
+        ],
+        acceptedSessionSpawns,
+        successfulCronAdds: 1,
+        itemLifecycle: { startedCount: 3, completedCount: 3, activeCount: 0 },
         messagesSnapshot: settledToolResults,
         lastAssistant: toolUseAssistant,
         currentAttemptAssistant: toolUseAssistant,
+        codeModeEngaged: true,
+        assistantTurns: 1,
+        bridgeCalls: { search: 1, describe: 2, call: 3 },
       });
     });
     const finalAssistant = {
@@ -1139,6 +1168,19 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(result.payloads?.[0]?.text).toBe("Write completed. Here is the final answer.");
+    expect(result.latestMcpAppChannelView).toEqual({ viewId: "view-after-tools" });
+    expect(result.successfulCronAdds).toBe(1);
+    expect(result.acceptedSessionSpawns).toEqual(acceptedSessionSpawns);
+    expect(result.meta.toolSummary).toEqual({
+      calls: 3,
+      tools: ["write", "cron", "sessions_spawn"],
+      failures: 0,
+    });
+    expect(result.meta.agentMeta).toMatchObject({
+      codeModeEngaged: true,
+      assistantTurns: 2,
+      bridgeCalls: { search: 1, describe: 2, call: 3 },
+    });
     const secondCall = runAttemptCall(1);
     expect(secondCall.prompt).toBe(SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION);
     expect(secondCall.disableTools).toBe(true);

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
@@ -91,6 +91,7 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
       finalizationSucceeded: false,
     };
   }
+  const settledFailureSignal = prepared.failureSignal;
 
   const runParams = input.terminalBase.runParams;
   const errorContext = input.terminalBase.activeErrorContext;
@@ -117,7 +118,7 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
       }),
       signalOwnedInterruption: false,
     };
-    prepared = prepareEmbeddedRunTerminal({
+    const finalizedPrepared = prepareEmbeddedRunTerminal({
       ...input.terminalBase,
       attempt,
       currentAttemptCompletedAssistant: attempt.currentAttemptCompletedAssistant,
@@ -126,6 +127,8 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
       lastRunPromptUsage,
       terminalState,
     });
+    // A failure-honest final answer cannot turn a settled cron denial into success.
+    prepared = { ...finalizedPrepared, failureSignal: settledFailureSignal };
     return {
       attempt,
       attemptAssistant: attempt.currentAttemptAssistant,

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
@@ -16,7 +16,10 @@ import {
   type EmbeddedRunTerminalState,
 } from "./terminal-outcome.js";
 import { prepareEmbeddedRunTerminal } from "./terminal-preparation.js";
-import { resolveSettledTurnFinalizationRequest } from "./terminal-resolution.js";
+import {
+  copyAttemptDeliveryState,
+  resolveSettledTurnFinalizationRequest,
+} from "./terminal-resolution.js";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
 
 type TerminalPreparationInput = Parameters<typeof prepareEmbeddedRunTerminal>[0];
@@ -188,8 +191,8 @@ function buildSettledTurnFinalizationAttemptResult(input: {
 }): EmbeddedRunAttemptResult {
   const { result, settledAttempt } = input;
   const text = resolveSettledTurnFinalizationText(result);
-  // Finalization bypasses ordinary attempt normalization. Rebuild only the
-  // terminal projection so settled side effects and retry state cannot leak in.
+  // Finalization replaces terminal ownership, not facts from already-settled tools.
+  // Keep those facts while replay, abort, and lifecycle state remain finalizer-local.
   return {
     terminal: { kind: "ok" },
     sessionIdUsed: settledAttempt.sessionIdUsed,
@@ -199,6 +202,7 @@ function buildSettledTurnFinalizationAttemptResult(input: {
     runtimeArtifact: settledAttempt.runtimeArtifact,
     systemPromptReport: settledAttempt.systemPromptReport,
     finalPromptText: input.prompt,
+    ...copyAttemptDeliveryState(settledAttempt),
     messagesSnapshot: [...settledAttempt.messagesSnapshot, result.assistant],
     assistantTexts: [text],
     assistantTranscriptOwned: result.assistantTranscriptOwned,
@@ -207,19 +211,12 @@ function buildSettledTurnFinalizationAttemptResult(input: {
     lastAssistant: result.assistant,
     currentAttemptAssistant: result.assistant,
     currentAttemptCompletedAssistant: result.assistant,
-    toolMetas: [],
-    acceptedSessionSpawns: [],
-    didSendViaMessagingTool: false,
-    didDeliverSourceReplyViaMessageTool: false,
-    didSendDeterministicApprovalPrompt: false,
-    messagingToolSentTexts: [],
-    messagingToolSentMediaUrls: [],
-    messagingToolSentTargets: [],
-    messagingToolSourceReplyPayloads: [],
+    toolMetas: settledAttempt.toolMetas,
     hasToolMediaBlockReply: false,
-    successfulCronAdds: 0,
     cloudCodeAssistFormatError: false,
     attemptUsage: result.usage,
+    codeModeEngaged: settledAttempt.codeModeEngaged,
+    assistantTurns: 1,
     replayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
     currentAttemptReplayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
     itemLifecycle: { startedCount: 0, completedCount: 0, activeCount: 0 },


### PR DESCRIPTION
Closes #119725

## What Problem This Solves

Fixes an issue where users whose agent completed tools and then needed isolated settled-turn finalization would receive a successful final answer whose run result no longer reported the actions that had already completed. Automation counts, accepted child sessions, MCP App views, tool summaries, code-mode engagement, and the original assistant turn could disappear at that boundary.

## Why This Change Was Made

The isolated finalizer correctly owns a fresh terminal state so it cannot replay tools or inherit abort/retry state, but it also rebuilt every settled fact as empty. This change reuses the existing delivery-state projection and carries the settled tool metadata into the synthetic terminal attempt while leaving replay, abort, lifecycle, pending work, and tool capability finalizer-local. The finalizer contributes one assistant turn and preserves whether code mode owned the settled attempt.

This is the narrow owner-boundary repair. It does not add a retry-wide accumulator, change error exits, alter config/defaults, or weaken the tool-free finalizer contract.

## User Impact

Completed automation, spawn, MCP App, tool, and run-stat facts remain visible after OpenClaw generates the missing final answer. Downstream status, continuation, accounting, and UI consumers receive a truthful result envelope instead of a finalizer-only projection.

## Evidence

- Pre-fix reproduction: Blacksmith Testbox `tbx_01kz9q718v732mhyq6n03np76x`, [run 31040720539](https://github.com/openclaw/openclaw/actions/runs/31040720539). The new boundary assertion failed because the settled MCP App view became `undefined`.
- Post-fix focused boundary: `pnpm test src/agents/embedded-agent-runner/run.incomplete-turn.test.ts` — 171/171 passing after the test was consolidated into the existing finalization scenario.
- Sibling harness contracts: 299/299 passing across the embedded-runner boundary, finalization-result contract, built-in OpenClaw harness, Codex finalizer, and Copilot harness.
- Hosted changed gate: complete `core, coreTests` lanes green on the initial repair, including core/core-test typechecks, changed-file lint/format, import cycles, SDK/plugin contracts, dead exports, and storage/schema guards. After the review move, all repeated code phases passed before the Testbox SSH endpoint closed without a final exit; exact-head hosted CI below is the authoritative final gate.
- Exact-head built gateway proof: Blacksmith Testbox `tbx_01kz9v5j4e0s1sdtct1ga948d9`, [run 31046121993](https://github.com/openclaw/openclaw/actions/runs/31046121993). `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build` passed, then both `qa-channel-failed-tool-terminal-finalization` and `cron-failed-tool-terminal-finalization` passed through fresh mock providers and ephemeral gateways with one tool-free finalization, no replay, and one visible delivery each.
- Exact-head hosted CI: [run 31045333920](https://github.com/openclaw/openclaw/actions/runs/31045333920) green for `a45c01b92e3f104f271681f898cf1fb3d597ba0b`.
- Exact-head ClawSweeper: [run 31045455016](https://github.com/openclaw/clawsweeper/actions/runs/31045455016) reports no code findings, security cleared, and patch correct. Its rank-up moves were exact-head CI and direct sibling Codex verification; both are satisfied here.
- AutoReview: clean, no accepted/actionable findings, correctness confidence 0.98.
- Production LOC: +14 / -14 (net 0). Tests: +63 / -5. No config/default surface changes.
- Codex upstream contract checked at `fa5d5ae047d1891a2f816c22d9ed926a0728ba47`: [`thread/inject_items` protocol](https://github.com/openai/codex/blob/fa5d5ae047d1891a2f816c22d9ed926a0728ba47/codex-rs/app-server-protocol/src/protocol/v2/thread.rs#L1490-L1494), [app-server validation/injection](https://github.com/openai/codex/blob/fa5d5ae047d1891a2f816c22d9ed926a0728ba47/codex-rs/app-server/src/request_processors/turn_processor.rs#L863-L888), and [core history-only ownership](https://github.com/openai/codex/blob/fa5d5ae047d1891a2f816c22d9ed926a0728ba47/codex-rs/core/src/codex_thread.rs#L516-L539) confirm that settled response items become model-visible history without starting or replaying a user turn.
- Public model identifier audit: PASS. The added test uses the documented [`gpt-5.5`](https://developers.openai.com/api/docs/models/gpt-5.5) ID; no private or inferred model identifiers are present.

Risk is medium because the returned terminal envelope feeds several consumers, but the change is confined to the successful isolated-finalization path and retains all existing fail-closed behavior. All landing gates are now satisfied.

- [x] AI-assisted
- [x] I understand the code and verified the owner boundary
- [x] AutoReview completed with no actionable finding
