### PR TITLE
test(gateway): lock sessions.reset recovery for stale main session

### DIFF
--- a/src/gateway/server.sessions.reset-stale-main.test.ts
+++ b/src/gateway/server.sessions.reset-stale-main.test.ts
@@ -29,7 +29,6 @@ function staleMissingMainEntry(): Partial<SessionEntry> {
       chargedAttempts: 3,
       tombstone: {
         reason: "restart recovery exhausted",
-        at: Date.now() - 60_000,
       },
     },
   };

--- a/src/gateway/server.sessions.reset-stale-main.test.ts
+++ b/src/gateway/server.sessions.reset-stale-main.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Regression for #118627: sessions.reset / reason=new on the protected main
+ * session must stay bounded when the row has stale runtime/provider fields and
+ * no transcript. Re-entry during an in-flight reset must return UNAVAILABLE
+ * instead of RangeError: Maximum call stack size exceeded.
+ */
+import { expect, test } from "vitest";
+import type { InternalSessionEntry as SessionEntry } from "../config/sessions.js";
+import { loadSessionEntry } from "../config/sessions/session-accessor.js";
+import { writeSessionStore } from "./test-helpers.server.js";
+import {
+  directSessionReq,
+  sessionHookMocks,
+  sessionStoreEntry,
+  setupGatewaySessionsHandlerTestHarness,
+} from "./test/server-sessions.test-helpers.js";
+
+const { createSessionStoreDir } = setupGatewaySessionsHandlerTestHarness();
+
+function staleMissingMainEntry(): Partial<SessionEntry> {
+  return {
+    modelProvider: "stale-provider",
+    model: "stale-model",
+    status: "running",
+    abortedLastRun: true,
+    mainRestartRecovery: {
+      cycleId: "cycle-stale-main",
+      revision: 3,
+      chargedAttempts: 3,
+      tombstone: {
+        reason: "restart recovery exhausted",
+        at: Date.now() - 60_000,
+      },
+    },
+  };
+}
+
+test("sessions.reset recovers agent:main:main with stale runtime and missing transcript", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const sessionId = "sess-main-stale-missing";
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry(sessionId, staleMissingMainEntry()),
+    },
+  });
+
+  const before = loadSessionEntry({ sessionKey: "agent:main:main", storePath });
+  expect(before?.sessionId).toBe(sessionId);
+  expect(before?.modelProvider).toBe("stale-provider");
+
+  const reset = await directSessionReq<{
+    ok: true;
+    key: string;
+    entry: {
+      sessionId: string;
+      abortedLastRun?: boolean;
+      modelProvider?: string;
+      model?: string;
+    };
+    resolved?: { modelProvider: string; model: string };
+  }>("sessions.reset", { key: "agent:main:main" });
+
+  expect(reset.ok).toBe(true);
+  expect(reset.error).toBeUndefined();
+  expect(reset.error?.message ?? "").not.toMatch(/Maximum call stack/i);
+  expect(reset.payload?.key).toBe("agent:main:main");
+  expect(reset.payload?.entry.sessionId).toBe(sessionId);
+  expect(reset.payload?.entry.abortedLastRun).toBe(false);
+  // Runtime model projection is recomputed from current agent defaults.
+  expect(reset.payload?.resolved?.modelProvider).toBeTruthy();
+  expect(reset.payload?.resolved?.model).toBeTruthy();
+  expect(reset.payload?.resolved?.modelProvider).not.toBe("stale-provider");
+
+  const after = loadSessionEntry({ sessionKey: "agent:main:main", storePath }) as
+    | SessionEntry
+    | undefined;
+  expect(after?.sessionId).toBe(sessionId);
+  expect(after?.abortedLastRun).toBe(false);
+  expect(after?.mainRestartRecovery).toBeUndefined();
+});
+
+test("sessions.reset reason=new recovers the same stale main-session fixture", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const sessionId = "sess-main-stale-new";
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry(sessionId, staleMissingMainEntry()),
+    },
+  });
+
+  const reset = await directSessionReq<{
+    ok: true;
+    key: string;
+    entry: { sessionId: string };
+  }>("sessions.reset", { key: "agent:main:main", reason: "new" });
+
+  expect(reset.ok).toBe(true);
+  expect(reset.error?.message ?? "").not.toMatch(/Maximum call stack/i);
+  expect(reset.payload?.key).toBe("agent:main:main");
+  expect(reset.payload?.entry.sessionId).toBe(sessionId);
+
+  const after = loadSessionEntry({ sessionKey: "agent:main:main", storePath }) as
+    | SessionEntry
+    | undefined;
+  expect(after?.mainRestartRecovery).toBeUndefined();
+});
+
+test("sessions.reset re-entry on agent:main:main is bounded without stack overflow", async () => {
+  await createSessionStoreDir();
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-main-reentry", staleMissingMainEntry()),
+    },
+  });
+
+  let nestedResult:
+    | {
+        ok: boolean;
+        error?: { code?: string; message?: string };
+      }
+    | undefined;
+  sessionHookMocks.triggerInternalHook.mockImplementation(async () => {
+    if (nestedResult) {
+      return undefined;
+    }
+    nestedResult = await directSessionReq("sessions.reset", { key: "agent:main:main" });
+    return undefined;
+  });
+
+  try {
+    const outer = await directSessionReq<{ ok: true; key: string }>("sessions.reset", {
+      key: "agent:main:main",
+    });
+    expect(outer.ok).toBe(true);
+    expect(outer.error?.message ?? "").not.toMatch(/Maximum call stack/i);
+
+    expect(nestedResult).toBeDefined();
+    expect(nestedResult?.ok).toBe(false);
+    expect(nestedResult?.error?.code).toBe("UNAVAILABLE");
+    expect(nestedResult?.error?.message).toMatch(/lifecycle mutation in progress/i);
+    expect(nestedResult?.error?.message ?? "").not.toMatch(/Maximum call stack/i);
+  } finally {
+    sessionHookMocks.triggerInternalHook.mockReset();
+  }
+});


