### PR TITLE
improve(gateway): defer inactive plugin runtime imports

### DIFF
--- a/extensions/acpx/lazy-import.test.ts
+++ b/extensions/acpx/lazy-import.test.ts
@@ -1,0 +1,62 @@
+import type {
+  OpenClawPluginNodeHostCommand,
+  OpenClawPluginNodeInvokePolicy,
+} from "openclaw/plugin-sdk/plugin-entry";
+import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
+import type { SessionCatalogProvider } from "openclaw/plugin-sdk/session-catalog";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("acpx Pi session catalog lazy imports", () => {
+  afterEach(() => {
+    vi.doUnmock("./src/pi-session-catalog-runtime.js");
+    vi.resetModules();
+  });
+
+  it("loads catalog and node handlers only on first use", async () => {
+    let runtimeImports = 0;
+    vi.doMock("./src/pi-session-catalog-runtime.js", () => {
+      runtimeImports += 1;
+      return {
+        createPiSessionCatalogRuntime: () => ({
+          list: async () => [],
+          read: async () => ({ hostId: "gateway", threadId: "", items: [] }),
+          continueSession: async () => ({ sessionKey: "agent:main:test" }),
+          checkUpstreamActivity: async () => [],
+          openTerminal: async () => ({ kind: "local", argv: ["pi"] }),
+        }),
+        listPiSessions: async () => "[]",
+        readPiSession: async () => "{}",
+        resumePiSession: async () => "{}",
+      };
+    });
+
+    const { default: acpxPlugin } = await import("./index.js");
+    const catalogs: SessionCatalogProvider[] = [];
+    const nodeCommands: OpenClawPluginNodeHostCommand[] = [];
+    const nodePolicies: OpenClawPluginNodeInvokePolicy[] = [];
+    acpxPlugin.register(
+      createTestPluginApi({
+        id: "acpx",
+        name: "ACPX",
+        source: "test",
+        config: {},
+        runtime: createPluginRuntimeMock(),
+        registerSessionCatalog: (provider) => catalogs.push(provider),
+        registerNodeHostCommand: (command) => nodeCommands.push(command),
+        registerNodeInvokePolicy: (policy) => nodePolicies.push(policy),
+      }),
+    );
+
+    expect(runtimeImports).toBe(0);
+    expect(catalogs).toHaveLength(1);
+    expect(nodeCommands).toHaveLength(3);
+    expect(nodePolicies).toHaveLength(1);
+
+    await expect(catalogs[0]?.list({})).resolves.toEqual([]);
+    await expect(catalogs[0]?.list({})).resolves.toEqual([]);
+    await expect(nodeCommands[0]?.handle()).resolves.toBe("[]");
+    await expect(nodeCommands[0]?.handle()).resolves.toBe("[]");
+    expect(runtimeImports).toBe(1);
+  });
+});

--- a/extensions/acpx/src/pi-session-catalog-plugin.ts
+++ b/extensions/acpx/src/pi-session-catalog-plugin.ts
@@ -1,131 +1,26 @@
-import process from "node:process";
-import { resolveAcpSessionAvailability } from "openclaw/plugin-sdk/acp-runtime";
-import { resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
-  decodeNodePtyResumeParams,
-  resolveNodeHostExecutable,
-  runNodePtyCommand,
-} from "openclaw/plugin-sdk/node-host";
+  createLazyRuntimeModule,
+  createLazyRuntimeSurface,
+} from "openclaw/plugin-sdk/lazy-runtime";
+import { resolveNodeHostExecutable } from "openclaw/plugin-sdk/node-host";
 import type {
   OpenClawPluginApi,
   OpenClawPluginNodeHostCommand,
   OpenClawPluginNodeInvokePolicy,
 } from "openclaw/plugin-sdk/plugin-entry";
-import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
-import type {
-  SessionCatalogHost,
-  SessionCatalogProvider,
-  SessionCatalogSession,
-  SessionCatalogTerminalPlan,
-  SessionCatalogTranscriptItem,
-  SessionsCatalogReadResult,
-} from "openclaw/plugin-sdk/session-catalog";
-import {
-  createSessionCatalogAdoptionCoordinator,
-  importSessionCatalogHistory,
-  listAdoptedSessionCatalogSessions,
-  sessionCatalogAdoptedSessionKey,
-  sessionCatalogAdoptedSourceKey,
-} from "openclaw/plugin-sdk/session-catalog";
+import type { SessionCatalogProvider } from "openclaw/plugin-sdk/session-catalog";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
-  isExactPiSessionCursor,
-  listLocalPiSessionPage,
-  readLocalPiTranscriptPage,
-  type PiSessionPage,
-} from "./pi-session-catalog.js";
+  PI_SESSIONS_LIST_COMMAND,
+  PI_SESSION_READ_COMMAND,
+  PI_TERMINAL_RESUME_COMMAND,
+} from "./pi-session-catalog-shared.js";
 import { piSessionStoreAvailable } from "./pi-session-paths.js";
-import { checkPiUpstreamActivity, linkContinuedPiSession } from "./pi-session-upstream-activity.js";
 
-const PI_SESSIONS_LIST_COMMAND = "acpx.pi.sessions.list.v1";
-const PI_SESSION_READ_COMMAND = "acpx.pi.sessions.read.v1";
-const PI_TERMINAL_RESUME_COMMAND = "acpx.pi.terminal.resume.v1";
-
-const CAPABILITY = "pi-sessions";
-const LOCAL_HOST_ID = "gateway";
-const MAX_PAGE_LIMIT = 100;
-const MAX_HOSTS = 100;
-const NODE_TIMEOUT_MS = 20_000;
-const SESSION_ID_PATTERN = /^(?!-)[A-Za-z0-9._:-]{1,256}$/u;
-const TRANSCRIPT_ITEM_TYPES = new Set([
-  "userMessage",
-  "agentMessage",
-  "reasoning",
-  "toolCall",
-  "toolResult",
-  "other",
-]);
-const ACPX_BACKEND_ID = "acpx";
-const PI_ACP_AGENT_ID = "pi";
-const PI_ADOPTED_SESSION_KEY_PREFIX = "plugin:acpx:catalog-adopt:pi:";
-
-class PiCatalogParamsError extends Error {}
-
-const continueAdoption =
-  createSessionCatalogAdoptionCoordinator<Awaited<ReturnType<typeof linkContinuedPiSession>>>();
-
-function validatePiThreadId(value: unknown): string {
-  if (typeof value !== "string" || !SESSION_ID_PATTERN.test(value)) {
-    throw new Error("INVALID_REQUEST: threadId is invalid");
-  }
-  return value;
-}
-
-function isOptionalString(value: unknown): boolean {
-  return value === undefined || typeof value === "string";
-}
-
-function isOptionalNumber(value: unknown): boolean {
-  return value === undefined || typeof value === "number";
-}
-
-function isNodeSession(value: unknown): value is SessionCatalogSession {
-  return (
-    isRecord(value) &&
-    typeof value.threadId === "string" &&
-    SESSION_ID_PATTERN.test(value.threadId) &&
-    typeof value.status === "string" &&
-    value.status.length > 0 &&
-    typeof value.archived === "boolean" &&
-    typeof value.canContinue === "boolean" &&
-    typeof value.canArchive === "boolean" &&
-    isOptionalString(value.name) &&
-    isOptionalString(value.cwd) &&
-    isOptionalString(value.source) &&
-    isOptionalString(value.modelProvider) &&
-    isOptionalString(value.cliVersion) &&
-    isOptionalString(value.gitBranch) &&
-    isOptionalString(value.sessionKey) &&
-    isOptionalNumber(value.createdAt) &&
-    isOptionalNumber(value.updatedAt) &&
-    isOptionalNumber(value.recencyAt)
-  );
-}
-
-function isNodeTranscriptItem(value: unknown): value is SessionCatalogTranscriptItem {
-  return (
-    isRecord(value) &&
-    typeof value.type === "string" &&
-    TRANSCRIPT_ITEM_TYPES.has(value.type) &&
-    isOptionalString(value.id) &&
-    isOptionalString(value.text) &&
-    isOptionalString(value.timestamp) &&
-    isOptionalString(value.model) &&
-    (value.truncated === undefined || typeof value.truncated === "boolean")
-  );
-}
-
-function parseNodeParams(paramsJSON?: string | null): unknown {
-  if (!paramsJSON) {
-    return undefined;
-  }
-  try {
-    return JSON.parse(paramsJSON) as unknown;
-  } catch (error) {
-    throw new Error("Pi session parameters must be valid JSON", { cause: error });
-  }
-}
+const PI_SESSIONS_CAPABILITY = "pi-sessions";
+const loadPiSessionCatalogModule = createLazyRuntimeModule(
+  () => import("./pi-session-catalog-runtime.js"),
+);
 
 function fullConfigCatalogEnabled(config: unknown): boolean {
   if (!isRecord(config) || !isRecord(config.plugins) || !isRecord(config.plugins.entries)) {
@@ -152,23 +47,23 @@ function createPiSessionNodeHostCommands(): OpenClawPluginNodeHostCommand[] {
   return [
     {
       command: PI_SESSIONS_LIST_COMMAND,
-      cap: CAPABILITY,
+      cap: PI_SESSIONS_CAPABILITY,
       dangerous: false,
       isAvailable: storeAvailable,
       handle: async (paramsJSON) =>
-        JSON.stringify(await listLocalPiSessionPage(parseNodeParams(paramsJSON))),
+        await (await loadPiSessionCatalogModule()).listPiSessions(paramsJSON),
     },
     {
       command: PI_SESSION_READ_COMMAND,
-      cap: CAPABILITY,
+      cap: PI_SESSIONS_CAPABILITY,
       dangerous: false,
       isAvailable: storeAvailable,
       handle: async (paramsJSON) =>
-        JSON.stringify(await readLocalPiTranscriptPage(parseNodeParams(paramsJSON))),
+        await (await loadPiSessionCatalogModule()).readPiSession(paramsJSON),
     },
     {
       command: PI_TERMINAL_RESUME_COMMAND,
-      cap: CAPABILITY,
+      cap: PI_SESSIONS_CAPABILITY,
       dangerous: false,
       duplex: true,
       isAvailable: ({ config, env }) =>
@@ -180,33 +75,8 @@ function createPiSessionNodeHostCommands(): OpenClawPluginNodeHostCommand[] {
             strategy: "direct",
           }),
         ),
-      handle: async (paramsJSON, io) => {
-        if (!io) {
-          throw new Error("Pi terminal command requires duplex transport");
-        }
-        const params = decodeNodePtyResumeParams(paramsJSON, validatePiThreadId);
-        const record = await requireLocalPiSession(params.threadId);
-        const resolution = resolveNodeHostExecutable("pi", {
-          env: process.env,
-          pathEnv: process.env.PATH ?? process.env.Path ?? "",
-          strategy: "direct",
-        });
-        if (!resolution) {
-          throw new Error("Pi CLI is unavailable");
-        }
-        return JSON.stringify(
-          await runNodePtyCommand(
-            {
-              file: resolution.executable,
-              args: ["--session", params.threadId],
-              cwd: record.cwd,
-              cols: params.cols,
-              rows: params.rows,
-            },
-            io,
-          ),
-        );
-      },
+      handle: async (paramsJSON, io) =>
+        await (await loadPiSessionCatalogModule()).resumePiSession(paramsJSON, io),
     },
   ];
 }
@@ -222,440 +92,24 @@ function createPiSessionNodeInvokePolicies(): OpenClawPluginNodeInvokePolicy[] {
   ];
 }
 
-function nodeLabel(node: { displayName?: string; remoteIp?: string; nodeId: string }): string {
-  return node.displayName?.trim() || node.remoteIp?.trim() || node.nodeId;
-}
-
-function unwrapNodePayload(value: unknown): unknown {
-  return isRecord(value) && typeof value.payloadJSON === "string"
-    ? (JSON.parse(value.payloadJSON) as unknown)
-    : value;
-}
-
-type CatalogNode = Awaited<ReturnType<PluginRuntime["nodes"]["list"]>>["nodes"][number];
-
-function setCatalogCapabilities(
-  page: PiSessionPage,
-  capabilities: { canContinue: boolean; canOpenTerminal: boolean },
-): PiSessionPage {
-  for (const session of page.sessions) {
-    session.canContinue = capabilities.canContinue && session.canContinue;
-    session.canOpenTerminal = capabilities.canOpenTerminal;
-  }
-  return page;
-}
-
-async function listPiNodeHost(
-  runtime: PluginRuntime,
-  query: Parameters<SessionCatalogProvider["list"]>[0],
-  node: CatalogNode,
-): Promise<SessionCatalogHost> {
-  const hostId = `node:${node.nodeId}`;
-  const common = {
-    hostId,
-    label: nodeLabel(node),
-    kind: "node" as const,
-    connected: node.connected === true,
-    nodeId: node.nodeId,
-  };
-  if (node.connected !== true) {
-    return {
-      ...common,
-      sessions: [],
-      error: { code: "NODE_OFFLINE", message: "Paired node is offline" },
-    };
-  }
-  try {
-    const cursor = query.cursors?.[hostId];
-    if (cursor !== undefined && !isExactPiSessionCursor(cursor)) {
-      throw new Error("cursor is invalid");
-    }
-    const raw = await runtime.nodes.invoke({
-      nodeId: node.nodeId,
-      command: PI_SESSIONS_LIST_COMMAND,
-      params: {
-        ...(query.limitPerHost ? { limit: query.limitPerHost } : {}),
-        ...(query.search ? { searchTerm: query.search } : {}),
-        ...(cursor !== undefined ? { cursor } : {}),
-      },
-      timeoutMs: NODE_TIMEOUT_MS,
-      scopes: ["operator.write"],
-    });
-    const page = parseNodeSessionPage(unwrapNodePayload(raw));
-    const commands = node.invocableCommands ?? node.commands;
-    const canOpenTerminal = commands?.includes(PI_TERMINAL_RESUME_COMMAND) === true;
-    return {
-      ...common,
-      ...setCatalogCapabilities(page, { canContinue: false, canOpenTerminal }),
-    };
-  } catch {
-    return {
-      ...common,
-      sessions: [],
-      error: { code: "NODE_INVOKE_FAILED", message: "Paired node Pi sessions are unavailable" },
-    };
-  }
-}
-
-function parseNodeSessionPage(value: unknown): PiSessionPage {
-  if (
-    !isRecord(value) ||
-    !Array.isArray(value.sessions) ||
-    value.sessions.length > MAX_PAGE_LIMIT
-  ) {
-    throw new Error("Pi node returned an invalid session page");
-  }
-  if (!value.sessions.every(isNodeSession)) {
-    throw new Error("Pi node returned an invalid session page");
-  }
-  const sessions = value.sessions;
-  const nextCursor = value.nextCursor;
-  if (nextCursor !== undefined && !isExactPiSessionCursor(nextCursor)) {
-    throw new Error("Pi node returned an invalid cursor");
-  }
-  return { sessions, ...(nextCursor !== undefined ? { nextCursor } : {}) };
-}
-
-function parseNodeTranscriptPage(value: unknown, threadId: string): SessionsCatalogReadResult {
-  if (
-    !isRecord(value) ||
-    value.threadId !== threadId ||
-    !Array.isArray(value.items) ||
-    value.items.length > MAX_PAGE_LIMIT ||
-    !value.items.every(isNodeTranscriptItem)
-  ) {
-    throw new Error("Pi node returned an invalid transcript page");
-  }
-  const nextCursor = value.nextCursor;
-  if (nextCursor !== undefined && !isExactPiSessionCursor(nextCursor)) {
-    throw new Error("Pi node returned an invalid cursor");
-  }
-  return {
-    hostId: LOCAL_HOST_ID,
-    threadId,
-    items: value.items,
-    ...(nextCursor !== undefined ? { nextCursor } : {}),
-  };
-}
-
-async function listPiHosts(
-  api: OpenClawPluginApi,
-  query: Parameters<SessionCatalogProvider["list"]>[0],
-): Promise<SessionCatalogHost[]> {
-  const runtime = api.runtime;
-  const canContinue = resolvePiContinuationAvailability(api).available;
-  const requested = query.hostIds ? new Set(query.hostIds) : undefined;
-  const hosts: SessionCatalogHost[] = [];
-  if ((!requested || requested.has(LOCAL_HOST_ID)) && piSessionStoreAvailable(process.env)) {
-    try {
-      hosts.push({
-        hostId: LOCAL_HOST_ID,
-        label: "Local Pi",
-        kind: "gateway",
-        connected: true,
-        ...(await listLocalPiSessionPage({
-          limit: query.limitPerHost,
-          ...(query.search ? { searchTerm: query.search } : {}),
-          cursor: query.cursors?.[LOCAL_HOST_ID],
-        }).then((page) =>
-          setCatalogCapabilities(page, {
-            canContinue,
-            canOpenTerminal:
-              resolveNodeHostExecutable("pi", {
-                env: process.env,
-                pathEnv: process.env.PATH ?? "",
-                strategy: "fallback",
-              }) !== undefined,
-          }),
-        )),
-      });
-    } catch {
-      hosts.push({
-        hostId: LOCAL_HOST_ID,
-        label: "Local Pi",
-        kind: "gateway",
-        connected: true,
-        sessions: [],
-        error: { code: "LOCAL_READ_FAILED", message: "Local Pi sessions are unavailable" },
-      });
-    }
-  }
-  let nodes: Awaited<ReturnType<PluginRuntime["nodes"]["list"]>>["nodes"];
-  try {
-    nodes = (await (query.listNodes?.() ?? runtime.nodes.list())).nodes;
-  } catch {
-    return hosts;
-  }
-  const eligible = nodes
-    .filter(
-      (node) =>
-        node.commands?.includes(PI_SESSIONS_LIST_COMMAND) &&
-        (!requested || requested.has(`node:${node.nodeId}`)),
-    )
-    .toSorted((left, right) => nodeLabel(left).localeCompare(nodeLabel(right)))
-    .slice(0, MAX_HOSTS - hosts.length);
-  const nodeHosts = await Promise.all(eligible.map((node) => listPiNodeHost(runtime, query, node)));
-  return [...hosts, ...nodeHosts];
-}
-
-async function requireLocalPiSession(threadId: string): Promise<SessionCatalogSession> {
-  const page = await listLocalPiSessionPage({ searchTerm: threadId, limit: MAX_PAGE_LIMIT });
-  const record = page.sessions.find((session) => session.threadId === threadId);
-  if (!record) {
-    throw new Error("Pi session is unavailable");
-  }
-  return record;
-}
-
-function currentPiCatalogConfig(api: OpenClawPluginApi): OpenClawConfig {
-  return (api.runtime.config?.current?.() ?? api.config ?? {}) as OpenClawConfig;
-}
-
-function resolvePiContinuationAvailability(
-  api: OpenClawPluginApi,
-): { available: true } | { available: false; message: string } {
-  const availability = resolveAcpSessionAvailability({
-    config: currentPiCatalogConfig(api),
-    backendId: ACPX_BACKEND_ID,
-    agentId: PI_ACP_AGENT_ID,
-  });
-  if (!availability.available) {
-    return availability;
-  }
-  const executable = resolveNodeHostExecutable("pi", {
-    env: process.env,
-    pathEnv: process.env.PATH ?? "",
-    strategy: "fallback",
-  });
-  return executable ? { available: true } : { available: false, message: "Pi CLI is unavailable" };
-}
-
-function listAdoptedPiSessions(api: OpenClawPluginApi): Map<string, string> {
-  return listAdoptedSessionCatalogSessions({
-    config: currentPiCatalogConfig(api),
-    pluginId: api.id,
-    runtime: api.runtime,
-    sourceFromEntry: (entry) => {
-      const acpx = isRecord(entry.pluginExtensions?.acpx) ? entry.pluginExtensions.acpx : undefined;
-      const marker = acpx && isRecord(acpx.piSessionCatalog) ? acpx.piSessionCatalog : undefined;
-      return marker && typeof marker.sourceThreadId === "string"
-        ? { hostId: LOCAL_HOST_ID, threadId: marker.sourceThreadId }
-        : undefined;
-    },
-  });
-}
-
-async function continuePiSession(
-  api: OpenClawPluginApi,
-  hostId: string,
-  threadId: string,
-): Promise<Awaited<ReturnType<typeof linkContinuedPiSession>>> {
-  if (hostId.startsWith("node:")) {
-    throw new PiCatalogParamsError("paired-node Pi session rows are view-only");
-  }
-  if (hostId !== LOCAL_HOST_ID) {
-    throw new PiCatalogParamsError("Pi session catalog hostId is invalid");
-  }
-  const availability = resolvePiContinuationAvailability(api);
-  if (!availability.available) {
-    throw new PiCatalogParamsError(availability.message);
-  }
-  const sourceKey = sessionCatalogAdoptedSourceKey(hostId, threadId);
-  return await continueAdoption({
-    sourceKey,
-    findExisting: () => listAdoptedPiSessions(api).get(sourceKey),
-    create: async () => {
-      const record = await requireLocalPiSession(threadId).catch(() => undefined);
-      if (!record) {
-        throw new PiCatalogParamsError("Pi session is unavailable");
-      }
-      if (!record.canContinue) {
-        throw new PiCatalogParamsError(
-          "Pi session is outside the session store supported by pi-acp",
-        );
-      }
-      const currentAvailability = resolvePiContinuationAvailability(api);
-      if (!currentAvailability.available) {
-        throw new PiCatalogParamsError(currentAvailability.message);
-      }
-      const config = currentPiCatalogConfig(api);
-      const marker = { sourceThreadId: threadId };
-      const created = await api.runtime.agent.session.createSessionEntry({
-        cfg: config,
-        key: sessionCatalogAdoptedSessionKey(PI_ADOPTED_SESSION_KEY_PREFIX, threadId),
-        agentId: resolveDefaultAgentId(config),
-        recoverMatchingInitialEntry: true,
-        ...(record.name ? { label: record.name } : {}),
-        ...(record.cwd ? { spawnedCwd: record.cwd } : {}),
-        initialEntry: {
-          acpBackendId: ACPX_BACKEND_ID,
-          acpSessionBinding: {
-            acpAgentId: PI_ACP_AGENT_ID,
-            agentSessionId: threadId,
-          },
-          pluginExtensions: { acpx: { piSessionCatalog: marker } },
-        },
-        afterCreate: async (entry) => {
-          await importSessionCatalogHistory({
-            catalogId: "pi",
-            threadId,
-            read: async ({ cursor, limit }) =>
-              await readPiTranscript(api.runtime, {
-                hostId,
-                threadId,
-                limit,
-                ...(cursor ? { cursor } : {}),
-              }),
-            sessionId: entry.sessionId,
-            sessionKey: entry.key,
-            agentId: entry.agentId,
-            ...(record.cwd ? { cwd: record.cwd } : {}),
-            config,
-          });
-          return { pluginExtensions: { acpx: { piSessionCatalog: marker } } };
-        },
-      });
-      return { sessionKey: created.key };
-    },
-    complete: async (continued) => await linkContinuedPiSession(continued.sessionKey, threadId),
-  });
-}
-
-async function resolveNodePiSession(params: {
-  runtime: PluginRuntime;
-  nodeId: string;
-  threadId: string;
-}): Promise<SessionCatalogSession> {
-  const raw = await params.runtime.nodes.invoke({
-    nodeId: params.nodeId,
-    command: PI_SESSIONS_LIST_COMMAND,
-    params: { searchTerm: params.threadId, limit: MAX_PAGE_LIMIT },
-    timeoutMs: NODE_TIMEOUT_MS,
-    scopes: ["operator.write"],
-  });
-  const page = parseNodeSessionPage(unwrapNodePayload(raw));
-  const record = page.sessions.find((session) => session.threadId === params.threadId);
-  if (!record) {
-    throw new Error("Pi session is unavailable");
-  }
-  return record;
-}
-
-async function openPiTerminal(params: {
-  runtime: PluginRuntime;
-  hostId: string;
-  threadId: string;
-}): Promise<SessionCatalogTerminalPlan> {
-  const title = `pi --session ${params.threadId.slice(0, 12)}…`;
-  if (params.hostId === LOCAL_HOST_ID) {
-    const record = await requireLocalPiSession(params.threadId);
-    const resolution = resolveNodeHostExecutable("pi", {
-      env: process.env,
-      pathEnv: process.env.PATH ?? "",
-      strategy: "fallback",
-    });
-    if (!resolution) {
-      throw new Error("Pi CLI is unavailable");
-    }
-    return {
-      kind: "local",
-      argv: [resolution.executable, "--session", params.threadId],
-      ...(record.cwd ? { cwd: record.cwd } : {}),
-      ...(resolution.pathEnv ? { pathEnv: resolution.pathEnv } : {}),
-      title,
-    };
-  }
-  if (!params.hostId.startsWith("node:")) {
-    throw new Error("hostId is invalid");
-  }
-  const nodeId = params.hostId.slice("node:".length);
-  const node = (await params.runtime.nodes.list()).nodes.find((candidate) => {
-    const commands = candidate.invocableCommands ?? candidate.commands;
-    return (
-      candidate.nodeId === nodeId &&
-      candidate.connected === true &&
-      commands?.includes(PI_SESSIONS_LIST_COMMAND) === true &&
-      commands.includes(PI_TERMINAL_RESUME_COMMAND)
-    );
-  });
-  if (!node) {
-    throw new Error("paired-node Pi terminal is unavailable");
-  }
-  const record = await resolveNodePiSession({
-    runtime: params.runtime,
-    nodeId,
-    threadId: params.threadId,
-  });
-  return {
-    kind: "node",
-    nodeId,
-    command: PI_TERMINAL_RESUME_COMMAND,
-    paramsJSON: JSON.stringify({ threadId: params.threadId }),
-    ...(record.cwd ? { cwd: record.cwd } : {}),
-    title,
-  };
-}
-
-async function readPiTranscript(
-  runtime: PluginRuntime,
-  request: Parameters<SessionCatalogProvider["read"]>[0],
-): Promise<SessionsCatalogReadResult> {
-  const cursor = request.cursor;
-  if (cursor !== undefined && !isExactPiSessionCursor(cursor)) {
-    throw new Error("cursor is invalid");
-  }
-  if (request.hostId === LOCAL_HOST_ID) {
-    return await readLocalPiTranscriptPage({
-      threadId: request.threadId,
-      ...(request.limit ? { limit: request.limit } : {}),
-      ...(cursor !== undefined ? { cursor } : {}),
-    });
-  }
-  if (!request.hostId.startsWith("node:")) {
-    throw new Error("hostId is invalid");
-  }
-  const nodeId = request.hostId.slice("node:".length);
-  const node = (await runtime.nodes.list()).nodes.find(
-    (candidate) =>
-      candidate.nodeId === nodeId &&
-      candidate.connected === true &&
-      candidate.commands?.includes(PI_SESSION_READ_COMMAND),
-  );
-  if (!node) {
-    throw new Error("paired-node Pi session host is unavailable");
-  }
-  const raw = await runtime.nodes.invoke({
-    nodeId,
-    command: PI_SESSION_READ_COMMAND,
-    params: {
-      threadId: request.threadId,
-      ...(request.limit ? { limit: request.limit } : {}),
-      ...(cursor !== undefined ? { cursor } : {}),
-    },
-    timeoutMs: NODE_TIMEOUT_MS,
-    scopes: ["operator.write"],
-  });
-  return {
-    ...parseNodeTranscriptPage(unwrapNodePayload(raw), request.threadId),
-    hostId: request.hostId,
-    label: nodeLabel(node),
-  };
-}
-
 export function registerPiSessionCatalog(api: OpenClawPluginApi): void {
   if (!isPiSessionCatalogEnabled(api.pluginConfig)) {
     return;
   }
-  api.registerSessionCatalog({
+  const loadCatalogRuntime = createLazyRuntimeSurface(loadPiSessionCatalogModule, (module) =>
+    module.createPiSessionCatalogRuntime(api),
+  );
+  const provider: SessionCatalogProvider = {
     id: "pi",
     label: "Pi",
-    list: async (query) => await listPiHosts(api, query),
-    read: async (request) => await readPiTranscript(api.runtime, request),
-    continueSession: async (request) =>
-      await continuePiSession(api, request.hostId, request.threadId),
-    checkUpstreamActivity: checkPiUpstreamActivity,
-    openTerminal: async (request) => await openPiTerminal({ runtime: api.runtime, ...request }),
-  });
+    list: async (query) => await (await loadCatalogRuntime()).list(query),
+    read: async (request) => await (await loadCatalogRuntime()).read(request),
+    continueSession: async (request) => await (await loadCatalogRuntime()).continueSession(request),
+    checkUpstreamActivity: async (probes) =>
+      await (await loadCatalogRuntime()).checkUpstreamActivity(probes),
+    openTerminal: async (request) => await (await loadCatalogRuntime()).openTerminal(request),
+  };
+  api.registerSessionCatalog(provider);
   for (const command of createPiSessionNodeHostCommands()) {
     api.registerNodeHostCommand(command);
   }

--- a/extensions/acpx/src/pi-session-catalog-runtime.ts
+++ b/extensions/acpx/src/pi-session-catalog-runtime.ts
@@ -1,0 +1,598 @@
+import process from "node:process";
+import { resolveAcpSessionAvailability } from "openclaw/plugin-sdk/acp-runtime";
+import { resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  decodeNodePtyResumeParams,
+  resolveNodeHostExecutable,
+  runNodePtyCommand,
+  type OpenClawPluginNodeHostCommandIo,
+} from "openclaw/plugin-sdk/node-host";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
+import type {
+  SessionCatalogHost,
+  SessionCatalogProvider,
+  SessionCatalogSession,
+  SessionCatalogTerminalPlan,
+  SessionCatalogTranscriptItem,
+  SessionsCatalogReadResult,
+} from "openclaw/plugin-sdk/session-catalog";
+import {
+  createSessionCatalogAdoptionCoordinator,
+  importSessionCatalogHistory,
+  listAdoptedSessionCatalogSessions,
+  sessionCatalogAdoptedSessionKey,
+  sessionCatalogAdoptedSourceKey,
+} from "openclaw/plugin-sdk/session-catalog";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  PI_SESSIONS_LIST_COMMAND,
+  PI_SESSION_READ_COMMAND,
+  PI_TERMINAL_RESUME_COMMAND,
+} from "./pi-session-catalog-shared.js";
+import {
+  isExactPiSessionCursor,
+  listLocalPiSessionPage,
+  readLocalPiTranscriptPage,
+  type PiSessionPage,
+} from "./pi-session-catalog.js";
+import { piSessionStoreAvailable } from "./pi-session-paths.js";
+import { checkPiUpstreamActivity, linkContinuedPiSession } from "./pi-session-upstream-activity.js";
+
+const LOCAL_HOST_ID = "gateway";
+const MAX_PAGE_LIMIT = 100;
+const MAX_HOSTS = 100;
+const NODE_TIMEOUT_MS = 20_000;
+const SESSION_ID_PATTERN = /^(?!-)[A-Za-z0-9._:-]{1,256}$/u;
+const TRANSCRIPT_ITEM_TYPES = new Set([
+  "userMessage",
+  "agentMessage",
+  "reasoning",
+  "toolCall",
+  "toolResult",
+  "other",
+]);
+const ACPX_BACKEND_ID = "acpx";
+const PI_ACP_AGENT_ID = "pi";
+const PI_ADOPTED_SESSION_KEY_PREFIX = "plugin:acpx:catalog-adopt:pi:";
+
+class PiCatalogParamsError extends Error {}
+
+const continueAdoption =
+  createSessionCatalogAdoptionCoordinator<Awaited<ReturnType<typeof linkContinuedPiSession>>>();
+
+function validatePiThreadId(value: unknown): string {
+  if (typeof value !== "string" || !SESSION_ID_PATTERN.test(value)) {
+    throw new Error("INVALID_REQUEST: threadId is invalid");
+  }
+  return value;
+}
+
+function isOptionalString(value: unknown): boolean {
+  return value === undefined || typeof value === "string";
+}
+
+function isOptionalNumber(value: unknown): boolean {
+  return value === undefined || typeof value === "number";
+}
+
+function isNodeSession(value: unknown): value is SessionCatalogSession {
+  return (
+    isRecord(value) &&
+    typeof value.threadId === "string" &&
+    SESSION_ID_PATTERN.test(value.threadId) &&
+    typeof value.status === "string" &&
+    value.status.length > 0 &&
+    typeof value.archived === "boolean" &&
+    typeof value.canContinue === "boolean" &&
+    typeof value.canArchive === "boolean" &&
+    isOptionalString(value.name) &&
+    isOptionalString(value.cwd) &&
+    isOptionalString(value.source) &&
+    isOptionalString(value.modelProvider) &&
+    isOptionalString(value.cliVersion) &&
+    isOptionalString(value.gitBranch) &&
+    isOptionalString(value.sessionKey) &&
+    isOptionalNumber(value.createdAt) &&
+    isOptionalNumber(value.updatedAt) &&
+    isOptionalNumber(value.recencyAt)
+  );
+}
+
+function isNodeTranscriptItem(value: unknown): value is SessionCatalogTranscriptItem {
+  return (
+    isRecord(value) &&
+    typeof value.type === "string" &&
+    TRANSCRIPT_ITEM_TYPES.has(value.type) &&
+    isOptionalString(value.id) &&
+    isOptionalString(value.text) &&
+    isOptionalString(value.timestamp) &&
+    isOptionalString(value.model) &&
+    (value.truncated === undefined || typeof value.truncated === "boolean")
+  );
+}
+
+function parseNodeParams(paramsJSON?: string | null): unknown {
+  if (!paramsJSON) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(paramsJSON) as unknown;
+  } catch (error) {
+    throw new Error("Pi session parameters must be valid JSON", { cause: error });
+  }
+}
+
+function nodeLabel(node: { displayName?: string; remoteIp?: string; nodeId: string }): string {
+  return node.displayName?.trim() || node.remoteIp?.trim() || node.nodeId;
+}
+
+function unwrapNodePayload(value: unknown): unknown {
+  return isRecord(value) && typeof value.payloadJSON === "string"
+    ? (JSON.parse(value.payloadJSON) as unknown)
+    : value;
+}
+
+type CatalogNode = Awaited<ReturnType<PluginRuntime["nodes"]["list"]>>["nodes"][number];
+
+function setCatalogCapabilities(
+  page: PiSessionPage,
+  capabilities: { canContinue: boolean; canOpenTerminal: boolean },
+): PiSessionPage {
+  for (const session of page.sessions) {
+    session.canContinue = capabilities.canContinue && session.canContinue;
+    session.canOpenTerminal = capabilities.canOpenTerminal;
+  }
+  return page;
+}
+
+async function listPiNodeHost(
+  runtime: PluginRuntime,
+  query: Parameters<SessionCatalogProvider["list"]>[0],
+  node: CatalogNode,
+): Promise<SessionCatalogHost> {
+  const hostId = `node:${node.nodeId}`;
+  const common = {
+    hostId,
+    label: nodeLabel(node),
+    kind: "node" as const,
+    connected: node.connected === true,
+    nodeId: node.nodeId,
+  };
+  if (node.connected !== true) {
+    return {
+      ...common,
+      sessions: [],
+      error: { code: "NODE_OFFLINE", message: "Paired node is offline" },
+    };
+  }
+  try {
+    const cursor = query.cursors?.[hostId];
+    if (cursor !== undefined && !isExactPiSessionCursor(cursor)) {
+      throw new Error("cursor is invalid");
+    }
+    const raw = await runtime.nodes.invoke({
+      nodeId: node.nodeId,
+      command: PI_SESSIONS_LIST_COMMAND,
+      params: {
+        ...(query.limitPerHost ? { limit: query.limitPerHost } : {}),
+        ...(query.search ? { searchTerm: query.search } : {}),
+        ...(cursor !== undefined ? { cursor } : {}),
+      },
+      timeoutMs: NODE_TIMEOUT_MS,
+      scopes: ["operator.write"],
+    });
+    const page = parseNodeSessionPage(unwrapNodePayload(raw));
+    const commands = node.invocableCommands ?? node.commands;
+    const canOpenTerminal = commands?.includes(PI_TERMINAL_RESUME_COMMAND) === true;
+    return {
+      ...common,
+      ...setCatalogCapabilities(page, { canContinue: false, canOpenTerminal }),
+    };
+  } catch {
+    return {
+      ...common,
+      sessions: [],
+      error: { code: "NODE_INVOKE_FAILED", message: "Paired node Pi sessions are unavailable" },
+    };
+  }
+}
+
+function parseNodeSessionPage(value: unknown): PiSessionPage {
+  if (
+    !isRecord(value) ||
+    !Array.isArray(value.sessions) ||
+    value.sessions.length > MAX_PAGE_LIMIT
+  ) {
+    throw new Error("Pi node returned an invalid session page");
+  }
+  if (!value.sessions.every(isNodeSession)) {
+    throw new Error("Pi node returned an invalid session page");
+  }
+  const sessions = value.sessions;
+  const nextCursor = value.nextCursor;
+  if (nextCursor !== undefined && !isExactPiSessionCursor(nextCursor)) {
+    throw new Error("Pi node returned an invalid cursor");
+  }
+  return { sessions, ...(nextCursor !== undefined ? { nextCursor } : {}) };
+}
+
+function parseNodeTranscriptPage(value: unknown, threadId: string): SessionsCatalogReadResult {
+  if (
+    !isRecord(value) ||
+    value.threadId !== threadId ||
+    !Array.isArray(value.items) ||
+    value.items.length > MAX_PAGE_LIMIT ||
+    !value.items.every(isNodeTranscriptItem)
+  ) {
+    throw new Error("Pi node returned an invalid transcript page");
+  }
+  const nextCursor = value.nextCursor;
+  if (nextCursor !== undefined && !isExactPiSessionCursor(nextCursor)) {
+    throw new Error("Pi node returned an invalid cursor");
+  }
+  return {
+    hostId: LOCAL_HOST_ID,
+    threadId,
+    items: value.items,
+    ...(nextCursor !== undefined ? { nextCursor } : {}),
+  };
+}
+
+async function listPiHosts(
+  api: OpenClawPluginApi,
+  query: Parameters<SessionCatalogProvider["list"]>[0],
+): Promise<SessionCatalogHost[]> {
+  const runtime = api.runtime;
+  const canContinue = resolvePiContinuationAvailability(api).available;
+  const requested = query.hostIds ? new Set(query.hostIds) : undefined;
+  const hosts: SessionCatalogHost[] = [];
+  if ((!requested || requested.has(LOCAL_HOST_ID)) && piSessionStoreAvailable(process.env)) {
+    try {
+      hosts.push({
+        hostId: LOCAL_HOST_ID,
+        label: "Local Pi",
+        kind: "gateway",
+        connected: true,
+        ...(await listLocalPiSessionPage({
+          limit: query.limitPerHost,
+          ...(query.search ? { searchTerm: query.search } : {}),
+          cursor: query.cursors?.[LOCAL_HOST_ID],
+        }).then((page) =>
+          setCatalogCapabilities(page, {
+            canContinue,
+            canOpenTerminal:
+              resolveNodeHostExecutable("pi", {
+                env: process.env,
+                pathEnv: process.env.PATH ?? "",
+                strategy: "fallback",
+              }) !== undefined,
+          }),
+        )),
+      });
+    } catch {
+      hosts.push({
+        hostId: LOCAL_HOST_ID,
+        label: "Local Pi",
+        kind: "gateway",
+        connected: true,
+        sessions: [],
+        error: { code: "LOCAL_READ_FAILED", message: "Local Pi sessions are unavailable" },
+      });
+    }
+  }
+  let nodes: Awaited<ReturnType<PluginRuntime["nodes"]["list"]>>["nodes"];
+  try {
+    nodes = (await (query.listNodes?.() ?? runtime.nodes.list())).nodes;
+  } catch {
+    return hosts;
+  }
+  const eligible = nodes
+    .filter(
+      (node) =>
+        node.commands?.includes(PI_SESSIONS_LIST_COMMAND) &&
+        (!requested || requested.has(`node:${node.nodeId}`)),
+    )
+    .toSorted((left, right) => nodeLabel(left).localeCompare(nodeLabel(right)))
+    .slice(0, MAX_HOSTS - hosts.length);
+  const nodeHosts = await Promise.all(eligible.map((node) => listPiNodeHost(runtime, query, node)));
+  return [...hosts, ...nodeHosts];
+}
+
+async function requireLocalPiSession(threadId: string): Promise<SessionCatalogSession> {
+  const page = await listLocalPiSessionPage({ searchTerm: threadId, limit: MAX_PAGE_LIMIT });
+  const record = page.sessions.find((session) => session.threadId === threadId);
+  if (!record) {
+    throw new Error("Pi session is unavailable");
+  }
+  return record;
+}
+
+function currentPiCatalogConfig(api: OpenClawPluginApi): OpenClawConfig {
+  return (api.runtime.config?.current?.() ?? api.config ?? {}) as OpenClawConfig;
+}
+
+function resolvePiContinuationAvailability(
+  api: OpenClawPluginApi,
+): { available: true } | { available: false; message: string } {
+  const availability = resolveAcpSessionAvailability({
+    config: currentPiCatalogConfig(api),
+    backendId: ACPX_BACKEND_ID,
+    agentId: PI_ACP_AGENT_ID,
+  });
+  if (!availability.available) {
+    return availability;
+  }
+  const executable = resolveNodeHostExecutable("pi", {
+    env: process.env,
+    pathEnv: process.env.PATH ?? "",
+    strategy: "fallback",
+  });
+  return executable ? { available: true } : { available: false, message: "Pi CLI is unavailable" };
+}
+
+function listAdoptedPiSessions(api: OpenClawPluginApi): Map<string, string> {
+  return listAdoptedSessionCatalogSessions({
+    config: currentPiCatalogConfig(api),
+    pluginId: api.id,
+    runtime: api.runtime,
+    sourceFromEntry: (entry) => {
+      const acpx = isRecord(entry.pluginExtensions?.acpx) ? entry.pluginExtensions.acpx : undefined;
+      const marker = acpx && isRecord(acpx.piSessionCatalog) ? acpx.piSessionCatalog : undefined;
+      return marker && typeof marker.sourceThreadId === "string"
+        ? { hostId: LOCAL_HOST_ID, threadId: marker.sourceThreadId }
+        : undefined;
+    },
+  });
+}
+
+async function continuePiSession(
+  api: OpenClawPluginApi,
+  hostId: string,
+  threadId: string,
+): Promise<Awaited<ReturnType<typeof linkContinuedPiSession>>> {
+  if (hostId.startsWith("node:")) {
+    throw new PiCatalogParamsError("paired-node Pi session rows are view-only");
+  }
+  if (hostId !== LOCAL_HOST_ID) {
+    throw new PiCatalogParamsError("Pi session catalog hostId is invalid");
+  }
+  const availability = resolvePiContinuationAvailability(api);
+  if (!availability.available) {
+    throw new PiCatalogParamsError(availability.message);
+  }
+  const sourceKey = sessionCatalogAdoptedSourceKey(hostId, threadId);
+  return await continueAdoption({
+    sourceKey,
+    findExisting: () => listAdoptedPiSessions(api).get(sourceKey),
+    create: async () => {
+      const record = await requireLocalPiSession(threadId).catch(() => undefined);
+      if (!record) {
+        throw new PiCatalogParamsError("Pi session is unavailable");
+      }
+      if (!record.canContinue) {
+        throw new PiCatalogParamsError(
+          "Pi session is outside the session store supported by pi-acp",
+        );
+      }
+      const currentAvailability = resolvePiContinuationAvailability(api);
+      if (!currentAvailability.available) {
+        throw new PiCatalogParamsError(currentAvailability.message);
+      }
+      const config = currentPiCatalogConfig(api);
+      const marker = { sourceThreadId: threadId };
+      const created = await api.runtime.agent.session.createSessionEntry({
+        cfg: config,
+        key: sessionCatalogAdoptedSessionKey(PI_ADOPTED_SESSION_KEY_PREFIX, threadId),
+        agentId: resolveDefaultAgentId(config),
+        recoverMatchingInitialEntry: true,
+        ...(record.name ? { label: record.name } : {}),
+        ...(record.cwd ? { spawnedCwd: record.cwd } : {}),
+        initialEntry: {
+          acpBackendId: ACPX_BACKEND_ID,
+          acpSessionBinding: {
+            acpAgentId: PI_ACP_AGENT_ID,
+            agentSessionId: threadId,
+          },
+          pluginExtensions: { acpx: { piSessionCatalog: marker } },
+        },
+        afterCreate: async (entry) => {
+          await importSessionCatalogHistory({
+            catalogId: "pi",
+            threadId,
+            read: async ({ cursor, limit }) =>
+              await readPiTranscript(api.runtime, {
+                hostId,
+                threadId,
+                limit,
+                ...(cursor ? { cursor } : {}),
+              }),
+            sessionId: entry.sessionId,
+            sessionKey: entry.key,
+            agentId: entry.agentId,
+            ...(record.cwd ? { cwd: record.cwd } : {}),
+            config,
+          });
+          return { pluginExtensions: { acpx: { piSessionCatalog: marker } } };
+        },
+      });
+      return { sessionKey: created.key };
+    },
+    complete: async (continued) => await linkContinuedPiSession(continued.sessionKey, threadId),
+  });
+}
+
+async function resolveNodePiSession(params: {
+  runtime: PluginRuntime;
+  nodeId: string;
+  threadId: string;
+}): Promise<SessionCatalogSession> {
+  const raw = await params.runtime.nodes.invoke({
+    nodeId: params.nodeId,
+    command: PI_SESSIONS_LIST_COMMAND,
+    params: { searchTerm: params.threadId, limit: MAX_PAGE_LIMIT },
+    timeoutMs: NODE_TIMEOUT_MS,
+    scopes: ["operator.write"],
+  });
+  const page = parseNodeSessionPage(unwrapNodePayload(raw));
+  const record = page.sessions.find((session) => session.threadId === params.threadId);
+  if (!record) {
+    throw new Error("Pi session is unavailable");
+  }
+  return record;
+}
+
+async function openPiTerminal(params: {
+  runtime: PluginRuntime;
+  hostId: string;
+  threadId: string;
+}): Promise<SessionCatalogTerminalPlan> {
+  const title = `pi --session ${params.threadId.slice(0, 12)}…`;
+  if (params.hostId === LOCAL_HOST_ID) {
+    const record = await requireLocalPiSession(params.threadId);
+    const resolution = resolveNodeHostExecutable("pi", {
+      env: process.env,
+      pathEnv: process.env.PATH ?? "",
+      strategy: "fallback",
+    });
+    if (!resolution) {
+      throw new Error("Pi CLI is unavailable");
+    }
+    return {
+      kind: "local",
+      argv: [resolution.executable, "--session", params.threadId],
+      ...(record.cwd ? { cwd: record.cwd } : {}),
+      ...(resolution.pathEnv ? { pathEnv: resolution.pathEnv } : {}),
+      title,
+    };
+  }
+  if (!params.hostId.startsWith("node:")) {
+    throw new Error("hostId is invalid");
+  }
+  const nodeId = params.hostId.slice("node:".length);
+  const node = (await params.runtime.nodes.list()).nodes.find((candidate) => {
+    const commands = candidate.invocableCommands ?? candidate.commands;
+    return (
+      candidate.nodeId === nodeId &&
+      candidate.connected === true &&
+      commands?.includes(PI_SESSIONS_LIST_COMMAND) === true &&
+      commands.includes(PI_TERMINAL_RESUME_COMMAND)
+    );
+  });
+  if (!node) {
+    throw new Error("paired-node Pi terminal is unavailable");
+  }
+  const record = await resolveNodePiSession({
+    runtime: params.runtime,
+    nodeId,
+    threadId: params.threadId,
+  });
+  return {
+    kind: "node",
+    nodeId,
+    command: PI_TERMINAL_RESUME_COMMAND,
+    paramsJSON: JSON.stringify({ threadId: params.threadId }),
+    ...(record.cwd ? { cwd: record.cwd } : {}),
+    title,
+  };
+}
+
+async function readPiTranscript(
+  runtime: PluginRuntime,
+  request: Parameters<SessionCatalogProvider["read"]>[0],
+): Promise<SessionsCatalogReadResult> {
+  const cursor = request.cursor;
+  if (cursor !== undefined && !isExactPiSessionCursor(cursor)) {
+    throw new Error("cursor is invalid");
+  }
+  if (request.hostId === LOCAL_HOST_ID) {
+    return await readLocalPiTranscriptPage({
+      threadId: request.threadId,
+      ...(request.limit ? { limit: request.limit } : {}),
+      ...(cursor !== undefined ? { cursor } : {}),
+    });
+  }
+  if (!request.hostId.startsWith("node:")) {
+    throw new Error("hostId is invalid");
+  }
+  const nodeId = request.hostId.slice("node:".length);
+  const node = (await runtime.nodes.list()).nodes.find(
+    (candidate) =>
+      candidate.nodeId === nodeId &&
+      candidate.connected === true &&
+      candidate.commands?.includes(PI_SESSION_READ_COMMAND),
+  );
+  if (!node) {
+    throw new Error("paired-node Pi session host is unavailable");
+  }
+  const raw = await runtime.nodes.invoke({
+    nodeId,
+    command: PI_SESSION_READ_COMMAND,
+    params: {
+      threadId: request.threadId,
+      ...(request.limit ? { limit: request.limit } : {}),
+      ...(cursor !== undefined ? { cursor } : {}),
+    },
+    timeoutMs: NODE_TIMEOUT_MS,
+    scopes: ["operator.write"],
+  });
+  return {
+    ...parseNodeTranscriptPage(unwrapNodePayload(raw), request.threadId),
+    hostId: request.hostId,
+    label: nodeLabel(node),
+  };
+}
+
+export async function listPiSessions(paramsJSON?: string | null): Promise<string> {
+  return JSON.stringify(await listLocalPiSessionPage(parseNodeParams(paramsJSON)));
+}
+
+export async function readPiSession(paramsJSON?: string | null): Promise<string> {
+  return JSON.stringify(await readLocalPiTranscriptPage(parseNodeParams(paramsJSON)));
+}
+
+export async function resumePiSession(
+  paramsJSON?: string | null,
+  io?: OpenClawPluginNodeHostCommandIo,
+): Promise<string> {
+  if (!io) {
+    throw new Error("Pi terminal command requires duplex transport");
+  }
+  const params = decodeNodePtyResumeParams(paramsJSON, validatePiThreadId);
+  const record = await requireLocalPiSession(params.threadId);
+  const resolution = resolveNodeHostExecutable("pi", {
+    env: process.env,
+    pathEnv: process.env.PATH ?? process.env.Path ?? "",
+    strategy: "direct",
+  });
+  if (!resolution) {
+    throw new Error("Pi CLI is unavailable");
+  }
+  return JSON.stringify(
+    await runNodePtyCommand(
+      {
+        file: resolution.executable,
+        args: ["--session", params.threadId],
+        cwd: record.cwd,
+        cols: params.cols,
+        rows: params.rows,
+      },
+      io,
+    ),
+  );
+}
+
+export function createPiSessionCatalogRuntime(api: OpenClawPluginApi) {
+  return {
+    list: async (query) => await listPiHosts(api, query),
+    read: async (request) => await readPiTranscript(api.runtime, request),
+    continueSession: async (request) =>
+      await continuePiSession(api, request.hostId, request.threadId),
+    checkUpstreamActivity: checkPiUpstreamActivity,
+    openTerminal: async (request) => await openPiTerminal({ runtime: api.runtime, ...request }),
+  } satisfies Pick<
+    SessionCatalogProvider,
+    "list" | "read" | "continueSession" | "checkUpstreamActivity" | "openTerminal"
+  >;
+}