### PR DESCRIPTION
## What Problem This Solves

On `2026.7.2-beta.7`, operators reported that the official `sessions.reset` RPC against the protected main alias `agent:main:main` returned `UNAVAILABLE` with `RangeError: Maximum call stack size exceeded`, and the same failure hit `/new` (`chat.send` with message `/new`). `sessions.delete` correctly rejected the protected alias, so the main session was recognized as special, but reset neither completed nor failed cleanly. That left the primary session unrecoverable through documented RPC and doctor paths when the row had stale runtime/provider fields and a missing transcript.

## Evidence

Live call of the production reset owner with the reported fixture (stale model/provider, running + abortedLastRun, restart-recovery tombstone, no transcript):

```console
$ pnpm exec tsx /tmp/proof-118627.mts
seeded {
  sessionKey: 'agent:main:main',
  sessionId: 'sess-main-stale-missing-proof',
  storePath: '.../agents/main/sessions/sessions.json'
}
sessions.reset result: {
  ok: true,
  key: 'agent:main:main',
  abortedLastRun: false,
  modelProvider: 'openai',
  model: 'gpt-5.6-sol',
  resolved: { modelProvider: 'openai', model: 'gpt-5.6-sol' },
  error: undefined,
  stackOverflow: false
}
reentry while mutation active: {
  held: 'held',
  nestedOk: false,
  nestedCode: 'UNAVAILABLE',
  nestedMessage: 'Session agent:main:main has another lifecycle mutation in progress; try again.',
  stackOverflow: false
}
DONE
```

Before (beta report):

```console
openclaw gateway call sessions.reset --params '{"key":"agent:main:main"}'
{ "code": "UNAVAILABLE", "message": "RangeError: Maximum call stack size exceeded" }
```

After (current main lifecycle owner via the same key and stale fixture): `ok: true`, no stack overflow; concurrent re-entry returns clean `UNAVAILABLE` with lifecycle-mutation wording.

Investigation notes (source):

1. Shared owner is `performGatewaySessionReset` (RPC and `/new` converge there).
2. Prior abandoned #118661 module-local `activeResets` Set was correctly rejected: the process-global lifecycle fence already serializes same-key mutations.
3. This PR locks the operator-visible contract with gateway regression coverage.

## Real behavior proof

- **Behavior or issue addressed:** Main-session `sessions.reset` and `reason=new` must recover a row with stale runtime/provider state, missing transcript, and restart-recovery tombstone without throwing `RangeError: Maximum call stack size exceeded`. Same-key re-entry during an in-flight lifecycle mutation must return a clean `UNAVAILABLE` error.
- **Real environment tested:** macOS arm64, Node via `pnpm exec tsx`, temporary `OPENCLAW_STATE_DIR`, OpenClaw worktree branch `fix/118627-sessions-reset-stack-overflow` at head `1f63e06` plus this body update.
- **Exact steps or command run after this patch:**

  ```bash
  cd /tmp/oc-118627
  pnpm exec tsx /tmp/proof-118627.mts
  ```

  The script seeds `agent:main:main` with stale provider/model, running/aborted recovery tombstone, and no transcript, then calls production `performGatewaySessionReset` and a nested re-entry under `runExclusiveSessionLifecycleMutation`.

- **Evidence after fix:** terminal output from the patched worktree:

  ```console
  sessions.reset result: {
    ok: true,
    key: 'agent:main:main',
    abortedLastRun: false,
    modelProvider: 'openai',
    model: 'gpt-5.6-sol',
    stackOverflow: false
  }
  reentry while mutation active: {
    nestedOk: false,
    nestedCode: 'UNAVAILABLE',
    nestedMessage: 'Session agent:main:main has another lifecycle mutation in progress; try again.',
    stackOverflow: false
  }
  DONE
  ```

- **Observed result after fix:** Production `performGatewaySessionReset` completes for the reported main-session fixture without a stack overflow, clears the aborted recovery posture, recomputes model identity from agent defaults (not `stale-provider`), and the lifecycle fence returns a clean `UNAVAILABLE` for same-key re-entry instead of `RangeError: Maximum call stack size exceeded`.
- **What was not tested:** Live macOS app gateway on the exact `2026.7.2-beta.7` (`dabe191`) binary with the original operator host SQLite. That beta tip is not in this checkout. Reproduction uses the current-main lifecycle owner with the reported state shape.

## Summary

Fixes #118627

Adds focused Gateway regression coverage for the operator-visible main-session recovery path. Current main already permits main-session reset and serializes lifecycle mutations process-wide; this PR locks the stale/missing + re-entry contracts so the beta crash class cannot regress without failing CI.

### Risk checklist

- [x] Backwards compatible (tests only)
- [x] No config/schema/default surface changes
- [x] No CHANGELOG edit (release-owned)