--- a/extensions/acpx/src/pi-session-catalog-shared.ts
+++ b/extensions/acpx/src/pi-session-catalog-shared.ts
@@ -1,0 +1,3 @@
+export const PI_SESSIONS_LIST_COMMAND = "acpx.pi.sessions.list.v1";
+export const PI_SESSION_READ_COMMAND = "acpx.pi.sessions.read.v1";
+export const PI_TERMINAL_RESUME_COMMAND = "acpx.pi.terminal.resume.v1";

--- a/extensions/google-meet/index.ts
+++ b/extensions/google-meet/index.ts
@@ -6,43 +6,27 @@ import { normalizeAgentId, parseAgentSessionKey } from "openclaw/plugin-sdk/rout
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { jsonResult as json } from "openclaw/plugin-sdk/tool-results";
 import { createMeetingTranscriptSourceProvider } from "openclaw/plugin-sdk/transcripts";
-import { buildGoogleMeetCalendarDayWindow, listGoogleMeetCalendarEvents } from "./src/calendar.js";
 import { GOOGLE_MEET_CLI_DESCRIPTOR } from "./src/cli-output-mode.js";
-import {
-  buildGoogleMeetPreflightReport,
-  endGoogleMeetActiveConference,
-  fetchLatestGoogleMeetConferenceRecord,
-} from "./src/meet.js";
-import { handleGoogleMeetNodeHostCommand } from "./src/node-host.js";
-import {
-  createGoogleMeetChromeNodeInvokePolicy,
-  GOOGLE_MEET_CHROME_NODE_COMMAND,
-} from "./src/node-invoke-policy.js";
 import {
   asParamRecord,
   assertGoogleMeetAgentToolActionSupported,
   callGoogleMeetGatewayFromTool,
-  createAndJoinMeetFromParams,
   createGoogleMeetRuntimeAccessor,
-  createMeetFromParams,
-  exportGoogleMeetBundleFromParams,
-  fetchResolvedGoogleMeetArtifacts,
-  fetchResolvedGoogleMeetAttendance,
+  createLazyGoogleMeetNodeInvokePolicy,
   formatGoogleMeetGatewayError,
   keepTrustedToolAgentId,
   loadGoogleMeetCliModule,
+  loadGoogleMeetNodeHostModule,
+  loadGoogleMeetPluginHelpers,
   normalizeMode,
   normalizeTransport,
-  resolveArtifactQueryFromParams,
-  resolveGoogleMeetTokenFromParams,
-  resolveMeetingFromParams,
   resolveMeetingInput,
-  resolveSpaceFromParams,
   sendGoogleMeetGatewayError,
   shouldJoinCreatedMeet,
   testing,
-} from "./src/plugin-helpers.js";
+} from "./src/plugin-registration.js";
 import { googleMeetConfigSchema, GoogleMeetToolSchema } from "./src/plugin-schema.js";
+import { GOOGLE_MEET_NODE_COMMAND } from "./src/transports/google-meet-platform-constants.js";
 
 export { testing };
 
@@ -85,14 +69,15 @@ export default definePluginEntry({
     };
     const queryActions = {
       latest: async (raw: Record<string, unknown>) => {
-        const token = await resolveGoogleMeetTokenFromParams(config, raw);
-        const resolved = await resolveMeetingFromParams({
+        const helpers = await loadGoogleMeetPluginHelpers();
+        const token = await helpers.resolveGoogleMeetTokenFromParams(config, raw);
+        const resolved = await helpers.resolveMeetingFromParams({
           config,
           raw,
           accessToken: token.accessToken,
         });
         return {
-          ...(await fetchLatestGoogleMeetConferenceRecord({
+          ...(await helpers.fetchLatestGoogleMeetConferenceRecord({
             accessToken: token.accessToken,
             meeting: resolved.meeting,
           })),
@@ -100,19 +85,28 @@ export default definePluginEntry({
         };
       },
       calendar_events: async (raw: Record<string, unknown>) => {
-        const token = await resolveGoogleMeetTokenFromParams(config, raw);
-        const window = raw.today === true ? buildGoogleMeetCalendarDayWindow() : {};
-        return listGoogleMeetCalendarEvents({
+        const helpers = await loadGoogleMeetPluginHelpers();
+        const token = await helpers.resolveGoogleMeetTokenFromParams(config, raw);
+        const window = raw.today === true ? helpers.buildGoogleMeetCalendarDayWindow() : {};
+        return helpers.listGoogleMeetCalendarEvents({
           accessToken: token.accessToken,
           calendarId: normalizeOptionalString(raw.calendarId),
           eventQuery: normalizeOptionalString(raw.event),
           ...window,
         });
       },
-      artifacts: async (raw: Record<string, unknown>) =>
-        fetchResolvedGoogleMeetArtifacts(await resolveArtifactQueryFromParams(config, raw)),
-      attendance: async (raw: Record<string, unknown>) =>
-        fetchResolvedGoogleMeetAttendance(await resolveArtifactQueryFromParams(config, raw)),
+      artifacts: async (raw: Record<string, unknown>) => {
+        const helpers = await loadGoogleMeetPluginHelpers();
+        return helpers.fetchResolvedGoogleMeetArtifacts(
+          await helpers.resolveArtifactQueryFromParams(config, raw),
+        );
+      },
+      attendance: async (raw: Record<string, unknown>) => {
+        const helpers = await loadGoogleMeetPluginHelpers();
+        return helpers.fetchResolvedGoogleMeetAttendance(
+          await helpers.resolveArtifactQueryFromParams(config, raw),
+        );
+      },
     };
     api.registerTranscriptSourceProvider(
       createMeetingTranscriptSourceProvider({
@@ -130,16 +124,17 @@ export default definePluginEntry({
 
     registerGatewayMethod("googlemeet.create", async ({ params, client, respond }) => {
       const raw = keepTrustedToolAgentId(asParamRecord(params), client);
+      const helpers = await loadGoogleMeetPluginHelpers();
       respond(
         true,
         shouldJoinCreatedMeet(raw)
-          ? await createAndJoinMeetFromParams({
+          ? await helpers.createAndJoinMeetFromParams({
               config,
               runtime: api.runtime,
               raw,
               ensureRuntime,
             })
-          : await createMeetFromParams({ config, runtime: api.runtime, raw }),
+          : await helpers.createMeetFromParams({ config, runtime: api.runtime, raw }),
       );
     });
 
@@ -212,7 +207,8 @@ export default definePluginEntry({
     }
 
     registerGatewayMethod("googlemeet.export", async ({ params, respond }) => {
-      respond(true, await exportGoogleMeetBundleFromParams(config, asParamRecord(params)));
+      const helpers = await loadGoogleMeetPluginHelpers();
+      respond(true, await helpers.exportGoogleMeetBundleFromParams(config, asParamRecord(params)));
     });
 
     registerGatewayMethod("googlemeet.leave", async ({ params, respond }) => {
@@ -231,10 +227,11 @@ export default definePluginEntry({
 
     registerGatewayMethod("googlemeet.endActiveConference", async ({ params, respond }) => {
       const raw = asParamRecord(params);
-      const token = await resolveGoogleMeetTokenFromParams(config, raw);
+      const helpers = await loadGoogleMeetPluginHelpers();
+      const token = await helpers.resolveGoogleMeetTokenFromParams(config, raw);
       respond(
         true,
-        await endGoogleMeetActiveConference({
+        await helpers.endGoogleMeetActiveConference({
           accessToken: token.accessToken,
           meeting: resolveMeetingInput(config, raw.meeting),
         }),
@@ -329,13 +326,18 @@ export default definePluginEntry({
                   await callGoogleMeetGatewayFromTool({ config, action: raw.action, raw }),
                 );
               case "resolve_space": {
-                const { token: _token, ...result } = await resolveSpaceFromParams(config, raw);
+                const helpers = await loadGoogleMeetPluginHelpers();
+                const { token: _token, ...result } = await helpers.resolveSpaceFromParams(
+                  config,
+                  raw,
+                );
                 return json(result);
               }
               case "preflight": {
-                const { meeting, token, space } = await resolveSpaceFromParams(config, raw);
+                const helpers = await loadGoogleMeetPluginHelpers();
+                const { meeting, token, space } = await helpers.resolveSpaceFromParams(config, raw);
                 return json(
-                  buildGoogleMeetPreflightReport({
+                  helpers.buildGoogleMeetPreflightReport({
                     input: meeting,
                     space,
                     previewAcknowledged: config.preview.enrollmentAcknowledged,
@@ -349,7 +351,8 @@ export default definePluginEntry({
               case "attendance":
                 return json(await queryActions[raw.action](raw));
               case "export": {
-                return json(await exportGoogleMeetBundleFromParams(config, raw));
+                const helpers = await loadGoogleMeetPluginHelpers();
+                return json(await helpers.exportGoogleMeetBundleFromParams(config, raw));
               }
               case "leave":
               case "speak": {
@@ -373,12 +376,13 @@ export default definePluginEntry({
     );
 
     api.registerNodeHostCommand({
-      command: GOOGLE_MEET_CHROME_NODE_COMMAND,
+      command: GOOGLE_MEET_NODE_COMMAND,
       cap: "google-meet",
       dangerous: true,
-      handle: handleGoogleMeetNodeHostCommand,
+      handle: async (paramsJSON) =>
+        await (await loadGoogleMeetNodeHostModule()).handleGoogleMeetNodeHostCommand(paramsJSON),
     });
-    api.registerNodeInvokePolicy(createGoogleMeetChromeNodeInvokePolicy(config));
+    api.registerNodeInvokePolicy(createLazyGoogleMeetNodeInvokePolicy(config));
 
     api.registerCli(
       async ({ program }) => {

--- a/extensions/google-meet/index.ts
+++ b/extensions/google-meet/index.ts
@@ -1,11 +1,8 @@
 // Google Meet plugin entrypoint registers its OpenClaw integration.
-import { readPositiveIntegerParam } from "openclaw/plugin-sdk/channel-actions";
-import { ErrorCodes, type GatewayRequestHandlerOptions } from "openclaw/plugin-sdk/gateway-runtime";
+import type { GatewayRequestHandlerOptions } from "openclaw/plugin-sdk/gateway-runtime";
 import { definePluginEntry, type OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
-import { normalizeAgentId, parseAgentSessionKey } from "openclaw/plugin-sdk/routing";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { jsonResult as json } from "openclaw/plugin-sdk/tool-results";
-import { createMeetingTranscriptSourceProvider } from "openclaw/plugin-sdk/transcripts";
 import { GOOGLE_MEET_CLI_DESCRIPTOR } from "./src/cli-output-mode.js";
 import {
   asParamRecord,
@@ -108,14 +105,17 @@ export default definePluginEntry({
         );
       },
     };
-    api.registerTranscriptSourceProvider(
-      createMeetingTranscriptSourceProvider({
-        id: "google-meet",
-        aliases: ["googlemeet", "meet"],
-        name: "Google Meet",
-        runtime: async () => (await ensureRuntime()).transcriptSourceRuntime(),
-      }),
-    );
+    const transcriptSourceRuntime = async () => (await ensureRuntime()).transcriptSourceRuntime();
+    api.registerTranscriptSourceProvider({
+      id: "google-meet",
+      aliases: ["googlemeet", "meet"],
+      name: "Google Meet",
+      sourceKinds: ["live-caption"],
+      start: async (request) =>
+        await (await transcriptSourceRuntime()).startTranscriptSource(request),
+      stop: async (request) =>
+        await (await transcriptSourceRuntime()).stopTranscriptSource(request),
+    });
 
     registerGatewayMethod("googlemeet.join", async (options) => {
       const runtime = await ensureRuntime();
@@ -146,11 +146,7 @@ export default definePluginEntry({
     registerGatewayMethod("googlemeet.transcript", async ({ params, respond }) => {
       const sessionId = normalizeOptionalString(params?.sessionId);
       if (!sessionId) {
-        sendGoogleMeetGatewayError(
-          respond,
-          new Error("sessionId required"),
-          ErrorCodes.INVALID_REQUEST,
-        );
+        sendGoogleMeetGatewayError(respond, new Error("sessionId required"), "INVALID_REQUEST");
         return;
       }
       const sinceIndex = (params as { sinceIndex?: unknown } | undefined)?.sinceIndex;
@@ -161,7 +157,7 @@ export default definePluginEntry({
         sendGoogleMeetGatewayError(
           respond,
           new Error("sinceIndex must be a non-negative safe integer"),
-          ErrorCodes.INVALID_REQUEST,
+          "INVALID_REQUEST",
         );
         return;
       }
@@ -214,11 +210,7 @@ export default definePluginEntry({
     registerGatewayMethod("googlemeet.leave", async ({ params, respond }) => {
       const sessionId = normalizeOptionalString(params?.sessionId);
       if (!sessionId) {
-        sendGoogleMeetGatewayError(
-          respond,
-          new Error("sessionId required"),
-          ErrorCodes.INVALID_REQUEST,
-        );
+        sendGoogleMeetGatewayError(respond, new Error("sessionId required"), "INVALID_REQUEST");
         return;
       }
       const runtime = await ensureRuntime();
@@ -241,11 +233,7 @@ export default definePluginEntry({
     registerGatewayMethod("googlemeet.speak", async ({ params, respond }) => {
       const sessionId = normalizeOptionalString(params?.sessionId);
       if (!sessionId) {
-        sendGoogleMeetGatewayError(
-          respond,
-          new Error("sessionId required"),
-          ErrorCodes.INVALID_REQUEST,
-        );
+        sendGoogleMeetGatewayError(respond, new Error("sessionId required"), "INVALID_REQUEST");
         return;
       }
       const runtime = await ensureRuntime();
@@ -260,6 +248,7 @@ export default definePluginEntry({
     registerGatewayMethod("googlemeet.testListen", async ({ params, client, respond }) => {
       const trustedParams = keepTrustedToolAgentId(asParamRecord(params), client);
       const runtime = await ensureRuntime();
+      const { readPositiveIntegerParam } = await import("openclaw/plugin-sdk/param-readers");
       respond(
         true,
         await runtime.testListen({
@@ -282,12 +271,14 @@ export default definePluginEntry({
         async execute(_toolCallId, params) {
           const raw = asParamRecord(params);
           const requesterSessionKey = normalizeOptionalString(toolContext.sessionKey);
-          // Agent ownership comes from trusted tool context, never model-supplied params.
-          // Some harnesses omit agentId but still provide its canonical session key.
-          const contextAgentId =
-            toolContext.agentId ?? parseAgentSessionKey(requesterSessionKey)?.agentId;
-          const agentId = contextAgentId ? normalizeAgentId(contextAgentId) : undefined;
           try {
+            const { normalizeAgentId, parseAgentSessionKey } =
+              await import("openclaw/plugin-sdk/routing");
+            // Agent ownership comes from trusted tool context, never model-supplied params.
+            // Some harnesses omit agentId but still provide its canonical session key.
+            const contextAgentId =
+              toolContext.agentId ?? parseAgentSessionKey(requesterSessionKey)?.agentId;
+            const agentId = contextAgentId ? normalizeAgentId(contextAgentId) : undefined;
             // Main-agent sessions belong to the persistent Gateway runtime. Only
             // non-default identities need trusted in-process routing metadata.
             const needsTrustedAgentRouting = Boolean(agentId && agentId !== "main");

--- a/extensions/google-meet/lazy-import.test.ts
+++ b/extensions/google-meet/lazy-import.test.ts
@@ -1,0 +1,200 @@
+import type {
+  OpenClawPluginApi,
+  OpenClawPluginNodeHostCommand,
+  OpenClawPluginNodeInvokePolicy,
+  OpenClawPluginNodeInvokePolicyContext,
+} from "openclaw/plugin-sdk/plugin-entry";
+import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { GoogleMeetConfig } from "./src/config.js";
+import { GOOGLE_MEET_NODE_COMMAND } from "./src/transports/google-meet-platform-constants.js";
+
+type GatewayHandler = Parameters<OpenClawPluginApi["registerGatewayMethod"]>[1];
+type CliRegistrar = Parameters<OpenClawPluginApi["registerCli"]>[0];
+
+describe("google-meet lazy imports", () => {
+  afterEach(() => {
+    for (const moduleId of [
+      "./src/plugin-helpers.js",
+      "./src/runtime.js",
+      "./src/node-host.js",
+      "./src/node-invoke-policy.js",
+      "./src/cli.js",
+    ]) {
+      vi.doUnmock(moduleId);
+    }
+    vi.resetModules();
+  });
+
+  it("loads each runtime owner only on first use", async () => {
+    let helperImports = 0;
+    let runtimeImports = 0;
+    let nodeHostImports = 0;
+    let nodePolicyImports = 0;
+    let cliImports = 0;
+
+    vi.doMock("./src/plugin-helpers.js", () => {
+      helperImports += 1;
+      return {
+        createMeetFromParams: async () => ({ meetingUri: "https://meet.google.com/abc-defg-hij" }),
+      };
+    });
+    vi.doMock("./src/runtime.js", () => {
+      runtimeImports += 1;
+      return {
+        GoogleMeetRuntime: class {
+          async status() {
+            return { sessions: [] };
+          }
+        },
+      };
+    });
+    vi.doMock("./src/node-host.js", () => {
+      nodeHostImports += 1;
+      return {
+        handleGoogleMeetNodeHostCommand: async () => JSON.stringify({ ok: true }),
+      };
+    });
+    vi.doMock("./src/node-invoke-policy.js", () => {
+      nodePolicyImports += 1;
+      return {
+        createGoogleMeetChromeNodeInvokePolicy: () => ({
+          commands: ["google-meet.chrome"],
+          dangerous: true,
+          handle: async () => ({ ok: true }),
+        }),
+      };
+    });
+    vi.doMock("./src/cli.js", () => {
+      cliImports += 1;
+      return {
+        registerGoogleMeetCli: () => {},
+      };
+    });
+
+    const { default: googleMeetPlugin } = await import("./index.js");
+    const gatewayMethods = new Map<string, GatewayHandler>();
+    const nodeCommands: OpenClawPluginNodeHostCommand[] = [];
+    const nodePolicies: OpenClawPluginNodeInvokePolicy[] = [];
+    const cliRegistrars: CliRegistrar[] = [];
+    googleMeetPlugin.register(
+      createTestPluginApi({
+        id: "google-meet",
+        name: "Google Meet",
+        source: "test",
+        config: {},
+        runtime: createPluginRuntimeMock(),
+        registerGatewayMethod: (method, handler) => gatewayMethods.set(method, handler),
+        registerNodeHostCommand: (command) => nodeCommands.push(command),
+        registerNodeInvokePolicy: (policy) => nodePolicies.push(policy),
+        registerCli: (registrar) => cliRegistrars.push(registrar),
+      }),
+    );
+
+    expect({
+      helperImports,
+      runtimeImports,
+      nodeHostImports,
+      nodePolicyImports,
+      cliImports,
+    }).toEqual({
+      helperImports: 0,
+      runtimeImports: 0,
+      nodeHostImports: 0,
+      nodePolicyImports: 0,
+      cliImports: 0,
+    });
+
+    const createHandler = gatewayMethods.get("googlemeet.create");
+    const statusHandler = gatewayMethods.get("googlemeet.status");
+    const respond = vi.fn();
+    await createHandler?.({ params: { join: false }, respond } as never);
+    await createHandler?.({ params: { join: false }, respond } as never);
+    await statusHandler?.({ params: {}, respond } as never);
+    await statusHandler?.({ params: {}, respond } as never);
+    await nodeCommands[0]?.handle();
+    await nodeCommands[0]?.handle();
+    await nodePolicies[0]?.handle({} as never);
+    await nodePolicies[0]?.handle({} as never);
+    await cliRegistrars[0]?.({ program: {} } as never);
+    await cliRegistrars[0]?.({ program: {} } as never);
+
+    expect({
+      helperImports,
+      runtimeImports,
+      nodeHostImports,
+      nodePolicyImports,
+      cliImports,
+    }).toEqual({
+      helperImports: 1,
+      runtimeImports: 1,
+      nodeHostImports: 1,
+      nodePolicyImports: 1,
+      cliImports: 1,
+    });
+  });
+
+  it("loads and caches the node policy delegate", async () => {
+    const delegateHandle = vi.fn<OpenClawPluginNodeInvokePolicy["handle"]>(async () => ({
+      ok: true,
+    }));
+    const loadPolicy = vi.fn(
+      async (_config: GoogleMeetConfig): Promise<OpenClawPluginNodeInvokePolicy> => ({
+        commands: [GOOGLE_MEET_NODE_COMMAND],
+        dangerous: true,
+        handle: delegateHandle,
+      }),
+    );
+    const { createLazyGoogleMeetNodeInvokePolicy } = await import("./src/plugin-registration.js");
+    const policy = createLazyGoogleMeetNodeInvokePolicy({} as GoogleMeetConfig, loadPolicy);
+
+    expect(policy.commands).toEqual([GOOGLE_MEET_NODE_COMMAND]);
+    expect(policy.dangerous).toBe(true);
+    expect(loadPolicy).not.toHaveBeenCalled();
+
+    await expect(policy.handle({} as OpenClawPluginNodeInvokePolicyContext)).resolves.toEqual({
+      ok: true,
+    });
+    await expect(policy.handle({} as OpenClawPluginNodeInvokePolicyContext)).resolves.toEqual({
+      ok: true,
+    });
+    expect(loadPolicy).toHaveBeenCalledTimes(1);
+    expect(delegateHandle).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails closed when the node policy cannot load", async () => {
+    const { createLazyGoogleMeetNodeInvokePolicy } = await import("./src/plugin-registration.js");
+    const policy = createLazyGoogleMeetNodeInvokePolicy({} as GoogleMeetConfig, async () => {
+      throw new Error("load failed");
+    });
+
+    await expect(policy.handle({} as OpenClawPluginNodeInvokePolicyContext)).resolves.toMatchObject(
+      {
+        ok: false,
+        code: "PLUGIN_POLICY_UNAVAILABLE",
+        unavailable: true,
+      },
+    );
+  });
+
+  it("does not rewrite node policy delegate failures", async () => {
+    const delegateError = new Error("delegate failed");
+    const { createLazyGoogleMeetNodeInvokePolicy } = await import("./src/plugin-registration.js");
+    const policy = createLazyGoogleMeetNodeInvokePolicy(
+      {} as GoogleMeetConfig,
+      async () =>
+        ({
+          commands: [GOOGLE_MEET_NODE_COMMAND],
+          dangerous: true,
+          handle: async () => {
+            throw delegateError;
+          },
+        }) satisfies OpenClawPluginNodeInvokePolicy,
+    );
+
+    await expect(policy.handle({} as OpenClawPluginNodeInvokePolicyContext)).rejects.toBe(
+      delegateError,
+    );
+  });
+});

--- a/extensions/google-meet/lazy-import.test.ts
+++ b/extensions/google-meet/lazy-import.test.ts
@@ -6,12 +6,14 @@ import type {
 } from "openclaw/plugin-sdk/plugin-entry";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
 import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
+import type { TranscriptSourceProvider } from "openclaw/plugin-sdk/transcripts";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GoogleMeetConfig } from "./src/config.js";
 import { GOOGLE_MEET_NODE_COMMAND } from "./src/transports/google-meet-platform-constants.js";
 
 type GatewayHandler = Parameters<OpenClawPluginApi["registerGatewayMethod"]>[1];
 type CliRegistrar = Parameters<OpenClawPluginApi["registerCli"]>[0];
+type ToolFactory = Parameters<OpenClawPluginApi["registerTool"]>[0];
 
 describe("google-meet lazy imports", () => {
   afterEach(() => {
@@ -21,6 +23,10 @@ describe("google-meet lazy imports", () => {
       "./src/node-host.js",
       "./src/node-invoke-policy.js",
       "./src/cli.js",
+      "openclaw/plugin-sdk/gateway-runtime",
+      "openclaw/plugin-sdk/param-readers",
+      "openclaw/plugin-sdk/routing",
+      "openclaw/plugin-sdk/transcripts",
     ]) {
       vi.doUnmock(moduleId);
     }
@@ -33,6 +39,10 @@ describe("google-meet lazy imports", () => {
     let nodeHostImports = 0;
     let nodePolicyImports = 0;
     let cliImports = 0;
+    let gatewayRuntimeImports = 0;
+    let paramReaderImports = 0;
+    let routingImports = 0;
+    let transcriptSdkImports = 0;
 
     vi.doMock("./src/plugin-helpers.js", () => {
       helperImports += 1;
@@ -46,6 +56,17 @@ describe("google-meet lazy imports", () => {
         GoogleMeetRuntime: class {
           async status() {
             return { sessions: [] };
+          }
+
+          async testListen() {
+            return { ok: true };
+          }
+
+          transcriptSourceRuntime() {
+            return {
+              startTranscriptSource: async () => ({ ok: true }),
+              stopTranscriptSource: async () => ({ ok: true }),
+            };
           }
         },
       };
@@ -72,12 +93,37 @@ describe("google-meet lazy imports", () => {
         registerGoogleMeetCli: () => {},
       };
     });
+    vi.doMock("openclaw/plugin-sdk/gateway-runtime", () => {
+      gatewayRuntimeImports += 1;
+      return {
+        callGatewayFromCli: async () => ({ ok: true }),
+      };
+    });
+    vi.doMock("openclaw/plugin-sdk/param-readers", () => {
+      paramReaderImports += 1;
+      return {
+        readPositiveIntegerParam: () => 2_500,
+      };
+    });
+    vi.doMock("openclaw/plugin-sdk/routing", () => {
+      routingImports += 1;
+      return {
+        normalizeAgentId: (value: string) => value,
+        parseAgentSessionKey: () => ({ agentId: "main" }),
+      };
+    });
+    vi.doMock("openclaw/plugin-sdk/transcripts", () => {
+      transcriptSdkImports += 1;
+      return {};
+    });
 
     const { default: googleMeetPlugin } = await import("./index.js");
     const gatewayMethods = new Map<string, GatewayHandler>();
     const nodeCommands: OpenClawPluginNodeHostCommand[] = [];
     const nodePolicies: OpenClawPluginNodeInvokePolicy[] = [];
     const cliRegistrars: CliRegistrar[] = [];
+    const transcriptProviders: TranscriptSourceProvider[] = [];
+    let toolFactory: ToolFactory | undefined;
     googleMeetPlugin.register(
       createTestPluginApi({
         id: "google-meet",
@@ -89,6 +135,10 @@ describe("google-meet lazy imports", () => {
         registerNodeHostCommand: (command) => nodeCommands.push(command),
         registerNodeInvokePolicy: (policy) => nodePolicies.push(policy),
         registerCli: (registrar) => cliRegistrars.push(registrar),
+        registerTool: (factory) => {
+          toolFactory = factory;
+        },
+        registerTranscriptSourceProvider: (provider) => transcriptProviders.push(provider),
       }),
     );
 
@@ -98,21 +148,58 @@ describe("google-meet lazy imports", () => {
       nodeHostImports,
       nodePolicyImports,
       cliImports,
+      gatewayRuntimeImports,
+      paramReaderImports,
+      routingImports,
+      transcriptSdkImports,
     }).toEqual({
       helperImports: 0,
       runtimeImports: 0,
       nodeHostImports: 0,
       nodePolicyImports: 0,
       cliImports: 0,
+      gatewayRuntimeImports: 0,
+      paramReaderImports: 0,
+      routingImports: 0,
+      transcriptSdkImports: 0,
     });
 
     const createHandler = gatewayMethods.get("googlemeet.create");
     const statusHandler = gatewayMethods.get("googlemeet.status");
+    const transcriptHandler = gatewayMethods.get("googlemeet.transcript");
+    const testListenHandler = gatewayMethods.get("googlemeet.testListen");
     const respond = vi.fn();
+    await transcriptHandler?.({ params: {}, respond } as never);
+    await transcriptHandler?.({ params: {}, respond } as never);
+    expect(gatewayRuntimeImports).toBe(0);
+
     await createHandler?.({ params: { join: false }, respond } as never);
     await createHandler?.({ params: { join: false }, respond } as never);
     await statusHandler?.({ params: {}, respond } as never);
     await statusHandler?.({ params: {}, respond } as never);
+    await testListenHandler?.({ params: { timeoutMs: 2_500 }, respond } as never);
+    await testListenHandler?.({ params: { timeoutMs: 2_500 }, respond } as never);
+    const transcriptProvider = transcriptProviders[0];
+    if (
+      typeof transcriptProvider?.start !== "function" ||
+      typeof transcriptProvider.stop !== "function"
+    ) {
+      throw new Error("expected Google Meet transcript provider");
+    }
+    await transcriptProvider.start({} as never);
+    await transcriptProvider.stop({} as never);
+
+    if (typeof toolFactory !== "function") {
+      throw new Error("expected Google Meet tool factory");
+    }
+    const registeredTool = toolFactory({ sessionKey: "agent:main:main" } as never);
+    const tool = Array.isArray(registeredTool) ? registeredTool[0] : registeredTool;
+    if (!tool) {
+      throw new Error("expected Google Meet tool");
+    }
+    await tool.execute("tool-call", { action: "status" } as never);
+    await tool.execute("tool-call", { action: "status" } as never);
+
     await nodeCommands[0]?.handle();
     await nodeCommands[0]?.handle();
     await nodePolicies[0]?.handle({} as never);
@@ -126,12 +213,20 @@ describe("google-meet lazy imports", () => {
       nodeHostImports,
       nodePolicyImports,
       cliImports,
+      gatewayRuntimeImports,
+      paramReaderImports,
+      routingImports,
+      transcriptSdkImports,
     }).toEqual({
       helperImports: 1,
       runtimeImports: 1,
       nodeHostImports: 1,
       nodePolicyImports: 1,
       cliImports: 1,
+      gatewayRuntimeImports: 1,
+      paramReaderImports: 1,
+      routingImports: 1,
+      transcriptSdkImports: 0,
     });
   });
 

--- a/extensions/google-meet/src/browser-manual-action-error.ts
+++ b/extensions/google-meet/src/browser-manual-action-error.ts
@@ -1,0 +1,36 @@
+import type { GoogleMeetChromeHealth } from "./transports/types.js";
+
+type GoogleMeetBrowserManualActionState = NonNullable<GoogleMeetChromeHealth["manualAction"]>;
+
+type GoogleMeetBrowserManualAction = {
+  source: "browser";
+  error: string;
+  manualAction: GoogleMeetBrowserManualActionState;
+  browser: {
+    nodeId: string;
+    targetId?: string;
+    browserUrl?: string;
+    browserTitle?: string;
+    notes?: string[];
+  };
+};
+
+export class GoogleMeetBrowserManualActionError extends Error {
+  readonly payload: GoogleMeetBrowserManualAction;
+
+  constructor(payload: Omit<GoogleMeetBrowserManualAction, "source" | "error">) {
+    super(`${payload.manualAction.reason}: ${payload.manualAction.message}`);
+    this.name = "GoogleMeetBrowserManualActionError";
+    this.payload = {
+      source: "browser",
+      error: this.message,
+      ...payload,
+    };
+  }
+}
+
+export function isGoogleMeetBrowserManualActionError(
+  error: unknown,
+): error is GoogleMeetBrowserManualActionError {
+  return error instanceof GoogleMeetBrowserManualActionError;
+}

--- a/extensions/google-meet/src/config.ts
+++ b/extensions/google-meet/src/config.ts
@@ -1,5 +1,4 @@
 // Google Meet helper module supports config behavior.
-import { buildMeetingSoxAudioCommands } from "openclaw/plugin-sdk/meeting-runtime";
 import {
   addTimerTimeoutGraceMs,
   resolvePositiveTimerTimeoutMs,
@@ -111,28 +110,29 @@ const DEFAULT_GOOGLE_MEET_AUDIO_BUFFER_BYTES = SOX_DEFAULT_BUFFER_BYTES / 2;
 const PLAIN_DECIMAL_NUMBER_RE = /^\d+(?:\.\d+)?$/;
 
 function buildGoogleMeetSoxAudioCommands(format: GoogleMeetChromeAudioFormat, bufferBytes: number) {
-  return format === "g711-ulaw-8khz"
-    ? buildMeetingSoxAudioCommands({
-        bufferBytes,
-        format: {
-          sampleRate: 8_000,
-          channels: 1,
-          encoding: "mu-law",
-          bits: 8,
-        },
-      })
-    : buildMeetingSoxAudioCommands({
-        bufferBytes,
-        device: "BlackHole 2ch",
-        deviceType: "coreaudio",
-        format: {
-          sampleRate: 24_000,
-          channels: 1,
-          encoding: "signed-integer",
-          bits: 16,
-          endian: "little",
-        },
-      });
+  // Config parsing runs during registration; command construction must not load
+  // the full meeting runtime before a Google Meet action needs it.
+  const wire =
+    format === "g711-ulaw-8khz"
+      ? ["-t", "raw", "-r", "8000", "-c", "1", "-e", "mu-law", "-b", "8", "-"]
+      : ["-t", "raw", "-r", "24000", "-c", "1", "-e", "signed-integer", "-b", "16", "-L", "-"];
+  const withBuffer = (executable: string, args: string[]) => [
+    executable,
+    "-q",
+    "--buffer",
+    String(bufferBytes),
+    ...args,
+  ];
+  if (format === "g711-ulaw-8khz") {
+    return {
+      inputCommand: withBuffer("rec", wire),
+      outputCommand: withBuffer("play", wire),
+    };
+  }
+  return {
+    inputCommand: withBuffer("sox", ["-t", "coreaudio", "BlackHole 2ch", ...wire]),
+    outputCommand: withBuffer("sox", [...wire, "-t", "coreaudio", "BlackHole 2ch"]),
+  };
 }
 
 const DEFAULT_GOOGLE_MEET_SOX_COMMANDS = buildGoogleMeetSoxAudioCommands(

--- a/extensions/google-meet/src/plugin-helpers.ts
+++ b/extensions/google-meet/src/plugin-helpers.ts
@@ -1,203 +1,22 @@
 import { readPositiveIntegerParam } from "openclaw/plugin-sdk/channel-actions";
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import {
-  callGatewayFromCli,
-  ErrorCodes,
-  errorShape,
-  type GatewayRequestHandlerOptions,
-} from "openclaw/plugin-sdk/gateway-runtime";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
-import { MeetingPlatformAdapter } from "openclaw/plugin-sdk/meeting-runtime";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
-import { isRecord, normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   buildGoogleMeetCalendarDayWindow,
   findGoogleMeetCalendarEvent,
   type GoogleMeetCalendarLookupResult,
 } from "./calendar.js";
-import {
-  resolveGoogleMeetGatewayOperationTimeoutMs,
-  type GoogleMeetConfig,
-  type GoogleMeetMode,
-  type GoogleMeetTransport,
-} from "./config.js";
+import type { GoogleMeetConfig } from "./config.js";
 import {
   fetchGoogleMeetArtifacts,
   fetchGoogleMeetAttendance,
   fetchGoogleMeetSpace,
 } from "./meet.js";
-import { GoogleMeetRuntime } from "./runtime.js";
-import { isGoogleMeetBrowserManualActionError } from "./transports/chrome-create.js";
+import { loadGoogleMeetCliModule, resolveMeetingInput } from "./plugin-registration.js";
+import type { GoogleMeetRuntime } from "./runtime.js";
 
 const loadGoogleMeetCreateModule = createLazyRuntimeModule(() => import("./create.js"));
-
-export const loadGoogleMeetCliModule = createLazyRuntimeModule(() => import("./cli.js"));
-
-export function asParamRecord(params: unknown): Record<string, unknown> {
-  return isRecord(params) ? params : {};
-}
-
-export function normalizeTransport(value: unknown): GoogleMeetTransport | undefined {
-  return value === "chrome" || value === "chrome-node" || value === "twilio" ? value : undefined;
-}
-
-export function normalizeMode(value: unknown): GoogleMeetMode | undefined {
-  if (value === "realtime") {
-    return "agent";
-  }
-  return value === "agent" || value === "bidi" || value === "transcribe" ? value : undefined;
-}
-
-export function resolveMeetingInput(config: GoogleMeetConfig, value: unknown): string {
-  const meeting = normalizeOptionalString(value) ?? config.defaults.meeting;
-  if (!meeting) {
-    throw new Error("Meeting input is required");
-  }
-  return meeting;
-}
-
-export function shouldJoinCreatedMeet(raw: Record<string, unknown>): boolean {
-  return raw.join !== false && raw.join !== "false";
-}
-
-const googleMeetToolDeps = {
-  callGatewayFromCli,
-  platform: () => process.platform,
-};
-
-export const testing = {
-  setCallGatewayFromCliForTests(next?: typeof callGatewayFromCli): void {
-    googleMeetToolDeps.callGatewayFromCli = next ?? callGatewayFromCli;
-  },
-  setPlatformForTests(next?: () => NodeJS.Platform): void {
-    googleMeetToolDeps.platform = next ?? (() => process.platform);
-  },
-  isGoogleMeetAgentToolActionUnsupportedOnHost,
-  resolveGoogleMeetGatewayOperationTimeoutMs,
-};
-
-type GoogleMeetGatewayToolAction =
-  | "join"
-  | "create"
-  | "status"
-  | "transcript"
-  | "recover_current_tab"
-  | "setup_status"
-  | "leave"
-  | "end_active_conference"
-  | "speak"
-  | "test_speech"
-  | "test_listen";
-
-function googleMeetGatewayMethodForToolAction(action: GoogleMeetGatewayToolAction): string {
-  switch (action) {
-    case "recover_current_tab":
-      return "googlemeet.recoverCurrentTab";
-    case "setup_status":
-      return "googlemeet.setup";
-    case "test_speech":
-      return "googlemeet.testSpeech";
-    case "test_listen":
-      return "googlemeet.testListen";
-    case "end_active_conference":
-      return "googlemeet.endActiveConference";
-    default:
-      return `googlemeet.${action}`;
-  }
-}
-
-function isGoogleMeetAgentToolActionUnsupportedOnHost(params: {
-  config: GoogleMeetConfig;
-  raw: Record<string, unknown>;
-  platform?: NodeJS.Platform;
-}): boolean {
-  const platform = params.platform ?? googleMeetToolDeps.platform();
-  if (platform === "darwin") {
-    return false;
-  }
-  const action = params.raw.action;
-  if (
-    action !== "join" &&
-    action !== "test_speech" &&
-    !(action === "create" && shouldJoinCreatedMeet(params.raw))
-  ) {
-    return false;
-  }
-  const transport = normalizeTransport(params.raw.transport) ?? params.config.defaultTransport;
-  const mode =
-    action === "test_speech"
-      ? "agent"
-      : (normalizeMode(params.raw.mode) ?? params.config.defaultMode);
-  return transport === "chrome" && MeetingPlatformAdapter.isTalkBackMode(mode);
-}
-
-export function assertGoogleMeetAgentToolActionSupported(params: {
-  config: GoogleMeetConfig;
-  raw: Record<string, unknown>;
-}): void {
-  if (!isGoogleMeetAgentToolActionUnsupportedOnHost(params)) {
-    return;
-  }
-  throw new Error(
-    "Google Meet local Chrome talk-back audio is macOS-only. On this host, use mode: transcribe, transport: twilio, or transport: chrome-node backed by a macOS node.",
-  );
-}
-
-function readGatewayErrorDetails(err: unknown): unknown {
-  if (!err || typeof err !== "object" || !("details" in err)) {
-    return undefined;
-  }
-  return (err as { details?: unknown }).details;
-}
-
-export async function callGoogleMeetGatewayFromTool(params: {
-  config: GoogleMeetConfig;
-  action: GoogleMeetGatewayToolAction;
-  raw: Record<string, unknown>;
-  runtime?: OpenClawPluginApi["runtime"];
-}): Promise<unknown> {
-  try {
-    if (params.runtime) {
-      return await params.runtime.gateway.request(
-        googleMeetGatewayMethodForToolAction(params.action),
-        params.raw,
-        {
-          timeoutMs: resolveGoogleMeetGatewayOperationTimeoutMs(params.config),
-          scopes: ["operator.admin"],
-        },
-      );
-    }
-    // Standalone agent workers connect as this bundled plugin, not as the
-    // model session; its Gateway methods remain the only exposed actions.
-    return await googleMeetToolDeps.callGatewayFromCli(
-      googleMeetGatewayMethodForToolAction(params.action),
-      {
-        json: true,
-        timeout: String(resolveGoogleMeetGatewayOperationTimeoutMs(params.config)),
-      },
-      params.raw,
-      { progress: false, scopes: ["operator.admin"] },
-    );
-  } catch (err) {
-    const details = readGatewayErrorDetails(err);
-    if (details && typeof details === "object") {
-      return details;
-    }
-    throw err;
-  }
-}
-
-export function keepTrustedToolAgentId(
-  raw: Record<string, unknown>,
-  client: GatewayRequestHandlerOptions["client"],
-): Record<string, unknown> {
-  const { agentId: rawAgentId, ...rest } = raw;
-  if (client?.internal?.pluginRuntimeOwnerId !== "google-meet") {
-    return rest;
-  }
-  const agentId = normalizeOptionalString(rawAgentId);
-  return agentId ? { ...rest, agentId } : rest;
-}
 
 export async function createMeetFromParams(params: {
   config: GoogleMeetConfig;
@@ -395,48 +214,10 @@ export async function exportGoogleMeetBundleFromParams(
     tokenSource,
   };
 }
-export function createGoogleMeetRuntimeAccessor(params: {
-  api: OpenClawPluginApi;
-  config: GoogleMeetConfig;
-}): () => Promise<GoogleMeetRuntime> {
-  let runtime: GoogleMeetRuntime | null = null;
-  return async () => {
-    if (!params.config.enabled) {
-      throw new Error("Google Meet plugin disabled in plugin config");
-    }
-    if (!runtime) {
-      runtime = new GoogleMeetRuntime({
-        config: params.config,
-        fullConfig: params.api.config,
-        runtime: params.api.runtime,
-        logger: params.api.logger,
-      });
-    }
-    return runtime;
-  };
-}
 
-export function formatGoogleMeetGatewayError(err: unknown) {
-  return isGoogleMeetBrowserManualActionError(err)
-    ? err.payload
-    : { error: formatErrorMessage(err) };
-}
-
-export function sendGoogleMeetGatewayError(
-  respond: GatewayRequestHandlerOptions["respond"],
-  err: unknown,
-  code: Parameters<typeof errorShape>[0] = ErrorCodes.UNAVAILABLE,
-): void {
-  const payload = formatGoogleMeetGatewayError(err);
-  respond(
-    false,
-    payload,
-    errorShape(
-      code,
-      typeof payload.error === "string" ? payload.error : "Google Meet request failed",
-      {
-        details: payload,
-      },
-    ),
-  );
-}
+export { buildGoogleMeetCalendarDayWindow, listGoogleMeetCalendarEvents } from "./calendar.js";
+export {
+  buildGoogleMeetPreflightReport,
+  endGoogleMeetActiveConference,
+  fetchLatestGoogleMeetConferenceRecord,
+} from "./meet.js";

--- a/extensions/google-meet/src/plugin-registration.ts
+++ b/extensions/google-meet/src/plugin-registration.ts
@@ -1,0 +1,281 @@
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import {
+  callGatewayFromCli,
+  ErrorCodes,
+  errorShape,
+  type GatewayRequestHandlerOptions,
+} from "openclaw/plugin-sdk/gateway-runtime";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
+import type {
+  OpenClawPluginApi,
+  OpenClawPluginNodeInvokePolicy,
+} from "openclaw/plugin-sdk/plugin-entry";
+import { isRecord, normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { isGoogleMeetBrowserManualActionError } from "./browser-manual-action-error.js";
+import {
+  resolveGoogleMeetGatewayOperationTimeoutMs,
+  type GoogleMeetConfig,
+  type GoogleMeetMode,
+  type GoogleMeetTransport,
+} from "./config.js";
+import type { GoogleMeetRuntime } from "./runtime.js";
+import { GOOGLE_MEET_NODE_COMMAND } from "./transports/google-meet-platform-constants.js";
+
+export const loadGoogleMeetPluginHelpers = createLazyRuntimeModule(
+  () => import("./plugin-helpers.js"),
+);
+export const loadGoogleMeetCliModule = createLazyRuntimeModule(() => import("./cli.js"));
+export const loadGoogleMeetNodeHostModule = createLazyRuntimeModule(() => import("./node-host.js"));
+
+const loadGoogleMeetRuntimeModule = createLazyRuntimeModule(() => import("./runtime.js"));
+const loadGoogleMeetNodeInvokePolicyModule = createLazyRuntimeModule(
+  () => import("./node-invoke-policy.js"),
+);
+
+type LoadGoogleMeetNodeInvokePolicy = (
+  config: GoogleMeetConfig,
+) => Promise<OpenClawPluginNodeInvokePolicy>;
+
+const loadGoogleMeetNodeInvokePolicy: LoadGoogleMeetNodeInvokePolicy = async (config) =>
+  (await loadGoogleMeetNodeInvokePolicyModule()).createGoogleMeetChromeNodeInvokePolicy(config);
+
+export function asParamRecord(params: unknown): Record<string, unknown> {
+  return isRecord(params) ? params : {};
+}
+
+export function normalizeTransport(value: unknown): GoogleMeetTransport | undefined {
+  return value === "chrome" || value === "chrome-node" || value === "twilio" ? value : undefined;
+}
+
+export function normalizeMode(value: unknown): GoogleMeetMode | undefined {
+  if (value === "realtime") {
+    return "agent";
+  }
+  return value === "agent" || value === "bidi" || value === "transcribe" ? value : undefined;
+}
+
+export function resolveMeetingInput(config: GoogleMeetConfig, value: unknown): string {
+  const meeting = normalizeOptionalString(value) ?? config.defaults.meeting;
+  if (!meeting) {
+    throw new Error("Meeting input is required");
+  }
+  return meeting;
+}
+
+export function shouldJoinCreatedMeet(raw: Record<string, unknown>): boolean {
+  return raw.join !== false && raw.join !== "false";
+}
+
+const googleMeetToolDeps = {
+  callGatewayFromCli,
+  platform: () => process.platform,
+};
+
+type GoogleMeetGatewayToolAction =
+  | "join"
+  | "create"
+  | "status"
+  | "transcript"
+  | "recover_current_tab"
+  | "setup_status"
+  | "leave"
+  | "end_active_conference"
+  | "speak"
+  | "test_speech"
+  | "test_listen";
+
+function googleMeetGatewayMethodForToolAction(action: GoogleMeetGatewayToolAction): string {
+  switch (action) {
+    case "recover_current_tab":
+      return "googlemeet.recoverCurrentTab";
+    case "setup_status":
+      return "googlemeet.setup";
+    case "test_speech":
+      return "googlemeet.testSpeech";
+    case "test_listen":
+      return "googlemeet.testListen";
+    case "end_active_conference":
+      return "googlemeet.endActiveConference";
+    default:
+      return `googlemeet.${action}`;
+  }
+}
+
+function isGoogleMeetAgentToolActionUnsupportedOnHost(params: {
+  config: GoogleMeetConfig;
+  raw: Record<string, unknown>;
+  platform?: NodeJS.Platform;
+}): boolean {
+  const platform = params.platform ?? googleMeetToolDeps.platform();
+  if (platform === "darwin") {
+    return false;
+  }
+  const action = params.raw.action;
+  if (
+    action !== "join" &&
+    action !== "test_speech" &&
+    !(action === "create" && shouldJoinCreatedMeet(params.raw))
+  ) {
+    return false;
+  }
+  const transport = normalizeTransport(params.raw.transport) ?? params.config.defaultTransport;
+  const mode =
+    action === "test_speech"
+      ? "agent"
+      : (normalizeMode(params.raw.mode) ?? params.config.defaultMode);
+  return transport === "chrome" && (mode === "agent" || mode === "bidi");
+}
+
+export function assertGoogleMeetAgentToolActionSupported(params: {
+  config: GoogleMeetConfig;
+  raw: Record<string, unknown>;
+}): void {
+  if (!isGoogleMeetAgentToolActionUnsupportedOnHost(params)) {
+    return;
+  }
+  throw new Error(
+    "Google Meet local Chrome talk-back audio is macOS-only. On this host, use mode: transcribe, transport: twilio, or transport: chrome-node backed by a macOS node.",
+  );
+}
+
+function readGatewayErrorDetails(err: unknown): unknown {
+  if (!err || typeof err !== "object" || !("details" in err)) {
+    return undefined;
+  }
+  return (err as { details?: unknown }).details;
+}
+
+export async function callGoogleMeetGatewayFromTool(params: {
+  config: GoogleMeetConfig;
+  action: GoogleMeetGatewayToolAction;
+  raw: Record<string, unknown>;
+  runtime?: OpenClawPluginApi["runtime"];
+}): Promise<unknown> {
+  try {
+    if (params.runtime) {
+      return await params.runtime.gateway.request(
+        googleMeetGatewayMethodForToolAction(params.action),
+        params.raw,
+        {
+          timeoutMs: resolveGoogleMeetGatewayOperationTimeoutMs(params.config),
+          scopes: ["operator.admin"],
+        },
+      );
+    }
+    // Standalone agent workers connect as this bundled plugin, not as the
+    // model session; its Gateway methods remain the only exposed actions.
+    return await googleMeetToolDeps.callGatewayFromCli(
+      googleMeetGatewayMethodForToolAction(params.action),
+      {
+        json: true,
+        timeout: String(resolveGoogleMeetGatewayOperationTimeoutMs(params.config)),
+      },
+      params.raw,
+      { progress: false, scopes: ["operator.admin"] },
+    );
+  } catch (err) {
+    const details = readGatewayErrorDetails(err);
+    if (details && typeof details === "object") {
+      return details;
+    }
+    throw err;
+  }
+}
+
+export function keepTrustedToolAgentId(
+  raw: Record<string, unknown>,
+  client: GatewayRequestHandlerOptions["client"],
+): Record<string, unknown> {
+  const { agentId: rawAgentId, ...rest } = raw;
+  if (client?.internal?.pluginRuntimeOwnerId !== "google-meet") {
+    return rest;
+  }
+  const agentId = normalizeOptionalString(rawAgentId);
+  return agentId ? { ...rest, agentId } : rest;
+}
+
+export function createGoogleMeetRuntimeAccessor(params: {
+  api: OpenClawPluginApi;
+  config: GoogleMeetConfig;
+}): () => Promise<GoogleMeetRuntime> {
+  let runtimePromise: Promise<GoogleMeetRuntime> | undefined;
+  return async () => {
+    if (!params.config.enabled) {
+      throw new Error("Google Meet plugin disabled in plugin config");
+    }
+    const runtime =
+      runtimePromise ??
+      (runtimePromise = loadGoogleMeetRuntimeModule().then(
+        ({ GoogleMeetRuntime: Runtime }) =>
+          new Runtime({
+            config: params.config,
+            fullConfig: params.api.config,
+            runtime: params.api.runtime,
+            logger: params.api.logger,
+          }),
+      ));
+    return await runtime;
+  };
+}
+
+export function createLazyGoogleMeetNodeInvokePolicy(
+  config: GoogleMeetConfig,
+  loadPolicy: LoadGoogleMeetNodeInvokePolicy = loadGoogleMeetNodeInvokePolicy,
+): OpenClawPluginNodeInvokePolicy {
+  let policyPromise: Promise<OpenClawPluginNodeInvokePolicy> | undefined;
+  return {
+    commands: [GOOGLE_MEET_NODE_COMMAND],
+    dangerous: true,
+    async handle(ctx) {
+      let policy: OpenClawPluginNodeInvokePolicy;
+      try {
+        policyPromise ??= loadPolicy(config);
+        policy = await policyPromise;
+      } catch (error) {
+        return {
+          ok: false,
+          code: "PLUGIN_POLICY_UNAVAILABLE",
+          message: `google-meet PLUGIN_POLICY_UNAVAILABLE: node.invoke policy unavailable: ${formatErrorMessage(error)}`,
+          unavailable: true,
+        };
+      }
+      return await policy.handle(ctx);
+    },
+  };
+}
+
+export function formatGoogleMeetGatewayError(err: unknown) {
+  return isGoogleMeetBrowserManualActionError(err)
+    ? err.payload
+    : { error: formatErrorMessage(err) };
+}
+
+export function sendGoogleMeetGatewayError(
+  respond: GatewayRequestHandlerOptions["respond"],
+  err: unknown,
+  code: Parameters<typeof errorShape>[0] = ErrorCodes.UNAVAILABLE,
+): void {
+  const payload = formatGoogleMeetGatewayError(err);
+  respond(
+    false,
+    payload,
+    errorShape(
+      code,
+      typeof payload.error === "string" ? payload.error : "Google Meet request failed",
+      {
+        details: payload,
+      },
+    ),
+  );
+}
+
+export const testing = {
+  setCallGatewayFromCliForTests(next?: typeof callGatewayFromCli): void {
+    googleMeetToolDeps.callGatewayFromCli = next ?? callGatewayFromCli;
+  },
+  setPlatformForTests(next?: () => NodeJS.Platform): void {
+    googleMeetToolDeps.platform = next ?? (() => process.platform);
+  },
+  isGoogleMeetAgentToolActionUnsupportedOnHost,
+  resolveGoogleMeetGatewayOperationTimeoutMs,
+};

--- a/extensions/google-meet/src/plugin-registration.ts
+++ b/extensions/google-meet/src/plugin-registration.ts
@@ -1,10 +1,5 @@
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import {
-  callGatewayFromCli,
-  ErrorCodes,
-  errorShape,
-  type GatewayRequestHandlerOptions,
-} from "openclaw/plugin-sdk/gateway-runtime";
+import type { GatewayRequestHandlerOptions } from "openclaw/plugin-sdk/gateway-runtime";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type {
   OpenClawPluginApi,
@@ -31,6 +26,16 @@ const loadGoogleMeetRuntimeModule = createLazyRuntimeModule(() => import("./runt
 const loadGoogleMeetNodeInvokePolicyModule = createLazyRuntimeModule(
   () => import("./node-invoke-policy.js"),
 );
+const loadGoogleMeetGatewayRuntimeModule = createLazyRuntimeModule(
+  () => import("openclaw/plugin-sdk/gateway-runtime"),
+);
+
+type GoogleMeetGatewayRuntimeModule = Awaited<
+  ReturnType<typeof loadGoogleMeetGatewayRuntimeModule>
+>;
+type CallGatewayFromCli = GoogleMeetGatewayRuntimeModule["callGatewayFromCli"];
+type GoogleMeetGatewayError = NonNullable<Parameters<GatewayRequestHandlerOptions["respond"]>[2]>;
+type GoogleMeetGatewayErrorCode = GoogleMeetGatewayError["code"];
 
 type LoadGoogleMeetNodeInvokePolicy = (
   config: GoogleMeetConfig,
@@ -66,8 +71,10 @@ export function shouldJoinCreatedMeet(raw: Record<string, unknown>): boolean {
   return raw.join !== false && raw.join !== "false";
 }
 
-const googleMeetToolDeps = {
-  callGatewayFromCli,
+const googleMeetToolDeps: {
+  callGatewayFromCli?: CallGatewayFromCli;
+  platform: () => NodeJS.Platform;
+} = {
   platform: () => process.platform,
 };
 
@@ -164,7 +171,10 @@ export async function callGoogleMeetGatewayFromTool(params: {
     }
     // Standalone agent workers connect as this bundled plugin, not as the
     // model session; its Gateway methods remain the only exposed actions.
-    return await googleMeetToolDeps.callGatewayFromCli(
+    const callGatewayFromCli =
+      googleMeetToolDeps.callGatewayFromCli ??
+      (await loadGoogleMeetGatewayRuntimeModule()).callGatewayFromCli;
+    return await callGatewayFromCli(
       googleMeetGatewayMethodForToolAction(params.action),
       {
         json: true,
@@ -253,25 +263,19 @@ export function formatGoogleMeetGatewayError(err: unknown) {
 export function sendGoogleMeetGatewayError(
   respond: GatewayRequestHandlerOptions["respond"],
   err: unknown,
-  code: Parameters<typeof errorShape>[0] = ErrorCodes.UNAVAILABLE,
+  code: GoogleMeetGatewayErrorCode = "UNAVAILABLE",
 ): void {
   const payload = formatGoogleMeetGatewayError(err);
-  respond(
-    false,
-    payload,
-    errorShape(
-      code,
-      typeof payload.error === "string" ? payload.error : "Google Meet request failed",
-      {
-        details: payload,
-      },
-    ),
-  );
+  respond(false, payload, {
+    code,
+    message: typeof payload.error === "string" ? payload.error : "Google Meet request failed",
+    details: payload,
+  });
 }
 
 export const testing = {
-  setCallGatewayFromCliForTests(next?: typeof callGatewayFromCli): void {
-    googleMeetToolDeps.callGatewayFromCli = next ?? callGatewayFromCli;
+  setCallGatewayFromCliForTests(next?: CallGatewayFromCli): void {
+    googleMeetToolDeps.callGatewayFromCli = next;
   },
   setPlatformForTests(next?: () => NodeJS.Platform): void {
     googleMeetToolDeps.platform = next ?? (() => process.platform);

--- a/extensions/google-meet/src/transports/chrome-create.ts
+++ b/extensions/google-meet/src/transports/chrome-create.ts
@@ -1,6 +1,7 @@
 // Google Meet plugin module implements chrome create behavior.
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import { sleep } from "openclaw/plugin-sdk/runtime-env";
+import { GoogleMeetBrowserManualActionError } from "../browser-manual-action-error.js";
 import type { GoogleMeetConfig } from "../config.js";
 import {
   asBrowserTabs,
@@ -39,39 +40,6 @@ type GoogleMeetBrowserCreateResult = {
   notes?: string[];
   source: "browser";
 };
-
-type GoogleMeetBrowserManualAction = {
-  source: "browser";
-  error: string;
-  manualAction: GoogleMeetBrowserManualActionState;
-  browser: {
-    nodeId: string;
-    targetId?: string;
-    browserUrl?: string;
-    browserTitle?: string;
-    notes?: string[];
-  };
-};
-
-class GoogleMeetBrowserManualActionError extends Error {
-  readonly payload: GoogleMeetBrowserManualAction;
-
-  constructor(payload: Omit<GoogleMeetBrowserManualAction, "source" | "error">) {
-    super(`${payload.manualAction.reason}: ${payload.manualAction.message}`);
-    this.name = "GoogleMeetBrowserManualActionError";
-    this.payload = {
-      source: "browser",
-      error: this.message,
-      ...payload,
-    };
-  }
-}
-
-export function isGoogleMeetBrowserManualActionError(
-  error: unknown,
-): error is GoogleMeetBrowserManualActionError {
-  return error instanceof GoogleMeetBrowserManualActionError;
-}
 
 function formatBrowserAutomationError(error: unknown): string {
   if (error instanceof Error) {

--- a/extensions/memory-core/index.test.ts
+++ b/extensions/memory-core/index.test.ts
@@ -222,10 +222,67 @@ describe("memory-core plugin runtime registration", () => {
     await runtime.getMemorySearchManager({ cfg, agentId: "main" });
 
     expect(createMemoryRuntimeMock).toHaveBeenCalledWith({
-      acquireLocalService: hostRuntime.llm.acquireLocalService,
+      acquireLocalService: expect.any(Function),
       openKeyedStore: expect.any(Function),
       withLease: expect.any(Function),
     });
+  });
+
+  it("defers nested host runtime access until the injected operation runs", async () => {
+    const acquireLocalService = vi.fn(async () => undefined);
+    const openKeyedStore = vi.fn(() => ({}));
+    const withLease = vi.fn(async (_options, run) => await run({}));
+    const llmGetter = vi.fn(() => ({ acquireLocalService }));
+    const stateGetter = vi.fn(() => ({ openKeyedStore, withLease }));
+    const host = Object.defineProperties(
+      {},
+      {
+        llm: { configurable: true, enumerable: true, get: llmGetter },
+        state: { configurable: true, enumerable: true, get: stateGetter },
+      },
+    ) as OpenClawPluginApi["runtime"];
+    let runtime: MemoryPluginRuntime | undefined;
+
+    plugin.register(
+      createTestPluginApi({
+        runtime: host,
+        registerMemoryCapability(capability) {
+          runtime = capability.runtime;
+        },
+      }),
+    );
+
+    expect(llmGetter).not.toHaveBeenCalled();
+    expect(stateGetter).not.toHaveBeenCalled();
+    await runtime?.getMemorySearchManager({ cfg: {}, agentId: "main" });
+    const injectedHost = createMemoryRuntimeMock.mock.calls.at(-1)?.[0];
+    if (
+      !injectedHost?.acquireLocalService ||
+      !injectedHost.openKeyedStore ||
+      !injectedHost.withLease
+    ) {
+      throw new Error("expected memory-core host operations");
+    }
+
+    const target = { providerId: "local", baseUrl: "http://127.0.0.1:11434" };
+    await injectedHost.acquireLocalService(target);
+    const storeOptions = { namespace: "lazy-host", maxEntries: 1 };
+    injectedHost.openKeyedStore(storeOptions);
+    const run = vi.fn(async () => "leased");
+    const leaseOptions = {
+      namespace: "lazy-host",
+      key: "manager",
+      database: { scope: "shared" as const },
+      leaseMs: 1_000,
+      waitMs: 1_000,
+    };
+    await injectedHost.withLease(leaseOptions, run as never);
+
+    expect(llmGetter).toHaveBeenCalledOnce();
+    expect(acquireLocalService).toHaveBeenCalledWith(target);
+    expect(stateGetter).toHaveBeenCalledTimes(2);
+    expect(openKeyedStore).toHaveBeenCalledWith(storeOptions);
+    expect(withLease).toHaveBeenCalledWith(leaseOptions, run);
   });
 
   it("forwards search-hit authorization through the registered memory runtime", async () => {
@@ -259,7 +316,7 @@ describe("memory-core plugin runtime registration", () => {
       hits,
     });
     expect(createMemoryRuntimeMock).toHaveBeenCalledWith({
-      acquireLocalService: hostRuntime.llm.acquireLocalService,
+      acquireLocalService: expect.any(Function),
       openKeyedStore: expect.any(Function),
       withLease: expect.any(Function),
     });

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -278,10 +278,11 @@ export default definePluginEntry({
   description: "File-backed memory search tools and CLI",
   kind: "memory",
   register(api) {
-    const acquireLocalService = api.runtime.llm?.acquireLocalService;
+    const acquireLocalService: MemoryCoreAcquireLocalService = (...args) =>
+      api.runtime.llm.acquireLocalService(...args);
     const openKeyedStore = <T>(options: OpenKeyedStoreOptions) =>
       api.runtime.state.openKeyedStore<T>(options);
-    const withLease = api.runtime.state.withLease.bind(api.runtime.state);
+    const withLease: PluginStateLeaseRunner = (...args) => api.runtime.state.withLease(...args);
     const host = { acquireLocalService, openKeyedStore, withLease } satisfies MemoryCoreRuntimeHost;
     configureMemoryCoreDreamingState(openKeyedStore);
     const memoryRuntime = createLazyMemoryRuntime(host);

--- a/src/gateway/server-import-boundary.test.ts
+++ b/src/gateway/server-import-boundary.test.ts
@@ -63,6 +63,9 @@ describe("gateway startup import boundaries", () => {
       /import\s+\{[^}]*attachGatewayWsMessageHandler[^}]*\}\s+from "\.\/ws-connection\/message-handler\.js"/s,
     );
     expect(wsConnection).toContain('import("./ws-connection/message-handler.js")');
+    expect(wsConnection).not.toContain('from "../talk-realtime-relay.js"');
+    expect(wsConnection).not.toContain('from "../talk-transcription-relay.js"');
+    expect(wsConnection).toContain('from "../talk-session-registry.js"');
     expect(readSource("src/gateway/server-aux-handlers.ts")).not.toMatch(
       /import\s+\{[^}]*create(?:Exec|Plugin|Secrets)[^}]*\}\s+from "\.\/server-methods\//s,
     );

--- a/src/gateway/server/ws-connection.test.ts
+++ b/src/gateway/server/ws-connection.test.ts
@@ -15,16 +15,14 @@ const {
   attachGatewayWsMessageHandlerMock,
   attachWorkerWsMessageHandlerMock,
   broadcastPresenceSnapshotMock,
-  closeTalkRealtimeRelaySessionsForConnectionMock,
-  closeTalkTranscriptionRelaySessionsForConnectionMock,
+  cleanupTalkConnectionMock,
   touchPresenceMock,
   upsertPresenceMock,
 } = vi.hoisted(() => ({
   attachGatewayWsMessageHandlerMock: vi.fn(),
   attachWorkerWsMessageHandlerMock: vi.fn((_params: unknown) => vi.fn()),
   broadcastPresenceSnapshotMock: vi.fn(),
-  closeTalkRealtimeRelaySessionsForConnectionMock: vi.fn(),
-  closeTalkTranscriptionRelaySessionsForConnectionMock: vi.fn(),
+  cleanupTalkConnectionMock: vi.fn(),
   touchPresenceMock: vi.fn(),
   upsertPresenceMock: vi.fn(),
 }));
@@ -42,12 +40,8 @@ vi.mock("../../infra/system-presence.js", () => ({
 vi.mock("./presence-events.js", () => ({
   broadcastPresenceSnapshot: broadcastPresenceSnapshotMock,
 }));
-vi.mock("../talk-realtime-relay.js", () => ({
-  closeTalkRealtimeRelaySessionsForConnection: closeTalkRealtimeRelaySessionsForConnectionMock,
-}));
-vi.mock("../talk-transcription-relay.js", () => ({
-  closeTalkTranscriptionRelaySessionsForConnection:
-    closeTalkTranscriptionRelaySessionsForConnectionMock,
+vi.mock("../talk-session-registry.js", () => ({
+  cleanupTalkConnection: cleanupTalkConnectionMock,
 }));
 
 import { attachGatewayWsConnectionHandler } from "./ws-connection.js";
@@ -102,8 +96,7 @@ describe("attachGatewayWsConnectionHandler", () => {
     attachGatewayWsMessageHandlerMock.mockReset();
     attachWorkerWsMessageHandlerMock.mockClear();
     broadcastPresenceSnapshotMock.mockReset();
-    closeTalkRealtimeRelaySessionsForConnectionMock.mockReset();
-    closeTalkTranscriptionRelaySessionsForConnectionMock.mockReset();
+    cleanupTalkConnectionMock.mockReset();
     touchPresenceMock.mockReset();
     upsertPresenceMock.mockReset();
   });
@@ -275,7 +268,7 @@ describe("attachGatewayWsConnectionHandler", () => {
     expect(socket.ping).toHaveBeenCalledOnce();
   });
 
-  it("releases connection-owned Talk relays when a gateway connection closes", async () => {
+  it("runs connection-owned Talk cleanup when a gateway connection closes", async () => {
     const { passed, socket } = await connectTestWs();
     const handlerParams = passed as {
       connId: string;
@@ -292,13 +285,10 @@ describe("attachGatewayWsConnectionHandler", () => {
 
     socket.emit("close", 1000, Buffer.from("done"));
 
-    expect(closeTalkRealtimeRelaySessionsForConnectionMock).toHaveBeenCalledOnce();
-    expect(closeTalkRealtimeRelaySessionsForConnectionMock).toHaveBeenCalledWith(
+    expect(cleanupTalkConnectionMock).toHaveBeenCalledOnce();
+    expect(cleanupTalkConnectionMock).toHaveBeenCalledWith(
       handlerParams.connId,
-    );
-    expect(closeTalkTranscriptionRelaySessionsForConnectionMock).toHaveBeenCalledOnce();
-    expect(closeTalkTranscriptionRelaySessionsForConnectionMock).toHaveBeenCalledWith(
-      handlerParams.connId,
+      expect.objectContaining({ warn: expect.any(Function) }),
     );
   });
 

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -28,8 +28,7 @@ import {
 } from "../server-constants.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "../server-methods/types.js";
 import { formatError } from "../server-utils.js";
-import { closeTalkRealtimeRelaySessionsForConnection } from "../talk-realtime-relay.js";
-import { closeTalkTranscriptionRelaySessionsForConnection } from "../talk-transcription-relay.js";
+import { cleanupTalkConnection } from "../talk-session-registry.js";
 import { formatForLog, logWs } from "../ws-log.js";
 import { getHealthVersion, incrementPresenceVersion } from "./health-state.js";
 import type { PreauthConnectionBudget } from "./preauth-connection-budget.js";
@@ -564,8 +563,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       }
       if (connectionKind === "gateway") {
         const context = buildRequestContext();
-        closeTalkRealtimeRelaySessionsForConnection(connId);
-        closeTalkTranscriptionRelaySessionsForConnection(connId);
+        cleanupTalkConnection(connId, logGateway);
         context.unsubscribeAllSessionEvents(connId);
         // Detach (or, with a zero grace period, kill) any PTY shells this
         // connection owned; detached sessions stay reattachable via

--- a/src/gateway/talk-realtime-relay-session-create.ts
+++ b/src/gateway/talk-realtime-relay-session-create.ts
@@ -33,6 +33,7 @@ import {
   abortRelayAgentRuns,
   cancelTalkRealtimeRelayProviderToolCall,
   closeRelaySession,
+  closeTalkRealtimeRelaySessionsForConnection,
   enforceRelaySessionLimits,
   pruneInactiveRelayAgentRuns,
   registerTalkRealtimeRelayAgentRun,
@@ -61,7 +62,10 @@ import {
   closeRelayVoiceSession,
   enqueueRelayVoiceTranscript,
 } from "./talk-realtime-relay-voice.js";
-import { forgetUnifiedTalkSession } from "./talk-session-registry.js";
+import {
+  forgetUnifiedTalkSession,
+  registerTalkConnectionCleanup,
+} from "./talk-session-registry.js";
 
 function isRelayAssistantEchoTranscript(session: RelaySession | undefined, text: string): boolean {
   return session?.harness.isLikelyAssistantEchoTranscript(text) ?? false;
@@ -602,6 +606,9 @@ export function createTalkRealtimeRelaySession(
   relayRef.current = relay;
   relay.cleanupTimer.unref?.();
   relaySessions.set(relaySessionId, relay);
+  registerTalkConnectionCleanup(params.connId, "realtime-relay", () => {
+    closeTalkRealtimeRelaySessionsForConnection(params.connId);
+  });
   bridge.connect().catch((error: unknown) => {
     const active = relaySessions.get(relaySessionId);
     if (active !== relay) {

--- a/src/gateway/talk-realtime-relay.test.ts
+++ b/src/gateway/talk-realtime-relay.test.ts
@@ -28,7 +28,6 @@ import { MAX_RELAY_TOOL_CALL_IDENTITIES } from "./talk-realtime-relay-tool-call-
 import {
   acknowledgeTalkRealtimeRelayMark,
   cancelTalkRealtimeRelayTurn,
-  closeTalkRealtimeRelaySessionsForConnection,
   createTalkRealtimeRelaySession as createTalkRealtimeRelaySessionRaw,
   ensureTalkRealtimeRelayVoiceSession,
   flushTalkRealtimeRelayVoiceWrites,
@@ -38,6 +37,7 @@ import {
   stopTalkRealtimeRelaySession as stopTalkRealtimeRelaySessionRaw,
   submitTalkRealtimeRelayToolResult,
 } from "./talk-realtime-relay.js";
+import { cleanupTalkConnection } from "./talk-session-registry.js";
 
 const activeRelaySessions = new Map<string, string>();
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -168,8 +168,7 @@ describe("talk realtime gateway relay", () => {
         throw new Error("provider close failed");
       });
 
-      expect(() => closeTalkRealtimeRelaySessionsForConnection("conn-owner")).not.toThrow();
-      closeTalkRealtimeRelaySessionsForConnection("conn-owner");
+      expect(() => cleanupTalkConnection("conn-owner", logGateway)).not.toThrow();
       await Promise.resolve();
       await Promise.resolve();
 
@@ -252,7 +251,7 @@ describe("talk realtime gateway relay", () => {
         relaySessionId: unrelated.relaySessionId,
         connId: "conn-other",
       });
-      closeTalkRealtimeRelaySessionsForConnection("conn-other");
+      cleanupTalkConnection("conn-other", logGateway);
       expect(bridgeCloses[2]).toHaveBeenCalledOnce();
     } finally {
       clientVoiceSessionTesting.reset();

--- a/src/gateway/talk-realtime-relay.ts
+++ b/src/gateway/talk-realtime-relay.ts
@@ -4,7 +4,6 @@ export { createTalkRealtimeRelaySession } from "./talk-realtime-relay-session-cr
 export {
   acknowledgeTalkRealtimeRelayMark,
   cancelTalkRealtimeRelayTurn,
-  closeTalkRealtimeRelaySessionsForConnection,
   ensureTalkRealtimeRelayVoiceSession,
   flushTalkRealtimeRelayVoiceWrites,
   registerTalkRealtimeRelayAgentRun,

--- a/src/gateway/talk-session-registry.test.ts
+++ b/src/gateway/talk-session-registry.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+import { cleanupTalkConnection, registerTalkConnectionCleanup } from "./talk-session-registry.js";
+
+describe("Talk connection cleanup registry", () => {
+  it("keeps one cleanup per relay kind and forgets the connection before running them", () => {
+    const replacedRealtimeCleanup = vi.fn();
+    const transcriptionCleanup = vi.fn();
+    const log = { warn: vi.fn() };
+    const realtimeCleanup = vi.fn(() => {
+      cleanupTalkConnection("conn-dedupe", log);
+    });
+
+    registerTalkConnectionCleanup("conn-dedupe", "realtime-relay", replacedRealtimeCleanup);
+    registerTalkConnectionCleanup("conn-dedupe", "realtime-relay", realtimeCleanup);
+    registerTalkConnectionCleanup("conn-dedupe", "transcription-relay", transcriptionCleanup);
+
+    cleanupTalkConnection("conn-dedupe", log);
+    cleanupTalkConnection("conn-dedupe", log);
+
+    expect(replacedRealtimeCleanup).not.toHaveBeenCalled();
+    expect(realtimeCleanup).toHaveBeenCalledOnce();
+    expect(transcriptionCleanup).toHaveBeenCalledOnce();
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("continues cleanup after one relay owner throws", () => {
+    const cleanupError = new Error("realtime cleanup failed");
+    const transcriptionCleanup = vi.fn();
+    const log = { warn: vi.fn() };
+
+    registerTalkConnectionCleanup("conn-error", "realtime-relay", () => {
+      throw cleanupError;
+    });
+    registerTalkConnectionCleanup("conn-error", "transcription-relay", transcriptionCleanup);
+
+    cleanupTalkConnection("conn-error", log);
+
+    expect(log.warn).toHaveBeenCalledWith(
+      "failed to run realtime-relay Talk cleanup after connection disconnect: realtime cleanup failed",
+    );
+    expect(transcriptionCleanup).toHaveBeenCalledOnce();
+  });
+});

--- a/src/gateway/talk-session-registry.ts
+++ b/src/gateway/talk-session-registry.ts
@@ -3,6 +3,10 @@
  * `sessionId` values to the concrete relay or managed-room backend.
  */
 import { resolveGlobalMap } from "../shared/global-singleton.js";
+import { formatError } from "./server-utils.js";
+
+type TalkConnectionCleanupKind = "realtime-relay" | "transcription-relay";
+
 export type UnifiedTalkSessionRecord =
   | {
       kind: "realtime-relay";
@@ -25,6 +29,47 @@ const unifiedTalkSessions = resolveGlobalMap<string, UnifiedTalkSessionRecord>(
   Symbol.for("openclaw.unifiedTalkSessions"),
   "close-and-restart",
 );
+const talkConnectionCleanups = resolveGlobalMap<string, Map<TalkConnectionCleanupKind, () => void>>(
+  Symbol.for("openclaw.talkConnectionCleanups"),
+  "close-and-restart",
+);
+
+/**
+ * Keeps one owner cleanup per relay kind until the connection closes.
+ * Replacing by kind stays bounded while the owner cleanup scans all live sessions.
+ */
+export function registerTalkConnectionCleanup(
+  connId: string,
+  kind: TalkConnectionCleanupKind,
+  cleanup: () => void,
+): void {
+  const cleanups =
+    talkConnectionCleanups.get(connId) ?? new Map<TalkConnectionCleanupKind, () => void>();
+  cleanups.set(kind, cleanup);
+  talkConnectionCleanups.set(connId, cleanups);
+}
+
+/** Runs and forgets every Talk cleanup owned by a disconnected gateway connection. */
+export function cleanupTalkConnection(
+  connId: string,
+  log: { warn: (message: string) => void },
+): void {
+  const cleanups = talkConnectionCleanups.get(connId);
+  if (!cleanups) {
+    return;
+  }
+  // Delete first so cleanup failures or re-entrancy cannot retain stale connection owners.
+  talkConnectionCleanups.delete(connId);
+  for (const [kind, cleanup] of cleanups) {
+    try {
+      cleanup();
+    } catch (error) {
+      log.warn(
+        `failed to run ${kind} Talk cleanup after connection disconnect: ${formatError(error)}`,
+      );
+    }
+  }
+}
 
 /** Associates a public Talk session id with its concrete gateway backend. */
 export function rememberUnifiedTalkSession(

--- a/src/gateway/talk-transcription-relay.test.ts
+++ b/src/gateway/talk-transcription-relay.test.ts
@@ -7,10 +7,13 @@ import type { RealtimeTranscriptionSessionCreateRequest } from "../realtime-tran
 import { createGatewayBroadcaster } from "./server-broadcast.js";
 import { MAX_BUFFERED_BYTES } from "./server-constants.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
-import { getUnifiedTalkSession, rememberUnifiedTalkSession } from "./talk-session-registry.js";
+import {
+  cleanupTalkConnection,
+  getUnifiedTalkSession,
+  rememberUnifiedTalkSession,
+} from "./talk-session-registry.js";
 import {
   cancelTalkTranscriptionRelayTurn,
-  closeTalkTranscriptionRelaySessionsForConnection,
   createTalkTranscriptionRelaySession,
   sendTalkTranscriptionRelayAudio,
   stopTalkTranscriptionRelaySession,
@@ -72,7 +75,7 @@ async function createStartedRelaySession(
   onRequest?: (req: RealtimeTranscriptionSessionCreateRequest) => void,
 ) {
   const provider = createTranscriptionProvider(sttSession, onRequest);
-  const { context, events } = createBroadcastContext();
+  const { context, events, logGateway } = createBroadcastContext();
   const session = createTalkTranscriptionRelaySession({
     context,
     connId: "conn-1",
@@ -80,7 +83,7 @@ async function createStartedRelaySession(
     providerConfig,
   });
   await Promise.resolve();
-  return { provider, events, session };
+  return { provider, events, logGateway, session };
 }
 
 function findPayloadByType(events: BroadcastEvent[], type: string): Record<string, unknown> {
@@ -478,9 +481,13 @@ describe("talk transcription gateway relay", () => {
     sttSession.close.mockImplementationOnce(() => {
       queueMicrotask(() => request?.onTranscript?.("disconnected provider transcript"));
     });
-    const { events, session } = await createStartedRelaySession(sttSession, {}, (value) => {
-      request = value;
-    });
+    const { events, logGateway, session } = await createStartedRelaySession(
+      sttSession,
+      {},
+      (value) => {
+        request = value;
+      },
+    );
 
     sendTalkTranscriptionRelayAudio({
       transcriptionSessionId: session.transcriptionSessionId,
@@ -491,7 +498,7 @@ describe("talk transcription gateway relay", () => {
       transcriptionSessionId: session.transcriptionSessionId,
       connId: "conn-1",
     });
-    closeTalkTranscriptionRelaySessionsForConnection("conn-1");
+    cleanupTalkConnection("conn-1", logGateway);
     await Promise.resolve();
 
     expect(
@@ -672,8 +679,7 @@ describe("talk transcription gateway relay", () => {
       throw new Error("provider close failed");
     });
 
-    expect(() => closeTalkTranscriptionRelaySessionsForConnection("conn-owner")).not.toThrow();
-    closeTalkTranscriptionRelaySessionsForConnection("conn-owner");
+    expect(() => cleanupTalkConnection("conn-owner", logGateway)).not.toThrow();
     await Promise.resolve();
     await Promise.resolve();
 
@@ -734,7 +740,7 @@ describe("talk transcription gateway relay", () => {
       transcriptionSessionId: unrelatedSession.transcriptionSessionId,
       connId: "conn-other",
     });
-    closeTalkTranscriptionRelaySessionsForConnection("conn-other");
+    cleanupTalkConnection("conn-other", logGateway);
     expect(unrelated.close).toHaveBeenCalledOnce();
   });
 

--- a/src/gateway/talk-transcription-relay.ts
+++ b/src/gateway/talk-transcription-relay.ts
@@ -22,7 +22,10 @@ import {
   closeTalkRelaySessionsForConnection,
   requireActiveTalkRelaySession,
 } from "./talk-relay-session-lifecycle.js";
-import { forgetUnifiedTalkSession } from "./talk-session-registry.js";
+import {
+  forgetUnifiedTalkSession,
+  registerTalkConnectionCleanup,
+} from "./talk-session-registry.js";
 
 /**
  * Gateway-owned relay for streaming speech-to-text providers used by Talk.
@@ -214,7 +217,7 @@ function closeTranscriptionSession(
 }
 
 /** Releases every transcription relay owned by a disconnected gateway connection. */
-export function closeTalkTranscriptionRelaySessionsForConnection(connId: string): void {
+function closeTalkTranscriptionRelaySessionsForConnection(connId: string): void {
   closeTalkRelaySessionsForConnection({
     sessions: transcriptionSessions.values(),
     connId,
@@ -375,6 +378,9 @@ export function createTalkTranscriptionRelaySession(
   relayRef.current = relay;
   relay.cleanupTimer.unref?.();
   transcriptionSessions.set(transcriptionSessionId, relay);
+  registerTalkConnectionCleanup(params.connId, "transcription-relay", () => {
+    closeTalkTranscriptionRelaySessionsForConnection(params.connId);
+  });
   sttSession
     .connect()
     .then(() => {


### PR DESCRIPTION
Related: #119087

## What Problem This Solves

Reduces eager default-plugin runtime loading during Gateway startup and standalone agent commands when Talk relay cleanup, ACPX session catalog access, Google Meet operations, and memory operations are not used.

This is a partial repair for #119087. It does not change the Gateway readiness contract or claim to resolve the remaining product decision around core readiness versus optional plugin availability.

## Why This Change Was Made

Keeps process-stable registration and cleanup metadata in lightweight modules, then defers owner-specific runtime imports until the operation that needs them. Configuration, storage, protocol, and readiness semantics remain unchanged.

The four owner-local changes are:

- Talk keeps a lightweight session cleanup registry instead of importing relay runtimes from the WebSocket connection path.
- ACPX keeps the session catalog facade small and imports the Pi catalog runtime on first catalog operation.
- Google Meet separates lightweight registration from browser, calendar, Meet API, meeting runtime, routing, parameter, transcript, and standalone Gateway helpers.
- memory-core passes host runtime operations through lazy wrappers instead of reading nested runtime getters during registration.

## User Impact

- Gateway reaches its TCP listener sooner without declaring readiness before sidecars complete.
- Fresh agent commands avoid loading unused plugin runtime graphs.
- ACPX and Google Meet cold entrypoint memory is materially lower.
- First-use behavior remains unchanged; owner runtime work occurs when its operation is invoked.

## Evidence

- Rebased implementation base: `ad80956428560ca7f450bd3dadd2eb897acb0d6d`
- Exact current head: `d7a95249350fdbc448daccac50e8d1ac86130545`
- Current main integration check: `6d2ba0d5622fa7aa21a4770cb4c6fd93cae44e04`; the two newer main commits are path-disjoint and GitHub reports the PR mergeable.
- Exact measured baseline: `2db3431f4aa198ba84c465bdf15506e783575431`
- Exact measured candidate: `aa46d04457393283c7edfe672eeadc4c96b4c842`; the current head preserves the same PR production diff after rebasing and includes only the previously reviewed lazy-import test-type narrowing.
- Matched performance runs:
  - baseline attempt 2: https://github.com/openclaw/openclaw/actions/runs/31043442309/attempts/2
  - candidate attempt 2: https://github.com/openclaw/openclaw/actions/runs/31043442120/attempts/2
- Kova attempt 2, five samples per ref, all 10 scenarios passing:
  - TCP listener: `5028 -> 4778ms` (`-5.0%`)
  - health ready: `5520 -> 5614ms` (`+1.7%`; readiness semantics unchanged)
  - Gateway RSS median: `956.1 -> 963.3MB` (`+0.8%`); p95 `967.1 -> 967.9MB`
  - cold agent turn: `4450 -> 3729ms` (`-16.2%`)
  - warm agent turn: `4218 -> 3485ms` (`-17.4%`)
  - agent-turn p95: `4546.9 -> 3714.4ms` (`-18.3%`)
  - cold pre-provider: `4265 -> 3586ms` (`-15.9%`)
  - agent RSS median: `885.1 -> 857.3MB` (`-3.1%`)
- Across both matched Kova attempts, the ten-sample medians are:
  - TCP listener: `5664 -> 4411ms` (`-22.1%`)
  - health ready: `6171 -> 5298.5ms` (`-14.1%`)
  - Gateway RSS: `960.4 -> 964.7MB` (`+0.45%`)
- Exact source-performance pair:
  - all 87 bundled entrypoints: `703.2 -> 628.0MB` (`-10.7%`)
  - ACPX isolated import: `511.7 -> 135.0MB` (`-73.6%`)
  - Google Meet isolated import: `547.8 -> 364.3MB` (`-33.5%`)
  - prepared one-agent listener: `3662 -> 2615ms` (`-28.6%`)
  - prepared many-agent listener: `4026 -> 2795ms` (`-30.6%`)
  - 50-plugin listener: `5258 -> 2937ms` (`-44.1%`)
  - 50 startup-lazy-plugin listener: `5002 -> 2848ms` (`-43.1%`)
- Source probes also show the intended Talk phase relocation on the default case: `gateway.ws-imports` falls from `561.1 -> 11.4ms`, while `sidecars.model-runtime-build.runtimePluginMs` rises from `261.8 -> 1147.9ms` on separate runners. The PR therefore does not claim to remove all readiness cost or close #119087.
- Focused tests at the current exact head: 326 assertions across 12 ACPX, Google Meet, memory-core, Gateway import-boundary, WebSocket connection, and Talk relay/session files.
- Static/build proof: `git diff --check`, oxfmt, direct changed-file oxlint, and the no-reconcile `sourcePerformance` build pass.
- Structured review: autoreview clean, no accepted/actionable finding, 0.98 correctness confidence; TruffleHog clean.
- Production delta: `+578/-1067`, net `-489` lines. Tests: `+483/-36`.
- Changelog: not required; this changes current-main implementation only and adds no public/config/storage contract.

Root cause: default plugin entrypoints mixed process-stable registration metadata with operational runtime imports, so registry construction loaded unrelated runtime graphs. The canonical fix is to keep registration lightweight and let each owner import its runtime at first use. No readiness fallback, compatibility shim, cache, or alternate execution path is added.

Sibling Codex protocol/runtime verification was performed against `openai/codex` commit `9d00bb01c0a712fb7c2f5b002bdf33bcc0fc352c`:

- `codex-rs/app-server-protocol/src/protocol/common.rs:474-510,855-870`
- `codex-rs/app-server/src/message_processor.rs:520-579,659-681,699-735,763-817`
- `codex-rs/app-server/src/lib.rs:1150-1160`

The lazy plugin registration changes do not alter Codex initialize, thread/turn ordering, or shutdown-drain contracts.

## Merge Gate

Merge only after clean exact-head CI and the latest exact-head ClawSweeper review has no unresolved `Before merge`, finding, security, owner-decision, merge-risk, or blocking rank-up item.

This PR was prepared with AI assistance.

Punchcard-Session: coral-workshop-workshop-3f
